### PR TITLE
ROX-9115: Avoid rate limiting with DeploymentTest

### DIFF
--- a/qa-tests-backend/src/test/groovy/DeploymentTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DeploymentTest.groovy
@@ -12,19 +12,23 @@ import util.Timer
 
 class DeploymentTest extends BaseSpecification {
     private static final String DEPLOYMENT_NAME = "image-join"
+    // The image name in quay.io includes the SHA from the original image
+    // imported from docker.io which is different then the SHA used by quay.io.
+    private static final String DEPLOYMENT_IMAGE_NAME = "quay.io/rhacs-eng/qa:nginx-204a9a8e65061b10b92ad361dd6f406248404fe60efd5d6a8f2595f18bb37aad"
+    private static final String DEPLOYMENT_IMAGE_SHA = "7413e4ab770f308c01659dd1015e61dcc1dead3923d4347dbf3c59206594332f"
     private static final String GKE_ORCHESTRATOR_DEPLOYMENT_NAME = "kube-dns"
     private static final String OPENSHIFT_ORCHESTRATOR_DEPLOYMENT_NAME = "apiserver"
     private static final String STACKROX_DEPLOYMENT_NAME = "central"
 
     private static final Deployment DEPLOYMENT = new Deployment()
             .setName(DEPLOYMENT_NAME)
-            .setImage("nginx@sha256:204a9a8e65061b10b92ad361dd6f406248404fe60efd5d6a8f2595f18bb37aad")
+            .setImage(DEPLOYMENT_IMAGE_NAME)
             .addLabel("app", "test")
             .setCommand(["sh", "-c", "apt-get -y update && sleep 600"])
 
     private static final Job JOB = new Job()
             .setName("test-job-pi")
-            .setImage("perl:5.32.1")
+            .setImage("quay.io/rhacs-eng/qa:perl")
             .addLabel("app", "test")
             .setCommand(["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"])
 
@@ -62,7 +66,7 @@ class DeploymentTest extends BaseSpecification {
         def img = null
         while (img == null && t.IsValid()) {
             img = ImageService.getImage(
-                    "sha256:204a9a8e65061b10b92ad361dd6f406248404fe60efd5d6a8f2595f18bb37aad", false)
+                    "sha256:"+DEPLOYMENT_IMAGE_SHA, false)
         }
         assert img != null
 
@@ -72,15 +76,15 @@ class DeploymentTest extends BaseSpecification {
 
         where:
         "Data inputs are: "
-        query                                                                                                   | _
-        "Image:docker.io/library/nginx@sha256:204a9a8e65061b10b92ad361dd6f406248404fe60efd5d6a8f2595f18bb37aad" | _
-        "Image Sha:sha256:204a9a8e65061b10b92ad361dd6f406248404fe60efd5d6a8f2595f18bb37aad"                     | _
-        "CVE:CVE-2018-18314+Fixable:true"                                                                       | _
-        "Deployment:${DEPLOYMENT_NAME}+Image:r/docker.*"                                                        | _
-        "Image:r/docker.*"                                                                                      | _
-        "Image:!stackrox.io"                                                                                    | _
-        "Deployment:${DEPLOYMENT_NAME}+Image:!stackrox.io"                                                      | _
-        "Image Remote:library/nginx+Image Registry:docker.io"                                                   | _
+        query                                                            | _
+        "Image:"+DEPLOYMENT_IMAGE_NAME                                   | _
+        "Image Sha:sha256:"+DEPLOYMENT_IMAGE_SHA                         | _
+        "CVE:CVE-2018-18314+Fixable:true"                                | _
+        "Deployment:${DEPLOYMENT_NAME}+Image:r/quay.io.*"                | _
+        "Image:r/quay.io.*"                                              | _
+        "Image:!stackrox.io"                                             | _
+        "Deployment:${DEPLOYMENT_NAME}+Image:!stackrox.io"               | _
+        "Image Remote:rhacs-eng/qa+Image Registry:quay.io"               | _
     }
 
     @Unroll
@@ -91,22 +95,22 @@ class DeploymentTest extends BaseSpecification {
         def img = null
         while (img == null && t.IsValid()) {
             img = ImageService.getImage(
-                    "sha256:204a9a8e65061b10b92ad361dd6f406248404fe60efd5d6a8f2595f18bb37aad", false)
+                    "sha256:"+DEPLOYMENT_IMAGE_SHA, false)
         }
         assert img != null
 
         then:
         def images = ImageService.getImages(RawQuery.newBuilder().setQuery(query).build())
         assert images.find {
-            x -> x.getId() == "sha256:204a9a8e65061b10b92ad361dd6f406248404fe60efd5d6a8f2595f18bb37aad" } != null
+            x -> x.getId() == "sha256:"+DEPLOYMENT_IMAGE_SHA } != null
 
         where:
         "Data inputs are: "
