### PR TITLE
Implement read-only view of individual collection page

### DIFF
--- a/ui/apps/platform/src/Components/PatternFly/BacklogListSelector.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/BacklogListSelector.tsx
@@ -7,7 +7,6 @@ import {
     EmptyStateVariant,
     Flex,
     FormGroup,
-    Title,
 } from '@patternfly/react-core';
 import { CubesIcon, MinusCircleIcon, PlusCircleIcon } from '@patternfly/react-icons';
 
@@ -92,7 +91,7 @@ function BacklogTable<Item>({
             ) : (
                 <EmptyState variant={EmptyStateVariant.xs}>
                     <EmptyStateIcon icon={CubesIcon} />
-                    <Title headingLevel="h4">No items remaining</Title>
+                    <p>No items remaining</p>
                 </EmptyState>
             )}
         </FormGroup>

--- a/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
@@ -34,6 +34,7 @@ import {
     Truncate,
 } from '@patternfly/react-core';
 import { CaretDownIcon, CubesIcon } from '@patternfly/react-icons';
+import { TableComposable, TableVariant, Tbody, Tr, Td } from '@patternfly/react-table';
 import { useFormik } from 'formik';
 import * as yup from 'yup';
 import isEmpty from 'lodash/isEmpty';
@@ -44,7 +45,6 @@ import useSelectToggle from 'hooks/patternfly/useSelectToggle';
 import useToasts from 'hooks/patternfly/useToasts';
 import { collectionsBasePath } from 'routePaths';
 import { CollectionResponse, deleteCollection } from 'services/CollectionsService';
-import { TableComposable, TableVariant, Tbody, Tr, Td } from '@patternfly/react-table';
 import { CollectionPageAction } from './collections.utils';
 import RuleSelector from './RuleSelector';
 import CollectionAttacher from './CollectionAttacher';

--- a/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
@@ -72,9 +72,7 @@ function AttachedCollectionTable({ collections }: { collections: CollectionRespo
     ) : (
         <EmptyState variant={EmptyStateVariant.xs}>
             <EmptyStateIcon icon={CubesIcon} />
-            <Title headingLevel="h4">
-                There are no other collections attached to this collection
-            </Title>
+            <p>There are no other collections attached to this collection</p>
         </EmptyState>
     );
 }
