### PR TITLE
CI: Fix tag for nightly builds

### DIFF
--- a/.github/actions/handle-tagged-build/action.yaml
+++ b/.github/actions/handle-tagged-build/action.yaml
@@ -1,0 +1,10 @@
+name: Handle tagged build
+description: Handle tagged build
+runs:
+  using: composite
+  steps:
+    - name: Handle tagged build
+      run: |
+        source ./scripts/ci/lib.sh
+        handle_gha_tagged_build
+      shell: bash

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,7 +7,8 @@ on:
   push:
     branches:
       - master
-      - nightlies
+    tags:
+      - '*-nightly-*'
 
 env:
   ROX_PRODUCT_BRANDING: RHACS_BRANDING
@@ -28,6 +29,8 @@ jobs:
       - uses: ./.github/actions/create-concatenated-ui-monorepo-lock
 
       - uses: ./.github/actions/cache-ui-dependencies
+
+      - uses: ./.github/actions/handle-tagged-build
 
       - name: Fetch UI deps
         run: make -C ui deps
@@ -56,6 +59,8 @@ jobs:
       - name: Cache Go dependencies
         uses: ./.github/actions/cache-go-dependencies
 
+      - uses: ./.github/actions/handle-tagged-build
+
       - name: Build CLI
         run: make cli
 
@@ -80,6 +85,8 @@ jobs:
 
       - name: Cache Go dependencies
         uses: ./.github/actions/cache-go-dependencies
+
+      - uses: ./.github/actions/handle-tagged-build
 
       - name: PR labels
         uses: joerick/pr-labels-action@v1.0.6
@@ -112,6 +119,8 @@ jobs:
 
     - name: Cache Go dependencies
       uses: ./.github/actions/cache-go-dependencies
+
+    - uses: ./.github/actions/handle-tagged-build
 
     - name: PR labels
       uses: joerick/pr-labels-action@v1.0.6
@@ -147,6 +156,8 @@ jobs:
 
       - name: Cache Go dependencies
         uses: ./.github/actions/cache-go-dependencies
+
+      - uses: ./.github/actions/handle-tagged-build
 
       - name: Resolve mods for protos
         run: go mod tidy
@@ -189,6 +200,8 @@ jobs:
       - name: Checkout submodules
         run: |
             git submodule update --init
+
+      - uses: ./.github/actions/handle-tagged-build
 
       - uses: actions/download-artifact@v3
         with:
@@ -273,6 +286,8 @@ jobs:
       run: |
         git submodule update --init
 
+    - uses: ./.github/actions/handle-tagged-build
+
     - uses: actions/download-artifact@v3
       with:
         name: ui-build
@@ -349,6 +364,8 @@ jobs:
       - name: Cache Go dependencies
         uses: ./.github/actions/cache-go-dependencies
 
+      - uses: ./.github/actions/handle-tagged-build
+
       - name: Resolve mods for protos
         run: go mod tidy
 
@@ -396,22 +413,30 @@ jobs:
       with:
         fetch-depth: 0
         ref: ${{ github.event.pull_request.head.sha }}
+
     - name: Cache Go dependencies
       uses: ./.github/actions/cache-go-dependencies
+
+    - uses: ./.github/actions/handle-tagged-build
+
     - name: Get tag
       id: tag
       run: |
         echo "TAG=$(make --quiet tag)" >> "$GITHUB_OUTPUT"
+
     - name: Build image
       run: make mock-grpc-server-image
+
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
+
     - name: Login to quay.io/rhacs-eng
       uses: docker/login-action@v2
       with:
         registry: quay.io
         username: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
         password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
+
     - name: Push to quay.io/rhacs-eng
       uses: docker/build-push-action@v3
       with:

