### PR TITLE
ROX-13634 resolve deployments by labels

### DIFF
--- a/sensor/common/store/mocks/types.go
+++ b/sensor/common/store/mocks/types.go
@@ -10,6 +10,7 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	storage "github.com/stackrox/rox/generated/storage"
 	rbac "github.com/stackrox/rox/sensor/common/rbac"
+	selector "github.com/stackrox/rox/sensor/common/selector"
 	service "github.com/stackrox/rox/sensor/common/service"
 	store "github.com/stackrox/rox/sensor/common/store"
 )
@@ -50,6 +51,20 @@ func (m *MockDeploymentStore) BuildDeploymentWithDependencies(id string, depende
 func (mr *MockDeploymentStoreMockRecorder) BuildDeploymentWithDependencies(id, dependencies interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildDeploymentWithDependencies", reflect.TypeOf((*MockDeploymentStore)(nil).BuildDeploymentWithDependencies), id, dependencies)
+}
+
+// FindDeploymentIDsByLabels mocks base method.
+func (m *MockDeploymentStore) FindDeploymentIDsByLabels(namespace string, sel selector.Selector) []string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindDeploymentIDsByLabels", namespace, sel)
+	ret0, _ := ret[0].([]string)
+	return ret0
+}
+
+// FindDeploymentIDsByLabels indicates an expected call of FindDeploymentIDsByLabels.
+func (mr *MockDeploymentStoreMockRecorder) FindDeploymentIDsByLabels(namespace, sel interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindDeploymentIDsByLabels", reflect.TypeOf((*MockDeploymentStore)(nil).FindDeploymentIDsByLabels), namespace, sel)
 }
 
 // FindDeploymentIDsWithServiceAccount mocks base method.

--- a/sensor/common/store/resolver/resolver.go
+++ b/sensor/common/store/resolver/resolver.go
@@ -1,6 +1,9 @@
 package resolver
 
-import "github.com/stackrox/rox/sensor/common/store"
+import (
+	"github.com/stackrox/rox/sensor/common/selector"
+	"github.com/stackrox/rox/sensor/common/store"
+)
 
 // DeploymentReference generates a list of deployment IDs that need to be updated given the deployment store.
 type DeploymentReference func(store store.DeploymentStore) []string
@@ -25,5 +28,12 @@ func ResolveDeploymentsByMultipleServiceAccounts(serviceAccounts []NamespaceServ
 			allIds = append(allIds, store.FindDeploymentIDsWithServiceAccount(sa.Namespace, sa.ServiceAccount)...)
 		}
 		return allIds
+	}
+}
+
+// ResolveDeploymentLabels returns a function that returns a list of deployment ids based on namespace and labels
+func ResolveDeploymentLabels(namespace string, sel selector.Selector) DeploymentReference {
+	return func(store store.DeploymentStore) []string {
+		return store.FindDeploymentIDsByLabels(namespace, sel)
 	}
 }

--- a/sensor/common/store/types.go
+++ b/sensor/common/store/types.go
@@ -3,6 +3,7 @@ package store
 import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/sensor/common/rbac"
+	"github.com/stackrox/rox/sensor/common/selector"
 	"github.com/stackrox/rox/sensor/common/service"
 )
 
@@ -12,6 +13,7 @@ type DeploymentStore interface {
 	GetAll() []*storage.Deployment
 	Get(id string) *storage.Deployment
 	FindDeploymentIDsWithServiceAccount(namespace, sa string) []string
+	FindDeploymentIDsByLabels(namespace string, sel selector.Selector) []string
 	BuildDeploymentWithDependencies(id string, dependencies Dependencies) (*storage.Deployment, error)
 }
 

--- a/sensor/kubernetes/listener/resources/deployment_store.go
+++ b/sensor/kubernetes/listener/resources/deployment_store.go
@@ -160,7 +160,7 @@ func (ds *DeploymentStore) FindDeploymentIDsByLabels(namespace string, sel selec
 			continue
 		}
 
-		if sel.Matches(selector.CreateLabelsWithLen(wrap.PodLabels)) {
+		if sel.Matches(selector.CreateLabelsWithLen(wrap.GetPodLabels())) {
 			resIDs = append(resIDs, id)
 		}
 	}

--- a/sensor/kubernetes/listener/resources/deployment_store.go
+++ b/sensor/kubernetes/listener/resources/deployment_store.go
@@ -145,6 +145,28 @@ func (ds *DeploymentStore) FindDeploymentIDsWithServiceAccount(namespace, sa str
 	return match
 }
 
