### PR TITLE
Minor collection fixes

### DIFF
--- a/ui/apps/platform/src/Containers/Collections/CollectionResults.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionResults.tsx
@@ -33,7 +33,11 @@ function fetchMatchingDeployments(
 ) {
     const pageSize = 10;
     const query = { [entity]: filterText };
-    const { request } = dryRunCollection(dryRunConfig, query, page, pageSize);
+    const sortOption = {
+        field: 'Deployment',
+        reversed: false,
+    };
+    const { request } = dryRunCollection(dryRunConfig, query, page, pageSize, sortOption);
     return request;
 }
 

--- a/ui/apps/platform/src/Containers/Collections/CollectionResults.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionResults.tsx
@@ -81,7 +81,7 @@ function CollectionResults({
     headerContent,
     dryRunConfig,
     configError,
-    setConfigError = () => {},
+    setConfigError,
 }: CollectionResultsProps) {
     const { isOpen, onToggle, closeSelect } = useSelectToggle();
     const [selected, setSelected] = useState<SelectorEntityType>('Deployment');
@@ -96,7 +96,7 @@ function CollectionResults({
             manualFetch: true,
             dedupKeyFn: ({ id }) => id,
             onError: (err) => {
-                setConfigError(parseConfigError(err));
+                setConfigError?.(parseConfigError(err));
             },
         });
 
@@ -117,7 +117,7 @@ function CollectionResults({
     }, [clearPages, configError]);
 
     const refreshResults = useCallback(() => {
-        setConfigError(undefined);
+        setConfigError?.(undefined);
         if (selectorRulesExist) {
             resetPages();
         }

--- a/ui/apps/platform/src/Containers/Collections/CollectionsTablePage.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionsTablePage.tsx
@@ -29,6 +29,7 @@ import useURLSearch from 'hooks/useURLSearch';
 import useURLPagination from 'hooks/useURLPagination';
 import useURLSort from 'hooks/useURLSort';
 import useToasts, { Toast } from 'hooks/patternfly/useToasts';
+import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import CollectionsTable from './CollectionsTable';
 
 type CollectionsTablePageProps = {
@@ -80,7 +81,8 @@ function CollectionsTablePage({ hasWriteAccessForCollections }: CollectionsTable
                 countRefetch();
             })
             .catch((err) => {
-                addToast(`Could not delete collection '${name}'`, 'danger', err.message);
+                const error = getAxiosErrorMessage(err);
+                addToast(`Could not delete collection '${name}'`, 'danger', error);
             });
     }
 


### PR DESCRIPTION
## Description

Fixes ROX-14065, ROX-14064, and half of ROX-14061

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

ROX-14061 - Attempt to delete a collection that is in use by another collection. The error message from the server should be displayed instead of a generic error message:
![image](https://user-images.githubusercontent.com/1292638/208804986-71eef689-00e2-4205-8ebb-09c88236b13c.png)

ROX-14064 - View a collection with rules that result in a deployment preview. The deployment results should be sorted alphabetically.
![image](https://user-images.githubusercontent.com/1292638/208805103-005403b1-fd0d-4a21-b543-7793e6bbe45c.png)

ROX-14065 - View a collection, then from the 'attach collections' section select another collection with rules that result in a deployment preview. When the modal opens, the results should be displayed in the sidebar instead of an infinite loading view.
![image](https://user-images.githubusercontent.com/1292638/208805222-ac51660c-0a22-4c75-83b0-68834de0c0ae.png)

