### PR TITLE
Dashrews/ROX-13102 Telemetry gatherer was using rocks/bolt on startup and no gatherer for Postgres

### DIFF
--- a/central/telemetry/gatherers/central.go
+++ b/central/telemetry/gatherers/central.go
@@ -49,7 +49,7 @@ func (c *CentralGatherer) Gather(ctx context.Context) *data.CentralInfo {
 		// Despite GoLand's warning it's okay for installationInfo to be nil, GetID() will return ""
 		ID:                 installationInfo.GetId(),
 		InstallationTime:   telemetry.GetTimeOrNil(installationInfo.GetCreated()),
-		Storage:            c.databaseGatherer.Gather(),
+		Storage:            c.databaseGatherer.Gather(ctx),
 		APIStats:           c.apiGatherer.Gather(),
 		Errors:             errList,
 		AutoUpgradeEnabled: autoUpgradeEnabled.GetEnableAutoUpgrade(),

--- a/central/telemetry/gatherers/database.go
+++ b/central/telemetry/gatherers/database.go
@@ -1,6 +1,9 @@
 package gatherers
 
 import (
+	"context"
+
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/errorhelpers"
 	"github.com/stackrox/rox/pkg/fsutils"
 	"github.com/stackrox/rox/pkg/migrations"
@@ -8,21 +11,23 @@ import (
 )
 
 type databaseGatherer struct {
-	bolt  *boltGatherer
-	bleve *bleveGatherer
-	rocks *rocksdbGatherer
+	bolt     *boltGatherer
+	bleve    *bleveGatherer
+	rocks    *rocksdbGatherer
+	postgres *postgresGatherer
 }
 
-func newDatabaseGatherer(rocks *rocksdbGatherer, bolt *boltGatherer, bleve *bleveGatherer) *databaseGatherer {
+func newDatabaseGatherer(rocks *rocksdbGatherer, bolt *boltGatherer, bleve *bleveGatherer, postgres *postgresGatherer) *databaseGatherer {
 	return &databaseGatherer{
-		bolt:  bolt,
-		bleve: bleve,
-		rocks: rocks,
+		bolt:     bolt,
+		bleve:    bleve,
+		rocks:    rocks,
+		postgres: postgres,
 	}
 }
 
 // Gather returns a list of stats about all the databases this Central is using
-func (d *databaseGatherer) Gather() *data.StorageInfo {
+func (d *databaseGatherer) Gather(ctx context.Context) *data.StorageInfo {
 	errList := errorhelpers.NewErrorList("")
 	capacity, used, err := fsutils.DiskStatsIn(migrations.DBMountPath())
 	errList.AddError(err)
@@ -31,15 +36,18 @@ func (d *databaseGatherer) Gather() *data.StorageInfo {
 		DiskCapacityBytes: int64(capacity),
 		DiskUsedBytes:     int64(used),
 		StorageType:       "unknown", // TODO: Figure out how to determine storage type (pvc etc.)
-		Databases: []*data.DatabaseStats{
-			d.bolt.Gather(),
-		},
-		Errors: errList.ErrorStrings(),
+		Databases:         []*data.DatabaseStats{},
+		Errors:            errList.ErrorStrings(),
 	}
 
-	storageInfo.Databases = append(storageInfo.Databases, d.rocks.Gather())
-	databaseStats := d.bleve.Gather()
-	storageInfo.Databases = append(storageInfo.Databases, databaseStats...)
+	if env.PostgresDatastoreEnabled.BooleanSetting() {
+		storageInfo.Databases = append(storageInfo.Databases, d.postgres.Gather(ctx))
+	} else {
+		storageInfo.Databases = append(storageInfo.Databases, d.bolt.Gather())
+		storageInfo.Databases = append(storageInfo.Databases, d.rocks.Gather())
+		databaseStats := d.bleve.Gather()
+		storageInfo.Databases = append(storageInfo.Databases, databaseStats...)
+	}
 
 	return storageInfo
 }

--- a/central/telemetry/gatherers/postgres.go
+++ b/central/telemetry/gatherers/postgres.go
@@ -1,0 +1,54 @@
+package gatherers
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v4/pgxpool"
+	"github.com/stackrox/rox/central/globaldb"
+	"github.com/stackrox/rox/pkg/errorhelpers"
+	"github.com/stackrox/rox/pkg/migrations"
+	"github.com/stackrox/rox/pkg/postgres/pgadmin"
+	"github.com/stackrox/rox/pkg/postgres/pgconfig"
+	"github.com/stackrox/rox/pkg/telemetry/data"
+)
+
+type postgresGatherer struct {
+	db *pgxpool.Pool
+}
+
+func newPostgresGatherer(db *pgxpool.Pool) *postgresGatherer {
+	return &postgresGatherer{
+		db: db,
+	}
+}
+
+// Gather returns telemetry information about the Postgres database used by this central
+func (d *postgresGatherer) Gather(ctx context.Context) *data.DatabaseStats {
+	errorList := errorhelpers.NewErrorList("postgres telemetry gather")
+	// Get Postgres config data
+	_, adminConfig, err := pgconfig.GetPostgresConfig()
+	errorList.AddError(err)
+
+	currentDBBytes, err := pgadmin.GetDatabaseSize(adminConfig, migrations.GetCurrentClone())
+	errorList.AddError(err)
+
+	tableStats := globaldb.CollectPostgresStats(ctx, globaldb.GetPostgres())
+
+	dbStats := &data.DatabaseStats{
+		Type:      "postgres",
+		UsedBytes: currentDBBytes,
+		Tables:    tableStats,
+		Errors:    errorList.ErrorStrings(),
+	}
+
+	// Check Postgres remaining capacity
+	availableDBBytes, err := pgadmin.GetRemainingCapacity(adminConfig)
+	errorList.AddError(err)
+
+	// In RDS or BYOBD configurations we may not be able to calculate this.
+	if availableDBBytes > 0 {
+		dbStats.AvailableBytes = availableDBBytes
+	}
+
+	return dbStats
+}

--- a/central/telemetry/gatherers/singleton.go
+++ b/central/telemetry/gatherers/singleton.go
@@ -1,6 +1,8 @@
 package gatherers
 
 import (
+	"github.com/pkg/errors"
+
 	clusterDatastore "github.com/stackrox/rox/central/cluster/datastore"
 	depDatastore "github.com/stackrox/rox/central/deployment/datastore"
 	"github.com/stackrox/rox/central/globaldb"
@@ -12,8 +14,10 @@ import (
 	"github.com/stackrox/rox/central/sensor/service/connection"
 	sensorUpgradeConfigDatastore "github.com/stackrox/rox/central/sensorupgradeconfig/datastore"
 	"github.com/stackrox/rox/pkg/env"
+	"github.com/stackrox/rox/pkg/postgres/pgconfig"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/pkg/telemetry/gatherers"
+	"github.com/stackrox/rox/pkg/utils"
 )
 
 var (
@@ -24,57 +28,49 @@ var (
 // Singleton initializes and returns a RoxGatherer singleton
 func Singleton() *RoxGatherer {
 	gathererInit.Do(func() {
+		var dbGatherer *databaseGatherer
+
 		if env.PostgresDatastoreEnabled.BooleanSetting() {
-			gatherer = newRoxGatherer(
-				newCentralGatherer(
-					installation.Singleton(),
-					newDatabaseGatherer(
-						nil,
-						nil,
-						nil,
-						newPostgresGatherer(globaldb.GetPostgres()),
-					),
-					newAPIGatherer(metrics.GRPCSingleton(), metrics.HTTPSingleton()),
-					gatherers.NewComponentInfoGatherer(),
-					sensorUpgradeConfigDatastore.Singleton(),
-				),
-				newClusterGatherer(
-					clusterDatastore.Singleton(),
-					nodeDatastore.Singleton(),
-					namespaceDatastore.Singleton(),
-					connection.ManagerSingleton(),
-					depDatastore.Singleton(),
-				),
+			_, adminConfig, err := pgconfig.GetPostgresConfig()
+			utils.CrashOnError(errors.Wrap(err, "unable to get Postgres config"))
+
+			dbGatherer = newDatabaseGatherer(
+				nil,
+				nil,
+				nil,
+				newPostgresGatherer(globaldb.GetPostgres(), adminConfig),
 			)
 		} else {
-			gatherer = newRoxGatherer(
-				newCentralGatherer(
-					installation.Singleton(),
-					newDatabaseGatherer(
-						newRocksDBGatherer(globaldb.GetRocksDB()),
-						newBoltGatherer(globaldb.GetGlobalDB()),
-						newBleveGatherer(
-							globalindex.GetGlobalIndex(),
-							globalindex.GetGlobalTmpIndex(),
-							globalindex.GetAlertIndex(),
-							globalindex.GetPodIndex(),
-							globalindex.GetProcessIndex(),
-						),
-						nil,
-					),
-					newAPIGatherer(metrics.GRPCSingleton(), metrics.HTTPSingleton()),
-					gatherers.NewComponentInfoGatherer(),
-					sensorUpgradeConfigDatastore.Singleton(),
+			dbGatherer = newDatabaseGatherer(
+				newRocksDBGatherer(globaldb.GetRocksDB()),
+				newBoltGatherer(globaldb.GetGlobalDB()),
+				newBleveGatherer(
+					globalindex.GetGlobalIndex(),
+					globalindex.GetGlobalTmpIndex(),
+					globalindex.GetAlertIndex(),
+					globalindex.GetPodIndex(),
+					globalindex.GetProcessIndex(),
 				),
-				newClusterGatherer(
-					clusterDatastore.Singleton(),
-					nodeDatastore.Singleton(),
-					namespaceDatastore.Singleton(),
-					connection.ManagerSingleton(),
-					depDatastore.Singleton(),
-				),
+				nil,
 			)
 		}
+
+		gatherer = newRoxGatherer(
+			newCentralGatherer(
+				installation.Singleton(),
+				dbGatherer,
+				newAPIGatherer(metrics.GRPCSingleton(), metrics.HTTPSingleton()),
+				gatherers.NewComponentInfoGatherer(),
+				sensorUpgradeConfigDatastore.Singleton(),
+			),
+			newClusterGatherer(
+				clusterDatastore.Singleton(),
+				nodeDatastore.Singleton(),
+				namespaceDatastore.Singleton(),
+				connection.ManagerSingleton(),
+				depDatastore.Singleton(),
+			),
+		)
 	})
 	return gatherer
 }

--- a/pkg/telemetry/data/central.go
+++ b/pkg/telemetry/data/central.go
@@ -54,13 +54,24 @@ type BucketStats struct {
 	Cardinality int    `json:"cardinality"`
 }
 
+// TableStats contains telemetry data about a DB table
+type TableStats struct {
+	Name      string `json:"name"`
+	RowCount  int64  `json:"rowCount"`
+	TableSize int64  `json:"tableSize"`
+	IndexSize int64  `json:"indexSize"`
+	ToastSize int64  `json:"toastSize"`
+}
+
 // DatabaseStats contains telemetry data about a DB
 type DatabaseStats struct {
-	Type      string         `json:"type"`
-	Path      string         `json:"path"`
-	UsedBytes int64          `json:"usedBytes"`
-	Buckets   []*BucketStats `json:"buckets,omitempty"`
-	Errors    []string       `json:"errors,omitempty"`
+	Type           string         `json:"type"`
+	Path           string         `json:"path"`
+	AvailableBytes int64          `json:"availableBytes"`
+	UsedBytes      int64          `json:"usedBytes"`
+	Buckets        []*BucketStats `json:"buckets,omitempty"`
+	Tables         []*TableStats  `json:"tables,omitempty"`
+	Errors         []string       `json:"errors,omitempty"`
 }
 
 // StorageInfo contains telemetry data about available disk, storage type, and the available databases


### PR DESCRIPTION
## Description

The diagnostics that gathered telemetry data was always using legacy databases which could cause potential consistency issues as those databases are phased out and the PVC is remove.  Furthermore, the telemetry-data in the diagnostic bundle did not contain Postgres stats as the gatherers were only pulling data for the legacy databases.  This PR updates it such that the gatherers pull data for Postgres if enabled and only initialize the legacy gatherers if postgres is not enabled.

It should be noted that Postgres metrics were already being written to prometheus.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Updated the test to run with Postgres if enabled.
