### PR TITLE
ROX-9115: Add suite/case/config/debug options to e2e test runner

### DIFF
--- a/.openshift-ci/post_tests.py
+++ b/.openshift-ci/post_tests.py
@@ -17,8 +17,7 @@ class PostTestsConstants:
     STORE_TIMEOUT = 5 * 60
     FIXUP_TIMEOUT = 5 * 60
     ARTIFACTS_TIMEOUT = 3 * 60
-    # Where the QA tests store failure logs:
-    # qa-tests-backend/src/main/groovy/common/Constants.groovy
+    # QA_TEST_DEBUG_LOGS - where the QA tests store failure logs.
     QA_TEST_DEBUG_LOGS = os.getenv("QA_TEST_DEBUG_LOGS")
     QA_SPOCK_RESULTS = "qa-tests-backend/build/spock-reports"
     K8S_LOG_DIR = "/tmp/k8s-service-logs"

--- a/.openshift-ci/post_tests.py
+++ b/.openshift-ci/post_tests.py
@@ -19,7 +19,7 @@ class PostTestsConstants:
     ARTIFACTS_TIMEOUT = 3 * 60
     # Where the QA tests store failure logs:
     # qa-tests-backend/src/main/groovy/common/Constants.groovy
-    QA_TEST_DEBUG_LOGS = "/tmp/qa-tests-backend-logs"
+    QA_TEST_DEBUG_LOGS = os.getenv("QA_TEST_DEBUG_LOGS")
     QA_SPOCK_RESULTS = "qa-tests-backend/build/spock-reports"
     K8S_LOG_DIR = "/tmp/k8s-service-logs"
     COLLECTOR_METRICS_DIR = "/tmp/collector-metrics"

