### PR TITLE
ROX-13469: Skip auth integration tests

### DIFF
--- a/ui/apps/platform/cypress/integration/auth.test.js
+++ b/ui/apps/platform/cypress/integration/auth.test.js
@@ -33,7 +33,7 @@ describe.skip('Authentication', () => {
     };
 
     it('should redirect user to login page, authenticate and redirect to the requested page', () => {
-        // Added in 3985 and changed the failures without solving them.
+        // Added in 3985 and replaced intermittent failures for this test to frequent failures for the next test.
         localStorage.removeItem('access_token'); // replace possible valid token left over from previous test file
 
         stubAPIs();

--- a/ui/apps/platform/cypress/integration/auth.test.js
+++ b/ui/apps/platform/cypress/integration/auth.test.js
@@ -9,7 +9,7 @@ const pagePath = '/main/systemconfig';
 const AUTHENTICATED = true;
 const UNAUTHENTICATED = false;
 
-describe('Authentication', () => {
+describe.skip('Authentication', () => {
     const setupAuth = (landingUrl, authStatusValid, authStatusResponse = {}) => {
         cy.intercept('GET', api.auth.loginAuthProviders, { fixture: 'auth/authProviders.json' }).as(
             'authProviders'
@@ -24,6 +24,8 @@ describe('Authentication', () => {
     };
 
     const stubAPIs = () => {
+        // TODO If and when we solve the timing failures, explicitly mock relevant responses!
+
         // Cypress routes have an override behaviour, so defining this first makes it the fallback.
         // Replace /.*/ RegExp for route method with '/v1/*' string for intercept method
         // because it is not limited to XHR, therefore it matches HTML requests too!
@@ -31,7 +33,9 @@ describe('Authentication', () => {
     };
 
     it('should redirect user to login page, authenticate and redirect to the requested page', () => {
+        // Added in 3985 and changed the failures without solving them.
         localStorage.removeItem('access_token'); // replace possible valid token left over from previous test file
+
         stubAPIs();
         setupAuth(pagePath, AUTHENTICATED);
         cy.location('pathname').should('eq', loginUrl);


### PR DESCRIPTION
## Description

Three strikes and auth tests are out.

1. Replaced main Dashboard with System Configuration to reduce need to mock responses in #3917
2. Added the following line to the failing test in #3985

    ```js
    localStorage.removeItem('access_token'); // replace possible valid token left over from previous test file
    ```

    Behavior **before** the change: failures in either postgress or non-postgress, but not usually both for any particular merge, for the **first** test in the file:
    `should redirect user to login page, authenticate and redirect to the requested page`

3. Behavior **after** the change: failures often in both postgress and non-postgress for the **second** test in the file:
     `'should allow authenticated user to enter'`

## Checklist
- [x] Investigated and inspected CI test results
- [x] Skipped integration tests

## Testing Performed