### PR TITLE
UI dev dependencies typescript 4.9.3

### DIFF
--- a/ui/apps/platform/package.json
+++ b/ui/apps/platform/package.json
@@ -167,7 +167,7 @@
         "redux-immutable-state-invariant": "^2.1.0",
         "redux-saga-test-plan": "^3.7.0",
         "tailwindcss": "^2.0.3",
-        "typescript": "^4.8.4"
+        "typescript": "^4.9.3"
     },
     "browserslist": [
         ">0.2%",

--- a/ui/apps/platform/src/Containers/Clusters/ClustersSidePanel.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClustersSidePanel.tsx
@@ -28,7 +28,6 @@ import DownloadHelmValues from './DownloadHelmValues';
 import {
     clusterDetailPollingInterval,
     newClusterDefault,
-    wizardSteps,
     centralEnvDefault,
 } from './cluster.helpers';
 import { CentralEnv, ClusterManagerType } from './clusterTypes';
@@ -47,6 +46,8 @@ const validate = (values) => {
     return errors;
 };
 
+type WizardStep = 'FORM' | 'DEPLOYMENT';
+
 type MessageState = {
     type: 'warn' | 'error';
     message: JSX.Element | string;
@@ -62,7 +63,7 @@ function ClustersSidePanel({ selectedClusterId, setSelectedClusterId }) {
     const [clusterRetentionInfo, setClusterRetentionInfo] =
         useState<DecommissionedClusterRetentionInfo>(null);
     const [centralEnv, setCentralEnv] = useState<CentralEnv>(centralEnvDefault);
-    const [wizardStep, setWizardStep] = useState(wizardSteps.FORM);
+    const [wizardStep, setWizardStep] = useState<WizardStep>('FORM');
     const [loadingCounter, setLoadingCounter] = useState(0);
     const [messageState, setMessageState] = useState<MessageState | null>(null);
     const [isBlocked, setIsBlocked] = useState(false);
@@ -78,7 +79,7 @@ function ClustersSidePanel({ selectedClusterId, setSelectedClusterId }) {
         setSelectedCluster(defaultCluster);
         setMessageState(null);
         setIsBlocked(false);
-        setWizardStep(wizardSteps.FORM);
+        setWizardStep('FORM');
         setPollingDelay(null);
     }
 
@@ -139,7 +140,7 @@ function ClustersSidePanel({ selectedClusterId, setSelectedClusterId }) {
                             setPollingDelay(null);
                         }
 
-                        if (wizardStep === wizardSteps.FORM) {
+                        if (wizardStep === 'FORM') {
                             switch (managerType(cluster)) {
                                 case 'MANAGER_TYPE_HELM_CHART':
                                     setMessageState({
@@ -244,7 +245,7 @@ function ClustersSidePanel({ selectedClusterId, setSelectedClusterId }) {
     }
 
     function onNext() {
-        if (wizardStep === wizardSteps.FORM) {
+        if (wizardStep === 'FORM') {
             setMessageState(null);
             setSubmissionError('');
             saveCluster(selectedCluster)
@@ -259,7 +260,7 @@ function ClustersSidePanel({ selectedClusterId, setSelectedClusterId }) {
                     const clusterWithId = { ...selectedCluster, id: newId };
                     setSelectedCluster(clusterWithId);
 
-                    setWizardStep(wizardSteps.DEPLOYMENT);
+                    setWizardStep('DEPLOYMENT');
 
                     if (!selectedCluster?.healthStatus?.lastContact) {
                         setPollingDelay(clusterDetailPollingInterval);
@@ -306,7 +307,7 @@ function ClustersSidePanel({ selectedClusterId, setSelectedClusterId }) {
     const selectedClusterName = (selectedCluster && selectedCluster.name) || '';
 
     // @TODO: improve error handling when adding support for new clusters
-    const isForm = wizardStep === wizardSteps.FORM;
+    const isForm = wizardStep === 'FORM';
     const iconClassName = 'h-4 w-4';
 
     const panelButtons = isBlocked ? (
@@ -359,7 +360,7 @@ function ClustersSidePanel({ selectedClusterId, setSelectedClusterId }) {
                             </div>
                         </div>
                     )}
-                    {!isBlocked && wizardStep === wizardSteps.FORM && (
+                    {!isBlocked && wizardStep === 'FORM' && (
                         <ClusterEditForm
                             centralEnv={centralEnv}
                             centralVersion={metadata.version}
@@ -371,7 +372,7 @@ function ClustersSidePanel({ selectedClusterId, setSelectedClusterId }) {
                             isLoading={loadingCounter > 0}
                         />
                     )}
-                    {!isBlocked && wizardStep === wizardSteps.DEPLOYMENT && (
+                    {!isBlocked && wizardStep === 'DEPLOYMENT' && (
                         <div className="flex flex-col md:flex-row p-4">
                             <ClusterDeployment
                                 editing={!!selectedCluster}

--- a/ui/apps/platform/src/Containers/Clusters/cluster.helpers.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/cluster.helpers.tsx
@@ -541,11 +541,6 @@ export function getUpgradeableClusters(clusters = []) {
     });
 }
 
-export const wizardSteps = Object.freeze({
-    FORM: 'FORM',
-    DEPLOYMENT: 'DEPLOYMENT',
-});
-
 export default {
     runtimeOptions,
     clusterTypeOptions,
@@ -554,5 +549,4 @@ export default {
     newClusterDefault,
     findUpgradeState,
     isUpToDateStateObject,
-    wizardSteps,
 };

--- a/ui/packages/ui-components/package.json
+++ b/ui/packages/ui-components/package.json
@@ -80,6 +80,6 @@
         "react-dom": "^17.0.2",
         "tailwindcss": "^2.0.3",
         "ts-jest": "^26.5.6",
-        "typescript": "^4.8.4"
+        "typescript": "^4.9.3"
     }
 }

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -18850,10 +18850,10 @@ typeface-open-sans@^1.1.13:
   resolved "https://registry.yarnpkg.com/typeface-open-sans/-/typeface-open-sans-1.1.13.tgz#32a09ebd7df59601e01ad81216f98ce641eeafd1"
   integrity sha512-lVGVHvYl7UJDFB9vN8r7NHw3sVm7Rjeow6b9AeABc/J+2mDaCkmcdVtw3QZnsJW39P+xm5zeggIj9gLHYGn9Iw==
 
-typescript@^4.8.4:
-  version "4.8.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
-  integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
+typescript@^4.9.3:
+  version "4.9.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.3.tgz#3aea307c1746b8c384435d8ac36b8a2e580d85db"
+  integrity sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==
 
 uglify-js@^3.1.4:
   version "3.13.7"


### PR DESCRIPTION
## Description

TypeScript releases a minor update every quarter.

https://github.com/microsoft/TypeScript/releases/tag/v4.9.3

1. https://devblogs.microsoft.com/typescript/announcing-typescript-4-9/#the-satisfies-operator

    > TypeScript developers are often faced with a dilemma: we want to ensure that some expression *matches* some type, but also want to keep the *most specific* type of that expression for inference purposes.

    > The new `satisfies` operator lets us validate that the type of an expression matches some type, without changing the resulting type of that expression.

    > `satisfies` can be used to catch lots of possible errors.

2. https://devblogs.microsoft.com/typescript/announcing-typescript-4-9/#unlisted-property-narrowing-with-the-in-operator

    > As developers, we often need to deal with values that aren’t fully known at runtime. In fact, we often don’t know if properties exist, whether we’re getting a response from a server or reading a configuration file. JavaScript’s `in` operator can check whether a property exists on an object.

    > TypeScript 4.9 makes the `in` operator a little bit more powerful when narrowing types that *don’t* list the property at all. Instead of leaving them as-is, the language will intersect their types with `Record<"property-key-being-checked", unknown>`.

3. https://devblogs.microsoft.com/typescript/announcing-typescript-4-9/#checks-for-equality-on-nan

    > TypeScript now errors on direct comparisons against `NaN`, and will suggest using some variation of `Number.isNaN` instead.

4. https://devblogs.microsoft.com/typescript/announcing-typescript-4-9/#file-watching-now-uses-file-system-events

    > In earlier versions, TypeScript leaned heavily on *polling* for watching individual files. Using a polling strategy meant checking the state of a file periodically for updates.

    > In TypeScript 4.9, file watching is powered by file system events by default, only falling back to polling if we fail to set up event-based watchers. For most developers, this should provide a much less resource-intensive experience when running in `--watch` mode, or running with a TypeScript-powered editor like Visual Studio or VS Code.

5. https://devblogs.microsoft.com/typescript/announcing-typescript-4-9/#remove-unused-imports-and-sort-imports-commands-for-editors

    > In TypeScript 4.3, we introduced a command called "Sort Imports" which would only sort imports in the file, but not remove them.

    > TypeScript 4.9 adds the other half, and now provides "Remove Unused Imports". TypeScript will now remove unused import names and statements, but will otherwise leave the relative ordering alone.

    > Visual Studio Code (1.73 and later) will have support built in and will surface these commands via its Command Palette.

6. https://devblogs.microsoft.com/typescript/announcing-typescript-4-9/#go-to-definition-on-return-keywords

    > In the editor, when running a go-to-definition on the `return` keyword, TypeScript will now jump you to the top of the corresponding function. This can be helpful to get a quick sense of which function a return belongs to.

    > We expect TypeScript will expand this functionality to more keywords such as `await` and `yield` or `switch`, `case`, and `default`.

7. What’s Next

    > Our next release will be TypeScript 5.0 – but have no fear, we believe 5.0 should be pretty easy to adopt.

    https://github.com/microsoft/TypeScript/issues/51362

### Errors

Because `yarn build` reports only the first error, and not even the name of the file:

1. `yarn tsc` in ui/apps/platform

    * src/Containers/Clusters/ClustersSidePanel.tsx

        > error TS2345: Argument of type '"DEPLOYMENT"' is not assignable to parameter of type 'SetStateAction<"FORM">'.

        ```js
        setWizardStep(wizardSteps.DEPLOYMENT);
        ```

        > error TS2367: This comparison appears to be unintentional because the types '"FORM"' and '"DEPLOYMENT"' have no overlap.

        ```js
        {!isBlocked && wizardStep === wizardSteps.DEPLOYMENT && (
        ```

2. `yarn tsc` in ui/packages/ui-components

### Solution

1. Replace object in helpers file with string union type in component file.
2. Declare type of `useState` hook.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

1. `yarn lint` in ui
2. `yarn build` in ui
3. `wc build/static/js/*.js` in ui
    * branch - master: -188 = 11083100 - 11083288 because replace object properties with literal strings