+// FindDeploymentIDsByLabels returns a slice of deployments based on matching namespace and labels
+func (ds *DeploymentStore) FindDeploymentIDsByLabels(namespace string, sel selector.Selector) (resIDs []string) {
+	ds.lock.RLock()
+	defer ds.lock.RUnlock()
+	ids, found := ds.deploymentIDs[namespace]
+	if !found || ids == nil {
+		return
+	}
+
+	for id := range ids {
+		wrap, found := ds.deployments[id]
+		if !found || wrap == nil {
+			continue
+		}
+
+		if sel.Matches(selector.CreateLabelsWithLen(wrap.PodLabels)) {
+			resIDs = append(resIDs, id)
+		}
+	}
+	return
+}
+
 func (ds *DeploymentStore) getWrap(id string) *deploymentWrap {
 	ds.lock.RLock()
 	defer ds.lock.RUnlock()

--- a/sensor/kubernetes/listener/resources/deployment_store_bench_test.go
+++ b/sensor/kubernetes/listener/resources/deployment_store_bench_test.go
@@ -1,0 +1,76 @@
+package resources
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/sensor/common/selector"
+)
+
+var (
+	benchStore            *DeploymentStore
+	namespaceSelectorPoll []namespaceAndSelector
+)
+
+const charset = "abcdef0123456789"
+
+type namespaceAndSelector struct {
+	namespace string
+	selector  selector.Selector
+}
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+
+	benchStore = newDeploymentStore()
+
+	for i := 0; i < 1000; i++ {
+		benchStore.addOrUpdateDeployment(createDeploymentWrap())
+	}
+}
+
+func BenchmarkFindDeploymentIDsByLabels(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		// These should match
+		for j := 0; j < 1000; j++ {
+			nsAndSel := namespaceSelectorPoll[rand.Intn(len(namespaceSelectorPoll))]
+			benchStore.FindDeploymentIDsByLabels(nsAndSel.namespace, nsAndSel.selector)
+		}
+
+		// These should not match
+		for j := 0; j < 1000; j++ {
+			benchStore.FindDeploymentIDsByLabels("no-match-ns", selector.CreateSelector(map[string]string{"no": "match"}))
+		}
+	}
+}
+
+func randStringWithLength(n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = charset[rand.Intn(len(charset))]
+	}
+	return string(b)
+}
+
+func createDeploymentWrap() *deploymentWrap {
+	labels := make(map[string]string)
+	for i := 0; i < rand.Intn(10); i++ {
+		labels[randStringWithLength(16)] = randStringWithLength(16)
+	}
+	nsAndSel := namespaceAndSelector{
+		namespace: randStringWithLength(16),
+		selector:  selector.CreateSelector(labels, selector.EmptyMatchesNothing()),
+	}
+	namespaceSelectorPoll = append(namespaceSelectorPoll, nsAndSel)
+	return &deploymentWrap{
+		Deployment: &storage.Deployment{
+			Labels:    labels,
+			PodLabels: labels,
+			Namespace: nsAndSel.namespace,
+			Id:        randStringWithLength(16),
+			Name:      randStringWithLength(16),
+		},
+	}
+}

--- a/sensor/kubernetes/listener/resources/deployment_store_test.go
+++ b/sensor/kubernetes/listener/resources/deployment_store_test.go
@@ -191,16 +191,16 @@ func (s *deploymentStoreSuite) Test_FindDeploymentIDsByLabels() {
 		"Labels do not match": {
 			namespace: "test-ns",
 			labels: map[string]string{
-				"app": "nginx",
+				"app": "no-match",
 			},
-			expectedIDs: []string{"uuid-2"},
+			expectedIDs: nil,
 		},
-		"Namespace do not match": {
-			namespace: "test-ns",
+		"Namespaces do not match": {
+			namespace: "ns-no-match",
 			labels: map[string]string{
 				"app": "nginx",
 			},
-			expectedIDs: []string{"uuid-2"},
+			expectedIDs: nil,
 		},
 		"Deployment with two labels vs a subset Selector": {
 			namespace: "test-ns",
@@ -223,9 +223,7 @@ func (s *deploymentStoreSuite) Test_FindDeploymentIDsByLabels() {
 		s.Run(testName, func() {
 			ids := s.deploymentStore.FindDeploymentIDsByLabels(c.namespace, selector.CreateSelector(c.labels))
 			s.Equal(len(c.expectedIDs), len(ids))
-			sort.Strings(ids)
-			sort.Strings(c.expectedIDs)
-			s.Equal(c.expectedIDs, ids)
+			s.ElementsMatch(c.expectedIDs, ids)
 		})
 	}
 }

--- a/sensor/kubernetes/listener/resources/deployment_store_test.go
+++ b/sensor/kubernetes/listener/resources/deployment_store_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/uuid"
 	"github.com/stackrox/rox/sensor/common/registry"
+	"github.com/stackrox/rox/sensor/common/selector"
 	"github.com/stackrox/rox/sensor/common/service"
 	"github.com/stackrox/rox/sensor/common/store"
 	"github.com/stackrox/rox/sensor/kubernetes/orchestratornamespaces"
@@ -143,6 +144,90 @@ func (s *deploymentStoreSuite) Test_BuildDeploymentWithDependencies_NoDeployment
 	})
 
 	s.ErrorContains(err, "some-uuid doesn't exist")
