### PR TITLE
Consolidate node datastores: part 3

### DIFF
--- a/central/sensor/service/pipeline/nodes/pipeline.go
+++ b/central/sensor/service/pipeline/nodes/pipeline.go
@@ -7,14 +7,12 @@ import (
 	clusterDataStore "github.com/stackrox/rox/central/cluster/datastore"
 	"github.com/stackrox/rox/central/enrichment"
 	countMetrics "github.com/stackrox/rox/central/metrics"
-	"github.com/stackrox/rox/central/node/datastore"
-	"github.com/stackrox/rox/central/node/globaldatastore"
+	nodeDatastore "github.com/stackrox/rox/central/node/datastore/dackbox/datastore"
 	"github.com/stackrox/rox/central/risk/manager"
 	"github.com/stackrox/rox/central/sensor/service/common"
 	"github.com/stackrox/rox/central/sensor/service/pipeline"
 	"github.com/stackrox/rox/central/sensor/service/pipeline/reconciliation"
 	"github.com/stackrox/rox/generated/internalapi/central"
-	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/metrics"
 	"github.com/stackrox/rox/pkg/nodes/enricher"
@@ -30,41 +28,36 @@ var (
 
 // GetPipeline returns an instantiation of this particular pipeline
 func GetPipeline() pipeline.Fragment {
-	return NewPipeline(clusterDataStore.Singleton(), globaldatastore.Singleton(), enrichment.NodeEnricherSingleton(), manager.Singleton())
+	return NewPipeline(clusterDataStore.Singleton(), nodeDatastore.Singleton(), enrichment.NodeEnricherSingleton(), manager.Singleton())
 }
 
 // NewPipeline returns a new instance of Pipeline.
-func NewPipeline(clusters clusterDataStore.DataStore, nodes globaldatastore.GlobalDataStore, enricher enricher.NodeEnricher, riskManager manager.Manager) pipeline.Fragment {
+func NewPipeline(clusters clusterDataStore.DataStore, nodes nodeDatastore.DataStore, enricher enricher.NodeEnricher, riskManager manager.Manager) pipeline.Fragment {
 	return &pipelineImpl{
-		clusterStore: clusters,
-		nodeStore:    nodes,
-		enricher:     enricher,
-		riskManager:  riskManager,
+		clusterStore:  clusters,
+		nodeDatastore: nodes,
+		enricher:      enricher,
+		riskManager:   riskManager,
 	}
 }
 
 type pipelineImpl struct {
-	clusterStore clusterDataStore.DataStore
-	nodeStore    globaldatastore.GlobalDataStore
-	enricher     enricher.NodeEnricher
-	riskManager  manager.Manager
+	clusterStore  clusterDataStore.DataStore
+	nodeDatastore nodeDatastore.DataStore
+	enricher      enricher.NodeEnricher
+	riskManager   manager.Manager
 }
 
 func (p *pipelineImpl) Reconcile(ctx context.Context, clusterID string, storeMap *reconciliation.StoreMap) error {
 	query := search.NewQueryBuilder().AddExactMatches(search.ClusterID, clusterID).ProtoQuery()
-	results, err := p.nodeStore.Search(ctx, query)
+	results, err := p.nodeDatastore.Search(ctx, query)
 	if err != nil {
 		return err
 	}
 
-	clusterStore, err := p.nodeStore.GetClusterNodeStore(ctx, clusterID, true)
-	if err != nil {
-		return errors.Wrap(err, "getting cluster-local node store")
-	}
-
 	store := storeMap.Get((*central.SensorEvent_Node)(nil))
 	return reconciliation.Perform(store, search.ResultsToIDSet(results), "nodes", func(id string) error {
-		return p.processRemove(clusterStore, &storage.Node{Id: id})
+		return p.processRemove(ctx, id)
 	})
 }
 
@@ -72,8 +65,8 @@ func (p *pipelineImpl) Match(msg *central.MsgFromSensor) bool {
 	return msg.GetEvent().GetNode() != nil
 }
 
-func (p *pipelineImpl) processRemove(ds datastore.DataStore, n *storage.Node) error {
-	return ds.RemoveNode(n.GetId())
+func (p *pipelineImpl) processRemove(ctx context.Context, id string) error {
+	return p.nodeDatastore.DeleteNodes(ctx, id)
 }
 
 // Run runs the pipeline template on the input and returns the output.
@@ -86,13 +79,8 @@ func (p *pipelineImpl) Run(ctx context.Context, clusterID string, msg *central.M
 		return errors.Errorf("unexpected resource type %T for cluster status", event.GetResource())
 	}
 
-	store, err := p.nodeStore.GetClusterNodeStore(ctx, clusterID, true)
-	if err != nil {
-		return errors.Wrap(err, "getting cluster-local node store")
-	}
-
 	if event.GetAction() == central.ResourceAction_REMOVE_RESOURCE {
-		return p.processRemove(store, node)
+		return p.processRemove(ctx, node.GetId())
 	}
 
 	node = node.Clone()


### PR DESCRIPTION
## Description

Removes global datastore from message pipeline.

Part 1: #4309 
Part 2: #4315 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed
CI