### PR TITLE
ROX-13963: Show banner when db unavailable

### DIFF
--- a/ui/apps/platform/src/Containers/MainPage/DatabaseUnavailableBanner.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/DatabaseUnavailableBanner.tsx
@@ -1,0 +1,19 @@
+import React, { ReactElement } from 'react';
+import { AlertVariant, Banner } from '@patternfly/react-core';
+
+function DatabaseUnavailableBanner(): ReactElement {
+    const message = (
+        <span className="pf-u-text-align-center">
+            The database is currently not available. If this problem persists, please contact
+            support.
+        </span>
+    );
+
+    return (
+        <Banner className="pf-u-text-align-center" isSticky variant={AlertVariant.danger}>
+            {message}
+        </Banner>
+    );
+}
+
+export default DatabaseUnavailableBanner;

--- a/ui/apps/platform/src/Containers/MainPage/MainPage.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/MainPage.tsx
@@ -19,6 +19,7 @@ import usePermissions from 'hooks/usePermissions';
 import { clustersBasePath } from 'routePaths';
 
 import CredentialExpiryBanner from './CredentialExpiryBanner';
+import DatabaseUnavailableBanner from './DatabaseUnavailableBanner';
 import VersionOutOfDate from './VersionOutOfDate';
 import Masthead from './Header/Masthead';
 import NavigationSidebar from './Sidebar/NavigationSidebar';
@@ -98,6 +99,7 @@ function MainPage(): ReactElement {
                     hasServiceIdentityWritePermission={hasServiceIdentityWritePermission}
                 />
                 {metadata?.stale && <VersionOutOfDate />}
+                {metadata && !metadata.dbAvailable && <DatabaseUnavailableBanner />}
                 <Page
                     mainContainerId="main-page-container"
                     header={<Masthead />}


### PR DESCRIPTION
## Description

A simple banner to indicate that the database is unavailable. (Closing a gap in UX, now that the Postgres database can run in a separate pod or cloud service, and be unavailable even if Central is up and serving the UI.)

Depending on the changes by @dashrews78 currently in this PR:
https://github.com/stackrox/stackrox/pull/4195

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

Deleted the database deployment and saw the message.
![Screen Shot 2022-12-20 at 12 32 51 PM](https://user-images.githubusercontent.com/715729/208732398-2971695b-3c29-4c84-b62d-4b97759836c8.png)
