### PR TITLE
Move helpers and selectors into same subfolders as credentialExpiry and systemConfig integration tests

### DIFF
--- a/ui/apps/platform/cypress/constants/CertExpiration.js
+++ b/ui/apps/platform/cypress/constants/CertExpiration.js
@@ -1,4 +1,0 @@
-export const selectors = {
-    centralCertExpiryBanner: '.pf-c-banner:contains("Central certificate")',
-    scannerCertExpiryBanner: '.pf-c-banner:contains("Scanner certificate")',
-};

--- a/ui/apps/platform/cypress/integration/credentialExpiry/credentialExpiry.helpers.js
+++ b/ui/apps/platform/cypress/integration/credentialExpiry/credentialExpiry.helpers.js
@@ -1,8 +1,13 @@
-import { interactAndWaitForResponses, interceptRequests, waitForResponses } from './request';
+import {
+    interactAndWaitForResponses,
+    interceptRequests,
+    waitForResponses,
+} from '../../helpers/request';
+
 import {
     visitSystemConfiguration,
     visitSystemConfigurationWithStaticResponseForPermissions,
-} from './systemConfig';
+} from '../systemConfig/systemConfig.helpers';
 
 // credentialexpiry
 

--- a/ui/apps/platform/cypress/integration/credentialExpiry/credentialExpiry.test.js
+++ b/ui/apps/platform/cypress/integration/credentialExpiry/credentialExpiry.test.js
@@ -1,12 +1,16 @@
 import dateFns from 'date-fns';
