### PR TITLE
ROX-13899: Clear selected deployments when namespace deselected in new Network Graph

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
@@ -51,6 +51,9 @@ const timeWindow = 'Past hour';
 // TODO: get real includePorts flag from user input
 const includePorts = true;
 
+// for MVP, always show Orchestrator Components
+const ALWAYS_SHOW_ORCHESTRATOR_COMPONENTS = true;
+
 function NetworkGraphPage() {
     const [edgeState, setEdgeState] = useState<EdgeState>('active');
     const [activeModel, setActiveModel] = useState<CustomModel>(emptyModel);
@@ -91,7 +94,8 @@ function NetworkGraphPage() {
                         deploymentsFromUrl,
                         queryToUse,
                         timestampToUse || undefined,
-                        includePorts
+                        includePorts,
+                        ALWAYS_SHOW_ORCHESTRATOR_COMPONENTS
                     ),
                     fetchNetworkPolicyGraph(
                         selectedClusterId,
@@ -99,7 +103,8 @@ function NetworkGraphPage() {
                         deploymentsFromUrl,
                         queryToUse,
                         undefined,
-                        includePorts
+                        includePorts,
+                        ALWAYS_SHOW_ORCHESTRATOR_COMPONENTS
                     ),
                 ])
                     .then((values) => {

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/NamespaceSelector.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/NamespaceSelector.tsx
@@ -3,6 +3,7 @@ import { Badge, Select, SelectOption, SelectVariant } from '@patternfly/react-co
 
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
 import { Namespace } from 'hooks/useFetchClusterNamespaces';
+import { NamespaceWithDeployments } from 'hooks/useFetchNamespaceDeployments';
 import { NamespaceIcon } from '../common/NetworkGraphIcons';
 
 function filterElementsWithValueProp(
@@ -21,6 +22,8 @@ function filterElementsWithValueProp(
 type NamespaceSelectorProps = {
     namespaces?: Namespace[];
     selectedNamespaces?: string[];
+    selectedDeployments?: string[];
+    deploymentsByNamespace?: NamespaceWithDeployments[];
     searchFilter: Partial<Record<string, string | string[]>>;
     setSearchFilter: (newFilter: Partial<Record<string, string | string[]>>) => void;
 };
@@ -28,6 +31,8 @@ type NamespaceSelectorProps = {
 function NamespaceSelector({
     namespaces = [],
     selectedNamespaces = [],
+    selectedDeployments = [],
+    deploymentsByNamespace = [],
     searchFilter,
     setSearchFilter,
 }: NamespaceSelectorProps) {
@@ -57,6 +62,11 @@ function NamespaceSelector({
         [namespaces]
     );
 
+    const deploymentLookup: Record<string, string[]> = deploymentsByNamespace.reduce((acc, ns) => {
+        const deployments = ns.deployments.map((deployment) => deployment.name);
+        return { ...acc, [ns.metadata.name]: deployments };
+    }, {});
+
     const onNamespaceSelect = (_, selected) => {
         closeNamespaceSelect();
 
@@ -64,8 +74,18 @@ function NamespaceSelector({
             ? selectedNamespaces.filter((nsFilter) => nsFilter !== selected)
             : selectedNamespaces.concat(selected);
 
+        const newDeploymentLookup = Object.fromEntries(
+            Object.entries(deploymentLookup).filter(([key]) => newSelection.includes(key))
+        );
+        const allowedDeployments = Object.values(newDeploymentLookup).flat(1);
+
+        const filteredSelectedDeployments = selectedDeployments.filter((deployment) =>
+            allowedDeployments.includes(deployment)
+        );
+
         const modifiedSearchObject = { ...searchFilter };
         modifiedSearchObject.Namespace = newSelection;
+        modifiedSearchObject.Deployment = filteredSelectedDeployments;
         setSearchFilter(modifiedSearchObject);
     };
 

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/NetworkBreadcrumbs.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/NetworkBreadcrumbs.tsx
@@ -47,6 +47,8 @@ function NetworkBreadcrumbs({
                     <NamespaceSelector
                         namespaces={namespaces}
                         selectedNamespaces={selectedNamespaces}
+                        selectedDeployments={selectedDeployments}
+                        deploymentsByNamespace={deploymentsByNamespace}
                         searchFilter={searchFilter}
                         setSearchFilter={setSearchFilter}
                     />

--- a/ui/apps/platform/src/services/NetworkService.js
+++ b/ui/apps/platform/src/services/NetworkService.js
@@ -159,7 +159,8 @@ export function fetchNetworkPolicyGraph(
     deployments,
     query,
     modification,
-    includePorts
+    includePorts,
+    includeOrchestratorComponents = false
 ) {
     const urlParams = query ? { query } : {};
     const namespaceQuery = namespaces.length > 0 ? `Namespace:${namespaces.join(',')}` : '';
@@ -172,7 +173,10 @@ export function fetchNetworkPolicyGraph(
     }
 
     // for openshift filtering toggle
-    if (localStorage.getItem(ORCHESTRATOR_COMPONENTS_KEY) !== 'true') {
+    if (
+        !includeOrchestratorComponents &&
+        localStorage.getItem(ORCHESTRATOR_COMPONENTS_KEY) !== 'true'
+    ) {
         urlParams.scope = {
             query: 'Orchestrator Component:false',
         };
@@ -213,6 +217,7 @@ export function fetchNetworkPolicyGraph(
  * @param {String} query
  * @param {Date} date
  * @param {boolean} includePorts
+ * @param {boolean} includeOrchestratorComponents
  *
  * @returns {Promise<Object, Error>}
  */
@@ -222,7 +227,8 @@ export function fetchNetworkFlowGraph(
     deployments,
     query = '',
     date = null,
-    includePorts = false
+    includePorts = false,
+    includeOrchestratorComponents = false
 ) {
     const urlParams = query ? { query } : {};
     const namespaceQuery = namespaces.length > 0 ? `Namespace:${namespaces.join(',')}` : '';
@@ -236,7 +242,10 @@ export function fetchNetworkFlowGraph(
         urlParams.includePorts = true;
     }
     // for openshift filtering toggle
-    if (localStorage.getItem(ORCHESTRATOR_COMPONENTS_KEY) !== 'true') {
+    if (
+        !includeOrchestratorComponents &&
+        localStorage.getItem(ORCHESTRATOR_COMPONENTS_KEY) !== 'true'
+    ) {
         urlParams.scope = {
             query: 'Orchestrator Component:false',
         };


### PR DESCRIPTION
## Description

By passing two additional parameters--the currently selected deployments and an array of all namespaces with their child deployments--to the Namespace select component of the Network Graph breadcrumbs, this additional logic filters the selected deployments whenever a namespace select change event occurs.

1. Whenever the Namespace select component re-renders, it build a map with each NS as a key, and a simple array of string values of its deployments as the key's value.
2. When a NS select event occurs, the change handler takes the new selection and uses it to filter that map of NS-deployments (object -> array of entries -> array filter -> back to filtered object)
3. It then flattens all those deployments into a single array of the allowed deployments.
4. It then filters the lists of currently selected deployments against the new list of allowed deployments.
5. In addition to updating the URL with selected namespaces, it updates the URL with filtered list of selected deployments.

Notes:
* I did not refactor this logic into a separate function, because it is currently only used in this one place. Refactoring for unit testing would be a good follow-up task.
* I also added a new optional parameter to the Network Service's  `fetchNetworkFlowGraph` and `fetchNetworkPolicyGraph` functions, that allows the new Network Graph to force Orchestrator components to always be shown.


## Checklist
- [ ] Investigated and inspected CI test results


## Testing Performed

Two namespaces and deployments from each selected
![Screen Shot 2022-12-21 at 5 25 35 PM](https://user-images.githubusercontent.com/715729/209022049-372d43df-e512-4014-87c7-0c29cdf21dba.png)

After de-selecting one of those namespaces, the deployments from the deselected NS no longer appear (gone from the URL, and hence graph and the select)
![Screen Shot 2022-12-21 at 5 25 55 PM](https://user-images.githubusercontent.com/715729/209022063-cdc9c281-c7ad-4b9e-9d16-f7d9d7accbb3.png)
