### PR TITLE
Rework collection rule selectors to contain an explicit match type

### DIFF
--- a/ui/apps/platform/cypress/integration/collections/Collections.helpers.js
+++ b/ui/apps/platform/cypress/integration/collections/Collections.helpers.js
@@ -106,9 +106,9 @@ export function tryDeleteCollection(collectionName) {
  * @param {string[]} deployments
  */
 export function assertDeploymentsAreMatchedExactly(deployments) {
+    assertDeploymentsAreMatched(deployments);
     cy.get(collectionSelectors.deploymentResults).its('length').should('be.eq', deployments.length);
     cy.get(collectionSelectors.viewMoreResultsButton).should('not.exist');
-    assertDeploymentsAreMatched(deployments);
 }
 
 export function assertDeploymentsAreMatched(deployments) {

--- a/ui/apps/platform/cypress/integration/collections/collectionsCrudWorkflow.test.js
+++ b/ui/apps/platform/cypress/integration/collections/collectionsCrudWorkflow.test.js
@@ -34,14 +34,15 @@ describe('Create collection', () => {
 
         cy.get('button:contains("All deployments")').click();
         cy.get('button:contains("Deployments with labels matching")').click();
-        cy.get('input[aria-label="Select label key for deployment rule 1 of 1"]').type('meta/name');
         cy.get('input[aria-label="Select label value 1 of 1 for deployment rule 1 of 1"]').type(
-            'visa.*'
+            'meta/name=visa-processor'
         );
+        cy.get(`button:contains('meta/name=visa-processor')`).click();
         cy.get('button[aria-label="Add deployment label value for rule 1"]').click();
         cy.get('input[aria-label="Select label value 2 of 2 for deployment rule 1 of 1"]').type(
-            'mastercard.*'
+            'meta/name=mastercard-processor'
         );
+        cy.get(`button:contains('meta/name=mastercard-processor')`).click();
 
         cy.get('button:contains("All namespaces")').click();
         cy.get('button:contains("Namespaces with names matching")').click();
@@ -67,19 +68,18 @@ describe('Create collection', () => {
         cy.get(`button:contains("Edit collection")`).click();
 
         cy.get('button[aria-label="Add deployment label rule"]').click();
-        cy.get('input[aria-label="Select label key for deployment rule 2 of 2"]').type(
-            'meta/net-visibility'
-        );
         cy.get('input[aria-label="Select label value 1 of 1 for deployment rule 2 of 2"]').type(
-            'public-facing'
+            'meta/net-visibility=public-facing'
         );
+        cy.get(`button:contains('meta/net-visibility=public-facing')`).click();
 
         cy.get('button[aria-label="Add deployment label value for rule 1"]').click();
         cy.get('input[aria-label="Select label value 3 of 3 for deployment rule 1 of 2"]').type(
-            'discover.*'
+            'meta/name=discover-processor'
         );
+        cy.get(`button:contains('meta/name=discover-processor')`).click();
 
-        cy.get(`button[aria-label='Delete mastercard.*']`).click();
+        cy.get(`button[aria-label='Delete meta/name=mastercard-processor']`).click();
 
         cy.get('button[aria-label="Add cluster name value"]').click();
         cy.get('input[aria-label="Select value 2 of 2 for the cluster name"]').type('staging');
@@ -97,9 +97,11 @@ describe('Create collection', () => {
         cy.get('a:contains("Financial deployments")').click();
 
         // Check "byLabel" inputs for deployment
-        cy.get(`input[aria-label^="Select label value"][value="visa.*"]`);
-        cy.get(`input[aria-label^="Select label value"][value="discover.*"]`);
-        cy.get(`input[aria-label^="Select label value"][value="mastercard.*"]`).should('not.exist');
+        cy.get(`input[aria-label^="Select label value"][value="meta/name=visa-processor"]`);
+        cy.get(`input[aria-label^="Select label value"][value="meta/name=discover-processor"]`);
+        cy.get(
+            `input[aria-label^="Select label value"][value="meta/name=mastercard-processor"]`
+        ).should('not.exist');
 
         // Check "byName" inputs for namespace
         cy.get(`input[aria-label$="for the namespace name"][value="payments"]`);

--- a/ui/apps/platform/cypress/integration/collections/deploymentMatching.test.js
+++ b/ui/apps/platform/cypress/integration/collections/deploymentMatching.test.js
@@ -54,14 +54,15 @@ describe('Collection deployment matching', () => {
         // Restrict collection to two specific deployments
         cy.get('button:contains("All deployments")').click();
         cy.get('button:contains("Deployments with labels matching")').click();
-        cy.get('input[aria-label="Select label key for deployment rule 1 of 1"]').type('app');
         cy.get('input[aria-label="Select label value 1 of 1 for deployment rule 1 of 1"]').type(
-            'collector'
+            'app=collector'
         );
+        cy.get(`button:contains('app=collector')`).click();
         cy.get('button[aria-label="Add deployment label value for rule 1"]').click();
         cy.get('input[aria-label="Select label value 2 of 2 for deployment rule 1 of 1"]').type(
-            'sensor'
+            'app=sensor'
         );
+        cy.get(`button:contains('app=sensor')`).click();
 
         assertDeploymentsAreMatchedExactly(['collector', 'sensor']);
 
@@ -100,15 +101,16 @@ describe('Collection deployment matching', () => {
         // Restrict collection to two specific deployments
         cy.get('button:contains("All deployments")').click();
         cy.get('button:contains("Deployments with labels matching")').click();
-        cy.get('input[aria-label="Select label key for deployment rule 1 of 1"]').type('k8s-app');
         cy.get('input[aria-label="Select label value 1 of 1 for deployment rule 1 of 1"]').type(
-            'calico-node-autoscaler'
+            'k8s-app=calico-node-autoscaler'
         );
+        cy.get(`button:contains('k8s-app=calico-node-autoscaler')`).click();
 
         cy.get('button[aria-label="Add deployment label value for rule 1"]').click();
         cy.get('input[aria-label="Select label value 2 of 2 for deployment rule 1 of 1"]').type(
-            'kube-dns'
+            'k8s-app=kube-dns'
         );
+        cy.get(`button:contains('k8s-app=kube-dns')`).click();
 
         assertDeploymentsAreMatchedExactly([
             'kube-dns',

--- a/ui/apps/platform/cypress/integration/collections/deploymentMatching.test.js
+++ b/ui/apps/platform/cypress/integration/collections/deploymentMatching.test.js
@@ -112,11 +112,7 @@ describe('Collection deployment matching', () => {
         );
         cy.get(`button:contains('k8s-app=kube-dns')`).click();
 
-        assertDeploymentsAreMatchedExactly([
-            'kube-dns',
-            'kube-dns-autoscaler',
-            'calico-node-vertical-autoscaler',
-        ]);
+        assertDeploymentsAreMatchedExactly(['kube-dns', 'calico-node-vertical-autoscaler']);
 
         // View another collection via modal
         cy.get(selectors.viewEmbeddedCollectionButton('Available', sampleCollectionName)).click();
@@ -133,7 +129,6 @@ describe('Collection deployment matching', () => {
         cy.get(selectors.attachCollectionButton(sampleCollectionName)).click();
         assertDeploymentsAreMatchedExactly([
             'kube-dns',
-            'kube-dns-autoscaler',
             'calico-node-vertical-autoscaler',
             'collector',
             'sensor',
@@ -141,11 +136,7 @@ describe('Collection deployment matching', () => {
 
         // Detach the collection, assert that embedded collection deployments are gone
         cy.get(selectors.detachCollectionButton(sampleCollectionName)).click();
-        assertDeploymentsAreMatchedExactly([
-            'kube-dns',
-            'kube-dns-autoscaler',
-            'calico-node-vertical-autoscaler',
-        ]);
+        assertDeploymentsAreMatchedExactly(['kube-dns', 'calico-node-vertical-autoscaler']);
 
         // Re-attach and save
         cy.get(selectors.attachCollectionButton(sampleCollectionName)).click();
@@ -159,9 +150,9 @@ describe('Collection deployment matching', () => {
         cy.get(`td[data-label="Collection"] a:contains("${withEmbeddedCollectionName}")`).click();
 
         // Filter to deployments with deployment name matching
-        cy.get(selectors.resultsPanelFilterInput).type('kube-dns');
+        cy.get(selectors.resultsPanelFilterInput).type('c');
 
-        assertDeploymentsAreMatchedExactly(['kube-dns', 'kube-dns-autoscaler']);
+        assertDeploymentsAreMatchedExactly(['calico-node-vertical-autoscaler', 'collector']);
 
         // Filter to deployments in namespaces matching
         cy.get(selectors.resultsPanelFilterEntitySelect).click();

--- a/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
@@ -124,8 +124,7 @@ function yupLabelRuleObject({ field }: ByLabelResourceSelector) {
                                 ),
                             matchType: yup
                                 .string()
-                                // TODO - requires BE
-                                // .required()
+                                .required()
                                 .matches(new RegExp(byLabelMatchTypes.join('|'))),
                         })
                     )
@@ -147,8 +146,7 @@ function yupNameRuleObject({ field }: ByNameResourceSelector) {
                         value: yup.string().trim().required(),
                         matchType: yup
                             .string()
-                            // TODO - requires BE
-                            // .required()
+                            .required()
                             .matches(new RegExp(byNameMatchType.join('|'))),
                     })
                 )

--- a/ui/apps/platform/src/Containers/Collections/RuleSelector/ByLabelSelector.tsx
+++ b/ui/apps/platform/src/Containers/Collections/RuleSelector/ByLabelSelector.tsx
@@ -6,10 +6,10 @@ import cloneDeep from 'lodash/cloneDeep';
 
 import useIndexKey from 'hooks/useIndexKey';
 import {
-    SelectorEntityType,
-    ScopedResourceSelector,
     ByLabelResourceSelector,
     ClientCollection,
+    ScopedResourceSelector,
+    SelectorEntityType,
 } from '../types';
 import { AutoCompleteSelect, AutoCompleteSelectProps } from './AutoCompleteSelect';
 

--- a/ui/apps/platform/src/Containers/Collections/RuleSelector/ByLabelSelector.tsx
+++ b/ui/apps/platform/src/Containers/Collections/RuleSelector/ByLabelSelector.tsx
@@ -1,50 +1,51 @@
 import React from 'react';
-import {
-    Flex,
-    Label,
-    FormGroup,
-    FlexItem,
-    Button,
-    Divider,
-    ValidatedOptions,
-    TextInput,
-} from '@patternfly/react-core';
+import { Label, Button, Divider, ValidatedOptions } from '@patternfly/react-core';
 import { TrashIcon } from '@patternfly/react-icons';
 import { FormikErrors } from 'formik';
 import cloneDeep from 'lodash/cloneDeep';
 
 import useIndexKey from 'hooks/useIndexKey';
-import { SelectorEntityType, ScopedResourceSelector, ByLabelResourceSelector } from '../types';
+import {
+    SelectorEntityType,
+    ScopedResourceSelector,
+    ByLabelResourceSelector,
+    ClientCollection,
+} from '../types';
+import { AutoCompleteSelect, AutoCompleteSelectProps } from './AutoCompleteSelect';
 
 export type ByLabelSelectorProps = {
+    collection: ClientCollection;
     entityType: SelectorEntityType;
     scopedResourceSelector: ByLabelResourceSelector;
     handleChange: (
         entityType: SelectorEntityType,
         scopedResourceSelector: ScopedResourceSelector
     ) => void;
+    placeholder: AutoCompleteSelectProps['placeholder'];
     validationErrors: FormikErrors<ByLabelResourceSelector> | undefined;
     isDisabled: boolean;
 };
 
 function ByLabelSelector({
+    collection,
     entityType,
     scopedResourceSelector,
     handleChange,
+    placeholder,
     validationErrors,
     isDisabled,
 }: ByLabelSelectorProps) {
     const { keyFor, invalidateIndexKeys } = useIndexKey();
     const lowerCaseEntity = entityType.toLowerCase();
-    function onChangeLabelKey(resourceSelector: ByLabelResourceSelector, ruleIndex, value) {
-        const newSelector = cloneDeep(resourceSelector);
-        newSelector.rules[ruleIndex].key = value;
-        handleChange(entityType, newSelector);
-    }
 
-    function onChangeLabelValue(resourceSelector, ruleIndex, valueIndex, value) {
+    function onChangeLabelValue(
+        resourceSelector: ByLabelResourceSelector,
+        ruleIndex: number,
+        valueIndex: number,
+        value: string
+    ) {
         const newSelector = cloneDeep(resourceSelector);
-        newSelector.rules[ruleIndex].values[valueIndex] = value;
+        newSelector.rules[ruleIndex].values[valueIndex].value = value;
         handleChange(entityType, newSelector);
     }
 
@@ -52,8 +53,11 @@ function ByLabelSelector({
         const selector = cloneDeep(scopedResourceSelector);
 
         // Only add a new form row if there are no blank entries
-        if (selector.rules.every(({ key, values }) => key && values.every((value) => value))) {
-            selector.rules.push({ operator: 'OR', key: '', values: [''] });
+        if (selector.rules.every(({ values }) => values.every(({ value }) => value))) {
+            selector.rules.push({
+                operator: 'OR',
+                values: [{ value: '', matchType: 'EXACT' }],
+            });
             handleChange(entityType, selector);
         }
     }
@@ -63,8 +67,8 @@ function ByLabelSelector({
         const rule = selector.rules[ruleIndex];
 
         // Only add a new form row if there are no blank entries
-        if (rule.values.every((value) => value)) {
-            rule.values.push('');
+        if (rule.values.every(({ value }) => value)) {
+            rule.values.push({ value: '', matchType: 'EXACT' });
             handleChange(entityType, selector);
         }
     }
@@ -94,155 +98,97 @@ function ByLabelSelector({
     return (
         <>
             {scopedResourceSelector.rules.map((rule, ruleIndex) => {
-                const keyValidationError = validationErrors?.rules?.[ruleIndex];
-                const keyValidation =
-                    typeof keyValidationError === 'string' || keyValidationError?.key
-                        ? ValidatedOptions.error
-                        : ValidatedOptions.default;
                 return (
                     <div key={keyFor(ruleIndex)}>
                         {ruleIndex > 0 && (
-                            <Flex
-                                className="pf-u-pt-md pf-u-pb-xl"
-                                spaceItems={{ default: 'spaceItemsNone' }}
-                                alignItems={{ default: 'alignItemsCenter' }}
-                            >
+                            <div className="rule-selector-label-rule-separator">
                                 <Label variant="outline" isCompact>
                                     and
                                 </Label>
-                                <span
-                                    style={{
-                                        borderBottom:
-                                            '2px dashed var(--pf-global--Color--light-300)',
-                                        flex: '1 1 0',
-                                    }}
-                                />
-                            </Flex>
+                            </div>
                         )}
 
-                        <Flex>
-                            <Flex className="pf-u-flex-grow-1 pf-u-mb-md">
-                                <FormGroup
-                                    fieldId={`${entityType}-label-key-${ruleIndex}`}
-                                    className="pf-u-flex-grow-1"
-                                    label={ruleIndex === 0 ? 'Label key' : ''}
-                                    isRequired={!isDisabled}
-                                >
-                                    <TextInput
-                                        id={`${entityType}-label-key-${ruleIndex}`}
-                                        aria-label={`Select label key for ${lowerCaseEntity} rule ${
-                                            ruleIndex + 1
-                                        } of ${scopedResourceSelector.rules.length}`}
-                                        value={rule.key}
-                                        onChange={(fieldValue: string) =>
-                                            onChangeLabelKey(
-                                                scopedResourceSelector,
-                                                ruleIndex,
-                                                fieldValue
-                                            )
-                                        }
-                                        validated={keyValidation}
-                                        readOnlyVariant={isDisabled ? 'plain' : undefined}
-                                    />
-                                </FormGroup>
-                                <FlexItem
-                                    className="pf-u-pb-xs"
-                                    alignSelf={{ default: 'alignSelfFlexEnd' }}
-                                >
-                                    =
-                                </FlexItem>
-                            </Flex>
-                            <FormGroup
-                                fieldId={`${entityType}-label-value-${ruleIndex}`}
-                                className="pf-u-flex-grow-1"
-                                label={ruleIndex === 0 ? 'Label value(s)' : ''}
-                                isRequired={!isDisabled}
-                            >
-                                <Flex
-                                    spaceItems={{ default: 'spaceItemsSm' }}
-                                    direction={{ default: 'column' }}
-                                >
-                                    {rule.values.map((value, valueIndex) => {
-                                        const valueValidationError =
-                                            validationErrors?.rules?.[ruleIndex];
-                                        const valueValidation =
-                                            typeof valueValidationError === 'string' ||
-                                            valueValidationError?.values?.[valueIndex]
-                                                ? ValidatedOptions.error
-                                                : ValidatedOptions.default;
-                                        return (
-                                            <Flex key={keyFor(valueIndex)}>
-                                                <TextInput
-                                                    id={`${entityType}-label-value-${ruleIndex}-${valueIndex}`}
-                                                    aria-label={`Select label value ${
-                                                        valueIndex + 1
-                                                    } of ${
-                                                        rule.values.length
-                                                    } for ${lowerCaseEntity} rule ${
-                                                        ruleIndex + 1
-                                                    } of ${scopedResourceSelector.rules.length}`}
-                                                    className="pf-u-flex-grow-1 pf-u-w-auto"
-                                                    value={value}
-                                                    onChange={(fieldValue: string) =>
-                                                        onChangeLabelValue(
-                                                            scopedResourceSelector,
-                                                            ruleIndex,
-                                                            valueIndex,
-                                                            fieldValue
-                                                        )
-                                                    }
-                                                    validated={valueValidation}
-                                                    readOnlyVariant={
-                                                        isDisabled ? 'plain' : undefined
-                                                    }
-                                                />
-                                                {!isDisabled && (
-                                                    <Button
-                                                        aria-label={`Delete ${value}`}
-                                                        variant="plain"
-                                                        onClick={() =>
-                                                            onDeleteValue(ruleIndex, valueIndex)
-                                                        }
-                                                    >
-                                                        <TrashIcon
-                                                            style={{ cursor: 'pointer' }}
-                                                            color="var(--pf-global--Color--dark-200)"
-                                                        />
-                                                    </Button>
-                                                )}
-                                            </Flex>
-                                        );
-                                    })}
-                                </Flex>
-                                {!isDisabled && (
-                                    <Button
-                                        aria-label={`Add ${lowerCaseEntity} label value for rule ${
-                                            ruleIndex + 1
-                                        }`}
-                                        className="pf-u-pl-0 pf-u-pt-md"
-                                        variant="link"
-                                        onClick={() => onAddLabelValue(ruleIndex)}
+                        <div className="rule-selector-list">
+                            {rule.values.map(({ value }, valueIndex) => {
+                                const valueValidationError = validationErrors?.rules?.[ruleIndex];
+                                const validated =
+                                    typeof valueValidationError === 'string' ||
+                                    valueValidationError?.values?.[valueIndex]
+                                        ? ValidatedOptions.error
+                                        : ValidatedOptions.default;
+                                const ariaLabel = `Select label value ${valueIndex + 1} of ${
+                                    rule.values.length
+                                } for ${lowerCaseEntity} rule ${ruleIndex + 1} of ${
+                                    scopedResourceSelector.rules.length
+                                }`;
+                                return (
+                                    <div
+                                        className="rule-selector-list-item"
+                                        key={keyFor(valueIndex)}
                                     >
-                                        Add value
-                                    </Button>
-                                )}
-                            </FormGroup>
-                        </Flex>
+                                        <AutoCompleteSelect
+                                            id={`${entityType}-label-value-${ruleIndex}-${valueIndex}`}
+                                            entityType={entityType}
+                                            typeAheadAriaLabel={ariaLabel}
+                                            className="pf-u-flex-grow-1 pf-u-w-auto"
+                                            selectedOption={value}
+                                            onChange={(val) =>
+                                                onChangeLabelValue(
+                                                    scopedResourceSelector,
+                                                    ruleIndex,
+                                                    valueIndex,
+                                                    val
+                                                )
+                                            }
+                                            placeholder={placeholder}
+                                            validated={validated}
+                                            isDisabled={isDisabled}
+                                            collection={collection}
+                                            autocompleteField={`${entityType} Label`}
+                                        />
+                                        {!isDisabled && (
+                                            <Button
+                                                aria-label={`Delete ${value}`}
+                                                variant="plain"
+                                                onClick={() => onDeleteValue(ruleIndex, valueIndex)}
+                                            >
+                                                <TrashIcon
+                                                    style={{ cursor: 'pointer' }}
+                                                    color="var(--pf-global--Color--dark-200)"
+                                                />
+                                            </Button>
+                                        )}
+                                    </div>
+                                );
+                            })}
+                        </div>
+                        {!isDisabled && (
+                            <Button
+                                aria-label={`Add ${lowerCaseEntity} label value for rule ${
+                                    ruleIndex + 1
+                                }`}
+                                className="rule-selector-add-value-button"
+                                variant="link"
+                                onClick={() => onAddLabelValue(ruleIndex)}
+                            >
+                                OR...
+                            </Button>
+                        )}
                     </div>
                 );
             })}
             {!isDisabled && (
-                <>
-                    <Divider component="div" className="pf-u-pt-lg" />
+                <div className="pf-u-pt-md">
+                    <Divider component="div" className="pf-u-pb-md" />
                     <Button
                         aria-label={`Add ${lowerCaseEntity} label rule`}
-                        className="pf-u-pl-0 pf-u-pt-md"
+                        className="pf-u-p-0"
                         variant="link"
                         onClick={onAddLabelRule}
                     >
-                        Add label rule
+                        Add label section (AND)
                     </Button>
-                </>
+                </div>
             )}
         </>
     );

--- a/ui/apps/platform/src/Containers/Collections/RuleSelector/MatchTypeSelect.tsx
+++ b/ui/apps/platform/src/Containers/Collections/RuleSelector/MatchTypeSelect.tsx
@@ -1,0 +1,47 @@
+import React, { ReactElement } from 'react';
+import { Select } from '@patternfly/react-core';
+import useSelectToggle from 'hooks/patternfly/useSelectToggle';
+import { ByLabelMatchType, ByNameMatchType, MatchType } from '../types';
+
+export type MatchTypeSelectProps<T extends MatchType> = {
+    onChange: (value: T) => void;
+    selected: T;
+    children: ReactElement[];
+    isDisabled?: boolean;
+};
+
+function MatchTypeSelect<T extends MatchType>({
+    onChange,
+    selected,
+    children,
+    isDisabled = false,
+}: MatchTypeSelectProps<T>) {
+    const { isOpen, onToggle, closeSelect } = useSelectToggle();
+
+    function onSelect(_, value) {
+        onChange(value);
+        closeSelect();
+    }
+
+    return (
+        <>
+            <Select
+                isOpen={isOpen}
+                onToggle={onToggle}
+                selections={selected}
+                onSelect={onSelect}
+                isDisabled={isDisabled}
+            >
+                {children}
+            </Select>
+        </>
+    );
+}
+
+export function NameMatchTypeSelect(props: MatchTypeSelectProps<ByNameMatchType>) {
+    return <MatchTypeSelect {...props} />;
+}
+
+export function LabelMatchTypeSelect(props: MatchTypeSelectProps<ByLabelMatchType>) {
+    return <MatchTypeSelect {...props} />;
+}

--- a/ui/apps/platform/src/Containers/Collections/RuleSelector/RuleSelector.css
+++ b/ui/apps/platform/src/Containers/Collections/RuleSelector/RuleSelector.css
@@ -1,0 +1,47 @@
+.rule-selector {
+  --rule-selector-spacer: var(--pf-global--spacer--md);
+  padding: var(--pf-global--spacer--lg);
+  border: 1px solid var(--pf-global--BorderColor--100);
+}
+
+.rule-selector-list {
+  border-left: solid 1px var(--pf-global--BorderColor--100);
+  margin-left: var(--rule-selector-spacer);
+}
+
+.rule-selector-list-item {
+  position: relative;
+  display: flex;
+  padding: var(--rule-selector-spacer) 0 0 var(--rule-selector-spacer);
+}
+
+.rule-selector-list-item:before {
+  position: absolute;
+  content: "";
+  left: 0;
+  bottom: var(--rule-selector-spacer);
+  height: 1px;
+  width: var(--rule-selector-spacer);
+  background-color: var(--pf-global--BorderColor--100);
+}
+
+.rule-selector-add-value-button {
+  padding: var(--rule-selector-spacer) 0 0 calc(var(--rule-selector-spacer) * 2);
+}
+
+.rule-selector-label-rule-separator {
+  display: flex;
+  align-items: center;
+  padding: var(--rule-selector-spacer) 0;
+}
+
+.rule-selector-label-rule-separator:after {
+  border-bottom: 2px dashed var(--pf-global--Color--light-300);
+  flex: 1 1 0;
+  content: "";
+  display: inline-block;
+}
+
+.rule-selector-match-type-select {
+  width: 180px;
+}

--- a/ui/apps/platform/src/Containers/Collections/RuleSelector/RuleSelector.test.tsx
+++ b/ui/apps/platform/src/Containers/Collections/RuleSelector/RuleSelector.test.tsx
@@ -75,43 +75,51 @@ describe('Collection RuleSelector component', () => {
         await user.click(screen.getByText('Deployments with names matching'));
 
         expect(resourceSelector.field).toBe('Deployment');
-        expect(resourceSelector.rule.values).toEqual(['']);
+        expect(resourceSelector.rule.values).toEqual([{ value: '', matchType: 'EXACT' }]);
 
         const typeAheadInput = screen.getByLabelText('Select value 1 of 1 for the deployment name');
         await user.type(typeAheadInput, 'visa-processor{Enter}');
 
         expect(resourceSelector.field).toBe('Deployment');
-        expect(resourceSelector.rule.values).toEqual(['visa-processor']);
+        expect(resourceSelector.rule.values).toEqual([
+            { value: 'visa-processor', matchType: 'EXACT' },
+        ]);
         expect(typeAheadInput).toHaveValue('visa-processor');
 
         // Attempt to add multiple blank values
-        await user.click(screen.getByText('Add value'));
-        await user.click(screen.getByText('Add value'));
+        await user.click(screen.getByLabelText('Add deployment name value'));
+        await user.click(screen.getByLabelText('Add deployment name value'));
 
         // Only a single blank value should be added
-        expect(resourceSelector.rule.values).toEqual(['visa-processor', '']);
+        expect(resourceSelector.rule.values).toEqual([
+            { value: 'visa-processor', matchType: 'EXACT' },
+            { value: '', matchType: 'EXACT' },
+        ]);
 
         // Add a couple more values
         await user.type(
             screen.getByLabelText('Select value 2 of 2 for the deployment name'),
             'mastercard-processor{Enter}'
         );
-        await user.click(screen.getByText('Add value'));
+        await user.click(screen.getByLabelText('Add deployment name value'));
         await user.type(
             screen.getByLabelText('Select value 3 of 3 for the deployment name'),
             'discover-processor{Enter}'
         );
 
         expect(resourceSelector.rule.values).toEqual([
-            'visa-processor',
-            'mastercard-processor',
-            'discover-processor',
+            { value: 'visa-processor', matchType: 'EXACT' },
+            { value: 'mastercard-processor', matchType: 'EXACT' },
+            { value: 'discover-processor', matchType: 'EXACT' },
         ]);
 
         await user.click(screen.getByLabelText('Delete mastercard-processor'));
 
         // Check that deletion in the center works
-        expect(resourceSelector.rule.values).toEqual(['visa-processor', 'discover-processor']);
+        expect(resourceSelector.rule.values).toEqual([
+            { value: 'visa-processor', matchType: 'EXACT' },
+            { value: 'discover-processor', matchType: 'EXACT' },
+        ]);
 
         // Check that deletion of all items removes the selector
         await user.click(screen.getByLabelText('Delete visa-processor'));
@@ -125,7 +133,7 @@ describe('Collection RuleSelector component', () => {
         let resourceSelector: ByLabelResourceSelector = {
             type: 'ByLabel',
             field: 'Deployment Label',
-            rules: [{ operator: 'OR', key: '', values: [''] }],
+            rules: [{ operator: 'OR', values: [{ value: '', matchType: 'EXACT' }] }],
         };
 
         const user = userEvent.setup();
@@ -137,62 +145,57 @@ describe('Collection RuleSelector component', () => {
         render(<DeploymentRuleSelector defaultSelector={{ type: 'All' }} onChange={onChange} />);
 
         await user.click(screen.getByLabelText('Select deployments by name or label'));
-        await user.click(screen.getByText('Deployments with labels matching'));
+        await user.click(screen.getByText('Deployments with labels matching exactly'));
 
         expect(resourceSelector.field).toBe('Deployment Label');
-        expect(resourceSelector.rules[0].key).toEqual('');
-        expect(resourceSelector.rules[0].values).toEqual(['']);
+        expect(resourceSelector.rules[0].values).toEqual([{ value: '', matchType: 'EXACT' }]);
 
-        await user.type(
-            screen.getByLabelText('Select label key for deployment rule 1 of 1'),
-            'kubernetes.io/metadata.name{Enter}'
-        );
         await user.type(
             screen.getByLabelText('Select label value 1 of 1 for deployment rule 1 of 1'),
-            'visa-processor{Enter}'
+            'kubernetes.io/metadata.name=visa-processor{Enter}'
         );
-        expect(resourceSelector.rules[0].key).toEqual('kubernetes.io/metadata.name');
-        expect(resourceSelector.rules[0].values).toEqual(['visa-processor']);
+        expect(resourceSelector.rules[0].values).toEqual([
+            { value: 'kubernetes.io/metadata.name=visa-processor', matchType: 'EXACT' },
+        ]);
 
         // Attempt to add multiple blank values
-        await user.click(screen.getByText('Add value'));
-        await user.click(screen.getByText('Add value'));
+        await user.click(screen.getByLabelText('Add deployment label value for rule 1'));
+        await user.click(screen.getByLabelText('Add deployment label value for rule 1'));
 
         // Only a single blank value should be added
-        expect(resourceSelector.rules[0].values).toEqual(['visa-processor', '']);
+        expect(resourceSelector.rules[0].values).toEqual([
+            { value: 'kubernetes.io/metadata.name=visa-processor', matchType: 'EXACT' },
+            { value: '', matchType: 'EXACT' },
+        ]);
 
         await user.type(
             screen.getByLabelText('Select label value 2 of 2 for deployment rule 1 of 1'),
-            'mastercard-processor{Enter}'
+            'kubernetes.io/metadata.name=mastercard-processor{Enter}'
         );
-        await user.click(screen.getByText('Add value'));
+        await user.click(screen.getByLabelText('Add deployment label value for rule 1'));
         await user.type(
             screen.getByLabelText('Select label value 3 of 3 for deployment rule 1 of 1'),
-            'discover-processor{Enter}'
+            'kubernetes.io/metadata.name=discover-processor{Enter}'
         );
 
         expect(resourceSelector.rules[0].values).toEqual([
-            'visa-processor',
-            'mastercard-processor',
-            'discover-processor',
+            { value: 'kubernetes.io/metadata.name=visa-processor', matchType: 'EXACT' },
+            { value: 'kubernetes.io/metadata.name=mastercard-processor', matchType: 'EXACT' },
+            { value: 'kubernetes.io/metadata.name=discover-processor', matchType: 'EXACT' },
         ]);
 
-        // Add another label rule and key'values
-        await user.click(screen.getByText('Add label rule'));
+        // Add another label rule
+        await user.click(screen.getByText('Add label section (AND)'));
 
-        await user.type(
-            screen.getByLabelText('Select label key for deployment rule 2 of 2'),
-            'kubernetes.io/metadata.release{Enter}'
-        );
         await user.type(
             screen.getByLabelText('Select label value 1 of 1 for deployment rule 2 of 2'),
-            'stable{Enter}'
+            'kubernetes.io/metadata.release=stable{Enter}'
         );
 
-        await user.click(screen.getAllByText('Add value')[1]);
+        await user.click(screen.getByLabelText('Add deployment label value for rule 2'));
         await user.type(
             screen.getByLabelText('Select label value 2 of 2 for deployment rule 2 of 2'),
-            'beta{Enter}'
+            'kubernetes.io/metadata.release=beta{Enter}'
         );
 
         expect(resourceSelector).toEqual({
@@ -201,23 +204,43 @@ describe('Collection RuleSelector component', () => {
             rules: [
                 {
                     operator: 'OR',
-                    key: 'kubernetes.io/metadata.name',
-                    values: ['visa-processor', 'mastercard-processor', 'discover-processor'],
+                    values: [
+                        {
+                            value: 'kubernetes.io/metadata.name=visa-processor',
+                            matchType: 'EXACT',
+                        },
+                        {
+                            value: 'kubernetes.io/metadata.name=mastercard-processor',
+                            matchType: 'EXACT',
+                        },
+                        {
+                            value: 'kubernetes.io/metadata.name=discover-processor',
+                            matchType: 'EXACT',
+                        },
+                    ],
                 },
                 {
                     operator: 'OR',
-                    key: 'kubernetes.io/metadata.release',
-                    values: ['stable', 'beta'],
+                    values: [
+                        { value: 'kubernetes.io/metadata.release=stable', matchType: 'EXACT' },
+                        { value: 'kubernetes.io/metadata.release=beta', matchType: 'EXACT' },
+                    ],
                 },
             ],
         });
 
         // Check that deletion of all items removes the selector
-        await user.click(screen.getByLabelText('Delete stable'));
-        await user.click(screen.getByLabelText('Delete beta'));
-        await user.click(screen.getByLabelText('Delete visa-processor'));
-        await user.click(screen.getByLabelText('Delete mastercard-processor'));
-        await user.click(screen.getByLabelText('Delete discover-processor'));
+        await user.click(screen.getByLabelText('Delete kubernetes.io/metadata.release=stable'));
+        await user.click(screen.getByLabelText('Delete kubernetes.io/metadata.release=beta'));
+        await user.click(
+            screen.getByLabelText('Delete kubernetes.io/metadata.name=visa-processor')
+        );
+        await user.click(
+            screen.getByLabelText('Delete kubernetes.io/metadata.name=mastercard-processor')
+        );
+        await user.click(
+            screen.getByLabelText('Delete kubernetes.io/metadata.name=discover-processor')
+        );
 
         expect(resourceSelector).toEqual({ type: 'All' });
         expect(screen.getByText('All deployments')).toBeInTheDocument();

--- a/ui/apps/platform/src/Containers/Collections/converter.test.ts
+++ b/ui/apps/platform/src/Containers/Collections/converter.test.ts
@@ -14,20 +14,31 @@ describe('Collection parser', () => {
                         {
                             operator: 'OR',
                             fieldName: 'Cluster',
-                            values: [{ value: 'production' }],
+                            values: [{ value: 'production', matchType: 'EXACT' }],
                         },
                         {
                             operator: 'OR',
                             fieldName: 'Namespace Label',
                             values: [
-                                { value: 'kubernetes.io/metadata.name=backend' },
-                                { value: 'kubernetes.io/metadata.name=frontend' },
+                                {
+                                    value: 'kubernetes.io/metadata.name=backend',
+                                    matchType: 'EXACT',
+                                },
+                                {
+                                    value: 'kubernetes.io/metadata.name=frontend',
+                                    matchType: 'EXACT',
+                                },
                             ],
                         },
                         {
                             operator: 'OR',
                             fieldName: 'Namespace Label',
-                            values: [{ value: 'kubernetes.io/metadata.release=stable' }],
+                            values: [
+                                {
+                                    value: 'kubernetes.io/metadata.release=stable',
+                                    matchType: 'EXACT',
+                                },
+                            ],
                         },
                     ],
                 },
@@ -45,20 +56,32 @@ describe('Collection parser', () => {
                     rules: [
                         {
                             operator: 'OR',
-                            key: 'kubernetes.io/metadata.name',
-                            values: ['backend', 'frontend'],
+                            values: [
+                                {
+                                    value: 'kubernetes.io/metadata.name=backend',
+                                    matchType: 'EXACT',
+                                },
+                                {
+                                    value: 'kubernetes.io/metadata.name=frontend',
+                                    matchType: 'EXACT',
+                                },
+                            ],
                         },
                         {
                             operator: 'OR',
-                            key: 'kubernetes.io/metadata.release',
-                            values: ['stable'],
+                            values: [
+                                {
+                                    value: 'kubernetes.io/metadata.release=stable',
+                                    matchType: 'EXACT',
+                                },
+                            ],
                         },
                     ],
                 },
                 Cluster: {
                     type: 'ByName',
                     field: 'Cluster',
-                    rule: { operator: 'OR', values: ['production'] },
+                    rule: { operator: 'OR', values: [{ value: 'production', matchType: 'EXACT' }] },
                 },
             },
             embeddedCollectionIds: ['12', '13', '14'],
@@ -98,12 +121,12 @@ describe('Collection parser', () => {
                         {
                             operator: 'OR',
                             fieldName: 'Cluster',
-                            values: [{ value: 'production' }],
+                            values: [{ value: 'production', matchType: 'EXACT' }],
                         },
                         {
                             operator: 'OR',
                             fieldName: 'Cluster Label',
-                            values: [{ value: 'key=value' }],
+                            values: [{ value: 'key=value', matchType: 'EXACT' }],
                         },
                     ],
                 },
@@ -125,7 +148,7 @@ describe('Collection parser', () => {
                         {
                             operator: 'AND',
                             fieldName: 'Cluster',
-                            values: [{ value: 'production' }],
+                            values: [{ value: 'production', matchType: 'EXACT' }],
                         },
                     ],
                 },
@@ -147,7 +170,7 @@ describe('Collection parser', () => {
                         {
                             operator: 'AND',
                             fieldName: 'Cluster Annotation',
-                            values: [{ value: 'production' }],
+                            values: [{ value: 'production', matchType: 'EXACT' }],
                         },
                     ],
                 },
@@ -166,7 +189,11 @@ describe('Collection parser', () => {
             resourceSelectors: [
                 {
                     rules: [
-                        { operator: 'OR', fieldName: 'Cluster Label', values: [{ value: '' }] },
+                        {
+                            operator: 'OR',
+                            fieldName: 'Cluster Label',
+                            values: [{ value: '', matchType: 'EXACT' }],
+                        },
                     ],
                 },
             ],
@@ -226,13 +253,25 @@ describe('Collection response generator', () => {
                     rules: [
                         {
                             operator: 'OR',
-                            key: 'kubernetes.io/metadata.name',
-                            values: ['backend', 'frontend'],
+                            values: [
+                                {
+                                    value: 'kubernetes.io/metadata.name=backend',
+                                    matchType: 'EXACT',
+                                },
+                                {
+                                    value: 'kubernetes.io/metadata.name=frontend',
+                                    matchType: 'EXACT',
+                                },
+                            ],
                         },
                         {
                             operator: 'OR',
-                            key: 'kubernetes.io/metadata.release',
-                            values: ['stable'],
+                            values: [
+                                {
+                                    value: 'kubernetes.io/metadata.release=stable',
+                                    matchType: 'EXACT',
+                                },
+                            ],
                         },
                     ],
                 },
@@ -240,7 +279,7 @@ describe('Collection response generator', () => {
                 Cluster: {
                     type: 'ByName',
                     field: 'Cluster',
-                    rule: { operator: 'OR', values: ['production'] },
+                    rule: { operator: 'OR', values: [{ value: 'production', matchType: 'EXACT' }] },
                 },
             },
             embeddedCollectionIds: ['12', '13', '14'],
@@ -255,20 +294,31 @@ describe('Collection response generator', () => {
                         {
                             operator: 'OR',
                             fieldName: 'Cluster',
-                            values: [{ value: 'production' }],
+                            values: [{ value: 'production', matchType: 'EXACT' }],
                         },
                         {
                             operator: 'OR',
                             fieldName: 'Namespace Label',
                             values: [
-                                { value: 'kubernetes.io/metadata.name=backend' },
-                                { value: 'kubernetes.io/metadata.name=frontend' },
+                                {
+                                    value: 'kubernetes.io/metadata.name=backend',
+                                    matchType: 'EXACT',
+                                },
+                                {
+                                    value: 'kubernetes.io/metadata.name=frontend',
+                                    matchType: 'EXACT',
+                                },
                             ],
                         },
                         {
                             operator: 'OR',
                             fieldName: 'Namespace Label',
-                            values: [{ value: 'kubernetes.io/metadata.release=stable' }],
+                            values: [
+                                {
+                                    value: 'kubernetes.io/metadata.release=stable',
+                                    matchType: 'EXACT',
+                                },
+                            ],
                         },
                     ],
                 },

--- a/ui/apps/platform/src/Containers/Collections/converter.test.ts
+++ b/ui/apps/platform/src/Containers/Collections/converter.test.ts
@@ -180,62 +180,6 @@ describe('Collection parser', () => {
 
         expect(isCollectionParseError(parseCollection(collectionResponse))).toBeTruthy();
     });
-
-    it('should correctly handle label key/value splitting on `=` delimiter', () => {
-        const collectionResponse: Collection = {
-            id: 'a-b-c',
-            name: 'Sample',
-            description: 'Sample description',
-            resourceSelectors: [
-                {
-                    rules: [
-                        {
-                            operator: 'OR',
-                            fieldName: 'Cluster Label',
-                            values: [{ value: '', matchType: 'EXACT' }],
-                        },
-                    ],
-                },
-            ],
-            embeddedCollections: [],
-        };
-
-        // Get the resource selector we are interested in without so many type assertions
-        function getLabelRule(collection: Collection): LabelSelectorRule {
-            return (
-                (parseCollection(collection) as ClientCollection).resourceSelector
-                    .Cluster as ByLabelResourceSelector
-            ).rules[0];
-        }
-
-        const firstLabelRule = collectionResponse.resourceSelectors[0].rules[0].values[0];
-
-        // Test empty label key handling (NOTE, this should be forbidden from occurring by BE)
-        firstLabelRule.value = '=test';
-        expect(getLabelRule(collectionResponse)).toMatchObject({ key: '', values: ['test'] });
-
-        // Test empty label value handling (NOTE, this should be forbidden from occurring by BE)
-        firstLabelRule.value = 'test=';
-        expect(getLabelRule(collectionResponse)).toMatchObject({ key: 'test', values: [''] });
-
-        // Test plain characters
-        firstLabelRule.value = 'key=value';
-        expect(getLabelRule(collectionResponse)).toMatchObject({ key: 'key', values: ['value'] });
-
-        // Test subdomain prefix
-        firstLabelRule.value = 'app.kubernetes.io/name=value';
-        expect(getLabelRule(collectionResponse)).toMatchObject({
-            key: 'app.kubernetes.io/name',
-            values: ['value'],
-        });
-
-        // Test multiple '=' characters
-        firstLabelRule.value = 'app.kubernetes.io/name=value=with=extra=eq';
-        expect(getLabelRule(collectionResponse)).toMatchObject({
-            key: 'app.kubernetes.io/name',
-            values: ['value=with=extra=eq'],
-        });
-    });
 });
 
 describe('Collection response generator', () => {

--- a/ui/apps/platform/src/Containers/Collections/converter.test.ts
+++ b/ui/apps/platform/src/Containers/Collections/converter.test.ts
@@ -1,6 +1,6 @@
 import { CollectionRequest, Collection } from 'services/CollectionsService';
 import { generateRequest, isCollectionParseError, parseCollection } from './converter';
-import { ByLabelResourceSelector, ClientCollection, LabelSelectorRule } from './types';
+import { ClientCollection } from './types';
 
 describe('Collection parser', () => {
     it('should convert between BE CollectionResponse and FE Collection', () => {

--- a/ui/apps/platform/src/Containers/Collections/types.ts
+++ b/ui/apps/platform/src/Containers/Collections/types.ts
@@ -27,20 +27,47 @@ export function isByAnnotationField(field: SelectorField): field is ByAnnotation
     return byAnnotationRegExp.test(field);
 }
 
+export const byLabelMatchTypes = ['EXACT'] as const;
+export type ByLabelMatchType = typeof byLabelMatchTypes[number];
+export const byNameMatchType = ['EXACT', 'REGEX'] as const;
+export type ByNameMatchType = typeof byNameMatchType[number];
+export type MatchType = ByNameMatchType | ByLabelMatchType;
+
 /**
  * A valid server side `SelectorRule` can use either 'AND' or 'OR' operations to resolve values, but
  * the current UI implementation only supports 'OR'.
  */
 export type NameSelectorRule = {
     operator: 'OR';
-    values: string[];
+    values: { value: string; matchType: ByNameMatchType }[];
 };
 
 export type LabelSelectorRule = {
     operator: 'OR';
-    key: string;
-    values: string[];
+    values: { value: string; matchType: ByLabelMatchType }[];
 };
+
+export function isNameMatchValue(value: {
+    value: string;
+    matchType: string;
+}): value is NameSelectorRule['values'][number] {
+    /*
+     TODO - Requires BE
+    return byNameMatchType.includes(value.matchType as ByNameMatchType);
+    */
+    return true;
+}
+
+export function isLabelMatchValue(value: {
+    value: string;
+    matchType: string;
+}): value is LabelSelectorRule['values'][number] {
+    /*
+     TODO - Requires BE
+    return byLabelMatchTypes.includes(value.matchType as ByLabelMatchType);
+    */
+    return true;
+}
 
 /**
  * The front end currently only supports rules defined for names and labels, annotations are excluded.

--- a/ui/apps/platform/src/Containers/Collections/types.ts
+++ b/ui/apps/platform/src/Containers/Collections/types.ts
@@ -51,22 +51,14 @@ export function isNameMatchValue(value: {
     value: string;
     matchType: string;
 }): value is NameSelectorRule['values'][number] {
-    /*
-     TODO - Requires BE
     return byNameMatchType.includes(value.matchType as ByNameMatchType);
-    */
-    return true;
 }
 
 export function isLabelMatchValue(value: {
     value: string;
     matchType: string;
 }): value is LabelSelectorRule['values'][number] {
-    /*
-     TODO - Requires BE
     return byLabelMatchTypes.includes(value.matchType as ByLabelMatchType);
-    */
-    return true;
 }
 
 /**

--- a/ui/apps/platform/src/services/CollectionsService.ts
+++ b/ui/apps/platform/src/services/CollectionsService.ts
@@ -14,7 +14,7 @@ export const collectionsAutocompleteUrl = '/v1/collections/autocomplete';
 
 export type SelectorRule = {
     fieldName: string;
-    values: { value: string }[];
+    values: { value: string; matchType: string }[];
     operator: 'AND' | 'OR';
 };
 


### PR DESCRIPTION
## Description

This reworks the rule selection piece of the collection form to allow (and enforce) users to choose between "exact matching" and "regex matching" for name based rules, as well as combine the label based rule inputs into a single input field.

The reasons for this are:
1. There was no way for the user to specify if they wanted an exact match versus a regex match, which was unintuitive when a user selected a single option from one of the dropdowns. e.g. If a user selected "namespace=stackrox", they would not expect the rule to match deployments in namespace "stackrox2", which is what would happen.
2. Forcing the user to enter `^` and `$` characters, or automatically adding them, was a clunky solution that applied to what most likely would be the _default_ use case of selecting an exact match.
3. Splitting the label field made regex matching difficult as per https://issues.redhat.com/browse/ROX-14063. Additionally, it was decided that regex matching for this section was not needed for MVP so the fields were combined into a single field for simplicity and the ability to support autocomplete.
4. Combining the label key and value fields allows us to support autocomplete for those fields.

## TODO

- [x] There are a handful of places that are commented out that rely on the BE support of the "match_type" field that need to be fixed once completed.
- As a follow up, update tests to account for regex/exact field semantics and verify deployment matching.

## Review notes

- Many of the changes, especially in the test files, are due to the underlying rule data structure change from `{ values: string[] }` to `{ values: { value: string, matchType: string }[] }`
- Unfortunately there were enough changes to the ByName and ByLabel selector components that the diffs in those files are fairly large, mostly due to JSX changes. IMO these files are easier to review in GitHub's "split" view.
- The ByName and ByLabel selector components are very similar, but not quite similar enough that abstracting the functionality wouldn't lead to more confusing code. Instead I abstracted what I could from the styles into CSS to minimize the duplication of inline `classNames` and PF `<Flex>` props.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

From the create collection page, click the "All deployments" dropdown and select "deployments with names matching".
![image](https://user-images.githubusercontent.com/1292638/211856002-32994ade-47ef-4565-93cb-e01fb5051fd7.png)

Enter a value for "An exact value of" and verify that the deployments match:
![image](https://user-images.githubusercontent.com/1292638/211856125-250e19aa-1aae-49c6-8fa6-5d6967a501c3.png)
Note that this matches only "central", _exactly_. Click the "OR" button to add an addtional rule to match exactly "central-db" as well.
![image](https://user-images.githubusercontent.com/1292638/211856323-668b5779-1684-4ad5-be0a-b3ccb4bb7d33.png)

Delete the second rule and change the dropdown next to the input box to "A regex value of". Since the regex `/central/` matches both central and central-db, both of those deployments are matched:
![image](https://user-images.githubusercontent.com/1292638/211856579-3aa7eb86-26ac-49c2-a4d0-5b536f6c61a6.png)

A more complex regex value with wildcards and boundaries should match the correct deployments:
![image](https://user-images.githubusercontent.com/1292638/211856797-c9ff00f0-e3f7-4cf8-83b4-7ed075c9ca39.png)

Regex and exact value matches should be able to be combined in a single rule:
![image](https://user-images.githubusercontent.com/1292638/211856914-ad18a217-9652-4e6c-a721-bf10ef5a2c24.png)

Delete the "by name" rules, and select "Deployments with labels matching exactly" from the dropdown. This should allow you to enter a value in to get an exact label match. Note that regex matching is not supported, so `app=central` should _only_ match the `central` deployment and not `central-db`. **This currently isn't working, as the testing so far has been done against a draft version of https://github.com/stackrox/stackrox/pull/4351. These tests steps need to be re-verified once the BE work is complete and merged.**
![image](https://user-images.githubusercontent.com/1292638/211857355-843c651e-83cd-436b-948d-2ad6ead96c25.png)

