### PR TITLE
ROX-9115: E2e test runner for non groovy tests

### DIFF
--- a/tests/e2e/run-e2e-tests.sh
+++ b/tests/e2e/run-e2e-tests.sh
@@ -158,7 +158,7 @@ _EODIRTY_
         cat <<_EOVERSION_
 ERROR: main and roxctl versions do not match. main: ${main_version} != roxctl: ${roxctl_version}.
 They are required to match for the ./deploy scripts to run without docker.
-Run 'make cli' to get matching versions.
+Run 'make cli-linux' to get matching versions.
 _EOVERSION_
         exit 1
     fi

--- a/tests/e2e/run-e2e-tests.sh
+++ b/tests/e2e/run-e2e-tests.sh
@@ -51,8 +51,12 @@ $script -c qa
 $script qa DeploymentTest 'Verify deployment of type Job is deleted once it completes'
 
 # Run the full set of qa-tests-backend/ tests. This is similar to what CI runs
-# for a PR.
+# for a PR as *-qa-e2e-tests.
 $script qa
+
+# Run the full set of tests/ e2e tests. This is similar to what CI runs
+# for a PR as *-nongroovy-e2e-tests.
+$script e2e
 _EOH_
     exit 1
 }

--- a/tests/e2e/run-e2e-tests.sh
+++ b/tests/e2e/run-e2e-tests.sh
@@ -51,7 +51,11 @@ $script -c qa
 $script qa DeploymentTest 'Verify deployment of type Job is deleted once it completes'
 
 # Run the full set of qa-tests-backend/ tests. This is similar to what CI runs
-# for a PR.
+# for *-qa-e2e-tests jobs on a PR.
+$script qa
+
+# Run the full set of 'non groovy' e2e tests. This is similar to what CI runs
+# for *-nongroovy-e2e-tests jobs on a PR.
 $script qa
 _EOH_
     exit 1

--- a/tests/e2e/run-e2e-tests.sh
+++ b/tests/e2e/run-e2e-tests.sh
@@ -186,8 +186,6 @@ _EOVAULTHELP_
         fi
     fi
 
-    check_rhacs_eng_image_exists "main" "$main_version"
-
     context="$(kubectl config current-context)"
     echo "This script will tear down resources, install ACS and run tests against '$context'."
 
@@ -205,6 +203,8 @@ _EOVAULTHELP_
 
     eval "$(vault kv get -format=json kv/selfservice/stackrox-stackrox-e2e-tests/credentials \
     | jq -r '.data.data | to_entries[] | select( .key|test("^[A-Z]") ) | "export \(.key|@sh)=\(.value|@sh)"')"
+
+    check_rhacs_eng_image_exists "main" "$main_version"
 
     # GCP login using the CI service account is required to access infra GKE clusters.
     setup_gcp

--- a/tests/e2e/run-e2e-tests.sh
+++ b/tests/e2e/run-e2e-tests.sh
@@ -204,7 +204,9 @@ _EOVAULTHELP_
     eval "$(vault kv get -format=json kv/selfservice/stackrox-stackrox-e2e-tests/credentials \
     | jq -r '.data.data | to_entries[] | select( .key|test("^[A-Z]") ) | "export \(.key|@sh)=\(.value|@sh)"')"
 
-    check_rhacs_eng_image_exists "main" "$main_version"
+    if ! check_rhacs_eng_image_exists "main" "$main_version"; then
+        die "ERROR: The main image is not present"
+    fi
 
     # GCP login using the CI service account is required to access infra GKE clusters.
     setup_gcp

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -74,36 +74,17 @@ test_e2e() {
 test_preamble() {
     require_executable "roxctl"
 
-    if ! is_CI; then
-        require_environment "MAIN_IMAGE_TAG" "This is typically the output from 'make tag'"
-
-        if [[ "$(roxctl version)" != "$MAIN_IMAGE_TAG" ]]; then
-            die "There is a version mismatch between roxctl and MAIN_IMAGE_TAG. A version mismatch can cause the deployment script to use a container roxctl which can have issues in dev environments."
-        fi
-        pwds="$(pgrep -f 'port-forward' -c || true)"
-        if [[ "$pwds" -gt 5 ]]; then
-            die "There are many port-fowards probably left over from a previous run of this test."
-        fi
-        cleanup_proxy_tests
-        export MAIN_TAG="$MAIN_IMAGE_TAG"
-    else
-        MAIN_TAG=$(make --quiet tag)
-        export MAIN_TAG
-    fi
+    MAIN_TAG=$(make --quiet tag)
+    export MAIN_TAG
 
     export ROX_PLAINTEXT_ENDPOINTS="8080,grpc@8081"
     export ROXDEPLOY_CONFIG_FILE_MAP="$ROOT/scripts/ci/endpoints/endpoints.yaml"
     
-    QUAY_REPO="rhacs-eng"
-    if is_CI; then
-        REGISTRY="quay.io/$QUAY_REPO"
-    else
-        REGISTRY="stackrox"
-    fi
+    local registry="quay.io/rhacs-eng"
 
-    SCANNER_IMAGE="$REGISTRY/scanner:$(cat "$ROOT"/SCANNER_VERSION)"
+    SCANNER_IMAGE="$registry/scanner:$(cat "$ROOT"/SCANNER_VERSION)"
     export SCANNER_IMAGE
-    SCANNER_DB_IMAGE="$REGISTRY/scanner-db:$(cat "$ROOT"/SCANNER_VERSION)"
+    SCANNER_DB_IMAGE="$registry/scanner-db:$(cat "$ROOT"/SCANNER_VERSION)"
     export SCANNER_DB_IMAGE
 
     export TRUSTED_CA_FILE="$ROOT/tests/bad-ca/untrusted-root-badssl-com.pem"

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -31,6 +31,8 @@ test_e2e() {
 
     deploy_stackrox
 
+    rm -f FAIL
+
     prepare_for_endpoints_test
 
     run_roxctl_tests


### PR DESCRIPTION
## Description

Per title, this adds support for running 'non groovy' e2e tests outside of CI.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

Manually ran without error.