### PR TITLE
ROX-13170: Adding table row actions for flows table

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentFlows.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentFlows.tsx
@@ -13,7 +13,9 @@ import {
     ToolbarItem,
 } from '@patternfly/react-core';
 import {
+    ActionsColumn,
     ExpandableRowContent,
+    IAction,
     TableComposable,
     Tbody,
     Td,
@@ -202,7 +204,7 @@ function DeploymentFlow() {
                     <TableComposable aria-label="Deployment flow" variant="compact">
                         <Thead>
                             <Tr>
-                                <Th width={10} />
+                                <Th />
                                 <Th
                                     select={{
                                         onSelect: (_event, isSelecting) =>
@@ -211,12 +213,29 @@ function DeploymentFlow() {
                                     }}
                                 />
                                 <Th width={40}>{columnNames.entity}</Th>
-                                <Th width={20}>{columnNames.direction}</Th>
-                                <Th width={30}>{columnNames.portAndProtocol}</Th>
+                                <Th>{columnNames.direction}</Th>
+                                <Th>{columnNames.portAndProtocol}</Th>
+                                <Th />
                             </Tr>
                         </Thead>
                         {flows.map((row, rowIndex) => {
                             const isExpanded = isRowExpanded(row);
+                            const rowActions: IAction[] = !row.children.length
+                                ? [
+                                      row.isAnomalous
+                                          ? {
+                                                itemKey: 'add-flow-to-baseline',
+                                                title: 'Add to baseline',
+                                                onClick: () => {},
+                                            }
+                                          : {
+                                                itemKey: 'mark-flow-as-anomalous',
+                                                title: 'Mark as anomalous',
+                                                onClick: () => {},
+                                            },
+                                  ]
+                                : [];
+
                             return (
                                 <Tbody key={row.id} isExpanded={isExpanded}>
                                     <Tr>
@@ -271,9 +290,28 @@ function DeploymentFlow() {
                                         <Td dataLabel={columnNames.portAndProtocol}>
                                             {row.port} / {row.protocol}
                                         </Td>
+                                        <Td isActionCell>
+                                            {!row.children.length && (
+                                                <ActionsColumn items={rowActions} />
+                                            )}
+                                        </Td>
                                     </Tr>
                                     {isExpanded &&
                                         row.children.map((child) => {
+                                            const childActions: IAction[] = [
+                                                child.isAnomalous
+                                                    ? {
+                                                          itemKey: 'add-flow-to-baseline',
+                                                          title: 'Add to baseline',
+                                                          onClick: () => {},
+                                                      }
+                                                    : {
+                                                          itemKey: 'mark-flow-as-anomalous',
+                                                          title: 'Mark as anomalous',
+                                                          onClick: () => {},
+                                                      },
+                                            ];
+
                                             return (
                                                 <Tr key={child.id} isExpanded={isExpanded}>
                                                     <Td />
@@ -306,6 +344,9 @@ function DeploymentFlow() {
                                                         <ExpandableRowContent>
                                                             {child.port} / {child.protocol}
                                                         </ExpandableRowContent>
+                                                    </Td>
+                                                    <Td isActionCell>
+                                                        <ActionsColumn items={childActions} />
                                                     </Td>
                                                 </Tr>
                                             );


### PR DESCRIPTION
## Description

This PR adds the table row actions for the flows table. This is an iterative addition. You can find all the subtasks here: https://issues.redhat.com/browse/ROX-12904

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Screenshots

### Add flow to baseline
<img width="1552" alt="Screenshot 2022-11-03 at 10 13 11 AM" src="https://user-images.githubusercontent.com/4805485/199789383-44461e85-8ec1-41f2-aea9-9a4ad40869a4.png">

### Mark flow as anomalous
<img width="1552" alt="Screenshot 2022-11-03 at 10 13 15 AM" src="https://user-images.githubusercontent.com/4805485/199789406-51bfdfc8-0c1a-425e-a4de-56bdc53b843e.png">
