### PR TITLE
Adjust columnIndex argument in vulnmanagement integration tests

### DIFF
--- a/ui/apps/platform/cypress/helpers/vulnmanagement/entities.js
+++ b/ui/apps/platform/cypress/helpers/vulnmanagement/entities.js
@@ -286,7 +286,7 @@ export function getCountAndNounFromNodeCVEsLinkResults([, count]) {
 export function verifySecondaryEntities(
     entitiesKey1,
     entitiesKey2,
-    columnIndex,
+    columnIndex, // one-based index includes checkbox, hidden, invisible
     entitiesRegExp2,
     getCountAndNounFromLinkResults = getCountAndNounFromSecondaryEntitiesLinkResults
 ) {
@@ -294,8 +294,7 @@ export function verifySecondaryEntities(
     visitVulnerabilityManagementEntities(entitiesKey1);
 
     // Find the first link for secondary entities.
-    // Plus 1 because of invisible .rt-td.hidden cell.
-    cy.get(`.rt-tbody .rt-td:nth-child(${columnIndex + 1})`)
+    cy.get(`.rt-tbody .rt-td:nth-child(${columnIndex})`)
         .contains('a', entitiesRegExp2)
         .then(($a) => {
             const { panelHeaderText, relatedEntitiesCount, relatedEntitiesNoun } =
@@ -339,7 +338,7 @@ export function verifySecondaryEntities(
 export function verifyFilteredSecondaryEntitiesLink(
     entitiesKey1,
     _entitiesKey2, // unused because response might have been cached
-    columnIndex,
+    columnIndex, // one-based index includes checkbox, hidden, invisible
     filteredEntitiesRegExp,
     getCountAndNounFromLinkResults
 ) {
@@ -347,7 +346,7 @@ export function verifyFilteredSecondaryEntitiesLink(
     visitVulnerabilityManagementEntities(entitiesKey1);
 
     // Find the first link for secondary entities.
-    cy.get(`.rt-tbody .rt-td:nth-child(${columnIndex + 1})`)
+    cy.get(`.rt-tbody .rt-td:nth-child(${columnIndex})`)
         .contains('a', filteredEntitiesRegExp)
         .then(($a) => {
             const { panelHeaderText } = getCountAndNounFromLinkResults(
@@ -371,7 +370,7 @@ export function verifyFilteredSecondaryEntitiesLink(
 export function verifyFixableCVEsLinkAndRiskAcceptanceTabs(
     entitiesKey1,
     _entitiesKey2, // unused because response might have been cached
-    columnIndex,
+    columnIndex, // one-based index includes checkbox, hidden, invisible
     fixableCVEsRegExp,
     getCountAndNounFromLinkResults
 ) {
@@ -379,7 +378,7 @@ export function verifyFixableCVEsLinkAndRiskAcceptanceTabs(
     visitVulnerabilityManagementEntities(entitiesKey1);
 
     // Find the first link for secondary entities.
-    cy.get(`.rt-tbody .rt-td:nth-child(${columnIndex + 1})`)
+    cy.get(`.rt-tbody .rt-td:nth-child(${columnIndex})`)
         .contains('a', fixableCVEsRegExp)
         .then(($a) => {
             const { panelHeaderText } = getCountAndNounFromLinkResults(

--- a/ui/apps/platform/cypress/integration/vulnmanagement/clusterCves.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/clusterCves.test.js
@@ -85,12 +85,12 @@ describe('Vulnerability Management Cluster (Platform) CVEs', () => {
         );
     });
 
-    // Argument 3 in verify functions is one-based index of column which has the links.
-    // Count the checkbox as the first column.
+    // Argument 3 in verify functions is index of column which has the links,
+    // The one-based index includes checkbox, hidden, invisible.
 
     // Some tests might fail in local deployment.
 
     it('should display links for clusters', () => {
-        verifySecondaryEntities(entitiesKey, 'clusters', 8, /^\d+ clusters?$/);
+        verifySecondaryEntities(entitiesKey, 'clusters', 9, /^\d+ clusters?$/);
     });
 });

--- a/ui/apps/platform/cypress/integration/vulnmanagement/clusterCves.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/clusterCves.test.js
@@ -85,7 +85,7 @@ describe('Vulnerability Management Cluster (Platform) CVEs', () => {
         );
     });
 
-    // Argument 3 in verify functions is index of column which has the links,
+    // Argument 3 in verify functions is index of column which has the links.
     // The one-based index includes checkbox, hidden, invisible.
 
     // Some tests might fail in local deployment.

--- a/ui/apps/platform/cypress/integration/vulnmanagement/clusters.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/clusters.test.js
@@ -88,7 +88,7 @@ describe('Vulnerability Management Clusters', () => {
         // Do not assert because of potential timing problem: get td elements before table re-renders.
     });
 
-    // Argument 3 in verify functions is index of column which has the links,
+    // Argument 3 in verify functions is index of column which has the links.
     // The one-based index includes checkbox, hidden, invisible.
 
     // Some tests might fail in local deployment.

--- a/ui/apps/platform/cypress/integration/vulnmanagement/clusters.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/clusters.test.js
@@ -88,7 +88,8 @@ describe('Vulnerability Management Clusters', () => {
         // Do not assert because of potential timing problem: get td elements before table re-renders.
     });
 
-    // Argument 3 in verify functions is one-based index of column which has the links.
+    // Argument 3 in verify functions is index of column which has the links,
+    // The one-based index includes checkbox, hidden, invisible.
 
     // Some tests might fail in local deployment.
 
@@ -96,7 +97,7 @@ describe('Vulnerability Management Clusters', () => {
         verifySecondaryEntities(
             entitiesKey,
             'image-cves',
-            2,
+            3,
             /^\d+ CVEs?$/,
             getCountAndNounFromImageCVEsLinkResults
         );
@@ -106,7 +107,7 @@ describe('Vulnerability Management Clusters', () => {
         verifyFilteredSecondaryEntitiesLink(
             entitiesKey,
             'image-cves',
-            2,
+            3,
             /^\d+ Fixable$/,
             getCountAndNounFromImageCVEsLinkResults
         );
@@ -116,7 +117,7 @@ describe('Vulnerability Management Clusters', () => {
         verifySecondaryEntities(
             entitiesKey,
             'node-cves',
-            3,
+            4,
             /^\d+ CVEs?$/,
             getCountAndNounFromNodeCVEsLinkResults
         );
@@ -126,21 +127,21 @@ describe('Vulnerability Management Clusters', () => {
         verifySecondaryEntities(
             entitiesKey,
             'cluster-cves',
-            4,
+            5,
             /^\d+ CVEs?$/,
             getCountAndNounFromClusterCVEsLinkResults
         );
     });
 
     it('should display links for namespaces', () => {
-        verifySecondaryEntities(entitiesKey, 'namespaces', 6, /^\d+ namespaces?$/);
+        verifySecondaryEntities(entitiesKey, 'namespaces', 7, /^\d+ namespaces?$/);
     });
 
     it('should display links for deployments', () => {
-        verifySecondaryEntities(entitiesKey, 'deployments', 6, /^\d+ deployments?$/);
+        verifySecondaryEntities(entitiesKey, 'deployments', 7, /^\d+ deployments?$/);
     });
 
     it('should display links for nodes', () => {
-        verifySecondaryEntities(entitiesKey, 'nodes', 6, /^\d+ nodes?$/);
+        verifySecondaryEntities(entitiesKey, 'nodes', 7, /^\d+ nodes?$/);
     });
 });

--- a/ui/apps/platform/cypress/integration/vulnmanagement/componentsNonPostgress.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/componentsNonPostgress.test.js
@@ -85,7 +85,8 @@ describe('Vulnerability Management Components', () => {
         // Do not assert because of potential timing problem: get td elements before table re-renders.
     });
 
-    // Argument 3 in verify functions is one-based index of column which has the links.
+    // Argument 3 in verify functions is index of column which has the links,
+    // The one-based index includes checkbox, hidden, invisible.
 
     // Some tests might fail in local deployment.
 
@@ -93,7 +94,7 @@ describe('Vulnerability Management Components', () => {
         verifySecondaryEntities(
             entitiesKey,
             'cves',
-            2,
+            3,
             /^\d+ CVEs?$/,
             getCountAndNounFromCVEsLinkResults
         );
@@ -103,18 +104,18 @@ describe('Vulnerability Management Components', () => {
         verifyFilteredSecondaryEntitiesLink(
             entitiesKey,
             'cves',
-            2,
+            3,
             /^\d+ Fixable$/,
             getCountAndNounFromCVEsLinkResults
         );
     });
 
     it('should display links for images', () => {
-        verifySecondaryEntities(entitiesKey, 'images', 5, /^\d+ images?$/);
+        verifySecondaryEntities(entitiesKey, 'images', 6, /^\d+ images?$/);
     });
 
     it('should display links for deployments', () => {
-        verifySecondaryEntities(entitiesKey, 'deployments', 6, /^\d+ deployments?$/);
+        verifySecondaryEntities(entitiesKey, 'deployments', 7, /^\d+ deployments?$/);
     });
 
     // Skip assertion about nodes because many component do not have a nodes link.

--- a/ui/apps/platform/cypress/integration/vulnmanagement/componentsNonPostgress.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/componentsNonPostgress.test.js
@@ -85,7 +85,7 @@ describe('Vulnerability Management Components', () => {
         // Do not assert because of potential timing problem: get td elements before table re-renders.
     });
 
-    // Argument 3 in verify functions is index of column which has the links,
+    // Argument 3 in verify functions is index of column which has the links.
     // The one-based index includes checkbox, hidden, invisible.
 
     // Some tests might fail in local deployment.

--- a/ui/apps/platform/cypress/integration/vulnmanagement/cvesNonPostgress.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/cvesNonPostgress.test.js
@@ -84,20 +84,20 @@ describe('Vulnerability Management CVEs', () => {
         );
     });
 
-    // Argument 3 in verify functions is one-based index of column which has the links.
-    // Count the checkbox as the first column.
+    // Argument 3 in verify functions is index of column which has the links,
+    // The one-based index includes checkbox, hidden, invisible.
 
     // Some tests might fail in local deployment.
 
     it('should display links for deployments', () => {
-        verifySecondaryEntities(entitiesKey, 'deployments', 8, /^\d+ deployments?$/);
+        verifySecondaryEntities(entitiesKey, 'deployments', 9, /^\d+ deployments?$/);
     });
 
     it('should display links for images', () => {
-        verifySecondaryEntities(entitiesKey, 'images', 8, /^\d+ images?$/);
+        verifySecondaryEntities(entitiesKey, 'images', 9, /^\d+ images?$/);
     });
 
     it('should display links for components', () => {
-        verifySecondaryEntities(entitiesKey, 'components', 8, /^\d+ components?$/);
+        verifySecondaryEntities(entitiesKey, 'components', 9, /^\d+ components?$/);
     });
 });

--- a/ui/apps/platform/cypress/integration/vulnmanagement/cvesNonPostgress.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/cvesNonPostgress.test.js
@@ -84,7 +84,7 @@ describe('Vulnerability Management CVEs', () => {
         );
     });
 
-    // Argument 3 in verify functions is index of column which has the links,
+    // Argument 3 in verify functions is index of column which has the links.
     // The one-based index includes checkbox, hidden, invisible.
 
     // Some tests might fail in local deployment.

--- a/ui/apps/platform/cypress/integration/vulnmanagement/deployments.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/deployments.test.js
@@ -78,7 +78,7 @@ describe('Vulnerability Management Deployments', () => {
         // Do not assert because of potential timing problem: get td elements before table re-renders.
     });
 
-    // Argument 3 in verify functions is index of column which has the links,
+    // Argument 3 in verify functions is index of column which has the links.
     // The one-based index includes checkbox, hidden, invisible.
 
     // Some tests might fail in local deployment.

--- a/ui/apps/platform/cypress/integration/vulnmanagement/deployments.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/deployments.test.js
@@ -78,7 +78,8 @@ describe('Vulnerability Management Deployments', () => {
         // Do not assert because of potential timing problem: get td elements before table re-renders.
     });
 
-    // Argument 3 in verify functions is one-based index of column which has the links.
+    // Argument 3 in verify functions is index of column which has the links,
+    // The one-based index includes checkbox, hidden, invisible.
 
     // Some tests might fail in local deployment.
 
@@ -86,7 +87,7 @@ describe('Vulnerability Management Deployments', () => {
         verifySecondaryEntities(
             entitiesKey,
             'image-cves',
-            2,
+            3,
             /^\d+ CVEs?$/,
             getCountAndNounFromImageCVEsLinkResults
         );
@@ -96,13 +97,13 @@ describe('Vulnerability Management Deployments', () => {
         verifyFilteredSecondaryEntitiesLink(
             entitiesKey,
             'image-cves',
-            2,
+            3,
             /^\d+ Fixable$/,
             getCountAndNounFromImageCVEsLinkResults
         );
     });
 
     it('should display links for images', () => {
-        verifySecondaryEntities(entitiesKey, 'images', 7, /^\d+ images?$/);
+        verifySecondaryEntities(entitiesKey, 'images', 8, /^\d+ images?$/);
     });
 });

--- a/ui/apps/platform/cypress/integration/vulnmanagement/deploymentsNonPostgress.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/deploymentsNonPostgress.test.js
@@ -84,7 +84,8 @@ describe('Vulnerability Management Deployments', () => {
         // Do not assert because of potential timing problem: get td elements before table re-renders.
     });
 
-    // Argument 3 in verify functions is one-based index of column which has the links.
+    // Argument 3 in verify functions is index of column which has the links,
+    // The one-based index includes checkbox, hidden, invisible.
 
     // Some tests might fail in local deployment.
 
@@ -92,7 +93,7 @@ describe('Vulnerability Management Deployments', () => {
         verifySecondaryEntities(
             entitiesKey,
             'cves',
-            2,
+            3,
             /^\d+ CVEs?$/,
             getCountAndNounFromCVEsLinkResults
         );
@@ -102,13 +103,13 @@ describe('Vulnerability Management Deployments', () => {
         verifyFilteredSecondaryEntitiesLink(
             entitiesKey,
             'cves',
-            2,
+            3,
             /^\d+ Fixable$/,
             getCountAndNounFromCVEsLinkResults
         );
     });
 
     it('should display links for images', () => {
-        verifySecondaryEntities(entitiesKey, 'images', 7, /^\d+ images?$/);
+        verifySecondaryEntities(entitiesKey, 'images', 8, /^\d+ images?$/);
     });
 });

--- a/ui/apps/platform/cypress/integration/vulnmanagement/deploymentsNonPostgress.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/deploymentsNonPostgress.test.js
@@ -84,7 +84,7 @@ describe('Vulnerability Management Deployments', () => {
         // Do not assert because of potential timing problem: get td elements before table re-renders.
     });
 
-    // Argument 3 in verify functions is index of column which has the links,
+    // Argument 3 in verify functions is index of column which has the links.
     // The one-based index includes checkbox, hidden, invisible.
 
     // Some tests might fail in local deployment.

--- a/ui/apps/platform/cypress/integration/vulnmanagement/imageComponents.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/imageComponents.test.js
@@ -119,7 +119,8 @@ describe('Vulnerability Management Image Components', () => {
         });
     });
 
-    // Argument 3 in verify functions is one-based index of column which has the links.
+    // Argument 3 in verify functions is index of column which has the links,
+    // The one-based index includes checkbox, hidden, invisible.
 
     // Some tests might fail in local deployment.
 
@@ -127,7 +128,7 @@ describe('Vulnerability Management Image Components', () => {
         verifySecondaryEntities(
             entitiesKey,
             'image-cves',
-            3,
+            4,
             /^\d+ CVEs?$/,
             getCountAndNounFromImageCVEsLinkResults
         );
@@ -137,17 +138,17 @@ describe('Vulnerability Management Image Components', () => {
         verifyFilteredSecondaryEntitiesLink(
             entitiesKey,
             'image-cves',
-            3,
+            4,
             /^\d+ Fixable$/,
             getCountAndNounFromImageCVEsLinkResults
         );
     });
 
     it('should display links for images', () => {
-        verifySecondaryEntities(entitiesKey, 'images', 6, /^\d+ images?$/);
+        verifySecondaryEntities(entitiesKey, 'images', 7, /^\d+ images?$/);
     });
 
     it('should display links for deployments', () => {
-        verifySecondaryEntities(entitiesKey, 'deployments', 7, /^\d+ deployments?$/);
+        verifySecondaryEntities(entitiesKey, 'deployments', 8, /^\d+ deployments?$/);
     });
 });

--- a/ui/apps/platform/cypress/integration/vulnmanagement/imageComponents.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/imageComponents.test.js
@@ -119,7 +119,7 @@ describe('Vulnerability Management Image Components', () => {
         });
     });
 
-    // Argument 3 in verify functions is index of column which has the links,
+    // Argument 3 in verify functions is index of column which has the links.
     // The one-based index includes checkbox, hidden, invisible.
 
     // Some tests might fail in local deployment.

--- a/ui/apps/platform/cypress/integration/vulnmanagement/imageCves.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/imageCves.test.js
@@ -128,21 +128,21 @@ describe('Vulnerability Management Image CVEs', () => {
         );
     });
 
-    // Argument 3 in verify functions is one-based index of column which has the links.
-    // Count the checkbox as the first column.
+    // Argument 3 in verify functions is index of column which has the links,
+    // The one-based index includes checkbox, hidden, invisible.
 
     // Some tests might fail in local deployment.
 
     it('should display links for deployments', () => {
-        verifySecondaryEntities(entitiesKey, 'deployments', 9, /^\d+ deployments?$/);
+        verifySecondaryEntities(entitiesKey, 'deployments', 10, /^\d+ deployments?$/);
     });
 
     it('should display links for images', () => {
-        verifySecondaryEntities(entitiesKey, 'images', 9, /^\d+ images?$/);
+        verifySecondaryEntities(entitiesKey, 'images', 10, /^\d+ images?$/);
     });
 
     it('should display links for image-components', () => {
-        verifySecondaryEntities(entitiesKey, 'image-components', 9, /^\d+ image components?$/);
+        verifySecondaryEntities(entitiesKey, 'image-components', 10, /^\d+ image components?$/);
     });
 
     // @TODO: Rework this test. Seems like each of these do the same thing

--- a/ui/apps/platform/cypress/integration/vulnmanagement/imageCves.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/imageCves.test.js
@@ -128,7 +128,7 @@ describe('Vulnerability Management Image CVEs', () => {
         );
     });
 
-    // Argument 3 in verify functions is index of column which has the links,
+    // Argument 3 in verify functions is index of column which has the links.
     // The one-based index includes checkbox, hidden, invisible.
 
     // Some tests might fail in local deployment.

--- a/ui/apps/platform/cypress/integration/vulnmanagement/images.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/images.test.js
@@ -115,7 +115,7 @@ describe('Vulnerability Management Images', () => {
         });
     });
 
-    // Argument 3 in verify functions is index of column which has the links,
+    // Argument 3 in verify functions is index of column which has the links.
     // The one-based index includes checkbox, hidden, invisible.
 
     // Some tests might fail in local deployment.

--- a/ui/apps/platform/cypress/integration/vulnmanagement/images.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/images.test.js
@@ -115,7 +115,8 @@ describe('Vulnerability Management Images', () => {
         });
     });
 
-    // Argument 3 in verify functions is one-based index of column which has the links.
+    // Argument 3 in verify functions is index of column which has the links,
+    // The one-based index includes checkbox, hidden, invisible.
 
     // Some tests might fail in local deployment.
 
@@ -123,7 +124,7 @@ describe('Vulnerability Management Images', () => {
         verifySecondaryEntities(
             entitiesKey,
             'image-cves',
-            2,
+            3,
             /^\d+ CVEs?$/,
             getCountAndNounFromImageCVEsLinkResults
         );
@@ -133,18 +134,18 @@ describe('Vulnerability Management Images', () => {
         verifyFixableCVEsLinkAndRiskAcceptanceTabs(
             entitiesKey,
             'image-cves',
-            2,
+            3,
             /^\d+ Fixable$/,
             getCountAndNounFromImageCVEsLinkResults
         );
     });
 
     it('should display links for deployments', () => {
-        verifySecondaryEntities(entitiesKey, 'deployments', 8, /^\d+ deployments?$/);
+        verifySecondaryEntities(entitiesKey, 'deployments', 9, /^\d+ deployments?$/);
     });
 
     it('should display links for image-components', () => {
-        verifySecondaryEntities(entitiesKey, 'image-components', 8, /^\d+ image components?$/);
+        verifySecondaryEntities(entitiesKey, 'image-components', 9, /^\d+ image components?$/);
     });
 
     it('should show entity icon, not back button, if there is only one item on the side panel stack', () => {

--- a/ui/apps/platform/cypress/integration/vulnmanagement/namespaces.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/namespaces.test.js
@@ -78,7 +78,7 @@ describe('Vulnerability Management Namespaces', () => {
         // Do not assert because of potential timing problem: get td elements before table re-renders.
     });
 
-    // Argument 3 in verify functions is index of column which has the links,
+    // Argument 3 in verify functions is index of column which has the links.
     // The one-based index includes checkbox, hidden, invisible.
 
     // Some tests might fail in local deployment.

--- a/ui/apps/platform/cypress/integration/vulnmanagement/namespaces.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/namespaces.test.js
@@ -78,7 +78,8 @@ describe('Vulnerability Management Namespaces', () => {
         // Do not assert because of potential timing problem: get td elements before table re-renders.
     });
 
-    // Argument 3 in verify functions is one-based index of column which has the links.
+    // Argument 3 in verify functions is index of column which has the links,
+    // The one-based index includes checkbox, hidden, invisible.
 
     // Some tests might fail in local deployment.
 
@@ -86,7 +87,7 @@ describe('Vulnerability Management Namespaces', () => {
         verifySecondaryEntities(
             entitiesKey,
             'image-cves',
-            2,
+            3,
             /^\d+ CVEs?$/,
             getCountAndNounFromImageCVEsLinkResults
         );
@@ -96,17 +97,17 @@ describe('Vulnerability Management Namespaces', () => {
         verifyFilteredSecondaryEntitiesLink(
             entitiesKey,
             'image-cves',
-            2,
+            3,
             /^\d+ Fixable$/,
             getCountAndNounFromImageCVEsLinkResults
         );
     });
 
     it('should display links for deployments', () => {
-        verifySecondaryEntities(entitiesKey, 'deployments', 4, /^\d+ deployments?$/);
+        verifySecondaryEntities(entitiesKey, 'deployments', 5, /^\d+ deployments?$/);
     });
 
     it('should display links for images', () => {
-        verifySecondaryEntities(entitiesKey, 'images', 5, /^\d+ images?$/);
+        verifySecondaryEntities(entitiesKey, 'images', 6, /^\d+ images?$/);
     });
 });

--- a/ui/apps/platform/cypress/integration/vulnmanagement/namespacesNonPostgress.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/namespacesNonPostgress.test.js
@@ -85,7 +85,8 @@ describe('Vulnerability Management Namespaces', () => {
         // Do not assert because of potential timing problem: get td elements before table re-renders.
     });
 
-    // Argument 3 in verify functions is one-based index of column which has the links.
+    // Argument 3 in verify functions is index of column which has the links,
+    // The one-based index includes checkbox, hidden, invisible.
 
     // Some tests might fail in local deployment.
 
@@ -93,7 +94,7 @@ describe('Vulnerability Management Namespaces', () => {
         verifySecondaryEntities(
             entitiesKey,
             'cves',
-            2,
+            3,
             /^\d+ CVEs?$/,
             getCountAndNounFromCVEsLinkResults
         );
@@ -103,17 +104,17 @@ describe('Vulnerability Management Namespaces', () => {
         verifyFilteredSecondaryEntitiesLink(
             entitiesKey,
             'cves',
-            2,
+            3,
             /^\d+ Fixable$/,
             getCountAndNounFromCVEsLinkResults
         );
     });
 
     it('should display links for deployments', () => {
-        verifySecondaryEntities(entitiesKey, 'deployments', 4, /^\d+ deployments?$/);
+        verifySecondaryEntities(entitiesKey, 'deployments', 5, /^\d+ deployments?$/);
     });
 
     it('should display links for images', () => {
-        verifySecondaryEntities(entitiesKey, 'images', 5, /^\d+ images?$/);
+        verifySecondaryEntities(entitiesKey, 'images', 6, /^\d+ images?$/);
     });
 });

--- a/ui/apps/platform/cypress/integration/vulnmanagement/namespacesNonPostgress.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/namespacesNonPostgress.test.js
@@ -85,7 +85,7 @@ describe('Vulnerability Management Namespaces', () => {
         // Do not assert because of potential timing problem: get td elements before table re-renders.
     });
 
-    // Argument 3 in verify functions is index of column which has the links,
+    // Argument 3 in verify functions is index of column which has the links.
     // The one-based index includes checkbox, hidden, invisible.
 
     // Some tests might fail in local deployment.

--- a/ui/apps/platform/cypress/integration/vulnmanagement/nodeComponents.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/nodeComponents.test.js
@@ -117,7 +117,8 @@ describe('Vulnerability Management Node Components', () => {
         });
     });
 
-    // Argument 3 in verify functions is one-based index of column which has the links.
+    // Argument 3 in verify functions is index of column which has the links,
+    // The one-based index includes checkbox, hidden, invisible.
 
     // Some tests might fail in local deployment.
 
@@ -125,7 +126,7 @@ describe('Vulnerability Management Node Components', () => {
         verifySecondaryEntities(
             entitiesKey,
             'node-cves',
-            3,
+            4,
             /^\d+ CVEs?$/,
             getCountAndNounFromNodeCVEsLinkResults
         );
@@ -135,13 +136,13 @@ describe('Vulnerability Management Node Components', () => {
         verifyFilteredSecondaryEntitiesLink(
             entitiesKey,
             'node-cves',
-            3,
+            4,
             /^\d+ Fixable$/,
             getCountAndNounFromNodeCVEsLinkResults
         );
     });
 
     it('should display links for nodes', () => {
-        verifySecondaryEntities(entitiesKey, 'nodes', 5, /^\d+ nodes?$/);
+        verifySecondaryEntities(entitiesKey, 'nodes', 6, /^\d+ nodes?$/);
     });
 });

--- a/ui/apps/platform/cypress/integration/vulnmanagement/nodeComponents.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/nodeComponents.test.js
@@ -117,7 +117,7 @@ describe('Vulnerability Management Node Components', () => {
         });
     });
 
-    // Argument 3 in verify functions is index of column which has the links,
+    // Argument 3 in verify functions is index of column which has the links.
     // The one-based index includes checkbox, hidden, invisible.
 
     // Some tests might fail in local deployment.

--- a/ui/apps/platform/cypress/integration/vulnmanagement/nodeCves.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/nodeCves.test.js
@@ -128,7 +128,7 @@ describe('Vulnerability Management Node CVEs', () => {
         );
     });
 
-    // Argument 3 in verify functions is index of column which has the links,
+    // Argument 3 in verify functions is index of column which has the links.
     // The one-based index includes checkbox, hidden, invisible.
 
     // Some tests might fail in local deployment.

--- a/ui/apps/platform/cypress/integration/vulnmanagement/nodeCves.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/nodeCves.test.js
@@ -128,16 +128,16 @@ describe('Vulnerability Management Node CVEs', () => {
         );
     });
 
-    // Argument 3 in verify functions is one-based index of column which has the links.
-    // Count the checkbox as the first column.
+    // Argument 3 in verify functions is index of column which has the links,
+    // The one-based index includes checkbox, hidden, invisible.
 
     // Some tests might fail in local deployment.
 
     it('should display links for nodes', () => {
-        verifySecondaryEntities(entitiesKey, 'nodes', 9, /^\d+ nodes?$/);
+        verifySecondaryEntities(entitiesKey, 'nodes', 10, /^\d+ nodes?$/);
     });
 
     it('should display links for node-components', () => {
-        verifySecondaryEntities(entitiesKey, 'node-components', 9, /^\d+ node components?$/);
+        verifySecondaryEntities(entitiesKey, 'node-components', 10, /^\d+ node components?$/);
     });
 });

--- a/ui/apps/platform/cypress/integration/vulnmanagement/policies.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/policies.test.js
@@ -78,7 +78,8 @@ describe('Vulnerability Management Policies', () => {
         });
     });
 
-    // Argument 3 in verify functions is one-based index of column which has the links.
+    // Argument 3 in verify functions is index of column which has the links.
+    // The one-based index includes checkbox, hidden, invisible.
 
     // Some tests might fail in local deployment.
 
@@ -86,7 +87,7 @@ describe('Vulnerability Management Policies', () => {
         verifyFilteredSecondaryEntitiesLink(
             entitiesKey,
             'deployments',
-            9,
+            10,
             /^\d+ failing deployments?$/,
             getPanelHeaderTextFromLinkResults
         );


### PR DESCRIPTION
## Description

Follow up residue from #3885

**Objective**: To prevent confusion.

Because `hasTableColumnHeadings` function explicitly asserts existence of checkbox, hidden, and invisible column headings:
1. Make comments more specific.
2. Increment `columnIndex` arguments of verify function calls to be consistent with arrays of column heading strings in the function call.
3. Replace `columnIndex + 1` with `columnIndex` in `nth-child` pseudo-selector.
    * `verifySecondaryEntities`
    * `verifyFilteredSecondaryEntitiesLink`
    * `verifyFixableCVEsLinkAndRiskAcceptanceTabs`

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed