### PR TITLE
ROX-13505: Fix error log scanning the postgres stat collection

### DIFF
--- a/central/globaldb/postgres.go
+++ b/central/globaldb/postgres.go
@@ -36,7 +36,7 @@ SELECT TABLE_NAME
               , SUM(c.reltuples) OVER (partition BY parent) AS row_estimate
               , SUM(pg_total_relation_size(c.oid)) OVER (partition BY parent) AS total_bytes
               , SUM(pg_indexes_size(c.oid)) OVER (partition BY parent) AS index_bytes
-              , SUM(pg_total_relation_size(reltoastrelid)) OVER (partition BY parent) AS toast_bytes
+              , SUM(COALESCE(pg_total_relation_size(reltoastrelid), 0)) OVER (partition BY parent) AS toast_bytes
               , parent
           FROM (
                 SELECT pg_class.oid

--- a/central/globaldb/postgres.go
+++ b/central/globaldb/postgres.go
@@ -131,7 +131,7 @@ func collectPostgresStats(ctx context.Context, db *pgxpool.Pool) {
 			tableSize   int
 		)
 		if err := row.Scan(&tableName, &rowEstimate, &totalSize, &indexSize, &toastSize, &tableSize); err != nil {
-			log.Errorf("error scanning row: %v", err)
+			log.Errorf("error scanning row for table %s: %v", tableName, err)
 			return
 		}
 


### PR DESCRIPTION
## Description

Fix the postgres stat collection error message which is caused by no reltoastrelid leading to null in toast_bytes

## Checklist
- [ ] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
