### PR TITLE
Delete unneeded node types devDependencies in ui

### DIFF
--- a/ui/apps/platform/package.json
+++ b/ui/apps/platform/package.json
@@ -128,7 +128,6 @@
         "@testing-library/user-event": "^14.2.1",
         "@types/jest": "^27.4.0",
         "@types/lodash": "^4.14.182",
-        "@types/node": "^17.0.16",
         "@types/pluralize": "^0.0.29",
         "@types/qs": "^6.9.7",
         "@types/react": "^17.0.34",

--- a/ui/packages/ui-components/package.json
+++ b/ui/packages/ui-components/package.json
@@ -52,7 +52,6 @@
         "@testing-library/react": "^12.1.2",
         "@testing-library/user-event": "^14.2.1",
         "@types/lodash": "^4.14.182",
-        "@types/node": "^17.0.16",
         "@types/react": "^17.0.34",
         "@types/react-dom": "^17.0.11",
         "@typescript-eslint/eslint-plugin": "^4.32.0",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -4378,7 +4378,7 @@
     "@types/node" "*"
     form-data "^3.0.0"
 
-"@types/node@*", "@types/node@>= 8", "@types/node@^17.0.16":
+"@types/node@*", "@types/node@>= 8":
   version "17.0.16"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.16.tgz#e3733f46797b9df9e853ca9f719c8a6f7b84cd26"
   integrity sha512-ydLaGVfQOQ6hI1xK2A5nVh8bl0OGoIfYMxPWHqqYe9bTkWCfqiVvZoh2I/QF2sNSkZzZyROBoTefIEI+PB6iIA==


### PR DESCRIPTION
## Description

Thank you Brad for finding with depcheck.

Although in theory, we might configure TypeScript to check JavaScript, but not compile these dev ops files, the benefit to check a few method calls from node `fs` and `path` module is not worth the cost.

### Analysis of apps/platform

8 `require` function calls:
* `const path = require('path');` from node in .eslintrc.js
* `const { defineConfig } = require('cypress');` not from node commented out in cypress.config.js
* `const tailwindcss = require('tailwindcss');` not from node in postcss.config.js
* `module.exports = require('@stackrox/tailwind-config');` not from node in tailwind.config.js
* `const path = require('path');` from node in cypress/mocha.config.js
* `const fetch = require('node-fetch');` not from node in scripts/generate-graphql-possible-types.js
* `const fs = require('fs');` from node in scripts/generate-graphql-possible-types.js
* `const { createProxyMiddleware } = require('http-proxy-middleware');` not from node in src/setupProxy.js

**Residue**: VS Code Problems pane reports prettier lint missing `,` problem, therefore `yarn lint` apparently does not check files in apps/platform folder itself.

### Analysis of packages/ui-components

3 `require` function calls, not including compiled output lib subfolder:
* `const path = require('path');` from node in .eslintrc.js
* `const tailwindcss = require('tailwindcss');` not from node in .postcssrc.js
* `module.exports = require('@stackrox/tailwind-config');` not from node in tailwind.config.js

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

1. `yarn` in ui: only one reference in dependencies of devDependencies specifies a minimum version, therefore nothing to cause future updates to types, but packages probably call only stable modules
2. `yarn lint` in ui
3. `yarn build` in ui