### PR TITLE
Call localStorage removeItem in first of auth integration tests

### DIFF
--- a/ui/apps/platform/cypress/integration/auth.test.js
+++ b/ui/apps/platform/cypress/integration/auth.test.js
@@ -32,6 +32,7 @@ describe('Authentication', () => {
 
     it('should redirect user to login page, authenticate and redirect to the requested page', () => {
         stubAPIs();
+        localStorage.setItem('access_token', 'my-token'); // replace possible valid token left over from previous test file
         setupAuth(pagePath, AUTHENTICATED);
         cy.location('pathname').should('eq', loginUrl);
         cy.get(selectors.providerSelect).should('have.text', 'auth-provider-name');

--- a/ui/apps/platform/cypress/integration/auth.test.js
+++ b/ui/apps/platform/cypress/integration/auth.test.js
@@ -31,8 +31,8 @@ describe('Authentication', () => {
     };
 
     it('should redirect user to login page, authenticate and redirect to the requested page', () => {
+        localStorage.removeItem('access_token'); // replace possible valid token left over from previous test file
         stubAPIs();
-        localStorage.setItem('access_token', 'my-token'); // replace possible valid token left over from previous test file
         setupAuth(pagePath, AUTHENTICATED);
         cy.location('pathname').should('eq', loginUrl);
         cy.get(selectors.providerSelect).should('have.text', 'auth-provider-name');


### PR DESCRIPTION
## Description

Keep removing possible reasons for a timing problem.

**Observation**: When the first test fails, the other tests succeed.

**Hypothesis**: Notice that the other tests have `localStorage.settem('access_token', 'my-token')` method call.

Does the first test allow a timing problem if it starts before cypress cleared local storage from the previous test file?

Snapshot from merge failure for #3971

![3971](https://user-images.githubusercontent.com/11862657/205125805-9bfa9ad0-923d-4588-a5ea-7027dedab359.png)

Notice requests for any authenticated page **before** new url /login

* GET /v1/availableAuthProviders
* GET /v1/featureflags
* GET /v1/loginAuthProviders
* GET /v1/mypermissions
* GET /v1/search/metadata/options?
* GET /v1/config/public

And then compare 401 status code for second occurrence:

* GET /v1/search/metadata/options?

This suggests the test **started** to visit /main/systemconfig (too bad, so sad scrolled out of view in left panel of cypress dashboard) and then switched to /login instead of Login and then System Configuration as the test assumes.

### Residue

Notice that `'/v1/*'` matches single-segment endpoint addresses, but not multi-segment endpoint addresses:

* GET /v1/search/metadata/options?
* GET /v1/config/public

Instead of replace with `'/v1/**'` explicitly mock relevant requests as a follow up.

For example, to prevent exception on System Configuration page because of `{}` empty body from default mock response.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration test

## Testing Performed