### PR TITLE
CI: Move builds to GHA

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,6 +1,12 @@
 name: Build
 on:
-  push
+  pull_request:
+    types:
+      - opened
+      - synchronize
+  push:
+    branches:
+      - master
 
 env:
   ROX_PRODUCT_BRANDING: RHACS_BRANDING

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,10 +1,6 @@
 name: Build
 on:
-  pull_request:
-    types:
-    - opened
-    - synchronize
-    - labeled
+  push
 
 env:
   ROX_PRODUCT_BRANDING: RHACS_BRANDING
@@ -12,10 +8,6 @@ env:
 jobs:
 
   pre-build-ui:
-    if: |
-      (github.event.action == 'labeled' && github.event.label.name == 'turbo-build') ||
-      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'turbo-build'))
-
     runs-on: ubuntu-latest
     container:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.49
@@ -44,9 +36,6 @@ jobs:
             ui/monorepo.lock
 
   pre-build-cli:
-    if: |
-      (github.event.action == 'labeled' && github.event.label.name == 'turbo-build') ||
-      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'turbo-build'))
     runs-on: ubuntu-latest
     container:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.49
@@ -72,9 +61,6 @@ jobs:
           path: cli-build.tgz
 
   pre-build-go-binaries:
-    if: |
-      (github.event.action == 'labeled' && github.event.label.name == 'turbo-build') ||
-      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'turbo-build'))
     runs-on: ubuntu-latest
     container:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.49
@@ -107,9 +93,6 @@ jobs:
           path: go-binaries-build.tgz
 
   pre-build-docs:
-    if: |
-      (github.event.action == 'labeled' && github.event.label.name == 'turbo-build') ||
-      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'turbo-build'))
     runs-on: ubuntu-latest
     container:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.49
@@ -139,9 +122,6 @@ jobs:
             image/docs
 
   build-and-push-main:
-    if: |
-      (github.event.action == 'labeled' && github.event.label.name == 'turbo-build') ||
-      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'turbo-build'))
     runs-on: ubuntu-latest
     needs: 
       - pre-build-ui
@@ -232,9 +212,6 @@ jobs:
             add_build_comment_to_pr
 
   build-and-push-operator:
-    if: |
-      (github.event.action == 'labeled' && github.event.label.name == 'turbo-build') ||
-      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'turbo-build'))
     runs-on: ubuntu-latest
     container:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.49
@@ -288,70 +265,7 @@ jobs:
         run: |
           make -C operator/ docker-push-index | cat
 
-  build-and-push-docs:
-    if: |
-      (github.event.action == 'labeled' && github.event.label.name == 'turbo-build') ||
-      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'turbo-build'))
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-        ref: ${{ github.event.pull_request.head.sha }}
-    - name: Checkout submodules
-      run: |
-        git submodule update --init
-    - name: Get docs tag
-      id: tag
-      run: |
-        echo "DOCS_TAG=$(make --quiet docs-tag)" >> "$GITHUB_OUTPUT"
-        echo "TAG=$(make --quiet tag)" >> "$GITHUB_OUTPUT"
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
-    - name: Build
-      uses: docker/build-push-action@v3
-      with:
-        context: docs
-        push: false
-        tags: |
-          quay.io/rhacs-eng/docs:${{ steps.tag.outputs.TAG }}
-          quay.io/rhacs-eng/docs:${{ steps.tag.outputs.DOCS_TAG }}
-          quay.io/stackrox-io/docs:${{ steps.tag.outputs.TAG }}
-          quay.io/stackrox-io/docs:${{ steps.tag.outputs.DOCS_TAG }}
-    - name: Login to quay.io/rhacs-eng
-      uses: docker/login-action@v2
-      with:
-        registry: quay.io
-        username: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
-        password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
-    - name: Push to quay.io/rhacs-eng
-      uses: docker/build-push-action@v3
-      with:
-        context: docs
-        push: true
-        tags: |
-          quay.io/rhacs-eng/docs:${{ steps.tag.outputs.TAG }}
-          quay.io/rhacs-eng/docs:${{ steps.tag.outputs.DOCS_TAG }}
-    - name: Login to quay.io/stackrox-io
-      uses: docker/login-action@v2
-      with:
-        registry: quay.io
-        username: ${{ secrets.QUAY_STACKROX_IO_RW_USERNAME }}
-        password: ${{ secrets.QUAY_STACKROX_IO_RW_PASSWORD }}
-    - name: Push to quay.io/stackrox-io
-      uses: docker/build-push-action@v3
-      with:
-        context: docs
-        push: true
-        tags: |
-          quay.io/stackrox-io/docs:${{ steps.tag.outputs.TAG }}
-          quay.io/stackrox-io/docs:${{ steps.tag.outputs.DOCS_TAG }}
-
   build-and-push-mock-grpc-server:
