### PR TITLE
ROX-13887: Revert rules to previously applied YAML

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPoliciesYAML.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPoliciesYAML.tsx
@@ -1,21 +1,31 @@
 import React from 'react';
 import { CodeEditor, CodeEditorControl, Language } from '@patternfly/react-code-editor';
-import { DownloadIcon, MoonIcon, ProcessAutomationIcon, SunIcon } from '@patternfly/react-icons';
-import { Bullseye, EmptyState, EmptyStateVariant, Title } from '@patternfly/react-core';
+import {
+    DownloadIcon,
+    MoonIcon,
+    ProcessAutomationIcon,
+    SunIcon,
+    UndoIcon,
+} from '@patternfly/react-icons';
 
 import { useTheme } from 'Containers/ThemeProvider';
 import download from 'utils/download';
 
 type NetworkPoliciesYAMLProp = {
     yaml: string;
-    generateNetworkPolicies?: () => void;
+    generateNetworkPolicies: () => void;
+    undoNetworkPolicies: () => void;
 };
 
 const downloadYAMLHandler = (fileName: string, fileContent: string) => () => {
     download(`${fileName}.yml`, fileContent, 'yml');
 };
 
-function NetworkPoliciesYAML({ yaml, generateNetworkPolicies }: NetworkPoliciesYAMLProp) {
+function NetworkPoliciesYAML({
+    yaml,
+    generateNetworkPolicies,
+    undoNetworkPolicies,
+}: NetworkPoliciesYAMLProp) {
     const { isDarkMode } = useTheme();
     const [customDarkMode, setCustomDarkMode] = React.useState(isDarkMode);
 
@@ -43,7 +53,7 @@ function NetworkPoliciesYAML({ yaml, generateNetworkPolicies }: NetworkPoliciesY
         />
     );
 
-    const generateNewYAMLControl = generateNetworkPolicies ? (
+    const generateNewYAMLControl = (
         <CodeEditorControl
             icon={<ProcessAutomationIcon />}
             aria-label="Generate a new YAML"
@@ -51,19 +61,17 @@ function NetworkPoliciesYAML({ yaml, generateNetworkPolicies }: NetworkPoliciesY
             onClick={generateNetworkPolicies}
             isVisible
         />
-    ) : null;
+    );
 
-    if (!yaml || yaml === '') {
-        return (
-            <Bullseye>
-                <EmptyState variant={EmptyStateVariant.xs}>
-                    <Title headingLevel="h2" size="md">
-                        No network policies
-                    </Title>
-                </EmptyState>
-            </Bullseye>
-        );
-    }
+    const revertRecentYAML = (
+        <CodeEditorControl
+            icon={<UndoIcon />}
+            aria-label="Revert most recently applied YAML"
+            toolTipText="Revert most recently applied YAML"
+            onClick={undoNetworkPolicies}
+            isVisible
+        />
+    );
 
     return (
         <div className="pf-u-h-100">
@@ -73,6 +81,7 @@ function NetworkPoliciesYAML({ yaml, generateNetworkPolicies }: NetworkPoliciesY
                     toggleDarkModeControl,
                     downloadYAMLControl,
                     generateNewYAMLControl,
+                    revertRecentYAML,
                 ]}
                 isCopyEnabled
                 isLineNumbersVisible

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPoliciesYAML.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPoliciesYAML.tsx
@@ -17,6 +17,12 @@ type NetworkPoliciesYAMLProp = {
     undoNetworkPolicies: () => void;
 };
 
+const labels = {
+    downloadYAML: 'Download YAML',
+    generateYAML: 'Generate a new YAML',
+    revertMostRecentYAML: 'Revert most recently applied YAML',
+};
+
 const downloadYAMLHandler = (fileName: string, fileContent: string) => () => {
     download(`${fileName}.yml`, fileContent, 'yml');
 };
@@ -46,8 +52,8 @@ function NetworkPoliciesYAML({
     const downloadYAMLControl = (
         <CodeEditorControl
             icon={<DownloadIcon />}
-            aria-label="Download YAML"
-            toolTipText="Download YAML"
+            aria-label={labels.downloadYAML}
+            toolTipText={labels.downloadYAML}
             onClick={downloadYAMLHandler('networkPolicy', yaml)}
             isVisible
         />
@@ -56,8 +62,8 @@ function NetworkPoliciesYAML({
     const generateNewYAMLControl = (
         <CodeEditorControl
             icon={<ProcessAutomationIcon />}
-            aria-label="Generate a new YAML"
-            toolTipText="Generate a new YAML"
+            aria-label={labels.generateYAML}
+            toolTipText={labels.generateYAML}
             onClick={generateNetworkPolicies}
             isVisible
         />
@@ -66,8 +72,8 @@ function NetworkPoliciesYAML({
     const revertRecentYAML = (
         <CodeEditorControl
             icon={<UndoIcon />}
-            aria-label="Revert most recently applied YAML"
-            toolTipText="Revert most recently applied YAML"
+            aria-label={labels.revertMostRecentYAML}
+            toolTipText={labels.revertMostRecentYAML}
             onClick={undoNetworkPolicies}
             isVisible
         />

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPolicySimulatorSidePanel.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPolicySimulatorSidePanel.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import {
     Alert,
-    AlertVariant,
     Bullseye,
     Button,
     Checkbox,
@@ -60,23 +59,20 @@ function NetworkPolicySimulatorSidePanel({
         });
     }
 
+    function undoNetworkPolicies() {
+        setNetworkPolicyModification({
+            state: 'UNDO',
+            options: {
+                clusterId: selectedClusterId,
+            },
+        });
+    }
+
     if (simulator.isLoading) {
         return (
             <Bullseye>
                 <Spinner isSVG size="lg" />
             </Bullseye>
-        );
-    }
-
-    // @TODO: I just did this like this for now, but I'll look into how an error should actually be displayed
-    if (simulator.error) {
-        return (
-            <Alert
-                isInline
-                variant={AlertVariant.danger}
-                title={simulator.error}
-                className="pf-u-mb-lg"
-            />
         );
     }
 
@@ -101,16 +97,65 @@ function NetworkPolicySimulatorSidePanel({
                 <Stack hasGutter>
                     <StackItem className="pf-u-p-md">
                         <Alert
-                            variant="success"
+                            variant={simulator.error ? 'danger' : 'success'}
                             isInline
                             isPlain
-                            title="Policies generated from all network activity"
+                            title={
+                                simulator.error
+                                    ? simulator.error
+                                    : 'Policies generated from all network activity'
+                            }
                         />
                     </StackItem>
                     <StackItem isFilled style={{ overflow: 'auto' }}>
                         <NetworkPoliciesYAML
                             yaml={yaml}
                             generateNetworkPolicies={generateNetworkPolicies}
+                            undoNetworkPolicies={undoNetworkPolicies}
+                        />
+                    </StackItem>
+                </Stack>
+            </div>
+        );
+    }
+
+    // @TODO: Consider how to reuse parts of this that are similiar between states
+    if (simulator.state === 'UNDO') {
+        const yaml = getDisplayYAMLFromNetworkPolicyModification(simulator.modification);
+        return (
+            <div>
+                <Flex
+                    direction={{ default: 'row' }}
+                    alignItems={{ default: 'alignItemsFlexEnd' }}
+                    className="pf-u-p-lg pf-u-mb-0"
+                >
+                    <FlexItem>
+                        <TextContent>
+                            <Text component={TextVariants.h2} className="pf-u-font-size-xl">
+                                Network Policy Simulator
+                            </Text>
+                        </TextContent>
+                    </FlexItem>
+                </Flex>
+                <Divider component="div" />
+                <Stack hasGutter>
+                    <StackItem className="pf-u-p-md">
+                        <Alert
+                            variant={simulator.error ? 'danger' : 'success'}
+                            isInline
+                            isPlain
+                            title={
+                                simulator.error
+                                    ? simulator.error
+                                    : 'Viewing modification that will undo last applied change'
+                            }
+                        />
+                    </StackItem>
+                    <StackItem isFilled style={{ overflow: 'auto' }}>
+                        <NetworkPoliciesYAML
+                            yaml={yaml}
+                            generateNetworkPolicies={generateNetworkPolicies}
+                            undoNetworkPolicies={undoNetworkPolicies}
                         />
                     </StackItem>
                 </Stack>

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPolicySimulatorSidePanel.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPolicySimulatorSidePanel.tsx
@@ -284,6 +284,8 @@ function NetworkPolicySimulatorSidePanel({
                         networkPolicies={
                             simulator.state === 'ACTIVE' ? simulator.networkPolicies : []
                         }
+                        generateNetworkPolicies={generateNetworkPolicies}
+                        undoNetworkPolicies={undoNetworkPolicies}
                     />
                 </TabContent>
             </StackItem>

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/ViewActiveYAMLs.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/ViewActiveYAMLs.tsx
@@ -14,9 +14,15 @@ import NetworkPoliciesYAML from './NetworkPoliciesYAML';
 
 type ViewActiveYamlsProps = {
     networkPolicies: NetworkPolicy[];
+    generateNetworkPolicies: () => void;
+    undoNetworkPolicies: () => void;
 };
 
-function ViewActiveYamls({ networkPolicies }: ViewActiveYamlsProps) {
+function ViewActiveYamls({
+    networkPolicies,
+    generateNetworkPolicies,
+    undoNetworkPolicies,
+}: ViewActiveYamlsProps) {
     const [selectedNetworkPolicy, setSelectedNetworkPolicy] = React.useState<
         NetworkPolicy | undefined
     >(networkPolicies?.[0]);
@@ -73,7 +79,11 @@ function ViewActiveYamls({ networkPolicies }: ViewActiveYamlsProps) {
                 </StackItem>
                 {selectedNetworkPolicy && (
                     <StackItem>
-                        <NetworkPoliciesYAML yaml={selectedNetworkPolicy.yaml} />
+                        <NetworkPoliciesYAML
+                            yaml={selectedNetworkPolicy.yaml}
+                            generateNetworkPolicies={generateNetworkPolicies}
+                            undoNetworkPolicies={undoNetworkPolicies}
+                        />
                     </StackItem>
                 )}
             </Stack>

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/simulatorUtils.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/simulatorUtils.ts
@@ -3,9 +3,6 @@ import { NetworkPolicyModification } from 'Containers/Network/networkTypes';
 export function getDisplayYAMLFromNetworkPolicyModification(
     modification: NetworkPolicyModification | null
 ): string {
-    if (!modification) {
-        return '';
-    }
     const { applyYaml, toDelete } = modification || {};
     const shouldDelete = toDelete && toDelete.length > 0;
     const showApplyYaml = applyYaml && applyYaml.length >= 2;


### PR DESCRIPTION
## Description

This PR is an iterative step to adding the network policy simulator to the network graph. This PR includes:
1. Updating the `NetworkPolicySimulatorSidePanel` to show the previously applied YAML when we are in the `UNDO` state of the network policy simulator.

<img width="1440" alt="Screenshot 2022-12-16 at 7 21 11 AM" src="https://user-images.githubusercontent.com/4805485/208130871-dc125333-acbc-40e3-9962-93ab3a8a3ae3.png">
<img width="1440" alt="Screenshot 2022-12-16 at 7 21 18 AM" src="https://user-images.githubusercontent.com/4805485/208130877-22df73bc-9377-48ef-b142-865fc8963184.png">


## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~
