### PR TITLE
Factor out helpers for Access Control integration tests

### DIFF
--- a/ui/apps/platform/cypress/constants/AccessControlPage.js
+++ b/ui/apps/platform/cypress/constants/AccessControlPage.js
@@ -1,31 +1,13 @@
 import scopeSelectors from '../helpers/scopeSelectors';
 
-export const authProvidersUrl = '/main/access-control/auth-providers';
-export const rolesUrl = '/main/access-control/roles';
-export const permissionSetsUrl = '/main/access-control/permission-sets';
-export const accessScopesUrl = '/main/access-control/access-scopes';
-
 function getFormGroupControlForLabel(label) {
     return `.pf-c-form__group-label:contains("${label}") + .pf-c-form__group-control`;
 }
 
 export const selectors = scopeSelectors('main', {
-    breadcrumbNav: '.pf-c-breadcrumb',
-    breadcrumbItem: '.pf-c-breadcrumb__item',
-    breadcrumbLink: 'a.pf-c-breadcrumb__link',
-    navLink: 'nav a',
-    navLinkCurrent: 'nav a.pf-m-current',
     alertTitle: '.pf-c-alert__title',
-    notFound: scopeSelectors('.pf-c-empty-state', {
-        title: 'h4',
-        a: 'a',
-    }),
 
     list: {
-        createButton: 'button:contains("Create")',
-        tdNameLink: 'td[data-label="Name"] a',
-        tdDescription: 'td[data-label="Description"]',
-
         authProviders: {
             dataRows: 'tbody tr',
             createDropdownItem: 'button:contains("Create auth provider") + ul button',

--- a/ui/apps/platform/cypress/constants/AccessControlPage.js
+++ b/ui/apps/platform/cypress/constants/AccessControlPage.js
@@ -14,9 +14,6 @@ export const selectors = scopeSelectors('main', {
             tdType: 'td[data-label="Type"]',
             tdMinimumAccessRole: 'td[data-label="Minimum access role',
             tdRules: 'td[data-label="Rules"]',
-            tdActions: 'td.pf-c-table__action .pf-c-dropdown__toggle',
-            deleteActionItem: 'td.pf-c-table__action button:contains("Delete auth provider")',
-            emptyState: '.pf-c-empty-state__content:contains("No auth providers")',
         },
 
         roles: {

--- a/ui/apps/platform/cypress/constants/AccessControlPage.js
+++ b/ui/apps/platform/cypress/constants/AccessControlPage.js
@@ -1,6 +1,5 @@
 import scopeSelectors from '../helpers/scopeSelectors';
 
-export const accessControlUrl = '/main/access-control';
 export const authProvidersUrl = '/main/access-control/auth-providers';
 export const rolesUrl = '/main/access-control/roles';
 export const permissionSetsUrl = '/main/access-control/permission-sets';
@@ -14,8 +13,6 @@ export const selectors = scopeSelectors('main', {
     breadcrumbNav: '.pf-c-breadcrumb',
     breadcrumbItem: '.pf-c-breadcrumb__item',
     breadcrumbLink: 'a.pf-c-breadcrumb__link',
-    h1: 'h1',
-    h2: 'h2',
     navLink: 'nav a',
     navLinkCurrent: 'nav a.pf-m-current',
     alertTitle: '.pf-c-alert__title',
@@ -26,8 +23,6 @@ export const selectors = scopeSelectors('main', {
 
     list: {
         createButton: 'button:contains("Create")',
-        th: 'th',
-        tdName: 'td[data-label="Name"]',
         tdNameLink: 'td[data-label="Name"] a',
         tdDescription: 'td[data-label="Description"]',
 

--- a/ui/apps/platform/cypress/helpers/request.js
+++ b/ui/apps/platform/cypress/helpers/request.js
@@ -64,8 +64,10 @@ export function waitForResponses(routeMatcherMap) {
     if (routeMatcherMap) {
         const aliases = Object.keys(routeMatcherMap).map((alias) => `@${alias}`);
 
-        cy.wait(aliases);
+        return cy.wait(aliases);
     }
+
+    return [];
 }
 
 /**
@@ -84,5 +86,5 @@ export function interactAndWaitForResponses(
 
     interactionCallback();
 
-    waitForResponses(routeMatcherMap);
+    return waitForResponses(routeMatcherMap);
 }

--- a/ui/apps/platform/cypress/helpers/request.js
+++ b/ui/apps/platform/cypress/helpers/request.js
@@ -59,6 +59,7 @@ export function interceptRequests(routeMatcherMap, staticResponseMap) {
  * Wait for responses after initial page visit or subsequent interaction.
  *
  * @param {Record<string, { method: string, url: string }>} [routeMatcherMap]
+ * @returns {{ request: Record<string, unknown>, response: Record<string, unknown>}[]}
  */
 export function waitForResponses(routeMatcherMap) {
     if (routeMatcherMap) {
@@ -76,6 +77,7 @@ export function waitForResponses(routeMatcherMap) {
  * @param {() => void} interactionCallback
  * @param {Record<string, { method: string, url: string }>} [routeMatcherMap]
  * @param {Record<string, { body: unknown } | { fixture: string }>} [staticResponseMap]
+ * @returns {{ request: Record<string, unknown>, response: Record<string, unknown>}[]}
  */
 export function interactAndWaitForResponses(
     interactionCallback,

--- a/ui/apps/platform/cypress/integration/accessControl/accessControl.helpers.js
+++ b/ui/apps/platform/cypress/integration/accessControl/accessControl.helpers.js
@@ -1,3 +1,4 @@
+import { interactAndWaitForResponses } from '../../helpers/request';
 import { getRegExpForTitleWithBranding } from '../../helpers/title';
 import { visit, visitWithStaticResponseForPermissions } from '../../helpers/visit';
 
@@ -221,3 +222,48 @@ export function clickEntityNameInTable(entitiesKey, entityName) {
 }
 
 // interact in entity page
+
+// Auth providers
+
+export const authProvidersAliasForPUT = 'PUT_authProviders';
+export const groupsBatchAliasForPOST = 'POST_groupsbatch';
+
+/**
+ * @param {Record<string, { body: unknown } | { fixture: string }>} [staticResponseMap]
+ */
+export function saveUpdatedAuthProvider(entityId, staticResponseMap) {
+    const routeMatcherMap = {
+        [authProvidersAliasForPUT]: {
+            method: 'PUT',
+            url: `/v1/authProviders/${entityId}`,
+        },
+        [groupsBatchAliasForPOST]: {
+            method: 'POST',
+            url: '/v1/groupsbatch',
+        },
+    };
+
+    return interactAndWaitForResponses(
+        () => {
+            cy.get('button:contains("Save")').click();
+        },
+        routeMatcherMap,
+        staticResponseMap
+    );
+}
+
+// Roles
+
+export function saveCreatedRole(entityName) {
+    const rolesAliasForPOST = 'POST_roles';
+    const routeMatcherMap = {
+        [rolesAliasForPOST]: {
+            method: 'POST',
+            url: `/v1/roles/${entityName}`, // url has entityName!
+        },
+    };
+
+    return interactAndWaitForResponses(() => {
+        cy.get('button:contains("Save")').click();
+    }, routeMatcherMap);
+}

--- a/ui/apps/platform/cypress/integration/accessControl/accessControl.helpers.js
+++ b/ui/apps/platform/cypress/integration/accessControl/accessControl.helpers.js
@@ -244,7 +244,7 @@ export function clickConfirmationToDeleteAuthProvider(entityId, staticResponseMa
 
     interactAndWaitForResponses(
         () => {
-            cy.get('.pf-c-modal-box__footer button:contains("Delete")');
+            cy.get('.pf-c-modal-box__footer button:contains("Delete")').click();
         },
         routeMatcherMap,
         staticResponseMap

--- a/ui/apps/platform/cypress/integration/accessControl/accessControl.helpers.js
+++ b/ui/apps/platform/cypress/integration/accessControl/accessControl.helpers.js
@@ -225,8 +225,34 @@ export function clickEntityNameInTable(entitiesKey, entityName) {
 
 // Auth providers
 
+export const authProvidersAliasForPOST = 'POST_authProviders';
 export const authProvidersAliasForPUT = 'PUT_authProviders';
 export const groupsBatchAliasForPOST = 'POST_groupsbatch';
+
+/**
+ * @param {Record<string, { body: unknown } | { fixture: string }>} [staticResponseMap]
+ */
+export function saveCreatedAuthProvider(staticResponseMap) {
+    const routeMatcherMap = {
+        [authProvidersAliasForPOST]: {
+            method: 'POST',
+            url: `/v1/authProviders`,
+        },
+        [groupsBatchAliasForPOST]: {
+            method: 'POST',
+            url: '/v1/groupsbatch',
+        },
+        [authProvidersAlias]: authProvidersRouteMatcher,
+    };
+
+    return interactAndWaitForResponses(
+        () => {
+            cy.get('button:contains("Save")').click();
+        },
+        routeMatcherMap,
+        staticResponseMap
+    );
+}
 
 /**
  * @param {Record<string, { body: unknown } | { fixture: string }>} [staticResponseMap]
@@ -241,6 +267,7 @@ export function saveUpdatedAuthProvider(entityId, staticResponseMap) {
             method: 'POST',
             url: '/v1/groupsbatch',
         },
+        [authProvidersAlias]: authProvidersRouteMatcher,
     };
 
     return interactAndWaitForResponses(

--- a/ui/apps/platform/cypress/integration/accessControl/accessControl.helpers.js
+++ b/ui/apps/platform/cypress/integration/accessControl/accessControl.helpers.js
@@ -225,7 +225,7 @@ export function clickRowActionMenuItemInTable(entityName, menuItemText) {
     cy.get(
         `tr:has(td[data-label="Name"] a:contains("${entityName}")) td.pf-c-table__action .pf-c-dropdown__toggle`
     ).click();
-    cy.get(`td.pf-c-table__action button[role="menuitem"]:contains("${menuItemText}")`);
+    cy.get(`td.pf-c-table__action button[role="menuitem"]:contains("${menuItemText}")`).click();
 }
 
 export const authProvidersAliasForDELETE = 'DELETE_authProviders';

--- a/ui/apps/platform/cypress/integration/accessControl/accessControl.helpers.js
+++ b/ui/apps/platform/cypress/integration/accessControl/accessControl.helpers.js
@@ -193,12 +193,7 @@ export function visitAccessControlEntitiesWithStaticResponseForPermissions(
     staticResponseForPermissions
 ) {
     const entitiesPath = getEntitiesPath(entitiesKey);
-    const routeMatcherMap = routeMatcherMapForEntitiesMap[entitiesKey];
-    visitWithStaticResponseForPermissions(
-        entitiesPath,
-        staticResponseForPermissions,
-        routeMatcherMap
-    );
+    visitWithStaticResponseForPermissions(entitiesPath, staticResponseForPermissions);
 
     cy.get(`h1:contains("${containerTitle}")`);
 }

--- a/ui/apps/platform/cypress/integration/accessControl/accessControl.helpers.js
+++ b/ui/apps/platform/cypress/integration/accessControl/accessControl.helpers.js
@@ -23,42 +23,42 @@ function getEntityPath(entitiesKey, entityId) {
     return `${basePath}/${entitiesKey}/${entityId}`;
 }
 
-// Export endpoint aliases and route matchers for entities.
+// Export endpoint aliases for entities.
 
 export const authProvidersAlias = 'authProviders';
-export const authProvidersRouteMatcher = {
+const authProvidersRouteMatcher = {
     method: 'GET',
     url: '/v1/authProviders',
 };
 
 export const rolesAlias = 'roles';
-export const rolesRouteMatcher = {
+const rolesRouteMatcher = {
     method: 'GET',
     url: '/v1/roles',
 };
 
 export const permissionSetsAlias = 'permissionsets';
-export const permissionSetsRouteMatcher = {
+const permissionSetsRouteMatcher = {
     method: 'GET',
     url: '/v1/permissionsets',
 };
 
 export const accessScopesAlias = 'simpleaccessscopes';
-export const accessScopesRouteMatcher = {
+const accessScopesRouteMatcher = {
     method: 'GET',
     url: '/v1/simpleaccessscopes',
 };
 
-// Export endpoint aliases and route matchers for related information.
+// Export endpoint aliases for related information.
 
 export const groupsAlias = 'groups';
-export const groupsRouteMatcher = {
+const groupsRouteMatcher = {
     method: 'GET',
     url: '/v1/groups',
 };
 
 export const resourcesAlias = 'resources';
-export const resourcesRouteMatcher = {
+const resourcesRouteMatcher = {
     method: 'GET',
     url: '/v1/resources',
 };

--- a/ui/apps/platform/cypress/integration/accessControl/accessControl.helpers.js
+++ b/ui/apps/platform/cypress/integration/accessControl/accessControl.helpers.js
@@ -1,0 +1,171 @@
+import { visit, visitWithStaticResponseForPermissions } from '../../helpers/visit';
+
+// Keys are path segments which correspond to entitiesKey arguments of functions below.
+export const authProvidersKey = 'auth-providers';
+export const rolesKey = 'roles';
+export const permissionSetsKey = 'permission-sets';
+export const accessScopesKey = 'access-scopes';
+
+// Keys order corresponds to tabs in user interface.
+const entitiesKeys = [authProvidersKey, rolesKey, permissionSetsKey, accessScopesKey];
+
+// Encapsulate page addresses.
+
+const basePath = '/main/access-control';
+
+function getEntitiesPath(entitiesKey) {
+    return `${basePath}/${entitiesKey}`;
+}
+
+function getEntityPath(entitiesKey, entityId) {
+    return `${basePath}/${entitiesKey}/${entityId}`;
+}
+
+// Export endpoint aliases and route matchers for entities.
+
+export const authProvidersAlias = 'authProviders';
+export const authProvidersRouteMatcher = {
+    method: 'GET',
+    url: '/v1/authProviders',
+};
+
+export const rolesAlias = 'roles';
+export const rolesRouteMatcher = {
+    method: 'GET',
+    url: '/v1/roles',
+};
+
+export const permissionSetsAlias = 'permissionsets';
+export const permissionSetsRouteMatcher = {
+    method: 'GET',
+    url: '/v1/permissionsets',
+};
+
+export const accessScopesAlias = 'simpleaccessscopes';
+export const accessScopesRouteMatcher = {
+    method: 'GET',
+    url: '/v1/simpleaccessscopes',
+};
+
+// Export endpoint aliases and route matchers for related information.
+
+export const groupsAlias = 'groups';
+export const groupsRouteMatcher = {
+    method: 'GET',
+    url: '/v1/groups',
+};
+
+export const resourcesAlias = 'resources';
+export const resourcesRouteMatcher = {
+    method: 'GET',
+    url: '/v1/resources',
+};
+
+// Encapsulate map from entities keys to routeMatcherMap objects.
+
+const routeMatcherMapForEntitiesMap = {
+    [authProvidersKey]: {
+        [authProvidersAlias]: authProvidersRouteMatcher,
+        [rolesAlias]: rolesRouteMatcher,
+        [groupsAlias]: groupsRouteMatcher,
+    },
+    [rolesKey]: {
+        [rolesAlias]: rolesRouteMatcher,
+        [groupsAlias]: groupsRouteMatcher,
+        [authProvidersAlias]: authProvidersRouteMatcher,
+        [permissionSetsAlias]: permissionSetsRouteMatcher,
+        [accessScopesAlias]: accessScopesRouteMatcher,
+    },
+    [permissionSetsKey]: {
+        [permissionSetsAlias]: permissionSetsRouteMatcher,
+        [resourcesAlias]: resourcesRouteMatcher,
+        [rolesAlias]: rolesRouteMatcher,
+    },
+    [accessScopesKey]: {
+        [accessScopesAlias]: accessScopesRouteMatcher,
+        [rolesAlias]: rolesRouteMatcher,
+    },
+};
+
+// Encapsulate page titles.
+
+const containerTitle = 'Access Control';
+
+const entitiesTitleMap = {
+    [authProvidersKey]: 'Auth providers',
+    [rolesKey]: 'Roles',
+    [permissionSetsKey]: 'Permission sets',
+    [accessScopesKey]: 'Access scopes',
+};
+
+// assert helpers
+
+function assertAccessControlNavLinks(entitiesKeySelected) {
+    entitiesKeys.forEach((entitiesKey) => {
+        const entitiesTitle = entitiesTitleMap[entitiesKey];
+        const isSelected = entitiesKey === entitiesKeySelected;
+
+        cy.get(`nav a.pf-c-nav__link:contains("${entitiesTitle}")`).should(
+            isSelected ? 'have.class' : 'not.have.class',
+            'pf-m-current'
+        );
+    });
+}
+
+export function assertAccessControlEntitiesTable(entitiesKey) {
+    cy.get(`h1:contains("${containerTitle}")`);
+    cy.get('.pf-c-breadcrumb').should('not.exist');
+    assertAccessControlNavLinks(entitiesKey);
+}
+
+// visit helpers
+
+/**
+ * @param {Record<string, { body: unknown } | { fixture: string }>} [staticResponseMap]
+ */
+export function visitAccessControlEntities(entitiesKey, staticResponseMap) {
+    visit(
+        getEntitiesPath(entitiesKey),
+        routeMatcherMapForEntitiesMap[entitiesKey],
+        staticResponseMap
+    );
+
+    assertAccessControlEntitiesTable(entitiesKey);
+}
+
+/**
+ * @param {'auth-providers' | 'roles' | 'permission-sets' | 'roles'} entitiesKey
+ * @param {{ body: unknown } | { fixture: string }} staticResponseForPermissions
+ */
+export function visitAccessControlEntitiesWithStaticResponseForPermissions(
+    entitiesKey,
+    staticResponseForPermissions
+) {
+    visitWithStaticResponseForPermissions(
+        getEntitiesPath(entitiesKey),
+        staticResponseForPermissions,
+        routeMatcherMapForEntitiesMap[entitiesKey]
+    );
+
+    cy.get(`h1:contains("${containerTitle}")`);
+}
+
+/**
+ * @param {Record<string, { body: unknown } | { fixture: string }>} [staticResponseMap]
+ */
+export function visitAccessControlEntity(entitiesKey, entityId, staticResponseMap) {
+    visit(
+        getEntityPath(entitiesKey, entityId),
+        routeMatcherMapForEntitiesMap[entitiesKey],
+        staticResponseMap
+    );
+}
+
+// interact in entities table
+
+export function clickEntityNameInTable(_entitiesKey, entityName) {
+    // Use entitiesKey if page ever makes a request.
+    cy.get(`td[data-label="Name"] a:contains("${entityName}")`).click();
+}
+
+// interact in entity page

--- a/ui/apps/platform/cypress/integration/accessControl/accessControl.helpers.js
+++ b/ui/apps/platform/cypress/integration/accessControl/accessControl.helpers.js
@@ -162,6 +162,9 @@ export function assertAccessControlEntityPage(entitiesKey) {
 }
 
 export function assertAccessControlEntityDoesNotExist(entitiesKey) {
+    cy.get('h2').should('not.exist');
+    cy.get('li.pf-c-breadcrumb__item:nth-child(2)').should('not.exist');
+
     cy.get('.pf-c-empty-state h4').should(
         'have.text',
         `${entityTitleMap[entitiesKey]} does not exist`

--- a/ui/apps/platform/cypress/integration/accessControl/accessControl.helpers.js
+++ b/ui/apps/platform/cypress/integration/accessControl/accessControl.helpers.js
@@ -162,11 +162,12 @@ export function assertAccessControlEntityPage(entitiesKey) {
 }
 
 export function assertAccessControlEntityDoesNotExist(entitiesKey) {
-    const entityTitle = entityTitleMap[entitiesKey];
-
-    cy.get('.pf-c-empty-state h4').should('have.text', `${entityTitle} does not exist`);
+    cy.get('.pf-c-empty-state h4').should(
+        'have.text',
+        `${entityTitleMap[entitiesKey]} does not exist`
+    );
     cy.get('.pf-c-empty-state a')
-        .should('have.text', entityTitle)
+        .should('have.text', entitiesTitleMap[entitiesKey])
         .should('have.attr', 'href', getEntitiesPath(entitiesKey));
 }
 

--- a/ui/apps/platform/cypress/integration/accessControl/accessControl.helpers.js
+++ b/ui/apps/platform/cypress/integration/accessControl/accessControl.helpers.js
@@ -221,6 +221,36 @@ export function clickEntityNameInTable(entitiesKey, entityName) {
     assertAccessControlEntityPage(entitiesKey);
 }
 
+export function clickRowActionMenuItemInTable(entityName, menuItemText) {
+    cy.get(
+        `tr:has(td[data-label="Name"] a:contains("${entityName}")) td.pf-c-table__action .pf-c-dropdown__toggle`
+    ).click();
+    cy.get(`td.pf-c-table__action button[role="menuitem"]:contains("${menuItemText}")`);
+}
+
+export const authProvidersAliasForDELETE = 'DELETE_authProviders';
+
+/**
+ * @param {Record<string, { body: unknown } | { fixture: string }>} [staticResponseMap]
+ */
+export function clickConfirmationToDeleteAuthProvider(entityId, staticResponseMap) {
+    const routeMatcherMap = {
+        [authProvidersAliasForDELETE]: {
+            method: 'DELETE',
+            url: `/v1/authProviders/${entityId}`,
+        },
+        [authProvidersAlias]: authProvidersRouteMatcher,
+    };
+
+    interactAndWaitForResponses(
+        () => {
+            cy.get('.pf-c-modal-box__footer button:contains("Delete")');
+        },
+        routeMatcherMap,
+        staticResponseMap
+    );
+}
+
 // interact in entity page
 
 // Auth providers

--- a/ui/apps/platform/cypress/integration/accessControl/accessControl.selectors.js
+++ b/ui/apps/platform/cypress/integration/accessControl/accessControl.selectors.js
@@ -1,4 +1,4 @@
-import scopeSelectors from '../helpers/scopeSelectors';
+import scopeSelectors from '../../helpers/scopeSelectors';
 
 function getFormGroupControlForLabel(label) {
     return `.pf-c-form__group-label:contains("${label}") + .pf-c-form__group-control`;

--- a/ui/apps/platform/cypress/integration/accessControl/accessControlAccessScopes.test.js
+++ b/ui/apps/platform/cypress/integration/accessControl/accessControlAccessScopes.test.js
@@ -1,17 +1,15 @@
-import { accessScopesUrl, selectors } from '../../constants/AccessControlPage';
+import { selectors } from '../../constants/AccessControlPage';
 
 import withAuth from '../../helpers/basicAuth';
-import { getRegExpForTitleWithBranding } from '../../helpers/title';
 
 import {
     accessScopesKey as entitiesKey,
+    assertAccessControlEntityDoesNotExist,
     clickEntityNameInTable,
     visitAccessControlEntities,
     visitAccessControlEntitiesWithStaticResponseForPermissions,
     visitAccessControlEntity,
 } from './accessControl.helpers';
-
-const h2 = 'Access scopes';
 
 const defaultNames = ['Unrestricted', 'Deny All'];
 
@@ -36,11 +34,9 @@ describe('Access Control Access scopes', () => {
     it('list has heading, button, and table head cells', () => {
         visitAccessControlEntities(entitiesKey);
 
-        // Table has plural noun in title.
-        cy.title().should('match', getRegExpForTitleWithBranding(`Access Control - ${h2}`));
-
         cy.contains('h2', /^\d+ results? found$/);
-        cy.get(selectors.list.createButton).should('have.text', 'Create access scope');
+
+        cy.get('button:contains("Create access scope")');
 
         cy.get('th:contains("Name")');
         cy.get('th:contains("Description")');
@@ -50,27 +46,20 @@ describe('Access Control Access scopes', () => {
     it('list has default names', () => {
         visitAccessControlEntities(entitiesKey);
 
-        defaultNames.forEach((name) => {
-            cy.get(`td[data-label="Name"] a:contains("${name}")`);
+        defaultNames.forEach((defaultName) => {
+            cy.get(`td[data-label="Name"] a:contains("${defaultName}")`);
         });
     });
 
     it('list link for default Deny All goes to form which has label instead of button and disabled input values', () => {
         visitAccessControlEntities(entitiesKey);
 
-        const name = 'Deny All';
-        clickEntityNameInTable(entitiesKey, name);
+        const entityName = 'Deny All';
+        clickEntityNameInTable(entitiesKey, entityName);
 
-        // Form has singular noun in title.
-        cy.title().should('match', getRegExpForTitleWithBranding(`Access Control - Access scope`));
+        cy.get(`h2:contains("${entityName}")`);
+        cy.get(`li.pf-c-breadcrumb__item:nth-child(2):contains("${entityName}")`);
 
-        cy.get(`${selectors.breadcrumbItem}:nth-child(1):contains("${h2}")`);
-        cy.get(`${selectors.breadcrumbItem}:nth-child(2):contains("${name}")`);
-
-        cy.get('h1').should('not.exist');
-        cy.get(selectors.navLinkCurrent).should('not.exist');
-
-        cy.get('h2').should('have.text', name);
         cy.get(selectors.form.notEditableLabel).should('exist');
         cy.get(selectors.form.editButton).should('not.exist');
 
@@ -83,16 +72,9 @@ describe('Access Control Access scopes', () => {
 
         visitAccessControlEntity(entitiesKey, entityId);
 
-        cy.get(`${selectors.breadcrumbItem}:nth-child(1):contains("${h2}")`);
-        cy.get(`${selectors.breadcrumbItem}:nth-child(2)`).should('not.exist');
-
-        cy.get('h1').should('not.exist');
-        cy.get(selectors.navLinkCurrent).should('not.exist');
         cy.get('h2').should('not.exist');
+        cy.get('li.pf-c-breadcrumb__item:nth-child(2)').should('not.exist');
 
-        cy.get(selectors.notFound.title).should('have.text', 'Access scope does not exist');
-        cy.get(selectors.notFound.a)
-            .should('have.text', h2)
-            .should('have.attr', 'href', accessScopesUrl);
+        assertAccessControlEntityDoesNotExist(entitiesKey);
     });
 });

--- a/ui/apps/platform/cypress/integration/accessControl/accessControlAccessScopes.test.js
+++ b/ui/apps/platform/cypress/integration/accessControl/accessControlAccessScopes.test.js
@@ -69,11 +69,7 @@ describe('Access Control Access scopes', () => {
 
     it('displays message instead of form if entity id does not exist', () => {
         const entityId = 'bogus';
-
         visitAccessControlEntity(entitiesKey, entityId);
-
-        cy.get('h2').should('not.exist');
-        cy.get('li.pf-c-breadcrumb__item:nth-child(2)').should('not.exist');
 
         assertAccessControlEntityDoesNotExist(entitiesKey);
     });

--- a/ui/apps/platform/cypress/integration/accessControl/accessControlAccessScopes.test.js
+++ b/ui/apps/platform/cypress/integration/accessControl/accessControlAccessScopes.test.js
@@ -41,6 +41,7 @@ describe('Access Control Access scopes', () => {
         cy.get('th:contains("Name")');
         cy.get('th:contains("Description")');
         cy.get('th:contains("Roles")');
+        cy.get('th[aria-label="Row actions"]');
     });
 
     it('list has default names', () => {

--- a/ui/apps/platform/cypress/integration/accessControl/accessControlAccessScopes.test.js
+++ b/ui/apps/platform/cypress/integration/accessControl/accessControlAccessScopes.test.js
@@ -1,5 +1,3 @@
-import { selectors } from '../../constants/AccessControlPage';
-
 import withAuth from '../../helpers/basicAuth';
 
 import {
@@ -10,6 +8,7 @@ import {
     visitAccessControlEntitiesWithStaticResponseForPermissions,
     visitAccessControlEntity,
 } from './accessControl.helpers';
+import { selectors } from './accessControl.selectors';
 
 const defaultNames = ['Unrestricted', 'Deny All'];
 

--- a/ui/apps/platform/cypress/integration/accessControl/accessControlAuthProviders.test.js
+++ b/ui/apps/platform/cypress/integration/accessControl/accessControlAuthProviders.test.js
@@ -1,4 +1,3 @@
-import { selectors, accessModalSelectors } from '../../constants/AccessControlPage';
 import sampleCert from '../../helpers/sampleCert';
 import { generateNameWithDate, getInputByLabel } from '../../helpers/formHelpers';
 import updateMinimumAccessRoleRequest from '../../fixtures/auth/updateMinimumAccessRole.json';
@@ -24,6 +23,7 @@ import {
     visitAccessControlEntitiesWithStaticResponseForPermissions,
     visitAccessControlEntity,
 } from './accessControl.helpers';
+import { selectors, accessModalSelectors } from './accessControl.selectors';
 
 describe('Access Control Auth providers', () => {
     withAuth();

--- a/ui/apps/platform/cypress/integration/accessControl/accessControlAuthProviders.test.js
+++ b/ui/apps/platform/cypress/integration/accessControl/accessControlAuthProviders.test.js
@@ -175,9 +175,6 @@ describe('Access Control Auth providers', () => {
         };
         saveUpdatedAuthProvider(entityId, staticResponseMapForUpdatedAuthProvider);
 
-        cy.get(selectors.form.saveButton).click();
-        cy.wait(['@PutAuthProvider', '@PostGroupsBatch']);
-
         cy.get(inputClientSecret)
             .should('be.disabled')
             .should('have.value', '')

--- a/ui/apps/platform/cypress/integration/accessControl/accessControlAuthProviders.test.js
+++ b/ui/apps/platform/cypress/integration/accessControl/accessControlAuthProviders.test.js
@@ -11,10 +11,12 @@ import {
     assertAccessControlEntityDoesNotExist,
     assertAccessControlEntityPage,
     authProvidersAlias,
+    authProvidersAliasForPOST,
     authProvidersAliasForPUT,
     authProvidersKey as entitiesKey,
     groupsAlias,
     groupsBatchAliasForPOST,
+    saveCreatedAuthProvider,
     saveUpdatedAuthProvider,
     visitAccessControlEntities,
     visitAccessControlEntitiesWithStaticResponseForPermissions,
@@ -313,15 +315,14 @@ describe('Access Control Auth providers', () => {
             delay: 1,
         });
 
-        cy.intercept('POST', api.auth.authProviders, { body: mockUserCertResponse }).as(
-            'CreateAuthProvider'
-        ); // mock POST means that the list is empty after save
+        const staticResponseMapForCreatedAuthProvider = {
+            [authProvidersAliasForPOST]: {
+                body: mockUserCertResponse,
+            },
+        };
+        saveCreatedAuthProvider(staticResponseMapForCreatedAuthProvider);
 
-        cy.get(selectors.form.saveButton).should('be.enabled').click();
-
-        cy.wait('@CreateAuthProvider'); // wait for POST to finish
-        cy.wait('@authProviders'); // wait for GET to finish, which means redirect back to list page
-        cy.location('pathname').should('eq', '/main/access-control/auth-providers');
+        assertAccessControlEntitiesPage(entitiesKey);
         cy.location('search').should('eq', '');
     });
 

--- a/ui/apps/platform/cypress/integration/accessControl/accessControlAuthProviders.test.js
+++ b/ui/apps/platform/cypress/integration/accessControl/accessControlAuthProviders.test.js
@@ -389,11 +389,7 @@ describe('Access Control Auth providers', () => {
 
     it('displays message instead of form if entity id does not exist', () => {
         const entityId = 'bogus';
-
         visitAccessControlEntity(entitiesKey, entityId);
-
-        cy.get('h2').should('not.exist');
-        cy.get('li.pf-c-breadcrumb__item:nth-child(2)').should('not.exist');
 
         assertAccessControlEntityDoesNotExist(entitiesKey);
     });

--- a/ui/apps/platform/cypress/integration/accessControl/accessControlAuthProviders.test.js
+++ b/ui/apps/platform/cypress/integration/accessControl/accessControlAuthProviders.test.js
@@ -1,18 +1,15 @@
-import {
-    authProvidersUrl,
-    selectors,
-    accessModalSelectors,
-} from '../../constants/AccessControlPage';
+import { selectors, accessModalSelectors } from '../../constants/AccessControlPage';
 import * as api from '../../constants/apiEndpoints';
 import sampleCert from '../../helpers/sampleCert';
 import { generateNameWithDate, getInputByLabel } from '../../helpers/formHelpers';
-import { getRegExpForTitleWithBranding } from '../../helpers/title';
 import updateMinimumAccessRoleRequest from '../../fixtures/auth/updateMinimumAccessRole.json';
 
 import withAuth from '../../helpers/basicAuth';
 
 import {
-    assertAccessControlEntitiesTable,
+    assertAccessControlEntitiesPage,
+    assertAccessControlEntityDoesNotExist,
+    assertAccessControlEntityPage,
     authProvidersAlias,
     authProvidersKey as entitiesKey,
     groupsAlias,
@@ -20,8 +17,6 @@ import {
     visitAccessControlEntitiesWithStaticResponseForPermissions,
     visitAccessControlEntity,
 } from './accessControl.helpers';
-
-const h2 = 'Auth providers';
 
 describe('Access Control Auth providers', () => {
     withAuth();
@@ -49,12 +44,6 @@ describe('Access Control Auth providers', () => {
         };
         visitAccessControlEntities(entitiesKey, staticResponseMap);
 
-        // Table has plural noun in title.
-        cy.title().should(
-            'match',
-            getRegExpForTitleWithBranding(`Access Control - Auth Providers`)
-        );
-
         cy.get('th:contains("Name")');
         cy.get('th:contains("Type")');
         cy.get('th:contains("Minimum access role")');
@@ -66,19 +55,13 @@ describe('Access Control Auth providers', () => {
 
         const type = 'Auth0';
 
-        cy.get(selectors.list.createButton).click();
+        cy.get('button:contains("Create auth provider")').click();
         cy.get(`${selectors.list.authProviders.createDropdownItem}:contains("${type}")`).click();
 
-        // Form has singular noun in title.
-        cy.title().should('match', getRegExpForTitleWithBranding(`Access Control - Auth provider`));
-
-        cy.get(`${selectors.breadcrumbItem}:nth-child(1):contains("${h2}")`);
-        cy.get(`${selectors.breadcrumbItem}:nth-child(2):contains("Create ${type} provider")`);
-
-        cy.get('h1').should('not.exist');
-        cy.get(selectors.navLinkCurrent).should('not.exist');
+        assertAccessControlEntityPage(entitiesKey);
 
         cy.get('h2').should('have.text', `Create ${type} provider`);
+        cy.get(`li.pf-c-breadcrumb__item:nth-child(2):contains("Create ${type} provider")`);
 
         cy.get(selectors.form.inputName).should('be.enabled').should('have.attr', 'required');
         cy.get(selectors.form.authProvider.selectAuthProviderType)
@@ -95,7 +78,7 @@ describe('Access Control Auth providers', () => {
         cy.get(selectors.form.saveButton).should('be.disabled');
         cy.get(selectors.form.cancelButton).click();
 
-        assertAccessControlEntitiesTable(entitiesKey);
+        assertAccessControlEntitiesPage(entitiesKey);
     });
 
     it('add OpenID Connect', () => {
@@ -103,16 +86,13 @@ describe('Access Control Auth providers', () => {
 
         const type = 'OpenID Connect';
 
-        cy.get(selectors.list.createButton).click();
+        cy.get('button:contains("Create auth provider")').click();
         cy.get(`${selectors.list.authProviders.createDropdownItem}:contains("${type}")`).click();
 
-        cy.get(`${selectors.breadcrumbItem}:nth-child(1):contains("${h2}")`);
-        cy.get(`${selectors.breadcrumbItem}:nth-child(2):contains("Create ${type} provider")`);
-
-        cy.get('h1').should('not.exist');
-        cy.get(selectors.navLinkCurrent).should('not.exist');
+        assertAccessControlEntityPage(entitiesKey);
 
         cy.get('h2').should('have.text', `Create ${type} provider`);
+        cy.get(`li.pf-c-breadcrumb__item:nth-child(2):contains("Create ${type} provider")`);
 
         cy.get(selectors.form.inputName).should('be.enabled').should('have.attr', 'required');
         cy.get(selectors.form.authProvider.selectAuthProviderType)
@@ -246,16 +226,13 @@ describe('Access Control Auth providers', () => {
 
         const type = 'SAML 2.0';
 
-        cy.get(selectors.list.createButton).click();
+        cy.get('button:contains("Create auth provider")').click();
         cy.get(`${selectors.list.authProviders.createDropdownItem}:contains("${type}")`).click();
 
-        cy.get(`${selectors.breadcrumbItem}:nth-child(1):contains("${h2}")`);
-        cy.get(`${selectors.breadcrumbItem}:nth-child(2):contains("Create ${type} provider")`);
-
-        cy.get('h1').should('not.exist');
-        cy.get(selectors.navLinkCurrent).should('not.exist');
+        assertAccessControlEntityPage(entitiesKey);
 
         cy.get('h2').should('have.text', `Create ${type} provider`);
+        cy.get(`li.pf-c-breadcrumb__item:nth-child(2):contains("Create ${type} provider")`);
 
         cy.get(selectors.form.inputName).should('be.enabled').should('have.attr', 'required');
         cy.get(selectors.form.authProvider.selectAuthProviderType)
@@ -275,7 +252,7 @@ describe('Access Control Auth providers', () => {
         cy.get(selectors.form.saveButton).should('be.disabled');
         cy.get(selectors.form.cancelButton).click();
 
-        assertAccessControlEntitiesTable(entitiesKey);
+        assertAccessControlEntitiesPage(entitiesKey);
     });
 
     it('add User Certificates', () => {
@@ -300,16 +277,13 @@ describe('Access Control Auth providers', () => {
 
         const type = 'User Certificates';
 
-        cy.get(selectors.list.createButton).click();
+        cy.get('button:contains("Create auth provider")').click();
         cy.get(`${selectors.list.authProviders.createDropdownItem}:contains("${type}")`).click();
 
-        cy.get(`${selectors.breadcrumbItem}:nth-child(1):contains("${h2}")`);
-        cy.get(`${selectors.breadcrumbItem}:nth-child(2):contains("Create ${type} provider")`);
-
-        cy.get('h1').should('not.exist');
-        cy.get(selectors.navLinkCurrent).should('not.exist');
+        assertAccessControlEntityPage(entitiesKey);
 
         cy.get('h2').should('have.text', `Create ${type} provider`);
+        cy.get(`li.pf-c-breadcrumb__item:nth-child(2):contains("Create ${type} provider")`);
 
         getInputByLabel('Name').should('be.enabled').should('have.attr', 'required');
         cy.get(selectors.form.authProvider.selectAuthProviderType)
@@ -345,16 +319,13 @@ describe('Access Control Auth providers', () => {
 
         const type = 'Google IAP';
 
-        cy.get(selectors.list.createButton).click();
+        cy.get('button:contains("Create auth provider")').click();
         cy.get(`${selectors.list.authProviders.createDropdownItem}:contains("${type}")`).click();
 
-        cy.get(`${selectors.breadcrumbItem}:nth-child(1):contains("${h2}")`);
-        cy.get(`${selectors.breadcrumbItem}:nth-child(2):contains("Create ${type} provider")`);
-
-        cy.get('h1').should('not.exist');
-        cy.get(selectors.navLinkCurrent).should('not.exist');
+        assertAccessControlEntityPage(entitiesKey);
 
         cy.get('h2').should('have.text', `Create ${type} provider`);
+        cy.get(`li.pf-c-breadcrumb__item:nth-child(2):contains("Create ${type} provider")`);
 
         cy.get(selectors.form.inputName).should('be.enabled').should('have.attr', 'required');
         cy.get(selectors.form.authProvider.selectAuthProviderType)
@@ -368,7 +339,7 @@ describe('Access Control Auth providers', () => {
         cy.get(selectors.form.saveButton).should('be.disabled');
         cy.get(selectors.form.cancelButton).click();
 
-        assertAccessControlEntitiesTable(entitiesKey);
+        assertAccessControlEntitiesPage(entitiesKey);
     });
 
     describe('empty state', () => {
@@ -421,16 +392,9 @@ describe('Access Control Auth providers', () => {
 
         visitAccessControlEntity(entitiesKey, entityId);
 
-        cy.get(`${selectors.breadcrumbItem}:nth-child(1):contains("${h2}")`);
-        cy.get(`${selectors.breadcrumbItem}:nth-child(2)`).should('not.exist');
-
-        cy.get('h1').should('not.exist');
-        cy.get(selectors.navLinkCurrent).should('not.exist');
         cy.get('h2').should('not.exist');
+        cy.get('li.pf-c-breadcrumb__item:nth-child(2)').should('not.exist');
 
-        cy.get(selectors.notFound.title).should('have.text', 'Auth provider does not exist');
-        cy.get(selectors.notFound.a)
-            .should('have.text', h2)
-            .should('have.attr', 'href', authProvidersUrl);
+        assertAccessControlEntityDoesNotExist(entitiesKey);
     });
 });

--- a/ui/apps/platform/cypress/integration/accessControl/accessControlAuthProviders.test.js
+++ b/ui/apps/platform/cypress/integration/accessControl/accessControlAuthProviders.test.js
@@ -51,6 +51,7 @@ describe('Access Control Auth providers', () => {
         cy.get('th:contains("Type")');
         cy.get('th:contains("Minimum access role")');
         cy.get('th:contains("Assigned rules")');
+        cy.get('th[aria-label="Row actions"]');
     });
 
     it('add Auth0', () => {

--- a/ui/apps/platform/cypress/integration/accessControl/accessControlAuthProviders.test.js
+++ b/ui/apps/platform/cypress/integration/accessControl/accessControlAuthProviders.test.js
@@ -132,6 +132,11 @@ describe('Access Control Auth providers', () => {
         cy.get(`${selectCallbackModeItem}:contains("HTTP POST")`).click();
         cy.get(checkboxDoNotUseClientSecret).check();
         cy.get(inputClientSecret).should('be.disabled').should('not.have.attr', 'required');
+
+        cy.get(selectors.form.saveButton).should('be.disabled');
+        cy.get(selectors.form.cancelButton).click();
+
+        assertAccessControlEntitiesPage(entitiesKey);
     });
 
     it('edits OpenID Connect with a client secret without losing the value', () => {

--- a/ui/apps/platform/cypress/integration/accessControl/accessControlPermissionSets.test.js
+++ b/ui/apps/platform/cypress/integration/accessControl/accessControlPermissionSets.test.js
@@ -1,18 +1,16 @@
-import { permissionSetsUrl, selectors } from '../../constants/AccessControlPage';
+import { selectors } from '../../constants/AccessControlPage';
 
 import withAuth from '../../helpers/basicAuth';
-import { getRegExpForTitleWithBranding } from '../../helpers/title';
 import { hasFeatureFlag } from '../../helpers/features';
 
 import {
+    assertAccessControlEntityDoesNotExist,
     clickEntityNameInTable,
     permissionSetsKey as entitiesKey,
     visitAccessControlEntities,
     visitAccessControlEntitiesWithStaticResponseForPermissions,
     visitAccessControlEntity,
 } from './accessControl.helpers';
-
-const h2 = 'Permission sets';
 
 const defaultNames = ['Admin', 'Analyst', 'Continuous Integration', 'None', 'Sensor Creator'];
 
@@ -37,14 +35,9 @@ describe('Access Control Permission sets', () => {
     it('list has heading, button, and table head cells', () => {
         visitAccessControlEntities(entitiesKey);
 
-        // Table has plural noun in title.
-        cy.title().should(
-            'match',
-            getRegExpForTitleWithBranding(`Access Control - Permission sets`)
-        );
-
         cy.contains('h2', /^\d+ results? found$/);
-        cy.get(selectors.list.createButton).should('have.text', 'Create permission set');
+
+        cy.get('button:contains("Create permission set")');
 
         cy.get('th:contains("Name")');
         cy.get('th:contains("Description")');
@@ -54,30 +47,20 @@ describe('Access Control Permission sets', () => {
     it('list has default names', () => {
         visitAccessControlEntities(entitiesKey);
 
-        defaultNames.forEach((name) => {
-            cy.get(`td[data-label="Name"] a:contains("${name}")`);
+        defaultNames.forEach((defaultName) => {
+            cy.get(`td[data-label="Name"] a:contains("${defaultName}")`);
         });
     });
 
     it('list link for default Admin goes to form which has label instead of button and disabled input values', () => {
         visitAccessControlEntities(entitiesKey);
 
-        const name = 'Admin';
-        clickEntityNameInTable(entitiesKey, name);
+        const entityName = 'Admin';
+        clickEntityNameInTable(entitiesKey, entityName);
 
-        // Form has singular noun in title.
-        cy.title().should(
-            'match',
-            getRegExpForTitleWithBranding(`Access Control - Permission set`)
-        );
+        cy.get('h2').should('have.text', entityName);
+        cy.get(`li.pf-c-breadcrumb__item:nth-child(2):contains("${entityName}")`);
 
-        cy.get(`${selectors.breadcrumbItem}:nth-child(1):contains("${h2}")`);
-        cy.get(`${selectors.breadcrumbItem}:nth-child(2):contains("${name}")`);
-
-        cy.get('h1').should('not.exist');
-        cy.get(selectors.navLinkCurrent).should('not.exist');
-
-        cy.get('h2').should('have.text', name);
         cy.get(selectors.form.notEditableLabel).should('exist');
         cy.get(selectors.form.editButton).should('not.exist');
 
@@ -405,16 +388,9 @@ describe('Access Control Permission sets', () => {
 
         visitAccessControlEntity(entitiesKey, entityId);
 
-        cy.get(`${selectors.breadcrumbItem}:nth-child(1):contains("${h2}")`);
-        cy.get(`${selectors.breadcrumbItem}:nth-child(2)`).should('not.exist');
-
-        cy.get('h1').should('not.exist');
-        cy.get(selectors.navLinkCurrent).should('not.exist');
         cy.get('h2').should('not.exist');
+        cy.get('li.pf-c-breadcrumb__item:nth-child(2)').should('not.exist');
 
-        cy.get(selectors.notFound.title).should('have.text', 'Permission set does not exist');
-        cy.get(selectors.notFound.a)
-            .should('have.text', h2)
-            .should('have.attr', 'href', permissionSetsUrl);
+        assertAccessControlEntityDoesNotExist(entitiesKey);
     });
 });

--- a/ui/apps/platform/cypress/integration/accessControl/accessControlPermissionSets.test.js
+++ b/ui/apps/platform/cypress/integration/accessControl/accessControlPermissionSets.test.js
@@ -1,5 +1,3 @@
-import { selectors } from '../../constants/AccessControlPage';
-
 import withAuth from '../../helpers/basicAuth';
 import { hasFeatureFlag } from '../../helpers/features';
 
@@ -11,6 +9,7 @@ import {
     visitAccessControlEntitiesWithStaticResponseForPermissions,
     visitAccessControlEntity,
 } from './accessControl.helpers';
+import { selectors } from './accessControl.selectors';
 
 const defaultNames = ['Admin', 'Analyst', 'Continuous Integration', 'None', 'Sensor Creator'];
 

--- a/ui/apps/platform/cypress/integration/accessControl/accessControlPermissionSets.test.js
+++ b/ui/apps/platform/cypress/integration/accessControl/accessControlPermissionSets.test.js
@@ -42,6 +42,7 @@ describe('Access Control Permission sets', () => {
         cy.get('th:contains("Name")');
         cy.get('th:contains("Description")');
         cy.get('th:contains("Roles")');
+        cy.get('th[aria-label="Row actions"]');
     });
 
     it('list has default names', () => {

--- a/ui/apps/platform/cypress/integration/accessControl/accessControlPermissionSets.test.js
+++ b/ui/apps/platform/cypress/integration/accessControl/accessControlPermissionSets.test.js
@@ -385,11 +385,7 @@ describe('Access Control Permission sets', () => {
 
     it('displays message instead of form if entity id does not exist', () => {
         const entityId = 'bogus';
-
         visitAccessControlEntity(entitiesKey, entityId);
-
-        cy.get('h2').should('not.exist');
-        cy.get('li.pf-c-breadcrumb__item:nth-child(2)').should('not.exist');
 
         assertAccessControlEntityDoesNotExist(entitiesKey);
     });

--- a/ui/apps/platform/cypress/integration/accessControl/accessControlRoles.test.js
+++ b/ui/apps/platform/cypress/integration/accessControl/accessControlRoles.test.js
@@ -6,15 +6,11 @@ import {
     assertAccessControlEntityDoesNotExist,
     clickEntityNameInTable,
     rolesKey as entitiesKey,
+    saveCreatedRole,
     visitAccessControlEntities,
     visitAccessControlEntitiesWithStaticResponseForPermissions,
     visitAccessControlEntity,
 } from './accessControl.helpers';
-
-// Migration from cy.server and cy.route to cy.intercept fails for /v1/roles/* imported from apiEndpoints.
-const rolesApi = {
-    list: '/v1/roles',
-};
 
 const defaultNames = ['Admin', 'Analyst', 'Continuous Integration', 'None', 'Sensor Creator'];
 
@@ -136,9 +132,7 @@ describe('Access Control Roles', () => {
             .should('be.enabled')
             .should('be.checked');
 
-        cy.intercept('POST', `${rolesApi.list}/${name}`).as('PostRoles');
-        cy.get(selectors.form.saveButton).click();
-        cy.wait('@PostRoles');
+        saveCreatedRole(name);
 
         cy.contains('h2', /^\d+ results? found$/).should('exist');
         cy.get(`td[data-label="Name"] a:contains("${name}")`).click();

--- a/ui/apps/platform/cypress/integration/accessControl/accessControlRoles.test.js
+++ b/ui/apps/platform/cypress/integration/accessControl/accessControlRoles.test.js
@@ -1,5 +1,3 @@
-import { selectors } from '../../constants/AccessControlPage';
-
 import withAuth from '../../helpers/basicAuth';
 
 import {
@@ -11,6 +9,7 @@ import {
     visitAccessControlEntitiesWithStaticResponseForPermissions,
     visitAccessControlEntity,
 } from './accessControl.helpers';
+import { selectors } from './accessControl.selectors';
 
 const defaultNames = ['Admin', 'Analyst', 'Continuous Integration', 'None', 'Sensor Creator'];
 

--- a/ui/apps/platform/cypress/integration/accessControl/accessControlRoles.test.js
+++ b/ui/apps/platform/cypress/integration/accessControl/accessControlRoles.test.js
@@ -43,6 +43,7 @@ describe('Access Control Roles', () => {
         cy.get('th:contains("Description")');
         cy.get('th:contains("Permission set")');
         cy.get('th:contains("Access scope")');
+        cy.get('th[aria-label="Row actions"]');
     });
 
     it('list has default names', () => {

--- a/ui/apps/platform/cypress/integration/accessControl/accessControlRoles.test.js
+++ b/ui/apps/platform/cypress/integration/accessControl/accessControlRoles.test.js
@@ -162,11 +162,7 @@ describe('Access Control Roles', () => {
 
     it('displays message instead of form if entity id does not exist', () => {
         const entityId = 'bogus';
-
         visitAccessControlEntity(entitiesKey, entityId);
-
-        cy.get('h2').should('not.exist');
-        cy.get('li.pf-c-breadcrumb__item:nth-child(2)').should('not.exist');
 
         assertAccessControlEntityDoesNotExist(entitiesKey);
     });


### PR DESCRIPTION
## Description

Apply consistent patterns and prevent timing failures.

Follow up replacement for accessControlAuthProviders.test.js in #2805

This test folder has 11 `cy.visit` method calls, similar size to 10 in userinfo.test.js which were replaced in #3869

### Background information

Here are links to cypress data structures:
* `routeMatcher` https://docs.cypress.io/api/commands/intercept#Matching-with-RouteMatcher
* `staticResponse` https://docs.cypress.io/api/commands/intercept#StaticResponse-objects

### Naming convention

Distinguish the **scope** of constants and functions:
1. Test-specific: `it` block for test or module scope in test file for tests.
2. Container-specific: whatever.helpers.js or whatever.selectors.js file in cypress/integration/whatever subfolder. Only rare import from other containers, like `interactAndVisitWhatever` function (for example, from Risk to Network Graph).
3. Global
    * cypress/helpers/whatever.js for example, basicAuth.js or features.js
    * cypress/selectors/whatever.js for example, navigation.js or pagination.js

End goals:
1. Move most of cypress/helpers/whatever.js to container subfolders as whatever.helpers.js files.
2. Move most of cypress/constants/whatever.js to container subfolders as whatever.selectors.js files.
3. Encapsulate most of apiEndpoints.js in container-specific helpers files.

Here is an example of contrast between global helpers file and container-specific helpers and selectors files:

```js
import withAuth from '../../helpers/basicAuth';

import {
    accessScopesKey as entitiesKey,
    assertAccessControlEntityDoesNotExist,
    clickEntityNameInTable,
    visitAccessControlEntities,
    visitAccessControlEntitiesWithStaticResponseForPermissions,
    visitAccessControlEntity,
} from './accessControl.helpers';
import { selectors } from './accessControl.selectors';
```

### Changed files

1. Rename cypress/constants/AccessControlPage.js as cypress/integration/accessControl/accessControl.selectors.js
    * Because only Access Control tests import from the file, move it into the container subfolder and name as counterpart to helpers file.
    * Delete whateverUrl because helpers file encapsulates page addresses.
    * Delete selectors either used only in helpers file or obvious like `th` elements.

2. Edit cypress/helpers/request.js
    * Return array of objects from `cy.wait` method in case test needs to assert.

3. Add cypress/integration/accessControl/accessControl.helpers.js
    * Apply light version of entities pattern from Configuration Management or Vulnerability Management helpers.
    * Write minimum number of helpers for create, update, and delete, because:
        * Workflow containers rarely mutate data.
        * API has are some irregularities, like POST /v1/roles/roleName insteads of /v1/roles
        * Test coverage is limited: too bad, so sad.

4. Edit cypress/integration/accessControl/accessControlAccessScopes.test.js
    * Use literal strings for obvious selectors like `th` element.
    * Keep import selectors for form.

5. Edit cypress/integration/accessControl/accessControlAuthProviders.test.js
    * Ditto the previous item.
    * Click **Cancel** button at end of tests which do not save created auth provider.

6. Edit cypress/integration/accessControl/accessControlPermissionSets.test.js

7. Edit cypress/integration/accessControl/accessControlRoles.test.js

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed