### PR TITLE
ROX-13740: use upstream fixed kuttl and cleanup workarounds 

### DIFF
--- a/operator/Makefile
+++ b/operator/Makefile
@@ -265,19 +265,19 @@ validate-crs:
 .PHONY: test-e2e
 test-e2e: build install validate-crs kuttl ensure-rox-main-image-exists ## Run e2e tests with local manager.
 	mkdir -p $(PROJECT_DIR)/build/kuttl-test-artifacts
-	KUTTL=$(KUTTL) REAL_KUBECONFIG=$${KUBECONFIG} ENABLE_WEBHOOKS=$(ENABLE_WEBHOOKS) $(KUTTL) test
+	KUTTL=$(KUTTL) ENABLE_WEBHOOKS=$(ENABLE_WEBHOOKS) $(KUTTL) test
 
 .PHONY: test-e2e-deployed
 test-e2e-deployed: validate-crs kuttl ## Run e2e tests with manager deployed on cluster.
 	mkdir -p $(PROJECT_DIR)/build/kuttl-test-artifacts
-	KUTTL=$(KUTTL) REAL_KUBECONFIG=$${KUBECONFIG} SKIP_MANAGER_START=1 $(KUTTL) test
+	KUTTL=$(KUTTL) SKIP_MANAGER_START=1 $(KUTTL) test
 
 .PHONY: test-upgrade
 test-upgrade: kuttl bundle-post-process ## Run OLM-based operator upgrade tests.
 	mkdir -p $(PROJECT_DIR)/build/kuttl-test-artifacts-upgrade
 	SKIP_MANAGER_START=1 \
 	NEW_PRODUCT_VERSION=$$(make --quiet --no-print-directory -C .. tag) \
-	KUTTL=$(KUTTL) REAL_KUBECONFIG=$${KUBECONFIG} $(KUTTL) test --config kuttl-test.yaml --artifacts-dir build/kuttl-test-artifacts-upgrade tests/upgrade
+	KUTTL=$(KUTTL) $(KUTTL) test --config kuttl-test.yaml --artifacts-dir build/kuttl-test-artifacts-upgrade tests/upgrade
 
 .PHONY: stackrox-image-pull-secret
 stackrox-image-pull-secret: ## Create default image pull secret for StackRox images on Quay.io. Used by Helm chart.

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -182,8 +182,8 @@ operator-sdk: ## Download operator-sdk necessary for scaffolding and bundling.
 	$(GET_GITHUB_RELEASE_FN); \
 	get_github_release $(OPERATOR_SDK) $${OPERATOR_SDK_URL}
 
-KUTTL_VERSION = 0.14.0-kubeconfig
-KUTTL_UPSTREAM = porridge
+KUTTL_VERSION = 0.15.0
+KUTTL_UPSTREAM = kudobuilder
 KUTTL ?= $(PROJECT_DIR)/bin/kubectl-kuttl-$(KUTTL_VERSION)
 .PHONY: kuttl
 kuttl: ## Download kuttl.

--- a/operator/tests/central/basic/20-verify-password.yaml
+++ b/operator/tests/central/basic/20-verify-password.yaml
@@ -1,4 +1,4 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-- script: KUBECONFIG="${REAL_KUBECONFIG}" kubectl exec -n $NAMESPACE deployment/central -- roxctl central whoami --insecure-skip-tls-verify -p letmein
+- script: kubectl exec -n $NAMESPACE deployment/central -- roxctl central whoami --insecure-skip-tls-verify -p letmein

--- a/operator/tests/central/basic/60-use-new-password.yaml
+++ b/operator/tests/central/basic/60-use-new-password.yaml
@@ -5,7 +5,7 @@ commands:
     # Updating the password may take some time, so retry until it works.
     set +e
     for i in `seq 60`; do
-      KUBECONFIG="${REAL_KUBECONFIG}" kubectl exec -n $NAMESPACE deployment/central -- roxctl central whoami --insecure-skip-tls-verify -p opensesame && exit 0
+      kubectl exec -n $NAMESPACE deployment/central -- roxctl central whoami --insecure-skip-tls-verify -p opensesame && exit 0
       sleep 1
     done
     exit 1

