### PR TITLE
Bugfixes for collection autocomplete

### DIFF
--- a/ui/apps/platform/src/Containers/Collections/RuleSelector/AutoCompleteSelect.tsx
+++ b/ui/apps/platform/src/Containers/Collections/RuleSelector/AutoCompleteSelect.tsx
@@ -38,6 +38,8 @@ export function AutoCompleteSelect({
 }: AutoCompleteSelectProps) {
     const { isOpen, onToggle, closeSelect } = useSelectToggle();
     const [typeahead, setTypeahead] = useState(selectedOption);
+    // When isTyping is true, autocomplete results will not be displayed. This prevents
+    // a clunky UX where the dropdown results and the user text get out of sync.
     const [isTyping, setIsTyping] = useState(false);
 
     const autocompleteCallback = useCallback(() => {

--- a/ui/apps/platform/src/Containers/Collections/RuleSelector/AutoCompleteSelect.tsx
+++ b/ui/apps/platform/src/Containers/Collections/RuleSelector/AutoCompleteSelect.tsx
@@ -38,14 +38,20 @@ export function AutoCompleteSelect({
 }: AutoCompleteSelectProps) {
     const { isOpen, onToggle, closeSelect } = useSelectToggle();
     const [typeahead, setTypeahead] = useState(selectedOption);
+    const [isTyping, setIsTyping] = useState(false);
 
     const autocompleteCallback = useCallback(() => {
         const shouldMakeRequest = isOpen && autocompleteProvider;
         if (shouldMakeRequest) {
-            return autocompleteProvider(typeahead);
+            const { request, cancel } = autocompleteProvider(typeahead);
+            request.finally(() => setIsTyping(false));
+            return { request, cancel };
         }
         return {
-            request: Promise.resolve([]),
+            request: new Promise<string[]>((resolve) => {
+                setIsTyping(false);
+                resolve([]);
+            }),
             cancel: () => {},
         };
     }, [isOpen, autocompleteProvider, typeahead]);
@@ -73,14 +79,18 @@ export function AutoCompleteSelect({
                 variant="typeahead"
                 isCreatable
                 isOpen={isOpen}
-                onFilter={() => getOptions(OptionComponent, data)}
+                onFilter={() => getOptions(OptionComponent, isTyping ? [] : data)}
                 onToggle={onToggle}
-                onTypeaheadInputChanged={updateTypeahead}
+                onTypeaheadInputChanged={(val: string) => {
+                    setIsTyping(true);
+                    updateTypeahead(val);
+                }}
+                onBlur={() => updateTypeahead(selectedOption)}
                 selections={selectedOption}
                 onSelect={onSelect}
                 isDisabled={isDisabled}
             >
-                {getOptions(OptionComponent, data)}
+                {getOptions(OptionComponent, isTyping ? [] : data)}
             </Select>
         </>
     );

--- a/ui/apps/platform/src/Containers/Collections/RuleSelector/RuleSelector.tsx
+++ b/ui/apps/platform/src/Containers/Collections/RuleSelector/RuleSelector.tsx
@@ -46,10 +46,14 @@ function RuleSelector({
     // because PatternFly will pass a `ref` to it
     const OptionComponent = forwardRef(
         (
-            props: { className: string; children: ReactNode },
+            props: {
+                className: string;
+                children: ReactNode;
+                onClick: (...args: unknown[]) => void;
+            },
             ref: ForwardedRef<HTMLButtonElement | null>
         ) => (
-            <button className={props.className} type="button" ref={ref}>
+            <button className={props.className} onClick={props.onClick} type="button" ref={ref}>
                 <ResourceIcon kind={entityType} />
                 {props.children}
             </button>


### PR DESCRIPTION
## Description

This fixes two issues with the autocomplete functionality:

1. The 'onClick' behavior was broken during the last round of refactoring, making it so selecting a value does not correctly apply it.

2. The autocomplete list will now be cleared while the user it typing.  Previously this led to clunky behavior where the list would remain populated with data that did not match the user's text until 800ms after typing was finished. (Due to the debounce). Now, when the user begins typing the dropdown options will be cleared until typing has finished.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Select an autocomplete input element and allow it to populate the first `#` default entries. Begin typing text into the input element and verify that the dropdown is cleared of items. When typing stops, verify that the autocomplete options are updated to match the entered text, if available.

Enter an autocomplete query (e.g. mastodon) and select the option from the list. The dropdown will close and the selected value will be entered into the input element.



