### PR TITLE
Dashrews/ROX-14026 add metric to state whether central is connected to Postgres or not

### DIFF
--- a/central/globaldb/metrics/metrics.go
+++ b/central/globaldb/metrics/metrics.go
@@ -177,6 +177,20 @@ var (
 		Name:      "postgres_table_toast_bytes",
 		Help:      "bytes being used by toast for a table",
 	}, []string{"Table"})
+
+	PostgresDBSize = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.CentralSubsystem.String(),
+		Name:      "postgres_db_size",
+		Help:      "bytes being used by Postgres Database",
+	})
+
+	PostgresConnected = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.CentralSubsystem.String(),
+		Name:      "postgres_connected",
+		Help:      "flag indicating if central is connected to the Postgres Database",
+	})
 )
 
 // SetGaugeInt sets a value for a gauge from an int

--- a/central/globaldb/metrics/metrics.go
+++ b/central/globaldb/metrics/metrics.go
@@ -151,47 +151,47 @@ var (
 		Subsystem: metrics.CentralSubsystem.String(),
 		Name:      "postgres_table_size",
 		Help:      "estimated number of rows in the table",
-	}, []string{"Table"})
+	}, []string{"table"})
 
 	PostgresIndexSize = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: metrics.PrometheusNamespace,
 		Subsystem: metrics.CentralSubsystem.String(),
 		Name:      "postgres_table_index_bytes",
 		Help:      "bytes being used by indexes for a table",
-	}, []string{"Table"})
+	}, []string{"table"})
 
 	PostgresTableTotalSize = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: metrics.PrometheusNamespace,
 		Subsystem: metrics.CentralSubsystem.String(),
 		Name:      "postgres_table_total_bytes",
 		Help:      "bytes being used by the table overall",
-	}, []string{"Table"})
+	}, []string{"table"})
 
 	PostgresTableDataSize = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: metrics.PrometheusNamespace,
 		Subsystem: metrics.CentralSubsystem.String(),
 		Name:      "postgres_table_data_bytes",
 		Help:      "bytes being used by the data for a table",
-	}, []string{"Table"})
+	}, []string{"table"})
 
 	PostgresToastSize = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: metrics.PrometheusNamespace,
 		Subsystem: metrics.CentralSubsystem.String(),
 		Name:      "postgres_table_toast_bytes",
 		Help:      "bytes being used by toast for a table",
-	}, []string{"Table"})
+	}, []string{"table"})
 
 	PostgresDBSize = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: metrics.PrometheusNamespace,
 		Subsystem: metrics.CentralSubsystem.String(),
-		Name:      "postgres_db_size",
+		Name:      "postgres_db_size_bytes",
 		Help:      "bytes being used by a Postgres Database",
-	}, []string{"Database"})
+	}, []string{"database"})
 
 	PostgresTotalSize = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: metrics.PrometheusNamespace,
 		Subsystem: metrics.CentralSubsystem.String(),
-		Name:      "postgres_total_size",
+		Name:      "postgres_total_size_bytes",
 		Help:      "bytes being used by Postgres all Databases",
 	})
 

--- a/central/globaldb/metrics/metrics.go
+++ b/central/globaldb/metrics/metrics.go
@@ -180,18 +180,18 @@ var (
 		Help:      "bytes being used by toast for a table",
 	}, []string{"Table"})
 
-	PostgresDBSize = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	PostgresDBSize = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: metrics.PrometheusNamespace,
 		Subsystem: metrics.CentralSubsystem.String(),
-		Name:      "postgres_db_size",
+		Name:      "postgres_active_db_size",
 		Help:      "bytes being used by Postgres Database",
-	}, []string{"Clone"})
+	})
 
 	PostgresConnected = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: metrics.PrometheusNamespace,
 		Subsystem: metrics.CentralSubsystem.String(),
 		Name:      "postgres_connected",
-		Help:      "flag indicating if central is connected to the Postgres Database",
+		Help:      "flag indicating if central is connected to the Postgres Database. 0 NOT connected, 1 connected",
 	})
 )
 

--- a/central/globaldb/metrics/metrics.go
+++ b/central/globaldb/metrics/metrics.go
@@ -49,6 +49,8 @@ func init() {
 		PostgresTableTotalSize,
 		PostgresTableDataSize,
 		PostgresToastSize,
+		PostgresDBSize,
+		PostgresConnected,
 	)
 }
 
@@ -178,12 +180,12 @@ var (
 		Help:      "bytes being used by toast for a table",
 	}, []string{"Table"})
 
-	PostgresDBSize = prometheus.NewGauge(prometheus.GaugeOpts{
+	PostgresDBSize = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: metrics.PrometheusNamespace,
 		Subsystem: metrics.CentralSubsystem.String(),
 		Name:      "postgres_db_size",
 		Help:      "bytes being used by Postgres Database",
-	})
+	}, []string{"Clone"})
 
 	PostgresConnected = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: metrics.PrometheusNamespace,

--- a/central/globaldb/metrics/metrics.go
+++ b/central/globaldb/metrics/metrics.go
@@ -50,6 +50,7 @@ func init() {
 		PostgresTableDataSize,
 		PostgresToastSize,
 		PostgresDBSize,
+		PostgresTotalSize,
 		PostgresConnected,
 	)
 }
@@ -180,11 +181,18 @@ var (
 		Help:      "bytes being used by toast for a table",
 	}, []string{"Table"})
 
-	PostgresDBSize = prometheus.NewGauge(prometheus.GaugeOpts{
+	PostgresDBSize = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: metrics.PrometheusNamespace,
 		Subsystem: metrics.CentralSubsystem.String(),
-		Name:      "postgres_active_db_size",
-		Help:      "bytes being used by Postgres Database",
+		Name:      "postgres_db_size",
+		Help:      "bytes being used by a Postgres Database",
+	}, []string{"Database"})
+
+	PostgresTotalSize = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.CentralSubsystem.String(),
+		Name:      "postgres_total_size",
+		Help:      "bytes being used by Postgres all Databases",
 	})
 
 	PostgresConnected = prometheus.NewGauge(prometheus.GaugeOpts{

--- a/central/globaldb/postgres.go
+++ b/central/globaldb/postgres.go
@@ -169,7 +169,7 @@ func CollectPostgresStats(ctx context.Context, db *pgxpool.Pool) *stats.Database
 			return nil
 		}
 
-		tableLabel := prometheus.Labels{"Table": tableName}
+		tableLabel := prometheus.Labels{"table": tableName}
 		metrics.PostgresTableCounts.With(tableLabel).Set(float64(rowEstimate))
 		metrics.PostgresTableTotalSize.With(tableLabel).Set(float64(totalSize))
 		metrics.PostgresIndexSize.With(tableLabel).Set(float64(indexSize))
@@ -204,9 +204,6 @@ func CollectPostgresDatabaseSizes(postgresConfig *pgxpool.Config) []*stats.Datab
 			return detailsSlice
 		}
 
