### PR TITLE
Remove python from central-db

### DIFF
--- a/image/postgres/Dockerfile.envsubst
+++ b/image/postgres/Dockerfile.envsubst
@@ -27,6 +27,7 @@ COPY scripts/init-entrypoint.sh /usr/local/bin/
 COPY --from=extracted_bundle /bundle/postgres.rpm /bundle/postgres-libs.rpm /bundle/postgres-server.rpm /bundle/postgres-contrib.rpm /tmp/
 
 RUN microdnf upgrade -y --nobest && \
+    # groupadd is in shadow-utils package that is not installed by default.
     microdnf install -y shadow-utils && \
     groupadd -g 70 postgres && \
     adduser postgres -u 70 -g 70 -d /var/lib/postgresql -s /bin/sh && \
@@ -36,10 +37,7 @@ RUN microdnf upgrade -y --nobest && \
         glibc-locale-source glibc-langpack-en \
         perl-libs libxslt && \
     rpm -i /tmp/postgres-libs.rpm /tmp/postgres-server.rpm /tmp/postgres.rpm /tmp/postgres-contrib.rpm && \
-    # The removal of /usr/share/zoneinfo from UBI minimal images is intentional.
-    # After building the image, the image is reduced in size as much as possible,
-    # and the /usr/share/zoneinfo directory is purged as it saves space
-    # in the final distribution of the image.
+    # Restore /usr/share/zoneinfo that's empty in ubi-minimal because postgres reads timezone data from it.
     # https://access.redhat.com/solutions/5616681
     microdnf reinstall tzdata && \
     microdnf clean all && \

--- a/image/postgres/Dockerfile.envsubst
+++ b/image/postgres/Dockerfile.envsubst
@@ -26,14 +26,16 @@ COPY scripts/docker-entrypoint.sh /usr/local/bin/
 COPY scripts/init-entrypoint.sh /usr/local/bin/
 COPY --from=extracted_bundle /bundle/postgres.rpm /bundle/postgres-libs.rpm /bundle/postgres-server.rpm /bundle/postgres-contrib.rpm /tmp/
 
-RUN groupadd -g 70 postgres && \
+RUN microdnf upgrade -y --nobest && \
+    microdnf install -y shadow-utils && \
+    groupadd -g 70 postgres && \
     adduser postgres -u 70 -g 70 -d /var/lib/postgresql -s /bin/sh && \
     rpm --import RPM-GPG-KEY-PGDG-13 && \
-    microdnf upgrade -y --nobest && \
     microdnf install -y \
         ca-certificates libicu systemd-sysv \
         glibc-locale-source glibc-langpack-en \
-        /tmp/postgres-libs.rpm /tmp/postgres-server.rpm /tmp/postgres.rpm /tmp/postgres-contrib.rpm && \
+        perl-libs libxslt && \
+    rpm -i /tmp/postgres-libs.rpm /tmp/postgres-server.rpm /tmp/postgres.rpm /tmp/postgres-contrib.rpm && \
     # The removal of /usr/share/zoneinfo from UBI minimal images is intentional.
     # After building the image, the image is reduced in size as much as possible,
     # and the /usr/share/zoneinfo directory is purged as it saves space

--- a/image/postgres/Dockerfile.envsubst
+++ b/image/postgres/Dockerfile.envsubst
@@ -1,6 +1,6 @@
 ARG BASE_REGISTRY=registry.access.redhat.com
-ARG BASE_IMAGE=ubi8/ubi
-ARG BASE_TAG=8.6
+ARG BASE_IMAGE=ubi8-minimal
+ARG BASE_TAG=8.7
 
 FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG} AS extracted_bundle
 
@@ -29,12 +29,18 @@ COPY --from=extracted_bundle /bundle/postgres.rpm /bundle/postgres-libs.rpm /bun
 RUN groupadd -g 70 postgres && \
     adduser postgres -u 70 -g 70 -d /var/lib/postgresql -s /bin/sh && \
     rpm --import RPM-GPG-KEY-PGDG-13 && \
-    dnf upgrade -y --nobest && \
-    dnf install -y \
+    microdnf upgrade -y --nobest && \
+    microdnf install -y \
         ca-certificates libicu systemd-sysv \
         glibc-locale-source glibc-langpack-en \
         /tmp/postgres-libs.rpm /tmp/postgres-server.rpm /tmp/postgres.rpm /tmp/postgres-contrib.rpm && \
-    dnf clean all && \
+    # The removal of /usr/share/zoneinfo from UBI minimal images is intentional.
+    # After building the image, the image is reduced in size as much as possible,
+    # and the /usr/share/zoneinfo directory is purged as it saves space
+    # in the final distribution of the image.
+    # https://access.redhat.com/solutions/5616681
+    microdnf reinstall tzdata && \
+    microdnf clean all && \
     rpm -e --nodeps $(rpm -qa curl '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*') && \
     rm -rf /var/cache/dnf /var/cache/yum && \
     localedef -f UTF-8 -i en_US en_US.UTF-8 && \


### PR DESCRIPTION
## Description

Python has many CVEs that are problematic for us during release. This PR reduce number of installed packages by switching to ubi-minimal. 

Refs: https://github.com/stackrox/scanner/pull/956
See: https://quay.io/repository/rhacs-eng/central-db/manifest/sha256:44ff7bdb6cec4b50bd22e6b93e26df78c33fdef421a61a5b5260faabf218a6ec?tab=vulnerabilities

## Testing Performed

CI