### PR TITLE
CI: Wait longer for images

### DIFF
--- a/.openshift-ci/pre_tests.py
+++ b/.openshift-ci/pre_tests.py
@@ -15,7 +15,7 @@ class PreSystemTests:
     PreSystemTests - System tests (upgrade, e2e) need images.
     """
 
-    POLL_TIMEOUT = 45 * 60
+    POLL_TIMEOUT = 60 * 60
 
     def run(self):
         subprocess.run(


### PR DESCRIPTION
## Description

We've had a few (well at least two) recent flakes where the images were slow to build. Waiting 15 minutes more might get them and it is no harm.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient