### PR TITLE
Add visitAndAssertBeforeResponses helper function for integration tests (part 1)

### DIFF
--- a/ui/apps/platform/cypress/helpers/compliance.js
+++ b/ui/apps/platform/cypress/helpers/compliance.js
@@ -1,7 +1,7 @@
 import { headingPlural, selectors, url } from '../constants/CompliancePage';
 
 import { getRouteMatcherMapForGraphQL, interactAndWaitForResponses } from './request';
-import { visit } from './visit';
+import { visitAndAssertBeforeResponses } from './visit';
 
 const routeMatcherMapForComplianceDashboard = getRouteMatcherMapForGraphQL([
     'clustersCount',
@@ -22,10 +22,16 @@ const routeMatcherMapForComplianceDashboard = getRouteMatcherMapForGraphQL([
     'complianceStandards_PCI_DSS_3_2',
 ]);
 
-export function visitComplianceDashboard() {
-    visit(url.dashboard, routeMatcherMapForComplianceDashboard);
+const dashboardTitle = 'Compliance';
 
-    cy.get('h1:contains("Compliance")');
+export function visitComplianceDashboard() {
+    visitAndAssertBeforeResponses(
+        url.dashboard,
+        () => {
+            cy.get(`h1:contains("${dashboardTitle}")`);
+        },
+        routeMatcherMapForComplianceDashboard
+    );
 }
 
 /*
@@ -75,9 +81,13 @@ export function visitComplianceEntities(entitiesKey) {
         opnameForEntities[entitiesKey],
     ]);
 
-    visit(url.entities[entitiesKey], routeMatcherMap);
-
-    cy.get(`h1:contains("${headingPlural[entitiesKey]}")`);
+    visitAndAssertBeforeResponses(
+        url.entities[entitiesKey],
+        () => {
+            cy.get(`h1:contains("${headingPlural[entitiesKey]}")`);
+        },
+        routeMatcherMap
+    );
 }
 
 /*
@@ -90,7 +100,11 @@ export function visitComplianceStandard(standardName) {
         'controls',
     ]);
 
-    visit(`${url.controls}?s[standard]=${standardName}`, routeMatcherMap);
-
-    cy.get(`h1:contains("${standardName}")`);
+    visitAndAssertBeforeResponses(
+        `${url.controls}?s[standard]=${standardName}`,
+        () => {
+            cy.get(`h1:contains("${standardName}")`);
+        },
+        routeMatcherMap
+    );
 }

--- a/ui/apps/platform/cypress/helpers/compliance.js
+++ b/ui/apps/platform/cypress/helpers/compliance.js
@@ -22,13 +22,13 @@ const routeMatcherMapForComplianceDashboard = getRouteMatcherMapForGraphQL([
     'complianceStandards_PCI_DSS_3_2',
 ]);
 
-const dashboardTitle = 'Compliance';
+const containerTitle = 'Compliance';
 
 export function visitComplianceDashboard() {
     visitAndAssertBeforeResponses(
         url.dashboard,
         () => {
-            cy.get(`h1:contains("${dashboardTitle}")`);
+            cy.get(`h1:contains("${containerTitle}")`);
         },
         routeMatcherMapForComplianceDashboard
     );

--- a/ui/apps/platform/cypress/helpers/configWorkflowUtils.js
+++ b/ui/apps/platform/cypress/helpers/configWorkflowUtils.js
@@ -144,13 +144,13 @@ const routeMatcherMapForConfigurationManagementDashboard = getRouteMatcherMapFor
     'secrets',
 ]);
 
-const dashboardTitle = 'Configuration Management';
+const containerTitle = 'Configuration Management';
 
 export function visitConfigurationManagementDashboard() {
     visitAndAssertBeforeResponses(
         basePath,
         () => {
-            cy.get(`h1:contains("h1:contains("${dashboardTitle}")")`);
+            cy.get(`h1:contains("h1:contains("${containerTitle}")")`);
         },
         routeMatcherMapForConfigurationManagementDashboard
     );

--- a/ui/apps/platform/cypress/helpers/configWorkflowUtils.js
+++ b/ui/apps/platform/cypress/helpers/configWorkflowUtils.js
@@ -150,7 +150,7 @@ export function visitConfigurationManagementDashboard() {
     visitAndAssertBeforeResponses(
         basePath,
         () => {
-            cy.get(`h1:contains("h1:contains("${containerTitle}")")`);
+            cy.get(`h1:contains("${containerTitle}")`);
         },
         routeMatcherMapForConfigurationManagementDashboard
     );

--- a/ui/apps/platform/cypress/helpers/configWorkflowUtils.js
+++ b/ui/apps/platform/cypress/helpers/configWorkflowUtils.js
@@ -1,6 +1,6 @@
 import { selectors as configManagementSelectors } from '../constants/ConfigManagementPage';
 import { getRouteMatcherMapForGraphQL, interactAndWaitForResponses } from './request';
-import { visit } from './visit';
+import { visitAndAssertBeforeResponses } from './visit';
 
 const basePath = '/main/configmanagement';
 
@@ -144,22 +144,36 @@ const routeMatcherMapForConfigurationManagementDashboard = getRouteMatcherMapFor
     'secrets',
 ]);
 
-export function visitConfigurationManagementDashboard() {
-    visit(basePath, routeMatcherMapForConfigurationManagementDashboard);
+const dashboardTitle = 'Configuration Management';
 
-    cy.get('h1:contains("Configuration Management")');
+export function visitConfigurationManagementDashboard() {
+    visitAndAssertBeforeResponses(
+        basePath,
+        () => {
+            cy.get(`h1:contains("h1:contains("${dashboardTitle}")")`);
+        },
+        routeMatcherMapForConfigurationManagementDashboard
+    );
 }
 
 export function visitConfigurationManagementEntities(entitiesKey) {
-    visit(getEntitiesPath(entitiesKey), getRouteMatcherMapForEntities(entitiesKey));
-
-    cy.get(`h1:contains("${headingForEntities[entitiesKey]}")`);
+    visitAndAssertBeforeResponses(
+        getEntitiesPath(entitiesKey),
+        () => {
+            cy.get(`h1:contains("${headingForEntities[entitiesKey]}")`);
+        },
+        getRouteMatcherMapForEntities(entitiesKey)
+    );
 }
 
 export function visitConfigurationManagementEntitiesWithSearch(entitiesKey, search) {
-    visit(`${getEntitiesPath(entitiesKey)}${search}`, getRouteMatcherMapForEntities(entitiesKey));
-
-    cy.get(`h1:contains("${headingForEntities[entitiesKey]}")`);
+    visitAndAssertBeforeResponses(
+        `${getEntitiesPath(entitiesKey)}${search}`,
+        () => {
+            cy.get(`h1:contains("${headingForEntities[entitiesKey]}")`);
+        },
+        getRouteMatcherMapForEntities(entitiesKey)
+    );
 }
 
 export function interactAndWaitForConfigurationManagementEntities(

--- a/ui/apps/platform/cypress/helpers/policies.js
+++ b/ui/apps/platform/cypress/helpers/policies.js
@@ -70,9 +70,6 @@ export function visitPolicy(policyId, staticResponseMap) {
         `${policiesPath}/${policyId}`,
         () => {
             cy.get(`a.pf-c-breadcrumb__link:contains("Policies")`);
-            cy.get('h2:contains("Policy details")');
-            cy.get('h2:contains("Policy behavior")');
-            cy.get('h2:contains("Policy criteria")');
         },
         routeMatcherMapForPolicy,
         staticResponseMap

--- a/ui/apps/platform/cypress/helpers/policies.js
+++ b/ui/apps/platform/cypress/helpers/policies.js
@@ -25,7 +25,7 @@ const routeMatcherMapForPolicies = {
     },
 };
 
-const containerTitle = 'Policy management';
+const containerTitle = 'Policy Management';
 
 /**
  * @param {Record<string, { body: unknown } | { fixture: string }>} [staticResponseMap]

--- a/ui/apps/platform/cypress/helpers/policies.js
+++ b/ui/apps/platform/cypress/helpers/policies.js
@@ -1,7 +1,7 @@
 import * as api from '../constants/apiEndpoints';
-import { selectors, url as policiesUrl } from '../constants/PoliciesPage';
+import { selectors, url as policiesPath } from '../constants/PoliciesPage';
 import { visitFromLeftNavExpandable } from './nav';
-import { visit } from './visit';
+import { visitAndAssertBeforeResponses } from './visit';
 
 // Navigation
 
@@ -9,7 +9,7 @@ export const notifiersAlias = 'notifiers';
 export const searchMetadataOptionsAlias = 'search/metadata/options';
 export const policiesAlias = 'policies';
 
-const routeMatcherMap = {
+const routeMatcherMapForPolicies = {
     [notifiersAlias]: {
         method: 'GET',
         url: api.integrations.notifiers,
@@ -25,30 +25,58 @@ const routeMatcherMap = {
     },
 };
 
-export function visitPolicies(staticResponseMap) {
-    visit(policiesUrl, routeMatcherMap, staticResponseMap);
+const containerTitle = 'Policy management';
 
-    cy.get('h1:contains("Policy management")');
-    cy.get(`.pf-c-nav__link.pf-m-current:contains("Policies")`);
+/**
+ * @param {Record<string, { body: unknown } | { fixture: string }>} [staticResponseMap]
+ */
+export function visitPolicies(staticResponseMap) {
+    visitAndAssertBeforeResponses(
+        policiesPath,
+        () => {
+            cy.get(`h1:contains("${containerTitle}")`);
+            cy.get(`.pf-c-nav__link.pf-m-current:contains("Policies")`);
+        },
+        routeMatcherMapForPolicies,
+        staticResponseMap
+    );
 }
 
 export function visitPoliciesFromLeftNav() {
-    visitFromLeftNavExpandable('Platform Configuration', 'Policy Management', routeMatcherMap);
+    visitFromLeftNavExpandable(
+        'Platform Configuration',
+        containerTitle,
+        routeMatcherMapForPolicies
+    );
 
-    cy.get('h1:contains("Policy management")');
+    cy.location('pathname').should('eq', policiesPath);
+    cy.get(`h1:contains("${containerTitle}")`);
     cy.get(`.pf-c-nav__link.pf-m-current:contains("Policies")`);
 }
 
+/**
+ * @param {string} policyId
+ * @param {Record<string, { body: unknown } | { fixture: string }>} [staticResponseMap]
+ */
 export function visitPolicy(policyId, staticResponseMap) {
-    const routeMatcherMapPolicy = {
+    const routeMatcherMapForPolicy = {
         'policies/id': {
             method: 'GET',
             url: api.policies.policy,
         },
     };
 
-    visit(`${policiesUrl}/${policyId}`, routeMatcherMapPolicy, staticResponseMap);
-    cy.get('h2:contains("Policy details")');
+    visitAndAssertBeforeResponses(
+        `${policiesPath}/${policyId}`,
+        () => {
+            cy.get(`a.pf-c-breadcrumb__link:contains("Policies")`);
+            cy.get('h2:contains("Policy details")');
+            cy.get('h2:contains("Policy behavior")');
+            cy.get('h2:contains("Policy criteria")');
+        },
+        routeMatcherMapForPolicy,
+        staticResponseMap
+    );
 }
 
 // Actions on policy table

--- a/ui/apps/platform/cypress/helpers/violations.js
+++ b/ui/apps/platform/cypress/helpers/violations.js
@@ -1,5 +1,5 @@
 import * as api from '../constants/apiEndpoints';
-import { url, selectors } from '../constants/ViolationsPage';
+import { url as basePath, selectors } from '../constants/ViolationsPage';
 
 import { visitFromLeftNav } from './nav';
 import { visit, visitAndAssertBeforeResponses } from './visit';
@@ -22,7 +22,7 @@ const containerTitle = 'Violations';
 export function visitViolationsFromLeftNav() {
     visitFromLeftNav(containerTitle, routeMatcherMapForViolations);
 
-    cy.location('pathname').should('eq', url);
+    cy.location('pathname').should('eq', basePath);
     cy.get(`h1:contains("${containerTitle}")`);
 }
 
@@ -31,7 +31,7 @@ export function visitViolationsFromLeftNav() {
  */
 export function visitViolations(staticResponseMap) {
     visitAndAssertBeforeResponses(
-        url,
+        basePath,
         () => {
             cy.get(`h1:contains("${containerTitle}")`);
         },
@@ -49,7 +49,7 @@ export function visitViolationsWithFixture(fixturePath) {
         };
 
         visitAndAssertBeforeResponses(
-            url,
+            basePath,
             () => {
                 cy.get(`h1:contains("${containerTitle}")`);
             },
@@ -91,7 +91,7 @@ export function visitViolationWithFixture(fixturePath) {
             body: alert,
         }).as('alerts/id');
 
-        visit(`${url}/${id}`);
+        visit(`${basePath}/${id}`);
 
         cy.wait('@alerts/id');
         cy.get(`${selectors.details.title}:contains("${name}")`);

--- a/ui/apps/platform/cypress/helpers/violations.js
+++ b/ui/apps/platform/cypress/helpers/violations.js
@@ -2,11 +2,11 @@ import * as api from '../constants/apiEndpoints';
 import { url, selectors } from '../constants/ViolationsPage';
 
 import { visitFromLeftNav } from './nav';
-import { visit } from './visit';
+import { visit, visitAndAssertBeforeResponses } from './visit';
 
 // visit
 
-const routeMatcherMap = {
+const routeMatcherMapForViolations = {
     alerts: {
         method: 'GET',
         url: api.alerts.alertsWithQuery,
@@ -17,17 +17,27 @@ const routeMatcherMap = {
     },
 };
 
+const containerTitle = 'Violations';
+
 export function visitViolationsFromLeftNav() {
-    visitFromLeftNav('Violations', routeMatcherMap);
+    visitFromLeftNav(containerTitle, routeMatcherMapForViolations);
 
     cy.location('pathname').should('eq', url);
-    cy.get('h1:contains("Violations")');
+    cy.get(`h1:contains("${containerTitle}")`);
 }
 
+/**
+ * @param {Record<string, { body: unknown } | { fixture: string }>} [staticResponseMap]
+ */
 export function visitViolations(staticResponseMap) {
-    visit(url, routeMatcherMap, staticResponseMap);
-
-    cy.get('h1:contains("Violations")');
+    visitAndAssertBeforeResponses(
+        url,
+        () => {
+            cy.get(`h1:contains("${containerTitle}")`);
+        },
+        routeMatcherMapForViolations,
+        staticResponseMap
+    );
 }
 
 export function visitViolationsWithFixture(fixturePath) {
@@ -38,9 +48,14 @@ export function visitViolationsWithFixture(fixturePath) {
             alertscount: { body: { count } },
         };
 
-        visit(url, routeMatcherMap, staticResponseMap);
-
-        cy.get('h1:contains("Violations")');
+        visitAndAssertBeforeResponses(
+            url,
+            () => {
+                cy.get(`h1:contains("${containerTitle}")`);
+            },
+            routeMatcherMapForViolations,
+            staticResponseMap
+        );
     });
 }
 

--- a/ui/apps/platform/cypress/helpers/visit.js
+++ b/ui/apps/platform/cypress/helpers/visit.js
@@ -43,6 +43,34 @@ const routeMatcherMapForAuthenticatedRoutes = {
 };
 
 /**
+ * Wait for responses to requests for any authenticated route,
+ * call function to make assertions for page which do not depend on data,
+ * and then wait for responses to requests for page.
+ *
+ * @param {string} pagePath
+ * @param {function} assertionCallback
+ * @param {Record<string, { method: string, url: string }>} [routeMatcherMap]
+ * @param {Record<string, { body: unknown } | { fixture: string }>} [staticResponseMap]
+ */
+export function visitAndAssertBeforeResponses(
+    pagePath,
+    assertionCallback,
+    routeMatcherMap,
+    staticResponseMap
+) {
+    interceptRequests(routeMatcherMapForAuthenticatedRoutes);
+    interceptRequests(routeMatcherMap, staticResponseMap);
+
+    cy.visit(pagePath);
+
+    waitForResponses(routeMatcherMapForAuthenticatedRoutes);
+
+    assertionCallback();
+
+    waitForResponses(routeMatcherMap);
+}
+
+/**
  * Wait for prerequisite requests to render container components.
  *
  * Always wait on generic requests for MainPage component.

--- a/ui/apps/platform/cypress/helpers/vulnmanagement/entities.js
+++ b/ui/apps/platform/cypress/helpers/vulnmanagement/entities.js
@@ -139,7 +139,7 @@ function opnameForPrimaryAndSecondaryEntities(entitiesKey1, entitiesKey2) {
 
 const basePath = '/main/vulnerability-management'; // dashboard
 
-const dashboardTitle = 'Vulnerability Management';
+const containerTitle = 'Vulnerability Management';
 
 function getEntitiesPath(entitiesKey, search = '') {
     return `${basePath}/${entitiesKey}${search}`;
@@ -160,14 +160,14 @@ export function visitVulnerabilityManagementDashboardFromLeftNav() {
 
     cy.location('pathname').should('eq', basePath);
     cy.location('search').should('eq', '');
-    cy.get(`h1:contains("${dashboardTitle}")`);
+    cy.get(`h1:contains("${containerTitle}")`);
 }
 
 export function visitVulnerabilityManagementDashboard() {
     visitAndAssertBeforeResponses(
         basePath,
         () => {
-            cy.get(`h1:contains("${dashboardTitle}")`);
+            cy.get(`h1:contains("${containerTitle}")`);
         },
         routeMatcherMapForVulnerabilityManagementDashboard
     );

--- a/ui/apps/platform/cypress/helpers/vulnmanagement/entities.js
+++ b/ui/apps/platform/cypress/helpers/vulnmanagement/entities.js
@@ -3,7 +3,7 @@ import { hasFeatureFlag } from '../features';
 
 import { visitFromLeftNavExpandable } from '../nav';
 import { getRouteMatcherMapForGraphQL, interactAndWaitForResponses } from '../request';
-import { visit } from '../visit';
+import { visitAndAssertBeforeResponses } from '../visit';
 
 let opnamesForDashboard = [
     'policiesCount',
@@ -80,6 +80,23 @@ const opnameForEntities = {
     policies: 'getPolicies',
 };
 
+// Headings on entities pages: Title Case style hides the inconsistencies.
+const headingSingular = {
+    clusters: 'cluster',
+    components: 'component',
+    'image-components': 'image component',
+    'node-components': 'node component',
+    cves: 'CVE',
+    'image-cves': 'Image CVE',
+    'node-cves': 'Node CVE',
+    'cluster-cves': 'Platform CVE',
+    deployments: 'deployment',
+    images: 'image',
+    namespaces: 'namespace',
+    nodes: 'node',
+    policies: 'policie',
+};
+
 // Headings on entities pages: uppercase style hides the inconsistencies.
 const headingPlural = {
     clusters: 'clusters',
@@ -122,6 +139,8 @@ function opnameForPrimaryAndSecondaryEntities(entitiesKey1, entitiesKey2) {
 
 const basePath = '/main/vulnerability-management'; // dashboard
 
+const dashboardTitle = 'Vulnerability Management';
+
 function getEntitiesPath(entitiesKey, search = '') {
     return `${basePath}/${entitiesKey}${search}`;
 }
@@ -141,13 +160,17 @@ export function visitVulnerabilityManagementDashboardFromLeftNav() {
 
     cy.location('pathname').should('eq', basePath);
     cy.location('search').should('eq', '');
-    cy.get('h1:contains("Vulnerability Management")');
+    cy.get(`h1:contains("${dashboardTitle}")`);
 }
 
 export function visitVulnerabilityManagementDashboard() {
-    visit(basePath, routeMatcherMapForVulnerabilityManagementDashboard);
-
-    cy.get('h1:contains("Vulnerability Management")');
+    visitAndAssertBeforeResponses(
+        basePath,
+        () => {
+            cy.get(`h1:contains("${dashboardTitle}")`);
+        },
+        routeMatcherMapForVulnerabilityManagementDashboard
+    );
 }
 
 /*
@@ -160,9 +183,13 @@ export function visitVulnerabilityManagementEntities(entitiesKey) {
         opnameForEntities[entitiesKey],
     ]);
 
-    visit(getEntitiesPath(entitiesKey), routeMatcherMap);
-
-    cy.get(`h1:contains("${headingPlural[entitiesKey]}")`);
+    visitAndAssertBeforeResponses(
+        getEntitiesPath(entitiesKey),
+        () => {
+            cy.get(`h1:contains("${headingPlural[entitiesKey]}")`);
+        },
+        routeMatcherMap
+    );
 }
 
 export function visitVulnerabilityManagementEntitiesWithSearch(entitiesKey, search) {
@@ -171,9 +198,13 @@ export function visitVulnerabilityManagementEntitiesWithSearch(entitiesKey, sear
         opnameForEntities[entitiesKey],
     ]);
 
-    visit(getEntitiesPath(entitiesKey, search), routeMatcherMap);
-
-    cy.get(`h1:contains("${headingPlural[entitiesKey]}")`);
+    visitAndAssertBeforeResponses(
+        getEntitiesPath(entitiesKey, search),
+        () => {
+            cy.get(`h1:contains("${headingPlural[entitiesKey]}")`);
+        },
+        routeMatcherMap
+    );
 }
 
 export function interactAndWaitForVulnerabilityManagementEntities(
@@ -206,7 +237,16 @@ export function visitVulnerabilityManagementEntityInSidePanel(
     const routeMatcherMap = getRouteMatcherMapForGraphQL([opname]);
     const staticResponseMap = staticResponseForEntity && { [opname]: staticResponseForEntity };
 
-    visit(getEntityPath(entitiesKey, entityId), routeMatcherMap, staticResponseMap);
+    visitAndAssertBeforeResponses(
+        getEntityPath(entitiesKey, entityId),
+        () => {
+            cy.get(
+                `${selectors.childEntityInfoHeader}:contains("${headingSingular[entitiesKey]}")`
+            );
+        },
+        routeMatcherMap,
+        staticResponseMap
+    );
 }
 
 export function interactAndWaitForVulnerabilityManagementEntity(

--- a/ui/apps/platform/cypress/integration/policies/policiesTable.test.js
+++ b/ui/apps/platform/cypress/integration/policies/policiesTable.test.js
@@ -48,8 +48,6 @@ describe('Policies table', () => {
 
     it('should navigate using the left nav', () => {
         visitPoliciesFromLeftNav();
-
-        cy.location('pathname').should('eq', url);
     });
 
     it('should have selected item in nav bar', () => {

--- a/ui/apps/platform/cypress/integration/policies/policiesTable.test.js
+++ b/ui/apps/platform/cypress/integration/policies/policiesTable.test.js
@@ -218,7 +218,7 @@ describe('Policies table', () => {
 
         // Policy table
         cy.location('search').should('eq', '');
-        cy.get(`.pf-c-title:contains('Policy management')`);
+        cy.get(`.pf-c-title:contains('Policy Management')`);
         cy.get(`.pf-c-nav__link.pf-m-current:contains("Policies")`);
     });
 
@@ -229,7 +229,7 @@ describe('Policies table', () => {
 
         // Policy table
         cy.location('search').should('eq', '');
-        cy.get(`.pf-c-title:contains('Policy management')`);
+        cy.get(`.pf-c-title:contains('Policy Management')`);
         cy.get(`.pf-c-nav__link.pf-m-current:contains("Policies")`);
     });
 
@@ -288,7 +288,7 @@ describe('Policies table', () => {
 
         deletePolicyInTable({ policyName, actionText: 'Delete policy' });
 
-        cy.get(`.pf-c-title:contains('Policy management')`);
+        cy.get(`.pf-c-title:contains('Policy Management')`);
         cy.get(`.pf-c-nav__link.pf-m-current:contains("Policies")`);
         cy.get(`${selectors.table.policyLink}:contains("${policyName}")`).should('not.exist');
     });

--- a/ui/apps/platform/src/Containers/PolicyManagement/PolicyManagementHeader.tsx
+++ b/ui/apps/platform/src/Containers/PolicyManagement/PolicyManagementHeader.tsx
@@ -20,9 +20,9 @@ function PolicyManagementHeader({ currentTabTitle }: PolicyManagementHeaderProps
 
     return (
         <>
-            <PageTitle title="Policy management - Policy categories" />
+            <PageTitle title="Policy Management - Policy categories" />
             <PageSection variant="light">
-                <Title headingLevel="h1">Policy management</Title>
+                <Title headingLevel="h1">Policy Management</Title>
             </PageSection>
             <PageSection variant="light" className="pf-u-px-sm pf-u-py-0">
                 <TabNav currentTabTitle={currentTabTitle} tabLinks={tabLinks} />


### PR DESCRIPTION
## Description

### Problem

Under pressure to solve timing failures in tests for various containers:

1. I replaced `cy.visit` method with generic `visit` function which intercepts requests and waits for responses according to `routeMatcherMapForAuthenticatedRoutes` object.

    * That worked well, with one exception: I incorrect includes credential expiry requests, which are not in sequence preceding, but instead in parallel with container-specific requests. Fixed in #3577

2. I wrote container-specific `visitWhatever` functions with `routeMatcherMapForWhatever` object and optional `staticResponseMap` argument.

    * However, I made a mistake in the pattern to call `visit` function with those arguments, **and then** assert page address or page header. Destination page address is an obvious prerequisite to requests and components usually render page header **before** instead of after responses to requests. Because the order of wait (API, API, and then DOM) contradicts the order of events, the pattern wastes the extra 4 seconds wait for DOM assertions.

    * Especially if containers or entity components take responsibility to make requests, but even if they render data from Redux store via sagas, it is possible to assert page address or page header **and then** intercept requests and wait for responses.

### Solution

This helper function adds another step to the pattern for interact and visit in #3917

To prevent timing problems if central slows down, invest cypress timeout in a more effective pattern which **alternates** API and DOM:

1. API: 10 seconds wait for requests and 30 seconds wait for responses in `routeMatcherForAuthenticatedRoutes` object.
2. DOM: 4 seconds wait for **container-specific** assertions in `assertionCallback` function.
3. API: 10 seconds wait for requests and 30 seconds wait for responses for **container-specific** `routeMatcherMapForWhatever` object.
4. DOM: 4 seconds wait for **test-specific** assertions after `visitWhatever` function call.

In part 1, apply the pattern to the following containers:
1. workflow
    * compliance
    * configmanagement
    * vulnmanagement
2. policies
3. violations

**Review recommendation**: before you review the test files, look at cypress/helpers/visit.js file to compare improved `visitAndAssertBeforeResponses` with baseline `visit` function (expand the following lines).

### Residue

1. cypress/helpers/policies.js
    * Replace inline intercept and wait with routeMatcherMap and helper functions.
2. cypress/integration/compliance/complianceList.test.js
    * Encapsulate reference to container path in tests.
3. cypress/integration/policies/policiesTable.test.js
    * Investigate how to encapsulate reference to policies path in 2 redirect tests.
4. cypress/integration/violations/tags.test.js
    * Encapsulate reference to container path in skipped tests.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed