### PR TITLE
ROX-13900: Customize network breadcrumb triggers

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
@@ -2,8 +2,6 @@ import React, { useState, useEffect } from 'react';
 import {
     PageSection,
     Title,
-    Flex,
-    FlexItem,
     Bullseye,
     Spinner,
     Button,
@@ -176,24 +174,30 @@ function NetworkGraphPage() {
     return (
         <>
             <PageTitle title="Network Graph" />
-            <PageSection variant="light">
-                <Flex alignItems={{ default: 'alignItemsCenter' }}>
-                    <FlexItem>
-                        <Title headingLevel="h1" className="pf-u-screen-reader">
-                            Network Graph
-                        </Title>
-                    </FlexItem>
-                    <FlexItem flex={{ default: 'flex_1' }}>
-                        <NetworkBreadcrumbs
-                            clusters={clusters}
-                            selectedCluster={selectedCluster}
-                            selectedNamespaces={namespacesFromUrl}
-                            selectedDeployments={deploymentsFromUrl}
-                        />
-                    </FlexItem>
-                    <Button variant="secondary">Manage CIDR blocks</Button>
-                    <SimulateNetworkPolicyButton simulation={simulation} />
-                </Flex>
+            <PageSection variant="light" padding={{ default: 'noPadding' }}>
+                <Toolbar data-testid="network-graph-selector-bar">
+                    <ToolbarContent>
+                        <ToolbarGroup variant="filter-group">
+                            <Title headingLevel="h1" className="pf-u-screen-reader">
+                                Network Graph
+                            </Title>
+                            <NetworkBreadcrumbs
+                                clusters={clusters}
+                                selectedCluster={selectedCluster}
+                                selectedNamespaces={namespacesFromUrl}
+                                selectedDeployments={deploymentsFromUrl}
+                            />
+                        </ToolbarGroup>
+                        <ToolbarGroup variant="button-group" alignment={{ default: 'alignRight' }}>
+                            <ToolbarItem spacer={{ default: 'spacerMd' }}>
+                                <Button variant="secondary">Manage CIDR blocks</Button>
+                            </ToolbarItem>
+                            <ToolbarItem spacer={{ default: 'spacerNone' }}>
+                                <SimulateNetworkPolicyButton simulation={simulation} />
+                            </ToolbarItem>
+                        </ToolbarGroup>
+                    </ToolbarContent>
+                </Toolbar>
             </PageSection>
             <Divider component="div" />
             <PageSection variant="light" padding={{ default: 'noPadding' }}>

--- a/ui/apps/platform/src/Containers/NetworkGraph/common/NetworkGraphIcons.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/common/NetworkGraphIcons.tsx
@@ -1,16 +1,28 @@
 import React from 'react';
 import { Badge } from '@patternfly/react-core';
 
-export function DeploymentIcon() {
-    return <Badge style={{ backgroundColor: 'rgb(0,102,205)' }}>D</Badge>;
+export function DeploymentIcon(props) {
+    return (
+        <Badge {...props} style={{ backgroundColor: 'rgb(0,102,205)' }}>
+            D
+        </Badge>
+    );
 }
 
-export function NamespaceIcon() {
-    return <Badge style={{ backgroundColor: 'rgb(32,79,23)' }}>NS</Badge>;
+export function NamespaceIcon(props) {
+    return (
+        <Badge {...props} style={{ backgroundColor: 'rgb(32,79,23)' }}>
+            NS
+        </Badge>
+    );
 }
 
-export function ClusterIcon() {
-    return <Badge style={{ backgroundColor: 'rgb(132,118,209)' }}>CL</Badge>;
+export function ClusterIcon(props) {
+    return (
+        <Badge {...props} style={{ backgroundColor: 'rgb(132,118,209)' }}>
+            CL
+        </Badge>
+    );
 }
 
 export function CidrBlockIcon() {

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/ClusterSelector.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/ClusterSelector.tsx
@@ -37,7 +37,7 @@ function ClusterSelector({
     const clusterSelectOptions: JSX.Element[] = clusters.map((cluster) => (
         <SelectOption key={cluster.id} value={cluster.name}>
             <span>
-                <ClusterIcon /> {cluster.name}
+                <ClusterIcon className="pf-u-mr-xs" /> {cluster.name}
             </span>
         </SelectOption>
     ));
@@ -45,7 +45,12 @@ function ClusterSelector({
     return (
         <Select
             isPlain
-            placeholderText={<em>Select a cluster</em>}
+            placeholderText={
+                <span>
+                    <ClusterIcon className="pf-u-mr-xs" />{' '}
+                    <span style={{ position: 'relative', top: '1px' }}>Cluster</span>
+                </span>
+            }
             aria-label="Select a cluster"
             onToggle={toggleIsClusterOpen}
             onSelect={onClusterSelect}

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/DeploymentSelector.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/DeploymentSelector.tsx
@@ -78,7 +78,12 @@ function DeploymentSelector({
             onSelect={onDeploymentSelect}
             onFilter={onFilterDeployments}
             className="deployment-select"
-            placeholderText="Deployments"
+            placeholderText={
+                <span>
+                    <DeploymentIcon className="pf-u-mr-xs" />{' '}
+                    <span style={{ position: 'relative', top: '1px' }}>Deployments</span>
+                </span>
+            }
             isDisabled={deploymentsByNamespace.length === 0}
             selections={selectedDeployments}
             variant={SelectVariant.checkbox}

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/DeploymentSelector.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/DeploymentSelector.tsx
@@ -85,6 +85,7 @@ function DeploymentSelector({
             maxHeight="275px"
             hasInlineFilter
             isGrouped
+            isPlain
         >
             {deploymentSelectOptions}
         </Select>

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/NamespaceSelector.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/NamespaceSelector.tsx
@@ -111,7 +111,12 @@ function NamespaceSelector({
             onSelect={onNamespaceSelect}
             onFilter={onFilterNamespaces}
             className="namespace-select"
-            placeholderText="Namespaces"
+            placeholderText={
+                <span>
+                    <NamespaceIcon className="pf-u-mr-xs" />{' '}
+                    <span style={{ position: 'relative', top: '1px' }}>Namespaces</span>
+                </span>
+            }
             isDisabled={namespaceSelectOptions.length === 0}
             selections={selectedNamespaces}
             variant={SelectVariant.checkbox}

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/NamespaceSelector.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/NamespaceSelector.tsx
@@ -117,6 +117,7 @@ function NamespaceSelector({
             variant={SelectVariant.checkbox}
             maxHeight="275px"
             hasInlineFilter
+            isPlain
         >
             {namespaceSelectOptions}
         </Select>

--- a/ui/apps/platform/src/css/trumps.css
+++ b/ui/apps/platform/src/css/trumps.css
@@ -59,7 +59,7 @@ button.pf-c-toggle-group__button:disabled {
     opacity: inherit;
 }
 
-.pf-c-select__toggle::before {
+.pf-c-select__toggle:not(.pf-m-plain)::before {
     position: absolute;
     top: 0;
     right: 0;

--- a/ui/apps/platform/src/css/trumps.css
+++ b/ui/apps/platform/src/css/trumps.css
@@ -93,6 +93,17 @@ button.pf-c-toggle-group__button:disabled {
     border-bottom-width: 2px !important;
 }
 
+/* Fix default text in plain PF Select */
+.pf-c-select__toggle.pf-m-plain .pf-c-select__toggle-text {
+    overflow: visible !important;
+}
+
+/* Remove gray background from plain PF Select trigger button when disabled */
+.pf-c-select__toggle.pf-m-disabled,
+.pf-c-select__toggle:disabled {
+    --pf-c-select__toggle--disabled--BackgroundColor: none;
+}
+
 /* overriding our tailwind config default of display: block for images, because it breaks the patternfly layout */
 .pf-c-button__icon.pf-m-start svg,
 .pf-c-button__icon.pf-m-end svg,


### PR DESCRIPTION
## Description

Customizing style of breadcrumbs to converge on mocks,
https://www.sketch.com/s/9d082d82-3515-40f2-875a-1b322a02bace/a/4alGAmA 

Two remaining issues:
1. If you only select one NS or one deployment, default PatternFly checkbox select behavior is to show a count of 1, not single name.
2. Separator for PatternFly Breadcrumb component list is hard-coded as RightAngle bracket, not slash.

Will check with UX about these two things after holiday break.


## Checklist
- [ ] Investigated and inspected CI test results


## Testing Performed

![Screen Shot 2022-12-22 at 4 37 59 PM](https://user-images.githubusercontent.com/715729/209234422-1a202e46-2816-423b-b6c4-a0d202e6450c.png)

![Screen Shot 2022-12-22 at 4 38 18 PM](https://user-images.githubusercontent.com/715729/209234437-a75aa66a-47e3-4ba0-8b33-e00abbe89382.png)

![Screen Shot 2022-12-22 at 4 38 27 PM](https://user-images.githubusercontent.com/715729/209234446-da65cec5-072b-4a73-8cad-ff862375d33e.png)
