### PR TITLE
ROX-13819: Recreate groups bucket

### DIFF
--- a/migrator/migrations/m_112_to_m_113_recreate_groups_bucket/migration.go
+++ b/migrator/migrations/m_112_to_m_113_recreate_groups_bucket/migration.go
@@ -1,0 +1,150 @@
+package m112tom113
+
+import (
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/migrator/log"
+	"github.com/stackrox/rox/migrator/migrations"
+	"github.com/stackrox/rox/migrator/types"
+	"github.com/stackrox/rox/pkg/errorhelpers"
+	bolt "go.etcd.io/bbolt"
+)
+
+type groupEntry struct {
+	key   []byte
+	value []byte
+}
+
+var (
+	bucketName = []byte("groups2")
+
+	migration = types.Migration{
+		StartingSeqNum: 112,
+		VersionAfter:   &storage.Version{SeqNum: 113},
+		Run: func(databases *types.Databases) error {
+			return recreateGroupsBucket(databases.BoltDB)
+		},
+	}
+)
+
+func init() {
+	migrations.MustRegisterMigration(migration)
+}
+
+func recreateGroupsBucket(db *bolt.DB) error {
+	// Short-circuit if the bucket does not exist.
+	exists, err := checkGroupBucketExists(db)
+	if err != nil {
+		return errors.Wrap(err, "error checking if groups bucket exists")
+	}
+	if !exists {
+		log.WriteToStderr("groups bucket did not exist, hence no re-creation of the groups bucket was done.")
+		return nil
+	}
+
+	groupEntries, err := fetchGroupsBucket(db)
+	if err != nil {
+		return errors.Wrap(err, "error fetching groups to remove")
+	}
+
+	// Drop the bucket.
+	if err := dropGroupsBucket(db); err != nil {
+		return errors.Wrap(err, "error dropping groups bucket")
+	}
+
+	// Create groups bucket and filter out invalid entries.
+	if err := createGroupsBucket(db, groupEntries); err != nil {
+		return errors.Wrap(err, "error recreating groups bucket")
+	}
+
+	return nil
+}
+
+func fetchGroupsBucket(db *bolt.DB) (groupEntries []groupEntry, err error) {
+	err = db.View(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket(bucketName)
+		// We previously checked that the bucket should be available, but still add this check here.
+		if bucket == nil {
+			return nil
+		}
+		return bucket.ForEach(func(k, v []byte) error {
+			groupEntries = append(groupEntries, groupEntry{key: k, value: v})
+			return nil
+		})
+	})
+	if err != nil {
+		return nil, err
+	}
+	return groupEntries, nil
+}
+
+func dropGroupsBucket(db *bolt.DB) error {
+	return db.Update(func(tx *bolt.Tx) error {
+		return tx.DeleteBucket(bucketName)
+	})
+}
+
+func createGroupsBucket(db *bolt.DB, groupEntries []groupEntry) (err error) {
+	err = db.Update(func(tx *bolt.Tx) error {
+		// Explicitly use the CreateBucket here instead of CreateBucketIfNotExists, as we require the bucket to be
+		// previously dropped.
+		bucket, err := tx.CreateBucket(bucketName)
+		if err != nil {
+			return err
+		}
+
+		var putGroupErrs errorhelpers.ErrorList
+		for _, entry := range groupEntries {
+			// By now, we can assume that the key will be a UUID and the value will be the group proto message.
+			// Here, we will check that the key will be a string and can be parsed as a UUID.
+			// If that's the case, the entry is valid, and we will add it to the re-created bucket.
+			// If not, we will log the invalid entry that will be dropped.
+			if !checkIfIDIsSet(entry.key) {
+				log.WriteToStderrf("Invalid group entry found in groups bucket (key=%s, value=%s). This entry"+
+					" will be dropped.",
+					entry.key, entry.value)
+				continue
+			}
+
+			if err := bucket.Put(entry.key, entry.value); err != nil {
+				putGroupErrs.AddError(err)
+			}
+		}
+
+		return putGroupErrs.ToError()
+	})
+	return err
+}
+
+func checkGroupBucketExists(db *bolt.DB) (exists bool, err error) {
+	exists = true
+	err = db.View(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket(bucketName)
+		if bucket == nil {
+			exists = false
+		}
+		return nil
+	})
+	return exists, err
+}
+
+const (
+	// Value has been taken from:
+	//	https://github.com/stackrox/stackrox/blob/master/central/group/datastore/validate.go#L13
+	groupIDPrefix = "io.stackrox.authz.group."
+	// Value has been taken from:
+	//	https://github.com/stackrox/stackrox/blob/master/migrator/migrations/m_105_to_m_106_group_id/migration.go#L134
+	groupMigratedIDPrefix = "io.stackrox.authz.group.migrated."
+)
+
+func checkIfIDIsSet(key []byte) bool {
+	stringKey := string(key)
+
+	if !strings.HasPrefix(stringKey, groupIDPrefix) && !strings.HasPrefix(stringKey, groupMigratedIDPrefix) {
+		return false
+	}
+
+	return true
+}

