### PR TITLE
Show filters in Risk Acceptance even when no results

### DIFF
--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ApprovedDeferrals/ApprovedDeferrals.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ApprovedDeferrals/ApprovedDeferrals.tsx
@@ -40,7 +40,7 @@ function ApprovedDeferrals(): ReactElement {
     const rows = data?.vulnerabilityRequests || [];
     const itemCount = data?.vulnerabilityRequestsCount || 0;
 
-    if (!isLoading && rows && rows.length === 0) {
+    if (!isLoading && rows && rows.length === 0 && !Object.keys(searchFilter).length) {
         return (
             <PageSection variant={PageSectionVariants.light} isFilled>
                 <EmptyStateTemplate title="No deferral requests were approved." headingLevel="h2" />

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ApprovedDeferrals/ApprovedDeferralsTable.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ApprovedDeferrals/ApprovedDeferralsTable.tsx
@@ -10,9 +10,11 @@ import {
     Bullseye,
     Spinner,
 } from '@patternfly/react-core';
+import { SearchIcon } from '@patternfly/react-icons';
 
 import RequestCommentsButton from 'Containers/VulnMgmt/RiskAcceptance/RequestComments/RequestCommentsButton';
 import BulkActionsDropdown from 'Components/PatternFly/BulkActionsDropdown';
+import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';
 import useTableSelection from 'hooks/useTableSelection';
 import { UsePaginationResult } from 'hooks/patternfly/usePagination';
 import usePermissions from 'hooks/usePermissions';
@@ -244,6 +246,21 @@ function ApprovedDeferralsTable({
                                 </Tr>
                             );
                         })}
+                        {!rows.length && (
+                            <Tr>
+                                <Td colSpan={8}>
+                                    <Bullseye>
+                                        <EmptyStateTemplate
+                                            title="No approved deferrals found"
+                                            headingLevel="h2"
+                                            icon={SearchIcon}
+                                        >
+                                            To continue, edit your filter settings and search again.
+                                        </EmptyStateTemplate>
+                                    </Bullseye>
+                                </Td>
+                            </Tr>
+                        )}
                     </Tbody>
                 </TableComposable>
             )}

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ApprovedFalsePositives/ApprovedFalsePositives.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ApprovedFalsePositives/ApprovedFalsePositives.tsx
@@ -39,7 +39,7 @@ function ApprovedFalsePositives(): ReactElement {
     const rows = data?.vulnerabilityRequests || [];
     const itemCount = data?.vulnerabilityRequestsCount || 0;
 
-    if (!isLoading && rows && rows.length === 0) {
+    if (!isLoading && rows && rows.length === 0 && !Object.keys(searchFilter).length) {
         return (
             <PageSection variant={PageSectionVariants.light} isFilled>
                 <EmptyStateTemplate

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ApprovedFalsePositives/ApprovedFalsePositivesTable.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ApprovedFalsePositives/ApprovedFalsePositivesTable.tsx
@@ -10,9 +10,11 @@ import {
     ToolbarContent,
     ToolbarItem,
 } from '@patternfly/react-core';
+import { SearchIcon } from '@patternfly/react-icons';
 
 import RequestCommentsButton from 'Containers/VulnMgmt/RiskAcceptance/RequestComments/RequestCommentsButton';
 import BulkActionsDropdown from 'Components/PatternFly/BulkActionsDropdown';
+import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';
 import useTableSelection from 'hooks/useTableSelection';
 import { UsePaginationResult } from 'hooks/patternfly/usePagination';
 import usePermissions from 'hooks/usePermissions';
@@ -223,6 +225,21 @@ function ApprovedFalsePositivesTable({
                                 </Tr>
                             );
                         })}
+                        {!rows.length && (
+                            <Tr>
+                                <Td colSpan={8}>
+                                    <Bullseye>
+                                        <EmptyStateTemplate
+                                            title="No approved false positives found"
+                                            headingLevel="h2"
+                                            icon={SearchIcon}
+                                        >
+                                            To continue, edit your filter settings and search again.
+                                        </EmptyStateTemplate>
+                                    </Bullseye>
+                                </Td>
+                            </Tr>
+                        )}
                     </Tbody>
                 </TableComposable>
             )}

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/PendingApprovals/PendingApprovals.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/PendingApprovals/PendingApprovals.tsx
@@ -49,7 +49,7 @@ function PendingApprovals(): ReactElement {
     const rows = data?.vulnerabilityRequests || [];
     const itemCount = data?.vulnerabilityRequestsCount || 0;
 
-    if (!isLoading && rows && rows.length === 0) {
+    if (!isLoading && rows && rows.length === 0 && !Object.keys(searchFilter).length) {
         return (
             <PageSection variant={PageSectionVariants.light} isFilled>
                 <EmptyStateTemplate title="No pending requests to approve." headingLevel="h2" />

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/PendingApprovals/PendingApprovalsTable.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/PendingApprovals/PendingApprovalsTable.tsx
@@ -10,9 +10,11 @@ import {
     ToolbarContent,
     ToolbarItem,
 } from '@patternfly/react-core';
+import { SearchIcon } from '@patternfly/react-icons';
 
 import RequestCommentsButton from 'Containers/VulnMgmt/RiskAcceptance/RequestComments/RequestCommentsButton';
 import BulkActionsDropdown from 'Components/PatternFly/BulkActionsDropdown';
+import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';
 import useTableSelection from 'hooks/useTableSelection';
 import { UsePaginationResult } from 'hooks/patternfly/usePagination';
 import usePermissions from 'hooks/usePermissions';
@@ -333,6 +335,21 @@ function PendingApprovalsTable({
                                 </Tr>
                             );
                         })}
+                        {!rows.length && (
+                            <Tr>
+                                <Td colSpan={8}>
+                                    <Bullseye>
+                                        <EmptyStateTemplate
+                                            title="No pending approvals found"
+                                            headingLevel="h2"
+                                            icon={SearchIcon}
+                                        >
+                                            To continue, edit your filter settings and search again.
+                                        </EmptyStateTemplate>
+                                    </Bullseye>
+                                </Td>
+                            </Tr>
+                        )}
                     </Tbody>
                 </TableComposable>
             )}


