### PR TITLE
ROX-13378: Group new resources with deprecated in UI

### DIFF
--- a/central/main.go
+++ b/central/main.go
@@ -246,6 +246,16 @@ func main() {
 	devmode.StartOnDevBuilds("central")
 
 	log.Infof("Running StackRox Version: %s", pkgVersion.GetMainVersion())
+	// TODO: ROX-12750 update with new list of replaced/deprecated resources
+	log.Warn("The following permission resources have been replaced:\n" +
+		"	Access replaces AuthProvider, Group, Licenses, and User\n" +
+		"	DeploymentExtension replaces Indicator, NetworkBaseline, ProcessWhitelist, and Risk\n" +
+		"	Integration replaces APIToken, BackupPlugins, ImageIntegration, Notifier, and SignatureIntegration\n" +
+		"	Image now also covers ImageComponent\n" +
+		"The following permission resources will be replaced in the upcoming versions:\n" +
+		"	Administration will replace AllComments, Config, DebugLogs, NetworkGraphConfig, ProbeUpload, ScannerDefinitions, SensorUpgradeConfig, and ServiceIdentity\n" +
+		"	Compliance will replace ComplianceRuns\n" +
+		"	Cluster will replace ClusterCVE.")
 	ensureDB(ctx)
 
 	// Need to remove the backup clone and set the current version

--- a/central/main.go
+++ b/central/main.go
@@ -253,7 +253,7 @@ func main() {
 		"	Integration replaces APIToken, BackupPlugins, ImageIntegration, Notifier, and SignatureIntegration\n" +
 		"	Image now also covers ImageComponent\n" +
 		"The following permission resources will be replaced in the upcoming versions:\n" +
-		"	Administration will replace AllComments, Config, DebugLogs, NetworkGraphConfig, ProbeUpload, ScannerDefinitions, SensorUpgradeConfig, and ServiceIdentity\n" +
+		"	Administration will replace AllComments, Config, DebugLogs, NetworkGraphConfig, ProbeUpload, ScannerBundle, ScannerDefinitions, SensorUpgradeConfig, and ServiceIdentity\n" +
 		"	Compliance will replace ComplianceRuns\n" +
 		"	Cluster will replace ClusterCVE.")
 	ensureDB(ctx)

--- a/central/main.go
+++ b/central/main.go
@@ -255,7 +255,7 @@ func main() {
 		"The following permission resources will be replaced in the upcoming versions:\n" +
 		"	Administration will replace AllComments, Config, DebugLogs, NetworkGraphConfig, ProbeUpload, ScannerBundle, ScannerDefinitions, SensorUpgradeConfig, and ServiceIdentity\n" +
 		"	Compliance will replace ComplianceRuns\n" +
-		"	Cluster will replace ClusterCVE.")
+		"	Cluster will cover ClusterCVE.")
 	ensureDB(ctx)
 
 	// Need to remove the backup clone and set the current version

