### PR TITLE
fix autogenerated image integration insecure setting

### DIFF
--- a/central/sensor/service/pipeline/imageintegrations/pipeline.go
+++ b/central/sensor/service/pipeline/imageintegrations/pipeline.go
@@ -172,13 +172,12 @@ func setUpIntegrationParams(ctx context.Context, imageIntegration *storage.Image
 		dockerCfg := config.Docker
 		validTLS, tlsErr := tlscheck.CheckTLS(ctx, dockerCfg.GetEndpoint())
 		if tlsErr != nil {
-			log.Debugf("reaching out for TLS check to %s: %v", dockerCfg.GetEndpoint(), err)
+			log.Debugf("reaching out for TLS check to %s: %v", dockerCfg.GetEndpoint(), tlsErr)
 			// Not enough evidence that we can skip TLS, so conservatively require it.
 			dockerCfg.Insecure = false
 		} else {
 			dockerCfg.Insecure = !validTLS
 		}
-		dockerCfg.Insecure = !validTLS
 		dockerCfg.Endpoint = parseEndpointForURL(dockerCfg.GetEndpoint())
 		description = dockerCfg.GetEndpoint()
 		matches = matchesDockerAuth


### PR DESCRIPTION
## Description

`dockerCfg.Insecure` is either set to `!validTLS` or `false` before this, but then we set it again to `!validTLS`. This removes that line. The multiple `dockerCfg.Insecure` settings were introduced in https://github.com/stackrox/stackrox/pull/2572. That PR  wanted to set `dockerCfg.Insecure = false` when `tlsErr != nil`, but it set it to `dockerCfg.Insecure = !validTLS = true` (since `validTLS = false` when `tlsErr != nil`).

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

CI
