### PR TITLE
ROX-14176: retry protoc download

### DIFF
--- a/make/github.mk
+++ b/make/github.mk
@@ -12,6 +12,8 @@ GET_GITHUB_RELEASE_FN = get_github_release() { \
 		for i in $$(seq $$attempts); do \
 			curl --silent --show-error --fail --location --output $${1} $${2} && break ;\
 			[ $$i -eq $$attempts ] && exit 1; \
+			echo "Retrying after $$(i*i) seconds..."; \
+			sleep $$(i*i); \
 		done ;\
 		[[ "$$(uname -s)" != "Darwin" ]] || xattr -c $${1} ;\
 		chmod +x $${1} ;\

--- a/make/github.mk
+++ b/make/github.mk
@@ -1,0 +1,18 @@
+# github.mk
+# Helpers for fetching released binaries from github projects.
+
+# For usage instructions, see uses of this macro elsewhere, since there is no
+# single standard for architecture naming.
+GET_GITHUB_RELEASE_FN = get_github_release() { \
+	[ -x $${1} ] || { \
+		set -euo pipefail ;\
+		mkdir -p bin ;\
+		attempts=5 ;\
+		for i in $$(seq $$attempts); do \
+			curl --silent --show-error --fail --location --output $${1} $${2} && break ;\
+			[ $$i -eq $$attempts ] && exit 1; \
+		done ;\
+		[[ "$$(uname -s)" != "Darwin" ]] || xattr -c $${1} ;\
+		chmod +x $${1} ;\
+	} \
+}

--- a/make/github.mk
+++ b/make/github.mk
@@ -6,6 +6,7 @@
 GET_GITHUB_RELEASE_FN = get_github_release() { \
 	[ -x $${1} ] || { \
 		set -euo pipefail ;\
+		echo "+ $${1}" ;\
 		mkdir -p bin ;\
 		attempts=5 ;\
 		for i in $$(seq $$attempts); do \

--- a/make/protogen.mk
+++ b/make/protogen.mk
@@ -37,15 +37,16 @@ endif
 PROTOC_VERSION := 21.4
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Linux)
-PROTOC_ARCH = linux
+PROTOC_OS = linux
 endif
 ifeq ($(UNAME_S),Darwin)
-PROTOC_ARCH = osx
+PROTOC_OS = osx
 endif
+PROTOC_ARCH=$(shell case $$(uname -m) in (aarch64) echo -n armv6 ;; (*) echo -n $$(uname -m) ;; esac)
 
 PROTO_PRIVATE_DIR := $(BASE_PATH)/.proto
 
-PROTOC_DIR := $(PROTO_PRIVATE_DIR)/protoc-$(PROTOC_ARCH)-$(PROTOC_VERSION)
+PROTOC_DIR := $(PROTO_PRIVATE_DIR)/protoc-$(PROTOC_OS)-$(PROTOC_VERSION)
 
 PROTOC := $(PROTOC_DIR)/bin/protoc
 
@@ -61,12 +62,15 @@ $(PROTO_GOBIN):
 	@echo "+ $@"
 	$(SILENT)mkdir -p "$@"
 
-PROTOC_ZIP := protoc-$(PROTOC_VERSION)-$(PROTOC_ARCH)-x86_64.zip
+PROTOC_ZIP := protoc-$(PROTOC_VERSION)-$(PROTOC_OS)-$(PROTOC_ARCH).zip
 PROTOC_FILE := $(PROTOC_DOWNLOADS_DIR)/$(PROTOC_ZIP)
+
+include $(BASE_PATH)/make/github.mk
 
 $(PROTOC_FILE): $(PROTOC_DOWNLOADS_DIR)
 	@echo "+ $@"
-	$(SILENT)wget -q "https://github.com/protocolbuffers/protobuf/releases/download/v$(PROTOC_VERSION)/$(PROTOC_ZIP)" -O "$@"
+	@$(GET_GITHUB_RELEASE_FN); \
+	get_github_release "$@" "https://github.com/protocolbuffers/protobuf/releases/download/v$(PROTOC_VERSION)/$(PROTOC_ZIP)"
 
 .PRECIOUS: $(PROTOC_FILE)
 

--- a/make/protogen.mk
+++ b/make/protogen.mk
@@ -42,11 +42,11 @@ endif
 ifeq ($(UNAME_S),Darwin)
 PROTOC_OS = osx
 endif
-PROTOC_ARCH=$(shell case $$(uname -m) in (aarch64) echo -n armv6 ;; (*) echo -n $$(uname -m) ;; esac)
+PROTOC_ARCH=$(shell case $$(uname -m) in (aarch64) echo armv6 ;; (*) uname -m ;; esac)
 
 PROTO_PRIVATE_DIR := $(BASE_PATH)/.proto
 
-PROTOC_DIR := $(PROTO_PRIVATE_DIR)/protoc-$(PROTOC_OS)-$(PROTOC_VERSION)
+PROTOC_DIR := $(PROTO_PRIVATE_DIR)/protoc-$(PROTOC_OS)-$(PROTOC_ARCH)-$(PROTOC_VERSION)
 
 PROTOC := $(PROTOC_DIR)/bin/protoc
 

--- a/make/protogen.mk
+++ b/make/protogen.mk
@@ -242,4 +242,4 @@ clean-proto-deps:
 	@echo "+ $@"
 	rm -f $(PROTOC_FILE)
 	rm -rf $(PROTOC_DIR)
-	rm -f $(PROTO_GOBIN)
+	rm -rf $(PROTO_GOBIN)

--- a/make/protogen.mk
+++ b/make/protogen.mk
@@ -68,7 +68,6 @@ PROTOC_FILE := $(PROTOC_DOWNLOADS_DIR)/$(PROTOC_ZIP)
 include $(BASE_PATH)/make/github.mk
 
 $(PROTOC_FILE): $(PROTOC_DOWNLOADS_DIR)
-	@echo "+ $@"
 	@$(GET_GITHUB_RELEASE_FN); \
 	get_github_release "$@" "https://github.com/protocolbuffers/protobuf/releases/download/v$(PROTOC_VERSION)/$(PROTOC_ZIP)"
 

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -178,7 +178,7 @@ OPERATOR_SDK = $(PROJECT_DIR)/bin/operator-sdk-$(OPERATOR_SDK_VERSION)
 .PHONY: operator-sdk
 operator-sdk: ## Download operator-sdk necessary for scaffolding and bundling.
 # See https://sdk.operatorframework.io/docs/installation/#install-from-github-release
-	@ARCH=$$(case $$(uname -m) in (x86_64) echo -n amd64 ;; (aarch64) echo -n arm64 ;; (*) echo -n $$(uname -m) ;; esac) ;\
+	@ARCH=$$(case $$(uname -m) in (x86_64) echo amd64 ;; (aarch64) echo arm64 ;; (*) uname -m ;; esac) ;\
 	OPERATOR_SDK_URL=https://github.com/operator-framework/operator-sdk/releases/download/v$(OPERATOR_SDK_VERSION)/operator-sdk_$(OS)_$${ARCH} ;\
 	$(GET_GITHUB_RELEASE_FN); \
 	get_github_release $(OPERATOR_SDK) $${OPERATOR_SDK_URL}
@@ -188,7 +188,7 @@ KUTTL_UPSTREAM = porridge
 KUTTL ?= $(PROJECT_DIR)/bin/kubectl-kuttl-$(KUTTL_VERSION)
 .PHONY: kuttl
 kuttl: ## Download kuttl.
-	@ARCH=$$(case $$(uname -m) in (aarch64) echo -n armv6 ;; (*) echo -n $$(uname -m) ;; esac) ;\
+	@ARCH=$$(case $$(uname -m) in (aarch64) echo armv6 ;; (*) uname -m ;; esac) ;\
 	KUTTL_URL=https://github.com/$(KUTTL_UPSTREAM)/kuttl/releases/download/v$(KUTTL_VERSION)/kubectl-kuttl_$(KUTTL_VERSION)_$(OS)_$${ARCH} ;\
 	$(GET_GITHUB_RELEASE_FN); \
 	get_github_release $(KUTTL) $${KUTTL_URL}

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -159,6 +159,7 @@ everything: build bundle ## Build everything (local binary, operator image, bund
 	$(MAKE) docker-push-index
 
 ##@ Dependencies download
+include $(PROJECT_DIR)/../make/github.mk
 
 CONTROLLER_GEN_VERSION = 0.10.0
 CONTROLLER_GEN = $(PROJECT_DIR)/bin/controller-gen-$(CONTROLLER_GEN_VERSION)
@@ -196,20 +197,6 @@ ENVTEST = $(PROJECT_DIR)/bin/setup-envtest
 .PHONY: envtest
 envtest: ## Download envtest-setup locally if necessary.
 	$(call go-get-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@latest)
-
-GET_GITHUB_RELEASE_FN = get_github_release() { \
-	[ -x $${1} ] || { \
-		set -euxo pipefail ;\
-		mkdir -p bin ;\
-		attempts=5 ;\
-		for i in $$(seq $$attempts); do \
-			curl --fail --location --output $${1} $${2} && break ;\
-			[ $$i -eq $$attempts ] && exit 1; \
-		done ;\
-		[[ "$$(uname -s)" != "Darwin" ]] || xattr -c $${1} ;\
-		chmod +x $${1} ;\
-	} \
-}
 
 # go-get-tool will 'go get -d' any package $2 and install it to $(PROJECT_DIR)/bin unless $1 already exists.
 define go-get-tool


### PR DESCRIPTION
## Description

Rather than invoke a silent `wget` once, reuse a macro that calls `curl` with retries, that already works for the operator  build.

While at it, I also fixed a broken clean target and improved portability a bit.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

I ran the relevant targets manually twice after cleaning the files. Otherwise relying on CI.