### PR TITLE
Add ignoreErrors option for ResizeObserver to Raven config

### DIFF
--- a/ui/apps/platform/src/installRaven.js
+++ b/ui/apps/platform/src/installRaven.js
@@ -10,9 +10,14 @@ export default function installRaven() {
         return;
     }
 
+    // Ignore exceptions from widgets on main dashboard in cypress integration tests.
+    const options = {
+        ignoreErrors: ['ResizeObserver loop limit exceeded'],
+    };
+
     // since hosted or on-prem Sentry isn't being used, there is no configuration we should be doing,
     // but raven-js requires to have some DSN (see https://github.com/getsentry/raven-js/issues/999)
-    Raven.config('https://fakeuser@noserver/stackrox').install();
+    Raven.config('https://fakeuser@noserver/stackrox', options).install();
 
     Raven.setTransport(({ data, onSuccess, onError }) => {
         axios.post('/api/logimbue', data).then(onSuccess, onError);


### PR DESCRIPTION
## Description

### Problem

Difficult to find exceptions for failing integration tests in logimbue-data.json file because of 23 exceptions:

```text
      "url": "https://central-lb/main/dashboard"
    },
    "exception": {
      "values": [
        {
          "value": "ResizeObserver loop limit exceeded",
```

### Analysis

Although there might be an idiom which dependencies could apply to prevent the exception, it seems to be an artifact of test environment from factors like headless browser at certain screen sizes.

### Solution

The practical solution consists of:
* cypress/support/e2e.js ignores the error so tests pass in #2067
* src/installRaven.js also needs to ignore the error to prevent clutter in logimbue-data.json file

https://docs.sentry.io/clients/javascript/config/

> `Raven.config()` can optionally be passed an additional argument for extra configuration

> Very often, you will come across specific errors that are a result of something other than your application, or errors that you’re completely not interested in. ignoreErrors is a list of these messages to be filtered out before being sent to Sentry as either regular expressions or strings. When using strings, they’ll partially match the messages, so if you need to achieve an exact match, use RegExp patterns instead.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

logimbue-data.json files has 25 exceptions without option and only 2 exceptions with option.