### PR TITLE
ROX-12902: adding control bar to PF network graph

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraph.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraph.tsx
@@ -6,6 +6,9 @@ import {
     SELECTION_EVENT,
     TopologySideBar,
     TopologyView,
+    createTopologyControlButtons,
+    defaultControlButtonsOptions,
+    TopologyControlBar,
     useVisualizationController,
     Visualization,
     VisualizationProvider,
@@ -264,6 +267,29 @@ const TopologyComponent = ({ detailType, detailId }: TopologyComponentProps) => 
             }
             sideBarOpen={!!selectedEntity}
             sideBarResizable
+            controlBar={
+                <TopologyControlBar
+                    controlButtons={createTopologyControlButtons({
+                        ...defaultControlButtonsOptions,
+                        zoomInCallback: () => {
+                            controller.getGraph().scaleBy(4 / 3);
+                        },
+                        zoomOutCallback: () => {
+                            controller.getGraph().scaleBy(0.75);
+                        },
+                        fitToScreenCallback: () => {
+                            controller.getGraph().fit(80);
+                        },
+                        resetViewCallback: () => {
+                            controller.getGraph().reset();
+                            controller.getGraph().layout();
+                        },
+                        legendCallback: () => {
+                            // console.log('hi');
+                        },
+                    })}
+                />
+            }
         >
             <VisualizationSurface state={{ selectedIds }} />
         </TopologyView>


### PR DESCRIPTION
As the title states -- adding zoom in/out/pan/fit buttons to the PF network graph 

<img width="998" alt="Screen Shot 2022-10-27 at 8 04 16 PM" src="https://user-images.githubusercontent.com/10412893/198488487-a72e0c2f-3847-4ba7-87b7-c503e564f5e6.png">
