### PR TITLE
Fix duplicate fetch requests in collections view more button

### DIFF
--- a/ui/apps/platform/src/Containers/Collections/hooks/useEmbeddedCollections.ts
+++ b/ui/apps/platform/src/Containers/Collections/hooks/useEmbeddedCollections.ts
@@ -64,7 +64,8 @@ function fetchDetachedCollections(
         );
         const detached = aggregateResult.concat(newDetached);
         const lastResponseSize = collections.length;
-        const shouldFetchMore = lastResponseSize > 0 && detached.length < minimumUpdateSize;
+        const shouldFetchMore =
+            lastResponseSize === pageSize && detached.length < minimumUpdateSize;
         const nextPage = pageNumber + 1;
 
         if (shouldFetchMore) {


### PR DESCRIPTION
## Description

An oversight in the logic determining whether or not there are more collections to be fetched was leading to more network requests than were needed. This fixes the logic and causes only one request per view-more click to be fired, as well as firing only a single request on the load of the collection form.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed


Load the collection form page and view the network tab to ensure only a single request is sent to the "list collections" endpoint. Click the view more button multiple times, and ensure that each click only results in a single request.
