### PR TITLE
Reuse NetworkEndpoint in "processes listening on ports" user-facing API

### DIFF
--- a/proto/api/v1/network_listening_endpoint_service.proto
+++ b/proto/api/v1/network_listening_endpoint_service.proto
@@ -1,0 +1,38 @@
+syntax = "proto3";
+
+option go_package = "v1";
+option java_package = "io.stackrox.proto.api.v1";
+
+import weak "google/api/annotations.proto";
+import "storage/network_flow.proto";
+
+package v1;
+
+message GetNetworkListeningEndpointsByNamespaceRequest {
+    string namespace = 1;
+}
+
+message GetNetworkListeningEndpointsByNamespaceAndDeploymentRequest {
+    string namespace = 1;
+    string deployment_id = 2;
+}
+
+message GetNetworkListeningEndpointsResponse {
+    repeated storage.NetworkEndpoint listening_endpoints = 1;
+}
+
+service NetworkListeningEndpointService {
+
+    rpc GetByNamespace (GetNetworkListeningEndpointsByNamespaceRequest) returns (GetNetworkListeningEndpointsResponse) {
+        option (google.api.http) = {
+            get: "/v1/networkendpoint/namespace/{namespace}"
+        };
+    }
+
+    rpc GetByNamespaceAndDeployment (GetNetworkListeningEndpointsByNamespaceAndDeploymentRequest) returns (GetNetworkListeningEndpointsResponse) {
+        option (google.api.http) = {
+            get: "/v1/networkendpoint/namespace/{namespace}/deployment/{deployment_id}"
+        };
+    }
+
+}

--- a/proto/storage/network_flow.proto
+++ b/proto/storage/network_flow.proto
@@ -83,12 +83,17 @@ message NetworkEntityInfo {
         bool       default  = 3 [(gogoproto.moretags) = 'search:"Default External Source,hidden"'];
     }
 
+    message ListenEndpoint {
+        ProcessIndicator originator = 1;
+    }
+
     Type               type            = 1 [(gogoproto.moretags) = 'sql:"index"'];
     string             id              = 2 [(gogoproto.moretags) = 'sql:"pk"'];
 
     oneof desc {
         Deployment     deployment      = 3;
         ExternalSource external_source = 4;
+        ListenEndpoint listen_endpoint = 5;
     }
 }
 


### PR DESCRIPTION
This is an attempt to use the NetworkEndpoint object from network-flow to report processes listening on ports through the customer API. This is achieved by enriching the NetworkEntityInfo with originator process information (in the form of ProcessIndicator).
The user API would return a list of NetworkEndpoint objects.