### PR TITLE
ROX-13257: Indentify entity for ComplianceByStandard widgets in side panels

### DIFF
--- a/ui/apps/platform/src/Containers/Compliance/Entity/Cluster.js
+++ b/ui/apps/platform/src/Containers/Compliance/Entity/Cluster.js
@@ -102,7 +102,11 @@ const ClusterPage = ({
                                         <ClusterVersion clusterId={id} />
                                     </div>
                                 </div>
-                                <ComplianceByStandards entityType={entityTypes.CLUSTER} />
+                                <ComplianceByStandards
+                                    entityId={id}
+                                    entityName={name}
+                                    entityType={entityTypes.CLUSTER}
+                                />
 
                                 {sidePanelMode && (
                                     <>

--- a/ui/apps/platform/src/Containers/Compliance/Entity/Deployment.js
+++ b/ui/apps/platform/src/Containers/Compliance/Entity/Deployment.js
@@ -144,7 +144,11 @@ const DeploymentPage = ({
                                 >
                                     <Labels labels={labels} />
                                 </Widget>
-                                <ComplianceByStandards entityType={entityTypes.DEPLOYMENT} />
+                                <ComplianceByStandards
+                                    entityId={id}
+                                    entityName={name}
+                                    entityType={entityTypes.DEPLOYMENT}
+                                />
                             </div>
                         </div>
                     );

--- a/ui/apps/platform/src/Containers/Compliance/Entity/Namespace.js
+++ b/ui/apps/platform/src/Containers/Compliance/Entity/Namespace.js
@@ -147,7 +147,11 @@ const NamespacePage = ({
                                 >
                                     <Labels labels={labels} />
                                 </Widget>
-                                <ComplianceByStandards entityType={entityTypes.NAMESPACE} />
+                                <ComplianceByStandards
+                                    entityId={id}
+                                    entityName={name}
+                                    entityType={entityTypes.NAMESPACE}
+                                />
                                 {sidePanelMode && (
                                     <>
                                         <div

--- a/ui/apps/platform/src/Containers/Compliance/Entity/Node.js
+++ b/ui/apps/platform/src/Containers/Compliance/Entity/Node.js
@@ -201,7 +201,11 @@ const NodePage = ({
                                 >
                                     <Labels labels={labels} />
                                 </Widget>
-                                <ComplianceByStandards entityType={entityTypes.NODE} />
+                                <ComplianceByStandards
+                                    entityId={id}
+                                    entityName={name}
+                                    entityType={entityTypes.NODE}
+                                />
                             </div>
                         </div>
                     );

--- a/ui/apps/platform/src/Containers/Compliance/widgets/ComplianceByStandards.tsx
+++ b/ui/apps/platform/src/Containers/Compliance/widgets/ComplianceByStandards.tsx
@@ -7,10 +7,16 @@ import { STANDARDS_QUERY } from 'queries/standard';
 import ComplianceByStandard from './ComplianceByStandard';
 
 type ComplianceByStandardsProps = {
+    entityId?: string;
+    entityName?: string;
     entityType?: ResourceType;
 };
 
-function ComplianceByStandards({ entityType }: ComplianceByStandardsProps): ReactElement {
+function ComplianceByStandards({
+    entityId,
+    entityName,
+    entityType,
+}: ComplianceByStandardsProps): ReactElement {
     const { loading, data, error } = useQuery(STANDARDS_QUERY);
     if (loading) {
         return <Loader />;
@@ -38,6 +44,9 @@ function ComplianceByStandards({ entityType }: ComplianceByStandardsProps): Reac
                     key={standardId}
                     standardName={standardName}
                     standardId={standardId}
+                    entityId={entityId}
+                    entityName={entityName}
+                    entityType={entityType}
                     className="pdf-page"
                 />
             ))}


### PR DESCRIPTION
## Description

### Problem

> Compliance UI sunburst graph not updating after config changes

The sunburst graphs in entity side panel are inconsistent with entities table.

Although updating does not cause of the problem, it focuses attention on it.

See **Testing performed** for reproduction steps.

### Analysis

1. Compliance dashboard page renders `<ComplianceByStandards />` element without props: all standards for all entities.
2. Compliance entity pages also render it without props: sunburst graphs in side panel have same percents as on compliance dashboard **instead of** in table. [Omitting props to identify the entity was a regression in rox 8441 on 2021-06-15]

### Solution

1. Add optional props to `ComplianceByStandards` component so it can render `ComplianceByStandard` elements with props to identify entity for side panel.

    ```ts
    type ComplianceByStandardsProps = {
        entityId?: string;
        entityName?: string;
        entityType?: ResourceType;
    };
    ```
2. Render element with props for the following entities:
    * Compliance/Entity/Cluster.js
    * Compliance/Entity/Deployment.js
    * Compliance/Entity/Namespace.js
    * Compliance/Entity/Node.js

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Unit test and regression tests added

## Testing Performed

### manual testing

StackRox Demo: percents vary somewhat between tests.

1. Visit /main/compliance and see same percents in bar chart and sunburst graphs:

    | Standard        |      |
    | :---            | ---: |
    | CIS Docker      |  65% |
    | CIS K8s         |  64% |
    | HIPAA           |  68% |
    | NIST SP 800-190 |  66% |
    | NIST SP 800-53  |  31% |
    | PCI             |  86% |

2. Visit /main/compliance/namespaces and see percents for **stackrox** in **security** cluster:

    | Standard        |      |
    | :---            | ---: |
    | CIS Docker      | 100% |
    | HIPAA           |  39% |
    | NIST SP 800-190 |  64% |
    | NIST SP 800-53  |  14% |
    | PCI             |  82% |
    | Overall         |  64% |

3. Click table row to open side panel and see:
    * Namespace Compliance widget in side panel has same percent as Overall in table
    * sunburst graphs in side panel have same percents as on compliance dashboard instead of in table

