### PR TITLE
Distinguish queries with same opname in compliance integration tests

### DIFF
--- a/ui/apps/platform/cypress/helpers/compliance.js
+++ b/ui/apps/platform/cypress/helpers/compliance.js
@@ -14,7 +14,7 @@ const routeMatcherMap = {};
     'getAggregatedResultsAcrossEntity_CLUSTER',
     'getAggregatedResultsByEntity_CLUSTER',
     'getAggregatedResultsAcrossEntity_NAMESPACE',
-    'getAggregatedResultsAcrottEntity_NODE',
+    'getAggregatedResultsAcrossEntity_NODE',
     'getComplianceStandards',
     'complianceStandards_CIS_Docker_v1_2_0',
     'complianceStandards_CIS_Kubernetes_v1_5',

--- a/ui/apps/platform/cypress/helpers/compliance.js
+++ b/ui/apps/platform/cypress/helpers/compliance.js
@@ -11,9 +11,17 @@ const routeMatcherMap = {};
     'nodesCount',
     'deploymentsCount',
     'runStatuses',
-    'getAggregatedResults', // 4 requests
+    'getAggregatedResultsAcrossEntity_CLUSTER',
+    'getAggregatedResultsByEntity_CLUSTER',
+    'getAggregatedResultsAcrossEntity_NAMESPACE',
+    'getAggregatedResultsAcrottEntity_NODE',
     'getComplianceStandards',
-    'complianceStandards', // 6 requests
+    'complianceStandards_CIS_Docker_v1_2_0',
+    'complianceStandards_CIS_Kubernetes_v1_5',
+    'complianceStandards_HIPAA_164',
+    'complianceStandards_NIST_800_190',
+    'complianceStandards_NIST_SP_800_53_Rev_4',
+    'complianceStandards_PCI_DSS_3_2',
 ].forEach((opname) => {
     routeMatcherMap[opname] = {
         method: 'POST',
@@ -21,49 +29,7 @@ const routeMatcherMap = {};
     };
 });
 
