### PR TITLE
Move collection form cancel callback higher in the component tree

### DIFF
--- a/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
@@ -80,6 +80,7 @@ export type CollectionFormProps = {
     /* collection responses for the embedded collections of `initialData` */
     initialEmbeddedCollections: CollectionResponse[];
     onSubmit: (collection: Collection) => Promise<void>;
+    onCancel: () => void;
     saveError?: CollectionSaveError | undefined;
     clearSaveError?: () => void;
     /* Table cells to render for each collection in the CollectionAttacher component */
@@ -141,6 +142,7 @@ function CollectionForm({
     saveError,
     clearSaveError = () => {},
     onSubmit,
+    onCancel,
     getCollectionTableCells,
 }: CollectionFormProps) {
     const history = useHistory();
@@ -205,10 +207,6 @@ function CollectionForm({
     const collectionTableCells = getCollectionTableCells(
         saveError?.type === 'CollectionLoop' ? saveError.loopId : undefined
     );
-
-    function onCancelSave() {
-        history.push({ pathname: `${collectionsBasePath}` });
-    }
 
     const onResourceSelectorChange = (
         entityType: SelectorEntityType,
@@ -435,7 +433,7 @@ function CollectionForm({
                     >
                         Save
                     </Button>
-                    <Button variant="secondary" isDisabled={isSubmitting} onClick={onCancelSave}>
+                    <Button variant="secondary" isDisabled={isSubmitting} onClick={onCancel}>
                         Cancel
                     </Button>
                 </div>

--- a/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
@@ -1,5 +1,4 @@
 import React, { ReactElement, useEffect } from 'react';
-import { useHistory } from 'react-router-dom';
 import {
     Alert,
     Badge,
@@ -23,7 +22,6 @@ import { useFormik } from 'formik';
 import * as yup from 'yup';
 
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
-import { collectionsBasePath } from 'routePaths';
 import { CollectionResponse } from 'services/CollectionsService';
 import { getIsValidLabelKey } from 'utils/labels';
 import { CollectionPageAction } from './collections.utils';
@@ -145,8 +143,6 @@ function CollectionForm({
     onCancel,
     getCollectionTableCells,
 }: CollectionFormProps) {
-    const history = useHistory();
-
     const isReadOnly = action.type === 'view' || !hasWriteAccessForCollections;
 
     const { isOpen: isRuleSectionOpen, onToggle: ruleSectionOnToggle } = useSelectToggle(true);

--- a/ui/apps/platform/src/Containers/Collections/CollectionFormDrawer.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionFormDrawer.tsx
@@ -34,6 +34,7 @@ export type CollectionFormDrawerProps = {
     toggleDrawer: (isOpen: boolean) => void;
     headerContent?: ReactElement;
     onSubmit: CollectionFormProps['onSubmit'];
+    onCancel: CollectionFormProps['onCancel'];
     saveError?: CollectionFormProps['saveError'];
     clearSaveError?: CollectionFormProps['clearSaveError'];
     getCollectionTableCells: CollectionFormProps['getCollectionTableCells'];
@@ -48,6 +49,7 @@ function CollectionFormDrawer({
     isDrawerOpen,
     toggleDrawer,
     onSubmit,
+    onCancel,
     saveError,
     clearSaveError,
     getCollectionTableCells,
@@ -98,6 +100,7 @@ function CollectionFormDrawer({
                                 initialData={initialData}
                                 initialEmbeddedCollections={initialEmbeddedCollections}
                                 onSubmit={onSubmit}
+                                onCancel={onCancel}
                                 saveError={saveError}
                                 clearSaveError={clearSaveError}
                                 getCollectionTableCells={getCollectionTableCells}

--- a/ui/apps/platform/src/Containers/Collections/CollectionFormModal.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionFormModal.tsx
@@ -102,6 +102,7 @@ function CollectionsFormModal({
                 toggleDrawer={toggleDrawer}
                 // Since the form cannot be submitted, stub this out with an empty promise
                 onSubmit={() => Promise.resolve()}
+                onCancel={onClose}
                 getCollectionTableCells={getCollectionTableCells}
             />
         );

--- a/ui/apps/platform/src/Containers/Collections/CollectionsFormPage.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionsFormPage.tsx
@@ -208,6 +208,9 @@ function CollectionsFormPage({
                             return Promise.reject(err);
                         })
                 }
+                onCancel={() => {
+                    history.push({ pathname: `${collectionsBasePath}` });
+                }}
                 saveError={saveError}
                 clearSaveError={() => setSaveError(undefined)}
                 getCollectionTableCells={getCollectionTableCells}


### PR DESCRIPTION
## Description

This moves the behavior of the "Cancel" button for the collection form higher in the component tree. Since this button will appear in the collection modal in the future (vuln reporting), we need to be able to customize its behavior.


## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Currently, the "Cancel" button can appear in any of the following situations:

- Go to the collections table and click the "Create collection" button, navigating to the collection form page.
- Go to the collections table and select "Edit collection" from a row menu, navigating to the collection form page.
- Go to the collections table and select "Clone collection" from a row menu, navigating to the collection form page.
- From the 'view' form for an individual collection, select "Edit collection" from the Action menu.
- From the 'view' form for an individual collection, select "Clone collection" from the Action menu.
- From each of the "Create", "Edit", and "Clone" modes of the collection form, refresh the browser. (Simulates direct navigation to the form.)

For each of the above cases, click the "Cancel" button at the bottom of the form and verify that the browser redirects to the collection table page.
