### PR TITLE
ROX-13676: Create external entities side panel layout

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraph.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraph.tsx
@@ -162,7 +162,11 @@ const TopologyComponent = ({ model }: TopologyComponentProps) => {
                         />
                     )}
                     {selectedEntity && selectedEntity?.data?.type === 'EXTERNAL_ENTITIES' && (
-                        <ExternalEntitiesSideBar />
+                        <ExternalEntitiesSideBar
+                            id={selectedEntity.id}
+                            nodes={model?.nodes || []}
+                            edges={model?.edges || []}
+                        />
                     )}
                 </TopologySideBar>
             }

--- a/ui/apps/platform/src/Containers/NetworkGraph/cidr/CidrBlockSideBar.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/cidr/CidrBlockSideBar.tsx
@@ -158,6 +158,7 @@ function CidrBlockSideBar({ id, nodes, edges }: CidrBlockSideBarProps): ReactEle
                             setExpandedRows={setExpandedRows}
                             selectedRows={selectedRows}
                             setSelectedRows={setSelectedRows}
+                            isEditable
                         />
                     </StackItem>
                 </Stack>

--- a/ui/apps/platform/src/Containers/NetworkGraph/common/FlowsTable.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/common/FlowsTable.tsx
@@ -23,6 +23,7 @@ type FlowsTableProps = {
     setExpandedRows: React.Dispatch<React.SetStateAction<string[]>>;
     selectedRows: string[];
     setSelectedRows: React.Dispatch<React.SetStateAction<string[]>>;
+    isEditable?: boolean;
 };
 
 const columnNames = {
@@ -40,6 +41,7 @@ function FlowsTable({
     setExpandedRows,
     selectedRows,
     setSelectedRows,
+    isEditable = false,
 }: FlowsTableProps): ReactElement {
     // getter functions
     const isRowExpanded = (row: Flow) => expandedRows.includes(row.id);
@@ -75,12 +77,14 @@ function FlowsTable({
             <Thead>
                 <Tr>
                     <Th />
-                    <Th
-                        select={{
-                            onSelect: (_event, isSelecting) => selectAllRows(isSelecting),
-                            isSelected: areAllRowsSelected,
-                        }}
-                    />
+                    {isEditable && (
+                        <Th
+                            select={{
+                                onSelect: (_event, isSelecting) => selectAllRows(isSelecting),
+                                isSelected: areAllRowsSelected,
+                            }}
+                        />
+                    )}
                     <Th width={40}>{columnNames.entity}</Th>
                     <Th>{columnNames.direction}</Th>
                     <Th>{columnNames.portAndProtocol}</Th>
@@ -121,19 +125,21 @@ function FlowsTable({
                                         : undefined
                                 }
                             />
-                            <Td
-                                select={
-                                    row.children && row.children.length === 0
-                                        ? {
-                                              rowIndex,
-                                              onSelect: (_event, isSelecting) =>
-                                                  setRowSelected(row, isSelecting),
-                                              isSelected: isRowSelected(row),
-                                              disable: !!row.children.length,
-                                          }
-                                        : undefined
-                                }
-                            />
+                            {isEditable && (
+                                <Td
+                                    select={
+                                        row.children && row.children.length === 0
+                                            ? {
+                                                  rowIndex,
+                                                  onSelect: (_event, isSelecting) =>
+                                                      setRowSelected(row, isSelecting),
+                                                  isSelected: isRowSelected(row),
+                                                  disable: !!row.children.length,
+                                              }
+                                            : undefined
+                                    }
+                                />
+                            )}
                             <Td dataLabel={columnNames.entity}>
                                 <Flex direction={{ default: 'row' }}>
                                     <FlexItem>
@@ -161,11 +167,13 @@ function FlowsTable({
                             <Td dataLabel={columnNames.portAndProtocol}>
                                 {row.port} / {row.protocol}
                             </Td>
-                            <Td isActionCell>
-                                {row.children && !row.children.length && (
-                                    <ActionsColumn items={rowActions} />
-                                )}
-                            </Td>
+                            {isEditable && (
+                                <Td isActionCell>
+                                    {row.children && !row.children.length && (
+                                        <ActionsColumn items={rowActions} />
+                                    )}
+                                </Td>
+                            )}
                         </Tr>
                         {isExpanded &&
                             row.children &&
@@ -187,14 +195,16 @@ function FlowsTable({
                                 return (
                                     <Tr key={child.id} isExpanded={isExpanded}>
                                         <Td />
-                                        <Td
-                                            select={{
-                                                rowIndex,
-                                                onSelect: (_event, isSelecting) =>
-                                                    setRowSelected(child, isSelecting),
-                                                isSelected: isRowSelected(child),
-                                            }}
-                                        />
+                                        {isEditable && (
+                                            <Td
+                                                select={{
+                                                    rowIndex,
+                                                    onSelect: (_event, isSelecting) =>
+                                                        setRowSelected(child, isSelecting),
+                                                    isSelected: isRowSelected(child),
+                                                }}
+                                            />
+                                        )}
                                         <Td>
                                             <ExpandableRowContent>
                                                 <Flex direction={{ default: 'row' }}>
@@ -217,9 +227,11 @@ function FlowsTable({
                                                 {child.port} / {child.protocol}
                                             </ExpandableRowContent>
                                         </Td>
-                                        <Td isActionCell>
-                                            <ActionsColumn items={childActions} />
-                                        </Td>
+                                        {isEditable && (
+                                            <Td isActionCell>
+                                                <ActionsColumn items={childActions} />
+                                            </Td>
+                                        )}
                                     </Tr>
                                 );
                             })}

--- a/ui/apps/platform/src/Containers/NetworkGraph/common/NetworkGraphIcons.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/common/NetworkGraphIcons.tsx
@@ -16,3 +16,7 @@ export function ClusterIcon() {
 export function CidrBlockIcon() {
     return <Badge style={{ backgroundColor: 'rgb(0,0,0)' }}>IP</Badge>;
 }
+
+export function ExternalEntitiesIcon() {
+    return <Badge style={{ backgroundColor: 'rgb(0,0,0)' }}>E</Badge>;
+}

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentBaselines.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentBaselines.tsx
@@ -184,6 +184,7 @@ function DeploymentBaselines() {
                         setExpandedRows={setExpandedRows}
                         selectedRows={selectedRows}
                         setSelectedRows={setSelectedRows}
+                        isEditable
                     />
                 </StackItem>
                 <Divider component="hr" />

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentFlows.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentFlows.tsx
@@ -154,6 +154,7 @@ function DeploymentFlow() {
                         setExpandedRows={setExpandedRows}
                         selectedRows={selectedRows}
                         setSelectedRows={setSelectedRows}
+                        isEditable
                     />
                 </StackItem>
             </Stack>

--- a/ui/apps/platform/src/Containers/NetworkGraph/external/ExternalEntitiesSideBar.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/external/ExternalEntitiesSideBar.tsx
@@ -1,23 +1,182 @@
-import React from 'react';
-import { Badge, Flex, FlexItem, Text, TextContent, TextVariants } from '@patternfly/react-core';
+import React, { ReactElement } from 'react';
+import {
+    Divider,
+    Flex,
+    FlexItem,
+    Stack,
+    StackItem,
+    Text,
+    TextContent,
+    TextVariants,
+    Toolbar,
+    ToolbarContent,
+    ToolbarItem,
+} from '@patternfly/react-core';
+import { EdgeModel } from '@patternfly/react-topology';
 
-function CidrBlockSideBar() {
+import { getNodeById } from '../utils/networkGraphUtils';
+import { getAllUniquePorts, getNumFlows } from '../utils/flowUtils';
+import { AdvancedFlowsFilterType } from '../common/AdvancedFlowsFilter/types';
+import { Flow } from '../types/flow.type';
+import { CustomNodeModel } from '../types/topology.type';
+
+import { ExternalEntitiesIcon } from '../common/NetworkGraphIcons';
+import AdvancedFlowsFilter, {
+    defaultAdvancedFlowsFilters,
+} from '../common/AdvancedFlowsFilter/AdvancedFlowsFilter';
+import EntityNameSearchInput from '../common/EntityNameSearchInput';
+import FlowsTable from '../common/FlowsTable';
+import FlowsTableHeaderText from '../common/FlowsTableHeaderText';
+
+type ExternalEntitiesSideBarProps = {
+    id: string;
+    nodes: CustomNodeModel[];
+    edges: EdgeModel[];
+};
+
+const flows: Flow[] = [
+    {
+        id: 'Deployment 1-naples-Ingress-Many-TCP',
+        type: 'Deployment',
+        entity: 'Deployment 1',
+        namespace: 'naples',
+        direction: 'Bi-directional',
+        port: 'MANY',
+        protocol: 'TCP',
+        isAnomalous: true,
+        children: [
+            {
+                id: 'Deployment 1-naples-Ingress-Many-TCP',
+                type: 'Deployment',
+                entity: 'Deployment 1',
+                namespace: 'naples',
+                direction: 'Egress',
+                port: '9000',
+                protocol: 'TCP',
+                isAnomalous: true,
+            },
+            {
+                id: 'Deployment 1-naples-Ingress-Many-TCP',
+                type: 'Deployment',
+                entity: 'Deployment 1',
+                namespace: 'naples',
+                direction: 'Ingress',
+                port: '8000',
+                protocol: 'TCP',
+                isAnomalous: true,
+            },
+        ],
+    },
+    {
+        id: 'Deployment 2-naples-Ingress-Many-UDP',
+        type: 'Deployment',
+        entity: 'Deployment 2',
+        namespace: 'naples',
+        direction: 'Ingress',
+        port: '8080',
+        protocol: 'UDP',
+        isAnomalous: true,
+        children: [],
+    },
+    {
+        id: 'Deployment 3-naples-Egress-7777-UDP',
+        type: 'Deployment',
+        entity: 'Deployment 3',
+        namespace: 'naples',
+        direction: 'Egress',
+        port: '7777',
+        protocol: 'UDP',
+        isAnomalous: true,
+        children: [],
+    },
+];
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function ExternalEntitiesSideBar({ id, nodes, edges }: ExternalEntitiesSideBarProps): ReactElement {
+    // component state
+    const [entityNameFilter, setEntityNameFilter] = React.useState<string>('');
+    const [advancedFilters, setAdvancedFilters] = React.useState<AdvancedFlowsFilterType>(
+        defaultAdvancedFlowsFilters
+    );
+    const initialExpandedRows = flows
+        .filter((row) => row.children && !!row.children.length)
+        .map((row) => row.id); // Default to all expanded
+    const [expandedRows, setExpandedRows] = React.useState<string[]>(initialExpandedRows);
+    const [selectedRows, setSelectedRows] = React.useState<string[]>([]);
+
+    // derived data
+    const externalEntitiesNode = getNodeById(nodes, id);
+    const numFlows = getNumFlows(flows);
+    const allUniquePorts = getAllUniquePorts(flows);
+
     return (
-        <Flex direction={{ default: 'column' }} flex={{ default: 'flex_1' }} className="pf-u-h-100">
-            <Flex direction={{ default: 'row' }} className="pf-u-p-md pf-u-mb-0">
-                <FlexItem>
-                    <Badge style={{ backgroundColor: 'rgb(0,102,205)' }}>E</Badge>
-                </FlexItem>
-                <FlexItem>
-                    <TextContent>
-                        <Text component={TextVariants.h2} className="pf-u-font-size-xl">
-                            External Entities
-                        </Text>
-                    </TextContent>
-                </FlexItem>
-            </Flex>
-        </Flex>
+        <Stack>
+            <StackItem>
+                <Flex direction={{ default: 'row' }} className="pf-u-p-md pf-u-mb-0">
+                    <FlexItem>
+                        <ExternalEntitiesIcon />
+                    </FlexItem>
+                    <FlexItem>
+                        <TextContent>
+                            <Text component={TextVariants.h1} className="pf-u-font-size-xl">
+                                {externalEntitiesNode?.label}
+                            </Text>
+                        </TextContent>
+                        <TextContent>
+                            <Text
+                                component={TextVariants.h2}
+                                className="pf-u-font-size-sm pf-u-color-200"
+                            >
+                                Connected Entities Outside Your Cluster
+                            </Text>
+                        </TextContent>
+                    </FlexItem>
+                </Flex>
+            </StackItem>
+            <StackItem isFilled style={{ overflow: 'auto' }} className="pf-u-p-md">
+                <Stack hasGutter>
+                    <StackItem>
+                        <Flex>
+                            <FlexItem flex={{ default: 'flex_1' }}>
+                                <EntityNameSearchInput
+                                    value={entityNameFilter}
+                                    setValue={setEntityNameFilter}
+                                />
+                            </FlexItem>
+                            <FlexItem>
+                                <AdvancedFlowsFilter
+                                    filters={advancedFilters}
+                                    setFilters={setAdvancedFilters}
+                                    allUniquePorts={allUniquePorts}
+                                />
+                            </FlexItem>
+                        </Flex>
+                    </StackItem>
+                    <Divider component="hr" />
+                    <StackItem>
+                        <Toolbar>
+                            <ToolbarContent>
+                                <ToolbarItem>
+                                    <FlowsTableHeaderText type="active" numFlows={numFlows} />
+                                </ToolbarItem>
+                            </ToolbarContent>
+                        </Toolbar>
+                    </StackItem>
+                    <StackItem>
+                        <FlowsTable
+                            label="External entities flows"
+                            flows={flows}
+                            numFlows={numFlows}
+                            expandedRows={expandedRows}
+                            setExpandedRows={setExpandedRows}
+                            selectedRows={selectedRows}
+                            setSelectedRows={setSelectedRows}
+                        />
+                    </StackItem>
+                </Stack>
+            </StackItem>
+        </Stack>
     );
 }
 
-export default CidrBlockSideBar;
+export default ExternalEntitiesSideBar;

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/modelUtils.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/modelUtils.tsx
@@ -16,7 +16,7 @@ function getNameByEntity(entity: NetworkEntityInfo): string {
         case 'DEPLOYMENT':
             return entity.deployment.name;
         case 'INTERNET':
-            return 'Internet';
+            return 'External Entities';
         case 'EXTERNAL_SOURCE':
             return entity.externalSource.name;
         default:


### PR DESCRIPTION
## Description

This PR fleshes out the External Entities side bar a little bit more. I've added a flows table that is not editable and made a few little edits to make the data more in line with what you see in the current network graph

<img width="1440" alt="Screenshot 2022-12-02 at 4 23 53 PM" src="https://user-images.githubusercontent.com/4805485/205413439-24b14bf8-8e43-4497-8cd6-795e1408a032.png">

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

