### PR TITLE
ROX-13216: Resolver component: implement deployment resolution given deployment ID reference

### DIFF
--- a/sensor/common/store/mocks/types.go
+++ b/sensor/common/store/mocks/types.go
@@ -368,3 +368,54 @@ func (mr *MockRBACStoreMockRecorder) GetPermissionLevelForDeployment(deployment 
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPermissionLevelForDeployment", reflect.TypeOf((*MockRBACStore)(nil).GetPermissionLevelForDeployment), deployment)
 }
+
+// MockProvider is a mock of Provider interface.
+type MockProvider struct {
+	ctrl     *gomock.Controller
+	recorder *MockProviderMockRecorder
+}
+
+// MockProviderMockRecorder is the mock recorder for MockProvider.
+type MockProviderMockRecorder struct {
+	mock *MockProvider
+}
+
+// NewMockProvider creates a new mock instance.
+func NewMockProvider(ctrl *gomock.Controller) *MockProvider {
+	mock := &MockProvider{ctrl: ctrl}
+	mock.recorder = &MockProviderMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockProvider) EXPECT() *MockProviderMockRecorder {
+	return m.recorder
+}
+
+// RBAC mocks base method.
+func (m *MockProvider) RBAC() store.RBACStore {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RBAC")
+	ret0, _ := ret[0].(store.RBACStore)
+	return ret0
+}
+
+// RBAC indicates an expected call of RBAC.
+func (mr *MockProviderMockRecorder) RBAC() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RBAC", reflect.TypeOf((*MockProvider)(nil).RBAC))
+}
+
+// Services mocks base method.
+func (m *MockProvider) Services() store.ServiceStore {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Services")
+	ret0, _ := ret[0].(store.ServiceStore)
+	return ret0
+}
+
+// Services indicates an expected call of Services.
+func (mr *MockProviderMockRecorder) Services() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Services", reflect.TypeOf((*MockProvider)(nil).Services))
+}

--- a/sensor/common/store/types.go
+++ b/sensor/common/store/types.go
@@ -52,3 +52,9 @@ type ServiceStore interface {
 type RBACStore interface {
 	GetPermissionLevelForDeployment(deployment rbac.NamespacedServiceAccount) storage.PermissionLevel
 }
+
+// Provider is a wrapper for injecting in memory stores as a dependency.
+type Provider interface {
+	Services() ServiceStore
+	RBAC() RBACStore
+}

--- a/sensor/kubernetes/eventpipeline/component/message.go
+++ b/sensor/kubernetes/eventpipeline/component/message.go
@@ -48,7 +48,7 @@ func NewResourceEvent(sensorMessages []*central.SensorEvent, detectionDeployment
 	}
 }
 
-// NewDeploymentRefEvent generates a resource event given a deployment reference.
+// NewDeploymentRefEvent returns a resource event given a deployment reference and a resource action.
 func NewDeploymentRefEvent(ref resolver.DeploymentReference, action central.ResourceAction) *ResourceEvent {
 	return &ResourceEvent{
 		DeploymentReference:  ref,

--- a/sensor/kubernetes/eventpipeline/component/message.go
+++ b/sensor/kubernetes/eventpipeline/component/message.go
@@ -31,6 +31,12 @@ type ResourceEvent struct {
 	// DeploymentReference returns an implementation of a struct that can return a list of deployment ids
 	// that require processing
 	DeploymentReference resolver.DeploymentReference
+
+	// ParentResourceAction is the resource action that will be sent to central on the deployment event.
+	// If the ResourceEvent originated on a deployment event, this should be set to whatever action triggered
+	// the event. For related resources updates, like RBACs and services, this should always be set to
+	// UPDATE.
+	ParentResourceAction central.ResourceAction
 }
 
 // NewResourceEvent wraps the SensorEvents, CompatibilityDetectionMessages, and the CompatibilityReprocessDeployments into a ResourceEvent message
@@ -43,9 +49,10 @@ func NewResourceEvent(sensorMessages []*central.SensorEvent, detectionDeployment
 }
 
 // NewDeploymentRefEvent generates a resource event given a deployment reference.
-func NewDeploymentRefEvent(ref resolver.DeploymentReference) *ResourceEvent {
+func NewDeploymentRefEvent(ref resolver.DeploymentReference, action central.ResourceAction) *ResourceEvent {
 	return &ResourceEvent{
-		DeploymentReference: ref,
+		DeploymentReference:  ref,
+		ParentResourceAction: action,
 	}
 }
 

--- a/sensor/kubernetes/eventpipeline/pipeline.go
+++ b/sensor/kubernetes/eventpipeline/pipeline.go
@@ -26,7 +26,7 @@ func New(client client.Interface, configHandler config.Handler, detector detecto
 	var depResolver component.Resolver
 	var resourceListener component.PipelineComponent
 	if features.ResyncDisabled.Enabled() {
-		depResolver = resolver.New(outputQueue)
+		depResolver = resolver.New(outputQueue, resources.DeploymentStoreSingleton(), storeProvider)
 		resourceListener = listener.New(client, configHandler, nodeName, resyncPeriod, traceWriter, depResolver, storeProvider)
 	} else {
 		resourceListener = listener.New(client, configHandler, nodeName, resyncPeriod, traceWriter, outputQueue, storeProvider)

--- a/sensor/kubernetes/eventpipeline/resolver/resolver.go
+++ b/sensor/kubernetes/eventpipeline/resolver/resolver.go
@@ -1,13 +1,16 @@
 package resolver
 
 import (
+	"github.com/stackrox/rox/sensor/common/store"
 	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/component"
 )
 
 // New instantiates a Resolver component
-func New(outputQueue component.OutputQueue) component.Resolver {
+func New(outputQueue component.OutputQueue, deploymentStore store.DeploymentStore, provider store.Provider) component.Resolver {
 	return &resolverImpl{
-		outputQueue: outputQueue,
-		innerQueue:  make(chan *component.ResourceEvent),
+		outputQueue:     outputQueue,
+		innerQueue:      make(chan *component.ResourceEvent),
+		deploymentStore: deploymentStore,
+		storeProvider:   provider,
 	}
 }

--- a/sensor/kubernetes/eventpipeline/resolver/resolver_impl.go
+++ b/sensor/kubernetes/eventpipeline/resolver/resolver_impl.go
@@ -1,12 +1,16 @@
 package resolver
 
 import (
+	"github.com/stackrox/rox/sensor/common/store"
 	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/component"
 )
 
 type resolverImpl struct {
 	outputQueue component.OutputQueue
 	innerQueue  chan *component.ResourceEvent
+
+	deploymentStore store.DeploymentStore
+	storeProvider   store.Provider
 }
 
 // Start the resolverImpl component

--- a/sensor/kubernetes/eventpipeline/resolver/resolver_impl.go
+++ b/sensor/kubernetes/eventpipeline/resolver/resolver_impl.go
@@ -3,8 +3,13 @@ package resolver
 import (
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/sensor/common/store"
 	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/component"
+)
+
+var (
+	log = logging.LoggerForModule()
 )
 
 type resolverImpl struct {
@@ -57,7 +62,8 @@ func (r *resolverImpl) processMessage(msg *component.ResourceEvent) {
 			})
 
 			if err != nil {
-				panic(err)
+				log.Warnf("Failed to build deployment dependency: %s", err)
+				continue
 			}
 
 			event := component.NewResourceEvent([]*central.SensorEvent{toEvent(msg.ParentResourceAction, d)}, nil, nil)

--- a/sensor/kubernetes/eventpipeline/resolver/resolver_impl.go
+++ b/sensor/kubernetes/eventpipeline/resolver/resolver_impl.go
@@ -54,6 +54,11 @@ func (r *resolverImpl) processMessage(msg *component.ResourceEvent) {
 
 		for _, id := range referenceIds {
 			preBuiltDeployment := r.deploymentStore.Get(id)
+			if preBuiltDeployment == nil {
+				log.Warnf("Deployment with id %s not found", id)
+				continue
+			}
+
 			permissionLevel := r.storeProvider.RBAC().GetPermissionLevelForDeployment(preBuiltDeployment)
 
 			d, err := r.deploymentStore.BuildDeploymentWithDependencies(id, store.Dependencies{
@@ -70,7 +75,6 @@ func (r *resolverImpl) processMessage(msg *component.ResourceEvent) {
 
 			component.MergeResourceEvents(msg, event)
 		}
-
 	}
 
 	r.outputQueue.Send(msg)

--- a/sensor/kubernetes/eventpipeline/resolver/resolver_impl.go
+++ b/sensor/kubernetes/eventpipeline/resolver/resolver_impl.go
@@ -60,10 +60,12 @@ func (r *resolverImpl) processMessage(msg *component.ResourceEvent) {
 			}
 
 			permissionLevel := r.storeProvider.RBAC().GetPermissionLevelForDeployment(preBuiltDeployment)
+			exposureInfo := r.storeProvider.Services().
+				GetExposureInfos(preBuiltDeployment.GetNamespace(), preBuiltDeployment.GetLabels())
 
 			d, err := r.deploymentStore.BuildDeploymentWithDependencies(id, store.Dependencies{
 				PermissionLevel: permissionLevel,
-				Exposures:       nil,
+				Exposures:       exposureInfo,
 			})
 
 			if err != nil {

--- a/sensor/kubernetes/eventpipeline/resolver/resolver_impl.go
+++ b/sensor/kubernetes/eventpipeline/resolver/resolver_impl.go
@@ -48,7 +48,6 @@ func (r *resolverImpl) processMessage(msg *component.ResourceEvent) {
 		referenceIds := msg.DeploymentReference(r.deploymentStore)
 
 		for _, id := range referenceIds {
-			// Build the dependency
 			preBuiltDeployment := r.deploymentStore.Get(id)
 			permissionLevel := r.storeProvider.RBAC().GetPermissionLevelForDeployment(preBuiltDeployment)
 
@@ -61,7 +60,7 @@ func (r *resolverImpl) processMessage(msg *component.ResourceEvent) {
 				panic(err)
 			}
 
-			event := component.NewResourceEvent([]*central.SensorEvent{toEvent(central.ResourceAction_UPDATE_RESOURCE, d)}, nil, nil)
+			event := component.NewResourceEvent([]*central.SensorEvent{toEvent(msg.ParentResourceAction, d)}, nil, nil)
 
 			component.MergeResourceEvents(msg, event)
 		}

--- a/sensor/kubernetes/eventpipeline/resolver/resolver_impl.go
+++ b/sensor/kubernetes/eventpipeline/resolver/resolver_impl.go
@@ -73,7 +73,8 @@ func (r *resolverImpl) processMessage(msg *component.ResourceEvent) {
 				continue
 			}
 
-			event := component.NewResourceEvent([]*central.SensorEvent{toEvent(msg.ParentResourceAction, d)}, nil, nil)
+			event := component.NewResourceEvent([]*central.SensorEvent{toEvent(msg.ParentResourceAction, d)},
+				[]component.CompatibilityDetectionMessage{{Object: d, Action: msg.ParentResourceAction}}, nil)
 
 			component.MergeResourceEvents(msg, event)
 		}

--- a/sensor/kubernetes/eventpipeline/resolver/resolver_test.go
+++ b/sensor/kubernetes/eventpipeline/resolver/resolver_test.go
@@ -1,0 +1,62 @@
+package resolver
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/sync"
+	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/component"
+	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/component/mocks"
+	"github.com/stretchr/testify/suite"
+)
+
+type resolverSuite struct {
+	suite.Suite
+
+	mockOutput *mocks.MockOutputQueue
+}
+
+var _ suite.SetupTestSuite = &resolverSuite{}
+
+func TestResolverSuite(t *testing.T) {
+	suite.Run(t, new(resolverSuite))
+}
+
+func (s *resolverSuite) SetupTest() {
+	mockCtrl := gomock.NewController(s.T())
+	s.mockOutput = mocks.NewMockOutputQueue(mockCtrl)
+}
+
+func (s *resolverSuite) Test_InitializeResolver() {
+	resolver := New(s.mockOutput)
+	err := resolver.Start()
+	s.NoError(err)
+}
+
+func (s *resolverSuite) Test_MessageSentToOutput() {
+	resolver := New(s.mockOutput)
+	err := resolver.Start()
+	s.NoError(err)
+
+	messageReceived := sync.WaitGroup{}
+	messageReceived.Add(1)
+
+	s.mockOutput.EXPECT().Send(gomock.Any()).Times(1).Do(func(arg0 interface{}) {
+		defer messageReceived.Done()
+	})
+
+	resolver.Send(&component.ResourceEvent{
+		ForwardMessages: []*central.SensorEvent{
+			{
+				Action: central.ResourceAction_UPDATE_RESOURCE,
+				Resource: &central.SensorEvent_Deployment{
+					Deployment: &storage.Deployment{Id: "abc"},
+				},
+			},
+		},
+	})
+
+	messageReceived.Wait()
+}

--- a/sensor/kubernetes/eventpipeline/resolver/resolver_test.go
+++ b/sensor/kubernetes/eventpipeline/resolver/resolver_test.go
@@ -92,19 +92,19 @@ func (s *resolverSuite) Test_Send_DeploymentWithRBACs() {
 	s.NoError(err)
 
 	testCases := map[string]struct {
-		deploymentId    string
+		deploymentID    string
 		permissionLevel storage.PermissionLevel
 	}{
 		"[1234]: None": {
-			deploymentId:    "1234",
+			deploymentID:    "1234",
 			permissionLevel: storage.PermissionLevel_NONE,
 		},
 		"[1234]: Elevated in namespace": {
-			deploymentId:    "1234",
+			deploymentID:    "1234",
 			permissionLevel: storage.PermissionLevel_ELEVATED_IN_NAMESPACE,
 		},
 		"[4321]: Elevated in cluster": {
-			deploymentId:    "4321",
+			deploymentID:    "4321",
 			permissionLevel: storage.PermissionLevel_ELEVATED_CLUSTER_WIDE,
 		},
 	}
@@ -114,10 +114,10 @@ func (s *resolverSuite) Test_Send_DeploymentWithRBACs() {
 			messageReceived := sync.WaitGroup{}
 			messageReceived.Add(1)
 
-			s.givenPermissionLevelForDeployment(testCase.deploymentId, testCase.permissionLevel)
+			s.givenPermissionLevelForDeployment(testCase.deploymentID, testCase.permissionLevel)
 
 			expectedDeployment := deploymentMatcher{
-				id:              testCase.deploymentId,
+				id:              testCase.deploymentID,
 				permissionLevel: testCase.permissionLevel,
 				exposure:        nil,
 			}
@@ -127,7 +127,7 @@ func (s *resolverSuite) Test_Send_DeploymentWithRBACs() {
 			})
 
 			s.resolver.Send(&component.ResourceEvent{
-				DeploymentReference: resolver.ResolveDeploymentIds(testCase.deploymentId),
+				DeploymentReference: resolver.ResolveDeploymentIds(testCase.deploymentID),
 			})
 
 			messageReceived.Wait()
@@ -231,7 +231,7 @@ func (s *resolverSuite) Test_Send_DeploymentNotFound() {
 	messageReceived := sync.WaitGroup{}
 	messageReceived.Add(1)
 
-	s.givenNilDeploymentForId()
+	s.givenNilDeployment()
 
 	s.mockRBACStore.EXPECT().GetPermissionLevelForDeployment(gomock.Any()).Times(0)
 	s.mockDeploymentStore.EXPECT().BuildDeploymentWithDependencies(gomock.Any(), gomock.Any()).Times(0)
@@ -324,7 +324,7 @@ func (s *resolverSuite) givenStubSensorEvent() *central.SensorEvent {
 
 func (s *resolverSuite) givenStubPortExposure() map[service.PortRef][]*storage.PortConfig_ExposureInfo {
 	return map[service.PortRef][]*storage.PortConfig_ExposureInfo{
-		service.PortRef{
+		{
 			Port:     intstr.IntOrString{IntVal: 8080},
 			Protocol: "TCP",
 		}: {
@@ -357,7 +357,7 @@ func (s *resolverSuite) givenBuildDependenciesError(deployment string) {
 		})
 }
 
-func (s *resolverSuite) givenNilDeploymentForId() {
+func (s *resolverSuite) givenNilDeployment() {
 	s.mockDeploymentStore.EXPECT().Get(gomock.Any()).Times(1).DoAndReturn(func(arg0 interface{}) *storage.Deployment {
 		return nil
 	})

--- a/sensor/kubernetes/eventpipeline/resolver/resolver_test.go
+++ b/sensor/kubernetes/eventpipeline/resolver/resolver_test.go
@@ -1,6 +1,7 @@
 package resolver
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -9,6 +10,7 @@ import (
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/sensor/common/store"
 	mocksStore "github.com/stackrox/rox/sensor/common/store/mocks"
+	"github.com/stackrox/rox/sensor/common/store/resolver"
 	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/component"
 	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/component/mocks"
 	"github.com/stretchr/testify/suite"
@@ -16,6 +18,8 @@ import (
 
 type resolverSuite struct {
 	suite.Suite
+
+	mockCtrl *gomock.Controller
 
 	mockOutput          *mocks.MockOutputQueue
 	mockDeploymentStore *mocksStore.MockDeploymentStore
@@ -26,18 +30,23 @@ type resolverSuite struct {
 }
 
 var _ suite.SetupTestSuite = &resolverSuite{}
+var _ suite.TearDownTestSuite = &resolverSuite{}
 
 func TestResolverSuite(t *testing.T) {
 	suite.Run(t, new(resolverSuite))
 }
 
-func (s *resolverSuite) SetupTest() {
-	mockCtrl := gomock.NewController(s.T())
+func (s *resolverSuite) TearDownTest() {
+	s.T().Cleanup(s.mockCtrl.Finish)
+}
 
-	s.mockOutput = mocks.NewMockOutputQueue(mockCtrl)
-	s.mockDeploymentStore = mocksStore.NewMockDeploymentStore(mockCtrl)
-	s.mockServiceStore = mocksStore.NewMockServiceStore(mockCtrl)
-	s.mockRBACStore = mocksStore.NewMockRBACStore(mockCtrl)
+func (s *resolverSuite) SetupTest() {
+	s.mockCtrl = gomock.NewController(s.T())
+
+	s.mockOutput = mocks.NewMockOutputQueue(s.mockCtrl)
+	s.mockDeploymentStore = mocksStore.NewMockDeploymentStore(s.mockCtrl)
+	s.mockServiceStore = mocksStore.NewMockServiceStore(s.mockCtrl)
+	s.mockRBACStore = mocksStore.NewMockRBACStore(s.mockCtrl)
 
 	s.resolver = New(s.mockOutput, s.mockDeploymentStore, &fakeProvider{
 		serviceStore: s.mockServiceStore,
@@ -73,6 +82,159 @@ func (s *resolverSuite) Test_MessageSentToOutput() {
 	})
 
 	messageReceived.Wait()
+}
+
+func (s *resolverSuite) Test_Send_DeploymentWithRBACs() {
+	err := s.resolver.Start()
+	s.NoError(err)
+
+	testCases := map[string]struct {
+		deploymentId    string
+		permissionLevel storage.PermissionLevel
+	}{
+		"[1234]: None": {
+			deploymentId:    "1234",
+			permissionLevel: storage.PermissionLevel_NONE,
+		},
+		"[1234]: Elevated in namespace": {
+			deploymentId:    "1234",
+			permissionLevel: storage.PermissionLevel_ELEVATED_IN_NAMESPACE,
+		},
+		"[4321]: Elevated in cluster": {
+			deploymentId:    "4321",
+			permissionLevel: storage.PermissionLevel_ELEVATED_CLUSTER_WIDE,
+		},
+	}
+
+	for name, testCase := range testCases {
+		s.Run(name, func() {
+			messageReceived := sync.WaitGroup{}
+			messageReceived.Add(1)
+
+			s.givenPermissionLevelForDeployment(testCase.deploymentId, testCase.permissionLevel)
+
+			expectedDeployment := deploymentMatcher{
+				id:              testCase.deploymentId,
+				permissionLevel: testCase.permissionLevel,
+				exposure:        nil,
+			}
+
+			s.mockOutput.EXPECT().Send(&expectedDeployment).Times(1).Do(func(arg0 interface{}) {
+				defer messageReceived.Done()
+			})
+
+			s.resolver.Send(&component.ResourceEvent{
+				DeploymentReference: resolver.ResolveDeploymentIds(testCase.deploymentId),
+			})
+
+			messageReceived.Wait()
+		})
+	}
+}
+
+func (s *resolverSuite) Test_Send_MultipleDeploymentRefs() {
+	err := s.resolver.Start()
+	s.NoError(err)
+
+	messageReceived := sync.WaitGroup{}
+	messageReceived.Add(1)
+
+	s.givenPermissionLevelForDeployment("1234", storage.PermissionLevel_NONE)
+	s.givenPermissionLevelForDeployment("4321", storage.PermissionLevel_ELEVATED_IN_NAMESPACE)
+
+	s.mockOutput.EXPECT().Send(&messageCounterMatcher{numEvents: 2}).Times(1).Do(func(arg0 interface{}) {
+		defer messageReceived.Done()
+	})
+
+	s.resolver.Send(&component.ResourceEvent{
+		DeploymentReference: resolver.ResolveDeploymentIds("1234", "4321"),
+	})
+
+	messageReceived.Wait()
+}
+
+func (s *resolverSuite) givenPermissionLevelForDeployment(deployment string, permissionLevel storage.PermissionLevel) {
+	s.mockDeploymentStore.EXPECT().Get(gomock.Eq(deployment)).Times(1).DoAndReturn(func(arg0 interface{}) *storage.Deployment {
+		return &storage.Deployment{}
+	})
+	s.mockRBACStore.EXPECT().GetPermissionLevelForDeployment(gomock.Any()).Times(1).
+		DoAndReturn(func(arg0 interface{}) storage.PermissionLevel { return permissionLevel })
+
+	s.mockDeploymentStore.EXPECT().BuildDeploymentWithDependencies(
+		gomock.Eq(deployment), gomock.Eq(store.Dependencies{
+			PermissionLevel: permissionLevel,
+			Exposures:       nil,
+		})).
+		Times(1).
+		DoAndReturn(func(arg0, arg1 interface{}) (*storage.Deployment, error) {
+			return &storage.Deployment{Id: deployment, ServiceAccountPermissionLevel: permissionLevel}, nil
+		})
+}
+
+type deploymentMatcher struct {
+	id              string
+	permissionLevel storage.PermissionLevel
+	exposure        interface{}
+	error           string
+}
+
+func (m *deploymentMatcher) Matches(target interface{}) bool {
+	event, ok := target.(*component.ResourceEvent)
+	if !ok {
+		m.error = "received message isn't a resource event"
+		return false
+	}
+
+	if len(event.ForwardMessages) < 1 {
+		m.error = fmt.Sprintf("not enough ForwardMessages: %d", len(event.ForwardMessages))
+		return false
+	}
+
+	deployment := event.ForwardMessages[0].GetDeployment()
+	if deployment == nil {
+		m.error = "no deployment in resource event message"
+		return false
+	}
+
+	if deployment.GetId() != m.id {
+		m.error = fmt.Sprintf("IDs don't match: expected %s != %s", m.id, deployment.GetId())
+		return false
+	}
+
+	if deployment.GetServiceAccountPermissionLevel() != m.permissionLevel {
+		m.error = fmt.Sprintf("Permission level doesn't match %s != %s", m.permissionLevel, deployment.GetServiceAccountPermissionLevel())
+		return false
+	}
+
+	return true
+}
+
+func (m *deploymentMatcher) String() string {
+	return fmt.Sprintf("Deployment (%s) (Permission: %s): %s", m.id, m.permissionLevel, m.error)
+}
+
+type messageCounterMatcher struct {
+	numEvents int
+	error     string
+}
+
+func (m *messageCounterMatcher) Matches(target interface{}) bool {
+	event, ok := target.(*component.ResourceEvent)
+	if !ok {
+		m.error = "received message isn't a resource event"
+		return false
+	}
+
+	if len(event.ForwardMessages) != m.numEvents {
+		m.error = fmt.Sprintf("expected %d events but received %d", m.numEvents, len(event.ForwardMessages))
+		return false
+	}
+
+	return true
+}
+
+func (m *messageCounterMatcher) String() string {
+	return fmt.Sprintf("expected %d: error %s", m.numEvents, m.error)
 }
 
 type fakeProvider struct {

--- a/sensor/kubernetes/eventpipeline/resolver/resolver_test.go
+++ b/sensor/kubernetes/eventpipeline/resolver/resolver_test.go
@@ -57,11 +57,6 @@ func (s *resolverSuite) SetupTest() {
 	})
 }
 
-func (s *resolverSuite) Test_InitializeResolver() {
-	err := s.resolver.Start()
-	s.NoError(err)
-}
-
 func (s *resolverSuite) Test_MessageSentToOutput() {
 	err := s.resolver.Start()
 	s.NoError(err)

--- a/sensor/kubernetes/listener/resources/deployments.go
+++ b/sensor/kubernetes/listener/resources/deployments.go
@@ -198,7 +198,7 @@ func (d *deploymentHandler) processWithType(obj, oldObj interface{}, action cent
 			// If re-sync is disabled, we don't need to process deployment relationships here. We pass a deployment
 			// references up the chain, which will be used to trigger the actual deployment event and detection.
 			events = component.MergeResourceEvents(events,
-				component.NewDeploymentRefEvent(resolver.ResolveDeploymentIds(deploymentWrap.GetId())))
+				component.NewDeploymentRefEvent(resolver.ResolveDeploymentIds(deploymentWrap.GetId()), action))
 		}
 	} else {
 		exposureInfos := d.serviceStore.GetExposureInfos(deploymentWrap.GetNamespace(), deploymentWrap.PodLabels)


### PR DESCRIPTION
## Description

Given a deployment ID provided by any of the handlers, build the deployment object using public interfaces from deployment, RBAC and Service stores. 

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

- Unit tests added
- CI
