### PR TITLE
ROX-13171: Add bulk actions for flows table

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentFlows.css
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentFlows.css
@@ -1,3 +1,7 @@
 .pf-c-table__toggle {
-    padding: 0 !important
+    padding: 0 !important;
+}
+
+tbody tr.pf-c-table__expandable-row td.pf-c-table__check label {
+    padding: 0;
 }


### PR DESCRIPTION
## Description

This PR adds the bulk actions dropdown and checkbox select for the flows table. This is an iterative addition. You can find all the subtasks here: https://issues.redhat.com/browse/ROX-12904

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Screenshots

### Checkboxes were added for each row to select flows
<img width="1552" alt="Screenshot 2022-11-02 at 3 44 23 PM" src="https://user-images.githubusercontent.com/4805485/199616931-c947075c-0d79-4571-8701-3481104187c7.png">

### Bulk actions lets you mark as anomalous or add to baseline (does not work yet)
<img width="1552" alt="Screenshot 2022-11-02 at 3 44 17 PM" src="https://user-images.githubusercontent.com/4805485/199616926-9772feeb-dd91-49f0-8a5f-9f53eef94c91.png">