### PR TITLE
ROX-13405: Prevent exception from groupsbatch request in auth providers integration test

### DIFF
--- a/ui/apps/platform/cypress/integration/accessControl/accessControlAuthProviders.test.js
+++ b/ui/apps/platform/cypress/integration/accessControl/accessControlAuthProviders.test.js
@@ -222,14 +222,8 @@ describe('Access Control Auth providers', () => {
         cy.intercept('PUT', '/v1/authProviders/auth-provider-1', {
             body: {},
         }).as('PutAuthProvider');
-        cy.intercept('POST', api.groups.batch, (req) => {
-            expect(req.body).to.deep.equal(
-                updateMinimumAccessRoleRequest,
-                `request: ${JSON.stringify(req.body)} expected: ${JSON.stringify(
-                    updateMinimumAccessRoleRequest
-                )}`
-            );
-            req.body = {};
+        cy.intercept('POST', api.groups.batch, {
+            body: {},
         }).as('PostGroupsBatch');
 
         const id = 'auth-provider-1';
@@ -245,7 +239,14 @@ describe('Access Control Auth providers', () => {
         cy.get(`${selectMinimumAccessRoleItem}:contains("Analyst")`).click();
 
         cy.get(selectors.form.saveButton).click();
-        cy.wait(['@PutAuthProvider', '@PostGroupsBatch']);
+        cy.wait(['@PutAuthProvider', '@PostGroupsBatch']).then(([, { request }]) => {
+            expect(request.body).to.deep.equal(
+                updateMinimumAccessRoleRequest,
+                `request: ${JSON.stringify(request.body)} expected: ${JSON.stringify(
+                    updateMinimumAccessRoleRequest
+                )}`
+            );
+        });
 
         cy.get(selectMinimumAccessRole).should('contain', 'Analyst');
     });


### PR DESCRIPTION
## Description

Warm up exercise for recommended integration tests in https://github.com/stackrox/stackrox/pull/3509#pullrequestreview-1155196412

### Problem

When logimbue-data.json file has exceptions from passing tests:
* At best, investigator has to ignore them.
* At worst, investigator might overlook a relevant exception for a failing.

### Analysis

1. See exception in logimbue-data.json file:

    ```text
        "url": "https://central-lb/main/access-control/auth-providers/auth-provider-1?action=edit"
        },
        "exception": {
        "values": [
            {
            "type": "Error",
            "value": "Request failed with status code 400",

        "breadcrumbs": {
        "values": [

            {
            "timestamp": 1667318477.409,
            "type": "http",
            "category": "xhr",
            "data": {
                "method": "GET",
                "url": "/v1/groups?authProviderId=auth-provider-1\u0026key=\u0026value=\u0026roleName=Analyst",
                "status_code": 200
            }
            },
            {
            "timestamp": 1667318477.41,
            "category": "redux-action",
            "message": "serverError/RECORD_SUCCESS"
            },
            {
            "timestamp": 1667318477.55,
            "type": "http",
            "category": "xhr",
            "data": {
                "method": "POST",
                "url": "/v1/groupsbatch",
                "status_code": 400
            }
            },
            {
            "timestamp": 1667318477.551,
            "category": "redux-action",
            "message": "auth/SET_AUTH_PROVIDER_ERROR"
            }
        ]
    ```

2. Follow `auth-providers/auth-provider-1?action=edit` clue to find 2 edit tests in cypress/integration/accessControl/accessControlAuthProviders.test.js
    * `'edits OpenID Connect with a client secret without losing the value'`
    * `'edit OpenID Connect minimum access role'`

3. Download accessControlAuthProviders.test.js.mp4 from videos folder to identify the second test. Although you can play the video online, you cannot drag along time axis unless you open download file in a player.

    <img width="1280" alt="groupsbatch-400" src="https://user-images.githubusercontent.com/11862657/199514492-6ba266ec-4202-4d0f-bcaf-081370466ed8.png">

4. Compare tests more carefully than I did in step 2 :)

    * `'edits OpenID Connect with a client secret without losing the value'`

        ```js
        cy.intercept('POST', api.groups.batch, {
            body: {},
        }).as('PostGroupsBatch');
        ```

    * `'edit OpenID Connect minimum access role'`

        ```js
        cy.intercept('POST', api.groups.batch, (req) => {
            expect(req.body).to.deep.equal(
                updateMinimumAccessRoleRequest,
                `request: ${JSON.stringify(req.body)} expected: ${JSON.stringify(
                    updateMinimumAccessRoleRequest
                )}`
            );
            req.body = {};
        }).as('PostGroupsBatch');
        ```

5. Observe that `body: {}` implies **response** body in contrast to `req.body = {}` for **request** body. That is, second intercept asserts the request, and then replaces payload with empty object for a real request (which is consistent with status code 400 for request).

### Solution

1. Use same intercept with mock response in both tests. 
2. Move request assertion to wait chain method in second test.
    * https://docs.cypress.io/api/commands/wait#Aliases
    * https://docs.cypress.io/api/commands/wait#Nesting

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration test

## Testing Performed

After the change, logimbue-data.json file does not have the exception.