### PR TITLE
ROX-13023: Use database count rather than result count in postgres scoped access control context

### DIFF
--- a/pkg/sac/search_helper.go
+++ b/pkg/sac/search_helper.go
@@ -273,8 +273,17 @@ func (h *pgSearchHelper) executeCount(ctx context.Context, q *v1.Query, searcher
 		return searcher.Count(ctx, q)
 	}
 
-	results, err := h.executeSearch(ctx, q, searcher)
-	return len(results), err
+	resourceWithAccess := permissions.View(h.resourceMD)
+	effectiveAccessScope, err := scopeChecker.EffectiveAccessScope(resourceWithAccess)
+	if err != nil {
+		return 0, err
+	}
+	scopedQuery, err := h.enrichQueryWithSACFilter(effectiveAccessScope, q)
+	if err != nil {
+		return 0, err
+	}
+
+	return searcher.Count(ctx, scopedQuery)
 }
 
 // searchHelper implementations


### PR DESCRIPTION
## Description

So far, queries to the datastore to count items when the user has a limited access scope do perform a scoped search, and the response is the number of items returned by the search.
This has the drawback that scoped count queries generate unnecessary traffic between the datastore and the service layer.
The goal of this change is in postgres mode to let the database return only the number of items matching the requester scope rather than all items matching the requester scope and letting the application code count the returned items.

## Checklist
- [ ] Investigated and inspected CI test results
~~- [ ] Unit test and regression tests added~~
~~- [ ] Evaluated and added CHANGELOG entry if required~~
~~- [ ] Determined and documented upgrade steps~~
~~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

Scoped access control tests do cover the Count function in most datastores. A manual run of datastore tests for sample central subdirectories was done, and triggered the new code path.

CI should be sufficient.