### PR TITLE
Remove unnecessary ResetTimer() for symmetry

### DIFF
--- a/sensor/kubernetes/listener/resources/networkpolicy_store_bench_test.go
+++ b/sensor/kubernetes/listener/resources/networkpolicy_store_bench_test.go
@@ -129,7 +129,6 @@ func BenchmarkUpsert_Add(b *testing.B) {
 			s := newNetworkPoliciesStore()
 			populateStore(s, int64(math.Pow(10, float64(scale))), scale, allLabels16, allValues16)
 			b.Run(fmt.Sprintf("L=%d-N=10^%d", numLabels, scale), func(b *testing.B) {
-				b.ResetTimer()
 				for i := 0; i < b.N; i++ {
 					np := newNPDummy(uuid.NewV4().String(), getRandom(namespaces), selectors[labelIdx])
 					s.Upsert(np)


### PR DESCRIPTION
## Description

I don't think the `.ResetTimer()` is needed here. I was reading through https://go.dev/blog/subtests and as per `Table-driven benchmarks`:

> Each invocation of the Run method creates a separate benchmark. An enclosing benchmark function that calls a Run method is only run once and is not measured.

`.ResetTimer()` is only needed if the setup work is done inside the actual benchmark function. Since we're using sub-benchmarks, only the inner function is observed.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Ran benchmark using:

```
go test -benchmem -timeout 0 -cpu 1 -benchmem -run=^$ -bench ^Benchmark github.com/stackrox/rox/sensor/kubernetes/listener/resources
```
