### PR TITLE
Telemetry: get request body from request parameters

### DIFF
--- a/central/telemetry/centralclient/interceptors.go
+++ b/central/telemetry/centralclient/interceptors.go
@@ -27,7 +27,7 @@ var (
 	}
 )
 
-// apiHandler represents a typical API handler type,
+// apiHandler represents a typical API handler type.
 // Example:
 //   (v1.ClustersServiceServer).PostCluster(context.Context, *storage.Cluster) (*storage.Cluster, error)
 type apiHandler[Service any, Request any, Response any] func(Service, context.Context, *Request) (*Response, error)
@@ -68,7 +68,7 @@ func clusterRegistered(rp *phonehome.RequestParams, props map[string]any) bool {
 
 	props["Code"] = rp.Code
 	cluster := getRequestPtr(v1.ClustersServiceServer.PostCluster)
-	if err := phonehome.GetRequestBody(rp, &cluster); err == nil {
+	if phonehome.GetGRPCRequestBody(rp, &cluster) == nil {
 		props["Cluster Type"] = cluster.GetType().String()
 		props["Cluster ID"] = cluster.GetId()
 		props["Managed By"] = cluster.GetManagedBy().String()
@@ -95,7 +95,7 @@ func clusterInitialized(rp *phonehome.RequestParams, props map[string]any) bool 
 	}
 
 	cluster := getRequestPtr(v1.ClustersServiceServer.PutCluster)
-	if err := phonehome.GetRequestBody(rp, &cluster); err == nil {
+	if phonehome.GetGRPCRequestBody(rp, &cluster) == nil {
 		uninitializedClustersLock.Lock()
 		defer uninitializedClustersLock.Unlock()
 

--- a/central/telemetry/centralclient/interceptors.go
+++ b/central/telemetry/centralclient/interceptors.go
@@ -1,7 +1,6 @@
 package centralclient
 
 import (
-	"context"
 	"net/http"
 	"strings"
 
@@ -26,18 +25,6 @@ var (
 		"roxctl":              {roxctl},
 	}
 )
-
-// apiHandler represents a typical API handler type.
-// Example:
-//   (v1.ClustersServiceServer).PostCluster(context.Context, *storage.Cluster) (*storage.Cluster, error)
-type apiHandler[Service any, Request any, Response any] func(Service, context.Context, *Request) (*Response, error)
-
-// getRequestPtr returns a nil pointer of the API handler response type.
-// Example:
-//   getRequestPtr(v1.ClustersServiceServer.PostCluster) *storage.Cluster
-func getRequestPtr[Service any, Request any, Response any](apiHandler[Service, Request, Response]) *Request {
-	return nil
-}
 
 // apiCall enables API Call events for the API paths specified in the
 // trackedPaths ("*" value enables all paths) and have no match in the
@@ -67,8 +54,7 @@ func clusterRegistered(rp *phonehome.RequestParams, props map[string]any) bool {
 	}
 
 	props["Code"] = rp.Code
-	cluster := getRequestPtr(v1.ClustersServiceServer.PostCluster)
-	if phonehome.GetGRPCRequestBody(rp, &cluster) == nil {
+	if cluster, err := phonehome.GetGRPCRequestBody(v1.ClustersServiceServer.PostCluster, rp); err == nil {
 		props["Cluster Type"] = cluster.GetType().String()
 		props["Cluster ID"] = cluster.GetId()
 		props["Managed By"] = cluster.GetManagedBy().String()
@@ -94,8 +80,7 @@ func clusterInitialized(rp *phonehome.RequestParams, props map[string]any) bool 
 		return false
 	}
 
-	cluster := getRequestPtr(v1.ClustersServiceServer.PutCluster)
-	if phonehome.GetGRPCRequestBody(rp, &cluster) == nil {
+	if cluster, err := phonehome.GetGRPCRequestBody(v1.ClustersServiceServer.PutCluster, rp); err == nil {
 		uninitializedClustersLock.Lock()
 		defer uninitializedClustersLock.Unlock()
 

--- a/central/telemetry/centralclient/interceptors.go
+++ b/central/telemetry/centralclient/interceptors.go
@@ -54,7 +54,7 @@ func clusterRegistered(rp *phonehome.RequestParams, props map[string]any) bool {
 	}
 
 	props["Code"] = rp.Code
-	if cluster, err := phonehome.GetGRPCRequestBody(v1.ClustersServiceServer.PostCluster, rp); err == nil {
+	if cluster := phonehome.GetGRPCRequestBody(v1.ClustersServiceServer.PostCluster, rp); cluster != nil {
 		props["Cluster Type"] = cluster.GetType().String()
 		props["Cluster ID"] = cluster.GetId()
 		props["Managed By"] = cluster.GetManagedBy().String()
@@ -80,7 +80,7 @@ func clusterInitialized(rp *phonehome.RequestParams, props map[string]any) bool 
 		return false
 	}
 
-	if cluster, err := phonehome.GetGRPCRequestBody(v1.ClustersServiceServer.PutCluster, rp); err == nil {
+	if cluster := phonehome.GetGRPCRequestBody(v1.ClustersServiceServer.PutCluster, rp); cluster != nil {
 		uninitializedClustersLock.Lock()
 		defer uninitializedClustersLock.Unlock()
 

--- a/pkg/telemetry/phonehome/client_config.go
+++ b/pkg/telemetry/phonehome/client_config.go
@@ -114,7 +114,7 @@ func (cfg *Config) AddInterceptorFunc(event string, f Interceptor) {
 func (cfg *Config) GetGRPCInterceptor() grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
 		resp, err := handler(ctx, req)
-		rp := getGRPCRequestDetails(ctx, err, info, req)
+		rp := getGRPCRequestDetails(ctx, err, info.FullMethod, req)
 		go cfg.track(rp)
 		return resp, err
 	}

--- a/pkg/telemetry/phonehome/interceptor.go
+++ b/pkg/telemetry/phonehome/interceptor.go
@@ -73,7 +73,7 @@ func getGRPCRequestDetails(ctx context.Context, err error, grpcFullMethod string
 	}
 }
 
-func getHTTPRequestDetails(ctx context.Context, r *http.Request, err error) *RequestParams {
+func getHTTPRequestDetails(ctx context.Context, r *http.Request, status int) *RequestParams {
 	id, iderr := authn.IdentityFromContext(ctx)
 	if iderr != nil {
 		log.Debug("Cannot identify user from context: ", iderr)
@@ -84,7 +84,7 @@ func getHTTPRequestDetails(ctx context.Context, r *http.Request, err error) *Req
 		UserID:    id,
 		Method:    r.Method,
 		Path:      r.URL.Path,
-		Code:      grpcError.ErrToHTTPStatus(err),
+		Code:      status,
 		HTTPReq:   r,
 	}
 }

--- a/pkg/telemetry/phonehome/interceptor.go
+++ b/pkg/telemetry/phonehome/interceptor.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stackrox/rox/pkg/grpc/authn"
 	grpcError "github.com/stackrox/rox/pkg/grpc/errors"
 	"github.com/stackrox/rox/pkg/grpc/requestinfo"
-	"google.golang.org/grpc"
 )
 
 const grpcGatewayUserAgentHeader = runtime.MetadataPrefix + "User-Agent"
@@ -45,7 +44,7 @@ func getUserAgent[getter func(string) []string](headers getter) string {
 	return strings.Join(userAgentValues, " ")
 }
 
-func getGRPCRequestDetails(ctx context.Context, err error, info *grpc.UnaryServerInfo, req any) *RequestParams {
+func getGRPCRequestDetails(ctx context.Context, err error, grpcFullMethod string, req any) *RequestParams {
 	id, iderr := authn.IdentityFromContext(ctx)
 	if iderr != nil {
 		log.Debug("Cannot identify user from context: ", iderr)
@@ -67,8 +66,8 @@ func getGRPCRequestDetails(ctx context.Context, err error, info *grpc.UnaryServe
 	return &RequestParams{
 		UserAgent: getUserAgent(ri.Metadata.Get),
 		UserID:    id,
-		Method:    info.FullMethod,
-		Path:      info.FullMethod,
+		Method:    grpcFullMethod,
+		Path:      grpcFullMethod,
 		Code:      int(erroxGRPC.RoxErrorToGRPCCode(err)),
 		GRPCReq:   req,
 	}

--- a/pkg/telemetry/phonehome/interceptor_test.go
+++ b/pkg/telemetry/phonehome/interceptor_test.go
@@ -166,14 +166,14 @@ func (s *interceptorTestSuite) TestHttpWithBody() {
 	req, _ = http.NewRequest(http.MethodPost, "/http/body", nil)
 	rp = getHTTPRequestDetails(context.Background(), req, nil)
 	rb, err = GetRequestBody[testBody](rp)
-	s.ErrorIs(err, errNoBody)
+	s.ErrorIs(err, ErrNoBody)
 	s.Nil(rb)
 
 	body = "null"
 	req, _ = http.NewRequest(http.MethodPost, "/http/body", bytes.NewReader([]byte(body)))
 	rp = getHTTPRequestDetails(context.Background(), req, nil)
 	rb, err = GetRequestBody[testBody](rp)
-	s.NoError(err)
+	s.ErrorIs(err, ErrNoBody)
 	s.Nil(rb)
 }
 
@@ -189,7 +189,7 @@ func (s *interceptorTestSuite) TestGrpcWithBody() {
 	rp = getGRPCRequestDetails(context.Background(), nil, "/grpc/body", nil)
 
 	rb, err = GetRequestBody[testBody](rp)
-	s.NoError(err)
+	s.ErrorIs(err, ErrNoBody)
 	s.Nil(rb)
 }
 

--- a/pkg/telemetry/phonehome/interceptor_test.go
+++ b/pkg/telemetry/phonehome/interceptor_test.go
@@ -153,34 +153,37 @@ func (s *interceptorTestSuite) TestHttpWithBody() {
 	req, _ := http.NewRequest(http.MethodPost, "/http/body", bytes.NewReader([]byte(body)))
 	rp := getHTTPRequestDetails(context.Background(), req, nil)
 
-	rb, err := GetRequestBody[testBody](rp)
+	var rb *testBody
+	err := GetRequestBody(rp, &rb)
 	if s.NoError(err) {
 		s.NotNil(rb)
 		s.Equal(42, rb.N)
 	}
 
-	e, err := GetRequestBody[error](rp)
+	var e *error
+	err = GetRequestBody(rp, &e)
 	s.ErrorIs(err, errBadType)
 	s.Nil(e)
 
 	req, _ = http.NewRequest(http.MethodPost, "/http/body", nil)
 	rp = getHTTPRequestDetails(context.Background(), req, nil)
-	rb, err = GetRequestBody[testBody](rp)
+	err = GetRequestBody(rp, &rb)
 	s.ErrorIs(err, ErrNoBody)
 	s.Nil(rb)
 
 	body = "null"
 	req, _ = http.NewRequest(http.MethodPost, "/http/body", bytes.NewReader([]byte(body)))
 	rp = getHTTPRequestDetails(context.Background(), req, nil)
-	rb, err = GetRequestBody[testBody](rp)
+	err = GetRequestBody(rp, &rb)
 	s.ErrorIs(err, ErrNoBody)
 	s.Nil(rb)
 }
 
 func (s *interceptorTestSuite) TestGrpcWithBody() {
 	rp := getGRPCRequestDetails(context.Background(), nil, "/grpc/body", &testBody{N: 42})
+	var rb *testBody
 
-	rb, err := GetRequestBody[testBody](rp)
+	err := GetRequestBody(rp, &rb)
 	if s.NoError(err) {
 		s.NotNil(rb)
 		s.Equal(42, rb.N)
@@ -188,7 +191,7 @@ func (s *interceptorTestSuite) TestGrpcWithBody() {
 
 	rp = getGRPCRequestDetails(context.Background(), nil, "/grpc/body", nil)
 
-	rb, err = GetRequestBody[testBody](rp)
+	err = GetRequestBody(rp, &rb)
 	s.ErrorIs(err, ErrNoBody)
 	s.Nil(rb)
 }

--- a/pkg/telemetry/phonehome/request_params.go
+++ b/pkg/telemetry/phonehome/request_params.go
@@ -5,11 +5,8 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/stackrox/rox/pkg/grpc/authn"
 )
-
-var errBadType = errors.New("unexpected body type")
 
 // RequestParams holds intercepted call parameters.
 type RequestParams struct {

--- a/pkg/telemetry/phonehome/request_params.go
+++ b/pkg/telemetry/phonehome/request_params.go
@@ -2,7 +2,6 @@ package phonehome
 
 import (
 	"context"
-	"io"
 	"net/http"
 	"strings"
 
@@ -52,15 +51,15 @@ func (rp *RequestParams) Is(s *ServiceMethod) bool {
 }
 
 // GetGRPCRequestBody returns the request body with the type inferred from the
-// API handler provided as the first argument. Returns io.EOF on nil body.
+// API handler provided as the first argument.
 func GetGRPCRequestBody[
 	F func(Service, context.Context, *Request) (*Response, error),
 	Service any,
 	Request any,
 	Response any,
-](_ F, rp *RequestParams) (*Request, error) {
-	if body, ok := rp.GRPCReq.(*Request); ok && body != nil {
-		return body, nil
+](_ F, rp *RequestParams) *Request {
+	if body, ok := rp.GRPCReq.(*Request); ok {
+		return body
 	}
-	return nil, io.EOF
+	return nil
 }

--- a/pkg/telemetry/phonehome/request_params.go
+++ b/pkg/telemetry/phonehome/request_params.go
@@ -2,7 +2,7 @@ package phonehome
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -78,7 +78,7 @@ func getHTTPBody[T any](req *http.Request) (*T, error) {
 	}
 
 	var bb []byte
-	if bb, err = ioutil.ReadAll(br); err != nil {
+	if bb, err = io.ReadAll(br); err != nil {
 		return nil, err
 	}
 	var body *T

--- a/pkg/telemetry/phonehome/request_params.go
+++ b/pkg/telemetry/phonehome/request_params.go
@@ -87,21 +87,24 @@ func getHTTPBody[T any](req *http.Request) (*T, error) {
 	return body, nil
 }
 
-// GetRequestBody returns the request body. Returns ErrNoBody error on nil body.
-func GetRequestBody[T any](rp *RequestParams) (*T, error) {
-	body, err := getGRPCBody[T](rp.GRPCReq)
+// GetRequestBody sets the output body argument. Returns ErrNoBody error on nil
+// result.
+func GetRequestBody[T any](rp *RequestParams, body **T) error {
+	var err error
+
+	*body, err = getGRPCBody[T](rp.GRPCReq)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	if body == nil {
-		body, err = getHTTPBody[T](rp.HTTPReq)
+	if *body == nil {
+		*body, err = getHTTPBody[T](rp.HTTPReq)
 	}
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	if body == nil {
-		return nil, ErrNoBody
+	if *body == nil {
+		return ErrNoBody
 	}
-	return body, nil
+	return nil
 }

--- a/pkg/telemetry/phonehome/request_params.go
+++ b/pkg/telemetry/phonehome/request_params.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/pkg/grpc/authn"
 )
 
+// ErrNoBody tells that the request has got no body.
 var ErrNoBody = errors.New("empty body")
 var errBadType = errors.New("unexpected body type")
 


### PR DESCRIPTION
## Description

When intercepting an API call, a telemetry interceptor function needs a way to access the request body.
For gRPC requests, it means casting the `any` object to the according type. For pure HTTP (not translated to gRPC), the body is not captured, as it would require creating a buffer to store a potentially positive body. This is probably ok, as HTTP requests are those like `/static`, `/docs` and such, which we won't track today.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

Unit tests, real events in the following PRs.