### PR TITLE
ROX-14102: Use downward API to get tenant ID, ignore apiserver access error

### DIFF
--- a/central/telemetry/centralclient/instance_config.go
+++ b/central/telemetry/centralclient/instance_config.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/pkg/telemetry/phonehome"
 	"github.com/stackrox/rox/pkg/version"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sVersion "k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
@@ -32,23 +32,13 @@ func getInstanceConfig() (*phonehome.Config, map[string]any, error) {
 	if key == "" {
 		return nil, nil, nil
 	}
-	rc, err := rest.InClusterConfig()
-	if err != nil {
-		return nil, nil, err
-	}
-	clientset, err := kubernetes.NewForConfig(rc)
-	if err != nil {
-		return nil, nil, err
-	}
-	v, err := clientset.ServerVersion()
-	if err != nil {
-		return nil, nil, err
-	}
 
-	deployments := clientset.AppsV1().Deployments(env.Namespace.Setting())
-	central, err := deployments.Get(context.Background(), "central", v1.GetOptions{})
-	if err != nil {
-		return nil, nil, errors.Wrap(err, "cannot get central deployment")
+	// k8s apiserver is not accessible in cloud service environment.
+	v := &k8sVersion.Info{GitVersion: "unknown"}
+	if rc, err := rest.InClusterConfig(); err == nil {
+		if clientset, err := kubernetes.NewForConfig(rc); err == nil {
+			v, _ = clientset.ServerVersion()
+		}
 	}
 
 	trackedPaths = set.NewFrozenSet(strings.Split(apiWhiteList.Setting(), ",")...)
@@ -64,7 +54,7 @@ func getInstanceConfig() (*phonehome.Config, map[string]any, error) {
 	}
 	centralID := ii.Id
 
-	tenantID := central.GetLabels()[phonehome.TenantIDLabel]
+	tenantID := env.TenantID.Setting()
 	// Consider on-prem central a tenant of itself:
 	if tenantID == "" {
 		tenantID = centralID

--- a/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml
+++ b/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml
@@ -115,6 +115,10 @@ spec:
           value: "false"
         - name: ROX_ENABLE_KERNEL_PACKAGE_UPLOAD
           value: "false"
+        - name: ROX_TENANT_ID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['rhacs.redhat.com/tenant']
         {{- end }}
         {{- if ._rox.central.db.enabled }}
         - name: ROX_POSTGRES_DATASTORE

--- a/pkg/env/managed.go
+++ b/pkg/env/managed.go
@@ -3,4 +3,7 @@ package env
 var (
 	// ManagedCentral is set to true to signal that the central is running as a managed instance.
 	ManagedCentral = RegisterBooleanSetting("ROX_MANAGED_CENTRAL", false)
+
+	// TenantID is set from the according central pod label with the Downward API.
+	TenantID = RegisterSetting("ROX_TENANT_ID", AllowEmpty())
 )

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/central.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/central.test.yaml
@@ -1,3 +1,9 @@
+defs: |
+  def container(obj; name):
+  obj.spec.template.spec.containers[] | select(.name == name);
+
+  def envVars(obj; container):
+  container(obj; container) | .env | from_entries;
 values:
   ca:
     cert: ""
@@ -85,3 +91,15 @@ tests:
     .securitycontextconstraints["stackrox-central"] | assertThat(. == null)
     .deployments["central"].spec.template.spec.affinity.nodeAffinity | .preferredDuringSchedulingIgnoredDuringExecution | assertThat(length == 5)
     verifyNodeAffinities(.deployments["central"])
+
+- name: Tenant ID should be set when env.managedServices is true
+  set:
+    env.managedServices: true
+  expect: |
+    envVars(.deployments.central; "central") | assertThat(has("ROX_TENANT_ID") == true)
+
+- name: Tenant ID should not be set when env.managedServices is false
+  set:
+    env.managedServices: false
+  expect: |
+    envVars(.deployments.central; "central") | assertThat(has("ROX_TENANT_ID") == false)


### PR DESCRIPTION
## Description

In the cloud services environment, central is not permitted to access the k8s apiserver.
This PR makes the central telemetry client to read the tenant ID from the `ROX_TENANT_ID` environment variable, which in turn is set via k8s downward API.

As the kubernetes version can only be retrieved via `/version` api request, any error regarding this request is ignored, effectively reporting "unknown" kubernetes version for cloud centrals.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

helmtest