### PR TITLE
Improve helper functions for credentialexpiry and systemconfig integration tests

### DIFF
--- a/ui/apps/platform/cypress/constants/SystemConfigPage.js
+++ b/ui/apps/platform/cypress/constants/SystemConfigPage.js
@@ -1,7 +1,5 @@
 import navigationSelectors from '../selectors/navigation';
 
-export const systemConfigUrl = '/main/systemconfig';
-
 const selectors = {
     navLinks: {
         configure: `${navigationSelectors.navExpandable}:contains("Platform Configuration")`,
@@ -13,7 +11,6 @@ const selectors = {
     pageHeader: {
         editButton: 'button:contains("Edit")',
         cancelButton: 'button:contains("Cancel")',
-        saveButton: 'button:contains("Save")',
     },
     header: {
         widget: '[data-testid="header-config"]',

--- a/ui/apps/platform/cypress/constants/apiEndpoints.js
+++ b/ui/apps/platform/cypress/constants/apiEndpoints.js
@@ -192,11 +192,6 @@ export const riskAcceptance = {
     markVulnerabilityFalsePositive: graphql('markVulnerabilityFalsePositive'),
 };
 
-export const system = {
-    config: '/v1/config',
-    configPublic: '/v1/config/public',
-};
-
 export const extensions = {
     diagnostics: '/api/extensions/diagnostics',
 };

--- a/ui/apps/platform/cypress/constants/apiEndpoints.js
+++ b/ui/apps/platform/cypress/constants/apiEndpoints.js
@@ -88,16 +88,6 @@ export const auth = {
     tokenRefresh: '/sso/session/tokenrefresh',
 };
 
-export const certExpiry = {
-    central: 'v1/credentialexpiry?component=CENTRAL',
-    scanner: 'v1/credentialexpiry?component=SCANNER',
-};
-
-export const certGen = {
-    central: 'api/extensions/certgen/central',
-    scanner: 'api/extensions/certgen/scanner',
-};
-
 export const dashboard = {
     summaryCounts: graphql('summary_counts'),
 };

--- a/ui/apps/platform/cypress/helpers/credentialExpiry.js
+++ b/ui/apps/platform/cypress/helpers/credentialExpiry.js
@@ -6,7 +6,11 @@ import {
 
 // credentialexpiry
 
-function renderCredentialExpiryBanner(componentUpperCase, expiry, staticResponseForPermissions) {
+function visitSystemConfigurationWithCredentialExpiryBanner(
+    componentUpperCase,
+    expiry,
+    staticResponseForPermissions
+) {
     const credentialExpiryAlias = 'credentialexpiry';
 
     const requestConfig = {
@@ -35,12 +39,26 @@ function renderCredentialExpiryBanner(componentUpperCase, expiry, staticResponse
     waitForResponses(requestConfig);
 }
 
-export function renderCentralCredentialExpiryBanner(expiry, staticResponseForPermissions) {
-    renderCredentialExpiryBanner('CENTRAL', expiry, staticResponseForPermissions);
+export function visitSystemConfigurationWithCentralCredentialExpiryBanner(
+    expiry,
+    staticResponseForPermissions
+) {
+    visitSystemConfigurationWithCredentialExpiryBanner(
+        'CENTRAL',
+        expiry,
+        staticResponseForPermissions
+    );
 }
 
-export function renderScannerCredentialExpiryBanner(expiry, staticResponseForPermissions) {
-    renderCredentialExpiryBanner('SCANNER', expiry, staticResponseForPermissions);
+export function visitSystemConfigurationWithScannerCredentialExpiryBanner(
+    expiry,
+    staticResponseForPermissions
+) {
+    visitSystemConfigurationWithCredentialExpiryBanner(
+        'SCANNER',
+        expiry,
+        staticResponseForPermissions
+    );
 }
 
 // certgen

--- a/ui/apps/platform/cypress/helpers/credentialExpiry.js
+++ b/ui/apps/platform/cypress/helpers/credentialExpiry.js
@@ -1,0 +1,63 @@
+import { interactAndWaitForResponses, interceptRequests, waitForResponses } from './request';
+import {
+    visitSystemConfiguration,
+    visitSystemConfigurationWithStaticResponseForPermissions,
+} from './systemConfig';
+
+// credentialexpiry
+
+function renderCredentialExpiryBanner(componentUpperCase, expiry, staticResponseForPermissions) {
+    const credentialExpiryAlias = 'credentialexpiry';
+
+    const requestConfig = {
+        routeMatcherMap: {
+            [credentialExpiryAlias]: {
+                method: 'GET',
+                url: `/v1/credentialexpiry?component=${componentUpperCase}`,
+            },
+        },
+    };
+
+    const staticResponseMap = {
+        [credentialExpiryAlias]: {
+            body: { expiry },
+        },
+    };
+
+    interceptRequests(requestConfig, staticResponseMap);
+
+    if (staticResponseForPermissions) {
+        visitSystemConfigurationWithStaticResponseForPermissions(staticResponseForPermissions);
+    } else {
+        visitSystemConfiguration();
+    }
+
+    waitForResponses(requestConfig);
+}
+
+export function renderCentralCredentialExpiryBanner(expiry, staticResponseForPermissions) {
+    renderCredentialExpiryBanner('CENTRAL', expiry, staticResponseForPermissions);
+}
+
+export function renderScannerCredentialExpiryBanner(expiry, staticResponseForPermissions) {
+    renderCredentialExpiryBanner('SCANNER', expiry, staticResponseForPermissions);
+}
+
+// certgen
+
+function interactAndWaitForCertificateDownload(componentLowerCase, interactionCallback) {
+    const requestConfig = {
+        method: 'POST',
+        url: `api/extensions/certgen/${componentLowerCase}`,
+    };
+
+    interactAndWaitForResponses(interactionCallback, requestConfig);
+}
+
+export function interactAndWaitForCentralCertificateDownload(interactionCallback) {
+    interactAndWaitForCertificateDownload('central', interactionCallback);
+}
+
+export function interactAndWaitForScannerCertificateDownload(interactionCallback) {
+    interactAndWaitForCertificateDownload('scanner', interactionCallback);
+}

--- a/ui/apps/platform/cypress/helpers/credentialExpiry.js
+++ b/ui/apps/platform/cypress/helpers/credentialExpiry.js
@@ -47,8 +47,10 @@ export function renderScannerCredentialExpiryBanner(expiry, staticResponseForPer
 
 function interactAndWaitForCertificateDownload(componentLowerCase, interactionCallback) {
     const requestConfig = {
-        method: 'POST',
-        url: `api/extensions/certgen/${componentLowerCase}`,
+        reouteMatcherMap: {
+            method: 'POST',
+            url: `api/extensions/certgen/${componentLowerCase}`,
+        },
     };
 
     interactAndWaitForResponses(interactionCallback, requestConfig);

--- a/ui/apps/platform/cypress/helpers/systemConfig.js
+++ b/ui/apps/platform/cypress/helpers/systemConfig.js
@@ -30,8 +30,8 @@ export function visitSystemConfiguration() {
 export function visitSystemConfigurationFromLeftNav() {
     visitFromLeftNavExpandable('Platform Configuration', title, requestConfigForGET);
 
-    cy.get(`h1:contains("${title}")`);
     cy.location('pathname').should('eq', basePath);
+    cy.get(`h1:contains("${title}")`);
 }
 
 export function visitSystemConfigurationWithStaticResponseForPermissions(

--- a/ui/apps/platform/cypress/helpers/systemConfig.js
+++ b/ui/apps/platform/cypress/helpers/systemConfig.js
@@ -1,0 +1,66 @@
+import { visitFromLeftNavExpandable } from './nav';
+import { interactAndWaitForResponses } from './request';
+import { visit, visitWithStaticResponseForPermissions } from './visit';
+
+const basePath = '/main/systemconfig';
+
+const configEndpoint = '/v1/config';
+
+const configAliasForGET = 'config';
+
+const requestConfigForGET = {
+    routeMatcherMap: {
+        [configAliasForGET]: {
+            method: 'GET',
+            url: configEndpoint,
+        },
+    },
+};
+
+const title = 'System Configuration';
+
+// visit
+
+export function visitSystemConfiguration() {
+    visit(basePath, requestConfigForGET);
+
+    cy.get(`h1:contains("${title}")`);
+}
+
+export function visitSystemConfigurationFromLeftNav() {
+    visitFromLeftNavExpandable('Platform Configuration', title, requestConfigForGET);
+
+    cy.get(`h1:contains("${title}")`);
+    cy.location('pathname').should('eq', basePath);
+}
+
+export function visitSystemConfigurationWithStaticResponseForPermissions(
+    staticResponseForPermissions
+) {
+    visitWithStaticResponseForPermissions(
+        basePath,
+        staticResponseForPermissions,
+        requestConfigForGET
+    );
+
+    cy.get(`h1:contains("${title}")`);
+}
+
+// save
+
+const configAliasForPUT = 'PUT_config';
+
+const requestConfigForPUT = {
+    routeMatcherMap: {
+        [configAliasForPUT]: {
+            method: 'PUT',
+            url: configEndpoint,
+        },
+    },
+};
+
+export function saveSystemConfiguration() {
+    interactAndWaitForResponses(() => {
+        cy.get('button:contains("Save")').click();
+    }, requestConfigForPUT);
+}

--- a/ui/apps/platform/cypress/helpers/visit.js
+++ b/ui/apps/platform/cypress/helpers/visit.js
@@ -31,7 +31,7 @@ const requestConfigGeneric = {
         }, // hooks/usePermissions and reducers/roles and sagas/authSagas
         [configPublicAlias]: {
             method: 'GET',
-            url: api.system.configPublic,
+            url: '/v1/config/public',
         }, // reducers/systemConfig and sagas/systemConfig
         [authStatusAlias]: {
             method: 'GET',

--- a/ui/apps/platform/cypress/integration/credentialExpiry.test.js
+++ b/ui/apps/platform/cypress/integration/credentialExpiry.test.js
@@ -81,7 +81,7 @@ describe('Credential expiry', () => {
                 fixture: 'auth/mypermissionsMinimalAccess.json',
             };
 
-            renderCentralCredentialExpiryBanner(expiry, staticResponseForPermissions);
+            renderScannerCredentialExpiryBanner(expiry, staticResponseForPermissions);
 
             cy.get(selectors.scannerCertExpiryBanner)
                 .invoke('text')

--- a/ui/apps/platform/cypress/integration/credentialExpiry.test.js
+++ b/ui/apps/platform/cypress/integration/credentialExpiry.test.js
@@ -24,7 +24,7 @@ describe('Credential expiry', () => {
             const expiry = dateFns.addMinutes(dateFns.addHours(new Date(), 23), 30);
 
             const staticResponseForPermissions = {
-                fixture: 'auth/mypermissionsMinimalAccess',
+                fixture: 'auth/mypermissionsMinimalAccess.json',
             };
 
             renderCentralCredentialExpiryBanner(expiry, staticResponseForPermissions);
@@ -78,7 +78,7 @@ describe('Credential expiry', () => {
             const expiry = dateFns.addMinutes(dateFns.addHours(new Date(), 23), 30);
 
             const staticResponseForPermissions = {
-                fixture: 'auth/mypermissionsMinimalAccess',
+                fixture: 'auth/mypermissionsMinimalAccess.json',
             };
 
             renderCentralCredentialExpiryBanner(expiry, staticResponseForPermissions);

--- a/ui/apps/platform/cypress/integration/credentialExpiry.test.js
+++ b/ui/apps/platform/cypress/integration/credentialExpiry.test.js
@@ -4,8 +4,8 @@ import { selectors } from '../constants/CertExpiration';
 import {
     interactAndWaitForCentralCertificateDownload,
     interactAndWaitForScannerCertificateDownload,
-    renderCentralCredentialExpiryBanner,
-    renderScannerCredentialExpiryBanner,
+    visitSystemConfigurationWithCentralCredentialExpiryBanner,
+    visitSystemConfigurationWithScannerCredentialExpiryBanner,
 } from '../helpers/credentialExpiry';
 
 describe('Credential expiry', () => {
@@ -15,7 +15,7 @@ describe('Credential expiry', () => {
         it('should not display banner if central cert is expiring more than 14 days later', () => {
             const expiry = dateFns.addHours(dateFns.addDays(new Date(), 15), 1);
 
-            renderCentralCredentialExpiryBanner(expiry);
+            visitSystemConfigurationWithCentralCredentialExpiryBanner(expiry);
 
             cy.get(selectors.centralCertExpiryBanner).should('not.exist');
         });
@@ -27,7 +27,10 @@ describe('Credential expiry', () => {
                 fixture: 'auth/mypermissionsMinimalAccess.json',
             };
 
-            renderCentralCredentialExpiryBanner(expiry, staticResponseForPermissions);
+            visitSystemConfigurationWithCentralCredentialExpiryBanner(
+                expiry,
+                staticResponseForPermissions
+            );
 
             cy.get(selectors.centralCertExpiryBanner)
                 .invoke('text')
@@ -41,7 +44,7 @@ describe('Credential expiry', () => {
         it('should show a warning banner if the expiry date is within 4-14 days', () => {
             const expiry = dateFns.addDays(new Date(), 10);
 
-            renderCentralCredentialExpiryBanner(expiry);
+            visitSystemConfigurationWithCentralCredentialExpiryBanner(expiry);
 
             cy.get(selectors.centralCertExpiryBanner).should('have.class', 'pf-m-warning');
         });
@@ -49,7 +52,7 @@ describe('Credential expiry', () => {
         it('should show a danger banner if the expiry date is less than or equal to 3 days', () => {
             const expiry = dateFns.addDays(new Date(), 2);
 
-            renderCentralCredentialExpiryBanner(expiry);
+            visitSystemConfigurationWithCentralCredentialExpiryBanner(expiry);
 
             cy.get(selectors.centralCertExpiryBanner).should('have.class', 'pf-m-danger');
         });
@@ -57,7 +60,7 @@ describe('Credential expiry', () => {
         it('should download the YAML', () => {
             const expiry = dateFns.addDays(new Date(), 1);
 
-            renderCentralCredentialExpiryBanner(expiry);
+            visitSystemConfigurationWithCentralCredentialExpiryBanner(expiry);
 
             interactAndWaitForCentralCertificateDownload(() => {
                 cy.get(selectors.centralCertExpiryBanner).find('button').click();
@@ -69,7 +72,7 @@ describe('Credential expiry', () => {
         it('should not display banner if scanner cert is expiring more than 14 days later', () => {
             const expiry = dateFns.addHours(dateFns.addDays(new Date(), 15), 1);
 
-            renderScannerCredentialExpiryBanner(expiry);
+            visitSystemConfigurationWithScannerCredentialExpiryBanner(expiry);
 
             cy.get(selectors.centralCertExpiryBanner).should('not.exist');
         });
@@ -81,7 +84,10 @@ describe('Credential expiry', () => {
                 fixture: 'auth/mypermissionsMinimalAccess.json',
             };
 
-            renderScannerCredentialExpiryBanner(expiry, staticResponseForPermissions);
+            visitSystemConfigurationWithScannerCredentialExpiryBanner(
+                expiry,
+                staticResponseForPermissions
+            );
 
             cy.get(selectors.scannerCertExpiryBanner)
                 .invoke('text')
@@ -95,7 +101,7 @@ describe('Credential expiry', () => {
         it('should show a warning banner if the expiry date is within 4-14 days', () => {
             const expiry = dateFns.addDays(new Date(), 10);
 
-            renderScannerCredentialExpiryBanner(expiry);
+            visitSystemConfigurationWithScannerCredentialExpiryBanner(expiry);
 
             cy.get(selectors.scannerCertExpiryBanner).should('have.class', 'pf-m-warning');
         });
@@ -103,7 +109,7 @@ describe('Credential expiry', () => {
         it('should show a danger banner if the expiry date is greater than 14 days', () => {
             const expiry = dateFns.addDays(new Date(), 2);
 
-            renderScannerCredentialExpiryBanner(expiry);
+            visitSystemConfigurationWithScannerCredentialExpiryBanner(expiry);
 
             cy.get(selectors.scannerCertExpiryBanner).should('have.class', 'pf-m-danger');
         });
@@ -111,7 +117,7 @@ describe('Credential expiry', () => {
         it('should download the YAML', () => {
             const expiry = dateFns.addDays(new Date(), 1);
 
-            renderScannerCredentialExpiryBanner(expiry);
+            visitSystemConfigurationWithScannerCredentialExpiryBanner(expiry);
 
             interactAndWaitForScannerCertificateDownload(() => {
                 cy.get(selectors.scannerCertExpiryBanner).find('button').click();

--- a/ui/apps/platform/cypress/integration/credentialExpiry.test.js
+++ b/ui/apps/platform/cypress/integration/credentialExpiry.test.js
@@ -8,10 +8,10 @@ import {
     renderScannerCredentialExpiryBanner,
 } from '../helpers/credentialExpiry';
 
-describe('Credential Expiry', () => {
+describe('Credential expiry', () => {
     withAuth();
 
-    describe('for Central', () => {
+    describe('for central', () => {
         it('should not display banner if central cert is expiring more than 14 days later', () => {
             const expiry = dateFns.addHours(dateFns.addDays(new Date(), 15), 1);
 
@@ -65,7 +65,7 @@ describe('Credential Expiry', () => {
         });
     });
 
-    describe('for Scanner', () => {
+    describe('for scanner', () => {
         it('should not display banner if scanner cert is expiring more than 14 days later', () => {
             const expiry = dateFns.addHours(dateFns.addDays(new Date(), 15), 1);
 

--- a/ui/apps/platform/cypress/integration/systemconfig.test.js
+++ b/ui/apps/platform/cypress/integration/systemconfig.test.js
@@ -1,19 +1,10 @@
-import selectors, { systemConfigUrl, text } from '../constants/SystemConfigPage';
+import selectors, { text } from '../constants/SystemConfigPage';
 import withAuth from '../helpers/basicAuth';
-import { visitFromLeftNavExpandable } from '../helpers/nav';
-import { system as configApi } from '../constants/apiEndpoints';
-
-function visitSytemConfigurationFromLeftNav() {
-    cy.intercept('GET', configApi.config).as('getSystemConfiguration');
-    visitFromLeftNavExpandable('Platform Configuration', 'System Configuration');
-    cy.wait('@getSystemConfiguration');
-}
-
-function visitSystemConfiguration() {
-    cy.intercept('GET', configApi.config).as('getSystemConfiguration');
-    cy.visit(systemConfigUrl);
-    cy.wait('@getSystemConfiguration');
-}
+import {
+    saveSystemConfiguration,
+    visitSystemConfiguration,
+    visitSystemConfigurationFromLeftNav,
+} from '../helpers/systemConfig';
 
 function editBaseConfig(type) {
     cy.get(selectors.pageHeader.editButton).click();
@@ -34,16 +25,12 @@ function editBannerConfig(type) {
     cy.get(selectors[type].widget).click();
 }
 
-function saveSystemConfiguration() {
-    cy.intercept('PUT', configApi.config).as('putSystemConfiguration');
-    cy.get(selectors.pageHeader.saveButton).click();
-    cy.wait('@putSystemConfiguration');
-}
-
 function disableConfig(type) {
     cy.get(selectors.pageHeader.editButton).click();
     cy.get(selectors[type].config.toggle).uncheck({ force: true }); // force for PatternFly Switch element
+
     saveSystemConfiguration();
+
     cy.get(selectors[type].state).contains('Disabled');
 }
 
@@ -59,9 +46,8 @@ describe('System Configuration', () => {
     withAuth();
 
     it('should go to System Configuration from main navigation', () => {
-        visitSytemConfigurationFromLeftNav();
-        cy.location('pathname').should('eq', systemConfigUrl);
-        cy.get('h1:contains("System Configuration")');
+        visitSystemConfigurationFromLeftNav();
+
         cy.get(selectors.dataRetention.widget).should('exist');
         cy.get(selectors.header.widget).should('exist');
         cy.get(selectors.footer.widget).should('exist');

--- a/ui/apps/platform/cypress/integration/systemconfig.test.js
+++ b/ui/apps/platform/cypress/integration/systemconfig.test.js
@@ -4,6 +4,7 @@ import {
     saveSystemConfiguration,
     visitSystemConfiguration,
     visitSystemConfigurationFromLeftNav,
+    visitSystemConfigurationWithStaticResponseForPermissions,
 } from '../helpers/systemConfig';
 
 function editBaseConfig(type) {
@@ -52,6 +53,16 @@ describe('System Configuration', () => {
         cy.get(selectors.header.widget).should('exist');
         cy.get(selectors.footer.widget).should('exist');
         cy.get(selectors.loginNotice.widget).should('exist');
+    });
+
+    it('should not render Edit button if READ_ACCESS to resource', () => {
+        const staticResponseForPermissions = {
+            fixture: 'auth/mypermissionsMinimalAccess.json',
+        };
+
+        visitSystemConfigurationWithStaticResponseForPermissions(staticResponseForPermissions);
+
+        cy.get(selectors.pageHeader.editButton).should('not.exist');
     });
 
     it('should allow the user to set data retention to "never delete"', () => {


### PR DESCRIPTION
## Description

Practice for collections and follow up improvements to visit helpers in #3577

### Objectives

* Encapsulate page and endpoint addresses in component/container specific helpers file.
* Encapsulate selectors which are needed only in specific helpers file.
* Call relevant generic functions from specific functions.

### Review

Cypress data structures:
* `RouteMatcher`: https://docs.cypress.io/api/commands/intercept#Matching-with-RouteMatcher
    For example, `{ method: 'GET', url: '/v1/collections' }` however, it needed `?query=*` query string to match!
* `StaticResponse`: https://docs.cypress.io/api/commands/intercept#StaticResponse-objects
    For example, response body: `{ body: { collections: […] } }`
    For example, fixture file: `{ fixture: 'collections/collectionsWhatever.json' }`

Here are conventions-in-progress for integration tests:
* `whateverAlias`
    for REST endpoint: delete **/v1/** and usually omit search query (prepend with method if other than GET)
    for GraphQL endpoints: delete **/api/graphql?opname=**
* `routeMatcherMap` object properties have alias for key and RouteMatcher object for value 
* `staticResponseMap` object properties have alias for key and StaticResponse object for value

### Changed files

1. Edit cypress/constants/SystemConfigPage.js
    * Delete `systemConfigUrl` because encapsulated in helpers file.
    * Delete `saveButton` because encapsulated in helpers file.

2. Edit cypress/constants/apiEndpoints.js
    * Delete `certExpiry` and `certGen` because encapsulated in credentialExpiry helpers file.
    * Delete `system` because `config` and `configPublic` are encapsulated in systemConfig and visit helpers files, respectively.

3. Add cypress/helpers/credentialExpiry.js
    * Add 1 generic `visitSystemConfigurationWithCredentialExpiryBanner` and 2 component-specific functions.
    * Add 1 generic `interactAndWaitForCertificateDownload` and 2 component-specific functions.

4. Add cypress/helpers/systemConfig.js
    * Add visit helper functions.
    * Add save helper function.

5. Edit cypress/helpers/visit.js
    * Replace `api.system.configPublic` with `'/v1/config/public'` because it is the only reference to the endpoint.

6. Rename cypress/integration/certexpiration.test.js as credentialExpiry.test.js
    * Align test file names with request endpoint and React component name.
    * Replace main dashboard which has several slower requests with System Configuration page which has one faster request.
    * Replace `mockCertExpiryAndVisitHomepage` function with visit helper functions.
    * Replace intercept and wait for permissions with optional `staticResponseForPermissions` argument.
    * Replace incomplete mock data with fixture.
    * Replace intercept and wait for certificate download with interact helper functions.

7. Edit cypress/integration/systemconfig.test.js
    * Replace 3 local functions with import from helpers file.
    * Leave the rest of the functions alone, because out of scope for the objectives.
    * Add a test of conditional rendering for read only permission.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed