### PR TITLE
ROX-13768: Avoid prow error highlights in IntegrationsSplunkViolationsTest

### DIFF
--- a/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
@@ -1775,7 +1775,10 @@ class Kubernetes implements OrchestratorMain {
 
             @Override
             void onExit(int code, Status s) {
-                log.debug("Command exited with $code - $s")
+                // Do not print the full status object here as it triggers prow
+                // error highlighting in CI. There is sufficient debug printed
+                // elsewhere.
+                log.debug("Command exited with $code")
                 switch (code) {
                     case 0:
                         status = ExecStatus.SUCCESS

--- a/qa-tests-backend/src/test/groovy/IntegrationsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/IntegrationsTest.groovy
@@ -102,7 +102,7 @@ class IntegrationsTest extends BaseSpecification {
             assert email["subject"] == "StackRox Test Email"
             assert email["from"][0]["address"] == Constants.EMAIL_NOTIFER_SENDER
             assert email["to"][0]["address"] == Constants.EMAIL_NOTIFIER_RECIPIENT
-            assert email["text"] == "This is a test email created to test integration with StackRox.\n\n"
+            assert email["text"] == "This is a test email crted to test integration with StackRox.\n\n"
 
             log.info "Found email with body:\n${email["text"]}"
         }

--- a/qa-tests-backend/src/test/groovy/IntegrationsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/IntegrationsTest.groovy
@@ -102,7 +102,7 @@ class IntegrationsTest extends BaseSpecification {
             assert email["subject"] == "StackRox Test Email"
             assert email["from"][0]["address"] == Constants.EMAIL_NOTIFER_SENDER
             assert email["to"][0]["address"] == Constants.EMAIL_NOTIFIER_RECIPIENT
-            assert email["text"] == "This is a test email crted to test integration with StackRox.\n\n"
+            assert email["text"] == "This is a test email created to test integration with StackRox.\n\n"
 
             log.info "Found email with body:\n${email["text"]}"
         }


### PR DESCRIPTION
## Description

This PR drops the status dump in the `onExit()` handler for `execInContainerByPodName()`. This will stop `exit status 7` from causing a highlighted log line in IntegrationsSplunkViolationsTest which is not a test failure and can be confusing.

I initially tried to sanitize the log message but the regex on the prow side is permissive and hard to avoid: https://github.com/openshift/release/blob/de819389443e8bbc64a38a943366aa7bd5bf7a8f/core-services/prow/02_config/_config.yaml#L91 (the `.*` is a bug for OSCI). For our purposes though there is no real value in the status dump so it is easiest to skip and move on.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

- [x] Force a failure in a different test and the splunk failure message should be missing. https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/stackrox_stackrox/4038/pull-ci-stackrox-stackrox-master-gke-qa-e2e-tests/1600244557033771008 - the connect error still occurs in the test and appears in the build log but is not highlighted