### PR TITLE
ROX-13360: Create deployment query by service account on Sensor in-memory store

### DIFF
--- a/sensor/common/store/mocks/types.go
+++ b/sensor/common/store/mocks/types.go
@@ -52,6 +52,20 @@ func (mr *MockDeploymentStoreMockRecorder) BuildDeploymentWithDependencies(id, d
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildDeploymentWithDependencies", reflect.TypeOf((*MockDeploymentStore)(nil).BuildDeploymentWithDependencies), id, dependencies)
 }
 
+// FindDeploymentIDsWithServiceAccount mocks base method.
+func (m *MockDeploymentStore) FindDeploymentIDsWithServiceAccount(namespace, sa string) []string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindDeploymentIDsWithServiceAccount", namespace, sa)
+	ret0, _ := ret[0].([]string)
+	return ret0
+}
+
+// FindDeploymentIDsWithServiceAccount indicates an expected call of FindDeploymentIDsWithServiceAccount.
+func (mr *MockDeploymentStoreMockRecorder) FindDeploymentIDsWithServiceAccount(namespace, sa interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindDeploymentIDsWithServiceAccount", reflect.TypeOf((*MockDeploymentStore)(nil).FindDeploymentIDsWithServiceAccount), namespace, sa)
+}
+
 // Get mocks base method.
 func (m *MockDeploymentStore) Get(id string) *storage.Deployment {
 	m.ctrl.T.Helper()

--- a/sensor/common/store/resolver/resolver.go
+++ b/sensor/common/store/resolver/resolver.go
@@ -11,3 +11,25 @@ func ResolveDeploymentIds(ids ...string) DeploymentReference {
 		return ids
 	}
 }
+
+// ResolveDeploymentsByServiceAccount returns the deployments matching a certain service account
+func ResolveDeploymentsByServiceAccount(namespace, serviceAccount string) DeploymentReference {
+	return func(store store.DeploymentStore) []string {
+		return store.FindDeploymentsWithServiceAccount(namespace, serviceAccount)
+	}
+}
+
+type NamespaceServiceAccount struct {
+	Namespace, ServiceAccount string
+}
+
+// ResolveDeploymentsByMultipleServiceAccounts a
+func ResolveDeploymentsByMultipleServiceAccounts(serviceAccounts []NamespaceServiceAccount) DeploymentReference {
+	return func(store store.DeploymentStore) []string {
+		var allIds []string
+		for _, sa := range serviceAccounts {
+			allIds = append(allIds, store.FindDeploymentsWithServiceAccount(sa.Namespace, sa.ServiceAccount)...)
+		}
+		return allIds
+	}
+}

--- a/sensor/common/store/resolver/resolver.go
+++ b/sensor/common/store/resolver/resolver.go
@@ -12,23 +12,17 @@ func ResolveDeploymentIds(ids ...string) DeploymentReference {
 	}
 }
 
-// ResolveDeploymentsByServiceAccount returns the deployments matching a certain service account
-func ResolveDeploymentsByServiceAccount(namespace, serviceAccount string) DeploymentReference {
-	return func(store store.DeploymentStore) []string {
-		return store.FindDeploymentsWithServiceAccount(namespace, serviceAccount)
-	}
-}
-
+// NamespaceServiceAccount is a helper struct that represents an object that has both a Namespace and a Service Account.
 type NamespaceServiceAccount struct {
 	Namespace, ServiceAccount string
 }
 
-// ResolveDeploymentsByMultipleServiceAccounts a
+// ResolveDeploymentsByMultipleServiceAccounts returns a list of deployment IDs given a list of ServiceAccounts
 func ResolveDeploymentsByMultipleServiceAccounts(serviceAccounts []NamespaceServiceAccount) DeploymentReference {
 	return func(store store.DeploymentStore) []string {
 		var allIds []string
 		for _, sa := range serviceAccounts {
-			allIds = append(allIds, store.FindDeploymentsWithServiceAccount(sa.Namespace, sa.ServiceAccount)...)
+			allIds = append(allIds, store.FindDeploymentIDsWithServiceAccount(sa.Namespace, sa.ServiceAccount)...)
 		}
 		return allIds
 	}

--- a/sensor/common/store/types.go
+++ b/sensor/common/store/types.go
@@ -11,7 +11,7 @@ import (
 type DeploymentStore interface {
 	GetAll() []*storage.Deployment
 	Get(id string) *storage.Deployment
-	FindDeploymentsWithServiceAccount(namespace, sa string) []string
+	FindDeploymentIDsWithServiceAccount(namespace, sa string) []string
 	BuildDeploymentWithDependencies(id string, dependencies Dependencies) (*storage.Deployment, error)
 }
 

--- a/sensor/common/store/types.go
+++ b/sensor/common/store/types.go
@@ -11,6 +11,7 @@ import (
 type DeploymentStore interface {
 	GetAll() []*storage.Deployment
 	Get(id string) *storage.Deployment
+	FindDeploymentsWithServiceAccount(namespace, sa string) []string
 	BuildDeploymentWithDependencies(id string, dependencies Dependencies) (*storage.Deployment, error)
 }
 

--- a/sensor/kubernetes/listener/resources/deployment_store.go
+++ b/sensor/kubernetes/listener/resources/deployment_store.go
@@ -127,6 +127,19 @@ func (ds *DeploymentStore) GetAll() []*storage.Deployment {
 	return ret
 }
 
+func (ds *DeploymentStore) FindDeploymentsWithServiceAccount(namespace, sa string) []string {
+	ds.lock.RLock()
+	defer ds.lock.RUnlock()
+
+	var match []string
+	for id, wrap := range ds.deployments {
+		if wrap.GetServiceAccount() == sa && wrap.GetNamespace() == namespace {
+			match = append(match, id)
+		}
+	}
+	return match
+}
+
 func (ds *DeploymentStore) getWrap(id string) *deploymentWrap {
 	ds.lock.RLock()
 	defer ds.lock.RUnlock()

--- a/sensor/kubernetes/listener/resources/deployment_store.go
+++ b/sensor/kubernetes/listener/resources/deployment_store.go
@@ -127,7 +127,8 @@ func (ds *DeploymentStore) GetAll() []*storage.Deployment {
 	return ret
 }
 
-func (ds *DeploymentStore) FindDeploymentsWithServiceAccount(namespace, sa string) []string {
+// FindDeploymentIDsWithServiceAccount returns all deployment IDs in `namespace` that have ServiceAccountName matching `sa`.
+func (ds *DeploymentStore) FindDeploymentIDsWithServiceAccount(namespace, sa string) []string {
 	ds.lock.RLock()
 	defer ds.lock.RUnlock()
 


### PR DESCRIPTION
## Description

In order to process deployments on RBAC updates, sensor must be able to find all local deployments that match a service account that was updated. 

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

- CI
- New unit tests
