### PR TITLE
Call interceptAndWaitForResponses function in container-specific visit functions

### DIFF
--- a/ui/apps/platform/cypress/constants/SystemHealth.js
+++ b/ui/apps/platform/cypress/constants/SystemHealth.js
@@ -1,7 +1,5 @@
 import scopeSelectors from '../helpers/scopeSelectors';
 
-export const systemHealthUrl = '/main/system-health';
-
 export const selectors = {
     bundle: {
         generateDiagnosticBundleButton: 'button:contains("Generate Diagnostic Bundle")',

--- a/ui/apps/platform/cypress/helpers/collections.js
+++ b/ui/apps/platform/cypress/helpers/collections.js
@@ -1,6 +1,7 @@
 import navSelectors from '../selectors/navigation';
 
 import { visitFromLeftNavExpandable } from './nav';
+import { interceptAndWaitForResponses } from './request';
 import { visit } from './visit';
 
 const basePath = '/main/collections';
@@ -19,27 +20,34 @@ const routeMatcherMapForCollections = {
     },
 };
 
+const title = 'Collections';
+
 // visit
 
+/**
+ * @param {Record<string, { body: unknown } | { fixture: string }>} [staticResponseMap]
+ */
 export function visitCollections(staticResponseMap) {
-    visit(basePath, routeMatcherMapForCollections, staticResponseMap);
+    visit(basePath);
 
-    cy.get('h1:contains("Collections")');
+    cy.get(`h1:contains("${title}")`);
     cy.get(`${navSelectors.navExpandable}:contains("Platform Configuration")`);
-    cy.get(`${navSelectors.nestedNavLinks}:contains("Collections")`).should(
+    cy.get(`${navSelectors.nestedNavLinks}:contains("${title}")`).should(
         'have.class',
         'pf-m-current'
     );
+
+    interceptAndWaitForResponses(routeMatcherMapForCollections, staticResponseMap);
 }
 
+/**
+ * @param {Record<string, { body: unknown } | { fixture: string }>} [staticResponseMap]
+ */
 export function visitCollectionsFromLeftNav(staticResponseMap) {
-    visitFromLeftNavExpandable(
-        'Platform Configuration',
-        'Collections',
-        routeMatcherMapForCollections,
-        staticResponseMap
-    );
+    visitFromLeftNavExpandable('Platform Configuration', title);
 
     cy.get('h1:contains("Collections")');
     cy.location('pathname').should('eq', basePath);
+
+    interceptAndWaitForResponses(routeMatcherMapForCollections, staticResponseMap);
 }

--- a/ui/apps/platform/cypress/helpers/compliance.js
+++ b/ui/apps/platform/cypress/helpers/compliance.js
@@ -1,6 +1,10 @@
 import { headingPlural, selectors, url } from '../constants/CompliancePage';
 
-import { getRouteMatcherMapForGraphQL, interactAndWaitForResponses } from './request';
+import {
+    getRouteMatcherMapForGraphQL,
+    interactAndWaitForResponses,
+    interceptAndWaitForResponses,
+} from './request';
 import { visit } from './visit';
 
 const routeMatcherMapForComplianceDashboard = getRouteMatcherMapForGraphQL([
@@ -23,9 +27,11 @@ const routeMatcherMapForComplianceDashboard = getRouteMatcherMapForGraphQL([
 ]);
 
 export function visitComplianceDashboard() {
-    visit(url.dashboard, routeMatcherMapForComplianceDashboard);
+    visit(url.dashboard);
 
     cy.get('h1:contains("Compliance")');
+
+    interceptAndWaitForResponses(routeMatcherMapForComplianceDashboard);
 }
 
 /*
@@ -75,9 +81,11 @@ export function visitComplianceEntities(entitiesKey) {
         opnameForEntities[entitiesKey],
     ]);
 
-    visit(url.entities[entitiesKey], routeMatcherMap);
+    visit(url.entities[entitiesKey]);
 
     cy.get(`h1:contains("${headingPlural[entitiesKey]}")`);
+
+    interceptAndWaitForResponses(routeMatcherMap);
 }
 
 /*
@@ -90,7 +98,9 @@ export function visitComplianceStandard(standardName) {
         'controls',
     ]);
 
-    visit(`${url.controls}?s[standard]=${standardName}`, routeMatcherMap);
+    visit(`${url.controls}?s[standard]=${standardName}`);
 
     cy.get(`h1:contains("${standardName}")`);
+
+    interceptAndWaitForResponses(routeMatcherMap);
 }

--- a/ui/apps/platform/cypress/helpers/configWorkflowUtils.js
+++ b/ui/apps/platform/cypress/helpers/configWorkflowUtils.js
@@ -1,5 +1,9 @@
 import { selectors as configManagementSelectors } from '../constants/ConfigManagementPage';
-import { getRouteMatcherMapForGraphQL, interactAndWaitForResponses } from './request';
+import {
+    getRouteMatcherMapForGraphQL,
+    interactAndWaitForResponses,
+    interceptAndWaitForResponses,
+} from './request';
 import { visit } from './visit';
 
 const basePath = '/main/configmanagement';
@@ -145,43 +149,53 @@ const routeMatcherMapForConfigurationManagementDashboard = getRouteMatcherMapFor
 ]);
 
 export function visitConfigurationManagementDashboard() {
-    visit(basePath, routeMatcherMapForConfigurationManagementDashboard);
+    visit(basePath);
 
     cy.get('h1:contains("Configuration Management")');
+
+    interceptAndWaitForResponses(routeMatcherMapForConfigurationManagementDashboard);
 }
 
 export function visitConfigurationManagementEntities(entitiesKey) {
-    visit(getEntitiesPath(entitiesKey), getRouteMatcherMapForEntities(entitiesKey));
+    visit(getEntitiesPath(entitiesKey));
 
     cy.get(`h1:contains("${headingForEntities[entitiesKey]}")`);
+
+    interceptAndWaitForResponses(getRouteMatcherMapForEntities(entitiesKey));
 }
 
 export function visitConfigurationManagementEntitiesWithSearch(entitiesKey, search) {
-    visit(`${getEntitiesPath(entitiesKey)}${search}`, getRouteMatcherMapForEntities(entitiesKey));
+    visit(`${getEntitiesPath(entitiesKey)}${search}`);
 
     cy.get(`h1:contains("${headingForEntities[entitiesKey]}")`);
+
+    interceptAndWaitForResponses(getRouteMatcherMapForEntities(entitiesKey));
 }
 
 export function interactAndWaitForConfigurationManagementEntities(
     interactionCallback,
     entitiesKey
 ) {
-    interactAndWaitForResponses(interactionCallback, getRouteMatcherMapForEntities(entitiesKey));
+    interactionCallback();
 
     cy.location('pathname').should('eq', getEntitiesPath(entitiesKey));
     cy.get(`h1:contains("${headingForEntities[entitiesKey]}")`);
+
+    interceptAndWaitForResponses(getRouteMatcherMapForEntities(entitiesKey));
 }
 
 export function interactAndWaitForConfigurationManagementEntityInSidePanel(
     interactionCallback,
     entitiesKey
 ) {
-    interactAndWaitForResponses(interactionCallback, getRouteMatcherMapForEntity(entitiesKey));
+    interactionCallback();
 
     cy.location('pathname').should('contain', getEntitiesPath(entitiesKey)); // contains because it ends with id
     cy.get(
         `[data-testid="breadcrumb-link-text"]:eq(0):contains("${headingForEntity[entitiesKey]}")`
     );
+
+    interceptAndWaitForResponses(getRouteMatcherMapForEntity(entitiesKey));
 }
 
 export function interactAndWaitForConfigurationManagementSecondaryEntityInSidePanel(
@@ -189,21 +203,25 @@ export function interactAndWaitForConfigurationManagementSecondaryEntityInSidePa
     entitiesKey1,
     entitiesKey2
 ) {
-    interactAndWaitForResponses(interactionCallback, getRouteMatcherMapForEntity(entitiesKey2));
+    interactionCallback();
 
     cy.location('pathname').should('contain', getEntitiesPath(entitiesKey1)); // contains because it has id
     cy.location('pathname').should('contain', segmentForEntity[entitiesKey2]); // contains because it has id
     cy.get(`[data-testid="breadcrumb-link-text"]:contains("${headingForEntity[entitiesKey2]}")`);
+
+    interceptAndWaitForResponses(getRouteMatcherMapForEntity(entitiesKey2));
 }
 
 export function interactAndWaitForConfigurationManagementEntityPage(
     interactionCallback,
     entitiesKey
 ) {
-    interactAndWaitForResponses(interactionCallback, getRouteMatcherMapForEntity(entitiesKey));
+    interactionCallback();
 
     cy.location('pathname').should('contain', getEntityPagePath(entitiesKey)); // contains because it ends with id
     cy.get(`h1 + div:contains("${headingForEntity[entitiesKey]}")`);
+
+    interceptAndWaitForResponses(getRouteMatcherMapForEntity(entitiesKey));
 }
 
 export function interactAndWaitForConfigurationManagementSecondaryEntities(

--- a/ui/apps/platform/cypress/helpers/main.js
+++ b/ui/apps/platform/cypress/helpers/main.js
@@ -1,7 +1,7 @@
 import { url as basePath } from '../constants/DashboardPage';
 import navSelectors from '../selectors/navigation';
 
-import { getRouteMatcherMapForGraphQL, interactAndWaitForResponses } from './request';
+import { getRouteMatcherMapForGraphQL, interceptAndWaitForResponses } from './request';
 import { visit } from './visit';
 
 /*
@@ -63,20 +63,22 @@ const title = 'Dashboard';
 // visit helpers
 
 export function visitMainDashboardFromLeftNav() {
-    interactAndWaitForResponses(() => {
-        cy.get(`${navSelectors.navLinks}:contains("${title}")`).click();
-    }, routeMatcherMap);
+    cy.get(`${navSelectors.navLinks}:contains("${title}")`).click();
 
     cy.location('pathname').should('eq', basePath);
     cy.get(`h1:contains("${title}")`);
+
+    interceptAndWaitForResponses(routeMatcherMap);
 }
 
 /**
  * @param {Record<string, { body: unknown } | { fixture: string }>} [staticResponseMap]
  */
 export function visitMainDashboard(staticResponseMap) {
-    visit(basePath, routeMatcherMap, staticResponseMap);
+    visit(basePath);
 
     cy.get(`.pf-c-nav__link.pf-m-current:contains("${title}")`);
     cy.get(`h1:contains("${title}")`);
+
+    interceptAndWaitForResponses(routeMatcherMap, staticResponseMap);
 }

--- a/ui/apps/platform/cypress/helpers/networkGraph.js
+++ b/ui/apps/platform/cypress/helpers/networkGraph.js
@@ -1,7 +1,11 @@
 import * as api from '../constants/apiEndpoints';
 import { selectors as networkGraphSelectors } from '../constants/NetworkPage';
 import { visitFromLeftNav } from './nav';
-import { getRouteMatcherMapForGraphQL, interactAndWaitForResponses } from './request';
+import {
+    getRouteMatcherMapForGraphQL,
+    interactAndWaitForResponses,
+    interceptAndWaitForResponses,
+} from './request';
 import { visit } from './visit';
 import selectSelectors from '../selectors/select';
 import tabSelectors from '../selectors/tab';
@@ -283,10 +287,12 @@ export function visitNetworkGraphFromLeftNav() {
 }
 
 export function visitNetworkGraph(staticResponseMap) {
-    visit(basePath, routeMatcherMapToVisitNetworkGraph, staticResponseMap);
+    visit(basePath);
 
     cy.get(networkGraphSelectors.networkGraphHeading);
     cy.get(networkGraphSelectors.emptyStateSubheading);
+
+    interceptAndWaitForResponses(routeMatcherMapToVisitNetworkGraph, staticResponseMap);
 }
 
 export function visitNetworkGraphWithNamespaceFilter(namespace) {

--- a/ui/apps/platform/cypress/helpers/policies.js
+++ b/ui/apps/platform/cypress/helpers/policies.js
@@ -1,6 +1,7 @@
 import * as api from '../constants/apiEndpoints';
 import { selectors, url as policiesUrl } from '../constants/PoliciesPage';
 import { visitFromLeftNavExpandable } from './nav';
+import { interceptAndWaitForResponses } from './request';
 import { visit } from './visit';
 
 // Navigation
@@ -25,30 +26,43 @@ const routeMatcherMap = {
     },
 };
 
+// visit
+
+/**
+ * @param {Record<string, { body: unknown } | { fixture: string }>} [staticResponseMap]
+ */
 export function visitPolicies(staticResponseMap) {
-    visit(policiesUrl, routeMatcherMap, staticResponseMap);
+    visit(policiesUrl);
 
     cy.get('h1:contains("Policy management")');
     cy.get(`.pf-c-nav__link.pf-m-current:contains("Policies")`);
+
+    interceptAndWaitForResponses(routeMatcherMap, staticResponseMap);
 }
 
 export function visitPoliciesFromLeftNav() {
-    visitFromLeftNavExpandable('Platform Configuration', 'Policy Management', routeMatcherMap);
+    visitFromLeftNavExpandable('Platform Configuration', 'Policy Management');
 
     cy.get('h1:contains("Policy management")');
     cy.get(`.pf-c-nav__link.pf-m-current:contains("Policies")`);
+
+    interceptAndWaitForResponses(routeMatcherMap);
 }
 
+export const policyAlias = 'policies/id';
+
 export function visitPolicy(policyId, staticResponseMap) {
-    const routeMatcherMapPolicy = {
-        'policies/id': {
+    const routeMatcherMapForPolicy = {
+        [policyAlias]: {
             method: 'GET',
             url: api.policies.policy,
         },
     };
 
-    visit(`${policiesUrl}/${policyId}`, routeMatcherMapPolicy, staticResponseMap);
+    visit(`${policiesUrl}/${policyId}`);
     cy.get('h2:contains("Policy details")');
+
+    interceptAndWaitForResponses(routeMatcherMapForPolicy, staticResponseMap);
 }
 
 // Actions on policy table

--- a/ui/apps/platform/cypress/helpers/request.js
+++ b/ui/apps/platform/cypress/helpers/request.js
@@ -69,6 +69,17 @@ export function waitForResponses(routeMatcherMap) {
 }
 
 /**
+ * Intercept requests and then wait for responses.
+ *
+ * @param {Record<string, { method: string, url: string }>} routeMatcherMap
+ * @param {Record<string, { body: unknown } | { fixture: string }>} staticResponseMap
+ */
+export function interceptAndWaitForResponses(routeMatcherMap, staticResponseMap) {
+    interceptRequests(routeMatcherMap, staticResponseMap);
+    waitForResponses(routeMatcherMap);
+}
+
+/**
  * Intercept requests before interaction and then wait for responses.
  *
  * @param {() => void} interactionCallback

--- a/ui/apps/platform/cypress/helpers/risk.js
+++ b/ui/apps/platform/cypress/helpers/risk.js
@@ -3,6 +3,7 @@ import { selectors as riskPageSelectors, url as riskURL } from '../constants/Ris
 import selectors from '../selectors/index';
 
 import { reachNetworkGraphWithDeploymentSelected } from './networkGraph';
+import { interceptAndWaitForResponses } from './request';
 import { visit } from './visit';
 
 // visit
@@ -26,16 +27,22 @@ const routeMatcherMap = {
     },
 };
 
-export function visitRiskDeployments() {
-    visit(riskURL, routeMatcherMap);
+const title = 'Risk';
 
-    cy.get('h1:contains("Risk")');
+export function visitRiskDeployments() {
+    visit(riskURL);
+
+    cy.get(`h1:contains("${title}")`);
+
+    interceptAndWaitForResponses(routeMatcherMap);
 }
 
 export function visitRiskDeploymentsWithSearchQuery(search) {
     visit(`${riskURL}${search}`, routeMatcherMap);
 
-    cy.get('h1:contains("Risk")');
+    cy.get(`h1:contains("${title}")`);
+
+    interceptAndWaitForResponses(routeMatcherMap);
 }
 
 export function viewRiskDeploymentByName(deploymentName) {

--- a/ui/apps/platform/cypress/helpers/systemConfig.js
+++ b/ui/apps/platform/cypress/helpers/systemConfig.js
@@ -1,5 +1,5 @@
 import { visitFromLeftNavExpandable } from './nav';
-import { interactAndWaitForResponses } from './request';
+import { interactAndWaitForResponses, interceptAndWaitForResponses } from './request';
 import { visit, visitWithStaticResponseForPermissions } from './visit';
 
 const basePath = '/main/systemconfig';
@@ -20,28 +20,30 @@ const title = 'System Configuration';
 // visit
 
 export function visitSystemConfiguration() {
-    visit(basePath, routeMatcherMapForGET);
+    visit(basePath);
 
     cy.get(`h1:contains("${title}")`);
+
+    interceptAndWaitForResponses(routeMatcherMapForGET);
 }
 
 export function visitSystemConfigurationFromLeftNav() {
-    visitFromLeftNavExpandable('Platform Configuration', title, routeMatcherMapForGET);
+    visitFromLeftNavExpandable('Platform Configuration', title);
 
     cy.location('pathname').should('eq', basePath);
     cy.get(`h1:contains("${title}")`);
+
+    interceptAndWaitForResponses(routeMatcherMapForGET);
 }
 
 export function visitSystemConfigurationWithStaticResponseForPermissions(
     staticResponseForPermissions
 ) {
-    visitWithStaticResponseForPermissions(
-        basePath,
-        staticResponseForPermissions,
-        routeMatcherMapForGET
-    );
+    visitWithStaticResponseForPermissions(basePath, staticResponseForPermissions);
 
     cy.get(`h1:contains("${title}")`);
+
+    interceptAndWaitForResponses(routeMatcherMapForGET);
 }
 
 // save

--- a/ui/apps/platform/cypress/helpers/systemHealth.js
+++ b/ui/apps/platform/cypress/helpers/systemHealth.js
@@ -1,7 +1,7 @@
 import * as api from '../constants/apiEndpoints';
-import { systemHealthUrl } from '../constants/SystemHealth';
 
 import { visitFromLeftNavExpandable } from './nav';
+import { interceptAndWaitForResponses } from './request';
 import { visit } from './visit';
 
 // clock
@@ -13,34 +13,43 @@ export function setClock(currentDatetime) {
 
 // visit
 
+export const basePath = '/main/system-health';
+
+export const integrationHealthImageIntegrationsAlias = 'integrationhealth/imageintegrations';
+export const imageIntegrationsAlias = 'imageintegrations';
+export const integrationHealthNotifiersAlias = 'integrationhealth/notifiers';
+export const notifiersAlias = 'notifiers';
+export const integrationHealthExternalBackupsAlias = 'integrationhealth/externalbackups';
+export const externalBackupsAlias = 'externalbackups';
+export const clustersAlias = 'clusters';
 export const integrationHealthVulnDefinitionsAlias = 'integrationhealth/vulndefinitions';
 
 const routeMatcherMap = {
-    'integrationhealth/imageintegrations': {
+    [integrationHealthImageIntegrationsAlias]: {
         method: 'GET',
         url: api.integrationHealth.imageIntegrations,
     },
-    imageintegrations: {
+    [imageIntegrationsAlias]: {
         method: 'GET',
         url: api.integrations.imageIntegrations,
     },
-    'integrationhealth/notifiers': {
+    [integrationHealthNotifiersAlias]: {
         method: 'GET',
         url: api.integrationHealth.notifiers,
     },
-    notifiers: {
+    [notifiersAlias]: {
         method: 'GET',
         url: api.integrations.notifiers,
     },
-    'integrationhealth/externalbackups': {
+    [integrationHealthExternalBackupsAlias]: {
         method: 'GET',
         url: api.integrationHealth.externalBackups,
     },
-    externalbackups: {
+    [externalBackupsAlias]: {
         method: 'GET',
         url: api.integrations.externalBackups,
     },
-    clusters: {
+    [clustersAlias]: {
         method: 'GET',
         url: api.clusters.list,
     },
@@ -50,15 +59,24 @@ const routeMatcherMap = {
     },
 };
 
-export function visitSystemHealthFromLeftNav() {
-    visitFromLeftNavExpandable('Platform Configuration', 'System Health', routeMatcherMap);
+const title = 'System Health';
 
-    cy.location('pathname').should('eq', systemHealthUrl);
-    cy.get('h1:contains("System Health")');
+export function visitSystemHealthFromLeftNav() {
+    visitFromLeftNavExpandable('Platform Configuration', title);
+
+    cy.location('pathname').should('eq', basePath);
+    cy.get(`h1:contains("${title}")`);
+
+    interceptAndWaitForResponses(routeMatcherMap);
 }
 
+/**
+ * @param {Record<string, { body: unknown } | { fixture: string }>} [staticResponseMap]
+ */
 export function visitSystemHealth(staticResponseMap) {
-    visit(systemHealthUrl, routeMatcherMap, staticResponseMap);
+    visit(basePath);
 
-    cy.get('h1:contains("System Health")');
+    cy.get(`h1:contains("${title}")`);
+
+    interceptAndWaitForResponses(routeMatcherMap, staticResponseMap);
 }

--- a/ui/apps/platform/cypress/helpers/vulnmanagement/entities.js
+++ b/ui/apps/platform/cypress/helpers/vulnmanagement/entities.js
@@ -2,7 +2,11 @@ import { selectors } from '../../constants/VulnManagementPage';
 import { hasFeatureFlag } from '../features';
 
 import { visitFromLeftNavExpandable } from '../nav';
-import { getRouteMatcherMapForGraphQL, interactAndWaitForResponses } from '../request';
+import {
+    getRouteMatcherMapForGraphQL,
+    interactAndWaitForResponses,
+    interceptAndWaitForResponses,
+} from '../request';
 import { visit } from '../visit';
 
 let opnamesForDashboard = [
@@ -132,22 +136,24 @@ function getEntityPath(entitiesKey, entityId) {
     return getEntitiesPath(entitiesKey, search);
 }
 
+const title = 'Vulnerability Management';
+
 export function visitVulnerabilityManagementDashboardFromLeftNav() {
-    visitFromLeftNavExpandable(
-        'Vulnerability Management',
-        'Dashboard',
-        routeMatcherMapForVulnerabilityManagementDashboard
-    );
+    visitFromLeftNavExpandable(title, 'Dashboard');
 
     cy.location('pathname').should('eq', basePath);
     cy.location('search').should('eq', '');
-    cy.get('h1:contains("Vulnerability Management")');
+    cy.get(`h1:contains("${title}")`);
+
+    interceptAndWaitForResponses(routeMatcherMapForVulnerabilityManagementDashboard);
 }
 
 export function visitVulnerabilityManagementDashboard() {
-    visit(basePath, routeMatcherMapForVulnerabilityManagementDashboard);
+    visit(basePath);
 
-    cy.get('h1:contains("Vulnerability Management")');
+    cy.get(`h1:contains("${title}")`);
+
+    interceptAndWaitForResponses(routeMatcherMapForVulnerabilityManagementDashboard);
 }
 
 /*
@@ -160,9 +166,11 @@ export function visitVulnerabilityManagementEntities(entitiesKey) {
         opnameForEntities[entitiesKey],
     ]);
 
-    visit(getEntitiesPath(entitiesKey), routeMatcherMap);
+    visit(getEntitiesPath(entitiesKey));
 
     cy.get(`h1:contains("${headingPlural[entitiesKey]}")`);
+
+    interceptAndWaitForResponses(routeMatcherMap);
 }
 
 export function visitVulnerabilityManagementEntitiesWithSearch(entitiesKey, search) {
@@ -171,11 +179,18 @@ export function visitVulnerabilityManagementEntitiesWithSearch(entitiesKey, sear
         opnameForEntities[entitiesKey],
     ]);
 
-    visit(getEntitiesPath(entitiesKey, search), routeMatcherMap);
+    visit(getEntitiesPath(entitiesKey, search));
 
     cy.get(`h1:contains("${headingPlural[entitiesKey]}")`);
+
+    interceptAndWaitForResponses(routeMatcherMap);
 }
 
+/**
+ * @param {function} interactionCallback
+ * @param {string} entitiesKey
+ * @param {{ body: unknown } | { fixture: string }} [staticResponseForEntities]
+ */
 export function interactAndWaitForVulnerabilityManagementEntities(
     interactionCallback,
     entitiesKey,
@@ -191,12 +206,19 @@ export function interactAndWaitForVulnerabilityManagementEntities(
     const routeMatcherMap = getRouteMatcherMapForGraphQL([opname]);
     const staticResponseMap = staticResponseForEntities && { [opname]: staticResponseForEntities };
 
-    interactAndWaitForResponses(interactionCallback, routeMatcherMap, staticResponseMap);
+    interactionCallback();
 
     cy.location('pathname').should('eq', getEntitiesPath(entitiesKey));
     cy.get(`h1:contains("${headingPlural[entitiesKey]}")`);
+
+    interceptAndWaitForResponses(routeMatcherMap, staticResponseMap);
 }
 
+/**
+ * @param {string} entitiesKey
+ * @param {string} entityId
+ * @param {{ body: unknown } | { fixture: string }} [staticResponseForEntity]
+ */
 export function visitVulnerabilityManagementEntityInSidePanel(
     entitiesKey,
     entityId,
@@ -206,9 +228,16 @@ export function visitVulnerabilityManagementEntityInSidePanel(
     const routeMatcherMap = getRouteMatcherMapForGraphQL([opname]);
     const staticResponseMap = staticResponseForEntity && { [opname]: staticResponseForEntity };
 
-    visit(getEntityPath(entitiesKey, entityId), routeMatcherMap, staticResponseMap);
+    visit(getEntityPath(entitiesKey, entityId));
+
+    interceptAndWaitForResponses(routeMatcherMap, staticResponseMap);
 }
 
+/**
+ * @param {function} interactionCallback
+ * @param {string} entitiesKey
+ * @param {{ body: unknown } | { fixture: string }} [staticResponseForEntity]
+ */
 export function interactAndWaitForVulnerabilityManagementEntity(
     interactionCallback,
     entitiesKey,
@@ -221,6 +250,12 @@ export function interactAndWaitForVulnerabilityManagementEntity(
     interactAndWaitForResponses(interactionCallback, routeMatcherMap, staticResponseMap);
 }
 
+/**
+ * @param {function} interactionCallback
+ * @param {string} entitiesKey1
+ * @param {string} entitiesKey2
+ * @param {{ body: unknown } | { fixture: string }} [staticResponseForSecondaryEntities]
+ */
 export function interactAndWaitForVulnerabilityManagementSecondaryEntities(
     interactionCallback,
     entitiesKey1,

--- a/ui/apps/platform/cypress/helpers/vulnmanagement/reporting.js
+++ b/ui/apps/platform/cypress/helpers/vulnmanagement/reporting.js
@@ -1,7 +1,11 @@
 import * as api from '../../constants/apiEndpoints';
 
 import { visitFromLeftNavExpandable } from '../nav';
-import { getRouteMatcherMapForGraphQL, interactAndWaitForResponses } from '../request';
+import {
+    getRouteMatcherMapForGraphQL,
+    interactAndWaitForResponses,
+    interceptAndWaitForResponses,
+} from '../request';
 import { visit } from '../visit';
 
 // visit
@@ -26,18 +30,27 @@ const routeMatcherMap = {
 
 const reportingPath = '/main/vulnerability-management/reports';
 
+const title = 'Vulnerability reporting';
+
 export function visitVulnerabilityReportingFromLeftNav() {
-    visitFromLeftNavExpandable('Vulnerability Management', 'Reporting', routeMatcherMap);
+    visitFromLeftNavExpandable('Vulnerability Management', 'Reporting');
 
     cy.location('pathname').should('eq', reportingPath);
     cy.location('search').should('eq', '');
-    cy.get('h1:contains("Vulnerability reporting")');
+    cy.get(`h1:contains("${title}")`);
+
+    interceptAndWaitForResponses(routeMatcherMap);
 }
 
+/**
+ * @param {Record<string, { body: unknown } | { fixture: string }>} [staticResponseMap]
+ */
 export function visitVulnerabilityReporting(staticResponseMap) {
-    visit(reportingPath, routeMatcherMap, staticResponseMap);
+    visit(reportingPath);
 
-    cy.get('h1:contains("Vulnerability reporting")');
+    cy.get(`h1:contains("${title}")`);
+
+    interceptAndWaitForResponses(routeMatcherMap, staticResponseMap);
 }
 
 export function visitVulnerabilityReportingWithFixture(fixturePath) {
@@ -71,10 +84,17 @@ const routeMatcherMapToCreate = {
     },
 };
 
+/**
+ * @param {Record<string, { body: unknown } | { fixture: string }>} [staticResponseMap]
+ */
 export function visitVulnerabilityReportingToCreate(staticResponseMap) {
     visit(`${reportingPath}?action=create`, routeMatcherMapToCreate, staticResponseMap);
 }
 
+/**
+ * @param {function} interactionCallback
+ * @param {Record<string, { body: unknown } | { fixture: string }>} [staticResponseMap]
+ */
 export function interactAndWaitToCreate(interactionCallback, staticResponseMap) {
     interactAndWaitForResponses(interactionCallback, routeMatcherMapToCreate, staticResponseMap);
 }

--- a/ui/apps/platform/cypress/integration/clusters/clusterDeletion.test.js
+++ b/ui/apps/platform/cypress/integration/clusters/clusterDeletion.test.js
@@ -1,7 +1,12 @@
 import { selectors } from '../../constants/ClustersPage';
 import withAuth from '../../helpers/basicAuth';
 import { hasFeatureFlag } from '../../helpers/features';
-import { visitClusterById, visitClusters, visitClustersWithFixture } from '../../helpers/clusters';
+import {
+    clusterAlias,
+    visitClusterById,
+    visitClusters,
+    visitClustersWithFixture,
+} from '../../helpers/clusters';
 
 describe('Clusters list clusterIdToRetentionInfo', () => {
     withAuth();
@@ -63,9 +68,13 @@ describe('Cluster page clusterRetentionInfo', () => {
         cy.fixture(fixturePath).then(({ clusters }) => {
             const cluster = clusters.find(({ name }) => name === clusterName);
 
-            visitClusterById(cluster.id, {
-                cluster: { body: { cluster, clusterRetentionInfo } },
-            });
+            const staticResponseMap = {
+                [clusterAlias]: {
+                    body: { cluster, clusterRetentionInfo },
+                },
+            };
+
+            visitClusterById(staticResponseMap);
 
             cy.get(selectors.clusterSidePanelHeading).contains(clusterName);
         });

--- a/ui/apps/platform/cypress/integration/systemHealth/clusters.test.js
+++ b/ui/apps/platform/cypress/integration/systemHealth/clusters.test.js
@@ -1,4 +1,3 @@
-import { clustersUrl } from '../../constants/ClustersPage';
 import { selectors } from '../../constants/SystemHealth';
 import withAuth from '../../helpers/basicAuth';
 import { reachClusters } from '../../helpers/clusters';
@@ -23,7 +22,6 @@ describe('System Health Clusters without fixture', () => {
         reachClusters(() => {
             cy.get(selectors.clusters.viewAllButton).click();
         });
-        cy.location('pathname').should('eq', clustersUrl);
     });
 });
 


### PR DESCRIPTION
## Description

### Problem

Under pressure to solve timing failures in tests for various containers:

1. I replaced `cy.visit` method with generic `visit` function which intercepts requests and waits for responses according to `routeMatcherMapForAuthenticatedRoutes` object.

    * That worked well, with one exception: I incorrect includes credential expiry requests, which are not in sequence preceding, but instead in parallel with container-specific requests. Fixed in #3577

2. I wrote container-specific `visitWhatever` functions with `routeMatcherMapForWhatever` object and optional `staticResponseMap` argument.

    * However, I made a mistake in the pattern to call `visit` function with those arguments, **and then** assert page address or page header. Destination page address is an obvious prerequisite to requests and components usually render page header **before** instead of **after* responses to requests. Because the order of wait (API, API, and then DOM) contradicts the order of events, the pattern wastes the extra 4 seconds wait for DOM assertions.

    * Especially if containers or entity components take responsibility to make requests, but even if they render data from Redux store via sagas, it is possible to assert page address or page header **and then** intercept requests and wait for responses. To prevent timing problems, **alternate** API and DOM consistent with order of events:
        * API: 10 seconds wait for requests and 30 seconds wait for responses for authenticated routes in `visit` function.
        * DOM: 4 seconds wait for container-specific assertions in `visitWhatever` function.
        * API: 10 seconds wait for requests and 30 seconds wait for responses for container page in `visitWhatever` function.
        * DOM: 4 secondds wait for test-specific assertions after `visitWhatever` function call.

### Solution

TODO

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed