### PR TITLE
Upgrade redoc library to fix disappearing menu

### DIFF
--- a/ui/apps/platform/package.json
+++ b/ui/apps/platform/package.json
@@ -87,7 +87,7 @@
         "react-transition-group": "^4.4.1",
         "react-truncate": "^2.4.0",
         "react-vis": "^1.11.5",
-        "redoc": "2.0.0-rc.74",
+        "redoc": "^2.0.0",
         "redux": "^4.1.2",
         "redux-form": "^8.3.7",
         "redux-saga": "^0.16.0",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -14667,10 +14667,10 @@ pend@~1.2.0:
   resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
   integrity sha1-elfrVQpng/kRUzH89GY9XI4AelA=
 
-perfect-scrollbar@^1.5.1:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/perfect-scrollbar/-/perfect-scrollbar-1.5.2.tgz#41167ac6bc95e3a5e87a7402fa36fdacca9bc298"
-  integrity sha512-McHAinFkyzKbBZrFtb4MT2mxkehp15KvOX/UrjB8C5EZZXHTHgyETo5IGFYtHRTI2Pb2bsV0OE0YnkjT9Cw3aw==
+perfect-scrollbar@^1.5.5:
+  version "1.5.5"
+  resolved "https://registry.yarnpkg.com/perfect-scrollbar/-/perfect-scrollbar-1.5.5.tgz#41a211a2fb52a7191eff301432134ea47052b27f"
+  integrity sha512-dzalfutyP3e/FOpdlhVryN4AJ5XDVauVWxybSkLZmakFE2sS3y3pc4JnSprw8tGmHvkaG5Edr5T7LBTZ+WWU2g==
 
 performance-now@^0.2.0:
   version "0.2.0"
@@ -16526,10 +16526,10 @@ redent@^4.0.0:
     indent-string "^5.0.0"
     strip-indent "^4.0.0"
 
-redoc@2.0.0-rc.74:
-  version "2.0.0-rc.74"
-  resolved "https://registry.yarnpkg.com/redoc/-/redoc-2.0.0-rc.74.tgz#29b30002ace4863a5a5f21f44af9369ff047266e"
-  integrity sha512-OeOWGcbmVdfVgN//7ispiRX0fhD7Gk3tWcERugyFfP8QX/1Pttw3jRYSXmiB0i+H48zFn20K1cMppBp/qzm5xQ==
+redoc@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/redoc/-/redoc-2.0.0.tgz#8b3047ca75b84d31558c6c92da7f84affef35c3e"
+  integrity sha512-rU8iLdAkT89ywOkYk66Mr+IofqaMASlRvTew0dJvopCORMIPUcPMxjlJbJNC6wsn2vvMnpUFLQ/0ISDWn9BWag==
   dependencies:
     "@redocly/openapi-core" "^1.0.0-beta.104"
     classnames "^2.3.1"
@@ -16543,7 +16543,7 @@ redoc@2.0.0-rc.74:
     mobx-react "^7.2.0"
     openapi-sampler "^1.3.0"
     path-browserify "^1.0.1"
-    perfect-scrollbar "^1.5.1"
+    perfect-scrollbar "^1.5.5"
     polished "^4.1.3"
     prismjs "^1.27.0"
     prop-types "^15.7.2"


### PR DESCRIPTION
## Description

The last menu item in the list of API services, VulnerabilityRequestService, would not appear unless you manually scrolled down to it and clicked around.

Upgrading to the latest version of this Swagger rendering library fixes it.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

Before upgrade
<img width="252" alt="Screen Shot 2022-12-08 at 7 42 56 PM" src="https://user-images.githubusercontent.com/715729/206596749-27bf864d-ddad-41f3-9df9-887829d9fbae.png">

After Upgrade
<img width="1599" alt="Screen Shot 2022-12-08 at 7 41 20 PM" src="https://user-images.githubusercontent.com/715729/206596769-5c6de732-d473-442d-b192-d77265789382.png">
