### PR TITLE
Dashrews/migration prob option 2

### DIFF
--- a/migrator/migrations/n_01_to_n_02_postgres_clusters/migration.go
+++ b/migrator/migrations/n_01_to_n_02_postgres_clusters/migration.go
@@ -34,6 +34,7 @@ var (
 			}
 			return nil
 		},
+		LegacyToPostgres: true,
 	}
 	batchSize = 10000
 	schema    = frozenSchema.ClustersSchema

--- a/migrator/migrations/n_02_to_n_03_postgres_namespaces/migration.go
+++ b/migrator/migrations/n_02_to_n_03_postgres_namespaces/migration.go
@@ -34,6 +34,7 @@ var (
 			}
 			return nil
 		},
+		LegacyToPostgres: true,
 	}
 	batchSize = 10000
 	schema    = frozenSchema.NamespacesSchema

--- a/migrator/migrations/n_03_to_n_04_postgres_deployments/migration.go
+++ b/migrator/migrations/n_03_to_n_04_postgres_deployments/migration.go
@@ -32,6 +32,7 @@ var (
 			}
 			return nil
 		},
+		LegacyToPostgres: true,
 	}
 	batchSize = 10000
 	schema    = frozenSchema.DeploymentsSchema

--- a/migrator/migrations/n_04_to_n_05_postgres_images/migration.go
+++ b/migrator/migrations/n_04_to_n_05_postgres_images/migration.go
@@ -34,6 +34,7 @@ var (
 			}
 			return nil
 		},
+		LegacyToPostgres: true,
 	}
 	batchSize = 500
 	schema    = frozenSchema.ImagesSchema

--- a/migrator/migrations/n_05_to_n_06_postgres_active_components/migration.go
+++ b/migrator/migrations/n_05_to_n_06_postgres_active_components/migration.go
@@ -33,6 +33,7 @@ var (
 			}
 			return nil
 		},
+		LegacyToPostgres: true,
 	}
 	batchSize      = 3000
 	imageBatchSize = 1000

--- a/migrator/migrations/n_06_to_n_07_postgres_alerts/migration.go
+++ b/migrator/migrations/n_06_to_n_07_postgres_alerts/migration.go
@@ -34,6 +34,7 @@ var (
 			}
 			return nil
 		},
+		LegacyToPostgres: true,
 	}
 	batchSize = 10000
 	schema    = frozenSchema.AlertsSchema

--- a/migrator/migrations/n_07_to_n_08_postgres_api_tokens/migration.go
+++ b/migrator/migrations/n_07_to_n_08_postgres_api_tokens/migration.go
@@ -34,6 +34,7 @@ var (
 			}
 			return nil
 		},
+		LegacyToPostgres: true,
 	}
 	batchSize = 10000
 	schema    = frozenSchema.ApiTokensSchema

--- a/migrator/migrations/n_08_to_n_09_postgres_auth_providers/migration.go
+++ b/migrator/migrations/n_08_to_n_09_postgres_auth_providers/migration.go
@@ -31,6 +31,7 @@ var (
 			}
 			return nil
 		},
+		LegacyToPostgres: true,
 	}
 	batchSize = 10000
 	schema    = frozenSchema.AuthProvidersSchema

--- a/migrator/migrations/n_09_to_n_10_postgres_cluster_cves/migration.go
+++ b/migrator/migrations/n_09_to_n_10_postgres_cluster_cves/migration.go
@@ -34,6 +34,7 @@ var (
 			}
 			return nil
 		},
+		LegacyToPostgres: true,
 	}
 	batchSize = 500
 	schema    = frozenSchema.ClusterCvesSchema

--- a/migrator/migrations/n_10_to_n_11_postgres_cluster_health_statuses/migration.go
+++ b/migrator/migrations/n_10_to_n_11_postgres_cluster_health_statuses/migration.go
@@ -34,6 +34,7 @@ var (
 			}
 			return nil
 		},
+		LegacyToPostgres: true,
 	}
 	batchSize = 10000
 	schema    = frozenSchema.ClusterHealthStatusesSchema

--- a/migrator/migrations/n_11_to_n_12_postgres_cluster_init_bundles/migration.go
+++ b/migrator/migrations/n_11_to_n_12_postgres_cluster_init_bundles/migration.go
@@ -34,6 +34,7 @@ var (
 			}
 			return nil
 		},
+		LegacyToPostgres: true,
 	}
 	batchSize = 10000
 	schema    = frozenSchema.ClusterInitBundlesSchema

--- a/migrator/migrations/n_12_to_n_13_postgres_compliance_domains/migration.go
+++ b/migrator/migrations/n_12_to_n_13_postgres_compliance_domains/migration.go
@@ -34,6 +34,7 @@ var (
 			}
 			return nil
 		},
+		LegacyToPostgres: true,
 	}
 	batchSize = 10000
 	schema    = frozenSchema.ComplianceDomainsSchema

--- a/migrator/migrations/n_13_to_n_14_postgres_compliance_operator_check_results/migration.go
+++ b/migrator/migrations/n_13_to_n_14_postgres_compliance_operator_check_results/migration.go
@@ -34,6 +34,7 @@ var (
 			}
 			return nil
 		},
+		LegacyToPostgres: true,
 	}
 	batchSize = 10000
 	schema    = frozenSchema.ComplianceOperatorCheckResultsSchema

--- a/migrator/migrations/n_14_to_n_15_postgres_compliance_operator_profiles/migration.go
+++ b/migrator/migrations/n_14_to_n_15_postgres_compliance_operator_profiles/migration.go
@@ -34,6 +34,7 @@ var (
 			}
 			return nil
 		},
+		LegacyToPostgres: true,
 	}
 	batchSize = 10000
 	schema    = frozenSchema.ComplianceOperatorProfilesSchema

--- a/migrator/migrations/n_15_to_n_16_postgres_compliance_operator_rules/migration.go
+++ b/migrator/migrations/n_15_to_n_16_postgres_compliance_operator_rules/migration.go
@@ -34,6 +34,7 @@ var (
 			}
 			return nil
 		},
+		LegacyToPostgres: true,
 	}
 	batchSize = 10000
 	schema    = frozenSchema.ComplianceOperatorRulesSchema

--- a/migrator/migrations/n_16_to_n_17_postgres_compliance_operator_scan_setting_bindings/migration.go
+++ b/migrator/migrations/n_16_to_n_17_postgres_compliance_operator_scan_setting_bindings/migration.go
@@ -34,6 +34,7 @@ var (
 			}
 			return nil
 		},
+		LegacyToPostgres: true,
 	}
 	batchSize = 10000
 	schema    = frozenSchema.ComplianceOperatorScanSettingBindingsSchema

--- a/migrator/migrations/n_17_to_n_18_postgres_compliance_operator_scans/migration.go
+++ b/migrator/migrations/n_17_to_n_18_postgres_compliance_operator_scans/migration.go
@@ -34,6 +34,7 @@ var (
 			}
 			return nil
 		},
+		LegacyToPostgres: true,
 	}
 	batchSize = 10000
 	schema    = frozenSchema.ComplianceOperatorScansSchema

--- a/migrator/migrations/n_18_to_n_19_postgres_compliance_run_metadata/migration.go
+++ b/migrator/migrations/n_18_to_n_19_postgres_compliance_run_metadata/migration.go
@@ -34,6 +34,7 @@ var (
 			}
 			return nil
 		},
+		LegacyToPostgres: true,
 	}
 	batchSize = 10000
 	schema    = frozenSchema.ComplianceRunMetadataSchema

--- a/migrator/migrations/n_19_to_n_20_postgres_compliance_run_results/migration.go
+++ b/migrator/migrations/n_19_to_n_20_postgres_compliance_run_results/migration.go
@@ -34,6 +34,7 @@ var (
 			}
 			return nil
 		},
+		LegacyToPostgres: true,
 	}
 	batchSize = 10000
 	schema    = frozenSchema.ComplianceRunResultsSchema

--- a/migrator/migrations/n_20_to_n_21_postgres_compliance_strings/migration.go
+++ b/migrator/migrations/n_20_to_n_21_postgres_compliance_strings/migration.go
@@ -34,6 +34,7 @@ var (
 			}
 			return nil
 		},
+		LegacyToPostgres: true,
 	}
 	batchSize = 10000
 	schema    = frozenSchema.ComplianceStringsSchema

--- a/migrator/migrations/n_21_to_n_22_postgres_configs/migration.go
+++ b/migrator/migrations/n_21_to_n_22_postgres_configs/migration.go
@@ -31,6 +31,7 @@ var (
 			}
 			return nil
 		},