-/*
- * getAggregatedResults opname has 4 requests with 2 duplicates for CLUSTER.
- * Each entity alias has a predicate to match the payload of the corresponding request.
- */
-const getAggregatedResults = {};
-['CLUSTER', 'NAMESPACE', 'NODE'].forEach((entity) => {
-    getAggregatedResults[entity] = (req) => {
-        const { groupBy, unit } = req.body.variables;
-        // "variables": { "groupBy": ["STANDARD", "CLUSTER"], "unit": "CHECK" }
-        return (
-            Array.isArray(groupBy) &&
-            groupBy[0] === 'STANDARD' &&
-            groupBy[1] === entity &&
-            unit === 'CHECK'
-        );
-    };
-});
-
-/*
- * complianceStandards opname has 6 requests.
- * Each standard name alias has a predicate to match the payload of the corresponding request.
- */
-const complianceStandards = {};
-[
-    'CIS Docker v1.2.0',
-    'CIS Kubernetes v1.5',
-    'HIPAA 164',
-    'NIST SP 800-190',
-    'NIST SP 800-53',
-    'PCI DSS 3.2.1',
-].forEach((standardName) => {
-    complianceStandards[standardName] = (req) => {
-        const { where } = req.body.variables;
-        return where === `Standard:${standardName}`;
-    };
-});
-
-const opnameAliasesMap = {
-    getAggregatedResults,
-    complianceStandards,
-};
-
-const requestConfig = { routeMatcherMap, opnameAliasesMap };
+const requestConfig = { routeMatcherMap };
 
 export function visitComplianceDashboard() {
     visit(url.dashboard, requestConfig);

--- a/ui/apps/platform/src/Containers/Compliance/widgets/ComplianceByStandard.js
+++ b/ui/apps/platform/src/Containers/Compliance/widgets/ComplianceByStandard.js
@@ -9,7 +9,7 @@ import Widget from 'Components/Widget';
 import Sunburst from 'Components/visuals/Sunburst';
 import Query from 'Components/CacheFirstQuery';
 import Loader from 'Components/Loader';
-import { COMPLIANCE_STANDARDS as QUERY } from 'queries/standard';
+import { COMPLIANCE_STANDARDS } from 'queries/standard';
 import queryService from 'utils/queryService';
 import searchContext from 'Containers/searchContext';
 import isGQLLoading from 'utils/gqlLoading';
@@ -196,7 +196,7 @@ const ComplianceByStandard = ({
     };
 
     return (
-        <Query query={QUERY} variables={variables}>
+        <Query query={COMPLIANCE_STANDARDS(standardId)} variables={variables}>
             {({ loading, data }) => {
                 let contents = null;
                 let viewStandardLink = null;

--- a/ui/apps/platform/src/Containers/Compliance/widgets/StandardsAcrossEntity.js
+++ b/ui/apps/platform/src/Containers/Compliance/widgets/StandardsAcrossEntity.js
@@ -98,7 +98,7 @@ const StandardsAcrossEntity = ({ match, location, entityType, bodyClassName, cla
         groupBy: [entityTypes.STANDARD, entityType],
         unit: entityTypes.CHECK,
     };
-    const { loading, error, data } = useQuery(AGGREGATED_RESULTS_ACROSS_ENTITY, {
+    const { loading, error, data } = useQuery(AGGREGATED_RESULTS_ACROSS_ENTITY(entityType), {
         variables,
     });
 

--- a/ui/apps/platform/src/Containers/Compliance/widgets/StandardsByEntity.js
+++ b/ui/apps/platform/src/Containers/Compliance/widgets/StandardsByEntity.js
@@ -107,7 +107,7 @@ const StandardsByEntity = ({ match, location, entityType, bodyClassName, classNa
         groupBy: [entityTypes.STANDARD, entityType],
         unit: entityTypes.CHECK,
     };
-    const { loading, error, data } = useQuery(AGGREGATED_RESULTS_STANDARDS_BY_ENTITY, {
+    const { loading, error, data } = useQuery(AGGREGATED_RESULTS_STANDARDS_BY_ENTITY(entityType), {
         variables,
     });
 

--- a/ui/apps/platform/src/queries/controls.js
+++ b/ui/apps/platform/src/queries/controls.js
@@ -1,7 +1,7 @@
 import { gql } from '@apollo/client';
 
-export const AGGREGATED_RESULTS_ACROSS_ENTITY = gql`
-    query getAggregatedResults(
+export const AGGREGATED_RESULTS_ACROSS_ENTITY = (entityType) => gql`
+    query getAggregatedResultsAcrossEntity_${entityType}(
         $groupBy: [ComplianceAggregation_Scope!]
         $unit: ComplianceAggregation_Scope!
         $where: String
@@ -115,8 +115,8 @@ export const AGGREGATED_RESULTS_ACROSS_ENTITIES = gql`
     }
 `;
 
-export const AGGREGATED_RESULTS_STANDARDS_BY_ENTITY = gql`
-    query getAggregatedResults(
+export const AGGREGATED_RESULTS_STANDARDS_BY_ENTITY = (entityType) => gql`
+    query getAggregatedResultsByEntity_${entityType}(
         $groupBy: [ComplianceAggregation_Scope!]
         $unit: ComplianceAggregation_Scope!
         $where: String

--- a/ui/apps/platform/src/queries/standard.js
+++ b/ui/apps/platform/src/queries/standard.js
@@ -92,8 +92,8 @@ export const LIST_STANDARD_NO_NODES = gql`
     }
 `;
 
-export const COMPLIANCE_STANDARDS = gql`
-    query complianceStandards($groupBy: [ComplianceAggregation_Scope!], $where: String) {
+export const COMPLIANCE_STANDARDS = (standardId) => gql`
+    query complianceStandards_${standardId}($groupBy: [ComplianceAggregation_Scope!], $where: String) {
         complianceStandards {
             id
             name


### PR DESCRIPTION
## Description

Prerequisite to simplify integration test configuration to intercept requests and wait for responses:
* replace `requestConfig: { opnameAliasesMap, routeMatcherMap }`
* with `routeMatcherMap`

### getAggregatedResults

Before changes, same opname requires payload predicate:
* `"variables": { "groupBy": ["STANDARD", "CLUSTER"], "unit": "CHECK" }`
* `"variables": { "groupBy": ["STANDARD", "NAMESPACE"], "unit": "CHECK" }`
* `"variables": { "groupBy": ["STANDARD", "CLUSTER"], "unit": "CHECK" }`
* `"variables": { "groupBy": ["STANDARD", "NODE"], "unit": "CHECK" }`

After changes, distinct opnames include prepositional phrase and entity type:
* `getAggregateResultsAcrossEntity_CLUSTER`
* `getAggregateResultsByEntity_CLUSTER`
* `getAggregateResultsAcrossEntity_NAMESPACE`
* `getAggregateResultsAcrossEntity_NODE`

### complianceStandards

Before changes, same opname requires payload predicate:
* `where: "Standard:CIS Docker v1.2.0"`
* `where: "Standard:"CIS Kubernetes v1.5"`
* `where: "Standard:"HIPAA 164"`
* `where: "Standard:"NIST SP 800-190"`
* `where: "Standard:"NIST SP 800-53"`
* `where: "Standard:"PCI DSS 3.2.1"`

After changes, distinct opnames include standard id:
* `complianceStandards_CIS_Docker_v1_2_0`
* `complianceStandards_CIS_Kubernetes_v1_5`
* `complianceStandards_HIPAA_164`
* `complianceStandards_NIST_800_190`
* `complianceStandards_NIST_SP_800_53_Rev_4`
* `complianceStandards_PCI_DSS_3_2`

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed