### PR TITLE
Disable Edit button for uneditable integrations

### DIFF
--- a/ui/apps/platform/src/Containers/Integrations/IntegrationPage.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationPage.tsx
@@ -9,10 +9,14 @@ import {
     Breadcrumb,
     BreadcrumbItem,
     Divider,
+    Tooltip,
 } from '@patternfly/react-core';
 
 import { integrationsPath } from 'routePaths';
-import { getIntegrationLabel } from 'Containers/Integrations/utils/integrationUtils';
+import {
+    getEditDisabledMessage,
+    getIntegrationLabel,
+} from 'Containers/Integrations/utils/integrationUtils';
 import PageTitle from 'Components/PageTitle';
 import LinkShim from 'Components/PatternFly/LinkShim';
 import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
@@ -35,6 +39,8 @@ function IntegrationPage({ title, children }: IntegrationPageProps): ReactElemen
     const integrationsListPath = `${integrationsPath}/${source}/${type}`;
     const integrationEditPath = `${integrationsPath}/${source}/${type}/edit/${id as string}`;
 
+    const editDisabledMessage = getEditDisabledMessage(type);
+
     return (
         <>
             <PageTitle title={title} />
@@ -55,13 +61,26 @@ function IntegrationPage({ title, children }: IntegrationPageProps): ReactElemen
                     </FlexItem>
                     {pageState === 'VIEW_DETAILS' && permissions[source].write && (
                         <FlexItem align={{ default: 'alignRight' }}>
-                            <Button
-                                variant={ButtonVariant.secondary}
-                                component={LinkShim}
-                                href={integrationEditPath}
-                            >
-                                Edit
-                            </Button>
+                            {editDisabledMessage ? (
+                                <Tooltip content={editDisabledMessage}>
+                                    <Button
+                                        variant={ButtonVariant.secondary}
+                                        component={LinkShim}
+                                        href={integrationEditPath}
+                                        isAriaDisabled={!!editDisabledMessage}
+                                    >
+                                        Edit
+                                    </Button>
+                                </Tooltip>
+                            ) : (
+                                <Button
+                                    variant={ButtonVariant.secondary}
+                                    component={LinkShim}
+                                    href={integrationEditPath}
+                                >
+                                    Edit
+                                </Button>
+                            )}
                         </FlexItem>
                     )}
                 </Flex>

--- a/ui/apps/platform/src/Containers/Integrations/utils/integrationUtils.ts
+++ b/ui/apps/platform/src/Containers/Integrations/utils/integrationUtils.ts
@@ -53,6 +53,16 @@ export function clearStoredCredentials<I extends IntegrationBase>(
     return integration;
 }
 
+export function getEditDisabledMessage(type) {
+    if (type === 'clusterInitBundle') {
+        return 'This Cluster Init Bundle can not be edited. Create a new Cluster Init Bundle or delete an existing one';
+    }
+    if (type === 'apitoken') {
+        return 'This API Token can not be edited. Create a new API Token or delete an existing one.';
+    }
+    return '';
+}
+
 export const daysOfWeek = [
     'Sunday',
     'Monday',


### PR DESCRIPTION
## Description

This little enhancement grew out of confusion during the HackFest for the new ACS Cloud Service. Kylie provided the UX pattern that will be used in new features, too, going forward.

This was a pain point for new users with the Cluster Init Bundle, but the same pattern applies to API Tokens.

(Note: We have to use the `isAriaDisabled` prop for the PatternFly component, instead of its `isDisabled` prop, in order for the Tooltip to be displayed. Reference: https://www.patternfly.org/v4/components/button#aria-disabled-examples

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

Cluster Init Bundle
<img width="1609" alt="Screen Shot 2022-12-01 at 3 30 26 PM" src="https://user-images.githubusercontent.com/715729/205155457-7b9d0b16-2442-49ae-8d59-3c7a5974f697.png">

API Token
<img width="1609" alt="Screen Shot 2022-12-01 at 3 30 11 PM" src="https://user-images.githubusercontent.com/715729/205155460-3ed40a49-c6fe-4d69-b159-3b9915b43cd6.png">

No tooltip when edit button is clickable
<img width="1609" alt="Screen Shot 2022-12-01 at 3 37 06 PM" src="https://user-images.githubusercontent.com/715729/205155455-5566b623-dd62-4df6-937b-4f3ccb98abdd.png">
