### PR TITLE
Add loading and error components for the getCollection request

### DIFF
--- a/ui/apps/platform/src/Containers/Collections/CollectionFormModal.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionFormModal.tsx
@@ -1,5 +1,15 @@
 import React, { ReactElement } from 'react';
-import { Button, Divider, Flex, FlexItem, Modal, Title, Truncate } from '@patternfly/react-core';
+import {
+    Bullseye,
+    Button,
+    Divider,
+    Flex,
+    FlexItem,
+    Modal,
+    Spinner,
+    Title,
+    Truncate,
+} from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import { useMediaQuery } from 'react-responsive';
 
@@ -8,6 +18,7 @@ import { collectionsBasePath } from 'routePaths';
 import { CollectionResponse } from 'services/CollectionsService';
 import useCollection from './hooks/useCollection';
 import CollectionFormDrawer, { CollectionFormDrawerProps } from './CollectionFormDrawer';
+import CollectionLoadError from './CollectionLoadError';
 
 export type CollectionsFormModalProps = {
     hasWriteAccessForCollections: boolean;
@@ -60,75 +71,94 @@ function CollectionsFormModal({
 
     let content: ReactElement | null = null;
 
+    let modalTitle = '';
+
     if (error) {
         content = (
-            <>
-                {error.message}
-                {/* TODO - Handle UI for network errors */}
-            </>
+            <Bullseye className="pf-u-p-2xl">
+                <CollectionLoadError error={error} />
+            </Bullseye>
         );
+        modalTitle = 'Collection error';
     } else if (loading) {
-        content = <>{/* TODO - Handle UI for loading state */}</>;
+        content = (
+            <Bullseye className="pf-u-p-2xl">
+                <Spinner isSVG />
+            </Bullseye>
+        );
+        modalTitle = 'Loading collection';
     } else if (data) {
         content = (
-            <Modal
-                isOpen
-                onClose={onClose}
-                aria-label={`View ${data.collection.name}`}
-                width="90vw"
-                hasNoBodyWrapper
-                header={
-                    <Flex className="pf-u-pb-md" alignItems={{ default: 'alignItemsCenter' }}>
-                        <FlexItem grow={{ default: 'grow' }}>
-                            <Title headingLevel="h2">{data.collection.name}</Title>
-                        </FlexItem>
-                        {hasWriteAccessForCollections && (
-                            <Button
-                                variant="link"
-                                component="a"
-                                href={`${collectionsBasePath}/${collectionId}?action=edit`}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                icon={<ExternalLinkAltIcon />}
-                                iconPosition="right"
-                            >
-                                Edit collection
-                            </Button>
-                        )}
-                        {isDrawerOpen ? (
-                            <Button variant="secondary" onClick={closeDrawer}>
-                                Hide results
-                            </Button>
-                        ) : (
-                            <Button variant="secondary" onClick={openDrawer}>
-                                Preview results
-                            </Button>
-                        )}
-                        <Divider orientation={{ default: 'vertical' }} component="div" />
-                    </Flex>
-                }
-            >
-                <Divider component="div" />
-                <CollectionFormDrawer
-                    // We do not want to present the user with options to change the collection when in this modal
-                    hasWriteAccessForCollections={false}
-                    action={{
-                        type: 'view',
-                        collectionId,
-                    }}
-                    collectionData={data}
-                    isInlineDrawer={isLargeScreen}
-                    isDrawerOpen={isDrawerOpen}
-                    toggleDrawer={toggleDrawer}
-                    // Since the form cannot be submitted, stub this out with an empty promise
-                    onSubmit={() => Promise.resolve()}
-                    getCollectionTableCells={getCollectionTableCells}
-                />
-            </Modal>
+            <CollectionFormDrawer
+                // We do not want to present the user with options to change the collection when in this modal
+                hasWriteAccessForCollections={false}
+                action={{
+                    type: 'view',
+                    collectionId,
+                }}
+                collectionData={data}
+                isInlineDrawer={isLargeScreen}
+                isDrawerOpen={isDrawerOpen}
+                toggleDrawer={toggleDrawer}
+                // Since the form cannot be submitted, stub this out with an empty promise
+                onSubmit={() => Promise.resolve()}
+                getCollectionTableCells={getCollectionTableCells}
+            />
         );
+        modalTitle = data.collection.name;
     }
 
-    return content;
+    const modalHeaderButtons =
+        error || loading ? (
+            ''
+        ) : (
+            <>
+                {hasWriteAccessForCollections && (
+                    <Button
+                        variant="link"
+                        component="a"
+                        href={`${collectionsBasePath}/${collectionId}?action=edit`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        icon={<ExternalLinkAltIcon />}
+                        iconPosition="right"
+                    >
+                        Edit collection
+                    </Button>
+                )}
+                {isDrawerOpen ? (
+                    <Button variant="secondary" onClick={closeDrawer}>
+                        Hide results
+                    </Button>
+                ) : (
+                    <Button variant="secondary" onClick={openDrawer}>
+                        Preview results
+                    </Button>
+                )}
+                <Divider orientation={{ default: 'vertical' }} component="div" />
+            </>
+        );
+
+    return (
+        <Modal
+            isOpen
+            onClose={onClose}
+            aria-label={modalTitle}
+            width="90vw"
+            hasNoBodyWrapper
+            header={
+                <Flex className="pf-u-pb-md" alignItems={{ default: 'alignItemsCenter' }}>
+                    <FlexItem grow={{ default: 'grow' }}>
+                        <Title headingLevel="h2">{modalTitle}</Title>
+                    </FlexItem>
+                    {modalHeaderButtons}
+                </Flex>
+            }
+        >
+            <Divider component="div" />
+            {content}
+        </Modal>
+    );
 }
 
 export default CollectionsFormModal;

--- a/ui/apps/platform/src/Containers/Collections/CollectionLoadError.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionLoadError.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { Bullseye, Title } from '@patternfly/react-core';
+import { ExclamationCircleIcon } from '@patternfly/react-icons';
+import { SVGIconProps } from '@patternfly/react-icons/dist/esm/createIcon';
+
+import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';
+import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
+
+export type CollectionLoadErrorProps = {
+    error: Error;
+};
+
+function ErrorIcon(props: SVGIconProps) {
+    return (
+        <ExclamationCircleIcon
+            {...props}
+            style={{ color: 'var(--pf-global--danger-color--200)' }}
+        />
+    );
+}
+
+function CollectionLoadError({ error }: CollectionLoadErrorProps) {
+    return (
+        <Bullseye>
+            <EmptyStateTemplate
+                title="There was an error loading this collection"
+                headingLevel="h2"
+                icon={ErrorIcon}
+            >
+                <Title headingLevel="h3">{getAxiosErrorMessage(error)}</Title>
+            </EmptyStateTemplate>
+        </Bullseye>
+    );
+}
+
+export default CollectionLoadError;

--- a/ui/apps/platform/src/Containers/Collections/CollectionsFormPage.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionsFormPage.tsx
@@ -6,6 +6,7 @@ import {
     AlertGroup,
     Breadcrumb,
     BreadcrumbItem,
+    Bullseye,
     Button,
     Divider,
     Dropdown,
@@ -15,6 +16,7 @@ import {
     Flex,
     FlexItem,
     PageSection,
+    Spinner,
     Title,
     Tooltip,
     Truncate,
@@ -35,6 +37,7 @@ import { Collection } from './types';
 import useCollection from './hooks/useCollection';
 import CollectionsFormModal from './CollectionFormModal';
 import { CollectionSaveError, parseSaveError } from './errorUtils';
+import CollectionLoadError from './CollectionLoadError';
 
 export type CollectionsFormPageProps = {
     hasWriteAccessForCollections: boolean;
@@ -195,12 +198,19 @@ function CollectionsFormPage({
     if (error) {
         content = (
             <>
-                {error.message}
-                {/* TODO - Handle UI for network errors */}
+                <Breadcrumb className="pf-u-my-xs pf-u-px-lg pf-u-py-md">
+                    <BreadcrumbItemLink to={collectionsBasePath}>Collections</BreadcrumbItemLink>
+                </Breadcrumb>
+                <Divider component="div" />
+                <CollectionLoadError error={error} />
             </>
         );
     } else if (loading) {
-        content = <>{/* TODO - Handle UI for loading state */}</>;
+        content = (
+            <Bullseye>
+                <Spinner isSVG />
+            </Bullseye>
+        );
     } else if (data) {
         const pageTitle = pageAction.type === 'create' ? 'Create collection' : data.collection.name;
         content = (


### PR DESCRIPTION
## Description

This adds the missing loading and error states for the getCollection request, on the main page and within a modal.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

The following test will require mocking or modification of the service code to force loading states and failures.

Visit the collection page for a single collection to see the loading state.
![image](https://user-images.githubusercontent.com/1292638/203392356-3db4b758-44da-40bd-8c5f-1bb6a83f307c.png)

Visit the collection page when a net request fails to see the error state.
![image](https://user-images.githubusercontent.com/1292638/203637109-7100c91c-85f2-47ca-923f-21c812b1b96d.png)


Open a collection modal from the main form page to see the loading state in the modal:
![image](https://user-images.githubusercontent.com/1292638/203393833-42a91a9d-4ec2-4bbf-ae81-fd3e9f8a4dd8.png)

Open a collection modal when a net request fails to see the error state in the modal:
![image](https://user-images.githubusercontent.com/1292638/203637286-37d39618-5442-4758-b274-d89629f29e28.png)

