### PR TITLE
Extract collection form from drawer wrapper layout

### DIFF
--- a/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
@@ -1,15 +1,7 @@
-import React, { ReactElement, useEffect } from 'react';
+import React, { ReactElement } from 'react';
 import { useHistory } from 'react-router-dom';
 import {
     Button,
-    Drawer,
-    DrawerActions,
-    DrawerCloseButton,
-    DrawerContent,
-    DrawerContentBody,
-    DrawerHead,
-    DrawerPanelBody,
-    DrawerPanelContent,
     EmptyState,
     EmptyStateIcon,
     EmptyStateVariant,
@@ -18,7 +10,6 @@ import {
     Form,
     FormGroup,
     Label,
-    Text,
     TextInput,
     Title,
     Truncate,
@@ -33,9 +24,7 @@ import { CollectionResponse } from 'services/CollectionsService';
 import { CollectionPageAction } from './collections.utils';
 import RuleSelector from './RuleSelector';
 import CollectionAttacher from './CollectionAttacher';
-import CollectionResults from './CollectionResults';
 import { Collection, ScopedResourceSelector, SelectorEntityType } from './types';
-import { parseCollection } from './converter';
 
 function AttachedCollectionTable({ collections }: { collections: CollectionResponse[] }) {
     return collections.length > 0 ? (
@@ -67,16 +56,10 @@ export type CollectionFormProps = {
     hasWriteAccessForCollections: boolean;
     /* The user's workflow action for this collection */
     action: CollectionPageAction;
-    /* initial, unparsed data used to populate the form */
-    collectionData: {
-        collection: Omit<CollectionResponse, 'id'>;
-        embeddedCollections: CollectionResponse[];
-    };
-    /* Whether or not to display the collection results in an inline drawer. If false, will
-    display collection results in an overlay drawer. */
-    useInlineDrawer: boolean;
-    isDrawerOpen: boolean;
-    toggleDrawer: (isOpen: boolean) => void;
+    /* parsed collection data used to populate the form */
+    initialData: Collection;
+    /* collection responses for the embedded collections of `initialData` */
+    initialEmbeddedCollections: CollectionResponse[];
     onSubmit: (collection: Collection) => Promise<void>;
     /* Callback used when clicking on a collection name in the CollectionAttacher section. If
     left undefined, collection names will not be linked. */
@@ -116,21 +99,11 @@ function yupResourceSelectorObject() {
 function CollectionForm({
     hasWriteAccessForCollections,
     action,
-    collectionData,
-    useInlineDrawer,
-    isDrawerOpen,
-    toggleDrawer,
+    initialData,
+    initialEmbeddedCollections,
     onSubmit,
-    headerContent,
 }: CollectionFormProps) {
     const history = useHistory();
-
-    const initialData = parseCollection(collectionData.collection);
-    const initialEmbeddedCollections = collectionData.embeddedCollections;
-
-    useEffect(() => {
-        toggleDrawer(useInlineDrawer);
-    }, [toggleDrawer, useInlineDrawer]);
 
     const isReadOnly = action.type === 'view' || !hasWriteAccessForCollections;
 
@@ -152,255 +125,172 @@ function CollectionForm({
             );
 
     return (
-        <>
-            <Drawer isExpanded={isDrawerOpen} isInline={useInlineDrawer}>
-                <DrawerContent
-                    panelContent={
-                        <DrawerPanelContent
-                            style={{
-                                borderLeft: 'var(--pf-global--BorderColor--100) 1px solid',
-                            }}
+        <Formik
+            initialValues={
+                action.type === 'clone'
+                    ? { ...initialData, name: `${initialData.name} (COPY)` }
+                    : initialData
+            }
+            onSubmit={(collection, { setSubmitting }) => {
+                onSubmit(collection).catch(() => {
+                    setSubmitting(false);
+                });
+            }}
+            validationSchema={yup.object({
+                name: yup.string().trim().required(),
+                description: yup.string(),
+                embeddedCollectionIds: yup.array(yup.string().trim().required()),
+                resourceSelector: yup.object().shape({
+                    Deployment: yupResourceSelectorObject(),
+                    Namespace: yupResourceSelectorObject(),
+                    Cluster: yupResourceSelectorObject(),
+                }),
+            })}
+        >
+            {({
+                values,
+                isValid,
+                errors,
+                handleChange,
+                handleBlur,
+                setFieldValue,
+                submitForm,
+                isSubmitting,
+            }) => (
+                <Form className="pf-u-background-color-200">
+                    <Flex
+                        className="pf-u-p-lg"
+                        spaceItems={{ default: 'spaceItemsMd' }}
+                        direction={{ default: 'column' }}
+                    >
+                        <Flex
+                            className="pf-u-background-color-100 pf-u-p-lg"
+                            direction={{ default: 'column' }}
+                            spaceItems={{ default: 'spaceItemsMd' }}
                         >
-                            <DrawerHead>
-                                <Title headingLevel="h2">Collection results</Title>
-                                <Text>See a live preview of current matches.</Text>
-                                <DrawerActions>
-                                    <DrawerCloseButton onClick={() => toggleDrawer(false)} />
-                                </DrawerActions>
-                            </DrawerHead>
-                            <DrawerPanelBody className="pf-u-h-100" style={{ overflow: 'auto' }}>
-                                <CollectionResults />
-                            </DrawerPanelBody>
-                        </DrawerPanelContent>
-                    }
-                >
-                    <DrawerContentBody className="pf-u-background-color-100 pf-u-display-flex pf-u-flex-direction-column">
-                        {headerContent}
-                        {initialData instanceof AggregateError ? (
-                            <>
-                                {initialData.errors}
-                                {/* TODO - Handle inline UI for unsupported rule errors */}
-                            </>
-                        ) : (
-                            <Formik
-                                initialValues={
-                                    action.type === 'clone'
-                                        ? { ...initialData, name: `${initialData.name} (COPY)` }
-                                        : initialData
-                                }
-                                onSubmit={(collection, { setSubmitting }) => {
-                                    onSubmit(collection).catch(() => {
-                                        setSubmitting(false);
-                                    });
-                                }}
-                                validationSchema={yup.object({
-                                    name: yup.string().trim().required(),
-                                    description: yup.string(),
-                                    embeddedCollectionIds: yup.array(
-                                        yup.string().trim().required()
-                                    ),
-                                    resourceSelector: yup.object().shape({
-                                        Deployment: yupResourceSelectorObject(),
-                                        Namespace: yupResourceSelectorObject(),
-                                        Cluster: yupResourceSelectorObject(),
-                                    }),
-                                })}
+                            <Title headingLevel="h2">Collection details</Title>
+                            <Flex direction={{ default: 'column', lg: 'row' }}>
+                                <FlexItem flex={{ default: 'flex_1' }}>
+                                    <FormGroup label="Name" fieldId="name" isRequired>
+                                        <TextInput
+                                            id="name"
+                                            name="name"
+                                            value={values.name}
+                                            validated={errors.name ? 'error' : 'default'}
+                                            onChange={(_, e) => handleChange(e)}
+                                            onBlur={handleBlur}
+                                            isDisabled={isReadOnly}
+                                        />
+                                    </FormGroup>
+                                </FlexItem>
+                                <FlexItem flex={{ default: 'flex_2' }}>
+                                    <FormGroup label="Description" fieldId="description">
+                                        <TextInput
+                                            id="description"
+                                            name="description"
+                                            value={values.description}
+                                            onChange={(_, e) => handleChange(e)}
+                                            onBlur={handleBlur}
+                                            isDisabled={isReadOnly}
+                                        />
+                                    </FormGroup>
+                                </FlexItem>
+                            </Flex>
+                        </Flex>
+
+                        <Flex
+                            className="pf-u-background-color-100 pf-u-p-lg"
+                            direction={{ default: 'column' }}
+                            spaceItems={{ default: 'spaceItemsMd' }}
+                        >
+                            <Title
+                                className={isReadOnly ? 'pf-u-mb-md' : 'pf-u-mb-xs'}
+                                headingLevel="h2"
                             >
-                                {({
-                                    values,
-                                    isValid,
-                                    errors,
-                                    handleChange,
-                                    handleBlur,
-                                    setFieldValue,
-                                    submitForm,
-                                    isSubmitting,
-                                }) => (
-                                    <Form className="pf-u-background-color-200">
-                                        <Flex
-                                            className="pf-u-p-lg"
-                                            spaceItems={{ default: 'spaceItemsMd' }}
-                                            direction={{ default: 'column' }}
-                                        >
-                                            <Flex
-                                                className="pf-u-background-color-100 pf-u-p-lg"
-                                                direction={{ default: 'column' }}
-                                                spaceItems={{ default: 'spaceItemsMd' }}
-                                            >
-                                                <Title headingLevel="h2">Collection details</Title>
-                                                <Flex direction={{ default: 'column', lg: 'row' }}>
-                                                    <FlexItem flex={{ default: 'flex_1' }}>
-                                                        <FormGroup
-                                                            label="Name"
-                                                            fieldId="name"
-                                                            isRequired
-                                                        >
-                                                            <TextInput
-                                                                id="name"
-                                                                name="name"
-                                                                value={values.name}
-                                                                validated={
-                                                                    errors.name
-                                                                        ? 'error'
-                                                                        : 'default'
-                                                                }
-                                                                onChange={(_, e) => handleChange(e)}
-                                                                onBlur={handleBlur}
-                                                                isDisabled={isReadOnly}
-                                                            />
-                                                        </FormGroup>
-                                                    </FlexItem>
-                                                    <FlexItem flex={{ default: 'flex_2' }}>
-                                                        <FormGroup
-                                                            label="Description"
-                                                            fieldId="description"
-                                                        >
-                                                            <TextInput
-                                                                id="description"
-                                                                name="description"
-                                                                value={values.description}
-                                                                onChange={(_, e) => handleChange(e)}
-                                                                onBlur={handleBlur}
-                                                                isDisabled={isReadOnly}
-                                                            />
-                                                        </FormGroup>
-                                                    </FlexItem>
-                                                </Flex>
-                                            </Flex>
+                                Collection rules
+                            </Title>
+                            {!isReadOnly && (
+                                <>
+                                    <p>
+                                        Select deployments via rules. You can use regular
+                                        expressions (RE2 syntax).
+                                    </p>
+                                </>
+                            )}
+                            <RuleSelector
+                                entityType="Deployment"
+                                scopedResourceSelector={values.resourceSelector.Deployment}
+                                handleChange={onResourceSelectorChange(setFieldValue)}
+                                validationErrors={errors.resourceSelector?.Deployment}
+                                isDisabled={isReadOnly}
+                            />
+                            <Label variant="outline" isCompact className="pf-u-align-self-center">
+                                in
+                            </Label>
+                            <RuleSelector
+                                entityType="Namespace"
+                                scopedResourceSelector={values.resourceSelector.Namespace}
+                                handleChange={onResourceSelectorChange(setFieldValue)}
+                                validationErrors={errors.resourceSelector?.Namespace}
+                                isDisabled={isReadOnly}
+                            />
+                            <Label variant="outline" isCompact className="pf-u-align-self-center">
+                                in
+                            </Label>
+                            <RuleSelector
+                                entityType="Cluster"
+                                scopedResourceSelector={values.resourceSelector.Cluster}
+                                handleChange={onResourceSelectorChange(setFieldValue)}
+                                validationErrors={errors.resourceSelector?.Cluster}
+                                isDisabled={isReadOnly}
+                            />
+                        </Flex>
 
-                                            <Flex
-                                                className="pf-u-background-color-100 pf-u-p-lg"
-                                                direction={{ default: 'column' }}
-                                                spaceItems={{ default: 'spaceItemsMd' }}
-                                            >
-                                                <Title
-                                                    className={
-                                                        isReadOnly ? 'pf-u-mb-md' : 'pf-u-mb-xs'
-                                                    }
-                                                    headingLevel="h2"
-                                                >
-                                                    Collection rules
-                                                </Title>
-                                                {!isReadOnly && (
-                                                    <>
-                                                        <p>
-                                                            Select deployments via rules. You can
-                                                            use regular expressions (RE2 syntax).
-                                                        </p>
-                                                    </>
-                                                )}
-                                                <RuleSelector
-                                                    entityType="Deployment"
-                                                    scopedResourceSelector={
-                                                        values.resourceSelector.Deployment
-                                                    }
-                                                    handleChange={onResourceSelectorChange(
-                                                        setFieldValue
-                                                    )}
-                                                    validationErrors={
-                                                        errors.resourceSelector?.Deployment
-                                                    }
-                                                    isDisabled={isReadOnly}
-                                                />
-                                                <Label
-                                                    variant="outline"
-                                                    isCompact
-                                                    className="pf-u-align-self-center"
-                                                >
-                                                    in
-                                                </Label>
-                                                <RuleSelector
-                                                    entityType="Namespace"
-                                                    scopedResourceSelector={
-                                                        values.resourceSelector.Namespace
-                                                    }
-                                                    handleChange={onResourceSelectorChange(
-                                                        setFieldValue
-                                                    )}
-                                                    validationErrors={
-                                                        errors.resourceSelector?.Namespace
-                                                    }
-                                                    isDisabled={isReadOnly}
-                                                />
-                                                <Label
-                                                    variant="outline"
-                                                    isCompact
-                                                    className="pf-u-align-self-center"
-                                                >
-                                                    in
-                                                </Label>
-                                                <RuleSelector
-                                                    entityType="Cluster"
-                                                    scopedResourceSelector={
-                                                        values.resourceSelector.Cluster
-                                                    }
-                                                    handleChange={onResourceSelectorChange(
-                                                        setFieldValue
-                                                    )}
-                                                    validationErrors={
-                                                        errors.resourceSelector?.Cluster
-                                                    }
-                                                    isDisabled={isReadOnly}
-                                                />
-                                            </Flex>
-
-                                            <Flex
-                                                className="pf-u-background-color-100 pf-u-p-lg"
-                                                direction={{ default: 'column' }}
-                                                spaceItems={{ default: 'spaceItemsMd' }}
-                                            >
-                                                <Title className="pf-u-mb-xs" headingLevel="h2">
-                                                    Attached collections
-                                                </Title>
-                                                {isReadOnly ? (
-                                                    <AttachedCollectionTable
-                                                        collections={initialEmbeddedCollections}
-                                                    />
-                                                ) : (
-                                                    <>
-                                                        <p>
-                                                            Extend this collection by attaching
-                                                            other sets.
-                                                        </p>
-                                                        <CollectionAttacher
-                                                            initialEmbeddedCollections={
-                                                                initialEmbeddedCollections
-                                                            }
-                                                            onSelectionChange={onEmbeddedCollectionsChange(
-                                                                setFieldValue
-                                                            )}
-                                                        />
-                                                    </>
-                                                )}
-                                            </Flex>
-                                        </Flex>
-                                        {action.type !== 'view' && (
-                                            <div className="pf-u-background-color-100 pf-u-p-lg pf-u-py-md">
-                                                <Button
-                                                    className="pf-u-mr-md"
-                                                    onClick={submitForm}
-                                                    isDisabled={isSubmitting || !isValid}
-                                                    isLoading={isSubmitting}
-                                                >
-                                                    Save
-                                                </Button>
-                                                <Button
-                                                    variant="secondary"
-                                                    isDisabled={isSubmitting}
-                                                    onClick={onCancelSave}
-                                                >
-                                                    Cancel
-                                                </Button>
-                                            </div>
+                        <Flex
+                            className="pf-u-background-color-100 pf-u-p-lg"
+                            direction={{ default: 'column' }}
+                            spaceItems={{ default: 'spaceItemsMd' }}
+                        >
+                            <Title className="pf-u-mb-xs" headingLevel="h2">
+                                Attached collections
+                            </Title>
+                            {isReadOnly ? (
+                                <AttachedCollectionTable collections={initialEmbeddedCollections} />
+                            ) : (
+                                <>
+                                    <p>Extend this collection by attaching other sets.</p>
+                                    <CollectionAttacher
+                                        initialEmbeddedCollections={initialEmbeddedCollections}
+                                        onSelectionChange={onEmbeddedCollectionsChange(
+                                            setFieldValue
                                         )}
-                                    </Form>
-                                )}
-                            </Formik>
-                        )}
-                    </DrawerContentBody>
-                </DrawerContent>
-            </Drawer>
-        </>
+                                    />
+                                </>
+                            )}
+                        </Flex>
+                    </Flex>
+                    {action.type !== 'view' && (
+                        <div className="pf-u-background-color-100 pf-u-p-lg pf-u-py-md">
+                            <Button
+                                className="pf-u-mr-md"
+                                onClick={submitForm}
+                                isDisabled={isSubmitting || !isValid}
+                                isLoading={isSubmitting}
+                            >
+                                Save
+                            </Button>
+                            <Button
+                                variant="secondary"
+                                isDisabled={isSubmitting}
+                                onClick={onCancelSave}
+                            >
+                                Cancel
+                            </Button>
+                        </div>
+                    )}
+                </Form>
+            )}
+        </Formik>
     );
 }
 

--- a/ui/apps/platform/src/Containers/Collections/CollectionFormDrawer.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionFormDrawer.tsx
@@ -1,0 +1,105 @@
+import React, { ReactElement, useEffect } from 'react';
+import {
+    Drawer,
+    DrawerActions,
+    DrawerCloseButton,
+    DrawerContent,
+    DrawerContentBody,
+    DrawerHead,
+    DrawerPanelBody,
+    DrawerPanelContent,
+    Text,
+    Title,
+} from '@patternfly/react-core';
+
+import { CollectionResponse } from 'services/CollectionsService';
+import { CollectionPageAction } from './collections.utils';
+import CollectionResults from './CollectionResults';
+import { Collection } from './types';
+import { parseCollection } from './converter';
+import CollectionForm from './CollectionForm';
+
+export type CollectionFormDrawerProps = {
+    hasWriteAccessForCollections: boolean;
+    /* The user's workflow action for this collection */
+    action: CollectionPageAction;
+    collectionData: {
+        collection: Omit<CollectionResponse, 'id'>;
+        embeddedCollections: CollectionResponse[];
+    };
+    /* Whether or not to display the collection results in an inline drawer. If false, will
+    display collection results in an overlay drawer. */
+    useInlineDrawer: boolean;
+    isDrawerOpen: boolean;
+    toggleDrawer: (isOpen: boolean) => void;
+    headerContent?: ReactElement;
+    onSubmit: (collection: Collection) => Promise<void>;
+    /* Callback used when clicking on a collection name in the CollectionAttacher section. If
+    left undefined, collection names will not be linked. */
+    appendTableLinkAction?: (collectionId: string) => void;
+};
+
+function CollectionFormDrawer({
+    hasWriteAccessForCollections,
+    action,
+    collectionData,
+    headerContent,
+    useInlineDrawer,
+    isDrawerOpen,
+    toggleDrawer,
+    onSubmit,
+}: CollectionFormDrawerProps) {
+    const initialData = parseCollection(collectionData.collection);
+    const initialEmbeddedCollections = collectionData.embeddedCollections;
+
+    useEffect(() => {
+        toggleDrawer(useInlineDrawer);
+    }, [toggleDrawer, useInlineDrawer]);
+
+    return (
+        <>
+            <Drawer isExpanded={isDrawerOpen} isInline={useInlineDrawer}>
+                <DrawerContent
+                    panelContent={
+                        <DrawerPanelContent
+                            style={{
+                                borderLeft: 'var(--pf-global--BorderColor--100) 1px solid',
+                            }}
+                        >
+                            <DrawerHead>
+                                <Title headingLevel="h2">Collection results</Title>
+                                <Text>See a live preview of current matches.</Text>
+                                <DrawerActions>
+                                    <DrawerCloseButton onClick={() => toggleDrawer(false)} />
+                                </DrawerActions>
+                            </DrawerHead>
+                            <DrawerPanelBody className="pf-u-h-100" style={{ overflow: 'auto' }}>
+                                <CollectionResults />
+                            </DrawerPanelBody>
+                        </DrawerPanelContent>
+                    }
+                >
+                    <DrawerContentBody className="pf-u-background-color-100 pf-u-display-flex pf-u-flex-direction-column">
+                        {headerContent}
+                        {initialData instanceof AggregateError ? (
+                            <>
+                                {initialData.errors}
+                                {/* TODO - Handle inline UI for unsupported rule errors */}
+                            </>
+                        ) : (
+                            <CollectionForm
+                                hasWriteAccessForCollections={hasWriteAccessForCollections}
+                                action={action}
+                                initialData={initialData}
+                                initialEmbeddedCollections={initialEmbeddedCollections}
+                                onSubmit={onSubmit}
+                            />
+                        )}
+                    </DrawerContentBody>
+                </DrawerContent>
+            </Drawer>
+        </>
+    );
+}
+
+export default CollectionFormDrawer;

--- a/ui/apps/platform/src/Containers/Collections/CollectionFormDrawer.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionFormDrawer.tsx
@@ -29,7 +29,7 @@ export type CollectionFormDrawerProps = {
     };
     /* Whether or not to display the collection results in an inline drawer. If false, will
     display collection results in an overlay drawer. */
-    useInlineDrawer: boolean;
+    isInlineDrawer: boolean;
     isDrawerOpen: boolean;
     toggleDrawer: (isOpen: boolean) => void;
     headerContent?: ReactElement;
@@ -44,7 +44,7 @@ function CollectionFormDrawer({
     action,
     collectionData,
     headerContent,
-    useInlineDrawer,
+    isInlineDrawer,
     isDrawerOpen,
     toggleDrawer,
     onSubmit,
@@ -53,12 +53,12 @@ function CollectionFormDrawer({
     const initialEmbeddedCollections = collectionData.embeddedCollections;
 
     useEffect(() => {
-        toggleDrawer(useInlineDrawer);
-    }, [toggleDrawer, useInlineDrawer]);
+        toggleDrawer(isInlineDrawer);
+    }, [toggleDrawer, isInlineDrawer]);
 
     return (
         <>
-            <Drawer isExpanded={isDrawerOpen} isInline={useInlineDrawer}>
+            <Drawer isExpanded={isDrawerOpen} isInline={isInlineDrawer}>
                 <DrawerContent
                     panelContent={
                         <DrawerPanelContent
@@ -68,7 +68,7 @@ function CollectionFormDrawer({
                         >
                             <DrawerHead>
                                 <Title headingLevel="h2">Collection results</Title>
-                                <Text>See a live preview of current matches.</Text>
+                                <Text>See a preview of current matches.</Text>
                                 <DrawerActions>
                                     <DrawerCloseButton onClick={() => toggleDrawer(false)} />
                                 </DrawerActions>

--- a/ui/apps/platform/src/Containers/Collections/CollectionsFormPage.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionsFormPage.tsx
@@ -192,7 +192,7 @@ function CollectionsFormPage({
                 hasWriteAccessForCollections={hasWriteAccessForCollections}
                 action={pageAction}
                 collectionData={data}
-                useInlineDrawer={isLargeScreen}
+                isInlineDrawer={isLargeScreen}
                 isDrawerOpen={isDrawerOpen}
                 toggleDrawer={toggleDrawer}
                 onSubmit={onSubmit}

--- a/ui/apps/platform/src/Containers/Collections/CollectionsFormPage.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionsFormPage.tsx
@@ -37,7 +37,7 @@ import ConfirmationModal from 'Components/PatternFly/ConfirmationModal';
 import useToasts from 'hooks/patternfly/useToasts';
 import { values } from 'lodash';
 import { CollectionPageAction } from './collections.utils';
-import CollectionForm from './CollectionForm';
+import CollectionFormDrawer from './CollectionFormDrawer';
 import { generateRequest } from './converter';
 import { Collection } from './types';
 
@@ -188,7 +188,7 @@ function CollectionsFormPage({
     } else if (data) {
         const pageTitle = pageAction.type === 'create' ? 'Create collection' : data.collection.name;
         content = (
-            <CollectionForm
+            <CollectionFormDrawer
                 hasWriteAccessForCollections={hasWriteAccessForCollections}
                 action={pageAction}
                 collectionData={data}

--- a/ui/apps/platform/src/Containers/Collections/CollectionsFormPage.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionsFormPage.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useCallback, useState } from 'react';
+import React, { ReactElement, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import {
     Alert,
@@ -19,16 +19,7 @@ import {
 } from '@patternfly/react-core';
 import { useMediaQuery } from 'react-responsive';
 
-import useRestQuery from 'Containers/Dashboard/hooks/useRestQuery';
-import {
-    CollectionResponse,
-    createCollection,
-    deleteCollection,
-    getCollection,
-    listCollections,
-    ResolvedCollectionResponse,
-    updateCollection,
-} from 'services/CollectionsService';
+import { createCollection, deleteCollection, updateCollection } from 'services/CollectionsService';
 import { CaretDownIcon } from '@patternfly/react-icons';
 import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
 import { collectionsBasePath } from 'routePaths';
@@ -40,40 +31,12 @@ import { CollectionPageAction } from './collections.utils';
 import CollectionFormDrawer from './CollectionFormDrawer';
 import { generateRequest } from './converter';
 import { Collection } from './types';
+import useCollection from './hooks/useCollection';
 
 export type CollectionsFormPageProps = {
     hasWriteAccessForCollections: boolean;
     pageAction: CollectionPageAction;
 };
-
-const defaultCollectionData: Omit<CollectionResponse, 'id'> = {
-    name: '',
-    description: '',
-    inUse: false,
-    embeddedCollections: [],
-    resourceSelectors: [],
-};
-
-const noopRequest = {
-    request: Promise.resolve<{
-        collection: Omit<CollectionResponse, 'id'>;
-        embeddedCollections: CollectionResponse[];
-    }>({ collection: defaultCollectionData, embeddedCollections: [] }),
-    cancel: () => {},
-};
-
-function getEmbeddedCollections({ collection }: ResolvedCollectionResponse): Promise<{
-    collection: CollectionResponse;
-    embeddedCollections: CollectionResponse[];
-}> {
-    if (collection.embeddedCollections.length === 0) {
-        return Promise.resolve({ collection, embeddedCollections: [] });
-    }
-    const idSearchString = collection.embeddedCollections.map(({ id }) => id).join(',');
-    const searchFilter = { 'Collection ID': idSearchString };
-    const { request } = listCollections(searchFilter, { field: 'name', reversed: false });
-    return request.then((embeddedCollections) => ({ collection, embeddedCollections }));
-}
 
 function CollectionsFormPage({
     hasWriteAccessForCollections,
@@ -82,14 +45,8 @@ function CollectionsFormPage({
     const history = useHistory();
     const isLargeScreen = useMediaQuery({ query: '(min-width: 992px)' }); // --pf-global--breakpoint--lg
     const collectionId = pageAction.type !== 'create' ? pageAction.collectionId : undefined;
-    const collectionFetcher = useCallback(() => {
-        if (!collectionId) {
-            return noopRequest;
-        }
-        const { request, cancel } = getCollection(collectionId);
-        return { request: request.then(getEmbeddedCollections), cancel };
-    }, [collectionId]);
-    const { data, loading, error } = useRestQuery(collectionFetcher);
+
+    const { data, loading, error } = useCollection(collectionId);
 
     const { toasts, addToast, removeToast } = useToasts();
 

--- a/ui/apps/platform/src/Containers/Collections/hooks/useCollection.ts
+++ b/ui/apps/platform/src/Containers/Collections/hooks/useCollection.ts
@@ -1,0 +1,50 @@
+import { useCallback } from 'react';
+
+import useRestQuery from 'Containers/Dashboard/hooks/useRestQuery';
+import {
+    CollectionResponse,
+    getCollection,
+    listCollections,
+    ResolvedCollectionResponse,
+} from 'services/CollectionsService';
+
+const defaultCollectionData: Omit<CollectionResponse, 'id'> = {
+    name: '',
+    description: '',
+    inUse: false,
+    embeddedCollections: [],
+    resourceSelectors: [],
+};
+
+const noopRequest = {
+    request: Promise.resolve<{
+        collection: Omit<CollectionResponse, 'id'>;
+        embeddedCollections: CollectionResponse[];
+    }>({ collection: defaultCollectionData, embeddedCollections: [] }),
+    cancel: () => {},
+};
+
+function getEmbeddedCollections({ collection }: ResolvedCollectionResponse): Promise<{
+    collection: CollectionResponse;
+    embeddedCollections: CollectionResponse[];
+}> {
+    if (collection.embeddedCollections.length === 0) {
+        return Promise.resolve({ collection, embeddedCollections: [] });
+    }
+    const idSearchString = collection.embeddedCollections.map(({ id }) => id).join(',');
+    const searchFilter = { 'Collection ID': idSearchString };
+    const { request } = listCollections(searchFilter, { field: 'name', reversed: false });
+    return request.then((embeddedCollections) => ({ collection, embeddedCollections }));
+}
+
+export default function useCollection(collectionId: string | undefined) {
+    const collectionFetcher = useCallback(() => {
+        if (!collectionId) {
+            return noopRequest;
+        }
+        const { request, cancel } = getCollection(collectionId);
+        return { request: request.then(getEmbeddedCollections), cancel };
+    }, [collectionId]);
+
+    return useRestQuery(collectionFetcher);
+}


### PR DESCRIPTION
## Description (2 of 3)

This is the second step to the refactor described in https://github.com/stackrox/stackrox/pull/3744, which decouples the `CollectionForm` from the PatternFly Drawer layout used to display it. Viewing the code changes with Github's "Hide whitespace" option enabled makes it more apparent how code was move around in this change.

This is another non-functional change that only aims to restructure this code.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.
