### PR TITLE
ROX-13402: Filter by pass or fail in Configuration Management Controls integration tests

### DIFF
--- a/ui/apps/platform/cypress/constants/ConfigManagementPage.js
+++ b/ui/apps/platform/cypress/constants/ConfigManagementPage.js
@@ -1,11 +1,6 @@
 import scopeSelectors from '../helpers/scopeSelectors';
 import tableSelectors from '../selectors/table';
 
-export const controlStatus = {
-    pass: 'pass',
-    fail: 'fail',
-};
-
 export const dashboardSelectors = {
     widgets: "[data-testid='widget']",
     tileLinks: "[data-testid='tile-link']",

--- a/ui/apps/platform/cypress/helpers/configWorkflowUtils.js
+++ b/ui/apps/platform/cypress/helpers/configWorkflowUtils.js
@@ -175,6 +175,12 @@ export function visitConfigurationManagementEntities(entitiesKey) {
     cy.get(`h1:contains("${headingForEntities[entitiesKey]}")`);
 }
 
+export function visitConfigurationManagementEntitiesWithSearch(entitiesKey, search) {
+    visit(`${getEntitiesPath(entitiesKey)}${search}`, getRequestConfigForEntities(entitiesKey));
+
+    cy.get(`h1:contains("${headingForEntities[entitiesKey]}")`);
+}
+
 export function interactAndWaitForConfigurationManagementEntities(
     interactionCallback,
     entitiesKey

--- a/ui/apps/platform/cypress/integration/configmanagement/ciscontrols.test.js
+++ b/ui/apps/platform/cypress/integration/configmanagement/ciscontrols.test.js
@@ -8,12 +8,9 @@ import {
     sidePanelEntityCountMatchesTableRows,
     interactAndWaitForConfigurationManagementScan,
     visitConfigurationManagementDashboard,
-    visitConfigurationManagementEntities,
+    visitConfigurationManagementEntitiesWithSearch,
 } from '../../helpers/configWorkflowUtils';
-import {
-    selectors as configManagementSelectors,
-    controlStatus,
-} from '../../constants/ConfigManagementPage';
+import { selectors as configManagementSelectors } from '../../constants/ConfigManagementPage';
 import withAuth from '../../helpers/basicAuth';
 
 const entitiesKey = 'controls';
@@ -72,24 +69,18 @@ describe('Configuration Management Controls', () => {
     });
 
     it('should show no failing nodes in the control findings section of a passing control', () => {
-        visitConfigurationManagementEntities(entitiesKey);
+        visitConfigurationManagementEntitiesWithSearch(entitiesKey, '?s[Compliance%20State]=Pass');
 
-        cy.get(configManagementSelectors.tableNextPage).click();
-        cy.get(configManagementSelectors.tableCells)
-            .contains(controlStatus.pass)
-            .eq(0)
-            .click({ force: true });
+        // Click first row which has pass in Control Status column to open control in side panel.
+        cy.get(`.rt-td:nth-child(4):contains("pass"):nth(0)`).click();
         cy.get(configManagementSelectors.failingNodes).should('have.length', 0);
     });
 
-    // ROX-13028: skip pending investigation why sometimes table has 0 failing nodes.
-    it.skip('should show failing nodes in the control findings section of a failing control', () => {
-        visitConfigurationManagementEntities(entitiesKey);
+    it('should show failing nodes in the control findings section of a failing control', () => {
+        visitConfigurationManagementEntitiesWithSearch(entitiesKey, '?s[Compliance%20State]=Fail');
 
-        cy.get(configManagementSelectors.tableCells)
-            .contains(controlStatus.fail)
-            .eq(0)
-            .click({ force: true });
+        // Click first row which has fail in Control Status column to open control in side panel.
+        cy.get(`.rt-td:nth-child(4):contains("fail"):nth(0)`).click();
         cy.get(configManagementSelectors.failingNodes).should('not.have.length', 0);
     });
 });


### PR DESCRIPTION
## Description

### Test failures

1. 1587828303694139392 from master build for 3650 on 2022-11-02
2. 1587828304025489408 from master build for 3650 on 2022-11-02
3. 1587829916785709056 from master build for 3647 on 2022-11-02
4. 1587829919214211072 from master build for 3647 on 2022-11-02
5. 1587833938586374144 from master build for 3631 on 2022-11-02
6. 1587833938636705792 from master build for 3631 on 2022-11-02
7. 1587880704069341184 from master build for 3659 on 2022-11-02
8. 1587880703985455104 from master build for 3659 on 2022-11-02

> Configuration Management Controls should show no failing nodes in the control findings section of a passing control

> Timed out retrying after 4000ms: Expected to find content: 'pass' within the element: [ <div.rt-td.hidden>, 199 more... ]

![Control_Status](https://user-images.githubusercontent.com/11862657/199603891-e3f72e49-edb0-43c1-8314-de43c6a4692f.png)

### Analysis

cypress/integration/configmanagement/ciscontrols.test.js has 2 similar tests at the end:

* `it('should show no failing nodes in the control findings section of a passing control'`

    On **second** page of table, click the first table row which has **pass** in a cell, and then assert:

    ```js
    cy.get(configManagementSelectors.tableNextPage).click();
    cy.get(configManagementSelectors.tableCells)
        .contains(controlStatus.pass)
        .eq(0)
        .click({ force: true });
    cy.get(configManagementSelectors.failingNodes).should('have.length', 0);
    ```

* `it.skip('should show failing nodes in the control findings section of a failing control'`

    On **first** page of table, click the first table row which has **fail** in a cell, and then assert:

    ```js
    cy.get(configManagementSelectors.tableCells)
        .contains(controlStatus.fail)
        .eq(0)
        .click({ force: true });
    cy.get(configManagementSelectors.failingNodes).should('not.have.length', 0);
    ```

Tests cannot assume that second page has **Pass** and first page has **Fail**.

stagingdb page 1 without search filter
![stagingdb-1](https://user-images.githubusercontent.com/11862657/199603947-820679d8-4208-4a0d-86e3-4c0af1acc096.png)

staging page 1 without search filter
![staging-1](https://user-images.githubusercontent.com/11862657/199603964-16c7b18f-acf9-4a09-bb63-9d22bc18cd0c.png)

staging page 1 with search filter: `?s[Compliance%20State]=Pass`
![staging-COMPLIANCE_STATE_Pass](https://user-images.githubusercontent.com/11862657/199603977-2f4bd848-481b-41e3-82b0-16468dd4ead0.png)

staging page 1 with search filter: `?s[Compliance%20State]=Fail`
![staging-COMPLIANCE_STATE_Fail](https://user-images.githubusercontent.com/11862657/199603990-b5ad29cb-2e51-46c1-b2d1-7d5d5a0253f7.png)

### Solution

1. Filter instead of assume which page has controls with expected compliance state.
2. Remove `skip` from formerly failing failing test (pardon pun). Now I understand better why it failed.
3. Limit element selector to Control Status column.

### Residue

* Why is there such variation in state/status of controls between staging, stagingdb, and on CI?

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed