### PR TITLE
ROX-12940: add download-diagnostics unit test

### DIFF
--- a/roxctl/central/debug/download_diagnostics_test.go
+++ b/roxctl/central/debug/download_diagnostics_test.go
@@ -84,7 +84,7 @@ func executeDiagnosticsCommand(t *testing.T, serverURL string, timeout time.Dura
 
 	// We are using common.DoHTTPRequestAndCheck200 inside GetZip(). This
 	// function uses  global variables that are set by command execution.
-	// TODO: ROX-13638 Change GetZip function to use HTTPClient from Environment.
+	// TODO(ROX-13638): Change GetZip function to use HTTPClient from Environment.
 	cmdArgs := []string{"--insecure-skip-tls-verify", "--insecure",
 		"--endpoint", serverURL,
 		"--password", "test",

--- a/roxctl/central/debug/download_diagnostics_test.go
+++ b/roxctl/central/debug/download_diagnostics_test.go
@@ -1,0 +1,105 @@
+package debug
+
+import (
+	"archive/zip"
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stackrox/rox/pkg/utils"
+	"github.com/stackrox/rox/roxctl/common/environment"
+	"github.com/stackrox/rox/roxctl/common/flags"
+	io2 "github.com/stackrox/rox/roxctl/common/io"
+	"github.com/stackrox/rox/roxctl/common/printer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDownloadDiagnosticsTimeoutReached(t *testing.T) {
+	shutdownServer := make(chan struct{}, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		<-shutdownServer
+	}))
+	defer server.Close()
+	defer close(shutdownServer)
+
+	_, stdErr, err := executeDiagnosticsCommand(t, server.URL, 10*time.Millisecond, "")
+
+	require.Error(t, err)
+	assert.True(t, isTimeoutError(err))
+	assert.Contains(t, stdErr.String(), "Timeout has been reached while creating diagnostic bundle")
+}
+
+func TestDownloadDiagnosticsServerError(t *testing.T) {
+	expectedErrorStr := "test-server-error"
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rw.WriteHeader(http.StatusInternalServerError)
+		_, _ = rw.Write([]byte(expectedErrorStr))
+	}))
+	defer server.Close()
+
+	_, stdErr, err := executeDiagnosticsCommand(t, server.URL, 20*time.Second, "")
+
+	require.Error(t, err)
+	assert.False(t, isTimeoutError(err))
+	assert.Contains(t, err.Error(), expectedErrorStr)
+	assert.NotContains(t, stdErr.String(), "Timeout has been reached while creating diagnostic bundle")
+}
+
+func TestDownloadDiagnosticsSuccess(t *testing.T) {
+	zipFilename := "test-file.zip"
+	tempDir, errTempDir := os.MkdirTemp("", "prefix")
+	require.NoError(t, errTempDir)
+	defer utils.IgnoreError(func() error {
+		return os.Remove(tempDir)
+	})
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rw.Header().Set("Content-Type", "application/zip")
+		rw.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s\"", zipFilename))
+		zipWriter := zip.NewWriter(rw)
+		require.NoError(t, zipWriter.Close())
+	}))
+	defer server.Close()
+
+	_, _, err := executeDiagnosticsCommand(t, server.URL, 20*time.Second, tempDir)
+
+	assert.NoError(t, err)
+	_, err = os.Stat(fmt.Sprintf("%s/%s", tempDir, zipFilename))
+	assert.NoError(t, err)
+}
+
+func executeDiagnosticsCommand(t *testing.T, serverURL string, timeout time.Duration, dir string) (*bytes.Buffer, *bytes.Buffer, error) {
+	testIO, _, stdOut, stdErr := io2.TestIO()
+	env := environment.NewTestCLIEnvironment(t, testIO, printer.DefaultColorPrinter())
+
+	cmd := downloadDiagnosticsCommand(env)
+	flags.AddConnectionFlags(cmd)
+	flags.AddPassword(cmd)
+
+	cmd.SilenceUsage = true
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+
+	// We are using common.DoHTTPRequestAndCheck200 inside GetZip(). This
+	// function uses  global variables that are set by command execution.
+	// TODO: Change GetZip function to use HTTPClient from Environment.
+	cmdArgs := []string{"--insecure-skip-tls-verify", "--insecure",
+		"--endpoint", serverURL,
+		"--password", "test",
+		"--timeout", timeout.String(),
+		"--output-dir", dir,
+	}
+	cmd.SetArgs(cmdArgs)
+
+	cmdExecutionErr := cmd.Execute()
+	if cmdExecutionErr != nil {
+		return stdOut, stdErr, cmdExecutionErr
+	}
+
+	return stdOut, stdErr, nil
+}

--- a/roxctl/scanner/uploaddb/uploaddb_test.go
+++ b/roxctl/scanner/uploaddb/uploaddb_test.go
@@ -42,7 +42,7 @@ func executeUpdateDbCommand(t *testing.T, serverURL string) (*bytes.Buffer, *byt
 
 	// We are using common.DoHTTPRequestAndCheck200 inside uploadDd(). This
 	// function uses  global variables that are set by command execution.
-	// TODO: ROX-13638 Change uploadDd function to use HTTPClient from Environment.
+	// TODO(ROX-13638): Change uploadDd function to use HTTPClient from Environment.
 	cmdArgs := []string{"--insecure-skip-tls-verify", "--insecure", "--endpoint", serverURL, "--password", "test"}
 	cmdArgs = append(cmdArgs, "--scanner-db-file", tmpFile.Name())
 	cmd.SetArgs(cmdArgs)

--- a/roxctl/scanner/uploaddb/uploaddb_test.go
+++ b/roxctl/scanner/uploaddb/uploaddb_test.go
@@ -42,7 +42,7 @@ func executeUpdateDbCommand(t *testing.T, serverURL string) (*bytes.Buffer, *byt
 
 	// We are using common.DoHTTPRequestAndCheck200 inside uploadDd(). This
 	// function uses  global variables that are set by command execution.
-	// TODO: Change uploadDd function to use HTTPClient from Environment.
+	// TODO: ROX-13638 Change uploadDd function to use HTTPClient from Environment.
 	cmdArgs := []string{"--insecure-skip-tls-verify", "--insecure", "--endpoint", serverURL, "--password", "test"}
 	cmdArgs = append(cmdArgs, "--scanner-db-file", tmpFile.Name())
 	cmd.SetArgs(cmdArgs)


### PR DESCRIPTION
Tests if `isTimeoutError` is working properly, as well as a successful case and internal server error case.

Refactoring of roxctl HTTP client to avoid depending on global state(flags) is moved to a separate JIRA:
https://issues.redhat.com/browse/ROX-13625

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
~~- [ ] Evaluated and added CHANGELOG entry if required~~
~~- [ ] Determined and documented upgrade steps~~
~~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed
