### PR TITLE
Fix collector volumeMounts 

### DIFF
--- a/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml
@@ -65,8 +65,7 @@ spec:
           readOnlyRootFilesystem: true
         volumeMounts:
         - mountPath: /host/var/run/docker.sock
-          name: var-run
-          subPath: var/run/docker.sock
+          name: var-run-docker-sock-ro
           readOnly: true
         - mountPath: /host/proc
           name: proc-ro
@@ -77,8 +76,7 @@ spec:
           name: etc-ro
           readOnly: true
         - mountPath: /host/usr/lib
-          name: usr-ro
-          subPath: usr/lib
+          name: usr-lib-ro
           readOnly: true
         - mountPath: /host/sys
           name: sys-ro
@@ -189,6 +187,9 @@ spec:
           path: /usr
         name: usr-ro
       - hostPath:
+          path: /usr/lib
+        name: usr-lib-ro
+      - hostPath:
           path: /lib
         name: lib-ro
       - hostPath:
@@ -206,6 +207,9 @@ spec:
       - hostPath:
           path: /var/run
         name: var-run
+      - hostPath:
+          path: /var/run/docker.sock
+        name: var-run-docker-sock-ro
       - name: certs
         secret:
           secretName: collector-tls


### PR DESCRIPTION
## Description

Revert incorrect usage of the `subPath` parameter of volume mount added in https://github.com/stackrox/stackrox/pull/2479. 

`subPath` should not be used, and instead, we should directly create a `hostPath` volume for the needed `volumeMount`.

Without this change, collector cannot determine which kernel version to use from `/usr/lib/os-release`.


## Checklist
- [ ] Investigated and inspected CI test results
~- [ ] Unit test and regression tests added~
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

CI is sufficient
