### PR TITLE
ROX-14155: Implement Access Control telemetry events

### DIFF
--- a/central/telemetry/centralclient/interceptors.go
+++ b/central/telemetry/centralclient/interceptors.go
@@ -136,12 +136,12 @@ var putAuthProvider = &phonehome.ServiceMethod{
 func createAuthProvider(rp *phonehome.RequestParams, props map[string]any) bool {
 	switch {
 	case rp.Is(postAuthProvider):
-		if ap, err := phonehome.GetGRPCRequestBody(v1.AuthProviderServiceServer.PostAuthProvider, rp); err == nil {
+		if ap := phonehome.GetGRPCRequestBody(v1.AuthProviderServiceServer.PostAuthProvider, rp); ap != nil {
 			props["Type"] = ap.GetProvider().GetType()
 		}
 		return true
 	case rp.Is(putAuthProvider):
-		if ap, err := phonehome.GetGRPCRequestBody(v1.AuthProviderServiceServer.PutAuthProvider, rp); err == nil {
+		if ap := phonehome.GetGRPCRequestBody(v1.AuthProviderServiceServer.PutAuthProvider, rp); ap != nil {
 			props["Type"] = ap.GetType()
 		}
 		return true

--- a/central/telemetry/centralclient/interceptors.go
+++ b/central/telemetry/centralclient/interceptors.go
@@ -24,7 +24,10 @@ var (
 		"Cluster Initialized": {clusterInitialized},
 		"roxctl":              {roxctl},
 
-		"Create Auth Provider": {createAuthProvider},
+		"Create Auth Provider":  {createAuthProvider},
+		"Create Access Scope":   {createSimpleAccessScope},
+		"Create Permission Set": {createPermissionSet},
+		"Create Role":           {createRole},
 	}
 )
 
@@ -118,18 +121,22 @@ func roxctl(rp *phonehome.RequestParams, props map[string]any) bool {
 	return true
 }
 
+//
 // Access control.
+//
+
+// Auth Provider:
 
 var postAuthProvider = &phonehome.ServiceMethod{
 	GRPCMethod: "/v1.AuthProviderService/PostAuthProvider",
 	HTTPMethod: http.MethodPost,
-	HTTPPath:   "/v1/authprovider",
+	HTTPPath:   "/v1/authProviders",
 }
 
 var putAuthProvider = &phonehome.ServiceMethod{
 	GRPCMethod: "/v1.AuthProviderService/PutAuthProvider",
 	HTTPMethod: http.MethodPut,
-	HTTPPath:   "/v1/authprovider",
+	HTTPPath:   "/v1/authProviders/*",
 }
 
 func createAuthProvider(rp *phonehome.RequestParams, props map[string]any) bool {
@@ -148,4 +155,58 @@ func createAuthProvider(rp *phonehome.RequestParams, props map[string]any) bool 
 		return true
 	}
 	return false
+}
+
+// Simple Access Scope:
+
+var postSimpleAccessScope = &phonehome.ServiceMethod{
+	GRPCMethod: "/v1.RoleService/PostSimpleAccessScope",
+	HTTPMethod: http.MethodPost,
+	HTTPPath:   "/v1/simpleaccessscopes",
+}
+
+var putSimpleAccessScope = &phonehome.ServiceMethod{
+	GRPCMethod: "/v1.RoleService/PutSimpleAccessScope",
+	HTTPMethod: http.MethodPut,
+	HTTPPath:   "/v1/simpleaccessscopes/*",
+}
+
+func createSimpleAccessScope(rp *phonehome.RequestParams, props map[string]any) bool {
+	return rp.Is(postSimpleAccessScope) || rp.Is(putSimpleAccessScope)
+}
+
+// Permission Set:
+
+var postPermissionSet = &phonehome.ServiceMethod{
+	GRPCMethod: "/v1.RoleService/PostPermissionSet",
+	HTTPMethod: http.MethodPost,
+	HTTPPath:   "/v1/permissionsets",
+}
+
+var putPermissionSet = &phonehome.ServiceMethod{
+	GRPCMethod: "/v1.RoleService/PutPermissionSet",
+	HTTPMethod: http.MethodPut,
+	HTTPPath:   "/v1/permissionsets/*",
+}
+
+func createPermissionSet(rp *phonehome.RequestParams, props map[string]any) bool {
+	return rp.Is(postPermissionSet) || rp.Is(putPermissionSet)
+}
+
+// Role:
+
+var postRole = &phonehome.ServiceMethod{
+	GRPCMethod: "/v1.RoleService/CreateRole",
+	HTTPMethod: http.MethodPost,
+	HTTPPath:   "/v1/roles",
+}
+
+var putRole = &phonehome.ServiceMethod{
+	GRPCMethod: "/v1.RoleService/UpdateRole",
+	HTTPMethod: http.MethodPut,
+	HTTPPath:   "/v1/roles/*",
+}
+
+func createRole(rp *phonehome.RequestParams, props map[string]any) bool {
+	return rp.Is(postRole) || rp.Is(putRole)
 }

--- a/central/telemetry/centralclient/interceptors.go
+++ b/central/telemetry/centralclient/interceptors.go
@@ -23,6 +23,8 @@ var (
 		"Cluster Registered":  {clusterRegistered},
 		"Cluster Initialized": {clusterInitialized},
 		"roxctl":              {roxctl},
+
+		"Create Auth Provider": {createAuthProvider},
 	}
 )
 
@@ -114,4 +116,36 @@ func roxctl(rp *phonehome.RequestParams, props map[string]any) bool {
 	props["User-Agent"] = rp.UserAgent
 	props["Method"] = rp.Method
 	return true
+}
+
+// Access control.
+
+var postAuthProvider = &phonehome.ServiceMethod{
+	GRPCMethod: "/v1.AuthProviderService/PostAuthProvider",
+	HTTPMethod: http.MethodPost,
+	HTTPPath:   "/v1/authprovider",
+}
+
+var putAuthProvider = &phonehome.ServiceMethod{
+	GRPCMethod: "/v1.AuthProviderService/PutAuthProvider",
+	HTTPMethod: http.MethodPut,
+	HTTPPath:   "/v1/authprovider",
+}
+
+func createAuthProvider(rp *phonehome.RequestParams, props map[string]any) bool {
+	switch {
+	case rp.Is(postAuthProvider):
+		ap := getRequestPtr(v1.AuthProviderServiceServer.PostAuthProvider)
+		if err := phonehome.GetRequestBody(rp, &ap); err == nil {
+			props["Type"] = ap.GetProvider().GetType()
+		}
+		return true
+	case rp.Is(putAuthProvider):
+		ap := getRequestPtr(v1.AuthProviderServiceServer.PutAuthProvider)
+		if err := phonehome.GetRequestBody(rp, &ap); err == nil {
+			props["Type"] = ap.GetType()
+		}
+		return true
+	}
+	return false
 }

--- a/central/telemetry/centralclient/interceptors.go
+++ b/central/telemetry/centralclient/interceptors.go
@@ -190,7 +190,7 @@ func createPermissionSet(rp *phonehome.RequestParams, props map[string]any) bool
 var postRole = &phonehome.ServiceMethod{
 	GRPCMethod: "/v1.RoleService/CreateRole",
 	HTTPMethod: http.MethodPost,
-	HTTPPath:   "/v1/roles",
+	HTTPPath:   "/v1/roles/*",
 }
 
 var putRole = &phonehome.ServiceMethod{


### PR DESCRIPTION
## Description

Tracking POST and PUT calls to Auth Provider, Role, Permission Set and Access Scope resources.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

Tested by creating and updating the according resources via UI. Resulting messages as seen on Segment:

### POST
```go
client.Track(&analytics.Track{
  UserId: "G6ft6pk2bkJbqCW1iIQ+uk8Tyk32FG0B+m58M4nn/vk=",
  Event: "Create Permission Set",
  Properties: map[string]interface{}{
    "Code": 200,
    "Method": "POST",
    "Path": "/v1/permissionsets",
    "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36 Rox Central/3.73.x-319-ge5636c714e (linux; amd64) grpc-go/1.51.0",
  },
})

client.Track(&analytics.Track{
  UserId: "G6ft6pk2bkJbqCW1iIQ+uk8Tyk32FG0B+m58M4nn/vk=",
  Event: "Create Auth Provider",
  Properties: map[string]interface{}{
    "Code": 200,
    "Method": "POST",
    "Path": "/v1/authProviders",
    "Type": "userpki",
    "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36 Rox Central/3.73.x-319-ge5636c714e (linux; amd64) grpc-go/1.51.0",
  },
})

client.Track(&analytics.Track{
  UserId: "G6ft6pk2bkJbqCW1iIQ+uk8Tyk32FG0B+m58M4nn/vk=",
  Event: "Create Role",
  Properties: map[string]interface{}{
    "Code": 200,
    "Method": "POST",
    "Path": "/v1/roles/abc",
    "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36 Rox Central/3.73.x-319-ge5636c714e (linux; amd64) grpc-go/1.51.0",
  },
})

client.Track(&analytics.Track{
  UserId: "G6ft6pk2bkJbqCW1iIQ+uk8Tyk32FG0B+m58M4nn/vk=",
  Event: "Create Access Scope",
  Properties: map[string]interface{}{
    "Code": 200,
    "Method": "POST",
    "Path": "/v1/simpleaccessscopes",
    "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36 Rox Central/3.73.x-319-ge5636c714e (linux; amd64) grpc-go/1.51.0",
  },
})
```
### PUT
```go
client.Track(&analytics.Track{
  UserId: "G6ft6pk2bkJbqCW1iIQ+uk8Tyk32FG0B+m58M4nn/vk=",
  Event: "Create Auth Provider",
  Properties: map[string]interface{}{
    "Code": 200,
    "Method": "PUT",
    "Path": "/v1/authProviders/f041585e-e23f-4616-ac41-33f10d569bdd",
    "Type": "userpki",
    "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36 Rox Central/3.73.x-319-ge5636c714e (linux; amd64) grpc-go/1.51.0",
  },
})

client.Track(&analytics.Track{
  UserId: "G6ft6pk2bkJbqCW1iIQ+uk8Tyk32FG0B+m58M4nn/vk=",
  Event: "Create Role",
  Properties: map[string]interface{}{
    "Code": 200,
    "Method": "PUT",
    "Path": "/v1/roles/abc",
    "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36 Rox Central/3.73.x-319-ge5636c714e (linux; amd64) grpc-go/1.51.0",
  },
})

client.Track(&analytics.Track{
  UserId: "G6ft6pk2bkJbqCW1iIQ+uk8Tyk32FG0B+m58M4nn/vk=",
  Event: "Create Access Scope",
  Properties: map[string]interface{}{
    "Code": 200,
    "Method": "PUT",
    "Path": "/v1/simpleaccessscopes/a8ddb63b-8fe0-4294-a2cc-5a90fe516b87",
    "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36 Rox Central/3.73.x-319-ge5636c714e (linux; amd64) grpc-go/1.51.0",
  },
})

client.Track(&analytics.Track{
  UserId: "G6ft6pk2bkJbqCW1iIQ+uk8Tyk32FG0B+m58M4nn/vk=",
  Event: "Create Permission Set",
  Properties: map[string]interface{}{
    "Code": 200,
    "Method": "PUT",
    "Path": "/v1/permissionsets/35865aac-1b91-40db-b4c3-ee214e2359d7",
    "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36 Rox Central/3.73.x-319-ge5636c714e (linux; amd64) grpc-go/1.51.0",
  },
})
```