### PR TITLE
ROX-13901: Add empty state to new NG when no namespaces selected

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
@@ -23,6 +23,7 @@ import { getQueryString } from 'utils/queryStringUtils';
 import timeWindowToDate from 'utils/timeWindows';
 
 import PageTitle from 'Components/PageTitle';
+import EmptyUnscopedState from './components/EmptyUnscopedState';
 import NetworkBreadcrumbs from './components/NetworkBreadcrumbs';
 import EdgeStateSelect, { EdgeState } from './EdgeStateSelect';
 import NetworkGraph from './NetworkGraph';
@@ -60,6 +61,8 @@ function NetworkGraphPage() {
         deployments: deploymentsFromUrl,
         remainingQuery,
     } = getScopeHierarchy(searchFilter);
+
+    const hasClusterNamespaceSelected = Boolean(clusterFromUrl && namespacesFromUrl.length);
 
     const { clusters } = useFetchClusters();
     const selectedClusterId = clusters.find((cl) => cl.name === clusterFromUrl)?.id;
@@ -202,7 +205,12 @@ function NetworkGraphPage() {
                 </Toolbar>
             </PageSection>
             <Divider component="div" />
-            <PageSection className="network-graph" padding={{ default: 'noPadding' }}>
+            <PageSection
+                className="network-graph"
+                variant={hasClusterNamespaceSelected ? 'default' : 'light'}
+                padding={{ default: 'noPadding' }}
+            >
+                {!hasClusterNamespaceSelected && <EmptyUnscopedState />}
                 {model.nodes && <NetworkGraph model={model} edgeState={edgeState} />}
                 {isLoading && (
                     <Bullseye>

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/EmptyUnscopedState.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/EmptyUnscopedState.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Bullseye, Title } from '@patternfly/react-core';
+import { Bullseye } from '@patternfly/react-core';
 import { ModuleIcon } from '@patternfly/react-icons';
 import { SVGIconProps } from '@patternfly/react-icons/dist/esm/createIcon';
 

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/EmptyUnscopedState.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/EmptyUnscopedState.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Bullseye, Title } from '@patternfly/react-core';
+import { ModuleIcon } from '@patternfly/react-icons';
+import { SVGIconProps } from '@patternfly/react-icons/dist/esm/createIcon';
+
+import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';
+
+function EmptyIcon(props: SVGIconProps) {
+    return (
+        <ModuleIcon {...props} size="lg" style={{ color: 'var(--pf-global--palette--red-100)' }} />
+    );
+}
+
+function EmptyUnscopedState() {
+    return (
+        <Bullseye>
+            <EmptyStateTemplate
+                title="Select a cluster and at least one namespace to render active deployment traffic
+                    on the graph"
+                headingLevel="h2"
+                icon={EmptyIcon}
+            />
+        </Bullseye>
+    );
+}
+
+export default EmptyUnscopedState;


### PR DESCRIPTION
## Description

Based on this mock:
https://www.sketch.com/s/9d082d82-3515-40f2-875a-1b322a02bace/a/4alGAmA

Open questions:
1. The icon in the mock does not exist in the set of PatternFly mocks. Checking with UX team for guidance. Used ModuleIcon  currently.
2. Based the typography on the empty state for Collections feature, but color of the main text is different in this mock than as in Collections. 

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

<img width="1562" alt="Screen Shot 2022-12-12 at 5 51 23 PM" src="https://user-images.githubusercontent.com/715729/207172876-96daa346-4d60-48ae-bfe0-b9a26361cffd.png">
<img width="1562" alt="Screen Shot 2022-12-12 at 5 51 28 PM" src="https://user-images.githubusercontent.com/715729/207172884-d6bfb2ba-81d5-47f4-99cc-5fe29198e401.png">
