### PR TITLE
`gosec` G104: Add `ShouldErr(err)` that returns `err`

### DIFF
--- a/central/clustercveedge/datastore/datastore_impl.go
+++ b/central/clustercveedge/datastore/datastore_impl.go
@@ -103,7 +103,7 @@ func (ds *datastoreImpl) filterReadable(ctx context.Context, ids []string) ([]st
 
 func (ds *datastoreImpl) Upsert(ctx context.Context, parts ...converter.ClusterCVEParts) error {
 	if env.PostgresDatastoreEnabled.BooleanSetting() {
-		return utils.Should(errors.New("Unexpected cluster-cve edge upsert when running on Postgres"))
+		return utils.ShouldErr(errors.New("Unexpected cluster-cve edge upsert when running on Postgres"))
 	}
 	if len(parts) == 0 {
 		return nil
@@ -121,7 +121,7 @@ func (ds *datastoreImpl) Upsert(ctx context.Context, parts ...converter.ClusterC
 
 func (ds *datastoreImpl) Delete(ctx context.Context, ids ...string) error {
 	if env.PostgresDatastoreEnabled.BooleanSetting() {
-		return utils.Should(errors.New("Unexpected cluster-cve edge upsert when running on Postgres"))
+		return utils.ShouldErr(errors.New("Unexpected cluster-cve edge upsert when running on Postgres"))
 	}
 	if ok, err := clustersSAC.WriteAllowed(ctx); err != nil {
 		return err

--- a/central/clustercveedge/datastore/store/postgres/full_store.go
+++ b/central/clustercveedge/datastore/store/postgres/full_store.go
@@ -32,14 +32,14 @@ type fullStoreImpl struct {
 
 func (f *fullStoreImpl) Upsert(_ context.Context, _ ...converter.ClusterCVEParts) error {
 	if env.PostgresDatastoreEnabled.BooleanSetting() {
-		return utils.Should(errors.New("Unexpected cluster-cve edge upsert when running on Postgres"))
+		return utils.ShouldErr(errors.New("Unexpected cluster-cve edge upsert when running on Postgres"))
 	}
 	return nil
 }
 
 func (f *fullStoreImpl) Delete(_ context.Context, _ ...string) error {
 	if env.PostgresDatastoreEnabled.BooleanSetting() {
-		return utils.Should(errors.New("Unexpected cluster-cve edge upsert when running on Postgres"))
+		return utils.ShouldErr(errors.New("Unexpected cluster-cve edge upsert when running on Postgres"))
 	}
 	return nil
 }

--- a/central/globaldb/v2backuprestore/manager/restore_process.go
+++ b/central/globaldb/v2backuprestore/manager/restore_process.go
@@ -76,7 +76,7 @@ type restoreProcess struct {
 func newRestoreProcess(ctx context.Context, id string, header *v1.DBRestoreRequestHeader, handlerFuncs []common.RestoreFileHandlerFunc, data io.Reader) (*restoreProcess, error) {
 	mfFiles := header.GetManifest().GetFiles()
 	if len(mfFiles) != len(handlerFuncs) {
-		return nil, utils.Should(errors.Errorf("mismatch: %d handler functions provided for %d files in the manifest", len(handlerFuncs), len(mfFiles)))
+		return nil, utils.ShouldErr(errors.Errorf("mismatch: %d handler functions provided for %d files in the manifest", len(handlerFuncs), len(mfFiles)))
 	}
 
 	files := make([]*restoreFile, 0, len(mfFiles))
@@ -99,7 +99,7 @@ func newRestoreProcess(ctx context.Context, id string, header *v1.DBRestoreReque
 
 	resumableDataReader, initAttach, detachEvents := ioutils.NewResumableReader(crc32.NewIEEE())
 	if err := initAttach.Attach(data, 0, nil); err != nil {
-		return nil, utils.Should(errors.Wrap(err, "could not attach initial reader to resumable reader"))
+		return nil, utils.ShouldErr(errors.Wrap(err, "could not attach initial reader to resumable reader"))
 	}
 
 	p := &restoreProcess{

--- a/central/graphql/resolvers/cluster_vulnerabilities.go
+++ b/central/graphql/resolvers/cluster_vulnerabilities.go
@@ -315,7 +315,7 @@ func withOpenShiftTypeFiltering(q string) string {
 
 func (resolver *clusterCVEResolver) clusterVulnerabilityScopeContext(ctx context.Context) context.Context {
 	if ctx == nil {
-		err := utils.Should(errors.New("argument 'ctx' is nil"))
+		err := utils.ShouldErr(errors.New("argument 'ctx' is nil"))
 		if err != nil {
 			log.Error(err)
 		}

--- a/central/graphql/resolvers/clusters.go
+++ b/central/graphql/resolvers/clusters.go
@@ -690,7 +690,7 @@ func (resolver *clusterResolver) NodeVulnerabilityCounter(ctx context.Context, a
 
 func (resolver *clusterResolver) clusterScopeContext(ctx context.Context) context.Context {
 	if ctx == nil {
-		err := utils.Should(errors.New("argument 'ctx' is nil"))
+		err := utils.ShouldErr(errors.New("argument 'ctx' is nil"))
 		if err != nil {
 			log.Error(err)
 		}

--- a/central/graphql/resolvers/deployments.go
+++ b/central/graphql/resolvers/deployments.go
@@ -604,7 +604,7 @@ func (resolver *deploymentResolver) ImageVulnerabilityCounter(ctx context.Contex
 
 func (resolver *deploymentResolver) deploymentScopeContext(ctx context.Context) context.Context {
 	if ctx == nil {
-		err := utils.Should(errors.New("argument 'ctx' is nil"))
+		err := utils.ShouldErr(errors.New("argument 'ctx' is nil"))
 		if err != nil {
 			log.Error(err)
 		}

--- a/central/graphql/resolvers/image_components.go
+++ b/central/graphql/resolvers/image_components.go
@@ -187,7 +187,7 @@ Utility Functions
 
 func (resolver *imageComponentResolver) imageComponentScopeContext(ctx context.Context) context.Context {
 	if ctx == nil {
-		err := utils.Should(errors.New("argument 'ctx' is nil"))
+		err := utils.ShouldErr(errors.New("argument 'ctx' is nil"))
 		if err != nil {
 			log.Error(err)
 		}

--- a/central/graphql/resolvers/image_vulnerabilities.go
+++ b/central/graphql/resolvers/image_vulnerabilities.go
@@ -269,7 +269,7 @@ func imageCveToVulnerabilityWithSeverity(in []*storage.ImageCVE) []Vulnerability
 
 func (resolver *imageCVEResolver) imageVulnerabilityScopeContext(ctx context.Context) context.Context {
 	if ctx == nil {
-		err := utils.Should(errors.New("argument 'ctx' is nil"))
+		err := utils.ShouldErr(errors.New("argument 'ctx' is nil"))
 		if err != nil {
 			log.Error(err)
 		}

--- a/central/graphql/resolvers/images.go
+++ b/central/graphql/resolvers/images.go
@@ -358,7 +358,7 @@ func (resolver *imageResolver) ImageComponentCount(ctx context.Context, args Raw
 
 func (resolver *imageResolver) imageScopeContext(ctx context.Context) context.Context {
 	if ctx == nil {
-		err := utils.Should(errors.New("argument 'ctx' is nil"))
+		err := utils.ShouldErr(errors.New("argument 'ctx' is nil"))
 		if err != nil {
 			log.Error(err)
 		}

--- a/central/graphql/resolvers/namespaces.go
+++ b/central/graphql/resolvers/namespaces.go
@@ -523,7 +523,7 @@ func (resolver *namespaceResolver) ImageComponentCount(ctx context.Context, args
 
 func (resolver *namespaceResolver) namespaceScopeContext(ctx context.Context) context.Context {
 	if ctx == nil {
-		err := utils.Should(errors.New("argument 'ctx' is nil"))
+		err := utils.ShouldErr(errors.New("argument 'ctx' is nil"))
 		if err != nil {
 			log.Error(err)
 		}

--- a/central/graphql/resolvers/node_components.go
+++ b/central/graphql/resolvers/node_components.go
@@ -154,7 +154,7 @@ func queryWithNodeIDRegexFilter(q string) string {
 
 func (resolver *nodeComponentResolver) nodeComponentScopeContext(ctx context.Context) context.Context {
 	if ctx == nil {
-		err := utils.Should(errors.New("argument 'ctx' is nil"))
+		err := utils.ShouldErr(errors.New("argument 'ctx' is nil"))
 		if err != nil {
 			log.Error(err)
 		}

--- a/central/graphql/resolvers/node_vulnerabilities.go
+++ b/central/graphql/resolvers/node_vulnerabilities.go
@@ -249,7 +249,7 @@ func withNodeCveTypeFiltering(q string) string {
 
 func (resolver *nodeCVEResolver) nodeVulnerabilityScopeContext(ctx context.Context) context.Context {
 	if ctx == nil {
-		err := utils.Should(errors.New("argument 'ctx' is nil"))
+		err := utils.ShouldErr(errors.New("argument 'ctx' is nil"))
 		if err != nil {
 			log.Error(err)
 		}

--- a/central/graphql/resolvers/nodes.go
+++ b/central/graphql/resolvers/nodes.go
@@ -533,7 +533,7 @@ func (resolver *nodeResolver) UnusedVarSink(_ context.Context, _ RawQuery) *int3
 
 func (resolver *nodeResolver) nodeScopeContext(ctx context.Context) context.Context {
 	if ctx == nil {
-		err := utils.Should(errors.New("argument 'ctx' is nil"))
+		err := utils.ShouldErr(errors.New("argument 'ctx' is nil"))
 		if err != nil {
 			log.Error(err)
 		}

--- a/central/image/service/service_impl.go
+++ b/central/image/service/service_impl.go
@@ -339,7 +339,7 @@ func (s *serviceImpl) GetImageVulnerabilitiesInternal(ctx context.Context, reque
 func (s *serviceImpl) acquireScanSemaphore() error {
 	if err := s.internalScanSemaphore.Acquire(concurrency.AsContext(concurrency.Timeout(maxSemaphoreWaitTime)), 1); err != nil {
 		s, err := status.New(codes.Unavailable, err.Error()).WithDetails(&v1.ScanImageInternalResponseDetails_TooManyParallelScans{})
-		if pkgUtils.Should(err) == nil {
+		if pkgUtils.ShouldErr(err) == nil {
 			return s.Err()
 		}
 	}

--- a/central/integrationhealth/datastore/datastore_impl.go
+++ b/central/integrationhealth/datastore/datastore_impl.go
@@ -91,7 +91,7 @@ func writeAllowed(ctx context.Context, typ storage.IntegrationHealth_Type) (bool
 	if typ != storage.IntegrationHealth_IMAGE_INTEGRATION &&
 		typ != storage.IntegrationHealth_NOTIFIER &&
 		typ != storage.IntegrationHealth_BACKUP {
-		return false, utils.Should(errors.New("Unknown integration type"))
+		return false, utils.ShouldErr(errors.New("Unknown integration type"))
 	}
 	return integrationSAC.WriteAllowed(ctx)
 }
@@ -100,7 +100,7 @@ func readAllowed(ctx context.Context, typ storage.IntegrationHealth_Type) (bool,
 	if typ != storage.IntegrationHealth_IMAGE_INTEGRATION &&
 		typ != storage.IntegrationHealth_NOTIFIER &&
 		typ != storage.IntegrationHealth_BACKUP {
-		return false, utils.Should(errors.New("Unknown integration type"))
+		return false, utils.ShouldErr(errors.New("Unknown integration type"))
 	}
 	return integrationSAC.ReadAllowed(ctx)
 }

--- a/central/networkbaseline/manager/manager_impl.go
+++ b/central/networkbaseline/manager/manager_impl.go
@@ -476,7 +476,7 @@ func (m *manager) ProcessBaselineStatusUpdate(ctx context.Context, modifyRequest
 				}
 			}
 		default:
-			return utils.Should(errors.Errorf("unknown status: %v", peerAndStatus.GetStatus()))
+			return utils.ShouldErr(errors.Errorf("unknown status: %v", peerAndStatus.GetStatus()))
 		}
 	}
 	if err := m.persistNetworkBaselines(modifiedDeploymentIDs, nil); err != nil {

--- a/central/policy/service/service_impl.go
+++ b/central/policy/service/service_impl.go
@@ -733,7 +733,7 @@ func (s *serviceImpl) ExportPolicies(ctx context.Context, request *v1.ExportPoli
 	if len(missingIndices) > 0 {
 		statusMsg, err := status.New(codes.InvalidArgument, "Some policies could not be retrieved. Check the error details for a list of policies that could not be found").WithDetails(errDetails)
 		if err != nil {
-			return nil, utils.Should(errors.Errorf("unexpected error creating status proto: %v", err))
+			return nil, utils.ShouldErr(errors.Errorf("unexpected error creating status proto: %v", err))
 		}
 		return nil, statusMsg.Err()
 	}

--- a/central/risk/handlers/timeline/csv.go
+++ b/central/risk/handlers/timeline/csv.go
@@ -191,7 +191,7 @@ func CSVHandler() http.HandlerFunc {
 			var podName, podUID, deploymentID, podStartTime, podContainerCount string
 
 			if podID, err := podUtils.ParsePodID(containerResolver.PodID()); err != nil {
-				log.Errorf("Unable to generate full CSV row for container %s: %v", containerName, utils.Should(err))
+				log.Errorf("Unable to generate full CSV row for container %s: %v", containerName, utils.ShouldErr(err))
 			} else {
 				podName = podID.Name
 				podUID = string(podID.UID)

--- a/central/sac/authorizer/builtin_scoped_authorizer.go
+++ b/central/sac/authorizer/builtin_scoped_authorizer.go
@@ -170,7 +170,7 @@ func (a *resourceLevelScopeCheckerCore) Allowed() bool {
 	}
 	for _, role := range a.roles {
 		scope, err := a.cache.getEffectiveAccessScope(role.GetAccessScope())
-		if utils.Should(err) != nil {
+		if utils.ShouldErr(err) != nil {
 			return false
 		}
 		if scope.State == effectiveaccessscope.Included {
@@ -235,7 +235,7 @@ type clusterNamespaceLevelScopeCheckerCore struct {
 func (a *clusterNamespaceLevelScopeCheckerCore) Allowed() bool {
 	for _, role := range a.roles {
 		scope, err := a.cache.getEffectiveAccessScope(role.GetAccessScope())
-		if utils.Should(err) != nil {
+		if utils.ShouldErr(err) != nil {
 			return false
 		}
 		if effectiveAccessScopeAllows(scope, a.resource, a.clusterID, a.namespace) {

--- a/central/sensor/service/connection/upgradecontroller/upgrade_controller.go
+++ b/central/sensor/service/connection/upgradecontroller/upgrade_controller.go
@@ -54,7 +54,7 @@ func validateTimeouts(t timeoutProvider) error {
 
 func newWithTimeoutProvider(clusterID string, storage ClusterStorage, autoTriggerEnabledFlag *concurrency.Flag, timeouts timeoutProvider) (UpgradeController, error) {
 	if err := validateTimeouts(timeouts); err != nil {
-		return nil, utils.Should(err)
+		return nil, utils.ShouldErr(err)
 	}
 
 	u := &upgradeController{

--- a/central/sensor/telemetry/controller_impl.go
+++ b/central/sensor/telemetry/controller_impl.go
@@ -184,7 +184,7 @@ func (c *controller) PullClusterInfo(ctx context.Context, cb ClusterInfoCallback
 func (c *controller) ProcessTelemetryDataResponse(resp *central.PullTelemetryDataResponse) error {
 	requestID := resp.GetRequestId()
 	if resp.GetPayload() == nil {
-		return utils.Should(errors.Errorf("received a telemetry response with an empty payload for requested ID %s", requestID))
+		return utils.ShouldErr(errors.Errorf("received a telemetry response with an empty payload for requested ID %s", requestID))
 	}
 
 	var retC chan *central.TelemetryResponsePayload

--- a/central/sensorupgrade/controlservice/service_impl.go
+++ b/central/sensorupgrade/controlservice/service_impl.go
@@ -76,7 +76,7 @@ func (s *service) UpgradeCheckInFromSensor(ctx context.Context, req *central.Upg
 	if err := s.connectionManager.ProcessUpgradeCheckInFromSensor(ctx, clusterID, req); err != nil {
 		if errors.Is(err, upgradecontroller.ErrNoUpgradeInProgress) {
 			s, err := status.New(codes.Internal, err.Error()).WithDetails(&central.UpgradeCheckInResponseDetails_NoUpgradeInProgress{})
-			if utils.Should(err) == nil {
+			if utils.ShouldErr(err) == nil {
 				return nil, s.Err()
 			}
 		}

--- a/compliance/collection/main.go
+++ b/compliance/collection/main.go
@@ -82,7 +82,7 @@ func runRecv(ctx context.Context, client sensor.ComplianceService_CommunicateCli
 				}
 			}
 		default:
-			_ = utils.Should(errors.Errorf("Unhandled msg type: %T", t))
+			utils.Should(errors.Errorf("Unhandled msg type: %T", t))
 		}
 	}
 }

--- a/operator/pkg/common/extensions/secret_reconciliator.go
+++ b/operator/pkg/common/extensions/secret_reconciliator.go
@@ -87,7 +87,7 @@ func (r *SecretReconciliator) ReconcileSecret(ctx context.Context, name string, 
 	}
 
 	if generate == nil {
-		return pkgUtils.Should(errors.Errorf("secret %s should exist, but no generation logic has been specified", name))
+		return pkgUtils.ShouldErr(errors.Errorf("secret %s should exist, but no generation logic has been specified", name))
 	}
 
 	// Try to generate the secret, in order to fix it.

--- a/pkg/auth/authproviders/provider_impl.go
+++ b/pkg/auth/authproviders/provider_impl.go
@@ -160,7 +160,7 @@ func (p *providerImpl) GetOrCreateBackend(ctx context.Context) (Backend, error) 
 		backend = p.backend
 	})
 	if backend == nil {
-		return nil, utils.Should(errors.New("unexpected: backend was nil"))
+		return nil, utils.ShouldErr(errors.New("unexpected: backend was nil"))
 	}
 	return backend, nil
 }

--- a/pkg/auth/authproviders/userpki/backend_factory_impl.go
+++ b/pkg/auth/authproviders/userpki/backend_factory_impl.go
@@ -47,7 +47,7 @@ func (f *factory) ProcessHTTPRequest(w http.ResponseWriter, r *http.Request) (pr
 
 	restURL := strings.TrimPrefix(r.URL.Path, f.callbackURLPath)
 	if len(restURL) == len(r.URL.Path) {
-		return "", "", utils.Should(httputil.Errorf(http.StatusNotFound, "invalid path %q, expected sub-path of %q", r.URL.Path, f.callbackURLPath))
+		return "", "", utils.ShouldErr(httputil.Errorf(http.StatusNotFound, "invalid path %q, expected sub-path of %q", r.URL.Path, f.callbackURLPath))
 	}
 
 	if restURL == "" {

--- a/pkg/auth/authproviders/userpki/backend_impl.go
+++ b/pkg/auth/authproviders/userpki/backend_impl.go
@@ -92,7 +92,7 @@ func (p *backendImpl) RefreshURL() string {
 func (p *backendImpl) ProcessHTTPRequest(w http.ResponseWriter, r *http.Request) (*authproviders.AuthResponse, error) {
 	restPath := strings.TrimPrefix(r.URL.Path, p.pathPrefix)
 	if len(restPath) == len(r.URL.Path) {
-		return nil, utils.Should(httputil.Errorf(http.StatusNotFound,
+		return nil, utils.ShouldErr(httputil.Errorf(http.StatusNotFound,
 			"invalid URL %q, expected sub-path of %q", r.URL.Path, p.pathPrefix))
 	}
 

--- a/pkg/booleanpolicy/augmentedobjs/construct.go
+++ b/pkg/booleanpolicy/augmentedobjs/construct.go
@@ -45,7 +45,7 @@ func ConstructDeploymentWithProcess(deployment *storage.Deployment, images []*st
 		pathutil.FieldStep("Containers"), pathutil.IndexStep(matchingContainerIdx), pathutil.FieldStep(processAugmentKey),
 	)
 	if err != nil {
-		return nil, utils.Should(err)
+		return nil, utils.ShouldErr(err)
 	}
 	return obj, nil
 }
@@ -61,7 +61,7 @@ func ConstructKubeResourceWithEvent(kubeResource interface{}, event *storage.Kub
 	}
 
 	if err := obj.AddPlainObjAt(event, pathutil.FieldStep(kubeEventAugKey)); err != nil {
-		return nil, utils.Should(err)
+		return nil, utils.ShouldErr(err)
 	}
 	return obj, nil
 }
@@ -146,7 +146,7 @@ func ConstructDeployment(deployment *storage.Deployment, images []*storage.Image
 
 	appliedPolicies := pathutil.NewAugmentedObj(applied)
 	if err := obj.AddAugmentedObjAt(appliedPolicies, pathutil.FieldStep(networkPoliciesAppliedKey)); err != nil {
-		return nil, utils.Should(err)
+		return nil, utils.ShouldErr(err)
 	}
 
 	for i, image := range images {
@@ -159,7 +159,7 @@ func ConstructDeployment(deployment *storage.Deployment, images []*storage.Image
 			pathutil.FieldStep("Containers"), pathutil.IndexStep(i), pathutil.FieldStep(imageAugmentKey),
 		)
 		if err != nil {
-			return nil, utils.Should(err)
+			return nil, utils.ShouldErr(err)
 		}
 	}
 
@@ -173,7 +173,7 @@ func ConstructDeployment(deployment *storage.Deployment, images []*storage.Image
 			)
 
 			if err != nil {
-				return nil, utils.Should(err)
+				return nil, utils.ShouldErr(err)
 			}
 		}
 	}
@@ -214,7 +214,7 @@ func ConstructImage(image *storage.Image) (*pathutil.AugmentedObj, error) {
 			pathutil.IndexStep(i), pathutil.FieldStep(dockerfileLineAugmentKey),
 		)
 		if err != nil {
-			return nil, utils.Should(err)
+			return nil, utils.ShouldErr(err)
 		}
 	}
 
@@ -230,7 +230,7 @@ func ConstructImage(image *storage.Image) (*pathutil.AugmentedObj, error) {
 			pathutil.FieldStep(componentAndVersionAugmentKey),
 		)
 		if err != nil {
-			return nil, utils.Should(err)
+			return nil, utils.ShouldErr(err)
 		}
 	}
 
@@ -247,7 +247,7 @@ func ConstructImage(image *storage.Image) (*pathutil.AugmentedObj, error) {
 		},
 		pathutil.FieldStep("SignatureVerificationData"),
 		pathutil.FieldStep(imageSignatureVerifiedKey)); err != nil {
-		return nil, utils.Should(err)
+		return nil, utils.ShouldErr(err)
 	}
 
 	return obj, nil

--- a/pkg/booleanpolicy/evaluator/pathutil/filter_linked.go
+++ b/pkg/booleanpolicy/evaluator/pathutil/filter_linked.go
@@ -168,7 +168,7 @@ func FilterMatchesToResults(fieldsToPathsAndValues map[string][]PathAndValueHold
 	// Panics will only happen with invalid inputs, which is always a programming error.
 	defer func() {
 		if r := recover(); r != nil {
-			err = utils.Should(errors.Errorf("invalid input: %v", r))
+			err = utils.ShouldErr(errors.Errorf("invalid input: %v", r))
 		}
 	}()
 	t := newTree()

--- a/pkg/cloudproviders/azure/attested_vmid.go
+++ b/pkg/cloudproviders/azure/attested_vmid.go
@@ -42,7 +42,7 @@ type attestedMetadata struct {
 func getAttestedVMID(ctx context.Context) (string, error) {
 	req, err := http.NewRequest(http.MethodGet, attestedMetadataBaseURL, nil)
 	if err != nil {
-		return "", utils.Should(err)
+		return "", utils.ShouldErr(err)
 	}
 	req = req.WithContext(ctx)
 

--- a/pkg/cloudproviders/gcp/cert_set.go
+++ b/pkg/cloudproviders/gcp/cert_set.go
@@ -30,7 +30,7 @@ func (s *certSet) Fetch(ctx context.Context) error {
 
 	req, err := http.NewRequest(http.MethodGet, certsURL, nil)
 	if err != nil {
-		return utils.Should(err)
+		return utils.ShouldErr(err)
 	}
 	req = req.WithContext(ctx)
 	resp, err := certificateHTTPClient.Do(req)

--- a/pkg/cloudproviders/gcp/identity_token.go
+++ b/pkg/cloudproviders/gcp/identity_token.go
@@ -35,7 +35,7 @@ type identityTokenClaims struct {
 func getIdentityToken(ctx context.Context, audience string) (string, error) {
 	req, err := http.NewRequest(http.MethodGet, baseIdentityURL, nil)
 	if err != nil {
-		return "", utils.Should(err)
+		return "", utils.ShouldErr(err)
 	}
 	req = req.WithContext(ctx)
 	q := req.URL.Query()

--- a/pkg/grpc/metrics/grpc_metrics_impl.go
+++ b/pkg/grpc/metrics/grpc_metrics_impl.go
@@ -33,7 +33,7 @@ func (g *grpcMetricsImpl) getOrCreateAllMetrics(path string) *perPathGRPCMetrics
 	perPathMetric := g.allMetrics[path]
 	if perPathMetric == nil {
 		panicLRU, err := lru.New(cacheSize)
-		err = utils.Should(errors.Wrap(err, "error creating an lru"))
+		err = utils.ShouldErr(errors.Wrap(err, "error creating an lru"))
 		if err != nil {
 			return nil
 		}

--- a/pkg/httputil/proxy/dial.go
+++ b/pkg/httputil/proxy/dial.go
@@ -57,7 +57,7 @@ func dialWithSocks5Proxy(ctx context.Context, proxyURL *url.URL, address string)
 	}
 	socksCtxDialer, _ := socksDialer.(proxy.ContextDialer)
 	if socksCtxDialer == nil {
-		return nil, utils.Should(errors.New("expected SOCKS5 dialer to implement DialContext"))
+		return nil, utils.ShouldErr(errors.New("expected SOCKS5 dialer to implement DialContext"))
 	}
 	return socksCtxDialer.DialContext(ctx, "tcp", address)
 }

--- a/pkg/httputil/proxy/proxy.go
+++ b/pkg/httputil/proxy/proxy.go
@@ -93,7 +93,7 @@ func AwareDialContext(ctx context.Context, address string) (net.Conn, error) {
 
 	fakeHTTPReq, err := http.NewRequest(http.MethodGet, fmt.Sprintf("tcp://%s", address), nil)
 	if err != nil {
-		return nil, utils.Should(errors.Wrapf(err, "failed to instantiate fake HTTP request for address %q", address))
+		return nil, utils.ShouldErr(errors.Wrapf(err, "failed to instantiate fake HTTP request for address %q", address))
 	}
 	proxyURL, err := configurator(fakeHTTPReq)
 	if err != nil {

--- a/pkg/k8sutil/unstructured.go
+++ b/pkg/k8sutil/unstructured.go
@@ -25,7 +25,7 @@ func UnstructuredFromYAML(yamlStr string) (*unstructured.Unstructured, error) {
 	}
 	asUnstructured, ok := obj.(*unstructured.Unstructured)
 	if !ok {
-		return nil, utils.Should(errors.Errorf("obj was not Unstructured (got %T)", obj))
+		return nil, utils.ShouldErr(errors.Errorf("obj was not Unstructured (got %T)", obj))
 	}
 	return asUnstructured, nil
 }

--- a/pkg/renderer/kubernetes.go
+++ b/pkg/renderer/kubernetes.go
@@ -127,7 +127,7 @@ func renderAndExtractSingleFileContents(c Config, mode mode, imageFlavor default
 	}
 
 	if len(files) != 1 {
-		return nil, utils.Should(errors.Errorf("got unexpected number of files when rendering in mode %s: %d", mode, len(files)))
+		return nil, utils.ShouldErr(errors.Errorf("got unexpected number of files when rendering in mode %s: %d", mode, len(files)))
 	}
 	return files[0].Content, nil
 }

--- a/pkg/renderer/readme.go
+++ b/pkg/renderer/readme.go
@@ -117,11 +117,11 @@ func instructions(c Config, mode mode) (string, error) {
 
 	tpl, err := helmTemplate.InitTemplate("temp").Parse(template)
 	if err != nil {
-		return "", utils.Should(err)
+		return "", utils.ShouldErr(err)
 	}
 	data, err := templates.ExecuteToBytes(tpl, &c)
 	if err != nil {
-		return "", utils.Should(err)
+		return "", utils.ShouldErr(err)
 	}
 
 	instructions := string(data)

--- a/pkg/safe/run.go
+++ b/pkg/safe/run.go
@@ -10,7 +10,7 @@ import (
 // Note: the error is passed through `utils.Should`, resulting in a panic on debug builds and a log message on
 // release builds.
 func RunE(fn func() error) error {
-	return utils.Should(runE(fn))
+	return utils.ShouldErr(runE(fn))
 }
 
 // runE is like RunE, but the result is not passed through utils.Should for better testability.

--- a/pkg/search/blevesearch/common.go
+++ b/pkg/search/blevesearch/common.go
@@ -366,7 +366,7 @@ func getSortOrderAndSearchAfter(pagination *v1.QueryPagination, optionsMap searc
 		// This checks that SearchAfter will have effect when used or returns an error.
 		// It appears that Bleve does not have validations for bleve.SearchRequest.SearchAfter. This closes the gap.
 		// See https://github.com/blevesearch/bleve/pull/1182#issuecomment-499216058
-		return nil, nil, utils.Should(errors.New("total ordering not guaranteed: SortOrder must contain DocID and SearchAfter value for it to ensure there are no ties, otherwise SearchAfter will not produce correct results"))
+		return nil, nil, utils.ShouldErr(errors.New("total ordering not guaranteed: SortOrder must contain DocID and SearchAfter value for it to ensure there are no ties, otherwise SearchAfter will not produce correct results"))
 	}
 
 	return sortOrder, searchAfter, nil

--- a/pkg/utils/must.go
+++ b/pkg/utils/must.go
@@ -39,7 +39,7 @@ func CrashOnError(errs ...error) {
 	}
 }
 
-// Should panics on development builds and logs on release builds
+// ShouldErr panics on development builds and logs on release builds
 // The expectation is that this function will be called with an error wrapped by errors.Wrap
 // so that tracing is easier
 func ShouldErr(errs ...error) error {

--- a/pkg/utils/must.go
+++ b/pkg/utils/must.go
@@ -42,7 +42,7 @@ func CrashOnError(errs ...error) {
 // Should panics on development builds and logs on release builds
 // The expectation is that this function will be called with an error wrapped by errors.Wrap
 // so that tracing is easier
-func Should(errs ...error) error {
+func ShouldErr(errs ...error) error {
 	for _, err := range errs {
 		if err != nil {
 			if buildinfo.ReleaseBuild {
@@ -54,4 +54,9 @@ func Should(errs ...error) error {
 		}
 	}
 	return nil
+}
+
+// Should wraps ShouldErr without returning the error. This removes gosec G104.
+func Should(errs ...error) {
+	_ = ShouldErr(errs...)
 }

--- a/roxctl/collector/supportpackages/upload/upload.go
+++ b/roxctl/collector/supportpackages/upload/upload.go
@@ -119,7 +119,7 @@ func buildUploadManifest(probeFilesInPackage map[string]*zip.File, existingFiles
 func (cmd *collectorSPUploadCommand) doFileUpload(manifest *v1.ProbeUploadManifest, data io.Reader) error {
 	totalSize, err := probeupload.AnalyzeManifest(manifest)
 	if err != nil {
-		return utils.Should(errors.Wrap(err, "generated invalid manifest"))
+		return utils.ShouldErr(errors.Wrap(err, "generated invalid manifest"))
 	}
 
 	manifestBytes, err := proto.Marshal(manifest)

--- a/sensor/admission-control/certs.go
+++ b/sensor/admission-control/certs.go
@@ -33,7 +33,7 @@ func configureCA() error {
 
 	// Found fallback CA
 	log.Infof("Switching to fallback CA file location")
-	if err := utils.Should(os.Setenv(mtls.CAFileEnvName, alternativeCAPath)); err != nil {
+	if err := utils.ShouldErr(os.Setenv(mtls.CAFileEnvName, alternativeCAPath)); err != nil {
 		return errors.Wrap(err, "failed to update environment for alternative CA location")
 	}
 	log.Info("Successfully configured CA to be read from fallback location")

--- a/sensor/admission-control/fetchcerts/fetch_certs.go
+++ b/sensor/admission-control/fetchcerts/fetch_certs.go
@@ -37,10 +37,10 @@ var (
 )
 
 func changeCertAndKeyFileEnvVars() error {
-	if err := utils.Should(os.Setenv(mtls.CertFilePathEnvName, certFile)); err != nil {
+	if err := utils.ShouldErr(os.Setenv(mtls.CertFilePathEnvName, certFile)); err != nil {
 		return errors.Wrap(err, "updating certificate path environment variable")
 	}
-	if err := utils.Should(os.Setenv(mtls.KeyFileEnvName, keyFile)); err != nil {
+	if err := utils.ShouldErr(os.Setenv(mtls.KeyFileEnvName, keyFile)); err != nil {
 		return errors.Wrap(err, "updating key path environment variable")
 	}
 	return nil

--- a/sensor/common/scannerclient/singleton.go
+++ b/sensor/common/scannerclient/singleton.go
@@ -23,7 +23,7 @@ func GRPCClientSingleton() *Client {
 		var err error
 		scannerClient, err = dial(env.ScannerSlimGRPCEndpoint.Setting())
 		// If err is not nil, then there was a configuration error.
-		_ = utils.Should(err)
+		utils.Should(err)
 	})
 	return scannerClient
 }

--- a/sensor/common/sensor/sensor.go
+++ b/sensor/common/sensor/sensor.go
@@ -208,7 +208,7 @@ func (s *Sensor) Start() {
 
 	for _, component := range s.components {
 		if err := component.Start(); err != nil {
-			_ = utils.Should(errors.Wrapf(err, "sensor component %T failed to start", component))
+			utils.Should(errors.Wrapf(err, "sensor component %T failed to start", component))
 		}
 	}
 

--- a/sensor/kubernetes/listener/resources/rbac/evaluator.go
+++ b/sensor/kubernetes/listener/resources/rbac/evaluator.go
@@ -42,7 +42,7 @@ func rolePermissionLevelToClusterPermissionLevel(permissionLevel rolePermissionL
 	case permissionNone:
 		return storage.PermissionLevel_NONE
 	}
-	_ = utils.Should(fmt.Errorf("unhandled permission level %d", permissionLevel))
+	utils.Should(fmt.Errorf("unhandled permission level %d", permissionLevel))
 	return storage.PermissionLevel_UNSET
 }
 
@@ -55,7 +55,7 @@ func rolePermissionLevelToNamespacePermissionLevel(permissionLevel rolePermissio
 	case permissionNone:
 		return storage.PermissionLevel_NONE
 	}
-	_ = utils.Should(fmt.Errorf("unhandled permission level %d", permissionLevel))
+	utils.Should(fmt.Errorf("unhandled permission level %d", permissionLevel))
 	return storage.PermissionLevel_UNSET
 }
 

--- a/sensor/kubernetes/listener/resources/secrets.go
+++ b/sensor/kubernetes/listener/resources/secrets.go
@@ -201,7 +201,7 @@ func getDockerConfigFromSecret(secret *v1.Secret) config.DockerConfig {
 		}
 		dockerConfig = dockerConfigJSON.Auths
 	default:
-		_ = utils.Should(errors.New("only Docker Config secrets are allowed"))
+		utils.Should(errors.New("only Docker Config secrets are allowed"))
 		return nil
 	}
 	return dockerConfig

--- a/sensor/kubernetes/upgrade/process.go
+++ b/sensor/kubernetes/upgrade/process.go
@@ -72,7 +72,7 @@ func newProcess(trigger *central.SensorUpgradeTrigger, checkInClient central.Sen
 	}
 	k8sClient, err := kubernetes.NewForConfig(&config)
 	if err != nil {
-		return nil, utils.Should(err)
+		return nil, utils.ShouldErr(err)
 	}
 	p.k8sClient = k8sClient
 
@@ -220,7 +220,7 @@ func (p *process) waitForDeploymentDeletionOnce(name string, uid types.UID) erro
 
 			obj, _ := ev.Object.(metav1.Object)
 			if obj == nil {
-				return utils.Should(errors.Errorf("object returned by watch is a non-k8s object of type %T", ev.Object))
+				return utils.ShouldErr(errors.Errorf("object returned by watch is a non-k8s object of type %T", ev.Object))
 			}
 
 			if obj.GetName() != name {

--- a/sensor/upgrader/bundle/fetcher.go
+++ b/sensor/upgrader/bundle/fetcher.go
@@ -29,12 +29,12 @@ func (f *fetcher) FetchBundle() (Contents, error) {
 	}
 	var buf bytes.Buffer
 	if err := new(jsonpb.Marshaler).Marshal(&buf, resByID); err != nil {
-		return nil, utils.Should(err)
+		return nil, utils.ShouldErr(err)
 	}
 
 	req, err := http.NewRequest(http.MethodPost, "/api/extensions/clusters/zip", &buf)
 	if err != nil {
-		return nil, utils.Should(err)
+		return nil, utils.ShouldErr(err)
 	}
 
 	resp, err := f.ctx.DoCentralHTTPRequest(req)

--- a/sensor/upgrader/resources/metadata.go
+++ b/sensor/upgrader/resources/metadata.go
@@ -54,7 +54,7 @@ func populateFromResourceList(resourceList *v1.APIResourceList, expectedGVKs map
 	gv, err := schema.ParseGroupVersion(resourceList.GroupVersion)
 	if err != nil {
 		// Should never happen, but let's be forgiving if it does.
-		log.Warnf("Failed to parse group version for resource list %v: %v", resourceList, utils.Should(err))
+		log.Warnf("Failed to parse group version for resource list %v: %v", resourceList, utils.ShouldErr(err))
 		return nil
 	}
 

--- a/sensor/upgrader/snapshot/snapshotter.go
+++ b/sensor/upgrader/snapshot/snapshotter.go
@@ -126,13 +126,13 @@ func (s *snapshotter) createStateSnapshot() ([]*unstructured.Unstructured, *v1.S
 	var compressedData bytes.Buffer
 	gzipWriter, err := gzip.NewWriterLevel(&compressedData, gzip.BestCompression)
 	if err != nil {
-		return nil, nil, utils.Should(err) // level is valid, so expect no error
+		return nil, nil, utils.ShouldErr(err) // level is valid, so expect no error
 	}
 	if _, err := gzipWriter.Write(bytes.Join(byteSlices, jsonSeparator)); err != nil {
-		return nil, nil, utils.Should(err)
+		return nil, nil, utils.ShouldErr(err)
 	}
 	if err := gzipWriter.Close(); err != nil {
-		return nil, nil, utils.Should(err)
+		return nil, nil, utils.ShouldErr(err)
 	}
 
 	secret := &v1.Secret{


### PR DESCRIPTION
## Description

* make `utils.Should(err)` return nothing
* make `utils.ShouldErr(err)` return `err`
* adapt the code

Alternatively, we could make all cases of `Should` be `_ = utils.Should(err)`.

See #3610.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

```sh
$ gosec ./...
```
