### PR TITLE
Update cypress 12.3.0 devDependencies in ui

### DIFF
--- a/ui/apps/platform/package.json
+++ b/ui/apps/platform/package.json
@@ -134,7 +134,7 @@
         "@types/react-redux": "^7.1.20",
         "autoprefixer": "^10.2.5",
         "babel-eslint": "^10.1.0",
-        "cypress": "^12.0.2",
+        "cypress": "^12.3.0",
         "eslint": "^7.32.0",
         "eslint-config-airbnb": "^18.2.1",
         "eslint-config-airbnb-typescript": "12.3.1",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -7327,10 +7327,10 @@ cyclist@^1.0.1:
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
 
-cypress@^12.0.2:
-  version "12.0.2"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-12.0.2.tgz#0437abf9d97ad4a972ab554968d58211b0ce4ae5"
-  integrity sha512-WnLx1DpnbF1vbpDBkgP14rK5yS3U+Gvxrv2fsB4Owma26oIyENj7DDRnsJbSZuTfG4mcuUJxAkRHJR2wBqBfMA==
+cypress@^12.3.0:
+  version "12.3.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-12.3.0.tgz#ae3fb0540aef4b5eab1ef2bcd0760caf2992b8bf"
+  integrity sha512-ZQNebibi6NBt51TRxRMYKeFvIiQZ01t50HSy7z/JMgRVqBUey3cdjog5MYEbzG6Ktti5ckDt1tfcC47lmFwXkw==
   dependencies:
     "@cypress/request" "^2.88.10"
     "@cypress/xvfb" "^1.2.4"


### PR DESCRIPTION
## Description

Upgrade to get baseline on current CI to compare with future improvements.

https://docs.cypress.io/guides/references/changelog#12-3-0

* Increased the pre-request proxy cleanup interval. The previous cleanup interval was too aggressive for projects loading a large number of JS modules, causing applications to load very slowly and in chunks.

* Fixed an issue where browsers distributed as universal binaries (Chrome, Firefox) on M1 Macs could be launched in the wrong architecture, resulting in poor performance in-browser.

* Upgraded engine.io from 5.2.1 to 6.2.1 to address security vulnerability where a specially crafted HTTP request can trigger an uncaught exception on the Engine.IO server, thus killing the Node.js process.

* Upgraded express from 4.17.1 to 4.17.3 to address security vulnerability.

* Upgraded simple-git from 3.4.0 to 3.15.0 to address security vulnerability.

https://docs.cypress.io/guides/references/changelog#12-2-0

* Added the ability to match on `resourceType` with `cy.intercept()`, and to see the resource type of an intercepted request as `req.resourceType`.

* Fixed a regression introduced in the Electron browser in Cypress 10.8.0 where the `CYPRESS_EVERY_NTH_FRAME` environment variable was not being set appropriately causing all frames to be captured which slowed down tests.

* Fixed an issue where an unhandled promise rejection would display an incomplete error message in the command log.

https://docs.cypress.io/guides/references/changelog#12-1-0

* Fixed an issue where `.select(index)` would fail when multiple `<option>` elements have the same value property.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed