### PR TITLE
[ROX-13741] Fix migration for active components

### DIFF
--- a/migrator/migrations/n_05_to_n_06_postgres_active_components/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_05_to_n_06_postgres_active_components/postgres/postgres_plugin.go
@@ -148,7 +148,7 @@ func (s *storeImpl) copyFromActiveComponents(ctx context.Context, tx pgx.Tx, obj
 
 			obj.GetId(),
 
-			obj.GetDeploymentId(),
+			pgutils.NilOrUUID(obj.GetDeploymentId()),
 
 			obj.GetComponentId(),
 

--- a/migrator/migrations/n_05_to_n_06_postgres_active_components/postgres/postgres_plugin.go
+++ b/migrator/migrations/n_05_to_n_06_postgres_active_components/postgres/postgres_plugin.go
@@ -77,7 +77,7 @@ func insertIntoActiveComponents(ctx context.Context, batch *pgx.Batch, obj *stor
 	values := []interface{}{
 		// parent primary keys start
 		obj.GetId(),
-		obj.GetDeploymentId(),
+		pgutils.NilOrUUID(obj.GetDeploymentId()),
 		obj.GetComponentId(),
 		serialized,
 	}


### PR DESCRIPTION
## Description

We have discovered this bug during testing of the 3.73.0 release.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## How to reproduce

1. Create Openshift 4 cluster
2. Create Central via operator
3. Create Secured Cluster via operator that connects to previously created central
4. After everything is connected and RocksDB is populated - edit Central CR and change `isEnabled` to `Enabled` for `db` property.
5. This will deploy the database and change settings in Central to use it. Migration will start and the problem should appear

## Testing

1. Execute unit tests for relevant migration but with the setting `batchAfter` to `1` so that Copy path is executed
2. It fails without this fix - an example of a test run can be found here: #3996 
3. With this fix, it works properly, and with executing the test with coverage, we can confirm that this execution path was used