### PR TITLE
ROX-14172: Fix Configmanagement UI test.

### DIFF
--- a/central/compliance/checks/nist80053/check_ac_14/check.go
+++ b/central/compliance/checks/nist80053/check_ac_14/check.go
@@ -5,6 +5,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	pkgCommon "github.com/stackrox/rox/pkg/compliance/checks/common"
 	pkgFramework "github.com/stackrox/rox/pkg/compliance/framework"
+	"github.com/stackrox/rox/pkg/k8srbac"
 	"github.com/stackrox/rox/pkg/set"
 )
 
@@ -76,9 +77,7 @@ func checkNoExtraPrivilegesForUnauthenticated(ctx framework.ComplianceContext) {
 	for _, binding := range k8sRoleBindings {
 		for _, subject := range binding.GetSubjects() {
 			if subject.GetName() == systemUnauthenticatedSubject && subject.GetKind() == storage.SubjectKind_GROUP {
-				// A binding is only binding cluster-wide if cluster role is true _and_ namespace is empty. Namespaced
-				// bindings may bind to cluster roles as well.
-				if binding.GetClusterRole() && binding.GetNamespace() == "" {
+				if k8srbac.IsClusterRoleBinding(binding) {
 					clusterRoleIDs.Add(binding.GetRoleId())
 				} else {
 					namespacedRoleIDSet, found := namespaceRoleIDs[binding.GetNamespace()]

--- a/central/compliance/checks/nist80053/check_ac_14/check.go
+++ b/central/compliance/checks/nist80053/check_ac_14/check.go
@@ -76,7 +76,9 @@ func checkNoExtraPrivilegesForUnauthenticated(ctx framework.ComplianceContext) {
 	for _, binding := range k8sRoleBindings {
 		for _, subject := range binding.GetSubjects() {
 			if subject.GetName() == systemUnauthenticatedSubject && subject.GetKind() == storage.SubjectKind_GROUP {
-				if binding.GetClusterRole() {
+				// A binding is only binding cluster-wide if cluster role is true _and_ namespace is empty. Namespaced
+				// bindings may bind to cluster roles as well.
+				if binding.GetClusterRole() && binding.GetNamespace() == "" {
 					clusterRoleIDs.Add(binding.GetRoleId())
 				} else {
 					namespacedRoleIDSet, found := namespaceRoleIDs[binding.GetNamespace()]

--- a/central/graphql/resolvers/generated.go
+++ b/central/graphql/resolvers/generated.go
@@ -519,7 +519,8 @@ func registerGeneratedTypes(builder generator.SchemaBuilder) {
 		"type: ContainerRuntime!",
 		"version: String!",
 	}))
-	utils.Must(builder.AddType("CosignSignature", []string{}))
+	utils.Must(builder.AddType("CosignSignature", []string{
+	}))
 	utils.Must(builder.AddType("DataSource", []string{
 		"id: ID!",
 		"name: String!",
@@ -596,7 +597,8 @@ func registerGeneratedTypes(builder generator.SchemaBuilder) {
 	utils.Must(builder.AddType("Exclusion_Image", []string{
 		"name: String!",
 	}))
-	utils.Must(builder.AddType("FalsePositiveRequest", []string{}))
+	utils.Must(builder.AddType("FalsePositiveRequest", []string{
+	}))
 	utils.Must(builder.AddInput("FalsePositiveVulnRequest", []string{
 		"comment: String",
 		"cve: String",
@@ -620,7 +622,8 @@ func registerGeneratedTypes(builder generator.SchemaBuilder) {
 		"invalidRunIds: [String!]!",
 		"runs: [ComplianceRun]!",
 	}))
-	utils.Must(builder.AddType("GetPermissionsResponse", []string{}))
+	utils.Must(builder.AddType("GetPermissionsResponse", []string{
+	}))
 	utils.Must(builder.AddType("GoogleProviderMetadata", []string{
 		"clusterName: String!",
 		"project: String!",
@@ -1318,6 +1321,7 @@ func registerGeneratedTypes(builder generator.SchemaBuilder) {
 		"skipTLSVerify: Boolean!",
 	}))
 	utils.Must(builder.AddType("Syslog", []string{
+		"extraFields: [KeyValuePair]!",
 		"localFacility: Syslog_LocalFacility!",
 		"tcpConfig: Syslog_TCPConfig",
 		"endpoint: SyslogEndpoint",
@@ -1417,7 +1421,8 @@ func registerGeneratedTypes(builder generator.SchemaBuilder) {
 		"VulnerabilityRequest_Scope_Image",
 		"VulnerabilityRequest_Scope_Global",
 	}))
-	utils.Must(builder.AddType("VulnerabilityRequest_Scope_Global", []string{}))
+	utils.Must(builder.AddType("VulnerabilityRequest_Scope_Global", []string{
+	}))
 	utils.Must(builder.AddType("VulnerabilityRequest_Scope_Image", []string{
 		"registry: String!",
 		"remote: String!",
@@ -14369,6 +14374,11 @@ func (resolver *Resolver) wrapSyslogsWithContext(ctx context.Context, values []*
 		output[i] = &syslogResolver{ctx: ctx, root: resolver, data: v}
 	}
 	return output, nil
+}
+
+func (resolver *syslogResolver) ExtraFields(ctx context.Context) ([]*keyValuePairResolver, error) {
+	value := resolver.data.GetExtraFields()
+	return resolver.root.wrapKeyValuePairs(value, nil)
 }
 
 func (resolver *syslogResolver) LocalFacility(ctx context.Context) string {

--- a/central/rbac/service/get_subject.go
+++ b/central/rbac/service/get_subject.go
@@ -56,9 +56,7 @@ func getSubjectFromStores(ctx context.Context, subjectName string, roleDS k8sRol
 	roleIDs := set.NewStringSet()
 	for _, binding := range relevantBindings {
 		roleIDs.Add(binding.GetRoleId())
-		// A binding is only binding cluster-wide if cluster role is true _and_ namespace is empty. Namespaced
-		// bindings may bind to cluster roles as well.
-		if binding.GetClusterRole() && binding.GetNamespace() == "" {
+		if k8srbac.IsClusterRoleBinding(binding) {
 			clusterBindings = append(clusterBindings, binding)
 		} else {
 			namespacedBindings[binding.GetNamespace()] = append(namespacedBindings[binding.GetNamespace()], binding)

--- a/central/rbac/service/get_subject.go
+++ b/central/rbac/service/get_subject.go
@@ -56,6 +56,8 @@ func getSubjectFromStores(ctx context.Context, subjectName string, roleDS k8sRol
 	roleIDs := set.NewStringSet()
 	for _, binding := range relevantBindings {
 		roleIDs.Add(binding.GetRoleId())
+		// A binding is only binding cluster-wide if cluster role is true _and_ namespace is empty. Namespaced
+		// bindings may bind to cluster roles as well.
 		if binding.GetClusterRole() && binding.GetNamespace() == "" {
 			clusterBindings = append(clusterBindings, binding)
 		} else {

--- a/central/rbac/utils/cluster_permission_evaluator.go
+++ b/central/rbac/utils/cluster_permission_evaluator.go
@@ -53,16 +53,11 @@ func (c *clusterPermissionEvaluator) RolesForSubject(ctx context.Context, subjec
 func (c *clusterPermissionEvaluator) getBindingsAndRoles(ctx context.Context, subject *storage.Subject) ([]*storage.K8SRoleBinding, []*storage.K8SRole) {
 	q := search.NewQueryBuilder().
 		AddExactMatches(search.ClusterID, c.clusterID).
-		// Only evaluate bindings which have bind a cluster role _and_ have no namespace. Otherwise, we are evaluating
-		// role bindings which bind a cluster role to a specific namespace and would mistakenly
-		// see them as "cluster scoped".
-		AddNullField(search.Namespace).
 		AddBools(search.ClusterRole, true).
 		AddExactMatches(search.SubjectName, subject.GetName()).
 		AddExactMatches(search.SubjectKind, subject.GetKind().String()).
 		ProtoQuery()
 	clusterRoleBindings, err := c.bindingsStore.SearchRawRoleBindings(ctx, q)
-
 	if err != nil {
 		log.Errorf("error searching for clusterrolebindings: %v", err)
 		return nil, nil

--- a/central/rbac/utils/cluster_permission_evaluator_test.go
+++ b/central/rbac/utils/cluster_permission_evaluator_test.go
@@ -97,7 +97,6 @@ func TestIsClusterAdmin(t *testing.T) {
 
 	clusterScopeQuery := search.NewQueryBuilder().
 		AddExactMatches(search.ClusterID, "cluster").
-		AddNullField(search.Namespace).
 		AddExactMatches(search.SubjectName, "foo").
 		AddExactMatches(search.SubjectKind, storage.SubjectKind_SERVICE_ACCOUNT.String()).
 		AddBools(search.ClusterRole, true).ProtoQuery()
@@ -194,7 +193,6 @@ func TestClusterPermissionsForSubject(t *testing.T) {
 
 	clusterScopeQuery := search.NewQueryBuilder().
 		AddExactMatches(search.ClusterID, "cluster").
-		AddNullField(search.Namespace).
 		AddExactMatches(search.SubjectName, "foo").
 		AddExactMatches(search.SubjectKind, storage.SubjectKind_SERVICE_ACCOUNT.String()).
 		AddBools(search.ClusterRole, true).ProtoQuery()

--- a/central/rbac/utils/namespace_permission_evaluator.go
+++ b/central/rbac/utils/namespace_permission_evaluator.go
@@ -58,7 +58,6 @@ func (c *namespacePermissionEvaluator) getBindingsAndRoles(ctx context.Context, 
 		log.Errorf("error searching for roleBindings: %v", err)
 		return nil, nil
 	}
-
 	roles := getRolesForRoleBindings(ctx, c.roleStore, roleBindings, c.clusterID, c.namespace)
 	return roleBindings, roles
 }

--- a/central/risk/multipliers/deployment/service_account_permissions_test.go
+++ b/central/risk/multipliers/deployment/service_account_permissions_test.go
@@ -231,7 +231,6 @@ func TestPermissionScore(t *testing.T) {
 			clusterScopeQuery := search.NewQueryBuilder().
 				AddExactMatches(search.ClusterID, deployment.GetClusterId()).
 				AddExactMatches(search.SubjectName, c.sa.Name).
-				AddNullField(search.Namespace).
 				AddExactMatches(search.SubjectKind, storage.SubjectKind_SERVICE_ACCOUNT.String()).
 				AddBools(search.ClusterRole, true).ProtoQuery()
 

--- a/central/serviceaccount/service/service_impl_test.go
+++ b/central/serviceaccount/service/service_impl_test.go
@@ -199,7 +199,6 @@ func (suite *ServiceAccountServiceTestSuite) setupMocks() {
 	clusterScopeQuery := search.NewQueryBuilder().
 		AddExactMatches(search.ClusterID, "cluster").
 		AddExactMatches(search.SubjectName, expectedSA.Name).
-		AddNullField(search.Namespace).
 		AddExactMatches(search.SubjectKind, storage.SubjectKind_SERVICE_ACCOUNT.String()).
 		AddBools(search.ClusterRole, true).ProtoQuery()
 	suite.mockBindingStore.EXPECT().SearchRawRoleBindings(gomock.Any(), clusterScopeQuery).AnyTimes().

--- a/pkg/k8srbac/evaluator.go
+++ b/pkg/k8srbac/evaluator.go
@@ -44,9 +44,7 @@ func MakeClusterEvaluator(roles []*storage.K8SRole, bindings []*storage.K8SRoleB
 	// Collect cluster role bindings.
 	var clusterBindings []*storage.K8SRoleBinding
 	for _, binding := range bindings {
-		// A binding is only binding cluster-wide if cluster role is true _and_ namespace is empty. Namespaced
-		// bindings may bind to cluster roles as well.
-		if binding.GetClusterRole() && binding.GetNamespace() == "" {
+		if IsClusterRoleBinding(binding) {
 			clusterBindings = append(clusterBindings, binding)
 		}
 	}

--- a/pkg/k8srbac/evaluator.go
+++ b/pkg/k8srbac/evaluator.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/stackrox/rox/generated/storage"
-	"github.com/stackrox/rox/pkg/set"
 )
 
 const clusterAdmin = "cluster-admin"
@@ -45,39 +44,11 @@ func MakeClusterEvaluator(roles []*storage.K8SRole, bindings []*storage.K8SRoleB
 	// Collect cluster role bindings.
 	var clusterBindings []*storage.K8SRoleBinding
 	for _, binding := range bindings {
-		if binding.GetClusterRole() {
+		// A binding is only binding cluster-wide if cluster role is true _and_ namespace is empty. Namespaced
+		// bindings may bind to cluster roles as well.
+		if binding.GetClusterRole() && binding.GetNamespace() == "" {
 			clusterBindings = append(clusterBindings, binding)
 		}
 	}
 	return NewEvaluator(clusterRoles, clusterBindings)
-}
-
-// MakeNamespaceEvaluators creates an evaluator per namespace with a binding present.
-func MakeNamespaceEvaluators(roles []*storage.K8SRole, bindings []*storage.K8SRoleBinding) map[string]Evaluator {
-	// Collect cluster roles.
-	namespaces := set.NewStringSet()
-	for _, binding := range bindings {
-		namespaces.Add(binding.GetNamespace())
-		for _, subject := range binding.GetSubjects() {
-			namespaces.Add(subject.GetNamespace())
-		}
-	}
-
-	evaluators := make(map[string]Evaluator)
-	for namespace := range namespaces {
-		evaluators[namespace] = MakeNamespaceEvaluator(namespace, roles, bindings)
-	}
-	return evaluators
-}
-
-// MakeNamespaceEvaluator creates an evaluator for the given namespace with the given roles and bindings.
-func MakeNamespaceEvaluator(namespace string, roles []*storage.K8SRole, bindings []*storage.K8SRoleBinding) Evaluator {
-	// Collect role bindings.
-	var namespacedBindings []*storage.K8SRoleBinding
-	for _, binding := range bindings {
-		if binding.GetClusterRole() || binding.GetNamespace() == namespace {
-			namespacedBindings = append(namespacedBindings, binding)
-		}
-	}
-	return NewEvaluator(roles, namespacedBindings)
 }

--- a/pkg/k8srbac/utils.go
+++ b/pkg/k8srbac/utils.go
@@ -20,11 +20,8 @@ var DefaultLabel = struct {
 	Value string
 }{Key: "kubernetes.io/bootstrapping", Value: "rbac-defaults"}
 
-// IsDefaultRole identifies default roles.
-// TODO(): Need to wire labels for this.
-func IsDefaultRole(role *storage.K8SRole) bool {
-	return role.GetLabels()[DefaultLabel.Key] == DefaultLabel.Value
-}
+// DefaultServiceAccountName is the name of service accounts that get created by default.
+const DefaultServiceAccountName = "default"
 
 // IsDefaultRoleBinding identifies default role bindings.
 // TODO(): Need to wire labels for this.
@@ -32,12 +29,11 @@ func IsDefaultRoleBinding(roleBinding *storage.K8SRoleBinding) bool {
 	return roleBinding.GetLabels()[DefaultLabel.Key] == DefaultLabel.Value
 }
 
-// DefaultServiceAccountName is the name of service accounts that get created by default.
-const DefaultServiceAccountName = "default"
-
-// IsDefaultServiceAccountSubject identifies subjects that are default service accounts.
-func IsDefaultServiceAccountSubject(sub *storage.Subject) bool {
-	return sub.GetKind() == storage.SubjectKind_SERVICE_ACCOUNT && sub.GetName() == DefaultServiceAccountName
+// IsClusterRoleBinding identifies cluster role bindings.
+func IsClusterRoleBinding(binding *storage.K8SRoleBinding) bool {
+	// A binding is only binding cluster-wide if cluster role is true _and_ namespace is empty. Namespaced
+	// bindings may bind to cluster roles as well.
+	return binding.GetClusterRole() && binding.GetNamespace() == ""
 }
 
 // EffectiveAdmin represents the rule that grants admin if granted by a policy rule.


### PR DESCRIPTION
## Description

With the change of #4031 , the cluster permission evaluator was changed.

Previously, it was sufficient enough to only specify `Cluster role == true` for cluster role bindings, however this has changed.

A cluster role binding has `Cluster role == true && Namespace == ""`.

The query that is currently being used in the cluster permission evaluator (using `AddNullField`) does not match. The reason for this is that there are two namespace fields within the role binding proto message: one for the binding, and one for the subject. Since the subject's namespace is never empty, this query didn't work properly.

This lead to a failing UI test, since the cluster admin roles were not shown correctly.

By fixing the query as well as deleting unused code + making sure that other places respect the condition of `cluster role == true && namespace == ""`, this should be fixed.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

- see CI.
