### PR TITLE
ROX-13177: Adding table bulk actions to baselines tab

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/common/FlowsBulkActions.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/common/FlowsBulkActions.tsx
@@ -1,0 +1,45 @@
+import React, { ReactElement } from 'react';
+import { DropdownItem } from '@patternfly/react-core';
+
+import BulkActionsDropdown from 'Components/PatternFly/BulkActionsDropdown';
+
+type FlowsBulkActionsProps = {
+    type: 'baseline' | 'active' | 'extraneous';
+    selectedRows: string[];
+    onClearSelectedRows: () => void;
+};
+
+function FlowsBulkActions({
+    type,
+    selectedRows,
+    onClearSelectedRows,
+}: FlowsBulkActionsProps): ReactElement {
+    // setter functions
+    const markSelectedAsAnomalous = () => {
+        // @TODO: Mark as anomalous
+        onClearSelectedRows();
+    };
+    const addSelectedToBaseline = () => {
+        // @TODO: Add to baseline
+        onClearSelectedRows();
+    };
+
+    return (
+        <BulkActionsDropdown isDisabled={selectedRows.length === 0}>
+            {type !== 'baseline' && (
+                <DropdownItem
+                    key="mark_as_anomalous"
+                    component="button"
+                    onClick={markSelectedAsAnomalous}
+                >
+                    Mark as anomalous
+                </DropdownItem>
+            )}
+            <DropdownItem key="add_to_baseline" component="button" onClick={addSelectedToBaseline}>
+                Add to baseline
+            </DropdownItem>
+        </BulkActionsDropdown>
+    );
+}
+
+export default FlowsBulkActions;

--- a/ui/apps/platform/src/Containers/NetworkGraph/common/FlowsTableHeaderText.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/common/FlowsTableHeaderText.tsx
@@ -1,0 +1,19 @@
+import React, { ReactElement } from 'react';
+import { Text, TextContent, TextVariants } from '@patternfly/react-core';
+
+type FlowsTableHeaderTextProps = {
+    type: 'baseline' | 'active' | 'extraneous';
+    numFlows: number;
+};
+
+function FlowsTableHeaderText({ type, numFlows }: FlowsTableHeaderTextProps): ReactElement {
+    return (
+        <TextContent>
+            <Text component={TextVariants.h3}>
+                {numFlows} {type} flows
+            </Text>
+        </TextContent>
+    );
+}
+
+export default FlowsTableHeaderText;

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentBaselines.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentBaselines.tsx
@@ -8,18 +8,24 @@ import {
     Stack,
     StackItem,
     Switch,
+    Toolbar,
+    ToolbarContent,
+    ToolbarItem,
     Tooltip,
 } from '@patternfly/react-core';
 import { HelpIcon } from '@patternfly/react-icons';
 
-import EntityNameSearchInput from '../common/EntityNameSearchInput';
-import AdvancedFlowsFilter, {
-    defaultAdvancedFlowsFilters,
-} from '../common/AdvancedFlowsFilter/AdvancedFlowsFilter';
 import { AdvancedFlowsFilterType } from '../common/AdvancedFlowsFilter/types';
 import { Flow } from '../types';
 import { getAllUniquePorts, getNumFlows } from '../utils/flowUtils';
+
+import AdvancedFlowsFilter, {
+    defaultAdvancedFlowsFilters,
+} from '../common/AdvancedFlowsFilter/AdvancedFlowsFilter';
+import EntityNameSearchInput from '../common/EntityNameSearchInput';
 import FlowsTable from '../common/FlowsTable';