+		LegacyToPostgres: true,
 	}
 	batchSize = 10000
 	schema    = frozenSchema.ConfigsSchema

--- a/migrator/migrations/n_22_to_n_23_postgres_external_backups/migration.go
+++ b/migrator/migrations/n_22_to_n_23_postgres_external_backups/migration.go
@@ -31,6 +31,7 @@ var (
 			}
 			return nil
 		},
+		LegacyToPostgres: true,
 	}
 	batchSize = 10000
 	schema    = frozenSchema.ExternalBackupsSchema

--- a/migrator/migrations/n_23_to_n_24_postgres_image_integrations/migration.go
+++ b/migrator/migrations/n_23_to_n_24_postgres_image_integrations/migration.go
@@ -31,6 +31,7 @@ var (
 			}
 			return nil
 		},
+		LegacyToPostgres: true,
 	}
 	batchSize = 10000
 	schema    = frozenSchema.ImageIntegrationsSchema

--- a/migrator/migrations/n_24_to_n_25_postgres_installation_infos/migration.go
+++ b/migrator/migrations/n_24_to_n_25_postgres_installation_infos/migration.go
@@ -31,6 +31,7 @@ var (
 			}
 			return nil
 		},
+		LegacyToPostgres: true,
 	}
 	batchSize = 10000
 	schema    = frozenSchema.InstallationInfosSchema

--- a/migrator/migrations/n_25_to_n_26_postgres_integration_healths/migration.go
+++ b/migrator/migrations/n_25_to_n_26_postgres_integration_healths/migration.go
@@ -34,6 +34,7 @@ var (
 			}
 			return nil
 		},
+		LegacyToPostgres: true,
 	}
 	batchSize = 10000
 	schema    = frozenSchema.IntegrationHealthsSchema

--- a/migrator/migrations/n_26_to_n_27_postgres_k8s_roles/migration.go
+++ b/migrator/migrations/n_26_to_n_27_postgres_k8s_roles/migration.go
@@ -34,6 +34,7 @@ var (
 			}
 			return nil
 		},
+		LegacyToPostgres: true,
 	}
 	batchSize = 10000
 	schema    = frozenSchema.K8sRolesSchema

--- a/migrator/migrations/n_27_to_n_28_postgres_log_imbues/migration.go
+++ b/migrator/migrations/n_27_to_n_28_postgres_log_imbues/migration.go
@@ -33,6 +33,7 @@ var (
 			}
 			return nil
 		},
+		LegacyToPostgres: true,
 	}
 	batchSize = 10000
 	schema    = frozenSchema.LogImbuesSchema

--- a/migrator/migrations/n_28_to_n_29_postgres_network_baselines/migration.go
+++ b/migrator/migrations/n_28_to_n_29_postgres_network_baselines/migration.go
@@ -34,6 +34,7 @@ var (
 			}
 			return nil
 		},
+		LegacyToPostgres: true,
 	}
 	batchSize = 10000
 	schema    = frozenSchema.NetworkBaselinesSchema

--- a/migrator/migrations/n_29_to_n_30_postgres_network_entities/migration.go
+++ b/migrator/migrations/n_29_to_n_30_postgres_network_entities/migration.go
@@ -34,6 +34,7 @@ var (
 			}
 			return nil
 		},
+		LegacyToPostgres: true,
 	}
 	batchSize = 10000
 	schema    = frozenSchema.NetworkEntitiesSchema

--- a/migrator/migrations/n_30_to_n_31_postgres_network_flows/migration.go
+++ b/migrator/migrations/n_30_to_n_31_postgres_network_flows/migration.go
@@ -34,6 +34,7 @@ var (
 			}
 			return nil
 		},
+		LegacyToPostgres: true,
 	}
 	schema = frozenSchema.NetworkFlowsSchema
 )

--- a/migrator/migrations/n_31_to_n_32_postgres_network_graph_configs/migration.go
+++ b/migrator/migrations/n_31_to_n_32_postgres_network_graph_configs/migration.go
@@ -34,6 +34,7 @@ var (
 			}
 			return nil
 		},
+		LegacyToPostgres: true,
 	}
 	batchSize = 10000
 	schema    = frozenSchema.NetworkGraphConfigsSchema

