### PR TITLE
GHA: fix create-release for milestones

### DIFF
--- a/.github/workflows/cut-rc.yml
+++ b/.github/workflows/cut-rc.yml
@@ -267,7 +267,7 @@ jobs:
           set -uo pipefail
           gh api -H "$ACCEPT_RAW" "${{env.script_url}}" | bash -s -- \
             create-release \
-            "${{ needs.variables.outputs.named-release-patch }}" \
+            "${{ needs.variables.outputs.milestone }}" \
             "true"
 
       - run: |

--- a/.github/workflows/scripts/create-release.sh
+++ b/.github/workflows/scripts/create-release.sh
@@ -23,7 +23,8 @@ create_release_notes() {
       -H "Accept: application/vnd.github.v3.raw" \
       "/repos/${GITHUB_REPOSITORY}/contents/CHANGELOG.md?ref=${TAG}"
     )"
-    ESCAPED_VERSION="${TAG//./\.}"
+    VERSION_WITHOUT_RC="${TAG/-rc.[0-9]*/}"
+    ESCAPED_VERSION="${VERSION_WITHOUT_RC//./\.}"
     OUTPUT="$(echo "$CHANGELOG" | sed -n "/^## \[$ESCAPED_VERSION]$/,/^## \[/p" | sed '1d;$d')"
     if [ "$(wc -m <<< "$OUTPUT" | awk '{ print $1 }')" -gt 150000 ]; then
         PREVIOUS_VERSION=$(echo "$CHANGELOG" | sed -n "/^## \[$ESCAPED_VERSION]$/,/^## \[/p" | tail -n 1 | tr -d '#[] ')


### PR DESCRIPTION
## Description

Failure: https://github.com/stackrox/stackrox/actions/runs/3514552051.

Cherry-picking changes from https://github.com/stackrox/stackrox/pull/3726.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Tested in #3726 and used successfully in https://github.com/stackrox/stackrox/actions/runs/3414350064. 

