### PR TITLE
Replace cypress visit method with helpers in userinfo integration tests

### DIFF
--- a/ui/apps/platform/cypress/constants/UserPage.js
+++ b/ui/apps/platform/cypress/constants/UserPage.js
@@ -1,8 +1,6 @@
 import pageSelectors from '../selectors/page';
 import scopeSelectors from '../helpers/scopeSelectors';
 
-export const url = '/main/user';
-
 const permissionColumn = (permission, testid) => {
     return `tr:contains("${permission}") td[data-testid="${testid}"]`;
 };

--- a/ui/apps/platform/cypress/helpers/user.js
+++ b/ui/apps/platform/cypress/helpers/user.js
@@ -1,0 +1,29 @@
+import { selectors as topNavSelectors } from '../constants/TopNavigation';
+import { visitMainDashboard } from './main';
+import { visit, visitWithStaticResponseForAuthStatus } from './visit';
+
+const basePath = '/main/user';
+
+const title = 'User Profile';
+
+export function visitUserProfile() {
+    visit(basePath);
+
+    cy.get(`h1:contains("${title}")`);
+}
+
+export function visitUserProfileFromTopNav() {
+    visitMainDashboard();
+
+    cy.get(topNavSelectors.menuButton).click();
+    cy.get(`a[role="menuitem"]:contains("${title}")`).click();
+
+    cy.location('pathname').should('eq', basePath);
+    cy.get(`h1:contains("${title}")`);
+}
+
+export function visitUserProfileWithStaticResponseForAuthStatus(staticResponseForAuthStatus) {
+    visitWithStaticResponseForAuthStatus(basePath, staticResponseForAuthStatus);
+
+    cy.get(`h1:contains("${title}")`);
+}