--- a/migrator/migrations/n_32_to_n_33_postgres_networkpolicies/migration.go
+++ b/migrator/migrations/n_32_to_n_33_postgres_networkpolicies/migration.go
@@ -31,6 +31,7 @@ var (
 			}
 			return nil
 		},
+		LegacyToPostgres: true,
 	}
 	batchSize = 10000
 	schema    = frozenSchema.NetworkpoliciesSchema

--- a/migrator/migrations/n_33_to_n_34_postgres_networkpoliciesundodeployments/migration.go
+++ b/migrator/migrations/n_33_to_n_34_postgres_networkpoliciesundodeployments/migration.go
@@ -34,6 +34,7 @@ var (
 			}
 			return nil
 		},
+		LegacyToPostgres: true,
 	}
 	batchSize = 10000
 	schema    = frozenSchema.NetworkpoliciesundodeploymentsSchema

--- a/migrator/migrations/n_34_to_n_35_postgres_networkpolicyapplicationundorecords/migration.go
+++ b/migrator/migrations/n_34_to_n_35_postgres_networkpolicyapplicationundorecords/migration.go
@@ -31,6 +31,7 @@ var (
 			}
 			return nil
 		},
+		LegacyToPostgres: true,
 	}
 	batchSize = 10000
 	schema    = frozenSchema.NetworkpolicyapplicationundorecordsSchema

--- a/migrator/migrations/n_35_to_n_36_postgres_nodes/migration.go
+++ b/migrator/migrations/n_35_to_n_36_postgres_nodes/migration.go
@@ -34,6 +34,7 @@ var (
 			}
 			return nil
 		},
+		LegacyToPostgres: true,
 	}
 	batchSize = 500
 	log       = loghelper.LogWrapper{}

--- a/migrator/migrations/n_36_to_n_37_postgres_notifiers/migration.go
+++ b/migrator/migrations/n_36_to_n_37_postgres_notifiers/migration.go
@@ -31,6 +31,7 @@ var (
 			}
 			return nil
 		},
+		LegacyToPostgres: true,
 	}
 	batchSize = 10000
 	schema    = frozenSchema.NotifiersSchema

--- a/migrator/migrations/n_37_to_n_38_postgres_permission_sets/migration.go
+++ b/migrator/migrations/n_37_to_n_38_postgres_permission_sets/migration.go
@@ -20,6 +20,7 @@ var (
 			// and still be able to convert the references in the roles table.
 			return nil
 		},
+		LegacyToPostgres: true,
 	}
 )
 

--- a/migrator/migrations/n_38_to_n_39_postgres_pods/migration.go
+++ b/migrator/migrations/n_38_to_n_39_postgres_pods/migration.go
@@ -34,6 +34,7 @@ var (
 			}
 			return nil
 		},
+		LegacyToPostgres: true,
 	}
 	batchSize = 10000
 	schema    = frozenSchema.PodsSchema

--- a/migrator/migrations/n_39_to_n_40_postgres_policies/migration.go
+++ b/migrator/migrations/n_39_to_n_40_postgres_policies/migration.go
@@ -31,6 +31,7 @@ var (
 			}
 			return nil
 		},
+		LegacyToPostgres: true,
 	}
 	batchSize = 10000
 	schema    = frozenSchema.PoliciesSchema

--- a/migrator/migrations/n_40_to_n_41_postgres_process_baseline_results/migration.go
+++ b/migrator/migrations/n_40_to_n_41_postgres_process_baseline_results/migration.go
@@ -34,6 +34,7 @@ var (
 			}
 			return nil
 		},
+		LegacyToPostgres: true,
 	}
 	batchSize = 10000
 	schema    = frozenSchema.ProcessBaselineResultsSchema

--- a/migrator/migrations/n_41_to_n_42_postgres_process_baselines/migration.go
+++ b/migrator/migrations/n_41_to_n_42_postgres_process_baselines/migration.go
@@ -34,6 +34,7 @@ var (
 			}
 			return nil
 		},
+		LegacyToPostgres: true,
 	}
 	batchSize = 10000
 	schema    = frozenSchema.ProcessBaselinesSchema

--- a/migrator/migrations/n_42_to_n_43_postgres_process_indicators/migration.go
+++ b/migrator/migrations/n_42_to_n_43_postgres_process_indicators/migration.go
@@ -34,6 +34,7 @@ var (
 			}
 			return nil
 		},
