### PR TITLE
ROX-13915: Move docker.io images used in ImageManagementTest to quayio/rhacs-eng to prevent rate limiting

### DIFF
--- a/qa-tests-backend/src/test/groovy/ImageManagementTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageManagementTest.groovy
@@ -220,7 +220,7 @@ class ImageManagementTest extends BaseSpecification {
         def deployment = new Deployment()
                 .setName("risk-image")
                 .setReplicas(1)
-                .setImage("mysql@sha256:f7985e36c668bb862a0e506f4ef9acdd1254cdf690469816f99633898895f7fa")
+                .setImage("quay.io/rhacs-eng/qa:mysql-from-docker-io")
                 .setCommand(["sleep", "60000"])
                 .setSkipReplicaWait(false)
 
@@ -230,7 +230,7 @@ class ImageManagementTest extends BaseSpecification {
         "Assert that riskScore is non-zero"
         withRetry(10, 3) {
             def image = ImageService.getImage(
-                    "sha256:f7985e36c668bb862a0e506f4ef9acdd1254cdf690469816f99633898895f7fa")
+                    "sha256:5c508e03f7f1987a393816a9ce2358f4abbdd36629972ba870af8f4cfcd031c0")
             assert image != null && image.riskScore != 0
         }
 


### PR DESCRIPTION
## Description

See title

## Checklist
- [x] Investigated and inspected CI test results
~[ ] Unit test and regression tests added~
~[ ] Evaluated and added CHANGELOG entry if required~
~[ ] Determined and documented upgrade steps~
~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

this is a test

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
