### PR TITLE
ROX-13440: Replace ambiguous central with sensor in networkGraph integration test

### DIFF
--- a/ui/apps/platform/cypress/integration/networkGraph/networkGraph.test.js
+++ b/ui/apps/platform/cypress/integration/networkGraph/networkGraph.test.js
@@ -56,17 +56,14 @@ describe('Network Graph Search', () => {
 
     it('should filter to show only a specific deployment and deployments connected to it', () => {
         visitNetworkGraphWithNamespaceFilter('stackrox');
-        selectDeploymentFilter('central');
+        selectDeploymentFilter('sensor');
 
         cy.getCytoscape(networkPageSelectors.cytoscapeContainer).then((cytoscape) => {
             const deployments = cytoscape.nodes().filter(filterDeployments);
-            expect(deployments.size()).to.be.at.least(3); // central, scanner, sensor
 
-            const minDeps = [];
-            deployments.forEach((deployment) => {
-                minDeps.push(deployment.data().name);
-            });
-            expect(minDeps).to.include.members(['central', 'scanner', 'sensor']);
+            const deploymentsExpected = ['admission-control', 'central', 'collector'];
+            const deploymentsReceived = deployments.map((deployment) => deployment.data().name);
+            expect(deploymentsReceived).to.include.members(deploymentsExpected);
         });
     });
 

--- a/ui/apps/platform/cypress/integration/networkGraph/networkGraph.test.js
+++ b/ui/apps/platform/cypress/integration/networkGraph/networkGraph.test.js
@@ -58,11 +58,13 @@ describe('Network Graph Search', () => {
         visitNetworkGraphWithNamespaceFilter('stackrox');
         selectDeploymentFilter('sensor');
 
-        cy.getCytoscape(networkPageSelectors.cytoscapeContainer).then((cytoscape) => {
-            const deployments = cytoscape.nodes().filter(filterDeployments);
+        const deploymentsExpected = ['admission-control', 'central', 'collector'];
 
-            const deploymentsExpected = ['admission-control', 'central', 'collector'];
-            const deploymentsReceived = deployments.map((deployment) => deployment.data().name);
+        cy.getCytoscape(networkPageSelectors.cytoscapeContainer).then((cytoscape) => {
+            const deploymentsReceived = cytoscape
+                .nodes()
+                .filter(filterDeployments)
+                .map((deployment) => deployment.data().name);
             expect(deploymentsReceived).to.include.members(deploymentsExpected);
         });
     });


### PR DESCRIPTION
## Description

### Test failures

> Network Graph Search should filter to show only a specific deployment and deployments connected to it

> expected 2 to be at least 3

![networkGraph](https://user-images.githubusercontent.com/11862657/200453123-5ee168c3-1aa4-4df4-8509-98d0d32be0a4.png)

* 1588508278575337472 from master build for 3696 on 2022-11-04
* 1588601390899400704 from master build for 3684 on 2022-11-04
* 1588608354094157824 from master build for 3668 on 2022-11-04
* 1588613244845559808 from master build for 3702 on 2022-11-04
* 1589590103959801856 from master build for 3718 on 2022-11-07
* 1589624539715735552 from master build for 3116 on 2022-11-07
* 1589657635995521024 from master build for 3642 on 2022-11-07
* 1589672927530323968 from master build for 3648 on 2022-11-07
* 1589721619394203648 from master build for 3707 on 2022-11-07

### Analysis

Credit to Van for analysis.

With postgress, deployment search filter might have first match in results list either central (running locally) or central-db (running in CI, who knows why).
* central has connected deployments scanner and sensor (also central-db for postgress)
* central-db has connected deployment central

### Solution

Replace ambiguous central with unambiguous sensor and also:
* Delete redundant numeric assertion which does not provide information if it fails.
* Rewrite deployment name assertion.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration test

## Testing Performed