### PR TITLE
Dashrews/migration prob

### DIFF
--- a/migrator/migrations/n_01_to_n_02_postgres_clusters/migration.go
+++ b/migrator/migrations/n_01_to_n_02_postgres_clusters/migration.go
@@ -24,6 +24,10 @@ var (
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 1,
 		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 2},
 		Run: func(databases *types.Databases) error {
+			if databases.PkgRocksDB == nil {
+				log.WriteToStderr("RocksDB is nil.  Skipping migration n01ton02")
+				return nil
+			}
 			legacyStore, err := legacy.New(databases.PkgRocksDB)
 			if err != nil {
 				return err

--- a/migrator/migrations/n_02_to_n_03_postgres_namespaces/migration.go
+++ b/migrator/migrations/n_02_to_n_03_postgres_namespaces/migration.go
@@ -24,6 +24,10 @@ var (
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 2,
 		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 3},
 		Run: func(databases *types.Databases) error {
+			if databases.PkgRocksDB == nil {
+				log.WriteToStderr("RocksDB is nil.  Skipping migration n02ton03")
+				return nil
+			}
 			legacyStore, err := legacy.New(databases.PkgRocksDB)
 			if err != nil {
 				return err

--- a/migrator/migrations/n_03_to_n_04_postgres_deployments/migration.go
+++ b/migrator/migrations/n_03_to_n_04_postgres_deployments/migration.go
@@ -25,6 +25,10 @@ var (
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 3,
 		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 4},
 		Run: func(databases *types.Databases) error {
+			if databases.PkgRocksDB == nil {
+				log.WriteToStderr("RocksDB is nil.  Skipping migration n03ton04")
+				return nil
+			}
 			legacyStore := legacy.New(rawDackbox.GetGlobalDackBox(), rawDackbox.GetKeyFence())
 			if err := move(databases.GormDB, databases.PostgresDB, legacyStore); err != nil {
 				return errors.Wrap(err,

--- a/migrator/migrations/n_04_to_n_05_postgres_images/migration.go
+++ b/migrator/migrations/n_04_to_n_05_postgres_images/migration.go
@@ -27,6 +27,10 @@ var (
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 4,
 		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 5},
 		Run: func(databases *types.Databases) error {
+			if databases.PkgRocksDB == nil {
+				log.WriteToStderr("RocksDB is nil.  Skipping migration n04ton05")
+				return nil
+			}
 			legacyStore := legacy.New(rawDackbox.GetGlobalDackBox(), rawDackbox.GetKeyFence(), false)
 			if err := move(databases.GormDB, databases.PostgresDB, legacyStore); err != nil {
 				return errors.Wrap(err,

--- a/migrator/migrations/n_05_to_n_06_postgres_active_components/migration.go
+++ b/migrator/migrations/n_05_to_n_06_postgres_active_components/migration.go
@@ -26,6 +26,10 @@ var (
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 5,
 		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 6},
 		Run: func(databases *types.Databases) error {
+			if databases.PkgRocksDB == nil {
+				log.WriteToStderr("RocksDB is nil.  Skipping migration n05ton06")
+				return nil
+			}
 			legacyStore := legacy.New(rawDackbox.GetGlobalDackBox(), rawDackbox.GetKeyFence())
 			if err := move(databases.GormDB, databases.PostgresDB, legacyStore); err != nil {
 				return errors.Wrap(err,

--- a/migrator/migrations/n_06_to_n_07_postgres_alerts/migration.go
+++ b/migrator/migrations/n_06_to_n_07_postgres_alerts/migration.go
@@ -24,6 +24,10 @@ var (
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 6,
 		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 7},
 		Run: func(databases *types.Databases) error {
+			if databases.PkgRocksDB == nil {
+				log.WriteToStderr("RocksDB is nil.  Skipping migration n06ton07")
+				return nil
+			}
 			legacyStore, err := legacy.New(databases.PkgRocksDB)
 			if err != nil {
 				return err

--- a/migrator/migrations/n_07_to_n_08_postgres_api_tokens/migration.go
+++ b/migrator/migrations/n_07_to_n_08_postgres_api_tokens/migration.go
@@ -24,6 +24,10 @@ var (
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 7,
 		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 8},
 		Run: func(databases *types.Databases) error {
+			if databases.PkgRocksDB == nil {
+				log.WriteToStderr("RocksDB is nil.  Skipping migration n07ton08")
+				return nil
+			}
 			legacyStore, err := legacy.New(databases.PkgRocksDB)
 			if err != nil {
 				return err

--- a/migrator/migrations/n_08_to_n_09_postgres_auth_providers/migration.go
+++ b/migrator/migrations/n_08_to_n_09_postgres_auth_providers/migration.go
@@ -24,6 +24,10 @@ var (
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 8,
 		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 9},
 		Run: func(databases *types.Databases) error {
+			if databases.BoltDB == nil {
+				log.WriteToStderr("Bolt is nil.  Skipping migration n08ton09")
+				return nil
+			}
 			legacyStore := legacy.New(databases.BoltDB)
 			if err := move(databases.GormDB, databases.PostgresDB, legacyStore); err != nil {
 				return errors.Wrap(err,

--- a/migrator/migrations/n_09_to_n_10_postgres_cluster_cves/migration.go
+++ b/migrator/migrations/n_09_to_n_10_postgres_cluster_cves/migration.go
@@ -27,6 +27,10 @@ var (
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 9,
 		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 10},
 		Run: func(databases *types.Databases) error {
+			if databases.PkgRocksDB == nil {
+				log.WriteToStderr("RocksDB is nil.  Skipping migration n09ton10")
+				return nil
+			}
 			legacyStore := legacy.New(rawDackbox.GetGlobalDackBox(), rawDackbox.GetKeyFence())
 			if err := move(databases.GormDB, databases.PostgresDB, legacyStore); err != nil {
 				return errors.Wrap(err,

--- a/migrator/migrations/n_10_to_n_11_postgres_cluster_health_statuses/migration.go
+++ b/migrator/migrations/n_10_to_n_11_postgres_cluster_health_statuses/migration.go
@@ -24,6 +24,10 @@ var (
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 10,
 		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 11},
 		Run: func(databases *types.Databases) error {
+			if databases.PkgRocksDB == nil {
+				log.WriteToStderr("RocksDB is nil.  Skipping migration n10ton11")
+				return nil
+			}
 			legacyStore, err := legacy.New(databases.PkgRocksDB)
 			if err != nil {
 				return err

--- a/migrator/migrations/n_11_to_n_12_postgres_cluster_init_bundles/migration.go
+++ b/migrator/migrations/n_11_to_n_12_postgres_cluster_init_bundles/migration.go
@@ -24,6 +24,10 @@ var (
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 11,
 		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 12},
 		Run: func(databases *types.Databases) error {
+			if databases.PkgRocksDB == nil {
+				log.WriteToStderr("RocksDB is nil.  Skipping migration n11ton12")
+				return nil
+			}
 			legacyStore, err := legacy.New(databases.PkgRocksDB)
 			if err != nil {
 				return err

--- a/migrator/migrations/n_12_to_n_13_postgres_compliance_domains/migration.go
+++ b/migrator/migrations/n_12_to_n_13_postgres_compliance_domains/migration.go
@@ -24,6 +24,10 @@ var (
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 12,
 		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 13},
 		Run: func(databases *types.Databases) error {
+			if databases.PkgRocksDB == nil {
+				log.WriteToStderr("RocksDB is nil.  Skipping migration n12ton13")
+				return nil
+			}
 			legacyStore, err := legacy.New(databases.PkgRocksDB)
 			if err != nil {
 				return err

--- a/migrator/migrations/n_13_to_n_14_postgres_compliance_operator_check_results/migration.go
+++ b/migrator/migrations/n_13_to_n_14_postgres_compliance_operator_check_results/migration.go
@@ -24,6 +24,10 @@ var (
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 13,
 		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 14},
 		Run: func(databases *types.Databases) error {
+			if databases.PkgRocksDB == nil {
+				log.WriteToStderr("RocksDB is nil.  Skipping migration n13ton14")
+				return nil
+			}
 			legacyStore, err := legacy.New(databases.PkgRocksDB)
 			if err != nil {
 				return err

--- a/migrator/migrations/n_14_to_n_15_postgres_compliance_operator_profiles/migration.go
+++ b/migrator/migrations/n_14_to_n_15_postgres_compliance_operator_profiles/migration.go
@@ -24,6 +24,10 @@ var (
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 14,
 		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 15},
 		Run: func(databases *types.Databases) error {
+			if databases.PkgRocksDB == nil {
+				log.WriteToStderr("RocksDB is nil.  Skipping migration n14ton15")
+				return nil
+			}
 			legacyStore, err := legacy.New(databases.PkgRocksDB)
 			if err != nil {
 				return err

--- a/migrator/migrations/n_15_to_n_16_postgres_compliance_operator_rules/migration.go
+++ b/migrator/migrations/n_15_to_n_16_postgres_compliance_operator_rules/migration.go
@@ -24,6 +24,10 @@ var (
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 15,
 		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 16},
 		Run: func(databases *types.Databases) error {
+			if databases.PkgRocksDB == nil {
+				log.WriteToStderr("RocksDB is nil.  Skipping migration n15ton16")
+				return nil
+			}
 			legacyStore, err := legacy.New(databases.PkgRocksDB)
 			if err != nil {
 				return err

--- a/migrator/migrations/n_16_to_n_17_postgres_compliance_operator_scan_setting_bindings/migration.go
+++ b/migrator/migrations/n_16_to_n_17_postgres_compliance_operator_scan_setting_bindings/migration.go
@@ -24,6 +24,10 @@ var (
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 16,
 		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 17},
 		Run: func(databases *types.Databases) error {
+			if databases.PkgRocksDB == nil {
+				log.WriteToStderr("RocksDB is nil.  Skipping migration n16ton17")
+				return nil
+			}
 			legacyStore, err := legacy.New(databases.PkgRocksDB)
 			if err != nil {
 				return err

--- a/migrator/migrations/n_17_to_n_18_postgres_compliance_operator_scans/migration.go
+++ b/migrator/migrations/n_17_to_n_18_postgres_compliance_operator_scans/migration.go
@@ -24,6 +24,10 @@ var (
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 17,
 		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 18},
 		Run: func(databases *types.Databases) error {
+			if databases.PkgRocksDB == nil {
+				log.WriteToStderr("RocksDB is nil.  Skipping migration n17ton18")
+				return nil
+			}
 			legacyStore, err := legacy.New(databases.PkgRocksDB)
 			if err != nil {
 				return err

--- a/migrator/migrations/n_18_to_n_19_postgres_compliance_run_metadata/migration.go
+++ b/migrator/migrations/n_18_to_n_19_postgres_compliance_run_metadata/migration.go
@@ -24,6 +24,10 @@ var (
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 18,
 		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 19},
 		Run: func(databases *types.Databases) error {
+			if databases.PkgRocksDB == nil {
+				log.WriteToStderr("RocksDB is nil.  Skipping migration n18ton19")
+				return nil
+			}
 			legacyStore, err := legacy.New(databases.PkgRocksDB)
 			if err != nil {
 				return err

--- a/migrator/migrations/n_19_to_n_20_postgres_compliance_run_results/migration.go
+++ b/migrator/migrations/n_19_to_n_20_postgres_compliance_run_results/migration.go
@@ -24,6 +24,10 @@ var (
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 19,
 		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 20},
 		Run: func(databases *types.Databases) error {
+			if databases.PkgRocksDB == nil {
+				log.WriteToStderr("RocksDB is nil.  Skipping migration n19ton20")
+				return nil
+			}
 			legacyStore, err := legacy.New(databases.PkgRocksDB)
 			if err != nil {
 				return err

--- a/migrator/migrations/n_20_to_n_21_postgres_compliance_strings/migration.go
+++ b/migrator/migrations/n_20_to_n_21_postgres_compliance_strings/migration.go
@@ -24,6 +24,10 @@ var (
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 20,
 		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 21},
 		Run: func(databases *types.Databases) error {
+			if databases.PkgRocksDB == nil {
+				log.WriteToStderr("RocksDB is nil.  Skipping migration n20ton21")
+				return nil
+			}
 			legacyStore, err := legacy.New(databases.PkgRocksDB)
 			if err != nil {
 				return err

--- a/migrator/migrations/n_21_to_n_22_postgres_configs/migration.go
+++ b/migrator/migrations/n_21_to_n_22_postgres_configs/migration.go
@@ -24,6 +24,10 @@ var (
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 21,
 		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 22},
 		Run: func(databases *types.Databases) error {
+			if databases.BoltDB == nil {
+				log.WriteToStderr("Bolt is nil.  Skipping migration n21ton22")
+				return nil
+			}
 			legacyStore := legacy.New(databases.BoltDB)
 			if err := move(databases.GormDB, databases.PostgresDB, legacyStore); err != nil {
 				return errors.Wrap(err,

--- a/migrator/migrations/n_22_to_n_23_postgres_external_backups/migration.go
+++ b/migrator/migrations/n_22_to_n_23_postgres_external_backups/migration.go
@@ -24,6 +24,10 @@ var (
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 22,
 		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 23},
 		Run: func(databases *types.Databases) error {
+			if databases.BoltDB == nil {
+				log.WriteToStderr("Bolt is nil.  Skipping migration n22ton23")
+				return nil
+			}
 			legacyStore := legacy.New(databases.BoltDB)
 			if err := move(databases.GormDB, databases.PostgresDB, legacyStore); err != nil {
 				return errors.Wrap(err,

--- a/migrator/migrations/n_23_to_n_24_postgres_image_integrations/migration.go
+++ b/migrator/migrations/n_23_to_n_24_postgres_image_integrations/migration.go
@@ -24,6 +24,10 @@ var (
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 23,
 		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 24},
 		Run: func(databases *types.Databases) error {
+			if databases.BoltDB == nil {
+				log.WriteToStderr("Bolt is nil.  Skipping migration n23ton24")
+				return nil
+			}
 			legacyStore := legacy.New(databases.BoltDB)
 			if err := move(databases.GormDB, databases.PostgresDB, legacyStore); err != nil {
 				return errors.Wrap(err,

--- a/migrator/migrations/n_24_to_n_25_postgres_installation_infos/migration.go
+++ b/migrator/migrations/n_24_to_n_25_postgres_installation_infos/migration.go
@@ -24,6 +24,10 @@ var (
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 24,
 		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 25},
 		Run: func(databases *types.Databases) error {
+			if databases.BoltDB == nil {
+				log.WriteToStderr("Bolt is nil.  Skipping migration n24ton25")
+				return nil
+			}
 			legacyStore := legacy.New(databases.BoltDB)
 			if err := move(databases.GormDB, databases.PostgresDB, legacyStore); err != nil {
 				return errors.Wrap(err,

--- a/migrator/migrations/n_25_to_n_26_postgres_integration_healths/migration.go
+++ b/migrator/migrations/n_25_to_n_26_postgres_integration_healths/migration.go
@@ -24,6 +24,10 @@ var (
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 25,
 		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 26},
 		Run: func(databases *types.Databases) error {
+			if databases.PkgRocksDB == nil {
+				log.WriteToStderr("RocksDB is nil.  Skipping migration n25ton26")
+				return nil
+			}
 			legacyStore, err := legacy.New(databases.PkgRocksDB)
 			if err != nil {
 				return err

--- a/migrator/migrations/n_26_to_n_27_postgres_k8s_roles/migration.go
+++ b/migrator/migrations/n_26_to_n_27_postgres_k8s_roles/migration.go
@@ -24,6 +24,10 @@ var (
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 26,
 		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 27},
 		Run: func(databases *types.Databases) error {
+			if databases.PkgRocksDB == nil {
+				log.WriteToStderr("RocksDB is nil.  Skipping migration n26ton27")
+				return nil
+			}
 			legacyStore, err := legacy.New(databases.PkgRocksDB)
 			if err != nil {
 				return err

--- a/migrator/migrations/n_27_to_n_28_postgres_log_imbues/migration.go
+++ b/migrator/migrations/n_27_to_n_28_postgres_log_imbues/migration.go
@@ -26,6 +26,10 @@ var (
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 27,
 		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 28},
 		Run: func(databases *types.Databases) error {
+			if databases.BoltDB == nil {
+				log.WriteToStderr("Bolt is nil.  Skipping migration n27ton28")
+				return nil
+			}
 			legacyStore := legacy.New(databases.BoltDB)
 			if err := move(databases.GormDB, databases.PostgresDB, legacyStore); err != nil {
 				return errors.Wrap(err,

--- a/migrator/migrations/n_28_to_n_29_postgres_network_baselines/migration.go
+++ b/migrator/migrations/n_28_to_n_29_postgres_network_baselines/migration.go
@@ -24,6 +24,10 @@ var (
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 28,
 		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 29},
 		Run: func(databases *types.Databases) error {
+			if databases.PkgRocksDB == nil {
+				log.WriteToStderr("RocksDB is nil.  Skipping migration n28ton29")
+				return nil
+			}
 			legacyStore, err := legacy.New(databases.PkgRocksDB)
 			if err != nil {
 				return err

--- a/migrator/migrations/n_29_to_n_30_postgres_network_entities/migration.go
+++ b/migrator/migrations/n_29_to_n_30_postgres_network_entities/migration.go
@@ -24,6 +24,10 @@ var (
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 29,
 		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 30},
 		Run: func(databases *types.Databases) error {
+			if databases.PkgRocksDB == nil {
+				log.WriteToStderr("RocksDB is nil.  Skipping migration n29ton30")
+				return nil
+			}
 			legacyStore, err := legacy.New(databases.PkgRocksDB)
 			if err != nil {
 				return err

--- a/migrator/migrations/n_31_to_n_32_postgres_network_graph_configs/migration.go
+++ b/migrator/migrations/n_31_to_n_32_postgres_network_graph_configs/migration.go
@@ -24,6 +24,10 @@ var (
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 31,
 		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 32},
 		Run: func(databases *types.Databases) error {
+			if databases.PkgRocksDB == nil {
+				log.WriteToStderr("RocksDB is nil.  Skipping migration n31ton32")
+				return nil
+			}
 			legacyStore, err := legacy.New(databases.PkgRocksDB)
 			if err != nil {
 				return err

--- a/migrator/migrations/n_32_to_n_33_postgres_networkpolicies/migration.go
+++ b/migrator/migrations/n_32_to_n_33_postgres_networkpolicies/migration.go
@@ -24,6 +24,10 @@ var (
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 32,
 		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 33},
 		Run: func(databases *types.Databases) error {
+			if databases.BoltDB == nil {
+				log.WriteToStderr("Bolt is nil.  Skipping migration n32ton33")
+				return nil
+			}
 			legacyStore := legacy.New(databases.BoltDB)
 			if err := move(databases.GormDB, databases.PostgresDB, legacyStore); err != nil {
 				return errors.Wrap(err,

--- a/migrator/migrations/n_33_to_n_34_postgres_networkpoliciesundodeployments/migration.go
+++ b/migrator/migrations/n_33_to_n_34_postgres_networkpoliciesundodeployments/migration.go
@@ -24,6 +24,10 @@ var (
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 33,
 		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 34},
 		Run: func(databases *types.Databases) error {
+			if databases.PkgRocksDB == nil {
+				log.WriteToStderr("RocksDB is nil.  Skipping migration n33ton34")
+				return nil
+			}
 			legacyStore, err := legacy.New(databases.PkgRocksDB)
 			if err != nil {
 				return err

--- a/migrator/migrations/n_34_to_n_35_postgres_networkpolicyapplicationundorecords/migration.go
+++ b/migrator/migrations/n_34_to_n_35_postgres_networkpolicyapplicationundorecords/migration.go
@@ -24,6 +24,10 @@ var (
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 34,
 		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 35},
 		Run: func(databases *types.Databases) error {
+			if databases.BoltDB == nil {
+				log.WriteToStderr("Bolt is nil.  Skipping migration n34ton35")
+				return nil
+			}
 			legacyStore := legacy.New(databases.BoltDB)
 			if err := move(databases.GormDB, databases.PostgresDB, legacyStore); err != nil {
 				return errors.Wrap(err,

--- a/migrator/migrations/n_35_to_n_36_postgres_nodes/migration.go
+++ b/migrator/migrations/n_35_to_n_36_postgres_nodes/migration.go
@@ -27,6 +27,10 @@ var (
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 35,
 		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 36},
 		Run: func(databases *types.Databases) error {
+			if databases.PkgRocksDB == nil {
+				log.WriteToStderr("RocksDB is nil.  Skipping migration n35ton36")
+				return nil
+			}
 			legacyStore := legacy.New(rawDackbox.GetGlobalDackBox(), rawDackbox.GetKeyFence(), true)
 			if err := move(databases.GormDB, databases.PostgresDB, legacyStore); err != nil {
 				return errors.Wrap(err,

--- a/migrator/migrations/n_36_to_n_37_postgres_notifiers/migration.go
+++ b/migrator/migrations/n_36_to_n_37_postgres_notifiers/migration.go
@@ -24,6 +24,10 @@ var (
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 36,
 		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 37},
 		Run: func(databases *types.Databases) error {
+			if databases.BoltDB == nil {
+				log.WriteToStderr("Bolt is nil.  Skipping migration n36ton37")
+				return nil
+			}
 			legacyStore := legacy.New(databases.BoltDB)
 			if err := move(databases.GormDB, databases.PostgresDB, legacyStore); err != nil {
 				return errors.Wrap(err,

--- a/migrator/migrations/n_38_to_n_39_postgres_pods/migration.go
+++ b/migrator/migrations/n_38_to_n_39_postgres_pods/migration.go
@@ -24,6 +24,10 @@ var (
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 38,
 		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 39},
 		Run: func(databases *types.Databases) error {
+			if databases.PkgRocksDB == nil {
+				log.WriteToStderr("RocksDB is nil.  Skipping migration n38ton39")
+				return nil
+			}
 			legacyStore, err := legacy.New(databases.PkgRocksDB)
 			if err != nil {
 				return err

--- a/migrator/migrations/n_39_to_n_40_postgres_policies/migration.go
+++ b/migrator/migrations/n_39_to_n_40_postgres_policies/migration.go
@@ -24,6 +24,10 @@ var (
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 39,
 		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 40},
 		Run: func(databases *types.Databases) error {
+			if databases.BoltDB == nil {
+				log.WriteToStderr("Bolt is nil.  Skipping migration n39ton40")
+				return nil
+			}
 			legacyStore := legacy.New(databases.BoltDB)
 			if err := move(databases.GormDB, databases.PostgresDB, legacyStore); err != nil {
 				return errors.Wrap(err,

--- a/migrator/migrations/n_40_to_n_41_postgres_process_baseline_results/migration.go
+++ b/migrator/migrations/n_40_to_n_41_postgres_process_baseline_results/migration.go
@@ -24,6 +24,10 @@ var (
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 40,
 		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 41},
 		Run: func(databases *types.Databases) error {
+			if databases.PkgRocksDB == nil {
+				log.WriteToStderr("RocksDB is nil.  Skipping migration n40ton41")
+				return nil
+			}
 			legacyStore, err := legacy.New(databases.PkgRocksDB)
 			if err != nil {
 				return err

--- a/migrator/migrations/n_41_to_n_42_postgres_process_baselines/migration.go
+++ b/migrator/migrations/n_41_to_n_42_postgres_process_baselines/migration.go
@@ -24,6 +24,10 @@ var (
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 41,
 		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 42},
 		Run: func(databases *types.Databases) error {
+			if databases.PkgRocksDB == nil {
+				log.WriteToStderr("RocksDB is nil.  Skipping migration n41ton42")
+				return nil
+			}
 			legacyStore, err := legacy.New(databases.PkgRocksDB)
 			if err != nil {
 				return err

--- a/migrator/migrations/n_42_to_n_43_postgres_process_indicators/migration.go
+++ b/migrator/migrations/n_42_to_n_43_postgres_process_indicators/migration.go
@@ -24,6 +24,10 @@ var (
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 42,
 		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 43},
 		Run: func(databases *types.Databases) error {
+			if databases.PkgRocksDB == nil {
+				log.WriteToStderr("RocksDB is nil.  Skipping migration n42ton43")
+				return nil
+			}
 			legacyStore, err := legacy.New(databases.PkgRocksDB)
 			if err != nil {
 				return err

--- a/migrator/migrations/n_43_to_n_44_postgres_report_configurations/migration.go
+++ b/migrator/migrations/n_43_to_n_44_postgres_report_configurations/migration.go
@@ -24,6 +24,10 @@ var (
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 43,
 		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 44},
 		Run: func(databases *types.Databases) error {
+			if databases.PkgRocksDB == nil {
+				log.WriteToStderr("RocksDB is nil.  Skipping migration n43ton44")
+				return nil
+			}
 			legacyStore, err := legacy.New(databases.PkgRocksDB)
 			if err != nil {
 				return err

--- a/migrator/migrations/n_44_to_n_45_postgres_risks/migration.go
+++ b/migrator/migrations/n_44_to_n_45_postgres_risks/migration.go
@@ -24,6 +24,10 @@ var (
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 44,
 		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 45},
 		Run: func(databases *types.Databases) error {
+			if databases.PkgRocksDB == nil {
+				log.WriteToStderr("RocksDB is nil.  Skipping migration n44ton45")
+				return nil
+			}
 			legacyStore, err := legacy.New(databases.PkgRocksDB)
 			if err != nil {
 				return err

--- a/migrator/migrations/n_45_to_n_46_postgres_role_bindings/migration.go
+++ b/migrator/migrations/n_45_to_n_46_postgres_role_bindings/migration.go
@@ -24,6 +24,10 @@ var (
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 45,
 		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 46},
 		Run: func(databases *types.Databases) error {
+			if databases.PkgRocksDB == nil {
+				log.WriteToStderr("RocksDB is nil.  Skipping migration n45ton46")
+				return nil
+			}
 			legacyStore, err := legacy.New(databases.PkgRocksDB)
 			if err != nil {
 				return err

--- a/migrator/migrations/n_47_to_n_48_postgres_secrets/migration.go
+++ b/migrator/migrations/n_47_to_n_48_postgres_secrets/migration.go
@@ -24,6 +24,10 @@ var (
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 47,
 		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 48},
 		Run: func(databases *types.Databases) error {
+			if databases.PkgRocksDB == nil {
+				log.WriteToStderr("RocksDB is nil.  Skipping migration n47ton48")
+				return nil
+			}
 			legacyStore, err := legacy.New(databases.PkgRocksDB)
 			if err != nil {
 				return err

--- a/migrator/migrations/n_48_to_n_49_postgres_sensor_upgrade_configs/migration.go
+++ b/migrator/migrations/n_48_to_n_49_postgres_sensor_upgrade_configs/migration.go
@@ -24,6 +24,10 @@ var (
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 48,
 		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 49},
 		Run: func(databases *types.Databases) error {
+			if databases.BoltDB == nil {
+				log.WriteToStderr("Bolt is nil.  Skipping migration n48ton49")
+				return nil
+			}
 			legacyStore := legacy.New(databases.BoltDB)
 			if err := move(databases.GormDB, databases.PostgresDB, legacyStore); err != nil {
 				return errors.Wrap(err,

--- a/migrator/migrations/n_49_to_n_50_postgres_service_accounts/migration.go
+++ b/migrator/migrations/n_49_to_n_50_postgres_service_accounts/migration.go
@@ -24,6 +24,10 @@ var (
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 49,
 		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 50},
 		Run: func(databases *types.Databases) error {
+			if databases.PkgRocksDB == nil {
+				log.WriteToStderr("RocksDB is nil.  Skipping migration n49ton50")
+				return nil
+			}
 			legacyStore, err := legacy.New(databases.PkgRocksDB)
 			if err != nil {
 				return err

--- a/migrator/migrations/n_50_to_n_51_postgres_service_identities/migration.go
+++ b/migrator/migrations/n_50_to_n_51_postgres_service_identities/migration.go
@@ -24,6 +24,10 @@ var (
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 50,
 		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 51},
 		Run: func(databases *types.Databases) error {
+			if databases.BoltDB == nil {
+				log.WriteToStderr("Bolt is nil.  Skipping migration n50ton51")
+				return nil
+			}
 			legacyStore := legacy.New(databases.BoltDB)
 			if err := move(databases.GormDB, databases.PostgresDB, legacyStore); err != nil {
 				return errors.Wrap(err,

--- a/migrator/migrations/n_51_to_n_52_postgres_signature_integrations/migration.go
+++ b/migrator/migrations/n_51_to_n_52_postgres_signature_integrations/migration.go
@@ -24,6 +24,10 @@ var (
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 51,
 		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 52},
 		Run: func(databases *types.Databases) error {
+			if databases.PkgRocksDB == nil {
+				log.WriteToStderr("RocksDB is nil.  Skipping migration n51ton52")
+				return nil
+			}
 			legacyStore, err := legacy.New(databases.PkgRocksDB)
 			if err != nil {
 				return err

--- a/migrator/migrations/n_52_to_n_53_postgres_simple_access_scopes/migration.go
+++ b/migrator/migrations/n_52_to_n_53_postgres_simple_access_scopes/migration.go
@@ -65,6 +65,10 @@ var (
 )
 
 func migrateAll(rocksDatabase *rocksdb.RocksDB, gormDB *gorm.DB, postgresDB *pgxpool.Pool) error {
+	if rocksDatabase == nil {
+		log.WriteToStderr("RocksDB is nil.  Skipping migration n52ton53")
+		return nil
+	}
 	legacyAccessScopeStore, err := legacysimpleaccessscopes.New(rocksDatabase)
 	if err != nil {
 		return err

--- a/migrator/migrations/n_53_to_n_54_postgres_vulnerability_requests/migration.go
+++ b/migrator/migrations/n_53_to_n_54_postgres_vulnerability_requests/migration.go
@@ -24,6 +24,10 @@ var (
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 53,
 		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 54},
 		Run: func(databases *types.Databases) error {
+			if databases.PkgRocksDB == nil {
+				log.WriteToStderr("RocksDB is nil.  Skipping migration n53ton54")
+				return nil
+			}
 			legacyStore, err := legacy.New(databases.PkgRocksDB)
 			if err != nil {
 				return err

--- a/migrator/migrations/n_54_to_n_55_postgres_watched_images/migration.go
+++ b/migrator/migrations/n_54_to_n_55_postgres_watched_images/migration.go
@@ -24,6 +24,10 @@ var (
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 54,
 		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 55},
 		Run: func(databases *types.Databases) error {
+			if databases.PkgRocksDB == nil {
+				log.WriteToStderr("RocksDB is nil.  Skipping migration n54ton55")
+				return nil
+			}
 			legacyStore, err := legacy.New(databases.PkgRocksDB)
 			if err != nil {
 				return err

--- a/migrator/migrations/n_55_to_n_56_postgres_policy_categories/migration.go
+++ b/migrator/migrations/n_55_to_n_56_postgres_policy_categories/migration.go
@@ -24,6 +24,10 @@ var (
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 55,
 		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 56},
 		Run: func(databases *types.Databases) error {
+			if databases.PkgRocksDB == nil {
+				log.WriteToStderr("RocksDB is nil.  Skipping migration n55ton56")
+				return nil
+			}
 			legacyStore, err := legacy.New(databases.PkgRocksDB)
 			if err != nil {
 				return err

--- a/migrator/migrations/n_56_to_n_57_postgres_groups/migration.go
+++ b/migrator/migrations/n_56_to_n_57_postgres_groups/migration.go
@@ -24,6 +24,10 @@ var (
 		StartingSeqNum: pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres() + 56,
 		VersionAfter:   &storage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNumWithoutPostgres()) + 57},
 		Run: func(databases *types.Databases) error {
+			if databases.BoltDB == nil {
+				log.WriteToStderr("Bolt is nil.  Skipping migration n56ton57")
+				return nil
+			}
 			legacyStore := legacy.New(databases.BoltDB)
 			if err := move(databases.GormDB, databases.PostgresDB, legacyStore); err != nil {
 				return errors.Wrap(err,

--- a/migrator/types/migration.go
+++ b/migrator/types/migration.go
@@ -37,4 +37,10 @@ type Migration struct {
 	// All other (optional) metadata can be whatever the user desires, and has no bearing on the
 	// functioning of the migrator.
 	VersionAfter *storage.Version
+	// LegacyToPostgres tells us if the migration is a legacy database to postgres migration.
+	// This allows us the ability to ensure that all databases exist before executing the migration.
+	// Particularly helpful in the event a patch release caused a new legacy migration to be added.
+	// This will allow us to skip migrations when the legacy databases are not passed to the runner
+	// because we have already migrated to Postgres.
+	LegacyToPostgres bool
 }


### PR DESCRIPTION
## Description

We need to be able to not panic when a legacy migration is added as part of a patch release or for some other reason.  We can take advantage of the fact that if we determine that Postgres is the source database, we will pass nils to the migrations for both Bolt and Rocks.  If we determine we need to migrate from legacy we are ensured that Bolt and Rocks are not nil because we fail before calling the runner if they are.  So here we are just taking the Postgres migrations and performing a nil check on the legacy DB and skipping that migration if it is nil.

This solution is a quick and dirty one based on the state that we have saved currently for migrations.  A larger refactor and storing additional state is also an option, but that would take longer to release and would prove unnecessary in a couple of releases.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Manual tests for now.  Spin up an environment from earlier in 3.73.  Upgrade to these images and note in the logs that migration 169 was skipped.  #4003 will have added this case to CI runs upon its completion.
