### PR TITLE
fix: use Roxbot GH token to create PR to openshift/release in start-release workflow

### DIFF
--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -267,6 +267,8 @@ jobs:
           git commit -m "Release $RELEASE files" >> "$GITHUB_STEP_SUMMARY"
       - name: Push and create PR
         if: env.DRY_RUN == 'false' && steps.check-existing.outputs.branch-exists == 'false'
+        env:
+          GH_TOKEN: "${{ secrets.ROBOT_ROX_GITHUB_TOKEN }}"
         run: |
           git push --set-upstream origin "$BRANCH"
 


### PR DESCRIPTION
## Description

Failed workflow: https://github.com/stackrox/stackrox/actions/runs/3478808735/jobs/5816620638.

We tried to create a PR to a repository outside our organization with the default GITHUB_TOKEN for the workflow run.
The fix is to create the PR with our bot user.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

With the ROBOT_ROX_GITHUB_TOKEN (reviewers find it in Bitwarden):

```
GH_TOKEN=*** gh pr create --repo openshift/release --title "WIP: Stackrox release 3.73" --base "master" --body "WIP: CI configuration files to support Stackrox release 3.73." --assignee tommartensen

> a pull request for branch "stackrox:stackrox-release-3.73" into branch "master" already exists:
> https://github.com/openshift/release/pull/34066
```

I assume that this resolves the permission issue.