@@ -375,14 +373,20 @@ function CollectionForm({
                                     direction={{ default: 'column' }}
                                     spaceItems={{ default: 'spaceItemsMd' }}
                                 >
-                                    <Title className="pf-u-mb-xs" headingLevel="h2">
-                                        Add new collection rules
+                                    <Title
+                                        className={isReadOnly ? 'pf-u-mb-md' : 'pf-u-mb-xs'}
+                                        headingLevel="h2"
+                                    >
+                                        Collection rules
                                     </Title>
-                                    <p>
-                                        Select deployments via rules. You can use regular
-                                        expressions (RE2 syntax).
-                                    </p>
-                                    <Divider className="pf-u-mb-lg" component="div" />
+                                    {!isReadOnly && (
+                                        <>
+                                            <p>
+                                                Select deployments via rules. You can use regular
+                                                expressions (RE2 syntax).
+                                            </p>
+                                        </>
+                                    )}
                                     <RuleSelector
                                         entityType="Deployment"
                                         scopedResourceSelector={values.resourceSelectors.Deployment}
@@ -425,20 +429,15 @@ function CollectionForm({
                                     direction={{ default: 'column' }}
                                     spaceItems={{ default: 'spaceItemsMd' }}
                                 >
+                                    <Title className="pf-u-mb-xs" headingLevel="h2">
+                                        Attached collections
+                                    </Title>
                                     {isReadOnly ? (
-                                        <>
-                                            <Title className="pf-u-mb-xs" headingLevel="h2">
-                                                Attached collections
-                                            </Title>
-                                            <AttachedCollectionTable
-                                                collections={initialEmbeddedCollections}
-                                            />
-                                        </>
+                                        <AttachedCollectionTable
+                                            collections={initialEmbeddedCollections}
+                                        />
                                     ) : (
                                         <>
-                                            <Title className="pf-u-mb-xs" headingLevel="h2">
-                                                Attach existing collections
-                                            </Title>
                                             <p>Extend this collection by attaching other sets.</p>
                                             <CollectionAttacher
                                                 initialEmbeddedCollections={

--- a/ui/apps/platform/src/Containers/Collections/RuleSelector/AutoCompleteSelect.tsx
+++ b/ui/apps/platform/src/Containers/Collections/RuleSelector/AutoCompleteSelect.tsx
@@ -9,6 +9,7 @@ export type AutoCompleteSelectProps = {
     typeAheadAriaLabel?: string;
     onChange: (value: string) => void;
     validated: ValidatedOptions;
+    isDisabled: boolean;
 };
 
 /* TODO Implement autocompletion */
@@ -19,6 +20,7 @@ export function AutoCompleteSelect({
     typeAheadAriaLabel,
     onChange,
     validated,
+    isDisabled,
 }: AutoCompleteSelectProps) {
     const { isOpen, onToggle, closeSelect } = useSelectToggle();
 
@@ -40,6 +42,7 @@ export function AutoCompleteSelect({
                 onToggle={onToggle}
                 selections={selectedOption}
                 onSelect={onSelect}
+                isDisabled={isDisabled}
             />
         </>
     );

--- a/ui/apps/platform/src/Containers/Collections/RuleSelector/ByLabelSelector.tsx
+++ b/ui/apps/platform/src/Containers/Collections/RuleSelector/ByLabelSelector.tsx
@@ -24,6 +24,7 @@ export type ByLabelSelectorProps = {
         scopedResourceSelector: ScopedResourceSelector
     ) => void;
     validationErrors: FormikErrors<ByLabelResourceSelector> | undefined;
+    isDisabled: boolean;
 };
 
 function ByLabelSelector({
@@ -31,6 +32,7 @@ function ByLabelSelector({
     scopedResourceSelector,
     handleChange,
     validationErrors,
+    isDisabled,
 }: ByLabelSelectorProps) {
     const { keyFor, invalidateIndexKeys } = useIndexKey();
     function onChangeLabelKey(resourceSelector: ByLabelResourceSelector, ruleIndex, value) {
@@ -139,6 +141,7 @@ function ByLabelSelector({
                                             )
                                         }
                                         validated={keyValidation}
+                                        isDisabled={isDisabled}
                                     />
                                 </FormGroup>
                                 <FlexItem
@@ -188,38 +191,51 @@ function ByLabelSelector({
                                                         )
                                                     }
                                                     validated={valueValidation}
+                                                    isDisabled={isDisabled}
                                                 />
-                                                <Button
-                                                    variant="plain"
-                                                    onClick={() =>
-                                                        onDeleteValue(ruleIndex, valueIndex)
-                                                    }
-                                                >
-                                                    <TrashIcon
-                                                        style={{ cursor: 'pointer' }}
-                                                        color="var(--pf-global--Color--dark-200)"
-                                                    />
-                                                </Button>
+                                                {!isDisabled && (
+                                                    <Button
+                                                        variant="plain"
+                                                        onClick={() =>
+                                                            onDeleteValue(ruleIndex, valueIndex)
+                                                        }
+                                                    >
+                                                        <TrashIcon
+                                                            style={{ cursor: 'pointer' }}
+                                                            color="var(--pf-global--Color--dark-200)"
+                                                        />
+                                                    </Button>
+                                                )}
                                             </Flex>
                                         );
                                     })}
                                 </Flex>
-                                <Button
-                                    className="pf-u-pl-0 pf-u-pt-md"
-                                    variant="link"
-                                    onClick={() => onAddLabelValue(ruleIndex)}
-                                >
-                                    Add value
-                                </Button>
+                                {!isDisabled && (
+                                    <Button
+                                        className="pf-u-pl-0 pf-u-pt-md"
+                                        variant="link"
+                                        onClick={() => onAddLabelValue(ruleIndex)}
+                                    >
+                                        Add value
+                                    </Button>
+                                )}
                             </FormGroup>
                         </Flex>
                     </div>
                 );
             })}
-            <Divider component="div" className="pf-u-pt-lg" />
-            <Button className="pf-u-pl-0 pf-u-pt-md" variant="link" onClick={onAddLabelRule}>
-                Add label rule
-            </Button>
+            {!isDisabled && (
+                <>
+                    <Divider component="div" className="pf-u-pt-lg" />
+                    <Button
+                        className="pf-u-pl-0 pf-u-pt-md"
+                        variant="link"
+                        onClick={onAddLabelRule}
+                    >
+                        Add label rule
+                    </Button>
+                </>
+            )}
         </>
     );
 }

--- a/ui/apps/platform/src/Containers/Collections/RuleSelector/ByNameSelector.tsx
+++ b/ui/apps/platform/src/Containers/Collections/RuleSelector/ByNameSelector.tsx
@@ -16,6 +16,7 @@ export type ByNameSelectorProps = {
         scopedResourceSelector: ScopedResourceSelector
     ) => void;
     validationErrors: FormikErrors<ByNameResourceSelector> | undefined;
+    isDisabled: boolean;
 };
 
 function ByNameSelector({
@@ -23,6 +24,7 @@ function ByNameSelector({
     scopedResourceSelector,
     handleChange,
     validationErrors,
+    isDisabled,
 }: ByNameSelectorProps) {
     const { keyFor, invalidateIndexKeys } = useIndexKey();
 
@@ -74,21 +76,26 @@ function ByNameSelector({
                                     ? ValidatedOptions.error
                                     : ValidatedOptions.default
                             }
+                            isDisabled={isDisabled}
                         />
-                        <Button variant="plain" onClick={() => onDeleteValue(index)}>
-                            <TrashIcon
-                                aria-label={`Delete ${value}`}
-                                className="pf-u-flex-shrink-1"
-                                style={{ cursor: 'pointer' }}
-                                color="var(--pf-global--Color--dark-200)"
-                            />
-                        </Button>
+                        {!isDisabled && (
+                            <Button variant="plain" onClick={() => onDeleteValue(index)}>
+                                <TrashIcon
+                                    aria-label={`Delete ${value}`}
+                                    className="pf-u-flex-shrink-1"
+                                    style={{ cursor: 'pointer' }}
+                                    color="var(--pf-global--Color--dark-200)"
+                                />
+                            </Button>
+                        )}
                     </Flex>
                 ))}
             </Flex>
-            <Button className="pf-u-pl-0 pf-u-pt-md" variant="link" onClick={onAddValue}>
-                Add value
-            </Button>
+            {!isDisabled && (
+                <Button className="pf-u-pl-0 pf-u-pt-md" variant="link" onClick={onAddValue}>
+                    Add value
+                </Button>
+            )}
         </FormGroup>
     );
 }

