### PR TITLE
Replace label selector dropdowns with plain text inputs

### DIFF
--- a/ui/apps/platform/cypress/integration/collections/collectionsCrudWorkflow.test.js
+++ b/ui/apps/platform/cypress/integration/collections/collectionsCrudWorkflow.test.js
@@ -57,16 +57,13 @@ describe('Create collection', () => {
         cy.get('button:contains("All deployments")').click();
         cy.get('button:contains("Deployments with labels matching")').click();
         cy.get('input[aria-label="Select label key for deployment rule 1 of 1"]').type('meta/name');
-        cy.get(`button:contains('Add "meta/name"')`).click();
         cy.get('input[aria-label="Select label value 1 of 1 for deployment rule 1 of 1"]').type(
             'visa.*'
         );
-        cy.get(`button:contains('Add "visa.*"')`).click();
         cy.get('button[aria-label="Add deployment label value for rule 1"]').click();
         cy.get('input[aria-label="Select label value 2 of 2 for deployment rule 1 of 1"]').type(
             'mastercard.*'
         );
-        cy.get(`button:contains('Add "mastercard.*"')`).click();
 
         cy.get('button:contains("All namespaces")').click();
         cy.get('button:contains("Namespaces with names matching")').click();
@@ -95,17 +92,14 @@ describe('Create collection', () => {
         cy.get('input[aria-label="Select label key for deployment rule 2 of 2"]').type(
             'meta/net-visibility'
         );
-        cy.get(`button:contains('Add "meta/net-visibility"')`).click();
         cy.get('input[aria-label="Select label value 1 of 1 for deployment rule 2 of 2"]').type(
             'public-facing'
         );
-        cy.get(`button:contains('Add "public-facing"')`).click();
 
         cy.get('button[aria-label="Add deployment label value for rule 1"]').click();
         cy.get('input[aria-label="Select label value 3 of 3 for deployment rule 1 of 2"]').type(
             'discover.*'
         );
-        cy.get(`button:contains('Add "discover.*"')`).click();
 
         cy.get(`button[aria-label='Delete mastercard.*']`).click();
 

--- a/ui/apps/platform/src/Containers/Collections/CollectionAttacher.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionAttacher.tsx
@@ -4,16 +4,16 @@ import { Alert, Button, debounce, Flex, SearchInput } from '@patternfly/react-co
 import BacklogListSelector, {
     BacklogListSelectorProps,
 } from 'Components/PatternFly/BacklogListSelector';
-import { CollectionResponse } from 'services/CollectionsService';
+import { Collection } from 'services/CollectionsService';
 import useEmbeddedCollections from './hooks/useEmbeddedCollections';
 
 export type CollectionAttacherProps = {
     // A collection ID that should not be visible in the collection attacher component. This is
     // used when editing a collection to prevent reference cycles.
     excludedCollectionId: string | null;
-    initialEmbeddedCollections: CollectionResponse[];
-    onSelectionChange: (collections: CollectionResponse[]) => void;
-    collectionTableCells: BacklogListSelectorProps<CollectionResponse>['cells'];
+    initialEmbeddedCollections: Collection[];
+    onSelectionChange: (collections: Collection[]) => void;
+    collectionTableCells: BacklogListSelectorProps<Collection>['cells'];
 };
 
 function compareNameLowercase(search: string): (item: { name: string }) => boolean {

--- a/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
@@ -22,13 +22,13 @@ import { useFormik } from 'formik';
 import * as yup from 'yup';
 
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
-import { CollectionResponse } from 'services/CollectionsService';
+import { Collection } from 'services/CollectionsService';
 import { getIsValidLabelKey } from 'utils/labels';
 import { CollectionPageAction } from './collections.utils';
 import RuleSelector from './RuleSelector';
 import CollectionAttacher, { CollectionAttacherProps } from './CollectionAttacher';
 import {
-    Collection,
+    ClientCollection,
     ScopedResourceSelector,
     SelectorEntityType,
     selectorEntityTypes,
@@ -44,7 +44,7 @@ function AttachedCollectionTable({
     collections,
     collectionTableCells,
 }: {
-    collections: CollectionResponse[];
+    collections: Collection[];
     collectionTableCells: CollectionAttacherProps['collectionTableCells'];
 }) {
     return collections.length > 0 ? (
@@ -74,11 +74,11 @@ export type CollectionFormProps = {
     /* The user's workflow action for this collection */
     action: CollectionPageAction;
     /* parsed collection data used to populate the form */
-    initialData: Collection;
+    initialData: ClientCollection;
     /* collection responses for the embedded collections of `initialData` */
-    initialEmbeddedCollections: CollectionResponse[];
-    onFormChange: (values: Collection) => void;
-    onSubmit: (collection: Collection) => Promise<void>;
+    initialEmbeddedCollections: Collection[];
+    onFormChange: (values: ClientCollection) => void;
+    onSubmit: (collection: ClientCollection) => Promise<void>;
     onCancel: () => void;
     saveError?: CollectionSaveError | undefined;
     clearSaveError?: () => void;
@@ -129,7 +129,7 @@ const validationSchema = yup.object({
     }),
 });
 
-function getRuleCount(resourceSelector: Collection['resourceSelector']) {
+function getRuleCount(resourceSelector: ClientCollection['resourceSelector']) {
     let count = 0;
 
     selectorEntityTypes.forEach((entityType) => {
@@ -229,7 +229,7 @@ function CollectionForm({
         scopedResourceSelector: ScopedResourceSelector
     ) => setFieldValue(`resourceSelector.${entityType}`, scopedResourceSelector);
 
-    const onEmbeddedCollectionsChange = (newCollections: CollectionResponse[]) => {
+    const onEmbeddedCollectionsChange = (newCollections: Collection[]) => {
         if (
             saveError?.type === 'CollectionLoop' &&
             !newCollections.find(({ id }) => id === saveError.loopId)

--- a/ui/apps/platform/src/Containers/Collections/CollectionFormDrawer.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionFormDrawer.tsx
@@ -12,7 +12,7 @@ import {
     Title,
 } from '@patternfly/react-core';
 
-import { CollectionResponse } from 'services/CollectionsService';
+import { Collection } from 'services/CollectionsService';
 import { CollectionPageAction } from './collections.utils';
 import CollectionResults from './CollectionResults';
 import { isCollectionParseError, parseCollection } from './converter';
@@ -25,8 +25,8 @@ export type CollectionFormDrawerProps = {
     /* The user's workflow action for this collection */
     action: CollectionPageAction;
     collectionData: {
-        collection: Omit<CollectionResponse, 'id'>;
-        embeddedCollections: CollectionResponse[];
+        collection: Omit<Collection, 'id'>;
+        embeddedCollections: Collection[];
     };
     /* Whether or not to display the collection results in an inline drawer. If false, will
     display collection results in an overlay drawer. */

--- a/ui/apps/platform/src/Containers/Collections/CollectionFormModal.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionFormModal.tsx
@@ -15,7 +15,7 @@ import { useMediaQuery } from 'react-responsive';
 
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
 import { collectionsBasePath } from 'routePaths';
-import { CollectionResponse } from 'services/CollectionsService';
+import { Collection } from 'services/CollectionsService';
 import useCollection from './hooks/useCollection';
 import CollectionFormDrawer, { CollectionFormDrawerProps } from './CollectionFormDrawer';
 import CollectionLoadError from './CollectionLoadError';
@@ -32,7 +32,7 @@ function getCollectionTableCells(): ReturnType<
     return [
         {
             name: 'Name',
-            render: ({ id, name }: CollectionResponse) => (
+            render: ({ id, name }: Collection) => (
                 <Button
                     variant="link"
                     component="a"

--- a/ui/apps/platform/src/Containers/Collections/CollectionsTable.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionsTable.tsx
@@ -21,18 +21,18 @@ import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';
 import LinkShim from 'Components/PatternFly/LinkShim';
 import { UseURLPaginationResult } from 'hooks/useURLPagination';
 import { GetSortParams } from 'hooks/useURLSort';
-import { CollectionResponse } from 'services/CollectionsService';
+import { Collection } from 'services/CollectionsService';
 import { SearchFilter } from 'types/search';
 import { collectionsBasePath } from 'routePaths';
 
 export type CollectionsTableProps = {
-    collections: CollectionResponse[];
+    collections: Collection[];
     collectionsCount: number;
     pagination: UseURLPaginationResult;
     searchFilter: SearchFilter;
     setSearchFilter: (searchFilter: SearchFilter) => void;
     getSortParams: GetSortParams;
-    onCollectionDelete: (collection: CollectionResponse) => Promise<void>;
+    onCollectionDelete: (collection: Collection) => Promise<void>;
     hasWriteAccess: boolean;
 };
 
@@ -51,7 +51,7 @@ function CollectionsTable({
     const history = useHistory();
     const { page, perPage, setPage, setPerPage } = pagination;
     const [isDeleting, setIsDeleting] = useState(false);
-    const [collectionToDelete, setCollectionToDelete] = useState<CollectionResponse | null>(null);
+    const [collectionToDelete, setCollectionToDelete] = useState<Collection | null>(null);
     const hasCollections = collections.length > 0;
 
     function getEnabledSortParams(field: string) {
@@ -81,7 +81,7 @@ function CollectionsTable({
         [setSearchFilter]
     );
 
-    function onConfirmDeleteCollection(collection: CollectionResponse) {
+    function onConfirmDeleteCollection(collection: Collection) {
         setIsDeleting(true);
         onCollectionDelete(collection).finally(() => {
             setCollectionToDelete(null);

--- a/ui/apps/platform/src/Containers/Collections/CollectionsTablePage.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionsTablePage.tsx
@@ -20,7 +20,7 @@ import LinkShim from 'Components/PatternFly/LinkShim';
 import { collectionsBasePath } from 'routePaths';
 import useRestQuery from 'Containers/Dashboard/hooks/useRestQuery';
 import {
-    CollectionResponse,
+    Collection,
     deleteCollection,
     getCollectionCount,
     listCollections,
@@ -70,7 +70,7 @@ function CollectionsTablePage({ hasWriteAccessForCollections }: CollectionsTable
     const isLoading = !isDataAvailable && (listLoading || countLoading);
     const loadError = listError || countError;
 
-    function onCollectionDelete({ id, name }: CollectionResponse) {
+    function onCollectionDelete({ id, name }: Collection) {
         const { request } = deleteCollection(id);
 
         return request

--- a/ui/apps/platform/src/Containers/Collections/RuleSelector/ByLabelSelector.tsx
+++ b/ui/apps/platform/src/Containers/Collections/RuleSelector/ByLabelSelector.tsx
@@ -7,6 +7,7 @@ import {
     Button,
     Divider,
     ValidatedOptions,
+    TextInput,
 } from '@patternfly/react-core';
 import { TrashIcon } from '@patternfly/react-icons';
 import { FormikErrors } from 'formik';
@@ -14,7 +15,6 @@ import cloneDeep from 'lodash/cloneDeep';
 
 import useIndexKey from 'hooks/useIndexKey';
 import { SelectorEntityType, ScopedResourceSelector, ByLabelResourceSelector } from '../types';
-import { AutoCompleteSelect } from './AutoCompleteSelect';
 
 export type ByLabelSelectorProps = {
     entityType: SelectorEntityType;
@@ -126,14 +126,14 @@ function ByLabelSelector({
                                     fieldId={`${entityType}-label-key-${ruleIndex}`}
                                     className="pf-u-flex-grow-1"
                                     label={ruleIndex === 0 ? 'Label key' : ''}
-                                    isRequired
+                                    isRequired={!isDisabled}
                                 >
-                                    <AutoCompleteSelect
+                                    <TextInput
                                         id={`${entityType}-label-key-${ruleIndex}`}
-                                        typeAheadAriaLabel={`Select label key for ${lowerCaseEntity} rule ${
+                                        aria-label={`Select label key for ${lowerCaseEntity} rule ${
                                             ruleIndex + 1
                                         } of ${scopedResourceSelector.rules.length}`}
-                                        selectedOption={rule.key}
+                                        value={rule.key}
                                         onChange={(fieldValue: string) =>
                                             onChangeLabelKey(
                                                 scopedResourceSelector,
@@ -142,7 +142,7 @@ function ByLabelSelector({
                                             )
                                         }
                                         validated={keyValidation}
-                                        isDisabled={isDisabled}
+                                        readOnlyVariant={isDisabled ? 'plain' : undefined}
                                     />
                                 </FormGroup>
                                 <FlexItem
@@ -156,7 +156,7 @@ function ByLabelSelector({
                                 fieldId={`${entityType}-label-value-${ruleIndex}`}
                                 className="pf-u-flex-grow-1"
                                 label={ruleIndex === 0 ? 'Label value(s)' : ''}
-                                isRequired
+                                isRequired={!isDisabled}
                             >
                                 <Flex
                                     spaceItems={{ default: 'spaceItemsSm' }}
@@ -172,9 +172,9 @@ function ByLabelSelector({
                                                 : ValidatedOptions.default;
                                         return (
                                             <Flex key={keyFor(valueIndex)}>
-                                                <AutoCompleteSelect
+                                                <TextInput
                                                     id={`${entityType}-label-value-${ruleIndex}-${valueIndex}`}
-                                                    typeAheadAriaLabel={`Select label value ${
+                                                    aria-label={`Select label value ${
                                                         valueIndex + 1
                                                     } of ${
                                                         rule.values.length
@@ -182,7 +182,7 @@ function ByLabelSelector({
                                                         ruleIndex + 1
                                                     } of ${scopedResourceSelector.rules.length}`}
                                                     className="pf-u-flex-grow-1 pf-u-w-auto"
-                                                    selectedOption={value}
+                                                    value={value}
                                                     onChange={(fieldValue: string) =>
                                                         onChangeLabelValue(
                                                             scopedResourceSelector,
@@ -192,7 +192,9 @@ function ByLabelSelector({
                                                         )
                                                     }
                                                     validated={valueValidation}
-                                                    isDisabled={isDisabled}
+                                                    readOnlyVariant={
+                                                        isDisabled ? 'plain' : undefined
+                                                    }
                                                 />
                                                 {!isDisabled && (
                                                     <Button

--- a/ui/apps/platform/src/Containers/Collections/RuleSelector/ByNameSelector.tsx
+++ b/ui/apps/platform/src/Containers/Collections/RuleSelector/ByNameSelector.tsx
@@ -78,7 +78,11 @@ function ByNameSelector({
     }
 
     return (
-        <FormGroup fieldId={`${entityType}-name-value`} label={`${entityType} name`} isRequired>
+        <FormGroup
+            fieldId={`${entityType}-name-value`}
+            label={`${entityType} name`}
+            isRequired={!isDisabled}
+        >
             <Flex spaceItems={{ default: 'spaceItemsSm' }} direction={{ default: 'column' }}>
                 {scopedResourceSelector.rule.values.map((value, index) => (
                     <Flex key={keyFor(index)}>

--- a/ui/apps/platform/src/Containers/Collections/RuleSelector/ByNameSelector.tsx
+++ b/ui/apps/platform/src/Containers/Collections/RuleSelector/ByNameSelector.tsx
@@ -9,14 +9,14 @@ import { getCollectionAutoComplete } from 'services/CollectionsService';
 import { AutoCompleteSelect } from './AutoCompleteSelect';
 import {
     ByNameResourceSelector,
-    Collection,
+    ClientCollection,
     ScopedResourceSelector,
     SelectorEntityType,
 } from '../types';
 import { generateRequest } from '../converter';
 
 export type ByNameSelectorProps = {
-    collection: Collection;
+    collection: ClientCollection;
     entityType: SelectorEntityType;
     scopedResourceSelector: ByNameResourceSelector;
     handleChange: (

--- a/ui/apps/platform/src/Containers/Collections/RuleSelector/RuleSelector.tsx
+++ b/ui/apps/platform/src/Containers/Collections/RuleSelector/RuleSelector.tsx
@@ -6,7 +6,7 @@ import { FormikErrors } from 'formik';
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
 import ResourceIcon from 'Components/PatternFly/ResourceIcon';
 import {
-    Collection,
+    ClientCollection,
     RuleSelectorOption,
     ScopedResourceSelector,
     SelectorEntityType,
@@ -20,7 +20,7 @@ function isRuleSelectorOption(value: string): value is RuleSelectorOption {
 }
 
 export type RuleSelectorProps = {
-    collection: Collection;
+    collection: ClientCollection;
     entityType: SelectorEntityType;
     scopedResourceSelector: ScopedResourceSelector;
     handleChange: (

--- a/ui/apps/platform/src/Containers/Collections/converter.test.ts
+++ b/ui/apps/platform/src/Containers/Collections/converter.test.ts
@@ -1,10 +1,10 @@
-import { CollectionRequest, CollectionResponse } from 'services/CollectionsService';
+import { CollectionRequest, Collection } from 'services/CollectionsService';
 import { generateRequest, isCollectionParseError, parseCollection } from './converter';
-import { ByLabelResourceSelector, Collection, LabelSelectorRule } from './types';
+import { ByLabelResourceSelector, ClientCollection, LabelSelectorRule } from './types';
 
 describe('Collection parser', () => {
     it('should convert between BE CollectionResponse and FE Collection', () => {
-        const collectionResponse: CollectionResponse = {
+        const collectionResponse: Collection = {
             id: 'a-b-c',
             name: 'Sample',
             description: 'Sample description',
@@ -35,7 +35,7 @@ describe('Collection parser', () => {
             ],
             embeddedCollections: [{ id: '12' }, { id: '13' }, { id: '14' }],
         };
-        const expectedCollection: Collection = {
+        const expectedCollection: ClientCollection = {
             name: 'Sample',
             description: 'Sample description',
             inUse: false,
@@ -65,7 +65,7 @@ describe('Collection parser', () => {
             },
             embeddedCollectionIds: ['12', '13', '14'],
         };
-        const parsedResponse = parseCollection(collectionResponse) as Collection;
+        const parsedResponse = parseCollection(collectionResponse) as ClientCollection;
         expect(isCollectionParseError(parsedResponse)).toBeFalsy();
         expect(parsedResponse.id).toEqual(expectedCollection.id);
         expect(parsedResponse.name).toEqual(expectedCollection.name);
@@ -79,7 +79,7 @@ describe('Collection parser', () => {
     });
 
     it('should error on multiple resource selectors', () => {
-        const collectionResponse: CollectionResponse = {
+        const collectionResponse: Collection = {
             id: 'a-b-c',
             name: 'Sample',
             description: 'Sample description',
@@ -91,7 +91,7 @@ describe('Collection parser', () => {
     });
 
     it('should error on rules for multiple fields for a single entity', () => {
-        const collectionResponse: CollectionResponse = {
+        const collectionResponse: Collection = {
             id: 'a-b-c',
             name: 'Sample',
             description: 'Sample description',
@@ -119,7 +119,7 @@ describe('Collection parser', () => {
     });
 
     it('should error on conjunction rules', () => {
-        const collectionResponse: CollectionResponse = {
+        const collectionResponse: Collection = {
             id: 'a-b-c',
             name: 'Sample',
             description: 'Sample description',
@@ -142,7 +142,7 @@ describe('Collection parser', () => {
     });
 
     it('should error on rules against annotation field names', () => {
-        const collectionResponse: CollectionResponse = {
+        const collectionResponse: Collection = {
             id: 'a-b-c',
             name: 'Sample',
             description: 'Sample description',
@@ -165,7 +165,7 @@ describe('Collection parser', () => {
     });
 
     it('should correctly handle label key/value splitting on `=` delimiter', () => {
-        const collectionResponse: CollectionResponse = {
+        const collectionResponse: Collection = {
             id: 'a-b-c',
             name: 'Sample',
             description: 'Sample description',
@@ -181,9 +181,9 @@ describe('Collection parser', () => {
         };
 
         // Get the resource selector we are interested in without so many type assertions
-        function getLabelRule(collection: CollectionResponse): LabelSelectorRule {
+        function getLabelRule(collection: Collection): LabelSelectorRule {
             return (
-                (parseCollection(collection) as Collection).resourceSelector
+                (parseCollection(collection) as ClientCollection).resourceSelector
                     .Cluster as ByLabelResourceSelector
             ).rules[0];
         }
@@ -220,7 +220,7 @@ describe('Collection parser', () => {
 
 describe('Collection response generator', () => {
     it('should convert between FE Collection and BE CollectionRequest', () => {
-        const collection: Collection = {
+        const collection: ClientCollection = {
             name: 'Sample',
             description: 'Sample description',
             inUse: false,

--- a/ui/apps/platform/src/Containers/Collections/converter.ts
+++ b/ui/apps/platform/src/Containers/Collections/converter.ts
@@ -1,7 +1,7 @@
-import { CollectionRequest, CollectionResponse, SelectorRule } from 'services/CollectionsService';
+import { CollectionRequest, Collection, SelectorRule } from 'services/CollectionsService';
 import { ensureExhaustive, isNonEmptyArray } from 'utils/type.utils';
 import {
-    Collection,
+    ClientCollection,
     SelectorField,
     SelectorEntityType,
     isSupportedSelectorField,
@@ -46,9 +46,9 @@ export function isCollectionParseError(
  * it will return a list of validation errors to the caller.
  */
 export function parseCollection(
-    data: Omit<CollectionResponse, 'id'>
-): Collection | CollectionParseError {
-    const collection: Collection = {
+    data: Omit<Collection, 'id'>
+): ClientCollection | CollectionParseError {
+    const collection: ClientCollection = {
         name: data.name,
         description: data.description,
         inUse: data.inUse,
@@ -160,7 +160,7 @@ export function parseCollection(
  * This function takes the UI supported representation of a `Collection` and generates
  * a server response in the generic `CollectionRequest` format supported by the back end.
  */
-export function generateRequest(collection: Collection): CollectionRequest {
+export function generateRequest(collection: ClientCollection): CollectionRequest {
     const rules: SelectorRule[] = [];
 
     selectorEntityTypes.forEach((entityType) => {

--- a/ui/apps/platform/src/Containers/Collections/hooks/useCollection.ts
+++ b/ui/apps/platform/src/Containers/Collections/hooks/useCollection.ts
@@ -2,13 +2,13 @@ import { useCallback } from 'react';
 
 import useRestQuery from 'Containers/Dashboard/hooks/useRestQuery';
 import {
-    CollectionResponse,
+    Collection,
     getCollection,
     listCollections,
-    ResolvedCollectionResponse,
+    CollectionResponseWithMatches,
 } from 'services/CollectionsService';
 
-const defaultCollectionData: Omit<CollectionResponse, 'id'> = {
+const defaultCollectionData: Omit<Collection, 'id'> = {
     name: '',
     description: '',
     inUse: false,
@@ -18,15 +18,15 @@ const defaultCollectionData: Omit<CollectionResponse, 'id'> = {
 
 const noopRequest = {
     request: Promise.resolve<{
-        collection: Omit<CollectionResponse, 'id'>;
-        embeddedCollections: CollectionResponse[];
+        collection: Omit<Collection, 'id'>;
+        embeddedCollections: Collection[];
     }>({ collection: defaultCollectionData, embeddedCollections: [] }),
     cancel: () => {},
 };
 
-function getEmbeddedCollections({ collection }: ResolvedCollectionResponse): Promise<{
-    collection: CollectionResponse;
-    embeddedCollections: CollectionResponse[];
+function getEmbeddedCollections({ collection }: CollectionResponseWithMatches): Promise<{
+    collection: Collection;
+    embeddedCollections: Collection[];
 }> {
     if (collection.embeddedCollections.length === 0) {
         return Promise.resolve({ collection, embeddedCollections: [] });

--- a/ui/apps/platform/src/Containers/Collections/hooks/useCollectionFormSubmission.ts
+++ b/ui/apps/platform/src/Containers/Collections/hooks/useCollectionFormSubmission.ts
@@ -1,22 +1,18 @@
 import { useState } from 'react';
 
-import {
-    updateCollection,
-    createCollection,
-    CollectionResponse,
-} from 'services/CollectionsService';
+import { updateCollection, createCollection, Collection } from 'services/CollectionsService';
 import { CollectionPageAction } from '../collections.utils';
 import { generateRequest } from '../converter';
 import { CollectionSaveError, parseSaveError } from '../errorUtils';
-import { Collection } from '../types';
+import { ClientCollection } from '../types';
 
 export function useCollectionFormSubmission(pageAction: CollectionPageAction) {
     const [saveError, setSaveError] = useState<CollectionSaveError | undefined>();
 
-    function onSubmit(collection: Collection): Promise<CollectionResponse> {
+    function onSubmit(collection: ClientCollection): Promise<Collection> {
         setSaveError(undefined);
 
-        return new Promise<CollectionResponse>((resolve, reject) => {
+        return new Promise<Collection>((resolve, reject) => {
             if (pageAction.type === 'view') {
                 // Logically should not happen, but just in case
                 return reject(new Error('A Collection form has been submitted in read-only view'));

--- a/ui/apps/platform/src/Containers/Collections/hooks/useDryRunConfiguration.ts
+++ b/ui/apps/platform/src/Containers/Collections/hooks/useDryRunConfiguration.ts
@@ -1,12 +1,12 @@
 import isEqual from 'lodash/isEqual';
 import { useState, useCallback } from 'react';
-import { CollectionRequest, CollectionResponse } from 'services/CollectionsService';
+import { Collection, CollectionRequest } from 'services/CollectionsService';
 import { generateRequest } from '../converter';
-import { Collection } from '../types';
+import { ClientCollection } from '../types';
 
 export default function useDryRunConfiguration(
     collectionId: string | undefined,
-    initialData: Omit<CollectionResponse, 'id'>
+    initialData: Omit<Collection, 'id'>
 ) {
     const id = collectionId;
     const [dryRunConfig, setDryRunConfig] = useState<CollectionRequest>(() => {
@@ -18,7 +18,7 @@ export default function useDryRunConfiguration(
     });
 
     const updateDryRunConfig = useCallback(
-        (values: Collection) => {
+        (values: ClientCollection) => {
             const nextConfig = { id, ...generateRequest(values) };
             const isEmbeddedCollectionsChanged = !isEqual(
                 dryRunConfig.embeddedCollectionIds,

--- a/ui/apps/platform/src/Containers/Collections/hooks/useEmbeddedCollections.ts
+++ b/ui/apps/platform/src/Containers/Collections/hooks/useEmbeddedCollections.ts
@@ -1,10 +1,10 @@
 import { useReducer, useEffect, Dispatch } from 'react';
 import sortBy from 'lodash/sortBy';
 
-import { CollectionResponse, listCollections } from 'services/CollectionsService';
+import { Collection, listCollections } from 'services/CollectionsService';
 import { ensureExhaustive } from 'utils/type.utils';
 
-type CollectionMap = Record<string, CollectionResponse>;
+type CollectionMap = Record<string, Collection>;
 
 // `pageSize` is the default number of items that will attempt to be pulled when the user
 // loads more items in the detached collections section
@@ -44,9 +44,9 @@ function fetchDetachedCollections(
     clientMap: CollectionMap,
     searchValue: string,
     pageNumber: number,
-    aggregateResult: CollectionResponse[]
+    aggregateResult: Collection[]
 ): Promise<{
-    detached: CollectionResponse[];
+    detached: Collection[];
     nextPage: number;
     lastResponseSize: number;
 }> {
@@ -130,7 +130,7 @@ function moveItem(from: CollectionMap, to: CollectionMap, id: string) {
     return [fromMap, toMap];
 }
 
-function arrayToMap(collections: CollectionResponse[]): Record<string, CollectionResponse> {
+function arrayToMap(collections: Collection[]): Record<string, Collection> {
     const map = {};
     collections.forEach(({ id, ...rest }) => {
         map[id] = { id, ...rest };
@@ -198,9 +198,9 @@ const initialState = {
 
 export type UseEmbeddedCollectionsReturn = {
     /** Client side state of attached collections */
-    attached: CollectionResponse[];
+    attached: Collection[];
     /** Client side state of detached collections */
-    detached: CollectionResponse[];
+    detached: Collection[];
     /** Move a collection from detached -> attached by id */
     attach: (id: string) => void;
     /** Move a collection from attached -> detached by id */
@@ -263,7 +263,7 @@ export type UseEmbeddedCollectionsReturn = {
  */
 export default function useEmbeddedCollections(
     excludedCollectionId: string | null,
-    initialAttachedCollections: CollectionResponse[]
+    initialAttachedCollections: Collection[]
 ): UseEmbeddedCollectionsReturn {
     const [state, dispatch] = useReducer(embeddedCollectionsReducer, initialState, (init) => ({
         ...init,

--- a/ui/apps/platform/src/Containers/Collections/types.ts
+++ b/ui/apps/platform/src/Containers/Collections/types.ts
@@ -74,10 +74,10 @@ export type ScopedResourceSelector =
     | ByLabelResourceSelector;
 
 /**
- * `Collection` is the front end representation of a valid collection, which is more
+ * `ClientCollection` is the front end representation of a valid collection, which is more
  * restricted than Collection objects that can be created via the API.
  */
-export type Collection = {
+export type ClientCollection = {
     id?: string;
     name: string;
     description: string;

--- a/ui/apps/platform/src/services/CollectionsService.ts
+++ b/ui/apps/platform/src/services/CollectionsService.ts
@@ -29,7 +29,7 @@ export type CollectionRequest = {
     embeddedCollectionIds: string[];
 };
 
-export type CollectionResponse = {
+export type Collection = {
     id: string;
     name: string;
     description: string;
@@ -46,7 +46,7 @@ export function listCollections(
     sortOption: ApiSortOption,
     page?: number,
     pageSize?: number
-): CancellableRequest<CollectionResponse[]> {
+): CancellableRequest<Collection[]> {
     let offset: number | undefined;
     if (typeof page === 'number' && typeof pageSize === 'number') {
         offset = page > 0 ? page * pageSize : 0;
@@ -59,7 +59,7 @@ export function listCollections(
     return makeCancellableAxiosRequest((signal) =>
         axios
             .get<{
-                collections: CollectionResponse[];
+                collections: Collection[];
             }>(`${collectionsBaseUrl}?${params}`, { signal })
             .then((response) => response.data.collections)
     );
@@ -77,8 +77,11 @@ export function getCollectionCount(searchFilter: SearchFilter): CancellableReque
     );
 }
 
-export type ResolvedCollectionResponse = {
-    collection: CollectionResponse;
+export type CollectionResponse = {
+    collection: Collection;
+};
+
+export type CollectionResponseWithMatches = CollectionResponse & {
     deployments: ListDeployment[];
 };
 
@@ -94,11 +97,13 @@ export type ResolvedCollectionResponse = {
 export function getCollection(
     id: string,
     options: { withMatches: boolean } = { withMatches: false }
-): CancellableRequest<ResolvedCollectionResponse> {
+): CancellableRequest<CollectionResponseWithMatches> {
     const params = qs.stringify(options);
     return makeCancellableAxiosRequest((signal) =>
         axios
-            .get<ResolvedCollectionResponse>(`${collectionsBaseUrl}/${id}?${params}`, { signal })
+            .get<CollectionResponseWithMatches>(`${collectionsBaseUrl}/${id}?${params}`, {
+                signal,
+            })
             .then((response) => response.data)
     );
 }
@@ -111,13 +116,11 @@ export function getCollection(
  * @returns
  *      The created collection object, with ID
  */
-export function createCollection(
-    collection: CollectionRequest
-): CancellableRequest<CollectionResponse> {
+export function createCollection(collection: CollectionRequest): CancellableRequest<Collection> {
     return makeCancellableAxiosRequest((signal) =>
         axios
             .post<CollectionResponse>(collectionsBaseUrl, collection, { signal })
-            .then((response) => response.data)
+            .then((response) => response.data.collection)
     );
 }
 
@@ -135,11 +138,13 @@ export function createCollection(
 export function updateCollection(
     id: string,
     collection: CollectionRequest
-): CancellableRequest<CollectionResponse> {
+): CancellableRequest<Collection> {
     return makeCancellableAxiosRequest((signal) =>
         axios
-            .patch<CollectionResponse>(`${collectionsBaseUrl}/${id}`, collection, { signal })
-            .then((response) => response.data)
+            .patch<CollectionResponse>(`${collectionsBaseUrl}/${id}`, collection, {
+                signal,
+            })
+            .then((response) => response.data.collection)
     );
 }
 


### PR DESCRIPTION
## Description

This replaces the typeahead dropdown inputs for _by label_ values with a plain text input. Since we are not doing autocomplete for these fields this should be a more appropriate UX.

Additionally, this removes the red "required" star from inputs when the form is in read only mode to reduce visual clutter.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Manual testing + verification of functionality covered by existing e2e tests.

Readonly variant of input fields:
![image](https://user-images.githubusercontent.com/1292638/205085215-7262cba4-2d53-4a44-aa76-e3c11ecf9664.png)

Editable variant of input fields:
![image](https://user-images.githubusercontent.com/1292638/205085327-97a177bc-943a-4379-b298-b2b928ef4279.png)

