### PR TITLE
Fix configmanagement opname exceptions and inconsistencies for integration tests

### DIFF
--- a/ui/apps/platform/cypress/helpers/configWorkflowUtils.js
+++ b/ui/apps/platform/cypress/helpers/configWorkflowUtils.js
@@ -93,15 +93,8 @@ const widgetTitleForEntity = {
     namespaces: 'Namespace',
 };
 
-// Default opname is entities path segment. For example, clusters.
-const opnameExceptionsForEntities = {
-    deployments: 'getDeployments',
-    roles: 'k8sRoles',
-    serviceaccounts: 'serviceAccounts',
-};
-
 function getRequestConfigForEntities(entitiesKey) {
-    const opname = opnameExceptionsForEntities[entitiesKey] ?? entitiesKey;
+    const opname = entitiesKey;
     return {
         routeMatcherMap: {
             [opname]: graphql(opname),

--- a/ui/apps/platform/cypress/helpers/configWorkflowUtils.js
+++ b/ui/apps/platform/cypress/helpers/configWorkflowUtils.js
@@ -104,13 +104,13 @@ function getRequestConfigForEntities(entitiesKey) {
 
 const opnameForEntity = {
     clusters: 'getCluster',
-    controls: 'controlById',
+    controls: 'getControl',
     deployments: 'getDeployment',
     images: 'getImage',
     namespaces: 'getNamespace',
     nodes: 'getNode',
     policies: 'getPolicy',
-    roles: 'k8sRole',
+    roles: 'getRole',
     secrets: 'getSecret',
     serviceaccounts: 'getServiceAccount',
     subjects: 'getSubject',
@@ -124,18 +124,6 @@ function getRequestConfigForEntity(entitiesKey) {
         },
     };
 }
-
-// Exception if prefix differs from opnameForEntity above.
-const opnamePrefixExceptionForPrimaryAndSecondaryEntities = {
-    clusters: 'getCluster_',
-    images: 'getImage_',
-    namespaces: 'getNamespace_',
-    policies: 'getPolicy_',
-    roles: 'getRole_',
-    secrets: 'getSecret_',
-    serviceaccounts: 'getServiceAccount_',
-    subjects: 'subject_',
-};
 
 const typeOfEntity = {
     clusters: 'CLUSTER',
@@ -152,10 +140,7 @@ const typeOfEntity = {
 };
 
 function opnameForPrimaryAndSecondaryEntities(entitiesKey1, entitiesKey2) {
-    const opnamePrefix =
-        opnamePrefixExceptionForPrimaryAndSecondaryEntities[entitiesKey1] ??
-        opnameForEntity[entitiesKey1];
-    return `${opnamePrefix}${typeOfEntity[entitiesKey2]}`;
+    return `${opnameForEntity[entitiesKey1]}_${typeOfEntity[entitiesKey2]}`;
 }
 
 const routeMatcherMapForDashboard = {};

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/Control.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/Control.js
@@ -17,7 +17,7 @@ import NodesWithFailedControls from './widgets/NodesWithFailedControls';
 import Nodes from '../List/Nodes';
 
 const QUERY = gql`
-    query controlById($id: ID!, $where: String) {
+    query getControl($id: ID!, $where: String) {
         results: complianceControl(id: $id) {
             interpretationText
             description

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/Deployment/Deployment.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/Deployment/Deployment.js
@@ -99,7 +99,7 @@ const Deployment = ({ id, entityContext, entityListType, query, pagination }) =>
         const countQuery = getConfigMgmtCountQuery(entityListType);
 
         return gql`
-            query getDeployment${entityListType}($id: ID!, $query: String, $pagination: Pagination) {
+            query getDeployment_${entityListType}($id: ID!, $query: String, $pagination: Pagination) {
                 deployment(id: $id) {
                     id
                     ${listFieldName}(query: $query, pagination: $pagination) { ...${fragmentName} }

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/Role.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/Role.js
@@ -30,7 +30,7 @@ const Role = ({ id, entityListType, entityId1, query, entityContext, pagination 
     };
 
     const defaultQuery = gql`
-        query k8sRole($id: ID!${entityListType ? ', $query: String' : ''}) {
+        query getRole($id: ID!${entityListType ? ', $query: String' : ''}) {
             k8sRole(id: $id) {
                 id
                 name

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/Subject.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/Subject.js
@@ -58,7 +58,7 @@ const Subject = ({ id, entityListType, entityId1, query, entityContext, paginati
         );
 
         return gql`
-            query subject_${entityListType}($id: ID, $query: String, $pagination: Pagination) {
+            query getSubject_${entityListType}($id: ID, $query: String, $pagination: Pagination) {
                 subject(id: $id) {
                     id
                     name

--- a/ui/apps/platform/src/queries/deployment.js
+++ b/ui/apps/platform/src/queries/deployment.js
@@ -76,7 +76,7 @@ export const DEPLOYMENT_NAME = gql`
 `;
 
 export const DEPLOYMENTS_QUERY = gql`
-    query getDeployments($query: String, $pagination: Pagination) {
+    query deployments($query: String, $pagination: Pagination) {
         results: deployments(query: $query, pagination: $pagination) {
             id
             name

--- a/ui/apps/platform/src/queries/role.js
+++ b/ui/apps/platform/src/queries/role.js
@@ -51,7 +51,7 @@ export const ROLE_NAME = gql`
 `;
 
 export const K8S_ROLES_QUERY = gql`
-    query k8sRoles($query: String, $pagination: Pagination) {
+    query roles($query: String, $pagination: Pagination) {
         results: k8sRoles(query: $query, pagination: $pagination) {
             ...k8RoleFields
         }

--- a/ui/apps/platform/src/queries/serviceAccount.js
+++ b/ui/apps/platform/src/queries/serviceAccount.js
@@ -43,7 +43,7 @@ export const SERVICE_ACCOUNT_FRAGMENT = gql`
     }
 `;
 export const SERVICE_ACCOUNTS_QUERY = gql`
-    query serviceAccounts($query: String, $pagination: Pagination) {
+    query serviceaccounts($query: String, $pagination: Pagination) {
         results: serviceAccounts(query: $query, pagination: $pagination) {
             id
             name


### PR DESCRIPTION
## Description

TL;DR pattern for opname of GraphQL queries:

* plural: roles for /main/configmanagement/roles
* singular: getRole for:
    * side panel: /main/configmanagement/roles/id
    * single page: /main/configmanagement/role/id
* combined: getRoleSUBJECT for:
    * side panel: /main/configmanagement/roles/id/subjects
    * single page: /main/configmanagement/role/id/subjects

### Analysis of current behavior

| path segment    | plural exception | singular entity   | prefix exception   | suffix          |
| :---            | :---             | :---              | :---               | :---            |
| clusters        |                  | getCluster        | getCluster_        | CLUSTER         |
| controls        |                  | controlById       |                    | CONTROL         |
| deployments     | getDeployments   | getDeployment     |                    | DEPLOYMENT      |
| images          |                  | getImage          | getImage_          | IMAGE           |
| namespaces      |                  | getNamespace      | getNamespace_      | NAMESPACE       |
| nodes           |                  | getNode           |                    | NODE            |
| policies        |                  | getPolicy         | getPolicy_         | POLICY          |
| roles           | k8sRoles         | k8sRole           | getRole_           | ROLE            |
| secrets         |                  | getSecret         | getSecret_         | SECRET          |
| serviceaccounts | serviceAccounts  | getServiceAccount | getServiceAccount_ | SERVICE_ACCOUNT |
| subjects        |                  | getSubject        | subject_           | SUBJECT         |

### Primary exceptions in current behavior

1. To intercept and wait for plural requests successfully, I tried most possibilities manually to find exceptions to path segment as opname.

    * The 3 **plural exceptions** require an extra map for the test helper function:

        ```js
        function getRequestConfigForEntities(entitiesKey) {
            const opname = opnameExceptionsForEntities[entitiesKey] ?? entitiesKey;
            return {
                routeMatcherMap: {
                    [opname]: graphql(opname),
                },
            };
        }
        ```

        * `getDeployments` given argument: `deployments` although `getCamelCase` is consistent with Vulnerability Management (too bad, so sad)
        * `k8sRoles` given argument: `roles`
        * `serviceAccounts` given argument: `serviceaccounts`

    * Without exceptions, here is a simpler test helper function:

        ```js
        function getRequestConfigForEntities(entitiesKey) {
            const opname = entitiesKey;
            return {
                routeMatcherMap: {
                    [opname]: graphql(opname),
                },
            };
        }
        ```

        * `deployments` given argument: `deployments`
        * `roles` given argument: `roles`
        * `serviceaccounts` given argument: `serviceaccounts`

2. To intercept and wait for combined requests successfully, I tried most possibilities manually to find exceptions to singular opname as prefix.

    * The 3 **prefix exceptions** require an extra map for the test helper function:

        ```js
        function opnameForPrimaryAndSecondaryEntities(entitiesKey1, entitiesKey2) {
            const opnamePrefix =
                opnamePrefixExceptionForPrimaryAndSecondaryEntities[entitiesKey1] ??
                opnameForEntity[entitiesKey1];
            return `${opnamePrefix}${typeOfEntity[entitiesKey2]}`;
        }
        ```

        * `getCluster_ROLE` given arguments: `clusters` and `roles` with underscore is in the majority
        * `getDeploymentIMAGE` given arguments: `deployments` and `images` without underscore is in the minority
        * `getRole_SUBJECT` given arguments: `roles` and `subjects` has underscore and follows `getCamelCase` pattern, both of which are in the majority, but is inconsistent with singular `k8sRole` opname (see next section).

    * Without exceptions, here is a simpler test helper function:

        ```js
        function opnameForPrimaryAndSecondaryEntities(entitiesKey1, entitiesKey2) {
            return `${opnameForEntity[entitiesKey1]}_${typeOfEntity[entitiesKey2]}`;
        }
        ```

        * `getCluster_ROLE` given arguments: `clusters` and `roles`
        * `getDeployment_IMAGE` given arguments: `deployments` and `images`
        * `getRole_SUBJECT` given arguments: `roles` and `subjects` becomes expected temporary failure

### Secondary inconsistencies in current behavior

Two singular requests have opnames which are inconsistent with getCamelCase pattern of the majority of singular opnames, although consistent with plural opnames.

* controls: `'controlById'` instead of `'getControl'`
* roles: `'k8sRole'` instead of `'getRole'` (see previous section).

### Residue

1. Investigate src/utils/queryMap to evaluate risk of inconsistency or reward for consistency with entity opnames in UI and tests: Compliance, Configuration Management, Vulnerability Management.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed

### manual testing

TODO Compare requests and results on infra demo to staging demo