### PR TITLE
Add usePaginatedQuery hook to abstract over infinite list queries

### DIFF
--- a/ui/apps/platform/src/hooks/usePaginatedQuery.test.ts
+++ b/ui/apps/platform/src/hooks/usePaginatedQuery.test.ts
@@ -1,0 +1,112 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+import { usePaginatedQuery } from 'hooks/usePaginatedQuery';
+
+describe('usePaginatedQuery hook', () => {
+    const data = [
+        { id: '1' },
+        { id: '2' },
+        { id: '3' },
+        { id: '4' },
+        { id: '4' }, // Duplicate item to simulate server side data changes or inconsistencies
+        { id: '5' },
+        { id: '6' },
+        { id: '7' },
+        { id: '8' },
+    ] as const;
+
+    const pageSize = 2;
+    const requestFn = (page: number) => {
+        const offset = page * pageSize;
+        return Promise.resolve(data.slice(offset, offset + pageSize));
+    };
+
+    it('should return paginated data without duplicates', async () => {
+        const { result, waitForNextUpdate } = renderHook(() =>
+            usePaginatedQuery(requestFn, pageSize, { dedupKeyFn: ({ id }) => id, debounceRate: 10 })
+        );
+
+        // Test initial empty state
+        expect(result.current.data).toHaveLength(0);
+
+        // Test after initial automatic fetch
+        await waitForNextUpdate();
+        expect(result.current.data).toEqual([[{ id: '1' }, { id: '2' }]]);
+
+        // Test event causing a fetch of the next page
+        act(() => {
+            // Test with an `immediate=true` parameter to cover immediate and debounced use cases
+            result.current.fetchNextPage(true);
+        });
+        await waitForNextUpdate();
+        expect(result.current.data).toEqual([
+            [{ id: '1' }, { id: '2' }],
+            [{ id: '3' }, { id: '4' }],
+        ]);
+
+        // Test event causing a fetch with duplicate data
+        act(() => {
+            result.current.fetchNextPage();
+        });
+        await waitForNextUpdate();
+        expect(result.current.data).toEqual([
+            [{ id: '1' }, { id: '2' }],
+            [{ id: '3' }, { id: '4' }],
+            [{ id: '5' }],
+        ]);
+
+        // Test subsequent fetch without duplicates again
+        act(() => {
+            result.current.fetchNextPage();
+        });
+        await waitForNextUpdate();
+        expect(result.current.data).toEqual([
+            [{ id: '1' }, { id: '2' }],
+            [{ id: '3' }, { id: '4' }],
+            [{ id: '5' }],
+            [{ id: '6' }, { id: '7' }],
+        ]);
+
+        // Test that end of results detected correctly
+        expect(result.current.isEndOfResults).toBeFalsy(); // `{ id: '8' }` still remaining
+        act(() => {
+            result.current.fetchNextPage();
+        });
+        await waitForNextUpdate();
+        expect(result.current.isEndOfResults).toBeTruthy();
+    });
+
+    it('should clear cached data when reset or clear function is called', async () => {
+        const { result, waitForNextUpdate } = renderHook(() =>
+            usePaginatedQuery(requestFn, pageSize, { dedupKeyFn: ({ id }) => id, debounceRate: 10 })
+        );
+
+        // Test initial empty state
+        expect(result.current.data).toHaveLength(0);
+
+        // Test after initial automatic fetch
+        await waitForNextUpdate();
+        expect(result.current.data).toEqual([[{ id: '1' }, { id: '2' }]]);
+
+        // Test that data is cleared correctly
+        act(() => {
+            result.current.resetPages();
+        });
+        expect(result.current.isRefreshingResults).toBeTruthy();
+        expect(result.current.isFetchingNextPage).toBeTruthy();
+        expect(result.current.data).toHaveLength(0);
+
+        // Test that reset automatically fetches the first page
+        await waitForNextUpdate();
+        expect(result.current.data).toHaveLength(1);
+        expect(result.current.isRefreshingResults).toBeFalsy();
+        expect(result.current.isFetchingNextPage).toBeFalsy();
+
+        // Test that clearing the data works correctly and _does not_ automatically fetch a new page
+        act(() => {
+            result.current.clearPages();
+        });
+        expect(result.current.data).toHaveLength(0);
+        expect(result.current.isRefreshingResults).toBeFalsy();
+        expect(result.current.isFetchingNextPage).toBeFalsy();
+    });
+});

