### PR TITLE
Implement collection attacher component.

### DIFF
--- a/ui/apps/platform/src/Components/PatternFly/BacklogListSelector.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/BacklogListSelector.tsx
@@ -79,6 +79,8 @@ function BacklogTable<Item>({
                                         variant="link"
                                         onClick={() => listAction(item)}
                                         icon={actionIcon}
+                                        className="pf-u-text-nowrap"
+                                        isInline
                                     >
                                         {buttonText}
                                     </Button>

--- a/ui/apps/platform/src/Components/PatternFly/BacklogListSelector.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/BacklogListSelector.tsx
@@ -1,0 +1,166 @@
+import React, { Key, ReactNode } from 'react';
+import {
+    Badge,
+    Button,
+    EmptyState,
+    EmptyStateIcon,
+    EmptyStateVariant,
+    Flex,
+    FormGroup,
+    Title,
+} from '@patternfly/react-core';
+import { CubesIcon, MinusCircleIcon, PlusCircleIcon } from '@patternfly/react-icons';
+
+import {
+    BaseCellProps,
+    TableComposable,
+    TableVariant,
+    Tbody,
+    Td,
+    Tr,
+} from '@patternfly/react-table';
+
+type BacklogTableProps<Item> = {
+    type: 'selected' | 'deselected';
+    label: string | undefined;
+    items: Item[];
+    listAction: (item: Item) => void;
+    rowKey: (item: Item) => Key;
+    cells: {
+        name: string;
+        render: (item: Item) => ReactNode;
+        width?: BaseCellProps['width'];
+    }[];
+    buttonText: string;
+};
+
+function BacklogTable<Item>({
+    type,
+    label,
+    items,
+    listAction,
+    rowKey,
+    cells,
+    buttonText,
+}: BacklogTableProps<Item>) {
+    const actionIcon =
+        type === 'selected' ? (
+            <MinusCircleIcon color="var(--pf-global--danger-color--200)" />
+        ) : (
+            <PlusCircleIcon color="var(--pf-global--primary-color--100)" />
+        );
+    return (
+        <FormGroup
+            label={
+                <>
+                    {label}
+                    <Badge className="pf-u-ml-sm" isRead>
+                        {items.length}
+                    </Badge>
+                </>
+            }
+        >
+            {items.length > 0 ? (
+                <TableComposable aria-label={label} variant={TableVariant.compact}>
+                    <Tbody>
+                        {items.map((item) => (
+                            <Tr key={rowKey(item)}>
+                                {cells.map(({ name, width, render }) => (
+                                    <Td key={name} dataLabel={name} width={width}>
+                                        {render(item)}
+                                    </Td>
+                                ))}
+                                <Td width={10} dataLabel="Item action">
+                                    <Button
+                                        variant="link"
+                                        onClick={() => listAction(item)}
+                                        icon={actionIcon}
+                                    >
+                                        {buttonText}
+                                    </Button>
+                                </Td>
+                            </Tr>
+                        ))}
+                    </Tbody>
+                </TableComposable>
+            ) : (
+                <EmptyState variant={EmptyStateVariant.xs}>
+                    <EmptyStateIcon icon={CubesIcon} />
+                    <Title headingLevel="h4">No items remaining</Title>
+                </EmptyState>
+            )}
+        </FormGroup>
+    );
+}
+
+export type BacklogListSelectorProps<Item> = {
+    selectedOptions: Item[];
+    deselectedOptions: Item[];
+    onSelectItem: (item: Item) => void;
+    onDeselectItem: (item: Item) => void;
+    onSelectionChange?: (selected: Item[], deselected: Item[]) => void;
+    rowKey: (item: Item) => Key;
+    cells: {
+        name: string;
+        render: (item: Item) => ReactNode;
+    }[];
+    selectedLabel?: string;
+    deselectedLabel?: string;
+    selectButtonText?: string;
+    deselectButtonText?: string;
+};
+
+function BacklogListSelector<Item>({
+    selectedOptions,
+    deselectedOptions,
+    onSelectItem,
+    onDeselectItem,
+    onSelectionChange = () => {},
+    rowKey,
+    cells,
+    selectedLabel = 'Selected items',
+    deselectedLabel = 'Deselected items',
+    selectButtonText = 'Add',
+    deselectButtonText = 'Remove',
+}: BacklogListSelectorProps<Item>) {
+    function onSelect(item: Item) {
+        onSelectItem(item);
+        onSelectionChange(
+            selectedOptions.concat(item),
+            deselectedOptions.filter((option) => option !== item)
+        );
+    }
+
+    function onDeselect(item: Item) {
+        onDeselectItem(item);
+        onSelectionChange(
+            selectedOptions.filter((option) => option !== item),
+            deselectedOptions.concat(item)
+        );
+    }
+
+    return (
+        <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsXl' }}>
+            <BacklogTable
+                type="selected"
+                label={selectedLabel}
+                items={selectedOptions}
+                listAction={onDeselect}
+                buttonText={deselectButtonText}
+                rowKey={rowKey}
+                cells={cells}
+            />
+            <BacklogTable
+                type="deselected"
+                label={deselectedLabel}
+                items={deselectedOptions}
+                listAction={onSelect}
+                rowKey={rowKey}
+                buttonText={selectButtonText}
+                cells={cells}
+            />
+        </Flex>
+    );
+}
+
+export default BacklogListSelector;

--- a/ui/apps/platform/src/Components/PatternFly/BacklogListSelector.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/BacklogListSelector.tsx
@@ -32,6 +32,7 @@ type BacklogTableProps<Item> = {
         width?: BaseCellProps['width'];
     }[];
     buttonText: string;
+    showBadge: boolean;
 };
 
 function BacklogTable<Item>({
@@ -42,6 +43,7 @@ function BacklogTable<Item>({
     rowKey,
     cells,
     buttonText,
+    showBadge,
 }: BacklogTableProps<Item>) {
     const actionIcon =
         type === 'selected' ? (
@@ -54,9 +56,11 @@ function BacklogTable<Item>({
             label={
                 <>
                     {label}
-                    <Badge className="pf-u-ml-sm" isRead>
-                        {items.length}
-                    </Badge>
+                    {showBadge && (
+                        <Badge className="pf-u-ml-sm" isRead>
+                            {items.length}
+                        </Badge>
+                    )}
                 </>
             }
         >
@@ -108,6 +112,7 @@ export type BacklogListSelectorProps<Item> = {
     deselectedLabel?: string;
     selectButtonText?: string;
     deselectButtonText?: string;
+    showBadge?: boolean;
 };
 
 function BacklogListSelector<Item>({
@@ -122,6 +127,7 @@ function BacklogListSelector<Item>({
     deselectedLabel = 'Deselected items',
     selectButtonText = 'Add',
     deselectButtonText = 'Remove',
+    showBadge = false,
 }: BacklogListSelectorProps<Item>) {
     function onSelect(item: Item) {
         onSelectItem(item);
@@ -149,6 +155,7 @@ function BacklogListSelector<Item>({
                 buttonText={deselectButtonText}
                 rowKey={rowKey}
                 cells={cells}
+                showBadge={showBadge}
             />
             <BacklogTable
                 type="deselected"
@@ -158,6 +165,7 @@ function BacklogListSelector<Item>({
                 rowKey={rowKey}
                 buttonText={selectButtonText}
                 cells={cells}
+                showBadge={showBadge}
             />
         </Flex>
     );

--- a/ui/apps/platform/src/Containers/Collections/CollectionAttacher.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionAttacher.tsx
@@ -2,8 +2,8 @@ import React, { useMemo, useState } from 'react';
 import { Alert, Button, debounce, Flex, SearchInput, Truncate } from '@patternfly/react-core';
 
 import BacklogListSelector from 'Components/PatternFly/BacklogListSelector';
+import { CollectionResponse } from 'services/CollectionsService';
 import useEmbeddedCollections from './hooks/useEmbeddedCollections';
-import { CollectionSlim } from './types';
 
 const selectorListCells = [
     {
@@ -21,8 +21,8 @@ const selectorListCells = [
 ];
 
 export type CollectionAttacherProps = {
-    initialEmbeddedCollections: CollectionSlim[];
-    onSelectionChange: (collections: CollectionSlim[]) => void;
+    initialEmbeddedCollections: CollectionResponse[];
+    onSelectionChange: (collections: CollectionResponse[]) => void;
 };
 
 function compareNameLowercase(search: string): (item: { name: string }) => boolean {

--- a/ui/apps/platform/src/Containers/Collections/CollectionAttacher.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionAttacher.tsx
@@ -36,7 +36,7 @@ function CollectionAttacher({
     const [search, setSearch] = useState('');
     const embedded = useEmbeddedCollections(initialEmbeddedCollections);
     const { attached, detached, attach, detach, hasMore, fetchMore, onSearch } = embedded;
-    const { fetchMoreLoading, fetchMoreError } = embedded;
+    const { isFetchingMore, fetchMoreError } = embedded;
 
     const onSearchInputChange = useMemo(
         () =>
@@ -83,7 +83,7 @@ function CollectionAttacher({
                     className="pf-u-align-self-flex-start"
                     variant="secondary"
                     onClick={() => fetchMore(search)}
-                    isLoading={fetchMoreLoading}
+                    isLoading={isFetchingMore}
                 >
                     View more
                 </Button>

--- a/ui/apps/platform/src/Containers/Collections/CollectionAttacher.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionAttacher.tsx
@@ -53,8 +53,8 @@ function CollectionAttacher({
     return (
         <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsXl' }}>
             <SearchInput
-                aria-label="Search by name"
-                placeholder="Search by name"
+                aria-label="Filter by name"
+                placeholder="Filter by name"
                 value={search}
                 onChange={onSearchInputChange}
             />

--- a/ui/apps/platform/src/Containers/Collections/CollectionAttacher.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionAttacher.tsx
@@ -1,7 +1,95 @@
-import React from 'react';
+import React, { useMemo, useState } from 'react';
+import { Alert, Button, debounce, Flex, SearchInput, Truncate } from '@patternfly/react-core';
 
-function CollectionAttacher() {
-    return <></>;
+import BacklogListSelector from 'Components/PatternFly/BacklogListSelector';
+import useEmbeddedCollections from './hooks/useEmbeddedCollections';
+import { CollectionSlim } from './types';
+
+const selectorListCells = [
+    {
+        name: 'Name',
+        render: ({ name }) => (
+            <Button variant="link" className="pf-u-pl-0">
+                {name}
+            </Button>
+        ),
+    },
+    {
+        name: 'Description',
+        render: ({ description }) => <Truncate content={description} />,
+    },
+];
+
+export type CollectionAttacherProps = {
+    initialEmbeddedCollections: CollectionSlim[];
+    onSelectionChange: (collections: CollectionSlim[]) => void;
+};
+
+function compareNameLowercase(search: string): (item: { name: string }) => boolean {
+    return ({ name }) => name.toLowerCase().includes(search.toLowerCase());
+}
+
+function CollectionAttacher({
+    initialEmbeddedCollections,
+    onSelectionChange,
+}: CollectionAttacherProps) {
+    const [search, setSearch] = useState('');
+    const embedded = useEmbeddedCollections(initialEmbeddedCollections);
+    const { attached, detached, attach, detach, hasMore, fetchMore, onSearch } = embedded;
+    const { fetchMoreLoading, fetchMoreError } = embedded;
+
+    const onSearchInputChange = useMemo(
+        () =>
+            debounce((value: string) => {
+                setSearch(value);
+                onSearch(value);
+            }, 800),
+        [onSearch]
+    );
+
+    const selectedOptions = attached.filter(compareNameLowercase(search));
+    const deselectedOptions = detached.filter(compareNameLowercase(search));
+
+    return (
+        <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsXl' }}>
+            <SearchInput
+                aria-label="Search by name"
+                placeholder="Search by name"
+                value={search}
+                onChange={onSearchInputChange}
+            />
+            <BacklogListSelector
+                selectedOptions={selectedOptions}
+                deselectedOptions={deselectedOptions}
+                onSelectItem={({ id }) => attach(id)}
+                onDeselectItem={({ id }) => detach(id)}
+                onSelectionChange={onSelectionChange}
+                rowKey={({ id }) => id}
+                cells={selectorListCells}
+                selectedLabel="Attached collections"
+                deselectedLabel="Detached collections"
+                selectButtonText="Attach"
+                deselectButtonText="Detach"
+            />
+            {fetchMoreError && (
+                <Alert
+                    variant="danger"
+                    isInline
+                    title="There was an error loading more collections"
+                />
+            )}
+            {hasMore && (
+                <Button
+                    className="pf-u-align-self-flex-start"
+                    variant="secondary"
+                    onClick={() => fetchMore(search)}
+                    isLoading={fetchMoreLoading}
+                >
+                    View more
+                </Button>
+            )}
+        </Flex>
+    );
 }
 
 export default CollectionAttacher;

--- a/ui/apps/platform/src/Containers/Collections/CollectionAttacher.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionAttacher.tsx
@@ -9,7 +9,7 @@ const selectorListCells = [
     {
         name: 'Name',
         render: ({ name }) => (
-            <Button variant="link" className="pf-u-pl-0">
+            <Button variant="link" className="pf-u-pl-0" isInline>
                 {name}
             </Button>
         ),

--- a/ui/apps/platform/src/Containers/Collections/CollectionsTable.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionsTable.tsx
@@ -85,7 +85,7 @@ function CollectionsTable({
     const onSearchInputChange = useMemo(
         () =>
             debounce(
-                (value: string) => setSearchFilter({ Collection: value }),
+                (value: string) => setSearchFilter({ 'Collection Name': value }),
                 SEARCH_INPUT_REQUEST_DELAY
             ),
         [setSearchFilter]

--- a/ui/apps/platform/src/Containers/Collections/hooks/useEmbeddedCollections.ts
+++ b/ui/apps/platform/src/Containers/Collections/hooks/useEmbeddedCollections.ts
@@ -1,0 +1,276 @@
+import { useReducer, useEffect, Dispatch } from 'react';
+import sortBy from 'lodash/sortBy';
+
+import { listCollections } from 'services/CollectionsService';
+import { ensureExhaustive } from 'utils/type.utils';
+import { CollectionSlim } from '../types';
+
+type CollectionMap = Record<string, CollectionSlim>;
+
+// `pageSize` is the default number of items that will attempt to be pulled when the user
+// loads more items in the detached collections section
+const pageSize = 10;
+// `minimumUpdateSize` is the minimum number of results that would be added to the UI without
+// triggering an additional request. If after client side filtering, the number of new collections
+// is below this number, we will pull another page worth of data.
+const minimumUpdateSize = pageSize / 2;
+
+/**
+ * Fetches more collections, aiming to update the client table with a minimum
+ * number of results. Collections that are already present client side will be filtered out
+ * from the server response. The number of collections added to the user's screen should be
+ * `minimumClientFetchResults` <= collections.length <= `pageSize`
+ *
+ * If the actual results to add to the detached collections list after filtering is not over the
+ * minimum, we fetch the next page and concat the two result lists. Repeat this process until
+ * we have enough results to show the user.
+ *
+ * If the response from the server contains less collections then the page size, display all
+ * aggregated results and set `hasMore` to `false`.
+ *
+ * @param clientMap
+ *      A mapping of {id -> collection} for all attached and detached collections that
+ *      are currently displayed in the UI.
+ * @param searchValue
+ *      A search string to used to filter collections by name.
+ * @param pageNumber
+ *      The current page of collections to fetch.
+ * @param aggregateResult
+ *      The aggregated list of collections built up by multiple successive calls to this function.
+ * @returns
+ *      A Promise that resolves with the retrieved detached collection list, the next
+ *      number, and the number of items returned in the last call to the server.
+ */
+function fetchDetachedCollections(
+    clientMap: CollectionMap,
+    searchValue: string,
+    pageNumber: number,
+    aggregateResult: CollectionSlim[]
+): Promise<{
+    detached: CollectionSlim[];
+    nextPage: number;
+    lastResponseSize: number;
+}> {
+    const searchOption = { 'Collection Name': searchValue };
+    const { request } = listCollections(
+        searchOption,
+        { field: 'name', reversed: false },
+        pageNumber - 1,
+        pageSize
+    );
+
+    return request.then((collections) => {
+        const newDetached = collections.filter(({ id }) => !clientMap[id]);
+        const detached = aggregateResult.concat(newDetached);
+        const lastResponseSize = collections.length;
+        const shouldFetchMore = lastResponseSize > 0 && detached.length < minimumUpdateSize;
+        const nextPage = pageNumber + 1;
+
+        if (shouldFetchMore) {
+            return fetchDetachedCollections(clientMap, searchValue, nextPage, detached);
+        }
+        return Promise.resolve({ detached, nextPage, lastResponseSize });
+    });
+}
+
+/**
+ * Given the current attached and detached lists displayed to the user, attempt to fetch
+ * more detached collections from the server.
+ */
+function fetchMore(
+    attached: CollectionMap,
+    detached: CollectionMap,
+    searchValue: string,
+    currentPage: number,
+    dispatch: Dispatch<ReducerPayload>
+) {
+    dispatch({ type: 'fetchMoreRequest' });
+
+    fetchDetachedCollections({ ...attached, ...detached }, searchValue, currentPage, [])
+        .then(({ detached: newDetached, nextPage, lastResponseSize }) => {
+            const nextDetached = { ...detached };
+            newDetached.forEach((collection) => {
+                nextDetached[collection.id] = collection;
+            });
+            dispatch({
+                type: 'fetchMoreComplete',
+                detached: nextDetached,
+                hasMore: lastResponseSize >= pageSize,
+                page: nextPage,
+            });
+        })
+        .catch((error) => {
+            dispatch({ type: 'fetchMoreError', error });
+        });
+}
+
+function moveItem(from: CollectionMap, to: CollectionMap, id: string) {
+    const toMap = { ...to };
+    const fromMap = { ...from };
+    const item = fromMap[id];
+    if (item) {
+        toMap[id] = item;
+        delete fromMap[id];
+    }
+    return [fromMap, toMap];
+}
+
+function arrayToMap(collections: CollectionSlim[]): Record<string, CollectionSlim> {
+    const map = {};
+    collections.forEach(({ id, ...rest }) => {
+        map[id] = { id, ...rest };
+    });
+    return map;
+}
+
+type UseEmbeddedCollectionsState = {
+    page: number;
+    hasMore: boolean;
+    fetchMoreLoading: boolean;
+    fetchMoreError: Error | null;
+    attached: CollectionMap;
+    detached: CollectionMap;
+};
+
+type ReducerPayload =
+    | { type: 'fetchMoreRequest' }
+    | { type: 'fetchMoreComplete'; detached: CollectionMap; page: number; hasMore: boolean }
+    | { type: 'fetchMoreError'; error: Error }
+    | { type: 'attachCollection'; id: string }
+    | { type: 'detachCollection'; id: string }
+    | { type: 'resetDetachedList' };
+
+function embeddedCollectionsReducer(
+    state: UseEmbeddedCollectionsState,
+    payload: ReducerPayload
+): UseEmbeddedCollectionsState {
+    switch (payload.type) {
+        case 'fetchMoreRequest':
+            return { ...state, fetchMoreLoading: true };
+        case 'fetchMoreComplete': {
+            return { ...state, ...payload, fetchMoreLoading: false, fetchMoreError: null };
+        }
+        case 'fetchMoreError':
+            return {
+                ...state,
+                fetchMoreLoading: false,
+                fetchMoreError: payload.error,
+            };
+        case 'attachCollection': {
+            const { id } = payload;
+            const [detached, attached] = moveItem(state.detached, state.attached, id);
+            return { ...state, attached, detached };
+        }
+        case 'detachCollection': {
+            const { id } = payload;
+            const [attached, detached] = moveItem(state.attached, state.detached, id);
+            return { ...state, attached, detached };
+        }
+        case 'resetDetachedList':
+            return { ...state, page: 1, hasMore: true, detached: {} };
+        default:
+            return ensureExhaustive(payload);
+    }
+}
+
+const initialState = {
+    page: 1,
+    hasMore: true,
+    fetchMoreLoading: false,
+    fetchMoreError: null,
+    detached: {},
+};
+
+export type UseEmbeddedCollectionsReturn = {
+    /** Client side state of attached collections */
+    attached: CollectionSlim[];
+    /** Client side state of detached collections */
+    detached: CollectionSlim[];
+    /** Move a collection from detached -> attached by id */
+    attach: (id: string) => void;
+    /** Move a collection from attached -> detached by id */
+    detach: (id: string) => void;
+    /** Whether or not more collections might be available to be loaded from the server */
+    hasMore: boolean;
+    /** Loads another page of collections from the server */
+    fetchMore: (search: string) => void;
+    /** Callback to fire when the search string changes */
+    onSearch: (search: string) => void;
+    /** Whether or not the current fetchMore request is loading */
+    fetchMoreLoading: boolean;
+    /** If a fetchMore request fails, the error, or null */
+    fetchMoreError: Error | null;
+};
+
+/**
+ * This hook maintains the 'attached' and 'detached' list of collections that are displayed in the
+ * UI and provides functions that can be used to modify them.
+ *
+ * Upon initialization, do the following:
+ * - Load a subset (page) of detached collections and store in a local object.
+ * - Store the most recent requested page number of detached collections.
+ * - Store whether or not _all_ of the detached collections have been loaded from the backend.
+ *
+ * When the user attaches a collection, remove it from the unattached list and
+ * add it to the attached list. Vice-versa when a user un-attaches a collection.
+ *
+ * If all of the unattached collections have not yet been loaded, display a "View more" button below the
+ * unattached list. If the user clicks this button, fetch the next page of unattached collections.
+ * - If there less results than the page size, remove the View more button. All items have been loaded client side.
+ * - If there are > zero results, remove any items from the results that exist in the
+ *   "attached" object or "detached" object to prevent rendering duplicates. This will occur when the
+ *   user has loaded some items and made changes to which collections are attached without saving.
+ * - If a "View more" request returns results, but the results are reduced below a threshold
+ *   when filtering due to local collection state, automatically refetch the next page for better UX.
+ *   This process will repeat until either no collections are returned from the server or the threshold
+ *   of items to display has been met.
+ *
+ * When the user enters a value in the search box:
+ *  - Filter the list of attached collections _during rendering only_.
+ *  - Clear the current page number, "hasMore" boolean, and local cache of unattached collections.
+ *  - Fetch the first page of unattached collections again, and resume the above functionality with the
+ *    filter in place.
+ *  - [Note] We cannot just filter the unattached list during rendering and make subsequent page fetches
+ *    with the search filter applied as that would leave holes in the unfiltered cache data when the user
+ *    clears the search value. On the other hand, running multiple "fetch more" requests and filtering
+ *    results by the search filter could result in many useless requests that lead to a bad UX.
+ *  - [Bonus] It may be nice in the future to be able to maintain multiple caches, keyed by search term, to avoid
+ *    many requests if the user clears the search box or reuses the search terms. Alternatively we could just keep a
+ *    "no search" cache, and a "search" cache to cover the two most expected use cases.
+ *  - [Bonus] In the future, we should track when the user has loaded all collections _without_ search filtering
+ *    as we can then disable the cache clearing/fetching behavior and filter the client side cache directly.
+ *
+ * @param initialAttachedCollectionIds
+ *      A list of attached collection ids used to populate the initial attached collection list.
+ */
+export default function useEmbeddedCollections(
+    initialAttachedCollections: CollectionSlim[]
+): UseEmbeddedCollectionsReturn {
+    const [state, dispatch] = useReducer(embeddedCollectionsReducer, initialState, (init) => ({
+        ...init,
+        attached: arrayToMap(initialAttachedCollections),
+    }));
+
+    const { attached, detached, page, hasMore, fetchMoreLoading, fetchMoreError } = state;
+
+    useEffect(() => {
+        return fetchMore(arrayToMap(initialAttachedCollections), {}, '', 1, dispatch);
+    }, [initialAttachedCollections]);
+
+    const onSearch = (search: string) => {
+        dispatch({ type: 'resetDetachedList' });
+        fetchMore(attached, {}, search, 1, dispatch);
+    };
+
+    return {
+        attached: sortBy(Object.values(attached), 'name'),
+        detached: sortBy(Object.values(detached), 'name'),
+        attach: (id: string) => dispatch({ type: 'attachCollection', id }),
+        detach: (id: string) => dispatch({ type: 'detachCollection', id }),
+        hasMore,
+        fetchMore: (search: string) => fetchMore(attached, detached, search, page, dispatch),
+        onSearch,
+        fetchMoreLoading,
+        fetchMoreError,
+    };
+}

--- a/ui/apps/platform/src/Containers/Collections/hooks/useEmbeddedCollections.ts
+++ b/ui/apps/platform/src/Containers/Collections/hooks/useEmbeddedCollections.ts
@@ -125,7 +125,7 @@ function arrayToMap(collections: CollectionResponse[]): Record<string, Collectio
 type UseEmbeddedCollectionsState = {
     page: number;
     hasMore: boolean;
-    fetchMoreLoading: boolean;
+    isFetchingMore: boolean;
     fetchMoreError: Error | null;
     attached: CollectionMap;
     detached: CollectionMap;
@@ -145,14 +145,14 @@ function embeddedCollectionsReducer(
 ): UseEmbeddedCollectionsState {
     switch (payload.type) {
         case 'fetchMoreRequest':
-            return { ...state, fetchMoreLoading: true };
+            return { ...state, isFetchingMore: true };
         case 'fetchMoreComplete': {
-            return { ...state, ...payload, fetchMoreLoading: false, fetchMoreError: null };
+            return { ...state, ...payload, isFetchingMore: false, fetchMoreError: null };
         }
         case 'fetchMoreError':
             return {
                 ...state,
-                fetchMoreLoading: false,
+                isFetchingMore: false,
                 fetchMoreError: payload.error,
             };
         case 'attachCollection': {
@@ -175,7 +175,7 @@ function embeddedCollectionsReducer(
 const initialState = {
     page: 1,
     hasMore: true,
-    fetchMoreLoading: false,
+    isFetchingMore: false,
     fetchMoreError: null,
     detached: {},
 };
@@ -196,7 +196,7 @@ export type UseEmbeddedCollectionsReturn = {
     /** Callback to fire when the search string changes */
     onSearch: (search: string) => void;
     /** Whether or not the current fetchMore request is loading */
-    fetchMoreLoading: boolean;
+    isFetchingMore: boolean;
     /** If a fetchMore request fails, the error, or null */
     fetchMoreError: Error | null;
 };
@@ -250,7 +250,7 @@ export default function useEmbeddedCollections(
         attached: arrayToMap(initialAttachedCollections),
     }));
 
-    const { attached, detached, page, hasMore, fetchMoreLoading, fetchMoreError } = state;
+    const { attached, detached, page, hasMore, isFetchingMore, fetchMoreError } = state;
 
     useEffect(() => {
         return fetchMore(arrayToMap(initialAttachedCollections), {}, '', 1, dispatch);
@@ -269,7 +269,7 @@ export default function useEmbeddedCollections(
         hasMore,
         fetchMore: (search: string) => fetchMore(attached, detached, search, page, dispatch),
         onSearch,
-        fetchMoreLoading,
+        isFetchingMore,
         fetchMoreError,
     };
 }

--- a/ui/apps/platform/src/Containers/Collections/hooks/useEmbeddedCollections.ts
+++ b/ui/apps/platform/src/Containers/Collections/hooks/useEmbeddedCollections.ts
@@ -1,11 +1,10 @@
 import { useReducer, useEffect, Dispatch } from 'react';
 import sortBy from 'lodash/sortBy';
 
-import { listCollections } from 'services/CollectionsService';
+import { CollectionResponse, listCollections } from 'services/CollectionsService';
 import { ensureExhaustive } from 'utils/type.utils';
-import { CollectionSlim } from '../types';
 
-type CollectionMap = Record<string, CollectionSlim>;
+type CollectionMap = Record<string, CollectionResponse>;
 
 // `pageSize` is the default number of items that will attempt to be pulled when the user
 // loads more items in the detached collections section
@@ -45,9 +44,9 @@ function fetchDetachedCollections(
     clientMap: CollectionMap,
     searchValue: string,
     pageNumber: number,
-    aggregateResult: CollectionSlim[]
+    aggregateResult: CollectionResponse[]
 ): Promise<{
-    detached: CollectionSlim[];
+    detached: CollectionResponse[];
     nextPage: number;
     lastResponseSize: number;
 }> {
@@ -115,7 +114,7 @@ function moveItem(from: CollectionMap, to: CollectionMap, id: string) {
     return [fromMap, toMap];
 }
 
-function arrayToMap(collections: CollectionSlim[]): Record<string, CollectionSlim> {
+function arrayToMap(collections: CollectionResponse[]): Record<string, CollectionResponse> {
     const map = {};
     collections.forEach(({ id, ...rest }) => {
         map[id] = { id, ...rest };
@@ -183,9 +182,9 @@ const initialState = {
 
 export type UseEmbeddedCollectionsReturn = {
     /** Client side state of attached collections */
-    attached: CollectionSlim[];
+    attached: CollectionResponse[];
     /** Client side state of detached collections */
-    detached: CollectionSlim[];
+    detached: CollectionResponse[];
     /** Move a collection from detached -> attached by id */
     attach: (id: string) => void;
     /** Move a collection from attached -> detached by id */
@@ -244,7 +243,7 @@ export type UseEmbeddedCollectionsReturn = {
  *      A list of attached collection ids used to populate the initial attached collection list.
  */
 export default function useEmbeddedCollections(
-    initialAttachedCollections: CollectionSlim[]
+    initialAttachedCollections: CollectionResponse[]
 ): UseEmbeddedCollectionsReturn {
     const [state, dispatch] = useReducer(embeddedCollectionsReducer, initialState, (init) => ({
         ...init,

--- a/ui/apps/platform/src/Containers/Collections/parser.ts
+++ b/ui/apps/platform/src/Containers/Collections/parser.ts
@@ -10,7 +10,6 @@ import {
     isByLabelSelector,
     isByNameField,
     isByLabelField,
-    CollectionSlim,
 } from './types';
 
 const fieldToEntityMap: Record<SelectorField, SelectorEntityType> = {
@@ -32,14 +31,12 @@ const LABEL_SEPARATOR = '=';
  * of a `Collection` that can be supported by the current UI controls. If any incompatibilities are detected
  * it will return a list of validation errors to the caller.
  */
-export function parseCollection(
-    data: CollectionResponse & { embedded: CollectionSlim[] }
-): Collection | AggregateError {
+export function parseCollection(data: CollectionResponse): Collection | AggregateError {
     const collection: Collection = {
         name: data.name,
         description: data.description,
         inUse: data.inUse,
-        embeddedCollections: data.embedded,
+        embeddedCollections: data.embeddedCollections.map(({ id }) => id),
         resourceSelectors: {
             Deployment: {},
             Namespace: {},

--- a/ui/apps/platform/src/Containers/Collections/parser.ts
+++ b/ui/apps/platform/src/Containers/Collections/parser.ts
@@ -10,6 +10,7 @@ import {
     isByLabelSelector,
     isByNameField,
     isByLabelField,
+    CollectionSlim,
 } from './types';
 
 const fieldToEntityMap: Record<SelectorField, SelectorEntityType> = {
@@ -31,12 +32,14 @@ const LABEL_SEPARATOR = '=';
  * of a `Collection` that can be supported by the current UI controls. If any incompatibilities are detected
  * it will return a list of validation errors to the caller.
  */
-export function parseCollection(data: CollectionResponse): Collection | AggregateError {
+export function parseCollection(
+    data: CollectionResponse & { embedded: CollectionSlim[] }
+): Collection | AggregateError {
     const collection: Collection = {
         name: data.name,
         description: data.description,
         inUse: data.inUse,
-        embeddedCollectionIds: data.embeddedCollections.map(({ id }) => id),
+        embeddedCollections: data.embedded,
         resourceSelectors: {
             Deployment: {},
             Namespace: {},

--- a/ui/apps/platform/src/Containers/Collections/types.ts
+++ b/ui/apps/platform/src/Containers/Collections/types.ts
@@ -72,8 +72,6 @@ export function isByLabelSelector(
     return isByLabelField(selector.field);
 }
 
-export type CollectionSlim = { id: string; name: string; description: string };
-
 /**
  * `Collection` is the front end representation of a valid collection, which is more
  * restricted than Collection objects that can be created via the API.
@@ -84,5 +82,5 @@ export type Collection = {
     description: string;
     inUse: boolean;
     resourceSelectors: Record<SelectorEntityType, ScopedResourceSelector>;
-    embeddedCollections: CollectionSlim[];
+    embeddedCollections: string[];
 };

--- a/ui/apps/platform/src/Containers/Collections/types.ts
+++ b/ui/apps/platform/src/Containers/Collections/types.ts
@@ -72,6 +72,8 @@ export function isByLabelSelector(
     return isByLabelField(selector.field);
 }
 
+export type CollectionSlim = { id: string; name: string; description: string };
+
 /**
  * `Collection` is the front end representation of a valid collection, which is more
  * restricted than Collection objects that can be created via the API.
@@ -82,5 +84,5 @@ export type Collection = {
     description: string;
     inUse: boolean;
     resourceSelectors: Record<SelectorEntityType, ScopedResourceSelector>;
-    embeddedCollectionIds: string[];
+    embeddedCollections: CollectionSlim[];
 };

--- a/ui/apps/platform/src/services/CollectionsService.ts
+++ b/ui/apps/platform/src/services/CollectionsService.ts
@@ -45,8 +45,8 @@ export type CollectionResponse = {
 export function listCollections(
     searchFilter: SearchFilter,
     sortOption: ApiSortOption,
-    page: number,
-    pageSize: number
+    page?: number,
+    pageSize?: number
 ): CancellableRequest<CollectionResponse[]> {
     const params = getListQueryParams(searchFilter, sortOption, page, pageSize);
     return makeCancellableAxiosRequest((signal) =>

--- a/ui/apps/platform/src/utils/searchUtils.ts
+++ b/ui/apps/platform/src/utils/searchUtils.ts
@@ -185,10 +185,13 @@ export function flattenFilterValue<UndefinedFallback>(
 export function getListQueryParams(
     searchFilter: SearchFilter,
     sortOption: ApiSortOption,
-    page: number,
-    pageSize: number
+    page?: number,
+    pageSize?: number
 ): string {
-    const offset = page > 0 ? page * pageSize : 0;
+    let offset: number | undefined;
+    if (typeof page === 'number' && typeof pageSize === 'number') {
+        offset = page > 0 ? page * pageSize : 0;
+    }
     const query = getRequestQueryStringForSearchFilter(searchFilter);
     return qs.stringify(
         {

--- a/ui/apps/platform/src/utils/type.utils.ts
+++ b/ui/apps/platform/src/utils/type.utils.ts
@@ -1,0 +1,8 @@
+/**
+ * This function is not callable. This can be used to ensure at compile time that a given code
+ * block cannot be reached, such as in the `default` case of a switch/case block to ensure
+ * all possible cases are covered.
+ */
+export function ensureExhaustive(_: never): never {
+    return _;
+}


### PR DESCRIPTION
## Description

Adds a UI component that allows users to attach and detach "embedded" collections from a collection configuration.

When the initial collection data is loaded, a secondary request will fetch metadata for all of the embedded collections of the initial collection. These embedded collections will make up the attached list in the widget, and are not paginated. 

Once this data is loaded and the form is rendered, the collection attacher component will attempt to fetch a page of detached collections (everything else in the system). Since this secondary request may include collections that are already part of the attached list, we need to filter the results client side. If this filtering results in less than half a page load, we fetch an additional page worth of data. The idea being we want to prevent situations where "View more" returns a full page sometimes, and then very few another time (possibly even zero), which could lead to looking like buggy behavior.

When the user enters a search term, the locally cached list of detached collections is cleared out and the page counter is reset. This will require refetching the detached collections, now filtered by search term. This could cause some wasted requests, but the alternative of keeping the cache and filtering client side had larger problems. If we don't clear cache and all data has not yet been loaded, there would be two ways to handle the follow up "view more" requests:

1. Pass the search term along with the request. This would have good performance, but would leave holes in the local cache data if the user then removed the search term. We would need to clear the local cache anyway or be unable to present the full data set to the user.
2. _Don't_ pass the search term along with the request, and filter the results client side. This would build up the local cache cleanly and show the user the full, accurate set of data. The downside here is that a search term with few, or zero, matches would create a string of requests that load all of the collections from the server. Worst case would be multiple sequential requests with a loading spinner that eventually resulted in no new data.

I've documented some potential workarounds and optimizations for this in the code that we can do as follow ups if needed.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Visit the collections page, and select a collection that has embedded collection data:
<img width="1676" alt="image" src="https://user-images.githubusercontent.com/1292638/198688512-9eea39cf-d996-4a8f-a5fc-7d43769ee292.png">

Clicking the "Attach" button should remove items from the bottom list and place them in the top list:
<img width="1676" alt="image" src="https://user-images.githubusercontent.com/1292638/198688617-2fa56074-c3c4-4679-9f64-daaee707ecb2.png">
<img width="1676" alt="image" src="https://user-images.githubusercontent.com/1292638/198689283-621ad5ca-0f66-44d1-931f-58ee37a280a9.png">

Clicking the "Detach" button should move items from the top list to the bottom list:
<img width="1676" alt="image" src="https://user-images.githubusercontent.com/1292638/198689485-431f714a-9bbf-49fe-9219-d8ebdc06e00f.png">
<img width="1676" alt="image" src="https://user-images.githubusercontent.com/1292638/198689506-2fe79ca5-c50d-40af-9d89-97be3e0f779b.png">

Entering a search value should filter the top and bottom lists by collection name, case insensitive:
<img width="1676" alt="image" src="https://user-images.githubusercontent.com/1292638/198689639-e112c195-3484-4f5d-b462-92839b4feb5f.png">
Clearing the filter should return the list to its previous state:
<img width="1676" alt="image" src="https://user-images.githubusercontent.com/1292638/198689708-0e5cc383-fdc5-456d-88b5-de9fa0f04dc8.png">

**To demo the "View more" behavior, I manually changed the `pageSize` and minimum threshold to be `1`.**

If there are more results on the server, a "View more" button should be displayed. 
<img width="1676" alt="image" src="https://user-images.githubusercontent.com/1292638/198693810-9e050eb1-b257-47a1-9ac4-231caf648609.png">

Clicking this button should load another page of results:
<img width="1676" alt="image" src="https://user-images.githubusercontent.com/1292638/198693848-07de168f-73a8-4ab3-8dc6-2403b5f23b1a.png">
<img width="1676" alt="image" src="https://user-images.githubusercontent.com/1292638/198693904-5a440c5b-df74-48ba-a3e0-5bf40b764aa5.png">

Continuously clicking this button will load more and more results from the server.

Note that when we get to the fifth item, two network requests are sent instead of one. This is because the first request contains only "Notable deployments", which is already present in the attached list. Since this would result in no new items in the detached collections list, another request is sent.
<img width="1676" alt="image" src="https://user-images.githubusercontent.com/1292638/198694253-2e7ef5f3-5603-4371-86fc-ddf92e05ec5d.png">

When all results have been loaded by the server, the view more button disappears.
<img width="1676" alt="image" src="https://user-images.githubusercontent.com/1292638/198694417-ed91cfc6-1993-4440-9699-895b45eed531.png">

Test that layout is usable on small screens:
<img width="350" alt="image" src="https://user-images.githubusercontent.com/1292638/198694911-e82e2c84-132c-43e2-ad2c-576d5555fb15.png">



