### PR TITLE
ROX-13377: Network Graph selection for namespace doesn't work

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
@@ -1,10 +1,12 @@
 import React, { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, useHistory } from 'react-router-dom';
 import { PageSection, Title, Flex, FlexItem } from '@patternfly/react-core';
 import { Model } from '@patternfly/react-topology';
 
 import { fetchNetworkFlowGraph } from 'services/NetworkService';
 import { fetchClustersAsArray, Cluster } from 'services/ClustersService';
+import { networkBasePathPF } from 'routePaths';
+
 import PageTitle from 'Components/PageTitle';
 import NetworkGraph from './NetworkGraph';
 import { transformData, graphModel } from './utils';
@@ -12,6 +14,7 @@ import { transformData, graphModel } from './utils';
 import './NetworkGraphPage.css';
 
 function NetworkGraphPage() {
+    const history = useHistory();
     const { detailType, detailId } = useParams();
     const [model, setModel] = useState<Model>({
         graph: graphModel,
@@ -41,6 +44,20 @@ function NetworkGraphPage() {
         }
     }, [clusters]);
 
+    function onSelectNode(type: string, id: string) {
+        // if found, and it's not the logical grouping of all external sources, then trigger URL update
+        if (id !== 'EXTERNAL') {
+            history.push(`${networkBasePathPF}/${type}/${id}`);
+        } else {
+            // otherwise, return to the graph-only state
+            history.push(`${networkBasePathPF}`);
+        }
+    }
+
+    function closeSidebar() {
+        history.push(`${networkBasePathPF}`);
+    }
+
     return (
         <>
             <PageTitle title="Network Graph" />
@@ -52,7 +69,13 @@ function NetworkGraphPage() {
                 </Flex>
             </PageSection>
             <PageSection className="network-graph no-padding">
-                <NetworkGraph detailType={detailType} detailId={detailId} model={model} />
+                <NetworkGraph
+                    detailType={detailType}
+                    detailId={detailId}
+                    model={model}
+                    closeSidebar={closeSidebar}
+                    onSelectNode={onSelectNode}
+                />
             </PageSection>
         </>
     );

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils.tsx
@@ -37,7 +37,7 @@ export function transformData(nodes: Node[]): Model {
             width: 75,
             height: 75,
             label: getLabel(entity),
-            data: {},
+            data: entity,
         };
         dataModel.nodes.push(node);
 
@@ -57,6 +57,7 @@ export function transformData(nodes: Node[]): Model {
                     data: {
                         collapsible: true,
                         showContextMenu: false,
+                        type: 'NAMESPACE',
                     },
                 };
             }


### PR DESCRIPTION
## Description

Essentially, the `findEntityById` function wasn't working quite right. The model didn't have a `groups` field. We only have `graph`, `nodes,` and `edges`. I also pulled out the URL-related logic up to the parent component since the NetworkGraph component doesn't need to know all that.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

<img width="1552" alt="Screen Shot 2022-10-31 at 11 26 05 AM" src="https://user-images.githubusercontent.com/4805485/199082173-9ac709c2-e5c9-44b7-b0d2-3e0944d51e7c.png">
<img width="1552" alt="Screen Shot 2022-10-31 at 11 26 09 AM" src="https://user-images.githubusercontent.com/4805485/199082177-8ea1242d-370e-4f3e-8e3c-6bc8be08a9e5.png">
<img width="1552" alt="Screen Shot 2022-10-31 at 11 26 12 AM" src="https://user-images.githubusercontent.com/4805485/199082181-a0665d24-e789-4c97-9dca-9b4ad79f397a.png">