### PR DESCRIPTION
## Description

Another area of the app that requires a slightly different empty state when filtering causes the results to be empty.

The way we nested the table and empty state message cause the user to get stuck with filters that cannot be cleared if there are no results for a set of filters.

This PR leaves the existing "empty" message when there are no pending, approved deferrals, or approved false positives, even without filters, but now shows the complex table component when there are results OR a filter applied, so that the user can modify or clear filters to "back out" to results.

I based the new "No search results" message on the example in the PatternFly docs.
https://www.patternfly.org/v4/components/table#composable-empty-state

This is the same approach as done in #4337 .
This may be worth abstracting later.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

With nothing in the database or filters (this existing behavior remains the same)
<img width="1741" alt="Screen Shot 2023-01-09 at 6 42 53 PM" src="https://user-images.githubusercontent.com/715729/211431238-2cc53f36-5004-436c-8ba9-d6d45cc517fb.png">
<img width="1741" alt="Screen Shot 2023-01-09 at 6 42 55 PM" src="https://user-images.githubusercontent.com/715729/211431150-49d0d236-1cb0-43ad-9cf1-5f874aa8c57f.png">
<img width="1741" alt="Screen Shot 2023-01-09 at 6 42 58 PM" src="https://user-images.githubusercontent.com/715729/211431188-863a7509-828b-4466-a104-4eaaad65d286.png">

With results but no filters applied (this existing behavior remains the same also)
<img width="1741" alt="Screen Shot 2023-01-09 at 6 42 07 PM" src="https://user-images.githubusercontent.com/715729/211431311-d82e520e-3c98-43e6-9038-0fb23be89cfe.png">
<img width="1741" alt="Screen Shot 2023-01-09 at 6 42 10 PM" src="https://user-images.githubusercontent.com/715729/211431319-324f4dbc-7345-4697-9e14-e67cfd29313f.png">
<img width="1741" alt="Screen Shot 2023-01-09 at 6 42 12 PM" src="https://user-images.githubusercontent.com/715729/211431332-d6c92589-3ae9-44cc-ad0a-440266e852a4.png">

With results in database, but filter causes returned result to be empty (new behavior, filter bar now available to allow filters to be modified or deleted)
<img width="1741" alt="Screen Shot 2023-01-09 at 6 27 03 PM" src="https://user-images.githubusercontent.com/715729/211431411-40705c06-2625-42ac-9e50-4240a0055207.png">
<img width="1741" alt="Screen Shot 2023-01-09 at 6 34 30 PM" src="https://user-images.githubusercontent.com/715729/211431415-1c7c2631-e93a-43fb-94b7-5d7b53581f46.png">
<img width="1741" alt="Screen Shot 2023-01-09 at 6 41 49 PM" src="https://user-images.githubusercontent.com/715729/211431426-9ffe6d08-9c19-4d8f-b727-4c1faa5d3056.png">

