### PR TITLE
ROX-13067: fill out port configurations section of deployment details

### DIFF
--- a/ui/apps/platform/src/Components/DeploymentPortConfig.tsx
+++ b/ui/apps/platform/src/Components/DeploymentPortConfig.tsx
@@ -1,0 +1,146 @@
+import React, { useState } from 'react';
+import {
+    Card,
+    CardBody,
+    DescriptionList,
+    DescriptionListDescription,
+    DescriptionListGroup,
+    DescriptionListTerm,
+    ExpandableSection,
+    Stack,
+    StackItem,
+} from '@patternfly/react-core';
+
+import { PortConfig } from 'types/deployment.proto';
+
+type DeploymentPortConfigProps = {
+    port: PortConfig;
+};
+
+function DeploymentPortConfig({ port }: DeploymentPortConfigProps) {
+    const [isExpanded, setIsExpanded] = useState(false);
+
+    const onToggle = (_isExpanded: boolean) => {
+        setIsExpanded(_isExpanded);
+    };
+
+    return (
+        <ExpandableSection
+            toggleText={port.name}
+            onToggle={onToggle}
+            isExpanded={isExpanded}
+            displaySize="large"
+            isWidthLimited
+        >
+            <Stack hasGutter>
+                <StackItem>
+                    <DescriptionList columnModifier={{ default: '2Col' }} isCompact>
+                        <DescriptionListGroup>
+                            <DescriptionListTerm>Container port</DescriptionListTerm>
+                            <DescriptionListDescription>
+                                {port.containerPort}
+                            </DescriptionListDescription>
+                        </DescriptionListGroup>
+                        <DescriptionListGroup>
+                            <DescriptionListTerm>Protocol</DescriptionListTerm>
+                            <DescriptionListDescription>{port.protocol}</DescriptionListDescription>
+                        </DescriptionListGroup>
+                        <DescriptionListGroup>
+                            <DescriptionListTerm>Exposure</DescriptionListTerm>
+                            <DescriptionListDescription>{port.exposure}</DescriptionListDescription>
+                        </DescriptionListGroup>
+                        <DescriptionListGroup>
+                            <DescriptionListTerm>Exposed port</DescriptionListTerm>
+                            <DescriptionListDescription>
+                                {port.exposedPort}
+                            </DescriptionListDescription>
+                        </DescriptionListGroup>
+                    </DescriptionList>
+                </StackItem>
+                <StackItem>
+                    <Stack hasGutter>
+                        {port.exposureInfos.map((exposureInfo) => {
+                            return (
+                                <StackItem>
+                                    <Card isFlat>
+                                        <CardBody>
+                                            <DescriptionList
+                                                columnModifier={{ default: '2Col' }}
+                                                isCompact
+                                            >
+                                                <DescriptionListGroup>
+                                                    <DescriptionListTerm>Level</DescriptionListTerm>
+                                                    <DescriptionListDescription>
+                                                        {exposureInfo.level}
+                                                    </DescriptionListDescription>
+                                                </DescriptionListGroup>
+                                                <DescriptionListGroup>
+                                                    <DescriptionListTerm>
+                                                        Service Name
+                                                    </DescriptionListTerm>
+                                                    <DescriptionListDescription>
+                                                        {exposureInfo.serviceName}
+                                                    </DescriptionListDescription>
+                                                </DescriptionListGroup>
+                                                <DescriptionListGroup>
+                                                    <DescriptionListTerm>
+                                                        Service ID
+                                                    </DescriptionListTerm>
+                                                    <DescriptionListDescription>
+                                                        {exposureInfo.serviceId}
+                                                    </DescriptionListDescription>
+                                                </DescriptionListGroup>
+                                                <DescriptionListGroup>
+                                                    <DescriptionListTerm>
+                                                        Service Cluster IP
+                                                    </DescriptionListTerm>
+                                                    <DescriptionListDescription>
+                                                        {exposureInfo.serviceClusterIp}
+                                                    </DescriptionListDescription>
+                                                </DescriptionListGroup>
+                                                <DescriptionListGroup>
+                                                    <DescriptionListTerm>
+                                                        Service Port
+                                                    </DescriptionListTerm>
+                                                    <DescriptionListDescription>
+                                                        {exposureInfo.servicePort}
+                                                    </DescriptionListDescription>
+                                                </DescriptionListGroup>
+                                                <DescriptionListGroup>
+                                                    <DescriptionListTerm>
+                                                        Node Port
+                                                    </DescriptionListTerm>
+                                                    <DescriptionListDescription>
+                                                        {exposureInfo.nodePort}
+                                                    </DescriptionListDescription>
+                                                </DescriptionListGroup>
+                                                <DescriptionListGroup>
+                                                    <DescriptionListTerm>
+                                                        External IPs
+                                                    </DescriptionListTerm>
+                                                    <DescriptionListDescription>
+                                                        -
+                                                    </DescriptionListDescription>
+                                                </DescriptionListGroup>
+                                                <DescriptionListGroup>
+                                                    <DescriptionListTerm>
+                                                        External Hostnames
+                                                    </DescriptionListTerm>
+                                                    <DescriptionListDescription>
+                                                        -
+                                                    </DescriptionListDescription>
+                                                </DescriptionListGroup>
+                                            </DescriptionList>
+                                        </CardBody>
+                                    </Card>
+                                </StackItem>
+                            );
+                        })}
+                    </Stack>
+                </StackItem>
+            </Stack>
+        </ExpandableSection>
+    );
+}
+
+export default DeploymentPortConfig;

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentDetails.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentDetails.tsx
@@ -20,9 +20,11 @@ import {
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import pluralize from 'pluralize';
 
-import { Deployment } from 'types/deployment.proto';
+import { Deployment, PortConfig } from 'types/deployment.proto';
 import { ListenPort } from 'types/networkFlow.proto';
 import { getDateTime } from 'utils/dateUtils';
+
+import DeploymentPortConfig from 'Components/DeploymentPortConfig';
 
 type DeploymentDetailsProps = {
     deployment: Deployment;
@@ -30,6 +32,47 @@ type DeploymentDetailsProps = {
     numInternalFlows: number;
     listenPorts: ListenPort[];
 };
+
+const mockPorts: PortConfig[] = [
+    {
+        name: 'api',
+        containerPort: 8443,
+        protocol: 'TCP',
+        exposure: 'INTERNAL',
+        exposedPort: 0,
+        exposureInfos: [
+            {
+                level: 'INTERNAL',
+                serviceName: 'sensor',
+                serviceId: 'b830c97f-7ecf-49c7-898c-ea9c68f2e131',
+                serviceClusterIp: '10.73.232.126',
+                servicePort: 443,
+                nodePort: 0,
+                externalIps: [],
+                externalHostnames: [],
+            },
+        ],
+    },
+    {
+        name: 'webhook',
+        containerPort: 9443,
+        protocol: 'TCP',
+        exposure: 'INTERNAL',
+        exposedPort: 0,
+        exposureInfos: [
+            {
+                level: 'INTERNAL',
+                serviceName: 'sensor-webhook',
+                serviceId: '3d879536-0521-4a52-9a8e-d33b4aa75ca5',
+                serviceClusterIp: '10.73.232.21',
+                servicePort: 443,
+                nodePort: 0,
+                externalIps: [],
+                externalHostnames: [],
+            },
+        ],
+    },
+];
 
 function DetailSection({ title, children }) {
     const [isExpanded, setIsExpanded] = useState(true);
@@ -248,7 +291,15 @@ function DeploymentDetails({
                 <Divider component="li" className="pf-u-mb-sm" />
                 <li>
                     <DetailSection title="Port configurations">
-                        @TODO: Add port configurations section
+                        <Stack hasGutter>
+                            {mockPorts.map((port) => {
+                                return (
+                                    <StackItem>
+                                        <DeploymentPortConfig port={port} />
+                                    </StackItem>
+                                );
+                            })}
+                        </Stack>
                     </DetailSection>
                 </li>
             </ul>


### PR DESCRIPTION
## Description

This PR fills out the port configurations section of the deployment details page. This is an iterative addition. You can find all the subtasks here:
https://issues.redhat.com/browse/ROX-12903

NOTE: I decided to break this down further. I will add real data for the network policy section and port config section of the details page in a separate PR

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

<img width="1552" alt="Screenshot 2022-11-04 at 4 22 14 PM" src="https://user-images.githubusercontent.com/4805485/200088550-a845ae41-30d1-46d1-99c1-02198ed74fe9.png">

