### PR TITLE
add other resources to pipeline benchmark

### DIFF
--- a/sensor/tests/pipeline/bench_test.go
+++ b/sensor/tests/pipeline/bench_test.go
@@ -137,7 +137,6 @@ func Benchmark_Pipeline(b *testing.B) {
 			deletion["service"] = append(deletion["service"], serviceName)
 		}
 
-		var objToDelete []*v1.Deployment
 		for i := 0; i < 1000; i++ {
 			deploymentName := randString(10)
 			createDeployment(fakeClient, testNamespace, deploymentName, appNames[i], serviceAccounts[i])
@@ -145,8 +144,8 @@ func Benchmark_Pipeline(b *testing.B) {
 		}
 
 		// Wait until last deployment is seen by central
-		obj := createDeployment(fakeClient, testNamespace, "FINAL", "", "")
-		objToDelete = append(objToDelete, obj)
+		createDeployment(fakeClient, testNamespace, "FINAL", "", "")
+		deletion["deployment"] = append(deletion["deployment"], "FINAL")
 		sig.Wait()
 
 		b.StopTimer()

--- a/sensor/tests/pipeline/bench_test.go
+++ b/sensor/tests/pipeline/bench_test.go
@@ -163,10 +163,6 @@ func Benchmark_Pipeline(b *testing.B) {
 		go utils.CrashOnError(deleteAll(fakeClient, "service", testNamespace, deletion["service"], &wg))
 
 		wg.Wait()
-		//for _, o := range objToDelete {
-		//	err := fakeClient.Kubernetes().AppsV1().Deployments(testNamespace).Delete(context.Background(), o.GetName(), metav1.DeleteOptions{})
-		//	require.NoError(b, err)
-		//}
 		err = fakeClient.Kubernetes().CoreV1().Namespaces().Delete(context.Background(), testNamespace, metav1.DeleteOptions{})
 		require.NoError(b, err)
 		b.StartTimer()

--- a/sensor/tests/pipeline/bench_test.go
+++ b/sensor/tests/pipeline/bench_test.go
@@ -22,7 +22,9 @@ import (
 	"google.golang.org/grpc/test/bufconn"
 	v1 "k8s.io/api/apps/v1"
 	core "k8s.io/api/core/v1"
+	v12 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 var (
@@ -32,8 +34,33 @@ var (
 	setupOnce sync.Once
 )
 
+var (
+	serviceAccounts []string
+	appNames        []string
+)
+
 func init() {
 	rand.Seed(time.Now().UnixNano())
+
+	serviceAccounts = make([]string, 1000)
+	for i := 0; i < 1000; i++ {
+		serviceAccounts[i] = randString(5)
+	}
+
+	appNames = make([]string, 1000)
+	for i := 0; i < 1000; i++ {
+		appNames[i] = randString(5)
+	}
+}
+
+func randomSA() string {
+	return serviceAccounts[rand.Intn(len(serviceAccounts))]
+}
+
+func randomAppName() map[string]string {
+	return map[string]string{
+		"app": appNames[rand.Intn(len(appNames))],
+	}
 }
 
 var letterRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
@@ -88,14 +115,37 @@ func Benchmark_Pipeline(b *testing.B) {
 			}
 		})
 
+		deletion := map[string][]string{
+			"deployment": {},
+			"role":       {},
+			"binding":    {},
+			"service":    {},
+		}
+
+		for i := 0; i < 100; i++ {
+			roleName := randString(10)
+			createRole(fakeClient, testNamespace, roleName)
+			bindingName := randString(10)
+			createBinding(fakeClient, testNamespace, bindingName, roleName)
+			deletion["role"] = append(deletion["role"], roleName)
+			deletion["binding"] = append(deletion["binding"], bindingName)
+		}
+
+		for i := 0; i < 100; i++ {
+			serviceName := randString(10)
+			createService(fakeClient, testNamespace, serviceName)
+			deletion["service"] = append(deletion["service"], serviceName)
+		}
+
 		var objToDelete []*v1.Deployment
 		for i := 0; i < 1000; i++ {
-			obj := createDeployment(fakeClient, testNamespace, randString(10))
-			objToDelete = append(objToDelete, obj)
+			deploymentName := randString(10)
+			createDeployment(fakeClient, testNamespace, deploymentName, appNames[i], serviceAccounts[i])
+			deletion["deployment"] = append(deletion["deployment"], deploymentName)
 		}
 
 		// Wait until last deployment is seen by central
-		obj := createDeployment(fakeClient, testNamespace, "FINAL")
+		obj := createDeployment(fakeClient, testNamespace, "FINAL", "", "")
 		objToDelete = append(objToDelete, obj)
 		sig.Wait()
 
@@ -104,22 +154,59 @@ func Benchmark_Pipeline(b *testing.B) {
 		// We need to delete so sensor data stores don't keep deployment objects lingering, which
 		// can cause subsequent runs of the benchmark to yield incorrect results.
 		// If this isn't done benchmark results can have a high discrepancy in results (> 10%)
-		for _, o := range objToDelete {
-			err := fakeClient.Kubernetes().AppsV1().Deployments(testNamespace).Delete(context.Background(), o.GetName(), metav1.DeleteOptions{})
-			require.NoError(b, err)
-		}
+		wg := sync.WaitGroup{}
+		wg.Add(4)
+
+		go utils.CrashOnError(deleteAll(fakeClient, "deployment", testNamespace, deletion["deployment"], &wg))
+		go utils.CrashOnError(deleteAll(fakeClient, "role", testNamespace, deletion["role"], &wg))
+		go utils.CrashOnError(deleteAll(fakeClient, "binding", testNamespace, deletion["binding"], &wg))
+		go utils.CrashOnError(deleteAll(fakeClient, "service", testNamespace, deletion["service"], &wg))
+
+		wg.Wait()
+		//for _, o := range objToDelete {
+		//	err := fakeClient.Kubernetes().AppsV1().Deployments(testNamespace).Delete(context.Background(), o.GetName(), metav1.DeleteOptions{})
+		//	require.NoError(b, err)
+		//}
 		err = fakeClient.Kubernetes().CoreV1().Namespaces().Delete(context.Background(), testNamespace, metav1.DeleteOptions{})
 		require.NoError(b, err)
 		b.StartTimer()
 	}
 }
 
-func createDeployment(fakeClient *k8s.ClientSet, namespace, name string) *v1.Deployment {
+func deleteAll(fakeClient *k8s.ClientSet, kind, namespace string, names []string, wg *sync.WaitGroup) error {
+	defer wg.Done()
+	for _, name := range names {
+		switch kind {
+		case "deployment":
+			if err := fakeClient.Kubernetes().AppsV1().Deployments(namespace).Delete(context.Background(), name, metav1.DeleteOptions{}); err != nil {
+				return err
+			}
+		case "role":
+			if err := fakeClient.Kubernetes().RbacV1().Roles(namespace).Delete(context.Background(), name, metav1.DeleteOptions{}); err != nil {
+				return err
+			}
+		case "binding":
+			if err := fakeClient.Kubernetes().RbacV1().RoleBindings(namespace).Delete(context.Background(), name, metav1.DeleteOptions{}); err != nil {
+				return err
+			}
+		case "service":
+			if err := fakeClient.Kubernetes().CoreV1().Services(namespace).Delete(context.Background(), name, metav1.DeleteOptions{}); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func createDeployment(fakeClient *k8s.ClientSet, namespace, name, appName, serviceAccount string) *v1.Deployment {
 	obj, err := fakeClient.Kubernetes().AppsV1().Deployments(namespace).Create(context.Background(),
 		&v1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: namespace,
+				Labels: map[string]string{
+					"app": appName,
+				},
 			},
 			Spec: v1.DeploymentSpec{
 				Template: core.PodTemplateSpec{
@@ -131,8 +218,79 @@ func createDeployment(fakeClient *k8s.ClientSet, namespace, name string) *v1.Dep
 								Image: "bar",
 							},
 						},
+						ServiceAccountName: serviceAccount,
 					},
 				},
+			},
+		}, metav1.CreateOptions{})
+	if err != nil {
+		panic(err)
+	}
+	return obj
+}
+
+func createRole(fakeClient *k8s.ClientSet, namespace, name string) *v12.Role {
+	obj, err := fakeClient.Kubernetes().RbacV1().Roles(namespace).Create(context.Background(),
+		&v12.Role{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+			Rules: []v12.PolicyRule{
+				{
+					Verbs:     []string{"list"},
+					APIGroups: []string{"deployments"},
+				},
+			},
+		}, metav1.CreateOptions{})
+	if err != nil {
+		panic(err)
+	}
+	return obj
+}
+
+func createBinding(fakeClient *k8s.ClientSet, namespace, name, ref string) *v12.RoleBinding {
+	obj, err := fakeClient.Kubernetes().RbacV1().RoleBindings(namespace).Create(context.Background(),
+		&v12.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+			Subjects: []v12.Subject{
+				{
+					Kind: "ServiceAccount",
+					Name: randomSA(),
+				},
+			},
+			RoleRef: v12.RoleRef{
+				Kind: "Role",
+				Name: ref,
+			},
+		}, metav1.CreateOptions{})
+	if err != nil {
+		panic(err)
+	}
+	return obj
+}
+
+func createService(fakeClient *k8s.ClientSet, namespace, name string) *core.Service {
+	obj, err := fakeClient.Kubernetes().CoreV1().Services(namespace).Create(context.Background(),
+		&core.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+			Spec: core.ServiceSpec{
+				Ports: []core.ServicePort{
+					{
+						Name:       "some.service",
+						Protocol:   "TCP",
+						Port:       80,
+						TargetPort: intstr.IntOrString{IntVal: 8080},
+					},
+				},
+				Selector: randomAppName(),
+				Type:     "LoadBalancer",
 			},
 		}, metav1.CreateOptions{})
 	if err != nil {


### PR DESCRIPTION
## Description

Adds more resources to the pipeline benchmark test. 

Testing against an older master commit `27598ba780` using 1 and 2 CPUs.

```
LOGLEVEL="panic" go test -bench=. -run=^# -cpu=1,2 -benchtime=15s -count=5 ./sensor/tests/pipeline
```

Results in `27598ba780`:
```
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
Benchmark_Pipeline     	      82	 362217531 ns/op
Benchmark_Pipeline     	      76	 374107365 ns/op
Benchmark_Pipeline     	      68	 412559199 ns/op
Benchmark_Pipeline     	      62	 403039596 ns/op
Benchmark_Pipeline     	      62	 429223487 ns/op
Benchmark_Pipeline-2   	     100	 258295991 ns/op
Benchmark_Pipeline-2   	     100	 271433119 ns/op
Benchmark_Pipeline-2   	      98	 262775850 ns/op
Benchmark_Pipeline-2   	     100	 279071768 ns/op
Benchmark_Pipeline-2   	      88	 274708586 ns/op
PASS
ok  	github.com/stackrox/rox/sensor/tests/pipeline	300.680s
```

Results in current master (with pipeline changes):
```
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
Benchmark_Pipeline     	      70	 417710609 ns/op
Benchmark_Pipeline     	      63	 439635435 ns/op
Benchmark_Pipeline     	      73	 452084103 ns/op
Benchmark_Pipeline     	      61	 421160479 ns/op
Benchmark_Pipeline     	      54	 446794429 ns/op
Benchmark_Pipeline-2   	     100	 239564399 ns/op
Benchmark_Pipeline-2   	     100	 229573150 ns/op
Benchmark_Pipeline-2   	     100	 239306448 ns/op
Benchmark_Pipeline-2   	     100	 238969205 ns/op
Benchmark_Pipeline-2   	     100	 257847904 ns/op
PASS
ok  	github.com/stackrox/rox/sensor/tests/pipeline	291.256s
```

Benchstat: underperforming on a single core but performing better when two cores are available. 
```
name         old time/op  new time/op  delta
_Pipeline     396ms ± 9%   435ms ± 4%   +9.91%  (p=0.032 n=5+5)
_Pipeline-2   269ms ± 4%   241ms ± 7%  -10.48%  (p=0.008 n=5+5)
```

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

- Bench tests as described above
