### PR TITLE
Tie user agents with StackRox

### DIFF
--- a/central/main.go
+++ b/central/main.go
@@ -241,7 +241,7 @@ func main() {
 		return
 	}
 
-	clientconn.SetUserAgent("central")
+	clientconn.SetUserAgent(clientconn.Central)
 
 	ctx := context.Background()
 	proxy.WatchProxyConfig(ctx, proxyConfigPath, proxyConfigFile, true)

--- a/compliance/collection/main.go
+++ b/compliance/collection/main.go
@@ -248,7 +248,7 @@ func initializeStream(ctx context.Context, cli sensor.ComplianceServiceClient) (
 func main() {
 	log.Infof("Running StackRox Version: %s", version.GetMainVersion())
 
-	clientconn.SetUserAgent("compliance")
+	clientconn.SetUserAgent(clientconn.Compliance)
 
 	conn, err := clientconn.AuthenticatedGRPCConnection(env.AdvertisedEndpoint.Setting(), mtls.SensorSubject)
 	if err != nil {

--- a/pkg/clientconn/useragent.go
+++ b/pkg/clientconn/useragent.go
@@ -11,6 +11,7 @@ import (
 
 var userAgent string
 
+// The following is the list of component names that tune their User-Agent.
 const (
 	AdmissionController = "Rox Admission Controller"
 	Central             = "Rox Central"

--- a/pkg/clientconn/useragent.go
+++ b/pkg/clientconn/useragent.go
@@ -11,8 +11,17 @@ import (
 
 var userAgent string
 
+const (
+	AdmissionController = "Rox Admission Controller"
+	Central             = "Rox Central"
+	Compliance          = "Rox Compliance"
+	Roxctl              = "roxctl"
+	Sensor              = "Rox Sensor"
+	Upgrader            = "Rox Upgrader"
+)
+
 func init() {
-	SetUserAgent("stackrox")
+	SetUserAgent("StackRox")
 }
 
 // SetUserAgent formats and sets a value to be used in the User-Agent HTTP

--- a/roxctl/main.go
+++ b/roxctl/main.go
@@ -31,7 +31,7 @@ func main() {
 
 	PatchPersistentPreRunHooks(c)
 
-	clientconn.SetUserAgent("roxctl")
+	clientconn.SetUserAgent(clientconn.Roxctl)
 
 	if err := c.Execute(); err != nil {
 		os.Exit(1)

--- a/sensor/admission-control/main.go
+++ b/sensor/admission-control/main.go
@@ -66,7 +66,7 @@ func mainCmd() error {
 		log.Errorf("Failed to configure certificates: %v. Connection to sensor might fail.", err)
 	}
 
-	clientconn.SetUserAgent("admission-control")
+	clientconn.SetUserAgent(clientconn.AdmissionController)
 
 	// Note that the following call returns immediately (connecting happens in the background), hence this does not
 	// delay readiness of the admission-control service even if sensor is unavailable.

--- a/sensor/kubernetes/main.go
+++ b/sensor/kubernetes/main.go
@@ -47,7 +47,7 @@ func main() {
 	} else {
 		sharedClientInterface = client.MustCreateInterface()
 	}
-	clientconn.SetUserAgent("sensor")
+	clientconn.SetUserAgent(clientconn.Sensor)
 	centralConnFactory, err := centralclient.NewCentralConnectionFactory(env.CentralEndpoint.Setting())
 	if err != nil {
 		utils.CrashOnError(errors.Wrapf(err, "sensor failed to start while initializing gRPC client to endpoint %s", env.CentralEndpoint.Setting()))

--- a/sensor/upgrader/main.go
+++ b/sensor/upgrader/main.go
@@ -35,7 +35,7 @@ func mainCmd() error {
 		return err
 	}
 
-	clientconn.SetUserAgent("upgrader")
+	clientconn.SetUserAgent(clientconn.Upgrader)
 
 	upgradeCtx, err := upgradectx.Create(context.Background(), upgraderCfg)
 	if err != nil {


### PR DESCRIPTION
## Description

To facilitate debugging, add "Rox" prefix to `User-Agent` values of ACS components.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] ~Unit test and regression tests added~
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

Strings change only to code added after the last release. CU run suffices.
