### PR TITLE
ROX-12924: Mitigate network fetch issues in imaging

### DIFF
--- a/.openshift-ci/build/build-main-and-bundle.sh
+++ b/.openshift-ci/build/build-main-and-bundle.sh
@@ -43,7 +43,7 @@ UI_BUILD_LOG="/tmp/ui_build_log.txt"
 background_build_ui() {
     info "Building the UI in the background"
 
-    (retry 3 false make -C ui build > "$UI_BUILD_LOG" 2>&1)&
+    (retry 5 false make -C ui build > "$UI_BUILD_LOG" 2>&1)&
     ui_build_pid=$!
 }
 

--- a/.openshift-ci/build/build-main-and-bundle.sh
+++ b/.openshift-ci/build/build-main-and-bundle.sh
@@ -43,7 +43,14 @@ UI_BUILD_LOG="/tmp/ui_build_log.txt"
 background_build_ui() {
     info "Building the UI in the background"
 
-    (retry 5 false make -C ui build > "$UI_BUILD_LOG" 2>&1)&
+    yarn_network_timeout=60000
+    increase_timeout_for_retries() {
+        yarn_network_timeout=$((yarn_network_timeout + 60000))
+        export YARN_NETWORK_TIMEOUT="$yarn_network_timeout"
+    }
+
+    (export RETRY_HOOK=increase_timeout_for_retries; \
+        retry 5 false make -C ui build > "$UI_BUILD_LOG" 2>&1)&
     ui_build_pid=$!
 }
 

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -169,6 +169,9 @@ retry() {
                 info "Retrying in $wait seconds..."
                 sleep $wait
             fi
+            if [[ -n "${RETRY_HOOK:-}" ]]; then
+                $RETRY_HOOK
+            fi
         else
             echo "Retry $count/$tries exited $exit, no more retries left."
             return $exit

--- a/ui/Makefile
+++ b/ui/Makefile
@@ -1,4 +1,5 @@
 UI_BASE_URL ?= https://localhost:8000
+YARN_NETWORK_TIMEOUT ?= 60000
 
 .PHONY: all
 all: deps lint test build
@@ -13,7 +14,7 @@ PACKAGE_JSON_FILES := $(shell find . -type d \( -name node_modules \) -prune -fa
 export REACT_APP_ROX_PRODUCT_BRANDING := $(shell $(MAKE) --quiet --no-print-directory -C .. product-branding)
 
 deps: yarn.lock $(PACKAGE_JSON_FILES)
-	yarn install --frozen-lockfile
+	yarn install --frozen-lockfile --network-timeout=$(YARN_NETWORK_TIMEOUT)
 	@touch deps
 
 .PHONY: printsrcs


### PR DESCRIPTION
## Description

There has been an increase in image failures in CI lately due to yarn package fetch failures. This PR attempts to mitigate the failures. The yarn cli has a default network timeout of 30 seconds, that is bumped to 60 seconds and 60 seconds is added for each retry. The retry count goes from 3 to 5.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient - Ideally yarn install fails a few times which may require some artificial tweaking of the timeout.

Update: Given the pass [here](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/stackrox_stackrox/4187/pull-ci-stackrox-stackrox-master-images/1603847624518012928/artifacts/build-logs/main-bundle.log) and the need to fix builds short term, I'll merge this and test the retries in a separate PR.
