### PR TITLE
Update prettier 2.8.0 devDependencies in ui

### DIFF
--- a/ui/apps/platform/package.json
+++ b/ui/apps/platform/package.json
@@ -159,7 +159,7 @@
         "npm-run-all": "^4.1.5",
         "postcss": "^8.3.4",
         "postcss-cli": "^8.3.1",
-        "prettier": "^2.7.1",
+        "prettier": "^2.8.0",
         "randomstring": "^1.2.1",
         "react-scripts": "^5.0.1",
         "react-test-renderer": "^17.0.2",

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/QuayIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/QuayIntegrationForm.tsx
@@ -327,56 +327,58 @@ function QuayIntegrationForm({
                             }
                         />
                     </FormLabelGroup>
-                    {values.config.categories.includes('REGISTRY') && isQuayRobotAccountsEnabled && (
-                        <Grid hasGutter>
-                            <GridItem span={12} lg={6}>
-                                <FormLabelGroup
-                                    label="Robot username"
-                                    fieldId="config.quay.registryRobotCredentials.username"
-                                    touched={touched}
-                                    errors={errors}
-                                >
-                                    <TextInput
-                                        type="text"
-                                        id="config.quay.registryRobotCredentials.username"
-                                        value={
-                                            values.config.quay.registryRobotCredentials?.username ??
-                                            ''
-                                        }
-                                        onChange={onChangeRobotUsername}
-                                        onBlur={handleBlur}
-                                        isDisabled={!isEditable || !values.updatePassword}
-                                    />
-                                </FormLabelGroup>
-                            </GridItem>
-                            <GridItem span={12} lg={6}>
-                                <FormLabelGroup
-                                    label="Robot password"
-                                    fieldId="config.quay.registryRobotCredentials.password"
-                                    touched={touched}
-                                    errors={errors}
-                                >
-                                    <TextInput
-                                        type="password"
-                                        id="config.quay.registryRobotCredentials.password"
-                                        value={
-                                            values.config.quay.registryRobotCredentials?.password ??
-                                            ''
-                                        }
-                                        onChange={onChangeRobotPassword}
-                                        onBlur={handleBlur}
-                                        isDisabled={!isEditable || !values.updatePassword}
-                                        placeholder={
-                                            values.updatePassword ||
-                                            !values.config.quay.registryRobotCredentials?.username
-                                                ? ''
-                                                : 'Currently-stored password will be used.'
-                                        }
-                                    />
-                                </FormLabelGroup>
-                            </GridItem>
-                        </Grid>
-                    )}
+                    {values.config.categories.includes('REGISTRY') &&
+                        isQuayRobotAccountsEnabled && (
+                            <Grid hasGutter>
+                                <GridItem span={12} lg={6}>
+                                    <FormLabelGroup
+                                        label="Robot username"
+                                        fieldId="config.quay.registryRobotCredentials.username"
+                                        touched={touched}
+                                        errors={errors}
+                                    >
+                                        <TextInput
+                                            type="text"
+                                            id="config.quay.registryRobotCredentials.username"
+                                            value={
+                                                values.config.quay.registryRobotCredentials
+                                                    ?.username ?? ''
+                                            }
+                                            onChange={onChangeRobotUsername}
+                                            onBlur={handleBlur}
+                                            isDisabled={!isEditable || !values.updatePassword}
+                                        />
+                                    </FormLabelGroup>
+                                </GridItem>
+                                <GridItem span={12} lg={6}>
+                                    <FormLabelGroup
+                                        label="Robot password"
+                                        fieldId="config.quay.registryRobotCredentials.password"
+                                        touched={touched}
+                                        errors={errors}
+                                    >
+                                        <TextInput
+                                            type="password"
+                                            id="config.quay.registryRobotCredentials.password"
+                                            value={
+                                                values.config.quay.registryRobotCredentials
+                                                    ?.password ?? ''
+                                            }
+                                            onChange={onChangeRobotPassword}
+                                            onBlur={handleBlur}
+                                            isDisabled={!isEditable || !values.updatePassword}
+                                            placeholder={
+                                                values.updatePassword ||
+                                                !values.config.quay.registryRobotCredentials
+                                                    ?.username
+                                                    ? ''
+                                                    : 'Currently-stored password will be used.'
+                                            }
+                                        />
+                                    </FormLabelGroup>
+                                </GridItem>
+                            </Grid>
+                        )}
                     <FormLabelGroup
                         fieldId="config.quay.insecure"
                         touched={touched}

--- a/ui/packages/tailwind-config/package.json
+++ b/ui/packages/tailwind-config/package.json
@@ -38,7 +38,7 @@
         "eslint-plugin-prettier": "^4.0.0",
         "postcss": "^8.3.4",
         "postcss-cli": "^8.3.1",
-        "prettier": "^2.7.1",
+        "prettier": "^2.8.0",
         "tailwindcss": "^2.0.3"
     }
 }

--- a/ui/packages/ui-components/package.json
+++ b/ui/packages/ui-components/package.json
@@ -74,7 +74,7 @@
         "npm-run-all": "^4.1.5",
         "postcss": "^8.3.4",
         "postcss-cli": "^8.3.1",
-        "prettier": "^2.7.1",
+        "prettier": "^2.8.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "tailwindcss": "^2.0.3",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -15493,10 +15493,10 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^2.7.1:
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.7.1.tgz#e235806850d057f97bb08368a4f7d899f7760c64"
-  integrity sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==
+prettier@^2.8.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.0.tgz#c7df58393c9ba77d6fba3921ae01faf994fb9dc9"
+  integrity sha512-9Lmg8hTFZKG0Asr/kW9Bp8tJjRVluO8EJQVfY2T7FMw9T5jy4I/Uvx0Rca/XWf50QQ1/SS48+6IJWnrb+2yemA==
 
 pretty-bytes@^5.3.0:
   version "5.5.0"


### PR DESCRIPTION
## Description

Prettier updates soon after TypeScript, if any new features affect parsing or formatting.

https://prettier.io/blog/2022/11/23/2.8.0.html
* Support TypeScript 4.9 `satisfies` operator.
    Auto-cccessors in classes will be supported in an upcoming 2.8 patch release. We have de-scoped them for now to ship `satisfies` operator sooner.
* Do not save the cache if the `--write` option wasn't specified.
* Add `--cache-location` option.
* Fix docblock parsing.

The Prettier team plans to release 3.0 within the next few months. If you are a plugin developer, get ready for the migration.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

1. `yarn lint` in ui
2. `yarn prettier --write src/Containers/Integrations/IntegrationForm/Forms/QuayIntegrationForm.tsx` in ui/apps/platform to fix 50 errors from indentation change because different line break after `&&`