### PR TITLE
ROX-13371: Add GKE Log links for life of cluster

### DIFF
--- a/scripts/ci/gke.sh
+++ b/scripts/ci/gke.sh
@@ -295,6 +295,7 @@ create_log_explorer_links() {
         <title><h4>GKE Logs Explorer</h4></title>
     </head>
     <body>
+    <p>(these links require a 'left-click -> open in tab')
     <ul style="padding-bottom: 28px; padding-left: 30px; font-family: Roboto,Helvetica,Arial,sans-serif;">
 HEAD
 
@@ -306,18 +307,20 @@ HEAD
     project="$(gcloud config get project --quiet)"
 
     for authUser in {0..2}; do
-        echo \
-\<li\>\
-\<a href=\"https://console.cloud.google.com/logs/query\;query=\
-resource.type=%22k8s_container%22%0A\
-resource.labels.cluster_name%3D%22"$CLUSTER_NAME"%22%0A\
-resource.labels.namespace_name%3D%22stackrox%22%0A\
-\;timeRange="$start_ts"%2F"$end_ts"\
-\;cursorTimestamp="$start_ts"\
-?authuser="$authUser"\
-\&project="$project"\
-\&orgonly=true\&supportedpurview=organizationId\"\>authUser "$authUser"\</a\>\
-\</li\> >> "$artifact_file"
+    cat >> "$artifact_file" << LINK
+      <li>
+        <a href="https://console.cloud.google.com/logs/query
+;query=
+resource.type=%22k8s_container%22%0A
+resource.labels.cluster_name%3D%22$CLUSTER_NAME%22%0A
+resource.labels.namespace_name%3D%22stackrox%22%0A
+;timeRange=$start_ts%2F$end_ts
+;cursorTimestamp=$start_ts
+?authuser=$authUser
+&project=$project
+&orgonly=true&supportedpurview=organizationId">authUser $authUser</a>
+      </li>
+LINK
     done
 
     cat >> "$artifact_file" <<- FOOT

--- a/scripts/ci/gke.sh
+++ b/scripts/ci/gke.sh
@@ -295,7 +295,7 @@ create_log_explorer_links() {
         <title><h4>GKE Logs Explorer</h4></title>
     </head>
     <body>
-    <ul style="background: #fff; padding-bottom: 20px;">
+    <ul style="background: #424242; padding-bottom: 20px; list-style-type: none; padding-left: 20px;">
 HEAD
 
     local start_ts
@@ -308,7 +308,7 @@ HEAD
     for authUser in {0..2}; do
         echo \
 \<li\>\
-\<a target=\"_blank\" href=\"https://console.cloud.google.com/logs/query\;query=\
+\<a href=\"https://console.cloud.google.com/logs/query\;query=\
 resource.type=%22k8s_container%22%0A\
 resource.labels.cluster_name%3D%22"$CLUSTER_NAME"%22%0A\
 resource.labels.namespace_name%3D%22stackrox%22%0A\

--- a/scripts/ci/gke.sh
+++ b/scripts/ci/gke.sh
@@ -308,7 +308,7 @@ HEAD
     for authUser in {0..2}; do
         echo \
 \<li\>\
-\<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://console.cloud.google.com/logs/query\;query=\
+\<a target=\"_blank\" href=\"https://console.cloud.google.com/logs/query\;query=\
 resource.type=%22k8s_container%22%0A\
 resource.labels.cluster_name%3D%22"$CLUSTER_NAME"%22%0A\
 resource.labels.namespace_name%3D%22stackrox%22%0A\

--- a/scripts/ci/gke.sh
+++ b/scripts/ci/gke.sh
@@ -279,7 +279,6 @@ teardown_gke_cluster() {
     info "Cluster deleting asynchronously"
 
     create_log_explorer_links
-    create_log_explorer_links2
 }
 
 create_log_explorer_links() {
@@ -291,12 +290,12 @@ create_log_explorer_links() {
     artifact_file="$ARTIFACT_DIR/gke-logs-summary.html"
 
     cat > "$artifact_file" <<- HEAD
-<html>
+<html style="background: #fff">
     <head>
         <title><h4>GKE Logs Explorer</h4></title>
     </head>
     <body>
-    <ul style="background: #424242; padding-bottom: 20px; list-style-type: none; padding-left: 20px;">
+    <ul style="padding-bottom: 28px; padding-left: 30px; font-family: Roboto,Helvetica,Arial,sans-serif;">
 HEAD
 
     local start_ts
@@ -325,37 +324,6 @@ resource.labels.namespace_name%3D%22stackrox%22%0A\
     </ul>
 </html>
 FOOT
-}
-
-create_log_explorer_links2() {
-    if [[ -z "${ARTIFACT_DIR:-}" ]]; then
-        info "No place for artifacts, skipping explorer links"
-        return
-    fi
-
-    artifact_file="$ARTIFACT_DIR/gke-logs.link.txt"
-
-    local start_ts
-    start_ts="$(cat /tmp/GKE_CLUSTER_CREATED_TIMESTAMP)"
-    local end_ts
-    end_ts="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
-    local project
-    project="$(gcloud config get project --quiet)"
-
-    for authUser in {0..2}; do
-        echo \
-\<li\>\
-\<a href=\"https://console.cloud.google.com/logs/query\;query=\
-resource.type=%22k8s_container%22%0A\
-resource.labels.cluster_name%3D%22"$CLUSTER_NAME"%22%0A\
-resource.labels.namespace_name%3D%22stackrox%22%0A\
-\;timeRange="$start_ts"%2F"$end_ts"\
-\;cursorTimestamp="$start_ts"\
-?authuser="$authUser"\
-\&project="$project"\
-\&orgonly=true\&supportedpurview=organizationId\"\>authUser "$authUser"\</a\>\
-\</li\> >> "$artifact_file"
-    done
 }
 
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then

--- a/scripts/ci/gke.sh
+++ b/scripts/ci/gke.sh
@@ -295,7 +295,7 @@ create_log_explorer_links() {
         <title><h4>GKE Logs Explorer</h4></title>
     </head>
     <body>
-    <p>(these links require a 'left-click -> open in tab')
+    <p>(These links require a 'right-click -> open in new tab'. The authUser is the number for your @stackrox.com account.)</p>
     <ul style="padding-bottom: 28px; padding-left: 30px; font-family: Roboto,Helvetica,Arial,sans-serif;">
 HEAD
 

--- a/scripts/ci/gke.sh
+++ b/scripts/ci/gke.sh
@@ -184,6 +184,8 @@ create_cluster() {
         info "Cluster creation failed"
         return 1
     fi
+
+    date -u +"%Y-%m-%dT%H:%M:%SZ" > /tmp/GKE_CLUSTER_CREATED_TIMESTAMP
 }
 
 wait_for_cluster() {
@@ -275,6 +277,53 @@ teardown_gke_cluster() {
     gcloud container clusters delete "$CLUSTER_NAME" --async
 
     info "Cluster deleting asynchronously"
+
+    create_log_explorer_links
+}
+
+create_log_explorer_links() {
+    if [[ -z "${ARTIFACT_DIR:-}" ]]; then
+        info "No place for artifacts, skipping explorer links"
+        return
+    fi
+
+    artifact_file="$ARTIFACT_DIR/gke-logs-summary.html"
+
+    cat > "$artifact_file" <<- HEAD
+<html>
+    <head>
+        <title><h4>GKE Logs Explorer</h4></title>
+    </head>
+    <body>
+    <ul style="background: #fff;">
+HEAD
+
+    local start_ts
+    start_ts="$(cat /tmp/GKE_CLUSTER_CREATED_TIMESTAMP)"
+    local end_ts
+    end_ts="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+    local project
+    project="$(gcloud config get project --quiet)"
+
+    for authUser in {0..2}; do
+        echo \
+\<li\>\
+\<a href=\"https://console.cloud.google.com/logs/query\;query=\
+resource.type=%22k8s_container%22%0A\
+resource.labels.cluster_name%3D%22"$CLUSTER_NAME"%22%0A\
+resource.labels.namespace_name%3D%22stackrox%22%0A\
+\;timeRange="$start_ts"%2F"$end_ts"\
+\;cursorTimestamp="$start_ts"\
+?authuser="$authUser"\
+\&project="$project"\
+\&orgonly=true\&supportedpurview=organizationId\"\>authUser "$authUser"\</a\>\
+\</li\> >> "$artifact_file"
+    done
+
+    cat >> "$artifact_file" <<- FOOT
+    </ul>
+</html>
+FOOT
 }
 
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then

--- a/scripts/ci/gke.sh
+++ b/scripts/ci/gke.sh
@@ -295,7 +295,7 @@ create_log_explorer_links() {
         <title><h4>GKE Logs Explorer</h4></title>
     </head>
     <body>
-    <ul style="background: #fff;">
+    <ul style="background: #fff; padding-bottom: 20px;">
 HEAD
 
     local start_ts
@@ -308,7 +308,7 @@ HEAD
     for authUser in {0..2}; do
         echo \
 \<li\>\
-\<a href=\"https://console.cloud.google.com/logs/query\;query=\
+\<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://console.cloud.google.com/logs/query\;query=\
 resource.type=%22k8s_container%22%0A\
 resource.labels.cluster_name%3D%22"$CLUSTER_NAME"%22%0A\
 resource.labels.namespace_name%3D%22stackrox%22%0A\


### PR DESCRIPTION
## Description

Adds links for GKE logs to prow results. [e.g.](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/stackrox_stackrox/4006/pull-ci-stackrox-stackrox-master-gke-postgres-qa-e2e-tests/1599849433204264960)

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient