### PR TITLE
Add error screen for collections with configurations unsupported by the UI

### DIFF
--- a/ui/apps/platform/src/Containers/Collections/CollectionFormDrawer.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionFormDrawer.tsx
@@ -15,8 +15,9 @@ import {
 import { CollectionResponse } from 'services/CollectionsService';
 import { CollectionPageAction } from './collections.utils';
 import CollectionResults from './CollectionResults';
-import { parseCollection } from './converter';
+import { isCollectionParseError, parseCollection } from './converter';
 import CollectionForm, { CollectionFormProps } from './CollectionForm';
+import UnsupportedCollectionState from './UnsupportedCollectionState';
 
 export type CollectionFormDrawerProps = {
     hasWriteAccessForCollections: boolean;
@@ -85,11 +86,11 @@ function CollectionFormDrawer({
                 >
                     <DrawerContentBody className="pf-u-background-color-100 pf-u-display-flex pf-u-flex-direction-column">
                         {headerContent}
-                        {initialData instanceof AggregateError ? (
-                            <>
-                                {initialData.errors}
-                                {/* TODO - Handle inline UI for unsupported rule errors */}
-                            </>
+                        {isCollectionParseError(initialData) ? (
+                            <UnsupportedCollectionState
+                                className="pf-u-pt-xl"
+                                errors={initialData.errors}
+                            />
                         ) : (
                             <CollectionForm
                                 hasWriteAccessForCollections={hasWriteAccessForCollections}

--- a/ui/apps/platform/src/Containers/Collections/UnsupportedCollectionState.tsx
+++ b/ui/apps/platform/src/Containers/Collections/UnsupportedCollectionState.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { ExpandableSection, List, ListItem } from '@patternfly/react-core';
+import { InfoCircleIcon } from '@patternfly/react-icons';
+
+import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';
+import { CollectionParseError } from './converter';
+
+export type UnsupportedCollectionStateProps = {
+    errors: CollectionParseError['errors'];
+    className?: string;
+};
+
+function UnsupportedCollectionState({ errors, className = '' }: UnsupportedCollectionStateProps) {
+    return (
+        <div className={className}>
+            <EmptyStateTemplate
+                title="This collection cannot be displayed"
+                headingLevel="h2"
+                icon={InfoCircleIcon}
+            >
+                <p className="pf-u-pb-lg">
+                    This collection is valid but cannot be displayed nor edited through the ACS UI
+                </p>
+                <ExpandableSection toggleText="More info">
+                    <List className="pf-u-text-align-left">
+                        {errors.map((err) => (
+                            <ListItem key={err}>{err}</ListItem>
+                        ))}
+                    </List>
+                </ExpandableSection>
+            </EmptyStateTemplate>
+        </div>
+    );
+}
+
+export default UnsupportedCollectionState;

--- a/ui/apps/platform/src/Containers/Collections/UnsupportedCollectionState.tsx
+++ b/ui/apps/platform/src/Containers/Collections/UnsupportedCollectionState.tsx
@@ -19,7 +19,8 @@ function UnsupportedCollectionState({ errors, className = '' }: UnsupportedColle
                 icon={InfoCircleIcon}
             >
                 <p className="pf-u-pb-lg">
-                    This collection is valid but cannot be displayed nor edited through the ACS UI
+                    This collection is valid but cannot be displayed nor edited through the user
+                    interface
                 </p>
                 <ExpandableSection toggleText="More info">
                     <List className="pf-u-text-align-left">

--- a/ui/apps/platform/src/Containers/Collections/converter.test.ts
+++ b/ui/apps/platform/src/Containers/Collections/converter.test.ts
@@ -1,5 +1,5 @@
 import { CollectionRequest, CollectionResponse } from 'services/CollectionsService';
-import { generateRequest, parseCollection } from './converter';
+import { generateRequest, isCollectionParseError, parseCollection } from './converter';
 import { ByLabelResourceSelector, Collection, LabelSelectorRule } from './types';
 
 describe('Collection parser', () => {
@@ -66,7 +66,7 @@ describe('Collection parser', () => {
             embeddedCollectionIds: ['12', '13', '14'],
         };
         const parsedResponse = parseCollection(collectionResponse) as Collection;
-        expect(parsedResponse).not.toBeInstanceOf(AggregateError);
+        expect(isCollectionParseError(parsedResponse)).toBeFalsy();
         expect(parsedResponse.id).toEqual(expectedCollection.id);
         expect(parsedResponse.name).toEqual(expectedCollection.name);
         expect(parsedResponse.description).toEqual(expectedCollection.description);
@@ -87,7 +87,7 @@ describe('Collection parser', () => {
             resourceSelectors: [{ rules: [] }, { rules: [] }],
             embeddedCollections: [],
         };
-        expect(parseCollection(collectionResponse)).toBeInstanceOf(AggregateError);
+        expect(isCollectionParseError(parseCollection(collectionResponse))).toBeTruthy();
     });
 
     it('should error on rules for multiple fields for a single entity', () => {
@@ -115,7 +115,7 @@ describe('Collection parser', () => {
             embeddedCollections: [],
         };
 
-        expect(parseCollection(collectionResponse)).toBeInstanceOf(AggregateError);
+        expect(isCollectionParseError(parseCollection(collectionResponse))).toBeTruthy();
     });
 
     it('should error on conjunction rules', () => {
@@ -138,7 +138,7 @@ describe('Collection parser', () => {
             embeddedCollections: [],
         };
 
-        expect(parseCollection(collectionResponse)).toBeInstanceOf(AggregateError);
+        expect(isCollectionParseError(parseCollection(collectionResponse))).toBeTruthy();
     });
 
     it('should error on rules against annotation field names', () => {
@@ -161,7 +161,7 @@ describe('Collection parser', () => {
             embeddedCollections: [],
         };
 
-        expect(parseCollection(collectionResponse)).toBeInstanceOf(AggregateError);
+        expect(isCollectionParseError(parseCollection(collectionResponse))).toBeTruthy();
     });
 
     it('should correctly handle label key/value splitting on `=` delimiter', () => {

--- a/ui/apps/platform/src/utils/type.utils.ts
+++ b/ui/apps/platform/src/utils/type.utils.ts
@@ -6,3 +6,11 @@
 export function ensureExhaustive(_: never): never {
     return _;
 }
+
+/**
+ * Type guard to check if an array is empty, and if so, narrows the array
+ * to a tuple that guarantees at least one element.
+ */
+export function isNonEmptyArray<T>(arr: T[]): arr is [T, ...T[]] {
+    return arr.length > 0;
+}


### PR DESCRIPTION
## Description

This adds a UI screen for when a collection response returned from the server contains valid configuration rules that cannot be displayed in the UI. Although these collections cannot be viewed or edited with the UI controls, their results can still be viewed and they can be attached to other collections.

This should occur rarely (or not at all) since the server checks most of these situations on create/edit, but this is a more user-friendly fallback instead of an error.

### Follow ups

- Work with UX and/or docs team on better wording for the specific error messages.
- If possible, remove the "Edit" and "Clone" options from the header dropdown.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Navigate to a collection page with rules that are unsupported by the UI. Note that this can only be accomplished currently by creating the collection via the API, and only by creating a collection with rules for two different fields for the same entity type. (e.g. A single collection with a rule for "Namespace" and "Namespace Label".) The collection page will display the following UI. Collection results will still be able to be displayed.
![image](https://user-images.githubusercontent.com/1292638/203347401-0671ab42-1641-4df6-a6bd-2298465a7d6c.png)

The  "More info" section can expand to give details information on why the collection cannot be displayed. (Better error info is TBD.)
![image](https://user-images.githubusercontent.com/1292638/203347593-4432d49a-4dc9-4768-af8d-e33d7ac973ae.png)

This collection can still be attached to other collections without error:
![image](https://user-images.githubusercontent.com/1292638/203347740-17d84a9b-ebe7-4df2-8fc3-790abd06bf80.png)

Viewing the collection in a modal will still display the error screen:
![image](https://user-images.githubusercontent.com/1292638/203347837-fed4d251-42fb-406f-a33f-2ee72e91cf70.png)



