### PR TITLE
Remove hardcoded Postgres minor version

### DIFF
--- a/.openshift-ci/build/build-main-and-bundle.sh
+++ b/.openshift-ci/build/build-main-and-bundle.sh
@@ -97,7 +97,7 @@ create_main_bundle_and_scripts() {
     fi
 
     DEBUG_BUILD="${DEBUG_BUILD}" \
-       "$ROOT/image/rhel/create-bundle.sh" image "local" "local" image/rhel
+       "$ROOT/image/rhel/create-bundle.sh" image "local" "local" image/rhel "true"
 }
 
 cleanup_image() {

--- a/image/rhel/create-bundle.sh
+++ b/image/rhel/create-bundle.sh
@@ -34,6 +34,8 @@ INPUT_ROOT="$1"
 DATA_IMAGE="$2"
 BUILDER_IMAGE="$3"
 OUTPUT_DIR="$4"
+# Install the PG repo natively if true (versus using a container)
+NATIVE_PG_INSTALL="${5:-false}"
 
 [[ -n "$INPUT_ROOT" && -n "$DATA_IMAGE" && -n "$BUILDER_IMAGE" && -n "$OUTPUT_DIR" ]] \
     || die "Usage: $0 <input-root-directory> <enc-data-image> <builder-image> <output-directory>"
@@ -132,14 +134,20 @@ postgres_url="https://download.postgresql.org/pub/repos/yum/${postgres_major}/re
 postgres_repo_url="https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-${arch}/pgdg-redhat-repo-latest.noarch.rpm"
 
 # Determine the Postgres minor version
-build_dir="$(mktemp -d)"
-docker build -q -t postgres-minor-image "${build_dir}" -f - <<EOF
+if [[ "${NATIVE_PG_INSTALL}" == "true" ]]; then
+    dnf install --disablerepo='*' -y "${postgres_repo_url}"
+    postgres_minor="$(dnf list --disablerepo='*' --enablerepo=pgdg${postgres_major} -y "postgresql${postgres_major}-devel.${arch}" | tail -n 1 | awk '{print $2}').${arch}"
+    echo "PG minor version: ${postgres_minor}"
+else
+    build_dir="$(mktemp -d)"
+    docker build -q -t postgres-minor-image "${build_dir}" -f - <<EOF
 FROM registry.access.redhat.com/ubi8/ubi:${pg_rhel_version}
 RUN dnf install --disablerepo='*' -y "${postgres_repo_url}"
 ENTRYPOINT dnf list ${dnf_list_args[@]+"${dnf_list_args[@]}"} --disablerepo='*' --enablerepo=pgdg${postgres_major} -y postgresql${postgres_major}-server.$arch | tail -n 1 | awk '{print \$2}'
 EOF
-postgres_minor="$(docker run --rm postgres-minor-image).${arch}"
-rm -rf "${build_dir}"
+    postgres_minor="$(docker run --rm postgres-minor-image).${arch}"
+    rm -rf "${build_dir}"
+fi
 
 curl -sS --fail -o "${bundle_root}/postgres.rpm" \
     "${postgres_url}/postgresql${postgres_major}-${postgres_minor}.rpm"

--- a/image/rhel/create-bundle.sh
+++ b/image/rhel/create-bundle.sh
@@ -126,8 +126,20 @@ curl -s -f -o "${bundle_root}/snappy.rpm" "${rpm_base_url}/snappy-1.1.8-3.${rpm_
 # Get postgres RPMs directly
 postgres_major="13"
 pg_rhel_major="8"
+pg_rhel_minor="6"
+pg_rhel_version="${pg_rhel_major}.${pg_rhel_minor}"
 postgres_url="https://download.postgresql.org/pub/repos/yum/${postgres_major}/redhat/rhel-${pg_rhel_major}-${arch}"
-postgres_minor="13.8-1PGDG.rhel8.${arch}"
+postgres_repo_url="https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-${arch}/pgdg-redhat-repo-latest.noarch.rpm"
+
+# Determine the Postgres minor version
+build_dir="$(mktemp -d)"
+docker build -q -t postgres-minor-image "${build_dir}" -f - <<EOF
+FROM registry.access.redhat.com/ubi8/ubi:${pg_rhel_version}
+RUN dnf install --disablerepo='*' -y "${postgres_repo_url}"
+ENTRYPOINT dnf list ${dnf_list_args[@]+"${dnf_list_args[@]}"} --disablerepo='*' --enablerepo=pgdg${postgres_major} -y postgresql${postgres_major}-server.$arch | tail -n 1 | awk '{print \$2}'
+EOF
+postgres_minor="$(docker run --rm postgres-minor-image).${arch}"
+rm -rf "${build_dir}"
 
 curl -sS --fail -o "${bundle_root}/postgres.rpm" \
     "${postgres_url}/postgresql${postgres_major}-${postgres_minor}.rpm"


### PR DESCRIPTION
## Description

The Postgres minor version that is hardcoded in `image/rhel/create-bundle.sh` is not guaranteed to exist. For example, for `arm64` architectures, the file does not exist anymore.

The minor version is actually determined programmatically in `image/postgres/create-bundle.sh`, so I used the same approach here.

## Checklist
- [ ] Investigated and inspected CI test results
~~- [ ] Unit test and regression tests added~~
~~- [ ] Evaluated and added CHANGELOG entry if required~~
~~- [ ] Determined and documented upgrade steps~~
~~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

I used `make image` to check that build works on `arm64`. CI should test that it works on `amd64`.
