### PR TITLE
Fix image signature query in reprocessor

### DIFF
--- a/central/reprocessor/reprocessor.go
+++ b/central/reprocessor/reprocessor.go
@@ -54,7 +54,7 @@ var (
 
 	imagesWithSignatureVerificationResultsQuery = search.NewQueryBuilder().
 							AddStringsHighlighted(search.ClusterID, search.WildcardString).
-							AddStrings(search.ImageSignatureFetchedTime, search.WildcardString).ProtoQuery()
+							AddDays(search.ImageSignatureFetchedTime, 0).ProtoQuery()
 )
 
 // Singleton returns the singleton reprocessor loop


### PR DESCRIPTION
## Description

Previously, this query worked although it was using `search.WildcardString` instead of a properly formatted timeout.

I assume we added validation of the timestamp value, and disallowing the `search.WildcardString` for it.

Hence, fixing this now to use the appropriate `AddDays` option instead.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

```
1. Create a deployment with a signature.
apiVersion: v1
kind: Pod
metadata:
  labels:
    run: daha-alt-nginx
  name: daha-alt-nginx
spec:
  containers:
  - image: docker.io/daha97/alt-nginx:1.23
    name: daha-alt-nginx
  dnsPolicy: ClusterFirst
  restartPolicy: Always

2. Create a signature integration

3. Observe within the logs that at least 1 image will be reprocessed.
reprocessor: 2022/12/06 01:52:29.176015 reprocessor.go:368: Info: Found 1 images to scan
reprocessor: 2022/12/06 01:52:29.332105 reprocessor.go:419: Info: Successfully reprocessed 1/1 images
reprocessor: 2022/12/06 01:52:29.332323 reprocessor.go:420: Info: Resyncing deployments now that images have been reprocessed...
```

