### PR TITLE
Replace requestConfig with routeMatcherMap in helper functions for integration tests

### DIFF
--- a/ui/apps/platform/cypress/constants/apiEndpoints.js
+++ b/ui/apps/platform/cypress/constants/apiEndpoints.js
@@ -1,4 +1,4 @@
-export const graphql = (operationName) => `/api/graphql?opname=${operationName}`;
+export const graphql = (opname) => `/api/graphql?opname=${opname}`;
 
 function searchObjToQuery(searchObj) {
     let result = '';
@@ -84,7 +84,6 @@ export const auth = {
     loginAuthProviders: '/v1/login/authproviders',
     authProviders: '/v1/authProviders',
     authStatus: '/v1/auth/status',
-    logout: '/sso/session/logout',
     tokenRefresh: '/sso/session/tokenrefresh',
 };
 
@@ -99,7 +98,6 @@ export const network = {
     networkBaselineLock: '/v1/networkbaseline/*/lock',
     networkBaselineUnlock: '/v1/networkbaseline/*/unlock',
     networkBaselinePeers: '/v1/networkbaseline/*/peers',
-    networkBaselineStatus: '/v1/networkbaseline/*/status',
     networkPoliciesGraph: '/v1/networkpolicies/cluster/*',
     networkGraph: '/v1/networkgraph/cluster/*',
     epoch: '/v1/networkpolicies/graph/epoch',
@@ -137,21 +135,6 @@ export const groups = {
 
 export const userAttributes = {
     list: '/v1/userattributes/*',
-};
-
-const complianceEntitiesOp = {
-    clusters: 'clustersList',
-    deployments: 'deploymentsList',
-    namespaces: 'namespaceList', // singular: too bad, so sad
-    nodes: 'nodesList',
-};
-
-export const compliance = {
-    // For example, graphqlEntities('clusters')
-    graphqlEntities: (key) => graphql(complianceEntitiesOp[key]),
-    export: {
-        csv: '/api/compliance/export/csv',
-    },
 };
 
 export const logs = '/api/logimbue';

--- a/ui/apps/platform/cypress/helpers/clusters.js
+++ b/ui/apps/platform/cypress/helpers/clusters.js
@@ -27,19 +27,20 @@ const routeMatcherMap = {
  * For example, click View All button from System Health.
  */
 export function reachClusters(interactionCallback, staticResponseMap) {
-    interactAndWaitForResponses(interactionCallback, { routeMatcherMap }, staticResponseMap);
+    interactAndWaitForResponses(interactionCallback, routeMatcherMap, staticResponseMap);
 
     cy.get(selectors.clustersListHeading).contains('Clusters');
 }
 
 export function visitClustersFromLeftNav() {
-    visitFromLeftNavExpandable('Platform Configuration', 'Clusters', { routeMatcherMap });
+    visitFromLeftNavExpandable('Platform Configuration', 'Clusters', routeMatcherMap);
 
+    cy.location('pathname').should('eq', clustersUrl);
     cy.get(selectors.clustersListHeading).contains('Clusters');
 }
 
 export function visitClusters(staticResponseMap) {
-    visit(clustersUrl, { routeMatcherMap }, staticResponseMap);
+    visit(clustersUrl, routeMatcherMap, staticResponseMap);
 
     cy.get(selectors.clustersListHeading).contains('Clusters');
 }
@@ -61,11 +62,7 @@ export function visitClusterById(clusterId, staticResponseMap) {
             url: `${api.clusters.list}/${clusterId}`,
         },
     };
-    visit(
-        `${clustersUrl}/${clusterId}`,
-        { routeMatcherMap: routeMatcherMapClusterById },
-        staticResponseMap
-    );
+    visit(`${clustersUrl}/${clusterId}`, routeMatcherMapClusterById, staticResponseMap);
 
     cy.get(selectors.clustersListHeading).contains('Clusters');
 }

--- a/ui/apps/platform/cypress/helpers/collections.js
+++ b/ui/apps/platform/cypress/helpers/collections.js
@@ -8,23 +8,21 @@ const basePath = '/main/collections';
 export const collectionsAlias = 'collections';
 export const collectionsCountAlias = 'collections/count';
 
-const requestConfigForCollections = {
-    routeMatcherMap: {
-        [collectionsAlias]: {
-            method: 'GET',
-            url: '/v1/collections?query.query=*',
-        },
-        [collectionsCountAlias]: {
-            method: 'GET',
-            url: '/v1/collectionscount?query.query=*',
-        },
+const routeMatcherMapForCollections = {
+    [collectionsAlias]: {
+        method: 'GET',
+        url: '/v1/collections?query.query=*',
+    },
+    [collectionsCountAlias]: {
+        method: 'GET',
+        url: '/v1/collectionscount?query.query=*',
     },
 };
 
 // visit
 
 export function visitCollections(staticResponseMap) {
-    visit(basePath, requestConfigForCollections, staticResponseMap);
+    visit(basePath, routeMatcherMapForCollections, staticResponseMap);
 
     cy.get('h1:contains("Collections")');
     cy.get(`${navSelectors.navExpandable}:contains("Platform Configuration")`);
@@ -38,7 +36,7 @@ export function visitCollectionsFromLeftNav(staticResponseMap) {
     visitFromLeftNavExpandable(
         'Platform Configuration',
         'Collections',
-        requestConfigForCollections,
+        routeMatcherMapForCollections,
         staticResponseMap
     );
 

--- a/ui/apps/platform/cypress/helpers/compliance.js
+++ b/ui/apps/platform/cypress/helpers/compliance.js
@@ -3,7 +3,7 @@ import { headingPlural, selectors, url } from '../constants/CompliancePage';
 import { getRouteMatcherMapForGraphQL, interactAndWaitForResponses } from './request';
 import { visit } from './visit';
 
-const routeMatcherMapForDashboard = getRouteMatcherMapForGraphQL([
+const routeMatcherMapForComplianceDashboard = getRouteMatcherMapForGraphQL([
     'clustersCount',
     'namespacesCount',
     'nodesCount',
@@ -23,7 +23,7 @@ const routeMatcherMapForDashboard = getRouteMatcherMapForGraphQL([
 ]);
 
 export function visitComplianceDashboard() {
-    visit(url.dashboard, routeMatcherMapForDashboard);
+    visit(url.dashboard, routeMatcherMapForComplianceDashboard);
 
     cy.get('h1:contains("Compliance")');
 }
@@ -35,7 +35,7 @@ export function scanCompliance() {
     const routeMatcherMapForTriggerScan = getRouteMatcherMapForGraphQL(['triggerScan']);
     const routeMatcherMap = {
         ...routeMatcherMapForTriggerScan,
-        ...routeMatcherMapForDashboard,
+        ...routeMatcherMapForComplianceDashboard,
     };
 
     cy.get(selectors.scanButton).should('not.have.attr', 'disabled');

--- a/ui/apps/platform/cypress/helpers/configWorkflowUtils.js
+++ b/ui/apps/platform/cypress/helpers/configWorkflowUtils.js
@@ -134,7 +134,7 @@ function opnameForPrimaryAndSecondaryEntities(entitiesKey1, entitiesKey2) {
     return `${opnameForEntity[entitiesKey1]}_${typeOfEntity[entitiesKey2]}`;
 }
 
-const routeMatcherMapForDashboard = getRouteMatcherMapForGraphQL([
+const routeMatcherMapForConfigurationManagementDashboard = getRouteMatcherMapForGraphQL([
     'numPolicies',
     'numCISControls',
     'policyViolationsBySeverity',
@@ -145,7 +145,7 @@ const routeMatcherMapForDashboard = getRouteMatcherMapForGraphQL([
 ]);
 
 export function visitConfigurationManagementDashboard() {
-    visit(basePath, routeMatcherMapForDashboard);
+    visit(basePath, routeMatcherMapForConfigurationManagementDashboard);
 
     cy.get('h1:contains("Configuration Management")');
 }
@@ -218,7 +218,7 @@ export function interactAndWaitForConfigurationManagementSecondaryEntities(
 }
 
 export function interactAndWaitForConfigurationManagementScan(interactionCallback) {
-    interactAndWaitForResponses(interactionCallback, routeMatcherMapForDashboard);
+    interactAndWaitForResponses(interactionCallback, routeMatcherMapForConfigurationManagementDashboard);
 }
 
 // specifying an "entityName" will try to select that row in the table

--- a/ui/apps/platform/cypress/helpers/configWorkflowUtils.js
+++ b/ui/apps/platform/cypress/helpers/configWorkflowUtils.js
@@ -218,7 +218,10 @@ export function interactAndWaitForConfigurationManagementSecondaryEntities(
 }
 
 export function interactAndWaitForConfigurationManagementScan(interactionCallback) {
-    interactAndWaitForResponses(interactionCallback, routeMatcherMapForConfigurationManagementDashboard);
+    interactAndWaitForResponses(
+        interactionCallback,
+        routeMatcherMapForConfigurationManagementDashboard
+    );
 }
 
 // specifying an "entityName" will try to select that row in the table

--- a/ui/apps/platform/cypress/helpers/credentialExpiry.js
+++ b/ui/apps/platform/cypress/helpers/credentialExpiry.js
@@ -13,12 +13,10 @@ function visitSystemConfigurationWithCredentialExpiryBanner(
 ) {
     const credentialExpiryAlias = 'credentialexpiry';
 
-    const requestConfig = {
-        routeMatcherMap: {
-            [credentialExpiryAlias]: {
-                method: 'GET',
-                url: `/v1/credentialexpiry?component=${componentUpperCase}`,
-            },
+    const routeMatcherMap = {
+        [credentialExpiryAlias]: {
+            method: 'GET',
+            url: `/v1/credentialexpiry?component=${componentUpperCase}`,
         },
     };
 
@@ -28,7 +26,7 @@ function visitSystemConfigurationWithCredentialExpiryBanner(
         },
     };
 
-    interceptRequests(requestConfig, staticResponseMap);
+    interceptRequests(routeMatcherMap, staticResponseMap);
 
     if (staticResponseForPermissions) {
         visitSystemConfigurationWithStaticResponseForPermissions(staticResponseForPermissions);
@@ -36,7 +34,7 @@ function visitSystemConfigurationWithCredentialExpiryBanner(
         visitSystemConfiguration();
     }
 
-    waitForResponses(requestConfig);
+    waitForResponses(routeMatcherMap);
 }
 
 export function visitSystemConfigurationWithCentralCredentialExpiryBanner(
@@ -64,14 +62,16 @@ export function visitSystemConfigurationWithScannerCredentialExpiryBanner(
 // certgen
 
 function interactAndWaitForCertificateDownload(componentLowerCase, interactionCallback) {
-    const requestConfig = {
-        reouteMatcherMap: {
+    const certgenAlias = 'certgen';
+
+    const routeMatcherMap = {
+        [certgenAlias]: {
             method: 'POST',
             url: `api/extensions/certgen/${componentLowerCase}`,
         },
     };
 
-    interactAndWaitForResponses(interactionCallback, requestConfig);
+    interactAndWaitForResponses(interactionCallback, routeMatcherMap);
 }
 
 export function interactAndWaitForCentralCertificateDownload(interactionCallback) {

--- a/ui/apps/platform/cypress/helpers/main.js
+++ b/ui/apps/platform/cypress/helpers/main.js
@@ -1,7 +1,7 @@
 import { url as basePath } from '../constants/DashboardPage';
 import navSelectors from '../selectors/navigation';
 
-import { getRouteMatcherForGraphQL, interactAndWaitForResponses } from './request';
+import { getRouteMatcherMapForGraphQL, interactAndWaitForResponses } from './request';
 import { visit } from './visit';
 
 /*
@@ -18,37 +18,44 @@ export const agingImagesQueryOpname = 'agingImagesQuery';
 export const alertsSummaryCountsGroupByCategoryAlias = 'alerts/summary/counts_CATEGORY';
 export const getAggregatedResultsOpname = 'getAggregatedResults';
 
-const routeMatcherMap = {
-    [summaryCountsOpname]: getRouteMatcherForGraphQL(summaryCountsOpname),
-    [getAllNamespacesByClusterOpname]: getRouteMatcherForGraphQL(getAllNamespacesByClusterOpname),
+const routeMatcherMapForSummaryCounts = getRouteMatcherMapForGraphQL([summaryCountsOpname]);
+const routeMatcherMapForSearchFilter = getRouteMatcherMapForGraphQL([
+    getAllNamespacesByClusterOpname,
+]);
+const routeMatcherMapForViolationsByPolicySeverity = {
     [alertsSummaryCountsAlias]: {
         method: 'GET',
         url: '/v1/alerts/summary/counts?request.query=',
     },
-
-    // ViolationsByPolicySeverity
-    [mostRecentAlertsOpname]: getRouteMatcherForGraphQL(mostRecentAlertsOpname),
-
-    // ImagesAtMostRisk
-    [getImagesOpname]: getRouteMatcherForGraphQL(getImagesOpname),
-
-    // DeploymentsAtMostRisk
+    ...getRouteMatcherMapForGraphQL([mostRecentAlertsOpname]),
+};
+const routeMatcherMapForImagesAtMostRisk = getRouteMatcherMapForGraphQL([getImagesOpname]);
+const routeMatcherMapForDeploymentsAtMostRisk = {
     [deploymentsWithProcessInfoAlias]: {
         method: 'GET',
         url: '/v1/deploymentswithprocessinfo?*',
     },
-
-    // AgingImages
-    [agingImagesQueryOpname]: getRouteMatcherForGraphQL(agingImagesQueryOpname),
-
-    // ViolationsByPolicySeverity ViolationsByPolicyCategory
+};
+const routeMatcherMapForAgingImages = getRouteMatcherMapForGraphQL([agingImagesQueryOpname]);
+const routeMatcherMapForViolationsByPolicyCategory = {
     [alertsSummaryCountsGroupByCategoryAlias]: {
         method: 'GET',
         url: '/v1/alerts/summary/counts?request.query=&group_by=CATEGORY',
     },
+};
+const routeMatcherMapForComplianceLevelsByStandard = getRouteMatcherMapForGraphQL([
+    getAggregatedResultsOpname,
+]);
 
-    // ComplianceLevelsByStandard
-    [getAggregatedResultsOpname]: getRouteMatcherForGraphQL(getAggregatedResultsOpname),
+const routeMatcherMap = {
+    ...routeMatcherMapForSummaryCounts,
+    ...routeMatcherMapForSearchFilter,
+    ...routeMatcherMapForViolationsByPolicySeverity,
+    ...routeMatcherMapForImagesAtMostRisk,
+    ...routeMatcherMapForDeploymentsAtMostRisk,
+    ...routeMatcherMapForAgingImages,
+    ...routeMatcherMapForViolationsByPolicyCategory,
+    ...routeMatcherMapForComplianceLevelsByStandard,
 };
 
 const title = 'Dashboard';

--- a/ui/apps/platform/cypress/helpers/main.js
+++ b/ui/apps/platform/cypress/helpers/main.js
@@ -1,68 +1,72 @@
-import * as api from '../constants/apiEndpoints';
-import { url } from '../constants/DashboardPage';
+import { url as basePath } from '../constants/DashboardPage';
 import navSelectors from '../selectors/navigation';
 
-import { interactAndWaitForResponses } from './request';
+import { getRouteMatcherForGraphQL, interactAndWaitForResponses } from './request';
 import { visit } from './visit';
 
 /*
  * Import relevant alias constants in test files that call visitMainDashboard function
  * with staticResponseMap argument to provide mock data for a widget.
  */
-export const mostRecentAlertsAlias = 'mostRecentAlerts';
-export const getImagesAlias = 'getImages';
-export const deploymentswithprocessinfoAlias = 'deploymentswithprocessinfo';
-export const agingImagesQueryAlias = 'agingImagesQuery';
+export const summaryCountsOpname = 'summary_counts';
+export const getAllNamespacesByClusterOpname = 'getAllNamespacesByCluster';
 export const alertsSummaryCountsAlias = 'alerts/summary/counts';
-export const getAggregatedResultsAlias = 'getAggregatedResults';
+export const mostRecentAlertsOpname = 'mostRecentAlerts';
+export const getImagesOpname = 'getImages';
+export const deploymentsWithProcessInfoAlias = 'deploymentswithprocessinfo';
+export const agingImagesQueryOpname = 'agingImagesQuery';
+export const alertsSummaryCountsGroupByCategoryAlias = 'alerts/summary/counts_CATEGORY';
+export const getAggregatedResultsOpname = 'getAggregatedResults';
 
-const requestConfig = {
-    routeMatcherMap: {
-        // ViolationsByPolicySeverity
-        [mostRecentAlertsAlias]: {
-            method: 'POST',
-            url: api.graphql('mostRecentAlerts'),
-        },
-        // ImagesAtMostRisk
-        [getImagesAlias]: {
-            method: 'POST',
-            url: api.graphql('getImages'),
-        },
-        // DeploymentsAtMostRisk
-        [deploymentswithprocessinfoAlias]: {
-            method: 'GET',
-            url: api.risks.riskyDeployments,
-        },
-        // AgingImages
-        [agingImagesQueryAlias]: {
-            method: 'POST',
-            url: api.graphql('agingImagesQuery'),
-        },
-        // ViolationsByPolicySeverity ViolationsByPolicyCategory
-        [alertsSummaryCountsAlias]: {
-            method: 'GET',
-            url: api.alerts.countsByCategory,
-        },
-        // ComplianceLevelsByStandard
-        [getAggregatedResultsAlias]: {
-            method: 'POST',
-            url: api.graphql('getAggregatedResults'),
-        },
+const routeMatcherMap = {
+    [summaryCountsOpname]: getRouteMatcherForGraphQL(summaryCountsOpname),
+    [getAllNamespacesByClusterOpname]: getRouteMatcherForGraphQL(getAllNamespacesByClusterOpname),
+    [alertsSummaryCountsAlias]: {
+        method: 'GET',
+        url: '/v1/alerts/summary/counts?request.query=',
     },
+
+    // ViolationsByPolicySeverity
+    [mostRecentAlertsOpname]: getRouteMatcherForGraphQL(mostRecentAlertsOpname),
+
+    // ImagesAtMostRisk
+    [getImagesOpname]: getRouteMatcherForGraphQL(getImagesOpname),
+
+    // DeploymentsAtMostRisk
+    [deploymentsWithProcessInfoAlias]: {
+        method: 'GET',
+        url: '/v1/deploymentswithprocessinfo?*',
+    },
+
+    // AgingImages
+    [agingImagesQueryOpname]: getRouteMatcherForGraphQL(agingImagesQueryOpname),
+
+    // ViolationsByPolicySeverity ViolationsByPolicyCategory
+    [alertsSummaryCountsGroupByCategoryAlias]: {
+        method: 'GET',
+        url: '/v1/alerts/summary/counts?request.query=&group_by=CATEGORY',
+    },
+
+    // ComplianceLevelsByStandard
+    [getAggregatedResultsOpname]: getRouteMatcherForGraphQL(getAggregatedResultsOpname),
 };
+
+const title = 'Dashboard';
 
 // visit helpers
 
 export function visitMainDashboardFromLeftNav() {
     interactAndWaitForResponses(() => {
-        cy.get(`${navSelectors.navLinks}:contains("Dashboard")`).click();
-    }, requestConfig);
+        cy.get(`${navSelectors.navLinks}:contains("${title}")`).click();
+    }, routeMatcherMap);
 
-    cy.get('h1:contains("Dashboard")');
+    cy.location('pathname').should('eq', basePath);
+    cy.get(`h1:contains("${title}")`);
 }
 
 export function visitMainDashboard(staticResponseMap) {
-    visit(url, requestConfig, staticResponseMap);
+    visit(basePath, routeMatcherMap, staticResponseMap);
 
-    cy.get('h1:contains("Dashboard")');
+    cy.get(`.pf-c-nav__link.pf-m-current:contains("${title}")`);
+    cy.get(`h1:contains("${title}")`);
 }

--- a/ui/apps/platform/cypress/helpers/main.js
+++ b/ui/apps/platform/cypress/helpers/main.js
@@ -71,6 +71,9 @@ export function visitMainDashboardFromLeftNav() {
     cy.get(`h1:contains("${title}")`);
 }
 
+/**
+ * @param {Record<string, { body: unknown } | { fixture: string }>} [staticResponseMap]
+ */
 export function visitMainDashboard(staticResponseMap) {
     visit(basePath, routeMatcherMap, staticResponseMap);
 

--- a/ui/apps/platform/cypress/helpers/nav.js
+++ b/ui/apps/platform/cypress/helpers/nav.js
@@ -2,8 +2,12 @@ import navSelectors from '../selectors/navigation';
 import { visitMainDashboard } from './main';
 import { interactAndWaitForResponses } from './request';
 
-/*
+/**
  * For example, visitFromLeftNav('Violations');
+ *
+ * @param {string} itemText
+ * @param {Record<string, { method: string, url: string }>} [routeMatcherMap]
+ * @param {Record<string, { body: unknown } | { fixture: string }>} [staticResponseMap]
  */
 export function visitFromLeftNav(itemText, routeMatcherMap, staticResponseMap) {
     visitMainDashboard();
@@ -17,9 +21,14 @@ export function visitFromLeftNav(itemText, routeMatcherMap, staticResponseMap) {
     );
 }
 
-/*
+/**
  * For example, visitFromLeftNavExpandable('Vulnerability Management', 'Reporting');
  * For example, visitFromLeftNavExpandable('Platform Configuration', 'Integrations');
+ *
+ * @param {string} expandableTitle
+ * @param {string} itemText
+ * @param {Record<string, { method: string, url: string }>} [routeMatcherMap]
+ * @param {Record<string, { body: unknown } | { fixture: string }>} [staticResponseMap]
  */
 export function visitFromLeftNavExpandable(
     expandableTitle,

--- a/ui/apps/platform/cypress/helpers/nav.js
+++ b/ui/apps/platform/cypress/helpers/nav.js
@@ -5,14 +5,14 @@ import { interactAndWaitForResponses } from './request';
 /*
  * For example, visitFromLeftNav('Violations');
  */
-export function visitFromLeftNav(itemText, requestConfig, staticResponseMap) {
+export function visitFromLeftNav(itemText, routeMatcherMap, staticResponseMap) {
     visitMainDashboard();
 
     interactAndWaitForResponses(
         () => {
             cy.get(`${navSelectors.navLinks}:contains("${itemText}")`).click();
         },
-        requestConfig,
+        routeMatcherMap,
         staticResponseMap
     );
 }
@@ -24,7 +24,7 @@ export function visitFromLeftNav(itemText, requestConfig, staticResponseMap) {
 export function visitFromLeftNavExpandable(
     expandableTitle,
     itemText,
-    requestConfig,
+    routeMatcherMap,
     staticResponseMap
 ) {
     visitMainDashboard();
@@ -34,7 +34,7 @@ export function visitFromLeftNavExpandable(
             cy.get(`${navSelectors.navExpandable}:contains("${expandableTitle}")`).click();
             cy.get(`${navSelectors.nestedNavLinks}:contains("${itemText}")`).click();
         },
-        requestConfig,
+        routeMatcherMap,
         staticResponseMap
     );
 }

--- a/ui/apps/platform/cypress/helpers/networkGraph.js
+++ b/ui/apps/platform/cypress/helpers/networkGraph.js
@@ -1,7 +1,7 @@
 import * as api from '../constants/apiEndpoints';
 import { selectors as networkGraphSelectors } from '../constants/NetworkPage';
 import { visitFromLeftNav } from './nav';
-import { getRouteMatcherForGraphQL, interactAndWaitForResponses } from './request';
+import { getRouteMatcherMapForGraphQL, interactAndWaitForResponses } from './request';
 import { visit } from './visit';
 import selectSelectors from '../selectors/select';
 import tabSelectors from '../selectors/tab';
@@ -220,6 +220,12 @@ export const networkPoliciesGraphEpochAlias = 'networkpolicies/graph/epoch';
 export const searchMetadataOptionsAlias = 'search/metadata/options';
 export const getClusterNamespaceNamesOpname = 'getClusterNamespaceNames';
 
+// Network Graph makes the following query on the first visit, but not subsequent visit via browser Back button.
+// Include it because each cypress test has a new connection, therefore behaves as a first visit.
+const routeMatcherMapForSearchFilter = getRouteMatcherMapForGraphQL([
+    getClusterNamespaceNamesOpname,
+]);
+
 const routeMatcherMapToVisitNetworkGraph = {
     [notifiersAlias]: {
         method: 'GET',
@@ -237,9 +243,7 @@ const routeMatcherMapToVisitNetworkGraph = {
         method: 'GET',
         url: api.search.optionsCategories('DEPLOYMENTS'),
     },
-    // Network Graph makes the following query on the first visit, but not subsequent visit via browser Back button.
-    // Include it because each cypress test has a new connection, therefore behaves as a first visit.
-    [getClusterNamespaceNamesOpname]: getRouteMatcherForGraphQL(getClusterNamespaceNamesOpname),
+    ...routeMatcherMapForSearchFilter,
 };
 
 export const deploymentAlias = 'deployments/id';

--- a/ui/apps/platform/cypress/helpers/networkGraph.js
+++ b/ui/apps/platform/cypress/helpers/networkGraph.js
@@ -1,7 +1,7 @@
 import * as api from '../constants/apiEndpoints';
 import { selectors as networkGraphSelectors } from '../constants/NetworkPage';
 import { visitFromLeftNav } from './nav';
-import { interactAndWaitForResponses } from './request';
+import { getRouteMatcherForGraphQL, interactAndWaitForResponses } from './request';
 import { visit } from './visit';
 import selectSelectors from '../selectors/select';
 import tabSelectors from '../selectors/tab';
@@ -34,19 +34,17 @@ export function clickOnNodeByName(cytoscape, node) {
 
 export const networkBaselineStatusAlias = 'networkbaseline/id/status';
 
-const requestConfigForDeploymentNode = {
-    routeMatcherMap: {
-        [networkBaselineStatusAlias]: {
-            method: 'POST',
-            url: api.network.networkBaselineStatus,
-        },
+const routeMatcherMapForDeploymentNode = {
+    [networkBaselineStatusAlias]: {
+        method: 'POST',
+        url: '/v1/networkbaseline/*/status',
     },
 };
 
 export function clickOnDeploymentNodeByName(cytoscape, name) {
     interactAndWaitForResponses(() => {
         clickOnNodeByName(cytoscape, { type: 'DEPLOYMENT', name });
-    }, requestConfigForDeploymentNode);
+    }, routeMatcherMapForDeploymentNode);
 }
 
 export function mouseOverNodeById(cytoscape, node) {
@@ -144,16 +142,14 @@ export function filterBySourceTarget(sourceNode, targetNode) {
 const networkGraphClusterAlias = 'networkgraph/cluster/id';
 const networkPoliciesClusterAlias = 'networkpolicies/cluster/id';
 
-const requestConfigToFilterGraph = {
-    routeMatcherMap: {
-        [networkGraphClusterAlias]: {
-            method: 'GET',
-            url: api.network.networkGraph,
-        },
-        [networkPoliciesClusterAlias]: {
-            method: 'GET',
-            url: api.network.networkPoliciesGraph,
-        },
+const routeMatcherMapForClusterInNetworkGraph = {
+    [networkGraphClusterAlias]: {
+        method: 'GET',
+        url: api.network.networkGraph,
+    },
+    [networkPoliciesClusterAlias]: {
+        method: 'GET',
+        url: api.network.networkPoliciesGraph,
     },
 };
 
@@ -161,7 +157,7 @@ export function selectDeploymentFilter(deploymentName) {
     interactAndWaitForResponses(() => {
         cy.get(networkGraphSelectors.toolbar.filterSelect).type('Deployment{enter}');
         cy.get(networkGraphSelectors.toolbar.filterSelect).type(`${deploymentName}{enter}{esc}`);
-    }, requestConfigToFilterGraph);
+    }, routeMatcherMapForClusterInNetworkGraph);
 }
 
 // Additional calls in a test can select additional namespaces.
@@ -173,7 +169,7 @@ export function selectNamespaceFilter(namespace) {
             `${selectSelectors.patternFlySelect.openMenu} span:contains("${namespace}")`
         ).click();
         cy.get(networkGraphSelectors.toolbar.namespaceSelect).click();
-    }, requestConfigToFilterGraph);
+    }, routeMatcherMapForClusterInNetworkGraph);
 }
 
 export function selectNamespaceFilterWithGraphAndPoliciesFixtures(
@@ -189,7 +185,7 @@ export function selectNamespaceFilterWithGraphAndPoliciesFixtures(
             ).click();
             cy.get(networkGraphSelectors.toolbar.namespaceSelect).click();
         },
-        requestConfigToFilterGraph,
+        routeMatcherMapForClusterInNetworkGraph,
         {
             [networkGraphClusterAlias]: { fixture: fixturePathGraph },
             [networkPoliciesClusterAlias]: { fixture: fixturePathPolicies },
@@ -209,7 +205,7 @@ export function selectNamespaceFilterWithNetworkGraphResponse(namespace, respons
             ).click();
             cy.get(networkGraphSelectors.toolbar.namespaceSelect).click();
         },
-        requestConfigToFilterGraph,
+        routeMatcherMapForClusterInNetworkGraph,
         {
             [networkGraphClusterAlias]: response,
         }
@@ -222,33 +218,39 @@ export const notifiersAlias = 'notifiers';
 export const clustersAlias = 'clusters';
 export const networkPoliciesGraphEpochAlias = 'networkpolicies/graph/epoch';
 export const searchMetadataOptionsAlias = 'search/metadata/options';
-export const getClusterNamespaceNamesAlias = 'getClusterNamespaceNames';
+export const getClusterNamespaceNamesOpname = 'getClusterNamespaceNames';
 
-const requestConfigToVisitGraph = {
-    routeMatcherMap: {
-        [notifiersAlias]: {
-            method: 'GET',
-            url: api.integrations.notifiers,
-        },
-        [clustersAlias]: {
-            method: 'GET',
-            url: api.clusters.list,
-        },
-        [networkPoliciesGraphEpochAlias]: {
-            method: 'GET',
-            url: `${api.network.epoch}?clusterId=null`,
-        },
-        [searchMetadataOptionsAlias]: {
-            method: 'GET',
-            url: api.search.optionsCategories('DEPLOYMENTS'),
-        },
-        // Network Graph makes the following query on the first visit, but not subsequent visit via browser Back button.
-        // Include it because each cypress test has a new connection, therefore behaves as a first visit.
-        [getClusterNamespaceNamesAlias]: {
-            method: 'POST',
-            url: api.graphql('getClusterNamespaceNames'),
-        },
+const routeMatcherMapToVisitNetworkGraph = {
+    [notifiersAlias]: {
+        method: 'GET',
+        url: api.integrations.notifiers,
     },
+    [clustersAlias]: {
+        method: 'GET',
+        url: api.clusters.list,
+    },
+    [networkPoliciesGraphEpochAlias]: {
+        method: 'GET',
+        url: `${api.network.epoch}?clusterId=*`, // either id or null if no cluster selected
+    },
+    [searchMetadataOptionsAlias]: {
+        method: 'GET',
+        url: api.search.optionsCategories('DEPLOYMENTS'),
+    },
+    // Network Graph makes the following query on the first visit, but not subsequent visit via browser Back button.
+    // Include it because each cypress test has a new connection, therefore behaves as a first visit.
+    [getClusterNamespaceNamesOpname]: getRouteMatcherForGraphQL(getClusterNamespaceNamesOpname),
+};
+
+export const deploymentAlias = 'deployments/id';
+
+const routeMatcherMapToVisitNetworkGraphWithDeploymentSelected = {
+    ...routeMatcherMapToVisitNetworkGraph,
+    [deploymentAlias]: {
+        method: 'GET',
+        url: '/v1/deployments/*',
+    },
+    ...routeMatcherMapForClusterInNetworkGraph,
 };
 
 export const basePath = '/main/network';
@@ -257,15 +259,19 @@ export const basePath = '/main/network';
  * Reach clusters by interaction from another container.
  * For example, click View Deployment in Network Graph button from Risk.
  */
-export function reachNetworkGraph(interactionCallback, staticResponseMap) {
-    interactAndWaitForResponses(interactionCallback, requestConfigToVisitGraph, staticResponseMap);
+export function reachNetworkGraphWithDeploymentSelected(interactionCallback, staticResponseMap) {
+    interactAndWaitForResponses(
+        interactionCallback,
+        routeMatcherMapToVisitNetworkGraphWithDeploymentSelected,
+        staticResponseMap
+    );
 
     cy.location('pathname').should('contain', basePath); // contain because pathname might have id
     cy.get(networkGraphSelectors.networkGraphHeading);
 }
 
 export function visitNetworkGraphFromLeftNav() {
-    visitFromLeftNav('Network', requestConfigToVisitGraph);
+    visitFromLeftNav('Network', routeMatcherMapToVisitNetworkGraph);
 
     cy.location('pathname').should('eq', basePath);
     cy.get(networkGraphSelectors.networkGraphHeading);
@@ -273,7 +279,7 @@ export function visitNetworkGraphFromLeftNav() {
 }
 
 export function visitNetworkGraph(staticResponseMap) {
-    visit(basePath, requestConfigToVisitGraph, staticResponseMap);
+    visit(basePath, routeMatcherMapToVisitNetworkGraph, staticResponseMap);
 
     cy.get(networkGraphSelectors.networkGraphHeading);
     cy.get(networkGraphSelectors.emptyStateSubheading);
@@ -314,7 +320,7 @@ export function interactAndWaitForChangeToNetworkFlows(interactionCallback) {
             },
             [networkBaselineStatusAlias]: {
                 method: 'POST',
-                url: api.network.networkBaselineStatus,
+                url: '/v1/networkbaseline/*/status',
             },
         },
     });

--- a/ui/apps/platform/cypress/helpers/networkGraph.js
+++ b/ui/apps/platform/cypress/helpers/networkGraph.js
@@ -305,23 +305,21 @@ export const networkBaselinePeersAlias = 'networkbaseline/id/peers';
 
 export function interactAndWaitForChangeToNetworkFlows(interactionCallback) {
     interactAndWaitForResponses(interactionCallback, {
-        routeMatcherMap: {
-            [networkBaselinePeersAlias]: {
-                method: 'PATCH',
-                url: api.network.networkBaselinePeers,
-            },
-            [networkGraphClusterAlias]: {
-                method: 'GET',
-                url: api.network.networkGraph,
-            },
-            [networkPoliciesClusterAlias]: {
-                method: 'GET',
-                url: api.network.networkPoliciesGraph,
-            },
-            [networkBaselineStatusAlias]: {
-                method: 'POST',
-                url: '/v1/networkbaseline/*/status',
-            },
+        [networkBaselinePeersAlias]: {
+            method: 'PATCH',
+            url: api.network.networkBaselinePeers,
+        },
+        [networkGraphClusterAlias]: {
+            method: 'GET',
+            url: api.network.networkGraph,
+        },
+        [networkPoliciesClusterAlias]: {
+            method: 'GET',
+            url: api.network.networkPoliciesGraph,
+        },
+        [networkBaselineStatusAlias]: {
+            method: 'POST',
+            url: '/v1/networkbaseline/*/status',
         },
     });
 }
@@ -336,11 +334,9 @@ export function clickBaselineSettingsTab() {
             cy.get(`${tabSelectors.tabs}:contains('Baseline Settings')`).click();
         },
         {
-            routeMatcherMap: {
-                [networkBaselineAlias]: {
-                    method: 'GET',
-                    url: api.network.networkBaseline,
-                },
+            [networkBaselineAlias]: {
+                method: 'GET',
+                url: api.network.networkBaseline,
             },
         }
     );

--- a/ui/apps/platform/cypress/helpers/policies.js
+++ b/ui/apps/platform/cypress/helpers/policies.js
@@ -26,14 +26,14 @@ const routeMatcherMap = {
 };
 
 export function visitPolicies(staticResponseMap) {
-    visit(policiesUrl, { routeMatcherMap }, staticResponseMap);
+    visit(policiesUrl, routeMatcherMap, staticResponseMap);
 
     cy.get('h1:contains("Policy management")');
     cy.get(`.pf-c-nav__link.pf-m-current:contains("Policies")`);
 }
 
 export function visitPoliciesFromLeftNav() {
-    visitFromLeftNavExpandable('Platform Configuration', 'Policy Management', { routeMatcherMap });
+    visitFromLeftNavExpandable('Platform Configuration', 'Policy Management', routeMatcherMap);
 
     cy.get('h1:contains("Policy management")');
     cy.get(`.pf-c-nav__link.pf-m-current:contains("Policies")`);
@@ -47,11 +47,7 @@ export function visitPolicy(policyId, staticResponseMap) {
         },
     };
 
-    visit(
-        `${policiesUrl}/${policyId}`,
-        { routeMatcherMap: routeMatcherMapPolicy },
-        staticResponseMap
-    );
+    visit(`${policiesUrl}/${policyId}`, routeMatcherMapPolicy, staticResponseMap);
     cy.get('h2:contains("Policy details")');
 }
 

--- a/ui/apps/platform/cypress/helpers/request.js
+++ b/ui/apps/platform/cypress/helpers/request.js
@@ -1,22 +1,4 @@
 /*
- * For pages which have GraphQL and REST requests.
- *
- * For example, given 'searchOptions' return:
- * {
- *     method: 'POST',
- *     url: '/api/graphql?opname=searchOptions',
- * }
- */
-export function getRouteMatcherForGraphQL(opname) {
-    return {
-        method: 'POST',
-        url: `/api/graphql?opname=${opname}`,
-    };
-}
-
-/*
- * For pages which have only GraphQL requests.
- *
  * For example, given ['searchOptions', 'getDeployments'] return:
  * {
  *     searchOptions: {
@@ -28,12 +10,19 @@ export function getRouteMatcherForGraphQL(opname) {
  *         url: '/api/graphql?opname=getDeployments',
  *     },
  * }
+ *
+ * Remember to enclose single opname in array brackets. For example, ['searchOptions']
+ *
+ * Use object spread to merge GraphQL object into object which has properties for REST requests.
  */
 export function getRouteMatcherMapForGraphQL(opnames) {
     const routeMatcherMap = {};
 
     opnames.forEach((opname) => {
-        routeMatcherMap[opname] = getRouteMatcherForGraphQL(opname);
+        routeMatcherMap[opname] = {
+            method: 'POST',
+            url: `/api/graphql?opname=${opname}`,
+        };
     });
 
     return routeMatcherMap;

--- a/ui/apps/platform/cypress/helpers/request.js
+++ b/ui/apps/platform/cypress/helpers/request.js
@@ -1,4 +1,4 @@
-/*
+/**
  * For example, given ['searchOptions', 'getDeployments'] return:
  * {
  *     searchOptions: {
@@ -14,6 +14,9 @@
  * Remember to enclose single opname in array brackets. For example, ['searchOptions']
  *
  * Use object spread to merge GraphQL object into object which has properties for REST requests.
+ *
+ * @param {[string]} opnames
+ * @returns Record<string, { method: string, url: string }>
  */
 export function getRouteMatcherMapForGraphQL(opnames) {
     const routeMatcherMap = {};
@@ -28,7 +31,7 @@ export function getRouteMatcherMapForGraphQL(opnames) {
     return routeMatcherMap;
 }
 
-/*
+/**
  * Intercept requests before initial page visit or subsequent interaction:
  * routeMatcherMap: { alias: routeMatcher, … }
  *
@@ -52,7 +55,7 @@ export function interceptRequests(routeMatcherMap, staticResponseMap) {
     }
 }
 
-/*
+/**
  * Wait for responses after initial page visit or subsequent interaction.
  *
  * @param {Record<string, { method: string, url: string }>} [routeMatcherMap]
@@ -65,7 +68,7 @@ export function waitForResponses(routeMatcherMap) {
     }
 }
 
-/*
+/**
  * Intercept requests before interaction and then wait for responses.
  *
  * @param {() => void} interactionCallback

--- a/ui/apps/platform/cypress/helpers/risk.js
+++ b/ui/apps/platform/cypress/helpers/risk.js
@@ -2,6 +2,7 @@ import * as api from '../constants/apiEndpoints';
 import { selectors as riskPageSelectors, url as riskURL } from '../constants/RiskPage';
 import selectors from '../selectors/index';
 
+import { reachNetworkGraphWithDeploymentSelected } from './networkGraph';
 import { visit } from './visit';
 
 // visit
@@ -50,11 +51,7 @@ export function viewRiskDeploymentByName(deploymentName) {
 }
 
 export function viewRiskDeploymentInNetworkGraph() {
-    // Assume location is risk deployment panel.
-    cy.intercept('GET', api.network.networkGraph).as('networkgraph/cluster/id');
-    cy.intercept('GET', api.network.networkPoliciesGraph).as('networkpolicies/cluster/id');
-
-    cy.get(riskPageSelectors.viewDeploymentsInNetworkGraphButton).click();
-
-    cy.wait(['@networkgraph/cluster/id', '@networkpolicies/cluster/id']);
+    reachNetworkGraphWithDeploymentSelected(() => {
+        cy.get(riskPageSelectors.viewDeploymentsInNetworkGraphButton).click();
+    });
 }

--- a/ui/apps/platform/cypress/helpers/risk.js
+++ b/ui/apps/platform/cypress/helpers/risk.js
@@ -27,13 +27,13 @@ const routeMatcherMap = {
 };
 
 export function visitRiskDeployments() {
-    visit(riskURL, { routeMatcherMap });
+    visit(riskURL, routeMatcherMap);
 
     cy.get('h1:contains("Risk")');
 }
 
 export function visitRiskDeploymentsWithSearchQuery(search) {
-    visit(`${riskURL}${search}`, { routeMatcherMap });
+    visit(`${riskURL}${search}`, routeMatcherMap);
 
     cy.get('h1:contains("Risk")');
 }

--- a/ui/apps/platform/cypress/helpers/systemConfig.js
+++ b/ui/apps/platform/cypress/helpers/systemConfig.js
@@ -8,12 +8,10 @@ const configEndpoint = '/v1/config';
 
 const configAliasForGET = 'config';
 
-const requestConfigForGET = {
-    routeMatcherMap: {
-        [configAliasForGET]: {
-            method: 'GET',
-            url: configEndpoint,
-        },
+const routeMatcherMapForGET = {
+    [configAliasForGET]: {
+        method: 'GET',
+        url: configEndpoint,
     },
 };
 
@@ -22,13 +20,13 @@ const title = 'System Configuration';
 // visit
 
 export function visitSystemConfiguration() {
-    visit(basePath, requestConfigForGET);
+    visit(basePath, routeMatcherMapForGET);
 
     cy.get(`h1:contains("${title}")`);
 }
 
 export function visitSystemConfigurationFromLeftNav() {
-    visitFromLeftNavExpandable('Platform Configuration', title, requestConfigForGET);
+    visitFromLeftNavExpandable('Platform Configuration', title, routeMatcherMapForGET);
 
     cy.location('pathname').should('eq', basePath);
     cy.get(`h1:contains("${title}")`);
@@ -40,7 +38,7 @@ export function visitSystemConfigurationWithStaticResponseForPermissions(
     visitWithStaticResponseForPermissions(
         basePath,
         staticResponseForPermissions,
-        requestConfigForGET
+        routeMatcherMapForGET
     );
 
     cy.get(`h1:contains("${title}")`);
@@ -50,17 +48,15 @@ export function visitSystemConfigurationWithStaticResponseForPermissions(
 
 const configAliasForPUT = 'PUT_config';
 
-const requestConfigForPUT = {
-    routeMatcherMap: {
-        [configAliasForPUT]: {
-            method: 'PUT',
-            url: configEndpoint,
-        },
+const routeMatcherMapForPUT = {
+    [configAliasForPUT]: {
+        method: 'PUT',
+        url: configEndpoint,
     },
 };
 
 export function saveSystemConfiguration() {
     interactAndWaitForResponses(() => {
         cy.get('button:contains("Save")').click();
-    }, requestConfigForPUT);
+    }, routeMatcherMapForPUT);
 }

--- a/ui/apps/platform/cypress/helpers/systemHealth.js
+++ b/ui/apps/platform/cypress/helpers/systemHealth.js
@@ -51,13 +51,14 @@ const routeMatcherMap = {
 };
 
 export function visitSystemHealthFromLeftNav() {
-    visitFromLeftNavExpandable('Platform Configuration', 'System Health', { routeMatcherMap });
+    visitFromLeftNavExpandable('Platform Configuration', 'System Health', routeMatcherMap);
 
+    cy.location('pathname').should('eq', systemHealthUrl);
     cy.get('h1:contains("System Health")');
 }
 
 export function visitSystemHealth(staticResponseMap) {
-    visit(systemHealthUrl, { routeMatcherMap }, staticResponseMap);
+    visit(systemHealthUrl, routeMatcherMap, staticResponseMap);
 
     cy.get('h1:contains("System Health")');
 }

--- a/ui/apps/platform/cypress/helpers/violations.js
+++ b/ui/apps/platform/cypress/helpers/violations.js
@@ -18,13 +18,14 @@ const routeMatcherMap = {
 };
 
 export function visitViolationsFromLeftNav() {
-    visitFromLeftNav('Violations', { routeMatcherMap });
+    visitFromLeftNav('Violations', routeMatcherMap);
 
+    cy.location('pathname').should('eq', url);
     cy.get('h1:contains("Violations")');
 }
 
 export function visitViolations(staticResponseMap) {
-    visit(url, { routeMatcherMap }, staticResponseMap);
+    visit(url, routeMatcherMap, staticResponseMap);
 
     cy.get('h1:contains("Violations")');
 }
@@ -37,7 +38,7 @@ export function visitViolationsWithFixture(fixturePath) {
             alertscount: { body: { count } },
         };
 
-        visit(url, { routeMatcherMap }, staticResponseMap);
+        visit(url, routeMatcherMap, staticResponseMap);
 
         cy.get('h1:contains("Violations")');
     });

--- a/ui/apps/platform/cypress/helpers/visit.js
+++ b/ui/apps/platform/cypress/helpers/visit.js
@@ -11,37 +11,35 @@ export const configPublicAlias = 'config/public';
 export const authStatusAlias = 'auth/status';
 
 // generic requests to render the MainPage component
-const requestConfigGeneric = {
-    routeMatcherMap: {
-        [availableAuthProvidersAlias]: {
-            method: 'GET',
-            url: api.auth.availableAuthProviders,
-        }, // reducers/auth and sagas/authSagas
-        [featureFlagsAlias]: {
-            method: 'GET',
-            url: api.featureFlags,
-        }, // reducers/featureFlags and sagas/featureFlagSagas
-        [loginAuthProvidersAlias]: {
-            method: 'GET',
-            url: api.auth.loginAuthProviders,
-        }, // reducers/auth and sagas/authSagas
-        [myPermissionsAlias]: {
-            method: 'GET',
-            url: api.roles.mypermissions,
-        }, // hooks/usePermissions and reducers/roles and sagas/authSagas
-        [configPublicAlias]: {
-            method: 'GET',
-            url: '/v1/config/public',
-        }, // reducers/systemConfig and sagas/systemConfig
-        [authStatusAlias]: {
-            method: 'GET',
-            url: api.auth.authStatus,
-        }, // sagas/authSagas
-        /*
-         * Intentionally omit credentialexpiry requests for central and scanner,
-         * because they are in parallel with (and possibly even delayed by) page-specific requests.
-         */
-    },
+const routeMatcherMapGeneric = {
+    [availableAuthProvidersAlias]: {
+        method: 'GET',
+        url: api.auth.availableAuthProviders,
+    }, // reducers/auth and sagas/authSagas
+    [featureFlagsAlias]: {
+        method: 'GET',
+        url: api.featureFlags,
+    }, // reducers/featureFlags and sagas/featureFlagSagas
+    [loginAuthProvidersAlias]: {
+        method: 'GET',
+        url: api.auth.loginAuthProviders,
+    }, // reducers/auth and sagas/authSagas
+    [myPermissionsAlias]: {
+        method: 'GET',
+        url: api.roles.mypermissions,
+    }, // hooks/usePermissions and reducers/roles and sagas/authSagas
+    [configPublicAlias]: {
+        method: 'GET',
+        url: '/v1/config/public',
+    }, // reducers/systemConfig and sagas/systemConfig
+    [authStatusAlias]: {
+        method: 'GET',
+        url: api.auth.authStatus,
+    }, // sagas/authSagas
+    /*
+     * Intentionally omit credentialexpiry requests for central and scanner,
+     * because they are in parallel with (and possibly even delayed by) page-specific requests.
+     */
 };
 
 /*
@@ -50,29 +48,24 @@ const requestConfigGeneric = {
  * Always wait on generic requests for MainPage component.
  *
  * Optionally intercept specific requests for container component:
- * routeMatcherMap: { key: routeMatcher, … }
+ * routeMatcherMap: { alias: routeMatcher, … }
  *
  * Optionally replace responses with stub for routeMatcher alias key:
  * staticResponseMap: { alias: { body }, … }
  * staticResponseMap: { alias: { fixture }, … }
  *
- * Optionally assign aliases for multiple GraphQL requests with routeMatcher opname key:
- * graphqlMultiAliasMap: { opname: { aliases, routeHandler }, … }
- *
- * Optionally wait for responses with waitOptions: { requestTimeout, responseTimeout }
- *
  * @param {string} pageUrl
- * @param {{ routeMatcherMap?: Record<string, { method: string, url: string }>, opnameAliasesMap?: Record<string, (request: Object) => boolean>, waitOptions?: { requestTimeout?: number, responseTimeout?: number } }} [requestConfig]
+ * @param {Record<string, { method: string, url: string }>} [routeMatcherMap]
  * @param {Record<string, { body: unknown } | { fixture: string }>} [staticResponseMap]
  */
-export function visit(pageUrl, requestConfig, staticResponseMap) {
-    interceptRequests(requestConfigGeneric);
-    interceptRequests(requestConfig, staticResponseMap);
+export function visit(pageUrl, routeMatcherMap, staticResponseMap) {
+    interceptRequests(routeMatcherMapGeneric);
+    interceptRequests(routeMatcherMap, staticResponseMap);
 
     cy.visit(pageUrl);
 
-    waitForResponses(requestConfigGeneric);
-    waitForResponses(requestConfig);
+    waitForResponses(routeMatcherMapGeneric);
+    waitForResponses(routeMatcherMap);
 }
 
 /*
@@ -83,23 +76,23 @@ export function visit(pageUrl, requestConfig, staticResponseMap) {
  *
  * @param {string} pageUrl
  * @param {{ body: { resourceToAccess: Record<string, string> } } | { fixture: string }} staticResponseForPermissions
- * @param {{ routeMatcherMap?: Record<string, { method: string, url: string }>, opnameAliasesMap?: Record<string, (request: Object) => boolean>, waitOptions?: { requestTimeout?: number, responseTimeout?: number } }} [requestConfig]
+ * @param {Record<string, { method: string, url: string }>} [routeMatcherMap]
  * @param {Record<string, { body: unknown } | { fixture: string }>} [staticResponseMap]
  */
 export function visitWithStaticResponseForPermissions(
     pageUrl,
     staticResponseForPermissions,
-    requestConfig,
+    routeMatcherMap,
     staticResponseMap
 ) {
     const staticResponseMapGeneric = {
         [myPermissionsAlias]: staticResponseForPermissions,
     };
-    interceptRequests(requestConfigGeneric, staticResponseMapGeneric);
-    interceptRequests(requestConfig, staticResponseMap);
+    interceptRequests(routeMatcherMapGeneric, staticResponseMapGeneric);
+    interceptRequests(routeMatcherMap, staticResponseMap);
 
     cy.visit(pageUrl);
 
-    waitForResponses(requestConfigGeneric);
-    waitForResponses(requestConfig);
+    waitForResponses(routeMatcherMapGeneric);
+    waitForResponses(routeMatcherMap);
 }

--- a/ui/apps/platform/cypress/helpers/visit.js
+++ b/ui/apps/platform/cypress/helpers/visit.js
@@ -42,7 +42,7 @@ const routeMatcherMapForAuthenticatedRoutes = {
      */
 };
 
-/*
+/**
  * Wait for prerequisite requests to render container components.
  *
  * Always wait on generic requests for MainPage component.
@@ -68,7 +68,7 @@ export function visit(pageUrl, routeMatcherMap, staticResponseMap) {
     waitForResponses(routeMatcherMap);
 }
 
-/*
+/**
  * Visit page to test conditional rendering for user role permissions specified as response or fixture.
  *
  * { body: { resourceToAccess: { … } } }

--- a/ui/apps/platform/cypress/helpers/visit.js
+++ b/ui/apps/platform/cypress/helpers/visit.js
@@ -2,7 +2,7 @@ import * as api from '../constants/apiEndpoints';
 
 import { interceptRequests, waitForResponses } from './request';
 
-// Single source of truth for keys in optional staticResponseMap argument.
+// Single source of truth for keys in staticResponseMapForAuthenticatedRoutes object.
 export const availableAuthProvidersAlias = 'availableAuthProviders';
 export const featureFlagsAlias = 'featureflags';
 export const loginAuthProvidersAlias = 'login/authproviders';
@@ -10,8 +10,8 @@ export const myPermissionsAlias = 'mypermissions';
 export const configPublicAlias = 'config/public';
 export const authStatusAlias = 'auth/status';
 
-// generic requests to render the MainPage component
-const routeMatcherMapGeneric = {
+// Requests to render pages via MainPage and Body components.
+const routeMatcherMapForAuthenticatedRoutes = {
     [availableAuthProvidersAlias]: {
         method: 'GET',
         url: api.auth.availableAuthProviders,
@@ -59,12 +59,12 @@ const routeMatcherMapGeneric = {
  * @param {Record<string, { body: unknown } | { fixture: string }>} [staticResponseMap]
  */
 export function visit(pageUrl, routeMatcherMap, staticResponseMap) {
-    interceptRequests(routeMatcherMapGeneric);
+    interceptRequests(routeMatcherMapForAuthenticatedRoutes);
     interceptRequests(routeMatcherMap, staticResponseMap);
 
     cy.visit(pageUrl);
 
-    waitForResponses(routeMatcherMapGeneric);
+    waitForResponses(routeMatcherMapForAuthenticatedRoutes);
     waitForResponses(routeMatcherMap);
 }
 
@@ -85,14 +85,17 @@ export function visitWithStaticResponseForPermissions(
     routeMatcherMap,
     staticResponseMap
 ) {
-    const staticResponseMapGeneric = {
+    const staticResponseMapForAuthenticatedRoutes = {
         [myPermissionsAlias]: staticResponseForPermissions,
     };
-    interceptRequests(routeMatcherMapGeneric, staticResponseMapGeneric);
+    interceptRequests(
+        routeMatcherMapForAuthenticatedRoutes,
+        staticResponseMapForAuthenticatedRoutes
+    );
     interceptRequests(routeMatcherMap, staticResponseMap);
 
     cy.visit(pageUrl);
 
-    waitForResponses(routeMatcherMapGeneric);
+    waitForResponses(routeMatcherMapForAuthenticatedRoutes);
     waitForResponses(routeMatcherMap);
 }

--- a/ui/apps/platform/cypress/helpers/vulnmanagement/entities.js
+++ b/ui/apps/platform/cypress/helpers/vulnmanagement/entities.js
@@ -41,7 +41,8 @@ if (hasFeatureFlag('ROX_POSTGRES_DATASTORE')) {
     );
 }
 
-const routeMatcherMapForDashboard = getRouteMatcherMapForGraphQL(opnamesForDashboard);
+const routeMatcherMapForVulnerabilityManagementDashboard =
+    getRouteMatcherMapForGraphQL(opnamesForDashboard);
 
 /*
  * The following keys are path segments which correspond to entityKeys arguments of functions below.
@@ -135,7 +136,7 @@ export function visitVulnerabilityManagementDashboardFromLeftNav() {
     visitFromLeftNavExpandable(
         'Vulnerability Management',
         'Dashboard',
-        routeMatcherMapForDashboard
+        routeMatcherMapForVulnerabilityManagementDashboard
     );
 
     cy.location('pathname').should('eq', basePath);
@@ -144,7 +145,7 @@ export function visitVulnerabilityManagementDashboardFromLeftNav() {
 }
 
 export function visitVulnerabilityManagementDashboard() {
-    visit(basePath, routeMatcherMapForDashboard);
+    visit(basePath, routeMatcherMapForVulnerabilityManagementDashboard);
 
     cy.get('h1:contains("Vulnerability Management")');
 }

--- a/ui/apps/platform/cypress/helpers/vulnmanagement/reporting.js
+++ b/ui/apps/platform/cypress/helpers/vulnmanagement/reporting.js
@@ -1,36 +1,31 @@
 import * as api from '../../constants/apiEndpoints';
 
 import { visitFromLeftNavExpandable } from '../nav';
-import { interactAndWaitForResponses } from '../request';
+import { getRouteMatcherForGraphQL, interactAndWaitForResponses } from '../request';
 import { visit } from '../visit';
 
 // visit
 
-const searchOptionsAlias = 'searchOptions';
+const searchOptionsOpname = 'searchOptions';
 const reportConfigurationsAlias = 'report/configurations';
 const reportConfigurationsCountAlias = 'report-configurations-count';
 
-const requestConfig = {
-    routeMatcherMap: {
-        [searchOptionsAlias]: {
-            method: 'POST',
-            url: api.graphql('searchOptions'),
-        },
-        [reportConfigurationsAlias]: {
-            method: 'GET',
-            url: '/v1/report/configurations*',
-        },
-        [reportConfigurationsCountAlias]: {
-            method: 'GET',
-            url: '/v1/report-configurations-count*',
-        },
+const routeMatcherMap = {
+    [searchOptionsOpname]: getRouteMatcherForGraphQL(searchOptionsOpname),
+    [reportConfigurationsAlias]: {
+        method: 'GET',
+        url: '/v1/report/configurations*',
+    },
+    [reportConfigurationsCountAlias]: {
+        method: 'GET',
+        url: '/v1/report-configurations-count*',
     },
 };
 
 const reportingPath = '/main/vulnerability-management/reports';
 
 export function visitVulnerabilityReportingFromLeftNav() {
-    visitFromLeftNavExpandable('Vulnerability Management', 'Reporting', requestConfig);
+    visitFromLeftNavExpandable('Vulnerability Management', 'Reporting', routeMatcherMap);
 
     cy.location('pathname').should('eq', reportingPath);
     cy.location('search').should('eq', '');
@@ -38,7 +33,7 @@ export function visitVulnerabilityReportingFromLeftNav() {
 }
 
 export function visitVulnerabilityReporting(staticResponseMap) {
-    visit(reportingPath, requestConfig, staticResponseMap);
+    visit(reportingPath, routeMatcherMap, staticResponseMap);
 
     cy.get('h1:contains("Vulnerability reporting")');
 }
@@ -63,23 +58,21 @@ export function visitVulnerabilityReportingWithFixture(fixturePath) {
 export const accessScopesAlias = 'simpleaccessscopes';
 export const notifiersAlias = 'notifiers';
 
-const requestConfigToCreate = {
-    routeMatcherMap: {
-        [accessScopesAlias]: {
-            method: 'GET',
-            url: api.accessScopes.list,
-        },
-        [notifiersAlias]: {
-            method: 'GET',
-            url: api.integrations.notifiers,
-        },
+const routeMatcherMapToCreate = {
+    [accessScopesAlias]: {
+        method: 'GET',
+        url: api.accessScopes.list,
+    },
+    [notifiersAlias]: {
+        method: 'GET',
+        url: api.integrations.notifiers,
     },
 };
 
 export function visitVulnerabilityReportingToCreate(staticResponseMap) {
-    visit(`${reportingPath}?action=create`, requestConfigToCreate, staticResponseMap);
+    visit(`${reportingPath}?action=create`, routeMatcherMapToCreate, staticResponseMap);
 }
 
 export function interactAndWaitToCreate(interactionCallback, staticResponseMap) {
-    interactAndWaitForResponses(interactionCallback, requestConfigToCreate, staticResponseMap);
+    interactAndWaitForResponses(interactionCallback, routeMatcherMapToCreate, staticResponseMap);
 }

--- a/ui/apps/platform/cypress/helpers/vulnmanagement/reporting.js
+++ b/ui/apps/platform/cypress/helpers/vulnmanagement/reporting.js
@@ -1,7 +1,7 @@
 import * as api from '../../constants/apiEndpoints';
 
 import { visitFromLeftNavExpandable } from '../nav';
-import { getRouteMatcherForGraphQL, interactAndWaitForResponses } from '../request';
+import { getRouteMatcherMapForGraphQL, interactAndWaitForResponses } from '../request';
 import { visit } from '../visit';
 
 // visit
@@ -10,8 +10,10 @@ const searchOptionsOpname = 'searchOptions';
 const reportConfigurationsAlias = 'report/configurations';
 const reportConfigurationsCountAlias = 'report-configurations-count';
 
+const routeMatcherMapForSearchFilter = getRouteMatcherMapForGraphQL([searchOptionsOpname]);
+
 const routeMatcherMap = {
-    [searchOptionsOpname]: getRouteMatcherForGraphQL(searchOptionsOpname),
+    ...routeMatcherMapForSearchFilter,
     [reportConfigurationsAlias]: {
         method: 'GET',
         url: '/v1/report/configurations*',

--- a/ui/apps/platform/cypress/integration/accessControl/accessControlAuthProviders.test.js
+++ b/ui/apps/platform/cypress/integration/accessControl/accessControlAuthProviders.test.js
@@ -31,7 +31,7 @@ const routeMatcherMap = {
 };
 
 function visitAuthProviders(staticResponseMap) {
-    visit(authProvidersUrl, { routeMatcherMap }, staticResponseMap);
+    visit(authProvidersUrl, routeMatcherMap, staticResponseMap);
 
     cy.get(selectors.breadcrumbNav).should('not.exist');
     cy.get(`${selectors.h1}:contains("${h1}")`);
@@ -41,7 +41,7 @@ function visitAuthProviders(staticResponseMap) {
 }
 
 function visitAuthProviderById(id, staticResponseMap) {
-    visit(`${authProvidersUrl}/${id}`, { routeMatcherMap }, staticResponseMap);
+    visit(`${authProvidersUrl}/${id}`, routeMatcherMap, staticResponseMap);
 }
 
 describe('Access Control Auth providers', () => {

--- a/ui/apps/platform/cypress/integration/apiReference.test.js
+++ b/ui/apps/platform/cypress/integration/apiReference.test.js
@@ -8,10 +8,8 @@ const apiReferencePath = '/main/apidocs';
 
 const apiReferenceAlias = 'docs/swagger';
 
-const requestConfig = {
-    routeMatcherMap: {
-        [apiReferenceAlias]: '/api/docs/swagger',
-    },
+const routeMatcherMap = {
+    [apiReferenceAlias]: '/api/docs/swagger',
 };
 
 const title = 'API Reference';
@@ -25,14 +23,14 @@ describe('API Reference', () => {
         interactAndWaitForResponses(() => {
             cy.get('button[aria-label="Help menu"').click();
             cy.get(`a:contains("${title}")`).click();
-        }, requestConfig);
+        }, routeMatcherMap);
 
         cy.location('pathname').should('eq', apiReferencePath);
         cy.get(`h1:contains("${title}")`);
     });
 
     it('should visit via path', () => {
-        visit(apiReferencePath, requestConfig);
+        visit(apiReferencePath, routeMatcherMap);
 
         cy.get(`h1:contains("${title}")`);
 

--- a/ui/apps/platform/cypress/integration/logout.test.js
+++ b/ui/apps/platform/cypress/integration/logout.test.js
@@ -1,4 +1,3 @@
-import * as api from '../constants/apiEndpoints';
 import { url as loginUrl } from '../constants/LoginPage';
 import { selectors as navSelectors } from '../constants/TopNavigation';
 import withAuth from '../helpers/basicAuth';
@@ -7,12 +6,10 @@ import { interactAndWaitForResponses } from '../helpers/request';
 
 const logoutAlias = 'logout';
 
-const requestConfigForLogout = {
-    routeMatcherMap: {
-        [logoutAlias]: {
-            method: 'POST',
-            url: api.auth.logout,
-        },
+const routeMatcherMapForLogout = {
+    [logoutAlias]: {
+        method: 'POST',
+        url: '/sso/session/logout',
     },
 };
 
@@ -33,7 +30,7 @@ describe('Logout', () => {
                 cy.get(navSelectors.menuButton).click();
                 cy.get(navSelectors.menuList.logoutButton).click();
             },
-            requestConfigForLogout,
+            routeMatcherMapForLogout,
             staticResponseMapForLogout
         );
 

--- a/ui/apps/platform/cypress/integration/risk/risk.test.js
+++ b/ui/apps/platform/cypress/integration/risk/risk.test.js
@@ -1,6 +1,5 @@
 import { selectors as RiskPageSelectors } from '../../constants/RiskPage';
 import withAuth from '../../helpers/basicAuth';
-import { reachNetworkGraph } from '../../helpers/networkGraph';
 import {
     deploymentswithprocessinfoAlias,
     deploymentscountAlias,
@@ -144,9 +143,7 @@ describe('Risk page', () => {
         it('should navigate to network page with selected deployment', () => {
             visitRiskDeployments();
             viewRiskDeploymentByName('collector');
-            reachNetworkGraph(() => {
-                viewRiskDeploymentInNetworkGraph();
-            });
+            viewRiskDeploymentInNetworkGraph();
         });
 
         const searchPlaceholderText = 'Add one or more resource filters';


### PR DESCRIPTION
## Description

Follow up removal of need for optional `requestConfig` properties
* `waitOptions` in #3307
* `opnameAliasesMap` in #3627

Replace occurrences of `requestConfig` with its only remaining `routeMatchMap` property.

Here is a first draft of documentation. Review also requested on where to make it more correct, clear, and complete (for the primary audience of test readers and writers, including from the viewpoint of part-time contributers from backend teams).

TL;DR

1. Why should tests wait for requests?
    * Negative: Remove timing as a reason for tests to fail.
    * Positive: Declare the most relevant data dependencies.
2. Replace imperative pattern with declarative pattern.
    * Replace `cy.intercept` and `cy.wait` in tests, or even in container helpers, with `routeMatcherMap` and `staticResponseMap` which organize Cypress data types in parallel objects.
    * Be able to wait on all relevant requests for container, but mock only relevant responses for test (for example, widget on main dashboard).
3. Encapsulate details in layers:
    * Factor out **how** to wait and mock as generic helpers. This is prerequisite knowledge for all tests.
    * Encapsulate **what** to wait for: generic requests to render any page. Ditto.
    * Encapsulate **what** to wait for container-specific requests with page and endpoint addresses. Also select selectors to verify pages, pardon pun. Also be able to encapsulate and compose interaction at source container to reach target container. For example, from Risk deployment to Network Graph. Limit knowledge for container tests to container **helpers** and container **constants**. Minimize import from constants/apiEndpoints.js file.

### Declarative specification of relevant requests

Cypress `RouteMatcher`: https://docs.cypress.io/api/commands/intercept#Matching-with-RouteMatcher

For example

* REST request to save changes on System Configuration page:

    ```js
    {
        method: 'PUT',
        url: configEndpoint,
    }
    ```

* GraphQL request helper function:

    ```js
    export function getRouteMatcherForGraphQL(opname) {
        return {
            method: 'POST',
            url: `/api/graphql?opname=${opname}`,
        };
    }
    ```

Test helpers for workflow entities wait on the only predictable request via 3 maps of plural opname, singular opname, and entity type for primary-secondary requests (although a particular page or side panel might make other requests).

For example, plural entities in Vulnerability Management:

```js
const opnameForEntities = {
    clusters: 'getClusters',
    components: 'getComponents',
    'image-components': 'getImageComponents',
    'node-components': 'getNodeComponents',
    cves: 'getCves',
    'image-cves': 'getImageCves',
    'node-cves': 'getNodeCves',
    'cluster-cves': 'getClusterCves',
    deployments: 'getDeployments',
    images: 'getImages',
    namespaces: 'getNamespaces',
    nodes: 'getNodes',
    policies: 'getPolicies',
};
```

### Declarative specification of mock responses

Cypress `StaticResponse`: https://docs.cypress.io/api/commands/intercept#StaticResponse-objects
* response body: `{ body: { collections: […] } }`
* fixture file: `{ fixture: 'collections/collectionsWhatever.json' }`

### Maps for requests and responses

Now `routeMatcherMap` and `staticResponseMap` have parallel structure:
* key consists of either
    * `whateverAlias` for REST endpoint: delete **/v1/** and usually omit search query (and prepend with method if other than GET)
    * `whateverOpname` for GraphQL endpoints: delete **/api/graphql?opname=**
* value consists of `RouteMatcher` or `StaticResponse` object

The keys in `staticResponseMap` object are often a subset of keys in `routeMatcherMap` object.

### Collections example

Collections need mock responses until endpoints are implemented.

Unless there are default collections, many tests will still need mock responses.

Why not `'count'` for the second alias? Prefer more specific:
* partly to prevent alias collisions.
* mostly to match up alias with endpoint at the left in Cypress dashboard.

Also, prefer to encapsulate addresses in container helpers file:
* Prevent leakage of details outside of the container.
* Reduce the number of files to read or write tests.

```js
const basePath = '/main/collections';

export const collectionsAlias = 'collections';
export const collectionsCountAlias = 'collections/count';

const routeMatcherMapForCollections = {
    [collectionsAlias]: {
        method: 'GET',
        url: '/v1/collections?query=*',
    },
    [collectionsCountAlias]: {
        method: 'GET',
        url: '/v1/collections/count?query=*',
    },
};

// visit

export function visitCollections(staticResponseMap) {
    visit(basePath, routeMatcherMapForCollections, staticResponseMap);

    // generic assertions
}
```

```js
const collections = [];
const count = collections.length;

const staticResponseMap = {
    [collectionsAlias]: {
        body: { collections },
    },
    [collectionsCountAlias]: {
        body: { count },
    },
};
```

```js
    it('should have table column headings', () => {
        visitCollections(staticResponseMap);

        cy.get('th:contains("Collection")');
        cy.get('th:contains("Description")');
        cy.get('th:contains("In use")');
    });
```

Here is an important, although invisible part of the pattern:
1. Generic helper functions have optional `routeMatcherMap` and `staticResponseMap` arguments. Caller is usually in another helper file (see item 2) except some tests might also call `interactAndWaitForResponses` function.
    * `interactAndWaitForResponses` in request.js
    * `visit` in visit.js
    * `visitFromLeftNav` or `visitFromLeftNavExpandable` in nav.js
2. Container-specific helper functions have encapsulated route matcher map and optional `staticResponseMap` argument. Helpers file exports `whateverAlias` or `whateverOpname` constants as keys.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed