### PR TITLE
[ROX-12923] Add retries to postgres Walk op

### DIFF
--- a/central/cluster/datastore/datastore_impl.go
+++ b/central/cluster/datastore/datastore_impl.go
@@ -37,7 +37,6 @@ import (
 	clusterValidation "github.com/stackrox/rox/pkg/cluster"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/env"
-	"github.com/stackrox/rox/pkg/errorhelpers"
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/images/defaults"
 	"github.com/stackrox/rox/pkg/postgres/pgutils"
@@ -719,16 +718,22 @@ func (ds *datastoreImpl) getAlerts(ctx context.Context, deploymentID string) ([]
 }
 
 func (ds *datastoreImpl) markAlertsStale(ctx context.Context, alerts []*storage.Alert) error {
-	errorList := errorhelpers.NewErrorList("unable to mark some alerts stale")
-	for _, alert := range alerts {
-		errorList.AddError(ds.alertDataStore.MarkAlertStale(ctx, alert.GetId()))
-		if errorList.ToError() == nil {
-			// run notifier for all the resolved alerts
-			alert.State = storage.ViolationState_RESOLVED
-			ds.notifier.ProcessAlert(ctx, alert)
-		}
+	if len(alerts) == 0 {
+		return nil
 	}
-	return errorList.ToError()
+
+	ids := make([]string, 0, len(alerts))
+	for _, alert := range alerts {
+		ids = append(ids, alert.GetId())
+	}
+	resolvedAlerts, err := ds.alertDataStore.MarkAlertStaleBatch(ctx, ids...)
+	if err != nil {
+		return err
+	}
+	for _, resolvedAlert := range resolvedAlerts {
+		ds.notifier.ProcessAlert(ctx, resolvedAlert)
+	}
+	return nil
 }
 
 func (ds *datastoreImpl) cleanUpNodeStore(ctx context.Context) {

--- a/central/cluster/datastore/datastore_impl.go
+++ b/central/cluster/datastore/datastore_impl.go
@@ -37,8 +37,10 @@ import (
 	clusterValidation "github.com/stackrox/rox/pkg/cluster"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/env"
+	"github.com/stackrox/rox/pkg/errorhelpers"
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/images/defaults"
+	"github.com/stackrox/rox/pkg/postgres/pgutils"
 	"github.com/stackrox/rox/pkg/protoconv"
 	"github.com/stackrox/rox/pkg/sac"
 	pkgSearch "github.com/stackrox/rox/pkg/search"
@@ -156,21 +158,20 @@ func (ds *datastoreImpl) UpdateClusterStatus(ctx context.Context, id string, sta
 }
 
 func (ds *datastoreImpl) buildIndex(ctx context.Context) error {
-	var clusters []*storage.Cluster
-	err := ds.clusterStorage.Walk(ctx, func(cluster *storage.Cluster) error {
-		clusters = append(clusters, cluster)
-		return nil
-	})
+	clusters, err := ds.collectClusters(ctx)
 	if err != nil {
 		return err
 	}
 
 	clusterHealthStatuses := make(map[string]*storage.ClusterHealthStatus)
-	err = ds.clusterHealthStorage.Walk(ctx, func(healthInfo *storage.ClusterHealthStatus) error {
-		clusterHealthStatuses[healthInfo.Id] = healthInfo
-		return nil
-	})
-	if err != nil {
+	walkFn := func() error {
+		clusterHealthStatuses = make(map[string]*storage.ClusterHealthStatus)
+		return ds.clusterHealthStorage.Walk(ctx, func(healthInfo *storage.ClusterHealthStatus) error {
+			clusterHealthStatuses[healthInfo.Id] = healthInfo
+			return nil
+		})
+	}
+	if err := pgutils.RetryIfPostgres(walkFn); err != nil {
 		return err
 	}
 
@@ -188,14 +189,10 @@ func (ds *datastoreImpl) registerClusterForNetworkGraphExtSrcs() error {
 			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
 			sac.ResourceScopeKeys(resources.Node, resources.NetworkGraph)))
 
-	var clusters []*storage.Cluster
-	if err := ds.clusterStorage.Walk(ctx, func(cluster *storage.Cluster) error {
-		clusters = append(clusters, cluster)
-		return nil
-	}); err != nil {
+	clusters, err := ds.collectClusters(ctx)
+	if err != nil {
 		return err
 	}
-
 	for _, cluster := range clusters {
 		ds.netEntityDataStore.RegisterCluster(ctx, cluster.GetId())
 	}
@@ -245,11 +242,7 @@ func (ds *datastoreImpl) GetClusters(ctx context.Context) ([]*storage.Cluster, e
 	if err != nil {
 		return nil, err
 	} else if ok {
-		var clusters []*storage.Cluster
-		err := ds.clusterStorage.Walk(ctx, func(cluster *storage.Cluster) error {
-			clusters = append(clusters, cluster)
-			return nil
-		})
+		clusters, err := ds.collectClusters(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -726,22 +719,16 @@ func (ds *datastoreImpl) getAlerts(ctx context.Context, deploymentID string) ([]
 }
 
 func (ds *datastoreImpl) markAlertsStale(ctx context.Context, alerts []*storage.Alert) error {
-	if len(alerts) == 0 {
-		return nil
-	}
-
-	ids := make([]string, 0, len(alerts))
+	errorList := errorhelpers.NewErrorList("unable to mark some alerts stale")
 	for _, alert := range alerts {
-		ids = append(ids, alert.GetId())
+		errorList.AddError(ds.alertDataStore.MarkAlertStale(ctx, alert.GetId()))
+		if errorList.ToError() == nil {
+			// run notifier for all the resolved alerts
+			alert.State = storage.ViolationState_RESOLVED
+			ds.notifier.ProcessAlert(ctx, alert)
+		}
 	}
-	resolvedAlerts, err := ds.alertDataStore.MarkAlertStaleBatch(ctx, ids...)
-	if err != nil {
-		return err
-	}
-	for _, resolvedAlert := range resolvedAlerts {
-		ds.notifier.ProcessAlert(ctx, resolvedAlert)
-	}
-	return nil
+	return errorList.ToError()
 }
 
 func (ds *datastoreImpl) cleanUpNodeStore(ctx context.Context) {
@@ -1046,4 +1033,19 @@ func configureFromHelmConfig(cluster *storage.Cluster, helmConfig *storage.Compl
 	cluster.AdmissionControllerEvents = staticConfig.GetAdmissionControllerEvents()
 	cluster.TolerationsConfig = staticConfig.GetTolerationsConfig().Clone()
 	cluster.SlimCollector = staticConfig.GetSlimCollector()
+}
+
+func (ds *datastoreImpl) collectClusters(ctx context.Context) ([]*storage.Cluster, error) {
+	var clusters []*storage.Cluster
+	walkFn := func() error {
+		clusters = clusters[:0]
+		return ds.clusterStorage.Walk(ctx, func(cluster *storage.Cluster) error {
+			clusters = append(clusters, cluster)
+			return nil
+		})
+	}
+	if err := pgutils.RetryIfPostgres(walkFn); err != nil {
+		return nil, err
+	}
+	return clusters, nil
 }

--- a/central/complianceoperator/checkresults/datastore/datastore.go
+++ b/central/complianceoperator/checkresults/datastore/datastore.go
@@ -36,6 +36,7 @@ func (d *datastoreImpl) Walk(ctx context.Context, fn func(result *storage.Compli
 	} else if !ok {
 		return errors.Wrap(sac.ErrResourceAccessDenied, "compliance operator check results read")
 	}
+	// Retry in the caller
 	return d.store.Walk(ctx, fn)
 }
 

--- a/central/detection/lifecycle/manager_impl.go
+++ b/central/detection/lifecycle/manager_impl.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/expiringcache"
 	"github.com/stackrox/rox/pkg/policies"
+	"github.com/stackrox/rox/pkg/postgres/pgutils"
 	"github.com/stackrox/rox/pkg/process/filter"
 	processBaselinePkg "github.com/stackrox/rox/pkg/processbaseline"
 	"github.com/stackrox/rox/pkg/protoutils"
@@ -93,28 +94,29 @@ func (m *managerImpl) copyAndResetIndicatorQueue() map[string]*storage.ProcessIn
 
 func (m *managerImpl) buildIndicatorFilter() {
 	ctx := sac.WithAllAccess(context.Background())
-	var processesToRemove []string
-
 	deploymentIDs, err := m.deploymentDataStore.GetDeploymentIDs(ctx)
 	if err != nil {
 		utils.Should(errors.Wrap(err, "error getting deployment IDs"))
 		return
 	}
 
-	deploymentIDSet := set.NewStringSet(deploymentIDs...)
-
-	err = m.processesDataStore.WalkAll(ctx, func(pi *storage.ProcessIndicator) error {
-		if !deploymentIDSet.Contains(pi.GetDeploymentId()) {
-			// Don't remove as these processes will be removed by GC
-			// but don't add to the filter
+	var processesToRemove []string
+	walkFn := func() error {
+		deploymentIDSet := set.NewStringSet(deploymentIDs...)
+		processesToRemove = processesToRemove[:0]
+		return m.processesDataStore.WalkAll(ctx, func(pi *storage.ProcessIndicator) error {
+			if !deploymentIDSet.Contains(pi.GetDeploymentId()) {
+				// Don't remove as these processes will be removed by GC
+				// but don't add to the filter
+				return nil
+			}
+			if !m.processFilter.Add(pi) {
+				processesToRemove = append(processesToRemove, pi.GetId())
+			}
 			return nil
-		}
-		if !m.processFilter.Add(pi) {
-			processesToRemove = append(processesToRemove, pi.GetId())
-		}
-		return nil
-	})
-	if err != nil {
+		})
+	}
+	if err := pgutils.RetryIfPostgres(walkFn); err != nil {
 		utils.Should(errors.Wrap(err, "error building indicator filter"))
 	}
 

--- a/central/networkbaseline/datastore/datastore_impl.go
+++ b/central/networkbaseline/datastore/datastore_impl.go
@@ -179,7 +179,6 @@ func (ds *dataStoreImpl) Walk(ctx context.Context, f func(baseline *storage.Netw
 	} else if !ok {
 		return nil
 	}
-
+	// Postgres retry in caller.
 	return ds.storage.Walk(ctx, f)
-
 }

--- a/central/pod/datastore/datastore_impl.go
+++ b/central/pod/datastore/datastore_impl.go
@@ -303,6 +303,6 @@ func (ds *datastoreImpl) WalkAll(ctx context.Context, fn func(pod *storage.Pod) 
 	} else if !ok {
 		return sac.ErrResourceAccessDenied
 	}
-
+	// Postgres retry in caller.
 	return ds.podStore.Walk(ctx, fn)
 }

--- a/central/policycategory/datastore/datastore_impl.go
+++ b/central/policycategory/datastore/datastore_impl.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/logging"
+	"github.com/stackrox/rox/pkg/postgres/pgutils"
 	"github.com/stackrox/rox/pkg/sac"
 	searchPkg "github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/sync"
@@ -44,11 +45,14 @@ func (ds *datastoreImpl) buildIndex() error {
 		return nil
 	}
 	var categories []*storage.PolicyCategory
-	err := ds.storage.Walk(policyCategoryCtx, func(category *storage.PolicyCategory) error {
-		categories = append(categories, category)
-		return nil
-	})
-	if err != nil {
+	walkFn := func() error {
+		categories = categories[:0]
+		return ds.storage.Walk(policyCategoryCtx, func(category *storage.PolicyCategory) error {
+			categories = append(categories, category)
+			return nil
+		})
+	}
+	if err := pgutils.RetryIfPostgres(walkFn); err != nil {
 		return err
 	}
 	return ds.indexer.AddPolicyCategories(categories)
@@ -107,14 +111,17 @@ func (ds *datastoreImpl) GetAllPolicyCategories(ctx context.Context) ([]*storage
 	}
 
 	var categories []*storage.PolicyCategory
-	err := ds.storage.Walk(ctx, func(category *storage.PolicyCategory) error {
-		categories = append(categories, category)
-		return nil
-	})
-	if err != nil {
+	walkFn := func() error {
+		categories = categories[:0]
+		return ds.storage.Walk(ctx, func(category *storage.PolicyCategory) error {
+			categories = append(categories, category)
+			return nil
+		})
+	}
+	if err := pgutils.RetryIfPostgres(walkFn); err != nil {
 		return nil, err
 	}
-	return categories, err
+	return categories, nil
 }
 
 // AddPolicyCategory inserts a policy category into the storage and the indexer

--- a/central/processbaseline/datastore/datastore_impl.go
+++ b/central/processbaseline/datastore/datastore_impl.go
@@ -436,6 +436,7 @@ func (ds *datastoreImpl) WalkAll(ctx context.Context, fn func(baseline *storage.
 	} else if !ok {
 		return sac.ErrResourceAccessDenied
 	}
+	// Postgres retries in the caller.
 	return ds.storage.Walk(ctx, fn)
 }
 

--- a/central/pruning/pruning.go
+++ b/central/pruning/pruning.go
@@ -30,6 +30,7 @@ import (
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/logging"
+	"github.com/stackrox/rox/pkg/postgres/pgutils"
 	"github.com/stackrox/rox/pkg/protoutils"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
@@ -191,14 +192,18 @@ func (g *garbageCollectorImpl) removeExpiredVulnRequests() {
 func (g *garbageCollectorImpl) removeOrphanedPods(clusters set.FrozenStringSet) {
 	var podIDsToRemove []string
 	staleClusterIDsFound := set.NewStringSet()
-	err := g.pods.WalkAll(pruningCtx, func(pod *storage.Pod) error {
-		if !clusters.Contains(pod.GetClusterId()) {
-			podIDsToRemove = append(podIDsToRemove, pod.GetId())
-			staleClusterIDsFound.Add(pod.GetClusterId())
-		}
-		return nil
-	})
-	if err != nil {
+	walkFn := func() error {
+		podIDsToRemove = podIDsToRemove[:0]
+		staleClusterIDsFound.Clear()
+		return g.pods.WalkAll(pruningCtx, func(pod *storage.Pod) error {
+			if !clusters.Contains(pod.GetClusterId()) {
+				podIDsToRemove = append(podIDsToRemove, pod.GetId())
+				staleClusterIDsFound.Add(pod.GetClusterId())
+			}
+			return nil
+		})
+	}
+	if err := pgutils.RetryIfPostgres(walkFn); err != nil {
 		log.Errorf("Error walking pods to find orphaned pods: %v", err)
 		return
 	}
@@ -319,20 +324,23 @@ func clusterIDsToNegationQuery(clusterIDSet set.FrozenStringSet) *v1.Query {
 func (g *garbageCollectorImpl) removeOrphanedProcesses(deploymentIDs, podIDs set.FrozenStringSet) {
 	var processesToPrune []string
 	now := types.TimestampNow()
-	err := g.processes.WalkAll(pruningCtx, func(pi *storage.ProcessIndicator) error {
-		if pi.GetPodUid() != "" && podIDs.Contains(pi.GetPodUid()) {
+	walkFn := func() error {
+		processesToPrune = processesToPrune[:0]
+		return g.processes.WalkAll(pruningCtx, func(pi *storage.ProcessIndicator) error {
+			if pi.GetPodUid() != "" && podIDs.Contains(pi.GetPodUid()) {
+				return nil
+			}
+			if pi.GetPodUid() == "" && deploymentIDs.Contains(pi.GetDeploymentId()) {
+				return nil
+			}
+			if protoutils.Sub(now, pi.GetSignal().GetTime()) < orphanWindow {
+				return nil
+			}
+			processesToPrune = append(processesToPrune, pi.GetId())
 			return nil
-		}
-		if pi.GetPodUid() == "" && deploymentIDs.Contains(pi.GetDeploymentId()) {
-			return nil
-		}
-		if protoutils.Sub(now, pi.GetSignal().GetTime()) < orphanWindow {
-			return nil
-		}
-		processesToPrune = append(processesToPrune, pi.GetId())
-		return nil
-	})
-	if err != nil {
+		})
+	}
+	if err := pgutils.RetryIfPostgres(walkFn); err != nil {
 		log.Error(errors.Wrap(err, "unable to walk processes and mark for pruning"))
 		return
 	}
@@ -403,25 +411,28 @@ func (g *garbageCollectorImpl) removeOrphanedProcessBaselines(deployments set.Fr
 func (g *garbageCollectorImpl) markOrphanedAlertsAsResolved(deployments set.FrozenStringSet) {
 	var alertsToResolve []string
 	now := types.TimestampNow()
-	err := g.alerts.WalkAll(pruningCtx, func(alert *storage.ListAlert) error {
-		// We should only remove orphaned deploy time alerts as they are not cleaned up by retention policies
-		// This will only happen when there is data inconsistency
-		if alert.GetLifecycleStage() != storage.LifecycleStage_DEPLOY {
+	walkFn := func() error {
+		alertsToResolve = alertsToResolve[:0]
+		return g.alerts.WalkAll(pruningCtx, func(alert *storage.ListAlert) error {
+			// We should only remove orphaned deploy time alerts as they are not cleaned up by retention policies
+			// This will only happen when there is data inconsistency
+			if alert.GetLifecycleStage() != storage.LifecycleStage_DEPLOY {
+				return nil
+			}
+			if alert.GetState() != storage.ViolationState_ACTIVE {
+				return nil
+			}
+			if deployments.Contains(alert.GetDeployment().GetId()) {
+				return nil
+			}
+			if protoutils.Sub(now, alert.GetTime()) < orphanWindow {
+				return nil
+			}
+			alertsToResolve = append(alertsToResolve, alert.GetId())
 			return nil
-		}
-		if alert.GetState() != storage.ViolationState_ACTIVE {
-			return nil
-		}
-		if deployments.Contains(alert.GetDeployment().GetId()) {
-			return nil
-		}
-		if protoutils.Sub(now, alert.GetTime()) < orphanWindow {
-			return nil
-		}
-		alertsToResolve = append(alertsToResolve, alert.GetId())
-		return nil
-	})
-	if err != nil {
+		})
+	}
+	if err := pgutils.RetryIfPostgres(walkFn); err != nil {
 		log.Error(errors.Wrap(err, "unable to walk alerts and mark for pruning"))
 		return
 	}

--- a/central/rbac/k8srole/datastore/datastore_impl.go
+++ b/central/rbac/k8srole/datastore/datastore_impl.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/debug"
 	"github.com/stackrox/rox/pkg/env"
+	"github.com/stackrox/rox/pkg/postgres/pgutils"
 	"github.com/stackrox/rox/pkg/sac"
 	searchPkg "github.com/stackrox/rox/pkg/search"
 )
@@ -39,18 +40,21 @@ func (d *datastoreImpl) buildIndex(ctx context.Context) error {
 
 	var roles []*storage.K8SRole
 	var count int
-	err := d.storage.Walk(ctx, func(role *storage.K8SRole) error {
-		roles = append(roles, role)
-		if len(roles) == batchSize {
-			if err := d.indexer.AddK8SRoles(roles); err != nil {
-				return err
+	// Postgres op retries not required. This is related to bleve indexing which is not used in postgres.
+	walkFn := func() error {
+		return d.storage.Walk(ctx, func(role *storage.K8SRole) error {
+			roles = append(roles, role)
+			if len(roles) == batchSize {
+				if err := d.indexer.AddK8SRoles(roles); err != nil {
+					return err
+				}
+				roles = roles[:0]
 			}
-			roles = roles[:0]
-		}
-		count++
-		return nil
-	})
-	if err != nil {
+			count++
+			return nil
+		})
+	}
+	if err := pgutils.RetryIfPostgres(walkFn); err != nil {
 		return err
 	}
 	if err := d.indexer.AddK8SRoles(roles); err != nil {

--- a/central/sensor/service/pipeline/complianceoperatorresults/pipeline.go
+++ b/central/sensor/service/pipeline/complianceoperatorresults/pipeline.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/metrics"
+	"github.com/stackrox/rox/pkg/postgres/pgutils"
 	"github.com/stackrox/rox/pkg/set"
 )
 
@@ -32,13 +33,16 @@ type pipelineImpl struct {
 
 func (s *pipelineImpl) Reconcile(ctx context.Context, clusterID string, storeMap *reconciliation.StoreMap) error {
 	existingIDs := set.NewStringSet()
-	err := s.datastore.Walk(ctx, func(check *storage.ComplianceOperatorCheckResult) error {
-		if check.GetClusterId() == clusterID {
-			existingIDs.Add(check.GetId())
-		}
-		return nil
-	})
-	if err != nil {
+	walkFn := func() error {
+		existingIDs.Clear()
+		return s.datastore.Walk(ctx, func(check *storage.ComplianceOperatorCheckResult) error {
+			if check.GetClusterId() == clusterID {
+				existingIDs.Add(check.GetId())
+			}
+			return nil
+		})
+	}
+	if err := pgutils.RetryIfPostgres(walkFn); err != nil {
 		return err
 	}
 

--- a/central/serviceaccount/datastore/datastore_impl.go
+++ b/central/serviceaccount/datastore/datastore_impl.go
@@ -35,6 +35,7 @@ func (d *datastoreImpl) buildIndex(ctx context.Context) error {
 	log.Info("[STARTUP] Indexing service accounts")
 	var serviceAccounts []*storage.ServiceAccount
 	var count int
+	// Postgres op retries not required. This is related to bleve indexing which is not used in postgres.
 	err := d.storage.Walk(ctx, func(sa *storage.ServiceAccount) error {
 		serviceAccounts = append(serviceAccounts, sa)
 		if len(serviceAccounts) == batchSize {

--- a/pkg/postgres/pgutils/retry.go
+++ b/pkg/postgres/pgutils/retry.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v4"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/timeutil"
 )
 
@@ -34,6 +35,15 @@ func Retry2[T any](fn func() (T, error)) (T, error) {
 	}
 	val, _, err := Retry3(fnWithReturn)
 	return val, err
+}
+
+// RetryIfPostgres is same as Retry except that it retries iff postgres is enabled.
+// that fails with transient errors
+func RetryIfPostgres(fn func() error) error {
+	if env.PostgresDatastoreEnabled.BooleanSetting() {
+		return Retry(fn)
+	}
+	return fn()
 }
 
 // Retry3 is used to specify how long to retry to successfully run a query with 3 return values


### PR DESCRIPTION
## Description

Add retries to `Walk` ops for Postgres. Unlike autogenerated retries for other postgres ops, this cannot be autogenerated because we have to ensure a consistent state between each retry for the closure. 

This PR covers all usages of Walks, except compliance which will come in a follow-up PR.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- ~Evaluated and added CHANGELOG entry if required~
- ~Determined and documented upgrade steps~
- ~Documented user facing changes~

If any of these don't apply, please comment below.

## Testing Performed
CI