### PR TITLE
Validate that label keys are valid k8s labels and ensure correct key splitting

### DIFF
--- a/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
@@ -21,6 +21,7 @@ import * as yup from 'yup';
 
 import { collectionsBasePath } from 'routePaths';
 import { CollectionResponse } from 'services/CollectionsService';
+import { getIsValidLabelKey } from 'utils/labels';
 import { CollectionPageAction } from './collections.utils';
 import RuleSelector from './RuleSelector';
 import CollectionAttacher from './CollectionAttacher';
@@ -81,7 +82,7 @@ function yupResourceSelectorObject() {
                   rules: yup.array().of(
                       yup.object().shape({
                           operator: yup.string().required().matches(/OR/),
-                          key: yup.string().trim().required(),
+                          key: yup.string().trim().required().test(getIsValidLabelKey),
                           values: yup.array().of(yup.string().trim().required()).required(),
                       })
                   ),

--- a/ui/apps/platform/src/Containers/Collections/converter.test.ts
+++ b/ui/apps/platform/src/Containers/Collections/converter.test.ts
@@ -1,6 +1,6 @@
 import { CollectionRequest, CollectionResponse } from 'services/CollectionsService';
 import { generateRequest, parseCollection } from './converter';
-import { Collection } from './types';
+import { ByLabelResourceSelector, Collection, LabelSelectorRule } from './types';
 
 describe('Collection parser', () => {
     it('should convert between BE CollectionResponse and FE Collection', () => {
@@ -162,6 +162,59 @@ describe('Collection parser', () => {
         };
 
         expect(parseCollection(collectionResponse)).toBeInstanceOf(AggregateError);
+    });
+
+    it('should correctly handle label key/value splitting on `=` delimiter', () => {
+        const collectionResponse: CollectionResponse = {
+            id: 'a-b-c',
+            name: 'Sample',
+            description: 'Sample description',
+            inUse: false,
+            resourceSelectors: [
+                {
+                    rules: [
+                        { operator: 'OR', fieldName: 'Cluster Label', values: [{ value: '' }] },
+                    ],
+                },
+            ],
+            embeddedCollections: [],
+        };
+
+        // Get the resource selector we are interested in without so many type assertions
+        function getLabelRule(collection: CollectionResponse): LabelSelectorRule {
+            return (
+                (parseCollection(collection) as Collection).resourceSelector
+                    .Cluster as ByLabelResourceSelector
+            ).rules[0];
+        }
+
+        const firstLabelRule = collectionResponse.resourceSelectors[0].rules[0].values[0];
+
+        // Test empty label key handling (NOTE, this should be forbidden from occurring by BE)
+        firstLabelRule.value = '=test';
+        expect(getLabelRule(collectionResponse)).toMatchObject({ key: '', values: ['test'] });
+
+        // Test empty label value handling (NOTE, this should be forbidden from occurring by BE)
+        firstLabelRule.value = 'test=';
+        expect(getLabelRule(collectionResponse)).toMatchObject({ key: 'test', values: [''] });
+
+        // Test plain characters
+        firstLabelRule.value = 'key=value';
+        expect(getLabelRule(collectionResponse)).toMatchObject({ key: 'key', values: ['value'] });
+
+        // Test subdomain prefix
+        firstLabelRule.value = 'app.kubernetes.io/name=value';
+        expect(getLabelRule(collectionResponse)).toMatchObject({
+            key: 'app.kubernetes.io/name',
+            values: ['value'],
+        });
+
+        // Test multiple '=' characters
+        firstLabelRule.value = 'app.kubernetes.io/name=value=with=extra=eq';
+        expect(getLabelRule(collectionResponse)).toMatchObject({
+            key: 'app.kubernetes.io/name',
+            values: ['value=with=extra=eq'],
+        });
     });
 });
 


### PR DESCRIPTION
## Description

This hardens the FE implementation of label rules with the following changes:

1. Label keys no longer accept any non-empty string. Keys must only contain valid k8s label characters.
2. When parsing label values, we now take into account the possibility that the delimiter (`=`) can be found in the value, by only splitting on the first occurance of this character.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Unit tests added.

In the collection form, test that valid values are accepted by formik:
<img width="772" alt="image" src="https://user-images.githubusercontent.com/1292638/201166299-219592af-614b-4ffd-a102-49621367fdc9.png">
<img width="772" alt="image" src="https://user-images.githubusercontent.com/1292638/201166335-9da9352c-b718-44ab-92f3-89c1c359b527.png">
<img width="772" alt="image" src="https://user-images.githubusercontent.com/1292638/201166611-ece167d4-c6e7-4556-a37b-51254eb56cb4.png">

Test that invalid values are not accepted:
<img width="772" alt="image" src="https://user-images.githubusercontent.com/1292638/201166702-3b429ce4-0df7-4ce3-807c-828a3d0a917c.png">
<img width="772" alt="image" src="https://user-images.githubusercontent.com/1292638/201166776-a5a806ed-9ca2-4a55-b39f-d7c2206b9b99.png">
<img width="772" alt="image" src="https://user-images.githubusercontent.com/1292638/201166964-45257422-544e-4971-aba5-91a525e9e1e1.png">

