### PR TITLE
ROX-9858: Add central-db to the list of related images

### DIFF
--- a/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
@@ -890,6 +890,7 @@ spec:
                 - name: RELATED_IMAGE_COLLECTOR_FULL
                 - name: RELATED_IMAGE_ROXCTL
                 - name: RELATED_IMAGE_DOCS
+                - name: RELATED_IMAGE_CENTRAL_DB
                 image: quay.io/stackrox-io/stackrox-operator:0.0.1
                 livenessProbe:
                   httpGet:

--- a/operator/config/manager/manager.yaml
+++ b/operator/config/manager/manager.yaml
@@ -43,6 +43,7 @@ spec:
         - name: RELATED_IMAGE_COLLECTOR_FULL
         - name: RELATED_IMAGE_ROXCTL
         - name: RELATED_IMAGE_DOCS
+        - name: RELATED_IMAGE_CENTRAL_DB
         image: controller:latest
         name: manager
         securityContext:

--- a/pkg/images/defaults/flavor.go
+++ b/pkg/images/defaults/flavor.go
@@ -180,10 +180,9 @@ func StackRoxIOReleaseImageFlavor() ImageFlavor {
 func RHACSReleaseImageFlavor() ImageFlavor {
 	v := version.GetAllVersionsUnified()
 	return ImageFlavor{
-		MainRegistry:  "registry.redhat.io/advanced-cluster-security",
-		MainImageName: "rhacs-main-rhel8",
-		MainImageTag:  v.MainVersion,
-		/* TODO(ROX-9858): Create repo rhacs-central-db-rhel8 when starting building rhacs */
+		MainRegistry:       "registry.redhat.io/advanced-cluster-security",
+		MainImageName:      "rhacs-main-rhel8",
+		MainImageTag:       v.MainVersion,
 		CentralDBImageTag:  v.MainVersion,
 		CentralDBImageName: "rhacs-central-db-rhel8",
 


### PR DESCRIPTION
## Description

See commit description.

## Checklist
- [x] Investigated and inspected CI test results

Nothing else matters (user-facing documentation is supposed to go in <https://issues.redhat.com/browse/ROX-12515>):
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

* CI should check if generated sources are up to date.
* Otherwise, it's impossible to fully test this upstream at this point. I will check contents of the operator-bundle image built downstream once this PR gets merged.