### PR TITLE
ROX-13226: Add panic handler for Istio updateCVEs

### DIFF
--- a/central/cve/fetcher/istio.go
+++ b/central/cve/fetcher/istio.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/facebookincubator/nvdtools/cvefeed/nvd/schema"
+	"github.com/pkg/errors"
 	"github.com/stackrox/k8s-istio-cve-pusher/nvd"
 	clusterDataStore "github.com/stackrox/rox/central/cluster/datastore"
 	clusterCVEEdgeDataStore "github.com/stackrox/rox/central/clustercveedge/datastore"
@@ -67,7 +68,13 @@ func (m *istioCVEManager) setCVEs(cves []*storage.EmbeddedVulnerability, nvdCVEs
 	m.embeddedCVEs = cves
 }
 
-func (m *istioCVEManager) updateCVEs(newCVEs []*schema.NVDCVEFeedJSON10DefCVEItem) error {
+func (m *istioCVEManager) updateCVEs(newCVEs []*schema.NVDCVEFeedJSON10DefCVEItem) (retErr error) {
+	defer func() {
+		if r := recover(); r != nil {
+			retErr = errors.Errorf("caught panic in Istio updateCVEs: %v", r)
+		}
+	}()
+
 	cves, err := utils.NvdCVEsToEmbeddedCVEs(newCVEs, utils.Istio)
 	if err != nil {
 		return err

--- a/central/cve/fetcher/istio_test.go
+++ b/central/cve/fetcher/istio_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/facebookincubator/nvdtools/cvefeed/nvd/schema"
+	"github.com/stackrox/rox/pkg/buildinfo"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -12,11 +13,16 @@ func TestUpdateCVEs(t *testing.T) {
 	newCVEs := make([]*schema.NVDCVEFeedJSON10DefCVEItem, 0)
 
 	var m *istioCVEManager
+	if buildinfo.ReleaseBuild {
+		// Panic should happen because m is nil, and we use
+		// several struct fields in called functions.
+		err := m.updateCVEs(newCVEs)
 
-	// Panic should happen because m is nil, and we use
-	// several struct fields in called functions.
-	err := m.updateCVEs(newCVEs)
-
-	assert.Error(t, err)
-	assert.True(t, strings.HasPrefix(err.Error(), "caught panic"), "Error should be returned by panic handler.")
+		assert.Error(t, err)
+		assert.True(t, strings.HasPrefix(err.Error(), "caught panic"), "Error should be returned by panic handler.")
+	} else {
+		assert.Panics(t, func() {
+			_ = m.updateCVEs(newCVEs)
+		})
+	}
 }

--- a/central/cve/fetcher/istio_test.go
+++ b/central/cve/fetcher/istio_test.go
@@ -1,0 +1,22 @@
+package fetcher
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/facebookincubator/nvdtools/cvefeed/nvd/schema"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUpdateCVEs(t *testing.T) {
+	newCVEs := make([]*schema.NVDCVEFeedJSON10DefCVEItem, 0)
+
+	var m *istioCVEManager
+
+	// Panic should happen because m is nil, and we use
+	// several struct fields in called functions.
+	err := m.updateCVEs(newCVEs)
+
+	assert.Error(t, err)
+	assert.True(t, strings.HasPrefix(err.Error(), "caught panic"), "Error should be returned by panic handler.")
+}


### PR DESCRIPTION
## Description

This PR adds a panic handler in Istio `updateCVEs` function.

**Some considerations**

I have looked at call hierarchy. The problematic function `NvdCVEToEmbeddedCVE` is always called from `updateCVEs -> NvdCVEsToEmbeddedCVEs -> NvdCVEToEmbeddedCVE`. But `updateCVEs` is called from 3 different functionalities:
- online mode - when the file is downloaded
- offline mode - when the file is uploaded by the user
- init - when the application starts. I'm not 100% sure, but I think that in this case, the file is already embedded in a docker image.

Going upper in the call hierarchy would mean that we should cover all 3 call paths, and we already have proper error handling there. So, I think it's sufficient to throw an error from `updateCVEs` to the caller.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- ~~[ ] Evaluated and added CHANGELOG entry if required~~
- ~~[ ] Determined and documented upgrade steps~~
- ~~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

## Testing Performed

1. Tested with added unit test
