### PR TITLE
ROX-14181: Add default origin to default resources

### DIFF
--- a/central/role/datastore/datastore_impl.go
+++ b/central/role/datastore/datastore_impl.go
@@ -127,7 +127,6 @@ func (ds *dataStoreImpl) RemoveRole(ctx context.Context, name string) error {
 		return err
 	}
 
-	// Verify storage constraints
 	if err := ds.verifyRoleForDeletion(ctx, name); err != nil {
 		return err
 	}
@@ -456,7 +455,7 @@ func (ds *dataStoreImpl) verifyRoleReferencesExist(ctx context.Context, role *st
 
 // Returns errox.InvalidArgs if the given role is a default one.
 func verifyNotDefaultRole(role *storage.Role) error {
-	if rolePkg.IsDefaultRoleName(role) {
+	if rolePkg.IsDefaultRole(role) {
 		return errors.Wrapf(errox.InvalidArgs, "default role %q cannot be modified or deleted", role.GetName())
 	}
 	return nil
@@ -489,7 +488,7 @@ func (ds *dataStoreImpl) verifyPermissionSetIDDoesNotExist(ctx context.Context, 
 }
 
 // Returns errox.InvalidArgs if the given permission set is a default
-// one. Note that IsDefaultRoleName() is reused due to the name sameness.
+// one. Note that IsDefaultRole() is reused due to the name sameness.
 func verifyNotDefaultPermissionSet(permissionSet *storage.PermissionSet) error {
 	if rolePkg.IsDefaultPermissionSet(permissionSet) {
 		return errors.Wrapf(errox.InvalidArgs, "default permission set %q cannot be modified or deleted",

--- a/central/role/datastore/datastore_impl.go
+++ b/central/role/datastore/datastore_impl.go
@@ -77,7 +77,7 @@ func (ds *dataStoreImpl) AddRole(ctx context.Context, role *storage.Role) error 
 	if err := rolePkg.ValidateRole(role); err != nil {
 		return errors.Wrap(errox.InvalidArgs, err.Error())
 	}
-	if err := verifyNotDefaultRole(role.GetName()); err != nil {
+	if err := verifyNotDefaultRole(role); err != nil {
 		return err
 	}
 
@@ -103,7 +103,7 @@ func (ds *dataStoreImpl) UpdateRole(ctx context.Context, role *storage.Role) err
 	if err := rolePkg.ValidateRole(role); err != nil {
 		return errors.Wrap(errox.InvalidArgs, err.Error())
 	}
-	if err := verifyNotDefaultRole(role.GetName()); err != nil {
+	if err := verifyNotDefaultRole(role); err != nil {
 		return err
 	}
 
@@ -126,11 +126,17 @@ func (ds *dataStoreImpl) RemoveRole(ctx context.Context, name string) error {
 	if err := sac.VerifyAuthzOK(roleSAC.WriteAllowed(ctx)); err != nil {
 		return err
 	}
-	if err := verifyNotDefaultRole(name); err != nil {
-		return err
-	}
+
 	// Verify storage constraints.
 	if err := ds.verifyRoleNameExists(ctx, name); err != nil {
+		return err
+	}
+
+	role, _, err := ds.roleStorage.Get(ctx, name)
+	if err != nil {
+		return err
+	}
+	if err := verifyNotDefaultRole(role); err != nil {
 		return err
 	}
 
@@ -184,7 +190,7 @@ func (ds *dataStoreImpl) AddPermissionSet(ctx context.Context, permissionSet *st
 	if err := rolePkg.ValidatePermissionSet(permissionSet); err != nil {
 		return errors.Wrap(errox.InvalidArgs, err.Error())
 	}
-	if err := verifyNotDefaultPermissionSet(permissionSet.GetName()); err != nil {
+	if err := verifyNotDefaultPermissionSet(permissionSet); err != nil {
 		return err
 	}
 
@@ -212,7 +218,7 @@ func (ds *dataStoreImpl) UpdatePermissionSet(ctx context.Context, permissionSet 
 	if err := rolePkg.ValidatePermissionSet(permissionSet); err != nil {
 		return errors.Wrap(errox.InvalidArgs, err.Error())
 	}
-	if err := verifyNotDefaultPermissionSet(permissionSet.GetName()); err != nil {
+	if err := verifyNotDefaultPermissionSet(permissionSet); err != nil {
 		return err
 	}
 
@@ -248,7 +254,7 @@ func (ds *dataStoreImpl) RemovePermissionSet(ctx context.Context, id string) err
 	if !found {
 		return errors.Wrapf(errox.NotFound, "id = %s", id)
 	}
-	if err := verifyNotDefaultPermissionSet(permissionSet.GetName()); err != nil {
+	if err := verifyNotDefaultPermissionSet(permissionSet); err != nil {
 		return err
 	}
 
@@ -457,9 +463,9 @@ func (ds *dataStoreImpl) verifyRoleReferencesExist(ctx context.Context, role *st
 }
 
 // Returns errox.InvalidArgs if the given role is a default one.
-func verifyNotDefaultRole(name string) error {
-	if rolePkg.IsDefaultRoleName(name) {
-		return errors.Wrapf(errox.InvalidArgs, "default role %q cannot be modified or deleted", name)
+func verifyNotDefaultRole(role *storage.Role) error {
+	if rolePkg.IsDefaultRoleName(role) {
+		return errors.Wrapf(errox.InvalidArgs, "default role %q cannot be modified or deleted", role.GetName())
 	}
 	return nil
 }
@@ -492,9 +498,10 @@ func (ds *dataStoreImpl) verifyPermissionSetIDDoesNotExist(ctx context.Context, 
 
 // Returns errox.InvalidArgs if the given permission set is a default
 // one. Note that IsDefaultRoleName() is reused due to the name sameness.
-func verifyNotDefaultPermissionSet(name string) error {
-	if rolePkg.IsDefaultRoleName(name) {
-		return errors.Wrapf(errox.InvalidArgs, "default permission set %q cannot be modified or deleted", name)
+func verifyNotDefaultPermissionSet(permissionSet *storage.PermissionSet) error {
+	if rolePkg.IsDefaultPermissionSet(permissionSet) {
+		return errors.Wrapf(errox.InvalidArgs, "default permission set %q cannot be modified or deleted",
+			permissionSet.GetName())
 	}
 	return nil
 }
@@ -553,7 +560,7 @@ func (ds *dataStoreImpl) verifyRoleNameExists(ctx context.Context, name string) 
 
 // Returns errox.InvalidArgs if the given scope is a default one.
 func verifyNotDefaultAccessScope(scope *storage.SimpleAccessScope) error {
-	if rolePkg.IsDefaultAccessScope(scope.GetId()) {
+	if rolePkg.IsDefaultAccessScope(scope) {
 		return errors.Wrapf(errox.InvalidArgs, "default access scope %q cannot be modified or deleted", scope.GetName())
 	}
 	return nil

--- a/central/role/datastore/singleton.go
+++ b/central/role/datastore/singleton.go
@@ -175,6 +175,9 @@ func getDefaultObjects() ([]*storage.Role, []*storage.PermissionSet, []*storage.
 			Name:          roleName,
 			Description:   attributes.description,
 			AccessScopeId: rolePkg.AccessScopeIncludeAll.GetId(),
+			Traits: &storage.Traits{
+				Origin: storage.Traits_DEFAULT,
+			},
 		}
 
 		permissionSet := &storage.PermissionSet{
@@ -182,6 +185,9 @@ func getDefaultObjects() ([]*storage.Role, []*storage.PermissionSet, []*storage.
 			Name:             role.Name,
 			Description:      role.Description,
 			ResourceToAccess: resourceToAccess,
+			Traits: &storage.Traits{
+				Origin: storage.Traits_DEFAULT,
+			},
 		}
 		role.PermissionSetId = permissionSet.Id
 		permissionSets = append(permissionSets, permissionSet)

--- a/central/role/default.go
+++ b/central/role/default.go
@@ -53,6 +53,9 @@ var (
 		Name:        "Deny All",
 		Description: "No access to scoped resources",
 		Rules:       &storage.SimpleAccessScope_Rules{},
+		Traits: &storage.Traits{
+			Origin: storage.Traits_DEFAULT,
+		},
 	}
 
 	// AccessScopeIncludeAll gives access to all resources. It is checked by ID, as
@@ -61,6 +64,9 @@ var (
 		Id:          getAccessScopeIncludeAllID(),
 		Name:        "Unrestricted",
 		Description: "Access to all clusters and namespaces",
+		Traits: &storage.Traits{
+			Origin: storage.Traits_DEFAULT,
+		},
 	}
 )
 

--- a/central/role/default.go
+++ b/central/role/default.go
@@ -84,15 +84,20 @@ func getAccessScopeIncludeAllID() string {
 	return EnsureValidAccessScopeID("unrestricted")
 }
 
-// IsDefaultRoleName checks if a given role name corresponds to a default role.
-func IsDefaultRoleName(name string) bool {
-	return DefaultRoleNames.Contains(name)
+// IsDefaultRoleName checks if a given role corresponds to a default role.
+func IsDefaultRoleName(role *storage.Role) bool {
+	return role.GetTraits().GetOrigin() == storage.Traits_DEFAULT
 }
 
-// IsDefaultAccessScope checks if a given access scope id corresponds to a
+// IsDefaultPermissionSet checks if a given permission set corresponds to a default role.
+func IsDefaultPermissionSet(permissionSet *storage.PermissionSet) bool {
+	return permissionSet.GetTraits().GetOrigin() == storage.Traits_DEFAULT
+}
+
+// IsDefaultAccessScope checks if a given access scope corresponds to a
 // default access scope.
-func IsDefaultAccessScope(id string) bool {
-	return defaultScopesIDs.Contains(id)
+func IsDefaultAccessScope(scope *storage.SimpleAccessScope) bool {
+	return scope.GetTraits().GetOrigin() == storage.Traits_DEFAULT
 }
 
 // GetAnalystPermissions returns permissions for `Analyst` role.

--- a/central/role/default.go
+++ b/central/role/default.go
@@ -84,8 +84,8 @@ func getAccessScopeIncludeAllID() string {
 	return EnsureValidAccessScopeID("unrestricted")
 }
 
-// IsDefaultRoleName checks if a given role corresponds to a default role.
-func IsDefaultRoleName(role *storage.Role) bool {
+// IsDefaultRole checks if a given role corresponds to a default role.
+func IsDefaultRole(role *storage.Role) bool {
 	return role.GetTraits().GetOrigin() == storage.Traits_DEFAULT || DefaultRoleNames.Contains(role.GetName())
 }
 

--- a/central/role/default.go
+++ b/central/role/default.go
@@ -86,18 +86,19 @@ func getAccessScopeIncludeAllID() string {
 
 // IsDefaultRoleName checks if a given role corresponds to a default role.
 func IsDefaultRoleName(role *storage.Role) bool {
-	return role.GetTraits().GetOrigin() == storage.Traits_DEFAULT
+	return role.GetTraits().GetOrigin() == storage.Traits_DEFAULT || DefaultRoleNames.Contains(role.GetName())
 }
 
 // IsDefaultPermissionSet checks if a given permission set corresponds to a default role.
 func IsDefaultPermissionSet(permissionSet *storage.PermissionSet) bool {
-	return permissionSet.GetTraits().GetOrigin() == storage.Traits_DEFAULT
+	return permissionSet.GetTraits().GetOrigin() == storage.Traits_DEFAULT ||
+		DefaultRoleNames.Contains(permissionSet.GetName())
 }
 
 // IsDefaultAccessScope checks if a given access scope corresponds to a
 // default access scope.
 func IsDefaultAccessScope(scope *storage.SimpleAccessScope) bool {
-	return scope.GetTraits().GetOrigin() == storage.Traits_DEFAULT
+	return scope.GetTraits().GetOrigin() == storage.Traits_DEFAULT || defaultScopesIDs.Contains(scope.GetId())
 }
 
 // GetAnalystPermissions returns permissions for `Analyst` role.

--- a/central/role/default_test.go
+++ b/central/role/default_test.go
@@ -1,0 +1,40 @@
+package role
+
+import (
+	"testing"
+
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsDefaultRole(t *testing.T) {
+	defaultRoleWithTraits := &storage.Role{Name: Admin, Traits: &storage.Traits{Origin: storage.Traits_DEFAULT}}
+	defaultRoleWithoutTraits := &storage.Role{Name: Admin}
+	nonDefaultRole := &storage.Role{Name: "some-random-role"}
+
+	assert.True(t, IsDefaultRole(defaultRoleWithTraits))
+	assert.True(t, IsDefaultRole(defaultRoleWithoutTraits))
+	assert.False(t, IsDefaultRole(nonDefaultRole))
+}
+
+func TestIsDefaultAccessScope(t *testing.T) {
+	defaultAccessScopeWithTraits := &storage.SimpleAccessScope{Id: unrestrictedAccessScopeID,
+		Traits: &storage.Traits{Origin: storage.Traits_DEFAULT}}
+	defaultAccessScopeWithoutTraits := &storage.SimpleAccessScope{Id: unrestrictedAccessScopeID}
+	nonDefaultAccessScope := &storage.SimpleAccessScope{Id: "some-random-access-scope"}
+
+	assert.True(t, IsDefaultAccessScope(defaultAccessScopeWithTraits))
+	assert.True(t, IsDefaultAccessScope(defaultAccessScopeWithoutTraits))
+	assert.False(t, IsDefaultAccessScope(nonDefaultAccessScope))
+}
+
+func TestIsDefaultPermissionSet(t *testing.T) {
+	defaultPermissionSetWithTraits := &storage.PermissionSet{Name: Admin,
+		Traits: &storage.Traits{Origin: storage.Traits_DEFAULT}}
+	defaultPermissionSetWithoutTraits := &storage.PermissionSet{Name: Admin}
+	nonDefaultPermissionSet := &storage.PermissionSet{Name: "some-random-permission-set"}
+
+	assert.True(t, IsDefaultPermissionSet(defaultPermissionSetWithTraits))
+	assert.True(t, IsDefaultPermissionSet(defaultPermissionSetWithoutTraits))
+	assert.False(t, IsDefaultPermissionSet(nonDefaultPermissionSet))
+}

--- a/central/role/default_test.go
+++ b/central/role/default_test.go
@@ -18,9 +18,9 @@ func TestIsDefaultRole(t *testing.T) {
 }
 
 func TestIsDefaultAccessScope(t *testing.T) {
-	defaultAccessScopeWithTraits := &storage.SimpleAccessScope{Id: unrestrictedAccessScopeID,
+	defaultAccessScopeWithTraits := &storage.SimpleAccessScope{Id: AccessScopeIncludeAll.GetId(),
 		Traits: &storage.Traits{Origin: storage.Traits_DEFAULT}}
-	defaultAccessScopeWithoutTraits := &storage.SimpleAccessScope{Id: unrestrictedAccessScopeID}
+	defaultAccessScopeWithoutTraits := &storage.SimpleAccessScope{Id: AccessScopeIncludeAll.GetId()}
 	nonDefaultAccessScope := &storage.SimpleAccessScope{Id: "some-random-access-scope"}
 
 	assert.True(t, IsDefaultAccessScope(defaultAccessScopeWithTraits))


### PR DESCRIPTION
## Description

This is a follow-up from #4291, where the traits message has been added to all relevant resources for declarative configuration.

The origin enum within the traits message can be used to identify default resources, and all default resources created (role, permission sets, access scopes) will specify it correctly now.

Note that a migration is not required in this case, as the default resources will be upserted on each restart of central irrespective of whether they have existed previously or not.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

- see CI.
