### PR TITLE
ROX-14217: Disable resync for RoleBindings and ClusterRoleBindings

### DIFF
--- a/sensor/kubernetes/listener/resource_event_handler.go
+++ b/sensor/kubernetes/listener/resource_event_handler.go
@@ -84,6 +84,7 @@ func (k *listenerImpl) handleAllEvents() {
 		k.credentialsManager,
 		k.traceWriter,
 		k.storeProvider,
+		k.client.Kubernetes(),
 	)
 
 	namespaceInformer := sif.Core().V1().Namespaces().Informer()

--- a/sensor/kubernetes/listener/resource_event_handler.go
+++ b/sensor/kubernetes/listener/resource_event_handler.go
@@ -92,8 +92,8 @@ func (k *listenerImpl) handleAllEvents() {
 
 	roleInformer := sif.Rbac().V1().Roles().Informer()
 	clusterRoleInformer := sif.Rbac().V1().ClusterRoles().Informer()
-	roleBindingInformer := resyncingSif.Rbac().V1().RoleBindings().Informer()
-	clusterRoleBindingInformer := resyncingSif.Rbac().V1().ClusterRoleBindings().Informer()
+	roleBindingInformer := sif.Rbac().V1().RoleBindings().Informer()
+	clusterRoleBindingInformer := sif.Rbac().V1().ClusterRoleBindings().Informer()
 
 	// prePodWaitGroup
 	prePodWaitGroup := &concurrency.WaitGroup{}

--- a/sensor/kubernetes/listener/resource_event_handler.go
+++ b/sensor/kubernetes/listener/resource_event_handler.go
@@ -93,8 +93,8 @@ func (k *listenerImpl) handleAllEvents() {
 
 	roleInformer := sif.Rbac().V1().Roles().Informer()
 	clusterRoleInformer := sif.Rbac().V1().ClusterRoles().Informer()
-	roleBindingInformer := sif.Rbac().V1().RoleBindings().Informer()
-	clusterRoleBindingInformer := sif.Rbac().V1().ClusterRoleBindings().Informer()
+	roleBindingInformer := resyncingSif.Rbac().V1().RoleBindings().Informer()
+	clusterRoleBindingInformer := resyncingSif.Rbac().V1().ClusterRoleBindings().Informer()
 
 	// prePodWaitGroup
 	prePodWaitGroup := &concurrency.WaitGroup{}

--- a/sensor/kubernetes/listener/resources/dispatcher.go
+++ b/sensor/kubernetes/listener/resources/dispatcher.go
@@ -20,6 +20,7 @@ import (
 	complianceOperatorDispatchers "github.com/stackrox/rox/sensor/kubernetes/listener/resources/complianceoperator/dispatchers"
 	"github.com/stackrox/rox/sensor/kubernetes/listener/resources/rbac"
 	"github.com/stackrox/rox/sensor/kubernetes/orchestratornamespaces"
+	"k8s.io/client-go/kubernetes"
 	v1Listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -66,6 +67,7 @@ func NewDispatcherRegistry(
 	credentialsManager awscredentials.RegistryCredentialsManager,
 	traceWriter io.Writer,
 	storeProvider *InMemoryStoreProvider,
+	k8sApi kubernetes.Interface,
 ) DispatcherRegistry {
 	serviceStore := storeProvider.serviceStore
 	rbacUpdater := storeProvider.rbacStore
@@ -83,7 +85,7 @@ func NewDispatcherRegistry(
 		deploymentHandler: newDeploymentHandler(clusterID, storeProvider.Services(), deploymentStore, podStore, endpointManager, nsStore,
 			rbacUpdater, podLister, processFilter, configHandler, namespaces, registryStore, credentialsManager),
 
-		rbacDispatcher:            rbac.NewDispatcher(rbacUpdater),
+		rbacDispatcher:            rbac.NewDispatcher(rbacUpdater, k8sApi),
 		namespaceDispatcher:       newNamespaceDispatcher(nsStore, serviceStore, deploymentStore, podStore, netPolicyStore),
 		serviceDispatcher:         newServiceDispatcher(serviceStore, deploymentStore, endpointManager, portExposureReconciler),
 		osRouteDispatcher:         newRouteDispatcher(serviceStore, portExposureReconciler),

--- a/sensor/kubernetes/listener/resources/dispatcher.go
+++ b/sensor/kubernetes/listener/resources/dispatcher.go
@@ -67,7 +67,7 @@ func NewDispatcherRegistry(
 	credentialsManager awscredentials.RegistryCredentialsManager,
 	traceWriter io.Writer,
 	storeProvider *InMemoryStoreProvider,
-	k8sApi kubernetes.Interface,
+	k8sAPI kubernetes.Interface,
 ) DispatcherRegistry {
 	serviceStore := storeProvider.serviceStore
 	rbacUpdater := storeProvider.rbacStore
@@ -85,7 +85,7 @@ func NewDispatcherRegistry(
 		deploymentHandler: newDeploymentHandler(clusterID, storeProvider.Services(), deploymentStore, podStore, endpointManager, nsStore,
 			rbacUpdater, podLister, processFilter, configHandler, namespaces, registryStore, credentialsManager),
 
-		rbacDispatcher:            rbac.NewDispatcher(rbacUpdater, k8sApi),
+		rbacDispatcher:            rbac.NewDispatcher(rbacUpdater, k8sAPI),
 		namespaceDispatcher:       newNamespaceDispatcher(nsStore, serviceStore, deploymentStore, podStore, netPolicyStore),
 		serviceDispatcher:         newServiceDispatcher(serviceStore, deploymentStore, endpointManager, portExposureReconciler),
 		osRouteDispatcher:         newRouteDispatcher(serviceStore, portExposureReconciler),

--- a/sensor/kubernetes/listener/resources/rbac/binding_fetcher.go
+++ b/sensor/kubernetes/listener/resources/rbac/binding_fetcher.go
@@ -6,6 +6,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/pkg/errorhelpers"
+	pkgKubernetes "github.com/stackrox/rox/pkg/kubernetes"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -53,11 +54,13 @@ func (r *bindingFetcher) generateDependentEvent(relatedBinding namespacedBinding
 		if err != nil {
 			return nil, errors.Wrapf(err, "fetching k8s API for ClusterRoleBinding %s", relatedBinding.name)
 		}
+		pkgKubernetes.TrimAnnotations(clusterBinding)
 		return toBindingEvent(toRoxClusterRoleBinding(clusterBinding, updateRoleID), central.ResourceAction_UPDATE_RESOURCE), nil
 	}
 	namespacedBinding, err := r.k8sAPI.RbacV1().RoleBindings(relatedBinding.namespace).Get(context.TODO(), relatedBinding.name, metav1.GetOptions{})
 	if err != nil {
 		return nil, errors.Wrapf(err, "fetching k8s API for ClusterRoleBinding %s", relatedBinding.name)
 	}
+	pkgKubernetes.TrimAnnotations(namespacedBinding)
 	return toBindingEvent(toRoxRoleBinding(namespacedBinding, updateRoleID, isClusterRole), central.ResourceAction_UPDATE_RESOURCE), nil
 }

--- a/sensor/kubernetes/listener/resources/rbac/binding_fetcher_test.go
+++ b/sensor/kubernetes/listener/resources/rbac/binding_fetcher_test.go
@@ -1,0 +1,48 @@
+package rbac
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_FetchBindingRemovesLastAppliedConfig(t *testing.T) {
+	fakeClient := fake.NewSimpleClientset()
+	_, err := fakeClient.RbacV1().ClusterRoleBindings().Create(context.Background(), &v1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-binding",
+			UID:  "test-uid",
+			Annotations: map[string]string{
+				"SomeKey": "SomeValue",
+				"kubectl.kubernetes.io/last-applied-configuration": "{\"some_prop\": \"value\"}",
+			},
+		},
+		Subjects: nil,
+		RoleRef: v1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     "test-role",
+		},
+	}, metav1.CreateOptions{})
+
+	require.NoError(t, err)
+
+	fetcher := newBindingFetcher(fakeClient)
+	event, err := fetcher.generateDependentEvent(namespacedBindingID{
+		name:      "test-binding",
+		namespace: "",
+		uid:       "test-uid",
+	}, "role-uid", true)
+
+	require.NoError(t, err)
+
+	assert.Equal(t, event.GetBinding().GetRoleId(), "role-uid")
+	annotations := event.GetBinding().GetAnnotations()
+	assert.Len(t, annotations, 1)
+	assert.Equal(t, annotations["SomeKey"], "SomeValue")
+}

--- a/sensor/kubernetes/listener/resources/rbac/binding_fetcher_test.go
+++ b/sensor/kubernetes/listener/resources/rbac/binding_fetcher_test.go
@@ -13,6 +13,8 @@ import (
 
 func Test_FetchBindingRemovesLastAppliedConfig(t *testing.T) {
 	fakeClient := fake.NewSimpleClientset()
+	fetcher := newBindingFetcher(fakeClient)
+
 	_, err := fakeClient.RbacV1().ClusterRoleBindings().Create(context.Background(), &v1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-binding",
@@ -32,7 +34,6 @@ func Test_FetchBindingRemovesLastAppliedConfig(t *testing.T) {
 
 	require.NoError(t, err)
 
-	fetcher := newBindingFetcher(fakeClient)
 	event, err := fetcher.generateDependentEvent(namespacedBindingID{
 		name:      "test-binding",
 		namespace: "",
@@ -43,6 +44,39 @@ func Test_FetchBindingRemovesLastAppliedConfig(t *testing.T) {
 
 	assert.Equal(t, event.GetBinding().GetRoleId(), "role-uid")
 	annotations := event.GetBinding().GetAnnotations()
+	assert.Len(t, annotations, 1)
+	assert.Equal(t, annotations["SomeKey"], "SomeValue")
+
+	_, err = fakeClient.RbacV1().RoleBindings("test-ns").Create(context.Background(), &v1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-ns-binding",
+			UID:       "test--ns-uid",
+			Namespace: "test-ns",
+			Annotations: map[string]string{
+				"SomeKey": "SomeValue",
+				"kubectl.kubernetes.io/last-applied-configuration": "{\"some_prop\": \"value\"}",
+			},
+		},
+		Subjects: nil,
+		RoleRef: v1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "Role",
+			Name:     "test-role",
+		},
+	}, metav1.CreateOptions{})
+
+	require.NoError(t, err)
+
+	event, err = fetcher.generateDependentEvent(namespacedBindingID{
+		name:      "test-ns-binding",
+		namespace: "test-ns",
+		uid:       "test-ns-uid",
+	}, "role-uid", true)
+
+	require.NoError(t, err)
+
+	assert.Equal(t, event.GetBinding().GetRoleId(), "role-uid")
+	annotations = event.GetBinding().GetAnnotations()
 	assert.Len(t, annotations, 1)
 	assert.Equal(t, annotations["SomeKey"], "SomeValue")
 }

--- a/sensor/kubernetes/listener/resources/rbac/binding_relationship.go
+++ b/sensor/kubernetes/listener/resources/rbac/binding_relationship.go
@@ -11,11 +11,11 @@ import (
 )
 
 type bindingFetcher struct {
-	k8sApi kubernetes.Interface
+	k8sAPI kubernetes.Interface
 }
 
-func newBindingFetcher(k8sApi kubernetes.Interface) *bindingFetcher {
-	return &bindingFetcher{k8sApi}
+func newBindingFetcher(k8sAPI kubernetes.Interface) *bindingFetcher {
+	return &bindingFetcher{k8sAPI}
 }
 
 func (r *bindingFetcher) generateManyDependentEvents(bindings []namespacedBindingID, updateRoleID string, isClusterRole bool) ([]*central.SensorEvent, error) {
@@ -37,16 +37,15 @@ func (r *bindingFetcher) generateManyDependentEvents(bindings []namespacedBindin
 
 func (r *bindingFetcher) generateDependentEvent(relatedBinding namespacedBindingID, updateRoleID string, isClusterRole bool) (*central.SensorEvent, error) {
 	if relatedBinding.IsClusterBinding() {
-		clusterBinding, err := r.k8sApi.RbacV1().ClusterRoleBindings().Get(context.TODO(), relatedBinding.name, metav1.GetOptions{})
+		clusterBinding, err := r.k8sAPI.RbacV1().ClusterRoleBindings().Get(context.TODO(), relatedBinding.name, metav1.GetOptions{})
 		if err != nil {
 			return nil, errors.Wrapf(err, "fetching k8s API for ClusterRoleBinding %s", relatedBinding.name)
 		}
 		return toBindingEvent(toRoxClusterRoleBinding(clusterBinding, updateRoleID), central.ResourceAction_UPDATE_RESOURCE), nil
-	} else {
-		namespacedBinding, err := r.k8sApi.RbacV1().RoleBindings(relatedBinding.namespace).Get(context.TODO(), relatedBinding.name, metav1.GetOptions{})
-		if err != nil {
-			return nil, errors.Wrapf(err, "fetching k8s API for ClusterRoleBinding %s", relatedBinding.name)
-		}
-		return toBindingEvent(toRoxRoleBinding(namespacedBinding, updateRoleID, isClusterRole), central.ResourceAction_UPDATE_RESOURCE), nil
 	}
+	namespacedBinding, err := r.k8sAPI.RbacV1().RoleBindings(relatedBinding.namespace).Get(context.TODO(), relatedBinding.name, metav1.GetOptions{})
+	if err != nil {
+		return nil, errors.Wrapf(err, "fetching k8s API for ClusterRoleBinding %s", relatedBinding.name)
+	}
+	return toBindingEvent(toRoxRoleBinding(namespacedBinding, updateRoleID, isClusterRole), central.ResourceAction_UPDATE_RESOURCE), nil
 }

--- a/sensor/kubernetes/listener/resources/rbac/binding_relationship.go
+++ b/sensor/kubernetes/listener/resources/rbac/binding_relationship.go
@@ -1,0 +1,52 @@
+package rbac
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stackrox/rox/pkg/errorhelpers"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+type bindingFetcher struct {
+	k8sApi kubernetes.Interface
+}
+
+func newBindingFetcher(k8sApi kubernetes.Interface) *bindingFetcher {
+	return &bindingFetcher{k8sApi}
+}
+
+func (r *bindingFetcher) generateManyDependentEvents(bindings []namespacedBindingID, updateRoleID string, isClusterRole bool) ([]*central.SensorEvent, error) {
+	errList := errorhelpers.NewErrorList("generating dependent binding events")
+	var result []*central.SensorEvent
+	for _, b := range bindings {
+		if newEvent, err := r.generateDependentEvent(b, updateRoleID, isClusterRole); err != nil {
+			errList.AddError(err)
+		} else {
+			result = append(result, newEvent)
+		}
+	}
+
+	if !errList.Empty() {
+		return nil, errList.ToError()
+	}
+	return result, nil
+}
+
+func (r *bindingFetcher) generateDependentEvent(relatedBinding namespacedBindingID, updateRoleID string, isClusterRole bool) (*central.SensorEvent, error) {
+	if relatedBinding.IsClusterBinding() {
+		clusterBinding, err := r.k8sApi.RbacV1().ClusterRoleBindings().Get(context.TODO(), relatedBinding.name, metav1.GetOptions{})
+		if err != nil {
+			return nil, errors.Wrapf(err, "fetching k8s API for ClusterRoleBinding %s", relatedBinding.name)
+		}
+		return toBindingEvent(toRoxClusterRoleBinding(clusterBinding, updateRoleID), central.ResourceAction_UPDATE_RESOURCE), nil
+	} else {
+		namespacedBinding, err := r.k8sApi.RbacV1().RoleBindings(relatedBinding.namespace).Get(context.TODO(), relatedBinding.name, metav1.GetOptions{})
+		if err != nil {
+			return nil, errors.Wrapf(err, "fetching k8s API for ClusterRoleBinding %s", relatedBinding.name)
+		}
+		return toBindingEvent(toRoxRoleBinding(namespacedBinding, updateRoleID, isClusterRole), central.ResourceAction_UPDATE_RESOURCE), nil
+	}
+}

--- a/sensor/kubernetes/listener/resources/rbac/dispatcher.go
+++ b/sensor/kubernetes/listener/resources/rbac/dispatcher.go
@@ -1,10 +1,9 @@
 package rbac
 
 import (
-	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
-	"github.com/stackrox/rox/pkg/utils"
+	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/component"
 	v1 "k8s.io/api/rbac/v1"
 )
@@ -12,29 +11,36 @@ import (
 // Dispatcher handles RBAC-related events
 type Dispatcher struct {
 	store Store
+	// pendingBindings holds the Binding events temporarily while the roles are not yet received. Any bindings without
+	// a role does not influence in the `PermissionLevel` of a deployment, so holding the binding until a role that
+	// matches it is received won't cause any loss of updates. This maps binding IDs to their K8s resource objects.
+	pendingBindings map[string]*storage.K8SRoleBinding
+}
+
+// rbacUpdate represents an RBAC event with the reference to deployments that might require reprocessing. These
+// deployments are dependents on this resource. The reference is based on the service account subject on the role
+// binding. Multiple subjects can be returned since the role can be updated with a subject change.
+type rbacUpdate struct {
+	events              []*central.SensorEvent
+	deploymentReference set.Set[namespacedSubject]
 }
 
 // NewDispatcher creates new instance of Dispatcher
 func NewDispatcher(store Store) *Dispatcher {
 	return &Dispatcher{
-		store: store,
+		store:           store,
+		pendingBindings: map[string]*storage.K8SRoleBinding{},
 	}
 }
 
 // ProcessEvent handles RBAC-related events
 func (r *Dispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAction) *component.ResourceEvent {
-	evt := r.processEvent(obj, action)
-	if evt == nil {
-		utils.Should(errors.Errorf("rbac obj %+v was not correlated to a sensor event", obj))
-		return nil
-	}
-	events := []*central.SensorEvent{
-		evt,
-	}
-	return component.NewResourceEvent(events, nil, nil)
+	update := r.processEvent(obj, action)
+	return component.NewResourceEvent(update.events, nil, nil)
 }
 
-func (r *Dispatcher) processEvent(obj interface{}, action central.ResourceAction) *central.SensorEvent {
+func (r *Dispatcher) processEvent(obj interface{}, action central.ResourceAction) rbacUpdate {
+	var update rbacUpdate
 	switch obj := obj.(type) {
 	case *v1.Role:
 		if action == central.ResourceAction_REMOVE_RESOURCE {
@@ -42,30 +48,57 @@ func (r *Dispatcher) processEvent(obj interface{}, action central.ResourceAction
 		} else {
 			r.store.UpsertRole(obj)
 		}
-		return toRoleEvent(toRoxRole(obj), action)
+		update.events = append(update.events, toRoleEvent(toRoxRole(obj), action))
+		update.events = append(update.events, r.processPendingBindingsMatching(obj.GetNamespace(), obj.GetName(), string(obj.GetUID()), false)...)
 	case *v1.RoleBinding:
 		if action == central.ResourceAction_REMOVE_RESOURCE {
 			r.store.RemoveBinding(obj)
 		} else {
 			r.store.UpsertBinding(obj)
 		}
-		return toBindingEvent(r.toRoxBinding(obj), action)
+		roxBinding := r.toRoxBinding(obj)
+		if roxBinding.GetRoleId() == "" {
+			r.pendingBindings[roxBinding.GetId()] = roxBinding
+		}
+		update.events = append(update.events, toBindingEvent(roxBinding, action))
 	case *v1.ClusterRole:
 		if action == central.ResourceAction_REMOVE_RESOURCE {
 			r.store.RemoveClusterRole(obj)
 		} else {
 			r.store.UpsertClusterRole(obj)
 		}
-		return toRoleEvent(toRoxClusterRole(obj), action)
+		update.events = append(update.events, toRoleEvent(toRoxClusterRole(obj), action))
+		update.events = append(update.events, r.processPendingBindingsMatching(obj.GetNamespace(), obj.GetName(), string(obj.GetUID()), true)...)
 	case *v1.ClusterRoleBinding:
 		if action == central.ResourceAction_REMOVE_RESOURCE {
 			r.store.RemoveClusterBinding(obj)
 		} else {
 			r.store.UpsertClusterBinding(obj)
 		}
-		return toBindingEvent(r.toRoxClusterRoleBinding(obj), action)
+		roxBinding := r.toRoxClusterRoleBinding(obj)
+		if roxBinding.GetRoleId() == "" {
+			r.pendingBindings[roxBinding.GetId()] = roxBinding
+		}
+		update.events = append(update.events, toBindingEvent(roxBinding, action))
 	}
-	return nil
+	return update
+}
+
+// processPendingBindingsMatching finds any binding events that were sent without a roleID, updates the roleID and
+// send them to central. Pending Bindings are then removed from the internal map, as any new updates will be able
+// to fetch the matching RoleID in the RBAC store.
+func (r *Dispatcher) processPendingBindingsMatching(namespace, name, id string, clusterWide bool) []*central.SensorEvent {
+	var updateEvents []*central.SensorEvent
+	bindings := r.store.FindBindingIDForRole(namespace, name, clusterWide)
+	log.Debugf("Found (%d) bindings for role (%s, %s): %+v", len(bindings), namespace, name, bindings)
+	for _, binding := range bindings {
+		if preProcessed, ok := r.pendingBindings[binding]; ok {
+			preProcessed.RoleId = id
+			updateEvents = append(updateEvents, toBindingEvent(preProcessed, central.ResourceAction_UPDATE_RESOURCE))
+			delete(r.pendingBindings, binding)
+		}
+	}
+	return updateEvents
 }
 
 func (r *Dispatcher) toRoxBinding(binding *v1.RoleBinding) *storage.K8SRoleBinding {

--- a/sensor/kubernetes/listener/resources/rbac/dispatcher.go
+++ b/sensor/kubernetes/listener/resources/rbac/dispatcher.go
@@ -24,10 +24,10 @@ type rbacUpdate struct {
 }
 
 // NewDispatcher creates new instance of Dispatcher
-func NewDispatcher(store Store, k8sApi kubernetes.Interface) *Dispatcher {
+func NewDispatcher(store Store, k8sAPI kubernetes.Interface) *Dispatcher {
 	return &Dispatcher{
 		store:   store,
-		fetcher: newBindingFetcher(k8sApi),
+		fetcher: newBindingFetcher(k8sAPI),
 	}
 }
 
@@ -42,7 +42,7 @@ func (r *Dispatcher) processEvent(obj interface{}, action central.ResourceAction
 	switch obj := obj.(type) {
 	case *v1.Role:
 		update.events = append(update.events, toRoleEvent(toRoxRole(obj), action))
-		relatedBindings := r.store.FindBindingIDForRole(obj.GetNamespace(), obj.GetName(), false)
+		relatedBindings := r.store.FindBindingIDForRole(obj.GetNamespace(), obj.GetName())
 		if action == central.ResourceAction_REMOVE_RESOURCE {
 			r.store.RemoveRole(obj)
 			update.events = append(update.events, r.mustGenerateRelatedEvents(relatedBindings, "", false)...)
@@ -62,7 +62,7 @@ func (r *Dispatcher) processEvent(obj interface{}, action central.ResourceAction
 		update.events = append(update.events, toBindingEvent(roxBinding, action))
 	case *v1.ClusterRole:
 		update.events = append(update.events, toRoleEvent(toRoxClusterRole(obj), action))
-		relatedBindings := r.store.FindBindingIDForRole(obj.GetNamespace(), obj.GetName(), true)
+		relatedBindings := r.store.FindBindingIDForRole(obj.GetNamespace(), obj.GetName())
 		if action == central.ResourceAction_REMOVE_RESOURCE {
 			r.store.RemoveClusterRole(obj)
 			update.events = append(update.events, r.mustGenerateRelatedEvents(relatedBindings, "", true)...)

--- a/sensor/kubernetes/listener/resources/rbac/dispatcher.go
+++ b/sensor/kubernetes/listener/resources/rbac/dispatcher.go
@@ -42,15 +42,15 @@ func (r *Dispatcher) processEvent(obj interface{}, action central.ResourceAction
 	switch obj := obj.(type) {
 	case *v1.Role:
 		update.events = append(update.events, toRoleEvent(toRoxRole(obj), action))
-		relatedBindings := r.store.FindBindingIDForRole(obj.GetNamespace(), obj.GetName())
+		relatedBindings := r.store.FindBindingForNamespacedRole(obj.GetNamespace(), obj.GetName())
 		if action == central.ResourceAction_REMOVE_RESOURCE {
 			r.store.RemoveRole(obj)
 			update.events = append(update.events, r.mustGenerateRelatedEvents(relatedBindings, "", false)...)
-		} else if action == central.ResourceAction_CREATE_RESOURCE {
+		} else if action == central.ResourceAction_UPDATE_RESOURCE {
+			r.store.UpsertRole(obj)
+		} else { // Create or Sync
 			r.store.UpsertRole(obj)
 			update.events = append(update.events, r.mustGenerateRelatedEvents(relatedBindings, string(obj.GetUID()), false)...)
-		} else {
-			r.store.UpsertRole(obj)
 		}
 	case *v1.RoleBinding:
 		if action == central.ResourceAction_REMOVE_RESOURCE {
@@ -62,15 +62,15 @@ func (r *Dispatcher) processEvent(obj interface{}, action central.ResourceAction
 		update.events = append(update.events, toBindingEvent(roxBinding, action))
 	case *v1.ClusterRole:
 		update.events = append(update.events, toRoleEvent(toRoxClusterRole(obj), action))
-		relatedBindings := r.store.FindBindingIDForRole(obj.GetNamespace(), obj.GetName())
+		relatedBindings := r.store.FindBindingForNamespacedRole(obj.GetNamespace(), obj.GetName())
 		if action == central.ResourceAction_REMOVE_RESOURCE {
 			r.store.RemoveClusterRole(obj)
 			update.events = append(update.events, r.mustGenerateRelatedEvents(relatedBindings, "", true)...)
-		} else if action == central.ResourceAction_CREATE_RESOURCE {
+		} else if action == central.ResourceAction_UPDATE_RESOURCE {
+			r.store.UpsertClusterRole(obj)
+		} else { // Create or Sync
 			r.store.UpsertClusterRole(obj)
 			update.events = append(update.events, r.mustGenerateRelatedEvents(relatedBindings, string(obj.GetUID()), true)...)
-		} else {
-			r.store.UpsertClusterRole(obj)
 		}
 	case *v1.ClusterRoleBinding:
 		if action == central.ResourceAction_REMOVE_RESOURCE {

--- a/sensor/kubernetes/listener/resources/rbac/namespaced_binding.go
+++ b/sensor/kubernetes/listener/resources/rbac/namespaced_binding.go
@@ -7,6 +7,7 @@ import (
 )
 
 type namespacedBindingID struct {
+	name      string
 	namespace string
 	uid       string
 }
@@ -43,11 +44,11 @@ func (b *namespacedBinding) Equal(other *namespacedBinding) bool {
 }
 
 func roleBindingToNamespacedBindingID(roleBinding *v1.RoleBinding) namespacedBindingID {
-	return namespacedBindingID{namespace: roleBinding.GetNamespace(), uid: string(roleBinding.GetUID())}
+	return namespacedBindingID{namespace: roleBinding.GetNamespace(), name: roleBinding.GetName(), uid: string(roleBinding.GetUID())}
 }
 
 func clusterRoleBindingToNamespacedBindingID(clusterRoleBinding *v1.ClusterRoleBinding) namespacedBindingID {
-	return namespacedBindingID{namespace: "", uid: string(clusterRoleBinding.GetUID())}
+	return namespacedBindingID{namespace: "", name: clusterRoleBinding.GetName(), uid: string(clusterRoleBinding.GetUID())}
 }
 
 // roleBindingToNamespacedBinding returns the namespaced binding from the role binding.

--- a/sensor/kubernetes/listener/resources/rbac/store.go
+++ b/sensor/kubernetes/listener/resources/rbac/store.go
@@ -23,7 +23,7 @@ type Store interface {
 	RemoveClusterBinding(binding *v1.ClusterRoleBinding)
 	GetPermissionLevelForDeployment(deployment rbac.NamespacedServiceAccount) storage.PermissionLevel
 
-	FindBindingIDForRole(namespace, roleName string, clusterWide bool) []string
+	FindBindingIDForRole(namespace, roleName string, clusterWide bool) []namespacedBindingID
 }
 
 // NewStore creates a new instance of Store

--- a/sensor/kubernetes/listener/resources/rbac/store.go
+++ b/sensor/kubernetes/listener/resources/rbac/store.go
@@ -23,7 +23,7 @@ type Store interface {
 	RemoveClusterBinding(binding *v1.ClusterRoleBinding)
 	GetPermissionLevelForDeployment(deployment rbac.NamespacedServiceAccount) storage.PermissionLevel
 
-	FindBindingIDForRole(namespace, roleName string, clusterWide bool) []namespacedBindingID
+	FindBindingIDForRole(namespace, roleName string) []namespacedBindingID
 }
 
 // NewStore creates a new instance of Store

--- a/sensor/kubernetes/listener/resources/rbac/store.go
+++ b/sensor/kubernetes/listener/resources/rbac/store.go
@@ -22,6 +22,8 @@ type Store interface {
 	UpsertClusterBinding(binding *v1.ClusterRoleBinding)
 	RemoveClusterBinding(binding *v1.ClusterRoleBinding)
 	GetPermissionLevelForDeployment(deployment rbac.NamespacedServiceAccount) storage.PermissionLevel
+
+	FindBindingIDForRole(namespace, roleName string, clusterWide bool) []string
 }
 
 // NewStore creates a new instance of Store

--- a/sensor/kubernetes/listener/resources/rbac/store.go
+++ b/sensor/kubernetes/listener/resources/rbac/store.go
@@ -23,7 +23,7 @@ type Store interface {
 	RemoveClusterBinding(binding *v1.ClusterRoleBinding)
 	GetPermissionLevelForDeployment(deployment rbac.NamespacedServiceAccount) storage.PermissionLevel
 
-	FindBindingIDForRole(namespace, roleName string) []namespacedBindingID
+	FindBindingForNamespacedRole(namespace, roleName string) []namespacedBindingID
 }
 
 // NewStore creates a new instance of Store

--- a/sensor/kubernetes/listener/resources/rbac/store_impl.go
+++ b/sensor/kubernetes/listener/resources/rbac/store_impl.go
@@ -111,6 +111,23 @@ func (rs *storeImpl) RemoveClusterBinding(binding *v1.ClusterRoleBinding) {
 	rs.removeRoleBindingGenericNoLock(bindingID)
 }
 
+func (rs *storeImpl) FindBindingIDForRole(namespace, roleName string, clusterWide bool) []string {
+	rs.lock.RLock()
+	defer rs.lock.RUnlock()
+
+	var matched []string
+	for binding, ref := range rs.bindings {
+		if ref.roleRef.name != roleName {
+			continue
+		}
+		if clusterWide || ref.roleRef.namespace == namespace {
+			matched = append(matched, binding.uid)
+		}
+	}
+
+	return matched
+}
+
 func (rs *storeImpl) rebuildEvaluatorBucketsNoLock() {
 	rs.bucketEvaluator = newBucketEvaluator(rs.roles, rs.bindings)
 	rs.dirty = false

--- a/sensor/kubernetes/listener/resources/rbac/store_impl.go
+++ b/sensor/kubernetes/listener/resources/rbac/store_impl.go
@@ -111,13 +111,16 @@ func (rs *storeImpl) RemoveClusterBinding(binding *v1.ClusterRoleBinding) {
 	rs.removeRoleBindingGenericNoLock(bindingID)
 }
 
-// TODO: Change name
-func (rs *storeImpl) FindBindingIDForRole(namespace, roleName string) []namespacedBindingID {
+func (rs *storeImpl) FindBindingForNamespacedRole(namespace, roleName string) []namespacedBindingID {
 	rs.lock.RLock()
 	defer rs.lock.RUnlock()
 
 	var matched []namespacedBindingID
 	for binding, ref := range rs.bindings {
+		// During binding processing `ref.roleRef.namespace` will be set to "" if binding references a ClusterRole.
+		// `namespace` parameter is also set to "" here, meaning that if the binding stored references a ClusterRole
+		// we can determine such by checking if ref.roleRef.namespace == namespace. Otherwise, this simply matches that
+		// a RoleBinding is in the same namespace that the Role being matched against.
 		if ref.roleRef.name == roleName && ref.roleRef.namespace == namespace {
 			matched = append(matched, binding)
 		}

--- a/sensor/kubernetes/listener/resources/rbac/store_impl.go
+++ b/sensor/kubernetes/listener/resources/rbac/store_impl.go
@@ -111,17 +111,18 @@ func (rs *storeImpl) RemoveClusterBinding(binding *v1.ClusterRoleBinding) {
 	rs.removeRoleBindingGenericNoLock(bindingID)
 }
 
-func (rs *storeImpl) FindBindingIDForRole(namespace, roleName string, clusterWide bool) []string {
+// TODO: Change name
+func (rs *storeImpl) FindBindingIDForRole(namespace, roleName string, clusterWide bool) []namespacedBindingID {
 	rs.lock.RLock()
 	defer rs.lock.RUnlock()
 
-	var matched []string
+	var matched []namespacedBindingID
 	for binding, ref := range rs.bindings {
 		if ref.roleRef.name != roleName {
 			continue
 		}
 		if clusterWide || ref.roleRef.namespace == namespace {
-			matched = append(matched, binding.uid)
+			matched = append(matched, binding)
 		}
 	}
 

--- a/sensor/kubernetes/listener/resources/rbac/store_impl.go
+++ b/sensor/kubernetes/listener/resources/rbac/store_impl.go
@@ -112,16 +112,13 @@ func (rs *storeImpl) RemoveClusterBinding(binding *v1.ClusterRoleBinding) {
 }
 
 // TODO: Change name
-func (rs *storeImpl) FindBindingIDForRole(namespace, roleName string, clusterWide bool) []namespacedBindingID {
+func (rs *storeImpl) FindBindingIDForRole(namespace, roleName string) []namespacedBindingID {
 	rs.lock.RLock()
 	defer rs.lock.RUnlock()
 
 	var matched []namespacedBindingID
 	for binding, ref := range rs.bindings {
-		if ref.roleRef.name != roleName {
-			continue
-		}
-		if clusterWide || ref.roleRef.namespace == namespace {
+		if ref.roleRef.name == roleName && ref.roleRef.namespace == namespace {
 			matched = append(matched, binding)
 		}
 	}

--- a/sensor/kubernetes/listener/resources/rbac/store_impl_test.go
+++ b/sensor/kubernetes/listener/resources/rbac/store_impl_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/protoconv"
 	"github.com/stackrox/rox/pkg/uuid"
 	"github.com/stretchr/testify/assert"
@@ -19,7 +20,12 @@ import (
 
 func TestStore(t *testing.T) {
 	// Run these tests only with feature flag enabled. Changes to the old path should be avoided whenever possible.
+	// TODO(ROX-14284): Re-enable this tests setting the custom env rather than the feature flag
 	t.Setenv("ROX_RESYNC_DISABLED", "true")
+	if !features.ResyncDisabled.Enabled() {
+		t.Skipf("Tests will fail if the new resyncless pass is disabled. E.g. in release tests")
+	}
+
 	// Namespace: n1
 	// Role: r1
 	// Bindings:

--- a/sensor/kubernetes/listener/resources/rbac/store_impl_test.go
+++ b/sensor/kubernetes/listener/resources/rbac/store_impl_test.go
@@ -18,6 +18,8 @@ import (
 )
 
 func TestStore(t *testing.T) {
+	// Run these tests only with feature flag enabled. Changes to the old path should be avoided whenever possible.
+	t.Setenv("ROX_RESYNC_DISABLED", "true")
 	// Namespace: n1
 	// Role: r1
 	// Bindings:

--- a/sensor/kubernetes/listener/resources/rbac/store_impl_test.go
+++ b/sensor/kubernetes/listener/resources/rbac/store_impl_test.go
@@ -141,7 +141,7 @@ func TestStore(t *testing.T) {
 		},
 		dispatcher.ProcessEvent(bindings[0], nil, central.ResourceAction_UPDATE_RESOURCE))
 
-	// Upsert the role for the previous binding. The next binding update will get its ID.
+	// Upsert the role for the previous binding. Should receive role and binding event related to role (b1).
 	assert.Equal(t,
 		&component.ResourceEvent{
 			ForwardMessages: []*central.SensorEvent{
@@ -163,6 +163,20 @@ func TestStore(t *testing.T) {
 								Resources: []string{""},
 								Verbs:     []string{"list"},
 							}},
+						},
+					},
+				},
+				{
+					Id:     "b1",
+					Action: central.ResourceAction_UPDATE_RESOURCE,
+					Resource: &central.SensorEvent_Binding{
+						Binding: &storage.K8SRoleBinding{
+							Id:        "b1",
+							Name:      "b1",
+							Namespace: "n1",
+							CreatedAt: protoconv.ConvertTimeToTimestamp(bindings[0].GetCreationTimestamp().Time),
+							RoleId:    "r1",
+							Subjects:  []*storage.Subject{},
 						},
 					},
 				}},
@@ -231,23 +245,55 @@ func TestStore(t *testing.T) {
 		},
 		dispatcher.ProcessEvent(clusterBindings[0], nil, central.ResourceAction_CREATE_RESOURCE))
 
-	// Upsert the role for the previous binding. The next binding update will get its ID.
+	// Upsert the role for the previous binding. Should receive role and two binding events related to role (b3 and b5).
 	assert.Equal(t,
 		&component.ResourceEvent{
-			ForwardMessages: []*central.SensorEvent{{
-				Id:     "r2",
-				Action: central.ResourceAction_UPDATE_RESOURCE,
-				Resource: &central.SensorEvent_Role{
-					Role: &storage.K8SRole{
-						Id:          "r2",
-						Name:        "r2",
-						Namespace:   "n1",
-						ClusterRole: true,
-						CreatedAt:   protoconv.ConvertTimeToTimestamp(clusterRoles[0].GetCreationTimestamp().Time),
-						Rules:       []*storage.PolicyRule{},
+			ForwardMessages: []*central.SensorEvent{
+				{
+					Id:     "r2",
+					Action: central.ResourceAction_UPDATE_RESOURCE,
+					Resource: &central.SensorEvent_Role{
+						Role: &storage.K8SRole{
+							Id:          "r2",
+							Name:        "r2",
+							Namespace:   "n1",
+							ClusterRole: true,
+							CreatedAt:   protoconv.ConvertTimeToTimestamp(clusterRoles[0].GetCreationTimestamp().Time),
+							Rules:       []*storage.PolicyRule{},
+						},
 					},
 				},
-			}},
+				{
+					Id:     "b5",
+					Action: central.ResourceAction_UPDATE_RESOURCE,
+					Resource: &central.SensorEvent_Binding{
+						Binding: &storage.K8SRoleBinding{
+							Id:          "b5",
+							Name:        "b5",
+							Namespace:   "n1",
+							RoleId:      "r2",
+							ClusterRole: true,
+							CreatedAt:   protoconv.ConvertTimeToTimestamp(bindings[2].GetCreationTimestamp().Time),
+							Subjects:    []*storage.Subject{},
+						},
+					},
+				},
+				{
+					Id:     "b3",
+					Action: central.ResourceAction_UPDATE_RESOURCE,
+					Resource: &central.SensorEvent_Binding{
+						Binding: &storage.K8SRoleBinding{
+							Id:          "b3",
+							Name:        "b3",
+							Namespace:   "n1",
+							ClusterRole: true,
+							RoleId:      "r2",
+							CreatedAt:   protoconv.ConvertTimeToTimestamp(clusterBindings[0].GetCreationTimestamp().Time),
+							Subjects:    []*storage.Subject{},
+						},
+					},
+				},
+			},
 		},
 		dispatcher.ProcessEvent(clusterRoles[0], nil, central.ResourceAction_UPDATE_RESOURCE))
 

--- a/sensor/tests/resource/helper.go
+++ b/sensor/tests/resource/helper.go
@@ -46,7 +46,7 @@ const (
 
 	// defaultCreationTimeout maximum time the test will wait until sensor emits
 	// resource creation event to central after fake resource was applied.
-	defaultCreationTimeout time.Duration = 10 * time.Second
+	defaultCreationTimeout time.Duration = 30 * time.Second
 )
 
 // YamlTestFile is a test file in YAML


### PR DESCRIPTION
## Description

Before fully disabling the re-sync for deployment-like resources we first need to disable it for RBAC Bindings.

We don't need to re-process bindings on _every_ Role/ClusterRole update, only if the Role wasn't in the system when the binding event was received. The approach here is to hold bindings in a `pending` map, where they are stored until the related Role is received. This way Sensor no longer needs to wait for a re-sync event to send the updated Binding event with `RoleID`.

This logic is hidden behind a feature flag.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] ~~Evaluated and added CHANGELOG entry if required~~
- [ ] ~~Determined and documented upgrade steps~~
- [ ] ~~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed
- Additional unit tests added to cover this case
- Tests added in #4296 cover Bindings getting updated on Role events
- E2E tests passed with version of the code without feature flag (re-sync disabled). Results here: https://prow.ci.openshift.org/pr-history/?org=stackrox&repo=stackrox&pr=4307