### PR TITLE
ROX-13661: Refactor `Stopper` and use it more

### DIFF
--- a/central/processindicator/datastore/datastore.go
+++ b/central/processindicator/datastore/datastore.go
@@ -36,7 +36,7 @@ type DataStore interface {
 	WalkAll(ctx context.Context, fn func(pi *storage.ProcessIndicator) error) error
 
 	// Stop signals all goroutines associated with this object to terminate.
-	Stop() bool
+	Stop()
 	// Wait waits until all goroutines associated with this object have terminated, or cancelWhen gets triggered.
 	// A return value of false indicates that cancelWhen was triggered.
 	Wait(cancelWhen concurrency.Waitable) bool
@@ -50,8 +50,7 @@ func New(store store.Store, indexer index.Indexer, searcher search.Searcher, pru
 		searcher:              searcher,
 		prunerFactory:         prunerFactory,
 		prunedArgsLengthCache: make(map[processindicator.ProcessWithContainerInfo]int),
-		stopSig:               concurrency.NewSignal(),
-		stoppedSig:            concurrency.NewSignal(),
+		stopper:               concurrency.NewStopper(),
 	}
 	ctx := sac.WithAllAccess(context.Background())
 	if err := d.buildIndex(ctx); err != nil {

--- a/central/processindicator/datastore/mocks/datastore.go
+++ b/central/processindicator/datastore/mocks/datastore.go
@@ -148,11 +148,9 @@ func (mr *MockDataStoreMockRecorder) SearchRawProcessIndicators(ctx, q interface
 }
 
 // Stop mocks base method.
-func (m *MockDataStore) Stop() bool {
+func (m *MockDataStore) Stop() {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Stop")
-	ret0, _ := ret[0].(bool)
-	return ret0
+	m.ctrl.Call(m, "Stop")
 }
 
 // Stop indicates an expected call of Stop.

--- a/central/vulnerabilityrequest/manager/requestmgr/manager_impl.go
+++ b/central/vulnerabilityrequest/manager/requestmgr/manager_impl.go
@@ -58,8 +58,7 @@ type managerImpl struct {
 	reObserveTimedDeferralsTickerDuration     time.Duration
 	reObserveWhenFixedDeferralsTickerDuration time.Duration
 
-	stopSig concurrency.Signal
-	stopped concurrency.Signal
+	stopper concurrency.Stopper
 }
 
 func (m *managerImpl) Start() {
@@ -70,8 +69,8 @@ func (m *managerImpl) Start() {
 }
 
 func (m *managerImpl) Stop() {
-	m.stopSig.Signal()
-	m.stopped.Wait()
+	m.stopper.Client().Stop()
+	_ = m.stopper.Client().Stopped().Wait()
 }
 
 func (m *managerImpl) Create(ctx context.Context, req *storage.VulnerabilityRequest) error {
@@ -372,7 +371,7 @@ func (m *managerImpl) getExpiredDeferrals() ([]*storage.VulnerabilityRequest, er
 }
 
 func (m *managerImpl) reObserveExpiredDeferrals() {
-	if m.stopped.IsDone() {
+	if m.stopper.Client().Stopped().IsDone() {
 		return
 	}
 
@@ -438,7 +437,7 @@ func (m *managerImpl) getFixableDeferrals() ([]*storage.VulnerabilityRequest, er
 }
 
 func (m *managerImpl) reObserveFixableDeferrals() {
-	if m.stopped.IsDone() {
+	if m.stopper.Client().Stopped().IsDone() {
 		return
 	}
 
@@ -459,7 +458,7 @@ func (m *managerImpl) reObserveFixableDeferrals() {
 }
 
 func (m *managerImpl) runExpiredDeferralsProcessor() {
-	defer m.stopped.Signal()
+	defer m.stopper.Flow().ReportStopped()
 	reObserveTimedDeferralsTicker := time.NewTicker(m.reObserveTimedDeferralsTickerDuration)
 	defer reObserveTimedDeferralsTicker.Stop()
 	reObserveWhenFixedDeferralsTicker := time.NewTicker(m.reObserveWhenFixedDeferralsTickerDuration)
@@ -471,7 +470,7 @@ func (m *managerImpl) runExpiredDeferralsProcessor() {
 
 	for {
 		select {
-		case <-m.stopSig.Done():
+		case <-m.stopper.Flow().StopRequested():
 			return
 		case <-reObserveTimedDeferralsTicker.C:
 			go m.reObserveExpiredDeferrals()

--- a/central/vulnerabilityrequest/manager/requestmgr/manager_impl_test.go
+++ b/central/vulnerabilityrequest/manager/requestmgr/manager_impl_test.go
@@ -171,8 +171,7 @@ func (s *VulnRequestManagerTestSuite) SetupTest() {
 		activeReqCache:                        s.activeReqCache,
 		reObserveTimedDeferralsTickerDuration: expiryLoopDurationForTest,
 		reObserveWhenFixedDeferralsTickerDuration: expiryLoopDurationForTest,
-		stopSig: concurrency.NewSignal(),
-		stopped: concurrency.NewSignal(),
+		stopper: concurrency.NewStopper(),
 	}
 }
 

--- a/central/vulnerabilityrequest/manager/requestmgr/singleton.go
+++ b/central/vulnerabilityrequest/manager/requestmgr/singleton.go
@@ -63,7 +63,6 @@ func New(
 
 		reObserveTimedDeferralsTickerDuration:     env.VulnDeferralTimedReObserveInterval.DurationSetting(),
 		reObserveWhenFixedDeferralsTickerDuration: env.VulnDeferralFixableReObserveInterval.DurationSetting(),
-		stopSig: concurrency.NewSignal(),
-		stopped: concurrency.NewSignal(),
+		stopper: concurrency.NewStopper(),
 	}
 }

--- a/compliance/collection/auditlog/auditlog.go
+++ b/compliance/collection/auditlog/auditlog.go
@@ -18,15 +18,15 @@ type Reader interface {
 	// StartReader will start the audit log reader process which will continuously read and send events until stopped.
 	// Returns true if the reader can be started (log exists and can be read). Log file missing is not considered an error.
 	StartReader(ctx context.Context) (bool, error)
-	// StopReader will stop the reader if it's started. Will return false if it was already stopped.
-	StopReader() bool
+	// StopReader will stop the reader if it's started.
+	StopReader()
 }
 
 // NewReader returns a new instance of Reader
 func NewReader(client sensor.ComplianceService_CommunicateClient, nodeName string, clusterID string, startState *storage.AuditLogFileState) Reader {
 	return &auditLogReaderImpl{
 		logPath:    defaultLogPath,
-		stopC:      concurrency.NewSignal(),
+		stopper:    concurrency.NewStopper(),
 		sender:     newAuditLogSender(client, nodeName, clusterID),
 		startState: startState,
 	}

--- a/pkg/concurrency/stopper.go
+++ b/pkg/concurrency/stopper.go
@@ -1,35 +1,116 @@
 package concurrency
 
-// NewStopper creates a new Stopper interface
+// NewStopper creates a new Stopper for arranging a graceful shutdown.
 func NewStopper() Stopper {
-	return Stopper{
-		stop:    NewSignal(),
-		stopped: NewSignal(),
+	return &stopperImpl{
+		stop:    NewErrorSignal(),
+		stopped: NewErrorSignal(),
 	}
 }
 
-// Stopper is an object that encapsulates both stop and stopped signals
-type Stopper struct {
-	stop    Signal
-	stopped Signal
+// Stopper encapsulates stop and stopped signals for arranging a graceful shutdown sequence for goroutines (and async
+// processing in general). These are referred as "stoppable" goroutines.
+type Stopper interface {
+	// Client returns an interface that should be used outside the goroutine to request a graceful shutdown and check
+	// the shutdown status.
+	Client() StopperClient
+
+	// Flow returns an interface that should be used in stoppable goroutine control flow to check and modify the state
+	// of Stopper. Flow should not be used outside the stoppable goroutine.
+	Flow() StopperFlow
+
+	// LowLevel allows to interact with the stopper at lower level. Callers should avoid using it unless there's no
+	// better alternative.
+	LowLevel() StopperLowLevel
 }
 
-// Stop signals the internal stop signal and effectively causes a push to StopDone
-func (s *Stopper) Stop() {
+// StopperClient represents an interface for an external client (external to a stoppable goroutine) to request the
+// stoppable goroutine to gracefully shutdown and to check the shutdown status.
+type StopperClient interface {
+	// Stop requests stoppable goroutine to shut down (or stop).
+	Stop()
+
+	// Stopped returns ReadOnlyErrorSignal that can be used for waiting until the stoppable goroutine reports that it
+	// finally stopped.
+	Stopped() ReadOnlyErrorSignal
+}
+
+// StopperFlow represents an interface that should be used by a stoppable goroutine to check and report its status of a
+// graceful shutdown.
+type StopperFlow interface {
+	// StopWithError initiates a shutdown due to an error that happened during async processing in goroutine. Should be
+	// called from the stoppable goroutine.
+	StopWithError(error)
+
+	// StopRequested provides a channel that should be checked in goroutine in select statements for goroutine to
+	// recognize that the shutdown was requested, and it needs to wrap up its work.
+	StopRequested() <-chan struct{}
+
+	// ReportStopped must be used by goroutine to report that the shutdown has been completed.
+	// It is best to call this as the last thing in goroutine. Consider using defer statement for this call.
+	ReportStopped()
+}
+
+// StopperLowLevel is a lower level API for interacting with Stopper. Callers should avoid using it unless there's no
+// better alternative.
+type StopperLowLevel interface {
+	// GetStopRequestSignal returns a ReadOnlyErrorSignal for the event when a stop was requested.
+	GetStopRequestSignal() ReadOnlyErrorSignal
+
+	// ResetStopRequest resets the stop request to the untriggered state. Returns true if the stop request was in the
+	// triggered state at the time of the call.
+	ResetStopRequest() bool
+}
+
+type stopperImpl struct {
+	// stop signal is for requesting shutdown.
+	stop ErrorSignal
+	// stopped is for signalling that the shutdown is complete.
+	stopped ErrorSignal
+}
+
+// Client and its functions.
+
+func (s *stopperImpl) Client() StopperClient {
+	return s
+}
+
+func (s *stopperImpl) Stop() {
 	s.stop.Signal()
 }
 
-// StopDone provides a channel to be used in select statements to interrupt the go routine
-func (s *Stopper) StopDone() <-chan struct{} {
+func (s *stopperImpl) Stopped() ReadOnlyErrorSignal {
+	return &s.stopped
+}
+
+// Flow and its functions.
+
+func (s *stopperImpl) Flow() StopperFlow {
+	return s
+}
+
+func (s *stopperImpl) StopWithError(err error) {
+	s.stop.SignalWithError(err)
+}
+
+func (s *stopperImpl) StopRequested() <-chan struct{} {
 	return s.stop.Done()
 }
 
-// Stopped signals that the stop has been completed
-func (s *Stopper) Stopped() {
-	s.stopped.Signal()
+func (s *stopperImpl) ReportStopped() {
+	s.stopped.SignalWithError(s.stop.Err())
 }
 
-// WaitForStopped waits for the stopped signal to be fired
-func (s *Stopper) WaitForStopped() {
-	s.stopped.Wait()
+// Low level API.
+
+func (s *stopperImpl) LowLevel() StopperLowLevel {
+	return s
+}
+
+func (s *stopperImpl) GetStopRequestSignal() ReadOnlyErrorSignal {
+	return &s.stop
+}
+
+func (s *stopperImpl) ResetStopRequest() bool {
+	return s.stop.Reset()
 }

--- a/pkg/concurrency/stopper_test.go
+++ b/pkg/concurrency/stopper_test.go
@@ -1,0 +1,125 @@
+package concurrency
+
+import (
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/suite"
+)
+
+type StopperTestSuite struct {
+	suite.Suite
+}
+
+func TestStopper(t *testing.T) {
+	suite.Run(t, &StopperTestSuite{})
+}
+
+// TestCommonCase demonstrates how to use Stopper for implementing a gracefully stoppable goroutine.
+func (s *StopperTestSuite) TestCommonCase() {
+	stopper := NewStopper()
+
+	s1 := NewSignal()
+	s2 := NewSignal()
+
+	// This is how to implement a gracefully stoppable goroutine.
+	go func() {
+		// The goroutine must report that it shut down at the end.
+		defer stopper.Flow().ReportStopped()
+		for {
+			select {
+			// This is how the goroutine finds out that it needs to stop.
+			case <-stopper.Flow().StopRequested():
+				return
+			// Simulate some work, e.g. reading from a channel.
+			case <-s1.Done():
+				// Here the goroutine will do its useful work. This will just unblock the test to proceed to the shutdown.
+				s2.Signal()
+			}
+		}
+	}()
+
+	s1.Signal()
+	s2.Wait() // Wait until it is time to shut down the goroutine.
+
+	// This is how to tell goroutine to stop.
+	stopper.Client().Stop()
+
+	// This is how to wait until the goroutine actually stops.
+	s.NoError(stopper.Client().Stopped().Wait())
+}
+
+// TestGoroutineError demonstrates how goroutine can stop itself on error and report this error.
+func (s *StopperTestSuite) TestGoroutineError() {
+	stopper := NewStopper()
+
+	ch := make(chan struct{})
+	close(ch)
+
+	go func() {
+		// stopper.Flow().ReportStopped() will make sure to propagate the error to be returned by
+		// stopper.Client().Stopped().Wait().
+		defer stopper.Flow().ReportStopped()
+		for {
+			select {
+			case <-stopper.Flow().StopRequested():
+				return
+			case _, ok := <-ch:
+				// The channel starts as closed by the way how the test is set up. This wouldn't be a case in normal
+				// code.
+				s.False(ok)
+				if !ok {
+					stopper.Flow().StopWithError(errors.New("test input channel was closed"))
+					return
+				}
+			}
+		}
+	}()
+
+	// Not calling stopper.Client().Stop() because the goroutine will stop by itself on error.
+
+	s.ErrorContains(stopper.Client().Stopped().Wait(), "test input channel was closed")
+}
+
+// TestGoroutineErrorPreserved verifies that the error reported by goroutine is preserved even in case the external
+// client requests it to stop. Note that who calls Stop* first is subject of race conditions therefore this test uses
+// a couple of signals to make sure StopWithError() inside goroutine is called before Stop() outside it.
+func (s *StopperTestSuite) TestGoroutineErrorPreserved() {
+	stopper := NewStopper()
+
+	s1 := NewSignal()
+	s2 := NewSignal()
+
+	go func() {
+		defer stopper.Flow().ReportStopped()
+		stopper.Flow().StopWithError(errors.New("test failure"))
+		s1.Signal()
+		s2.Wait()
+	}()
+
+	s1.Wait()
+	stopper.Client().Stop()
+	s2.Signal() // This makes sure that stopper.Client().Stop() is called before stopper.Flow().ReportStopped().
+
+	s.ErrorContains(stopper.Client().Stopped().Wait(), "test failure")
+}
+
+// TestOnlyStop verifies (and demonstrates) the case found in sensor/common/config/handler.go where the code relies
+// only on signalling stopperImpl.stop without touching stopperImpl.stopped.
+// Although Stopper can be used this way, it isn't probably a good idea to use it. The purpose of Stopper is to help
+// have standard protocol of the graceful shutdown whereas a single event is not enough for that.
+func (s *StopperTestSuite) TestOnlyStop() {
+	stopper := NewStopper()
+	action := func() error {
+		select {
+		case <-stopper.Flow().StopRequested():
+			return errors.New("no action - stop was requested")
+		default:
+			return nil
+		}
+	}
+
+	s.NoError(action())
+	stopper.Client().Stop()
+	s.ErrorContains(action(), "no action - stop was requested")
+}

--- a/sensor/admission-control/main.go
+++ b/sensor/admission-control/main.go
@@ -5,7 +5,6 @@ import (
 	"os/signal"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/stackrox/rox/pkg/clientconn"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/devmode"
@@ -77,9 +76,7 @@ func mainCmd() error {
 	}
 
 	mgr := manager.New(sensorConn, namespace)
-	if err := mgr.Start(); err != nil {
-		return errors.Wrap(err, "starting admission control manager")
-	}
+	mgr.Start()
 
 	if err := settingswatch.WatchK8sForSettingsUpdatesAsync(mgr.Stopped(), mgr.SettingsUpdateC(), namespace); err != nil {
 		log.Errorf("Could not watch Kubernetes for settings updates: %v. Functionality might be impacted", err)

--- a/sensor/admission-control/manager/evaluate_runtime.go
+++ b/sensor/admission-control/manager/evaluate_runtime.go
@@ -145,7 +145,7 @@ func (m *manager) evaluatePodEvent(s *state, req *admission.AdmissionRequest, ev
 
 func (m *manager) waitForDeploymentAndDetect(s *state, event *storage.KubernetesEvent) {
 	select {
-	case <-m.stopSig.Done():
+	case <-m.stopper.Flow().StopRequested():
 		return
 	case <-m.initialSyncSig.Done():
 		deployment := m.getDeploymentForPod(event.GetObject().GetNamespace(), event.GetObject().GetName())

--- a/sensor/admission-control/manager/manager.go
+++ b/sensor/admission-control/manager/manager.go
@@ -13,7 +13,7 @@ import (
 
 // Manager manages the main business logic of the admission control service.
 type Manager interface {
-	Start() error
+	Start()
 	Stop()
 	Stopped() concurrency.ErrorWaitable
 

--- a/sensor/admission-control/manager/manager_impl.go
+++ b/sensor/admission-control/manager/manager_impl.go
@@ -70,8 +70,7 @@ func (s *state) activeForOperation(op admission.Operation) bool {
 }
 
 type manager struct {
-	stopSig    concurrency.Signal
-	stoppedSig concurrency.ErrorSignal
+	stopper concurrency.Stopper
 
 	client     sensor.ImageServiceClient
 	imageCache sizeboundedcache.Cache[string, imageCacheEntry]
@@ -113,7 +112,7 @@ func NewManager(namespace string, maxImageCacheSize int64, imageServiceClient se
 	return &manager{
 		settingsStream: concurrency.NewValueStream[*sensor.AdmissionControlSettings](nil),
 		settingsC:      make(chan *sensor.AdmissionControlSettings),
-		stoppedSig:     concurrency.NewErrorSignal(),
+		stopper:        concurrency.NewStopper(),
 		syncC:          make(chan *concurrency.Signal),
 
 		client:     imageServiceClient,
@@ -150,8 +149,8 @@ func (m *manager) Sync(ctx context.Context) error {
 	case m.syncC <- &syncSig:
 	case <-ctx.Done():
 		return ctx.Err()
-	case <-m.stoppedSig.Done():
-		return m.stoppedSig.ErrorWithDefault(pkgErr.New("manager was stopped"))
+	case <-m.stopper.Client().Stopped().Done():
+		return m.stopper.Client().Stopped().ErrorWithDefault(pkgErr.New("manager was stopped"))
 	}
 
 	select {
@@ -159,13 +158,13 @@ func (m *manager) Sync(ctx context.Context) error {
 		return nil
 	case <-ctx.Done():
 		return ctx.Err()
-	case <-m.stoppedSig.Done():
-		return m.stoppedSig.ErrorWithDefault(pkgErr.New("manager was stopped"))
+	case <-m.stopper.Client().Stopped().Done():
+		return m.stopper.Client().Stopped().ErrorWithDefault(pkgErr.New("manager was stopped"))
 	}
 }
 
 func (m *manager) Start() error {
-	if !m.stopSig.Reset() {
+	if m.stopper.LowLevel().ResetStopRequest() {
 		return pkgErr.New("admission control manager has already been started")
 	}
 
@@ -174,11 +173,11 @@ func (m *manager) Start() error {
 }
 
 func (m *manager) Stop() {
-	m.stopSig.Signal()
+	m.stopper.Client().Stop()
 }
 
 func (m *manager) Stopped() concurrency.ErrorWaitable {
-	return &m.stoppedSig
+	return m.stopper.Client().Stopped()
 }
 
 func (m *manager) SettingsUpdateC() chan<- *sensor.AdmissionControlSettings {
@@ -194,12 +193,12 @@ func (m *manager) InitialResourceSyncSig() *concurrency.Signal {
 }
 
 func (m *manager) run() {
-	defer m.stoppedSig.Signal()
+	defer m.stopper.Flow().ReportStopped()
 	defer log.Info("Stopping watcher")
 
-	for !m.stopSig.IsDone() {
+	for {
 		select {
-		case <-m.stopSig.Done():
+		case <-m.stopper.Flow().StopRequested():
 			m.ProcessNewSettings(nil)
 			return
 		case newSettings := <-m.settingsC:
@@ -211,7 +210,7 @@ func (m *manager) run() {
 			// channels. The duplication of select branches is a bit ugly, but inevitable
 			// without reflection.
 			select {
-			case <-m.stopSig.Done():
+			case <-m.stopper.Flow().StopRequested():
 				m.ProcessNewSettings(nil)
 				return
 			case newSettings := <-m.settingsC:
@@ -417,7 +416,7 @@ func (m *manager) filterAndPutAttemptedAlertsOnChan(op admission.Operation, aler
 
 func (m *manager) putAlertsOnChan(alerts []*storage.Alert) {
 	select {
-	case <-m.stopSig.Done():
+	case <-m.stopper.Flow().StopRequested():
 		return
 	case m.alertsC <- alerts:
 	}

--- a/sensor/admission-control/manager/manager_impl.go
+++ b/sensor/admission-control/manager/manager_impl.go
@@ -163,13 +163,8 @@ func (m *manager) Sync(ctx context.Context) error {
 	}
 }
 
-func (m *manager) Start() error {
-	if m.stopper.LowLevel().ResetStopRequest() {
-		return pkgErr.New("admission control manager has already been started")
-	}
-
+func (m *manager) Start() {
 	go m.run()
-	return nil
 }
 
 func (m *manager) Stop() {

--- a/sensor/admission-control/service/service_test.go
+++ b/sensor/admission-control/service/service_test.go
@@ -36,8 +36,7 @@ func TestExecIntoPodNameEventPolicy(t *testing.T) {
 		managerTesting.TestManagerOptions{Policy: policy},
 	)
 
-	err = mgr.Start()
-	require.NoError(t, err)
+	mgr.Start()
 	defer mgr.Stop()
 
 	const deploymentID = "f3237faf-8350-4c39-b045-ff4c493ddb71"
@@ -108,8 +107,7 @@ func TestLatestTagPolicyAdmissionReview(t *testing.T) {
 		},
 	})
 
-	err = mgr.Start()
-	require.NoError(t, err)
+	mgr.Start()
 	defer mgr.Stop()
 
 	runv1 := serviceTestRun{

--- a/sensor/common/compliance/command_handler.go
+++ b/sensor/common/compliance/command_handler.go
@@ -24,7 +24,6 @@ func NewCommandHandler(complianceService Service) CommandHandler {
 
 		scrapeIDToState: make(map[string]*scrapeState),
 
-		stopC:    concurrency.NewErrorSignal(),
-		stoppedC: concurrency.NewErrorSignal(),
+		stopper: concurrency.NewStopper(),
 	}
 }

--- a/sensor/common/compliance/node_inventory_handler.go
+++ b/sensor/common/compliance/node_inventory_handler.go
@@ -18,8 +18,7 @@ func NewNodeInventoryHandler(ch <-chan *storage.NodeInventory) NodeInventoryHand
 	return &nodeInventoryHandlerImpl{
 		inventories: ch,
 		toCentral:   nil,
-		stopC:       concurrency.NewErrorSignal(),
 		lock:        &sync.Mutex{},
-		stoppedC:    concurrency.NewErrorSignal(),
+		stopper:     concurrency.NewStopper(),
 	}
 }

--- a/sensor/common/component.go
+++ b/sensor/common/component.go
@@ -10,7 +10,7 @@ import (
 // as well as sending messages back to central.
 type SensorComponent interface {
 	Start() error
-	Stop(err error)
+	Stop(err error) // TODO: get rid of err argument as it always seems to be effectively nil.
 	Capabilities() []centralsensor.SensorCapability
 
 	ProcessMessage(msg *central.MsgToSensor) error

--- a/sensor/common/enforcer/enforcer.go
+++ b/sensor/common/enforcer/enforcer.go
@@ -32,16 +32,14 @@ func CreateEnforcer(enforcementMap map[storage.EnforcementAction]EnforceFunc) En
 	return &enforcer{
 		enforcementMap: enforcementMap,
 		actionsC:       make(chan *central.SensorEnforcement, 10),
-		stopC:          concurrency.NewSignal(),
-		stoppedC:       concurrency.NewSignal(),
+		stopper:        concurrency.NewStopper(),
 	}
 }
 
 type enforcer struct {
 	enforcementMap map[storage.EnforcementAction]EnforceFunc
 	actionsC       chan *central.SensorEnforcement
-	stopC          concurrency.Signal
-	stoppedC       concurrency.Signal
+	stopper        concurrency.Stopper
 }
 
 func (e *enforcer) Capabilities() []centralsensor.SensorCapability {
@@ -114,13 +112,13 @@ func (e *enforcer) ProcessMessage(msg *central.MsgToSensor) error {
 	select {
 	case e.actionsC <- enforcement:
 		return nil
-	case <-e.stoppedC.Done():
+	case <-e.stopper.Flow().StopRequested():
 		return errors.Errorf("unable to send enforcement: %s", proto.MarshalTextString(enforcement))
 	}
 }
 
 func (e *enforcer) start() {
-	defer e.stoppedC.Signal()
+	defer e.stopper.Flow().ReportStopped()
 
 	for {
 		select {
@@ -131,12 +129,12 @@ func (e *enforcer) start() {
 				continue
 			}
 
-			if err := f(concurrency.AsContext(&e.stopC), action); err != nil {
+			if err := f(concurrency.AsContext(e.stopper.LowLevel().GetStopRequestSignal()), action); err != nil {
 				log.Errorf("error during enforcement. action: %s err: %v", proto.MarshalTextString(action), err)
 			} else {
 				log.Infof("enforcement successful. action %s", proto.MarshalTextString(action))
 			}
-		case <-e.stopC.Done():
+		case <-e.stopper.Flow().StopRequested():
 			log.Info("Shutting down Enforcer")
 			return
 		}
@@ -149,6 +147,6 @@ func (e *enforcer) Start() error {
 }
 
 func (e *enforcer) Stop(_ error) {
-	e.stopC.Signal()
-	e.stoppedC.Wait()
+	e.stopper.Client().Stop()
+	_ = e.stopper.Client().Stopped().Wait()
 }

--- a/sensor/common/sensor/central_communication.go
+++ b/sensor/common/sensor/central_communication.go
@@ -22,7 +22,6 @@ func NewCentralCommunication(components ...common.SensorComponent) CentralCommun
 		sender:     NewCentralSender(components...),
 		components: components,
 
-		stopC:    concurrency.NewErrorSignal(),
-		stoppedC: concurrency.NewErrorSignal(),
+		stopper: concurrency.NewStopper(),
 	}
 }

--- a/sensor/common/sensor/central_receiver.go
+++ b/sensor/common/sensor/central_receiver.go
@@ -16,9 +16,7 @@ type CentralReceiver interface {
 // NewCentralReceiver returns a new instance of a Receiver.
 func NewCentralReceiver(receivers ...common.SensorComponent) CentralReceiver {
 	return &centralReceiverImpl{
-		stopC:    concurrency.NewErrorSignal(),
-		stoppedC: concurrency.NewErrorSignal(),
-
+		stopper:   concurrency.NewStopper(),
 		receivers: receivers,
 	}
 }

--- a/sensor/common/sensor/central_receiver_impl.go
+++ b/sensor/common/sensor/central_receiver_impl.go
@@ -10,47 +10,45 @@ import (
 
 type centralReceiverImpl struct {
 	receivers []common.SensorComponent
-
-	stopC    concurrency.ErrorSignal
-	stoppedC concurrency.ErrorSignal
+	stopper   concurrency.Stopper
 }
 
 func (s *centralReceiverImpl) Start(stream central.SensorService_CommunicateClient, onStops ...func(error)) {
 	go s.receive(stream, onStops...)
 }
 
-func (s *centralReceiverImpl) Stop(err error) {
-	s.stopC.SignalWithError(err)
+func (s *centralReceiverImpl) Stop(_ error) {
+	s.stopper.Client().Stop()
 }
 
 func (s *centralReceiverImpl) Stopped() concurrency.ReadOnlyErrorSignal {
-	return &s.stoppedC
+	return s.stopper.Client().Stopped()
 }
 
-// Take in data processed by central, run post processing, then send it to the output channel.
+// Take in data processed by central, run post-processing, then send it to the output channel.
 func (s *centralReceiverImpl) receive(stream central.SensorService_CommunicateClient, onStops ...func(error)) {
 	defer func() {
-		s.stoppedC.SignalWithError(s.stopC.Err())
-		runAll(s.stopC.Err(), onStops...)
+		s.stopper.Flow().ReportStopped()
+		runAll(s.stopper.Client().Stopped().Err(), onStops...)
 	}()
 
 	for {
 		select {
-		case <-s.stopC.Done():
+		case <-s.stopper.Flow().StopRequested():
 			return
 
 		case <-stream.Context().Done():
-			s.stopC.SignalWithError(stream.Context().Err())
+			s.stopper.Flow().StopWithError(stream.Context().Err())
 			return
 
 		default:
 			msg, err := stream.Recv()
 			if err == io.EOF {
-				s.stopC.Signal()
+				s.stopper.Flow().StopWithError(nil)
 				return
 			}
 			if err != nil {
-				s.stopC.SignalWithError(err)
+				s.stopper.Flow().StopWithError(err)
 				return
 			}
 			for _, r := range s.receivers {

--- a/sensor/common/sensor/central_sender.go
+++ b/sensor/common/sensor/central_sender.go
@@ -16,9 +16,7 @@ type CentralSender interface {
 // NewCentralSender returns a new instance of a CentralSender.
 func NewCentralSender(senders ...common.SensorComponent) CentralSender {
 	return &centralSenderImpl{
-		stopC:    concurrency.NewErrorSignal(),
-		stoppedC: concurrency.NewErrorSignal(),
-
+		stopper: concurrency.NewStopper(),
 		senders: senders,
 	}
 }


### PR DESCRIPTION
## Description

Refactor existing `Stopper` to be used in all places where we previously had `stopC` and `stoppedC`.
Induced by https://github.com/stackrox/stackrox/pull/3800

Note that I am not trying to fix things in this PR, just reduce the amount of different patterns. Some things look very questionable but I refrain from fixing them in the absence of unit tests.

It is best to review this PR by going through commits. This way the size isn't overwhelming.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added

No need in the following:
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

* Relying on CI.