### PR TITLE
Switch collection text fields to use PF readonly variant

### DIFF
--- a/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
@@ -236,7 +236,7 @@ function CollectionForm({
                             <FormGroup
                                 label="Name"
                                 fieldId="name"
-                                isRequired
+                                isRequired={!isReadOnly}
                                 helperTextInvalid={errors.name}
                                 validated={errors.name ? 'error' : 'default'}
                             >
@@ -252,7 +252,7 @@ function CollectionForm({
                                         handleChange(e);
                                     }}
                                     onBlur={handleBlur}
-                                    isDisabled={isReadOnly}
+                                    readOnlyVariant={isReadOnly ? 'plain' : undefined}
                                 />
                             </FormGroup>
                         </FlexItem>
@@ -264,7 +264,7 @@ function CollectionForm({
                                     value={values.description}
                                     onChange={(_, e) => handleChange(e)}
                                     onBlur={handleBlur}
-                                    isDisabled={isReadOnly}
+                                    readOnlyVariant={isReadOnly ? 'plain' : undefined}
                                 />
                             </FormGroup>
                         </FlexItem>


### PR DESCRIPTION
## Description

This updates the style of the name and description inputs (for visual and accessibility reasons) to use the PatternFly readonly variant instead of setting the fields to `disabled`.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Before:
<img width="853" alt="image" src="https://user-images.githubusercontent.com/1292638/204311956-db58626c-f31c-42d8-96f8-d426cbbfb0aa.png">

After:
<img width="853" alt="image" src="https://user-images.githubusercontent.com/1292638/204312013-4f3da88a-8d79-4cc5-8f3b-7e8abec17cff.png">

After when not readonly:
<img width="853" alt="image" src="https://user-images.githubusercontent.com/1292638/204312112-2fb314d3-47bb-48c8-8d33-845b2707dfba.png">

