### PR TITLE
ROX-13764 Added error check for invalid charecters in syslog hostname

### DIFF
--- a/central/notifiers/syslog/syslog_test.go
+++ b/central/notifiers/syslog/syslog_test.go
@@ -243,3 +243,32 @@ func (s *SyslogNotifierTestSuite) TestAlerts() {
 	s.mockSender.EXPECT().SendSyslog(gomock.Any()).Return(nil)
 	s.Require().NoError(syslog.AlertNotify(context.Background(), testAlert))
 }
+
+func (s *SyslogNotifierTestSuite) TestValidateRemoteConfig() {
+	tcpConfig := &storage.Syslog_TCPConfig{
+		Hostname:      "google.com",
+		Port:          66666666,
+		SkipTlsVerify: true,
+		UseTls:        true,
+	}
+	_, errPort := validateRemoteConfig(tcpConfig)
+	s.Error(errPort)
+
+	tcpConfigExtraSpace := &storage.Syslog_TCPConfig{
+		Hostname:      "10.46.152.34 ",
+		Port:          514,
+		SkipTlsVerify: true,
+		UseTls:        true,
+	}
+	_, errURL := validateRemoteConfig(tcpConfigExtraSpace)
+	s.Error(errURL)
+
+	tcpConfigValidIP := &storage.Syslog_TCPConfig{
+		Hostname:      "10.46.152.34",
+		Port:          514,
+		SkipTlsVerify: true,
+		UseTls:        true,
+	}
+	_, errURLValidIP := validateRemoteConfig(tcpConfigValidIP)
+	s.NoError(errURLValidIP)
+}

--- a/central/notifiers/syslog/tcp_sender.go
+++ b/central/notifiers/syslog/tcp_sender.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net"
+	"net/url"
 	"strconv"
 	"sync/atomic"
 	"time"
@@ -82,7 +83,17 @@ func validateRemoteConfig(endpointConfig *storage.Syslog_TCPConfig) (string, err
 		return "", errors.Errorf("invalid port number %d must be between 1 and 65535", port)
 	}
 
-	return fmt.Sprintf("%s:%d", endpointConfig.GetHostname(), endpointConfig.GetPort()), nil
+	hostName := fmt.Sprintf("%s:%d", endpointConfig.GetHostname(), endpointConfig.GetPort())
+
+	sysURL := fmt.Sprintf("tcp://%s", hostName)
+
+	_, err := url.ParseRequestURI(sysURL)
+
+	if err != nil {
+		return "", errors.New("invalid host name")
+	}
+
+	return hostName, nil
 }
 
 func (s *tcpSender) dialWithRetry() (net.Conn, error) {


### PR DESCRIPTION
This PR adds a check to valid hostname has valid character. If user saves syslog notifier with invalid ip/hostname like extra space character then  api throws an error.
<img width="1028" alt="Screenshot 2022-12-12 at 4 28 25 PM" src="https://user-images.githubusercontent.com/8596931/207197848-d38fcbcb-0ef2-4077-b9f5-156c7db959f2.png">

Testing Performed
All CI e2e tests passed
Added new unit tests
Manually tested adding new syslog with invalid hostname. see screenshot attached
