### PR TITLE
ROX-13318: Fix skipTLSVerify property on Generic Webhook integration form

### DIFF
--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/GenericWebhookIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/GenericWebhookIntegrationForm.tsx
@@ -31,7 +31,7 @@ import FormLabelGroup from '../FormLabelGroup';
 export type GenericWebhookIntegration = {
     generic: {
         endpoint: string;
-        skipTlsVerify: boolean;
+        skipTLSVerify: boolean;
         auditLoggingEnabled: boolean;
         caCert: string;
         username: string;
@@ -105,7 +105,7 @@ export const defaultValues: GenericWebhookIntegrationFormValues = {
         name: '',
         generic: {
             endpoint: '',
-            skipTlsVerify: false,
+            skipTLSVerify: false,
             auditLoggingEnabled: false,
             caCert: '',
             username: '',
@@ -207,13 +207,13 @@ function GenericWebhookIntegrationForm({
                         </FormLabelGroup>
                         <FormLabelGroup
                             label=""
-                            fieldId="notifier.generic.skipTlsVerify"
+                            fieldId="notifier.generic.skipTLSVerify"
                             errors={errors}
                         >
                             <Checkbox
                                 label="Skip TLS verification"
-                                id="notifier.generic.skipTlsVerify"
-                                isChecked={values.notifier.generic.skipTlsVerify}
+                                id="notifier.generic.skipTLSVerify"
+                                isChecked={values.notifier.generic.skipTLSVerify}
                                 onChange={onChange}
                                 onBlur={handleBlur}
                                 isDisabled={!isEditable}

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/GenericWebhookIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/GenericWebhookIntegrationForm.tsx
@@ -15,38 +15,17 @@ import { PlusCircleIcon, TrashIcon } from '@patternfly/react-icons';
 import * as yup from 'yup';
 import { FieldArray, FormikProvider } from 'formik';
 
-import { NotifierIntegrationBase } from 'services/NotifierIntegrationsService';
-
 import usePageState from 'Containers/Integrations/hooks/usePageState';
 import FormMessage from 'Components/PatternFly/FormMessage';
 import FormTestButton from 'Components/PatternFly/FormTestButton';
 import FormSaveButton from 'Components/PatternFly/FormSaveButton';
 import FormCancelButton from 'Components/PatternFly/FormCancelButton';
+import { GenericNotifierIntegration as GenericWebhookIntegration } from 'types/notifier.proto';
 import useIntegrationForm from '../useIntegrationForm';
 import { IntegrationFormProps } from '../integrationFormTypes';
 
 import IntegrationFormActions from '../IntegrationFormActions';
 import FormLabelGroup from '../FormLabelGroup';
-
-export type GenericWebhookIntegration = {
-    generic: {
-        endpoint: string;
-        skipTLSVerify: boolean;
-        auditLoggingEnabled: boolean;
-        caCert: string;
-        username: string;
-        password: string;
-        headers: {
-            key: string;
-            value: string;
-        }[];
-        extraFields: {
-            key: string;
-            value: string;
-        }[];
-    };
-    type: 'generic';
-} & NotifierIntegrationBase;
 
 export type GenericWebhookIntegrationFormValues = {
     notifier: GenericWebhookIntegration;


### PR DESCRIPTION
## Description

Casing is hard. Fixes a casing typo in one of the fields in the Generic Webhook integration objection.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

Manual testing
<img width="1511" alt="Screen Shot 2022-10-27 at 5 14 21 PM" src="https://user-images.githubusercontent.com/715729/198411039-22742234-753d-41aa-9c05-e3b25d81a8d9.png">
