### PR TITLE
Update Vuln Reporting UI to use collections instead of resource scopes

### DIFF
--- a/ui/apps/platform/cypress/fixtures/collections/collections.json
+++ b/ui/apps/platform/cypress/fixtures/collections/collections.json
@@ -1,0 +1,20 @@
+{
+    "collections": [
+        {
+            "id": "34e57a20-c630-4767-baa9-0cb26c1274b9",
+            "name": "Security Cluster Collection (CYPRESS)",
+            "description": "Test collection for Cypress e2e tests",
+            "resourceSelectors": [
+                {
+                    "rules": [
+                        {
+                            "operator": "OR",
+                            "fieldName": "Cluster",
+                            "values": [{ "value": "security" }]
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/ui/apps/platform/cypress/integration/vulnmanagement/reporting/reporting.helpers.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/reporting/reporting.helpers.js
@@ -97,8 +97,10 @@ export function visitVulnerabilityReportingWithFixture(fixturePath) {
 // action create
 
 export const accessScopesAlias = 'simpleaccessscopes';
+export const collectionsAlias = 'collections';
 export const notifiersAlias = 'notifiers';
 
+// TODO This object can be deleted once the ROX_OBJECT_COLLECTIONS feature flag is removed
 const routeMatcherMapToCreate = {
     [accessScopesAlias]: {
         method: 'GET',
@@ -110,10 +112,31 @@ const routeMatcherMapToCreate = {
     },
 };
 
-export function visitVulnerabilityReportingToCreate(staticResponseMap) {
-    visit(`${basePath}?action=create`, routeMatcherMapToCreate, staticResponseMap);
+const routeMatcherMapToCreateWithCollections = {
+    [collectionsAlias]: {
+        method: 'GET',
+        url: '/v1/collections*',
+    },
+    [notifiersAlias]: {
+        method: 'GET',
+        url: '/v1/notifiers',
+    },
+};
+
+export function visitVulnerabilityReportingToCreate(staticResponseMap, isCollectionsEnabled) {
+    const routeMatcherMap = isCollectionsEnabled
+        ? routeMatcherMapToCreateWithCollections
+        : routeMatcherMapToCreate;
+    visit(`${basePath}?action=create`, routeMatcherMap, staticResponseMap);
 }
 
-export function interactAndWaitToCreateReport(interactionCallback, staticResponseMap) {
-    interactAndWaitForResponses(interactionCallback, routeMatcherMapToCreate, staticResponseMap);
+export function interactAndWaitToCreateReport(
+    interactionCallback,
+    staticResponseMap,
+    isCollectionsEnabled
+) {
+    const routeMatcherMap = isCollectionsEnabled
+        ? routeMatcherMapToCreateWithCollections
+        : routeMatcherMapToCreate;
+    interactAndWaitForResponses(interactionCallback, routeMatcherMap, staticResponseMap);
 }

--- a/ui/apps/platform/src/Containers/Collections/CollectionsFormPage.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionsFormPage.tsx
@@ -324,7 +324,10 @@ function CollectionsFormPage({
             {modalCollectionId && (
                 <CollectionsFormModal
                     hasWriteAccessForCollections={hasWriteAccessForCollections}
-                    collectionId={modalCollectionId}
+                    modalAction={{
+                        type: 'view',
+                        collectionId: modalCollectionId,
+                    }}
                     onClose={() => setModalCollectionId(null)}
                 />
             )}

--- a/ui/apps/platform/src/Containers/Collections/errorUtils.ts
+++ b/ui/apps/platform/src/Containers/Collections/errorUtils.ts
@@ -50,7 +50,7 @@ export function parseConfigError(err: Error): CollectionConfigError {
         // Error for collection update
         /name already in use/.test(rawMessage)
     ) {
-        return { type: 'DuplicateName', message: 'Name must be unique' };
+        return { type: 'DuplicateName', message: 'The collection name must be unique' };
     }
 
     if (/name should not be empty/.test(rawMessage)) {

--- a/ui/apps/platform/src/Containers/VulnMgmt/Reports/Components/ScopeName.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Reports/Components/ScopeName.tsx
@@ -3,14 +3,17 @@ import { Button, ButtonVariant, Spinner } from '@patternfly/react-core';
 
 import LinkShim from 'Components/PatternFly/LinkShim';
 import { getEntityPath } from 'Containers/AccessControl/accessControlPaths';
+import useFeatureFlags from 'hooks/useFeatureFlags';
 import useFetchScopes from 'hooks/useFetchScopes';
+import useCollection from 'Containers/Collections/hooks/useCollection';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
+import { collectionsBasePath } from 'routePaths';
 
 type ScopeNameProps = {
     scopeId: string;
 };
 
-function ScopeName({ scopeId }: ScopeNameProps): ReactElement {
+function AccessScopeName({ scopeId }: ScopeNameProps): ReactElement {
     const scopesResult = useFetchScopes();
 
     if (!scopeId) {
@@ -33,6 +36,41 @@ function ScopeName({ scopeId }: ScopeNameProps): ReactElement {
         <Button variant={ButtonVariant.link} isInline component={LinkShim} href={url}>
             {fullScope?.name || scopeId}
         </Button>
+    );
+}
+
+function CollectionScopeName({ scopeId }: ScopeNameProps): ReactElement {
+    const { data, loading, error } = useCollection(scopeId);
+
+    if (!scopeId) {
+        return <em>No report scope specified</em>;
+    }
+
+    if (loading) {
+        return <Spinner isSVG size="md" />;
+    }
+
+    if (error) {
+        return <span>Error getting scope info. {getAxiosErrorMessage(error)}</span>;
+    }
+
+    const url = `${collectionsBasePath}/${scopeId}`;
+
+    return (
+        <Button variant={ButtonVariant.link} isInline component={LinkShim} href={url}>
+            {data?.collection?.name || scopeId}
+        </Button>
+    );
+}
+
+function ScopeName(props: ScopeNameProps) {
+    const { isFeatureFlagEnabled } = useFeatureFlags();
+    const isCollectionsEnabled = isFeatureFlagEnabled('ROX_OBJECT_COLLECTIONS');
+
+    return isCollectionsEnabled ? (
+        <CollectionScopeName {...props} />
+    ) : (
+        <AccessScopeName {...props} />
     );
 }
 

--- a/ui/apps/platform/src/Containers/VulnMgmt/Reports/Detail/VulnMgmtReportDetail.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Reports/Detail/VulnMgmtReportDetail.tsx
@@ -236,7 +236,7 @@ function VulnMgmtReportDetail({ report }: VulnMgmtReportDetailProps): ReactEleme
                                 </DescriptionListDescription>
                             </DescriptionListGroup>
                             <DescriptionListGroup>
-                                <DescriptionListTerm>Resource scope</DescriptionListTerm>
+                                <DescriptionListTerm>Report scope</DescriptionListTerm>
                                 <DescriptionListDescription>
                                     <ScopeName scopeId={report?.scopeId} />
                                 </DescriptionListDescription>

--- a/ui/apps/platform/src/Containers/VulnMgmt/Reports/Form/CollectionSelection.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Reports/Form/CollectionSelection.tsx
@@ -1,0 +1,167 @@
+import React, { useMemo, useState, ReactElement, useCallback } from 'react';
+import {
+    Button,
+    ButtonVariant,
+    Flex,
+    FlexItem,
+    Select,
+    SelectOption,
+    SelectProps,
+    SelectVariant,
+} from '@patternfly/react-core';
+import sortBy from 'lodash/sortBy';
+import uniqBy from 'lodash/uniqBy';
+
+import FormLabelGroup from 'Components/PatternFly/FormLabelGroup';
+import { Collection, listCollections } from 'services/CollectionsService';
+import CollectionsFormModal from 'Containers/Collections/CollectionFormModal';
+import { useCollectionFormSubmission } from 'Containers/Collections/hooks/useCollectionFormSubmission';
+import { useFormik } from 'formik';
+import useSelectToggle from 'hooks/patternfly/useSelectToggle';
+import { usePaginatedQuery } from 'hooks/usePaginatedQuery';
+
+const COLLECTION_PAGE_SIZE = 10;
+
+type CollectionSelectionProps = {
+    scopeId: string;
+    setFieldValue: ReturnType<typeof useFormik<{ scopeId: string }>>['setFieldValue'];
+    allowCreate: boolean;
+};
+
+function CollectionSelection({
+    scopeId,
+    setFieldValue,
+    allowCreate,
+}: CollectionSelectionProps): ReactElement {
+    const { isOpen, onToggle } = useSelectToggle();
+    const { configError, setConfigError, onSubmit } = useCollectionFormSubmission({
+        type: 'create',
+    });
+    const [search, setSearch] = useState('');
+
+    const [isCollectionModalOpen, setIsCollectionModalOpen] = useState(false);
+
+    const requestFn = useCallback(
+        (page: number) => {
+            return listCollections(
+                { 'Collection Name': search },
+                { field: 'Collection Name', reversed: false },
+                page,
+                COLLECTION_PAGE_SIZE
+            ).request;
+        },
+        [search]
+    );
+
+    const { data, isEndOfResults, isFetchingNextPage, fetchNextPage } = usePaginatedQuery(
+        requestFn,
+        COLLECTION_PAGE_SIZE
+    );
+
+    // Combines the server-side fetched pages of collections data with the local cache
+    // of created collections to create a flattened array sorted by name. This is intended to keep
+    // the collection dropdown up to date with any collections that the user creates while in the form.
+    //
+    // Previously this was not needed since the component would refetch _all_ access scopes
+    // upon creation of a new access scope, but we cannot do that efficiently since the collection dropdown
+    // is paginated.
+    //
+    // This functionality can likely be removed if we move to a library based method of data fetching.
+    const [createdCollections, setCreatedCollections] = useState<Collection[]>([]);
+    const sortedCollections = useMemo(() => {
+        // This is inefficient due to the multiple loops and the fact that we are already tracking
+        // uniqueness for the _server side_ values, but need to do it twice to handle possible client
+        // side values. However, 'N' should be small here and we are memoizing the result.
+        const sorted = sortBy(data.flat().concat(createdCollections), ['name']);
+        return uniqBy(sorted, 'id');
+    }, [data, createdCollections]);
+
+    function onToggleCollectionModal() {
+        setIsCollectionModalOpen((current) => !current);
+    }
+
+    function onScopeChange(_id, selection) {
+        onToggle(false);
+        return setFieldValue('scopeId', selection);
+    }
+
+    let selectLoadingVariant: SelectProps['loadingVariant'];
+
+    if (isFetchingNextPage) {
+        selectLoadingVariant = 'spinner';
+    } else if (!isEndOfResults) {
+        selectLoadingVariant = {
+            text: 'View more',
+            onClick: () => fetchNextPage(),
+        };
+    }
+
+    return (
+        <>
+            <Flex alignItems={{ default: 'alignItemsFlexEnd' }}>
+                <FlexItem>
+                    <FormLabelGroup
+                        className="pf-u-mb-md"
+                        isRequired
+                        label="Configure report scope"
+                        fieldId="scopeId"
+                        touched={{}}
+                        errors={{}}
+                    >
+                        <Select
+                            id="scopeId"
+                            onSelect={onScopeChange}
+                            selections={scopeId}
+                            placeholderText="Select a collection"
+                            variant={SelectVariant.typeahead}
+                            isOpen={isOpen}
+                            onToggle={onToggle}
+                            onTypeaheadInputChanged={setSearch}
+                            loadingVariant={selectLoadingVariant}
+                            isInputValuePersisted
+                        >
+                            {sortedCollections.map(({ id, name, description }) => (
+                                <SelectOption key={id} value={id} description={description}>
+                                    {name}
+                                </SelectOption>
+                            ))}
+                        </Select>
+                    </FormLabelGroup>
+                </FlexItem>
+                {allowCreate && (
+                    <FlexItem>
+                        <Button
+                            className="pf-u-mb-md"
+                            variant={ButtonVariant.secondary}
+                            onClick={onToggleCollectionModal}
+                        >
+                            Create collection
+                        </Button>
+                    </FlexItem>
+                )}
+            </Flex>
+            {isCollectionModalOpen && (
+                <CollectionsFormModal
+                    hasWriteAccessForCollections={allowCreate}
+                    modalAction={{ type: 'create' }}
+                    onClose={() => setIsCollectionModalOpen(false)}
+                    configError={configError}
+                    setConfigError={setConfigError}
+                    onSubmit={(collection) =>
+                        onSubmit(collection).then((collectionResponse) =>
+                            setFieldValue('scopeId', collectionResponse.id).then(() => {
+                                setIsCollectionModalOpen(false);
+                                setCreatedCollections((oldCollections) => [
+                                    ...oldCollections,
+                                    collectionResponse,
+                                ]);
+                            })
+                        )
+                    }
+                />
+            )}
+        </>
+    );
+}
+
+export default CollectionSelection;


### PR DESCRIPTION
## Description

Switches over the VM reporting section to use Collections instead of Access Scopes when the `ROX_OBJECT_COLLECTIONS` feature flag is enabled.

**Note that this change comes with the following caveats**

1. The back end being used is a build from the (currently un-merged) branch that implements the BE functionality: https://github.com/stackrox/stackrox/pull/4100 
2. A database migration _has not_ occurred to handle existing VM report configurations that we saved using access scopes as the scoping mechanism. Existing VM reports will not work against this branch, we can only test the creation, edit, and view behavior of VM reports created against the branch in PR 4100 above.

From a reviewing perspective, there are three main sections that are changed:

1. [The Cypress tests are updated](https://github.com/stackrox/stackrox/pull/4200/files#diff-9039ca8a276bc8943a3a87f7637e11ad94b8545871e8f291a7be720a8b1fcec3) (everything changed under `/cypress/`) to wait on the collection request instead of the access scope request. I don't believe the tests care about the data that is returned at this point, just that the request succeeds. 
2. [The Collection modal is updated](https://github.com/stackrox/stackrox/pull/4200/files#diff-1bb9bd1a8a08241dc7d2dab94ee53244c04b2f36c537b063ad9aed419de857e1) (everything changed under `/src/Containers/Collections/`) to allow creation of new collections. Previously the modal was restricted to the read-only use case.
3. [The VM reporting section](https://github.com/stackrox/stackrox/pull/4200/files#diff-9e00882975b1b1629a0e9161a272ec236578f12b20109709f988ecaaa230bb92) (everything under `/src/Containers/VulnMgmt/`) is updated to use collections and the collection modal.

## Follow ups

- The layout of the collection dropdown combined with the floating bottom bar is a little hard to use. We should evaluate if there is a good way to avoid the back and forth scrolling that needs to occur when browsing the list.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Visit the VM reporting page and click the creation button. The prior access scope dropdown has been replaced with a collections dropdown.
<img width="1359" alt="image" src="https://user-images.githubusercontent.com/1292638/208722741-a098faf6-19ac-40d8-a550-2ba834614310.png">

Opening the collections dropdown will reveal the first 10 collection results, the rest accessible via a "View more" lazy loading component.
<img width="1359" alt="image" src="https://user-images.githubusercontent.com/1292638/208722898-0695cdfb-71d6-4061-adb0-f63f28e778a9.png">

Clicking the view more button will load more collections into the list.
<img width="1359" alt="image" src="https://user-images.githubusercontent.com/1292638/208723320-5f387c79-f6e3-4f79-ab44-1373561251f7.png">

Selecting an item in the list makes it the selected report scope for the VM report.
<img width="1359" alt="image" src="https://user-images.githubusercontent.com/1292638/208723425-b3f598aa-57c0-43af-986c-93cd7fe181d2.png">

Opening the dropdown and entering text into the typeahead box will filter the dropdown to only include collections that have a name starting with the entered text. If there are more than 10 matching collections, the view more button will allow more to be loaded.
<img width="1359" alt="image" src="https://user-images.githubusercontent.com/1292638/208723626-fd0b7e9c-dffd-4597-895c-fe6a5459f9ef.png">

Clicking the "Create collection" button from the form will open a collection modal and allow creation of a new collection. Results previews, filtering, and error handling will have the full functionality as if the collection is being created directly via the collection page.
![image](https://user-images.githubusercontent.com/1292638/208723914-44a5b0ce-4ba0-4939-8667-823ca70e8f6e.png)
![image](https://user-images.githubusercontent.com/1292638/208727904-7b1fd353-c67e-434e-b4ce-7dd81a8e8c9c.png)
![image](https://user-images.githubusercontent.com/1292638/208728065-399ccfff-1b10-45f2-9a61-2dc11d589b5d.png)

Saving the collection will create it in the database, populate the collection dropdown, and set the scope ID for the report form.
![image](https://user-images.githubusercontent.com/1292638/208728199-26af9a41-aab4-4c35-ad23-b5c5e361e1b8.png)

Opening the dropdown and clicking 'view more' until the server results are exhausted will not cause a duplicate entry in the dropdown. (The newly creation collection has not yet been stored in the pagination results, so it is possible that it will be returned by the server when viewing more collections.)
![image](https://user-images.githubusercontent.com/1292638/208728374-40fba036-6fd6-484e-9abb-9da9a0f5ba71.png)

Filling out the rest of the form and submitting it correctly saves the VM report config as well as the referenced collection.
![image](https://user-images.githubusercontent.com/1292638/208732060-bd35894a-ac7d-4075-b81c-2cbea6ff6bd8.png)
![image](https://user-images.githubusercontent.com/1292638/208732083-8ede2dd7-cfa9-4406-a539-a6eeb6ad14d1.png)
Clicking on the report scope link in the details view correctly navigates the user to the collection's page.
![image](https://user-images.githubusercontent.com/1292638/208732181-c094adbc-894d-43f8-9040-6dd723377aff.png)







