### PR TITLE
ROX-13378: Access Control page permissions

### DIFF
--- a/ui/apps/platform/cypress/integration/accessControl/accessControlAccessScopes.test.js
+++ b/ui/apps/platform/cypress/integration/accessControl/accessControlAccessScopes.test.js
@@ -29,13 +29,9 @@ describe('Access Control Access scopes', () => {
         cy.wait('@GetMyPermissions');
 
         cy.get(selectors.h1).should('have.text', h1);
-        cy.get(selectors.navLink).should('not.exist');
-
-        cy.get(selectors.h2).should('not.exist');
-
         cy.get(selectors.alertTitle).should(
             'contain', // not have.text because it contains "Info alert:" for screen reader
-            'You do not have permission to view Access Control'
+            'You do not have permission to view access scopes.'
         );
     });
 

--- a/ui/apps/platform/cypress/integration/accessControl/accessControlAuthProviders.test.js
+++ b/ui/apps/platform/cypress/integration/accessControl/accessControlAuthProviders.test.js
@@ -54,12 +54,10 @@ describe('Access Control Auth providers', () => {
         visitWithStaticResponseForPermissions(authProvidersUrl, staticResponseForPermissions);
 
         cy.get(`${selectors.h1}:contains("${h1}")`);
-        cy.get(selectors.navLink).should('not.exist');
-        cy.get(selectors.h2).should('not.exist');
 
         cy.get(selectors.alertTitle).should(
             'contain', // instead of have.text because of "Info alert:" for screen reader
-            'You do not have permission to view Access Control'
+            'You do not have permission to view auth providers.'
         );
     });
 

--- a/ui/apps/platform/cypress/integration/accessControl/accessControlPermissionSets.test.js
+++ b/ui/apps/platform/cypress/integration/accessControl/accessControlPermissionSets.test.js
@@ -35,13 +35,10 @@ describe('Access Control Permission sets', () => {
         cy.wait('@GetMyPermissions');
 
         cy.get(selectors.h1).should('have.text', h1);
-        cy.get(selectors.navLink).should('not.exist');
-
-        cy.get(selectors.h2).should('not.exist');
 
         cy.get(selectors.alertTitle).should(
             'contain', // not have.text because it contains "Info alert:" for screen reader
-            'You do not have permission to view Access Control'
+            'You do not have permission to view permission sets.'
         );
     });
 

--- a/ui/apps/platform/cypress/integration/accessControl/accessControlRoles.test.js
+++ b/ui/apps/platform/cypress/integration/accessControl/accessControlRoles.test.js
@@ -37,13 +37,10 @@ describe('Access Control Roles', () => {
         cy.wait('@GetMyPermissions');
 
         cy.get(selectors.h1).should('have.text', h1);
-        cy.get(selectors.navLink).should('not.exist');
-
-        cy.get(selectors.h2).should('not.exist');
 
         cy.get(selectors.alertTitle).should(
             'contain', // not have.text because it contains "Info alert:" for screen reader
-            'You do not have permission to view Access Control'
+            'You do not have permission to view roles.'
         );
     });
 

--- a/ui/apps/platform/src/Containers/AccessControl/AccessControl.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessControl.tsx
@@ -14,7 +14,7 @@ import AccessControlNoPermission from './AccessControlNoPermission';
 
 const paramId = ':entityId?';
 