-import withAuth from '../helpers/basicAuth';
-import { selectors } from '../constants/CertExpiration';
+
+import withAuth from '../../helpers/basicAuth';
+
 import {
     interactAndWaitForCentralCertificateDownload,
     interactAndWaitForScannerCertificateDownload,
     visitSystemConfigurationWithCentralCredentialExpiryBanner,
     visitSystemConfigurationWithScannerCredentialExpiryBanner,
-} from '../helpers/credentialExpiry';
+} from './credentialExpiry.helpers';
+
+const centralCredentialExpiryBanner = '.pf-c-banner:contains("Central certificate")';
+const scannerCredentialExpiryBanner = '.pf-c-banner:contains("Scanner certificate")';
 
 describe('Credential expiry', () => {
     withAuth();
@@ -17,7 +21,7 @@ describe('Credential expiry', () => {
 
             visitSystemConfigurationWithCentralCredentialExpiryBanner(expiry);
 
-            cy.get(selectors.centralCertExpiryBanner).should('not.exist');
+            cy.get(centralCredentialExpiryBanner).should('not.exist');
         });
 
         it('should display banner without download button if user does not have the required permission', () => {
@@ -32,13 +36,13 @@ describe('Credential expiry', () => {
                 staticResponseForPermissions
             );
 
-            cy.get(selectors.centralCertExpiryBanner)
+            cy.get(centralCredentialExpiryBanner)
                 .invoke('text')
                 .then((text) => {
                     expect(text).to.include('Central certificate expires in 23 hours');
                     expect(text).to.include('Contact your administrator');
                 });
-            cy.get(selectors.centralCertExpiryBanner).find('button').should('not.exist');
+            cy.get(centralCredentialExpiryBanner).find('button').should('not.exist');
         });
 
         it('should show a warning banner if the expiry date is within 4-14 days', () => {
@@ -46,7 +50,7 @@ describe('Credential expiry', () => {
 
             visitSystemConfigurationWithCentralCredentialExpiryBanner(expiry);
 
-            cy.get(selectors.centralCertExpiryBanner).should('have.class', 'pf-m-warning');
+            cy.get(centralCredentialExpiryBanner).should('have.class', 'pf-m-warning');
         });
 
         it('should show a danger banner if the expiry date is less than or equal to 3 days', () => {
@@ -54,7 +58,7 @@ describe('Credential expiry', () => {
 
             visitSystemConfigurationWithCentralCredentialExpiryBanner(expiry);
 
-            cy.get(selectors.centralCertExpiryBanner).should('have.class', 'pf-m-danger');
+            cy.get(centralCredentialExpiryBanner).should('have.class', 'pf-m-danger');
         });
 
         it('should download the YAML', () => {
@@ -63,7 +67,7 @@ describe('Credential expiry', () => {
             visitSystemConfigurationWithCentralCredentialExpiryBanner(expiry);
 
             interactAndWaitForCentralCertificateDownload(() => {
-                cy.get(selectors.centralCertExpiryBanner).find('button').click();
+                cy.get(centralCredentialExpiryBanner).find('button').click();
             });
         });
     });
@@ -74,7 +78,7 @@ describe('Credential expiry', () => {
 
             visitSystemConfigurationWithScannerCredentialExpiryBanner(expiry);
 
-            cy.get(selectors.centralCertExpiryBanner).should('not.exist');
+            cy.get(centralCredentialExpiryBanner).should('not.exist');
         });
 
         it("should display banner without download button if user doesn't have the required permission", () => {
@@ -89,13 +93,13 @@ describe('Credential expiry', () => {
                 staticResponseForPermissions
             );
 
-            cy.get(selectors.scannerCertExpiryBanner)
+            cy.get(scannerCredentialExpiryBanner)
                 .invoke('text')
                 .then((text) => {
                     expect(text).to.include('Scanner certificate expires in 23 hours');
                     expect(text).to.include('Contact your administrator');
                 });
-            cy.get(selectors.scannerCertExpiryBanner).find('button').should('not.exist');
+            cy.get(scannerCredentialExpiryBanner).find('button').should('not.exist');
         });
 
         it('should show a warning banner if the expiry date is within 4-14 days', () => {
@@ -103,7 +107,7 @@ describe('Credential expiry', () => {
 
             visitSystemConfigurationWithScannerCredentialExpiryBanner(expiry);
 
-            cy.get(selectors.scannerCertExpiryBanner).should('have.class', 'pf-m-warning');
+            cy.get(scannerCredentialExpiryBanner).should('have.class', 'pf-m-warning');
         });
 
         it('should show a danger banner if the expiry date is greater than 14 days', () => {
@@ -111,7 +115,7 @@ describe('Credential expiry', () => {
 
             visitSystemConfigurationWithScannerCredentialExpiryBanner(expiry);
 
-            cy.get(selectors.scannerCertExpiryBanner).should('have.class', 'pf-m-danger');
+            cy.get(scannerCredentialExpiryBanner).should('have.class', 'pf-m-danger');
         });
 
         it('should download the YAML', () => {
@@ -120,7 +124,7 @@ describe('Credential expiry', () => {
             visitSystemConfigurationWithScannerCredentialExpiryBanner(expiry);
 
             interactAndWaitForScannerCertificateDownload(() => {
-                cy.get(selectors.scannerCertExpiryBanner).find('button').click();
+                cy.get(scannerCredentialExpiryBanner).find('button').click();
             });
         });
     });

--- a/ui/apps/platform/cypress/integration/systemConfig/systemConfig.helpers.js
+++ b/ui/apps/platform/cypress/integration/systemConfig/systemConfig.helpers.js
@@ -1,6 +1,7 @@
-import { visitFromLeftNavExpandable } from './nav';
-import { interactAndWaitForResponses } from './request';
-import { visit, visitWithStaticResponseForPermissions } from './visit';
+import { selectors as topNavSelectors } from '../../constants/TopNavigation';
+import { visitFromLeftNavExpandable } from '../../helpers/nav';
+import { interactAndWaitForResponses } from '../../helpers/request';
+import { visit, visitWithStaticResponseForPermissions } from '../../helpers/visit';
 
 const basePath = '/main/systemconfig';
 
@@ -59,4 +60,11 @@ export function saveSystemConfiguration() {
     interactAndWaitForResponses(() => {
         cy.get('button:contains("Save")').click();
     }, routeMatcherMapForPUT);
+}
+
+// interact
+
+export function logOut() {
+    cy.get(topNavSelectors.menuButton).click();
+    cy.get(topNavSelectors.menuList.logoutButton).click();
 }

--- a/ui/apps/platform/cypress/integration/systemConfig/systemConfig.selectors.js
+++ b/ui/apps/platform/cypress/integration/systemConfig/systemConfig.selectors.js
@@ -1,17 +1,4 @@
-import navigationSelectors from '../selectors/navigation';
-
-const selectors = {
-    navLinks: {
-        configure: `${navigationSelectors.navExpandable}:contains("Platform Configuration")`,
-        subnavMenu: '[data-testid="configure-subnav"]',
-        systemConfig: `${navigationSelectors.navLinks}:contains("System Configuration")`,
-        topNav: '[aria-label="User menu"]',
-        logout: '.pf-c-page__header-tools-item button:contains("Log out")',
-    },
-    pageHeader: {
-        editButton: 'button:contains("Edit")',
-        cancelButton: 'button:contains("Cancel")',
-    },
+export const selectors = {
     header: {
         widget: '[data-testid="header-config"]',
         state: '[data-testid="header-state"]',
@@ -66,5 +53,3 @@ export const text = {
     color: '#000000',
     backgroundColor: '#ffff00',
 };
-
-export default selectors;

--- a/ui/apps/platform/cypress/integration/systemConfig/systemConfig.test.js
+++ b/ui/apps/platform/cypress/integration/systemConfig/systemConfig.test.js
@@ -1,15 +1,17 @@
-import selectors, { text } from '../constants/SystemConfigPage';
-import withAuth from '../helpers/basicAuth';
+import withAuth from '../../helpers/basicAuth';
+import { getRegExpForTitleWithBranding } from '../../helpers/title';
+
 import {
+    logOut,
     saveSystemConfiguration,
     visitSystemConfiguration,
     visitSystemConfigurationFromLeftNav,
     visitSystemConfigurationWithStaticResponseForPermissions,
-} from '../helpers/systemConfig';
-import { getRegExpForTitleWithBranding } from '../helpers/title';
+} from './systemConfig.helpers';
+import { selectors, text } from './systemConfig.selectors';
 
 function editBaseConfig(type) {
-    cy.get(selectors.pageHeader.editButton).click();
+    cy.get('button:contains("Edit")').click();
 
     cy.get(selectors[type].config.toggle).should('exist');
     cy.get(selectors[type].config.toggle).check({ force: true }); // force for PatternFly Switch element
@@ -28,7 +30,7 @@ function editBannerConfig(type) {
 }
 
 function disableConfig(type) {
-    cy.get(selectors.pageHeader.editButton).click();
+    cy.get('button:contains("Edit")').click();
     cy.get(selectors[type].config.toggle).uncheck({ force: true }); // force for PatternFly Switch element
 
     saveSystemConfiguration();
@@ -69,7 +71,7 @@ describe('System Configuration', () => {
 
         visitSystemConfigurationWithStaticResponseForPermissions(staticResponseForPermissions);
 
-        cy.get(selectors.pageHeader.editButton).should('not.exist');
+        cy.get('button:contains("Edit")').should('not.exist');
     });
 
     it('should allow the user to set data retention to "never delete"', () => {
@@ -77,7 +79,7 @@ describe('System Configuration', () => {
 
         const neverDeletedText = 'Never deleted';
 
-        cy.get(selectors.pageHeader.editButton).click();
+        cy.get('button:contains("Edit")').click();
 
         // If you reran the test without setting these random values first, it won’t save.
         // The save button is disabled when the form is pristine (ie. already 0)
@@ -93,7 +95,7 @@ describe('System Configuration', () => {
         saveSystemConfiguration();
 
         // Change input values to 0 to set it to "never delete"
-        cy.get(selectors.pageHeader.editButton).click();
+        cy.get('button:contains("Edit")').click();
 
         cy.get(getNumericInputByLabel('All runtime violations')).clear().type(0);
         cy.get(getNumericInputByLabel('Runtime violations for deleted deployments'))
@@ -151,8 +153,9 @@ describe('System Configuration', () => {
         saveSystemConfiguration();
 
         cy.get(selectors.loginNotice.state).contains('Enabled');
-        cy.get(selectors.navLinks.topNav).click();
-        cy.get(selectors.navLinks.logout).click();
+
+        logOut();
+
         cy.get(selectors.loginNotice.banner).should('exist');
     });
 });


### PR DESCRIPTION
## Description

### Naming convention

Distinguish the **scope** of constants and functions:
1. Test-specific: `it` block for test or module scope in test file for tests.
2. Container-specific: whatever.helpers.js or whatever.selectors.js file in cypress/integration/whatever subfolder. Only rare import from other containers, like `interactAndVisitWhatever` function (for example, from Risk to Network Graph).
3. Global
    * cypress/helpers/whatever.js for example, basicAuth.js or features.js
    * cypress/selectors/whatever.js for example, navigation.js or pagination.js

End goals:
1. Move most of cypress/helpers/whatever.js to container subfolders as whatever.helpers.js files.
2. Move most of cypress/constants/whatever.js to container subfolders as whatever.selectors.js files.
3. Encapsulate most of apiEndpoints.js in container-specific helpers files.

### Changed files

1. Delete cypress/constants/CertExpiration.js
    * Move selectors to test file.

2. Edit, move, and rename cypress/constants/SystemConfigPage.js as systemConfig.**selectors**.js
    * Delete unneeded or unused selectors.

3. Edit, move, and rename cypress/helpers/credentialExpiry.js as credentialExpiry.**helpers**.js

4. Edit, move, and rename cypress/helpers/systemConfig.js as systemConfig.**helpers**.js
    * Adapt `logOut` function from logout.test.js

5. Edit and move credentialExpiry.test.js to credentialExpiry subfolder

6. Edit, move, and rename systemconfig.test.js to systemConfig subfolder as systemConfig.test.js

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed