### PR TITLE
ROX-13757: Workflow Administration Migration

### DIFF
--- a/central/reportconfigurations/service/service_impl.go
+++ b/central/reportconfigurations/service/service_impl.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/grpc/authz"
+	"github.com/stackrox/rox/pkg/grpc/authz/or"
 	"github.com/stackrox/rox/pkg/grpc/authz/perrpc"
 	"github.com/stackrox/rox/pkg/grpc/authz/user"
 	"github.com/stackrox/rox/pkg/logging"
@@ -29,18 +30,24 @@ import (
 var (
 	authorizer = perrpc.FromMap(map[authz.Authorizer][]string{
 		// TODO: ROX-13888 Replace VulnerabilityReports with WorkflowAdministration.
-		user.With(permissions.View(resources.VulnerabilityReports)): {
+		or.Or(
+			user.With(permissions.View(resources.VulnerabilityReports)),
+			user.With(permissions.View(resources.WorkflowAdministration))): {
 			"/v1.ReportConfigurationService/GetReportConfigurations",
 			"/v1.ReportConfigurationService/GetReportConfiguration",
 			"/v1.ReportConfigurationService/CountReportConfigurations",
 		},
 		// TODO: ROX-13888 Replace VulnerabilityReports with WorkflowAdministration.
-		user.With(permissions.Modify(resources.VulnerabilityReports), permissions.View(resources.Integration), permissions.View(resources.Role)): {
+		or.Or(
+			user.With(permissions.Modify(resources.VulnerabilityReports), permissions.View(resources.Integration), permissions.View(resources.Role)),
+			user.With(permissions.Modify(resources.WorkflowAdministration), permissions.View(resources.Integration))): {
 			"/v1.ReportConfigurationService/PostReportConfiguration",
 			"/v1.ReportConfigurationService/UpdateReportConfiguration",
 		},
 		// TODO: ROX-13888 Replace VulnerabilityReports with WorkflowAdministration.
-		user.With(permissions.Modify(resources.VulnerabilityReports)): {
+		or.Or(
+			user.With(permissions.Modify(resources.VulnerabilityReports)),
+			user.With(permissions.Modify(resources.WorkflowAdministration))): {
 			"/v1.ReportConfigurationService/DeleteReportConfiguration",
 		},
 	})

--- a/central/role/datastore/singleton.go
+++ b/central/role/datastore/singleton.go
@@ -155,12 +155,13 @@ var vulnReportingDefaultRoles = map[string]roleAttributes{
 		postgresID:  vulnReporterPermissionSetID,
 		description: "For users: use it to create and manage vulnerability reporting configurations for scheduled vulnerability reports",
 		resourceWithAccess: []permissions.ResourceWithAccess{
-			// TODO: ROX-13888 Replace VulnerabilityReports with WorkflowAdministration.
-			permissions.View(resources.VulnerabilityReports),   // required for vuln report configurations
-			permissions.Modify(resources.VulnerabilityReports), // required for vuln report configurations
-			permissions.View(resources.Role),                   // required for scopes
-			permissions.View(resources.Image),                  // required to gather CVE data for the report
-			permissions.View(resources.Integration),            // required for vuln report configurations
+			permissions.View(resources.WorkflowAdministration),   // required for vuln report configurations
+			permissions.Modify(resources.WorkflowAdministration), // required for vuln report configurations
+			permissions.View(resources.Role),                     // required for scopes
+			permissions.View(resources.Image),                    // required to gather CVE data for the report
+			permissions.View(resources.Integration),              // required for vuln report configurations
+			permissions.View(resources.VulnerabilityReports),     // required for vuln report configurations prior to collections
+			permissions.Modify(resources.VulnerabilityReports),   // required for vuln report configurations prior to collections
 		},
 	},
 }

--- a/central/role/datastore/singleton.go
+++ b/central/role/datastore/singleton.go
@@ -149,6 +149,7 @@ var defaultRoles = map[string]roleAttributes{
 	},
 }
 
+// TODO ROX-13888 when we migrate to WorkflowAdministration we can remove VulnerabilityReports and Role resources
 var vulnReportingDefaultRoles = map[string]roleAttributes{
 	rolePkg.VulnReporter: {
 		idSuffix:    "vulnreporter",

--- a/migrator/migrations/m_169_to_m_170_collections_sac_resource_migration/migration.go
+++ b/migrator/migrations/m_169_to_m_170_collections_sac_resource_migration/migration.go
@@ -1,0 +1,68 @@
+package m169tom170
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v4/pgxpool"
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/migrator/migrations"
+	permissionSetPostgresStore "github.com/stackrox/rox/migrator/migrations/m_169_to_m_170_collections_sac_resource_migration/permissionsetpostgresstore"
+	"github.com/stackrox/rox/migrator/types"
+	"github.com/stackrox/rox/pkg/sac"
+)
+
+const (
+	batchSize = 500
+
+	workflowAdminResource       = "WorkflowAdministration"
+	reportConfigurationResource = "ReportConfiguration"
+
+	startSeqNum = 169
+)
+
+var (
+	migration = types.Migration{
+		StartingSeqNum: startSeqNum,
+		VersionAfter:   &storage.Version{SeqNum: int32(startSeqNum + 1)}, // 170
+		Run: func(databases *types.Databases) error {
+			err := migrateWorkflowAdministrationPermissionSet(databases.PostgresDB)
+			if err != nil {
+				return errors.Wrap(err, "updating WorkflowAdministration permissions")
+			}
+			return nil
+		},
+	}
+)
+
+func migrateWorkflowAdministrationPermissionSet(db *pgxpool.Pool) error {
+	ctx := sac.WithAllAccess(context.Background())
+	pgStore := permissionSetPostgresStore.New(db)
+	permissionSetsToInsert := make([]*storage.PermissionSet, 0, batchSize)
+	err := pgStore.Walk(ctx, func(obj *storage.PermissionSet) error {
+		if accessLevel, found := obj.GetResourceToAccess()[reportConfigurationResource]; found {
+			newPermissionSet := obj.Clone()
+			newPermissionSet.ResourceToAccess[workflowAdminResource] = accessLevel
+			permissionSetsToInsert = append(permissionSetsToInsert, newPermissionSet)
+			if len(permissionSetsToInsert) >= batchSize {
+				err := pgStore.UpsertMany(ctx, permissionSetsToInsert)
+				if err != nil {
+					return err
+				}
+				permissionSetsToInsert = permissionSetsToInsert[:0]
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	if len(permissionSetsToInsert) > 0 {
+		err = pgStore.UpsertMany(ctx, permissionSetsToInsert)
+	}
+	return err
+}
+
+func init() {
+	migrations.MustRegisterMigration(migration)
+}

--- a/migrator/migrations/m_169_to_m_170_collections_sac_resource_migration/migration.go
+++ b/migrator/migrations/m_169_to_m_170_collections_sac_resource_migration/migration.go
@@ -28,7 +28,7 @@ var (
 		Run: func(databases *types.Databases) error {
 			err := migrateWorkflowAdministrationPermissionSet(databases.PostgresDB)
 			if err != nil {
-				return errors.Wrap(err, "updating WorkflowAdministration permissions")
+				return errors.Wrapf(err, "updating %q permissions", workflowAdminResource)
 			}
 			return nil
 		},

--- a/migrator/migrations/m_169_to_m_170_collections_sac_resource_migration/migration_test.go
+++ b/migrator/migrations/m_169_to_m_170_collections_sac_resource_migration/migration_test.go
@@ -1,0 +1,136 @@
+//go:build sql_integration
+
+package m169tom170
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackrox/rox/generated/storage"
+	permissionSetPostgresStore "github.com/stackrox/rox/migrator/migrations/m_168_to_m_169_postgres_remove_clustercve_permission/permissionsetpostgresstore"
+	pghelper "github.com/stackrox/rox/migrator/migrations/postgreshelper"
+	"github.com/stackrox/rox/migrator/types"
+	"github.com/stackrox/rox/pkg/postgres/schema"
+	"github.com/stretchr/testify/suite"
+)
+
+const (
+	id0 = "A161527B-D34F-42B8-A783-23E39B4DE15A"
+	id1 = "DC04A5F8-6018-46E5-B590-87325FBF1945"
+	id2 = "9C91FA2B-AE95-4C74-98A7-17AF76CC8209"
+	id3 = "ABBA7029-EAED-4FFD-8FB0-02CA9F2B6A21"
+)
+
+var (
+	unmigratedPSs = []*storage.PermissionSet{
+		{
+			Id:   id0,
+			Name: "ps0",
+			ResourceToAccess: map[string]storage.Access{
+				"ReportConfiguration": storage.Access_READ_ACCESS,
+				"Image":               storage.Access_READ_WRITE_ACCESS,
+			},
+		},
+		{
+			Id:   id1,
+			Name: "ps1",
+			ResourceToAccess: map[string]storage.Access{
+				"ReportConfiguration": storage.Access_READ_WRITE_ACCESS,
+				"Cluster":             storage.Access_READ_ACCESS,
+				"Image":               storage.Access_READ_WRITE_ACCESS,
+			},
+		},
+	}
+
+	unmigratedPSsAfterMigration = []*storage.PermissionSet{
+		{
+			Id:   id0,
+			Name: "ps0",
+			ResourceToAccess: map[string]storage.Access{
+				"ReportConfiguration":    storage.Access_READ_ACCESS,
+				"WorkflowAdministration": storage.Access_READ_ACCESS,
+				"Image":                  storage.Access_READ_WRITE_ACCESS,
+			},
+		},
+		{
+			Id:   id1,
+			Name: "ps1",
+			ResourceToAccess: map[string]storage.Access{
+				"ReportConfiguration":    storage.Access_READ_WRITE_ACCESS,
+				"WorkflowAdministration": storage.Access_READ_WRITE_ACCESS,
+				"Cluster":                storage.Access_READ_ACCESS,
+				"Image":                  storage.Access_READ_WRITE_ACCESS,
+			},
+		},
+	}
+
+	alreadyMigratedPSs = []*storage.PermissionSet{
+		{
+			Id:               id2,
+			Name:             "ps2",
+			ResourceToAccess: map[string]storage.Access{"Image": storage.Access_READ_WRITE_ACCESS},
+		},
+		{
+			Id:               id3,
+			Name:             "ps3",
+			ResourceToAccess: map[string]storage.Access{"Image": storage.Access_READ_WRITE_ACCESS},
+		},
+	}
+)
+
+type psMigrationTestSuite struct {
+	suite.Suite
+
+	db    *pghelper.TestPostgres
+	store permissionSetPostgresStore.Store
+}
+
+func TestMigration(t *testing.T) {
+	suite.Run(t, new(psMigrationTestSuite))
+}
+
+func (s *psMigrationTestSuite) SetupTest() {
+	s.db = pghelper.ForT(s.T(), true)
+	s.store = permissionSetPostgresStore.New(s.db.Pool)
+	schema.ApplySchemaForTable(context.Background(), s.db.GetGormDB(), schema.PermissionSetsTableName)
+}
+
+func (s *psMigrationTestSuite) TearDownTest() {
+	s.db.Teardown(s.T())
+}
+
+func (s *psMigrationTestSuite) TestMigration() {
+	ctx := context.Background()
+	var psToUpsert []*storage.PermissionSet
+	psToUpsert = append(psToUpsert, unmigratedPSs...)
+	psToUpsert = append(psToUpsert, alreadyMigratedPSs...)
+
+	s.NoError(s.store.UpsertMany(ctx, psToUpsert))
+
+	dbs := &types.Databases{
+		PostgresDB: s.db.Pool,
+	}
+
+	s.NoError(migration.Run(dbs))
+
+	var allPSsAfterMigration []*storage.PermissionSet
+
+	checkErr := s.store.Walk(ctx, func(obj *storage.PermissionSet) error {
+		allPSsAfterMigration = append(allPSsAfterMigration, obj)
+		return nil
+	})
+	s.NoError(checkErr)
+
+	var expectedPSsAfterMigration []*storage.PermissionSet
+	expectedPSsAfterMigration = append(expectedPSsAfterMigration, unmigratedPSsAfterMigration...)
+	expectedPSsAfterMigration = append(expectedPSsAfterMigration, alreadyMigratedPSs...)
+
+	s.ElementsMatch(expectedPSsAfterMigration, allPSsAfterMigration)
+}
+
+func (s *psMigrationTestSuite) TestMigrationOnCleanDB() {
+	dbs := &types.Databases{
+		PostgresDB: s.db.Pool,
+	}
+	s.NoError(migration.Run(dbs))
+}

--- a/migrator/migrations/m_169_to_m_170_collections_sac_resource_migration/permissionsetpostgresstore/postgres_plugin.go
+++ b/migrator/migrations/m_169_to_m_170_collections_sac_resource_migration/permissionsetpostgresstore/postgres_plugin.go
@@ -47,6 +47,7 @@ var (
 	targetResource = resources.Role
 )
 
+// Store is the interface for interactions with the database storage
 type Store interface {
 	UpsertMany(ctx context.Context, objs []*storage.PermissionSet) error
 	Walk(ctx context.Context, fn func(obj *storage.PermissionSet) error) error
@@ -218,9 +219,8 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.PermissionSe
 
 		if len(objs) < batchAfter {
 			return s.upsert(ctx, objs...)
-		} else {
-			return s.copyFrom(ctx, objs...)
 		}
+		return s.copyFrom(ctx, objs...)
 	})
 }
 

--- a/migrator/migrations/m_169_to_m_170_collections_sac_resource_migration/permissionsetpostgresstore/postgres_plugin.go
+++ b/migrator/migrations/m_169_to_m_170_collections_sac_resource_migration/permissionsetpostgresstore/postgres_plugin.go
@@ -1,0 +1,305 @@
+package postgres
+
+import (
+	"context"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/jackc/pgx/v4"
+	"github.com/jackc/pgx/v4/pgxpool"
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/central/metrics"
+	"github.com/stackrox/rox/central/role/resources"
+	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/logging"
+	ops "github.com/stackrox/rox/pkg/metrics"
+	"github.com/stackrox/rox/pkg/postgres/pgutils"
+	pkgSchema "github.com/stackrox/rox/pkg/postgres/schema"
+	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/postgres"
+	"github.com/stackrox/rox/pkg/sync"
+)
+
+// This file is a partial copy of central/role/store/permissionset/postgres/store.go
+// in the state it had when the migration was written.
+// Only the relevant functions (Walk, DeleteMany and UpsertMany) are kept.
+// The kept functions are stripped from the scoped access control checks.
+
+const (
+	baseTable = "permission_sets"
+
+	batchAfter = 100
+
+	// using copyFrom, we may not even want to batch.  It would probably be simpler
+	// to deal with failures if we just sent it all.  Something to think about as we
+	// proceed and move into more e2e and larger performance testing
+	batchSize = 10000
+
+	cursorBatchSize = 50
+	deleteBatchSize = 5000
+)
+
+var (
+	log            = logging.LoggerForModule()
+	schema         = pkgSchema.PermissionSetsSchema
+	targetResource = resources.Role
+)
+
+type Store interface {
+	UpsertMany(ctx context.Context, objs []*storage.PermissionSet) error
+	Walk(ctx context.Context, fn func(obj *storage.PermissionSet) error) error
+}
+
+type storeImpl struct {
+	db    *pgxpool.Pool
+	mutex sync.Mutex
+}
+
+// New returns a new Store instance using the provided sql instance.
+func New(db *pgxpool.Pool) Store {
+	return &storeImpl{
+		db: db,
+	}
+}
+
+func insertIntoPermissionSets(ctx context.Context, batch *pgx.Batch, obj *storage.PermissionSet) error {
+
+	serialized, marshalErr := obj.Marshal()
+	if marshalErr != nil {
+		return marshalErr
+	}
+
+	values := []interface{}{
+		// parent primary keys start
+		pgutils.NilOrUUID(obj.GetId()),
+		obj.GetName(),
+		serialized,
+	}
+
+	finalStr := "INSERT INTO permission_sets (Id, Name, serialized) VALUES($1, $2, $3) ON CONFLICT(Id) DO UPDATE SET Id = EXCLUDED.Id, Name = EXCLUDED.Name, serialized = EXCLUDED.serialized"
+	batch.Queue(finalStr, values...)
+
+	return nil
+}
+
+func (s *storeImpl) copyFromPermissionSets(ctx context.Context, tx pgx.Tx, objs ...*storage.PermissionSet) error {
+
+	inputRows := [][]interface{}{}
+
+	var err error
+
+	// This is a copy so first we must delete the rows and re-add them
+	// Which is essentially the desired behaviour of an upsert.
+	var deletes []string
+
+	copyCols := []string{
+
+		"id",
+
+		"name",
+
+		"serialized",
+	}
+
+	for idx, obj := range objs {
+		// Todo: ROX-9499 Figure out how to more cleanly template around this issue.
+		log.Debugf("This is here for now because there is an issue with pods_TerminatedInstances where the obj in the loop is not used as it only consists of the parent id and the idx.  Putting this here as a stop gap to simply use the object.  %s", obj)
+
+		serialized, marshalErr := obj.Marshal()
+		if marshalErr != nil {
+			return marshalErr
+		}
+
+		inputRows = append(inputRows, []interface{}{
+
+			pgutils.NilOrUUID(obj.GetId()),
+
+			obj.GetName(),
+
+			serialized,
+		})
+
+		// Add the id to be deleted.
+		deletes = append(deletes, obj.GetId())
+
+		// if we hit our batch size we need to push the data
+		if (idx+1)%batchSize == 0 || idx == len(objs)-1 {
+			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
+			// delete for the top level parent
+
+			if err := s.DeleteMany(ctx, deletes); err != nil {
+				return err
+			}
+			// clear the inserts and vals for the next batch
+			deletes = nil
+
+			_, err = tx.CopyFrom(ctx, pgx.Identifier{"permission_sets"}, copyCols, pgx.CopyFromRows(inputRows))
+
+			if err != nil {
+				return err
+			}
+
+			// clear the input rows for the next batch
+			inputRows = inputRows[:0]
+		}
+	}
+
+	return err
+}
+
+func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.PermissionSet) error {
+	conn, release, err := s.acquireConn(ctx, ops.Get, "PermissionSet")
+	if err != nil {
+		return err
+	}
+	defer release()
+
+	tx, err := conn.Begin(ctx)
+	if err != nil {
+		return err
+	}
+
+	if err := s.copyFromPermissionSets(ctx, tx, objs...); err != nil {
+		if err := tx.Rollback(ctx); err != nil {
+			return err
+		}
+		return err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.PermissionSet) error {
+	conn, release, err := s.acquireConn(ctx, ops.Get, "PermissionSet")
+	if err != nil {
+		return err
+	}
+	defer release()
+
+	for _, obj := range objs {
+		batch := &pgx.Batch{}
+		if err := insertIntoPermissionSets(ctx, batch, obj); err != nil {
+			return err
+		}
+		batchResults := conn.SendBatch(ctx, batch)
+		var result *multierror.Error
+		for i := 0; i < batch.Len(); i++ {
+			_, err := batchResults.Exec()
+			result = multierror.Append(result, err)
+		}
+		if err := batchResults.Close(); err != nil {
+			return err
+		}
+		if err := result.ErrorOrNil(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.PermissionSet) error {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.UpdateMany, "PermissionSet")
+
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_WRITE_ACCESS).Resource(targetResource)
+	if !scopeChecker.IsAllowed() {
+		return sac.ErrResourceAccessDenied
+	}
+
+	return pgutils.Retry(func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
+
+		if len(objs) < batchAfter {
+			return s.upsert(ctx, objs...)
+		} else {
+			return s.copyFrom(ctx, objs...)
+		}
+	})
+}
+
+func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*pgxpool.Conn, func(), error) {
+	defer metrics.SetAcquireDBConnDuration(time.Now(), op, typ)
+	conn, err := s.db.Acquire(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	return conn, conn.Release, nil
+}
+
+// Delete removes the specified IDs from the store
+func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.RemoveMany, "PermissionSet")
+
+	var sacQueryFilter *v1.Query
+
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_WRITE_ACCESS).Resource(targetResource)
+	if !scopeChecker.IsAllowed() {
+		return sac.ErrResourceAccessDenied
+	}
+
+	// Batch the deletes
+	localBatchSize := deleteBatchSize
+	numRecordsToDelete := len(ids)
+	for {
+		if len(ids) == 0 {
+			break
+		}
+
+		if len(ids) < localBatchSize {
+			localBatchSize = len(ids)
+		}
+
+		idBatch := ids[:localBatchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+			log.Error(err)
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		ids = ids[localBatchSize:]
+	}
+
+	return nil
+}
+
+// Walk iterates over all of the objects in the store and applies the closure
+func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.PermissionSet) error) error {
+	var sacQueryFilter *v1.Query
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_ACCESS).Resource(targetResource)
+	if !scopeChecker.IsAllowed() {
+		return nil
+	}
+	fetcher, closer, err := postgres.RunCursorQueryForSchema[storage.PermissionSet](ctx, schema, sacQueryFilter, s.db)
+	if err != nil {
+		return err
+	}
+	defer closer()
+	for {
+		rows, err := fetcher(cursorBatchSize)
+		if err != nil {
+			return pgutils.ErrNilIfNoRows(err)
+		}
+		for _, data := range rows {
+			if err := fn(data); err != nil {
+				return err
+			}
+		}
+		if len(rows) != cursorBatchSize {
+			break
+		}
+	}
+	return nil
+}

--- a/migrator/runner/all.go
+++ b/migrator/runner/all.go
@@ -125,4 +125,5 @@ import (
 
 	// Postgres -> Postgres migrations
 	_ "github.com/stackrox/rox/migrator/migrations/m_168_to_m_169_postgres_remove_clustercve_permission"
+	_ "github.com/stackrox/rox/migrator/migrations/m_169_to_m_170_collections_sac_resource_migration"
 )

--- a/pkg/migrations/internal/seq_num.go
+++ b/pkg/migrations/internal/seq_num.go
@@ -4,7 +4,7 @@ var (
 	// CurrentDBVersionSeqNum is the current DB version number.
 	// This must be incremented every time we write a migration.
 	// It is a shared constant between central and the migrator binary.
-	CurrentDBVersionSeqNum = 169
+	CurrentDBVersionSeqNum = 170
 
 	// LastRocksDBVersionSeqNum is the sequence number for the last RocksDB version.
 	LastRocksDBVersionSeqNum = 112


### PR DESCRIPTION
## Description

Providing a new postgres -> postgres migration to allow permissions sets that have read/write permissions on report configuration to have the same level of access on the new Workflow Administration permission.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

Manually verified that upgrading a cluster from a previous version to this current version provides the new sac resource.