### PR TITLE
Fix whitespace below collection attacher table

### DIFF
--- a/ui/apps/platform/src/Containers/Collections/CollectionsFormPage.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionsFormPage.tsx
@@ -161,7 +161,6 @@ function CollectionsFormPage({
                         ) : null}
                     </Flex>
                 ),
-                width: 25,
             },
             {
                 name: 'Description',


### PR DESCRIPTION
## Description

As title. 

I wasn't able to quickly determine _why_ this was happening, but the fix was easy without ill effects. This shifts the layout of the name cell in the table a bit back and forth between desktop/mobile views which seems to have very minor pros/cons between the two.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Before change:
<img width="500" alt="image" src="https://user-images.githubusercontent.com/1292638/206255578-688436fe-f9f8-4600-a440-bda0a2eafeb5.png">
<img width="300" alt="image" src="https://user-images.githubusercontent.com/1292638/206255687-b83f4755-9151-4e00-9441-f9349c9408b5.png">

After change:
<img width="500" alt="image" src="https://user-images.githubusercontent.com/1292638/206255853-18bb50a8-b156-417f-9ed3-1da4f09abd5a.png">
<img width="300" alt="image" src="https://user-images.githubusercontent.com/1292638/206255950-d8546cb2-c04e-49f6-af28-64b69e8c3c51.png">

