### PR TITLE
Add team to image vuln slack message

### DIFF
--- a/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
@@ -362,7 +362,7 @@ class DefaultPoliciesTest extends BaseSpecification {
     }
 
     String team(String img) {
-        if (img.contains('canner')) {
+        if (img.contains('scanner')) {
             return '@acs-scanner-team'
         }
         if (img.contains('collector')) {

--- a/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
@@ -347,7 +347,7 @@ class DefaultPoliciesTest extends BaseSpecification {
         }
 
         imageFixableVulnMap.each { k, v ->
-            slackPayload += "\n${k}: ${v}"
+            slackPayload += "\n${k}: ${v} ${team(k)}"
         }
         SlackUtil.sendMessage(slackPayload)
 
@@ -359,6 +359,19 @@ class DefaultPoliciesTest extends BaseSpecification {
 
         then:
         assert !hadGetErrors
+    }
+
+    String team(String img) {
+        if (img.contains("scanner")) {
+            return "@acs-scanner-team"
+        }
+        if (img.contains("collector")) {
+            return "@collector-team"
+        }
+        if (img.contains("roxctl")) {
+            return "@merlin-team"
+        }
+        return "@support-oncall-eng"
     }
 
     @Unroll

--- a/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
@@ -362,16 +362,13 @@ class DefaultPoliciesTest extends BaseSpecification {
     }
 
     String team(String img) {
-        if (img.contains("scanner")) {
-            return "@acs-scanner-team"
+        if (img.contains('canner')) {
+            return '@acs-scanner-team'
         }
-        if (img.contains("collector")) {
-            return "@collector-team"
+        if (img.contains('collector')) {
+            return '@collector-team'
         }
-        if (img.contains("roxctl")) {
-            return "@merlin-team"
-        }
-        return "@support-oncall-eng"
+        return img.contains('roxctl') ? '@merlin-team' : '@support-oncall-eng'
     }
 
     @Unroll


### PR DESCRIPTION
## Description

Notify responsible team about found vulnerabilities in image.

## Testing Performed

Nightly CI must run on this as this runs only for tagged commits. 