### PR TITLE
ROX-12844: Refactor sensor image enrichment with multiple image names

### DIFF
--- a/central/image/service/service_impl.go
+++ b/central/image/service/service_impl.go
@@ -222,14 +222,14 @@ func (s *serviceImpl) ScanImageInternal(ctx context.Context, request *v1.ScanIma
 			return nil, err
 		}
 
-		// If the image exists, and the request's image name exists within the images name, we return the image which
-		// includes the scan information (which includes signature data).
+		// If the image exists and the image name from the request matches at least one stored image name(/reference),
+		// then we returned the stored image.
 		// Otherwise, we run the enrichment pipeline using the existing image with the requests image being added to it.
 		if exists {
 			if protoutils.SliceContains(request.GetImage().GetName(), existingImg.GetNames()) {
 				return internalScanRespFromImage(existingImg), nil
 			}
-			existingImg.Names = append(existingImg.GetNames(), request.GetImage().GetName())
+			existingImg.Names = append(existingImg.Names, request.GetImage().GetName())
 			img = existingImg
 			// We only want to force re-fetching of signatures and verification data, the additional image name has no
 			// impact on image scan data.

--- a/central/image/service/service_impl.go
+++ b/central/image/service/service_impl.go
@@ -29,6 +29,7 @@ import (
 	"github.com/stackrox/rox/pkg/images/enricher"
 	"github.com/stackrox/rox/pkg/images/types"
 	"github.com/stackrox/rox/pkg/images/utils"
+	"github.com/stackrox/rox/pkg/protoutils"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/paginated"
 	"github.com/stackrox/rox/pkg/set"
@@ -207,37 +208,65 @@ func (s *serviceImpl) ScanImageInternal(ctx context.Context, request *v1.ScanIma
 
 	defer s.internalScanSemaphore.Release(1)
 
-	imgID := request.GetImage().GetId()
+	var (
+		img      *storage.Image
+		fetchOpt enricher.FetchOption
+	)
 
+	imgID := request.GetImage().GetId()
 	// Always pull the image from the store if the ID != "". Central will manage the reprocessing over the images.
 	if imgID != "" {
 		existingImg, exists, err := s.datastore.GetImage(ctx, imgID)
 		if err != nil {
 			return nil, err
 		}
-		// If the scan exists, return the scan.
-		// Otherwise, run the enrichment pipeline.
+
+		// If the image exists, and the request's image name exists within the images name, we return the image which
+		// includes the scan information (which includes signature data).
+		// Otherwise, we run the enrichment pipeline using the existing image with the requests image being added to it.
 		if exists {
-			return internalScanRespFromImage(existingImg), nil
+			if protoutils.SliceContains(request.GetImage().GetName(), existingImg.GetNames()) {
+				return internalScanRespFromImage(existingImg), nil
+			}
+			existingImg.Names = append(existingImg.GetNames(), request.GetImage().GetName())
+			img = existingImg
+			// We only want to force re-fetching of signatures and verification data, the additional image name has no
+			// impact on image scan data.
+			fetchOpt = enricher.ForceRefetchSignaturesOnly
 		}
 	}
 
-	// If no ID, then don't use caches as they could return stale data
-	fetchOpt := enricher.UseCachesIfPossible
-	if request.GetCachedOnly() {
-		fetchOpt = enricher.NoExternalMetadata
-	} else if imgID == "" {
-		fetchOpt = enricher.ForceRefetch
+	if img == nil {
+		fetchOpt = enricher.UseCachesIfPossible
+		if request.GetCachedOnly() {
+			fetchOpt = enricher.NoExternalMetadata
+		} else if imgID == "" { // If no ID, then don't use caches as they could return stale data.
+			fetchOpt = enricher.ForceRefetch
+		}
+		img = types.ToImage(request.GetImage())
 	}
 
-	img := types.ToImage(request.GetImage())
+	s.enrichImage(ctx, img, fetchOpt, request.GetSource())
+	// Due to discrepancies in digests retrieved from metadata pulls and k8s, only upsert if the request
+	// contained a digest.
+	if imgID != "" {
+		_ = s.saveImage(img)
+	}
 
+	return internalScanRespFromImage(img), nil
+}
+
+// enrichImage will enrich the given image, additionally applying the request source and fetch option to the request.
+// Any occurred error will be logged, and the given image will be modified, after execution it will contain the enriched
+// image data (i.e. scan results, signature data etc.).
+func (s *serviceImpl) enrichImage(ctx context.Context, img *storage.Image, fetchOpt enricher.FetchOption,
+	requestSource *v1.ScanImageInternalRequest_Source) {
 	var source *enricher.RequestSource
-	if request.GetSource() != nil {
+	if requestSource != nil {
 		source = &enricher.RequestSource{
-			ClusterID:        request.GetSource().GetClusterId(),
-			Namespace:        request.GetSource().GetNamespace(),
-			ImagePullSecrets: set.NewStringSet(request.GetSource().GetImagePullSecrets()...),
+			ClusterID:        requestSource.GetClusterId(),
+			Namespace:        requestSource.GetNamespace(),
+			ImagePullSecrets: set.NewStringSet(requestSource.GetImagePullSecrets()...),
 		}
 	}
 
@@ -248,18 +277,10 @@ func (s *serviceImpl) ScanImageInternal(ctx context.Context, request *v1.ScanIma
 	}
 
 	if _, err := s.enricher.EnrichImage(ctx, enrichmentContext, img); err != nil {
-		log.Errorf("error enriching image %q: %v", request.GetImage().GetName().GetFullName(), err)
-		// purposefully, don't return here because we still need to save it into the DB so there is a reference
-		// even if we weren't able to enrich it
+		log.Errorf("error enriching image %q: %v", img.GetName().GetFullName(), err)
+		// Purposefully, don't return here because we still need to save it into the DB so there is a reference
+		// even if we weren't able to enrich it.
 	}
-
-	// Due to discrepancies in digests retrieved from metadata pulls and k8s, only upsert if the request
-	// contained a digest
-	if imgID != "" {
-		_ = s.saveImage(img)
-	}
-
-	return internalScanRespFromImage(img), nil
 }
 
 // ScanImage scans an image and returns the result

--- a/pkg/images/enricher/enricher_impl.go
+++ b/pkg/images/enricher/enricher_impl.go
@@ -362,7 +362,7 @@ func (e *enricherImpl) enrichImageWithRegistry(ctx context.Context, image *stora
 
 func (e *enricherImpl) fetchFromDatabase(ctx context.Context, img *storage.Image, option FetchOption) (*storage.Image, bool) {
 	if option.forceRefetchCachedValues() {
-		// When refetched values should be used, reset the existing values for signature and signature verification data.
+		// When re-fetched values should be used, reset the existing values for signature and signature verification data.
 		img.Signature = nil
 		img.SignatureVerificationData = nil
 		return img, false

--- a/pkg/protoutils/slice_contains.go
+++ b/pkg/protoutils/slice_contains.go
@@ -1,0 +1,13 @@
+package protoutils
+
+import "github.com/gogo/protobuf/proto"
+
+// SliceContains returns whether the given slice of proto objects contains the given proto object.
+func SliceContains[T proto.Message](msg T, slice []T) bool {
+	for _, elem := range slice {
+		if proto.Equal(elem, msg) {
+			return true
+		}
+	}
+	return false
+}

--- a/sensor/common/detector/enricher.go
+++ b/sensor/common/detector/enricher.go
@@ -155,7 +155,7 @@ func (e *enricher) getImageFromCache(key string) (*storage.Image, bool) {
 
 func (e *enricher) runScan(req *scanImageRequest) imageChanResult {
 	// Cache key is either going to be image full name or image ID.
-	// In cae of image full name, we can skip. In case of image ID, we should make sure to check if the image's name
+	// In case of image full name, we can skip. In case of image ID, we should make sure to check if the image's name
 	// is equal / contained in the images `Names` field.
 	key := imagecacheutils.GetImageCacheKey(req.containerImage)
 


### PR DESCRIPTION
## Description

[The parent PR has the initial problem statement as well as the references to all follow-up PRs that have been done, please consult it to get the full context of changes being made here.](https://github.com/stackrox/stackrox/pull/3511)

Additionally, [this doc exists for a overview of the changes being made within this series of PRs.](https://docs.google.com/document/d/1xxBQMRGQHOJg1E44iCUkMOGul7ht_496VubhSZYJ42k/edit?usp=sharing)

Within this PR, the sensor will now re-scan images that have the same digest, but have different image names associated with them. This will lead to central correctly upserting and re-fetching signatures & signature verification data for the newly added image name. It will also ensure that this will be continuously reprocessed.

Note that there will be more follow-ups coming, specifically:
- Changing the image signature policy to take the image full name of the deployment into account when verifying signatures.
- Adding E2E tests that cover the cases with images with the same digest but different image names.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
~~- [ ] Evaluated and added CHANGELOG entry if required~~
~~- [ ] Determined and documented upgrade steps~~
~~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

Manual tests (note, that automated E2E tests will be added in a follow-up, essentially emulating whatever I have done here now + the policy part):
```bash
# The test setup requires two images, located in two different repositories within a container registry, e.g. dockerhub.
# I have prepped two images for the manual tests specifically, with [crane](https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane.md) we can check that they have the same digest:
crane digest  daha97/nginx:1.23
sha256:6ad8394ad31b269b563566998fd80a8f259e8decf16e807f8310ecc10c687385

crane digest daha97/alt-nginx:1.23
sha256:6ad8394ad31b269b563566998fd80a8f259e8decf16e807f8310ecc10c687385

# (As an additional note, only `alt-nginx` has a signature associated with it).

# Start with creating a pod running the first image:
k run --image=daha97/nginx:1.23

# Observe within the API that the image has been created successfully + enriched:
roxcurl /v1/images | jq
....
    {
      "id": "sha256:6ad8394ad31b269b563566998fd80a8f259e8decf16e807f8310ecc10c687385",
      "name": "docker.io/daha97/nginx:1.23",
      "components": 108,
      "cves": 72,
      "fixableCves": 0,
      "created": "2022-11-15T13:14:32.170016733Z",
      "lastUpdated": "2022-11-25T03:11:11.222162138Z",
      "priority": "1"
    }
....

# Inspecting the image closer should reveal that no signature data is associated with it:
roxcurl /v1/images/sha256:6ad8394ad31b269b563566998fd80a8f259e8decf16e807f8310ecc10c687385 | jq -r '.notes'
  "notes": [
    "MISSING_SIGNATURE",
    "MISSING_SIGNATURE_VERIFICATION_DATA"
  ]

# We also observe the "names" field being populated correctly, but only with a single name:
roxcurl /v1/images/sha256:6ad8394ad31b269b563566998fd80a8f259e8decf16e807f8310ecc10c687385 | jq -r '.names'
[
  {
    "registry": "docker.io",
    "remote": "daha97/nginx",
    "tag": "1.23",
    "fullName": "docker.io/daha97/nginx:1.23"
  }
]

# Now, create another pod running the second image:
k run --image=daha97/alt-nginx:1.23

# Observe within the names field that this now contains two entries:
roxcurl /v1/images/sha256:6ad8394ad31b269b563566998fd80a8f259e8decf16e807f8310ecc10c687385 | jq -r '.names'
[
  {
    "registry": "docker.io",
    "remote": "daha97/nginx",
    "tag": "1.23",
    "fullName": "docker.io/daha97/nginx:1.23"
  },
  {
    "registry": "docker.io",
    "remote": "daha97/alt-nginx",
    "tag": "1.23",
    "fullName": "docker.io/daha97/alt-nginx:1.23"
  }
]

# Additionally, we see that the image signature will be fetched. If we now configure a signature integration, this would also be verified:
roxcurl /v1/images/sha256:6ad8394ad31b269b563566998fd80a8f259e8decf16e807f8310ecc10c687385 | jq -r '.notes'
  "notes": [
    "MISSING_SIGNATURE_VERIFICATION_DATA"
  ]
```