### PR TITLE
rox-13715 collector mock grpc server fix too many pings

### DIFF
--- a/integration-tests/mock-grpc-server/main.go
+++ b/integration-tests/mock-grpc-server/main.go
@@ -171,7 +171,6 @@ func main() {
 		log.Fatal(err)
 	}
 
-	//grpcServer := grpc.NewServer()
 	maxMsgSize := 12 * 1024 * 1024
 	grpcServer := grpc.NewServer(
                 grpc.MaxRecvMsgSize(maxMsgSize),

--- a/integration-tests/mock-grpc-server/main.go
+++ b/integration-tests/mock-grpc-server/main.go
@@ -173,15 +173,15 @@ func main() {
 
 	maxMsgSize := 12 * 1024 * 1024
 	grpcServer := grpc.NewServer(
-                grpc.MaxRecvMsgSize(maxMsgSize),
-                grpc.KeepaliveParams(keepalive.ServerParameters{
-                        Time: 40 * time.Second,
-                }),
-                grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
-                        MinTime:             5 * time.Second,
-                        PermitWithoutStream: true,
-                }),
-        )
+		grpc.MaxRecvMsgSize(maxMsgSize),
+		grpc.KeepaliveParams(keepalive.ServerParameters{
+			Time: 40 * time.Second,
+		}),
+		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
+			MinTime:             5 * time.Second,
+			PermitWithoutStream: true,
+		}),
+	)
 
 	sensorAPI.RegisterSignalServiceServer(grpcServer, newServer(db))
 	sensorAPI.RegisterNetworkConnectionInfoServiceServer(grpcServer, newServer(db))


### PR DESCRIPTION
## Description

When running a collector integration test for a long time there are errors similar to 

74 chttp2_transport.cc:1096]   Received a GOAWAY with error code ENHANCE_YOUR_CALM and debug data equal to "too_many_pings"

An explanation for this error can be found here https://github.com/grpc/grpc/blob/master/doc/keepalive.md

This PR is related to https://github.com/stackrox/collector/pull/911

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Integration tests pass when using new mock grpc server image 
- [x] Integration tests fail when using old mock grpc server image

## Testing Performed

Go to collector repo. 

git checkout e766270879073f79c5f45a6abdc14a73cd038e98
make integration-tests-many-processes-listening-on-ports (Test will run for half an hour to over an hour and fail)
Modify the line 
GRPCServerImage:   "quay.io/rhacs-eng/grpc-server:3.72.x-281-g25a7abf818",
in intgration-tests/suites/common/collector_manager.go
to
GRPCServerImage:   "3.73.x-95-gd43176a427",
make integration-tests-many-processes-listening-on-ports (Test should pass)