+}
+
+func withLabels(deployment *v1.Deployment, labels map[string]string) *v1.Deployment {
+	deployment.Spec.Template.Labels = labels
+	return deployment
+}
+
+func (s *deploymentStoreSuite) Test_FindDeploymentIDsByLabels() {
+	deployments := []*v1.Deployment{
+		withLabels(makeDeploymentObject("d-1", "test-ns", "uuid-1"), map[string]string{}),
+		withLabels(makeDeploymentObject("d-2", "test-ns", "uuid-2"), map[string]string{
+			"app": "nginx",
+		}),
+		withLabels(makeDeploymentObject("d-3", "test-ns", "uuid-3"), map[string]string{
+			"no": "match",
+		}),
+		withLabels(makeDeploymentObject("d-4", "test-ns-no-match", "uuid-4"), map[string]string{
+			"app": "nginx",
+		}),
+		withLabels(makeDeploymentObject("d-5", "test-ns", "uuid-5"), map[string]string{
+			"app":  "nginx-2",
+			"role": "backend",
+		}),
+	}
+	for _, d := range deployments {
+		s.deploymentStore.addOrUpdateDeployment(s.createDeploymentWrap(d))
+	}
+	cases := map[string]struct {
+		namespace   string
+		labels      map[string]string
+		expectedIDs []string
+	}{
+		"No labels": {
+			namespace:   "test-ns",
+			labels:      nil,
+			expectedIDs: nil,
+		},
+		"Match": {
+			namespace: "test-ns",
+			labels: map[string]string{
+				"app": "nginx",
+			},
+			expectedIDs: []string{"uuid-2"},
+		},
+		"Labels do not match": {
+			namespace: "test-ns",
+			labels: map[string]string{
+				"app": "nginx",
+			},
+			expectedIDs: []string{"uuid-2"},
+		},
+		"Namespace do not match": {
+			namespace: "test-ns",
+			labels: map[string]string{
+				"app": "nginx",
+			},
+			expectedIDs: []string{"uuid-2"},
+		},
+		"Deployment with two labels vs a subset Selector": {
+			namespace: "test-ns",
+			labels: map[string]string{
+				"app": "nginx-2",
+			},
+			expectedIDs: []string{"uuid-5"},
+		},
+		"Deployment with two labels vs a superset Selector": {
+			namespace: "test-ns",
+			labels: map[string]string{
+				"app":  "nginx-2",
+				"role": "backend",
+				"l3":   "val3",
+			},
+			expectedIDs: nil,
+		},
+	}
+	for testName, c := range cases {
+		s.Run(testName, func() {
+			ids := s.deploymentStore.FindDeploymentIDsByLabels(c.namespace, selector.CreateSelector(c.labels))
+			s.Equal(len(c.expectedIDs), len(ids))
+			sort.Strings(ids)
+			sort.Strings(c.expectedIDs)
+			s.Equal(c.expectedIDs, ids)
+		})
+	}
 }
 
 func makeDeploymentObject(name, namespace string, id types.UID) *v1.Deployment {


### PR DESCRIPTION
## Description

Resolving deployment IDs based on labels. This enables us to resolve deployment dependencies on services/network policies updates.

This was part of #4015 

Depends on #4323

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

* Test the resources package locally
* Run the newly added benchmark `go test -bench=. -count=2 -run=^# github.com/stackrox/rox/sensor/kubernetes/listener/resources -test.bench FindDeploymentIDsByLabels`
