### PR TITLE
Fix config-shape to be consistent with templates

### DIFF
--- a/image/templates/helm/stackrox-central/internal/config-shape.yaml
+++ b/image/templates/helm/stackrox-central/internal/config-shape.yaml
@@ -73,15 +73,14 @@ central:
     enabled: false # bool
     nodeSelector: null # string | dict
     tolerations: null # [dict]
-    configuration:
-      source:
-        string: null # string
-        minConns: null # int
-        maxConns: null # int
-        statementTimeoutMs: null #int
-      password:
-        value: null # string
-        generate: null # bool
+    source:
+      string: null # string
+      minConns: null # int
+      maxConns: null # int
+      statementTimeoutMs: null #int
+    password:
+      value: null # string
+      generate: null # bool
     serviceTLS:
       cert: null # string
       key: null # string


### PR DESCRIPTION
## Description

The current central db password configuration does not seem to be align with what we defined in the config-shape.yaml. It is under the dict of configration in config-shape but directly under db elsewhere. It looks like wrong to me. 
So, change the config-shape to match what is in function.
Reference:
https://github.com/stackrox/stackrox/blob/abb390ecf3d610d7df494e9b37bee557ab7e3dff/image/templates/helm/stackrox-central/templates/_central_setup.tpl#L43

## Checklist
- [ ] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
