### PR TITLE
Add Cypress tests for collection CRUD operations

### DIFF
--- a/ui/apps/platform/cypress/constants/apiEndpoints.js
+++ b/ui/apps/platform/cypress/constants/apiEndpoints.js
@@ -182,10 +182,3 @@ export const extensions = {
 export const permissions = {
     mypermissions: '/v1/mypermissions',
 };
-
-export const collections = {
-    baseUrl: '/v1/collections',
-    count: '/v1/collectionscount',
-    dryRun: '/v1/collections/dryrun',
-    autocomplete: '/v1/collections/autocomplete',
-};

--- a/ui/apps/platform/cypress/constants/apiEndpoints.js
+++ b/ui/apps/platform/cypress/constants/apiEndpoints.js
@@ -182,3 +182,10 @@ export const extensions = {
 export const permissions = {
     mypermissions: '/v1/mypermissions',
 };
+
+export const collections = {
+    baseUrl: '/v1/collections',
+    count: '/v1/collectionscount',
+    dryRun: '/v1/collections/dryrun',
+    autocomplete: '/v1/collections/autocomplete',
+};

--- a/ui/apps/platform/cypress/integration/collections/collectionsCrudWorkflow.test.js
+++ b/ui/apps/platform/cypress/integration/collections/collectionsCrudWorkflow.test.js
@@ -8,13 +8,14 @@ function tryDeleteCollection(collectionName) {
     const auth = { bearer: Cypress.env('ROX_AUTH_TOKEN') };
 
     cy.request({
-        url: `${collectionsApi.baseUrl}?query.query=Collection Name:${collectionName}`,
+        url: `${collectionsApi.baseUrl}?query.query=Collection Name:"${collectionName}"`,
         auth,
     }).as('listCollections');
 
     cy.get('@listCollections').then((res) => {
-        if (res.body.collections.length > 0) {
-            const { id } = res.body.collections[0];
+        const collection = res.body.collections.find(({ name }) => name === collectionName);
+        if (collection) {
+            const { id } = collection;
             const url = `${collectionsApi.baseUrl}/${id}`;
             cy.request({ url, auth, method: 'DELETE' });
         }

--- a/ui/apps/platform/cypress/integration/collections/collectionsCrudWorkflow.test.js
+++ b/ui/apps/platform/cypress/integration/collections/collectionsCrudWorkflow.test.js
@@ -1,0 +1,149 @@
+import withAuth from '../../helpers/basicAuth';
+import { collections as collectionsApi } from '../../constants/apiEndpoints';
+import { visitCollections } from '../../helpers/collections';
+import { hasFeatureFlag } from '../../helpers/features';
+
+// Cleanup an existing collection via API call
+function tryDeleteCollection(collectionName) {
+    const auth = { bearer: Cypress.env('ROX_AUTH_TOKEN') };
+
+    cy.request({
+        url: `${collectionsApi.baseUrl}?query.query=Collection Name:${collectionName}`,
+        auth,
+    }).as('listCollections');
+
+    cy.get('@listCollections').then((res) => {
+        if (res.body.collections.length > 0) {
+            const { id } = res.body.collections[0];
+            const url = `${collectionsApi.baseUrl}/${id}`;
+            cy.request({ url, auth, method: 'DELETE' });
+        }
+    });
+}
+
+describe('Create collection', () => {
+    withAuth();
+
+    beforeEach(function beforeHook() {
+        if (!hasFeatureFlag('ROX_OBJECT_COLLECTIONS')) {
+            this.skip();
+        }
+        // Ignore autocomplete requests
+        // TODO Remove this once the feature is in
+        cy.intercept(`${collectionsApi.autocomplete}`, {});
+    });
+
+    const collectionName = 'Financial deployments';
+    const clonedName = `${collectionName} (COPY)`;
+
+    it('should allow creation of a new collection', () => {
+        // Cleanup from potential previous test runs
+        tryDeleteCollection(collectionName);
+        tryDeleteCollection(clonedName);
+
+        visitCollections();
+
+        cy.get('a:contains("Create collection")').click();
+        cy.get('input[name="name"]').type(collectionName);
+        cy.get('input[name="description"]').type('A collection for financial data');
+
+        cy.get('button:contains("All deployments")').click();
+        cy.get('button:contains("Deployments with labels matching")').click();
+        cy.get('input[aria-label="Select label key for deployment rule 1 of 1"]').type('meta/name');
+        cy.get(`button:contains('Add "meta/name"')`).click();
+        cy.get('input[aria-label="Select label value 1 of 1 for deployment rule 1 of 1"]').type(
+            'visa.*'
+        );
+        cy.get(`button:contains('Add "visa.*"')`).click();
+        cy.get('button[aria-label="Add deployment label value for rule 1"]').click();
+        cy.get('input[aria-label="Select label value 2 of 2 for deployment rule 1 of 1"]').type(
+            'mastercard.*'
+        );
+        cy.get(`button:contains('Add "mastercard.*"')`).click();
+
+        cy.get('button:contains("All namespaces")').click();
+        cy.get('button:contains("Namespaces with names matching")').click();
+        cy.get('input[aria-label="Select value 1 of 1 for the namespace name"]').type('payments');
+        cy.get(`button:contains('Add "payments"')`).click();
+
+        cy.get('button:contains("All clusters")').click();
+        cy.get('button:contains("Clusters with names matching")').click();
+        cy.get('input[aria-label="Select value 1 of 1 for the cluster name"]').type('production');
+        cy.get(`button:contains('Add "production"')`).click();
+
+        cy.get('button:contains("Save")').click();
+
+        cy.get('a:contains("Financial deployments")');
+    });
+
+    it('should allow editing an existing collection', () => {
+        visitCollections();
+
+        // Make changes to an existing collection
+        cy.get(`a:contains("${collectionName}")`).click();
+        cy.get(`button:contains("Actions")`).click();
+        cy.get(`button:contains("Edit collection")`).click();
+
+        cy.get('button[aria-label="Add deployment label rule"]').click();
+        cy.get('input[aria-label="Select label key for deployment rule 2 of 2"]').type(
+            'meta/net-visibility'
+        );
+        cy.get(`button:contains('Add "meta/net-visibility"')`).click();
+        cy.get('input[aria-label="Select label value 1 of 1 for deployment rule 2 of 2"]').type(
+            'public-facing'
+        );
+        cy.get(`button:contains('Add "public-facing"')`).click();
+
+        cy.get('button[aria-label="Add deployment label value for rule 1"]').click();
+        cy.get('input[aria-label="Select label value 3 of 3 for deployment rule 1 of 2"]').type(
+            'discover.*'
+        );
+        cy.get(`button:contains('Add "discover.*"')`).click();
+
+        cy.get(`button[aria-label='Delete mastercard.*']`).click();
+
+        cy.get('button[aria-label="Add cluster name value"]').click();
+        cy.get('input[aria-label="Select value 2 of 2 for the cluster name"]').type('staging');
+        cy.get(`button:contains('Add "staging"')`).click();
+
+        cy.get('input[aria-label="Select value 1 of 2 for the cluster name"]').type(
+            '{selectAll}security'
+        );
+        cy.get(`button:contains('Add "security"')`).click();
+
+        // Save
+        cy.get('button:contains("Save")').click();
+
+        // Revisit the collection page and verify that the changes have stuck
+        cy.get('a:contains("Financial deployments")').click();
+
+        cy.get(`input[aria-label^="Select label value"][value="visa.*"]`);
+        cy.get(`input[aria-label^="Select label value"][value="discover.*"]`);
+        cy.get(`input[aria-label^="Select label value"][value="mastercard.*"]`).should('not.exist');
+
+        cy.get(`input[aria-label$="for the namespace name"][value="payments"]`);
+
+        cy.get(`input[aria-label$="for the cluster name"][value="staging"]`);
+        cy.get(`input[aria-label$="for the cluster name"][value="security"]`);
+        cy.get(`input[aria-label$="for the cluster name"][value="production"]`).should('not.exist');
+    });
+
+    it('should allow cloning an existing collection', () => {
+        // Cleanup from potential previous test runs
+        tryDeleteCollection(clonedName);
+        visitCollections();
+
+        // Make changes to an existing collection
+        cy.get(`a:contains("${collectionName}")`).click();
+        cy.get(`button:contains("Actions")`).click();
+        cy.get(`button:contains("Clone collection")`).click();
+
+        // Clone it with the default values
+        cy.get(`input[name="name"][value="${clonedName}"]`);
+        cy.get('button:contains("Save")').click();
+
+        // Ensure both collections are available
+        cy.get(`a:contains("${collectionName}")`);
+        cy.get(`a:contains("${clonedName}")`);
+    });
+});

--- a/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react';
+import React, { ReactElement, useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
 import {
     Alert,
@@ -160,10 +160,7 @@ function CollectionForm({
         submitForm,
         isSubmitting,
     } = useFormik({
-        initialValues:
-            action.type === 'clone'
-                ? { ...initialData, name: `${initialData.name} (COPY)` }
-                : initialData,
+        initialValues: initialData,
         onSubmit: (collection, { setSubmitting }) => {
             onSubmit(collection).catch(() => {
                 setSubmitting(false);
@@ -180,6 +177,21 @@ function CollectionForm({
             }),
         }),
     });
+
+    // Synchronize the value of "name" in the form field when the page action changes
+    // e.g. from 'view' -> 'clone'
+    useEffect(() => {
+        const nameValue = {
+            create: '',
+            view: initialData.name,
+            edit: initialData.name,
+            clone: `${initialData.name} (COPY)`,
+        }[action.type];
+
+        setFieldValue('name', nameValue).catch(() => {
+            // Nothing to do on error
+        });
+    }, [action.type, initialData.name, setFieldValue]);
 
     const errors = {
         ...formikErrors,

--- a/ui/apps/platform/src/Containers/Collections/RuleSelector/ByLabelSelector.tsx
+++ b/ui/apps/platform/src/Containers/Collections/RuleSelector/ByLabelSelector.tsx
@@ -35,6 +35,7 @@ function ByLabelSelector({
     isDisabled,
 }: ByLabelSelectorProps) {
     const { keyFor, invalidateIndexKeys } = useIndexKey();
+    const lowerCaseEntity = entityType.toLowerCase();
     function onChangeLabelKey(resourceSelector: ByLabelResourceSelector, ruleIndex, value) {
         const newSelector = cloneDeep(resourceSelector);
         newSelector.rules[ruleIndex].key = value;
@@ -129,7 +130,7 @@ function ByLabelSelector({
                                 >
                                     <AutoCompleteSelect
                                         id={`${entityType}-label-key-${ruleIndex}`}
-                                        typeAheadAriaLabel={`Select label key for ${entityType.toLowerCase()} rule ${
+                                        typeAheadAriaLabel={`Select label key for ${lowerCaseEntity} rule ${
                                             ruleIndex + 1
                                         } of ${scopedResourceSelector.rules.length}`}
                                         selectedOption={rule.key}
@@ -177,7 +178,7 @@ function ByLabelSelector({
                                                         valueIndex + 1
                                                     } of ${
                                                         rule.values.length
-                                                    } for ${entityType.toLowerCase()} rule ${
+                                                    } for ${lowerCaseEntity} rule ${
                                                         ruleIndex + 1
                                                     } of ${scopedResourceSelector.rules.length}`}
                                                     className="pf-u-flex-grow-1 pf-u-w-auto"
@@ -195,13 +196,13 @@ function ByLabelSelector({
                                                 />
                                                 {!isDisabled && (
                                                     <Button
+                                                        aria-label={`Delete ${value}`}
                                                         variant="plain"
                                                         onClick={() =>
                                                             onDeleteValue(ruleIndex, valueIndex)
                                                         }
                                                     >
                                                         <TrashIcon
-                                                            aria-label={`Delete ${value}`}
                                                             style={{ cursor: 'pointer' }}
                                                             color="var(--pf-global--Color--dark-200)"
                                                         />
@@ -213,6 +214,9 @@ function ByLabelSelector({
                                 </Flex>
                                 {!isDisabled && (
                                     <Button
+                                        aria-label={`Add ${lowerCaseEntity} label value for rule ${
+                                            ruleIndex + 1
+                                        }`}
                                         className="pf-u-pl-0 pf-u-pt-md"
                                         variant="link"
                                         onClick={() => onAddLabelValue(ruleIndex)}
@@ -229,6 +233,7 @@ function ByLabelSelector({
                 <>
                     <Divider component="div" className="pf-u-pt-lg" />
                     <Button
+                        aria-label={`Add ${lowerCaseEntity} label rule`}
                         className="pf-u-pl-0 pf-u-pt-md"
                         variant="link"
                         onClick={onAddLabelRule}

--- a/ui/apps/platform/src/Containers/Collections/RuleSelector/ByNameSelector.tsx
+++ b/ui/apps/platform/src/Containers/Collections/RuleSelector/ByNameSelector.tsx
@@ -38,6 +38,7 @@ function ByNameSelector({
     OptionComponent,
 }: ByNameSelectorProps) {
     const { keyFor, invalidateIndexKeys } = useIndexKey();
+    const lowerCaseEntity = entityType.toLowerCase();
     const autocompleteProvider = useCallback(
         (search: string) => {
             const req = generateRequest(collection);
@@ -85,7 +86,7 @@ function ByNameSelector({
                             id={`${entityType}-name-value-${index}`}
                             typeAheadAriaLabel={`Select value ${index + 1} of ${
                                 scopedResourceSelector.rule.values.length
-                            } for the ${entityType.toLowerCase()} name`}
+                            } for the ${lowerCaseEntity} name`}
                             className="pf-u-flex-grow-1 pf-u-w-auto"
                             selectedOption={value}
                             onChange={onChangeValue(scopedResourceSelector, index)}
@@ -99,9 +100,12 @@ function ByNameSelector({
                             OptionComponent={OptionComponent}
                         />
                         {!isDisabled && (
-                            <Button variant="plain" onClick={() => onDeleteValue(index)}>
+                            <Button
+                                aria-label={`Delete ${value}`}
+                                variant="plain"
+                                onClick={() => onDeleteValue(index)}
+                            >
                                 <TrashIcon
-                                    aria-label={`Delete ${value}`}
                                     className="pf-u-flex-shrink-1"
                                     style={{ cursor: 'pointer' }}
                                     color="var(--pf-global--Color--dark-200)"
@@ -112,7 +116,12 @@ function ByNameSelector({
                 ))}
             </Flex>
             {!isDisabled && (
-                <Button className="pf-u-pl-0 pf-u-pt-md" variant="link" onClick={onAddValue}>
+                <Button
+                    aria-label={`Add ${lowerCaseEntity} name value`}
+                    className="pf-u-pl-0 pf-u-pt-md"
+                    variant="link"
+                    onClick={onAddValue}
+                >
                     Add value
                 </Button>
             )}


### PR DESCRIPTION
## Description

Add Cypress e2e tests for core collection CRUD workflows: create/edit/clone/delete.

Enhances the aria-label values for existing value selectors for better accessibility and more reliable test hooks.

Fixes a bug with the collection name in the form, where in some cases the `(COPY)` string was not appended in clone mode.

## Follow ups

- Tests for the embedded collection feature
- Tests that assert on values in the collection results sidebar at a basic level

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Local Cypress test run:
<img width="1331" alt="image" src="https://user-images.githubusercontent.com/1292638/204833093-5f0be937-9524-484f-8a24-1e8c6fcdb26b.png">

Additionally, each test was manually interrupted and then the entire spec was run again from the start to ensure mid-spec failures correctly clean up data stored server side.