-        query                                                                                                   | _
-        "Deployment:${DEPLOYMENT_NAME}"                                                                         | _
-        "Label:app=test"                                                                                        | _
-        "Image:docker.io/library/nginx@sha256:204a9a8e65061b10b92ad361dd6f406248404fe60efd5d6a8f2595f18bb37aad" | _
-        "Label:app=test+Image:docker.io/library/nginx"                                                          | _
+        query                                               | _
+        "Deployment:${DEPLOYMENT_NAME}"                     | _
+        "Label:app=test"                                    | _
+        "Image:"+DEPLOYMENT_IMAGE_NAME                      | _
+        "Label:app=test+Image:"+DEPLOYMENT_IMAGE_NAME       | _
     }
 
     @Unroll

--- a/qa-tests-backend/src/test/groovy/DeploymentTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DeploymentTest.groovy
@@ -13,7 +13,7 @@ import util.Timer
 class DeploymentTest extends BaseSpecification {
     private static final String DEPLOYMENT_NAME = "image-join"
     // The image name in quay.io includes the SHA from the original image
-    // imported from docker.io which is different then the SHA used by quay.io.
+    // imported from docker.io which is somewhat confusingly different.
     private static final String DEPLOYMENT_IMAGE_NAME = "quay.io/rhacs-eng/qa:nginx-204a9a8e65061b10b92ad361dd6f406248404fe60efd5d6a8f2595f18bb37aad"
     private static final String DEPLOYMENT_IMAGE_SHA = "7413e4ab770f308c01659dd1015e61dcc1dead3923d4347dbf3c59206594332f"
     private static final String GKE_ORCHESTRATOR_DEPLOYMENT_NAME = "kube-dns"

--- a/qa-tests-backend/src/test/groovy/DeploymentTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DeploymentTest.groovy
@@ -14,8 +14,10 @@ class DeploymentTest extends BaseSpecification {
     private static final String DEPLOYMENT_NAME = "image-join"
     // The image name in quay.io includes the SHA from the original image
     // imported from docker.io which is somewhat confusingly different.
-    private static final String DEPLOYMENT_IMAGE_NAME = "quay.io/rhacs-eng/qa:nginx-204a9a8e65061b10b92ad361dd6f406248404fe60efd5d6a8f2595f18bb37aad"
-    private static final String DEPLOYMENT_IMAGE_SHA = "7413e4ab770f308c01659dd1015e61dcc1dead3923d4347dbf3c59206594332f"
+    private static final String DEPLOYMENT_IMAGE_NAME =
+        "quay.io/rhacs-eng/qa:nginx-204a9a8e65061b10b92ad361dd6f406248404fe60efd5d6a8f2595f18bb37aad"
+    private static final String DEPLOYMENT_IMAGE_SHA =
+        "7413e4ab770f308c01659dd1015e61dcc1dead3923d4347dbf3c59206594332f"
     private static final String GKE_ORCHESTRATOR_DEPLOYMENT_NAME = "kube-dns"
     private static final String OPENSHIFT_ORCHESTRATOR_DEPLOYMENT_NAME = "apiserver"
     private static final String STACKROX_DEPLOYMENT_NAME = "central"


### PR DESCRIPTION
## Description

`DeploymentTest.groovy` can flake subject to docker.io rate limiting. I've noticed this in particular when running standalone tests for ROX-9115. This PR changes the test to use images from quay.io/rhacs-eng/qa.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

CI is sufficient