### PR TITLE
Implement create/clone/edit functionality for collection form

### DIFF
--- a/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
@@ -43,12 +43,18 @@ import ConfirmationModal from 'Components/PatternFly/ConfirmationModal';
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
 import useToasts from 'hooks/patternfly/useToasts';
 import { collectionsBasePath } from 'routePaths';
-import { CollectionResponse, deleteCollection } from 'services/CollectionsService';
+import {
+    CollectionResponse,
+    createCollection,
+    deleteCollection,
+    updateCollection,
+} from 'services/CollectionsService';
 import { CollectionPageAction } from './collections.utils';
 import RuleSelector from './RuleSelector';
 import CollectionAttacher from './CollectionAttacher';
 import CollectionResults from './CollectionResults';
 import { Collection, ScopedResourceSelector, SelectorEntityType } from './types';
+import { generateRequest } from './converter';
 
 function AttachedCollectionTable({ collections }: { collections: CollectionResponse[] }) {
     return collections.length > 0 ? (
@@ -147,9 +153,19 @@ function CollectionForm({
     const [isDeleting, setIsDeleting] = useState(false);
     const { toasts, addToast, removeToast } = useToasts();
 
-    const { values, errors, handleChange, handleBlur, setFieldValue } = useFormik({
+    const {
+        values,
+        isValid,
+        errors,
+        handleChange,
+        handleBlur,
+        setFieldValue,
+        submitForm,
+        isSubmitting,
+        setSubmitting,
+    } = useFormik({
         initialValues: initialData,
-        onSubmit: () => {},
+        onSubmit: onSaveCollection,
         validationSchema: yup.object({
             name: yup.string().trim().required(),
             description: yup.string(),
@@ -191,11 +207,7 @@ function CollectionForm({
         deleteCollection(deleteId)
             .request.then(history.goBack)
             .catch((err) => {
-                addToast(
-                    `Could not delete collection ${initialData.name ?? ''}`,
-                    'danger',
-                    err.message
-                );
+                addToast(`Could not delete collection ${initialData.name}`, 'danger', err.message);
             })
             .finally(() => {
                 setDeleteId(null);
@@ -205,6 +217,38 @@ function CollectionForm({
 
     function onCancelDeleteCollection() {
         setDeleteId(null);
+    }
+
+    function onSaveCollection(collection: Collection) {
+        if (action.type === 'view') {
+            // Logically should not happen, but just in case
+            return;
+        }
+
+        const saveServiceCall =
+            action.type === 'edit'
+                ? (payload) => updateCollection(action.collectionId, payload)
+                : (payload) => createCollection(payload);
+
+        const requestPayload = generateRequest(collection);
+        const { request } = saveServiceCall(requestPayload);
+
+        request
+            .then(() => {
+                history.push({ pathname: `${collectionsBasePath}` });
+            })
+            .catch((err) => {
+                addToast(
+                    `There was an error saving collection '${values.name}'`,
+                    'danger',
+                    err.message
+                );
+                setSubmitting(false);
+            });
+    }
+
+    function onCancelSave() {
+        history.push({ pathname: `${collectionsBasePath}` });
     }
 
     const onResourceSelectorChange = (
@@ -450,8 +494,21 @@ function CollectionForm({
                             </Flex>
                             {action.type !== 'view' && (
                                 <div className="pf-u-background-color-100 pf-u-p-lg pf-u-py-md">
-                                    <Button className="pf-u-mr-md">Save</Button>
-                                    <Button variant="secondary">Cancel</Button>
+                                    <Button
+                                        className="pf-u-mr-md"
+                                        onClick={submitForm}
+                                        isDisabled={isSubmitting || !isValid}
+                                        isLoading={isSubmitting}
+                                    >
+                                        Save
+                                    </Button>
+                                    <Button
+                                        variant="secondary"
+                                        isDisabled={isSubmitting}
+                                        onClick={onCancelSave}
+                                    >
+                                        Cancel
+                                    </Button>
                                 </div>
                             )}
                         </Form>

--- a/ui/apps/platform/src/Containers/Collections/CollectionsFormPage.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionsFormPage.tsx
@@ -85,6 +85,9 @@ function CollectionsFormPage({
     } else if (loading) {
         content = <>{/* TODO - Handle UI for loading state */}</>;
     } else if (initialData) {
+        if (pageAction.type === 'clone') {
+            initialData.name += ' (COPY)';
+        }
         content = (
             <CollectionForm
                 hasWriteAccessForCollections={hasWriteAccessForCollections}


### PR DESCRIPTION
## Description

Hooks up the "Save" and "Cancel" buttons on the form in order to implement Create/Clone/Edit for collections.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Visit the collection page and click the "Create Collection" button. Fill out the form with relevant details.
![image](https://user-images.githubusercontent.com/1292638/199549415-eefbe3a5-f280-4853-9f95-d9ea0f60e520.png)
Note that there is an additional value for label left blank in the screenshot below:
![image](https://user-images.githubusercontent.com/1292638/199549564-b2c105bb-e03d-4634-8191-10c1900845c7.png)
Attach a couple of collections:
![image](https://user-images.githubusercontent.com/1292638/199550648-14522956-8469-42df-8682-4362cfc640b1.png)

Notice that the "Save" button is disabled since the form is not in a valid state.

Go back to the blank field and enter a value.
![image](https://user-images.githubusercontent.com/1292638/199550837-52b52d4c-9cea-4aa7-a8f1-be797ea50dbc.png)
![image](https://user-images.githubusercontent.com/1292638/199550889-aa20daa3-c90c-4298-818d-ed83ef6d5fa9.png)

Click on the Save button, both the "Save" and "Cancel" buttons will be disabled when the request is in flight. Once the request succeeds, the page will return to the collection list and the new collection will be present.
![image](https://user-images.githubusercontent.com/1292638/199551218-e8f94c80-0278-4717-b374-fb23f77d0372.png)

Clicking on this collection from the list will take you to the read-only view of the collection, with the details matching the values that were entered during creation.
![image](https://user-images.githubusercontent.com/1292638/199551406-f7173ca6-b3e9-46e6-8a3d-6c11db3be5ca.png)
![image](https://user-images.githubusercontent.com/1292638/199551455-0a59a353-8a9c-40f8-bea1-e842a4295675.png)

Scroll back to the top of the page and select "Edit collection" from the Action dropdown. The form fields will be enabled and become editable.
![image](https://user-images.githubusercontent.com/1292638/199551635-e311770e-415c-4800-bc85-b3325df58b0f.png)

Make some changes to the form, observing that invalid values cause the "Save" button to be disabled like in the "create" mode above.
![image](https://user-images.githubusercontent.com/1292638/199551917-35165b59-9898-448a-939f-b88ccbab75cc.png)
![image](https://user-images.githubusercontent.com/1292638/199551995-c01c31e0-70b3-4da9-a24d-439c07e34185.png)

Fill in the missing values and submit the form.
![image](https://user-images.githubusercontent.com/1292638/199552251-7f632413-d549-4fec-a649-52b921e81b87.png)

After being redirected to the collections table, select this collection again and verify that the field values have been updated correctly and that a new collection has _not_ been created.
![image](https://user-images.githubusercontent.com/1292638/199552599-52fc9d39-a72d-40f3-9a2b-5acef7c4ab57.png)
![image](https://user-images.githubusercontent.com/1292638/199552516-4b9efa35-7206-49f7-aca6-8a7eb1c36932.png)
![image](https://user-images.githubusercontent.com/1292638/199552545-a705483e-cf45-495b-8d8b-fcd28a0dfacb.png)

From the collections table, open the table menu for this collection and select "Clone collection".
![image](https://user-images.githubusercontent.com/1292638/199552732-2065dacc-cf7d-4259-bd6e-2b9ddf90aeb7.png)

The collection form will be presented with the text " (COPY)" appended to the collection name.
![image](https://user-images.githubusercontent.com/1292638/199552883-f1cbb070-19a4-4678-ac90-2e41bc459e49.png)

Make some changes to the rules and save the collection.
![image](https://user-images.githubusercontent.com/1292638/199553000-908e1174-ae23-4636-acbe-1271148db3dd.png)

Notice on the collection table page that a new collection has been created. Visit the collection page for each of these collections and verify that they contain different rule sets.
![image](https://user-images.githubusercontent.com/1292638/199553187-7fb1b967-6863-40ee-857a-6e49b5efb1c4.png)

For any collection, view the edit or clone page, and then visit the "Create collection" page. Scrolling to the bottom of the form on any of these pages and clicking the "Cancel" button will redirect you to the collections table.

**This test requires manual editing of the mock server.**
For the create, edit, and clone modes, click Save and view the result when the server returns an error. A toast should be displayed and the user will remain on the form page:
![image](https://user-images.githubusercontent.com/1292638/199553796-11b6e138-6c22-4126-a213-c3bda39193d3.png)


