### PR TITLE
ROX-13223: Cherry pick fix for CVE list update (#3596)

### DIFF
--- a/central/cve/converter/utils/convert_utils.go
+++ b/central/cve/converter/utils/convert_utils.go
@@ -76,7 +76,7 @@ func NvdCVEToEmbeddedCVE(nvdCVE *schema.NVDCVEFeedJSON10DefCVEItem, ct CVEType) 
 		return nil, errors.Errorf("unknown CVE type: %d", ct)
 	}
 
-	if nvdCVE.Impact != nil {
+	if nvdCVE.Impact != nil && nvdCVE.Impact.BaseMetricV2 != nil {
 		cvssv2, err := nvdCvssv2ToProtoCvssv2(nvdCVE.Impact.BaseMetricV2)
 		if err != nil {
 			return nil, err
@@ -84,7 +84,9 @@ func NvdCVEToEmbeddedCVE(nvdCVE *schema.NVDCVEFeedJSON10DefCVEItem, ct CVEType) 
 		cve.CvssV2 = cvssv2
 		cve.Cvss = cvssv2.Score
 		cve.ScoreVersion = storage.EmbeddedVulnerability_V2
+	}
 
+	if nvdCVE.Impact != nil && nvdCVE.Impact.BaseMetricV3 != nil {
 		cvssv3, err := nvdCvssv3ToProtoCvssv3(nvdCVE.Impact.BaseMetricV3)
 		if err != nil {
 			return nil, err

--- a/central/cve/fetcher/fetch_utils.go
+++ b/central/cve/fetcher/fetch_utils.go
@@ -19,10 +19,10 @@ import (
 const (
 	fetchDelay            = 2 * time.Hour
 	preloadedCVEsBasePath = "/stackrox/static-data"
-	k8sCVEsURL            = "https://definitions.stackrox.io/cve/k8s/cve-list.json"
-	k8sCVEsChecksumURL    = "https://definitions.stackrox.io/cve/k8s/checksum"
-	istioCVEsURL          = "https://definitions.stackrox.io/cve/istio/cve-list.json"
-	istioCVEsChecksumURL  = "https://definitions.stackrox.io/cve/istio/checksum"
+	k8sCVEsURL            = "https://definitions.stackrox.io/cve2/k8s/cve-list.json"
+	k8sCVEsChecksumURL    = "https://definitions.stackrox.io/cve2/k8s/checksum"
+	istioCVEsURL          = "https://definitions.stackrox.io/cve2/istio/cve-list.json"
+	istioCVEsChecksumURL  = "https://definitions.stackrox.io/cve2/istio/checksum"
 	commonCveDir          = "cve"
 	k8sCVEsDir            = "k8s"
 	istioCVEsDir          = "istio"

--- a/image/fetch-stackrox-data.sh
+++ b/image/fetch-stackrox-data.sh
@@ -6,8 +6,8 @@ set -euo pipefail
 
 fetch_stackrox_data() {
     mkdir -p /stackrox-data/cve/istio
-    wget -O /stackrox-data/cve/istio/checksum "https://definitions.stackrox.io/cve/istio/checksum"
-    wget -O /stackrox-data/cve/istio/cve-list.json "https://definitions.stackrox.io/cve/istio/cve-list.json"
+    wget -O /stackrox-data/cve/istio/checksum "https://definitions.stackrox.io/cve2/istio/checksum"
+    wget -O /stackrox-data/cve/istio/cve-list.json "https://definitions.stackrox.io/cve2/istio/cve-list.json"
 
     mkdir -p /tmp/external-networks
     local latest_prefix


### PR DESCRIPTION
## Description

(cherry picked from commit 1e39f5a2f2d7d7c95b991ee63d8b1c911439bd1d)

This PR provides a fix for the issue with problematic CVE list files.

We have cherry-picked two commits:
- the first commit fixes nil checks for missing "Version 2" properties in JSON
- the second one switches the URL to files that will omit "Version 2" properties in JSON

More info about the problem and decisions on how to solve it can be found in the documents attached to the ticket.

## Checklist

TBD

## Testing Performed

TBD
