### PR TITLE
Temporarily disable failing image scanning tests

### DIFF
--- a/qa-tests-backend/src/test/groovy/ImageScanningTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageScanningTest.groovy
@@ -785,21 +785,22 @@ class ImageScanningTest extends BaseSpecification {
         where:
         testName                                           | integrationName  | scannerName |
                 imageIntegrationConfig
-        "quay registry with token"                         | "quay"           | "Stackrox Scanner" |
-                { -> QuayImageIntegration.createCustomIntegration(
-                        [oauthToken: Env.mustGet("QUAY_RHACS_ENG_BEARER_TOKEN"), includeScanner: false,]) }
+        // TODO ROX-14183: Re-enable the tests once QUAY_RHACS_ENG_BEARER_TOKEN holds a valid token.
+        //"quay registry with token"                         | "quay"           | "Stackrox Scanner" |
+        //        { -> QuayImageIntegration.createCustomIntegration(
+        //                [oauthToken: Env.mustGet("QUAY_RHACS_ENG_BEARER_TOKEN"), includeScanner: false,]) }
         "quay with robot creds only"                      | "quay"    |  "Stackrox Scanner" |
                 { -> QuayImageIntegration.createCustomIntegration(
                         [oauthToken: "", useRobotCreds: true, includeScanner: false,]) }
 
-        "quay registry+scanner with token"                  | "quay"   | "quay" |
-                { -> QuayImageIntegration.createCustomIntegration(
-                        [oauthToken: Env.mustGet("QUAY_RHACS_ENG_BEARER_TOKEN"), includeScanner: true,]) }
+        //"quay registry+scanner with token"                  | "quay"   | "quay" |
+        //        { -> QuayImageIntegration.createCustomIntegration(
+        //                [oauthToken: Env.mustGet("QUAY_RHACS_ENG_BEARER_TOKEN"), includeScanner: true,]) }
 
-        "quay registry+scanner with token and robot creds"  | "quay"   | "quay" |
-                { -> QuayImageIntegration.createCustomIntegration(
-                        [oauthToken: Env.mustGet("QUAY_RHACS_ENG_BEARER_TOKEN"), useRobotCreds: true,
-                         includeScanner: true,]) }
+        //"quay registry+scanner with token and robot creds"  | "quay"   | "quay" |
+        //        { -> QuayImageIntegration.createCustomIntegration(
+        //                [oauthToken: Env.mustGet("QUAY_RHACS_ENG_BEARER_TOKEN"), useRobotCreds: true,
+        //                 includeScanner: true,]) }
     }
 
     @SuppressWarnings('LineLength')


### PR DESCRIPTION
## Description

Disable the currently failing image scanning tests.

The tests fail due to the `QUAY_RHACS_ENG_BEARER_TOKEN` being invalid / not authorized to pull from `quay.io/rhacs-eng/qa`.

Once the issue [ROX-14183](https://issues.redhat.com/browse/ROX-14183) has been solved, the tests can be re-enabled once more.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

- see CI.