### PR TITLE
ROX-13357: store refactor

### DIFF
--- a/sensor/common/rbac/namespaced_service_account.go
+++ b/sensor/common/rbac/namespaced_service_account.go
@@ -1,0 +1,7 @@
+package rbac
+
+// NamespacedServiceAccount keeps a pair of service account and used namespace.
+type NamespacedServiceAccount interface {
+	GetServiceAccount() string
+	GetNamespace() string
+}

--- a/sensor/common/service/port_ref.go
+++ b/sensor/common/service/port_ref.go
@@ -1,17 +1,17 @@
-package resources
+package service
 
 import (
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-type portRef struct {
+type PortRef struct {
 	Port     intstr.IntOrString
 	Protocol v1.Protocol
 }
 
-func portRefOf(svcPort v1.ServicePort) portRef {
-	return portRef{
+func PortRefOf(svcPort v1.ServicePort) PortRef {
+	return PortRef{
 		Port:     svcPort.TargetPort,
 		Protocol: svcPort.Protocol,
 	}

--- a/sensor/common/service/port_ref.go
+++ b/sensor/common/service/port_ref.go
@@ -1,15 +1,17 @@
 package service
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
+// PortRef is the reference to a service's port.
 type PortRef struct {
 	Port     intstr.IntOrString
 	Protocol v1.Protocol
 }
 
+// PortRefOf returns a PortRef definition based on a v1.ServicePort spec.
 func PortRefOf(svcPort v1.ServicePort) PortRef {
 	return PortRef{
 		Port:     svcPort.TargetPort,

--- a/sensor/common/store/deployment_dependency.go
+++ b/sensor/common/store/deployment_dependency.go
@@ -1,0 +1,13 @@
+package store
+
+import (
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/sensor/common/service"
+)
+
+// Dependencies are properties that belong to a storage.Deployment object, but don't come directly from the
+// k8s deployment spec. They need to be enhanced from other resources, like RBACs and Services.
+type Dependencies struct {
+	PermissionLevel storage.PermissionLevel
+	Exposures       []map[service.PortRef][]*storage.PortConfig_ExposureInfo
+}

--- a/sensor/common/store/mocks/types.go
+++ b/sensor/common/store/mocks/types.go
@@ -9,6 +9,9 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	storage "github.com/stackrox/rox/generated/storage"
+	rbac "github.com/stackrox/rox/sensor/common/rbac"
+	service "github.com/stackrox/rox/sensor/common/service"
+	store "github.com/stackrox/rox/sensor/common/store"
 )
 
 // MockDeploymentStore is a mock of DeploymentStore interface.
@@ -32,6 +35,21 @@ func NewMockDeploymentStore(ctrl *gomock.Controller) *MockDeploymentStore {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockDeploymentStore) EXPECT() *MockDeploymentStoreMockRecorder {
 	return m.recorder
+}
+
+// BuildDeploymentWithDependencies mocks base method.
+func (m *MockDeploymentStore) BuildDeploymentWithDependencies(id string, dependencies store.Dependencies) (*storage.Deployment, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BuildDeploymentWithDependencies", id, dependencies)
+	ret0, _ := ret[0].(*storage.Deployment)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// BuildDeploymentWithDependencies indicates an expected call of BuildDeploymentWithDependencies.
+func (mr *MockDeploymentStoreMockRecorder) BuildDeploymentWithDependencies(id, dependencies interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildDeploymentWithDependencies", reflect.TypeOf((*MockDeploymentStore)(nil).BuildDeploymentWithDependencies), id, dependencies)
 }
 
 // Get mocks base method.
@@ -275,4 +293,78 @@ func (m *MockServiceAccountStore) Remove(sa *storage.ServiceAccount) {
 func (mr *MockServiceAccountStoreMockRecorder) Remove(sa interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Remove", reflect.TypeOf((*MockServiceAccountStore)(nil).Remove), sa)
+}
+
+// MockServiceStore is a mock of ServiceStore interface.
+type MockServiceStore struct {
+	ctrl     *gomock.Controller
+	recorder *MockServiceStoreMockRecorder
+}
+
+// MockServiceStoreMockRecorder is the mock recorder for MockServiceStore.
+type MockServiceStoreMockRecorder struct {
+	mock *MockServiceStore
+}
+
+// NewMockServiceStore creates a new mock instance.
+func NewMockServiceStore(ctrl *gomock.Controller) *MockServiceStore {
+	mock := &MockServiceStore{ctrl: ctrl}
+	mock.recorder = &MockServiceStoreMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockServiceStore) EXPECT() *MockServiceStoreMockRecorder {
+	return m.recorder
+}
+
+// GetExposureInfos mocks base method.
+func (m *MockServiceStore) GetExposureInfos(namespace string, labels map[string]string) []map[service.PortRef][]*storage.PortConfig_ExposureInfo {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetExposureInfos", namespace, labels)
+	ret0, _ := ret[0].([]map[service.PortRef][]*storage.PortConfig_ExposureInfo)
+	return ret0
+}
+
+// GetExposureInfos indicates an expected call of GetExposureInfos.
+func (mr *MockServiceStoreMockRecorder) GetExposureInfos(namespace, labels interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetExposureInfos", reflect.TypeOf((*MockServiceStore)(nil).GetExposureInfos), namespace, labels)
+}
+
+// MockRBACStore is a mock of RBACStore interface.
+type MockRBACStore struct {
+	ctrl     *gomock.Controller
+	recorder *MockRBACStoreMockRecorder
+}
+
+// MockRBACStoreMockRecorder is the mock recorder for MockRBACStore.
+type MockRBACStoreMockRecorder struct {
+	mock *MockRBACStore
+}
+
+// NewMockRBACStore creates a new mock instance.
+func NewMockRBACStore(ctrl *gomock.Controller) *MockRBACStore {
+	mock := &MockRBACStore{ctrl: ctrl}
+	mock.recorder = &MockRBACStoreMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockRBACStore) EXPECT() *MockRBACStoreMockRecorder {
+	return m.recorder
+}
+
+// GetPermissionLevelForDeployment mocks base method.
+func (m *MockRBACStore) GetPermissionLevelForDeployment(deployment rbac.NamespacedServiceAccount) storage.PermissionLevel {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPermissionLevelForDeployment", deployment)
+	ret0, _ := ret[0].(storage.PermissionLevel)
+	return ret0
+}
+
+// GetPermissionLevelForDeployment indicates an expected call of GetPermissionLevelForDeployment.
+func (mr *MockRBACStoreMockRecorder) GetPermissionLevelForDeployment(deployment interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPermissionLevelForDeployment", reflect.TypeOf((*MockRBACStore)(nil).GetPermissionLevelForDeployment), deployment)
 }

--- a/sensor/common/store/types.go
+++ b/sensor/common/store/types.go
@@ -1,12 +1,17 @@
 package store
 
-import "github.com/stackrox/rox/generated/storage"
+import (
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/sensor/common/rbac"
+	"github.com/stackrox/rox/sensor/common/service"
+)
 
 // DeploymentStore provides functionality to fetch all deployments from underlying store.
 //go:generate mockgen-wrapper
 type DeploymentStore interface {
 	GetAll() []*storage.Deployment
 	Get(id string) *storage.Deployment
+	BuildDeploymentWithDependencies(id string, dependencies Dependencies) (*storage.Deployment, error)
 }
 
 // PodStore provides functionality to fetch all pods from underlying store.
@@ -34,4 +39,16 @@ type ServiceAccountStore interface {
 	Add(sa *storage.ServiceAccount)
 	Remove(sa *storage.ServiceAccount)
 	GetImagePullSecrets(namespace, name string) []string
+}
+
+// ServiceStore provides functionality to find port exposure infos from in-memory services
+//go:generate mockgen-wrapper
+type ServiceStore interface {
+	GetExposureInfos(namespace string, labels map[string]string) []map[service.PortRef][]*storage.PortConfig_ExposureInfo
+}
+
+// RBACStore provides functionality to find permission level from in-memory RBACs
+//go:generate mockgen-wrapper
+type RBACStore interface {
+	GetPermissionLevelForDeployment(deployment rbac.NamespacedServiceAccount) storage.PermissionLevel
 }

--- a/sensor/kubernetes/eventpipeline/pipeline.go
+++ b/sensor/kubernetes/eventpipeline/pipeline.go
@@ -13,13 +13,14 @@ import (
 	"github.com/stackrox/rox/sensor/kubernetes/client"
 	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/output"
 	"github.com/stackrox/rox/sensor/kubernetes/listener"
+	"github.com/stackrox/rox/sensor/kubernetes/listener/resources"
 )
 
 // New instantiates the eventPipeline component
-func New(client client.Interface, configHandler config.Handler, detector detector.Detector, nodeName string, resyncPeriod time.Duration, traceWriter io.Writer) common.SensorComponent {
+func New(client client.Interface, configHandler config.Handler, detector detector.Detector, nodeName string, resyncPeriod time.Duration, traceWriter io.Writer, storeProvider *resources.InMemoryStoreProvider) common.SensorComponent {
 	// TODO(ROX-13413): Move this env.EventPipelineOutputQueueSize to CreateOptions
 	outputQueue := output.New(detector, env.EventPipelineOutputQueueSize.IntegerSetting())
-	resourceListener := listener.New(client, configHandler, nodeName, resyncPeriod, traceWriter, outputQueue)
+	resourceListener := listener.New(client, configHandler, nodeName, resyncPeriod, traceWriter, outputQueue, storeProvider)
 
 	pipelineResponses := make(chan *central.MsgFromSensor)
 	return &eventPipeline{

--- a/sensor/kubernetes/listener/listener.go
+++ b/sensor/kubernetes/listener/listener.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackrox/rox/sensor/common/config"
 	"github.com/stackrox/rox/sensor/kubernetes/client"
 	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/component"
+	"github.com/stackrox/rox/sensor/kubernetes/listener/resources"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -19,7 +20,7 @@ var (
 )
 
 // New returns a new kubernetes listener.
-func New(client client.Interface, configHandler config.Handler, nodeName string, resyncPeriod time.Duration, traceWriter io.Writer, queue component.OutputQueue) component.PipelineComponent {
+func New(client client.Interface, configHandler config.Handler, nodeName string, resyncPeriod time.Duration, traceWriter io.Writer, queue component.OutputQueue, storeProvider *resources.InMemoryStoreProvider) component.PipelineComponent {
 	k := &listenerImpl{
 		client:             client,
 		stopSig:            concurrency.NewSignal(),
@@ -28,6 +29,7 @@ func New(client client.Interface, configHandler config.Handler, nodeName string,
 		resyncPeriod:       resyncPeriod,
 		traceWriter:        traceWriter,
 		outputQueue:        queue,
+		storeProvider:      storeProvider,
 	}
 	return k
 }

--- a/sensor/kubernetes/listener/listener_impl.go
+++ b/sensor/kubernetes/listener/listener_impl.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/sensor/common/config"
 	"github.com/stackrox/rox/sensor/kubernetes/client"
 	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/component"
+	"github.com/stackrox/rox/sensor/kubernetes/listener/resources"
 )
 
 const (
@@ -28,6 +29,7 @@ type listenerImpl struct {
 	resyncPeriod       time.Duration
 	traceWriter        io.Writer
 	outputQueue        component.OutputQueue
+	storeProvider      *resources.InMemoryStoreProvider
 }
 
 func (k *listenerImpl) Start() error {

--- a/sensor/kubernetes/listener/resource_event_handler.go
+++ b/sensor/kubernetes/listener/resource_event_handler.go
@@ -77,6 +77,7 @@ func (k *listenerImpl) handleAllEvents() {
 		orchestratornamespaces.Singleton(),
 		k.credentialsManager,
 		k.traceWriter,
+		k.storeProvider,
 	)
 
 	namespaceInformer := sif.Core().V1().Namespaces().Informer()

--- a/sensor/kubernetes/listener/resources/convert.go
+++ b/sensor/kubernetes/listener/resources/convert.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/rox/pkg/uuid"
 	"github.com/stackrox/rox/sensor/common/registry"
+	"github.com/stackrox/rox/sensor/common/service"
 	"github.com/stackrox/rox/sensor/kubernetes/listener/resources/references"
 	"github.com/stackrox/rox/sensor/kubernetes/orchestratornamespaces"
 	"github.com/stackrox/rox/sensor/kubernetes/selector"
@@ -61,7 +62,7 @@ type deploymentWrap struct {
 	*storage.Deployment
 	registryOverride string
 	original         interface{}
-	portConfigs      map[portRef]*storage.PortConfig
+	portConfigs      map[service.PortRef]*storage.PortConfig
 	pods             []*v1.Pod
 	// registryStore is the image registry store to use when determining if an image is cluster-local.
 	registryStore *registry.Store
@@ -391,12 +392,12 @@ func (w *deploymentWrap) populatePorts() {
 	w.mutex.Lock()
 	defer w.mutex.Unlock()
 
-	w.portConfigs = make(map[portRef]*storage.PortConfig)
+	w.portConfigs = make(map[service.PortRef]*storage.PortConfig)
 	for _, c := range w.GetContainers() {
 		for _, p := range c.GetPorts() {
-			w.portConfigs[portRef{Port: intstr.FromInt(int(p.ContainerPort)), Protocol: v1.Protocol(p.Protocol)}] = p
+			w.portConfigs[service.PortRef{Port: intstr.FromInt(int(p.ContainerPort)), Protocol: v1.Protocol(p.Protocol)}] = p
 			if p.Name != "" {
-				w.portConfigs[portRef{Port: intstr.FromString(p.Name), Protocol: v1.Protocol(p.Protocol)}] = p
+				w.portConfigs[service.PortRef{Port: intstr.FromString(p.Name), Protocol: v1.Protocol(p.Protocol)}] = p
 			}
 		}
 	}
@@ -451,17 +452,17 @@ func (w *deploymentWrap) resetPortExposureNoLock() {
 	}
 }
 
-func (w *deploymentWrap) updatePortExposureFromStore(store *serviceStore) {
-	w.mutex.Lock()
-	defer w.mutex.Unlock()
-
-	w.resetPortExposureNoLock()
-
-	svcs := store.getMatchingServicesWithRoutes(w.Namespace, w.PodLabels)
-	for _, svc := range svcs {
-		w.updatePortExposureUncheckedNoLock(svc)
-	}
-}
+//func (w *deploymentWrap) updatePortExposureFromStore(store *serviceStore) {
+//	w.mutex.Lock()
+//	defer w.mutex.Unlock()
+//
+//	w.resetPortExposureNoLock()
+//
+//	svcs := store.getMatchingServicesWithRoutes(w.Namespace, w.PodLabels)
+//	for _, svc := range svcs {
+//		w.updatePortExposureUncheckedNoLock(svc)
+//	}
+//}
 
 func (w *deploymentWrap) updatePortExposureFromServices(svcs ...serviceWithRoutes) {
 	w.mutex.Lock()
@@ -470,7 +471,7 @@ func (w *deploymentWrap) updatePortExposureFromServices(svcs ...serviceWithRoute
 	w.resetPortExposureNoLock()
 
 	for _, svc := range svcs {
-		w.updatePortExposureUncheckedNoLock(svc)
+		w.updatePortExposureUncheckedNoLock(svc.exposure())
 	}
 }
 
@@ -482,11 +483,22 @@ func (w *deploymentWrap) updatePortExposure(svc serviceWithRoutes) {
 	w.mutex.Lock()
 	defer w.mutex.Unlock()
 
-	w.updatePortExposureUncheckedNoLock(svc)
+	w.updatePortExposureUncheckedNoLock(svc.exposure())
 }
 
-func (w *deploymentWrap) updatePortExposureUncheckedNoLock(svc serviceWithRoutes) {
-	for ref, exposureInfos := range svc.exposure() {
+func (w *deploymentWrap) updatePortExposureFromStorage(portExposures []map[service.PortRef][]*storage.PortConfig_ExposureInfo) {
+	w.mutex.Lock()
+	defer w.mutex.Unlock()
+
+	w.resetPortExposureNoLock()
+
+	for _, exposureInfo := range portExposures {
+		w.updatePortExposureUncheckedNoLock(exposureInfo)
+	}
+}
+
+func (w *deploymentWrap) updatePortExposureUncheckedNoLock(portExposure map[service.PortRef][]*storage.PortConfig_ExposureInfo) {
+	for ref, exposureInfos := range portExposure {
 		portCfg := w.portConfigs[ref]
 		if portCfg == nil {
 			if ref.Port.Type == intstr.String {
@@ -544,7 +556,7 @@ func (w *deploymentWrap) Clone() *deploymentWrap {
 		}
 	}
 	if w.portConfigs != nil {
-		ret.portConfigs = make(map[portRef]*storage.PortConfig)
+		ret.portConfigs = make(map[service.PortRef]*storage.PortConfig)
 		for k, v := range w.portConfigs {
 			ret.portConfigs[k] = v.Clone()
 		}

--- a/sensor/kubernetes/listener/resources/deployment_store.go
+++ b/sensor/kubernetes/listener/resources/deployment_store.go
@@ -143,7 +143,7 @@ func (ds *DeploymentStore) Get(id string) *storage.Deployment {
 	return wrap.GetDeployment()
 }
 
-// BuildDeploymentWithDependencies creates storage.Deployment object using external object dependencies
+// BuildDeploymentWithDependencies creates storage.Deployment object using external object dependencies.
 func (ds *DeploymentStore) BuildDeploymentWithDependencies(id string, dependencies store.Dependencies) (*storage.Deployment, error) {
 	wrap := ds.getWrap(id)
 	clonedWrap := wrap.Clone()

--- a/sensor/kubernetes/listener/resources/deployment_store.go
+++ b/sensor/kubernetes/listener/resources/deployment_store.go
@@ -149,7 +149,7 @@ func (ds *DeploymentStore) BuildDeploymentWithDependencies(id string, dependenci
 	clonedWrap := wrap.Clone()
 
 	clonedWrap.updateServiceAccountPermissionLevel(dependencies.PermissionLevel)
-	clonedWrap.updatePortExposureFromStorage(dependencies.Exposures)
+	clonedWrap.updatePortExposureSlice(dependencies.Exposures)
 	if err := clonedWrap.updateHash(); err != nil {
 		return nil, err
 	}

--- a/sensor/kubernetes/listener/resources/deployment_store.go
+++ b/sensor/kubernetes/listener/resources/deployment_store.go
@@ -1,6 +1,7 @@
 package resources
 
 import (
+	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/sync"
@@ -131,9 +132,6 @@ func (ds *DeploymentStore) getWrap(id string) *deploymentWrap {
 	defer ds.lock.RUnlock()
 
 	wrap := ds.deployments[id]
-	if wrap == nil {
-		return nil
-	}
 	return wrap
 }
 
@@ -146,6 +144,9 @@ func (ds *DeploymentStore) Get(id string) *storage.Deployment {
 // BuildDeploymentWithDependencies creates storage.Deployment object using external object dependencies.
 func (ds *DeploymentStore) BuildDeploymentWithDependencies(id string, dependencies store.Dependencies) (*storage.Deployment, error) {
 	wrap := ds.getWrap(id)
+	if wrap != nil {
+		return nil, errors.Errorf("deployment with ID %s doesn't exist in the internal deployment store", id)
+	}
 	clonedWrap := wrap.Clone()
 
 	clonedWrap.updateServiceAccountPermissionLevel(dependencies.PermissionLevel)

--- a/sensor/kubernetes/listener/resources/deployment_store.go
+++ b/sensor/kubernetes/listener/resources/deployment_store.go
@@ -144,7 +144,7 @@ func (ds *DeploymentStore) Get(id string) *storage.Deployment {
 // BuildDeploymentWithDependencies creates storage.Deployment object using external object dependencies.
 func (ds *DeploymentStore) BuildDeploymentWithDependencies(id string, dependencies store.Dependencies) (*storage.Deployment, error) {
 	wrap := ds.getWrap(id)
-	if wrap != nil {
+	if wrap == nil {
 		return nil, errors.Errorf("deployment with ID %s doesn't exist in the internal deployment store", id)
 	}
 	clonedWrap := wrap.Clone()

--- a/sensor/kubernetes/listener/resources/deployment_store_test.go
+++ b/sensor/kubernetes/listener/resources/deployment_store_test.go
@@ -1,0 +1,107 @@
+package resources
+
+import (
+	"testing"
+
+	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/uuid"
+	"github.com/stackrox/rox/sensor/common/registry"
+	"github.com/stackrox/rox/sensor/common/service"
+	"github.com/stackrox/rox/sensor/common/store"
+	"github.com/stackrox/rox/sensor/kubernetes/orchestratornamespaces"
+	"github.com/stretchr/testify/suite"
+	v1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+type deploymentStoreSuite struct {
+	suite.Suite
+	deploymentStore *DeploymentStore
+	namespaceStore  *namespaceStore
+	mockPodLister   *mockPodLister
+}
+
+func TestDeploymentStoreSuite(t *testing.T) {
+	suite.Run(t, new(deploymentStoreSuite))
+}
+
+var _ suite.SetupTestSuite = &deploymentStoreSuite{}
+
+func (s *deploymentStoreSuite) SetupTest() {
+	s.namespaceStore = newNamespaceStore()
+	s.namespaceStore.addNamespace(&storage.NamespaceMetadata{Name: "test-ns", Id: "1"})
+	s.deploymentStore = newDeploymentStore()
+	s.mockPodLister = &mockPodLister{}
+}
+
+func (s *deploymentStoreSuite) createDeploymentWrap(deploymentObj interface{}) *deploymentWrap {
+	action := central.ResourceAction_CREATE_RESOURCE
+	wrap := newDeploymentEventFromResource(deploymentObj, &action,
+		"deployment", "", s.mockPodLister, s.namespaceStore, hierarchyFromPodLister(s.mockPodLister), "", orchestratornamespaces.Singleton(), registry.Singleton())
+	return wrap
+}
+
+func (s *deploymentStoreSuite) Test_BuildDeploymentWithDependencies() {
+	uid := uuid.NewV4()
+	wrap := s.createDeploymentWrap(makeDeploymentObject("test-deployment", "test-ns", types.UID(uid.String())))
+	s.deploymentStore.addOrUpdateDeployment(wrap)
+
+	expectedExposureInfo := storage.PortConfig_ExposureInfo{
+		Level:       storage.PortConfig_EXTERNAL,
+		ServiceName: "test.service",
+		ServicePort: 5432,
+	}
+
+	deployment, err := s.deploymentStore.BuildDeploymentWithDependencies(uid.String(), store.Dependencies{
+		PermissionLevel: storage.PermissionLevel_CLUSTER_ADMIN,
+		Exposures: []map[service.PortRef][]*storage.PortConfig_ExposureInfo{
+			{
+				service.PortRefOf(stubService()): []*storage.PortConfig_ExposureInfo{&expectedExposureInfo},
+			},
+		},
+	})
+
+	s.NoError(err, "should not have error building dependencies")
+
+	s.Require().Len(deployment.GetPorts(), 1)
+	s.Require().Len(deployment.GetPorts()[0].GetExposureInfos(), 1)
+
+	s.Equal(expectedExposureInfo, *deployment.GetPorts()[0].GetExposureInfos()[0])
+	s.Equal(storage.PermissionLevel_CLUSTER_ADMIN, deployment.GetServiceAccountPermissionLevel(), "Service account permission level")
+}
+
+func (s *deploymentStoreSuite) Test_BuildDeploymentWithDependencies_NoDeployment() {
+	_, err := s.deploymentStore.BuildDeploymentWithDependencies("some-uuid", store.Dependencies{
+		PermissionLevel: storage.PermissionLevel_CLUSTER_ADMIN,
+		Exposures:       []map[service.PortRef][]*storage.PortConfig_ExposureInfo{},
+	})
+
+	s.ErrorContains(err, "some-uuid doesn't exist")
+}
+
+func makeDeploymentObject(name, namespace string, id types.UID) *v1.Deployment {
+	return &v1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			UID:       id,
+		},
+	}
+}
+
+func stubService() corev1.ServicePort {
+	return corev1.ServicePort{
+		Name:        "test.service",
+		Protocol:    "TCP",
+		AppProtocol: nil,
+		Port:        5432,
+		TargetPort: intstr.IntOrString{
+			IntVal: 4321,
+		},
+		NodePort: 0,
+	}
+}

--- a/sensor/kubernetes/listener/resources/deployments.go
+++ b/sensor/kubernetes/listener/resources/deployments.go
@@ -165,7 +165,8 @@ func (d *deploymentHandler) processWithType(obj, oldObj interface{}, action cent
 		return events
 	}
 
-	deploymentWrap.updatePortExposureFromStore(d.serviceStore)
+	services := d.serviceStore.getMatchingServicesWithRoutes(deploymentWrap.GetNamespace(), deploymentWrap.PodLabels)
+	deploymentWrap.updatePortExposureFromServices(services...)
 	if action != central.ResourceAction_REMOVE_RESOURCE {
 		// Make sure to clone and add deploymentWrap to the store if this function is being used at places other than
 		// right after deploymentWrap object creation.

--- a/sensor/kubernetes/listener/resources/deployments.go
+++ b/sensor/kubernetes/listener/resources/deployments.go
@@ -165,8 +165,8 @@ func (d *deploymentHandler) processWithType(obj, oldObj interface{}, action cent
 		return events
 	}
 
-	services := d.serviceStore.getMatchingServicesWithRoutes(deploymentWrap.GetNamespace(), deploymentWrap.PodLabels)
-	deploymentWrap.updatePortExposureFromServices(services...)
+	exposureInfos := d.serviceStore.GetExposureInfos(deploymentWrap.GetNamespace(), deploymentWrap.PodLabels)
+	deploymentWrap.updatePortExposureSlice(exposureInfos)
 	if action != central.ResourceAction_REMOVE_RESOURCE {
 		// Make sure to clone and add deploymentWrap to the store if this function is being used at places other than
 		// right after deploymentWrap object creation.

--- a/sensor/kubernetes/listener/resources/deployments.go
+++ b/sensor/kubernetes/listener/resources/deployments.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stackrox/rox/sensor/common/awscredentials"
 	"github.com/stackrox/rox/sensor/common/config"
 	"github.com/stackrox/rox/sensor/common/registry"
+	"github.com/stackrox/rox/sensor/common/store"
 	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/component"
 	"github.com/stackrox/rox/sensor/kubernetes/listener/resources/rbac"
 	"github.com/stackrox/rox/sensor/kubernetes/listener/resources/references"
@@ -66,7 +67,7 @@ func (d *deploymentDispatcherImpl) ProcessEvent(obj, oldObj interface{}, action 
 // deploymentHandler handles deployment resource events and does the actual processing.
 type deploymentHandler struct {
 	podLister              v1listers.PodLister
-	serviceStore           *serviceStore
+	serviceStore           store.ServiceStore
 	deploymentStore        *DeploymentStore
 	podStore               *PodStore
 	endpointManager        endpointManager
@@ -85,7 +86,7 @@ type deploymentHandler struct {
 // newDeploymentHandler creates and returns a new deployment handler.
 func newDeploymentHandler(
 	clusterID string,
-	serviceStore *serviceStore,
+	serviceStore store.ServiceStore,
 	deploymentStore *DeploymentStore,
 	podStore *PodStore,
 	endpointManager endpointManager,

--- a/sensor/kubernetes/listener/resources/dispatcher.go
+++ b/sensor/kubernetes/listener/resources/dispatcher.go
@@ -65,8 +65,10 @@ func NewDispatcherRegistry(
 	namespaces *orchestratornamespaces.OrchestratorNamespaces,
 	credentialsManager awscredentials.RegistryCredentialsManager,
 	traceWriter io.Writer,
+	storeProvider *InMemoryStoreProvider,
 ) DispatcherRegistry {
-	serviceStore := newServiceStore()
+	serviceStore := storeProvider.serviceStore
+	rbacUpdater := storeProvider.rbacStore
 	serviceAccountStore := ServiceAccountStoreSingleton()
 	deploymentStore := DeploymentStoreSingleton()
 	podStore := PodStoreSingleton()
@@ -74,7 +76,6 @@ func NewDispatcherRegistry(
 	nsStore := newNamespaceStore()
 	netPolicyStore := NetworkPolicySingleton()
 	endpointManager := newEndpointManager(serviceStore, deploymentStore, podStore, nodeStore, entityStore)
-	rbacUpdater := rbac.NewStore()
 	portExposureReconciler := newPortExposureReconciler(deploymentStore, serviceStore)
 	registryStore := registry.Singleton()
 

--- a/sensor/kubernetes/listener/resources/dispatcher.go
+++ b/sensor/kubernetes/listener/resources/dispatcher.go
@@ -76,11 +76,11 @@ func NewDispatcherRegistry(
 	nsStore := newNamespaceStore()
 	netPolicyStore := NetworkPolicySingleton()
 	endpointManager := newEndpointManager(serviceStore, deploymentStore, podStore, nodeStore, entityStore)
-	portExposureReconciler := newPortExposureReconciler(deploymentStore, serviceStore)
+	portExposureReconciler := newPortExposureReconciler(deploymentStore, storeProvider.Services())
 	registryStore := registry.Singleton()
 
 	return &registryImpl{
-		deploymentHandler: newDeploymentHandler(clusterID, serviceStore, deploymentStore, podStore, endpointManager, nsStore,
+		deploymentHandler: newDeploymentHandler(clusterID, storeProvider.Services(), deploymentStore, podStore, endpointManager, nsStore,
 			rbacUpdater, podLister, processFilter, configHandler, namespaces, registryStore, credentialsManager),
 
 		rbacDispatcher:            rbac.NewDispatcher(rbacUpdater),
@@ -89,7 +89,7 @@ func NewDispatcherRegistry(
 		osRouteDispatcher:         newRouteDispatcher(serviceStore, portExposureReconciler),
 		secretDispatcher:          newSecretDispatcher(registryStore),
 		networkPolicyDispatcher:   newNetworkPolicyDispatcher(netPolicyStore, deploymentStore),
-		nodeDispatcher:            newNodeDispatcher(serviceStore, deploymentStore, nodeStore, endpointManager),
+		nodeDispatcher:            newNodeDispatcher(deploymentStore, nodeStore, endpointManager),
 		serviceAccountDispatcher:  newServiceAccountDispatcher(serviceAccountStore),
 		clusterOperatorDispatcher: newClusterOperatorDispatcher(namespaces),
 

--- a/sensor/kubernetes/listener/resources/endpoints.go
+++ b/sensor/kubernetes/listener/resources/endpoints.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stackrox/rox/pkg/net"
 	podUtils "github.com/stackrox/rox/pkg/pods/utils"
 	"github.com/stackrox/rox/sensor/common/clusterentities"
+	"github.com/stackrox/rox/sensor/common/service"
 	"github.com/stackrox/rox/sensor/kubernetes/selector"
 	v1 "k8s.io/api/core/v1"
 )
@@ -157,7 +158,7 @@ func addEndpointDataForServicePort(deployment *deploymentWrap, serviceIPs []net.
 	targetInfo := clusterentities.EndpointTargetInfo{
 		PortName: port.Name,
 	}
-	if portCfg := deployment.portConfigs[portRefOf(port)]; portCfg != nil {
+	if portCfg := deployment.portConfigs[service.PortRefOf(port)]; portCfg != nil {
 		targetInfo.ContainerPort = uint16(portCfg.ContainerPort)
 	} else {
 		targetInfo.ContainerPort = uint16(port.TargetPort.IntValue())

--- a/sensor/kubernetes/listener/resources/endpoints.go
+++ b/sensor/kubernetes/listener/resources/endpoints.go
@@ -217,7 +217,7 @@ func (m *endpointManagerImpl) OnNodeCreate(node *nodeWrap) {
 	}
 
 	updates := make(map[string]*clusterentities.EntityData)
-	for _, svc := range m.serviceStore.NodePortServicesSnapshot() {
+	for _, svc := range m.serviceStore.nodePortServicesSnapshot() {
 		for _, deployment := range m.deploymentStore.getMatchingDeployments(svc.Namespace, svc.selector) {
 			update, ok := updates[deployment.GetId()]
 			if !ok {
@@ -238,7 +238,7 @@ func (m *endpointManagerImpl) OnNodeCreate(node *nodeWrap) {
 func (m *endpointManagerImpl) OnNodeUpdateOrRemove() {
 	affectedDeployments := make(map[*deploymentWrap]struct{})
 
-	for _, svc := range m.serviceStore.NodePortServicesSnapshot() {
+	for _, svc := range m.serviceStore.nodePortServicesSnapshot() {
 		for _, deployment := range m.deploymentStore.getMatchingDeployments(svc.Namespace, svc.selector) {
 			affectedDeployments[deployment] = struct{}{}
 		}

--- a/sensor/kubernetes/listener/resources/node.go
+++ b/sensor/kubernetes/listener/resources/node.go
@@ -11,15 +11,13 @@ import (
 )
 
 type nodeDispatcher struct {
-	serviceStore    *serviceStore
 	deploymentStore *DeploymentStore
 	nodeStore       *nodeStore
 	endpointManager endpointManager
 }
 
-func newNodeDispatcher(serviceStore *serviceStore, deploymentStore *DeploymentStore, nodeStore *nodeStore, endpointManager endpointManager) *nodeDispatcher {
+func newNodeDispatcher(deploymentStore *DeploymentStore, nodeStore *nodeStore, endpointManager endpointManager) *nodeDispatcher {
 	return &nodeDispatcher{
-		serviceStore:    serviceStore,
 		deploymentStore: deploymentStore,
 		nodeStore:       nodeStore,
 		endpointManager: endpointManager,

--- a/sensor/kubernetes/listener/resources/port_exposure_reconciler.go
+++ b/sensor/kubernetes/listener/resources/port_exposure_reconciler.go
@@ -27,12 +27,11 @@ func newPortExposureReconciler(deploymentStore *DeploymentStore, serviceStore *s
 func (p *portExposureReconcilerImpl) UpdateExposuresForMatchingDeployments(namespace string, sel selector.Selector) []*central.SensorEvent {
 	var events []*central.SensorEvent
 	for _, deploymentWrap := range p.deploymentStore.getMatchingDeployments(namespace, sel) {
-		if svcs := p.serviceStore.getMatchingServicesWithRoutes(deploymentWrap.Namespace, deploymentWrap.PodLabels); len(svcs) > 0 || deploymentWrap.anyNonHostPort() {
+		if exposureInfo := p.serviceStore.GetExposureInfos(deploymentWrap.Namespace, deploymentWrap.PodLabels); len(exposureInfo) > 0 || deploymentWrap.anyNonHostPort() {
 			cloned := deploymentWrap.Clone()
-			cloned.updatePortExposureFromServices(svcs...)
+			cloned.updatePortExposureSlice(exposureInfo)
 			p.deploymentStore.addOrUpdateDeployment(cloned)
 		}
-
 		events = append(events, deploymentWrap.toEvent(central.ResourceAction_UPDATE_RESOURCE))
 	}
 	return events
@@ -41,8 +40,11 @@ func (p *portExposureReconcilerImpl) UpdateExposuresForMatchingDeployments(names
 func (p *portExposureReconcilerImpl) UpdateExposureOnServiceCreate(svc serviceWithRoutes) []*central.SensorEvent {
 	var events []*central.SensorEvent
 	for _, deploymentWrap := range p.deploymentStore.getMatchingDeployments(svc.Namespace, svc.selector) {
+		if svc.selector.Matches(selector.CreateLabelsWithLen(deploymentWrap.PodLabels)) {
+			continue
+		}
 		cloned := deploymentWrap.Clone()
-		cloned.updatePortExposure(svc)
+		cloned.updatePortExposure(svc.exposure())
 		p.deploymentStore.addOrUpdateDeployment(cloned)
 		events = append(events, cloned.toEvent(central.ResourceAction_UPDATE_RESOURCE))
 	}

--- a/sensor/kubernetes/listener/resources/port_exposure_reconciler.go
+++ b/sensor/kubernetes/listener/resources/port_exposure_reconciler.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stackrox/rox/sensor/common/store"
 	"github.com/stackrox/rox/sensor/kubernetes/selector"
 )
 
@@ -14,10 +15,10 @@ type portExposureReconciler interface {
 
 type portExposureReconcilerImpl struct {
 	deploymentStore *DeploymentStore
-	serviceStore    *serviceStore
+	serviceStore    store.ServiceStore
 }
 
-func newPortExposureReconciler(deploymentStore *DeploymentStore, serviceStore *serviceStore) portExposureReconciler {
+func newPortExposureReconciler(deploymentStore *DeploymentStore, serviceStore store.ServiceStore) portExposureReconciler {
 	return &portExposureReconcilerImpl{
 		deploymentStore: deploymentStore,
 		serviceStore:    serviceStore,

--- a/sensor/kubernetes/listener/resources/rbac/store.go
+++ b/sensor/kubernetes/listener/resources/rbac/store.go
@@ -2,14 +2,9 @@ package rbac
 
 import (
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/sensor/common/rbac"
 	v1 "k8s.io/api/rbac/v1"
 )
-
-// NamespacedServiceAccount keeps a pair of service account and used namespace.
-type NamespacedServiceAccount interface {
-	GetServiceAccount() string
-	GetNamespace() string
-}
 
 // Store handles correlating updates to K8s rbac types and generates events from them.
 type Store interface {
@@ -26,7 +21,7 @@ type Store interface {
 
 	UpsertClusterBinding(binding *v1.ClusterRoleBinding)
 	RemoveClusterBinding(binding *v1.ClusterRoleBinding)
-	GetPermissionLevelForDeployment(deployment NamespacedServiceAccount) storage.PermissionLevel
+	GetPermissionLevelForDeployment(deployment rbac.NamespacedServiceAccount) storage.PermissionLevel
 }
 
 // NewStore creates a new instance of Store

--- a/sensor/kubernetes/listener/resources/rbac/store_impl.go
+++ b/sensor/kubernetes/listener/resources/rbac/store_impl.go
@@ -4,6 +4,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/sync"
+	"github.com/stackrox/rox/sensor/common/rbac"
 	v1 "k8s.io/api/rbac/v1"
 )
 
@@ -21,7 +22,7 @@ type storeImpl struct {
 	dirty           bool
 }
 
-func (rs *storeImpl) GetPermissionLevelForDeployment(d NamespacedServiceAccount) storage.PermissionLevel {
+func (rs *storeImpl) GetPermissionLevelForDeployment(d rbac.NamespacedServiceAccount) storage.PermissionLevel {
 	subject := &storage.Subject{
 		Kind:      storage.SubjectKind_SERVICE_ACCOUNT,
 		Name:      d.GetServiceAccount(),

--- a/sensor/kubernetes/listener/resources/service_store.go
+++ b/sensor/kubernetes/listener/resources/service_store.go
@@ -2,7 +2,9 @@ package resources
 
 import (
 	routeV1 "github.com/openshift/api/route/v1"
+	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/sync"
+	"github.com/stackrox/rox/sensor/common/service"
 	"github.com/stackrox/rox/sensor/kubernetes/selector"
 	v1 "k8s.io/api/core/v1"
 	k8sLabels "k8s.io/apimachinery/pkg/labels"
@@ -147,6 +149,14 @@ func (ss *serviceStore) getMatchingServicesWithRoutes(namespace string, labels m
 		}
 	}
 	return matching
+}
+
+// GetExposureInfos returns all port exposure definition for services matching a namespace and a set of labels.
+func (ss *serviceStore) GetExposureInfos(namespace string, labels map[string]string) (result []map[service.PortRef][]*storage.PortConfig_ExposureInfo) {
+	for _, svc := range ss.getMatchingServicesWithRoutes(namespace, labels) {
+		result = append(result, svc.exposure())
+	}
+	return
 }
 
 func (ss *serviceStore) getService(namespace string, name string) *serviceWrap {

--- a/sensor/kubernetes/listener/resources/service_store.go
+++ b/sensor/kubernetes/listener/resources/service_store.go
@@ -102,8 +102,8 @@ func (ss *serviceStore) addOrUpdateService(svc *serviceWrap) {
 	}
 }
 
-// NodePortServicesSnapshot returns a snapshot of the service wraps
-func (ss *serviceStore) NodePortServicesSnapshot() []*serviceWrap {
+// nodePortServicesSnapshot returns a snapshot of the service wraps
+func (ss *serviceStore) nodePortServicesSnapshot() []*serviceWrap {
 	ss.lock.RLock()
 	defer ss.lock.RUnlock()
 

--- a/sensor/kubernetes/listener/resources/store_provider.go
+++ b/sensor/kubernetes/listener/resources/store_provider.go
@@ -1,0 +1,30 @@
+package resources
+
+import (
+	"github.com/stackrox/rox/sensor/common/store"
+	"github.com/stackrox/rox/sensor/kubernetes/listener/resources/rbac"
+)
+
+// InMemoryStoreProvider holds all stores used in sensor and exposes a public interface for each that can be used outside of the listeners.
+type InMemoryStoreProvider struct {
+	serviceStore *serviceStore
+	rbacStore    rbac.Store
+}
+
+// InitializeStore creates the store instances
+func InitializeStore() *InMemoryStoreProvider {
+	return &InMemoryStoreProvider{
+		serviceStore: newServiceStore(),
+		rbacStore:    rbac.NewStore(),
+	}
+}
+
+// Services returns the service store public interface
+func (p *InMemoryStoreProvider) Services() store.ServiceStore {
+	return p.serviceStore
+}
+
+// RBAC returns the RBAC store public interface
+func (p *InMemoryStoreProvider) RBAC() store.RBACStore {
+	return p.rbacStore
+}

--- a/sensor/kubernetes/sensor/sensor.go
+++ b/sensor/kubernetes/sensor/sensor.go
@@ -101,9 +101,12 @@ func CreateSensor(cfg *CreateOptions) (*sensor.Sensor, error) {
 		return nil, errors.Wrap(err, "creating enforcer")
 	}
 
+	// TODO: Move other singleton stores into the store provider
+	storeProvider := resources.InitializeStore()
+
 	imageCache := expiringcache.NewExpiringCache(env.ReprocessInterval.DurationSetting())
 	policyDetector := detector.New(enforcer, admCtrlSettingsMgr, resources.DeploymentStoreSingleton(), resources.ServiceAccountStoreSingleton(), imageCache, auditLogEventsInput, auditLogCollectionManager, resources.NetworkPolicySingleton())
-	pipeline := eventpipeline.New(cfg.k8sClient, configHandler, policyDetector, k8sNodeName.Setting(), cfg.resyncPeriod, cfg.traceWriter)
+	pipeline := eventpipeline.New(cfg.k8sClient, configHandler, policyDetector, k8sNodeName.Setting(), cfg.resyncPeriod, cfg.traceWriter, storeProvider)
 	admCtrlMsgForwarder := admissioncontroller.NewAdmCtrlMsgForwarder(admCtrlSettingsMgr, pipeline)
 
 	imageService := image.NewService(imageCache, registry.Singleton())

--- a/sensor/kubernetes/sensor/sensor.go
+++ b/sensor/kubernetes/sensor/sensor.go
@@ -101,7 +101,7 @@ func CreateSensor(cfg *CreateOptions) (*sensor.Sensor, error) {
 		return nil, errors.Wrap(err, "creating enforcer")
 	}
 
-	// TODO: Move other singleton stores into the store provider
+	// TODO(ROX-13603): Move other singleton stores into the store provider
 	storeProvider := resources.InitializeStore()
 
 	imageCache := expiringcache.NewExpiringCache(env.ReprocessInterval.DurationSetting())


### PR DESCRIPTION
## Description

This is the third attempt on refactoring the in memory stores to accommodate the follow-up changes required by re-sync. 

1. The first approach, was to move store implementation to `sensor/common/store`, which meant also pulling up all wrappers and exposing them publicly. (PR #3663)
2. The second approach was about splitting the wrapper, parsing and store into different package (`sensor/common/store`, `sensor/kubernetes/convert` and `sensor/kubernetes/store`). Which made the code more complex and prone to cyclic dependencies. (draft, no PR)
3. This approach is about slightly changing the exposed APIs to only expose `storage.*` type objects and no wrappers. This way, there's no need to make wrappers and parsing logic public. (This PR)

The good thing about this approach is that it doesn't force a big design change in the stores nor the wrappers.

Additionally, rather than adding singletons for services and RBAC stores, a new entity store provider entity was created. This allows stores to be injected as dependencies to sensor components rather than access globally using a singleton. Ideally, other global stores (e.g. Deployments and Network Policies) should also move to the store provider. [This closed ticket](https://issues.redhat.com/browse/ROX-11027) was meant to solve this, but we found a workaround in the tests and the root of the problem was never fixed.

Another added bonus is that the deployment wrap functions no longer depends on service wraps. They take the storage type parameters for port exposure instead.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
