### PR TITLE
ROX-13178: add simulate baseline as network policy button

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentBaselines.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentBaselines.tsx
@@ -17,14 +17,6 @@ function DeploymentBaselines() {
     const [isExcludingPortsAndProtocols, setIsExcludingPortsAndProtocols] =
         React.useState<boolean>(false);
 
-    const handleAlertingOnViolations = (checked: boolean) => {
-        setIsAlertingOnViolations(checked);
-    };
-
-    const handleExcludingPortsAndProtocols = (checked: boolean) => {
-        setIsExcludingPortsAndProtocols(checked);
-    };
-
     return (
         <div className="pf-u-h-100 pf-u-p-md">
             <Stack hasGutter>
@@ -35,7 +27,7 @@ function DeploymentBaselines() {
                                 id="simple-switch"
                                 label="Alert on baseline violation"
                                 isChecked={isAlertingOnViolations}
-                                onChange={handleAlertingOnViolations}
+                                onChange={setIsAlertingOnViolations}
                             />
                         </FlexItem>
                         <FlexItem>
@@ -66,7 +58,7 @@ function DeploymentBaselines() {
                                 id="exclude-ports-and-protocols-checkbox"
                                 label="Exclude ports & protocols"
                                 isChecked={isExcludingPortsAndProtocols}
-                                onChange={handleExcludingPortsAndProtocols}
+                                onChange={setIsExcludingPortsAndProtocols}
                             />
                         </FlexItem>
                         <FlexItem>

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentBaselines.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentBaselines.tsx
@@ -1,12 +1,28 @@
 import React from 'react';
-import { Flex, FlexItem, Stack, StackItem, Switch, Tooltip } from '@patternfly/react-core';
+import {
+    Button,
+    Checkbox,
+    Divider,
+    Flex,
+    FlexItem,
+    Stack,
+    StackItem,
+    Switch,
+    Tooltip,
+} from '@patternfly/react-core';
 import { HelpIcon } from '@patternfly/react-icons';
 
 function DeploymentBaselines() {
     const [isAlertingOnViolations, setIsAlertingOnViolations] = React.useState<boolean>(false);
+    const [isExcludingPortsAndProtocols, setIsExcludingPortsAndProtocols] =
+        React.useState<boolean>(false);
 
     const handleAlertingOnViolations = (checked: boolean) => {
         setIsAlertingOnViolations(checked);
+    };
+
+    const handleExcludingPortsAndProtocols = (checked: boolean) => {
+        setIsExcludingPortsAndProtocols(checked);
     };
 
     return (
@@ -32,6 +48,29 @@ function DeploymentBaselines() {
                             >
                                 <HelpIcon className="pf-u-color-200" />
                             </Tooltip>
+                        </FlexItem>
+                    </Flex>
+                </StackItem>
+                <Divider component="hr" />
+                <StackItem isFilled>@TODO: Table</StackItem>
+                <Divider component="hr" />
+                <StackItem>
+                    <Flex
+                        direction={{ default: 'column' }}
+                        spaceItems={{ default: 'spaceItemsMd' }}
+                        alignItems={{ default: 'alignItemsCenter' }}
+                        justifyContent={{ default: 'justifyContentCenter' }}
+                    >
+                        <FlexItem>
+                            <Checkbox
+                                id="exclude-ports-and-protocols-checkbox"
+                                label="Exclude ports & protocols"
+                                isChecked={isExcludingPortsAndProtocols}
+                                onChange={handleExcludingPortsAndProtocols}
+                            />
+                        </FlexItem>
+                        <FlexItem>
+                            <Button variant="primary">Simulate baseline as network policy</Button>
                         </FlexItem>
                     </Flex>
                 </StackItem>

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentSideBar.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentSideBar.tsx
@@ -133,6 +133,7 @@ function DeploymentSideBar({ deploymentId, nodes, edges }: DeploymentSideBarProp
                     eventKey="Baselines"
                     id="Baselines"
                     hidden={activeKeyTab !== 'Baselines'}
+                    className="pf-u-h-100"
                 >
                     <DeploymentBaselines />
                 </TabContent>


### PR DESCRIPTION
## Description

This PR adds the checkbox for excluding/including ports and protocols and the "simulate baseline as network policy" button to the baseline tab

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Screenshots

<img width="448" alt="Screenshot 2022-11-21 at 4 09 51 PM" src="https://user-images.githubusercontent.com/4805485/203183467-79689771-d389-42b0-b41c-ef1381da0c6c.png">
