### PR TITLE
ROX-13168: Add traffic filters

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentFlows.css
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentFlows.css
@@ -5,3 +5,7 @@
 tbody tr.pf-c-table__expandable-row td.pf-c-table__check label {
     padding: 0;
 }
+
+.advanced-flows-filters-select .pf-c-select__menu {
+    min-width: 300px;
+}

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentFlows.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentFlows.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {
+    Divider,
     DropdownItem,
     Flex,
     FlexItem,
@@ -25,8 +26,11 @@ import {
 } from '@patternfly/react-table';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 
-import './DeploymentFlows.css';
 import BulkActionsDropdown from 'Components/PatternFly/BulkActionsDropdown';
+import AdvancedFlowsFilter, { defaultAdvancedFlowsFilters } from '../flows/AdvancedFlowsFilter';
+
+import './DeploymentFlows.css';
+import { AdvancedFlowsFilterType } from '../flows/types';
 
 interface FlowBase {
     id: string;
@@ -118,16 +122,19 @@ const flows: Flow[] = [
 ];
 
 function DeploymentFlow() {
-    // derived values
+    // component state
+    const [advancedFilters, setAdvancedFilters] = React.useState<AdvancedFlowsFilterType>(
+        defaultAdvancedFlowsFilters
+    );
+    const initialExpandedRows = flows.filter((row) => !!row.children.length).map((row) => row.id); // Default to all expanded
+    const [expandedRows, setExpandedRows] = React.useState<string[]>(initialExpandedRows);
+    const [selectedRows, setSelectedRows] = React.useState<string[]>([]);
+
+    // derived data
     const totalFlows = flows.reduce((acc, curr) => {
         // if there are no children then it counts as 1 flow
         return acc + (curr.children.length ? curr.children.length : 1);
     }, 0);
-
-    // component state
-    const initialExpandedRows = flows.filter((row) => !!row.children.length).map((row) => row.id); // Default to all expanded
-    const [expandedRows, setExpandedRows] = React.useState<string[]>(initialExpandedRows);
-    const [selectedRows, setSelectedRows] = React.useState<string[]>([]);
 
     // getter functions
     const isRowExpanded = (row: Flow) => expandedRows.includes(row.id);
@@ -169,6 +176,18 @@ function DeploymentFlow() {
     return (
         <div className="pf-u-h-100 pf-u-p-md">
             <Stack hasGutter>
+                <StackItem>
+                    <Flex>
+                        <FlexItem flex={{ default: 'flex_1' }} />
+                        <FlexItem>
+                            <AdvancedFlowsFilter
+                                filters={advancedFilters}
+                                setFilters={setAdvancedFilters}
+                            />
+                        </FlexItem>
+                    </Flex>
+                </StackItem>
+                <Divider component="hr" />
                 <StackItem>
                     <Toolbar>
                         <ToolbarContent>

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentFlows.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentFlows.tsx
@@ -25,6 +25,7 @@ import {
     Tr,
 } from '@patternfly/react-table';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
+import { uniq } from 'lodash';
 
 import BulkActionsDropdown from 'Components/PatternFly/BulkActionsDropdown';
 import AdvancedFlowsFilter, { defaultAdvancedFlowsFilters } from '../flows/AdvancedFlowsFilter';
@@ -92,7 +93,7 @@ const flows: Flow[] = [
         entity: 'Deployment 1',
         namespace: 'naples',
         direction: 'Ingress',
-        port: 'Many',
+        port: '9000',
         protocol: 'TCP',
         isAnomalous: true,
         children: [],
@@ -103,7 +104,7 @@ const flows: Flow[] = [
         entity: 'Deployment 2',
         namespace: 'naples',
         direction: 'Ingress',
-        port: 'Many',
+        port: '8080',
         protocol: 'UDP',
         isAnomalous: false,
         children: [],
@@ -135,6 +136,13 @@ function DeploymentFlow() {
         // if there are no children then it counts as 1 flow
         return acc + (curr.children.length ? curr.children.length : 1);
     }, 0);
+    const allPorts = flows.reduce((acc, curr) => {
+        if (curr.children.length) {
+            return [...acc, ...curr.children.map((child) => child.port)];
+        }
+        return [...acc, curr.port];
+    }, [] as string[]);
+    const allUniqPorts = uniq(allPorts);
 
     // getter functions
     const isRowExpanded = (row: Flow) => expandedRows.includes(row.id);
@@ -183,6 +191,7 @@ function DeploymentFlow() {
                             <AdvancedFlowsFilter
                                 filters={advancedFilters}
                                 setFilters={setAdvancedFilters}
+                                allUniqPorts={allUniqPorts}
                             />
                         </FlexItem>
                     </Flex>

--- a/ui/apps/platform/src/Containers/NetworkGraph/flows/AdvancedFlowsFilter.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/flows/AdvancedFlowsFilter.tsx
@@ -1,0 +1,113 @@
+import React from 'react';
+import {
+    Select,
+    SelectGroup,
+    SelectOption,
+    SelectPosition,
+    SelectVariant,
+} from '@patternfly/react-core';
+
+import useMultiSelect from 'hooks/useMultiSelect';
+import { AdvancedFlowsFilterType } from './types';
+import { filtersToSelections, selectionsToFilters } from './advancedFlowsFilterUtils';
+
+export type AdvancedFlowsFilterProps = {
+    filters: AdvancedFlowsFilterType;
+    setFilters: React.Dispatch<React.SetStateAction<AdvancedFlowsFilterType>>;
+};
+
+export const defaultAdvancedFlowsFilters: AdvancedFlowsFilterType = {
+    flows: [],
+    directionality: [],
+    protocols: [],
+    ports: [],
+};
+
+function AdvancedFlowsFilter({
+    filters,
+    setFilters,
+}: AdvancedFlowsFilterProps): React.ReactElement {
+    // derived state
+    const selections = filtersToSelections(filters);
+
+    // component state
+    const [isFilterDropdownOpen, setIsFilterDropdownOpen] = React.useState(false);
+    const {
+        isOpen: isPortsSelectOpen,
+        onToggle: onTogglePortsSelect,
+        onSelect: onSelectPorts,
+    } = useMultiSelect(handlePortsSelect, filters.ports, false);
+
+    // setters
+    const onFilterDropdownToggle = (isOpen: boolean) => {
+        setIsFilterDropdownOpen(isOpen);
+    };
+    const onTrafficFilterSelect = (_, selection) => {
+        if (selections.includes(selection)) {
+            setFilters((prevFilters) => {
+                const prevSelection = filtersToSelections(prevFilters);
+                const newSelection = prevSelection.filter((item) => item !== selection);
+                const newFilters = selectionsToFilters(newSelection);
+                return newFilters;
+            });
+        } else {
+            setFilters((prevFilters) => {
+                const prevSelection = filtersToSelections(prevFilters);
+                const newSelection = [...prevSelection, selection] as string[];
+                const newFilters = selectionsToFilters(newSelection);
+                return newFilters;
+            });
+        }
+    };
+    function handlePortsSelect(selection) {
+        setFilters((prevFilters) => {
+            const newFilters = { ...prevFilters };
+            newFilters.ports = selection;
+            return newFilters;
+        });
+    }
+
+    return (
+        <Select
+            className="advanced-flows-filters-select"
+            variant={SelectVariant.checkbox}
+            onToggle={onFilterDropdownToggle}
+            onSelect={onTrafficFilterSelect}
+            selections={selections}
+            isOpen={isFilterDropdownOpen}
+            placeholderText="Advanced"
+            aria-labelledby="advanced-flows-filters-select"
+            isGrouped
+            position={SelectPosition.right}
+        >
+            <SelectGroup label="Deployment flows">
+                <SelectOption value="anomalous">Anomalous flows</SelectOption>
+                <SelectOption value="baseline">Baselined flows</SelectOption>
+            </SelectGroup>
+            <SelectGroup label="Flow directionality">
+                <SelectOption value="ingress">Ingress (inbound)</SelectOption>
+                <SelectOption value="egress">Egress (outbound)</SelectOption>
+            </SelectGroup>
+            <SelectGroup label="Protocols">
+                <SelectOption value="TCP">TCP</SelectOption>
+                <SelectOption value="UDP">UDP</SelectOption>
+            </SelectGroup>
+            <SelectGroup label="Ports">
+                <Select
+                    className="pf-u-px-md"
+                    variant={SelectVariant.typeaheadMulti}
+                    aria-label="Select one or more days"
+                    onToggle={onTogglePortsSelect}
+                    onSelect={onSelectPorts}
+                    selections={filters.ports}
+                    isOpen={isPortsSelectOpen}
+                    placeholderText="Select ports"
+                    isCreatable
+                    createText="Select port"
+                />
+            </SelectGroup>
+        </Select>
+    );
+}
+
+export default AdvancedFlowsFilter;

--- a/ui/apps/platform/src/Containers/NetworkGraph/flows/AdvancedFlowsFilter.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/flows/AdvancedFlowsFilter.tsx
@@ -14,6 +14,7 @@ import { filtersToSelections, selectionsToFilters } from './advancedFlowsFilterU
 export type AdvancedFlowsFilterProps = {
     filters: AdvancedFlowsFilterType;
     setFilters: React.Dispatch<React.SetStateAction<AdvancedFlowsFilterType>>;
+    allUniqPorts: string[];
 };
 
 export const defaultAdvancedFlowsFilters: AdvancedFlowsFilterType = {
@@ -26,6 +27,7 @@ export const defaultAdvancedFlowsFilters: AdvancedFlowsFilterType = {
 function AdvancedFlowsFilter({
     filters,
     setFilters,
+    allUniqPorts,
 }: AdvancedFlowsFilterProps): React.ReactElement {
     // derived state
     const selections = filtersToSelections(filters);
@@ -96,15 +98,18 @@ function AdvancedFlowsFilter({
                 <Select
                     className="pf-u-px-md"
                     variant={SelectVariant.typeaheadMulti}
-                    aria-label="Select one or more days"
+                    aria-label="Select ports"
                     onToggle={onTogglePortsSelect}
                     onSelect={onSelectPorts}
                     selections={filters.ports}
                     isOpen={isPortsSelectOpen}
                     placeholderText="Select ports"
-                    isCreatable
-                    createText="Select port"
-                />
+                    menuAppendTo="parent"
+                >
+                    {allUniqPorts.map((port) => {
+                        return <SelectOption value={port}>{port}</SelectOption>;
+                    })}
+                </Select>
             </SelectGroup>
         </Select>
     );

--- a/ui/apps/platform/src/Containers/NetworkGraph/flows/advancedFlowsFilterUtils.test.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/flows/advancedFlowsFilterUtils.test.ts
@@ -1,0 +1,166 @@
+import { AdvancedFlowsFilterType } from './types';
+import { filtersToSelections, selectionsToFilters } from './advancedFlowsFilterUtils';
+
+describe('advancedFlowsFilterUtils', () => {
+    describe('filtersToSelections', () => {
+        it('should convert filters with flows to selections', () => {
+            const filters: AdvancedFlowsFilterType = {
+                flows: ['baseline', 'anomalous'],
+                directionality: [],
+                protocols: [],
+                ports: [],
+            };
+
+            const selections = filtersToSelections(filters);
+
+            expect(selections).toEqual(['baseline', 'anomalous']);
+        });
+
+        it('should convert filters with directionality to selections', () => {
+            const filters: AdvancedFlowsFilterType = {
+                flows: [],
+                directionality: ['egress', 'ingress'],
+                protocols: [],
+                ports: [],
+            };
+
+            const selections = filtersToSelections(filters);
+
+            expect(selections).toEqual(['egress', 'ingress']);
+        });
+
+        it('should convert filters with protocols to selections', () => {
+            const filters: AdvancedFlowsFilterType = {
+                flows: [],
+                directionality: [],
+                protocols: ['TCP', 'UDP'],
+                ports: [],
+            };
+
+            const selections = filtersToSelections(filters);
+
+            expect(selections).toEqual(['TCP', 'UDP']);
+        });
+
+        it('should convert filters with ports to selections', () => {
+            const filters: AdvancedFlowsFilterType = {
+                flows: [],
+                directionality: [],
+                protocols: [],
+                ports: ['9000', '8080'],
+            };
+
+            const selections = filtersToSelections(filters);
+
+            expect(selections).toEqual(['9000', '8080']);
+        });
+
+        it('should convert filters with combination of values to selections', () => {
+            const filters: AdvancedFlowsFilterType = {
+                flows: ['anomalous', 'baseline'],
+                directionality: ['egress', 'ingress'],
+                protocols: ['TCP', 'UDP'],
+                ports: ['9000', '8080'],
+            };
+
+            const selections = filtersToSelections(filters);
+
+            expect(selections).toEqual([
+                'anomalous',
+                'baseline',
+                'egress',
+                'ingress',
+                'TCP',
+                'UDP',
+                '9000',
+                '8080',
+            ]);
+        });
+    });
+
+    describe('selectionsToFilters', () => {
+        it('should convert selections with flows to filters', () => {
+            const selections: string[] = ['anomalous', 'baseline'];
+
+            const filters = selectionsToFilters(selections);
+
+            const expectedFilters: AdvancedFlowsFilterType = {
+                flows: ['anomalous', 'baseline'],
+                directionality: [],
+                protocols: [],
+                ports: [],
+            };
+
+            expect(filters).toEqual(expectedFilters);
+        });
+
+        it('should convert selections with directionality to filters', () => {
+            const selections: string[] = ['ingress', 'egress'];
+
+            const filters = selectionsToFilters(selections);
+
+            const expectedFilters: AdvancedFlowsFilterType = {
+                flows: [],
+                directionality: ['ingress', 'egress'],
+                protocols: [],
+                ports: [],
+            };
+
+            expect(filters).toEqual(expectedFilters);
+        });
+
+        it('should convert selections with protocols to filters', () => {
+            const selections: string[] = ['TCP', 'UDP'];
+
+            const filters = selectionsToFilters(selections);
+
+            const expectedFilters: AdvancedFlowsFilterType = {
+                flows: [],
+                directionality: [],
+                protocols: ['TCP', 'UDP'],
+                ports: [],
+            };
+
+            expect(filters).toEqual(expectedFilters);
+        });
+
+        it('should convert selections with ports to filters', () => {
+            const selections: string[] = ['9000', '8080'];
+
+            const filters = selectionsToFilters(selections);
+
+            const expectedFilters: AdvancedFlowsFilterType = {
+                flows: [],
+                directionality: [],
+                protocols: [],
+                ports: ['9000', '8080'],
+            };
+
+            expect(filters).toEqual(expectedFilters);
+        });
+
+        it('should convert selections with combination of values to filters', () => {
+            const selections: string[] = [
+                'anomalous',
+                'baseline',
+                'egress',
+                'ingress',
+                'TCP',
+                'UDP',
+                '9000',
+                '8080',
+            ];
+
+            const filters = selectionsToFilters(selections);
+
+            const expectedFilters: AdvancedFlowsFilterType = {
+                flows: ['anomalous', 'baseline'],
+                directionality: ['egress', 'ingress'],
+                protocols: ['TCP', 'UDP'],
+                ports: ['9000', '8080'],
+            };
+
+            expect(filters).toEqual(expectedFilters);
+        });
+    });
+});

--- a/ui/apps/platform/src/Containers/NetworkGraph/flows/advancedFlowsFilterUtils.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/flows/advancedFlowsFilterUtils.ts
@@ -1,0 +1,42 @@
+import { AdvancedFlowsFilterType, FilterValue } from './types';
+
+function isValidPort(port: string): boolean {
+    const portNum = parseInt(port, 10);
+    if (Number.isNaN(portNum)) {
+        return false;
+    }
+    return portNum >= 1 && portNum <= 65535;
+}
+
+// This function is used to convert our filters data structure to an array of strings
+// which the Select component expects
+export function filtersToSelections(filters: AdvancedFlowsFilterType): FilterValue[] {
+    return Object.values(filters).reduce((acc, curr) => {
+        return [...acc, ...Object.values(curr)];
+    }, []);
+}
+
+// This function is used to convert the selections array of strings, which the Select component
+// expects, into our filters data structure
+export function selectionsToFilters(selections: string[]): AdvancedFlowsFilterType {
+    const filters: AdvancedFlowsFilterType = {
+        flows: [],
+        directionality: [],
+        protocols: [],
+        ports: [],
+    };
+    selections.forEach((selection) => {
+        if (selection === 'anomalous' || selection === 'baseline') {
+            filters.flows.push(selection);
+        } else if (selection === 'ingress' || selection === 'egress') {
+            filters.directionality.push(selection);
+        } else if (selection === 'TCP' || selection === 'UDP') {
+            filters.protocols.push(selection);
+        } else if (isValidPort(selection)) {
+            filters.ports.push(selection);
+        } else {
+            // do nothing
+        }
+    });
+    return filters;
+}

--- a/ui/apps/platform/src/Containers/NetworkGraph/flows/types.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/flows/types.ts
@@ -1,0 +1,16 @@
+type Flows = 'anomalous' | 'baseline';
+
+type Directionality = 'egress' | 'ingress';
+
+type Protocols = 'TCP' | 'UDP';
+
+type Ports = string; // number format
+
+export type FilterValue = Flows | Directionality | Protocols | Ports;
+
+export type AdvancedFlowsFilterType = {
+    flows: Flows[];
+    directionality: Directionality[];
+    protocols: Protocols[];
+    ports: Ports[];
+};


### PR DESCRIPTION
## Description

I'm creating a new component called `AdvancedFlowsFilter` which will contain a dropdown for filtering by deployment flows, directionality, protocols, ports

<img width="452" alt="Screenshot 2022-11-11 at 10 43 03 AM" src="https://user-images.githubusercontent.com/4805485/201409440-396323b4-f65e-4a29-94b9-6dde3a2e1cf5.png">

**Reference Mocks:** https://www.sketch.com/s/9d082d82-3515-40f2-875a-1b322a02bace/a/zxLMR2W

This draft PR is being sent out to get thoughts on the following:

1. **What do we think about having this new component to manage the filters?** It will take care of organizing the filter data into a data structure so that the parent component can access it in a reasonable format
2. **Where should this new component live?** I placed it in a new directory called `flows`. I considered creating a `DeploymentFlows` directory and placing `DeploymentFlows.tsx`, `DeploymentFlows.css`, and `AdvancedFlowsFilters` within that directory, but wasn't sure if nesting too much would be too much. Putting it within the `flows` directory seems reasonable since we seem to be separating components by sub-features so far

**More things I need to do:**
1. Add tests for the helper functions used to organize the filter data


## Checklist
- [ ] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

<img width="721" alt="Screenshot 2022-11-11 at 10 43 46 AM" src="https://user-images.githubusercontent.com/4805485/201409563-a29a5c9e-c643-48f3-b456-cc39810d2fd5.png">


