### PR TITLE
ROX-13368: Skip failing nongroovy tests

### DIFF
--- a/tests/active_vuln_test.go
+++ b/tests/active_vuln_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/retry"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/pkg/testutils/centralgrpc"
@@ -72,6 +73,9 @@ type ComponentsAndVulnsWithActiveState struct {
 }
 
 func TestActiveVulnerability(t *testing.T) {
+	if env.PostgresDatastoreEnabled.BooleanSetting() {
+		t.Skip("ROX-13420")
+	}
 	waitForImageScanned(t)
 	for idx, tc := range nginxImages {
 		t.Run(tc.version, func(t *testing.T) {
@@ -91,6 +95,9 @@ func runTestActiveVulnerability(t *testing.T, idx int, testCase nginxImage) {
 }
 
 func TestActiveVulnerability_SetImage(t *testing.T) {
+	if env.PostgresDatastoreEnabled.BooleanSetting() {
+		t.Skip("ROX-13420")
+	}
 	waitForImageScanned(t)
 	setupDeploymentWithReplicas(t, nginxImages[0].getImage(), avmDeploymentName, 3)
 	defer teardownDeployment(t, avmDeploymentName)

--- a/tests/backup_test.go
+++ b/tests/backup_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/stackrox/rox/pkg/backup"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/migrations"
 	"github.com/stackrox/rox/pkg/tar"
 	"github.com/stackrox/rox/pkg/testutils/centralgrpc"
@@ -22,6 +23,10 @@ import (
 
 // Grab the backup DB and open it, ensuring that there are values for deployments
 func TestBackup(t *testing.T) {
+	if env.PostgresDatastoreEnabled.BooleanSetting() {
+		t.Skip("ROX-13420")
+	}
+
 	setupNginxLatestTagDeployment(t)
 	defer teardownNginxLatestTagDeployment(t)
 

--- a/tests/feature_flag_test.go
+++ b/tests/feature_flag_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/testutils/centralgrpc"
 	"github.com/stretchr/testify/assert"
@@ -14,6 +15,10 @@ import (
 
 func TestFeatureFlagSettings(t *testing.T) {
 	t.Parallel()
+
+	if env.PostgresDatastoreEnabled.BooleanSetting() {
+		t.Skip("ROX-13420")
+	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()

--- a/tests/roxctl/istio-support.sh
+++ b/tests/roxctl/istio-support.sh
@@ -58,10 +58,12 @@ test_roxctl_cmd() {
 
 test_roxctl_cmd central generate k8s none --output-format kubectl
 test_roxctl_cmd central generate openshift none
-test_roxctl_cmd sensor generate k8s --name k8s-istio-test-cluster  --continue-if-exists
-test_roxctl_cmd sensor get-bundle k8s-istio-test-cluster
-test_roxctl_cmd sensor generate openshift --name os-istio-test-cluster --continue-if-exists
-test_roxctl_cmd sensor get-bundle os-istio-test-cluster
+if [ -z "${ROX_POSTGRES_DATASTORE}" ] || [ "${ROX_POSTGRES_DATASTORE}" == "false" ]; then #TODO(ROX-13420): Fix and enable on postgres
+    test_roxctl_cmd sensor generate k8s --name k8s-istio-test-cluster  --continue-if-exists
+    test_roxctl_cmd sensor get-bundle k8s-istio-test-cluster
+    test_roxctl_cmd sensor generate openshift --name os-istio-test-cluster --continue-if-exists
+    test_roxctl_cmd sensor get-bundle os-istio-test-cluster
+fi
 
 if [ $FAILURES -eq 0 ]; then
   echo "Passed"


### PR DESCRIPTION
## Description

Let's skip failing non groovy tests on postgres and enable them later.

## Tests

To make if faster I created a test branch with PG enabled on nongroovy test
https://github.com/stackrox/stackrox/pull/3700