-		databaseLabel := prometheus.Labels{"Database": database}
-		metrics.PostgresDBSize.With(databaseLabel).Set(float64(dbSize))
-
 		dbDetails := &stats.DatabaseDetailsStats{
 			DatabaseName: database,
 			DatabaseSize: int64(dbSize),
@@ -222,7 +219,7 @@ func CollectPostgresDatabaseStats(postgresConfig *pgxpool.Config) {
 	dbStats := CollectPostgresDatabaseSizes(postgresConfig)
 
 	for _, dbStat := range dbStats {
-		databaseLabel := prometheus.Labels{"Database": dbStat.DatabaseName}
+		databaseLabel := prometheus.Labels{"database": dbStat.DatabaseName}
 		metrics.PostgresDBSize.With(databaseLabel).Set(float64(dbStat.DatabaseSize))
 	}
 

--- a/central/globaldb/postgres.go
+++ b/central/globaldb/postgres.go
@@ -193,10 +193,7 @@ func CollectPostgresStats(ctx context.Context, db *pgxpool.Pool) *stats.Database
 }
 
 // CollectPostgresDatabaseStats -- collect database level stats for Postgres
-func CollectPostgresDatabaseStats(ctx context.Context, postgresConfig *pgxpool.Config) {
-	ctx, cancel := context.WithTimeout(ctx, PostgresQueryTimeout)
-	defer cancel()
-
+func CollectPostgresDatabaseStats(postgresConfig *pgxpool.Config) {
 	cloneSize, err := pgadmin.GetDatabaseSize(postgresConfig, migrations.CurrentDatabase)
 	if err != nil {
 		log.Errorf("error fetching clone size: %v", err)
@@ -211,6 +208,6 @@ func startMonitoringPostgres(ctx context.Context, db *pgxpool.Pool, postgresConf
 	defer t.Stop()
 	for range t.C {
 		_ = CollectPostgresStats(ctx, db)
-		CollectPostgresDatabaseStats(ctx, postgresConfig)
+		CollectPostgresDatabaseStats(postgresConfig)
 	}
 }

--- a/central/globaldb/postgres_test.go
+++ b/central/globaldb/postgres_test.go
@@ -21,13 +21,10 @@ func TestConfigSetup(t *testing.T) {
 }
 
 func (s *PostgresUtilitySuite) SetupSuite() {
-	s.T().Setenv(env.PostgresDatastoreEnabled.EnvVar(), "true")
-
 	if !env.PostgresDatastoreEnabled.BooleanSetting() {
 		s.T().Skip("Skip postgres store tests")
 		s.T().SkipNow()
 	}
-
 }
 
 func (s *PostgresUtilitySuite) TestSourceParser() {

--- a/central/telemetry/gatherers/postgres.go
+++ b/central/telemetry/gatherers/postgres.go
@@ -30,14 +30,10 @@ func (d *postgresGatherer) Gather(ctx context.Context) *data.DatabaseStats {
 	currentDBBytes, err := pgadmin.GetDatabaseSize(d.adminConfig, migrations.GetCurrentClone())
 	errorList.AddError(err)
 
-	tableStats := globaldb.CollectPostgresStats(ctx, d.db)
-
-	dbStats := &data.DatabaseStats{
-		Type:      "postgres",
-		UsedBytes: currentDBBytes,
-		Tables:    tableStats,
-		Errors:    errorList.ErrorStrings(),
-	}
+	dbStats := globaldb.CollectPostgresStats(ctx, d.db)
+	dbStats.Type = "postgres"
+	dbStats.UsedBytes = currentDBBytes
+	dbStats.Errors = errorList.ErrorStrings()
 
 	// Check Postgres remaining capacity
 	availableDBBytes, err := pgadmin.GetRemainingCapacity(d.adminConfig)

--- a/pkg/postgres/pgadmin/admin_utils.go
+++ b/pkg/postgres/pgadmin/admin_utils.go
@@ -417,7 +417,7 @@ func GetDatabaseSize(postgresConfig *pgxpool.Config, dbName string) (int64, erro
 		return 0, err
 	}
 
-	log.Infof("%q size = %d.", dbName, dbSize)
+	log.Debugf("%q size = %d.", dbName, dbSize)
 	return dbSize, nil
 }
 
@@ -467,8 +467,6 @@ func GetAllDatabases(postgresConfig *pgxpool.Config) []string {
 
 		clones = append(clones, cloneName)
 	}
-
-	log.Infof("database clones => %s", clones)
 
 	return clones
 }

--- a/pkg/postgres/pgadmin/admin_utils.go
+++ b/pkg/postgres/pgadmin/admin_utils.go
@@ -381,13 +381,7 @@ func GetRemainingCapacity(postgresConfig *pgxpool.Config) (int64, error) {
 	// Close the admin connection pool
 	defer connectPool.Close()
 
-	// Create a context with a timeout
-	ctx, cancel := context.WithTimeout(context.Background(), PostgresQueryTimeout)
-	defer cancel()
-
-	row := connectPool.QueryRow(ctx, totalSizeStmt)
-	var sizeUsed int64
-	err := row.Scan(&sizeUsed)
+	sizeUsed, err := GetTotalPostgresSize(postgresConfig)
 	if err != nil {
 		return 0, err
 	}
@@ -425,4 +419,56 @@ func GetDatabaseSize(postgresConfig *pgxpool.Config, dbName string) (int64, erro
 
 	log.Infof("%q size = %d.", dbName, dbSize)
 	return dbSize, nil
+}
+
+// GetTotalPostgresSize - retrieves the total size of all Postgres databases
+func GetTotalPostgresSize(postgresConfig *pgxpool.Config) (int64, error) {
+	// Connect to database for admin functions
+	connectPool := GetAdminPool(postgresConfig)
+	// Close the admin connection pool
+	defer connectPool.Close()
+
+	// Create a context with a timeout
+	ctx, cancel := context.WithTimeout(context.Background(), PostgresQueryTimeout)
+	defer cancel()
+
+	row := connectPool.QueryRow(ctx, totalSizeStmt)
+	var sizeUsed int64
+	err := row.Scan(&sizeUsed)
+	if err != nil {
+		return 0, err
+	}
+
+	return sizeUsed, nil
+}
+
+// GetAllDatabases - returns list of databases in Postgres
+func GetAllDatabases(postgresConfig *pgxpool.Config) []string {
+	// Connect to different database for admin functions
+	connectPool := GetAdminPool(postgresConfig)
+	// Close the admin connection pool
+	defer connectPool.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), PostgresQueryTimeout)
+	defer cancel()
+
+	rows, err := connectPool.Query(ctx, "SELECT datname FROM pg_catalog.pg_database")
+	if err != nil {
+		return nil
+	}
+	defer rows.Close()
+
+	var clones []string
+	for rows.Next() {
+		var cloneName string
+		if err := rows.Scan(&cloneName); err != nil {
+			return nil
+		}
+
+		clones = append(clones, cloneName)
+	}
+
+	log.Infof("database clones => %s", clones)
+
+	return clones
 }

--- a/pkg/telemetry/data/central.go
+++ b/pkg/telemetry/data/central.go
@@ -64,16 +64,22 @@ type TableStats struct {
 	ToastSize int64  `json:"toastSize"`
 }
 
+type DatabaseDetailsStats struct {
+	DatabaseName string `json:"databaseName"`
+	DatabaseSize int64  `json:"databaseSize"`
+}
+
 // DatabaseStats contains telemetry data about a DB
 type DatabaseStats struct {
-	Type              string         `json:"type"`
-	Path              string         `json:"path"`
-	AvailableBytes    int64          `json:"availableBytes"`
-	DatabaseAvailable bool           `json:"databaseAvailable,omitempty"`
-	UsedBytes         int64          `json:"usedBytes"`
-	Buckets           []*BucketStats `json:"buckets,omitempty"`
-	Tables            []*TableStats  `json:"tables,omitempty"`
-	Errors            []string       `json:"errors,omitempty"`
+	Type              string                  `json:"type"`
+	Path              string                  `json:"path"`
+	AvailableBytes    int64                   `json:"availableBytes,omitempty"`
+	DatabaseAvailable bool                    `json:"databaseAvailable,omitempty"`
+	UsedBytes         int64                   `json:"usedBytes"`
+	Buckets           []*BucketStats          `json:"buckets,omitempty"`
+	Tables            []*TableStats           `json:"tables,omitempty"`
+	DatabaseDetails   []*DatabaseDetailsStats `json:"databaseDetails,omitempty"`
+	Errors            []string                `json:"errors,omitempty"`
 }
 
 // StorageInfo contains telemetry data about available disk, storage type, and the available databases

--- a/pkg/telemetry/data/central.go
+++ b/pkg/telemetry/data/central.go
@@ -59,15 +59,15 @@ type BucketStats struct {
 type TableStats struct {
 	Name      string `json:"name"`
 	RowCount  int64  `json:"rowCount"`
-	TableSize int64  `json:"tableSize"`
-	IndexSize int64  `json:"indexSize"`
-	ToastSize int64  `json:"toastSize"`
+	TableSize int64  `json:"tableSizeBytes"`
+	IndexSize int64  `json:"indexSizeBytes"`
+	ToastSize int64  `json:"toastSizeBytes"`
 }
 
 // DatabaseDetailsStats contains telemetry details about sizing of databases
 type DatabaseDetailsStats struct {
 	DatabaseName string `json:"databaseName"`
-	DatabaseSize int64  `json:"databaseSize"`
+	DatabaseSize int64  `json:"databaseSizeBytes"`
 }
 
 // DatabaseStats contains telemetry data about a DB

--- a/pkg/telemetry/data/central.go
+++ b/pkg/telemetry/data/central.go
@@ -66,13 +66,14 @@ type TableStats struct {
 
 // DatabaseStats contains telemetry data about a DB
 type DatabaseStats struct {
-	Type           string         `json:"type"`
-	Path           string         `json:"path"`
-	AvailableBytes int64          `json:"availableBytes"`
-	UsedBytes      int64          `json:"usedBytes"`
-	Buckets        []*BucketStats `json:"buckets,omitempty"`
-	Tables         []*TableStats  `json:"tables,omitempty"`
-	Errors         []string       `json:"errors,omitempty"`
+	Type              string         `json:"type"`
+	Path              string         `json:"path"`
+	AvailableBytes    int64          `json:"availableBytes"`
+	DatabaseAvailable bool           `json:"databaseAvailable,omitempty"`
+	UsedBytes         int64          `json:"usedBytes"`
+	Buckets           []*BucketStats `json:"buckets,omitempty"`
+	Tables            []*TableStats  `json:"tables,omitempty"`
+	Errors            []string       `json:"errors,omitempty"`
 }
 
 // StorageInfo contains telemetry data about available disk, storage type, and the available databases

--- a/pkg/telemetry/data/central.go
+++ b/pkg/telemetry/data/central.go
@@ -64,6 +64,7 @@ type TableStats struct {
 	ToastSize int64  `json:"toastSize"`
 }
 
+// DatabaseDetailsStats contains telemetry details about sizing of databases
 type DatabaseDetailsStats struct {
 	DatabaseName string `json:"databaseName"`
 	DatabaseSize int64  `json:"databaseSize"`


### PR DESCRIPTION
## Description

Add a couple metrics to prometheus for the Postgres database `postgres_active_db_size` provides the size of the active database and `postgres_connected` is a simple flag indicating if central is connected to the database or not.  `0` being NOT connected and `1` being connected.  The idea with these is to hit some immediate needs as we work the greater issue of what metrics to have.

From prometheus metrics
```
# TYPE rox_central_postgres_connected gauge
rox_central_postgres_connected 1
# TYPE rox_central_postgres_db_size_bytes gauge
rox_central_postgres_db_size_bytes{database="central_active"} 1.9427887e+07
rox_central_postgres_db_size_bytes{database="postgres"} 8.090159e+06
rox_central_postgres_db_size_bytes{database="template0"} 7.938563e+06 
rox_central_postgres_db_size_bytes{database="template1"} 7.938563e+06
```

from telemetry-data.json
```
          "databaseDetails": [
            { 
              "databaseName": "postgres",
              "databaseSizeBytes": 8090159
            },
            { 
              "databaseName": "central_active",
              "databaseSizeBytes": 19427887
            },
            { 
              "databaseName": "template1",
              "databaseSizeBytes": 7938563
            },
            { 
              "databaseName": "template0",
              "databaseSizeBytes": 7938563
            } 
          ] 
```

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Local testing by running diagnostic bundles to see the data gets dumped into `metrics-1` and `telemetry-data.json`.  Additionally added a unit test.
