### PR TITLE
ROX-13883: upload network policy yaml

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/hooks/useNetworkPolicySimulator.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/hooks/useNetworkPolicySimulator.ts
@@ -50,7 +50,8 @@ type SetNetworkPolicyModificationAction =
     | {
           state: 'UPLOAD';
           options: {
-              modification: NetworkPolicyModification;
+              modification: NetworkPolicyModification | null;
+              error: string;
           };
       };
 
@@ -178,7 +179,7 @@ function useNetworkPolicySimulator({ clusterId }): {
                 setSimulator({
                     state,
                     modification: options.modification,
-                    error: '',
+                    error: options.error,
                     isLoading: false,
                 });
                 break;

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPoliciesYAML.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPoliciesYAML.tsx
@@ -1,37 +1,23 @@
 import React from 'react';
 import { CodeEditor, CodeEditorControl, Language } from '@patternfly/react-code-editor';
-import {
-    DownloadIcon,
-    MoonIcon,
-    ProcessAutomationIcon,
-    SunIcon,
-    UndoIcon,
-} from '@patternfly/react-icons';
+import { DownloadIcon, MoonIcon, SunIcon } from '@patternfly/react-icons';
 
 import { useTheme } from 'Containers/ThemeProvider';
 import download from 'utils/download';
 
 type NetworkPoliciesYAMLProp = {
     yaml: string;
-    generateNetworkPolicies: () => void;
-    undoNetworkPolicies: () => void;
 };
 
 const labels = {
     downloadYAML: 'Download YAML',
-    generateYAML: 'Generate a new YAML',
-    revertMostRecentYAML: 'Revert most recently applied YAML',
 };
 
 const downloadYAMLHandler = (fileName: string, fileContent: string) => () => {
     download(`${fileName}.yml`, fileContent, 'yml');
 };
 
-function NetworkPoliciesYAML({
-    yaml,
-    generateNetworkPolicies,
-    undoNetworkPolicies,
-}: NetworkPoliciesYAMLProp) {
+function NetworkPoliciesYAML({ yaml }: NetworkPoliciesYAMLProp) {
     const { isDarkMode } = useTheme();
     const [customDarkMode, setCustomDarkMode] = React.useState(isDarkMode);
 
@@ -59,36 +45,11 @@ function NetworkPoliciesYAML({
         />
     );
 
-    const generateNewYAMLControl = (
-        <CodeEditorControl
-            icon={<ProcessAutomationIcon />}
-            aria-label={labels.generateYAML}
-            toolTipText={labels.generateYAML}
-            onClick={generateNetworkPolicies}
-            isVisible
-        />
-    );
-
-    const revertRecentYAML = (
-        <CodeEditorControl
-            icon={<UndoIcon />}
-            aria-label={labels.revertMostRecentYAML}
-            toolTipText={labels.revertMostRecentYAML}
-            onClick={undoNetworkPolicies}
-            isVisible
-        />
-    );
-
     return (
         <div className="pf-u-h-100">
             <CodeEditor
                 isDarkTheme={customDarkMode}
-                customControls={[
-                    toggleDarkModeControl,
-                    downloadYAMLControl,
-                    generateNewYAMLControl,
-                    revertRecentYAML,
-                ]}
+                customControls={[toggleDarkModeControl, downloadYAMLControl]}
                 isCopyEnabled
                 isLineNumbersVisible
                 isReadOnly

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkSimulatorActions.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkSimulatorActions.tsx
@@ -1,0 +1,83 @@
+import {
+    Dropdown,
+    DropdownDirection,
+    DropdownItem,
+    DropdownToggle,
+    Split,
+    SplitItem,
+} from '@patternfly/react-core';
+import React from 'react';
+import UploadYAMLButton from './UploadYAMLButton';
+
+type NetworkSimulatorActionsProps = {
+    generateNetworkPolicies: () => void;
+    undoNetworkPolicies: () => void;
+    onFileInputChange: (
+        _event: React.ChangeEvent<HTMLInputElement> | React.DragEvent<HTMLElement>,
+        file: File
+    ) => void;
+};
+
+const actionsDropdownId = 'network-simulator-actions-dropdown';
+
+const labels = {
+    generate: 'Rebuild rules from active traffic',
+    undo: 'Revert rules to previously applied YAML',
+    apply: 'Apply network policies',
+    share: 'Share YAML with notifiers',
+};
+
+function NetworkSimulatorActions({
+    generateNetworkPolicies,
+    undoNetworkPolicies,
+    onFileInputChange,
+}: NetworkSimulatorActionsProps) {
+    const [isActionsOpen, setIsActionsOpen] = React.useState(false);
+
+    const onToggle = (isOpen: boolean) => {
+        setIsActionsOpen(isOpen);
+    };
+
+    const onFocus = () => {
+        const element = document.getElementById(actionsDropdownId);
+        element?.focus();
+    };
+
+    const onSelect = () => {
+        setIsActionsOpen(false);
+        onFocus();
+    };
+
+    const actionsDropdownItems = [
+        <DropdownItem key="generate" tooltip="" onClick={generateNetworkPolicies}>
+            {labels.generate}
+        </DropdownItem>,
+        <DropdownItem key="undo" tooltip="" onClick={undoNetworkPolicies}>
+            {labels.undo}
+        </DropdownItem>,
+    ];
+
+    return (
+        <Split hasGutter className="pf-u-p-md">
+            <SplitItem>
+                <UploadYAMLButton onFileInputChange={onFileInputChange} />
+            </SplitItem>
+            <SplitItem>
+                <Dropdown
+                    direction={DropdownDirection.up}
+                    position="left"
+                    onSelect={onSelect}
+                    toggle={
+                        <DropdownToggle id={actionsDropdownId} onToggle={onToggle}>
+                            Actions
+                        </DropdownToggle>
+                    }
+                    isOpen={isActionsOpen}
+                    dropdownItems={actionsDropdownItems}
+                />
+            </SplitItem>
+        </Split>
+    );
+}
+
+export default NetworkSimulatorActions;

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/UploadYAMLButton.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/UploadYAMLButton.tsx
@@ -1,0 +1,37 @@
+import { Button, FileUpload } from '@patternfly/react-core';
+import { FileUploadIcon } from '@patternfly/react-icons';
+import React from 'react';
+
+type UploadYAMLButtonProps = {
+    onFileInputChange: (
+        _event: React.ChangeEvent<HTMLInputElement> | React.DragEvent<HTMLElement>,
+        file: File
+    ) => void;
+};
+
+function UploadYAMLButton({ onFileInputChange }: UploadYAMLButtonProps) {
+    return (
+        <>
+            <Button
+                variant="secondary"
+                icon={<FileUploadIcon />}
+                onClick={() => {
+                    document.getElementById('upload-network-policy-browse-button')?.click();
+                }}
+            >
+                Upload YAML
+            </Button>
+            <div className="pf-u-hidden">
+                <FileUpload
+                    id="upload-network-policy"
+                    filenamePlaceholder="Drag and drop a YAML or upload one"
+                    onFileInputChange={onFileInputChange}
+                    hideDefaultPreview
+                    browseButtonText="Upload"
+                />
+            </div>
+        </>
+    );
+}
+
+export default UploadYAMLButton;

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/ViewActiveYAMLs.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/ViewActiveYAMLs.tsx
@@ -11,17 +11,23 @@ import {
 import { NetworkPolicy } from 'types/networkPolicy.proto';
 import SelectSingle from 'Components/SelectSingle';
 import NetworkPoliciesYAML from './NetworkPoliciesYAML';
+import NetworkSimulatorActions from './NetworkSimulatorActions';
 
 type ViewActiveYamlsProps = {
     networkPolicies: NetworkPolicy[];
     generateNetworkPolicies: () => void;
     undoNetworkPolicies: () => void;
+    onFileInputChange: (
+        _event: React.ChangeEvent<HTMLInputElement> | React.DragEvent<HTMLElement>,
+        file: File
+    ) => void;
 };
 
 function ViewActiveYamls({
     networkPolicies,
     generateNetworkPolicies,
     undoNetworkPolicies,
+    onFileInputChange,
 }: ViewActiveYamlsProps) {
     const [selectedNetworkPolicy, setSelectedNetworkPolicy] = React.useState<
         NetworkPolicy | undefined
@@ -79,10 +85,15 @@ function ViewActiveYamls({
                 </StackItem>
                 {selectedNetworkPolicy && (
                     <StackItem>
-                        <NetworkPoliciesYAML
-                            yaml={selectedNetworkPolicy.yaml}
+                        <NetworkPoliciesYAML yaml={selectedNetworkPolicy.yaml} />
+                    </StackItem>
+                )}
+                {selectedNetworkPolicy && (
+                    <StackItem>
+                        <NetworkSimulatorActions
                             generateNetworkPolicies={generateNetworkPolicies}
                             undoNetworkPolicies={undoNetworkPolicies}
+                            onFileInputChange={onFileInputChange}
                         />
                     </StackItem>
                 )}


### PR DESCRIPTION
## Description

This PR is an iterative step to adding the network policy simulator to the network graph. This PR includes:
1. Adding the logic for uploading a network policy YAML
2. Changing the way we let the user do simulator actions. I decided to not go the code editor control route and just do it the way the mocks originally intended. The controls will be shown below the code editor now

<img width="1440" alt="Screenshot 2022-12-20 at 10 18 49 AM" src="https://user-images.githubusercontent.com/4805485/208737832-ee1c9cd0-4c65-44ef-9229-5492141c0d34.png">

<img width="1440" alt="Screenshot 2022-12-20 at 10 13 53 AM" src="https://user-images.githubusercontent.com/4805485/208737694-f25444d0-55d9-419d-9bf8-b379f5105704.png">


## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~