--- a/ui/apps/platform/cypress/integration/accessControl/accessControlPermissionSets.test.js
+++ b/ui/apps/platform/cypress/integration/accessControl/accessControlPermissionSets.test.js
@@ -157,7 +157,7 @@ describe('Access Control Permission sets', () => {
             $tds.get().forEach((td) => {
                 const resource = td.textContent;
                 // TODO: ROX-12750 Rename DebugLogs to Administration
-                if (resource === 'DebugLogs') {
+                if (resource.includes('DebugLogs')) {
                     cy.get(getReadAccessIconForResource(resource)).should(
                         'have.attr',
                         'aria-label',
@@ -209,7 +209,7 @@ describe('Access Control Permission sets', () => {
 
             $tds.get().forEach((td) => {
                 const resource = td.textContent;
-                if (!resourcesLimited.includes(resource)) {
+                if (!resourcesLimited.some((v) => resource.includes(v))) {
                     cy.get(getReadAccessIconForResource(resource)).should(
                         'have.attr',
                         'aria-label',
@@ -315,7 +315,7 @@ describe('Access Control Permission sets', () => {
 
             $tds.get().forEach((td) => {
                 const resource = td.textContent;
-                if (!resourcesLimited.includes(resource)) {
+                if (!resourcesLimited.some((v) => resource.includes(v))) {
                     cy.get(getReadAccessIconForResource(resource)).should(
                         'have.attr',
                         'aria-label',

--- a/ui/apps/platform/src/Containers/AccessControl/AccessControl.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessControl.tsx
@@ -67,7 +67,7 @@ function AccessControl(): ReactElement {
                                 <b>Compliance</b> will replace <b>ComplianceRuns</b>
                             </ListItem>
                             <ListItem>
-                                <b>Cluster</b> will replace <b>ClusterCVE</b>
+                                <b>Cluster</b> will cover <b>ClusterCVE</b>
                             </ListItem>
                         </List>
                     </>

--- a/ui/apps/platform/src/Containers/AccessControl/AccessControl.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessControl.tsx
@@ -3,6 +3,7 @@ import { Redirect, Route, Switch } from 'react-router-dom';
 
 import usePermissions from 'hooks/usePermissions';
 
+import { Alert } from '@patternfly/react-core';
 import { accessControlBasePath, accessControlPath, getEntityPath } from './accessControlPaths';
 
 import AccessControlNoPermission from './AccessControlNoPermission';
@@ -18,11 +19,60 @@ function AccessControl(): ReactElement {
     // TODO is read access required for all routes in improved Access Control?
     // TODO Is write access required anywhere in classic Access Control?
     const { hasReadAccess } = usePermissions();
-    const hasReadAccessForAuthProvider = hasReadAccess('Access');
+    const hasReadAccessForAccessControlPages = hasReadAccess('Access');
 
     return (
         <>
-            {hasReadAccessForAuthProvider ? (
+            <Alert
+                isInline
+                variant="warning"
+                title={
+                    <>
+                        <p>The following permission resources have been replaced:</p>
+                        <ul>
+                            <li>
+                                <b>Access</b> replaces{' '}
+                                <b>AuthProvider, Group, Licenses, and User</b>
+                            </li>
+                            <li>
+                                <b>DeploymentExtension</b> replaces{' '}
+                                <b>Indicator, NetworkBaseline, ProcessWhitelist, and Risk</b>
+                            </li>
+                            <li>
+                                <b>Integration</b> replaces{' '}
+                                <b>
+                                    APIToken, BackupPlugins, ImageIntegration, Notifier, and
+                                    SignatureIntegration
+                                </b>
+                            </li>
+                            <li>
+                                <b>Image</b> now also covers <b>ImageComponent</b>
+                            </li>
+                        </ul>
+
+                        <p>
+                            The following permission resources will be replaced in the upcoming
+                            versions:
+                        </p>
+                        <ul>
+                            <li>
+                                <b>Administration</b> will replace{' '}
+                                <b>
+                                    AllComments, Config, DebugLogs, NetworkGraphConfig, ProbeUpload,
+                                    ScannerDefinitions, SensorUpgradeConfig, and ServiceIdentity
+                                </b>
+                            </li>
+                            <li>
+                                <b>Compliance</b> will replace <b>ComplianceRuns</b>
+                            </li>
+                            <li>
+                                <b>Cluster</b> will replace <b>ClusterCVE</b>
+                            </li>
+                        </ul>
+                    </>
+                }
+            />
+            {hasReadAccessForAccessControlPages ? (
                 <Switch>
                     <Route exact path={accessControlBasePath}>
                         <Redirect to={getEntityPath('AUTH_PROVIDER')} />

--- a/ui/apps/platform/src/Containers/AccessControl/AccessControl.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessControl.tsx
@@ -59,7 +59,8 @@ function AccessControl(): ReactElement {
                                 <b>Administration</b> will replace{' '}
                                 <b>
                                     AllComments, Config, DebugLogs, NetworkGraphConfig, ProbeUpload,
-                                    ScannerDefinitions, SensorUpgradeConfig, and ServiceIdentity
+                                    ScannerBundle, ScannerDefinitions, SensorUpgradeConfig, and
+                                    ServiceIdentity
                                 </b>
                             </ListItem>
                             <ListItem>

--- a/ui/apps/platform/src/Containers/AccessControl/AccessControl.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessControl.tsx
@@ -3,7 +3,7 @@ import { Redirect, Route, Switch } from 'react-router-dom';
 
 import usePermissions from 'hooks/usePermissions';
 
-import { Alert } from '@patternfly/react-core';
+import { Alert, List, ListItem } from '@patternfly/react-core';
 import { accessControlBasePath, accessControlPath, getEntityPath } from './accessControlPaths';
 
 import AccessControlNoPermission from './AccessControlNoPermission';
@@ -29,46 +29,46 @@ function AccessControl(): ReactElement {
                 title={
                     <>
                         <p>The following permission resources have been replaced:</p>
-                        <ul>
-                            <li>
+                        <List>
+                            <ListItem>
                                 <b>Access</b> replaces{' '}
                                 <b>AuthProvider, Group, Licenses, and User</b>
-                            </li>
-                            <li>
+                            </ListItem>
+                            <ListItem>
                                 <b>DeploymentExtension</b> replaces{' '}
                                 <b>Indicator, NetworkBaseline, ProcessWhitelist, and Risk</b>
-                            </li>
-                            <li>
+                            </ListItem>
+                            <ListItem>
                                 <b>Integration</b> replaces{' '}
                                 <b>
                                     APIToken, BackupPlugins, ImageIntegration, Notifier, and
                                     SignatureIntegration
                                 </b>
-                            </li>
-                            <li>
+                            </ListItem>
+                            <ListItem>
                                 <b>Image</b> now also covers <b>ImageComponent</b>
-                            </li>
-                        </ul>
+                            </ListItem>
+                        </List>
 
                         <p>
                             The following permission resources will be replaced in the upcoming
                             versions:
                         </p>
-                        <ul>
-                            <li>
+                        <List>
+                            <ListItem>
                                 <b>Administration</b> will replace{' '}
                                 <b>
                                     AllComments, Config, DebugLogs, NetworkGraphConfig, ProbeUpload,
                                     ScannerDefinitions, SensorUpgradeConfig, and ServiceIdentity
                                 </b>
-                            </li>
-                            <li>
+                            </ListItem>
+                            <ListItem>
                                 <b>Compliance</b> will replace <b>ComplianceRuns</b>
-                            </li>
-                            <li>
+                            </ListItem>
+                            <ListItem>
                                 <b>Cluster</b> will replace <b>ClusterCVE</b>
-                            </li>
-                        </ul>
+                            </ListItem>
+                        </List>
                     </>
                 }
             />

--- a/ui/apps/platform/src/Containers/AccessControl/PermissionSets/PermissionsTable.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/PermissionSets/PermissionsTable.tsx
@@ -8,7 +8,14 @@ import { PermissionsMap } from 'services/RolesService';
 
 import { ReadAccessIcon, WriteAccessIcon } from './AccessIcons';
 import { getReadAccessCount, getWriteAccessCount } from './permissionSets.utils';
-import ResourceDescription from './ResourceDescription';
+import { ResourceDescription } from './ResourceDescription';
+import {
+    replacedResourceMapping,
+    resourceRemovalReleaseVersions,
+    resourceSubstitutions,
+    deprecatedResourceRowStyle,
+} from '../../../constants/accessControl';
+import { ResourceName } from '../../../types/roleResources';
 
 export type PermissionsTableProps = {
     resourceToAccess: PermissionsMap;
@@ -51,8 +58,41 @@ function PermissionsTable({
             </Thead>
             <Tbody>
                 {resourceToAccessEntries.map(([resource, accessLevel]) => (
-                    <Tr key={resource}>
-                        <Td dataLabel="Resource">{resource}</Td>
+                    <Tr
+                        key={resource}
+                        style={
+                            resourceRemovalReleaseVersions.has(resource as ResourceName)
+                                ? deprecatedResourceRowStyle
+                                : {}
+                        }
+                    >
+                        <Td dataLabel="Resource">
+                            <p>{resource}</p>
+                            <p style={{ fontStyle: 'italic' }}>
+                                {resourceSubstitutions[resource] && (
+                                    <>Replaces {resourceSubstitutions[resource].join(', ')}</>
+                                )}
+                            </p>
+                            <p style={{ fontStyle: 'italic' }}>
+                                {resourceRemovalReleaseVersions.has(resource as ResourceName) && (
+                                    <>
+                                        Will be removed in{' '}
+                                        {resourceRemovalReleaseVersions.get(
+                                            resource as ResourceName
+                                        )}
+                                        .
+                                    </>
+                                )}
+                            </p>
+                            <p style={{ fontStyle: 'italic' }}>
+                                {replacedResourceMapping.has(resource as ResourceName) && (
+                                    <>
+                                        Will be replaced by{' '}
+                                        {replacedResourceMapping.get(resource as ResourceName)}.
+                                    </>
+                                )}
+                            </p>
+                        </Td>
                         <Td dataLabel="Description">
                             <ResourceDescription resource={resource} />
                         </Td>

--- a/ui/apps/platform/src/Containers/AccessControl/PermissionSets/ResourceDescription.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/PermissionSets/ResourceDescription.tsx
@@ -11,6 +11,7 @@ const resourceDescriptions: Record<ResourceName, string> = {
     Alert: 'Read: View policy violations. Write: Resolve or edit policy violations.',
     CVE: 'Internal use only',
     Cluster: 'Read: View secured clusters. Write: Add, modify, or delete secured clusters.',
+    ClusterCVE: 'Internal use only',
     Compliance:
         'Read: View compliance standards, results, and runs. Write: Add, modify, or delete scheduled compliance runs.',
     Deployment: 'Read: View deployments (workloads) in secured clusters. Write: N/A',
@@ -72,7 +73,7 @@ export type ResourceDescriptionProps = {
     resource: string;
 };
 
-function ResourceDescription({ resource }: ResourceDescriptionProps): ReactElement {
+export function ResourceDescription({ resource }: ResourceDescriptionProps): ReactElement {
     // The description becomes the prop for possible future request from backend.
     const description = resourceDescriptions[resource] ?? '';
     const readIndex = description.indexOf('Read: ');

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationsNoPermission.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationsNoPermission.tsx
@@ -1,0 +1,30 @@
+import React, { ReactElement } from 'react';
+import {
+    Alert,
+    AlertVariant,
+    Divider,
+    PageSection,
+    PageSectionVariants,
+    Title,
+} from '@patternfly/react-core';
+
+function IntegrationsNoPermission(): ReactElement {
+    return (
+        <>
+            <PageSection variant="light">
+                <Title headingLevel="h1">Integrations</Title>
+            </PageSection>
+            <Divider component="div" />
+            <PageSection variant={PageSectionVariants.light}>
+                <Alert
+                    className="pf-u-mt-md"
+                    title="You do not have permission to view Integrations"
+                    variant={AlertVariant.info}
+                    isInline
+                />
+            </PageSection>
+        </>
+    );
+}
+
+export default IntegrationsNoPermission;

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationsPage.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationsPage.tsx
@@ -15,16 +15,28 @@ import IntegrationsListPage from './IntegrationsListPage';
 import CreateIntegrationPage from './CreateIntegrationPage';
 import EditIntegrationPage from './EditIntegrationPage';
 import IntegrationDetailsPage from './IntegrationDetailsPage';
+import usePermissions from '../../hooks/usePermissions';
+import IntegrationsNoPermission from './IntegrationsNoPermission';
 
-const Page = (): ReactElement => (
-    <Switch>
-        <Route exact path={integrationsPath} component={IntegrationTilesPage} />
-        <Route exact path={integrationsListPath} component={IntegrationsListPage} />
-        <Route path={integrationCreatePath} component={CreateIntegrationPage} />
-        <Route path={integrationEditPath} component={EditIntegrationPage} />
-        <Route path={integrationDetailsPath} component={IntegrationDetailsPage} />
-        <Route component={IntegrationsNotFoundPage} />
-    </Switch>
-);
+const Page = (): ReactElement => {
+    const { hasReadAccess } = usePermissions();
+    const hasReadAccessForIntegrations = hasReadAccess('Integration');
+    return (
+        <>
+            {hasReadAccessForIntegrations ? (
+                <Switch>
+                    <Route exact path={integrationsPath} component={IntegrationTilesPage} />
+                    <Route exact path={integrationsListPath} component={IntegrationsListPage} />
+                    <Route path={integrationCreatePath} component={CreateIntegrationPage} />
+                    <Route path={integrationEditPath} component={EditIntegrationPage} />
+                    <Route path={integrationDetailsPath} component={IntegrationDetailsPage} />
+                    <Route component={IntegrationsNotFoundPage} />
+                </Switch>
+            ) : (
+                <IntegrationsNoPermission />
+            )}
+        </>
+    );
+};
 
 export default Page;

--- a/ui/apps/platform/src/Containers/User/UserPermissionsTable.tsx
+++ b/ui/apps/platform/src/Containers/User/UserPermissionsTable.tsx
@@ -7,6 +7,11 @@ import {
     ReadAccessIcon,
     WriteAccessIcon,
 } from 'Containers/AccessControl/PermissionSets/AccessIcons';
+import {
+    deprecatedResourceRowStyle,
+    resourceRemovalReleaseVersions,
+} from '../../constants/accessControl';
+import { ResourceName } from '../../types/roleResources';
 
 export type UserPermissionsTableProps = {
     permissions: PermissionsMap;
@@ -24,7 +29,14 @@ function UserPermissionsTable({ permissions }: UserPermissionsTableProps): React
             </Thead>
             <Tbody>
                 {Object.entries(permissions).map(([resource, accessLevel]) => (
-                    <Tr key={resource}>
+                    <Tr
+                        key={resource}
+                        style={
+                            resourceRemovalReleaseVersions.has(resource as ResourceName)
+                                ? deprecatedResourceRowStyle
+                                : {}
+                        }
+                    >
                         <Td key="resourceName" dataLabel="Resource">
                             {resource}
                         </Td>

--- a/ui/apps/platform/src/constants/accessControl.ts
+++ b/ui/apps/platform/src/constants/accessControl.ts
@@ -1,4 +1,6 @@
 /* constants specific to Roles */
+import { ResourceName } from '../types/roleResources';
+
 export const NO_ACCESS = 'NO_ACCESS';
 export const READ_ACCESS = 'READ_ACCESS';
 export const READ_WRITE_ACCESS = 'READ_WRITE_ACCESS';
@@ -86,3 +88,49 @@ export const defaultSelectedRole = {
     name: '',
     resourceToAccess: defaultNewRolePermissions,
 };
+
+// TODO: ROX-12750 update with new list of replaced/deprecated resources
+export const resourceSubstitutions: Record<string, string[]> = {
+    Access: ['AuthProvider', 'Group', 'Licenses', 'User'],
+    DeploymentExtension: ['Indicator', 'NetworkBaseline', 'ProcessWhitelist', 'Risk'],
+    Integration: [
+        'APIToken',
+        'BackupPlugins',
+        'ImageIntegration',
+        'Notifier',
+        'SignatureIntegration',
+    ],
+    Image: ['ImageComponent'],
+};
+
+// TODO: ROX-12750 update with new list of replaced/deprecated resources
+export const resourceRemovalReleaseVersions = new Map<ResourceName, string>([
+    ['AllComments', '3.75'],
+    ['ComplianceRuns', '3.75'],
+    ['Config', '3.75'],
+    ['DebugLogs', '3.75'],
+    ['NetworkGraphConfig', '3.75'],
+    ['ProbeUpload', '3.75'],
+    ['ScannerBundle', '3.75'],
+    ['ScannerDefinitions', '3.75'],
+    ['SensorUpgradeConfig', '3.75'],
+    ['ServiceIdentity', '3.75'],
+    ['ClusterCVE', '3.74'],
+]);
+
+// TODO(ROX-11453): Remove this mapping once the old resources are fully deprecated.
+export const replacedResourceMapping = new Map<ResourceName, string>([
+    ['AllComments', 'Administration'],
+    ['ComplianceRuns', 'Compliance'],
+    ['Config', 'Administration'],
+    ['DebugLogs', 'Administration'],
+    ['NetworkGraphConfig', 'Administration'],
+    ['ProbeUpload', 'Administration'],
+    ['ScannerBundle', 'Administration'],
+    ['ScannerDefinitions', 'Administration'],
+    ['SensorUpgradeConfig', 'Administration'],
+    ['ServiceIdentity', 'Administration'],
+    ['ClusterCVE', 'Cluster'],
+]);
+
+export const deprecatedResourceRowStyle = { backgroundColor: 'rgb(255,250,205)' };

--- a/ui/apps/platform/src/constants/accessControl.ts
+++ b/ui/apps/platform/src/constants/accessControl.ts
@@ -120,6 +120,8 @@ export const resourceRemovalReleaseVersions = new Map<ResourceName, string>([
 
 // TODO(ROX-11453): Remove this mapping once the old resources are fully deprecated.
 export const replacedResourceMapping = new Map<ResourceName, string>([
+    // TODO: ROX-12750 Remove AllComments, ComplianceRunSchedule, ComplianceRuns, Config, DebugLogs,
+    // NetworkGraphConfig, ProbeUpload, ScannerBundle, ScannerDefinitions, SensorUpgradeConfig and ServiceIdentity.
     ['AllComments', 'Administration'],
     ['ComplianceRuns', 'Compliance'],
     ['Config', 'Administration'],

--- a/ui/apps/platform/src/hooks/usePermissions.ts
+++ b/ui/apps/platform/src/hooks/usePermissions.ts
@@ -4,6 +4,7 @@ import { createStructuredSelector } from 'reselect';
 import { selectors } from 'reducers';
 import { Access } from 'types/role.proto';
 import { ResourceName } from 'types/roleResources';
+import { replacedResourceMapping } from 'constants/accessControl';
 
 export type HasNoAccess = (resourceName: ResourceName) => boolean;
 export type HasReadAccess = (resourceName: ResourceName) => boolean;
@@ -23,22 +24,6 @@ const stateSelector = createStructuredSelector<{
     userRolePermissions: selectors.getUserRolePermissions,
     isLoadingPermissions: selectors.getIsLoadingUserRolePermissions,
 });
-
-// TODO(ROX-11453): Remove this mapping once the old resources are fully deprecated.
-const replacedResourceMapping = new Map<ResourceName, string>([
-    // TODO: ROX-12750 Remove AllComments, ComplianceRunSchedule, ComplianceRuns, Config, DebugLogs,
-    // NetworkGraphConfig, ProbeUpload, ScannerBundle, ScannerDefinitions, SensorUpgradeConfig and ServiceIdentity.
-    ['AllComments', 'Administration'],
-    ['ComplianceRuns', 'Compliance'],
-    ['Config', 'Administration'],
-    ['DebugLogs', 'Administration'],
-    ['NetworkGraphConfig', 'Administration'],
-    ['ProbeUpload', 'Administration'],
-    ['ScannerBundle', 'Administration'],
-    ['ScannerDefinitions', 'Administration'],
-    ['SensorUpgradeConfig', 'Administration'],
-    ['ServiceIdentity', 'Administration'],
-]);
 
 const usePermissions = (): UsePermissionsResponse => {
     const { userRolePermissions, isLoadingPermissions } = useSelector(stateSelector);

--- a/ui/apps/platform/src/reducers/roles.js
+++ b/ui/apps/platform/src/reducers/roles.js
@@ -2,6 +2,7 @@ import { combineReducers } from 'redux';
 import isEqual from 'lodash/isEqual';
 
 import { createFetchingActionTypes, createFetchingActions } from 'utils/fetchingReduxRoutines';
+import { replacedResourceMapping } from '../constants/accessControl';
 
 export const ACCESS_LEVEL = Object.freeze({
     READ_WRITE_ACCESS: 'READ_WRITE_ACCESS',
@@ -103,22 +104,6 @@ const getSelectedRole = (state) => state.selectedRole;
 const getUserRolePermissions = (state) => state.userRolePermissions;
 const getUserRolePermissionsError = (state) => state.error;
 const getIsLoadingUserRolePermissions = (state) => state.isLoading;
-
-// TODO(ROX-11453): Remove this mapping once the old resources are fully deprecated.
-const replacedResourceMapping = new Map([
-    // TODO: ROX-12750 Remove AllComments, ComplianceRunSchedule, ComplianceRuns, Config, DebugLogs,
-    // NetworkGraphConfig, ProbeUpload, ScannerBundle, ScannerDefinitions, SensorUpgradeConfig and ServiceIdentity.
-    ['AllComments', 'Administration'],
-    ['ComplianceRuns', 'Compliance'],
-    ['Config', 'Administration'],
-    ['DebugLogs', 'Administration'],
-    ['NetworkGraphConfig', 'Administration'],
-    ['ProbeUpload', 'Administration'],
-    ['ScannerBundle', 'Administration'],
-    ['ScannerDefinitions', 'Administration'],
-    ['SensorUpgradeConfig', 'Administration'],
-    ['ServiceIdentity', 'Administration'],
-]);
 
 /*
  * Given resource string (for example, "Integration") and role or permissionSet object,

--- a/ui/apps/platform/src/types/roleResources.ts
+++ b/ui/apps/platform/src/types/roleResources.ts
@@ -40,6 +40,7 @@ export type ResourceName =
     // TODO: ROX-12750 Remove AllComments, ComplianceRunSchedule, ComplianceRuns, Config, DebugLogs,
     // NetworkGraphConfig, ProbeUpload, ScannerBundle, ScannerDefinitions, SensorUpgradeConfig and ServiceIdentity.
     | 'AllComments'
+    | 'ClusterCVE'
     | 'ComplianceRuns'
     | 'Config'
     | 'DebugLogs'
@@ -49,5 +50,4 @@ export type ResourceName =
     | 'ScannerDefinitions'
     | 'SensorUpgradeConfig'
     | 'ServiceIdentity'
-    | 'ClusterCVE'
     ;

--- a/ui/apps/platform/src/types/roleResources.ts
+++ b/ui/apps/platform/src/types/roleResources.ts
@@ -49,4 +49,5 @@ export type ResourceName =
     | 'ScannerDefinitions'
     | 'SensorUpgradeConfig'
     | 'ServiceIdentity'
+    | 'ClusterCVE'
     ;


### PR DESCRIPTION
## Description

1. Creates banner on `Access Control` page notifying of resource changes
2. Creates log entry similar to banner on Central startup
3. All replacing resources are marked in the UI
4. All deprecated/to-be-deprecated/to-be-removed resources are marked and show the version of deprecation
5. Added ClusterCVE resource description as it was missing
6. Guard “Integrations” by `Integration` permission

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

https://user-images.githubusercontent.com/78353299/199859029-9d10b9c6-0c86-46e0-975a-83cf05715370.mov

<img width="1764" alt="Screenshot 2022-11-04 at 00 42 24" src="https://user-images.githubusercontent.com/78353299/199859052-15bb797b-edd0-457b-ac1e-c2056cb67455.png">

