### PR TITLE
Only show blank collection name error on field touch

### DIFF
--- a/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
@@ -152,6 +152,7 @@ function CollectionForm({
     const {
         values,
         errors: formikErrors,
+        touched,
         handleChange,
         handleBlur,
         setFieldValue,
@@ -244,13 +245,13 @@ function CollectionForm({
                                 fieldId="name"
                                 isRequired={!isReadOnly}
                                 helperTextInvalid={errors.name}
-                                validated={errors.name ? 'error' : 'default'}
+                                validated={errors.name && touched.name ? 'error' : 'default'}
                             >
                                 <TextInput
                                     id="name"
                                     name="name"
                                     value={values.name}
-                                    validated={errors.name ? 'error' : 'default'}
+                                    validated={errors.name && touched.name ? 'error' : 'default'}
                                     onChange={(_, e) => {
                                         if (saveError?.type === 'DuplicateName') {
                                             clearSaveError();


### PR DESCRIPTION
## Description

Previously the error state for the name field would be shown as soon as the form was loaded when in creation mode. This defers showing the error until the field has been "touched".

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Visit the main collection page and click the "Create collection" button.  When the form initially loads, the name field should not be in the error state.
![image](https://user-images.githubusercontent.com/1292638/205734090-f8ce6f77-d866-472e-aa69-43986709698f.png)


Click into the name field, and then outside of the name field to "touch" it. If the field is left blank, the error state should appear.
![image](https://user-images.githubusercontent.com/1292638/205734118-e2556c0b-3ed2-4b00-980f-466695864a98.png)
![image](https://user-images.githubusercontent.com/1292638/205734134-fc21a90f-c254-4740-8888-99ee761782c9.png)

Entering a value into the form field clears the error.
![image](https://user-images.githubusercontent.com/1292638/205734240-aed7a943-152f-4df0-b1c9-6e60ee57a22f.png)

