### PR TITLE
ROX-13479: Add simulate network policies tab

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraph.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraph.tsx
@@ -15,6 +15,7 @@ import {
 } from '@patternfly/react-topology';
 
 import { networkBasePathPF } from 'routePaths';
+import { getQueryObject, getQueryString } from 'utils/queryStringUtils';
 import stylesComponentFactory from './components/stylesComponentFactory';
 import defaultLayoutFactory from './layouts/defaultLayoutFactory';
 import defaultComponentFactory from './components/defaultComponentFactory';
@@ -23,12 +24,14 @@ import NamespaceSideBar from './namespace/NamespaceSideBar';
 import CidrBlockSideBar from './cidr/CidrBlockSideBar';
 import ExternalEntitiesSideBar from './externalEntities/ExternalEntitiesSideBar';
 import ExternalGroupSideBar from './external/ExternalGroupSideBar';
+import NetworkPolicySimulatorSidePanel from './simulation/NetworkPolicySimulatorSidePanel';
 import { EdgeState } from './EdgeStateSelect';
 
 import './Topology.css';
 import { getNodeById } from './utils/networkGraphUtils';
 import { CustomModel, CustomNodeModel } from './types/topology.type';
 import { createExtraneousNodes } from './utils/modelUtils';
+import { Simulation } from './utils/getSimulation';
 
 // TODO: move these type defs to a central location
 export const UrlDetailType = {
@@ -51,11 +54,13 @@ function getUrlParamsForEntity(selectedEntity: CustomNodeModel): [UrlDetailTypeV
 export type NetworkGraphProps = {
     model: CustomModel;
     edgeState: EdgeState;
+    simulation: Simulation;
 };
 
 export type TopologyComponentProps = {
     model: CustomModel;
     edgeState: EdgeState;
+    simulation: Simulation;
 };
 
 function getNodeEdges(selectedNode) {
@@ -124,7 +129,19 @@ function setExtraneousNodes(controller, detailId) {
     }
 }
 
-const TopologyComponent = ({ model, edgeState }: TopologyComponentProps) => {
+// @TODO: Consider a better approach to managing the side panel related state (simulation + URL path for entities)
+function clearSimulationQuery(search: string): string {
+    const modifiedSearchFilter = getQueryObject(search);
+    // eslint-disable-next-line @typescript-eslint/dot-notation
+    if (modifiedSearchFilter.s && modifiedSearchFilter['s']['Simulation']) {
+        // eslint-disable-next-line @typescript-eslint/dot-notation
+        delete modifiedSearchFilter['s']['Simulation'];
+    }
+    const queryString = getQueryString(modifiedSearchFilter);
+    return queryString;
+}
+
+const TopologyComponent = ({ model, edgeState, simulation }: TopologyComponentProps) => {
     const history = useHistory();
     const { detailId } = useParams();
     const selectedEntity = detailId && getNodeById(model?.nodes, detailId);
@@ -139,7 +156,8 @@ const TopologyComponent = ({ model, edgeState }: TopologyComponentProps) => {
     }
 
     function closeSidebar() {
-        history.push(`${networkBasePathPF}${history.location.search as string}`);
+        const queryString = clearSimulationQuery(history.location.search);
+        history.push(`${networkBasePathPF}${queryString}`);
     }
 
     function onSelect(ids: string[]) {
@@ -149,16 +167,13 @@ const TopologyComponent = ({ model, edgeState }: TopologyComponentProps) => {
         // @ts-ignore
         if (newSelectedEntity) {
             const [newDetailType, newDetailId] = getUrlParamsForEntity(newSelectedEntity);
+            const queryString = clearSimulationQuery(history.location.search);
             // if found, and it's not the logical grouping of all external sources, then trigger URL update
             if (newDetailId !== 'EXTERNAL') {
-                history.push(
-                    `${networkBasePathPF}/${newDetailType}/${newDetailId}${
-                        history.location.search as string
-                    }`
-                );
+                history.push(`${networkBasePathPF}/${newDetailType}/${newDetailId}${queryString}`);
             } else {
                 // otherwise, return to the graph-only state
-                history.push(`${networkBasePathPF}${history.location.search as string}`);
+                history.push(`${networkBasePathPF}${queryString}`);
             }
         }
     }
@@ -180,6 +195,9 @@ const TopologyComponent = ({ model, edgeState }: TopologyComponentProps) => {
         <TopologyView
             sideBar={
                 <TopologySideBar resizable onClose={closeSidebar}>
+                    {simulation.isOn && simulation.type === 'network policy' && (
+                        <NetworkPolicySimulatorSidePanel />
+                    )}
                     {selectedEntity && selectedEntity?.data?.type === 'NAMESPACE' && (
                         <NamespaceSideBar
                             namespaceId={selectedEntity.id}
@@ -217,7 +235,7 @@ const TopologyComponent = ({ model, edgeState }: TopologyComponentProps) => {
                     )}
                 </TopologySideBar>
             }
-            sideBarOpen={!!selectedEntity}
+            sideBarOpen={!!selectedEntity || simulation.isOn}
             sideBarResizable
             controlBar={
                 <TopologyControlBar
@@ -248,7 +266,7 @@ const TopologyComponent = ({ model, edgeState }: TopologyComponentProps) => {
     );
 };
 
-const NetworkGraph = React.memo<NetworkGraphProps>(({ model, edgeState }) => {
+const NetworkGraph = React.memo<NetworkGraphProps>(({ model, edgeState, simulation }) => {
     const controller = new Visualization();
     controller.registerLayoutFactory(defaultLayoutFactory);
     controller.registerComponentFactory(defaultComponentFactory);
@@ -257,7 +275,7 @@ const NetworkGraph = React.memo<NetworkGraphProps>(({ model, edgeState }) => {
     return (
         <div className="pf-ri__topology-demo">
             <VisualizationProvider controller={controller}>
-                <TopologyComponent model={model} edgeState={edgeState} />
+                <TopologyComponent model={model} edgeState={edgeState} simulation={simulation} />
             </VisualizationProvider>
         </div>
     );

--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraph.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraph.tsx
@@ -195,7 +195,7 @@ const TopologyComponent = ({ model, edgeState, simulation }: TopologyComponentPr
         <TopologyView
             sideBar={
                 <TopologySideBar resizable onClose={closeSidebar}>
-                    {simulation.isOn && simulation.type === 'network policy' && (
+                    {simulation.isOn && simulation.type === 'networkPolicy' && (
                         <NetworkPolicySimulatorSidePanel />
                     )}
                     {selectedEntity && selectedEntity?.data?.type === 'NAMESPACE' && (

--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
@@ -23,6 +23,7 @@ import { getQueryString } from 'utils/queryStringUtils';
 import timeWindowToDate from 'utils/timeWindows';
 
 import PageTitle from 'Components/PageTitle';
+import useURLParameter from 'hooks/useURLParameter';
 import EmptyUnscopedState from './components/EmptyUnscopedState';
 import NetworkBreadcrumbs from './components/NetworkBreadcrumbs';
 import SimulateNetworkPolicyButton from './simulation/SimulateNetworkPolicyButton';
@@ -56,6 +57,7 @@ function NetworkGraphPage() {
     const [model, setModel] = useState<CustomModel>(emptyModel);
     const [isLoading, setIsLoading] = useState(false);
     const { searchFilter } = useURLSearch();
+    const [simulationQueryValue] = useURLParameter('simulation', undefined);
 
     const {
         cluster: clusterFromUrl,
@@ -63,7 +65,7 @@ function NetworkGraphPage() {
         deployments: deploymentsFromUrl,
         remainingQuery,
     } = getScopeHierarchy(searchFilter);
-    const simulation = getSimulation(searchFilter);
+    const simulation = getSimulation(simulationQueryValue);
 
     const hasClusterNamespaceSelected = Boolean(clusterFromUrl && namespacesFromUrl.length);
 

--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
@@ -25,6 +25,7 @@ import timeWindowToDate from 'utils/timeWindows';
 import PageTitle from 'Components/PageTitle';
 import EmptyUnscopedState from './components/EmptyUnscopedState';
 import NetworkBreadcrumbs from './components/NetworkBreadcrumbs';
+import SimulateNetworkPolicyButton from './simulation/SimulateNetworkPolicyButton';
 import EdgeStateSelect, { EdgeState } from './EdgeStateSelect';
 import NetworkGraph from './NetworkGraph';
 import {
@@ -34,6 +35,7 @@ import {
     graphModel,
 } from './utils/modelUtils';
 import getScopeHierarchy from './utils/getScopeHierarchy';
+import getSimulation from './utils/getSimulation';
 import { CustomModel, CustomNodeModel, PolicyNodeModel } from './types/topology.type';
 
 import './NetworkGraphPage.css';
@@ -61,6 +63,7 @@ function NetworkGraphPage() {
         deployments: deploymentsFromUrl,
         remainingQuery,
     } = getScopeHierarchy(searchFilter);
+    const simulation = getSimulation(searchFilter);
 
     const hasClusterNamespaceSelected = Boolean(clusterFromUrl && namespacesFromUrl.length);
 
@@ -177,7 +180,7 @@ function NetworkGraphPage() {
                         />
                     </FlexItem>
                     <Button variant="secondary">Manage CIDR blocks</Button>
-                    <Button variant="secondary">Simulate network policy</Button>
+                    <SimulateNetworkPolicyButton simulation={simulation} />
                 </Flex>
             </PageSection>
             <Divider component="div" />
@@ -211,7 +214,9 @@ function NetworkGraphPage() {
                 padding={{ default: 'noPadding' }}
             >
                 {!hasClusterNamespaceSelected && <EmptyUnscopedState />}
-                {model.nodes && <NetworkGraph model={model} edgeState={edgeState} />}
+                {model.nodes && (
+                    <NetworkGraph model={model} edgeState={edgeState} simulation={simulation} />
+                )}
                 {isLoading && (
                     <Bullseye>
                         <Spinner isSVG />

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPolicySimulatorSidePanel.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPolicySimulatorSidePanel.tsx
@@ -31,7 +31,7 @@ function NetworkPolicySimulatorSidePanel() {
                 <Flex direction={{ default: 'row' }} className="pf-u-p-md pf-u-mb-0">
                     <FlexItem>
                         <TextContent>
-                            <Text component={TextVariants.h1} className="pf-u-font-size-xl">
+                            <Text component={TextVariants.h2} className="pf-u-font-size-xl">
                                 Simulate network policy
                             </Text>
                         </TextContent>

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPolicySimulatorSidePanel.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPolicySimulatorSidePanel.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import {
+    Flex,
+    FlexItem,
+    Stack,
+    StackItem,
+    Tab,
+    TabContent,
+    Tabs,
+    TabTitleText,
+    Text,
+    TextContent,
+    TextVariants,
+} from '@patternfly/react-core';
+
+import useTabs from 'hooks/patternfly/useTabs';
+
+const tabs = {
+    SIMULATE_NETWORK_POLICIES: 'Simulate network policies',
+    VIEW_ACTIVE_YAMLS: 'View active YAMLS',
+};
+
+function NetworkPolicySimulatorSidePanel() {
+    const { activeKeyTab, onSelectTab } = useTabs({
+        defaultTab: tabs.SIMULATE_NETWORK_POLICIES,
+    });
+
+    return (
+        <Stack>
+            <StackItem>
+                <Flex direction={{ default: 'row' }} className="pf-u-p-md pf-u-mb-0">
+                    <FlexItem>
+                        <TextContent>
+                            <Text component={TextVariants.h1} className="pf-u-font-size-xl">
+                                Simulate network policy
+                            </Text>
+                        </TextContent>
+                    </FlexItem>
+                </Flex>
+            </StackItem>
+            <StackItem>
+                <Tabs activeKey={activeKeyTab} onSelect={onSelectTab}>
+                    <Tab
+                        eventKey={tabs.SIMULATE_NETWORK_POLICIES}
+                        tabContentId={tabs.SIMULATE_NETWORK_POLICIES}
+                        title={<TabTitleText>{tabs.SIMULATE_NETWORK_POLICIES}</TabTitleText>}
+                    />
+                    <Tab
+                        eventKey={tabs.VIEW_ACTIVE_YAMLS}
+                        tabContentId={tabs.VIEW_ACTIVE_YAMLS}
+                        title={<TabTitleText>{tabs.VIEW_ACTIVE_YAMLS}</TabTitleText>}
+                    />
+                </Tabs>
+            </StackItem>
+            <StackItem isFilled style={{ overflow: 'auto' }}>
+                <TabContent
+                    eventKey={tabs.SIMULATE_NETWORK_POLICIES}
+                    id={tabs.SIMULATE_NETWORK_POLICIES}
+                    hidden={activeKeyTab !== tabs.SIMULATE_NETWORK_POLICIES}
+                >
+                    <div>Simulate network policies</div>
+                </TabContent>
+                <TabContent
+                    eventKey={tabs.VIEW_ACTIVE_YAMLS}
+                    id={tabs.VIEW_ACTIVE_YAMLS}
+                    hidden={activeKeyTab !== tabs.VIEW_ACTIVE_YAMLS}
+                >
+                    <div>View active YAMLs</div>
+                </TabContent>
+            </StackItem>
+        </Stack>
+    );
+}
+
+export default NetworkPolicySimulatorSidePanel;

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/SimulateNetworkPolicyButton.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/SimulateNetworkPolicyButton.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { Button } from '@patternfly/react-core';
+import { useHistory } from 'react-router-dom';
+
+import useURLSearch from 'hooks/useURLSearch';
+import { networkBasePathPF } from 'routePaths';
+import { Simulation } from '../utils/getSimulation';
+
+type SimulateNetworkPolicyButtonProps = {
+    simulation: Simulation;
+};
+
+function SimulateNetworkPolicyButton({ simulation }: SimulateNetworkPolicyButtonProps) {
+    const history = useHistory();
+    const { searchFilter, setSearchFilter } = useURLSearch();
+
+    function enableNetworkPolicySimulation() {
+        const searchObject = {
+            ...searchFilter,
+            Simulation: 'network policy',
+        };
+        history.push(networkBasePathPF);
+        setSearchFilter(searchObject);
+    }
+
+    return (
+        <Button
+            variant="secondary"
+            isDisabled={simulation.isOn}
+            onClick={enableNetworkPolicySimulation}
+        >
+            Simulate network policy
+        </Button>
+    );
+}
+
+export default SimulateNetworkPolicyButton;

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/SimulateNetworkPolicyButton.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/SimulateNetworkPolicyButton.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { Button } from '@patternfly/react-core';
 import { useHistory } from 'react-router-dom';
 
-import useURLSearch from 'hooks/useURLSearch';
 import { networkBasePathPF } from 'routePaths';
+import useURLParameter from 'hooks/useURLParameter';
 import { Simulation } from '../utils/getSimulation';
 
 type SimulateNetworkPolicyButtonProps = {
@@ -12,15 +12,15 @@ type SimulateNetworkPolicyButtonProps = {
 
 function SimulateNetworkPolicyButton({ simulation }: SimulateNetworkPolicyButtonProps) {
     const history = useHistory();
-    const { searchFilter, setSearchFilter } = useURLSearch();
+
+    const [, setSimulationQueryValue] = useURLParameter('simulation', undefined);
 
     function enableNetworkPolicySimulation() {
-        const searchObject = {
-            ...searchFilter,
-            Simulation: 'network policy',
-        };
-        history.push(networkBasePathPF);
-        setSearchFilter(searchObject);
+        history.push({
+            path: networkBasePathPF,
+            search: history.location.search,
+        });
+        setSimulationQueryValue('networkPolicy');
     }
 
     return (

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/getSimulation.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/getSimulation.ts
@@ -1,0 +1,29 @@
+import { SearchFilter } from 'types/search';
+
+type SimulationOn = {
+    isOn: true;
+    type: 'baseline' | 'network policy';
+};
+
+type SimulationOff = {
+    isOn: false;
+};
+
+export type Simulation = SimulationOn | SimulationOff;
+
+function getSimulation(searchFilter: SearchFilter): Simulation {
+    const simulationType = searchFilter.Simulation;
+    if (!simulationType || (simulationType !== 'baseline' && simulationType !== 'network policy')) {
+        const simulation: Simulation = {
+            isOn: false,
+        };
+        return simulation;
+    }
+    const simulation: Simulation = {
+        isOn: true,
+        type: simulationType,
+    };
+    return simulation;
+}
+
+export default getSimulation;

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/getSimulation.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/getSimulation.ts
@@ -1,8 +1,8 @@
-import { SearchFilter } from 'types/search';
+import { QueryValue } from 'hooks/useURLParameter';
 
 type SimulationOn = {
     isOn: true;
-    type: 'baseline' | 'network policy';
+    type: 'baseline' | 'networkPolicy';
 };
 
 type SimulationOff = {
@@ -11,9 +11,11 @@ type SimulationOff = {
 
 export type Simulation = SimulationOn | SimulationOff;
 
-function getSimulation(searchFilter: SearchFilter): Simulation {
-    const simulationType = searchFilter.Simulation;
-    if (!simulationType || (simulationType !== 'baseline' && simulationType !== 'network policy')) {
+function getSimulation(simulationQueryValue: QueryValue): Simulation {
+    if (
+        !simulationQueryValue ||
+        (simulationQueryValue !== 'baseline' && simulationQueryValue !== 'networkPolicy')
+    ) {
         const simulation: Simulation = {
             isOn: false,
         };
@@ -21,7 +23,7 @@ function getSimulation(searchFilter: SearchFilter): Simulation {
     }
     const simulation: Simulation = {
         isOn: true,
-        type: simulationType,
+        type: simulationQueryValue,
     };
     return simulation;
 }


### PR DESCRIPTION
## Description

This PR is an iterative addition for the network policy simulation side panel. Things that were included:
1. A new type called `Simulation` was created to show whether the simulation mode is on and what type of simulation it is (ie. `network policy` or `baseline`)
2. The simulation state will be kept in the URL like this: `.../network-graph/?s[Simulation]=network policy` or `.../network-graph/deployment/:id?s[Simulation]=baseline`
3. Changes were made in `NetworkGraphPage` and `NetworkGraph` to decide when to show the network policy simulation side panel 
4. Changes were made in `NetworkGraph`, specifically in the functions where we select a node or close the side panel, to remove the simulation state from the search query. The method I used could be improved, and we can consider maybe using a state machine or some way to synchronize the state better

<img width="1440" alt="Screenshot 2022-12-08 at 11 19 00 AM" src="https://user-images.githubusercontent.com/4805485/206555524-4d4da2ab-a610-4c57-a49d-fe5f0e568382.png">


## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~
