### PR TITLE
ROX-13903: Skip NetworkFlowTest test when not in CI

### DIFF
--- a/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
@@ -34,6 +34,7 @@ import util.Timer
 import org.junit.Assume
 import org.junit.experimental.categories.Category
 import spock.lang.Ignore
+import spock.lang.IgnoreIf
 import spock.lang.Shared
 import spock.lang.Stepwise
 import spock.lang.Unroll
@@ -722,6 +723,9 @@ class NetworkFlowTest extends BaseSpecification {
         }
     }
 
+    // ROX-13903 - applyGeneratedNetworkPolicy() can hang when run via the
+    // standalone test runner.
+    @IgnoreIf({ !Env.IN_CI })
     @Unroll
     @Category([BAT])
     def "Verify network policy generator apply/undo with delete modes: #deleteMode #note"() {


### PR DESCRIPTION
## Description

Per title and ROX-13903, it is flaky.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

CI is sufficient