### PR TITLE
ROX-9115: E2e test runner for upgrade tests

### DIFF
--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -1391,7 +1391,7 @@ save_junit_success() {
         die "missing args. usage: save_junit_success <class> <description>"
     fi
 
-    if [[ -z "${ARTIFACT_DIR}" ]]; then
+    if [[ -z "${ARTIFACT_DIR:-}" ]]; then
         info "Warning: save_junit_success() requires the \$ARTIFACT_DIR variable to be set"
         return
     fi
@@ -1412,7 +1412,7 @@ save_junit_failure() {
         die "missing args. usage: save_junit_failure <class> <description> <details>"
     fi
 
-    if [[ -z "${ARTIFACT_DIR}" ]]; then
+    if [[ -z "${ARTIFACT_DIR:-}" ]]; then
         info "Warning: save_junit_failure() requires an ARTIFACT_DIR"
         return
     fi

--- a/tests/e2e/run-e2e-tests-README.md
+++ b/tests/e2e/run-e2e-tests-README.md
@@ -1,0 +1,74 @@
+# A local test runner for various E2E tests
+
+`run-e2e-tests.sh` aims to provide a secure and accessible method for running
+E2E tests that typically are only supported in CI. It does this by importing
+test credentials from hashicorp vault and using the same test container that CI
+uses. This should facilitate a test development workflow where the overhead to
+making changes to test code and verifying them is minimal. 
+
+## The Tested Image Version
+
+By default this test runner emulates CI and relies on the output of `make tag`
+to determin which images are deployed via `deploy/` scripts. When local changes
+are made this tag goes `-dirty` and that suffix is dropped to facilitate local
+changes to tests without the need to build and push `-dirty` images. In order to
+satisfy the tight coupling between the `deploy/` scripts and roxctl version, a
+matching `roxctl` is pulled from the public image and supplied to the test
+container as `/usr/local/bin/roxctl`.
+
+A `-t` flag can be used to set a particular version and override the default
+behaviour of `make tag`.
+
+## Vault Access
+
+There are a number of required steps to get access to vault:
+
+1. Log in to the secrets collection manager at
+https://selfservice.vault.ci.openshift.org/secretcollection?ui=true (This is a
+Red Hat-ism and will require SSO)
+2. Ask a team member to add you to the collections required for this test:
+stackrox-stackrox-initial and stackrox-stackrox-e2e-tests.
+3. Login to the vault at: https://vault.ci.openshift.org/ui/vault/secrets (Use
+*OIDC*) You should see these secret collections under kv/
+4. Copy a 'token' from that UI and enter it at the prompt when running the
+`run-e2e-tests.sh` script. (You can skip the prompt by setting this to a
+VAULT_TOKEN environment variable)
+
+The 'token' will expire hourly and you will need to renew it through the vault UI.
+
+## Usage
+
+For basic usage see `run-e2e-tests.sh -h`
+
+### qa-tests-backend/ tests - 'qa' flavor
+
+Configure only:
+```
+# Just configure the cluster in the current environment so it can run these tests:
+run-e2e-tests.sh -c qa
+```
+
+A single suite:
+```
+# Run DeploymentTest.groovy suite:
+run-e2e-tests.sh -d qa DeploymentTest
+```
+
+`-d`? Collects debug for failing tests under `/tmp/qa-tests-backend-logs/`
+similar to how CI tests operate.
+
+Test everything (_actually just BAT_)
+```
+run-e2e-tests.sh -d qa
+```
+
+### Non groovy tests - 'e2e' flavor
+
+Run everything just like CI:
+```
+run-e2e-tests.sh -d e2e
+```
+
+TBD - split configuration from test. separate the various test facets (roxctl,
+integration, destructive, etc)
+

--- a/tests/e2e/run-e2e-tests.sh
+++ b/tests/e2e/run-e2e-tests.sh
@@ -41,7 +41,7 @@ Options:
   -h - show this help.
 
 E2e flavor:
-  one of qa|e2e|upgrade, defaults to qa
+  one of qa|e2e, defaults to qa
 
 Examples:
 # Configure a cluster to run qa-tests-backend/ tests.
@@ -59,8 +59,7 @@ $script qa
 # for *-nongroovy-e2e-tests jobs on a PR.
 $script e2e
 
-# Run the upgrade test.
-$script upgrade
+See tests/e2e/run-e2e-tests-README.md for more details.
 _EOH_
     exit 1
 }
@@ -161,7 +160,7 @@ main() {
 
     flavor="${1:-qa}"
     case "$flavor" in
-        qa|e2e|upgrade)
+        qa|e2e)
             ;;
         *)
             die "flavor $flavor not supported"
@@ -262,9 +261,6 @@ _EOVAULTHELP_
         e2e)
             run_e2e_flavor
             ;;
-        upgrade)
-            run_upgrade_flavor
-            ;;
         *)
             die "flavor $flavor not supported"
             ;;
