### PR TITLE
ROX-14039: Pad test timeout to fix flake

### DIFF
--- a/tests/ca_setup_test.go
+++ b/tests/ca_setup_test.go
@@ -75,7 +75,9 @@ func TestCASetup(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.url, func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+			internalServiceTimeout := 20 * time.Second
+			testTimeoutPadding := 500 * time.Millisecond
+			ctx, cancel := context.WithTimeout(context.Background(), internalServiceTimeout+testTimeoutPadding)
 			defer cancel()
 			resp, err := service.URLHasValidCert(ctx, &central.URLHasValidCertRequest{Url: c.url})
 			require.NoError(t, err)


### PR DESCRIPTION
## Description

The [service can take up to 20s to return](https://github.com/stackrox/stackrox/blob/751e9fbcb93715110f542fe155744d76bd26d90e/central/development/service/service_impl.go#L107), so the timeout in the test needs to be a little higher.

As a side note, this test is inherently flaky, because among other things it depends on an external service that is [*not intended* to be used in this way](https://github.com/chromium/badssl.com#disclaimer). Tracking that in https://issues.redhat.com/browse/ROX-14078

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

CI is sufficient