### PR TITLE
Add more descriptive validation and errors to collection form

### DIFF
--- a/ui/apps/platform/src/Components/PatternFly/BacklogListSelector.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/BacklogListSelector.tsx
@@ -108,6 +108,7 @@ export type BacklogListSelectorProps<Item> = {
     cells: {
         name: string;
         render: (item: Item) => ReactNode;
+        width?: BaseCellProps['width'];
     }[];
     selectedLabel?: string;
     deselectedLabel?: string;

--- a/ui/apps/platform/src/Containers/Collections/CollectionAttacher.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionAttacher.tsx
@@ -1,7 +1,9 @@
-import React, { ReactNode, useMemo, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { Alert, Button, debounce, Flex, SearchInput } from '@patternfly/react-core';
 
-import BacklogListSelector from 'Components/PatternFly/BacklogListSelector';
+import BacklogListSelector, {
+    BacklogListSelectorProps,
+} from 'Components/PatternFly/BacklogListSelector';
 import { CollectionResponse } from 'services/CollectionsService';
 import useEmbeddedCollections from './hooks/useEmbeddedCollections';
 
@@ -11,7 +13,7 @@ export type CollectionAttacherProps = {
     excludedCollectionId: string | null;
     initialEmbeddedCollections: CollectionResponse[];
     onSelectionChange: (collections: CollectionResponse[]) => void;
-    collectionTableCells: { name: string; render: (collection: CollectionResponse) => ReactNode }[];
+    collectionTableCells: BacklogListSelectorProps<CollectionResponse>['cells'];
 };
 
 function compareNameLowercase(search: string): (item: { name: string }) => boolean {

--- a/ui/apps/platform/src/Containers/Collections/CollectionFormDrawer.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionFormDrawer.tsx
@@ -15,7 +15,6 @@ import {
 import { CollectionResponse } from 'services/CollectionsService';
 import { CollectionPageAction } from './collections.utils';
 import CollectionResults from './CollectionResults';
-import { Collection } from './types';
 import { parseCollection } from './converter';
 import CollectionForm, { CollectionFormProps } from './CollectionForm';
 
@@ -33,8 +32,10 @@ export type CollectionFormDrawerProps = {
     isDrawerOpen: boolean;
     toggleDrawer: (isOpen: boolean) => void;
     headerContent?: ReactElement;
-    onSubmit: (collection: Collection) => Promise<void>;
-    collectionTableCells: CollectionFormProps['collectionTableCells'];
+    onSubmit: CollectionFormProps['onSubmit'];
+    saveError?: CollectionFormProps['saveError'];
+    clearSaveError?: CollectionFormProps['clearSaveError'];
+    getCollectionTableCells: CollectionFormProps['getCollectionTableCells'];
 };
 
 function CollectionFormDrawer({
@@ -46,7 +47,9 @@ function CollectionFormDrawer({
     isDrawerOpen,
     toggleDrawer,
     onSubmit,
-    collectionTableCells,
+    saveError,
+    clearSaveError,
+    getCollectionTableCells,
 }: CollectionFormDrawerProps) {
     const initialData = parseCollection(collectionData.collection);
     const initialEmbeddedCollections = collectionData.embeddedCollections;
@@ -94,7 +97,9 @@ function CollectionFormDrawer({
                                 initialData={initialData}
                                 initialEmbeddedCollections={initialEmbeddedCollections}
                                 onSubmit={onSubmit}
-                                collectionTableCells={collectionTableCells}
+                                saveError={saveError}
+                                clearSaveError={clearSaveError}
+                                getCollectionTableCells={getCollectionTableCells}
                             />
                         )}
                     </DrawerContentBody>

--- a/ui/apps/platform/src/Containers/Collections/CollectionFormModal.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionFormModal.tsx
@@ -7,35 +7,41 @@ import useSelectToggle from 'hooks/patternfly/useSelectToggle';
 import { collectionsBasePath } from 'routePaths';
 import { CollectionResponse } from 'services/CollectionsService';
 import useCollection from './hooks/useCollection';
-import CollectionFormDrawer from './CollectionFormDrawer';
+import CollectionFormDrawer, { CollectionFormDrawerProps } from './CollectionFormDrawer';
 
 export type CollectionsFormModalProps = {
     hasWriteAccessForCollections: boolean;
     collectionId: string;
     onClose: () => void;
 };
-const collectionTableCells = [
-    {
-        name: 'Name',
-        render: ({ id, name }: CollectionResponse) => (
-            <Button
-                variant="link"
-                component="a"
-                isInline
-                href={`${collectionsBasePath}/${id}?action=edit`}
-                target="_blank"
-                rel="noopener noreferrer"
-                icon={<ExternalLinkAltIcon />}
-            >
-                {name}
-            </Button>
-        ),
-    },
-    {
-        name: 'Description',
-        render: ({ description }) => <Truncate content={description} />,
-    },
-];
+
+function getCollectionTableCells(): ReturnType<
+    CollectionFormDrawerProps['getCollectionTableCells']
+> {
+    return [
+        {
+            name: 'Name',
+            render: ({ id, name }: CollectionResponse) => (
+                <Button
+                    variant="link"
+                    component="a"
+                    isInline
+                    href={`${collectionsBasePath}/${id}?action=edit`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    icon={<ExternalLinkAltIcon />}
+                >
+                    {name}
+                </Button>
+            ),
+            width: 25,
+        },
+        {
+            name: 'Description',
+            render: ({ description }) => <Truncate content={description} />,
+        },
+    ];
+}
 
 function CollectionsFormModal({
     hasWriteAccessForCollections,
@@ -116,7 +122,7 @@ function CollectionsFormModal({
                     toggleDrawer={toggleDrawer}
                     // Since the form cannot be submitted, stub this out with an empty promise
                     onSubmit={() => Promise.resolve()}
-                    collectionTableCells={collectionTableCells}
+                    getCollectionTableCells={getCollectionTableCells}
                 />
             </Modal>
         );

--- a/ui/apps/platform/src/Containers/Collections/errorUtils.ts
+++ b/ui/apps/platform/src/Containers/Collections/errorUtils.ts
@@ -49,7 +49,7 @@ export function parseSaveError(err: Error): CollectionSaveError {
         // Error for collection update
         /name already in use/.test(rawMessage)
     ) {
-        return { type: 'DuplicateName', message: 'Collection name values must be unique' };
+        return { type: 'DuplicateName', message: 'Name must be unique' };
     }
 
     if (/failed to compile rule value regex/.test(rawMessage)) {

--- a/ui/apps/platform/src/Containers/Collections/errorUtils.ts
+++ b/ui/apps/platform/src/Containers/Collections/errorUtils.ts
@@ -1,0 +1,76 @@
+import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
+
+type CollectionSaveErrorType =
+    | 'CollectionLoop'
+    | 'DuplicateName'
+    | 'InvalidRule'
+    | 'EmptyCollection'
+    | 'UnknownError';
+
+export type CollectionSaveError =
+    | {
+          type: 'CollectionLoop';
+          message: string;
+          details?: string;
+          loopId: string | undefined;
+      }
+    | {
+          type: Exclude<CollectionSaveErrorType, 'CollectionLoop'>;
+          message: string;
+          details?: string;
+      };
+
+/**
+ * Given an error, attempt to categorize and provide more information to the user. These are
+ * errors that cannot be detected by general `yup` validation and often can only be detected
+ * by the server.
+ *
+ * @param err An instance of an Error
+ * @return A categorized error specific to collections
+ */
+export function parseSaveError(err: Error): CollectionSaveError {
+    const rawMessage = getAxiosErrorMessage(err);
+
+    if (/create a loop/.test(rawMessage)) {
+        const errorRegex = /^edge between '[0-9a-fA-F-]*' and '(?<loopId>[0-9a-fA-F-]*)'/;
+        const matches = errorRegex.exec(rawMessage);
+        const loopId = matches?.groups?.loopId;
+        return {
+            type: 'CollectionLoop',
+            message: 'An attached collection has created a loop, which is not supported',
+            details: 'Detach the invalid collection and try saving again',
+            loopId,
+        };
+    }
+
+    if (
+        // Error for collection save
+        /collections must have non-empty, unique `name` values/.test(rawMessage) ||
+        // Error for collection update
+        /name already in use/.test(rawMessage)
+    ) {
+        return { type: 'DuplicateName', message: 'Collection name values must be unique' };
+    }
+
+    if (/failed to compile rule value regex/.test(rawMessage)) {
+        return {
+            type: 'InvalidRule',
+            message:
+                'The server was unable to process a regular expression used in a collection rule',
+            details: rawMessage,
+        };
+    }
+
+    if (/Cannot save an empty collection/.test(rawMessage)) {
+        return {
+            type: 'EmptyCollection',
+            message: rawMessage,
+        };
+    }
+
+    return {
+        type: 'UnknownError',
+        message: 'An unexpected error has occurred saving the collection',
+        details: rawMessage,
+    };
+}

--- a/ui/apps/platform/src/css/trumps.css
+++ b/ui/apps/platform/src/css/trumps.css
@@ -85,6 +85,14 @@ button.pf-c-toggle-group__button:disabled {
     border-width: inherit !important;
 }
 
+/* Un-override the above override when the <Select> component is in an invalid state */
+.pf-m-invalid .pf-c-select__toggle::before {
+    /* Why are these pseudo elements not able to access the vars? */
+    /* border-bottom-color: var(--pf-c-select__toggle--before--BorderBottomColor); */
+    border-bottom-color: rgb(201, 25, 11) !important;
+    border-bottom-width: 2px !important;
+}
+
 /* overriding our tailwind config default of display: block for images, because it breaks the patternfly layout */
 .pf-c-button__icon.pf-m-start svg,
 .pf-c-button__icon.pf-m-end svg,


### PR DESCRIPTION
## Description

This adds descriptive inline error messages to the UI when there are validation issues with the Collection form. This primarily handles error situations that cannot easily be done through `yup` validation, such as server response errors and errors that results in invalid _combinations_ of fields.

When an error occurs on submit, an inline alert will be placed at the top of the page and will scroll the user to the top. More descriptive errors will be placed inline as close as possible to the problem site, either inline as a PatternFly `helperTextInvalid` or as an inline alert in the relevant section.

Note: currently most of these errors occur server side and are triggered when the user attempts to save a collection. Once the dry run endpoint is implemented and used for collection results, these errors should be occurring each time the form value changes to an invalid configuration. Once this happens, we might want to distinguish between "save" errors and "dry run" errors, and not automatically scroll the page when the latter occurs since the alert should appear inline directly where the user currently is.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Manual testing of known error cases:

The name field is left empty:
![image](https://user-images.githubusercontent.com/1292638/202784904-ecdd7996-06f5-4fc0-b896-acd3f4f8562a.png)

A rule dropdown is left empty (these do not have inline error messages as each field is not currently wrapped in its own `FormGroup`. As a follow up I'd like to see if it makes sense semantically to wrap each in a field group if the group is not going to contain a label.)
![image](https://user-images.githubusercontent.com/1292638/202785115-3d0be6d1-18a0-44fd-953f-425eaee9cc5e.png)

Saving a collection that has the same name as another collection in the system. After this error occurs, changing the value of the name input should clear the error message.
![image](https://user-images.githubusercontent.com/1292638/202785384-9cc55204-02b9-4f0a-aee8-7fe5104e3d20.png)
![image](https://user-images.githubusercontent.com/1292638/202786903-909974e0-4a7c-4449-9992-511f57af952c.png)


A regex value is used that does not validate on the server. Currently the server response does not give us any indication of _which_ value is incorrect, so the error is placed at the top of the section. This is one case where it felt valuable to show the actual server error message to the user.
![image](https://user-images.githubusercontent.com/1292638/202785646-d128ac80-a95a-4fe8-a2d1-7798870cf4d3.png)

A collection is saved that contains an attached collection that forms a loop.
![image](https://user-images.githubusercontent.com/1292638/202785855-cdf304bd-7364-4de8-b9c6-6f1909289b79.png)
<img width="1675" alt="image" src="https://user-images.githubusercontent.com/1292638/202785919-fbcac919-d2d2-480e-9edc-7d31c2909df7.png">
Detaching the offending collection will clear this error:
<img width="1675" alt="image" src="https://user-images.githubusercontent.com/1292638/202786001-e2066b31-d5e3-4b3d-bf69-fe2cd4d91250.png">

An attempt is made to save an empty collection:
![image](https://user-images.githubusercontent.com/1292638/202786417-6c09732c-cac6-41e6-a80f-4c3ad8db48a9.png)
![image](https://user-images.githubusercontent.com/1292638/202786433-b1c838c7-841b-4f19-acf1-028e27f2495f.png)





