### PR TITLE
ROX-13175: add table to show baseline flows

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/common/FlowsTable.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/common/FlowsTable.tsx
@@ -1,0 +1,226 @@
+import React, { ReactElement } from 'react';
+import {
+    ActionsColumn,
+    ExpandableRowContent,
+    IAction,
+    TableComposable,
+    Tbody,
+    Td,
+    Th,
+    Thead,
+    Tr,
+} from '@patternfly/react-table';
+import { Flex, FlexItem, Text, TextContent, TextVariants } from '@patternfly/react-core';
+import { ExclamationCircleIcon } from '@patternfly/react-icons';
+
+import { Flow, FlowBase } from '../types';
+
+type FlowsTableProps = {
+    label: string;
+    flows: Flow[];
+    numFlows: number;
+    expandedRows: string[];
+    setExpandedRows: React.Dispatch<React.SetStateAction<string[]>>;
+    selectedRows: string[];
+    setSelectedRows: React.Dispatch<React.SetStateAction<string[]>>;
+};
+
+const columnNames = {
+    entity: 'Entity',
+    direction: 'Direction',
+    portAndProtocol: 'Port / protocol',
+};
+
+function FlowsTable({
+    label,
+    flows,
+    numFlows,
+    expandedRows,
+    setExpandedRows,
+    selectedRows,
+    setSelectedRows,
+}: FlowsTableProps): ReactElement {
+    // getter functions
+    const isRowExpanded = (row: Flow) => expandedRows.includes(row.id);
+    const areAllRowsSelected = selectedRows.length === numFlows;
+    const isRowSelected = (row: Flow | FlowBase) => selectedRows.includes(row.id);
+
+    // setter functions
+    const setRowExpanded = (row: Flow, isExpanding = true) =>
+        setExpandedRows((prevExpanded) => {
+            const otherExpandedRows = prevExpanded.filter((r) => r !== row.id);
+            return isExpanding ? [...otherExpandedRows, row.id] : otherExpandedRows;
+        });
+    const setRowSelected = (row: Flow | FlowBase, isSelecting = true) =>
+        setSelectedRows((prevSelected) => {
+            const otherSelectedRows = prevSelected.filter((r) => r !== row.id);
+            return isSelecting ? [...otherSelectedRows, row.id] : otherSelectedRows;
+        });
+    const selectAllRows = (isSelecting = true) => {
+        if (isSelecting) {
+            const newSelectedRows = flows.reduce((acc, curr) => {
+                if (curr.children.length !== 0) {
+                    return [...acc, ...curr.children.map((child) => child.id)];
+                }
+                return [...acc, curr.id];
+            }, [] as string[]);
+            return setSelectedRows(newSelectedRows);
+        }
+        return setSelectedRows([]);
+    };
+
+    return (
+        <TableComposable aria-label={label} variant="compact">
+            <Thead>
+                <Tr>
+                    <Th />
+                    <Th
+                        select={{
+                            onSelect: (_event, isSelecting) => selectAllRows(isSelecting),
+                            isSelected: areAllRowsSelected,
+                        }}
+                    />
+                    <Th width={40}>{columnNames.entity}</Th>
+                    <Th>{columnNames.direction}</Th>
+                    <Th>{columnNames.portAndProtocol}</Th>
+                    <Th />
+                </Tr>
+            </Thead>
+            {flows.map((row, rowIndex) => {
+                const isExpanded = isRowExpanded(row);
+                const rowActions: IAction[] = !row.children.length
+                    ? [
+                          row.isAnomalous
+                              ? {
+                                    itemKey: 'add-flow-to-baseline',
+                                    title: 'Add to baseline',
+                                    onClick: () => {},
+                                }
+                              : {
+                                    itemKey: 'mark-flow-as-anomalous',
+                                    title: 'Mark as anomalous',
+                                    onClick: () => {},
+                                },
+                      ]
+                    : [];
+
+                return (
+                    <Tbody key={row.id} isExpanded={isExpanded}>
+                        <Tr>
+                            <Td
+                                expand={
+                                    row.children.length
+                                        ? {
+                                              rowIndex,
+                                              isExpanded,
+                                              onToggle: () => setRowExpanded(row, !isExpanded),
+                                              expandId: 'flow-expandable',
+                                          }
+                                        : undefined
+                                }
+                            />
+                            <Td
+                                select={
+                                    row.children.length === 0
+                                        ? {
+                                              rowIndex,
+                                              onSelect: (_event, isSelecting) =>
+                                                  setRowSelected(row, isSelecting),
+                                              isSelected: isRowSelected(row),
+                                              disable: !!row.children.length,
+                                          }
+                                        : undefined
+                                }
+                            />
+                            <Td dataLabel={columnNames.entity}>
+                                <Flex direction={{ default: 'row' }}>
+                                    <FlexItem>
+                                        <div>{row.entity}</div>
+                                        <div>
+                                            <TextContent>
+                                                <Text component={TextVariants.small}>
+                                                    {row.type === 'Deployment'
+                                                        ? `in "${row.namespace}"`
+                                                        : `${row.children.length} active flows`}
+                                                </Text>
+                                            </TextContent>
+                                        </div>
+                                    </FlexItem>
+                                    {row.isAnomalous && (
+                                        <FlexItem>
+                                            <ExclamationCircleIcon className="pf-u-danger-color-100" />
+                                        </FlexItem>
+                                    )}
+                                </Flex>
+                            </Td>
+                            <Td dataLabel={columnNames.direction}>{row.direction}</Td>
+                            <Td dataLabel={columnNames.portAndProtocol}>
+                                {row.port} / {row.protocol}
+                            </Td>
+                            <Td isActionCell>
+                                {!row.children.length && <ActionsColumn items={rowActions} />}
+                            </Td>
+                        </Tr>
+                        {isExpanded &&
+                            row.children.map((child) => {
+                                const childActions: IAction[] = [
+                                    child.isAnomalous
+                                        ? {
+                                              itemKey: 'add-flow-to-baseline',
+                                              title: 'Add to baseline',
+                                              onClick: () => {},
+                                          }
+                                        : {
+                                              itemKey: 'mark-flow-as-anomalous',
+                                              title: 'Mark as anomalous',
+                                              onClick: () => {},
+                                          },
+                                ];
+
+                                return (
+                                    <Tr key={child.id} isExpanded={isExpanded}>
+                                        <Td />
+                                        <Td
+                                            select={{
+                                                rowIndex,
+                                                onSelect: (_event, isSelecting) =>
+                                                    setRowSelected(child, isSelecting),
+                                                isSelected: isRowSelected(child),
+                                            }}
+                                        />
+                                        <Td>
+                                            <ExpandableRowContent>
+                                                <Flex direction={{ default: 'row' }}>
+                                                    <FlexItem>{child.entity}</FlexItem>
+                                                    {row.isAnomalous && (
+                                                        <FlexItem>
+                                                            <ExclamationCircleIcon className="pf-u-danger-color-100" />
+                                                        </FlexItem>
+                                                    )}
+                                                </Flex>
+                                            </ExpandableRowContent>
+                                        </Td>
+                                        <Td>
+                                            <ExpandableRowContent>
+                                                {child.direction}
+                                            </ExpandableRowContent>
+                                        </Td>
+                                        <Td>
+                                            <ExpandableRowContent>
+                                                {child.port} / {child.protocol}
+                                            </ExpandableRowContent>
+                                        </Td>
+                                        <Td isActionCell>
+                                            <ActionsColumn items={childActions} />
+                                        </Td>
+                                    </Tr>
+                                );
+                            })}
+                    </Tbody>
+                );
+            })}
+        </TableComposable>
+    );
+}
+
+export default FlowsTable;

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentBaselines.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentBaselines.tsx
@@ -98,7 +98,7 @@ function DeploymentBaselines() {
         defaultAdvancedFlowsFilters
     );
     const initialExpandedRows = baselines
