### PR TITLE
Extract collection fetching code into hook

### DIFF
--- a/ui/apps/platform/src/Containers/Collections/CollectionsFormPage.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionsFormPage.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useCallback, useState } from 'react';
+import React, { ReactElement, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import {
     Alert,
@@ -19,16 +19,7 @@ import {
 } from '@patternfly/react-core';
 import { useMediaQuery } from 'react-responsive';
 
-import useRestQuery from 'Containers/Dashboard/hooks/useRestQuery';
-import {
-    CollectionResponse,
-    createCollection,
-    deleteCollection,
-    getCollection,
-    listCollections,
-    ResolvedCollectionResponse,
-    updateCollection,
-} from 'services/CollectionsService';
+import { createCollection, deleteCollection, updateCollection } from 'services/CollectionsService';
 import { CaretDownIcon } from '@patternfly/react-icons';
 import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
 import { collectionsBasePath } from 'routePaths';
@@ -40,40 +31,12 @@ import { CollectionPageAction } from './collections.utils';
 import CollectionFormDrawer from './CollectionFormDrawer';
 import { generateRequest } from './converter';
 import { Collection } from './types';
+import useCollection from './hooks/useCollection';
 
 export type CollectionsFormPageProps = {
     hasWriteAccessForCollections: boolean;
     pageAction: CollectionPageAction;
 };
-
-const defaultCollectionData: Omit<CollectionResponse, 'id'> = {
-    name: '',
-    description: '',
-    inUse: false,
-    embeddedCollections: [],
-    resourceSelectors: [],
-};
-
-const noopRequest = {
-    request: Promise.resolve<{
-        collection: Omit<CollectionResponse, 'id'>;
-        embeddedCollections: CollectionResponse[];
-    }>({ collection: defaultCollectionData, embeddedCollections: [] }),
-    cancel: () => {},
-};
-
-function getEmbeddedCollections({ collection }: ResolvedCollectionResponse): Promise<{
-    collection: CollectionResponse;
-    embeddedCollections: CollectionResponse[];
-}> {
-    if (collection.embeddedCollections.length === 0) {
-        return Promise.resolve({ collection, embeddedCollections: [] });
-    }
-    const idSearchString = collection.embeddedCollections.map(({ id }) => id).join(',');
-    const searchFilter = { 'Collection ID': idSearchString };
-    const { request } = listCollections(searchFilter, { field: 'name', reversed: false });
-    return request.then((embeddedCollections) => ({ collection, embeddedCollections }));
-}
 
 function CollectionsFormPage({
     hasWriteAccessForCollections,
@@ -82,14 +45,8 @@ function CollectionsFormPage({
     const history = useHistory();
     const isLargeScreen = useMediaQuery({ query: '(min-width: 992px)' }); // --pf-global--breakpoint--lg
     const collectionId = pageAction.type !== 'create' ? pageAction.collectionId : undefined;
-    const collectionFetcher = useCallback(() => {
-        if (!collectionId) {
-            return noopRequest;
-        }
-        const { request, cancel } = getCollection(collectionId);
-        return { request: request.then(getEmbeddedCollections), cancel };
-    }, [collectionId]);
-    const { data, loading, error } = useRestQuery(collectionFetcher);
+
+    const { data, loading, error } = useCollection(collectionId);
 
     const { toasts, addToast, removeToast } = useToasts();
 

--- a/ui/apps/platform/src/Containers/Collections/hooks/useCollection.ts
+++ b/ui/apps/platform/src/Containers/Collections/hooks/useCollection.ts
@@ -1,0 +1,50 @@
+import { useCallback } from 'react';
+
+import useRestQuery from 'Containers/Dashboard/hooks/useRestQuery';
+import {
+    CollectionResponse,
+    getCollection,
+    listCollections,
+    ResolvedCollectionResponse,
+} from 'services/CollectionsService';
+
+const defaultCollectionData: Omit<CollectionResponse, 'id'> = {
+    name: '',
+    description: '',
+    inUse: false,
+    embeddedCollections: [],
+    resourceSelectors: [],
+};
+
+const noopRequest = {
+    request: Promise.resolve<{
+        collection: Omit<CollectionResponse, 'id'>;
+        embeddedCollections: CollectionResponse[];
+    }>({ collection: defaultCollectionData, embeddedCollections: [] }),
+    cancel: () => {},
+};
+
+function getEmbeddedCollections({ collection }: ResolvedCollectionResponse): Promise<{
+    collection: CollectionResponse;
+    embeddedCollections: CollectionResponse[];
+}> {
+    if (collection.embeddedCollections.length === 0) {
+        return Promise.resolve({ collection, embeddedCollections: [] });
+    }
+    const idSearchString = collection.embeddedCollections.map(({ id }) => id).join(',');
+    const searchFilter = { 'Collection ID': idSearchString };
+    const { request } = listCollections(searchFilter, { field: 'name', reversed: false });
+    return request.then((embeddedCollections) => ({ collection, embeddedCollections }));
+}
+
+export default function useCollection(collectionId: string | undefined) {
+    const collectionFetcher = useCallback(() => {
+        if (!collectionId) {
+            return noopRequest;
+        }
+        const { request, cancel } = getCollection(collectionId);
+        return { request: request.then(getEmbeddedCollections), cancel };
+    }, [collectionId]);
+
+    return useRestQuery(collectionFetcher);
+}


### PR DESCRIPTION
## Description (3 of 3)

This extracts the collection and embedded collection fetching logic into a reusable hook, which will be needed later when we add an independent modal for displaying the collection form.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

