### PR TITLE
CI: Fix K8sEventDetectionTest/ReconciliationTest skip for OpenShift

### DIFF
--- a/qa-tests-backend/src/test/groovy/K8sEventDetectionTest.groovy
+++ b/qa-tests-backend/src/test/groovy/K8sEventDetectionTest.groovy
@@ -8,7 +8,6 @@ import services.AlertService
 import services.PolicyService
 import util.Env
 
-import org.junit.Assume
 import spock.lang.IgnoreIf
 import spock.lang.Retry
 import spock.lang.Tag

--- a/qa-tests-backend/src/test/groovy/ReconciliationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ReconciliationTest.groovy
@@ -1,5 +1,7 @@
 import static Services.getViolationsWithTimeout
 
+import orchestratormanager.OrchestratorTypes
+
 import io.fabric8.kubernetes.api.model.Pod
 import io.fabric8.kubernetes.api.model.apps.Deployment as OrchestratorDeployment
 

--- a/qa-tests-backend/src/test/groovy/ReconciliationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ReconciliationTest.groovy
@@ -17,7 +17,7 @@ import services.NetworkPolicyService
 import services.SecretService
 import util.Timer
 
-import org.junit.Assume
+import spock.lang.IgnoreIf
 import spock.lang.Retry
 import spock.lang.Tag
 

--- a/qa-tests-backend/src/test/groovy/ReconciliationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ReconciliationTest.groovy
@@ -98,11 +98,9 @@ class ReconciliationTest extends BaseSpecification {
 
     @Tag("SensorBounce")
     @Tag("COMPATIBILITY")
+    // RS-361 - Fails on OSD
+    @IgnoreIf({ Env.mustGetOrchestratorType() == OrchestratorTypes.OPENSHIFT })
     def "Verify the Sensor reconciles after being restarted"() {
-        // RS-361 - Fails on OSD. Need help troubleshooting. Disabling for now.
-        Assume.assumeFalse(ClusterService.isOpenShift3())
-        Assume.assumeFalse(ClusterService.isOpenShift4())
-
         when:
         "Get Sensor and counts"
 

--- a/qa-tests-backend/src/test/groovy/ReconciliationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ReconciliationTest.groovy
@@ -16,6 +16,7 @@ import services.NamespaceService
 import services.NetworkPolicyService
 import services.SecretService
 import util.Timer
+import util.Env
 
 import spock.lang.IgnoreIf
 import spock.lang.Retry


### PR DESCRIPTION
## Description

The update to spock 2.x (#4135) caused OpenShift tests to fail with incorrect skipping of the K8sEventDetectionTest. I'm not clear how this worked with spock 1.x but it did. This PR ensures that no part of the test is attempted under OpenShift.

Update: There is a similar issue with the skipped ReconciliationTest. Retry=0 & Assume statements do not seem to behave well together. I will create a follow on PR / JIRA to investigate as there may be outstanding bugs waiting when tests are re-enabled for example. 

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

- [x] runs K8sEventDetectionTest under GKE
- [x] does not run K8sEventDetectionTest under OpenShift
- [x] runs ReconciliationTest under GKE
- [x] does not run ReconciliationTest under OpenShift