### PR TITLE
ROX-13326: (release 3.73) disable migration code generation for role stores.

### DIFF
--- a/central/role/store/permissionset/postgres/gen.go
+++ b/central/role/store/permissionset/postgres/gen.go
@@ -1,3 +1,3 @@
 package postgres
 
-//go:generate pg-table-bindings-wrapper --type=storage.PermissionSet --migration-seq 37 --migrate-from rocksdb
+//go:generate pg-table-bindings-wrapper --type=storage.PermissionSet

--- a/central/role/store/permissionset/rocksdb/gen.go
+++ b/central/role/store/permissionset/rocksdb/gen.go
@@ -1,3 +1,3 @@
 package rocksdb
 
-//go:generate rocksdb-bindings-wrapper --type=PermissionSet --bucket=permission_sets --cache --uniq-key-func GetName() --migration-seq 37 --migrate-to permission_sets
+//go:generate rocksdb-bindings-wrapper --type=PermissionSet --bucket=permission_sets --cache --uniq-key-func GetName()

--- a/central/role/store/role/postgres/gen.go
+++ b/central/role/store/role/postgres/gen.go
@@ -1,3 +1,3 @@
 package postgres
 
-//go:generate pg-table-bindings-wrapper --type=storage.Role --migration-seq 46 --migrate-from rocksdb
+//go:generate pg-table-bindings-wrapper --type=storage.Role

--- a/central/role/store/role/rocksdb/gen.go
+++ b/central/role/store/role/rocksdb/gen.go
@@ -1,3 +1,3 @@
 package rocksdb
 
-//go:generate rocksdb-bindings-wrapper --type=Role --bucket=roles --cache --key-func GetName() --migration-seq 46 --migrate-to roles
+//go:generate rocksdb-bindings-wrapper --type=Role --bucket=roles --cache --key-func GetName()

--- a/central/role/store/simpleaccessscope/postgres/gen.go
+++ b/central/role/store/simpleaccessscope/postgres/gen.go
@@ -1,3 +1,3 @@
 package postgres
 
-//go:generate pg-table-bindings-wrapper --type=storage.SimpleAccessScope --migration-seq 52 --migrate-from rocksdb
+//go:generate pg-table-bindings-wrapper --type=storage.SimpleAccessScope

--- a/central/role/store/simpleaccessscope/rocksdb/gen.go
+++ b/central/role/store/simpleaccessscope/rocksdb/gen.go
@@ -1,3 +1,3 @@
 package rocksdb
 
-//go:generate rocksdb-bindings-wrapper --type=SimpleAccessScope --bucket=simple_access_scopes --cache --uniq-key-func GetName() --migration-seq 52 --migrate-to simple_access_scopes
+//go:generate rocksdb-bindings-wrapper --type=SimpleAccessScope --bucket=simple_access_scopes --cache --uniq-key-func GetName()


### PR DESCRIPTION
Addendum to https://github.com/stackrox/stackrox/pull/3862

After the freeze of database schemas on master, some conflicts had to be solved to merge on head.
After this conflict resolution, the removal of some code generator arguments were forgotten in the cherrypick/merge to release-3.73 . This PR fixes the code generator options for role-related stores (do not auto-generate migration code).