-function AccessControl(): ReactElement {
+export function AccessControl(): ReactElement {
     // TODO is read access required for all routes in improved Access Control?
     // TODO Is write access required anywhere in classic Access Control?
     const { hasReadAccess } = usePermissions();
@@ -102,5 +102,3 @@ function AccessControl(): ReactElement {
         </>
     );
 }
-
-export default AccessControl;

--- a/ui/apps/platform/src/Containers/AccessControl/AccessControl.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessControl.tsx
@@ -14,7 +14,7 @@ import AccessControlNoPermission from './AccessControlNoPermission';
 
 const paramId = ':entityId?';
 
-export function AccessControl(): ReactElement {
+function AccessControl(): ReactElement {
     // TODO is read access required for all routes in improved Access Control?
     // TODO Is write access required anywhere in classic Access Control?
     const { hasReadAccess } = usePermissions();
@@ -102,3 +102,5 @@ export function AccessControl(): ReactElement {
         </>
     );
 }
+
+export default AccessControl;

--- a/ui/apps/platform/src/Containers/AccessControl/AccessControl.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessControl.tsx
@@ -9,16 +9,10 @@ import AccessScopes from './AccessScopes/AccessScopes';
 import AuthProviders from './AuthProviders/AuthProviders';
 import PermissionSets from './PermissionSets/PermissionSets';
 import Roles from './Roles/Roles';
-import usePermissions from '../../hooks/usePermissions';
-import AccessControlNoPermission from './AccessControlNoPermission';
 
 const paramId = ':entityId?';
 
 function AccessControl(): ReactElement {
-    // TODO is read access required for all routes in improved Access Control?
-    // TODO Is write access required anywhere in classic Access Control?
-    const { hasReadAccess } = usePermissions();
-
     return (
         <>
             <Alert
@@ -71,34 +65,30 @@ function AccessControl(): ReactElement {
                     </>
                 }
             />
-            {hasReadAccess('Access') || hasReadAccess('Role') ? (
-                <Switch>
-                    <Route exact path={accessControlBasePath}>
-                        <Redirect to={getEntityPath('AUTH_PROVIDER')} />
-                    </Route>
-                    <Route path={accessControlPath}>
-                        <Switch>
-                            <Route path={getEntityPath('AUTH_PROVIDER', paramId)}>
-                                <AuthProviders />
-                            </Route>
-                            <Route path={getEntityPath('ROLE', paramId)}>
-                                <Roles />
-                            </Route>
-                            <Route path={getEntityPath('PERMISSION_SET', paramId)}>
-                                <PermissionSets />
-                            </Route>
-                            <Route path={getEntityPath('ACCESS_SCOPE', paramId)}>
-                                <AccessScopes />
-                            </Route>
-                            <Route>
-                                <AccessControlRouteNotFound />
-                            </Route>
-                        </Switch>
-                    </Route>
-                </Switch>
-            ) : (
-                <AccessControlNoPermission subPage="Access Control" isNavHidden />
-            )}
+            <Switch>
+                <Route exact path={accessControlBasePath}>
+                    <Redirect to={getEntityPath('AUTH_PROVIDER')} />
+                </Route>
+                <Route path={accessControlPath}>
+                    <Switch>
+                        <Route path={getEntityPath('AUTH_PROVIDER', paramId)}>
+                            <AuthProviders />
+                        </Route>
+                        <Route path={getEntityPath('ROLE', paramId)}>
+                            <Roles />
+                        </Route>
+                        <Route path={getEntityPath('PERMISSION_SET', paramId)}>
+                            <PermissionSets />
+                        </Route>
+                        <Route path={getEntityPath('ACCESS_SCOPE', paramId)}>
+                            <AccessScopes />
+                        </Route>
+                        <Route>
+                            <AccessControlRouteNotFound />
+                        </Route>
+                    </Switch>
+                </Route>
+            </Switch>
         </>
     );
 }

--- a/ui/apps/platform/src/Containers/AccessControl/AccessControl.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessControl.tsx
@@ -1,17 +1,16 @@
 import React, { ReactElement } from 'react';
 import { Redirect, Route, Switch } from 'react-router-dom';
 
-import usePermissions from 'hooks/usePermissions';
-
 import { Alert, List, ListItem } from '@patternfly/react-core';
 import { accessControlBasePath, accessControlPath, getEntityPath } from './accessControlPaths';
 
-import AccessControlNoPermission from './AccessControlNoPermission';
 import AccessControlRouteNotFound from './AccessControlRouteNotFound';
 import AccessScopes from './AccessScopes/AccessScopes';
 import AuthProviders from './AuthProviders/AuthProviders';
 import PermissionSets from './PermissionSets/PermissionSets';
 import Roles from './Roles/Roles';
+import usePermissions from '../../hooks/usePermissions';
+import AccessControlNoPermission from './AccessControlNoPermission';
 
 const paramId = ':entityId?';
 
@@ -19,7 +18,6 @@ function AccessControl(): ReactElement {
     // TODO is read access required for all routes in improved Access Control?
     // TODO Is write access required anywhere in classic Access Control?
     const { hasReadAccess } = usePermissions();
-    const hasReadAccessForAccessControlPages = hasReadAccess('Access');
 
     return (
         <>
@@ -73,7 +71,7 @@ function AccessControl(): ReactElement {
                     </>
                 }
             />
-            {hasReadAccessForAccessControlPages ? (
+            {hasReadAccess('Access') || hasReadAccess('Role') ? (
                 <Switch>
                     <Route exact path={accessControlBasePath}>
                         <Redirect to={getEntityPath('AUTH_PROVIDER')} />
@@ -99,7 +97,7 @@ function AccessControl(): ReactElement {
                     </Route>
                 </Switch>
             ) : (
-                <AccessControlNoPermission />
+                <AccessControlNoPermission subPage="Access Control" isNavHidden />
             )}
         </>
     );

--- a/ui/apps/platform/src/Containers/AccessControl/AccessControlNoPermission.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessControlNoPermission.tsx
@@ -21,7 +21,7 @@ function AccessControlNoPermission({
             <PageSection variant={PageSectionVariants.light}>
                 <Alert
                     className="pf-u-mt-md"
-                    title={`You do not have permission to view ${subPage}`}
+                    title={`You do not have permission to view ${subPage}. To access this page, you should have access to both Role and Access resources.`}
                     variant={AlertVariant.info}
                     isInline
                 />

--- a/ui/apps/platform/src/Containers/AccessControl/AccessControlNoPermission.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessControlNoPermission.tsx
@@ -2,15 +2,24 @@ import React, { ReactElement } from 'react';
 import { Alert, AlertVariant, PageSection, PageSectionVariants } from '@patternfly/react-core';
 
 import AccessControlHeading from './AccessControlHeading';
+import { AccessControlEntityType } from '../../constants/entityTypes';
 
-function AccessControlNoPermission(): ReactElement {
+type AccessControlNoPermissionProps = {
+    subPage: string;
+    entityType: AccessControlEntityType;
+};
+
+function AccessControlNoPermission({
+    subPage,
+    entityType,
+}: AccessControlNoPermissionProps): ReactElement {
     return (
         <>
-            <AccessControlHeading isNavHidden />
+            <AccessControlHeading entityType={entityType} />
             <PageSection variant={PageSectionVariants.light}>
                 <Alert
                     className="pf-u-mt-md"
-                    title="You do not have permission to view Access Control"
+                    title={`You do not have permission to view ${subPage}`}
                     variant={AlertVariant.info}
                     isInline
                 />

--- a/ui/apps/platform/src/Containers/AccessControl/AccessControlNoPermission.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessControlNoPermission.tsx
@@ -6,16 +6,18 @@ import { AccessControlEntityType } from '../../constants/entityTypes';
 
 type AccessControlNoPermissionProps = {
     subPage: string;
-    entityType: AccessControlEntityType;
+    entityType?: AccessControlEntityType;
+    isNavHidden?: boolean;
 };
 
 function AccessControlNoPermission({
     subPage,
     entityType,
+    isNavHidden = false,
 }: AccessControlNoPermissionProps): ReactElement {
     return (
         <>
-            <AccessControlHeading entityType={entityType} />
+            <AccessControlHeading isNavHidden={isNavHidden} entityType={entityType} />
             <PageSection variant={PageSectionVariants.light}>
                 <Alert
                     className="pf-u-mt-md"

--- a/ui/apps/platform/src/Containers/AccessControl/AccessScopes/AccessScopeFormWrapper.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessScopes/AccessScopeFormWrapper.tsx
@@ -23,6 +23,7 @@ import {
     getIsValidRules,
 } from './accessScopes.utils';
 import AccessScopeForm from './AccessScopeForm';
+import usePermissions from '../../../hooks/usePermissions';
 
 export type AccessScopeFormWrapperProps = {
     isActionable: boolean;
@@ -45,6 +46,8 @@ function AccessScopeFormWrapper({
 }: AccessScopeFormWrapperProps): ReactElement {
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [alertSubmit, setAlertSubmit] = useState<ReactElement | null>(null);
+    const { hasReadWriteAccess } = usePermissions();
+    const hasWriteAccessForPage = hasReadWriteAccess('Role') && hasReadWriteAccess('Access');
 
     // Disable Save button while editing label selectors.
     const [labelSelectorsEditingState, setLabelSelectorsEditingState] =
@@ -127,7 +130,7 @@ function AccessScopeFormWrapper({
                                     <Button
                                         variant="primary"
                                         onClick={handleEdit}
-                                        isDisabled={action === 'edit'}
+                                        isDisabled={!hasWriteAccessForPage || action === 'edit'}
                                         isSmall
                                     >
                                         Edit access scope

--- a/ui/apps/platform/src/Containers/AccessControl/AccessScopes/AccessScopes.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessScopes/AccessScopes.tsx
@@ -105,6 +105,15 @@ function AccessScopes(): ReactElement {
             });
     }, []);
 
+    // Return "no access" page immediately if user doesn't have enough permissions.
+    if (!hasReadAccessForAccessScopes) {
+        return (
+            <>
+                <AccessControlNoPermission subPage="access scopes" entityType={entityType} />
+            </>
+        );
+    }
+
     function handleCreate() {
         history.push(getEntityPath(entityType, undefined, { action: 'create' }));
     }
@@ -152,14 +161,6 @@ function AccessScopes(): ReactElement {
     const accessScope = accessScopes.find(({ id }) => id === entityId);
     const hasAction = Boolean(action);
     const isList = typeof entityId !== 'string' && !hasAction;
-
-    if (!hasReadAccessForAccessScopes) {
-        return (
-            <>
-                <AccessControlNoPermission subPage="access scopes" entityType={entityType} />
-            </>
-        );
-    }
 
     return (
         <>

--- a/ui/apps/platform/src/Containers/AccessControl/AccessScopes/AccessScopes.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessScopes/AccessScopes.tsx
@@ -40,8 +40,9 @@ import usePermissions from '../../../hooks/usePermissions';
 const entityType = 'ACCESS_SCOPE';
 
 function AccessScopes(): ReactElement {
-    const { hasReadAccess } = usePermissions();
-    const hasReadAccessForAccessScopes = hasReadAccess('Role');
+    const { hasReadAccess, hasReadWriteAccess } = usePermissions();
+    const hasReadAccessToPage = hasReadAccess('Role') && hasReadAccess('Access');
+    const hasWriteAccessForPage = hasReadWriteAccess('Role') && hasReadWriteAccess('Access');
     const history = useHistory();
     const { search } = useLocation();
     const queryObject = getQueryObject(search);
@@ -106,7 +107,7 @@ function AccessScopes(): ReactElement {
     }, []);
 
     // Return "no access" page immediately if user doesn't have enough permissions.
-    if (!hasReadAccessForAccessScopes) {
+    if (!hasReadAccessToPage) {
         return (
             <>
                 <AccessControlNoPermission subPage="access scopes" entityType={entityType} />
@@ -176,7 +177,11 @@ function AccessScopes(): ReactElement {
                             </AccessControlDescription>
                         }
                         actionComponent={
-                            <Button variant="primary" onClick={handleCreate}>
+                            <Button
+                                isDisabled={!hasWriteAccessForPage}
+                                variant="primary"
+                                onClick={handleCreate}
+                            >
                                 Create access scope
                             </Button>
                         }

--- a/ui/apps/platform/src/Containers/AccessControl/AccessScopes/AccessScopes.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessScopes/AccessScopes.tsx
@@ -34,10 +34,14 @@ import './AccessScopes.css';
 import AccessControlHeading from '../AccessControlHeading';
 import AccessControlBreadcrumbs from '../AccessControlBreadcrumbs';
 import AccessControlHeaderActionBar from '../AccessControlHeaderActionBar';
+import AccessControlNoPermission from '../AccessControlNoPermission';
+import usePermissions from '../../../hooks/usePermissions';
 
 const entityType = 'ACCESS_SCOPE';
 
 function AccessScopes(): ReactElement {
+    const { hasReadAccess } = usePermissions();
+    const hasReadAccessForAccessScopes = hasReadAccess('Role');
     const history = useHistory();
     const { search } = useLocation();
     const queryObject = getQueryObject(search);
@@ -148,6 +152,14 @@ function AccessScopes(): ReactElement {
     const accessScope = accessScopes.find(({ id }) => id === entityId);
     const hasAction = Boolean(action);
     const isList = typeof entityId !== 'string' && !hasAction;
+
+    if (!hasReadAccessForAccessScopes) {
+        return (
+            <>
+                <AccessControlNoPermission subPage="Access Scopes" entityType={entityType} />
+            </>
+        );
+    }
 
     return (
         <>

--- a/ui/apps/platform/src/Containers/AccessControl/AccessScopes/AccessScopes.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessScopes/AccessScopes.tsx
@@ -156,7 +156,7 @@ function AccessScopes(): ReactElement {
     if (!hasReadAccessForAccessScopes) {
         return (
             <>
-                <AccessControlNoPermission subPage="Access Scopes" entityType={entityType} />
+                <AccessControlNoPermission subPage="access scopes" entityType={entityType} />
             </>
         );
     }

--- a/ui/apps/platform/src/Containers/AccessControl/AccessScopes/AccessScopesList.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessScopes/AccessScopesList.tsx
@@ -15,6 +15,7 @@ import { AccessScope, getIsDefaultAccessScopeId } from 'services/AccessScopesSer
 import { Role } from 'services/RolesService';
 
 import { AccessControlEntityLink, RolesLink } from '../AccessControlLinks';
+import usePermissions from '../../../hooks/usePermissions';
 
 const entityType = 'ACCESS_SCOPE';
 
@@ -32,6 +33,8 @@ function AccessScopesList({
     const [idDeleting, setIdDeleting] = useState('');
     const [nameConfirmingDelete, setNameConfirmingDelete] = useState<string | null>(null);
     const [alertDelete, setAlertDelete] = useState<ReactElement | null>(null);
+    const { hasReadWriteAccess } = usePermissions();
+    const hasWriteAccessForPage = hasReadWriteAccess('Role') && hasReadWriteAccess('Access');
 
     function onClickDelete(id: string) {
         setIdDeleting(id);
@@ -101,6 +104,7 @@ function AccessScopesList({
                             <Td
                                 actions={{
                                     disable:
+                                        !hasWriteAccessForPage ||
                                         idDeleting === id ||
                                         getIsDefaultAccessScopeId(id) ||
                                         roles.some(({ accessScopeId }) => accessScopeId === id),

--- a/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviders.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviders.tsx
@@ -100,6 +100,15 @@ function AuthProviders(): ReactElement {
         }
     }, [dispatch, hasReadAccessForAuthProviders, hasReadAccessForRoles]);
 
+    // Return "no access" page immediately if user doesn't have enough permissions.
+    if (!hasReadAccessForAuthProviders) {
+        return (
+            <>
+                <AccessControlNoPermission subPage="auth providers" entityType={entityType} />
+            </>
+        );
+    }
+
     function onToggleCreateMenu(isOpen) {
         setIsCreateMenuOpen(isOpen);
     }
@@ -146,14 +155,6 @@ function AuthProviders(): ReactElement {
             {label}
         </DropdownItem>
     ));
-
-    if (!hasReadAccessForAuthProviders) {
-        return (
-            <>
-                <AccessControlNoPermission subPage="auth providers" entityType={entityType} />
-            </>
-        );
-    }
 
     return (
         <>

--- a/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviders.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviders.tsx
@@ -39,6 +39,8 @@ import AuthProvidersList from './AuthProvidersList';
 import AccessControlBreadcrumbs from '../AccessControlBreadcrumbs';
 import AccessControlHeading from '../AccessControlHeading';
 import AccessControlHeaderActionBar from '../AccessControlHeaderActionBar';
+import usePermissions from '../../../hooks/usePermissions';
+import AccessControlNoPermission from '../AccessControlNoPermission';
 
 const entityType = 'AUTH_PROVIDER';
 
@@ -65,6 +67,9 @@ function getNewAuthProviderObj(type) {
 }
 
 function AuthProviders(): ReactElement {
+    const { hasReadAccess } = usePermissions();
+    const hasReadAccessForAuthProviders = hasReadAccess('Access');
+    const hasReadAccessForRoles = hasReadAccess('Role');
     const history = useHistory();
     const { search } = useLocation();
     const queryObject = getQueryObject(search);
@@ -138,6 +143,14 @@ function AuthProviders(): ReactElement {
         </DropdownItem>
     ));
 
+    if (!hasReadAccessForAuthProviders) {
+        return (
+            <>
+                <AccessControlNoPermission subPage="Auth providers" entityType={entityType} />
+            </>
+        );
+    }
+
     return (
         <>
             <AccessControlPageTitle entityType={entityType} isList={isList} />
@@ -184,7 +197,7 @@ function AuthProviders(): ReactElement {
                 />
             )}
             <PageSection variant={isList ? 'default' : 'light'}>
-                {isFetchingAuthProviders || isFetchingRoles ? (
+                {isFetchingAuthProviders || (isFetchingRoles && hasReadAccessForRoles) ? (
                     <Bullseye>
                         <Spinner isSVG />
                     </Bullseye>

--- a/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviders.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviders.tsx
@@ -146,7 +146,7 @@ function AuthProviders(): ReactElement {
     if (!hasReadAccessForAuthProviders) {
         return (
             <>
-                <AccessControlNoPermission subPage="Auth providers" entityType={entityType} />
+                <AccessControlNoPermission subPage="auth providers" entityType={entityType} />
             </>
         );
     }

--- a/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviders.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviders.tsx
@@ -91,10 +91,14 @@ function AuthProviders(): ReactElement {
     const authProvidersWithRules = mergeGroupsWithAuthProviders(authProviders, groups);
 
     useEffect(() => {
-        dispatch(authActions.fetchAuthProviders.request());
-        dispatch(roleActions.fetchRoles.request());
-        dispatch(groupActions.fetchGroups.request());
-    }, [dispatch]);
+        if (hasReadAccessForAuthProviders) {
+            dispatch(authActions.fetchAuthProviders.request());
+        }
+        if (hasReadAccessForRoles) {
+            dispatch(roleActions.fetchRoles.request());
+            dispatch(groupActions.fetchGroups.request());
+        }
+    }, [dispatch, hasReadAccessForAuthProviders, hasReadAccessForRoles]);
 
     function onToggleCreateMenu(isOpen) {
         setIsCreateMenuOpen(isOpen);

--- a/ui/apps/platform/src/Containers/AccessControl/PermissionSets/PermissionSetForm.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/PermissionSets/PermissionSetForm.tsx
@@ -23,6 +23,7 @@ import { PermissionSet } from 'services/RolesService';
 import { AccessControlQueryAction } from '../accessControlPaths';
 
 import PermissionsTable from './PermissionsTable';
+import usePermissions from '../../../hooks/usePermissions';
 
 export type PermissionSetFormProps = {
     isActionable: boolean;
@@ -45,6 +46,8 @@ function PermissionSetForm({
 }: PermissionSetFormProps): ReactElement {
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [alertSubmit, setAlertSubmit] = useState<ReactElement | null>(null);
+    const { hasReadWriteAccess } = usePermissions();
+    const hasWriteAccessForPage = hasReadWriteAccess('Role') && hasReadWriteAccess('Access');
 
     const { dirty, errors, handleChange, isValid, resetForm, setFieldValue, values } = useFormik({
         initialValues: permissionSet,
@@ -128,7 +131,7 @@ function PermissionSetForm({
                                     <Button
                                         variant="primary"
                                         onClick={handleEdit}
-                                        isDisabled={action === 'edit'}
+                                        isDisabled={!hasWriteAccessForPage || action === 'edit'}
                                         isSmall
                                     >
                                         Edit permission set

--- a/ui/apps/platform/src/Containers/AccessControl/PermissionSets/PermissionSets.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/PermissionSets/PermissionSets.tsx
@@ -41,8 +41,9 @@ import usePermissions from '../../../hooks/usePermissions';
 const entityType = 'PERMISSION_SET';
 
 function PermissionSets(): ReactElement {
-    const { hasReadAccess } = usePermissions();
-    const hasReadAccessForPermissionSets = hasReadAccess('Role');
+    const { hasReadAccess, hasReadWriteAccess } = usePermissions();
+    const hasReadAccessForPage = hasReadAccess('Role') && hasReadAccess('Access');
+    const hasWriteAccessForPage = hasReadWriteAccess('Role') && hasReadWriteAccess('Access');
     const history = useHistory();
     const { search } = useLocation();
     const queryObject = getQueryObject(search);
@@ -133,7 +134,7 @@ function PermissionSets(): ReactElement {
     }, []);
 
     // Return "no access" page immediately if user doesn't have enough permissions.
-    if (!hasReadAccessForPermissionSets) {
+    if (!hasReadAccessForPage) {
         return (
             <>
                 <AccessControlNoPermission subPage="permission sets" entityType={entityType} />
@@ -203,7 +204,11 @@ function PermissionSets(): ReactElement {
                             </AccessControlDescription>
                         }
                         actionComponent={
-                            <Button variant="primary" onClick={handleCreate}>
+                            <Button
+                                isDisabled={!hasWriteAccessForPage}
+                                variant="primary"
+                                onClick={handleCreate}
+                            >
                                 Create permission set
                             </Button>
                         }

--- a/ui/apps/platform/src/Containers/AccessControl/PermissionSets/PermissionSets.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/PermissionSets/PermissionSets.tsx
@@ -35,10 +35,14 @@ import { getNewPermissionSet, getCompletePermissionSet } from './permissionSets.
 import AccessControlHeaderActionBar from '../AccessControlHeaderActionBar';
 import AccessControlBreadcrumbs from '../AccessControlBreadcrumbs';
 import AccessControlHeading from '../AccessControlHeading';
+import AccessControlNoPermission from '../AccessControlNoPermission';
+import usePermissions from '../../../hooks/usePermissions';
 
 const entityType = 'PERMISSION_SET';
 
 function PermissionSets(): ReactElement {
+    const { hasReadAccess } = usePermissions();
+    const hasReadAccessForPermissionSets = hasReadAccess('Role');
     const history = useHistory();
     const { search } = useLocation();
     const queryObject = getQueryObject(search);
@@ -175,6 +179,14 @@ function PermissionSets(): ReactElement {
     const permissionSet = permissionSets.find(({ id }) => id === entityId);
     const hasAction = Boolean(action);
     const isList = typeof entityId !== 'string' && !hasAction;
+
+    if (!hasReadAccessForPermissionSets) {
+        return (
+            <>
+                <AccessControlNoPermission subPage="Permission Sets" entityType={entityType} />
+            </>
+        );
+    }
 
     return (
         <>

--- a/ui/apps/platform/src/Containers/AccessControl/PermissionSets/PermissionSets.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/PermissionSets/PermissionSets.tsx
@@ -132,6 +132,15 @@ function PermissionSets(): ReactElement {
             });
     }, []);
 
+    // Return "no access" page immediately if user doesn't have enough permissions.
+    if (!hasReadAccessForPermissionSets) {
+        return (
+            <>
+                <AccessControlNoPermission subPage="permission sets" entityType={entityType} />
+            </>
+        );
+    }
+
     function handleCreate() {
         history.push(getEntityPath(entityType, undefined, { action: 'create' }));
     }
@@ -179,14 +188,6 @@ function PermissionSets(): ReactElement {
     const permissionSet = permissionSets.find(({ id }) => id === entityId);
     const hasAction = Boolean(action);
     const isList = typeof entityId !== 'string' && !hasAction;
-
-    if (!hasReadAccessForPermissionSets) {
-        return (
-            <>
-                <AccessControlNoPermission subPage="permission sets" entityType={entityType} />
-            </>
-        );
-    }
 
     return (
         <>

--- a/ui/apps/platform/src/Containers/AccessControl/PermissionSets/PermissionSets.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/PermissionSets/PermissionSets.tsx
@@ -183,7 +183,7 @@ function PermissionSets(): ReactElement {
     if (!hasReadAccessForPermissionSets) {
         return (
             <>
-                <AccessControlNoPermission subPage="Permission Sets" entityType={entityType} />
+                <AccessControlNoPermission subPage="permission sets" entityType={entityType} />
             </>
         );
     }

--- a/ui/apps/platform/src/Containers/AccessControl/PermissionSets/PermissionSetsList.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/PermissionSets/PermissionSetsList.tsx
@@ -14,6 +14,7 @@ import { TableComposable, Tbody, Td, Thead, Th, Tr } from '@patternfly/react-tab
 import { PermissionSet, Role } from 'services/RolesService';
 
 import { AccessControlEntityLink, RolesLink } from '../AccessControlLinks';
+import usePermissions from '../../../hooks/usePermissions';
 
 const entityType = 'PERMISSION_SET';
 
@@ -32,6 +33,8 @@ function PermissionSetsList({
     const [idDeleting, setIdDeleting] = useState('');
     const [nameConfirmingDelete, setNameConfirmingDelete] = useState<string | null>(null);
     const [alertDelete, setAlertDelete] = useState<ReactElement | null>(null);
+    const { hasReadWriteAccess } = usePermissions();
+    const hasWriteAccessForPage = hasReadWriteAccess('Role') && hasReadWriteAccess('Access');
 
     function onClickDelete(id: string) {
         setIdDeleting(id);
@@ -102,6 +105,7 @@ function PermissionSetsList({
                                 <Td
                                     actions={{
                                         disable:
+                                            !hasWriteAccessForPage ||
                                             idDeleting === id ||
                                             roles.some(
                                                 ({ permissionSetId }) => permissionSetId === id

--- a/ui/apps/platform/src/Containers/AccessControl/PermissionSets/ResourceDescription.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/PermissionSets/ResourceDescription.tsx
@@ -35,7 +35,6 @@ const resourceDescriptions: Record<ResourceName, string> = {
     Node: 'Read: View Kubernetes nodes in secured clusters. Write: N/A',
     Role: 'Read: View roles, permision sets and access scopes. Write: Add, modify or delete roles, permission sets and access scopes.',
     Policy: 'Read: View system policies. Write: Add, modify, or delete system policies.',
-    Role: 'Read: View roles, permision sets and access scopes. Write: Add, modify or delete roles, permission sets and access scopes.',
     Secret: 'Read: View metadata about secrets in secured clusters. Write: N/A',
     ServiceAccount: 'Read: List Kubernetes service accounts in secured clusters. Write: N/A',
     VulnerabilityManagementApprovals:

--- a/ui/apps/platform/src/Containers/AccessControl/PermissionSets/ResourceDescription.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/PermissionSets/ResourceDescription.tsx
@@ -33,6 +33,7 @@ const resourceDescriptions: Record<ResourceName, string> = {
     NetworkPolicy:
         'Read: View network policies in secured clusters and simulate changes. Write: Apply network policy changes in secured clusters.',
     Node: 'Read: View Kubernetes nodes in secured clusters. Write: N/A',
+    Role: 'Read: View roles, permision sets and access scopes. Write: Add, modify or delete roles, permission sets and access scopes.',
     Policy: 'Read: View system policies. Write: Add, modify, or delete system policies.',
     Role: 'Read: View roles, permision sets and access scopes. Write: Add, modify or delete roles, permission sets and access scopes.',
     Secret: 'Read: View metadata about secrets in secured clusters. Write: N/A',

--- a/ui/apps/platform/src/Containers/AccessControl/Roles/RoleForm.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/Roles/RoleForm.tsx
@@ -25,6 +25,7 @@ import AccessScopesTable from './AccessScopesTable';
 import PermissionSetsTable from './PermissionSetsTable';
 
 import './RoleForm.css';
+import usePermissions from '../../../hooks/usePermissions';
 
 export type RoleFormProps = {
     isActionable: boolean;
@@ -51,6 +52,8 @@ function RoleForm({
 }: RoleFormProps): ReactElement {
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [alertSubmit, setAlertSubmit] = useState<ReactElement | null>(null);
+    const { hasReadWriteAccess } = usePermissions();
+    const hasWriteAccessForPage = hasReadWriteAccess('Role') && hasReadWriteAccess('Access');
 
     const { dirty, errors, handleChange, isValid, resetForm, values } = useFormik({
         initialValues: role,
@@ -122,7 +125,7 @@ function RoleForm({
                                     <Button
                                         variant="primary"
                                         onClick={handleEdit}
-                                        isDisabled={action === 'edit'}
+                                        isDisabled={!hasWriteAccessForPage || action === 'edit'}
                                         isSmall
                                     >
                                         Edit role

--- a/ui/apps/platform/src/Containers/AccessControl/Roles/Roles.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/Roles/Roles.tsx
@@ -54,8 +54,9 @@ const roleNew: Role = {
 };
 
 function Roles(): ReactElement {
-    const { hasReadAccess } = usePermissions();
-    const hasReadAccessForRoles = hasReadAccess('Role');
+    const { hasReadAccess, hasReadWriteAccess } = usePermissions();
+    const hasReadAccessForPage = hasReadAccess('Role') && hasReadAccess('Access');
+    const hasWriteAccessForPage = hasReadWriteAccess('Role') && hasReadWriteAccess('Access');
     const history = useHistory();
     const { search } = useLocation();
     const queryObject = getQueryObject(search);
@@ -183,7 +184,7 @@ function Roles(): ReactElement {
     }, []);
 
     // Return "no access" page immediately if user doesn't have enough permissions.
-    if (!hasReadAccessForRoles) {
+    if (!hasReadAccessForPage) {
         return (
             <>
                 <AccessControlNoPermission subPage="roles" entityType={entityType} />
@@ -251,7 +252,11 @@ function Roles(): ReactElement {
                             </AccessControlDescription>
                         }
                         actionComponent={
-                            <Button variant="primary" onClick={handleCreate}>
+                            <Button
+                                isDisabled={!hasWriteAccessForPage}
+                                variant="primary"
+                                onClick={handleCreate}
+                            >
                                 Create role
                             </Button>
                         }

--- a/ui/apps/platform/src/Containers/AccessControl/Roles/Roles.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/Roles/Roles.tsx
@@ -40,6 +40,8 @@ import RolesList from './RolesList';
 import AccessControlBreadcrumbs from '../AccessControlBreadcrumbs';
 import AccessControlHeaderActionBar from '../AccessControlHeaderActionBar';
 import AccessControlHeading from '../AccessControlHeading';
+import usePermissions from '../../../hooks/usePermissions';
+import AccessControlNoPermission from '../AccessControlNoPermission';
 
 const entityType = 'ROLE';
 
@@ -52,6 +54,8 @@ const roleNew: Role = {
 };
 
 function Roles(): ReactElement {
+    const { hasReadAccess } = usePermissions();
+    const hasReadAccessForRoles = hasReadAccess('Role');
     const history = useHistory();
     const { search } = useLocation();
     const queryObject = getQueryObject(search);
@@ -223,6 +227,14 @@ function Roles(): ReactElement {
     const role = roles.find(({ name }) => name === entityName);
     const hasAction = Boolean(action);
     const isList = typeof entityName !== 'string' && !hasAction;
+
+    if (!hasReadAccessForRoles) {
+        return (
+            <>
+                <AccessControlNoPermission subPage="Roles" entityType={entityType} />
+            </>
+        );
+    }
 
     return (
         <>

--- a/ui/apps/platform/src/Containers/AccessControl/Roles/Roles.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/Roles/Roles.tsx
@@ -182,6 +182,15 @@ function Roles(): ReactElement {
             });
     }, []);
 
+    // Return "no access" page immediately if user doesn't have enough permissions.
+    if (!hasReadAccessForRoles) {
+        return (
+            <>
+                <AccessControlNoPermission subPage="roles" entityType={entityType} />
+            </>
+        );
+    }
+
     function handleCreate() {
         history.push(getEntityPath(entityType, undefined, { action: 'create' }));
     }
@@ -227,14 +236,6 @@ function Roles(): ReactElement {
     const role = roles.find(({ name }) => name === entityName);
     const hasAction = Boolean(action);
     const isList = typeof entityName !== 'string' && !hasAction;
-
-    if (!hasReadAccessForRoles) {
-        return (
-            <>
-                <AccessControlNoPermission subPage="roles" entityType={entityType} />
-            </>
-        );
-    }
 
     return (
         <>

--- a/ui/apps/platform/src/Containers/AccessControl/Roles/Roles.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/Roles/Roles.tsx
@@ -231,7 +231,7 @@ function Roles(): ReactElement {
     if (!hasReadAccessForRoles) {
         return (
             <>
-                <AccessControlNoPermission subPage="Roles" entityType={entityType} />
+                <AccessControlNoPermission subPage="roles" entityType={entityType} />
             </>
         );
     }

--- a/ui/apps/platform/src/Containers/AccessControl/Roles/RolesList.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/Roles/RolesList.tsx
@@ -18,6 +18,7 @@ import { PermissionSet, Role } from 'services/RolesService';
 
 import { AccessControlEntityLink } from '../AccessControlLinks';
 import { AccessControlQueryFilter } from '../accessControlPaths';
+import usePermissions from '../../../hooks/usePermissions';
 
 // Return whether an auth provider rule refers to a role name,
 // therefore need to disable the delete action for the role.
@@ -47,6 +48,8 @@ function RolesList({
     const [nameDeleting, setNameDeleting] = useState('');
     const [nameConfirmingDelete, setNameConfirmingDelete] = useState<string | null>(null);
     const [alertDelete, setAlertDelete] = useState<ReactElement | null>(null);
+    const { hasReadWriteAccess } = usePermissions();
+    const hasWriteAccessForPage = hasReadWriteAccess('Role') && hasReadWriteAccess('Access');
 
     function onClickDelete(name: string) {
         setNameDeleting(name);
@@ -138,6 +141,7 @@ function RolesList({
                                     <Td
                                         actions={{
                                             disable:
+                                                !hasWriteAccessForPage ||
                                                 nameDeleting === name ||
                                                 getIsDefaultRoleName(name) ||
                                                 getHasRoleName(groups, name),


### PR DESCRIPTION
## Description

**Before this PR:** “Access Control” page forever loads when the user has `Access` permission but not Role permission. 

**After this PR**: 
Change to "by tab" permission check:
* `Access` permission   check for Auth providers
* `Role` check for Roles, Permission sets and Access scopes

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed
<img width="1775" alt="Screenshot 2022-11-07 at 13 26 12" src="https://user-images.githubusercontent.com/78353299/200310126-5efdf1b0-3306-45a3-86c2-4e0adc5837eb.png">

<img width="1785" alt="Screenshot 2022-11-07 at 13 26 24" src="https://user-images.githubusercontent.com/78353299/200310161-e6c310b9-fbba-4615-a444-8e20d1bfaf13.png">

