### PR TITLE
ROX-14239: Fix VM report search when no results returned

### DIFF
--- a/ui/apps/platform/src/Containers/VulnMgmt/Reports/VulnMgmtReportTablePage.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Reports/VulnMgmtReportTablePage.tsx
@@ -110,7 +110,6 @@ function ReportTablePage({ query }: ReportTablePageProps): ReactElement {
             triggerRefresh();
         });
     }
-
     return (
         <>
             <PageSection variant={PageSectionVariants.light}>
@@ -157,7 +156,7 @@ function ReportTablePage({ query }: ReportTablePageProps): ReactElement {
                     </Bullseye>
                 </PageSection>
             )}
-            {!isLoading && reports && reports?.length > 0 && (
+            {!isLoading && (reports?.length || Boolean(Object.keys(filteredSearch).length)) && (
                 <VulnMgmtReportTablePanel
                     reports={reports || []}
                     reportCount={reportCount}
@@ -176,7 +175,7 @@ function ReportTablePage({ query }: ReportTablePageProps): ReactElement {
                     onDeleteReports={onDeleteReports}
                 />
             )}
-            {!isLoading && !reports?.length && (
+            {!isLoading && !reports?.length && !Object.keys(filteredSearch).length && (
                 <PageSection variant={PageSectionVariants.light} isFilled>
                     <EmptyStateTemplate
                         title="No reports are currently configured."

--- a/ui/apps/platform/src/Containers/VulnMgmt/Reports/VulnMgmtReportTablePanel.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Reports/VulnMgmtReportTablePanel.tsx
@@ -3,6 +3,7 @@ import {
     Alert,
     AlertGroup,
     AlertVariant,
+    Bullseye,
     Button,
     ButtonVariant,
     DropdownItem,
@@ -14,6 +15,7 @@ import {
     ToolbarContent,
     ToolbarItem,
 } from '@patternfly/react-core';
+import { SearchIcon } from '@patternfly/react-icons';
 import { TableComposable, Thead, Tbody, Tr, Th, Td } from '@patternfly/react-table';
 import pluralize from 'pluralize';
 
@@ -21,6 +23,7 @@ import usePermissions from 'hooks/usePermissions';
 import useTableSelection from 'hooks/useTableSelection';
 import BulkActionsDropdown from 'Components/PatternFly/BulkActionsDropdown';
 import ConfirmationModal from 'Components/PatternFly/ConfirmationModal';
+import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';
 import LinkShim from 'Components/PatternFly/LinkShim';
 import SearchFilterResults from 'Components/PatternFly/SearchFilterResults';
 import TableCell from 'Components/PatternFly/TableCell';
@@ -264,18 +267,19 @@ function ReportingTablePanel({
                                 }}
                             />
                             {columns.map(({ Header, sortField }, idx) => {
-                                const sortParams = sortField
-                                    ? {
-                                          sort: {
-                                              sortBy: {
-                                                  index: activeSortIndex,
-                                                  direction: activeSortDirection,
+                                const sortParams =
+                                    sortField && Boolean(reports.length)
+                                        ? {
+                                              sort: {
+                                                  sortBy: {
+                                                      index: activeSortIndex,
+                                                      direction: activeSortDirection,
+                                                  },
+                                                  onSort,
+                                                  columnIndex: idx,
                                               },
-                                              onSort,
-                                              columnIndex: idx,
-                                          },
-                                      }
-                                    : {};
+                                          }
+                                        : {};
                                 return (
                                     <Th key={Header} modifier="wrap" {...sortParams}>
                                         {Header}
@@ -346,6 +350,21 @@ function ReportingTablePanel({
                                 </Tr>
                             );
                         })}
+                        {!reports.length && (
+                            <Tr>
+                                <Td colSpan={8}>
+                                    <Bullseye>
+                                        <EmptyStateTemplate
+                                            title="No results found"
+                                            headingLevel="h2"
+                                            icon={SearchIcon}
+                                        >
+                                            Try clearing some of the filters
+                                        </EmptyStateTemplate>
+                                    </Bullseye>
+                                </Td>
+                            </Tr>
+                        )}
                     </Tbody>
                 </TableComposable>
             </PageSection>

--- a/ui/apps/platform/src/css/trumps.css
+++ b/ui/apps/platform/src/css/trumps.css
@@ -114,6 +114,11 @@ button.pf-c-toggle-group__button:disabled {
     filter: inherit; /* replace invert(0.3) */
 }
 
+/* override width of thead checkbox so that it's not cut off when table is empty */
+.pf-c-table thead tr > .pf-c-table__check {
+    min-width: 44px;
+}
+
 button.pf-c-tree-view__node {
     font-weight: inherit; /* override 600 from ui-components */
 }


### PR DESCRIPTION
## Description

The way we nested the table and empty state message cause the user to get stuck with filters that cannot be cleared if there are no results for a set of filters.

This PR leaves the existing "empty" message when there are no reports even without filters, but now shows the complex table component when there are results OR a filter applied, so that the user can modify or clear filters to "back out" to results.

I based the new "No search results" message on the example in the PatternFly docs.
https://www.patternfly.org/v4/components/table#composable-empty-state

Notes:
1. For better UX, I disable the sorting on the table if it is shown but there are no results.
2. I add an override to the CSS, because when the table is shown with no results, the checkbox was getting cut off on the right. (I considered hiding the checkbox or the whole header row when there were no results, but that made the layout a little too "jumpy".)

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

Manual testing

With no reports or filters (this existing behavior remains the same)
<img width="1552" alt="Screen Shot 2023-01-09 at 5 47 12 PM" src="https://user-images.githubusercontent.com/715729/211424177-3896349c-6b67-47a2-9c41-764e9755c461.png">

With report but no filters applied (this existing behavior remains the same also)
<img width="1552" alt="Screen Shot 2023-01-09 at 5 47 40 PM" src="https://user-images.githubusercontent.com/715729/211424331-f6eaff9a-d308-458c-b11c-10ea8097b7bd.png">

With report, but filter causes returned result to be empty (new behavior, filter bar now available to allow filters to be modified or deleted)
<img width="1552" alt="Screen Shot 2023-01-09 at 5 47 54 PM" src="https://user-images.githubusercontent.com/715729/211424464-0abd5f06-31c7-4202-9b06-6be361619668.png">
