### PR TITLE
ROX-13782: Fix Compliance crash with operator standards

### DIFF
--- a/ui/apps/platform/src/queries/standard.js
+++ b/ui/apps/platform/src/queries/standard.js
@@ -93,7 +93,10 @@ export const LIST_STANDARD_NO_NODES = gql`
 `;
 
 export const COMPLIANCE_STANDARDS = (standardId) => gql`
-    query complianceStandards_${standardId}($groupBy: [ComplianceAggregation_Scope!], $where: String) {
+    query complianceStandards_${standardId.replace(
+        /\W/g,
+        '_'
+    )}($groupBy: [ComplianceAggregation_Scope!], $where: String) {
         complianceStandards {
             id
             name


### PR DESCRIPTION
## Description

The Compliance Operator standards,
* ocp4-cis
* opc4-cis-node
* opc4-high

were causing a crash when their GraphQL queries were parsed on the Compliance section dashboard.

This change sanitizes those query names, and replaces all non-word characters with underscores, `_`.


## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

Manual testing

Here is the non-crashing dashboard, which includes those operator standards.
<img width="1546" alt="Screen Shot 2022-12-06 at 8 53 57 PM" src="https://user-images.githubusercontent.com/715729/206069393-39f4ef17-bde5-4987-8fd2-022d360a0a81.png">
