### PR TITLE
ROX-13646: Add logs for port-forwarding in E2E tests

### DIFF
--- a/.openshift-ci/post_tests.py
+++ b/.openshift-ci/post_tests.py
@@ -26,6 +26,7 @@ class PostTestsConstants:
     DIAGNOSTIC_OUTPUT = "diagnostic-bundle"
     CENTRAL_DATA_OUTPUT = "central-data"
     STACKROX_LOG_DIR = "/tmp/stackrox-logs"
+    PORT_FORWARD_LOGS = "/tmp/port-forward-logs"
 
 
 class NullPostTest:
@@ -142,6 +143,7 @@ class PostClusterTest(StoreArtifacts):
         self.collect_service_logs()
         if self._check_stackrox_logs:
             self.check_stackrox_logs()
+        self.add_port_forward_logs()
         self.store_artifacts(test_outputs)
         self.add_test_results(test_results)
         self.handle_run_failure()
@@ -219,6 +221,9 @@ class PostClusterTest(StoreArtifacts):
             ["tests/e2e/lib.sh", "check_stackrox_logs", PostTestsConstants.K8S_LOG_DIR],
             timeout=PostTestsConstants.CHECK_TIMEOUT,
         )
+
+    def add_port_forward_logs(self):
+        self.data_to_store.append(PostTestsConstants.PORT_FORWARD_LOGS)
 
 
 class CheckStackroxLogs(StoreArtifacts):

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -11,6 +11,7 @@ source "$TEST_ROOT/scripts/ci/lib.sh"
 source "$TEST_ROOT/scripts/ci/test_state.sh"
 
 export QA_TEST_DEBUG_LOGS="/tmp/qa-tests-backend-logs"
+export PORT_FORWARD_LOGS="/tmp/port-forward-logs"
 
 # shellcheck disable=SC2120
 deploy_stackrox() {
@@ -239,8 +240,12 @@ start_port_forwards_for_test() {
     ulimit -n 65535 || true
 
     central_pod="$(kubectl -n stackrox get po -lapp=central -oname | head -n 1)"
+
+    mkdir -p "$PORT_FORWARD_LOGS"
+
     for target_port in 8080 8081 8082 8443 8444 8445 8446 8447 8448; do
-        nohup kubectl -n stackrox port-forward "${central_pod}" "$((target_port + 10000)):${target_port}" </dev/null &>/dev/null &
+        log_file="$PORT_FORWARD_LOGS/central-${target_port}.log"
+        nohup kubectl -n stackrox port-forward "${central_pod}" "$((target_port + 10000)):${target_port}" > "${log_file}" 2>&1 &
     done
     sleep 1
 }

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -245,7 +245,7 @@ start_port_forwards_for_test() {
 
     for target_port in 8080 8081 8082 8443 8444 8445 8446 8447 8448; do
         log_file="$PORT_FORWARD_LOGS/central-${target_port}.log"
-        nohup kubectl -n stackrox port-forward "${central_pod}" "$((target_port + 10000)):${target_port}" > "${log_file}" 2>&1 &
+        nohup kubectl -n stackrox port-forward "${central_pod}" "$((target_port + 10000)):${target_port}" < /dev/null > "${log_file}" 2>&1 &
     done
     sleep 1
 }


### PR DESCRIPTION
## Description

This PR adds logging of port-forwarding processes and storing them on the gcp storage among other artifacts and logs.
This is necessary to continue CI flake investigation when the port forwarding process is aborted for an unknown reason.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed
Tested on CI that logs are uploaded correctly for the jobs where they are used. 
Also checked that QA jobs are not affected by the change.

![Screenshot 2023-01-11 at 13 05 14](https://user-images.githubusercontent.com/8366110/211801977-e12c63cb-e912-4791-afc2-56818011312b.png)
 
![image](https://user-images.githubusercontent.com/8366110/211802131-ec6c25ef-d1be-41a5-8743-32eb6a609caa.png)

