### PR TITLE
Return early when Namespace is nil

### DIFF
--- a/compliance/collection/nodeinventorizer/nodeinventory.go
+++ b/compliance/collection/nodeinventorizer/nodeinventory.go
@@ -32,6 +32,10 @@ func (n *NodeInventoryCollector) Scan(nodeName string) (*storage.NodeInventory, 
 
 	protoComponents := protoComponentsFromScanComponents(componentsHost)
 
+	if protoComponents == nil {
+		log.Warn("Empty components returned from NodeInventory")
+	}
+
 	m := &storage.NodeInventory{
 		NodeName:   nodeName,
 		ScanTime:   timestamp.TimestampNow(),
@@ -42,7 +46,7 @@ func (n *NodeInventoryCollector) Scan(nodeName string) (*storage.NodeInventory, 
 
 func protoComponentsFromScanComponents(c *nodes.Components) *scannerV1.Components {
 
-	if c == nil {
+	if c == nil || c.OSNamespace == nil {
 		return nil
 	}
 


### PR DESCRIPTION
Quick fix for situations where RHCOS Nodescanning is activated through the feature flag but ACS is running on non-RHCOS nodes.
This currently leads to nil pointer exceptions, which need to be fixed.


Testing performed:
- Tested on local colima
- Verified correct operation on OS4 cluster (still produces valid inventory messages)