### PR TITLE
[ROX-13441][POSTGRES] Propagate context correctly in retries

### DIFF
--- a/pkg/search/postgres/common.go
+++ b/pkg/search/postgres/common.go
@@ -14,6 +14,7 @@ import (
 	"github.com/pkg/errors"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/pkg/buildinfo"
+	"github.com/stackrox/rox/pkg/contextutil"
 	"github.com/stackrox/rox/pkg/devbuild"
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/logging"
@@ -581,6 +582,7 @@ func RunSearchRequest(ctx context.Context, category v1.SearchCategory, q *v1.Que
 	schema := mapping.GetTableFromCategory(category)
 
 	return pgutils.Retry2(func() ([]searchPkg.Result, error) {
+		ctx := contextutil.WithValuesFrom(context.Background(), ctx)
 		return RunSearchRequestForSchema(ctx, schema, q, db)
 	})
 }
@@ -704,6 +706,7 @@ func RunSearchRequestForSchema(ctx context.Context, schema *walker.Schema, q *v1
 		return nil, nil
 	}
 	return pgutils.Retry2(func() ([]searchPkg.Result, error) {
+		ctx := contextutil.WithValuesFrom(context.Background(), ctx)
 		return retryableRunSearchRequestForSchema(ctx, query, schema, db)
 	})
 }
@@ -713,6 +716,7 @@ func RunCountRequest(ctx context.Context, category v1.SearchCategory, q *v1.Quer
 	schema := mapping.GetTableFromCategory(category)
 
 	return pgutils.Retry2(func() (int, error) {
+		ctx := contextutil.WithValuesFrom(context.Background(), ctx)
 		return RunCountRequestForSchema(ctx, schema, q, db)
 	})
 }
@@ -726,6 +730,7 @@ func RunCountRequestForSchema(ctx context.Context, schema *walker.Schema, q *v1.
 	queryStr := query.AsSQL()
 
 	return pgutils.Retry2(func() (int, error) {
+		ctx := contextutil.WithValuesFrom(context.Background(), ctx)
 		var count int
 		row := tracedQueryRow(ctx, db, queryStr, query.Data...)
 		if err := row.Scan(&count); err != nil {
@@ -758,6 +763,7 @@ func RunGetQueryForSchema[T any, PT unmarshaler[T]](ctx context.Context, schema 
 	queryStr := query.AsSQL()
 
 	return pgutils.Retry2(func() (*T, error) {
+		ctx := contextutil.WithValuesFrom(context.Background(), ctx)
 		row := tracedQueryRow(ctx, db, queryStr, query.Data...)
 		return unmarshal[T, PT](row)
 	})
@@ -785,6 +791,7 @@ func RunGetManyQueryForSchema[T any, PT unmarshaler[T]](ctx context.Context, sch
 	}
 
 	return pgutils.Retry2(func() ([]*T, error) {
+		ctx := contextutil.WithValuesFrom(context.Background(), ctx)
 		return retryableRunGetManyQueryForSchema[T, PT](ctx, query, db)
 	})
 }
@@ -841,6 +848,7 @@ func RunDeleteRequestForSchema(ctx context.Context, schema *walker.Schema, q *v1
 	}
 
 	return pgutils.Retry(func() error {
+		ctx := contextutil.WithValuesFrom(context.Background(), ctx)
 		_, err = db.Exec(ctx, query.AsSQL(), query.Data...)
 		if err != nil {
 			return errors.Wrapf(err, "could not delete from %q", schema.Table)


### PR DESCRIPTION
## Description

Noticed that the context canceled on Postgres operations. Consequently, search operations seem to be failing and causing central log spam:
```
pkg/search/postgres: 2022/11/10 20:57:23.714605 common.go:628: Error: Query issue: select alerts.Id::text from alerts where (alerts.Deployment_Id = $1 and ((alerts.State = $2) or (alerts.State = $3))) order by alerts.Time desc [4169b3e6-2d50-4243-be15-0faa239e5ed1 0 3]: context canceled
```
This seems to have originated from incorrect context propagation in Postgres operation retries.

## Checklist
- [ ] Investigated and inspected CI test results
- ~Unit test and regression tests added~
- ~Evaluated and added CHANGELOG entry if required~
- ~Determined and documented upgrade steps~
- ~Documented user facing changes~

If any of these don't apply, please comment below.

## Testing Performed
non-trivial. Will monitor the CI on master commits.