### PR TITLE
ROX-13540: Allow Sensor Component `NodeScanHandler` to start max. once 

### DIFF
--- a/sensor/common/compliance/nodescan_handler.go
+++ b/sensor/common/compliance/nodescan_handler.go
@@ -21,6 +21,5 @@ func NewNodeScanHandler(ch <-chan *storage.NodeScanV2) NodeScanHandler {
 		stopC:     concurrency.NewErrorSignal(),
 		lock:      &sync.Mutex{},
 		stoppedC:  concurrency.NewErrorSignal(),
-		numStarts: 0,
 	}
 }

--- a/sensor/common/compliance/nodescan_handler.go
+++ b/sensor/common/compliance/nodescan_handler.go
@@ -1,6 +1,7 @@
 package compliance
 
 import (
+	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/sensor/common"
@@ -15,9 +16,7 @@ type NodeScanHandler interface {
 func NewNodeScanHandler(ch <-chan *storage.NodeScanV2) NodeScanHandler {
 	return &nodeScanHandlerImpl{
 		nodeScans: ch,
-		toCentral: nil,
-
-		stopC:    concurrency.NewErrorSignal(),
-		stoppedC: concurrency.NewErrorSignal(),
+		toCentral: make(chan *central.MsgFromSensor),
+		stopC:     concurrency.NewErrorSignal(),
 	}
 }

--- a/sensor/common/compliance/nodescan_handler.go
+++ b/sensor/common/compliance/nodescan_handler.go
@@ -1,7 +1,6 @@
 package compliance
 
 import (
-	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/sync"

--- a/sensor/common/compliance/nodescan_handler.go
+++ b/sensor/common/compliance/nodescan_handler.go
@@ -20,8 +20,8 @@ func NewNodeScanHandler(ch <-chan *storage.NodeScanV2) NodeScanHandler {
 		nodeScans: ch,
 		toCentral: make(chan *central.MsgFromSensor),
 		stopC:     concurrency.NewErrorSignal(),
-		startedC:  concurrency.NewSignal(),
 		lock:      &sync.Mutex{},
 		stoppedC:  concurrency.NewErrorSignal(),
+		numStarts: 0,
 	}
 }

--- a/sensor/common/compliance/nodescan_handler.go
+++ b/sensor/common/compliance/nodescan_handler.go
@@ -1,7 +1,6 @@
 package compliance
 
 import (
-	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/sensor/common"
@@ -16,7 +15,7 @@ type NodeScanHandler interface {
 func NewNodeScanHandler(ch <-chan *storage.NodeScanV2) NodeScanHandler {
 	return &nodeScanHandlerImpl{
 		nodeScans: ch,
-		toCentral: make(chan *central.MsgFromSensor),
+		toCentral: nil,
 
 		stopC:    concurrency.NewErrorSignal(),
 		stoppedC: concurrency.NewErrorSignal(),

--- a/sensor/common/compliance/nodescan_handler.go
+++ b/sensor/common/compliance/nodescan_handler.go
@@ -17,11 +17,11 @@ type NodeScanHandler interface {
 // NewNodeScanHandler returns a new instance of a NodeScanHandler
 func NewNodeScanHandler(ch <-chan *storage.NodeScanV2) NodeScanHandler {
 	return &nodeScanHandlerImpl{
-		nodeScans:    ch,
-		toCentral:    make(chan *central.MsgFromSensor),
-		stopC:        concurrency.NewErrorSignal(),
-		startedC:     concurrency.NewSignal(),
-		lock:         &sync.Mutex{},
-		runFinishedC: concurrency.NewErrorSignal(),
+		nodeScans: ch,
+		toCentral: make(chan *central.MsgFromSensor),
+		stopC:     concurrency.NewErrorSignal(),
+		startedC:  concurrency.NewSignal(),
+		lock:      &sync.Mutex{},
+		stoppedC:  concurrency.NewErrorSignal(),
 	}
 }

--- a/sensor/common/compliance/nodescan_handler.go
+++ b/sensor/common/compliance/nodescan_handler.go
@@ -18,7 +18,7 @@ type NodeScanHandler interface {
 func NewNodeScanHandler(ch <-chan *storage.NodeScanV2) NodeScanHandler {
 	return &nodeScanHandlerImpl{
 		nodeScans: ch,
-		toCentral: make(chan *central.MsgFromSensor),
+		toCentral: nil,
 		stopC:     concurrency.NewErrorSignal(),
 		lock:      &sync.Mutex{},
 		stoppedC:  concurrency.NewErrorSignal(),

--- a/sensor/common/compliance/nodescan_handler.go
+++ b/sensor/common/compliance/nodescan_handler.go
@@ -21,7 +21,7 @@ func NewNodeScanHandler(ch <-chan *storage.NodeScanV2) NodeScanHandler {
 		toCentral:    make(chan *central.MsgFromSensor),
 		stopC:        concurrency.NewErrorSignal(),
 		startedC:     concurrency.NewSignal(),
-		toCentralMux: &sync.Mutex{},
+		lock:         &sync.Mutex{},
 		runFinishedC: concurrency.NewErrorSignal(),
 	}
 }

--- a/sensor/common/compliance/nodescan_handler.go
+++ b/sensor/common/compliance/nodescan_handler.go
@@ -4,19 +4,24 @@ import (
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/sensor/common"
 )
 
 // NodeScanHandler is responsible for handling the arriving NodeScanV2 messages, processing then, and sending them to central
 type NodeScanHandler interface {
 	common.SensorComponent
+	Stopped() concurrency.ReadOnlyErrorSignal
 }
 
 // NewNodeScanHandler returns a new instance of a NodeScanHandler
 func NewNodeScanHandler(ch <-chan *storage.NodeScanV2) NodeScanHandler {
 	return &nodeScanHandlerImpl{
-		nodeScans: ch,
-		toCentral: make(chan *central.MsgFromSensor),
-		stopC:     concurrency.NewErrorSignal(),
+		nodeScans:    ch,
+		toCentral:    make(chan *central.MsgFromSensor),
+		stopC:        concurrency.NewErrorSignal(),
+		startedC:     concurrency.NewSignal(),
+		toCentralMux: &sync.Mutex{},
+		runFinishedC: concurrency.NewErrorSignal(),
 	}
 }

--- a/sensor/common/compliance/nodescan_handler_impl.go
+++ b/sensor/common/compliance/nodescan_handler_impl.go
@@ -64,7 +64,9 @@ func (c *nodeScanHandlerImpl) ProcessMessage(_ *central.MsgToSensor) error {
 func (c *nodeScanHandlerImpl) run() <-chan *central.MsgFromSensor {
 	toC := make(chan *central.MsgFromSensor)
 	go func() {
-		defer c.stoppedC.SignalWithError(c.stopC.Err())
+		defer func() {
+			c.stoppedC.SignalWithError(c.stopC.Err())
+		}()
 		defer close(toC)
 		for !c.stopC.IsDone() {
 			select {

--- a/sensor/common/compliance/nodescan_handler_impl.go
+++ b/sensor/common/compliance/nodescan_handler_impl.go
@@ -11,7 +11,10 @@ import (
 	"github.com/stackrox/rox/pkg/sync"
 )
 
-var errStartMoreThanOnce = errors.New("unable to start the component more than once")
+var (
+	errInputChanClosed   = errors.New("channel receiving node scans v2 is closed")
+	errStartMoreThanOnce = errors.New("unable to start the component more than once")
+)
 
 type nodeScanHandlerImpl struct {
 	nodeScans <-chan *storage.NodeScanV2
@@ -75,7 +78,7 @@ func (c *nodeScanHandlerImpl) run() <-chan *central.MsgFromSensor {
 				return
 			case scan, ok := <-c.nodeScans:
 				if !ok {
-					c.stopC.SignalWithError(errors.New("channel receiving node scans v2 is closed"))
+					c.stopC.SignalWithError(errInputChanClosed)
 					return
 				}
 				// TODO(ROX-12943): Do something with the scan, e.g., attach NodeID

--- a/sensor/common/compliance/nodescan_handler_impl.go
+++ b/sensor/common/compliance/nodescan_handler_impl.go
@@ -64,20 +64,19 @@ func (c *nodeScanHandlerImpl) run() {
 }
 
 func (c *nodeScanHandlerImpl) sendScan(scan *storage.NodeScanV2) {
-	if scan != nil {
-		select {
-		case <-c.stopC.Done():
-			return
-		case c.toCentral <- &central.MsgFromSensor{
-			Msg: &central.MsgFromSensor_Event{
-				Event: &central.SensorEvent{
-					Resource: &central.SensorEvent_NodeScanV2{
-						NodeScanV2: scan,
-					},
+	if scan == nil {
+		return
+	}
+	select {
+	case <-c.stopC.Done():
+	case c.toCentral <- &central.MsgFromSensor{
+		Msg: &central.MsgFromSensor_Event{
+			Event: &central.SensorEvent{
+				Resource: &central.SensorEvent_NodeScanV2{
+					NodeScanV2: scan,
 				},
 			},
-		}:
-			return
-		}
+		},
+	}:
 	}
 }

--- a/sensor/common/compliance/nodescan_handler_impl.go
+++ b/sensor/common/compliance/nodescan_handler_impl.go
@@ -16,13 +16,13 @@ type nodeScanHandlerImpl struct {
 	lock *sync.Mutex
 
 	stopC concurrency.ErrorSignal
-	// runFinishedC is signaled when the goroutine inside of run() finishes
-	runFinishedC concurrency.ErrorSignal
-	startedC     concurrency.Signal
+	// stoppedC is signaled when the goroutine inside of run() finishes
+	stoppedC concurrency.ErrorSignal
+	startedC concurrency.Signal
 }
 
 func (c *nodeScanHandlerImpl) Stopped() concurrency.ReadOnlyErrorSignal {
-	return &c.runFinishedC
+	return &c.stoppedC
 }
 
 func (c *nodeScanHandlerImpl) Capabilities() []centralsensor.SensorCapability {
@@ -64,7 +64,7 @@ func (c *nodeScanHandlerImpl) ProcessMessage(_ *central.MsgToSensor) error {
 func (c *nodeScanHandlerImpl) run() <-chan *central.MsgFromSensor {
 	toC := make(chan *central.MsgFromSensor)
 	go func() {
-		defer c.runFinishedC.Signal()
+		defer c.stoppedC.Signal()
 		defer close(toC)
 		for !c.stopC.IsDone() {
 			select {

--- a/sensor/common/compliance/nodescan_handler_impl.go
+++ b/sensor/common/compliance/nodescan_handler_impl.go
@@ -12,8 +12,7 @@ type nodeScanHandlerImpl struct {
 	nodeScans <-chan *storage.NodeScanV2
 	toCentral chan *central.MsgFromSensor
 
-	stopC    concurrency.ErrorSignal
-	stoppedC concurrency.ErrorSignal
+	stopC concurrency.ErrorSignal
 }
 
 func (c *nodeScanHandlerImpl) Capabilities() []centralsensor.SensorCapability {
@@ -44,10 +43,6 @@ func (c *nodeScanHandlerImpl) ProcessMessage(_ *central.MsgToSensor) error {
 }
 
 func (c *nodeScanHandlerImpl) run() {
-	c.toCentral = make(chan *central.MsgFromSensor)
-	defer c.stoppedC.SignalWithError(c.stopC.Err())
-	defer close(c.toCentral)
-
 	for !c.stopC.IsDone() {
 		select {
 		case <-c.stopC.Done():

--- a/sensor/common/compliance/nodescan_handler_impl.go
+++ b/sensor/common/compliance/nodescan_handler_impl.go
@@ -6,13 +6,23 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/centralsensor"
 	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/sync"
 )
 
 type nodeScanHandlerImpl struct {
 	nodeScans <-chan *storage.NodeScanV2
-	toCentral chan *central.MsgFromSensor
+	toCentral <-chan *central.MsgFromSensor
+	// toCentralMux prevents the race condition between Start() [writer] and ResponsesC() [reader]
+	toCentralMux *sync.Mutex
 
 	stopC concurrency.ErrorSignal
+	// runFinishedC is signaled when the goroutine inside of run() finishes
+	runFinishedC concurrency.ErrorSignal
+	startedC     concurrency.Signal
+}
+
+func (c *nodeScanHandlerImpl) Stopped() concurrency.ReadOnlyErrorSignal {
+	return &c.runFinishedC
 }
 
 func (c *nodeScanHandlerImpl) Capabilities() []centralsensor.SensorCapability {
@@ -20,20 +30,27 @@ func (c *nodeScanHandlerImpl) Capabilities() []centralsensor.SensorCapability {
 }
 
 func (c *nodeScanHandlerImpl) ResponsesC() <-chan *central.MsgFromSensor {
+	c.toCentralMux.Lock()
+	defer c.toCentralMux.Unlock()
 	return c.toCentral
 }
 
 func (c *nodeScanHandlerImpl) Start() error {
-	// c.run closes chan toCentral on exit, so we do not want to close twice in case of a restart
-	if !c.stopC.IsDone() {
-		go c.run()
-		return nil
+	c.toCentralMux.Lock()
+	defer c.toCentralMux.Unlock()
+	if c.startedC.IsDone() {
+		return errors.New("running handler must be stopped before it can be started again")
 	}
-	return errors.New("stopped handlers cannot be restarted")
+	c.startedC.Signal()
+	if !c.stopC.IsDone() {
+		c.toCentral = c.run()
+	}
+	return nil
 }
 
 func (c *nodeScanHandlerImpl) Stop(err error) {
 	c.stopC.SignalWithError(err)
+	c.startedC.Reset()
 }
 
 func (c *nodeScanHandlerImpl) ProcessMessage(_ *central.MsgToSensor) error {
@@ -42,29 +59,37 @@ func (c *nodeScanHandlerImpl) ProcessMessage(_ *central.MsgToSensor) error {
 	return nil
 }
 
-func (c *nodeScanHandlerImpl) run() {
-	for !c.stopC.IsDone() {
-		select {
-		case <-c.stopC.Done():
-			return
-		case scan, ok := <-c.nodeScans:
-			if !ok {
-				c.stopC.SignalWithError(errors.New("channel receiving node scans v2 is closed"))
+// run handles the messages from Compliance and forwards them to Central
+// This is the only goroutine that writes into the toCentral channel, thus it is responsible for creating and closing that chan
+func (c *nodeScanHandlerImpl) run() <-chan *central.MsgFromSensor {
+	toC := make(chan *central.MsgFromSensor)
+	go func() {
+		defer c.runFinishedC.Signal()
+		defer close(toC)
+		for !c.stopC.IsDone() {
+			select {
+			case <-c.stopC.Done():
 				return
+			case scan, ok := <-c.nodeScans:
+				if !ok {
+					c.stopC.SignalWithError(errors.New("channel receiving node scans v2 is closed"))
+					return
+				}
+				// TODO(ROX-12943): Do something with the scan, e.g., attach NodeID
+				c.sendScan(toC, scan)
 			}
-			// TODO(ROX-12943): Do something with the scan, e.g., attach NodeID
-			c.sendScan(scan)
 		}
-	}
+	}()
+	return toC
 }
 
-func (c *nodeScanHandlerImpl) sendScan(scan *storage.NodeScanV2) {
+func (c *nodeScanHandlerImpl) sendScan(toC chan *central.MsgFromSensor, scan *storage.NodeScanV2) {
 	if scan == nil {
 		return
 	}
 	select {
 	case <-c.stopC.Done():
-	case c.toCentral <- &central.MsgFromSensor{
+	case toC <- &central.MsgFromSensor{
 		Msg: &central.MsgFromSensor_Event{
 			Event: &central.SensorEvent{
 				Resource: &central.SensorEvent_NodeScanV2{

--- a/sensor/common/compliance/nodescan_handler_impl.go
+++ b/sensor/common/compliance/nodescan_handler_impl.go
@@ -70,9 +70,9 @@ func (c *nodeScanHandlerImpl) run() <-chan *central.MsgFromSensor {
 	toC := make(chan *central.MsgFromSensor)
 	go func() {
 		defer func() {
+			close(toC)
 			c.stoppedC.SignalWithError(c.stopC.Err())
 		}()
-		defer close(toC)
 		for !c.stopC.IsDone() {
 			select {
 			case <-c.stopC.Done():

--- a/sensor/common/compliance/nodescan_handler_impl.go
+++ b/sensor/common/compliance/nodescan_handler_impl.go
@@ -11,6 +11,8 @@ import (
 	"github.com/stackrox/rox/pkg/sync"
 )
 
+var errStartMoreThanOnce = errors.New("unable to start the component more than once")
+
 type nodeScanHandlerImpl struct {
 	nodeScans <-chan *storage.NodeScanV2
 	toCentral <-chan *central.MsgFromSensor
@@ -39,7 +41,7 @@ func (c *nodeScanHandlerImpl) ResponsesC() <-chan *central.MsgFromSensor {
 
 func (c *nodeScanHandlerImpl) Start() error {
 	if !atomic.CompareAndSwapUint32(&c.numStarts, 0, 1) {
-		return errors.New("unable to start - component reached the maximum number of starts: 1")
+		return errStartMoreThanOnce
 	}
 	c.lock.Lock()
 	defer c.lock.Unlock()

--- a/sensor/common/compliance/nodescan_handler_impl.go
+++ b/sensor/common/compliance/nodescan_handler_impl.go
@@ -70,9 +70,9 @@ func (c *nodeScanHandlerImpl) run() <-chan *central.MsgFromSensor {
 	toC := make(chan *central.MsgFromSensor)
 	go func() {
 		defer func() {
-			close(toC)
 			c.stoppedC.SignalWithError(c.stopC.Err())
 		}()
+		defer close(toC)
 		for !c.stopC.IsDone() {
 			select {
 			case <-c.stopC.Done():

--- a/sensor/common/compliance/nodescan_handler_impl.go
+++ b/sensor/common/compliance/nodescan_handler_impl.go
@@ -44,6 +44,7 @@ func (c *nodeScanHandlerImpl) ProcessMessage(_ *central.MsgToSensor) error {
 }
 
 func (c *nodeScanHandlerImpl) run() {
+	c.toCentral = make(chan *central.MsgFromSensor)
 	defer c.stoppedC.SignalWithError(c.stopC.Err())
 	defer close(c.toCentral)
 

--- a/sensor/common/compliance/nodescan_handler_impl.go
+++ b/sensor/common/compliance/nodescan_handler_impl.go
@@ -33,6 +33,7 @@ func (c *nodeScanHandlerImpl) Capabilities() []centralsensor.SensorCapability {
 	return []centralsensor.SensorCapability{centralsensor.NodeScanningCap}
 }
 
+// ResponsesC returns a channel with messages to Central. It must be called after Start() for the channel to be not nil
 func (c *nodeScanHandlerImpl) ResponsesC() <-chan *central.MsgFromSensor {
 	c.lock.Lock()
 	defer c.lock.Unlock()

--- a/sensor/common/compliance/nodescan_handler_test.go
+++ b/sensor/common/compliance/nodescan_handler_test.go
@@ -164,6 +164,9 @@ func (s *NodeScanHandlerTestSuite) TestRestartHandler() {
 		err := h.Start()
 		s.Error(err)
 		s.ErrorIs(err, errStartMoreThanOnce)
+
+		err = h.Stopped().Wait()
+		s.True(errors.Is(err, nil) || errors.Is(err, errInputChanClosed))
 	})
 }
 
@@ -177,6 +180,9 @@ func (s *NodeScanHandlerTestSuite) TestDoubleStartHandler() {
 		s.Error(err)
 		s.ErrorIs(err, errStartMoreThanOnce)
 		h.Stop(nil)
+
+		err = h.Stopped().Wait()
+		s.True(errors.Is(err, nil) || errors.Is(err, errInputChanClosed))
 	})
 }
 
@@ -187,5 +193,8 @@ func (s *NodeScanHandlerTestSuite) TestDoubleStopHandler() {
 		s.consumeToCentral(h)
 		h.Stop(nil)
 		h.Stop(nil)
+
+		err := h.Stopped().Wait()
+		s.True(errors.Is(err, nil) || errors.Is(err, errInputChanClosed))
 	})
 }

--- a/sensor/common/compliance/nodescan_handler_test.go
+++ b/sensor/common/compliance/nodescan_handler_test.go
@@ -154,11 +154,8 @@ func (s *NodeScanHandlerTestSuite) TestHandlerRegularRoutine() {
 	s.NoError(producer.stoppedC.Wait())
 	s.NoError(consumer.stoppedC.Wait())
 
-	errTest := errors.New("example-stop-error")
-	h.Stop(errTest)
-	s.ErrorIs(h.Stopped().Wait(), errTest)
-
-	stopAll(s.T(), producer, consumer)
+	h.Stop(nil)
+	s.NoError(h.Stopped().Wait())
 }
 
 func (s *NodeScanHandlerTestSuite) TestHandlerStoppedError() {

--- a/sensor/common/compliance/nodescan_handler_test.go
+++ b/sensor/common/compliance/nodescan_handler_test.go
@@ -242,15 +242,12 @@ func (s *NodeScanHandlerTestSuite) TestDoubleStartHandler() {
 
 		consumer := consumeAndCount(h.ResponsesC(), 10)
 		s.NoError(producer.stoppedC.Wait())
-		s.NoError(consumer.stoppedC.Wait())
 
-		err := h.Start()
-		s.Error(err)
-		s.ErrorIs(err, errStartMoreThanOnce)
+		s.ErrorIs(h.Start(), errStartMoreThanOnce)
 		h.Stop(nil)
 		s.NoError(h.Stopped().Wait())
 
-		stopAll(s.T(), producer, consumer)
+		s.NoError(consumer.stoppedC.Wait())
 	})
 }
 
@@ -266,7 +263,5 @@ func (s *NodeScanHandlerTestSuite) TestDoubleStopHandler() {
 		h.Stop(nil)
 		h.Stop(nil)
 		s.NoError(h.Stopped().Wait())
-
-		stopAll(s.T(), producer, consumer)
 	})
 }

--- a/sensor/common/compliance/nodescan_handler_test.go
+++ b/sensor/common/compliance/nodescan_handler_test.go
@@ -2,6 +2,7 @@ package compliance
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	timestamp "github.com/gogo/protobuf/types"
@@ -99,6 +100,16 @@ func (s *NodeScanHandlerTestSuite) TestHandlerRegularRoutine() {
 	s.NoError(h.Start())
 	s.consumeToCentral(h)
 	h.Stop(nil)
+}
+
+func (s *NodeScanHandlerTestSuite) TestHandlerStoppedError() {
+	h := NewNodeScanHandler(s.generateTestInput())
+	s.NoError(h.Start())
+	s.consumeToCentral(h)
+	errTest := errors.New("example-stop-error")
+	h.Stop(errTest)
+	err := h.Stopped().Wait()
+	s.ErrorIs(err, errTest)
 }
 
 // generateTestInput generates 10 input messages to the NodeScanHandler

--- a/sensor/common/compliance/nodescan_handler_test.go
+++ b/sensor/common/compliance/nodescan_handler_test.go
@@ -77,7 +77,7 @@ func (s *NodeScanHandlerTestSuite) TestStopHandler() {
 	s.consumeToCentral(h)
 	// This is a producer that stops the handler after producing the first message and then sends many (29) more messages
 	// The intent here it to test whether the handler can shutdown with no leaks when the context is canceled despite of
-	// multiple messages waiting in the channel to be processed
+	// multiple messages waiting to be written to the channel
 	go func() {
 		defer close(nodeScans)
 		for i := 0; i < 30; i++ {

--- a/sensor/common/compliance/nodescan_handler_test.go
+++ b/sensor/common/compliance/nodescan_handler_test.go
@@ -46,14 +46,12 @@ func fakeNodeScanV2(nodeName string) *storage.NodeScanV2 {
 	return msg
 }
 
+var _ suite.TearDownTestSuite = (*NodeScanHandlerTestSuite)(nil)
+
 type NodeScanHandlerTestSuite struct {
 	suite.Suite
 	cancel context.CancelFunc
 	ctx    context.Context
-}
-
-func (s *NodeScanHandlerTestSuite) SetupTest() {
-
 }
 
 func assertNoGoroutineLeaks(t *testing.T) {

--- a/sensor/common/compliance/nodescan_handler_test.go
+++ b/sensor/common/compliance/nodescan_handler_test.go
@@ -216,7 +216,6 @@ func (s *NodeScanHandlerTestSuite) TestRestartHandler() {
 		s.NoError(h.Stopped().Wait())
 
 		s.ErrorIs(h.Start(), errStartMoreThanOnce)
-		s.NoError(h.Stopped().Wait())
 	})
 }
 

--- a/sensor/common/compliance/nodescan_handler_test.go
+++ b/sensor/common/compliance/nodescan_handler_test.go
@@ -170,8 +170,6 @@ func (s *NodeScanHandlerTestSuite) TestHandlerStoppedError() {
 	errTest := errors.New("example-stop-error")
 	h.Stop(errTest)
 	s.ErrorIs(h.Stopped().Wait(), errTest)
-
-	stopAll(s.T(), producer, consumer)
 }
 
 // generateTestInputNoClose generates numToProduce messages of type NodeScanV2

--- a/sensor/common/compliance/nodescan_handler_test.go
+++ b/sensor/common/compliance/nodescan_handler_test.go
@@ -226,13 +226,10 @@ func (s *NodeScanHandlerTestSuite) TestRestartHandler() {
 		s.NoError(producer.stoppedC.Wait())
 		s.NoError(consumer.stoppedC.Wait())
 		h.Stop(nil)
-
-		err := h.Start()
-		s.Error(err)
-		s.ErrorIs(err, errStartMoreThanOnce)
 		s.NoError(h.Stopped().Wait())
 
-		stopAll(s.T(), producer, consumer)
+		s.ErrorIs(h.Start(), errStartMoreThanOnce)
+		s.NoError(h.Stopped().Wait())
 	})
 }
 

--- a/sensor/common/compliance/nodescan_handler_test.go
+++ b/sensor/common/compliance/nodescan_handler_test.go
@@ -172,19 +172,18 @@ func (s *NodeScanHandlerTestSuite) TestHandlerStoppedError() {
 	s.ErrorIs(h.Stopped().Wait(), errTest)
 }
 
-// generateTestInputNoClose generates numToProduce messages of type NodeScanV2
-// It returns channel that must be closed
+// generateTestInputNoClose generates numToProduce messages of type NodeScanV2.
+// It returns a channel that must be closed by the caller.
 func (s *NodeScanHandlerTestSuite) generateTestInputNoClose(numToProduce int) (chan *storage.NodeScanV2, stoppable) {
 	input := make(chan *storage.NodeScanV2)
 	st := newStoppable()
-	// this is a producer that sends 10 nodescan messages
 	go func() {
 		defer st.signalStopped()
 		for i := 0; i < numToProduce; i++ {
 			select {
 			case <-st.stopC.Done():
 				return
-			case input <- fakeNodeScanV2("Node"):
+			case input <- fakeNodeScanV2(fmt.Sprintf("Node-%d", i)):
 			}
 		}
 	}()

--- a/sensor/common/compliance/nodescan_handler_test.go
+++ b/sensor/common/compliance/nodescan_handler_test.go
@@ -82,7 +82,7 @@ func assertNoGoroutineLeaks(t *testing.T) {
 }
 
 func (s *NodeScanHandlerTestSuite) TearDownTest() {
-	defer assertNoGoroutineLeaks(s.T())
+	assertNoGoroutineLeaks(s.T())
 }
 
 // stopAll gracefully stops stoppables

--- a/sensor/common/compliance/nodescan_handler_test.go
+++ b/sensor/common/compliance/nodescan_handler_test.go
@@ -195,40 +195,36 @@ func consumeAndCount[T any](ch <-chan *T, numToConsume int) stoppable {
 }
 
 func (s *NodeScanHandlerTestSuite) TestMultipleStartHandler() {
-	s.NotPanics(func() {
-		ch, producer := s.generateTestInputNoClose(10)
-		defer close(ch)
-		h := NewNodeScanHandler(ch)
+	ch, producer := s.generateTestInputNoClose(10)
+	defer close(ch)
+	h := NewNodeScanHandler(ch)
 
-		s.NoError(h.Start())
-		s.ErrorIs(h.Start(), errStartMoreThanOnce)
+	s.NoError(h.Start())
+	s.ErrorIs(h.Start(), errStartMoreThanOnce)
 
-		consumer := consumeAndCount(h.ResponsesC(), 10)
+	consumer := consumeAndCount(h.ResponsesC(), 10)
 
-		s.ErrorIs(h.Start(), errStartMoreThanOnce)
+	s.ErrorIs(h.Start(), errStartMoreThanOnce)
 
-		s.NoError(producer.stoppedC.Wait())
-		s.NoError(consumer.stoppedC.Wait())
+	s.NoError(producer.stoppedC.Wait())
+	s.NoError(consumer.stoppedC.Wait())
 
-		h.Stop(nil)
-		s.NoError(h.Stopped().Wait())
+	h.Stop(nil)
+	s.NoError(h.Stopped().Wait())
 
-		// No second start even after a stop
-		s.ErrorIs(h.Start(), errStartMoreThanOnce)
-	})
+	// No second start even after a stop
+	s.ErrorIs(h.Start(), errStartMoreThanOnce)
 }
 
 func (s *NodeScanHandlerTestSuite) TestDoubleStopHandler() {
-	s.NotPanics(func() {
-		ch, producer := s.generateTestInputNoClose(10)
-		defer close(ch)
-		h := NewNodeScanHandler(ch)
-		s.NoError(h.Start())
-		consumer := consumeAndCount(h.ResponsesC(), 10)
-		s.NoError(producer.stoppedC.Wait())
-		s.NoError(consumer.stoppedC.Wait())
-		h.Stop(nil)
-		h.Stop(nil)
-		s.NoError(h.Stopped().Wait())
-	})
+	ch, producer := s.generateTestInputNoClose(10)
+	defer close(ch)
+	h := NewNodeScanHandler(ch)
+	s.NoError(h.Start())
+	consumer := consumeAndCount(h.ResponsesC(), 10)
+	s.NoError(producer.stoppedC.Wait())
+	s.NoError(consumer.stoppedC.Wait())
+	h.Stop(nil)
+	h.Stop(nil)
+	s.NoError(h.Stopped().Wait())
 }

--- a/sensor/common/compliance/nodescan_handler_test.go
+++ b/sensor/common/compliance/nodescan_handler_test.go
@@ -131,7 +131,7 @@ func (s *NodeScanHandlerTestSuite) TestStopHandler() {
 	s.NoError(consumer.stoppedC.Wait())
 	s.ErrorIs(h.Stopped().Wait(), errTest)
 
-	stopAll(s.T(), producer, consumer)
+	stopAll(s.T(), producer)
 }
 
 func (s *NodeScanHandlerTestSuite) TestHandlerRegularRoutine() {

--- a/sensor/common/compliance/nodescan_handler_test.go
+++ b/sensor/common/compliance/nodescan_handler_test.go
@@ -121,9 +121,8 @@ func (s *NodeScanHandlerTestSuite) TestStopHandler() {
 	h := NewNodeScanHandler(nodeScans)
 	s.NoError(h.Start())
 	consumer := consumeAndCount(h.ResponsesC(), 1)
-	// This is a producer that stops the handler after producing the first message and then sends many (29) more messages
-	// The intent here it to test whether the handler can shutdown with no leaks when the context is canceled despite of
-	// multiple messages waiting to be written to the channel
+	// This is a producer that stops the handler after producing the first message and then sends many (29) more messages.
+	// This is to test whether the handler can shutdown with no leaks when the producer keeps producing messages.
 	go func() {
 		defer producer.signalStopped()
 		for i := 0; i < 30; i++ {

--- a/sensor/common/compliance/nodescan_handler_test.go
+++ b/sensor/common/compliance/nodescan_handler_test.go
@@ -102,7 +102,10 @@ func (s *NodeScanHandlerTestSuite) TestHandlerRegularRoutine() {
 	h := NewNodeScanHandler(s.generateTestInput())
 	s.NoError(h.Start())
 	s.consumeToCentral(h)
-	h.Stop(nil)
+	errTest := errors.New("example-stop-error")
+	h.Stop(errTest)
+	err := h.Stopped().Wait()
+	s.True(errors.Is(err, errTest) || errors.Is(err, errInputChanClosed))
 }
 
 func (s *NodeScanHandlerTestSuite) TestHandlerStoppedError() {

--- a/sensor/common/compliance/nodescan_handler_test.go
+++ b/sensor/common/compliance/nodescan_handler_test.go
@@ -194,22 +194,6 @@ func consumeAndCount[T any](ch <-chan *T, numToConsume int) stoppable {
 	return st
 }
 
-func (s *NodeScanHandlerTestSuite) TestRestartHandler() {
-	s.NotPanics(func() {
-		ch, producer := s.generateTestInputNoClose(10)
-		defer close(ch)
-		h := NewNodeScanHandler(ch)
-		s.NoError(h.Start())
-		consumer := consumeAndCount(h.ResponsesC(), 10)
-		s.NoError(producer.stoppedC.Wait())
-		s.NoError(consumer.stoppedC.Wait())
-		h.Stop(nil)
-		s.NoError(h.Stopped().Wait())
-
-		s.ErrorIs(h.Start(), errStartMoreThanOnce)
-	})
-}
-
 func (s *NodeScanHandlerTestSuite) TestMultipleStartHandler() {
 	s.NotPanics(func() {
 		ch, producer := s.generateTestInputNoClose(10)

--- a/sensor/common/compliance/nodescan_handler_test.go
+++ b/sensor/common/compliance/nodescan_handler_test.go
@@ -1,7 +1,6 @@
 package compliance
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -40,11 +39,7 @@ func (st *stoppable) signalAndWait(err error) error {
 }
 
 func TestNodeScanHandler(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	suite.Run(t, &NodeScanHandlerTestSuite{
-		ctx:    ctx,
-		cancel: cancel,
-	})
+	suite.Run(t, &NodeScanHandlerTestSuite{})
 }
 
 func fakeNodeScanV2(nodeName string) *storage.NodeScanV2 {
@@ -77,8 +72,6 @@ var _ suite.TearDownTestSuite = (*NodeScanHandlerTestSuite)(nil)
 
 type NodeScanHandlerTestSuite struct {
 	suite.Suite
-	cancel context.CancelFunc
-	ctx    context.Context
 }
 
 func assertNoGoroutineLeaks(t *testing.T) {
@@ -90,7 +83,6 @@ func assertNoGoroutineLeaks(t *testing.T) {
 
 func (s *NodeScanHandlerTestSuite) TearDownTest() {
 	defer assertNoGoroutineLeaks(s.T())
-	s.cancel()
 }
 
 // stopAll gracefully stops stoppables

--- a/sensor/common/compliance/nodescan_handler_test.go
+++ b/sensor/common/compliance/nodescan_handler_test.go
@@ -144,7 +144,7 @@ func (s *NodeScanHandlerTestSuite) TestRestartHandler() {
 
 		err := h.Start()
 		s.Error(err)
-		s.ErrorContains(err, "unable to start - component reached the maximum number of starts: 1")
+		s.ErrorIs(err, errStartMoreThanOnce)
 	})
 }
 
@@ -156,7 +156,7 @@ func (s *NodeScanHandlerTestSuite) TestDoubleStartHandler() {
 
 		err := h.Start()
 		s.Error(err)
-		s.ErrorContains(err, "unable to start - component reached the maximum number of starts: 1")
+		s.ErrorIs(err, errStartMoreThanOnce)
 		h.Stop(nil)
 	})
 }

--- a/sensor/common/compliance/nodescan_handler_test.go
+++ b/sensor/common/compliance/nodescan_handler_test.go
@@ -75,7 +75,9 @@ func (s *NodeScanHandlerTestSuite) TestStopHandler() {
 	nodeScans := make(chan *storage.NodeScanV2)
 	h := NewNodeScanHandler(nodeScans)
 	s.consumeToCentral(h)
-	// this is a producer that stops the handler after producing the first message and then sends many (29) more messages
+	// This is a producer that stops the handler after producing the first message and then sends many (29) more messages
+	// The intent here it to test whether the handler can shutdown with no leaks when the context is canceled despite of
+	// multiple messages waiting in the channel to be processed
 	go func() {
 		defer close(nodeScans)
 		for i := 0; i < 30; i++ {

--- a/sensor/common/compliance/nodescan_handler_test.go
+++ b/sensor/common/compliance/nodescan_handler_test.go
@@ -86,7 +86,7 @@ func (s *NodeScanHandlerTestSuite) TestStopHandler() {
 			}
 		}
 	}()
-	// this is a producer that stops the handler after producing the first message and then sends 30 more messages
+	// this is a producer that stops the handler after producing the first message and then sends many (29) more messages
 	go func() {
 		defer close(nodeScans)
 		for i := 0; i < 30; i++ {
@@ -101,8 +101,7 @@ func (s *NodeScanHandlerTestSuite) TestStopHandler() {
 		}
 	}()
 
-	err := h.Start()
-	s.Assert().NoError(err)
+	s.Assert().NoError(h.Start())
 }
 
 func (s *NodeScanHandlerTestSuite) TestRestartHandler() {

--- a/sensor/common/compliance/nodescan_handler_test.go
+++ b/sensor/common/compliance/nodescan_handler_test.go
@@ -109,7 +109,9 @@ func (s *NodeScanHandlerTestSuite) TestHandlerStoppedError() {
 	errTest := errors.New("example-stop-error")
 	h.Stop(errTest)
 	err := h.Stopped().Wait()
-	s.ErrorIs(err, errTest)
+	// if generateTestInput finishes before call to Stop(), err is errInputChanClosed
+	// otherwise it is errTest. Both are fine as a reason for stopping the handler
+	s.True(errors.Is(err, errTest) || errors.Is(err, errInputChanClosed))
 }
 
 // generateTestInput generates 10 input messages to the NodeScanHandler


### PR DESCRIPTION
## Description

This is a follow-up PR to address review comments from #3533.
The original PR was merged by accident without addressing optional but
good suggestions.

This PR changes the NodeScan component to start maximally once.

It includes:
- ~🗑️ Removing `stoppedC` leftover~ (readded in d7353aed4c076ee0b9e3a9ad492ab84d28a93433)
- 🐛 Handling a panic when two or more consecutive Start() calls happen without a Stop() call in-between
- 🧪 Adding a regression test for the two or more consecutive Start() calls
- 🐛 Fixing previously undiscovered race condition
- 💄 Removing one level of indentation in `sendScan`
- 💄 Using `s.Assert()` instead `assert.`
- ~✨ (Extra) Making the component restartable~ (removed in d7353aed4c076ee0b9e3a9ad492ab84d28a93433)
- Re-added `Stopped()` so that the tests can wait for the handler to finish work. 

### Extra

After the first [comment about not closing the `toCentral` channel](https://github.com/stackrox/stackrox/pull/3800/files#r1023454649), I decided that the only clean solution to that challenge it to make the component restartable. I added the restartability in https://github.com/stackrox/stackrox/pull/3800/commits/be4bb7cde40d2548bc71fa84d6fd1a3b158d3752.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added

### Not applies

- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))


## Testing Performed

- [x] CI
- [x] `go test -race -count=1 -v -run ^TestNodeScanHandler$
  ./sensor/common/compliance`
- [x] `go test -race -count=12 -v -run ^TestNodeScanHandler$
  ./sensor/common/compliance` (more executions at once)
- [x] Manual deployment of cluster locally, enabling the FF (`ROX_RHCOS_NODE_SCANNING=true)`, and
  confirming that the messages are sent to Sensor and Central. Also
killing sensor pod and making sure that it gets restarted and
self-heals.
