### PR TITLE
ROX-12814: Disable PolicyFieldsTest on openshift.

### DIFF
--- a/qa-tests-backend/src/test/groovy/PolicyFieldsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/PolicyFieldsTest.groovy
@@ -23,7 +23,7 @@ import spock.lang.Shared
 import spock.lang.Unroll
 import util.Env
 
-// TODO(ROX-12814): Scanner OOMs on this test in some Openshift jobs.
+// Scanner OOMs on this test in some Openshift jobs. See ROX-12814.
 @IgnoreIf({ Env.mustGetOrchestratorType() == OrchestratorTypes.OPENSHIFT })
 class PolicyFieldsTest extends BaseSpecification {
 

--- a/qa-tests-backend/src/test/groovy/PolicyFieldsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/PolicyFieldsTest.groovy
@@ -18,10 +18,13 @@ import org.junit.Assume
 import org.junit.experimental.categories.Category
 import services.AlertService
 import services.PolicyService
+import spock.lang.IgnoreIf
 import spock.lang.Shared
 import spock.lang.Unroll
 import util.Env
 
+// TODO(ROX-12814): Scanner OOMs on this test in some Openshift jobs.
+@IgnoreIf({ Env.mustGetOrchestratorType() == OrchestratorTypes.OPENSHIFT })
 class PolicyFieldsTest extends BaseSpecification {
 
     // NOTE: this is populated by registerDeployments call, do not manually


### PR DESCRIPTION
## Description

Scanner OOMs pretty reliably on this test on osd jobs for over 2 weeks.
Disabling for now according to [our policy](https://srox.slack.com/archives/CELUQKESC/p1667906225265369).

## Checklist
- [ ] Investigated and inspected CI test results to make sure this test was skipped
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

Relying on CI.
/test all