### PR TITLE
ROX-13820: Change cert validation error to a warn

### DIFF
--- a/roxctl/common/tls.go
+++ b/roxctl/common/tls.go
@@ -41,7 +41,7 @@ func (v *insecureVerifierWithWarning) VerifyPeerCertificate(leaf *x509.Certifica
 	if err != nil {
 		v.printWarningOnce.Do(func() {
 			v.logger.WarnfLn(warningMsg)
-			v.logger.ErrfLn("Certificate validation error: %v", err)
+			v.logger.WarnfLn("Certificate validation error: %v", err)
 		})
 	}
 	return nil


### PR DESCRIPTION
## Description

CI uses `roxctl` a lot in various test scenarios and often (always?) with invalid certs. This logs `ERROR:	Certificate validation error:` which is then highlighted in the prow build.log and stands out when people try to triage failures, leading to a log of confusion (ROX-11454 and more).

This PR changes the `ERROR:` to a `WARN:`. Ideally we would change prow to not highlight anything with `ERROR:` in it. But convincing the OpenShift team that that is a good idea is a [WIP](https://github.com/openshift/release/pull/34672#issuecomment-1349191490). Changing roxctl seems reasonable to me.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

CI is sufficient