### PR TITLE
ROX-13368: Skip failing nongroovy tests on PG

### DIFF
--- a/tests/container_instances_test.go
+++ b/tests/container_instances_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/graph-gophers/graphql-go"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/sliceutils"
 	"github.com/stackrox/rox/pkg/testutils"
 	"github.com/stretchr/testify/require"
@@ -19,6 +20,10 @@ type ContainerNameGroup struct {
 }
 
 func TestContainerInstances(testT *testing.T) {
+	if env.PostgresDatastoreEnabled.BooleanSetting() {
+		testT.Skip("ROX-13420")
+	}
+
 	// https://stack-rox.atlassian.net/browse/ROX-6493
 	// - the process events expected in this test are not reliably detected.
 	testutils.Retry(testT, 3, 5*time.Second, func(retryT testutils.T) {

--- a/tests/excluded_scopes_test.go
+++ b/tests/excluded_scopes_test.go
@@ -9,12 +9,16 @@ import (
 	"github.com/gogo/protobuf/proto"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/testutils/centralgrpc"
 	"github.com/stretchr/testify/require"
 )
 
 func TestExcludedScopes(t *testing.T) {
+	if env.PostgresDatastoreEnabled.BooleanSetting() {
+		t.Skip("ROX-13420")
+	}
 	defer teardownTestExcludedScopes(t)
 	setupNginxLatestTagDeployment(t)
 	verifyNoAlertForExcludedScopes(t)

--- a/tests/networkpolicy_test.go
+++ b/tests/networkpolicy_test.go
@@ -10,6 +10,7 @@ import (
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/buildinfo"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/testutils"
 	"github.com/stackrox/rox/pkg/testutils/centralgrpc"
@@ -118,6 +119,9 @@ func Test_GetViolationForIngressPolicy(t *testing.T) {
 	conn := centralgrpc.GRPCConnectionToCentral(t)
 	if buildinfo.ReleaseBuild || !CheckIfCentralHasFeatureFlag(t, conn) {
 		t.Skip("Feature flag disabled")
+	}
+	if env.PostgresDatastoreEnabled.BooleanSetting() {
+		t.Skip("ROX-13420")
 	}
 
 	testCases := map[string]struct {

--- a/tests/pods_test.go
+++ b/tests/pods_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/graph-gophers/graphql-go"
 	"github.com/stackrox/rox/central/graphql/resolvers/inputtypes"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/sliceutils"
 	"github.com/stackrox/rox/pkg/testutils"
 	"github.com/stretchr/testify/require"
@@ -39,6 +40,9 @@ type Event struct {
 }
 
 func TestPod(testT *testing.T) {
+	if env.PostgresDatastoreEnabled.BooleanSetting() {
+		testT.Skip("ROX-13420")
+	}
 	// https://stack-rox.atlassian.net/browse/ROX-6631
 	// - the process events expected in this test are not reliably detected.
 	testutils.Retry(testT, 3, 5*time.Second, func(retryT testutils.T) {


### PR DESCRIPTION
## Description

Skip tests that are failing on nongroovy tests https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/33730/rehearse-33730-pull-ci-stackrox-stackrox-master-gke-postgres-nongroovy-e2e-tests/1589573492305563648

## Testing Performed

CI