### PR TITLE
Don't use protobuf values (instead of pointers) in function and method signatures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -294,10 +294,10 @@ include make/protogen.mk
 .PHONY: go-easyjson-srcs
 go-easyjson-srcs: $(EASYJSON_BIN)
 	@echo "+ $@"
-	$(SILENT)easyjson -pkg -ptr_receivers pkg/docker/types/types.go
-	$(SILENT)easyjson -pkg -ptr_receivers pkg/docker/types/container.go
-	$(SILENT)easyjson -pkg -ptr_receivers pkg/docker/types/image.go
-	$(SILENT)easyjson -pkg -ptr_receivers pkg/compliance/compress/compress.go
+	$(SILENT)easyjson -pkg pkg/docker/types/types.go
+	$(SILENT)easyjson -pkg pkg/docker/types/container.go
+	$(SILENT)easyjson -pkg pkg/docker/types/image.go
+	$(SILENT)easyjson -pkg pkg/compliance/compress/compress.go
 
 .PHONY: clean-easyjson-srcs
 clean-easyjson-srcs:

--- a/Makefile
+++ b/Makefile
@@ -294,10 +294,10 @@ include make/protogen.mk
 .PHONY: go-easyjson-srcs
 go-easyjson-srcs: $(EASYJSON_BIN)
 	@echo "+ $@"
-	$(SILENT)easyjson -pkg pkg/docker/types/types.go
-	$(SILENT)easyjson -pkg pkg/docker/types/container.go
-	$(SILENT)easyjson -pkg pkg/docker/types/image.go
-	$(SILENT)easyjson -pkg pkg/compliance/compress/compress.go
+	$(SILENT)easyjson -pkg -ptr_receivers pkg/docker/types/types.go
+	$(SILENT)easyjson -pkg -ptr_receivers pkg/docker/types/container.go
+	$(SILENT)easyjson -pkg -ptr_receivers pkg/docker/types/image.go
+	$(SILENT)easyjson -pkg -ptr_receivers pkg/compliance/compress/compress.go
 
 .PHONY: clean-easyjson-srcs
 clean-easyjson-srcs:

