### PR TITLE
ROX-13433: Adding Extraneous Flows graph

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraph.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraph.tsx
@@ -27,7 +27,7 @@ import { EdgeState } from './EdgeStateSelect';
 import './Topology.css';
 import { getNodeById } from './utils/networkGraphUtils';
 import { CustomModel, CustomNodeModel } from './types/topology.type';
-import { getExtraneousNodes } from './utils/modelUtils';
+import { createExtraneousNodes } from './utils/modelUtils';
 
 // TODO: move these type defs to a central location
 export const UrlDetailType = {
@@ -91,7 +91,7 @@ function setEdges(controller, detailId) {
     }
 }
 
-function setExtraneousNode(controller, detailId) {
+function setExtraneousNodes(controller, detailId) {
     if (!detailId) {
         // if there is no selected node, check if extraneous nodes exist and clear them
         const extraneousIngressNode = controller.getNodeById('extraneous-ingress');
@@ -104,7 +104,7 @@ function setExtraneousNode(controller, detailId) {
         }
     } else {
         const currentModel = controller.toModel();
-        const { extraneousEgressNode, extraneousIngressNode } = getExtraneousNodes();
+        const { extraneousEgressNode, extraneousIngressNode } = createExtraneousNodes();
         // else if there is a selected node, create a node to collect extraneous flows
         const selectedNode = controller.getNodeById(detailId);
         const { networkPolicyState } = selectedNode?.data || {};
@@ -133,7 +133,7 @@ const TopologyComponent = ({ model, edgeState }: TopologyComponentProps) => {
     if (controller.hasGraph()) {
         setEdges(controller, detailId);
         if (edgeState === 'extraneous') {
-            setExtraneousNode(controller, detailId);
+            setExtraneousNodes(controller, detailId);
         }
     }
 

--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraph.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraph.tsx
@@ -22,10 +22,12 @@ import DeploymentSideBar from './deployment/DeploymentSideBar';
 import NamespaceSideBar from './namespace/NamespaceSideBar';
 import CidrBlockSideBar from './cidr/CidrBlockSideBar';
 import ExternalEntitiesSideBar from './external/ExternalEntitiesSideBar';
+import { EdgeState } from './EdgeStateSelect';
 
 import './Topology.css';
 import { getNodeById } from './utils/networkGraphUtils';
 import { CustomModel, CustomNodeModel } from './types/topology.type';
+import { getExtraneousNodes } from './utils/modelUtils';
 
 // TODO: move these type defs to a central location
 export const UrlDetailType = {
@@ -47,10 +49,12 @@ function getUrlParamsForEntity(selectedEntity: CustomNodeModel): [UrlDetailTypeV
 
 export type NetworkGraphProps = {
     model: CustomModel;
+    edgeState: EdgeState;
 };
 
 export type TopologyComponentProps = {
     model: CustomModel;
+    edgeState: EdgeState;
 };
 
 function getNodeEdges(selectedNode) {
@@ -87,7 +91,41 @@ function setEdges(controller, detailId) {
     }
 }
 
-const TopologyComponent = ({ model }: TopologyComponentProps) => {
+function setExtraneousNode(controller, detailId) {
+    console.log('setExtraneousNode');
+    if (!detailId) {
+        // if there is no selected node, check if extraneous nodes exist and clear them
+        const extraneousIngressNode = controller.getNodeById('extraneous-ingress');
+        if (extraneousIngressNode) {
+            controller.removeElement(extraneousIngressNode);
+        }
+        const extraneousEgressNode = controller.getNodeById('extraneous-egress');
+        if (extraneousEgressNode) {
+            controller.removeElement(extraneousEgressNode);
+        }
+    } else {
+        const currentModel = controller.toModel();
+        const { extraneousEgressNode, extraneousIngressNode } = getExtraneousNodes();
+        // else if there is a selected node, create a node to collect extraneous flows
+        const selectedNode = controller.getNodeById(detailId);
+        const { networkPolicyState } = selectedNode?.data || {};
+        console.log('setExtraneousNode selectedNode', selectedNode);
+        if (networkPolicyState === 'ingress') {
+            // if the node has ingress policies from policy graph, create extraneous egress node
+            currentModel.nodes.push(extraneousEgressNode);
+        } else if (networkPolicyState === 'egress') {
+            // if the node has egress policies from policy graph, create extraneous ingress node
+            currentModel.nodes.push(extraneousIngressNode);
+        } else if (networkPolicyState === 'none') {
+            // if the node has no policies, create both extraneous ingress and egress nodes
+            currentModel.nodes.push(extraneousEgressNode);
+            currentModel.nodes.push(extraneousIngressNode);
+        }
+        controller.fromModel(currentModel);
+    }
+}
+
+const TopologyComponent = ({ model, edgeState }: TopologyComponentProps) => {
     const history = useHistory();
     const { detailId } = useParams();
     const selectedEntity = detailId && getNodeById(model?.nodes, detailId);
@@ -96,6 +134,9 @@ const TopologyComponent = ({ model }: TopologyComponentProps) => {
     // to prevent error where graph hasn't initialized yet
     if (controller.hasGraph()) {
         setEdges(controller, detailId);
+        if (edgeState === 'extraneous') {
+            setExtraneousNode(controller, detailId);
+        }
     }
 
     function closeSidebar() {
@@ -197,7 +238,7 @@ const TopologyComponent = ({ model }: TopologyComponentProps) => {
     );
 };
 
-const NetworkGraph = React.memo<NetworkGraphProps>(({ model }) => {
+const NetworkGraph = React.memo<NetworkGraphProps>(({ model, edgeState }) => {
     const controller = new Visualization();
     controller.registerLayoutFactory(defaultLayoutFactory);
     controller.registerComponentFactory(defaultComponentFactory);
@@ -206,7 +247,7 @@ const NetworkGraph = React.memo<NetworkGraphProps>(({ model }) => {
     return (
         <div className="pf-ri__topology-demo">
             <VisualizationProvider controller={controller}>
-                <TopologyComponent model={model} />
+                <TopologyComponent model={model} edgeState={edgeState} />
             </VisualizationProvider>
         </div>
     );

--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraph.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraph.tsx
@@ -92,7 +92,6 @@ function setEdges(controller, detailId) {
 }
 
 function setExtraneousNode(controller, detailId) {
-    console.log('setExtraneousNode');
     if (!detailId) {
         // if there is no selected node, check if extraneous nodes exist and clear them
         const extraneousIngressNode = controller.getNodeById('extraneous-ingress');
@@ -109,7 +108,6 @@ function setExtraneousNode(controller, detailId) {
         // else if there is a selected node, create a node to collect extraneous flows
         const selectedNode = controller.getNodeById(detailId);
         const { networkPolicyState } = selectedNode?.data || {};
-        console.log('setExtraneousNode selectedNode', selectedNode);
         if (networkPolicyState === 'ingress') {
             // if the node has ingress policies from policy graph, create extraneous egress node
             currentModel.nodes.push(extraneousEgressNode);

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/StyleNode.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/StyleNode.tsx
@@ -27,7 +27,6 @@ import AlternateIcon from '@patternfly/react-icons/dist/esm/icons/regions-icon';
 import FolderOpenIcon from '@patternfly/react-icons/dist/esm/icons/folder-open-icon';
 import BlueprintIcon from '@patternfly/react-icons/dist/esm/icons/blueprint-icon';
 import PauseCircle from '@patternfly/react-icons/dist/esm/icons/pause-circle-icon';
-import Thumbtack from '@patternfly/react-icons/dist/esm/icons/thumbtack-icon';
 import useDetailsLevel from '@patternfly/react-topology/dist/esm/hooks/useDetailsLevel';
 import { SVGIconProps } from '@patternfly/react-icons/dist/esm/createIcon';
 
@@ -130,12 +129,6 @@ const renderDecorators = (
                 element,
                 TopologyQuadrant.lowerLeft,
                 <PauseCircle />,
-                getShapeDecoratorCenter
-            )}
-            {renderDecorator(
-                element,
-                TopologyQuadrant.lowerRight,
-                <Thumbtack />,
                 getShapeDecoratorCenter
             )}
         </>

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/defaultComponentFactory.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/defaultComponentFactory.tsx
@@ -2,16 +2,22 @@ import { ComponentType } from 'react';
 import {
     GraphElement,
     ComponentFactory,
-    ModelKind,
     GraphComponent,
     DefaultNode,
     DefaultEdge,
     DefaultGroup,
 } from '@patternfly/react-topology';
 
+enum CustomModelKind {
+    node = 'node',
+    graph = 'graph',
+    edge = 'edge',
+    fakeGroup = 'fakeGroup',
+}
+
 // @ts-expect-error TODO: raise type error issue with patternfly/react-topology team
 const defaultComponentFactory: ComponentFactory = (
-    kind: ModelKind,
+    kind: CustomModelKind,
     type: string
 ):
     | ComponentType<{ element: GraphElement }>
@@ -25,12 +31,14 @@ const defaultComponentFactory: ComponentFactory = (
             return DefaultGroup;
         default:
             switch (kind) {
-                case ModelKind.graph:
+                case CustomModelKind.graph:
                     return GraphComponent;
-                case ModelKind.node:
+                case CustomModelKind.node:
                     return DefaultNode;
-                case ModelKind.edge:
+                case CustomModelKind.edge:
                     return DefaultEdge;
+                case CustomModelKind.fakeGroup:
+                    return DefaultNode;
                 default:
                     return undefined;
             }

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/stylesComponentFactory.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/stylesComponentFactory.tsx
@@ -33,6 +33,12 @@ const stylesComponentFactory: ComponentFactory = (kind: ModelKind, type: string)
                 // @ts-ignore
                 withSelection()(StyleGroup)
             );
+        case 'fakeGroup':
+            return withDragNode(nodeDragSourceSpec('node', true, true))(
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
+                withSelection()(StyleNode)
+            );
         case 'edge':
             return StyleEdge;
         default:

--- a/ui/apps/platform/src/Containers/NetworkGraph/types/topology.type.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/types/topology.type.ts
@@ -10,7 +10,9 @@ export type CustomNodeModel =
     | DeploymentNodeModel
     | ExternalNodeModel
     | ExternalEntitiesNodeModel
-    | CIDRBlockNodeModel;
+    | CIDRBlockNodeModel
+    | PolicyNodeModel
+    | ExtraneousNodeModel;
 
 export type NamespaceNodeModel = Override<NodeModel, { data: NamespaceData }>;
 
@@ -21,6 +23,10 @@ export type ExternalNodeModel = Override<NodeModel, { data: ExternalData }>;
 export type ExternalEntitiesNodeModel = Override<NodeModel, { data: ExternalEntitiesData }>;
 
 export type CIDRBlockNodeModel = Override<NodeModel, { data: CIDRBlockData }>;
+
+export type PolicyNodeModel = Override<NodeModel, { data: PolicyDeploymentData }>;
+
+export type ExtraneousNodeModel = Override<NodeModel, { data: ExtraneousData }>;
 
 export type CustomNodeData =
     | NamespaceData
@@ -35,6 +41,8 @@ export type NamespaceData = {
     showContextMenu: boolean;
 };
 
+export type NetworkPolicyState = 'none' | 'both' | 'ingress' | 'egress';
+
 export type DeploymentData = {
     type: 'DEPLOYMENT';
     id: string;
@@ -45,6 +53,7 @@ export type DeploymentData = {
         namespace: string;
     };
     policyIds: string[];
+    networkPolicyState: NetworkPolicyState;
 };
 
 export type ExternalData = {
@@ -66,4 +75,24 @@ export type CIDRBlockData = {
         default: boolean;
         name: string;
     };
+};
+
+export type PolicyDeploymentData = {
+    type: 'DEPLOYMENT';
+    id: string;
+    deployment: {
+        cluster: string;
+        listenPorts: ListenPort[];
+        name: string;
+        namespace: string;
+    };
+    policyIds: string[];
+    nonIsolatedIngress: boolean;
+    nonIsolatedEgress: boolean;
+};
+
+export type ExtraneousData = {
+    type: 'EXTRANEOUS';
+    collapsible: boolean;
+    showContextMenu: boolean;
 };

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/modelUtils.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/modelUtils.tsx
@@ -1,4 +1,4 @@
-import { EdgeModel } from '@patternfly/react-topology';
+import { EdgeModel, EdgeStyle } from '@patternfly/react-topology';
 
 import { NetworkEntityInfo, Node } from 'types/networkFlow.proto';
 import { ensureExhaustive } from 'utils/type.utils';
@@ -7,8 +7,12 @@ import {
     CustomNodeData,
     CustomNodeModel,
     ExternalNodeModel,
+    ExternalData,
     NamespaceData,
     NamespaceNodeModel,
+    PolicyNodeModel,
+    ExtraneousNodeModel,
+    NetworkPolicyState,
 } from '../types/topology.type';
 
 function getNameByEntity(entity: NetworkEntityInfo): string {
@@ -24,10 +28,29 @@ function getNameByEntity(entity: NetworkEntityInfo): string {
     }
 }
 
-function getDataByEntityType(entity: NetworkEntityInfo, policyIds: string[]): CustomNodeData {
+function getNetworkPolicyState(policyNode?: PolicyNodeModel): NetworkPolicyState {
+    let networkPolicyState: NetworkPolicyState = 'none';
+    if (policyNode) {
+        const { nonIsolatedEgress, nonIsolatedIngress } = policyNode.data;
+        if (!nonIsolatedIngress && !nonIsolatedEgress) {
+            networkPolicyState = 'both';
+        } else if (nonIsolatedEgress) {
+            networkPolicyState = 'ingress';
+        } else if (nonIsolatedIngress) {
+            networkPolicyState = 'egress';
+        }
+    }
+    return networkPolicyState;
+}
+
+function getDataByEntityType(
+    entity: NetworkEntityInfo,
+    policyIds: string[],
+    policyNode?: PolicyNodeModel
+): CustomNodeData {
     switch (entity.type) {
         case 'DEPLOYMENT':
-            return { ...entity, policyIds };
+            return { ...entity, policyIds, networkPolicyState: getNetworkPolicyState(policyNode) };
         case 'INTERNET':
             return { ...entity, type: 'EXTERNAL_ENTITIES' };
         case 'EXTERNAL_SOURCE':
@@ -43,7 +66,60 @@ export const graphModel = {
     layout: 'ColaGroups',
 };
 
-export function transformData(nodes: Node[]): CustomModel {
+function getNamespaceNode(namespace: string, deploymentId: string): NamespaceNodeModel {
+    const namespaceData: NamespaceData = {
+        collapsible: true,
+        showContextMenu: false,
+        type: 'NAMESPACE',
+    };
+    return {
+        id: namespace,
+        type: 'group',
+        children: [deploymentId],
+        group: true,
+        label: namespace,
+        style: { padding: 15 },
+        data: namespaceData,
+    };
+}
+
+function getExternalGroupNode(): ExternalNodeModel {
+    const externalGroupData: ExternalData = {
+        collapsible: true,
+        showContextMenu: false,
+        type: 'EXTERNAL',
+    };
+    return {
+        id: 'External to cluster',
+        type: 'group',
+        children: [],
+        group: true,
+        label: 'External to cluster',
+        style: { padding: 15 },
+        data: externalGroupData,
+    };
+}
+
+function getNodeModel(
+    entity: NetworkEntityInfo,
+    policyIds: string[],
+    policyNode?: PolicyNodeModel
+): CustomNodeModel {
+    const node = {
+        id: entity.id,
+        type: 'node',
+        width: 75,
+        height: 75,
+        label: getNameByEntity(entity),
+    } as CustomNodeModel;
+    node.data = getDataByEntityType(entity, policyIds, policyNode);
+    return node;
+}
+
+export function transformActiveData(
+    nodes: Node[],
+    policyNodeMap: Record<string, PolicyNodeModel>
+): CustomModel {
     const dataModel = {
         graph: graphModel,
         nodes: [] as CustomNodeModel[],
@@ -54,70 +130,39 @@ export function transformData(nodes: Node[]): CustomModel {
     let externalNode: ExternalNodeModel | null = null;
 
     nodes.forEach(({ entity, policyIds, outEdges }) => {
+        const { type, id } = entity;
         // creating each node and adding to data model
-        const node = {
-            id: entity.id,
-            type: 'node',
-            width: 75,
-            height: 75,
-            label: getNameByEntity(entity),
-            data: getDataByEntityType(entity, policyIds),
-        } as CustomNodeModel;
+        const node = getNodeModel(entity, policyIds, policyNodeMap[id]);
 
         dataModel.nodes.push(node);
 
         // to group deployments into namespaces
-        if (entity.type === 'DEPLOYMENT') {
+        if (type === 'DEPLOYMENT') {
             const { namespace } = entity.deployment;
             const namespaceNode = namespaceNodes[namespace];
             if (namespaceNode && namespaceNode?.children) {
-                namespaceNode?.children.push(entity.id);
+                namespaceNode?.children.push(id);
             } else {
-                const namespaceData: NamespaceData = {
-                    collapsible: true,
-                    showContextMenu: false,
-                    type: 'NAMESPACE',
-                };
-                namespaceNodes[namespace] = {
-                    id: namespace,
-                    type: 'group',
-                    children: [entity.id],
-                    group: true,
-                    label: namespace,
-                    style: { padding: 15 },
-                    data: namespaceData,
-                };
+                namespaceNodes[namespace] = getNamespaceNode(namespace, id);
             }
         }
 
         // to group external entities and cidr blocks to external grouping
-        if (entity.type === 'EXTERNAL_SOURCE' || entity.type === 'INTERNET') {
+        if (type === 'EXTERNAL_SOURCE' || type === 'INTERNET') {
             if (!externalNode) {
-                externalNode = {
-                    id: 'External to cluster',
-                    type: 'group',
-                    children: [],
-                    group: true,
-                    label: 'External to cluster',
-                    style: { padding: 15 },
-                    data: {
-                        type: 'EXTERNAL',
-                        collapsible: true,
-                        showContextMenu: false,
-                    },
-                };
+                externalNode = getExternalGroupNode();
             }
             if (externalNode && externalNode?.children) {
-                externalNode.children.push(entity.id);
+                externalNode.children.push(id);
             }
         }
 
         // creating edges based off of outEdges per node and adding to data model
         Object.keys(outEdges).forEach((nodeIdx) => {
             const edge = {
-                id: `${entity.id} ${nodes[nodeIdx].entity.id as string}`,
+                id: `${id} ${nodes[nodeIdx].entity.id as string}`,
                 type: 'edge',
-                source: entity.id,
+                source: id,
                 target: nodes[nodeIdx].entity.id,
                 visible: false,
             };
@@ -136,6 +181,141 @@ export function transformData(nodes: Node[]): CustomModel {
     return dataModel;
 }
 
-// export function transformExtraneousFlows(nodes: Node[]): Model {
+export function transformPolicyData(nodes: Node[]): CustomModel {
+    const dataModel = {
+        graph: graphModel,
+        nodes: [] as CustomNodeModel[],
+        edges: [] as EdgeModel[],
+    };
+    nodes.forEach(({ entity, policyIds, outEdges }) => {
+        const node = getNodeModel(entity, policyIds);
+        dataModel.nodes.push(node);
 
-// }
+        // creating edges based off of outEdges per node and adding to data model
+        Object.keys(outEdges).forEach((nodeIdx) => {
+            const edge = {
+                id: `${entity.id} ${nodes[nodeIdx].entity.id as string}`,
+                type: 'edge',
+                source: entity.id,
+                target: nodes[nodeIdx].entity.id,
+                visible: false,
+                edgeStyle: EdgeStyle.dashed,
+            };
+            dataModel.edges.push(edge);
+        });
+    });
+    return dataModel;
+}
+
+export function createExtraneousFlowsModel(
+    policyDataModel: CustomModel,
+    activeNodeMap: Record<string, CustomNodeModel>,
+    activeEdgeMap: Record<string, EdgeModel>
+): CustomModel {
+    const dataModel = {
+        graph: graphModel,
+        nodes: [] as CustomNodeModel[],
+        edges: [] as EdgeModel[],
+    };
+    const namespaceNodes: Record<string, NamespaceNodeModel> = {};
+    let externalNode: ExternalNodeModel | null = null;
+    // add all non-group nodes from the active graph
+    Object.values(activeNodeMap).forEach((node) => {
+        if (!node.group) {
+            dataModel.nodes.push(node);
+        }
+    });
+
+    // loop through each node in policy graph to see if it exists in the active graph
+    policyDataModel.nodes?.forEach((node) => {
+        // add to extraneous flows model when the node is not in the active graph
+        // and is not a group node in the policy graph
+        if (!activeNodeMap[node.id] && !node.group) {
+            dataModel.nodes.push(node);
+        }
+    });
+
+    // loop through each edge in policy graph to see if it exists in the active graph
+    policyDataModel.edges?.forEach((edge) => {
+        // only add to extraneous flows model when edge is not in the active graph
+        if (!activeEdgeMap[edge.id]) {
+            dataModel.edges.push(edge);
+        }
+    });
+
+    // TODO: need somewhere to check the currently selected node to see if it is nonIsolated ingress/egress
+    // and add the appropriate Egress flows or Ingress flows grouped node accordingly
+
+    // find namespace and external nodes
+    dataModel.nodes.forEach(({ data }) => {
+        const { type } = data;
+        // to group deployments into namespaces
+        if (type === 'DEPLOYMENT') {
+            const { deployment, id } = data;
+            const { namespace } = deployment;
+            const namespaceNode = namespaceNodes[namespace];
+            if (namespaceNode && namespaceNode?.children) {
+                namespaceNode?.children.push(id);
+            } else {
+                namespaceNodes[namespace] = getNamespaceNode(namespace, id);
+            }
+        }
+
+        // to group external entities and cidr blocks to external grouping
+        if (type === 'EXTERNAL_ENTITIES' || type === 'CIDR_BLOCK') {
+            if (!externalNode) {
+                externalNode = getExternalGroupNode();
+            }
+            if (externalNode && externalNode?.children) {
+                externalNode.children.push(data.id);
+            }
+        }
+    });
+
+    // add namespace nodes to data model
+    dataModel.nodes.push(...Object.values(namespaceNodes));
+
+    // add external group node to data model
+    if (externalNode) {
+        dataModel.nodes.push(externalNode);
+    }
+
+    return dataModel;
+}
+
+export function getExtraneousNodes(): {
+    extraneousEgressNode: ExtraneousNodeModel;
+    extraneousIngressNode: ExtraneousNodeModel;
+} {
+    const extraneousEgressNode: ExtraneousNodeModel = {
+        id: 'extraneous-egress',
+        type: 'node',
+        width: 75,
+        height: 75,
+        label: 'Egress flows',
+        group: true,
+        // TODO: figure out how to fake group node
+        children: [],
+        data: {
+            collapsible: false,
+            showContextMenu: false,
+            type: 'EXTRANEOUS',
+        },
+    };
+    const extraneousIngressNode: ExtraneousNodeModel = {
+        id: 'extraneous-ingress',
+        type: 'node',
+        width: 75,
+        height: 75,
+        label: 'Ingress flows',
+        group: true,
+        // TODO: figure out how to fake group node
+        children: [],
+        data: {
+            collapsible: false,
+            showContextMenu: false,
+            type: 'EXTRANEOUS',
+        },
+    };
+    return { extraneousEgressNode, extraneousIngressNode };
+}

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/modelUtils.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/modelUtils.tsx
@@ -283,7 +283,7 @@ export function createExtraneousFlowsModel(
     return dataModel;
 }
 
-export function getExtraneousNodes(): {
+export function createExtraneousNodes(): {
     extraneousEgressNode: ExtraneousNodeModel;
     extraneousIngressNode: ExtraneousNodeModel;
 } {

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/modelUtils.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/modelUtils.tsx
@@ -289,13 +289,13 @@ export function getExtraneousNodes(): {
 } {
     const extraneousEgressNode: ExtraneousNodeModel = {
         id: 'extraneous-egress',
-        type: 'node',
+        type: 'fakeGroup',
         width: 75,
         height: 75,
         label: 'Egress flows',
-        group: true,
         // TODO: figure out how to fake group node
-        children: [],
+        // group: true,
+        // children: [],
         data: {
             collapsible: false,
             showContextMenu: false,
@@ -304,13 +304,13 @@ export function getExtraneousNodes(): {
     };
     const extraneousIngressNode: ExtraneousNodeModel = {
         id: 'extraneous-ingress',
-        type: 'node',
+        type: 'fakeGroup',
         width: 75,
         height: 75,
         label: 'Ingress flows',
-        group: true,
         // TODO: figure out how to fake group node
-        children: [],
+        // group: true,
+        // children: [],
         data: {
             collapsible: false,
             showContextMenu: false,

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/modelUtils.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/modelUtils.tsx
@@ -135,3 +135,7 @@ export function transformData(nodes: Node[]): CustomModel {
 
     return dataModel;
 }
+
+// export function transformExtraneousFlows(nodes: Node[]): Model {
+
+// }


### PR DESCRIPTION
This will need to be rebased off of Saif's data structure PR, but it adds the extraneous flows graph logic, refactors some of the node/grouped node generating utils, and adds a new `fakeGroup` type to accommodate for the allowed in/egress flows node that appears for the extraneous flows graph when a node is selected. 

The `ingress flows` and `egress flows` will be added in a separate PR to incrementally add changes

<img width="907" alt="image" src="https://user-images.githubusercontent.com/10412893/205773651-499a1041-ad81-44e9-a790-9437b85c3f29.png">

active traffic w central selected: 
<img width="1440" alt="Screenshot 2022-12-05 at 4 10 51 PM" src="https://user-images.githubusercontent.com/10412893/205774003-ab9fa6e6-6451-4774-a41b-d3d7a4a26cab.png">

extraneous flows w central selected:
<img width="1427" alt="Screenshot 2022-12-05 at 4 11 30 PM" src="https://user-images.githubusercontent.com/10412893/205774017-7790ac65-48dd-41e7-8064-3a2c9547bb63.png">