-    if: |
-      (github.event.action == 'labeled' && github.event.label.name == 'turbo-build') ||
-      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'turbo-build'))
     runs-on: ubuntu-latest
     container:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.49

--- a/scripts/ci/jobs/push-images.sh
+++ b/scripts/ci/jobs/push-images.sh
@@ -45,7 +45,7 @@ push_images() {
     fi
 
     if [[ -n "${MAIN_IMAGE}" ]]; then
-        if is_OPENSHIFT_CI && is_in_PR_context && pr_has_label "turbo-build" && [[ "$brand" == "RHACS_BRANDING" ]]; then
+        if is_OPENSHIFT_CI && [[ "$brand" == "RHACS_BRANDING" ]]; then
             info "Images were built and pushed elsewhere, skipping it here."
         else
             push_main_image_set "$push_context" "$brand"
@@ -56,20 +56,18 @@ push_images() {
         push_race_condition_debug_image
     fi
     if [[ -n "${OPERATOR_IMAGE:-}" ]]; then
-        if is_OPENSHIFT_CI && is_in_PR_context && pr_has_label "turbo-build"; then
+        if is_OPENSHIFT_CI; then
             info "Operator images were built and pushed elsewhere, skipping it here."
         else
             push_operator_image_set "$push_context" "$brand"
         fi
     fi
     if [[ -n "${MOCK_GRPC_SERVER_IMAGE:-}" ]]; then
-        push_mock_grpc_server_image
-    fi
-
-    if is_in_PR_context && [[ "$brand" == "STACKROX_BRANDING" ]] && [[ -n "${MAIN_IMAGE}" ]]; then
-        add_build_comment_to_pr || {
-            info "Could not add a comment to the PR"
-        }
+        if is_OPENSHIFT_CI; then
+            info "Mock GRPC image was built and pushed elsewhere, skipping it here."
+        else
+            push_mock_grpc_server_image
+        fi
     fi
 }
 

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -875,8 +875,8 @@ get_pr_details() {
         fi
         [[ "${pull_request}" == "null" ]] && _not_a_PR
     elif is_GITHUB_ACTIONS; then
-        jq -r "${GITHUB_EVENT_PATH}" || true
         pull_request="$(jq -r .pull_request.number "${GITHUB_EVENT_PATH}")" || _not_a_PR
+        [[ "${pull_request}" == "null" ]] && _not_a_PR
         org="${GITHUB_REPOSITORY_OWNER}"
         repo="${GITHUB_REPOSITORY#*/}"
     else

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -875,6 +875,7 @@ get_pr_details() {
         fi
         [[ "${pull_request}" == "null" ]] && _not_a_PR
     elif is_GITHUB_ACTIONS; then
+        jq -r "${GITHUB_EVENT_PATH}" || true
         pull_request="$(jq -r .pull_request.number "${GITHUB_EVENT_PATH}")" || _not_a_PR
         org="${GITHUB_REPOSITORY_OWNER}"
         repo="${GITHUB_REPOSITORY#*/}"


### PR DESCRIPTION
## Description

Image builds are on a downhill slide with OpenShift CI. This [PR](https://github.com/stackrox/stackrox/pull/4184) for example had 4 consecutive failures building the main image. #test-platform is [unresponsive](https://coreos.slack.com/archives/CBN38N3MW/p1671215358151709) (albeit a Friday afternoon).

This PR will change the builds to run using GHA for PRs and main branch merge. The required branch protection step for this repo can change to GHA once people rebase. This PR also removes the obsolete docs image. 

Followup PRs will be needed to:
- Address releases
- Add check steps
- Also cover StackRox branded images
- Add the `-race` image (in progress).
- Completely remove imaging from OSCI

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient.
- [x] builds and pushed in GHA
- [x] only builds `-race` and StackRox brands in OSCI
