### PR TITLE
ROX-13356: Use deployment ID reference when processing deployments

### DIFF
--- a/sensor/common/store/resolver/resolver.go
+++ b/sensor/common/store/resolver/resolver.go
@@ -1,0 +1,12 @@
+package resolver
+
+import "github.com/stackrox/rox/sensor/common/store"
+
+type DeploymentReference func(store store.DeploymentStore) []string
+
+// ResolveDeploymentIds is an identify function that simply returns a list of deployment ids passed
+func ResolveDeploymentIds(ids ...string) DeploymentReference {
+	return func(_ store.DeploymentStore) []string {
+		return ids
+	}
+}

--- a/sensor/common/store/resolver/resolver.go
+++ b/sensor/common/store/resolver/resolver.go
@@ -2,6 +2,7 @@ package resolver
 
 import "github.com/stackrox/rox/sensor/common/store"
 
+// DeploymentReference generates a list of deployment IDs that need to be updated given the deployment store.
 type DeploymentReference func(store store.DeploymentStore) []string
 
 // ResolveDeploymentIds is an identify function that simply returns a list of deployment ids passed

--- a/sensor/kubernetes/eventpipeline/component/message.go
+++ b/sensor/kubernetes/eventpipeline/component/message.go
@@ -3,6 +3,7 @@ package component
 import (
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/sensor/common/store/resolver"
 )
 
 // CompatibilityDetectionMessage should be used by old handlers
@@ -26,6 +27,10 @@ type ResourceEvent struct {
 	// CompatibilityReprocessDeployments is also used for compatibility reasons with Network Policy handlers
 	// in the future this will not be needed as the dependencies are taken care by the resolvers
 	CompatibilityReprocessDeployments []string
+
+	// DeploymentReference returns an implementation of a struct that can return a list of deployment ids
+	// that require processing
+	DeploymentReference resolver.DeploymentReference
 }
 
 // NewResourceEvent wraps the SensorEvents, CompatibilityDetectionMessages, and the CompatibilityReprocessDeployments into a ResourceEvent message
@@ -34,6 +39,12 @@ func NewResourceEvent(sensorMessages []*central.SensorEvent, detectionDeployment
 		ForwardMessages:                   sensorMessages,
 		CompatibilityDetectionDeployment:  detectionDeployment,
 		CompatibilityReprocessDeployments: reprocessDeploymentsIds,
+	}
+}
+
+func NewDeploymentRefEvent(ref resolver.DeploymentReference) *ResourceEvent {
+	return &ResourceEvent{
+		DeploymentReference: ref,
 	}
 }
 

--- a/sensor/kubernetes/eventpipeline/component/message.go
+++ b/sensor/kubernetes/eventpipeline/component/message.go
@@ -42,6 +42,7 @@ func NewResourceEvent(sensorMessages []*central.SensorEvent, detectionDeployment
 	}
 }
 
