### PR TITLE
ROX-14048: add GH workflow to verify releases are done

### DIFF
--- a/.github/workflows/scripts/verify-release.sh
+++ b/.github/workflows/scripts/verify-release.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+#
+# Verifies that for a given release all artifacts
+# have been published.
+#
+set -euo pipefail
+
+check_args() {
+    RELEASE_PATCH="$1"
+    LATEST_VERSION="$2"
+    RELEASE="$3"
+    PROJECT="$4"
+    ERRATA_NAME="$5"
+
+    check_not_empty \
+        RELEASE_PATCH \
+        LATEST_VERSION \
+        RELEASE \
+        PROJECT \
+        ERRATA_NAME
+}
+
+mark_failed() {
+    touch failed_validation
+}
+
+trap_for_failed_validation() {
+    if [ -f failed_validation ]; then
+        exit 1
+    fi
+}
+
+check_dir_not_empty() {
+    DIR="$1"
+    if [ -d "$DIR" ]; then
+        if [ -n "$(find "$DIR" -maxdepth 0 -empty)" ]; then
+            mark_failed
+            gh_log error "The required directory ${DIR} is empty."
+        fi
+    else
+        mark_failed
+        gh_log error "The required directory ${DIR} does not exist."
+    fi
+}
+
+check_url_page_exists() {
+    URL="$1"
+    curl -sSLf "$URL" --output /dev/null || {
+        mark_failed
+        gh_log error "Retrieving $URL failed."
+    }
+}
+
+check_url_yaml_contains() {
+    URL="$1"
+    QUERY="$2"
+    curl -sSLf "$URL" 2>/dev/null | yq -e "$QUERY" >/dev/null || {
+        mark_failed
+        gh_log error "The Helm index does not contain the new version."
+    }
+}
+
+check_docker_image() {
+    IMAGE="$1"
+
+    DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect "$IMAGE" >/dev/null || {
+        mark_failed
+        gh_log error "The required image $IMAGE does not exist."
+    }
+}
+
+validate_helm_charts() {
+    RELEASE_PATCH="$1"
+    LATEST_VERSION="$2"
+    git clone --quiet https://github.com/stackrox/helm-charts
+    check_dir_not_empty "helm-charts/${RELEASE_PATCH}"
+    if [ "${LATEST_VERSION}" == "true" ]; then
+        if ! grep -q "${RELEASE_PATCH}" < "helm-charts/latest/central-services/Chart.yaml"; then
+            mark_failed
+            gh_log error "The symbolic link to the latest chart does not point to the ${RELEASE_PATCH} version."
+        fi
+    fi
+
+    check_url_yaml_contains "https://charts.stackrox.io/index.yaml" ".entries.central-services[] | select( .appVersion == \"${RELEASE_PATCH}\")"
+    check_url_yaml_contains "https://charts.stackrox.io/index.yaml" ".entries.secured-cluster-services[] | select( .appVersion == \"${RELEASE_PATCH}\")"
+}
+
+validate_images() {
+    RELEASE_PATCH="$1"
+    check_docker_image "registry.redhat.io/advanced-cluster-security/rhacs-main-rhel8:${RELEASE_PATCH}"
+    check_docker_image "quay.io/stackrox-io/main:${RELEASE_PATCH}"
+    check_docker_image "quay.io/rhacs-eng/main:${RELEASE_PATCH}"
+}
+
+validate_docs() {
+    RELEASE="$1"
+    check_url_page_exists "https://docs.openshift.com/acs/${RELEASE}/welcome/index.html"
+}
+
+validate_jira_release() {
+    PROJECT="$1"
+    RELEASE_PATCH="$2"
+
+    IS_RELEASED=$(curl -sSLf \
+        -H "Authorization: Bearer $JIRA_TOKEN" \
+        "https://issues.redhat.com/rest/api/2/project/${PROJECT}/versions" \
+    | jq -r ".[] | select(.name == \"${RELEASE_PATCH}\") | .released")
+    if [ "${IS_RELEASED}" != "true" ]; then
+        mark_failed
+        gh_log error "JIRA Release $RELEASE_PATCH has not been marked as done."
+    fi
+}
+
+validate_errata() {
+    ERRATA_NAME="$1"
+    check_url_page_exists "https://access.redhat.com/errata/${ERRATA_NAME}"
+}
+
+main() {
+    RELEASE_PATCH="$1"
+    LATEST_VERSION="$2"
+    RELEASE="$3"
+    PROJECT="$4"
+    ERRATA_NAME="$5"
+
+    TMP_DIR="$(mktemp -d)"
+    pushd "$TMP_DIR" >/dev/null
+
+    validate_helm_charts "$RELEASE_PATCH" "$LATEST_VERSION"
+    validate_images "$RELEASE_PATCH"
+    validate_docs "$RELEASE"
+    validate_jira_release "$PROJECT" "$RELEASE_PATCH"
+    validate_errata "$ERRATA_NAME"
+
+    trap_for_failed_validation
+    popd >/dev/null 2>&1
+    rm -rf "$TMP_DIR"
+}
+
+check_args "$@"
+main "$@"

