### PR TITLE
ROX-13407: Central built-in telemetry with Amplitude (initial)

### DIFF
--- a/central/main.go
+++ b/central/main.go
@@ -9,8 +9,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/stackrox/rox/central/telemetry/marketing"
-
 	"github.com/NYTimes/gziphandler"
 	alertDatastore "github.com/stackrox/rox/central/alert/datastore"
 	alertService "github.com/stackrox/rox/central/alert/service"
@@ -130,6 +128,7 @@ import (
 	"github.com/stackrox/rox/central/splunk"
 	summaryService "github.com/stackrox/rox/central/summary/service"
 	"github.com/stackrox/rox/central/telemetry/gatherers"
+	"github.com/stackrox/rox/central/telemetry/marketing"
 	telemetryService "github.com/stackrox/rox/central/telemetry/service"
 	"github.com/stackrox/rox/central/tlsconfig"
 	"github.com/stackrox/rox/central/ui"

--- a/central/telemetry/marketing/gatherer.go
+++ b/central/telemetry/marketing/gatherer.go
@@ -2,7 +2,6 @@ package marketing
 
 import (
 	"context"
-	"sync"
 	"time"
 
 	apDataStore "github.com/stackrox/rox/central/authprovider/datastore"
@@ -12,6 +11,7 @@ import (
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stackrox/rox/pkg/sync"
 	mpkg "github.com/stackrox/rox/pkg/telemetry/marketing"
 	"github.com/stackrox/rox/pkg/version"
 )

--- a/central/telemetry/marketing/gatherer.go
+++ b/central/telemetry/marketing/gatherer.go
@@ -34,7 +34,8 @@ var (
 	once sync.Once
 )
 
-func NewGatherer(t mpkg.Telemeter) {
+// InitGatherer initializes the periodic telemetry data gatherer.
+func InitGatherer(t mpkg.Telemeter) {
 	once.Do(func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		m = &marketing{
@@ -47,6 +48,7 @@ func NewGatherer(t mpkg.Telemeter) {
 	})
 }
 
+// Singleton returns the previously initialized telemeter instance.
 func Singleton() *marketing {
 	return m
 }
@@ -55,7 +57,6 @@ func (m *marketing) loop() {
 	for !m.stopSig.IsDone() {
 		select {
 		case <-m.ticker.C:
-			log.Info("Tick.")
 			go m.gather()
 		case <-m.stopSig.Done():
 			return
@@ -91,8 +92,8 @@ func addTotal[T any](props map[string]any, key string, f func(context.Context) (
 }
 
 func (m *marketing) gather() {
-	log.Info("Starting marketing telemetry data collection.")
-	defer log.Info("Done with marketing telemetry data collection.")
+	log.Debug("Starting marketing telemetry data collection.")
+	defer log.Debug("Done with marketing telemetry data collection.")
 
 	totals := make(map[string]any)
 	rs := roles.Singleton()
@@ -113,10 +114,10 @@ func (m *marketing) gather() {
 		return
 	}
 
-	providerIdNames := make(map[string]string)
+	providerIDNames := make(map[string]string)
 	providerNames := make([]string, len(providers))
 	for _, provider := range providers {
-		providerIdNames[provider.GetId()] = provider.GetName()
+		providerIDNames[provider.GetId()] = provider.GetName()
 		providerNames = append(providerNames, provider.GetName())
 	}
 	totals["Auth Providers"] = providerNames
@@ -128,7 +129,7 @@ func (m *marketing) gather() {
 	}
 
 	for id, n := range providerGroups {
-		totals["Total Groups of "+providerIdNames[id]] = n
+		totals["Total Groups of "+providerIDNames[id]] = n
 	}
 	m.telemeter.Identify(totals)
 }

--- a/central/telemetry/marketing/gatherer.go
+++ b/central/telemetry/marketing/gatherer.go
@@ -22,6 +22,7 @@ var (
 
 type marketing struct {
 	telemeter mpkg.Telemeter
+	period    time.Duration
 	ticker    *time.Ticker
 	stopSig   concurrency.Signal
 	ctx       context.Context
@@ -35,11 +36,12 @@ var (
 )
 
 // InitGatherer initializes the periodic telemetry data gatherer.
-func InitGatherer(t mpkg.Telemeter) {
+func InitGatherer(t mpkg.Telemeter, p time.Duration) {
 	once.Do(func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		m = &marketing{
 			telemeter: t,
+			period:    p,
 			userAgent: "central/" + version.GetMainVersion(),
 			ctx:       sac.WithAllAccess(ctx),
 			cancel:    cancel,
@@ -62,15 +64,15 @@ func (m *marketing) loop() {
 			return
 		}
 	}
-	log.Info("Loop stopped.")
+	log.Debug("Loop stopped.")
 }
 
 func (m *marketing) Start() {
 	if mpkg.Enabled() {
 		m.telemeter.Start()
-		m.ticker = time.NewTicker(1 * time.Minute)
+		m.ticker = time.NewTicker(m.period)
 		go m.loop()
-		log.Info("Marketing telemetry data collection ticker enabled.")
+		log.Debug("Marketing telemetry data collection ticker enabled.")
 	}
 }
 

--- a/central/telemetry/marketing/interceptor.go
+++ b/central/telemetry/marketing/interceptor.go
@@ -4,12 +4,11 @@ import (
 	"context"
 	"strings"
 
-	mpkg "github.com/stackrox/rox/pkg/telemetry/marketing"
-
 	erroxGRPC "github.com/stackrox/rox/pkg/errox/grpc"
 	grpcError "github.com/stackrox/rox/pkg/grpc/errors"
 	"github.com/stackrox/rox/pkg/grpc/requestinfo"
 	"github.com/stackrox/rox/pkg/set"
+	mpkg "github.com/stackrox/rox/pkg/telemetry/marketing"
 	"google.golang.org/grpc"
 )
 

--- a/central/telemetry/marketing/interceptor.go
+++ b/central/telemetry/marketing/interceptor.go
@@ -1,0 +1,34 @@
+package marketing
+
+import (
+	"context"
+
+	mpkg "github.com/stackrox/rox/pkg/telemetry/marketing"
+
+	"github.com/stackrox/rox/pkg/grpc/requestinfo"
+	"github.com/stackrox/rox/pkg/set"
+	"google.golang.org/grpc"
+)
+
+func interceptor(d *mpkg.Device, t mpkg.Telemeter) grpc.UnaryServerInterceptor {
+
+	trackedPaths := set.NewFrozenSet(d.ApiPaths...)
+
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp any, err error) {
+		resp, err = handler(ctx, req)
+
+		ri := requestinfo.FromContext(ctx)
+		if ri.HTTPRequest != nil && ri.HTTPRequest.URL != nil {
+			path := ri.HTTPRequest.URL.Path
+			ua := ri.HTTPRequest.Headers.Get("User-Agent")
+			t.Track(ua, "User-Agent")
+			if trackedPaths.Contains(path) {
+				log.Debug("Telemetry tracks ", path)
+				t.TrackProp(ua, "API Call", "Path", path)
+			}
+		} else {
+			log.Info("No HTTP data: ")
+		}
+		return
+	}
+}

--- a/central/telemetry/marketing/interceptor.go
+++ b/central/telemetry/marketing/interceptor.go
@@ -13,11 +13,13 @@ import (
 	"google.golang.org/grpc"
 )
 
+var ignoredPaths = set.NewFrozenSet("/v1/ping", "/v1/metadata")
+
 func track(ctx context.Context, t mpkg.Telemeter, err error, info *grpc.UnaryServerInfo, trackedPaths set.FrozenSet[string]) {
 	userAgent, path, code := getRequestDetails(ctx, err, info)
 
 	// Track the API path and error code of some requests:
-	if path != "/v1/ping" && (trackedPaths.Contains("*") || trackedPaths.Contains(path)) {
+	if !ignoredPaths.Contains(path) && (trackedPaths.Contains("*") || trackedPaths.Contains(path)) {
 		t.TrackProps("API Call", map[string]any{
 			"Path":       path,
 			"Code":       code,

--- a/central/telemetry/marketing/marketing.go
+++ b/central/telemetry/marketing/marketing.go
@@ -1,0 +1,17 @@
+package marketing
+
+import (
+	mpkg "github.com/stackrox/rox/pkg/telemetry/marketing"
+	"github.com/stackrox/rox/pkg/telemetry/marketing/amplitude"
+	"google.golang.org/grpc"
+)
+
+func Init() grpc.UnaryServerInterceptor {
+	if mpkg.Enabled() {
+		device := mpkg.GetDeviceProperties()
+		telemeter := amplitude.Init(device)
+		NewGatherer(telemeter)
+		return interceptor(device, telemeter)
+	}
+	return nil
+}

--- a/central/telemetry/marketing/marketing.go
+++ b/central/telemetry/marketing/marketing.go
@@ -2,6 +2,7 @@ package marketing
 
 import (
 	"context"
+	"time"
 
 	"github.com/stackrox/rox/pkg/set"
 	mpkg "github.com/stackrox/rox/pkg/telemetry/marketing"
@@ -21,7 +22,7 @@ func Init() grpc.UnaryServerInterceptor {
 
 		telemeter := amplitude.Init(config)
 
-		InitGatherer(telemeter)
+		InitGatherer(telemeter, 5*time.Minute)
 
 		trackedPaths := set.NewFrozenSet(config.APIPaths...)
 		log.Info("Telemetry device ID:", config.ID)

--- a/go.mod
+++ b/go.mod
@@ -149,6 +149,7 @@ require (
 	github.com/ProtonMail/go-crypto v0.0.0-20220113124808-70ae35bab23f // indirect
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d // indirect
 	github.com/acomagu/bufpipe v1.0.3 // indirect
+	github.com/amplitude/analytics-go v0.0.11
 	github.com/andybalholm/brotli v1.0.3 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d // indirect
 	github.com/beevik/etree v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -207,8 +207,6 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/alexflint/go-filemutex v0.0.0-20171022225611-72bdc8eae2ae/go.mod h1:CgnQgUtFrFz9mxFNtED3jI5tLDjKlOM+oUF/sTk6ps0=
-github.com/amplitude/analytics-go v0.0.10-0.20221027231036-9944eaeec86f h1:iPBse6W0UmIJxESYXWKitKTbwtsXJ1gOcWoYtk5WL6E=
-github.com/amplitude/analytics-go v0.0.10-0.20221027231036-9944eaeec86f/go.mod h1:usOqpc3xyDqxJyjGKWVIDbuVvk2H93KX1Skir/TM0nA=
 github.com/amplitude/analytics-go v0.0.11 h1:AiNzIGfT9qFLsor4TM5prOG8xUwORDgHx5VRJwBh54I=
 github.com/amplitude/analytics-go v0.0.11/go.mod h1:usOqpc3xyDqxJyjGKWVIDbuVvk2H93KX1Skir/TM0nA=
 github.com/andybalholm/brotli v1.0.0/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu3qAvBg8x/Y=

--- a/go.sum
+++ b/go.sum
@@ -207,6 +207,10 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/alexflint/go-filemutex v0.0.0-20171022225611-72bdc8eae2ae/go.mod h1:CgnQgUtFrFz9mxFNtED3jI5tLDjKlOM+oUF/sTk6ps0=
+github.com/amplitude/analytics-go v0.0.10-0.20221027231036-9944eaeec86f h1:iPBse6W0UmIJxESYXWKitKTbwtsXJ1gOcWoYtk5WL6E=
+github.com/amplitude/analytics-go v0.0.10-0.20221027231036-9944eaeec86f/go.mod h1:usOqpc3xyDqxJyjGKWVIDbuVvk2H93KX1Skir/TM0nA=
+github.com/amplitude/analytics-go v0.0.11 h1:AiNzIGfT9qFLsor4TM5prOG8xUwORDgHx5VRJwBh54I=
+github.com/amplitude/analytics-go v0.0.11/go.mod h1:usOqpc3xyDqxJyjGKWVIDbuVvk2H93KX1Skir/TM0nA=
 github.com/andybalholm/brotli v1.0.0/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu3qAvBg8x/Y=
 github.com/andybalholm/brotli v1.0.1/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu3qAvBg8x/Y=
 github.com/andybalholm/brotli v1.0.3 h1:fpcw+r1N1h0Poc1F/pHbW40cUm/lMEQslZtCkBQ0UnM=

--- a/pkg/env/telemetry.go
+++ b/pkg/env/telemetry.go
@@ -13,4 +13,7 @@ var (
 
 	// TelemetryFrequency is the frequency at which we will report telemetry
 	TelemetryFrequency = registerDurationSetting("ROX_TELEMETRY_FREQUENCY", 24*time.Hour)
+
+	// AmplitudeApiKey can be empty to disable marketing telemetry collection
+	AmplitudeApiKey = RegisterSetting("AMPLITUDE_API_KEY", AllowEmpty())
 )

--- a/pkg/env/telemetry.go
+++ b/pkg/env/telemetry.go
@@ -14,6 +14,6 @@ var (
 	// TelemetryFrequency is the frequency at which we will report telemetry
 	TelemetryFrequency = registerDurationSetting("ROX_TELEMETRY_FREQUENCY", 24*time.Hour)
 
-	// AmplitudeApiKey can be empty to disable marketing telemetry collection
-	AmplitudeApiKey = RegisterSetting("AMPLITUDE_API_KEY", AllowEmpty())
+	// AmplitudeAPIKey can be empty to disable marketing telemetry collection
+	AmplitudeAPIKey = RegisterSetting("AMPLITUDE_API_KEY", AllowEmpty())
 )

--- a/pkg/env/telemetry.go
+++ b/pkg/env/telemetry.go
@@ -15,5 +15,5 @@ var (
 	TelemetryFrequency = registerDurationSetting("ROX_TELEMETRY_FREQUENCY", 24*time.Hour)
 
 	// AmplitudeAPIKey can be empty to disable marketing telemetry collection
-	AmplitudeAPIKey = RegisterSetting("AMPLITUDE_API_KEY", AllowEmpty())
+	AmplitudeAPIKey = RegisterSetting("ROX_AMPLITUDE_API_KEY", AllowEmpty())
 )

--- a/pkg/telemetry/marketing/amplitude/amplitude.go
+++ b/pkg/telemetry/marketing/amplitude/amplitude.go
@@ -1,0 +1,105 @@
+package amplitude
+
+import (
+	"sync"
+	"time"
+
+	"github.com/amplitude/analytics-go/amplitude"
+	"github.com/amplitude/analytics-go/amplitude/types"
+	"github.com/stackrox/rox/pkg/env"
+	"github.com/stackrox/rox/pkg/logging"
+	"github.com/stackrox/rox/pkg/telemetry/marketing"
+	"github.com/stackrox/rox/pkg/version"
+)
+
+var (
+	log  = logging.LoggerForModule()
+	once sync.Once
+	a    *ampl
+)
+
+type ampl struct {
+	client   amplitude.Client
+	opts     *types.EventOptions
+	identity amplitude.Identify
+}
+
+// Ensure Telemeter interface implementation.
+var _ = marketing.Telemeter((*ampl)(nil))
+
+func (t *ampl) Identify(props map[string]any) {
+	t.identity = amplitude.Identify{}
+	for k, v := range props {
+		t.identity.Set(k, v)
+	}
+	t.client.Identify(t.identity, amplitude.EventOptions{UserID: t.opts.DeviceID, DeviceID: t.opts.DeviceID})
+}
+
+func Init(device *marketing.Device) marketing.Telemeter {
+	once.Do(func() {
+		key := env.AmplitudeApiKey.Setting()
+		server := ""
+		a = initAmplitude(device, key, server)
+	})
+	return a
+}
+
+func initAmplitude(device *marketing.Device, key, server string) *ampl {
+	amplitude_config := amplitude.NewConfig(key)
+	if server != "" {
+		amplitude_config.ServerURL = server
+	}
+	amplitude_config.FlushInterval = 1 * time.Hour
+	amplitude_config.Logger = log
+
+	log.Info("Telemetry device ID:", device.ID)
+
+	client := amplitude.NewClient(amplitude_config)
+
+	identify := amplitude.Identify{}
+	identify.SetOnce("Central version", version.GetMainVersion())
+	identify.SetOnce("Chart version", version.GetChartVersion())
+
+	return &ampl{
+		client:   client,
+		identity: identify,
+		opts: &amplitude.EventOptions{
+			DeviceID:  device.ID,
+			ProductID: version.GetMainVersion(),
+			Platform:  device.Version,
+		},
+	}
+}
+
+func (t *ampl) Start() {
+}
+
+func (t *ampl) Stop() {
+	if t != nil {
+		t.client.Flush()
+		t.client.Shutdown()
+	}
+}
+
+func (t *ampl) TrackProps(userAgent, event string, props map[string]any) {
+	if t == nil {
+		return
+	}
+	opts := *t.opts
+	opts.AppVersion = userAgent
+	t.client.Track(amplitude.Event{
+		UserID:          t.opts.DeviceID,
+		DeviceID:        t.opts.DeviceID,
+		EventType:       event,
+		EventProperties: props,
+		EventOptions:    opts,
+	})
+}
+
+func (t *ampl) TrackProp(userAgent, event string, key string, value any) {
+	t.TrackProps(userAgent, event, map[string]any{key: value})
+}
+
+func (t *ampl) Track(userAgent, event string) {
+	t.TrackProps(userAgent, event, nil)
+}

--- a/pkg/telemetry/marketing/amplitude/amplitude.go
+++ b/pkg/telemetry/marketing/amplitude/amplitude.go
@@ -1,13 +1,13 @@
 package amplitude
 
 import (
-	"sync"
 	"time"
 
 	"github.com/amplitude/analytics-go/amplitude"
 	"github.com/amplitude/analytics-go/amplitude/types"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/logging"
+	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/pkg/telemetry/marketing"
 	"github.com/stackrox/rox/pkg/version"
 )

--- a/pkg/telemetry/marketing/k8s.go
+++ b/pkg/telemetry/marketing/k8s.go
@@ -10,7 +10,10 @@ import (
 	"k8s.io/client-go/rest"
 )
 
-func getK8SData() (*Device, error) {
+const annotation = "stackrox.com/telemetry-apipaths"
+
+// GetDeviceConfig collects the central instance telemetry configuration.
+func GetDeviceConfig() (*Config, error) {
 	rc, err := rest.InClusterConfig()
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot create k8s config")
@@ -29,11 +32,11 @@ func getK8SData() (*Device, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot get central deployment")
 	}
-	paths := d.GetAnnotations()["stackrox.com/telemetry-apipaths"]
+	paths := d.GetAnnotations()[annotation]
 
-	return &Device{
+	return &Config{
 		ID:       string(d.GetUID()),
 		Version:  v.GitVersion,
-		ApiPaths: strings.Split(paths, ","),
+		APIPaths: strings.Split(paths, ","),
 	}, nil
 }

--- a/pkg/telemetry/marketing/k8s.go
+++ b/pkg/telemetry/marketing/k8s.go
@@ -1,0 +1,39 @@
+package marketing
+
+import (
+	"context"
+	"strings"
+
+	"github.com/pkg/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+func getK8SData() (*Device, error) {
+	rc, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot create k8s config")
+	}
+	clientset, err := kubernetes.NewForConfig(rc)
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot create k8s clientset")
+	}
+	v, err := clientset.ServerVersion()
+	if err != nil {
+		return nil, err
+	}
+	di := clientset.AppsV1().Deployments("stackrox")
+	opts := v1.GetOptions{}
+	d, err := di.Get(context.Background(), "central", opts)
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot get central deployment")
+	}
+	paths := d.GetAnnotations()["stackrox.com/telemetry-apipaths"]
+
+	return &Device{
+		ID:       string(d.GetUID()),
+		Version:  v.GitVersion,
+		ApiPaths: strings.Split(paths, ","),
+	}, nil
+}

--- a/pkg/telemetry/marketing/telemeter.go
+++ b/pkg/telemetry/marketing/telemeter.go
@@ -2,9 +2,9 @@ package marketing
 
 import (
 	"github.com/stackrox/rox/pkg/env"
-	"github.com/stackrox/rox/pkg/logging"
 )
 
+// Telemeter defines a common interface for telemetry gatherers.
 type Telemeter interface {
 	Start()
 	Stop()
@@ -14,27 +14,14 @@ type Telemeter interface {
 	TrackProps(userAgent, event string, props map[string]any)
 }
 
-var (
-	log = logging.LoggerForModule()
-)
-
+// Enabled tells whether telemetry data collection is enabled.
 func Enabled() bool {
-	return env.AmplitudeApiKey.Setting() != ""
+	return env.AmplitudeAPIKey.Setting() != ""
 }
 
-// Device represents the central instance properties.
-type Device struct {
+// Config represents the central instance telemetry configuration.
+type Config struct {
 	ID       string
 	Version  string
-	ApiPaths []string
-}
-
-// GetDeviceProperties collects the central instance properties.
-func GetDeviceProperties() *Device {
-	d, err := getK8SData()
-	if err != nil {
-		log.Errorf("Failed to get device data: %v", err)
-		return nil
-	}
-	return d
+	APIPaths []string
 }

--- a/pkg/telemetry/marketing/telemeter.go
+++ b/pkg/telemetry/marketing/telemeter.go
@@ -1,0 +1,40 @@
+package marketing
+
+import (
+	"github.com/stackrox/rox/pkg/env"
+	"github.com/stackrox/rox/pkg/logging"
+)
+
+type Telemeter interface {
+	Start()
+	Stop()
+	Identify(props map[string]any)
+	Track(userAgent, event string)
+	TrackProp(userAgent, event string, key string, value any)
+	TrackProps(userAgent, event string, props map[string]any)
+}
+
+var (
+	log = logging.LoggerForModule()
+)
+
+func Enabled() bool {
+	return env.AmplitudeApiKey.Setting() != ""
+}
+
+// Device represents the central instance properties.
+type Device struct {
+	ID       string
+	Version  string
+	ApiPaths []string
+}
+
+// GetDeviceProperties collects the central instance properties.
+func GetDeviceProperties() *Device {
+	d, err := getK8SData()
+	if err != nil {
+		log.Errorf("Failed to get device data: %v", err)
+		return nil
+	}
+	return d
+}

--- a/pkg/telemetry/marketing/telemeter.go
+++ b/pkg/telemetry/marketing/telemeter.go
@@ -9,9 +9,9 @@ type Telemeter interface {
 	Start()
 	Stop()
 	Identify(props map[string]any)
-	Track(userAgent, event string)
-	TrackProp(userAgent, event string, key string, value any)
-	TrackProps(userAgent, event string, props map[string]any)
+	Track(event string)
+	TrackProp(event string, key string, value any)
+	TrackProps(event string, props map[string]any)
 }
 
 // Enabled tells whether telemetry data collection is enabled.
@@ -21,7 +21,8 @@ func Enabled() bool {
 
 // Config represents the central instance telemetry configuration.
 type Config struct {
-	ID       string
-	Version  string
-	APIPaths []string
+	ID           string
+	Orchestrator string
+	Version      string
+	APIPaths     []string
 }


### PR DESCRIPTION
## Description

Amplitude telemetry collector, implementing a Telemeter interface to collect:
* specified GRPC and HTTP API calls events, ignoring `/v1/ping` and /v1/metadata`;
* central configuration data such as total number of roles, permissionsets, authproviders and groups;
* disabled by default.

Configuration:
* Amplitude API key is taken from `AMPLITUDE_API_KEY` environment variable;
* `DeviceID` is taken from the central deployment UID;
* API paths for interception are taken from a central deployment annotation;
* Central configuration is pushed to Amplitude as user identification event (updating the previous values).

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] ~Unit test and regression tests added~
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Test dashboard on amplitude.
### API calls
![image](https://user-images.githubusercontent.com/20665445/200595597-5edfaf0b-bc3a-424f-be59-b5503e225603.png)

### Central features
![image](https://user-images.githubusercontent.com/20665445/200596401-2bc7828a-c04e-46de-b7f2-8b328d5bebcb.png)

