### PR TITLE
Dashrews/ROX-14166 postgres version to diag bundle

### DIFF
--- a/central/debug/service/service.go
+++ b/central/debug/service/service.go
@@ -704,7 +704,7 @@ func buildVersions(ctx context.Context) version.Versions {
 	// Add the database version if Postgres
 	if env.PostgresDatastoreEnabled.BooleanSetting() {
 		versions.Database = "PostgresDB"
-		versions.DatabaseVersion = globaldb.GetPostgresVersion(ctx, globaldb.GetPostgres())
+		versions.DatabaseServerVersion = globaldb.GetPostgresVersion(ctx, globaldb.GetPostgres())
 	}
 
 	return versions

--- a/central/globaldb/postgres.go
+++ b/central/globaldb/postgres.go
@@ -54,6 +54,8 @@ SELECT TABLE_NAME
   ) a
   WHERE oid = parent
 ) a;`
+
+	versionQuery = `SHOW server_version;`
 )
 
 var (
@@ -110,6 +112,20 @@ func InitializePostgres(ctx context.Context) *pgxpool.Pool {
 
 	})
 	return postgresDB
+}
+
+// GetPostgresVersion -- return version of the database
+func GetPostgresVersion(ctx context.Context, db *pgxpool.Pool) string {
+	ctx, cancel := context.WithTimeout(ctx, PostgresQueryTimeout)
+	defer cancel()
+
+	row := db.QueryRow(ctx, versionQuery)
+	var version string
+	if err := row.Scan(&version); err != nil {
+		log.Errorf("error fetching database version: %v", err)
+		return ""
+	}
+	return version
 }
 
 // CollectPostgresStats -- collect table level stats for Postgres

--- a/pkg/postgres/pgadmin/admin_utils.go
+++ b/pkg/postgres/pgadmin/admin_utils.go
@@ -426,3 +426,25 @@ func GetDatabaseSize(postgresConfig *pgxpool.Config, dbName string) (int64, erro
 	log.Infof("%q size = %d.", dbName, dbSize)
 	return dbSize, nil
 }
+
+// GetDatabaseVersion - returns the version of the database in use
+func GetDatabaseVersion(postgresConfig *pgxpool.Config) string {
+	// Connect to different database for admin functions
+	connectPool := GetAdminPool(postgresConfig)
+	// Close the admin connection pool
+	defer connectPool.Close()
+
+	// Create a context with a timeout
+	ctx, cancel := context.WithTimeout(context.Background(), PostgresQueryTimeout)
+	defer cancel()
+
+	versionStmt := "SHOW server_version;"
+
+	row := connectPool.QueryRow(ctx, versionStmt)
+	var version string
+	if err := row.Scan(&version); err != nil {
+		return ""
+	}
+
+	return version
+}

--- a/pkg/postgres/pgadmin/admin_utils.go
+++ b/pkg/postgres/pgadmin/admin_utils.go
@@ -426,25 +426,3 @@ func GetDatabaseSize(postgresConfig *pgxpool.Config, dbName string) (int64, erro
 	log.Infof("%q size = %d.", dbName, dbSize)
 	return dbSize, nil
 }
-
-// GetDatabaseVersion - returns the version of the database in use
-func GetDatabaseVersion(postgresConfig *pgxpool.Config) string {
-	// Connect to different database for admin functions
-	connectPool := GetAdminPool(postgresConfig)
-	// Close the admin connection pool
-	defer connectPool.Close()
-
-	// Create a context with a timeout
-	ctx, cancel := context.WithTimeout(context.Background(), PostgresQueryTimeout)
-	defer cancel()
-
-	versionStmt := "SHOW server_version;"
-
-	row := connectPool.QueryRow(ctx, versionStmt)
-	var version string
-	if err := row.Scan(&version); err != nil {
-		return ""
-	}
-
-	return version
-}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -44,8 +44,8 @@ type Versions struct {
 	ScannerVersion string `json:"ScannerVersion"`
 	ChartVersion   string `json:"ChartVersion"`
 	// The Database versioning needs to be added by the caller due to scoping issues of config availabilty
-	Database        string `json:"Database,omitempty"`
-	DatabaseVersion string `json:"DatabaseVersion,omitempty"`
+	Database              string `json:"Database,omitempty"`
+	DatabaseServerVersion string `json:"DatabaseServerVersion,omitempty"`
 }
 
 // GetAllVersionsDevelopment returns all of the various pieces of version information for development builds of the product.

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -44,8 +44,8 @@ type Versions struct {
 	ScannerVersion string `json:"ScannerVersion"`
 	ChartVersion   string `json:"ChartVersion"`
 	// The Database versioning needs to be added by the caller due to scoping issues of config availabilty
-	Database        string `json:"Database"`
-	DatabaseVersion string `json:"DatabaseVersion"`
+	Database        string `json:"Database,omitempty"`
+	DatabaseVersion string `json:"DatabaseVersion,omitempty"`
 }
 
 // GetAllVersionsDevelopment returns all of the various pieces of version information for development builds of the product.

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -43,6 +43,9 @@ type Versions struct {
 	// or rely on defaults.ImageFlavor if you need a default collector image tag.
 	ScannerVersion string `json:"ScannerVersion"`
 	ChartVersion   string `json:"ChartVersion"`
+	// The Database versioning needs to be added by the caller due to scoping issues of config availabilty
+	Database        string `json:"Database"`
+	DatabaseVersion string `json:"DatabaseVersion"`
 }
 
 // GetAllVersionsDevelopment returns all of the various pieces of version information for development builds of the product.


### PR DESCRIPTION
## Description

We need to add some postgres information to the diagnostic bundle.  This PR will add the Postgres version to the versions.json file returned from the `debug/versions.json` endpoint as well as the debug and diagnostic bundles.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Pulled debug and diagnostic bundles as well as hit the `debug/versions.json`.  Results locally were:
```
{
  "BuildDate": "2023-01-09T14:21:58Z",
  "CollectorVersion": "3.12.x-87-g3c7ee0569a",
  "GitCommit": "dfdc3d960f",
  "GoVersion": "go1.18.4",
  "MainVersion": "3.73.x-345-gdfdc3d960f-dirty",
  "Platform": "linux/amd64",
  "ScannerVersion": "2.27.x-14-ga0e7c00033",
  "ChartVersion": "73.0.345-gdfdc3d960f-dirty",
  "Database": "PostgresDB",
  "DatabaseServerVersion": "13.9"
}
```
