### PR TITLE
ROX-11756: Add SAC tests for cluster CVE object

### DIFF
--- a/central/cluster/datastore/datastore.go
+++ b/central/cluster/datastore/datastore.go
@@ -2,29 +2,19 @@ package datastore
 
 import (
 	"context"
-	"testing"
 
-	"github.com/blevesearch/bleve"
-	"github.com/jackc/pgx/v4/pgxpool"
 	alertDataStore "github.com/stackrox/rox/central/alert/datastore"
 	"github.com/stackrox/rox/central/cluster/datastore/internal/search"
 	"github.com/stackrox/rox/central/cluster/index"
 	clusterStore "github.com/stackrox/rox/central/cluster/store/cluster"
-	clusterPostgresStore "github.com/stackrox/rox/central/cluster/store/cluster/postgres"
-	clusterRocksDBStore "github.com/stackrox/rox/central/cluster/store/cluster/rocksdb"
 	clusterHealthStore "github.com/stackrox/rox/central/cluster/store/clusterhealth"
-	clusterHealthPostgresStore "github.com/stackrox/rox/central/cluster/store/clusterhealth/postgres"
-	clusterHealthRocksDBStore "github.com/stackrox/rox/central/cluster/store/clusterhealth/rocksdb"
 	clusterCVEDS "github.com/stackrox/rox/central/cve/cluster/datastore"
-	clusterCVEDataStore "github.com/stackrox/rox/central/cve/cluster/datastore"
 	deploymentDataStore "github.com/stackrox/rox/central/deployment/datastore"
 	imageIntegrationDataStore "github.com/stackrox/rox/central/imageintegration/datastore"
 	namespaceDataStore "github.com/stackrox/rox/central/namespace/datastore"
 	networkBaselineManager "github.com/stackrox/rox/central/networkbaseline/manager"
 	netEntityDataStore "github.com/stackrox/rox/central/networkgraph/entity/datastore"
 	netFlowsDataStore "github.com/stackrox/rox/central/networkgraph/flow/datastore"
-	nodeNodeDataStore "github.com/stackrox/rox/central/node/datastore/dackbox/datastore"
-	nodeGlobalDataStore "github.com/stackrox/rox/central/node/datastore/dackbox/globaldatastore"
 	nodeDataStore "github.com/stackrox/rox/central/node/globaldatastore"
 	notifierProcessor "github.com/stackrox/rox/central/notifier/processor"
 	podDataStore "github.com/stackrox/rox/central/pod/datastore"
@@ -39,16 +29,12 @@ import (
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/concurrency"
-	"github.com/stackrox/rox/pkg/dackbox"
-	dackboxConcurrency "github.com/stackrox/rox/pkg/dackbox/concurrency"
 	"github.com/stackrox/rox/pkg/dackbox/graph"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/logging"
-	rocksdbBase "github.com/stackrox/rox/pkg/rocksdb"
 	"github.com/stackrox/rox/pkg/sac"
 	pkgSearch "github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/simplecache"
-	"go.etcd.io/bbolt"
 )
 
 var (
@@ -157,151 +143,4 @@ func New(
 
 	go ds.cleanUpNodeStore(cleanupCtx)
 	return ds, nil
-}
-
-// GetTestPostgresDataStore provides a datastore connected to postgres for testing purposes.
-func GetTestPostgresDataStore(t *testing.T, pool *pgxpool.Pool) (DataStore, error) {
-	clusterdbstore := clusterPostgresStore.New(pool)
-	clusterhealthdbstore := clusterHealthPostgresStore.New(pool)
-	indexer := clusterPostgresStore.NewIndexer(pool)
-	alertStore, err := alertDataStore.GetTestPostgresDataStore(t, pool)
-	if err != nil {
-		return nil, err
-	}
-	namespaceStore, err := namespaceDataStore.GetTestPostgresDataStore(t, pool)
-	if err != nil {
-		return nil, err
-	}
-	deploymentStore, err := deploymentDataStore.GetTestPostgresDataStore(t, pool)
-	if err != nil {
-		return nil, err
-	}
-	nodeInternalStore, err := nodeNodeDataStore.GetTestPostgresDataStore(t, pool)
-	if err != nil {
-		return nil, err
-	}
-	nodeStore := nodeGlobalDataStore.New(nodeInternalStore)
-	podStore, err := podDataStore.GetTestPostgresDataStore(t, pool)
-	if err != nil {
-		return nil, err
-	}
-	secretStore, err := secretDataStore.GetTestPostgresDataStore(t, pool)
-	if err != nil {
-		return nil, err
-	}
-	netFlowStore, err := netFlowsDataStore.GetTestPostgresClusterDataStore(t, pool)
-	if err != nil {
-		return nil, err
-	}
-	netEntityStore, err := netEntityDataStore.GetTestPostgresDataStore(t, pool)
-	if err != nil {
-		return nil, err
-	}
-	serviceAccountStore, err := serviceAccountDataStore.GetTestPostgresDataStore(t, pool)
-	if err != nil {
-		return nil, err
-	}
-	k8sRoleStore, err := roleDataStore.GetTestPostgresDataStore(t, pool)
-	if err != nil {
-		return nil, err
-	}
-	k8sRoleBindingStore, err := roleBindingDataStore.GetTestPostgresDataStore(t, pool)
-	if err != nil {
-		return nil, err
-	}
-	networkBaselineManager, err := networkBaselineManager.GetTestPostgresManager(t, pool)
-	if err != nil {
-		return nil, err
-	}
-	iiStore, err := imageIntegrationDataStore.GetTestPostgresDataStore(t, pool)
-	if err != nil {
-		return nil, err
-	}
-	clusterCVEStore, err := clusterCVEDataStore.GetTestPostgresDataStore(t, pool)
-	if err != nil {
-		return nil, err
-	}
-
-	sensorCnxMgr := connection.ManagerSingleton()
-	clusterRanker := ranking.ClusterRanker()
-
-	return New(clusterdbstore, clusterhealthdbstore, clusterCVEStore,
-		alertStore, iiStore, namespaceStore, deploymentStore,
-		nodeStore, podStore, secretStore, netFlowStore, netEntityStore,
-		serviceAccountStore, k8sRoleStore, k8sRoleBindingStore, sensorCnxMgr, nil,
-		nil, clusterRanker, indexer, networkBaselineManager)
-}
-
-// GetTestRocksBleveDataStore provides a datastore connected to rocksdb and bleve for testing purposes.
-func GetTestRocksBleveDataStore(t *testing.T, rocksengine *rocksdbBase.RocksDB, bleveIndex bleve.Index, dacky *dackbox.DackBox, keyFence dackboxConcurrency.KeyFence, boltengine *bbolt.DB) (DataStore, error) {
-	clusterdbstore, err := clusterRocksDBStore.New(rocksengine)
-	if err != nil {
-		return nil, err
-	}
-	clusterhealthdbstore, err := clusterHealthRocksDBStore.New(rocksengine)
-	if err != nil {
-		return nil, err
-	}
-	indexer := index.New(bleveIndex)
-	alertStore, err := alertDataStore.GetTestRocksBleveDataStore(t, rocksengine, bleveIndex)
-	if err != nil {
-		return nil, err
-	}
-	namespaceStore, err := namespaceDataStore.GetTestRocksBleveDataStore(t, rocksengine, bleveIndex, dacky, keyFence)
-	if err != nil {
-		return nil, err
-	}
-	deploymentStore, err := deploymentDataStore.GetTestRocksBleveDataStore(t, rocksengine, bleveIndex, dacky, keyFence)
-	if err != nil {
-		return nil, err
-	}
-	nodeInternalStore, err := nodeNodeDataStore.GetTestRocksBleveDataStore(t, rocksengine, bleveIndex, dacky, keyFence)
-	if err != nil {
-		return nil, err
-	}
-	nodeStore := nodeGlobalDataStore.New(nodeInternalStore)
-	podStore, err := podDataStore.GetTestRocksBleveDataStore(t, rocksengine, bleveIndex)
-	if err != nil {
-		return nil, err
-	}
-	secretStore, err := secretDataStore.GetTestRocksBleveDataStore(t, rocksengine, bleveIndex)
-	if err != nil {
-		return nil, err
-	}
-	netFlowStore, err := netFlowsDataStore.GetTestRocksBleveClusterDataStore(t, rocksengine)
-	if err != nil {
-		return nil, err
-	}
-	netEntityStore, err := netEntityDataStore.GetTestRocksBleveDataStore(t, rocksengine)
-	if err != nil {
-		return nil, err
-	}
-	serviceAccountStore, err := serviceAccountDataStore.GetTestRocksBleveDataStore(t, rocksengine, bleveIndex)
-	if err != nil {
-		return nil, err
-	}
-	k8sRoleStore, err := roleDataStore.GetTestRocksBleveDataStore(t, rocksengine, bleveIndex)
-	if err != nil {
-		return nil, err
-	}
-	k8sRoleBindingStore, err := roleBindingDataStore.GetTestRocksBleveDataStore(t, rocksengine, bleveIndex)
-	if err != nil {
-		return nil, err
-	}
-	networkBaselineManager, err := networkBaselineManager.GetTestRocksBleveManager(t, rocksengine, bleveIndex, dacky, keyFence, boltengine)
-	if err != nil {
-		return nil, err
-	}
-	iiStore, err := imageIntegrationDataStore.GetTestRocksBleveDataStore(t, boltengine, bleveIndex)
-	if err != nil {
-		return nil, err
-	}
-	sensorCnxMgr := connection.ManagerSingleton()
-	clusterRanker := ranking.ClusterRanker()
-
-	return New(clusterdbstore, clusterhealthdbstore, nil,
-		alertStore, iiStore, namespaceStore, deploymentStore,
-		nodeStore, podStore, secretStore, netFlowStore, netEntityStore,
-		serviceAccountStore, k8sRoleStore, k8sRoleBindingStore, sensorCnxMgr, nil,
-		dacky, clusterRanker, indexer, networkBaselineManager)
 }

--- a/central/cluster/datastore/datastore_test_constructors.go
+++ b/central/cluster/datastore/datastore_test_constructors.go
@@ -1,0 +1,181 @@
+package datastore
+
+import (
+	"testing"
+
+	"github.com/blevesearch/bleve"
+	"github.com/jackc/pgx/v4/pgxpool"
+	alertDataStore "github.com/stackrox/rox/central/alert/datastore"
+	"github.com/stackrox/rox/central/cluster/index"
+	clusterPostgresStore "github.com/stackrox/rox/central/cluster/store/cluster/postgres"
+	clusterRocksDBStore "github.com/stackrox/rox/central/cluster/store/cluster/rocksdb"
+	clusterHealthPostgresStore "github.com/stackrox/rox/central/cluster/store/clusterhealth/postgres"
+	clusterHealthRocksDBStore "github.com/stackrox/rox/central/cluster/store/clusterhealth/rocksdb"
+	clusterCVEDataStore "github.com/stackrox/rox/central/cve/cluster/datastore"
+	deploymentDataStore "github.com/stackrox/rox/central/deployment/datastore"
+	imageIntegrationDataStore "github.com/stackrox/rox/central/imageintegration/datastore"
+	namespaceDataStore "github.com/stackrox/rox/central/namespace/datastore"
+	networkBaselineManager "github.com/stackrox/rox/central/networkbaseline/manager"
+	netEntityDataStore "github.com/stackrox/rox/central/networkgraph/entity/datastore"
+	netFlowsDataStore "github.com/stackrox/rox/central/networkgraph/flow/datastore"
+	nodeNodeDataStore "github.com/stackrox/rox/central/node/datastore/dackbox/datastore"
+	nodeGlobalDataStore "github.com/stackrox/rox/central/node/datastore/dackbox/globaldatastore"
+	podDataStore "github.com/stackrox/rox/central/pod/datastore"
+	"github.com/stackrox/rox/central/ranking"
+	roleDataStore "github.com/stackrox/rox/central/rbac/k8srole/datastore"
+	roleBindingDataStore "github.com/stackrox/rox/central/rbac/k8srolebinding/datastore"
+	secretDataStore "github.com/stackrox/rox/central/secret/datastore"
+	"github.com/stackrox/rox/central/sensor/service/connection"
+	serviceAccountDataStore "github.com/stackrox/rox/central/serviceaccount/datastore"
+	"github.com/stackrox/rox/pkg/dackbox"
+	dackboxConcurrency "github.com/stackrox/rox/pkg/dackbox/concurrency"
+	rocksdbBase "github.com/stackrox/rox/pkg/rocksdb"
+	"go.etcd.io/bbolt"
+)
+
+// GetTestPostgresDataStore provides a datastore connected to postgres for testing purposes.
+func GetTestPostgresDataStore(t *testing.T, pool *pgxpool.Pool) (DataStore, error) {
+	clusterdbstore := clusterPostgresStore.New(pool)
+	clusterhealthdbstore := clusterHealthPostgresStore.New(pool)
+	indexer := clusterPostgresStore.NewIndexer(pool)
+	alertStore, err := alertDataStore.GetTestPostgresDataStore(t, pool)
+	if err != nil {
+		return nil, err
+	}
+	namespaceStore, err := namespaceDataStore.GetTestPostgresDataStore(t, pool)
+	if err != nil {
+		return nil, err
+	}
+	deploymentStore, err := deploymentDataStore.GetTestPostgresDataStore(t, pool)
+	if err != nil {
+		return nil, err
+	}
+	nodeInternalStore, err := nodeNodeDataStore.GetTestPostgresDataStore(t, pool)
+	if err != nil {
+		return nil, err
+	}
+	nodeStore := nodeGlobalDataStore.New(nodeInternalStore)
+	podStore, err := podDataStore.GetTestPostgresDataStore(t, pool)
+	if err != nil {
+		return nil, err
+	}
+	secretStore, err := secretDataStore.GetTestPostgresDataStore(t, pool)
+	if err != nil {
+		return nil, err
+	}
+	netFlowStore, err := netFlowsDataStore.GetTestPostgresClusterDataStore(t, pool)
+	if err != nil {
+		return nil, err
+	}
+	netEntityStore, err := netEntityDataStore.GetTestPostgresDataStore(t, pool)
+	if err != nil {
+		return nil, err
+	}
+	serviceAccountStore, err := serviceAccountDataStore.GetTestPostgresDataStore(t, pool)
+	if err != nil {
+		return nil, err
+	}
+	k8sRoleStore, err := roleDataStore.GetTestPostgresDataStore(t, pool)
+	if err != nil {
+		return nil, err
+	}
+	k8sRoleBindingStore, err := roleBindingDataStore.GetTestPostgresDataStore(t, pool)
+	if err != nil {
+		return nil, err
+	}
+	networkBaselineManager, err := networkBaselineManager.GetTestPostgresManager(t, pool)
+	if err != nil {
+		return nil, err
+	}
+	iiStore, err := imageIntegrationDataStore.GetTestPostgresDataStore(t, pool)
+	if err != nil {
+		return nil, err
+	}
+	clusterCVEStore, err := clusterCVEDataStore.GetTestPostgresDataStore(t, pool)
+	if err != nil {
+		return nil, err
+	}
+
+	sensorCnxMgr := connection.ManagerSingleton()
+	clusterRanker := ranking.ClusterRanker()
+
+	return New(clusterdbstore, clusterhealthdbstore, clusterCVEStore,
+		alertStore, iiStore, namespaceStore, deploymentStore,
+		nodeStore, podStore, secretStore, netFlowStore, netEntityStore,
+		serviceAccountStore, k8sRoleStore, k8sRoleBindingStore, sensorCnxMgr, nil,
+		nil, clusterRanker, indexer, networkBaselineManager)
+}
+
+// GetTestRocksBleveDataStore provides a datastore connected to rocksdb and bleve for testing purposes.
+func GetTestRocksBleveDataStore(t *testing.T, rocksengine *rocksdbBase.RocksDB, bleveIndex bleve.Index, dacky *dackbox.DackBox, keyFence dackboxConcurrency.KeyFence, boltengine *bbolt.DB) (DataStore, error) {
+	clusterdbstore, err := clusterRocksDBStore.New(rocksengine)
+	if err != nil {
+		return nil, err
+	}
+	clusterhealthdbstore, err := clusterHealthRocksDBStore.New(rocksengine)
+	if err != nil {
+		return nil, err
+	}
+	indexer := index.New(bleveIndex)
+	alertStore, err := alertDataStore.GetTestRocksBleveDataStore(t, rocksengine, bleveIndex)
+	if err != nil {
+		return nil, err
+	}
+	namespaceStore, err := namespaceDataStore.GetTestRocksBleveDataStore(t, rocksengine, bleveIndex, dacky, keyFence)
+	if err != nil {
+		return nil, err
+	}
+	deploymentStore, err := deploymentDataStore.GetTestRocksBleveDataStore(t, rocksengine, bleveIndex, dacky, keyFence)
+	if err != nil {
+		return nil, err
+	}
+	nodeInternalStore, err := nodeNodeDataStore.GetTestRocksBleveDataStore(t, rocksengine, bleveIndex, dacky, keyFence)
+	if err != nil {
+		return nil, err
+	}
+	nodeStore := nodeGlobalDataStore.New(nodeInternalStore)
+	podStore, err := podDataStore.GetTestRocksBleveDataStore(t, rocksengine, bleveIndex)
+	if err != nil {
+		return nil, err
+	}
+	secretStore, err := secretDataStore.GetTestRocksBleveDataStore(t, rocksengine, bleveIndex)
+	if err != nil {
+		return nil, err
+	}
+	netFlowStore, err := netFlowsDataStore.GetTestRocksBleveClusterDataStore(t, rocksengine)
+	if err != nil {
+		return nil, err
+	}
+	netEntityStore, err := netEntityDataStore.GetTestRocksBleveDataStore(t, rocksengine)
+	if err != nil {
+		return nil, err
+	}
+	serviceAccountStore, err := serviceAccountDataStore.GetTestRocksBleveDataStore(t, rocksengine, bleveIndex)
+	if err != nil {
+		return nil, err
+	}
+	k8sRoleStore, err := roleDataStore.GetTestRocksBleveDataStore(t, rocksengine, bleveIndex)
+	if err != nil {
+		return nil, err
+	}
+	k8sRoleBindingStore, err := roleBindingDataStore.GetTestRocksBleveDataStore(t, rocksengine, bleveIndex)
+	if err != nil {
+		return nil, err
+	}
+	networkBaselineManager, err := networkBaselineManager.GetTestRocksBleveManager(t, rocksengine, bleveIndex, dacky, keyFence, boltengine)
+	if err != nil {
+		return nil, err
+	}
+	iiStore, err := imageIntegrationDataStore.GetTestRocksBleveDataStore(t, boltengine, bleveIndex)
+	if err != nil {
+		return nil, err
+	}
+	sensorCnxMgr := connection.ManagerSingleton()
+	clusterRanker := ranking.ClusterRanker()
+
+	return New(clusterdbstore, clusterhealthdbstore, nil,
+		alertStore, iiStore, namespaceStore, deploymentStore,
+		nodeStore, podStore, secretStore, netFlowStore, netEntityStore,
+		serviceAccountStore, k8sRoleStore, k8sRoleBindingStore, sensorCnxMgr, nil,
+		dacky, clusterRanker, indexer, networkBaselineManager)
+}

--- a/central/clustercveedge/datastore/datastore_test_constructors.go
+++ b/central/clustercveedge/datastore/datastore_test_constructors.go
@@ -1,0 +1,25 @@
+package datastore
+
+import (
+	"testing"
+
+	"github.com/blevesearch/bleve"
+	"github.com/stackrox/rox/central/clustercveedge/index"
+	"github.com/stackrox/rox/central/clustercveedge/search"
+	dackboxStore "github.com/stackrox/rox/central/clustercveedge/store/dackbox"
+	cveIndex "github.com/stackrox/rox/central/cve/index"
+	"github.com/stackrox/rox/pkg/dackbox"
+	dackboxConcurrency "github.com/stackrox/rox/pkg/dackbox/concurrency"
+	rocksdbBase "github.com/stackrox/rox/pkg/rocksdb"
+)
+
+func GetTestRocksBleveDataStore(t *testing.T, _ *rocksdbBase.RocksDB, bleveIndex bleve.Index, dacky *dackbox.DackBox, keyFence dackboxConcurrency.KeyFence) (DataStore, error) {
+	storage, err := dackboxStore.New(dacky, keyFence)
+	if err != nil {
+		return nil, err
+	}
+	indexer := index.New(bleveIndex)
+	cveIndexer := cveIndex.New(bleveIndex)
+	searcher := search.New(storage, indexer, cveIndexer, dacky)
+	return New(dacky, storage, indexer, searcher)
+}

--- a/central/clustercveedge/datastore/datastore_test_constructors.go
+++ b/central/clustercveedge/datastore/datastore_test_constructors.go
@@ -13,6 +13,7 @@ import (
 	rocksdbBase "github.com/stackrox/rox/pkg/rocksdb"
 )
 
+// GetTestRocksBleveDataStore provides a datastore connected to rocksdb and bleve for testing purposes.
 func GetTestRocksBleveDataStore(t *testing.T, _ *rocksdbBase.RocksDB, bleveIndex bleve.Index, dacky *dackbox.DackBox, keyFence dackboxConcurrency.KeyFence) (DataStore, error) {
 	storage, err := dackboxStore.New(dacky, keyFence)
 	if err != nil {

--- a/central/cve/cluster/datastore/datastore.go
+++ b/central/cve/cluster/datastore/datastore.go
@@ -2,14 +2,11 @@ package datastore
 
 import (
 	"context"
-	"testing"
 
 	"github.com/gogo/protobuf/types"
-	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/stackrox/rox/central/cve/cluster/datastore/index"
 	"github.com/stackrox/rox/central/cve/cluster/datastore/search"
 	"github.com/stackrox/rox/central/cve/cluster/datastore/store"
-	"github.com/stackrox/rox/central/cve/cluster/datastore/store/postgres"
 	"github.com/stackrox/rox/central/cve/common"
 	"github.com/stackrox/rox/central/cve/converter/v2"
 	v1 "github.com/stackrox/rox/generated/api/v1"
@@ -52,12 +49,4 @@ func New(storage store.Store, indexer index.Indexer, searcher search.Searcher) (
 		return nil, err
 	}
 	return ds, nil
-}
-
-// GetTestPostgresDataStore provides a datastore connected to postgres for testing purposes.
-func GetTestPostgresDataStore(_ *testing.T, pool *pgxpool.Pool) (DataStore, error) {
-	dbstore := postgres.NewFullStore(pool)
-	indexer := postgres.NewIndexer(pool)
-	searcher := search.New(dbstore, indexer)
-	return New(dbstore, indexer, searcher)
 }

--- a/central/cve/cluster/datastore/datastore_test_constructors.go
+++ b/central/cve/cluster/datastore/datastore_test_constructors.go
@@ -1,0 +1,17 @@
+package datastore
+
+import (
+	"testing"
+
+	"github.com/jackc/pgx/v4/pgxpool"
+	"github.com/stackrox/rox/central/cve/cluster/datastore/search"
+	"github.com/stackrox/rox/central/cve/cluster/datastore/store/postgres"
+)
+
+// GetTestPostgresDataStore provides a datastore connected to postgres for testing purposes.
+func GetTestPostgresDataStore(_ *testing.T, pool *pgxpool.Pool) (DataStore, error) {
+	dbstore := postgres.NewFullStore(pool)
+	indexer := postgres.NewIndexer(pool)
+	searcher := search.New(dbstore, indexer)
+	return New(dbstore, indexer, searcher)
+}

--- a/central/cve/cluster/datastoretest/datastore_sac_test.go
+++ b/central/cve/cluster/datastoretest/datastore_sac_test.go
@@ -990,7 +990,6 @@ func addDurationToTimestamp(ts *types.Timestamp, duration *types.Duration) *type
 	nanosInSecond := int32(1000 * 1000 * 1000)
 	if nanos >= nanosInSecond {
 		seconds += int64(nanos / nanosInSecond)
-		nanos %= nanosInSecond
 	}
 	return &types.Timestamp{
 		Seconds: seconds,

--- a/central/cve/cluster/datastoretest/datastore_sac_test.go
+++ b/central/cve/cluster/datastoretest/datastore_sac_test.go
@@ -1,0 +1,1160 @@
+package datastoretest
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/gogo/protobuf/types"
+	clusterCVEDataStore "github.com/stackrox/rox/central/cve/cluster/datastore"
+	"github.com/stackrox/rox/central/cve/converter/utils"
+	cveConverterV2 "github.com/stackrox/rox/central/cve/converter/v2"
+	cveDataStore "github.com/stackrox/rox/central/cve/datastore"
+	dackboxTestUtils "github.com/stackrox/rox/central/dackbox/testutils"
+	"github.com/stackrox/rox/central/role/resources"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/env"
+	"github.com/stackrox/rox/pkg/fixtures"
+	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stackrox/rox/pkg/sac/testconsts"
+	"github.com/stackrox/rox/pkg/search"
+	"github.com/stretchr/testify/suite"
+)
+
+const (
+	clusterOS = ""
+
+	waitForIndexing     = true
+	dontWaitForIndexing = false
+)
+
+var (
+	allAccessCtx = sac.WithAllAccess(context.Background())
+)
+
+func TestClusterCVEDatastoreSAC(t *testing.T) {
+	suite.Run(t, new(clusterCVEDatastoreSACSuite))
+}
+
+type clusterCVEDatastoreSACSuite struct {
+	suite.Suite
+
+	pgStore          clusterCVEDataStore.DataStore
+	legacyStore      cveDataStore.DataStore
+	dackboxTestStore dackboxTestUtils.DackboxTestDataStore
+}
+
+func (s *clusterCVEDatastoreSACSuite) SetupSuite() {
+	var err error
+	s.dackboxTestStore, err = dackboxTestUtils.NewDackboxTestDataStore(s.T())
+	s.Require().NoError(err)
+	if env.PostgresDatastoreEnabled.BooleanSetting() {
+		s.pgStore, err = clusterCVEDataStore.GetTestPostgresDataStore(s.T(), s.dackboxTestStore.GetPostgresPool())
+		s.Require().NoError(err)
+	} else {
+		s.legacyStore, err = cveDataStore.GetTestRocksBleveDataStore(
+			s.T(),
+			s.dackboxTestStore.GetRocksEngine(),
+			s.dackboxTestStore.GetBleveIndex(),
+			s.dackboxTestStore.GetDackbox(),
+			s.dackboxTestStore.GetKeyFence(),
+			s.dackboxTestStore.GetIndexQ(),
+		)
+		s.Require().NoError(err)
+	}
+}
+
+func (s *clusterCVEDatastoreSACSuite) TearDownSuite() {
+	s.Require().NoError(s.dackboxTestStore.Cleanup(s.T()))
+}
+
+func (s *clusterCVEDatastoreSACSuite) cleanImageToVulnerabilitiesGraph(waitForIndexing bool) {
+	s.Require().NoError(s.dackboxTestStore.CleanClusterToVulnerabilitiesGraph(waitForIndexing))
+}
+
+func getCveID(vulnerability *storage.EmbeddedVulnerability, os string) string {
+	if env.PostgresDatastoreEnabled.BooleanSetting() {
+		return vulnerability.GetCve()
+	}
+	return utils.EmbeddedCVEToProtoCVE(os, vulnerability).GetId()
+}
+
+type testCase struct {
+	name       string
+	ctx        context.Context
+	visibleCVE map[string]bool
+}
+
+func getClusterCVETestCases(_ *testing.T, validCluster1 string, validCluster2 string, readTest bool) []testCase {
+	return []testCase{
+		{
+			name: "Full read-write access has access to all data",
+			ctx: sac.WithGlobalAccessScopeChecker(
+				context.Background(),
+				sac.AllowFixedScopes(
+					sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+					sac.ResourceScopeKeys(resources.Cluster),
+				),
+			),
+			visibleCVE: map[string]bool{
+				fixtures.GetEmbeddedClusterCVE1234x0001().GetCve(): true,
+				fixtures.GetEmbeddedClusterCVE4567x0002().GetCve(): true,
+				fixtures.GetEmbeddedClusterCVE2345x0003().GetCve(): true,
+			},
+		},
+		{
+			name: "Full read-only access has access to all data",
+			ctx: sac.WithGlobalAccessScopeChecker(
+				context.Background(),
+				sac.AllowFixedScopes(
+					sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
+					sac.ResourceScopeKeys(resources.Cluster),
+				),
+			),
+			visibleCVE: map[string]bool{
+				fixtures.GetEmbeddedClusterCVE1234x0001().GetCve(): readTest,
+				fixtures.GetEmbeddedClusterCVE4567x0002().GetCve(): readTest,
+				fixtures.GetEmbeddedClusterCVE2345x0003().GetCve(): readTest,
+			},
+		},
+		{
+			name: "Full cluster access has access to all data for the cluster",
+			ctx: sac.WithGlobalAccessScopeChecker(
+				context.Background(),
+				sac.AllowFixedScopes(
+					sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+					sac.ResourceScopeKeys(resources.Cluster),
+					sac.ClusterScopeKeys(validCluster1),
+				),
+			),
+			visibleCVE: map[string]bool{
+				fixtures.GetEmbeddedClusterCVE1234x0001().GetCve(): true,
+				fixtures.GetEmbeddedClusterCVE4567x0002().GetCve(): true,
+				fixtures.GetEmbeddedClusterCVE2345x0003().GetCve(): false,
+			},
+		},
+		{
+			name: "Partial cluster access has access to no data",
+			ctx: sac.WithGlobalAccessScopeChecker(
+				context.Background(),
+				sac.AllowFixedScopes(
+					sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+					sac.ResourceScopeKeys(resources.Cluster),
+					sac.ClusterScopeKeys(validCluster1),
+					sac.NamespaceScopeKeys(testconsts.NamespaceA),
+				),
+			),
+			visibleCVE: map[string]bool{
+				fixtures.GetEmbeddedClusterCVE1234x0001().GetCve(): false,
+				fixtures.GetEmbeddedClusterCVE4567x0002().GetCve(): false,
+				fixtures.GetEmbeddedClusterCVE2345x0003().GetCve(): false,
+			},
+		},
+		{
+			name: "Full access to other cluster has access to all data for that cluster",
+			ctx: sac.WithGlobalAccessScopeChecker(
+				context.Background(),
+				sac.AllowFixedScopes(
+					sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+					sac.ResourceScopeKeys(resources.Cluster),
+					sac.ClusterScopeKeys(validCluster2),
+				),
+			),
+			visibleCVE: map[string]bool{
+				fixtures.GetEmbeddedClusterCVE1234x0001().GetCve(): false,
+				fixtures.GetEmbeddedClusterCVE4567x0002().GetCve(): true,
+				fixtures.GetEmbeddedClusterCVE2345x0003().GetCve(): true,
+			},
+		},
+		{
+			name: "Partial access to other cluster has access to no data",
+			ctx: sac.WithGlobalAccessScopeChecker(
+				context.Background(),
+				sac.AllowFixedScopes(
+					sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+					sac.ResourceScopeKeys(resources.Cluster),
+					sac.ClusterScopeKeys(validCluster2),
+					sac.NamespaceScopeKeys(testconsts.NamespaceB),
+				),
+			),
+			visibleCVE: map[string]bool{
+				fixtures.GetEmbeddedClusterCVE1234x0001().GetCve(): false,
+				fixtures.GetEmbeddedClusterCVE4567x0002().GetCve(): false,
+				fixtures.GetEmbeddedClusterCVE2345x0003().GetCve(): false,
+			},
+		},
+		{
+			name: "Full access to wrong cluster has access to no data",
+			ctx: sac.WithGlobalAccessScopeChecker(
+				context.Background(),
+				sac.AllowFixedScopes(
+					sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+					sac.ResourceScopeKeys(resources.Cluster),
+					sac.ClusterScopeKeys(testconsts.WrongCluster),
+				),
+			),
+			visibleCVE: map[string]bool{
+				fixtures.GetEmbeddedClusterCVE1234x0001().GetCve(): false,
+				fixtures.GetEmbeddedClusterCVE4567x0002().GetCve(): false,
+				fixtures.GetEmbeddedClusterCVE2345x0003().GetCve(): false,
+			},
+		},
+	}
+}
+
+func getClusterCVEUpsertTestCases(_ *testing.T, validCluster1 string, validCluster2 string) []testCase {
+	return []testCase{
+		{
+			name: "Full read-write access has access to all data",
+			ctx: sac.WithGlobalAccessScopeChecker(
+				context.Background(),
+				sac.AllowFixedScopes(
+					sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+					sac.ResourceScopeKeys(resources.Cluster),
+				),
+			),
+			visibleCVE: map[string]bool{
+				fixtures.GetEmbeddedClusterCVE1234x0001().GetCve(): true,
+				fixtures.GetEmbeddedClusterCVE4567x0002().GetCve(): true,
+				fixtures.GetEmbeddedClusterCVE2345x0003().GetCve(): true,
+			},
+		},
+		{
+			name: "Full read-only access cannot modify any data",
+			ctx: sac.WithGlobalAccessScopeChecker(
+				context.Background(),
+				sac.AllowFixedScopes(
+					sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
+					sac.ResourceScopeKeys(resources.Cluster),
+				),
+			),
+			visibleCVE: map[string]bool{
+				fixtures.GetEmbeddedClusterCVE1234x0001().GetCve(): false,
+				fixtures.GetEmbeddedClusterCVE4567x0002().GetCve(): false,
+				fixtures.GetEmbeddedClusterCVE2345x0003().GetCve(): false,
+			},
+		},
+		{
+			name: "Full cluster access access cannot modify any data",
+			ctx: sac.WithGlobalAccessScopeChecker(
+				context.Background(),
+				sac.AllowFixedScopes(
+					sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+					sac.ResourceScopeKeys(resources.Cluster),
+					sac.ClusterScopeKeys(validCluster1),
+				),
+			),
+			visibleCVE: map[string]bool{
+				fixtures.GetEmbeddedClusterCVE1234x0001().GetCve(): false,
+				fixtures.GetEmbeddedClusterCVE4567x0002().GetCve(): false,
+				fixtures.GetEmbeddedClusterCVE2345x0003().GetCve(): false,
+			},
+		},
+		{
+			name: "Partial cluster access cannot modify any data",
+			ctx: sac.WithGlobalAccessScopeChecker(
+				context.Background(),
+				sac.AllowFixedScopes(
+					sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+					sac.ResourceScopeKeys(resources.Cluster),
+					sac.ClusterScopeKeys(validCluster1),
+					sac.NamespaceScopeKeys(testconsts.NamespaceA),
+				),
+			),
+			visibleCVE: map[string]bool{
+				fixtures.GetEmbeddedClusterCVE1234x0001().GetCve(): false,
+				fixtures.GetEmbeddedClusterCVE4567x0002().GetCve(): false,
+				fixtures.GetEmbeddedClusterCVE2345x0003().GetCve(): false,
+			},
+		},
+		{
+			name: "Full access to other cluster cannot modify any data",
+			ctx: sac.WithGlobalAccessScopeChecker(
+				context.Background(),
+				sac.AllowFixedScopes(
+					sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+					sac.ResourceScopeKeys(resources.Cluster),
+					sac.ClusterScopeKeys(validCluster2),
+				),
+			),
+			visibleCVE: map[string]bool{
+				fixtures.GetEmbeddedClusterCVE1234x0001().GetCve(): false,
+				fixtures.GetEmbeddedClusterCVE4567x0002().GetCve(): false,
+				fixtures.GetEmbeddedClusterCVE2345x0003().GetCve(): false,
+			},
+		},
+		{
+			name: "Partial access to other cluster cannot modify any data",
+			ctx: sac.WithGlobalAccessScopeChecker(
+				context.Background(),
+				sac.AllowFixedScopes(
+					sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+					sac.ResourceScopeKeys(resources.Cluster),
+					sac.ClusterScopeKeys(validCluster2),
+					sac.NamespaceScopeKeys(testconsts.NamespaceB),
+				),
+			),
+			visibleCVE: map[string]bool{
+				fixtures.GetEmbeddedClusterCVE1234x0001().GetCve(): false,
+				fixtures.GetEmbeddedClusterCVE4567x0002().GetCve(): false,
+				fixtures.GetEmbeddedClusterCVE2345x0003().GetCve(): false,
+			},
+		},
+		{
+			name: "Full access to wrong cluster cannot modify any data",
+			ctx: sac.WithGlobalAccessScopeChecker(
+				context.Background(),
+				sac.AllowFixedScopes(
+					sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+					sac.ResourceScopeKeys(resources.Cluster),
+					sac.ClusterScopeKeys(testconsts.WrongCluster),
+				),
+			),
+			visibleCVE: map[string]bool{
+				fixtures.GetEmbeddedClusterCVE1234x0001().GetCve(): false,
+				fixtures.GetEmbeddedClusterCVE4567x0002().GetCve(): false,
+				fixtures.GetEmbeddedClusterCVE2345x0003().GetCve(): false,
+			},
+		},
+	}
+}
+
+func getClusterCVESuppressUnsuppressTestCases(_ *testing.T, validCluster1 string, validCluster2 string) []testCase {
+	return []testCase{
+		{
+			name: "Full read-write access has suppress/unsuppress access to all data",
+			ctx: sac.WithGlobalAccessScopeChecker(
+				context.Background(),
+				sac.AllowFixedScopes(
+					sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+					sac.ResourceScopeKeys(resources.Cluster, resources.VulnerabilityManagementRequests, resources.VulnerabilityManagementApprovals),
+				),
+			),
+			visibleCVE: map[string]bool{
+				fixtures.GetEmbeddedClusterCVE1234x0001().GetCve(): true,
+				fixtures.GetEmbeddedClusterCVE4567x0002().GetCve(): true,
+				fixtures.GetEmbeddedClusterCVE2345x0003().GetCve(): true,
+			},
+		},
+		{
+			name: "Full read-only access cannot suppress or unsuppress any data",
+			ctx: sac.WithGlobalAccessScopeChecker(
+				context.Background(),
+				sac.AllowFixedScopes(
+					sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
+					sac.ResourceScopeKeys(resources.Cluster, resources.VulnerabilityManagementRequests, resources.VulnerabilityManagementApprovals),
+				),
+			),
+			visibleCVE: map[string]bool{
+				fixtures.GetEmbeddedClusterCVE1234x0001().GetCve(): false,
+				fixtures.GetEmbeddedClusterCVE4567x0002().GetCve(): false,
+				fixtures.GetEmbeddedClusterCVE2345x0003().GetCve(): false,
+			},
+		},
+		{
+			name: "Full cluster access cannot suppress or unsuppress any data",
+			ctx: sac.WithGlobalAccessScopeChecker(
+				context.Background(),
+				sac.AllowFixedScopes(
+					sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+					sac.ResourceScopeKeys(resources.Cluster, resources.VulnerabilityManagementRequests, resources.VulnerabilityManagementApprovals),
+					sac.ClusterScopeKeys(validCluster1),
+				),
+			),
+			visibleCVE: map[string]bool{
+				fixtures.GetEmbeddedClusterCVE1234x0001().GetCve(): false,
+				fixtures.GetEmbeddedClusterCVE4567x0002().GetCve(): false,
+				fixtures.GetEmbeddedClusterCVE2345x0003().GetCve(): false,
+			},
+		},
+		{
+			name: "Partial cluster access cannot suppress or unsuppress any data",
+			ctx: sac.WithGlobalAccessScopeChecker(
+				context.Background(),
+				sac.AllowFixedScopes(
+					sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+					sac.ResourceScopeKeys(resources.Cluster, resources.VulnerabilityManagementRequests, resources.VulnerabilityManagementApprovals),
+					sac.ClusterScopeKeys(validCluster1),
+					sac.NamespaceScopeKeys(testconsts.NamespaceA),
+				),
+			),
+			visibleCVE: map[string]bool{
+				fixtures.GetEmbeddedClusterCVE1234x0001().GetCve(): false,
+				fixtures.GetEmbeddedClusterCVE4567x0002().GetCve(): false,
+				fixtures.GetEmbeddedClusterCVE2345x0003().GetCve(): false,
+			},
+		},
+		{
+			name: "Full access to other cluster cannot suppress or unsuppress any data",
+			ctx: sac.WithGlobalAccessScopeChecker(
+				context.Background(),
+				sac.AllowFixedScopes(
+					sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+					sac.ResourceScopeKeys(resources.Cluster, resources.VulnerabilityManagementRequests, resources.VulnerabilityManagementApprovals),
+					sac.ClusterScopeKeys(validCluster2),
+				),
+			),
+			visibleCVE: map[string]bool{
+				fixtures.GetEmbeddedClusterCVE1234x0001().GetCve(): false,
+				fixtures.GetEmbeddedClusterCVE4567x0002().GetCve(): false,
+				fixtures.GetEmbeddedClusterCVE2345x0003().GetCve(): false,
+			},
+		},
+		{
+			name: "Partial access to other cluster cannot suppress or unsuppress any data",
+			ctx: sac.WithGlobalAccessScopeChecker(
+				context.Background(),
+				sac.AllowFixedScopes(
+					sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+					sac.ResourceScopeKeys(resources.Cluster, resources.VulnerabilityManagementRequests, resources.VulnerabilityManagementApprovals),
+					sac.ClusterScopeKeys(validCluster2),
+					sac.NamespaceScopeKeys(testconsts.NamespaceB),
+				),
+			),
+			visibleCVE: map[string]bool{
+				fixtures.GetEmbeddedClusterCVE1234x0001().GetCve(): false,
+				fixtures.GetEmbeddedClusterCVE4567x0002().GetCve(): false,
+				fixtures.GetEmbeddedClusterCVE2345x0003().GetCve(): false,
+			},
+		},
+		{
+			name: "Full access to wrong cluster cannot suppress or unsuppress any data",
+			ctx: sac.WithGlobalAccessScopeChecker(
+				context.Background(),
+				sac.AllowFixedScopes(
+					sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+					sac.ResourceScopeKeys(resources.Cluster, resources.VulnerabilityManagementRequests, resources.VulnerabilityManagementApprovals),
+					sac.ClusterScopeKeys(testconsts.WrongCluster),
+				),
+			),
+			visibleCVE: map[string]bool{
+				fixtures.GetEmbeddedClusterCVE1234x0001().GetCve(): false,
+				fixtures.GetEmbeddedClusterCVE4567x0002().GetCve(): false,
+				fixtures.GetEmbeddedClusterCVE2345x0003().GetCve(): false,
+			},
+		},
+	}
+}
+
+func embeddedVulnerabilityToClusterCVE(from *storage.EmbeddedVulnerability) *storage.ClusterCVE {
+	ret := &storage.ClusterCVE{
+		Id: from.GetCve(),
+		CveBaseInfo: &storage.CVEInfo{
+			Cve:          from.GetCve(),
+			Summary:      from.GetSummary(),
+			Link:         from.GetLink(),
+			PublishedOn:  from.GetPublishedOn(),
+			CreatedAt:    from.GetFirstSystemOccurrence(),
+			LastModified: from.GetLastModified(),
+			CvssV2:       from.GetCvssV2(),
+			CvssV3:       from.GetCvssV3(),
+		},
+		Cvss:         from.GetCvss(),
+		Severity:     from.GetSeverity(),
+		Snoozed:      from.GetSuppressed(),
+		SnoozeStart:  from.GetSuppressActivation(),
+		SnoozeExpiry: from.GetSuppressExpiry(),
+	}
+	if ret.GetCveBaseInfo().GetCvssV3() != nil {
+		ret.CveBaseInfo.ScoreVersion = storage.CVEInfo_V3
+		ret.ImpactScore = from.GetCvssV3().GetImpactScore()
+	} else if ret.GetCveBaseInfo().GetCvssV2() != nil {
+		ret.CveBaseInfo.ScoreVersion = storage.CVEInfo_V2
+		ret.ImpactScore = from.GetCvssV2().GetImpactScore()
+	}
+	return ret
+}
+
+func (s *clusterCVEDatastoreSACSuite) checkCVEStored(targetCVE string,
+	cve *storage.EmbeddedVulnerability,
+	shouldBeStored bool) {
+	if env.PostgresDatastoreEnabled.BooleanSetting() {
+		obj, found, err := s.pgStore.Get(allAccessCtx, targetCVE)
+		s.NoError(err)
+		if shouldBeStored {
+			s.True(found)
+			s.NotNil(obj)
+			s.Equal(cve.GetCvss(), obj.GetCvss())
+			s.Equal(cve.GetCvssV3().GetVector(), obj.GetCveBaseInfo().GetCvssV3().GetVector())
+		} else {
+			s.False(found)
+			s.Nil(obj)
+		}
+	} else {
+		obj, found, err := s.legacyStore.Get(allAccessCtx, targetCVE)
+		s.NoError(err)
+		if shouldBeStored {
+			s.True(found)
+			s.NotNil(obj)
+			s.Equal(cve.GetCvss(), obj.GetCvss())
+			s.Equal(cve.GetCvssV3().GetVector(), obj.GetCvssV3().GetVector())
+		} else {
+			s.False(found)
+			s.Nil(obj)
+		}
+	}
+}
+
+func (s *clusterCVEDatastoreSACSuite) TestUpsertClusterCVEData() {
+	if !env.PostgresDatastoreEnabled.BooleanSetting() {
+		s.T().Skip("CVE Cluster datastore Upsert is postgres-only")
+	}
+	err := s.dackboxTestStore.PushClusterToVulnerabilitiesGraph(dontWaitForIndexing)
+	defer s.cleanImageToVulnerabilitiesGraph(dontWaitForIndexing)
+	s.Require().NoError(err)
+	validClusters := s.dackboxTestStore.GetStoredClusterIDs()
+	s.Require().True(len(validClusters) >= 2)
+
+	testCases := getClusterCVEUpsertTestCases(s.T(), validClusters[0], validClusters[1])
+	embeddedClusterCVE1 := fixtures.GetEmbeddedClusterCVE1234x0001()
+	cve1FixVersion := embeddedClusterCVE1.GetFixedBy()
+	embeddedClusterCVE2 := fixtures.GetEmbeddedClusterCVE4567x0002()
+	cve2FixVersion := embeddedClusterCVE2.GetFixedBy()
+	embeddedClusterCVE3 := fixtures.GetEmbeddedClusterCVE2345x0003()
+	cve3FixVersion := embeddedClusterCVE3.GetFixedBy()
+	cve1ID := getCveID(embeddedClusterCVE1, clusterOS)
+	cve2ID := getCveID(embeddedClusterCVE2, clusterOS)
+	cve3ID := getCveID(embeddedClusterCVE3, clusterOS)
+	dummyCluster1 := &storage.Cluster{Id: validClusters[0]}
+	dummyCluster2 := &storage.Cluster{Id: validClusters[1]}
+	cluster1Only := []*storage.Cluster{dummyCluster1}
+	cluster2Only := []*storage.Cluster{dummyCluster2}
+	clusterCVE1 := embeddedVulnerabilityToClusterCVE(embeddedClusterCVE1)
+	clusterCVE2 := embeddedVulnerabilityToClusterCVE(embeddedClusterCVE2)
+	clusterCVE3 := embeddedVulnerabilityToClusterCVE(embeddedClusterCVE3)
+	clusterCVEParts1x1 := cveConverterV2.NewClusterCVEParts(clusterCVE1, cluster1Only, cve1FixVersion)
+	clusterCVEParts1x2 := cveConverterV2.NewClusterCVEParts(clusterCVE2, cluster1Only, cve2FixVersion)
+	clusterCVEParts2x2 := cveConverterV2.NewClusterCVEParts(clusterCVE2, cluster2Only, cve2FixVersion)
+	clusterCVEParts2x3 := cveConverterV2.NewClusterCVEParts(clusterCVE3, cluster2Only, cve3FixVersion)
+
+	s.Require().NoError(s.pgStore.DeleteClusterCVEsInternal(allAccessCtx, validClusters[0]))
+	s.Require().NoError(s.pgStore.DeleteClusterCVEsInternal(allAccessCtx, validClusters[1]))
+	for _, c := range testCases {
+		s.Run(c.name, func() {
+			ctx := c.ctx
+			s.checkCVEStored(cve1ID, embeddedClusterCVE1, false)
+			err = s.pgStore.UpsertClusterCVEsInternal(ctx, storage.CVE_OPENSHIFT_CVE, clusterCVEParts1x1)
+			if c.visibleCVE[cve1ID] {
+				s.NoError(err)
+				s.checkCVEStored(cve1ID, embeddedClusterCVE1, true)
+			} else {
+				s.ErrorIs(err, sac.ErrResourceAccessDenied)
+			}
+			s.checkCVEStored(cve2ID, embeddedClusterCVE2, false)
+			err = s.pgStore.UpsertClusterCVEsInternal(ctx, storage.CVE_OPENSHIFT_CVE, clusterCVEParts1x2)
+			if c.visibleCVE[cve2ID] {
+				s.NoError(err)
+				s.checkCVEStored(cve2ID, embeddedClusterCVE2, true)
+			} else {
+				s.ErrorIs(err, sac.ErrResourceAccessDenied)
+			}
+			err = s.pgStore.UpsertClusterCVEsInternal(ctx, storage.CVE_K8S_CVE, clusterCVEParts2x2)
+			if c.visibleCVE[cve2ID] {
+				s.NoError(err)
+			} else {
+				s.ErrorIs(err, sac.ErrResourceAccessDenied)
+			}
+			s.checkCVEStored(cve3ID, embeddedClusterCVE3, false)
+			err = s.pgStore.UpsertClusterCVEsInternal(ctx, storage.CVE_K8S_CVE, clusterCVEParts2x3)
+			if c.visibleCVE[cve3ID] {
+				s.NoError(err)
+				s.checkCVEStored(cve3ID, embeddedClusterCVE3, true)
+			} else {
+				s.ErrorIs(err, sac.ErrResourceAccessDenied)
+			}
+			s.NoError(s.pgStore.DeleteClusterCVEsInternal(allAccessCtx, validClusters[0]))
+			s.NoError(s.pgStore.DeleteClusterCVEsInternal(allAccessCtx, validClusters[1]))
+		})
+	}
+}
+
+func (s *clusterCVEDatastoreSACSuite) TestDeleteClusterCVEData() {
+	if !env.PostgresDatastoreEnabled.BooleanSetting() {
+		s.T().Skip("CVE Cluster datastore Delete is postgres-only")
+	}
+	err := s.dackboxTestStore.PushClusterToVulnerabilitiesGraph(dontWaitForIndexing)
+	defer s.cleanImageToVulnerabilitiesGraph(dontWaitForIndexing)
+	s.Require().NoError(err)
+	validClusters := s.dackboxTestStore.GetStoredClusterIDs()
+	s.Require().True(len(validClusters) >= 2)
+
+	testCases := getClusterCVETestCases(s.T(), validClusters[0], validClusters[1], false)
+
+	// Prepare data for re-injection
+	embeddedClusterCVE1 := fixtures.GetEmbeddedClusterCVE1234x0001()
+	cve1FixVersion := embeddedClusterCVE1.GetFixedBy()
+	embeddedClusterCVE2 := fixtures.GetEmbeddedClusterCVE4567x0002()
+	cve2FixVersion := embeddedClusterCVE2.GetFixedBy()
+	embeddedClusterCVE3 := fixtures.GetEmbeddedClusterCVE2345x0003()
+	cve3FixVersion := embeddedClusterCVE3.GetFixedBy()
+	cve1ID := getCveID(embeddedClusterCVE1, clusterOS)
+	cve2ID := getCveID(embeddedClusterCVE2, clusterOS)
+	cve3ID := getCveID(embeddedClusterCVE3, clusterOS)
+	dummyCluster1 := &storage.Cluster{Id: validClusters[0]}
+	dummyCluster2 := &storage.Cluster{Id: validClusters[1]}
+	cluster1Only := []*storage.Cluster{dummyCluster1}
+	cluster2Only := []*storage.Cluster{dummyCluster2}
+	clusterCVE1 := embeddedVulnerabilityToClusterCVE(embeddedClusterCVE1)
+	clusterCVE2 := embeddedVulnerabilityToClusterCVE(embeddedClusterCVE2)
+	clusterCVE3 := embeddedVulnerabilityToClusterCVE(embeddedClusterCVE3)
+	clusterCVEParts1x1 := cveConverterV2.NewClusterCVEParts(clusterCVE1, cluster1Only, cve1FixVersion)
+	clusterCVEParts1x2 := cveConverterV2.NewClusterCVEParts(clusterCVE2, cluster1Only, cve2FixVersion)
+	clusterCVEParts2x2 := cveConverterV2.NewClusterCVEParts(clusterCVE2, cluster2Only, cve2FixVersion)
+	clusterCVEParts2x3 := cveConverterV2.NewClusterCVEParts(clusterCVE3, cluster2Only, cve3FixVersion)
+
+	s.Require().NoError(s.pgStore.DeleteClusterCVEsInternal(allAccessCtx, validClusters[0]))
+	s.Require().NoError(s.pgStore.DeleteClusterCVEsInternal(allAccessCtx, validClusters[1]))
+	for _, c := range testCases {
+		s.Run(c.name, func() {
+			err = s.pgStore.UpsertClusterCVEsInternal(allAccessCtx, storage.CVE_OPENSHIFT_CVE, clusterCVEParts1x1)
+			s.Require().NoError(err)
+			err = s.pgStore.UpsertClusterCVEsInternal(allAccessCtx, storage.CVE_OPENSHIFT_CVE, clusterCVEParts1x2)
+			s.Require().NoError(err)
+			err = s.pgStore.UpsertClusterCVEsInternal(allAccessCtx, storage.CVE_K8S_CVE, clusterCVEParts2x2)
+			s.Require().NoError(err)
+			err = s.pgStore.UpsertClusterCVEsInternal(allAccessCtx, storage.CVE_K8S_CVE, clusterCVEParts2x3)
+			s.Require().NoError(err)
+			s.checkCVEStored(cve1ID, embeddedClusterCVE1, true)
+			s.checkCVEStored(cve2ID, embeddedClusterCVE2, true)
+			s.checkCVEStored(cve3ID, embeddedClusterCVE3, true)
+			err = s.pgStore.DeleteClusterCVEsInternal(c.ctx, validClusters[0])
+			if c.visibleCVE[cve1ID] {
+				s.NoError(err)
+				s.checkCVEStored(cve1ID, embeddedClusterCVE1, false)
+			} else {
+				s.ErrorIs(err, sac.ErrResourceAccessDenied)
+			}
+			err = s.pgStore.DeleteClusterCVEsInternal(c.ctx, validClusters[1])
+			if c.visibleCVE[cve3ID] {
+				s.NoError(err)
+				s.checkCVEStored(cve3ID, embeddedClusterCVE3, false)
+			} else {
+				s.ErrorIs(err, sac.ErrResourceAccessDenied)
+			}
+			if c.visibleCVE[cve1ID] && c.visibleCVE[cve3ID] {
+				s.checkCVEStored(cve2ID, embeddedClusterCVE2, false)
+			}
+			s.Require().NoError(s.pgStore.DeleteClusterCVEsInternal(allAccessCtx, validClusters[0]))
+			s.Require().NoError(s.pgStore.DeleteClusterCVEsInternal(allAccessCtx, validClusters[1]))
+		})
+	}
+}
+
+func (s *clusterCVEDatastoreSACSuite) runTestExistCVE(targetCVE string) {
+	err := s.dackboxTestStore.PushClusterToVulnerabilitiesGraph(dontWaitForIndexing)
+	defer s.cleanImageToVulnerabilitiesGraph(dontWaitForIndexing)
+	s.Require().NoError(err)
+	validClusters := s.dackboxTestStore.GetStoredClusterIDs()
+	s.Require().True(len(validClusters) >= 2)
+
+	for _, c := range getClusterCVETestCases(s.T(), validClusters[0], validClusters[1], true) {
+		s.Run(c.name, func() {
+			ctx := c.ctx
+			var exists bool
+			if env.PostgresDatastoreEnabled.BooleanSetting() {
+				exists, err = s.pgStore.Exists(ctx, targetCVE)
+			} else {
+				exists, err = s.legacyStore.Exists(ctx, targetCVE)
+			}
+			s.NoError(err)
+			s.Equal(c.visibleCVE[targetCVE], exists)
+		})
+	}
+}
+
+func (s *clusterCVEDatastoreSACSuite) TestExistsSingleCVE() {
+	targetCVE := getCveID(fixtures.GetEmbeddedClusterCVE1234x0001(), clusterOS)
+	s.runTestExistCVE(targetCVE)
+}
+
+func (s *clusterCVEDatastoreSACSuite) TestExistsSharedCVE() {
+	targetCVE := getCveID(fixtures.GetEmbeddedClusterCVE4567x0002(), clusterOS)
+	s.runTestExistCVE(targetCVE)
+}
+
+func (s *clusterCVEDatastoreSACSuite) runTestGetCVE(targetCVE string, cveObj *storage.EmbeddedVulnerability) {
+	err := s.dackboxTestStore.PushClusterToVulnerabilitiesGraph(dontWaitForIndexing)
+	defer s.cleanImageToVulnerabilitiesGraph(dontWaitForIndexing)
+	s.Require().NoError(err)
+	validClusters := s.dackboxTestStore.GetStoredClusterIDs()
+	s.Require().True(len(validClusters) >= 2)
+
+	for _, c := range getClusterCVETestCases(s.T(), validClusters[0], validClusters[1], true) {
+		s.Run(c.name, func() {
+			ctx := c.ctx
+			var exists bool
+			var v3AttackVector string
+			var cvss float32
+			if env.PostgresDatastoreEnabled.BooleanSetting() {
+				var obj *storage.ClusterCVE
+				obj, exists, err = s.pgStore.Get(ctx, targetCVE)
+				if c.visibleCVE[targetCVE] {
+					s.NotNil(obj)
+				} else {
+					s.Nil(obj)
+				}
+				if exists {
+					v3AttackVector = obj.GetCveBaseInfo().GetCvssV3().GetVector()
+					cvss = obj.GetCvss()
+				}
+			} else {
+				var obj *storage.CVE
+				obj, exists, err = s.legacyStore.Get(ctx, targetCVE)
+				if c.visibleCVE[targetCVE] {
+					s.NotNil(obj)
+				} else {
+					s.Nil(obj)
+				}
+				if exists {
+					v3AttackVector = obj.GetCvssV3().GetVector()
+					cvss = obj.GetCvss()
+				}
+			}
+			if c.visibleCVE[targetCVE] {
+				s.Equal(cveObj.GetCvss(), cvss)
+				s.Equal(cveObj.GetCvssV3().GetVector(), v3AttackVector)
+				s.True(exists)
+			} else {
+				s.False(exists)
+			}
+			s.NoError(err)
+			s.Equal(c.visibleCVE[targetCVE], exists)
+		})
+	}
+}
+
+func (s *clusterCVEDatastoreSACSuite) TestGetSingleCVE() {
+	targetCVE := getCveID(fixtures.GetEmbeddedClusterCVE1234x0001(), clusterOS)
+	cveObj := fixtures.GetEmbeddedClusterCVE1234x0001()
+	s.runTestGetCVE(targetCVE, cveObj)
+}
+
+func (s *clusterCVEDatastoreSACSuite) TestGetSharedCVE() {
+	targetCVE := getCveID(fixtures.GetEmbeddedClusterCVE4567x0002(), clusterOS)
+	cveObj := fixtures.GetEmbeddedClusterCVE4567x0002()
+	s.runTestGetCVE(targetCVE, cveObj)
+}
+
+func (s *clusterCVEDatastoreSACSuite) TestGetBatch() {
+	err := s.dackboxTestStore.PushClusterToVulnerabilitiesGraph(dontWaitForIndexing)
+	defer s.cleanImageToVulnerabilitiesGraph(dontWaitForIndexing)
+	s.Require().NoError(err)
+	validClusters := s.dackboxTestStore.GetStoredClusterIDs()
+	s.Require().True(len(validClusters) >= 2)
+
+	targetCVE1 := getCveID(fixtures.GetEmbeddedClusterCVE1234x0001(), clusterOS)
+	targetCVE2 := getCveID(fixtures.GetEmbeddedClusterCVE4567x0002(), clusterOS)
+	targetCVE3 := getCveID(fixtures.GetEmbeddedClusterCVE2345x0003(), clusterOS)
+	cve1 := fixtures.GetEmbeddedClusterCVE1234x0001()
+	cve2 := fixtures.GetEmbeddedClusterCVE4567x0002()
+	cve3 := fixtures.GetEmbeddedClusterCVE2345x0003()
+
+	targetCVEs := []string{targetCVE1, targetCVE2, targetCVE3}
+
+	testCases := getClusterCVETestCases(s.T(), validClusters[0], validClusters[1], true)
+	for _, c := range testCases {
+		s.Run(c.name, func() {
+			ctx := c.ctx
+			vectorsPerCVE := make(map[string]string, 0)
+			cvssPerCVE := make(map[string]float32, 0)
+			visibleCVEs := 0
+			for _, visible := range c.visibleCVE {
+				if visible {
+					visibleCVEs++
+				}
+			}
+			if env.PostgresDatastoreEnabled.BooleanSetting() {
+				results, err := s.pgStore.GetBatch(ctx, targetCVEs)
+				s.NoError(err)
+				s.Equal(visibleCVEs, len(results))
+				for _, cve := range results {
+					cveName := cve.GetCveBaseInfo().GetCve()
+					cvss := cve.GetCvss()
+					v3AttackVector := cve.GetCveBaseInfo().GetCvssV3().GetVector()
+					vectorsPerCVE[cveName] = v3AttackVector
+					cvssPerCVE[cveName] = cvss
+				}
+			} else {
+				results, err := s.legacyStore.GetBatch(ctx, targetCVEs)
+				s.NoError(err)
+				s.Equal(visibleCVEs, len(results))
+				for _, cve := range results {
+					cveName := cve.GetId()
+					cvss := cve.GetCvss()
+					v3AttackVector := cve.GetCvssV3().GetVector()
+					vectorsPerCVE[cveName] = v3AttackVector
+					cvssPerCVE[cveName] = cvss
+				}
+			}
+			if c.visibleCVE[targetCVE1] {
+				s.Equal(cve1.GetCvssV3().GetVector(), vectorsPerCVE[targetCVE1])
+				s.Equal(cve1.GetCvss(), cvssPerCVE[targetCVE1])
+			}
+			if c.visibleCVE[targetCVE2] {
+				s.Equal(cve2.GetCvssV3().GetVector(), vectorsPerCVE[targetCVE2])
+				s.Equal(cve2.GetCvss(), cvssPerCVE[targetCVE2])
+			}
+			if c.visibleCVE[targetCVE3] {
+				s.Equal(cve3.GetCvssV3().GetVector(), vectorsPerCVE[targetCVE3])
+				s.Equal(cve3.GetCvss(), cvssPerCVE[targetCVE3])
+			}
+		})
+	}
+}
+
+func (s *clusterCVEDatastoreSACSuite) TestCount() {
+	err := s.dackboxTestStore.PushClusterToVulnerabilitiesGraph(waitForIndexing)
+	defer s.cleanImageToVulnerabilitiesGraph(waitForIndexing)
+	s.Require().NoError(err)
+	validClusters := s.dackboxTestStore.GetStoredClusterIDs()
+	s.Require().True(len(validClusters) >= 2)
+
+	testCases := getClusterCVETestCases(s.T(), validClusters[0], validClusters[1], true)
+	for _, c := range testCases {
+		s.Run(c.name, func() {
+			ctx := c.ctx
+			visibleCVEs := 0
+			for _, visible := range c.visibleCVE {
+				if visible {
+					visibleCVEs++
+				}
+			}
+			if env.PostgresDatastoreEnabled.BooleanSetting() {
+				count, err := s.pgStore.Count(ctx, search.EmptyQuery())
+				s.NoError(err)
+				s.Equal(visibleCVEs, count)
+			} else {
+				count, err := s.legacyStore.Count(ctx, search.EmptyQuery())
+				s.NoError(err)
+				s.Equal(visibleCVEs, count)
+			}
+		})
+	}
+}
+
+func (s *clusterCVEDatastoreSACSuite) TestSearch() {
+	err := s.dackboxTestStore.PushClusterToVulnerabilitiesGraph(waitForIndexing)
+	defer s.cleanImageToVulnerabilitiesGraph(waitForIndexing)
+	s.Require().NoError(err)
+	validClusters := s.dackboxTestStore.GetStoredClusterIDs()
+	s.Require().True(len(validClusters) >= 2)
+
+	testCases := getClusterCVETestCases(s.T(), validClusters[0], validClusters[1], true)
+	for _, c := range testCases {
+		s.Run(c.name, func() {
+			ctx := c.ctx
+			visibleCVEs := 0
+			for _, visible := range c.visibleCVE {
+				if visible {
+					visibleCVEs++
+				}
+			}
+			foundIDs := make([]string, 0, 3)
+			if env.PostgresDatastoreEnabled.BooleanSetting() {
+				results, err := s.pgStore.Search(ctx, search.EmptyQuery())
+				s.NoError(err)
+				s.Equal(visibleCVEs, len(results))
+				for _, r := range results {
+					foundIDs = append(foundIDs, r.ID)
+				}
+			} else {
+				results, err := s.legacyStore.Search(ctx, search.EmptyQuery())
+				s.NoError(err)
+				s.Equal(visibleCVEs, len(results))
+				for _, r := range results {
+					foundIDs = append(foundIDs, r.ID)
+				}
+			}
+			for _, identifier := range foundIDs {
+				s.True(c.visibleCVE[identifier])
+			}
+		})
+	}
+
+}
+
+func (s *clusterCVEDatastoreSACSuite) TestSearchClusterCVEs() {
+	err := s.dackboxTestStore.PushClusterToVulnerabilitiesGraph(waitForIndexing)
+	defer s.cleanImageToVulnerabilitiesGraph(waitForIndexing)
+	s.Require().NoError(err)
+	validClusters := s.dackboxTestStore.GetStoredClusterIDs()
+	s.Require().True(len(validClusters) >= 2)
+
+	testCases := getClusterCVETestCases(s.T(), validClusters[0], validClusters[1], true)
+	for _, c := range testCases {
+		s.Run(c.name, func() {
+			ctx := c.ctx
+			visibleCVEs := 0
+			for _, visible := range c.visibleCVE {
+				if visible {
+					visibleCVEs++
+				}
+			}
+			foundIDs := make([]string, 0, 3)
+			if env.PostgresDatastoreEnabled.BooleanSetting() {
+				results, err := s.pgStore.SearchClusterCVEs(ctx, search.EmptyQuery())
+				s.NoError(err)
+				s.Equal(visibleCVEs, len(results))
+				for _, r := range results {
+					foundIDs = append(foundIDs, r.GetId())
+				}
+			} else {
+				results, err := s.legacyStore.SearchCVEs(ctx, search.EmptyQuery())
+				s.NoError(err)
+				s.Equal(visibleCVEs, len(results))
+				for _, r := range results {
+					foundIDs = append(foundIDs, r.GetId())
+				}
+			}
+			for _, identifier := range foundIDs {
+				s.True(c.visibleCVE[identifier])
+			}
+		})
+	}
+}
+
+func (s *clusterCVEDatastoreSACSuite) TestSearchRawClusterCVEs() {
+	err := s.dackboxTestStore.PushClusterToVulnerabilitiesGraph(waitForIndexing)
+	defer s.cleanImageToVulnerabilitiesGraph(waitForIndexing)
+	s.Require().NoError(err)
+	validClusters := s.dackboxTestStore.GetStoredClusterIDs()
+	s.Require().True(len(validClusters) >= 2)
+
+	targetCVE1 := getCveID(fixtures.GetEmbeddedClusterCVE1234x0001(), clusterOS)
+	targetCVE2 := getCveID(fixtures.GetEmbeddedClusterCVE4567x0002(), clusterOS)
+	targetCVE3 := getCveID(fixtures.GetEmbeddedClusterCVE2345x0003(), clusterOS)
+	cve1 := fixtures.GetEmbeddedClusterCVE1234x0001()
+	cve2 := fixtures.GetEmbeddedClusterCVE4567x0002()
+	cve3 := fixtures.GetEmbeddedClusterCVE2345x0003()
+
+	testCases := getClusterCVETestCases(s.T(), validClusters[0], validClusters[1], true)
+	for _, c := range testCases {
+		s.Run(c.name, func() {
+			ctx := c.ctx
+			visibleCVEs := 0
+			for _, visible := range c.visibleCVE {
+				if visible {
+					visibleCVEs++
+				}
+			}
+			vectorsPerCVE := make(map[string]string, 0)
+			cvssPerCVE := make(map[string]float32, 0)
+			foundIDs := make([]string, 0, 3)
+			if env.PostgresDatastoreEnabled.BooleanSetting() {
+				results, err := s.pgStore.SearchRawCVEs(ctx, search.EmptyQuery())
+				s.NoError(err)
+				s.Equal(visibleCVEs, len(results))
+				for _, r := range results {
+					foundIDs = append(foundIDs, r.GetId())
+					cveName := r.GetId()
+					v3AttackVector := r.GetCveBaseInfo().GetCvssV3().GetVector()
+					cvss := r.GetCvss()
+					vectorsPerCVE[cveName] = v3AttackVector
+					cvssPerCVE[cveName] = cvss
+				}
+			} else {
+				results, err := s.legacyStore.SearchRawCVEs(ctx, search.EmptyQuery())
+				s.NoError(err)
+				s.Equal(visibleCVEs, len(results))
+				for _, r := range results {
+					foundIDs = append(foundIDs, r.GetId())
+					cveName := r.GetId()
+					v3AttackVector := r.GetCvssV3().GetVector()
+					cvss := r.GetCvss()
+					vectorsPerCVE[cveName] = v3AttackVector
+					cvssPerCVE[cveName] = cvss
+				}
+			}
+			for _, identifier := range foundIDs {
+				s.True(c.visibleCVE[identifier])
+			}
+			if c.visibleCVE[targetCVE1] {
+				s.Equal(cve1.GetCvssV3().GetVector(), vectorsPerCVE[targetCVE1])
+				s.Equal(cve1.GetCvss(), cvssPerCVE[targetCVE1])
+			}
+			if c.visibleCVE[targetCVE2] {
+				s.Equal(cve2.GetCvssV3().GetVector(), vectorsPerCVE[targetCVE2])
+				s.Equal(cve2.GetCvss(), cvssPerCVE[targetCVE2])
+			}
+			if c.visibleCVE[targetCVE3] {
+				s.Equal(cve3.GetCvssV3().GetVector(), vectorsPerCVE[targetCVE3])
+				s.Equal(cve3.GetCvss(), cvssPerCVE[targetCVE3])
+			}
+		})
+	}
+}
+
+func addDurationToTimestamp(ts *types.Timestamp, duration *types.Duration) *types.Timestamp {
+	nanos := ts.GetNanos() + duration.GetNanos()
+	seconds := ts.GetSeconds() + duration.GetSeconds()
+	nanosInSecond := int32(1000 * 1000 * 1000)
+	if nanos >= nanosInSecond {
+		seconds += int64(nanos / nanosInSecond)
+		nanos %= nanosInSecond
+	}
+	return &types.Timestamp{
+		Seconds: seconds,
+		Nanos:   int32(0),
+	}
+}
+
+func (s *clusterCVEDatastoreSACSuite) checkCVESnoozed(targetCVE string,
+	snoozeStart *types.Timestamp,
+	snoozeDuration *types.Duration,
+	shouldBeSnoozed bool) {
+	var err error
+	var found bool
+	var objSnoozed bool
+	var objSnoozeStart *types.Timestamp
+	var objSnoozeExpiry *types.Timestamp
+	expectedSnoozeExpire := addDurationToTimestamp(snoozeStart, snoozeDuration)
+	if env.PostgresDatastoreEnabled.BooleanSetting() {
+		var obj *storage.ClusterCVE
+		obj, found, err = s.pgStore.Get(allAccessCtx, targetCVE)
+		if found {
+			objSnoozed = obj.GetSnoozed()
+			objSnoozeStart = obj.GetSnoozeStart()
+			objSnoozeExpiry = obj.GetSnoozeExpiry()
+		} else {
+			objSnoozed = false
+			objSnoozeStart = nil
+			objSnoozeExpiry = nil
+		}
+	} else {
+		var obj *storage.CVE
+		obj, found, err = s.legacyStore.Get(allAccessCtx, targetCVE)
+		if found {
+			objSnoozed = obj.GetSuppressed()
+			objSnoozeStart = obj.GetSuppressActivation()
+			objSnoozeExpiry = obj.GetSuppressExpiry()
+		} else {
+			objSnoozed = false
+			objSnoozeStart = nil
+			objSnoozeExpiry = nil
+		}
+	}
+	s.NoError(err)
+	s.True(found)
+	if shouldBeSnoozed {
+		s.True(objSnoozed)
+		s.Equal(snoozeStart, objSnoozeStart)
+		s.Equal(expectedSnoozeExpire, objSnoozeExpiry)
+	} else {
+		s.False(objSnoozed)
+	}
+}
+
+func (s *clusterCVEDatastoreSACSuite) checkCVEUnsnoozed(targetCVE string,
+	snoozeStart *types.Timestamp,
+	snoozeDuration *types.Duration,
+	shouldBeUnsnoozed bool) {
+	var err error
+	var found bool
+	var objSnoozed bool
+	var objSnoozeStart *types.Timestamp
+	var objSnoozeExpiry *types.Timestamp
+	expectedSnoozeExpire := addDurationToTimestamp(snoozeStart, snoozeDuration)
+	if env.PostgresDatastoreEnabled.BooleanSetting() {
+		var obj *storage.ClusterCVE
+		obj, found, err = s.pgStore.Get(allAccessCtx, targetCVE)
+		if found {
+			objSnoozed = obj.GetSnoozed()
+			objSnoozeStart = obj.GetSnoozeStart()
+			objSnoozeExpiry = obj.GetSnoozeExpiry()
+		} else {
+			objSnoozed = false
+			objSnoozeStart = nil
+			objSnoozeExpiry = nil
+		}
+	} else {
+		var obj *storage.CVE
+		obj, found, err = s.legacyStore.Get(allAccessCtx, targetCVE)
+		if found {
+			objSnoozed = obj.GetSuppressed()
+			objSnoozeStart = obj.GetSuppressActivation()
+			objSnoozeExpiry = obj.GetSuppressExpiry()
+		} else {
+			objSnoozed = false
+			objSnoozeStart = nil
+			objSnoozeExpiry = nil
+		}
+	}
+	s.NoError(err)
+	s.True(found)
+	if shouldBeUnsnoozed {
+		s.False(objSnoozed)
+	} else {
+		s.True(objSnoozed)
+		s.Equal(snoozeStart, objSnoozeStart)
+		s.Equal(expectedSnoozeExpire, objSnoozeExpiry)
+	}
+}
+
+func (s *clusterCVEDatastoreSACSuite) runTestSuppressUnsuppressCVE(targetCVE string) {
+	err := s.dackboxTestStore.PushClusterToVulnerabilitiesGraph(dontWaitForIndexing)
+	defer s.cleanImageToVulnerabilitiesGraph(dontWaitForIndexing)
+	s.Require().NoError(err)
+	validClusters := s.dackboxTestStore.GetStoredClusterIDs()
+	s.Require().True(len(validClusters) >= 2)
+
+	for _, c := range getClusterCVESuppressUnsuppressTestCases(s.T(), validClusters[0], validClusters[1]) {
+		s.Run(c.name, func() {
+			ctx := c.ctx
+			snoozeStart := types.TimestampNow()
+			snoozeStart.Nanos = 0
+			snoozeDuration := types.DurationProto(10 * time.Minute)
+			if env.PostgresDatastoreEnabled.BooleanSetting() {
+				err = s.pgStore.Suppress(ctx, snoozeStart, snoozeDuration, targetCVE)
+			} else {
+				err = s.legacyStore.Suppress(ctx, snoozeStart, snoozeDuration, targetCVE)
+			}
+			if c.visibleCVE[targetCVE] {
+				s.NoError(err)
+			} else {
+				s.ErrorIs(err, sac.ErrResourceAccessDenied)
+			}
+			s.checkCVESnoozed(targetCVE, snoozeStart, snoozeDuration, c.visibleCVE[targetCVE])
+			if !c.visibleCVE[targetCVE] {
+				if env.PostgresDatastoreEnabled.BooleanSetting() {
+					err = s.pgStore.Suppress(allAccessCtx, snoozeStart, snoozeDuration, targetCVE)
+				} else {
+					err = s.legacyStore.Suppress(allAccessCtx, snoozeStart, snoozeDuration, targetCVE)
+				}
+				s.NoError(err)
+			}
+			// Ensure the object is now snoozed
+			s.checkCVESnoozed(targetCVE, snoozeStart, snoozeDuration, true)
+			// Unsuppress
+			if env.PostgresDatastoreEnabled.BooleanSetting() {
+				err = s.pgStore.Unsuppress(ctx, targetCVE)
+			} else {
+				err = s.legacyStore.Unsuppress(ctx, targetCVE)
+			}
+			if c.visibleCVE[targetCVE] {
+				s.NoError(err)
+			} else {
+				s.ErrorIs(err, sac.ErrResourceAccessDenied)
+			}
+			// Check unsuppressed worked
+			s.checkCVEUnsnoozed(targetCVE, snoozeStart, snoozeDuration, c.visibleCVE[targetCVE])
+			if !c.visibleCVE[targetCVE] {
+				if env.PostgresDatastoreEnabled.BooleanSetting() {
+					err = s.pgStore.Unsuppress(allAccessCtx, targetCVE)
+				} else {
+					err = s.legacyStore.Unsuppress(allAccessCtx, targetCVE)
+				}
+				s.NoError(err)
+			}
+		})
+	}
+}
+
+func (s *clusterCVEDatastoreSACSuite) TestSuppressUnsuppressSingleCVE() {
+	targetCVE := getCveID(fixtures.GetEmbeddedClusterCVE1234x0001(), clusterOS)
+	s.runTestSuppressUnsuppressCVE(targetCVE)
+}
+
+func (s *clusterCVEDatastoreSACSuite) TestSuppressUnsuppressSharedCVE() {
+	targetCVE := getCveID(fixtures.GetEmbeddedClusterCVE4567x0002(), clusterOS)
+	s.runTestSuppressUnsuppressCVE(targetCVE)
+}

--- a/pkg/fixtures/dackbox.go
+++ b/pkg/fixtures/dackbox.go
@@ -1157,3 +1157,179 @@ func GetScopedNode2(nodeID string, clusterID string) *storage.Node {
 	}
 	return node
 }
+
+////////////////////////
+// Clusters with CVEs //
+
+// Data relationships
+//
+//       Cluster
+//          ^ *
+//          |
+//    ClusterCVEEdge
+//          |
+//          v *
+//         CVE
+//
+// For testing purposes, a graph of objects like the one below could be used.
+//
+// Cluster1 --+--> ClusterCVE1
+//            |
+//            |
+//            +----------+
+//                       |
+//                       v
+//                   ClusterCVE2
+//                       ^
+//                       |
+//            +----------+
+//            |
+// Cluster2 --+--> ClusterCVE3
+//
+
+// GetEmbeddedClusterCVE1234x0001 provides a pseudo-realistic image CVE for dackbox datastore integration testing.
+func GetEmbeddedClusterCVE1234x0001() *storage.EmbeddedVulnerability {
+	return &storage.EmbeddedVulnerability{
+		Cve:          "CVE-1234-0001",
+		Cvss:         5.8,
+		Summary:      "Find some inspiring quote on an evil topic to insert here.",
+		Link:         "book://author/title",
+		SetFixedBy:   &storage.EmbeddedVulnerability_FixedBy{FixedBy: ""},
+		ScoreVersion: storage.EmbeddedVulnerability_V2,
+		CvssV2: &storage.CVSSV2{
+			Vector:              "AV:N/AC:M/Au:N/C:P/I:P/A:N",
+			AttackVector:        storage.CVSSV2_ATTACK_NETWORK,
+			AccessComplexity:    storage.CVSSV2_ACCESS_MEDIUM,
+			Authentication:      storage.CVSSV2_AUTH_NONE,
+			Confidentiality:     storage.CVSSV2_IMPACT_PARTIAL,
+			Integrity:           storage.CVSSV2_IMPACT_PARTIAL,
+			Availability:        storage.CVSSV2_IMPACT_NONE,
+			ExploitabilityScore: 8.6,
+			ImpactScore:         4.9,
+			Score:               5.8,
+			Severity:            storage.CVSSV2_MEDIUM,
+		},
+		CvssV3:            nil,
+		PublishedOn:       &types.Timestamp{Seconds: 1234567890},
+		LastModified:      &types.Timestamp{Seconds: 1235467890},
+		VulnerabilityType: storage.EmbeddedVulnerability_OPENSHIFT_VULNERABILITY,
+		VulnerabilityTypes: []storage.EmbeddedVulnerability_VulnerabilityType{
+			storage.EmbeddedVulnerability_OPENSHIFT_VULNERABILITY,
+		},
+		Suppressed:            false,
+		SuppressActivation:    nil,
+		SuppressExpiry:        nil,
+		FirstSystemOccurrence: &types.Timestamp{Seconds: 1243567890},
+		FirstImageOccurrence:  &types.Timestamp{Seconds: 1245367890},
+		Severity:              storage.VulnerabilitySeverity_MODERATE_VULNERABILITY_SEVERITY,
+		State:                 storage.VulnerabilityState_OBSERVED,
+	}
+}
+
+// GetEmbeddedClusterCVE4567x0002 provides a pseudo-realistic image CVE for dackbox datastore integration testing.
+func GetEmbeddedClusterCVE4567x0002() *storage.EmbeddedVulnerability {
+	return &storage.EmbeddedVulnerability{
+		Cve:          "CVE-4567-0002",
+		Cvss:         7.5,
+		Summary:      "Find some inspiring quote on an evil topic to insert here.",
+		Link:         "book://author/title",
+		SetFixedBy:   &storage.EmbeddedVulnerability_FixedBy{FixedBy: "1.1.1"},
+		ScoreVersion: storage.EmbeddedVulnerability_V3,
+		CvssV2: &storage.CVSSV2{
+			Vector:              "AV:N/AC:L/Au:N/C:N/I:P/A:N",
+			AttackVector:        storage.CVSSV2_ATTACK_NETWORK,
+			AccessComplexity:    storage.CVSSV2_ACCESS_LOW,
+			Authentication:      storage.CVSSV2_AUTH_NONE,
+			Confidentiality:     storage.CVSSV2_IMPACT_NONE,
+			Integrity:           storage.CVSSV2_IMPACT_PARTIAL,
+			Availability:        storage.CVSSV2_IMPACT_NONE,
+			ExploitabilityScore: 10.0,
+			ImpactScore:         2.9,
+			Score:               5.0,
+			Severity:            storage.CVSSV2_MEDIUM,
+		},
+		CvssV3: &storage.CVSSV3{
+			Vector:              "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",
+			ExploitabilityScore: 3.9,
+			ImpactScore:         3.6,
+			AttackVector:        storage.CVSSV3_ATTACK_NETWORK,
+			AttackComplexity:    storage.CVSSV3_COMPLEXITY_LOW,
+			PrivilegesRequired:  storage.CVSSV3_PRIVILEGE_NONE,
+			UserInteraction:     storage.CVSSV3_UI_NONE,
+			Scope:               storage.CVSSV3_UNCHANGED,
+			Confidentiality:     storage.CVSSV3_IMPACT_NONE,
+			Integrity:           storage.CVSSV3_IMPACT_HIGH,
+			Availability:        storage.CVSSV3_IMPACT_NONE,
+			Score:               7.5,
+			Severity:            storage.CVSSV3_HIGH,
+		},
+		PublishedOn:       &types.Timestamp{Seconds: 1234567890},
+		LastModified:      &types.Timestamp{Seconds: 1235467890},
+		VulnerabilityType: storage.EmbeddedVulnerability_ISTIO_VULNERABILITY,
+		VulnerabilityTypes: []storage.EmbeddedVulnerability_VulnerabilityType{
+			storage.EmbeddedVulnerability_K8S_VULNERABILITY,
+			storage.EmbeddedVulnerability_ISTIO_VULNERABILITY,
+			storage.EmbeddedVulnerability_OPENSHIFT_VULNERABILITY,
+		},
+		Suppressed:            false,
+		SuppressActivation:    nil,
+		SuppressExpiry:        nil,
+		FirstSystemOccurrence: &types.Timestamp{Seconds: 1243567890},
+		FirstImageOccurrence:  &types.Timestamp{Seconds: 1245367890},
+		Severity:              storage.VulnerabilitySeverity_IMPORTANT_VULNERABILITY_SEVERITY,
+		State:                 storage.VulnerabilityState_OBSERVED,
+	}
+}
+
+// GetEmbeddedClusterCVE2345x0003 provides a pseudo-realistic image CVE for dackbox datastore integration testing.
+func GetEmbeddedClusterCVE2345x0003() *storage.EmbeddedVulnerability {
+	return &storage.EmbeddedVulnerability{
+		Cve:          "CVE-2345-0003",
+		Cvss:         7.8,
+		Summary:      "Find some inspiring quote on an evil topic to insert here.",
+		Link:         "book://author/title",
+		SetFixedBy:   &storage.EmbeddedVulnerability_FixedBy{FixedBy: ""},
+		ScoreVersion: storage.EmbeddedVulnerability_V3,
+		CvssV2: &storage.CVSSV2{
+			Vector:              "AV:N/AC:M/Au:N/C:P/I:P/A:P",
+			AttackVector:        storage.CVSSV2_ATTACK_NETWORK,
+			AccessComplexity:    storage.CVSSV2_ACCESS_MEDIUM,
+			Authentication:      storage.CVSSV2_AUTH_NONE,
+			Confidentiality:     storage.CVSSV2_IMPACT_PARTIAL,
+			Integrity:           storage.CVSSV2_IMPACT_PARTIAL,
+			Availability:        storage.CVSSV2_IMPACT_PARTIAL,
+			ExploitabilityScore: 8.6,
+			ImpactScore:         6.4,
+			Score:               6.8,
+			Severity:            storage.CVSSV2_MEDIUM,
+		},
+		CvssV3: &storage.CVSSV3{
+			Vector:              "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+			ExploitabilityScore: 1.8,
+			ImpactScore:         5.9,
+			AttackVector:        storage.CVSSV3_ATTACK_LOCAL,
+			AttackComplexity:    storage.CVSSV3_COMPLEXITY_LOW,
+			PrivilegesRequired:  storage.CVSSV3_PRIVILEGE_NONE,
+			UserInteraction:     storage.CVSSV3_UI_REQUIRED,
+			Scope:               storage.CVSSV3_UNCHANGED,
+			Confidentiality:     storage.CVSSV3_IMPACT_HIGH,
+			Integrity:           storage.CVSSV3_IMPACT_HIGH,
+			Availability:        storage.CVSSV3_IMPACT_HIGH,
+			Score:               7.8,
+			Severity:            storage.CVSSV3_HIGH,
+		},
+		PublishedOn:       &types.Timestamp{Seconds: 1234567890},
+		LastModified:      &types.Timestamp{Seconds: 1235467890},
+		VulnerabilityType: storage.EmbeddedVulnerability_K8S_VULNERABILITY,
+		VulnerabilityTypes: []storage.EmbeddedVulnerability_VulnerabilityType{
+			storage.EmbeddedVulnerability_K8S_VULNERABILITY,
+		},
+		Suppressed:            false,
+		SuppressActivation:    nil,
+		SuppressExpiry:        nil,
+		FirstSystemOccurrence: &types.Timestamp{Seconds: 1243567890},
+		FirstImageOccurrence:  &types.Timestamp{Seconds: 1245367890},
+		Severity:              storage.VulnerabilitySeverity_LOW_VULNERABILITY_SEVERITY,
+		State:                 storage.VulnerabilityState_OBSERVED,
+	}
+}

--- a/tools/allowed-large-files
+++ b/tools/allowed-large-files
@@ -21,6 +21,7 @@ pkg/booleanpolicy/default_policies_test.go
 pkg/branding/files/red_hat_acs_logo_rgb.png
 pkg/branding/files/stackrox_integration_logo.png
 pkg/docker/types/types_easyjson.go
+pkg/fixtures/dackbox.go
 pkg/fixtures/image.go
 pkg/mitre/files/mitre.json
 pkg/mocks/github.com/aws/aws-sdk-go/service/securityhub/securityhubiface/mocks/mocks.go


### PR DESCRIPTION
## Description

With the migration to postgres and the associated re-desing of scoped access control, it is necessary to validate that the Scoped Access Control data filtering works the same before and after the migration.
This change covers the Dackbox ClusterCVE objects.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
~~- [ ] Evaluated and added CHANGELOG entry if required~~
~~- [ ] Determined and documented upgrade steps~~
~~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

CI run should be enough.