### PR TITLE
ROX-13326: Access control UUID support in the UI

### DIFF
--- a/ui/apps/platform/src/Containers/AccessControl/AccessScopes/AccessScopeForm.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessScopes/AccessScopeForm.tsx
@@ -85,9 +85,12 @@ function AccessScopeForm({ hasAction, alertSubmit, formik }: AccessScopeFormProp
      * before its first requirement or value has been added.
      */
     const isValidRules =
-        values.id !== defaultAccessScopeIds.Unrestricted && getIsValidRules(values.rules);
+        values.id !== defaultAccessScopeIds.Unrestricted &&
+        values.id !== defaultAccessScopeIds.UnrestrictedPostgres &&
+        getIsValidRules(values.rules);
     useEffect(() => {
-        if (values.id === defaultAccessScopeIds.Unrestricted) {
+        if (values.id === defaultAccessScopeIds.Unrestricted ||
+            values.id === defaultAccessScopeIds.UnrestrictedPostgres) {
             return;
         }
         setCounterComputing((counterPrev) => counterPrev + 1);
@@ -195,7 +198,8 @@ function AccessScopeForm({ hasAction, alertSubmit, formik }: AccessScopeFormProp
                 />
             </FormGroup>
             {alertCompute}
-            {values.id !== defaultAccessScopeIds.Unrestricted && (
+            {values.id !== defaultAccessScopeIds.Unrestricted &&
+                values.id !== defaultAccessScopeIds.UnrestrictedPostgres &&(
                 <Flex
                     direction={{ default: 'row' }}
                     spaceItems={{ default: 'spaceItemsSm', xl: 'spaceItemsLg' }}

--- a/ui/apps/platform/src/Containers/AccessControl/AccessScopes/AccessScopeForm.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessScopes/AccessScopeForm.tsx
@@ -19,6 +19,7 @@ import {
     LabelSelectorsKey,
     computeEffectiveAccessScopeClusters,
     defaultAccessScopeIds,
+    getIsUnrestrictedAccessScopeId
 } from 'services/AccessScopesService';
 
 import {
@@ -85,12 +86,9 @@ function AccessScopeForm({ hasAction, alertSubmit, formik }: AccessScopeFormProp
      * before its first requirement or value has been added.
      */
     const isValidRules =
-        values.id !== defaultAccessScopeIds.Unrestricted &&
-        values.id !== defaultAccessScopeIds.UnrestrictedPostgres &&
-        getIsValidRules(values.rules);
+        !getIsUnrestrictedAccessScopeId(values.id) && getIsValidRules(values.rules);
     useEffect(() => {
-        if (values.id === defaultAccessScopeIds.Unrestricted ||
-            values.id === defaultAccessScopeIds.UnrestrictedPostgres) {
+        if (getIsUnrestrictedAccessScopeId(values.id)) {
             return;
         }
         setCounterComputing((counterPrev) => counterPrev + 1);
@@ -198,8 +196,7 @@ function AccessScopeForm({ hasAction, alertSubmit, formik }: AccessScopeFormProp
                 />
             </FormGroup>
             {alertCompute}
-            {values.id !== defaultAccessScopeIds.Unrestricted &&
-                values.id !== defaultAccessScopeIds.UnrestrictedPostgres &&(
+            { !getIsUnrestrictedAccessScopeId(values.id) && (
                 <Flex
                     direction={{ default: 'row' }}
                     spaceItems={{ default: 'spaceItemsSm', xl: 'spaceItemsLg' }}

--- a/ui/apps/platform/src/Containers/AccessControl/AccessScopes/AccessScopeFormWrapper.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessScopes/AccessScopeFormWrapper.tsx
@@ -82,7 +82,9 @@ function AccessScopeFormWrapper({
      * before its first requirement or value has been added.
      */
     const isValidRules =
-        values.id !== defaultAccessScopeIds.Unrestricted && getIsValidRules(values.rules);
+        values.id !== defaultAccessScopeIds.Unrestricted &&
+        values.id !== defaultAccessScopeIds.UnrestrictedPostgres &&
+        getIsValidRules(values.rules);
 
     function onClickSubmit() {
         // TODO submit through Formik, especially to update its initialValue.

--- a/ui/apps/platform/src/Containers/AccessControl/AccessScopes/AccessScopeFormWrapper.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessScopes/AccessScopeFormWrapper.tsx
@@ -13,7 +13,11 @@ import {
     ToolbarItem,
 } from '@patternfly/react-core';
 
-import { AccessScope, defaultAccessScopeIds } from 'services/AccessScopesService';
+import {
+    AccessScope,
+    defaultAccessScopeIds,
+    getIsUnrestrictedAccessScopeId
+} from 'services/AccessScopesService';
 
 import { AccessControlQueryAction } from '../accessControlPaths';
 
@@ -82,9 +86,7 @@ function AccessScopeFormWrapper({
      * before its first requirement or value has been added.
      */
     const isValidRules =
-        values.id !== defaultAccessScopeIds.Unrestricted &&
-        values.id !== defaultAccessScopeIds.UnrestrictedPostgres &&
-        getIsValidRules(values.rules);
+        !getIsUnrestrictedAccessScopeId(values.id) && getIsValidRules(values.rules);
 
     function onClickSubmit() {
         // TODO submit through Formik, especially to update its initialValue.

--- a/ui/apps/platform/src/services/AccessScopesService.ts
+++ b/ui/apps/platform/src/services/AccessScopesService.ts
@@ -14,6 +14,10 @@ export function getIsDefaultAccessScopeId(id: string): boolean {
     return Object.values(defaultAccessScopeIds).includes(id);
 }
 
+export function getIsUnrestrictedAccessScopeId(id: string): boolean {
+    return id === defaultAccessScopeIds.Unrestricted || id === defaultAccessScopeIds.UnrestrictedPostgres
+}
+
 export type SimpleAccessScopeNamespace = {
     clusterName: string;
     namespaceName: string;

--- a/ui/apps/platform/src/services/AccessScopesService.ts
+++ b/ui/apps/platform/src/services/AccessScopesService.ts
@@ -3,6 +3,10 @@ import { Empty } from './types';
 
 const accessScopessUrl = '/v1/simpleaccessscopes';
 
+/*
+ * TODO: ROX-13585 - remove the pre-postgres constants once the migration to postgres
+ * is completed and the support for BoltDB, RocksDB and Bleve is dropped.
+ */
 export const defaultAccessScopeIds = {
     Unrestricted: 'io.stackrox.authz.accessscope.unrestricted',
     UnrestrictedPostgres: 'ffffffff-ffff-fff4-f5ff-ffffffffffff',

--- a/ui/apps/platform/src/services/AccessScopesService.ts
+++ b/ui/apps/platform/src/services/AccessScopesService.ts
@@ -5,7 +5,9 @@ const accessScopessUrl = '/v1/simpleaccessscopes';
 
 export const defaultAccessScopeIds = {
     Unrestricted: 'io.stackrox.authz.accessscope.unrestricted',
+    UnrestrictedPostgres: 'ffffffff-ffff-fff4-f5ff-ffffffffffff',
     DenyAll: 'io.stackrox.authz.accessscope.denyall',
+    DenyAllPostgres: 'ffffffff-ffff-fff4-f5ff-fffffffffffe'
 };
 
 export function getIsDefaultAccessScopeId(id: string): boolean {


### PR DESCRIPTION
## Description

The goal here (as started with PRs https://github.com/stackrox/stackrox/pull/3802 and https://github.com/stackrox/stackrox/pull/3725) is to rely on postgres built-in UUID types, which are more compact and can bring performance improvements in data lookups.

Manual testing highlighted a bug when opening the Unrestricted access scope page.
The goal here is to support the hardcoded UUID format too.

PR stack:
https://github.com/stackrox/stackrox/pull/3802 (server support code)
+- https://github.com/stackrox/stackrox/pull/3725 (data migration)
... +- https://github.com/stackrox/stackrox/pull/3818 (UI code)

## Checklist
- [ ] Investigated and inspected CI test results
~~- [ ] Unit test and regression tests added~~
~~- [ ] Evaluated and added CHANGELOG entry if required~~
~~- [ ] Determined and documented upgrade steps~~
~~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

Manual testing:
- start central in postgres mode on a version containing the code of the two pull requests listed above and the one at hand here.
- navigate to access control
- open the access scope tab
- open the `Unrestricted` access scope

The `Unrestricted` access scope has a special internal representation, which requires dedicated handling. The point of the change here is to ensure the dedicated handling also applies to the dedicated UUID identifier.