--- a/ui/apps/platform/src/hooks/usePaginatedQuery.ts
+++ b/ui/apps/platform/src/hooks/usePaginatedQuery.ts
@@ -4,18 +4,18 @@ import { debounce } from 'lodash';
 function filterNextPage<Item, ItemKey>(
     results: Item[],
     itemKeys: Set<ItemKey>,
-    keyFn: ((item: Item) => ItemKey) | undefined
+    dedupKeyFn: ((item: Item) => ItemKey) | undefined
 ) {
     // If a deduplication function has been provided, use it to ensure only unique items
     // are added to the data results. Otherwise, return the results directly without the need
     // to update the key Set.
-    if (!keyFn) {
+    if (!dedupKeyFn) {
         return { nextPageItems: results, nextKeys: itemKeys };
     }
     const nextPageItems: Item[] = [];
     const nextKeys = new Set(itemKeys);
     results.forEach((item) => {
-        const itemKey = keyFn(item);
+        const itemKey = dedupKeyFn(item);
         if (!nextKeys.has(itemKey)) {
             nextKeys.add(itemKey);
             nextPageItems.push(item);
@@ -80,6 +80,9 @@ export function usePaginatedQuery<Item, ItemKey>(
         manualFetch?: boolean;
     } = {}
 ): UsePaginatedQueryReturn<Item> {
+    // These initialOptions are stored in state instead of being destructured directly since
+    // the `fetchPageHandler` function below relies on the reference of `dedupKeyFn`. By storing these
+    // in state, it removes the burden of wrapping in a useCallback or useMemo from the caller.
     const [{ debounceRate, dedupKeyFn, onError, manualFetch = false }] = useState(initialOptions);
     const [isRefreshingResults, setIsRefreshingResults] = useState(false);
     const [isFetchingNextPage, setIsFetchingNextPage] = useState(false);

--- a/ui/apps/platform/src/hooks/usePaginatedQuery.ts
+++ b/ui/apps/platform/src/hooks/usePaginatedQuery.ts
@@ -1,0 +1,187 @@
+import { useState, useCallback, useEffect, useMemo } from 'react';
+import { debounce } from 'lodash';
+
+function filterNextPage<Item, ItemKey>(
+    results: Item[],
+    itemKeys: Set<ItemKey>,
+    keyFn: ((item: Item) => ItemKey) | undefined
+) {
+    // If a deduplication function has been provided, use it to ensure only unique items
+    // are added to the data results. Otherwise, return the results directly without the need
+    // to update the key Set.
+    if (!keyFn) {
+        return { nextPageItems: results, nextKeys: itemKeys };
+    }
+    const nextPageItems: Item[] = [];
+    const nextKeys = new Set(itemKeys);
+    results.forEach((item) => {
+        const itemKey = keyFn(item);
+        if (!nextKeys.has(itemKey)) {
+            nextKeys.add(itemKey);
+            nextPageItems.push(item);
+        }
+    });
+    return { nextPageItems, nextKeys };
+}
+
+export type UsePaginatedQueryReturn<Item> = {
+    /** The returned data. Each item in the top level array is a page of data `Item`s */
+    data: Item[][];
+    /** The current page */
+    page: number;
+    /** If the last fetch resulted in an error the `Error` value will appear here */
+    lastFetchError: Error | null;
+    /** If a page fetch is in flight */
+    isFetchingNextPage: boolean;
+    /** If a page fetch is in flight due to the caller refreshing the entire paginated results array */
+    isRefreshingResults: boolean;
+    /** If no more results are present on the server */
+    isEndOfResults: boolean;
+    /** Imperatively request the next page, which will declaratively be available in `data` */
+    fetchNextPage: (immediate?: boolean) => void;
+    /** Clears the entire `data` array and fetches the first page from the beginning */
+    resetPages: () => void;
+    /** Clears the entire `data` array and does not fetch a new page */
+    clearPages: () => void;
+};
+
+/**
+ * This hook is used for infinite loading query patterns via pagination. It's primary use case is a UI list
+ * that we want to infinitely load via something like a "View more" button, that shows all resulting data in
+ * a single UI. i.e. It does not use traditional "paged" UI components.
+ *
+ * In addition to fetching the data, this hook also can handle deduplicating the response in cases where the source
+ * data changes faster than it is loaded in the UI. This is needed to avoid React key conflicts when rendering the
+ * data, as well as for ensuring the results are unique.
+ *
+ * Conceptually it is similar to tanstack-query's https://tanstack.com/query/v4/docs/guides/infinite-queries or
+ * SWR's https://swr.vercel.app/docs/pagination#useswrinfinite so that we can replace this logic if we move
+ * to library based querying in the future.
+ */
+export function usePaginatedQuery<Item, ItemKey>(
+    /** The function used to fetch each page of data */
+    queryFn: (page: number) => Promise<Item[]>,
+    /** The number of items to retrieve per page */
+    pageSize: number,
+    initialOptions: {
+        /** How much debounce delay should occur before the fetch request is sent */
+        debounceRate?: number;
+        /**
+         * The function used to determine the unique key of each item to avoid duplication. If
+         * this parameter is omitted the hook will allow duplicate data in the results.
+         */
+        dedupKeyFn?: (item: Item) => ItemKey;
+        /** Callback function to fire if a request results in an error */
+        onError?: (err: Error) => void;
+        /**
+         *  Whether or not the initial fetch call for the first page should be automatic or require
+         * a manual call to `fetchNextPage`
+         */
+        manualFetch?: boolean;
+    } = {}
+): UsePaginatedQueryReturn<Item> {
+    const [{ debounceRate, dedupKeyFn, onError, manualFetch = false }] = useState(initialOptions);
+    const [isRefreshingResults, setIsRefreshingResults] = useState(false);
+    const [isFetchingNextPage, setIsFetchingNextPage] = useState(false);
+    const [isEndOfResults, setIsEndOfResults] = useState(false);
+    const [lastFetchError, setLastFetchError] = useState<Error | null>(null);
+
+    const [itemKeys, setItemKeys] = useState<Set<ItemKey>>(new Set());
+    const [itemPages, setItemPages] = useState<Item[][]>([]);
+
+    // Pages are zero-indexed, so the length of the current cached data array is equal
+    // to the current page
+    const page = itemPages.length;
+
+    const fetchPageHandler = useCallback(
+        (fetchFn: typeof queryFn, nextPage: number, nextItemKeys: Set<ItemKey>) => {
+            return fetchFn(nextPage)
+                .then((res) => {
+                    setLastFetchError(null);
+                    if (res.length < pageSize) {
+                        setIsEndOfResults(true);
+                    }
+                    const { nextPageItems, nextKeys } = filterNextPage(
+                        res,
+                        nextItemKeys,
+                        dedupKeyFn
+                    );
+                    setItemPages((prevData) => {
+                        const nextData = [...prevData];
+                        // We set directly via array index here instead of appending to prevent bugs when
+                        // additional fetch requests are initiated before the first completes.
+                        nextData[nextPage] = nextPageItems;
+                        return nextData;
+                    });
+                    setItemKeys(nextKeys);
+                })
+                .catch((err) => {
+                    setLastFetchError(err);
+                    if (onError) {
+                        onError(err);
+                    }
+                })
+                .finally(() => {
+                    setIsFetchingNextPage(false);
+                    setIsRefreshingResults(false);
+                });
+        },
+        [dedupKeyFn, onError, pageSize]
+    );
+
+    // Retain a reference to the debounced fetch function and the raw fetch function for cases
+    // we know that we want to fetch the data _now_.
+    // (e.g. We would want to debounce for text input `keypress` events, but a single
+    // "View more" button that is immediately disabled once clicked can fetch without delay.)
+    const pageFetcher = useMemo(() => {
+        setIsFetchingNextPage(true);
+        return {
+            debounced: debounce(fetchPageHandler, debounceRate ?? 0),
+            immediate: fetchPageHandler,
+        };
+    }, [debounceRate, fetchPageHandler]);
+
+    const fetchNextPage = useCallback(
+        (immediate = false) => {
+            if (immediate) {
+                return pageFetcher.immediate(queryFn, page, itemKeys);
+            }
+            return pageFetcher.debounced(queryFn, page, itemKeys);
+        },
+        [pageFetcher, queryFn, page, itemKeys]
+    );
+
+    const clearPages = useCallback(() => {
+        setItemPages([]);
+        setItemKeys(new Set());
+        setIsEndOfResults(false);
+        setLastFetchError(null);
+    }, []);
+
+    const resetPages = useCallback(() => {
+        clearPages();
+        setIsRefreshingResults(true);
+        setIsFetchingNextPage(true);
+        // Error handling and state setting already complete, so ignore this error
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
+        pageFetcher.debounced(queryFn, 0, new Set());
+    }, [clearPages, pageFetcher, queryFn]);
+
+    useEffect(() => {
+        if (!manualFetch) {
+            resetPages();
+        }
+    }, [manualFetch, resetPages]);
+
+    return {
+        data: itemPages,
+        page,
+        lastFetchError,
+        isFetchingNextPage,
+        isRefreshingResults,
+        isEndOfResults,
+        fetchNextPage,
+        resetPages,
+        clearPages,
+    };
+}


### PR DESCRIPTION
## Description

This adds a hook that allows us to fetch data that will be presented in an "infinite list" type UI.

This is something that would likely be better of handled by a library like react-query or SWR, but integration with those libraries is likely a ways off in the future. On the other hand, since this pattern occurs 3 times in Collections already I thought it would be valuable to extract this logic instead of copy-pasting similar code in each component. I think we should have an end goal of deleting this hook and replacing with something standard down the line.

## Follow ups

- Convert existing CollectionResults logic to use this hook ([Draft] https://github.com/stackrox/stackrox/pull/4198)
- Use this hook for the Collection dropdown in the updated Vuln Mgmt form
- Use this hook for the Collection Attacher component (if possible)

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Core functionality is tested via unit tests.

Manual functionality is tested in the implementation of this for the first two follow up items above. (PRs coming soon.)
