### PR TITLE
ROX-12380: Scope subjects to cluster role for Most Cluster Admin Roles widget

### DIFF
--- a/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/widgets/UsersWithMostClusterAdminRoles.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/widgets/UsersWithMostClusterAdminRoles.js
@@ -11,10 +11,10 @@ import Lollipop from 'Components/visuals/Lollipop';
 import ReactRouterPropTypes from 'react-router-prop-types';
 
 const QUERY = gql`
-    query usersWithClusterAdminRoles {
+    query usersWithClusterAdminRoles($query: String) {
         clusters {
             id
-            subjects {
+            subjects(query: $query) {
                 id
                 name
                 clusterAdmin
@@ -75,7 +75,12 @@ const UsersWithMostClusterAdminRoles = ({ match, location }) => {
     }
 
     return (
-        <Query query={QUERY}>
+        <Query
+            query={QUERY}
+            variables={{
+                query: 'Cluster Role:true',
+            }}
+        >
             {({ loading, data, networkStatus }) => {
                 let contents = <Loader />;
                 let viewAllLink;


### PR DESCRIPTION
## Description

Per Charmik in the Jira request:
> The query is used by "Users with most cluster admin roles" widget and queries all clusters and all subjects within each cluster. With postgres is enabled, the widget call a query with "Cluster Role:true" filter added to subjects because for all clusterAdmin subjects, their RoleBindings would have ClusterRole set to true. The additional filter can improve the turnaround time of the query in many cases.

## Checklist
- [ ] Investigated and inspected CI test results


## Testing Performed

Gives the same results before and after the optimization.

![Screen Shot 2022-10-31 at 11 39 06 AM](https://user-images.githubusercontent.com/715729/199049249-05f8ae65-4be5-4f34-b3d1-642a54a2949a.png)
