### PR TITLE
ROX-13468: Skip risk sort by Priority integration test

### DIFF
--- a/ui/apps/platform/cypress/integration/risk/risk.test.js
+++ b/ui/apps/platform/cypress/integration/risk/risk.test.js
@@ -38,9 +38,9 @@ describe('Risk page', () => {
         });
 
         /*
-         * ROX-13468: assertSortedItems sometimes fails for sort descending.
+         * ROX-13468: assertSortedItems sometimes fails for sort descending (step 2) or resort ascending (step 3).
          * This is the only sort test that fails and Risk is the only occurrence of TableV2 element.
-         * Skip test given the comment below about initial table state and other possible rendering problems.
+         * Skip test given the comment below (step 0) initial table state and other possible rendering problems.
          */
         it.skip('should sort the Priority column', () => {
             visitRiskDeployments();


### PR DESCRIPTION
## Description

### Test failure

> Risk page without mock API should sort the Priority column

> AssertionError: expected 'notAscendingNumberValuesFromElements(24, 19)' to equal ''

![prow](https://user-images.githubusercontent.com/11862657/202499774-3a2ff21a-9216-4570-9ff4-c1ec92a794cd.png)

cypress/integration/risk.test.js

Most recent failure:
* 1593163448022208512 from master build for 3831 on 10-17

### Analysis

Although most failures have been because rows still sorted ascending after click to sort descending, this failure is because rows still sorted descending after click to sort ascending again.

This is the only sort test that fails and Risk is the only occurrence of `TableV2` element. Given that the element does not render initial table state, it might have other rendering problems which cause timing problems for the test.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration test

## Testing Performed