### PR TITLE
CI: Always build the -race image in GHA

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -100,9 +100,6 @@ jobs:
           path: go-binaries-build.tgz
 
   pre-build-go-binaries-rcd:
-    if: |
-      (github.event.action == 'labeled' && github.event.label.name == 'turbo-build') ||
-      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'turbo-build'))
     runs-on: ubuntu-latest
     container:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.49
@@ -257,9 +254,6 @@ jobs:
             add_build_comment_to_pr
 
   build-and-push-main-rcd:
-    if: |
-      (github.event.action == 'labeled' && github.event.label.name == 'turbo-build') ||
-      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'turbo-build'))
     runs-on: ubuntu-latest
     needs:
     - pre-build-ui


### PR DESCRIPTION
## Description

Follow on for #3958 & #4215. These images are required for nightlies.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

- [x] run `/test gke-race-condition-qa-e2e-tests`