### PR TITLE
Add e2e tests for vm report config creation with collections

### DIFF
--- a/ui/apps/platform/cypress/helpers/formHelpers.js
+++ b/ui/apps/platform/cypress/helpers/formHelpers.js
@@ -40,6 +40,16 @@ export function getHelperElementByLabel(label) {
         });
 }
 
+/**
+ * Gets the parent `div` of a dt/dd description list group given the text value of the `dt`
+ * element and the text value of the `dd` element.
+ * @param {string} term The text content of the `dt` element
+ * @param {string} description The text content of the `dd` element
+ */
+export function getDescriptionListGroup(term, description) {
+    return cy.get(`div:has(dt:has(*:contains("${term}")) + dd:has(*:contains("${description}")))`);
+}
+
 export function generateNameWithDate(name) {
     const randomValue = new Date().toISOString();
     return `${name}-${randomValue}`;

--- a/ui/apps/platform/cypress/integration/vulnmanagement/reporting/reporting.helpers.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/reporting/reporting.helpers.js
@@ -140,3 +140,27 @@ export function interactAndWaitToCreateReport(
         : routeMatcherMapToCreate;
     interactAndWaitForResponses(interactionCallback, routeMatcherMap, staticResponseMap);
 }
+
+/**
+ * Deletes a VM report configuration via API, given the report config name. Note that since
+ * report configuration names are not unique, this will delete all reports matching the provided
+ * argument.
+ * @param {string} reportConfigName The name of the report to delete.
+ */
+export function tryDeleteVMReportConfigs(reportConfigName) {
+    const baseUrl = `/v1/report/configurations`;
+    const auth = { bearer: Cypress.env('ROX_AUTH_TOKEN') };
+
+    // Note that this list is unfiltered, which shouldn't be a problem in CI environments but we
+    // can change to a search filter once https://issues.redhat.com/browse/ROX-14238 is fixed
+    // if neded.
+    cy.request({ url: baseUrl, auth }).as('listReportConfigs');
+
+    cy.get('@listReportConfigs').then((res) => {
+        res.body.reportConfigs.forEach(({ id, name }) => {
+            if (name === reportConfigName) {
+                cy.request({ url: `${baseUrl}/${id}`, auth, method: 'DELETE' });
+            }
+        });
+    });
+}

--- a/ui/apps/platform/cypress/integration/vulnmanagement/reporting/reportingForm.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/reporting/reportingForm.test.js
@@ -1,6 +1,12 @@
 import withAuth from '../../../helpers/basicAuth';
 import { hasFeatureFlag } from '../../../helpers/features';
-import { getHelperElementByLabel, getInputByLabel } from '../../../helpers/formHelpers';
+import {
+    getDescriptionListGroup,
+    getHelperElementByLabel,
+    getInputByLabel,
+} from '../../../helpers/formHelpers';
+import { tryDeleteCollection } from '../../collections/Collections.helpers';
+import { tryDeleteIntegration } from '../../integrations/integrations.helpers';
 
 import {
     accessScopesAlias,
@@ -8,6 +14,7 @@ import {
     interactAndVisitVulnerabilityReporting,
     interactAndWaitToCreateReport,
     notifiersAlias,
+    tryDeleteVMReportConfigs,
     visitVulnerabilityReporting,
     visitVulnerabilityReportingToCreate,
 } from './reporting.helpers';
@@ -122,5 +129,115 @@ describe('Vulnerability Management Reporting form', () => {
 
         // TODO: once we are able to manipulate the PatternFly select element, uncomment and complete the test
         // cy.get('button:contains("Create")').should('be.enabled').click();
+    });
+
+    it('should allow creation of a report configuration', () => {
+        if (!isCollectionsEnabled) {
+            return;
+        }
+        // TODO Remove this once the feature is in
+        cy.intercept('/v1/collections/autocomplete', {});
+
+        const reportName = 'report config [e2e test]';
+        const reportDescription = 'ui e2e test report';
+        const collectionName = 'stackrox ns collection [e2e test]';
+        const emailNotifierName = 'report config email notifier [e2e test]';
+        const integrationsSource = 'notifiers';
+
+        // Delete collection from previous calls, if present
+        tryDeleteCollection(collectionName);
+        tryDeleteIntegration(integrationsSource, emailNotifierName);
+        tryDeleteVMReportConfigs(reportName);
+
+        visitVulnerabilityReportingToCreate({}, isCollectionsEnabled);
+
+        cy.get('h1:contains("Create an image vulnerability report")');
+
+        // Fill out report details
+        getInputByLabel('Report name').type(reportName);
+        getInputByLabel('Description').type(reportDescription);
+
+        getInputByLabel('Repeat report…').click();
+        cy.get('button[role="option"]:contains("Monthly")').click();
+
+        cy.get('button:has(*:contains("Select days"))').click();
+        cy.get('*[role="listbox"] span:contains("The middle of the month")').click();
+
+        getInputByLabel('Distribution list').type('scooby@mysteryinc.com');
+
+        cy.get('button:has(*:contains("Fixable states selected"))').click();
+        cy.get('*[role="listbox"] span:contains("Unfixable")').click();
+
+        cy.get('button:has(*:contains("Severities selected"))').click();
+        cy.get('*[role="listbox"] span:contains("Moderate")').click();
+        cy.get('*[role="listbox"] span:contains("Low")').click();
+
+        // Create an email notifier via modal
+        cy.get('button:contains("Create email notifier")').click();
+        getInputByLabel('Integration name').type(emailNotifierName);
+        getInputByLabel('Email server').type('e2e.test.rox.systems:465');
+        getInputByLabel('Enable unauthenticated SMTP').click();
+        getInputByLabel('Sender').type('e2e-test-sender@rox.systems');
+        getInputByLabel('Default recipient').type('e2e-test-recipient@rox.systems');
+        cy.get('*[role="dialog"] button:contains("Save integration")').click();
+
+        // The newly created notifier should automatically be selected in the input
+        cy.get(`button[aria-label="Select a notifier"]:contains("${emailNotifierName}")`);
+
+        // Create a collection via modal
+        cy.get('button:contains("Create collection")').click();
+
+        cy.get('*[role="dialog"] input[name="name"]').type(collectionName);
+        cy.get('*[role="dialog"] button:contains("All namespaces")').click();
+        cy.get('*[role="dialog"] button:contains("Namespaces with names matching")').click();
+        cy.get(
+            '*[role="dialog"] input[aria-label="Select value 1 of 1 for the namespace name"]'
+        ).type('stackrox');
+        cy.get(`*[role="dialog"] button:contains('stackrox')`).click();
+        cy.get('*[role="dialog"] button:contains("Save")').click();
+
+        // The newly created collection should automatically be selected
+        cy.get(`input[placeholder="Select a collection"]`)
+            .invoke('val')
+            .should('equal', collectionName);
+
+        // Create the VM Report config
+        cy.get('button[data-testid="create-btn"]').click();
+
+        // Redirected back to report config table
+        // TODO For some reason when submitting the form via a browser automated by Cypress, we get a white screen with
+        // no error information, so we have to manually visit the report config table from here.
+        visitVulnerabilityReporting();
+
+        // Find the report in the table and click it to go to the details page
+        cy.get(`td a:contains("${reportName}")`).click();
+
+        cy.get(`h1:contains("${reportName}")`);
+
+        // Check that entered values were saved correctly on the details view
+        getDescriptionListGroup('Description', reportDescription);
+        getDescriptionListGroup('CVE fixability type', 'Fixable');
+        getDescriptionListGroup('Notification method', emailNotifierName);
+        getDescriptionListGroup('Distribution list', 'scooby@mysteryinc.com');
+        getDescriptionListGroup(
+            'Reporting schedule',
+            'Repeat report monthly on the middle of the month'
+        );
+        getDescriptionListGroup('CVE severities', 'Critical');
+        getDescriptionListGroup('CVE severities', 'Important');
+        getDescriptionListGroup('CVE severities', 'Moderate').should('not.exist');
+        getDescriptionListGroup('CVE severities', 'Low').should('not.exist');
+        getDescriptionListGroup('Report scope', collectionName);
+
+        // Visit the linked collection page
+        cy.get(`a:contains("${collectionName}")`).click();
+
+        // Verify that we have landed on the correct collection page
+        cy.get(`h1:contains("${collectionName}")`);
+
+        // Self cleanup
+        tryDeleteCollection(collectionName);
+        tryDeleteIntegration(integrationsSource, emailNotifierName);
+        tryDeleteVMReportConfigs(reportName);
     });
 });

--- a/ui/apps/platform/src/Components/SelectSingle/SelectSingle.tsx
+++ b/ui/apps/platform/src/Components/SelectSingle/SelectSingle.tsx
@@ -3,6 +3,7 @@ import { Select, SelectVariant } from '@patternfly/react-core';
 
 export type SelectSingleProps = {
     toggleIcon?: ReactElement;
+    toggleAriaLabel?: string;
     id: string;
     value: string;
     handleSelect: (name: string, value: string) => void;
@@ -16,6 +17,7 @@ export type SelectSingleProps = {
 
 function SelectSingle({
     toggleIcon,
+    toggleAriaLabel,
     id,
     value,
     handleSelect,
@@ -40,6 +42,7 @@ function SelectSingle({
         <Select
             variant={isTypeahead}
             toggleIcon={toggleIcon}
+            toggleAriaLabel={toggleAriaLabel}
             id={id}
             isDisabled={isDisabled}
             isOpen={isOpen}

--- a/ui/apps/platform/src/Containers/VulnMgmt/Reports/Form/NotifierSelection.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Reports/Form/NotifierSelection.tsx
@@ -89,6 +89,7 @@ function NotifierSelection({
                     >
                         <SelectSingle
                             id="emailConfig.notifierId"
+                            toggleAriaLabel="Select a notifier"
                             value={notifierId}
                             handleSelect={onNotifierChange}
                             placeholderText="Select a notifier"


### PR DESCRIPTION
## Description

Adds a Cypress e2e test to cover:

- Creation of a VM report config
- Creation of an email notifier via modal from within the VM config page
- Creation of a collection via modal from within the VM config page

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Local Cypress run:
<img width="1676" alt="image" src="https://user-images.githubusercontent.com/1292638/211573168-9ec2dc90-607f-4095-8122-c6bf34bd23c5.png">

