### PR TITLE
CI: Port image scan to GHA

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -446,6 +446,7 @@ jobs:
           quay.io/rhacs-eng/grpc-server:${{ steps.tag.outputs.TAG }}
 
   scan-images-with-roxctl:
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     needs:
       - build-and-push-main
@@ -482,5 +483,4 @@ jobs:
 
       - name: Scan images
         run: |
-          roxctl version
           ./release/scripts/scan-images-with-roxctl.sh

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -467,9 +467,20 @@ jobs:
 
       - uses: ./.github/actions/handle-tagged-build
 
+      - uses: actions/download-artifact@v3
+        with:
+          name: cli-build
+
       - name: Unpack cli build
         run: |
           tar xvzf cli-build.tgz
-          source ./scripts/ci/lib.sh
-          install_built_roxctl_in_gopath
+
+      - name: Install roxctl
+        run: |
+          ./scripts/ci/lib.sh install_built_roxctl_in_gopath
           roxctl version
+
+      - name: Scan images
+        run: |
+          roxctl version
+          ./release/scripts/scan-images-with-roxctl.sh

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -444,3 +444,32 @@ jobs:
         push: true
         tags: |
           quay.io/rhacs-eng/grpc-server:${{ steps.tag.outputs.TAG }}
+
+  scan-images-with-roxctl:
+    runs-on: ubuntu-latest
+    needs:
+      - build-and-push-main
+    container:
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.49
+      env:
+        STACKROX_CI_INSTANCE_API_KEY: ${{ secrets.STACKROX_CI_INSTANCE_API_KEY }}
+        STACKROX_CI_INSTANCE_CENTRAL_HOST: ${{ secrets.STACKROX_CI_INSTANCE_CENTRAL_HOST }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Checkout submodules
+        run: |
+            git submodule update --init
+
+      - uses: ./.github/actions/handle-tagged-build
+
+      - name: Unpack cli build
+        run: |
+          tar xvzf cli-build.tgz
+          source ./scripts/ci/lib.sh
+          install_built_roxctl_in_gopath
+          roxctl version

--- a/release/scripts/scan-images-with-roxctl.sh
+++ b/release/scripts/scan-images-with-roxctl.sh
@@ -17,15 +17,10 @@ scan_images_with_roxctl() {
     collector_tag=$(make collector-tag)
     local scanner_tag
     scanner_tag=$(make scanner-tag)
-    local docs_prerelease_tag
-    docs_prerelease_tag=$(make docs-tag)
 
     # check main images
     images+=("main:$release_tag")
     images+=("central-db:$release_tag")
-
-    # check docs image - using the pre-release tag (not the release tag)
-    images+=("docs:$docs_prerelease_tag")
 
     # check collector images
     images+=("collector:${collector_tag}-slim")

--- a/scripts/ci/jobs/release-mgmt.sh
+++ b/scripts/ci/jobs/release-mgmt.sh
@@ -30,10 +30,6 @@ release_mgmt() {
 
     fi
 
-    "$ROOT/release/scripts/scan-images-with-roxctl.sh" || {
-        pre_release_warnings+=("Errors were found in image scans.")
-    }
-
     if [[ "${#pre_release_warnings[@]}" != "0" ]]; then
         info "ERROR: Issues were found:"
         for issue in "${pre_release_warnings[@]}"; do


### PR DESCRIPTION
## Description

Images are not pushed in OSCI so this check is moved to GHA. Also removes the docs image from the scan per ROX-12465.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

- [x] Only runs for pushes to master
