### PR TITLE
Update collection page title based on context

### DIFF
--- a/ui/apps/platform/src/Containers/Collections/CollectionsFormPage.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionsFormPage.tsx
@@ -30,6 +30,7 @@ import { collectionsBasePath } from 'routePaths';
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
 import ConfirmationModal from 'Components/PatternFly/ConfirmationModal';
 import useToasts from 'hooks/patternfly/useToasts';
+import PageTitle from 'Components/PageTitle';
 import { CollectionPageAction } from './collections.utils';
 import CollectionFormDrawer, { CollectionFormDrawerProps } from './CollectionFormDrawer';
 import { generateRequest } from './converter';
@@ -43,6 +44,20 @@ export type CollectionsFormPageProps = {
     hasWriteAccessForCollections: boolean;
     pageAction: CollectionPageAction;
 };
+
+function getPageTitle(
+    pageAction: CollectionPageAction,
+    pageData: ReturnType<typeof useCollection>['data']
+): string {
+    const pageTitleSuffix = pageData ? ` - ${pageData.collection.name}` : '';
+    const titles = {
+        create: `Create Collection`,
+        clone: `Clone Collection${pageTitleSuffix}`,
+        edit: `Edit Collection${pageTitleSuffix}`,
+        view: `Collection${pageTitleSuffix}`,
+    };
+    return titles[pageAction.type];
+}
 
 function CollectionsFormPage({
     hasWriteAccessForCollections,
@@ -212,7 +227,7 @@ function CollectionsFormPage({
             </Bullseye>
         );
     } else if (data) {
-        const pageTitle = pageAction.type === 'create' ? 'Create collection' : data.collection.name;
+        const pageName = pageAction.type === 'create' ? 'Create collection' : data.collection.name;
         content = (
             <CollectionFormDrawer
                 hasWriteAccessForCollections={hasWriteAccessForCollections}
@@ -231,7 +246,7 @@ function CollectionsFormPage({
                             <BreadcrumbItemLink to={collectionsBasePath}>
                                 Collections
                             </BreadcrumbItemLink>
-                            <BreadcrumbItem>{pageTitle}</BreadcrumbItem>
+                            <BreadcrumbItem>{pageName}</BreadcrumbItem>
                         </Breadcrumb>
                         <Divider component="div" />
                         <Flex
@@ -240,7 +255,7 @@ function CollectionsFormPage({
                             alignItems={{ default: 'alignItemsFlexStart', md: 'alignItemsCenter' }}
                         >
                             <Title className="pf-u-flex-grow-1" headingLevel="h1">
-                                {pageTitle}
+                                {pageName}
                             </Title>
                             <FlexItem align={{ default: 'alignLeft', md: 'alignRight' }}>
                                 {pageAction.type === 'view' && hasWriteAccessForCollections && (
@@ -330,6 +345,7 @@ function CollectionsFormPage({
 
     return (
         <PageSection className="pf-u-h-100" padding={{ default: 'noPadding' }}>
+            <PageTitle title={getPageTitle(pageAction, data)} />
             {content}
             {modalCollectionId && (
                 <CollectionsFormModal


### PR DESCRIPTION
## Description

This updates collection page titles to reflect the current page context.

Note that in cases where a page title reflects a specific collection, part of the title will be blank until the collection data loads. e.g. When editing "HIPAA Sensitive", the page title will initially be "Edit Collection", and change to "Edit Collection - HIPAA Sensitive" once the data for the collection has loaded. When the title changes in this way, the history will be updated in-place so that the partial title will not be reflected in the browser's history.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Navigate through the Collection pages and view page history. The navigation flow that resulted in the following bottom-up history is this:

- Navigate to the Collections page via the sidebar link
- Navigate to a specific collection via the table (HIPAA Sensitive)
- From this readonly collection view, select "Edit collection" from the menu
- Navigate to the Collections page via the sidebar link
- Navigate to a specific collection via the table (HIPAA Sensitive)
- From this readonly collection view, select "Edit collection" from the menu
- Navigate to the Collections page via the sidebar link
- Click the "Create collection" button

![image](https://user-images.githubusercontent.com/1292638/204353850-4fd0aeaf-c552-46e7-a705-c3686be17e7d.png)

