### PR TITLE
Telemetry: improve gRPC request details from wrapped HTTP

### DIFF
--- a/central/telemetry/centralclient/interceptors_test.go
+++ b/central/telemetry/centralclient/interceptors_test.go
@@ -27,22 +27,22 @@ func (t *interceptorsTest) SetupTest() {
 func (t *interceptorsTest) TestClusterRegisteredNoFire() {
 	props := map[string]any{}
 
-	// Path is not "/v1.ClustersService/PostCluster":
+	// Method is not "/v1.ClustersService/PostCluster":
 	rp := &phonehome.RequestParams{
-		Path: "random",
+		Method: "random",
 	}
-	t.False(clusterRegistered(rp, props), "must not fire, as Path doesn't match")
+	t.False(clusterRegistered(rp, props), "must not fire, as Method doesn't match")
 	t.Empty(props, "props must not be touched")
 }
 
 func (t *interceptorsTest) TestClusterRegisteredFire() {
 	props := map[string]any{}
 
-	// Test for matching Path:
+	// Test for matching Method:
 	rp := &phonehome.RequestParams{
-		Path: "/v1.ClustersService/PostCluster",
+		Method: "/v1.ClustersService/PostCluster",
 	}
-	t.True(clusterRegistered(rp, props), "must fire, as Path matches")
+	t.True(clusterRegistered(rp, props), "must fire, as Method matches")
 	t.Equal(map[string]any{"Code": 0}, props, "props must have only Code, as gRPC request details are not provided")
 
 	// Test with gRPC request details:
@@ -56,7 +56,7 @@ func (t *interceptorsTest) TestClusterRegisteredFire() {
 	}
 	t.False(uninitializedClusters.Contains("cluster-id"), "cluster-id must not be registered as uninitialized yet")
 	// remembers the uninitialized cluster in memory:
-	t.True(clusterRegistered(rp, props), "must fire, as Path matches, and cluster-id has not been registered")
+	t.True(clusterRegistered(rp, props), "must fire, as Method matches, and cluster-id has not been registered")
 	t.Equal(map[string]any{
 		"Code":         0,
 		"Cluster ID":   "cluster-id",
@@ -69,11 +69,11 @@ func (t *interceptorsTest) TestClusterRegisteredFire() {
 func (t *interceptorsTest) TestClusterInitializedNoFire() {
 	props := map[string]any{}
 
-	// Path is not "/v1.ClustersService/PutCluster":
+	// Method is not "/v1.ClustersService/PutCluster":
 	rp := &phonehome.RequestParams{
-		Path: "random",
+		Method: "random",
 	}
-	t.False(clusterInitialized(rp, props), "must not fire, as Path doesn't match")
+	t.False(clusterInitialized(rp, props), "must not fire, as Method doesn't match")
 	t.Empty(props)
 	t.False(uninitializedClusters.Contains("cluster-id"))
 }
@@ -84,7 +84,7 @@ func (t *interceptorsTest) TestClusterInitializedFire() {
 
 	props := map[string]any{}
 	rp := &phonehome.RequestParams{
-		Path: "/v1.ClustersService/PutCluster",
+		Method: "/v1.ClustersService/PutCluster",
 		GRPCReq: &storage.Cluster{
 			Type:      storage.ClusterType_GENERIC_CLUSTER,
 			Id:        "cluster-id",

--- a/pkg/telemetry/phonehome/interceptor.go
+++ b/pkg/telemetry/phonehome/interceptor.go
@@ -51,10 +51,18 @@ func getGRPCRequestDetails(ctx context.Context, err error, info *grpc.UnaryServe
 		log.Debug("Cannot identify user from context: ", iderr)
 	}
 
+	// Keep gRPC full method in the form of /service/method if there's no
+	// original HTTP request provided:
+	path := info.FullMethod
+	ri := requestinfo.FromContext(ctx)
+	if ri.HTTPRequest != nil && ri.HTTPRequest.URL != nil {
+		path = ri.HTTPRequest.URL.Path
+	}
+
 	return &RequestParams{
-		UserAgent: getUserAgent(requestinfo.FromContext(ctx).Metadata.Get),
+		UserAgent: getUserAgent(ri.Metadata.Get),
 		UserID:    id,
-		Path:      info.FullMethod,
+		Path:      path,
 		Code:      int(erroxGRPC.RoxErrorToGRPCCode(err)),
 		GRPCReq:   req,
 	}

--- a/pkg/telemetry/phonehome/interceptor.go
+++ b/pkg/telemetry/phonehome/interceptor.go
@@ -51,18 +51,24 @@ func getGRPCRequestDetails(ctx context.Context, err error, info *grpc.UnaryServe
 		log.Debug("Cannot identify user from context: ", iderr)
 	}
 
-	// Keep gRPC full method in the form of /service/method if there's no
-	// original HTTP request provided:
-	path := info.FullMethod
+	// Use the wrapped HTTP request details if provided:
 	ri := requestinfo.FromContext(ctx)
 	if ri.HTTPRequest != nil && ri.HTTPRequest.URL != nil {
-		path = ri.HTTPRequest.URL.Path
+		return &RequestParams{
+			UserAgent: getUserAgent(ri.Metadata.Get),
+			UserID:    id,
+			Method:    ri.HTTPRequest.Method,
+			Path:      ri.HTTPRequest.URL.Path,
+			Code:      grpcError.ErrToHTTPStatus(err),
+			GRPCReq:   req,
+		}
 	}
 
 	return &RequestParams{
 		UserAgent: getUserAgent(ri.Metadata.Get),
 		UserID:    id,
-		Path:      path,
+		Method:    info.FullMethod,
+		Path:      info.FullMethod,
 		Code:      int(erroxGRPC.RoxErrorToGRPCCode(err)),
 		GRPCReq:   req,
 	}
@@ -77,6 +83,7 @@ func getHTTPRequestDetails(ctx context.Context, r *http.Request, err error) *Req
 	return &RequestParams{
 		UserAgent: getUserAgent(r.Header.Values),
 		UserID:    id,
+		Method:    r.Method,
 		Path:      r.URL.Path,
 		Code:      grpcError.ErrToHTTPStatus(err),
 		HTTPReq:   r,

--- a/pkg/telemetry/phonehome/request_params.go
+++ b/pkg/telemetry/phonehome/request_params.go
@@ -10,20 +10,21 @@ import (
 type RequestParams struct {
 	UserAgent string
 	UserID    authn.Identity
+	Method    string
 	Path      string
 	Code      int
 	GRPCReq   any
 	HTTPReq   *http.Request
 }
 
-// GetMethod returns the HTTP method for HTTP requests, or rp.Path otherwise.
-func (rp *RequestParams) GetMethod() string {
-	switch {
-	case rp.HTTPReq == nil:
-		return rp.Path // i.e. in the form of /service/method for gRPC requests.
-	case rp.HTTPReq.Method != "":
-		return rp.HTTPReq.Method
-	default:
-		return http.MethodGet
-	}
+// ServiceMethod describes a service method with its gRPC and HTTP variants.
+type ServiceMethod struct {
+	GRPCMethod string
+	HTTPMethod string
+	HTTPPath   string
+}
+
+// Is checks wether the request targets the service method: either gRPC or HTTP.
+func (rp *RequestParams) Is(s *ServiceMethod) bool {
+	return rp.Method == s.GRPCMethod || (rp.Method == s.HTTPMethod && rp.Path == s.HTTPPath)
 }

--- a/pkg/telemetry/phonehome/request_params_test.go
+++ b/pkg/telemetry/phonehome/request_params_test.go
@@ -7,14 +7,33 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestRequestParams_GetMethod(t *testing.T) {
-	rp := &RequestParams{Path: "/v1.Service/Method"}
-	assert.Equal(t, rp.Path, rp.GetMethod(), "must be equal to Path, as there's no request details")
+func TestRequestParams_Is(t *testing.T) {
+	assert.True(t, (&RequestParams{}).
+		Is(&ServiceMethod{}),
+	)
+	assert.True(t, (&RequestParams{Method: "/v1.service/method"}).
+		Is(&ServiceMethod{GRPCMethod: "/v1.service/method"}),
+	)
+	assert.True(t, (&RequestParams{Method: "CONNECT", Path: "/v1/method"}).
+		Is(&ServiceMethod{HTTPMethod: http.MethodConnect, HTTPPath: "/v1/method"}),
+	)
+	assert.True(t, (&RequestParams{Method: "CONNECT", Path: "/v1/method"}).
+		Is(&ServiceMethod{GRPCMethod: "different", HTTPMethod: http.MethodConnect, HTTPPath: "/v1/method"}),
+	)
 
-	rp = &RequestParams{Path: "/v1/method"}
-	rp.HTTPReq, _ = http.NewRequest(http.MethodPost, "/path", nil)
-	assert.Equal(t, http.MethodPost, rp.GetMethod(), "must be POST, as the HTTP request is provided")
-
-	rp.HTTPReq, _ = http.NewRequest("", "/path", nil)
-	assert.Equal(t, http.MethodGet, rp.GetMethod(), "must be GET, as this is the default HTTP method")
+	assert.False(t, (&RequestParams{Method: "some path"}).
+		Is(&ServiceMethod{}),
+	)
+	assert.False(t, (&RequestParams{Path: "/v2.service/method"}).
+		Is(&ServiceMethod{GRPCMethod: "/v1.service/method"}),
+	)
+	assert.False(t, (&RequestParams{Method: "CONNECT", Path: "/v2/method"}).
+		Is(&ServiceMethod{HTTPMethod: http.MethodConnect, HTTPPath: "/v1/method"}),
+	)
+	assert.False(t, (&RequestParams{Method: "GET", Path: "/v1/method"}).
+		Is(&ServiceMethod{HTTPMethod: http.MethodConnect, HTTPPath: "/v1/method"}),
+	)
+	assert.False(t, (&RequestParams{Method: "GET", Path: "/v1/method"}).
+		Is(&ServiceMethod{GRPCMethod: "/v1/method"}),
+	)
 }


### PR DESCRIPTION
## Description

Take the HTTP request info from the wrapped request when intercepting gRPC calls.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

Example of the intercepted `/v1/clusters` call coming from the UI:
```
client.Track(&analytics.Track{
  UserId: "G6ft6pk2bkJbqCW1iIQ+uk8Tyk32FG0B+m58M4nn/vk=",
  Event: "API Call",
  Properties: map[string]interface{}{
    "Code": 200,
    "Method": "GET",
    "Path": "/v1/clusters",
    "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36 Rox Central/3.73.x-289-gbe8b638586-dirty (linux; amd64) grpc-go/1.51.0",
  },
})
```
