### PR TITLE
Fix losing search params on node opening/clsoing in PF Network Graph

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraph.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraph.tsx
@@ -100,7 +100,7 @@ const TopologyComponent = ({ model }: TopologyComponentProps) => {
     }
 
     function closeSidebar() {
-        history.push(`${networkBasePathPF}`);
+        history.push(`${networkBasePathPF}${history.location.search as string}`);
     }
 
     function onSelect(ids: string[]) {
@@ -112,10 +112,14 @@ const TopologyComponent = ({ model }: TopologyComponentProps) => {
             const [newDetailType, newDetailId] = getUrlParamsForEntity(newSelectedEntity);
             // if found, and it's not the logical grouping of all external sources, then trigger URL update
             if (newDetailId !== 'EXTERNAL') {
-                history.push(`${networkBasePathPF}/${newDetailType}/${newDetailId}`);
+                history.push(
+                    `${networkBasePathPF}/${newDetailType}/${newDetailId}${
+                        history.location.search as string
+                    }`
+                );
             } else {
                 // otherwise, return to the graph-only state
-                history.push(`${networkBasePathPF}`);
+                history.push(`${networkBasePathPF}${history.location.search as string}`);
             }
         }
     }


### PR DESCRIPTION
## Description

The URL was not merging the selected cluster/namespace breadcrumb path with the selected deployment state on the graph.

This PR fixes that.

## Checklist
- [x] Investigated and inspected CI test results (ui-e2e-test failure is an unrelated flake)

## Testing Performed

Graph with search
<img width="1630" alt="Screen Shot 2022-12-02 at 10 41 26 AM" src="https://user-images.githubusercontent.com/715729/205333345-1f408e93-7833-4983-b072-55d5f7ee98d2.png">

Opening a node, search is preserved
<img width="1630" alt="Screen Shot 2022-12-02 at 10 41 35 AM" src="https://user-images.githubusercontent.com/715729/205333377-5a0deaf8-3011-4393-a4df-a609a2c19ac9.png">

Closing a node, search is still preserved
<img width="1630" alt="Screen Shot 2022-12-02 at 10 53 19 AM" src="https://user-images.githubusercontent.com/715729/205333395-165bd12a-15cd-41aa-8531-82ed40a2c645.png">
