### PR TITLE
ROX-13786: Use SAC search helper FilteredSearcher and associated Search and Count functions instead of Apply and ApplyCount

### DIFF
--- a/central/processbaseline/search/searcher_impl.go
+++ b/central/processbaseline/search/searcher_impl.go
@@ -67,9 +67,9 @@ func (s *searcherImpl) SearchRawProcessBaselines(ctx context.Context, q *v1.Quer
 		err     error
 	)
 	if env.PostgresDatastoreEnabled.BooleanSetting() {
-		results, err = deploymentExtensionPostgresSACSearchHelper.Apply(s.indexer.Search)(ctx, q)
+		results, err = deploymentExtensionPostgresSACSearchHelper.FilteredSearcher(s.indexer).Search(ctx, q)
 	} else {
-		results, err = deploymentExtensionSACSearchHelper.Apply(s.indexer.Search)(ctx, q)
+		results, err = deploymentExtensionSACSearchHelper.FilteredSearcher(s.indexer).Search(ctx, q)
 	}
 	if err != nil || len(results) == 0 {
 		return nil, err

--- a/central/processindicator/search/searcher_impl.go
+++ b/central/processindicator/search/searcher_impl.go
@@ -37,15 +37,15 @@ func (s *searcherImpl) SearchRawProcessIndicators(ctx context.Context, q *v1.Que
 
 func (s *searcherImpl) Search(ctx context.Context, q *v1.Query) ([]search.Result, error) {
 	if env.PostgresDatastoreEnabled.BooleanSetting() {
-		return deploymentExtensionSACPostgresSearchHelper.Apply(s.indexer.Search)(ctx, q)
+		return deploymentExtensionSACPostgresSearchHelper.FilteredSearcher(s.indexer).Search(ctx, q)
 	}
-	return deploymentExtensionSACSearchHelper.Apply(s.indexer.Search)(ctx, q)
+	return deploymentExtensionSACSearchHelper.FilteredSearcher(s.indexer).Search(ctx, q)
 }
 
 // Count returns the number of search results from the query
 func (s *searcherImpl) Count(ctx context.Context, q *v1.Query) (int, error) {
 	if env.PostgresDatastoreEnabled.BooleanSetting() {
-		return deploymentExtensionSACPostgresSearchHelper.ApplyCount(s.indexer.Count)(ctx, q)
+		return deploymentExtensionSACPostgresSearchHelper.FilteredSearcher(s.indexer).Count(ctx, q)
 	}
-	return deploymentExtensionSACSearchHelper.ApplyCount(s.indexer.Count)(ctx, q)
+	return deploymentExtensionSACSearchHelper.FilteredSearcher(s.indexer).Count(ctx, q)
 }

--- a/central/rbac/k8srole/datastore/datastore_sac_test.go
+++ b/central/rbac/k8srole/datastore/datastore_sac_test.go
@@ -198,6 +198,35 @@ func (s *k8sRoleSACSuite) runSearchTest(c testutils.SACSearchTestCase) {
 	testutils.ValidateSACSearchResultDistribution(&s.Suite, c.Results, resultCounts)
 }
 
+func (s *k8sRoleSACSuite) runCountTest(c testutils.SACSearchTestCase) {
+	ctx := s.testContexts[c.ScopeKey]
+	count, err := s.datastore.Count(ctx, nil)
+	s.Require().NoError(err)
+	expectedCount := 0
+	for _, clusterData := range c.Results {
+		for _, namespaceItemCount := range clusterData {
+			expectedCount += namespaceItemCount
+		}
+	}
+	s.Equal(expectedCount, count)
+}
+
+func (s *k8sRoleSACSuite) TestScopedCount() {
+	for name, c := range testutils.GenericScopedSACSearchTestCases(s.T()) {
+		s.Run(name, func() {
+			s.runCountTest(c)
+		})
+	}
+}
+
+func (s *k8sRoleSACSuite) TestUnrestrictedCount() {
+	for name, c := range testutils.GenericUnrestrictedRawSACSearchTestCases(s.T()) {
+		s.Run(name, func() {
+			s.runCountTest(c)
+		})
+	}
+}
+
 func (s *k8sRoleSACSuite) TestScopedSearch() {
 	for name, c := range testutils.GenericScopedSACSearchTestCases(s.T()) {
 		s.Run(name, func() {

--- a/central/rbac/k8srole/search/searcher_impl.go
+++ b/central/rbac/k8srole/search/searcher_impl.go
@@ -69,18 +69,18 @@ func (ds *searcherImpl) searchRoles(ctx context.Context, q *v1.Query) ([]*storag
 
 func (ds *searcherImpl) getSearchResults(ctx context.Context, q *v1.Query) ([]search.Result, error) {
 	if env.PostgresDatastoreEnabled.BooleanSetting() {
-		return k8sRolesSACPgSearchHelper.Apply(ds.indexer.Search)(ctx, q)
+		return k8sRolesSACPgSearchHelper.FilteredSearcher(ds.indexer).Search(ctx, q)
 	}
 
-	return k8sRolesSACSearchHelper.Apply(ds.indexer.Search)(ctx, q)
+	return k8sRolesSACSearchHelper.FilteredSearcher(ds.indexer).Search(ctx, q)
 }
 
 func (ds *searcherImpl) getCountResults(ctx context.Context, q *v1.Query) (int, error) {
 	if env.PostgresDatastoreEnabled.BooleanSetting() {
-		return k8sRolesSACPgSearchHelper.ApplyCount(ds.indexer.Count)(ctx, q)
+		return k8sRolesSACPgSearchHelper.FilteredSearcher(ds.indexer).Count(ctx, q)
 	}
 
-	return k8sRolesSACSearchHelper.ApplyCount(ds.indexer.Count)(ctx, q)
+	return k8sRolesSACSearchHelper.FilteredSearcher(ds.indexer).Count(ctx, q)
 }
 
 func convertMany(roles []*storage.K8SRole, results []search.Result) []*v1.SearchResult {

--- a/central/rbac/k8srolebinding/datastore/datastore_sac_test.go
+++ b/central/rbac/k8srolebinding/datastore/datastore_sac_test.go
@@ -199,6 +199,35 @@ func (s *k8sRoleBindingSACSuite) runSearchTest(c testutils.SACSearchTestCase) {
 	testutils.ValidateSACSearchResultDistribution(&s.Suite, c.Results, resultCounts)
 }
 
+func (s *k8sRoleBindingSACSuite) runCountTest(c testutils.SACSearchTestCase) {
+	ctx := s.testContexts[c.ScopeKey]
+	count, err := s.datastore.Count(ctx, nil)
+	s.Require().NoError(err)
+	expectedCount := 0
+	for _, clusterData := range c.Results {
+		for _, namespaceItemCount := range clusterData {
+			expectedCount += namespaceItemCount
+		}
+	}
+	s.Equal(expectedCount, count)
+}
+
+func (s *k8sRoleBindingSACSuite) TestScopedCount() {
+	for name, c := range testutils.GenericScopedSACSearchTestCases(s.T()) {
+		s.Run(name, func() {
+			s.runCountTest(c)
+		})
+	}
+}
+
+func (s *k8sRoleBindingSACSuite) TestUnrestrictedCount() {
+	for name, c := range testutils.GenericUnrestrictedRawSACSearchTestCases(s.T()) {
+		s.Run(name, func() {
+			s.runCountTest(c)
+		})
+	}
+}
+
 func (s *k8sRoleBindingSACSuite) TestScopedSearch() {
 	for name, c := range testutils.GenericScopedSACSearchTestCases(s.T()) {
 		s.Run(name, func() {

--- a/central/rbac/k8srolebinding/search/searcher_impl.go
+++ b/central/rbac/k8srolebinding/search/searcher_impl.go
@@ -39,17 +39,17 @@ func (ds *searcherImpl) SearchRoleBindings(ctx context.Context, q *v1.Query) ([]
 // Search returns the raw search results from the query.
 func (ds *searcherImpl) Search(ctx context.Context, q *v1.Query) ([]search.Result, error) {
 	if env.PostgresDatastoreEnabled.BooleanSetting() {
-		return k8sRoleBindingsSACPostgresSearchHelper.Apply(ds.index.Search)(ctx, q)
+		return k8sRoleBindingsSACPostgresSearchHelper.FilteredSearcher(ds.index).Search(ctx, q)
 	}
-	return k8sRoleBindingsSACSearchHelper.Apply(ds.index.Search)(ctx, q)
+	return k8sRoleBindingsSACSearchHelper.FilteredSearcher(ds.index).Search(ctx, q)
 }
 
 // Count returns the number of search results from the query.
 func (ds *searcherImpl) Count(ctx context.Context, q *v1.Query) (int, error) {
 	if env.PostgresDatastoreEnabled.BooleanSetting() {
-		return k8sRoleBindingsSACPostgresSearchHelper.ApplyCount(ds.index.Count)(ctx, q)
+		return k8sRoleBindingsSACPostgresSearchHelper.FilteredSearcher(ds.index).Count(ctx, q)
 	}
-	return k8sRoleBindingsSACSearchHelper.ApplyCount(ds.index.Count)(ctx, q)
+	return k8sRoleBindingsSACSearchHelper.FilteredSearcher(ds.index).Count(ctx, q)
 }
 
 // SearchRawRoleBindings returns the rolebindings that match the query.

--- a/central/serviceaccount/datastore/datastore_sac_test.go
+++ b/central/serviceaccount/datastore/datastore_sac_test.go
@@ -229,6 +229,35 @@ func (s *serviceAccountSACSuite) runSearchTest(c testutils.SACSearchTestCase) {
 	testutils.ValidateSACSearchResultDistribution(&s.Suite, c.Results, resultCounts)
 }
 
+func (s *serviceAccountSACSuite) runCountTest(c testutils.SACSearchTestCase) {
+	ctx := s.testContexts[c.ScopeKey]
+	count, err := s.datastore.Count(ctx, nil)
+	s.Require().NoError(err)
+	expectedCount := 0
+	for _, clusterData := range c.Results {
+		for _, namespaceResultCount := range clusterData {
+			expectedCount += namespaceResultCount
+		}
+	}
+	s.Equal(expectedCount, count)
+}
+
+func (s *serviceAccountSACSuite) TestScopedCount() {
+	for name, c := range testutils.GenericScopedSACSearchTestCases(s.T()) {
+		s.Run(name, func() {
+			s.runCountTest(c)
+		})
+	}
+}
+
+func (s *serviceAccountSACSuite) TestUnrestrictedCount() {
+	for name, c := range testutils.GenericUnrestrictedRawSACSearchTestCases(s.T()) {
+		s.Run(name, func() {
+			s.runCountTest(c)
+		})
+	}
+}
+
 func (s *serviceAccountSACSuite) TestScopedSearch() {
 	for name, c := range testutils.GenericScopedSACSearchTestCases(s.T()) {
 		s.Run(name, func() {

--- a/central/serviceaccount/search/searcher_impl.go
+++ b/central/serviceaccount/search/searcher_impl.go
@@ -58,16 +58,16 @@ func (ds *searcherImpl) Count(ctx context.Context, q *v1.Query) (int, error) {
 
 func (ds *searcherImpl) getSearchResults(ctx context.Context, q *v1.Query) ([]search.Result, error) {
 	if env.PostgresDatastoreEnabled.BooleanSetting() {
-		return serviceAccountsSACPostgresSearchHelper.Apply(ds.indexer.Search)(ctx, q)
+		return serviceAccountsSACPostgresSearchHelper.FilteredSearcher(ds.indexer).Search(ctx, q)
 	}
-	return serviceAccountsSACSearchHelper.Apply(ds.indexer.Search)(ctx, q)
+	return serviceAccountsSACSearchHelper.FilteredSearcher(ds.indexer).Search(ctx, q)
 }
 
 func (ds *searcherImpl) getCount(ctx context.Context, q *v1.Query) (int, error) {
 	if env.PostgresDatastoreEnabled.BooleanSetting() {
-		return serviceAccountsSACPostgresSearchHelper.ApplyCount(ds.indexer.Count)(ctx, q)
+		return serviceAccountsSACPostgresSearchHelper.FilteredSearcher(ds.indexer).Count(ctx, q)
 	}
-	return serviceAccountsSACSearchHelper.ApplyCount(ds.indexer.Count)(ctx, q)
+	return serviceAccountsSACSearchHelper.FilteredSearcher(ds.indexer).Count(ctx, q)
 }
 
 func (ds *searcherImpl) searchServiceAccounts(ctx context.Context, q *v1.Query) ([]*storage.ServiceAccount, []search.Result, error) {

--- a/pkg/sac/tests/search_helper_test.go
+++ b/pkg/sac/tests/search_helper_test.go
@@ -35,7 +35,7 @@ func fakeResult(id, cluster, namespace string) search.Result {
 	}
 }
 
-func TestSearchHelper_TestApply_WithFilter(t *testing.T) {
+func TestSearchHelper_TestFilteredSearch_WithFilter(t *testing.T) {
 	options := search.OptionsMapFromMap(v1.SearchCategory_DEPLOYMENTS, map[search.FieldLabel]*search.Field{
 		search.ClusterID: {
 			FieldPath: "cluster_id",
@@ -59,6 +59,10 @@ func TestSearchHelper_TestApply_WithFilter(t *testing.T) {
 			fakeResult("6", "cluster3", "nsB"),
 		}, nil
 	}
+	mockSearcher := blevesearch.UnsafeSearcherImpl{
+		SearchFunc: mockSearchFunc,
+		CountFunc:  nil,
+	}
 
 	h, err := sac.NewSearchHelper(testNSResource, options, sac.ForResource(testNSResource).ScopeChecker)
 	require.NoError(t, err)
@@ -77,14 +81,14 @@ func TestSearchHelper_TestApply_WithFilter(t *testing.T) {
 
 	ctx := sac.WithGlobalAccessScopeChecker(context.Background(), scc)
 
-	searchResults, err := h.Apply(mockSearchFunc)(ctx, search.EmptyQuery())
+	searchResults, err := h.FilteredSearcher(mockSearcher).Search(ctx, search.EmptyQuery())
 	require.NoError(t, err)
 
 	resultIDs := search.ResultsToIDs(searchResults)
 	assert.ElementsMatch(t, resultIDs, []string{"1", "2", "3"})
 }
 
-func TestSearchHelper_TestApply_WithAllAccess(t *testing.T) {
+func TestSearchHelper_TestFilteredSearch_WithAllAccess(t *testing.T) {
 	options := search.OptionsMapFromMap(v1.SearchCategory_DEPLOYMENTS, map[search.FieldLabel]*search.Field{
 		search.ClusterID: {
 			FieldPath: "cluster_id",
@@ -108,6 +112,10 @@ func TestSearchHelper_TestApply_WithAllAccess(t *testing.T) {
 			fakeResult("6", "cluster3", "nsB"),
 		}, nil
 	}
+	mockSearcher := blevesearch.UnsafeSearcherImpl{
+		SearchFunc: mockSearchFunc,
+		CountFunc:  nil,
+	}
 
 	h, err := sac.NewSearchHelper(testNSResource, options, sac.ForResource(testNSResource).ScopeChecker)
 	require.NoError(t, err)
@@ -116,7 +124,7 @@ func TestSearchHelper_TestApply_WithAllAccess(t *testing.T) {
 
 	ctx := sac.WithGlobalAccessScopeChecker(context.Background(), scc)
 
-	searchResults, err := h.Apply(mockSearchFunc)(ctx, search.EmptyQuery())
+	searchResults, err := h.FilteredSearcher(mockSearcher).Search(ctx, search.EmptyQuery())
 	require.NoError(t, err)
 	resultIDs := search.ResultsToIDs(searchResults)
 	assert.ElementsMatch(t, resultIDs, []string{"1", "2", "3", "4", "5", "6"})


### PR DESCRIPTION
## Description

The SAC Search helper ApplyCount function can panic in scoped context.
This change deprecates and removes this function in favour of other SAC helper utilities.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
~~- [ ] Evaluated and added CHANGELOG entry if required~~
~~- [ ] Determined and documented upgrade steps~~
~~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

CI should be enough