### PR TITLE
ROX-13730: Remove OpenShift 3 mode from Cluster form options

### DIFF
--- a/ui/apps/platform/src/Containers/Clusters/cluster.helpers.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/cluster.helpers.tsx
@@ -35,7 +35,6 @@ export const runtimeOptions = [
 
 export const clusterTypes = {
     KUBERNETES: 'KUBERNETES_CLUSTER',
-    OPENSHIFT_3: 'OPENSHIFT_CLUSTER',
     OPENSHIFT_4: 'OPENSHIFT4_CLUSTER',
 };
 
@@ -44,11 +43,6 @@ export const clusterTypeOptions = [
         label: 'Kubernetes',
         tableDisplay: 'Kubernetes',
         value: clusterTypes.KUBERNETES,
-    },
-    {
-        label: 'OpenShift 3.x compatiblity mode',
-        tableDisplay: 'OpenShift 3.x compatiblity mode',
-        value: clusterTypes.OPENSHIFT_3,
     },
     {
         label: 'OpenShift 4.x',

--- a/ui/apps/platform/src/css/trumps.css
+++ b/ui/apps/platform/src/css/trumps.css
@@ -8,6 +8,11 @@ body {
     font-family: var(--pf-global--FontFamily--sans-serif) !important;
 }
 
+/* overrides the extra chevron in select inputs in the classic StackRox style on cluster form */
+[data-testid="clusters-side-panel"] select {
+    background-image: none;
+}
+
 /* overrides the default link styling in Tailwind (`inherit`) with PF's default blue */
 .pf-c-page__main-section a {
     color: var(--pf-global--link--Color);


### PR DESCRIPTION
## Description

A tester during the HackFest noticed that our Cluster form still has an OpenShift 3 option, but we no longer support that version of OpenShift.

## Checklist
- [x] Investigated and inspected CI test results


## Testing Performed

Before this code change
<img width="639" alt="Screen Shot 2022-12-05 at 10 47 37 AM" src="https://user-images.githubusercontent.com/715729/205729578-4a0fc584-c869-4e4c-9da6-fb9b0af3bfea.png">


After this code change
<img width="613" alt="Screen Shot 2022-12-05 at 11 14 08 AM" src="https://user-images.githubusercontent.com/715729/205729608-805c5a53-06a6-4c5c-9683-decd88e5da15.png">
