### PR TITLE
ROX-13466: Fix deletion of groups with empty properties

### DIFF
--- a/central/group/datastore/datastore.go
+++ b/central/group/datastore/datastore.go
@@ -21,6 +21,7 @@ type DataStore interface {
 	Mutate(ctx context.Context, remove, update, add []*storage.Group, force bool) error
 	Remove(ctx context.Context, props *storage.GroupProperties, force bool) error
 	RemoveAllWithAuthProviderID(ctx context.Context, authProviderID string, force bool) error
+	RemoveAllWithEmptyProperties(ctx context.Context) error
 }
 
 // New returns a new DataStore instance.

--- a/central/group/datastore/datastore_impl.go
+++ b/central/group/datastore/datastore_impl.go
@@ -3,10 +3,12 @@ package datastore
 import (
 	"context"
 
+	"github.com/gogo/protobuf/proto"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/central/group/datastore/internal/store"
 	"github.com/stackrox/rox/central/role/resources"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/errorhelpers"
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/postgres/pgutils"
 	"github.com/stackrox/rox/pkg/sac"
@@ -218,6 +220,41 @@ func (ds *dataStoreImpl) RemoveAllWithAuthProviderID(ctx context.Context, authPr
 	return ds.Mutate(ctx, groups, nil, nil, force)
 }
 
+func (ds *dataStoreImpl) RemoveAllWithEmptyProperties(ctx context.Context) error {
+	// Search through all groups and verify whether any group exists with empty properties and attempt to delete them.
+	isEmptyGroupPropertiesF := func(props *storage.GroupProperties) bool {
+		if props.GetAuthProviderId() == "" && props.GetKey() == "" && props.GetValue() == "" {
+			return true
+		}
+		return false
+	}
+	groups, err := ds.GetFiltered(ctx, isEmptyGroupPropertiesF)
+	if err != nil {
+		return err
+	}
+
+	var removeGroupErrs errorhelpers.ErrorList
+	for _, group := range groups {
+		// Since we are dealing with empty properties, we only require the ID to be set.
+		// In case the ID is not set, add the error to the error list.
+		id := group.GetProps().GetId()
+		if id == "" {
+			removeGroupErrs.AddError(errox.InvalidArgs.Newf("group %s has no ID set and cannot be deleted",
+				proto.MarshalTextString(group)))
+			continue
+		}
+		_, err := ds.validateGroupExists(ctx, id)
+		if err != nil {
+			removeGroupErrs.AddError(err)
+			continue
+		}
+		if err := ds.storage.Delete(ctx, id); err != nil {
+			removeGroupErrs.AddError(err)
+		}
+	}
+	return removeGroupErrs.ToError()
+}
+
 // Helpers
 //////////
 
@@ -370,12 +407,9 @@ func (ds *dataStoreImpl) getDefaultGroupForProps(ctx context.Context, props *sto
 // validateMutableGroupIDNoLock validates whether a group allows changes or not based on the mutability mode set.
 // NOTE: This function assumes that the call to this function is already behind a lock.
 func (ds *dataStoreImpl) validateMutableGroupIDNoLock(ctx context.Context, id string, force bool) error {
-	group, exists, err := ds.storage.Get(ctx, id)
+	group, err := ds.validateGroupExists(ctx, id)
 	if err != nil {
 		return err
-	}
-	if !exists {
-		return errox.NotFound.Newf("group with id %q was not found", id)
 	}
 
 	switch group.GetProps().GetTraits().GetMutabilityMode() {
@@ -392,4 +426,15 @@ func (ds *dataStoreImpl) validateMutableGroupIDNoLock(ctx context.Context, id st
 			group.GetProps().GetTraits().GetMutabilityMode().String()))
 	}
 	return errox.InvalidArgs.Newf("group %q is immutable", id)
+}
+
+func (ds *dataStoreImpl) validateGroupExists(ctx context.Context, id string) (*storage.Group, error) {
+	group, exists, err := ds.storage.Get(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, errox.NotFound.Newf("group with id %q was not found", id)
+	}
+	return group, nil
 }

--- a/central/group/datastore/mocks/datastore.go
+++ b/central/group/datastore/mocks/datastore.go
@@ -136,6 +136,20 @@ func (mr *MockDataStoreMockRecorder) RemoveAllWithAuthProviderID(ctx, authProvid
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveAllWithAuthProviderID", reflect.TypeOf((*MockDataStore)(nil).RemoveAllWithAuthProviderID), ctx, authProviderID, force)
 }
 
+// RemoveAllWithEmptyProperties mocks base method.
+func (m *MockDataStore) RemoveAllWithEmptyProperties(ctx context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoveAllWithEmptyProperties", ctx)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RemoveAllWithEmptyProperties indicates an expected call of RemoveAllWithEmptyProperties.
+func (mr *MockDataStoreMockRecorder) RemoveAllWithEmptyProperties(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveAllWithEmptyProperties", reflect.TypeOf((*MockDataStore)(nil).RemoveAllWithEmptyProperties), ctx)
+}
+
 // Update mocks base method.
 func (m *MockDataStore) Update(ctx context.Context, group *storage.Group, force bool) error {
 	m.ctrl.T.Helper()

--- a/central/group/datastore/singleton.go
+++ b/central/group/datastore/singleton.go
@@ -19,13 +19,6 @@ var (
 	once sync.Once
 )
 
-var isEmptyGroupPropertiesF = func(props *storage.GroupProperties) bool {
-	if props.GetAuthProviderId() == "" && props.GetKey() == "" && props.GetValue() == "" {
-		return true
-	}
-	return false
-}
-
 func initialize() {
 	if env.PostgresDatastoreEnabled.BooleanSetting() {
 		ds = New(postgres.New(globaldb.GetPostgres()))
@@ -39,12 +32,7 @@ func initialize() {
 			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
 			sac.ResourceScopeKeys(resources.Access)))
 
-	grps, err := ds.GetFiltered(ctx, isEmptyGroupPropertiesF)
-	utils.Should(err)
-	for _, grp := range grps {
-		err = ds.Remove(ctx, grp.GetProps(), true)
-		utils.Should(err)
-	}
+	utils.Should(ds.RemoveAllWithEmptyProperties(ctx))
 }
 
 // Singleton returns the singleton providing access to the roles store.


### PR DESCRIPTION
## Description

For additional context, see [ROX-13446](https://issues.redhat.com/browse/ROX-13446) as well.

During startup and the initialization of the group datastore, we attempt to delete groups with empty properties.

This has been there historically for quite some time ([the initial PR that introduced this](https://github.com/stackrox/rox/pull/1659) + [the associated ticket ROX-1698](https://issues.redhat.com/browse/ROX-1698)).

Now, we added validation with the move from the tuple ID key for groups (using its propreties) to a single UUID.
This leads to an issue when trying to remove groups with empty properties during startup.
Since the properties will be empty, the validation which is done within the `Remove` call, will fail (since the validation is checking whether auth provider ID is set etc.).

Within this PR, a separate function has been introduced at the datastore layer that will:
- retrieve all groups with empty properties.
- delete those groups, skipping validation and other mutability trait verification.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
~~- [ ] Evaluated and added CHANGELOG entry if required~~
~~- [ ] Determined and documented upgrade steps~~
~~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into 
[rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

- see unit tests added running within CI and passing.
