### PR TITLE
Bump github.com/np-guard/cluster-topology-analyzer to 1.3.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -64,7 +64,7 @@ require (
 	github.com/mailru/easyjson v0.7.7
 	github.com/mitchellh/go-wordwrap v1.0.1
 	github.com/mitchellh/hashstructure/v2 v2.0.2
-	github.com/np-guard/cluster-topology-analyzer v1.2.3-0.20220905143132-4bca39e41111
+	github.com/np-guard/cluster-topology-analyzer v1.3.2
 	github.com/nxadm/tail v1.4.8
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/opencontainers/go-digest v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -1534,8 +1534,8 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLA
 github.com/nightlyone/lockfile v1.0.0/go.mod h1:rywoIealpdNse2r832aiD9jRk8ErCatROs6LzC841CI=
 github.com/nishanths/exhaustive v0.1.0/go.mod h1:S1j9110vxV1ECdCudXRkeMnFQ/DQk9ajLT0Uf2MYZQQ=
 github.com/nishanths/predeclared v0.0.0-20200524104333-86fad755b4d3/go.mod h1:nt3d53pc1VYcphSCIaYAJtnPYnr3Zyn8fMq2wvPGPso=
-github.com/np-guard/cluster-topology-analyzer v1.2.3-0.20220905143132-4bca39e41111 h1:dQjrYzyElZpra9SgEECdXvau0HAdZ/KansI/lrBuWd8=
-github.com/np-guard/cluster-topology-analyzer v1.2.3-0.20220905143132-4bca39e41111/go.mod h1:wl55xYBibeYdVg8/ceW/31AIDhbyDIqJ9JDeloVp0wo=
+github.com/np-guard/cluster-topology-analyzer v1.3.2 h1:MxtiI3HY53cCre3bhXncFfLToMxoSptBhpjFgvvH3YE=
+github.com/np-guard/cluster-topology-analyzer v1.3.2/go.mod h1:ND3000Gqsb3c8HSXqFBGsp9RcbPl3saFOrtP4M9VypY=
 github.com/nwaples/rardecode v1.1.0 h1:vSxaY8vQhOcVr4mm5e8XllHWTiM4JF507A0Katqw7MQ=
 github.com/nwaples/rardecode v1.1.0/go.mod h1:5DzqNKiOdpKKBH87u8VlvAnPZMXcGRhxWkRpHbbfGS0=
 github.com/oklog/oklog v0.3.2/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtbWGs=


### PR DESCRIPTION
## Description

go mod tidy fails with go1.18:
```
go: downloading github.com/np-guard/cluster-topology-analyzer v1.2.3-0.20220905143132-4bca39e41111
github.com/stackrox/rox/roxctl/generate/netpol imports
	github.com/np-guard/cluster-topology-analyzer/pkg/controller: github.com/np-guard/cluster-topology-analyzer@v1.2.3-0.20220905143132-4bca39e41111: invalid version: unknown revision 4bca39e41111
```

There is now a tag which includes the needed changes, so use that.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed
