### PR TITLE
ROX-13172: Add toggle to alert on baseline violations

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentBaselines.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentBaselines.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { Flex, FlexItem, Stack, StackItem, Switch, Tooltip } from '@patternfly/react-core';
+import { HelpIcon } from '@patternfly/react-icons';
+
+function DeploymentBaselines() {
+    const [isAlertingOnViolations, setIsAlertingOnViolations] = React.useState<boolean>(false);
+
+    const handleAlertingOnViolations = (checked: boolean) => {
+        setIsAlertingOnViolations(checked);
+    };
+
+    return (
+        <div className="pf-u-h-100 pf-u-p-md">
+            <Stack hasGutter>
+                <StackItem>
+                    <Flex alignItems={{ default: 'alignItemsCenter' }}>
+                        <FlexItem>
+                            <Switch
+                                id="simple-switch"
+                                label="Alert on baseline violation"
+                                isChecked={isAlertingOnViolations}
+                                onChange={handleAlertingOnViolations}
+                            />
+                        </FlexItem>
+                        <FlexItem>
+                            <Tooltip
+                                content={
+                                    <div>
+                                        Trigger violations for network policies not in the baseline
+                                    </div>
+                                }
+                            >
+                                <HelpIcon className="pf-u-color-200" />
+                            </Tooltip>
+                        </FlexItem>
+                    </Flex>
+                </StackItem>
+            </Stack>
+        </div>
+    );
+}
+
+export default DeploymentBaselines;

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentSideBar.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentSideBar.tsx
@@ -30,6 +30,7 @@ import {
 import DeploymentDetails from './DeploymentDetails';
 import DeploymentNetworkPolicies from './DeploymentNetworkPolicies';
 import DeploymentFlows from './DeploymentFlows';
+import DeploymentBaselines from './DeploymentBaselines';
 
 type DeploymentSideBarProps = {
     deploymentId: string;
@@ -130,7 +131,7 @@ function DeploymentSideBar({ deploymentId, nodes, edges }: DeploymentSideBarProp
                     id="Baselines"
                     hidden={activeKeyTab !== 'Baselines'}
                 >
-                    <div className="pf-u-h-100 pf-u-p-md">TODO: Add Baselines</div>
+                    <DeploymentBaselines />
                 </TabContent>
                 <TabContent
                     eventKey="Network policies"


### PR DESCRIPTION
## Description

This PR adds the toggle that alerts on baseline violations. This is an iterative addition. The rest of the subtasks can be found here: https://issues.redhat.com/browse/ROX-12905

<img width="452" alt="Screenshot 2022-11-15 at 11 44 15 AM" src="https://user-images.githubusercontent.com/4805485/202011624-65b27fe4-ac5a-45e2-b6de-6c19c279703c.png">
<img width="453" alt="Screenshot 2022-11-15 at 11 44 02 AM" src="https://user-images.githubusercontent.com/4805485/202011613-30812967-0f29-4df0-b269-563bafb309f3.png">


## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

