### PR TITLE
Start a pprof server for realtime metric observation

### DIFF
--- a/tools/local-sensor/main.go
+++ b/tools/local-sensor/main.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	_ "net/http/pprof" // #nosec G108
 	"os"
 	"os/signal"
 	"path"
@@ -33,8 +34,6 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/test/bufconn"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
-
-	_ "net/http/pprof"
 )
 
 // local-sensor is an application that allows you to run sensor in your host machine, while mocking a


### PR DESCRIPTION
## Description

Other than outputting the pprof metric bundle to files, we could provide an http pprof server for realtime observations. This also allows to explore other pprof metrics that are not exported now, like `goroutines` and `mutext`. 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Example:
```
go tool pprof -http localhost:9090 http://localhost:6060/debug/pprof/goroutine
```
