### PR TITLE
ROX-13593: Add telemetry options to central Helm chart

### DIFF
--- a/image/templates/helm/stackrox-central/internal/config-shape.yaml
+++ b/image/templates/helm/stackrox-central/internal/config-shape.yaml
@@ -19,7 +19,11 @@ ca:
   generate: null # bool
 additionalCAs: null # string | [string] | dict
 central:
-  disableTelemetry: null # bool
+  telemetry:
+    enabled: null # bool
+    storage:
+      endpoint: null # string
+      key: null # string
   config: null # string | dict
   dbConfig: null # string | dict
   endpointsConfig: null # string | dict

--- a/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml
+++ b/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml
@@ -96,8 +96,12 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        - name: ROX_INIT_TELEMETRY_ENABLED
-          value: {{ ._rox.central.disableTelemetry | not | quote }}
+        {{- if ._rox.central.telemetry.enabled }}
+        - name: ROX_TELEMETRY_ENDPOINT
+          value: {{ ._rox.central.telemetry.storage.endpoint | quote }}
+        - name: ROX_TELEMETRY_STORAGE_KEY_V1
+          value: {{ ._rox.central.telemetry.storage.key | quote }}
+        {{- end }}
         - name: ROX_OFFLINE_MODE
           value: {{ ._rox.env.offlineMode | quote }}
         {{- if and (eq ._rox.env.openshift 4) (not ._rox.env.managedServices) }}

--- a/image/templates/helm/stackrox-central/values-public.yaml.example.htpl
+++ b/image/templates/helm/stackrox-central/values-public.yaml.example.htpl
@@ -15,8 +15,6 @@
 # configuration:
 # - `image.registry`: if you are pulling images from a registry other than `stackrox.io`.
 # - `env.offlineMode`: if you want to run StackRox in offline mode.
-# - `central.disableTelemetry`: if you want to opt out of the transmission of telemetry and
-#   diagnostic data.
 # - `central.endpointsConfig`: if you want to expose additional endpoints (such as endpoints
 #   without TLS) in Central.
 # - `central.resources`: if the default resource configuration for Central is not adequate
@@ -90,10 +88,6 @@
 #
 # # Public configuration options for the StackRox Central deployment.
 # central:
-#   # disableTelemetry=true will opt out of transmitting telemetry data to StackRox.
-#   # This only has an effect upon initial deployment.
-#   disableTelemetry: false
-#
 #   # General configuration options for the Central deployment.
 #   # See the `config/central/config.yaml.default` file that is shipped with this chart
 #   # for a fully documented version.

--- a/image/templates/helm/stackrox-central/values.yaml.htpl
+++ b/image/templates/helm/stackrox-central/values.yaml.htpl
@@ -105,9 +105,12 @@
 #
 #central:
 #
-#  # Indicates whether telemetry data collection should be disabled. This defaults to true
-#  # in offline mode, and false otherwise. Only has an effect upon the first installation.
-#  disableTelemetry: null
+#  # Settings for telemetry data collection. Telemetry is disabled by default.
+#  telemetry:
+#    enabled: false
+#    storage:
+#      endpoint: null
+#      key: null
 #
 #
 #  config: "@config/central/config.yaml|config/central/config.yaml.default"

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/telemetry.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/telemetry.test.yaml
@@ -1,0 +1,25 @@
+defs: |
+  def container(obj; name):
+  obj.spec.template.spec.containers[] | select(.name == name);
+
+  def envVars(obj; container):
+  container(obj; container) | .env | from_entries;
+
+tests:
+  - name: Central telemetry should not be enabled by default
+    expect: |
+      envVars(.deployments.central; "central") | assertThat(has("ROX_TELEMETRY_STORAGE_KEY_V1") == false)
+
+  - name: Central telemetry should be enabled when enabled
+    set:
+      central.telemetry.enabled: true
+      central.telemetry.storage.key: "key"
+    expect: |
+      envVars(.deployments.central; "central")["ROX_TELEMETRY_STORAGE_KEY_V1"] | assertThat(. == "key")
+
+  - name: Central monitoring should be disabled when not enabled
+    set:
+      central.telemetry.enabled: false
+      central.telemetry.storage.key: "key"
+    expect: |
+      envVars(.deployments.central; "central") | assertThat(has("ROX_TELEMETRY_STORAGE_KEY_V1") == false)

--- a/pkg/renderer/helm_values.go
+++ b/pkg/renderer/helm_values.go
@@ -43,7 +43,11 @@ image:
 {{- end }}
 
 central:
-  disableTelemetry: {{ not .K8sConfig.EnableTelemetry }}
+  telemetry:
+    enabled: {{ .K8sConfig.Telemetry.Enabled }}
+    storage:
+      endpoint: {{ .K8sConfig.Telemetry.StorageEndpoint }}
+      key: {{ .K8sConfig.Telemetry.StorageKey }}
 
   {{- if ne (.GetConfigOverride "endpoints.yaml") "" }}
   endpointsConfig: |
@@ -108,7 +112,7 @@ central:
       {{ .HostPath.DB.NodeSelectorKey | quote }}: {{ .HostPath.DB.NodeSelectorValue | quote }}
     {{- end }}
     {{- end }}
-  
+
     {{- if .K8sConfig.ImageOverrides.CentralDB }}
     image:
       {{- if .K8sConfig.ImageOverrides.CentralDB.Registry }}
@@ -210,7 +214,7 @@ ca:
 
 {{- if ne (index .SecretsBase64Map "central-license") "" }}
 # StackRox license key
-licenseKey: | 
+licenseKey: |
   {{- index .SecretsBase64Map "central-license" | b64dec | nindent 2 }}
 {{- end }}
 
@@ -258,7 +262,7 @@ scanner:
   dbPassword:
     value: {{ index .SecretsBase64Map "scanner-db-password" | b64dec }}
   {{- end }}
- 
+
   {{- if ne (index .SecretsBase64Map "scanner-cert.pem") "" }}
   # Internal "scanner.stackrox.svc" service TLS certificate.
   serviceTLS:
@@ -297,7 +301,7 @@ ca:
 
 {{- if ne (index .SecretsBase64Map "central-license") "" }}
 # StackRox license key
-licenseKey: | 
+licenseKey: |
   {{- index .SecretsBase64Map "central-license" | b64dec | nindent 2 }}
 {{- end }}
 
@@ -360,7 +364,7 @@ scanner:
   dbPassword:
     value: {{ index .SecretsBase64Map "scanner-db-password" | b64dec }}
   {{- end }}
- 
+
   {{- if ne (index .SecretsBase64Map "scanner-cert.pem") "" }}
   # Internal "scanner.stackrox.svc" service TLS certificate.
   serviceTLS:

--- a/pkg/renderer/templater.go
+++ b/pkg/renderer/templater.go
@@ -65,6 +65,13 @@ type CommonConfig struct {
 	ScannerDBImage string
 }
 
+// TelemetryConfig contains config to set up the transimission of telemtry and diagnostic data.
+type TelemetryConfig struct {
+	Enabled         bool
+	StorageEndpoint string
+	StorageKey      string
+}
+
 // PersistenceType describes the type of persistence
 type PersistenceType string
 
