### PR TITLE
Enable caching for eslint

### DIFF
--- a/ui/apps/platform/package.json
+++ b/ui/apps/platform/package.json
@@ -111,7 +111,7 @@
         "build": "DISABLE_ESLINT_PLUGIN=true CI=false GENERATE_SOURCEMAP=false react-scripts build",
         "test": "JEST_JUNIT_UNIQUE_OUTPUT_NAME=true JEST_JUNIT_OUTPUT_DIR=${TEST_RESULTS_OUTPUT_DIR:-test-results}/reports react-scripts test --verbose=true --slowTestThreshold=1  --coverage --reporters=default --reporters=jest-junit",
         "test-watch": "react-scripts test",
-        "lint": "NODE_PATH=src eslint --quiet --ext .js,.ts,.tsx src cypress tailwind.config.js .prettierrc.js .eslintrc.js",
+        "lint": "NODE_PATH=src eslint --cache --quiet --ext .js,.ts,.tsx src cypress tailwind.config.js .prettierrc.js .eslintrc.js",
         "cypress-open": "./scripts/cypress.sh open --config defaultCommandTimeout=8000",
         "cypress-spec": "./scripts/cypress.sh run --spec",
         "test-e2e": "./scripts/cypress.sh run --reporter mocha-multi-reporters --reporter-options configFile=cypress/mocha.config.js",

--- a/ui/packages/tailwind-config/package.json
+++ b/ui/packages/tailwind-config/package.json
@@ -21,7 +21,7 @@
         "build": "postcss ./index.tw.css -o ./tailwind.css",
         "start": "yarn build",
         "lint:non-src": "prettier --check '**/*.{md,css,json}'",
-        "lint:src": "eslint --ext .js ./",
+        "lint:src": "eslint --cache --ext .js ./",
         "lint": "npm-run-all lint:*",
         "lint-fix:non-src": "prettier --write '**/*.{md,css,json}'",
         "lint-fix:src": "eslint --fix --ext .js ./",

--- a/ui/packages/ui-components/package.json
+++ b/ui/packages/ui-components/package.json
@@ -27,7 +27,7 @@
         "test": "JEST_JUNIT_UNIQUE_OUTPUT_NAME=true JEST_JUNIT_OUTPUT_DIR=${TEST_RESULTS_OUTPUT_DIR:-test-results}/reports jest --verbose=true --slowTestThreshold=1 --coverage --reporters=default --reporters=jest-junit",
         "test:watch": "jest --watch-all",
         "lint:non-src": "prettier --check '**/*.{md,css,json}'",
-        "lint:src": "eslint --ext .js,.ts,.tsx ./",
+        "lint:src": "eslint --cache --ext .js,.ts,.tsx ./",
         "lint": "npm-run-all lint:*",
         "lint-fix:non-src": "prettier --write '**/*.{md,css,json}'",
         "lint-fix:src": "eslint --fix --ext .js,.ts,.tsx ./",


### PR DESCRIPTION
## Description

