### PR TITLE
ROX-13433: Adding extraneous node/flows count to extraneous graph 

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraph.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraph.tsx
@@ -106,40 +106,39 @@ const TopologyComponent = ({ model, edgeState, simulation }: TopologyComponentPr
         setEdges();
     }
 
-    function setExtraneousNodes() {
-        const currentModel = controller.toModel();
-        const { extraneousEgressNode, extraneousIngressNode } = createExtraneousNodes(325);
+    function showExtraneousNodes() {
         // else if there is a selected node, create a node to collect extraneous flows
         const selectedNode = controller.getNodeById(detailId);
         console.log('selectedNode', selectedNode, detailId);
         // TODO: figure out if/how to support namespaces
         if (selectedNode?.data?.type === 'DEPLOYMENT') {
             const { networkPolicyState } = selectedNode?.data || {};
+            const extraneousIngressNode = controller.getElementById('extraneous-ingress');
+            const extraneousEgressNode = controller.getElementById('extraneous-egress');
             if (networkPolicyState === 'ingress') {
-                // if the node has ingress policies from policy graph, create extraneous egress node
-                currentModel.nodes?.push(extraneousEgressNode);
+                // if the node has ingress policies from policy graph, show extraneous egress node
+                extraneousEgressNode?.setVisible(true);
             } else if (networkPolicyState === 'egress') {
-                // if the node has egress policies from policy graph, create extraneous ingress node
-                currentModel.nodes?.push(extraneousIngressNode);
+                // if the node has egress policies from policy graph, show extraneous ingress node
+                extraneousIngressNode?.setVisible(true);
             } else if (networkPolicyState === 'none') {
-                // if the node has no policies, create both extraneous ingress and egress nodes
-                currentModel.nodes?.push(extraneousEgressNode);
-                currentModel.nodes?.push(extraneousIngressNode);
+                // if the node has no policies, show both extraneous ingress and egress nodes
+                extraneousEgressNode?.setVisible(true);
+                extraneousIngressNode?.setVisible(true);
             }
-            controller.fromModel(currentModel);
         }
     }
 
-    function removeExtraneousNodes() {
-        console.log('removeExtraneousNodes');
+    function hideExtraneousNodes() {
+        console.log('hideExtraneousNodes');
         // if there is no selected node, check if extraneous nodes exist and remove them
         const extraneousIngressNode = controller.getElementById('extraneous-ingress');
         if (extraneousIngressNode) {
-            controller.removeElement(extraneousIngressNode);
+            extraneousIngressNode.setVisible(false);
         }
         const extraneousEgressNode = controller.getElementById('extraneous-egress');
         if (extraneousEgressNode) {
-            controller.removeElement(extraneousEgressNode);
+            extraneousEgressNode.setVisible(false);
         }
     }
 
@@ -205,9 +204,9 @@ const TopologyComponent = ({ model, edgeState, simulation }: TopologyComponentPr
 
     function setNodes() {
         console.log('setNodes');
-        removeExtraneousNodes();
+        hideExtraneousNodes();
         if (edgeState === 'extraneous' && detailId) {
-            setExtraneousNodes();
+            showExtraneousNodes();
         }
     }
 

--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraph.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraph.tsx
@@ -12,6 +12,7 @@ import {
     Visualization,
     VisualizationSurface,
     VisualizationProvider,
+    EdgeModel,
 } from '@patternfly/react-topology';
 
 import { networkBasePathPF } from 'routePaths';
@@ -30,7 +31,7 @@ import { EdgeState } from './EdgeStateSelect';
 import './Topology.css';
 import { getNodeById } from './utils/networkGraphUtils';
 import { CustomModel, CustomNodeModel } from './types/topology.type';
-import { createExtraneousNodes } from './utils/modelUtils';
+import { createExtraneousEdges } from './utils/modelUtils';
 import { Simulation } from './utils/getSimulation';
 
 // TODO: move these type defs to a central location
@@ -75,60 +76,6 @@ function setVisibleEdges(edges) {
     });
 }
 
-function setEdges(controller, detailId) {
-    controller
-        .getGraph()
-        .getEdges()
-        .forEach((edge) => {
-            edge.setVisible(false);
-        });
-
-    if (detailId) {
-        const selectedNode = controller.getNodeById(detailId);
-        if (selectedNode?.isGroup()) {
-            selectedNode.getAllNodeChildren().forEach((child) => {
-                // set visible edges
-                setVisibleEdges(getNodeEdges(child));
-            });
-        } else if (selectedNode) {
-            // set visible edges
-            setVisibleEdges(getNodeEdges(selectedNode));
-        }
-    }
-}
-
-function setExtraneousNodes(controller, detailId) {
-    if (!detailId) {
-        // if there is no selected node, check if extraneous nodes exist and clear them
-        const extraneousIngressNode = controller.getNodeById('extraneous-ingress');
-        if (extraneousIngressNode) {
-            controller.removeElement(extraneousIngressNode);
-        }
-        const extraneousEgressNode = controller.getNodeById('extraneous-egress');
-        if (extraneousEgressNode) {
-            controller.removeElement(extraneousEgressNode);
-        }
-    } else {
-        const currentModel = controller.toModel();
-        const { extraneousEgressNode, extraneousIngressNode } = createExtraneousNodes();
-        // else if there is a selected node, create a node to collect extraneous flows
-        const selectedNode = controller.getNodeById(detailId);
-        const { networkPolicyState } = selectedNode?.data || {};
-        if (networkPolicyState === 'ingress') {
-            // if the node has ingress policies from policy graph, create extraneous egress node
-            currentModel.nodes.push(extraneousEgressNode);
-        } else if (networkPolicyState === 'egress') {
-            // if the node has egress policies from policy graph, create extraneous ingress node
-            currentModel.nodes.push(extraneousIngressNode);
-        } else if (networkPolicyState === 'none') {
-            // if the node has no policies, create both extraneous ingress and egress nodes
-            currentModel.nodes.push(extraneousEgressNode);
-            currentModel.nodes.push(extraneousIngressNode);
-        }
-        controller.fromModel(currentModel);
-    }
-}
-
 // @TODO: Consider a better approach to managing the side panel related state (simulation + URL path for entities)
 function clearSimulationQuery(search: string): string {
     const modifiedSearchFilter = getQueryObject(search);
@@ -146,12 +93,90 @@ const TopologyComponent = ({ model, edgeState, simulation }: TopologyComponentPr
     const { detailId } = useParams();
     const selectedEntity = detailId && getNodeById(model?.nodes, detailId);
     const controller = useVisualizationController();
+    console.log('TopologyComponent controller', controller);
 
     // to prevent error where graph hasn't initialized yet
     if (controller.hasGraph()) {
-        setEdges(controller, detailId);
-        if (edgeState === 'extraneous') {
-            setExtraneousNodes(controller, detailId);
+        rerenderGraph();
+    }
+
+    function rerenderGraph() {
+        console.log('rerenderGraph');
+        setNodes();
+        setEdges();
+    }
+
+    function setExtraneousNodes() {
+        const currentModel = controller.toModel();
+        const { extraneousEgressNode, extraneousIngressNode } = createExtraneousNodes(325);
+        // else if there is a selected node, create a node to collect extraneous flows
+        const selectedNode = controller.getNodeById(detailId);
+        console.log('selectedNode', selectedNode, detailId);
+        // TODO: figure out if/how to support namespaces
+        if (selectedNode?.data?.type === 'DEPLOYMENT') {
+            const { networkPolicyState } = selectedNode?.data || {};
+            if (networkPolicyState === 'ingress') {
+                // if the node has ingress policies from policy graph, create extraneous egress node
+                currentModel.nodes?.push(extraneousEgressNode);
+            } else if (networkPolicyState === 'egress') {
+                // if the node has egress policies from policy graph, create extraneous ingress node
+                currentModel.nodes?.push(extraneousIngressNode);
+            } else if (networkPolicyState === 'none') {
+                // if the node has no policies, create both extraneous ingress and egress nodes
+                currentModel.nodes?.push(extraneousEgressNode);
+                currentModel.nodes?.push(extraneousIngressNode);
+            }
+            controller.fromModel(currentModel);
+        }
+    }
+
+    function removeExtraneousNodes() {
+        console.log('removeExtraneousNodes');
+        // if there is no selected node, check if extraneous nodes exist and remove them
+        const extraneousIngressNode = controller.getElementById('extraneous-ingress');
+        if (extraneousIngressNode) {
+            controller.removeElement(extraneousIngressNode);
+        }
+        const extraneousEgressNode = controller.getElementById('extraneous-egress');
+        if (extraneousEgressNode) {
+            controller.removeElement(extraneousEgressNode);
+        }
+    }
+
+    function setExtraneousEdges() {
+        const currentModel = controller.toModel();
+        const { extraneousEgressEdge, extraneousIngressEdge } = createExtraneousEdges(detailId);
+        const selectedNode = controller.getNodeById(detailId);
+        // else if there is a selected node, create a node to collect extraneous flows
+        console.log('selectedNode', selectedNode, detailId);
+        // TODO: figure out if/how to support namespaces
+        if (selectedNode?.data?.type === 'DEPLOYMENT') {
+            const { networkPolicyState } = selectedNode?.data || {};
+            const edges: EdgeModel[] = currentModel.edges || [];
+            console.log('setting extraneous edges', edges);
+            if (networkPolicyState === 'ingress') {
+                edges.push(extraneousEgressEdge);
+            } else if (networkPolicyState === 'egress') {
+                edges.push(extraneousIngressEdge);
+            } else if (networkPolicyState === 'none') {
+                edges.push(extraneousEgressEdge);
+                edges.push(extraneousIngressEdge);
+            }
+            currentModel.edges = edges;
+            controller.fromModel(currentModel);
+        }
+    }
+
+    function removeExtraneousEdges() {
+        console.log('removeExtraneousEdges');
+        // if there is no selected node, check if extraneous edges exist and remove them
+        const extraneousIngressEdge = controller.getElementById('extraneous-ingress-edge');
+        if (extraneousIngressEdge) {
+            controller.removeElement(extraneousIngressEdge);
+        }
+        const extraneousEgressEdge = controller.getElementById('extraneous-egress-edge');
+        if (extraneousEgressEdge) {
+            controller.removeElement(extraneousEgressEdge);
         }
     }
 
@@ -178,11 +203,49 @@ const TopologyComponent = ({ model, edgeState, simulation }: TopologyComponentPr
         }
     }
 
+    function setNodes() {
+        console.log('setNodes');
+        removeExtraneousNodes();
+        if (edgeState === 'extraneous' && detailId) {
+            setExtraneousNodes();
+        }
+    }
+
+    // TODO: figure out how to add/show edges more performantly/smoothly
+    function setEdges() {
+        console.log('setEdges');
+        removeExtraneousEdges();
+        controller
+            .getGraph()
+            .getEdges()
+            .forEach((edge) => {
+                edge.setVisible(false);
+            });
+
+        if (detailId) {
+            const selectedNode = controller.getNodeById(detailId);
+            if (selectedNode?.isGroup()) {
+                selectedNode.getAllNodeChildren().forEach((child) => {
+                    // set visible edges
+                    setVisibleEdges(getNodeEdges(child));
+                });
+            } else if (selectedNode) {
+                // set visible edges
+                setVisibleEdges(getNodeEdges(selectedNode));
+            }
+
+            // setting extraneous edges
+            if (edgeState === 'extraneous') {
+                setExtraneousEdges();
+            }
+        }
+    }
+
     React.useEffect(() => {
         controller.fromModel(model, false);
         controller.addEventListener(SELECTION_EVENT, onSelect);
 
-        setEdges(controller, detailId);
+        rerenderGraph();
 
         return () => {
             controller.removeEventListener(SELECTION_EVENT, onSelect);

--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraph.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraph.tsx
@@ -27,12 +27,12 @@ import ExternalEntitiesSideBar from './externalEntities/ExternalEntitiesSideBar'
 import ExternalGroupSideBar from './external/ExternalGroupSideBar';
 import NetworkPolicySimulatorSidePanel from './simulation/NetworkPolicySimulatorSidePanel';
 import { EdgeState } from './EdgeStateSelect';
-
-import './Topology.css';
 import { getNodeById } from './utils/networkGraphUtils';
 import { CustomModel, CustomNodeModel } from './types/topology.type';
 import { createExtraneousEdges } from './utils/modelUtils';
 import { Simulation } from './utils/getSimulation';
+
+import './Topology.css';
 
 // TODO: move these type defs to a central location
 export const UrlDetailType = {
@@ -93,7 +93,6 @@ const TopologyComponent = ({ model, edgeState, simulation }: TopologyComponentPr
     const { detailId } = useParams();
     const selectedEntity = detailId && getNodeById(model?.nodes, detailId);
     const controller = useVisualizationController();
-    console.log('TopologyComponent controller', controller);
 
     // to prevent error where graph hasn't initialized yet
     if (controller.hasGraph()) {
@@ -101,7 +100,6 @@ const TopologyComponent = ({ model, edgeState, simulation }: TopologyComponentPr
     }
 
     function rerenderGraph() {
-        console.log('rerenderGraph');
         setNodes();
         setEdges();
     }
@@ -109,10 +107,10 @@ const TopologyComponent = ({ model, edgeState, simulation }: TopologyComponentPr
     function showExtraneousNodes() {
         // else if there is a selected node, create a node to collect extraneous flows
         const selectedNode = controller.getNodeById(detailId);
-        console.log('selectedNode', selectedNode, detailId);
         // TODO: figure out if/how to support namespaces
-        if (selectedNode?.data?.type === 'DEPLOYMENT') {
-            const { networkPolicyState } = selectedNode?.data || {};
+        const { data } = selectedNode || {};
+        if (data?.type === 'DEPLOYMENT') {
+            const { networkPolicyState } = data || {};
             const extraneousIngressNode = controller.getElementById('extraneous-ingress');
             const extraneousEgressNode = controller.getElementById('extraneous-egress');
             if (networkPolicyState === 'ingress') {
@@ -130,7 +128,6 @@ const TopologyComponent = ({ model, edgeState, simulation }: TopologyComponentPr
     }
 
     function hideExtraneousNodes() {
-        console.log('hideExtraneousNodes');
         // if there is no selected node, check if extraneous nodes exist and remove them
         const extraneousIngressNode = controller.getElementById('extraneous-ingress');
         if (extraneousIngressNode) {
@@ -144,20 +141,25 @@ const TopologyComponent = ({ model, edgeState, simulation }: TopologyComponentPr
 
     function setExtraneousEdges() {
         const currentModel = controller.toModel();
+        const extraneousIngressNode = controller.getElementById('extraneous-ingress');
+        const extraneousEgressNode = controller.getElementById('extraneous-egress');
         const { extraneousEgressEdge, extraneousIngressEdge } = createExtraneousEdges(detailId);
         const selectedNode = controller.getNodeById(detailId);
+        const { data } = selectedNode || {};
         // else if there is a selected node, create a node to collect extraneous flows
-        console.log('selectedNode', selectedNode, detailId);
         // TODO: figure out if/how to support namespaces
-        if (selectedNode?.data?.type === 'DEPLOYMENT') {
-            const { networkPolicyState } = selectedNode?.data || {};
+        if (data?.type === 'DEPLOYMENT') {
+            const { networkPolicyState } = data || {};
             const edges: EdgeModel[] = currentModel.edges || [];
-            console.log('setting extraneous edges', edges);
-            if (networkPolicyState === 'ingress') {
+            if (networkPolicyState === 'ingress' && extraneousEgressNode) {
                 edges.push(extraneousEgressEdge);
-            } else if (networkPolicyState === 'egress') {
+            } else if (networkPolicyState === 'egress' && extraneousIngressNode) {
                 edges.push(extraneousIngressEdge);
-            } else if (networkPolicyState === 'none') {
+            } else if (
+                networkPolicyState === 'none' &&
+                extraneousEgressNode &&
+                extraneousIngressNode
+            ) {
                 edges.push(extraneousEgressEdge);
                 edges.push(extraneousIngressEdge);
             }
@@ -167,7 +169,6 @@ const TopologyComponent = ({ model, edgeState, simulation }: TopologyComponentPr
     }
 
     function removeExtraneousEdges() {
-        console.log('removeExtraneousEdges');
         // if there is no selected node, check if extraneous edges exist and remove them
         const extraneousIngressEdge = controller.getElementById('extraneous-ingress-edge');
         if (extraneousIngressEdge) {
@@ -203,7 +204,6 @@ const TopologyComponent = ({ model, edgeState, simulation }: TopologyComponentPr
     }
 
     function setNodes() {
-        console.log('setNodes');
         hideExtraneousNodes();
         if (edgeState === 'extraneous' && detailId) {
             showExtraneousNodes();
@@ -212,7 +212,6 @@ const TopologyComponent = ({ model, edgeState, simulation }: TopologyComponentPr
 
     // TODO: figure out how to add/show edges more performantly/smoothly
     function setEdges() {
-        console.log('setEdges');
         removeExtraneousEdges();
         controller
             .getGraph()

--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraph.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraph.tsx
@@ -108,6 +108,8 @@ const TopologyComponent = ({ model, edgeState, simulation }: TopologyComponentPr
         // else if there is a selected node, create a node to collect extraneous flows
         const selectedNode = controller.getNodeById(detailId);
         // TODO: figure out if/how to support namespaces
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore TS2339: Property 'data' does not exist on type 'Node<NodeModel, any> | {}'.
         const { data } = selectedNode || {};
         if (data?.type === 'DEPLOYMENT') {
             const { networkPolicyState } = data || {};
@@ -145,6 +147,8 @@ const TopologyComponent = ({ model, edgeState, simulation }: TopologyComponentPr
         const extraneousEgressNode = controller.getElementById('extraneous-egress');
         const { extraneousEgressEdge, extraneousIngressEdge } = createExtraneousEdges(detailId);
         const selectedNode = controller.getNodeById(detailId);
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore TS2339: Property 'data' does not exist on type 'Node<NodeModel, any> | {}'.
         const { data } = selectedNode || {};
         // else if there is a selected node, create a node to collect extraneous flows
         // TODO: figure out if/how to support namespaces

--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
@@ -17,6 +17,7 @@ import { EdgeModel } from '@patternfly/react-topology';
 import useDeepCompareEffect from 'use-deep-compare-effect';
 
 import useFetchClusters from 'hooks/useFetchClusters';
+import useFetchDeploymentCount from 'hooks/useFetchDeploymentCount';
 import useURLSearch from 'hooks/useURLSearch';
 import { fetchNetworkFlowGraph, fetchNetworkPolicyGraph } from 'services/NetworkService';
 import { getQueryString } from 'utils/queryStringUtils';
@@ -37,7 +38,7 @@ import {
 } from './utils/modelUtils';
 import getScopeHierarchy from './utils/getScopeHierarchy';
 import getSimulation from './utils/getSimulation';
-import { CustomModel, CustomNodeModel, PolicyNodeModel } from './types/topology.type';
+import { CustomModel, CustomNodeModel, DeploymentNodeModel } from './types/topology.type';
 
 import './NetworkGraphPage.css';
 
@@ -72,6 +73,7 @@ function NetworkGraphPage() {
     const { clusters } = useFetchClusters();
     const selectedClusterId = clusters.find((cl) => cl.name === clusterFromUrl)?.id;
     const selectedCluster = { name: clusterFromUrl, id: selectedClusterId };
+    const { deploymentCount } = useFetchDeploymentCount(selectedClusterId || '');
 
     useDeepCompareEffect(() => {
         // only refresh the graph data from the API if both a cluster and at least one namespace are selected
@@ -103,7 +105,7 @@ function NetworkGraphPage() {
                     .then((values) => {
                         const activeNodeMap: Record<string, CustomNodeModel> = {};
                         const activeEdgeMap: Record<string, EdgeModel> = {};
-                        const policyNodeMap: Record<string, PolicyNodeModel> = {};
+                        const policyNodeMap: Record<string, DeploymentNodeModel> = {};
 
                         // get policy nodes from api response
                         const { nodes: policyNodes } = values[1].response;
@@ -114,7 +116,7 @@ function NetworkGraphPage() {
                         policyDataModel.nodes?.forEach((node) => {
                             // no grouped nodes in policy graph data model
                             if (!policyNodeMap[node.id]) {
-                                policyNodeMap[node.id] = node as PolicyNodeModel;
+                                policyNodeMap[node.id] = node as DeploymentNodeModel;
                             }
                         });
 

--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
@@ -77,7 +77,7 @@ function NetworkGraphPage() {
 
     useDeepCompareEffect(() => {
         // only refresh the graph data from the API if both a cluster and at least one namespace are selected
-        if (clusterFromUrl && namespacesFromUrl.length > 0) {
+        if (clusterFromUrl && namespacesFromUrl.length > 0 && deploymentCount) {
             if (selectedClusterId) {
                 setIsLoading(true);
 
@@ -110,7 +110,10 @@ function NetworkGraphPage() {
                         // get policy nodes from api response
                         const { nodes: policyNodes } = values[1].response;
                         // transform policy data to DataModel
-                        const policyDataModel = transformPolicyData(policyNodes, deploymentCount);
+                        const policyDataModel = transformPolicyData(
+                            policyNodes,
+                            deploymentCount || 0
+                        );
                         // set policyNodeMap to be able to cross reference nodes by id
                         // to enhance active node data
                         policyDataModel.nodes?.forEach((node) => {
@@ -155,7 +158,7 @@ function NetworkGraphPage() {
                     .finally(() => setIsLoading(false));
             }
         }
-    }, [clusters, clusterFromUrl, namespacesFromUrl, deploymentsFromUrl]);
+    }, [clusters, clusterFromUrl, namespacesFromUrl, deploymentsFromUrl, deploymentCount]);
 
     useEffect(() => {
         if (edgeState === 'active') {

--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
@@ -110,7 +110,7 @@ function NetworkGraphPage() {
                         // get policy nodes from api response
                         const { nodes: policyNodes } = values[1].response;
                         // transform policy data to DataModel
-                        const policyDataModel = transformPolicyData(policyNodes);
+                        const policyDataModel = transformPolicyData(policyNodes, deploymentCount);
                         // set policyNodeMap to be able to cross reference nodes by id
                         // to enhance active node data
                         policyDataModel.nodes?.forEach((node) => {

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/DefaultFakeGroup.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/DefaultFakeGroup.tsx
@@ -68,10 +68,10 @@ const DefaultFakeGroup = ({
     return React.createElement(
         'g',
         { ref: labelHoverRef, onClick: onSelect, className: groupClassName },
-        React.createElement(
-            Layer,
-            { id: 'groups' },
-            React.createElement(
+        // eslint-disable-next-line react/no-children-prop
+        React.createElement(Layer, {
+            id: 'groups',
+            children: React.createElement(
                 'g',
                 { ref: refs, onClick: onSelect },
                 ShapeComponent &&
@@ -108,11 +108,13 @@ const DefaultFakeGroup = ({
                             filter,
                         })
                     )
-            )
-        ),
+            ),
+        }),
         shapeSize &&
             React.createElement(LabelBadge, {
                 className: styles.topologyGroupCollapsedBadge,
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore TS2769: No overload matches this call.
                 ref: badgeRef,
                 x: shapeSize.width - 8,
                 y:

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/DefaultFakeGroup.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/DefaultFakeGroup.tsx
@@ -1,0 +1,167 @@
+/* eslint-disable no-void */
+/* eslint-disable no-cond-assign */
+/* eslint-disable @typescript-eslint/restrict-plus-operands */
+/* eslint-disable no-return-assign */
+import * as React from 'react';
+import { observer } from 'mobx-react';
+import { css } from '@patternfly/react-styles';
+import styles from '@patternfly/react-styles/css/components/Topology/topology-components';
+import {
+    Layer,
+    LabelPosition,
+    LabelBadge,
+    Ellipse,
+    NodeLabel,
+    createSvgIdUrl,
+    useCombineRefs,
+    useHover,
+    useSize,
+    useDragNode,
+} from '@patternfly/react-topology';
+
+const DefaultFakeGroup = ({
+    className,
+    children,
+    element,
+    selected,
+    onSelect,
+    hover,
+    label,
+    secondaryLabel,
+    showLabel = true,
+    truncateLength,
+    collapsedWidth,
+    collapsedHeight,
+    getCollapsedShape,
+    collapsedShadowOffset = 8,
+    dragNodeRef,
+    dragging,
+    labelPosition,
+    badge,
+    badgeColor,
+    badgeTextColor,
+    badgeBorderColor,
+    badgeClassName,
+    badgeLocation,
+    labelIconClass,
+    labelIcon,
+    labelIconPadding,
+}) => {
+    // eslint-disable-next-line @typescript-eslint/naming-convention, no-underscore-dangle
+    let _a: number | undefined;
+    const [hovered, hoverRef] = useHover();
+    const [labelHover, labelHoverRef] = useHover();
+    const dragLabelRef = useDragNode()[1];
+    const [shapeSize, shapeRef] = useSize([collapsedWidth, collapsedHeight]);
+    const refs = useCombineRefs(hoverRef, dragNodeRef, shapeRef);
+    const isHover = hover !== undefined ? hover : hovered;
+    const childCount: number = element.data.flows;
+    const [badgeSize, badgeRef] = useSize([childCount]);
+    const groupClassName = css(
+        styles.topologyGroup,
+        className,
+        dragging && 'pf-m-dragging',
+        selected && 'pf-m-selected'
+    );
+    const ShapeComponent = getCollapsedShape ? getCollapsedShape(element) : Ellipse;
+    const filter = isHover || dragging ? createSvgIdUrl('NodeShadowsFilterId--hover') : undefined;
+    return React.createElement(
+        'g',
+        { ref: labelHoverRef, onClick: onSelect, className: groupClassName },
+        React.createElement(
+            Layer,
+            { id: 'groups' },
+            React.createElement(
+                'g',
+                { ref: refs, onClick: onSelect },
+                ShapeComponent &&
+                    React.createElement(
+                        React.Fragment,
+                        null,
+                        React.createElement(
+                            'g',
+                            { transform: `translate(${collapsedShadowOffset * 2}, 0)` },
+                            React.createElement(ShapeComponent, {
+                                className: css(styles.topologyNodeBackground, 'pf-m-disabled'),
+                                element,
+                                width: collapsedWidth,
+                                height: collapsedHeight,
+                            })
+                        ),
+                        React.createElement(
+                            'g',
+                            { transform: `translate(${collapsedShadowOffset}, 0)` },
+                            React.createElement(ShapeComponent, {
+                                className: css(styles.topologyNodeBackground, 'pf-m-disabled'),
+                                element,
+                                width: collapsedWidth,
+                                height: collapsedHeight,
+                            })
+                        ),
+                        React.createElement(ShapeComponent, {
+                            className: css(styles.topologyNodeBackground),
+                            key:
+                                isHover || dragging ? 'shape-background-hover' : 'shape-background',
+                            element,
+                            width: collapsedWidth,
+                            height: collapsedHeight,
+                            filter,
+                        })
+                    )
+            )
+        ),
+        shapeSize &&
+            React.createElement(LabelBadge, {
+                className: styles.topologyGroupCollapsedBadge,
+                ref: badgeRef,
+                x: shapeSize.width - 8,
+                y:
+                    (shapeSize.width -
+                        ((_a =
+                            badgeSize === null || badgeSize === void 0
+                                ? void 0
+                                : badgeSize.height) !== null && _a !== void 0
+                            ? _a
+                            : 0)) /
+                    2,
+                badge: `${childCount}`,
+                badgeColor,
+                badgeTextColor,
+                badgeBorderColor,
+            }),
+        showLabel &&
+            React.createElement(
+                NodeLabel,
+                {
+                    className: styles.topologyGroupLabel,
+                    x:
+                        labelPosition === LabelPosition.right
+                            ? collapsedWidth + 8
+                            : collapsedWidth / 2,
+                    y:
+                        labelPosition === LabelPosition.right
+                            ? collapsedHeight / 2
+                            : collapsedHeight + 6,
+                    paddingX: 8,
+                    paddingY: 5,
+                    dragRef: dragNodeRef ? dragLabelRef : undefined,
+                    status: element.getNodeStatus(),
+                    secondaryLabel,
+                    truncateLength,
+                    badge,
+                    badgeColor,
+                    badgeTextColor,
+                    badgeBorderColor,
+                    badgeClassName,
+                    badgeLocation,
+                    labelIconClass,
+                    labelIcon,
+                    labelIconPadding,
+                    hover: isHover || labelHover,
+                },
+                label || element.getLabel()
+            ),
+        children
+    );
+};
+export default observer(DefaultFakeGroup);

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/DefaultFakeGroup.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/DefaultFakeGroup.tsx
@@ -55,7 +55,7 @@ const DefaultFakeGroup = ({
     const [shapeSize, shapeRef] = useSize([collapsedWidth, collapsedHeight]);
     const refs = useCombineRefs(hoverRef, dragNodeRef, shapeRef);
     const isHover = hover !== undefined ? hover : hovered;
-    const childCount: number = element.data.flows;
+    const childCount: number = element.data.numFlows;
     const [badgeSize, badgeRef] = useSize([childCount]);
     const groupClassName = css(
         styles.topologyGroup,

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/StyleFakeGroup.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/StyleFakeGroup.tsx
@@ -1,0 +1,90 @@
+/* eslint-disable @typescript-eslint/no-unsafe-return */
+import * as React from 'react';
+import {
+    Node,
+    observer,
+    ScaleDetailsLevel,
+    ShapeProps,
+    WithDragNodeProps,
+    WithSelectionProps,
+} from '@patternfly/react-topology';
+import AlternateIcon from '@patternfly/react-icons/dist/esm/icons/regions-icon';
+import DefaultIcon from '@patternfly/react-icons/dist/esm/icons/builder-image-icon';
+import useDetailsLevel from '@patternfly/react-topology/dist/esm/hooks/useDetailsLevel';
+import DefaultFakeGroup from './DefaultFakeGroup';
+
+const ICON_PADDING = 20;
+
+export enum DataTypes {
+    Default,
+    Alternate,
+}
+
+type StyleGroupProps = {
+    element: Node;
+    collapsedWidth?: number;
+    collapsedHeight?: number;
+    onCollapseChange?: (group: Node, collapsed: boolean) => void;
+    getCollapsedShape?: (node: Node) => React.FunctionComponent<ShapeProps>;
+    collapsedShadowOffset?: number; // defaults to 10
+} & WithDragNodeProps &
+    WithSelectionProps;
+
+const StyleFakeGroup: React.FunctionComponent<StyleGroupProps> = ({
+    element,
+    collapsedWidth = 75,
+    collapsedHeight = 75,
+    ...rest
+}) => {
+    const data = element.getData();
+    const detailsLevel = useDetailsLevel();
+
+    const getTypeIcon = (dataType?: DataTypes): any => {
+        switch (dataType) {
+            case DataTypes.Alternate:
+                return AlternateIcon;
+            default:
+                return DefaultIcon;
+        }
+    };
+
+    const renderIcon = (): React.ReactNode => {
+        const iconSize = Math.min(collapsedWidth, collapsedHeight) - ICON_PADDING * 2;
+        const Component = getTypeIcon(data.dataType);
+
+        return (
+            <g
+                transform={`translate(${(collapsedWidth - iconSize) / 2}, ${
+                    (collapsedHeight - iconSize) / 2
+                })`}
+            >
+                <Component style={{ color: '#393F44' }} width={iconSize} height={iconSize} />
+            </g>
+        );
+    };
+
+    const passedData = React.useMemo(() => {
+        const newData = { ...data };
+        Object.keys(newData).forEach((key) => {
+            if (newData[key] === undefined) {
+                delete newData[key];
+            }
+        });
+        return newData;
+    }, [data]);
+
+    return (
+        <DefaultFakeGroup
+            element={element}
+            collapsedWidth={collapsedWidth}
+            collapsedHeight={collapsedHeight}
+            showLabel={detailsLevel === ScaleDetailsLevel.high}
+            {...rest}
+            {...passedData}
+        >
+            {renderIcon()}
+        </DefaultFakeGroup>
+    );
+};
+
+export default observer(StyleFakeGroup);

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/stylesComponentFactory.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/stylesComponentFactory.tsx
@@ -13,6 +13,7 @@ import {
 import StyleNode from './StyleNode';
 import StyleGroup from './StyleGroup';
 import StyleEdge from './StyleEdge';
+import StyleFakeGroup from './StyleFakeGroup';
 
 const stylesComponentFactory: ComponentFactory = (kind: ModelKind, type: string): any => {
     if (kind === ModelKind.graph) {
@@ -37,7 +38,7 @@ const stylesComponentFactory: ComponentFactory = (kind: ModelKind, type: string)
             return withDragNode(nodeDragSourceSpec('node', true, true))(
                 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
                 // @ts-ignore
-                withSelection()(StyleNode)
+                withSelection()(StyleFakeGroup)
             );
         case 'edge':
             return StyleEdge;

--- a/ui/apps/platform/src/Containers/NetworkGraph/types/topology.type.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/types/topology.type.ts
@@ -78,5 +78,5 @@ export type ExtraneousData = {
     type: 'EXTRANEOUS';
     collapsible: boolean;
     showContextMenu: boolean;
-    flows: number;
+    numFlows: number;
 };

--- a/ui/apps/platform/src/Containers/NetworkGraph/types/topology.type.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/types/topology.type.ts
@@ -11,7 +11,6 @@ export type CustomNodeModel =
     | ExternalNodeModel
     | ExternalEntitiesNodeModel
     | CIDRBlockNodeModel
-    | PolicyNodeModel
     | ExtraneousNodeModel;
 
 export type NamespaceNodeModel = Override<NodeModel, { data: NamespaceData }>;
@@ -23,8 +22,6 @@ export type ExternalNodeModel = Override<NodeModel, { data: ExternalData }>;
 export type ExternalEntitiesNodeModel = Override<NodeModel, { data: ExternalEntitiesData }>;
 
 export type CIDRBlockNodeModel = Override<NodeModel, { data: CIDRBlockData }>;
-
-export type PolicyNodeModel = Override<NodeModel, { data: PolicyDeploymentData }>;
 
 export type ExtraneousNodeModel = Override<NodeModel, { data: ExtraneousData }>;
 
@@ -77,22 +74,9 @@ export type CIDRBlockData = {
     };
 };
 
-export type PolicyDeploymentData = {
-    type: 'DEPLOYMENT';
-    id: string;
-    deployment: {
-        cluster: string;
-        listenPorts: ListenPort[];
-        name: string;
-        namespace: string;
-    };
-    policyIds: string[];
-    nonIsolatedIngress: boolean;
-    nonIsolatedEgress: boolean;
-};
-
 export type ExtraneousData = {
     type: 'EXTRANEOUS';
     collapsible: boolean;
     showContextMenu: boolean;
+    flows: number;
 };

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/modelUtils.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/modelUtils.tsx
@@ -187,7 +187,7 @@ function getNetworkPolicyState(
     return networkPolicyState;
 }
 
-export function transformPolicyData(nodes: Node[], flows?: number): CustomModel {
+export function transformPolicyData(nodes: Node[], flows: number): CustomModel {
     const dataModel = {
         graph: graphModel,
         nodes: [] as CustomNodeModel[],
@@ -293,7 +293,7 @@ export function createExtraneousFlowsModel(
     return dataModel;
 }
 
-export function createExtraneousNodes(flows?: number): {
+export function createExtraneousNodes(flows: number): {
     extraneousEgressNode: ExtraneousNodeModel;
     extraneousIngressNode: ExtraneousNodeModel;
 } {
@@ -308,7 +308,7 @@ export function createExtraneousNodes(flows?: number): {
             collapsible: false,
             showContextMenu: false,
             type: 'EXTRANEOUS',
-            flows: flows || 0,
+            flows,
         },
     };
     const extraneousIngressNode: ExtraneousNodeModel = {
@@ -322,7 +322,7 @@ export function createExtraneousNodes(flows?: number): {
             collapsible: false,
             showContextMenu: false,
             type: 'EXTRANEOUS',
-            flows: flows || 0,
+            flows,
         },
     };
     return { extraneousEgressNode, extraneousIngressNode };

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/modelUtils.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/modelUtils.tsx
@@ -10,7 +10,7 @@ import {
     ExternalData,
     NamespaceData,
     NamespaceNodeModel,
-    PolicyNodeModel,
+    DeploymentNodeModel,
     ExtraneousNodeModel,
     NetworkPolicyState,
 } from '../types/topology.type';
@@ -23,38 +23,6 @@ function getNameByEntity(entity: NetworkEntityInfo): string {
             return 'External Entities';
         case 'EXTERNAL_SOURCE':
             return entity.externalSource.name;
-        default:
-            return ensureExhaustive(entity);
-    }
-}
-
-function getNetworkPolicyState(policyNode?: PolicyNodeModel): NetworkPolicyState {
-    let networkPolicyState: NetworkPolicyState = 'none';
-    if (policyNode) {
-        const { nonIsolatedEgress, nonIsolatedIngress } = policyNode.data;
-        if (!nonIsolatedIngress && !nonIsolatedEgress) {
-            networkPolicyState = 'both';
-        } else if (nonIsolatedEgress) {
-            networkPolicyState = 'ingress';
-        } else if (nonIsolatedIngress) {
-            networkPolicyState = 'egress';
-        }
-    }
-    return networkPolicyState;
-}
-
-function getDataByEntityType(
-    entity: NetworkEntityInfo,
-    policyIds: string[],
-    policyNode?: PolicyNodeModel
-): CustomNodeData {
-    switch (entity.type) {
-        case 'DEPLOYMENT':
-            return { ...entity, policyIds, networkPolicyState: getNetworkPolicyState(policyNode) };
-        case 'INTERNET':
-            return { ...entity, type: 'EXTERNAL_ENTITIES' };
-        case 'EXTERNAL_SOURCE':
-            return { ...entity, type: 'CIDR_BLOCK' };
         default:
             return ensureExhaustive(entity);
     }
@@ -100,10 +68,31 @@ function getExternalGroupNode(): ExternalNodeModel {
     };
 }
 
+function getDataByEntityType(
+    entity: NetworkEntityInfo,
+    policyIds: string[],
+    networkPolicyState: NetworkPolicyState
+): CustomNodeData {
+    switch (entity.type) {
+        case 'DEPLOYMENT':
+            return {
+                ...entity,
+                policyIds,
+                networkPolicyState,
+            };
+        case 'INTERNET':
+            return { ...entity, type: 'EXTERNAL_ENTITIES' };
+        case 'EXTERNAL_SOURCE':
+            return { ...entity, type: 'CIDR_BLOCK' };
+        default:
+            return ensureExhaustive(entity);
+    }
+}
+
 function getNodeModel(
     entity: NetworkEntityInfo,
     policyIds: string[],
-    policyNode?: PolicyNodeModel
+    networkPolicyState: NetworkPolicyState
 ): CustomNodeModel {
     const node = {
         id: entity.id,
@@ -112,13 +101,13 @@ function getNodeModel(
         height: 75,
         label: getNameByEntity(entity),
     } as CustomNodeModel;
-    node.data = getDataByEntityType(entity, policyIds, policyNode);
+    node.data = getDataByEntityType(entity, policyIds, networkPolicyState);
     return node;
 }
 
 export function transformActiveData(
     nodes: Node[],
-    policyNodeMap: Record<string, PolicyNodeModel>
+    policyNodeMap: Record<string, DeploymentNodeModel>
 ): CustomModel {
     const dataModel = {
         graph: graphModel,
@@ -131,8 +120,9 @@ export function transformActiveData(
 
     nodes.forEach(({ entity, policyIds, outEdges }) => {
         const { type, id } = entity;
+        const { networkPolicyState } = policyNodeMap[id]?.data || {};
         // creating each node and adding to data model
-        const node = getNodeModel(entity, policyIds, policyNodeMap[id]);
+        const node = getNodeModel(entity, policyIds, networkPolicyState);
 
         dataModel.nodes.push(node);
 
@@ -181,14 +171,31 @@ export function transformActiveData(
     return dataModel;
 }
 
+function getNetworkPolicyState(
+    nonIsolatedEgress: boolean,
+    nonIsolatedIngress: boolean
+): NetworkPolicyState {
+    let networkPolicyState: NetworkPolicyState = 'none';
+
+    if (!nonIsolatedIngress && !nonIsolatedEgress) {
+        networkPolicyState = 'both';
+    } else if (nonIsolatedEgress) {
+        networkPolicyState = 'ingress';
+    } else if (nonIsolatedIngress) {
+        networkPolicyState = 'egress';
+    }
+    return networkPolicyState;
+}
+
 export function transformPolicyData(nodes: Node[]): CustomModel {
     const dataModel = {
         graph: graphModel,
         nodes: [] as CustomNodeModel[],
         edges: [] as EdgeModel[],
     };
-    nodes.forEach(({ entity, policyIds, outEdges }) => {
-        const node = getNodeModel(entity, policyIds);
+    nodes.forEach(({ entity, policyIds, outEdges, nonIsolatedEgress, nonIsolatedIngress }) => {
+        const networkPolicyState = getNetworkPolicyState(nonIsolatedEgress, nonIsolatedIngress);
+        const node = getNodeModel(entity, policyIds, networkPolicyState);
         dataModel.nodes.push(node);
 
         // creating edges based off of outEdges per node and adding to data model
@@ -283,7 +290,7 @@ export function createExtraneousFlowsModel(
     return dataModel;
 }
 
-export function createExtraneousNodes(): {
+export function createExtraneousNodes(flows: number): {
     extraneousEgressNode: ExtraneousNodeModel;
     extraneousIngressNode: ExtraneousNodeModel;
 } {
@@ -293,13 +300,11 @@ export function createExtraneousNodes(): {
         width: 75,
         height: 75,
         label: 'Egress flows',
-        // TODO: figure out how to fake group node
-        // group: true,
-        // children: [],
         data: {
             collapsible: false,
             showContextMenu: false,
             type: 'EXTRANEOUS',
+            flows,
         },
     };
     const extraneousIngressNode: ExtraneousNodeModel = {
@@ -308,14 +313,37 @@ export function createExtraneousNodes(): {
         width: 75,
         height: 75,
         label: 'Ingress flows',
-        // TODO: figure out how to fake group node
-        // group: true,
-        // children: [],
         data: {
             collapsible: false,
             showContextMenu: false,
             type: 'EXTRANEOUS',
+            flows,
         },
     };
     return { extraneousEgressNode, extraneousIngressNode };
+}
+
+export function createExtraneousEdges(selectedId: string): {
+    extraneousEgressEdge: EdgeModel;
+    extraneousIngressEdge: EdgeModel;
+} {
+    const extraneousEgressEdge = {
+        id: 'extraneous-egress-edge',
+        type: 'edge',
+        // we will need to set this dynamically using edge.setSource(node)
+        source: selectedId,
+        target: 'extraneous-egress',
+        visible: true,
+        edgeStyle: EdgeStyle.dashed,
+    };
+    const extraneousIngressEdge = {
+        id: 'extraneous-ingress-edge',
+        type: 'edge',
+        source: 'extraneous-ingress',
+        // we will need to set this dynamically using edge.setTarget(node)
+        target: selectedId,
+        visible: true,
+        edgeStyle: EdgeStyle.dashed,
+    };
+    return { extraneousEgressEdge, extraneousIngressEdge };
 }

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/modelUtils.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/modelUtils.tsx
@@ -293,7 +293,7 @@ export function createExtraneousFlowsModel(
     return dataModel;
 }
 
-export function createExtraneousNodes(flows: number): {
+export function createExtraneousNodes(numFlows: number): {
     extraneousEgressNode: ExtraneousNodeModel;
     extraneousIngressNode: ExtraneousNodeModel;
 } {
@@ -308,7 +308,7 @@ export function createExtraneousNodes(flows: number): {
             collapsible: false,
             showContextMenu: false,
             type: 'EXTRANEOUS',
-            flows,
+            numFlows,
         },
     };
     const extraneousIngressNode: ExtraneousNodeModel = {
@@ -322,20 +322,20 @@ export function createExtraneousNodes(flows: number): {
             collapsible: false,
             showContextMenu: false,
             type: 'EXTRANEOUS',
-            flows,
+            numFlows,
         },
     };
     return { extraneousEgressNode, extraneousIngressNode };
 }
 
-export function createExtraneousEdges(selectedId: string): {
+export function createExtraneousEdges(selectedNodeId: string): {
     extraneousEgressEdge: EdgeModel;
     extraneousIngressEdge: EdgeModel;
 } {
     const extraneousEgressEdge = {
         id: 'extraneous-egress-edge',
         type: 'edge',
-        source: selectedId,
+        source: selectedNodeId,
         target: 'extraneous-egress',
         visible: true,
         edgeStyle: EdgeStyle.dashed,
@@ -344,7 +344,7 @@ export function createExtraneousEdges(selectedId: string): {
         id: 'extraneous-ingress-edge',
         type: 'edge',
         source: 'extraneous-ingress',
-        target: selectedId,
+        target: selectedNodeId,
         visible: true,
         edgeStyle: EdgeStyle.dashed,
     };

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/modelUtils.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/modelUtils.tsx
@@ -335,7 +335,6 @@ export function createExtraneousEdges(selectedId: string): {
     const extraneousEgressEdge = {
         id: 'extraneous-egress-edge',
         type: 'edge',
-        // we will need to set this dynamically using edge.setSource(node)
         source: selectedId,
         target: 'extraneous-egress',
         visible: true,
@@ -345,7 +344,6 @@ export function createExtraneousEdges(selectedId: string): {
         id: 'extraneous-ingress-edge',
         type: 'edge',
         source: 'extraneous-ingress',
-        // we will need to set this dynamically using edge.setTarget(node)
         target: selectedId,
         visible: true,
         edgeStyle: EdgeStyle.dashed,

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/modelUtils.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/modelUtils.tsx
@@ -187,7 +187,7 @@ function getNetworkPolicyState(
     return networkPolicyState;
 }
 
-export function transformPolicyData(nodes: Node[]): CustomModel {
+export function transformPolicyData(nodes: Node[], flows?: number): CustomModel {
     const dataModel = {
         graph: graphModel,
         nodes: [] as CustomNodeModel[],
@@ -211,6 +211,9 @@ export function transformPolicyData(nodes: Node[]): CustomModel {
             dataModel.edges.push(edge);
         });
     });
+    const { extraneousEgressNode, extraneousIngressNode } = createExtraneousNodes(flows);
+    dataModel.nodes.push(extraneousEgressNode);
+    dataModel.nodes.push(extraneousIngressNode);
     return dataModel;
 }
 
@@ -290,7 +293,7 @@ export function createExtraneousFlowsModel(
     return dataModel;
 }
 
-export function createExtraneousNodes(flows: number): {
+export function createExtraneousNodes(flows?: number): {
     extraneousEgressNode: ExtraneousNodeModel;
     extraneousIngressNode: ExtraneousNodeModel;
 } {
@@ -300,11 +303,12 @@ export function createExtraneousNodes(flows: number): {
         width: 75,
         height: 75,
         label: 'Egress flows',
+        visible: false,
         data: {
             collapsible: false,
             showContextMenu: false,
             type: 'EXTRANEOUS',
-            flows,
+            flows: flows || 0,
         },
     };
     const extraneousIngressNode: ExtraneousNodeModel = {
@@ -313,11 +317,12 @@ export function createExtraneousNodes(flows: number): {
         width: 75,
         height: 75,
         label: 'Ingress flows',
+        visible: false,
         data: {
             collapsible: false,
             showContextMenu: false,
             type: 'EXTRANEOUS',
-            flows,
+            flows: flows || 0,
         },
     };
     return { extraneousEgressNode, extraneousIngressNode };

--- a/ui/apps/platform/src/hooks/useFetchDeploymentCount.ts
+++ b/ui/apps/platform/src/hooks/useFetchDeploymentCount.ts
@@ -1,8 +1,14 @@
 import { useState, useEffect } from 'react';
-import { gql, useQuery } from '@apollo/client';
+import { gql, useQuery, ApolloError } from '@apollo/client';
 
 type DeploymentCountResponse = {
     count: number;
+};
+
+type UseFetchDeploymentCount = {
+    loading: boolean;
+    error: ApolloError | undefined;
+    deploymentCount: number | undefined;
 };
 
 const DEPLOYMENT_COUNT_FOR_CLUSTER = gql`
@@ -11,7 +17,7 @@ const DEPLOYMENT_COUNT_FOR_CLUSTER = gql`
     }
 `;
 
-function useFetchDeploymentCount(selectedClusterId: string) {
+function useFetchDeploymentCount(selectedClusterId: string): UseFetchDeploymentCount {
     const [deploymentCount, setDeploymentCount] = useState<number>();
 
     // If the selectedClusterId has not been set yet, do not run the gql query

--- a/ui/apps/platform/src/hooks/useFetchDeploymentCount.ts
+++ b/ui/apps/platform/src/hooks/useFetchDeploymentCount.ts
@@ -1,0 +1,42 @@
+import { useState, useEffect } from 'react';
+import { gql, useQuery } from '@apollo/client';
+
+type DeploymentCountResponse = {
+    count: number;
+};
+
+const DEPLOYMENT_COUNT_FOR_CLUSTER = gql`
+    query deployments($query: String) {
+        count: deploymentCount(query: $query)
+    }
+`;
+
+function useFetchDeploymentCount(selectedClusterId: string) {
+    const [deploymentCount, setDeploymentCount] = useState<number>();
+
+    // If the selectedClusterId has not been set yet, do not run the gql query
+    const queryOptions = selectedClusterId
+        ? { variables: { id: selectedClusterId } }
+        : { skip: true };
+
+    const { loading, error, data } = useQuery<DeploymentCountResponse, { id: string }>(
+        DEPLOYMENT_COUNT_FOR_CLUSTER,
+        queryOptions
+    );
+
+    useEffect(() => {
+        if (!data || !data.count) {
+            return;
+        }
+
+        setDeploymentCount(data.count);
+    }, [data]);
+
+    return {
+        loading,
+        error,
+        deploymentCount,
+    };
+}
+
+export default useFetchDeploymentCount;


### PR DESCRIPTION
as title states above -- created a FakeGroup style of node to emulate the DefaultGroup style. it should look like the regular grouped node, just collapsed. the count next to the node should reflect the total deployment in the selected cluster. 

<img width="811" alt="image" src="https://user-images.githubusercontent.com/10412893/207241537-3bdb267a-d887-421a-b6b9-d509d14a1f43.png">

fwiw i also refactored some of the rendering logic in the `modelUtils.ts` file and also in `NetworkGraph.ts` to simplify the conditional rendering logic required for the extraneous flows node.
