### PR TITLE
ROX-13351: Use an image tagged as latest in quay.io/rhacs-eng for DefaultPoliciesTest

### DIFF
--- a/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
@@ -85,7 +85,7 @@ class DefaultPoliciesTest extends BaseSpecification {
     static final private List<Deployment> DEPLOYMENTS = [
         new Deployment()
             .setName (NGINX_LATEST)
-            .setImage ("quay.io/rhacs-eng/qa:latest") // this is docker.io/redis:7.0.8-alpine but tagged as latest
+            .setImage ("quay.io/rhacs-eng/qa:latest") // this is docker.io/nginx:1.22-alpine but tagged as latest
             .addPort (22)
             .addLabel ("app", "test")
             .setEnv([SECRET: 'true']),

--- a/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
@@ -85,7 +85,7 @@ class DefaultPoliciesTest extends BaseSpecification {
     static final private List<Deployment> DEPLOYMENTS = [
         new Deployment()
             .setName (NGINX_LATEST)
-            .setImage ("nginx")
+            .setImage ("quay.io/rhacs-eng/qa:latest") // this is docker.io/redis:7.0.8-alpine but tagged as latest
             .addPort (22)
             .addLabel ("app", "test")
             .setEnv([SECRET: 'true']),


### PR DESCRIPTION
## Description

Grabbed a nginx image (nginx:1.22-alpine) and tagged it as qa:latest. This prevents rate limiting or slow down from docker.io from impacting these tests

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

this is a test

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
