### PR TITLE
ROX-13582: Intercepting API calls

### DIFF
--- a/central/main.go
+++ b/central/main.go
@@ -165,6 +165,7 @@ import (
 	"github.com/stackrox/rox/pkg/grpc/authz/or"
 	"github.com/stackrox/rox/pkg/grpc/authz/perrpc"
 	"github.com/stackrox/rox/pkg/grpc/authz/user"
+	"github.com/stackrox/rox/pkg/grpc/client/authn/basic"
 	"github.com/stackrox/rox/pkg/grpc/errors"
 	"github.com/stackrox/rox/pkg/grpc/routes"
 	"github.com/stackrox/rox/pkg/httputil"
@@ -538,6 +539,10 @@ func startGRPCServer() {
 	if cfg := centralclient.InstanceConfig(); cfg.Enabled() {
 		config.HTTPInterceptors = append(config.HTTPInterceptors, cfg.GetHTTPInterceptor())
 		config.UnaryInterceptors = append(config.UnaryInterceptors, cfg.GetGRPCInterceptor())
+		// Central adds itself to the tenant group, with no group properties:
+		cfg.Telemeter().Group(cfg.GroupID, cfg.ClientID, nil)
+		// Add the local admin user as well, with no extra group properties:
+		cfg.Telemeter().Group(cfg.GroupID, cfg.HashUserID(basic.DefaultUsername, basicAuthProvider.ID()), nil)
 	}
 
 	// Before authorization is checked, we want to inject the sac client into the context.

--- a/central/main.go
+++ b/central/main.go
@@ -535,6 +535,11 @@ func startGRPCServer() {
 	)
 	config.HTTPInterceptors = append(config.HTTPInterceptors, observe.AuthzTraceHTTPInterceptor(authzTraceSink))
 
+	if cfg := centralclient.InstanceConfig(); cfg.Enabled() {
+		config.HTTPInterceptors = append(config.HTTPInterceptors, cfg.GetHTTPInterceptor())
+		config.UnaryInterceptors = append(config.UnaryInterceptors, cfg.GetGRPCInterceptor())
+	}
+
 	// Before authorization is checked, we want to inject the sac client into the context.
 	config.PreAuthContextEnrichers = append(config.PreAuthContextEnrichers,
 		centralSAC.GetEnricher().GetPreAuthContextEnricher(authzTraceSink),

--- a/central/telemetry/centralclient/instance_config.go
+++ b/central/telemetry/centralclient/instance_config.go
@@ -76,8 +76,7 @@ func getInstanceConfig() (*phonehome.Config, map[string]any, error) {
 			StorageKey:   key,
 			Endpoint:     env.TelemetryEndpoint.Setting(),
 			PushInterval: env.TelemetryFrequency.DurationSetting(),
-		},
-		map[string]any{
+		}, map[string]any{
 			"Central version":    version.GetMainVersion(),
 			"Chart version":      version.GetChartVersion(),
 			"Orchestrator":       orchestrator,

--- a/central/telemetry/centralclient/instance_config.go
+++ b/central/telemetry/centralclient/instance_config.go
@@ -19,6 +19,10 @@ import (
 	"k8s.io/client-go/rest"
 )
 
+const (
+	apiPathsAnnotation = "rhacs.redhat.com/telemetry-apipaths"
+)
+
 var (
 	config *phonehome.Config
 	once   sync.Once

--- a/central/telemetry/centralclient/instance_config.go
+++ b/central/telemetry/centralclient/instance_config.go
@@ -114,11 +114,6 @@ func InstanceConfig() *phonehome.Config {
 				config.AddInterceptorFunc(event, f)
 			}
 		}
-		// Central adds itself to the tenant group, adding its properties to the
-		// group properties:
-		config.Telemeter().Group(config.GroupID, config.ClientID, props)
-		// Add the local admin user as well, with no extra group properties:
-		config.Telemeter().Group(config.GroupID, config.HashUserID("admin", ""), nil)
 
 		config.Gatherer().AddGatherer(func(ctx context.Context) (map[string]any, error) {
 			return props, nil

--- a/central/telemetry/centralclient/instance_config.go
+++ b/central/telemetry/centralclient/instance_config.go
@@ -19,11 +19,9 @@ import (
 	"k8s.io/client-go/rest"
 )
 
-const (
-	apiPathsAnnotation = "rhacs.redhat.com/telemetry-apipaths"
-)
-
 var (
+	apiWhiteList = env.RegisterSetting("ROX_TELEMETRY_API_WHITELIST", env.AllowEmpty())
+
 	config *phonehome.Config
 	once   sync.Once
 	log    = logging.LoggerForModule()
@@ -53,8 +51,7 @@ func getInstanceConfig() (*phonehome.Config, map[string]any, error) {
 		return nil, nil, errors.Wrap(err, "cannot get central deployment")
 	}
 
-	paths := central.GetAnnotations()[apiPathsAnnotation]
-	trackedPaths = set.NewFrozenSet(strings.Split(paths, ",")...)
+	trackedPaths = set.NewFrozenSet(strings.Split(apiWhiteList.Setting(), ",")...)
 
 	orchestrator := storage.ClusterType_KUBERNETES_CLUSTER.String()
 	if env.OpenshiftAPI.BooleanSetting() {
@@ -89,7 +86,7 @@ func getInstanceConfig() (*phonehome.Config, map[string]any, error) {
 }
 
 // InstanceConfig collects the central instance telemetry configuration from
-// central Deployment labels and annotations, installation store and
+// central Deployment labels and environment variables, installation store and
 // orchestrator properties. The collected data is used for configuring the
 // telemetry client.
 func InstanceConfig() *phonehome.Config {

--- a/central/telemetry/centralclient/interceptors.go
+++ b/central/telemetry/centralclient/interceptors.go
@@ -1,0 +1,104 @@
+package centralclient
+
+import (
+	"strings"
+	"sync"
+
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/set"
+	"github.com/stackrox/rox/pkg/telemetry/phonehome"
+)
+
+var (
+	trackedPaths set.FrozenSet[string]
+	ignoredPaths = []string{"/v1/ping", "/v1/metadata", "/static/"}
+
+	clusterStatus = map[string]storage.ClusterHealthStatus_HealthStatusLabel{}
+	mux           = &sync.Mutex{}
+
+	interceptors = map[string][]phonehome.Interceptor{
+		"API Call":            {apiCall},
+		"Cluster Registered":  {postCluster},
+		"Cluster Initialized": {putCluster},
+		"roxctl":              {roxctl},
+	}
+)
+
+// Adds Path, Code and User-Agent properties to API Call events for the API
+// paths which start from the prefixes specified in the
+// rhacs.redhat.com/telemetry-apipaths central deployment annotation
+// ("*" value enables all paths) and are not in the ignoredPath list.
+func apiCall(rp *phonehome.RequestParams, props map[string]any) bool {
+	for _, ip := range ignoredPaths {
+		if strings.HasPrefix(rp.Path, ip) {
+			return false
+		}
+	}
+	if trackedPaths.Contains("*") || trackedPaths.Contains(rp.Path) {
+		props["Path"] = rp.Path
+		props["Code"] = rp.Code
+		props["User-Agent"] = rp.UserAgent
+		return true
+	}
+	return false
+}
+
+// Adds Post Cluster call specific properties to the Post Cluster event.
+func postCluster(rp *phonehome.RequestParams, props map[string]any) bool {
+	if rp.Path != "/v1.ClustersService/PostCluster" {
+		return false
+	}
+	props["Code"] = rp.Code
+	if req, ok := rp.GrpcReq.(*storage.Cluster); ok {
+		props["Cluster Type"] = req.GetType().String()
+		props["Cluster ID"] = req.GetId()
+		props["Managed By"] = req.GetManagedBy().String()
+		mux.Lock()
+		defer mux.Unlock()
+		clusterStatus[req.GetId()] = req.GetHealthStatus().GetSensorHealthStatus()
+	}
+	return true
+}
+
+// Adds Put Cluster call specific properties to the Put Cluster event.
+// The event is triggered when a previously posted cluster changes state from
+// UNINITIALIZED to something else.
+func putCluster(rp *phonehome.RequestParams, props map[string]any) bool {
+	if rp.Path != "/v1.ClustersService/PutCluster" {
+		return false
+	}
+	if req, ok := rp.GrpcReq.(*storage.Cluster); ok {
+		mux.Lock()
+		defer mux.Unlock()
+		lastStatus, ok := clusterStatus[req.GetId()]
+		newStatus := req.GetHealthStatus().GetSensorHealthStatus()
+		if !ok && newStatus == storage.ClusterHealthStatus_UNINITIALIZED {
+			clusterStatus[req.GetId()] = newStatus
+		} else if lastStatus == storage.ClusterHealthStatus_UNINITIALIZED &&
+			newStatus != lastStatus {
+			delete(clusterStatus, req.GetId())
+			props["Code"] = rp.Code
+			props["Cluster Type"] = req.GetType().String()
+			props["Cluster ID"] = req.GetId()
+			props["Managed By"] = req.GetManagedBy().String()
+			return true
+		}
+	}
+	return false
+}
+
+// Adds properties to the roxctl event.
+func roxctl(rp *phonehome.RequestParams, props map[string]any) bool {
+	if !strings.Contains(rp.UserAgent, "roxctl") {
+		return false
+	}
+	props["Path"] = rp.Path
+	props["Code"] = rp.Code
+	props["User-Agent"] = rp.UserAgent
+	if rp.HttpReq != nil {
+		props["Protocol"] = "HTTP"
+	} else {
+		props["Protocol"] = "GRPC"
+	}
+	return true
+}

--- a/central/telemetry/centralclient/interceptors.go
+++ b/central/telemetry/centralclient/interceptors.go
@@ -18,8 +18,8 @@ var (
 
 	interceptors = map[string][]phonehome.Interceptor{
 		"API Call":            {apiCall},
-		"Cluster Registered":  {postCluster},
-		"Cluster Initialized": {putCluster},
+		"Cluster Registered":  {clusterRegistered},
+		"Cluster Initialized": {clusterInitialized},
 		"roxctl":              {roxctl},
 	}
 )
@@ -45,8 +45,8 @@ func apiCall(rp *phonehome.RequestParams, props map[string]any) bool {
 	return false
 }
 
-// Adds Post Cluster call specific properties to the Post Cluster event.
-func postCluster(rp *phonehome.RequestParams, props map[string]any) bool {
+// Adds specific properties to the Cluster Registered event.
+func clusterRegistered(rp *phonehome.RequestParams, props map[string]any) bool {
 	if rp.Path != "/v1.ClustersService/PostCluster" {
 		return false
 	}
@@ -64,10 +64,10 @@ func postCluster(rp *phonehome.RequestParams, props map[string]any) bool {
 	return true
 }
 
-// Adds Put Cluster call specific properties to the Put Cluster event.
+// Adds specific properties to the Cluster Initialized event.
 // The event is triggered when a previously posted cluster changes state from
 // UNINITIALIZED to something else.
-func putCluster(rp *phonehome.RequestParams, props map[string]any) bool {
+func clusterInitialized(rp *phonehome.RequestParams, props map[string]any) bool {
 	if rp.Path != "/v1.ClustersService/PutCluster" {
 		return false
 	}

--- a/central/telemetry/centralclient/interceptors.go
+++ b/central/telemetry/centralclient/interceptors.go
@@ -49,7 +49,7 @@ func postCluster(rp *phonehome.RequestParams, props map[string]any) bool {
 		return false
 	}
 	props["Code"] = rp.Code
-	if req, ok := rp.GrpcReq.(*storage.Cluster); ok {
+	if req, ok := rp.GRPCReq.(*storage.Cluster); ok {
 		props["Cluster Type"] = req.GetType().String()
 		props["Cluster ID"] = req.GetId()
 		props["Managed By"] = req.GetManagedBy().String()
@@ -67,7 +67,7 @@ func putCluster(rp *phonehome.RequestParams, props map[string]any) bool {
 	if rp.Path != "/v1.ClustersService/PutCluster" {
 		return false
 	}
-	if req, ok := rp.GrpcReq.(*storage.Cluster); ok {
+	if req, ok := rp.GRPCReq.(*storage.Cluster); ok {
 		mux.Lock()
 		defer mux.Unlock()
 		lastStatus, ok := clusterStatus[req.GetId()]
@@ -95,7 +95,7 @@ func roxctl(rp *phonehome.RequestParams, props map[string]any) bool {
 	props["Path"] = rp.Path
 	props["Code"] = rp.Code
 	props["User-Agent"] = rp.UserAgent
-	if rp.HttpReq != nil {
+	if rp.HTTPReq != nil {
 		props["Protocol"] = "HTTP"
 	} else {
 		props["Protocol"] = "GRPC"

--- a/central/telemetry/centralclient/interceptors.go
+++ b/central/telemetry/centralclient/interceptors.go
@@ -2,10 +2,10 @@ package centralclient
 
 import (
 	"strings"
-	"sync"
 
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/set"
+	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/pkg/telemetry/phonehome"
 )
 

--- a/central/telemetry/centralclient/interceptors.go
+++ b/central/telemetry/centralclient/interceptors.go
@@ -11,7 +11,7 @@ import (
 
 var (
 	trackedPaths set.FrozenSet[string]
-	ignoredPaths = []string{"/v1/ping", "/v1/metadata", "/static/"}
+	ignoredPaths = []string{"/v1/ping", "/v1.PingService/Ping", "/v1/metadata", "/static/"}
 
 	clusterStatus = map[string]storage.ClusterHealthStatus_HealthStatusLabel{}
 	mux           = &sync.Mutex{}

--- a/central/telemetry/centralclient/interceptors.go
+++ b/central/telemetry/centralclient/interceptors.go
@@ -39,7 +39,6 @@ func apiCall(rp *phonehome.RequestParams, props map[string]any) bool {
 		props["Code"] = rp.Code
 		props["User-Agent"] = rp.UserAgent
 		props["Method"] = rp.GetMethod()
-		props["Protocol"] = rp.GetProtocol()
 		return true
 	}
 	return false
@@ -104,6 +103,5 @@ func roxctl(rp *phonehome.RequestParams, props map[string]any) bool {
 	props["Code"] = rp.Code
 	props["User-Agent"] = rp.UserAgent
 	props["Method"] = rp.GetMethod()
-	props["Protocol"] = rp.GetProtocol()
 	return true
 }

--- a/central/telemetry/centralclient/interceptors.go
+++ b/central/telemetry/centralclient/interceptors.go
@@ -38,6 +38,8 @@ func apiCall(rp *phonehome.RequestParams, props map[string]any) bool {
 		props["Path"] = rp.Path
 		props["Code"] = rp.Code
 		props["User-Agent"] = rp.UserAgent
+		props["Method"] = rp.GetMethod()
+		props["Protocol"] = rp.GetProtocol()
 		return true
 	}
 	return false
@@ -95,10 +97,7 @@ func roxctl(rp *phonehome.RequestParams, props map[string]any) bool {
 	props["Path"] = rp.Path
 	props["Code"] = rp.Code
 	props["User-Agent"] = rp.UserAgent
-	if rp.HTTPReq != nil {
-		props["Protocol"] = "HTTP"
-	} else {
-		props["Protocol"] = "GRPC"
-	}
+	props["Method"] = rp.GetMethod()
+	props["Protocol"] = rp.GetProtocol()
 	return true
 }

--- a/central/telemetry/centralclient/interceptors.go
+++ b/central/telemetry/centralclient/interceptors.go
@@ -24,10 +24,10 @@ var (
 	}
 )
 
-// Adds Path, Code and User-Agent properties to API Call events for the API
-// paths which start from the prefixes specified in the
-// rhacs.redhat.com/telemetry-apipaths central deployment annotation
-// ("*" value enables all paths) and are not in the ignoredPath list.
+// Adds Path, Code, User-Agent and Method properties to API Call events for the
+// API paths specified in the ROX_TELEMETRY_API_WHITELIST central deployment
+// environment variable ("*" value enables all paths) and have no prefix from
+// the ignoredPaths list.
 func apiCall(rp *phonehome.RequestParams, props map[string]any) bool {
 	for _, ip := range ignoredPaths {
 		if strings.HasPrefix(rp.Path, ip) {

--- a/central/telemetry/centralclient/interceptors_test.go
+++ b/central/telemetry/centralclient/interceptors_test.go
@@ -6,27 +6,46 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/telemetry/phonehome"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
 )
 
-func Test_clusterRegistered(t *testing.T) {
+func TestInterceptors(t *testing.T) {
+	suite.Run(t, new(interceptorsTest))
+}
+
+var _ suite.SetupTestSuite = (*interceptorsTest)(nil)
+
+type interceptorsTest struct {
+	suite.Suite
+}
+
+func (i *interceptorsTest) SetupTest() {
 	// clean the global set of uninitialized clusters:
 	uninitializedClusters = set.NewSet[string]()
+}
 
+func (t *interceptorsTest) TestClusterRegisteredNoFire() {
 	props := map[string]any{}
 
+	// Path is not "/v1.ClustersService/PostCluster":
 	rp := &phonehome.RequestParams{
 		Path: "random",
 	}
-	assert.False(t, clusterRegistered(rp, props))
-	assert.Empty(t, props)
+	t.False(clusterRegistered(rp, props), "must not fire, as Path doesn't match")
+	t.Empty(props, "props must not be touched")
+}
 
-	rp = &phonehome.RequestParams{
+func (t *interceptorsTest) TestClusterRegisteredFire() {
+	props := map[string]any{}
+
+	// Test for matching Path:
+	rp := &phonehome.RequestParams{
 		Path: "/v1.ClustersService/PostCluster",
 	}
-	assert.True(t, clusterRegistered(rp, props))
-	assert.Equal(t, map[string]any{"Code": 0}, props)
+	t.True(clusterRegistered(rp, props), "must fire, as Path matches")
+	t.Equal(map[string]any{"Code": 0}, props, "props must have only Code, as gRPC request details are not provided")
 
+	// Test with gRPC request details:
 	rp.GRPCReq = &storage.Cluster{
 		Type:      storage.ClusterType_GENERIC_CLUSTER,
 		Id:        "cluster-id",
@@ -35,68 +54,66 @@ func Test_clusterRegistered(t *testing.T) {
 			SensorHealthStatus: storage.ClusterHealthStatus_UNINITIALIZED,
 		},
 	}
-	assert.False(t, uninitializedClusters.Contains("cluster-id"))
+	t.False(uninitializedClusters.Contains("cluster-id"), "cluster-id must not be registered as uninitialized yet")
 	// remembers the uninitialized cluster in memory:
-	assert.True(t, clusterRegistered(rp, props))
-	assert.Equal(t, map[string]any{
+	t.True(clusterRegistered(rp, props), "must fire, as Path matches, and cluster-id has not been registered")
+	t.Equal(map[string]any{
 		"Code":         0,
 		"Cluster ID":   "cluster-id",
 		"Cluster Type": "GENERIC_CLUSTER",
 		"Managed By":   "MANAGER_TYPE_MANUAL",
-	}, props)
-	assert.True(t, uninitializedClusters.Contains("cluster-id"))
+	}, props, "props must have all the fields from the gRPC request details")
+	t.True(uninitializedClusters.Contains("cluster-id"), "cluster-id must be registered as uninitialized now")
 }
 
-func Test_clusterInitialized(t *testing.T) {
-	// clean the global set of uninitialized clusters:
-	uninitializedClusters = set.NewSet[string]()
-
+func (t *interceptorsTest) TestClusterInitializedNoFire() {
 	props := map[string]any{}
 
+	// Path is not "/v1.ClustersService/PutCluster":
 	rp := &phonehome.RequestParams{
 		Path: "random",
 	}
-	assert.False(t, clusterInitialized(rp, props))
-	assert.Empty(t, props)
-	assert.False(t, uninitializedClusters.Contains("cluster-id"))
+	t.False(clusterInitialized(rp, props), "must not fire, as Path doesn't match")
+	t.Empty(props)
+	t.False(uninitializedClusters.Contains("cluster-id"))
+}
 
-	rp = &phonehome.RequestParams{
+func (t *interceptorsTest) TestClusterInitializedFire() {
+	// Register the uninitialized cluster:
+	uninitializedClusters.Add("cluster-id")
+
+	props := map[string]any{}
+	rp := &phonehome.RequestParams{
+		Path: "/v1.ClustersService/PutCluster",
 		GRPCReq: &storage.Cluster{
 			Type:      storage.ClusterType_GENERIC_CLUSTER,
 			Id:        "cluster-id",
 			ManagedBy: storage.ManagerType_MANAGER_TYPE_MANUAL,
 			HealthStatus: &storage.ClusterHealthStatus{
-				SensorHealthStatus: storage.ClusterHealthStatus_UNINITIALIZED,
+				SensorHealthStatus: storage.ClusterHealthStatus_HEALTHY,
 			},
 		}}
 
-	rp.Path = "/v1.ClustersService/PostCluster"
-	// remembers the uninitialized cluster in memory:
-	assert.True(t, clusterRegistered(rp, props))
-	assert.True(t, uninitializedClusters.Contains("cluster-id"))
-
-	rp.GRPCReq.(*storage.Cluster).HealthStatus.SensorHealthStatus = storage.ClusterHealthStatus_HEALTHY
-
-	rp.Path = "/v1.ClustersService/PutCluster"
 	// removes the now initialized cluster from memory:
-	assert.True(t, clusterInitialized(rp, props), "Should fire because the sensor is healthy")
-	assert.Equal(t, map[string]any{
+	t.True(clusterInitialized(rp, props), "must fire because the sensor is healthy")
+	t.False(uninitializedClusters.Contains("cluster-id"))
+
+	t.Equal(map[string]any{
 		"Code":         0,
 		"Cluster ID":   "cluster-id",
 		"Cluster Type": "GENERIC_CLUSTER",
 		"Managed By":   "MANAGER_TYPE_MANUAL",
 	}, props)
-	assert.False(t, uninitializedClusters.Contains("cluster-id"))
 
 	props = map[string]any{}
-	assert.False(t, clusterInitialized(rp, props), "Should not fire, as the cluster is forgotten already")
-	assert.Empty(t, props)
+	t.False(clusterInitialized(rp, props), "must not fire, as the cluster is forgotten already")
+	t.Empty(props)
 
 	rp.GRPCReq.(*storage.Cluster).HealthStatus.SensorHealthStatus = storage.ClusterHealthStatus_UNINITIALIZED
 	// adds cluster back to memory:
-	assert.False(t, clusterInitialized(rp, props), "Should not fire because the known sensor is UNINITIALIZED again")
-	assert.True(t, uninitializedClusters.Contains("cluster-id"))
+	t.False(clusterInitialized(rp, props), "must not fire because the known sensor is UNINITIALIZED again")
+	t.True(uninitializedClusters.Contains("cluster-id"))
 
 	rp.GRPCReq.(*storage.Cluster).HealthStatus.SensorHealthStatus = storage.ClusterHealthStatus_DEGRADED
-	assert.True(t, clusterInitialized(rp, props), "Should fire again because the sensor is somehow initialized")
+	t.True(clusterInitialized(rp, props), "must fire again because the sensor is somehow initialized")
 }

--- a/central/telemetry/centralclient/interceptors_test.go
+++ b/central/telemetry/centralclient/interceptors_test.go
@@ -19,7 +19,7 @@ type interceptorsTest struct {
 	suite.Suite
 }
 
-func (i *interceptorsTest) SetupTest() {
+func (t *interceptorsTest) SetupTest() {
 	// clean the global set of uninitialized clusters:
 	uninitializedClusters = set.NewSet[string]()
 }

--- a/central/telemetry/centralclient/interceptors_test.go
+++ b/central/telemetry/centralclient/interceptors_test.go
@@ -1,0 +1,102 @@
+package centralclient
+
+import (
+	"testing"
+
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/set"
+	"github.com/stackrox/rox/pkg/telemetry/phonehome"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_postCluster(t *testing.T) {
+	// clean the global set of uninitialized clusters:
+	uninitializedClusters = set.NewSet[string]()
+
+	props := map[string]any{}
+
+	rp := &phonehome.RequestParams{
+		Path: "random",
+	}
+	assert.False(t, postCluster(rp, props))
+	assert.Empty(t, props)
+
+	rp = &phonehome.RequestParams{
+		Path: "/v1.ClustersService/PostCluster",
+	}
+	assert.True(t, postCluster(rp, props))
+	assert.Equal(t, map[string]any{"Code": 0}, props)
+
+	rp.GRPCReq = &storage.Cluster{
+		Type:      storage.ClusterType_GENERIC_CLUSTER,
+		Id:        "cluster-id",
+		ManagedBy: storage.ManagerType_MANAGER_TYPE_MANUAL,
+		HealthStatus: &storage.ClusterHealthStatus{
+			SensorHealthStatus: storage.ClusterHealthStatus_UNINITIALIZED,
+		},
+	}
+	assert.False(t, uninitializedClusters.Contains("cluster-id"))
+	// remembers the uninitialized cluster in memory:
+	assert.True(t, postCluster(rp, props))
+	assert.Equal(t, map[string]any{
+		"Code":         0,
+		"Cluster ID":   "cluster-id",
+		"Cluster Type": "GENERIC_CLUSTER",
+		"Managed By":   "MANAGER_TYPE_MANUAL",
+	}, props)
+	assert.True(t, uninitializedClusters.Contains("cluster-id"))
+}
+
+func Test_putCluster(t *testing.T) {
+	// clean the global set of uninitialized clusters:
+	uninitializedClusters = set.NewSet[string]()
+
+	props := map[string]any{}
+
+	rp := &phonehome.RequestParams{
+		Path: "random",
+	}
+	assert.False(t, putCluster(rp, props))
+	assert.Empty(t, props)
+	assert.False(t, uninitializedClusters.Contains("cluster-id"))
+
+	rp = &phonehome.RequestParams{
+		GRPCReq: &storage.Cluster{
+			Type:      storage.ClusterType_GENERIC_CLUSTER,
+			Id:        "cluster-id",
+			ManagedBy: storage.ManagerType_MANAGER_TYPE_MANUAL,
+			HealthStatus: &storage.ClusterHealthStatus{
+				SensorHealthStatus: storage.ClusterHealthStatus_UNINITIALIZED,
+			},
+		}}
+
+	rp.Path = "/v1.ClustersService/PostCluster"
+	// remembers the uninitialized cluster in memory:
+	assert.True(t, postCluster(rp, props))
+	assert.True(t, uninitializedClusters.Contains("cluster-id"))
+
+	rp.GRPCReq.(*storage.Cluster).HealthStatus.SensorHealthStatus = storage.ClusterHealthStatus_HEALTHY
+
+	rp.Path = "/v1.ClustersService/PutCluster"
+	// removes the now initialized cluster from memory:
+	assert.True(t, putCluster(rp, props), "Should fire because the sensor is healthy")
+	assert.Equal(t, map[string]any{
+		"Code":         0,
+		"Cluster ID":   "cluster-id",
+		"Cluster Type": "GENERIC_CLUSTER",
+		"Managed By":   "MANAGER_TYPE_MANUAL",
+	}, props)
+	assert.False(t, uninitializedClusters.Contains("cluster-id"))
+
+	props = map[string]any{}
+	assert.False(t, putCluster(rp, props), "Should not fire, as the cluster is forgotten already")
+	assert.Empty(t, props)
+
+	rp.GRPCReq.(*storage.Cluster).HealthStatus.SensorHealthStatus = storage.ClusterHealthStatus_UNINITIALIZED
+	// adds cluster back to memory:
+	assert.False(t, putCluster(rp, props), "Should not fire because the known sensor is UNINITIALIZED again")
+	assert.True(t, uninitializedClusters.Contains("cluster-id"))
+
+	rp.GRPCReq.(*storage.Cluster).HealthStatus.SensorHealthStatus = storage.ClusterHealthStatus_DEGRADED
+	assert.True(t, putCluster(rp, props), "Should fire again because the sensor is somehow initialized")
+}

--- a/pkg/telemetry/phonehome/client_config.go
+++ b/pkg/telemetry/phonehome/client_config.go
@@ -113,7 +113,7 @@ func (cfg *Config) AddInterceptorFunc(event string, f Interceptor) {
 func (cfg *Config) GetGRPCInterceptor() grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
 		resp, err := handler(ctx, req)
-		rp := getGrpcRequestDetails(ctx, err, info, req)
+		rp := getGRPCRequestDetails(ctx, err, info, req)
 		go cfg.track(rp)
 		return resp, err
 	}
@@ -125,7 +125,7 @@ func (cfg *Config) GetHTTPInterceptor() httputil.HTTPInterceptor {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			statusTrackingWriter := httputil.NewStatusTrackingWriter(w)
 			handler.ServeHTTP(statusTrackingWriter, r)
-			rp := getHttpRequestDetails(r.Context(), r, statusCodeToError(statusTrackingWriter.GetStatusCode()))
+			rp := getHTTPRequestDetails(r.Context(), r, statusCodeToError(statusTrackingWriter.GetStatusCode()))
 			go cfg.track(rp)
 		})
 	}

--- a/pkg/telemetry/phonehome/client_config.go
+++ b/pkg/telemetry/phonehome/client_config.go
@@ -19,6 +19,12 @@ var (
 // services tenant ID. The value of the label becomes the group ID if not empty.
 const TenantIDLabel = "rhacs.redhat.com/tenant"
 
+// Interceptor is a function which will be called on every API call if none of
+// the previous interceptors in the chain returned false.
+// An Interceptor function may add custom properties to the props map so that
+// they appear in the event.
+type Interceptor func(rp *RequestParams, props map[string]any) bool
+
 // Config represents a telemetry client instance configuration.
 type Config struct {
 	// ClientID identifies an entity that reports telemetry data.
@@ -37,6 +43,10 @@ type Config struct {
 
 	telemeter Telemeter
 	gatherer  Gatherer
+
+	// Map of event name to the list of interceptors, that gather properties for
+	// the event.
+	interceptors map[string][]Interceptor
 }
 
 // Enabled tells whether telemetry data collection is enabled.

--- a/pkg/telemetry/phonehome/hash.go
+++ b/pkg/telemetry/phonehome/hash.go
@@ -9,9 +9,8 @@ import (
 )
 
 func hash(id string) string {
-	sha := sha256.New()
-	_, _ = sha.Write([]byte(id))
-	return base64.StdEncoding.EncodeToString(sha.Sum(nil))
+	h := sha256.Sum256([]byte(id))
+	return base64.StdEncoding.EncodeToString(h[:])
 }
 
 // HashUserID anonymizes user ID so that it can be sent to the external

--- a/pkg/telemetry/phonehome/hash_test.go
+++ b/pkg/telemetry/phonehome/hash_test.go
@@ -39,3 +39,8 @@ func TestConfig_HashUserAuthID(t *testing.T) {
 	h = cfg.HashUserAuthID(id)
 	assert.Equal(t, hash("test-client:test-provider:test-id"), h)
 }
+
+func TestConfig_HashAdminUserID(t *testing.T) {
+	admin := "2a3e1829-8f84-40c1-a761-006f07a59666:4df1b98c-24ed-4073-a9ad-356aec6bb62d:admin"
+	assert.Equal(t, "+5GOIqkMuJMFDqJcMKvAGvbSRtCUjqdCB+UeU1hOqQA=", hash(admin))
+}

--- a/pkg/telemetry/phonehome/interceptor.go
+++ b/pkg/telemetry/phonehome/interceptor.go
@@ -19,8 +19,8 @@ type RequestParams struct {
 	UserID    authn.Identity
 	Path      string
 	Code      int
-	GrpcReq   any
-	HttpReq   *http.Request
+	GRPCReq   any
+	HTTPReq   *http.Request
 }
 
 var (
@@ -55,7 +55,7 @@ func getGrpcRequestDetails(ctx context.Context, err error, info *grpc.UnaryServe
 		UserID:    id,
 		Path:      info.FullMethod,
 		Code:      int(erroxGRPC.RoxErrorToGRPCCode(err)),
-		GrpcReq:   req,
+		GRPCReq:   req,
 	}
 }
 
@@ -70,6 +70,6 @@ func getHttpRequestDetails(ctx context.Context, r *http.Request, err error) *Req
 		UserID:    id,
 		Path:      r.URL.Path,
 		Code:      grpcError.ErrToHTTPStatus(err),
-		HttpReq:   r,
+		HTTPReq:   r,
 	}
 }

--- a/pkg/telemetry/phonehome/interceptor.go
+++ b/pkg/telemetry/phonehome/interceptor.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"net/http"
 	"strings"
-	"sync"
 
 	erroxGRPC "github.com/stackrox/rox/pkg/errox/grpc"
 	"github.com/stackrox/rox/pkg/grpc/authn"
 	grpcError "github.com/stackrox/rox/pkg/grpc/errors"
 	"github.com/stackrox/rox/pkg/grpc/requestinfo"
+	"github.com/stackrox/rox/pkg/sync"
 	"google.golang.org/grpc"
 )
 

--- a/pkg/telemetry/phonehome/interceptor.go
+++ b/pkg/telemetry/phonehome/interceptor.go
@@ -13,16 +13,6 @@ import (
 	"google.golang.org/grpc"
 )
 
-// RequestParams holds intercepted call parameters.
-type RequestParams struct {
-	UserAgent string
-	UserID    authn.Identity
-	Path      string
-	Code      int
-	GRPCReq   any
-	HTTPReq   *http.Request
-}
-
 var (
 	mux = &sync.Mutex{}
 )

--- a/pkg/telemetry/phonehome/interceptor.go
+++ b/pkg/telemetry/phonehome/interceptor.go
@@ -1,0 +1,122 @@
+package phonehome
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"sync"
+
+	"github.com/pkg/errors"
+	erroxGRPC "github.com/stackrox/rox/pkg/errox/grpc"
+	"github.com/stackrox/rox/pkg/grpc/authn"
+	grpcError "github.com/stackrox/rox/pkg/grpc/errors"
+	"github.com/stackrox/rox/pkg/grpc/requestinfo"
+	"github.com/stackrox/rox/pkg/httputil"
+	"google.golang.org/grpc"
+)
+
+// RequestParams holds intercepted call parameters.
+type RequestParams struct {
+	UserAgent string
+	UserID    authn.Identity
+	Path      string
+	Code      int
+	GrpcReq   any
+	HttpReq   *http.Request
+}
+
+var (
+	mux = &sync.Mutex{}
+)
+
+// AddInterceptorFunc appends the custom list of telemetry interceptors with the
+// provided function.
+func (cfg *Config) AddInterceptorFunc(event string, f Interceptor) {
+	mux.Lock()
+	defer mux.Unlock()
+	if cfg.interceptors == nil {
+		cfg.interceptors = make(map[string][]Interceptor, 1)
+	}
+	cfg.interceptors[event] = append(cfg.interceptors[event], f)
+}
+
+func (cfg *Config) track(rp *RequestParams, t Telemeter) {
+	for event, funcs := range cfg.interceptors {
+		props := map[string]any{}
+		ok := true
+		for _, interceptor := range funcs {
+			if ok = interceptor(rp, props); !ok {
+				break
+			}
+		}
+		if ok {
+			t.Track(event, cfg.HashUserAuthID(rp.UserID), props)
+		}
+	}
+}
+
+func (cfg *Config) getGrpcRequestDetails(ctx context.Context, err error, info *grpc.UnaryServerInfo, req any) *RequestParams {
+	id, iderr := authn.IdentityFromContext(ctx)
+	if iderr != nil {
+		log.Debug("Cannot identify user from context: ", iderr)
+	}
+
+	ri := requestinfo.FromContext(ctx)
+	return &RequestParams{
+		UserAgent: strings.Join(ri.Metadata.Get("User-Agent"), ", "),
+		UserID:    id,
+		Path:      info.FullMethod,
+		Code:      int(erroxGRPC.RoxErrorToGRPCCode(err)),
+		GrpcReq:   req,
+	}
+}
+
+func (cfg *Config) getHttpRequestDetails(ctx context.Context, r *http.Request, err error) *RequestParams {
+	id, iderr := authn.IdentityFromContext(ctx)
+	if iderr != nil {
+		log.Debug("Cannot identify user from context: ", iderr)
+	}
+
+	return &RequestParams{
+		UserAgent: strings.Join(r.Header.Values("User-Agent"), ", "),
+		UserID:    id,
+		Path:      r.URL.Path,
+		Code:      grpcError.ErrToHTTPStatus(err),
+		HttpReq:   r,
+	}
+}
+
+// getGRPCInterceptor returns an API interceptor function for GRPC requests.
+func (cfg *Config) getGRPCInterceptor(t Telemeter) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		resp, err := handler(ctx, req)
+		rp := cfg.getGrpcRequestDetails(ctx, err, info, req)
+		go cfg.track(rp, t)
+		return resp, err
+	}
+}
+
+func statusCodeToError(code *int) error {
+	if code == nil || *code == http.StatusOK {
+		return nil
+	}
+	return errors.Errorf("%d %s", *code, http.StatusText(*code))
+}
+
+// getHTTPInterceptor returns an API interceptor function for HTTP requests.
+func (cfg *Config) getHTTPInterceptor(t Telemeter) httputil.HTTPInterceptor {
+	return func(handler http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			statusTrackingWriter := httputil.NewStatusTrackingWriter(w)
+			handler.ServeHTTP(statusTrackingWriter, r)
+			rp := cfg.getHttpRequestDetails(r.Context(), r, statusCodeToError(statusTrackingWriter.GetStatusCode()))
+			go cfg.track(rp, t)
+		})
+	}
+}
+
+// MakeInterceptors returns a couple of interceptors.
+func (cfg *Config) MakeInterceptors() (grpc.UnaryServerInterceptor, httputil.HTTPInterceptor) {
+	t := cfg.Telemeter()
+	return cfg.getGRPCInterceptor(t), cfg.getHTTPInterceptor(t)
+}

--- a/pkg/telemetry/phonehome/interceptor.go
+++ b/pkg/telemetry/phonehome/interceptor.go
@@ -33,7 +33,7 @@ func (cfg *Config) track(rp *RequestParams) {
 	}
 }
 
-func getGrpcRequestDetails(ctx context.Context, err error, info *grpc.UnaryServerInfo, req any) *RequestParams {
+func getGRPCRequestDetails(ctx context.Context, err error, info *grpc.UnaryServerInfo, req any) *RequestParams {
 	id, iderr := authn.IdentityFromContext(ctx)
 	if iderr != nil {
 		log.Debug("Cannot identify user from context: ", iderr)
@@ -49,7 +49,7 @@ func getGrpcRequestDetails(ctx context.Context, err error, info *grpc.UnaryServe
 	}
 }
 
-func getHttpRequestDetails(ctx context.Context, r *http.Request, err error) *RequestParams {
+func getHTTPRequestDetails(ctx context.Context, r *http.Request, err error) *RequestParams {
 	id, iderr := authn.IdentityFromContext(ctx)
 	if iderr != nil {
 		log.Debug("Cannot identify user from context: ", iderr)

--- a/pkg/telemetry/phonehome/interceptor_test.go
+++ b/pkg/telemetry/phonehome/interceptor_test.go
@@ -117,7 +117,7 @@ func (s *interceptorTestSuite) TestGrpcRequestInfo() {
 	ctx, err := rih.UpdateContextForGRPC(metadata.NewIncomingContext(ctx, md))
 	s.NoError(err)
 
-	rp := getGrpcRequestDetails(ctx, err, &grpc.UnaryServerInfo{
+	rp := getGRPCRequestDetails(ctx, err, &grpc.UnaryServerInfo{
 		FullMethod: testRP.Path,
 	}, "request")
 	s.Equal(testRP.Path, rp.Path)
@@ -141,7 +141,7 @@ func (s *interceptorTestSuite) TestHttpRequestInfo() {
 	req.Header.Add("User-Agent", testRP.UserAgent)
 
 	ctx := authn.ContextWithIdentity(context.Background(), testRP.UserID, nil)
-	rp := getHttpRequestDetails(ctx, req, err)
+	rp := getHTTPRequestDetails(ctx, req, err)
 	s.Equal(testRP.Path, rp.Path)
 	s.Equal(testRP.Code, rp.Code)
 	s.Equal(testRP.UserAgent, rp.UserAgent)

--- a/pkg/telemetry/phonehome/interceptor_test.go
+++ b/pkg/telemetry/phonehome/interceptor_test.go
@@ -45,7 +45,7 @@ func (s *interceptorTestSuite) TestAddGrpcInterceptor() {
 		Code:      0,
 		UserAgent: "test",
 		UserID:    nil,
-		GrpcReq: &testRequest{
+		GRPCReq: &testRequest{
 			value: "test value",
 		},
 	}
@@ -56,7 +56,7 @@ func (s *interceptorTestSuite) TestAddGrpcInterceptor() {
 
 	cfg.AddInterceptorFunc("TestEvent", func(rp *RequestParams, props map[string]any) bool {
 		if rp.Path == testRP.Path {
-			if tr, ok := rp.GrpcReq.(*testRequest); ok {
+			if tr, ok := rp.GRPCReq.(*testRequest); ok {
 				props["Property"] = tr.value
 			}
 		}
@@ -80,7 +80,7 @@ func (s *interceptorTestSuite) TestAddHttpInterceptor() {
 	}
 	req, err := http.NewRequest(http.MethodPost, "https://test"+testRP.Path+"?test_key=test_value", nil)
 	s.NoError(err)
-	testRP.HttpReq = req
+	testRP.HTTPReq = req
 	cfg := &Config{
 		ClientID:  "test",
 		telemeter: s.mockTelemeter,
@@ -88,7 +88,7 @@ func (s *interceptorTestSuite) TestAddHttpInterceptor() {
 
 	cfg.AddInterceptorFunc("TestEvent", func(rp *RequestParams, props map[string]any) bool {
 		if rp.Path == testRP.Path {
-			props["Property"] = rp.HttpReq.FormValue("test_key")
+			props["Property"] = rp.HTTPReq.FormValue("test_key")
 		}
 		return true
 	})
@@ -104,7 +104,6 @@ func (s *interceptorTestSuite) TestAddHttpInterceptor() {
 
 func (s *interceptorTestSuite) TestGrpcRequestInfo() {
 	testRP := &RequestParams{
-		UserID:    nil,
 		Code:      0,
 		UserAgent: "test",
 		Path:      "/v1.Test",
@@ -125,7 +124,7 @@ func (s *interceptorTestSuite) TestGrpcRequestInfo() {
 	s.Equal(testRP.Code, rp.Code)
 	s.Equal(testRP.UserAgent, rp.UserAgent)
 	s.Nil(rp.UserID)
-	s.Equal("request", rp.GrpcReq)
+	s.Equal("request", rp.GRPCReq)
 }
 
 func (s *interceptorTestSuite) TestHttpRequestInfo() {

--- a/pkg/telemetry/phonehome/interceptor_test.go
+++ b/pkg/telemetry/phonehome/interceptor_test.go
@@ -1,0 +1,154 @@
+package phonehome
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stackrox/rox/pkg/grpc/authn"
+	idmocks "github.com/stackrox/rox/pkg/grpc/authn/mocks"
+	"github.com/stackrox/rox/pkg/grpc/requestinfo"
+	"github.com/stackrox/rox/pkg/telemetry/phonehome/mocks"
+	"github.com/stretchr/testify/suite"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/peer"
+)
+
+type interceptorTestSuite struct {
+	suite.Suite
+
+	mockTelemeter *mocks.MockTelemeter
+	ctrl          *gomock.Controller
+}
+
+var _ suite.SetupTestSuite = (*interceptorTestSuite)(nil)
+
+func TestInterceptor(t *testing.T) {
+	suite.Run(t, new(interceptorTestSuite))
+}
+
+func (s *interceptorTestSuite) SetupTest() {
+	s.ctrl = gomock.NewController(s.T())
+	s.mockTelemeter = mocks.NewMockTelemeter(s.ctrl)
+}
+
+type testRequest struct {
+	value string
+}
+
+func (s *interceptorTestSuite) TestAddGrpcInterceptor() {
+	testRP := &RequestParams{
+		Path:      "/v1.Abc",
+		Code:      0,
+		UserAgent: "test",
+		UserID:    nil,
+		GrpcReq: &testRequest{
+			value: "test value",
+		},
+	}
+	cfg := &Config{
+		ClientID: "test",
+	}
+
+	cfg.AddInterceptorFunc("TestEvent", func(rp *RequestParams, props map[string]any) bool {
+		if rp.Path == testRP.Path {
+			if tr, ok := rp.GrpcReq.(*testRequest); ok {
+				props["Property"] = tr.value
+			}
+		}
+		return true
+	})
+
+	s.mockTelemeter.EXPECT().Track("TestEvent", cfg.HashUserAuthID(nil), map[string]any{
+		"Property": "test value",
+	}).Times(1)
+
+	cfg.track(testRP, s.mockTelemeter)
+}
+
+func (s *interceptorTestSuite) TestAddHttpInterceptor() {
+	mockID := idmocks.NewMockIdentity(s.ctrl)
+	testRP := &RequestParams{
+		Path:      "/v1/abc",
+		Code:      200,
+		UserAgent: "test",
+		UserID:    mockID,
+	}
+	req, err := http.NewRequest(http.MethodPost, "https://test"+testRP.Path+"?test_key=test_value", nil)
+	s.NoError(err)
+	testRP.HttpReq = req
+	cfg := &Config{
+		ClientID: "test",
+	}
+
+	cfg.AddInterceptorFunc("TestEvent", func(rp *RequestParams, props map[string]any) bool {
+		if rp.Path == testRP.Path {
+			props["Property"] = rp.HttpReq.FormValue("test_key")
+		}
+		return true
+	})
+
+	mockID.EXPECT().ExternalAuthProvider().Return(nil).Times(2)
+	mockID.EXPECT().UID().Return("id").Times(2)
+	s.mockTelemeter.EXPECT().Track("TestEvent", cfg.HashUserAuthID(mockID), map[string]any{
+		"Property": "test_value",
+	}).Times(1)
+
+	cfg.track(testRP, s.mockTelemeter)
+}
+
+func (s *interceptorTestSuite) TestGrpcRequestInfo() {
+	testRP := &RequestParams{
+		UserID:    nil,
+		Code:      0,
+		UserAgent: "test",
+		Path:      "/v1.Test",
+	}
+	cfg := &Config{
+		ClientID: "test",
+	}
+
+	md := metadata.New(nil)
+	md.Set("User-Agent", testRP.UserAgent)
+	ctx := peer.NewContext(context.Background(), &peer.Peer{Addr: &net.UnixAddr{Net: "pipe"}})
+
+	rih := requestinfo.NewRequestInfoHandler()
+	ctx, err := rih.UpdateContextForGRPC(metadata.NewIncomingContext(ctx, md))
+	s.NoError(err)
+
+	rp := cfg.getGrpcRequestDetails(ctx, err, &grpc.UnaryServerInfo{
+		FullMethod: testRP.Path,
+	}, "request")
+	s.Equal(testRP.Path, rp.Path)
+	s.Equal(testRP.Code, rp.Code)
+	s.Equal(testRP.UserAgent, rp.UserAgent)
+	s.Nil(rp.UserID)
+	s.Equal("request", rp.GrpcReq)
+}
+
+func (s *interceptorTestSuite) TestHttpRequestInfo() {
+	mockID := idmocks.NewMockIdentity(s.ctrl)
+	testRP := &RequestParams{
+		UserID:    mockID,
+		Code:      200,
+		UserAgent: "test",
+		Path:      "/v1/test",
+	}
+	cfg := &Config{
+		ClientID: "test",
+	}
+
+	req, err := http.NewRequest(http.MethodPost, "https://test"+testRP.Path+"?test_key=test_value", nil)
+	s.NoError(err)
+	req.Header.Add("User-Agent", testRP.UserAgent)
+
+	ctx := authn.ContextWithIdentity(context.Background(), testRP.UserID, nil)
+	rp := cfg.getHttpRequestDetails(ctx, req, err)
+	s.Equal(testRP.Path, rp.Path)
+	s.Equal(testRP.Code, rp.Code)
+	s.Equal(testRP.UserAgent, rp.UserAgent)
+	s.Equal(mockID, rp.UserID)
+}

--- a/pkg/telemetry/phonehome/request_params.go
+++ b/pkg/telemetry/phonehome/request_params.go
@@ -1,0 +1,59 @@
+package phonehome
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/stackrox/rox/pkg/grpc/authn"
+)
+
+// RequestParams holds intercepted call parameters.
+type RequestParams struct {
+	UserAgent string
+	UserID    authn.Identity
+	Path      string
+	Code      int
+	GRPCReq   any
+	HTTPReq   *http.Request
+}
+
+// GetProtocol returns HTTP for requests with HTTP request and gRPC otherwise.
+func (rp *RequestParams) GetProtocol() string {
+	if rp.HTTPReq != nil {
+		return "HTTP"
+	}
+	return "gRPC"
+}
+
+// GetMethod returns the HTTP method for HTTP requests, or the method matching
+// the API path prefix for gRPC requests. Default: GET.
+func (rp *RequestParams) GetMethod() string {
+	if rp.HTTPReq != nil {
+		if rp.HTTPReq.Method == "" {
+			return http.MethodGet
+		}
+	} else {
+		path := rp.Path[strings.LastIndex(rp.Path, "/")+1:]
+		switch {
+		case strings.HasPrefix(path, "Get"):
+			return http.MethodGet
+		case strings.HasPrefix(path, "Post"):
+			return http.MethodPost
+		case strings.HasPrefix(path, "Put"):
+			return http.MethodPut
+		case strings.HasPrefix(path, "Delete"):
+			return http.MethodDelete
+		case strings.HasPrefix(path, "Patch"):
+			return http.MethodPatch
+		case strings.HasPrefix(path, "Head"):
+			return http.MethodHead
+		case strings.HasPrefix(path, "Connect"):
+			return http.MethodConnect
+		case strings.HasPrefix(path, "Options"):
+			return http.MethodOptions
+		case strings.HasPrefix(path, "Trace"):
+			return http.MethodTrace
+		}
+	}
+	return http.MethodGet
+}

--- a/pkg/telemetry/phonehome/request_params.go
+++ b/pkg/telemetry/phonehome/request_params.go
@@ -2,7 +2,6 @@ package phonehome
 
 import (
 	"net/http"
-	"strings"
 
 	"github.com/stackrox/rox/pkg/grpc/authn"
 )
@@ -17,35 +16,14 @@ type RequestParams struct {
 	HTTPReq   *http.Request
 }
 
-// GetMethod returns the HTTP method for HTTP requests, or the method matching
-// the API path prefix for gRPC requests. Default: GET.
+// GetMethod returns the HTTP method for HTTP requests, or rp.Path otherwise.
 func (rp *RequestParams) GetMethod() string {
-	if rp.HTTPReq != nil {
-		if rp.HTTPReq.Method == "" {
-			return http.MethodGet
-		}
-	} else {
-		path := rp.Path[strings.LastIndex(rp.Path, "/")+1:]
-		switch {
-		case strings.HasPrefix(path, "Get"):
-			return http.MethodGet
-		case strings.HasPrefix(path, "Post"):
-			return http.MethodPost
-		case strings.HasPrefix(path, "Put"):
-			return http.MethodPut
-		case strings.HasPrefix(path, "Delete"):
-			return http.MethodDelete
-		case strings.HasPrefix(path, "Patch"):
-			return http.MethodPatch
-		case strings.HasPrefix(path, "Head"):
-			return http.MethodHead
-		case strings.HasPrefix(path, "Connect"):
-			return http.MethodConnect
-		case strings.HasPrefix(path, "Options"):
-			return http.MethodOptions
-		case strings.HasPrefix(path, "Trace"):
-			return http.MethodTrace
-		}
+	switch {
+	case rp.HTTPReq == nil:
+		return rp.Path // i.e. in the form of /service/method for gRPC requests.
+	case rp.HTTPReq.Method != "":
+		return rp.HTTPReq.Method
+	default:
+		return http.MethodGet
 	}
-	return http.MethodGet
 }

--- a/pkg/telemetry/phonehome/request_params.go
+++ b/pkg/telemetry/phonehome/request_params.go
@@ -17,14 +17,6 @@ type RequestParams struct {
 	HTTPReq   *http.Request
 }
 
-// GetProtocol returns HTTP for requests with HTTP request and gRPC otherwise.
-func (rp *RequestParams) GetProtocol() string {
-	if rp.HTTPReq != nil {
-		return "HTTP"
-	}
-	return "gRPC"
-}
-
 // GetMethod returns the HTTP method for HTTP requests, or the method matching
 // the API path prefix for gRPC requests. Default: GET.
 func (rp *RequestParams) GetMethod() string {

--- a/pkg/telemetry/phonehome/request_params_test.go
+++ b/pkg/telemetry/phonehome/request_params_test.go
@@ -8,30 +8,13 @@ import (
 )
 
 func TestRequestParams_GetMethod(t *testing.T) {
-	methods := map[string]string{
-		"Get":     http.MethodGet,
-		"Post":    http.MethodPost,
-		"Put":     http.MethodPut,
-		"Delete":  http.MethodDelete,
-		"Patch":   http.MethodPatch,
-		"Head":    http.MethodHead,
-		"Connect": http.MethodConnect,
-		"Options": http.MethodOptions,
-		"Trace":   http.MethodTrace,
-		"Sixth":   http.MethodGet,
-	}
-	for prefix, method := range methods {
-		rp := &RequestParams{
-			Path: "/v1.Service/" + prefix + "Finger",
-		}
-		assert.Equal(t, method, rp.GetMethod())
-	}
-	rp := &RequestParams{
-		Path: "",
-	}
-	assert.Equal(t, http.MethodGet, rp.GetMethod())
-	rp = &RequestParams{
-		Path: "PutFinger",
-	}
-	assert.Equal(t, http.MethodPut, rp.GetMethod())
+	rp := &RequestParams{Path: "/v1.Service/Method"}
+	assert.Equal(t, rp.Path, rp.GetMethod(), "must be equal to Path, as there's no request details")
+
+	rp = &RequestParams{Path: "/v1/method"}
+	rp.HTTPReq, _ = http.NewRequest(http.MethodPost, "/path", nil)
+	assert.Equal(t, http.MethodPost, rp.GetMethod(), "must be POST, as the HTTP request is provided")
+
+	rp.HTTPReq, _ = http.NewRequest("", "/path", nil)
+	assert.Equal(t, http.MethodGet, rp.GetMethod(), "must be GET, as this is the default HTTP method")
 }

--- a/pkg/telemetry/phonehome/request_params_test.go
+++ b/pkg/telemetry/phonehome/request_params_test.go
@@ -7,21 +7,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestRequestParams_GetProtocol(t *testing.T) {
-	rp := &RequestParams{
-		HTTPReq: &http.Request{},
-	}
-	assert.Equal(t, "HTTP", rp.GetProtocol())
-
-	rp = &RequestParams{
-		GRPCReq: &http.Request{},
-	}
-	assert.Equal(t, "gRPC", rp.GetProtocol())
-
-	rp = &RequestParams{}
-	assert.Equal(t, "gRPC", rp.GetProtocol())
-}
-
 func TestRequestParams_GetMethod(t *testing.T) {
 	methods := map[string]string{
 		"Get":     http.MethodGet,

--- a/pkg/telemetry/phonehome/request_params_test.go
+++ b/pkg/telemetry/phonehome/request_params_test.go
@@ -1,0 +1,52 @@
+package phonehome
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRequestParams_GetProtocol(t *testing.T) {
+	rp := &RequestParams{
+		HTTPReq: &http.Request{},
+	}
+	assert.Equal(t, "HTTP", rp.GetProtocol())
+
+	rp = &RequestParams{
+		GRPCReq: &http.Request{},
+	}
+	assert.Equal(t, "gRPC", rp.GetProtocol())
+
+	rp = &RequestParams{}
+	assert.Equal(t, "gRPC", rp.GetProtocol())
+}
+
+func TestRequestParams_GetMethod(t *testing.T) {
+	methods := map[string]string{
+		"Get":     http.MethodGet,
+		"Post":    http.MethodPost,
+		"Put":     http.MethodPut,
+		"Delete":  http.MethodDelete,
+		"Patch":   http.MethodPatch,
+		"Head":    http.MethodHead,
+		"Connect": http.MethodConnect,
+		"Options": http.MethodOptions,
+		"Trace":   http.MethodTrace,
+		"Sixth":   http.MethodGet,
+	}
+	for prefix, method := range methods {
+		rp := &RequestParams{
+			Path: "/v1.Service/" + prefix + "Finger",
+		}
+		assert.Equal(t, method, rp.GetMethod())
+	}
+	rp := &RequestParams{
+		Path: "",
+	}
+	assert.Equal(t, http.MethodGet, rp.GetMethod())
+	rp = &RequestParams{
+		Path: "PutFinger",
+	}
+	assert.Equal(t, http.MethodPut, rp.GetMethod())
+}


### PR DESCRIPTION
## Description

Another piece of #3819.
API call interceptor, that issues various events from configured filters.

`ROX_TELEMETRY_API_WHITELIST` environment variable may be set on the central deployment with a comma separated list of API paths (or "*" for any path except a hardcoded list of ignored ones), which will trigger generic "API Call" events, with three properties:
* Path — the API Path;
* Code — the service response status code;
* User-Agent — the client's User Agent;
* HTTP Method, or something alike computed from gRPC method.

Other implemented events are:
* "Cluster Registered", for when a cluster is posted to the DB;
* "Cluster Initialized", for when a cluster changes its state from `UNINITIALIZED` to something;
* "roxctl", for when an API is called by `roxctl`.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

Unit tests.

Example of an "API Call" event received by Segment:
```json
{
  "context": {
    "Client ID": "2a3e1829-8f84-40c1-a761-006f07a59666",
    "Client Name": "Central",
    "library": {
      "name": "analytics-go",
      "version": "3.0.0"
    }
  },
  "event": "API Call",
  "integrations": {},
  "messageId": "59a4f17d-616f-4588-bfc0-c88890330441",
  "originalTimestamp": "2022-12-13T17:51:42.079249978Z",
  "properties": {
    "Code": 500,
    "Method": "GET",
    "Path": "/api/extensions/scannerdefinitions",
    "User-Agent": "Go-http-client/1.1"
  },
  "receivedAt": "2022-12-13T17:52:18.204Z",
  "sentAt": "2022-12-13T17:52:18.113Z",
  "timestamp": "2022-12-13T17:51:42.170Z",
  "type": "track",
  "userId": "fxVLkxH4kOj9UdfZOP3Rcz8Yw/64sAyZgoMXJ6cGynE=",
  "writeKey": "..."
}
```
