### PR TITLE
ROX-12844: Refactor image signature policy

### DIFF
--- a/central/image/service/service_impl.go
+++ b/central/image/service/service_impl.go
@@ -222,14 +222,14 @@ func (s *serviceImpl) ScanImageInternal(ctx context.Context, request *v1.ScanIma
 			return nil, err
 		}
 
-		// If the image exists, and the request's image name exists within the images name, we return the image which
-		// includes the scan information (which includes signature data).
+		// If the image exists and the image name from the request matches at least one stored image name(/reference),
+		// then we returned the stored image.
 		// Otherwise, we run the enrichment pipeline using the existing image with the requests image being added to it.
 		if exists {
 			if protoutils.SliceContains(request.GetImage().GetName(), existingImg.GetNames()) {
 				return internalScanRespFromImage(existingImg), nil
 			}
-			existingImg.Names = append(existingImg.GetNames(), request.GetImage().GetName())
+			existingImg.Names = append(existingImg.Names, request.GetImage().GetName())
 			img = existingImg
 			// We only want to force re-fetching of signatures and verification data, the additional image name has no
 			// impact on image scan data.

--- a/central/image/service/service_impl.go
+++ b/central/image/service/service_impl.go
@@ -29,6 +29,7 @@ import (
 	"github.com/stackrox/rox/pkg/images/enricher"
 	"github.com/stackrox/rox/pkg/images/types"
 	"github.com/stackrox/rox/pkg/images/utils"
+	"github.com/stackrox/rox/pkg/protoutils"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/paginated"
 	"github.com/stackrox/rox/pkg/set"
@@ -207,37 +208,65 @@ func (s *serviceImpl) ScanImageInternal(ctx context.Context, request *v1.ScanIma
 
 	defer s.internalScanSemaphore.Release(1)
 
-	imgID := request.GetImage().GetId()
+	var (
+		img      *storage.Image
+		fetchOpt enricher.FetchOption
+	)
 
+	imgID := request.GetImage().GetId()
 	// Always pull the image from the store if the ID != "". Central will manage the reprocessing over the images.
 	if imgID != "" {
 		existingImg, exists, err := s.datastore.GetImage(ctx, imgID)
 		if err != nil {
 			return nil, err
 		}
-		// If the scan exists, return the scan.
-		// Otherwise, run the enrichment pipeline.
+
+		// If the image exists, and the request's image name exists within the images name, we return the image which
+		// includes the scan information (which includes signature data).
+		// Otherwise, we run the enrichment pipeline using the existing image with the requests image being added to it.
 		if exists {
-			return internalScanRespFromImage(existingImg), nil
+			if protoutils.SliceContains(request.GetImage().GetName(), existingImg.GetNames()) {
+				return internalScanRespFromImage(existingImg), nil
+			}
+			existingImg.Names = append(existingImg.GetNames(), request.GetImage().GetName())
+			img = existingImg
+			// We only want to force re-fetching of signatures and verification data, the additional image name has no
+			// impact on image scan data.
+			fetchOpt = enricher.ForceRefetchSignaturesOnly
 		}
 	}
 
-	// If no ID, then don't use caches as they could return stale data
-	fetchOpt := enricher.UseCachesIfPossible
-	if request.GetCachedOnly() {
-		fetchOpt = enricher.NoExternalMetadata
-	} else if imgID == "" {
-		fetchOpt = enricher.ForceRefetch
+	if img == nil {
+		fetchOpt = enricher.UseCachesIfPossible
+		if request.GetCachedOnly() {
+			fetchOpt = enricher.NoExternalMetadata
+		} else if imgID == "" { // If no ID, then don't use caches as they could return stale data.
+			fetchOpt = enricher.ForceRefetch
+		}
+		img = types.ToImage(request.GetImage())
 	}
 
-	img := types.ToImage(request.GetImage())
+	s.enrichImage(ctx, img, fetchOpt, request.GetSource())
+	// Due to discrepancies in digests retrieved from metadata pulls and k8s, only upsert if the request
+	// contained a digest.
+	if imgID != "" {
+		_ = s.saveImage(img)
+	}
 
+	return internalScanRespFromImage(img), nil
+}
+
+// enrichImage will enrich the given image, additionally applying the request source and fetch option to the request.
+// Any occurred error will be logged, and the given image will be modified, after execution it will contain the enriched
+// image data (i.e. scan results, signature data etc.).
+func (s *serviceImpl) enrichImage(ctx context.Context, img *storage.Image, fetchOpt enricher.FetchOption,
+	requestSource *v1.ScanImageInternalRequest_Source) {
 	var source *enricher.RequestSource
-	if request.GetSource() != nil {
+	if requestSource != nil {
 		source = &enricher.RequestSource{
-			ClusterID:        request.GetSource().GetClusterId(),
-			Namespace:        request.GetSource().GetNamespace(),
-			ImagePullSecrets: set.NewStringSet(request.GetSource().GetImagePullSecrets()...),
+			ClusterID:        requestSource.GetClusterId(),
+			Namespace:        requestSource.GetNamespace(),
+			ImagePullSecrets: set.NewStringSet(requestSource.GetImagePullSecrets()...),
 		}
 	}
 
@@ -248,18 +277,10 @@ func (s *serviceImpl) ScanImageInternal(ctx context.Context, request *v1.ScanIma
 	}
 
 	if _, err := s.enricher.EnrichImage(ctx, enrichmentContext, img); err != nil {
-		log.Errorf("error enriching image %q: %v", request.GetImage().GetName().GetFullName(), err)
-		// purposefully, don't return here because we still need to save it into the DB so there is a reference
-		// even if we weren't able to enrich it
+		log.Errorf("error enriching image %q: %v", img.GetName().GetFullName(), err)
+		// Purposefully, don't return here because we still need to save it into the DB so there is a reference
+		// even if we weren't able to enrich it.
 	}
-
-	// Due to discrepancies in digests retrieved from metadata pulls and k8s, only upsert if the request
-	// contained a digest
-	if imgID != "" {
-		_ = s.saveImage(img)
-	}
-
-	return internalScanRespFromImage(img), nil
 }
 
 // ScanImage scans an image and returns the result

--- a/pkg/booleanpolicy/augmentedobjs/construct.go
+++ b/pkg/booleanpolicy/augmentedobjs/construct.go
@@ -138,6 +138,8 @@ func ConstructDeploymentWithNetworkFlowInfo(
 }
 
 // ConstructDeployment constructs the augmented deployment object.
+// It assumes that the given images are in the same order as the containers specified within the given deployment.
+// If there's a mismatch in the amount of containers on the deployment and the given images, an error will be returned.
 func ConstructDeployment(deployment *storage.Deployment, images []*storage.Image, applied *NetworkPoliciesApplied) (*pathutil.AugmentedObj, error) {
 	obj := pathutil.NewAugmentedObj(deployment)
 	if len(images) != len(deployment.GetContainers()) {

--- a/pkg/booleanpolicy/augmentedobjs/construct.go
+++ b/pkg/booleanpolicy/augmentedobjs/construct.go
@@ -6,6 +6,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/booleanpolicy/evaluator/pathutil"
+	"github.com/stackrox/rox/pkg/sliceutils"
 	"github.com/stackrox/rox/pkg/utils"
 )
 
@@ -150,7 +151,10 @@ func ConstructDeployment(deployment *storage.Deployment, images []*storage.Image
 	}
 
 	for i, image := range images {
-		augmentedImg, err := ConstructImage(image)
+		// Since we ensure that both images and containers have the same length, this will not lead to index out of
+		// bounds panics.
+		containerImageFullName := deployment.GetContainers()[i].GetImage().GetName().GetFullName()
+		augmentedImg, err := ConstructImage(image, containerImageFullName)
 		if err != nil {
 			return nil, err
 		}
@@ -182,7 +186,7 @@ func ConstructDeployment(deployment *storage.Deployment, images []*storage.Image
 }
 
 // ConstructImage constructs the augmented image object.
-func ConstructImage(image *storage.Image) (*pathutil.AugmentedObj, error) {
+func ConstructImage(image *storage.Image, imageFullName string) (*pathutil.AugmentedObj, error) {
 	if image == nil {
 		return pathutil.NewAugmentedObj(image), nil
 	}
@@ -236,7 +240,12 @@ func ConstructImage(image *storage.Image) (*pathutil.AugmentedObj, error) {
 
 	ids := []string{}
 	for _, result := range image.GetSignatureVerificationData().GetResults() {
-		if result.GetStatus() == storage.ImageSignatureVerificationResult_VERIFIED {
+		// We only want signature verification results to be added that:
+		// - have a verified result.
+		// - the verified image references contains the image full name that is currently specified. This can either
+		// be equal to `img.GetName().GetFullName()`, or when used within a deployment, the container image's full name.
+		if result.GetStatus() == storage.ImageSignatureVerificationResult_VERIFIED &&
+			sliceutils.Find(result.GetVerifiedImageReferences(), imageFullName) != -1 {
 			ids = append(ids, result.GetVerifierId())
 		}
 	}

--- a/pkg/booleanpolicy/default_policies_test.go
+++ b/pkg/booleanpolicy/default_policies_test.go
@@ -2160,8 +2160,9 @@ func (suite *DefaultPoliciesTestSuite) TestImageVerified() {
 		}}),
 		imageWithSignatureVerificationResults("image_nil_results", nil),
 		imageWithSignatureVerificationResults("verified_by_0", []*storage.ImageSignatureVerificationResult{{
-			VerifierId: verifier0,
-			Status:     storage.ImageSignatureVerificationResult_VERIFIED,
+			VerifierId:              verifier0,
+			Status:                  storage.ImageSignatureVerificationResult_VERIFIED,
+			VerifiedImageReferences: []string{"verified_by_0"},
 		}}),
 		imageWithSignatureVerificationResults("unverified_image", []*storage.ImageSignatureVerificationResult{{
 			VerifierId: unverifier,
@@ -2171,15 +2172,18 @@ func (suite *DefaultPoliciesTestSuite) TestImageVerified() {
 			VerifierId: verifier2,
 			Status:     storage.ImageSignatureVerificationResult_FAILED_VERIFICATION,
 		}, {
-			VerifierId: verifier3,
-			Status:     storage.ImageSignatureVerificationResult_VERIFIED,
+			VerifierId:              verifier3,
+			Status:                  storage.ImageSignatureVerificationResult_VERIFIED,
+			VerifiedImageReferences: []string{"verified_by_3"},
 		}}),
 		imageWithSignatureVerificationResults("verified_by_2_and_3", []*storage.ImageSignatureVerificationResult{{
-			VerifierId: verifier2,
-			Status:     storage.ImageSignatureVerificationResult_VERIFIED,
+			VerifierId:              verifier2,
+			Status:                  storage.ImageSignatureVerificationResult_VERIFIED,
+			VerifiedImageReferences: []string{"verified_by_2_and_3"},
 		}, {
-			VerifierId: verifier3,
-			Status:     storage.ImageSignatureVerificationResult_VERIFIED,
+			VerifierId:              verifier3,
+			Status:                  storage.ImageSignatureVerificationResult_VERIFIED,
+			VerifiedImageReferences: []string{"verified_by_2_and_3"},
 		}}),
 	}
 
@@ -2268,6 +2272,82 @@ func (suite *DefaultPoliciesTestSuite) TestImageVerified() {
 				}
 			}
 			suite.True(c.expectedMatches.Difference(matchedImages.Freeze()).IsEmpty(), matchedImages)
+		})
+	}
+}
+
+func (suite *DefaultPoliciesTestSuite) TestImageVerified_WithDeployment() {
+	const (
+		verifier1 = "io.stackrox.signatureintegration.00000000-0000-0000-0000-000000000002"
+		verifier2 = "io.stackrox.signatureintegration.00000000-0000-0000-0000-000000000003"
+		verifier3 = "io.stackrox.signatureintegration.00000000-0000-0000-0000-000000000004"
+	)
+
+	images := []*storage.Image{
+		imageWithSignatureVerificationResults("image_verified_by_1", []*storage.ImageSignatureVerificationResult{
+			{
+				VerifierId:              verifier1,
+				Status:                  storage.ImageSignatureVerificationResult_VERIFIED,
+				VerifiedImageReferences: []string{"image_verified_by_1"},
+			},
+		}),
+		imageWithSignatureVerificationResults("image_with_alternative_verified_reference", []*storage.ImageSignatureVerificationResult{
+			{
+				VerifierId:              verifier2,
+				Status:                  storage.ImageSignatureVerificationResult_VERIFIED,
+				VerifiedImageReferences: []string{"image_verified_by_2"},
+			},
+		}),
+		imageWithSignatureVerificationResults("image_verified_by_2", []*storage.ImageSignatureVerificationResult{
+			{
+				VerifierId:              verifier3,
+				Status:                  storage.ImageSignatureVerificationResult_VERIFIED,
+				VerifiedImageReferences: []string{"image_with_alternative_verified_reference", "image_verified_by_2"},
+			},
+		}),
+	}
+
+	cases := map[string]struct {
+		deployment       *storage.Deployment
+		image            *storage.Image
+		matchingVerifier string
+		expectViolation  bool
+	}{
+		"deployment with matching verified image reference shouldn't lead in alert message": {
+			deployment:       deploymentWithImage("deployment_with_image_verified_by_1", images[0]),
+			image:            images[0],
+			matchingVerifier: verifier1,
+		},
+		"deployment with verified result but no matching verified image reference should lead to alert message": {
+			deployment:       deploymentWithImage("deployment_with_image_alternative_verified_reference", images[1]),
+			image:            images[1],
+			matchingVerifier: verifier2,
+			expectViolation:  true,
+		},
+		"deployment with verified result and multiple matching verified image references shouldn't lead to alert message": {
+			deployment:       deploymentWithImage("deployment_with_image_verified_by_2", images[2]),
+			image:            images[2],
+			matchingVerifier: verifier3,
+		},
+	}
+
+	for name, c := range cases {
+		suite.Run(name, func() {
+			deploymentMatcher, err := BuildDeploymentMatcher(policyWithSingleFieldAndValues(fieldnames.ImageSignatureVerifiedBy,
+				[]string{c.matchingVerifier}, false, storage.BooleanOperator_OR))
+			suite.Require().NoError(err)
+
+			violations, err := deploymentMatcher.MatchDeployment(nil, EnhancedDeployment{
+				Deployment: c.deployment,
+				Images:     []*storage.Image{c.image},
+			})
+			suite.Require().NoError(err)
+
+			if c.expectViolation {
+				suite.NotEmpty(violations.AlertViolations)
+			} else {
+				suite.Empty(violations.AlertViolations)
+			}
 		})
 	}
 }

--- a/pkg/booleanpolicy/matcher_impl.go
+++ b/pkg/booleanpolicy/matcher_impl.go
@@ -193,7 +193,7 @@ func matchWithEvaluator(sectionAndEval sectionAndEvaluator, obj *pathutil.Augmen
 
 func (m *matcherImpl) MatchImage(cache *CacheReceptacle, image *storage.Image) (Violations, error) {
 	violations, err := m.getViolations(cache, func() (*pathutil.AugmentedObj, error) {
-		return augmentedobjs.ConstructImage(image)
+		return augmentedobjs.ConstructImage(image, image.GetName().GetFullName())
 	}, nil, nil, nil, nil)
 	if err != nil || violations == nil {
 		return Violations{}, err

--- a/pkg/images/enricher/enricher_impl.go
+++ b/pkg/images/enricher/enricher_impl.go
@@ -362,7 +362,7 @@ func (e *enricherImpl) enrichImageWithRegistry(ctx context.Context, image *stora
 
 func (e *enricherImpl) fetchFromDatabase(ctx context.Context, img *storage.Image, option FetchOption) (*storage.Image, bool) {
 	if option.forceRefetchCachedValues() {
-		// When refetched values should be used, reset the existing values for signature and signature verification data.
+		// When re-fetched values should be used, reset the existing values for signature and signature verification data.
 		img.Signature = nil
 		img.SignatureVerificationData = nil
 		return img, false

--- a/pkg/protoutils/slice_contains.go
+++ b/pkg/protoutils/slice_contains.go
@@ -1,0 +1,13 @@
+package protoutils
+
+import "github.com/gogo/protobuf/proto"
+
+// SliceContains returns whether the given slice of proto objects contains the given proto object.
+func SliceContains[T proto.Message](msg T, slice []T) bool {
+	for _, elem := range slice {
+		if proto.Equal(elem, msg) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/signatures/public_key_verifier_test.go
+++ b/pkg/signatures/public_key_verifier_test.go
@@ -258,6 +258,30 @@ func TestRetrieveVerificationDataFromImage_Failure(t *testing.T) {
 	}
 }
 
+func TestDockerReferenceFromImageName(t *testing.T) {
+	cases := map[string]struct {
+		name *storage.ImageName
+		res  string
+	}{
+		"shouldn't rewrite registry name for quay.io": {
+			name: &storage.ImageName{FullName: "quay.io/some-repo/image:latest"},
+			res:  "quay.io/some-repo/image",
+		},
+		"should rewrite registry name for docker.io": {
+			name: &storage.ImageName{FullName: "docker.io/some-repo/image:latest"},
+			res:  "index.docker.io/some-repo/image",
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			res, err := dockerReferenceFromImageName(c.name)
+			assert.NoError(t, err)
+			assert.Equal(t, c.res, res)
+		})
+	}
+}
+
 func generateImageWithCosignSignature(imgString, b64Sig, b64SigPayload string) (*storage.Image, error) {
 	cimg, err := imgUtils.GenerateImageFromString(imgString)
 	if err != nil {

--- a/sensor/common/detector/enricher.go
+++ b/sensor/common/detector/enricher.go
@@ -155,7 +155,7 @@ func (e *enricher) getImageFromCache(key string) (*storage.Image, bool) {
 
 func (e *enricher) runScan(req *scanImageRequest) imageChanResult {
 	// Cache key is either going to be image full name or image ID.
-	// In cae of image full name, we can skip. In case of image ID, we should make sure to check if the image's name
+	// In case of image full name, we can skip. In case of image ID, we should make sure to check if the image's name
 	// is equal / contained in the images `Names` field.
 	key := imagecacheutils.GetImageCacheKey(req.containerImage)
 


### PR DESCRIPTION
## Description

[The parent PR has the initial problem statement as well as the references to all follow-up PRs that have been done, please consult it to get the full context of changes being made here.](https://github.com/stackrox/stackrox/pull/3511)

Additionally, [this doc exists for a overview of the changes being made within this series of PRs.](https://docs.google.com/document/d/1xxBQMRGQHOJg1E44iCUkMOGul7ht_496VubhSZYJ42k/edit?usp=sharing)

Within this PR, the image signature policy has been refactor to take into account the specified image's full name when adding verified signature verification results to the augmented object.

Previously, we wouldn't distinguish between the location of the signature (image an image with the same digest, coming from `docker.io/repo-a/nginx:1.23` and another one from `quay.io/qa/nginx:1.23`, where only one of them has a signature associated with it). This would have lead to false-positives / false-negatives, depending on the image being used within the policy and the given `storage.Image`.

Now, when evaluating the policy within the context of using it within deployments, the container image name will be used to determine which signatures for _which specific reference_ to only consider, instead of considering _every_ available, verified signature verification result.

There will be one more follow-up after this PR, adding automated E2E tests that cover the scenarios described in the referenced document, ensuring the whole E2E flow works as expected.

## Checklist
- [X] Investigated and inspected CI test results
- [X] Unit test and regression tests added
~~- [ ] Evaluated and added CHANGELOG entry if required~~
~~- [ ] Determined and documented upgrade steps~~
~~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed
- see CI + unit tests.

Manual test (note that there will be a follow-up created that makes these steps unneccessary):
```
# Ensure you have two images which have the same digest, but only one of them is signed.
# (If you don't have them at hand, you can re-use `docker.io/daha97/nginx:1.23` & `docker.io/daha97/alt-nginx:1.23`, with the latter having the signature.

# 1. Create the signature integration that has the public key for the signed image using the public key below:
-----BEGIN PUBLIC KEY-----
MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAELjCxSf0Ap7tePs2DsAMmkJPOk1oG
z+i4WGmVCis0Z9CXITuLu+UQQPdsbSlvyR+ybm6pJFz+nHgakAgqixW70w==
-----END PUBLIC KEY-----

# 2. Create a pod that runs the first image, which has no signature:
apiVersion: v1
kind: Pod
metadata:
  creationTimestamp: null
  labels:
    run: daha-nginx
  name: daha-nginx
spec:
  containers:
  - image: docker.io/daha97/nginx:1.23
    name: daha-nginx
    resources: {}
  dnsPolicy: ClusterFirst
  restartPolicy: Always
status: {}

# 3. Observe within the API that the image is detected, the `names` field contains a single image name, and the notes indicate a missing signature + signature verification data:
roxcurl /v1/images/sha256:6ad8394ad31b269b563566998fd80a8f259e8decf16e807f8310ecc10c687385 | jq -r '.names'                                                                                                                                                                                                           
[
  {
    "registry": "docker.io",
    "remote": "daha97/nginx",
    "tag": "1.23",
    "fullName": "docker.io/daha97/nginx:1.23"
  }
]

roxcurl /v1/images/sha256:6ad8394ad31b269b563566998fd80a8f259e8decf16e807f8310ecc10c687385 | jq -r '.notes'                                                                                                                                                                                                           

[
    "MISSING_SIGNATURE",
    "MISSING_SIGNATURE_VERIFICATION_DATA"
]

# 4. Create a pod that runs the second image, which has a signature:
apiVersion: v1
kind: Pod
metadata:
  creationTimestamp: null
  labels:
    run: daha-alt-nginx
  name: daha-alt-nginx
spec:
  containers:
  - image: docker.io/daha97/alt-nginx:1.23
    name: daha-alt-nginx
    resources: {}
  dnsPolicy: ClusterFirst
  restartPolicy: Always
status: {}

# 5. Observe within the API that the additional image name is detected within central, the `names` field contains two entries, and the notes do not indicate missing signature data nor signature verification data:
roxcurl /v1/images/sha256:6ad8394ad31b269b563566998fd80a8f259e8decf16e807f8310ecc10c687385 | jq -r '.names'                                                                                                                                                                                                           
[
  {
    "registry": "docker.io",
    "remote": "daha97/nginx",
    "tag": "1.23",
    "fullName": "docker.io/daha97/nginx:1.23"
  },
  {
    "registry": "docker.io",
    "remote": "daha97/alt-nginx",
    "tag": "1.23",
    "fullName": "docker.io/daha97/alt-nginx:1.23"
  }
]

roxcurl /v1/images/sha256:6ad8394ad31b269b563566998fd80a8f259e8decf16e807f8310ecc10c687385 | jq -r '.notes'                                                                                                                                                                                                           
[]

# 6. Create a policy that creates violations for images whose signatures cannot be verified with the signature integration created in step 1. Observe within the dry-run part that a single violation exists for the pod running the image _without_ the signature (probably is best to scope it to the namespace the pods are deployed to, avoiding any additional noise):
```
![Screenshot 2022-11-30 at 05 31 34](https://user-images.githubusercontent.com/89904305/204708050-20e3eab8-4895-4240-bb3e-94c107d7ff54.png)
