### PR TITLE
ROX-13068: Use real data for deployment details

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
@@ -7,7 +7,7 @@ import { fetchClustersAsArray, Cluster } from 'services/ClustersService';
 
 import PageTitle from 'Components/PageTitle';
 import NetworkGraph from './NetworkGraph';
-import { transformData, graphModel } from './utils';
+import { transformData, graphModel } from './utils/modelUtils';
 
 import './NetworkGraphPage.css';
 

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentDetails.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentDetails.tsx
@@ -18,6 +18,18 @@ import {
     TextVariants,
 } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
+import pluralize from 'pluralize';
+
+import { Deployment } from 'types/deployment.proto';
+import { ListenPort } from 'types/networkFlow.proto';
+import { getDateTime } from 'utils/dateUtils';
+
+type DeploymentDetailsProps = {
+    deployment: Deployment;
+    numExternalFlows: number;
+    numInternalFlows: number;
+    listenPorts: ListenPort[];
+};
 
 function DetailSection({ title, children }) {
     const [isExpanded, setIsExpanded] = useState(true);
@@ -43,7 +55,12 @@ function DetailSection({ title, children }) {
     );
 }
 
-function DeploymentDetails() {
+function DeploymentDetails({
+    deployment,
+    numExternalFlows,
+    numInternalFlows,
+    listenPorts,
+}: DeploymentDetailsProps) {
     return (
         <div className="pf-u-h-100 pf-u-p-md">
             <ul>
@@ -63,7 +80,8 @@ function DeploymentDetails() {
                                                 color="red"
                                                 icon={<ExclamationCircleIcon />}
                                             >
-                                                2 external flows
+                                                {numExternalFlows} external{' '}
+                                                {pluralize('flow', numExternalFlows)}
                                             </Label>
                                         </FlexItem>
                                         <FlexItem>
@@ -72,7 +90,8 @@ function DeploymentDetails() {
                                                 color="gold"
                                                 icon={<ExclamationCircleIcon />}
                                             >
-                                                3 internal flows
+                                                {numInternalFlows} internal{' '}
+                                                {pluralize('flow', numInternalFlows)}
                                             </Label>
                                         </FlexItem>
                                     </Flex>
@@ -110,7 +129,19 @@ function DeploymentDetails() {
                                         alignItems={{ default: 'alignItemsCenter' }}
                                     >
                                         <FlexItem>
-                                            <Label variant="outline">TCP: 2020, 2021</Label>
+                                            <LabelGroup>
+                                                {listenPorts.map(({ port, l4protocol }) => {
+                                                    const protocol = l4protocol.replace(
+                                                        'L4_PROTOCOL_',
+                                                        ''
+                                                    );
+                                                    return (
+                                                        <Label variant="outline">
+                                                            {protocol}: {port}
+                                                        </Label>
+                                                    );
+                                                })}
+                                            </LabelGroup>
                                         </FlexItem>
                                     </Flex>
                                 </DescriptionListDescription>
@@ -128,21 +159,21 @@ function DeploymentDetails() {
                                         <DescriptionListTerm>Name</DescriptionListTerm>
                                         <DescriptionListDescription>
                                             <Button variant="link" isInline>
-                                                visa-processor
+                                                {deployment.name}
                                             </Button>
                                         </DescriptionListDescription>
                                     </DescriptionListGroup>
                                     <DescriptionListGroup>
                                         <DescriptionListTerm>Created</DescriptionListTerm>
                                         <DescriptionListDescription>
-                                            12/09/21 | 6:03:23 PM
+                                            {getDateTime(deployment.created)}
                                         </DescriptionListDescription>
                                     </DescriptionListGroup>
                                     <DescriptionListGroup>
                                         <DescriptionListTerm>Cluster</DescriptionListTerm>
                                         <DescriptionListDescription>
                                             <Button variant="link" isInline>
-                                                Production
+                                                {deployment.clusterName}
                                             </Button>
                                         </DescriptionListDescription>
                                     </DescriptionListGroup>
@@ -150,7 +181,7 @@ function DeploymentDetails() {
                                         <DescriptionListTerm>Namespace</DescriptionListTerm>
                                         <DescriptionListDescription>
                                             <Button variant="link" isInline>
-                                                Naples
+                                                {deployment.namespace}
                                             </Button>
                                         </DescriptionListDescription>
                                     </DescriptionListGroup>
@@ -158,7 +189,7 @@ function DeploymentDetails() {
                                         <DescriptionListTerm>Replicas</DescriptionListTerm>
                                         <DescriptionListDescription>
                                             <Button variant="link" isInline>
-                                                2 pods
+                                                {deployment.replicas}
                                             </Button>
                                         </DescriptionListDescription>
                                     </DescriptionListGroup>
@@ -166,7 +197,7 @@ function DeploymentDetails() {
                                         <DescriptionListTerm>Service account</DescriptionListTerm>
                                         <DescriptionListDescription>
                                             <Button variant="link" isInline>
-                                                visa-processor
+                                                {deployment.serviceAccount}
                                             </Button>
                                         </DescriptionListDescription>
                                     </DescriptionListGroup>
@@ -178,10 +209,15 @@ function DeploymentDetails() {
                                         <DescriptionListTerm>Labels</DescriptionListTerm>
                                         <DescriptionListDescription>
                                             <LabelGroup>
-                                                <Label color="blue">app:visa-processor</Label>
-                                                <Label color="blue">
-                                                    helm.sh/release-namespace:naples
-                                                </Label>
+                                                {Object.keys(deployment.labels).map((labelKey) => {
+                                                    const labelValue = deployment.labels[labelKey];
+                                                    const label = `${labelKey}:${labelValue}`;
+                                                    return (
+                                                        <Label key={label} color="blue">
+                                                            {label}
+                                                        </Label>
+                                                    );
+                                                })}
                                             </LabelGroup>
                                         </DescriptionListDescription>
                                     </DescriptionListGroup>
@@ -189,29 +225,19 @@ function DeploymentDetails() {
                                         <DescriptionListTerm>Annotations</DescriptionListTerm>
                                         <DescriptionListDescription>
                                             <LabelGroup>
-                                                <Label color="blue">
-                                                    deprecated.daemonset.template.generation:15
-                                                </Label>
-                                                <Label color="blue">
-                                                    email:support@stackrox.com
-                                                </Label>
+                                                {Object.keys(deployment.annotations).map(
+                                                    (annotationKey) => {
+                                                        const annotationValue =
+                                                            deployment.annotations[annotationKey];
+                                                        const annotation = `${annotationKey}:${annotationValue}`;
+                                                        return (
+                                                            <Label key={annotationKey} color="blue">
+                                                                {annotation}
+                                                            </Label>
+                                                        );
+                                                    }
+                                                )}
                                             </LabelGroup>
-                                        </DescriptionListDescription>
-                                    </DescriptionListGroup>
-                                </DescriptionList>
-                            </StackItem>
-                            <StackItem>
-                                <DescriptionList columnModifier={{ default: '2Col' }}>
-                                    <DescriptionListGroup>
-                                        <DescriptionListTerm>AddCapabilities</DescriptionListTerm>
-                                        <DescriptionListDescription>
-                                            SYS_ADMIN
-                                        </DescriptionListDescription>
-                                    </DescriptionListGroup>
-                                    <DescriptionListGroup>
-                                        <DescriptionListTerm>Privileged</DescriptionListTerm>
-                                        <DescriptionListDescription>
-                                            true
                                         </DescriptionListDescription>
                                     </DescriptionListGroup>
                                 </DescriptionList>

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/modelUtils.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/modelUtils.tsx
@@ -2,7 +2,7 @@ import { Model, NodeModel, EdgeModel } from '@patternfly/react-topology';
 
 import { NetworkEntityInfo, Node } from 'types/networkFlow.proto';
 
-function getLabel(entity: NetworkEntityInfo): string {
+function getNameByEntity(entity: NetworkEntityInfo): string {
     const { type } = entity;
     switch (type) {
         case 'DEPLOYMENT':
@@ -29,15 +29,19 @@ export function transformData(nodes: Node[]): Model {
         edges: [] as EdgeModel[],
     };
     const groupNodes = {} as NodeModel;
-    nodes.forEach(({ entity, outEdges }) => {
+    nodes.forEach(({ entity, policyIds, outEdges }) => {
         // creating each node and adding to data model
         const node = {
             id: entity.id,
             type: 'node',
             width: 75,
             height: 75,
-            label: getLabel(entity),
-            data: entity,
+            label: getNameByEntity(entity),
+            // @TODO: create a consistent data structure for "data" between all nodes
+            data: {
+                ...entity,
+                policyIds,
+            },
         };
         dataModel.nodes.push(node);
 
@@ -54,6 +58,7 @@ export function transformData(nodes: Node[]): Model {
                     group: true,
                     label: namespace,
                     style: { padding: 15 },
+                    // @TODO: create a consistent data structure for "data" between all nodes
                     data: {
                         collapsible: true,
                         showContextMenu: false,

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/networkGraphUtils.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/networkGraphUtils.ts
@@ -1,0 +1,72 @@
+import { EdgeModel, Model, NodeModel } from '@patternfly/react-topology';
+
+import { ListenPort } from 'types/networkFlow.proto';
+
+/* node helper functions */
+
+function getExternalNodeIds(nodes: NodeModel[]): string[] {
+    const externalNodeIds =
+        nodes?.reduce((acc, curr) => {
+            if (curr.data.type === 'INTERNET' || curr.data.type === 'EXTERNAL_SOURCE') {
+                return [...acc, curr.id];
+            }
+            return acc;
+        }, [] as string[]) || [];
+    return externalNodeIds;
+}
+
+export function getNodeById(model: Model, nodeId: string | undefined): NodeModel | undefined {
+    return model.nodes?.find((node) => node.id === nodeId);
+}
+
+/* edge helper functions */
+
+export function getNumInternalFlows(
+    nodes: NodeModel[],
+    edges: EdgeModel[],
+    deploymentId: string
+): number {
+    const externalNodeIds = getExternalNodeIds(nodes);
+    const numInternalFlows =
+        edges?.reduce((acc, edge) => {
+            if (
+                (edge.source === deploymentId && !externalNodeIds.includes(edge.target || '')) ||
+                (edge.target === deploymentId && !externalNodeIds.includes(edge.source || ''))
+            ) {
+                return acc + 1;
+            }
+            return acc;
+        }, 0) || 0;
+    return numInternalFlows;
+}
+
+export function getNumExternalFlows(
+    nodes: NodeModel[],
+    edges: EdgeModel[],
+    deploymentId: string
+): number {
+    const externalNodeIds = getExternalNodeIds(nodes);
+    const numExternalFlows =
+        edges?.reduce((acc, edge) => {
+            if (
+                (edge.source === deploymentId && externalNodeIds.includes(edge.target || '')) ||
+                (edge.target === deploymentId && externalNodeIds.includes(edge.source || ''))
+            ) {
+                return acc + 1;
+            }
+            return acc;
+        }, 0) || 0;
+    return numExternalFlows;
+}
+
+/* deployment helper functions */
+
+export function getListenPorts(nodes: NodeModel[], deploymentId: string): ListenPort[] {
+    const deployment = nodes?.find((node) => {
+        return node.id === deploymentId;
+    });
+    if (!deployment) {
+        return [];
+    }
+    return deployment.data.deployment.listenPorts as ListenPort[];
+}

--- a/ui/apps/platform/src/hooks/useFetchDeployment.ts
+++ b/ui/apps/platform/src/hooks/useFetchDeployment.ts
@@ -1,0 +1,33 @@
+import { useEffect, useState } from 'react';
+import { fetchDeployment } from 'services/DeploymentsService';
+
+import { Deployment } from 'types/deployment.proto';
+
+type Result = { isLoading: boolean; deployment: Deployment | null; error: string | null };
+
+const defaultResultState = { deployment: null, error: null, isLoading: true };
+
+/*
+ * This hook does an API call to the deployment API to get a deployment
+ */
+function useFetchDeployment(deploymentId: string): Result {
+    const [result, setResult] = useState<Result>(defaultResultState);
+
+    useEffect(() => {
+        setResult(defaultResultState);
+
+        if (deploymentId) {
+            fetchDeployment(deploymentId)
+                .then((data) => {
+                    setResult({ deployment: data || null, error: null, isLoading: false });
+                })
+                .catch((error) => {
+                    setResult({ deployment: null, error, isLoading: false });
+                });
+        }
+    }, [deploymentId]);
+
+    return result;
+}
+
+export default useFetchDeployment;


### PR DESCRIPTION
## Description

This PR adds real data for the deployment details page. This is an iterative addition. You can find all the subtasks here:
https://issues.redhat.com/browse/ROX-12903

NOTE: I decided to break this down further. I will add real data for the network policy section and port config section of the details page in a separate PR

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

<img width="1552" alt="Screenshot 2022-11-03 at 4 02 15 PM" src="https://user-images.githubusercontent.com/4805485/199851288-dbbbbcb6-227c-4385-8626-d1b2d7b3cbea.png">
<img width="1552" alt="Screenshot 2022-11-03 at 4 02 18 PM" src="https://user-images.githubusercontent.com/4805485/199851291-64a71509-53d3-4b58-836e-2565c50ba9fb.png">

