### PR TITLE
ROX-13584: test if compatibility tests are working as intended

### DIFF
--- a/qa-tests-backend/scripts/run-compatibility.sh
+++ b/qa-tests-backend/scripts/run-compatibility.sh
@@ -33,6 +33,7 @@ compatibility_test() {
 
         deploy_stackrox
         echo "Stackrox deployed"
+        kubectl -n stackrox get deploy,ds -o wide
 
         deploy_default_psp
         deploy_webhook_server


### PR DESCRIPTION
Do not review.
Do not merge.

Just testing prow output for central/sensor compatibility tests.