### PR TITLE
Replace cypress visit method with helper in product branding integration tests

### DIFF
--- a/ui/apps/platform/cypress/integration/productBranding.test.js
+++ b/ui/apps/platform/cypress/integration/productBranding.test.js
@@ -1,8 +1,8 @@
 import withAuth from '../helpers/basicAuth';
 import selectors from '../constants/GeneralPage';
-import { url as dashboardUrl } from '../constants/DashboardPage';
 import { url as loginUrl } from '../constants/LoginPage';
 import * as api from '../constants/apiEndpoints';
+import { visitMainDashboard } from '../helpers/main';
 
 describe('Logo and title product branding checks', () => {
     withAuth();
@@ -11,9 +11,10 @@ describe('Logo and title product branding checks', () => {
 
     it('Should render the login page with matching logo and page title', () => {
         // Ensure that the page title matches the logo branding
-        cy.intercept(api.metadata).as('metadataReq');
+        cy.intercept('GET', api.metadata).as('metadata');
         cy.visit(loginUrl);
-        cy.wait('@metadataReq');
+        cy.wait('@metadata');
+
         cy.title().then((title) => {
             if (title.includes(redHatTitleText)) {
                 cy.get(selectors.rhacsLogoImage);
@@ -28,9 +29,8 @@ describe('Logo and title product branding checks', () => {
 
     it('Should render the main dashboard with matching logo and page title', () => {
         // Ensure that the page title matches the logo branding
-        cy.intercept('POST', api.dashboard.summaryCounts).as('summaryCounts');
-        cy.visit(dashboardUrl);
-        cy.wait('@summaryCounts');
+        visitMainDashboard();
+
         cy.title().then((title) => {
             if (title.includes(redHatTitleText)) {
                 cy.get(selectors.rhacsLogoImage);


### PR DESCRIPTION
## Description

Apply consistent patterns and prevent timing failures.

Keep `cy.visit` for Login page in the first test because it does not have a helper function, but replace with `visitMainDashboard` function in the second test.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration test

## Testing Performed