### PR TITLE
Rename variable ScannerGRPCEndpoint to ScannerSlimGRPCEndpoint

### DIFF
--- a/pkg/env/sensor.go
+++ b/pkg/env/sensor.go
@@ -13,9 +13,9 @@ var (
 	// SensorEndpoint is used to communicate the sensor endpoint to other services in the same cluster.
 	SensorEndpoint = RegisterSetting("ROX_SENSOR_ENDPOINT", WithDefault("sensor.stackrox.svc:443"))
 
-	// ScannerGRPCEndpoint is used to communicate the scanner endpoint to other services in the same cluster.
+	// ScannerSlimGRPCEndpoint is used to communicate the scanner endpoint to other services in the same cluster.
 	// This is typically used for Sensor to communicate with a local Scanner-slim's gRPC server.
-	ScannerGRPCEndpoint = RegisterSetting("ROX_SCANNER_GRPC_ENDPOINT", WithDefault("scanner.stackrox.svc:8443"))
+	ScannerSlimGRPCEndpoint = RegisterSetting("ROX_SCANNER_GRPC_ENDPOINT", WithDefault("scanner.stackrox.svc:8443"))
 
 	// LocalImageScanningEnabled is used to specify if Sensor should attempt to scan images via a local Scanner.
 	LocalImageScanningEnabled = RegisterBooleanSetting("ROX_LOCAL_IMAGE_SCANNING_ENABLED", false)

--- a/sensor/common/scannerclient/singleton.go
+++ b/sensor/common/scannerclient/singleton.go
@@ -21,7 +21,7 @@ func GRPCClientSingleton() *Client {
 		}
 
 		var err error
-		scannerClient, err = dial(env.ScannerGRPCEndpoint.Setting())
+		scannerClient, err = dial(env.ScannerSlimGRPCEndpoint.Setting())
 		// If err is not nil, then there was a configuration error.
 		_ = utils.Should(err)
 	})


### PR DESCRIPTION
## Description

Rename scanner env variable to better differentiate that this variable is used by Sensor for Slim Scanners.
I was confused in PR https://github.com/stackrox/stackrox/pull/3469 because this variable is set differently from Central's endpoint configuration.

## Checklist
- [ ] 
- [ ] Investigated and inspected CI test results
- [ ] ~~Unit test and regression tests added~~
- [ ] ~~Evaluated and added CHANGELOG entry if required~~
- [ ] ~~Determined and documented upgrade steps~~
- [ ] ~~Documented user facing changes (create PR based on [openshift/openshift-docs]~~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

 - CI