### PR TITLE
Fix nil pointer panic in telemetry config

### DIFF
--- a/central/telemetry/centralclient/instance_config.go
+++ b/central/telemetry/centralclient/instance_config.go
@@ -38,7 +38,9 @@ func getInstanceConfig() (*phonehome.Config, map[string]any, error) {
 	v := &k8sVersion.Info{GitVersion: "unknown"}
 	if rc, err := rest.InClusterConfig(); err == nil {
 		if clientset, err := kubernetes.NewForConfig(rc); err == nil {
-			v, _ = clientset.ServerVersion()
+			if serverVersion, err := clientset.ServerVersion(); err == nil {
+				v = serverVersion
+			}
 		}
 	}
 


### PR DESCRIPTION
## Description

In restricted environments (e.g. ACSCS), Central may not be able to reach out to the Kubernetes API server to retrieve metadata (e.g. due to missing RBAC, proxy configuration etc.).

While we added logic to ignore potential errors during initialization (e.g. reading the service account token / CA from file, setting up the clients), we ignore any error returned from `discoveryclient.ServerVersion()`.

This lead to `v` being set to `nil` when `err != nil` ([see reference](https://github.com/kubernetes/client-go/blob/master/discovery/discovery_client.go#L567-L578)) and subsequently to a nil pointer panic when accessing `v.GitVersion`.

Now, we do not ignore the error and only set `v` in case of `err == nil`.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

