### PR TITLE
ROX-13707: Add filtering for external group side bar

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraph.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraph.tsx
@@ -301,7 +301,7 @@ const TopologyComponent = ({
                             edges={model?.edges || []}
                         />
                     )}
-                    {selectedEntity && selectedEntity?.data?.type === 'EXTERNAL' && (
+                    {selectedEntity && selectedEntity?.data?.type === 'EXTERNAL_GROUP' && (
                         <ExternalGroupSideBar
                             id={selectedEntity.id}
                             nodes={model?.nodes || []}

--- a/ui/apps/platform/src/Containers/NetworkGraph/external/ExternalGroupSideBar.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/external/ExternalGroupSideBar.tsx
@@ -49,6 +49,15 @@ function ExternalGroupSideBar({ id, nodes, edges }: ExternalGroupSideBarProps): 
         (node) => node.data.type === 'CIDR_BLOCK' || node.data.type === 'EXTERNAL_ENTITIES'
     ) as (ExternalEntitiesNodeModel | CIDRBlockNodeModel)[];
 
+    const filteredExternalNodes = entityNameFilter
+        ? externalNodes.filter((externalNode) => {
+              if (externalNode.label) {
+                  return externalNode.label.includes(entityNameFilter);
+              }
+              return false;
+          })
+        : externalNodes;
+
     return (
         <Stack>
             <StackItem>
@@ -89,7 +98,7 @@ function ExternalGroupSideBar({ id, nodes, edges }: ExternalGroupSideBarProps): 
                                 <ToolbarItem>
                                     <TextContent>
                                         <Text component={TextVariants.h3}>
-                                            {externalNodes.length} results found
+                                            {filteredExternalNodes.length} results found
                                         </Text>
                                     </TextContent>
                                 </ToolbarItem>
@@ -106,7 +115,7 @@ function ExternalGroupSideBar({ id, nodes, edges }: ExternalGroupSideBarProps): 
                                 </Tr>
                             </Thead>
                             <Tbody>
-                                {externalNodes.map((externalNode) => {
+                                {filteredExternalNodes.map((externalNode) => {
                                     const entityIcon =
                                         externalNode.data.type === 'CIDR_BLOCK' ? (
                                             <CidrBlockIcon />


### PR DESCRIPTION
## Description

This PRs completes the integration with real data for the external group side bar by adding the filtering for the data. The rest of that side bar already uses real data


https://user-images.githubusercontent.com/4805485/211621535-e5e6dfc6-1e45-422e-aac0-ae3171b582a8.mov

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~