Enabled the [eslint cache](https://eslint.org/docs/latest/user-guide/command-line-interface#caching) to only lint files that have been changed since the last lint run. In CI this should always run the full lint job since `.eslintcache` is .gitignored.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

#### From top level ui/

Before change:
<pre>
yarn lint
yarn run v1.22.19
$ yarn build:packages && lerna run lint --parallel --stream
$ lerna run build --stream --ignore @stackrox/*-app
lerna notice cli v3.22.1
lerna info versioning independent
lerna notice filter excluding "@stackrox/*-app"
lerna info filter [ '!@stackrox/*-app' ]
lerna info Executing command in 2 packages: "yarn run build"
@stackrox/tailwind-config: $ postcss ./index.tw.css -o ./tailwind.css
@stackrox/ui-components: $ npm-run-all build:*
@stackrox/ui-components: $ postcss ./src/index.tw.css -o ./lib/ui-components.css
@stackrox/ui-components: $ tsc --build
lerna success run Ran npm script 'build' in 2 packages in 4.6s:
lerna success - @stackrox/tailwind-config
lerna success - @stackrox/ui-components
lerna notice cli v3.22.1
lerna info versioning independent
lerna info Executing command in 3 packages: "yarn run lint"
@stackrox/tailwind-config: $ npm-run-all lint:*
@stackrox/platform-app: $ NODE_PATH=src eslint --cache --quiet --ext .js,.ts,.tsx src cypress tailwind.config.js .prettierrc.js .eslintrc.js
@stackrox/ui-components: $ npm-run-all lint:*
@stackrox/tailwind-config: $ prettier --check '**/*.{md,css,json}'
@stackrox/ui-components: $ prettier --check '**/*.{md,css,json}'
@stackrox/tailwind-config: Checking formatting...
@stackrox/ui-components: Checking formatting...
@stackrox/tailwind-config: All matched files use Prettier code style!
@stackrox/ui-components: All matched files use Prettier code style!
@stackrox/ui-components: $ eslint --cache --ext .js,.ts,.tsx ./
@stackrox/tailwind-config: $ eslint --cache --ext .js ./
lerna success run Ran npm script 'lint' in 3 packages in 79.2s:
lerna success - @stackrox/platform-app
lerna success - @stackrox/tailwind-config
lerna success - @stackrox/ui-components
✨  <b>Done in 84.96s.</b>
</pre>

After change:
<pre>
yarn lint
yarn run v1.22.19
$ yarn build:packages && lerna run lint --parallel --stream
$ lerna run build --stream --ignore @stackrox/*-app
lerna notice cli v3.22.1
lerna info versioning independent
lerna notice filter excluding "@stackrox/*-app"
lerna info filter [ '!@stackrox/*-app' ]
lerna info Executing command in 2 packages: "yarn run build"
@stackrox/tailwind-config: $ postcss ./index.tw.css -o ./tailwind.css
@stackrox/ui-components: $ npm-run-all build:*
@stackrox/ui-components: $ postcss ./src/index.tw.css -o ./lib/ui-components.css
@stackrox/ui-components: $ tsc --build
lerna success run Ran npm script 'build' in 2 packages in 4.4s:
lerna success - @stackrox/tailwind-config
lerna success - @stackrox/ui-components
lerna notice cli v3.22.1
lerna info versioning independent
lerna info Executing command in 3 packages: "yarn run lint"
@stackrox/platform-app: $ NODE_PATH=src eslint --cache --quiet --ext .js,.ts,.tsx src cypress tailwind.config.js .prettierrc.js .eslintrc.js
@stackrox/tailwind-config: $ npm-run-all lint:*
@stackrox/ui-components: $ npm-run-all lint:*
@stackrox/tailwind-config: $ prettier --check '**/*.{md,css,json}'
@stackrox/ui-components: $ prettier --check '**/*.{md,css,json}'
@stackrox/tailwind-config: Checking formatting...
@stackrox/ui-components: Checking formatting...
@stackrox/tailwind-config: All matched files use Prettier code style!
@stackrox/ui-components: All matched files use Prettier code style!
@stackrox/tailwind-config: $ eslint --cache --ext .js ./
@stackrox/ui-components: $ eslint --cache --ext .js,.ts,.tsx ./
lerna success run Ran npm script 'lint' in 3 packages in 2.7s:
lerna success - @stackrox/platform-app
lerna success - @stackrox/tailwind-config
lerna success - @stackrox/ui-components
✨  <b>Done in 8.41s.</b>
</pre>

#### From ui/apps/platform

Before change:
<pre>
yarn lint
yarn run v1.22.19
$ NODE_PATH=src eslint --cache --quiet --ext .js,.ts,.tsx src cypress tailwind.config.js .prettierrc.js .eslintrc.js
✨  <b>Done in 105.60s.</b>
</pre>

After change:
<pre>
yarn lint
yarn run v1.22.19
$ NODE_PATH=src eslint --cache --quiet --ext .js,.ts,.tsx src cypress tailwind.config.js .prettierrc.js .eslintrc.js
✨  <b>Done in 2.88s.</b>
</pre>

Testing that a lint error is picked up in an existing file:
<pre>
yarn lint
yarn run v1.22.19
$ NODE_PATH=src eslint --cache --quiet --ext .js,.ts,.tsx src cypress tailwind.config.js .prettierrc.js .eslintrc.js
/Users/dvail/go/src/github.com/stackrox/stackrox/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
  3:8  error  'camelCase' is defined but never used  @typescript-eslint/no-unused-vars

✖ 1 problem (1 error, 0 warnings)

error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
</pre>

Fix the lint error (slower, but still much better with caching enabled):
<pre>
yarn lint
yarn run v1.22.19
$ NODE_PATH=src eslint --cache --quiet --ext .js,.ts,.tsx src cypress tailwind.config.js .prettierrc.js .eslintrc.js
✨  <b>Done in 12.67s.</b>
</pre>

Test that errors in new files are picked up correctly:
```typescript
import React, { useState } from 'react';

export default function Lint() {
    return <></>;
}
```
<pre>
yarn lint
yarn run v1.22.19
$ NODE_PATH=src eslint --cache --quiet --ext .js,.ts,.tsx src cypress tailwind.config.js .prettierrc.js .eslintrc.js
/Users/dvail/go/src/github.com/stackrox/stackrox/ui/apps/platform/src/Containers/Collections/Lint.tsx
  1:17  error  'useState' is defined but never used  @typescript-eslint/no-unused-vars

✖ 1 problem (1 error, 0 warnings)

error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
</pre>