### PR TITLE
[ROX-13890] Update Vuln reporting to use collections to match deployments when collections' feature flag is enabled

### DIFF
--- a/central/reportconfigurations/service/service.go
+++ b/central/reportconfigurations/service/service.go
@@ -6,7 +6,7 @@ import (
 	notifierDataStore "github.com/stackrox/rox/central/notifier/datastore"
 	"github.com/stackrox/rox/central/reportconfigurations/datastore"
 	"github.com/stackrox/rox/central/reports/manager"
-	collectionDS "github.com/stackrox/rox/central/resourcecollection/datastore"
+	collectionDataStore "github.com/stackrox/rox/central/resourcecollection/datastore"
 	accessScopeStore "github.com/stackrox/rox/central/role/datastore"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/pkg/grpc"
@@ -24,15 +24,13 @@ type Service interface {
 func New(reportConfigStore datastore.DataStore,
 	notifierStore notifierDataStore.DataStore,
 	accessScopeStore accessScopeStore.DataStore,
-	collectionDataStore collectionDS.DataStore,
-	collectionQueryResolver collectionDS.QueryResolver,
+	collectionDS collectionDataStore.DataStore,
 	manager manager.Manager) Service {
 	return &serviceImpl{
-		manager:                 manager,
-		reportConfigStore:       reportConfigStore,
-		notifierStore:           notifierStore,
-		accessScopeStore:        accessScopeStore,
-		collectionDataStore:     collectionDataStore,
-		collectionQueryResolver: collectionQueryResolver,
+		manager:             manager,
+		reportConfigStore:   reportConfigStore,
+		notifierStore:       notifierStore,
+		accessScopeStore:    accessScopeStore,
+		collectionDatastore: collectionDS,
 	}
 }

--- a/central/reportconfigurations/service/service.go
+++ b/central/reportconfigurations/service/service.go
@@ -6,6 +6,7 @@ import (
 	notifierDataStore "github.com/stackrox/rox/central/notifier/datastore"
 	"github.com/stackrox/rox/central/reportconfigurations/datastore"
 	"github.com/stackrox/rox/central/reports/manager"
+	collectionDS "github.com/stackrox/rox/central/resourcecollection/datastore"
 	accessScopeStore "github.com/stackrox/rox/central/role/datastore"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/pkg/grpc"
@@ -20,11 +21,18 @@ type Service interface {
 }
 
 // New returns a new instance of the service. Please use the Singleton instead.
-func New(reportConfigStore datastore.DataStore, notifierStore notifierDataStore.DataStore, accessScopeStore accessScopeStore.DataStore, manager manager.Manager) Service {
+func New(reportConfigStore datastore.DataStore,
+	notifierStore notifierDataStore.DataStore,
+	accessScopeStore accessScopeStore.DataStore,
+	collectionDataStore collectionDS.DataStore,
+	collectionQueryResolver collectionDS.QueryResolver,
+	manager manager.Manager) Service {
 	return &serviceImpl{
-		manager:           manager,
-		reportConfigStore: reportConfigStore,
-		notifierStore:     notifierStore,
-		accessScopeStore:  accessScopeStore,
+		manager:                 manager,
+		reportConfigStore:       reportConfigStore,
+		notifierStore:           notifierStore,
+		accessScopeStore:        accessScopeStore,
+		collectionDataStore:     collectionDataStore,
+		collectionQueryResolver: collectionQueryResolver,
 	}
 }

--- a/central/reportconfigurations/service/service_impl.go
+++ b/central/reportconfigurations/service/service_impl.go
@@ -9,12 +9,14 @@ import (
 	notifierDataStore "github.com/stackrox/rox/central/notifier/datastore"
 	"github.com/stackrox/rox/central/reportconfigurations/datastore"
 	"github.com/stackrox/rox/central/reports/manager"
+	collectionDS "github.com/stackrox/rox/central/resourcecollection/datastore"
 	accessScopeStore "github.com/stackrox/rox/central/role/datastore"
 	"github.com/stackrox/rox/central/role/resources"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/auth/permissions"
 	"github.com/stackrox/rox/pkg/errox"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/grpc/authz"
 	"github.com/stackrox/rox/pkg/grpc/authz/perrpc"
 	"github.com/stackrox/rox/pkg/grpc/authz/user"
@@ -48,10 +50,12 @@ var (
 type serviceImpl struct {
 	v1.UnimplementedReportConfigurationServiceServer
 
-	manager           manager.Manager
-	reportConfigStore datastore.DataStore
-	notifierStore     notifierDataStore.DataStore
-	accessScopeStore  accessScopeStore.DataStore
+	manager                 manager.Manager
+	reportConfigStore       datastore.DataStore
+	notifierStore           notifierDataStore.DataStore
+	accessScopeStore        accessScopeStore.DataStore
+	collectionDataStore     collectionDS.DataStore
+	collectionQueryResolver collectionDS.QueryResolver
 }
 
 func (s *serviceImpl) GetReportConfigurations(ctx context.Context, query *v1.RawQuery) (*v1.GetReportConfigurationsResponse, error) {
@@ -203,12 +207,19 @@ func (s *serviceImpl) validateReportConfiguration(ctx context.Context, config *s
 		}
 	}
 
-	_, found, err := s.accessScopeStore.GetAccessScope(ctx, config.GetScopeId())
-	if !found || err != nil {
-		return errors.Wrapf(errox.NotFound, "Access scope %s not found. Error: %s", config.GetScopeId(), err)
+	if features.ObjectCollections.Enabled() {
+		_, found, err := s.collectionDataStore.Get(ctx, config.GetId())
+		if !found || err != nil {
+			return errors.Wrapf(errox.NotFound, "Collection %s not found. Error: %s", config.GetScopeId(), err)
+		}
+	} else {
+		_, found, err := s.accessScopeStore.GetAccessScope(ctx, config.GetScopeId())
+		if !found || err != nil {
+			return errors.Wrapf(errox.NotFound, "Access scope %s not found. Error: %s", config.GetScopeId(), err)
+		}
 	}
 
-	_, found, err = s.notifierStore.GetNotifier(ctx, config.GetEmailConfig().GetNotifierId())
+	_, found, err := s.notifierStore.GetNotifier(ctx, config.GetEmailConfig().GetNotifierId())
 	if err != nil {
 		return errors.Wrapf(errox.NotFound, "Failed to fetch notifier %s with error %s", config.GetEmailConfig().GetNotifierId(), err)
 	}

--- a/central/reportconfigurations/service/service_impl.go
+++ b/central/reportconfigurations/service/service_impl.go
@@ -207,7 +207,7 @@ func (s *serviceImpl) validateReportConfiguration(ctx context.Context, config *s
 	}
 
 	if features.ObjectCollections.Enabled() {
-		_, found, err := s.collectionDatastore.Get(ctx, config.GetId())
+		_, found, err := s.collectionDatastore.Get(ctx, config.GetScopeId())
 		if !found || err != nil {
 			return errors.Wrapf(errox.NotFound, "Collection %s not found. Error: %s", config.GetScopeId(), err)
 		}

--- a/central/reportconfigurations/service/service_impl.go
+++ b/central/reportconfigurations/service/service_impl.go
@@ -9,7 +9,7 @@ import (
 	notifierDataStore "github.com/stackrox/rox/central/notifier/datastore"
 	"github.com/stackrox/rox/central/reportconfigurations/datastore"
 	"github.com/stackrox/rox/central/reports/manager"
-	collectionDS "github.com/stackrox/rox/central/resourcecollection/datastore"
+	collectionDataStore "github.com/stackrox/rox/central/resourcecollection/datastore"
 	accessScopeStore "github.com/stackrox/rox/central/role/datastore"
 	"github.com/stackrox/rox/central/role/resources"
 	v1 "github.com/stackrox/rox/generated/api/v1"
@@ -50,12 +50,11 @@ var (
 type serviceImpl struct {
 	v1.UnimplementedReportConfigurationServiceServer
 
-	manager                 manager.Manager
-	reportConfigStore       datastore.DataStore
-	notifierStore           notifierDataStore.DataStore
-	accessScopeStore        accessScopeStore.DataStore
-	collectionDataStore     collectionDS.DataStore
-	collectionQueryResolver collectionDS.QueryResolver
+	manager             manager.Manager
+	reportConfigStore   datastore.DataStore
+	notifierStore       notifierDataStore.DataStore
+	accessScopeStore    accessScopeStore.DataStore
+	collectionDatastore collectionDataStore.DataStore
 }
 
 func (s *serviceImpl) GetReportConfigurations(ctx context.Context, query *v1.RawQuery) (*v1.GetReportConfigurationsResponse, error) {
@@ -208,7 +207,7 @@ func (s *serviceImpl) validateReportConfiguration(ctx context.Context, config *s
 	}
 
 	if features.ObjectCollections.Enabled() {
-		_, found, err := s.collectionDataStore.Get(ctx, config.GetId())
+		_, found, err := s.collectionDatastore.Get(ctx, config.GetId())
 		if !found || err != nil {
 			return errors.Wrapf(errox.NotFound, "Collection %s not found. Error: %s", config.GetScopeId(), err)
 		}

--- a/central/reportconfigurations/service/service_impl_test.go
+++ b/central/reportconfigurations/service/service_impl_test.go
@@ -8,6 +8,7 @@ import (
 	notifierMocks "github.com/stackrox/rox/central/notifier/datastore/mocks"
 	"github.com/stackrox/rox/central/reportconfigurations/datastore/mocks"
 	managerMocks "github.com/stackrox/rox/central/reports/manager/mocks"
+	collectionMocks "github.com/stackrox/rox/central/resourcecollection/datastore/mocks"
 	accessScopeMocks "github.com/stackrox/rox/central/role/datastore/mocks"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/pkg/fixtures"
@@ -34,8 +35,9 @@ func (s *TestReportConfigurationServiceTestSuite) SetupTest() {
 	s.notifierDatastore = notifierMocks.NewMockDataStore(s.mockCtrl)
 	s.accessScopeStore = accessScopeMocks.NewMockDataStore(s.mockCtrl)
 	s.manager = managerMocks.NewMockManager(s.mockCtrl)
-
-	s.service = New(s.reportConfigDatastore, s.notifierDatastore, s.accessScopeStore, s.manager)
+	collectionDataStore := collectionMocks.NewMockDataStore(s.mockCtrl)
+	collectionQueryResolver := collectionMocks.NewMockQueryResolver(s.mockCtrl)
+	s.service = New(s.reportConfigDatastore, s.notifierDatastore, s.accessScopeStore, collectionDataStore, collectionQueryResolver, s.manager)
 }
 
 func (s *TestReportConfigurationServiceTestSuite) TearDownTest() {

--- a/central/reportconfigurations/service/service_impl_test.go
+++ b/central/reportconfigurations/service/service_impl_test.go
@@ -8,9 +8,9 @@ import (
 	notifierMocks "github.com/stackrox/rox/central/notifier/datastore/mocks"
 	"github.com/stackrox/rox/central/reportconfigurations/datastore/mocks"
 	managerMocks "github.com/stackrox/rox/central/reports/manager/mocks"
-	collectionMocks "github.com/stackrox/rox/central/resourcecollection/datastore/mocks"
 	accessScopeMocks "github.com/stackrox/rox/central/role/datastore/mocks"
 	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/fixtures"
 	"github.com/stretchr/testify/suite"
 )
@@ -30,13 +30,16 @@ type TestReportConfigurationServiceTestSuite struct {
 }
 
 func (s *TestReportConfigurationServiceTestSuite) SetupTest() {
+	if features.ObjectCollections.Enabled() {
+		s.T().Skip("Skip test when ObjectCollections is enabled")
+		s.T().SkipNow()
+	}
 	s.mockCtrl = gomock.NewController(s.T())
 	s.reportConfigDatastore = mocks.NewMockDataStore(s.mockCtrl)
 	s.notifierDatastore = notifierMocks.NewMockDataStore(s.mockCtrl)
 	s.accessScopeStore = accessScopeMocks.NewMockDataStore(s.mockCtrl)
 	s.manager = managerMocks.NewMockManager(s.mockCtrl)
-	collectionDataStore := collectionMocks.NewMockDataStore(s.mockCtrl)
-	s.service = New(s.reportConfigDatastore, s.notifierDatastore, s.accessScopeStore, collectionDataStore, s.manager)
+	s.service = New(s.reportConfigDatastore, s.notifierDatastore, s.accessScopeStore, nil, s.manager)
 }
 
 func (s *TestReportConfigurationServiceTestSuite) TearDownTest() {

--- a/central/reportconfigurations/service/service_impl_test.go
+++ b/central/reportconfigurations/service/service_impl_test.go
@@ -36,8 +36,7 @@ func (s *TestReportConfigurationServiceTestSuite) SetupTest() {
 	s.accessScopeStore = accessScopeMocks.NewMockDataStore(s.mockCtrl)
 	s.manager = managerMocks.NewMockManager(s.mockCtrl)
 	collectionDataStore := collectionMocks.NewMockDataStore(s.mockCtrl)
-	collectionQueryResolver := collectionMocks.NewMockQueryResolver(s.mockCtrl)
-	s.service = New(s.reportConfigDatastore, s.notifierDatastore, s.accessScopeStore, collectionDataStore, collectionQueryResolver, s.manager)
+	s.service = New(s.reportConfigDatastore, s.notifierDatastore, s.accessScopeStore, collectionDataStore, s.manager)
 }
 
 func (s *TestReportConfigurationServiceTestSuite) TearDownTest() {

--- a/central/reportconfigurations/service/singleton.go
+++ b/central/reportconfigurations/service/singleton.go
@@ -4,6 +4,7 @@ import (
 	notifierDataStore "github.com/stackrox/rox/central/notifier/datastore"
 	reportConfigDS "github.com/stackrox/rox/central/reportconfigurations/datastore"
 	"github.com/stackrox/rox/central/reports/manager"
+	collectionDS "github.com/stackrox/rox/central/resourcecollection/datastore"
 	accessScopeStore "github.com/stackrox/rox/central/role/datastore"
 	"github.com/stackrox/rox/pkg/sync"
 )
@@ -14,7 +15,8 @@ var (
 )
 
 func initialize() {
-	svc = New(reportConfigDS.Singleton(), notifierDataStore.Singleton(), accessScopeStore.Singleton(), manager.Singleton())
+	collectionDataStore, collectionQueryResolver := collectionDS.Singleton()
+	svc = New(reportConfigDS.Singleton(), notifierDataStore.Singleton(), accessScopeStore.Singleton(), collectionDataStore, collectionQueryResolver, manager.Singleton())
 }
 
 // Singleton provides the instance of the service to register.

--- a/central/reportconfigurations/service/singleton.go
+++ b/central/reportconfigurations/service/singleton.go
@@ -4,7 +4,7 @@ import (
 	notifierDataStore "github.com/stackrox/rox/central/notifier/datastore"
 	reportConfigDS "github.com/stackrox/rox/central/reportconfigurations/datastore"
 	"github.com/stackrox/rox/central/reports/manager"
-	collectionDS "github.com/stackrox/rox/central/resourcecollection/datastore"
+	collectionDataStore "github.com/stackrox/rox/central/resourcecollection/datastore"
 	accessScopeStore "github.com/stackrox/rox/central/role/datastore"
 	"github.com/stackrox/rox/pkg/sync"
 )
@@ -15,8 +15,8 @@ var (
 )
 
 func initialize() {
-	collectionDataStore, collectionQueryResolver := collectionDS.Singleton()
-	svc = New(reportConfigDS.Singleton(), notifierDataStore.Singleton(), accessScopeStore.Singleton(), collectionDataStore, collectionQueryResolver, manager.Singleton())
+	collectionDS, _ := collectionDataStore.Singleton()
+	svc = New(reportConfigDS.Singleton(), notifierDataStore.Singleton(), accessScopeStore.Singleton(), collectionDS, manager.Singleton())
 }
 
 // Singleton provides the instance of the service to register.

--- a/central/reports/common/query_builder.go
+++ b/central/reports/common/query_builder.go
@@ -1,12 +1,15 @@
 package common
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
 
+	collectionDataStore "github.com/stackrox/rox/central/resourcecollection/datastore"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/sac/effectiveaccessscope"
 	"github.com/stackrox/rox/pkg/search"
 )
@@ -14,34 +17,48 @@ import (
 // ReportQuery encapsulates the cve specific fields query, and the resource scope
 // queries to be used in a report generation run
 type ReportQuery struct {
-	CveFieldsQuery string
-	ScopeQueries   []string
+	CveFieldsQuery   string
+	ScopeQueries     []string
+	DeploymentsQuery *v1.Query
 }
 
 type queryBuilder struct {
-	clusters              []*storage.Cluster
-	namespaces            []*storage.NamespaceMetadata
-	scope                 *storage.SimpleAccessScope
-	vulnFilters           *storage.VulnerabilityReportFilters
-	lastSuccessfulRunTime time.Time
+	clusters                []*storage.Cluster
+	namespaces              []*storage.NamespaceMetadata
+	scope                   *storage.SimpleAccessScope
+	vulnFilters             *storage.VulnerabilityReportFilters
+	collection              *storage.ResourceCollection
+	collectionQueryResolver collectionDataStore.QueryResolver
+	lastSuccessfulRunTime   time.Time
 }
 
 // NewVulnReportQueryBuilder builds a query builder to build scope and cve filtering queries for vuln reporting
 func NewVulnReportQueryBuilder(clusters []*storage.Cluster,
-	namespaces []*storage.NamespaceMetadata, scope *storage.SimpleAccessScope,
-	vulnFilters *storage.VulnerabilityReportFilters, lastSuccessfulRunTime time.Time) *queryBuilder {
+	namespaces []*storage.NamespaceMetadata, scope *storage.SimpleAccessScope, collection *storage.ResourceCollection,
+	vulnFilters *storage.VulnerabilityReportFilters, collectionQueryRes collectionDataStore.QueryResolver,
+	lastSuccessfulRunTime time.Time) *queryBuilder {
 	return &queryBuilder{
-		clusters:              clusters,
-		namespaces:            namespaces,
-		scope:                 scope,
-		vulnFilters:           vulnFilters,
-		lastSuccessfulRunTime: lastSuccessfulRunTime,
+		clusters:                clusters,
+		namespaces:              namespaces,
+		scope:                   scope,
+		vulnFilters:             vulnFilters,
+		collection:              collection,
+		collectionQueryResolver: collectionQueryRes,
+		lastSuccessfulRunTime:   lastSuccessfulRunTime,
 	}
 }
 
 // BuildQuery builds scope and cve filtering queries for vuln reporting
-func (q *queryBuilder) BuildQuery() (*ReportQuery, error) {
-	scopeQueries, err := q.buildScopeQueries()
+func (q *queryBuilder) BuildQuery(ctx context.Context) (*ReportQuery, error) {
+	var err error
+	var deploymentsQuery *v1.Query
+	var scopeQueries []string
+	if !features.ObjectCollections.Enabled() {
+		scopeQueries, err = q.buildScopeQueries()
+	} else {
+		deploymentsQuery, err = q.collectionQueryResolver.ResolveCollectionQuery(ctx, q.collection)
+	}
+
 	if err != nil {
 		return nil, err
 	}
@@ -52,6 +69,7 @@ func (q *queryBuilder) BuildQuery() (*ReportQuery, error) {
 	return &ReportQuery{
 		cveQuery,
 		scopeQueries,
+		deploymentsQuery,
 	}, nil
 }
 

--- a/central/reports/common/query_builder.go
+++ b/central/reports/common/query_builder.go
@@ -17,8 +17,10 @@ import (
 // ReportQuery encapsulates the cve specific fields query, and the resource scope
 // queries to be used in a report generation run
 type ReportQuery struct {
-	CveFieldsQuery   string
-	ScopeQueries     []string
+	CveFieldsQuery string
+	// ScopeQueries are used when scoping vuln report using an access-scope
+	ScopeQueries []string
+	// DeploymentsQuery is used when scoping vuln report using a resource-collection
 	DeploymentsQuery *v1.Query
 }
 
@@ -53,10 +55,10 @@ func (q *queryBuilder) BuildQuery(ctx context.Context) (*ReportQuery, error) {
 	var err error
 	var deploymentsQuery *v1.Query
 	var scopeQueries []string
-	if !features.ObjectCollections.Enabled() {
-		scopeQueries, err = q.buildScopeQueries()
-	} else {
+	if features.ObjectCollections.Enabled() {
 		deploymentsQuery, err = q.collectionQueryResolver.ResolveCollectionQuery(ctx, q.collection)
+	} else {
+		scopeQueries, err = q.buildScopeQueries()
 	}
 
 	if err != nil {

--- a/central/reports/common/query_builder_test.go
+++ b/central/reports/common/query_builder_test.go
@@ -1,10 +1,12 @@
 package common
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -66,8 +68,10 @@ var vulnFilters = &storage.VulnerabilityReportFilters{
 }
 
 func TestBuildQuery(t *testing.T) {
-	qb := NewVulnReportQueryBuilder(clusters, namespaces, accessScope, vulnFilters, time.Now())
-	rq, err := qb.BuildQuery()
+	// TODO : Skip is collections is enabled
+	qb := NewVulnReportQueryBuilder(clusters, namespaces, accessScope, nil, vulnFilters, nil, time.Now())
+	ctx := sac.WithAllAccess(context.Background())
+	rq, err := qb.BuildQuery(ctx)
 	assert.NoError(t, err)
 
 	assert.ElementsMatch(t, []string{`Cluster:"remote"+Namespace:"ns1"`, `Cluster:"secured"+Namespace:"ns2"`}, rq.ScopeQueries)

--- a/central/reports/common/query_builder_test.go
+++ b/central/reports/common/query_builder_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stretchr/testify/assert"
 )
@@ -68,7 +69,10 @@ var vulnFilters = &storage.VulnerabilityReportFilters{
 }
 
 func TestBuildQuery(t *testing.T) {
-	// TODO(ROX-13958) : Skip if collections is enabled
+	if features.ObjectCollections.Enabled() {
+		t.Skip("Skip test when ObjectCollections is enabled")
+		t.SkipNow()
+	}
 	qb := NewVulnReportQueryBuilder(clusters, namespaces, accessScope, nil, vulnFilters, nil, time.Now())
 	ctx := sac.WithAllAccess(context.Background())
 	rq, err := qb.BuildQuery(ctx)

--- a/central/reports/common/query_builder_test.go
+++ b/central/reports/common/query_builder_test.go
@@ -68,7 +68,7 @@ var vulnFilters = &storage.VulnerabilityReportFilters{
 }
 
 func TestBuildQuery(t *testing.T) {
-	// TODO : Skip is collections is enabled
+	// TODO(ROX-13958) : Skip if collections is enabled
 	qb := NewVulnReportQueryBuilder(clusters, namespaces, accessScope, nil, vulnFilters, nil, time.Now())
 	ctx := sac.WithAllAccess(context.Background())
 	rq, err := qb.BuildQuery(ctx)

--- a/central/reports/common/report_formatter.go
+++ b/central/reports/common/report_formatter.go
@@ -36,7 +36,8 @@ var (
 	}
 )
 
-type imageVulnerability struct {
+// ImageVulnerability data used for generating vuln reports
+type ImageVulnerability struct {
 	Cve               string        `json:"cve,omitempty"`
 	Severity          string        `json:"severity,omitempty"`
 	FixedByVersion    string        `json:"fixedByVersion,omitempty"`
@@ -45,28 +46,31 @@ type imageVulnerability struct {
 	Link              string        `json:"link,omitempty"`
 }
 
-type imageComponent struct {
+// ImageComponent data used for generating vuln reports
+type ImageComponent struct {
 	Name                 string                `json:"name,omitempty"`
-	ImageVulnerabilities []*imageVulnerability `json:"imageVulnerabilities,omitempty"`
-	Vulns                []*imageVulnerability `json:"vulns,omitempty"`
+	ImageVulnerabilities []*ImageVulnerability `json:"imageVulnerabilities,omitempty"`
+	Vulns                []*ImageVulnerability `json:"vulns,omitempty"`
 }
 
-type image struct {
+// Image data used for generating vuln reports
+type Image struct {
 	Name            *storage.ImageName `json:"name,omitempty"`
-	ImageComponents []*imageComponent  `json:"imageComponents,omitempty"`
-	Components      []*imageComponent  `json:"components,omitempty"`
+	ImageComponents []*ImageComponent  `json:"imageComponents,omitempty"`
+	Components      []*ImageComponent  `json:"components,omitempty"`
 }
 
-type deployment struct {
+// Deployment data used for generating vuln reports
+type Deployment struct {
 	Cluster        *storage.Cluster `json:"cluster,omitempty"`
 	Namespace      string           `json:"namespace,omitempty"`
 	DeploymentName string           `json:"name,omitempty"`
-	Images         []*image         `json:"images,omitempty"`
+	Images         []*Image         `json:"images,omitempty"`
 }
 
 // Result is the query results of running a single cvefields query and scope query combination
 type Result struct {
-	Deployments []*deployment `json:"deployments,omitempty"`
+	Deployments []*Deployment `json:"deployments,omitempty"`
 }
 
 // Format takes in the results of vuln report query, converts to CSV and returns zipped CSV data and
@@ -129,14 +133,14 @@ func Format(results []Result) (*bytes.Buffer, error) {
 	return &zipBuf, nil
 }
 
-func (img *image) getComponents() []*imageComponent {
+func (img *Image) getComponents() []*ImageComponent {
 	if env.PostgresDatastoreEnabled.BooleanSetting() {
 		return img.ImageComponents
 	}
 	return img.Components
 }
 
-func (component *imageComponent) getVulnerabilities() []*imageVulnerability {
+func (component *ImageComponent) getVulnerabilities() []*ImageVulnerability {
 	if env.PostgresDatastoreEnabled.BooleanSetting() {
 		return component.ImageVulnerabilities
 	}

--- a/central/reports/common/report_formatter.go
+++ b/central/reports/common/report_formatter.go
@@ -60,6 +60,7 @@ type image struct {
 // Deployment data used for generating vuln reports
 type Deployment struct {
 	Cluster        *storage.Cluster `json:"cluster,omitempty"`
+	ClusterName    string           `json:"clusterName,omitempty"`
 	Namespace      string           `json:"namespace,omitempty"`
 	DeploymentName string           `json:"name,omitempty"`
 	Images         []*image         `json:"images,omitempty"`
@@ -84,7 +85,7 @@ func Format(results []Result) (*bytes.Buffer, error) {
 							discoveredTs = v.DiscoveredAtImage.Time.Format("January 02, 2006")
 						}
 						csvWriter.AddValue(csv.Value{
-							d.Cluster.Name,
+							d.GetClusterName(),
 							d.Namespace,
 							d.DeploymentName,
 							i.Name.FullName,
@@ -128,6 +129,14 @@ func Format(results []Result) (*bytes.Buffer, error) {
 		return nil, errors.Wrap(err, "unable to create a zip file of the vuln report")
 	}
 	return &zipBuf, nil
+}
+
+// GetClusterName returns name of cluster containing the Deployment
+func (dep *Deployment) GetClusterName() string {
+	if env.PostgresDatastoreEnabled.BooleanSetting() {
+		return dep.ClusterName
+	}
+	return dep.Cluster.GetName()
 }
 
 func (img *image) getComponents() []*imageComponent {

--- a/central/reports/common/report_formatter.go
+++ b/central/reports/common/report_formatter.go
@@ -36,8 +36,7 @@ var (
 	}
 )
 
-// ImageVulnerability data used for generating vuln reports
-type ImageVulnerability struct {
+type imageVulnerability struct {
 	Cve               string        `json:"cve,omitempty"`
 	Severity          string        `json:"severity,omitempty"`
 	FixedByVersion    string        `json:"fixedByVersion,omitempty"`
@@ -46,18 +45,16 @@ type ImageVulnerability struct {
 	Link              string        `json:"link,omitempty"`
 }
 
-// ImageComponent data used for generating vuln reports
-type ImageComponent struct {
+type imageComponent struct {
 	Name                 string                `json:"name,omitempty"`
-	ImageVulnerabilities []*ImageVulnerability `json:"imageVulnerabilities,omitempty"`
-	Vulns                []*ImageVulnerability `json:"vulns,omitempty"`
+	ImageVulnerabilities []*imageVulnerability `json:"imageVulnerabilities,omitempty"`
+	Vulns                []*imageVulnerability `json:"vulns,omitempty"`
 }
 
-// Image data used for generating vuln reports
-type Image struct {
+type image struct {
 	Name            *storage.ImageName `json:"name,omitempty"`
-	ImageComponents []*ImageComponent  `json:"imageComponents,omitempty"`
-	Components      []*ImageComponent  `json:"components,omitempty"`
+	ImageComponents []*imageComponent  `json:"imageComponents,omitempty"`
+	Components      []*imageComponent  `json:"components,omitempty"`
 }
 
 // Deployment data used for generating vuln reports
@@ -65,7 +62,7 @@ type Deployment struct {
 	Cluster        *storage.Cluster `json:"cluster,omitempty"`
 	Namespace      string           `json:"namespace,omitempty"`
 	DeploymentName string           `json:"name,omitempty"`
-	Images         []*Image         `json:"images,omitempty"`
+	Images         []*image         `json:"images,omitempty"`
 }
 
 // Result is the query results of running a single cvefields query and scope query combination
@@ -133,14 +130,14 @@ func Format(results []Result) (*bytes.Buffer, error) {
 	return &zipBuf, nil
 }
 
-func (img *Image) getComponents() []*ImageComponent {
+func (img *image) getComponents() []*imageComponent {
 	if env.PostgresDatastoreEnabled.BooleanSetting() {
 		return img.ImageComponents
 	}
 	return img.Components
 }
 
-func (component *ImageComponent) getVulnerabilities() []*ImageVulnerability {
+func (component *imageComponent) getVulnerabilities() []*imageVulnerability {
 	if env.PostgresDatastoreEnabled.BooleanSetting() {
 		return component.ImageVulnerabilities
 	}

--- a/central/reports/manager/singleton.go
+++ b/central/reports/manager/singleton.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stackrox/rox/central/notifier/processor"
 	reportConfigDS "github.com/stackrox/rox/central/reportconfigurations/datastore"
 	"github.com/stackrox/rox/central/reports/scheduler"
+	collectionDataStore "github.com/stackrox/rox/central/resourcecollection/datastore"
 	roleDataStore "github.com/stackrox/rox/central/role/datastore"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/sync"
@@ -20,13 +21,16 @@ var (
 )
 
 func initialize() {
+	collectionDS, collectionQueryRes := collectionDataStore.Singleton()
 	instance = &managerImpl{
 		scheduler: scheduler.New(
 			reportConfigDS.Singleton(),
 			notifierDataStore.Singleton(),
 			clusterDataStore.Singleton(),
 			namespaceDataStore.Singleton(),
+			collectionDS,
 			roleDataStore.Singleton(),
+			collectionQueryRes,
 			processor.Singleton(),
 		),
 	}

--- a/central/reports/manager/singleton.go
+++ b/central/reports/manager/singleton.go
@@ -2,6 +2,7 @@ package manager
 
 import (
 	clusterDataStore "github.com/stackrox/rox/central/cluster/datastore"
+	deploymentDataStore "github.com/stackrox/rox/central/deployment/datastore"
 	namespaceDataStore "github.com/stackrox/rox/central/namespace/datastore"
 	notifierDataStore "github.com/stackrox/rox/central/notifier/datastore"
 	"github.com/stackrox/rox/central/notifier/processor"
@@ -28,6 +29,7 @@ func initialize() {
 			notifierDataStore.Singleton(),
 			clusterDataStore.Singleton(),
 			namespaceDataStore.Singleton(),
+			deploymentDataStore.Singleton(),
 			collectionDS,
 			roleDataStore.Singleton(),
 			collectionQueryRes,

--- a/central/reports/scheduler/schedule.go
+++ b/central/reports/scheduler/schedule.go
@@ -416,7 +416,7 @@ func (s *scheduler) runPaginatedQuery(ctx context.Context, scopeQuery, cveQuery 
 					return common.Result{}, err
 				}
 				scopeQuery = fmt.Sprintf("%s:%q", search.DeploymentID.String(), strings.Join(deploymentIds, ","))
-				log.Infof("ROX-12629 : scopeQuery  ")
+				log.Infof("ROX-12629 : deployments scopeQuery : %s", scopeQuery)
 				gqlPaginationOffset = 0
 			}
 		} else {

--- a/central/reports/scheduler/schedule.go
+++ b/central/reports/scheduler/schedule.go
@@ -166,7 +166,7 @@ type reportEmailFormat struct {
 // New instantiates a new cron scheduler and supports adding and removing report configurations
 func New(reportConfigDS reportConfigDS.DataStore, notifierDS notifierDataStore.DataStore,
 	clusterDS clusterDataStore.DataStore, namespaceDS namespaceDataStore.DataStore,
-	collectionDS collectionDataStore.DataStore, roleDS roleDataStore.DataStore,
+	deploymentDS deploymentDataStore.DataStore, collectionDS collectionDataStore.DataStore, roleDS roleDataStore.DataStore,
 	collectionQueryRes collectionDataStore.QueryResolver, notificationProcessor processor.Processor) Scheduler {
 	cronScheduler := cron.New()
 	cronScheduler.Start()
@@ -182,6 +182,7 @@ func New(reportConfigDS reportConfigDS.DataStore, notifierDS notifierDataStore.D
 		notifierDatastore:       notifierDS,
 		clusterDatastore:        clusterDS,
 		namespaceDatastore:      namespaceDS,
+		deploymentDatastore:     deploymentDS,
 		collectionDatastore:     collectionDS,
 		roleDatastore:           roleDS,
 		collectionQueryResolver: collectionQueryRes,

--- a/central/reports/scheduler/schedule.go
+++ b/central/reports/scheduler/schedule.go
@@ -415,7 +415,7 @@ func (s *scheduler) runPaginatedQuery(ctx context.Context, scopeQuery, cveQuery 
 				if err != nil || len(deploymentIds) == 0 {
 					return common.Result{}, err
 				}
-				scopeQuery = fmt.Sprintf("%s:%q", search.DeploymentID.String(), strings.Join(deploymentIds, ","))
+				scopeQuery = fmt.Sprintf("%s:%s", search.DeploymentID.String(), strings.Join(deploymentIds, ","))
 				log.Infof("ROX-12629 : deployments scopeQuery : %s", scopeQuery)
 				gqlPaginationOffset = 0
 			}


### PR DESCRIPTION
## Description

- When collections feature flag is enabled, scope_id field in reportConfiguration will be treated as collection id.
- Vuln reporting workflow will use the collections id to fetch the collections and then create a report based on the deployments that match that collection.
- The final results will be primarily grouped by cluster name and secondarily by namespace.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Manual testing by creating a collection and using it in a vuln report

![517FF47A-E277-4624-8B39-FE821C7CE345](https://user-images.githubusercontent.com/101146970/207419180-fedc4b54-9df4-4e10-831e-ccea65f2df44.jpeg)

![1B68E5D4-9168-4FD7-A7FF-14B6DF967ACE_1_105_c](https://user-images.githubusercontent.com/101146970/207419236-7ee28bce-37d9-419d-af3f-6e2d48d46b21.jpeg)

![CF36F461-6352-44F4-9C33-3EB9D114A2DE_1_105_c](https://user-images.githubusercontent.com/101146970/207419266-68f132bf-00e4-4d12-bb84-4cbea5ddca08.jpeg)

Created separate task to add unit tests, and performing manual testing for this one.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
