### PR TITLE
Move helpers and selectors into same subfolder as clusters integration tests

### DIFF
--- a/ui/apps/platform/cypress/constants/apiEndpoints.js
+++ b/ui/apps/platform/cypress/constants/apiEndpoints.js
@@ -50,11 +50,7 @@ export const alerts = {
 };
 
 export const clusters = {
-    single: 'v1/clusters/**',
     list: 'v1/clusters',
-    clusterDefaults: '/v1/cluster-defaults',
-    sensorUpgradesConfig: '/v1/sensorupgrades/config',
-    zip: 'api/extensions/clusters/zip',
 };
 
 export const risks = {

--- a/ui/apps/platform/cypress/helpers/main.js
+++ b/ui/apps/platform/cypress/helpers/main.js
@@ -80,3 +80,18 @@ export function visitMainDashboard(staticResponseMap) {
     cy.get(`.pf-c-nav__link.pf-m-current:contains("${title}")`);
     cy.get(`h1:contains("${title}")`);
 }
+
+/**
+ * @param {{data: Record<string, number>}} staticResponseForSummaryCounts
+ */
+export function visitMainDashboardWithStaticResponseForSummaryCounts(
+    staticResponseForSummaryCounts
+) {
+    // Omit requests for widgets in case Dashboard redirects to Clusters page.
+    const staticResponseMapForSummaryCounts = {
+        [summaryCountsOpname]: staticResponseForSummaryCounts,
+    };
+    visit(basePath, routeMatcherMapForSummaryCounts, staticResponseMapForSummaryCounts);
+
+    cy.get(`h1:contains("${title}")`);
+}

--- a/ui/apps/platform/cypress/helpers/main.js
+++ b/ui/apps/platform/cypress/helpers/main.js
@@ -87,11 +87,11 @@ export function visitMainDashboard(staticResponseMap) {
 export function visitMainDashboardWithStaticResponseForSummaryCounts(
     staticResponseForSummaryCounts
 ) {
-    // Omit requests for widgets in case Dashboard redirects to Clusters page.
+    // Omit requests for widgets because Dashboard redirects to Clusters page.
     const staticResponseMapForSummaryCounts = {
         [summaryCountsOpname]: staticResponseForSummaryCounts,
     };
     visit(basePath, routeMatcherMapForSummaryCounts, staticResponseMapForSummaryCounts);
 
-    cy.get(`h1:contains("${title}")`);
+    // Omit assertion for Dashboard heading.
 }

--- a/ui/apps/platform/cypress/integration/clusters/Clusters.selectors.js
+++ b/ui/apps/platform/cypress/integration/clusters/Clusters.selectors.js
@@ -1,37 +1,12 @@
-import scopeSelectors from '../helpers/scopeSelectors';
-
-export const clustersUrl = '/main/clusters';
+import scopeSelectors from '../../helpers/scopeSelectors';
 
 export const selectors = {
-    configure: 'ul.pf-c-nav__list li button:contains("Platform Configuration")',
-    navLink: 'ul.pf-c-nav__list li a.pf-c-nav__link:contains("Clusters")',
-    clustersListHeading: 'h1:contains("Clusters")',
-    clusterSidePanelHeading: '[data-testid="clusters-side-panel-header"]',
-    autoUpgradeInput: '[id="enableAutoUpgrade"]',
     clusters: scopeSelectors('[data-testid="clusters-table"]', {
         // Ignore the first checkbox column and last delete column.
-        tableHeadingCell: '.rt-th:not(:first-child):not(.hidden)',
         tableDataCell: '.rt-tr-group:not(.hidden) .rt-td:not(:first-child):not(.hidden)',
-        tableRowGroup: '.rt-tr-group:not(.hidden)',
-        k8sCluster0: 'div.rt-td:contains("Kubernetes Cluster 0")',
     }),
-    buttons: {
-        new: 'button:contains("New")',
-        next: 'button:contains("Next")',
-        downloadYAML: 'button:contains("Download YAML")',
-        delete: 'button:contains("Delete")',
-        test: 'button:contains("Test")',
-        create: 'button:contains("Create")',
-        cancelDelete: '.dialog button:contains("Cancel")',
-        confirmDelete: '.dialog button:contains("Delete")',
-        generate: 'button:contains("Generate"):not([disabled])',
-        revoke: 'button:contains("Revoke")',
-        closePanel: 'button[data-testid="cancel"]',
-    },
     clusterForm: scopeSelectors('[data-testid="cluster-form"]', {
         nameInput: 'input[name="name"]',
-        imageInput: 'input[name="mainImage"]',
-        endpointInput: 'input[name="centralApiEndpoint"]',
     }),
     clusterHealth: scopeSelectors('[data-testid="clusters-side-panel"]', {
         clusterStatus: '[data-testid="clusterStatus"]',
@@ -60,7 +35,4 @@ export const selectors = {
         upgradeToReissueCertificate: '[data-testid="upgradeToReissueCertificate"]',
         upgradedToReissueCertificate: '[data-testid="upgradedToReissueCertificate"]',
     }),
-    dialog: '.dialog',
-    checkboxes: 'input[data-testid="checkbox-table-row-selector"',
-    sidePanel: '[data-testid="clusters-side-panel"]',
 };

--- a/ui/apps/platform/cypress/integration/clusters/clusterDeletion.test.js
+++ b/ui/apps/platform/cypress/integration/clusters/clusterDeletion.test.js
@@ -1,7 +1,12 @@
-import { selectors } from '../../constants/ClustersPage';
 import withAuth from '../../helpers/basicAuth';
 import { hasFeatureFlag } from '../../helpers/features';
-import { visitClusterById, visitClusters, visitClustersWithFixture } from '../../helpers/clusters';
+
+import {
+    assertClusterNameInSidePanel,
+    visitClusterById,
+    visitClusters,
+    visitClustersWithFixture,
+} from './Clusters.helpers';
 
 describe('Clusters list clusterIdToRetentionInfo', () => {
     withAuth();
@@ -17,7 +22,7 @@ describe('Clusters list clusterIdToRetentionInfo', () => {
     it('should display Cluster Deletion column', () => {
         visitClusters();
 
-        cy.get(`${selectors.clusters.tableHeadingCell}:contains("Cluster Deletion")`);
+        cy.get(`.rt-th:contains("Cluster Deletion")`);
     });
 
     // .rt-td:nth(6) because [data-testid="clusterDeletion"] fails for unknown reason :(
@@ -52,7 +57,7 @@ describe('Cluster page clusterRetentionInfo', () => {
 
         const clusterName = 'remote';
         cy.get(`[data-testid="cluster-name"]:contains("${clusterName}")`).click();
-        cy.get(`${selectors.clusterSidePanelHeading}:contains("${clusterName}")`);
+        assertClusterNameInSidePanel(clusterName);
         cy.get('div:contains("Cluster Deletion"):contains("Not applicable")');
     });
 
@@ -67,7 +72,7 @@ describe('Cluster page clusterRetentionInfo', () => {
                 cluster: { body: { cluster, clusterRetentionInfo } },
             });
 
-            cy.get(selectors.clusterSidePanelHeading).contains(clusterName);
+            assertClusterNameInSidePanel(clusterName);
         });
     }
 

--- a/ui/apps/platform/cypress/integration/clusters/clusterDeletion.test.js
+++ b/ui/apps/platform/cypress/integration/clusters/clusterDeletion.test.js
@@ -3,6 +3,7 @@ import { hasFeatureFlag } from '../../helpers/features';
 
 import {
     assertClusterNameInSidePanel,
+    clusterAlias,
     visitClusterById,
     visitClusters,
     visitClustersWithFixture,
@@ -67,10 +68,11 @@ describe('Cluster page clusterRetentionInfo', () => {
     function visitClusterWithRetentionInfo(clusterRetentionInfo) {
         cy.fixture(fixturePath).then(({ clusters }) => {
             const cluster = clusters.find(({ name }) => name === clusterName);
+            const staticResponseMap = {
+                [clusterAlias]: { body: { cluster, clusterRetentionInfo } },
+            };
 
-            visitClusterById(cluster.id, {
-                cluster: { body: { cluster, clusterRetentionInfo } },
-            });
+            visitClusterById(cluster.id, staticResponseMap);
 
             assertClusterNameInSidePanel(clusterName);
         });

--- a/ui/apps/platform/cypress/integration/clusters/clusters.test.js
+++ b/ui/apps/platform/cypress/integration/clusters/clusters.test.js
@@ -23,7 +23,7 @@ describe('Clusters', () => {
         cy.title().should('match', getRegExpForTitleWithBranding('Clusters'));
 
         cy.get('.rt-th:contains("Name")');
-        cy.get('.rt-th:contains("Cloud Provider"');
+        cy.get('.rt-th:contains("Cloud Provider")');
         cy.get('.rt-th:contains("Cluster Status")');
         cy.get('.rt-th:contains("Sensor Upgrade")');
         cy.get('.rt-th:contains("Credential Expiration")');

--- a/ui/apps/platform/cypress/integration/clusters/clusters.test.js
+++ b/ui/apps/platform/cypress/integration/clusters/clusters.test.js
@@ -1,198 +1,33 @@
-import cloneDeep from 'lodash/cloneDeep';
-
-import { clustersUrl, selectors } from '../../constants/ClustersPage';
-import { clusters as clustersApi } from '../../constants/apiEndpoints';
 import withAuth from '../../helpers/basicAuth';
-import {
-    visitClusters,
-    visitClustersFromLeftNav,
-    visitClustersWithFixtureMetadataDatetime,
-    visitClusterByNameWithFixture,
-    visitClusterByNameWithFixtureMetadataDatetime,
-    visitDashboardWithNoClusters,
-} from '../../helpers/clusters';
-import { hasFeatureFlag } from '../../helpers/features';
 import { getRegExpForTitleWithBranding } from '../../helpers/title';
 
-describe('Clusters page', () => {
+import { visitClusters, visitClustersFromLeftNav } from './Clusters.helpers';
+import { selectors } from './Clusters.selectors';
+
+describe('Clusters', () => {
     withAuth();
 
-    describe('smoke tests', () => {
-        it('should be linked in the Platform Configuration menu', () => {
-            visitClustersFromLeftNav();
-        });
-
-        it('should have a toggle control for the auto-upgrade setting', () => {
-            visitClusters();
-
-            cy.get(selectors.autoUpgradeInput);
-        });
-
-        it('should display title and columns expected in clusters list page', () => {
-            visitClusters();
-
-            cy.title().should('match', getRegExpForTitleWithBranding('Clusters'));
-
-            [
-                'Name',
-                'Cloud Provider',
-                'Cluster Status',
-                'Sensor Upgrade',
-                'Credential Expiration',
-                // Cluster Deletion: see clusterDeletion.test.js
-            ].forEach((heading, index) => {
-                /*
-                 * Important: nth is pseudo selector for zero-based index of matching cells.
-                 * Do not use the one-based nth-child selector,
-                 * because tableHeadingCell does not match cells which have first-child and hidden class.
-                 */
-                cy.get(
-                    `${selectors.clusters.tableHeadingCell}:nth(${index}):contains("${heading}")`
-                );
-            });
-        });
+    it('should visit via link in left nav', () => {
+        visitClustersFromLeftNav();
     });
 
-    describe('when no secured clusters are added yet (only applies to Cloud Service)', () => {
-        it('should should redirect to the Clusters page', () => {
-            visitDashboardWithNoClusters();
+    it('should have a toggle control for the auto-upgrade setting', () => {
+        visitClusters();
 
-            cy.url().should('contain', `${clustersUrl}`);
-
-            cy.get(selectors.clustersListHeading);
-
-            cy.get(
-                'p:contains("You have successfully deployed a Red Hat Advanced Cluster Security platform.")'
-            );
-
-            cy.get('h2:contains("Configure the clusters you want to secure.")');
-
-            cy.get('a:contains("View instructions")');
-        });
-    });
-});
-
-describe('Cluster Certificate Expiration', () => {
-    withAuth();
-
-    const fixturePath = 'clusters/health.json';
-
-    const metadata = {
-        version: '3.0.50.0', // for comparison to `sensorVersion` in clusters fixture
-        buildFlavor: 'release',
-        releaseBuild: true,
-        licenseStatus: 'VALID',
-    };
-
-    // For comparison to `lastContact` and `sensorCertExpiry` in clusters fixture.
-    const currentDatetime = new Date('2020-08-31T13:01:00Z');
-
-    describe('Credential Expiration status is Healthy', () => {
-        it('should not show link or form', () => {
-            const clusterName = 'kappa-kilogramme-10';
-            visitClusterByNameWithFixtureMetadataDatetime(
-                clusterName,
-                fixturePath,
-                metadata,
-                currentDatetime
-            );
-
-            cy.get(selectors.clusterHealth.credentialExpiration).should('have.text', 'in 1 month');
-            cy.get(selectors.clusterHealth.reissueCertificatesLink).should('not.exist');
-            cy.get(selectors.clusterHealth.downloadToReissueCertificate).should('not.exist');
-            cy.get(selectors.clusterHealth.upgradeToReissueCertificate).should('not.exist');
-            cy.get(selectors.clusterHealth.reissueCertificateButton).should('not.exist');
-        });
+        cy.get('[id="enableAutoUpgrade"]');
     });
 
-    describe('Sensor is not up to date with Central', () => {
-        const expectedExpiration = 'in 6 days on Monday'; // Unhealthy
+    it('should display title and columns expected in clusters list page', () => {
+        visitClusters();
 
-        it('should disable the upgrade option', () => {
-            const clusterName = 'epsilon-edison-5';
-            visitClusterByNameWithFixtureMetadataDatetime(
-                clusterName,
-                fixturePath,
-                metadata,
-                currentDatetime
-            );
+        cy.title().should('match', getRegExpForTitleWithBranding('Clusters'));
 
-            cy.get(selectors.clusterHealth.credentialExpiration).should(
-                'have.text',
-                expectedExpiration
-            );
-            cy.get(selectors.clusterHealth.reissueCertificatesLink);
-            cy.get(selectors.clusterHealth.downloadToReissueCertificate)
-                .should('be.enabled')
-                .should('be.checked');
-            cy.get(selectors.clusterHealth.upgradeToReissueCertificate).should('be.disabled');
-            cy.get(selectors.clusterHealth.reissueCertificateButton).should('be.enabled');
-        });
-
-        // TODO mock Download YAML file for it('should display a message for success instead of the form')
-    });
-
-    describe('Sensor is up to date with Central', () => {
-        const expectedExpiration = 'in 29 days on 09/29/2020'; // Degraded
-
-        it('should enable the upgrade option', () => {
-            const clusterName = 'eta-7';
-            visitClusterByNameWithFixtureMetadataDatetime(
-                clusterName,
-                fixturePath,
-                metadata,
-                currentDatetime
-            );
-
-            cy.get(selectors.clusterHealth.credentialExpiration).should(
-                'have.text',
-                expectedExpiration
-            );
-            cy.get(selectors.clusterHealth.reissueCertificatesLink);
-            cy.get(selectors.clusterHealth.downloadToReissueCertificate).should('be.enabled');
-            cy.get(selectors.clusterHealth.upgradeToReissueCertificate)
-                .should('be.enabled')
-                .should('be.checked');
-            cy.get(selectors.clusterHealth.reissueCertificateButton).should('be.enabled');
-        });
-
-        it('should display a message for success instead of the form', () => {
-            const clusterName = 'eta-7';
-            visitClustersWithFixtureMetadataDatetime(fixturePath, metadata, currentDatetime);
-
-            cy.fixture(fixturePath).then(({ clusters }) => {
-                const n = clusters.findIndex((cluster) => cluster.name === clusterName);
-                const cluster = cloneDeep(clusters[n]);
-
-                // Mock the result of using an automatic upgrade to re-issue the certificate.
-                cluster.status.upgradeStatus.mostRecentProcess = {
-                    type: 'CERT_ROTATION',
-                    initiatedAt: currentDatetime,
-                    progress: {
-                        upgradeState: 'UPGRADE_COMPLETE',
-                    },
-                };
-
-                cy.intercept('GET', clustersApi.single, {
-                    body: { cluster, clusterRetentionInfo: null },
-                }).as('getCluster');
-                cy.get(`${selectors.clusters.tableRowGroup}:nth-child(${n + 1})`).click();
-                cy.wait('@getCluster');
-
-                cy.get(selectors.clusterHealth.credentialExpiration).should(
-                    'have.text',
-                    expectedExpiration
-                );
-                cy.get(selectors.clusterHealth.reissueCertificatesLink);
-                cy.get(selectors.clusterHealth.upgradedToReissueCertificate).should(
-                    'have.text',
-                    'An automatic upgrade applied new credentials to the cluster 0 seconds ago.'
-                );
-                cy.get(selectors.clusterHealth.downloadToReissueCertificate).should('not.exist');
-                cy.get(selectors.clusterHealth.upgradeToReissueCertificate).should('not.exist');
-                cy.get(selectors.clusterHealth.reissueCertificateButton).should('not.exist');
-            });
-        });
+        cy.get('.rt-th:contains("Name")');
+        cy.get('.rt-th:contains("Cloud Provider"');
+        cy.get('.rt-th:contains("Cluster Status")');
+        cy.get('.rt-th:contains("Sensor Upgrade")');
+        cy.get('.rt-th:contains("Credential Expiration")');
+        // Cluster Deletion: see clusterDeletion.test.js
     });
 });
 
@@ -203,13 +38,13 @@ describe.skip('Cluster Creation Flow', () => {
     it('Should be able to fill out the Kubernetes form, download config files and see cluster checked-in', () => {
         visitClusters();
 
-        cy.get(selectors.buttons.new).click();
+        cy.get('button:contains("New Cluster")').click();
 
         const clusterName = 'Kubernetes Cluster TestInstance';
         cy.get(selectors.clusterForm.nameInput).type(clusterName);
 
-        cy.intercept('POST', clustersApi.list).as('postCluster');
-        cy.get(selectors.buttons.next).click();
+        cy.intercept('POST', '/v1/clusters').as('postCluster');
+        cy.get('button:contains("Next")').click();
         // TypeError: Cannot read properties of undefined (reading 'overallHealthStatus')
         cy.wait('@postCluster').then(({ response }) => {
             const clusterId = response.cluster.id;
@@ -220,7 +55,7 @@ describe.skip('Cluster Creation Flow', () => {
             //   based on: https://github.com/cypress-io/cypress/issues/1956#issuecomment-455157737
             cy.fixture('clusters/sensor-kubernetes-cluster-testinstance.zip').then((dataURI) => {
                 return cy
-                    .intercept('POST', clustersApi.zip, {
+                    .intercept('POST', 'api/extensions/clusters/zip', {
                         headers: {
                             'content-disposition':
                                 'attachment; filename="sensor-kubernetes-cluster-testinstance.zip"',
@@ -230,14 +65,14 @@ describe.skip('Cluster Creation Flow', () => {
                     .as('download');
             });
             */
-            cy.intercept('POST', clustersApi.zip).as('download');
-            cy.get(selectors.buttons.downloadYAML).click();
+            cy.intercept('POST', 'api/extensions/clusters/zip').as('download');
+            cy.get('button:contains("Download YAML")').click();
             cy.wait('@download');
 
             cy.get('div:contains("Waiting for the cluster to check in successfully...")');
 
             // make cluster to "check-in" by adding "lastContact"
-            cy.intercept('GET', `${clustersApi.list}/${clusterId}`, {
+            cy.intercept('GET', `${'/v1/clusters'}/${clusterId}`, {
                 body: {
                     cluster: {
                         id: clusterId,
@@ -253,395 +88,18 @@ describe.skip('Cluster Creation Flow', () => {
                 'not.exist'
             );
 
-            cy.intercept('GET', clustersApi.list).as('getClusters');
-            cy.get(selectors.buttons.closePanel).click();
+            cy.intercept('GET', '/v1/clusters').as('getClusters');
+            cy.get('button[data-testid="cancel"]').click();
             cy.wait('@getClusters');
 
             // clean up after the test by deleting the cluster
-            cy.intercept('DELETE', clustersApi.list).as('deleteCluster');
+            cy.intercept('DELETE', '/v1/clusters').as('deleteCluster');
             cy.get(`.rt-tr:contains("${clusterName}") .rt-td input[type="checkbox"]`).check();
-            cy.get(selectors.buttons.delete).click();
-            cy.get(selectors.buttons.confirmDelete).click();
+            cy.get('button:contains("Delete")').click();
+            cy.get('.dialog button:contains("Delete")').click();
             cy.wait(['@deleteCluster', '@getClusters']);
 
             cy.get(`.rt-tr:contains("${clusterName}")`).should('not.exist');
-        });
-    });
-});
-
-describe('Cluster management', () => {
-    withAuth();
-
-    it('should indicate which clusters are managed by Helm and the Operator', () => {
-        const fixturePath = 'clusters/health.json';
-        visitClusters({
-            clusters: { fixture: fixturePath },
-        });
-
-        const helmIndicator = '[data-testid="cluster-name"] img[alt="Managed by Helm"]';
-        const k8sOperatorIndicator =
-            '[data-testid="cluster-name"] img[alt="Managed by a Kubernetes Operator"]';
-        const anyIndicator = '[data-testid="cluster-name"] img';
-        cy.get(`${selectors.clusters.tableRowGroup}:eq(0) ${helmIndicator}`).should('exist');
-        cy.get(`${selectors.clusters.tableRowGroup}:eq(1) ${anyIndicator}`).should('not.exist');
-        cy.get(`${selectors.clusters.tableRowGroup}:eq(2) ${k8sOperatorIndicator}`).should('exist');
-        cy.get(`${selectors.clusters.tableRowGroup}:eq(3) ${helmIndicator}`).should('exist');
-        cy.get(`${selectors.clusters.tableRowGroup}:eq(4) ${anyIndicator}`).should('not.exist');
-        cy.get(`${selectors.clusters.tableRowGroup}:eq(5) ${anyIndicator}`).should('not.exist');
-        cy.get(`${selectors.clusters.tableRowGroup}:eq(6) ${anyIndicator}`).should('not.exist');
-    });
-});
-
-describe('Cluster configuration', () => {
-    withAuth();
-
-    const fixturePath = 'clusters/health.json';
-
-    const assertConfigurationReadOnly = () => {
-        const form = cy.get('[data-testid="cluster-form"]').children();
-        [
-            'name',
-            'mainImage',
-            'centralApiEndpoint',
-            'collectorImage',
-            'admissionControllerEvents',
-            'admissionController',
-            'admissionControllerUpdates',
-            'tolerationsConfig.disabled',
-            'slimCollector',
-            'dynamicConfig.registryOverride',
-            'dynamicConfig.admissionControllerConfig.enabled',
-            'dynamicConfig.admissionControllerConfig.enforceOnUpdates',
-            'dynamicConfig.admissionControllerConfig.timeoutSeconds',
-            'dynamicConfig.admissionControllerConfig.scanInline',
-            'dynamicConfig.admissionControllerConfig.disableBypass',
-            'dynamicConfig.disableAuditLogs',
-        ].forEach((id) => form.get(`input[id="${id}"]`).should('be.disabled'));
-        ['Select a cluster type', 'Select a runtime option'].forEach((label) =>
-            form.get(`select[aria-label="${label}"]`).should('be.disabled')
-        );
-    };
-
-    it('should be read-only for Helm-based installations', () => {
-        visitClusterByNameWithFixture('alpha-amsterdam-1', fixturePath);
-        assertConfigurationReadOnly();
-    });
-
-    it('should be read-only for unknown manager installations that have a defined Helm config', () => {
-        visitClusterByNameWithFixture('kappa-kilogramme-10', fixturePath);
-        assertConfigurationReadOnly();
-    });
-});
-
-describe('Cluster Health', () => {
-    withAuth();
-
-    const fixturePath = 'clusters/health.json';
-    const metadata = {
-        version: '3.0.50.0', // for comparison to `sensorVersion` in clusters fixture
-        buildFlavor: 'release',
-        releaseBuild: true,
-        licenseStatus: 'VALID',
-    };
-    const datetimeISOString = '2020-08-31T13:01:00Z'; // for comparison to `lastContact` and `sensorCertExpiry` in clusters fixture
-
-    const expectedClusters = [
-        {
-            expectedInListAndSide: {
-                clusterName: 'alpha-amsterdam-1',
-                cloudProvider: 'Not applicable',
-                clusterStatus: 'Uninitialized',
-                sensorUpgrade: 'Not applicable',
-                credentialExpiration: 'Not applicable',
-                clusterDeletion: 'Not applicable',
-            },
-            expectedInSide: {
-                admissionControlHealthInfo: null,
-                collectorHealthInfo: null,
-                healthInfoComplete: null,
-                sensorVersion: null,
-                centralVersion: null,
-                sensorStatus: 'Uninitialized',
-                collectorStatus: 'Uninitialized',
-                admissionControlStatus: 'Uninitialized',
-            },
-        },
-        {
-            expectedInListAndSide: {
-                clusterName: 'epsilon-edison-5',
-                cloudProvider: 'AWS us-west1',
-                clusterStatus: 'Unhealthy',
-                sensorUpgrade: 'Upgrade available',
-                credentialExpiration: 'in 6 days on Monday',
-                clusterDeletion: 'in 90 days',
-            },
-            expectedInSide: {
-                admissionControlHealthInfo: {
-                    totalReadyPods: '3',
-                    totalDesiredPods: '3',
-                },
-                collectorHealthInfo: {
-                    totalReadyPods: '10',
-                    totalDesiredPods: '10',
-                    totalRegisteredNodes: '12',
-                },
-                healthInfoComplete: null,
-                sensorVersion: '3.0.48.0',
-                centralVersion: '3.0.50.0',
-                sensorStatus: 'Unhealthy for 1 hour',
-                collectorStatus: 'Healthy 1 hour ago',
-                admissionControlStatus: 'Healthy 1 hour ago',
-            },
-        },
-        {
-            expectedInListAndSide: {
-                clusterName: 'eta-7',
-                cloudProvider: 'GCP us-west1',
-                clusterStatus: 'Unhealthy',
-                sensorUpgrade: 'Up to date with Central',
-                credentialExpiration: 'in 29 days on 09/29/2020',
-                clusterDeletion: 'Not applicable',
-            },
-            expectedInSide: {
-                admissionControlHealthInfo: {
-                    totalReadyPods: '1',
-                    totalDesiredPods: '3',
-                },
-                collectorHealthInfo: {
-                    totalReadyPods: '3',
-                    totalDesiredPods: '5',
-                    totalRegisteredNodes: '6',
-                },
-                healthInfoComplete: null,
-                sensorVersion: '3.0.50.0',
-                centralVersion: '3.0.50.0',
-                sensorStatus: 'Healthy',
-                collectorStatus: 'Unhealthy',
-                admissionControlStatus: 'Unhealthy',
-            },
-        },
-        {
-            expectedInListAndSide: {
-                clusterName: 'kappa-kilogramme-10',
-                cloudProvider: 'AWS us-central1',
-                clusterStatus: 'Degraded',
-                sensorUpgrade: 'Up to date with Central',
-                credentialExpiration: 'in 1 month',
-                clusterDeletion: 'Not applicable',
-            },
-            expectedInSide: {
-                admissionControlHealthInfo: {
-                    totalReadyPods: '3',
-                    totalDesiredPods: '3',
-                },
-                collectorHealthInfo: {
-                    totalReadyPods: '10',
-                    totalDesiredPods: '10',
-                    totalRegisteredNodes: '12',
-                },
-                healthInfoComplete: null,
-                sensorVersion: '3.0.50.0',
-                centralVersion: '3.0.50.0',
-                sensorStatus: 'Degraded for 2 minutes',
-                collectorStatus: 'Healthy 2 minutes ago',
-                admissionControlStatus: 'Healthy 2 minutes ago',
-            },
-        },
-        {
-            expectedInListAndSide: {
-                clusterName: 'lambda-liverpool-11',
-                cloudProvider: 'GCP us-central1',
-                clusterStatus: 'Degraded',
-                sensorUpgrade: 'Up to date with Central',
-                credentialExpiration: 'in 2 months',
-                clusterDeletion: 'Not applicable',
-            },
-            expectedInSide: {
-                admissionControlHealthInfo: {
-                    totalReadyPods: '3',
-                    totalDesiredPods: '3',
-                },
-                collectorHealthInfo: {
-                    totalReadyPods: '8',
-                    totalDesiredPods: '10',
-                    totalRegisteredNodes: '12',
-                },
-                healthInfoComplete: null,
-                sensorVersion: '3.0.50.0',
-                centralVersion: '3.0.50.0',
-                sensorStatus: 'Healthy',
-                collectorStatus: 'Degraded',
-                admissionControlStatus: 'Healthy',
-            },
-        },
-        {
-            expectedInListAndSide: {
-                clusterName: 'mu-madegascar-12',
-                cloudProvider: 'AWS eu-central1',
-                clusterStatus: 'Healthy',
-                sensorUpgrade: 'Upgrade available',
-                credentialExpiration: 'in 12 months',
-                clusterDeletion: 'Not applicable',
-            },
-            expectedInSide: {
-                admissionControlHealthInfo: null,
-                collectorHealthInfo: null,
-                healthInfoComplete: {
-                    admissionControl: 'Upgrade Sensor to get Admission Control health information',
-                    collector: 'Upgrade Sensor to get Collector health information',
-                },
-                sensorVersion: '3.0.47.0',
-                centralVersion: '3.0.50.0',
-                sensorStatus: 'Healthy',
-                collectorStatus: 'Unavailable',
-                admissionControlStatus: 'Unavailable',
-            },
-        },
-        {
-            expectedInListAndSide: {
-                clusterName: 'nu-york-13',
-                cloudProvider: 'AWS ap-southeast1',
-                clusterStatus: 'Healthy',
-                sensorUpgrade: 'Up to date with Central',
-                credentialExpiration: 'in 1 year',
-                clusterDeletion: 'Not applicable',
-            },
-            expectedInSide: {
-                admissionControlHealthInfo: {
-                    totalReadyPods: '3',
-                    totalDesiredPods: '3',
-                },
-                collectorHealthInfo: {
-                    totalReadyPods: '7',
-                    totalDesiredPods: '7',
-                    totalRegisteredNodes: '7',
-                },
-                healthInfoComplete: null,
-                sensorVersion: '3.0.50.0',
-                centralVersion: '3.0.50.0',
-                sensorStatus: 'Healthy',
-                collectorStatus: 'Healthy',
-                admissionControlStatus: 'Healthy',
-            },
-        },
-    ];
-
-    it('should appear in the list', function () {
-        if (!hasFeatureFlag('ROX_DECOMMISSIONED_CLUSTER_RETENTION')) {
-            this.skip();
-        }
-
-        visitClustersWithFixtureMetadataDatetime(fixturePath, metadata, datetimeISOString);
-
-        /*
-         * Some cells have no internal markup (for example, Name or Cloud Provider).
-         * Other cells have div and spans for status color versus default color.
-         */
-        cy.get(selectors.clusters.tableDataCell).should(($tds) => {
-            let n = 0;
-            expectedClusters.forEach(({ expectedInListAndSide }) => {
-                Object.keys(expectedInListAndSide).forEach((key) => {
-                    if (key === 'clusterStatus') {
-                        expect($tds.eq(n).text()).to.include(expectedInListAndSide[key]);
-                    } else {
-                        expect($tds.eq(n).text()).to.equal(expectedInListAndSide[key]);
-                    }
-                    n += 1;
-                });
-            });
-            expect($tds.length).to.equal(n);
-        });
-    });
-
-    expectedClusters.forEach(({ expectedInListAndSide, expectedInSide }) => {
-        const { clusterName, clusterStatus, sensorUpgrade, credentialExpiration } =
-            expectedInListAndSide;
-        const {
-            admissionControlHealthInfo,
-            collectorHealthInfo,
-            healthInfoComplete,
-            sensorVersion,
-            centralVersion,
-            sensorStatus,
-            collectorStatus,
-            admissionControlStatus,
-        } = expectedInSide;
-
-        it(`should appear in the form for ${clusterName}`, () => {
-            visitClusterByNameWithFixtureMetadataDatetime(
-                clusterName,
-                fixturePath,
-                metadata,
-                datetimeISOString
-            );
-
-            cy.get(selectors.clusterForm.nameInput).should('have.value', clusterName);
-
-            // Cluster Status
-            cy.get(selectors.clusterHealth.clusterStatus).should('have.text', clusterStatus);
-
-            // Sensor Status
-            cy.get(selectors.clusterHealth.sensorStatus).should('have.text', sensorStatus);
-
-            // Collector Status
-            cy.get(selectors.clusterHealth.collectorStatus).should('have.text', collectorStatus);
-            if (collectorHealthInfo !== null) {
-                const { totalReadyPods, totalDesiredPods, totalRegisteredNodes } =
-                    collectorHealthInfo;
-                cy.get(selectors.clusterHealth.collectorHealthInfo.totalReadyPods).should(
-                    'have.text',
-                    totalReadyPods
-                );
-                cy.get(selectors.clusterHealth.collectorHealthInfo.totalDesiredPods).should(
-                    'have.text',
-                    totalDesiredPods
-                );
-                cy.get(selectors.clusterHealth.collectorHealthInfo.totalRegisteredNodes).should(
-                    'have.text',
-                    totalRegisteredNodes
-                );
-            }
-            // Admission Control Status
-            cy.get(selectors.clusterHealth.admissionControlStatus).should(
-                'have.text',
-                admissionControlStatus
-            );
-            if (admissionControlHealthInfo !== null) {
-                const { totalReadyPods, totalDesiredPods } = admissionControlHealthInfo;
-                cy.get(selectors.clusterHealth.admissionControlHealthInfo.totalReadyPods).should(
-                    'have.text',
-                    totalReadyPods
-                );
-                cy.get(selectors.clusterHealth.admissionControlHealthInfo.totalDesiredPods).should(
-                    'have.text',
-                    totalDesiredPods
-                );
-            }
-            if (healthInfoComplete !== null) {
-                cy.get(selectors.clusterHealth.admissionControlInfoComplete).should(
-                    'have.text',
-                    healthInfoComplete.admissionControl
-                );
-                cy.get(selectors.clusterHealth.collectorInfoComplete).should(
-                    'have.text',
-                    healthInfoComplete.collector
-                );
-            }
-
-            // Sensor Upgrade
-            cy.get(selectors.clusterHealth.sensorUpgrade).should('have.text', sensorUpgrade);
-            if (typeof sensorVersion === 'string') {
-                cy.get(selectors.clusterHealth.sensorVersion).should('have.text', sensorVersion);
-            }
-            if (typeof centralVersion === 'string') {
-                cy.get(selectors.clusterHealth.centralVersion).should('have.text', centralVersion);
-            }
-
-            // Credential Expiration
-            cy.get(selectors.clusterHealth.credentialExpiration).should(
-                'have.text',
-                credentialExpiration
-            );
         });
     });
 });

--- a/ui/apps/platform/cypress/integration/clusters/clustersCertificateExpiration.test.js
+++ b/ui/apps/platform/cypress/integration/clusters/clustersCertificateExpiration.test.js
@@ -1,0 +1,137 @@
+import cloneDeep from 'lodash/cloneDeep';
+
+import withAuth from '../../helpers/basicAuth';
+
+import {
+    clusterAlias,
+    visitClusterById,
+    visitClusterByNameWithFixtureMetadataDatetime,
+    visitClustersWithFixtureMetadataDatetime,
+} from './Clusters.helpers';
+import { selectors } from './Clusters.selectors';
+
+// There is some overlap between tests for Certificate Expiration and Health Status.
+describe('Clusters Certificate Expiration', () => {
+    withAuth();
+
+    const fixturePath = 'clusters/health.json';
+
+    const metadata = {
+        version: '3.0.50.0', // for comparison to `sensorVersion` in clusters fixture
+        buildFlavor: 'release',
+        releaseBuild: true,
+        licenseStatus: 'VALID',
+    };
+
+    // For comparison to `lastContact` and `sensorCertExpiry` in clusters fixture.
+    const currentDatetime = new Date('2020-08-31T13:01:00Z');
+
+    describe('status is Healthy', () => {
+        it('should not show link or form', () => {
+            const clusterName = 'kappa-kilogramme-10';
+            visitClusterByNameWithFixtureMetadataDatetime(
+                clusterName,
+                fixturePath,
+                metadata,
+                currentDatetime
+            );
+
+            cy.get(selectors.clusterHealth.credentialExpiration).should('have.text', 'in 1 month');
+            cy.get(selectors.clusterHealth.reissueCertificatesLink).should('not.exist');
+            cy.get(selectors.clusterHealth.downloadToReissueCertificate).should('not.exist');
+            cy.get(selectors.clusterHealth.upgradeToReissueCertificate).should('not.exist');
+            cy.get(selectors.clusterHealth.reissueCertificateButton).should('not.exist');
+        });
+    });
+
+    describe('Sensor is not up to date with Central', () => {
+        const expectedExpiration = 'in 6 days on Monday'; // Unhealthy
+
+        it('should disable the upgrade option', () => {
+            const clusterName = 'epsilon-edison-5';
+            visitClusterByNameWithFixtureMetadataDatetime(
+                clusterName,
+                fixturePath,
+                metadata,
+                currentDatetime
+            );
+
+            cy.get(selectors.clusterHealth.credentialExpiration).should(
+                'have.text',
+                expectedExpiration
+            );
+            cy.get(selectors.clusterHealth.reissueCertificatesLink);
+            cy.get(selectors.clusterHealth.downloadToReissueCertificate)
+                .should('be.enabled')
+                .should('be.checked');
+            cy.get(selectors.clusterHealth.upgradeToReissueCertificate).should('be.disabled');
+            cy.get(selectors.clusterHealth.reissueCertificateButton).should('be.enabled');
+        });
+
+        // TODO mock Download YAML file for it('should display a message for success instead of the form')
+    });
+
+    describe('Sensor is up to date with Central', () => {
+        const expectedExpiration = 'in 29 days on 09/29/2020'; // Degraded
+
+        it('should enable the upgrade option', () => {
+            const clusterName = 'eta-7';
+            visitClusterByNameWithFixtureMetadataDatetime(
+                clusterName,
+                fixturePath,
+                metadata,
+                currentDatetime
+            );
+
+            cy.get(selectors.clusterHealth.credentialExpiration).should(
+                'have.text',
+                expectedExpiration
+            );
+            cy.get(selectors.clusterHealth.reissueCertificatesLink);
+            cy.get(selectors.clusterHealth.downloadToReissueCertificate).should('be.enabled');
+            cy.get(selectors.clusterHealth.upgradeToReissueCertificate)
+                .should('be.enabled')
+                .should('be.checked');
+            cy.get(selectors.clusterHealth.reissueCertificateButton).should('be.enabled');
+        });
+
+        it('should display a message for success instead of the form', () => {
+            const clusterName = 'eta-7';
+            visitClustersWithFixtureMetadataDatetime(fixturePath, metadata, currentDatetime);
+
+            cy.fixture(fixturePath).then(({ clusters }) => {
+                const n = clusters.findIndex((cluster) => cluster.name === clusterName);
+                const cluster = cloneDeep(clusters[n]);
+
+                // Mock the result of using an automatic upgrade to re-issue the certificate.
+                cluster.status.upgradeStatus.mostRecentProcess = {
+                    type: 'CERT_ROTATION',
+                    initiatedAt: currentDatetime,
+                    progress: {
+                        upgradeState: 'UPGRADE_COMPLETE',
+                    },
+                };
+
+                const staticResponseMap = {
+                    [clusterAlias]: {
+                        body: { cluster, clusterRetentionInfo: null },
+                    },
+                };
+                visitClusterById(cluster.id, staticResponseMap);
+
+                cy.get(selectors.clusterHealth.credentialExpiration).should(
+                    'have.text',
+                    expectedExpiration
+                );
+                cy.get(selectors.clusterHealth.reissueCertificatesLink);
+                cy.get(selectors.clusterHealth.upgradedToReissueCertificate).should(
+                    'have.text',
+                    'An automatic upgrade applied new credentials to the cluster 0 seconds ago.'
+                );
+                cy.get(selectors.clusterHealth.downloadToReissueCertificate).should('not.exist');
+                cy.get(selectors.clusterHealth.upgradeToReissueCertificate).should('not.exist');
+                cy.get(selectors.clusterHealth.reissueCertificateButton).should('not.exist');
+            });
+        });
+    });
+});

--- a/ui/apps/platform/cypress/integration/clusters/clustersHealthStatus.test.js
+++ b/ui/apps/platform/cypress/integration/clusters/clustersHealthStatus.test.js
@@ -1,0 +1,322 @@
+import withAuth from '../../helpers/basicAuth';
+import { hasFeatureFlag } from '../../helpers/features';
+
+import {
+    visitClusterByNameWithFixtureMetadataDatetime,
+    visitClustersWithFixtureMetadataDatetime,
+} from './Clusters.helpers';
+import { selectors } from './Clusters.selectors';
+
+// There is some overlap between tests for Certificate Expiration and Health Status.
+describe('Clusters Health Status', () => {
+    withAuth();
+
+    const fixturePath = 'clusters/health.json';
+    const metadata = {
+        version: '3.0.50.0', // for comparison to `sensorVersion` in clusters fixture
+        buildFlavor: 'release',
+        releaseBuild: true,
+        licenseStatus: 'VALID',
+    };
+    const datetimeISOString = '2020-08-31T13:01:00Z'; // for comparison to `lastContact` and `sensorCertExpiry` in clusters fixture
+
+    const expectedClusters = [
+        {
+            expectedInListAndSide: {
+                clusterName: 'alpha-amsterdam-1',
+                cloudProvider: 'Not applicable',
+                clusterStatus: 'Uninitialized',
+                sensorUpgrade: 'Not applicable',
+                credentialExpiration: 'Not applicable',
+                clusterDeletion: 'Not applicable',
+            },
+            expectedInSide: {
+                admissionControlHealthInfo: null,
+                collectorHealthInfo: null,
+                healthInfoComplete: null,
+                sensorVersion: null,
+                centralVersion: null,
+                sensorStatus: 'Uninitialized',
+                collectorStatus: 'Uninitialized',
+                admissionControlStatus: 'Uninitialized',
+            },
+        },
+        {
+            expectedInListAndSide: {
+                clusterName: 'epsilon-edison-5',
+                cloudProvider: 'AWS us-west1',
+                clusterStatus: 'Unhealthy',
+                sensorUpgrade: 'Upgrade available',
+                credentialExpiration: 'in 6 days on Monday',
+                clusterDeletion: 'in 90 days',
+            },
+            expectedInSide: {
+                admissionControlHealthInfo: {
+                    totalReadyPods: '3',
+                    totalDesiredPods: '3',
+                },
+                collectorHealthInfo: {
+                    totalReadyPods: '10',
+                    totalDesiredPods: '10',
+                    totalRegisteredNodes: '12',
+                },
+                healthInfoComplete: null,
+                sensorVersion: '3.0.48.0',
+                centralVersion: '3.0.50.0',
+                sensorStatus: 'Unhealthy for 1 hour',
+                collectorStatus: 'Healthy 1 hour ago',
+                admissionControlStatus: 'Healthy 1 hour ago',
+            },
+        },
+        {
+            expectedInListAndSide: {
+                clusterName: 'eta-7',
+                cloudProvider: 'GCP us-west1',
+                clusterStatus: 'Unhealthy',
+                sensorUpgrade: 'Up to date with Central',
+                credentialExpiration: 'in 29 days on 09/29/2020',
+                clusterDeletion: 'Not applicable',
+            },
+            expectedInSide: {
+                admissionControlHealthInfo: {
+                    totalReadyPods: '1',
+                    totalDesiredPods: '3',
+                },
+                collectorHealthInfo: {
+                    totalReadyPods: '3',
+                    totalDesiredPods: '5',
+                    totalRegisteredNodes: '6',
+                },
+                healthInfoComplete: null,
+                sensorVersion: '3.0.50.0',
+                centralVersion: '3.0.50.0',
+                sensorStatus: 'Healthy',
+                collectorStatus: 'Unhealthy',
+                admissionControlStatus: 'Unhealthy',
+            },
+        },
+        {
+            expectedInListAndSide: {
+                clusterName: 'kappa-kilogramme-10',
+                cloudProvider: 'AWS us-central1',
+                clusterStatus: 'Degraded',
+                sensorUpgrade: 'Up to date with Central',
+                credentialExpiration: 'in 1 month',
+                clusterDeletion: 'Not applicable',
+            },
+            expectedInSide: {
+                admissionControlHealthInfo: {
+                    totalReadyPods: '3',
+                    totalDesiredPods: '3',
+                },
+                collectorHealthInfo: {
+                    totalReadyPods: '10',
+                    totalDesiredPods: '10',
+                    totalRegisteredNodes: '12',
+                },
+                healthInfoComplete: null,
+                sensorVersion: '3.0.50.0',
+                centralVersion: '3.0.50.0',
+                sensorStatus: 'Degraded for 2 minutes',
+                collectorStatus: 'Healthy 2 minutes ago',
+                admissionControlStatus: 'Healthy 2 minutes ago',
+            },
+        },
+        {
+            expectedInListAndSide: {
+                clusterName: 'lambda-liverpool-11',
+                cloudProvider: 'GCP us-central1',
+                clusterStatus: 'Degraded',
+                sensorUpgrade: 'Up to date with Central',
+                credentialExpiration: 'in 2 months',
+                clusterDeletion: 'Not applicable',
+            },
+            expectedInSide: {
+                admissionControlHealthInfo: {
+                    totalReadyPods: '3',
+                    totalDesiredPods: '3',
+                },
+                collectorHealthInfo: {
+                    totalReadyPods: '8',
+                    totalDesiredPods: '10',
+                    totalRegisteredNodes: '12',
+                },
+                healthInfoComplete: null,
+                sensorVersion: '3.0.50.0',
+                centralVersion: '3.0.50.0',
+                sensorStatus: 'Healthy',
+                collectorStatus: 'Degraded',
+                admissionControlStatus: 'Healthy',
+            },
+        },
+        {
+            expectedInListAndSide: {
+                clusterName: 'mu-madegascar-12',
+                cloudProvider: 'AWS eu-central1',
+                clusterStatus: 'Healthy',
+                sensorUpgrade: 'Upgrade available',
+                credentialExpiration: 'in 12 months',
+                clusterDeletion: 'Not applicable',
+            },
+            expectedInSide: {
+                admissionControlHealthInfo: null,
+                collectorHealthInfo: null,
+                healthInfoComplete: {
+                    admissionControl: 'Upgrade Sensor to get Admission Control health information',
+                    collector: 'Upgrade Sensor to get Collector health information',
+                },
+                sensorVersion: '3.0.47.0',
+                centralVersion: '3.0.50.0',
+                sensorStatus: 'Healthy',
+                collectorStatus: 'Unavailable',
+                admissionControlStatus: 'Unavailable',
+            },
+        },
+        {
+            expectedInListAndSide: {
+                clusterName: 'nu-york-13',
+                cloudProvider: 'AWS ap-southeast1',
+                clusterStatus: 'Healthy',
+                sensorUpgrade: 'Up to date with Central',
+                credentialExpiration: 'in 1 year',
+                clusterDeletion: 'Not applicable',
+            },
+            expectedInSide: {
+                admissionControlHealthInfo: {
+                    totalReadyPods: '3',
+                    totalDesiredPods: '3',
+                },
+                collectorHealthInfo: {
+                    totalReadyPods: '7',
+                    totalDesiredPods: '7',
+                    totalRegisteredNodes: '7',
+                },
+                healthInfoComplete: null,
+                sensorVersion: '3.0.50.0',
+                centralVersion: '3.0.50.0',
+                sensorStatus: 'Healthy',
+                collectorStatus: 'Healthy',
+                admissionControlStatus: 'Healthy',
+            },
+        },
+    ];
+
+    it('should appear in the list', function () {
+        if (!hasFeatureFlag('ROX_DECOMMISSIONED_CLUSTER_RETENTION')) {
+            this.skip();
+        }
+
+        visitClustersWithFixtureMetadataDatetime(fixturePath, metadata, datetimeISOString);
+
+        /*
+         * Some cells have no internal markup (for example, Name or Cloud Provider).
+         * Other cells have div and spans for status color versus default color.
+         */
+        cy.get(selectors.clusters.tableDataCell).should(($tds) => {
+            let n = 0;
+            expectedClusters.forEach(({ expectedInListAndSide }) => {
+                Object.keys(expectedInListAndSide).forEach((key) => {
+                    if (key === 'clusterStatus') {
+                        expect($tds.eq(n).text()).to.include(expectedInListAndSide[key]);
+                    } else {
+                        expect($tds.eq(n).text()).to.equal(expectedInListAndSide[key]);
+                    }
+                    n += 1;
+                });
+            });
+            expect($tds.length).to.equal(n);
+        });
+    });
+
+    expectedClusters.forEach(({ expectedInListAndSide, expectedInSide }) => {
+        const { clusterName, clusterStatus, sensorUpgrade, credentialExpiration } =
+            expectedInListAndSide;
+        const {
+            admissionControlHealthInfo,
+            collectorHealthInfo,
+            healthInfoComplete,
+            sensorVersion,
+            centralVersion,
+            sensorStatus,
+            collectorStatus,
+            admissionControlStatus,
+        } = expectedInSide;
+
+        it(`should appear in the form for ${clusterName}`, () => {
+            visitClusterByNameWithFixtureMetadataDatetime(
+                clusterName,
+                fixturePath,
+                metadata,
+                datetimeISOString
+            );
+
+            cy.get(selectors.clusterForm.nameInput).should('have.value', clusterName);
+
+            // Cluster Status
+            cy.get(selectors.clusterHealth.clusterStatus).should('have.text', clusterStatus);
+
+            // Sensor Status
+            cy.get(selectors.clusterHealth.sensorStatus).should('have.text', sensorStatus);
+
+            // Collector Status
+            cy.get(selectors.clusterHealth.collectorStatus).should('have.text', collectorStatus);
+            if (collectorHealthInfo !== null) {
+                const { totalReadyPods, totalDesiredPods, totalRegisteredNodes } =
+                    collectorHealthInfo;
+                cy.get(selectors.clusterHealth.collectorHealthInfo.totalReadyPods).should(
+                    'have.text',
+                    totalReadyPods
+                );
+                cy.get(selectors.clusterHealth.collectorHealthInfo.totalDesiredPods).should(
+                    'have.text',
+                    totalDesiredPods
+                );
+                cy.get(selectors.clusterHealth.collectorHealthInfo.totalRegisteredNodes).should(
+                    'have.text',
+                    totalRegisteredNodes
+                );
+            }
+            // Admission Control Status
+            cy.get(selectors.clusterHealth.admissionControlStatus).should(
+                'have.text',
+                admissionControlStatus
+            );
+            if (admissionControlHealthInfo !== null) {
+                const { totalReadyPods, totalDesiredPods } = admissionControlHealthInfo;
+                cy.get(selectors.clusterHealth.admissionControlHealthInfo.totalReadyPods).should(
+                    'have.text',
+                    totalReadyPods
+                );
+                cy.get(selectors.clusterHealth.admissionControlHealthInfo.totalDesiredPods).should(
+                    'have.text',
+                    totalDesiredPods
+                );
+            }
+            if (healthInfoComplete !== null) {
+                cy.get(selectors.clusterHealth.admissionControlInfoComplete).should(
+                    'have.text',
+                    healthInfoComplete.admissionControl
+                );
+                cy.get(selectors.clusterHealth.collectorInfoComplete).should(
+                    'have.text',
+                    healthInfoComplete.collector
+                );
+            }
+
+            // Sensor Upgrade
+            cy.get(selectors.clusterHealth.sensorUpgrade).should('have.text', sensorUpgrade);
+            if (typeof sensorVersion === 'string') {
+                cy.get(selectors.clusterHealth.sensorVersion).should('have.text', sensorVersion);
+            }
+            if (typeof centralVersion === 'string') {
+                cy.get(selectors.clusterHealth.centralVersion).should('have.text', centralVersion);
+            }
+
+            // Credential Expiration
+            cy.get(selectors.clusterHealth.credentialExpiration).should(
+                'have.text',
+                credentialExpiration
+            );
+        });
+    });
+});

--- a/ui/apps/platform/cypress/integration/clusters/clustersManager.test.js
+++ b/ui/apps/platform/cypress/integration/clusters/clustersManager.test.js
@@ -1,0 +1,65 @@
+import withAuth from '../../helpers/basicAuth';
+
+import { visitClusterByNameWithFixture, visitClustersWithFixture } from './Clusters.helpers';
+
+describe('Cluster managedBy', () => {
+    withAuth();
+
+    it('should indicate Helm and Operator', () => {
+        const fixturePath = 'clusters/health.json';
+        visitClustersWithFixture(fixturePath);
+
+        const helmIndicator = '[data-testid="cluster-name"] img[alt="Managed by Helm"]';
+        const k8sOperatorIndicator =
+            '[data-testid="cluster-name"] img[alt="Managed by a Kubernetes Operator"]';
+        const anyIndicator = '[data-testid="cluster-name"] img';
+        cy.get(`.rt-tr-group:eq(0) ${helmIndicator}`).should('exist'); // alpha-amsterdam-1
+        cy.get(`.rt-tr-group:eq(1) ${anyIndicator}`).should('not.exist'); // epsilon-edison-5
+        cy.get(`.rt-tr-group:eq(2) ${k8sOperatorIndicator}`).should('exist'); // eta-7
+        cy.get(`.rt-tr-group:eq(3) ${helmIndicator}`).should('exist'); // kappa-kilogramme-10
+        cy.get(`.rt-tr-group:eq(4) ${anyIndicator}`).should('not.exist'); // lambda-liverpool-11
+        cy.get(`.rt-tr-group:eq(5) ${anyIndicator}`).should('not.exist'); // mu-madegascar-12
+        cy.get(`.rt-tr-group:eq(6) ${anyIndicator}`).should('not.exist'); // nu-york-13
+    });
+});
+
+describe('Cluster configuration', () => {
+    withAuth();
+
+    const fixturePath = 'clusters/health.json';
+
+    const assertConfigurationReadOnly = () => {
+        const form = cy.get('[data-testid="cluster-form"]').children();
+        [
+            'name',
+            'mainImage',
+            'centralApiEndpoint',
+            'collectorImage',
+            'admissionControllerEvents',
+            'admissionController',
+            'admissionControllerUpdates',
+            'tolerationsConfig.disabled',
+            'slimCollector',
+            'dynamicConfig.registryOverride',
+            'dynamicConfig.admissionControllerConfig.enabled',
+            'dynamicConfig.admissionControllerConfig.enforceOnUpdates',
+            'dynamicConfig.admissionControllerConfig.timeoutSeconds',
+            'dynamicConfig.admissionControllerConfig.scanInline',
+            'dynamicConfig.admissionControllerConfig.disableBypass',
+            'dynamicConfig.disableAuditLogs',
+        ].forEach((id) => form.get(`input[id="${id}"]`).should('be.disabled'));
+        ['Select a cluster type', 'Select a runtime option'].forEach((label) =>
+            form.get(`select[aria-label="${label}"]`).should('be.disabled')
+        );
+    };
+
+    it('should be read-only for Helm-based installations', () => {
+        visitClusterByNameWithFixture('alpha-amsterdam-1', fixturePath);
+        assertConfigurationReadOnly();
+    });
+
+    it('should be read-only for unknown manager installations that have a defined Helm config', () => {
+        visitClusterByNameWithFixture('kappa-kilogramme-10', fixturePath);
+        assertConfigurationReadOnly();
+    });
+});

--- a/ui/apps/platform/cypress/integration/clusters/redirectFromDashboard.test.js
+++ b/ui/apps/platform/cypress/integration/clusters/redirectFromDashboard.test.js
@@ -1,5 +1,5 @@
 import withAuth from '../../helpers/basicAuth';
-import { summaryCountsOpname, visitMainDashboard } from '../../helpers/main';
+import { visitMainDashboardWithStaticResponseForSummaryCounts } from '../../helpers/main';
 
 import { clustersAlias, interactAndVisitClusters } from './Clusters.helpers';
 
@@ -16,21 +16,19 @@ describe('Clusters', () => {
         };
 
         interactAndVisitClusters(() => {
-            const staticResponseMapForDashboard = {
-                [summaryCountsOpname]: {
-                    body: {
-                        data: {
-                            clusterCount: 0, // no secured clusters
-                            nodeCount: 3,
-                            violationCount: 20,
-                            deploymentCount: 35,
-                            imageCount: 31,
-                            secretCount: 15,
-                        },
+            const staticResponseForSummaryCounts = {
+                body: {
+                    data: {
+                        clusterCount: 0, // no secured clusters
+                        nodeCount: 3,
+                        violationCount: 20,
+                        deploymentCount: 35,
+                        imageCount: 31,
+                        secretCount: 15,
                     },
                 },
             };
-            visitMainDashboard(staticResponseMapForDashboard);
+            visitMainDashboardWithStaticResponseForSummaryCounts(staticResponseForSummaryCounts);
         }, staticResponseMapForClusters);
 
         cy.get(

--- a/ui/apps/platform/cypress/integration/clusters/redirectFromDashboard.test.js
+++ b/ui/apps/platform/cypress/integration/clusters/redirectFromDashboard.test.js
@@ -1,0 +1,36 @@
+import withAuth from '../../helpers/basicAuth';
+import { summaryCountsOpname, visitMainDashboard } from '../../helpers/main';
+
+import { clustersAlias, interactAndVisitClusters } from './Clusters.helpers';
+
+describe('Clusters', () => {
+    withAuth();
+
+    it('should redirect from Dashboard when no secured clusters have been added (only applies to Cloud Service)', () => {
+        const staticResponseMapForClusters = {
+            [clustersAlias]: {
+                body: {
+                    clusters: [], // no secured clusters
+                },
+            },
+        };
+
+        interactAndVisitClusters(() => {
+            const staticResponseMapForDashboard = {
+                [summaryCountsOpname]: {
+                    body: {
+                        data: {
+                            clusterCount: 0, // no secured clusters
+                            nodeCount: 3,
+                            violationCount: 20,
+                            deploymentCount: 35,
+                            imageCount: 31,
+                            secretCount: 15,
+                        },
+                    },
+                },
+            };
+            visitMainDashboard(staticResponseMapForDashboard);
+        }, staticResponseMapForClusters);
+    });
+});

--- a/ui/apps/platform/cypress/integration/clusters/redirectFromDashboard.test.js
+++ b/ui/apps/platform/cypress/integration/clusters/redirectFromDashboard.test.js
@@ -32,5 +32,13 @@ describe('Clusters', () => {
             };
             visitMainDashboard(staticResponseMapForDashboard);
         }, staticResponseMapForClusters);
+
+        cy.get(
+            'p:contains("You have successfully deployed a Red Hat Advanced Cluster Security platform.")'
+        );
+
+        cy.get('h2:contains("Configure the clusters you want to secure.")');
+
+        cy.get('a:contains("View instructions")');
     });
 });

--- a/ui/apps/platform/cypress/integration/systemHealth/clusters.test.js
+++ b/ui/apps/platform/cypress/integration/systemHealth/clusters.test.js
@@ -1,7 +1,6 @@
-import { clustersUrl } from '../../constants/ClustersPage';
 import { selectors } from '../../constants/SystemHealth';
 import withAuth from '../../helpers/basicAuth';
-import { interactAndVisitClusters } from '../../helpers/clusters';
+import { interactAndVisitClusters } from '../clusters/Clusters.helpers';
 import { setClock, visitSystemHealth } from '../../helpers/systemHealth';
 
 function visitSystemHealthWithClustersFixtureFilteredByNames(fixturePath, clusterNames) {
@@ -23,7 +22,6 @@ describe('System Health Clusters without fixture', () => {
         interactAndVisitClusters(() => {
             cy.get(selectors.clusters.viewAllButton).click();
         });
-        cy.location('pathname').should('eq', clustersUrl);
     });
 });
 


### PR DESCRIPTION
## Description

### Objectives

* Reduce import dependencies so it is easier to adapt tests in a sibling folder for future clusters page.
* Practice new patterns as prerequisite to train the team.

### Naming convention

Distinguish the **scope** of constants and functions:
1. Test-specific: `it` block for test or module scope in test file for tests.
2. Container-specific: whatever.helpers.js or whatever.selectors.js file in cypress/integration/whatever subfolder. Only rare import from other containers, like `interactAndVisitWhatever` function (for example, from Risk to Network Graph).
3. Global
    * cypress/helpers/whatever.js for example, basicAuth.js or features.js
    * cypress/selectors/whatever.js for example, navigation.js or pagination.js

End goals:
1. Move most of cypress/helpers/whatever.js to container subfolders as Whatever.helpers.js files.
2. Move most of cypress/constants/whatever.js to container subfolders as Whatever.selectors.js files.
3. Encapsulate most of apiEndpoints.js in container-specific helpers files.

### Changed files

1. Edit cypress/constants/apiEndpoints.js
    * Delete properties except `list` in `clusters` object.

2. Edit, move, and rename cypress/constants/ClustersPage.js as Clusters.**selectors**.js
    * Delete unused selectors.
    * Move unique selectors into helpers or test files.

3. Edit, move, and rename cypress/helpers/clusters.js as Clusters.**helpers**.js
    * Export alias constants for static response maps in tests.
    * Add `assertClusterNameInSidePanel` function.
    * Replace `visitDashboardWithNoClusters` function with static response maps and helper function calls in test.

4. Edit cypress/helpers/main.js
    * Add `visitMainDashboardWithStaticResponseForSummaryCounts` function for redirect test.

5. Edit cypress/integration/clusters/clusterDeletion.test.js

6. Edit cypress/integration/clusters/clusters.test.js
    * Remove extra level of first `describe` block.
    * Move `describe` blocks to new test files.
    * Replace import endpoints and selectors in skip `describe` block for cluster creation
        **Van: is there any reason to keep this test?**

7. Add cypress/integration/clusters/clustersCertificateExpiration.test.js

8. Add cypress/integration/clusters/clustersHealthStatus.test.js

9. Add cypress/integration/clusters/clustersManager.test.js

10. Add cypress/integration/clusters/redirectFromDashboard.test.js
    * Move and rewrite test to call helper functions with static response map arguments.

    **Van: do you have any preference whether or not to prefix this file name?**
    For example, clustersRedirectFromDashboard.test.js
    * On one side of the coin, with prefix fits well with its siblings in this folder.
    * On the other side of the coin, I do not like to imply a general convention to prefix names in all folders.

11. Edit cypress/integration/systemHealth/clusters.test.js
    * Delete redundant assertion to remove need for `clustersUrl` import.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed