### PR TITLE
ROX-13644 enable fake k8s client in sensor integration tests

### DIFF
--- a/sensor/tests/resource/pod/pod_test.go
+++ b/sensor/tests/resource/pod/pod_test.go
@@ -13,7 +13,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	"sigs.k8s.io/e2e-framework/klient/k8s"
 	"sigs.k8s.io/e2e-framework/klient/wait"
-	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
 )
 
 var (
@@ -77,7 +76,7 @@ func (s *PodHierarchySuite) Test_ContainerSpecOnDeployment() {
 		NginxDeployment,
 	}, func(t *testing.T, testC *resource.TestContext, objects map[string]k8s.Object) {
 		// wait until pods are created
-		err := wait.For(conditions.New(testC.Resources()).ResourceMatch(objects[NginxDeployment.File], func(object k8s.Object) bool {
+		err := wait.For(resource.WaitForResourceMatchFunc(testC.Resources())(objects[NginxDeployment.File], func(object k8s.Object) bool {
 			d := object.(*appsv1.Deployment)
 			return d.Status.AvailableReplicas == 3 && d.Status.ReadyReplicas == 3
 		}), wait.WithTimeout(time.Second*10))
@@ -100,7 +99,7 @@ func (s *PodHierarchySuite) Test_ParentlessPodsAreTreatedAsDeployments() {
 		NginxPod,
 	}, func(t *testing.T, testC *resource.TestContext, objects map[string]k8s.Object) {
 		// wait until pods are created
-		err := wait.For(conditions.New(testC.Resources()).ResourceMatch(objects[NginxDeployment.File], func(object k8s.Object) bool {
+		err := wait.For(resource.WaitForResourceMatchFunc(testC.Resources())(objects[NginxDeployment.File], func(object k8s.Object) bool {
 			d := object.(*appsv1.Deployment)
 			return d.Status.AvailableReplicas == 3 && d.Status.ReadyReplicas == 3
 		}), wait.WithTimeout(time.Second*10))

--- a/sensor/tests/resource/service/service_test.go
+++ b/sensor/tests/resource/service/service_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/utils"
+	k8s2 "github.com/stackrox/rox/sensor/debugger/k8s"
 	"github.com/stackrox/rox/sensor/tests/resource"
 	"github.com/stackrox/rox/sensor/testutils"
 	"github.com/stretchr/testify/require"
@@ -117,8 +118,6 @@ type DeploymentExposureSuite struct {
 }
 
 func Test_DeploymentExposure(t *testing.T) {
-	// TODO(ROX-13644): reenable the test
-	t.Skip("Disabling these tests until we refactor the helper.go to enable fake k8s clients (ROX-13644)")
 	suite.Run(t, new(DeploymentExposureSuite))
 }
 
@@ -135,8 +134,9 @@ func (s *DeploymentExposureSuite) SetupSuite() {
 	if err != nil {
 		log.Fatalln(err)
 	}
-	config := resource.CentralConfig{
+	config := resource.ContextConfig{
 		InitialSystemPolicies: policies,
+		FakeK8sClient:         k8s2.MakeFakeClient(),
 	}
 	if testContext, err := resource.NewContextWithConfig(s.T(), config); err != nil {
 		s.Fail("failed to setup test context: %s", err)


### PR DESCRIPTION
## Description

This PR enables the `TestContext` used in sensor's integration tests to use a fake k8s client.

The PR also reenables the `DeploymentExposure` tests that now use this fake client. By changing this, the flake [ROX-12948](https://issues.redhat.com/browse/ROX-12948) should be fixed.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

* [ ] Five consecutive successful runs in CI
* [x] Manual testing with `make sensor-integration-test`
