### PR TITLE
Consolidate node datastores: part 1

### DIFF
--- a/central/node/service/service_impl.go
+++ b/central/node/service/service_impl.go
@@ -5,16 +5,16 @@ import (
 
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/pkg/errors"
-	"github.com/stackrox/rox/central/node/globaldatastore"
+	"github.com/stackrox/rox/central/node/datastore/dackbox/datastore"
 	"github.com/stackrox/rox/central/role/resources"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/auth/permissions"
-	"github.com/stackrox/rox/pkg/errox"
 	pkgGRPC "github.com/stackrox/rox/pkg/grpc"
 	"github.com/stackrox/rox/pkg/grpc/authz"
 	"github.com/stackrox/rox/pkg/grpc/authz/perrpc"
 	"github.com/stackrox/rox/pkg/grpc/authz/user"
+	"github.com/stackrox/rox/pkg/search"
 	"google.golang.org/grpc"
 )
 
@@ -30,13 +30,13 @@ var (
 type nodeServiceImpl struct {
 	v1.UnimplementedNodeServiceServer
 
-	nodeStore globaldatastore.GlobalDataStore
+	nodeDatastore datastore.DataStore
 }
 
 // New creates a new node service from the given node store.
-func New(nodeStore globaldatastore.GlobalDataStore) pkgGRPC.APIService {
+func New(nodeDatastore datastore.DataStore) pkgGRPC.APIService {
 	return &nodeServiceImpl{
-		nodeStore: nodeStore,
+		nodeDatastore: nodeDatastore,
 	}
 }
 
@@ -54,12 +54,8 @@ func (s *nodeServiceImpl) AuthFuncOverride(ctx context.Context, fullMethodName s
 }
 
 func (s *nodeServiceImpl) ListNodes(ctx context.Context, req *v1.ListNodesRequest) (*v1.ListNodesResponse, error) {
-	clusterLocalStore, err := s.nodeStore.GetClusterNodeStore(ctx, req.GetClusterId(), false)
-	if err != nil {
-		return nil, errors.Errorf("could not access per-cluster node store for cluster %q: %v", req.GetClusterId(), err)
-	}
-
-	nodes, err := clusterLocalStore.ListNodes()
+	nodes, err := s.nodeDatastore.SearchRawNodes(ctx,
+		search.NewQueryBuilder().AddExactMatches(search.ClusterID, req.GetClusterId()).ProtoQuery())
 	if err != nil {
 		return nil, errors.Errorf("could not list notes in cluster %s: %v", req.GetClusterId(), err)
 	}
@@ -69,19 +65,11 @@ func (s *nodeServiceImpl) ListNodes(ctx context.Context, req *v1.ListNodesReques
 }
 
 func (s *nodeServiceImpl) GetNode(ctx context.Context, req *v1.GetNodeRequest) (*storage.Node, error) {
-	clusterLocalStore, err := s.nodeStore.GetClusterNodeStore(ctx, req.GetClusterId(), false)
-	if err != nil {
-		return nil, errors.Errorf("could not access per-cluster node store for cluster %q: %v", req.GetClusterId(), err)
+	// Nodes have non-composite unique node ID, hence, cluster ID is not required to retrieve a node.
+	// Note that whether we provide clusterID or not, the searcher will always perform SAC check in the graph.
+	node, found, err := s.nodeDatastore.GetNode(ctx, req.GetNodeId())
+	if err != nil || !found {
+		return nil, errors.Errorf("could not locate node %q for cluster %s: %v", req.GetNodeId(), req.GetClusterId(), err)
 	}
-
-	node, err := clusterLocalStore.GetNode(req.GetNodeId())
-	if err != nil {
-		return nil, errors.Errorf("could not locate node %q in per-cluster node store for cluster %s: %v", req.GetNodeId(), req.GetClusterId(), err)
-	}
-
-	if node == nil {
-		return nil, errors.Wrapf(errox.NotFound, "node %q in cluster %q does not exist", req.GetNodeId(), req.GetClusterId())
-	}
-
 	return node, nil
 }

--- a/central/node/service/singleton.go
+++ b/central/node/service/singleton.go
@@ -1,7 +1,7 @@
 package service
 
 import (
-	"github.com/stackrox/rox/central/node/globaldatastore"
+	"github.com/stackrox/rox/central/node/datastore/dackbox/datastore"
 	"github.com/stackrox/rox/pkg/grpc"
 	"github.com/stackrox/rox/pkg/sync"
 )
@@ -14,7 +14,7 @@ var (
 // Singleton returns the singleton instance for the node service.
 func Singleton() grpc.APIService {
 	serviceInstanceInit.Do(func() {
-		serviceInstance = New(globaldatastore.Singleton())
+		serviceInstance = New(datastore.Singleton())
 	})
 	return serviceInstance
 }


### PR DESCRIPTION
## Description

This is first of several PRs to refactor and simplify the node datastore. Nodes has multiple exported datastore interfaces:
- `central/node/globaldatastore/datastore.go`
- `central/node/datastore/datastore.go`
- `central/node/datastore/datastore.go`
 
It isn't very clear (and not necessary), and could be simplified with consolidation. For example, one can retrieve nodes for a cluster with clusterID query.

Note that the actual code change is limited to 2 files only and can be found in the first commit. The second commit is the result of running `make style`

## Checklist
- [ ] Investigated and inspected CI test results
- ~Unit test and regression tests added~
- ~Evaluated and added CHANGELOG entry if required~
- ~Determined and documented upgrade steps~
- ~Documented user facing changes~

If any of these don't apply, please comment below.

## Testing Performed
CI