### PR TITLE
Use quay.io in scanner tests

### DIFF
--- a/qa-tests-backend/src/test/groovy/ImageManagementTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageManagementTest.groovy
@@ -88,13 +88,13 @@ class ImageManagementTest extends BaseSpecification {
 
         imageTag               | expected
         "nginx-1.19-alpine"    | "alpine:v3.13"
-        "busybox-1-30"         | "busybox:1.30.0"
+        "busybox-1-30"         | "busybox:1.30.1"
         "centos7-base"         | "centos:7"
         // We explicitly do not support Fedora at this time.
         FEDORA_28              | "unknown"
-        "docker-io-nginx-1-10" | "debian:8"
-        "docker-io-nginx-1-12" | "debian:9"
-        "ubi9-slf4j"           | "rhel:9.0"
+        "nginx-1-9"            | "debian:8"
+        "nginx-1-17-1"         | "debian:9"
+        "ubi9-slf4j"           | "rhel:9"
         "apache-server"        | "ubuntu:14.04"
         "ubuntu-22.10-openssl" | "ubuntu:22.10"
     }

--- a/qa-tests-backend/src/test/groovy/ImageManagementTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageManagementTest.groovy
@@ -80,7 +80,7 @@ class ImageManagementTest extends BaseSpecification {
     @Category(BAT)
     def "Verify image scan finds correct base OS - #qaImageTag"() {
         when:
-        def img = Services.scanImage("quay.io/rhacs-eng/qa:$imageTag")
+        def img = Services.scanImage("quay.io/rhacs-eng/qa:$qaImageTag")
         then:
         assert img.scan.operatingSystem == expected
         where:

--- a/qa-tests-backend/src/test/groovy/ImageManagementTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageManagementTest.groovy
@@ -78,7 +78,7 @@ class ImageManagementTest extends BaseSpecification {
 
     @Unroll
     @Category(BAT)
-    def "Verify image scan finds correct base OS - #imageTag"() {
+    def "Verify image scan finds correct base OS - #qaImageTag"() {
         when:
         def img = Services.scanImage("quay.io/rhacs-eng/qa:$imageTag")
         then:
@@ -86,7 +86,7 @@ class ImageManagementTest extends BaseSpecification {
         where:
         "Data inputs are: "
 
-        imageTag               | expected
+        qaImageTag             | expected
         "nginx-1.19-alpine"    | "alpine:v3.13"
         "busybox-1-30"         | "busybox:1.30.1"
         "centos7-base"         | "centos:7"

--- a/qa-tests-backend/src/test/groovy/ImageManagementTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageManagementTest.groovy
@@ -15,6 +15,8 @@ import util.Env
 
 class ImageManagementTest extends BaseSpecification {
 
+    String FEDORA_28 = "fedora-6fb84ba634fe68572a2ac99741062695db24b921d0aa72e61ee669902f88c187"
+
     @Unroll
     @Category([BAT, Integration])
     def "Verify CI/CD Integration Endpoint - #policy - #imageRegistry #note"() {
@@ -76,24 +78,25 @@ class ImageManagementTest extends BaseSpecification {
 
     @Unroll
     @Category(BAT)
-    def "Verify image scan finds correct base OS - #imageName"() {
+    def "Verify image scan finds correct base OS - #imageTag"() {
         when:
-        def img = Services.scanImage(imageRegistry + "/" + imageRemote + ":" + imageTag)
+        def img = Services.scanImage("quay.io/rhacs-eng/qa" + ":" + imageTag)
         then:
         assert img.scan.operatingSystem == expected
         where:
         "Data inputs are: "
 
-        imageName               | imageRegistry | imageRemote       | imageTag         | expected
-        "alpine:3.10.0"         | "docker.io"   | "library/alpine"  | "3.10.0"         | "alpine:v3.10"
-        "busybox:1.32.0"        | "docker.io"   | "library/busybox" | "1.32.0"         | "busybox:1.32.0"
-        "centos:centos8.2.2004" | "docker.io"   | "library/centos"  | "centos8.2.2004" | "centos:8"
+        imageTag               | expected
+        "nginx-1.19-alpine"    | "alpine:v3.13"
+        "busybox-1-30"         | "busybox:1.30.0"
+        "centos7-base"         | "centos:7"
         // We explicitly do not support Fedora at this time.
-        "fedora:33"             | "docker.io"   | "library/fedora"  | "33"             | "unknown"
-        "nginx:1.10"            | "docker.io"   | "library/nginx"   | "1.10"           | "debian:8"
-        "nginx:1.19"            | "docker.io"   | "library/nginx"   | "1.19"           | "debian:10"
-        // TODO: Add check for RHEL
-        "ubuntu:14.04"          | "docker.io"   | "library/ubuntu"  | "14.04"          | "ubuntu:14.04"
+        FEDORA_28              | "unknown"
+        "docker-io-nginx-1-10" | "debian:8"
+        "docker-io-nginx-1-12" | "debian:9"
+        "ubi9-slf4j"           | "rhel:9.0"
+        "apache-server"        | "ubuntu:14.04"
+        "ubuntu-22.10-openssl" | "ubuntu:22.10"
     }
 
     @Unroll

--- a/qa-tests-backend/src/test/groovy/ImageManagementTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageManagementTest.groovy
@@ -15,7 +15,7 @@ import util.Env
 
 class ImageManagementTest extends BaseSpecification {
 
-    String FEDORA_28 = "fedora-6fb84ba634fe68572a2ac99741062695db24b921d0aa72e61ee669902f88c187"
+    private static final String FEDORA_28 = "fedora-6fb84ba634fe68572a2ac99741062695db24b921d0aa72e61ee669902f88c187"
 
     @Unroll
     @Category([BAT, Integration])
@@ -80,7 +80,7 @@ class ImageManagementTest extends BaseSpecification {
     @Category(BAT)
     def "Verify image scan finds correct base OS - #imageTag"() {
         when:
-        def img = Services.scanImage("quay.io/rhacs-eng/qa" + ":" + imageTag)
+        def img = Services.scanImage("quay.io/rhacs-eng/qa:$imageTag")
         then:
         assert img.scan.operatingSystem == expected
         where:


### PR DESCRIPTION
## Description

We should not use docker.io as we can get rate limited. This PR changes some images to use their quay.io alternatives.
### Refs: 
- f1b2e7223d001ae6e9b887ccc4957c45fd20abf8
- https://github.com/stackrox/stackrox/pull/2683/files/dd5a91b0b735fe76821a65f1b587523dcda8940b#r1005612645

## Testing Performed

CI