### PR TITLE
ROX-14056: Disable failing gke_version_compatibility_tests

### DIFF
--- a/scripts/ci/jobs/gke_version_compatibility_tests.py
+++ b/scripts/ci/jobs/gke_version_compatibility_tests.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env -S python3 -u
 
+# ROX-14056 - Disabled
+import sys
+sys.exit(0)
+
 """
 Run version compatibility tests
 """


### PR DESCRIPTION
## Description

This was broken by the API change in https://github.com/stackrox/stackrox/pull/4195 (I assume). Disabling until fixed.

ref: https://srox.slack.com/archives/C0321S70YK1/p1671658169495739

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient.