### PR TITLE
Prevent the collection being edited from displaying in its own embedded list

### DIFF
--- a/ui/apps/platform/src/Containers/Collections/CollectionAttacher.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionAttacher.tsx
@@ -21,6 +21,9 @@ const selectorListCells = [
 ];
 
 export type CollectionAttacherProps = {
+    // A collection ID that should not be visible in the collection attacher component. This is
+    // used when editing a collection to prevent reference cycles.
+    excludedCollectionId: string | null;
     initialEmbeddedCollections: CollectionResponse[];
     onSelectionChange: (collections: CollectionResponse[]) => void;
 };
@@ -30,11 +33,12 @@ function compareNameLowercase(search: string): (item: { name: string }) => boole
 }
 
 function CollectionAttacher({
+    excludedCollectionId,
     initialEmbeddedCollections,
     onSelectionChange,
 }: CollectionAttacherProps) {
     const [search, setSearch] = useState('');
-    const embedded = useEmbeddedCollections(initialEmbeddedCollections);
+    const embedded = useEmbeddedCollections(excludedCollectionId, initialEmbeddedCollections);
     const { attached, detached, attach, detach, hasMore, fetchMore, onSearch } = embedded;
     const { isFetchingMore, fetchMoreError } = embedded;
 

--- a/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
@@ -258,6 +258,9 @@ function CollectionForm({
                         <>
                             <p>Extend this collection by attaching other sets.</p>
                             <CollectionAttacher
+                                excludedCollectionId={
+                                    action.type === 'edit' ? action.collectionId : null
+                                }
                                 initialEmbeddedCollections={initialEmbeddedCollections}
                                 onSelectionChange={onEmbeddedCollectionsChange}
                             />

--- a/ui/apps/platform/src/Containers/Collections/hooks/useEmbeddedCollections.ts
+++ b/ui/apps/platform/src/Containers/Collections/hooks/useEmbeddedCollections.ts
@@ -26,7 +26,6 @@ const minimumUpdateSize = pageSize / 2;
  *
  * If the response from the server contains less collections then the page size, display all
  * aggregated results and set `hasMore` to `false`.
- *
  * @param clientMap
  *      A mapping of {id -> collection} for all attached and detached collections that
  *      are currently displayed in the UI.
@@ -41,6 +40,7 @@ const minimumUpdateSize = pageSize / 2;
  *      number, and the number of items returned in the last call to the server.
  */
 function fetchDetachedCollections(
+    excludedCollectionId: string | null,
     clientMap: CollectionMap,
     searchValue: string,
     pageNumber: number,
@@ -59,14 +59,22 @@ function fetchDetachedCollections(
     );
 
     return request.then((collections) => {
-        const newDetached = collections.filter(({ id }) => !clientMap[id]);
+        const newDetached = collections.filter(
+            ({ id }) => !clientMap[id] && id !== excludedCollectionId
+        );
         const detached = aggregateResult.concat(newDetached);
         const lastResponseSize = collections.length;
         const shouldFetchMore = lastResponseSize > 0 && detached.length < minimumUpdateSize;
         const nextPage = pageNumber + 1;
 
         if (shouldFetchMore) {
-            return fetchDetachedCollections(clientMap, searchValue, nextPage, detached);
+            return fetchDetachedCollections(
+                excludedCollectionId,
+                clientMap,
+                searchValue,
+                nextPage,
+                detached
+            );
         }
         return Promise.resolve({ detached, nextPage, lastResponseSize });
     });
@@ -77,6 +85,7 @@ function fetchDetachedCollections(
  * more detached collections from the server.
  */
 function fetchMore(
+    excludedCollectionId: string | null,
     attached: CollectionMap,
     detached: CollectionMap,
     searchValue: string,
@@ -85,7 +94,13 @@ function fetchMore(
 ) {
     dispatch({ type: 'fetchMoreRequest' });
 
-    fetchDetachedCollections({ ...attached, ...detached }, searchValue, currentPage, [])
+    fetchDetachedCollections(
+        excludedCollectionId,
+        { ...attached, ...detached },
+        searchValue,
+        currentPage,
+        []
+    )
         .then(({ detached: newDetached, nextPage, lastResponseSize }) => {
             const nextDetached = { ...detached };
             newDetached.forEach((collection) => {
@@ -239,10 +254,14 @@ export type UseEmbeddedCollectionsReturn = {
  *  - [Bonus] In the future, we should track when the user has loaded all collections _without_ search filtering
  *    as we can then disable the cache clearing/fetching behavior and filter the client side cache directly.
  *
+ * @param excludedCollectionId
+ *      The ids of the main collection that the other collections are being attached to, or `null` if
+ *      a new collection is being created.
  * @param initialAttachedCollectionIds
  *      A list of attached collection ids used to populate the initial attached collection list.
  */
 export default function useEmbeddedCollections(
+    excludedCollectionId: string | null,
     initialAttachedCollections: CollectionResponse[]
 ): UseEmbeddedCollectionsReturn {
     const [state, dispatch] = useReducer(embeddedCollectionsReducer, initialState, (init) => ({
@@ -253,12 +272,19 @@ export default function useEmbeddedCollections(
     const { attached, detached, page, hasMore, isFetchingMore, fetchMoreError } = state;
 
     useEffect(() => {
-        return fetchMore(arrayToMap(initialAttachedCollections), {}, '', 1, dispatch);
-    }, [initialAttachedCollections]);
+        return fetchMore(
+            excludedCollectionId,
+            arrayToMap(initialAttachedCollections),
+            {},
+            '',
+            1,
+            dispatch
+        );
+    }, [excludedCollectionId, initialAttachedCollections]);
 
     const onSearch = (search: string) => {
         dispatch({ type: 'resetDetachedList' });
-        fetchMore(attached, {}, search, 1, dispatch);
+        fetchMore(excludedCollectionId, attached, {}, search, 1, dispatch);
     };
 
     return {
@@ -267,7 +293,8 @@ export default function useEmbeddedCollections(
         attach: (id: string) => dispatch({ type: 'attachCollection', id }),
         detach: (id: string) => dispatch({ type: 'detachCollection', id }),
         hasMore,
-        fetchMore: (search: string) => fetchMore(attached, detached, search, page, dispatch),
+        fetchMore: (search: string) =>
+            fetchMore(excludedCollectionId, attached, detached, search, page, dispatch),
         onSearch,
         isFetchingMore,
         fetchMoreError,


### PR DESCRIPTION
## Description

Prior to this change, the collection being edited would appear in the "detached collections" list in the collection form. This should not happen, as circular references are invalid.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Load the collections page and select one of the collections for editing.
![image](https://user-images.githubusercontent.com/1292638/201417305-dccb6709-6598-464a-a583-bdc9a7a916a9.png)

When editing the collection, scroll to the "attach collections" section and see that the collection being edited is not present in its own "attach collections" list.
![image](https://user-images.githubusercontent.com/1292638/201417377-dd8a64bf-d6d7-48ba-a350-53553543306b.png)

Visit the "clone" page for the same collection. The original collection being cloned should be visible in the attachment list.
<img width="1674" alt="image" src="https://user-images.githubusercontent.com/1292638/201683666-a961d2a4-f245-4e58-b9f9-3e09e14d46d1.png">


Visit the collection creation page and verify that _all_ collections are available for attachment.
![image](https://user-images.githubusercontent.com/1292638/201683454-a211f1be-7b45-4793-89b8-1fb7e8709c92.png)