+		LegacyToPostgres: true,
 	}
 	batchSize = 10000
 	schema    = frozenSchema.ProcessIndicatorsSchema

--- a/migrator/migrations/n_43_to_n_44_postgres_report_configurations/migration.go
+++ b/migrator/migrations/n_43_to_n_44_postgres_report_configurations/migration.go
@@ -34,6 +34,7 @@ var (
 			}
 			return nil
 		},
+		LegacyToPostgres: true,
 	}
 	batchSize = 10000
 	schema    = frozenSchema.ReportConfigurationsSchema

--- a/migrator/migrations/n_44_to_n_45_postgres_risks/migration.go
+++ b/migrator/migrations/n_44_to_n_45_postgres_risks/migration.go
@@ -34,6 +34,7 @@ var (
 			}
 			return nil
 		},
+		LegacyToPostgres: true,
 	}
 	batchSize = 10000
 	schema    = frozenSchema.RisksSchema

--- a/migrator/migrations/n_45_to_n_46_postgres_role_bindings/migration.go
+++ b/migrator/migrations/n_45_to_n_46_postgres_role_bindings/migration.go
@@ -34,6 +34,7 @@ var (
 			}
 			return nil
 		},
+		LegacyToPostgres: true,
 	}
 	batchSize = 10000
 	schema    = frozenSchema.RoleBindingsSchema

--- a/migrator/migrations/n_46_to_n_47_postgres_roles/migration.go
+++ b/migrator/migrations/n_46_to_n_47_postgres_roles/migration.go
@@ -22,6 +22,7 @@ var (
 			// and still be able to convert the references in the roles table.
 			return nil
 		},
+		LegacyToPostgres: true,
 	}
 )
 

--- a/migrator/migrations/n_47_to_n_48_postgres_secrets/migration.go
+++ b/migrator/migrations/n_47_to_n_48_postgres_secrets/migration.go
@@ -34,6 +34,7 @@ var (
 			}
 			return nil
 		},
+		LegacyToPostgres: true,
 	}
 	batchSize = 10000
 	schema    = frozenSchema.SecretsSchema

--- a/migrator/migrations/n_48_to_n_49_postgres_sensor_upgrade_configs/migration.go
+++ b/migrator/migrations/n_48_to_n_49_postgres_sensor_upgrade_configs/migration.go
@@ -31,6 +31,7 @@ var (
 			}
 			return nil
 		},
+		LegacyToPostgres: true,
 	}
 	batchSize = 10000
 	schema    = frozenSchema.SensorUpgradeConfigsSchema

--- a/migrator/migrations/n_49_to_n_50_postgres_service_accounts/migration.go
+++ b/migrator/migrations/n_49_to_n_50_postgres_service_accounts/migration.go
@@ -34,6 +34,7 @@ var (
 			}
 			return nil
 		},
+		LegacyToPostgres: true,
 	}
 	batchSize = 10000
 	schema    = frozenSchema.ServiceAccountsSchema

--- a/migrator/migrations/n_50_to_n_51_postgres_service_identities/migration.go
+++ b/migrator/migrations/n_50_to_n_51_postgres_service_identities/migration.go
@@ -31,6 +31,7 @@ var (
 			}
 			return nil
 		},
+		LegacyToPostgres: true,
 	}
 	batchSize = 10000
 	schema    = frozenSchema.ServiceIdentitiesSchema

--- a/migrator/migrations/n_51_to_n_52_postgres_signature_integrations/migration.go
+++ b/migrator/migrations/n_51_to_n_52_postgres_signature_integrations/migration.go
@@ -34,6 +34,7 @@ var (
 			}
 			return nil
 		},
+		LegacyToPostgres: true,
 	}
 	batchSize = 10000
 	schema    = frozenSchema.SignatureIntegrationsSchema

--- a/migrator/migrations/n_52_to_n_53_postgres_simple_access_scopes/migration.go
+++ b/migrator/migrations/n_52_to_n_53_postgres_simple_access_scopes/migration.go
@@ -42,6 +42,7 @@ var (
 		Run: func(databases *types.Databases) error {
 			return migrateAll(databases.PkgRocksDB, databases.GormDB, databases.PostgresDB)
 		},
+		LegacyToPostgres: true,
 	}
 	batchSize = 1000
 	log       = loghelper.LogWrapper{}