--- a/ui/apps/platform/src/Containers/Collections/RuleSelector/RuleSelector.tsx
+++ b/ui/apps/platform/src/Containers/Collections/RuleSelector/RuleSelector.tsx
@@ -30,6 +30,7 @@ export type RuleSelectorProps = {
         scopedResourceSelector: ScopedResourceSelector
     ) => void;
     validationErrors: FormikErrors<ScopedResourceSelector> | undefined;
+    isDisabled?: boolean;
 };
 
 function RuleSelector({
@@ -37,6 +38,7 @@ function RuleSelector({
     scopedResourceSelector,
     handleChange,
     validationErrors,
+    isDisabled = false,
 }: RuleSelectorProps) {
     const { isOpen, onToggle, closeSelect } = useSelectToggle();
     const pluralEntity = pluralize(entityType);
@@ -84,6 +86,7 @@ function RuleSelector({
                 onToggle={onToggle}
                 selections={selection}
                 onSelect={onRuleOptionSelect}
+                isDisabled={isDisabled}
             >
                 <SelectOption value="All">All {pluralEntity.toLowerCase()}</SelectOption>
                 <SelectOption value="ByName">{pluralEntity} with names matching</SelectOption>
@@ -96,6 +99,7 @@ function RuleSelector({
                     scopedResourceSelector={scopedResourceSelector}
                     handleChange={handleChange}
                     validationErrors={validationErrors}
+                    isDisabled={isDisabled}
                 />
             )}
 
@@ -105,6 +109,7 @@ function RuleSelector({
                     scopedResourceSelector={scopedResourceSelector}
                     handleChange={handleChange}
                     validationErrors={validationErrors}
+                    isDisabled={isDisabled}
                 />
             )}
         </div>

--- a/ui/apps/platform/src/css/trumps.css
+++ b/ui/apps/platform/src/css/trumps.css
@@ -80,6 +80,11 @@ button.pf-c-toggle-group__button:disabled {
     border-width: 1px !important;
 }
 
+/* Un-override the above override when the <Select> component is disabled */
+.pf-c-select__toggle.pf-m-disabled::before {
+    border-width: inherit !important;
+}
+
 /* overriding our tailwind config default of display: block for images, because it breaks the patternfly layout */
 .pf-c-button__icon.pf-m-start svg,
 .pf-c-button__icon.pf-m-end svg,


### PR DESCRIPTION
## Description

This implements the read-only "view" mode of individual collection pages.

Form controls will be disabled and non-interactive, extraneous UI components (trash buttons) will not be visible, and the collection attacher component will be replaced with a read-only alternative display.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Visit the collection page and select a collection from the table. The browser will navigate to the read only view for that collection with the constraints in the above description. 
Clicking on disabled UI controls will have no effect. Tab-navigation will skip over the disabled controls.
![image](https://user-images.githubusercontent.com/1292638/199500650-6135f1a2-8595-4eb0-bcbc-f651dbc332dc.png)
![image](https://user-images.githubusercontent.com/1292638/199500719-3cd83e6e-d3f1-4369-9596-4b7e6ee4b992.png)

When viewing a collection with no embedded collections in read-only mode, an empty state component will appear in place of the table:
<img width="831" alt="image" src="https://user-images.githubusercontent.com/1292638/199500844-8409d48c-a5af-4906-97b2-b105496e5a0e.png">

Mobile layout views:
<img width="350" alt="image" src="https://user-images.githubusercontent.com/1292638/199501023-d7db4fea-ca18-49ee-8f98-a131b78ad080.png">
<img width="350" alt="image" src="https://user-images.githubusercontent.com/1292638/199262046-1146fc90-2b4f-4e02-8ed7-3d98a0790755.png">
<img width="350" alt="image" src="https://user-images.githubusercontent.com/1292638/199262077-59b5c72b-f054-41d4-a7bb-713db090293d.png">
<img width="350" alt="image" src="https://user-images.githubusercontent.com/1292638/199262151-4417b5ea-16dd-4591-af3d-1892020043aa.png">