+import FlowsTableHeaderText from '../common/FlowsTableHeaderText';
+import FlowsBulkActions from '../common/FlowsBulkActions';
 
 const baselines: Flow[] = [
     {
@@ -150,6 +156,23 @@ function DeploymentBaselines() {
                             />
                         </FlexItem>
                     </Flex>
+                </StackItem>
+                <Divider component="hr" />
+                <StackItem>
+                    <Toolbar>
+                        <ToolbarContent>
+                            <ToolbarItem>
+                                <FlowsTableHeaderText type="baseline" numFlows={numBaselines} />
+                            </ToolbarItem>
+                            <ToolbarItem alignment={{ default: 'alignRight' }}>
+                                <FlowsBulkActions
+                                    type="baseline"
+                                    selectedRows={selectedRows}
+                                    onClearSelectedRows={() => setSelectedRows([])}
+                                />
+                            </ToolbarItem>
+                        </ToolbarContent>
+                    </Toolbar>
                 </StackItem>
                 <Divider component="hr" />
                 <StackItem>

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentFlows.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentFlows.tsx
@@ -1,30 +1,28 @@
 import React from 'react';
 import {
     Divider,
-    DropdownItem,
     Flex,
     FlexItem,
     Stack,
     StackItem,
-    Text,
-    TextContent,
-    TextVariants,
     Toolbar,
     ToolbarContent,
     ToolbarItem,
 } from '@patternfly/react-core';
 
-import BulkActionsDropdown from 'Components/PatternFly/BulkActionsDropdown';
+import { AdvancedFlowsFilterType } from '../common/AdvancedFlowsFilter/types';
+import { Flow } from '../types';
+import { getAllUniquePorts, getNumFlows } from '../utils/flowUtils';
+
 import AdvancedFlowsFilter, {
     defaultAdvancedFlowsFilters,
 } from '../common/AdvancedFlowsFilter/AdvancedFlowsFilter';
+import EntityNameSearchInput from '../common/EntityNameSearchInput';
+import FlowsTable from '../common/FlowsTable';
+import FlowsTableHeaderText from '../common/FlowsTableHeaderText';
+import FlowsBulkActions from '../common/FlowsBulkActions';
 
 import './DeploymentFlows.css';
-import { AdvancedFlowsFilterType } from '../common/AdvancedFlowsFilter/types';
-import EntityNameSearchInput from '../common/EntityNameSearchInput';
-import { Flow } from '../types';
-import { getAllUniquePorts, getNumFlows } from '../utils/flowUtils';
-import FlowsTable from '../common/FlowsTable';
 
 const flows: Flow[] = [
     {
@@ -110,16 +108,6 @@ function DeploymentFlow() {
     const numFlows = getNumFlows(flows);
     const allUniquePorts = getAllUniquePorts(flows);
 
-    // setter functions
-    const markSelectedAsAnomalous = () => {
-        // @TODO: Mark as anomalous
-        setSelectedRows([]);
-    };
-    const addSelectedToBaseline = () => {
-        // @TODO: Add to baseline
-        setSelectedRows([]);
-    };
-
     return (
         <div className="pf-u-h-100 pf-u-p-md">
             <Stack hasGutter>
@@ -145,27 +133,14 @@ function DeploymentFlow() {
                     <Toolbar>
                         <ToolbarContent>
                             <ToolbarItem>
-                                <TextContent>
-                                    <Text component={TextVariants.h3}>{numFlows} active flows</Text>
-                                </TextContent>
+                                <FlowsTableHeaderText type="active" numFlows={numFlows} />
                             </ToolbarItem>
                             <ToolbarItem alignment={{ default: 'alignRight' }}>
-                                <BulkActionsDropdown isDisabled={selectedRows.length === 0}>
-                                    <DropdownItem
-                                        key="mark_as_anomalous"
-                                        component="button"
-                                        onClick={markSelectedAsAnomalous}
-                                    >
-                                        Mark as anomalous
-                                    </DropdownItem>
-                                    <DropdownItem
-                                        key="add_to_baseline"
-                                        component="button"
-                                        onClick={addSelectedToBaseline}
-                                    >
-                                        Add to baseline
-                                    </DropdownItem>
-                                </BulkActionsDropdown>
+                                <FlowsBulkActions
+                                    type="active"
+                                    selectedRows={selectedRows}
+                                    onClearSelectedRows={() => setSelectedRows([])}
+                                />
                             </ToolbarItem>
                         </ToolbarContent>
                     </Toolbar>

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/flowUtils.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/flowUtils.ts
@@ -1,7 +1,7 @@
 import { uniq } from 'lodash';
 import { Flow } from '../types';
 
-export function getAllUniquePorts(flows: Flow[]) {
+export function getAllUniquePorts(flows: Flow[]): string[] {
     const allPorts = flows.reduce((acc, curr) => {
         if (curr.children && curr.children.length) {
             return [...acc, ...curr.children.map((child) => child.port)];
@@ -12,7 +12,7 @@ export function getAllUniquePorts(flows: Flow[]) {
     return allUniquePorts;
 }
 
-export function getNumFlows(flows: Flow[]) {
+export function getNumFlows(flows: Flow[]): number {
     const numFlows = flows.reduce((acc, curr) => {
         // if there are no children then it counts as 1 flow
         return acc + (curr.children && curr.children.length ? curr.children.length : 1);


### PR DESCRIPTION
## Description

This PR adds the bulk actions to the baselines tab. Changes in this PR include the following:
1. I extracted out the table header text and bulk actions into separate components called `FlowsTableHeaderText` and `FlowsBulkActions`. This makes it easier to reuse between the flows and baselines tab
2. Some minor import rearranging and clean up

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Screenshots

<img width="452" alt="Screenshot 2022-11-23 at 10 42 08 AM" src="https://user-images.githubusercontent.com/4805485/203624546-cef3df45-1789-4413-9740-cba0888ebd86.png">
