### PR TITLE
 ROX-13704: Fix pagination for queries with Policy Violated search term

### DIFF
--- a/central/graphql/resolvers/policies.go
+++ b/central/graphql/resolvers/policies.go
@@ -344,18 +344,20 @@ func (resolver *policyResolver) UnusedVarSink(ctx context.Context, args RawQuery
 }
 
 func inverseFilterFailingDeploymentsQuery(q *v1.Query) (*v1.Query, bool) {
-	failingDeploymentsQuery := false
+	isFailingDeploymentsQuery := false
 	local := q.Clone()
 	filtered, _ := search.FilterQuery(local, func(bq *v1.BaseQuery) bool {
 		matchFieldQuery, ok := bq.GetQuery().(*v1.BaseQuery_MatchFieldQuery)
 		if ok {
 			if matchFieldQuery.MatchFieldQuery.GetField() == search.PolicyViolated.String() {
-				failingDeploymentsQuery = true
+				isFailingDeploymentsQuery = true
 				return false
 			}
 		}
 		return true
 	})
-
-	return filtered, failingDeploymentsQuery
+	if filtered != nil {
+		filtered.Pagination = q.Pagination
+	}
+	return filtered, isFailingDeploymentsQuery
 }


### PR DESCRIPTION
## Description
Preserve the original query pagination in the filtered query when policy violated is a search term.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed
Manual at cluster, thanks @dvail !