### PR TITLE
ROX-13380: Conditional rendering edges for deployments and namespaces

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { PageSection, Title, Flex, FlexItem } from '@patternfly/react-core';
+import { PageSection, Title, Flex, FlexItem, Bullseye, Spinner } from '@patternfly/react-core';
 import { Model } from '@patternfly/react-topology';
 
 import { fetchNetworkFlowGraph } from 'services/NetworkService';
@@ -11,10 +11,13 @@ import { transformData, graphModel } from './utils';
 
 import './NetworkGraphPage.css';
 
+const emptyModel = {
+    graph: graphModel,
+};
+
 function NetworkGraphPage() {
-    const [model, setModel] = useState<Model>({
-        graph: graphModel,
-    });
+    const [model, setModel] = useState<Model>(emptyModel);
+    const [isLoading, setIsLoading] = useState(false);
     const [clusters, setClusters] = useState<Cluster[]>([]);
 
     useEffect(() => {
@@ -29,6 +32,7 @@ function NetworkGraphPage() {
 
     useEffect(() => {
         if (clusters.length > 0) {
+            setIsLoading(true);
             fetchNetworkFlowGraph(clusters[0].id, [])
                 .then(({ response }) => {
                     const dataModel = transformData(response.nodes);
@@ -36,11 +40,10 @@ function NetworkGraphPage() {
                 })
                 .catch(() => {
                     // TODO
-                });
+                })
+                .finally(() => setIsLoading(false));
         }
     }, [clusters]);
-
-    console.log('NetworkGraphPage');
 
     return (
         <>
@@ -53,7 +56,12 @@ function NetworkGraphPage() {
                 </Flex>
             </PageSection>
             <PageSection className="network-graph no-padding">
-                <NetworkGraph model={model} />
+                {model.nodes && <NetworkGraph model={model} />}
+                {isLoading && (
+                    <Bullseye>
+                        <Spinner isSVG />
+                    </Bullseye>
+                )}
             </PageSection>
         </>
     );

--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
@@ -1,11 +1,9 @@
 import React, { useEffect, useState } from 'react';
-import { useParams, useHistory } from 'react-router-dom';
 import { PageSection, Title, Flex, FlexItem } from '@patternfly/react-core';
 import { Model } from '@patternfly/react-topology';
 
 import { fetchNetworkFlowGraph } from 'services/NetworkService';
 import { fetchClustersAsArray, Cluster } from 'services/ClustersService';
-import { networkBasePathPF } from 'routePaths';
 
 import PageTitle from 'Components/PageTitle';
 import NetworkGraph from './NetworkGraph';
@@ -14,8 +12,6 @@ import { transformData, graphModel } from './utils';
 import './NetworkGraphPage.css';
 
 function NetworkGraphPage() {
-    const history = useHistory();
-    const { detailType, detailId } = useParams();
     const [model, setModel] = useState<Model>({
         graph: graphModel,
     });
@@ -44,19 +40,7 @@ function NetworkGraphPage() {
         }
     }, [clusters]);
 
-    function onSelectNode(type: string, id: string) {
-        // if found, and it's not the logical grouping of all external sources, then trigger URL update
-        if (id !== 'EXTERNAL') {
-            history.push(`${networkBasePathPF}/${type}/${id}`);
-        } else {
-            // otherwise, return to the graph-only state
-            history.push(`${networkBasePathPF}`);
-        }
-    }
-
-    function closeSidebar() {
-        history.push(`${networkBasePathPF}`);
-    }
+    console.log('NetworkGraphPage');
 
     return (
         <>
@@ -69,13 +53,7 @@ function NetworkGraphPage() {
                 </Flex>
             </PageSection>
             <PageSection className="network-graph no-padding">
-                <NetworkGraph
-                    detailType={detailType}
-                    detailId={detailId}
-                    model={model}
-                    closeSidebar={closeSidebar}
-                    onSelectNode={onSelectNode}
-                />
+                <NetworkGraph model={model} />
             </PageSection>
         </>
     );

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils.tsx
@@ -70,8 +70,7 @@ export function transformData(nodes: Node[]): Model {
                 type: 'edge',
                 source: entity.id,
                 target: nodes[nodeIdx].entity.id,
-                // TODO: figure out how to conditionally render performantly
-                // visible: false,
+                visible: false,
             };
             dataModel.edges.push(edge);
         });


### PR DESCRIPTION
as the title states -- the default graph should render no edges 

<img width="1137" alt="image" src="https://user-images.githubusercontent.com/10412893/199139328-8b482bd0-3cc6-4dae-b260-1f7e91526c08.png">

clicking on a deployment should render only edges related to said deployment

<img width="1145" alt="image" src="https://user-images.githubusercontent.com/10412893/199139361-79ae74c8-122a-4558-9159-c5892adcf66c.png">

closing the side panel (unselecting the deployment) should clear the edges

<img width="1148" alt="image" src="https://user-images.githubusercontent.com/10412893/199139392-1928de0b-754a-4b04-802c-ace2b27e4b9c.png">

clicking on a namespace should render only edges related to the child deployments within said namespace

<img width="1151" alt="image" src="https://user-images.githubusercontent.com/10412893/199139431-4eeaa8a9-973b-4330-85df-65728b628253.png">

also -- the graph should not flicker/rerender on clicking on nodes now :) 