### PR TITLE
Implement permission checks for Collection UI routes and functionality

### DIFF
--- a/ui/apps/platform/src/Containers/AccessControl/PermissionSets/ResourceDescription.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/PermissionSets/ResourceDescription.tsx
@@ -61,6 +61,8 @@ const resourceDescriptions: Record<ResourceName, string> = {
         'Read: View all vulnerability report configurations. Write: Add, modify or delete vulnerability report configurations.',
     WatchedImage:
         'Read: View undeployed watched images monitored. Write: Configure watched images.',
+    WorkflowAdministration:
+        'Read: View all resource collections. Write: Add, modify, or delete resource collections.',
 };
 
 export type ResourceDescriptionProps = {

--- a/ui/apps/platform/src/Containers/Collections/CollectionsPage.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionsPage.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 
+import usePermissions from 'hooks/usePermissions';
 import useURLParameter from 'hooks/useURLParameter';
 
 import CollectionsTablePage from './CollectionsTablePage';
@@ -8,9 +9,8 @@ import CollectionsFormPage from './CollectionsFormPage';
 import { parsePageActionProp } from './collections.utils';
 
 function CollectionsPage() {
-    // TODO Implement permissions once https://issues.redhat.com/browse/ROX-12619 is merged
-    // const { hasWriteAccess } = usePermissions();
-    const hasWriteAccessForCollections = true; // hasWriteAccess('TODO');
+    const { hasReadWriteAccess } = usePermissions();
+    const hasWriteAccessForCollections = hasReadWriteAccess('WorkflowAdministration');
 
     const [pageAction, setPageAction] = useURLParameter('action', undefined);
     const { collectionId } = useParams();

--- a/ui/apps/platform/src/Containers/MainPage/Body.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Body.tsx
@@ -103,8 +103,7 @@ function Body({ hasReadAccess, isFeatureFlagEnabled }: BodyProps): ReactElement 
     const isNetworkGraphPatternflyEnabled = isFeatureFlagEnabled('ROX_NETWORK_GRAPH_PATTERNFLY');
 
     const hasVulnerabilityReportsPermission = hasReadAccess('VulnerabilityReports');
-    // TODO Implement permissions once https://issues.redhat.com/browse/ROX-12619 is merged
-    const hasCollectionsPermission = true; // hasReadAccess('TODO');
+    const hasCollectionsPermission = hasReadAccess('WorkflowAdministration');
 
     return (
         <div

--- a/ui/apps/platform/src/Containers/MainPage/Sidebar/NavigationSidebar.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Sidebar/NavigationSidebar.tsx
@@ -59,10 +59,7 @@ function NavigationSidebar({
         systemHealthPath,
     ];
 
-    // TODO
-    // - This must be restricted based on permissions once the BE is in place https://issues.redhat.com/browse/ROX-12695
-    // - See also https://issues.redhat.com/browse/ROX-12619
-    if (isFeatureFlagEnabled('ROX_OBJECT_COLLECTIONS')) {
+    if (isFeatureFlagEnabled('ROX_OBJECT_COLLECTIONS') && hasReadAccess('WorkflowAdministration')) {
         // Insert 'Collections' after 'Policy Management'
         platformConfigurationPaths.splice(
             platformConfigurationPaths.indexOf(policyManagementBasePath) + 1,

--- a/ui/apps/platform/src/types/roleResources.ts
+++ b/ui/apps/platform/src/types/roleResources.ts
@@ -34,6 +34,7 @@ export type ResourceName =
     | 'VulnerabilityManagementRequests'
     | 'VulnerabilityReports'
     | 'WatchedImage'
+    | 'WorkflowAdministration'
     // To-be-deprecated resources.
     | 'AllComments'
     | 'ComplianceRuns'


### PR DESCRIPTION
## Description

Adds permission checks for Collections under the 'WorkflowAdministration' permission.

NO_ACCESS
- The collection URLs will return a 404 page
- The collection link will not be visible in the sidebar nav

READ_ACCESS
- The collection link will be visible in the sidebar nav
- The collection table will display the full list of collection
        - Without the "Bulk action" dropdown
        - Without the table action items
        - Without the "Create collection" button
- Individual collection pages will display the collection details in a read only view
        - The action menu to edit/clone/delete the collection will not be visible

READ_WRITE_ACCESS
- The full feature set of collections will be available

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

For the following tests, I manually set a breakpoint and intercepted the permissions response, changing the returned value for the `WorkflowAdministration` permission.

**NO_ACCESS**

Viewing the UI with NO_ACCESS causes the Collection link to not be rendered in the sidebar. Attempting to bypass this and visiting the URL directly will return the standard 404 page.
<img width="1676" alt="image" src="https://user-images.githubusercontent.com/1292638/200029305-9e383e9e-aa3f-4ad4-90d3-55aa4365e002.png">

**READ_ACCESS**

The Collection link will be visible in the sidebar, and the user will be able to navigate to the collection page. The collection table will show a list of all collections, with name links. None of the controls that imply the ability to change a collection will be present:
- Bulk actions dropdown
- Individual row menu items (edit/clone/delete)
- Checkboxes to allow row selection
- The "Create collection" button

Visiting one of the individual collection pages will display the collection details in the read-only view. The action menu to allow editing/cloning/deleting a collection will not be present.
<img width="1676" alt="image" src="https://user-images.githubusercontent.com/1292638/200029884-829c56ae-ffc8-4c4a-8ef3-d32700ac9a20.png">
<img width="1676" alt="image" src="https://user-images.githubusercontent.com/1292638/200029902-ac1d9913-3425-470b-886a-613ecbca9eb0.png">

Attempting to directly enter a write-access-required URL will result in a regular rendering of the read-only page as well.
<img width="1676" alt="image" src="https://user-images.githubusercontent.com/1292638/200030129-6739ec31-e19c-4c6b-9de5-40411a3506f4.png">

**READ_WRITE_ACCESS**

Viewing the collection page with READ_WRITE_ACCESS will display all of the relevant collection controls.

On the collection table page:
<img width="1676" alt="image" src="https://user-images.githubusercontent.com/1292638/200030468-6eaf4492-cdb2-442d-8545-37b17de36151.png">

On the individual collection page:
<img width="1676" alt="image" src="https://user-images.githubusercontent.com/1292638/200030600-6d7fe99a-fcf9-4e19-b945-ebbbed0f037c.png">

Visiting the edit or clone pages will render an editable form:
<img width="1676" alt="image" src="https://user-images.githubusercontent.com/1292638/200030663-61f0e4b3-d471-4a2b-883b-4e7e88e3b0d3.png">

