### PR TITLE
Remove collection inUse flag from UI

### DIFF
--- a/ui/apps/platform/cypress/integration/collections/collectionsTable.test.js
+++ b/ui/apps/platform/cypress/integration/collections/collectionsTable.test.js
@@ -46,7 +46,6 @@ describe('Collections table', () => {
 
         cy.get('th:contains("Collection")');
         cy.get('th:contains("Description")');
-        cy.get('th:contains("In use")');
     });
 
     it('should have button to create collection if role has READ_WRITE_ACCESS', () => {

--- a/ui/apps/platform/src/Containers/Collections/CollectionsFormPage.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionsFormPage.tsx
@@ -31,6 +31,7 @@ import useSelectToggle from 'hooks/patternfly/useSelectToggle';
 import ConfirmationModal from 'Components/PatternFly/ConfirmationModal';
 import useToasts from 'hooks/patternfly/useToasts';
 import PageTitle from 'Components/PageTitle';
+import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import { CollectionPageAction } from './collections.utils';
 import CollectionFormDrawer, { CollectionFormDrawerProps } from './CollectionFormDrawer';
 import useCollection from './hooks/useCollection';
@@ -111,10 +112,11 @@ function CollectionsFormPage({
         deleteCollection(deleteId)
             .request.then(history.goBack)
             .catch((err) => {
+                const message = getAxiosErrorMessage(err);
                 addToast(
                     `Could not delete collection ${data?.collection?.name ?? ''}`,
                     'danger',
-                    err.message
+                    message
                 );
             })
             .finally(() => {
@@ -268,14 +270,11 @@ function CollectionsFormPage({
                                                 <DropdownItem
                                                     key="Delete collection"
                                                     component="button"
-                                                    isDisabled={data.collection.inUse}
                                                     onClick={() =>
                                                         setDeleteId(pageAction.collectionId)
                                                     }
                                                 >
-                                                    {data.collection.inUse
-                                                        ? 'Cannot delete (in use)'
-                                                        : 'Delete collection'}
+                                                    Delete collection
                                                 </DropdownItem>,
                                             ]}
                                         />

--- a/ui/apps/platform/src/Containers/Collections/CollectionsTable.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionsTable.tsx
@@ -132,17 +132,10 @@ function CollectionsTable({
             <TableComposable variant={TableVariant.compact}>
                 <Thead>
                     <Tr>
-                        <Th
-                            modifier="wrap"
-                            width={25}
-                            sort={getEnabledSortParams('Collection Name')}
-                        >
+                        <Th modifier="wrap" sort={getEnabledSortParams('Collection Name')}>
                             Collection
                         </Th>
                         <Th modifier="wrap">Description</Th>
-                        <Th modifier="wrap" width={10}>
-                            In use
-                        </Th>
                         <Th aria-label="Row actions" />
                     </Tr>
                 </Thead>
@@ -166,7 +159,7 @@ function CollectionsTable({
                         </Tr>
                     )}
                     {collections.map((collection) => {
-                        const { id, name, description, inUse } = collection;
+                        const { id, name, description } = collection;
                         const actionItems = [
                             {
                                 title: 'Edit collection',
@@ -180,9 +173,8 @@ function CollectionsTable({
                                 isSeparator: true,
                             },
                             {
-                                title: inUse ? 'Cannot delete (in use)' : 'Delete collection',
+                                title: 'Delete collection',
                                 onClick: () => setCollectionToDelete(collection),
-                                isDisabled: inUse,
                             },
                         ];
 
@@ -201,7 +193,6 @@ function CollectionsTable({
                                 <Td dataLabel="Description">
                                     <Truncate content={description || '-'} tooltipPosition="top" />
                                 </Td>
-                                <Td dataLabel="In Use">{inUse ? 'Yes' : 'No'}</Td>
                                 {hasWriteAccess && <Td actions={{ items: actionItems }} />}
                             </Tr>
                         );

--- a/ui/apps/platform/src/Containers/Collections/RuleSelector/RuleSelector.test.tsx
+++ b/ui/apps/platform/src/Containers/Collections/RuleSelector/RuleSelector.test.tsx
@@ -28,7 +28,6 @@ function DeploymentRuleSelector({ defaultSelector, onChange }) {
             collection={{
                 name: '',
                 description: '',
-                inUse: false,
                 resourceSelector: {
                     Deployment: { type: 'All' },
                     Namespace: { type: 'All' },

--- a/ui/apps/platform/src/Containers/Collections/converter.test.ts
+++ b/ui/apps/platform/src/Containers/Collections/converter.test.ts
@@ -8,7 +8,6 @@ describe('Collection parser', () => {
             id: 'a-b-c',
             name: 'Sample',
             description: 'Sample description',
-            inUse: false,
             resourceSelectors: [
                 {
                     rules: [
@@ -38,7 +37,6 @@ describe('Collection parser', () => {
         const expectedCollection: ClientCollection = {
             name: 'Sample',
             description: 'Sample description',
-            inUse: false,
             resourceSelector: {
                 Deployment: { type: 'All' },
                 Namespace: {
@@ -83,7 +81,6 @@ describe('Collection parser', () => {
             id: 'a-b-c',
             name: 'Sample',
             description: 'Sample description',
-            inUse: false,
             resourceSelectors: [{ rules: [] }, { rules: [] }],
             embeddedCollections: [],
         };
@@ -95,7 +92,6 @@ describe('Collection parser', () => {
             id: 'a-b-c',
             name: 'Sample',
             description: 'Sample description',
-            inUse: false,
             resourceSelectors: [
                 {
                     rules: [
@@ -123,7 +119,6 @@ describe('Collection parser', () => {
             id: 'a-b-c',
             name: 'Sample',
             description: 'Sample description',
-            inUse: false,
             resourceSelectors: [
                 {
                     rules: [
@@ -146,7 +141,6 @@ describe('Collection parser', () => {
             id: 'a-b-c',
             name: 'Sample',
             description: 'Sample description',
-            inUse: false,
             resourceSelectors: [
                 {
                     rules: [
@@ -169,7 +163,6 @@ describe('Collection parser', () => {
             id: 'a-b-c',
             name: 'Sample',
             description: 'Sample description',
-            inUse: false,
             resourceSelectors: [
                 {
                     rules: [
@@ -223,7 +216,6 @@ describe('Collection response generator', () => {
         const collection: ClientCollection = {
             name: 'Sample',
             description: 'Sample description',
-            inUse: false,
             resourceSelector: {
                 // "All" should result in no rules
                 Deployment: { type: 'All' },

--- a/ui/apps/platform/src/Containers/Collections/converter.ts
+++ b/ui/apps/platform/src/Containers/Collections/converter.ts
@@ -51,7 +51,6 @@ export function parseCollection(
     const collection: ClientCollection = {
         name: data.name,
         description: data.description,
-        inUse: data.inUse,
         embeddedCollectionIds: data.embeddedCollections.map(({ id }) => id),
         resourceSelector: {
             Deployment: { type: 'All' },

--- a/ui/apps/platform/src/Containers/Collections/hooks/useCollection.ts
+++ b/ui/apps/platform/src/Containers/Collections/hooks/useCollection.ts
@@ -11,7 +11,6 @@ import {
 const defaultCollectionData: Omit<Collection, 'id'> = {
     name: '',
     description: '',
-    inUse: false,
     embeddedCollections: [],
     resourceSelectors: [],
 };

--- a/ui/apps/platform/src/Containers/Collections/types.ts
+++ b/ui/apps/platform/src/Containers/Collections/types.ts
@@ -81,7 +81,6 @@ export type ClientCollection = {
     id?: string;
     name: string;
     description: string;
-    inUse: boolean;
     resourceSelector: Record<SelectorEntityType, ScopedResourceSelector>;
     embeddedCollectionIds: string[];
 };

--- a/ui/apps/platform/src/services/CollectionsService.ts
+++ b/ui/apps/platform/src/services/CollectionsService.ts
@@ -33,7 +33,6 @@ export type Collection = {
     id: string;
     name: string;
     description: string;
-    inUse: boolean;
     resourceSelectors: ResourceSelector[];
     embeddedCollections: { id: string }[];
 };


### PR DESCRIPTION
## Description

Removes the `inUse` flag from the FE collection type and from the collection table. This will not be implemented for MVP.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Visit the collection table page and verify that the "in use" column is not present.
![image](https://user-images.githubusercontent.com/1292638/210583054-0271817c-08de-46f2-98a2-f5992152ac39.png)

Create a collection, and add another collection to is as an embedded collection. Then, attempt to delete the embedded collection and verify that an error is displayed in the UI. (Better error message needed in https://issues.redhat.com/browse/ROX-14061.)
![image](https://user-images.githubusercontent.com/1292638/210583294-a9036bb4-6834-40a5-83b9-9fe7fec4556d.png)
![image](https://user-images.githubusercontent.com/1292638/210583756-269a52f3-4536-410a-8286-0028a4a74334.png)