--- a/ui/apps/platform/cypress/helpers/visit.js
+++ b/ui/apps/platform/cypress/helpers/visit.js
@@ -69,6 +69,38 @@ export function visit(pageUrl, routeMatcherMap, staticResponseMap) {
 }
 
 /**
+ * Visit page to test conditional rendering for authentication status specified as response or fixture.
+ *
+ * { body: { resourceToAccess: { … } } }
+ * { fixture: 'fixtures/wherever/whatever.json' }
+ *
+ * @param {string} pageUrl
+ * @param {{ body: { userInfo: Record<string, unknown> } } | { fixture: string }} staticResponseForAuthStatus
+ * @param {Record<string, { method: string, url: string }>} [routeMatcherMap]
+ * @param {Record<string, { body: unknown } | { fixture: string }>} [staticResponseMap]
+ */
+export function visitWithStaticResponseForAuthStatus(
+    pageUrl,
+    staticResponseForAuthStatus,
+    routeMatcherMap,
+    staticResponseMap
+) {
+    const staticResponseMapForAuthenticatedRoutes = {
+        [authStatusAlias]: staticResponseForAuthStatus,
+    };
+    interceptRequests(
+        routeMatcherMapForAuthenticatedRoutes,
+        staticResponseMapForAuthenticatedRoutes
+    );
+    interceptRequests(routeMatcherMap, staticResponseMap);
+
+    cy.visit(pageUrl);
+
+    waitForResponses(routeMatcherMapForAuthenticatedRoutes);
+    waitForResponses(routeMatcherMap);
+}
+
+/**
  * Visit page to test conditional rendering for user role permissions specified as response or fixture.
  *
  * { body: { resourceToAccess: { … } } }

--- a/ui/apps/platform/cypress/integration/userinfo.test.js
+++ b/ui/apps/platform/cypress/integration/userinfo.test.js
@@ -1,47 +1,41 @@
-import withAuth from '../helpers/basicAuth';
-import { selectors as userPageSelectors, url as userPageUrl } from '../constants/UserPage';
-import { url as dashboardURL } from '../constants/DashboardPage';
+import { selectors as userPageSelectors } from '../constants/UserPage';
 import { selectors as topNavSelectors } from '../constants/TopNavigation';
-import * as api from '../constants/apiEndpoints';
+import withAuth from '../helpers/basicAuth';
+import { getRegExpForTitleWithBranding } from '../helpers/title';
+import {
+    visitUserProfile,
+    visitUserProfileFromTopNav,
+    visitUserProfileWithStaticResponseForAuthStatus,
+} from '../helpers/user';
 
-describe('User Info', () => {
+const staticResponseForAdminRoleWithoutProvider = {
+    fixture: 'auth/adminUserStatus',
+};
+
+const staticResponseForMultiRolesWithOidcProvider = {
+    fixture: 'auth/multiRolesUserStatus',
+};
+
+const staticResponseForAdminRoleWithBasicProvider = {
+    fixture: 'auth/basicAuthAdminStatus',
+};
+
+describe('User Profile', () => {
     withAuth();
 
-    function interceptWithoutMockUser() {
-        cy.intercept('GET', api.auth.authStatus).as('authStatus');
-    }
-
-    function interceptWithMockAdminUser() {
-        cy.intercept('GET', api.auth.authStatus, {
-            fixture: 'auth/adminUserStatus',
-        }).as('authStatus');
-    }
-
-    function interceptWithMockMultiRolesUser() {
-        cy.intercept('GET', api.auth.authStatus, {
-            fixture: 'auth/multiRolesUserStatus',
-        }).as('authStatus');
-    }
-
-    function interceptWithMockBasicUser() {
-        cy.intercept('GET', api.auth.authStatus, {
-            fixture: 'auth/basicAuthAdminStatus',
-        }).as('authStatus');
-    }
-
-    describe('User Info in Top Navigation', () => {
+    describe('in top navigation', () => {
         it('should show initials in the user avatar', () => {
-            interceptWithMockAdminUser();
-            cy.visit(dashboardURL);
-            cy.wait('@authStatus');
+            visitUserProfileWithStaticResponseForAuthStatus(
+                staticResponseForAdminRoleWithoutProvider
+            );
 
             cy.get(topNavSelectors.menuButton).should('contain.text', 'AI');
         });
 
         it('should show name, email and a single role', () => {
-            interceptWithMockAdminUser();
-            cy.visit(dashboardURL);
-            cy.wait('@authStatus');
+            visitUserProfileWithStaticResponseForAuthStatus(
+                staticResponseForAdminRoleWithoutProvider
+            );
 
             cy.get(topNavSelectors.menuButton).click();
 
@@ -54,9 +48,9 @@ describe('User Info', () => {
         });
 
         it('should show username when name is missed, and all roles', () => {
-            interceptWithMockMultiRolesUser();
-            cy.visit(dashboardURL);
-            cy.wait('@authStatus');
+            visitUserProfileWithStaticResponseForAuthStatus(
+                staticResponseForMultiRolesWithOidcProvider
+            );
 
             cy.get(topNavSelectors.menuButton).click();
 
@@ -73,41 +67,30 @@ describe('User Info', () => {
         });
 
         it('should navigate to the user page', () => {
-            interceptWithoutMockUser();
-            cy.visit(dashboardURL);
-            cy.wait('@authStatus');
-
-            cy.get(topNavSelectors.menuButton).click();
-            cy.get(topNavSelectors.menuList.userName).click();
-            cy.wait('@authStatus');
-
-            cy.location('pathname').should('eq', userPageUrl);
+            visitUserProfileFromTopNav();
         });
     });
 
-    describe('User Page', () => {
-        // TODO after we split into 2 test files and factor out helper functions.
-        /*
+    describe('page', () => {
         it('should have title', () => {
             visitUserProfile();
-    
+
             cy.title().should('match', getRegExpForTitleWithBranding('User Profile'));
         });
-        */
 
         it('should show user name and email', () => {
-            interceptWithMockAdminUser();
-            cy.visit(userPageUrl);
-            cy.wait('@authStatus');
+            visitUserProfileWithStaticResponseForAuthStatus(
+                staticResponseForAdminRoleWithoutProvider
+            );
 
             cy.get(userPageSelectors.userName).should('contain.text', 'Artificial Intelligence');
             cy.get(userPageSelectors.userEmail).should('contain.text', 'ai@stackrox.com');
         });
 
         it('should show all the user roles', () => {
-            interceptWithMockMultiRolesUser();
-            cy.visit(userPageUrl);
-            cy.wait('@authStatus');
+            visitUserProfileWithStaticResponseForAuthStatus(
+                staticResponseForMultiRolesWithOidcProvider
+            );
 
             cy.get(`${userPageSelectors.userRoleNames}:contains("Admin")`);
             cy.get(`${userPageSelectors.userRoleNames}:contains("Analyst")`);
@@ -115,9 +98,9 @@ describe('User Info', () => {
         });
 
         it('should show correct permissions for the role', () => {
-            interceptWithMockMultiRolesUser();
-            cy.visit(userPageUrl);
-            cy.wait('@authStatus');
+            visitUserProfileWithStaticResponseForAuthStatus(
+                staticResponseForMultiRolesWithOidcProvider
+            );
 
             cy.get(`${userPageSelectors.userRoleNames}:contains("Analyst")`).click();
 
@@ -127,9 +110,7 @@ describe('User Info', () => {
         });
 
         it('should properly highlight current nav item', () => {
-            interceptWithoutMockUser();
-            cy.visit(userPageUrl);
-            cy.wait('@authStatus');
+            visitUserProfile();
 
             const { userPermissionsForRoles, userRoleNames } = userPageSelectors;
             const userRoleAdmin = `${userRoleNames}:contains("Admin")`;
@@ -151,9 +132,9 @@ describe('User Info', () => {
         });
 
         it('should display aggregated permissions for basic auth user', () => {
-            interceptWithMockBasicUser();
-            cy.visit(userPageUrl);
-            cy.wait('@authStatus');
+            visitUserProfileWithStaticResponseForAuthStatus(
+                staticResponseForAdminRoleWithBasicProvider
+            );
 
             cy.get(userPageSelectors.userName).should('contain.text', 'admin');
             cy.get(userPageSelectors.authProviderName).should('contain.text', 'Basic');
@@ -167,9 +148,9 @@ describe('User Info', () => {
         });
 
         it('should show correct aggregated permissions for multi roles user', () => {
-            interceptWithMockMultiRolesUser();
-            cy.visit(userPageUrl);
-            cy.wait('@authStatus');
+            visitUserProfileWithStaticResponseForAuthStatus(
+                staticResponseForMultiRolesWithOidcProvider
+            );
 
             cy.get(userPageSelectors.userName).should('contain.text', 'ai');
             cy.get(userPageSelectors.authProviderName).should('contain.text', 'My OIDC Provider');


### PR DESCRIPTION
## Description

Apply consistent patterns and prevent timing failures.

This test file has 10 `cy.visit` method calls (the most remaining in any test file).

### Background

In case it helps, here are links to cypress data structures:

* `routeMatcher` https://docs.cypress.io/api/commands/intercept#Matching-with-RouteMatcher
* `staticResponse` https://docs.cypress.io/api/commands/intercept#StaticResponse-objects

Here is the relevant part from beginning of cypress/helpers/visit.js file:

```js
// Single source of truth for keys in staticResponseMapForAuthenticatedRoutes object.
export const availableAuthProvidersAlias = 'availableAuthProviders';
export const featureFlagsAlias = 'featureflags';
export const loginAuthProvidersAlias = 'login/authproviders';
export const myPermissionsAlias = 'mypermissions';
export const configPublicAlias = 'config/public';
export const authStatusAlias = 'auth/status';

// Requests to render pages via MainPage and Body components.
const routeMatcherMapForAuthenticatedRoutes = {

    [authStatusAlias]: {
        method: 'GET',
        url: api.auth.authStatus,
    }, // sagas/authSagas

};
```

### Changed files

1. Edit cypress/constants/UserPage.js
    * Delete `url` to encapsulate page address in helpers file.

2. Add cypress/helpers/user.js
    * Add helper functions similar to for other containers.

3. Edit cypress/helpers/visit.js
    * Add `visitWithStaticResponseForAuthStatus` similar to `visitWithStaticResponseForPermissions` helper function.

4. Edit cypress/integration/userinfo.test.js
    * Replace `interceptWhatever` functions with `staticResponseForWhatever` objects.
    * Replace sandwiches of `interceptWhatever`, `cy.visit`, `cy.wait` calls with `visitWithStaticResponseForAuthStatus` function calls.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed