### PR TITLE
ROX-13629 Add delete pod/deployment integration tests

### DIFF
--- a/sensor/tests/resource/pod/pod_test.go
+++ b/sensor/tests/resource/pod/pod_test.go
@@ -1,14 +1,17 @@
 package pod
 
 import (
+	"context"
 	"sort"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
+	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/sensor/tests/resource"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	appsv1 "k8s.io/api/apps/v1"
 	"sigs.k8s.io/e2e-framework/klient/k8s"
@@ -53,7 +56,7 @@ func sortAlphabetically(list []string) {
 }
 
 func assertDeploymentContainerImages(images ...string) resource.AssertFunc {
-	return func(deployment *storage.Deployment) error {
+	return func(deployment *storage.Deployment, _ central.ResourceAction) error {
 		if len(deployment.GetContainers()) != len(images) {
 			return errors.Errorf("number of containers does not match slice of images provided: %d != %d", len(deployment.GetContainers()), len(images))
 		}
@@ -121,5 +124,72 @@ func (s *PodHierarchySuite) Test_ParentlessPodsAreTreatedAsDeployments() {
 		uniquePodNames := resource.GetUniquePodNamesFromPrefix(messages, "sensor-integration", "nginx-")
 		s.Require().Len(uniquePodNames, 4,
 			"Should have received four different pod events (3 from nginx-deployment and 1 from nginx-rouge")
+	})
+}
+
+func (s *PodHierarchySuite) Test_DeleteDeployment() {
+	s.testContext.RunBare("Removing a deployment should send empty violation", func(t *testing.T, testC *resource.TestContext, _ map[string]k8s.Object) {
+		deleteDep, err := testC.ApplyFileNoObject(context.Background(), resource.DefaultNamespace, NginxDeployment)
+		require.NoError(t, err)
+
+		var id string
+		// Check the deployment is processed
+		testC.LastDeploymentState("nginx-deployment", func(deployment *storage.Deployment, _ central.ResourceAction) error {
+			id = deployment.GetId()
+			return nil
+		}, "deployment should be processed")
+		testC.GetFakeCentral().ClearReceivedBuffer()
+
+		// Delete the deployment
+		err = deleteDep()
+		require.NoError(t, err)
+
+		// Check deployment and action
+		testC.LastDeploymentStateWithTimeout("nginx-deployment", func(_ *storage.Deployment, action central.ResourceAction) error {
+			if action != central.ResourceAction_REMOVE_RESOURCE {
+				return errors.New("ResourceAction should be REMOVE_RESOURCE")
+			}
+			return nil
+		}, "deployment should be deleted", 10*time.Second)
+		testC.LastViolationStateByID(id, func(alertResults *central.AlertResults) error {
+			if alertResults.GetAlerts() != nil {
+				return errors.New("AlertResults should be empty")
+			}
+			return nil
+		}, "Should have an empty violation", true)
+		testC.GetFakeCentral().ClearReceivedBuffer()
+	})
+}
+
+func (s *PodHierarchySuite) Test_DeletePod() {
+	s.testContext.RunBare("Removing a rogue pod should send empty violation", func(t *testing.T, testC *resource.TestContext, _ map[string]k8s.Object) {
+		deletePod, err := testC.ApplyFileNoObject(context.Background(), resource.DefaultNamespace, NginxPod)
+		require.NoError(t, err)
+		var id string
+		// Check the pod is processed
+		testC.LastDeploymentState("nginx-rogue", func(deployment *storage.Deployment, _ central.ResourceAction) error {
+			id = deployment.GetId()
+			return nil
+		}, "rogue pod should be processed")
+		testC.GetFakeCentral().ClearReceivedBuffer()
+
+		// Delete the pod
+		err = deletePod()
+		require.NoError(t, err)
+
+		// Check pod and action
+		testC.LastDeploymentStateWithTimeout("nginx-rogue", func(_ *storage.Deployment, action central.ResourceAction) error {
+			if action != central.ResourceAction_REMOVE_RESOURCE {
+				return errors.New("ResourceAction should be REMOVE_RESOURCE")
+			}
+			return nil
+		}, "rogue pod should be deleted", 10*time.Second)
+		testC.LastViolationStateByID(id, func(alertResults *central.AlertResults) error {
+			if alertResults.GetAlerts() != nil {
+				return errors.New("AlertResults should be empty")
+			}
+			return nil
+		}, "Should have an empty violation", true)
+		testC.GetFakeCentral().ClearReceivedBuffer()
 	})
 }

--- a/sensor/tests/resource/pod/pod_test.go
+++ b/sensor/tests/resource/pod/pod_test.go
@@ -148,7 +148,7 @@ func (s *PodHierarchySuite) Test_DeleteDeployment() {
 				return errors.New("ResourceAction should be REMOVE_RESOURCE")
 			}
 			return nil
-		}, "deployment should be deleted", 10*time.Second)
+		}, "deployment should be deleted", 5*time.Minute)
 		testC.LastViolationStateByID(id, func(alertResults *central.AlertResults) error {
 			if alertResults.GetAlerts() != nil {
 				return errors.New("AlertResults should be empty")
@@ -179,7 +179,7 @@ func (s *PodHierarchySuite) Test_DeletePod() {
 				return errors.New("ResourceAction should be REMOVE_RESOURCE")
 			}
 			return nil
-		}, "rogue pod should be deleted", 10*time.Second)
+		}, "rogue pod should be deleted", 5*time.Minute)
 		testC.LastViolationStateByID(id, func(alertResults *central.AlertResults) error {
 			if alertResults.GetAlerts() != nil {
 				return errors.New("AlertResults should be empty")

--- a/sensor/tests/resource/role/role_test.go
+++ b/sensor/tests/resource/role/role_test.go
@@ -48,7 +48,7 @@ func (s *RoleDependencySuite) SetupSuite() {
 }
 
 func assertPermissionLevel(permissionLevel storage.PermissionLevel) resource.AssertFunc {
-	return func(deployment *storage.Deployment) error {
+	return func(deployment *storage.Deployment, _ central.ResourceAction) error {
 		if deployment.ServiceAccountPermissionLevel != permissionLevel {
 			return errors.Errorf("expected permission level %s but found %s", permissionLevel, deployment.ServiceAccountPermissionLevel)
 		}

--- a/sensor/tests/resource/service/service_test.go
+++ b/sensor/tests/resource/service/service_test.go
@@ -97,13 +97,13 @@ func checkPortConfig(deployment *storage.Deployment, ports []*storage.PortConfig
 }
 
 func assertLastDeploymentHasPortExposure(ports []*storage.PortConfig) resource.AssertFunc {
-	return func(deployment *storage.Deployment) error {
+	return func(deployment *storage.Deployment, _ central.ResourceAction) error {
 		return checkPortConfig(deployment, ports)
 	}
 }
 
 func assertLastDeploymentMissingPortExposure(ports []*storage.PortConfig) resource.AssertFunc {
-	return func(deployment *storage.Deployment) error {
+	return func(deployment *storage.Deployment, _ central.ResourceAction) error {
 		if err := checkPortConfig(deployment, ports); err != nil {
 			return nil
 		}


### PR DESCRIPTION
## Description

Adds integration tests for the deletion of pods and deployments.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

* CI
* Manual testing with and without the `ROX_RESYNC_DISABLED` feature flag enabled.
