### PR TITLE
ROX-13531: Stop pushing docs

### DIFF
--- a/scripts/ci/jobs/push-images.sh
+++ b/scripts/ci/jobs/push-images.sh
@@ -52,9 +52,6 @@ push_images() {
             push_matching_collector_scanner_images "$brand"
         fi
     fi
-    if [[ -n "${PIPELINE_DOCS_IMAGE:-}" ]]; then
-        push_docs_image
-    fi
     if [[ -n "${MAIN_RCD_IMAGE:-}" ]]; then
         push_race_condition_debug_image
     fi

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -352,26 +352,6 @@ push_operator_image_set() {
     done
 }
 
-push_docs_image() {
-    info "Pushing the docs image: $PIPELINE_DOCS_IMAGE"
-
-    if ! is_OPENSHIFT_CI; then
-        die "Only supported in OpenShift CI"
-    fi
-
-    oc registry login
-    local docs_tag
-    docs_tag="$(make --quiet docs-tag)"
-
-    local registries=("quay.io/rhacs-eng" "quay.io/stackrox-io")
-
-    for registry in "${registries[@]}"; do
-        registry_rw_login "$registry"
-        oc_image_mirror "$PIPELINE_DOCS_IMAGE" "${registry}/docs:$docs_tag"
-        oc_image_mirror "$PIPELINE_DOCS_IMAGE" "${registry}/docs:$(make --quiet tag)"
-    done
-}
-
 push_race_condition_debug_image() {
     info "Pushing the -race image: $MAIN_RCD_IMAGE"
 


### PR DESCRIPTION
## Description

Per ROX-12465/ROX-13531, standalone docs images are no longer required.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient - build should still pass.
