### PR TITLE
Revert "Bump ubi8-micro from 8.7 to 8.7-1 in /operator (#3889)"

### DIFF
--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -54,7 +54,7 @@ RUN GOOS=$(go env GOOS) GOARCH=$(go env GOARCH) scripts/go-build.sh operator
 # Copy the operator binary to a location from where it will be taken into the final image.
 RUN cp -a bin/$(go env GOOS)_$(go env GOARCH)/operator stackrox-operator
 
-FROM registry.access.redhat.com/ubi8-micro:8.7-1
+FROM registry.access.redhat.com/ubi8-micro:8.7
 
 ARG roxpath
 


### PR DESCRIPTION
## Description

This reverts commit 9e2ca730982836246a26bbe3f3fbe0c767217a5d, i.e. https://github.com/stackrox/stackrox/pull/3889.

We should not use finer-grained tags like `8.7-1` because `8.7` is a floating tag and it should be advanced whenever there's a new `8.7-x` image is build.

## Checklist
Won't do any of these:
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

* Not required. It worked with `8.7` before.