### PR TITLE
Only enable ROX_OBJECT_COLLECTIONS feature flag during gke-postgres-ui-e2e job

### DIFF
--- a/scripts/ci/jobs/gke_postgres_ui_e2e_tests.py
+++ b/scripts/ci/jobs/gke_postgres_ui_e2e_tests.py
@@ -16,6 +16,9 @@ os.environ["ORCHESTRATOR_FLAVOR"] = "k8s"
 # use postgres
 os.environ["ROX_POSTGRES_DATASTORE"] = "true"
 
+# Enable 'Collections' feature during development
+os.environ["ROX_OBJECT_COLLECTIONS"] = "true"
+
 # Override test env defaults here:
 # (for defaults see: tests/e2e/lib.sh export_test_environment())
 # TODO(janisz): Reenable below setting.

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -56,7 +56,6 @@ export_test_environment() {
     ci_export ROX_QUAY_ROBOT_ACCOUNTS "${ROX_QUAY_ROBOT_ACCOUNTS:-true}"
     ci_export ROX_SEARCH_PAGE_UI "${ROX_SEARCH_PAGE_UI:-true}"
     ci_export ROX_SYSTEM_HEALTH_PF "${ROX_SYSTEM_HEALTH_PF:-true}"
-    ci_export ROX_OBJECT_COLLECTIONS "${ROX_OBJECT_COLLECTIONS:-true}"
 }
 
 deploy_central() {


### PR DESCRIPTION
## Description

This enables the ROX_OBJECT_COLLECTIONS flag during CI for _only_ the UI e2e job where Postgres is deployed. Previously this flag was enabled on all e2e jobs.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Ensure Collection based Cypress tests run during CI.
