### PR TITLE
GHA: improve message to upstream release engineer after running finish-release

### DIFF
--- a/.github/workflows/finish-release.yml
+++ b/.github/workflows/finish-release.yml
@@ -128,10 +128,13 @@ jobs:
 
             { "type": "section", "text": { "type": "mrkdwn", "text":
             ":${{ fromJSON('["desert", "white_check_mark"]')[github.event.inputs.dry-run != 'true'] }}:
-            *<${{ steps.release.outputs.url }} | ${{ inputs.version }}> of <${{github.server_url}}/${{github.repository}}|${{github.repository}}> has been published on GitHub.*" }},
+            *Release <${{ steps.release.outputs.url }} | ${{ inputs.version }}> of <${{github.server_url}}/${{github.repository}}|${{github.repository}}> has been published on GitHub.*" }},
 
             { "type": "section", "text": { "type": "mrkdwn", "text":
-            ":arrow_right: Look for a CI generated PR created in <https://github.com/stackrox/release-artifacts/pulls|stackrox/release-artifacts> repository
-            and confirm that members of the @release-publishers Slack group got notified about
-            it.\n\n:arrow_right: Let's trigger the downstream release!" }}
+            ":arrow_right: Tell the downstream release engineer to trigger the downstream release,
+            and once the downstream release is complete, merge the PR created by CI in
+            <https://github.com/stackrox/release-artifacts/pulls|stackrox/release-artifacts>
+            repository." }},
+            { "type": "section", "text": { "type": "mrkdwn", "text":
+            ":arrow_right: Check the status of the upstream CI for the release tag in <https://prow.ci.openshift.org/?repo=stackrox%2Fstackrox&job=*release-${{ needs.variables.outputs.release }}*|Openshift CI> and follow up on any failures." }}
             ]}


### PR DESCRIPTION
## Description

Cherry-pick from 
* https://github.com/stackrox/test-gh-actions/pull/79
* https://github.com/stackrox/test-gh-actions/pull/80

The updated message should make the order of events for triggering downstream and merging the `release-artifacts` PR clearer. Also reminds them to follow the Openshift CI jobs for the release tag, as there may be flakes or other issues, e.g. in pushing the images, creating the `release-artifacts` PR etc.

## Testing Performed

No testable changes.