### PR TITLE
ROX-11829: Diagnostic bundles generated contain info about central's environment if flag is set

### DIFF
--- a/central/debug/service/diagnostics.go
+++ b/central/debug/service/diagnostics.go
@@ -276,8 +276,10 @@ func (s *serviceImpl) getK8sDiagnostics(ctx context.Context, zipWriter *zip.Writ
 	// Pull data from the central cluster.
 	// TODO: It would be nice if we could add a flag to a sensor connection that indicates whether this sensor is
 	// running colocated with central, so we could skip this.
-	wg.Add(1)
-	go pullCentralClusterDiagnostics(subCtx, filesC, &wg, opts.since)
+	if opts.withCentral {
+		wg.Add(1)
+		go pullCentralClusterDiagnostics(subCtx, filesC, &wg, opts.since)
+	}
 
 	go func() {
 		select {

--- a/central/debug/service/service.go
+++ b/central/debug/service/service.go
@@ -611,7 +611,7 @@ func (s *serviceImpl) getDebugDump(w http.ResponseWriter, r *http.Request) {
 		withLogImbue:      true,
 		withAccessControl: true,
 		withNotifiers:     true,
-		withCentral:       !env.DisableCentralDiagnostics.BooleanSetting(),
+		withCentral:       env.EnableCentralDiagnostics.BooleanSetting(),
 		telemetryMode:     0,
 	}
 
@@ -656,7 +656,7 @@ func (s *serviceImpl) getDiagnosticDump(w http.ResponseWriter, r *http.Request) 
 		withCPUProfile:    false,
 		withLogImbue:      true,
 		withAccessControl: true,
-		withCentral:       !env.DisableCentralDiagnostics.BooleanSetting(),
+		withCentral:       env.EnableCentralDiagnostics.BooleanSetting(),
 		withNotifiers:     true,
 	}
 

--- a/central/debug/service/service.go
+++ b/central/debug/service/service.go
@@ -563,13 +563,13 @@ func (s *serviceImpl) writeZippedDebugDump(ctx context.Context, w http.ResponseW
 	fetchAndAddJSONToZip(ctx, zipWriter, "system-configuration.json", s.getConfig)
 
 	// Get logs last to also catch logs made during creation of diag bundle.
-	if opts.logs == localLogs {
+	if opts.withCentral && opts.logs == localLogs {
 		if err := getLogs(zipWriter); err != nil {
 			log.Error(err)
 		}
 	}
 
-	if opts.withLogImbue {
+	if opts.withCentral && opts.withLogImbue {
 		if err := s.getLogImbue(ctx, zipWriter); err != nil {
 			log.Error(err)
 		}
@@ -628,11 +628,6 @@ func (s *serviceImpl) getDebugDump(w http.ResponseWriter, r *http.Request) {
 		} else {
 			opts.logs = noLogs
 		}
-	}
-
-	if env.DisableCentralDiagnostics.BooleanSetting() {
-		// Regardless of query, don't generate logs for managed central
-		opts.logs = noLogs
 	}
 
 	telemetryModeStr := query.Get("telemetry")

--- a/central/telemetry/gatherers/rox.go
+++ b/central/telemetry/gatherers/rox.go
@@ -21,9 +21,14 @@ func newRoxGatherer(central *CentralGatherer, cluster *ClusterGatherer) *RoxGath
 }
 
 // Gather returns telemetry information about this Rox
-func (c *RoxGatherer) Gather(ctx context.Context, pullFromSensors bool) *data.TelemetryData {
-	return &data.TelemetryData{
-		Central:  c.central.Gather(ctx),
+func (c *RoxGatherer) Gather(ctx context.Context, pullFromSensors bool, pullFromCentral bool) *data.TelemetryData {
+	telemetryData := &data.TelemetryData{
 		Clusters: c.cluster.Gather(ctx, pullFromSensors),
 	}
+
+	if pullFromCentral {
+		telemetryData.Central = c.central.Gather(ctx)
+	}
+
+	return telemetryData
 }

--- a/image/templates/helm/stackrox-central/templates/01-central-03-diagnostics-rbac.yaml
+++ b/image/templates/helm/stackrox-central/templates/01-central-03-diagnostics-rbac.yaml
@@ -1,5 +1,6 @@
 {{- include "srox.init" . -}}
 
+{{- if not ._rox.env.managedServices }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -42,3 +43,4 @@ subjects:
   - kind: ServiceAccount
     name: central
     namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml
+++ b/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml
@@ -107,8 +107,8 @@ spec:
         {{- if ._rox.env.managedServices }}
         - name: ROX_MANAGED_CENTRAL
           value: "true"
-        - name: ROX_DISABLE_CENTRAL_DIAGNOSTICS
-          value: "true"
+        - name: ROX_ENABLE_CENTRAL_DIAGNOSTICS
+          value: "false"
         {{- end }}
         {{- if ._rox.central.db.enabled }}
         - name: ROX_POSTGRES_DATASTORE

--- a/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml
+++ b/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml
@@ -107,6 +107,8 @@ spec:
         {{- if ._rox.env.managedServices }}
         - name: ROX_MANAGED_CENTRAL
           value: "true"
+        - name: ROX_DISABLE_CENTRAL_DIAGNOSTICS
+          value: "true"
         {{- end }}
         {{- if ._rox.central.db.enabled }}
         - name: ROX_POSTGRES_DATASTORE

--- a/pkg/env/central_diagnostics.go
+++ b/pkg/env/central_diagnostics.go
@@ -1,0 +1,6 @@
+package env
+
+var (
+	// DisableCentralDiagnostics is set to true to signal that diagnostic bundles or dumps should not contain any information about central or the environment that central runs in.
+	DisableCentralDiagnostics = RegisterBooleanSetting("ROX_DISABLE_CENTRAL_DIAGNOSTICS", false)
+)

--- a/pkg/env/central_diagnostics.go
+++ b/pkg/env/central_diagnostics.go
@@ -1,6 +1,6 @@
 package env
 
 var (
-	// DisableCentralDiagnostics is set to true to signal that diagnostic bundles or dumps should not contain any information about central or the environment that central runs in.
-	DisableCentralDiagnostics = RegisterBooleanSetting("ROX_DISABLE_CENTRAL_DIAGNOSTICS", false)
+	// EnableCentralDiagnostics is set to true to signal that diagnostic bundles or dumps should contain information about central or the environment that central runs in.
+	EnableCentralDiagnostics = RegisterBooleanSetting("ROX_ENABLE_CENTRAL_DIAGNOSTICS", true)
 )


### PR DESCRIPTION
## Description

Exclude any information that is specific to central and central's environment from diagnostic bundle and debug dump. Of course that wouldn't enough if central was part of a secured cluster, but in managed services we know that won't be the case. See the [ticket](https://issues.redhat.com/browse/ROX-11829) for way more info.

Additionally conditionally remove the RBAC required to get diagnostic info from central's service account if it's a managed service central.

Lastly, the setting is controlled via an _undocumented_ independent environment variable that anyone can set and get the same behavior (with the caveat of the secured cluster issue as mentioned previously).

I decided to use a preexisting setting in the helm chart, `._rox.env.managedServices` to force the environment variable to be set. This avoids having to coordinate with fleet manager. Still unsure about if that's the right approach.

## Checklist
- [x] Investigated and inspected CI test results
~[ ] Unit test and regression tests added~
~[ ] Evaluated and added CHANGELOG entry if required~
~[ ] Determined and documented upgrade steps~
~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

Manually tested

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
