### PR TITLE
Fix turbo build image generation

### DIFF
--- a/image/rhel/create-bundle.sh
+++ b/image/rhel/create-bundle.sh
@@ -109,7 +109,7 @@ fi
 if [[ "${DATA_IMAGE}" != "local" ]]; then
   # Extract data from data container image
   mkdir -p "${bundle_root}/stackrox/static-data/"
-  extract_from_image "${DATA_IMAGE}" "/stackrox-data" "${bundle_root}/stackrox/static-data/"
+  extract_from_image "${DATA_IMAGE}" "/stackrox-data/." "${bundle_root}/stackrox/static-data/"
   extract_from_image "${BUILDER_IMAGE}" "/usr/local/bin/ldb" "${bundle_root}/usr/local/bin/ldb"
 else
   cp -a "/stackrox-data" "${bundle_root}/stackrox/static-data/"


### PR DESCRIPTION
## Description

When using GHA bundle data are incorectly copied to wrong directory.
This PR fixes this by using `dir/.` idiom of `cp`.


### Refs: 
- #1333
- https://askubuntu.com/questions/86822/how-can-i-copy-the-contents-of-a-folder-to-another-folder-in-a-different-directo

## Testing Performed

CI
