### PR TITLE
Run builds in parallel on GHA

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -61,7 +61,7 @@ jobs:
         uses: ./.github/actions/cache-go-dependencies
 
       - name: Build CLI
-        run: make cli
+        run: make cli -j 2
 
       - name: Bundle build to preserve permissions
         run: tar -cvzf cli-build.tgz bin


### PR DESCRIPTION
## Description

Previous implementation of makefile for cli prevents multiple jobs.
Now we should get significant speedup by passing `-j` option.
