### PR TITLE
Fix front end types for collection responses

### DIFF
--- a/ui/apps/platform/src/Containers/Collections/hooks/useCollection.ts
+++ b/ui/apps/platform/src/Containers/Collections/hooks/useCollection.ts
@@ -5,7 +5,7 @@ import {
     CollectionResponse,
     getCollection,
     listCollections,
-    ResolvedCollectionResponse,
+    ResolvedCollectionResponseWithMatches,
 } from 'services/CollectionsService';
 
 const defaultCollectionData: Omit<CollectionResponse, 'id'> = {
@@ -24,7 +24,7 @@ const noopRequest = {
     cancel: () => {},
 };
 
-function getEmbeddedCollections({ collection }: ResolvedCollectionResponse): Promise<{
+function getEmbeddedCollections({ collection }: ResolvedCollectionResponseWithMatches): Promise<{
     collection: CollectionResponse;
     embeddedCollections: CollectionResponse[];
 }> {

--- a/ui/apps/platform/src/Containers/Collections/hooks/useCollectionFormSubmission.ts
+++ b/ui/apps/platform/src/Containers/Collections/hooks/useCollectionFormSubmission.ts
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import {
     updateCollection,
     createCollection,
-    CollectionResponse,
+    ResolvedCollectionResponse,
 } from 'services/CollectionsService';
 import { CollectionPageAction } from '../collections.utils';
 import { generateRequest } from '../converter';
@@ -13,10 +13,10 @@ import { Collection } from '../types';
 export function useCollectionFormSubmission(pageAction: CollectionPageAction) {
     const [saveError, setSaveError] = useState<CollectionSaveError | undefined>();
 
-    function onSubmit(collection: Collection): Promise<CollectionResponse> {
+    function onSubmit(collection: Collection): Promise<ResolvedCollectionResponse> {
         setSaveError(undefined);
 
-        return new Promise<CollectionResponse>((resolve, reject) => {
+        return new Promise<ResolvedCollectionResponse>((resolve, reject) => {
             if (pageAction.type === 'view') {
                 // Logically should not happen, but just in case
                 return reject(new Error('A Collection form has been submitted in read-only view'));

--- a/ui/apps/platform/src/services/CollectionsService.ts
+++ b/ui/apps/platform/src/services/CollectionsService.ts
@@ -79,6 +79,9 @@ export function getCollectionCount(searchFilter: SearchFilter): CancellableReque
 
 export type ResolvedCollectionResponse = {
     collection: CollectionResponse;
+};
+
+export type ResolvedCollectionResponseWithMatches = ResolvedCollectionResponse & {
     deployments: ListDeployment[];
 };
 
@@ -94,11 +97,13 @@ export type ResolvedCollectionResponse = {
 export function getCollection(
     id: string,
     options: { withMatches: boolean } = { withMatches: false }
-): CancellableRequest<ResolvedCollectionResponse> {
+): CancellableRequest<ResolvedCollectionResponseWithMatches> {
     const params = qs.stringify(options);
     return makeCancellableAxiosRequest((signal) =>
         axios
-            .get<ResolvedCollectionResponse>(`${collectionsBaseUrl}/${id}?${params}`, { signal })
+            .get<ResolvedCollectionResponseWithMatches>(`${collectionsBaseUrl}/${id}?${params}`, {
+                signal,
+            })
             .then((response) => response.data)
     );
 }
@@ -113,10 +118,10 @@ export function getCollection(
  */
 export function createCollection(
     collection: CollectionRequest
-): CancellableRequest<CollectionResponse> {
+): CancellableRequest<ResolvedCollectionResponse> {
     return makeCancellableAxiosRequest((signal) =>
         axios
-            .post<CollectionResponse>(collectionsBaseUrl, collection, { signal })
+            .post<ResolvedCollectionResponse>(collectionsBaseUrl, collection, { signal })
             .then((response) => response.data)
     );
 }
@@ -135,10 +140,12 @@ export function createCollection(
 export function updateCollection(
     id: string,
     collection: CollectionRequest
-): CancellableRequest<CollectionResponse> {
+): CancellableRequest<ResolvedCollectionResponse> {
     return makeCancellableAxiosRequest((signal) =>
         axios
-            .patch<CollectionResponse>(`${collectionsBaseUrl}/${id}`, collection, { signal })
+            .patch<ResolvedCollectionResponse>(`${collectionsBaseUrl}/${id}`, collection, {
+                signal,
+            })
             .then((response) => response.data)
     );
 }


### PR DESCRIPTION
## Description

This updates the response types for collection 'update' and 'create' functions to match the structure provided by the API. The actual collection config is wrapped in a `{ collection: <config> }` object. Easy for these to slip under the radar until we attempt to use the returned data...


## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Type-level change only - manual spot check and automated tests.
