### PR TITLE
Add e2e tests for Collection permissions

### DIFF
--- a/ui/apps/platform/cypress/integration/collections/Collections.selectors.js
+++ b/ui/apps/platform/cypress/integration/collections/Collections.selectors.js
@@ -27,6 +27,7 @@ const resultsPanelFilterEntitySelectOption = (entity) =>
 const resultsPanelFilterInput = `${resultsPanel} input[aria-label="Filter by name"]`;
 
 export const collectionSelectors = {
+    tableLinkByName: (name) => `td[data-label="Collection"] a:contains("${name}")`,
     modal: '*[role="dialog"]',
     modalClose: '*[role="dialog"] button[aria-label="Close"]',
     resultsPanel,

--- a/ui/apps/platform/cypress/integration/collections/permissions.test.js
+++ b/ui/apps/platform/cypress/integration/collections/permissions.test.js
@@ -69,7 +69,7 @@ describe('Collection permission checks', () => {
         cy.get(`button:contains("Save")`).should('not.exist');
     });
 
-    it('should not provide the full UI to users with read-write access', () => {
+    it('should provide the full UI to users with read-write access', () => {
         // Mock a 'READ_WRITE_ACCESS' permission response
         visitWithStaticResponseForPermissions('/main', {
             body: { resourceToAccess: { WorkflowAdministration: 'READ_WRITE_ACCESS' } },

--- a/ui/apps/platform/cypress/integration/collections/permissions.test.js
+++ b/ui/apps/platform/cypress/integration/collections/permissions.test.js
@@ -1,0 +1,116 @@
+import withAuth from '../../helpers/basicAuth';
+import { hasFeatureFlag } from '../../helpers/features';
+import { visit, visitWithStaticResponseForPermissions } from '../../helpers/visit';
+import navSelectors from '../../selectors/navigation';
+import { tryDeleteCollection, visitCollections } from './Collections.helpers';
+import { collectionSelectors } from './Collections.selectors';
+
+// Quick utility to create a basic collection for permission testing
+function createCollection(name) {
+    // Ignore autocomplete requests
+    // TODO Remove this once the feature is in
+    cy.intercept('/v1/collections/autocomplete', {});
+    localStorage.setItem('access_token', Cypress.env('ROX_AUTH_TOKEN'));
+    tryDeleteCollection(name);
+    visitCollections();
+    cy.get('a:contains("Create collection")').click();
+    cy.get('input[name="name"]').type(name);
+    cy.get('input[name="description"]').type('A collection for permission testing purposes');
+    cy.get('button:contains("All namespaces")').click();
+    cy.get('button:contains("Namespaces with names matching")').click();
+    cy.get('input[aria-label="Select value 1 of 1 for the namespace name"]').type('stackrox');
+    cy.get(`button:contains('stackrox')`).click();
+    cy.get('button:contains("Save")').click();
+}
+
+describe('Collection permission checks', () => {
+    withAuth();
+
+    const collectionName = 'Permission test collection';
+
+    beforeEach(function beforeHook() {
+        if (!hasFeatureFlag('ROX_OBJECT_COLLECTIONS')) {
+            this.skip();
+        }
+    });
+
+    // Ensure a collection exists in the system for permission tests
+    if (hasFeatureFlag('ROX_OBJECT_COLLECTIONS')) {
+        before(() => createCollection(collectionName));
+        after(() => tryDeleteCollection(collectionName));
+    }
+
+    it('should prevent users with no access from viewing collections', () => {
+        // Mock a 'NO_ACCESS' permission response
+        visitWithStaticResponseForPermissions('/main', {
+            body: { resourceToAccess: { WorkflowAdministration: 'NO_ACCESS' } },
+        });
+        // Expand the Platform Config section for ease of debugging
+        cy.get(`${navSelectors.navExpandable}:contains("Platform Configuration")`).click();
+        cy.get(`${navSelectors.nestedNavLinks}:contains("Collections")`).should('not.exist');
+
+        // Test direct visit via URL
+        visit('/main/collections');
+        // The Collections header should not be present, and a not found 404 message will be displayed
+        cy.get('h1:contains("Collections")').should('not.exist');
+        cy.get('h4:contains("cannot be found")');
+    });
+
+    it('should not provide mutable UI controls to users with read-only access', () => {
+        // Mock a 'READ_ACCESS' permission response
+        visitWithStaticResponseForPermissions('/main', {
+            body: { resourceToAccess: { WorkflowAdministration: 'READ_ACCESS' } },
+        });
+        // Ensure the collections link is visible and takes the user to the collections table
+        cy.get(`${navSelectors.navExpandable}:contains("Platform Configuration")`).click();
+        cy.get(`${navSelectors.nestedNavLinks}:contains("Collections")`).click();
+
+        cy.get('h1:contains("Collections")');
+        // Ensure the 'Create collection' button does not exist
+        cy.get('*:contains("Create collection")').should('not.exist');
+
+        const linkSelector = collectionSelectors.tableLinkByName(collectionName);
+        // Check existence of row before negative assertion
+        cy.get(`tr:has(${linkSelector})`);
+        // Ensure table rows do not have an action menu
+        cy.get(`tr:has(${linkSelector}) button[aria-label="Actions"]`).should('not.exist');
+        // Visit page for individual collection and verify action button is not present
+        cy.get(linkSelector).click();
+        cy.get(`h1:contains("${collectionName}")`);
+        cy.get(`button:contains("Actions")`).should('not.exist');
+        cy.get(`button:contains("Save")`).should('not.exist');
+    });
+
+    it('should not provide the full UI to users with read-write access', () => {
+        // Mock a 'READ_WRITE_ACCESS' permission response
+        visitWithStaticResponseForPermissions('/main', {
+            body: { resourceToAccess: { WorkflowAdministration: 'READ_WRITE_ACCESS' } },
+        });
+        // Ensure the collections link is visible and takes the user to the collections table
+        cy.get(`${navSelectors.navExpandable}:contains("Platform Configuration")`).click();
+        cy.get(`${navSelectors.nestedNavLinks}:contains("Collections")`).click();
+
+        cy.get('h1:contains("Collections")');
+        // Ensure the 'Create collection' button is visible
+        cy.get('*:contains("Create collection")');
+
+        const linkSelector = collectionSelectors.tableLinkByName(collectionName);
+        // Ensure that menu options in table rows are available
+        cy.get(`tr:has(${linkSelector}) button[aria-label="Actions"]`).click();
+        cy.get(`tr:has(${linkSelector}) button:contains("Edit collection")`);
+        cy.get(`tr:has(${linkSelector}) button:contains("Clone collection")`);
+        cy.get(`tr:has(${linkSelector}) button:contains("Delete collection")`);
+
+        // Visit page for individual collection and verify action button is present
+        cy.get(linkSelector).click();
+        cy.get(`h1:contains("${collectionName}")`);
+        cy.get(`button:contains("Actions")`).click();
+        cy.get(`ul[role="menu"] button:contains("Edit collection")`);
+        cy.get(`ul[role="menu"] button:contains("Clone collection")`);
+        cy.get(`ul[role="menu"] button:contains("Delete collection")`);
+
+        // Enter edit mode and verify "save" button is present
+        cy.get(`ul[role="menu"] button:contains("Edit collection")`).click();
+        cy.get(`button:contains("Save")`);
+    });
+});


### PR DESCRIPTION
## Description

Adds tests to check the behavior of a user having `NO_ACCESS`, `READ_ACCESS`, or `READ_WRITE_ACCESS` on the `WorkflowAdministration` permission as it pertains to rendering the Collections UI.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Local Cypress test run.
<img width="1334" alt="image" src="https://user-images.githubusercontent.com/1292638/211033202-a8747702-b1be-41d0-9986-d724963eb324.png">

