### PR TITLE
ROX-13271: Add compatibility test failure todos

### DIFF
--- a/qa-tests-backend/scripts/run-compatibility.sh
+++ b/qa-tests-backend/scripts/run-compatibility.sh
@@ -49,7 +49,7 @@ compatibility_test() {
 
     export CLUSTER="${ORCHESTRATOR_FLAVOR^^}"
 
-    make -C qa-tests-backend compatibility-test FAIL_FAST=FALSE || touch FAIL
+    make -C qa-tests-backend compatibility-test || touch FAIL
 
     store_qa_test_results "compatibility-test-sensor-${SENSOR_CHART_VERSION}"
     [[ ! -f FAIL ]] || die "compatibility-test-sensor-${SENSOR_CHART_VERSION}"

--- a/qa-tests-backend/src/test/groovy/AutocompleteTest.groovy
+++ b/qa-tests-backend/src/test/groovy/AutocompleteTest.groovy
@@ -1,4 +1,5 @@
 import groups.BAT
+import groups.COMPATIBILITY
 import io.stackrox.proto.api.v1.SearchServiceOuterClass
 import io.stackrox.proto.api.v1.SearchServiceOuterClass.RawSearchRequest
 import io.stackrox.proto.api.v1.SearchServiceOuterClass.SearchCategory
@@ -14,9 +15,7 @@ class AutocompleteTest extends BaseSpecification {
 
     private static final String GROUP_AUTOCOMPLETE = isPostgresRun() ? "GROUP" : "group"
 
-// TODO(ROX-13271): Investigate why AutocompleteTests fail with older Sensor versions and maybe fix it
-// Re-Add COMPATIBILITY tag here
-    @Category([BAT])
+    @Category([BAT, COMPATIBILITY])
     def "Verify Autocomplete: #query #category #contains"() {
         when:
         SearchServiceOuterClass.AutocompleteResponse resp = SearchService.autocomplete(
@@ -41,9 +40,7 @@ class AutocompleteTest extends BaseSpecification {
     }
 
     @Unroll
-// TODO(ROX-13271): Investigate why AutocompleteTests fail with older Sensor versions and maybe fix it
-// Re-Add COMPATIBILITY tag here
-    @Category([BAT])
+    @Category([BAT, COMPATIBILITY])
     def "Verify #category search options contains #options"() {
         when:
         def resp = SearchService.options(category)

--- a/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
@@ -44,6 +44,7 @@ import util.Env
 import util.Helpers
 import util.SlackUtil
 
+// TODO(ROX-13738): Re-enable these tests in compatibility-test step
 @Stepwise // We need to verify all of the expected alerts are present before other tests.
 class DefaultPoliciesTest extends BaseSpecification {
     // Deployment names

--- a/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
@@ -38,6 +38,7 @@ import spock.lang.Shared
 import spock.lang.Stepwise
 import spock.lang.Unroll
 
+// TODO(ROX-13739): Re-enable these tests in compatibility-test step
 @Stepwise
 class NetworkFlowTest extends BaseSpecification {
 


### PR DESCRIPTION
## Description

- Possible compatibility issues in QA tests for older version of sensors. Two bugs were created and JIRA and the TODO's are added as comments here.
- Fix a small bug where setting the fail fast to false actually enabled fail fast.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed


