### PR TITLE
Dashrews/ROX-13243 do not copy databases if no migrations are to run

### DIFF
--- a/migrator/clone/clone_test.go
+++ b/migrator/clone/clone_test.go
@@ -23,7 +23,7 @@ import (
 
 var (
 	preHistoryVer = versionPair{version: "3.0.56.0", seqNum: 62}
-	preVer        = versionPair{version: "3.0.57.0", seqNum: 65}
+	preVer        = versionPair{version: "3.0.57.0", seqNum: 64}
 	currVer       = versionPair{version: "3.0.58.0", seqNum: 65}
 	futureVer     = versionPair{version: "10001.0.0.0", seqNum: 6533}
 	moreFutureVer = versionPair{version: "10002.0.0.0", seqNum: 7533}

--- a/migrator/clone/clone_test.go
+++ b/migrator/clone/clone_test.go
@@ -438,6 +438,8 @@ func doTestForceRollbackFailure(t *testing.T) {
 
 				dbm = NewPostgres(mock.mountPath, c.forceRollback, config, sourceMap)
 
+				// Since postgres version no longer makes a previous if the sequence number doesn't change
+				// the error message for a dev build may differ
 				if c.postgresDevErrorMessage != "" && currVer != releaseVer {
 					expectedError = c.postgresDevErrorMessage
 				}

--- a/migrator/clone/postgres/db_clone_manager_impl.go
+++ b/migrator/clone/postgres/db_clone_manager_impl.go
@@ -183,7 +183,6 @@ func (d *dbCloneManagerImpl) GetCloneToMigrate(rocksVersion *migrations.Migratio
 	}
 
 	prevClone, prevExists := d.cloneMap[PreviousClone]
-	log.Infof("SHREWS -- %d = %d", currClone.GetSeqNum(), migrations.CurrentDBVersionSeqNum())
 	// Only need to make a copy if the migrations need to be performed
 	if d.rollbackEnabled() && currClone.GetSeqNum() != migrations.CurrentDBVersionSeqNum() {
 		// If previous clone has the same version as current version, the previous upgrade was not completed.

--- a/migrator/clone/postgres/db_clone_manager_impl.go
+++ b/migrator/clone/postgres/db_clone_manager_impl.go
@@ -73,13 +73,11 @@ func (d *dbCloneManagerImpl) Scan() error {
 	if currClone.GetSeqNum() > migrations.CurrentDBVersionSeqNum() || version.CompareVersions(currClone.GetVersion(), version.GetMainVersion()) > 0 {
 		// If there is no previous clone or force rollback is not requested, we cannot downgrade.
 		prevClone, prevExists := d.cloneMap[PreviousClone]
-		if !prevExists {
-			if currClone.GetSeqNum() > migrations.CurrentDBVersionSeqNum() {
-				if version.GetVersionKind(currClone.GetVersion()) == version.ReleaseKind && version.GetVersionKind(version.GetMainVersion()) == version.ReleaseKind {
-					return errors.New(metadata.ErrNoPrevious)
-				}
-				return errors.New(metadata.ErrNoPreviousInDevEnv)
+		if !prevExists && currClone.GetSeqNum() > migrations.CurrentDBVersionSeqNum() {
+			if version.GetVersionKind(currClone.GetVersion()) == version.ReleaseKind && version.GetVersionKind(version.GetMainVersion()) == version.ReleaseKind {
+				return errors.New(metadata.ErrNoPrevious)
 			}
+			return errors.New(metadata.ErrNoPreviousInDevEnv)
 		}
 
 		// Force rollback is not requested.

--- a/migrator/clone/postgres/db_clone_manager_impl.go
+++ b/migrator/clone/postgres/db_clone_manager_impl.go
@@ -183,6 +183,7 @@ func (d *dbCloneManagerImpl) GetCloneToMigrate(rocksVersion *migrations.Migratio
 	}
 
 	prevClone, prevExists := d.cloneMap[PreviousClone]
+	log.Infof("SHREWS -- %d = %d", currClone.GetSeqNum(), migrations.CurrentDBVersionSeqNum())
 	// Only need to make a copy if the migrations need to be performed
 	if d.rollbackEnabled() && currClone.GetSeqNum() != migrations.CurrentDBVersionSeqNum() {
 		// If previous clone has the same version as current version, the previous upgrade was not completed.

--- a/migrator/clone/postgres/db_clone_manager_impl.go
+++ b/migrator/clone/postgres/db_clone_manager_impl.go
@@ -183,7 +183,7 @@ func (d *dbCloneManagerImpl) GetCloneToMigrate(rocksVersion *migrations.Migratio
 	}
 
 	prevClone, prevExists := d.cloneMap[PreviousClone]
-	if d.rollbackEnabled() && currClone.GetVersion() != version.GetMainVersion() {
+	if d.rollbackEnabled() && currClone.GetSeqNum() != migrations.CurrentDBVersionSeqNum() {
 		// If previous clone has the same version as current version, the previous upgrade was not completed.
 		// Central could be in a loop of booting up the service. So we should continue to run with current.
 		if prevExists && currClone.GetVersion() == prevClone.GetVersion() {

--- a/migrator/clone/postgres/db_clone_manager_impl.go
+++ b/migrator/clone/postgres/db_clone_manager_impl.go
@@ -183,6 +183,7 @@ func (d *dbCloneManagerImpl) GetCloneToMigrate(rocksVersion *migrations.Migratio
 	}
 
 	prevClone, prevExists := d.cloneMap[PreviousClone]
+	// Only need to make a copy if the migrations need to be performed
 	if d.rollbackEnabled() && currClone.GetSeqNum() != migrations.CurrentDBVersionSeqNum() {
 		// If previous clone has the same version as current version, the previous upgrade was not completed.
 		// Central could be in a loop of booting up the service. So we should continue to run with current.

--- a/pkg/postgres/pgadmin/admin_utils.go
+++ b/pkg/postgres/pgadmin/admin_utils.go
@@ -337,7 +337,7 @@ func getAvailablePostgresCapacity(postgresConfig *pgxpool.Config) (int64, error)
 
 	// We should only get the header row and the row for the size of $PGDATA.  If we
 	// get more than that, then $PGDATA is not defined
-	if len(rawCapacityInfo) != 2 {
+	if len(rawCapacityInfo) < 2 {
 		if err := tx.Rollback(ctx); err != nil {
 			return 0, err
 		}

--- a/pkg/postgres/pgadmin/admin_utils.go
+++ b/pkg/postgres/pgadmin/admin_utils.go
@@ -337,7 +337,7 @@ func getAvailablePostgresCapacity(postgresConfig *pgxpool.Config) (int64, error)
 
 	// We should only get the header row and the row for the size of $PGDATA.  If we
 	// get more than that, then $PGDATA is not defined
-	if len(rawCapacityInfo) < 2 {
+	if len(rawCapacityInfo) != 2 {
 		if err := tx.Rollback(ctx); err != nil {
 			return 0, err
 		}


### PR DESCRIPTION
## Description

This PR speeds up upgrades to new versions of software by not copying databases around unless there is a migration job to execute.  So if the database will not change as a result of the upgrade, there is no need to make a copy of it.  

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Added a unit test and updated the integration `clone_test` accordingly.
