### PR TITLE
Revert eslint caching for apps/platform

### DIFF
--- a/ui/apps/platform/package.json
+++ b/ui/apps/platform/package.json
@@ -110,7 +110,7 @@
         "build": "DISABLE_ESLINT_PLUGIN=true CI=false GENERATE_SOURCEMAP=false react-scripts build",
         "test": "JEST_JUNIT_UNIQUE_OUTPUT_NAME=true JEST_JUNIT_OUTPUT_DIR=${TEST_RESULTS_OUTPUT_DIR:-test-results}/reports react-scripts test --verbose=true --slowTestThreshold=1  --coverage --reporters=default --reporters=jest-junit",
         "test-watch": "react-scripts test",
-        "lint": "NODE_PATH=src eslint --cache --quiet --ext .js,.ts,.tsx src cypress tailwind.config.js .prettierrc.js .eslintrc.js",
+        "lint": "NODE_PATH=src eslint --quiet --ext .js,.ts,.tsx src cypress tailwind.config.js .prettierrc.js .eslintrc.js",
         "cypress-open": "./scripts/cypress.sh open --config defaultCommandTimeout=8000",
         "cypress-spec": "./scripts/cypress.sh run --spec",
         "test-e2e": "./scripts/cypress.sh run --reporter mocha-multi-reporters --reporter-options configFile=cypress/mocha.config.js",

--- a/ui/packages/tailwind-config/package.json
+++ b/ui/packages/tailwind-config/package.json
@@ -21,7 +21,7 @@
         "build": "postcss ./index.tw.css -o ./tailwind.css",
         "start": "yarn build",
         "lint:non-src": "prettier --check '**/*.{md,css,json}'",
-        "lint:src": "eslint --cache --ext .js ./",
+        "lint:src": "eslint --ext .js ./",
         "lint": "npm-run-all lint:*",
         "lint-fix:non-src": "prettier --write '**/*.{md,css,json}'",
         "lint-fix:src": "eslint --fix --ext .js ./",

--- a/ui/packages/ui-components/package.json
+++ b/ui/packages/ui-components/package.json
@@ -27,7 +27,7 @@
         "test": "JEST_JUNIT_UNIQUE_OUTPUT_NAME=true JEST_JUNIT_OUTPUT_DIR=${TEST_RESULTS_OUTPUT_DIR:-test-results}/reports jest --verbose=true --slowTestThreshold=1 --coverage --reporters=default --reporters=jest-junit",
         "test:watch": "jest --watch-all",
         "lint:non-src": "prettier --check '**/*.{md,css,json}'",
-        "lint:src": "eslint --cache --ext .js,.ts,.tsx ./",
+        "lint:src": "eslint --ext .js,.ts,.tsx ./",
         "lint": "npm-run-all lint:*",
         "lint-fix:non-src": "prettier --write '**/*.{md,css,json}'",
         "lint-fix:src": "eslint --fix --ext .js,.ts,.tsx ./",


### PR DESCRIPTION
## Description

Reverts https://github.com/stackrox/stackrox/pull/3902/files

I'm not sure that having a second yarn command (that we would have to run separately) in each pacakge of the repo is worth it for the relatively minor speed boost we get from having this enabled. I was hoping there was an env var way to configure this but alas I could not find one.

I might revisit this when time in the future but it isn't high priority enough to figure out a better solution for now.
