### PR TITLE
[ROX-13701] Handle deployment label parsing correctly in GetLabels API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -483,7 +483,7 @@ go-postgres-unit-tests: build-prep test-prep
 	@# The -p 1 passed to go test is required to ensure that tests of different packages are not run in parallel, so as to avoid conflicts when interacting with the DB.
 	set -o pipefail ; \
 	CGO_ENABLED=1 GODEBUG=cgocheck=2 MUTEX_WATCHDOG_TIMEOUT_SECS=30 ROX_POSTGRES_DATASTORE=true GOTAGS=$(GOTAGS),test,sql_integration scripts/go-test.sh -p 1 -race -cover -coverprofile test-output/coverage.out -v \
-		$(shell git ls-files -- '*postgres/*_test.go' '*postgres_test.go' '*datastore_sac_test.go' '*clone_test.go' 'migrator/migrations/n_*/migration_test.go' '*pruning_test.go' '*reprocessor_test.go' '*enricher_impl_test.go' '*v2/parts_test.go' '*version/ensure_test.go' '*version/store/store_impl_test.go' '*activecomponent/updater/updater_impl_test.go' '*role/validate_test.go' '*search/service/service_impl_test.go' | sed -e 's@^@./@g' | xargs -n 1 dirname | sort | uniq | xargs go list| grep -v '^github.com/stackrox/rox/tests$$' | grep -Ev $(UNIT_TEST_IGNORE)) \
+		$(shell git ls-files -- '*postgres/*_test.go' '*postgres_test.go' '*datastore_sac_test.go' '*clone_test.go' 'migrator/migrations/n_*/migration_test.go' '*pruning_test.go' '*reprocessor_test.go' '*enricher_impl_test.go' '*v2/parts_test.go' '*version/ensure_test.go' '*version/store/store_impl_test.go' '*activecomponent/updater/updater_impl_test.go' '*role/validate_test.go' '*search/service/service_impl_test.go' '*deployment/service/service_impl_test.go' | sed -e 's@^@./@g' | xargs -n 1 dirname | sort | uniq | xargs go list| grep -v '^github.com/stackrox/rox/tests$$' | grep -Ev $(UNIT_TEST_IGNORE)) \
 		| tee $(GO_TEST_OUTPUT_PATH)
 
 .PHONY: shell-unit-tests

--- a/central/deployment/service/service_impl_test.go
+++ b/central/deployment/service/service_impl_test.go
@@ -141,7 +141,7 @@ func TestLabelsMap(t *testing.T) {
 			results, err := ds.Search(ctx, queryForLabels())
 			assert.NoError(t, err)
 			actualMap, actualValues := labelsMapFromSearchResults(results)
-			
+
 			assert.Equal(t, c.expectedMap, actualMap)
 			assert.ElementsMatch(t, c.expectedValues, actualValues)
 		})

--- a/central/search/service/service_impl.go
+++ b/central/search/service/service_impl.go
@@ -250,6 +250,9 @@ func RunAutoComplete(ctx context.Context, queryString string, categories []v1.Se
 		}
 		for _, r := range results {
 			matches := trimMatches(r.Matches, fieldPaths)
+			// In postgres, we do not need to combine map key and values matches as `k=v` because it is already done by postgres searcher.
+			// With postgres, the following condition will not pass anyway.
+			//
 			// This implies that the object is a map because it has multiple values
 			if isMapMatch(matches) {
 				autocompleteResults = append(autocompleteResults, handleMapResults(matches, r.Score)...)

--- a/pkg/search/postgres/query/map_query.go
+++ b/pkg/search/postgres/query/map_query.go
@@ -11,7 +11,8 @@ import (
 	"github.com/stackrox/rox/pkg/utils"
 )
 
-func parseMapQuery(label string) (string, string, bool) {
+// ParseMapQuery parses a label stored in the form k=v.
+func ParseMapQuery(label string) (string, string, bool) {
 	hasEquals := strings.Contains(label, "=")
 	key, value := stringutils.Split2(label, "=")
 	return key, value, hasEquals
@@ -54,7 +55,7 @@ func newMapQuery(ctx *queryAndFieldContext) (*QueryEntry, error) {
 		}), nil
 	}
 
-	key, value, hasEquals := parseMapQuery(query)
+	key, value, hasEquals := ParseMapQuery(query)
 	keyNegated := stringutils.ConsumePrefix(&key, search.NegationPrefix)
 	// This is a special case where the query we construct becomes a (non) existence query
 	if value == "" && key != "" && hasEquals {


### PR DESCRIPTION
## Description

This PR fixes the issue with `DeploymentService` endpoint `GetLabels` that returned nil in Postgres.

In postgres, map(string, string) matches are returned as`key=value` on the field path as compared to separate match paths `{fieldpath}.keypair.key` and `{fieldpath}.keypair.value`. 

Deployment API and global search API are the only spots where map key-value pair matches are processed. The global search API handles the kv pairs correctly since it also considers the map field path.
 
## Checklist
- [ ] Investigated and inspected CI test results
- [X] Unit test and regression tests added
- ~Evaluated and added CHANGELOG entry if required~
- ~Determined and documented upgrade steps~
- ~Documented user facing changes~

If any of these don't apply, please comment below.

## Testing Performed
Unit
