### PR TITLE
ROX-13345: Enable back previously flaked test for debugging

### DIFF
--- a/qa-tests-backend/src/test/groovy/ImageScanningTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageScanningTest.groovy
@@ -493,9 +493,6 @@ class ImageScanningTest extends BaseSpecification {
     @Tag("Integration")
     def "Verify image scan exceptions - #scanner.name() - #testAspect"() {
         Assume.assumeTrue(scanner.isTestable())
-        // TODO(ROX-13345): Remove the following call to re-enable the test when the cause is fixed.
-        Assume.assumeFalse(
-            testAspect == "missing required registry" && Env.mustGetOrchestratorType() == OrchestratorTypes.OPENSHIFT)
         cleanupSetupForRetry()
 
         when:


### PR DESCRIPTION
## Description

This reverts #3798

After running the E2E test a couple of times in this PR, there is some confidence that the tests are passing. This is an attempt to re-enable it. I acknowledge the test failure is intermittent, so it is still possible that the failures will resurface. We will tackle issues before the policy disable this tests again. 

## Checklist
- [X] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

CI
