### PR TITLE
ROX-11826: Disable kernel support package uploads for managed central

### DIFF
--- a/central/main.go
+++ b/central/main.go
@@ -672,16 +672,20 @@ func customRoutes() (customRoutes []routes.CustomRoute) {
 
 	if env.PostgresDatastoreEnabled.BooleanSetting() {
 		customRoutes = append(customRoutes, routes.CustomRoute{
-			Route:         "/db/backup",
-			Authorizer:    dbAuthz.DBReadAccessAuthorizer(),
-			ServerHandler: httputil.HandlerNotImplementedIfSettingDisabled(!env.ManagedCentral.BooleanSetting(), globaldbHandlers.BackupDB(nil, nil, globaldb.GetPostgres(), false)),
-			Compression:   true,
+			Route:      "/db/backup",
+			Authorizer: dbAuthz.DBReadAccessAuthorizer(),
+			ServerHandler: utils.IfThenElse[http.Handler](
+				env.ManagedCentral.BooleanSetting(), httputil.NotImplementedHandler("api is not supported in a managed central environment."),
+				globaldbHandlers.BackupDB(nil, nil, globaldb.GetPostgres(), false)),
+			Compression: true,
 		})
 		customRoutes = append(customRoutes, routes.CustomRoute{
-			Route:         "/api/extensions/backup",
-			Authorizer:    user.WithRole(role.Admin),
-			ServerHandler: httputil.HandlerNotImplementedIfSettingDisabled(!env.ManagedCentral.BooleanSetting(), globaldbHandlers.BackupDB(nil, nil, globaldb.GetPostgres(), true)),
-			Compression:   true,
+			Route:      "/api/extensions/backup",
+			Authorizer: user.WithRole(role.Admin),
+			ServerHandler: utils.IfThenElse[http.Handler](
+				env.ManagedCentral.BooleanSetting(), httputil.NotImplementedHandler("api is not supported in a managed central environment."),
+				globaldbHandlers.BackupDB(nil, nil, globaldb.GetPostgres(), true)),
+			Compression: true,
 		})
 		customRoutes = append(customRoutes, routes.CustomRoute{
 			Route:         "/api/export/csv/node/cve",
@@ -703,16 +707,20 @@ func customRoutes() (customRoutes []routes.CustomRoute) {
 		})
 	} else {
 		customRoutes = append(customRoutes, routes.CustomRoute{
-			Route:         "/db/backup",
-			Authorizer:    dbAuthz.DBReadAccessAuthorizer(),
-			ServerHandler: httputil.HandlerNotImplementedIfSettingDisabled(!env.ManagedCentral.BooleanSetting(), globaldbHandlers.BackupDB(globaldb.GetGlobalDB(), globaldb.GetRocksDB(), nil, false)),
-			Compression:   true,
+			Route:      "/db/backup",
+			Authorizer: dbAuthz.DBReadAccessAuthorizer(),
+			ServerHandler: utils.IfThenElse[http.Handler](
+				env.ManagedCentral.BooleanSetting(), httputil.NotImplementedHandler("api is not supported in a managed central environment."),
+				globaldbHandlers.BackupDB(globaldb.GetGlobalDB(), globaldb.GetRocksDB(), nil, false)),
+			Compression: true,
 		})
 		customRoutes = append(customRoutes, routes.CustomRoute{
-			Route:         "/api/extensions/backup",
-			Authorizer:    user.WithRole(role.Admin),
-			ServerHandler: httputil.HandlerNotImplementedIfSettingDisabled(!env.ManagedCentral.BooleanSetting(), globaldbHandlers.BackupDB(globaldb.GetGlobalDB(), globaldb.GetRocksDB(), nil, true)),
-			Compression:   true,
+			Route:      "/api/extensions/backup",
+			Authorizer: user.WithRole(role.Admin),
+			ServerHandler: utils.IfThenElse[http.Handler](
+				env.ManagedCentral.BooleanSetting(), httputil.NotImplementedHandler("api is not supported in a managed central environment."),
+				globaldbHandlers.BackupDB(globaldb.GetGlobalDB(), globaldb.GetRocksDB(), nil, true)),
+			Compression: true,
 		})
 	}
 

--- a/central/main.go
+++ b/central/main.go
@@ -164,6 +164,7 @@ import (
 	"github.com/stackrox/rox/pkg/grpc/authz/user"
 	"github.com/stackrox/rox/pkg/grpc/errors"
 	"github.com/stackrox/rox/pkg/grpc/routes"
+	"github.com/stackrox/rox/pkg/httputil"
 	"github.com/stackrox/rox/pkg/httputil/proxy"
 	"github.com/stackrox/rox/pkg/logging"
 	pkgMetrics "github.com/stackrox/rox/pkg/metrics"
@@ -673,13 +674,13 @@ func customRoutes() (customRoutes []routes.CustomRoute) {
 		customRoutes = append(customRoutes, routes.CustomRoute{
 			Route:         "/db/backup",
 			Authorizer:    dbAuthz.DBReadAccessAuthorizer(),
-			ServerHandler: notImplementedOnManagedServices(globaldbHandlers.BackupDB(nil, nil, globaldb.GetPostgres(), false)),
+			ServerHandler: httputil.HandlerNotImplementedIfSettingDisabled(!env.ManagedCentral.BooleanSetting(), globaldbHandlers.BackupDB(nil, nil, globaldb.GetPostgres(), false)),
 			Compression:   true,
 		})
 		customRoutes = append(customRoutes, routes.CustomRoute{
 			Route:         "/api/extensions/backup",
 			Authorizer:    user.WithRole(role.Admin),
-			ServerHandler: notImplementedOnManagedServices(globaldbHandlers.BackupDB(nil, nil, globaldb.GetPostgres(), true)),
+			ServerHandler: httputil.HandlerNotImplementedIfSettingDisabled(!env.ManagedCentral.BooleanSetting(), globaldbHandlers.BackupDB(nil, nil, globaldb.GetPostgres(), true)),
 			Compression:   true,
 		})
 		customRoutes = append(customRoutes, routes.CustomRoute{
@@ -704,13 +705,13 @@ func customRoutes() (customRoutes []routes.CustomRoute) {
 		customRoutes = append(customRoutes, routes.CustomRoute{
 			Route:         "/db/backup",
 			Authorizer:    dbAuthz.DBReadAccessAuthorizer(),
-			ServerHandler: notImplementedOnManagedServices(globaldbHandlers.BackupDB(globaldb.GetGlobalDB(), globaldb.GetRocksDB(), nil, false)),
+			ServerHandler: httputil.HandlerNotImplementedIfSettingDisabled(!env.ManagedCentral.BooleanSetting(), globaldbHandlers.BackupDB(globaldb.GetGlobalDB(), globaldb.GetRocksDB(), nil, false)),
 			Compression:   true,
 		})
 		customRoutes = append(customRoutes, routes.CustomRoute{
 			Route:         "/api/extensions/backup",
 			Authorizer:    user.WithRole(role.Admin),
-			ServerHandler: notImplementedOnManagedServices(globaldbHandlers.BackupDB(globaldb.GetGlobalDB(), globaldb.GetRocksDB(), nil, true)),
+			ServerHandler: httputil.HandlerNotImplementedIfSettingDisabled(!env.ManagedCentral.BooleanSetting(), globaldbHandlers.BackupDB(globaldb.GetGlobalDB(), globaldb.GetRocksDB(), nil, true)),
 			Compression:   true,
 		})
 	}
@@ -751,17 +752,6 @@ func customRoutes() (customRoutes []routes.CustomRoute) {
 
 	customRoutes = append(customRoutes, debugRoutes()...)
 	return
-}
-
-func notImplementedOnManagedServices(fn http.Handler) http.Handler {
-	if !env.ManagedCentral.BooleanSetting() {
-		return fn
-	}
-	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		errMsg := "api is not supported in a managed central environment."
-		log.Error(errMsg)
-		http.Error(w, errMsg, http.StatusNotImplemented)
-	})
 }
 
 func debugRoutes() []routes.CustomRoute {

--- a/central/main.go
+++ b/central/main.go
@@ -672,20 +672,16 @@ func customRoutes() (customRoutes []routes.CustomRoute) {
 
 	if env.PostgresDatastoreEnabled.BooleanSetting() {
 		customRoutes = append(customRoutes, routes.CustomRoute{
-			Route:      "/db/backup",
-			Authorizer: dbAuthz.DBReadAccessAuthorizer(),
-			ServerHandler: utils.IfThenElse[http.Handler](
-				env.ManagedCentral.BooleanSetting(), httputil.NotImplementedHandler("api is not supported in a managed central environment."),
-				globaldbHandlers.BackupDB(nil, nil, globaldb.GetPostgres(), false)),
-			Compression: true,
+			Route:         "/db/backup",
+			Authorizer:    dbAuthz.DBReadAccessAuthorizer(),
+			ServerHandler: notImplementedOnManagedServices(globaldbHandlers.BackupDB(nil, nil, globaldb.GetPostgres(), false)),
+			Compression:   true,
 		})
 		customRoutes = append(customRoutes, routes.CustomRoute{
-			Route:      "/api/extensions/backup",
-			Authorizer: user.WithRole(role.Admin),
-			ServerHandler: utils.IfThenElse[http.Handler](
-				env.ManagedCentral.BooleanSetting(), httputil.NotImplementedHandler("api is not supported in a managed central environment."),
-				globaldbHandlers.BackupDB(nil, nil, globaldb.GetPostgres(), true)),
-			Compression: true,
+			Route:         "/api/extensions/backup",
+			Authorizer:    user.WithRole(role.Admin),
+			ServerHandler: notImplementedOnManagedServices(globaldbHandlers.BackupDB(nil, nil, globaldb.GetPostgres(), true)),
+			Compression:   true,
 		})
 		customRoutes = append(customRoutes, routes.CustomRoute{
 			Route:         "/api/export/csv/node/cve",
@@ -707,20 +703,16 @@ func customRoutes() (customRoutes []routes.CustomRoute) {
 		})
 	} else {
 		customRoutes = append(customRoutes, routes.CustomRoute{
-			Route:      "/db/backup",
-			Authorizer: dbAuthz.DBReadAccessAuthorizer(),
-			ServerHandler: utils.IfThenElse[http.Handler](
-				env.ManagedCentral.BooleanSetting(), httputil.NotImplementedHandler("api is not supported in a managed central environment."),
-				globaldbHandlers.BackupDB(globaldb.GetGlobalDB(), globaldb.GetRocksDB(), nil, false)),
-			Compression: true,
+			Route:         "/db/backup",
+			Authorizer:    dbAuthz.DBReadAccessAuthorizer(),
+			ServerHandler: notImplementedOnManagedServices(globaldbHandlers.BackupDB(globaldb.GetGlobalDB(), globaldb.GetRocksDB(), nil, false)),
+			Compression:   true,
 		})
 		customRoutes = append(customRoutes, routes.CustomRoute{
-			Route:      "/api/extensions/backup",
-			Authorizer: user.WithRole(role.Admin),
-			ServerHandler: utils.IfThenElse[http.Handler](
-				env.ManagedCentral.BooleanSetting(), httputil.NotImplementedHandler("api is not supported in a managed central environment."),
-				globaldbHandlers.BackupDB(globaldb.GetGlobalDB(), globaldb.GetRocksDB(), nil, true)),
-			Compression: true,
+			Route:         "/api/extensions/backup",
+			Authorizer:    user.WithRole(role.Admin),
+			ServerHandler: notImplementedOnManagedServices(globaldbHandlers.BackupDB(globaldb.GetGlobalDB(), globaldb.GetRocksDB(), nil, true)),
+			Compression:   true,
 		})
 	}
 
@@ -760,6 +752,12 @@ func customRoutes() (customRoutes []routes.CustomRoute) {
 
 	customRoutes = append(customRoutes, debugRoutes()...)
 	return
+}
+
+func notImplementedOnManagedServices(fn http.Handler) http.Handler {
+	return utils.IfThenElse[http.Handler](
+		env.ManagedCentral.BooleanSetting(), httputil.NotImplementedHandler("api is not supported in a managed central environment."),
+		fn)
 }
 
 func debugRoutes() []routes.CustomRoute {

--- a/central/probeupload/service/service_impl.go
+++ b/central/probeupload/service/service_impl.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stackrox/rox/central/role/resources"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/pkg/auth/permissions"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/grpc/authz"
 	"github.com/stackrox/rox/pkg/grpc/authz/idcheck"
 	"github.com/stackrox/rox/pkg/grpc/authz/perrpc"
@@ -79,7 +80,7 @@ func (s *service) CustomRoutes() []routes.CustomRoute {
 		{
 			Route:         "/api/extensions/probeupload",
 			Authorizer:    user.With(permissions.Modify(resources.ProbeUpload)),
-			ServerHandler: http.HandlerFunc(s.handleProbeUpload),
+			ServerHandler: httputil.HandlerNotImplementedIfSettingDisabled(!env.DisableKernelPackageUpload.BooleanSetting(), http.HandlerFunc(s.handleProbeUpload)),
 			Compression:   false,
 		},
 		{

--- a/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml
+++ b/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml
@@ -109,8 +109,8 @@ spec:
           value: "true"
         - name: ROX_ENABLE_CENTRAL_DIAGNOSTICS
           value: "false"
-        - name: ROX_DISABLE_KERNEL_PACKAGE_UPLOAD
-          value: "true"
+        - name: ROX_ENABLE_KERNEL_PACKAGE_UPLOAD
+          value: "false"
         {{- end }}
         {{- if ._rox.central.db.enabled }}
         - name: ROX_POSTGRES_DATASTORE

--- a/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml
+++ b/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml
@@ -109,6 +109,8 @@ spec:
           value: "true"
         - name: ROX_ENABLE_CENTRAL_DIAGNOSTICS
           value: "false"
+        - name: ROX_DISABLE_KERNEL_PACKAGE_UPLOAD
+          value: "true"
         {{- end }}
         {{- if ._rox.central.db.enabled }}
         - name: ROX_POSTGRES_DATASTORE

--- a/pkg/env/kernel_package_upload.go
+++ b/pkg/env/kernel_package_upload.go
@@ -1,0 +1,6 @@
+package env
+
+var (
+	// DisableKernelPackageUpload is set to true to signal that kernel support package uploads should be disabled.
+	DisableKernelPackageUpload = RegisterBooleanSetting("ROX_DISABLE_KERNEL_PACKAGE_UPLOAD", false)
+)

--- a/pkg/env/kernel_package_upload.go
+++ b/pkg/env/kernel_package_upload.go
@@ -1,6 +1,6 @@
 package env
 
 var (
-	// DisableKernelPackageUpload is set to true to signal that kernel support package uploads should be disabled.
-	DisableKernelPackageUpload = RegisterBooleanSetting("ROX_DISABLE_KERNEL_PACKAGE_UPLOAD", false)
+	// EnableKernelPackageUpload is set to true to signal that kernel support package uploads should be supported.
+	EnableKernelPackageUpload = RegisterBooleanSetting("ROX_ENABLE_KERNEL_PACKAGE_UPLOAD", true)
 )

--- a/pkg/httputil/handler.go
+++ b/pkg/httputil/handler.go
@@ -16,14 +16,9 @@ func WrapHandlerFunc(handlerFn func(req *http.Request) error) http.HandlerFunc {
 	})
 }
 
-// HandlerNotImplementedIfSettingDisabled takes a handler func and returns a handler func that will error out if
-// specified boolean is disabled, otherwise it will return the given handler func
-func HandlerNotImplementedIfSettingDisabled(enabled bool, fn http.Handler) http.Handler {
-	if enabled {
-		return fn
-	}
+// NotImplementedHandler returns an HTTP Handler func that returns 501 Not Implemented with a custom error message.
+func NotImplementedHandler(errMsg string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		errMsg := "api is disabled due to central setting"
 		log.Error(errMsg)
 		http.Error(w, errMsg, http.StatusNotImplemented)
 	})

--- a/pkg/httputil/handler.go
+++ b/pkg/httputil/handler.go
@@ -1,6 +1,8 @@
 package httputil
 
-import "net/http"
+import (
+	"net/http"
+)
 
 // WrapHandlerFunc wraps a function returning an error into an HTTP handler func that returns a 200 OK with empty
 // contents upon success, and sends an error formatted according to `WriteError` to the client otherwise.
@@ -11,5 +13,18 @@ func WrapHandlerFunc(handlerFn func(req *http.Request) error) http.HandlerFunc {
 			WriteError(w, err)
 			return
 		}
+	})
+}
+
+// HandlerNotImplementedIfSettingDisabled takes a handler func and returns a handler func that will error out if
+// specified boolean is disabled, otherwise it will return the given handler func
+func HandlerNotImplementedIfSettingDisabled(enabled bool, fn http.Handler) http.Handler {
+	if enabled {
+		return fn
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		errMsg := "api is disabled due to central setting"
+		log.Error(errMsg)
+		http.Error(w, errMsg, http.StatusNotImplemented)
 	})
 }

--- a/pkg/utils/if_then_else.go
+++ b/pkg/utils/if_then_else.go
@@ -1,0 +1,9 @@
+package utils
+
+// IfThenElse is a ternary operator function that will return `a` if `cond` is true, otherwise it will return `b`
+func IfThenElse[T any](cond bool, a, b T) T {
+	if cond {
+		return a
+	}
+	return b
+}


### PR DESCRIPTION
## Description

This is only used for those running in offline mode and thus is unnecessary in managed central. Uses a new env var, `ROX_DISABLE_KERNEL_PACKAGE_UPLOAD`, which is enabled by default for managed central (via helm).

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
~[ ] Evaluated and added CHANGELOG entry if required~
~[ ] Determined and documented upgrade steps~
~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
