### PR TITLE
Rename reach and interactAndVisit helper functions for integration tests

### DIFF
--- a/ui/apps/platform/cypress/constants/NetworkPage.js
+++ b/ui/apps/platform/cypress/constants/NetworkPage.js
@@ -12,7 +12,6 @@ const networkEntityTabbedOverlay = '[data-testid="network-entity-tabbed-overlay"
 
 export const selectors = {
     cytoscapeContainer: '#cytoscapeContainer',
-    networkGraphHeading: 'h1:contains("Network Graph")',
     emptyStateSubheading:
         '.pf-c-empty-state h2:contains("Please select at least one namespace from your cluster")',
     simulatorSuccessMessage: 'div[data-testid="message-body"]:contains("Policies processed")',

--- a/ui/apps/platform/cypress/helpers/clusters.js
+++ b/ui/apps/platform/cypress/helpers/clusters.js
@@ -1,8 +1,8 @@
 import * as api from '../constants/apiEndpoints';
-import { clustersUrl, selectors } from '../constants/ClustersPage';
+import { selectors } from '../constants/ClustersPage';
 
 import { visitFromLeftNavExpandable } from './nav';
-import { interactAndWaitForResponses } from './request';
+import { interceptRequests, waitForResponses } from './request';
 import { visit } from './visit';
 
 const routeMatcherMap = {
@@ -20,29 +20,41 @@ const routeMatcherMap = {
     },
 };
 
+const basePath = '/main/clusters';
+
+const title = 'Clusters';
+
 // Navigation
 
-/*
- * Reach clusters by interaction from another container.
+/**
+ * Visit clusters by interaction from another container.
  * For example, click View All button from System Health.
+ *
+ * @param {function} interactionCallback
+ * @param {Record<string, { body: unknown } | { fixture: string }>} [staticResponseMap]
  */
-export function reachClusters(interactionCallback, staticResponseMap) {
-    interactAndWaitForResponses(interactionCallback, routeMatcherMap, staticResponseMap);
+export function interactAndVisitClusters(interactionCallback, staticResponseMap) {
+    interceptRequests(routeMatcherMap, staticResponseMap);
 
-    cy.get(selectors.clustersListHeading).contains('Clusters');
+    interactionCallback();
+
+    cy.location('pathname').should('eq', basePath);
+    cy.get(`h1:contains("${title}")`);
+
+    waitForResponses(routeMatcherMap);
 }
 
 export function visitClustersFromLeftNav() {
-    visitFromLeftNavExpandable('Platform Configuration', 'Clusters', routeMatcherMap);
+    visitFromLeftNavExpandable('Platform Configuration', title, routeMatcherMap);
 
-    cy.location('pathname').should('eq', clustersUrl);
-    cy.get(selectors.clustersListHeading).contains('Clusters');
+    cy.location('pathname').should('eq', basePath);
+    cy.get(`h1:contains("${title}")`);
 }
 
 export function visitClusters(staticResponseMap) {
-    visit(clustersUrl, routeMatcherMap, staticResponseMap);
+    visit(basePath, routeMatcherMap, staticResponseMap);
 
-    cy.get(selectors.clustersListHeading).contains('Clusters');
+    cy.get(`h1:contains("${title}")`);
 }
 
 export function visitClustersWithFixture(fixturePath) {
@@ -62,9 +74,9 @@ export function visitClusterById(clusterId, staticResponseMap) {
             url: `${api.clusters.list}/${clusterId}`,
         },
     };
-    visit(`${clustersUrl}/${clusterId}`, routeMatcherMapClusterById, staticResponseMap);
+    visit(`${basePath}/${clusterId}`, routeMatcherMapClusterById, staticResponseMap);
 
-    cy.get(selectors.clustersListHeading).contains('Clusters');
+    cy.get(`h1:contains("${title}")`);
 }
 
 export function visitClustersWithFixtureMetadataDatetime(fixturePath, metadata, datetimeISOString) {

--- a/ui/apps/platform/cypress/helpers/networkGraph.js
+++ b/ui/apps/platform/cypress/helpers/networkGraph.js
@@ -1,7 +1,12 @@
 import * as api from '../constants/apiEndpoints';
 import { selectors as networkGraphSelectors } from '../constants/NetworkPage';
 import { visitFromLeftNav } from './nav';
-import { getRouteMatcherMapForGraphQL, interactAndWaitForResponses } from './request';
+import {
+    getRouteMatcherMapForGraphQL,
+    interactAndWaitForResponses,
+    interceptRequests,
+    waitForResponses,
+} from './request';
 import { visit } from './visit';
 import selectSelectors from '../selectors/select';
 import tabSelectors from '../selectors/tab';
@@ -259,33 +264,41 @@ const routeMatcherMapToVisitNetworkGraphWithDeploymentSelected = {
 
 export const basePath = '/main/network';
 
-/*
- * Reach clusters by interaction from another container.
- * For example, click View Deployment in Network Graph button from Risk.
- */
-export function reachNetworkGraphWithDeploymentSelected(interactionCallback, staticResponseMap) {
-    interactAndWaitForResponses(
-        interactionCallback,
-        routeMatcherMapToVisitNetworkGraphWithDeploymentSelected,
-        staticResponseMap
-    );
+const title = 'Network Graph';
 
-    cy.location('pathname').should('contain', basePath); // contain because pathname might have id
-    cy.get(networkGraphSelectors.networkGraphHeading);
+/**
+ * Visit network graph deployment by interaction from another container.
+ * For example, click View Deployment in Network Graph button from Risk.
+ *
+ * @param {function} interactionCallback
+ * @param {Record<string, { body: unknown } | { fixture: string }>} [staticResponseMap]
+ */
+export function interactAndVisitNetworkGraphWithDeploymentSelected(
+    interactionCallback,
+    staticResponseMap
+) {
+    interceptRequests(routeMatcherMapToVisitNetworkGraphWithDeploymentSelected, staticResponseMap);
+
+    interactionCallback();
+
+    cy.location('pathname').should('contain', basePath); // contain because pathname has id
+    cy.get(`h1:contains("${title}")`);
+
+    waitForResponses(routeMatcherMapToVisitNetworkGraphWithDeploymentSelected, staticResponseMap);
 }
 
 export function visitNetworkGraphFromLeftNav() {
     visitFromLeftNav('Network', routeMatcherMapToVisitNetworkGraph);
 
     cy.location('pathname').should('eq', basePath);
-    cy.get(networkGraphSelectors.networkGraphHeading);
+    cy.get(`h1:contains("${title}")`);
     cy.get(networkGraphSelectors.emptyStateSubheading);
 }
 
 export function visitNetworkGraph(staticResponseMap) {
     visit(basePath, routeMatcherMapToVisitNetworkGraph, staticResponseMap);
 
-    cy.get(networkGraphSelectors.networkGraphHeading);
+    cy.get(`h1:contains("${title}")`);
     cy.get(networkGraphSelectors.emptyStateSubheading);
 }
 

--- a/ui/apps/platform/cypress/helpers/risk.js
+++ b/ui/apps/platform/cypress/helpers/risk.js
@@ -2,7 +2,7 @@ import * as api from '../constants/apiEndpoints';
 import { selectors as riskPageSelectors, url as riskURL } from '../constants/RiskPage';
 import selectors from '../selectors/index';
 
-import { reachNetworkGraphWithDeploymentSelected } from './networkGraph';
+import { interactAndVisitNetworkGraphWithDeploymentSelected } from './networkGraph';
 import { visit } from './visit';
 
 // visit
@@ -51,7 +51,7 @@ export function viewRiskDeploymentByName(deploymentName) {
 }
 
 export function viewRiskDeploymentInNetworkGraph() {
-    reachNetworkGraphWithDeploymentSelected(() => {
+    interactAndVisitNetworkGraphWithDeploymentSelected(() => {
         cy.get(riskPageSelectors.viewDeploymentsInNetworkGraphButton).click();
     });
 }

--- a/ui/apps/platform/cypress/integration/systemHealth/clusters.test.js
+++ b/ui/apps/platform/cypress/integration/systemHealth/clusters.test.js
@@ -1,7 +1,7 @@
 import { clustersUrl } from '../../constants/ClustersPage';
 import { selectors } from '../../constants/SystemHealth';
 import withAuth from '../../helpers/basicAuth';
-import { reachClusters } from '../../helpers/clusters';
+import { interactAndVisitClusters } from '../../helpers/clusters';
 import { setClock, visitSystemHealth } from '../../helpers/systemHealth';
 
 function visitSystemHealthWithClustersFixtureFilteredByNames(fixturePath, clusterNames) {
@@ -20,7 +20,7 @@ describe('System Health Clusters without fixture', () => {
     it('should go to Clusters via click View All', () => {
         visitSystemHealth();
 
-        reachClusters(() => {
+        interactAndVisitClusters(() => {
             cy.get(selectors.clusters.viewAllButton).click();
         });
         cy.location('pathname').should('eq', clustersUrl);


### PR DESCRIPTION
## Description

Improve on an unclear and inconsistent naming convention.

Use the 2 updated functions to verify a pattern to make assertions about the destination container which do not depend on response to requests, for example:
* page address: destination page does not make requests until **after** the page address changes
* page breadcrumbs or heading: destination page usually renders something **before** and independent of responses to requests. Any assertions which depend on responses are therefore test specific after return from helper function.

Original pattern:

1. Call interaction function (source container).
2. API: 10 seconds wait for requests and 30 seconds wait for responses (destination container).
3. DOM: 4 seconds wait for assertions (destination container).

Improved pattern:

1. Call interaction function (source container).
2. DOM: 4 seconds wait for assertions (destination container).
3. API: 10 seconds wait for requests and 30 seconds wait for responses (destination container).

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed