### PR TITLE
Add more logs to DefaultPoliciesTest for debugging "Apache struts : CVE-2017-5638" CI flake

### DIFF
--- a/qa-tests-backend/src/main/groovy/util/Helpers.groovy
+++ b/qa-tests-backend/src/main/groovy/util/Helpers.groovy
@@ -144,7 +144,7 @@ class Helpers {
             FileWriter sout = new FileWriter(output)
             StringBuilder serr = new StringBuilder()
 
-            proc.consumeProcessOutput(sout, serr)
+            proc.waitForProcessOutput(sout, serr)
             proc.waitFor()
 
             if (proc.exitValue() != 0) {

--- a/qa-tests-backend/src/main/groovy/util/Helpers.groovy
+++ b/qa-tests-backend/src/main/groovy/util/Helpers.groovy
@@ -139,7 +139,7 @@ class Helpers {
             Path imageScans = Paths.get(Constants.FAILURE_DEBUG_DIR).resolve("image-scans")
             new File(imageScans.toAbsolutePath().toString()).mkdirs()
 
-            Process proc = "./scripts/ci/roxctl.sh image scan -i ${image}".execute(null, new File(".."))
+            Process proc = "./scripts/ci/roxctl.sh image scan -i ${image} -a -f".execute(null, new File(".."))
             String output = imageScans.resolve(saveName).toAbsolutePath()
             FileWriter sout = new FileWriter(output)
             StringBuilder serr = new StringBuilder()

--- a/qa-tests-backend/src/main/groovy/util/Helpers.groovy
+++ b/qa-tests-backend/src/main/groovy/util/Helpers.groovy
@@ -139,7 +139,7 @@ class Helpers {
             Path imageScans = Paths.get(Constants.FAILURE_DEBUG_DIR).resolve("image-scans")
             new File(imageScans.toAbsolutePath().toString()).mkdirs()
 
-            Process proc = "./scripts/ci/roxctl.sh image scan -i ${image} -a -f".execute(null, new File(".."))
+            Process proc = "./scripts/ci/roxctl.sh image scan -i ${image} -a".execute(null, new File(".."))
             String output = imageScans.resolve(saveName).toAbsolutePath()
             FileWriter sout = new FileWriter(output)
             StringBuilder serr = new StringBuilder()

--- a/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
@@ -187,11 +187,11 @@ class DefaultPoliciesTest extends BaseSpecification {
             log.info "Temporarily enabled policy '${policyName}'"
             policyEnabled = true
         }
-        // debugging to see if the test fails due to incomplete scan
+        //TODO ROX-11612 debugging to see if the test fails due to incomplete scan
         if (policyName == "Apache Struts: CVE-2017-5638") {
             def image = ImageService.scanImage("library/nginx:1.10", true)
             if (!hasApacheStrutsVuln(image)) {
-                log.warn("[Apache struts] CVE-2017-5638 is absent from image scan")
+                log.warn("[ROX-11612] CVE-2017-5638 is absent from image scan")
             }
         }
 


### PR DESCRIPTION
## Description

Added warnings when struts component or CVE-2017-5638 is not present in the scan. Also, the helper function used to get the image scan and log it did not wait to consume the complete output. The PR fixes that too.

## Checklist
- [ ] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed


In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