--- a/central/compliance/datastore/internal/store/strings.go
+++ b/central/compliance/datastore/internal/store/strings.go
@@ -7,13 +7,13 @@ import (
 )
 
 type stringCollector struct {
-	stringsProto  storage.ComplianceStrings
+	stringsProto  *storage.ComplianceStrings
 	stringIndices map[string]int
 }
 
 func newStringCollector(runID string) *stringCollector {
 	return &stringCollector{
-		stringsProto: storage.ComplianceStrings{
+		stringsProto: &storage.ComplianceStrings{
 			Id: runID,
 		},
 		stringIndices: make(map[string]int),
@@ -42,7 +42,7 @@ func ExternalizeStrings(resultsProto *storage.ComplianceRunResults) *storage.Com
 	for _, nodeResults := range resultsProto.GetNodeResults() {
 		externalizeStringsForEntity(nodeResults, sc)
 	}
-	return &sc.stringsProto
+	return sc.stringsProto
 }
 
 func externalizeStringsForEntity(entityResults *storage.ComplianceRunResults_EntityResults, strings *stringCollector) {

--- a/central/networkgraph/flow/datastore/flow.go
+++ b/central/networkgraph/flow/datastore/flow.go
@@ -12,8 +12,8 @@ import (
 //
 //go:generate mockgen-wrapper
 type FlowDataStore interface {
-	GetAllFlows(ctx context.Context, since *types.Timestamp) ([]*storage.NetworkFlow, types.Timestamp, error)
-	GetMatchingFlows(ctx context.Context, pred func(*storage.NetworkFlowProperties) bool, since *types.Timestamp) ([]*storage.NetworkFlow, types.Timestamp, error)
+	GetAllFlows(ctx context.Context, since *types.Timestamp) ([]*storage.NetworkFlow, *types.Timestamp, error)
+	GetMatchingFlows(ctx context.Context, pred func(*storage.NetworkFlowProperties) bool, since *types.Timestamp) ([]*storage.NetworkFlow, *types.Timestamp, error)
 	// GetFlowsForDeployment returns all flows referencing a specific deployment id
 	GetFlowsForDeployment(ctx context.Context, deploymentID string, adjustForGraph bool) ([]*storage.NetworkFlow, error)
 

--- a/central/networkgraph/flow/datastore/flow_impl.go
+++ b/central/networkgraph/flow/datastore/flow_impl.go
@@ -29,28 +29,28 @@ type flowDataStoreImpl struct {
 	deletedDeploymentsCache   expiringcache.Cache
 }
 
-func (fds *flowDataStoreImpl) GetAllFlows(ctx context.Context, since *types.Timestamp) ([]*storage.NetworkFlow, types.Timestamp, error) {
+func (fds *flowDataStoreImpl) GetAllFlows(ctx context.Context, since *types.Timestamp) ([]*storage.NetworkFlow, *types.Timestamp, error) {
 	flows, ts, err := fds.storage.GetAllFlows(ctx, since)
 	if err != nil {
-		return nil, types.Timestamp{}, nil
+		return nil, nil, nil
 	}
 
 	flows, err = fds.adjustFlowsForGraphConfig(ctx, flows)
 	if err != nil {
-		return nil, types.Timestamp{}, err
+		return nil, nil, err
 	}
 	return flows, ts, nil
 }
 
-func (fds *flowDataStoreImpl) GetMatchingFlows(ctx context.Context, pred func(*storage.NetworkFlowProperties) bool, since *types.Timestamp) ([]*storage.NetworkFlow, types.Timestamp, error) {
+func (fds *flowDataStoreImpl) GetMatchingFlows(ctx context.Context, pred func(*storage.NetworkFlowProperties) bool, since *types.Timestamp) ([]*storage.NetworkFlow, *types.Timestamp, error) {
 	flows, ts, err := fds.storage.GetMatchingFlows(ctx, pred, since)
 	if err != nil {
-		return nil, types.Timestamp{}, nil
+		return nil, nil, nil
 	}
 
 	flows, err = fds.adjustFlowsForGraphConfig(ctx, flows)
 	if err != nil {
-		return nil, types.Timestamp{}, err
+		return nil, nil, err
 	}
 	return flows, ts, nil
 }

--- a/central/networkgraph/flow/datastore/internal/store/flow.go
+++ b/central/networkgraph/flow/datastore/internal/store/flow.go
@@ -12,8 +12,8 @@ import (
 //
 //go:generate mockgen-wrapper
 type FlowStore interface {
-	GetAllFlows(ctx context.Context, since *types.Timestamp) ([]*storage.NetworkFlow, types.Timestamp, error)
-	GetMatchingFlows(ctx context.Context, pred func(*storage.NetworkFlowProperties) bool, since *types.Timestamp) ([]*storage.NetworkFlow, types.Timestamp, error)
+	GetAllFlows(ctx context.Context, since *types.Timestamp) ([]*storage.NetworkFlow, *types.Timestamp, error)
+	GetMatchingFlows(ctx context.Context, pred func(*storage.NetworkFlowProperties) bool, since *types.Timestamp) ([]*storage.NetworkFlow, *types.Timestamp, error)
 	// GetFlowsForDeployment returns all flows referencing a specific deployment id
 	GetFlowsForDeployment(ctx context.Context, deploymentID string) ([]*storage.NetworkFlow, error)
 

--- a/central/networkgraph/flow/datastore/internal/store/mocks/flow.go
+++ b/central/networkgraph/flow/datastore/internal/store/mocks/flow.go
@@ -38,11 +38,11 @@ func (m *MockFlowStore) EXPECT() *MockFlowStoreMockRecorder {
 }
 
 // GetAllFlows mocks base method.
-func (m *MockFlowStore) GetAllFlows(ctx context.Context, since *types.Timestamp) ([]*storage.NetworkFlow, types.Timestamp, error) {
+func (m *MockFlowStore) GetAllFlows(ctx context.Context, since *types.Timestamp) ([]*storage.NetworkFlow, *types.Timestamp, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAllFlows", ctx, since)
 	ret0, _ := ret[0].([]*storage.NetworkFlow)
-	ret1, _ := ret[1].(types.Timestamp)
+	ret1, _ := ret[1].(*types.Timestamp)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }
@@ -69,11 +69,11 @@ func (mr *MockFlowStoreMockRecorder) GetFlowsForDeployment(ctx, deploymentID int
 }
 
 // GetMatchingFlows mocks base method.
-func (m *MockFlowStore) GetMatchingFlows(ctx context.Context, pred func(*storage.NetworkFlowProperties) bool, since *types.Timestamp) ([]*storage.NetworkFlow, types.Timestamp, error) {
+func (m *MockFlowStore) GetMatchingFlows(ctx context.Context, pred func(*storage.NetworkFlowProperties) bool, since *types.Timestamp) ([]*storage.NetworkFlow, *types.Timestamp, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMatchingFlows", ctx, pred, since)
 	ret0, _ := ret[0].([]*storage.NetworkFlow)
-	ret1, _ := ret[1].(types.Timestamp)
+	ret1, _ := ret[1].(*types.Timestamp)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }

--- a/central/networkgraph/flow/datastore/internal/store/postgres/store.go
+++ b/central/networkgraph/flow/datastore/internal/store/postgres/store.go
@@ -101,8 +101,8 @@ var (
 // FlowStore stores all of the flows for a single cluster.
 type FlowStore interface {
 	// GetAllFlows The methods below are the ones that match the flow interface which is what we probably have to match.
-	GetAllFlows(ctx context.Context, since *types.Timestamp) ([]*storage.NetworkFlow, types.Timestamp, error)
-	GetMatchingFlows(ctx context.Context, pred func(*storage.NetworkFlowProperties) bool, since *types.Timestamp) ([]*storage.NetworkFlow, types.Timestamp, error)
+	GetAllFlows(ctx context.Context, since *types.Timestamp) ([]*storage.NetworkFlow, *types.Timestamp, error)
+	GetMatchingFlows(ctx context.Context, pred func(*storage.NetworkFlowProperties) bool, since *types.Timestamp) ([]*storage.NetworkFlow, *types.Timestamp, error)
 	// GetFlowsForDeployment returns all flows referencing a specific deployment id
 	GetFlowsForDeployment(ctx context.Context, deploymentID string) ([]*storage.NetworkFlow, error)
 
@@ -383,19 +383,19 @@ func (s *flowStoreImpl) retryableRemoveFlowsForDeployment(ctx context.Context, i
 }
 
 // GetAllFlows returns the object, if it exists from the store, timestamp and error
-func (s *flowStoreImpl) GetAllFlows(ctx context.Context, since *types.Timestamp) ([]*storage.NetworkFlow, types.Timestamp, error) {
+func (s *flowStoreImpl) GetAllFlows(ctx context.Context, since *types.Timestamp) ([]*storage.NetworkFlow, *types.Timestamp, error) {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetAll, "NetworkFlow")
 
-	return pgutils.Retry3(func() ([]*storage.NetworkFlow, types.Timestamp, error) {
+	return pgutils.Retry3(func() ([]*storage.NetworkFlow, *types.Timestamp, error) {
 		return s.retryableGetAllFlows(ctx, since)
 	})
 }
 
-func (s *flowStoreImpl) retryableGetAllFlows(ctx context.Context, since *types.Timestamp) ([]*storage.NetworkFlow, types.Timestamp, error) {
+func (s *flowStoreImpl) retryableGetAllFlows(ctx context.Context, since *types.Timestamp) ([]*storage.NetworkFlow, *types.Timestamp, error) {
 	var rows pgx.Rows
 	var err error
 	// Default to Now as that is when we are reading them
-	lastUpdateTS := *types.TimestampNow()
+	lastUpdateTS := types.TimestampNow()
 
 	// handling case when since is nil.  Assumption is we want everything in that case vs when date is not null
 	if since == nil {
@@ -404,33 +404,33 @@ func (s *flowStoreImpl) retryableGetAllFlows(ctx context.Context, since *types.T
 		rows, err = s.db.Query(ctx, getSinceStmt, pgutils.NilOrTime(since), s.clusterID)
 	}
 	if err != nil {
-		return nil, types.Timestamp{}, pgutils.ErrNilIfNoRows(err)
+		return nil, nil, pgutils.ErrNilIfNoRows(err)
 	}
 	defer rows.Close()
 
 	flows, err := s.readRows(rows, nil)
 	if err != nil {
-		return nil, types.Timestamp{}, pgutils.ErrNilIfNoRows(err)
+		return nil, nil, pgutils.ErrNilIfNoRows(err)
 	}
 
 	return flows, lastUpdateTS, nil
 }
 
 // GetMatchingFlows iterates over all of the objects in the store and applies the closure
-func (s *flowStoreImpl) GetMatchingFlows(ctx context.Context, pred func(*storage.NetworkFlowProperties) bool, since *types.Timestamp) ([]*storage.NetworkFlow, types.Timestamp, error) {
+func (s *flowStoreImpl) GetMatchingFlows(ctx context.Context, pred func(*storage.NetworkFlowProperties) bool, since *types.Timestamp) ([]*storage.NetworkFlow, *types.Timestamp, error) {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetMany, "NetworkFlow")
 
-	return pgutils.Retry3(func() ([]*storage.NetworkFlow, types.Timestamp, error) {
+	return pgutils.Retry3(func() ([]*storage.NetworkFlow, *types.Timestamp, error) {
 		return s.retryableGetMatchingFlows(ctx, pred, since)
 	})
 }
 
-func (s *flowStoreImpl) retryableGetMatchingFlows(ctx context.Context, pred func(*storage.NetworkFlowProperties) bool, since *types.Timestamp) ([]*storage.NetworkFlow, types.Timestamp, error) {
+func (s *flowStoreImpl) retryableGetMatchingFlows(ctx context.Context, pred func(*storage.NetworkFlowProperties) bool, since *types.Timestamp) ([]*storage.NetworkFlow, *types.Timestamp, error) {
 	var rows pgx.Rows
 	var err error
 
 	// Default to Now as that is when we are reading them
-	lastUpdateTS := *types.TimestampNow()
+	lastUpdateTS := types.TimestampNow()
 
 	// handling case when since is nil.  Assumption is we want everything in that case vs when date is not null
 	if since == nil {
@@ -440,7 +440,7 @@ func (s *flowStoreImpl) retryableGetMatchingFlows(ctx context.Context, pred func
 	}
 
 	if err != nil {
-		return nil, types.Timestamp{}, pgutils.ErrNilIfNoRows(err)
+		return nil, nil, pgutils.ErrNilIfNoRows(err)
 	}
 	defer rows.Close()
 

--- a/central/networkgraph/flow/datastore/internal/store/rocksdb/flow_impl.go
+++ b/central/networkgraph/flow/datastore/internal/store/rocksdb/flow_impl.go
@@ -31,10 +31,10 @@ var (
 )
 
 // GetAllFlows returns all the flows in the store.
-func (s *flowStoreImpl) GetAllFlows(ctx context.Context, since *types.Timestamp) (flows []*storage.NetworkFlow, ts types.Timestamp, err error) {
+func (s *flowStoreImpl) GetAllFlows(ctx context.Context, since *types.Timestamp) (flows []*storage.NetworkFlow, ts *types.Timestamp, err error) {
 	defer metrics.SetRocksDBOperationDurationTime(time.Now(), ops.GetAll, "NetworkFlow")
 	if err := s.db.IncRocksDBInProgressOps(); err != nil {
-		return nil, types.Timestamp{}, err
+		return nil, nil, err
 	}
 	defer s.db.DecRocksDBInProgressOps()
 
@@ -42,10 +42,10 @@ func (s *flowStoreImpl) GetAllFlows(ctx context.Context, since *types.Timestamp)
 	return flows, ts, err
 }
 
-func (s *flowStoreImpl) GetMatchingFlows(ctx context.Context, pred func(*storage.NetworkFlowProperties) bool, since *types.Timestamp) (flows []*storage.NetworkFlow, ts types.Timestamp, err error) {
+func (s *flowStoreImpl) GetMatchingFlows(ctx context.Context, pred func(*storage.NetworkFlowProperties) bool, since *types.Timestamp) (flows []*storage.NetworkFlow, ts *types.Timestamp, err error) {
 	defer metrics.SetRocksDBOperationDurationTime(time.Now(), ops.GetMany, "NetworkFlow")
 	if err := s.db.IncRocksDBInProgressOps(); err != nil {
-		return nil, types.Timestamp{}, err
+		return nil, nil, err
 	}
 	defer s.db.DecRocksDBInProgressOps()
 
@@ -208,13 +208,13 @@ func (s *flowStoreImpl) getID(props *storage.NetworkFlowProperties) []byte {
 	return s.getFullKey(common.GetID(props))
 }
 
-func (s *flowStoreImpl) readFlows(pred func(*storage.NetworkFlowProperties) bool, since *types.Timestamp) (flows []*storage.NetworkFlow, lastUpdateTS types.Timestamp, err error) {
+func (s *flowStoreImpl) readFlows(pred func(*storage.NetworkFlowProperties) bool, since *types.Timestamp) (flows []*storage.NetworkFlow, lastUpdateTS *types.Timestamp, err error) {
 	// The entry for this should be present, but make sure we have a sane default if it is not
-	lastUpdateTS = *types.TimestampNow()
+	lastUpdateTS = types.TimestampNow()
 
 	err = generic.DefaultForEachItemWithPrefix(s.db, s.keyPrefix, true, func(k, v []byte) error {
 		if bytes.Equal(k, updatedTSKey) {
-			return proto.Unmarshal(v, &lastUpdateTS)
+			return proto.Unmarshal(v, lastUpdateTS)
 		}
 		if pred != nil {
 			props, err := common.ParseID(k)

--- a/central/networkgraph/flow/datastore/internal/store/testcommon/flow.go
+++ b/central/networkgraph/flow/datastore/internal/store/testcommon/flow.go
@@ -86,7 +86,7 @@ func (suite *FlowStoreTestSuite) TestStore() {
 	// I don't think these time checks make sense based on how this will work in PG.
 	// Not sure it made sense regardless.
 	if !env.PostgresDatastoreEnabled.BooleanSetting() {
-		suite.Equal(updateTS, timestamp.FromProtobuf(&readUpdateTS))
+		suite.Equal(updateTS, timestamp.FromProtobuf(readUpdateTS))
 	}
 
 	readFlows, readUpdateTS, err = suite.tested.GetAllFlows(context.Background(), protoconv.ConvertTimeToTimestamp(t2))
@@ -95,7 +95,7 @@ func (suite *FlowStoreTestSuite) TestStore() {
 	// I don't think these time checks make sense based on how this will work in PG.
 	// Not sure it made sense regardless.
 	if !env.PostgresDatastoreEnabled.BooleanSetting() {
-		suite.Equal(updateTS, timestamp.FromProtobuf(&readUpdateTS))
+		suite.Equal(updateTS, timestamp.FromProtobuf(readUpdateTS))
 	}
 
 	readFlows, readUpdateTS, err = suite.tested.GetAllFlows(context.Background(), protoconv.ConvertTimeToTimestamp(time.Now()))
@@ -104,7 +104,7 @@ func (suite *FlowStoreTestSuite) TestStore() {
 	// I don't think these time checks make sense based on how this will work in PG.
 	// Not sure it made sense regardless.
 	if !env.PostgresDatastoreEnabled.BooleanSetting() {
-		suite.Equal(updateTS, timestamp.FromProtobuf(&readUpdateTS))
+		suite.Equal(updateTS, timestamp.FromProtobuf(readUpdateTS))
 	}
 
 	updateTS += 1337
@@ -134,7 +134,7 @@ func (suite *FlowStoreTestSuite) TestStore() {
 	// I don't think these time checks make sense based on how this will work in PG.
 	// Not sure it made sense regardless.
 	if !env.PostgresDatastoreEnabled.BooleanSetting() {
-		suite.Equal(updateTS, timestamp.FromProtobuf(&readUpdateTS))
+		suite.Equal(updateTS, timestamp.FromProtobuf(readUpdateTS))
 	}
 
 	updateTS += 42
@@ -147,7 +147,7 @@ func (suite *FlowStoreTestSuite) TestStore() {
 	// I don't think these time checks make sense based on how this will work in PG.
 	// Not sure it made sense regardless.
 	if !env.PostgresDatastoreEnabled.BooleanSetting() {
-		suite.Equal(updateTS, timestamp.FromProtobuf(&readUpdateTS))
+		suite.Equal(updateTS, timestamp.FromProtobuf(readUpdateTS))
 	}
 
 	node1Flows, readUpdateTS, err := suite.tested.GetMatchingFlows(context.Background(), func(props *storage.NetworkFlowProperties) bool {
@@ -164,7 +164,7 @@ func (suite *FlowStoreTestSuite) TestStore() {
 	// I don't think these time checks make sense based on how this will work in PG.
 	// Not sure it made sense regardless.
 	if !env.PostgresDatastoreEnabled.BooleanSetting() {
-		suite.Equal(updateTS, timestamp.FromProtobuf(&readUpdateTS))
+		suite.Equal(updateTS, timestamp.FromProtobuf(readUpdateTS))
 	}
 }
 

--- a/central/networkgraph/flow/datastore/mocks/flow.go
+++ b/central/networkgraph/flow/datastore/mocks/flow.go
@@ -38,11 +38,11 @@ func (m *MockFlowDataStore) EXPECT() *MockFlowDataStoreMockRecorder {
 }
 
 // GetAllFlows mocks base method.
-func (m *MockFlowDataStore) GetAllFlows(ctx context.Context, since *types.Timestamp) ([]*storage.NetworkFlow, types.Timestamp, error) {
+func (m *MockFlowDataStore) GetAllFlows(ctx context.Context, since *types.Timestamp) ([]*storage.NetworkFlow, *types.Timestamp, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAllFlows", ctx, since)
 	ret0, _ := ret[0].([]*storage.NetworkFlow)
-	ret1, _ := ret[1].(types.Timestamp)
+	ret1, _ := ret[1].(*types.Timestamp)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }
@@ -69,11 +69,11 @@ func (mr *MockFlowDataStoreMockRecorder) GetFlowsForDeployment(ctx, deploymentID
 }
 
 // GetMatchingFlows mocks base method.
-func (m *MockFlowDataStore) GetMatchingFlows(ctx context.Context, pred func(*storage.NetworkFlowProperties) bool, since *types.Timestamp) ([]*storage.NetworkFlow, types.Timestamp, error) {
+func (m *MockFlowDataStore) GetMatchingFlows(ctx context.Context, pred func(*storage.NetworkFlowProperties) bool, since *types.Timestamp) ([]*storage.NetworkFlow, *types.Timestamp, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMatchingFlows", ctx, pred, since)
 	ret0, _ := ret[0].([]*storage.NetworkFlow)
-	ret1, _ := ret[1].(types.Timestamp)
+	ret1, _ := ret[1].(*types.Timestamp)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }

--- a/central/networkgraph/service/service_impl_test.go
+++ b/central/networkgraph/service/service_impl_test.go
@@ -262,7 +262,7 @@ func (s *NetworkGraphServiceTestSuite) TestGenerateNetworkGraphWithSAC() {
 	s.flows.EXPECT().GetFlowStore(ctxHasClusterWideNetworkFlowAccessMatcher, "mycluster").Return(mockFlowStore, nil)
 
 	mockFlowStore.EXPECT().GetMatchingFlows(ctxHasClusterWideNetworkFlowAccessMatcher, gomock.Any(), gomock.Eq(ts)).DoAndReturn(
-		func(ctx context.Context, pred func(*storage.NetworkFlowProperties) bool, _ *types.Timestamp) ([]*storage.NetworkFlow, types.Timestamp, error) {
+		func(ctx context.Context, pred func(*storage.NetworkFlowProperties) bool, _ *types.Timestamp) ([]*storage.NetworkFlow, *types.Timestamp, error) {
 			flows := []*storage.NetworkFlow{depFlow("depA", "depB"),
 				depFlow("depA", "depD"),
 				depFlow("depA", "depE"),
@@ -308,7 +308,7 @@ func (s *NetworkGraphServiceTestSuite) TestGenerateNetworkGraphWithSAC() {
 				anyFlow(es3ID.String(), storage.NetworkEntityInfo_EXTERNAL_SOURCE, "depD", storage.NetworkEntityInfo_DEPLOYMENT),
 				anyFlow(es3ID.String(), storage.NetworkEntityInfo_EXTERNAL_SOURCE, es2ID.String(), storage.NetworkEntityInfo_EXTERNAL_SOURCE),
 			}
-			return networkgraph.FilterFlowsByPredicate(flows, pred), *types.TimestampNow(), nil
+			return networkgraph.FilterFlowsByPredicate(flows, pred), types.TimestampNow(), nil
 		})
 
 	s.networkTreeMgr.EXPECT().GetReadOnlyNetworkTree(gomock.Any(), gomock.Any()).Return(networkTree)
@@ -506,7 +506,7 @@ func (s *NetworkGraphServiceTestSuite) testGenerateNetworkGraphAllAccess(withLis
 		})
 
 	mockFlowStore.EXPECT().GetMatchingFlows(ctxHasClusterWideNetworkFlowAccessMatcher, gomock.Any(), gomock.Eq(ts)).DoAndReturn(
-		func(ctx context.Context, pred func(*storage.NetworkFlowProperties) bool, _ *types.Timestamp) ([]*storage.NetworkFlow, types.Timestamp, error) {
+		func(ctx context.Context, pred func(*storage.NetworkFlowProperties) bool, _ *types.Timestamp) ([]*storage.NetworkFlow, *types.Timestamp, error) {
 			flows := []*storage.NetworkFlow{
 				depFlow("depA", "depB"),
 				depFlow("depA", "depD"),
@@ -543,7 +543,7 @@ func (s *NetworkGraphServiceTestSuite) testGenerateNetworkGraphAllAccess(withLis
 				anyFlow(es3ID.String(), storage.NetworkEntityInfo_EXTERNAL_SOURCE, "depD", storage.NetworkEntityInfo_DEPLOYMENT),
 				anyFlow(es3ID.String(), storage.NetworkEntityInfo_EXTERNAL_SOURCE, es1ID.String(), storage.NetworkEntityInfo_EXTERNAL_SOURCE),
 			}
-			return networkgraph.FilterFlowsByPredicate(flows, pred), *types.TimestampNow(), nil
+			return networkgraph.FilterFlowsByPredicate(flows, pred), types.TimestampNow(), nil
 		})
 
 	s.networkTreeMgr.EXPECT().GetReadOnlyNetworkTree(gomock.Any(), gomock.Any()).Return(networkTree)

--- a/central/networkpolicies/generator/generator_impl_test.go
+++ b/central/networkpolicies/generator/generator_impl_test.go
@@ -383,7 +383,7 @@ func (s *generatorTestSuite) TestGenerate() {
 					},
 				},
 			},
-		}, *types.TimestampNow(), nil)
+		}, types.TimestampNow(), nil)
 
 	s.mockNetTreeMgr.EXPECT().GetReadOnlyNetworkTree(gomock.Any(), gomock.Any()).Return(nil)
 	s.mockNetTreeMgr.EXPECT().GetDefaultNetworkTree(gomock.Any()).Return(nil)
@@ -661,7 +661,7 @@ func (s *generatorTestSuite) TestGenerateWithMaskedUnselectedAndDeleted() {
 			depFlow("depF", "depC"),
 			depFlow("depF", "depD"),
 			depFlow("depF", "depG"),
-		}, *types.TimestampNow(), nil)
+		}, types.TimestampNow(), nil)
 
 	s.mockNetTreeMgr.EXPECT().GetReadOnlyNetworkTree(gomock.Any(), gomock.Any()).Return(nil)
 	s.mockNetTreeMgr.EXPECT().GetDefaultNetworkTree(gomock.Any()).Return(nil)

--- a/central/sensor/service/pipeline/networkflowupdate/flow_store_updater_impl.go
+++ b/central/sensor/service/pipeline/networkflowupdate/flow_store_updater_impl.go
@@ -46,7 +46,7 @@ func (s *flowPersisterImpl) markExistingFlowsAsTerminatedIfNotSeen(ctx context.C
 		return err
 	}
 
-	closeTS := timestamp.FromProtobuf(&lastUpdateTS)
+	closeTS := timestamp.FromProtobuf(lastUpdateTS)
 	if closeTS == 0 {
 		closeTS = timestamp.Now()
 	}

--- a/central/sensor/service/pipeline/networkflowupdate/flow_store_updater_impl_test.go
+++ b/central/sensor/service/pipeline/networkflowupdate/flow_store_updater_impl_test.go
@@ -132,7 +132,7 @@ func (suite *FlowStoreUpdaterTestSuite) TestUpdate() {
 	}
 
 	// Return storedFlows on DB read.
-	suite.mockFlows.EXPECT().GetAllFlows(suite.hasWriteCtx, gomock.Any()).Return(storedFlows, *firstTimestamp, nil)
+	suite.mockFlows.EXPECT().GetAllFlows(suite.hasWriteCtx, gomock.Any()).Return(storedFlows, firstTimestamp, nil)
 
 	suite.mockBaselines.EXPECT().ProcessFlowUpdate(testutils.PredMatcher("equivalent map except for timestamp", func(got map[networkgraph.NetworkConnIndicator]timestamp.MicroTS) bool {
 		expectedMap := map[networkgraph.NetworkConnIndicator]timestamp.MicroTS{

--- a/central/splunk/violations_query_test.go
+++ b/central/splunk/violations_query_test.go
@@ -114,7 +114,7 @@ func (s *violationsTestSuite) TestQueryAlertsWithTimestamp() {
 		},
 	}
 
-	s.withAlerts(these(&s.processAlert, &s.k8sAlert, &s.deployAlert), func(alertsDS datastore.DataStore) {
+	s.withAlerts(these(s.processAlert, s.k8sAlert, s.deployAlert), func(alertsDS datastore.DataStore) {
 		for _, c := range cases {
 			s.Run(c.name, func() {
 				alerts := s.queryAlertsWithCheckpoint(alertsDS, c.timestamp, defaultPaginationSettings.maxAlertsFromQuery)
@@ -128,7 +128,7 @@ func (s *violationsTestSuite) TestQueryAlertsWithTimestamp() {
 }
 
 func (s *violationsTestSuite) TestQueryAlertsAreSortedByAlertID() {
-	alerts := []*storage.Alert{&s.processAlert, &s.k8sAlert, &s.deployAlert, &s.networkAlert}
+	alerts := []*storage.Alert{s.processAlert, s.k8sAlert, s.deployAlert, s.networkAlert}
 	sortedIDs := make([]string, 0, len(alerts))
 	// Generate new random UUIDs for Alerts. This will make it highly likely that default ordering of alerts by
 	// decreasing timestamp does not match ordering by ID. Therefore we'll be able to validate that our requested
@@ -187,7 +187,7 @@ func (s *violationsTestSuite) TestQueryAlertsFromAlertIDAndWithLimit() {
 		{fromAlertID: "", limit: defaultPaginationSettings.maxAlertsFromQuery, result: ids},
 	}
 
-	s.withAlerts(these(&s.processAlert, &s.k8sAlert, &s.deployAlert, &s.networkAlert), func(alertsDS datastore.DataStore) {
+	s.withAlerts(these(s.processAlert, s.k8sAlert, s.deployAlert, s.networkAlert), func(alertsDS datastore.DataStore) {
 		for _, c := range cases {
 			s.Run(fmt.Sprintf("from:%q, limit:%d", c.fromAlertID, c.limit), func() {
 				result := s.queryAlertsWithCheckpoint(alertsDS, "2000-01-01T00:00:00Z__2021-03-26T17:36:00Z__"+c.fromAlertID, c.limit)

--- a/go.mod
+++ b/go.mod
@@ -423,6 +423,9 @@ replace (
 
 	github.com/heroku/docker-registry-client => github.com/stackrox/docker-registry-client v0.0.0-20220204234128-07f109db0819
 
+	// Fork of easyjson is needed to avoid value copies of protobuf messages.
+	github.com/mailru/easyjson => github.com/misberner/easyjson v0.0.0-20220806042407-84cd25193300
+
 	// github.com/mikefarah/yaml/v2 is a clone of github.com/go-yaml/yaml/v2.
 	// Both github.com/go-yaml/yaml/v2 and github.com/go-yaml/yaml/v3 do not provide go.sum
 	// so dependabot is not able to check dependecies.

--- a/go.mod
+++ b/go.mod
@@ -423,9 +423,6 @@ replace (
 
 	github.com/heroku/docker-registry-client => github.com/stackrox/docker-registry-client v0.0.0-20220204234128-07f109db0819
 
-	// Fork of easyjson is needed to avoid value copies of protobuf messages.
-	github.com/mailru/easyjson => github.com/misberner/easyjson v0.0.0-20220806042407-84cd25193300
-
 	// github.com/mikefarah/yaml/v2 is a clone of github.com/go-yaml/yaml/v2.
 	// Both github.com/go-yaml/yaml/v2 and github.com/go-yaml/yaml/v3 do not provide go.sum
 	// so dependabot is not able to check dependecies.

--- a/go.sum
+++ b/go.sum
@@ -1373,6 +1373,13 @@ github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czP
 github.com/magiconair/properties v1.8.5/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPKd5NZ3oSwXrF60=
 github.com/magiconair/properties v1.8.6 h1:5ibWZ6iY0NctNGWo87LalDlEZ6R41TqbbDamhfG/Qzo=
 github.com/magiconair/properties v1.8.6/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPKd5NZ3oSwXrF60=
+github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
+github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
+github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
+github.com/mailru/easyjson v0.7.0/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
+github.com/mailru/easyjson v0.7.6/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
+github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
+github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/maratori/testpackage v1.0.1/go.mod h1:ddKdw+XG0Phzhx8BFDTKgpWP4i7MpApTE5fXSKAqwDU=
 github.com/markbates/errx v1.1.0 h1:QDFeR+UP95dO12JgW+tgi2UVfo0V8YBHiUIOaeBPiEI=
 github.com/markbates/errx v1.1.0/go.mod h1:PLa46Oex9KNbVDZhKel8v1OT7hD5JZ2eI7AHhA0wswc=
@@ -1440,8 +1447,6 @@ github.com/mholt/archiver/v3 v3.5.1/go.mod h1:e3dqJ7H78uzsRSEACH1joayhuSyhnonssn
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/pkcs11 v1.0.2/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
 github.com/miekg/pkcs11 v1.0.3/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
-github.com/misberner/easyjson v0.0.0-20220806042407-84cd25193300 h1:MTUTG/4Z6D3BSL3+/+akTjrooNshy/g8LNNvu1kJaJ8=
-github.com/misberner/easyjson v0.0.0-20220806042407-84cd25193300/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible/go.mod h1:8AuVvqP/mXw1px98n46wfvcGfQ4ci2FwoAjKYxuo3Z4=
 github.com/mistifyio/go-zfs/v3 v3.0.0/go.mod h1:CzVgeB0RvF2EGzQnytKVvVSDwmKJXxkOTUGbNrTja/k=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=

--- a/go.sum
+++ b/go.sum
@@ -1373,13 +1373,6 @@ github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czP
 github.com/magiconair/properties v1.8.5/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPKd5NZ3oSwXrF60=
 github.com/magiconair/properties v1.8.6 h1:5ibWZ6iY0NctNGWo87LalDlEZ6R41TqbbDamhfG/Qzo=
 github.com/magiconair/properties v1.8.6/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPKd5NZ3oSwXrF60=
-github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
-github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
-github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
-github.com/mailru/easyjson v0.7.0/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
-github.com/mailru/easyjson v0.7.6/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
-github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
-github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/maratori/testpackage v1.0.1/go.mod h1:ddKdw+XG0Phzhx8BFDTKgpWP4i7MpApTE5fXSKAqwDU=
 github.com/markbates/errx v1.1.0 h1:QDFeR+UP95dO12JgW+tgi2UVfo0V8YBHiUIOaeBPiEI=
 github.com/markbates/errx v1.1.0/go.mod h1:PLa46Oex9KNbVDZhKel8v1OT7hD5JZ2eI7AHhA0wswc=
@@ -1447,6 +1440,8 @@ github.com/mholt/archiver/v3 v3.5.1/go.mod h1:e3dqJ7H78uzsRSEACH1joayhuSyhnonssn
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/pkcs11 v1.0.2/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
 github.com/miekg/pkcs11 v1.0.3/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
+github.com/misberner/easyjson v0.0.0-20220806042407-84cd25193300 h1:MTUTG/4Z6D3BSL3+/+akTjrooNshy/g8LNNvu1kJaJ8=
+github.com/misberner/easyjson v0.0.0-20220806042407-84cd25193300/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible/go.mod h1:8AuVvqP/mXw1px98n46wfvcGfQ4ci2FwoAjKYxuo3Z4=
 github.com/mistifyio/go-zfs/v3 v3.0.0/go.mod h1:CzVgeB0RvF2EGzQnytKVvVSDwmKJXxkOTUGbNrTja/k=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=

--- a/migrator/migrations/m_100_to_m_101_cluster_id_netpol_undo_store/migration.go
+++ b/migrator/migrations/m_100_to_m_101_cluster_id_netpol_undo_store/migration.go
@@ -12,7 +12,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: 100,
-		VersionAfter:   storage.Version{SeqNum: 101},
+		VersionAfter:   &storage.Version{SeqNum: 101},
 		Run: func(databases *types.Databases) error {
 			if err := addClusterIDToNetworkPolicyApplicationUndoRecord(databases.BoltDB); err != nil {
 				return errors.Wrap(err,

--- a/migrator/migrations/m_101_to_m_102_drop_license_buckets/migration.go
+++ b/migrator/migrations/m_101_to_m_102_drop_license_buckets/migration.go
@@ -13,7 +13,7 @@ var (
 
 	migration = types.Migration{
 		StartingSeqNum: 101,
-		VersionAfter:   storage.Version{SeqNum: 102},
+		VersionAfter:   &storage.Version{SeqNum: 102},
 		Run: func(databases *types.Databases) error {
 			if err := dropBuckets(databases.BoltDB); err != nil {
 				return errors.Wrap(err, "error dropping buckets from Bolt")

--- a/migrator/migrations/m_102_to_m_103_migrate_serial/migration.go
+++ b/migrator/migrations/m_102_to_m_103_migrate_serial/migration.go
@@ -16,7 +16,7 @@ var (
 
 	migration = types.Migration{
 		StartingSeqNum: 102,
-		VersionAfter:   storage.Version{SeqNum: 103},
+		VersionAfter:   &storage.Version{SeqNum: 103},
 		Run: func(databases *types.Databases) error {
 			if err := migrateSerials(databases.BoltDB); err != nil {
 				return errors.Wrap(err, "error migrating service identity serials")

--- a/migrator/migrations/m_103_to_m_104_networkpolicy_guidance/migration.go
+++ b/migrator/migrations/m_103_to_m_104_networkpolicy_guidance/migration.go
@@ -14,7 +14,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: 103,
-		VersionAfter:   storage.Version{SeqNum: 104},
+		VersionAfter:   &storage.Version{SeqNum: 104},
 		Run: func(databases *types.Databases) error {
 			err := updatePolicies(databases.BoltDB)
 			if err != nil {

--- a/migrator/migrations/m_104_to_m_105_active_component/migration.go
+++ b/migrator/migrations/m_104_to_m_105_active_component/migration.go
@@ -21,7 +21,7 @@ var (
 
 	migration = types.Migration{
 		StartingSeqNum: 104,
-		VersionAfter:   storage.Version{SeqNum: 105},
+		VersionAfter:   &storage.Version{SeqNum: 105},
 		Run: func(databases *types.Databases) error {
 			return updateActiveComponents(databases.RocksDB)
 		},

--- a/migrator/migrations/m_105_to_m_106_group_id/migration.go
+++ b/migrator/migrations/m_105_to_m_106_group_id/migration.go
@@ -21,7 +21,7 @@ var (
 
 	migration = types.Migration{
 		StartingSeqNum: 105,
-		VersionAfter:   storage.Version{SeqNum: 106},
+		VersionAfter:   &storage.Version{SeqNum: 106},
 		Run: func(databases *types.Databases) error {
 			return migrateGroupsStoredByCompositeKey(databases.BoltDB)
 		},

--- a/migrator/migrations/m_106_to_m_107_policy_categories/migration.go
+++ b/migrator/migrations/m_106_to_m_107_policy_categories/migration.go
@@ -22,7 +22,7 @@ var (
 
 	migration = types.Migration{
 		StartingSeqNum: 106,
-		VersionAfter:   storage.Version{SeqNum: 107},
+		VersionAfter:   &storage.Version{SeqNum: 107},
 		Run: func(databases *types.Databases) error {
 			return addUserDefinedCategories(databases.BoltDB, databases.RocksDB)
 		},

--- a/migrator/migrations/m_107_to_m_108_remove_auth_plugin/migration.go
+++ b/migrator/migrations/m_107_to_m_108_remove_auth_plugin/migration.go
@@ -17,7 +17,7 @@ const (
 var (
 	migration = types.Migration{
 		StartingSeqNum: 107,
-		VersionAfter:   storage.Version{SeqNum: 108},
+		VersionAfter:   &storage.Version{SeqNum: 108},
 		Run: func(databases *types.Databases) error {
 			err := migratePS(databases.RocksDB)
 			if err != nil {

--- a/migrator/migrations/m_108_to_m_109_compliance_run_schedules/migration.go
+++ b/migrator/migrations/m_108_to_m_109_compliance_run_schedules/migration.go
@@ -12,7 +12,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: 108,
-		VersionAfter:   storage.Version{SeqNum: 109},
+		VersionAfter:   &storage.Version{SeqNum: 109},
 		Run: func(databases *types.Databases) error {
 			return removeComplianceRunScheduleFromPermissionSets(databases.RocksDB)
 		},

--- a/migrator/migrations/m_109_to_m_110_networkpolicy_guidance_2/migration.go
+++ b/migrator/migrations/m_109_to_m_110_networkpolicy_guidance_2/migration.go
@@ -14,7 +14,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: 109,
-		VersionAfter:   storage.Version{SeqNum: 110},
+		VersionAfter:   &storage.Version{SeqNum: 110},
 		Run: func(databases *types.Databases) error {
 			err := updatePolicies(databases.BoltDB)
 			if err != nil {

--- a/migrator/migrations/m_55_to_m_56_node_scanning_empty/migration.go
+++ b/migrator/migrations/m_55_to_m_56_node_scanning_empty/migration.go
@@ -9,7 +9,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: 55,
-		VersionAfter:   storage.Version{SeqNum: 56},
+		VersionAfter:   &storage.Version{SeqNum: 56},
 		Run: func(databases *types.Databases) error {
 			return nil
 		},

--- a/migrator/migrations/m_56_to_m_57_compliance_policy_categories/migration.go
+++ b/migrator/migrations/m_56_to_m_57_compliance_policy_categories/migration.go
@@ -24,7 +24,7 @@ type policyUpdate struct {
 var (
 	migration = types.Migration{
 		StartingSeqNum: 56,
-		VersionAfter:   storage.Version{SeqNum: 57},
+		VersionAfter:   &storage.Version{SeqNum: 57},
 		Run: func(databases *types.Databases) error {
 			return migrateNewPolicyCategories(databases.BoltDB)
 		},

--- a/migrator/migrations/m_57_to_m_58_update_run_secrets_volume_policy_regex/migration.go
+++ b/migrator/migrations/m_57_to_m_58_update_run_secrets_volume_policy_regex/migration.go
@@ -13,7 +13,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: 57,
-		VersionAfter:   storage.Version{SeqNum: 58},
+		VersionAfter:   &storage.Version{SeqNum: 58},
 		Run: func(databases *types.Databases) error {
 			err := updateRunSecretsVolumePolicy(databases.BoltDB)
 			if err != nil {

--- a/migrator/migrations/m_58_to_m_59_node_scanning_flag_on/migration.go
+++ b/migrator/migrations/m_58_to_m_59_node_scanning_flag_on/migration.go
@@ -22,7 +22,7 @@ var (
 
 	migration = types.Migration{
 		StartingSeqNum: 58,
-		VersionAfter:   storage.Version{SeqNum: 59},
+		VersionAfter:   &storage.Version{SeqNum: 59},
 		Run: func(databases *types.Databases) error {
 			if err := migrateNodes(databases.BoltDB, databases.RocksDB); err != nil {
 				return err

--- a/migrator/migrations/m_59_to_m_60_add_docker_cis_category_to_existing/migration.go
+++ b/migrator/migrations/m_59_to_m_60_add_docker_cis_category_to_existing/migration.go
@@ -17,7 +17,7 @@ const (
 var (
 	migration = types.Migration{
 		StartingSeqNum: 59,
-		VersionAfter:   storage.Version{SeqNum: 60},
+		VersionAfter:   &storage.Version{SeqNum: 60},
 		Run: func(databases *types.Databases) error {
 			return migrateNewPolicyCategories(databases.BoltDB)
 		},

--- a/migrator/migrations/m_60_to_m_61_update_network_management_policy_regex/migration.go
+++ b/migrator/migrations/m_60_to_m_61_update_network_management_policy_regex/migration.go
@@ -13,7 +13,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: 60,
-		VersionAfter:   storage.Version{SeqNum: 61},
+		VersionAfter:   &storage.Version{SeqNum: 61},
 		Run: func(databases *types.Databases) error {
 			err := updateNetworkManagementExecutionPolicy(databases.BoltDB)
 			if err != nil {

--- a/migrator/migrations/m_61_to_m_62_multiple_cve_types/migration.go
+++ b/migrator/migrations/m_61_to_m_62_multiple_cve_types/migration.go
@@ -18,7 +18,7 @@ const (
 var (
 	migration = types.Migration{
 		StartingSeqNum: 61,
-		VersionAfter:   storage.Version{SeqNum: 62},
+		VersionAfter:   &storage.Version{SeqNum: 62},
 		Run: func(databases *types.Databases) error {
 			return migrateCVEs(databases.RocksDB)
 		},

--- a/migrator/migrations/m_62_to_m_63_splunk_source_type/migration.go
+++ b/migrator/migrations/m_62_to_m_63_splunk_source_type/migration.go
@@ -19,7 +19,7 @@ var (
 
 	migration = types.Migration{
 		StartingSeqNum: 62,
-		VersionAfter:   storage.Version{SeqNum: 63},
+		VersionAfter:   &storage.Version{SeqNum: 63},
 		Run: func(databases *types.Databases) error {
 			return migrateSplunkSourceType(databases.BoltDB)
 		},

--- a/migrator/migrations/m_63_to_m_64_exclude_some_openshift_operators_from_policies/migration.go
+++ b/migrator/migrations/m_63_to_m_64_exclude_some_openshift_operators_from_policies/migration.go
@@ -22,7 +22,7 @@ type policyUpdate struct {
 var (
 	migration = types.Migration{
 		StartingSeqNum: 63,
-		VersionAfter:   storage.Version{SeqNum: 64},
+		VersionAfter:   &storage.Version{SeqNum: 64},
 		Run: func(databases *types.Databases) error {
 			err := updatePoliciesWithOSExclusions(databases.BoltDB)
 			if err != nil {

--- a/migrator/migrations/m_64_to_m_65_detect_openshift4_cluster_on_exec_webhooks/migration.go
+++ b/migrator/migrations/m_64_to_m_65_detect_openshift4_cluster_on_exec_webhooks/migration.go
@@ -17,7 +17,7 @@ var (
 var (
 	migration = types.Migration{
 		StartingSeqNum: 64,
-		VersionAfter:   storage.Version{SeqNum: 65},
+		VersionAfter:   &storage.Version{SeqNum: 65},
 		Run: func(databases *types.Databases) error {
 			return migrateOpenShiftClusterType(databases.RocksDB)
 		},

--- a/migrator/migrations/m_65_to_m_66_policy_bug_fixes/migration.go
+++ b/migrator/migrations/m_65_to_m_66_policy_bug_fixes/migration.go
@@ -16,7 +16,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: 65,
-		VersionAfter:   storage.Version{SeqNum: 66},
+		VersionAfter:   &storage.Version{SeqNum: 66},
 		Run: func(databases *types.Databases) error {
 			err := updatePolicies(databases.BoltDB)
 			if err != nil {
@@ -111,7 +111,7 @@ func updateK8sDashPolicy(bucket *bolt.Bucket) error {
 	}
 
 	section.PolicyGroups[0].Values[0].Value = k8sDashNewCriteria
-	if err := putPolicy(policy, bucket); err != nil {
+	if err := putPolicy(&policy, bucket); err != nil {
 		return err
 	}
 
@@ -144,7 +144,7 @@ func updateCurlPolicy(bucket *bolt.Bucket) error {
 	}
 
 	policy.Remediation = curlNewRemediation
-	if err := putPolicy(policy, bucket); err != nil {
+	if err := putPolicy(&policy, bucket); err != nil {
 		return err
 	}
 
@@ -176,7 +176,7 @@ func updateIptablesPolicy(bucket *bolt.Bucket) error {
 		return nil
 	}
 
-	if err := putPolicy(policy, bucket); err != nil {
+	if err := putPolicy(&policy, bucket); err != nil {
 		return err
 	}
 
@@ -207,8 +207,8 @@ func getPolicySectionIfUnmodified(policy *storage.Policy, existingPolicyGroups [
 	return section
 }
 
-func putPolicy(policy storage.Policy, bucket *bolt.Bucket) error {
-	policyBytes, err := proto.Marshal(&policy)
+func putPolicy(policy *storage.Policy, bucket *bolt.Bucket) error {
+	policyBytes, err := proto.Marshal(policy)
 	if err != nil {
 		return errors.Wrapf(err, "marshaling migrated policy %q with id %q", policy.GetName(), policy.GetId())
 	}

--- a/migrator/migrations/m_66_to_m_67_missing_policy_migrations/migration.go
+++ b/migrator/migrations/m_66_to_m_67_missing_policy_migrations/migration.go
@@ -18,7 +18,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: 66,
-		VersionAfter:   storage.Version{SeqNum: 67},
+		VersionAfter:   &storage.Version{SeqNum: 67},
 		Run: func(databases *types.Databases) error {
 			err := updatePolicies(databases.BoltDB)
 			if err != nil {

--- a/migrator/migrations/m_67_to_m_68_exclude_pdcsi_from_mount_propagation/migration.go
+++ b/migrator/migrations/m_67_to_m_68_exclude_pdcsi_from_mount_propagation/migration.go
@@ -18,7 +18,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: 67,
-		VersionAfter:   storage.Version{SeqNum: 68},
+		VersionAfter:   &storage.Version{SeqNum: 68},
 		Run: func(databases *types.Databases) error {
 			err := updatePolicies(databases.BoltDB)
 			if err != nil {

--- a/migrator/migrations/m_68_to_m_69_update_global_access_roles/migration.go
+++ b/migrator/migrations/m_68_to_m_69_update_global_access_roles/migration.go
@@ -13,7 +13,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: 68,
-		VersionAfter:   storage.Version{SeqNum: 69},
+		VersionAfter:   &storage.Version{SeqNum: 69},
 		Run: func(databases *types.Databases) error {
 			err := migrateRoles(databases.BoltDB)
 			if err != nil {

--- a/migrator/migrations/m_69_to_m_70_add_xmrig_to_crypto_policy/migration.go
+++ b/migrator/migrations/m_69_to_m_70_add_xmrig_to_crypto_policy/migration.go
@@ -18,7 +18,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: 69,
-		VersionAfter:   storage.Version{SeqNum: 70},
+		VersionAfter:   &storage.Version{SeqNum: 70},
 		Run: func(databases *types.Databases) error {
 			err := updatePolicies(databases.BoltDB)
 			if err != nil {

--- a/migrator/migrations/m_70_to_m_71_disable_audit_log_collection/migration.go
+++ b/migrator/migrations/m_70_to_m_71_disable_audit_log_collection/migration.go
@@ -18,7 +18,7 @@ var (
 var (
 	migration = types.Migration{
 		StartingSeqNum: 70,
-		VersionAfter:   storage.Version{SeqNum: 71},
+		VersionAfter:   &storage.Version{SeqNum: 71},
 		Run: func(databases *types.Databases) error {
 			return disableAuditLogCollection(databases.RocksDB)
 		},

--- a/migrator/migrations/m_71_to_m_72_delete_namespacesac_bucket/migration.go
+++ b/migrator/migrations/m_71_to_m_72_delete_namespacesac_bucket/migration.go
@@ -11,7 +11,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: 71,
-		VersionAfter:   storage.Version{SeqNum: 72},
+		VersionAfter:   &storage.Version{SeqNum: 72},
 		Run: func(databases *types.Databases) error {
 			return deleteNamespaceSACBucketAndEdges(databases.RocksDB)
 		},

--- a/migrator/migrations/m_72_to_m_73_change_roles_to_sac_v2/migration.go
+++ b/migrator/migrations/m_72_to_m_73_change_roles_to_sac_v2/migration.go
@@ -15,7 +15,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: 72,
-		VersionAfter:   storage.Version{SeqNum: 73},
+		VersionAfter:   &storage.Version{SeqNum: 73},
 		Run: func(databases *types.Databases) error {
 			err := migrateRoles(databases.BoltDB, databases.RocksDB)
 			if err != nil {

--- a/migrator/migrations/m_73_to_m_74_runtime_policy_event_source/migration.go
+++ b/migrator/migrations/m_73_to_m_74_runtime_policy_event_source/migration.go
@@ -12,7 +12,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: 73,
-		VersionAfter:   storage.Version{SeqNum: 74},
+		VersionAfter:   &storage.Version{SeqNum: 74},
 		Run: func(databases *types.Databases) error {
 			err := migrateDefaultRuntimeEventSource(databases.BoltDB)
 			if err != nil {

--- a/migrator/migrations/m_74_to_m_75_severity_policy/migration.go
+++ b/migrator/migrations/m_74_to_m_75_severity_policy/migration.go
@@ -15,7 +15,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: 74,
-		VersionAfter:   storage.Version{SeqNum: 75},
+		VersionAfter:   &storage.Version{SeqNum: 75},
 		Run: func(databases *types.Databases) error {
 			err := migrateSeverityPolicy(databases.BoltDB)
 			if err != nil {

--- a/migrator/migrations/m_75_to_m_76_exclude_compliance_operator_dnf_policy/migration.go
+++ b/migrator/migrations/m_75_to_m_76_exclude_compliance_operator_dnf_policy/migration.go
@@ -18,7 +18,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: 75,
-		VersionAfter:   storage.Version{SeqNum: 76},
+		VersionAfter:   &storage.Version{SeqNum: 76},
 		Run: func(databases *types.Databases) error {
 			err := updatePolicies(databases.BoltDB)
 			if err != nil {

--- a/migrator/migrations/m_76_to_m_77_move_roles_to_rocksdb/migration.go
+++ b/migrator/migrations/m_76_to_m_77_move_roles_to_rocksdb/migration.go
@@ -14,7 +14,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: 76,
-		VersionAfter:   storage.Version{SeqNum: 77},
+		VersionAfter:   &storage.Version{SeqNum: 77},
 		Run: func(databases *types.Databases) error {
 			err := migrateRoles(databases.BoltDB, databases.RocksDB)
 			if err != nil {

--- a/migrator/migrations/m_77_to_m_78_mitre/migration.go
+++ b/migrator/migrations/m_77_to_m_78_mitre/migration.go
@@ -17,7 +17,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: 77,
-		VersionAfter:   storage.Version{SeqNum: 78},
+		VersionAfter:   &storage.Version{SeqNum: 78},
 		Run: func(databases *types.Databases) error {
 			err := updatePoliciesWithMitre(databases.BoltDB)
 			if err != nil {

--- a/migrator/migrations/m_78_to_m_79_exclude_openshift_sdn_host_pids_policy/migration.go
+++ b/migrator/migrations/m_78_to_m_79_exclude_openshift_sdn_host_pids_policy/migration.go
@@ -14,7 +14,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: 78,
-		VersionAfter:   storage.Version{SeqNum: 79},
+		VersionAfter:   &storage.Version{SeqNum: 79},
 		Run: func(databases *types.Databases) error {
 			err := updatePolicies(databases.BoltDB)
 			if err != nil {

--- a/migrator/migrations/m_79_to_m_80_more_openshift_exclusions/migration.go
+++ b/migrator/migrations/m_79_to_m_80_more_openshift_exclusions/migration.go
@@ -14,7 +14,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: 79,
-		VersionAfter:   storage.Version{SeqNum: 80},
+		VersionAfter:   &storage.Version{SeqNum: 80},
 		Run: func(databases *types.Databases) error {
 			err := updatePolicies(databases.BoltDB)
 			if err != nil {

--- a/migrator/migrations/m_80_to_m_81_rm_demo_policies/migration.go
+++ b/migrator/migrations/m_80_to_m_81_rm_demo_policies/migration.go
@@ -16,7 +16,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: 80,
-		VersionAfter:   storage.Version{SeqNum: 81},
+		VersionAfter:   &storage.Version{SeqNum: 81},
 		Run: func(databases *types.Databases) error {
 			err := rmDemoPolicies(databases.BoltDB)
 			if err != nil {

--- a/migrator/migrations/m_81_to_m_82_modify_docker_policies/migration.go
+++ b/migrator/migrations/m_81_to_m_82_modify_docker_policies/migration.go
@@ -14,7 +14,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: 81,
-		VersionAfter:   storage.Version{SeqNum: 82},
+		VersionAfter:   &storage.Version{SeqNum: 82},
 		Run: func(databases *types.Databases) error {
 			err := updatePolicies(databases.BoltDB)
 			if err != nil {

--- a/migrator/migrations/m_82_to_m_83_default_pol_flag/migration.go
+++ b/migrator/migrations/m_82_to_m_83_default_pol_flag/migration.go
@@ -17,7 +17,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: 82,
-		VersionAfter:   storage.Version{SeqNum: 83},
+		VersionAfter:   &storage.Version{SeqNum: 83},
 		Run: func(databases *types.Databases) error {
 			err := updatePoliciesWithDefaultFlag(databases.BoltDB)
 			if err != nil {

--- a/migrator/migrations/m_83_to_m_84_mitre_fixes/migration.go
+++ b/migrator/migrations/m_83_to_m_84_mitre_fixes/migration.go
@@ -14,7 +14,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: 83,
-		VersionAfter:   storage.Version{SeqNum: 84},
+		VersionAfter:   &storage.Version{SeqNum: 84},
 		Run: func(databases *types.Databases) error {
 			err := updatePolicies(databases.BoltDB)
 			if err != nil {

--- a/migrator/migrations/m_84_to_m_85_exclude_compliance_op_policy/migration.go
+++ b/migrator/migrations/m_84_to_m_85_exclude_compliance_op_policy/migration.go
@@ -14,7 +14,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: 84,
-		VersionAfter:   storage.Version{SeqNum: 85},
+		VersionAfter:   &storage.Version{SeqNum: 85},
 		Run: func(databases *types.Databases) error {
 			err := updatePolicies(databases.BoltDB)
 			if err != nil {

--- a/migrator/migrations/m_85_to_m_86_apktools_policy/migration.go
+++ b/migrator/migrations/m_85_to_m_86_apktools_policy/migration.go
@@ -14,7 +14,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: 85,
-		VersionAfter:   storage.Version{SeqNum: 86},
+		VersionAfter:   &storage.Version{SeqNum: 86},
 		Run: func(databases *types.Databases) error {
 			err := updatePolicies(databases.BoltDB)
 			if err != nil {

--- a/migrator/migrations/m_86_to_m_87_microdnf_policy/migration.go
+++ b/migrator/migrations/m_86_to_m_87_microdnf_policy/migration.go
@@ -14,7 +14,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: 86,
-		VersionAfter:   storage.Version{SeqNum: 87},
+		VersionAfter:   &storage.Version{SeqNum: 87},
 		Run: func(databases *types.Databases) error {
 			err := updatePolicies(databases.BoltDB)
 			if err != nil {

--- a/migrator/migrations/m_87_to_m_88_central_secret_policy/migration.go
+++ b/migrator/migrations/m_87_to_m_88_central_secret_policy/migration.go
@@ -14,7 +14,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: 87,
-		VersionAfter:   storage.Version{SeqNum: 88},
+		VersionAfter:   &storage.Version{SeqNum: 88},
 		Run: func(databases *types.Databases) error {
 			err := updatePolicies(databases.BoltDB)
 			if err != nil {

--- a/migrator/migrations/m_88_to_m_89_update_log4shell_policy/migration.go
+++ b/migrator/migrations/m_88_to_m_89_update_log4shell_policy/migration.go
@@ -14,7 +14,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: 88,
-		VersionAfter:   storage.Version{SeqNum: 89},
+		VersionAfter:   &storage.Version{SeqNum: 89},
 		Run: func(databases *types.Databases) error {
 			err := updatePolicies(databases.BoltDB)
 			if err != nil {

--- a/migrator/migrations/m_89_to_m_90_vuln_state/migration.go
+++ b/migrator/migrations/m_89_to_m_90_vuln_state/migration.go
@@ -21,7 +21,7 @@ var (
 
 	migration = types.Migration{
 		StartingSeqNum: 89,
-		VersionAfter:   storage.Version{SeqNum: 90},
+		VersionAfter:   &storage.Version{SeqNum: 90},
 		Run:            updateImageCVEEdgesWithVulnState,
 	}
 

--- a/migrator/migrations/m_90_to_m_91_snooze_permissions/migration.go
+++ b/migrator/migrations/m_90_to_m_91_snooze_permissions/migration.go
@@ -22,7 +22,7 @@ var (
 
 	migration = types.Migration{
 		StartingSeqNum: 90,
-		VersionAfter:   storage.Version{SeqNum: 91},
+		VersionAfter:   &storage.Version{SeqNum: 91},
 		Run:            updateVulnSnoozePermissions,
 	}
 

--- a/migrator/migrations/m_91_to_m_92_write_edges_to_graph/migration.go
+++ b/migrator/migrations/m_91_to_m_92_write_edges_to_graph/migration.go
@@ -18,7 +18,7 @@ const (
 var (
 	migration = types.Migration{
 		StartingSeqNum: 91,
-		VersionAfter:   storage.Version{SeqNum: 92},
+		VersionAfter:   &storage.Version{SeqNum: 92},
 		Run:            writeImageCVEEdgesToGraph,
 	}
 

--- a/migrator/migrations/m_92_to_m_93_cleanup_orphaned_rbac_cluster_objs/migration.go
+++ b/migrator/migrations/m_92_to_m_93_cleanup_orphaned_rbac_cluster_objs/migration.go
@@ -24,7 +24,7 @@ var (
 
 	migration = types.Migration{
 		StartingSeqNum: 92,
-		VersionAfter:   storage.Version{SeqNum: 93},
+		VersionAfter:   &storage.Version{SeqNum: 93},
 		Run:            cleanupOrphanedRBACObjectsFromDeletedClusters,
 	}
 

--- a/migrator/migrations/m_93_to_m_94_role_accessscopeid/migration.go
+++ b/migrator/migrations/m_93_to_m_94_role_accessscopeid/migration.go
@@ -15,7 +15,7 @@ const unrestrictedScopeID = "io.stackrox.authz.accessscope.unrestricted"
 var (
 	migration = types.Migration{
 		StartingSeqNum: 93,
-		VersionAfter:   storage.Version{SeqNum: 94},
+		VersionAfter:   &storage.Version{SeqNum: 94},
 		Run: func(databases *types.Databases) error {
 			if err := updateRoles(databases.RocksDB); err != nil {
 				return errors.Wrap(err,

--- a/migrator/migrations/m_94_to_m_95_cluster_health_status_id/migration.go
+++ b/migrator/migrations/m_94_to_m_95_cluster_health_status_id/migration.go
@@ -19,7 +19,7 @@ var (
 
 	migration = types.Migration{
 		StartingSeqNum: 94,
-		VersionAfter:   storage.Version{SeqNum: 95},
+		VersionAfter:   &storage.Version{SeqNum: 95},
 		Run:            addIDToClusterHealthStatus,
 	}
 

--- a/migrator/migrations/m_95_to_m_96_alert_scoping_information_at_root/migration.go
+++ b/migrator/migrations/m_95_to_m_96_alert_scoping_information_at_root/migration.go
@@ -19,7 +19,7 @@ var (
 
 	migration = types.Migration{
 		StartingSeqNum: 95,
-		VersionAfter:   storage.Version{SeqNum: 96},
+		VersionAfter:   &storage.Version{SeqNum: 96},
 		Run:            copyAlertScopingInformationToRoot,
 	}
 

--- a/migrator/migrations/m_96_to_m_97_modify_default_vulnreportcreator_role/migration.go
+++ b/migrator/migrations/m_96_to_m_97_modify_default_vulnreportcreator_role/migration.go
@@ -18,7 +18,7 @@ var (
 
 	migration = types.Migration{
 		StartingSeqNum: 96,
-		VersionAfter:   storage.Version{SeqNum: 97},
+		VersionAfter:   &storage.Version{SeqNum: 97},
 		Run: func(databases *types.Databases) error {
 			if err := updateDefaultPermissionsForVulnCreatorRole(databases.RocksDB); err != nil {
 				return errors.Wrap(err,

--- a/migrator/migrations/m_97_to_98_exclude_oauth_sa_kubeadmin_pol/migration.go
+++ b/migrator/migrations/m_97_to_98_exclude_oauth_sa_kubeadmin_pol/migration.go
@@ -14,7 +14,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: 97,
-		VersionAfter:   storage.Version{SeqNum: 98},
+		VersionAfter:   &storage.Version{SeqNum: 98},
 		Run: func(databases *types.Databases) error {
 			err := updatePolicies(databases.BoltDB)
 			if err != nil {

--- a/migrator/migrations/m_98_to_m_99_process_alert_comments/migration.go
+++ b/migrator/migrations/m_98_to_m_99_process_alert_comments/migration.go
@@ -11,7 +11,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: 98,
-		VersionAfter:   storage.Version{SeqNum: 99},
+		VersionAfter:   &storage.Version{SeqNum: 99},
 		Run: func(databases *types.Databases) error {
 			err := deleteProcessAndAlertCommentsBuckets(databases.BoltDB)
 			if err != nil {

--- a/migrator/migrations/m_99_to_m_100_violation_report_branding/migration.go
+++ b/migrator/migrations/m_99_to_m_100_violation_report_branding/migration.go
@@ -14,7 +14,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: 99,
-		VersionAfter:   storage.Version{SeqNum: 100},
+		VersionAfter:   &storage.Version{SeqNum: 100},
 		Run: func(databases *types.Databases) error {
 			err := updatePolicies(databases.BoltDB)
 			if err != nil {

--- a/migrator/migrations/n_01_to_n_02_postgres_clusters/migration.go
+++ b/migrator/migrations/n_01_to_n_02_postgres_clusters/migration.go
@@ -21,7 +21,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 1,
-		VersionAfter:   storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 2},
+		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 2},
 		Run: func(databases *types.Databases) error {
 			legacyStore, err := legacy.New(databases.PkgRocksDB)
 			if err != nil {

--- a/migrator/migrations/n_02_to_n_03_postgres_namespaces/migration.go
+++ b/migrator/migrations/n_02_to_n_03_postgres_namespaces/migration.go
@@ -21,7 +21,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 2,
-		VersionAfter:   storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 3},
+		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 3},
 		Run: func(databases *types.Databases) error {
 			legacyStore, err := legacy.New(databases.PkgRocksDB)
 			if err != nil {

--- a/migrator/migrations/n_03_to_n_04_postgres_deployments/migration.go
+++ b/migrator/migrations/n_03_to_n_04_postgres_deployments/migration.go
@@ -22,7 +22,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 3,
-		VersionAfter:   storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 4},
+		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 4},
 		Run: func(databases *types.Databases) error {
 			legacyStore := legacy.New(rawDackbox.GetGlobalDackBox(), rawDackbox.GetKeyFence())
 			if err := move(databases.GormDB, databases.PostgresDB, legacyStore); err != nil {

--- a/migrator/migrations/n_04_to_n_05_postgres_images/migration.go
+++ b/migrator/migrations/n_04_to_n_05_postgres_images/migration.go
@@ -24,7 +24,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 4,
-		VersionAfter:   storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 5},
+		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 5},
 		Run: func(databases *types.Databases) error {
 			legacyStore := legacy.New(rawDackbox.GetGlobalDackBox(), rawDackbox.GetKeyFence(), false)
 			if err := move(databases.GormDB, databases.PostgresDB, legacyStore); err != nil {

--- a/migrator/migrations/n_05_to_n_06_postgres_active_components/migration.go
+++ b/migrator/migrations/n_05_to_n_06_postgres_active_components/migration.go
@@ -23,7 +23,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 5,
-		VersionAfter:   storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 6},
+		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 6},
 		Run: func(databases *types.Databases) error {
 			legacyStore := legacy.New(rawDackbox.GetGlobalDackBox(), rawDackbox.GetKeyFence())
 			if err := move(databases.GormDB, databases.PostgresDB, legacyStore); err != nil {

--- a/migrator/migrations/n_06_to_n_07_postgres_alerts/migration.go
+++ b/migrator/migrations/n_06_to_n_07_postgres_alerts/migration.go
@@ -21,7 +21,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 6,
-		VersionAfter:   storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 7},
+		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 7},
 		Run: func(databases *types.Databases) error {
 			legacyStore, err := legacy.New(databases.PkgRocksDB)
 			if err != nil {

--- a/migrator/migrations/n_07_to_n_08_postgres_api_tokens/migration.go
+++ b/migrator/migrations/n_07_to_n_08_postgres_api_tokens/migration.go
@@ -21,7 +21,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 7,
-		VersionAfter:   storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 8},
+		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 8},
 		Run: func(databases *types.Databases) error {
 			legacyStore, err := legacy.New(databases.PkgRocksDB)
 			if err != nil {

--- a/migrator/migrations/n_08_to_n_09_postgres_auth_providers/migration.go
+++ b/migrator/migrations/n_08_to_n_09_postgres_auth_providers/migration.go
@@ -21,7 +21,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 8,
-		VersionAfter:   storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 9},
+		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 9},
 		Run: func(databases *types.Databases) error {
 			legacyStore := legacy.New(databases.BoltDB)
 			if err := move(databases.GormDB, databases.PostgresDB, legacyStore); err != nil {

--- a/migrator/migrations/n_09_to_n_10_postgres_cluster_cves/migration.go
+++ b/migrator/migrations/n_09_to_n_10_postgres_cluster_cves/migration.go
@@ -24,7 +24,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 9,
-		VersionAfter:   storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 10},
+		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 10},
 		Run: func(databases *types.Databases) error {
 			legacyStore := legacy.New(rawDackbox.GetGlobalDackBox(), rawDackbox.GetKeyFence())
 			if err := move(databases.GormDB, databases.PostgresDB, legacyStore); err != nil {

--- a/migrator/migrations/n_10_to_n_11_postgres_cluster_health_statuses/migration.go
+++ b/migrator/migrations/n_10_to_n_11_postgres_cluster_health_statuses/migration.go
@@ -21,7 +21,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 10,
-		VersionAfter:   storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 11},
+		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 11},
 		Run: func(databases *types.Databases) error {
 			legacyStore, err := legacy.New(databases.PkgRocksDB)
 			if err != nil {

--- a/migrator/migrations/n_11_to_n_12_postgres_cluster_init_bundles/migration.go
+++ b/migrator/migrations/n_11_to_n_12_postgres_cluster_init_bundles/migration.go
@@ -21,7 +21,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 11,
-		VersionAfter:   storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 12},
+		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 12},
 		Run: func(databases *types.Databases) error {
 			legacyStore, err := legacy.New(databases.PkgRocksDB)
 			if err != nil {

--- a/migrator/migrations/n_12_to_n_13_postgres_compliance_domains/migration.go
+++ b/migrator/migrations/n_12_to_n_13_postgres_compliance_domains/migration.go
@@ -21,7 +21,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 12,
-		VersionAfter:   storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 13},
+		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 13},
 		Run: func(databases *types.Databases) error {
 			legacyStore, err := legacy.New(databases.PkgRocksDB)
 			if err != nil {

--- a/migrator/migrations/n_13_to_n_14_postgres_compliance_operator_check_results/migration.go
+++ b/migrator/migrations/n_13_to_n_14_postgres_compliance_operator_check_results/migration.go
@@ -21,7 +21,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 13,
-		VersionAfter:   storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 14},
+		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 14},
 		Run: func(databases *types.Databases) error {
 			legacyStore, err := legacy.New(databases.PkgRocksDB)
 			if err != nil {

--- a/migrator/migrations/n_14_to_n_15_postgres_compliance_operator_profiles/migration.go
+++ b/migrator/migrations/n_14_to_n_15_postgres_compliance_operator_profiles/migration.go
@@ -21,7 +21,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 14,
-		VersionAfter:   storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 15},
+		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 15},
 		Run: func(databases *types.Databases) error {
 			legacyStore, err := legacy.New(databases.PkgRocksDB)
 			if err != nil {

--- a/migrator/migrations/n_15_to_n_16_postgres_compliance_operator_rules/migration.go
+++ b/migrator/migrations/n_15_to_n_16_postgres_compliance_operator_rules/migration.go
@@ -21,7 +21,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 15,
-		VersionAfter:   storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 16},
+		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 16},
 		Run: func(databases *types.Databases) error {
 			legacyStore, err := legacy.New(databases.PkgRocksDB)
 			if err != nil {

--- a/migrator/migrations/n_16_to_n_17_postgres_compliance_operator_scan_setting_bindings/migration.go
+++ b/migrator/migrations/n_16_to_n_17_postgres_compliance_operator_scan_setting_bindings/migration.go
@@ -21,7 +21,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 16,
-		VersionAfter:   storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 17},
+		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 17},
 		Run: func(databases *types.Databases) error {
 			legacyStore, err := legacy.New(databases.PkgRocksDB)
 			if err != nil {

--- a/migrator/migrations/n_17_to_n_18_postgres_compliance_operator_scans/migration.go
+++ b/migrator/migrations/n_17_to_n_18_postgres_compliance_operator_scans/migration.go
@@ -21,7 +21,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 17,
-		VersionAfter:   storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 18},
+		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 18},
 		Run: func(databases *types.Databases) error {
 			legacyStore, err := legacy.New(databases.PkgRocksDB)
 			if err != nil {

--- a/migrator/migrations/n_18_to_n_19_postgres_compliance_run_metadata/migration.go
+++ b/migrator/migrations/n_18_to_n_19_postgres_compliance_run_metadata/migration.go
@@ -21,7 +21,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 18,
-		VersionAfter:   storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 19},
+		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 19},
 		Run: func(databases *types.Databases) error {
 			legacyStore, err := legacy.New(databases.PkgRocksDB)
 			if err != nil {

--- a/migrator/migrations/n_19_to_n_20_postgres_compliance_run_results/migration.go
+++ b/migrator/migrations/n_19_to_n_20_postgres_compliance_run_results/migration.go
@@ -21,7 +21,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 19,
-		VersionAfter:   storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 20},
+		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 20},
 		Run: func(databases *types.Databases) error {
 			legacyStore, err := legacy.New(databases.PkgRocksDB)
 			if err != nil {

--- a/migrator/migrations/n_20_to_n_21_postgres_compliance_strings/migration.go
+++ b/migrator/migrations/n_20_to_n_21_postgres_compliance_strings/migration.go
@@ -21,7 +21,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 20,
-		VersionAfter:   storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 21},
+		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 21},
 		Run: func(databases *types.Databases) error {
 			legacyStore, err := legacy.New(databases.PkgRocksDB)
 			if err != nil {

--- a/migrator/migrations/n_21_to_n_22_postgres_configs/migration.go
+++ b/migrator/migrations/n_21_to_n_22_postgres_configs/migration.go
@@ -21,7 +21,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 21,
-		VersionAfter:   storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 22},
+		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 22},
 		Run: func(databases *types.Databases) error {
 			legacyStore := legacy.New(databases.BoltDB)
 			if err := move(databases.GormDB, databases.PostgresDB, legacyStore); err != nil {

--- a/migrator/migrations/n_22_to_n_23_postgres_external_backups/migration.go
+++ b/migrator/migrations/n_22_to_n_23_postgres_external_backups/migration.go
@@ -21,7 +21,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 22,
-		VersionAfter:   storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 23},
+		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 23},
 		Run: func(databases *types.Databases) error {
 			legacyStore := legacy.New(databases.BoltDB)
 			if err := move(databases.GormDB, databases.PostgresDB, legacyStore); err != nil {

--- a/migrator/migrations/n_23_to_n_24_postgres_image_integrations/migration.go
+++ b/migrator/migrations/n_23_to_n_24_postgres_image_integrations/migration.go
@@ -21,7 +21,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 23,
-		VersionAfter:   storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 24},
+		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 24},
 		Run: func(databases *types.Databases) error {
 			legacyStore := legacy.New(databases.BoltDB)
 			if err := move(databases.GormDB, databases.PostgresDB, legacyStore); err != nil {

--- a/migrator/migrations/n_24_to_n_25_postgres_installation_infos/migration.go
+++ b/migrator/migrations/n_24_to_n_25_postgres_installation_infos/migration.go
@@ -21,7 +21,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 24,
-		VersionAfter:   storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 25},
+		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 25},
 		Run: func(databases *types.Databases) error {
 			legacyStore := legacy.New(databases.BoltDB)
 			if err := move(databases.GormDB, databases.PostgresDB, legacyStore); err != nil {

--- a/migrator/migrations/n_25_to_n_26_postgres_integration_healths/migration.go
+++ b/migrator/migrations/n_25_to_n_26_postgres_integration_healths/migration.go
@@ -21,7 +21,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 25,
-		VersionAfter:   storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 26},
+		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 26},
 		Run: func(databases *types.Databases) error {
 			legacyStore, err := legacy.New(databases.PkgRocksDB)
 			if err != nil {

--- a/migrator/migrations/n_26_to_n_27_postgres_k8s_roles/migration.go
+++ b/migrator/migrations/n_26_to_n_27_postgres_k8s_roles/migration.go
@@ -21,7 +21,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 26,
-		VersionAfter:   storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 27},
+		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 27},
 		Run: func(databases *types.Databases) error {
 			legacyStore, err := legacy.New(databases.PkgRocksDB)
 			if err != nil {

--- a/migrator/migrations/n_27_to_n_28_postgres_log_imbues/migration.go
+++ b/migrator/migrations/n_27_to_n_28_postgres_log_imbues/migration.go
@@ -23,7 +23,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 27,
-		VersionAfter:   storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 28},
+		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 28},
 		Run: func(databases *types.Databases) error {
 			legacyStore := legacy.New(databases.BoltDB)
 			if err := move(databases.GormDB, databases.PostgresDB, legacyStore); err != nil {

--- a/migrator/migrations/n_28_to_n_29_postgres_network_baselines/migration.go
+++ b/migrator/migrations/n_28_to_n_29_postgres_network_baselines/migration.go
@@ -21,7 +21,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 28,
-		VersionAfter:   storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 29},
+		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 29},
 		Run: func(databases *types.Databases) error {
 			legacyStore, err := legacy.New(databases.PkgRocksDB)
 			if err != nil {

--- a/migrator/migrations/n_29_to_n_30_postgres_network_entities/migration.go
+++ b/migrator/migrations/n_29_to_n_30_postgres_network_entities/migration.go
@@ -21,7 +21,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 29,
-		VersionAfter:   storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 30},
+		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 30},
 		Run: func(databases *types.Databases) error {
 			legacyStore, err := legacy.New(databases.PkgRocksDB)
 			if err != nil {

--- a/migrator/migrations/n_30_to_n_31_postgres_network_flows/legacy/cluster_impl.go
+++ b/migrator/migrations/n_30_to_n_31_postgres_network_flows/legacy/cluster_impl.go
@@ -34,7 +34,7 @@ func (s *clusterStoreImpl) GetFlowStore(clusterID string) store.FlowStore {
 }
 
 // Walk walks through all flows in cluster store
-func (s *clusterStoreImpl) Walk(ctx context.Context, fn func(clusterID string, ts types.Timestamp, allFlows []*storage.NetworkFlow) error) error {
+func (s *clusterStoreImpl) Walk(ctx context.Context, fn func(clusterID string, ts *types.Timestamp, allFlows []*storage.NetworkFlow) error) error {
 	iterator := s.db.NewIterator(readOptions)
 	defer iterator.Close()
 	// Runs are sorted by time, so we must iterate over each key to see if it has the correct run ID.

--- a/migrator/migrations/n_30_to_n_31_postgres_network_flows/legacy/flow_impl.go
+++ b/migrator/migrations/n_30_to_n_31_postgres_network_flows/legacy/flow_impl.go
@@ -30,9 +30,9 @@ var (
 )
 
 // GetAllFlows returns all the flows in the store.
-func (s *flowStoreImpl) GetAllFlows(ctx context.Context, since *types.Timestamp) (flows []*storage.NetworkFlow, ts types.Timestamp, err error) {
+func (s *flowStoreImpl) GetAllFlows(ctx context.Context, since *types.Timestamp) (flows []*storage.NetworkFlow, ts *types.Timestamp, err error) {
 	if err := s.db.IncRocksDBInProgressOps(); err != nil {
-		return nil, types.Timestamp{}, err
+		return nil, nil, err
 	}
 	defer s.db.DecRocksDBInProgressOps()
 
@@ -79,13 +79,13 @@ func (s *flowStoreImpl) getID(props *storage.NetworkFlowProperties) []byte {
 	return s.getFullKey(common.GetID(props))
 }
 
-func (s *flowStoreImpl) readFlows(pred func(*storage.NetworkFlowProperties) bool, since *types.Timestamp) (flows []*storage.NetworkFlow, lastUpdateTS types.Timestamp, err error) {
+func (s *flowStoreImpl) readFlows(pred func(*storage.NetworkFlowProperties) bool, since *types.Timestamp) (flows []*storage.NetworkFlow, lastUpdateTS *types.Timestamp, err error) {
 	// The entry for this should be present, but make sure we have a sane default if it is not
-	lastUpdateTS = *types.TimestampNow()
+	lastUpdateTS = types.TimestampNow()
 
 	err = generic.DefaultForEachItemWithPrefix(s.db, s.keyPrefix, true, func(k, v []byte) error {
 		if bytes.Equal(k, updatedTSKey) {
-			return proto.Unmarshal(v, &lastUpdateTS)
+			return proto.Unmarshal(v, lastUpdateTS)
 		}
 		if pred != nil {
 			props, err := common.ParseID(k)

--- a/migrator/migrations/n_30_to_n_31_postgres_network_flows/migration.go
+++ b/migrator/migrations/n_30_to_n_31_postgres_network_flows/migration.go
@@ -24,7 +24,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 30,
-		VersionAfter:   storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 31},
+		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 31},
 		Run: func(databases *types.Databases) error {
 			legacyStore := legacy.NewClusterStore(databases.PkgRocksDB)
 			if err := move(databases.GormDB, databases.PostgresDB, legacyStore); err != nil {
@@ -43,9 +43,9 @@ func move(gormDB *gorm.DB, postgresDB *pgxpool.Pool, legacyStore store.ClusterSt
 
 	clusterStore := pgStore.NewClusterStore(postgresDB)
 
-	return legacyStore.Walk(ctx, func(clusterID string, ts protoTypes.Timestamp, allFlows []*storage.NetworkFlow) error {
+	return legacyStore.Walk(ctx, func(clusterID string, ts *protoTypes.Timestamp, allFlows []*storage.NetworkFlow) error {
 		store := clusterStore.GetFlowStore(clusterID)
-		return store.UpsertFlows(ctx, allFlows, timestamp.FromProtobuf(&ts))
+		return store.UpsertFlows(ctx, allFlows, timestamp.FromProtobuf(ts))
 	})
 }
 

--- a/migrator/migrations/n_30_to_n_31_postgres_network_flows/postgres/cluster_impl.go
+++ b/migrator/migrations/n_30_to_n_31_postgres_network_flows/postgres/cluster_impl.go
@@ -39,7 +39,7 @@ func (s *clusterStoreImpl) CreateFlowStore(_ context.Context, clusterID string) 
 }
 
 // Walk is a stub for satisfying interfaces
-func (s *clusterStoreImpl) Walk(_ context.Context, _ func(clusterID string, _ types.Timestamp, _ []*storage.NetworkFlow) error) error {
+func (s *clusterStoreImpl) Walk(_ context.Context, _ func(clusterID string, _ *types.Timestamp, _ []*storage.NetworkFlow) error) error {
 	utils.CrashOnError(errors.New("Unexpected call to stub interface"))
 	return nil
 }

--- a/migrator/migrations/n_30_to_n_31_postgres_network_flows/store/store.go
+++ b/migrator/migrations/n_30_to_n_31_postgres_network_flows/store/store.go
@@ -11,11 +11,11 @@ import (
 // ClusterStore stores the network edges per cluster.
 type ClusterStore interface {
 	GetFlowStore(clusterID string) FlowStore
-	Walk(ctx context.Context, fn func(clusterID string, ts types.Timestamp, allFlows []*storage.NetworkFlow) error) error
+	Walk(ctx context.Context, fn func(clusterID string, ts *types.Timestamp, allFlows []*storage.NetworkFlow) error) error
 }
 
 // FlowStore stores all the flows for a single cluster.
 type FlowStore interface {
-	GetAllFlows(ctx context.Context, since *types.Timestamp) ([]*storage.NetworkFlow, types.Timestamp, error)
+	GetAllFlows(ctx context.Context, since *types.Timestamp) ([]*storage.NetworkFlow, *types.Timestamp, error)
 	UpsertFlows(ctx context.Context, flows []*storage.NetworkFlow, lastUpdateTS timestamp.MicroTS) error
 }

--- a/migrator/migrations/n_31_to_n_32_postgres_network_graph_configs/migration.go
+++ b/migrator/migrations/n_31_to_n_32_postgres_network_graph_configs/migration.go
@@ -21,7 +21,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 31,
-		VersionAfter:   storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 32},
+		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 32},
 		Run: func(databases *types.Databases) error {
 			legacyStore, err := legacy.New(databases.PkgRocksDB)
 			if err != nil {

--- a/migrator/migrations/n_32_to_n_33_postgres_networkpolicies/migration.go
+++ b/migrator/migrations/n_32_to_n_33_postgres_networkpolicies/migration.go
@@ -21,7 +21,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 32,
-		VersionAfter:   storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 33},
+		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 33},
 		Run: func(databases *types.Databases) error {
 			legacyStore := legacy.New(databases.BoltDB)
 			if err := move(databases.GormDB, databases.PostgresDB, legacyStore); err != nil {

--- a/migrator/migrations/n_33_to_n_34_postgres_networkpoliciesundodeployments/migration.go
+++ b/migrator/migrations/n_33_to_n_34_postgres_networkpoliciesundodeployments/migration.go
@@ -21,7 +21,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 33,
-		VersionAfter:   storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 34},
+		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 34},
 		Run: func(databases *types.Databases) error {
 			legacyStore, err := legacy.New(databases.PkgRocksDB)
 			if err != nil {

--- a/migrator/migrations/n_34_to_n_35_postgres_networkpolicyapplicationundorecords/migration.go
+++ b/migrator/migrations/n_34_to_n_35_postgres_networkpolicyapplicationundorecords/migration.go
@@ -21,7 +21,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 34,
-		VersionAfter:   storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 35},
+		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 35},
 		Run: func(databases *types.Databases) error {
 			legacyStore := legacy.New(databases.BoltDB)
 			if err := move(databases.GormDB, databases.PostgresDB, legacyStore); err != nil {

--- a/migrator/migrations/n_35_to_n_36_postgres_nodes/migration.go
+++ b/migrator/migrations/n_35_to_n_36_postgres_nodes/migration.go
@@ -24,7 +24,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 35,
-		VersionAfter:   storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 36},
+		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 36},
 		Run: func(databases *types.Databases) error {
 			legacyStore := legacy.New(rawDackbox.GetGlobalDackBox(), rawDackbox.GetKeyFence(), true)
 			if err := move(databases.GormDB, databases.PostgresDB, legacyStore); err != nil {

--- a/migrator/migrations/n_36_to_n_37_postgres_notifiers/migration.go
+++ b/migrator/migrations/n_36_to_n_37_postgres_notifiers/migration.go
@@ -21,7 +21,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 36,
-		VersionAfter:   storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 37},
+		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 37},
 		Run: func(databases *types.Databases) error {
 			legacyStore := legacy.New(databases.BoltDB)
 			if err := move(databases.GormDB, databases.PostgresDB, legacyStore); err != nil {

--- a/migrator/migrations/n_37_to_n_38_postgres_permission_sets/migration.go
+++ b/migrator/migrations/n_37_to_n_38_postgres_permission_sets/migration.go
@@ -21,7 +21,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 37,
-		VersionAfter:   storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 38},
+		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 38},
 		Run: func(databases *types.Databases) error {
 			legacyStore, err := legacy.New(databases.PkgRocksDB)
 			if err != nil {

--- a/migrator/migrations/n_38_to_n_39_postgres_pods/migration.go
+++ b/migrator/migrations/n_38_to_n_39_postgres_pods/migration.go
@@ -21,7 +21,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 38,
-		VersionAfter:   storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 39},
+		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 39},
 		Run: func(databases *types.Databases) error {
 			legacyStore, err := legacy.New(databases.PkgRocksDB)
 			if err != nil {

--- a/migrator/migrations/n_39_to_n_40_postgres_policies/migration.go
+++ b/migrator/migrations/n_39_to_n_40_postgres_policies/migration.go
@@ -21,7 +21,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 39,
-		VersionAfter:   storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 40},
+		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 40},
 		Run: func(databases *types.Databases) error {
 			legacyStore := legacy.New(databases.BoltDB)
 			if err := move(databases.GormDB, databases.PostgresDB, legacyStore); err != nil {

--- a/migrator/migrations/n_40_to_n_41_postgres_process_baseline_results/migration.go
+++ b/migrator/migrations/n_40_to_n_41_postgres_process_baseline_results/migration.go
@@ -21,7 +21,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 40,
-		VersionAfter:   storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 41},
+		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 41},
 		Run: func(databases *types.Databases) error {
 			legacyStore, err := legacy.New(databases.PkgRocksDB)
 			if err != nil {

--- a/migrator/migrations/n_41_to_n_42_postgres_process_baselines/migration.go
+++ b/migrator/migrations/n_41_to_n_42_postgres_process_baselines/migration.go
@@ -21,7 +21,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 41,
-		VersionAfter:   storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 42},
+		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 42},
 		Run: func(databases *types.Databases) error {
 			legacyStore, err := legacy.New(databases.PkgRocksDB)
 			if err != nil {

--- a/migrator/migrations/n_42_to_n_43_postgres_process_indicators/migration.go
+++ b/migrator/migrations/n_42_to_n_43_postgres_process_indicators/migration.go
@@ -21,7 +21,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 42,
-		VersionAfter:   storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 43},
+		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 43},
 		Run: func(databases *types.Databases) error {
 			legacyStore, err := legacy.New(databases.PkgRocksDB)
 			if err != nil {

--- a/migrator/migrations/n_43_to_n_44_postgres_report_configurations/migration.go
+++ b/migrator/migrations/n_43_to_n_44_postgres_report_configurations/migration.go
@@ -21,7 +21,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 43,
-		VersionAfter:   storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 44},
+		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 44},
 		Run: func(databases *types.Databases) error {
 			legacyStore, err := legacy.New(databases.PkgRocksDB)
 			if err != nil {

--- a/migrator/migrations/n_44_to_n_45_postgres_risks/migration.go
+++ b/migrator/migrations/n_44_to_n_45_postgres_risks/migration.go
@@ -21,7 +21,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 44,
-		VersionAfter:   storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 45},
+		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 45},
 		Run: func(databases *types.Databases) error {
 			legacyStore, err := legacy.New(databases.PkgRocksDB)
 			if err != nil {

--- a/migrator/migrations/n_45_to_n_46_postgres_role_bindings/migration.go
+++ b/migrator/migrations/n_45_to_n_46_postgres_role_bindings/migration.go
@@ -21,7 +21,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 45,
-		VersionAfter:   storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 46},
+		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 46},
 		Run: func(databases *types.Databases) error {
 			legacyStore, err := legacy.New(databases.PkgRocksDB)
 			if err != nil {

--- a/migrator/migrations/n_46_to_n_47_postgres_roles/migration.go
+++ b/migrator/migrations/n_46_to_n_47_postgres_roles/migration.go
@@ -21,7 +21,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 46,
-		VersionAfter:   storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 47},
+		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 47},
 		Run: func(databases *types.Databases) error {
 			legacyStore, err := legacy.New(databases.PkgRocksDB)
 			if err != nil {

--- a/migrator/migrations/n_47_to_n_48_postgres_secrets/migration.go
+++ b/migrator/migrations/n_47_to_n_48_postgres_secrets/migration.go
@@ -21,7 +21,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 47,
-		VersionAfter:   storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 48},
+		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 48},
 		Run: func(databases *types.Databases) error {
 			legacyStore, err := legacy.New(databases.PkgRocksDB)
 			if err != nil {

--- a/migrator/migrations/n_48_to_n_49_postgres_sensor_upgrade_configs/migration.go
+++ b/migrator/migrations/n_48_to_n_49_postgres_sensor_upgrade_configs/migration.go
@@ -21,7 +21,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 48,
-		VersionAfter:   storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 49},
+		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 49},
 		Run: func(databases *types.Databases) error {
 			legacyStore := legacy.New(databases.BoltDB)
 			if err := move(databases.GormDB, databases.PostgresDB, legacyStore); err != nil {

--- a/migrator/migrations/n_49_to_n_50_postgres_service_accounts/migration.go
+++ b/migrator/migrations/n_49_to_n_50_postgres_service_accounts/migration.go
@@ -21,7 +21,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 49,
-		VersionAfter:   storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 50},
+		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 50},
 		Run: func(databases *types.Databases) error {
 			legacyStore, err := legacy.New(databases.PkgRocksDB)
 			if err != nil {

--- a/migrator/migrations/n_50_to_n_51_postgres_service_identities/migration.go
+++ b/migrator/migrations/n_50_to_n_51_postgres_service_identities/migration.go
@@ -21,7 +21,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 50,
-		VersionAfter:   storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 51},
+		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 51},
 		Run: func(databases *types.Databases) error {
 			legacyStore := legacy.New(databases.BoltDB)
 			if err := move(databases.GormDB, databases.PostgresDB, legacyStore); err != nil {

--- a/migrator/migrations/n_51_to_n_52_postgres_signature_integrations/migration.go
+++ b/migrator/migrations/n_51_to_n_52_postgres_signature_integrations/migration.go
@@ -21,7 +21,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 51,
-		VersionAfter:   storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 52},
+		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 52},
 		Run: func(databases *types.Databases) error {
 			legacyStore, err := legacy.New(databases.PkgRocksDB)
 			if err != nil {

--- a/migrator/migrations/n_52_to_n_53_postgres_simple_access_scopes/migration.go
+++ b/migrator/migrations/n_52_to_n_53_postgres_simple_access_scopes/migration.go
@@ -21,7 +21,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 52,
-		VersionAfter:   storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 53},
+		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 53},
 		Run: func(databases *types.Databases) error {
 			legacyStore, err := legacy.New(databases.PkgRocksDB)
 			if err != nil {

--- a/migrator/migrations/n_53_to_n_54_postgres_vulnerability_requests/migration.go
+++ b/migrator/migrations/n_53_to_n_54_postgres_vulnerability_requests/migration.go
@@ -21,7 +21,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 53,
-		VersionAfter:   storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 54},
+		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 54},
 		Run: func(databases *types.Databases) error {
 			legacyStore, err := legacy.New(databases.PkgRocksDB)
 			if err != nil {

--- a/migrator/migrations/n_54_to_n_55_postgres_watched_images/migration.go
+++ b/migrator/migrations/n_54_to_n_55_postgres_watched_images/migration.go
@@ -21,7 +21,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 54,
-		VersionAfter:   storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 55},
+		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 55},
 		Run: func(databases *types.Databases) error {
 			legacyStore, err := legacy.New(databases.PkgRocksDB)
 			if err != nil {

--- a/migrator/migrations/n_55_to_n_56_postgres_policy_categories/migration.go
+++ b/migrator/migrations/n_55_to_n_56_postgres_policy_categories/migration.go
@@ -21,7 +21,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 55,
-		VersionAfter:   storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 56},
+		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 56},
 		Run: func(databases *types.Databases) error {
 			legacyStore, err := legacy.New(databases.PkgRocksDB)
 			if err != nil {

--- a/migrator/migrations/n_56_to_n_57_postgres_groups/migration.go
+++ b/migrator/migrations/n_56_to_n_57_postgres_groups/migration.go
@@ -21,7 +21,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 56,
-		VersionAfter:   storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 57},
+		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 57},
 		Run: func(databases *types.Databases) error {
 			legacyStore := legacy.New(databases.BoltDB)
 			if err := move(databases.GormDB, databases.PostgresDB, legacyStore); err != nil {

--- a/migrator/runner/runner.go
+++ b/migrator/runner/runner.go
@@ -54,7 +54,7 @@ func runMigrations(databases *types.Databases, startingSeqNum int) error {
 			return errors.Wrapf(err, "error running migration starting at %d", seqNum)
 		}
 
-		err = updateVersion(databases, &migration.VersionAfter)
+		err = updateVersion(databases, migration.VersionAfter)
 		if err != nil {
 			return errors.Wrapf(err, "failed to update version after migration %d", seqNum)
 		}

--- a/migrator/types/migration.go
+++ b/migrator/types/migration.go
@@ -36,5 +36,5 @@ type Migration struct {
 	// The seq num in VersionAfter MUST be one greater than the StartingSeqNum of this migration.
 	// All other (optional) metadata can be whatever the user desires, and has no bearing on the
 	// functioning of the migrator.
-	VersionAfter storage.Version
+	VersionAfter *storage.Version
 }

--- a/pkg/auth/authproviders/provider.go
+++ b/pkg/auth/authproviders/provider.go
@@ -51,7 +51,9 @@ type Provider interface {
 
 // NewProvider creates a new provider with the input options.
 func NewProvider(options ...ProviderOption) (Provider, error) {
-	provider := &providerImpl{}
+	provider := &providerImpl{
+		storedInfo: &storage.AuthProvider{},
+	}
 	if err := applyOptions(provider, options...); err != nil {
 		return nil, err
 	}
@@ -73,10 +75,10 @@ func applyOptions(provider *providerImpl, options ...ProviderOption) error {
 
 // Input provider must be locked when run.
 func validateProvider(provider *providerImpl) error {
-	if provider.storedInfo.Id == "" {
+	if provider.storedInfo.GetId() == "" {
 		return errors.New("auth providers must have an id")
 	}
-	if provider.storedInfo.Name == "" {
+	if provider.storedInfo.GetName() == "" {
 		return errors.New("auth providers must have a name")
 	}
 	return nil

--- a/pkg/auth/authproviders/provider_commands.go
+++ b/pkg/auth/authproviders/provider_commands.go
@@ -19,7 +19,7 @@ func DefaultAddToStore(ctx context.Context, store Store) ProviderOption {
 		if pr.doNotStore {
 			return nil
 		}
-		return store.AddAuthProvider(ctx, &pr.storedInfo)
+		return store.AddAuthProvider(ctx, pr.storedInfo)
 	}
 }
 
@@ -29,7 +29,7 @@ func UpdateStore(ctx context.Context, store Store) ProviderOption {
 		if pr.doNotStore {
 			return nil
 		}
-		return store.UpdateAuthProvider(ctx, &pr.storedInfo)
+		return store.UpdateAuthProvider(ctx, pr.storedInfo)
 	}
 }
 
@@ -47,8 +47,8 @@ func DeleteFromStore(ctx context.Context, store Store, providerID string, force 
 		}
 		// a deleted provider should no longer be accessible, but it's still cached as a token source so mark it as
 		// no longer valid
-		pr.storedInfo = storage.AuthProvider{
-			Id:      pr.storedInfo.Id,
+		pr.storedInfo = &storage.AuthProvider{
+			Id:      pr.storedInfo.GetId(),
 			Enabled: false,
 		}
 		return nil

--- a/pkg/auth/authproviders/provider_default_options.go
+++ b/pkg/auth/authproviders/provider_default_options.go
@@ -16,8 +16,11 @@ import (
 // DefaultNewID sets the id of the provider to a new value if not already set.
 func DefaultNewID() ProviderOption {
 	return func(pr *providerImpl) error {
-		if pr.storedInfo.Id != "" {
+		if pr.storedInfo.GetId() != "" {
 			return nil
+		}
+		if pr.storedInfo == nil {
+			return errors.New("no storage information for auth provider")
 		}
 		pr.storedInfo.Id = uuid.NewV4().String()
 		return nil
@@ -27,9 +30,13 @@ func DefaultNewID() ProviderOption {
 // DefaultLoginURL fills in the login url if not set using a function that creates a url for the provider id.
 func DefaultLoginURL(fn func(authProviderID string) string) ProviderOption {
 	return func(pr *providerImpl) error {
-		if pr.storedInfo.LoginUrl == "" {
-			pr.storedInfo.LoginUrl = fn(pr.storedInfo.Id)
+		if pr.storedInfo.GetLoginUrl() != "" {
+			return nil
 		}
+		if pr.storedInfo == nil {
+			return errors.New("no storage information for auth provider")
+		}
+		pr.storedInfo.LoginUrl = fn(pr.storedInfo.Id)
 		return nil
 	}
 }
@@ -57,10 +64,10 @@ func DefaultRoleMapperOption(fn func(id string) permissions.RoleMapper) Provider
 		if pr.roleMapper != nil {
 			return nil
 		}
-		if pr.storedInfo.Id == "" {
+		if pr.storedInfo.GetId() == "" {
 			return nil
 		}
-		pr.roleMapper = fn(pr.storedInfo.Id)
+		pr.roleMapper = fn(pr.storedInfo.GetId())
 		return nil
 	}
 }
@@ -73,19 +80,20 @@ func DefaultBackend(ctx context.Context, backendFactoryPool map[string]BackendFa
 		}
 
 		// Get the backend factory for the type of provider.
-		backendFactory := backendFactoryPool[pr.storedInfo.Type]
+		backendFactory := backendFactoryPool[pr.storedInfo.GetType()]
 		if backendFactory == nil {
-			return errors.Errorf("provider type %q is either unknown, no longer available, or incompatible with this installation", pr.storedInfo.Type)
+			return errors.Errorf("provider type %q is either unknown, no longer available, or incompatible with this installation", pr.storedInfo.GetType())
 		}
 
 		pr.backendFactory = backendFactory
 
 		// Create the backend for the provider.
-		backend, err := backendFactory.CreateBackend(ctx, pr.storedInfo.Id, AllUIEndpoints(&pr.storedInfo), pr.storedInfo.Config, pr.storedInfo.ClaimMappings)
+		backend, err := backendFactory.CreateBackend(ctx, pr.storedInfo.GetId(), AllUIEndpoints(pr.storedInfo), pr.storedInfo.GetConfig(), pr.storedInfo.GetClaimMappings())
 		if err != nil {
-			return errors.Wrapf(err, "unable to create backend for provider id %s", pr.storedInfo.Id)
+			return errors.Wrapf(err, "unable to create backend for provider id %s", pr.storedInfo.GetId())
 		}
 		pr.backend = backend
+		// We can assume that pr.storedInfo is non-nil here because pr.storedInfo.GetType() referenced a valid auth provider type.
 		pr.storedInfo.Config = backend.Config()
 		return nil
 	}

--- a/pkg/auth/authproviders/provider_options.go
+++ b/pkg/auth/authproviders/provider_options.go
@@ -27,9 +27,9 @@ func WithBackendFromFactory(ctx context.Context, factory BackendFactory) Provide
 	return func(pr *providerImpl) error {
 		pr.backendFactory = factory
 
-		backend, err := factory.CreateBackend(ctx, pr.storedInfo.Id, AllUIEndpoints(&pr.storedInfo), pr.storedInfo.Config, nil)
+		backend, err := factory.CreateBackend(ctx, pr.storedInfo.GetId(), AllUIEndpoints(pr.storedInfo), pr.storedInfo.GetConfig(), nil)
 		if err != nil {
-			return errors.Wrapf(err, "failed to create auth provider of type %s", pr.storedInfo.Type)
+			return errors.Wrapf(err, "failed to create auth provider of type %s", pr.storedInfo.GetType())
 		}
 
 		pr.backend = backend
@@ -57,7 +57,7 @@ func WithRoleMapper(roleMapper permissions.RoleMapper) ProviderOption {
 // WithStorageView sets the values in the store auth provider from the input value.
 func WithStorageView(stored *storage.AuthProvider) ProviderOption {
 	return func(pr *providerImpl) error {
-		pr.storedInfo = *stored
+		pr.storedInfo = stored.Clone()
 		return nil
 	}
 }
@@ -65,6 +65,9 @@ func WithStorageView(stored *storage.AuthProvider) ProviderOption {
 // WithID sets the id for the provider to the input value.
 func WithID(id string) ProviderOption {
 	return func(pr *providerImpl) error {
+		if pr.storedInfo == nil {
+			return errors.New("UNEXPECTED: no storage data for auth provider")
+		}
 		pr.storedInfo.Id = id
 		return nil
 	}
@@ -73,6 +76,9 @@ func WithID(id string) ProviderOption {
 // WithType sets the type for the provider.
 func WithType(typ string) ProviderOption {
 	return func(pr *providerImpl) error {
+		if pr.storedInfo == nil {
+			return errors.New("UNEXPECTED: no storage data for auth provider")
+		}
 		pr.storedInfo.Type = typ
 		return nil
 	}
@@ -81,6 +87,9 @@ func WithType(typ string) ProviderOption {
 // WithName sets the name for the provider.
 func WithName(name string) ProviderOption {
 	return func(pr *providerImpl) error {
+		if pr.storedInfo == nil {
+			return errors.New("UNEXPECTED: no storage data for auth provider")
+		}
 		pr.storedInfo.Name = name
 		return nil
 	}
@@ -89,6 +98,9 @@ func WithName(name string) ProviderOption {
 // WithEnabled sets the enabled flag for the provider.
 func WithEnabled(enabled bool) ProviderOption {
 	return func(pr *providerImpl) error {
+		if pr.storedInfo == nil {
+			return errors.New("UNEXPECTED: no storage data for auth provider")
+		}
 		pr.storedInfo.Enabled = enabled
 		return nil
 	}
@@ -107,6 +119,9 @@ func WithValidateCallback(store Store) ProviderOption {
 // WithActive sets the active flag for the provider.
 func WithActive(active bool) ProviderOption {
 	return func(pr *providerImpl) error {
+		if pr.storedInfo == nil {
+			return errors.New("UNEXPECTED: no storage data for auth provider")
+		}
 		pr.storedInfo.Validated = active
 		pr.storedInfo.Active = active
 		return nil
@@ -116,6 +131,9 @@ func WithActive(active bool) ProviderOption {
 // WithConfig sets the config for the provider.
 func WithConfig(config map[string]string) ProviderOption {
 	return func(pr *providerImpl) error {
+		if pr.storedInfo == nil {
+			return errors.New("UNEXPECTED: no storage data for auth provider")
+		}
 		pr.storedInfo.Config = config
 		return nil
 	}
@@ -136,6 +154,9 @@ func WithAttributeVerifier(stored *storage.AuthProvider) ProviderOption {
 // WithVisibility sets the visibility for the auth provider.
 func WithVisibility(visibility storage.Traits_Visibility) ProviderOption {
 	return func(pr *providerImpl) error {
+		if pr.storedInfo == nil {
+			return errors.New("UNEXPECTED: no storage data for auth provider")
+		}
 		if pr.storedInfo.GetTraits() != nil {
 			pr.storedInfo.Traits.Visibility = visibility
 		} else {

--- a/pkg/compliance/compress/compress_easyjson.go
+++ b/pkg/compliance/compress/compress_easyjson.go
@@ -72,7 +72,7 @@ func easyjson24245084DecodeGithubComStackroxRoxPkgComplianceCompress(in *jlexer.
 		in.Consumed()
 	}
 }
-func easyjson24245084EncodeGithubComStackroxRoxPkgComplianceCompress(out *jwriter.Writer, in *ResultWrapper) {
+func easyjson24245084EncodeGithubComStackroxRoxPkgComplianceCompress(out *jwriter.Writer, in ResultWrapper) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -95,7 +95,7 @@ func easyjson24245084EncodeGithubComStackroxRoxPkgComplianceCompress(out *jwrite
 				if v2Value == nil {
 					out.RawString("null")
 				} else {
-					easyjson24245084EncodeGithubComStackroxRoxGeneratedInternalapiCompliance(out, &*v2Value)
+					easyjson24245084EncodeGithubComStackroxRoxGeneratedInternalapiCompliance(out, *v2Value)
 				}
 			}
 			out.RawByte('}')
@@ -105,14 +105,14 @@ func easyjson24245084EncodeGithubComStackroxRoxPkgComplianceCompress(out *jwrite
 }
 
 // MarshalJSON supports json.Marshaler interface
-func (v *ResultWrapper) MarshalJSON() ([]byte, error) {
+func (v ResultWrapper) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
 	easyjson24245084EncodeGithubComStackroxRoxPkgComplianceCompress(&w, v)
 	return w.Buffer.BuildBytes(), w.Error
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
-func (v *ResultWrapper) MarshalEasyJSON(w *jwriter.Writer) {
+func (v ResultWrapper) MarshalEasyJSON(w *jwriter.Writer) {
 	easyjson24245084EncodeGithubComStackroxRoxPkgComplianceCompress(w, v)
 }
 
@@ -212,7 +212,7 @@ func easyjson24245084DecodeGithubComStackroxRoxGeneratedInternalapiCompliance(in
 		in.Consumed()
 	}
 }
-func easyjson24245084EncodeGithubComStackroxRoxGeneratedInternalapiCompliance(out *jwriter.Writer, in *compliance.ComplianceStandardResult) {
+func easyjson24245084EncodeGithubComStackroxRoxGeneratedInternalapiCompliance(out *jwriter.Writer, in compliance.ComplianceStandardResult) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -234,7 +234,7 @@ func easyjson24245084EncodeGithubComStackroxRoxGeneratedInternalapiCompliance(ou
 				if v5Value == nil {
 					out.RawString("null")
 				} else {
-					easyjson24245084EncodeGithubComStackroxRoxGeneratedStorage(out, &*v5Value)
+					easyjson24245084EncodeGithubComStackroxRoxGeneratedStorage(out, *v5Value)
 				}
 			}
 			out.RawByte('}')
@@ -262,7 +262,7 @@ func easyjson24245084EncodeGithubComStackroxRoxGeneratedInternalapiCompliance(ou
 				if v6Value == nil {
 					out.RawString("null")
 				} else {
-					easyjson24245084EncodeGithubComStackroxRoxGeneratedStorage(out, &*v6Value)
+					easyjson24245084EncodeGithubComStackroxRoxGeneratedStorage(out, *v6Value)
 				}
 			}
 			out.RawByte('}')
@@ -332,7 +332,7 @@ func easyjson24245084DecodeGithubComStackroxRoxGeneratedStorage(in *jlexer.Lexer
 		in.Consumed()
 	}
 }
-func easyjson24245084EncodeGithubComStackroxRoxGeneratedStorage(out *jwriter.Writer, in *storage.ComplianceResultValue) {
+func easyjson24245084EncodeGithubComStackroxRoxGeneratedStorage(out *jwriter.Writer, in storage.ComplianceResultValue) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -349,7 +349,7 @@ func easyjson24245084EncodeGithubComStackroxRoxGeneratedStorage(out *jwriter.Wri
 				if v9 == nil {
 					out.RawString("null")
 				} else {
-					easyjson24245084EncodeGithubComStackroxRoxGeneratedStorageComplianceResultValue(out, &*v9)
+					easyjson24245084EncodeGithubComStackroxRoxGeneratedStorageComplianceResultValue(out, *v9)
 				}
 			}
 			out.RawByte(']')
@@ -402,7 +402,7 @@ func easyjson24245084DecodeGithubComStackroxRoxGeneratedStorageComplianceResultV
 		in.Consumed()
 	}
 }
-func easyjson24245084EncodeGithubComStackroxRoxGeneratedStorageComplianceResultValue(out *jwriter.Writer, in *storage.ComplianceResultValue_Evidence) {
+func easyjson24245084EncodeGithubComStackroxRoxGeneratedStorageComplianceResultValue(out *jwriter.Writer, in storage.ComplianceResultValue_Evidence) {
 	out.RawByte('{')
 	first := true
 	_ = first

--- a/pkg/compliance/compress/compress_easyjson.go
+++ b/pkg/compliance/compress/compress_easyjson.go
@@ -72,7 +72,7 @@ func easyjson24245084DecodeGithubComStackroxRoxPkgComplianceCompress(in *jlexer.
 		in.Consumed()
 	}
 }
-func easyjson24245084EncodeGithubComStackroxRoxPkgComplianceCompress(out *jwriter.Writer, in ResultWrapper) {
+func easyjson24245084EncodeGithubComStackroxRoxPkgComplianceCompress(out *jwriter.Writer, in *ResultWrapper) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -95,7 +95,7 @@ func easyjson24245084EncodeGithubComStackroxRoxPkgComplianceCompress(out *jwrite
 				if v2Value == nil {
 					out.RawString("null")
 				} else {
-					easyjson24245084EncodeGithubComStackroxRoxGeneratedInternalapiCompliance(out, *v2Value)
+					easyjson24245084EncodeGithubComStackroxRoxGeneratedInternalapiCompliance(out, &*v2Value)
 				}
 			}
 			out.RawByte('}')
@@ -105,14 +105,14 @@ func easyjson24245084EncodeGithubComStackroxRoxPkgComplianceCompress(out *jwrite
 }
 
 // MarshalJSON supports json.Marshaler interface
-func (v ResultWrapper) MarshalJSON() ([]byte, error) {
+func (v *ResultWrapper) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
 	easyjson24245084EncodeGithubComStackroxRoxPkgComplianceCompress(&w, v)
 	return w.Buffer.BuildBytes(), w.Error
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
-func (v ResultWrapper) MarshalEasyJSON(w *jwriter.Writer) {
+func (v *ResultWrapper) MarshalEasyJSON(w *jwriter.Writer) {
 	easyjson24245084EncodeGithubComStackroxRoxPkgComplianceCompress(w, v)
 }
 
@@ -212,7 +212,7 @@ func easyjson24245084DecodeGithubComStackroxRoxGeneratedInternalapiCompliance(in
 		in.Consumed()
 	}
 }
-func easyjson24245084EncodeGithubComStackroxRoxGeneratedInternalapiCompliance(out *jwriter.Writer, in compliance.ComplianceStandardResult) {
+func easyjson24245084EncodeGithubComStackroxRoxGeneratedInternalapiCompliance(out *jwriter.Writer, in *compliance.ComplianceStandardResult) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -234,7 +234,7 @@ func easyjson24245084EncodeGithubComStackroxRoxGeneratedInternalapiCompliance(ou
 				if v5Value == nil {
 					out.RawString("null")
 				} else {
-					easyjson24245084EncodeGithubComStackroxRoxGeneratedStorage(out, *v5Value)
+					easyjson24245084EncodeGithubComStackroxRoxGeneratedStorage(out, &*v5Value)
 				}
 			}
 			out.RawByte('}')
@@ -262,7 +262,7 @@ func easyjson24245084EncodeGithubComStackroxRoxGeneratedInternalapiCompliance(ou
 				if v6Value == nil {
 					out.RawString("null")
 				} else {
-					easyjson24245084EncodeGithubComStackroxRoxGeneratedStorage(out, *v6Value)
+					easyjson24245084EncodeGithubComStackroxRoxGeneratedStorage(out, &*v6Value)
 				}
 			}
 			out.RawByte('}')
@@ -332,7 +332,7 @@ func easyjson24245084DecodeGithubComStackroxRoxGeneratedStorage(in *jlexer.Lexer
 		in.Consumed()
 	}
 }
-func easyjson24245084EncodeGithubComStackroxRoxGeneratedStorage(out *jwriter.Writer, in storage.ComplianceResultValue) {
+func easyjson24245084EncodeGithubComStackroxRoxGeneratedStorage(out *jwriter.Writer, in *storage.ComplianceResultValue) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -349,7 +349,7 @@ func easyjson24245084EncodeGithubComStackroxRoxGeneratedStorage(out *jwriter.Wri
 				if v9 == nil {
 					out.RawString("null")
 				} else {
-					easyjson24245084EncodeGithubComStackroxRoxGeneratedStorageComplianceResultValue(out, *v9)
+					easyjson24245084EncodeGithubComStackroxRoxGeneratedStorageComplianceResultValue(out, &*v9)
 				}
 			}
 			out.RawByte(']')
@@ -402,7 +402,7 @@ func easyjson24245084DecodeGithubComStackroxRoxGeneratedStorageComplianceResultV
 		in.Consumed()
 	}
 }
-func easyjson24245084EncodeGithubComStackroxRoxGeneratedStorageComplianceResultValue(out *jwriter.Writer, in storage.ComplianceResultValue_Evidence) {
+func easyjson24245084EncodeGithubComStackroxRoxGeneratedStorageComplianceResultValue(out *jwriter.Writer, in *storage.ComplianceResultValue_Evidence) {
 	out.RawByte('{')
 	first := true
 	_ = first

--- a/pkg/docker/types/container_easyjson.go
+++ b/pkg/docker/types/container_easyjson.go
@@ -69,7 +69,7 @@ func easyjson1dbef17bDecodeGithubComStackroxRoxPkgDockerTypes(in *jlexer.Lexer, 
 		in.Consumed()
 	}
 }
-func easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes(out *jwriter.Writer, in *ContainerList) {
+func easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes(out *jwriter.Writer, in ContainerList) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -103,14 +103,14 @@ func easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes(out *jwriter.Write
 }
 
 // MarshalJSON supports json.Marshaler interface
-func (v *ContainerList) MarshalJSON() ([]byte, error) {
+func (v ContainerList) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
 	easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes(&w, v)
 	return w.Buffer.BuildBytes(), w.Error
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
-func (v *ContainerList) MarshalEasyJSON(w *jwriter.Writer) {
+func (v ContainerList) MarshalEasyJSON(w *jwriter.Writer) {
 	easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes(w, v)
 }
 
@@ -226,7 +226,7 @@ func easyjson1dbef17bDecodeGithubComStackroxRoxPkgDockerTypes1(in *jlexer.Lexer,
 		in.Consumed()
 	}
 }
-func easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes1(out *jwriter.Writer, in *ContainerJSON) {
+func easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes1(out *jwriter.Writer, in ContainerJSON) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -240,7 +240,7 @@ func easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes1(out *jwriter.Writ
 				if v4 > 0 {
 					out.RawByte(',')
 				}
-				easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes2(out, &v5)
+				easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes2(out, v5)
 			}
 			out.RawByte(']')
 		}
@@ -253,7 +253,7 @@ func easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes1(out *jwriter.Writ
 		} else {
 			out.RawString(prefix)
 		}
-		easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes3(out, &*in.Config)
+		easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes3(out, *in.Config)
 	}
 	if in.NetworkSettings != nil {
 		const prefix string = ",\"NetworkSettings\":"
@@ -263,7 +263,7 @@ func easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes1(out *jwriter.Writ
 		} else {
 			out.RawString(prefix)
 		}
-		easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes4(out, &*in.NetworkSettings)
+		easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes4(out, *in.NetworkSettings)
 	}
 	{
 		const prefix string = ",\"Id\":"
@@ -283,7 +283,7 @@ func easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes1(out *jwriter.Writ
 	if in.State != nil {
 		const prefix string = ",\"State\":"
 		out.RawString(prefix)
-		easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes5(out, &*in.State)
+		easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes5(out, *in.State)
 	}
 	if in.Name != "" {
 		const prefix string = ",\"Name\":"
@@ -298,20 +298,20 @@ func easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes1(out *jwriter.Writ
 	if in.HostConfig != nil {
 		const prefix string = ",\"HostConfig\":"
 		out.RawString(prefix)
-		easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes6(out, &*in.HostConfig)
+		easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes6(out, *in.HostConfig)
 	}
 	out.RawByte('}')
 }
 
 // MarshalJSON supports json.Marshaler interface
-func (v *ContainerJSON) MarshalJSON() ([]byte, error) {
+func (v ContainerJSON) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
 	easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes1(&w, v)
 	return w.Buffer.BuildBytes(), w.Error
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
-func (v *ContainerJSON) MarshalEasyJSON(w *jwriter.Writer) {
+func (v ContainerJSON) MarshalEasyJSON(w *jwriter.Writer) {
 	easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes1(w, v)
 }
 
@@ -464,7 +464,7 @@ func easyjson1dbef17bDecodeGithubComStackroxRoxPkgDockerTypes6(in *jlexer.Lexer,
 		in.Consumed()
 	}
 }
-func easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes6(out *jwriter.Writer, in *HostConfig) {
+func easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes6(out *jwriter.Writer, in HostConfig) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -539,7 +539,7 @@ func easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes6(out *jwriter.Writ
 		} else {
 			out.RawString(prefix)
 		}
-		easyjson1dbef17bEncodeGithubComDockerDockerApiTypesContainer(out, &in.RestartPolicy)
+		easyjson1dbef17bEncodeGithubComDockerDockerApiTypesContainer(out, in.RestartPolicy)
 	}
 	if in.IpcMode != "" {
 		const prefix string = ",\"IpcMode\":"
@@ -635,7 +635,7 @@ func easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes6(out *jwriter.Writ
 				if v15 > 0 {
 					out.RawByte(',')
 				}
-				easyjson1dbef17bEncodeGithubComDockerDockerApiTypesContainer1(out, &v16)
+				easyjson1dbef17bEncodeGithubComDockerDockerApiTypesContainer1(out, v16)
 			}
 			out.RawByte(']')
 		}
@@ -657,7 +657,7 @@ func easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes6(out *jwriter.Writ
 				if v18 == nil {
 					out.RawString("null")
 				} else {
-					easyjson1dbef17bEncodeGithubComDockerGoUnits(out, &*v18)
+					easyjson1dbef17bEncodeGithubComDockerGoUnits(out, *v18)
 				}
 			}
 			out.RawByte(']')
@@ -700,7 +700,7 @@ func easyjson1dbef17bDecodeGithubComDockerGoUnits(in *jlexer.Lexer, out *go_unit
 		in.Consumed()
 	}
 }
-func easyjson1dbef17bEncodeGithubComDockerGoUnits(out *jwriter.Writer, in *go_units.Ulimit) {
+func easyjson1dbef17bEncodeGithubComDockerGoUnits(out *jwriter.Writer, in go_units.Ulimit) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -756,7 +756,7 @@ func easyjson1dbef17bDecodeGithubComDockerDockerApiTypesContainer1(in *jlexer.Le
 		in.Consumed()
 	}
 }
-func easyjson1dbef17bEncodeGithubComDockerDockerApiTypesContainer1(out *jwriter.Writer, in *container.DeviceMapping) {
+func easyjson1dbef17bEncodeGithubComDockerDockerApiTypesContainer1(out *jwriter.Writer, in container.DeviceMapping) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -810,7 +810,7 @@ func easyjson1dbef17bDecodeGithubComDockerDockerApiTypesContainer(in *jlexer.Lex
 		in.Consumed()
 	}
 }
-func easyjson1dbef17bEncodeGithubComDockerDockerApiTypesContainer(out *jwriter.Writer, in *container.RestartPolicy) {
+func easyjson1dbef17bEncodeGithubComDockerDockerApiTypesContainer(out *jwriter.Writer, in container.RestartPolicy) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -867,7 +867,7 @@ func easyjson1dbef17bDecodeGithubComStackroxRoxPkgDockerTypes5(in *jlexer.Lexer,
 		in.Consumed()
 	}
 }
-func easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes5(out *jwriter.Writer, in *ContainerState) {
+func easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes5(out *jwriter.Writer, in ContainerState) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -885,7 +885,7 @@ func easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes5(out *jwriter.Writ
 		} else {
 			out.RawString(prefix)
 		}
-		easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes7(out, &*in.Health)
+		easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes7(out, *in.Health)
 	}
 	out.RawByte('}')
 }
@@ -920,7 +920,7 @@ func easyjson1dbef17bDecodeGithubComStackroxRoxPkgDockerTypes7(in *jlexer.Lexer,
 		in.Consumed()
 	}
 }
-func easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes7(out *jwriter.Writer, in *Health) {
+func easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes7(out *jwriter.Writer, in Health) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -1022,7 +1022,7 @@ func easyjson1dbef17bDecodeGithubComStackroxRoxPkgDockerTypes4(in *jlexer.Lexer,
 		in.Consumed()
 	}
 }
-func easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes4(out *jwriter.Writer, in *NetworkSettings) {
+func easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes4(out *jwriter.Writer, in NetworkSettings) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -1041,7 +1041,7 @@ func easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes4(out *jwriter.Writ
 				}
 				out.String(string(v22Name))
 				out.RawByte(':')
-				easyjson1dbef17bEncode(out, &v22Value)
+				easyjson1dbef17bEncode(out, v22Value)
 			}
 			out.RawByte('}')
 		}
@@ -1073,7 +1073,7 @@ func easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes4(out *jwriter.Writ
 						if v24 > 0 {
 							out.RawByte(',')
 						}
-						easyjson1dbef17bEncodeGithubComDockerGoConnectionsNat(out, &v25)
+						easyjson1dbef17bEncodeGithubComDockerGoConnectionsNat(out, v25)
 					}
 					out.RawByte(']')
 				}
@@ -1116,7 +1116,7 @@ func easyjson1dbef17bDecodeGithubComDockerGoConnectionsNat(in *jlexer.Lexer, out
 		in.Consumed()
 	}
 }
-func easyjson1dbef17bEncodeGithubComDockerGoConnectionsNat(out *jwriter.Writer, in *nat.PortBinding) {
+func easyjson1dbef17bEncodeGithubComDockerGoConnectionsNat(out *jwriter.Writer, in nat.PortBinding) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -1161,7 +1161,7 @@ func easyjson1dbef17bDecode(in *jlexer.Lexer, out *struct{}) {
 		in.Consumed()
 	}
 }
-func easyjson1dbef17bEncode(out *jwriter.Writer, in *struct{}) {
+func easyjson1dbef17bEncode(out *jwriter.Writer, in struct{}) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -1208,7 +1208,7 @@ func easyjson1dbef17bDecodeGithubComStackroxRoxPkgDockerTypes3(in *jlexer.Lexer,
 		in.Consumed()
 	}
 }
-func easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes3(out *jwriter.Writer, in *Config) {
+func easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes3(out *jwriter.Writer, in Config) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -1216,7 +1216,7 @@ func easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes3(out *jwriter.Writ
 		const prefix string = ",\"Healthcheck\":"
 		first = false
 		out.RawString(prefix[1:])
-		easyjson1dbef17bEncodeGithubComDockerDockerApiTypesContainer2(out, &*in.Healthcheck)
+		easyjson1dbef17bEncodeGithubComDockerDockerApiTypesContainer2(out, *in.Healthcheck)
 	}
 	if in.User != "" {
 		const prefix string = ",\"User\":"
@@ -1290,7 +1290,7 @@ func easyjson1dbef17bDecodeGithubComDockerDockerApiTypesContainer2(in *jlexer.Le
 		in.Consumed()
 	}
 }
-func easyjson1dbef17bEncodeGithubComDockerDockerApiTypesContainer2(out *jwriter.Writer, in *container.HealthConfig) {
+func easyjson1dbef17bEncodeGithubComDockerDockerApiTypesContainer2(out *jwriter.Writer, in container.HealthConfig) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -1394,7 +1394,7 @@ func easyjson1dbef17bDecodeGithubComStackroxRoxPkgDockerTypes2(in *jlexer.Lexer,
 		in.Consumed()
 	}
 }
-func easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes2(out *jwriter.Writer, in *MountPoint) {
+func easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes2(out *jwriter.Writer, in MountPoint) {
 	out.RawByte('{')
 	first := true
 	_ = first

--- a/pkg/docker/types/container_easyjson.go
+++ b/pkg/docker/types/container_easyjson.go
@@ -69,7 +69,7 @@ func easyjson1dbef17bDecodeGithubComStackroxRoxPkgDockerTypes(in *jlexer.Lexer, 
 		in.Consumed()
 	}
 }
-func easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes(out *jwriter.Writer, in ContainerList) {
+func easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes(out *jwriter.Writer, in *ContainerList) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -103,14 +103,14 @@ func easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes(out *jwriter.Write
 }
 
 // MarshalJSON supports json.Marshaler interface
-func (v ContainerList) MarshalJSON() ([]byte, error) {
+func (v *ContainerList) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
 	easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes(&w, v)
 	return w.Buffer.BuildBytes(), w.Error
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
-func (v ContainerList) MarshalEasyJSON(w *jwriter.Writer) {
+func (v *ContainerList) MarshalEasyJSON(w *jwriter.Writer) {
 	easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes(w, v)
 }
 
@@ -226,7 +226,7 @@ func easyjson1dbef17bDecodeGithubComStackroxRoxPkgDockerTypes1(in *jlexer.Lexer,
 		in.Consumed()
 	}
 }
-func easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes1(out *jwriter.Writer, in ContainerJSON) {
+func easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes1(out *jwriter.Writer, in *ContainerJSON) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -240,7 +240,7 @@ func easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes1(out *jwriter.Writ
 				if v4 > 0 {
 					out.RawByte(',')
 				}
-				easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes2(out, v5)
+				easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes2(out, &v5)
 			}
 			out.RawByte(']')
 		}
@@ -253,7 +253,7 @@ func easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes1(out *jwriter.Writ
 		} else {
 			out.RawString(prefix)
 		}
-		easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes3(out, *in.Config)
+		easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes3(out, &*in.Config)
 	}
 	if in.NetworkSettings != nil {
 		const prefix string = ",\"NetworkSettings\":"
@@ -263,7 +263,7 @@ func easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes1(out *jwriter.Writ
 		} else {
 			out.RawString(prefix)
 		}
-		easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes4(out, *in.NetworkSettings)
+		easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes4(out, &*in.NetworkSettings)
 	}
 	{
 		const prefix string = ",\"Id\":"
@@ -283,7 +283,7 @@ func easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes1(out *jwriter.Writ
 	if in.State != nil {
 		const prefix string = ",\"State\":"
 		out.RawString(prefix)
-		easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes5(out, *in.State)
+		easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes5(out, &*in.State)
 	}
 	if in.Name != "" {
 		const prefix string = ",\"Name\":"
@@ -298,20 +298,20 @@ func easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes1(out *jwriter.Writ
 	if in.HostConfig != nil {
 		const prefix string = ",\"HostConfig\":"
 		out.RawString(prefix)
-		easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes6(out, *in.HostConfig)
+		easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes6(out, &*in.HostConfig)
 	}
 	out.RawByte('}')
 }
 
 // MarshalJSON supports json.Marshaler interface
-func (v ContainerJSON) MarshalJSON() ([]byte, error) {
+func (v *ContainerJSON) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
 	easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes1(&w, v)
 	return w.Buffer.BuildBytes(), w.Error
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
-func (v ContainerJSON) MarshalEasyJSON(w *jwriter.Writer) {
+func (v *ContainerJSON) MarshalEasyJSON(w *jwriter.Writer) {
 	easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes1(w, v)
 }
 
@@ -464,7 +464,7 @@ func easyjson1dbef17bDecodeGithubComStackroxRoxPkgDockerTypes6(in *jlexer.Lexer,
 		in.Consumed()
 	}
 }
-func easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes6(out *jwriter.Writer, in HostConfig) {
+func easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes6(out *jwriter.Writer, in *HostConfig) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -539,7 +539,7 @@ func easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes6(out *jwriter.Writ
 		} else {
 			out.RawString(prefix)
 		}
-		easyjson1dbef17bEncodeGithubComDockerDockerApiTypesContainer(out, in.RestartPolicy)
+		easyjson1dbef17bEncodeGithubComDockerDockerApiTypesContainer(out, &in.RestartPolicy)
 	}
 	if in.IpcMode != "" {
 		const prefix string = ",\"IpcMode\":"
@@ -635,7 +635,7 @@ func easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes6(out *jwriter.Writ
 				if v15 > 0 {
 					out.RawByte(',')
 				}
-				easyjson1dbef17bEncodeGithubComDockerDockerApiTypesContainer1(out, v16)
+				easyjson1dbef17bEncodeGithubComDockerDockerApiTypesContainer1(out, &v16)
 			}
 			out.RawByte(']')
 		}
@@ -657,7 +657,7 @@ func easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes6(out *jwriter.Writ
 				if v18 == nil {
 					out.RawString("null")
 				} else {
-					easyjson1dbef17bEncodeGithubComDockerGoUnits(out, *v18)
+					easyjson1dbef17bEncodeGithubComDockerGoUnits(out, &*v18)
 				}
 			}
 			out.RawByte(']')
@@ -700,7 +700,7 @@ func easyjson1dbef17bDecodeGithubComDockerGoUnits(in *jlexer.Lexer, out *go_unit
 		in.Consumed()
 	}
 }
-func easyjson1dbef17bEncodeGithubComDockerGoUnits(out *jwriter.Writer, in go_units.Ulimit) {
+func easyjson1dbef17bEncodeGithubComDockerGoUnits(out *jwriter.Writer, in *go_units.Ulimit) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -756,7 +756,7 @@ func easyjson1dbef17bDecodeGithubComDockerDockerApiTypesContainer1(in *jlexer.Le
 		in.Consumed()
 	}
 }
-func easyjson1dbef17bEncodeGithubComDockerDockerApiTypesContainer1(out *jwriter.Writer, in container.DeviceMapping) {
+func easyjson1dbef17bEncodeGithubComDockerDockerApiTypesContainer1(out *jwriter.Writer, in *container.DeviceMapping) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -810,7 +810,7 @@ func easyjson1dbef17bDecodeGithubComDockerDockerApiTypesContainer(in *jlexer.Lex
 		in.Consumed()
 	}
 }
-func easyjson1dbef17bEncodeGithubComDockerDockerApiTypesContainer(out *jwriter.Writer, in container.RestartPolicy) {
+func easyjson1dbef17bEncodeGithubComDockerDockerApiTypesContainer(out *jwriter.Writer, in *container.RestartPolicy) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -867,7 +867,7 @@ func easyjson1dbef17bDecodeGithubComStackroxRoxPkgDockerTypes5(in *jlexer.Lexer,
 		in.Consumed()
 	}
 }
-func easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes5(out *jwriter.Writer, in ContainerState) {
+func easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes5(out *jwriter.Writer, in *ContainerState) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -885,7 +885,7 @@ func easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes5(out *jwriter.Writ
 		} else {
 			out.RawString(prefix)
 		}
-		easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes7(out, *in.Health)
+		easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes7(out, &*in.Health)
 	}
 	out.RawByte('}')
 }
@@ -920,7 +920,7 @@ func easyjson1dbef17bDecodeGithubComStackroxRoxPkgDockerTypes7(in *jlexer.Lexer,
 		in.Consumed()
 	}
 }
-func easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes7(out *jwriter.Writer, in Health) {
+func easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes7(out *jwriter.Writer, in *Health) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -1022,7 +1022,7 @@ func easyjson1dbef17bDecodeGithubComStackroxRoxPkgDockerTypes4(in *jlexer.Lexer,
 		in.Consumed()
 	}
 }
-func easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes4(out *jwriter.Writer, in NetworkSettings) {
+func easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes4(out *jwriter.Writer, in *NetworkSettings) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -1041,7 +1041,7 @@ func easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes4(out *jwriter.Writ
 				}
 				out.String(string(v22Name))
 				out.RawByte(':')
-				easyjson1dbef17bEncode(out, v22Value)
+				easyjson1dbef17bEncode(out, &v22Value)
 			}
 			out.RawByte('}')
 		}
@@ -1073,7 +1073,7 @@ func easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes4(out *jwriter.Writ
 						if v24 > 0 {
 							out.RawByte(',')
 						}
-						easyjson1dbef17bEncodeGithubComDockerGoConnectionsNat(out, v25)
+						easyjson1dbef17bEncodeGithubComDockerGoConnectionsNat(out, &v25)
 					}
 					out.RawByte(']')
 				}
@@ -1116,7 +1116,7 @@ func easyjson1dbef17bDecodeGithubComDockerGoConnectionsNat(in *jlexer.Lexer, out
 		in.Consumed()
 	}
 }
-func easyjson1dbef17bEncodeGithubComDockerGoConnectionsNat(out *jwriter.Writer, in nat.PortBinding) {
+func easyjson1dbef17bEncodeGithubComDockerGoConnectionsNat(out *jwriter.Writer, in *nat.PortBinding) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -1161,7 +1161,7 @@ func easyjson1dbef17bDecode(in *jlexer.Lexer, out *struct{}) {
 		in.Consumed()
 	}
 }
-func easyjson1dbef17bEncode(out *jwriter.Writer, in struct{}) {
+func easyjson1dbef17bEncode(out *jwriter.Writer, in *struct{}) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -1208,7 +1208,7 @@ func easyjson1dbef17bDecodeGithubComStackroxRoxPkgDockerTypes3(in *jlexer.Lexer,
 		in.Consumed()
 	}
 }
-func easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes3(out *jwriter.Writer, in Config) {
+func easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes3(out *jwriter.Writer, in *Config) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -1216,7 +1216,7 @@ func easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes3(out *jwriter.Writ
 		const prefix string = ",\"Healthcheck\":"
 		first = false
 		out.RawString(prefix[1:])
-		easyjson1dbef17bEncodeGithubComDockerDockerApiTypesContainer2(out, *in.Healthcheck)
+		easyjson1dbef17bEncodeGithubComDockerDockerApiTypesContainer2(out, &*in.Healthcheck)
 	}
 	if in.User != "" {
 		const prefix string = ",\"User\":"
@@ -1290,7 +1290,7 @@ func easyjson1dbef17bDecodeGithubComDockerDockerApiTypesContainer2(in *jlexer.Le
 		in.Consumed()
 	}
 }
-func easyjson1dbef17bEncodeGithubComDockerDockerApiTypesContainer2(out *jwriter.Writer, in container.HealthConfig) {
+func easyjson1dbef17bEncodeGithubComDockerDockerApiTypesContainer2(out *jwriter.Writer, in *container.HealthConfig) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -1394,7 +1394,7 @@ func easyjson1dbef17bDecodeGithubComStackroxRoxPkgDockerTypes2(in *jlexer.Lexer,
 		in.Consumed()
 	}
 }
-func easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes2(out *jwriter.Writer, in MountPoint) {
+func easyjson1dbef17bEncodeGithubComStackroxRoxPkgDockerTypes2(out *jwriter.Writer, in *MountPoint) {
 	out.RawByte('{')
 	first := true
 	_ = first

--- a/pkg/docker/types/image_easyjson.go
+++ b/pkg/docker/types/image_easyjson.go
@@ -106,7 +106,7 @@ func easyjson220accf5DecodeGithubComStackroxRoxPkgDockerTypes(in *jlexer.Lexer, 
 		in.Consumed()
 	}
 }
-func easyjson220accf5EncodeGithubComStackroxRoxPkgDockerTypes(out *jwriter.Writer, in ImageInspect) {
+func easyjson220accf5EncodeGithubComStackroxRoxPkgDockerTypes(out *jwriter.Writer, in *ImageInspect) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -146,20 +146,20 @@ func easyjson220accf5EncodeGithubComStackroxRoxPkgDockerTypes(out *jwriter.Write
 	if in.Config != nil {
 		const prefix string = ",\"Config\":"
 		out.RawString(prefix)
-		easyjson220accf5EncodeGithubComStackroxRoxPkgDockerTypes1(out, *in.Config)
+		easyjson220accf5EncodeGithubComStackroxRoxPkgDockerTypes1(out, &*in.Config)
 	}
 	out.RawByte('}')
 }
 
 // MarshalJSON supports json.Marshaler interface
-func (v ImageInspect) MarshalJSON() ([]byte, error) {
+func (v *ImageInspect) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
 	easyjson220accf5EncodeGithubComStackroxRoxPkgDockerTypes(&w, v)
 	return w.Buffer.BuildBytes(), w.Error
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
-func (v ImageInspect) MarshalEasyJSON(w *jwriter.Writer) {
+func (v *ImageInspect) MarshalEasyJSON(w *jwriter.Writer) {
 	easyjson220accf5EncodeGithubComStackroxRoxPkgDockerTypes(w, v)
 }
 
@@ -215,7 +215,7 @@ func easyjson220accf5DecodeGithubComStackroxRoxPkgDockerTypes1(in *jlexer.Lexer,
 		in.Consumed()
 	}
 }
-func easyjson220accf5EncodeGithubComStackroxRoxPkgDockerTypes1(out *jwriter.Writer, in Config) {
+func easyjson220accf5EncodeGithubComStackroxRoxPkgDockerTypes1(out *jwriter.Writer, in *Config) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -223,7 +223,7 @@ func easyjson220accf5EncodeGithubComStackroxRoxPkgDockerTypes1(out *jwriter.Writ
 		const prefix string = ",\"Healthcheck\":"
 		first = false
 		out.RawString(prefix[1:])
-		easyjson220accf5EncodeGithubComDockerDockerApiTypesContainer(out, *in.Healthcheck)
+		easyjson220accf5EncodeGithubComDockerDockerApiTypesContainer(out, &*in.Healthcheck)
 	}
 	if in.User != "" {
 		const prefix string = ",\"User\":"
@@ -297,7 +297,7 @@ func easyjson220accf5DecodeGithubComDockerDockerApiTypesContainer(in *jlexer.Lex
 		in.Consumed()
 	}
 }
-func easyjson220accf5EncodeGithubComDockerDockerApiTypesContainer(out *jwriter.Writer, in container.HealthConfig) {
+func easyjson220accf5EncodeGithubComDockerDockerApiTypesContainer(out *jwriter.Writer, in *container.HealthConfig) {
 	out.RawByte('{')
 	first := true
 	_ = first

--- a/pkg/docker/types/image_easyjson.go
+++ b/pkg/docker/types/image_easyjson.go
@@ -106,7 +106,7 @@ func easyjson220accf5DecodeGithubComStackroxRoxPkgDockerTypes(in *jlexer.Lexer, 
 		in.Consumed()
 	}
 }
-func easyjson220accf5EncodeGithubComStackroxRoxPkgDockerTypes(out *jwriter.Writer, in *ImageInspect) {
+func easyjson220accf5EncodeGithubComStackroxRoxPkgDockerTypes(out *jwriter.Writer, in ImageInspect) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -146,20 +146,20 @@ func easyjson220accf5EncodeGithubComStackroxRoxPkgDockerTypes(out *jwriter.Write
 	if in.Config != nil {
 		const prefix string = ",\"Config\":"
 		out.RawString(prefix)
-		easyjson220accf5EncodeGithubComStackroxRoxPkgDockerTypes1(out, &*in.Config)
+		easyjson220accf5EncodeGithubComStackroxRoxPkgDockerTypes1(out, *in.Config)
 	}
 	out.RawByte('}')
 }
 
 // MarshalJSON supports json.Marshaler interface
-func (v *ImageInspect) MarshalJSON() ([]byte, error) {
+func (v ImageInspect) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
 	easyjson220accf5EncodeGithubComStackroxRoxPkgDockerTypes(&w, v)
 	return w.Buffer.BuildBytes(), w.Error
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
-func (v *ImageInspect) MarshalEasyJSON(w *jwriter.Writer) {
+func (v ImageInspect) MarshalEasyJSON(w *jwriter.Writer) {
 	easyjson220accf5EncodeGithubComStackroxRoxPkgDockerTypes(w, v)
 }
 
@@ -215,7 +215,7 @@ func easyjson220accf5DecodeGithubComStackroxRoxPkgDockerTypes1(in *jlexer.Lexer,
 		in.Consumed()
 	}
 }
-func easyjson220accf5EncodeGithubComStackroxRoxPkgDockerTypes1(out *jwriter.Writer, in *Config) {
+func easyjson220accf5EncodeGithubComStackroxRoxPkgDockerTypes1(out *jwriter.Writer, in Config) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -223,7 +223,7 @@ func easyjson220accf5EncodeGithubComStackroxRoxPkgDockerTypes1(out *jwriter.Writ
 		const prefix string = ",\"Healthcheck\":"
 		first = false
 		out.RawString(prefix[1:])
-		easyjson220accf5EncodeGithubComDockerDockerApiTypesContainer(out, &*in.Healthcheck)
+		easyjson220accf5EncodeGithubComDockerDockerApiTypesContainer(out, *in.Healthcheck)
 	}
 	if in.User != "" {
 		const prefix string = ",\"User\":"
@@ -297,7 +297,7 @@ func easyjson220accf5DecodeGithubComDockerDockerApiTypesContainer(in *jlexer.Lex
 		in.Consumed()
 	}
 }
-func easyjson220accf5EncodeGithubComDockerDockerApiTypesContainer(out *jwriter.Writer, in *container.HealthConfig) {
+func easyjson220accf5EncodeGithubComDockerDockerApiTypesContainer(out *jwriter.Writer, in container.HealthConfig) {
 	out.RawByte('{')
 	first := true
 	_ = first

--- a/pkg/docker/types/types_easyjson.go
+++ b/pkg/docker/types/types_easyjson.go
@@ -106,14 +106,14 @@ func easyjson6601e8cdDecodeGithubComStackroxRoxPkgDockerTypes(in *jlexer.Lexer, 
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes(out *jwriter.Writer, in *Data) {
+func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes(out *jwriter.Writer, in Data) {
 	out.RawByte('{')
 	first := true
 	_ = first
 	{
 		const prefix string = ",\"Info\":"
 		out.RawString(prefix[1:])
-		easyjson6601e8cdEncodeGithubComDockerDockerApiTypes(out, &in.Info)
+		easyjson6601e8cdEncodeGithubComDockerDockerApiTypes(out, in.Info)
 	}
 	{
 		const prefix string = ",\"Containers\":"
@@ -126,7 +126,7 @@ func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes(out *jwriter.Write
 				if v3 > 0 {
 					out.RawByte(',')
 				}
-				easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes1(out, &v4)
+				easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes1(out, v4)
 			}
 			out.RawByte(']')
 		}
@@ -142,7 +142,7 @@ func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes(out *jwriter.Write
 				if v5 > 0 {
 					out.RawByte(',')
 				}
-				easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes2(out, &v6)
+				easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes2(out, v6)
 			}
 			out.RawByte(']')
 		}
@@ -150,20 +150,20 @@ func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes(out *jwriter.Write
 	{
 		const prefix string = ",\"BridgeNetwork\":"
 		out.RawString(prefix)
-		easyjson6601e8cdEncodeGithubComDockerDockerApiTypes1(out, &in.BridgeNetwork)
+		easyjson6601e8cdEncodeGithubComDockerDockerApiTypes1(out, in.BridgeNetwork)
 	}
 	out.RawByte('}')
 }
 
 // MarshalJSON supports json.Marshaler interface
-func (v *Data) MarshalJSON() ([]byte, error) {
+func (v Data) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
 	easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes(&w, v)
 	return w.Buffer.BuildBytes(), w.Error
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
-func (v *Data) MarshalEasyJSON(w *jwriter.Writer) {
+func (v Data) MarshalEasyJSON(w *jwriter.Writer) {
 	easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes(w, v)
 }
 
@@ -324,7 +324,7 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypes1(in *jlexer.Lexer, out 
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComDockerDockerApiTypes1(out *jwriter.Writer, in *types.NetworkResource) {
+func easyjson6601e8cdEncodeGithubComDockerDockerApiTypes1(out *jwriter.Writer, in types.NetworkResource) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -361,7 +361,7 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypes1(out *jwriter.Writer, i
 	{
 		const prefix string = ",\"IPAM\":"
 		out.RawString(prefix)
-		easyjson6601e8cdEncodeGithubComDockerDockerApiTypesNetwork(out, &in.IPAM)
+		easyjson6601e8cdEncodeGithubComDockerDockerApiTypesNetwork(out, in.IPAM)
 	}
 	{
 		const prefix string = ",\"Internal\":"
@@ -381,7 +381,7 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypes1(out *jwriter.Writer, i
 	{
 		const prefix string = ",\"ConfigFrom\":"
 		out.RawString(prefix)
-		easyjson6601e8cdEncodeGithubComDockerDockerApiTypesNetwork1(out, &in.ConfigFrom)
+		easyjson6601e8cdEncodeGithubComDockerDockerApiTypesNetwork1(out, in.ConfigFrom)
 	}
 	{
 		const prefix string = ",\"ConfigOnly\":"
@@ -404,7 +404,7 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypes1(out *jwriter.Writer, i
 				}
 				out.String(string(v12Name))
 				out.RawByte(':')
-				easyjson6601e8cdEncodeGithubComDockerDockerApiTypes2(out, &v12Value)
+				easyjson6601e8cdEncodeGithubComDockerDockerApiTypes2(out, v12Value)
 			}
 			out.RawByte('}')
 		}
@@ -460,7 +460,7 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypes1(out *jwriter.Writer, i
 				if v15 > 0 {
 					out.RawByte(',')
 				}
-				easyjson6601e8cdEncodeGithubComDockerDockerApiTypesNetwork2(out, &v16)
+				easyjson6601e8cdEncodeGithubComDockerDockerApiTypesNetwork2(out, v16)
 			}
 			out.RawByte(']')
 		}
@@ -479,7 +479,7 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypes1(out *jwriter.Writer, i
 				}
 				out.String(string(v17Name))
 				out.RawByte(':')
-				easyjson6601e8cdEncodeGithubComDockerDockerApiTypesNetwork3(out, &v17Value)
+				easyjson6601e8cdEncodeGithubComDockerDockerApiTypesNetwork3(out, v17Value)
 			}
 			out.RawByte('}')
 		}
@@ -565,7 +565,7 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypesNetwork3(in *jlexer.Lexe
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesNetwork3(out *jwriter.Writer, in *network.ServiceInfo) {
+func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesNetwork3(out *jwriter.Writer, in network.ServiceInfo) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -606,7 +606,7 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesNetwork3(out *jwriter.Wr
 				if v22 > 0 {
 					out.RawByte(',')
 				}
-				easyjson6601e8cdEncodeGithubComDockerDockerApiTypesNetwork4(out, &v23)
+				easyjson6601e8cdEncodeGithubComDockerDockerApiTypesNetwork4(out, v23)
 			}
 			out.RawByte(']')
 		}
@@ -664,7 +664,7 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypesNetwork4(in *jlexer.Lexe
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesNetwork4(out *jwriter.Writer, in *network.Task) {
+func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesNetwork4(out *jwriter.Writer, in network.Task) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -739,7 +739,7 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypesNetwork2(in *jlexer.Lexe
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesNetwork2(out *jwriter.Writer, in *network.PeerInfo) {
+func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesNetwork2(out *jwriter.Writer, in network.PeerInfo) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -794,7 +794,7 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypes2(in *jlexer.Lexer, out 
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComDockerDockerApiTypes2(out *jwriter.Writer, in *types.EndpointResource) {
+func easyjson6601e8cdEncodeGithubComDockerDockerApiTypes2(out *jwriter.Writer, in types.EndpointResource) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -856,7 +856,7 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypesNetwork1(in *jlexer.Lexe
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesNetwork1(out *jwriter.Writer, in *network.ConfigReference) {
+func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesNetwork1(out *jwriter.Writer, in network.ConfigReference) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -937,7 +937,7 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypesNetwork(in *jlexer.Lexer
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesNetwork(out *jwriter.Writer, in *network.IPAM) {
+func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesNetwork(out *jwriter.Writer, in network.IPAM) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -978,7 +978,7 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesNetwork(out *jwriter.Wri
 				if v29 > 0 {
 					out.RawByte(',')
 				}
-				easyjson6601e8cdEncodeGithubComDockerDockerApiTypesNetwork5(out, &v30)
+				easyjson6601e8cdEncodeGithubComDockerDockerApiTypesNetwork5(out, v30)
 			}
 			out.RawByte(']')
 		}
@@ -1040,7 +1040,7 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypesNetwork5(in *jlexer.Lexe
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesNetwork5(out *jwriter.Writer, in *network.IPAMConfig) {
+func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesNetwork5(out *jwriter.Writer, in network.IPAMConfig) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -1150,14 +1150,14 @@ func easyjson6601e8cdDecodeGithubComStackroxRoxPkgDockerTypes2(in *jlexer.Lexer,
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes2(out *jwriter.Writer, in *ImageWrap) {
+func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes2(out *jwriter.Writer, in ImageWrap) {
 	out.RawByte('{')
 	first := true
 	_ = first
 	{
 		const prefix string = ",\"image\":"
 		out.RawString(prefix[1:])
-		easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes3(out, &in.Image)
+		easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes3(out, in.Image)
 	}
 	{
 		const prefix string = ",\"history\":"
@@ -1170,7 +1170,7 @@ func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes2(out *jwriter.Writ
 				if v34 > 0 {
 					out.RawByte(',')
 				}
-				easyjson6601e8cdEncodeGithubComDockerDockerApiTypesImage(out, &v35)
+				easyjson6601e8cdEncodeGithubComDockerDockerApiTypesImage(out, v35)
 			}
 			out.RawByte(']')
 		}
@@ -1239,7 +1239,7 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypesImage(in *jlexer.Lexer, 
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesImage(out *jwriter.Writer, in *image.HistoryResponseItem) {
+func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesImage(out *jwriter.Writer, in image.HistoryResponseItem) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -1373,7 +1373,7 @@ func easyjson6601e8cdDecodeGithubComStackroxRoxPkgDockerTypes3(in *jlexer.Lexer,
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes3(out *jwriter.Writer, in *ImageInspect) {
+func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes3(out *jwriter.Writer, in ImageInspect) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -1413,7 +1413,7 @@ func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes3(out *jwriter.Writ
 	if in.Config != nil {
 		const prefix string = ",\"Config\":"
 		out.RawString(prefix)
-		easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes4(out, &*in.Config)
+		easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes4(out, *in.Config)
 	}
 	out.RawByte('}')
 }
@@ -1458,7 +1458,7 @@ func easyjson6601e8cdDecodeGithubComStackroxRoxPkgDockerTypes4(in *jlexer.Lexer,
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes4(out *jwriter.Writer, in *Config) {
+func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes4(out *jwriter.Writer, in Config) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -1466,7 +1466,7 @@ func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes4(out *jwriter.Writ
 		const prefix string = ",\"Healthcheck\":"
 		first = false
 		out.RawString(prefix[1:])
-		easyjson6601e8cdEncodeGithubComDockerDockerApiTypesContainer(out, &*in.Healthcheck)
+		easyjson6601e8cdEncodeGithubComDockerDockerApiTypesContainer(out, *in.Healthcheck)
 	}
 	if in.User != "" {
 		const prefix string = ",\"User\":"
@@ -1540,7 +1540,7 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypesContainer(in *jlexer.Lex
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesContainer(out *jwriter.Writer, in *container.HealthConfig) {
+func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesContainer(out *jwriter.Writer, in container.HealthConfig) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -1702,7 +1702,7 @@ func easyjson6601e8cdDecodeGithubComStackroxRoxPkgDockerTypes1(in *jlexer.Lexer,
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes1(out *jwriter.Writer, in *ContainerJSON) {
+func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes1(out *jwriter.Writer, in ContainerJSON) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -1716,7 +1716,7 @@ func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes1(out *jwriter.Writ
 				if v49 > 0 {
 					out.RawByte(',')
 				}
-				easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes5(out, &v50)
+				easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes5(out, v50)
 			}
 			out.RawByte(']')
 		}
@@ -1729,7 +1729,7 @@ func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes1(out *jwriter.Writ
 		} else {
 			out.RawString(prefix)
 		}
-		easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes4(out, &*in.Config)
+		easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes4(out, *in.Config)
 	}
 	if in.NetworkSettings != nil {
 		const prefix string = ",\"NetworkSettings\":"
@@ -1739,7 +1739,7 @@ func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes1(out *jwriter.Writ
 		} else {
 			out.RawString(prefix)
 		}
-		easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes6(out, &*in.NetworkSettings)
+		easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes6(out, *in.NetworkSettings)
 	}
 	{
 		const prefix string = ",\"Id\":"
@@ -1759,7 +1759,7 @@ func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes1(out *jwriter.Writ
 	if in.State != nil {
 		const prefix string = ",\"State\":"
 		out.RawString(prefix)
-		easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes7(out, &*in.State)
+		easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes7(out, *in.State)
 	}
 	if in.Name != "" {
 		const prefix string = ",\"Name\":"
@@ -1774,7 +1774,7 @@ func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes1(out *jwriter.Writ
 	if in.HostConfig != nil {
 		const prefix string = ",\"HostConfig\":"
 		out.RawString(prefix)
-		easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes8(out, &*in.HostConfig)
+		easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes8(out, *in.HostConfig)
 	}
 	out.RawByte('}')
 }
@@ -1916,7 +1916,7 @@ func easyjson6601e8cdDecodeGithubComStackroxRoxPkgDockerTypes8(in *jlexer.Lexer,
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes8(out *jwriter.Writer, in *HostConfig) {
+func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes8(out *jwriter.Writer, in HostConfig) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -1991,7 +1991,7 @@ func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes8(out *jwriter.Writ
 		} else {
 			out.RawString(prefix)
 		}
-		easyjson6601e8cdEncodeGithubComDockerDockerApiTypesContainer1(out, &in.RestartPolicy)
+		easyjson6601e8cdEncodeGithubComDockerDockerApiTypesContainer1(out, in.RestartPolicy)
 	}
 	if in.IpcMode != "" {
 		const prefix string = ",\"IpcMode\":"
@@ -2087,7 +2087,7 @@ func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes8(out *jwriter.Writ
 				if v60 > 0 {
 					out.RawByte(',')
 				}
-				easyjson6601e8cdEncodeGithubComDockerDockerApiTypesContainer2(out, &v61)
+				easyjson6601e8cdEncodeGithubComDockerDockerApiTypesContainer2(out, v61)
 			}
 			out.RawByte(']')
 		}
@@ -2109,7 +2109,7 @@ func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes8(out *jwriter.Writ
 				if v63 == nil {
 					out.RawString("null")
 				} else {
-					easyjson6601e8cdEncodeGithubComDockerGoUnits(out, &*v63)
+					easyjson6601e8cdEncodeGithubComDockerGoUnits(out, *v63)
 				}
 			}
 			out.RawByte(']')
@@ -2152,7 +2152,7 @@ func easyjson6601e8cdDecodeGithubComDockerGoUnits(in *jlexer.Lexer, out *go_unit
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComDockerGoUnits(out *jwriter.Writer, in *go_units.Ulimit) {
+func easyjson6601e8cdEncodeGithubComDockerGoUnits(out *jwriter.Writer, in go_units.Ulimit) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -2208,7 +2208,7 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypesContainer2(in *jlexer.Le
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesContainer2(out *jwriter.Writer, in *container.DeviceMapping) {
+func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesContainer2(out *jwriter.Writer, in container.DeviceMapping) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -2262,7 +2262,7 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypesContainer1(in *jlexer.Le
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesContainer1(out *jwriter.Writer, in *container.RestartPolicy) {
+func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesContainer1(out *jwriter.Writer, in container.RestartPolicy) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -2319,7 +2319,7 @@ func easyjson6601e8cdDecodeGithubComStackroxRoxPkgDockerTypes7(in *jlexer.Lexer,
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes7(out *jwriter.Writer, in *ContainerState) {
+func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes7(out *jwriter.Writer, in ContainerState) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -2337,7 +2337,7 @@ func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes7(out *jwriter.Writ
 		} else {
 			out.RawString(prefix)
 		}
-		easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes9(out, &*in.Health)
+		easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes9(out, *in.Health)
 	}
 	out.RawByte('}')
 }
@@ -2372,7 +2372,7 @@ func easyjson6601e8cdDecodeGithubComStackroxRoxPkgDockerTypes9(in *jlexer.Lexer,
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes9(out *jwriter.Writer, in *Health) {
+func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes9(out *jwriter.Writer, in Health) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -2474,7 +2474,7 @@ func easyjson6601e8cdDecodeGithubComStackroxRoxPkgDockerTypes6(in *jlexer.Lexer,
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes6(out *jwriter.Writer, in *NetworkSettings) {
+func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes6(out *jwriter.Writer, in NetworkSettings) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -2493,7 +2493,7 @@ func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes6(out *jwriter.Writ
 				}
 				out.String(string(v67Name))
 				out.RawByte(':')
-				easyjson6601e8cdEncode(out, &v67Value)
+				easyjson6601e8cdEncode(out, v67Value)
 			}
 			out.RawByte('}')
 		}
@@ -2525,7 +2525,7 @@ func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes6(out *jwriter.Writ
 						if v69 > 0 {
 							out.RawByte(',')
 						}
-						easyjson6601e8cdEncodeGithubComDockerGoConnectionsNat(out, &v70)
+						easyjson6601e8cdEncodeGithubComDockerGoConnectionsNat(out, v70)
 					}
 					out.RawByte(']')
 				}
@@ -2568,7 +2568,7 @@ func easyjson6601e8cdDecodeGithubComDockerGoConnectionsNat(in *jlexer.Lexer, out
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComDockerGoConnectionsNat(out *jwriter.Writer, in *nat.PortBinding) {
+func easyjson6601e8cdEncodeGithubComDockerGoConnectionsNat(out *jwriter.Writer, in nat.PortBinding) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -2613,7 +2613,7 @@ func easyjson6601e8cdDecode(in *jlexer.Lexer, out *struct{}) {
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncode(out *jwriter.Writer, in *struct{}) {
+func easyjson6601e8cdEncode(out *jwriter.Writer, in struct{}) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -2662,7 +2662,7 @@ func easyjson6601e8cdDecodeGithubComStackroxRoxPkgDockerTypes5(in *jlexer.Lexer,
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes5(out *jwriter.Writer, in *MountPoint) {
+func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes5(out *jwriter.Writer, in MountPoint) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -3090,7 +3090,7 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypes(in *jlexer.Lexer, out *
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComDockerDockerApiTypes(out *jwriter.Writer, in *types.Info) {
+func easyjson6601e8cdEncodeGithubComDockerDockerApiTypes(out *jwriter.Writer, in types.Info) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -3176,7 +3176,7 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypes(out *jwriter.Writer, in
 	{
 		const prefix string = ",\"Plugins\":"
 		out.RawString(prefix)
-		easyjson6601e8cdEncodeGithubComDockerDockerApiTypes3(out, &in.Plugins)
+		easyjson6601e8cdEncodeGithubComDockerDockerApiTypes3(out, in.Plugins)
 	}
 	{
 		const prefix string = ",\"MemoryLimit\":"
@@ -3319,7 +3319,7 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypes(out *jwriter.Writer, in
 		if in.RegistryConfig == nil {
 			out.RawString("null")
 		} else {
-			easyjson6601e8cdEncodeGithubComDockerDockerApiTypesRegistry(out, &*in.RegistryConfig)
+			easyjson6601e8cdEncodeGithubComDockerDockerApiTypesRegistry(out, *in.RegistryConfig)
 		}
 	}
 	{
@@ -3343,7 +3343,7 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypes(out *jwriter.Writer, in
 				if v87 > 0 {
 					out.RawByte(',')
 				}
-				easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm(out, &v88)
+				easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm(out, v88)
 			}
 			out.RawByte(']')
 		}
@@ -3425,7 +3425,7 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypes(out *jwriter.Writer, in
 				}
 				out.String(string(v91Name))
 				out.RawByte(':')
-				easyjson6601e8cdEncodeGithubComDockerDockerApiTypes4(out, &v91Value)
+				easyjson6601e8cdEncodeGithubComDockerDockerApiTypes4(out, v91Value)
 			}
 			out.RawByte('}')
 		}
@@ -3438,7 +3438,7 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypes(out *jwriter.Writer, in
 	{
 		const prefix string = ",\"Swarm\":"
 		out.RawString(prefix)
-		easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm1(out, &in.Swarm)
+		easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm1(out, in.Swarm)
 	}
 	{
 		const prefix string = ",\"LiveRestoreEnabled\":"
@@ -3458,17 +3458,17 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypes(out *jwriter.Writer, in
 	{
 		const prefix string = ",\"ContainerdCommit\":"
 		out.RawString(prefix)
-		easyjson6601e8cdEncodeGithubComDockerDockerApiTypes5(out, &in.ContainerdCommit)
+		easyjson6601e8cdEncodeGithubComDockerDockerApiTypes5(out, in.ContainerdCommit)
 	}
 	{
 		const prefix string = ",\"RuncCommit\":"
 		out.RawString(prefix)
-		easyjson6601e8cdEncodeGithubComDockerDockerApiTypes5(out, &in.RuncCommit)
+		easyjson6601e8cdEncodeGithubComDockerDockerApiTypes5(out, in.RuncCommit)
 	}
 	{
 		const prefix string = ",\"InitCommit\":"
 		out.RawString(prefix)
-		easyjson6601e8cdEncodeGithubComDockerDockerApiTypes5(out, &in.InitCommit)
+		easyjson6601e8cdEncodeGithubComDockerDockerApiTypes5(out, in.InitCommit)
 	}
 	{
 		const prefix string = ",\"SecurityOptions\":"
@@ -3500,7 +3500,7 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypes(out *jwriter.Writer, in
 				if v94 > 0 {
 					out.RawByte(',')
 				}
-				easyjson6601e8cdEncodeGithubComDockerDockerApiTypes6(out, &v95)
+				easyjson6601e8cdEncodeGithubComDockerDockerApiTypes6(out, v95)
 			}
 			out.RawByte(']')
 		}
@@ -3556,7 +3556,7 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypes6(in *jlexer.Lexer, out 
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComDockerDockerApiTypes6(out *jwriter.Writer, in *types.NetworkAddressPool) {
+func easyjson6601e8cdEncodeGithubComDockerDockerApiTypes6(out *jwriter.Writer, in types.NetworkAddressPool) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -3605,7 +3605,7 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypes5(in *jlexer.Lexer, out 
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComDockerDockerApiTypes5(out *jwriter.Writer, in *types.Commit) {
+func easyjson6601e8cdEncodeGithubComDockerDockerApiTypes5(out *jwriter.Writer, in types.Commit) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -3720,7 +3720,7 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypesSwarm1(in *jlexer.Lexer,
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm1(out *jwriter.Writer, in *swarm.Info) {
+func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm1(out *jwriter.Writer, in swarm.Info) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -3760,7 +3760,7 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm1(out *jwriter.Writ
 				if v100 > 0 {
 					out.RawByte(',')
 				}
-				easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm2(out, &v101)
+				easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm2(out, v101)
 			}
 			out.RawByte(']')
 		}
@@ -3778,7 +3778,7 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm1(out *jwriter.Writ
 	if in.Cluster != nil {
 		const prefix string = ",\"Cluster\":"
 		out.RawString(prefix)
-		easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm3(out, &*in.Cluster)
+		easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm3(out, *in.Cluster)
 	}
 	if len(in.Warnings) != 0 {
 		const prefix string = ",\"Warnings\":"
@@ -3870,7 +3870,7 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypesSwarm3(in *jlexer.Lexer,
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm3(out *jwriter.Writer, in *swarm.ClusterInfo) {
+func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm3(out *jwriter.Writer, in swarm.ClusterInfo) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -3882,12 +3882,12 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm3(out *jwriter.Writ
 	{
 		const prefix string = ",\"Spec\":"
 		out.RawString(prefix)
-		easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm4(out, &in.Spec)
+		easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm4(out, in.Spec)
 	}
 	{
 		const prefix string = ",\"TLSInfo\":"
 		out.RawString(prefix)
-		easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm5(out, &in.TLSInfo)
+		easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm5(out, in.TLSInfo)
 	}
 	{
 		const prefix string = ",\"RootRotationInProgress\":"
@@ -3923,7 +3923,7 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm3(out *jwriter.Writ
 	if true {
 		const prefix string = ",\"Version\":"
 		out.RawString(prefix)
-		easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm6(out, &in.Version)
+		easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm6(out, in.Version)
 	}
 	if true {
 		const prefix string = ",\"CreatedAt\":"
@@ -3968,7 +3968,7 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypesSwarm6(in *jlexer.Lexer,
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm6(out *jwriter.Writer, in *swarm.Version) {
+func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm6(out *jwriter.Writer, in swarm.Version) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -4025,7 +4025,7 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypesSwarm5(in *jlexer.Lexer,
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm5(out *jwriter.Writer, in *swarm.TLSInfo) {
+func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm5(out *jwriter.Writer, in swarm.TLSInfo) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -4116,7 +4116,7 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypesSwarm4(in *jlexer.Lexer,
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm4(out *jwriter.Writer, in *swarm.Spec) {
+func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm4(out *jwriter.Writer, in swarm.Spec) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -4124,7 +4124,7 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm4(out *jwriter.Writ
 		const prefix string = ",\"Orchestration\":"
 		first = false
 		out.RawString(prefix[1:])
-		easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm7(out, &in.Orchestration)
+		easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm7(out, in.Orchestration)
 	}
 	if true {
 		const prefix string = ",\"Raft\":"
@@ -4134,7 +4134,7 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm4(out *jwriter.Writ
 		} else {
 			out.RawString(prefix)
 		}
-		easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm8(out, &in.Raft)
+		easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm8(out, in.Raft)
 	}
 	if true {
 		const prefix string = ",\"Dispatcher\":"
@@ -4144,7 +4144,7 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm4(out *jwriter.Writ
 		} else {
 			out.RawString(prefix)
 		}
-		easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm9(out, &in.Dispatcher)
+		easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm9(out, in.Dispatcher)
 	}
 	if true {
 		const prefix string = ",\"CAConfig\":"
@@ -4154,7 +4154,7 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm4(out *jwriter.Writ
 		} else {
 			out.RawString(prefix)
 		}
-		easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm10(out, &in.CAConfig)
+		easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm10(out, in.CAConfig)
 	}
 	if true {
 		const prefix string = ",\"TaskDefaults\":"
@@ -4164,7 +4164,7 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm4(out *jwriter.Writ
 		} else {
 			out.RawString(prefix)
 		}
-		easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm11(out, &in.TaskDefaults)
+		easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm11(out, in.TaskDefaults)
 	}
 	if true {
 		const prefix string = ",\"EncryptionConfig\":"
@@ -4174,7 +4174,7 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm4(out *jwriter.Writ
 		} else {
 			out.RawString(prefix)
 		}
-		easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm12(out, &in.EncryptionConfig)
+		easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm12(out, in.EncryptionConfig)
 	}
 	if in.Name != "" {
 		const prefix string = ",\"Name\":"
@@ -4245,7 +4245,7 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypesSwarm12(in *jlexer.Lexer
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm12(out *jwriter.Writer, in *swarm.EncryptionConfig) {
+func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm12(out *jwriter.Writer, in swarm.EncryptionConfig) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -4295,7 +4295,7 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypesSwarm11(in *jlexer.Lexer
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm11(out *jwriter.Writer, in *swarm.TaskDefaults) {
+func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm11(out *jwriter.Writer, in swarm.TaskDefaults) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -4303,7 +4303,7 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm11(out *jwriter.Wri
 		const prefix string = ",\"LogDriver\":"
 		first = false
 		out.RawString(prefix[1:])
-		easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm13(out, &*in.LogDriver)
+		easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm13(out, *in.LogDriver)
 	}
 	out.RawByte('}')
 }
@@ -4358,7 +4358,7 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypesSwarm13(in *jlexer.Lexer
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm13(out *jwriter.Writer, in *swarm.Driver) {
+func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm13(out *jwriter.Writer, in swarm.Driver) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -4462,7 +4462,7 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypesSwarm10(in *jlexer.Lexer
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm10(out *jwriter.Writer, in *swarm.CAConfig) {
+func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm10(out *jwriter.Writer, in swarm.CAConfig) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -4489,7 +4489,7 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm10(out *jwriter.Wri
 				if v119 == nil {
 					out.RawString("null")
 				} else {
-					easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm14(out, &*v119)
+					easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm14(out, *v119)
 				}
 			}
 			out.RawByte(']')
@@ -4582,7 +4582,7 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypesSwarm14(in *jlexer.Lexer
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm14(out *jwriter.Writer, in *swarm.ExternalCA) {
+func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm14(out *jwriter.Writer, in swarm.ExternalCA) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -4653,7 +4653,7 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypesSwarm9(in *jlexer.Lexer,
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm9(out *jwriter.Writer, in *swarm.DispatcherConfig) {
+func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm9(out *jwriter.Writer, in swarm.DispatcherConfig) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -4712,7 +4712,7 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypesSwarm8(in *jlexer.Lexer,
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm8(out *jwriter.Writer, in *swarm.RaftConfig) {
+func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm8(out *jwriter.Writer, in swarm.RaftConfig) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -4798,7 +4798,7 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypesSwarm7(in *jlexer.Lexer,
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm7(out *jwriter.Writer, in *swarm.OrchestrationConfig) {
+func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm7(out *jwriter.Writer, in swarm.OrchestrationConfig) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -4843,7 +4843,7 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypesSwarm2(in *jlexer.Lexer,
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm2(out *jwriter.Writer, in *swarm.Peer) {
+func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm2(out *jwriter.Writer, in swarm.Peer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -4913,7 +4913,7 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypes4(in *jlexer.Lexer, out 
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComDockerDockerApiTypes4(out *jwriter.Writer, in *types.Runtime) {
+func easyjson6601e8cdEncodeGithubComDockerDockerApiTypes4(out *jwriter.Writer, in types.Runtime) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -4987,7 +4987,7 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypesSwarm(in *jlexer.Lexer, 
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm(out *jwriter.Writer, in *swarm.GenericResource) {
+func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm(out *jwriter.Writer, in swarm.GenericResource) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -4995,7 +4995,7 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm(out *jwriter.Write
 		const prefix string = ",\"NamedResourceSpec\":"
 		first = false
 		out.RawString(prefix[1:])
-		easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm15(out, &*in.NamedResourceSpec)
+		easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm15(out, *in.NamedResourceSpec)
 	}
 	if in.DiscreteResourceSpec != nil {
 		const prefix string = ",\"DiscreteResourceSpec\":"
@@ -5005,7 +5005,7 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm(out *jwriter.Write
 		} else {
 			out.RawString(prefix)
 		}
-		easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm16(out, &*in.DiscreteResourceSpec)
+		easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm16(out, *in.DiscreteResourceSpec)
 	}
 	out.RawByte('}')
 }
@@ -5042,7 +5042,7 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypesSwarm16(in *jlexer.Lexer
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm16(out *jwriter.Writer, in *swarm.DiscreteGenericResource) {
+func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm16(out *jwriter.Writer, in swarm.DiscreteGenericResource) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -5097,7 +5097,7 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypesSwarm15(in *jlexer.Lexer
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm15(out *jwriter.Writer, in *swarm.NamedGenericResource) {
+func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm15(out *jwriter.Writer, in swarm.NamedGenericResource) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -5284,7 +5284,7 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypesRegistry(in *jlexer.Lexe
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesRegistry(out *jwriter.Writer, in *registry.ServiceConfig) {
+func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesRegistry(out *jwriter.Writer, in registry.ServiceConfig) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -5363,7 +5363,7 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesRegistry(out *jwriter.Wr
 				if v136Value == nil {
 					out.RawString("null")
 				} else {
-					easyjson6601e8cdEncodeGithubComDockerDockerApiTypesRegistry1(out, &*v136Value)
+					easyjson6601e8cdEncodeGithubComDockerDockerApiTypesRegistry1(out, *v136Value)
 				}
 			}
 			out.RawByte('}')
@@ -5445,7 +5445,7 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypesRegistry1(in *jlexer.Lex
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesRegistry1(out *jwriter.Writer, in *registry.IndexInfo) {
+func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesRegistry1(out *jwriter.Writer, in registry.IndexInfo) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -5603,7 +5603,7 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypes3(in *jlexer.Lexer, out 
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComDockerDockerApiTypes3(out *jwriter.Writer, in *types.PluginsInfo) {
+func easyjson6601e8cdEncodeGithubComDockerDockerApiTypes3(out *jwriter.Writer, in types.PluginsInfo) {
 	out.RawByte('{')
 	first := true
 	_ = first

--- a/pkg/docker/types/types_easyjson.go
+++ b/pkg/docker/types/types_easyjson.go
@@ -106,14 +106,14 @@ func easyjson6601e8cdDecodeGithubComStackroxRoxPkgDockerTypes(in *jlexer.Lexer, 
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes(out *jwriter.Writer, in Data) {
+func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes(out *jwriter.Writer, in *Data) {
 	out.RawByte('{')
 	first := true
 	_ = first
 	{
 		const prefix string = ",\"Info\":"
 		out.RawString(prefix[1:])
-		easyjson6601e8cdEncodeGithubComDockerDockerApiTypes(out, in.Info)
+		easyjson6601e8cdEncodeGithubComDockerDockerApiTypes(out, &in.Info)
 	}
 	{
 		const prefix string = ",\"Containers\":"
@@ -126,7 +126,7 @@ func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes(out *jwriter.Write
 				if v3 > 0 {
 					out.RawByte(',')
 				}
-				easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes1(out, v4)
+				easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes1(out, &v4)
 			}
 			out.RawByte(']')
 		}
@@ -142,7 +142,7 @@ func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes(out *jwriter.Write
 				if v5 > 0 {
 					out.RawByte(',')
 				}
-				easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes2(out, v6)
+				easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes2(out, &v6)
 			}
 			out.RawByte(']')
 		}
@@ -150,20 +150,20 @@ func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes(out *jwriter.Write
 	{
 		const prefix string = ",\"BridgeNetwork\":"
 		out.RawString(prefix)
-		easyjson6601e8cdEncodeGithubComDockerDockerApiTypes1(out, in.BridgeNetwork)
+		easyjson6601e8cdEncodeGithubComDockerDockerApiTypes1(out, &in.BridgeNetwork)
 	}
 	out.RawByte('}')
 }
 
 // MarshalJSON supports json.Marshaler interface
-func (v Data) MarshalJSON() ([]byte, error) {
+func (v *Data) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
 	easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes(&w, v)
 	return w.Buffer.BuildBytes(), w.Error
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
-func (v Data) MarshalEasyJSON(w *jwriter.Writer) {
+func (v *Data) MarshalEasyJSON(w *jwriter.Writer) {
 	easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes(w, v)
 }
 
@@ -324,7 +324,7 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypes1(in *jlexer.Lexer, out 
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComDockerDockerApiTypes1(out *jwriter.Writer, in types.NetworkResource) {
+func easyjson6601e8cdEncodeGithubComDockerDockerApiTypes1(out *jwriter.Writer, in *types.NetworkResource) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -361,7 +361,7 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypes1(out *jwriter.Writer, i
 	{
 		const prefix string = ",\"IPAM\":"
 		out.RawString(prefix)
-		easyjson6601e8cdEncodeGithubComDockerDockerApiTypesNetwork(out, in.IPAM)
+		easyjson6601e8cdEncodeGithubComDockerDockerApiTypesNetwork(out, &in.IPAM)
 	}
 	{
 		const prefix string = ",\"Internal\":"
@@ -381,7 +381,7 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypes1(out *jwriter.Writer, i
 	{
 		const prefix string = ",\"ConfigFrom\":"
 		out.RawString(prefix)
-		easyjson6601e8cdEncodeGithubComDockerDockerApiTypesNetwork1(out, in.ConfigFrom)
+		easyjson6601e8cdEncodeGithubComDockerDockerApiTypesNetwork1(out, &in.ConfigFrom)
 	}
 	{
 		const prefix string = ",\"ConfigOnly\":"
@@ -404,7 +404,7 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypes1(out *jwriter.Writer, i
 				}
 				out.String(string(v12Name))
 				out.RawByte(':')
-				easyjson6601e8cdEncodeGithubComDockerDockerApiTypes2(out, v12Value)
+				easyjson6601e8cdEncodeGithubComDockerDockerApiTypes2(out, &v12Value)
 			}
 			out.RawByte('}')
 		}
@@ -460,7 +460,7 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypes1(out *jwriter.Writer, i
 				if v15 > 0 {
 					out.RawByte(',')
 				}
-				easyjson6601e8cdEncodeGithubComDockerDockerApiTypesNetwork2(out, v16)
+				easyjson6601e8cdEncodeGithubComDockerDockerApiTypesNetwork2(out, &v16)
 			}
 			out.RawByte(']')
 		}
@@ -479,7 +479,7 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypes1(out *jwriter.Writer, i
 				}
 				out.String(string(v17Name))
 				out.RawByte(':')
-				easyjson6601e8cdEncodeGithubComDockerDockerApiTypesNetwork3(out, v17Value)
+				easyjson6601e8cdEncodeGithubComDockerDockerApiTypesNetwork3(out, &v17Value)
 			}
 			out.RawByte('}')
 		}
@@ -565,7 +565,7 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypesNetwork3(in *jlexer.Lexe
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesNetwork3(out *jwriter.Writer, in network.ServiceInfo) {
+func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesNetwork3(out *jwriter.Writer, in *network.ServiceInfo) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -606,7 +606,7 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesNetwork3(out *jwriter.Wr
 				if v22 > 0 {
 					out.RawByte(',')
 				}
-				easyjson6601e8cdEncodeGithubComDockerDockerApiTypesNetwork4(out, v23)
+				easyjson6601e8cdEncodeGithubComDockerDockerApiTypesNetwork4(out, &v23)
 			}
 			out.RawByte(']')
 		}
@@ -664,7 +664,7 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypesNetwork4(in *jlexer.Lexe
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesNetwork4(out *jwriter.Writer, in network.Task) {
+func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesNetwork4(out *jwriter.Writer, in *network.Task) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -739,7 +739,7 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypesNetwork2(in *jlexer.Lexe
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesNetwork2(out *jwriter.Writer, in network.PeerInfo) {
+func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesNetwork2(out *jwriter.Writer, in *network.PeerInfo) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -794,7 +794,7 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypes2(in *jlexer.Lexer, out 
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComDockerDockerApiTypes2(out *jwriter.Writer, in types.EndpointResource) {
+func easyjson6601e8cdEncodeGithubComDockerDockerApiTypes2(out *jwriter.Writer, in *types.EndpointResource) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -856,7 +856,7 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypesNetwork1(in *jlexer.Lexe
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesNetwork1(out *jwriter.Writer, in network.ConfigReference) {
+func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesNetwork1(out *jwriter.Writer, in *network.ConfigReference) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -937,7 +937,7 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypesNetwork(in *jlexer.Lexer
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesNetwork(out *jwriter.Writer, in network.IPAM) {
+func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesNetwork(out *jwriter.Writer, in *network.IPAM) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -978,7 +978,7 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesNetwork(out *jwriter.Wri
 				if v29 > 0 {
 					out.RawByte(',')
 				}
-				easyjson6601e8cdEncodeGithubComDockerDockerApiTypesNetwork5(out, v30)
+				easyjson6601e8cdEncodeGithubComDockerDockerApiTypesNetwork5(out, &v30)
 			}
 			out.RawByte(']')
 		}
@@ -1040,7 +1040,7 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypesNetwork5(in *jlexer.Lexe
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesNetwork5(out *jwriter.Writer, in network.IPAMConfig) {
+func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesNetwork5(out *jwriter.Writer, in *network.IPAMConfig) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -1150,14 +1150,14 @@ func easyjson6601e8cdDecodeGithubComStackroxRoxPkgDockerTypes2(in *jlexer.Lexer,
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes2(out *jwriter.Writer, in ImageWrap) {
+func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes2(out *jwriter.Writer, in *ImageWrap) {
 	out.RawByte('{')
 	first := true
 	_ = first
 	{
 		const prefix string = ",\"image\":"
 		out.RawString(prefix[1:])
-		easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes3(out, in.Image)
+		easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes3(out, &in.Image)
 	}
 	{
 		const prefix string = ",\"history\":"
@@ -1170,7 +1170,7 @@ func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes2(out *jwriter.Writ
 				if v34 > 0 {
 					out.RawByte(',')
 				}
-				easyjson6601e8cdEncodeGithubComDockerDockerApiTypesImage(out, v35)
+				easyjson6601e8cdEncodeGithubComDockerDockerApiTypesImage(out, &v35)
 			}
 			out.RawByte(']')
 		}
@@ -1239,7 +1239,7 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypesImage(in *jlexer.Lexer, 
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesImage(out *jwriter.Writer, in image.HistoryResponseItem) {
+func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesImage(out *jwriter.Writer, in *image.HistoryResponseItem) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -1373,7 +1373,7 @@ func easyjson6601e8cdDecodeGithubComStackroxRoxPkgDockerTypes3(in *jlexer.Lexer,
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes3(out *jwriter.Writer, in ImageInspect) {
+func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes3(out *jwriter.Writer, in *ImageInspect) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -1413,7 +1413,7 @@ func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes3(out *jwriter.Writ
 	if in.Config != nil {
 		const prefix string = ",\"Config\":"
 		out.RawString(prefix)
-		easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes4(out, *in.Config)
+		easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes4(out, &*in.Config)
 	}
 	out.RawByte('}')
 }
@@ -1458,7 +1458,7 @@ func easyjson6601e8cdDecodeGithubComStackroxRoxPkgDockerTypes4(in *jlexer.Lexer,
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes4(out *jwriter.Writer, in Config) {
+func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes4(out *jwriter.Writer, in *Config) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -1466,7 +1466,7 @@ func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes4(out *jwriter.Writ
 		const prefix string = ",\"Healthcheck\":"
 		first = false
 		out.RawString(prefix[1:])
-		easyjson6601e8cdEncodeGithubComDockerDockerApiTypesContainer(out, *in.Healthcheck)
+		easyjson6601e8cdEncodeGithubComDockerDockerApiTypesContainer(out, &*in.Healthcheck)
 	}
 	if in.User != "" {
 		const prefix string = ",\"User\":"
@@ -1540,7 +1540,7 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypesContainer(in *jlexer.Lex
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesContainer(out *jwriter.Writer, in container.HealthConfig) {
+func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesContainer(out *jwriter.Writer, in *container.HealthConfig) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -1702,7 +1702,7 @@ func easyjson6601e8cdDecodeGithubComStackroxRoxPkgDockerTypes1(in *jlexer.Lexer,
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes1(out *jwriter.Writer, in ContainerJSON) {
+func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes1(out *jwriter.Writer, in *ContainerJSON) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -1716,7 +1716,7 @@ func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes1(out *jwriter.Writ
 				if v49 > 0 {
 					out.RawByte(',')
 				}
-				easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes5(out, v50)
+				easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes5(out, &v50)
 			}
 			out.RawByte(']')
 		}
@@ -1729,7 +1729,7 @@ func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes1(out *jwriter.Writ
 		} else {
 			out.RawString(prefix)
 		}
-		easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes4(out, *in.Config)
+		easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes4(out, &*in.Config)
 	}
 	if in.NetworkSettings != nil {
 		const prefix string = ",\"NetworkSettings\":"
@@ -1739,7 +1739,7 @@ func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes1(out *jwriter.Writ
 		} else {
 			out.RawString(prefix)
 		}
-		easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes6(out, *in.NetworkSettings)
+		easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes6(out, &*in.NetworkSettings)
 	}
 	{
 		const prefix string = ",\"Id\":"
@@ -1759,7 +1759,7 @@ func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes1(out *jwriter.Writ
 	if in.State != nil {
 		const prefix string = ",\"State\":"
 		out.RawString(prefix)
-		easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes7(out, *in.State)
+		easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes7(out, &*in.State)
 	}
 	if in.Name != "" {
 		const prefix string = ",\"Name\":"
@@ -1774,7 +1774,7 @@ func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes1(out *jwriter.Writ
 	if in.HostConfig != nil {
 		const prefix string = ",\"HostConfig\":"
 		out.RawString(prefix)
-		easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes8(out, *in.HostConfig)
+		easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes8(out, &*in.HostConfig)
 	}
 	out.RawByte('}')
 }
@@ -1916,7 +1916,7 @@ func easyjson6601e8cdDecodeGithubComStackroxRoxPkgDockerTypes8(in *jlexer.Lexer,
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes8(out *jwriter.Writer, in HostConfig) {
+func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes8(out *jwriter.Writer, in *HostConfig) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -1991,7 +1991,7 @@ func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes8(out *jwriter.Writ
 		} else {
 			out.RawString(prefix)
 		}
-		easyjson6601e8cdEncodeGithubComDockerDockerApiTypesContainer1(out, in.RestartPolicy)
+		easyjson6601e8cdEncodeGithubComDockerDockerApiTypesContainer1(out, &in.RestartPolicy)
 	}
 	if in.IpcMode != "" {
 		const prefix string = ",\"IpcMode\":"
@@ -2087,7 +2087,7 @@ func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes8(out *jwriter.Writ
 				if v60 > 0 {
 					out.RawByte(',')
 				}
-				easyjson6601e8cdEncodeGithubComDockerDockerApiTypesContainer2(out, v61)
+				easyjson6601e8cdEncodeGithubComDockerDockerApiTypesContainer2(out, &v61)
 			}
 			out.RawByte(']')
 		}
@@ -2109,7 +2109,7 @@ func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes8(out *jwriter.Writ
 				if v63 == nil {
 					out.RawString("null")
 				} else {
-					easyjson6601e8cdEncodeGithubComDockerGoUnits(out, *v63)
+					easyjson6601e8cdEncodeGithubComDockerGoUnits(out, &*v63)
 				}
 			}
 			out.RawByte(']')
@@ -2152,7 +2152,7 @@ func easyjson6601e8cdDecodeGithubComDockerGoUnits(in *jlexer.Lexer, out *go_unit
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComDockerGoUnits(out *jwriter.Writer, in go_units.Ulimit) {
+func easyjson6601e8cdEncodeGithubComDockerGoUnits(out *jwriter.Writer, in *go_units.Ulimit) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -2208,7 +2208,7 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypesContainer2(in *jlexer.Le
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesContainer2(out *jwriter.Writer, in container.DeviceMapping) {
+func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesContainer2(out *jwriter.Writer, in *container.DeviceMapping) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -2262,7 +2262,7 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypesContainer1(in *jlexer.Le
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesContainer1(out *jwriter.Writer, in container.RestartPolicy) {
+func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesContainer1(out *jwriter.Writer, in *container.RestartPolicy) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -2319,7 +2319,7 @@ func easyjson6601e8cdDecodeGithubComStackroxRoxPkgDockerTypes7(in *jlexer.Lexer,
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes7(out *jwriter.Writer, in ContainerState) {
+func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes7(out *jwriter.Writer, in *ContainerState) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -2337,7 +2337,7 @@ func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes7(out *jwriter.Writ
 		} else {
 			out.RawString(prefix)
 		}
-		easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes9(out, *in.Health)
+		easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes9(out, &*in.Health)
 	}
 	out.RawByte('}')
 }
@@ -2372,7 +2372,7 @@ func easyjson6601e8cdDecodeGithubComStackroxRoxPkgDockerTypes9(in *jlexer.Lexer,
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes9(out *jwriter.Writer, in Health) {
+func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes9(out *jwriter.Writer, in *Health) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -2474,7 +2474,7 @@ func easyjson6601e8cdDecodeGithubComStackroxRoxPkgDockerTypes6(in *jlexer.Lexer,
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes6(out *jwriter.Writer, in NetworkSettings) {
+func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes6(out *jwriter.Writer, in *NetworkSettings) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -2493,7 +2493,7 @@ func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes6(out *jwriter.Writ
 				}
 				out.String(string(v67Name))
 				out.RawByte(':')
-				easyjson6601e8cdEncode(out, v67Value)
+				easyjson6601e8cdEncode(out, &v67Value)
 			}
 			out.RawByte('}')
 		}
@@ -2525,7 +2525,7 @@ func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes6(out *jwriter.Writ
 						if v69 > 0 {
 							out.RawByte(',')
 						}
-						easyjson6601e8cdEncodeGithubComDockerGoConnectionsNat(out, v70)
+						easyjson6601e8cdEncodeGithubComDockerGoConnectionsNat(out, &v70)
 					}
 					out.RawByte(']')
 				}
@@ -2568,7 +2568,7 @@ func easyjson6601e8cdDecodeGithubComDockerGoConnectionsNat(in *jlexer.Lexer, out
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComDockerGoConnectionsNat(out *jwriter.Writer, in nat.PortBinding) {
+func easyjson6601e8cdEncodeGithubComDockerGoConnectionsNat(out *jwriter.Writer, in *nat.PortBinding) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -2613,7 +2613,7 @@ func easyjson6601e8cdDecode(in *jlexer.Lexer, out *struct{}) {
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncode(out *jwriter.Writer, in struct{}) {
+func easyjson6601e8cdEncode(out *jwriter.Writer, in *struct{}) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -2662,7 +2662,7 @@ func easyjson6601e8cdDecodeGithubComStackroxRoxPkgDockerTypes5(in *jlexer.Lexer,
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes5(out *jwriter.Writer, in MountPoint) {
+func easyjson6601e8cdEncodeGithubComStackroxRoxPkgDockerTypes5(out *jwriter.Writer, in *MountPoint) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -3090,7 +3090,7 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypes(in *jlexer.Lexer, out *
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComDockerDockerApiTypes(out *jwriter.Writer, in types.Info) {
+func easyjson6601e8cdEncodeGithubComDockerDockerApiTypes(out *jwriter.Writer, in *types.Info) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -3176,7 +3176,7 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypes(out *jwriter.Writer, in
 	{
 		const prefix string = ",\"Plugins\":"
 		out.RawString(prefix)
-		easyjson6601e8cdEncodeGithubComDockerDockerApiTypes3(out, in.Plugins)
+		easyjson6601e8cdEncodeGithubComDockerDockerApiTypes3(out, &in.Plugins)
 	}
 	{
 		const prefix string = ",\"MemoryLimit\":"
@@ -3319,7 +3319,7 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypes(out *jwriter.Writer, in
 		if in.RegistryConfig == nil {
 			out.RawString("null")
 		} else {
-			easyjson6601e8cdEncodeGithubComDockerDockerApiTypesRegistry(out, *in.RegistryConfig)
+			easyjson6601e8cdEncodeGithubComDockerDockerApiTypesRegistry(out, &*in.RegistryConfig)
 		}
 	}
 	{
@@ -3343,7 +3343,7 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypes(out *jwriter.Writer, in
 				if v87 > 0 {
 					out.RawByte(',')
 				}
-				easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm(out, v88)
+				easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm(out, &v88)
 			}
 			out.RawByte(']')
 		}
@@ -3425,7 +3425,7 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypes(out *jwriter.Writer, in
 				}
 				out.String(string(v91Name))
 				out.RawByte(':')
-				easyjson6601e8cdEncodeGithubComDockerDockerApiTypes4(out, v91Value)
+				easyjson6601e8cdEncodeGithubComDockerDockerApiTypes4(out, &v91Value)
 			}
 			out.RawByte('}')
 		}
@@ -3438,7 +3438,7 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypes(out *jwriter.Writer, in
 	{
 		const prefix string = ",\"Swarm\":"
 		out.RawString(prefix)
-		easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm1(out, in.Swarm)
+		easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm1(out, &in.Swarm)
 	}
 	{
 		const prefix string = ",\"LiveRestoreEnabled\":"
@@ -3458,17 +3458,17 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypes(out *jwriter.Writer, in
 	{
 		const prefix string = ",\"ContainerdCommit\":"
 		out.RawString(prefix)
-		easyjson6601e8cdEncodeGithubComDockerDockerApiTypes5(out, in.ContainerdCommit)
+		easyjson6601e8cdEncodeGithubComDockerDockerApiTypes5(out, &in.ContainerdCommit)
 	}
 	{
 		const prefix string = ",\"RuncCommit\":"
 		out.RawString(prefix)
-		easyjson6601e8cdEncodeGithubComDockerDockerApiTypes5(out, in.RuncCommit)
+		easyjson6601e8cdEncodeGithubComDockerDockerApiTypes5(out, &in.RuncCommit)
 	}
 	{
 		const prefix string = ",\"InitCommit\":"
 		out.RawString(prefix)
-		easyjson6601e8cdEncodeGithubComDockerDockerApiTypes5(out, in.InitCommit)
+		easyjson6601e8cdEncodeGithubComDockerDockerApiTypes5(out, &in.InitCommit)
 	}
 	{
 		const prefix string = ",\"SecurityOptions\":"
@@ -3500,7 +3500,7 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypes(out *jwriter.Writer, in
 				if v94 > 0 {
 					out.RawByte(',')
 				}
-				easyjson6601e8cdEncodeGithubComDockerDockerApiTypes6(out, v95)
+				easyjson6601e8cdEncodeGithubComDockerDockerApiTypes6(out, &v95)
 			}
 			out.RawByte(']')
 		}
@@ -3556,7 +3556,7 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypes6(in *jlexer.Lexer, out 
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComDockerDockerApiTypes6(out *jwriter.Writer, in types.NetworkAddressPool) {
+func easyjson6601e8cdEncodeGithubComDockerDockerApiTypes6(out *jwriter.Writer, in *types.NetworkAddressPool) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -3605,7 +3605,7 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypes5(in *jlexer.Lexer, out 
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComDockerDockerApiTypes5(out *jwriter.Writer, in types.Commit) {
+func easyjson6601e8cdEncodeGithubComDockerDockerApiTypes5(out *jwriter.Writer, in *types.Commit) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -3720,7 +3720,7 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypesSwarm1(in *jlexer.Lexer,
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm1(out *jwriter.Writer, in swarm.Info) {
+func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm1(out *jwriter.Writer, in *swarm.Info) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -3760,7 +3760,7 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm1(out *jwriter.Writ
 				if v100 > 0 {
 					out.RawByte(',')
 				}
-				easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm2(out, v101)
+				easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm2(out, &v101)
 			}
 			out.RawByte(']')
 		}
@@ -3778,7 +3778,7 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm1(out *jwriter.Writ
 	if in.Cluster != nil {
 		const prefix string = ",\"Cluster\":"
 		out.RawString(prefix)
-		easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm3(out, *in.Cluster)
+		easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm3(out, &*in.Cluster)
 	}
 	if len(in.Warnings) != 0 {
 		const prefix string = ",\"Warnings\":"
@@ -3870,7 +3870,7 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypesSwarm3(in *jlexer.Lexer,
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm3(out *jwriter.Writer, in swarm.ClusterInfo) {
+func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm3(out *jwriter.Writer, in *swarm.ClusterInfo) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -3882,12 +3882,12 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm3(out *jwriter.Writ
 	{
 		const prefix string = ",\"Spec\":"
 		out.RawString(prefix)
-		easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm4(out, in.Spec)
+		easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm4(out, &in.Spec)
 	}
 	{
 		const prefix string = ",\"TLSInfo\":"
 		out.RawString(prefix)
-		easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm5(out, in.TLSInfo)
+		easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm5(out, &in.TLSInfo)
 	}
 	{
 		const prefix string = ",\"RootRotationInProgress\":"
@@ -3923,7 +3923,7 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm3(out *jwriter.Writ
 	if true {
 		const prefix string = ",\"Version\":"
 		out.RawString(prefix)
-		easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm6(out, in.Version)
+		easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm6(out, &in.Version)
 	}
 	if true {
 		const prefix string = ",\"CreatedAt\":"
@@ -3968,7 +3968,7 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypesSwarm6(in *jlexer.Lexer,
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm6(out *jwriter.Writer, in swarm.Version) {
+func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm6(out *jwriter.Writer, in *swarm.Version) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -4025,7 +4025,7 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypesSwarm5(in *jlexer.Lexer,
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm5(out *jwriter.Writer, in swarm.TLSInfo) {
+func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm5(out *jwriter.Writer, in *swarm.TLSInfo) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -4116,7 +4116,7 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypesSwarm4(in *jlexer.Lexer,
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm4(out *jwriter.Writer, in swarm.Spec) {
+func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm4(out *jwriter.Writer, in *swarm.Spec) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -4124,7 +4124,7 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm4(out *jwriter.Writ
 		const prefix string = ",\"Orchestration\":"
 		first = false
 		out.RawString(prefix[1:])
-		easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm7(out, in.Orchestration)
+		easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm7(out, &in.Orchestration)
 	}
 	if true {
 		const prefix string = ",\"Raft\":"
@@ -4134,7 +4134,7 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm4(out *jwriter.Writ
 		} else {
 			out.RawString(prefix)
 		}
-		easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm8(out, in.Raft)
+		easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm8(out, &in.Raft)
 	}
 	if true {
 		const prefix string = ",\"Dispatcher\":"
@@ -4144,7 +4144,7 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm4(out *jwriter.Writ
 		} else {
 			out.RawString(prefix)
 		}
-		easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm9(out, in.Dispatcher)
+		easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm9(out, &in.Dispatcher)
 	}
 	if true {
 		const prefix string = ",\"CAConfig\":"
@@ -4154,7 +4154,7 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm4(out *jwriter.Writ
 		} else {
 			out.RawString(prefix)
 		}
-		easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm10(out, in.CAConfig)
+		easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm10(out, &in.CAConfig)
 	}
 	if true {
 		const prefix string = ",\"TaskDefaults\":"
@@ -4164,7 +4164,7 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm4(out *jwriter.Writ
 		} else {
 			out.RawString(prefix)
 		}
-		easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm11(out, in.TaskDefaults)
+		easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm11(out, &in.TaskDefaults)
 	}
 	if true {
 		const prefix string = ",\"EncryptionConfig\":"
@@ -4174,7 +4174,7 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm4(out *jwriter.Writ
 		} else {
 			out.RawString(prefix)
 		}
-		easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm12(out, in.EncryptionConfig)
+		easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm12(out, &in.EncryptionConfig)
 	}
 	if in.Name != "" {
 		const prefix string = ",\"Name\":"
@@ -4245,7 +4245,7 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypesSwarm12(in *jlexer.Lexer
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm12(out *jwriter.Writer, in swarm.EncryptionConfig) {
+func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm12(out *jwriter.Writer, in *swarm.EncryptionConfig) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -4295,7 +4295,7 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypesSwarm11(in *jlexer.Lexer
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm11(out *jwriter.Writer, in swarm.TaskDefaults) {
+func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm11(out *jwriter.Writer, in *swarm.TaskDefaults) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -4303,7 +4303,7 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm11(out *jwriter.Wri
 		const prefix string = ",\"LogDriver\":"
 		first = false
 		out.RawString(prefix[1:])
-		easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm13(out, *in.LogDriver)
+		easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm13(out, &*in.LogDriver)
 	}
 	out.RawByte('}')
 }
@@ -4358,7 +4358,7 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypesSwarm13(in *jlexer.Lexer
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm13(out *jwriter.Writer, in swarm.Driver) {
+func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm13(out *jwriter.Writer, in *swarm.Driver) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -4462,7 +4462,7 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypesSwarm10(in *jlexer.Lexer
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm10(out *jwriter.Writer, in swarm.CAConfig) {
+func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm10(out *jwriter.Writer, in *swarm.CAConfig) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -4489,7 +4489,7 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm10(out *jwriter.Wri
 				if v119 == nil {
 					out.RawString("null")
 				} else {
-					easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm14(out, *v119)
+					easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm14(out, &*v119)
 				}
 			}
 			out.RawByte(']')
@@ -4582,7 +4582,7 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypesSwarm14(in *jlexer.Lexer
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm14(out *jwriter.Writer, in swarm.ExternalCA) {
+func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm14(out *jwriter.Writer, in *swarm.ExternalCA) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -4653,7 +4653,7 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypesSwarm9(in *jlexer.Lexer,
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm9(out *jwriter.Writer, in swarm.DispatcherConfig) {
+func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm9(out *jwriter.Writer, in *swarm.DispatcherConfig) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -4712,7 +4712,7 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypesSwarm8(in *jlexer.Lexer,
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm8(out *jwriter.Writer, in swarm.RaftConfig) {
+func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm8(out *jwriter.Writer, in *swarm.RaftConfig) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -4798,7 +4798,7 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypesSwarm7(in *jlexer.Lexer,
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm7(out *jwriter.Writer, in swarm.OrchestrationConfig) {
+func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm7(out *jwriter.Writer, in *swarm.OrchestrationConfig) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -4843,7 +4843,7 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypesSwarm2(in *jlexer.Lexer,
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm2(out *jwriter.Writer, in swarm.Peer) {
+func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm2(out *jwriter.Writer, in *swarm.Peer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -4913,7 +4913,7 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypes4(in *jlexer.Lexer, out 
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComDockerDockerApiTypes4(out *jwriter.Writer, in types.Runtime) {
+func easyjson6601e8cdEncodeGithubComDockerDockerApiTypes4(out *jwriter.Writer, in *types.Runtime) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -4987,7 +4987,7 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypesSwarm(in *jlexer.Lexer, 
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm(out *jwriter.Writer, in swarm.GenericResource) {
+func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm(out *jwriter.Writer, in *swarm.GenericResource) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -4995,7 +4995,7 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm(out *jwriter.Write
 		const prefix string = ",\"NamedResourceSpec\":"
 		first = false
 		out.RawString(prefix[1:])
-		easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm15(out, *in.NamedResourceSpec)
+		easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm15(out, &*in.NamedResourceSpec)
 	}
 	if in.DiscreteResourceSpec != nil {
 		const prefix string = ",\"DiscreteResourceSpec\":"
@@ -5005,7 +5005,7 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm(out *jwriter.Write
 		} else {
 			out.RawString(prefix)
 		}
-		easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm16(out, *in.DiscreteResourceSpec)
+		easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm16(out, &*in.DiscreteResourceSpec)
 	}
 	out.RawByte('}')
 }
@@ -5042,7 +5042,7 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypesSwarm16(in *jlexer.Lexer
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm16(out *jwriter.Writer, in swarm.DiscreteGenericResource) {
+func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm16(out *jwriter.Writer, in *swarm.DiscreteGenericResource) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -5097,7 +5097,7 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypesSwarm15(in *jlexer.Lexer
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm15(out *jwriter.Writer, in swarm.NamedGenericResource) {
+func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesSwarm15(out *jwriter.Writer, in *swarm.NamedGenericResource) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -5284,7 +5284,7 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypesRegistry(in *jlexer.Lexe
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesRegistry(out *jwriter.Writer, in registry.ServiceConfig) {
+func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesRegistry(out *jwriter.Writer, in *registry.ServiceConfig) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -5363,7 +5363,7 @@ func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesRegistry(out *jwriter.Wr
 				if v136Value == nil {
 					out.RawString("null")
 				} else {
-					easyjson6601e8cdEncodeGithubComDockerDockerApiTypesRegistry1(out, *v136Value)
+					easyjson6601e8cdEncodeGithubComDockerDockerApiTypesRegistry1(out, &*v136Value)
 				}
 			}
 			out.RawByte('}')
@@ -5445,7 +5445,7 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypesRegistry1(in *jlexer.Lex
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesRegistry1(out *jwriter.Writer, in registry.IndexInfo) {
+func easyjson6601e8cdEncodeGithubComDockerDockerApiTypesRegistry1(out *jwriter.Writer, in *registry.IndexInfo) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -5603,7 +5603,7 @@ func easyjson6601e8cdDecodeGithubComDockerDockerApiTypes3(in *jlexer.Lexer, out 
 		in.Consumed()
 	}
 }
-func easyjson6601e8cdEncodeGithubComDockerDockerApiTypes3(out *jwriter.Writer, in types.PluginsInfo) {
+func easyjson6601e8cdEncodeGithubComDockerDockerApiTypes3(out *jwriter.Writer, in *types.PluginsInfo) {
 	out.RawByte('{')
 	first := true
 	_ = first

--- a/roxctl/sensor/generate/generate.go
+++ b/roxctl/sensor/generate/generate.go
@@ -53,13 +53,13 @@ type sensorGenerateCommand struct {
 	enablePodSecurityPolicies bool
 
 	// injected or constructed values
-	cluster     storage.Cluster
+	cluster     *storage.Cluster
 	env         environment.Environment
 	getBundleFn util.GetBundleFn
 }
 
-func defaultCluster() storage.Cluster {
-	return storage.Cluster{
+func defaultCluster() *storage.Cluster {
+	return &storage.Cluster{
 		TolerationsConfig: &storage.TolerationsConfig{
 			Disabled: false,
 		},
@@ -188,7 +188,7 @@ func (s *sensorGenerateCommand) createCluster(ctx context.Context, svc v1.Cluste
 		s.cluster.DynamicConfig.AdmissionControllerConfig = nil
 	}
 
-	response, err := svc.PostCluster(ctx, &s.cluster)
+	response, err := svc.PostCluster(ctx, s.cluster)
 	if err != nil {
 		return "", err
 	}

--- a/roxctl/sensor/generate/generate_test.go
+++ b/roxctl/sensor/generate/generate_test.go
@@ -70,7 +70,6 @@ func (m *mockClustersServiceServer) GetClusters(ctx context.Context, in *v1.GetC
 
 type sensorGenerateTestSuite struct {
 	suite.Suite
-	cmd sensorGenerateCommand
 }
 
 type expectedWarning struct {
@@ -122,7 +121,9 @@ func (s *sensorGenerateTestSuite) newTestMockEnvironmentWithConn(conn *grpc.Clie
 func (s *sensorGenerateTestSuite) createMockedCommand(getDefaultsF getDefaultsFn, postClusterF postClusterFn) (*bytes.Buffer, *bytes.Buffer, closeFunction, sensorGenerateCommand, *mockClustersServiceServer) {
 	var out, errOut *bytes.Buffer
 	conn, closeF, mock := s.createGRPCMockClustersService(getDefaultsF, postClusterF)
-	cmd := s.cmd
+	cmd := sensorGenerateCommand{
+		cluster: &storage.Cluster{},
+	}
 	cmd.env, out, errOut = s.newTestMockEnvironmentWithConn(conn)
 	return out, errOut, closeF, cmd, mock
 }

--- a/roxctl/sensor/generate/k8s.go
+++ b/roxctl/sensor/generate/k8s.go
@@ -23,7 +23,7 @@ func k8s(generateCmd *sensorGenerateCommand) *cobra.Command {
 		RunE: util.RunENoArgs(func(c *cobra.Command) error {
 			k8sCommand.ConstructK8s()
 
-			if err := clusterValidation.ValidatePartial(&k8sCommand.cluster); err.ToError() != nil {
+			if err := clusterValidation.ValidatePartial(k8sCommand.cluster); err.ToError() != nil {
 				return err.ToError()
 			}
 			return k8sCommand.fullClusterCreation()

--- a/roxctl/sensor/generate/openshift.go
+++ b/roxctl/sensor/generate/openshift.go
@@ -67,7 +67,7 @@ func openshift(generateCmd *sensorGenerateCommand) *cobra.Command {
 				return err
 			}
 
-			if err := clusterValidation.ValidatePartial(&openshiftCommand.cluster).ToError(); err != nil {
+			if err := clusterValidation.ValidatePartial(openshiftCommand.cluster).ToError(); err != nil {
 				return err
 			}
 			return openshiftCommand.fullClusterCreation()

--- a/sensor/kubernetes/listener/resources/rbac/store_impl_test.go
+++ b/sensor/kubernetes/listener/resources/rbac/store_impl_test.go
@@ -730,27 +730,27 @@ func TestStoreGetPermissionLevelForDeployment(t *testing.T) {
 	}
 
 	testCases := []struct {
-		deployment storage.Deployment
+		deployment *storage.Deployment
 		expected   storage.PermissionLevel
 	}{
-		{expected: storage.PermissionLevel_ELEVATED_CLUSTER_WIDE, deployment: storage.Deployment{ServiceAccount: "cluster-elevated-subject", Namespace: "n1"}},
-		{expected: storage.PermissionLevel_ELEVATED_CLUSTER_WIDE, deployment: storage.Deployment{ServiceAccount: "cluster-elevated-subject-2", Namespace: "n1"}},
-		{expected: storage.PermissionLevel_ELEVATED_CLUSTER_WIDE, deployment: storage.Deployment{ServiceAccount: "cluster-elevated-subject-3"}},
-		{expected: storage.PermissionLevel_ELEVATED_CLUSTER_WIDE, deployment: storage.Deployment{ServiceAccount: "cluster-elevated-subject-4"}},
-		{expected: storage.PermissionLevel_CLUSTER_ADMIN, deployment: storage.Deployment{ServiceAccount: "cluster-admin-2", Namespace: "n1"}},
-		{expected: storage.PermissionLevel_ELEVATED_CLUSTER_WIDE, deployment: storage.Deployment{ServiceAccount: "cluster-namespace-subject", Namespace: "n1"}},
-		{expected: storage.PermissionLevel_NONE, deployment: storage.Deployment{ServiceAccount: "cluster-elevated-subject"}},
-		{expected: storage.PermissionLevel_NONE, deployment: storage.Deployment{ServiceAccount: "cluster-admin-subject", Namespace: "n1"}},
-		{expected: storage.PermissionLevel_CLUSTER_ADMIN, deployment: storage.Deployment{ServiceAccount: "cluster-admin-subject"}},
-		{expected: storage.PermissionLevel_NONE, deployment: storage.Deployment{ServiceAccount: "cluster-none-subject"}},
-		{expected: storage.PermissionLevel_NONE, deployment: storage.Deployment{ServiceAccount: "cluster-none-subject", Namespace: "n1"}},
-		{expected: storage.PermissionLevel_ELEVATED_IN_NAMESPACE, deployment: storage.Deployment{ServiceAccount: "admin-subject", Namespace: "n1"}},
-		{expected: storage.PermissionLevel_DEFAULT, deployment: storage.Deployment{ServiceAccount: "default-subject", Namespace: "n1"}},
-		{expected: storage.PermissionLevel_ELEVATED_IN_NAMESPACE, deployment: storage.Deployment{ServiceAccount: "elevated-subject", Namespace: "n1"}},
-		{expected: storage.PermissionLevel_ELEVATED_IN_NAMESPACE, deployment: storage.Deployment{ServiceAccount: "elevated-subject-2", Namespace: "n1"}},
-		{expected: storage.PermissionLevel_NONE, deployment: storage.Deployment{ServiceAccount: "elevated-subject-2", Namespace: "n2"}},
-		{expected: storage.PermissionLevel_NONE, deployment: storage.Deployment{ServiceAccount: "default-subject"}},
-		{expected: storage.PermissionLevel_NONE, deployment: storage.Deployment{ServiceAccount: "admin-subject"}},
+		{expected: storage.PermissionLevel_ELEVATED_CLUSTER_WIDE, deployment: &storage.Deployment{ServiceAccount: "cluster-elevated-subject", Namespace: "n1"}},
+		{expected: storage.PermissionLevel_ELEVATED_CLUSTER_WIDE, deployment: &storage.Deployment{ServiceAccount: "cluster-elevated-subject-2", Namespace: "n1"}},
+		{expected: storage.PermissionLevel_ELEVATED_CLUSTER_WIDE, deployment: &storage.Deployment{ServiceAccount: "cluster-elevated-subject-3"}},
+		{expected: storage.PermissionLevel_ELEVATED_CLUSTER_WIDE, deployment: &storage.Deployment{ServiceAccount: "cluster-elevated-subject-4"}},
+		{expected: storage.PermissionLevel_CLUSTER_ADMIN, deployment: &storage.Deployment{ServiceAccount: "cluster-admin-2", Namespace: "n1"}},
+		{expected: storage.PermissionLevel_ELEVATED_CLUSTER_WIDE, deployment: &storage.Deployment{ServiceAccount: "cluster-namespace-subject", Namespace: "n1"}},
+		{expected: storage.PermissionLevel_NONE, deployment: &storage.Deployment{ServiceAccount: "cluster-elevated-subject"}},
+		{expected: storage.PermissionLevel_NONE, deployment: &storage.Deployment{ServiceAccount: "cluster-admin-subject", Namespace: "n1"}},
+		{expected: storage.PermissionLevel_CLUSTER_ADMIN, deployment: &storage.Deployment{ServiceAccount: "cluster-admin-subject"}},
+		{expected: storage.PermissionLevel_NONE, deployment: &storage.Deployment{ServiceAccount: "cluster-none-subject"}},
+		{expected: storage.PermissionLevel_NONE, deployment: &storage.Deployment{ServiceAccount: "cluster-none-subject", Namespace: "n1"}},
+		{expected: storage.PermissionLevel_ELEVATED_IN_NAMESPACE, deployment: &storage.Deployment{ServiceAccount: "admin-subject", Namespace: "n1"}},
+		{expected: storage.PermissionLevel_DEFAULT, deployment: &storage.Deployment{ServiceAccount: "default-subject", Namespace: "n1"}},
+		{expected: storage.PermissionLevel_ELEVATED_IN_NAMESPACE, deployment: &storage.Deployment{ServiceAccount: "elevated-subject", Namespace: "n1"}},
+		{expected: storage.PermissionLevel_ELEVATED_IN_NAMESPACE, deployment: &storage.Deployment{ServiceAccount: "elevated-subject-2", Namespace: "n1"}},
+		{expected: storage.PermissionLevel_NONE, deployment: &storage.Deployment{ServiceAccount: "elevated-subject-2", Namespace: "n2"}},
+		{expected: storage.PermissionLevel_NONE, deployment: &storage.Deployment{ServiceAccount: "default-subject"}},
+		{expected: storage.PermissionLevel_NONE, deployment: &storage.Deployment{ServiceAccount: "admin-subject"}},
 	}
 	store := setupStore(roles, clusterRoles, bindings, clusterBindings)
 	storeWithNoRoles := setupStore(roles, clusterRoles, bindings, clusterBindings)
@@ -774,21 +774,21 @@ func TestStoreGetPermissionLevelForDeployment(t *testing.T) {
 			tc.deployment.ServiceAccount, tc.deployment.Namespace, tc.expected)
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			assert.Equal(t, tc.expected.String(), store.GetPermissionLevelForDeployment(&tc.deployment).String())
+			assert.Equal(t, tc.expected.String(), store.GetPermissionLevelForDeployment(tc.deployment).String())
 		})
 
 		name = fmt.Sprintf("%q in namespace %q should have NO permisions after removing roles but keeping bindings",
 			tc.deployment.ServiceAccount, tc.deployment.Namespace)
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			assert.Equal(t, storage.PermissionLevel_NONE.String(), storeWithNoRoles.GetPermissionLevelForDeployment(&tc.deployment).String())
+			assert.Equal(t, storage.PermissionLevel_NONE.String(), storeWithNoRoles.GetPermissionLevelForDeployment(tc.deployment).String())
 		})
 
 		name = fmt.Sprintf("%q in namespace %q should have NO permisions after removing bindings but keeping roles",
 			tc.deployment.ServiceAccount, tc.deployment.Namespace)
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			assert.Equal(t, storage.PermissionLevel_NONE.String(), storeWithNoBindings.GetPermissionLevelForDeployment(&tc.deployment).String())
+			assert.Equal(t, storage.PermissionLevel_NONE.String(), storeWithNoBindings.GetPermissionLevelForDeployment(tc.deployment).String())
 		})
 	}
 }

--- a/tools/generate-helpers/pg-table-bindings/migration.go.tpl
+++ b/tools/generate-helpers/pg-table-bindings/migration.go.tpl
@@ -30,7 +30,7 @@ import (
 var (
 	migration = types.Migration{
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + {{.Migration.MigrateSequence}},
-		VersionAfter:   storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + {{add .Migration.MigrateSequence 1}}},
+		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + {{add .Migration.MigrateSequence 1}}},
 		Run: func(databases *types.Databases) error {
 			{{- if $rocksDB}}
 				{{- if $dackbox}}

--- a/tools/roxvet/analyzers/protoptrs/analyzer.go
+++ b/tools/roxvet/analyzers/protoptrs/analyzer.go
@@ -6,6 +6,7 @@ import (
 	"go/types"
 	"regexp"
 
+	"github.com/stackrox/rox/tools/roxvet/common"
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/passes/inspect"
 	"golang.org/x/tools/go/ast/inspector"
@@ -35,7 +36,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		(*ast.FuncType)(nil),
 		(*ast.StructType)(nil),
 	}
-	inspectResult.Preorder(nodeFilter, func(n ast.Node) {
+	common.FilteredPreorder(inspectResult, common.Not(common.IsGeneratedFile), nodeFilter, func(n ast.Node) {
 		var relevantFields []*ast.Field
 		switch t := n.(type) {
 		case *ast.FuncType:

--- a/tools/roxvet/analyzers/protoptrs/analyzer.go
+++ b/tools/roxvet/analyzers/protoptrs/analyzer.go
@@ -1,0 +1,77 @@
+package protoptrs
+
+import (
+	"go/ast"
+	"go/token"
+	"go/types"
+	"regexp"
+
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
+	"golang.org/x/tools/go/ast/inspector"
+)
+
+var (
+	protoMsgType = types.NewInterfaceType(
+		[]*types.Func{
+			types.NewFunc(token.NoPos, nil, "ProtoMessage", types.NewSignatureType(nil, nil, nil, types.NewTuple(), types.NewTuple(), false)),
+		},
+		nil).Complete()
+
+	protoTypesRegex = regexp.MustCompile(`^github\.com/stackrox/rox/generated[./]|^github\.com/gogo/protobuf/types[./]`)
+)
+
+// Analyzer is the go vet entrypoint
+var Analyzer = &analysis.Analyzer{
+	Name:     "protoptrs",
+	Doc:      "checks that protobuf message types are only used as pointers",
+	Requires: []*analysis.Analyzer{inspect.Analyzer},
+	Run:      run,
+}
+
+func run(pass *analysis.Pass) (interface{}, error) {
+	inspectResult := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+	nodeFilter := []ast.Node{
+		(*ast.FuncType)(nil),
+		(*ast.StructType)(nil),
+	}
+	inspectResult.Preorder(nodeFilter, func(n ast.Node) {
+		var relevantFields []*ast.Field
+		switch t := n.(type) {
+		case *ast.FuncType:
+			if t.Params != nil {
+				relevantFields = append(relevantFields, t.Params.List...)
+			}
+			if t.Results != nil {
+				relevantFields = append(relevantFields, t.Results.List...)
+			}
+		case *ast.StructType:
+			if t.Fields != nil {
+				relevantFields = append(relevantFields, t.Fields.List...)
+			}
+		}
+
+		for _, field := range relevantFields {
+			ty := pass.TypesInfo.TypeOf(field.Type)
+			if ty == nil {
+				continue
+			}
+			if named, _ := ty.(*types.Named); named == nil || !protoTypesRegex.MatchString(named.String()) {
+				continue
+			}
+			structTy, _ := ty.Underlying().(*types.Struct)
+			if structTy == nil {
+				continue
+			}
+			tyPtr := types.NewPointer(ty)
+			if !types.Implements(tyPtr, protoMsgType) {
+				continue
+			}
+			pass.Report(analysis.Diagnostic{
+				Pos:     field.Type.Pos(),
+				Message: "Always use pointers to proto message types in parameters, return values, and struct fields",
+			})
+		}
+	})
+	return nil, nil
+}

--- a/tools/roxvet/roxvet.go
+++ b/tools/roxvet/roxvet.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stackrox/rox/tools/roxvet/analyzers/importpackagenames"
 	"github.com/stackrox/rox/tools/roxvet/analyzers/needlessformat"
 	"github.com/stackrox/rox/tools/roxvet/analyzers/protoclone"
+	"github.com/stackrox/rox/tools/roxvet/analyzers/protoptrs"
 	"github.com/stackrox/rox/tools/roxvet/analyzers/regexes"
 	"github.com/stackrox/rox/tools/roxvet/analyzers/storeinterface"
 	"github.com/stackrox/rox/tools/roxvet/analyzers/uncheckederrors"
@@ -26,6 +27,7 @@ func main() {
 		regexes.Analyzer,
 		uncheckedifassign.Analyzer,
 		protoclone.Analyzer,
+		protoptrs.Analyzer,
 		unusedroxctlargs.Analyzer,
 		filepathwalk.Analyzer,
 		validateimports.Analyzer,


### PR DESCRIPTION
## Description

Copying a protobuf message will result in a vet error in a [future version of the protobuf library](https://gist.github.com/misberner/de1f70db96defcf562da3b8956c8151c), so create a linter to prohibit that, and fix all existing usages.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

- CI
- Ran `make roxvet` locally until no further errors were reported
