### PR TITLE
CI: Do not push the -race image in OSCI

### DIFF
--- a/scripts/ci/jobs/push-images.sh
+++ b/scripts/ci/jobs/push-images.sh
@@ -53,7 +53,11 @@ push_images() {
         fi
     fi
     if [[ -n "${MAIN_RCD_IMAGE:-}" ]]; then
-        push_race_condition_debug_image
+        if is_OPENSHIFT_CI; then
+            info "-race image was built and pushed elsewhere, skipping it here."
+        else
+            push_race_condition_debug_image
+        fi
     fi
     if [[ -n "${OPERATOR_IMAGE:-}" ]]; then
         if is_OPENSHIFT_CI; then


### PR DESCRIPTION
## Description

Follow on from #3958. 

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

- [x] Check that the image is no longer pushed in OSCI. But *is* in GHA.
