### PR TITLE
ROX-12948 Disable DeploymentExposure tests

### DIFF
--- a/sensor/tests/resource/service/service_test.go
+++ b/sensor/tests/resource/service/service_test.go
@@ -117,6 +117,7 @@ type DeploymentExposureSuite struct {
 }
 
 func Test_DeploymentExposure(t *testing.T) {
+	t.Skip("Disabling these tests until we refactor the helper.go to enable fake k8s clients (ROX-13644)")
 	suite.Run(t, new(DeploymentExposureSuite))
 }
 

--- a/sensor/tests/resource/service/service_test.go
+++ b/sensor/tests/resource/service/service_test.go
@@ -117,6 +117,7 @@ type DeploymentExposureSuite struct {
 }
 
 func Test_DeploymentExposure(t *testing.T) {
+	// TODO(ROX-13644): reenable the test
 	t.Skip("Disabling these tests until we refactor the helper.go to enable fake k8s clients (ROX-13644)")
 	suite.Run(t, new(DeploymentExposureSuite))
 }


### PR DESCRIPTION
## Description

This will disable the `DeploymentExposure` tests until we refactor the `helper.go` to enable it to use fake k8s clients.

**Context**: These tests are flaky due to ports not being released on time for the next test to run. We decided to use a fake k8s client to solve this issue but, since mayor refactors are needed in `helper.go`, we will disable the test to avoid failures in CI in the meantime.

## Checklist
- [ ] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

* CI
* Manual testing shows the tests are skipped
