### PR TITLE
Fix gradlew test not found issue

### DIFF
--- a/qa-tests-backend/build.gradle
+++ b/qa-tests-backend/build.gradle
@@ -229,3 +229,7 @@ task runSampleScript(dependsOn: 'classes', type: JavaExec) {
         classpath = sourceSets.main.runtimeClasspath
     }
 }
+
+test {
+    useJUnitPlatform()
+}


### PR DESCRIPTION
## Description

Executing tests manually using `./gradlew test --tests=TestName` throws test not found error. 
This PR intends to fix the issue.

Error log:
```
$ ./gradlew test $GRADLE_TEST_ARGS --tests=AutocompleteTest
> Task :extractIncludeProto UP-TO-DATE
> Task :extractProto UP-TO-DATE
> Task :generateProto UP-TO-DATE
> Task :compileJava UP-TO-DATE
> Task :compileGroovy UP-TO-DATE
> Task :processResources UP-TO-DATE
> Task :classes UP-TO-DATE
> Task :extractIncludeTestProto UP-TO-DATE
> Task :extractTestProto UP-TO-DATE
> Task :generateTestProto NO-SOURCE
> Task :compileTestJava NO-SOURCE
> Task :compileTestGroovy UP-TO-DATE
> Task :processTestResources UP-TO-DATE
> Task :testClasses UP-TO-DATE
> Task :test FAILED
11 actionable tasks: 1 executed, 10 up-to-date

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':test'.
> No tests found for given includes: [AutocompleteTest](--tests filter)

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.

* Get more help at https://help.gradle.org/

BUILD FAILED in 878ms
```

