### PR TITLE
Move API Reference integration tests

### DIFF
--- a/ui/apps/platform/cypress/constants/ApiReferencePage.js
+++ b/ui/apps/platform/cypress/constants/ApiReferencePage.js
@@ -1,1 +1,0 @@
-export const url = '/main/apidocs';

--- a/ui/apps/platform/cypress/constants/apiEndpoints.js
+++ b/ui/apps/platform/cypress/constants/apiEndpoints.js
@@ -199,7 +199,3 @@ export const extensions = {
 export const permissions = {
     mypermissions: '/v1/mypermissions',
 };
-
-export const apiDocs = {
-    docs: '/api/docs/swagger',
-};

--- a/ui/apps/platform/cypress/integration/apiReference.test.js
+++ b/ui/apps/platform/cypress/integration/apiReference.test.js
@@ -1,0 +1,35 @@
+import { visitMainDashboard } from '../helpers/main';
+import { interactAndWaitForResponses } from '../helpers/request';
+import { visit } from '../helpers/visit';
+
+const apiReferencePath = '/main/apidocs';
+
+const apiReferenceAlias = 'docs/swagger';
+
+const requestConfig = {
+    routeMatcherMap: {
+        [apiReferenceAlias]: '/api/docs/swagger',
+    },
+};
+
+const title = 'API Reference';
+
+describe('API Reference', () => {
+    it('should visit via menu on top nav', () => {
+        visitMainDashboard();
+
+        interactAndWaitForResponses(() => {
+            cy.get('button[aria-label="Help menu"').click();
+            cy.get(`a:contains("${title}")`).click();
+        }, requestConfig);
+
+        cy.location('pathname').should('eq', apiReferencePath);
+        cy.get(`h1:contains("${title}")`);
+    });
+
+    it('should visit via path', () => {
+        visit(apiReferencePath, requestConfig);
+
+        cy.get(`h1:contains("${title}")`);
+    });
+});

--- a/ui/apps/platform/cypress/integration/apiReference.test.js
+++ b/ui/apps/platform/cypress/integration/apiReference.test.js
@@ -1,3 +1,4 @@
+import withAuth from '../helpers/basicAuth';
 import { visitMainDashboard } from '../helpers/main';
 import { interactAndWaitForResponses } from '../helpers/request';
 import { visit } from '../helpers/visit';
@@ -15,6 +16,8 @@ const requestConfig = {
 const title = 'API Reference';
 
 describe('API Reference', () => {
+    withAuth();
+
     it('should visit via menu on top nav', () => {
         visitMainDashboard();
 

--- a/ui/apps/platform/cypress/integration/general.test.js
+++ b/ui/apps/platform/cypress/integration/general.test.js
@@ -1,7 +1,5 @@
-import { url as apidocsUrl } from '../constants/ApiReferencePage';
 import { url as userUrl } from '../constants/UserPage';
 import selectors from '../constants/GeneralPage';
-import * as api from '../constants/apiEndpoints';
 import withAuth from '../helpers/basicAuth';
 import { visitComplianceDashboard, visitComplianceEntities } from '../helpers/compliance';
 import { visitMainDashboard, visitMainDashboardFromLeftNav } from '../helpers/main';
@@ -56,24 +54,6 @@ describe('General sanity checks', () => {
 
             cy.title().should('match', new RegExp(`User Profile | ${productNameRegExp}`));
         });
-
-        it('for API Docs', () => {
-            // User Profile test often failed when preceded by this test, so move to last place.
-            cy.intercept('GET', api.apiDocs.docs).as('apiDocs');
-            visit(apidocsUrl);
-            cy.wait('@apiDocs', { responseTimeout: 10000 }); // api docs are sloooooow
-
-            cy.title().should('match', new RegExp(`API Reference | ${productNameRegExp}`));
-        });
-    });
-
-    // TODO: Fix interactive steps for ROX-6826 and merge with the preceding tests to replace visit with assertion about apidocsUrl.
-    xit('should go to API docs', () => {
-        cy.visit('/');
-        cy.get(selectors.navLinks.apidocs).as('apidocs');
-        cy.get('@apidocs').click();
-
-        cy.url().should('contain', apidocsUrl);
     });
 
     it('should allow to navigate to another page after exception happens on a page', () => {

--- a/ui/apps/platform/src/Containers/MainPage/Header/HelpMenu.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Header/HelpMenu.tsx
@@ -47,7 +47,7 @@ function HelpMenu(): ReactElement {
 
     return (
         <ApplicationLauncher
-            aria-label="Help Menu"
+            aria-label="Help menu"
             isGrouped
             isOpen={isHelpMenuOpen}
             items={appLauncherItems}


### PR DESCRIPTION
## Description
Found in search for occurrences of `cy.visit` method call in tests files.

Move out of general tests into separate test file whose name distinguishes API Reference from Help Center.

### Objectives

* Encapsulate page and endpoint addresses in test file (too simple to need helpers file).
* Encapsulate selectors which are needed only in test file.
* Call relevant generic functions from specific functions.

### Changed files

1. Delete cypress/constants/ApiReferencePage.js
    * Encapsulate page path in test file.

2. Edit cypress/constants/apiEndpoints.js
    * Encapsulate endpoint path in test file.

3. Add cypress/integration/apiReference.test.js

4. Edit cypress/integration/general.test.js
    * Move and rewrite tests.

5. Edit src/Containers/MainPage/Header/HelpMenu.tsx
    * Replace title case with sentence case in `aria-label` attribute to follow guidelines and be consistent with `aria-label="User menu"` attribute.

### Residue

1. Decide what to do about general.test.js file, for example:
    * Move title tests to container test files?
    * Investigate whether error boundary test causes exception at /main/violations in logimbue-data.json file. If we keep the test, move it into a unique errorBoundary.test.js file.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed