### PR TITLE
Add Count*(ctx) methods to the stores used for telemetry

### DIFF
--- a/central/authprovider/datastore/telemetry.go
+++ b/central/authprovider/datastore/telemetry.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/pkg/errors"
 	groupDataStore "github.com/stackrox/rox/central/group/datastore"
+	"github.com/stackrox/rox/central/role/resources"
+	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/telemetry/phonehome"
@@ -12,9 +14,10 @@ import (
 
 // Gather auth provider names and number of groups per auth provider.
 var Gather phonehome.GatherFunc = func(ctx context.Context) (map[string]any, error) {
-	// WithAllAccess is required only to fetch and calculate the number of
-	// auth providers and groups. It is not propagated anywhere else.
-	ctx = sac.WithAllAccess(ctx)
+	ctx = sac.WithGlobalAccessScopeChecker(ctx,
+		sac.AllowFixedScopes(
+			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
+			sac.ResourceScopeKeys(resources.Access)))
 	props := make(map[string]any)
 
 	providers, err := Singleton().GetAllAuthProviders(ctx)

--- a/central/graphql/resolvers/generated.go
+++ b/central/graphql/resolvers/generated.go
@@ -790,6 +790,7 @@ func registerGeneratedTypes(builder generator.SchemaBuilder) {
 	generator.RegisterProtoEnum(builder, reflect.TypeOf(storage.ManagerType(0)))
 	utils.Must(builder.AddType("Metadata", []string{
 		"buildFlavor: String!",
+		"dbAvailable: Boolean!",
 		"licenseStatus: Metadata_LicenseStatus!",
 		"releaseBuild: Boolean!",
 		"version: String!",
@@ -9311,6 +9312,11 @@ func (resolver *Resolver) wrapMetadatasWithContext(ctx context.Context, values [
 
 func (resolver *metadataResolver) BuildFlavor(ctx context.Context) string {
 	value := resolver.data.GetBuildFlavor()
+	return value
+}
+
+func (resolver *metadataResolver) DbAvailable(ctx context.Context) bool {
+	value := resolver.data.GetDbAvailable()
 	return value
 }
 

--- a/central/role/datastore/datastore.go
+++ b/central/role/datastore/datastore.go
@@ -13,18 +13,21 @@ import (
 type DataStore interface {
 	GetRole(ctx context.Context, name string) (*storage.Role, bool, error)
 	GetAllRoles(ctx context.Context) ([]*storage.Role, error)
+	CountRoles(ctx context.Context) (int, error)
 	AddRole(ctx context.Context, role *storage.Role) error
 	UpdateRole(ctx context.Context, role *storage.Role) error
 	RemoveRole(ctx context.Context, name string) error
 
 	GetPermissionSet(ctx context.Context, id string) (*storage.PermissionSet, bool, error)
 	GetAllPermissionSets(ctx context.Context) ([]*storage.PermissionSet, error)
+	CountPermissionSets(ctx context.Context) (int, error)
 	AddPermissionSet(ctx context.Context, permissionSet *storage.PermissionSet) error
 	UpdatePermissionSet(ctx context.Context, permissionSet *storage.PermissionSet) error
 	RemovePermissionSet(ctx context.Context, id string) error
 
 	GetAccessScope(ctx context.Context, id string) (*storage.SimpleAccessScope, bool, error)
 	GetAllAccessScopes(ctx context.Context) ([]*storage.SimpleAccessScope, error)
+	CountAccessScopes(ctx context.Context) (int, error)
 	AddAccessScope(ctx context.Context, scope *storage.SimpleAccessScope) error
 	UpdateAccessScope(ctx context.Context, scope *storage.SimpleAccessScope) error
 	RemoveAccessScope(ctx context.Context, id string) error

--- a/central/role/datastore/datastore_impl.go
+++ b/central/role/datastore/datastore_impl.go
@@ -174,7 +174,7 @@ func (ds *dataStoreImpl) CountPermissionSets(ctx context.Context) (int, error) {
 		return 0, err
 	}
 
-	return ds.CountPermissionSets(ctx)
+	return ds.permissionSetStorage.Count(ctx)
 }
 
 func (ds *dataStoreImpl) AddPermissionSet(ctx context.Context, permissionSet *storage.PermissionSet) error {
@@ -308,7 +308,7 @@ func (ds *dataStoreImpl) CountAccessScopes(ctx context.Context) (int, error) {
 		return 0, err
 	}
 
-	return ds.CountAccessScopes(ctx)
+	return ds.accessScopeStorage.Count(ctx)
 }
 
 func (ds *dataStoreImpl) AddAccessScope(ctx context.Context, scope *storage.SimpleAccessScope) error {

--- a/central/role/datastore/datastore_impl.go
+++ b/central/role/datastore/datastore_impl.go
@@ -46,6 +46,14 @@ func (ds *dataStoreImpl) GetAllRoles(ctx context.Context) ([]*storage.Role, erro
 	return ds.getAllRolesNoScopeCheck(ctx)
 }
 
+func (ds *dataStoreImpl) CountRoles(ctx context.Context) (int, error) {
+	if ok, err := roleSAC.ReadAllowed(ctx); !ok || err != nil {
+		return 0, err
+	}
+
+	return ds.roleStorage.Count(ctx)
+}
+
 func (ds *dataStoreImpl) getAllRolesNoScopeCheck(ctx context.Context) ([]*storage.Role, error) {
 	var roles []*storage.Role
 	walkFn := func() error {
@@ -159,6 +167,14 @@ func (ds *dataStoreImpl) GetAllPermissionSets(ctx context.Context) ([]*storage.P
 	}
 
 	return permissionSets, nil
+}
+
+func (ds *dataStoreImpl) CountPermissionSets(ctx context.Context) (int, error) {
+	if ok, err := roleSAC.ReadAllowed(ctx); !ok || err != nil {
+		return 0, err
+	}
+
+	return ds.CountPermissionSets(ctx)
 }
 
 func (ds *dataStoreImpl) AddPermissionSet(ctx context.Context, permissionSet *storage.PermissionSet) error {
@@ -285,6 +301,14 @@ func (ds *dataStoreImpl) GetAllAccessScopes(ctx context.Context) ([]*storage.Sim
 	}
 
 	return scopes, nil
+}
+
+func (ds *dataStoreImpl) CountAccessScopes(ctx context.Context) (int, error) {
+	if ok, err := roleSAC.ReadAllowed(ctx); !ok || err != nil {
+		return 0, err
+	}
+
+	return ds.CountAccessScopes(ctx)
 }
 
 func (ds *dataStoreImpl) AddAccessScope(ctx context.Context, scope *storage.SimpleAccessScope) error {

--- a/central/role/datastore/mocks/datastore.go
+++ b/central/role/datastore/mocks/datastore.go
@@ -78,6 +78,51 @@ func (mr *MockDataStoreMockRecorder) AddRole(ctx, role interface{}) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddRole", reflect.TypeOf((*MockDataStore)(nil).AddRole), ctx, role)
 }
 
+// CountAccessScopes mocks base method.
+func (m *MockDataStore) CountAccessScopes(ctx context.Context) (int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CountAccessScopes", ctx)
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CountAccessScopes indicates an expected call of CountAccessScopes.
+func (mr *MockDataStoreMockRecorder) CountAccessScopes(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountAccessScopes", reflect.TypeOf((*MockDataStore)(nil).CountAccessScopes), ctx)
+}
+
+// CountPermissionSets mocks base method.
+func (m *MockDataStore) CountPermissionSets(ctx context.Context) (int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CountPermissionSets", ctx)
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CountPermissionSets indicates an expected call of CountPermissionSets.
+func (mr *MockDataStoreMockRecorder) CountPermissionSets(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountPermissionSets", reflect.TypeOf((*MockDataStore)(nil).CountPermissionSets), ctx)
+}
+
+// CountRoles mocks base method.
+func (m *MockDataStore) CountRoles(ctx context.Context) (int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CountRoles", ctx)
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CountRoles indicates an expected call of CountRoles.
+func (mr *MockDataStoreMockRecorder) CountRoles(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountRoles", reflect.TypeOf((*MockDataStore)(nil).CountRoles), ctx)
+}
+
 // GetAccessScope mocks base method.
 func (m *MockDataStore) GetAccessScope(ctx context.Context, id string) (*storage.SimpleAccessScope, bool, error) {
 	m.ctrl.T.Helper()

--- a/central/role/datastore/telemetry.go
+++ b/central/role/datastore/telemetry.go
@@ -3,6 +3,8 @@ package datastore
 import (
 	"context"
 
+	"github.com/stackrox/rox/central/role/resources"
+	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/errorhelpers"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/telemetry/phonehome"
@@ -11,10 +13,11 @@ import (
 // Gather the total amount of permission sets, access scopes, and roles for
 // phone home telemetry.
 var Gather phonehome.GatherFunc = func(ctx context.Context) (map[string]any, error) {
-	// WithAllAccess is required only to fetch and calculate the number of
-	// permission sets, roles and access scopes. It is not propagated anywhere
-	// else.
-	ctx = sac.WithAllAccess(ctx)
+	ctx = sac.WithGlobalAccessScopeChecker(ctx,
+		sac.AllowFixedScopes(
+			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
+			sac.ResourceScopeKeys(resources.Role)))
+
 	totals := make(map[string]any)
 	rs := Singleton()
 

--- a/central/role/datastore/telemetry.go
+++ b/central/role/datastore/telemetry.go
@@ -22,9 +22,9 @@ var Gather phonehome.GatherFunc = func(ctx context.Context) (map[string]any, err
 	rs := Singleton()
 
 	gatherErrs := errorhelpers.NewErrorList("cannot gather from role store")
-	gatherErrs.AddError(phonehome.AddTotal(ctx, totals, "PermissionSets", rs.GetAllPermissionSets))
-	gatherErrs.AddError(phonehome.AddTotal(ctx, totals, "Roles", rs.GetAllRoles))
-	gatherErrs.AddError(phonehome.AddTotal(ctx, totals, "Access Scopes", rs.GetAllAccessScopes))
+	gatherErrs.AddError(phonehome.AddTotal(ctx, totals, "PermissionSets", rs.CountPermissionSets))
+	gatherErrs.AddError(phonehome.AddTotal(ctx, totals, "Roles", rs.CountRoles))
+	gatherErrs.AddError(phonehome.AddTotal(ctx, totals, "Access Scopes", rs.CountAccessScopes))
 
 	return totals, gatherErrs.ToError()
 }

--- a/central/role/store/mocks/store.go
+++ b/central/role/store/mocks/store.go
@@ -35,6 +35,21 @@ func (m *MockPermissionSetStore) EXPECT() *MockPermissionSetStoreMockRecorder {
 	return m.recorder
 }
 
+// Count mocks base method.
+func (m *MockPermissionSetStore) Count(ctx context.Context) (int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Count", ctx)
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Count indicates an expected call of Count.
+func (mr *MockPermissionSetStoreMockRecorder) Count(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Count", reflect.TypeOf((*MockPermissionSetStore)(nil).Count), ctx)
+}
+
 // Delete mocks base method.
 func (m *MockPermissionSetStore) Delete(ctx context.Context, id string) error {
 	m.ctrl.T.Helper()
@@ -130,6 +145,21 @@ func (m *MockSimpleAccessScopeStore) EXPECT() *MockSimpleAccessScopeStoreMockRec
 	return m.recorder
 }
 
+// Count mocks base method.
+func (m *MockSimpleAccessScopeStore) Count(ctx context.Context) (int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Count", ctx)
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Count indicates an expected call of Count.
+func (mr *MockSimpleAccessScopeStoreMockRecorder) Count(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Count", reflect.TypeOf((*MockSimpleAccessScopeStore)(nil).Count), ctx)
+}
+
 // Delete mocks base method.
 func (m *MockSimpleAccessScopeStore) Delete(ctx context.Context, id string) error {
 	m.ctrl.T.Helper()
@@ -223,6 +253,21 @@ func NewMockRoleStore(ctrl *gomock.Controller) *MockRoleStore {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockRoleStore) EXPECT() *MockRoleStoreMockRecorder {
 	return m.recorder
+}
+
+// Count mocks base method.
+func (m *MockRoleStore) Count(ctx context.Context) (int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Count", ctx)
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Count indicates an expected call of Count.
+func (mr *MockRoleStoreMockRecorder) Count(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Count", reflect.TypeOf((*MockRoleStore)(nil).Count), ctx)
 }
 
 // Delete mocks base method.

--- a/central/role/store/store.go
+++ b/central/role/store/store.go
@@ -10,6 +10,7 @@ import (
 //go:generate mockgen-wrapper
 type PermissionSetStore interface {
 	Get(ctx context.Context, id string) (*storage.PermissionSet, bool, error)
+	Count(ctx context.Context) (int, error)
 	Upsert(ctx context.Context, obj *storage.PermissionSet) error
 	UpsertMany(ctx context.Context, obj []*storage.PermissionSet) error
 	Delete(ctx context.Context, id string) error
@@ -20,6 +21,7 @@ type PermissionSetStore interface {
 //go:generate mockgen-wrapper
 type SimpleAccessScopeStore interface {
 	Get(ctx context.Context, id string) (*storage.SimpleAccessScope, bool, error)
+	Count(ctx context.Context) (int, error)
 	Upsert(ctx context.Context, obj *storage.SimpleAccessScope) error
 	UpsertMany(ctx context.Context, obj []*storage.SimpleAccessScope) error
 	Delete(ctx context.Context, id string) error
@@ -30,6 +32,7 @@ type SimpleAccessScopeStore interface {
 //go:generate mockgen-wrapper
 type RoleStore interface {
 	Get(ctx context.Context, id string) (*storage.Role, bool, error)
+	Count(ctx context.Context) (int, error)
 	Upsert(ctx context.Context, obj *storage.Role) error
 	UpsertMany(ctx context.Context, obj []*storage.Role) error
 	Delete(ctx context.Context, id string) error

--- a/central/signatureintegration/datastore/datastore.go
+++ b/central/signatureintegration/datastore/datastore.go
@@ -12,6 +12,7 @@ import (
 type DataStore interface {
 	GetSignatureIntegration(ctx context.Context, id string) (*storage.SignatureIntegration, bool, error)
 	GetAllSignatureIntegrations(ctx context.Context) ([]*storage.SignatureIntegration, error)
+	CountSignatureIntegrations(ctx context.Context) (int, error)
 	AddSignatureIntegration(ctx context.Context, integration *storage.SignatureIntegration) (*storage.SignatureIntegration, error)
 	UpdateSignatureIntegration(ctx context.Context, integration *storage.SignatureIntegration) (bool, error)
 	RemoveSignatureIntegration(ctx context.Context, id string) error

--- a/central/signatureintegration/datastore/datastore_impl.go
+++ b/central/signatureintegration/datastore/datastore_impl.go
@@ -62,6 +62,14 @@ func (d *datastoreImpl) GetAllSignatureIntegrations(ctx context.Context) ([]*sto
 	return integrations, nil
 }
 
+func (d *datastoreImpl) CountSignatureIntegrations(ctx context.Context) (int, error) {
+	if ok, err := integrationSAC.ReadAllowed(ctx); !ok || err != nil {
+		return 0, err
+	}
+
+	return d.storage.Count(ctx)
+}
+
 func (d *datastoreImpl) AddSignatureIntegration(ctx context.Context, integration *storage.SignatureIntegration) (*storage.SignatureIntegration, error) {
 	if err := sac.VerifyAuthzOK(integrationSAC.WriteAllowed(ctx)); err != nil {
 		return nil, err

--- a/central/signatureintegration/datastore/telemetry.go
+++ b/central/signatureintegration/datastore/telemetry.go
@@ -18,7 +18,7 @@ var Gather phonehome.GatherFunc = func(ctx context.Context) (map[string]any, err
 			sac.ResourceScopeKeys(resources.Integration)))
 	totals := make(map[string]any)
 	si := Singleton()
-	if err := phonehome.AddTotal(ctx, totals, "Signature Integrations", si.GetAllSignatureIntegrations); err != nil {
+	if err := phonehome.AddTotal(ctx, totals, "Signature Integrations", si.CountSignatureIntegrations); err != nil {
 		return nil, errors.Wrap(err, "failed to get signature integrations")
 	}
 	return totals, nil

--- a/central/signatureintegration/datastore/telemetry.go
+++ b/central/signatureintegration/datastore/telemetry.go
@@ -4,15 +4,18 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
+	"github.com/stackrox/rox/central/role/resources"
+	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/telemetry/phonehome"
 )
 
 // Gather number of signature integrations.
 var Gather phonehome.GatherFunc = func(ctx context.Context) (map[string]any, error) {
-	// WithAllAccess is required only to fetch and calculate the number of
-	// signature integrations. It is not propagated anywhere else.
-	ctx = sac.WithAllAccess(ctx)
+	ctx = sac.WithGlobalAccessScopeChecker(ctx,
+		sac.AllowFixedScopes(
+			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
+			sac.ResourceScopeKeys(resources.Integration)))
 	totals := make(map[string]any)
 	si := Singleton()
 	if err := phonehome.AddTotal(ctx, totals, "Signature Integrations", si.GetAllSignatureIntegrations); err != nil {

--- a/central/signatureintegration/store/mocks/store.go
+++ b/central/signatureintegration/store/mocks/store.go
@@ -35,6 +35,21 @@ func (m *MockSignatureIntegrationStore) EXPECT() *MockSignatureIntegrationStoreM
 	return m.recorder
 }
 
+// Count mocks base method.
+func (m *MockSignatureIntegrationStore) Count(ctx context.Context) (int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Count", ctx)
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Count indicates an expected call of Count.
+func (mr *MockSignatureIntegrationStoreMockRecorder) Count(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Count", reflect.TypeOf((*MockSignatureIntegrationStore)(nil).Count), ctx)
+}
+
 // Delete mocks base method.
 func (m *MockSignatureIntegrationStore) Delete(ctx context.Context, id string) error {
 	m.ctrl.T.Helper()

--- a/central/signatureintegration/store/store.go
+++ b/central/signatureintegration/store/store.go
@@ -10,6 +10,7 @@ import (
 //go:generate mockgen-wrapper
 type SignatureIntegrationStore interface {
 	Get(ctx context.Context, id string) (*storage.SignatureIntegration, bool, error)
+	Count(ctx context.Context) (int, error)
 	Upsert(ctx context.Context, obj *storage.SignatureIntegration) error
 	Delete(ctx context.Context, id string) error
 	Walk(ctx context.Context, fn func(obj *storage.SignatureIntegration) error) error

--- a/central/telemetry/centralclient/instance_config.go
+++ b/central/telemetry/centralclient/instance_config.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/central/installation/store"
+	"github.com/stackrox/rox/central/role/resources"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/logging"
@@ -58,7 +59,12 @@ func getInstanceConfig() (*phonehome.Config, map[string]any, error) {
 		orchestrator = storage.ClusterType_OPENSHIFT_CLUSTER.String()
 	}
 
-	ii, _, err := store.Singleton().Get(sac.WithAllAccess(context.Background()))
+	ii, _, err := store.Singleton().Get(
+		sac.WithGlobalAccessScopeChecker(context.Background(),
+			sac.AllowFixedScopes(
+				sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
+				sac.ResourceScopeKeys(resources.InstallationInfo))))
+
 	if err != nil || ii == nil {
 		return nil, nil, errors.Wrap(err, "cannot get installation information")
 	}

--- a/pkg/telemetry/phonehome/client_config.go
+++ b/pkg/telemetry/phonehome/client_config.go
@@ -51,7 +51,8 @@ type Config struct {
 
 	// Map of event name to the list of interceptors, that gather properties for
 	// the event.
-	interceptors map[string][]Interceptor
+	interceptors     map[string][]Interceptor
+	interceptorsLock sync.Mutex
 }
 
 // Enabled tells whether telemetry data collection is enabled.
@@ -101,8 +102,8 @@ func (cfg *Config) Telemeter() Telemeter {
 // AddInterceptorFunc appends the custom list of telemetry interceptors with the
 // provided function.
 func (cfg *Config) AddInterceptorFunc(event string, f Interceptor) {
-	mux.Lock()
-	defer mux.Unlock()
+	cfg.interceptorsLock.Lock()
+	defer cfg.interceptorsLock.Unlock()
 	if cfg.interceptors == nil {
 		cfg.interceptors = make(map[string][]Interceptor, 1)
 	}

--- a/pkg/telemetry/phonehome/gatherer.go
+++ b/pkg/telemetry/phonehome/gatherer.go
@@ -111,7 +111,7 @@ func (g *gatherer) AddGatherer(f GatherFunc) {
 }
 
 // AddTotal sets an entry in the props map with key and number returned by f as
-//the value.
+// the value.
 func AddTotal(ctx context.Context, props map[string]any, key string, f func(context.Context) (int, error)) error {
 	ps, err := f(ctx)
 	if err != nil {

--- a/pkg/telemetry/phonehome/gatherer.go
+++ b/pkg/telemetry/phonehome/gatherer.go
@@ -110,13 +110,13 @@ func (g *gatherer) AddGatherer(f GatherFunc) {
 	g.gatherFuncs = append(g.gatherFuncs, f)
 }
 
-// AddTotal sets an entry in the props map with key and number of elements
-// returned by f as the value.
-func AddTotal[T any](ctx context.Context, props map[string]any, key string, f func(context.Context) ([]*T, error)) error {
+// AddTotal sets an entry in the props map with key and number returned by f as
+//the value.
+func AddTotal(ctx context.Context, props map[string]any, key string, f func(context.Context) (int, error)) error {
 	ps, err := f(ctx)
 	if err != nil {
 		return errors.Wrapf(err, "failed to get %s", key)
 	}
-	props["Total "+key] = len(ps)
+	props["Total "+key] = ps
 	return nil
 }

--- a/pkg/telemetry/phonehome/interceptor.go
+++ b/pkg/telemetry/phonehome/interceptor.go
@@ -10,18 +10,15 @@ import (
 	"github.com/stackrox/rox/pkg/grpc/authn"
 	grpcError "github.com/stackrox/rox/pkg/grpc/errors"
 	"github.com/stackrox/rox/pkg/grpc/requestinfo"
-	"github.com/stackrox/rox/pkg/sync"
 	"google.golang.org/grpc"
 )
 
 const grpcGatewayUserAgentHeader = runtime.MetadataPrefix + "User-Agent"
 
-var (
-	mux = &sync.Mutex{}
-)
-
 func (cfg *Config) track(rp *RequestParams) {
 	id := cfg.HashUserAuthID(rp.UserID)
+	cfg.interceptorsLock.Lock()
+	defer cfg.interceptorsLock.Unlock()
 	for event, funcs := range cfg.interceptors {
 		props := map[string]any{}
 		ok := true

--- a/pkg/telemetry/phonehome/segment/segment.go
+++ b/pkg/telemetry/phonehome/segment/segment.go
@@ -6,7 +6,6 @@ import (
 	segment "github.com/segmentio/analytics-go"
 	"github.com/stackrox/rox/pkg/httputil/proxy"
 	"github.com/stackrox/rox/pkg/logging"
-	"go.uber.org/zap/zapcore"
 )
 
 var (
@@ -48,7 +47,7 @@ type logWrapper struct {
 }
 
 func (l *logWrapper) Logf(format string, args ...any) {
-	l.internal.Logf(zapcore.InfoLevel, format, args...)
+	l.internal.Infof(format, args...)
 }
 
 func (l *logWrapper) Errorf(format string, args ...any) {


### PR DESCRIPTION
## Description

Use `Count()` method to get the number of elements from stores instead of fetching all objects.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

Tested looking at the Segment debug messages, which came same as before.