### PR TITLE
Revert fine-grained host paths for compliance mounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,6 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 - ROX-13500: Previously, deployment YAML check on V1 CronJob workload would cause Central to panic. This is now fixed.
 - `cves.ids` field of `storage.VulnerabilityRequest` object, which is in the response of `VulnerabilityRequestService` (`/v1/cve/requests/`) endpoints, has been renamed to `cves.cves`.
 - ROX-13347: Vulnerability reporting scopes specifying cluster and/or namespace names now perform exact matches on those entities, as opposed to the erroneous prefix match.
-- ROX-9350: The compliance container no longer mounts the entire host root to prevent a recursive mount of other pods' persistent volumes.
 
 ## [3.72.0]
 

--- a/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml
@@ -65,7 +65,8 @@ spec:
           readOnlyRootFilesystem: true
         volumeMounts:
         - mountPath: /host/var/run/docker.sock
-          name: var-run-docker-sock-ro
+          name: var-run
+          subPath: var/run/docker.sock
           readOnly: true
         - mountPath: /host/proc
           name: proc-ro
@@ -76,7 +77,8 @@ spec:
           name: etc-ro
           readOnly: true
         - mountPath: /host/usr/lib
-          name: usr-lib-ro
+          name: usr-ro
+          subPath: usr/lib
           readOnly: true
         - mountPath: /host/sys
           name: sys-ro
@@ -187,9 +189,6 @@ spec:
           path: /usr
         name: usr-ro
       - hostPath:
-          path: /usr/lib
-        name: usr-lib-ro
-      - hostPath:
           path: /lib
         name: lib-ro
       - hostPath:
@@ -207,9 +206,6 @@ spec:
       - hostPath:
           path: /var/run
         name: var-run
-      - hostPath:
-          path: /var/run/docker.sock
-        name: var-run-docker-sock-ro
       - name: certs
         secret:
           secretName: collector-tls

--- a/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml
@@ -65,8 +65,7 @@ spec:
           readOnlyRootFilesystem: true
         volumeMounts:
         - mountPath: /host/var/run/docker.sock
-          name: var-run
-          subPath: var/run/docker.sock
+          name: var-run-docker-sock
           readOnly: true
         - mountPath: /host/proc
           name: proc-ro
@@ -77,8 +76,7 @@ spec:
           name: etc-ro
           readOnly: true
         - mountPath: /host/usr/lib
-          name: usr-ro
-          subPath: usr/lib
+          name: usr-lib-ro
           readOnly: true
         - mountPath: /host/sys
           name: sys-ro
@@ -118,49 +116,16 @@ spec:
           name: etc-ssl
         - mountPath: /etc/pki/ca-trust/
           name: etc-pki-volume
-        - mountPath: /host/etc
-          name: etc-ro
-          readOnly: true
-        - mountPath: /host/proc
-          name: proc-ro
-          readOnly: true
-        - mountPath: /host/opt
-          name: opt-ro
-          readOnly: true
-        - mountPath: /host/run
-          name: run-ro
-          readOnly: true
-        - mountPath: /host/srv
-          name: srv-ro
-          readOnly: true
-        - mountPath: /host/sys
-          name: sys-ro
-          readOnly: true
-        - mountPath: /host/usr
-          name: usr-ro
-          readOnly: true
-        - mountPath: /host/lib
-          name: lib-ro
-          readOnly: true
-        - mountPath: /host/var/lib/kubelet/kubeconfig
-          name: var-lib-kubelet-kubeconfig
-          readOnly: true
-        - mountPath: /host/var/lib/docker
-          name: var-lib-docker
-          readOnly: true
-        - mountPath: /host/var/lib/containers
-          name: var-lib-containers
-          readOnly: true
-        - mountPath: /host/var/log
-          name: var-log
-          readOnly: true
-        - mountPath: /host/var/run
-          name: var-run
+        - mountPath: /host
+          name: host-root-ro
           readOnly: true
         - mountPath: /run/secrets/stackrox.io/certs/
           name: certs
           readOnly: true
       volumes:
+      - hostPath:
+          path: /var/run/docker.sock
+        name: var-run-docker-sock
       - hostPath:
           path: /proc
         name: proc-ro
@@ -171,41 +136,14 @@ spec:
           path: /etc
         name: etc-ro
       - hostPath:
-          path: /sys
+          path: /usr/lib
+        name: usr-lib-ro
+      - hostPath:
+          path: /sys/
         name: sys-ro
       - hostPath:
           path: /dev
         name: dev-ro
-      - hostPath:
-          path: /opt
-        name: opt-ro
-      - hostPath:
-          path: /run
-        name: run-ro
-      - hostPath:
-          path: /srv
-        name: srv-ro
-      - hostPath:
-          path: /usr
-        name: usr-ro
-      - hostPath:
-          path: /lib
-        name: lib-ro
-      - hostPath:
-          path: /var/lib/kubelet/kubeconfig
-        name: var-lib-kubelet-kubeconfig
-      - hostPath:
-          path: /var/lib/docker
-        name: var-lib-docker
-      - hostPath:
-          path: /var/lib/containers
-        name: var-lib-containers
-      - hostPath:
-          path: /var/log
-        name: var-log
-      - hostPath:
-          path: /var/run
-        name: var-run
       - name: certs
         secret:
           secretName: collector-tls
@@ -216,6 +154,9 @@ spec:
             path: key.pem
           - key: ca.pem
             path: ca.pem
+      - hostPath:
+          path: /
+        name: host-root-ro
       - name: etc-ssl
         emptyDir: {}
       - name: etc-pki-volume


### PR DESCRIPTION
## Description

An issue was found in https://issues.redhat.com/browse/ROX-13580 that caused the new compliance mounts to fail due missing `/srv` on COS nodes.

Revert "Fix collector volumeMounts #2479"
Revert "Use fine-grained host paths for compliance mounts #2479"

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
