### PR TITLE
Extract form submission logic for collection form

### DIFF
--- a/ui/apps/platform/src/Containers/Collections/hooks/useCollectionFormSubmission.ts
+++ b/ui/apps/platform/src/Containers/Collections/hooks/useCollectionFormSubmission.ts
@@ -1,0 +1,52 @@
+import { useState } from 'react';
+
+import {
+    updateCollection,
+    createCollection,
+    CollectionResponse,
+} from 'services/CollectionsService';
+import { CollectionPageAction } from '../collections.utils';
+import { generateRequest } from '../converter';
+import { CollectionSaveError, parseSaveError } from '../errorUtils';
+import { Collection } from '../types';
+
+export function useCollectionFormSubmission(pageAction: CollectionPageAction) {
+    const [saveError, setSaveError] = useState<CollectionSaveError | undefined>();
+
+    function onSubmit(collection: Collection): Promise<CollectionResponse> {
+        setSaveError(undefined);
+
+        return new Promise<CollectionResponse>((resolve, reject) => {
+            if (pageAction.type === 'view') {
+                // Logically should not happen, but just in case
+                return reject(new Error('A Collection form has been submitted in read-only view'));
+            }
+            const isEmptyCollection =
+                Object.values(collection.resourceSelector).every(({ type }) => type === 'All') &&
+                collection.embeddedCollectionIds.length === 0;
+
+            if (isEmptyCollection) {
+                return reject(new Error('Cannot save an empty collection'));
+            }
+
+            const saveServiceCall =
+                pageAction.type === 'edit'
+                    ? (payload) => updateCollection(pageAction.collectionId, payload)
+                    : (payload) => createCollection(payload);
+
+            const requestPayload = generateRequest(collection);
+            const { request } = saveServiceCall(requestPayload);
+
+            return resolve(request);
+        }).catch((err) => {
+            setSaveError(parseSaveError(err));
+            return Promise.reject(err);
+        });
+    }
+
+    return {
+        saveError,
+        setSaveError,
+        onSubmit,
+    };
+}


### PR DESCRIPTION
## Description

This extracts the function that handles submitting the collection form and the associated error tracking into a hook so that it can be reused for the upcoming vuln reporting integration.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Verify e2e tests

Edit a collection and force an error (duplicate collection name, attached collection loop) to ensure error propagation functions as it did before. The error should be displayed in an alert and the page should scroll to the alert box.
![image](https://user-images.githubusercontent.com/1292638/205105873-434c8290-05da-45b4-97b5-4052a105bb60.png)
