### PR TITLE
ROX-13555: adding externally connected decorator to deployments

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/components/StyleNode.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/StyleNode.tsx
@@ -24,7 +24,7 @@ import {
 } from '@patternfly/react-topology';
 import DefaultIcon from '@patternfly/react-icons/dist/esm/icons/builder-image-icon';
 import AlternateIcon from '@patternfly/react-icons/dist/esm/icons/regions-icon';
-// import { PficonNetworkRangeIcon } from '@patternfly/react-icons';
+import { PficonNetworkRangeIcon } from '@patternfly/react-icons';
 import useDetailsLevel from '@patternfly/react-topology/dist/esm/hooks/useDetailsLevel';
 import { SVGIconProps } from '@patternfly/react-icons/dist/esm/createIcon';
 
@@ -139,15 +139,17 @@ const renderDecorators = (
         y: number;
     }
 ): React.ReactNode => {
-    const { showPolicyState, networkPolicyState } = data;
+    const { showPolicyState, networkPolicyState, showExternalState, isExternallyConnected } = data;
     return (
         <>
-            {/* {renderDecorator(
-                element,
-                TopologyQuadrant.upperRight,
-                <PficonNetworkRangeIcon />,
-                getShapeDecoratorCenter
-            )} */}
+            {showExternalState &&
+                isExternallyConnected &&
+                renderDecorator(
+                    element,
+                    TopologyQuadrant.upperRight,
+                    <PficonNetworkRangeIcon />,
+                    getShapeDecoratorCenter
+                )}
             {showPolicyState &&
                 renderDecorator(
                     element,

--- a/ui/apps/platform/src/Containers/NetworkGraph/external/ExternalGroupSideBar.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/external/ExternalGroupSideBar.tsx
@@ -20,7 +20,7 @@ import {
     CIDRBlockNodeModel,
     CustomNodeModel,
     ExternalEntitiesNodeModel,
-    ExternalNodeModel,
+    ExternalGroupNodeModel,
 } from '../types/topology.type';
 
 import { CidrBlockIcon, ExternalEntitiesIcon } from '../common/NetworkGraphIcons';
@@ -44,7 +44,7 @@ function ExternalGroupSideBar({ id, nodes, edges }: ExternalGroupSideBarProps): 
     const [entityNameFilter, setEntityNameFilter] = React.useState<string>('');
 
     // derived data
-    const externalGroupNode = getNodeById(nodes, id) as ExternalNodeModel;
+    const externalGroupNode = getNodeById(nodes, id) as ExternalGroupNodeModel;
     const externalNodes = nodes.filter(
         (node) => node.data.type === 'CIDR_BLOCK' || node.data.type === 'EXTERNAL_ENTITIES'
     ) as (ExternalEntitiesNodeModel | CIDRBlockNodeModel)[];

--- a/ui/apps/platform/src/Containers/NetworkGraph/types/topology.type.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/types/topology.type.ts
@@ -1,6 +1,6 @@
 import { Model, NodeModel } from '@patternfly/react-topology';
 
-import { ListenPort } from 'types/networkFlow.proto';
+import { ListenPort, Edge } from 'types/networkFlow.proto';
 import { Override } from 'utils/type.utils';
 
 export type CustomModel = Override<Model, { nodes?: CustomNodeModel[] }>;
@@ -8,7 +8,7 @@ export type CustomModel = Override<Model, { nodes?: CustomNodeModel[] }>;
 export type CustomNodeModel =
     | NamespaceNodeModel
     | DeploymentNodeModel
-    | ExternalNodeModel
+    | ExternalGroupNodeModel
     | ExternalEntitiesNodeModel
     | CIDRBlockNodeModel
     | ExtraneousNodeModel;
@@ -17,7 +17,7 @@ export type NamespaceNodeModel = Override<NodeModel, { data: NamespaceData }>;
 
 export type DeploymentNodeModel = Override<NodeModel, { data: DeploymentData }>;
 
-export type ExternalNodeModel = Override<NodeModel, { data: ExternalData }>;
+export type ExternalGroupNodeModel = Override<NodeModel, { data: ExternalGroupData }>;
 
 export type ExternalEntitiesNodeModel = Override<NodeModel, { data: ExternalEntitiesData }>;
 
@@ -28,7 +28,7 @@ export type ExtraneousNodeModel = Override<NodeModel, { data: ExtraneousData }>;
 export type CustomNodeData =
     | NamespaceData
     | DeploymentData
-    | ExternalData
+    | ExternalGroupData
     | ExternalEntitiesData
     | CIDRBlockData;
 
@@ -52,10 +52,12 @@ export type DeploymentData = {
     policyIds: string[];
     networkPolicyState: NetworkPolicyState;
     showPolicyState: boolean;
+    isExternallyConnected: boolean;
+    showExternalState: boolean;
 };
 
-export type ExternalData = {
-    type: 'EXTERNAL';
+export type ExternalGroupData = {
+    type: 'EXTERNAL_GROUP';
     collapsible: boolean;
     showContextMenu: boolean;
 };
@@ -63,6 +65,7 @@ export type ExternalData = {
 export type ExternalEntitiesData = {
     type: 'EXTERNAL_ENTITIES';
     id: string;
+    outEdges: Edge[];
 };
 
 export type CIDRBlockData = {
@@ -73,6 +76,7 @@ export type CIDRBlockData = {
         default: boolean;
         name: string;
     };
+    outEdges: Edge[];
 };
 
 export type ExtraneousData = {

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/modelUtils.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/modelUtils.tsx
@@ -255,6 +255,9 @@ function getNetworkPolicyState(
     return networkPolicyState;
 }
 
+// external connections can only be active, so this is hard coded to false
+const POLICY_NODE_EXTERNALLY_CONNECTED_VALUE = false;
+
 export function transformPolicyData(nodes: Node[], flows: number): CustomModel {
     const dataModel = {
         graph: graphModel,
@@ -263,7 +266,13 @@ export function transformPolicyData(nodes: Node[], flows: number): CustomModel {
     };
     nodes.forEach(({ entity, policyIds, outEdges, nonIsolatedEgress, nonIsolatedIngress }) => {
         const networkPolicyState = getNetworkPolicyState(nonIsolatedEgress, nonIsolatedIngress);
-        const node = getNodeModel(entity, policyIds, networkPolicyState, false, outEdges);
+        const node = getNodeModel(
+            entity,
+            policyIds,
+            networkPolicyState,
+            POLICY_NODE_EXTERNALLY_CONNECTED_VALUE,
+            outEdges
+        );
         dataModel.nodes.push(node);
 
         // creating edges based off of outEdges per node and adding to data model

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/modelUtils.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/modelUtils.tsx
@@ -1,38 +1,42 @@
 import { EdgeModel, EdgeStyle } from '@patternfly/react-topology';
 
-import { NetworkEntityInfo, Node } from 'types/networkFlow.proto';
+import {
+    DeploymentNetworkEntityInfo,
+    ExternalSourceNetworkEntityInfo,
+    InternetNetworkEntityInfo,
+    NetworkEntityInfo,
+    Node,
+    Edge,
+} from 'types/networkFlow.proto';
 import { ensureExhaustive } from 'utils/type.utils';
 import {
     CustomModel,
-    CustomNodeData,
     CustomNodeModel,
-    ExternalNodeModel,
-    ExternalData,
+    ExternalGroupNodeModel,
+    ExternalGroupData,
     NamespaceData,
     NamespaceNodeModel,
     DeploymentNodeModel,
     ExtraneousNodeModel,
     NetworkPolicyState,
+    ExternalEntitiesNodeModel,
+    CIDRBlockNodeModel,
 } from '../types/topology.type';
-
-function getNameByEntity(entity: NetworkEntityInfo): string {
-    switch (entity.type) {
-        case 'DEPLOYMENT':
-            return entity.deployment.name;
-        case 'INTERNET':
-            return 'External Entities';
-        case 'EXTERNAL_SOURCE':
-            return entity.externalSource.name;
-        default:
-            return ensureExhaustive(entity);
-    }
-}
 
 export const graphModel = {
     id: 'stackrox-active-graph',
     type: 'graph',
     layout: 'ColaGroups',
 };
+
+function getBaseNode(id: string): CustomNodeModel {
+    return {
+        id,
+        type: 'node',
+        width: 75,
+        height: 75,
+    } as CustomNodeModel;
+}
 
 function getNamespaceNode(namespace: string, deploymentId: string): NamespaceNodeModel {
     const namespaceData: NamespaceData = {
@@ -51,11 +55,11 @@ function getNamespaceNode(namespace: string, deploymentId: string): NamespaceNod
     };
 }
 
-function getExternalGroupNode(): ExternalNodeModel {
-    const externalGroupData: ExternalData = {
+function getExternalGroupNode(): ExternalGroupNodeModel {
+    const externalGroupData: ExternalGroupData = {
         collapsible: true,
         showContextMenu: false,
-        type: 'EXTERNAL',
+        type: 'EXTERNAL_GROUP',
     };
     return {
         id: 'External to cluster',
@@ -68,23 +72,45 @@ function getExternalGroupNode(): ExternalNodeModel {
     };
 }
 
-function getDataByEntityType(
-    entity: NetworkEntityInfo,
+function getDeploymentNodeModel(
+    entity: DeploymentNetworkEntityInfo,
     policyIds: string[],
-    networkPolicyState: NetworkPolicyState
-): CustomNodeData {
+    networkPolicyState: NetworkPolicyState,
+    isExternallyConnected: boolean
+): DeploymentNodeModel {
+    const baseNode = getBaseNode(entity.id) as DeploymentNodeModel;
+    return {
+        ...baseNode,
+        label: entity.deployment.name,
+        data: {
+            ...entity,
+            policyIds,
+            networkPolicyState,
+            showPolicyState: true,
+            isExternallyConnected,
+            showExternalState: true,
+        },
+    };
+}
+
+function getExternalNodeModel(
+    entity: ExternalSourceNetworkEntityInfo | InternetNetworkEntityInfo,
+    outEdges: Edge[]
+): ExternalEntitiesNodeModel | CIDRBlockNodeModel {
+    const baseNode = getBaseNode(entity.id);
     switch (entity.type) {
-        case 'DEPLOYMENT':
-            return {
-                ...entity,
-                policyIds,
-                networkPolicyState,
-                showPolicyState: true,
-            };
         case 'INTERNET':
-            return { ...entity, type: 'EXTERNAL_ENTITIES' };
+            return {
+                ...baseNode,
+                label: 'External Entities',
+                data: { ...entity, type: 'EXTERNAL_ENTITIES', outEdges },
+            };
         case 'EXTERNAL_SOURCE':
-            return { ...entity, type: 'CIDR_BLOCK' };
+            return {
+                ...baseNode,
+                label: entity.externalSource.name,
+                data: { ...entity, type: 'CIDR_BLOCK', outEdges },
+            };
         default:
             return ensureExhaustive(entity);
     }
@@ -93,17 +119,24 @@ function getDataByEntityType(
 function getNodeModel(
     entity: NetworkEntityInfo,
     policyIds: string[],
-    networkPolicyState: NetworkPolicyState
+    networkPolicyState: NetworkPolicyState,
+    isExternallyConnected: boolean,
+    outEdges: Edge[]
 ): CustomNodeModel {
-    const node = {
-        id: entity.id,
-        type: 'node',
-        width: 75,
-        height: 75,
-        label: getNameByEntity(entity),
-    } as CustomNodeModel;
-    node.data = getDataByEntityType(entity, policyIds, networkPolicyState);
-    return node;
+    switch (entity.type) {
+        case 'DEPLOYMENT':
+            return getDeploymentNodeModel(
+                entity,
+                policyIds,
+                networkPolicyState,
+                isExternallyConnected
+            );
+        case 'EXTERNAL_SOURCE':
+        case 'INTERNET':
+            return getExternalNodeModel(entity, outEdges);
+        default:
+            return ensureExhaustive(entity);
+    }
 }
 
 export function transformActiveData(
@@ -117,15 +150,16 @@ export function transformActiveData(
     };
 
     const namespaceNodes: Record<string, NamespaceNodeModel> = {};
-    let externalNode: ExternalNodeModel | null = null;
+    const externalNodes: Record<string, ExternalEntitiesNodeModel | CIDRBlockNodeModel> = {};
+    const deploymentNodes: Record<string, DeploymentNodeModel> = {};
 
     nodes.forEach(({ entity, policyIds, outEdges }) => {
         const { type, id } = entity;
         const { networkPolicyState } = policyNodeMap[id]?.data || {};
-        // creating each node and adding to data model
-        const node = getNodeModel(entity, policyIds, networkPolicyState);
-
-        dataModel.nodes.push(node);
+        const isExternallyConnected = Object.keys(outEdges).some((nodeIdx) => {
+            const { entity: targetEntity } = nodes[nodeIdx];
+            return targetEntity.type === 'EXTERNAL_SOURCE' || targetEntity.type === 'INTERNET';
+        });
 
         // to group deployments into namespaces
         if (type === 'DEPLOYMENT') {
@@ -136,15 +170,23 @@ export function transformActiveData(
             } else {
                 namespaceNodes[namespace] = getNamespaceNode(namespace, id);
             }
+
+            // creating deployment nodes
+            const deploymentNode = getDeploymentNodeModel(
+                entity,
+                policyIds,
+                networkPolicyState,
+                isExternallyConnected
+            );
+
+            deploymentNodes[id] = deploymentNode;
         }
 
         // to group external entities and cidr blocks to external grouping
         if (type === 'EXTERNAL_SOURCE' || type === 'INTERNET') {
-            if (!externalNode) {
-                externalNode = getExternalGroupNode();
-            }
-            if (externalNode && externalNode?.children) {
-                externalNode.children.push(id);
+            const externalNode = getExternalNodeModel(entity, outEdges);
+            if (!externalNodes[id]) {
+                externalNodes[id] = externalNode;
             }
         }
 
@@ -161,13 +203,38 @@ export function transformActiveData(
         });
     });
 
+    const externalNodeIds = Object.keys(externalNodes);
+    if (externalNodeIds.length > 0) {
+        // adding external outEdges to nodes to indicate externally connected state
+        Object.values(externalNodes).forEach((externalNode) => {
+            const { outEdges } = externalNode.data || {};
+            Object.keys(outEdges).forEach((nodeIdx) => {
+                const { id: targetNodeId } = nodes[nodeIdx];
+                if (deploymentNodes[targetNodeId]) {
+                    deploymentNodes[targetNodeId].data.isExternallyConnected = true;
+                }
+            });
+        });
+        // add external group node to data model
+        const externalGroupNode: ExternalGroupNodeModel = getExternalGroupNode();
+        externalNodeIds.forEach((externalNodeId) => {
+            if (externalGroupNode?.children) {
+                externalGroupNode.children.push(externalNodeId);
+            }
+        });
+
+        // add external group node to data model
+        dataModel.nodes.push(externalGroupNode);
+    }
+
+    // add deployment nodes to data model
+    dataModel.nodes.push(...Object.values(deploymentNodes));
+
     // add namespace nodes to data model
     dataModel.nodes.push(...Object.values(namespaceNodes));
 
-    // add external group node to data model
-    if (externalNode) {
-        dataModel.nodes.push(externalNode);
-    }
+    // add external nodes to data model
+    dataModel.nodes.push(...Object.values(externalNodes));
 
     return dataModel;
 }
@@ -196,7 +263,7 @@ export function transformPolicyData(nodes: Node[], flows: number): CustomModel {
     };
     nodes.forEach(({ entity, policyIds, outEdges, nonIsolatedEgress, nonIsolatedIngress }) => {
         const networkPolicyState = getNetworkPolicyState(nonIsolatedEgress, nonIsolatedIngress);
-        const node = getNodeModel(entity, policyIds, networkPolicyState);
+        const node = getNodeModel(entity, policyIds, networkPolicyState, false, outEdges);
         dataModel.nodes.push(node);
 
         // creating edges based off of outEdges per node and adding to data model
@@ -229,7 +296,7 @@ export function createExtraneousFlowsModel(
         edges: [] as EdgeModel[],
     };
     const namespaceNodes: Record<string, NamespaceNodeModel> = {};
-    let externalNode: ExternalNodeModel | null = null;
+    let externalNode: ExternalGroupNodeModel | null = null;
     // add all non-group nodes from the active graph
     Object.values(activeNodeMap).forEach((node) => {
         if (!node.group) {


### PR DESCRIPTION
also refactored a bit of the logic in `modelUtils` to be:
* more type specific for external entities
* allow for cross referencing nodes before adding them to the data model (needed to check if the node is externally connected)
* renamed `EXTERNAL` node type to `EXTERNAL_GROUP` to be more specific

if a deployment is connected (ingress or egress) to any nodes inside the `External to cluster` group on the graph, it should have the `IP` decorator on the top right corner of the node.
<img width="604" alt="image" src="https://user-images.githubusercontent.com/10412893/209053937-c3917619-de56-44af-8df2-266bb36bb4f3.png">
<img width="517" alt="image" src="https://user-images.githubusercontent.com/10412893/209053960-4a5f7c4d-4e3b-4954-ae07-2d78958786c2.png">

everything else should work as before/expected on both active and extraneous graphs.