### PR TITLE
Run style action on PRs, tags and master

### DIFF
--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -1,11 +1,9 @@
 name: Style
 on:
+  push:
+    branches:
+      - master
   pull_request:
-    types:
-    - labeled
-    - opened
-    - reopened
-    - synchronize
 
 env:
   ROX_PRODUCT_BRANDING: RHACS_BRANDING

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -1,8 +1,11 @@
 name: Style
 on:
   push:
+    tags:
+       - '*'
     branches:
       - master
+      - release-*
   pull_request:
 
 env:


### PR DESCRIPTION
## Description

Currently we are running style action only on PRs. This is suboptimal as cache is not populated by master branch. This change enables `style` on all PRs and pushes to master
