### PR TITLE
Update UI Collection requests for BE compatibiltiy

### DIFF
--- a/ui/apps/platform/cypress/helpers/collections.js
+++ b/ui/apps/platform/cypress/helpers/collections.js
@@ -12,11 +12,11 @@ const requestConfigForCollections = {
     routeMatcherMap: {
         [collectionsAlias]: {
             method: 'GET',
-            url: '/v1/collections?query=*',
+            url: '/v1/collections?query.query=*',
         },
         [collectionsCountAlias]: {
             method: 'GET',
-            url: '/v1/collections/count?query=*',
+            url: '/v1/collectionscount?query.query=*',
         },
     },
 };

--- a/ui/apps/platform/src/Containers/Collections/CollectionsTable.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionsTable.tsx
@@ -132,13 +132,15 @@ function CollectionsTable({
             <TableComposable variant={TableVariant.compact}>
                 <Thead>
                     <Tr>
-                        <Th modifier="wrap" width={25} sort={getEnabledSortParams('name')}>
+                        <Th
+                            modifier="wrap"
+                            width={25}
+                            sort={getEnabledSortParams('Collection Name')}
+                        >
                             Collection
                         </Th>
-                        <Th modifier="wrap" sort={getEnabledSortParams('description')}>
-                            Description
-                        </Th>
-                        <Th modifier="wrap" width={10} sort={getEnabledSortParams('inUse')}>
+                        <Th modifier="wrap">Description</Th>
+                        <Th modifier="wrap" width={10}>
                             In use
                         </Th>
                         <Th aria-label="Row actions" />

--- a/ui/apps/platform/src/Containers/Collections/CollectionsTablePage.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionsTablePage.tsx
@@ -36,8 +36,8 @@ type CollectionsTablePageProps = {
 };
 
 const sortOptions = {
-    sortFields: ['name', 'description', 'inUse'],
-    defaultSortOption: { field: 'name', direction: 'asc' } as const,
+    sortFields: ['Collection Name'],
+    defaultSortOption: { field: 'Collection Name', direction: 'asc' } as const,
 };
 
 function CollectionsTablePage({ hasWriteAccessForCollections }: CollectionsTablePageProps) {
@@ -65,6 +65,7 @@ function CollectionsTablePage({ hasWriteAccessForCollections }: CollectionsTable
         error: countError,
         refetch: countRefetch,
     } = useRestQuery(countQuery);
+
     const isDataAvailable = typeof listData !== 'undefined' && typeof countData !== 'undefined';
     const isLoading = !isDataAvailable && (listLoading || countLoading);
     const loadError = listError || countError;

--- a/ui/apps/platform/src/Containers/Collections/hooks/useCollection.ts
+++ b/ui/apps/platform/src/Containers/Collections/hooks/useCollection.ts
@@ -33,7 +33,10 @@ function getEmbeddedCollections({ collection }: ResolvedCollectionResponse): Pro
     }
     const idSearchString = collection.embeddedCollections.map(({ id }) => id).join(',');
     const searchFilter = { 'Collection ID': idSearchString };
-    const { request } = listCollections(searchFilter, { field: 'name', reversed: false });
+    const { request } = listCollections(searchFilter, {
+        field: 'Collection Name',
+        reversed: false,
+    });
     return request.then((embeddedCollections) => ({ collection, embeddedCollections }));
 }
 

--- a/ui/apps/platform/src/Containers/Collections/hooks/useEmbeddedCollections.ts
+++ b/ui/apps/platform/src/Containers/Collections/hooks/useEmbeddedCollections.ts
@@ -53,7 +53,7 @@ function fetchDetachedCollections(
     const searchOption = { 'Collection Name': searchValue };
     const { request } = listCollections(
         searchOption,
-        { field: 'name', reversed: false },
+        { field: 'Collection Name', reversed: false },
         pageNumber - 1,
         pageSize
     );

--- a/ui/apps/platform/src/services/CollectionsService.ts
+++ b/ui/apps/platform/src/services/CollectionsService.ts
@@ -2,13 +2,13 @@ import qs from 'qs';
 
 import { ListDeployment } from 'types/deployment.proto';
 import { SearchFilter, ApiSortOption } from 'types/search';
-import { getListQueryParams, getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
+import { getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
 import { CancellableRequest, makeCancellableAxiosRequest } from './cancellationUtils';
 import axios from './instance';
 import { Empty, Pagination } from './types';
 
 export const collectionsBaseUrl = '/v1/collections';
-export const collectionsCountUrl = '/v1/collections/count';
+export const collectionsCountUrl = '/v1/collectionscount';
 export const collectionsDryRunUrl = '/v1/collections/dryrun';
 export const collectionsAutocompleteUrl = '/v1/collections/autocomplete';
 
@@ -47,7 +47,15 @@ export function listCollections(
     page?: number,
     pageSize?: number
 ): CancellableRequest<CollectionResponse[]> {
-    const params = getListQueryParams(searchFilter, sortOption, page, pageSize);
+    let offset: number | undefined;
+    if (typeof page === 'number' && typeof pageSize === 'number') {
+        offset = page > 0 ? page * pageSize : 0;
+    }
+    const query = {
+        query: getRequestQueryStringForSearchFilter(searchFilter),
+        pagination: { offset, limit: pageSize, sortOption },
+    };
+    const params = qs.stringify({ query }, { allowDots: true });
     return makeCancellableAxiosRequest((signal) =>
         axios
             .get<{
@@ -64,7 +72,7 @@ export function getCollectionCount(searchFilter: SearchFilter): CancellableReque
     const query = getRequestQueryStringForSearchFilter(searchFilter);
     return makeCancellableAxiosRequest((signal) =>
         axios
-            .get<{ count: number }>(`${collectionsCountUrl}?query=${query}`, { signal })
+            .get<{ count: number }>(`${collectionsCountUrl}?query.query=${query}`, { signal })
             .then((response) => response.data.count)
     );
 }
@@ -130,7 +138,7 @@ export function updateCollection(
 ): CancellableRequest<CollectionResponse> {
     return makeCancellableAxiosRequest((signal) =>
         axios
-            .put<CollectionResponse>(`${collectionsBaseUrl}/${id}`, collection, { signal })
+            .patch<CollectionResponse>(`${collectionsBaseUrl}/${id}`, collection, { signal })
             .then((response) => response.data)
     );
 }


### PR DESCRIPTION
## Description

This updates the FE API calls to work with the the BE implementation.

Changes:
1. Wraps the entire query payload object in a new object with a single `query` key.
2. Uses `Collection Name` instead of `name` for sorting in the request.
3. Updates the `/v1/collections/count` URL to be `/v1/collectionscount` to avoid BE routing conflicts
4. Changes the updateCollection service call to use PATCH instead of PUT (the UI is still sending the entire collection object on update requests, for simplicity)

3 and 4 [discussion thread](https://srox.slack.com/archives/C03LJH0JSEB/p1668193037080579)
3 and 4 [PR that this change depends on](https://github.com/stackrox/stackrox/pull/3792)

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Run the FE against the BE API _without_ mocking Collection endpoints and test the standard operations of view/create/update/delete/clone. (This can be done by omitting any custom proxies, or only proxying to the autocomplete endpoints e.g. `YARN_CUSTOM_PROXIES='/v1/collections/autocomplete,http://localhost:3030' YARN_START_TARGET=https://<ip_addr> yarn start`.)

Note: bugs and UX issues will be fixed as separate follow ups, as this PR is only to update the API calls to use the BE defined structure.