### PR TITLE
Increase global default jest timeout

### DIFF
--- a/ui/apps/platform/src/Containers/Collections/RuleSelector/RuleSelector.test.tsx
+++ b/ui/apps/platform/src/Containers/Collections/RuleSelector/RuleSelector.test.tsx
@@ -6,8 +6,6 @@ import '@testing-library/jest-dom/extend-expect';
 import RuleSelector from './RuleSelector';
 import { ByLabelResourceSelector, ByNameResourceSelector, ScopedResourceSelector } from '../types';
 
-jest.setTimeout(10000);
-
 // Component wrapper to allow a higher level component to feed updated state back to the RuleSelector.
 function DeploymentRuleSelector({ defaultSelector, onChange }) {
     const [resourceSelector, setResourceSelector] =

--- a/ui/apps/platform/src/Containers/Dashboard/ScopeBar.test.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/ScopeBar.test.tsx
@@ -8,8 +8,6 @@ import renderWithRouter from 'test-utils/renderWithRouter';
 import ScopeBar, { namespacesQuery } from './ScopeBar';
 import { Cluster, Namespace } from './types';
 
-jest.setTimeout(10000);
-
 const clusterNamespaces = {
     production: ['backend', 'default', 'frontend', 'kube-system', 'medical', 'payments'],
     security: ['default', ' kube-system', 'stackrox'],

--- a/ui/apps/platform/src/Containers/Dashboard/Widgets/AgingImages.test.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/Widgets/AgingImages.test.tsx
@@ -8,8 +8,6 @@ import renderWithRouter from 'test-utils/renderWithRouter';
 import { mockChartsWithoutAnimation } from 'test-utils/mocks/@patternfly/react-charts';
 import AgingImages, { imageCountQuery } from './AgingImages';
 
-jest.setTimeout(10000);
-
 const range0 = '30';
 const range1 = '90';
 const range2 = '180';

--- a/ui/apps/platform/src/Containers/Dashboard/Widgets/ComplianceLevelsByStandard.test.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/Widgets/ComplianceLevelsByStandard.test.tsx
@@ -11,8 +11,6 @@ import entityTypes, { standardEntityTypes } from 'constants/entityTypes';
 import { complianceBasePath, urlEntityListTypes } from 'routePaths';
 import ComplianceLevelsByStandard from './ComplianceLevelsByStandard';
 
-jest.setTimeout(10000);
-
 /*
 These standards have been formatted for easier verification of the expected ordering in
 tests compared to a direct hard coding in the mocked response below.

--- a/ui/apps/platform/src/Containers/Dashboard/Widgets/ViolationsByPolicyCategory.test.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/Widgets/ViolationsByPolicyCategory.test.tsx
@@ -7,8 +7,6 @@ import renderWithRouter from 'test-utils/renderWithRouter';
 import { mockChartsWithoutAnimation } from 'test-utils/mocks/@patternfly/react-charts';
 import ViolationsByPolicyCategory from './ViolationsByPolicyCategory';
 
-jest.setTimeout(10000);
-
 jest.mock('@patternfly/react-charts', () => mockChartsWithoutAnimation);
 jest.mock('hooks/useResizeObserver');
 

--- a/ui/apps/platform/src/setupTests.js
+++ b/ui/apps/platform/src/setupTests.js
@@ -6,6 +6,8 @@ import { disableFragmentWarnings } from '@apollo/client';
 // `cveFields` fragment that is dynamically used throughout Vuln Management
 disableFragmentWarnings();
 
+jest.setTimeout(15000);
+
 class Spy {
     spy = null;
 


### PR DESCRIPTION
## Description

Updates the global timeout for jest (ui-unit-test) test from 5000ms to 15000ms. This should make the rare timeout flake when we have an infrastructure hiccup even more rare, if not eliminate them completely.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

Run `yarn test` with the following lines in an arbitrary test file:

```javascript
await new Promise((res) => setTimeout(res, 4800));
await new Promise((res) => setTimeout(res, 9800));
await new Promise((res) => setTimeout(res, 14800));
```

When running the test with the final line, the test fails:
```
  Violations by policy category widget
    ✕ should sort a policy violations by category widget by severity and volume of violations (15057 ms)
```
