### PR TITLE
Dynamically determine directory for UI auth token script

### DIFF
--- a/ui/apps/platform/scripts/get-auth-token.sh
+++ b/ui/apps/platform/scripts/get-auth-token.sh
@@ -4,11 +4,13 @@
 # Env vars ROX_USERNAME and ROX_PASSWORD are expected to be set for basic auth,
 # otherwise k8s deployment assumed from where basic auth creds are retrieved.
 
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
+
 api_endpoint="${UI_BASE_URL:-https://localhost:8000}"
 
 if [[ -z "$ROX_USERNAME" || -z "$ROX_PASSWORD" ]]; then
   # basic auth creds weren't set (e.g. by CI), assume local k8s deployment
-  source ../../../scripts/k8s/export-basic-auth-creds.sh ../../../deploy/k8s
+  source "${DIR}/../../../../scripts/k8s/export-basic-auth-creds.sh" "${DIR}/../../../../deploy/k8s"
 fi
 
 if [[ -n "$ROX_USERNAME" && -n "$ROX_PASSWORD" ]]; then


### PR DESCRIPTION
## Description

The utility script that gets a valid auth token (e.g. for Cypress runs) previously needed to be run with `pwd` equal to the location of the script. This change makes it so that the script can be run from anywhere and it will correctly find the files it needs.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Run `get-auth-token.sh` from a variety of directories. Each time a valid auth token should be echoed.

Run `cypress open` and ensure Cypress is able to authenticate and run tests.
