### PR TITLE
Dashrews/ROX-14211 jsonpb allow unknown pkg utilities

### DIFF
--- a/pkg/defaults/categories/categories.go
+++ b/pkg/defaults/categories/categories.go
@@ -1,7 +1,6 @@
 package categories
 
 import (
-	"bytes"
 	"embed"
 	"path/filepath"
 
@@ -55,7 +54,7 @@ func readCategoryFile(path string) (*storage.PolicyCategory, error) {
 	utils.CrashOnError(err)
 
 	var category storage.PolicyCategory
-	err = jsonutil.JSONUnmarshaler().Unmarshal(bytes.NewReader(contents), &category)
+	err = jsonutil.JSONBytesToProto(contents, &category)
 	if err != nil {
 		log.Errorf("Unable to unmarshal category (%s) json: %s", path, err)
 		return nil, err

--- a/pkg/defaults/categories/categories.go
+++ b/pkg/defaults/categories/categories.go
@@ -5,9 +5,9 @@ import (
 	"embed"
 	"path/filepath"
 
-	"github.com/golang/protobuf/jsonpb"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/errorhelpers"
+	"github.com/stackrox/rox/pkg/jsonutil"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/utils"
 )
@@ -55,7 +55,7 @@ func readCategoryFile(path string) (*storage.PolicyCategory, error) {
 	utils.CrashOnError(err)
 
 	var category storage.PolicyCategory
-	err = jsonpb.Unmarshal(bytes.NewReader(contents), &category)
+	err = jsonutil.JSONUnmarshaler().Unmarshal(bytes.NewReader(contents), &category)
 	if err != nil {
 		log.Errorf("Unable to unmarshal category (%s) json: %s", path, err)
 		return nil, err

--- a/pkg/defaults/policies/policies.go
+++ b/pkg/defaults/policies/policies.go
@@ -1,7 +1,6 @@
 package policies
 
 import (
-	"bytes"
 	"embed"
 	"path/filepath"
 
@@ -71,7 +70,7 @@ func ReadPolicyFile(path string) (*storage.Policy, error) {
 	utils.CrashOnError(err)
 
 	var policy storage.Policy
-	err = jsonutil.JSONUnmarshaler().Unmarshal(bytes.NewReader(contents), &policy)
+	err = jsonutil.JSONBytesToProto(contents, &policy)
 	if err != nil {
 		log.Errorf("Unable to unmarshal policy (%s) json: %s", path, err)
 		return nil, err

--- a/pkg/defaults/policies/policies.go
+++ b/pkg/defaults/policies/policies.go
@@ -5,11 +5,11 @@ import (
 	"embed"
 	"path/filepath"
 
-	"github.com/golang/protobuf/jsonpb"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/booleanpolicy/policyversion"
 	"github.com/stackrox/rox/pkg/errorhelpers"
 	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/jsonutil"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/utils"
 )
@@ -71,7 +71,7 @@ func ReadPolicyFile(path string) (*storage.Policy, error) {
 	utils.CrashOnError(err)
 
 	var policy storage.Policy
-	err = jsonpb.Unmarshal(bytes.NewReader(contents), &policy)
+	err = jsonutil.JSONUnmarshaler().Unmarshal(bytes.NewReader(contents), &policy)
 	if err != nil {
 		log.Errorf("Unable to unmarshal policy (%s) json: %s", path, err)
 		return nil, err

--- a/pkg/helm/config/roundtrip_test.go
+++ b/pkg/helm/config/roundtrip_test.go
@@ -10,13 +10,13 @@ import (
 	"testing"
 
 	"github.com/ghodss/yaml"
-	"github.com/golang/protobuf/jsonpb"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/image"
 	"github.com/stackrox/rox/pkg/helm/charts"
 	helmUtil "github.com/stackrox/rox/pkg/helm/util"
 	flavorUtils "github.com/stackrox/rox/pkg/images/defaults/testutils"
+	"github.com/stackrox/rox/pkg/jsonutil"
 	"github.com/stackrox/rox/pkg/k8sutil"
 	"github.com/stackrox/rox/pkg/maputil"
 	"github.com/stretchr/testify/suite"
@@ -112,7 +112,7 @@ func (h *helmConfigSuite) toClusterConfig(helmCfg chartutil.Values) (*storage.Co
 
 	var clusterCfg storage.CompleteClusterConfig
 
-	err = jsonpb.Unmarshal(buf, &clusterCfg)
+	err = jsonutil.JSONUnmarshaler().Unmarshal(buf, &clusterCfg)
 	if err != nil {
 		return nil, errors.Wrap(err, "JSON unmarshalling")
 	}

--- a/pkg/helm/config/roundtrip_test.go
+++ b/pkg/helm/config/roundtrip_test.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -108,11 +107,10 @@ func (h *helmConfigSuite) toClusterConfig(helmCfg chartutil.Values) (*storage.Co
 	if err != nil {
 		return nil, errors.Wrap(err, "converting YAML to JSON")
 	}
-	buf := bytes.NewBuffer(clusterCfgJSON)
 
 	var clusterCfg storage.CompleteClusterConfig
 
-	err = jsonutil.JSONUnmarshaler().Unmarshal(buf, &clusterCfg)
+	err = jsonutil.JSONBytesToProto(clusterCfgJSON, &clusterCfg)
 	if err != nil {
 		return nil, errors.Wrap(err, "JSON unmarshalling")
 	}

--- a/pkg/jsonutil/conversion.go
+++ b/pkg/jsonutil/conversion.go
@@ -1,6 +1,7 @@
 package jsonutil
 
 import (
+	"bytes"
 	"regexp"
 	"strings"
 
@@ -34,6 +35,11 @@ func JSONUnmarshaler() *jsonpb.Unmarshaler {
 // JSONToProto converts a string containing JSON into a proto message.
 func JSONToProto(json string, m proto.Message) error {
 	return JSONUnmarshaler().Unmarshal(strings.NewReader(json), m)
+}
+
+// JSONBytesToProto converts bytes containing JSON into a proto message.
+func JSONBytesToProto(contents []byte, m proto.Message) error {
+	return JSONUnmarshaler().Unmarshal(bytes.NewReader(contents), m)
 }
 
 // ProtoToJSON converts a proto message into a string containing JSON.

--- a/pkg/jsonutil/conversion_test.go
+++ b/pkg/jsonutil/conversion_test.go
@@ -110,4 +110,9 @@ func TestNoErrorOnUnknownAttribute(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Equal(t, "6500", proto.GetId())
+
+	err = JSONBytesToProto([]byte(json), &proto)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "6500", proto.GetId())
 }

--- a/pkg/telemetry/data/central.go
+++ b/pkg/telemetry/data/central.go
@@ -98,7 +98,7 @@ func (l *LicenseJSON) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON unmarshals license JSON bytes into a License object, following jsonpb rules.
 func (l *LicenseJSON) UnmarshalJSON(data []byte) error {
-	return jsonutil.JSONUnmarshaler().Unmarshal(bytes.NewReader(data), (*licenseproto.License)(l))
+	return jsonutil.JSONBytesToProto(data, (*licenseproto.License)(l))
 }
 
 // CentralInfo contains telemetry data specific to StackRox' Central deployment

--- a/pkg/telemetry/data/central.go
+++ b/pkg/telemetry/data/central.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/golang/protobuf/jsonpb"
 	licenseproto "github.com/stackrox/rox/generated/shared/license"
+	"github.com/stackrox/rox/pkg/jsonutil"
 	"google.golang.org/grpc/codes"
 )
 
@@ -97,7 +98,7 @@ func (l *LicenseJSON) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON unmarshals license JSON bytes into a License object, following jsonpb rules.
 func (l *LicenseJSON) UnmarshalJSON(data []byte) error {
-	return jsonpb.Unmarshal(bytes.NewReader(data), (*licenseproto.License)(l))
+	return jsonutil.JSONUnmarshaler().Unmarshal(bytes.NewReader(data), (*licenseproto.License)(l))
 }
 
 // CentralInfo contains telemetry data specific to StackRox' Central deployment


### PR DESCRIPTION
## Description

Trying to trickle these through as they are fairly quick after #4316.  Simply use the JSONUnmarshaler instead of jsonpb directly to ensure that AllowUnknownFields is set for unmarshaling to avoid compatibility issues.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Simply using a method that is already tested in `pkg/jsonutil/conversion_test.go`
