### PR TITLE
Call triggerScan in configmanagement ciscontrol integration test

### DIFF
--- a/ui/apps/platform/cypress/integration/configmanagement/ciscontrols.test.js
+++ b/ui/apps/platform/cypress/integration/configmanagement/ciscontrols.test.js
@@ -12,6 +12,7 @@ import {
 } from '../../helpers/configWorkflowUtils';
 import { selectors as configManagementSelectors } from '../../constants/ConfigManagementPage';
 import withAuth from '../../helpers/basicAuth';
+import { triggerScan } from '../../helpers/compliance';
 
 const entitiesKey = 'controls';
 
@@ -19,6 +20,9 @@ describe('Configuration Management Controls', () => {
     withAuth();
 
     it('should render the controls list and open the side panel when a row is clicked', () => {
+        // ROX-13537: See if compliance scan prevents failure of last tests because no Pass or no Fail status.
+        triggerScan();
+
         visitConfigurationManagementDashboard();
 
         // This and the following tests assumes that scan results are available


### PR DESCRIPTION
## Description

### Test failure

> Configuration Management Controls should show failing nodes in the control findings section of a failing control

> Timed out retrying after 4000ms: Expected to find element: `.rt-td:nth-child(4):contains("fail"):nth(0)`, but never found it.

cypress/integration/configmanagement/ciscontrols.test.js

### Analysis

Screenshot at failure has no controls with **Fail** status:
![screenshot](https://user-images.githubusercontent.com/11862657/206730305-8de20fca-20bb-4b54-aa45-fd77be00b666.png)

Video frame earlier in test file has first control with **Pass** status and the rest with **N/A** (elsewhere I have seen with dash).
<img width="1280" alt="video" src="https://user-images.githubusercontent.com/11862657/206730334-cacb26df-bb09-474e-973e-4a50d9d8cf5a.png">

1. No frontend exceptions in logimbue-data.json file from diagnostic bundle.
2. Only observation from central log file is timing of compliance runs.
    * Between 1 and 2 seconds time interval from starting to completed.
    * 2 individual runs and 2 sets of 6 runs for item 4 below:

        configmanagement/ciscontrols.test.js 23 + 1 = 24 seconds
        10:14:01.705924 Info: Starting compliance run for standard "CIS Docker v1.2.0"

        configmanagement/clusters.test.js 34 = 2 = 36 seconds
        skip test which depends on scan

        configmanagement/dashboard.test.js (16 / 26) * 42 = 26 and 24 + 36 + 26 = 1:26 compare 1:37 = 15:38 - 14:01
        10:15:38.928605 Info: Starting compliance run for standard "CIS Docker v1.2.0"

        configmanagement/nodes.test.js calls `triggerScan` function
        10:17:22.027370 Info: Starting compliance run for standard "NIST SP 800-53"
        10:17:22.027425 Info: Starting compliance run for standard "PCI DSS 3.2.1"
        10:17:22.027496 Info: Starting compliance run for standard "CIS Docker v1.2.0"
        10:17:22.027597 Info: Starting compliance run for standard "CIS Kubernetes v1.5"
        10:17:22.027622 Info: Starting compliance run for standard "HIPAA 164"
        10:17:22.027644 Info: Starting compliance run for standard "NIST SP 800-190"

        compliance/complianceDashboard.test.js calls `scanCompliance` function (equivalent to `triggerScan` but for test files in compliance folder versus test files in other folders)
        10:23:56.647087 Info: Starting compliance run for standard "NIST SP 800-53"
        10:23:56.647189 Info: Starting compliance run for standard "PCI DSS 3.2.1"
        10:23:56.647213 Info: Starting compliance run for standard "CIS Docker v1.2.0"
        10:23:56.647248 Info: Starting compliance run for standard "CIS Kubernetes v1.5"
        10:23:56.647267 Info: Starting compliance run for standard "HIPAA 164"
        10:23:56.647287 Info: Starting compliance run for standard "NIST SP 800-190"

Relative order of **configmanagement** and **compliance** subfolders from build-log.text file.

1. 1587833938636705792 from master build for 3631 on 2022-11-02 non-postgress
    * accessControl
    * clusters
    * collections
    * **compliance**
    * **configmanagement**

2. 1592222224792686592 from master build for 3793 on 2022-11-14 non-postgress
    * accessControl
    * clusters
    * collections
    * **configmanagement**
    * **compliance**

3. 1598752220898136064 from master build for 3999 on 2022-12-02 postgress
    * accessControl
    * clusters
    * collections
    * **configmanagement**
    * **compliance**

4. 1600787945571225600 from master build for 4061 on 2022-12-08 postgress
    * accessControl
    * clusters
    * **configmanagement**
    * collections
    * integrations
    * **compliance**

In 3 out of 4 investigated test failures, **configmanagement** preceded **compliance** subfolder.

### Step forward

See whether it makes a difference to visit Compliance and scan all standards before visit Configuration Management to scan CIS Docker v1.2.0 standard.

### Residue

1. Ask whether the hypothesis is plausible or what else to look for in logs.
2. Apply consistent changes to 3 configmanagement tests which depend on scan:
    * ciscontrols.test.js
    * clusters.test.js currently skipped `'should open the side panel to show the same number of Controls when the Controls link is clicked'` test
    * dashboard.test.js

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration test

## Testing Performed