--- a/migrator/migrations/n_53_to_n_54_postgres_vulnerability_requests/migration.go
+++ b/migrator/migrations/n_53_to_n_54_postgres_vulnerability_requests/migration.go
@@ -34,6 +34,7 @@ var (
 			}
 			return nil
 		},
+		LegacyToPostgres: true,
 	}
 	batchSize = 10000
 	schema    = frozenSchema.VulnerabilityRequestsSchema

--- a/migrator/migrations/n_54_to_n_55_postgres_watched_images/migration.go
+++ b/migrator/migrations/n_54_to_n_55_postgres_watched_images/migration.go
@@ -34,6 +34,7 @@ var (
 			}
 			return nil
 		},
+		LegacyToPostgres: true,
 	}
 	batchSize = 10000
 	schema    = frozenSchema.WatchedImagesSchema

--- a/migrator/migrations/n_55_to_n_56_postgres_policy_categories/migration.go
+++ b/migrator/migrations/n_55_to_n_56_postgres_policy_categories/migration.go
@@ -34,6 +34,7 @@ var (
 			}
 			return nil
 		},
+		LegacyToPostgres: true,
 	}
 	batchSize = 10000
 	schema    = frozenSchema.PolicyCategoriesSchema

--- a/migrator/migrations/n_56_to_n_57_postgres_groups/migration.go
+++ b/migrator/migrations/n_56_to_n_57_postgres_groups/migration.go
@@ -31,6 +31,7 @@ var (
 			}
 			return nil
 		},
+		LegacyToPostgres: true,
 	}
 	batchSize = 10000
 	schema    = frozenSchema.GroupsSchema

--- a/migrator/runner/runner.go
+++ b/migrator/runner/runner.go
@@ -54,13 +54,13 @@ func runMigrations(databases *types.Databases, startingSeqNum int) error {
 		// added a new legacy migration.  If we determine that Postgres is the active database,
 		// the legacy databases will be nil when the runner is called.  So if we have already
 		// migrated to Postgres these legacy databases will be nil.
-		if !(migration.LegacyToPostgres && databases.PkgRocksDB == nil && databases.BoltDB == nil) {
+		if migration.LegacyToPostgres && (databases.PkgRocksDB == nil || databases.BoltDB == nil) {
+			log.WriteToStderrf("Skipping migration %d as it is a legacy to Postgres migration without the legacy databases present", seqNum)
+		} else {
 			err := migration.Run(databases)
 			if err != nil {
 				return errors.Wrapf(err, "error running migration starting at %d", seqNum)
 			}
-		} else {
-			log.WriteToStderrf("Skipping migration %d as it is a legacy to Postgres migration without the legacy databases present", seqNum)
 		}
 
 		err := updateVersion(databases, migration.VersionAfter)

--- a/migrator/types/migration.go
+++ b/migrator/types/migration.go
@@ -37,4 +37,10 @@ type Migration struct {
 	// All other (optional) metadata can be whatever the user desires, and has no bearing on the
 	// functioning of the migrator.
 	VersionAfter *storage.Version
+	// LegacyToPostgres tells us if the migration is a legacy database to postgres migration.
+	// This allows us the ability to ensure that all databases exist before executing the migration.
+	// Particularly helpful in the event a patch release caused a new legacy migration to be added.
+	// This will allow us to skip migrations when the legacy databases are not passed to the runner
+	// because we have already migrated to Postgres.
+	LegacyToPostgres bool
 }


### PR DESCRIPTION
## Description

We need to be able to not panic when a legacy migration is added as part of a patch release or for some other reason.  We can take advantage of the fact that if we determine that Postgres is the source database, we will pass nils to the migrations for both Bolt and Rocks.  If we determine we need to migrate from legacy we are ensured that Bolt and Rocks are not nil because we fail before calling the runner if they are.  So here we have annotated the migrations if they are a legacy to Postgres migration.  If they are and the legacy database are nil, we skip those migrations.

This solution is a quick and dirty one based on the state that we have saved currently for migrations.  A larger refactor and storing additional state is also an option, but that would take longer to release and would prove unnecessary in a couple of releases.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Manual tests for now.  Spin up an environment from earlier in 3.73.  Upgrade to these images and note in the logs that migration 169 was skipped.  #4003 will have added this case to CI runs upon its completion.
