### PR TITLE
ROX-13502: Remove the circular dependency between cluster datastore init and cscc notifier init

### DIFF
--- a/central/notifiers/cscc/cscc_test.go
+++ b/central/notifiers/cscc/cscc_test.go
@@ -52,7 +52,7 @@ func TestWithFakeCSCC(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	clusterStore := clusterMocks.NewMockDataStore(mockCtrl)
 	clusterStore.EXPECT().GetCluster(gomock.Any(), "test_id").Return(cluster, true, nil)
-	scc, _ := newCSCC(s, clusterStore)
+	scc, _ := newCSCC(s)
 
 	alertID := "myAlertID"
 	severity := findings.High
@@ -76,7 +76,7 @@ func TestWithFakeCSCC(t *testing.T) {
 	findingID := ""
 	var finding *findings.Finding
 	var err error
-	findingID, finding, err = scc.initFinding(context.Background(), testAlert)
+	findingID, finding, err = scc.initFinding(context.Background(), testAlert, clusterStore)
 	assert.NoError(t, err)
 	assert.Equal(t, "myAlertID", findingID)
 	assert.NotEmpty(t, finding)


### PR DESCRIPTION
## Description

A recent change brought in the cscc init dependency on cluster datastore singleton causing a circular dependency leading to a central hang during upgrade of a cluster with a cscc notifier. This is a regression and a release blocker. Fix was to remove the init dependency and initialize the cluster singleton closer to use, in the `AlertNotify` path instead of cscc init.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))


## Testing Performed
Manually upgraded staging cluster, which had central  in hung state to PR image. Results from staging, upgrade successful, and central is back up.
```
ksanchet@ksanchet-mac:~/go/src/github.com/stackrox/stackrox$ kc get pods -n stackrox
NAME                                 READY   STATUS    RESTARTS           AGE
admission-control-7759746db9-49mf5   1/1     Running   0                  9d
admission-control-7759746db9-bb2vl   1/1     Running   0                  9d
admission-control-7759746db9-w2496   1/1     Running   0                  9d
central-7cddcb694d-rkm8r             0/1     Running   1 (3h7m ago)       6d23h
collector-fvhtb                      2/2     Running   264 (27m ago)      9d
collector-rchwl                      2/2     Running   265 (27m ago)      9d
collector-s5srl                      2/2     Running   267 (27m ago)      9d
monitoring-789c644886-v2mcd          2/2     Running   0                  9d
scanner-5b74ddd776-96f8c             1/1     Running   0                  9d
scanner-5b74ddd776-p7lg5             1/1     Running   0                  9d
scanner-db-5cfbbdbf69-48smb          1/1     Running   0                  9d
sensor-c84cbb987-nv6fz               1/1     Running   1451 (3m47s ago)   9d
ksanchet@ksanchet-mac:~/go/src/github.com/stackrox/stackrox$ kubectl -n stackrox set image deploy/central central=quay.io/rhacs-eng/main:3.72.x-585-g9fab31d377
deployment.apps/central image updated
ksanchet@ksanchet-mac:~/go/src/github.com/stackrox/stackrox$ kc get pods -n stackrox
NAME                                 READY   STATUS    RESTARTS          AGE
admission-control-7759746db9-49mf5   1/1     Running   0                 9d
admission-control-7759746db9-bb2vl   1/1     Running   0                 9d
admission-control-7759746db9-w2496   1/1     Running   0                 9d
central-56b795c65f-kzvhc             1/1     Running   0                 3m13s
collector-fvhtb                      2/2     Running   265 (18m ago)     9d
collector-rchwl                      2/2     Running   266 (18m ago)     9d
collector-s5srl                      2/2     Running   268 (18m ago)     9d
monitoring-789c644886-v2mcd          2/2     Running   0                 9d
scanner-5b74ddd776-96f8c             1/1     Running   0                 9d
scanner-5b74ddd776-p7lg5             1/1     Running   0                 9d
scanner-db-5cfbbdbf69-48smb          1/1     Running   0                 9d
sensor-c84cbb987-nv6fz               1/1     Running   1455 (7m2s ago)   9d
```