### PR TITLE
Skip sort by Severity in Violations integration tests

### DIFF
--- a/ui/apps/platform/cypress/integration/violations/violations.test.js
+++ b/ui/apps/platform/cypress/integration/violations/violations.test.js
@@ -153,7 +153,7 @@ describe('Violations', () => {
         // Conditionally rendered: Policy scope
     });
 
-    it('should sort the Severity column', () => {
+    it.skip('should sort the Severity column', () => {
         visitViolations();
 
         const thSelector = 'th[scope="col"]:contains("Severity")';
@@ -168,6 +168,8 @@ describe('Violations', () => {
         }, 'desc');
 
         cy.get(thSelector).should('have.attr', 'aria-sort', 'descending');
+
+        cy.wait(1000); // prevent timing failures
         cy.get(tdSelector).then((items) => {
             assertSortedItems(items, callbackForPairOfDescendingPolicySeverityValuesFromElements);
         });
@@ -178,6 +180,8 @@ describe('Violations', () => {
         }, 'asc');
 
         cy.get(thSelector).should('have.attr', 'aria-sort', 'ascending');
+
+        cy.wait(1000); // prevent timing failures
         cy.get(tdSelector).then((items) => {
             assertSortedItems(items, callbackForPairOfAscendingPolicySeverityValuesFromElements);
         });


### PR DESCRIPTION
## Description

### Test failures

> Violations should sort the Severity colum

> expected 'notDescendingPolicySeverityValuesFromElements(Low, High)' to equal ''

cypress/integration/violations/violations.test.js

Test failed for merge after passed for branch #4185

1. 1605234443025387520 from master build for 4185 on 2022-12-20
2. 1605234443025387520 from master build for 4206 on 2022-12-20
3. 1605268491831611392 from master build for 4181 on 2022-12-20
4. 1605268351142072320 from master build for 4195 on 2022-12-20

Both postgress and non-postgress tests.

### Analysis

1. Wait on `@alerts_reversed=true` alias for correct response.
2. Assert query string in page address.
3. Assert descending indicator in column heading.
4. Column is sorted descending in snapshot when test fails.

![violations-sort](https://user-images.githubusercontent.com/11862657/208765466-33157cea-d93e-4064-807f-42d33422ca6f.png)

Hypothesis: Test gets 50 `td` elements before table has re-rendered?

### Solution

1. Skip test for rest of 2022.
2. Add `cy.wait(1000);` method call to test in 2023.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration test

## Testing Performed