### PR TITLE
ROX-13449: Keep compatibility tests running after failure

### DIFF
--- a/qa-tests-backend/scripts/run-compatibility.sh
+++ b/qa-tests-backend/scripts/run-compatibility.sh
@@ -47,7 +47,7 @@ compatibility_test() {
 
     export CLUSTER="${ORCHESTRATOR_FLAVOR^^}"
 
-    make -C qa-tests-backend compatibility-test || touch FAIL
+    make -C qa-tests-backend compatibility-test FAIL_FAST=FALSE || touch FAIL
 
     store_qa_test_results "compatibility-test-sensor-$SENSOR_IMAGE_TAG"
     [[ ! -f FAIL ]] || die "compatibility-test-sensor-$SENSOR_IMAGE_TAG"

--- a/qa-tests-backend/src/test/groovy/CertExpiryTest.groovy
+++ b/qa-tests-backend/src/test/groovy/CertExpiryTest.groovy
@@ -6,7 +6,7 @@ import util.Cert
 
 @Category([BAT, COMPATIBILITY])
 class CertExpiryTest extends BaseSpecification {
-    def: "Failing test"() {
+    def "Failing test - Delete before merging"() {
         when:
         "This test is supposed to fail"
 

--- a/qa-tests-backend/src/test/groovy/CertExpiryTest.groovy
+++ b/qa-tests-backend/src/test/groovy/CertExpiryTest.groovy
@@ -6,6 +6,7 @@ import util.Cert
 
 @Category([BAT, COMPATIBILITY])
 class CertExpiryTest extends BaseSpecification {
+//TODO(ROX-13449): Delete the following test case before merging
     def "Failing test - Delete before merging"() {
         when:
         "This test is supposed to fail"

--- a/qa-tests-backend/src/test/groovy/CertExpiryTest.groovy
+++ b/qa-tests-backend/src/test/groovy/CertExpiryTest.groovy
@@ -6,6 +6,17 @@ import util.Cert
 
 @Category([BAT, COMPATIBILITY])
 class CertExpiryTest extends BaseSpecification {
+
+//TODO(ROX-13449): Delete the following test case before merging
+    def "Failing test - Delete before merging"() {
+        when:
+        "This test is supposed to fail"
+
+        then:
+        "Check the behavior of the fail-fast flag in Prow"
+        assert False
+    }
+
     def "Test Central cert expiry"() {
         when:
         "Fetch the current central-tls secret, and the central cert expiry as returned by Central"

--- a/qa-tests-backend/src/test/groovy/CertExpiryTest.groovy
+++ b/qa-tests-backend/src/test/groovy/CertExpiryTest.groovy
@@ -6,16 +6,6 @@ import util.Cert
 
 @Category([BAT, COMPATIBILITY])
 class CertExpiryTest extends BaseSpecification {
-//TODO(ROX-13449): Delete the following test case before merging
-    def "Failing test - Delete before merging"() {
-        when:
-        "This test is supposed to fail"
-
-        then:
-        "Check the behavior of the fail-fast flag in Prow"
-        assert False
-    }
-
     def "Test Central cert expiry"() {
         when:
         "Fetch the current central-tls secret, and the central cert expiry as returned by Central"

--- a/qa-tests-backend/src/test/groovy/CertExpiryTest.groovy
+++ b/qa-tests-backend/src/test/groovy/CertExpiryTest.groovy
@@ -6,6 +6,14 @@ import util.Cert
 
 @Category([BAT, COMPATIBILITY])
 class CertExpiryTest extends BaseSpecification {
+    def: "Failing test"() {
+        when:
+        "This test is supposed to fail"
+
+        then:
+        "Check the behavior of the fail-fast flag in Prow"
+        assert False
+    }
 
     def "Test Central cert expiry"() {
         when:

--- a/qa-tests-backend/src/test/groovy/CertExpiryTest.groovy
+++ b/qa-tests-backend/src/test/groovy/CertExpiryTest.groovy
@@ -7,16 +7,6 @@ import util.Cert
 @Category([BAT, COMPATIBILITY])
 class CertExpiryTest extends BaseSpecification {
 
-//TODO(ROX-13449): Delete the following test case before merging
-    def "Failing test - Delete before merging"() {
-        when:
-        "This test is supposed to fail"
-
-        then:
-        "Check the behavior of the fail-fast flag in Prow"
-        assert False
-    }
-
     def "Test Central cert expiry"() {
         when:
         "Fetch the current central-tls secret, and the central cert expiry as returned by Central"

--- a/scripts/ci/jobs/gke_version_compatibility_tests.py
+++ b/scripts/ci/jobs/gke_version_compatibility_tests.py
@@ -23,4 +23,4 @@ for version in versions:
     try:
         make_compatibility_test_runner(cluster=gkecluster).run()
     except Exception:
-        pass
+        print(f"Exception \"{Exception}\" raised in compatibility test for sensor version {version}")

--- a/scripts/ci/jobs/gke_version_compatibility_tests.py
+++ b/scripts/ci/jobs/gke_version_compatibility_tests.py
@@ -20,4 +20,7 @@ gkecluster=GKECluster("qa-e2e-test")
 
 for version in versions:
     os.environ["SENSOR_IMAGE_TAG"] = version
-    make_compatibility_test_runner(cluster=gkecluster).run()
+    try:
+        make_compatibility_test_runner(cluster=gkecluster).run()
+    except Exception:
+        pass

--- a/scripts/ci/jobs/gke_version_compatibility_tests.py
+++ b/scripts/ci/jobs/gke_version_compatibility_tests.py
@@ -18,9 +18,17 @@ versions=get_latest_release_versions(4)
 
 gkecluster=GKECluster("qa-e2e-test")
 
+sensor_failures_count = 0
 for version in versions:
     os.environ["SENSOR_IMAGE_TAG"] = version
     try:
         make_compatibility_test_runner(cluster=gkecluster).run()
     except Exception:
         print(f"Exception \"{Exception}\" raised in compatibility test for sensor version {version}")
+        sensor_failures_count += 1
+
+if sensor_failures_count > 0:
+    raise SensorVersionsFailure(f"Compatibility tests failed for {sensor_failures_count} Sensor versions.")
+
+class SensorVersionsFailure(Exception):
+    pass

--- a/scripts/ci/jobs/gke_version_compatibility_tests.py
+++ b/scripts/ci/jobs/gke_version_compatibility_tests.py
@@ -28,7 +28,7 @@ for version in versions:
         failing_sensor_versions += version
 
 if len(failing_sensor_versions) > 0:
-    raise SensorVersionsFailure(f"Compatibility tests failed for Sensor versions {failing_sensor_versions}.")
+    raise SensorVersionsFailure(f"Compatibility tests failed for Sensor versions " + ', '.join(failing_sensor_versions))
 
 class SensorVersionsFailure(Exception):
     pass

--- a/scripts/ci/jobs/gke_version_compatibility_tests.py
+++ b/scripts/ci/jobs/gke_version_compatibility_tests.py
@@ -18,17 +18,17 @@ versions=get_latest_release_versions(4)
 
 gkecluster=GKECluster("qa-e2e-test")
 
-sensor_failures_count = 0
+failing_sensor_versions = []
 for version in versions:
     os.environ["SENSOR_IMAGE_TAG"] = version
     try:
         make_compatibility_test_runner(cluster=gkecluster).run()
     except Exception:
         print(f"Exception \"{Exception}\" raised in compatibility test for sensor version {version}")
-        sensor_failures_count += 1
+        failing_sensor_versions += version
 
-if sensor_failures_count > 0:
-    raise SensorVersionsFailure(f"Compatibility tests failed for {sensor_failures_count} Sensor versions.")
+if len(failing_sensor_versions) > 0:
+    raise SensorVersionsFailure(f"Compatibility tests failed for Sensor versions {failing_sensor_versions}.")
 
 class SensorVersionsFailure(Exception):
     pass


### PR DESCRIPTION
Disabled the FAIL-FAST flag for gke-version-compatibility-tests to ensure test runs continue after a failure, added a try / catch block to the python loop calling those tests to keep running tests for the next sensor version after failure.

Added an always failing test for to ensure test failing behaviour can be checked, this will be deleted before merging.