### PR TITLE
ROX-13228: Performance benchmarking baselines for collection workflows

### DIFF
--- a/central/resourcecollection/datastore/datastore_bench_test.go
+++ b/central/resourcecollection/datastore/datastore_bench_test.go
@@ -1,0 +1,138 @@
+//go:build sql_integration
+
+package datastore
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"testing"
+
+	"github.com/jackc/pgx/v4/pgxpool"
+	"github.com/stackrox/rox/central/resourcecollection/datastore/search"
+	"github.com/stackrox/rox/central/resourcecollection/datastore/store/postgres"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/env"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
+	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stackrox/rox/pkg/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func BenchmarkCollections(b *testing.B) {
+	b.Setenv(env.PostgresDatastoreEnabled.EnvVar(), "true")
+
+	if !env.PostgresDatastoreEnabled.BooleanSetting() {
+		b.Skip("Skip postgres store tests")
+		b.SkipNow()
+	}
+
+	ctx := sac.WithAllAccess(context.Background())
+
+	source := pgtest.GetConnectionString(b)
+	config, err := pgxpool.ParseConfig(source)
+	require.NoError(b, err)
+
+	pool, err := pgxpool.ConnectConfig(ctx, config)
+	require.NoError(b, err)
+	gormDB := pgtest.OpenGormDB(b, source)
+	defer pgtest.CloseGormDB(b, gormDB)
+
+	db := pool
+	defer db.Close()
+
+	postgres.Destroy(ctx, db)
+	store := postgres.CreateTableAndNewStore(ctx, db, gormDB)
+	index := postgres.NewIndexer(db)
+	datastore, err := New(store, index, search.New(store, index))
+	require.NoError(b, err)
+
+	numSeedObjects := 5000
+
+	ids := make([]string, 0, numSeedObjects)
+	collections := make([]*storage.ResourceCollection, 0, numSeedObjects)
+	for i := 0; i < numSeedObjects; i++ {
+		name := fmt.Sprintf("%d", i)
+		collections = append(collections, getTestCollection(name, nil))
+		require.NoError(b, datastore.AddCollection(ctx, collections[i]))
+		ids = append(ids, collections[i].GetId())
+	}
+
+	// DryRun Add
+	b.Run("DryRunAddCollection", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			var start, end int
+			start = i % numSeedObjects
+			if start < numSeedObjects-5 {
+				end = start + 5
+			} else {
+				end = numSeedObjects - 1
+			}
+			collection := getTestCollection("name", ids[start:end])
+			err = datastore.DryRunAddCollection(ctx, collection)
+			require.NoError(b, err)
+		}
+	})
+
+	// DryRun Update
+	b.Run("DryRunUpdateCollection", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			var start, end int
+			start = rand.Intn(numSeedObjects-i-1) + i + 1
+			if start < numSeedObjects-5 {
+				end = start + 5
+			} else {
+				end = numSeedObjects - 1
+			}
+			collection := getTestCollection("name", ids[start:end])
+			collection.Id = collections[i].GetId()
+			err = datastore.DryRunUpdateCollection(ctx, collection)
+			require.NoError(b, err)
+		}
+	})
+
+	// Update
+	b.Run("UpdateCollection", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			var start, end int
+			start = rand.Intn(numSeedObjects-i-1) + i + 1
+			if start < numSeedObjects-5 {
+				end = start + 5
+			} else {
+				end = numSeedObjects - 1
+			}
+			collection := getTestCollection(uuid.NewV4().String(), ids[start:end])
+			collection.Id = collections[i].GetId()
+			err = datastore.DryRunUpdateCollection(ctx, collection)
+			require.NoError(b, err)
+		}
+	})
+
+	// graphInit
+	dsImpl := &datastoreImpl{
+		storage:  store,
+		indexer:  index,
+		searcher: search.New(store, index),
+	}
+	b.Run("graphInit", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			require.NoError(b, resetLocalGraph(dsImpl))
+		}
+	})
+
+	// Add, last so we know how many entries for previous runs
+	b.Run("AddCollection", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			var start, end int
+			start = i % numSeedObjects
+			if start < numSeedObjects-5 {
+				end = start + 5
+			} else {
+				end = numSeedObjects - 1
+			}
+			collection := getTestCollection(uuid.NewV4().String(), ids[start:end])
+			err = datastore.AddCollection(ctx, collection)
+			require.NoError(b, err)
+		}
+	})
+}

--- a/central/resourcecollection/datastore/datastore_bench_test.go
+++ b/central/resourcecollection/datastore/datastore_bench_test.go
@@ -103,7 +103,7 @@ func BenchmarkCollections(b *testing.B) {
 			}
 			collection := getTestCollection(uuid.NewV4().String(), ids[start:end])
 			collection.Id = collections[i].GetId()
-			err = datastore.DryRunUpdateCollection(ctx, collection)
+			err = datastore.UpdateCollection(ctx, collection)
 			require.NoError(b, err)
 		}
 	})


### PR DESCRIPTION
```GOROOT=/usr/local/opt/go/libexec #gosetup
GOPATH=/Users/oscarward/go #gosetup
/usr/local/opt/go/libexec/bin/go test -c -tags sql_integration -o /private/var/folders/44/6672qnyj1jg_8zgf2729kxh40000gn/T/GoLand/___BenchmarkCollections_in_github_com_stackrox_rox_central_resourcecollection_datastore.test github.com/stackrox/rox/central/resourcecollection/datastore #gosetup
/private/var/folders/44/6672qnyj1jg_8zgf2729kxh40000gn/T/GoLand/___BenchmarkCollections_in_github_com_stackrox_rox_central_resourcecollection_datastore.test -test.v -test.paniconexit0 -test.bench ^\QBenchmarkCollections\E$ -test.run ^$ -test.benchmem
goos: darwin
goarch: amd64
pkg: github.com/stackrox/rox/central/resourcecollection/datastore
cpu: Intel(R) Core(TM) i5-1038NG7 CPU @ 2.00GHz
BenchmarkCollections
BenchmarkCollections/DryRunAddCollection
BenchmarkCollections/DryRunAddCollection-8         	     313	   3866425 ns/op	 2569101 B/op	     413 allocs/op
BenchmarkCollections/DryRunUpdateCollection
BenchmarkCollections/DryRunUpdateCollection-8      	     274	   4439996 ns/op	 2573570 B/op	     478 allocs/op
BenchmarkCollections/UpdateCollection
BenchmarkCollections/UpdateCollection-8            	     178	   7334850 ns/op	 2907069 B/op	    3981 allocs/op
BenchmarkCollections/graphInit
BenchmarkCollections/graphInit-8                   	      12	 100315980 ns/op	11042746 B/op	  124287 allocs/op
BenchmarkCollections/AddCollection
BenchmarkCollections/AddCollection-8               	     130	   9770113 ns/op	 3311003 B/op	    7278 allocs/op
PASS

Process finished with the exit code 0
```