### PR TITLE
ROX-13671: Add API users to the tenant group

### DIFF
--- a/pkg/telemetry/phonehome/hash.go
+++ b/pkg/telemetry/phonehome/hash.go
@@ -9,9 +9,8 @@ import (
 )
 
 func hash(id string) string {
-	sha := sha256.New()
-	_, _ = sha.Write([]byte(id))
-	return base64.StdEncoding.EncodeToString(sha.Sum(nil))
+	h := sha256.Sum256([]byte(id))
+	return base64.StdEncoding.EncodeToString(h[:])
 }
 
 // HashUserID anonymizes user ID so that it can be sent to the external

--- a/pkg/telemetry/phonehome/hash_test.go
+++ b/pkg/telemetry/phonehome/hash_test.go
@@ -39,3 +39,8 @@ func TestConfig_HashUserAuthID(t *testing.T) {
 	h = cfg.HashUserAuthID(id)
 	assert.Equal(t, hash("test-client:test-provider:test-id"), h)
 }
+
+func TestConfig_HashAdminUserID(t *testing.T) {
+	admin := "2a3e1829-8f84-40c1-a761-006f07a59666:4df1b98c-24ed-4073-a9ad-356aec6bb62d:admin"
+	assert.Equal(t, "+5GOIqkMuJMFDqJcMKvAGvbSRtCUjqdCB+UeU1hOqQA=", hash(admin))
+}


### PR DESCRIPTION
## Description

Adding users to the tenant (or central) group on login.
The default admin user (basic auth provider) is added by central on startup (#4072).

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

Testing a user of a SAML auth provider issues this event:
```json
{
  "context": {
    "Client ID": "2a3e1829-8f84-40c1-a761-006f07a59666",
    "Client Name": "Central",
    "library": {
      "name": "analytics-go",
      "version": "3.0.0"
    }
  },
  "groupId": "2a3e1829-8f84-40c1-a761-006f07a59666",
  "integrations": {},
  "messageId": "71d7d862-6cc9-44b9-af9c-53b726079137",
  "originalTimestamp": "2022-12-13T19:37:02.434248064Z",
  "receivedAt": "2022-12-13T19:37:40.541Z",
  "sentAt": "2022-12-13T19:37:39.713Z",
  "timestamp": "2022-12-13T19:37:03.262Z",
  "traits": null,
  "type": "group",
  "userId": "6LKgjQNIVQHJUSK/Lr5T/KAI/tnJ1IQ1P7idLQRJhl8=",
  "writeKey": "..."
}
```