### PR TITLE
ROX-13417: use real data for port config section

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraph.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraph.tsx
@@ -125,10 +125,10 @@ const TopologyComponent = ({ model }: TopologyComponentProps) => {
         controller.addEventListener(SELECTION_EVENT, onSelect);
 
         setEdges(controller, detailId);
+
         return () => {
             controller.removeEventListener(SELECTION_EVENT, onSelect);
         };
-        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [controller, model]);
 
     const selectedIds = selectedEntity ? [selectedEntity.id] : [];

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentDetails.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentDetails.tsx
@@ -6,6 +6,8 @@ import {
     DescriptionListGroup,
     DescriptionListTerm,
     Divider,
+    EmptyState,
+    EmptyStateVariant,
     ExpandableSection,
     Flex,
     FlexItem,
@@ -16,11 +18,12 @@ import {
     Text,
     TextContent,
     TextVariants,
+    Title,
 } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import pluralize from 'pluralize';
 
-import { Deployment, PortConfig } from 'types/deployment.proto';
+import { Deployment } from 'types/deployment.proto';
 import { ListenPort } from 'types/networkFlow.proto';
 import { getDateTime } from 'utils/dateUtils';
 
@@ -32,47 +35,6 @@ type DeploymentDetailsProps = {
     numInternalFlows: number;
     listenPorts: ListenPort[];
 };
-
-const mockPorts: PortConfig[] = [
-    {
-        name: 'api',
-        containerPort: 8443,
-        protocol: 'TCP',
-        exposure: 'INTERNAL',
-        exposedPort: 0,
-        exposureInfos: [
-            {
-                level: 'INTERNAL',
-                serviceName: 'sensor',
-                serviceId: 'b830c97f-7ecf-49c7-898c-ea9c68f2e131',
-                serviceClusterIp: '10.73.232.126',
-                servicePort: 443,
-                nodePort: 0,
-                externalIps: [],
-                externalHostnames: [],
-            },
-        ],
-    },
-    {
-        name: 'webhook',
-        containerPort: 9443,
-        protocol: 'TCP',
-        exposure: 'INTERNAL',
-        exposedPort: 0,
-        exposureInfos: [
-            {
-                level: 'INTERNAL',
-                serviceName: 'sensor-webhook',
-                serviceId: '3d879536-0521-4a52-9a8e-d33b4aa75ca5',
-                serviceClusterIp: '10.73.232.21',
-                servicePort: 443,
-                nodePort: 0,
-                externalIps: [],
-                externalHostnames: [],
-            },
-        ],
-    },
-];
 
 function DetailSection({ title, children }) {
     const [isExpanded, setIsExpanded] = useState(true);
@@ -291,15 +253,23 @@ function DeploymentDetails({
                 <Divider component="li" className="pf-u-mb-sm" />
                 <li>
                     <DetailSection title="Port configurations">
-                        <Stack hasGutter>
-                            {mockPorts.map((port) => {
-                                return (
-                                    <StackItem>
-                                        <DeploymentPortConfig port={port} />
-                                    </StackItem>
-                                );
-                            })}
-                        </Stack>
+                        {deployment.ports.length ? (
+                            <Stack hasGutter>
+                                {deployment.ports.map((port) => {
+                                    return (
+                                        <StackItem>
+                                            <DeploymentPortConfig port={port} />
+                                        </StackItem>
+                                    );
+                                })}
+                            </Stack>
+                        ) : (
+                            <EmptyState variant={EmptyStateVariant.xs}>
+                                <Title headingLevel="h4" size="md">
+                                    No ports available
+                                </Title>
+                            </EmptyState>
+                        )}
                     </DetailSection>
                 </li>
             </ul>


### PR DESCRIPTION
## Description

This PR uses real data for the port configurations section of the deployment details page. This is an iterative addition. You can find all the subtasks here:
https://issues.redhat.com/browse/ROX-12903

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

<img width="1552" alt="Screenshot 2022-11-07 at 5 02 48 PM" src="https://user-images.githubusercontent.com/4805485/200467996-0929698d-7130-4ab8-9153-0f5c4f288c73.png">
<img width="1552" alt="Screenshot 2022-11-07 at 5 03 18 PM" src="https://user-images.githubusercontent.com/4805485/200467999-93fb5850-4062-4523-b5b8-9a21c681f1e8.png">
<img width="1552" alt="Screenshot 2022-11-07 at 5 06 08 PM" src="https://user-images.githubusercontent.com/4805485/200468001-4b22775e-4c3c-4373-9275-0747088cfa52.png">