### PR TITLE
ROX-14278: External groups side bar not showing properly

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraph.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraph.tsx
@@ -301,7 +301,7 @@ const TopologyComponent = ({
                             edges={model?.edges || []}
                         />
                     )}
-                    {selectedEntity && selectedEntity?.data?.type === 'EXTERNAL' && (
+                    {selectedEntity && selectedEntity?.data?.type === 'EXTERNAL_GROUP' && (
                         <ExternalGroupSideBar
                             id={selectedEntity.id}
                             nodes={model?.nodes || []}


### PR DESCRIPTION
## Description

The external groups were not showing properly in the sidebar. This fixes it

<img width="1440" alt="Screenshot 2023-01-10 at 9 16 12 AM" src="https://user-images.githubusercontent.com/4805485/211618358-59e1efb5-54c7-47a8-92e2-763e93680302.png">


## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~
