### PR TITLE
ROX-13875: Handle GKE create timeout

### DIFF
--- a/scripts/ci/gke.sh
+++ b/scripts/ci/gke.sh
@@ -132,7 +132,7 @@ create_cluster() {
         gcloud config set compute/zone "${zone}"
         status=0
         # shellcheck disable=SC2153
-        timeout 630 gcloud beta container clusters create \
+        timeout 200 gcloud beta container clusters create \
             --machine-type "${MACHINE_TYPE}" \
             --num-nodes "${NUM_NODES}" \
             --disk-type=pd-standard \
@@ -169,6 +169,10 @@ create_cluster() {
 
             if [[ "${success}" == 1 ]]; then
                 info "Successfully launched cluster ${CLUSTER_NAME}"
+                local kubeconfig="${KUBECONFIG:-${HOME}/.kube/config}"
+                ls -l "${kubeconfig}" || true
+                gcloud container clusters get-credentials "$CLUSTER_NAME"
+                ls -l "${kubeconfig}" || true
                 break
             fi
             info "Timed out"

--- a/scripts/ci/gke.sh
+++ b/scripts/ci/gke.sh
@@ -132,7 +132,7 @@ create_cluster() {
         gcloud config set compute/zone "${zone}"
         status=0
         # shellcheck disable=SC2153
-        timeout 200 gcloud beta container clusters create \
+        timeout 630 gcloud beta container clusters create \
             --machine-type "${MACHINE_TYPE}" \
             --num-nodes "${NUM_NODES}" \
             --disk-type=pd-standard \


### PR DESCRIPTION
## Description

A number of recent GKE E2e test failures indicate that the gcloud command timed out. The code that handles this timeout does not attempt to procure the KUBECONFIG when the cluster was indeed created.

https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/branch-ci-stackrox-stackrox-nightlies-gke-ui-e2e-tests/1602168949057785856
https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/branch-ci-stackrox-stackrox-master-merge-gke-ui-e2e-tests/1602247960660283392
https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/branch-ci-stackrox-stackrox-master-merge-gke-postgres-upgrade-tests/1602243246824624128

```
INFO: Mon Dec 12 05:38:46 UTC 2022: gcloud command timed out. Checking to see if cluster is still creating
```
This PR ensures that the cluster KUBECONFIG is populated in this timeout case.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

- [x] run with a shortened timeout, expect the cluster to create asynchronously and the KUBECONFIG to be populated for the rest of the test. [[1]](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/stackrox_stackrox/4138/pull-ci-stackrox-stackrox-master-gke-qa-e2e-tests/1602900931827994624/artifacts/gke-qa-e2e-tests/stackrox-e2e/build-log.txt)