--- a/migrator/migrations/m_112_to_m_113_recreate_groups_bucket/migration_test.go
+++ b/migrator/migrations/m_112_to_m_113_recreate_groups_bucket/migration_test.go
@@ -95,6 +95,12 @@ func (suite *recreateGroupsBucketMigrationTestSuite) TestMigrate() {
 				value: []byte(""),
 			},
 		},
+		"invalid-group-stored-by-id": {
+			entry: groupEntry{
+				key:   []byte(existingGroup.GetProps().GetId() + "make-it-unique"),
+				value: rawInvalidGroup,
+			},
+		},
 		"invalid-bytes": {
 			entry: groupEntry{
 				key:   []byte("some-random-bytes-no-one-knows"),

--- a/migrator/migrations/m_112_to_m_113_recreate_groups_bucket/migration_test.go
+++ b/migrator/migrations/m_112_to_m_113_recreate_groups_bucket/migration_test.go
@@ -91,8 +91,8 @@ func (suite *recreateGroupsBucketMigrationTestSuite) TestMigrate() {
 		},
 		"invalid-group": {
 			entry: groupEntry{
-				key:   rawInvalidGroup,
-				value: []byte(""),
+				key:   []byte("some-random-key"),
+				value: rawInvalidGroup,
 			},
 		},
 		"invalid-group-stored-by-id": {
@@ -141,13 +141,12 @@ func (suite *recreateGroupsBucketMigrationTestSuite) TestMigrate() {
 			// In case the entry should not exist, it shouldn't be possible to retrieve any values from the given key.
 			if !c.existsAfterMigration {
 				suite.Empty(bucket.Get(c.entry.key))
-				continue
+			} else {
+				// In case the entry should exist, it should match the expected value.
+				value := bucket.Get(c.entry.key)
+				suite.NotEmpty(value)
+				suite.Equal(c.entry.value, value)
 			}
-
-			// In case the entry should exist, it should match the expected value.
-			value := bucket.Get(c.entry.key)
-			suite.NotEmpty(value)
-			suite.Equal(c.entry.value, value)
 		}
 		return nil
 	})

--- a/migrator/migrations/m_112_to_m_113_recreate_groups_bucket/migration_test.go
+++ b/migrator/migrations/m_112_to_m_113_recreate_groups_bucket/migration_test.go
@@ -1,0 +1,162 @@
+package m112tom113
+
+import (
+	"testing"
+
+	"github.com/gogo/protobuf/proto"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/migrator/bolthelpers"
+	"github.com/stackrox/rox/pkg/testutils"
+	"github.com/stackrox/rox/pkg/uuid"
+	"github.com/stretchr/testify/suite"
+	bolt "go.etcd.io/bbolt"
+)
+
+func TestMigration(t *testing.T) {
+	suite.Run(t, new(recreateGroupsBucketMigrationTestSuite))
+}
+
+type recreateGroupsBucketMigrationTestSuite struct {
+	suite.Suite
+
+	db *bolt.DB
+}
+
+func (suite *recreateGroupsBucketMigrationTestSuite) SetupTest() {
+	db, err := bolthelpers.NewTemp(testutils.DBFileName(suite))
+	suite.Require().NoError(err, "failed to make BoltDB")
+	suite.db = db
+}
+
+func (suite *recreateGroupsBucketMigrationTestSuite) TearDownTest() {
+	testutils.TearDownDB(suite.db)
+}
+
+func (suite *recreateGroupsBucketMigrationTestSuite) TestMigrate() {
+	// existingGroup should not be dropped during re-creation.
+	existingGroup := &storage.Group{
+		Props: &storage.GroupProperties{
+			Id:             "io.stackrox.authz.group." + uuid.NewV4().String(),
+			AuthProviderId: "some-value",
+		},
+		RoleName: "some-value",
+	}
+	rawExistingGroup, err := proto.Marshal(existingGroup)
+	suite.NoError(err)
+
+	// migratedGroup should not be dropped during re-creation.
+	migratedGroup := &storage.Group{
+		Props: &storage.GroupProperties{
+			Id:             "io.stackrox.authz.group.migrated." + uuid.NewV4().String(),
+			AuthProviderId: "some-value",
+		},
+		RoleName: "some-value",
+	}
+	rawMigratedGroup, err := proto.Marshal(migratedGroup)
+	suite.NoError(err)
+
+	// invalidGroup should be dropped during re-creation.
+	invalidGroup := &storage.Group{
+		Props: &storage.GroupProperties{
+			Key: "some-value",
+		},
+		RoleName: "",
+	}
+	rawInvalidGroup, err := proto.Marshal(invalidGroup)
+	suite.NoError(err)
+
+	// The following cases represent the entries within the groups bucket _before_ migration.
+	// After migration, note that:
+	// - existing-group should not have been dropped, due to having an ID.
+	// - migrated-group should not have been dropped, due to having an ID.
+	// - invalid-group should have been dropped, due to no ID.
+	// - invalid-bytes should have been dropped, due to some weird data and no group proto message.
+	cases := map[string]struct {
+		entry                groupEntry
+		existsAfterMigration bool
+	}{
+		"existing-group": {
+			entry: groupEntry{
+				key:   []byte(existingGroup.GetProps().GetId()),
+				value: rawExistingGroup,
+			},
+			existsAfterMigration: true,
+		},
+		"migrated-group": {
+			entry: groupEntry{
+				key:   []byte(migratedGroup.GetProps().GetId()),
+				value: rawMigratedGroup,
+			},
+			existsAfterMigration: true,
+		},
+		"invalid-group": {
+			entry: groupEntry{
+				key:   rawInvalidGroup,
+				value: []byte(""),
+			},
+		},
+		"invalid-bytes": {
+			entry: groupEntry{
+				key:   []byte("some-random-bytes-no-one-knows"),
+				value: []byte("some-other-random-bytes"),
+			},
+		},
+	}
+
+	var expectedEntriesAfterMigration int
+	for _, c := range cases {
+		if c.existsAfterMigration {
+			expectedEntriesAfterMigration++
+		}
+	}
+
+	// 1. Migration should succeed if the bucket does not exist.
+	suite.NoError(recreateGroupsBucket(suite.db))
+
+	// 2. Add the groups to the groups bucket before running the migration.
+	err = suite.db.Update(func(tx *bolt.Tx) error {
+		bucket, err := tx.CreateBucketIfNotExists(bucketName)
+		suite.NoError(err)
+		for _, c := range cases {
+			suite.NoError(bucket.Put(c.entry.key, c.entry.value))
+		}
+		return nil
+	})
+	suite.NoError(err)
+
+	// 3. Run the migration to re-create the groups bucket and remove invalid entries.
+	suite.NoError(recreateGroupsBucket(suite.db))
+
+	// 4. Verify that all entries are as expected.
+	err = suite.db.View(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket(bucketName)
+
+		for _, c := range cases {
+			// In case the entry should not exist, it shouldn't be possible to retrieve any values from the given key.
+			if !c.existsAfterMigration {
+				suite.Empty(bucket.Get(c.entry.key))
+				continue
+			}
+
+			// In case the entry should exist, it should match the expected value.
+			value := bucket.Get(c.entry.key)
+			suite.NotEmpty(value)
+			suite.Equal(c.entry.value, value)
+		}
+		return nil
+	})
+	suite.NoError(err)
+
+	// 5. Verify that the entries count matches.
+	var actualEntriesCount int
+	err = suite.db.View(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket(bucketName)
+
+		return bucket.ForEach(func(k, v []byte) error {
+			actualEntriesCount++
+			return nil
+		})
+	})
+	suite.NoError(err)
+	suite.Equal(expectedEntriesAfterMigration, actualEntriesCount)
+}

