### PR TITLE
Revert "ROX-10895: Detect role bindings to cluster roles within namespace RBAC evaluator"

### DIFF
--- a/central/rbac/utils/cluster_permission_evaluator.go
+++ b/central/rbac/utils/cluster_permission_evaluator.go
@@ -53,10 +53,6 @@ func (c *clusterPermissionEvaluator) RolesForSubject(ctx context.Context, subjec
 func (c *clusterPermissionEvaluator) getBindingsAndRoles(ctx context.Context, subject *storage.Subject) ([]*storage.K8SRoleBinding, []*storage.K8SRole) {
 	q := search.NewQueryBuilder().
 		AddExactMatches(search.ClusterID, c.clusterID).
-		// Only evaluate bindings which have bind a cluster role _and_ have no namespace. Otherwise, we are evaluating
-		// role bindings which bind a cluster role to a specific namespace and would mistakenly
-		// see them as "cluster scoped".
-		AddNullField(search.Namespace).
 		AddBools(search.ClusterRole, true).
 		AddExactMatches(search.SubjectName, subject.GetName()).
 		AddExactMatches(search.SubjectKind, subject.GetKind().String()).
@@ -67,6 +63,7 @@ func (c *clusterPermissionEvaluator) getBindingsAndRoles(ctx context.Context, su
 		log.Errorf("error searching for clusterrolebindings: %v", err)
 		return nil, nil
 	}
-	roles := getRolesForRoleBindings(ctx, c.roleStore, clusterRoleBindings, c.clusterID, "")
+
+	roles := getRolesForBindings(ctx, c.roleStore, clusterRoleBindings)
 	return clusterRoleBindings, roles
 }

--- a/central/rbac/utils/cluster_permission_evaluator_test.go
+++ b/central/rbac/utils/cluster_permission_evaluator_test.go
@@ -97,7 +97,6 @@ func TestIsClusterAdmin(t *testing.T) {
 
 	clusterScopeQuery := search.NewQueryBuilder().
 		AddExactMatches(search.ClusterID, "cluster").
-		AddNullField(search.Namespace).
 		AddExactMatches(search.SubjectName, "foo").
 		AddExactMatches(search.SubjectKind, storage.SubjectKind_SERVICE_ACCOUNT.String()).
 		AddBools(search.ClusterRole, true).ProtoQuery()
@@ -194,7 +193,6 @@ func TestClusterPermissionsForSubject(t *testing.T) {
 
 	clusterScopeQuery := search.NewQueryBuilder().
 		AddExactMatches(search.ClusterID, "cluster").
-		AddNullField(search.Namespace).
 		AddExactMatches(search.SubjectName, "foo").
 		AddExactMatches(search.SubjectKind, storage.SubjectKind_SERVICE_ACCOUNT.String()).
 		AddBools(search.ClusterRole, true).ProtoQuery()

--- a/central/rbac/utils/common.go
+++ b/central/rbac/utils/common.go
@@ -4,70 +4,19 @@ import (
 	"context"
 
 	"github.com/stackrox/rox/central/rbac/k8srole/datastore"
-	"github.com/stackrox/rox/central/role/resources"
 	"github.com/stackrox/rox/generated/storage"
-	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/set"
 )
 
-// getRolesForRoleBindings will retrieve all roles referenced in the given role bindings.
-// If a namespace is given, the context used to retrieve cluster roles will be elevated, in assumption
-// that the role bindings were scoped to a specific namespace and referencing a cluster role.
-// If the namespace is set to empty, the given context will be used to retrieve the cluster roles.
-func getRolesForRoleBindings(ctx context.Context, roleStore datastore.DataStore,
-	bindings []*storage.K8SRoleBinding, clusterID string, namespace string) []*storage.K8SRole {
-	roleIDs, clusterRoleIDs := getRoleIDsFromBindings(bindings)
-	roles := make([]*storage.K8SRole, 0, roleIDs.Cardinality()+clusterRoleIDs.Cardinality())
-
-	// Fetch the roles without elevating the context.
-	// Only attempt to fetch namespace scoped role bindings if a namespace is given.
-	if namespace != "" {
-		roles = append(roles, fetchRoles(ctx, roleStore, roleIDs)...)
-	}
-
-	clusterRoleCtx := ctx
-	if namespace != "" {
-		// For namespaced cluster role bindings, we need to potentially elevate the contexts access scope.
-		// It could be that an access scope is constrained to a single namespace. If any role binding exists within that
-		// namespace, we currently would be unable to list the permissions whatever is bound to that role binding has
-		// (e.g. service account, user, group etc.).
-		// Since we received feedback that this is an appreciated information, we will elevate the context here and give
-		// READ access to the whole cluster under the following conditions:
-		// - the current access scope doesn't allow READ access to K8S roles for the whole cluster.
-		// - the READ access to the whole cluster will only be applicable for cluster roles.
-		// - the context will not be propagated afterwards to the client.
-		clusterK8SRoleScopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_ACCESS).
-			Resource(resources.K8sRole).ClusterID(clusterID)
-		if !clusterK8SRoleScopeChecker.IsAllowed() {
-			clusterRoleCtx = sac.WithGlobalAccessScopeChecker(ctx, sac.AllowFixedScopes(
-				sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
-				sac.ResourceScopeKeys(resources.K8sRole), sac.ClusterScopeKeys(clusterID)))
-		}
-	}
-
-	// Fetch cluster roles with potentially elevated context.
-	roles = append(roles, fetchRoles(clusterRoleCtx, roleStore, clusterRoleIDs)...)
-
-	return roles
-}
-
-func getRoleIDsFromBindings(bindings []*storage.K8SRoleBinding) (set.StringSet, set.StringSet) {
+func getRolesForBindings(ctx context.Context, roleStore datastore.DataStore, bindings []*storage.K8SRoleBinding) []*storage.K8SRole {
 	roleIDs := set.NewStringSet()
-	clusterRoleIDs := set.NewStringSet()
 	for _, binding := range bindings {
 		roleID := binding.GetRoleId()
 		if roleID != "" {
-			if binding.GetClusterRole() {
-				clusterRoleIDs.Add(roleID)
-			} else {
-				roleIDs.Add(roleID)
-			}
+			roleIDs.Add(roleID)
 		}
 	}
-	return roleIDs, clusterRoleIDs
-}
 
-func fetchRoles(ctx context.Context, roleStore datastore.DataStore, roleIDs set.StringSet) []*storage.K8SRole {
 	roles := make([]*storage.K8SRole, 0, roleIDs.Cardinality())
 	for roleID := range roleIDs {
 		role, exists, err := roleStore.GetRole(ctx, roleID)

--- a/central/rbac/utils/namespace_permission_evaluator.go
+++ b/central/rbac/utils/namespace_permission_evaluator.go
@@ -49,16 +49,17 @@ func (c *namespacePermissionEvaluator) getBindingsAndRoles(ctx context.Context, 
 	q := search.NewQueryBuilder().
 		AddExactMatches(search.ClusterID, c.clusterID).
 		AddExactMatches(search.Namespace, c.namespace).
+		AddBools(search.ClusterRole, false).
 		AddExactMatches(search.SubjectName, subject.GetName()).
 		AddExactMatches(search.SubjectKind, subject.GetKind().String()).
 		ProtoQuery()
-	roleBindings, err := c.bindingsStore.SearchRawRoleBindings(ctx, q)
+	rolebindings, err := c.bindingsStore.SearchRawRoleBindings(ctx, q)
 
 	if err != nil {
-		log.Errorf("error searching for roleBindings: %v", err)
+		log.Errorf("error searching for rolebindings: %v", err)
 		return nil, nil
 	}
 
-	roles := getRolesForRoleBindings(ctx, c.roleStore, roleBindings, c.clusterID, c.namespace)
-	return roleBindings, roles
+	roles := getRolesForBindings(ctx, c.roleStore, rolebindings)
+	return rolebindings, roles
 }

--- a/central/rbac/utils/namespace_permission_evaluator_test.go
+++ b/central/rbac/utils/namespace_permission_evaluator_test.go
@@ -8,7 +8,6 @@ import (
 	roleMocks "github.com/stackrox/rox/central/rbac/k8srole/datastore/mocks"
 	bindingMocks "github.com/stackrox/rox/central/rbac/k8srolebinding/datastore/mocks"
 	"github.com/stackrox/rox/generated/storage"
-	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stretchr/testify/assert"
 )
@@ -115,11 +114,12 @@ func TestNamespacePermissionsForSubject(t *testing.T) {
 		AddExactMatches(search.ClusterID, "cluster").
 		AddExactMatches(search.Namespace, "namespace").
 		AddExactMatches(search.SubjectName, "subject").
-		AddExactMatches(search.SubjectKind, storage.SubjectKind_SERVICE_ACCOUNT.String()).ProtoQuery()
+		AddExactMatches(search.SubjectKind, storage.SubjectKind_SERVICE_ACCOUNT.String()).
+		AddBools(search.ClusterRole, false).ProtoQuery()
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			ctx := sac.WithAllAccess(context.Background())
+			ctx := context.Background()
 
 			mockBindingDatastore.EXPECT().SearchRawRoleBindings(ctx, namespaceScopeQuery).Return(c.inputBindings, nil).AnyTimes()
 			mockRoleDatastore.EXPECT().GetRole(ctx, "role1").Return(c.inputRoles[0], true, nil).AnyTimes()

--- a/central/risk/multipliers/deployment/service_account_permissions_test.go
+++ b/central/risk/multipliers/deployment/service_account_permissions_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stackrox/rox/central/risk/multipliers"
 	saMocks "github.com/stackrox/rox/central/serviceaccount/datastore/mocks"
 	"github.com/stackrox/rox/generated/storage"
-	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stretchr/testify/assert"
 )
@@ -215,7 +214,7 @@ func TestPermissionScore(t *testing.T) {
 
 	for _, c := range clusterCases {
 		t.Run(c.name, func(t *testing.T) {
-			ctx := sac.WithAllAccess(context.Background())
+			ctx := context.Background()
 
 			mockCtrl := gomock.NewController(t)
 
@@ -231,7 +230,6 @@ func TestPermissionScore(t *testing.T) {
 			clusterScopeQuery := search.NewQueryBuilder().
 				AddExactMatches(search.ClusterID, deployment.GetClusterId()).
 				AddExactMatches(search.SubjectName, c.sa.Name).
-				AddNullField(search.Namespace).
 				AddExactMatches(search.SubjectKind, storage.SubjectKind_SERVICE_ACCOUNT.String()).
 				AddBools(search.ClusterRole, true).ProtoQuery()
 
@@ -241,7 +239,8 @@ func TestPermissionScore(t *testing.T) {
 				AddExactMatches(search.ClusterID, deployment.GetClusterId()).
 				AddExactMatches(search.Namespace, deployment.GetNamespace()).
 				AddExactMatches(search.SubjectName, c.sa.Name).
-				AddExactMatches(search.SubjectKind, storage.SubjectKind_SERVICE_ACCOUNT.String()).ProtoQuery()
+				AddExactMatches(search.SubjectKind, storage.SubjectKind_SERVICE_ACCOUNT.String()).
+				AddBools(search.ClusterRole, false).ProtoQuery()
 
 			mockBindingDatastore.EXPECT().SearchRawRoleBindings(ctx, namespaceScopeQuery).Return([]*storage.K8SRoleBinding{}, nil).AnyTimes()
 

--- a/pkg/search/query_builder.go
+++ b/pkg/search/query_builder.go
@@ -244,7 +244,7 @@ func (qb *QueryBuilder) AddStringsHighlighted(k FieldLabel, v ...string) *QueryB
 	return qb.AddStrings(k, v...).MarkHighlighted(k)
 }
 
-// AddNullField adds a query for documents that don't contain the specified field.
+// AddNullField adds a very for documents that don't contain the specified field.
 func (qb *QueryBuilder) AddNullField(k FieldLabel) *QueryBuilder {
 	return qb.AddStrings(k, NullString)
 }


### PR DESCRIPTION
Reverts stackrox/stackrox#4031

There are UI test failures which need to be fixed.