### PR TITLE
ROX-13361: RBAC deployments relationship

### DIFF
--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -54,7 +54,7 @@ var (
 	ProcessesListeningOnPort = registerFeature("Enable Processes Listening on Port", "ROX_PROCESSES_LISTENING_ON_PORT", false)
 
 	// ResyncDisabled disables the resync behavior of the kubernetes listeners in sensor
-	ResyncDisabled = registerFeature("Disable the re-sync", "ROX_RESYNC_DISABLED", true)
+	ResyncDisabled = registerFeature("Disable the re-sync", "ROX_RESYNC_DISABLED", false)
 
 	// ClairV4Scanner enables Clair v4 as an Image Integration option
 	ClairV4Scanner = registerFeature("Enable Clair v4 as an Image Integration option", "ROX_CLAIR_V4_SCANNING", false)

--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -54,7 +54,7 @@ var (
 	ProcessesListeningOnPort = registerFeature("Enable Processes Listening on Port", "ROX_PROCESSES_LISTENING_ON_PORT", false)
 
 	// ResyncDisabled disables the resync behavior of the kubernetes listeners in sensor
-	ResyncDisabled = registerFeature("Disable the re-sync", "ROX_RESYNC_DISABLED", false)
+	ResyncDisabled = registerFeature("Disable the re-sync", "ROX_RESYNC_DISABLED", true)
 
 	// ClairV4Scanner enables Clair v4 as an Image Integration option
 	ClairV4Scanner = registerFeature("Enable Clair v4 as an Image Integration option", "ROX_CLAIR_V4_SCANNING", false)

--- a/sensor/kubernetes/eventpipeline/component/message.go
+++ b/sensor/kubernetes/eventpipeline/component/message.go
@@ -32,6 +32,9 @@ type ResourceEvent struct {
 	// that require processing
 	DeploymentReference resolver.DeploymentReference
 
+	// DeploymentTiming has the timing object that needs to be added to any deployments resolved by this event.
+	DeploymentTiming *central.Timing
+
 	// ParentResourceAction is the resource action that will be sent to central on the deployment event.
 	// If the ResourceEvent originated on a deployment event, this should be set to whatever action triggered
 	// the event. For related resources updates, like RBACs and services, this should always be set to

--- a/sensor/kubernetes/eventpipeline/resolver/resolver_impl.go
+++ b/sensor/kubernetes/eventpipeline/resolver/resolver_impl.go
@@ -81,7 +81,7 @@ func (r *resolverImpl) processMessage(msg *component.ResourceEvent) {
 				continue
 			}
 
-			event := component.NewResourceEvent([]*central.SensorEvent{toEvent(msg.ParentResourceAction, d)},
+			event := component.NewResourceEvent([]*central.SensorEvent{toEvent(msg.ParentResourceAction, d, msg.DeploymentTiming)},
 				[]component.CompatibilityDetectionMessage{{Object: d, Action: msg.ParentResourceAction}}, nil)
 
 			component.MergeResourceEvents(msg, event)
@@ -91,10 +91,11 @@ func (r *resolverImpl) processMessage(msg *component.ResourceEvent) {
 	r.outputQueue.Send(msg)
 }
 
-func toEvent(action central.ResourceAction, deployment *storage.Deployment) *central.SensorEvent {
+func toEvent(action central.ResourceAction, deployment *storage.Deployment, timing *central.Timing) *central.SensorEvent {
 	return &central.SensorEvent{
 		Id:     deployment.GetId(),
 		Action: action,
+		Timing: timing,
 		Resource: &central.SensorEvent_Deployment{
 			Deployment: deployment.Clone(),
 		},

--- a/sensor/kubernetes/listener/resources/dispatcher.go
+++ b/sensor/kubernetes/listener/resources/dispatcher.go
@@ -215,6 +215,13 @@ func (m metricDispatcher) ProcessEvent(obj, oldObj interface{}, action central.R
 		metrics.SetResourceProcessingDurationForResource(e)
 	}
 	metrics.IncK8sEventCount(action.String(), dispatcher)
+
+	events.DeploymentTiming = &central.Timing{
+		Dispatcher: dispatcher,
+		Resource:   "Deployment",
+		Nanos:      start,
+	}
+
 	return events
 }
 

--- a/sensor/kubernetes/listener/resources/rbac/dispatcher.go
+++ b/sensor/kubernetes/listener/resources/rbac/dispatcher.go
@@ -118,17 +118,15 @@ func (r *Dispatcher) processEvent(obj interface{}, action central.ResourceAction
 func (r *Dispatcher) findSubjectForBinding(binding metav1.Object) []namespacedSubject {
 	if features.ResyncDisabled.Enabled() {
 		return r.store.FindSubjectForBindingID(binding.GetNamespace(), binding.GetName(), string(binding.GetUID()))
-	} else {
-		return nil
 	}
+	return nil
 }
 
 func (r *Dispatcher) findSubjectForRole(role metav1.Object) []namespacedSubject {
 	if features.ResyncDisabled.Enabled() {
 		return r.store.FindSubjectForRole(role.GetNamespace(), role.GetName())
-	} else {
-		return nil
 	}
+	return nil
 }
 
 func (r *Dispatcher) mustGenerateRelatedEvents(obj metav1.Object, roleID string, isClusterRole bool) []*central.SensorEvent {

--- a/sensor/kubernetes/listener/resources/rbac/dispatcher.go
+++ b/sensor/kubernetes/listener/resources/rbac/dispatcher.go
@@ -41,8 +41,7 @@ func (r *Dispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAct
 	serviceAccountReferences := mapReference(update.deploymentReference)
 	component.MergeResourceEvents(componentMessage, component.NewDeploymentRefEvent(
 		resolver.ResolveDeploymentsByMultipleServiceAccounts(serviceAccountReferences),
-		central.ResourceAction_UPDATE_RESOURCE,
-	))
+		central.ResourceAction_UPDATE_RESOURCE, false))
 
 	return componentMessage
 }

--- a/sensor/kubernetes/listener/resources/rbac/evaluator.go
+++ b/sensor/kubernetes/listener/resources/rbac/evaluator.go
@@ -4,11 +4,20 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/utils"
 )
 
 type namespacedSubject string
+
+func (ns namespacedSubject) splitNamespaceAndName() (string, string, error) {
+	parts := strings.Split(string(ns), "#")
+	if len(parts) != 2 {
+		return "", "", errors.Errorf("unpacking namespaced subject: expected value to be split by # symbol: %s", string(ns))
+	}
+	return parts[0], parts[1], nil
+}
 
 func nsSubjectFromSubject(s *storage.Subject) namespacedSubject {
 	b := strings.Builder{}

--- a/sensor/kubernetes/listener/resources/rbac/store.go
+++ b/sensor/kubernetes/listener/resources/rbac/store.go
@@ -23,6 +23,8 @@ type Store interface {
 	RemoveClusterBinding(binding *v1.ClusterRoleBinding)
 	GetPermissionLevelForDeployment(deployment rbac.NamespacedServiceAccount) storage.PermissionLevel
 
+	FindSubjectForRole(namespace, roleName string) []namespacedSubject
+	FindSubjectForBindingID(namespace, name, uuid string) []namespacedSubject
 	FindBindingForNamespacedRole(namespace, roleName string) []namespacedBindingID
 }
 

--- a/sensor/kubernetes/listener/resources/rbac/store_impl_test.go
+++ b/sensor/kubernetes/listener/resources/rbac/store_impl_test.go
@@ -430,7 +430,12 @@ func TestStore_DispatcherEvents(t *testing.T) {
 }
 
 func TestStore_DeploymentRelationship(t *testing.T) {
+	// Run these tests only with feature flag enabled. Changes to the old path should be avoided whenever possible.
+	// TODO(ROX-14284): Re-enable this tests setting the custom env rather than the feature flag
 	t.Setenv("ROX_RESYNC_DISABLED", "true")
+	if !features.ResyncDisabled.Enabled() {
+		t.Skipf("Tests will fail if the new resyncless pass is disabled. E.g. in release tests")
+	}
 	roles := []*v1.Role{
 		{
 			ObjectMeta: metav1.ObjectMeta{

--- a/sensor/kubernetes/listener/resources/rbac/store_impl_test.go
+++ b/sensor/kubernetes/listener/resources/rbac/store_impl_test.go
@@ -501,7 +501,7 @@ func TestStore_DeploymentRelationship(t *testing.T) {
 		},
 		"No service account update if only a role is received": {
 			orderedUpdates:         []any{roles[0]},
-			serviceAccountsUpdates: []string{},
+			serviceAccountsUpdates: nil,
 		},
 		"Update service account both on binding and role update": {
 			orderedUpdates:         []any{bindings[0], roles[0]},
@@ -513,7 +513,7 @@ func TestStore_DeploymentRelationship(t *testing.T) {
 		},
 		"No service account update if only a custer role is received": {
 			orderedUpdates:         []any{clusterRoles[0]},
-			serviceAccountsUpdates: []string{},
+			serviceAccountsUpdates: nil,
 		},
 		"Update service account both on cluster binding and cluster role update": {
 			orderedUpdates:         []any{clusterBindings[0], clusterRoles[0]},
@@ -546,6 +546,8 @@ func TestStore_DeploymentRelationship(t *testing.T) {
 				assert.NotNil(t, r)
 				r(deploymentStore)
 			}
+
+			assert.Equal(t, testCase.serviceAccountsUpdates, orderedServiceAccounts)
 		})
 
 	}


### PR DESCRIPTION
Depends on #4307 ✅ 

## Description

Generate ServiceAccount deployment references on RBAC dispatcher. This allows for Deployments to be processed if an RBAC that references a ServiceAccount used by a deployment changes. 

This is required to disable the re-sync of Deployment resources. 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed
- Added and changed RBAC store tests to account for ServiceAccount reference generated on events.
