### PR TITLE
Delete unneeded react-is devDependencies in ui-components

### DIFF
--- a/ui/packages/ui-components/package.json
+++ b/ui/packages/ui-components/package.json
@@ -78,7 +78,6 @@
         "prettier": "^2.7.1",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
-        "react-is": "^17.0.2",
         "tailwindcss": "^2.0.3",
         "ts-jest": "^26.5.6",
         "typescript": "^4.8.4"


### PR DESCRIPTION
## Description

Thank you Brad for finding with depcheck.

This looks like a mistaken needle in a huge haystack:
* 2020-07-30 rox 5906 has references to `react-is` only in yarn.lock file as dependency of dependencies.
    Files changed: 1429
* 2020-08-30 rox 6347 has `"react-is": "^16.13.1"` in added packages/ui-components/package.json file but no other references than in yarn.lock file.
    Files changed: 95

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

1. `yarn` in ui: no changes to yarn.lock file because version is consistent with other react dependencies.
2. `yarn build` in ui