### PR TITLE
ROX-14108: Adding simulation frame

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraph.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraph.tsx
@@ -33,6 +33,12 @@ import { createExtraneousEdges } from './utils/modelUtils';
 import { Simulation } from './utils/getSimulation';
 
 import './Topology.css';
+import useNetworkPolicySimulator, {
+    ApplyNetworkPolicyModification,
+    NetworkPolicySimulator,
+    SetNetworkPolicyModification,
+} from './hooks/useNetworkPolicySimulator';
+import SimulationFrame from './simulation/SimulationFrame';
 
 // TODO: move these type defs to a central location
 export const UrlDetailType = {
@@ -64,6 +70,9 @@ export type TopologyComponentProps = {
     edgeState: EdgeState;
     simulation: Simulation;
     selectedClusterId: string;
+    simulator: NetworkPolicySimulator;
+    setNetworkPolicyModification: SetNetworkPolicyModification;
+    applyNetworkPolicyModification: ApplyNetworkPolicyModification;
 };
 
 function getNodeEdges(selectedNode) {
@@ -91,6 +100,9 @@ const TopologyComponent = ({
     edgeState,
     simulation,
     selectedClusterId,
+    simulator,
+    setNetworkPolicyModification,
+    applyNetworkPolicyModification,
 }: TopologyComponentProps) => {
     const history = useHistory();
     const { detailId } = useParams();
@@ -266,7 +278,12 @@ const TopologyComponent = ({
             sideBar={
                 <TopologySideBar resizable onClose={closeSidebar}>
                     {simulation.isOn && simulation.type === 'networkPolicy' && (
-                        <NetworkPolicySimulatorSidePanel selectedClusterId={selectedClusterId} />
+                        <NetworkPolicySimulatorSidePanel
+                            selectedClusterId={selectedClusterId}
+                            simulator={simulator}
+                            setNetworkPolicyModification={setNetworkPolicyModification}
+                            applyNetworkPolicyModification={applyNetworkPolicyModification}
+                        />
                     )}
                     {selectedEntity && selectedEntity?.data?.type === 'NAMESPACE' && (
                         <NamespaceSideBar
@@ -343,17 +360,26 @@ const NetworkGraph = React.memo<NetworkGraphProps>(
         controller.registerComponentFactory(defaultComponentFactory);
         controller.registerComponentFactory(stylesComponentFactory);
 
+        const { simulator, setNetworkPolicyModification, applyNetworkPolicyModification } =
+            useNetworkPolicySimulator({
+                simulation,
+                clusterId: selectedClusterId,
+            });
+
         return (
-            <div className="pf-ri__topology-demo">
+            <SimulationFrame simulator={simulator}>
                 <VisualizationProvider controller={controller}>
                     <TopologyComponent
                         model={model}
                         edgeState={edgeState}
                         simulation={simulation}
                         selectedClusterId={selectedClusterId}
+                        simulator={simulator}
+                        setNetworkPolicyModification={setNetworkPolicyModification}
+                        applyNetworkPolicyModification={applyNetworkPolicyModification}
                     />
                 </VisualizationProvider>
-            </div>
+            </SimulationFrame>
         );
     }
 );

--- a/ui/apps/platform/src/Containers/NetworkGraph/hooks/useNetworkPolicySimulator.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/hooks/useNetworkPolicySimulator.ts
@@ -5,8 +5,9 @@ import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import * as networkService from 'services/NetworkService';
 import { ensureExhaustive } from 'utils/type.utils';
 import { NetworkPolicy } from 'types/networkPolicy.proto';
+import { Simulation } from '../utils/getSimulation';
 
-type NetworkPolicySimulator =
+export type NetworkPolicySimulator =
     | {
           state: 'ACTIVE';
           networkPolicies: NetworkPolicy[];
@@ -19,6 +20,10 @@ type NetworkPolicySimulator =
           isLoading: boolean;
           error: string;
       };
+
+export type SetNetworkPolicyModification = (action: SetNetworkPolicyModificationAction) => void;
+
+export type ApplyNetworkPolicyModification = () => void;
 
 type SetNetworkPolicyModificationAction =
     | {
@@ -51,10 +56,15 @@ type SetNetworkPolicyModificationAction =
           };
       };
 
-function useNetworkPolicySimulator({ clusterId }): {
+type UseNetworkPolicySimulatorParams = {
+    simulation: Simulation;
+    clusterId: string;
+};
+
+function useNetworkPolicySimulator({ simulation, clusterId }: UseNetworkPolicySimulatorParams): {
     simulator: NetworkPolicySimulator;
-    setNetworkPolicyModification: (action: SetNetworkPolicyModificationAction) => void;
-    applyNetworkPolicyModification: () => void;
+    setNetworkPolicyModification: SetNetworkPolicyModification;
+    applyNetworkPolicyModification: ApplyNetworkPolicyModification;
 } {
     const defaultResultState = {
         state: 'ACTIVE',
@@ -73,7 +83,7 @@ function useNetworkPolicySimulator({ clusterId }): {
                 searchQuery: '',
             },
         });
-    }, []);
+    }, [clusterId, simulation.isOn]);
 
     function setNetworkPolicyModification(action: SetNetworkPolicyModificationAction): void {
         const { state, options } = action;

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPolicySimulatorSidePanel.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPolicySimulatorSidePanel.tsx
@@ -21,7 +21,11 @@ import {
 
 import useTabs from 'hooks/patternfly/useTabs';
 import ViewActiveYAMLs from './ViewActiveYAMLs';
-import useNetworkPolicySimulator from '../hooks/useNetworkPolicySimulator';
+import {
+    ApplyNetworkPolicyModification,
+    NetworkPolicySimulator,
+    SetNetworkPolicyModification,
+} from '../hooks/useNetworkPolicySimulator';
 import NetworkPoliciesYAML from './NetworkPoliciesYAML';
 import { getDisplayYAMLFromNetworkPolicyModification } from '../utils/simulatorUtils';
 import UploadYAMLButton from './UploadYAMLButton';
@@ -30,6 +34,9 @@ import NotifyYAMLModal from './NotifyYAMLModal';
 
 type NetworkPolicySimulatorSidePanelProps = {
     selectedClusterId: string;
+    simulator: NetworkPolicySimulator;
+    setNetworkPolicyModification: SetNetworkPolicyModification;
+    applyNetworkPolicyModification: ApplyNetworkPolicyModification;
 };
 
 const tabs = {
@@ -39,6 +46,9 @@ const tabs = {
 
 function NetworkPolicySimulatorSidePanel({
     selectedClusterId,
+    simulator,
+    setNetworkPolicyModification,
+    applyNetworkPolicyModification,
 }: NetworkPolicySimulatorSidePanelProps) {
     const { activeKeyTab, onSelectTab, setActiveKeyTab } = useTabs({
         defaultTab: tabs.SIMULATE_NETWORK_POLICIES,
@@ -46,10 +56,6 @@ function NetworkPolicySimulatorSidePanel({
     const [isExcludingPortsAndProtocols, setIsExcludingPortsAndProtocols] =
         React.useState<boolean>(false);
     const [isNotifyModalOpen, setIsNotifyModalOpen] = React.useState(false);
-    const { simulator, setNetworkPolicyModification, applyNetworkPolicyModification } =
-        useNetworkPolicySimulator({
-            clusterId: selectedClusterId,
-        });
 
     function handleFileInputChange(
         _event: React.ChangeEvent<HTMLInputElement> | React.DragEvent<HTMLElement>,

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/SimulationFrame.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/SimulationFrame.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { ScreenIcon } from '@patternfly/react-icons';
+
+import { Flex, FlexItem } from '@patternfly/react-core';
+import { NetworkPolicySimulator } from '../hooks/useNetworkPolicySimulator';
+
+type SimulationFrameProps = {
+    simulator: NetworkPolicySimulator;
+    children: React.ReactNode;
+};
+
+function SimulationFrame({ simulator, children }: SimulationFrameProps) {
+    const isSimulating =
+        simulator.state === 'GENERATED' ||
+        simulator.state === 'UNDO' ||
+        simulator.state === 'UPLOAD';
+
+    let style = {};
+    if (isSimulating) {
+        style = { position: 'relative', border: '5px solid rgb(115,188,247)' };
+    } else {
+        style = {};
+    }
+    return (
+        <div className="pf-ri__topology-demo" style={style}>
+            {children}
+            {isSimulating && (
+                <Flex
+                    className="pf-u-p-sm"
+                    style={{
+                        backgroundColor: 'rgb(224,233,242)',
+                        position: 'absolute',
+                        left: '0',
+                        top: '0',
+                        zIndex: 100,
+                    }}
+                    alignItems={{ default: 'alignItemsCenter' }}
+                >
+                    <FlexItem>
+                        <ScreenIcon className="pf-u-info-color-100" />
+                    </FlexItem>
+                    <FlexItem>
+                        <div className="pf-u-info-color-100">Simulated view</div>
+                    </FlexItem>
+                </Flex>
+            )}
+        </div>
+    );
+}
+
+export default SimulationFrame;


### PR DESCRIPTION
## Description

This PR is an iterative step to adding the network policy simulator to the network graph. This PR includes:
1. Adding a `SimulationFrame` which shows a border around the network graph when simulating

<img width="1440" alt="Screenshot 2022-12-22 at 1 00 04 PM" src="https://user-images.githubusercontent.com/4805485/209225976-cc5cefec-1cf9-4092-abad-65c7487c3d9d.png">


## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge~ into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))
