### PR TITLE
ROX-13345: disable 'missing required registry' aspect on openshift

### DIFF
--- a/qa-tests-backend/src/test/groovy/ImageScanningTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageScanningTest.groovy
@@ -492,6 +492,7 @@ class ImageScanningTest extends BaseSpecification {
     @Category(Integration)
     def "Verify image scan exceptions - #scanner.name() - #testAspect"() {
         Assume.assumeTrue(scanner.isTestable())
+        Assume.assumeFalse(testAspect == "missing required registry" && Env.mustGetOrchestratorType() == OrchestratorTypes.OPENSHIFT)
         cleanupSetupForRetry()
 
         when:


### PR DESCRIPTION
## Description

This aspect has been failing pretty reliably on OSD and ROSA for the last two weeks.
Disabling for now according to [our policy](https://srox.slack.com/archives/CELUQKESC/p1667906225265369).

## Checklist
- [ ] Investigated and inspected CI test results to make sure this aspect was skipped
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

Relying on CI.