### PR TITLE
ROX-13708 Fix pagination of violating deployments in VM Policy table

### DIFF
--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Policy/VulnMgmtEntityPolicy.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Policy/VulnMgmtEntityPolicy.js
@@ -69,6 +69,7 @@ const VulnMgmtEntityPolicy = ({
                         name
                     }
                 }
+                deploymentCount${queryVarParam}
                 unusedVarSink(query: $scopeQuery)
             }
         }

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Policy/VulnMgmtEntityPolicy.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Policy/VulnMgmtEntityPolicy.js
@@ -7,18 +7,13 @@ import useCases from 'constants/useCaseTypes';
 import entityTypes from 'constants/entityTypes';
 import { defaultCountKeyMap } from 'constants/workflowPages.constants';
 import workflowStateContext from 'Containers/workflowStateContext';
-import {
-    DEPLOYMENT_LIST_FRAGMENT,
-    DEPLOYMENT_LIST_FRAGMENT_UPDATED,
-} from 'Containers/VulnMgmt/VulnMgmt.fragments';
 import WorkflowEntityPage from 'Containers/Workflow/WorkflowEntityPage';
-import useFeatureFlags from 'hooks/useFeatureFlags';
 import queryService from 'utils/queryService';
 import VulnMgmtPolicyOverview from './VulnMgmtPolicyOverview';
 import VulnMgmtList from '../../List/VulnMgmtList';
 import { getScopeQuery, vulMgmtPolicyQuery } from '../VulnMgmtPolicyQueryUtil';
 
-const VulmMgmtEntityPolicy = ({
+const VulnMgmtEntityPolicy = ({
     entityId,
     entityListType,
     search,
@@ -30,15 +25,8 @@ const VulmMgmtEntityPolicy = ({
     const queryVarParam = entityContext[entityTypes.POLICY] ? '' : '(query: $scopeQuery)';
     const workflowState = useContext(workflowStateContext);
 
-    const { isFeatureFlagEnabled } = useFeatureFlags();
-    const showVMUpdates = isFeatureFlagEnabled('ROX_POSTGRES_DATASTORE');
-
-    const fragmentToUse = showVMUpdates
-        ? DEPLOYMENT_LIST_FRAGMENT_UPDATED
-        : DEPLOYMENT_LIST_FRAGMENT;
-
     const overviewQuery = gql`
-        query getPolicy($id: ID!, $policyQuery: String, $scopeQuery: String) {
+        query getPolicy($id: ID!, $scopeQuery: String) {
             result: policy(id: $id) {
                 id
                 name
@@ -81,14 +69,9 @@ const VulmMgmtEntityPolicy = ({
                         name
                     }
                 }
-                deploymentCount${queryVarParam}
-                deployments${queryVarParam} {
-                    ...deploymentFields
-                }
                 unusedVarSink(query: $scopeQuery)
             }
         }
-        ${fragmentToUse}
     `;
 
     function getListQuery(listFieldName, fragmentName, fragment) {
@@ -143,10 +126,10 @@ const VulmMgmtEntityPolicy = ({
     );
 };
 
-VulmMgmtEntityPolicy.propTypes = {
+VulnMgmtEntityPolicy.propTypes = {
     ...workflowEntityPropTypes,
     setRefreshTrigger: PropTypes.func,
 };
-VulmMgmtEntityPolicy.defaultProps = workflowEntityDefaultProps;
+VulnMgmtEntityPolicy.defaultProps = workflowEntityDefaultProps;
 
-export default VulmMgmtEntityPolicy;
+export default VulnMgmtEntityPolicy;

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Policy/VulnMgmtEntityPolicy.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Policy/VulnMgmtEntityPolicy.js
@@ -16,10 +16,9 @@ import useFeatureFlags from 'hooks/useFeatureFlags';
 import queryService from 'utils/queryService';
 import VulnMgmtPolicyOverview from './VulnMgmtPolicyOverview';
 import VulnMgmtList from '../../List/VulnMgmtList';
-import { entityPriorityField } from '../../VulnMgmt.constants';
 import { getScopeQuery, vulMgmtPolicyQuery } from '../VulnMgmtPolicyQueryUtil';
 
-const VulnMgmtEntityPolicy = ({
+const VulmMgmtEntityPolicy = ({
     entityId,
     entityListType,
     search,
@@ -39,7 +38,7 @@ const VulnMgmtEntityPolicy = ({
         : DEPLOYMENT_LIST_FRAGMENT;
 
     const overviewQuery = gql`
-        query getPolicy($id: ID!, $policyQuery: String, $scopeQuery: String, $deploymentQuery: String, $deploymentPagination: Pagination) {
+        query getPolicy($id: ID!, $policyQuery: String, $scopeQuery: String) {
             result: policy(id: $id) {
                 id
                 name
@@ -82,8 +81,8 @@ const VulnMgmtEntityPolicy = ({
                         name
                     }
                 }
-                deploymentCount(query: $deploymentQuery)
-                deployments(query: $deploymentQuery, pagination: $deploymentPagination) {
+                deploymentCount${queryVarParam}
+                deployments${queryVarParam} {
                     ...deploymentFields
                 }
                 unusedVarSink(query: $scopeQuery)
@@ -111,13 +110,7 @@ const VulnMgmtEntityPolicy = ({
     `;
     }
 
-    console.log('parent workflowstate', workflowState.getCurrentPagingState());
-
     const fullEntityContext = workflowState.getEntityContext();
-    const deploymentQueryObject = {
-        'Policy Violated': true,
-        ...queryService.entityContextToQueryObject(fullEntityContext),
-    };
     const queryOptions = {
         variables: {
             id: entityId,
@@ -127,15 +120,6 @@ const VulnMgmtEntityPolicy = ({
             }),
             ...vulMgmtPolicyQuery,
             scopeQuery: getScopeQuery(fullEntityContext),
-            deploymentQuery: queryService.objectToWhereClause(deploymentQueryObject),
-            deploymentPagination: {
-                offset: 0,
-                limit: 5,
-                sortOption: {
-                    field: entityPriorityField.DEPLOYMENT,
-                    reversed: false,
-                },
-            },
         },
     };
 
@@ -159,10 +143,10 @@ const VulnMgmtEntityPolicy = ({
     );
 };
 
-VulnMgmtEntityPolicy.propTypes = {
+VulmMgmtEntityPolicy.propTypes = {
     ...workflowEntityPropTypes,
     setRefreshTrigger: PropTypes.func,
 };
-VulnMgmtEntityPolicy.defaultProps = workflowEntityDefaultProps;
+VulmMgmtEntityPolicy.defaultProps = workflowEntityDefaultProps;
 
-export default VulnMgmtEntityPolicy;
+export default VulmMgmtEntityPolicy;

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Policy/VulnMgmtPolicyOverview.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Policy/VulnMgmtPolicyOverview.js
@@ -64,7 +64,7 @@ const noop = () => {};
 const VulnMgmtPolicyOverview = ({ data, entityContext, setRefreshTrigger }) => {
     const workflowState = useContext(workflowStateContext);
     const { isFeatureFlagEnabled } = useFeatureFlags();
-    const { page, onSetPage } = usePagination();
+    const [page, setPage] = useState(1);
     const [sort, setSort] = useState({
         field: entityPriorityField.DEPLOYMENT,
         reversed: false,
@@ -255,27 +255,25 @@ const VulnMgmtPolicyOverview = ({ data, entityContext, setRefreshTrigger }) => {
                     if (loading && !policyData) {
                         return <Loader />;
                     }
-                    const { deployments, deploymentCount } = policyData;
+                    const failingDeployments = policyData.deployments;
+                    const totalCount = policyData.deploymentCount;
+                    const headerText = `${totalCount} ${pluralize(
+                        entityTypes.DEPLOYMENT,
+                        totalCount
+                    )} ${pluralizeHas(totalCount)} failed across this policy`;
                     return (
                         <div className="pdf-page pdf-stretch pdf-new flex shadow rounded relative bg-base-100 mb-4 mx-4">
                             <TableWidget
-                                header={`${deploymentCount} ${pluralize(
-                                    entityTypes.DEPLOYMENT,
-                                    deploymentCount
-                                )} ${pluralizeHas(deploymentCount)} failed across this policy`}
-                                rows={deployments}
+                                header={headerText}
+                                rows={failingDeployments}
                                 entityType={entityTypes.DEPLOYMENT}
                                 noDataText="No deployments have failed across this policy"
                                 className="bg-base-100"
                                 columns={getDeploymentTableColumns(workflowState)}
+                                /* TODO Remove `pageSize` */
                                 pageSize={2}
-                                parentPageState={{
-                                    page,
-                                    setPage: (newPage) => onSetPage(undefined, newPage),
-                                    totalCount: deploymentCount,
-                                }}
+                                parentPageState={{ page, setPage, totalCount }}
                                 sortHandler={setSort}
-                                defaultSorted={[sort]}
                             />
                         </div>
                     );

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Policy/VulnMgmtPolicyOverview.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Policy/VulnMgmtPolicyOverview.js
@@ -28,7 +28,6 @@ import { updatePolicyDisabledState } from 'services/PoliciesService';
 import { entityGridContainerBaseClassName } from 'Containers/Workflow/WorkflowEntityPage';
 import BooleanPolicySection from 'Containers/Policies/Wizard/Step3/BooleanPolicyLogicSection';
 import useFeatureFlags from 'hooks/useFeatureFlags';
-import usePagination from 'hooks/patternfly/usePagination';
 import { getExcludedNamesByType } from 'utils/policyUtils';
 import queryService from 'utils/queryService';
 import { pluralizeHas } from 'utils/textUtils';
@@ -64,7 +63,7 @@ const noop = () => {};
 const VulnMgmtPolicyOverview = ({ data, entityContext, setRefreshTrigger }) => {
     const workflowState = useContext(workflowStateContext);
     const { isFeatureFlagEnabled } = useFeatureFlags();
-    const [page, setPage] = useState(1);
+    const [page, setPage] = useState(0);
     const [sort, setSort] = useState({
         field: entityPriorityField.DEPLOYMENT,
         reversed: false,

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Policy/VulnMgmtPolicyOverview.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Policy/VulnMgmtPolicyOverview.js
@@ -59,6 +59,7 @@ const emptyPolicy = {
     exclusions: [],
 };
 
+const deploymentPageSize = 20;
 const noop = () => {};
 const VulnMgmtPolicyOverview = ({ data, entityContext, setRefreshTrigger }) => {
     const workflowState = useContext(workflowStateContext);
@@ -244,7 +245,7 @@ const VulnMgmtPolicyOverview = ({ data, entityContext, setRefreshTrigger }) => {
                 ...queryService.entityContextToQueryObject(fullEntityContext),
             }),
             ...vulMgmtPolicyQuery,
-            pagination: queryService.getPagination(sort, page, 2 /* TODO Remove this param */),
+            pagination: queryService.getPagination(sort, page, deploymentPageSize),
         };
 
         policyFindingsContent = (
@@ -269,8 +270,7 @@ const VulnMgmtPolicyOverview = ({ data, entityContext, setRefreshTrigger }) => {
                                 noDataText="No deployments have failed across this policy"
                                 className="bg-base-100"
                                 columns={getDeploymentTableColumns(workflowState)}
-                                /* TODO Remove `pageSize` */
-                                pageSize={2}
+                                pageSize={deploymentPageSize}
                                 parentPageState={{ page, setPage, totalCount }}
                                 sortHandler={setSort}
                             />

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Policy/VulnMgmtPolicyOverview.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Policy/VulnMgmtPolicyOverview.js
@@ -77,7 +77,6 @@ const VulnMgmtPolicyOverview = ({ data, entityContext, setRefreshTrigger }) => {
         scope,
         exclusions,
         deployments,
-        deploymentCount,
     } = safeData;
     const [currentDisabledState, setCurrentDisabledState] = useState(disabled);
 
@@ -122,6 +121,20 @@ const VulnMgmtPolicyOverview = ({ data, entityContext, setRefreshTrigger }) => {
             </ButtonLink>
         </div>
     );
+
+    // @TODO: extract this out to make it re-usable and easier to test
+    const failingDeployments = deployments.filter((singleDeploy) => {
+        if (
+            singleDeploy.policyStatus === 'pass' ||
+            !singleDeploy.deployAlerts ||
+            !singleDeploy.deployAlerts.length
+        ) {
+            return false;
+        }
+        return singleDeploy.deployAlerts.some((alert) => {
+            return alert && alert.policy && alert.policy.id === id;
+        });
+    });
 
     const descriptionBlockMetadata = [
         {
@@ -203,27 +216,18 @@ const VulnMgmtPolicyOverview = ({ data, entityContext, setRefreshTrigger }) => {
     } else {
         const getDeploymentTableColumns = getCurriedDeploymentTableColumns(isFeatureFlagEnabled);
 
-        console.log(workflowState);
-        // TODO Extract deploymentCount and deployments section of query here, wrap in `<QUERY>` to allow for
-        // conditional rendering w.o. hook
-
         policyFindingsContent = (
             <div className="pdf-page pdf-stretch pdf-new flex shadow rounded relativebg-base-100 mb-4 mx-4">
                 <TableWidget
-                    header={`${deploymentCount} ${pluralize(
+                    header={`${failingDeployments.length} ${pluralize(
                         entityTypes.DEPLOYMENT,
-                        deploymentCount
-                    )} ${pluralizeHas(deploymentCount)} failed across this policy`}
-                    rows={deployments}
+                        failingDeployments.length
+                    )} ${pluralizeHas(failingDeployments.length)} failed across this policy`}
+                    rows={failingDeployments}
                     entityType={entityTypes.DEPLOYMENT}
                     noDataText="No deployments have failed across this policy"
                     className="bg-base-100"
                     columns={getDeploymentTableColumns(workflowState)}
-                    pageSize={2}
-                    parentPageState={{
-                        setPage: (page) => workflowState.setPage(page),
-                        totalCount: 10,
-                    }}
                     defaultSorted={[
                         {
                             id: 'priority',

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/TableWidget.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/TableWidget.js
@@ -44,6 +44,8 @@ const TableWidget = ({
     const totalCount = parentPageState?.totalCount || rows.length;
     const useServerSidePagination = !!sortHandler;
 
+    console.log('table pagination', pageSize, currentPage, totalCount);
+
     const headerComponents = (
         <div className="flex">
             {headerActions}

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/TableWidget.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/TableWidget.js
@@ -44,8 +44,6 @@ const TableWidget = ({
     const totalCount = parentPageState?.totalCount || rows.length;
     const useServerSidePagination = !!sortHandler;
 
-    console.log('table pagination', pageSize, currentPage, totalCount);
-
     const headerComponents = (
         <div className="flex">
             {headerActions}


### PR DESCRIPTION
## Description

This adds pagination to the VM PolicyOverview table of deployments that are failing the policy.

## Approach

From what I can tell in staging and based on the headings of each section, the deployment table that is displayed when you click a row in the policy list should be identical to the table that is displayed when you click the "# failing deployments" text in the table cell.

VM -> Policies -> Click "Fixable severity at least important" row
<img width="1676" alt="image" src="https://user-images.githubusercontent.com/1292638/205353133-aa2994b4-9264-421a-8981-b3b42f1b8d16.png">

VM -> Policies -> Click "29 failing deployments" link in "Fixable severity at least important" row
<img width="1676" alt="image" src="https://user-images.githubusercontent.com/1292638/205353268-c6e2837b-c25a-40e0-9cc0-79133a02024d.png">

The general idea here is that we _remove_ the `deployment` subresolver from the entity query in VulnMgmtEntityPolicy and replace it with a separate query in the child component VulnMgmtPolicyOverview.

This has the downside of requiring an extra request when the details panel is opened.

The upsides are:
- We don't request the deployment list until it is needed
- We can actually do pagination of this secondary table
- When we paginate the second table, it doesn't require us to refetch the entire policy entity query each time the deployment query changes

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Manual comparison of local branch and staging UI against staging data for both of the above pages via YARN_START_TARGET. For each policy with failing deployments, click the table row as well as the "# failing deployments" link and view the list of deployments in the table. Sorting by name, verify that the exact same deployments appear in each table. The UI should be identical across the two builds, with the exception of this PR having the data split into table pages.

Test against a scaled data cluster and ensure that very large lists of deployments do not cause a timeout and successfully paginate the data. (Note that the "related entities" side panel is not present in the screenshots below because the endpoint returns a `deploymentCount` of `0` due to the data being mocked - it is rendered correctly when running against staging data.)

Clicking on the table row:
![image](https://user-images.githubusercontent.com/1292638/209196259-e63a5b4e-6cc6-4de7-a781-03cafe5cbec6.png)
![image](https://user-images.githubusercontent.com/1292638/209196322-ebfe5efb-90df-431c-b63d-3664af8241c3.png)

Clicking on the failed deployments link:
![image](https://user-images.githubusercontent.com/1292638/209198984-ab76a658-d60d-482b-b5c0-98f5fb718b66.png)
![image](https://user-images.githubusercontent.com/1292638/209199025-84f0da61-d5bb-4920-b5fa-745ffffe45df.png)


