### PR TITLE
CI: Use COS for some E2E

### DIFF
--- a/scripts/ci/jobs/gke_postgres_qa_e2e_tests.py
+++ b/scripts/ci/jobs/gke_postgres_qa_e2e_tests.py
@@ -7,8 +7,9 @@ import os
 from base_qa_e2e_test import make_qa_e2e_test_runner
 from clusters import GKECluster
 
-# set required test parameters
+# set test parameters
 os.environ["ORCHESTRATOR_FLAVOR"] = "k8s"
+os.environ["GCP_IMAGE_TYPE"] = "cos_containerd"
 
 # use postgres
 os.environ["ROX_POSTGRES_DATASTORE"] = "true"

--- a/scripts/ci/jobs/gke_qa_e2e_tests.py
+++ b/scripts/ci/jobs/gke_qa_e2e_tests.py
@@ -7,8 +7,9 @@ import os
 from base_qa_e2e_test import make_qa_e2e_test_runner
 from clusters import GKECluster
 
-# set required test parameters
+# set test parameters
 os.environ["ORCHESTRATOR_FLAVOR"] = "k8s"
+os.environ["GCP_IMAGE_TYPE"] = "cos_containerd"
 
 # don't use postgres
 os.environ["ROX_POSTGRES_DATASTORE"] = "false"

--- a/scripts/ci/jobs/gke_race_condition_qa_e2e_tests.py
+++ b/scripts/ci/jobs/gke_race_condition_qa_e2e_tests.py
@@ -7,8 +7,9 @@ import os
 from base_qa_e2e_test import make_qa_e2e_test_runner
 from clusters import GKECluster
 
-# set required test parameters
+# set test parameters
 os.environ["ORCHESTRATOR_FLAVOR"] = "k8s"
+os.environ["GCP_IMAGE_TYPE"] = "cos_containerd"
 
 # use -rcd image for stackrox/main
 os.environ["MAIN_IMAGE_TAG"] = os.environ["STACKROX_BUILD_TAG"] + "-rcd"

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -40,7 +40,6 @@ export_test_environment() {
     ci_export ADMISSION_CONTROLLER_UPDATES "${ADMISSION_CONTROLLER_UPDATES:-true}"
     ci_export ADMISSION_CONTROLLER "${ADMISSION_CONTROLLER:-true}"
     ci_export COLLECTION_METHOD "${COLLECTION_METHOD:-ebpf}"
-    ci_export GCP_IMAGE_TYPE "${GCP_IMAGE_TYPE:-COS}"
     ci_export LOAD_BALANCER "${LOAD_BALANCER:-lb}"
     ci_export LOCAL_PORT "${LOCAL_PORT:-443}"
     ci_export MONITORING_SUPPORT "${MONITORING_SUPPORT:-false}"


### PR DESCRIPTION
## Description

COS==Googles container optimized OS. In Circle CI, the gke-e2e + postgres + -race flavors used that node image type. This PR reverts to that behavior. And uses containerd as required with GKE going forward.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

CI flavors affected + all tests.
