### PR TITLE
Dashrews/ROX-13103 move v1 db/restore api route to legacy DB only routes

### DIFF
--- a/central/main.go
+++ b/central/main.go
@@ -616,11 +616,6 @@ func customRoutes() (customRoutes []routes.CustomRoute) {
 			Compression:   true,
 		},
 		{
-			Route:         "/db/restore",
-			Authorizer:    dbAuthz.DBWriteAccessAuthorizer(),
-			ServerHandler: globaldbHandlers.RestoreDB(globaldb.GetGlobalDB(), globaldb.GetRocksDB()),
-		},
-		{
 			Route:         "/api/docs/swagger",
 			Authorizer:    user.With(permissions.View(resources.Integration)),
 			ServerHandler: docs.Swagger(),
@@ -729,6 +724,13 @@ func customRoutes() (customRoutes []routes.CustomRoute) {
 			Authorizer:    user.WithRole(role.Admin),
 			ServerHandler: notImplementedOnManagedServices(globaldbHandlers.BackupDB(globaldb.GetGlobalDB(), globaldb.GetRocksDB(), nil, true)),
 			Compression:   true,
+		})
+
+		// v1 style restore endpoint, not supported for Postgres
+		customRoutes = append(customRoutes, routes.CustomRoute{
+			Route:         "/db/restore",
+			Authorizer:    dbAuthz.DBWriteAccessAuthorizer(),
+			ServerHandler: globaldbHandlers.RestoreDB(globaldb.GetGlobalDB(), globaldb.GetRocksDB()),
 		})
 	}
 


### PR DESCRIPTION
## Description

the V1 restore api `db/restore` does not support Postgres.  It only supports legacy databases.  So when building the custom routes we need to ensure that it only exists in the legacy databases.  This will ensure that it does not try to gain a connection to the legacy databases when they do not exist.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
