### PR TITLE
Add autocomplete for name selector dropdowns

### DIFF
--- a/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
@@ -212,6 +212,7 @@ function CollectionForm({
                         </>
                     )}
                     <RuleSelector
+                        collection={values}
                         entityType="Deployment"
                         scopedResourceSelector={values.resourceSelector.Deployment}
                         handleChange={onResourceSelectorChange}
@@ -222,6 +223,7 @@ function CollectionForm({
                         in
                     </Label>
                     <RuleSelector
+                        collection={values}
                         entityType="Namespace"
                         scopedResourceSelector={values.resourceSelector.Namespace}
                         handleChange={onResourceSelectorChange}
@@ -232,6 +234,7 @@ function CollectionForm({
                         in
                     </Label>
                     <RuleSelector
+                        collection={values}
                         entityType="Cluster"
                         scopedResourceSelector={values.resourceSelector.Cluster}
                         handleChange={onResourceSelectorChange}

--- a/ui/apps/platform/src/Containers/Collections/RuleSelector/AutoCompleteSelect.tsx
+++ b/ui/apps/platform/src/Containers/Collections/RuleSelector/AutoCompleteSelect.tsx
@@ -1,6 +1,16 @@
-import React from 'react';
-import { Select, ValidatedOptions } from '@patternfly/react-core';
+import React, { ReactElement, useCallback, useMemo, useState } from 'react';
+import {
+    debounce,
+    Select,
+    SelectOption,
+    SelectOptionProps,
+    ValidatedOptions,
+} from '@patternfly/react-core';
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
+import useRestQuery from 'Containers/Dashboard/hooks/useRestQuery';
+import { CancellableRequest } from 'services/cancellationUtils';
+import ResourceIcon from 'Components/PatternFly/ResourceIcon';
+import { SelectorEntityType } from '../types';
 
 export type AutoCompleteSelectProps = {
     id: string;
@@ -10,9 +20,29 @@ export type AutoCompleteSelectProps = {
     onChange: (value: string) => void;
     validated: ValidatedOptions;
     isDisabled: boolean;
+    autocompleteProvider?: (search: string) => CancellableRequest<string[]>;
 };
 
-/* TODO Implement autocompletion */
+function ResourceSelectOption({ option, entityType }) {
+    return (
+        <SelectOption
+            value={option}
+            component={(props) => (
+                <div {...props}>
+                    <ResourceIcon kind={entityType} />
+                    {option}
+                </div>
+            )}
+        />
+    );
+}
+
+function getOptions(data: string[] | undefined): ReactElement[] | undefined {
+    return data?.map((option) => (
+        <ResourceSelectOption key={option} option={option} entityType="Deployment" />
+    ));
+}
+
 export function AutoCompleteSelect({
     id,
     selectedOption,
@@ -21,13 +51,34 @@ export function AutoCompleteSelect({
     onChange,
     validated,
     isDisabled,
+    autocompleteProvider,
 }: AutoCompleteSelectProps) {
     const { isOpen, onToggle, closeSelect } = useSelectToggle();
+    const [typeahead, setTypeahead] = useState(selectedOption);
+
+    const autocompleteCallback = useCallback(() => {
+        const shouldMakeRequest = isOpen && autocompleteProvider;
+        if (shouldMakeRequest) {
+            return autocompleteProvider(typeahead);
+        }
+        return {
+            request: Promise.resolve([]),
+            cancel: () => {},
+        };
+    }, [isOpen, autocompleteProvider, typeahead]);
+
+    const { data } = useRestQuery(autocompleteCallback);
 
     function onSelect(_, value) {
         onChange(value);
         closeSelect();
     }
+
+    // Debounce the autocomplete requests to not overload the backend
+    const updateTypeahead = useMemo(
+        () => debounce((value: string) => setTypeahead(value), 800),
+        []
+    );
 
     return (
         <>
@@ -39,11 +90,15 @@ export function AutoCompleteSelect({
                 variant="typeahead"
                 isCreatable
                 isOpen={isOpen}
+                onFilter={() => getOptions(data)}
                 onToggle={onToggle}
+                onTypeaheadInputChanged={updateTypeahead}
                 selections={selectedOption}
                 onSelect={onSelect}
                 isDisabled={isDisabled}
-            />
+            >
+                {getOptions(data)}
+            </Select>
         </>
     );
 }

--- a/ui/apps/platform/src/Containers/Collections/RuleSelector/AutoCompleteSelect.tsx
+++ b/ui/apps/platform/src/Containers/Collections/RuleSelector/AutoCompleteSelect.tsx
@@ -1,11 +1,5 @@
-import React, { ComponentType, ReactElement, useCallback, useMemo, useState } from 'react';
-import {
-    debounce,
-    Select,
-    SelectOption,
-    SelectOptionProps,
-    ValidatedOptions,
-} from '@patternfly/react-core';
+import React, { ReactElement, ReactNode, useCallback, useMemo, useState } from 'react';
+import { debounce, Select, SelectOption, ValidatedOptions } from '@patternfly/react-core';
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
 import useRestQuery from 'Containers/Dashboard/hooks/useRestQuery';
 import { CancellableRequest } from 'services/cancellationUtils';
@@ -19,21 +13,15 @@ export type AutoCompleteSelectProps = {
     validated: ValidatedOptions;
     isDisabled: boolean;
     autocompleteProvider?: (search: string) => CancellableRequest<string[]>;
-    OptionComponent?: ComponentType<SelectOptionProps>;
+    OptionComponent?: ReactNode;
 };
 
 function getOptions(
-    OptionComponent: ComponentType<SelectOptionProps>,
+    OptionComponent: ReactNode,
     data: string[] | undefined
 ): ReactElement[] | undefined {
     return data?.map((value) => (
-        <SelectOption
-            key={value}
-            value={value}
-            component={(props: SelectOptionProps) => (
-                <OptionComponent className={props.className} value={value} />
-            )}
-        />
+        <SelectOption key={value} value={value} component={OptionComponent} />
     ));
 }
 
@@ -46,7 +34,7 @@ export function AutoCompleteSelect({
     validated,
     isDisabled,
     autocompleteProvider,
-    OptionComponent = SelectOption,
+    OptionComponent = 'button',
 }: AutoCompleteSelectProps) {
     const { isOpen, onToggle, closeSelect } = useSelectToggle();
     const [typeahead, setTypeahead] = useState(selectedOption);

--- a/ui/apps/platform/src/Containers/Collections/RuleSelector/AutoCompleteSelect.tsx
+++ b/ui/apps/platform/src/Containers/Collections/RuleSelector/AutoCompleteSelect.tsx
@@ -28,8 +28,11 @@ function getOptions(
 ): ReactElement[] | undefined {
     return data?.map((value) => (
         <SelectOption
+            key={value}
             value={value}
-            component={(props: SelectOptionProps) => <OptionComponent {...props} value={value} />}
+            component={(props: SelectOptionProps) => (
+                <OptionComponent className={props.className} value={value} />
+            )}
         />
     ));
 }

--- a/ui/apps/platform/src/Containers/Collections/RuleSelector/AutoCompleteSelect.tsx
+++ b/ui/apps/platform/src/Containers/Collections/RuleSelector/AutoCompleteSelect.tsx
@@ -34,7 +34,7 @@ export function AutoCompleteSelect({
     validated,
     isDisabled,
     autocompleteProvider,
-    OptionComponent = 'button',
+    OptionComponent = SelectOption,
 }: AutoCompleteSelectProps) {
     const { isOpen, onToggle, closeSelect } = useSelectToggle();
     const [typeahead, setTypeahead] = useState(selectedOption);

--- a/ui/apps/platform/src/Containers/Collections/RuleSelector/AutoCompleteSelect.tsx
+++ b/ui/apps/platform/src/Containers/Collections/RuleSelector/AutoCompleteSelect.tsx
@@ -1,11 +1,5 @@
 import React, { ReactElement, useCallback, useMemo, useState } from 'react';
-import {
-    debounce,
-    Select,
-    SelectOption,
-    SelectOptionProps,
-    ValidatedOptions,
-} from '@patternfly/react-core';
+import { debounce, Select, SelectOption, ValidatedOptions } from '@patternfly/react-core';
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
 import useRestQuery from 'Containers/Dashboard/hooks/useRestQuery';
 import { CancellableRequest } from 'services/cancellationUtils';
@@ -21,6 +15,7 @@ export type AutoCompleteSelectProps = {
     validated: ValidatedOptions;
     isDisabled: boolean;
     autocompleteProvider?: (search: string) => CancellableRequest<string[]>;
+    entityType: SelectorEntityType;
 };
 
 function ResourceSelectOption({ option, entityType }) {
@@ -37,9 +32,12 @@ function ResourceSelectOption({ option, entityType }) {
     );
 }
 
-function getOptions(data: string[] | undefined): ReactElement[] | undefined {
+function getOptions(
+    data: string[] | undefined,
+    entityType: SelectorEntityType
+): ReactElement[] | undefined {
     return data?.map((option) => (
-        <ResourceSelectOption key={option} option={option} entityType="Deployment" />
+        <ResourceSelectOption key={option} option={option} entityType={entityType} />
     ));
 }
 
@@ -52,6 +50,7 @@ export function AutoCompleteSelect({
     validated,
     isDisabled,
     autocompleteProvider,
+    entityType,
 }: AutoCompleteSelectProps) {
     const { isOpen, onToggle, closeSelect } = useSelectToggle();
     const [typeahead, setTypeahead] = useState(selectedOption);
@@ -90,14 +89,14 @@ export function AutoCompleteSelect({
                 variant="typeahead"
                 isCreatable
                 isOpen={isOpen}
-                onFilter={() => getOptions(data)}
+                onFilter={() => getOptions(data, entityType)}
                 onToggle={onToggle}
                 onTypeaheadInputChanged={updateTypeahead}
                 selections={selectedOption}
                 onSelect={onSelect}
                 isDisabled={isDisabled}
             >
-                {getOptions(data)}
+                {getOptions(data, entityType)}
             </Select>
         </>
     );

--- a/ui/apps/platform/src/Containers/Collections/RuleSelector/AutoCompleteSelect.tsx
+++ b/ui/apps/platform/src/Containers/Collections/RuleSelector/AutoCompleteSelect.tsx
@@ -1,10 +1,14 @@
-import React, { ReactElement, useCallback, useMemo, useState } from 'react';
-import { debounce, Select, SelectOption, ValidatedOptions } from '@patternfly/react-core';
+import React, { ComponentType, ReactElement, useCallback, useMemo, useState } from 'react';
+import {
+    debounce,
+    Select,
+    SelectOption,
+    SelectOptionProps,
+    ValidatedOptions,
+} from '@patternfly/react-core';
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
 import useRestQuery from 'Containers/Dashboard/hooks/useRestQuery';
 import { CancellableRequest } from 'services/cancellationUtils';
-import ResourceIcon from 'Components/PatternFly/ResourceIcon';
-import { SelectorEntityType } from '../types';
 
 export type AutoCompleteSelectProps = {
     id: string;
@@ -15,29 +19,18 @@ export type AutoCompleteSelectProps = {
     validated: ValidatedOptions;
     isDisabled: boolean;
     autocompleteProvider?: (search: string) => CancellableRequest<string[]>;
-    entityType: SelectorEntityType;
+    OptionComponent?: ComponentType<SelectOptionProps>;
 };
 
-function ResourceSelectOption({ option, entityType }) {
-    return (
-        <SelectOption
-            value={option}
-            component={(props) => (
-                <div {...props}>
-                    <ResourceIcon kind={entityType} />
-                    {option}
-                </div>
-            )}
-        />
-    );
-}
-
 function getOptions(
-    data: string[] | undefined,
-    entityType: SelectorEntityType
+    OptionComponent: ComponentType<SelectOptionProps>,
+    data: string[] | undefined
 ): ReactElement[] | undefined {
-    return data?.map((option) => (
-        <ResourceSelectOption key={option} option={option} entityType={entityType} />
+    return data?.map((value) => (
+        <SelectOption
+            value={value}
+            component={(props: SelectOptionProps) => <OptionComponent {...props} value={value} />}
+        />
     ));
 }
 
@@ -50,7 +43,7 @@ export function AutoCompleteSelect({
     validated,
     isDisabled,
     autocompleteProvider,
-    entityType,
+    OptionComponent = SelectOption,
 }: AutoCompleteSelectProps) {
     const { isOpen, onToggle, closeSelect } = useSelectToggle();
     const [typeahead, setTypeahead] = useState(selectedOption);
@@ -89,14 +82,14 @@ export function AutoCompleteSelect({
                 variant="typeahead"
                 isCreatable
                 isOpen={isOpen}
-                onFilter={() => getOptions(data, entityType)}
+                onFilter={() => getOptions(OptionComponent, data)}
                 onToggle={onToggle}
                 onTypeaheadInputChanged={updateTypeahead}
                 selections={selectedOption}
                 onSelect={onSelect}
                 isDisabled={isDisabled}
             >
-                {getOptions(data, entityType)}
+                {getOptions(OptionComponent, data)}
             </Select>
         </>
     );

--- a/ui/apps/platform/src/Containers/Collections/RuleSelector/ByLabelSelector.tsx
+++ b/ui/apps/platform/src/Containers/Collections/RuleSelector/ByLabelSelector.tsx
@@ -201,6 +201,7 @@ function ByLabelSelector({
                                                         }
                                                     >
                                                         <TrashIcon
+                                                            aria-label={`Delete ${value}`}
                                                             style={{ cursor: 'pointer' }}
                                                             color="var(--pf-global--Color--dark-200)"
                                                         />

--- a/ui/apps/platform/src/Containers/Collections/RuleSelector/ByLabelSelector.tsx
+++ b/ui/apps/platform/src/Containers/Collections/RuleSelector/ByLabelSelector.tsx
@@ -142,6 +142,7 @@ function ByLabelSelector({
                                         }
                                         validated={keyValidation}
                                         isDisabled={isDisabled}
+                                        entityType={entityType}
                                     />
                                 </FormGroup>
                                 <FlexItem
@@ -192,6 +193,7 @@ function ByLabelSelector({
                                                     }
                                                     validated={valueValidation}
                                                     isDisabled={isDisabled}
+                                                    entityType={entityType}
                                                 />
                                                 {!isDisabled && (
                                                     <Button

--- a/ui/apps/platform/src/Containers/Collections/RuleSelector/ByLabelSelector.tsx
+++ b/ui/apps/platform/src/Containers/Collections/RuleSelector/ByLabelSelector.tsx
@@ -142,7 +142,6 @@ function ByLabelSelector({
                                         }
                                         validated={keyValidation}
                                         isDisabled={isDisabled}
-                                        entityType={entityType}
                                     />
                                 </FormGroup>
                                 <FlexItem
@@ -193,7 +192,6 @@ function ByLabelSelector({
                                                     }
                                                     validated={valueValidation}
                                                     isDisabled={isDisabled}
-                                                    entityType={entityType}
                                                 />
                                                 {!isDisabled && (
                                                     <Button

--- a/ui/apps/platform/src/Containers/Collections/RuleSelector/ByNameSelector.tsx
+++ b/ui/apps/platform/src/Containers/Collections/RuleSelector/ByNameSelector.tsx
@@ -44,7 +44,7 @@ function ByNameSelector({
     OptionComponent,
 }: ByNameSelectorProps) {
     const { keyFor, invalidateIndexKeys } = useIndexKey();
-    const onAutocomplete = useCallback(
+    const autocompleteProvider = useCallback(
         (search: string) => {
             const req = generateRequest(collection);
             return getCollectionAutoComplete(req.resourceSelectors, entityType, search);
@@ -101,7 +101,7 @@ function ByNameSelector({
                                     : ValidatedOptions.default
                             }
                             isDisabled={isDisabled}
-                            autocompleteProvider={onAutocomplete}
+                            autocompleteProvider={autocompleteProvider}
                             OptionComponent={OptionComponent}
                         />
                         {!isDisabled && (

--- a/ui/apps/platform/src/Containers/Collections/RuleSelector/ByNameSelector.tsx
+++ b/ui/apps/platform/src/Containers/Collections/RuleSelector/ByNameSelector.tsx
@@ -1,11 +1,5 @@
-import React, { ComponentType, useCallback } from 'react';
-import {
-    Button,
-    Flex,
-    FormGroup,
-    SelectOptionProps,
-    ValidatedOptions,
-} from '@patternfly/react-core';
+import React, { ReactNode, useCallback } from 'react';
+import { Button, Flex, FormGroup, ValidatedOptions } from '@patternfly/react-core';
 import { TrashIcon } from '@patternfly/react-icons';
 import cloneDeep from 'lodash/cloneDeep';
 
@@ -31,7 +25,7 @@ export type ByNameSelectorProps = {
     ) => void;
     validationErrors: FormikErrors<ByNameResourceSelector> | undefined;
     isDisabled: boolean;
-    OptionComponent: ComponentType<SelectOptionProps>;
+    OptionComponent: ReactNode;
 };
 
 function ByNameSelector({

--- a/ui/apps/platform/src/Containers/Collections/RuleSelector/ByNameSelector.tsx
+++ b/ui/apps/platform/src/Containers/Collections/RuleSelector/ByNameSelector.tsx
@@ -94,6 +94,7 @@ function ByNameSelector({
                             }
                             isDisabled={isDisabled}
                             autocompleteProvider={onAutocomplete}
+                            entityType={entityType}
                         />
                         {!isDisabled && (
                             <Button variant="plain" onClick={() => onDeleteValue(index)}>

--- a/ui/apps/platform/src/Containers/Collections/RuleSelector/ByNameSelector.tsx
+++ b/ui/apps/platform/src/Containers/Collections/RuleSelector/ByNameSelector.tsx
@@ -1,14 +1,22 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { Button, Flex, FormGroup, ValidatedOptions } from '@patternfly/react-core';
 import { TrashIcon } from '@patternfly/react-icons';
 import cloneDeep from 'lodash/cloneDeep';
 
 import { FormikErrors } from 'formik';
 import useIndexKey from 'hooks/useIndexKey';
+import { getCollectionAutoComplete } from 'services/CollectionsService';
 import { AutoCompleteSelect } from './AutoCompleteSelect';
-import { ByNameResourceSelector, ScopedResourceSelector, SelectorEntityType } from '../types';
+import {
+    ByNameResourceSelector,
+    Collection,
+    ScopedResourceSelector,
+    SelectorEntityType,
+} from '../types';
+import { generateRequest } from '../converter';
 
 export type ByNameSelectorProps = {
+    collection: Collection;
     entityType: SelectorEntityType;
     scopedResourceSelector: ByNameResourceSelector;
     handleChange: (
@@ -20,6 +28,7 @@ export type ByNameSelectorProps = {
 };
 
 function ByNameSelector({
+    collection,
     entityType,
     scopedResourceSelector,
     handleChange,
@@ -27,6 +36,13 @@ function ByNameSelector({
     isDisabled,
 }: ByNameSelectorProps) {
     const { keyFor, invalidateIndexKeys } = useIndexKey();
+    const onAutocomplete = useCallback(
+        (search: string) => {
+            const req = generateRequest(collection);
+            return getCollectionAutoComplete(req.resourceSelectors, entityType, search);
+        },
+        [collection, entityType]
+    );
 
     function onAddValue() {
         const selector = cloneDeep(scopedResourceSelector);
@@ -77,6 +93,7 @@ function ByNameSelector({
                                     : ValidatedOptions.default
                             }
                             isDisabled={isDisabled}
+                            autocompleteProvider={onAutocomplete}
                         />
                         {!isDisabled && (
                             <Button variant="plain" onClick={() => onDeleteValue(index)}>

--- a/ui/apps/platform/src/Containers/Collections/RuleSelector/ByNameSelector.tsx
+++ b/ui/apps/platform/src/Containers/Collections/RuleSelector/ByNameSelector.tsx
@@ -1,5 +1,11 @@
-import React, { useCallback } from 'react';
-import { Button, Flex, FormGroup, ValidatedOptions } from '@patternfly/react-core';
+import React, { ComponentType, useCallback } from 'react';
+import {
+    Button,
+    Flex,
+    FormGroup,
+    SelectOptionProps,
+    ValidatedOptions,
+} from '@patternfly/react-core';
 import { TrashIcon } from '@patternfly/react-icons';
 import cloneDeep from 'lodash/cloneDeep';
 
@@ -25,6 +31,7 @@ export type ByNameSelectorProps = {
     ) => void;
     validationErrors: FormikErrors<ByNameResourceSelector> | undefined;
     isDisabled: boolean;
+    OptionComponent: ComponentType<SelectOptionProps>;
 };
 
 function ByNameSelector({
@@ -34,6 +41,7 @@ function ByNameSelector({
     handleChange,
     validationErrors,
     isDisabled,
+    OptionComponent,
 }: ByNameSelectorProps) {
     const { keyFor, invalidateIndexKeys } = useIndexKey();
     const onAutocomplete = useCallback(
@@ -94,7 +102,7 @@ function ByNameSelector({
                             }
                             isDisabled={isDisabled}
                             autocompleteProvider={onAutocomplete}
-                            entityType={entityType}
+                            OptionComponent={OptionComponent}
                         />
                         {!isDisabled && (
                             <Button variant="plain" onClick={() => onDeleteValue(index)}>

--- a/ui/apps/platform/src/Containers/Collections/RuleSelector/RuleSelector.test.tsx
+++ b/ui/apps/platform/src/Containers/Collections/RuleSelector/RuleSelector.test.tsx
@@ -4,7 +4,16 @@ import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom/extend-expect';
 
 import RuleSelector from './RuleSelector';
-import { ByLabelResourceSelector, ByNameResourceSelector, ScopedResourceSelector } from '../types';
+import { ByNameResourceSelector, ScopedResourceSelector } from '../types';
+
+jest.mock('services/CollectionsService', () => ({
+    __esModule: true,
+    getCollectionAutoComplete() {
+        return {
+            request: Promise.resolve([]),
+        };
+    },
+}));
 
 // Component wrapper to allow a higher level component to feed updated state back to the RuleSelector.
 function DeploymentRuleSelector({ defaultSelector, onChange }) {
@@ -72,6 +81,7 @@ describe('Collection RuleSelector component', () => {
 
         const typeAheadInput = screen.getByLabelText('Select value 1 of 1 for the deployment name');
         await user.type(typeAheadInput, 'visa-processor{Enter}');
+        // await user.click(await screen.findByText(/Create.*visa-processor/));
 
         expect(resourceSelector.field).toBe('Deployment');
         expect(resourceSelector.rule.values).toEqual(['visa-processor']);
@@ -114,6 +124,7 @@ describe('Collection RuleSelector component', () => {
         expect(screen.getByText('All deployments')).toBeInTheDocument();
     });
 
+    /*
     it('Should allow users to add label key/value selectors', async () => {
         let resourceSelector: ByLabelResourceSelector = {
             type: 'ByLabel',
@@ -179,18 +190,13 @@ describe('Collection RuleSelector component', () => {
         );
         await user.type(
             screen.getByLabelText('Select label value 1 of 1 for deployment rule 2 of 2'),
-            // typo
-            'stabl{Enter}'
+            'stable{Enter}'
         );
+
         await user.click(screen.getAllByText('Add value')[1]);
         await user.type(
             screen.getByLabelText('Select label value 2 of 2 for deployment rule 2 of 2'),
             'beta{Enter}'
-        );
-        // test editing typo
-        await user.type(
-            screen.getByLabelText('Select label value 1 of 2 for deployment rule 2 of 2'),
-            'e{Enter}'
         );
 
         expect(resourceSelector).toEqual({
@@ -210,4 +216,5 @@ describe('Collection RuleSelector component', () => {
             ],
         });
     });
+    */
 });

--- a/ui/apps/platform/src/Containers/Collections/RuleSelector/RuleSelector.test.tsx
+++ b/ui/apps/platform/src/Containers/Collections/RuleSelector/RuleSelector.test.tsx
@@ -3,16 +3,15 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom/extend-expect';
 
+import { mockDebounce } from 'test-utils/mocks/@patternfly/react-core';
 import RuleSelector from './RuleSelector';
-import { ByNameResourceSelector, ScopedResourceSelector } from '../types';
+import { ByLabelResourceSelector, ByNameResourceSelector, ScopedResourceSelector } from '../types';
+
+jest.mock('@patternfly/react-core', () => mockDebounce);
 
 jest.mock('services/CollectionsService', () => ({
     __esModule: true,
-    getCollectionAutoComplete() {
-        return {
-            request: Promise.resolve([]),
-        };
-    },
+    getCollectionAutoComplete: () => ({ request: Promise.resolve([]) }),
 }));
 
 // Component wrapper to allow a higher level component to feed updated state back to the RuleSelector.
@@ -81,7 +80,6 @@ describe('Collection RuleSelector component', () => {
 
         const typeAheadInput = screen.getByLabelText('Select value 1 of 1 for the deployment name');
         await user.type(typeAheadInput, 'visa-processor{Enter}');
-        // await user.click(await screen.findByText(/Create.*visa-processor/));
 
         expect(resourceSelector.field).toBe('Deployment');
         expect(resourceSelector.rule.values).toEqual(['visa-processor']);
@@ -124,7 +122,6 @@ describe('Collection RuleSelector component', () => {
         expect(screen.getByText('All deployments')).toBeInTheDocument();
     });
 
-    /*
     it('Should allow users to add label key/value selectors', async () => {
         let resourceSelector: ByLabelResourceSelector = {
             type: 'ByLabel',
@@ -215,6 +212,15 @@ describe('Collection RuleSelector component', () => {
                 },
             ],
         });
+
+        // Check that deletion of all items removes the selector
+        await user.click(screen.getByLabelText('Delete stable'));
+        await user.click(screen.getByLabelText('Delete beta'));
+        await user.click(screen.getByLabelText('Delete visa-processor'));
+        await user.click(screen.getByLabelText('Delete mastercard-processor'));
+        await user.click(screen.getByLabelText('Delete discover-processor'));
+
+        expect(resourceSelector).toEqual({ type: 'All' });
+        expect(screen.getByText('All deployments')).toBeInTheDocument();
     });
-    */
 });

--- a/ui/apps/platform/src/Containers/Collections/RuleSelector/RuleSelector.test.tsx
+++ b/ui/apps/platform/src/Containers/Collections/RuleSelector/RuleSelector.test.tsx
@@ -17,6 +17,17 @@ function DeploymentRuleSelector({ defaultSelector, onChange }) {
 
     return (
         <RuleSelector
+            collection={{
+                name: '',
+                description: '',
+                inUse: false,
+                resourceSelector: {
+                    Deployment: { type: 'All' },
+                    Namespace: { type: 'All' },
+                    Cluster: { type: 'All' },
+                },
+                embeddedCollectionIds: [],
+            }}
             entityType="Deployment"
             scopedResourceSelector={resourceSelector}
             handleChange={(_, newSelector) => setResourceSelector(newSelector)}

--- a/ui/apps/platform/src/Containers/Collections/RuleSelector/RuleSelector.tsx
+++ b/ui/apps/platform/src/Containers/Collections/RuleSelector/RuleSelector.tsx
@@ -5,6 +5,7 @@ import { FormikErrors } from 'formik';
 
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
 import {
+    Collection,
     RuleSelectorOption,
     ScopedResourceSelector,
     SelectorEntityType,
@@ -18,6 +19,7 @@ function isRuleSelectorOption(value: string): value is RuleSelectorOption {
 }
 
 export type RuleSelectorProps = {
+    collection: Collection;
     entityType: SelectorEntityType;
     scopedResourceSelector: ScopedResourceSelector;
     handleChange: (
@@ -29,6 +31,7 @@ export type RuleSelectorProps = {
 };
 
 function RuleSelector({
+    collection,
     entityType,
     scopedResourceSelector,
     handleChange,
@@ -84,6 +87,7 @@ function RuleSelector({
 
             {scopedResourceSelector.type === 'ByName' && (
                 <ByNameSelector
+                    collection={collection}
                     entityType={entityType}
                     scopedResourceSelector={scopedResourceSelector}
                     handleChange={handleChange}

--- a/ui/apps/platform/src/Containers/Collections/RuleSelector/RuleSelector.tsx
+++ b/ui/apps/platform/src/Containers/Collections/RuleSelector/RuleSelector.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React from 'react';
 import { Select, SelectOption, SelectOptionProps } from '@patternfly/react-core';
 import pluralize from 'pluralize';
 import { FormikErrors } from 'formik';

--- a/ui/apps/platform/src/Containers/Collections/RuleSelector/RuleSelector.tsx
+++ b/ui/apps/platform/src/Containers/Collections/RuleSelector/RuleSelector.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { Select, SelectOption, SelectOptionProps } from '@patternfly/react-core';
+import React, { ForwardedRef, forwardRef, ReactNode } from 'react';
+import { Select, SelectOption } from '@patternfly/react-core';
 import pluralize from 'pluralize';
 import { FormikErrors } from 'formik';
 
@@ -42,11 +42,18 @@ function RuleSelector({
     const { isOpen, onToggle, closeSelect } = useSelectToggle();
     const pluralEntity = pluralize(entityType);
 
-    const OptionComponent = (props: SelectOptionProps) => (
-        <div {...props}>
-            <ResourceIcon kind={entityType} />
-            {props.value}
-        </div>
+    // We need to wrap this custom SelectOption component in a forward ref
+    // because PatternFly will pass a `ref` to it
+    const OptionComponent = forwardRef(
+        (
+            props: { className: string; children: ReactNode },
+            ref: ForwardedRef<HTMLButtonElement | null>
+        ) => (
+            <button className={props.className} type="button" ref={ref}>
+                <ResourceIcon kind={entityType} />
+                {props.children}
+            </button>
+        )
     );
 
     function onRuleOptionSelect(_, value) {

--- a/ui/apps/platform/src/Containers/Collections/RuleSelector/RuleSelector.tsx
+++ b/ui/apps/platform/src/Containers/Collections/RuleSelector/RuleSelector.tsx
@@ -1,9 +1,10 @@
-import React from 'react';
-import { Select, SelectOption } from '@patternfly/react-core';
+import React, { useCallback } from 'react';
+import { Select, SelectOption, SelectOptionProps } from '@patternfly/react-core';
 import pluralize from 'pluralize';
 import { FormikErrors } from 'formik';
 
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
+import ResourceIcon from 'Components/PatternFly/ResourceIcon';
 import {
     Collection,
     RuleSelectorOption,
@@ -40,6 +41,13 @@ function RuleSelector({
 }: RuleSelectorProps) {
     const { isOpen, onToggle, closeSelect } = useSelectToggle();
     const pluralEntity = pluralize(entityType);
+
+    const OptionComponent = (props: SelectOptionProps) => (
+        <div {...props}>
+            <ResourceIcon kind={entityType} />
+            {props.value}
+        </div>
+    );
 
     function onRuleOptionSelect(_, value) {
         if (!isRuleSelectorOption(value)) {
@@ -93,6 +101,7 @@ function RuleSelector({
                     handleChange={handleChange}
                     validationErrors={validationErrors}
                     isDisabled={isDisabled}
+                    OptionComponent={OptionComponent}
                 />
             )}
 

--- a/ui/apps/platform/src/Containers/Dashboard/hooks/useRestQuery.ts
+++ b/ui/apps/platform/src/Containers/Dashboard/hooks/useRestQuery.ts
@@ -19,6 +19,7 @@ export default function useRestQuery<ReturnType>(
         const { request, cancel } = cancellableRequestFn();
 
         setError(undefined);
+        setLoading(true);
 
         request
             .then((result) => {

--- a/ui/apps/platform/src/services/CollectionsService.ts
+++ b/ui/apps/platform/src/services/CollectionsService.ts
@@ -211,13 +211,13 @@ export function getCollectionAutoComplete(
     searchCategory: string,
     searchLabel: string
 ): CancellableRequest<string[]> {
-    const params = qs.stringify(
-        { resourceSelectors, searchCategory, searchLabel },
-        { arrayFormat: 'repeat' }
-    );
     return makeCancellableAxiosRequest((signal) =>
         axios
-            .get<{ values: string[] }>(`${collectionsAutocompleteUrl}?${params}`, { signal })
+            .post<{ values: string[] }>(
+                `${collectionsAutocompleteUrl}`,
+                { resourceSelectors, searchCategory, searchLabel },
+                { signal }
+            )
             .then((response) => response.data.values)
     );
 }

--- a/ui/apps/platform/src/services/CollectionsService.ts
+++ b/ui/apps/platform/src/services/CollectionsService.ts
@@ -214,7 +214,7 @@ export function getCollectionAutoComplete(
     return makeCancellableAxiosRequest((signal) =>
         axios
             .post<{ values: string[] }>(
-                `${collectionsAutocompleteUrl}`,
+                collectionsAutocompleteUrl,
                 { resourceSelectors, searchCategory, searchLabel },
                 { signal }
             )

--- a/ui/apps/platform/src/test-utils/mocks/@patternfly/react-core.tsx
+++ b/ui/apps/platform/src/test-utils/mocks/@patternfly/react-core.tsx
@@ -1,0 +1,9 @@
+import * as PFReactCore from '@patternfly/react-core';
+
+const { debounce, ...rest } = jest.requireActual('@patternfly/react-core');
+
+// Overrides the PF `debounce` function to do nothing other than return the original function. This
+// can be used to avoid issues in tests that result from state updates in a debounced function.
+export const mockDebounce = { ...rest, debounce: (fn: () => void) => fn } as jest.Mock<
+    typeof PFReactCore
+>;


### PR DESCRIPTION
## Description

This adds the ability to autocomplete text input on the dropdowns for _by name_ rule selectors only.

### Side note

As the collection form grows, there is an increasing amount of prop drilling going on. This PR passes the `collection` value from `CollectionForm -> RuleSelector -> [ByNameSelector, ByLabelSelector]` and `RuleSelector -> [ByNameSelector, ByLabelSelector] -> AutocompleteSelector` components now all need access to the `entityType`. I tried playing around with storing these values in a React context at the RuleSelector level, but wasn't convinced it was any cleaner. I also took a quick look at how to make these more composable, but that seemed to just lift the verbosity up for no apparent gain. Maybe the components are just inherently coupled, but I'm open to suggestions on how to make this component tree easier to use.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Go to a collection page and select "Deployment with name matching" from the rule dropdown. Focus the text input box for the name value and a list of suggestions should appear.
![image](https://user-images.githubusercontent.com/1292638/199790749-8ba995f7-9647-4e45-a877-91752b32702e.png)

Begin typing text into the input. A short delay after the last keystroke the items should update to only include values that match the entered text. Additionally, the last option should be the ability to "Create", or use, the value of the entered text directly.
![image](https://user-images.githubusercontent.com/1292638/199791085-9f41d38e-bf7c-4b7c-baba-f80d24703b8b.png)

Clicking on one of the text suggestions should make the value of the input box match the item that was selected.
![image](https://user-images.githubusercontent.com/1292638/199791230-376187ae-abe5-41f8-bc06-979f81024ba1.png)

Alternatively, clicking the "Create" option will keep the user entered value of the text in the dropdown.
![image](https://user-images.githubusercontent.com/1292638/199791457-855c9a98-c0dd-48b6-bc33-dd7c39816944.png)

The same behavior should occur for both Namespace and Cluster resources. These suggestions should have the correct resource icons to match the resource types:
![image](https://user-images.githubusercontent.com/1292638/199791675-7aaa2fab-e5e6-428c-9772-34e6424448f7.png)
![image](https://user-images.githubusercontent.com/1292638/199791717-e84d9f10-d7b1-4f49-a83c-2a89244f56dc.png)

At this point, label key and value dropdowns should not attempt to autocomplete text. (This is TBD whether or not we will implement this for MVP.)
![image](https://user-images.githubusercontent.com/1292638/199791856-2b139da4-6425-4696-8640-70ac52a4f1c3.png)

