### PR TITLE
ROX-13480: Add view active yamls tab

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraph.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraph.tsx
@@ -55,12 +55,14 @@ export type NetworkGraphProps = {
     model: CustomModel;
     edgeState: EdgeState;
     simulation: Simulation;
+    selectedClusterId: string;
 };
 
 export type TopologyComponentProps = {
     model: CustomModel;
     edgeState: EdgeState;
     simulation: Simulation;
+    selectedClusterId: string;
 };
 
 function getNodeEdges(selectedNode) {
@@ -141,7 +143,12 @@ function clearSimulationQuery(search: string): string {
     return queryString;
 }
 
-const TopologyComponent = ({ model, edgeState, simulation }: TopologyComponentProps) => {
+const TopologyComponent = ({
+    model,
+    edgeState,
+    simulation,
+    selectedClusterId,
+}: TopologyComponentProps) => {
     const history = useHistory();
     const { detailId } = useParams();
     const selectedEntity = detailId && getNodeById(model?.nodes, detailId);
@@ -196,7 +203,7 @@ const TopologyComponent = ({ model, edgeState, simulation }: TopologyComponentPr
             sideBar={
                 <TopologySideBar resizable onClose={closeSidebar}>
                     {simulation.isOn && simulation.type === 'networkPolicy' && (
-                        <NetworkPolicySimulatorSidePanel />
+                        <NetworkPolicySimulatorSidePanel selectedClusterId={selectedClusterId} />
                     )}
                     {selectedEntity && selectedEntity?.data?.type === 'NAMESPACE' && (
                         <NamespaceSideBar
@@ -266,20 +273,27 @@ const TopologyComponent = ({ model, edgeState, simulation }: TopologyComponentPr
     );
 };
 
-const NetworkGraph = React.memo<NetworkGraphProps>(({ model, edgeState, simulation }) => {
-    const controller = new Visualization();
-    controller.registerLayoutFactory(defaultLayoutFactory);
-    controller.registerComponentFactory(defaultComponentFactory);
-    controller.registerComponentFactory(stylesComponentFactory);
+const NetworkGraph = React.memo<NetworkGraphProps>(
+    ({ model, edgeState, simulation, selectedClusterId }) => {
+        const controller = new Visualization();
+        controller.registerLayoutFactory(defaultLayoutFactory);
+        controller.registerComponentFactory(defaultComponentFactory);
+        controller.registerComponentFactory(stylesComponentFactory);
 
-    return (
-        <div className="pf-ri__topology-demo">
-            <VisualizationProvider controller={controller}>
-                <TopologyComponent model={model} edgeState={edgeState} simulation={simulation} />
-            </VisualizationProvider>
-        </div>
-    );
-});
+        return (
+            <div className="pf-ri__topology-demo">
+                <VisualizationProvider controller={controller}>
+                    <TopologyComponent
+                        model={model}
+                        edgeState={edgeState}
+                        simulation={simulation}
+                        selectedClusterId={selectedClusterId}
+                    />
+                </VisualizationProvider>
+            </div>
+        );
+    }
+);
 
 NetworkGraph.displayName = 'NetworkGraph';
 

--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
@@ -217,7 +217,12 @@ function NetworkGraphPage() {
             >
                 {!hasClusterNamespaceSelected && <EmptyUnscopedState />}
                 {model.nodes && (
-                    <NetworkGraph model={model} edgeState={edgeState} simulation={simulation} />
+                    <NetworkGraph
+                        model={model}
+                        edgeState={edgeState}
+                        simulation={simulation}
+                        selectedClusterId={selectedClusterId || ''}
+                    />
                 )}
                 {isLoading && (
                     <Bullseye>

--- a/ui/apps/platform/src/Containers/NetworkGraph/hooks/apis/useFetchActiveYAMLs.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/hooks/apis/useFetchActiveYAMLs.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState } from 'react';
+import { fetchNetworkPoliciesByClusterId } from 'services/NetworkService';
+import { NetworkPolicy } from 'types/networkPolicy.proto';
+
+type Result = { isLoading: boolean; networkPolicies: NetworkPolicy[]; error: string | null };
+
+const defaultResultState = { networkPolicies: [], error: null, isLoading: true };
+
+type UseFetchActiveYAMLsParams = {
+    clusterId: string;
+};
+
+function useFetchActiveYAMLs({ clusterId }: UseFetchActiveYAMLsParams): Result {
+    const [result, setResult] = useState<Result>(defaultResultState);
+
+    useEffect(() => {
+        setResult(defaultResultState);
+
+        fetchNetworkPoliciesByClusterId(clusterId)
+            .then((data: NetworkPolicy[]) => {
+                setResult({ networkPolicies: data, error: null, isLoading: false });
+            })
+            .catch((error) => {
+                setResult({ networkPolicies: [], error, isLoading: false });
+            });
+    }, [clusterId]);
+
+    return result;
+}
+
+export default useFetchActiveYAMLs;

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPolicySimulatorSidePanel.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPolicySimulatorSidePanel.tsx
@@ -15,16 +15,23 @@ import {
     TextContent,
     TextVariants,
 } from '@patternfly/react-core';
+import { FileUploadIcon } from '@patternfly/react-icons';
 
 import useTabs from 'hooks/patternfly/useTabs';
-import { FileUploadIcon } from '@patternfly/react-icons';
+import ViewActiveYAMLs from './ViewActiveYAMLs';
+
+type NetworkPolicySimulatorSidePanelProps = {
+    selectedClusterId: string;
+};
 
 const tabs = {
     SIMULATE_NETWORK_POLICIES: 'Simulate network policies',
     VIEW_ACTIVE_YAMLS: 'View active YAMLS',
 };
 
-function NetworkPolicySimulatorSidePanel() {
+function NetworkPolicySimulatorSidePanel({
+    selectedClusterId,
+}: NetworkPolicySimulatorSidePanelProps) {
     const { activeKeyTab, onSelectTab } = useTabs({
         defaultTab: tabs.SIMULATE_NETWORK_POLICIES,
     });
@@ -145,7 +152,7 @@ function NetworkPolicySimulatorSidePanel() {
                     id={tabs.VIEW_ACTIVE_YAMLS}
                     hidden={activeKeyTab !== tabs.VIEW_ACTIVE_YAMLS}
                 >
-                    <div>View active YAMLs</div>
+                    <ViewActiveYAMLs selectedClusterId={selectedClusterId} />
                 </TabContent>
             </StackItem>
         </Stack>

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/ViewActiveYAMLs.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/ViewActiveYAMLs.tsx
@@ -1,0 +1,147 @@
+import React, { useEffect } from 'react';
+import {
+    Alert,
+    AlertVariant,
+    Bullseye,
+    Button,
+    EmptyState,
+    EmptyStateVariant,
+    SelectOption,
+    Spinner,
+    Stack,
+    StackItem,
+    Title,
+} from '@patternfly/react-core';
+import { CodeEditor, CodeEditorControl, Language } from '@patternfly/react-code-editor';
+import { MoonIcon, SunIcon } from '@patternfly/react-icons';
+import { useTheme } from 'Containers/ThemeProvider';
+import download from 'utils/download';
+import { NetworkPolicy } from 'types/networkPolicy.proto';
+import SelectSingle from 'Components/SelectSingle';
+import useFetchActiveYAMLs from '../hooks/apis/useFetchActiveYAMLs';
+
+type ViewActiveYamlsProps = {
+    selectedClusterId: string;
+};
+
+const downloadYAMLHandler = (fileName: string, fileContent: string) => () => {
+    download(`${fileName}.yml`, fileContent, 'yml');
+};
+
+function ViewActiveYamls({ selectedClusterId }: ViewActiveYamlsProps) {
+    const { networkPolicies, isLoading, error } = useFetchActiveYAMLs({
+        clusterId: selectedClusterId,
+    });
+    const { isDarkMode } = useTheme();
+    const [customDarkMode, setCustomDarkMode] = React.useState(isDarkMode);
+    const [selectedNetworkPolicy, setSelectedNetworkPolicy] = React.useState<
+        NetworkPolicy | undefined
+    >(networkPolicies?.[0]);
+
+    useEffect(() => {
+        if (networkPolicies?.length && !selectedNetworkPolicy) {
+            setSelectedNetworkPolicy(networkPolicies[0]);
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [networkPolicies]);
+
+    function onToggleDarkMode() {
+        setCustomDarkMode((prevValue) => !prevValue);
+    }
+
+    function handleSelectedNetworkPolicy(_, value: string) {
+        const newlySelectedNetworkPolicy = networkPolicies?.find(
+            (networkPolicy) => networkPolicy.name === value
+        );
+        setSelectedNetworkPolicy(newlySelectedNetworkPolicy);
+    }
+
+    const customControl = (
+        <CodeEditorControl
+            icon={customDarkMode ? <SunIcon /> : <MoonIcon />}
+            aria-label="Toggle dark mode"
+            toolTipText={customDarkMode ? 'Toggle to light mode' : 'Toggle to dark mode'}
+            onClick={onToggleDarkMode}
+            isVisible
+        />
+    );
+
+    if (isLoading) {
+        return (
+            <Bullseye>
+                <Spinner isSVG size="lg" />
+            </Bullseye>
+        );
+    }
+
+    if (error) {
+        return (
+            <Alert isInline variant={AlertVariant.danger} title={error} className="pf-u-mb-lg" />
+        );
+    }
+
+    if (networkPolicies.length === 0) {
+        return (
+            <Bullseye>
+                <EmptyState variant={EmptyStateVariant.xs}>
+                    <Title headingLevel="h4" size="md">
+                        No network policies
+                    </Title>
+                </EmptyState>
+            </Bullseye>
+        );
+    }
+
+    return (
+        <div className="pf-u-h-100 pf-u-p-md">
+            <Stack hasGutter>
+                <StackItem>
+                    <SelectSingle
+                        id="search-filter-attributes-select"
+                        value={selectedNetworkPolicy?.name || ''}
+                        handleSelect={handleSelectedNetworkPolicy}
+                        placeholderText="Select a network policy"
+                    >
+                        {networkPolicies.map((networkPolicy) => {
+                            return (
+                                <SelectOption key={networkPolicy.name} value={networkPolicy.name}>
+                                    {networkPolicy.name}
+                                </SelectOption>
+                            );
+                        })}
+                    </SelectSingle>
+                </StackItem>
+                {selectedNetworkPolicy && (
+                    <StackItem>
+                        <div className="pf-u-h-100">
+                            <CodeEditor
+                                isDarkTheme={customDarkMode}
+                                customControls={customControl}
+                                isCopyEnabled
+                                isLineNumbersVisible
+                                isReadOnly
+                                code={selectedNetworkPolicy.yaml}
+                                language={Language.yaml}
+                                height="300px"
+                            />
+                        </div>
+                    </StackItem>
+                )}
+                {selectedNetworkPolicy && (
+                    <StackItem>
+                        <Button
+                            onClick={downloadYAMLHandler(
+                                selectedNetworkPolicy.name,
+                                selectedNetworkPolicy.yaml
+                            )}
+                        >
+                            Export YAML
+                        </Button>
+                    </StackItem>
+                )}
+            </Stack>
+        </div>
+    );
+}
+
+export default ViewActiveYamls;

--- a/ui/apps/platform/src/services/NetworkService.js
+++ b/ui/apps/platform/src/services/NetworkService.js
@@ -323,6 +323,17 @@ export function getActiveNetworkModification(clusterId, deploymentQuery) {
     });
 }
 
+export function fetchNetworkPoliciesByClusterId(clusterId) {
+    const params = queryString.stringify({ clusterId });
+    const options = {
+        method: 'GET',
+        url: `${networkPoliciesBaseUrl}?${params}`,
+    };
+    return axios(options).then((response) => {
+        return response?.data?.networkPolicies;
+    });
+}
+
 /**
  * Retrieves the modification that will undo the last action done through the stackrox UI.
  *


### PR DESCRIPTION
## Description

This PR is an iterative addition to the network policy simulator. We will display the active network policy yamls in the "view active yamls" tab

<img width="1440" alt="Screenshot 2022-12-09 at 12 22 15 PM" src="https://user-images.githubusercontent.com/4805485/206790720-af8dc115-ff52-44b7-88e7-c11e4796137f.png">

## Checklist
- [ ] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~
