### PR TITLE
Create collection results component

### DIFF
--- a/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
@@ -79,6 +79,7 @@ export type CollectionFormProps = {
     initialData: Collection;
     /* collection responses for the embedded collections of `initialData` */
     initialEmbeddedCollections: CollectionResponse[];
+    onFormChange: (values: Collection) => void;
     onSubmit: (collection: Collection) => Promise<void>;
     saveError?: CollectionSaveError | undefined;
     clearSaveError?: () => void;
@@ -118,6 +119,17 @@ function yupResourceSelectorObject() {
     });
 }
 
+const validationSchema = yup.object({
+    name: yup.string().trim().required(),
+    description: yup.string(),
+    embeddedCollectionIds: yup.array(yup.string().trim().required()),
+    resourceSelector: yup.object().shape({
+        Deployment: yupResourceSelectorObject(),
+        Namespace: yupResourceSelectorObject(),
+        Cluster: yupResourceSelectorObject(),
+    }),
+});
+
 function getRuleCount(resourceSelector: Collection['resourceSelector']) {
     let count = 0;
 
@@ -140,6 +152,7 @@ function CollectionForm({
     initialEmbeddedCollections,
     saveError,
     clearSaveError = () => {},
+    onFormChange,
     onSubmit,
     getCollectionTableCells,
 }: CollectionFormProps) {
@@ -166,17 +179,23 @@ function CollectionForm({
                 setSubmitting(false);
             });
         },
-        validationSchema: yup.object({
-            name: yup.string().trim().required(),
-            description: yup.string(),
-            embeddedCollectionIds: yup.array(yup.string().trim().required()),
-            resourceSelector: yup.object().shape({
-                Deployment: yupResourceSelectorObject(),
-                Namespace: yupResourceSelectorObject(),
-                Cluster: yupResourceSelectorObject(),
-            }),
-        }),
+        validationSchema,
     });
+
+    useEffect(() => {
+        if (saveError) {
+            return;
+        }
+        // We need to manually validate the values onChange here since Formik update the values
+        // before validation and the declarative state has `isValid === true` and `isValidation == false`
+        // at the same time that the actual value object is invalid.
+        validationSchema
+            .validate(values)
+            .then(() => onFormChange(values))
+            .catch(() => {
+                /* Validation failed, do not propagate change */
+            });
+    }, [values, saveError, onFormChange]);
 
     // Synchronize the value of "name" in the form field when the page action changes
     // e.g. from 'view' -> 'clone'

--- a/ui/apps/platform/src/Containers/Collections/CollectionFormDrawer.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionFormDrawer.tsx
@@ -18,6 +18,7 @@ import CollectionResults from './CollectionResults';
 import { isCollectionParseError, parseCollection } from './converter';
 import CollectionForm, { CollectionFormProps } from './CollectionForm';
 import UnsupportedCollectionState from './UnsupportedCollectionState';
+import useDryRunConfiguration from './hooks/useDryRunConfiguration';
 
 export type CollectionFormDrawerProps = {
     hasWriteAccessForCollections: boolean;
@@ -54,6 +55,11 @@ function CollectionFormDrawer({
 }: CollectionFormDrawerProps) {
     const initialData = parseCollection(collectionData.collection);
     const initialEmbeddedCollections = collectionData.embeddedCollections;
+    const collectionId = action.type !== 'create' ? action.collectionId : undefined;
+    const { dryRunConfig, updateDryRunConfig } = useDryRunConfiguration(
+        collectionId,
+        collectionData.collection
+    );
 
     useEffect(() => {
         toggleDrawer(isInlineDrawer);
@@ -79,7 +85,7 @@ function CollectionFormDrawer({
                                 )}
                             </DrawerHead>
                             <DrawerPanelBody className="pf-u-h-100" style={{ overflow: 'auto' }}>
-                                <CollectionResults />
+                                <CollectionResults dryRunConfig={dryRunConfig} />
                             </DrawerPanelBody>
                         </DrawerPanelContent>
                     }
@@ -97,6 +103,7 @@ function CollectionFormDrawer({
                                 action={action}
                                 initialData={initialData}
                                 initialEmbeddedCollections={initialEmbeddedCollections}
+                                onFormChange={updateDryRunConfig}
                                 onSubmit={onSubmit}
                                 saveError={saveError}
                                 clearSaveError={clearSaveError}

--- a/ui/apps/platform/src/Containers/Collections/CollectionResults.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionResults.tsx
@@ -1,7 +1,153 @@
-import React from 'react';
+import React, { useCallback, useEffect, useState, useMemo } from 'react';
+import {
+    Button,
+    Divider,
+    EmptyState,
+    EmptyStateIcon,
+    EmptyStateVariant,
+    Flex,
+    FlexItem,
+    Select,
+    SearchInput,
+    SelectOption,
+    debounce,
+} from '@patternfly/react-core';
+import { ListIcon } from '@patternfly/react-icons';
+import useSelectToggle from 'hooks/patternfly/useSelectToggle';
+import ResourceIcon from 'Components/PatternFly/ResourceIcon';
 
-function CollectionResults() {
-    return <></>;
+import { dryRunCollection } from 'services/CollectionsService';
+import { ListDeployment } from 'types/deployment.proto';
+
+function CollectionResults({ dryRunConfig }) {
+    const { isOpen, onToggle, closeSelect } = useSelectToggle();
+    const [selected, setSelected] = useState('Deployment');
+    const [filterText, setFilterText] = useState('');
+    const [isEndOfResults, setIsEndOfResults] = useState(false);
+    const [deployments, setDeployments] = useState<ListDeployment[]>([]);
+    const [hasRuleSelected, setHasRuleSelected] = useState(false);
+
+    function onRuleOptionSelect(_, value) {
+        setSelected(value);
+        setFilterText('');
+        closeSelect();
+    }
+
+    const fetchDryRun = useCallback(
+        (page: number) => {
+            const pageSize = 10;
+            const query = filterText ? `${selected}:${filterText}` : '';
+            const { request } = dryRunCollection(dryRunConfig, query, page, pageSize);
+            request
+                .then((results) => {
+                    setIsEndOfResults(results.length < 10);
+                    setDeployments((current) => (page === 0 ? results : [...current, ...results]));
+                    setHasRuleSelected(true);
+                })
+                .catch(() => {
+                    // TODO: indicate results not loading properly?
+                });
+        },
+        [dryRunConfig, filterText, selected]
+    );
+
+    useEffect(() => {
+        if (dryRunConfig.resourceSelectors?.[0]?.rules?.length > 0) {
+            fetchDryRun(0);
+        } else {
+            setHasRuleSelected(false);
+        }
+    }, [dryRunConfig, fetchDryRun]);
+
+    const onSearchInputChange = useMemo(
+        () =>
+            debounce((value: string) => {
+                setFilterText(value);
+            }, 800),
+        []
+    );
+
+    const currentPage = Math.floor((deployments.length - 1) / 10);
+
+    return (
+        <>
+            <Divider />
+            {!hasRuleSelected ? (
+                <EmptyState variant={EmptyStateVariant.xs}>
+                    <EmptyStateIcon icon={ListIcon} />
+                    <p>
+                        Add selector rules or attach existing collections to view resource matches
+                    </p>
+                </EmptyState>
+            ) : (
+                <Flex
+                    spaceItems={{ default: 'spaceItemsNone' }}
+                    alignItems={{ default: 'alignItemsCenter' }}
+                    className="pf-u-mt-lg"
+                >
+                    <FlexItem>
+                        <Select
+                            toggleAriaLabel="Select by name or label"
+                            isOpen={isOpen}
+                            onToggle={onToggle}
+                            selections={selected}
+                            onSelect={onRuleOptionSelect}
+                            isDisabled={false}
+                        >
+                            <SelectOption value="Deployment">Deployment</SelectOption>
+                            <SelectOption value="Namespace">Namespace</SelectOption>
+                            <SelectOption value="Cluster">Cluster</SelectOption>
+                        </Select>
+                    </FlexItem>
+                    <FlexItem grow={{ default: 'grow' }}>
+                        <SearchInput
+                            aria-label="Filter by name"
+                            placeholder="Filter by name"
+                            value={filterText}
+                            onChange={onSearchInputChange}
+                        />
+                    </FlexItem>
+                    <Flex
+                        direction={{ default: 'column' }}
+                        grow={{ default: 'grow' }}
+                        className="pf-u-mt-lg"
+                    >
+                        {deployments.map((deployment) => {
+                            return (
+                                <Flex key={deployment.id}>
+                                    <FlexItem>
+                                        <ResourceIcon kind="Deployment" />
+                                    </FlexItem>
+                                    <FlexItem>
+                                        <div>{deployment.name}</div>
+                                        <span className="pf-u-color-400 pf-u-font-size-xs">
+                                            In &quot;{deployment.cluster} / {deployment.namespace}
+                                            &quot;
+                                        </span>
+                                    </FlexItem>
+                                    <Divider className="pf-u-mt-md" />
+                                </Flex>
+                            );
+                        })}
+                        {!isEndOfResults ? (
+                            <Button
+                                variant="link"
+                                isInline
+                                className="pf-u-text-align-center"
+                                onClick={() => fetchDryRun(currentPage + 1)}
+                            >
+                                View more
+                            </Button>
+                        ) : (
+                            <span className="pf-u-color-400 pf-u-text-align-center pf-u-font-size-sm">
+                                end of results
+                            </span>
+                        )}
+                    </Flex>
+                </Flex>
+            )}
+        </>
+    );
 }
 
 export default CollectionResults;

--- a/ui/apps/platform/src/Containers/Collections/hooks/useDryRunConfiguration.ts
+++ b/ui/apps/platform/src/Containers/Collections/hooks/useDryRunConfiguration.ts
@@ -1,0 +1,42 @@
+import isEqual from 'lodash/isEqual';
+import { useState, useCallback } from 'react';
+import { CollectionRequest, CollectionResponse } from 'services/CollectionsService';
+import { generateRequest } from '../converter';
+import { Collection } from '../types';
+
+export default function useDryRunConfiguration(
+    collectionId: string | undefined,
+    initialData: Omit<CollectionResponse, 'id'>
+) {
+    const id = collectionId;
+    const [dryRunConfig, setDryRunConfig] = useState<CollectionRequest>(() => {
+        // Use the `CollectionResponse` from the initial `getCollection` request here to support
+        // collections that have configs unsupported from the UI, but can also have results displayed
+        const { name, description, embeddedCollections, resourceSelectors } = initialData;
+        const embeddedCollectionIds = embeddedCollections.map((collection) => collection.id);
+        return { id, name, description, resourceSelectors, embeddedCollectionIds };
+    });
+
+    const updateDryRunConfig = useCallback(
+        (values: Collection) => {
+            const nextConfig = { id, ...generateRequest(values) };
+            const isEmbeddedCollectionsChanged = !isEqual(
+                dryRunConfig.embeddedCollectionIds,
+                nextConfig.embeddedCollectionIds
+            );
+            const isResourceSelectorChanged = !isEqual(
+                dryRunConfig.resourceSelectors,
+                nextConfig.resourceSelectors
+            );
+            if (isEmbeddedCollectionsChanged || isResourceSelectorChanged) {
+                setDryRunConfig(nextConfig);
+            }
+        },
+        [dryRunConfig.embeddedCollectionIds, dryRunConfig.resourceSelectors, id]
+    );
+
+    return {
+        dryRunConfig,
+        updateDryRunConfig,
+    };
+}

--- a/ui/apps/platform/src/services/CollectionsService.ts
+++ b/ui/apps/platform/src/services/CollectionsService.ts
@@ -189,22 +189,21 @@ export type CollectionDryRunResponse = {
  */
 export function dryRunCollection(
     collectionRequest: CollectionRequest,
-    searchFilter: string,
+    searchFilter: SearchFilter,
     page: number,
-    pageSize: number
+    pageSize: number,
+    sortOption?: ApiSortOption
 ): CancellableRequest<ListDeployment[]> {
+    const query = getRequestQueryStringForSearchFilter(searchFilter);
     const dryRunRequest: CollectionDryRunRequest = {
         ...collectionRequest,
         options: {
             filterQuery: {
-                query: searchFilter,
+                query,
                 pagination: {
                     offset: page * pageSize,
                     limit: pageSize,
-                    sortOption: {
-                        field: '',
-                        reversed: false,
-                    },
+                    ...(sortOption && { sortOption }),
                 },
             },
             withMatches: true,

--- a/ui/apps/platform/src/services/CollectionsService.ts
+++ b/ui/apps/platform/src/services/CollectionsService.ts
@@ -5,7 +5,7 @@ import { SearchFilter, ApiSortOption } from 'types/search';
 import { getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
 import { CancellableRequest, makeCancellableAxiosRequest } from './cancellationUtils';
 import axios from './instance';
-import { Empty, Pagination } from './types';
+import { Empty, FilterQuery } from './types';
 
 export const collectionsBaseUrl = '/v1/collections';
 export const collectionsCountUrl = '/v1/collectionscount';
@@ -159,8 +159,8 @@ export function deleteCollection(id: string): CancellableRequest<Empty> {
 
 export type CollectionDryRunRequest = CollectionRequest & {
     options: {
-        pagination: Pagination;
-        skipDeploymentMatching: boolean;
+        filterQuery: FilterQuery;
+        withMatches: boolean;
     };
 };
 
@@ -188,12 +188,28 @@ export type CollectionDryRunResponse = {
  * @returns A list of deployments that are resolved by the collection.
  */
 export function dryRunCollection(
-    dryRunRequest: CollectionDryRunRequest
-    // TODO `ListDeployment` will make this impossible to paginate without loading the entire
-    // dataset client side. Ask [BE] if there is an efficient way to aggregate namespaces/clusters
-    // under a matching deployment name similar to the graphql query. An alternative might be to
-    // change the rendering of the list to not group deployments, but to sort alphabetically.
+    collectionRequest: CollectionRequest,
+    searchFilter: string,
+    page: number,
+    pageSize: number
 ): CancellableRequest<ListDeployment[]> {
+    const dryRunRequest: CollectionDryRunRequest = {
+        ...collectionRequest,
+        options: {
+            filterQuery: {
+                query: searchFilter,
+                pagination: {
+                    offset: page * pageSize,
+                    limit: pageSize,
+                    sortOption: {
+                        field: '',
+                        reversed: false,
+                    },
+                },
+            },
+            withMatches: true,
+        },
+    };
     return makeCancellableAxiosRequest((signal) =>
         axios
             .post<CollectionDryRunResponse>(collectionsDryRunUrl, dryRunRequest, {

--- a/ui/apps/platform/src/services/types.ts
+++ b/ui/apps/platform/src/services/types.ts
@@ -3,7 +3,7 @@ import { ApiSortOption } from 'types/search';
 export type Pagination = {
     offset: number;
     limit: number;
-    sortOption: ApiSortOption;
+    sortOption?: ApiSortOption;
 };
 
 export type FilterQuery = {

--- a/ui/apps/platform/src/services/types.ts
+++ b/ui/apps/platform/src/services/types.ts
@@ -6,4 +6,9 @@ export type Pagination = {
     sortOption: ApiSortOption;
 };
 
+export type FilterQuery = {
+    query: string;
+    pagination: Pagination;
+};
+
 export type Empty = Record<string, never>;


### PR DESCRIPTION
## Description

This add a live preview of currently selected deployments based off the rules selected

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Before any rules have been created or a separate collection has been attached
![Screenshot 2022-12-07 at 11 09 04 AM](https://user-images.githubusercontent.com/61400697/206245004-ff725868-bffe-449a-996c-c81dfaefebb9.png)

Once a rule has been created, the first 10 deployments matching the rules should display with the option to view 10 more using the "view more" link
![Screenshot 2022-12-07 at 11 09 20 AM](https://user-images.githubusercontent.com/61400697/206245142-6d942f46-b14a-4f0f-a32f-bdce55cf36a5.png)


The ability to filter results will fetch deployments using the input field
![Screenshot 2022-12-07 at 11 09 40 AM](https://user-images.githubusercontent.com/61400697/206245177-3c26e6f7-c6e4-4d6d-8be9-d06632ddba5a.png)
