### PR TITLE
ROX-13882: Generate and simulate network policies integration

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPoliciesYAML.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPoliciesYAML.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { CodeEditor, CodeEditorControl, Language } from '@patternfly/react-code-editor';
+import { DownloadIcon, MoonIcon, ProcessAutomationIcon, SunIcon } from '@patternfly/react-icons';
+import { Bullseye, EmptyState, EmptyStateVariant, Title } from '@patternfly/react-core';
+
+import { useTheme } from 'Containers/ThemeProvider';
+import download from 'utils/download';
+
+type NetworkPoliciesYAMLProp = {
+    yaml: string;
+    generateNetworkPolicies?: () => void;
+};
+
+const downloadYAMLHandler = (fileName: string, fileContent: string) => () => {
+    download(`${fileName}.yml`, fileContent, 'yml');
+};
+
+function NetworkPoliciesYAML({ yaml, generateNetworkPolicies }: NetworkPoliciesYAMLProp) {
+    const { isDarkMode } = useTheme();
+    const [customDarkMode, setCustomDarkMode] = React.useState(isDarkMode);
+
+    function onToggleDarkMode() {
+        setCustomDarkMode((prevValue) => !prevValue);
+    }
+
+    const toggleDarkModeControl = (
+        <CodeEditorControl
+            icon={customDarkMode ? <SunIcon /> : <MoonIcon />}
+            aria-label="Toggle dark mode"
+            toolTipText={customDarkMode ? 'Toggle to light mode' : 'Toggle to dark mode'}
+            onClick={onToggleDarkMode}
+            isVisible
+        />
+    );
+
+    const downloadYAMLControl = (
+        <CodeEditorControl
+            icon={<DownloadIcon />}
+            aria-label="Download YAML"
+            toolTipText="Download YAML"
+            onClick={downloadYAMLHandler('networkPolicy', yaml)}
+            isVisible
+        />
+    );
+
+    const generateNewYAMLControl = generateNetworkPolicies ? (
+        <CodeEditorControl
+            icon={<ProcessAutomationIcon />}
+            aria-label="Generate a new YAML"
+            toolTipText="Generate a new YAML"
+            onClick={generateNetworkPolicies}
+            isVisible
+        />
+    ) : null;
+
+    if (!yaml || yaml === '') {
+        return (
+            <Bullseye>
+                <EmptyState variant={EmptyStateVariant.xs}>
+                    <Title headingLevel="h4" size="md">
+                        No network policies
+                    </Title>
+                </EmptyState>
+            </Bullseye>
+        );
+    }
+
+    return (
+        <div className="pf-u-h-100">
+            <CodeEditor
+                isDarkTheme={customDarkMode}
+                customControls={[
+                    toggleDarkModeControl,
+                    downloadYAMLControl,
+                    generateNewYAMLControl,
+                ]}
+                isCopyEnabled
+                isLineNumbersVisible
+                isReadOnly
+                code={yaml}
+                language={Language.yaml}
+                height="300px"
+            />
+        </div>
+    );
+}
+
+export default NetworkPoliciesYAML;

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPoliciesYAML.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPoliciesYAML.tsx
@@ -57,7 +57,7 @@ function NetworkPoliciesYAML({ yaml, generateNetworkPolicies }: NetworkPoliciesY
         return (
             <Bullseye>
                 <EmptyState variant={EmptyStateVariant.xs}>
-                    <Title headingLevel="h4" size="md">
+                    <Title headingLevel="h2" size="md">
                         No network policies
                     </Title>
                 </EmptyState>

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/ViewActiveYAMLs.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/ViewActiveYAMLs.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect } from 'react';
 import {
     Bullseye,
-    Button,
     EmptyState,
     EmptyStateVariant,
     SelectOption,
@@ -9,24 +8,15 @@ import {
     StackItem,
     Title,
 } from '@patternfly/react-core';
-import { CodeEditor, CodeEditorControl, Language } from '@patternfly/react-code-editor';
-import { MoonIcon, SunIcon } from '@patternfly/react-icons';
-import { useTheme } from 'Containers/ThemeProvider';
-import download from 'utils/download';
 import { NetworkPolicy } from 'types/networkPolicy.proto';
 import SelectSingle from 'Components/SelectSingle';
+import NetworkPoliciesYAML from './NetworkPoliciesYAML';
 
 type ViewActiveYamlsProps = {
     networkPolicies: NetworkPolicy[];
 };
 
-const downloadYAMLHandler = (fileName: string, fileContent: string) => () => {
-    download(`${fileName}.yml`, fileContent, 'yml');
-};
-
 function ViewActiveYamls({ networkPolicies }: ViewActiveYamlsProps) {
-    const { isDarkMode } = useTheme();
-    const [customDarkMode, setCustomDarkMode] = React.useState(isDarkMode);
     const [selectedNetworkPolicy, setSelectedNetworkPolicy] = React.useState<
         NetworkPolicy | undefined
     >(networkPolicies?.[0]);
@@ -38,26 +28,12 @@ function ViewActiveYamls({ networkPolicies }: ViewActiveYamlsProps) {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [networkPolicies]);
 
-    function onToggleDarkMode() {
-        setCustomDarkMode((prevValue) => !prevValue);
-    }
-
     function handleSelectedNetworkPolicy(_, value: string) {
         const newlySelectedNetworkPolicy = networkPolicies?.find(
             (networkPolicy) => networkPolicy.name === value
         );
         setSelectedNetworkPolicy(newlySelectedNetworkPolicy);
     }
-
-    const customControl = (
-        <CodeEditorControl
-            icon={customDarkMode ? <SunIcon /> : <MoonIcon />}
-            aria-label="Toggle dark mode"
-            toolTipText={customDarkMode ? 'Toggle to light mode' : 'Toggle to dark mode'}
-            onClick={onToggleDarkMode}
-            isVisible
-        />
-    );
 
     if (networkPolicies.length === 0) {
         return (
@@ -72,50 +48,32 @@ function ViewActiveYamls({ networkPolicies }: ViewActiveYamlsProps) {
     }
 
     return (
-        <div className="pf-u-h-100 pf-u-p-md">
-            <Stack hasGutter>
+        <div className="pf-u-h-100">
+            <Stack>
                 <StackItem>
-                    <SelectSingle
-                        id="search-filter-attributes-select"
-                        value={selectedNetworkPolicy?.name || ''}
-                        handleSelect={handleSelectedNetworkPolicy}
-                        placeholderText="Select a network policy"
-                    >
-                        {networkPolicies.map((networkPolicy) => {
-                            return (
-                                <SelectOption key={networkPolicy.name} value={networkPolicy.name}>
-                                    {networkPolicy.name}
-                                </SelectOption>
-                            );
-                        })}
-                    </SelectSingle>
+                    <div className="pf-u-p-md">
+                        <SelectSingle
+                            id="search-filter-attributes-select"
+                            value={selectedNetworkPolicy?.name || ''}
+                            handleSelect={handleSelectedNetworkPolicy}
+                            placeholderText="Select a network policy"
+                        >
+                            {networkPolicies.map((networkPolicy) => {
+                                return (
+                                    <SelectOption
+                                        key={networkPolicy.name}
+                                        value={networkPolicy.name}
+                                    >
+                                        {networkPolicy.name}
+                                    </SelectOption>
+                                );
+                            })}
+                        </SelectSingle>
+                    </div>
                 </StackItem>
                 {selectedNetworkPolicy && (
                     <StackItem>
-                        <div className="pf-u-h-100">
-                            <CodeEditor
-                                isDarkTheme={customDarkMode}
-                                customControls={customControl}
-                                isCopyEnabled
-                                isLineNumbersVisible
-                                isReadOnly
-                                code={selectedNetworkPolicy.yaml}
-                                language={Language.yaml}
-                                height="300px"
-                            />
-                        </div>
-                    </StackItem>
-                )}
-                {selectedNetworkPolicy && (
-                    <StackItem>
-                        <Button
-                            onClick={downloadYAMLHandler(
-                                selectedNetworkPolicy.name,
-                                selectedNetworkPolicy.yaml
-                            )}
-                        >
-                            Export YAML
-                        </Button>
+                        <NetworkPoliciesYAML yaml={selectedNetworkPolicy.yaml} />
                     </StackItem>
                 )}
             </Stack>

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/simulatorUtils.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/simulatorUtils.ts
@@ -10,13 +10,11 @@ export function getDisplayYAMLFromNetworkPolicyModification(
     const shouldDelete = toDelete && toDelete.length > 0;
     const showApplyYaml = applyYaml && applyYaml.length >= 2;
 
-    // Format toDelete portion of YAML.
-    let toDeleteSection;
-    if (shouldDelete && toDelete) {
-        toDeleteSection = toDelete
-            .map((entry) => `# kubectl -n ${entry.namespace} delete networkpolicy ${entry.name}`)
-            .join('\n');
-    }
+    const toDeleteSection = shouldDelete
+        ? toDelete
+              .map((entry) => `# kubectl -n ${entry.namespace} delete networkpolicy ${entry.name}`)
+              .join('\n')
+        : '';
 
     // Format complete YAML for display.
     let displayYaml: string;

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/simulatorUtils.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/simulatorUtils.ts
@@ -1,0 +1,34 @@
+import { NetworkPolicyModification } from 'Containers/Network/networkTypes';
+
+export function getDisplayYAMLFromNetworkPolicyModification(
+    modification: NetworkPolicyModification | null
+): string {
+    if (!modification) {
+        return '';
+    }
+    const { applyYaml, toDelete } = modification || {};
+    const shouldDelete = toDelete && toDelete.length > 0;
+    const showApplyYaml = applyYaml && applyYaml.length >= 2;
+
+    // Format toDelete portion of YAML.
+    let toDeleteSection;
+    if (shouldDelete && toDelete) {
+        toDeleteSection = toDelete
+            .map((entry) => `# kubectl -n ${entry.namespace} delete networkpolicy ${entry.name}`)
+            .join('\n');
+    }
+
+    // Format complete YAML for display.
+    let displayYaml: string;
+    if (shouldDelete && showApplyYaml) {
+        displayYaml = [toDeleteSection, applyYaml].join('\n---\n');
+    } else if (shouldDelete && !showApplyYaml) {
+        displayYaml = toDeleteSection;
+    } else if (!shouldDelete && showApplyYaml) {
+        displayYaml = applyYaml;
+    } else {
+        displayYaml = 'No policies need to be created or deleted.';
+    }
+
+    return displayYaml;
+}


### PR DESCRIPTION
## Description

This PR is an iterative step to adding the network policy simulator to the network graph. This PR includes:
1. Refactoring out the YAML section of the `ViewActiveYAML` component and putting it into a new component called `NetworkPoliciesYAML`
2. Updating the `NetworkPolicySimulatorSidePanel` to show the generated YAML when we are in the `GENERATED` state of the network policy simulator.
3.  Adding a function in the `utils/simulatorUtils` to display the yaml in a specific way as used in this file `src/Containers/Network/SidePanel/Simulator/SuccessViewTabs.tsx`

<img width="1440" alt="Screenshot 2022-12-15 at 4 50 34 PM" src="https://user-images.githubusercontent.com/4805485/207999172-dde699d0-4ce1-44fc-988a-23c09f8b322d.png">
<img width="1440" alt="Screenshot 2022-12-15 at 4 51 00 PM" src="https://user-images.githubusercontent.com/4805485/207999190-383fe50c-0562-4e18-b3a9-712992c455b1.png">


## Checklist
- [ ] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~