### PR TITLE
ROX-13714: Implement a new rate limited logger, and use it to log failed auth messages.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -128,6 +128,8 @@ require (
 	sigs.k8s.io/yaml v1.3.0
 )
 
+require github.com/hashicorp/golang-lru v0.5.4
+
 require (
 	cloud.google.com/go v0.105.0 // indirect
 	cloud.google.com/go/compute v1.14.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1028,6 +1028,8 @@ github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09
 github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA0oac0k90=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
+github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/golang-lru/v2 v2.0.1 h1:5pv5N1lT1fjLg2VQ5KWc7kmucp2x/kvFOnxuVTqZ6x4=
 github.com/hashicorp/golang-lru/v2 v2.0.1/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=

--- a/pkg/logging/rate_limited_logger.go
+++ b/pkg/logging/rate_limited_logger.go
@@ -1,0 +1,68 @@
+package logging
+
+import (
+	"time"
+
+	lru "github.com/hashicorp/golang-lru"
+	"golang.org/x/time/rate"
+)
+
+// RateLimitedLogger wraps a zap.SugaredLogger that supports rate limiting.
+type RateLimitedLogger struct {
+	*Logger
+	frequency    float64
+	burst        int
+	rateLimiters *lru.Cache
+}
+
+// NewRateLimitLogger returns a rate limited logger
+func NewRateLimitLogger(l *Logger, size int, logLines int, interval time.Duration, burst int) *RateLimitedLogger {
+	cache, err := lru.New(size)
+	if err != nil {
+		l.Errorf("unable to create rate limiter cache for logger in module %q: %v", l.module.name, err)
+		return nil
+	}
+	return &RateLimitedLogger{
+		l,
+		float64(logLines) / interval.Seconds(),
+		burst,
+		cache,
+	}
+}
+
+// ErrorL logs a templated error message if allowed by the rate limiter corresponding to the identifier
+func (rl *RateLimitedLogger) ErrorL(limiter string, template string, args ...interface{}) {
+	if rl.allowLog(limiter) {
+		rl.Errorf(template, args...)
+	}
+}
+
+// WarnL logs a templated warn message if allowed by the rate limiter corresponding to the identifier
+func (rl *RateLimitedLogger) WarnL(limiter string, template string, args ...interface{}) {
+	if rl.allowLog(limiter) {
+		rl.Warnf(template, args...)
+	}
+}
+
+// InfoL logs a templated info message if allowed by the rate limiter corresponding to the identifier
+func (rl *RateLimitedLogger) InfoL(limiter string, template string, args ...interface{}) {
+	if rl.allowLog(limiter) {
+		rl.Infof(template, args...)
+	}
+}
+
+// DebugL logs a templated debug message if allowed by the rate limiter corresponding to the identifier
+func (rl *RateLimitedLogger) DebugL(limiter string, template string, args ...interface{}) {
+	if rl.allowLog(limiter) {
+		rl.Debugf(template, args...)
+	}
+}
+
+func (rl *RateLimitedLogger) allowLog(limiter string) bool {
+	_, _ = rl.rateLimiters.ContainsOrAdd(limiter, rate.NewLimiter(rate.Limit(rl.frequency), rl.burst))
+
+	if lim, ok := rl.rateLimiters.Get(limiter); ok {
+		return lim.(*rate.Limiter).Allow()
+	}
+	return false
+}


### PR DESCRIPTION
## Description
1. Added a new rate limited logger
2. Added support to rate limit failed auth messages by hostname
3. Added hostname to failed auth log messages

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed
Manual using curl on cluster. 