@@ -85,6 +92,8 @@ func (m PersistenceType) String() string {
 // K8sConfig contains k8s fields
 type K8sConfig struct {
 	CommonConfig
+
+	Telemetry TelemetryConfig
 
 	// ImageFlavorName is the name of the flavor selected by the user with CLI parameters
 	ImageFlavorName string
@@ -110,8 +119,6 @@ type K8sConfig struct {
 	Command string
 
 	OfflineMode bool
-
-	EnableTelemetry bool
 
 	// IstioVersion is the version of Istio to render for (if any)
 	IstioVersion string

--- a/roxctl/central/generate/generate.go
+++ b/roxctl/central/generate/generate.go
@@ -198,12 +198,12 @@ func createBundle(logger logger.Logger, config renderer.Config) (*zip.Wrapper, e
 	if config.K8sConfig != nil {
 		config.Environment[env.OfflineModeEnv.EnvVar()] = strconv.FormatBool(config.K8sConfig.OfflineMode)
 
-		if config.K8sConfig.EnableTelemetry {
+		if config.K8sConfig.Telemetry.Enabled {
 			logger.InfofLn(`Unless run in offline mode,
  StackRox Kubernetes Security Platform collects and transmits aggregated usage and system health information.
   If you want to OPT OUT from this, re-generate the deployment bundle with the '--enable-telemetry=false' flag`)
 		}
-		config.Environment[env.InitialTelemetryEnabledEnv.EnvVar()] = strconv.FormatBool(config.K8sConfig.EnableTelemetry)
+		config.Environment[env.InitialTelemetryEnabledEnv.EnvVar()] = strconv.FormatBool(config.K8sConfig.Telemetry.Enabled)
 	}
 
 	config.SecretsByteMap["htpasswd"] = htpasswd

--- a/roxctl/central/generate/k8s.go
+++ b/roxctl/central/generate/k8s.go
@@ -103,7 +103,7 @@ func k8sBasedOrchestrator(cliEnvironment environment.Environment, k8sConfig *ren
 	flagWrap.StringVar(&k8sConfig.ScannerImage, flags.FlagNameScannerImage, "", "scanner image to use"+defaultImageHelp, "scanner")
 	flagWrap.StringVar(&k8sConfig.ScannerDBImage, flags.FlagNameScannerDBImage, "", "scanner-db image to use"+defaultImageHelp, "scanner")
 
-	flagWrap.BoolVar(&k8sConfig.EnableTelemetry, "enable-telemetry", true, "whether to enable telemetry", "central")
+	flagWrap.BoolVar(&k8sConfig.Telemetry.Enabled, "enable-telemetry", false, "whether to enable telemetry", "central")
 
 	k8sConfig.EnableCentralDB = env.PostgresDatastoreEnabled.BooleanSetting()
 

--- a/roxctl/helm/derivelocalvalues/derivelocalvalues.go
+++ b/roxctl/helm/derivelocalvalues/derivelocalvalues.go
@@ -266,8 +266,16 @@ func derivePublicLocalValuesForCentralServices(ctx context.Context, namespace st
 				"false") == "true",
 		},
 		"central": map[string]interface{}{
-			"disableTelemetry": k8s.evaluateToString(ctx, "deployment", "central",
-				`{.spec.template.spec.containers[?(@.name == "central")].env[?(@.name == "ROX_INIT_TELEMETRY_ENABLED")].value}`, "true") == "false",
+			"telemetry": map[string]interface{}{
+				"enabled": k8s.evaluateToString(ctx, "deployment", "central",
+					`{.spec.template.spec.containers[?(@.name == "central")].env[?(@.name == "ROX_TELEMETRY_STORAGE_KEY_V1")].value}`, "") != "",
+				"storage": map[string]interface{}{
+					"endpoint": k8s.evaluateToString(ctx, "deployment", "central",
+						`{.spec.template.spec.containers[?(@.name == "central")].env[?(@.name == "ROX_TELEMETRY_ENDPOINT")].value}`, ""),
+					"key": k8s.evaluateToString(ctx, "deployment", "central",
+						`{.spec.template.spec.containers[?(@.name == "central")].env[?(@.name == "ROX_TELEMETRY_STORAGE_KEY_V1")].value}`, ""),
+				},
+			},
 			"config":          k8s.evaluateToStringP(ctx, "configmap", "central-config", `{.data['central-config\.yaml']}`),
 			"dbConfig":        k8s.evaluateToStringP(ctx, "configmap", "central-db-connection", `{.data['central-db-connection\.yaml']}`),
 			"endpointsConfig": k8s.evaluateToStringP(ctx, "configmap", "central-endpoints", `{.data['endpoints\.yaml']}`),


### PR DESCRIPTION
## Description

The current telemetry implementation has been deprecated, but not removed from the code base as a whole. It will be replaced by a new telemetry implementation (see #3819). We are planning to use an installation toggle to give opt-in/opt-out of the new telemetry collection. If enabled, the installation sets up a telemetry storage key, which enables the collection within Central.

The current `disableTelemetry` flag is removed. The current telemetry data store and api are deprecated and will be removed later. The installation toggle will be the only way to enable/disable telemetry - even if that then requires rolling the central pod.

This PR sets up the following configuration for the new telemetry stack:
- A user facing boolean setting to enable/disable telemetry (`telemetry.enabled`).
- Two options to configure the telemetry storage backend (`telemetry.storage`). Initially, at least the storage key has to be provided manually to enable telemetry. Eventually, the storage will be hardcoded with a default value in the chart.

An addition to the central CRD for the operator installation method will follow.

Note that we are not planning to roll out telemetry to on-premise users at this time. Telemetry will initially be a feature only enabled for the ACS cloud service. However, we want to lay the config ground work for future a on-premise rollout.

We opted to not document the flags publicly to avoid confusion of on-prem users, for whom the telemetry options are currently ineffective. The current `disableTelemetry` flag is still part of upstream documentation (https://docs.openshift.com/acs/3.72/installing/installing_helm/install-helm-customization.html#central-services-public-configuration-file-central_acs-install-helm-customization) - this entry will be removed from the documentation.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] Evaluated and added CHANGELOG entry if required
- [ ] ~Determined and documented upgrade steps~
- [x] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.