### PR TITLE
Remove obsolete authProviders request for Integrations page

### DIFF
--- a/ui/apps/platform/src/Containers/Integrations/IntegrationTilesPage/IntegrationTilesPage.js
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationTilesPage/IntegrationTilesPage.js
@@ -15,7 +15,6 @@ import IntegrationsSection from './IntegrationsSection';
 const IntegrationTilesPage = ({
     apiTokens,
     clusterInitBundles,
-    authProviders,
     backups,
     imageIntegrations,
     notifiers,
@@ -29,13 +28,14 @@ const IntegrationTilesPage = ({
 
         switch (source) {
             case 'authProviders': {
+                // Integrations Authentication Tokens differ from Access Control Auth providers.
                 if (type === 'apitoken') {
                     return apiTokens;
                 }
                 if (type === 'clusterInitBundle') {
                     return clusterInitBundles;
                 }
-                return authProviders.filter(typeLowerMatches);
+                return [];
             }
             case 'notifiers': {
                 return notifiers.filter(typeLowerMatches);
@@ -126,11 +126,6 @@ const IntegrationTilesPage = ({
 };
 
 IntegrationTilesPage.propTypes = {
-    authProviders: PropTypes.arrayOf(
-        PropTypes.shape({
-            name: PropTypes.string.isRequired,
-        })
-    ).isRequired,
     apiTokens: PropTypes.arrayOf(
         PropTypes.shape({
             name: PropTypes.string.isRequired,
@@ -153,7 +148,6 @@ IntegrationTilesPage.propTypes = {
 };
 
 const mapStateToProps = createStructuredSelector({
-    authProviders: selectors.getAuthProviders,
     apiTokens: selectors.getAPITokens,
     clusterInitBundles: selectors.getClusterInitBundles,
     notifiers: selectors.getNotifiers,

--- a/ui/apps/platform/src/Containers/Integrations/hooks/useIntegrations.ts
+++ b/ui/apps/platform/src/Containers/Integrations/hooks/useIntegrations.ts
@@ -6,7 +6,6 @@ import { selectors } from 'reducers';
 import { Integration, IntegrationSource, IntegrationType } from '../utils/integrationUtils';
 
 const selectIntegrations = createStructuredSelector({
-    authProviders: selectors.getAuthProviders,
     apiTokens: selectors.getAPITokens,
     clusterInitBundles: selectors.getClusterInitBundles,
     notifiers: selectors.getNotifiers,
@@ -26,7 +25,6 @@ const useIntegrations = ({ source, type }: UseIntegrations): UseIntegrationsResp
     const {
         apiTokens,
         clusterInitBundles,
-        authProviders,
         notifiers,
         backups,
         imageIntegrations,
@@ -39,13 +37,14 @@ const useIntegrations = ({ source, type }: UseIntegrations): UseIntegrationsResp
 
         switch (source) {
             case 'authProviders': {
+                // Integrations Authentication Tokens differ from Access Control Auth providers.
                 if (type === 'apitoken') {
                     return apiTokens;
                 }
                 if (type === 'clusterInitBundle') {
                     return clusterInitBundles;
                 }
-                return authProviders.filter(typeLowerMatches);
+                return [];
             }
             case 'notifiers': {
                 return notifiers.filter(typeLowerMatches);

--- a/ui/apps/platform/src/sagas/authSagas.js
+++ b/ui/apps/platform/src/sagas/authSagas.js
@@ -5,14 +5,8 @@ import queryString from 'qs';
 import Raven from 'raven-js';
 import { Base64 } from 'js-base64';
 
-import {
-    loginPath,
-    testLoginResultsPath,
-    accessControlPath,
-    authResponsePrefix,
-    integrationsPath,
-} from 'routePaths';
-import { takeEveryLocation, takeEveryNewlyMatchedLocation } from 'utils/sagaEffects';
+import { loginPath, testLoginResultsPath, authResponsePrefix } from 'routePaths';
+import { takeEveryLocation } from 'utils/sagaEffects';
 import * as AuthService from 'services/AuthService';
 import fetchUsersAttributes from 'services/AttributesService';
 import { fetchUserRolePermissions } from 'services/RolesService';
@@ -339,13 +333,6 @@ function* watchDeleteAuthProvider() {
     yield takeLatest(types.DELETE_AUTH_PROVIDER, deleteAuthProvider);
 }
 
-function* watchLocationForAuthProviders() {
-    const effects = [accessControlPath, integrationsPath].map((path) =>
-        takeEveryNewlyMatchedLocation(path, getAuthProviders)
-    );
-    yield all(effects);
-}
-
 function* fetchAvailableProviderTypes() {
     try {
         const result = yield call(AuthService.fetchAvailableProviderTypes);
@@ -383,7 +370,6 @@ export default function* auth() {
     }
 
     yield all([
-        fork(watchLocationForAuthProviders),
         takeEveryLocation(loginPath, handleLoginPageRedirect),
         fork(watchSaveAuthProvider),
         fork(watchDeleteAuthProvider),

--- a/ui/apps/platform/src/sagas/authSagas.test.js
+++ b/ui/apps/platform/src/sagas/authSagas.test.js
@@ -17,28 +17,6 @@ const createStateSelectors = (authProviders = [], authStatus = AUTH_STATUS.LOADI
 ];
 
 describe('Auth Sagas', () => {
-    it('should get and put auth providers when on access page', () => {
-        const authProviders = [{ name: 'ap1', validated: true }];
-        const fetchMock = jest
-            .fn()
-            .mockReturnValueOnce({ response: [] })
-            .mockReturnValueOnce({ response: authProviders });
-
-        return expectSaga(saga)
-            .provide([
-                ...createStateSelectors(),
-                [call(AuthService.fetchAuthProviders), dynamic(fetchMock)],
-                [call(AuthService.fetchLoginAuthProviders), dynamic(fetchMock)],
-                [call(AuthService.logout), null],
-                [call(fetchUserRolePermissions), { response: {} }],
-                [call(AuthService.fetchAvailableProviderTypes), { response: [] }],
-            ])
-            .put(actions.fetchAuthProviders.success(authProviders))
-            .dispatch(createLocationChange('/'))
-            .dispatch(createLocationChange('/main/access'))
-            .silentRun();
-    });
-
     it('should not do a service call to get auth providers when location changes to violations, policies, etc.', () => {
         const fetchMock = jest.fn().mockReturnValue({ response: [] });
         return expectSaga(saga)


### PR DESCRIPTION
## Description

### Problem

Given user role permissions which have `'NO_ACCESS'` for `'Access'` resource, visit Integrations page, and see redirect to Login page.

TL;DR

* `'Integration'` is the only prerequisite resource for Integrations page.
* GET /v1/authProviders request, which requires `'Access'` resource, was needed by Integrations page when it had auth providers, but not needed since they have moved.

### Analysis part 1: request causes redirect

Credit to Ivan to find the problem and search the code during testing of #3720

1. src/sagas/authSagas.js watches `integrationsPath` to call `fetchAuthProviders` service function. The request fails with 403 status code.

    ```js
    export function* getAuthProviders() {
        try {
            const result = yield call(AuthService.fetchAuthProviders);
            yield put(actions.fetchAuthProviders.success(result?.response || []));
        } catch (error) {
            yield put(actions.fetchAuthProviders.failure(error));
        }
    }
    ```

2. src/reducers/auth.js `authStatus` reducer has case for failure action.

    ```js
    case types.FETCH_AUTH_PROVIDERS.FAILURE:
        return AUTH_STATUS.AUTH_PROVIDERS_LOADING_ERROR;
    ```

3. src/Containers/MainPage/AuthenticatedRoutes.tsx redirects to Login page.

    ```js
    case AUTH_STATUS.LOGGED_OUT:
    case AUTH_STATUS.AUTH_PROVIDERS_LOADING_ERROR:
    case AUTH_STATUS.LOGIN_AUTH_PROVIDERS_LOADING_ERROR:
        return (
            <Redirect
                to={{
                    pathname: '/login',
                    state: { from: location.pathname },
                }}
            />
        );
    ```

### Analysis part 2: response not used

Although auth providers had been on Integrations page, they moved to Access page and then to Auth providers page.

Terminology is misleading. Integrations has **Authentication Tokens** heading, but:
* /main/integrations/authProviders/apitoken
* /main/integrations/authProviders/clusterInitBundle

2 occurrences of `getAuthProviders` selector are on dead code paths:

1. src/Containers/Integrations/IntegrationTilesPage/IntegrationTilesPage.js

    ```ts
    switch (source) {
        case 'authProviders': {
            if (type === 'apitoken') {
                return apiTokens;
            }
            if (type === 'clusterInitBundle') {
                return clusterInitBundles;
            }
            return authProviders.filter(typeLowerMatches);
        }
    ```

2. src/Containers/Integrations/hooks/useIntegrations.ts

    ```ts
    switch (source) {
        case 'authProviders': {
            if (type === 'apitoken') {
                return apiTokens;
            }
            if (type === 'clusterInitBundle') {
                return clusterInitBundles;
            }
            return authProviders.filter(typeLowerMatches);
        }
    ```

### Analysis part 3: saga not needed

Access Control does not depend on authSagas to call `fetchAuthProviders` function:

1. src/Containers/AccessControl/AuthProviders/AuthProviders.tsx

    ```ts
    useEffect(() => {
        dispatch(authActions.fetchAuthProviders.request());
        dispatch(roleActions.fetchRoles.request());
        dispatch(groupActions.fetchGroups.request());
    }, [dispatch]);
    ```

2. src/Containers/AccessControl/Roles/Roles.tsx

    ```ts
    Promise.all([fetchGroups(), fetchAuthProviders()])
    ```

Therefore the following saga is not needed because:
* Obsolete /main/access path, therefore never matches.
* Data in Redux store is no longer used for /main/integrations path.

```js
function* watchLocationForAuthProviders() {
    const effects = [accessControlPath, integrationsPath].map((path) =>
        takeEveryNewlyMatchedLocation(path, getAuthProviders)
    );
    yield all(effects);
}
```

### Residue

1. Add integration tests for user role permissions.
2. integrationSagas both expose and hide in global scope cause-effect relationships better encapsulated and seen in container scope.
3. auth reducer has obsolete actions and selectors:
    * action creator function: `setAuthProviderEditingState` has 2 calls
    * selector: `getAuthProviderEditingState` has 0 calls
4. sagas have references to `accessControlPath` which are probably obsolete:
    * attributesSagas
    * groupsSagas
    * roleSagas

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Edited unit tests

## Testing Performed

1. `yarn test` in ui/apps/platform to see obsolete test fail
2. `yarn lint` in ui
3. `yarn build` in ui
4. `wc build/static/js/*.chunk.js` in ui
    * branch - master: -124 = 8730599 - 8730723