### PR TITLE
ROX-13689: Bump operator SDK to 1.24.1 version

### DIFF
--- a/operator/Makefile
+++ b/operator/Makefile
@@ -105,6 +105,11 @@ OS=$(shell uname | tr A-Z a-z)
 
 PROJECT_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 
+## Location to install dependencies to
+LOCALBIN ?= $(shell pwd)/bin
+$(LOCALBIN):
+	mkdir -p $(LOCALBIN)
+
 # Setting SHELL to bash allows bash commands to be executed by recipes.
 # This is a requirement for 'setup-envtest.sh' in the test target.
 # Options are set to exit when a recipe line exits non-zero or a piped command fails.
@@ -161,20 +166,36 @@ everything: build bundle ## Build everything (local binary, operator image, bund
 ##@ Dependencies download
 include $(PROJECT_DIR)/../make/github.mk
 
-CONTROLLER_GEN_VERSION = 0.10.0
-CONTROLLER_GEN = $(PROJECT_DIR)/bin/controller-gen-$(CONTROLLER_GEN_VERSION)
-.PHONY: controller-gen
-controller-gen: ## Download controller-gen locally if necessary.
-	$(call go-get-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v$(CONTROLLER_GEN_VERSION))
+## Tool Versions
+KUSTOMIZE_VERSION ?= v4.5.5
+CONTROLLER_TOOLS_VERSION ?= v0.10.0
 
-KUSTOMIZE_VERSION = 4.5.7
-KUSTOMIZE = $(PROJECT_DIR)/bin/kustomize-$(KUSTOMIZE_VERSION)
+## Tool Binaries
+KUSTOMIZE ?= $(LOCALBIN)/kustomize
+CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
+ENVTEST ?= $(LOCALBIN)/setup-envtest
+
+
+KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
+
 .PHONY: kustomize
-kustomize: ## Download kustomize locally if necessary.
-	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v4@v$(KUSTOMIZE_VERSION))
+kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
+$(KUSTOMIZE): $(LOCALBIN)
+	test -s $(LOCALBIN)/kustomize || { curl -s $(KUSTOMIZE_INSTALL_SCRIPT) | bash -s -- $(subst v,,$(KUSTOMIZE_VERSION)) $(LOCALBIN); }
 
-OPERATOR_SDK_VERSION = 1.20.1
-OPERATOR_SDK = $(PROJECT_DIR)/bin/operator-sdk-$(OPERATOR_SDK_VERSION)
+.PHONY: controller-gen
+controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary.
+$(CONTROLLER_GEN): $(LOCALBIN)
+	test -s $(LOCALBIN)/controller-gen || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_TOOLS_VERSION)
+
+.PHONY: envtest
+envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
+$(ENVTEST): $(LOCALBIN)
+	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+
+OPERATOR_SDK_VERSION = 1.24.1
+OPERATOR_SDK = $(LOCALBIN)/operator-sdk-$(OPERATOR_SDK_VERSION)
+
 .PHONY: operator-sdk
 operator-sdk: ## Download operator-sdk necessary for scaffolding and bundling.
 # See https://sdk.operatorframework.io/docs/installation/#install-from-github-release
@@ -238,7 +259,7 @@ vet: ## Run go vet against code.
 	go vet ./...
 
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.23
+ENVTEST_K8S_VERSION = 1.24
 
 .PHONY: test
 test: manifests generate fmt vet envtest ## Run tests.

--- a/operator/README.md
+++ b/operator/README.md
@@ -189,7 +189,7 @@ $ kubectl -n bundle-test patch serviceaccount default -p '{"imagePullSecrets": [
 # Use one-liner above.
 
 # 4. Run bundle.
-$ bin/operator-sdk-1.20.1 run bundle \
+$ bin/operator-sdk-1.24.1 run bundle \
   quay.io/rhacs-eng/stackrox-operator-bundle:v$(make --quiet tag) \
   --pull-secret-name my-opm-image-pull-secrets \
   --service-account default \

--- a/operator/bundle.Dockerfile
+++ b/operator/bundle.Dockerfile
@@ -7,7 +7,7 @@ LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=rhacs-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=latest
 LABEL operators.operatorframework.io.bundle.channel.default.v1=latest
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.19.0+git
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.24.1
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 

--- a/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
@@ -19,7 +19,7 @@ metadata:
       services necessary to secure each of your OpenShift and Kubernetes clusters.
     operatorframework.io/suggested-namespace: rhacs-operator
     operators.openshift.io/infrastructure-features: '["disconnected", "proxy-aware"]'
-    operators.operatorframework.io/builder: operator-sdk-v1.19.0+git
+    operators.operatorframework.io/builder: operator-sdk-v1.24.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     support: Red Hat
   name: rhacs-operator.v0.0.1
@@ -943,7 +943,7 @@ spec:
                 - --upstream=http://127.0.0.1:8080/
                 - --logtostderr=true
                 - --v=0
-                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.0
                 name: kube-rbac-proxy
                 ports:
                 - containerPort: 8443

--- a/operator/bundle/metadata/annotations.yaml
+++ b/operator/bundle/metadata/annotations.yaml
@@ -6,7 +6,7 @@ annotations:
   operators.operatorframework.io.bundle.package.v1: rhacs-operator
   operators.operatorframework.io.bundle.channels.v1: latest
   operators.operatorframework.io.bundle.channel.default.v1: latest
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.19.0+git
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.24.1
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
 

--- a/operator/bundle/tests/scorecard/config.yaml
+++ b/operator/bundle/tests/scorecard/config.yaml
@@ -8,7 +8,7 @@ stages:
   - entrypoint:
     - scorecard-test
     - basic-check-spec
