### PR TITLE
Delete the test namespace before creating if already exists

### DIFF
--- a/sensor/tests/resource/helper.go
+++ b/sensor/tests/resource/helper.go
@@ -28,6 +28,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	v13 "k8s.io/api/networking/v1"
 	v12 "k8s.io/api/rbac/v1"
+
 	// import gcp
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"sigs.k8s.io/e2e-framework/klient/conf"
@@ -153,32 +154,32 @@ func (c *TestContext) Resources() *resources.Resources {
 	return c.r
 }
 
-func deleteNs(ctx context.Context, name string, r *resources.Resources) error {
+func (c *TestContext) deleteNs(ctx context.Context, name string) error {
 	nsObj := v1.Namespace{}
 	nsObj.Name = name
-	err := r.Delete(ctx, &nsObj)
+	err := c.r.Delete(ctx, &nsObj)
 	if err != nil {
 		return err
 	}
 
 	// wait for deletion to be finished
-	if err := wait.For(conditions.New(r).ResourceDeleted(&nsObj)); err != nil {
-		fmt.Println("failed to wait for namespace deletion")
+	if err := wait.For(conditions.New(c.r).ResourceDeleted(&nsObj)); err != nil {
+		c.t.Logf("failed to wait for namespace %s deletion\n", nsObj.Name)
 	}
 	return nil
 }
 
-func createTestNs(ctx context.Context, r *resources.Resources, name string) (*v1.Namespace, func() error, error) {
+func (c *TestContext) createTestNs(ctx context.Context, name string) (*v1.Namespace, func() error, error) {
 	utils.IgnoreError(func() error {
-		return deleteNs(ctx, name, r)
+		return c.deleteNs(ctx, name)
 	})
 	nsObj := v1.Namespace{}
 	nsObj.Name = name
-	if err := r.Create(ctx, &nsObj); err != nil {
+	if err := c.r.Create(ctx, &nsObj); err != nil {
 		return nil, nil, err
 	}
 	return &nsObj, func() error {
-		return deleteNs(ctx, name, r)
+		return c.deleteNs(ctx, name)
 	}, nil
 }
 
@@ -189,7 +190,7 @@ func (c *TestContext) GetFakeCentral() *centralDebug.FakeService {
 
 // RunWithResources runs the test case applying files in `files` slice in order.
 func (c *TestContext) RunWithResources(files []YamlTestFile, testCase TestCallback) {
-	_, removeNamespace, err := createTestNs(context.Background(), c.r, DefaultNamespace)
+	_, removeNamespace, err := c.createTestNs(context.Background(), DefaultNamespace)
 	defer utils.IgnoreError(removeNamespace)
 	if err != nil {
 		c.t.Fatalf("failed to create namespace: %s", err)
@@ -216,7 +217,7 @@ func (c *TestContext) RunWithResources(files []YamlTestFile, testCase TestCallba
 // RunBare runs a test case without applying any resources to the cluster.
 func (c *TestContext) RunBare(name string, testCase TestCallback) {
 	c.t.Run(name, func(t *testing.T) {
-		_, removeNamespace, err := createTestNs(context.Background(), c.r, DefaultNamespace)
+		_, removeNamespace, err := c.createTestNs(context.Background(), DefaultNamespace)
 		defer utils.IgnoreError(removeNamespace)
 		if err != nil {
 			t.Fatalf("failed to create namespace: %s", err)
@@ -450,7 +451,7 @@ func (c *TestContext) ApplyFile(ctx context.Context, ns string, file YamlTestFil
 
 			// wait for deletion to be finished
 			if err := wait.For(conditions.New(c.r).ResourceDeleted(obj)); err != nil {
-				fmt.Println("failed to wait for resource deletion")
+				c.t.Logf("failed to wait for resource deletion")
 			}
 			return nil
 		}


### PR DESCRIPTION
## Description

Try to delete the `sensor-integration` namespace before attempting to create it. If the namespace is already created (e.g. a previous failed run when debugging locally) the tests crash. This will prevent the tests from crashing if the namespace was already present.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

* CI
* Manual testing:
```
# Create the sensor-integration namespace
kubectl create ns sensor-integration
# Run the integration tests
make sensor-integration-test
```
