### PR TITLE
[ROX-13403] : Fix node -> topVuln sub resolver bug when node cves is empty

### DIFF
--- a/central/graphql/resolvers/nodes.go
+++ b/central/graphql/resolvers/nodes.go
@@ -374,7 +374,7 @@ func (resolver *nodeResolver) TopVuln(ctx context.Context, args RawQuery) (Vulne
 	}
 
 	query, err := resolver.getTopNodeCVEV1Query(args)
-	if err != nil {
+	if err != nil || query == nil {
 		return nil, err
 	}
 	vulnResolver, err := resolver.unwrappedTopVulnQuery(ctx, query)
@@ -394,7 +394,7 @@ func (resolver *nodeResolver) TopNodeVulnerability(ctx context.Context, args Raw
 		}
 
 		query, err := resolver.getTopNodeCVEV1Query(args)
-		if err != nil {
+		if err != nil || query == nil {
 			return nil, err
 		}
 		vulnResolver, err := resolver.unwrappedTopVulnQuery(ctx, query)


### PR DESCRIPTION
## Description

Issue happens when postgres is disabled

When there are no node cves, the topVuln sub resolver passes a nil query to cveDatastore, which results in datastore returning all cves including image and platform cves. The fix avoids querying cveDatastore and returns topVuln value as nil when there are no cves in a node.

## Checklist
- [ ] Investigated and inspected CI test results~
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