-    image: quay.io/operator-framework/scorecard-test:v1.20.1
+    image: quay.io/operator-framework/scorecard-test:v1.24.1
     labels:
       suite: basic
       test: basic-check-spec-test
@@ -18,7 +18,7 @@ stages:
   - entrypoint:
     - scorecard-test
     - olm-bundle-validation
-    image: quay.io/operator-framework/scorecard-test:v1.20.1
+    image: quay.io/operator-framework/scorecard-test:v1.24.1
     labels:
       suite: olm
       test: olm-bundle-validation-test
@@ -28,7 +28,7 @@ stages:
   - entrypoint:
     - scorecard-test
     - olm-crds-have-validation
-    image: quay.io/operator-framework/scorecard-test:v1.20.1
+    image: quay.io/operator-framework/scorecard-test:v1.24.1
     labels:
       suite: olm
       test: olm-crds-have-validation-test
@@ -38,7 +38,7 @@ stages:
   - entrypoint:
     - scorecard-test
     - olm-crds-have-resources
-    image: quay.io/operator-framework/scorecard-test:v1.20.1
+    image: quay.io/operator-framework/scorecard-test:v1.24.1
     labels:
       suite: olm
       test: olm-crds-have-resources-test
@@ -48,7 +48,7 @@ stages:
   - entrypoint:
     - scorecard-test
     - olm-spec-descriptors
-    image: quay.io/operator-framework/scorecard-test:v1.20.1
+    image: quay.io/operator-framework/scorecard-test:v1.24.1
     labels:
       suite: olm
       test: olm-spec-descriptors-test
@@ -58,7 +58,7 @@ stages:
   - entrypoint:
     - scorecard-test
     - olm-status-descriptors
-    image: quay.io/operator-framework/scorecard-test:v1.20.1
+    image: quay.io/operator-framework/scorecard-test:v1.24.1
     labels:
       suite: olm
       test: olm-status-descriptors-test

--- a/operator/config/default/kustomization.yaml
+++ b/operator/config/default/kustomization.yaml
@@ -9,10 +9,12 @@ namespace: stackrox-operator-system
 namePrefix: rhacs-operator-
 
 # Labels to add to all resources and selectors.
-#commonLabels:
-#  someName: someValue
+#labels:
+#- includeSelectors: true
+#  pairs:
+#    someName: someValue
 
-bases:
+resources:
 - ../crd
 - ../rbac
 - ../manager

--- a/operator/config/default/manager_auth_proxy_patch.yaml
+++ b/operator/config/default/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/operator/config/scorecard-versioned/kustomization.yaml
+++ b/operator/config/scorecard-versioned/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
 images:
 - name: scorecard-test
   newName: quay.io/operator-framework/scorecard-test
-  newTag: v1.20.1
+  newTag: v1.24.1


### PR DESCRIPTION
## Description

Upgrade Operator SDK from 1.20.1 to 1.24.1 and apply necessary migrations according to [Upgrade SDK Version](https://sdk.operatorframework.io/docs/upgrading-sdk-version/)

This includes:
- replace `go-get-tool` with `go install`
- download `kustomize` binaries directly
- bump `kube-rbac-proxy`
- e.t.c.


**Note1: Upgrading to 1.25 and 1.26 is blocked by 1.19 golang version**
**Note2: controller-gen version is still ahead. controller-gen will be update to v0.10.0 only in 1.26 SDK version**

## Checklist
- [x] Investigated and inspected CI test results
~- [ ] Unit test and regression tests added~
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

Run locally effected commands, e.g `test`:
```
✗ make -C operator kuttl test
/Library/Developer/CommandLineTools/usr/bin/make -C .. proto-generated-srcs
+ Checking if github.com/grpc-ecosystem/grpc-gateway is up-to-date
+ Checking if github.com/gogo/protobuf is up-to-date
....
ok  	github.com/stackrox/rox/operator/pkg/utils	1.171s	coverage: 45.9% of statements
?   	github.com/stackrox/rox/operator/pkg/utils/testutils	[no test files]
?   	github.com/stackrox/rox/operator/pkg/values/testing	[no test files]
ok  	github.com/stackrox/rox/operator/pkg/values/translation	1.034s	coverage: 67.3% of statements
```

Building bundle locally:
```
✗ make -C operator generate manifests bundle
/Library/Developer/CommandLineTools/usr/bin/make -C .. proto-generated-srcs
+ Checking if github.com/grpc-ecosystem/grpc-gateway is up-to-date
+ Checking if github.com/gogo/protobuf is up-to-date
...
mv bundle/manifests/rhacs-operator.clusterserviceversion.yaml.fixed \
       bundle/manifests/rhacs-operator.clusterserviceversion.yaml
/Users/akurlov/go/src/github.com/stackrox/stackrox/operator/bin/operator-sdk-1.24.1 bundle validate ./bundle --select-optional suite=operatorframework
INFO[0000] All validation tests have completed successfully
```

docker build:
```
✗ make -C operator docker-build
mkdir -p build/
sed -e 's,${ROX_IMAGE_FLAVOR},opensource,g; s,${BUILD_IMAGE_VERSION},stackrox-build-0.3.49,' < Dockerfile > build/Dockerfile.gen
/Library/Developer/CommandLineTools/usr/bin/make -C .. proto-generated-srcs
....
#22 writing image sha256:723364fb6aa4f2730770bf881357e9a9422db12eb7cdf478016407fa23142a15 done
#22 naming to quay.io/stackrox-io/stackrox-operator:3.73.0-275-g44614c0c60-dirty done
#22 DONE 0.4s

Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them
```
