### PR TITLE
Fix AddCluster error with cluster exists

### DIFF
--- a/central/cluster/datastore/datastore_impl.go
+++ b/central/cluster/datastore/datastore_impl.go
@@ -314,7 +314,7 @@ func (ds *datastoreImpl) AddCluster(ctx context.Context, cluster *storage.Cluste
 	}
 	_, found := ds.nameToIDCache.Get(cluster.Name)
 	if found {
-		return "", errox.AlreadyExists.Newf("cannot add cluster %s, it already exists", cluster.GetName())
+		return "", errox.AlreadyExists.Newf("the cluster with name %s exists, cannot re-add it", cluster.GetName())
 	}
 
 	ds.lock.Lock()

--- a/central/cluster/datastore/datastore_impl.go
+++ b/central/cluster/datastore/datastore_impl.go
@@ -312,6 +312,10 @@ func (ds *datastoreImpl) AddCluster(ctx context.Context, cluster *storage.Cluste
 	if err := checkWriteSac(ctx, cluster.GetId()); err != nil {
 		return "", err
 	}
+	_, found := ds.nameToIDCache.Get(cluster.Name)
+	if found {
+		return "", errox.AlreadyExists.Newf("cannot add cluster %s, it already exists", cluster.GetName())
+	}
 
 	ds.lock.Lock()
 	defer ds.lock.Unlock()


### PR DESCRIPTION
## Description
Fix an issue blocking non-groovy test.
```
roxctl --insecure-skip-tls-verify -e 35.188.132.52:443 -p omJnRzC1JyvbsX5Zjz5B1wE84 sensor generate openshift --name os-istio-test-cluster --continue-if-exists --output-dir /tmp/tmp.b78Sol7JBW
[OK] No DestinationRule will be created
[FAIL] Error invoking command
Captured output was:
ERROR:	error creating cluster: rpc error: code = Internal desc = ERROR: duplicate key value violates unique constraint "clusters_name_key" (SQLSTATE 23505)
```
Link: https://srox.slack.com/archives/C030MTTE1S5/p1667498696672839

Feel free to remove this section if it is overkill for your PR, and the title of your PR is sufficiently descriptive.](https://srox.slack.com/archives/C030MTTE1S5/p1667496808272139)

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
