### PR TITLE
fix Operator reconciliation for external Central DB

### DIFF
--- a/operator/pkg/central/extensions/reconcile_tls.go
+++ b/operator/pkg/central/extensions/reconcile_tls.go
@@ -62,7 +62,7 @@ func (r *createCentralTLSExtensionRun) Execute(ctx context.Context) error {
 	}
 
 	internalCentralDBEnabled := r.centralObj.Spec.Central.CentralDBEnabled() && !r.centralObj.Spec.Central.DB.IsExternal()
-	if err := r.ReconcileSecret(ctx, "central-db-tls", internalCentralDBEnabled && !shouldDelete, r.validateCentralDBTLSData, r.generateScannerDBTLSData, true); err != nil {
+	if err := r.ReconcileSecret(ctx, "central-db-tls", internalCentralDBEnabled && !shouldDelete, r.validateCentralDBTLSData, r.generateCentralDBTLSData, true); err != nil {
 		return errors.Wrap(err, "reconciling central-db-tls secret")
 	}
 
@@ -78,7 +78,7 @@ func (r *createCentralTLSExtensionRun) Execute(ctx context.Context) error {
 }
 
 //lint:ignore U1000 ignore unused method. TODO(ROX-9969): remove lint ignore after the init-bundle cert rotation stabilization.
-func (r createCentralTLSExtensionRun) reconcileInitBundleSecrets(ctx context.Context, shouldDelete bool) error {
+func (r *createCentralTLSExtensionRun) reconcileInitBundleSecrets(ctx context.Context, shouldDelete bool) error {
 	bundleSecretShouldExist, err := r.shouldBundleSecretsExist(ctx, shouldDelete)
 	if err != nil {
 		return err

--- a/pkg/mtls/cn_test.go
+++ b/pkg/mtls/cn_test.go
@@ -61,6 +61,15 @@ func TestSubject(t *testing.T) {
 				OU: "ADMISSION_CONTROL_SERVICE",
 			},
 		},
+		{
+			input:    Subject{ServiceType: storage.ServiceType_CENTRAL_DB_SERVICE, Identifier: "Central DB/serialNumber=14079776202872467048"},
+			cn:       "CENTRAL_DB_SERVICE: Central DB/serialNumber=14079776202872467048",
+			hostname: "central-db.stackrox",
+			ou:       "CENTRAL_DB_SERVICE",
+			name: cfcsr.Name{
+				OU: "CENTRAL_DB_SERVICE",
+			},
+		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
## Description

I deployed Central via the Operator in a PR, and it was stuck crash-looping because the x509 cert for Central DB was given Scanner DB's data. This needs to be populated with Central DB data.

This was correct for some time until this PR https://github.com/stackrox/stackrox/pull/3322

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

Deploy Central via the Operator created by this PR and see that it no longer crash loops due an incorrect x509 cert (perhaps it crashes due to some other reason, but this PR does not care about that 😄). Along with this, you can see `central-db-tls`'s `cert.pem` is correctly for Central DB. You can copy and paste it from the OpenShift console and then run something like `openssl x509 -in cert.pem -text` to look at the contents of the cert. You will see something along the lines of `Subject: OU=CENTRAL_DB_SERVICE, CN=CENTRAL_DB_SERVICE: Central DB/serialNumber=XXXXXXXXXXXXXX` and 
```
X509v3 Subject Alternative Name: 
                DNS:central-db.stackrox, DNS:central-db.stackrox.svc
```
