### PR TITLE
Adds loading indicator to collection results panel

### DIFF
--- a/ui/apps/platform/src/Containers/Collections/CollectionResults.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionResults.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useState, useMemo, ReactNode } from 'react';
 import {
+    debounce,
     Button,
     Divider,
     EmptyState,
@@ -10,10 +11,9 @@ import {
     Select,
     SearchInput,
     SelectOption,
-    debounce,
-    Title,
     Skeleton,
     Spinner,
+    Title,
 } from '@patternfly/react-core';
 import { ExclamationCircleIcon, ListIcon } from '@patternfly/react-icons';
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
@@ -36,7 +36,7 @@ function fetchMatchingDeployments(
     return request;
 }
 
-function RefreshingDeployment() {
+function DeploymentSkeleton() {
     return (
         <Flex className="pf-u-mb-0">
             <FlexItem style={{ flex: '0 1 24px' }}>
@@ -209,7 +209,7 @@ function CollectionResults({
                     {isRefreshingResults ? (
                         <>
                             {deployments.map((deployment: ListDeployment) => (
-                                <RefreshingDeployment key={`refreshing-${deployment.id}`} />
+                                <DeploymentSkeleton key={`refreshing-${deployment.id}`} />
                             ))}
                             <Spinner className="pf-u-align-self-center" size="lg" />
                         </>


### PR DESCRIPTION
## Description

This adds a visual indication that new data is loading when the results sidebar is updating.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Visit the collection form and enter values that result in results in the sidebar.
![image](https://user-images.githubusercontent.com/1292638/207198586-51e6dab7-a299-4ea1-926b-c15a751592f8.png)

Make a change to the form rules. Immediately upon changing the rules, the side panel should replace the previous results with placeholders. Once the request completes the new data should be loaded into place.
![image](https://user-images.githubusercontent.com/1292638/207198852-c6dd1260-4e24-4f12-920b-53a4053819f6.png)
![image](https://user-images.githubusercontent.com/1292638/207198882-1665c1a8-d485-4576-8286-132653f6e276.png)

The behavior of the search in the sidebar should be identical.
![image](https://user-images.githubusercontent.com/1292638/207198969-12aac753-4203-404c-b533-f229ce603067.png)
![image](https://user-images.githubusercontent.com/1292638/207198978-4c7c2c23-e3e9-4be0-9b9b-8177cc664420.png)

This loading state should _not_ be displayed when clicking the view more link. (no visual)

Mobile views:
<img src="https://user-images.githubusercontent.com/1292638/207199118-d909137b-1f05-4cdb-ba30-e4808003990f.png" width="300px" />
<img src="https://user-images.githubusercontent.com/1292638/207199136-32c4ea5a-82d3-4d21-b7e6-968ff47f305b.png" width="300px" />



