### PR TITLE
ROX-13272: Label JUnit test with sensor version prefix on compatibility tests

### DIFF
--- a/qa-tests-backend/scripts/run-compatibility.sh
+++ b/qa-tests-backend/scripts/run-compatibility.sh
@@ -62,7 +62,7 @@ update_junit_prefix_with_sensor_version() {
     result_folder="${ROOT}/qa-tests-backend/build/test-results/testCOMPATIBILITY"
     info "Updating all test in $result_folder to have $SENSOR_CHART_VERSION prefix"
     for f in $result_folder/*.xml; do
-        sed -i "s/testcase name=\"/testcase name=\"[${SENSOR_CHART_VERSION}]/g" "$f"
+        sed -i "s/testcase name=\"/testcase name=\"[${SENSOR_CHART_VERSION}] /g" "$f"
     done
 }
 

--- a/qa-tests-backend/scripts/run-compatibility.sh
+++ b/qa-tests-backend/scripts/run-compatibility.sh
@@ -61,7 +61,7 @@ compatibility_test() {
 update_junit_prefix_with_sensor_version() {
     result_folder="${ROOT}/qa-tests-backend/build/test-results/testCOMPATIBILITY"
     info "Updating all test in $result_folder to have $SENSOR_CHART_VERSION prefix"
-    for f in $result_folder/*.xml; do
+    for f in "$result_folder"/*.xml; do
         sed -i "s/testcase name=\"/testcase name=\"[${SENSOR_CHART_VERSION}] /g" "$f"
     done
 }

--- a/qa-tests-backend/scripts/run-compatibility.sh
+++ b/qa-tests-backend/scripts/run-compatibility.sh
@@ -59,7 +59,7 @@ compatibility_test() {
 }
 
 update_junit_prefix_with_sensor_version() {
-    result_folder="${ROOT}qa-tests-backend/build/test-results/test"
+    result_folder="${ROOT}/qa-tests-backend/build/test-results/test"
     info "Updating all test in $result_folder to have $SENSOR_CHART_VERSION prefix"
     for f in $result_folder/*.xml; do
         sed -i "s/testcase name=\"/testcase name=\"[${SENSOR_CHART_VERSION}]/g" "$f"

--- a/qa-tests-backend/scripts/run-compatibility.sh
+++ b/qa-tests-backend/scripts/run-compatibility.sh
@@ -52,8 +52,18 @@ compatibility_test() {
 
     make -C qa-tests-backend compatibility-test || touch FAIL
 
+    update_junit_prefix_with_sensor_version
+
     store_qa_test_results "compatibility-test-sensor-${SENSOR_CHART_VERSION}"
     [[ ! -f FAIL ]] || die "compatibility-test-sensor-${SENSOR_CHART_VERSION}"
+}
+
+update_junit_prefix_with_sensor_version() {
+    result_folder="${ROOT}qa-tests-backend/build/test-results/test"
+    info "Updating all test in $result_folder to have $SENSOR_CHART_VERSION prefix"
+    for f in $result_folder/*.xml; do
+        sed -i "s/testcase name=\"/testcase name=\"[${SENSOR_CHART_VERSION}]/g" "$f"
+    done
 }
 
 

--- a/qa-tests-backend/scripts/run-compatibility.sh
+++ b/qa-tests-backend/scripts/run-compatibility.sh
@@ -59,7 +59,7 @@ compatibility_test() {
 }
 
 update_junit_prefix_with_sensor_version() {
-    result_folder="${ROOT}/qa-tests-backend/build/test-results/test"
+    result_folder="${ROOT}/qa-tests-backend/build/test-results/testCOMPATIBILITY"
     info "Updating all test in $result_folder to have $SENSOR_CHART_VERSION prefix"
     for f in $result_folder/*.xml; do
         sed -i "s/testcase name=\"/testcase name=\"[${SENSOR_CHART_VERSION}]/g" "$f"


### PR DESCRIPTION
## Description

This PR adds a script to post-process JUnit XML to have a sensor version prefix on each test case name. 

A test that fails on three different sensor versions (e.g. `70`, `71` and `72`) would look something like this in prow:
```
DefaultPoliciesTest: [70.0.0] Verify risk factors on struts deployment: Service Reachability
DefaultPoliciesTest: [71.1.0] Verify risk factors on struts deployment: Service Reachability
DefaultPoliciesTest: [72.2.0] Verify risk factors on struts deployment: Service Reachability
```

Here's the example with the failing tests on PR #4196:

![image](https://user-images.githubusercontent.com/6811076/208741719-3413b20c-118f-435a-ac63-a08abcdf4ac8.png)

## Checklist
- [x] Investigated and inspected CI test results
- [ ] ~~Unit test and regression tests added~~
- [ ] ~~Evaluated and added CHANGELOG entry if required~~
- [ ] ~~Determined and documented upgrade steps~~
- [ ] ~~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

## Testing Performed

- Enabled known compatibility failures in test PR #4196 
