### PR TITLE
Dashrews/ROX-14206 jsonpb configure unmarshaler to allow unknown fields in pkg/jsonutil

### DIFF
--- a/pkg/jsonutil/conversion.go
+++ b/pkg/jsonutil/conversion.go
@@ -21,9 +21,18 @@ const (
 	OptUnEscape
 )
 
+// JSONUnmarshaler returns a jsonpb Unmarshaler configured to allow unknown fields
+func JSONUnmarshaler() jsonpb.Unmarshaler {
+	var unmarshaler = jsonpb.Unmarshaler{}
+	unmarshaler.AllowUnknownFields = true
+
+	return unmarshaler
+}
+
 // JSONToProto converts a string containing JSON into a proto message.
 func JSONToProto(json string, m proto.Message) error {
-	return jsonpb.UnmarshalString(json, m)
+	unmarshaler := JSONUnmarshaler()
+	return unmarshaler.Unmarshal(strings.NewReader(json), m)
 }
 
 // ProtoToJSON converts a proto message into a string containing JSON.
@@ -59,11 +68,13 @@ func ProtoToJSON(m proto.Message, options ...ConversionOption) (string, error) {
 // unEscape restores characters escaped by JSON marshaller on behalf of the
 // jsonpb library. There is no option to disable escaping and a strong
 // opposition to add such functionality into jsonpb:
-//     https://github.com/golang/protobuf/pull/409#issuecomment-350385601
+//
+//	https://github.com/golang/protobuf/pull/409#issuecomment-350385601
 //
 // An alternative suggested by the jsonpb maintainers is to post process the
 // result JSON:
-//     https://github.com/golang/protobuf/issues/407
+//
+//	https://github.com/golang/protobuf/issues/407
 func unEscape(json string) string {
 	return re.ReplaceAllStringFunc(json, func(match string) string {
 		// If the match starts with "\\u...", the backwards slash is escaped,

--- a/pkg/jsonutil/conversion.go
+++ b/pkg/jsonutil/conversion.go
@@ -21,18 +21,19 @@ const (
 	OptUnEscape
 )
 
-// JSONUnmarshaler returns a jsonpb Unmarshaler configured to allow unknown fields
-func JSONUnmarshaler() jsonpb.Unmarshaler {
-	var unmarshaler = jsonpb.Unmarshaler{}
-	unmarshaler.AllowUnknownFields = true
-
-	return unmarshaler
+// JSONUnmarshaler returns a jsonpb Unmarshaler configured to allow unknown fields,
+// i.e. not error out unmarshaling JSON that contains attributes not defined in proto.
+// This Unmarshaler must be used everywhere instead of direct calls to jsonpb.Unmarshal
+// and jsonpb.UnmarshalString.
+func JSONUnmarshaler() *jsonpb.Unmarshaler {
+	return &jsonpb.Unmarshaler{
+		AllowUnknownFields: true,
+	}
 }
 
 // JSONToProto converts a string containing JSON into a proto message.
 func JSONToProto(json string, m proto.Message) error {
-	unmarshaler := JSONUnmarshaler()
-	return unmarshaler.Unmarshal(strings.NewReader(json), m)
+	return JSONUnmarshaler().Unmarshal(strings.NewReader(json), m)
 }
 
 // ProtoToJSON converts a proto message into a string containing JSON.

--- a/pkg/jsonutil/conversion_test.go
+++ b/pkg/jsonutil/conversion_test.go
@@ -10,10 +10,9 @@ import (
 
 func TestConversion(t *testing.T) {
 	type conversionTestCase struct {
-		desc            string
-		str             string
-		escaped         bool
-		addUnknonwField bool
+		desc    string
+		str     string
+		escaped bool
 	}
 
 	testCases := []conversionTestCase{
@@ -21,41 +20,21 @@ func TestConversion(t *testing.T) {
 			"String without special characters is preserved",
 			"E = mc^2",
 			false,
-			false,
 		},
 		{
 			"Some special characters (<, >, &) are escaped",
 			"A <= B & B >= C",
-			true,
-			false,
-		},
-		{
-			"String without special characters is preserved",
-			"E = mc^2",
-			false,
-			true,
-		},
-		{
-			"Some special characters (<, >, &) are escaped",
-			"A <= B & B >= C",
-			true,
 			true,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			// Unknown fields will be excluded in the result so we need to build a target JSON
-			// that will exclude those to verify the proto conversion was good.
-			inputJSON := jsonify(tc.str, tc.addUnknonwField)
-			targetJSON := jsonify(tc.str, false)
-			verifyJSONToProtoToJSON(t, inputJSON, targetJSON, !tc.escaped, []ConversionOption{})
+			verifyJSONToProtoToJSON(t, jsonify(tc.str), !tc.escaped, []ConversionOption{})
 		})
 
 		t.Run(tc.desc+" in compact JSON", func(t *testing.T) {
-			inputJSON := jsonifyCompact(tc.str, tc.addUnknonwField)
-			targetJSON := jsonifyCompact(tc.str, false)
-			verifyJSONToProtoToJSON(t, inputJSON, targetJSON, !tc.escaped, []ConversionOption{OptCompact})
+			verifyJSONToProtoToJSON(t, jsonifyCompact(tc.str), !tc.escaped, []ConversionOption{OptCompact})
 		})
 	}
 }
@@ -87,40 +66,29 @@ func TestConversionWithUnEscape(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			jsonData := jsonify(tc.str, false)
-			verifyJSONToProtoToJSON(t, jsonData, jsonData, true, []ConversionOption{OptUnEscape})
+			verifyJSONToProtoToJSON(t, jsonify(tc.str), true, []ConversionOption{OptUnEscape})
 		})
 
 		t.Run(tc.desc+" in compact JSON", func(t *testing.T) {
 			// Prevent JSON conversion from escaping specific charters.
-			jsonData := jsonifyCompact(tc.str, false)
-			verifyJSONToProtoToJSON(t, jsonData, jsonData, true, []ConversionOption{OptUnEscape, OptCompact})
+			verifyJSONToProtoToJSON(t, jsonifyCompact(tc.str), true, []ConversionOption{OptUnEscape, OptCompact})
 		})
 	}
 }
 
 // Hand-made compact JSON representation of v1.ResourceByID.
-func jsonifyCompact(value string, unknownField bool) string {
-	if unknownField {
-		return fmt.Sprintf(`{"id":"%s","unknownfield":"junk"}`, value)
-	}
+func jsonifyCompact(value string) string {
 	return fmt.Sprintf(`{"id":"%s"}`, value)
 }
 
 // Hand-made JSON representation of v1.ResourceByID.
-func jsonify(value string, unknownField bool) string {
-	if unknownField {
-		return fmt.Sprintf(`{
-  "id": "%s",
-  "unknownfield": "junk"
-}`, value)
-	}
+func jsonify(value string) string {
 	return fmt.Sprintf(`{
   "id": "%s"
 }`, value)
 }
 
-func verifyJSONToProtoToJSON(t *testing.T, inputJSON string, targetJSON string, shouldPreserve bool, options []ConversionOption) {
+func verifyJSONToProtoToJSON(t *testing.T, inputJSON string, shouldPreserve bool, options []ConversionOption) {
 	// Use ResourceByID proto because it contains a single string field.
 	var proto v1.ResourceByID
 
@@ -131,5 +99,15 @@ func verifyJSONToProtoToJSON(t *testing.T, inputJSON string, targetJSON string, 
 	// Conversion to only JSON escapes characters if specified in options.
 	convertedJSON, err := ProtoToJSON(&proto, options...)
 	assert.NoError(t, err)
-	assert.Equalf(t, shouldPreserve, targetJSON == convertedJSON, "original JSON:\n%s\ntargetJSON:\n%s\nconvertedJSON:\n%s", inputJSON, targetJSON, convertedJSON)
+	assert.Equalf(t, shouldPreserve, inputJSON == convertedJSON, "original JSON:\n%s\nconvertedJSON:\n%s", inputJSON, convertedJSON)
+}
+
+func TestNoErrorOnUnknownAttribute(t *testing.T) {
+	const json = `{ "id": "6500", "unknownField": "junk" }`
+	var proto v1.ResourceByID
+
+	err := JSONToProto(json, &proto)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "6500", proto.GetId())
 }

--- a/pkg/jsonutil/conversion_test.go
+++ b/pkg/jsonutil/conversion_test.go
@@ -10,9 +10,10 @@ import (
 
 func TestConversion(t *testing.T) {
 	type conversionTestCase struct {
-		desc    string
-		str     string
-		escaped bool
+		desc            string
+		str             string
+		escaped         bool
+		addUnknonwField bool
 	}
 
 	testCases := []conversionTestCase{
@@ -20,21 +21,35 @@ func TestConversion(t *testing.T) {
 			"String without special characters is preserved",
 			"E = mc^2",
 			false,
+			false,
 		},
 		{
 			"Some special characters (<, >, &) are escaped",
 			"A <= B & B >= C",
+			true,
+			false,
+		},
+		{
+			"String without special characters is preserved",
+			"E = mc^2",
+			false,
+			true,
+		},
+		{
+			"Some special characters (<, >, &) are escaped",
+			"A <= B & B >= C",
+			true,
 			true,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			verifyJSONToProtoToJSON(t, jsonify(tc.str), !tc.escaped, []ConversionOption{})
+			verifyJSONToProtoToJSON(t, jsonify(tc.str, tc.addUnknonwField), !tc.escaped, []ConversionOption{})
 		})
 
 		t.Run(tc.desc+" in compact JSON", func(t *testing.T) {
-			verifyJSONToProtoToJSON(t, jsonifyCompact(tc.str), !tc.escaped, []ConversionOption{OptCompact})
+			verifyJSONToProtoToJSON(t, jsonifyCompact(tc.str, tc.addUnknonwField), !tc.escaped, []ConversionOption{OptCompact})
 		})
 	}
 }
@@ -66,23 +81,23 @@ func TestConversionWithUnEscape(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			verifyJSONToProtoToJSON(t, jsonify(tc.str), true, []ConversionOption{OptUnEscape})
+			verifyJSONToProtoToJSON(t, jsonify(tc.str, false), true, []ConversionOption{OptUnEscape})
 		})
 
 		t.Run(tc.desc+" in compact JSON", func(t *testing.T) {
 			// Prevent JSON conversion from escaping specific charters.
-			verifyJSONToProtoToJSON(t, jsonifyCompact(tc.str), true, []ConversionOption{OptUnEscape, OptCompact})
+			verifyJSONToProtoToJSON(t, jsonifyCompact(tc.str, false), true, []ConversionOption{OptUnEscape, OptCompact})
 		})
 	}
 }
 
 // Hand-made compact JSON representation of v1.ResourceByID.
-func jsonifyCompact(value string) string {
+func jsonifyCompact(value string, unknownField bool) string {
 	return fmt.Sprintf(`{"id":"%s"}`, value)
 }
 
 // Hand-made JSON representation of v1.ResourceByID.
-func jsonify(value string) string {
+func jsonify(value string, unknownField bool) string {
 	return fmt.Sprintf(`{
   "id": "%s"
 }`, value)


### PR DESCRIPTION
## Description

ROX-14206 is part of the greater ROX-14188 to ensure that uses of jsonpb unmarshalers are configured to allow for unknown fields to be present for compatibility.  This issue was exposed recently when a field was added to the `metadata` service that subsequently broke older sensors connected to the update central.  Updated `JSONToProto` to AllowUnknownFields.  Additionally added `JSONUnmarshaler` that will return an unmarshaler configured to AllowUnknownFields that should be used as the rest of ROX-14206 progresses.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