@@ -300,10 +296,6 @@ run_qa_flavor() {
 
 run_e2e_flavor() {
     "$ROOT/tests/e2e/run.sh" 2>&1 | sed -e 's/^/test output: /'
-}
-
-run_upgrade_flavor() {
-    "$ROOT/tests/upgrade/run.sh" 2>&1 | sed -e 's/^/test output: /'
 }
 
 main "$@"

--- a/tests/e2e/run-e2e-tests.sh
+++ b/tests/e2e/run-e2e-tests.sh
@@ -211,7 +211,7 @@ There are a number of required steps to get access to vault:
 2. Ask a team member to add you to the collections required for this test:
 stackrox-stackrox-initial and stackrox-stackrox-e2e-tests.
 3. Login to the vault at: https://vault.ci.openshift.org/ui/vault/secrets (Use *OIDC*)
-You should see these secrets under kv/
+You should see these secret collections under kv/
 4. Copy a 'token' from that UI and rerun this script.
 The 'token' will expire hourly and you will need to renew it through the vault UI.
 _EOVAULTHELP_

--- a/tests/e2e/run-e2e-tests.sh
+++ b/tests/e2e/run-e2e-tests.sh
@@ -303,6 +303,7 @@ run_e2e_flavor() {
 }
 
 run_upgrade_flavor() {
+    make upgrader
     "$ROOT/tests/upgrade/run.sh" 2>&1 | sed -e 's/^/test output: /'
 }
 

--- a/tests/e2e/run-e2e-tests.sh
+++ b/tests/e2e/run-e2e-tests.sh
@@ -41,7 +41,7 @@ Options:
   -h - show this help.
 
 E2e flavor:
-  one of qa|e2e|ui|upgrade, defaults to qa
+  one of qa|e2e|upgrade, defaults to qa
 
 Examples:
 # Configure a cluster to run qa-tests-backend/ tests.
@@ -161,7 +161,7 @@ main() {
 
     flavor="${1:-qa}"
     case "$flavor" in
-        qa|e2e)
+        qa|e2e|upgrade)
             ;;
         *)
             die "flavor $flavor not supported"
@@ -181,9 +181,9 @@ main() {
 
     cd "$ROOT"
 
-    if [[ "$flavor" == "e2e" ]]; then
+    if [[ "$flavor" != "qa" ]]; then
         if [[ -n "${suite}" || -n "${case}" ]]; then
-            die "ERROR: Suite and Case are not supported with e2e flavor"
+            die "ERROR: Suite and Case are only supported with qa flavor"
         fi
     fi
 
@@ -262,6 +262,9 @@ _EOVAULTHELP_
         e2e)
             run_e2e_flavor
             ;;
+        upgrade)
+            run_upgrade_flavor
+            ;;
         *)
             die "flavor $flavor not supported"
             ;;
@@ -297,6 +300,10 @@ run_qa_flavor() {
 
 run_e2e_flavor() {
     "$ROOT/tests/e2e/run.sh" 2>&1 | sed -e 's/^/test output: /'
+}
+
+run_upgrade_flavor() {
+    "$ROOT/tests/upgrade/run.sh" 2>&1 | sed -e 's/^/test output: /'
 }
 
 main "$@"

--- a/tests/e2e/run-e2e-tests.sh
+++ b/tests/e2e/run-e2e-tests.sh
@@ -58,6 +58,9 @@ $script qa
 # Run the full set of 'non groovy' e2e tests. This is similar to what CI runs
 # for *-nongroovy-e2e-tests jobs on a PR.
 $script e2e
+
+# Run the upgrade test.
+$script upgrade
 _EOH_
     exit 1
 }

--- a/tests/e2e/run-e2e-tests.sh
+++ b/tests/e2e/run-e2e-tests.sh
@@ -303,7 +303,6 @@ run_e2e_flavor() {
 }
 
 run_upgrade_flavor() {
-    make upgrader
     "$ROOT/tests/upgrade/run.sh" 2>&1 | sed -e 's/^/test output: /'
 }
 

--- a/tests/upgrade/run.sh
+++ b/tests/upgrade/run.sh
@@ -29,20 +29,13 @@ test_upgrade() {
 
     REPO_FOR_TIME_TRAVEL="/tmp/rox-upgrade-test"
     DEPLOY_DIR="deploy/k8s"
-    QUAY_REPO="rhacs-eng"
-    if is_CI; then
-        REGISTRY="quay.io/$QUAY_REPO"
-    else
-        REGISTRY="stackrox"
-    fi
+    REGISTRY="quay.io/rhacs-eng"
 
     export OUTPUT_FORMAT="helm"
     export STORAGE="pvc"
     export CLUSTER_TYPE_FOR_TEST=K8S
 
-    if is_CI; then
-        export ROXCTL_IMAGE_REPO="quay.io/$QUAY_REPO/roxctl"
-    fi
+    export ROXCTL_IMAGE_REPO="$REGISTRY/roxctl"
 
     preamble
     setup_deployment_env false false


### PR DESCRIPTION
## Description

Enables execution of the upgrade test through `run-e2e-tests.sh`. Adds more detailed docs.

Full disclosure: the test does not completely run. `bin/upgrader` panics with:
```
```

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

CI+upgrade tests.