### PR TITLE
for 3.72.2 fix diff in allowed-large-files

### DIFF
--- a/tools/allowed-large-files
+++ b/tools/allowed-large-files
@@ -5,6 +5,8 @@ central/alert/datastore/internal/store/postgres/store.go
 central/cluster/datastore/datastore_impl_test.go
 central/compliance/checks/fixtures/scraped.go
 central/compliance/standards/metadata/pci_dss_3_2.go
+central/cve/converter/utils/test-fixture-cve-list.json
+central/cve/fetcher/testdata/cve-list.json
 central/graphql/resolvers/generated.go
 central/networkpolicies/graph/evaluator_test.go
 central/pruning/pruning_test.go


### PR DESCRIPTION
Cherry-pick of #3532 failed with a merge conflict. This fixes that conflict to allow the automation to retry the cherry-pick.

A local test on this branch of `git cherry-pick -x 93c873d9cc430d55af88b7b16061d490f81e0d19` shows no conflict.

We could make a new PR for the changes in #3532, or manually cherry-pick and push but I am not familiar with all of the changes in the PR and fixing this merge-conflict has less manual-action risk.