--- a/operator/tests/common/delete-central-assert.yaml
+++ b/operator/tests/common/delete-central-assert.yaml
@@ -12,5 +12,5 @@ commands:
     # With 6 objects in the assert file, each attempt typically takes ~22 seconds (including the 1s sleep between attempts),
     # although it can occasionally take significantly longer, see https://github.com/kudobuilder/kuttl/issues/321
     # So we specify a timeout value of 13, aiming for under 5 minutes.
-    KUBECONFIG="${REAL_KUBECONFIG}" ${KUTTL:-kubectl-kuttl} errors --timeout 13 $errors_file
+    ${KUTTL:-kubectl-kuttl} errors --timeout 13 $errors_file
     rm $errors_file

--- a/operator/tests/common/fetch-bundle.yaml
+++ b/operator/tests/common/fetch-bundle.yaml
@@ -1,5 +1,5 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-- script: KUBECONFIG="${REAL_KUBECONFIG}" kubectl exec -n $NAMESPACE deployment/central -- roxctl central --insecure-skip-tls-verify init-bundles generate testing-cluster -p letmein --output-secrets - > init-bundle.yaml
-- script: KUBECONFIG="${REAL_KUBECONFIG}" kubectl apply -n $NAMESPACE -f init-bundle.yaml
+- script: kubectl exec -n $NAMESPACE deployment/central -- roxctl central --insecure-skip-tls-verify init-bundles generate testing-cluster -p letmein --output-secrets - > init-bundle.yaml
+- script: kubectl apply -n $NAMESPACE -f init-bundle.yaml

--- a/operator/tests/common/image-pull-secrets.yaml
+++ b/operator/tests/common/image-pull-secrets.yaml
@@ -7,6 +7,6 @@ commands:
     secret=$(mktemp)
     registry_hostname=quay.io
     ../../../../deploy/common/pull-secret.sh stackrox ${registry_hostname} > $secret
-    KUBECONFIG="${REAL_KUBECONFIG}" kubectl -n $NAMESPACE create -f $secret
+    kubectl -n $NAMESPACE create -f $secret
     echo "Created pull secret for ${registry_hostname} in $NAMESPACE"
     rm $secret

--- a/operator/tests/upgrade/upgrade/20-assert.yaml
+++ b/operator/tests/upgrade/upgrade/20-assert.yaml
@@ -13,7 +13,7 @@ commands:
     # With 5 objects in the assert file, each attempt typically takes ~18 seconds (including the 1s sleep between attempts),
     # although it can occasionally take significantly longer, see https://github.com/kudobuilder/kuttl/issues/321
     # So we specify a timeout value of 16, aiming for under 5 minutes.
-    KUBECONFIG="${REAL_KUBECONFIG}" ${KUTTL:-kubectl-kuttl} assert --namespace $NAMESPACE --timeout 16 $assert_file
+    ${KUTTL:-kubectl-kuttl} assert --namespace $NAMESPACE --timeout 16 $assert_file
     rm $assert_file
 collectors:
 - type: pod

--- a/operator/tests/upgrade/upgrade/20-upgrade-operator.yaml
+++ b/operator/tests/upgrade/upgrade/20-upgrade-operator.yaml
@@ -3,5 +3,5 @@ kind: TestStep
 commands:
 # We invoke the upgrade script via make such that we do not need to redefine here or plumb through
 # from the parent make: the namespace and operator version string (which are arguments to upgrade script).
-- script: KUBECONFIG="${REAL_KUBECONFIG}" make -C ../../.. upgrade-via-olm
+- script: make -C ../../.. upgrade-via-olm
   timeout: 600


### PR DESCRIPTION
## Description

The fix for using correct kubeconfig when running `kuttl` in-cluster is now [released](https://github.com/kudobuilder/kuttl/releases/tag/v0.15.0) upstream:
- stop using my custom fix build
- clean up the `$REAL_KUBECONFIG` workaround that passed the kubeconfig path behind `kuttl`s back

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

CI is sufficient.