### PR TITLE
Untie documentation link from the product version

### DIFF
--- a/ui/apps/platform/src/Containers/Clusters/AddClusterPrompt.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/AddClusterPrompt.tsx
@@ -49,7 +49,7 @@ function AddClusterPrompt() {
                         component="a"
                         target="_blank"
                         rel="noopener noreferrer nofollow"
-                        href="https://docs.openshift.com/acs/3.72/installing/install-ocp-operator.html#adding-a-new-cluster-to-rhacs"
+                        href="https://docs.openshift.com/acs/installing/install-ocp-operator.html#adding-a-new-cluster-to-rhacs"
                     >
                         View instructions
                     </Button>


### PR DESCRIPTION
## Description

This follows up on https://github.com/stackrox/stackrox/pull/3541/files#r1014009939

## Checklist
- [x] Investigated and inspected CI test results

None of these will be done:
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

* Opened <https://docs.openshift.com/acs/installing/install-ocp-operator.html#adding-a-new-cluster-to-rhacs> the browser and saw it being redirected automatically to <https://docs.openshift.com/acs/3.72/installing/install-ocp-operator.html#adding-a-new-cluster-to-rhacs>.
