### PR TITLE
Upgrade cypress 12.0.2 devDependencies in ui

### DIFF
--- a/ui/apps/platform/package.json
+++ b/ui/apps/platform/package.json
@@ -134,7 +134,7 @@
         "@types/react-redux": "^7.1.20",
         "autoprefixer": "^10.2.5",
         "babel-eslint": "^10.1.0",
-        "cypress": "^12.0.1",
+        "cypress": "^12.0.2",
         "eslint": "^7.32.0",
         "eslint-config-airbnb": "^18.2.1",
         "eslint-config-airbnb-typescript": "12.3.1",

--- a/ui/apps/platform/package.json
+++ b/ui/apps/platform/package.json
@@ -134,7 +134,7 @@
         "@types/react-redux": "^7.1.20",
         "autoprefixer": "^10.2.5",
         "babel-eslint": "^10.1.0",
-        "cypress": "^11.2.0",
+        "cypress": "^12.0.1",
         "eslint": "^7.32.0",
         "eslint-config-airbnb": "^18.2.1",
         "eslint-config-airbnb-typescript": "12.3.1",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -7327,10 +7327,10 @@ cyclist@^1.0.1:
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
 
-cypress@^12.0.1:
-  version "12.0.1"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-12.0.1.tgz#3a51a38b2f162256c7226e68e902cfe1750e3d92"
-  integrity sha512-I1Ag5RsPEINfUlQtV6xwkd6ktJuu5QGiKZ3pFa/IXjcyCY6I7CH3gOz0juLOhg/LXOPrQtZH35ulcWDQohyyEA==
+cypress@^12.0.2:
+  version "12.0.2"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-12.0.2.tgz#0437abf9d97ad4a972ab554968d58211b0ce4ae5"
+  integrity sha512-WnLx1DpnbF1vbpDBkgP14rK5yS3U+Gvxrv2fsB4Owma26oIyENj7DDRnsJbSZuTfG4mcuUJxAkRHJR2wBqBfMA==
   dependencies:
     "@cypress/request" "^2.88.10"
     "@cypress/xvfb" "^1.2.4"

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -7327,10 +7327,10 @@ cyclist@^1.0.1:
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
 
-cypress@^11.2.0:
-  version "11.2.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-11.2.0.tgz#63edef8c387b687066c5493f6f0ad7b9ced4b2b7"
-  integrity sha512-u61UGwtu7lpsNWLUma/FKNOsrjcI6wleNmda/TyKHe0dOBcVjbCPlp1N6uwFZ0doXev7f/91YDpU9bqDCFeBLA==
+cypress@^12.0.1:
+  version "12.0.1"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-12.0.1.tgz#3a51a38b2f162256c7226e68e902cfe1750e3d92"
+  integrity sha512-I1Ag5RsPEINfUlQtV6xwkd6ktJuu5QGiKZ3pFa/IXjcyCY6I7CH3gOz0juLOhg/LXOPrQtZH35ulcWDQohyyEA==
   dependencies:
     "@cypress/request" "^2.88.10"
     "@cypress/xvfb" "^1.2.4"


### PR DESCRIPTION
## Description

Upgrade promptly to get baseline on current CI to compare with future improvements.

### Resouces

https://docs.cypress.io/guides/references/changelog#12-0-0

1. Cypress has always recommended writing tests in a clean context. In Cypress 12, we enforce running tests in a clean browser context through **test isolation**. This option is configurable, but is **enabled by default**. Whether enabled or disabled, this changes how Cypress cleans up the browser context before each test and you may experience test errors with this upgrade.

2. Additionally in this release, enhancements were made to how Cypress manages DOM element resolution to reduce the likelihood of hitting detached DOM errors due to maintaining stale DOM references. We've updated our Retry-ability Guide with all the details if you'd like to learn more.

3. The `cy.server()` and `cy.route()` commands have been removed.

4. Cypress now throws an error if any Cypress commands are invoked from inside a `.should()` callback. This previously resulted in unusual and undefined behavior.

5. The `cy.request()` command now uses `querystringify` to stringify & parse the `qs` options. This change aligns with how the `cy.visit()` command generates urls with query parameters.

https://docs.cypress.io/guides/references/migration-guide#Migrating-to-Cypress-12-0

1. The `testIsolation` config option is enabled by default. This means Cypress resets the browser context *before* each test by:

    * clearing the dom state by visiting `about:blank`
    * clearing `cookies` in all domains
    * clearing `localStorage` in all domains
    * clearing `sessionStorage` in all domains

2. Cypress always re-queries aliases when they are referenced. This can result in certain tests that used to pass could start to fail.

https://docs.cypress.io/guides/core-concepts/retry-ability

Good information, although same behavior as in previous versions:

1. While all methods you chain off of `cy` in your Cypress tests are commands, there are some different types of commands it's important to understand: **queries**, **assertions** and **actions** have special rules about retryability.

2. Queries and assertions are always executed in order, and always retry 'from the top'. If you have multiple assertions, Cypress will retry until each passes before moving on to the next one.

3. Only queries can be retried, but most other commands still have built-in *waiting*.

4. By default each command that retries does so for up to 4 seconds - the `defaultCommandTimeout` setting.

5. We do not recommend changing the command timeout globally. Instead, pass the individual command's `{ timeout: ms }` option to retry for a different period of time

6. Any command that isn't a query, such as `cy.click()`, follows different rules than queries do. Cypress will retry any queries leading up to a command, and retry any assertions after a command, but commands themselves never retry - nor does anything leading up to them after they've resolved.

7. Actions should be at the end of chains, not the middle.

https://docs.cypress.io/guides/references/changelog#12-0-2

1. Fixed a regression in 12.0.0 where `.contains()` received multiple elements as a subject, it only searched inside the first one.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed