### PR TITLE
ROX-13936: Introduce ID for RHELComponents

### DIFF
--- a/compliance/collection/nodeinventorizer/nodeinventory.go
+++ b/compliance/collection/nodeinventorizer/nodeinventory.go
@@ -92,8 +92,5 @@ func convertAndDedupRHELComponents(rc *database.RHELv2Components) []*scannerV1.R
 }
 
 func makeComponentKey(component *scannerV1.RHELComponent) string {
-	if component == nil {
-		return ""
-	}
 	return component.Name + ":" + component.Version + ":" + component.Arch + ":" + component.Module
 }

--- a/compliance/collection/nodeinventorizer/nodeinventory.go
+++ b/compliance/collection/nodeinventorizer/nodeinventory.go
@@ -65,13 +65,13 @@ func convertRHELComponents(rc *database.RHELv2Components) []*scannerV1.RHELCompo
 	}
 	v1rhelc := make([]*scannerV1.RHELComponent, 0, len(rc.Packages))
 	for _, rhelc := range rc.Packages {
-		rhelcId, err := hashstructure.Hash(rhelc, hashstructure.FormatV2, nil)
+		rhelcID, err := hashstructure.Hash(rhelc, hashstructure.FormatV2, nil)
 		if err != nil {
-			log.Warnf("Could not create id for RHELComponent %d", rhelc.Name)
-			rhelcId = 0
+			log.Warnf("Could not create id for RHELComponent %q", rhelc.Name)
+			rhelcID = 0
 		}
 		v1rhelc = append(v1rhelc, &scannerV1.RHELComponent{
-			Id:          int64(rhelcId),
+			Id:          int64(rhelcID),
 			Name:        rhelc.Name,
 			Namespace:   rc.Dist,
 			Version:     rhelc.Version,

--- a/compliance/collection/nodeinventorizer/nodeinventory.go
+++ b/compliance/collection/nodeinventorizer/nodeinventory.go
@@ -95,5 +95,5 @@ func makeComponentKey(component *scannerV1.RHELComponent) string {
 	if component == nil {
 		return ""
 	}
-	return component.Name +":"+  component.Version +":"+ component.Arch +":"+ component.Module
+	return component.Name + ":" + component.Version + ":" + component.Arch + ":" + component.Module
 }

--- a/compliance/collection/nodeinventorizer/nodeinventory.go
+++ b/compliance/collection/nodeinventorizer/nodeinventory.go
@@ -2,6 +2,7 @@ package nodeinventorizer
 
 import (
 	timestamp "github.com/gogo/protobuf/types"
+	"github.com/mitchellh/hashstructure/v2"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/scanner/database"
 	scannerV1 "github.com/stackrox/scanner/generated/scanner/api/v1"
@@ -65,8 +66,13 @@ func convertRHELComponents(rc *database.RHELv2Components) []*scannerV1.RHELCompo
 	}
 	v1rhelc := make([]*scannerV1.RHELComponent, 0, len(rc.Packages))
 	for _, rhelc := range rc.Packages {
+		rhelcId, err := hashstructure.Hash(v1rhelc, hashstructure.FormatV2, nil)
+		if err != nil {
+			log.Warnf("Could not create id for RHELComponent %d", rhelc.Name)
+			rhelcId = 0
+		}
 		v1rhelc = append(v1rhelc, &scannerV1.RHELComponent{
-			// TODO(ROX-13936): Find out if ID field is needed here
+			Id:          int64(rhelcId),
 			Name:        rhelc.Name,
 			Namespace:   rc.Dist,
 			Version:     rhelc.Version,

--- a/compliance/collection/nodeinventorizer/nodeinventory.go
+++ b/compliance/collection/nodeinventorizer/nodeinventory.go
@@ -42,7 +42,6 @@ func (n *NodeInventoryCollector) Scan(nodeName string) (*storage.NodeInventory, 
 }
 
 func protoComponentsFromScanComponents(c *nodes.Components) *scannerV1.Components {
-
 	if c == nil {
 		return nil
 	}
@@ -66,7 +65,7 @@ func convertRHELComponents(rc *database.RHELv2Components) []*scannerV1.RHELCompo
 	}
 	v1rhelc := make([]*scannerV1.RHELComponent, 0, len(rc.Packages))
 	for _, rhelc := range rc.Packages {
-		rhelcId, err := hashstructure.Hash(v1rhelc, hashstructure.FormatV2, nil)
+		rhelcId, err := hashstructure.Hash(rhelc, hashstructure.FormatV2, nil)
 		if err != nil {
 			log.Warnf("Could not create id for RHELComponent %d", rhelc.Name)
 			rhelcId = 0

--- a/compliance/collection/nodeinventorizer/nodeinventory.go
+++ b/compliance/collection/nodeinventorizer/nodeinventory.go
@@ -83,7 +83,7 @@ func convertAndDedupRHELComponents(rc *database.RHELv2Components) []*scannerV1.R
 				log.Debugf("Adding component %v to convertedComponents", comp.Name)
 				convertedComponents[compKey] = comp
 			} else {
-				log.Warnf("Detected package collision in Node Inventory scan. Skipping package %v at index %v", comp, i)
+				log.Warnf("Detected package collision in Node Inventory scan. Skipping package %s at index %d", compKey, i)
 			}
 		}
 

--- a/compliance/collection/nodeinventorizer/nodeinventory.go
+++ b/compliance/collection/nodeinventorizer/nodeinventory.go
@@ -95,5 +95,5 @@ func makeComponentKey(component *scannerV1.RHELComponent) string {
 	if component == nil {
 		return ""
 	}
-	return component.Name + component.Version + component.Arch + component.Module
+	return component.Name +":"+  component.Version +":"+ component.Arch +":"+ component.Module
 }

--- a/compliance/collection/nodeinventorizer/nodeinventory_test.go
+++ b/compliance/collection/nodeinventorizer/nodeinventory_test.go
@@ -18,11 +18,13 @@ type NodeInventorizerTestSuite struct {
 
 func (s *NodeInventorizerTestSuite) TestConvertRHELComponentIDs() {
 	testCases := map[string]struct {
-		inComponents []*database.RHELv2Package
-		expectedLen  int
+		inComponents  []*database.RHELv2Package
+		outComponents []*scannerV1.RHELComponent
+		expectedLen   int
 	}{
 		"nil-inComponents": {
-			inComponents: nil,
+			inComponents:  nil,
+			outComponents: make([]*scannerV1.RHELComponent, 0),
 		},
 		"one-component": {
 			inComponents: []*database.RHELv2Package{
@@ -34,6 +36,15 @@ func (s *NodeInventorizerTestSuite) TestConvertRHELComponentIDs() {
 						"/usr/lib64/libz.so.1":      {},
 						"/usr/lib64/libz.so.1.2.11": {},
 					},
+				},
+			},
+			outComponents: []*scannerV1.RHELComponent{
+				{
+					Id:        0,
+					Name:      "zlib",
+					Namespace: "MockDist",
+					Version:   "1.2.11-16.el8_2",
+					Arch:      "x86_64",
 				},
 			},
 			expectedLen: 1,
@@ -55,6 +66,22 @@ func (s *NodeInventorizerTestSuite) TestConvertRHELComponentIDs() {
 					Arch:    "x86_64",
 				},
 			},
+			outComponents: []*scannerV1.RHELComponent{
+				{
+					Id:        0,
+					Name:      "zlib",
+					Namespace: "MockDist",
+					Version:   "1.2.11-16.el8_2",
+					Arch:      "x86_64",
+				},
+				{
+					Id:        1,
+					Name:      "redhat-release",
+					Namespace: "MockDist",
+					Version:   "8.3-1.0.el8",
+					Arch:      "x86_64",
+				},
+			},
 			expectedLen: 2,
 		},
 		"collision-component": {
@@ -70,6 +97,15 @@ func (s *NodeInventorizerTestSuite) TestConvertRHELComponentIDs() {
 					Arch:    "x86_64",
 				},
 			},
+			outComponents: []*scannerV1.RHELComponent{
+				{
+					Id:        0,
+					Name:      "redhat-release",
+					Namespace: "MockDist",
+					Version:   "8.3-1.0.el8",
+					Arch:      "x86_64",
+				},
+			},
 			expectedLen: 1,
 		},
 	}
@@ -83,6 +119,7 @@ func (s *NodeInventorizerTestSuite) TestConvertRHELComponentIDs() {
 			convertedComponents := convertAndDedupRHELComponents(mockComponents)
 			if testCase.inComponents != nil {
 				s.Equal(testCase.expectedLen, len(convertedComponents))
+				s.ElementsMatch(testCase.outComponents, convertedComponents)
 			} else {
 				s.Nil(convertedComponents)
 			}

--- a/compliance/collection/nodeinventorizer/nodeinventory_test.go
+++ b/compliance/collection/nodeinventorizer/nodeinventory_test.go
@@ -25,6 +25,20 @@ func (s *NodeInventorizerTestSuite) TestConvertRHELComponentIDs() {
 		"nil-inComponents": {
 			inComponents: nil,
 		},
+		"one-component": {
+			inComponents: []*database.RHELv2Package{
+				{
+					Name:    "zlib",
+					Version: "1.2.11-16.el8_2",
+					Arch:    "x86_64",
+					ExecutableToDependencies: database.StringToStringsMap{
+						"/usr/lib64/libz.so.1":      {},
+						"/usr/lib64/libz.so.1.2.11": {},
+					},
+				},
+			},
+			expectedLen: 1,
+		},
 		"multi-component": {
 			inComponents: []*database.RHELv2Package{
 				{

--- a/compliance/collection/nodeinventorizer/nodeinventory_test.go
+++ b/compliance/collection/nodeinventorizer/nodeinventory_test.go
@@ -161,10 +161,6 @@ func (s *NodeInventorizerTestSuite) TestMakeComponentKey() {
 			},
 			expected: "日本語:1.2.3:x42:Mod",
 		},
-		"Nil component": {
-			component: nil,
-			expected:  "",
-		},
 	}
 
 	for testName, testCase := range testcases {

--- a/compliance/collection/nodeinventorizer/nodeinventory_test.go
+++ b/compliance/collection/nodeinventorizer/nodeinventory_test.go
@@ -140,7 +140,7 @@ func (s *NodeInventorizerTestSuite) TestMakeComponentKey() {
 				Arch:    "x42",
 				Module:  "Mod",
 			},
-			expected: "Name1.2.3x42Mod",
+			expected: "Name:1.2.3:x42:Mod",
 		},
 		"Missing part": {
 			component: &scannerV1.RHELComponent{
@@ -149,7 +149,7 @@ func (s *NodeInventorizerTestSuite) TestMakeComponentKey() {
 				Arch:    "x42",
 				Module:  "Mod",
 			},
-			expected: "1.2.3x42Mod",
+			expected: ":1.2.3:x42:Mod",
 		},
 		"Internationalized": {
 			component: &scannerV1.RHELComponent{
@@ -159,7 +159,7 @@ func (s *NodeInventorizerTestSuite) TestMakeComponentKey() {
 				Arch:    "x42",
 				Module:  "Mod",
 			},
-			expected: "日本語1.2.3x42Mod",
+			expected: "日本語:1.2.3:x42:Mod",
 		},
 		"Nil component": {
 			component: nil,


### PR DESCRIPTION
## Description

This PR introduces an ID for RHELComponent conversions in Node Inventories.
As described in ROX-13936, a unique ID is needed for all components to be correctly displayed.

`ID`s only need to be unique per `Node` (and therefore, per `NodeInventory`).
Packages are generally identified by the unique tuple `(Name, Version, Arch, Module)` in Scanner, whereas the ID is currently only used in [Scanners rhelv2_vulnerability.go](https://github.com/stackrox/scanner/blob/4aec14bf42567fc3a8972826b9537a444aae5e0d/database/pgsql/rhelv2_vulnerability.go#L211) to deduplicate a list of incoming packages.
Hence, I have introduced a local structure to check for duplicates locally by checking the component tuple before converting said component.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [x] Determined and documented upgrade steps
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~