+// NewDeploymentRefEvent generates a resource event given a deployment reference.
 func NewDeploymentRefEvent(ref resolver.DeploymentReference) *ResourceEvent {
 	return &ResourceEvent{
 		DeploymentReference: ref,

--- a/sensor/kubernetes/listener/resources/deployments.go
+++ b/sensor/kubernetes/listener/resources/deployments.go
@@ -195,7 +195,7 @@ func (d *deploymentHandler) processWithType(obj, oldObj interface{}, action cent
 			// if resource is being removed, we can create the remove message here without related resources
 			events = component.MergeResourceEvents(events, component.NewResourceEvent([]*central.SensorEvent{deploymentWrap.toEvent(action)}, nil, nil))
 		} else {
-			// If re-sync is disabled, we need don't process deployment relationships here. We pass a deployment
+			// If re-sync is disabled, we don't need to process deployment relationships here. We pass a deployment
 			// references up the chain, which will be used to trigger the actual deployment event and detection.
 			events = component.MergeResourceEvents(events,
 				component.NewDeploymentRefEvent(resolver.ResolveDeploymentIds(deploymentWrap.GetId())))

--- a/sensor/kubernetes/listener/resources/deployments.go
+++ b/sensor/kubernetes/listener/resources/deployments.go
@@ -7,6 +7,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/process/filter"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/utils"
@@ -15,6 +16,7 @@ import (
 	"github.com/stackrox/rox/sensor/common/config"
 	"github.com/stackrox/rox/sensor/common/registry"
 	"github.com/stackrox/rox/sensor/common/store"
+	"github.com/stackrox/rox/sensor/common/store/resolver"
 	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/component"
 	"github.com/stackrox/rox/sensor/kubernetes/listener/resources/rbac"
 	"github.com/stackrox/rox/sensor/kubernetes/listener/resources/references"
@@ -166,12 +168,7 @@ func (d *deploymentHandler) processWithType(obj, oldObj interface{}, action cent
 		return events
 	}
 
-	exposureInfos := d.serviceStore.GetExposureInfos(deploymentWrap.GetNamespace(), deploymentWrap.PodLabels)
-	deploymentWrap.updatePortExposureSlice(exposureInfos)
 	if action != central.ResourceAction_REMOVE_RESOURCE {
-		// Make sure to clone and add deploymentWrap to the store if this function is being used at places other than
-		// right after deploymentWrap object creation.
-		deploymentWrap.updateServiceAccountPermissionLevel(d.rbac.GetPermissionLevelForDeployment(deploymentWrap.GetDeployment()))
 		d.deploymentStore.addOrUpdateDeployment(deploymentWrap)
 		d.endpointManager.OnDeploymentCreateOrUpdate(deploymentWrap)
 	} else {
@@ -180,19 +177,42 @@ func (d *deploymentHandler) processWithType(obj, oldObj interface{}, action cent
 		d.endpointManager.OnDeploymentRemove(deploymentWrap)
 		d.processFilter.Delete(deploymentWrap.GetId())
 	}
-	if err := deploymentWrap.updateHash(); err != nil {
-		log.Errorf("UNEXPECTED: could not calculate hash of deployment %s: %v", deploymentWrap.GetId(), err)
-	}
 
 	events = d.appendIntegrationsOnCredentials(action, deploymentWrap.GetContainers(), events)
-	outputMessage := component.NewResourceEvent([]*central.SensorEvent{deploymentWrap.toEvent(action)}, []component.CompatibilityDetectionMessage{
-		{
-			Object: deploymentWrap.GetDeployment(),
-			Action: action,
-		},
-	}, nil)
 
-	events = component.MergeResourceEvents(events, outputMessage)
+	if features.ResyncDisabled.Enabled() {
+		if action == central.ResourceAction_REMOVE_RESOURCE {
+			// if resource is being removed, we can create the remove message here without related resources
+			events = component.MergeResourceEvents(events, component.NewResourceEvent([]*central.SensorEvent{deploymentWrap.toEvent(action)}, nil, nil))
+		} else {
+			// If re-sync is disabled, we need don't process deployment relationships here. We pass a deployment
+			// references up the chain, which will be used to trigger the actual deployment event and detection.
+			events = component.MergeResourceEvents(events,
+				component.NewDeploymentRefEvent(resolver.ResolveDeploymentIds(deploymentWrap.GetId())))
+		}
+	} else {
+		exposureInfos := d.serviceStore.GetExposureInfos(deploymentWrap.GetNamespace(), deploymentWrap.PodLabels)
+		deploymentWrap.updatePortExposureSlice(exposureInfos)
+		if action != central.ResourceAction_REMOVE_RESOURCE {
+			// Make sure to clone and add deploymentWrap to the store if this function is being used at places other than
+			// right after deploymentWrap object creation.
+			deploymentWrap.updateServiceAccountPermissionLevel(d.rbac.GetPermissionLevelForDeployment(deploymentWrap.GetDeployment()))
+		}
+
+		if err := deploymentWrap.updateHash(); err != nil {
+			log.Errorf("UNEXPECTED: could not calculate hash of deployment %s: %v", deploymentWrap.GetId(), err)
+		}
+
+		events = component.MergeResourceEvents(events, component.NewResourceEvent([]*central.SensorEvent{deploymentWrap.toEvent(action)}, nil, nil))
+		// Compatibility: send detection message directly from here
+		events = component.MergeResourceEvents(events, component.NewResourceEvent(nil, []component.CompatibilityDetectionMessage{
+			{
+				Object: deploymentWrap.GetDeployment(),
+				Action: action,
+			},
+		}, nil))
+	}
+
 	return events
 }
 

--- a/sensor/kubernetes/listener/resources/deployments.go
+++ b/sensor/kubernetes/listener/resources/deployments.go
@@ -182,6 +182,16 @@ func (d *deploymentHandler) processWithType(obj, oldObj interface{}, action cent
 
 	if features.ResyncDisabled.Enabled() {
 		if action == central.ResourceAction_REMOVE_RESOURCE {
+			// At the moment we need to also send this deployment to the compatibility module when it's being deleted.
+			// Moving forward, there might be a different way to solve this, for example by changing the compatibility
+			// module to accept only deployment IDs rather than the entire deployment object. For more info on this
+			// check the PR comment here: https://github.com/stackrox/stackrox/pull/3695#discussion_r1030214615
+			events = component.MergeResourceEvents(events, component.NewResourceEvent(nil, []component.CompatibilityDetectionMessage{
+				{
+					Object: deploymentWrap.GetDeployment(),
+					Action: action,
+				},
+			}, nil))
 			// if resource is being removed, we can create the remove message here without related resources
 			events = component.MergeResourceEvents(events, component.NewResourceEvent([]*central.SensorEvent{deploymentWrap.toEvent(action)}, nil, nil))
 		} else {


### PR DESCRIPTION
Depends on #3653 

## Description

This will be used by a future component that can find deployments that need processing based on a `DeploymentReference` implementation. 

## Checklist
- [ ] Run tests locally with feature flag enabled
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

This is hidden behind a feature flag, and for now it's not supposed to work as is, because nothing consumes the `DeploymentReference` property. 