-        .filter((row) => !!row.children.length)
+        .filter((row) => row.children && !!row.children.length)
         .map((row) => row.id); // Default to all expanded
     const [expandedRows, setExpandedRows] = React.useState<string[]>(initialExpandedRows);
     const [selectedRows, setSelectedRows] = React.useState<string[]>([]);

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentBaselines.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentBaselines.tsx
@@ -18,7 +18,8 @@ import AdvancedFlowsFilter, {
 } from '../common/AdvancedFlowsFilter/AdvancedFlowsFilter';
 import { AdvancedFlowsFilterType } from '../common/AdvancedFlowsFilter/types';
 import { Flow } from '../types';
-import { getAllUniquePorts } from '../utils/flowUtils';
+import { getAllUniquePorts, getNumFlows } from '../utils/flowUtils';
+import FlowsTable from '../common/FlowsTable';
 
 const baselines: Flow[] = [
     {
@@ -96,7 +97,14 @@ function DeploymentBaselines() {
     const [advancedFilters, setAdvancedFilters] = React.useState<AdvancedFlowsFilterType>(
         defaultAdvancedFlowsFilters
     );
+    const initialExpandedRows = baselines
+        .filter((row) => !!row.children.length)
+        .map((row) => row.id); // Default to all expanded
+    const [expandedRows, setExpandedRows] = React.useState<string[]>(initialExpandedRows);
+    const [selectedRows, setSelectedRows] = React.useState<string[]>([]);
 
+    // derived data
+    const numBaselines = getNumFlows(baselines);
     const allUniquePorts = getAllUniquePorts(baselines);
 
     return (
@@ -144,10 +152,21 @@ function DeploymentBaselines() {
                     </Flex>
                 </StackItem>
                 <Divider component="hr" />
-                <StackItem isFilled>@TODO: Table</StackItem>
+                <StackItem>
+                    <FlowsTable
+                        label="Deployment baselines"
+                        flows={baselines}
+                        numFlows={numBaselines}
+                        expandedRows={expandedRows}
+                        setExpandedRows={setExpandedRows}
+                        selectedRows={selectedRows}
+                        setSelectedRows={setSelectedRows}
+                    />
+                </StackItem>
                 <Divider component="hr" />
                 <StackItem>
                     <Flex
+                        className="pf-u-pb-md"
                         direction={{ default: 'column' }}
                         spaceItems={{ default: 'spaceItemsMd' }}
                         alignItems={{ default: 'alignItemsCenter' }}

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentFlows.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentFlows.tsx
@@ -100,7 +100,9 @@ function DeploymentFlow() {
     const [advancedFilters, setAdvancedFilters] = React.useState<AdvancedFlowsFilterType>(
         defaultAdvancedFlowsFilters
     );
-    const initialExpandedRows = flows.filter((row) => !!row.children.length).map((row) => row.id); // Default to all expanded
+    const initialExpandedRows = flows
+        .filter((row) => row.children && !!row.children.length)
+        .map((row) => row.id); // Default to all expanded
     const [expandedRows, setExpandedRows] = React.useState<string[]>(initialExpandedRows);
     const [selectedRows, setSelectedRows] = React.useState<string[]>([]);
 

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentFlows.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentFlows.tsx
@@ -13,18 +13,6 @@ import {
     ToolbarContent,
     ToolbarItem,
 } from '@patternfly/react-core';
-import {
-    ActionsColumn,
-    ExpandableRowContent,
-    IAction,
-    TableComposable,
-    Tbody,
-    Td,
-    Th,
-    Thead,
-    Tr,
-} from '@patternfly/react-table';
-import { ExclamationCircleIcon } from '@patternfly/react-icons';
 
 import BulkActionsDropdown from 'Components/PatternFly/BulkActionsDropdown';
 import AdvancedFlowsFilter, {
@@ -34,14 +22,9 @@ import AdvancedFlowsFilter, {
 import './DeploymentFlows.css';
 import { AdvancedFlowsFilterType } from '../common/AdvancedFlowsFilter/types';
 import EntityNameSearchInput from '../common/EntityNameSearchInput';
-import { Flow, FlowBase } from '../types';
-import { getAllUniquePorts } from '../utils/flowUtils';
-
-const columnNames = {
-    entity: 'Entity',
-    direction: 'Direction',
-    portAndProtocol: 'Port / protocol',
-};
+import { Flow } from '../types';
+import { getAllUniquePorts, getNumFlows } from '../utils/flowUtils';
+import FlowsTable from '../common/FlowsTable';
 
 const flows: Flow[] = [
     {
@@ -122,40 +105,10 @@ function DeploymentFlow() {
     const [selectedRows, setSelectedRows] = React.useState<string[]>([]);
 
     // derived data
-    const totalFlows = flows.reduce((acc, curr) => {
-        // if there are no children then it counts as 1 flow
-        return acc + (curr.children.length ? curr.children.length : 1);
-    }, 0);
+    const numFlows = getNumFlows(flows);
     const allUniquePorts = getAllUniquePorts(flows);
 
-    // getter functions
-    const isRowExpanded = (row: Flow) => expandedRows.includes(row.id);
-    const areAllRowsSelected = selectedRows.length === totalFlows;
-    const isRowSelected = (row: Flow | FlowBase) => selectedRows.includes(row.id);
-
     // setter functions
-    const setRowExpanded = (row: Flow, isExpanding = true) =>
-        setExpandedRows((prevExpanded) => {
-            const otherExpandedRows = prevExpanded.filter((r) => r !== row.id);
-            return isExpanding ? [...otherExpandedRows, row.id] : otherExpandedRows;
-        });
-    const setRowSelected = (row: Flow | FlowBase, isSelecting = true) =>
-        setSelectedRows((prevSelected) => {
-            const otherSelectedRows = prevSelected.filter((r) => r !== row.id);
-            return isSelecting ? [...otherSelectedRows, row.id] : otherSelectedRows;
-        });
-    const selectAllRows = (isSelecting = true) => {
-        if (isSelecting) {
-            const newSelectedRows = flows.reduce((acc, curr) => {
-                if (curr.children.length !== 0) {
-                    return [...acc, ...curr.children.map((child) => child.id)];
-                }
-                return [...acc, curr.id];
-            }, [] as string[]);
-            return setSelectedRows(newSelectedRows);
-        }
-        return setSelectedRows([]);
-    };
     const markSelectedAsAnomalous = () => {
         // @TODO: Mark as anomalous
         setSelectedRows([]);
@@ -191,9 +144,7 @@ function DeploymentFlow() {
                         <ToolbarContent>
                             <ToolbarItem>
                                 <TextContent>
-                                    <Text component={TextVariants.h3}>
-                                        {totalFlows} active flows
-                                    </Text>
+                                    <Text component={TextVariants.h3}>{numFlows} active flows</Text>
                                 </TextContent>
                             </ToolbarItem>
                             <ToolbarItem alignment={{ default: 'alignRight' }}>
@@ -218,160 +169,15 @@ function DeploymentFlow() {
                     </Toolbar>
                 </StackItem>
                 <StackItem>
-                    <TableComposable aria-label="Deployment flow" variant="compact">
-                        <Thead>
-                            <Tr>
-                                <Th />
-                                <Th
-                                    select={{
-                                        onSelect: (_event, isSelecting) =>
-                                            selectAllRows(isSelecting),
-                                        isSelected: areAllRowsSelected,
-                                    }}
-                                />
-                                <Th width={40}>{columnNames.entity}</Th>
-                                <Th>{columnNames.direction}</Th>
-                                <Th>{columnNames.portAndProtocol}</Th>
-                                <Th />
-                            </Tr>
-                        </Thead>
-                        {flows.map((row, rowIndex) => {
-                            const isExpanded = isRowExpanded(row);
-                            const rowActions: IAction[] = !row.children.length
-                                ? [
-                                      row.isAnomalous
-                                          ? {
-                                                itemKey: 'add-flow-to-baseline',
-                                                title: 'Add to baseline',
-                                                onClick: () => {},
-                                            }
-                                          : {
-                                                itemKey: 'mark-flow-as-anomalous',
-                                                title: 'Mark as anomalous',
-                                                onClick: () => {},
-                                            },
-                                  ]
-                                : [];
-
-                            return (
-                                <Tbody key={row.id} isExpanded={isExpanded}>
-                                    <Tr>
-                                        <Td
-                                            expand={
-                                                row.children.length
-                                                    ? {
-                                                          rowIndex,
-                                                          isExpanded,
-                                                          onToggle: () =>
-                                                              setRowExpanded(row, !isExpanded),
-                                                          expandId: 'flow-expandable',
-                                                      }
-                                                    : undefined
-                                            }
-                                        />
-                                        <Td
-                                            select={
-                                                row.children.length === 0
-                                                    ? {
-                                                          rowIndex,
-                                                          onSelect: (_event, isSelecting) =>
-                                                              setRowSelected(row, isSelecting),
-                                                          isSelected: isRowSelected(row),
-                                                          disable: !!row.children.length,
-                                                      }
-                                                    : undefined
-                                            }
-                                        />
-                                        <Td dataLabel={columnNames.entity}>
-                                            <Flex direction={{ default: 'row' }}>
-                                                <FlexItem>
-                                                    <div>{row.entity}</div>
-                                                    <div>
-                                                        <TextContent>
-                                                            <Text component={TextVariants.small}>
-                                                                {row.type === 'Deployment'
-                                                                    ? `in "${row.namespace}"`
-                                                                    : `${row.children.length} active flows`}
-                                                            </Text>
-                                                        </TextContent>
-                                                    </div>
-                                                </FlexItem>
-                                                {row.isAnomalous && (
-                                                    <FlexItem>
-                                                        <ExclamationCircleIcon className="pf-u-danger-color-100" />
-                                                    </FlexItem>
-                                                )}
-                                            </Flex>
-                                        </Td>
-                                        <Td dataLabel={columnNames.direction}>{row.direction}</Td>
-                                        <Td dataLabel={columnNames.portAndProtocol}>
-                                            {row.port} / {row.protocol}
-                                        </Td>
-                                        <Td isActionCell>
-                                            {!row.children.length && (
-                                                <ActionsColumn items={rowActions} />
-                                            )}
-                                        </Td>
-                                    </Tr>
-                                    {isExpanded &&
-                                        row.children.map((child) => {
-                                            const childActions: IAction[] = [
-                                                child.isAnomalous
-                                                    ? {
-                                                          itemKey: 'add-flow-to-baseline',
-                                                          title: 'Add to baseline',
-                                                          onClick: () => {},
-                                                      }
-                                                    : {
-                                                          itemKey: 'mark-flow-as-anomalous',
-                                                          title: 'Mark as anomalous',
-                                                          onClick: () => {},
-                                                      },
-                                            ];
-
-                                            return (
-                                                <Tr key={child.id} isExpanded={isExpanded}>
-                                                    <Td />
-                                                    <Td
-                                                        select={{
-                                                            rowIndex,
-                                                            onSelect: (_event, isSelecting) =>
-                                                                setRowSelected(child, isSelecting),
-                                                            isSelected: isRowSelected(child),
-                                                        }}
-                                                    />
-                                                    <Td>
-                                                        <ExpandableRowContent>
-                                                            <Flex direction={{ default: 'row' }}>
-                                                                <FlexItem>{child.entity}</FlexItem>
-                                                                {row.isAnomalous && (
-                                                                    <FlexItem>
-                                                                        <ExclamationCircleIcon className="pf-u-danger-color-100" />
-                                                                    </FlexItem>
-                                                                )}
-                                                            </Flex>
-                                                        </ExpandableRowContent>
-                                                    </Td>
-                                                    <Td>
-                                                        <ExpandableRowContent>
-                                                            {child.direction}
-                                                        </ExpandableRowContent>
-                                                    </Td>
-                                                    <Td>
-                                                        <ExpandableRowContent>
-                                                            {child.port} / {child.protocol}
-                                                        </ExpandableRowContent>
-                                                    </Td>
-                                                    <Td isActionCell>
-                                                        <ActionsColumn items={childActions} />
-                                                    </Td>
-                                                </Tr>
-                                            );
-                                        })}
-                                </Tbody>
-                            );
-                        })}
-                    </TableComposable>
+                    <FlowsTable
+                        label="Deployment flows"
+                        flows={flows}
+                        numFlows={numFlows}
+                        expandedRows={expandedRows}
+                        setExpandedRows={setExpandedRows}
+                        selectedRows={selectedRows}
+                        setSelectedRows={setSelectedRows}
+                    />
                 </StackItem>
             </Stack>
         </div>

--- a/ui/apps/platform/src/Containers/NetworkGraph/types.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/types.ts
@@ -1,4 +1,4 @@
-export interface FlowBase {
+export type IndividualFlow = {
     id: string;
     type: 'Deployment' | 'External';
     entity: string;
@@ -7,8 +7,19 @@ export interface FlowBase {
     port: string;
     protocol: string;
     isAnomalous: boolean;
-}
+    children?: undefined;
+};
 
-export interface Flow extends FlowBase {
-    children: FlowBase[];
-}
+export type AggregatedFlow = {
+    id: string;
+    type: 'Deployment' | 'External';
+    entity: string;
+    namespace: string;
+    direction: string;
+    port: string;
+    protocol: string;
+    isAnomalous: boolean;
+    children: IndividualFlow[];
+};
+
+export type Flow = IndividualFlow | AggregatedFlow;

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/flowUtils.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/flowUtils.ts
@@ -3,7 +3,7 @@ import { Flow } from '../types';
 
 export function getAllUniquePorts(flows: Flow[]) {
     const allPorts = flows.reduce((acc, curr) => {
-        if (curr.children.length) {
+        if (curr.children && curr.children.length) {
             return [...acc, ...curr.children.map((child) => child.port)];
         }
         return [...acc, curr.port];
@@ -15,7 +15,7 @@ export function getAllUniquePorts(flows: Flow[]) {
 export function getNumFlows(flows: Flow[]) {
     const numFlows = flows.reduce((acc, curr) => {
         // if there are no children then it counts as 1 flow
-        return acc + (curr.children.length ? curr.children.length : 1);
+        return acc + (curr.children && curr.children.length ? curr.children.length : 1);
     }, 0);
     return numFlows;
 }

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/flowUtils.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/flowUtils.ts
@@ -11,3 +11,11 @@ export function getAllUniquePorts(flows: Flow[]) {
     const allUniquePorts = uniq(allPorts);
     return allUniquePorts;
 }
+
+export function getNumFlows(flows: Flow[]) {
+    const numFlows = flows.reduce((acc, curr) => {
+        // if there are no children then it counts as 1 flow
+        return acc + (curr.children.length ? curr.children.length : 1);
+    }, 0);
+    return numFlows;
+}


### PR DESCRIPTION
## Description

This PR adds the baselines table. Changes include the following:
1. Because there is similar logic between flows and baselines, I encapsulated the table logic into a separate component called `FlowsTable`
2. I created a new util function called `getNumFlows` that is used for flows and baselines

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Screenshots

<img width="454" alt="Screenshot 2022-11-21 at 5 12 30 PM" src="https://user-images.githubusercontent.com/4805485/203190181-e9516626-68ca-4ec4-af21-9aec5744b0df.png">