--- a/qa-tests-backend/scripts/run-part-1.sh
+++ b/qa-tests-backend/scripts/run-part-1.sh
@@ -20,7 +20,7 @@ test_part_1() {
 }
 
 config_part_1() {
-    info "Configuring the cluster to run part I of e2e tests"
+    info "Configuring the cluster to run part 1 of e2e tests"
 
     require_environment "ORCHESTRATOR_FLAVOR"
     require_environment "KUBECONFIG"

--- a/qa-tests-backend/scripts/run-part-1.sh
+++ b/qa-tests-backend/scripts/run-part-1.sh
@@ -15,6 +15,13 @@ set -euo pipefail
 test_part_1() {
     info "Starting test (qa-tests-backend part I)"
 
+    config_part_1
+    run_tests_part_1
+}
+
+config_part_1() {
+    info "Configuring the cluster to run part I of e2e tests"
+
     require_environment "ORCHESTRATOR_FLAVOR"
     require_environment "KUBECONFIG"
 
@@ -30,8 +37,6 @@ test_part_1() {
     deploy_default_psp
     deploy_webhook_server
     get_ECR_docker_pull_password
-
-    run_tests_part_1
 }
 
 run_tests_part_1() {
@@ -72,4 +77,6 @@ run_tests_part_1() {
     [[ ! -f FAIL ]] || die "Part 1 tests failed"
 }
 
-test_part_1
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    test_part_1 "$*"
+fi

--- a/qa-tests-backend/src/main/groovy/common/Constants.groovy
+++ b/qa-tests-backend/src/main/groovy/common/Constants.groovy
@@ -10,7 +10,6 @@ class Constants {
     static final EMAIL_NOTIFER_SENDER = "${UUID.randomUUID()}@stackrox.com"
     static final EMAIL_NOTIFER_FULL_FROM = "${EMAIL_NOTIFER_FROM} <${EMAIL_NOTIFER_SENDER}>"
     static final EMAIL_NOTIFIER_RECIPIENT = "stackrox.qa@gmail.com"
-    static final FAILURE_DEBUG_DIR = "/tmp/qa-tests-backend-logs"
     static final FAILURE_DEBUG_LIMIT = 10
     static final AUTO_REGISTERED_STACKROX_SCANNER_INTEGRATION = "Stackrox Scanner"
     static final ANY_FIXED_VULN_POLICY = "any-fixed-vulnerabilities"

--- a/qa-tests-backend/src/main/groovy/util/Env.groovy
+++ b/qa-tests-backend/src/main/groovy/util/Env.groovy
@@ -23,8 +23,8 @@ class Env {
     static final IN_CI = (System.getenv("CI") != null)
     static final CI_JOBNAME = System.getenv("CI_JOB_NAME") ?: System.getenv("CIRCLE_JOB") ?: ""
     static final CI_TAG = System.getenv("CIRCLE_TAG")
-    static final GATHER_DEBUG_LOGS = (System.getenv("GATHER_DEBUG_LOGS") == "true")
-    static final QA_TEST_DEBUG_LOGS = System.getenv("QA_TEST_DEBUG_LOGS", "")
+    static final GATHER_QA_TEST_DEBUG_LOGS = (System.getenv("GATHER_QA_TEST_DEBUG_LOGS") == "true")
+    static final QA_TEST_DEBUG_LOGS = System.getenv("QA_TEST_DEBUG_LOGS") ?: ""
 
     private static final Env INSTANCE = new Env()
 

--- a/qa-tests-backend/src/main/groovy/util/Env.groovy
+++ b/qa-tests-backend/src/main/groovy/util/Env.groovy
@@ -24,6 +24,7 @@ class Env {
     static final CI_JOBNAME = System.getenv("CI_JOB_NAME") ?: System.getenv("CIRCLE_JOB") ?: ""
     static final CI_TAG = System.getenv("CIRCLE_TAG")
     static final GATHER_DEBUG_LOGS = (System.getenv("GATHER_DEBUG_LOGS") == "true")
+    static final QA_TEST_DEBUG_LOGS = System.getenv("QA_TEST_DEBUG_LOGS", "")
 
     private static final Env INSTANCE = new Env()
 

--- a/qa-tests-backend/src/main/groovy/util/Env.groovy
+++ b/qa-tests-backend/src/main/groovy/util/Env.groovy
@@ -23,6 +23,7 @@ class Env {
     static final IN_CI = (System.getenv("CI") != null)
     static final CI_JOBNAME = System.getenv("CI_JOB_NAME") ?: System.getenv("CIRCLE_JOB") ?: ""
     static final CI_TAG = System.getenv("CIRCLE_TAG")
+    static final GATHER_DEBUG_LOGS = (System.getenv("GATHER_DEBUG_LOGS") == "true")
 
     private static final Env INSTANCE = new Env()
 

--- a/qa-tests-backend/src/main/groovy/util/Helpers.groovy
+++ b/qa-tests-backend/src/main/groovy/util/Helpers.groovy
@@ -88,8 +88,8 @@ class Helpers {
     }
 
     static void collectDebugForFailure(Throwable exception) {
-        if (!Env.IN_CI && !Env.GATHER_DEBUG_LOGS) {
-            log.info "Won't collect logs without CI=true or GATHER_DEBUG_LOGS=true"
+        if (!Env.IN_CI && !Env.GATHER_QA_TEST_DEBUG_LOGS) {
+            log.info "Won't collect logs without CI=true or GATHER_QA_TEST_DEBUG_LOGS=true"
             return
         }
 
@@ -133,8 +133,8 @@ class Helpers {
 
     // collectImageScanForDebug(image) - a best effort debug tool to get a complete image scan.
     static void collectImageScanForDebug(String image, String saveName) {
-        if (!Env.IN_CI && !Env.GATHER_DEBUG_LOGS) {
-            log.info "Won't collect image scans without CI=true or GATHER_DEBUG_LOGS=true"
+        if (!Env.IN_CI && !Env.GATHER_QA_TEST_DEBUG_LOGS) {
+            log.info "Won't collect image scans without CI=true or GATHER_QA_TEST_DEBUG_LOGS=true"
             return
         }
 

--- a/qa-tests-backend/src/main/groovy/util/Helpers.groovy
+++ b/qa-tests-backend/src/main/groovy/util/Helpers.groovy
@@ -88,7 +88,7 @@ class Helpers {
     }
 
     static void collectDebugForFailure(Throwable exception) {
-        if (collectDebug()) {
+        if (!collectDebug()) {
             return
         }
 
@@ -127,7 +127,7 @@ class Helpers {
 
     // collectImageScanForDebug(image) - a best effort debug tool to get a complete image scan.
     static void collectImageScanForDebug(String image, String saveName) {
-        if (collectDebug()) {
+        if (!collectDebug()) {
             return
         }
 
@@ -162,7 +162,7 @@ class Helpers {
         log.debug "Ran: ${cmd}\nExit: ${proc.exitValue()}\nStdout: $sout\nStderr: $serr"
     }
 
-    private Boolean collectDebug() {
+    private static Boolean collectDebug() {
         if ((Env.IN_CI || Env.GATHER_QA_TEST_DEBUG_LOGS) && (Env.QA_TEST_DEBUG_LOGS != "")) {
             return true
         }

--- a/qa-tests-backend/src/main/groovy/util/Helpers.groovy
+++ b/qa-tests-backend/src/main/groovy/util/Helpers.groovy
@@ -88,13 +88,7 @@ class Helpers {
     }
 
     static void collectDebugForFailure(Throwable exception) {
-        if (!Env.IN_CI && !Env.GATHER_QA_TEST_DEBUG_LOGS) {
-            log.info "Won't collect logs without CI=true or GATHER_QA_TEST_DEBUG_LOGS=true"
-            return
-        }
-
-        if (Env.QA_TEST_DEBUG_LOGS == "") {
-            log.info "Won't collect logs when QA_TEST_DEBUG_LOGS is not set"
+        if (collectDebug()) {
             return
         }
 
@@ -133,13 +127,7 @@ class Helpers {
 
     // collectImageScanForDebug(image) - a best effort debug tool to get a complete image scan.
     static void collectImageScanForDebug(String image, String saveName) {
-        if (!Env.IN_CI && !Env.GATHER_QA_TEST_DEBUG_LOGS) {
-            log.info "Won't collect image scans without CI=true or GATHER_QA_TEST_DEBUG_LOGS=true"
-            return
-        }
-
-        if (Env.QA_TEST_DEBUG_LOGS == "") {
-            log.info "Won't collect image scans when QA_TEST_DEBUG_LOGS is not set"
+        if (collectDebug()) {
             return
         }
 
@@ -172,5 +160,18 @@ class Helpers {
         proc.consumeProcessOutput(sout, serr)
         proc.waitFor()
         log.debug "Ran: ${cmd}\nExit: ${proc.exitValue()}\nStdout: $sout\nStderr: $serr"
+    }
+
+    private Boolean collectDebug() {
+        if ((Env.IN_CI || Env.GATHER_QA_TEST_DEBUG_LOGS) && (Env.QA_TEST_DEBUG_LOGS != "")) {
+            return true
+        }
+
+        log.warn("Debug collection will be skipped. "+
+                 "[CI: ${Env.IN_CI},"+
+                 " GATHER_QA_TEST_DEBUG_LOGS: ${Env.GATHER_QA_TEST_DEBUG_LOGS},"+
+                 " QA_TEST_DEBUG_LOGS: ${Env.QA_TEST_DEBUG_LOGS}]")
+
+        return false
     }
 }

--- a/qa-tests-backend/src/main/groovy/util/Helpers.groovy
+++ b/qa-tests-backend/src/main/groovy/util/Helpers.groovy
@@ -162,7 +162,7 @@ class Helpers {
         log.debug "Ran: ${cmd}\nExit: ${proc.exitValue()}\nStdout: $sout\nStderr: $serr"
     }
 
-    private static Boolean collectDebug() {
+    private static boolean collectDebug() {
         if ((Env.IN_CI || Env.GATHER_QA_TEST_DEBUG_LOGS) && (Env.QA_TEST_DEBUG_LOGS != "")) {
             return true
         }

--- a/qa-tests-backend/src/main/groovy/util/Helpers.groovy
+++ b/qa-tests-backend/src/main/groovy/util/Helpers.groovy
@@ -88,8 +88,8 @@ class Helpers {
     }
 
     static void collectDebugForFailure(Throwable exception) {
-        if (!Env.IN_CI) {
-            log.info "Won't collect logs when not in CI"
+        if (!Env.IN_CI && !Env.GATHER_DEBUG_LOGS) {
+            log.info "Won't collect logs without CI=true or GATHER_DEBUG_LOGS=true"
             return
         }
 

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -340,7 +340,7 @@ remove_existing_stackrox_resources() {
 # identify the source of pull/scheduling latency, request throttling, etc.
 # I tried increasing the timeout from 5m to 20m for OSD but it did not help.
 wait_for_api() {
-    info "Waiting for Central to start"
+    info "Waiting for Central to be ready"
 
     start_time="$(date '+%s')"
     max_seconds=300

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -10,6 +10,8 @@ source "$TEST_ROOT/scripts/lib.sh"
 source "$TEST_ROOT/scripts/ci/lib.sh"
 source "$TEST_ROOT/scripts/ci/test_state.sh"
 
+export QA_TEST_DEBUG_LOGS="/tmp/qa-tests-backend-logs"
+
 deploy_stackrox() {
     deploy_central
 

--- a/tests/e2e/run-e2e-tests.sh
+++ b/tests/e2e/run-e2e-tests.sh
@@ -45,6 +45,7 @@ _EOH_
 
 if [[ ! -f "/i-am-rox-ci-image" ]]; then
     kubeconfig="${KUBECONFIG:-${HOME}/.kube/config}"
+    mkdir -p "${HOME}/.gradle/caches"
     mkdir -p "$QA_TEST_DEBUG_LOGS"
     docker run \
       -v "$ROOT:$ROOT:z" \
@@ -71,7 +72,7 @@ while getopts ":cdyo:m:" option; do
             config_only="true"
             ;;
         d)
-            export GATHER_DEBUG_LOGS="true"
+            export GATHER_QA_TEST_DEBUG_LOGS="true"
             ;;
         o)
             orchestrator="${OPTARG}"

--- a/tests/e2e/run-e2e-tests.sh
+++ b/tests/e2e/run-e2e-tests.sh
@@ -17,7 +17,15 @@ require_environment "QA_TEST_DEBUG_LOGS"
 usage() {
     script=$(basename "$0")
     cat <<_EOH_
-Usage: $script [Options...] [E2e flavor] [Suite] [Case]
+Usage:
+ $script [Options...] [E2e flavor]
+ 
+   Configures the cluster and runs all suites.
+ 
+ $script [Options...] [E2e flavor] Suite [Case]
+ 
+   Expects a previously configured cluster and runs only selected suite/case.
+ 
 
 Options:
   -c - configure the cluster for test but do not run any tests.

--- a/tests/e2e/run-e2e-tests.sh
+++ b/tests/e2e/run-e2e-tests.sh
@@ -37,7 +37,8 @@ $script -c qa
 # cluster).
 $script qa DeploymentTest 'Verify deployment of type Job is deleted once it completes'
 
-# Run the full set of qa-tests-backend/ tests, similar to CI for a PR.
+# Run the full set of qa-tests-backend/ tests. This is similar to what CI runs
+# for a PR.
 $script qa
 _EOH_
     exit 1

--- a/tests/e2e/run-e2e-tests.sh
+++ b/tests/e2e/run-e2e-tests.sh
@@ -14,17 +14,31 @@ source "$ROOT/tests/e2e/lib.sh"
 
 require_environment "QA_TEST_DEBUG_LOGS"
 
-usage() { 
+usage() {
+    script=$(basename "$0")
     cat <<_EOH_
-Usage: $0 [Options...] [E2e flavor] [Suite] [Case]
+Usage: $script [Options...] [E2e flavor] [Suite] [Case]
+
 Options:
   -c - configure the cluster for test but do not run any tests.
   -d - enable debug log gathering to '${QA_TEST_DEBUG_LOGS}'.
   -m - override 'make tag' for the version to install.
   -o - choose the cluster variety. defaults to k8s.
   -y - run without prompts.
+
 E2e flavor:
   one of qa|e2e|ui|upgrade, defaults to qa
+
+Examples:
+# Configure a cluster to run qa-tests-backend/ tests.
+$script -c qa
+
+# Run a single qa-tests-backend/ test case (expects a previously configured
+# cluster).
+$script qa DeploymentTest 'Verify deployment of type Job is deleted once it completes'
+
+# Run the full set of qa-tests-backend/ tests, similar to CI for a PR.
+$script qa
 _EOH_
     exit 1
 }

--- a/tests/e2e/run-e2e-tests.sh
+++ b/tests/e2e/run-e2e-tests.sh
@@ -10,24 +10,35 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd)"
 source "$ROOT/scripts/lib.sh"
 source "$ROOT/scripts/ci/lib.sh"
 source "$ROOT/scripts/ci/gcp.sh"
+source "$ROOT/tests/e2e/lib.sh"
+
+qa_logs="/tmp/qa-tests-backend-logs"
 
 usage() { 
     cat <<_EOH_
-Usage: $0 [-m <tag>] [-o k8s|openshift] [-y] [<e2e flavor: one of qa|e2e|ui|upgrade, defaults to qa>]
+Usage: $0 [Options...] [E2e flavor] [Suite] [Case]
+Options:
+  -c - configure the cluster for test but do not run any tests.
+  -d - enable debug log gathering to '${qa_logs}'.
   -m - override 'make tag' for the version to install.
   -o - choose the cluster variety. defaults to k8s.
   -y - run without prompts.
+E2e flavor:
+  one of qa|e2e|ui|upgrade, defaults to qa
 _EOH_
     exit 1
 }
 
 if [[ ! -f "/i-am-rox-ci-image" ]]; then
     kubeconfig="${KUBECONFIG:-${HOME}/.kube/config}"
+    mkdir -p "$qa_logs"
     docker run \
       -v "$ROOT:$ROOT:z" \
       -w "$ROOT" \
       -e "KUBECONFIG=${kubeconfig}" \
       -v "${kubeconfig}:${kubeconfig}:z" \
+      -v "${HOME}/.gradle/caches:/root/.gradle/caches:z" \
+      -v "${qa_logs}:${qa_logs}:z" \
       -e VAULT_TOKEN \
       --platform linux/amd64 \
       --rm -it \
@@ -36,11 +47,18 @@ if [[ ! -f "/i-am-rox-ci-image" ]]; then
     exit 0
 fi
 
+config_only="false"
 orchestrator="k8s"
 prompt="true"
 
-while getopts ":yo:m:" option; do
+while getopts ":cdyo:m:" option; do
     case "$option" in
+        c)
+            config_only="true"
+            ;;
+        d)
+            export GATHER_DEBUG_LOGS="true"
+            ;;
         o)
             orchestrator="${OPTARG}"
             ;;
@@ -73,6 +91,9 @@ case "$orchestrator" in
         usage
         ;;
 esac
+
+suite="${2:-}"
+case="${3:-}"
 
 cd "$ROOT"
 
@@ -156,4 +177,26 @@ export ORCHESTRATOR_FLAVOR="$orchestrator"
 # required to get a running central
 export ROX_POSTGRES_DATASTORE="${ROX_POSTGRES_DATASTORE:-false}"
 
-"$ROOT/qa-tests-backend/scripts/run-part-1.sh" 2>&1 | sed -e 's/^/test output: /'
+if [[ -z "$suite" && -z "$case" ]]; then
+    if [[ "${config_only}" == "false" ]]; then
+        "$ROOT/qa-tests-backend/scripts/run-part-1.sh" 2>&1 | sed -e 's/^/test output: /'
+    else
+        source "$ROOT/qa-tests-backend/scripts/run-part-1.sh"
+        config_part_1 2>&1 | sed -e 's/^/config output: /'
+    fi
+else
+    export_test_environment
+    setup_deployment_env false false
+    export CLUSTER="${ORCHESTRATOR_FLAVOR^^}"
+    wait_for_api
+    export DEPLOY_DIR="$ROOT/deploy/${ORCHESTRATOR_FLAVOR}"
+    get_central_basic_auth_creds
+
+    pushd qa-tests-backend
+    if [[ -z "$case" ]]; then
+        ./gradlew test --console=plain --tests="$suite"
+    else
+        ./gradlew test --console=plain --tests="$suite.$case"
+    fi
+    popd
+fi


### PR DESCRIPTION
## Description

Continues from #3888 to:
- Allow `qa-tests-backend/` tests to run just for a suite or suite and case.
- Run just the 'configuration' steps for `qa-tests-backend/` i.e. setup and deployment.
- Support post test failure debug gathering.
- Examples.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI+:
- [x] openshift and upgrade test for `QA_TEST_DEBUG_LOGS` env var dependency coverage

Manual:
- [x] debug is gathered when a test fails with `-d`
- [x] logs still gathered on failure in CI