--- a/.github/workflows/variables.yml
+++ b/.github/workflows/variables.yml
@@ -20,6 +20,9 @@ on:
       name:
         description: Release name (N)
         value: ${{jobs.parse.outputs.name}}
+      named-release:
+        description: Release name and minor version (A.B[-N])
+        value: ${{format('{0}{1}', jobs.parse.outputs.release, jobs.parse.outputs.dash-name)}}
       named-release-patch:
         description: Release.patch-name (A.B.C[-N])
         value: ${{format('{0}.{1}{2}', jobs.parse.outputs.release, jobs.parse.outputs.patch, jobs.parse.outputs.dash-name)}}

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -1,0 +1,95 @@
+name: Verify release
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Release version (A.B.C[-N])
+        required: true
+        default: 0.0.0-test
+        type: string
+      errata:
+        description: Name of the related Errata advisory
+        required: true
+        default: "RHSA-1970:0000"
+        type: string
+      latest-version:
+        description: Is this latest published version? (enables additional checks)
+        required: true
+        default: false
+        type: boolean
+
+env:
+  script_url: /repos/${{ github.repository }}/contents/.github/workflows/scripts/common.sh?ref=${{ github.ref_name }}
+  ACCEPT_RAW: "Accept: application/vnd.github.v3.raw"
+  GH_TOKEN: ${{ github.token }}
+  GH_NO_UPDATE_NOTIFIER: 1
+
+run-name: ${{ format('Verify release {0}', inputs.version) }}
+
+# Ensure that only a single release automation workflow can run at a time.
+concurrency: Release automation
+
+jobs:
+  run-parameters:
+    name: Run parameters
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          {
+            echo "Event: ${{ github.event_name }}"
+            if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+              echo '```'
+              echo "${{ toJSON(inputs) }}"
+              echo '```'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  variables:
+    name: Setup variables
+    uses: ./.github/workflows/variables.yml
+    with:
+      version: ${{ inputs.version }}
+
+  properties:
+    name: Read repository properties
+    runs-on: ubuntu-latest
+    outputs:
+      jira-project: ${{ steps.properties.outputs.jira-project }}
+    steps:
+      - name: Read workflow properties file
+        id: properties
+        env:
+          PROPERTIES_URL: /repos/${{ github.repository }}/contents/.github/properties?ref=${{ github.ref_name }}
+        run: gh api -H "$ACCEPT_RAW" "$PROPERTIES_URL" >> "$GITHUB_OUTPUT"
+
+  verify-release:
+    name: Verify all artifacts for release ${{ needs.variables.outputs.named-release-patch }} are published
+    runs-on: ubuntu-latest
+    needs: [variables, properties]
+    env:
+      JIRA_TOKEN: ${{ secrets.JIRA_TOKEN }}
+    steps:
+      - name: Login to Quay.io
+        uses: docker/login-action@v2
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_REGISTRY_USERNAME_RO }}
+          password: ${{ secrets.QUAY_REGISTRY_PASSWORD_RO }}
+
+      - name: Login to registry.redhat.io
+        uses: docker/login-action@v2
+        with:
+          registry: registry.redhat.io
+          username: ${{ secrets.RH_REGISTRY_USERNAME_RO }}
+          password: ${{ secrets.RH_REGISTRY_PASSWORD_RO }}
+
+      - name: Verify all artifacts are published
+        run: |
+          set -uo pipefail
+          gh api -H "$ACCEPT_RAW" "${{ env.script_url }}" | bash -s -- \
+            verify-release \
+            "${{ needs.variables.outputs.named-release-patch }}" \
+            "${{ github.event.inputs.latest-version }}" \
+            "${{ needs.variables.outputs.named-release }}" \
+            "${{ needs.properties.outputs.jira-project }}" \
+            "${{ github.event.inputs.errata }}"


### PR DESCRIPTION
Cherry pick of https://github.com/stackrox/test-gh-actions/pull/82.

## Description

The following checks are done:

* Check if https://github.com/stackrox/helm-charts was updated
* Check if https://charts.stackrox.io/index.yaml was updated
* Check if new images were published (only checking `main`)
  * quay.io/rhacs-eng/main
  * quay.io/stackrox-io/main
* Check docs were published for minor version, e.g. 3.73
* Check that the JIRA release was marked as released/done
* Check that given Errata was published at access.redhat.com

## Inputs to the workflow

* Version, e.g. 3.73.1
* Errata Name, e.g. RHEA-2022:9097
* Whether this is the latest release (for a check in the Helm repository)

## Checklist
- [ ] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

* Done in private fork of repository (because a new workflow must be from a main branch)
* Test cases:
  * 3.73.1 as latest release
  * 3.73.0 as a previous release
  * 3.74.0 as an incomplete release
<img width="1143" alt="Screenshot 2023-01-04 at 11 25 51" src="https://user-images.githubusercontent.com/9576848/210535046-0508d874-4bb5-4ac2-858e-728448ea6c3c.png">

<img width="1143" alt="Screenshot 2023-01-04 at 11 27 15" src="https://user-images.githubusercontent.com/9576848/210535294-e099b336-6dad-431b-835f-6a3d18980de9.png">

