### PR TITLE
ROX-13582: Follow-up. Limit context access scope, comments, naming

### DIFF
--- a/central/authprovider/datastore/telemetry.go
+++ b/central/authprovider/datastore/telemetry.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/pkg/errors"
 	groupDataStore "github.com/stackrox/rox/central/group/datastore"
+	"github.com/stackrox/rox/central/role/resources"
+	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/telemetry/phonehome"
@@ -12,9 +14,10 @@ import (
 
 // Gather auth provider names and number of groups per auth provider.
 var Gather phonehome.GatherFunc = func(ctx context.Context) (map[string]any, error) {
-	// WithAllAccess is required only to fetch and calculate the number of
-	// auth providers and groups. It is not propagated anywhere else.
-	ctx = sac.WithAllAccess(ctx)
+	ctx = sac.WithGlobalAccessScopeChecker(ctx,
+		sac.AllowFixedScopes(
+			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
+			sac.ResourceScopeKeys(resources.Access)))
 	props := make(map[string]any)
 
 	providers, err := Singleton().GetAllAuthProviders(ctx)

--- a/central/role/datastore/telemetry.go
+++ b/central/role/datastore/telemetry.go
@@ -3,6 +3,8 @@ package datastore
 import (
 	"context"
 
+	"github.com/stackrox/rox/central/role/resources"
+	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/errorhelpers"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/telemetry/phonehome"
@@ -11,10 +13,11 @@ import (
 // Gather the total amount of permission sets, access scopes, and roles for
 // phone home telemetry.
 var Gather phonehome.GatherFunc = func(ctx context.Context) (map[string]any, error) {
-	// WithAllAccess is required only to fetch and calculate the number of
-	// permission sets, roles and access scopes. It is not propagated anywhere
-	// else.
-	ctx = sac.WithAllAccess(ctx)
+	ctx = sac.WithGlobalAccessScopeChecker(ctx,
+		sac.AllowFixedScopes(
+			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
+			sac.ResourceScopeKeys(resources.Role)))
+
 	totals := make(map[string]any)
 	rs := Singleton()
 

--- a/central/signatureintegration/datastore/telemetry.go
+++ b/central/signatureintegration/datastore/telemetry.go
@@ -4,15 +4,18 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
+	"github.com/stackrox/rox/central/role/resources"
+	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/telemetry/phonehome"
 )
 
 // Gather number of signature integrations.
 var Gather phonehome.GatherFunc = func(ctx context.Context) (map[string]any, error) {
-	// WithAllAccess is required only to fetch and calculate the number of
-	// signature integrations. It is not propagated anywhere else.
-	ctx = sac.WithAllAccess(ctx)
+	ctx = sac.WithGlobalAccessScopeChecker(ctx,
+		sac.AllowFixedScopes(
+			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
+			sac.ResourceScopeKeys(resources.Integration)))
 	totals := make(map[string]any)
 	si := Singleton()
 	if err := phonehome.AddTotal(ctx, totals, "Signature Integrations", si.GetAllSignatureIntegrations); err != nil {

--- a/central/telemetry/centralclient/instance_config.go
+++ b/central/telemetry/centralclient/instance_config.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/central/installation/store"
+	"github.com/stackrox/rox/central/role/resources"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/logging"
@@ -58,7 +59,12 @@ func getInstanceConfig() (*phonehome.Config, map[string]any, error) {
 		orchestrator = storage.ClusterType_OPENSHIFT_CLUSTER.String()
 	}
 
-	ii, _, err := store.Singleton().Get(sac.WithAllAccess(context.Background()))
+	ii, _, err := store.Singleton().Get(
+		sac.WithGlobalAccessScopeChecker(context.Background(),
+			sac.AllowFixedScopes(
+				sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
+				sac.ResourceScopeKeys(resources.InstallationInfo))))
+
 	if err != nil || ii == nil {
 		return nil, nil, errors.Wrap(err, "cannot get installation information")
 	}

--- a/pkg/telemetry/phonehome/client_config.go
+++ b/pkg/telemetry/phonehome/client_config.go
@@ -51,7 +51,8 @@ type Config struct {
 
 	// Map of event name to the list of interceptors, that gather properties for
 	// the event.
-	interceptors map[string][]Interceptor
+	interceptors     map[string][]Interceptor
+	interceptorsLock sync.Mutex
 }
 
 // Enabled tells whether telemetry data collection is enabled.
@@ -101,8 +102,8 @@ func (cfg *Config) Telemeter() Telemeter {
 // AddInterceptorFunc appends the custom list of telemetry interceptors with the
 // provided function.
 func (cfg *Config) AddInterceptorFunc(event string, f Interceptor) {
-	mux.Lock()
-	defer mux.Unlock()
+	cfg.interceptorsLock.Lock()
+	defer cfg.interceptorsLock.Unlock()
 	if cfg.interceptors == nil {
 		cfg.interceptors = make(map[string][]Interceptor, 1)
 	}

--- a/pkg/telemetry/phonehome/interceptor.go
+++ b/pkg/telemetry/phonehome/interceptor.go
@@ -10,18 +10,15 @@ import (
 	"github.com/stackrox/rox/pkg/grpc/authn"
 	grpcError "github.com/stackrox/rox/pkg/grpc/errors"
 	"github.com/stackrox/rox/pkg/grpc/requestinfo"
-	"github.com/stackrox/rox/pkg/sync"
 	"google.golang.org/grpc"
 )
 
 const grpcGatewayUserAgentHeader = runtime.MetadataPrefix + "User-Agent"
 
-var (
-	mux = &sync.Mutex{}
-)
-
 func (cfg *Config) track(rp *RequestParams) {
 	id := cfg.HashUserAuthID(rp.UserID)
+	cfg.interceptorsLock.Lock()
+	defer cfg.interceptorsLock.Unlock()
 	for event, funcs := range cfg.interceptors {
 		props := map[string]any{}
 		ok := true

--- a/pkg/telemetry/phonehome/segment/segment.go
+++ b/pkg/telemetry/phonehome/segment/segment.go
@@ -6,7 +6,6 @@ import (
 	segment "github.com/segmentio/analytics-go"
 	"github.com/stackrox/rox/pkg/httputil/proxy"
 	"github.com/stackrox/rox/pkg/logging"
-	"go.uber.org/zap/zapcore"
 )
 
 var (
@@ -48,7 +47,7 @@ type logWrapper struct {
 }
 
 func (l *logWrapper) Logf(format string, args ...any) {
-	l.internal.Logf(zapcore.InfoLevel, format, args...)
+	l.internal.Infof(format, args...)
 }
 
 func (l *logWrapper) Errorf(format string, args ...any) {


### PR DESCRIPTION
## Description

Following up #4072.

* Limiting the scope for accessing data stores
* Comments
* Naming

## Checklist
- [x] Investigated and inspected CI test results
- [ ] ~Unit test and regression tests added~
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

Tested with local run and events on Segment didn't differ from previous results.