### PR TITLE
ROX-13746:  Add Deployments to Network Graph filter

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
@@ -64,11 +64,12 @@ function NetworkGraphPage() {
     } = getScopeHierarchy(searchFilter);
 
     const { clusters } = useFetchClusters();
+    const selectedClusterId = clusters.find((cl) => cl.name === clusterFromUrl)?.id;
+    const selectedCluster = { name: clusterFromUrl, id: selectedClusterId };
 
     useDeepCompareEffect(() => {
         // only refresh the graph data from the API if both a cluster and at least one namespace are selected
         if (clusterFromUrl && namespacesFromUrl.length > 0) {
-            const selectedClusterId = clusters.find((cl) => cl.name === clusterFromUrl)?.id;
             if (selectedClusterId) {
                 setIsLoading(true);
 
@@ -165,7 +166,11 @@ function NetworkGraphPage() {
                         </Title>
                     </FlexItem>
                     <FlexItem flex={{ default: 'flex_1' }}>
-                        <NetworkBreadcrumbs clusters={clusters} />
+                        <NetworkBreadcrumbs
+                            clusters={clusters}
+                            selectedCluster={selectedCluster}
+                            selectedNamespaces={namespacesFromUrl}
+                        />
                     </FlexItem>
                     <Button variant="secondary">Manage CIDR blocks</Button>
                     <Button variant="secondary">Simulate network policy</Button>

--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
@@ -52,13 +52,11 @@ function NetworkGraphPage() {
     const [extraneousFlowsModel, setExtraneousFlowsModel] = useState<CustomModel>(emptyModel);
     const [model, setModel] = useState<CustomModel>(emptyModel);
     const [isLoading, setIsLoading] = useState(false);
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { searchFilter } = useURLSearch();
 
     const {
         cluster: clusterFromUrl,
         namespaces: namespacesFromUrl,
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         deployments: deploymentsFromUrl,
         remainingQuery,
     } = getScopeHierarchy(searchFilter);
@@ -80,6 +78,7 @@ function NetworkGraphPage() {
                     fetchNetworkFlowGraph(
                         selectedClusterId,
                         namespacesFromUrl,
+                        deploymentsFromUrl,
                         queryToUse,
                         timestampToUse || undefined,
                         includePorts
@@ -87,6 +86,7 @@ function NetworkGraphPage() {
                     fetchNetworkPolicyGraph(
                         selectedClusterId,
                         namespacesFromUrl,
+                        deploymentsFromUrl,
                         queryToUse,
                         undefined,
                         includePorts
@@ -145,7 +145,7 @@ function NetworkGraphPage() {
                     .finally(() => setIsLoading(false));
             }
         }
-    }, [clusters, clusterFromUrl, namespacesFromUrl]);
+    }, [clusters, clusterFromUrl, namespacesFromUrl, deploymentsFromUrl]);
 
     useEffect(() => {
         if (edgeState === 'active') {
@@ -170,6 +170,7 @@ function NetworkGraphPage() {
                             clusters={clusters}
                             selectedCluster={selectedCluster}
                             selectedNamespaces={namespacesFromUrl}
+                            selectedDeployments={deploymentsFromUrl}
                         />
                     </FlexItem>
                     <Button variant="secondary">Manage CIDR blocks</Button>

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/ClusterSelector.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/ClusterSelector.tsx
@@ -4,22 +4,25 @@ import { Select, SelectOption } from '@patternfly/react-core';
 import { Cluster } from 'types/cluster.proto';
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
 import { ClusterIcon } from '../common/NetworkGraphIcons';
-import getScopeHierarchy from '../utils/getScopeHierarchy';
 
 type ClusterSelectorProps = {
     clusters: Cluster[];
+    selectedClusterName?: string;
     searchFilter: Partial<Record<string, string | string[]>>;
     setSearchFilter: (newFilter: Partial<Record<string, string | string[]>>) => void;
 };
 
-function ClusterSelector({ clusters = [], searchFilter, setSearchFilter }: ClusterSelectorProps) {
+function ClusterSelector({
+    clusters = [],
+    selectedClusterName = '',
+    searchFilter,
+    setSearchFilter,
+}: ClusterSelectorProps) {
     const {
         isOpen: isClusterOpen,
         toggleSelect: toggleIsClusterOpen,
         closeSelect: closeClusterSelect,
     } = useSelectToggle();
-
-    const { cluster: selectedClusterName } = getScopeHierarchy(searchFilter);
 
     const onClusterSelect = (_, value) => {
         closeClusterSelect();

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/DeploymentSelector.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/DeploymentSelector.tsx
@@ -1,0 +1,96 @@
+import React, { useCallback, ChangeEvent } from 'react';
+import { Select, SelectOption, SelectVariant } from '@patternfly/react-core';
+
+import useFetchClusterNamespaces from 'hooks/useFetchClusterNamespaces';
+import useSelectToggle from 'hooks/patternfly/useSelectToggle';
+import { NamespaceIcon } from '../common/NetworkGraphIcons';
+import getScopeHierarchy from '../utils/getScopeHierarchy';
+
+function filterElementsWithValueProp(
+    filterValue: string,
+    elements: React.ReactElement[] | undefined
+): React.ReactElement[] | undefined {
+    if (filterValue === '' || elements === undefined) {
+        return elements;
+    }
+
+    return elements.filter((reactElement) =>
+        reactElement.props.value?.toLowerCase().includes(filterValue.toLowerCase())
+    );
+}
+
+type NamespaceSelectorProps = {
+    selectedClusterId: string;
+    searchFilter: Partial<Record<string, string | string[]>>;
+    setSearchFilter: (newFilter: Partial<Record<string, string | string[]>>) => void;
+};
+
+function NamespaceSelector({
+    selectedClusterId = '',
+    searchFilter,
+    setSearchFilter,
+}: NamespaceSelectorProps) {
+    const {
+        isOpen: isNamespaceOpen,
+        toggleSelect: toggleIsNamespaceOpen,
+        closeSelect: closeNamespaceSelect,
+    } = useSelectToggle();
+
+    const { namespaces: selectedNamespaces } = getScopeHierarchy(searchFilter);
+    const { loading, error, namespaces } = useFetchClusterNamespaces(selectedClusterId);
+
+    const onFilterNamespaces = useCallback(
+        (e: ChangeEvent<HTMLInputElement> | null, filterValue: string) =>
+            filterElementsWithValueProp(
+                filterValue,
+                namespaces.map((namespace) => (
+                    <SelectOption key={namespace} value={namespace}>
+                        <span>
+                            <NamespaceIcon /> {namespace}
+                        </span>
+                    </SelectOption>
+                ))
+            ),
+        [namespaces]
+    );
+
+    const onNamespaceSelect = (_, selected) => {
+        closeNamespaceSelect();
+
+        const newSelection = selectedNamespaces.find((nsFilter) => nsFilter === selected)
+            ? selectedNamespaces.filter((nsFilter) => nsFilter !== selected)
+            : selectedNamespaces.concat(selected);
+
+        const modifiedSearchObject = { ...searchFilter };
+        modifiedSearchObject.Namespace = newSelection;
+        setSearchFilter(modifiedSearchObject);
+    };
+
+    const namespaceSelectOptions: JSX.Element[] = namespaces.map((namespace) => (
+        <SelectOption key={namespace} value={namespace}>
+            <span>
+                <NamespaceIcon /> {namespace}
+            </span>
+        </SelectOption>
+    ));
+
+    return (
+        <Select
+            isOpen={isNamespaceOpen}
+            onToggle={toggleIsNamespaceOpen}
+            onSelect={onNamespaceSelect}
+            onFilter={onFilterNamespaces}
+            className="namespace-select"
+            placeholderText="Namespaces"
+            isDisabled={!selectedClusterId || loading || Boolean(error)}
+            selections={selectedNamespaces}
+            variant={SelectVariant.checkbox}
+            maxHeight="275px"
+            hasInlineFilter
+        >
+            {namespaceSelectOptions}
+        </Select>
+    );
+}
+
+export default NamespaceSelector;

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/DeploymentSelector.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/DeploymentSelector.tsx
@@ -1,10 +1,8 @@
 import React, { useCallback, ChangeEvent } from 'react';
 import { Select, SelectOption, SelectVariant } from '@patternfly/react-core';
 
-import useFetchClusterNamespaces from 'hooks/useFetchClusterNamespaces';
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
-import { NamespaceIcon } from '../common/NetworkGraphIcons';
-import getScopeHierarchy from '../utils/getScopeHierarchy';
+import { DeploymentIcon } from '../common/NetworkGraphIcons';
 
 function filterElementsWithValueProp(
     filterValue: string,
@@ -19,78 +17,77 @@ function filterElementsWithValueProp(
     );
 }
 
-type NamespaceSelectorProps = {
-    selectedClusterId: string;
+type DeploymentSelectorProps = {
+    deployments: string[];
+    selectedDeployments: string[];
     searchFilter: Partial<Record<string, string | string[]>>;
     setSearchFilter: (newFilter: Partial<Record<string, string | string[]>>) => void;
 };
 
-function NamespaceSelector({
-    selectedClusterId = '',
+function DeploymentSelector({
+    deployments = [],
+    selectedDeployments = [],
     searchFilter,
     setSearchFilter,
-}: NamespaceSelectorProps) {
+}: DeploymentSelectorProps) {
     const {
-        isOpen: isNamespaceOpen,
-        toggleSelect: toggleIsNamespaceOpen,
-        closeSelect: closeNamespaceSelect,
+        isOpen: isDeploymentOpen,
+        toggleSelect: toggleIsDeploymentOpen,
+        closeSelect: closeDeploymentSelect,
     } = useSelectToggle();
 
-    const { namespaces: selectedNamespaces } = getScopeHierarchy(searchFilter);
-    const { loading, error, namespaces } = useFetchClusterNamespaces(selectedClusterId);
-
-    const onFilterNamespaces = useCallback(
+    const onFilterDeployments = useCallback(
         (e: ChangeEvent<HTMLInputElement> | null, filterValue: string) =>
             filterElementsWithValueProp(
                 filterValue,
-                namespaces.map((namespace) => (
-                    <SelectOption key={namespace} value={namespace}>
+                deployments.map((deployment) => (
+                    <SelectOption key={deployment} value={deployment}>
                         <span>
-                            <NamespaceIcon /> {namespace}
+                            <DeploymentIcon /> {deployment}
                         </span>
                     </SelectOption>
                 ))
             ),
-        [namespaces]
+        [deployments]
     );
 
-    const onNamespaceSelect = (_, selected) => {
-        closeNamespaceSelect();
+    const onDeploymentSelect = (_, selected) => {
+        closeDeploymentSelect();
 
-        const newSelection = selectedNamespaces.find((nsFilter) => nsFilter === selected)
-            ? selectedNamespaces.filter((nsFilter) => nsFilter !== selected)
-            : selectedNamespaces.concat(selected);
+        const newSelection = selectedDeployments.find((nsFilter) => nsFilter === selected)
+            ? selectedDeployments.filter((nsFilter) => nsFilter !== selected)
+            : selectedDeployments.concat(selected);
 
         const modifiedSearchObject = { ...searchFilter };
-        modifiedSearchObject.Namespace = newSelection;
+        modifiedSearchObject.Deployment = newSelection;
         setSearchFilter(modifiedSearchObject);
     };
 
-    const namespaceSelectOptions: JSX.Element[] = namespaces.map((namespace) => (
-        <SelectOption key={namespace} value={namespace}>
+    const deploymentSelectOptions: JSX.Element[] = deployments.map((deployment) => (
+        <SelectOption key={deployment} value={deployment}>
             <span>
-                <NamespaceIcon /> {namespace}
+                <DeploymentIcon /> {deployment}
             </span>
         </SelectOption>
     ));
 
     return (
         <Select
-            isOpen={isNamespaceOpen}
-            onToggle={toggleIsNamespaceOpen}
-            onSelect={onNamespaceSelect}
-            onFilter={onFilterNamespaces}
-            className="namespace-select"
-            placeholderText="Namespaces"
-            isDisabled={!selectedClusterId || loading || Boolean(error)}
-            selections={selectedNamespaces}
+            isOpen={isDeploymentOpen}
+            onToggle={toggleIsDeploymentOpen}
+            onSelect={onDeploymentSelect}
+            onFilter={onFilterDeployments}
+            className="deployment-select"
+            placeholderText="Deployments"
+            isDisabled={deployments.length === 0}
+            selections={selectedDeployments}
             variant={SelectVariant.checkbox}
             maxHeight="275px"
             hasInlineFilter
         >
-            {namespaceSelectOptions}
+            {deploymentSelectOptions}
         </Select>
     );
 }
 
-export default NamespaceSelector;
+export default DeploymentSelector;

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/DeploymentSelector.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/DeploymentSelector.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, ChangeEvent } from 'react';
 import { Select, SelectOption, SelectVariant } from '@patternfly/react-core';
 
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
+import { NamespaceWithDeployments } from 'hooks/useFetchClusterNamespaces';
 import { DeploymentIcon } from '../common/NetworkGraphIcons';
 
 function filterElementsWithValueProp(
@@ -18,14 +19,29 @@ function filterElementsWithValueProp(
 }
 
 type DeploymentSelectorProps = {
-    deployments: string[];
+    deploymentsByNamespace: NamespaceWithDeployments[];
     selectedDeployments: string[];
     searchFilter: Partial<Record<string, string | string[]>>;
     setSearchFilter: (newFilter: Partial<Record<string, string | string[]>>) => void;
 };
 
+/*
+      <SelectGroup label="Status" key="group1">
+        <SelectOption key={0} value="Running" />
+        <SelectOption key={1} value="Stopped" />
+        <SelectOption key={2} value="Down" />
+        <SelectOption key={3} value="Degraded" />
+        <SelectOption key={4} value="Needs maintenance" />
+      </SelectGroup>,
+      <SelectGroup label="Vendor names" key="group2">
+        <SelectOption key={5} value="Dell" />
+        <SelectOption key={6} value="Samsung" isDisabled />
+        <SelectOption key={7} value="Hewlett-Packard" />
+      </SelectGroup>
+
+*/
 function DeploymentSelector({
-    deployments = [],
+    deploymentsByNamespace = [],
     selectedDeployments = [],
     searchFilter,
     setSearchFilter,
@@ -40,7 +56,7 @@ function DeploymentSelector({
         (e: ChangeEvent<HTMLInputElement> | null, filterValue: string) =>
             filterElementsWithValueProp(
                 filterValue,
-                deployments.map((deployment) => (
+                deploymentsByNamespace.map((deployment) => (
                     <SelectOption key={deployment} value={deployment}>
                         <span>
                             <DeploymentIcon /> {deployment}
@@ -48,7 +64,7 @@ function DeploymentSelector({
                     </SelectOption>
                 ))
             ),
-        [deployments]
+        [deploymentsByNamespace]
     );
 
     const onDeploymentSelect = (_, selected) => {
@@ -63,7 +79,7 @@ function DeploymentSelector({
         setSearchFilter(modifiedSearchObject);
     };
 
-    const deploymentSelectOptions: JSX.Element[] = deployments.map((deployment) => (
+    const deploymentSelectOptions: JSX.Element[] = deploymentsByNamespace.map((deployment) => (
         <SelectOption key={deployment} value={deployment}>
             <span>
                 <DeploymentIcon /> {deployment}
@@ -79,7 +95,7 @@ function DeploymentSelector({
             onFilter={onFilterDeployments}
             className="deployment-select"
             placeholderText="Deployments"
-            isDisabled={deployments.length === 0}
+            isDisabled={deploymentsByNamespace.length === 0}
             selections={selectedDeployments}
             variant={SelectVariant.checkbox}
             maxHeight="275px"

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/NamespaceSelector.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/NamespaceSelector.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, ChangeEvent } from 'react';
-import { Select, SelectOption, SelectVariant } from '@patternfly/react-core';
+import { Badge, Select, SelectOption, SelectVariant } from '@patternfly/react-core';
 
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
 import { Namespace } from 'hooks/useFetchClusterNamespaces';
@@ -42,9 +42,14 @@ function NamespaceSelector({
             filterElementsWithValueProp(
                 filterValue,
                 namespaces.map((namespace) => (
-                    <SelectOption key={namespace.metadata.id} value={namespace.metadata.name}>
+                    <SelectOption
+                        key={namespace.metadata.id}
+                        value={namespace.metadata.name}
+                        isDisabled={namespace.deploymentCount < 1}
+                    >
                         <span>
-                            <NamespaceIcon /> {namespace.metadata.name}
+                            <NamespaceIcon /> {namespace.metadata.name}{' '}
+                            <Badge isRead>{namespace.deploymentCount}</Badge>
                         </span>
                     </SelectOption>
                 ))
@@ -66,9 +71,14 @@ function NamespaceSelector({
 
     const namespaceSelectOptions: JSX.Element[] = namespaces.map((namespace) => {
         return (
-            <SelectOption key={namespace.metadata.id} value={namespace.metadata.name}>
+            <SelectOption
+                key={namespace.metadata.id}
+                value={namespace.metadata.name}
+                isDisabled={namespace.deploymentCount < 1}
+            >
                 <span>
-                    <NamespaceIcon /> {namespace.metadata.name}
+                    <NamespaceIcon /> {namespace.metadata.name}{' '}
+                    <Badge isRead>{namespace.deploymentCount}</Badge>
                 </span>
             </SelectOption>
         );

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/NamespaceSelector.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/NamespaceSelector.tsx
@@ -25,17 +25,6 @@ type NamespaceSelectorProps = {
     setSearchFilter: (newFilter: Partial<Record<string, string | string[]>>) => void;
 };
 
-function NamespaceSelectOption({ namespace }) {
-    console.log({ namespace });
-    return (
-        <SelectOption key={namespace.metadata.id} value={namespace.metadata.name}>
-            <span>
-                <NamespaceIcon /> {namespace.metadata.name}
-            </span>
-        </SelectOption>
-    );
-}
-
 function NamespaceSelector({
     namespaces = [],
     selectedNamespaces = [],
@@ -52,7 +41,13 @@ function NamespaceSelector({
         (e: ChangeEvent<HTMLInputElement> | null, filterValue: string) =>
             filterElementsWithValueProp(
                 filterValue,
-                namespaces.map((namespace) => <NamespaceSelectOption namespace={namespace} />)
+                namespaces.map((namespace) => (
+                    <SelectOption key={namespace.metadata.id} value={namespace.metadata.name}>
+                        <span>
+                            <NamespaceIcon /> {namespace.metadata.name}
+                        </span>
+                    </SelectOption>
+                ))
             ),
         [namespaces]
     );
@@ -69,9 +64,15 @@ function NamespaceSelector({
         setSearchFilter(modifiedSearchObject);
     };
 
-    const namespaceSelectOptions: JSX.Element[] = namespaces.map((namespace) => (
-        <NamespaceSelectOption namespace={namespace} />
-    ));
+    const namespaceSelectOptions: JSX.Element[] = namespaces.map((namespace) => {
+        return (
+            <SelectOption key={namespace.metadata.id} value={namespace.metadata.name}>
+                <span>
+                    <NamespaceIcon /> {namespace.metadata.name}
+                </span>
+            </SelectOption>
+        );
+    });
 
     return (
         <Select

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/NetworkBreadcrumbs.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/NetworkBreadcrumbs.tsx
@@ -3,21 +3,33 @@ import { Breadcrumb, BreadcrumbItem } from '@patternfly/react-core';
 
 import { Cluster } from 'types/cluster.proto';
 import useURLSearch from 'hooks/useURLSearch';
+import useFetchClusterNamespaces from 'hooks/useFetchClusterNamespaces';
+import useFetchNamespaceDeployments from 'hooks/useFetchNamespaceDeployments';
 import ClusterSelector from './ClusterSelector';
 import NamespaceSelector from './NamespaceSelector';
-import getScopeHierarchy from '../utils/getScopeHierarchy';
+// import DeploymentSelector from './DeploymentSelector';
 
 type NetworkBreadcrumbsProps = {
     clusters: Cluster[];
+    selectedCluster?: { name?: string; id?: string };
+    selectedNamespaces: string[];
 };
 
-function NetworkBreadcrumbs({ clusters = [] }: NetworkBreadcrumbsProps) {
+function NetworkBreadcrumbs({
+    clusters = [],
+    selectedCluster = {},
+    selectedNamespaces = [],
+}: NetworkBreadcrumbsProps) {
     const { searchFilter, setSearchFilter } = useURLSearch();
 
-    const { cluster: selectedClusterName } = getScopeHierarchy(searchFilter);
-
-    const selectedClusterId =
-        clusters.find((cluster) => cluster.name === selectedClusterName)?.id || '';
+    const { loading, error, namespaces } = useFetchClusterNamespaces(selectedCluster?.id);
+    const selectedNamespaceIds = namespaces.reduce((acc: string[], namespace) => {
+        return selectedNamespaces.includes(namespace.metadata.name)
+            ? [...acc, namespace.metadata.id]
+            : acc;
+    }, []);
+    const { deploymentsByNamespace } = useFetchNamespaceDeployments(selectedNamespaceIds);
+    console.log({ deploymentsByNamespace });
 
     return (
         <>
@@ -25,17 +37,27 @@ function NetworkBreadcrumbs({ clusters = [] }: NetworkBreadcrumbsProps) {
                 <BreadcrumbItem isDropdown>
                     <ClusterSelector
                         clusters={clusters}
+                        selectedClusterName={selectedCluster?.name ?? ''}
                         searchFilter={searchFilter}
                         setSearchFilter={setSearchFilter}
                     />
                 </BreadcrumbItem>
                 <BreadcrumbItem isDropdown>
                     <NamespaceSelector
-                        selectedClusterId={selectedClusterId}
+                        namespaces={namespaces}
+                        selectedNamespaces={selectedNamespaces}
                         searchFilter={searchFilter}
                         setSearchFilter={setSearchFilter}
                     />
                 </BreadcrumbItem>
+                {/* <BreadcrumbItem isDropdown>
+                    <NamespaceSelector
+                        selectedNamespaces={selectedDeployments}
+                        selectedDeployments={selectedDeployments}
+                        searchFilter={searchFilter}
+                        setSearchFilter={setSearchFilter}
+                    />
+                </BreadcrumbItem> */}
             </Breadcrumb>
         </>
     );

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/NetworkBreadcrumbs.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/NetworkBreadcrumbs.tsx
@@ -7,29 +7,30 @@ import useFetchClusterNamespaces from 'hooks/useFetchClusterNamespaces';
 import useFetchNamespaceDeployments from 'hooks/useFetchNamespaceDeployments';
 import ClusterSelector from './ClusterSelector';
 import NamespaceSelector from './NamespaceSelector';
-// import DeploymentSelector from './DeploymentSelector';
+import DeploymentSelector from './DeploymentSelector';
 
 type NetworkBreadcrumbsProps = {
     clusters: Cluster[];
     selectedCluster?: { name?: string; id?: string };
     selectedNamespaces: string[];
+    selectedDeployments: string[];
 };
 
 function NetworkBreadcrumbs({
     clusters = [],
     selectedCluster = {},
     selectedNamespaces = [],
+    selectedDeployments = [],
 }: NetworkBreadcrumbsProps) {
     const { searchFilter, setSearchFilter } = useURLSearch();
 
     const { loading, error, namespaces } = useFetchClusterNamespaces(selectedCluster?.id);
-    const selectedNamespaceIds = namespaces.reduce((acc: string[], namespace) => {
+    const selectedNamespaceIds = namespaces.reduce<string[]>((acc: string[], namespace) => {
         return selectedNamespaces.includes(namespace.metadata.name)
             ? [...acc, namespace.metadata.id]
             : acc;
     }, []);
     const { deploymentsByNamespace } = useFetchNamespaceDeployments(selectedNamespaceIds);
-    console.log({ deploymentsByNamespace });
 
     return (
         <>
@@ -50,14 +51,14 @@ function NetworkBreadcrumbs({
                         setSearchFilter={setSearchFilter}
                     />
                 </BreadcrumbItem>
-                {/* <BreadcrumbItem isDropdown>
-                    <NamespaceSelector
-                        selectedNamespaces={selectedDeployments}
+                <BreadcrumbItem isDropdown>
+                    <DeploymentSelector
+                        deploymentsByNamespace={deploymentsByNamespace}
                         selectedDeployments={selectedDeployments}
                         searchFilter={searchFilter}
                         setSearchFilter={setSearchFilter}
                     />
-                </BreadcrumbItem> */}
+                </BreadcrumbItem>
             </Breadcrumb>
         </>
     );

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/NetworkBreadcrumbs.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/NetworkBreadcrumbs.tsx
@@ -24,7 +24,7 @@ function NetworkBreadcrumbs({
 }: NetworkBreadcrumbsProps) {
     const { searchFilter, setSearchFilter } = useURLSearch();
 
-    const { loading, error, namespaces } = useFetchClusterNamespaces(selectedCluster?.id);
+    const { namespaces } = useFetchClusterNamespaces(selectedCluster?.id);
     const selectedNamespaceIds = namespaces.reduce<string[]>((acc: string[], namespace) => {
         return selectedNamespaces.includes(namespace.metadata.name)
             ? [...acc, namespace.metadata.id]

--- a/ui/apps/platform/src/hooks/useFetchClusterNamespaces.ts
+++ b/ui/apps/platform/src/hooks/useFetchClusterNamespaces.ts
@@ -6,6 +6,7 @@ export type Namespace = {
         id: string;
         name: string;
     };
+    deploymentCount;
 };
 type NamespaceResponse = {
     id: string;
@@ -23,6 +24,7 @@ const NAMESPACES_FOR_CLUSTER_QUERY = gql`
                     id
                     name
                 }
+                deploymentCount
             }
         }
     }

--- a/ui/apps/platform/src/hooks/useFetchClusterNamespaces.ts
+++ b/ui/apps/platform/src/hooks/useFetchClusterNamespaces.ts
@@ -15,7 +15,7 @@ type NamespaceResponse = {
 };
 
 const NAMESPACES_FOR_CLUSTER_QUERY = gql`
-    query getClusterNamespaceNames($id: ID!) {
+    query getClusterNamespaces($id: ID!) {
         results: cluster(id: $id) {
             id
             namespaces {

--- a/ui/apps/platform/src/hooks/useFetchClusterNamespaces.ts
+++ b/ui/apps/platform/src/hooks/useFetchClusterNamespaces.ts
@@ -1,8 +1,9 @@
 import { useState, useEffect } from 'react';
 import { gql, useQuery } from '@apollo/client';
 
-type Namespace = {
+export type Namespace = {
     metadata: {
+        id: string;
         name: string;
     };
 };
@@ -19,6 +20,7 @@ const NAMESPACES_FOR_CLUSTER_QUERY = gql`
             id
             namespaces {
                 metadata {
+                    id
                     name
                 }
             }
@@ -26,8 +28,8 @@ const NAMESPACES_FOR_CLUSTER_QUERY = gql`
     }
 `;
 
-function useFetchClusterNamespaces(selectedClusterId: string) {
-    const [availableNamespaces, setAvailableNamespaces] = useState<string[]>([]);
+function useFetchClusterNamespaces(selectedClusterId?: string) {
+    const [availableNamespaces, setAvailableNamespaces] = useState<Namespace[]>([]);
 
     // If the selectedClusterId has not been set yet, do not run the gql query
     const queryOptions = selectedClusterId
@@ -44,9 +46,7 @@ function useFetchClusterNamespaces(selectedClusterId: string) {
             return;
         }
 
-        const namespaces = data.results.namespaces.map(({ metadata }) => metadata.name);
-
-        setAvailableNamespaces(namespaces);
+        setAvailableNamespaces(data.results.namespaces);
     }, [data]);
 
     return {

--- a/ui/apps/platform/src/hooks/useFetchNamespaceDeployments.ts
+++ b/ui/apps/platform/src/hooks/useFetchNamespaceDeployments.ts
@@ -6,16 +6,15 @@ import queryService from 'utils/queryService';
 type Deployment = {
     name: string;
 };
+export type NamespaceWithDeployments = {
+    metadata: {
+        id: string;
+        name: string;
+    };
+    deployments: Deployment[];
+};
 type DeploymentResponse = {
-    results: [
-        {
-            metadata: {
-                id: string;
-                name: string;
-            };
-            deployments: Deployment[];
-        }
-    ];
+    results: NamespaceWithDeployments[];
 };
 
 const DEPLOYMENTS_FOR_NAMESPACE_QUERY = gql`

--- a/ui/apps/platform/src/hooks/useFetchNamespaceDeployments.ts
+++ b/ui/apps/platform/src/hooks/useFetchNamespaceDeployments.ts
@@ -4,6 +4,7 @@ import { gql, useQuery } from '@apollo/client';
 import queryService from 'utils/queryService';
 
 type Deployment = {
+    id: string;
     name: string;
 };
 export type NamespaceWithDeployments = {
@@ -33,7 +34,7 @@ const DEPLOYMENTS_FOR_NAMESPACE_QUERY = gql`
 `;
 
 function useFetchNamespaceDeployments(selectedNamespaceIds: string[]) {
-    const [availableDeployments, setAvailableNamespaces] = useState<Record<string, any>[]>([]);
+    const [availableDeployments, setAvailableNamespaces] = useState<NamespaceWithDeployments[]>([]);
 
     const searchClause = { 'Namespace ID': selectedNamespaceIds };
     // If the selectedNamespaceId has not been set yet, do not run the gql query

--- a/ui/apps/platform/src/hooks/useFetchNamespaceDeployments.ts
+++ b/ui/apps/platform/src/hooks/useFetchNamespaceDeployments.ts
@@ -1,0 +1,61 @@
+import { useState, useEffect } from 'react';
+import { gql, useQuery } from '@apollo/client';
+
+type Namespace = {
+    metadata: {
+        name: string;
+    };
+};
+type NamespaceResponse = {
+    id: string;
+    results: {
+        namespaces: Namespace[];
+    };
+};
+
+const DEPLOYMENTS_FOR_NAMESPACE_QUERY = gql`
+    query getNamespaceDeploymentsNames($id: ID!) {
+        results: namespace(id: $id) {
+            metadata {
+                name
+                id
+            }
+            deployments {
+                name
+                id
+            }
+        }
+    }
+`;
+
+function useFetchNamespaceDeployments(selectedNamespaceId: string) {
+    const [availableNamespaces, setAvailableNamespaces] = useState<string[]>([]);
+
+    // If the selectedNamespaceId has not been set yet, do not run the gql query
+    const queryOptions = selectedNamespaceId
+        ? { variables: { id: selectedNamespaceId } }
+        : { skip: true };
+
+    const { loading, error, data } = useQuery<NamespaceResponse, { id: string }>(
+        DEPLOYMENTS_FOR_NAMESPACE_QUERY,
+        queryOptions
+    );
+
+    useEffect(() => {
+        if (!data || !data.results) {
+            return;
+        }
+
+        const namespaces = data.results.namespaces.map(({ metadata }) => metadata.name);
+
+        setAvailableNamespaces(namespaces);
+    }, [data]);
+
+    return {
+        loading,
+        error,
+        namespaces: availableNamespaces,
+    };
+}
+
+export default useFetchNamespaceDeployments;

--- a/ui/apps/platform/src/sagas/networkSagas.js
+++ b/ui/apps/platform/src/sagas/networkSagas.js
@@ -29,13 +29,14 @@ import timeWindowToDate from 'utils/timeWindows';
 import queryService from 'utils/queryService';
 import { filterModes } from 'constants/networkFilterModes';
 
-function* getFlowGraph(clusterId, namespaces, query, timeWindow, includePorts) {
+function* getFlowGraph(clusterId, namespaces, deployments, query, timeWindow, includePorts) {
     let flowGraph;
     try {
         const req = yield call(
             service.fetchNetworkFlowGraph,
             clusterId,
             namespaces,
+            deployments,
             query,
             timeWindowToDate(timeWindow),
             includePorts
@@ -48,13 +49,14 @@ function* getFlowGraph(clusterId, namespaces, query, timeWindow, includePorts) {
     return flowGraph;
 }
 
-function* getPolicyGraph(clusterId, namespaces, query, modification, includePorts) {
+function* getPolicyGraph(clusterId, namespaces, deployments, query, modification, includePorts) {
     let policyGraph;
     try {
         const req = yield call(
             service.fetchNetworkPolicyGraph,
             clusterId,
             namespaces,
+            deployments,
             query,
             modification,
             includePorts
@@ -77,14 +79,30 @@ function* getNetworkGraphs(clusterId, namespaces, query) {
         return;
     }
 
+    // TODO: consider changing the call signature in NetworkService module to take an object
+    // because the number of positional params for the functions whick get flows and policies has
+    // become unwieldy
+    // Example: when we added a specific deployment option for the new PF Network Graph
+    // it broke the old graph's network sagas.
+    const EMPTY_DEPLOYMENT_FILTER = [];
+
     const timeWindow = yield select(selectors.getNetworkActivityTimeWindow);
     const modification = yield select(selectors.getNetworkPolicyModification);
 
-    const flowGraph = yield call(getFlowGraph, clusterId, namespaces, query, timeWindow, true);
+    const flowGraph = yield call(
+        getFlowGraph,
+        clusterId,
+        namespaces,
+        EMPTY_DEPLOYMENT_FILTER,
+        query,
+        timeWindow,
+        true
+    );
     const policyGraph = yield call(
         getPolicyGraph,
         clusterId,
         namespaces,
+        EMPTY_DEPLOYMENT_FILTER,
         query,
         modification,
         true

--- a/ui/apps/platform/src/services/NetworkService.js
+++ b/ui/apps/platform/src/services/NetworkService.js
@@ -134,7 +134,7 @@ export function toggleAlertBaselineViolations({ deploymentId, enable }) {
 }
 
 /*
- * Retrieves the last security policy applied for a deployement
+ * Retrieves the last security policy applied for a deployment
  *
  * @param   {string}  deploymentId
  * @returns {Promise<Object, Error>}
@@ -153,10 +153,19 @@ export function getUndoModificationForDeployment(deploymentId) {
  *
  * @returns {Promise<Object, Error>}
  */
-export function fetchNetworkPolicyGraph(clusterId, namespaces, query, modification, includePorts) {
+export function fetchNetworkPolicyGraph(
+    clusterId,
+    namespaces,
+    deployments,
+    query,
+    modification,
+    includePorts
+) {
     const urlParams = query ? { query } : {};
     const namespaceQuery = namespaces.length > 0 ? `Namespace:${namespaces.join(',')}` : '';
+    const deploymentQuery = deployments.length > 0 ? `Deployment:${deployments.join(',')}` : '';
     urlParams.query = query ? `${query}+${namespaceQuery}` : namespaceQuery;
+    urlParams.query = deploymentQuery ? `${urlParams.query}+${deploymentQuery}` : urlParams.query;
 
     if (includePorts) {
         urlParams.includePorts = true;
@@ -200,6 +209,7 @@ export function fetchNetworkPolicyGraph(clusterId, namespaces, query, modificati
  *
  * @param {!String} clusterId
  * @param {String[]} namespaces
+ * @param {String[]} deployments
  * @param {String} query
  * @param {Date} date
  * @param {boolean} includePorts
@@ -209,13 +219,16 @@ export function fetchNetworkPolicyGraph(clusterId, namespaces, query, modificati
 export function fetchNetworkFlowGraph(
     clusterId,
     namespaces,
+    deployments,
     query = '',
     date = null,
     includePorts = false
 ) {
     const urlParams = query ? { query } : {};
     const namespaceQuery = namespaces.length > 0 ? `Namespace:${namespaces.join(',')}` : '';
+    const deploymentQuery = deployments.length > 0 ? `Deployment:${deployments.join(',')}` : '';
     urlParams.query = query ? `${query}+${namespaceQuery}` : namespaceQuery;
+    urlParams.query = deploymentQuery ? `${urlParams.query}+${deploymentQuery}` : urlParams.query;
     if (date) {
         urlParams.since = date.toISOString();
     }


### PR DESCRIPTION
## Description

Functioning Deployment picker added to new Network Breadcrumbs component


Future work:
1. Fix PatternFly bug where selected deployments' checkboxes are not checked
2. Clear selected deployments from URL when their namespace is deselected
3. Customize the breadcrumb select triggers' style (not currently one of the options in PatternFly)

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

Manual testing for now

Deployment options for a selected namespace
<img width="1531" alt="Screen Shot 2022-12-09 at 6 24 01 PM" src="https://user-images.githubusercontent.com/715729/206811712-2cb8a152-e584-4296-b80f-6b9854da7cd4.png">


Only one deployment selected
<img width="1531" alt="Screen Shot 2022-12-09 at 6 24 08 PM" src="https://user-images.githubusercontent.com/715729/206811701-6f5d99cd-0f89-4b62-a8e8-7fe2eccbf430.png">


Deployment options for two selected namespaces
<img width="1531" alt="Screen Shot 2022-12-09 at 6 29 35 PM" src="https://user-images.githubusercontent.com/715729/206811693-d452f7fe-4803-4108-90e0-d6a5ac828ec6.png">
