### PR TITLE
remove make proto-fmt

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,6 @@ require (
 	github.com/aws/aws-sdk-go v1.44.119
 	github.com/blevesearch/bleve v1.0.14
 	github.com/cenkalti/backoff/v3 v3.2.2
-	github.com/ckaznocha/protoc-gen-lint v0.3.0
 	github.com/cloudflare/cfssl v1.6.3
 	github.com/containers/image/v5 v5.23.0
 	github.com/coreos/go-oidc/v3 v3.4.0

--- a/go.sum
+++ b/go.sum
@@ -317,8 +317,6 @@ github.com/cilium/ebpf v0.0.0-20200110133405-4032b1d8aae3/go.mod h1:MA5e5Lr8slmE
 github.com/cilium/ebpf v0.0.0-20200702112145-1c8d4c9ef775/go.mod h1:7cR51M8ViRLIdUjrmSXlK9pkrsDlLHbO8jiB8X8JnOc=
 github.com/cilium/ebpf v0.2.0/go.mod h1:To2CFviqOWL/M0gIMsvSMlqe7em/l1ALkX1PyjrX2Qs=
 github.com/cilium/ebpf v0.4.0/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJXRs=
-github.com/ckaznocha/protoc-gen-lint v0.3.0 h1:9SJQVaRJqC2riK2qOovq2+Hmle0wn9KWY+Yh/u6/tMg=
-github.com/ckaznocha/protoc-gen-lint v0.3.0/go.mod h1:ASGO5J8wYQ8yJPBE68EntfsSKRU8tp7qAskT3BjIsvE=
 github.com/clbanning/x2j v0.0.0-20191024224557-825249438eec/go.mod h1:jMjuTZXRI4dUb/I5gc9Hdhagfvm9+RyrPryS/auMzxE=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/backoff v0.0.0-20161212185259-647f3cdfc87a/go.mod h1:rzgs2ZOiguV6/NpiDgADjRLPNyZlApIWxKpkT+X8SdY=

--- a/make/protogen.mk
+++ b/make/protogen.mk
@@ -94,11 +94,6 @@ $(PROTOC_GEN_GO_BIN): $(MODFILE_DIR)/github.com/gogo/protobuf/UPDATE_CHECK $(PRO
 	@echo "+ $@"
 	$(SILENT)GOBIN=$(PROTO_GOBIN) go install github.com/gogo/protobuf/$(notdir $@)
 
-PROTOC_GEN_LINT := $(PROTO_GOBIN)/protoc-gen-lint
-$(PROTOC_GEN_LINT): $(MODFILE_DIR)/github.com/ckaznocha/protoc-gen-lint/UPDATE_CHECK $(PROTO_GOBIN)
-	@echo "+ $@"
-	$(SILENT)GOBIN=$(PROTO_GOBIN) go install github.com/ckaznocha/protoc-gen-lint
-
 GOGO_M_STR := Mgoogle/protobuf/any.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/duration.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/struct.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/timestamp.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/wrappers.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/empty.proto=github.com/gogo/protobuf/types
 
 # The --go_out=M... argument specifies the go package to use for an imported proto file.
@@ -129,18 +124,6 @@ $(PROTOC_INCLUDES): $(PROTOC)
 
 GOGO_DIR = $(shell go list -f '{{.Dir}}' -m github.com/gogo/protobuf)
 GRPC_GATEWAY_DIR = $(shell go list -f '{{.Dir}}' -m github.com/grpc-ecosystem/grpc-gateway)
-
-.PHONY: proto-fmt
-proto-fmt: $(PROTOC_GEN_LINT)
-	@echo "Checking for proto style errors"
-	$(SILENT)PATH=$(PROTO_GOBIN) $(PROTOC) \
-		-I$(PROTOC_INCLUDES) \
-		-I$(GOGO_DIR)/protobuf \
-		-I$(GRPC_GATEWAY_DIR)/third_party/googleapis \
-		-I$(SCANNER_PROTO_BASE_PATH) \
-		--lint_out=. \
-		--proto_path=$(PROTO_BASE_PATH) \
-		$(ALL_PROTOS)
 
 PROTO_DEPS=$(PROTOC) $(PROTOC_INCLUDES)
 

--- a/tools/tools-import.go
+++ b/tools/tools-import.go
@@ -9,7 +9,6 @@ package tools
 
 import (
 	// Tool dependencies, not used anywhere in the code.
-	_ "github.com/ckaznocha/protoc-gen-lint"
 	_ "github.com/golang/mock/mockgen"
 	_ "github.com/mailru/easyjson/easyjson"
 	_ "golang.org/x/tools/cmd/stringer"


### PR DESCRIPTION
## Description

It looks like proto-fmt is not used anywhere (especially is not called from `make style`).
When I run it locally I get list of errors. It will be great to have it enabled in CI but since it was not there for so long lets remove it.

## Testing Performed

CI