### PR TITLE
ROX-14177: Retry `go mod download`.

### DIFF
--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -25,7 +25,8 @@ COPY go.sum go.sum
 # However it does _not_ seem to resolve packages _incorrectly_ and so should be safe especially given that downloaded
 # packages are only used during build and later this docker layer is discarded (only resulting binary goes in the final
 # image).
-RUN go mod download
+# Retry as the proxy can be unavailable at times.
+RUN go mod download || go mod download || go mod download
 
 # Copy operator source
 COPY operator/ operator/


### PR DESCRIPTION
## Description

Apparently it can fail sometimes due to go proxy unavailability, see parent of the ticket.

Ideally we could just reuse the cached modules inside the container, but that will be a more involved change, if it's at all possible.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

Relying on CI.