### PR TITLE
fix: remove RC information from TAG passed to create-release

### DIFF
--- a/.github/workflows/scripts/create-release.sh
+++ b/.github/workflows/scripts/create-release.sh
@@ -23,7 +23,7 @@ create_release_notes() {
       -H "Accept: application/vnd.github.v3.raw" \
       "/repos/${GITHUB_REPOSITORY}/contents/CHANGELOG.md?ref=${TAG}"
     )"
-    VERSION_WITHOUT_RC=${TAG/-rc.[0-9]*/}
+    VERSION_WITHOUT_RC="${TAG/-rc.[0-9]*/}"
     ESCAPED_VERSION="${VERSION_WITHOUT_RC//./\.}"
     OUTPUT="$(echo "$CHANGELOG" | sed -n "/^## \[$ESCAPED_VERSION]$/,/^## \[/p" | sed '1d;$d')"
     if [ "$(wc -m <<< "$OUTPUT" | awk '{ print $1 }')" -gt 150000 ]; then

--- a/.github/workflows/scripts/create-release.sh
+++ b/.github/workflows/scripts/create-release.sh
@@ -23,7 +23,8 @@ create_release_notes() {
       -H "Accept: application/vnd.github.v3.raw" \
       "/repos/${GITHUB_REPOSITORY}/contents/CHANGELOG.md?ref=${TAG}"
     )"
-    ESCAPED_VERSION="${TAG//./\.}"
+    VERSION_WITHOUT_RC=${TAG/-rc.[0-9]*/}
+    ESCAPED_VERSION="${VERSION_WITHOUT_RC//./\.}"
     OUTPUT="$(echo "$CHANGELOG" | sed -n "/^## \[$ESCAPED_VERSION]$/,/^## \[/p" | sed '1d;$d')"
     if [ "$(wc -m <<< "$OUTPUT" | awk '{ print $1 }')" -gt 150000 ]; then
         PREVIOUS_VERSION=$(echo "$CHANGELOG" | sed -n "/^## \[$ESCAPED_VERSION]$/,/^## \[/p" | tail -n 1 | tr -d '#[] ')


### PR DESCRIPTION
## Description

To find the to be released version in the CHANGELOG, we need to strip the RC information from the TAG. 