### PR TITLE
ROX-13263: Add namespaces to deployments search options

### DIFF
--- a/central/globalindex/mapping/mapping.go
+++ b/central/globalindex/mapping/mapping.go
@@ -109,9 +109,9 @@ func getPostgresEntityOptionsMap() map[v1.SearchCategory]search.OptionsMap {
 	)
 
 	deploymentsCustomSearchOptions := search.CombineOptionsMaps(
+		schema.DeploymentsSchema.OptionsMap,
 		schema.ImagesSchema.OptionsMap,
 		schema.ProcessIndicatorsSchema.OptionsMap,
-		schema.DeploymentsSchema.OptionsMap,
 	)
 
 	imageToVulnerabilitySearchOptions := search.CombineOptionsMaps(

--- a/tests/options_test.go
+++ b/tests/options_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestOptions(t *testing.T) {
+func TestOptionsMapExist(t *testing.T) {
 	t.Parallel()
 
 	conn := centralgrpc.GRPCConnectionToCentral(t)
@@ -37,4 +37,9 @@ func TestOptions(t *testing.T) {
 			assert.ElementsMatch(t, options.GetOptions(categories), resp.GetOptions())
 		})
 	}
+}
+
+func TestOptionsMap(t *testing.T) {
+	optionsMap := options.GetOptions([]v1.SearchCategory{v1.SearchCategory_DEPLOYMENTS})
+	assert.Contains(t, optionsMap, "Namespace")
 }

--- a/ui/apps/platform/cypress/integration/networkGraph/networkGraph.test.js
+++ b/ui/apps/platform/cypress/integration/networkGraph/networkGraph.test.js
@@ -11,7 +11,6 @@ import {
     visitNetworkGraph,
     visitNetworkGraphWithNamespaceFilter,
 } from '../../helpers/networkGraph';
-import { hasFeatureFlag } from '../../helpers/features';
 
 describe('Network Deployment Details', () => {
     withAuth();
@@ -55,10 +54,7 @@ describe('Network Graph Search', () => {
         });
     });
 
-    it('should filter to show only a specific deployment and deployments connected to it', function () {
-        if (hasFeatureFlag('ROX_POSTGRES_DATASTORE')) {
-            this.skip();
-        }
+    it('should filter to show only a specific deployment and deployments connected to it', () => {
         visitNetworkGraphWithNamespaceFilter('stackrox');
         selectDeploymentFilter('central');
 

--- a/ui/apps/platform/cypress/integration/risk/risk.test.js
+++ b/ui/apps/platform/cypress/integration/risk/risk.test.js
@@ -14,7 +14,6 @@ import {
     callbackForPairOfAscendingNumberValuesFromElements,
     callbackForPairOfDescendingNumberValuesFromElements,
 } from '../../helpers/sort';
-import { hasFeatureFlag } from '../../helpers/features';
 
 describe('Risk page', () => {
     withAuth();
@@ -161,10 +160,7 @@ describe('Risk page', () => {
             cy.get(RiskPageSelectors.search.searchLabels).should('not.exist');
         });
 
-        it('should have a single URL search param key/value pair in its search bar', function () {
-            if (hasFeatureFlag('ROX_POSTGRES_DATASTORE')) {
-                this.skip();
-            }
+        it('should have a single URL search param key/value pair in its search bar', () => {
             visitRiskDeployments();
 
             const nsOption = 'Namespace';
@@ -196,10 +192,7 @@ describe('Risk page', () => {
             });
         });
 
-        it('should have multiple URL search param key/value pairs in its search bar', function () {
-            if (hasFeatureFlag('ROX_POSTGRES_DATASTORE')) {
-                this.skip();
-            }
+        it('should have multiple URL search param key/value pairs in its search bar', () => {
             visitRiskDeployments();
 
             const nsOption = 'Namespace';


### PR DESCRIPTION
## Description

We need to add namespaces to search options for deployments to be able to use them in graphql queries and UI.

## Testing Performed

CI