--- a/scripts/ci/bats/lib_handle_gha_tagged_build.bats
+++ b/scripts/ci/bats/lib_handle_gha_tagged_build.bats
@@ -6,14 +6,19 @@ load "../../test_helpers.bats"
 function setup() {
     unset OPENSHIFT_CI
     unset GITHUB_REF
+    export GITHUB_ENV="$(mktemp)"
     source "${BATS_TEST_DIRNAME}/../lib.sh"
+}
+
+function cleanup() {
+    rm -f "$GITHUB_ENV"
 }
 
 @test "without any env" {
     run handle_gha_tagged_build
     assert_success
     assert_output --partial 'No GITHUB_REF in env'
-    refute_output --partial 'set-output'
+    assert_equal "$(cat $GITHUB_ENV)" ""
 }
 
 @test "with a ref that does not indicate a tagged build" {
@@ -21,7 +26,7 @@ function setup() {
     run handle_gha_tagged_build
     assert_success
     assert_output --partial 'This is not a tagged build'
-    refute_output --partial 'set-output'
+    assert_equal "$(cat $GITHUB_ENV)" ""
 }
 
 @test "with a highly unusual ref that might incorrectly indicate a tagged build" {
@@ -29,7 +34,7 @@ function setup() {
     run handle_gha_tagged_build
     assert_success
     assert_output --partial 'This is not a tagged build'
-    refute_output --partial 'set-output'
+    assert_equal "$(cat $GITHUB_ENV)" ""
 }
 
 @test "with a ref that indicates a tagged build" {
@@ -37,5 +42,5 @@ function setup() {
     run handle_gha_tagged_build
     assert_success
     assert_output --partial 'This is a tagged build: 3.73.x-nightly-20221221'
-    assert_output --partial '::set-output name=CIRCLE_TAG::3.73.x-nightly-20221221'
+    assert_equal "$(cat $GITHUB_ENV)" "CIRCLE_TAG=3.73.x-nightly-20221221"
 }

--- a/scripts/ci/bats/lib_handle_gha_tagged_build.bats
+++ b/scripts/ci/bats/lib_handle_gha_tagged_build.bats
@@ -1,0 +1,41 @@
+#!/usr/bin/env bats
+# shellcheck disable=SC1091
+
+load "../../test_helpers.bats"
+
+function setup() {
+    unset OPENSHIFT_CI
+    unset GITHUB_REF
+    source "${BATS_TEST_DIRNAME}/../lib.sh"
+}
+
+@test "without any env" {
+    run handle_gha_tagged_build
+    assert_success
+    assert_output --partial 'No GITHUB_REF in env'
+    refute_output --partial 'set-output'
+}
+
+@test "with a ref that does not indicate a tagged build" {
+    export GITHUB_REF="refs/heads/nightlies"
+    run handle_gha_tagged_build
+    assert_success
+    assert_output --partial 'This is not a tagged build'
+    refute_output --partial 'set-output'
+}
+
+@test "with a highly unusual ref that might incorrectly indicate a tagged build" {
+    export GITHUB_REF="refs/remotes/origin/refs/tags/something"
+    run handle_gha_tagged_build
+    assert_success
+    assert_output --partial 'This is not a tagged build'
+    refute_output --partial 'set-output'
+}
+
+@test "with a ref that indicates a tagged build" {
+    export GITHUB_REF="refs/tags/3.73.x-nightly-20221221"
+    run handle_gha_tagged_build
+    assert_success
+    assert_output --partial 'This is a tagged build: 3.73.x-nightly-20221221'
+    assert_output --partial '::set-output name=CIRCLE_TAG::3.73.x-nightly-20221221'
+}

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -1490,7 +1490,7 @@ handle_gha_tagged_build() {
     if [[ "${GITHUB_REF:-}" =~ ^refs/tags/ ]]; then
         tag="${GITHUB_REF#refs/tags/*}"
         echo "This is a tagged build: $tag"
-        echo "::set-output name=CIRCLE_TAG::$tag"
+        echo "CIRCLE_TAG=$tag" >> "$GITHUB_ENV"
     else
         echo "This is not a tagged build"
     fi

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -1481,6 +1481,21 @@ is_system_test_without_images() {
     esac
 }
 
+handle_gha_tagged_build() {
+    if [[ -z "${GITHUB_REF:-}" ]]; then
+        echo "No GITHUB_REF in env"
+        exit 0
+    fi
+    echo "GITHUB_REF: ${GITHUB_REF}"
+    if [[ "${GITHUB_REF:-}" =~ ^refs/tags/ ]]; then
+        tag="${GITHUB_REF#refs/tags/*}"
+        echo "This is a tagged build: $tag"
+        echo "::set-output name=CIRCLE_TAG::$tag"
+    else
+        echo "This is not a tagged build"
+    fi
+}
+
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
     if [[ "$#" -lt 1 ]]; then
         die "When invoked at the command line a method is required."


### PR DESCRIPTION
## Description

Moving builds from OSCI to GHA broke nightly builds. This PR fixes that by emulating the behavior we relied on from Circle  CI where CIRCLE_TAG indicates 'CI is being run due to a tag being pushed'. GHA provides GITHUB_REF which can be used for a similar purpose.

@rukletsov for the joy of BATS.
@BradLugo also for the joy of BATS.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

https://github.com/stackrox/stackrox/actions/workflows/build.yaml?query=branch%3Agavin%2FCI%2Ffix-nightlies

- [x] PR creation should not build with a git tag
- [x] A commit pushed to a PR should not build with a git tag
- [x] A non `-nightly-` git tag pushed to a PR branch should be ignored by GHA - runs `style` which is a bug in the `style` workflow and not for this PR: https://github.com/stackrox/stackrox/actions/runs/3752387634
- [x] A `-nightly-` git tag pushed to a PR branch should build `-nightly-` images, pushed to quay etc for e2e test usage
