### PR TITLE
Add ability to view embedded collections in a pop up modal

### DIFF
--- a/ui/apps/platform/src/Containers/Collections/CollectionAttacher.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionAttacher.tsx
@@ -5,27 +5,13 @@ import BacklogListSelector from 'Components/PatternFly/BacklogListSelector';
 import { CollectionResponse } from 'services/CollectionsService';
 import useEmbeddedCollections from './hooks/useEmbeddedCollections';
 
-const selectorListCells = [
-    {
-        name: 'Name',
-        render: ({ name }) => (
-            <Button variant="link" className="pf-u-pl-0" isInline>
-                {name}
-            </Button>
-        ),
-    },
-    {
-        name: 'Description',
-        render: ({ description }) => <Truncate content={description} />,
-    },
-];
-
 export type CollectionAttacherProps = {
     // A collection ID that should not be visible in the collection attacher component. This is
     // used when editing a collection to prevent reference cycles.
     excludedCollectionId: string | null;
     initialEmbeddedCollections: CollectionResponse[];
     onSelectionChange: (collections: CollectionResponse[]) => void;
+    onItemClick: (collectionId: string) => void;
 };
 
 function compareNameLowercase(search: string): (item: { name: string }) => boolean {
@@ -36,6 +22,7 @@ function CollectionAttacher({
     excludedCollectionId,
     initialEmbeddedCollections,
     onSelectionChange,
+    onItemClick,
 }: CollectionAttacherProps) {
     const [search, setSearch] = useState('');
     const embedded = useEmbeddedCollections(excludedCollectionId, initialEmbeddedCollections);
@@ -50,6 +37,26 @@ function CollectionAttacher({
             }, 800),
         [onSearch]
     );
+
+    const selectorListCells = [
+        {
+            name: 'Name',
+            render: ({ id, name }) => (
+                <Button
+                    variant="link"
+                    className="pf-u-pl-0"
+                    isInline
+                    onClick={() => onItemClick(id)}
+                >
+                    {name}
+                </Button>
+            ),
+        },
+        {
+            name: 'Description',
+            render: ({ description }) => <Truncate content={description} />,
+        },
+    ];
 
     const selectedOptions = attached.filter(compareNameLowercase(search));
     const deselectedOptions = detached.filter(compareNameLowercase(search));

--- a/ui/apps/platform/src/Containers/Collections/CollectionAttacher.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionAttacher.tsx
@@ -1,5 +1,5 @@
-import React, { useMemo, useState } from 'react';
-import { Alert, Button, debounce, Flex, SearchInput, Truncate } from '@patternfly/react-core';
+import React, { ReactNode, useMemo, useState } from 'react';
+import { Alert, Button, debounce, Flex, SearchInput } from '@patternfly/react-core';
 
 import BacklogListSelector from 'Components/PatternFly/BacklogListSelector';
 import { CollectionResponse } from 'services/CollectionsService';
@@ -11,7 +11,7 @@ export type CollectionAttacherProps = {
     excludedCollectionId: string | null;
     initialEmbeddedCollections: CollectionResponse[];
     onSelectionChange: (collections: CollectionResponse[]) => void;
-    onItemClick: (collectionId: string) => void;
+    collectionTableCells: { name: string; render: (collection: CollectionResponse) => ReactNode }[];
 };
 
 function compareNameLowercase(search: string): (item: { name: string }) => boolean {
@@ -22,7 +22,7 @@ function CollectionAttacher({
     excludedCollectionId,
     initialEmbeddedCollections,
     onSelectionChange,
-    onItemClick,
+    collectionTableCells,
 }: CollectionAttacherProps) {
     const [search, setSearch] = useState('');
     const embedded = useEmbeddedCollections(excludedCollectionId, initialEmbeddedCollections);
@@ -37,26 +37,6 @@ function CollectionAttacher({
             }, 800),
         [onSearch]
     );
-
-    const selectorListCells = [
-        {
-            name: 'Name',
-            render: ({ id, name }) => (
-                <Button
-                    variant="link"
-                    className="pf-u-pl-0"
-                    isInline
-                    onClick={() => onItemClick(id)}
-                >
-                    {name}
-                </Button>
-            ),
-        },
-        {
-            name: 'Description',
-            render: ({ description }) => <Truncate content={description} />,
-        },
-    ];
 
     const selectedOptions = attached.filter(compareNameLowercase(search));
     const deselectedOptions = detached.filter(compareNameLowercase(search));
@@ -76,7 +56,7 @@ function CollectionAttacher({
                 onDeselectItem={({ id }) => detach(id)}
                 onSelectionChange={onSelectionChange}
                 rowKey={({ id }) => id}
-                cells={selectorListCells}
+                cells={collectionTableCells}
                 selectedLabel="Attached collections"
                 deselectedLabel="Detached collections"
                 selectButtonText="Attach"

--- a/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
@@ -27,14 +27,25 @@ import RuleSelector from './RuleSelector';
 import CollectionAttacher from './CollectionAttacher';
 import { Collection, ScopedResourceSelector, SelectorEntityType } from './types';
 
-function AttachedCollectionTable({ collections }: { collections: CollectionResponse[] }) {
+function AttachedCollectionTable({
+    collections,
+    onItemClick,
+}: {
+    collections: CollectionResponse[];
+    onItemClick: (id: string) => void;
+}) {
     return collections.length > 0 ? (
         <TableComposable aria-label="Attached collections" variant={TableVariant.compact}>
             <Tbody>
-                {collections.map(({ name, description }) => (
+                {collections.map(({ id, name, description }) => (
                     <Tr key={name}>
                         <Td dataLabel="Name">
-                            <Button variant="link" className="pf-u-pl-0" isInline>
+                            <Button
+                                variant="link"
+                                className="pf-u-pl-0"
+                                isInline
+                                onClick={() => onItemClick(id)}
+                            >
                                 {name}
                             </Button>
                         </Td>
@@ -62,9 +73,8 @@ export type CollectionFormProps = {
     /* collection responses for the embedded collections of `initialData` */
     initialEmbeddedCollections: CollectionResponse[];
     onSubmit: (collection: Collection) => Promise<void>;
-    /* Callback used when clicking on a collection name in the CollectionAttacher section. If
-    left undefined, collection names will not be linked. */
-    appendTableLinkAction?: (collectionId: string) => void;
+    /* Callback used when clicking on a collection name in the CollectionAttacher section. */
+    appendTableLinkAction: (collectionId: string) => void;
     /* content to render before the main form */
     headerContent?: ReactElement;
 };
@@ -103,6 +113,7 @@ function CollectionForm({
     initialData,
     initialEmbeddedCollections,
     onSubmit,
+    appendTableLinkAction,
 }: CollectionFormProps) {
     const history = useHistory();
 
@@ -253,7 +264,10 @@ function CollectionForm({
                         Attached collections
                     </Title>
                     {isReadOnly ? (
-                        <AttachedCollectionTable collections={initialEmbeddedCollections} />
+                        <AttachedCollectionTable
+                            collections={initialEmbeddedCollections}
+                            onItemClick={appendTableLinkAction}
+                        />
                     ) : (
                         <>
                             <p>Extend this collection by attaching other sets.</p>
@@ -263,6 +277,7 @@ function CollectionForm({
                                 }
                                 initialEmbeddedCollections={initialEmbeddedCollections}
                                 onSelectionChange={onEmbeddedCollectionsChange}
+                                onItemClick={appendTableLinkAction}
                             />
                         </>
                     )}

--- a/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
@@ -12,7 +12,6 @@ import {
     Label,
     TextInput,
     Title,
-    Truncate,
 } from '@patternfly/react-core';
 import { CubesIcon } from '@patternfly/react-icons';
 import { TableComposable, TableVariant, Tbody, Tr, Td } from '@patternfly/react-table';
@@ -24,34 +23,26 @@ import { CollectionResponse } from 'services/CollectionsService';
 import { getIsValidLabelKey } from 'utils/labels';
 import { CollectionPageAction } from './collections.utils';
 import RuleSelector from './RuleSelector';
-import CollectionAttacher from './CollectionAttacher';
+import CollectionAttacher, { CollectionAttacherProps } from './CollectionAttacher';
 import { Collection, ScopedResourceSelector, SelectorEntityType } from './types';
 
 function AttachedCollectionTable({
     collections,
-    onItemClick,
+    collectionTableCells,
 }: {
     collections: CollectionResponse[];
-    onItemClick: (id: string) => void;
+    collectionTableCells: CollectionAttacherProps['collectionTableCells'];
 }) {
     return collections.length > 0 ? (
         <TableComposable aria-label="Attached collections" variant={TableVariant.compact}>
             <Tbody>
-                {collections.map(({ id, name, description }) => (
-                    <Tr key={name}>
-                        <Td dataLabel="Name">
-                            <Button
-                                variant="link"
-                                className="pf-u-pl-0"
-                                isInline
-                                onClick={() => onItemClick(id)}
-                            >
-                                {name}
-                            </Button>
-                        </Td>
-                        <Td dataLabel="Description">
-                            <Truncate content={description} />
-                        </Td>
+                {collections.map((collection) => (
+                    <Tr key={collection.name}>
+                        {collectionTableCells.map(({ name, render }) => (
+                            <Td key={name} dataLabel={name}>
+                                {render(collection)}
+                            </Td>
+                        ))}
                     </Tr>
                 ))}
             </Tbody>
@@ -73,8 +64,8 @@ export type CollectionFormProps = {
     /* collection responses for the embedded collections of `initialData` */
     initialEmbeddedCollections: CollectionResponse[];
     onSubmit: (collection: Collection) => Promise<void>;
-    /* Callback used when clicking on a collection name in the CollectionAttacher section. */
-    appendTableLinkAction: (collectionId: string) => void;
+    /* Table cells to render for each collection in the CollectionAttacher component */
+    collectionTableCells: CollectionAttacherProps['collectionTableCells'];
     /* content to render before the main form */
     headerContent?: ReactElement;
 };
@@ -113,7 +104,7 @@ function CollectionForm({
     initialData,
     initialEmbeddedCollections,
     onSubmit,
-    appendTableLinkAction,
+    collectionTableCells,
 }: CollectionFormProps) {
     const history = useHistory();
 
@@ -266,7 +257,7 @@ function CollectionForm({
                     {isReadOnly ? (
                         <AttachedCollectionTable
                             collections={initialEmbeddedCollections}
-                            onItemClick={appendTableLinkAction}
+                            collectionTableCells={collectionTableCells}
                         />
                     ) : (
                         <>
@@ -277,7 +268,7 @@ function CollectionForm({
                                 }
                                 initialEmbeddedCollections={initialEmbeddedCollections}
                                 onSelectionChange={onEmbeddedCollectionsChange}
-                                onItemClick={appendTableLinkAction}
+                                collectionTableCells={collectionTableCells}
                             />
                         </>
                     )}

--- a/ui/apps/platform/src/Containers/Collections/CollectionFormDrawer.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionFormDrawer.tsx
@@ -1,5 +1,6 @@
 import React, { ReactElement, useEffect } from 'react';
 import {
+    Button,
     Drawer,
     DrawerActions,
     DrawerCloseButton,
@@ -10,6 +11,7 @@ import {
     DrawerPanelContent,
     Text,
     Title,
+    Truncate,
 } from '@patternfly/react-core';
 
 import { CollectionResponse } from 'services/CollectionsService';
@@ -17,7 +19,7 @@ import { CollectionPageAction } from './collections.utils';
 import CollectionResults from './CollectionResults';
 import { Collection } from './types';
 import { parseCollection } from './converter';
-import CollectionForm from './CollectionForm';
+import CollectionForm, { CollectionFormProps } from './CollectionForm';
 
 export type CollectionFormDrawerProps = {
     hasWriteAccessForCollections: boolean;
@@ -34,8 +36,7 @@ export type CollectionFormDrawerProps = {
     toggleDrawer: (isOpen: boolean) => void;
     headerContent?: ReactElement;
     onSubmit: (collection: Collection) => Promise<void>;
-    /* Callback used when clicking on a collection name in the CollectionAttacher section. */
-    appendTableLinkAction: (collectionId: string) => void;
+    collectionTableCells: CollectionFormProps['collectionTableCells'];
 };
 
 function CollectionFormDrawer({
@@ -47,7 +48,7 @@ function CollectionFormDrawer({
     isDrawerOpen,
     toggleDrawer,
     onSubmit,
-    appendTableLinkAction,
+    collectionTableCells,
 }: CollectionFormDrawerProps) {
     const initialData = parseCollection(collectionData.collection);
     const initialEmbeddedCollections = collectionData.embeddedCollections;
@@ -95,7 +96,7 @@ function CollectionFormDrawer({
                                 initialData={initialData}
                                 initialEmbeddedCollections={initialEmbeddedCollections}
                                 onSubmit={onSubmit}
-                                appendTableLinkAction={appendTableLinkAction}
+                                collectionTableCells={collectionTableCells}
                             />
                         )}
                     </DrawerContentBody>

--- a/ui/apps/platform/src/Containers/Collections/CollectionFormDrawer.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionFormDrawer.tsx
@@ -34,9 +34,8 @@ export type CollectionFormDrawerProps = {
     toggleDrawer: (isOpen: boolean) => void;
     headerContent?: ReactElement;
     onSubmit: (collection: Collection) => Promise<void>;
-    /* Callback used when clicking on a collection name in the CollectionAttacher section. If
-    left undefined, collection names will not be linked. */
-    appendTableLinkAction?: (collectionId: string) => void;
+    /* Callback used when clicking on a collection name in the CollectionAttacher section. */
+    appendTableLinkAction: (collectionId: string) => void;
 };
 
 function CollectionFormDrawer({
@@ -48,6 +47,7 @@ function CollectionFormDrawer({
     isDrawerOpen,
     toggleDrawer,
     onSubmit,
+    appendTableLinkAction,
 }: CollectionFormDrawerProps) {
     const initialData = parseCollection(collectionData.collection);
     const initialEmbeddedCollections = collectionData.embeddedCollections;
@@ -69,9 +69,11 @@ function CollectionFormDrawer({
                             <DrawerHead>
                                 <Title headingLevel="h2">Collection results</Title>
                                 <Text>See a preview of current matches.</Text>
-                                <DrawerActions>
-                                    <DrawerCloseButton onClick={() => toggleDrawer(false)} />
-                                </DrawerActions>
+                                {!isInlineDrawer && (
+                                    <DrawerActions>
+                                        <DrawerCloseButton onClick={() => toggleDrawer(false)} />
+                                    </DrawerActions>
+                                )}
                             </DrawerHead>
                             <DrawerPanelBody className="pf-u-h-100" style={{ overflow: 'auto' }}>
                                 <CollectionResults />
@@ -93,6 +95,7 @@ function CollectionFormDrawer({
                                 initialData={initialData}
                                 initialEmbeddedCollections={initialEmbeddedCollections}
                                 onSubmit={onSubmit}
+                                appendTableLinkAction={appendTableLinkAction}
                             />
                         )}
                     </DrawerContentBody>

--- a/ui/apps/platform/src/Containers/Collections/CollectionFormDrawer.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionFormDrawer.tsx
@@ -1,6 +1,5 @@
 import React, { ReactElement, useEffect } from 'react';
 import {
-    Button,
     Drawer,
     DrawerActions,
     DrawerCloseButton,
@@ -11,7 +10,6 @@ import {
     DrawerPanelContent,
     Text,
     Title,
-    Truncate,
 } from '@patternfly/react-core';
 
 import { CollectionResponse } from 'services/CollectionsService';

--- a/ui/apps/platform/src/Containers/Collections/CollectionFormModal.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionFormModal.tsx
@@ -1,10 +1,11 @@
 import React, { ReactElement } from 'react';
-import { Button, Divider, Flex, FlexItem, Modal, Title } from '@patternfly/react-core';
+import { Button, Divider, Flex, FlexItem, Modal, Title, Truncate } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import { useMediaQuery } from 'react-responsive';
 
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
 import { collectionsBasePath } from 'routePaths';
+import { CollectionResponse } from 'services/CollectionsService';
 import useCollection from './hooks/useCollection';
 import CollectionFormDrawer from './CollectionFormDrawer';
 
@@ -13,6 +14,28 @@ export type CollectionsFormModalProps = {
     collectionId: string;
     onClose: () => void;
 };
+const collectionTableCells = [
+    {
+        name: 'Name',
+        render: ({ id, name }: CollectionResponse) => (
+            <Button
+                variant="link"
+                component="a"
+                isInline
+                href={`${collectionsBasePath}/${id}?action=edit`}
+                target="_blank"
+                rel="noopener noreferrer"
+                icon={<ExternalLinkAltIcon />}
+            >
+                {name}
+            </Button>
+        ),
+    },
+    {
+        name: 'Description',
+        render: ({ description }) => <Truncate content={description} />,
+    },
+];
 
 function CollectionsFormModal({
     hasWriteAccessForCollections,
@@ -92,10 +115,7 @@ function CollectionsFormModal({
                     toggleDrawer={toggleDrawer}
                     // Since the form cannot be submitted, stub this out with an empty promise
                     onSubmit={() => Promise.resolve()}
-                    appendTableLinkAction={(id) => {
-                        const url = `${window.location.origin}${collectionsBasePath}/${id}`;
-                        window.open(url, '_blank', 'noopener noreferrer');
-                    }}
+                    collectionTableCells={collectionTableCells}
                 />
             </Modal>
         );

--- a/ui/apps/platform/src/Containers/Collections/CollectionFormModal.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionFormModal.tsx
@@ -1,0 +1,107 @@
+import React, { ReactElement } from 'react';
+import { Button, Divider, Flex, FlexItem, Modal, Title } from '@patternfly/react-core';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+import { useMediaQuery } from 'react-responsive';
+
+import useSelectToggle from 'hooks/patternfly/useSelectToggle';
+import { collectionsBasePath } from 'routePaths';
+import useCollection from './hooks/useCollection';
+import CollectionFormDrawer from './CollectionFormDrawer';
+
+export type CollectionsFormModalProps = {
+    hasWriteAccessForCollections: boolean;
+    collectionId: string;
+    onClose: () => void;
+};
+
+function CollectionsFormModal({
+    hasWriteAccessForCollections,
+    collectionId,
+    onClose,
+}: CollectionsFormModalProps) {
+    const isLargeScreen = useMediaQuery({ query: '(min-width: 992px)' }); // --pf-global--breakpoint--lg
+    const {
+        isOpen: isDrawerOpen,
+        toggleSelect: toggleDrawer,
+        closeSelect: closeDrawer,
+        openSelect: openDrawer,
+    } = useSelectToggle(isLargeScreen);
+
+    const { data, loading, error } = useCollection(collectionId);
+
+    let content: ReactElement | null = null;
+
+    if (error) {
+        content = (
+            <>
+                {error.message}
+                {/* TODO - Handle UI for network errors */}
+            </>
+        );
+    } else if (loading) {
+        content = <>{/* TODO - Handle UI for loading state */}</>;
+    } else if (data) {
+        content = (
+            <Modal
+                isOpen
+                onClose={onClose}
+                aria-label={`View ${data.collection.name}`}
+                width="90vw"
+                hasNoBodyWrapper
+                header={
+                    <Flex className="pf-u-pb-md" alignItems={{ default: 'alignItemsCenter' }}>
+                        <FlexItem grow={{ default: 'grow' }}>
+                            <Title headingLevel="h2">{data.collection.name}</Title>
+                        </FlexItem>
+                        {hasWriteAccessForCollections && (
+                            <Button
+                                variant="link"
+                                component="a"
+                                href={`${collectionsBasePath}/${collectionId}?action=edit`}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                icon={<ExternalLinkAltIcon />}
+                            >
+                                Edit collection
+                            </Button>
+                        )}
+                        {isDrawerOpen ? (
+                            <Button variant="secondary" onClick={closeDrawer}>
+                                Hide results
+                            </Button>
+                        ) : (
+                            <Button variant="secondary" onClick={openDrawer}>
+                                Preview results
+                            </Button>
+                        )}
+                        <Divider orientation={{ default: 'vertical' }} component="div" />
+                    </Flex>
+                }
+            >
+                <Divider component="div" />
+                <CollectionFormDrawer
+                    // We do not want to present the user with options to change the collection when in this modal
+                    hasWriteAccessForCollections={false}
+                    action={{
+                        type: 'view',
+                        collectionId,
+                    }}
+                    collectionData={data}
+                    isInlineDrawer={isLargeScreen}
+                    isDrawerOpen={isDrawerOpen}
+                    toggleDrawer={toggleDrawer}
+                    // Since the form cannot be submitted, stub this out with an empty promise
+                    onSubmit={() => Promise.resolve()}
+                    appendTableLinkAction={(id) => {
+                        const url = `${window.location.origin}${collectionsBasePath}/${id}`;
+                        window.open(url, '_blank', 'noopener noreferrer');
+                    }}
+                />
+            </Modal>
+        );
+    }
+
+    return content;
+}
+
+export default CollectionsFormModal;

--- a/ui/apps/platform/src/Containers/Collections/CollectionFormModal.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionFormModal.tsx
@@ -84,6 +84,7 @@ function CollectionsFormModal({
                                 target="_blank"
                                 rel="noopener noreferrer"
                                 icon={<ExternalLinkAltIcon />}
+                                iconPosition="right"
                             >
                                 Edit collection
                             </Button>

--- a/ui/apps/platform/src/Containers/Collections/CollectionsFormPage.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionsFormPage.tsx
@@ -32,6 +32,7 @@ import CollectionFormDrawer from './CollectionFormDrawer';
 import { generateRequest } from './converter';
 import { Collection } from './types';
 import useCollection from './hooks/useCollection';
+import CollectionsFormModal from './CollectionFormModal';
 
 export type CollectionsFormPageProps = {
     hasWriteAccessForCollections: boolean;
@@ -52,6 +53,7 @@ function CollectionsFormPage({
 
     const [isDeleting, setIsDeleting] = useState(false);
     const [deleteId, setDeleteId] = useState<string | null>(null);
+    const [modalCollectionId, setModalCollectionId] = useState<string | null>(null);
 
     const {
         isOpen: menuIsOpen,
@@ -153,9 +155,7 @@ function CollectionsFormPage({
                 isDrawerOpen={isDrawerOpen}
                 toggleDrawer={toggleDrawer}
                 onSubmit={onSubmit}
-                appendTableLinkAction={() => {
-                    /* TODO */
-                }}
+                appendTableLinkAction={setModalCollectionId}
                 headerContent={
                     <>
                         <Breadcrumb className="pf-u-my-xs pf-u-px-lg pf-u-py-md">
@@ -230,11 +230,11 @@ function CollectionsFormPage({
                                 )}
                                 {isDrawerOpen ? (
                                     <Button variant="secondary" onClick={closeDrawer}>
-                                        Hide collection results
+                                        Hide results
                                     </Button>
                                 ) : (
                                     <Button variant="secondary" onClick={openDrawer}>
-                                        Preview collection results
+                                        Preview results
                                     </Button>
                                 )}
                             </FlexItem>
@@ -249,6 +249,13 @@ function CollectionsFormPage({
     return (
         <PageSection className="pf-u-h-100" padding={{ default: 'noPadding' }}>
             {content}
+            {modalCollectionId && (
+                <CollectionsFormModal
+                    hasWriteAccessForCollections={hasWriteAccessForCollections}
+                    collectionId={modalCollectionId}
+                    onClose={() => setModalCollectionId(null)}
+                />
+            )}
             <AlertGroup isToast isLiveRegion>
                 {toasts.map(({ key, variant, title, children }) => (
                     <Alert

--- a/ui/apps/platform/src/Containers/Collections/CollectionsFormPage.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionsFormPage.tsx
@@ -16,6 +16,7 @@ import {
     FlexItem,
     PageSection,
     Title,
+    Truncate,
 } from '@patternfly/react-core';
 import { useMediaQuery } from 'react-responsive';
 
@@ -133,6 +134,21 @@ function CollectionsFormPage({
             });
     }
 
+    const collectionTableCells = [
+        {
+            name: 'Name',
+            render: ({ id, name }) => (
+                <Button variant="link" isInline onClick={() => setModalCollectionId(id)}>
+                    {name}
+                </Button>
+            ),
+        },
+        {
+            name: 'Description',
+            render: ({ description }) => <Truncate content={description} />,
+        },
+    ];
+
     let content: ReactElement | undefined;
 
     if (error) {
@@ -155,7 +171,7 @@ function CollectionsFormPage({
                 isDrawerOpen={isDrawerOpen}
                 toggleDrawer={toggleDrawer}
                 onSubmit={onSubmit}
-                appendTableLinkAction={setModalCollectionId}
+                collectionTableCells={collectionTableCells}
                 headerContent={
                     <>
                         <Breadcrumb className="pf-u-my-xs pf-u-px-lg pf-u-py-md">


### PR DESCRIPTION
## Description

This adds the ability to view the collection form and results in a modal. The collection name links in the "Attached collections" section now open this modal allowing the user to get a quick view of this nested collection. When viewing a collection in the modal, clicking the link in the "Attached collections" table yet again will instead open a new tab to view that collection.

Additionally, the drawer panel close "X" button is removed when the drawer is displayed inline. This is to avoid conflicting with the same "X" close button in the modal that appears in nearly the same location, as well as the fact that we have a dedicated hide/show button next to the panel. The exception to this is when the drawer panel overlays the main content, since without the "X" button there would be no way to close the panel.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Navigate to a collection page that has attached collections.
![image](https://user-images.githubusercontent.com/1292638/200931479-b45c26e8-f562-4ec5-b05b-ac291d494697.png)

Clicking on one of the collections in the table will open a modal that displays the information of the collection in read only mode.
![image](https://user-images.githubusercontent.com/1292638/200932589-7b1c6a28-ace7-41d8-9a5d-2771b15569ec.png)

From within the modal, clicking an embedded collection will open a new tab for that collection in "view" mode.
![image](https://user-images.githubusercontent.com/1292638/200932795-1280ca72-3f2f-43cf-8e50-07eb6e543366.png)

At the top of the modal, clicking the "Edit collection" button will open a new tab for the modal collection in "edit" mode.
![image](https://user-images.githubusercontent.com/1292638/200932981-a0e8796f-bef2-4ea6-a47f-0b4a38e134f3.png)

Small screen views:
![image](https://user-images.githubusercontent.com/1292638/200933705-618b9c9b-6dea-41ea-bfde-1a5f77aa92fb.png)
![image](https://user-images.githubusercontent.com/1292638/200933747-f827183e-6b7c-444b-9a75-ceb1b09b5270.png)
![image](https://user-images.githubusercontent.com/1292638/200933824-490f4d67-270b-4de6-a132-6aa1223a93f0.png)
![image](https://user-images.githubusercontent.com/1292638/200933876-8b81335e-4f04-4a3d-9502-900ed532b498.png)



