### PR TITLE
ROX-12989: Resync-less Deployments+RBAC MVP prototype

### DIFF
--- a/sensor/kubernetes/eventpipeline/message/message.go
+++ b/sensor/kubernetes/eventpipeline/message/message.go
@@ -8,6 +8,7 @@ import (
 type DeploymentRef struct {
 	Namespace, Id string
 	Action        central.ResourceAction
+	Subject       string
 }
 
 type ResourceEvent struct {
@@ -16,6 +17,12 @@ type ResourceEvent struct {
 	// DeploymentRefs is an experimental field to provide a new way of resolving
 	// deployment dependencies. The objective of this field is to reduce (and eventually remove)
 	// the usage of resource re-sync.
+	// NOTE: After implementing a prototype of this, I don't thing a slice is a good idea.
+	// It makes more sense for the handler that requires multiple deployment updates to send
+	// the deployment reference fields. E.g. selectors, subjects etc...
+	// The reference can then be a single slice.
+	// Additionally, this could be implemented in a way that the reference is parsed by
+	// different resolvers which will query the deployment store differently.
 	DeploymentRefs []DeploymentRef
 
 	// CompatibilityDetectionDeployment should be used by old handlers

--- a/sensor/kubernetes/eventpipeline/message/message.go
+++ b/sensor/kubernetes/eventpipeline/message/message.go
@@ -1,0 +1,35 @@
+package message
+
+import (
+	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stackrox/rox/generated/storage"
+)
+
+type DeploymentRef struct {
+	Namespace, Id string
+	Action        central.ResourceAction
+}
+
+type ResourceEvent struct {
+	ForwardMessages []*central.SensorEvent
+
+	// DeploymentRefs is an experimental field to provide a new way of resolving
+	// deployment dependencies. The objective of this field is to reduce (and eventually remove)
+	// the usage of resource re-sync.
+	DeploymentRefs []DeploymentRef
+
+	// CompatibilityDetectionDeployment should be used by old handlers
+	// and it's here for retrocompatibility reasons.
+	// This property should be removed in the future and only the
+	// DetectionObject should be sent
+	CompatibilityDetectionDeployment []CompatibilityDetectionMessage
+
+	// ReprocessDeployments is also used for compatibility reasons with Network Policy handlers
+	// in the future this will not be needed as the dependencies are taken care by the resolvers
+	ReprocessDeployments []string
+}
+
+type CompatibilityDetectionMessage struct {
+	Object *storage.Deployment
+	Action central.ResourceAction
+}

--- a/sensor/kubernetes/eventpipeline/output/output.go
+++ b/sensor/kubernetes/eventpipeline/output/output.go
@@ -18,18 +18,27 @@ type DetectionObject struct {
 	networkPoliciesApplied *augmentedobjs.NetworkPoliciesApplied
 }
 
+type CompatibilityDetectionMessage struct {
+	Object *storage.Deployment
+	Action central.ResourceAction
+}
+
 type OutputMessage struct {
 	ForwardMessages []*central.SensorEvent
 
 	// DetectionObject should be used by the new path
-	DetectionObject *DetectionObject
+	// DetectionObject *DetectionObject
 
-	Action central.ResourceAction
+	// Action central.ResourceAction
 	// CompatibilityDetectionDeployment should be used by old handlers
 	// and its here for retrocompatibility reasons.
 	// This property should be removed in the future and only the
 	// DetectionObject should be sent
-	CompatibilityDetectionDeployment *storage.Deployment
+	CompatibilityDetectionDeployment []CompatibilityDetectionMessage
+
+	// ReprocessDeployments is also used for compatibility reasons with Network Policy handlers
+	// in the future this will not be needed as the dependencies are taken care by the resolvers
+	ReprocessDeployments []string
 }
 
 type Queue interface {

--- a/sensor/kubernetes/eventpipeline/output/output.go
+++ b/sensor/kubernetes/eventpipeline/output/output.go
@@ -3,7 +3,6 @@ package output
 import (
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
-	"github.com/stackrox/rox/pkg/booleanpolicy/augmentedobjs"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/sensor/common/detector"
 )
@@ -12,26 +11,16 @@ var (
 	boundedQueueSize = 100
 )
 
-type DetectionObject struct {
-	deployment             *storage.Deployment
-	images                 []*storage.Image
-	networkPoliciesApplied *augmentedobjs.NetworkPoliciesApplied
-}
-
 type CompatibilityDetectionMessage struct {
 	Object *storage.Deployment
 	Action central.ResourceAction
 }
 
-type OutputMessage struct {
+type Message struct {
 	ForwardMessages []*central.SensorEvent
 
-	// DetectionObject should be used by the new path
-	// DetectionObject *DetectionObject
-
-	// Action central.ResourceAction
 	// CompatibilityDetectionDeployment should be used by old handlers
-	// and its here for retrocompatibility reasons.
+	// and it's here for retrocompatibility reasons.
 	// This property should be removed in the future and only the
 	// DetectionObject should be sent
 	CompatibilityDetectionDeployment []CompatibilityDetectionMessage
@@ -42,12 +31,12 @@ type OutputMessage struct {
 }
 
 type Queue interface {
-	Send(detectionObject *OutputMessage)
+	Send(detectionObject *Message)
 	ResponseC() <-chan *central.MsgFromSensor
 }
 
 func New(stopSig *concurrency.Signal, detector detector.Detector) Queue {
-	ch := make(chan *OutputMessage, boundedQueueSize)
+	ch := make(chan *Message, boundedQueueSize)
 	forwardQueue := make(chan *central.MsgFromSensor)
 	outputQueue := &outputImpl{
 		detector:     detector,

--- a/sensor/kubernetes/eventpipeline/output/output.go
+++ b/sensor/kubernetes/eventpipeline/output/output.go
@@ -2,41 +2,22 @@ package output
 
 import (
 	"github.com/stackrox/rox/generated/internalapi/central"
-	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/sensor/common/detector"
+	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/message"
 )
 
 var (
 	boundedQueueSize = 100
 )
 
-type CompatibilityDetectionMessage struct {
-	Object *storage.Deployment
-	Action central.ResourceAction
-}
-
-type Message struct {
-	ForwardMessages []*central.SensorEvent
-
-	// CompatibilityDetectionDeployment should be used by old handlers
-	// and it's here for retrocompatibility reasons.
-	// This property should be removed in the future and only the
-	// DetectionObject should be sent
-	CompatibilityDetectionDeployment []CompatibilityDetectionMessage
-
-	// ReprocessDeployments is also used for compatibility reasons with Network Policy handlers
-	// in the future this will not be needed as the dependencies are taken care by the resolvers
-	ReprocessDeployments []string
-}
-
 type Queue interface {
-	Send(detectionObject *Message)
+	Send(detectionObject *message.ResourceEvent)
 	ResponseC() <-chan *central.MsgFromSensor
 }
 
 func New(stopSig *concurrency.Signal, detector detector.Detector) Queue {
-	ch := make(chan *Message, boundedQueueSize)
+	ch := make(chan *message.ResourceEvent, boundedQueueSize)
 	forwardQueue := make(chan *central.MsgFromSensor)
 	outputQueue := &outputImpl{
 		detector:     detector,

--- a/sensor/kubernetes/eventpipeline/output/output.go
+++ b/sensor/kubernetes/eventpipeline/output/output.go
@@ -1,0 +1,51 @@
+package output
+
+import (
+	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/booleanpolicy/augmentedobjs"
+	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/sensor/common/detector"
+)
+
+var (
+	boundedQueueSize = 100
+)
+
+type DetectionObject struct {
+	deployment             *storage.Deployment
+	images                 []*storage.Image
+	networkPoliciesApplied *augmentedobjs.NetworkPoliciesApplied
+}
+
+type OutputMessage struct {
+	ForwardMessages []*central.SensorEvent
+
+	// DetectionObject should be used by the new path
+	DetectionObject *DetectionObject
+
+	Action central.ResourceAction
+	// CompatibilityDetectionDeployment should be used by old handlers
+	// and its here for retrocompatibility reasons.
+	// This property should be removed in the future and only the
+	// DetectionObject should be sent
+	CompatibilityDetectionDeployment *storage.Deployment
+}
+
+type Queue interface {
+	Send(detectionObject *OutputMessage)
+	ResponseC() <-chan *central.MsgFromSensor
+}
+
+func New(stopSig *concurrency.Signal, detector detector.Detector) Queue {
+	ch := make(chan *OutputMessage, boundedQueueSize)
+	forwardQueue := make(chan *central.MsgFromSensor)
+	outputQueue := &outputImpl{
+		detector:     detector,
+		stopSig:      stopSig,
+		innerQueue:   ch,
+		forwardQueue: forwardQueue,
+	}
+	go outputQueue.startProcessing()
+	return outputQueue
+}

--- a/sensor/kubernetes/eventpipeline/output/output_impl.go
+++ b/sensor/kubernetes/eventpipeline/output/output_impl.go
@@ -1,0 +1,47 @@
+package output
+
+import (
+	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/sensor/common/detector"
+)
+
+type outputImpl struct {
+	innerQueue   chan *OutputMessage
+	stopSig      *concurrency.Signal
+	forwardQueue chan *central.MsgFromSensor
+	detector     detector.Detector
+}
+
+func (q *outputImpl) Send(msg *OutputMessage) {
+	q.innerQueue <- msg
+}
+
+func (q *outputImpl) ResponseC() <-chan *central.MsgFromSensor {
+	return q.forwardQueue
+}
+
+func (q *outputImpl) startProcessing() {
+	for {
+		select {
+		case <-q.stopSig.Done():
+			return
+		case msg, more := <-q.innerQueue:
+			if !more {
+				return
+			}
+
+			for _, resourceUpdates := range msg.ForwardMessages {
+				q.forwardQueue <- &central.MsgFromSensor{
+					Msg: &central.MsgFromSensor_Event{
+						Event: resourceUpdates,
+					},
+				}
+			}
+
+			if msg.CompatibilityDetectionDeployment != nil {
+				q.detector.ProcessDeployment(msg.CompatibilityDetectionDeployment, msg.Action)
+			}
+		}
+	}
+}

--- a/sensor/kubernetes/eventpipeline/output/output_impl.go
+++ b/sensor/kubernetes/eventpipeline/output/output_impl.go
@@ -5,6 +5,7 @@ import (
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/sensor/common/detector"
+	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/message"
 )
 
 var (
@@ -12,13 +13,13 @@ var (
 )
 
 type outputImpl struct {
-	innerQueue   chan *Message
+	innerQueue   chan *message.ResourceEvent
 	stopSig      *concurrency.Signal
 	forwardQueue chan *central.MsgFromSensor
 	detector     detector.Detector
 }
 
-func (q *outputImpl) Send(msg *Message) {
+func (q *outputImpl) Send(msg *message.ResourceEvent) {
 	q.innerQueue <- msg
 }
 
@@ -35,6 +36,7 @@ func (q *outputImpl) startProcessing() {
 			if !more {
 				return
 			}
+			//log.Infof("OUTPUT QUEUE MESSAGE: %+v", msg)
 			for _, resourceUpdates := range msg.ForwardMessages {
 				q.forwardQueue <- &central.MsgFromSensor{
 					Msg: &central.MsgFromSensor_Event{

--- a/sensor/kubernetes/eventpipeline/output/output_impl.go
+++ b/sensor/kubernetes/eventpipeline/output/output_impl.go
@@ -12,13 +12,13 @@ var (
 )
 
 type outputImpl struct {
-	innerQueue   chan *OutputMessage
+	innerQueue   chan *Message
 	stopSig      *concurrency.Signal
 	forwardQueue chan *central.MsgFromSensor
 	detector     detector.Detector
 }
 
-func (q *outputImpl) Send(msg *OutputMessage) {
+func (q *outputImpl) Send(msg *Message) {
 	q.innerQueue <- msg
 }
 
@@ -35,7 +35,6 @@ func (q *outputImpl) startProcessing() {
 			if !more {
 				return
 			}
-			log.Infof("RECEIVING MESSAGE: %+v", msg)
 			for _, resourceUpdates := range msg.ForwardMessages {
 				q.forwardQueue <- &central.MsgFromSensor{
 					Msg: &central.MsgFromSensor_Event{

--- a/sensor/kubernetes/eventpipeline/pipeline.go
+++ b/sensor/kubernetes/eventpipeline/pipeline.go
@@ -11,13 +11,16 @@ import (
 	"github.com/stackrox/rox/sensor/common/detector"
 	"github.com/stackrox/rox/sensor/kubernetes/client"
 	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/output"
+	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/resolver"
 	"github.com/stackrox/rox/sensor/kubernetes/listener"
 )
 
 func New(client client.Interface, configHandler config.Handler, detector detector.Detector, nodeName string, resyncPeriod time.Duration, traceWriter io.Writer) common.SensorComponent {
 	stopSig := concurrency.NewSignal()
 	outputQueue := output.New(&stopSig, detector)
-	resourceListener := listener.New(client, configHandler, nodeName, resyncPeriod, traceWriter, outputQueue)
+	resolverQueue := resolver.New(outputQueue)
+
+	resourceListener := listener.New(client, configHandler, nodeName, resyncPeriod, traceWriter, resolverQueue)
 
 	pipelineResposnes := make(chan *central.MsgFromSensor)
 	return &eventPipeline{

--- a/sensor/kubernetes/eventpipeline/pipeline.go
+++ b/sensor/kubernetes/eventpipeline/pipeline.go
@@ -16,8 +16,6 @@ import (
 
 func New(client client.Interface, configHandler config.Handler, detector detector.Detector, nodeName string, resyncPeriod time.Duration, traceWriter io.Writer) common.SensorComponent {
 	stopSig := concurrency.NewSignal()
-	// dependencyResolver := ...New()
-	// objectEnhancer := ...New()
 	outputQueue := output.New(&stopSig, detector)
 	resourceListener := listener.New(client, configHandler, detector, nodeName, resyncPeriod, traceWriter, outputQueue)
 

--- a/sensor/kubernetes/eventpipeline/pipeline.go
+++ b/sensor/kubernetes/eventpipeline/pipeline.go
@@ -17,7 +17,7 @@ import (
 func New(client client.Interface, configHandler config.Handler, detector detector.Detector, nodeName string, resyncPeriod time.Duration, traceWriter io.Writer) common.SensorComponent {
 	stopSig := concurrency.NewSignal()
 	outputQueue := output.New(&stopSig, detector)
-	resourceListener := listener.New(client, configHandler, detector, nodeName, resyncPeriod, traceWriter, outputQueue)
+	resourceListener := listener.New(client, configHandler, nodeName, resyncPeriod, traceWriter, outputQueue)
 
 	pipelineResposnes := make(chan *central.MsgFromSensor)
 	return &eventPipeline{

--- a/sensor/kubernetes/eventpipeline/pipeline.go
+++ b/sensor/kubernetes/eventpipeline/pipeline.go
@@ -1,0 +1,32 @@
+package eventpipeline
+
+import (
+	"io"
+	"time"
+
+	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/sensor/common"
+	"github.com/stackrox/rox/sensor/common/config"
+	"github.com/stackrox/rox/sensor/common/detector"
+	"github.com/stackrox/rox/sensor/kubernetes/client"
+	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/output"
+	"github.com/stackrox/rox/sensor/kubernetes/listener"
+)
+
+func New(client client.Interface, configHandler config.Handler, detector detector.Detector, nodeName string, resyncPeriod time.Duration, traceWriter io.Writer) common.SensorComponent {
+	stopSig := concurrency.NewSignal()
+	// dependencyResolver := ...New()
+	// objectEnhancer := ...New()
+	outputQueue := output.New(&stopSig, detector)
+	// TODO: create listener without detector and pass `output` subcomponent
+	resourceListener := listener.New(client, configHandler, detector, nodeName, resyncPeriod, traceWriter)
+
+	pipelineResposnes := make(chan *central.MsgFromSensor)
+	return &eventPipeline{
+		eventsC:  pipelineResposnes,
+		listener: resourceListener,
+		stopSig:  &stopSig,
+		output:   outputQueue,
+	}
+}

--- a/sensor/kubernetes/eventpipeline/pipeline.go
+++ b/sensor/kubernetes/eventpipeline/pipeline.go
@@ -19,8 +19,7 @@ func New(client client.Interface, configHandler config.Handler, detector detecto
 	// dependencyResolver := ...New()
 	// objectEnhancer := ...New()
 	outputQueue := output.New(&stopSig, detector)
-	// TODO: create listener without detector and pass `output` subcomponent
-	resourceListener := listener.New(client, configHandler, detector, nodeName, resyncPeriod, traceWriter)
+	resourceListener := listener.New(client, configHandler, detector, nodeName, resyncPeriod, traceWriter, outputQueue)
 
 	pipelineResposnes := make(chan *central.MsgFromSensor)
 	return &eventPipeline{

--- a/sensor/kubernetes/eventpipeline/pipeline_impl.go
+++ b/sensor/kubernetes/eventpipeline/pipeline_impl.go
@@ -1,0 +1,83 @@
+package eventpipeline
+
+import (
+	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stackrox/rox/pkg/centralsensor"
+	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/logging"
+	"github.com/stackrox/rox/sensor/common"
+	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/output"
+)
+
+var (
+	log = logging.LoggerForModule()
+)
+
+type eventPipeline struct {
+	listener common.SensorComponent
+	output   output.Queue
+
+	eventsC chan *central.MsgFromSensor
+	stopSig *concurrency.Signal
+}
+
+// Capabilities implements common.SensorComponent
+func (*eventPipeline) Capabilities() []centralsensor.SensorCapability {
+	return nil
+}
+
+// ProcessMessage implements common.SensorComponent
+func (*eventPipeline) ProcessMessage(msg *central.MsgToSensor) error {
+	return nil
+}
+
+// ResponsesC implements common.SensorComponent
+func (p *eventPipeline) ResponsesC() <-chan *central.MsgFromSensor {
+	return p.eventsC
+}
+
+// Start implements common.SensorComponent
+func (p *eventPipeline) Start() error {
+	log.Info("STARTING EVENT PIPELINE")
+	if err := p.listener.Start(); err != nil {
+		return err
+	}
+	go p.forwardMessages()
+	return nil
+}
+
+// Stop implements common.SensorComponent
+func (p *eventPipeline) Stop(err error) {
+	p.listener.Stop(err)
+}
+
+// forwardMessages from listener component to responses channel
+// TODO: Remove this and refactor listeners so they send message to the pipeline queue instead.
+func (p *eventPipeline) forwardMessages() {
+	log.Info("starting message forwarding")
+	defer func() { 
+		log.Info("stopping message forward")
+	}()
+
+	for {
+		select {
+		case <-p.stopSig.Done():
+			return
+		case msg, more := <-p.output.ResponseC():
+			if !more {
+				// TODO: Add warning / error / log
+				return
+			}
+			p.eventsC <- msg
+		case msg, more := <-p.listener.ResponsesC():
+			log.Info("forwarding message from listener")
+			if !more {
+				// TODO: Add warning / error / log
+				return
+			}
+			p.eventsC <- msg
+		}
+
+	}
+
+}

--- a/sensor/kubernetes/eventpipeline/pipeline_impl.go
+++ b/sensor/kubernetes/eventpipeline/pipeline_impl.go
@@ -55,7 +55,7 @@ func (p *eventPipeline) Stop(err error) {
 // TODO: Remove this and refactor listeners so they send message to the pipeline queue instead.
 func (p *eventPipeline) forwardMessages() {
 	log.Info("starting message forwarding")
-	defer func() { 
+	defer func() {
 		log.Info("stopping message forward")
 	}()
 

--- a/sensor/kubernetes/eventpipeline/pipeline_impl.go
+++ b/sensor/kubernetes/eventpipeline/pipeline_impl.go
@@ -38,7 +38,6 @@ func (p *eventPipeline) ResponsesC() <-chan *central.MsgFromSensor {
 
 // Start implements common.SensorComponent
 func (p *eventPipeline) Start() error {
-	log.Info("STARTING EVENT PIPELINE")
 	if err := p.listener.Start(); err != nil {
 		return err
 	}
@@ -54,11 +53,6 @@ func (p *eventPipeline) Stop(err error) {
 // forwardMessages from listener component to responses channel
 // TODO: Remove this and refactor listeners so they send message to the pipeline queue instead.
 func (p *eventPipeline) forwardMessages() {
-	log.Info("starting message forwarding")
-	defer func() {
-		log.Info("stopping message forward")
-	}()
-
 	for {
 		select {
 		case <-p.stopSig.Done():
@@ -70,7 +64,6 @@ func (p *eventPipeline) forwardMessages() {
 			}
 			p.eventsC <- msg
 		case msg, more := <-p.listener.ResponsesC():
-			log.Info("forwarding message from listener")
 			if !more {
 				// TODO: Add warning / error / log
 				return

--- a/sensor/kubernetes/eventpipeline/resolver/resolver.go
+++ b/sensor/kubernetes/eventpipeline/resolver/resolver.go
@@ -1,0 +1,91 @@
+package resolver
+
+import (
+	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/logging"
+	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/message"
+	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/output"
+)
+
+var (
+	log = logging.LoggerForModule()
+)
+
+type DeploymentResolver interface {
+	ProcessDependencies(ref message.DeploymentRef) (*storage.Deployment, error)
+}
+
+type Resolver interface {
+	Send(pipelineMessage *message.ResourceEvent)
+	SetDeploymentResolver(resolver DeploymentResolver)
+}
+
+type resolverImpl struct {
+	innerQueue                   chan *message.ResourceEvent
+	outputQueue                  output.Queue
+	deploymentDependencyResolver DeploymentResolver
+}
+
+func New(queue output.Queue) Resolver {
+	resolver := &resolverImpl{
+		outputQueue: queue,
+		innerQueue:  make(chan *message.ResourceEvent, 100),
+	}
+	go resolver.startProcessing()
+	return resolver
+}
+
+func (r *resolverImpl) SetDeploymentResolver(resolver DeploymentResolver) {
+	r.deploymentDependencyResolver = resolver
+}
+
+func (r *resolverImpl) startProcessing() {
+	for {
+		// TODO: use a select block + signal to abort
+		msg, more := <-r.innerQueue
+		if !more {
+			return
+		}
+		r.processMessage(msg)
+	}
+}
+
+func (r *resolverImpl) processMessage(pipelineMessage *message.ResourceEvent) {
+	// log.Infof("PROCESSING DEPLOYMENT IDS: %v", pipelineMessage.DeploymentRefs)
+	for _, deploymentRef := range pipelineMessage.DeploymentRefs {
+		// Process deployments
+		// This should be executed whenever a deployment event was triggered
+		// or if a dependency from a deployment was changed
+		// For dependencies, multiple deployments could have the resource as a
+		// dependency, this is why we need to process each one individually.
+		deployment, err := r.deploymentDependencyResolver.ProcessDependencies(deploymentRef)
+		if err != nil {
+			log.Warnf("deployment resolver failed for deployment %s: %s", deploymentRef.Id, err)
+		}
+
+		pipelineMessage.CompatibilityDetectionDeployment = append(pipelineMessage.CompatibilityDetectionDeployment,
+			message.CompatibilityDetectionMessage{
+				Object: deployment,
+				Action: deploymentRef.Action,
+			})
+
+		pipelineMessage.ForwardMessages = append(pipelineMessage.ForwardMessages,
+			&central.SensorEvent{
+				Id:     deploymentRef.Id,
+				Action: deploymentRef.Action,
+				Resource: &central.SensorEvent_Deployment{
+					Deployment: deployment,
+				},
+			})
+	}
+
+	// Clean up deployment ref field
+	pipelineMessage.DeploymentRefs = []message.DeploymentRef{}
+
+	r.outputQueue.Send(pipelineMessage)
+}
+
+func (r *resolverImpl) Send(pipelineMessage *message.ResourceEvent) {
+	r.innerQueue <- pipelineMessage
+}

--- a/sensor/kubernetes/listener/listener.go
+++ b/sensor/kubernetes/listener/listener.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stackrox/rox/sensor/common/awscredentials"
 	"github.com/stackrox/rox/sensor/common/config"
 	"github.com/stackrox/rox/sensor/kubernetes/client"
-	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/output"
+	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/resolver"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -21,7 +21,7 @@ var (
 )
 
 // New returns a new kubernetes listener.
-func New(client client.Interface, configHandler config.Handler, nodeName string, resyncPeriod time.Duration, traceWriter io.Writer, queue output.Queue) common.SensorComponent {
+func New(client client.Interface, configHandler config.Handler, nodeName string, resyncPeriod time.Duration, traceWriter io.Writer, resolverQueue resolver.Resolver) common.SensorComponent {
 	k := &listenerImpl{
 		client:             client,
 		eventsC:            make(chan *central.MsgFromSensor, 10),
@@ -30,7 +30,7 @@ func New(client client.Interface, configHandler config.Handler, nodeName string,
 		credentialsManager: createCredentialsManager(client, nodeName),
 		resyncPeriod:       resyncPeriod,
 		traceWriter:        traceWriter,
-		outputQueue:        queue,
+		resolverQueue:      resolverQueue,
 	}
 	return k
 }

--- a/sensor/kubernetes/listener/listener.go
+++ b/sensor/kubernetes/listener/listener.go
@@ -32,6 +32,7 @@ func New(client client.Interface, configHandler config.Handler, detector detecto
 		credentialsManager: createCredentialsManager(client, nodeName),
 		resyncPeriod:       resyncPeriod,
 		traceWriter:        traceWriter,
+		outputQueue:        queue,
 	}
 	return k
 }

--- a/sensor/kubernetes/listener/listener.go
+++ b/sensor/kubernetes/listener/listener.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stackrox/rox/sensor/common"
 	"github.com/stackrox/rox/sensor/common/awscredentials"
 	"github.com/stackrox/rox/sensor/common/config"
-	"github.com/stackrox/rox/sensor/common/detector"
 	"github.com/stackrox/rox/sensor/kubernetes/client"
 	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/output"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -22,13 +21,12 @@ var (
 )
 
 // New returns a new kubernetes listener.
-func New(client client.Interface, configHandler config.Handler, detector detector.Detector, nodeName string, resyncPeriod time.Duration, traceWriter io.Writer, queue output.Queue) common.SensorComponent {
+func New(client client.Interface, configHandler config.Handler, nodeName string, resyncPeriod time.Duration, traceWriter io.Writer, queue output.Queue) common.SensorComponent {
 	k := &listenerImpl{
 		client:             client,
 		eventsC:            make(chan *central.MsgFromSensor, 10),
 		stopSig:            concurrency.NewSignal(),
 		configHandler:      configHandler,
-		detector:           detector,
 		credentialsManager: createCredentialsManager(client, nodeName),
 		resyncPeriod:       resyncPeriod,
 		traceWriter:        traceWriter,

--- a/sensor/kubernetes/listener/listener.go
+++ b/sensor/kubernetes/listener/listener.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stackrox/rox/sensor/common/config"
 	"github.com/stackrox/rox/sensor/common/detector"
 	"github.com/stackrox/rox/sensor/kubernetes/client"
+	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/output"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -21,7 +22,7 @@ var (
 )
 
 // New returns a new kubernetes listener.
-func New(client client.Interface, configHandler config.Handler, detector detector.Detector, nodeName string, resyncPeriod time.Duration, traceWriter io.Writer) common.SensorComponent {
+func New(client client.Interface, configHandler config.Handler, detector detector.Detector, nodeName string, resyncPeriod time.Duration, traceWriter io.Writer, queue output.Queue) common.SensorComponent {
 	k := &listenerImpl{
 		client:             client,
 		eventsC:            make(chan *central.MsgFromSensor, 10),

--- a/sensor/kubernetes/listener/listener_impl.go
+++ b/sensor/kubernetes/listener/listener_impl.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stackrox/rox/sensor/common/awscredentials"
 	"github.com/stackrox/rox/sensor/common/config"
 	"github.com/stackrox/rox/sensor/kubernetes/client"
-	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/output"
+	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/resolver"
 )
 
 const (
@@ -29,7 +29,7 @@ type listenerImpl struct {
 	configHandler      config.Handler
 	resyncPeriod       time.Duration
 	traceWriter        io.Writer
-	outputQueue        output.Queue
+	resolverQueue      resolver.Resolver
 }
 
 func (k *listenerImpl) Start() error {

--- a/sensor/kubernetes/listener/listener_impl.go
+++ b/sensor/kubernetes/listener/listener_impl.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackrox/rox/sensor/common/config"
 	"github.com/stackrox/rox/sensor/common/detector"
 	"github.com/stackrox/rox/sensor/kubernetes/client"
+	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/output"
 )
 
 const (
@@ -30,6 +31,7 @@ type listenerImpl struct {
 	detector           detector.Detector
 	resyncPeriod       time.Duration
 	traceWriter        io.Writer
+	outputQueue        output.Queue
 }
 
 func (k *listenerImpl) Start() error {

--- a/sensor/kubernetes/listener/listener_impl.go
+++ b/sensor/kubernetes/listener/listener_impl.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/sensor/common/awscredentials"
 	"github.com/stackrox/rox/sensor/common/config"
-	"github.com/stackrox/rox/sensor/common/detector"
 	"github.com/stackrox/rox/sensor/kubernetes/client"
 	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/output"
 )
@@ -28,7 +27,6 @@ type listenerImpl struct {
 	stopSig            concurrency.Signal
 	credentialsManager awscredentials.RegistryCredentialsManager
 	configHandler      config.Handler
-	detector           detector.Detector
 	resyncPeriod       time.Duration
 	traceWriter        io.Writer
 	outputQueue        output.Queue

--- a/sensor/kubernetes/listener/resource_event_handler.go
+++ b/sensor/kubernetes/listener/resource_event_handler.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stackrox/rox/sensor/common/clusterentities"
 	"github.com/stackrox/rox/sensor/common/clusterid"
 	"github.com/stackrox/rox/sensor/common/processfilter"
+	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/output"
 	"github.com/stackrox/rox/sensor/kubernetes/listener/resources"
 	"github.com/stackrox/rox/sensor/kubernetes/orchestratornamespaces"
 	"k8s.io/apimachinery/pkg/types"
@@ -96,15 +97,15 @@ func (k *listenerImpl) handleAllEvents() {
 	stopSignal := &k.stopSig
 
 	// Informers that need to be synced initially
-	handle(namespaceInformer, dispatchers.ForNamespaces(), k.eventsC, &syncingResources, prePodWaitGroup, stopSignal, &eventLock)
-	handle(secretInformer, dispatchers.ForSecrets(), k.eventsC, &syncingResources, prePodWaitGroup, stopSignal, &eventLock)
-	handle(saInformer, dispatchers.ForServiceAccounts(), k.eventsC, &syncingResources, prePodWaitGroup, stopSignal, &eventLock)
+	handle(namespaceInformer, dispatchers.ForNamespaces(), k.outputQueue, &syncingResources, prePodWaitGroup, stopSignal, &eventLock)
+	handle(secretInformer, dispatchers.ForSecrets(), k.outputQueue, &syncingResources, prePodWaitGroup, stopSignal, &eventLock)
+	handle(saInformer, dispatchers.ForServiceAccounts(), k.outputQueue, &syncingResources, prePodWaitGroup, stopSignal, &eventLock)
 
 	// RBAC dispatchers handles multiple sets of data
-	handle(roleInformer, dispatchers.ForRBAC(), k.eventsC, &syncingResources, prePodWaitGroup, stopSignal, &eventLock)
-	handle(clusterRoleInformer, dispatchers.ForRBAC(), k.eventsC, &syncingResources, prePodWaitGroup, stopSignal, &eventLock)
-	handle(roleBindingInformer, dispatchers.ForRBAC(), k.eventsC, &syncingResources, prePodWaitGroup, stopSignal, &eventLock)
-	handle(clusterRoleBindingInformer, dispatchers.ForRBAC(), k.eventsC, &syncingResources, prePodWaitGroup, stopSignal, &eventLock)
+	handle(roleInformer, dispatchers.ForRBAC(), k.outputQueue, &syncingResources, prePodWaitGroup, stopSignal, &eventLock)
+	handle(clusterRoleInformer, dispatchers.ForRBAC(), k.outputQueue, &syncingResources, prePodWaitGroup, stopSignal, &eventLock)
+	handle(roleBindingInformer, dispatchers.ForRBAC(), k.outputQueue, &syncingResources, prePodWaitGroup, stopSignal, &eventLock)
+	handle(clusterRoleBindingInformer, dispatchers.ForRBAC(), k.outputQueue, &syncingResources, prePodWaitGroup, stopSignal, &eventLock)
 
 	var osConfigFactory osConfigExtVersions.SharedInformerFactory
 	if k.client.OpenshiftConfig() != nil {
@@ -119,16 +120,16 @@ func (k *listenerImpl) handleAllEvents() {
 	// For openshift clusters only
 	if osConfigFactory != nil {
 		handle(osConfigFactory.Config().V1().ClusterOperators().Informer(), dispatchers.ForClusterOperators(),
-			k.eventsC, nil, prePodWaitGroup, stopSignal, &eventLock)
+			k.outputQueue, nil, prePodWaitGroup, stopSignal, &eventLock)
 	}
 
 	if crdSharedInformerFactory != nil {
 		log.Info("syncing compliance operator resources")
 		// Handle results, rules, and scan setting bindings first
-		handle(complianceResultInformer, dispatchers.ForComplianceOperatorResults(), k.eventsC, &syncingResources, prePodWaitGroup, stopSignal, &eventLock)
-		handle(complianceRuleInformer, dispatchers.ForComplianceOperatorRules(), k.eventsC, &syncingResources, prePodWaitGroup, stopSignal, &eventLock)
-		handle(complianceScanSettingBindingsInformer, dispatchers.ForComplianceOperatorScanSettingBindings(), k.eventsC, &syncingResources, prePodWaitGroup, stopSignal, &eventLock)
-		handle(complianceScanInformer, dispatchers.ForComplianceOperatorScans(), k.eventsC, &syncingResources, prePodWaitGroup, stopSignal, &eventLock)
+		handle(complianceResultInformer, dispatchers.ForComplianceOperatorResults(), k.outputQueue, &syncingResources, prePodWaitGroup, stopSignal, &eventLock)
+		handle(complianceRuleInformer, dispatchers.ForComplianceOperatorRules(), k.outputQueue, &syncingResources, prePodWaitGroup, stopSignal, &eventLock)
+		handle(complianceScanSettingBindingsInformer, dispatchers.ForComplianceOperatorScanSettingBindings(), k.outputQueue, &syncingResources, prePodWaitGroup, stopSignal, &eventLock)
+		handle(complianceScanInformer, dispatchers.ForComplianceOperatorScans(), k.outputQueue, &syncingResources, prePodWaitGroup, stopSignal, &eventLock)
 	}
 
 	sif.Start(stopSignal.Done())
@@ -158,26 +159,26 @@ func (k *listenerImpl) handleAllEvents() {
 	preTopLevelDeploymentWaitGroup := &concurrency.WaitGroup{}
 
 	// Non-deployment types.
-	handle(sif.Networking().V1().NetworkPolicies().Informer(), dispatchers.ForNetworkPolicies(), k.eventsC, &syncingResources, preTopLevelDeploymentWaitGroup, stopSignal, &eventLock)
-	handle(sif.Core().V1().Nodes().Informer(), dispatchers.ForNodes(), k.eventsC, &syncingResources, preTopLevelDeploymentWaitGroup, stopSignal, &eventLock)
-	handle(sif.Core().V1().Services().Informer(), dispatchers.ForServices(), k.eventsC, &syncingResources, preTopLevelDeploymentWaitGroup, stopSignal, &eventLock)
+	handle(sif.Networking().V1().NetworkPolicies().Informer(), dispatchers.ForNetworkPolicies(), k.outputQueue, &syncingResources, preTopLevelDeploymentWaitGroup, stopSignal, &eventLock)
+	handle(sif.Core().V1().Nodes().Informer(), dispatchers.ForNodes(), k.outputQueue, &syncingResources, preTopLevelDeploymentWaitGroup, stopSignal, &eventLock)
+	handle(sif.Core().V1().Services().Informer(), dispatchers.ForServices(), k.outputQueue, &syncingResources, preTopLevelDeploymentWaitGroup, stopSignal, &eventLock)
 
 	if osRouteFactory != nil {
-		handle(osRouteFactory.Route().V1().Routes().Informer(), dispatchers.ForOpenshiftRoutes(), k.eventsC, &syncingResources, preTopLevelDeploymentWaitGroup, stopSignal, &eventLock)
+		handle(osRouteFactory.Route().V1().Routes().Informer(), dispatchers.ForOpenshiftRoutes(), k.outputQueue, &syncingResources, preTopLevelDeploymentWaitGroup, stopSignal, &eventLock)
 	}
 
 	// Deployment subtypes (this ensures that the hierarchy maps are generated correctly)
-	handle(resyncingSif.Batch().V1().Jobs().Informer(), dispatchers.ForJobs(), k.eventsC, &syncingResources, preTopLevelDeploymentWaitGroup, stopSignal, &eventLock)
-	handle(resyncingSif.Apps().V1().ReplicaSets().Informer(), dispatchers.ForDeployments(kubernetes.ReplicaSet), k.eventsC, &syncingResources, preTopLevelDeploymentWaitGroup, stopSignal, &eventLock)
-	handle(resyncingSif.Core().V1().ReplicationControllers().Informer(), dispatchers.ForDeployments(kubernetes.ReplicationController), k.eventsC, &syncingResources, preTopLevelDeploymentWaitGroup, stopSignal, &eventLock)
+	handle(resyncingSif.Batch().V1().Jobs().Informer(), dispatchers.ForJobs(), k.outputQueue, &syncingResources, preTopLevelDeploymentWaitGroup, stopSignal, &eventLock)
+	handle(resyncingSif.Apps().V1().ReplicaSets().Informer(), dispatchers.ForDeployments(kubernetes.ReplicaSet), k.outputQueue, &syncingResources, preTopLevelDeploymentWaitGroup, stopSignal, &eventLock)
+	handle(resyncingSif.Core().V1().ReplicationControllers().Informer(), dispatchers.ForDeployments(kubernetes.ReplicationController), k.outputQueue, &syncingResources, preTopLevelDeploymentWaitGroup, stopSignal, &eventLock)
 
 	if features.ComplianceOperatorCheckResults.Enabled() {
 		// Compliance operator profiles are handled AFTER results, rules, and scan setting bindings have been synced
 		if complianceProfileInformer != nil {
-			handle(complianceProfileInformer, dispatchers.ForComplianceOperatorProfiles(), k.eventsC, &syncingResources, preTopLevelDeploymentWaitGroup, stopSignal, &eventLock)
+			handle(complianceProfileInformer, dispatchers.ForComplianceOperatorProfiles(), k.outputQueue, &syncingResources, preTopLevelDeploymentWaitGroup, stopSignal, &eventLock)
 		}
 		if complianceTailoredProfileInformer != nil {
-			handle(complianceTailoredProfileInformer, dispatchers.ForComplianceOperatorTailoredProfiles(), k.eventsC, &syncingResources, preTopLevelDeploymentWaitGroup, stopSignal, &eventLock)
+			handle(complianceTailoredProfileInformer, dispatchers.ForComplianceOperatorTailoredProfiles(), k.outputQueue, &syncingResources, preTopLevelDeploymentWaitGroup, stopSignal, &eventLock)
 		}
 	}
 
@@ -199,13 +200,13 @@ func (k *listenerImpl) handleAllEvents() {
 	wg := &concurrency.WaitGroup{}
 
 	// Deployment types.
-	handle(resyncingSif.Apps().V1().DaemonSets().Informer(), dispatchers.ForDeployments(kubernetes.DaemonSet), k.eventsC, &syncingResources, wg, stopSignal, &eventLock)
-	handle(resyncingSif.Apps().V1().Deployments().Informer(), dispatchers.ForDeployments(kubernetes.Deployment), k.eventsC, &syncingResources, wg, stopSignal, &eventLock)
-	handle(resyncingSif.Apps().V1().StatefulSets().Informer(), dispatchers.ForDeployments(kubernetes.StatefulSet), k.eventsC, &syncingResources, wg, stopSignal, &eventLock)
-	handle(resyncingSif.Batch().V1beta1().CronJobs().Informer(), dispatchers.ForDeployments(kubernetes.CronJob), k.eventsC, &syncingResources, wg, stopSignal, &eventLock)
+	handle(resyncingSif.Apps().V1().DaemonSets().Informer(), dispatchers.ForDeployments(kubernetes.DaemonSet), k.outputQueue, &syncingResources, wg, stopSignal, &eventLock)
+	handle(resyncingSif.Apps().V1().Deployments().Informer(), dispatchers.ForDeployments(kubernetes.Deployment), k.outputQueue, &syncingResources, wg, stopSignal, &eventLock)
+	handle(resyncingSif.Apps().V1().StatefulSets().Informer(), dispatchers.ForDeployments(kubernetes.StatefulSet), k.outputQueue, &syncingResources, wg, stopSignal, &eventLock)
+	handle(resyncingSif.Batch().V1beta1().CronJobs().Informer(), dispatchers.ForDeployments(kubernetes.CronJob), k.outputQueue, &syncingResources, wg, stopSignal, &eventLock)
 
 	if osAppsFactory != nil {
-		handle(osAppsFactory.Apps().V1().DeploymentConfigs().Informer(), dispatchers.ForDeployments(kubernetes.DeploymentConfig), k.eventsC, &syncingResources, wg, stopSignal, &eventLock)
+		handle(osAppsFactory.Apps().V1().DeploymentConfigs().Informer(), dispatchers.ForDeployments(kubernetes.DeploymentConfig), k.outputQueue, &syncingResources, wg, stopSignal, &eventLock)
 	}
 
 	// SharedInformerFactories can have Start called multiple times which will start the rest of the handlers
@@ -225,7 +226,7 @@ func (k *listenerImpl) handleAllEvents() {
 
 	// Finally, run the pod informer, and process pod events.
 	podWaitGroup := &concurrency.WaitGroup{}
-	handle(podInformer.Informer(), dispatchers.ForDeployments(kubernetes.Pod), k.eventsC, &syncingResources, podWaitGroup, stopSignal, &eventLock)
+	handle(podInformer.Informer(), dispatchers.ForDeployments(kubernetes.Pod), k.outputQueue, &syncingResources, podWaitGroup, stopSignal, &eventLock)
 	sif.Start(stopSignal.Done())
 
 	if !concurrency.WaitInContext(podWaitGroup, stopSignal) {
@@ -237,15 +238,15 @@ func (k *listenerImpl) handleAllEvents() {
 	// Set the flag that all objects present at start up have been consumed.
 	syncingResources.Set(false)
 
-	k.eventsC <- &central.MsgFromSensor{
-		Msg: &central.MsgFromSensor_Event{
-			Event: &central.SensorEvent{
+	k.outputQueue.Send(&output.OutputMessage{
+		ForwardMessages: []*central.SensorEvent{
+			{
 				Resource: &central.SensorEvent_Synced{
 					Synced: &central.SensorEvent_ResourcesSynced{},
 				},
 			},
 		},
-	}
+	})
 }
 
 // Helper function that creates and adds a handler to an informer.
@@ -253,7 +254,7 @@ func (k *listenerImpl) handleAllEvents() {
 func handle(
 	informer cache.SharedIndexInformer,
 	dispatcher resources.Dispatcher,
-	output chan<- *central.MsgFromSensor,
+	outputQueue output.Queue,
 	syncingResources *concurrency.Flag,
 	wg *concurrency.WaitGroup,
 	stopSignal *concurrency.Signal,
@@ -262,7 +263,7 @@ func handle(
 	handlerImpl := &resourceEventHandlerImpl{
 		eventLock:        eventLock,
 		dispatcher:       dispatcher,
-		output:           output,
+		outputQueue:      outputQueue,
 		syncingResources: syncingResources,
 
 		hasSeenAllInitialIDsSignal: concurrency.NewSignal(),

--- a/sensor/kubernetes/listener/resource_event_handler.go
+++ b/sensor/kubernetes/listener/resource_event_handler.go
@@ -74,7 +74,6 @@ func (k *listenerImpl) handleAllEvents() {
 		clusterentities.StoreInstance(),
 		processfilter.Singleton(),
 		k.configHandler,
-		k.detector,
 		orchestratornamespaces.Singleton(),
 		k.credentialsManager,
 		k.traceWriter,

--- a/sensor/kubernetes/listener/resource_event_handler.go
+++ b/sensor/kubernetes/listener/resource_event_handler.go
@@ -26,7 +26,7 @@ import (
 
 func (k *listenerImpl) handleAllEvents() {
 	sif := informers.NewSharedInformerFactory(k.client.Kubernetes(), noResyncPeriod)
-	resyncingSif := informers.NewSharedInformerFactory(k.client.Kubernetes(), k.resyncPeriod)
+	resyncingSif := informers.NewSharedInformerFactory(k.client.Kubernetes(), noResyncPeriod)
 
 	// Create informer factories for needed orchestrators.
 	var osAppsFactory osAppsExtVersions.SharedInformerFactory

--- a/sensor/kubernetes/listener/resource_event_handler.go
+++ b/sensor/kubernetes/listener/resource_event_handler.go
@@ -238,7 +238,7 @@ func (k *listenerImpl) handleAllEvents() {
 	// Set the flag that all objects present at start up have been consumed.
 	syncingResources.Set(false)
 
-	k.outputQueue.Send(&output.OutputMessage{
+	k.outputQueue.Send(&output.Message{
 		ForwardMessages: []*central.SensorEvent{
 			{
 				Resource: &central.SensorEvent_Synced{

--- a/sensor/kubernetes/listener/resource_event_handler_impl.go
+++ b/sensor/kubernetes/listener/resource_event_handler_impl.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stackrox/rox/pkg/kubernetes"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/pkg/utils"
-	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/output"
+	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/resolver"
 	"github.com/stackrox/rox/sensor/kubernetes/listener/resources"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -20,7 +20,7 @@ type resourceEventHandlerImpl struct {
 	eventLock  *sync.Mutex
 	dispatcher resources.Dispatcher
 
-	outputQueue      output.Queue
+	outputQueue      resolver.Resolver
 	syncingResources *concurrency.Flag
 
 	syncLock                   sync.Mutex

--- a/sensor/kubernetes/listener/resource_event_handler_impl.go
+++ b/sensor/kubernetes/listener/resource_event_handler_impl.go
@@ -105,14 +105,8 @@ func (h *resourceEventHandlerImpl) sendResourceEvent(obj, oldObj interface{}, ac
 		kubernetes.TrimAnnotations(metaObj)
 	}
 
-	evWraps := h.dispatcher.ProcessEvent(obj, oldObj, action)
-	h.sendEvents(evWraps...)
-}
-
-func (h *resourceEventHandlerImpl) sendEvents(evWraps ...*central.SensorEvent) {
-	for _, evWrap := range evWraps {
-		h.outputQueue.Send(evWrap)
-	}
+	message := h.dispatcher.ProcessEvent(obj, oldObj, action)
+	h.outputQueue.Send(message)
 }
 
 func getObjUID(newObj interface{}) types.UID {

--- a/sensor/kubernetes/listener/resources/clusteroperator.go
+++ b/sensor/kubernetes/listener/resources/clusteroperator.go
@@ -3,6 +3,7 @@ package resources
 import (
 	v1 "github.com/openshift/api/config/v1"
 	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/output"
 	"github.com/stackrox/rox/sensor/kubernetes/orchestratornamespaces"
 )
 
@@ -18,8 +19,8 @@ func newClusterOperatorDispatcher(namespaces *orchestratornamespaces.Orchestrato
 	}
 }
 
-// Process processes a cluster operator resource event, and returns the sensor events to emit in response.
-func (c *clusterOperatorDispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAction) []*central.SensorEvent {
+// ProcessEvent processes a cluster operator resource event, and returns the sensor events to emit in response.
+func (c *clusterOperatorDispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAction) *output.OutputMessage {
 	clusterOperator, ok := obj.(*v1.ClusterOperator)
 
 	if !ok {

--- a/sensor/kubernetes/listener/resources/clusteroperator.go
+++ b/sensor/kubernetes/listener/resources/clusteroperator.go
@@ -20,7 +20,7 @@ func newClusterOperatorDispatcher(namespaces *orchestratornamespaces.Orchestrato
 }
 
 // ProcessEvent processes a cluster operator resource event, and returns the sensor events to emit in response.
-func (c *clusterOperatorDispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAction) *output.OutputMessage {
+func (c *clusterOperatorDispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAction) *output.Message {
 	clusterOperator, ok := obj.(*v1.ClusterOperator)
 
 	if !ok {

--- a/sensor/kubernetes/listener/resources/clusteroperator.go
+++ b/sensor/kubernetes/listener/resources/clusteroperator.go
@@ -3,7 +3,7 @@ package resources
 import (
 	v1 "github.com/openshift/api/config/v1"
 	"github.com/stackrox/rox/generated/internalapi/central"
-	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/output"
+	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/message"
 	"github.com/stackrox/rox/sensor/kubernetes/orchestratornamespaces"
 )
 
@@ -20,7 +20,7 @@ func newClusterOperatorDispatcher(namespaces *orchestratornamespaces.Orchestrato
 }
 
 // ProcessEvent processes a cluster operator resource event, and returns the sensor events to emit in response.
-func (c *clusterOperatorDispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAction) *output.Message {
+func (c *clusterOperatorDispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAction) *message.ResourceEvent {
 	clusterOperator, ok := obj.(*v1.ClusterOperator)
 
 	if !ok {

--- a/sensor/kubernetes/listener/resources/complianceoperator/dispatchers/complianceoperatorprofiles.go
+++ b/sensor/kubernetes/listener/resources/complianceoperator/dispatchers/complianceoperatorprofiles.go
@@ -23,7 +23,7 @@ func NewProfileDispatcher() *ProfileDispatcher {
 }
 
 // ProcessEvent processes a compliance operator profile
-func (c *ProfileDispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAction) *output.OutputMessage {
+func (c *ProfileDispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAction) *output.Message {
 	var complianceProfile v1alpha1.Profile
 
 	unstructuredObject, ok := obj.(*unstructured.Unstructured)

--- a/sensor/kubernetes/listener/resources/complianceoperator/dispatchers/complianceoperatorprofiles.go
+++ b/sensor/kubernetes/listener/resources/complianceoperator/dispatchers/complianceoperatorprofiles.go
@@ -5,7 +5,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/complianceoperator/api/v1alpha1"
 	"github.com/stackrox/rox/pkg/logging"
-	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/output"
+	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/message"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -23,7 +23,7 @@ func NewProfileDispatcher() *ProfileDispatcher {
 }
 
 // ProcessEvent processes a compliance operator profile
-func (c *ProfileDispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAction) *output.Message {
+func (c *ProfileDispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAction) *message.ResourceEvent {
 	var complianceProfile v1alpha1.Profile
 
 	unstructuredObject, ok := obj.(*unstructured.Unstructured)

--- a/sensor/kubernetes/listener/resources/complianceoperator/dispatchers/complianceoperatorprofiles.go
+++ b/sensor/kubernetes/listener/resources/complianceoperator/dispatchers/complianceoperatorprofiles.go
@@ -5,6 +5,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/complianceoperator/api/v1alpha1"
 	"github.com/stackrox/rox/pkg/logging"
+	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/output"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -22,7 +23,7 @@ func NewProfileDispatcher() *ProfileDispatcher {
 }
 
 // ProcessEvent processes a compliance operator profile
-func (c *ProfileDispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAction) []*central.SensorEvent {
+func (c *ProfileDispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAction) *output.OutputMessage {
 	var complianceProfile v1alpha1.Profile
 
 	unstructuredObject, ok := obj.(*unstructured.Unstructured)
@@ -50,7 +51,7 @@ func (c *ProfileDispatcher) ProcessEvent(obj, _ interface{}, action central.Reso
 		})
 	}
 
-	return []*central.SensorEvent{
+	events := []*central.SensorEvent{
 		{
 			Id:     protoProfile.GetId(),
 			Action: action,
@@ -59,4 +60,5 @@ func (c *ProfileDispatcher) ProcessEvent(obj, _ interface{}, action central.Reso
 			},
 		},
 	}
+	return wrapOutputMessage(events, nil, nil)
 }

--- a/sensor/kubernetes/listener/resources/complianceoperator/dispatchers/complianceoperatorresults.go
+++ b/sensor/kubernetes/listener/resources/complianceoperator/dispatchers/complianceoperatorresults.go
@@ -4,6 +4,7 @@ import (
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/complianceoperator/api/v1alpha1"
+	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/output"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -39,7 +40,7 @@ func statusToProtoStatus(status v1alpha1.ComplianceCheckStatus) storage.Complian
 }
 
 // ProcessEvent processes a compliance operator check result
-func (c *ResultDispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAction) []*central.SensorEvent {
+func (c *ResultDispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAction) *output.OutputMessage {
 	var complianceCheckResult v1alpha1.ComplianceCheckResult
 
 	unstructuredObject, ok := obj.(*unstructured.Unstructured)
@@ -54,7 +55,7 @@ func (c *ResultDispatcher) ProcessEvent(obj, _ interface{}, action central.Resou
 	}
 
 	id := string(complianceCheckResult.UID)
-	return []*central.SensorEvent{
+	events := []*central.SensorEvent{
 		{
 			Id:     id,
 			Action: action,
@@ -72,4 +73,5 @@ func (c *ResultDispatcher) ProcessEvent(obj, _ interface{}, action central.Resou
 			},
 		},
 	}
+	return wrapOutputMessage(events, nil, nil)
 }

--- a/sensor/kubernetes/listener/resources/complianceoperator/dispatchers/complianceoperatorresults.go
+++ b/sensor/kubernetes/listener/resources/complianceoperator/dispatchers/complianceoperatorresults.go
@@ -4,7 +4,7 @@ import (
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/complianceoperator/api/v1alpha1"
-	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/output"
+	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/message"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -40,7 +40,7 @@ func statusToProtoStatus(status v1alpha1.ComplianceCheckStatus) storage.Complian
 }
 
 // ProcessEvent processes a compliance operator check result
-func (c *ResultDispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAction) *output.Message {
+func (c *ResultDispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAction) *message.ResourceEvent {
 	var complianceCheckResult v1alpha1.ComplianceCheckResult
 
 	unstructuredObject, ok := obj.(*unstructured.Unstructured)

--- a/sensor/kubernetes/listener/resources/complianceoperator/dispatchers/complianceoperatorresults.go
+++ b/sensor/kubernetes/listener/resources/complianceoperator/dispatchers/complianceoperatorresults.go
@@ -40,7 +40,7 @@ func statusToProtoStatus(status v1alpha1.ComplianceCheckStatus) storage.Complian
 }
 
 // ProcessEvent processes a compliance operator check result
-func (c *ResultDispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAction) *output.OutputMessage {
+func (c *ResultDispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAction) *output.Message {
 	var complianceCheckResult v1alpha1.ComplianceCheckResult
 
 	unstructuredObject, ok := obj.(*unstructured.Unstructured)

--- a/sensor/kubernetes/listener/resources/complianceoperator/dispatchers/complianceoperatorrules.go
+++ b/sensor/kubernetes/listener/resources/complianceoperator/dispatchers/complianceoperatorrules.go
@@ -4,7 +4,7 @@ import (
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/complianceoperator/api/v1alpha1"
-	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/output"
+	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/message"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -19,7 +19,7 @@ func NewRulesDispatcher() *RulesDispatcher {
 }
 
 // ProcessEvent processes a rule event
-func (c *RulesDispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAction) *output.Message {
+func (c *RulesDispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAction) *message.ResourceEvent {
 	var complianceRule v1alpha1.Rule
 
 	unstructuredObject, ok := obj.(*unstructured.Unstructured)

--- a/sensor/kubernetes/listener/resources/complianceoperator/dispatchers/complianceoperatorrules.go
+++ b/sensor/kubernetes/listener/resources/complianceoperator/dispatchers/complianceoperatorrules.go
@@ -4,6 +4,7 @@ import (
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/complianceoperator/api/v1alpha1"
+	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/output"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -18,7 +19,7 @@ func NewRulesDispatcher() *RulesDispatcher {
 }
 
 // ProcessEvent processes a rule event
-func (c *RulesDispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAction) []*central.SensorEvent {
+func (c *RulesDispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAction) *output.OutputMessage {
 	var complianceRule v1alpha1.Rule
 
 	unstructuredObject, ok := obj.(*unstructured.Unstructured)
@@ -32,7 +33,7 @@ func (c *RulesDispatcher) ProcessEvent(obj, _ interface{}, action central.Resour
 		return nil
 	}
 	id := string(complianceRule.UID)
-	return []*central.SensorEvent{
+	events := []*central.SensorEvent{
 		{
 			Id:     id,
 			Action: action,
@@ -50,4 +51,5 @@ func (c *RulesDispatcher) ProcessEvent(obj, _ interface{}, action central.Resour
 			},
 		},
 	}
+	return wrapOutputMessage(events, nil, nil)
 }

--- a/sensor/kubernetes/listener/resources/complianceoperator/dispatchers/complianceoperatorrules.go
+++ b/sensor/kubernetes/listener/resources/complianceoperator/dispatchers/complianceoperatorrules.go
@@ -19,7 +19,7 @@ func NewRulesDispatcher() *RulesDispatcher {
 }
 
 // ProcessEvent processes a rule event
-func (c *RulesDispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAction) *output.OutputMessage {
+func (c *RulesDispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAction) *output.Message {
 	var complianceRule v1alpha1.Rule
 
 	unstructuredObject, ok := obj.(*unstructured.Unstructured)

--- a/sensor/kubernetes/listener/resources/complianceoperator/dispatchers/complianceoperatorscans.go
+++ b/sensor/kubernetes/listener/resources/complianceoperator/dispatchers/complianceoperatorscans.go
@@ -4,6 +4,7 @@ import (
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/complianceoperator/api/v1alpha1"
+	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/output"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -17,7 +18,7 @@ func NewScanDispatcher() *ScanDispatcher {
 }
 
 // ProcessEvent processes a compliance operator scan
-func (c *ScanDispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAction) []*central.SensorEvent {
+func (c *ScanDispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAction) *output.OutputMessage {
 	var complianceScan v1alpha1.ComplianceScan
 
 	unstructuredObject, ok := obj.(*unstructured.Unstructured)
@@ -38,7 +39,7 @@ func (c *ScanDispatcher) ProcessEvent(obj, _ interface{}, action central.Resourc
 		Labels:      complianceScan.Labels,
 		Annotations: complianceScan.Annotations,
 	}
-	return []*central.SensorEvent{
+	events := []*central.SensorEvent{
 		{
 			Id:     protoScan.GetId(),
 			Action: action,
@@ -47,4 +48,5 @@ func (c *ScanDispatcher) ProcessEvent(obj, _ interface{}, action central.Resourc
 			},
 		},
 	}
+	return wrapOutputMessage(events, nil, nil)
 }

--- a/sensor/kubernetes/listener/resources/complianceoperator/dispatchers/complianceoperatorscans.go
+++ b/sensor/kubernetes/listener/resources/complianceoperator/dispatchers/complianceoperatorscans.go
@@ -18,7 +18,7 @@ func NewScanDispatcher() *ScanDispatcher {
 }
 
 // ProcessEvent processes a compliance operator scan
-func (c *ScanDispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAction) *output.OutputMessage {
+func (c *ScanDispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAction) *output.Message {
 	var complianceScan v1alpha1.ComplianceScan
 
 	unstructuredObject, ok := obj.(*unstructured.Unstructured)

--- a/sensor/kubernetes/listener/resources/complianceoperator/dispatchers/complianceoperatorscans.go
+++ b/sensor/kubernetes/listener/resources/complianceoperator/dispatchers/complianceoperatorscans.go
@@ -4,7 +4,7 @@ import (
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/complianceoperator/api/v1alpha1"
-	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/output"
+	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/message"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -18,7 +18,7 @@ func NewScanDispatcher() *ScanDispatcher {
 }
 
 // ProcessEvent processes a compliance operator scan
-func (c *ScanDispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAction) *output.Message {
+func (c *ScanDispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAction) *message.ResourceEvent {
 	var complianceScan v1alpha1.ComplianceScan
 
 	unstructuredObject, ok := obj.(*unstructured.Unstructured)

--- a/sensor/kubernetes/listener/resources/complianceoperator/dispatchers/complianceoperatorscansettingbindings.go
+++ b/sensor/kubernetes/listener/resources/complianceoperator/dispatchers/complianceoperatorscansettingbindings.go
@@ -19,7 +19,7 @@ func NewScanSettingBindingsDispatcher() *ScanSettingBindings {
 }
 
 // ProcessEvent processes a scan setting binding event
-func (c *ScanSettingBindings) ProcessEvent(obj, _ interface{}, action central.ResourceAction) *output.OutputMessage {
+func (c *ScanSettingBindings) ProcessEvent(obj, _ interface{}, action central.ResourceAction) *output.Message {
 	var scanSettingBindings v1alpha1.ScanSettingBinding
 
 	unstructuredObject, ok := obj.(*unstructured.Unstructured)

--- a/sensor/kubernetes/listener/resources/complianceoperator/dispatchers/complianceoperatorscansettingbindings.go
+++ b/sensor/kubernetes/listener/resources/complianceoperator/dispatchers/complianceoperatorscansettingbindings.go
@@ -4,6 +4,7 @@ import (
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/complianceoperator/api/v1alpha1"
+	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/output"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -18,7 +19,7 @@ func NewScanSettingBindingsDispatcher() *ScanSettingBindings {
 }
 
 // ProcessEvent processes a scan setting binding event
-func (c *ScanSettingBindings) ProcessEvent(obj, _ interface{}, action central.ResourceAction) []*central.SensorEvent {
+func (c *ScanSettingBindings) ProcessEvent(obj, _ interface{}, action central.ResourceAction) *output.OutputMessage {
 	var scanSettingBindings v1alpha1.ScanSettingBinding
 
 	unstructuredObject, ok := obj.(*unstructured.Unstructured)
@@ -40,7 +41,7 @@ func (c *ScanSettingBindings) ProcessEvent(obj, _ interface{}, action central.Re
 	}
 
 	id := string(scanSettingBindings.UID)
-	return []*central.SensorEvent{
+	events := []*central.SensorEvent{
 		{
 			Id:     id,
 			Action: action,
@@ -55,4 +56,5 @@ func (c *ScanSettingBindings) ProcessEvent(obj, _ interface{}, action central.Re
 			},
 		},
 	}
+	return wrapOutputMessage(events, nil, nil)
 }

--- a/sensor/kubernetes/listener/resources/complianceoperator/dispatchers/complianceoperatorscansettingbindings.go
+++ b/sensor/kubernetes/listener/resources/complianceoperator/dispatchers/complianceoperatorscansettingbindings.go
@@ -4,7 +4,7 @@ import (
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/complianceoperator/api/v1alpha1"
-	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/output"
+	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/message"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -19,7 +19,7 @@ func NewScanSettingBindingsDispatcher() *ScanSettingBindings {
 }
 
 // ProcessEvent processes a scan setting binding event
-func (c *ScanSettingBindings) ProcessEvent(obj, _ interface{}, action central.ResourceAction) *output.Message {
+func (c *ScanSettingBindings) ProcessEvent(obj, _ interface{}, action central.ResourceAction) *message.ResourceEvent {
 	var scanSettingBindings v1alpha1.ScanSettingBinding
 
 	unstructuredObject, ok := obj.(*unstructured.Unstructured)

--- a/sensor/kubernetes/listener/resources/complianceoperator/dispatchers/complianceoperatortailoredprofiles.go
+++ b/sensor/kubernetes/listener/resources/complianceoperator/dispatchers/complianceoperatortailoredprofiles.go
@@ -25,7 +25,7 @@ func NewTailoredProfileDispatcher(profileLister cache.GenericLister) *TailoredPr
 }
 
 // ProcessEvent processes a compliance operator tailored profile
-func (c *TailoredProfileDispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAction) *output.OutputMessage {
+func (c *TailoredProfileDispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAction) *output.Message {
 	var tailoredProfile v1alpha1.TailoredProfile
 
 	unstructuredObject, ok := obj.(*unstructured.Unstructured)

--- a/sensor/kubernetes/listener/resources/complianceoperator/dispatchers/complianceoperatortailoredprofiles.go
+++ b/sensor/kubernetes/listener/resources/complianceoperator/dispatchers/complianceoperatortailoredprofiles.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stackrox/rox/pkg/complianceoperator/api/v1alpha1"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/stringutils"
+	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/output"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/cache"
@@ -24,7 +25,7 @@ func NewTailoredProfileDispatcher(profileLister cache.GenericLister) *TailoredPr
 }
 
 // ProcessEvent processes a compliance operator tailored profile
-func (c *TailoredProfileDispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAction) []*central.SensorEvent {
+func (c *TailoredProfileDispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAction) *output.OutputMessage {
 	var tailoredProfile v1alpha1.TailoredProfile
 
 	unstructuredObject, ok := obj.(*unstructured.Unstructured)
@@ -88,7 +89,7 @@ func (c *TailoredProfileDispatcher) ProcessEvent(obj, _ interface{}, action cent
 		})
 	}
 
-	return []*central.SensorEvent{
+	events := []*central.SensorEvent{
 		{
 			Id:     protoProfile.GetId(),
 			Action: action,
@@ -97,4 +98,5 @@ func (c *TailoredProfileDispatcher) ProcessEvent(obj, _ interface{}, action cent
 			},
 		},
 	}
+	return wrapOutputMessage(events, nil, nil)
 }

--- a/sensor/kubernetes/listener/resources/complianceoperator/dispatchers/complianceoperatortailoredprofiles.go
+++ b/sensor/kubernetes/listener/resources/complianceoperator/dispatchers/complianceoperatortailoredprofiles.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stackrox/rox/pkg/complianceoperator/api/v1alpha1"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/stringutils"
-	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/output"
+	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/message"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/cache"
@@ -25,7 +25,7 @@ func NewTailoredProfileDispatcher(profileLister cache.GenericLister) *TailoredPr
 }
 
 // ProcessEvent processes a compliance operator tailored profile
-func (c *TailoredProfileDispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAction) *output.Message {
+func (c *TailoredProfileDispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAction) *message.ResourceEvent {
 	var tailoredProfile v1alpha1.TailoredProfile
 
 	unstructuredObject, ok := obj.(*unstructured.Unstructured)

--- a/sensor/kubernetes/listener/resources/complianceoperator/dispatchers/helper.go
+++ b/sensor/kubernetes/listener/resources/complianceoperator/dispatchers/helper.go
@@ -7,8 +7,8 @@ import (
 
 // TODO: Merge this with resources.helper
 
-func wrapOutputMessage(sensorMessages []*central.SensorEvent, detectionDeployment []output.CompatibilityDetectionMessage, reprocessDeploymentsIds []string) *output.OutputMessage {
-	return &output.OutputMessage{
+func wrapOutputMessage(sensorMessages []*central.SensorEvent, detectionDeployment []output.CompatibilityDetectionMessage, reprocessDeploymentsIds []string) *output.Message {
+	return &output.Message{
 		ForwardMessages:                  sensorMessages,
 		CompatibilityDetectionDeployment: detectionDeployment,
 		ReprocessDeployments:             reprocessDeploymentsIds,

--- a/sensor/kubernetes/listener/resources/complianceoperator/dispatchers/helper.go
+++ b/sensor/kubernetes/listener/resources/complianceoperator/dispatchers/helper.go
@@ -2,13 +2,13 @@ package dispatchers
 
 import (
 	"github.com/stackrox/rox/generated/internalapi/central"
-	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/output"
+	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/message"
 )
 
 // TODO: Merge this with resources.helper
 
-func wrapOutputMessage(sensorMessages []*central.SensorEvent, detectionDeployment []output.CompatibilityDetectionMessage, reprocessDeploymentsIds []string) *output.Message {
-	return &output.Message{
+func wrapOutputMessage(sensorMessages []*central.SensorEvent, detectionDeployment []message.CompatibilityDetectionMessage, reprocessDeploymentsIds []string) *message.ResourceEvent {
+	return &message.ResourceEvent{
 		ForwardMessages:                  sensorMessages,
 		CompatibilityDetectionDeployment: detectionDeployment,
 		ReprocessDeployments:             reprocessDeploymentsIds,

--- a/sensor/kubernetes/listener/resources/complianceoperator/dispatchers/helper.go
+++ b/sensor/kubernetes/listener/resources/complianceoperator/dispatchers/helper.go
@@ -1,9 +1,11 @@
-package resources
+package dispatchers
 
 import (
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/output"
 )
+
+// TODO: Merge this with resources.helper
 
 func wrapOutputMessage(sensorMessages []*central.SensorEvent, detectionDeployment []output.CompatibilityDetectionMessage, reprocessDeploymentsIds []string) *output.OutputMessage {
 	return &output.OutputMessage{
@@ -14,13 +16,7 @@ func wrapOutputMessage(sensorMessages []*central.SensorEvent, detectionDeploymen
 }
 
 func mergeOutputMessages(dest, src *output.OutputMessage) {
-	if dest == nil {
-		dest = &output.OutputMessage{}
-	}
-
-	if src != nil {
-		dest.ReprocessDeployments = append(dest.ReprocessDeployments, src.ReprocessDeployments...)
-		dest.ForwardMessages = append(dest.ForwardMessages, src.ForwardMessages...)
-		dest.CompatibilityDetectionDeployment = append(dest.CompatibilityDetectionDeployment)
-	}
+	dest.ReprocessDeployments = append(dest.ReprocessDeployments, src.ReprocessDeployments...)
+	dest.ForwardMessages = append(dest.ForwardMessages, src.ForwardMessages...)
+	dest.CompatibilityDetectionDeployment = append(dest.CompatibilityDetectionDeployment)
 }

--- a/sensor/kubernetes/listener/resources/complianceoperator/dispatchers/helper.go
+++ b/sensor/kubernetes/listener/resources/complianceoperator/dispatchers/helper.go
@@ -14,9 +14,3 @@ func wrapOutputMessage(sensorMessages []*central.SensorEvent, detectionDeploymen
 		ReprocessDeployments:             reprocessDeploymentsIds,
 	}
 }
-
-func mergeOutputMessages(dest, src *output.OutputMessage) {
-	dest.ReprocessDeployments = append(dest.ReprocessDeployments, src.ReprocessDeployments...)
-	dest.ForwardMessages = append(dest.ForwardMessages, src.ForwardMessages...)
-	dest.CompatibilityDetectionDeployment = append(dest.CompatibilityDetectionDeployment)
-}

--- a/sensor/kubernetes/listener/resources/convert.go
+++ b/sensor/kubernetes/listener/resources/convert.go
@@ -450,7 +450,7 @@ func (w *deploymentWrap) resetPortExposureNoLock() {
 	}
 }
 
-func (w *deploymentWrap) updatePortExposureFromStore(store *serviceStore) {
+func (w *deploymentWrap) updatePortExposureFromStore(store *ServiceStore) {
 	w.mutex.Lock()
 	defer w.mutex.Unlock()
 

--- a/sensor/kubernetes/listener/resources/deployment_dependency.go
+++ b/sensor/kubernetes/listener/resources/deployment_dependency.go
@@ -1,0 +1,53 @@
+package resources
+
+import (
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/set"
+	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/message"
+	"github.com/stackrox/rox/sensor/kubernetes/listener/resources/rbac"
+)
+
+type deploymentDependencyResolution struct {
+	store        *DeploymentStore
+	serviceStore *ServiceStore
+	rbac         rbac.Store
+}
+
+func NewDeploymentResolver(deploymentStore *DeploymentStore, serviceStore *ServiceStore, rbacStore rbac.Store) *deploymentDependencyResolution {
+	return &deploymentDependencyResolution{
+		store:        deploymentStore,
+		serviceStore: serviceStore,
+		rbac:         rbacStore,
+	}
+}
+
+func (r *deploymentDependencyResolution) ProcessDependencies(ref message.DeploymentRef) (*storage.Deployment, error) {
+	ids := set.NewStringSet(ref.Id)
+	deploymentWraps := r.store.getDeploymentsByIDs(ref.Namespace, ids)
+	if len(deploymentWraps) > 1 {
+		return nil, errors.Errorf("should have single deployment with id %s in store but instead found %d", ref.Id, len(deploymentWraps))
+	}
+
+	if len(deploymentWraps) == 0 {
+		// This probably means that the deployment was deleted before a dependent
+		// was scheduled to be processed. This can be dropped.
+		log.Debugf("Deployment id %s is not on local store. Must have been deleted", ref.Id)
+		return nil, nil
+	}
+
+	// This is the prototype of a "snapshot"
+	deploymentWrap := deploymentWraps[0].Clone()
+
+	deploymentWrap.updatePortExposureFromStore(r.serviceStore)
+	deploymentWrap.updateServiceAccountPermissionLevel(r.rbac.GetPermissionLevelForDeployment(deploymentWrap.GetDeployment()))
+	if err := deploymentWrap.updateHash(); err != nil {
+		return nil, errors.Errorf("UNEXPECTED: could not calculate hash of deployment %s: %v", deploymentWrap.GetId(), err)
+	}
+
+	// NOTE: We don't want to upsert the updated deployment in the local store
+	// if running on the new pipeline, the relationship data is always computed
+	// through this function, regardless of the event that originated.
+
+	return deploymentWrap.GetDeployment(), nil
+}

--- a/sensor/kubernetes/listener/resources/deployment_store.go
+++ b/sensor/kubernetes/listener/resources/deployment_store.go
@@ -86,6 +86,22 @@ func (ds *DeploymentStore) getMatchingDeployments(namespace string, sel selector
 	return
 }
 
+func (ds *DeploymentStore) getDeploymentsWithServiceAccountAndNamespace(namespace, sa string) (matching []*deploymentWrap) {
+	ds.lock.RLock()
+	defer ds.lock.RUnlock()
+
+	for _, depl := range ds.deployments {
+		if namespace != "" && namespace != depl.GetNamespace() {
+			// TODO: check if we really want to filter out if namespace doesn't match? Probably yes.
+			continue
+		}
+		if depl.GetServiceAccount() == sa {
+			matching = append(matching, depl)
+		}
+	}
+	return
+}
+
 // CountDeploymentsForNamespace returns the number of deployments in a namespace
 func (ds *DeploymentStore) CountDeploymentsForNamespace(namespace string) int {
 	ds.lock.RLock()

--- a/sensor/kubernetes/listener/resources/deployments.go
+++ b/sensor/kubernetes/listener/resources/deployments.go
@@ -158,14 +158,14 @@ func (d *deploymentHandler) processWithType(obj, oldObj interface{}, action cent
 		// On removes, we may not get the owning deployment ID if the deployment was deleted before the pod.
 		// This is okay. We still want to send the remove event anyway.
 		if action == central.ResourceAction_REMOVE_RESOURCE || owningDeploymentID != "" {
-			mergeOutputMessages(events, d.processPodEvent(owningDeploymentID, objAsPod, action))
+			events = mergeOutputMessages(events, d.processPodEvent(owningDeploymentID, objAsPod, action))
 		}
 	}
 
 	if deploymentWrap == nil {
 		if objAsPod != nil {
 			// It's only a pod event and the pod belongs to another resource (e.g. deployment)
-			mergeOutputMessages(events, d.maybeUpdateParentsOfPod(objAsPod, oldObj, action))
+			events = mergeOutputMessages(events, d.maybeUpdateParentsOfPod(objAsPod, oldObj, action))
 		}
 		return events
 	}
@@ -195,7 +195,7 @@ func (d *deploymentHandler) processWithType(obj, oldObj interface{}, action cent
 		},
 	}, nil)
 
-	mergeOutputMessages(events, outputMessage)
+	events = mergeOutputMessages(events, outputMessage)
 	return events
 }
 
@@ -218,7 +218,7 @@ func (d *deploymentHandler) appendIntegrationsOnCredentials(
 	for _, c := range containers {
 		if r := c.GetImage().GetName().GetRegistry(); registries.Add(r) {
 			if e := d.getImageIntegrationEvent(r); e != nil {
-				mergeOutputMessages(events, wrapOutputMessage([]*central.SensorEvent{e}, nil, nil))
+				events = mergeOutputMessages(events, wrapOutputMessage([]*central.SensorEvent{e}, nil, nil))
 			}
 		}
 	}
@@ -289,7 +289,7 @@ func (d *deploymentHandler) maybeUpdateParentsOfPod(pod *v1.Pod, oldObj interfac
 	var events *output.OutputMessage
 	for _, owner := range owners {
 		ev := d.processWithType(owner.original, nil, central.ResourceAction_UPDATE_RESOURCE, owner.Type)
-		mergeOutputMessages(events, ev)
+		events = mergeOutputMessages(events, ev)
 	}
 	return events
 }

--- a/sensor/kubernetes/listener/resources/deployments.go
+++ b/sensor/kubernetes/listener/resources/deployments.go
@@ -13,7 +13,6 @@ import (
 	"github.com/stackrox/rox/pkg/uuid"
 	"github.com/stackrox/rox/sensor/common/awscredentials"
 	"github.com/stackrox/rox/sensor/common/config"
-	"github.com/stackrox/rox/sensor/common/detector"
 	"github.com/stackrox/rox/sensor/common/registry"
 	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/output"
 	"github.com/stackrox/rox/sensor/kubernetes/listener/resources/rbac"
@@ -80,8 +79,6 @@ type deploymentHandler struct {
 	orchestratorNamespaces *orchestratornamespaces.OrchestratorNamespaces
 	registryStore          *registry.Store
 
-	detector detector.Detector
-
 	clusterID string
 }
 
@@ -97,7 +94,6 @@ func newDeploymentHandler(
 	podLister v1listers.PodLister,
 	processFilter filter.Filter,
 	config config.Handler,
-	detector detector.Detector,
 	namespaces *orchestratornamespaces.OrchestratorNamespaces,
 	registryStore *registry.Store,
 	credentialsManager awscredentials.RegistryCredentialsManager,
@@ -113,7 +109,6 @@ func newDeploymentHandler(
 		config:                 config,
 		hierarchy:              references.NewParentHierarchy(),
 		rbac:                   rbac,
-		detector:               detector,
 		orchestratorNamespaces: namespaces,
 		registryStore:          registryStore,
 		clusterID:              clusterID,

--- a/sensor/kubernetes/listener/resources/dispatcher.go
+++ b/sensor/kubernetes/listener/resources/dispatcher.go
@@ -29,7 +29,7 @@ import (
 // in response.
 //go:generate mockgen-wrapper
 type Dispatcher interface {
-	ProcessEvent(obj, oldObj interface{}, action central.ResourceAction) *output.OutputMessage
+	ProcessEvent(obj, oldObj interface{}, action central.ResourceAction) *output.Message
 }
 
 // DispatcherRegistry provides dispatchers to use.
@@ -148,12 +148,12 @@ type InformerK8sMsg struct {
 	EventsOutput []string
 }
 
-func (m dumpingDispatcher) ProcessEvent(obj, oldObj interface{}, action central.ResourceAction) *output.OutputMessage {
+func (m dumpingDispatcher) ProcessEvent(obj, oldObj interface{}, action central.ResourceAction) *output.Message {
 	now := time.Now().Unix()
 	dispType := strings.Trim(fmt.Sprintf("%T", obj), "*")
 	events := m.Dispatcher.ProcessEvent(obj, oldObj, action)
 	if events == nil {
-		events = &output.OutputMessage{}
+		events = &output.Message{}
 	}
 
 	if m.writer == nil {
@@ -198,13 +198,13 @@ type metricDispatcher struct {
 	Dispatcher
 }
 
-func (m metricDispatcher) ProcessEvent(obj, oldObj interface{}, action central.ResourceAction) *output.OutputMessage {
+func (m metricDispatcher) ProcessEvent(obj, oldObj interface{}, action central.ResourceAction) *output.Message {
 	start := time.Now().UnixNano()
 	dispatcher := strings.Trim(fmt.Sprintf("%T", obj), "*")
 
 	events := m.Dispatcher.ProcessEvent(obj, oldObj, action)
 	if events == nil {
-		events = &output.OutputMessage{}
+		events = &output.Message{}
 	}
 
 	for _, e := range events.ForwardMessages {

--- a/sensor/kubernetes/listener/resources/dispatcher.go
+++ b/sensor/kubernetes/listener/resources/dispatcher.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stackrox/rox/sensor/common/detector"
 	"github.com/stackrox/rox/sensor/common/metrics"
 	"github.com/stackrox/rox/sensor/common/registry"
+	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/output"
 	complianceOperatorDispatchers "github.com/stackrox/rox/sensor/kubernetes/listener/resources/complianceoperator/dispatchers"
 	"github.com/stackrox/rox/sensor/kubernetes/listener/resources/rbac"
 	"github.com/stackrox/rox/sensor/kubernetes/orchestratornamespaces"
@@ -28,7 +29,7 @@ import (
 // in response.
 //go:generate mockgen-wrapper
 type Dispatcher interface {
-	ProcessEvent(obj, oldObj interface{}, action central.ResourceAction) []*central.SensorEvent
+	ProcessEvent(obj, oldObj interface{}, action central.ResourceAction) *output.OutputMessage
 }
 
 // DispatcherRegistry provides dispatchers to use.
@@ -147,7 +148,7 @@ type InformerK8sMsg struct {
 	EventsOutput []string
 }
 
-func (m dumpingDispatcher) ProcessEvent(obj, oldObj interface{}, action central.ResourceAction) []*central.SensorEvent {
+func (m dumpingDispatcher) ProcessEvent(obj, oldObj interface{}, action central.ResourceAction) *output.OutputMessage {
 	now := time.Now().Unix()
 	dispType := strings.Trim(fmt.Sprintf("%T", obj), "*")
 	events := m.Dispatcher.ProcessEvent(obj, oldObj, action)
@@ -157,7 +158,7 @@ func (m dumpingDispatcher) ProcessEvent(obj, oldObj interface{}, action central.
 
 	var eventsOutput []string
 	marshaler := jsonpb.Marshaler{}
-	for _, e := range events {
+	for _, e := range events.ForwardMessages {
 		ev, err := marshaler.MarshalToString(e)
 		if err != nil {
 			log.Warnf("Error marshaling msg: %s\n", err.Error())
@@ -193,12 +194,12 @@ type metricDispatcher struct {
 	Dispatcher
 }
 
-func (m metricDispatcher) ProcessEvent(obj, oldObj interface{}, action central.ResourceAction) []*central.SensorEvent {
+func (m metricDispatcher) ProcessEvent(obj, oldObj interface{}, action central.ResourceAction) *output.OutputMessage {
 	start := time.Now().UnixNano()
 	dispatcher := strings.Trim(fmt.Sprintf("%T", obj), "*")
 
 	events := m.Dispatcher.ProcessEvent(obj, oldObj, action)
-	for _, e := range events {
+	for _, e := range events.ForwardMessages {
 		e.Timing = &central.Timing{
 			Dispatcher: dispatcher,
 			Resource:   metricsPkg.GetResourceString(e),

--- a/sensor/kubernetes/listener/resources/dispatcher.go
+++ b/sensor/kubernetes/listener/resources/dispatcher.go
@@ -14,7 +14,6 @@ import (
 	"github.com/stackrox/rox/sensor/common/awscredentials"
 	"github.com/stackrox/rox/sensor/common/clusterentities"
 	"github.com/stackrox/rox/sensor/common/config"
-	"github.com/stackrox/rox/sensor/common/detector"
 	"github.com/stackrox/rox/sensor/common/metrics"
 	"github.com/stackrox/rox/sensor/common/registry"
 	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/output"
@@ -63,7 +62,6 @@ func NewDispatcherRegistry(
 	entityStore *clusterentities.Store,
 	processFilter filter.Filter,
 	configHandler config.Handler,
-	detector detector.Detector,
 	namespaces *orchestratornamespaces.OrchestratorNamespaces,
 	credentialsManager awscredentials.RegistryCredentialsManager,
 	traceWriter io.Writer,
@@ -82,14 +80,14 @@ func NewDispatcherRegistry(
 
 	return &registryImpl{
 		deploymentHandler: newDeploymentHandler(clusterID, serviceStore, deploymentStore, podStore, endpointManager, nsStore,
-			rbacUpdater, podLister, processFilter, configHandler, detector, namespaces, registryStore, credentialsManager),
+			rbacUpdater, podLister, processFilter, configHandler, namespaces, registryStore, credentialsManager),
 
 		rbacDispatcher:            rbac.NewDispatcher(rbacUpdater),
 		namespaceDispatcher:       newNamespaceDispatcher(nsStore, serviceStore, deploymentStore, podStore, netPolicyStore),
 		serviceDispatcher:         newServiceDispatcher(serviceStore, deploymentStore, endpointManager, portExposureReconciler),
 		osRouteDispatcher:         newRouteDispatcher(serviceStore, portExposureReconciler),
 		secretDispatcher:          newSecretDispatcher(registryStore),
-		networkPolicyDispatcher:   newNetworkPolicyDispatcher(netPolicyStore, deploymentStore, detector),
+		networkPolicyDispatcher:   newNetworkPolicyDispatcher(netPolicyStore, deploymentStore),
 		nodeDispatcher:            newNodeDispatcher(serviceStore, deploymentStore, nodeStore, endpointManager),
 		serviceAccountDispatcher:  newServiceAccountDispatcher(serviceAccountStore),
 		clusterOperatorDispatcher: newClusterOperatorDispatcher(namespaces),

--- a/sensor/kubernetes/listener/resources/dispatcher.go
+++ b/sensor/kubernetes/listener/resources/dispatcher.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stackrox/rox/sensor/common/config"
 	"github.com/stackrox/rox/sensor/common/metrics"
 	"github.com/stackrox/rox/sensor/common/registry"
-	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/output"
+	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/message"
 	complianceOperatorDispatchers "github.com/stackrox/rox/sensor/kubernetes/listener/resources/complianceoperator/dispatchers"
 	"github.com/stackrox/rox/sensor/kubernetes/listener/resources/rbac"
 	"github.com/stackrox/rox/sensor/kubernetes/orchestratornamespaces"
@@ -28,7 +28,7 @@ import (
 // in response.
 //go:generate mockgen-wrapper
 type Dispatcher interface {
-	ProcessEvent(obj, oldObj interface{}, action central.ResourceAction) *output.Message
+	ProcessEvent(obj, oldObj interface{}, action central.ResourceAction) *message.ResourceEvent
 }
 
 // DispatcherRegistry provides dispatchers to use.
@@ -65,8 +65,9 @@ func NewDispatcherRegistry(
 	namespaces *orchestratornamespaces.OrchestratorNamespaces,
 	credentialsManager awscredentials.RegistryCredentialsManager,
 	traceWriter io.Writer,
+	serviceStore *ServiceStore,
+	rbacUpdater rbac.Store,
 ) DispatcherRegistry {
-	serviceStore := newServiceStore()
 	serviceAccountStore := ServiceAccountStoreSingleton()
 	deploymentStore := DeploymentStoreSingleton()
 	podStore := PodStoreSingleton()
@@ -74,7 +75,6 @@ func NewDispatcherRegistry(
 	nsStore := newNamespaceStore()
 	netPolicyStore := NetworkPolicySingleton()
 	endpointManager := newEndpointManager(serviceStore, deploymentStore, podStore, nodeStore, entityStore)
-	rbacUpdater := rbac.NewStore()
 	portExposureReconciler := newPortExposureReconciler(deploymentStore, serviceStore)
 	registryStore := registry.Singleton()
 
@@ -146,12 +146,12 @@ type InformerK8sMsg struct {
 	EventsOutput []string
 }
 
-func (m dumpingDispatcher) ProcessEvent(obj, oldObj interface{}, action central.ResourceAction) *output.Message {
+func (m dumpingDispatcher) ProcessEvent(obj, oldObj interface{}, action central.ResourceAction) *message.ResourceEvent {
 	now := time.Now().Unix()
 	dispType := strings.Trim(fmt.Sprintf("%T", obj), "*")
 	events := m.Dispatcher.ProcessEvent(obj, oldObj, action)
 	if events == nil {
-		events = &output.Message{}
+		events = &message.ResourceEvent{}
 	}
 
 	if m.writer == nil {
@@ -196,13 +196,13 @@ type metricDispatcher struct {
 	Dispatcher
 }
 
-func (m metricDispatcher) ProcessEvent(obj, oldObj interface{}, action central.ResourceAction) *output.Message {
+func (m metricDispatcher) ProcessEvent(obj, oldObj interface{}, action central.ResourceAction) *message.ResourceEvent {
 	start := time.Now().UnixNano()
 	dispatcher := strings.Trim(fmt.Sprintf("%T", obj), "*")
 
 	events := m.Dispatcher.ProcessEvent(obj, oldObj, action)
 	if events == nil {
-		events = &output.Message{}
+		events = &message.ResourceEvent{}
 	}
 
 	for _, e := range events.ForwardMessages {

--- a/sensor/kubernetes/listener/resources/dispatcher.go
+++ b/sensor/kubernetes/listener/resources/dispatcher.go
@@ -152,6 +152,10 @@ func (m dumpingDispatcher) ProcessEvent(obj, oldObj interface{}, action central.
 	now := time.Now().Unix()
 	dispType := strings.Trim(fmt.Sprintf("%T", obj), "*")
 	events := m.Dispatcher.ProcessEvent(obj, oldObj, action)
+	if events == nil {
+		events = &output.OutputMessage{}
+	}
+
 	if m.writer == nil {
 		return events
 	}
@@ -199,6 +203,10 @@ func (m metricDispatcher) ProcessEvent(obj, oldObj interface{}, action central.R
 	dispatcher := strings.Trim(fmt.Sprintf("%T", obj), "*")
 
 	events := m.Dispatcher.ProcessEvent(obj, oldObj, action)
+	if events == nil {
+		events = &output.OutputMessage{}
+	}
+
 	for _, e := range events.ForwardMessages {
 		e.Timing = &central.Timing{
 			Dispatcher: dispatcher,

--- a/sensor/kubernetes/listener/resources/endpoints.go
+++ b/sensor/kubernetes/listener/resources/endpoints.go
@@ -21,7 +21,7 @@ type endpointManager interface {
 }
 
 type endpointManagerImpl struct {
-	serviceStore    *serviceStore
+	serviceStore    *ServiceStore
 	deploymentStore *DeploymentStore
 	podStore        *PodStore
 	nodeStore       *nodeStore
@@ -29,7 +29,7 @@ type endpointManagerImpl struct {
 	entityStore *clusterentities.Store
 }
 
-func newEndpointManager(serviceStore *serviceStore, deploymentStore *DeploymentStore, podStore *PodStore, nodeStore *nodeStore, entityStore *clusterentities.Store) endpointManager {
+func newEndpointManager(serviceStore *ServiceStore, deploymentStore *DeploymentStore, podStore *PodStore, nodeStore *nodeStore, entityStore *clusterentities.Store) endpointManager {
 	return &endpointManagerImpl{
 		serviceStore:    serviceStore,
 		deploymentStore: deploymentStore,

--- a/sensor/kubernetes/listener/resources/helper.go
+++ b/sensor/kubernetes/listener/resources/helper.go
@@ -21,7 +21,7 @@ func mergeOutputMessages(dest, src *output.OutputMessage) *output.OutputMessage 
 	if src != nil {
 		dest.ReprocessDeployments = append(dest.ReprocessDeployments, src.ReprocessDeployments...)
 		dest.ForwardMessages = append(dest.ForwardMessages, src.ForwardMessages...)
-		dest.CompatibilityDetectionDeployment = append(dest.CompatibilityDetectionDeployment)
+		dest.CompatibilityDetectionDeployment = append(dest.CompatibilityDetectionDeployment, src.CompatibilityDetectionDeployment...)
 	}
 	return dest
 }

--- a/sensor/kubernetes/listener/resources/helper.go
+++ b/sensor/kubernetes/listener/resources/helper.go
@@ -2,26 +2,33 @@ package resources
 
 import (
 	"github.com/stackrox/rox/generated/internalapi/central"
-	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/output"
+	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/message"
 )
 
-func wrapOutputMessage(sensorMessages []*central.SensorEvent, detectionDeployment []output.CompatibilityDetectionMessage, reprocessDeploymentsIds []string) *output.Message {
-	return &output.Message{
+func wrapOutputMessage(sensorMessages []*central.SensorEvent, detectionDeployment []message.CompatibilityDetectionMessage, reprocessDeploymentsIds []string) *message.ResourceEvent {
+	return &message.ResourceEvent{
 		ForwardMessages:                  sensorMessages,
 		CompatibilityDetectionDeployment: detectionDeployment,
 		ReprocessDeployments:             reprocessDeploymentsIds,
 	}
 }
 
-func mergeOutputMessages(dest, src *output.Message) *output.Message {
+func deploymentIdsMessage(ids []message.DeploymentRef) *message.ResourceEvent {
+	return &message.ResourceEvent{
+		DeploymentRefs: ids,
+	}
+}
+
+func mergeOutputMessages(dest, src *message.ResourceEvent) *message.ResourceEvent {
 	if dest == nil {
-		dest = &output.Message{}
+		dest = &message.ResourceEvent{}
 	}
 
 	if src != nil {
 		dest.ReprocessDeployments = append(dest.ReprocessDeployments, src.ReprocessDeployments...)
 		dest.ForwardMessages = append(dest.ForwardMessages, src.ForwardMessages...)
 		dest.CompatibilityDetectionDeployment = append(dest.CompatibilityDetectionDeployment, src.CompatibilityDetectionDeployment...)
+		dest.DeploymentRefs = append(dest.DeploymentRefs, src.DeploymentRefs...)
 	}
 	return dest
 }

--- a/sensor/kubernetes/listener/resources/helper.go
+++ b/sensor/kubernetes/listener/resources/helper.go
@@ -1,0 +1,16 @@
+package resources
+
+import (
+	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/output"
+)
+
+func wrapOutputMessage(sensorMessages []*central.SensorEvent, action central.ResourceAction, detectionDeployment *storage.Deployment, reprocessDeploymentsIds []string) *output.OutputMessage {
+	return &output.OutputMessage{
+		ForwardMessages:                  sensorMessages,
+		Action:                           action,
+		CompatibilityDetectionDeployment: detectionDeployment,
+		ReprocessDeployments:             reprocessDeploymentsIds,
+	}
+}

--- a/sensor/kubernetes/listener/resources/helper.go
+++ b/sensor/kubernetes/listener/resources/helper.go
@@ -5,17 +5,17 @@ import (
 	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/output"
 )
 
-func wrapOutputMessage(sensorMessages []*central.SensorEvent, detectionDeployment []output.CompatibilityDetectionMessage, reprocessDeploymentsIds []string) *output.OutputMessage {
-	return &output.OutputMessage{
+func wrapOutputMessage(sensorMessages []*central.SensorEvent, detectionDeployment []output.CompatibilityDetectionMessage, reprocessDeploymentsIds []string) *output.Message {
+	return &output.Message{
 		ForwardMessages:                  sensorMessages,
 		CompatibilityDetectionDeployment: detectionDeployment,
 		ReprocessDeployments:             reprocessDeploymentsIds,
 	}
 }
 
-func mergeOutputMessages(dest, src *output.OutputMessage) *output.OutputMessage {
+func mergeOutputMessages(dest, src *output.Message) *output.Message {
 	if dest == nil {
-		dest = &output.OutputMessage{}
+		dest = &output.Message{}
 	}
 
 	if src != nil {

--- a/sensor/kubernetes/listener/resources/helper.go
+++ b/sensor/kubernetes/listener/resources/helper.go
@@ -13,7 +13,7 @@ func wrapOutputMessage(sensorMessages []*central.SensorEvent, detectionDeploymen
 	}
 }
 
-func mergeOutputMessages(dest, src *output.OutputMessage) {
+func mergeOutputMessages(dest, src *output.OutputMessage) *output.OutputMessage {
 	if dest == nil {
 		dest = &output.OutputMessage{}
 	}
@@ -23,4 +23,5 @@ func mergeOutputMessages(dest, src *output.OutputMessage) {
 		dest.ForwardMessages = append(dest.ForwardMessages, src.ForwardMessages...)
 		dest.CompatibilityDetectionDeployment = append(dest.CompatibilityDetectionDeployment)
 	}
+	return dest
 }

--- a/sensor/kubernetes/listener/resources/jobs.go
+++ b/sensor/kubernetes/listener/resources/jobs.go
@@ -4,6 +4,7 @@ import (
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/pkg/kubernetes"
 	"github.com/stackrox/rox/pkg/set"
+	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/output"
 	v1 "k8s.io/api/batch/v1"
 )
 
@@ -23,7 +24,7 @@ func newJobDispatcherImpl(handler *deploymentHandler) Dispatcher {
 }
 
 // ProcessEvent processes a deployment resource events, and returns the sensor events to emit in response.
-func (d *jobDispatcherImpl) ProcessEvent(obj, oldObj interface{}, action central.ResourceAction) []*central.SensorEvent {
+func (d *jobDispatcherImpl) ProcessEvent(obj, oldObj interface{}, action central.ResourceAction) *output.OutputMessage {
 	job, ok := obj.(*v1.Job)
 	if !ok {
 		log.Errorf("could not process object because it is not of type job: %T", obj)

--- a/sensor/kubernetes/listener/resources/jobs.go
+++ b/sensor/kubernetes/listener/resources/jobs.go
@@ -24,7 +24,7 @@ func newJobDispatcherImpl(handler *deploymentHandler) Dispatcher {
 }
 
 // ProcessEvent processes a deployment resource events, and returns the sensor events to emit in response.
-func (d *jobDispatcherImpl) ProcessEvent(obj, oldObj interface{}, action central.ResourceAction) *output.OutputMessage {
+func (d *jobDispatcherImpl) ProcessEvent(obj, oldObj interface{}, action central.ResourceAction) *output.Message {
 	job, ok := obj.(*v1.Job)
 	if !ok {
 		log.Errorf("could not process object because it is not of type job: %T", obj)

--- a/sensor/kubernetes/listener/resources/jobs.go
+++ b/sensor/kubernetes/listener/resources/jobs.go
@@ -4,7 +4,7 @@ import (
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/pkg/kubernetes"
 	"github.com/stackrox/rox/pkg/set"
-	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/output"
+	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/message"
 	v1 "k8s.io/api/batch/v1"
 )
 
@@ -24,7 +24,7 @@ func newJobDispatcherImpl(handler *deploymentHandler) Dispatcher {
 }
 
 // ProcessEvent processes a deployment resource events, and returns the sensor events to emit in response.
-func (d *jobDispatcherImpl) ProcessEvent(obj, oldObj interface{}, action central.ResourceAction) *output.Message {
+func (d *jobDispatcherImpl) ProcessEvent(obj, oldObj interface{}, action central.ResourceAction) *message.ResourceEvent {
 	job, ok := obj.(*v1.Job)
 	if !ok {
 		log.Errorf("could not process object because it is not of type job: %T", obj)

--- a/sensor/kubernetes/listener/resources/namespace.go
+++ b/sensor/kubernetes/listener/resources/namespace.go
@@ -55,5 +55,5 @@ func (h *namespaceDispatcher) ProcessEvent(obj, _ interface{}, action central.Re
 				Namespace: roxNamespace,
 			},
 		},
-		}, action, nil)
+		}, nil, nil)
 }

--- a/sensor/kubernetes/listener/resources/namespace.go
+++ b/sensor/kubernetes/listener/resources/namespace.go
@@ -4,7 +4,7 @@ import (
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/protoconv"
-	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/output"
+	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/message"
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -28,7 +28,7 @@ func newNamespaceDispatcher(nsStore *namespaceStore, deletionListeners ...Namesp
 }
 
 // ProcessEvent processes namespace resource events, and returns the sensor events to emit in response.
-func (h *namespaceDispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAction) *output.Message {
+func (h *namespaceDispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAction) *message.ResourceEvent {
 	ns := obj.(*v1.Namespace)
 
 	if action == central.ResourceAction_REMOVE_RESOURCE {

--- a/sensor/kubernetes/listener/resources/namespace.go
+++ b/sensor/kubernetes/listener/resources/namespace.go
@@ -28,7 +28,7 @@ func newNamespaceDispatcher(nsStore *namespaceStore, deletionListeners ...Namesp
 }
 
 // ProcessEvent processes namespace resource events, and returns the sensor events to emit in response.
-func (h *namespaceDispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAction) *output.OutputMessage {
+func (h *namespaceDispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAction) *output.Message {
 	ns := obj.(*v1.Namespace)
 
 	if action == central.ResourceAction_REMOVE_RESOURCE {

--- a/sensor/kubernetes/listener/resources/namespace.go
+++ b/sensor/kubernetes/listener/resources/namespace.go
@@ -4,6 +4,7 @@ import (
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/protoconv"
+	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/output"
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -27,7 +28,7 @@ func newNamespaceDispatcher(nsStore *namespaceStore, deletionListeners ...Namesp
 }
 
 // ProcessEvent processes namespace resource events, and returns the sensor events to emit in response.
-func (h *namespaceDispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAction) []*central.SensorEvent {
+func (h *namespaceDispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAction) *output.OutputMessage {
 	ns := obj.(*v1.Namespace)
 
 	if action == central.ResourceAction_REMOVE_RESOURCE {
@@ -46,12 +47,13 @@ func (h *namespaceDispatcher) ProcessEvent(obj, _ interface{}, action central.Re
 
 	h.nsStore.addNamespace(roxNamespace)
 
-	return []*central.SensorEvent{{
-		Id:     string(ns.GetUID()),
-		Action: action,
-		Resource: &central.SensorEvent_Namespace{
-			Namespace: roxNamespace,
+	return wrapOutputMessage(
+		[]*central.SensorEvent{{
+			Id:     string(ns.GetUID()),
+			Action: action,
+			Resource: &central.SensorEvent_Namespace{
+				Namespace: roxNamespace,
+			},
 		},
-	},
-	}
+		}, action, nil)
 }

--- a/sensor/kubernetes/listener/resources/networkpolicy.go
+++ b/sensor/kubernetes/listener/resources/networkpolicy.go
@@ -27,7 +27,7 @@ func newNetworkPolicyDispatcher(networkPolicyStore store.NetworkPolicyStore, dep
 }
 
 // ProcessEvent processes a network policy resource event and returns the sensor events to generate.
-func (h *networkPolicyDispatcher) ProcessEvent(obj, old interface{}, action central.ResourceAction) *output.OutputMessage {
+func (h *networkPolicyDispatcher) ProcessEvent(obj, old interface{}, action central.ResourceAction) *output.Message {
 	np := obj.(*networkingV1.NetworkPolicy)
 
 	roxNetpol := networkPolicyConversion.KubernetesNetworkPolicyWrap{NetworkPolicy: np}.ToRoxNetworkPolicy()

--- a/sensor/kubernetes/listener/resources/networkpolicy.go
+++ b/sensor/kubernetes/listener/resources/networkpolicy.go
@@ -5,7 +5,6 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/features"
 	networkPolicyConversion "github.com/stackrox/rox/pkg/protoconv/networkpolicy"
-	"github.com/stackrox/rox/sensor/common/detector"
 	"github.com/stackrox/rox/sensor/common/store"
 	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/output"
 	networkingV1 "k8s.io/api/networking/v1"
@@ -15,14 +14,12 @@ import (
 type networkPolicyDispatcher struct {
 	netpolStore     store.NetworkPolicyStore
 	deploymentStore *DeploymentStore
-	detector        detector.Detector
 }
 
-func newNetworkPolicyDispatcher(networkPolicyStore store.NetworkPolicyStore, deploymentStore *DeploymentStore, detector detector.Detector) *networkPolicyDispatcher {
+func newNetworkPolicyDispatcher(networkPolicyStore store.NetworkPolicyStore, deploymentStore *DeploymentStore) *networkPolicyDispatcher {
 	return &networkPolicyDispatcher{
 		netpolStore:     networkPolicyStore,
 		deploymentStore: deploymentStore,
-		detector:        detector,
 	}
 }
 

--- a/sensor/kubernetes/listener/resources/networkpolicy.go
+++ b/sensor/kubernetes/listener/resources/networkpolicy.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stackrox/rox/pkg/features"
 	networkPolicyConversion "github.com/stackrox/rox/pkg/protoconv/networkpolicy"
 	"github.com/stackrox/rox/sensor/common/store"
-	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/output"
+	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/message"
 	networkingV1 "k8s.io/api/networking/v1"
 )
 
@@ -24,7 +24,7 @@ func newNetworkPolicyDispatcher(networkPolicyStore store.NetworkPolicyStore, dep
 }
 
 // ProcessEvent processes a network policy resource event and returns the sensor events to generate.
-func (h *networkPolicyDispatcher) ProcessEvent(obj, old interface{}, action central.ResourceAction) *output.Message {
+func (h *networkPolicyDispatcher) ProcessEvent(obj, old interface{}, action central.ResourceAction) *message.ResourceEvent {
 	np := obj.(*networkingV1.NetworkPolicy)
 
 	roxNetpol := networkPolicyConversion.KubernetesNetworkPolicyWrap{NetworkPolicy: np}.ToRoxNetworkPolicy()

--- a/sensor/kubernetes/listener/resources/node.go
+++ b/sensor/kubernetes/listener/resources/node.go
@@ -6,18 +6,18 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/k8sutil"
 	"github.com/stackrox/rox/pkg/protoconv/k8s"
-	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/output"
+	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/message"
 	v1 "k8s.io/api/core/v1"
 )
 
 type nodeDispatcher struct {
-	serviceStore    *serviceStore
+	serviceStore    *ServiceStore
 	deploymentStore *DeploymentStore
 	nodeStore       *nodeStore
 	endpointManager endpointManager
 }
 
-func newNodeDispatcher(serviceStore *serviceStore, deploymentStore *DeploymentStore, nodeStore *nodeStore, endpointManager endpointManager) *nodeDispatcher {
+func newNodeDispatcher(serviceStore *ServiceStore, deploymentStore *DeploymentStore, nodeStore *nodeStore, endpointManager endpointManager) *nodeDispatcher {
 	return &nodeDispatcher{
 		serviceStore:    serviceStore,
 		deploymentStore: deploymentStore,
@@ -38,7 +38,7 @@ func convertTaints(taints []v1.Taint) []*storage.Taint {
 	return roxTaints
 }
 
-func (h *nodeDispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAction) *output.Message {
+func (h *nodeDispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAction) *message.ResourceEvent {
 	node := obj.(*v1.Node)
 	if action == central.ResourceAction_REMOVE_RESOURCE {
 		h.nodeStore.removeNode(node)

--- a/sensor/kubernetes/listener/resources/node.go
+++ b/sensor/kubernetes/listener/resources/node.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/k8sutil"
 	"github.com/stackrox/rox/pkg/protoconv/k8s"
+	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/output"
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -37,7 +38,7 @@ func convertTaints(taints []v1.Taint) []*storage.Taint {
 	return roxTaints
 }
 
-func (h *nodeDispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAction) []*central.SensorEvent {
+func (h *nodeDispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAction) *output.OutputMessage {
 	node := obj.(*v1.Node)
 	if action == central.ResourceAction_REMOVE_RESOURCE {
 		h.nodeStore.removeNode(node)
@@ -96,5 +97,5 @@ func (h *nodeDispatcher) ProcessEvent(obj, _ interface{}, action central.Resourc
 		},
 	}
 
-	return events
+	return wrapOutputMessage(events, nil, nil)
 }

--- a/sensor/kubernetes/listener/resources/node.go
+++ b/sensor/kubernetes/listener/resources/node.go
@@ -38,7 +38,7 @@ func convertTaints(taints []v1.Taint) []*storage.Taint {
 	return roxTaints
 }
 
-func (h *nodeDispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAction) *output.OutputMessage {
+func (h *nodeDispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAction) *output.Message {
 	node := obj.(*v1.Node)
 	if action == central.ResourceAction_REMOVE_RESOURCE {
 		h.nodeStore.removeNode(node)

--- a/sensor/kubernetes/listener/resources/port_exposure_reconciler.go
+++ b/sensor/kubernetes/listener/resources/port_exposure_reconciler.go
@@ -13,10 +13,10 @@ type portExposureReconciler interface {
 
 type portExposureReconcilerImpl struct {
 	deploymentStore *DeploymentStore
-	serviceStore    *serviceStore
+	serviceStore    *ServiceStore
 }
 
-func newPortExposureReconciler(deploymentStore *DeploymentStore, serviceStore *serviceStore) portExposureReconciler {
+func newPortExposureReconciler(deploymentStore *DeploymentStore, serviceStore *ServiceStore) portExposureReconciler {
 	return &portExposureReconcilerImpl{
 		deploymentStore: deploymentStore,
 		serviceStore:    serviceStore,

--- a/sensor/kubernetes/listener/resources/rbac/dispatcher.go
+++ b/sensor/kubernetes/listener/resources/rbac/dispatcher.go
@@ -22,7 +22,7 @@ func NewDispatcher(store Store) *Dispatcher {
 }
 
 // ProcessEvent handles RBAC-related events
-func (r *Dispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAction) *output.OutputMessage {
+func (r *Dispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAction) *output.Message {
 	evt := r.processEvent(obj, action)
 	if evt == nil {
 		utils.Should(errors.Errorf("rbac obj %+v was not correlated to a sensor event", obj))
@@ -31,7 +31,7 @@ func (r *Dispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAct
 	events := []*central.SensorEvent{
 		evt,
 	}
-	return &output.OutputMessage{
+	return &output.Message{
 		ForwardMessages:                  events,
 		CompatibilityDetectionDeployment: nil,
 		ReprocessDeployments:             nil,

--- a/sensor/kubernetes/listener/resources/rbac/dispatcher.go
+++ b/sensor/kubernetes/listener/resources/rbac/dispatcher.go
@@ -1,6 +1,8 @@
 package rbac
 
 import (
+	"strings"
+
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
@@ -21,24 +23,46 @@ func NewDispatcher(store Store) *Dispatcher {
 	}
 }
 
+type rbacUpdated struct {
+	event           *central.SensorEvent
+	topLevelUpdates []namespacedSubject
+}
+
 // ProcessEvent handles RBAC-related events
 func (r *Dispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAction) *message.ResourceEvent {
-	evt := r.processEvent(obj, action)
-	if evt == nil {
+	result := r.processEvent(obj, action)
+	if result.event == nil {
 		utils.Should(errors.Errorf("rbac obj %+v was not correlated to a sensor event", obj))
 		return nil
 	}
 	events := []*central.SensorEvent{
-		evt,
+		result.event,
 	}
 	return &message.ResourceEvent{
 		ForwardMessages:                  events,
 		CompatibilityDetectionDeployment: nil,
 		ReprocessDeployments:             nil,
+		// Deployments that must be updated
+		DeploymentRefs: mapToDeploymentRef(result.topLevelUpdates),
 	}
 }
 
-func (r *Dispatcher) processEvent(obj interface{}, action central.ResourceAction) *central.SensorEvent {
+func mapToDeploymentRef(subjects []namespacedSubject) []message.DeploymentRef {
+	var topLevelReferences []message.DeploymentRef
+	for _, subj := range subjects {
+		var ref message.DeploymentRef
+		parts := strings.Split(string(subj), "#")
+		if len(parts[0]) != 0 {
+			ref.Namespace = parts[0]
+		}
+		ref.Subject = parts[1]
+		topLevelReferences = append(topLevelReferences, ref)
+	}
+	return topLevelReferences
+}
+
+func (r *Dispatcher) processEvent(obj interface{}, action central.ResourceAction) rbacUpdated {
+	var result rbacUpdated
 	switch obj := obj.(type) {
 	case *v1.Role:
 		if action == central.ResourceAction_REMOVE_RESOURCE {
@@ -46,30 +70,45 @@ func (r *Dispatcher) processEvent(obj interface{}, action central.ResourceAction
 		} else {
 			r.store.UpsertRole(obj)
 		}
-		return toRoleEvent(toRoxRole(obj), action)
+		result.topLevelUpdates = r.store.FindSubjectsFromNamespacedRole(obj.GetNamespace(), obj.GetName())
+		result.event = toRoleEvent(toRoxRole(obj), action)
 	case *v1.RoleBinding:
+		// Try to find subjects before. Because if it's an update or delete, the bindings will be
+		// overwritten. So they need to be merged together
+		result.topLevelUpdates = r.store.FindSubjectForBinding(obj.GetNamespace(), string(obj.GetUID()))
+		binding := roleBindingToNamespacedBinding(obj)
+		result.topLevelUpdates = append(result.topLevelUpdates, binding.subjects...)
+
 		if action == central.ResourceAction_REMOVE_RESOURCE {
 			r.store.RemoveBinding(obj)
 		} else {
 			r.store.UpsertBinding(obj)
 		}
-		return toBindingEvent(r.toRoxBinding(obj), action)
+		result.event = toBindingEvent(r.toRoxBinding(obj), action)
 	case *v1.ClusterRole:
 		if action == central.ResourceAction_REMOVE_RESOURCE {
 			r.store.RemoveClusterRole(obj)
 		} else {
 			r.store.UpsertClusterRole(obj)
 		}
-		return toRoleEvent(toRoxClusterRole(obj), action)
+		result.topLevelUpdates = r.store.FindSubjectsFromNamespacedRole("", obj.GetName())
+		result.event = toRoleEvent(toRoxClusterRole(obj), action)
 	case *v1.ClusterRoleBinding:
+		// Try to find subjects before. Because if it's an update or delete, the bindings will be
+		// overwritten. So they need to be merged together
+		result.topLevelUpdates = r.store.FindSubjectForBinding(obj.GetNamespace(), string(obj.GetUID()))
+		binding := clusterRoleBindingToNamespacedBinding(obj)
+		result.topLevelUpdates = append(result.topLevelUpdates, binding.subjects...)
+
 		if action == central.ResourceAction_REMOVE_RESOURCE {
 			r.store.RemoveClusterBinding(obj)
 		} else {
 			r.store.UpsertClusterBinding(obj)
 		}
-		return toBindingEvent(r.toRoxClusterRoleBinding(obj), action)
+		result.topLevelUpdates = r.store.FindSubjectForBinding("", string(obj.GetUID()))
+		result.event = toBindingEvent(r.toRoxClusterRoleBinding(obj), action)
 	}
-	return nil
+	return result
 }
 
 func (r *Dispatcher) toRoxBinding(binding *v1.RoleBinding) *storage.K8SRoleBinding {

--- a/sensor/kubernetes/listener/resources/rbac/dispatcher.go
+++ b/sensor/kubernetes/listener/resources/rbac/dispatcher.go
@@ -5,7 +5,7 @@ import (
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/utils"
-	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/output"
+	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/message"
 	v1 "k8s.io/api/rbac/v1"
 )
 
@@ -22,7 +22,7 @@ func NewDispatcher(store Store) *Dispatcher {
 }
 
 // ProcessEvent handles RBAC-related events
-func (r *Dispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAction) *output.Message {
+func (r *Dispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAction) *message.ResourceEvent {
 	evt := r.processEvent(obj, action)
 	if evt == nil {
 		utils.Should(errors.Errorf("rbac obj %+v was not correlated to a sensor event", obj))
@@ -31,7 +31,7 @@ func (r *Dispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAct
 	events := []*central.SensorEvent{
 		evt,
 	}
-	return &output.Message{
+	return &message.ResourceEvent{
 		ForwardMessages:                  events,
 		CompatibilityDetectionDeployment: nil,
 		ReprocessDeployments:             nil,

--- a/sensor/kubernetes/listener/resources/rbac/dispatcher.go
+++ b/sensor/kubernetes/listener/resources/rbac/dispatcher.go
@@ -5,6 +5,7 @@ import (
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/utils"
+	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/output"
 	v1 "k8s.io/api/rbac/v1"
 )
 
@@ -21,14 +22,19 @@ func NewDispatcher(store Store) *Dispatcher {
 }
 
 // ProcessEvent handles RBAC-related events
-func (r *Dispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAction) []*central.SensorEvent {
+func (r *Dispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAction) *output.OutputMessage {
 	evt := r.processEvent(obj, action)
 	if evt == nil {
 		utils.Should(errors.Errorf("rbac obj %+v was not correlated to a sensor event", obj))
 		return nil
 	}
-	return []*central.SensorEvent{
+	events := []*central.SensorEvent{
 		evt,
+	}
+	return &output.OutputMessage{
+		ForwardMessages:                  events,
+		CompatibilityDetectionDeployment: nil,
+		ReprocessDeployments:             nil,
 	}
 }
 

--- a/sensor/kubernetes/listener/resources/rbac/store.go
+++ b/sensor/kubernetes/listener/resources/rbac/store.go
@@ -27,6 +27,9 @@ type Store interface {
 	UpsertClusterBinding(binding *v1.ClusterRoleBinding)
 	RemoveClusterBinding(binding *v1.ClusterRoleBinding)
 	GetPermissionLevelForDeployment(deployment NamespacedServiceAccount) storage.PermissionLevel
+
+	FindSubjectsFromNamespacedRole(namespace, roleName string) []namespacedSubject
+	FindSubjectForBinding(namespace, uuid string) []namespacedSubject
 }
 
 // NewStore creates a new instance of Store

--- a/sensor/kubernetes/listener/resources/rbac/store_impl.go
+++ b/sensor/kubernetes/listener/resources/rbac/store_impl.go
@@ -48,6 +48,32 @@ func (rs *storeImpl) GetNamespacedRoleIDOrEmpty(roleRef namespacedRoleRef) strin
 	return ""
 }
 
+func (rs *storeImpl) FindSubjectForBinding(namespace, uuid string) []namespacedSubject {
+	rs.lock.RLock()
+	defer rs.lock.RUnlock()
+
+	id := namespacedBindingID{namespace: namespace, uid: uuid}
+	if binding, ok := rs.bindings[id]; !ok {
+		return nil
+	} else {
+		return binding.subjects
+	}
+}
+
+func (rs *storeImpl) FindSubjectsFromNamespacedRole(namespace, roleName string) []namespacedSubject {
+	rs.lock.RLock()
+	defer rs.lock.RUnlock()
+
+	var matched []namespacedSubject
+	for _, binding := range rs.bindings {
+		if binding.roleRef.name == roleName && binding.roleRef.namespace == namespace {
+			matched = append(matched, binding.subjects...)
+		}
+	}
+
+	return matched
+}
+
 func (rs *storeImpl) UpsertRole(role *v1.Role) {
 	rs.lock.Lock()
 	defer rs.lock.Unlock()

--- a/sensor/kubernetes/listener/resources/route.go
+++ b/sensor/kubernetes/listener/resources/route.go
@@ -3,6 +3,7 @@ package resources
 import (
 	routeV1 "github.com/openshift/api/route/v1"
 	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/output"
 )
 
 type routeDispatcher struct {
@@ -17,7 +18,7 @@ func newRouteDispatcher(serviceStore *serviceStore, portExposureReconciler portE
 	}
 }
 
-func (r *routeDispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAction) []*central.SensorEvent {
+func (r *routeDispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAction) *output.OutputMessage {
 	route, _ := obj.(*routeV1.Route)
 	if route == nil {
 		return nil
@@ -41,5 +42,6 @@ func (r *routeDispatcher) ProcessEvent(obj, _ interface{}, action central.Resour
 	if existingService == nil {
 		return nil
 	}
-	return r.portExposureReconciler.UpdateExposuresForMatchingDeployments(existingService.Namespace, existingService.selector)
+	events := r.portExposureReconciler.UpdateExposuresForMatchingDeployments(existingService.Namespace, existingService.selector)
+	return wrapOutputMessage(events, nil, nil)
 }

--- a/sensor/kubernetes/listener/resources/route.go
+++ b/sensor/kubernetes/listener/resources/route.go
@@ -3,22 +3,22 @@ package resources
 import (
 	routeV1 "github.com/openshift/api/route/v1"
 	"github.com/stackrox/rox/generated/internalapi/central"
-	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/output"
+	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/message"
 )
 
 type routeDispatcher struct {
-	serviceStore           *serviceStore
+	serviceStore           *ServiceStore
 	portExposureReconciler portExposureReconciler
 }
 
-func newRouteDispatcher(serviceStore *serviceStore, portExposureReconciler portExposureReconciler) *routeDispatcher {
+func newRouteDispatcher(serviceStore *ServiceStore, portExposureReconciler portExposureReconciler) *routeDispatcher {
 	return &routeDispatcher{
 		serviceStore:           serviceStore,
 		portExposureReconciler: portExposureReconciler,
 	}
 }
 
-func (r *routeDispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAction) *output.Message {
+func (r *routeDispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAction) *message.ResourceEvent {
 	route, _ := obj.(*routeV1.Route)
 	if route == nil {
 		return nil

--- a/sensor/kubernetes/listener/resources/route.go
+++ b/sensor/kubernetes/listener/resources/route.go
@@ -18,7 +18,7 @@ func newRouteDispatcher(serviceStore *serviceStore, portExposureReconciler portE
 	}
 }
 
-func (r *routeDispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAction) *output.OutputMessage {
+func (r *routeDispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAction) *output.Message {
 	route, _ := obj.(*routeV1.Route)
 	if route == nil {
 		return nil

--- a/sensor/kubernetes/listener/resources/route_test.go
+++ b/sensor/kubernetes/listener/resources/route_test.go
@@ -109,7 +109,7 @@ type RouteAndServiceDispatcherTestSuite struct {
 	suite.Suite
 
 	depStore     *DeploymentStore
-	serviceStore *serviceStore
+	serviceStore *ServiceStore
 
 	serviceDispatcher *serviceDispatcher
 	routeDispatcher   *routeDispatcher
@@ -124,7 +124,7 @@ func (suite *RouteAndServiceDispatcherTestSuite) SetupTest() {
 	suite.mockEndpointManager = &mockEndpointManager{}
 
 	suite.depStore = newDeploymentStore()
-	suite.serviceStore = newServiceStore()
+	suite.serviceStore = NewServiceStore()
 	suite.serviceDispatcher = newServiceDispatcher(suite.serviceStore, suite.depStore, suite.mockEndpointManager, suite.mockReconciler)
 	suite.routeDispatcher = newRouteDispatcher(suite.serviceStore, suite.mockReconciler)
 }

--- a/sensor/kubernetes/listener/resources/secrets.go
+++ b/sensor/kubernetes/listener/resources/secrets.go
@@ -226,7 +226,7 @@ func imageIntegationIDSetFromSecret(secret *v1.Secret) (set.StringSet, error) {
 	return imageIntegrationIDSet, nil
 }
 
-func (s *secretDispatcher) processDockerConfigEvent(secret, oldSecret *v1.Secret, action central.ResourceAction) *output.OutputMessage {
+func (s *secretDispatcher) processDockerConfigEvent(secret, oldSecret *v1.Secret, action central.ResourceAction) *output.Message {
 	dockerConfig := getDockerConfigFromSecret(secret)
 	if len(dockerConfig) == 0 {
 		return nil
@@ -314,7 +314,7 @@ func getProtoSecret(secret *v1.Secret) *storage.Secret {
 	}
 }
 
-func secretToSensorEvent(action central.ResourceAction, secret *storage.Secret) *output.OutputMessage {
+func secretToSensorEvent(action central.ResourceAction, secret *storage.Secret) *output.Message {
 	event := &central.SensorEvent{
 		Id:     secret.GetId(),
 		Action: action,
@@ -326,7 +326,7 @@ func secretToSensorEvent(action central.ResourceAction, secret *storage.Secret) 
 }
 
 // ProcessEvent processes a secret resource event, and returns the sensor events to emit in response.
-func (s *secretDispatcher) ProcessEvent(obj, oldObj interface{}, action central.ResourceAction) *output.OutputMessage {
+func (s *secretDispatcher) ProcessEvent(obj, oldObj interface{}, action central.ResourceAction) *output.Message {
 	secret := obj.(*v1.Secret)
 
 	oldSecret, ok := oldObj.(*v1.Secret)

--- a/sensor/kubernetes/listener/resources/secrets.go
+++ b/sensor/kubernetes/listener/resources/secrets.go
@@ -22,7 +22,7 @@ import (
 	"github.com/stackrox/rox/pkg/uuid"
 	"github.com/stackrox/rox/sensor/common/clusterid"
 	"github.com/stackrox/rox/sensor/common/registry"
-	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/output"
+	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/message"
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -226,7 +226,7 @@ func imageIntegationIDSetFromSecret(secret *v1.Secret) (set.StringSet, error) {
 	return imageIntegrationIDSet, nil
 }
 
-func (s *secretDispatcher) processDockerConfigEvent(secret, oldSecret *v1.Secret, action central.ResourceAction) *output.Message {
+func (s *secretDispatcher) processDockerConfigEvent(secret, oldSecret *v1.Secret, action central.ResourceAction) *message.ResourceEvent {
 	dockerConfig := getDockerConfigFromSecret(secret)
 	if len(dockerConfig) == 0 {
 		return nil
@@ -314,7 +314,7 @@ func getProtoSecret(secret *v1.Secret) *storage.Secret {
 	}
 }
 
-func secretToSensorEvent(action central.ResourceAction, secret *storage.Secret) *output.Message {
+func secretToSensorEvent(action central.ResourceAction, secret *storage.Secret) *message.ResourceEvent {
 	event := &central.SensorEvent{
 		Id:     secret.GetId(),
 		Action: action,
@@ -326,7 +326,7 @@ func secretToSensorEvent(action central.ResourceAction, secret *storage.Secret) 
 }
 
 // ProcessEvent processes a secret resource event, and returns the sensor events to emit in response.
-func (s *secretDispatcher) ProcessEvent(obj, oldObj interface{}, action central.ResourceAction) *output.Message {
+func (s *secretDispatcher) ProcessEvent(obj, oldObj interface{}, action central.ResourceAction) *message.ResourceEvent {
 	secret := obj.(*v1.Secret)
 
 	oldSecret, ok := oldObj.(*v1.Secret)

--- a/sensor/kubernetes/listener/resources/secrets.go
+++ b/sensor/kubernetes/listener/resources/secrets.go
@@ -299,7 +299,7 @@ func (s *secretDispatcher) processDockerConfigEvent(secret, oldSecret *v1.Secret
 	}}
 	// return append(sensorEvents, secretToSensorEvent(action, protoSecret))
 	events := wrapOutputMessage(sensorEvents, nil, nil)
-	mergeOutputMessages(events, secretToSensorEvent(action, protoSecret))
+	events = mergeOutputMessages(events, secretToSensorEvent(action, protoSecret))
 	return events
 }
 

--- a/sensor/kubernetes/listener/resources/service.go
+++ b/sensor/kubernetes/listener/resources/service.go
@@ -4,7 +4,7 @@ import (
 	routeV1 "github.com/openshift/api/route/v1"
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
-	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/output"
+	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/message"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -119,14 +119,14 @@ func (s *serviceWithRoutes) exposure() map[portRef][]*storage.PortConfig_Exposur
 
 // serviceDispatcher handles service resource events.
 type serviceDispatcher struct {
-	serviceStore           *serviceStore
+	serviceStore           *ServiceStore
 	deploymentStore        *DeploymentStore
 	endpointManager        endpointManager
 	portExposureReconciler portExposureReconciler
 }
 
 // newServiceDispatcher creates and returns a new service handler.
-func newServiceDispatcher(serviceStore *serviceStore, deploymentStore *DeploymentStore, endpointManager endpointManager, portExposureReconciler portExposureReconciler) *serviceDispatcher {
+func newServiceDispatcher(serviceStore *ServiceStore, deploymentStore *DeploymentStore, endpointManager endpointManager, portExposureReconciler portExposureReconciler) *serviceDispatcher {
 	return &serviceDispatcher{
 		serviceStore:           serviceStore,
 		deploymentStore:        deploymentStore,
@@ -136,7 +136,7 @@ func newServiceDispatcher(serviceStore *serviceStore, deploymentStore *Deploymen
 }
 
 // ProcessEvent processes a service resource event, and returns the sensor events to emit in response.
-func (sh *serviceDispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAction) *output.Message {
+func (sh *serviceDispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAction) *message.ResourceEvent {
 	svc := obj.(*v1.Service)
 	if action == central.ResourceAction_CREATE_RESOURCE {
 		return sh.processCreate(svc)
@@ -165,13 +165,13 @@ func (sh *serviceDispatcher) ProcessEvent(obj, _ interface{}, action central.Res
 	return sh.updateDeploymentsFromStore(svc.Namespace, sel)
 }
 
-func (sh *serviceDispatcher) updateDeploymentsFromStore(namespace string, sel selector) *output.Message {
+func (sh *serviceDispatcher) updateDeploymentsFromStore(namespace string, sel selector) *message.ResourceEvent {
 	events := sh.portExposureReconciler.UpdateExposuresForMatchingDeployments(namespace, sel)
 	sh.endpointManager.OnServiceUpdateOrRemove(namespace, sel)
 	return wrapOutputMessage(events, nil, nil)
 }
 
-func (sh *serviceDispatcher) processCreate(svc *v1.Service) *output.Message {
+func (sh *serviceDispatcher) processCreate(svc *v1.Service) *message.ResourceEvent {
 	svcWrap := wrapService(svc)
 	sh.serviceStore.addOrUpdateService(svcWrap)
 	events := sh.portExposureReconciler.UpdateExposureOnServiceCreate(serviceWithRoutes{

--- a/sensor/kubernetes/listener/resources/service.go
+++ b/sensor/kubernetes/listener/resources/service.go
@@ -136,7 +136,7 @@ func newServiceDispatcher(serviceStore *serviceStore, deploymentStore *Deploymen
 }
 
 // ProcessEvent processes a service resource event, and returns the sensor events to emit in response.
-func (sh *serviceDispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAction) *output.OutputMessage {
+func (sh *serviceDispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAction) *output.Message {
 	svc := obj.(*v1.Service)
 	if action == central.ResourceAction_CREATE_RESOURCE {
 		return sh.processCreate(svc)
@@ -165,13 +165,13 @@ func (sh *serviceDispatcher) ProcessEvent(obj, _ interface{}, action central.Res
 	return sh.updateDeploymentsFromStore(svc.Namespace, sel)
 }
 
-func (sh *serviceDispatcher) updateDeploymentsFromStore(namespace string, sel selector) *output.OutputMessage {
+func (sh *serviceDispatcher) updateDeploymentsFromStore(namespace string, sel selector) *output.Message {
 	events := sh.portExposureReconciler.UpdateExposuresForMatchingDeployments(namespace, sel)
 	sh.endpointManager.OnServiceUpdateOrRemove(namespace, sel)
 	return wrapOutputMessage(events, nil, nil)
 }
 
-func (sh *serviceDispatcher) processCreate(svc *v1.Service) *output.OutputMessage {
+func (sh *serviceDispatcher) processCreate(svc *v1.Service) *output.Message {
 	svcWrap := wrapService(svc)
 	sh.serviceStore.addOrUpdateService(svcWrap)
 	events := sh.portExposureReconciler.UpdateExposureOnServiceCreate(serviceWithRoutes{

--- a/sensor/kubernetes/listener/resources/service_store.go
+++ b/sensor/kubernetes/listener/resources/service_store.go
@@ -13,8 +13,8 @@ type routeRef struct {
 	name      string
 }
 
-// serviceStore stores service objects (by namespace and UID)
-type serviceStore struct {
+// ServiceStore stores service objects (by namespace and UID)
+type ServiceStore struct {
 	// namespace->name->svcWrap
 	services map[string]map[string]*serviceWrap
 	// namespace->serviceName->routes
@@ -26,9 +26,9 @@ type serviceStore struct {
 	lock sync.RWMutex
 }
 
-// newServiceStore creates and returns a new service store.
-func newServiceStore() *serviceStore {
-	return &serviceStore{
+// NewServiceStore creates and returns a new service store.
+func NewServiceStore() *ServiceStore {
+	return &ServiceStore{
 		services:                make(map[string]map[string]*serviceWrap),
 		routesByServiceMetadata: make(map[string]map[string][]*routeV1.Route),
 		routesByRouteRef:        make(map[routeRef]*routeV1.Route),
@@ -36,7 +36,7 @@ func newServiceStore() *serviceStore {
 	}
 }
 
-func (ss *serviceStore) upsertRoute(route *routeV1.Route) {
+func (ss *ServiceStore) upsertRoute(route *routeV1.Route) {
 	ss.lock.Lock()
 	defer ss.lock.Unlock()
 	ref := routeRef{name: route.Name, namespace: route.Namespace}
@@ -52,12 +52,12 @@ func (ss *serviceStore) upsertRoute(route *routeV1.Route) {
 	nsMap[route.Spec.To.Name] = append(nsMap[route.Spec.To.Name], route)
 }
 
-func (ss *serviceStore) removeRoute(route *routeV1.Route) {
+func (ss *ServiceStore) removeRoute(route *routeV1.Route) {
 	ss.lock.Lock()
 	defer ss.lock.Unlock()
 	ss.removeRouteNoLock(route)
 }
-func (ss *serviceStore) removeRouteNoLock(route *routeV1.Route) {
+func (ss *ServiceStore) removeRouteNoLock(route *routeV1.Route) {
 	nsMap := ss.routesByServiceMetadata[route.Namespace]
 	thisRouteIdx := -1
 	svcName := route.Spec.To.Name
@@ -82,7 +82,7 @@ func (ss *serviceStore) removeRouteNoLock(route *routeV1.Route) {
 	delete(ss.routesByRouteRef, routeRef{name: route.Name, namespace: route.Namespace})
 }
 
-func (ss *serviceStore) addOrUpdateService(svc *serviceWrap) {
+func (ss *ServiceStore) addOrUpdateService(svc *serviceWrap) {
 	ss.lock.Lock()
 	defer ss.lock.Unlock()
 
@@ -100,7 +100,7 @@ func (ss *serviceStore) addOrUpdateService(svc *serviceWrap) {
 }
 
 // NodePortServicesSnapshot returns a snapshot of the service wraps
-func (ss *serviceStore) NodePortServicesSnapshot() []*serviceWrap {
+func (ss *ServiceStore) NodePortServicesSnapshot() []*serviceWrap {
 	ss.lock.RLock()
 	defer ss.lock.RUnlock()
 
@@ -111,7 +111,7 @@ func (ss *serviceStore) NodePortServicesSnapshot() []*serviceWrap {
 	return wraps
 }
 
-func (ss *serviceStore) removeService(svc *v1.Service) {
+func (ss *ServiceStore) removeService(svc *v1.Service) {
 	ss.lock.Lock()
 	defer ss.lock.Unlock()
 
@@ -124,7 +124,7 @@ func (ss *serviceStore) removeService(svc *v1.Service) {
 }
 
 // OnNamespaceDeleted reacts to a namespace deletion, deleting all services in that namespace from the store.
-func (ss *serviceStore) OnNamespaceDeleted(ns string) {
+func (ss *ServiceStore) OnNamespaceDeleted(ns string) {
 	ss.lock.Lock()
 	defer ss.lock.Unlock()
 
@@ -132,7 +132,7 @@ func (ss *serviceStore) OnNamespaceDeleted(ns string) {
 	delete(ss.routesByServiceMetadata, ns)
 }
 
-func (ss *serviceStore) getMatchingServicesWithRoutes(namespace string, labels map[string]string) (matching []serviceWithRoutes) {
+func (ss *ServiceStore) getMatchingServicesWithRoutes(namespace string, labels map[string]string) (matching []serviceWithRoutes) {
 	labelSet := k8sLabels.Set(labels)
 	ss.lock.RLock()
 	defer ss.lock.RUnlock()
@@ -148,13 +148,13 @@ func (ss *serviceStore) getMatchingServicesWithRoutes(namespace string, labels m
 	return matching
 }
 
-func (ss *serviceStore) getService(namespace string, name string) *serviceWrap {
+func (ss *ServiceStore) getService(namespace string, name string) *serviceWrap {
 	ss.lock.RLock()
 	defer ss.lock.RUnlock()
 
 	return ss.services[namespace][name]
 }
 
-func (ss *serviceStore) getRoutesForService(svcWrap *serviceWrap) []*routeV1.Route {
+func (ss *ServiceStore) getRoutesForService(svcWrap *serviceWrap) []*routeV1.Route {
 	return ss.routesByServiceMetadata[svcWrap.Namespace][svcWrap.Name]
 }

--- a/sensor/kubernetes/listener/resources/serviceaccount.go
+++ b/sensor/kubernetes/listener/resources/serviceaccount.go
@@ -21,7 +21,7 @@ func newServiceAccountDispatcher(serviceAccountStore *ServiceAccountStore) *serv
 }
 
 // ProcessEvent processes a service account resource event, and returns the sensor events to emit in response.
-func (s *serviceAccountDispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAction) *output.OutputMessage {
+func (s *serviceAccountDispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAction) *output.Message {
 	serviceAccount := obj.(*v1.ServiceAccount)
 
 	var serviceAccountSecrets []string

--- a/sensor/kubernetes/listener/resources/serviceaccount.go
+++ b/sensor/kubernetes/listener/resources/serviceaccount.go
@@ -4,7 +4,7 @@ import (
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/protoconv"
-	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/output"
+	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/message"
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -21,7 +21,7 @@ func newServiceAccountDispatcher(serviceAccountStore *ServiceAccountStore) *serv
 }
 
 // ProcessEvent processes a service account resource event, and returns the sensor events to emit in response.
-func (s *serviceAccountDispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAction) *output.Message {
+func (s *serviceAccountDispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAction) *message.ResourceEvent {
 	serviceAccount := obj.(*v1.ServiceAccount)
 
 	var serviceAccountSecrets []string

--- a/sensor/kubernetes/listener/resources/serviceaccount.go
+++ b/sensor/kubernetes/listener/resources/serviceaccount.go
@@ -4,6 +4,7 @@ import (
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/protoconv"
+	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/output"
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -20,7 +21,7 @@ func newServiceAccountDispatcher(serviceAccountStore *ServiceAccountStore) *serv
 }
 
 // ProcessEvent processes a service account resource event, and returns the sensor events to emit in response.
-func (s *serviceAccountDispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAction) []*central.SensorEvent {
+func (s *serviceAccountDispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAction) *output.OutputMessage {
 	serviceAccount := obj.(*v1.ServiceAccount)
 
 	var serviceAccountSecrets []string
@@ -57,11 +58,12 @@ func (s *serviceAccountDispatcher) ProcessEvent(obj, _ interface{}, action centr
 		s.serviceAccountStore.Add(sa.ServiceAccount)
 	}
 
-	return []*central.SensorEvent{
+	events := []*central.SensorEvent{
 		{
 			Id:       string(serviceAccount.UID),
 			Action:   action,
 			Resource: sa,
 		},
 	}
+	return wrapOutputMessage(events, nil, nil)
 }

--- a/sensor/kubernetes/sensor/sensor.go
+++ b/sensor/kubernetes/sensor/sensor.go
@@ -41,13 +41,13 @@ import (
 	"github.com/stackrox/rox/sensor/kubernetes/clustermetrics"
 	"github.com/stackrox/rox/sensor/kubernetes/clusterstatus"
 	"github.com/stackrox/rox/sensor/kubernetes/enforcer"
+	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline"
 	"github.com/stackrox/rox/sensor/kubernetes/listener/resources"
 	"github.com/stackrox/rox/sensor/kubernetes/localscanner"
 	"github.com/stackrox/rox/sensor/kubernetes/networkpolicies"
 	"github.com/stackrox/rox/sensor/kubernetes/orchestrator"
 	"github.com/stackrox/rox/sensor/kubernetes/telemetry"
 	"github.com/stackrox/rox/sensor/kubernetes/upgrade"
-	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline"
 )
 
 var (
@@ -103,7 +103,6 @@ func CreateSensor(cfg *CreateOptions) (*sensor.Sensor, error) {
 	imageCache := expiringcache.NewExpiringCache(env.ReprocessInterval.DurationSetting())
 	policyDetector := detector.New(enforcer, admCtrlSettingsMgr, resources.DeploymentStoreSingleton(), resources.ServiceAccountStoreSingleton(), imageCache, auditLogEventsInput, auditLogCollectionManager, resources.NetworkPolicySingleton())
 	pipeline := eventpipeline.New(cfg.k8sClient, configHandler, policyDetector, k8sNodeName.Setting(), cfg.resyncPeriod, cfg.traceWriter)
-	// resourceListener := listener.New(cfg.k8sClient, configHandler, policyDetector, k8sNodeName.Setting(), cfg.resyncPeriod, cfg.traceWriter)
 	admCtrlMsgForwarder := admissioncontroller.NewAdmCtrlMsgForwarder(admCtrlSettingsMgr, pipeline)
 
 	imageService := image.NewService(imageCache, registry.Singleton())

--- a/sensor/kubernetes/sensor/sensor.go
+++ b/sensor/kubernetes/sensor/sensor.go
@@ -41,13 +41,13 @@ import (
 	"github.com/stackrox/rox/sensor/kubernetes/clustermetrics"
 	"github.com/stackrox/rox/sensor/kubernetes/clusterstatus"
 	"github.com/stackrox/rox/sensor/kubernetes/enforcer"
-	"github.com/stackrox/rox/sensor/kubernetes/listener"
 	"github.com/stackrox/rox/sensor/kubernetes/listener/resources"
 	"github.com/stackrox/rox/sensor/kubernetes/localscanner"
 	"github.com/stackrox/rox/sensor/kubernetes/networkpolicies"
 	"github.com/stackrox/rox/sensor/kubernetes/orchestrator"
 	"github.com/stackrox/rox/sensor/kubernetes/telemetry"
 	"github.com/stackrox/rox/sensor/kubernetes/upgrade"
+	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline"
 )
 
 var (
@@ -102,8 +102,9 @@ func CreateSensor(cfg *CreateOptions) (*sensor.Sensor, error) {
 
 	imageCache := expiringcache.NewExpiringCache(env.ReprocessInterval.DurationSetting())
 	policyDetector := detector.New(enforcer, admCtrlSettingsMgr, resources.DeploymentStoreSingleton(), resources.ServiceAccountStoreSingleton(), imageCache, auditLogEventsInput, auditLogCollectionManager, resources.NetworkPolicySingleton())
-	resourceListener := listener.New(cfg.k8sClient, configHandler, policyDetector, k8sNodeName.Setting(), cfg.resyncPeriod, cfg.traceWriter)
-	admCtrlMsgForwarder := admissioncontroller.NewAdmCtrlMsgForwarder(admCtrlSettingsMgr, resourceListener)
+	pipeline := eventpipeline.New(cfg.k8sClient, configHandler, policyDetector, k8sNodeName.Setting(), cfg.resyncPeriod, cfg.traceWriter)
+	// resourceListener := listener.New(cfg.k8sClient, configHandler, policyDetector, k8sNodeName.Setting(), cfg.resyncPeriod, cfg.traceWriter)
+	admCtrlMsgForwarder := admissioncontroller.NewAdmCtrlMsgForwarder(admCtrlSettingsMgr, pipeline)
 
 	imageService := image.NewService(imageCache, registry.Singleton())
 	complianceCommandHandler := compliance.NewCommandHandler(complianceService)

--- a/sensor/tests/resource/helper.go
+++ b/sensor/tests/resource/helper.go
@@ -259,6 +259,7 @@ func (c *TestContext) LastDeploymentStateWithTimeout(name string, assertion Asse
 			messages := c.GetFakeCentral().GetAllMessages()
 			lastDeploymentUpdate := GetLastMessageWithDeploymentName(messages, "sensor-integration", name)
 			deployment := lastDeploymentUpdate.GetEvent().GetDeployment()
+			c.t.Logf("checking state on deployment %v (%v) \n", deployment, messages)
 			if deployment != nil {
 				if lastErr = assertion(deployment); lastErr == nil {
 					return


### PR DESCRIPTION
## Description

A prototype that (seems to) work for disabling the re-sync for deployments and RBACs. 🎉 

Note: services most likely fail, since they are still don't implement parent lookup like RBACs.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
