### PR TITLE
ROX-9858: Override central-db img with RELATED_IMAGE_CENTRAL_DB

### DIFF
--- a/operator/pkg/central/values/translation/image_overrides.go
+++ b/operator/pkg/central/values/translation/image_overrides.go
@@ -5,6 +5,7 @@ import "github.com/stackrox/rox/operator/pkg/images"
 var (
 	imageOverrides = images.Overrides{
 		images.Main:      "central.image.fullRef",
+		images.CentralDB: "central.db.image.fullRef",
 		images.Scanner:   "scanner.image.fullRef",
 		images.ScannerDB: "scanner.dbImage.fullRef",
 	}

--- a/operator/pkg/images/env.go
+++ b/operator/pkg/images/env.go
@@ -5,6 +5,7 @@ import "github.com/stackrox/rox/pkg/env"
 // Environment variable settings for related image overrides.
 var (
 	Main          = env.RegisterSetting("RELATED_IMAGE_MAIN")
+	CentralDB     = env.RegisterSetting("RELATED_IMAGE_CENTRAL_DB")
 	Scanner       = env.RegisterSetting("RELATED_IMAGE_SCANNER")
 	ScannerSlim   = env.RegisterSetting("RELATED_IMAGE_SCANNER_SLIM")
 	ScannerDB     = env.RegisterSetting("RELATED_IMAGE_SCANNER_DB")


### PR DESCRIPTION
## Description

This is needed for OpenShift operator deployments with images built downstream where `RELATED_IMAGE_CENTRAL_DB` variable (and similar ones for other images) get injected concrete image pull specs at the build time.

For example
```
- name: RELATED_IMAGE_DOCS
  value: registry.redhat.io/advanced-cluster-security/rhacs-docs-rhel8@sha256:f7fba1cb18a970d3dad81d766f97710c612763de7df9a98cbbc9f8447d5768a2
- name: RELATED_IMAGE_CENTRAL_DB
  value: registry.redhat.io/advanced-cluster-security/rhacs-central-db-rhel8@sha256:e247978017ee920218e26099f7fea9c63d29bf94fed1a0de5c0c8007cf5b8d37
```

This follows up on https://github.com/stackrox/stackrox/pull/3643 and should hopefully complete that change.

If this change is not done, `central-db` image gets deployed as `registry.redhat.io/advanced-cluster-security/rhacs-central-db-rhel8:1.0.0` which is wrong. It must be deployed using spec that's provided in `RELATED_IMAGE_CENTRAL_DB` environment variable.

## Checklist
- [x] Investigated and inspected CI test results
- ~~[ ] Unit test and regression tests added~~ - not this time :-(

These don't matter here and won't be done:
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

* None. Will test manually with images built downstream.
