### PR TITLE
ROX-13529: delete mention of RELATED_IMAGE_DOCS

### DIFF
--- a/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
@@ -889,7 +889,6 @@ spec:
                 - name: RELATED_IMAGE_COLLECTOR_SLIM
                 - name: RELATED_IMAGE_COLLECTOR_FULL
                 - name: RELATED_IMAGE_ROXCTL
-                - name: RELATED_IMAGE_DOCS
                 - name: RELATED_IMAGE_CENTRAL_DB
                 image: quay.io/stackrox-io/stackrox-operator:0.0.1
                 livenessProbe:

--- a/operator/config/manager/manager.yaml
+++ b/operator/config/manager/manager.yaml
@@ -42,7 +42,6 @@ spec:
         - name: RELATED_IMAGE_COLLECTOR_SLIM
         - name: RELATED_IMAGE_COLLECTOR_FULL
         - name: RELATED_IMAGE_ROXCTL
-        - name: RELATED_IMAGE_DOCS
         - name: RELATED_IMAGE_CENTRAL_DB
         image: controller:latest
         name: manager


### PR DESCRIPTION
## Description

This PR removes all mentions of "RELATED_IMAGE_DOCS" in the repo.

## Checklist
- [x] Investigated and inspected CI test results
~- [ ] Unit test and regression tests added~
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

`make bundle` and CI