--- a/migrator/runner/all.go
+++ b/migrator/runner/all.go
@@ -14,6 +14,7 @@ import (
 	_ "github.com/stackrox/rox/migrator/migrations/m_109_to_m_110_networkpolicy_guidance_2"
 	_ "github.com/stackrox/rox/migrator/migrations/m_110_to_m_111_replace_deprecated_resources"
 	_ "github.com/stackrox/rox/migrator/migrations/m_111_to_m_112_groups_invalid_values"
+	_ "github.com/stackrox/rox/migrator/migrations/m_112_to_m_113_recreate_groups_bucket"
 	_ "github.com/stackrox/rox/migrator/migrations/m_55_to_m_56_node_scanning_empty"
 	_ "github.com/stackrox/rox/migrator/migrations/m_56_to_m_57_compliance_policy_categories"
 	_ "github.com/stackrox/rox/migrator/migrations/m_57_to_m_58_update_run_secrets_volume_policy_regex"

--- a/pkg/migrations/internal/seq_num.go
+++ b/pkg/migrations/internal/seq_num.go
@@ -4,7 +4,7 @@ var (
 	// CurrentDBVersionSeqNum is the current DB version number.
 	// This must be incremented every time we write a migration.
 	// It is a shared constant between central and the migrator binary.
-	CurrentDBVersionSeqNum = 112
+	CurrentDBVersionSeqNum = 113
 	// PostgresDBVersionPlus is the current DB version number with Postgres DB data migration.
 	PostgresDBVersionPlus = 56
 )


### PR DESCRIPTION
## Description

We currently run into an issue [ROX-13819](https://issues.redhat.com/browse/ROX-13819) where we are observing invalid group entries.

While there has been [another attempt in creating a migration for that](https://github.com/stackrox/stackrox/pull/3789). it turns out the specific bucket of the customer was not migrated properly.

The current reasons for this are unknown.

Now, to ensure we start with a clean bucket, we have agreed on doing the following:
- Read all the bucket entries in-memory (since the groups store is a low-frequent and volume store, this should be of no concern).
- Drop the groups bucket.
- Re-create the groups bucket with the key-value pairs hold in-memory. If it cannot be determined that the key is a ID belonging to a group, the entry will be dropped and logged.

This way, we ensure we are reinstating a clean groups bucket after this migration.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

```
1. Create a prior instance (e.g. 3.73.0 release) _without_ postgres enabled.
2. Create a couple of groups.
roxcurl /v1/groups -X POST -d '{"roleName": "", "props": {"authProviderId": "something", "key": "somewhere", "value":"somehow"}}'

roxcurl /v1/groups
{"groups":[{"props":{"id":"io.stackrox.authz.group.340a6739-4b5c-4bef-b229-a7755b621593","traits":null,"authProviderId":"something","key":"somewhere","value":"somehow"},"roleName":"abc"},{"props":{"id":"io.stackrox.authz.group.37817f74-8b68-47a9-b7e3-b326739c4b96","traits":null,"authProviderId":"a779715b-d696-4c6d-ae9b-3aaf953554ff","key":"name","value":"aa"},"roleName":"Sensor Creator"},{"props":{"id":"io.stackrox.authz.group.3fe77b94-01aa-41ea-b6e5-d42dd8606451","traits":null,"authProviderId":"a779715b-d696-4c6d-ae9b-3aaf953554ff","key":"","value":""},"roleName":"Admin"},{"props":{"id":"io.stackrox.authz.group.7e6d645a-ba75-445e-9402-6fbfbb743912","traits":null,"authProviderId":"a779715b-d696-4c6d-ae9b-3aaf953554ff","key":"groups","value":"adsadasd"},"roleName":"Sensor Creator"},{"props":{"id":"io.stackrox.authz.group.ab329ef5-29be-4bcd-859d-062303455574","traits":null,"authProviderId":"a779715b-d696-4c6d-ae9b-3aaf953554ff","key":"userid","value":"asdasdasdasdasd"},"roleName":"Analyst"},{"props":{"id":"io.stackrox.authz.group.be588a60-1cd7-4704-85f9-190bd69b1a1d","traits":null,"authProviderId":"a779715b-d696-4c6d-ae9b-3aaf953554ff","key":"groups","value":"asdqweqeqweqw"},"roleName":"Vulnerability Management Approver"},{"props":{"id":"io.stackrox.authz.group.c6eda2df-479d-437a-a958-c95a197f2d0d","traits":null,"authProviderId":"a779715b-d696-4c6d-ae9b-3aaf953554ff","key":"userid","value":"123123123123"},"roleName":"Analyst"},{"props":{"id":"io.stackrox.authz.group.e32849f3-2be7-4914-b53a-a36d369464b4","traits":null,"authProviderId":"a779715b-d696-4c6d-ae9b-3aaf953554ff","key":"email","value":"someone@somewhere"},"roleName":"Vulnerability Management Approver"}]}

roxcurl /v1/groups | jq -r '.groups | length'                                                                                                                                                                                                                                                                        
8

4. Upgrade to the current version which includes the migration.
5. Observe within the logs that the migration for sequence 113 is executed:
Migrator: 2022/12/08 21:44:56.923080 log.go:18: Info: Run migrator.run() with version: 3.73.x-188-ge0a6c74774, DB sequence: 113
Migrator: 2022/12/08 21:44:56.923511 log.go:18: Info: conf.Maintenance.ForceRollbackVersion: none
pkg/migrations: 2022/12/08 21:44:56.923987 migration_version.go:58: Info: Migration version of database at /var/lib/stackrox/current: &{/var/lib/stackrox/current 3.73.0 112 0001-01-01 00:00:00 +0000 UTC}
clone/rocksdb: 2022/12/08 21:44:56.924136 db_clone_manager_impl.go:66: Info: Found clone current -> .db-init
clone/rocksdb: 2022/12/08 21:44:56.924223 db_clone_manager_impl.go:124: Info: Database clones:
clone/rocksdb: 2022/12/08 21:44:56.924275 db_clone_manager_impl.go:126: Info: current -> &{/var/lib/stackrox/current 3.73.0 112 0001-01-01 00:00:00 +0000 UTC}
pkg/migrations: 2022/12/08 21:44:56.931565 migration_version.go:58: Info: Migration version of database at /var/lib/stackrox/.db-46ce3067-d797-49f2-9909-1efb6b7c9b04: &{/var/lib/stackrox/.db-46ce3067-d797-49f2-9909-1efb6b7c9b04 3.73.0 112 0001-01-01 00:00:00 +0000 UTC}
Migrator: 2022/12/08 21:44:56.931671 log.go:18: Info: Clone to Migrate "temp", ""
Migrator: 2022/12/08 21:44:56.931720 log.go:13: Info: starting DB compaction
Migrator: 2022/12/08 21:44:56.931865 log.go:18: Info: Free fraction of 0.0625 (16384/262144) is < 0.7500. Will not compact
Migrator: 2022/12/08 21:44:57.042237 log.go:18: Info: In runner.Run
Migrator: 2022/12/08 21:44:57.042567 log.go:18: Info: Found DB at version 112, which is less than what we expect (113). Running migrations...
Migrator: 2022/12/08 21:44:57.050522 log.go:18: Info: Successfully updated DB from version 112 to 113

7. Verify that the amount of groups is the same as beforehand:
roxcurl /v1/groups
{"groups":[{"props":{"id":"io.stackrox.authz.group.340a6739-4b5c-4bef-b229-a7755b621593","traits":null,"authProviderId":"something","key":"somewhere","value":"somehow"},"roleName":"abc"},{"props":{"id":"io.stackrox.authz.group.37817f74-8b68-47a9-b7e3-b326739c4b96","traits":null,"authProviderId":"a779715b-d696-4c6d-ae9b-3aaf953554ff","key":"name","value":"aa"},"roleName":"Sensor Creator"},{"props":{"id":"io.stackrox.authz.group.3fe77b94-01aa-41ea-b6e5-d42dd8606451","traits":null,"authProviderId":"a779715b-d696-4c6d-ae9b-3aaf953554ff","key":"","value":""},"roleName":"Admin"},{"props":{"id":"io.stackrox.authz.group.7e6d645a-ba75-445e-9402-6fbfbb743912","traits":null,"authProviderId":"a779715b-d696-4c6d-ae9b-3aaf953554ff","key":"groups","value":"adsadasd"},"roleName":"Sensor Creator"},{"props":{"id":"io.stackrox.authz.group.ab329ef5-29be-4bcd-859d-062303455574","traits":null,"authProviderId":"a779715b-d696-4c6d-ae9b-3aaf953554ff","key":"userid","value":"asdasdasdasdasd"},"roleName":"Analyst"},{"props":{"id":"io.stackrox.authz.group.be588a60-1cd7-4704-85f9-190bd69b1a1d","traits":null,"authProviderId":"a779715b-d696-4c6d-ae9b-3aaf953554ff","key":"groups","value":"asdqweqeqweqw"},"roleName":"Vulnerability Management Approver"},{"props":{"id":"io.stackrox.authz.group.c6eda2df-479d-437a-a958-c95a197f2d0d","traits":null,"authProviderId":"a779715b-d696-4c6d-ae9b-3aaf953554ff","key":"userid","value":"123123123123"},"roleName":"Analyst"},{"props":{"id":"io.stackrox.authz.group.e32849f3-2be7-4914-b53a-a36d369464b4","traits":null,"authProviderId":"a779715b-d696-4c6d-ae9b-3aaf953554ff","key":"email","value":"someone@somewhere"},"roleName":"Vulnerability Management Approver"}]}

roxcurl /v1/groups | jq -r '.groups | length'                                                                                                                                                                                                                                                                        
8


```
