### PR TITLE
Telemetry: remove unused Telemeter.Start() method

### DIFF
--- a/pkg/telemetry/phonehome/mocks/telemeter.go
+++ b/pkg/telemetry/phonehome/mocks/telemeter.go
@@ -57,18 +57,6 @@ func (mr *MockTelemeterMockRecorder) Identify(userID, props interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Identify", reflect.TypeOf((*MockTelemeter)(nil).Identify), userID, props)
 }
 
-// Start mocks base method.
-func (m *MockTelemeter) Start() {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Start")
-}
-
-// Start indicates an expected call of Start.
-func (mr *MockTelemeterMockRecorder) Start() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockTelemeter)(nil).Start))
-}
-
 // Stop mocks base method.
 func (m *MockTelemeter) Stop() {
 	m.ctrl.T.Helper()

--- a/pkg/telemetry/phonehome/segment/segment.go
+++ b/pkg/telemetry/phonehome/segment/segment.go
@@ -55,9 +55,6 @@ func (l *logWrapper) Errorf(format string, args ...any) {
 	l.internal.Errorf(format, args...)
 }
 
-func (t *segmentTelemeter) Start() {
-}
-
 func (t *segmentTelemeter) Stop() {
 	if t != nil {
 		if err := t.client.Close(); err != nil {

--- a/pkg/telemetry/phonehome/telemeter.go
+++ b/pkg/telemetry/phonehome/telemeter.go
@@ -3,7 +3,6 @@ package phonehome
 // Telemeter defines a common interface for telemetry gatherers.
 //go:generate mockgen-wrapper
 type Telemeter interface {
-	Start()
 	Stop()
 	Identify(userID string, props map[string]any)
 	Track(event, userID string, props map[string]any)
@@ -12,7 +11,6 @@ type Telemeter interface {
 
 type nilTelemeter struct{}
 
-func (t *nilTelemeter) Start()                                             {}
 func (t *nilTelemeter) Stop()                                              {}
 func (t *nilTelemeter) Identify(userID string, props map[string]any)       {}
 func (t *nilTelemeter) Track(event, userID string, props map[string]any)   {}


### PR DESCRIPTION
## Description

Telemeter.Start() was added to complete the symmetry with Stop(), but now
is being removed as there's no plan to use it.
