### PR TITLE
ROX-13885: applying network policies in network simulator

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPolicySimulatorSidePanel.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPolicySimulatorSidePanel.tsx
@@ -39,14 +39,15 @@ const tabs = {
 function NetworkPolicySimulatorSidePanel({
     selectedClusterId,
 }: NetworkPolicySimulatorSidePanelProps) {
-    const { activeKeyTab, onSelectTab } = useTabs({
+    const { activeKeyTab, onSelectTab, setActiveKeyTab } = useTabs({
         defaultTab: tabs.SIMULATE_NETWORK_POLICIES,
     });
     const [isExcludingPortsAndProtocols, setIsExcludingPortsAndProtocols] =
         React.useState<boolean>(false);
-    const { simulator, setNetworkPolicyModification } = useNetworkPolicySimulator({
-        clusterId: selectedClusterId,
-    });
+    const { simulator, setNetworkPolicyModification, applyNetworkPolicyModification } =
+        useNetworkPolicySimulator({
+            clusterId: selectedClusterId,
+        });
 
     function handleFileInputChange(
         _event: React.ChangeEvent<HTMLInputElement> | React.DragEvent<HTMLElement>,
@@ -109,6 +110,11 @@ function NetworkPolicySimulatorSidePanel({
         });
     }
 
+    function applyNetworkPolicies() {
+        applyNetworkPolicyModification();
+        setActiveKeyTab(tabs.VIEW_ACTIVE_YAMLS);
+    }
+
     if (simulator.isLoading) {
         return (
             <Bullseye>
@@ -156,6 +162,7 @@ function NetworkPolicySimulatorSidePanel({
                             generateNetworkPolicies={generateNetworkPolicies}
                             undoNetworkPolicies={undoNetworkPolicies}
                             onFileInputChange={handleFileInputChange}
+                            applyNetworkPolicies={applyNetworkPolicies}
                         />
                     </StackItem>
                 </Stack>
@@ -203,6 +210,7 @@ function NetworkPolicySimulatorSidePanel({
                             generateNetworkPolicies={generateNetworkPolicies}
                             undoNetworkPolicies={undoNetworkPolicies}
                             onFileInputChange={handleFileInputChange}
+                            applyNetworkPolicies={applyNetworkPolicies}
                         />
                     </StackItem>
                 </Stack>
@@ -231,10 +239,12 @@ function NetworkPolicySimulatorSidePanel({
                 <Stack hasGutter>
                     <StackItem className="pf-u-p-md">
                         <Alert
-                            variant="success"
+                            variant={simulator.error ? 'danger' : 'success'}
                             isInline
                             isPlain
-                            title="Uploaded policies processed"
+                            title={
+                                simulator.error ? simulator.error : 'Uploaded policies processed'
+                            }
                         />
                     </StackItem>
                     <StackItem isFilled style={{ overflow: 'auto' }}>
@@ -245,6 +255,7 @@ function NetworkPolicySimulatorSidePanel({
                             generateNetworkPolicies={generateNetworkPolicies}
                             undoNetworkPolicies={undoNetworkPolicies}
                             onFileInputChange={handleFileInputChange}
+                            applyNetworkPolicies={applyNetworkPolicies}
                         />
                     </StackItem>
                 </Stack>

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkSimulatorActions.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkSimulatorActions.tsx
@@ -16,6 +16,7 @@ type NetworkSimulatorActionsProps = {
         _event: React.ChangeEvent<HTMLInputElement> | React.DragEvent<HTMLElement>,
         file: File
     ) => void;
+    applyNetworkPolicies?: () => void;
 };
 
 const actionsDropdownId = 'network-simulator-actions-dropdown';
@@ -31,6 +32,7 @@ function NetworkSimulatorActions({
     generateNetworkPolicies,
     undoNetworkPolicies,
     onFileInputChange,
+    applyNetworkPolicies,
 }: NetworkSimulatorActionsProps) {
     const [isActionsOpen, setIsActionsOpen] = React.useState(false);
 
@@ -56,6 +58,14 @@ function NetworkSimulatorActions({
             {labels.undo}
         </DropdownItem>,
     ];
+
+    if (applyNetworkPolicies) {
+        actionsDropdownItems.unshift(
+            <DropdownItem key="apply" tooltip="" onClick={applyNetworkPolicies}>
+                {labels.apply}
+            </DropdownItem>
+        );
+    }
 
     return (
         <Split hasGutter className="pf-u-p-md">

--- a/ui/apps/platform/src/hooks/patternfly/useTabs.ts
+++ b/ui/apps/platform/src/hooks/patternfly/useTabs.ts
@@ -8,7 +8,7 @@ function useTabs({ defaultTab }: { defaultTab: string }) {
         setActiveKeyTab(eventKey);
     }
 
-    return { activeKeyTab, onSelectTab };
+    return { activeKeyTab, onSelectTab, setActiveKeyTab };
 }
 
 export default useTabs;


### PR DESCRIPTION
## Description

This PR is an iterative step to adding the network policy simulator to the network graph. This PR includes:
1. Adding another function returned by the `useNetworkSimulator` hook called `applyNetworkPolicyModification`. This function applies the network policy modification value currently stored, and changes the state accordingly. If it applies successfully, it will then switch to the active YAMLs with the new network policy added in the select dropdown. If it was not successful, it will remain in the same state and show an error

Note: I could possibly add another field to the `NetworkPolicySimulator` type called `success` or `message` that shows any successful messages. That way when we do switch to the active YAMLs we can see a message that the action was successful. If you look at the first attached video, try to determine if it's intuitive that the action was successful

### Successful apply
https://user-images.githubusercontent.com/4805485/208966204-01265613-3249-4ed1-acf1-67faf94e1027.mov

### Error when applying
https://user-images.githubusercontent.com/4805485/208966528-370bfc05-f889-402f-9547-6fd11c7cf1d4.mov



## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

