### PR TITLE
[ROX-14343] Move schema search category registration to schema init

### DIFF
--- a/central/activecomponent/datastore/internal/store/postgres/index.go
+++ b/central/activecomponent/datastore/internal/store/postgres/index.go
@@ -13,12 +13,7 @@ import (
 	search "github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/blevesearch"
 	"github.com/stackrox/rox/pkg/search/postgres"
-	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
-
-func init() {
-	mapping.RegisterCategoryToTable(v1.SearchCategory_ACTIVE_COMPONENT, schema)
-}
 
 // NewIndexer returns new indexer for `storage.ActiveComponent`.
 func NewIndexer(db *pgxpool.Pool) *indexerImpl {

--- a/central/alert/datastore/internal/store/postgres/index.go
+++ b/central/alert/datastore/internal/store/postgres/index.go
@@ -13,12 +13,7 @@ import (
 	search "github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/blevesearch"
 	"github.com/stackrox/rox/pkg/search/postgres"
-	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
-
-func init() {
-	mapping.RegisterCategoryToTable(v1.SearchCategory_ALERTS, schema)
-}
 
 // NewIndexer returns new indexer for `storage.Alert`.
 func NewIndexer(db *pgxpool.Pool) *indexerImpl {

--- a/central/cluster/store/cluster/postgres/index.go
+++ b/central/cluster/store/cluster/postgres/index.go
@@ -13,12 +13,7 @@ import (
 	search "github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/blevesearch"
 	"github.com/stackrox/rox/pkg/search/postgres"
-	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
-
-func init() {
-	mapping.RegisterCategoryToTable(v1.SearchCategory_CLUSTERS, schema)
-}
 
 // NewIndexer returns new indexer for `storage.Cluster`.
 func NewIndexer(db *pgxpool.Pool) *indexerImpl {

--- a/central/cluster/store/clusterhealth/postgres/index.go
+++ b/central/cluster/store/clusterhealth/postgres/index.go
@@ -13,12 +13,7 @@ import (
 	search "github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/blevesearch"
 	"github.com/stackrox/rox/pkg/search/postgres"
-	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
-
-func init() {
-	mapping.RegisterCategoryToTable(v1.SearchCategory_CLUSTER_HEALTH, schema)
-}
 
 // NewIndexer returns new indexer for `storage.ClusterHealthStatus`.
 func NewIndexer(db *pgxpool.Pool) *indexerImpl {

--- a/central/clustercveedge/datastore/store/postgres/index.go
+++ b/central/clustercveedge/datastore/store/postgres/index.go
@@ -13,12 +13,7 @@ import (
 	search "github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/blevesearch"
 	"github.com/stackrox/rox/pkg/search/postgres"
-	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
-
-func init() {
-	mapping.RegisterCategoryToTable(v1.SearchCategory_CLUSTER_VULN_EDGE, schema)
-}
 
 // NewIndexer returns new indexer for `storage.ClusterCVEEdge`.
 func NewIndexer(db *pgxpool.Pool) *indexerImpl {

--- a/central/compliance/datastore/internal/store/postgres/domain/index.go
+++ b/central/compliance/datastore/internal/store/postgres/domain/index.go
@@ -13,12 +13,7 @@ import (
 	search "github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/blevesearch"
 	"github.com/stackrox/rox/pkg/search/postgres"
-	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
-
-func init() {
-	mapping.RegisterCategoryToTable(v1.SearchCategory_COMPLIANCE_DOMAIN, schema)
-}
 
 // NewIndexer returns new indexer for `storage.ComplianceDomain`.
 func NewIndexer(db *pgxpool.Pool) *indexerImpl {

--- a/central/compliance/datastore/internal/store/postgres/metadata/index.go
+++ b/central/compliance/datastore/internal/store/postgres/metadata/index.go
@@ -13,12 +13,7 @@ import (
 	search "github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/blevesearch"
 	"github.com/stackrox/rox/pkg/search/postgres"
-	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
-
-func init() {
-	mapping.RegisterCategoryToTable(v1.SearchCategory_COMPLIANCE_METADATA, schema)
-}
 
 // NewIndexer returns new indexer for `storage.ComplianceRunMetadata`.
 func NewIndexer(db *pgxpool.Pool) *indexerImpl {

--- a/central/compliance/datastore/internal/store/postgres/results/index.go
+++ b/central/compliance/datastore/internal/store/postgres/results/index.go
@@ -13,12 +13,7 @@ import (
 	search "github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/blevesearch"
 	"github.com/stackrox/rox/pkg/search/postgres"
-	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
-
-func init() {
-	mapping.RegisterCategoryToTable(v1.SearchCategory_COMPLIANCE_RESULTS, schema)
-}
 
 // NewIndexer returns new indexer for `storage.ComplianceRunResults`.
 func NewIndexer(db *pgxpool.Pool) *indexerImpl {

--- a/central/componentcveedge/datastore/store/postgres/index.go
+++ b/central/componentcveedge/datastore/store/postgres/index.go
@@ -13,12 +13,7 @@ import (
 	search "github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/blevesearch"
 	"github.com/stackrox/rox/pkg/search/postgres"
-	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
-
-func init() {
-	mapping.RegisterCategoryToTable(v1.SearchCategory_COMPONENT_VULN_EDGE, schema)
-}
 
 // NewIndexer returns new indexer for `storage.ComponentCVEEdge`.
 func NewIndexer(db *pgxpool.Pool) *indexerImpl {

--- a/central/cve/cluster/datastore/store/postgres/index.go
+++ b/central/cve/cluster/datastore/store/postgres/index.go
@@ -13,12 +13,7 @@ import (
 	search "github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/blevesearch"
 	"github.com/stackrox/rox/pkg/search/postgres"
-	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
-
-func init() {
-	mapping.RegisterCategoryToTable(v1.SearchCategory_CLUSTER_VULNERABILITIES, schema)
-}
 
 // NewIndexer returns new indexer for `storage.ClusterCVE`.
 func NewIndexer(db *pgxpool.Pool) *indexerImpl {

--- a/central/cve/image/datastore/store/postgres/index.go
+++ b/central/cve/image/datastore/store/postgres/index.go
@@ -13,12 +13,7 @@ import (
 	search "github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/blevesearch"
 	"github.com/stackrox/rox/pkg/search/postgres"
-	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
-
-func init() {
-	mapping.RegisterCategoryToTable(v1.SearchCategory_IMAGE_VULNERABILITIES, schema)
-}
 
 // NewIndexer returns new indexer for `storage.ImageCVE`.
 func NewIndexer(db *pgxpool.Pool) *indexerImpl {

--- a/central/cve/node/datastore/store/postgres/index.go
+++ b/central/cve/node/datastore/store/postgres/index.go
@@ -13,12 +13,7 @@ import (
 	search "github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/blevesearch"
 	"github.com/stackrox/rox/pkg/search/postgres"
-	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
-
-func init() {
-	mapping.RegisterCategoryToTable(v1.SearchCategory_NODE_VULNERABILITIES, schema)
-}
 
 // NewIndexer returns new indexer for `storage.NodeCVE`.
 func NewIndexer(db *pgxpool.Pool) *indexerImpl {

--- a/central/deployment/datastore/datastore_impl_postgres_test.go
+++ b/central/deployment/datastore/datastore_impl_postgres_test.go
@@ -19,12 +19,10 @@ import (
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/fixtures"
 	"github.com/stackrox/rox/pkg/postgres/pgtest"
-	"github.com/stackrox/rox/pkg/postgres/schema"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/sac/testconsts"
 	"github.com/stackrox/rox/pkg/scancomponent"
 	pkgSearch "github.com/stackrox/rox/pkg/search"
-	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 	"github.com/stackrox/rox/pkg/search/scoped"
 	"github.com/stackrox/rox/pkg/uuid"
 	"github.com/stretchr/testify/assert"
@@ -81,21 +79,9 @@ func (s *DeploymentPostgresDataStoreTestSuite) SetupSuite() {
 		nil, s.db, nil, nil, s.imageDatastore, nil, nil, s.riskDataStore,
 		nil, nil, ranking.ClusterRanker(), ranking.NamespaceRanker(), ranking.DeploymentRanker())
 	s.Require().NoError(err)
-
-	mapping.RegisterCategoryToTable(v1.SearchCategory_IMAGE_COMPONENTS, schema.ImageComponentsSchema)
-	mapping.RegisterCategoryToTable(v1.SearchCategory_IMAGE_VULNERABILITIES, schema.ImageCvesSchema)
-	mapping.RegisterCategoryToTable(v1.SearchCategory_IMAGE_COMPONENT_EDGE, schema.ImageComponentEdgesSchema)
-	mapping.RegisterCategoryToTable(v1.SearchCategory_COMPONENT_VULN_EDGE, schema.ImageComponentCveEdgesSchema)
-	mapping.RegisterCategoryToTable(v1.SearchCategory_IMAGE_VULN_EDGE, schema.ImageCveEdgesSchema)
 }
 
 func (s *DeploymentPostgresDataStoreTestSuite) TearDownSuite() {
-	mapping.UnregisterCategory(v1.SearchCategory_IMAGE_COMPONENTS)
-	mapping.UnregisterCategory(v1.SearchCategory_IMAGE_VULNERABILITIES)
-	mapping.UnregisterCategory(v1.SearchCategory_IMAGE_COMPONENT_EDGE)
-	mapping.UnregisterCategory(v1.SearchCategory_COMPONENT_VULN_EDGE)
-	mapping.UnregisterCategory(v1.SearchCategory_IMAGE_VULN_EDGE)
-
 	s.db.Close()
 	pgtest.CloseGormDB(s.T(), s.gormDB)
 	s.mockCtrl.Finish()

--- a/central/deployment/store/postgres/index.go
+++ b/central/deployment/store/postgres/index.go
@@ -13,12 +13,7 @@ import (
 	search "github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/blevesearch"
 	"github.com/stackrox/rox/pkg/search/postgres"
-	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
-
-func init() {
-	mapping.RegisterCategoryToTable(v1.SearchCategory_DEPLOYMENTS, schema)
-}
 
 // NewIndexer returns new indexer for `storage.Deployment`.
 func NewIndexer(db *pgxpool.Pool) *indexerImpl {

--- a/central/image/datastore/store/postgres/index.go
+++ b/central/image/datastore/store/postgres/index.go
@@ -12,12 +12,7 @@ import (
 	search "github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/blevesearch"
 	"github.com/stackrox/rox/pkg/search/postgres"
-	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
-
-func init() {
-	mapping.RegisterCategoryToTable(v1.SearchCategory_IMAGES, schema)
-}
 
 // NewIndexer returns a new image indexer.
 func NewIndexer(db *pgxpool.Pool) *indexerImpl {

--- a/central/imagecomponent/datastore/store/postgres/index.go
+++ b/central/imagecomponent/datastore/store/postgres/index.go
@@ -13,12 +13,7 @@ import (
 	search "github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/blevesearch"
 	"github.com/stackrox/rox/pkg/search/postgres"
-	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
-
-func init() {
-	mapping.RegisterCategoryToTable(v1.SearchCategory_IMAGE_COMPONENTS, schema)
-}
 
 // NewIndexer returns new indexer for `storage.ImageComponent`.
 func NewIndexer(db *pgxpool.Pool) *indexerImpl {

--- a/central/imagecomponentedge/datastore/internal/store/postgres/index.go
+++ b/central/imagecomponentedge/datastore/internal/store/postgres/index.go
@@ -13,12 +13,7 @@ import (
 	search "github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/blevesearch"
 	"github.com/stackrox/rox/pkg/search/postgres"
-	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
-
-func init() {
-	mapping.RegisterCategoryToTable(v1.SearchCategory_IMAGE_COMPONENT_EDGE, schema)
-}
 
 // NewIndexer returns new indexer for `storage.ImageComponentEdge`.
 func NewIndexer(db *pgxpool.Pool) *indexerImpl {

--- a/central/imagecveedge/datastore/postgres/index.go
+++ b/central/imagecveedge/datastore/postgres/index.go
@@ -13,12 +13,7 @@ import (
 	search "github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/blevesearch"
 	"github.com/stackrox/rox/pkg/search/postgres"
-	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
-
-func init() {
-	mapping.RegisterCategoryToTable(v1.SearchCategory_IMAGE_VULN_EDGE, schema)
-}
 
 // NewIndexer returns new indexer for `storage.ImageCVEEdge`.
 func NewIndexer(db *pgxpool.Pool) *indexerImpl {

--- a/central/imageintegration/store/postgres/index.go
+++ b/central/imageintegration/store/postgres/index.go
@@ -13,12 +13,7 @@ import (
 	search "github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/blevesearch"
 	"github.com/stackrox/rox/pkg/search/postgres"
-	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
-
-func init() {
-	mapping.RegisterCategoryToTable(v1.SearchCategory_IMAGE_INTEGRATIONS, schema)
-}
 
 // NewIndexer returns new indexer for `storage.ImageIntegration`.
 func NewIndexer(db *pgxpool.Pool) *indexerImpl {

--- a/central/namespace/store/postgres/index.go
+++ b/central/namespace/store/postgres/index.go
@@ -13,12 +13,7 @@ import (
 	search "github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/blevesearch"
 	"github.com/stackrox/rox/pkg/search/postgres"
-	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
-
-func init() {
-	mapping.RegisterCategoryToTable(v1.SearchCategory_NAMESPACES, schema)
-}
 
 // NewIndexer returns new indexer for `storage.NamespaceMetadata`.
 func NewIndexer(db *pgxpool.Pool) *indexerImpl {

--- a/central/networkbaseline/store/postgres/index.go
+++ b/central/networkbaseline/store/postgres/index.go
@@ -13,12 +13,7 @@ import (
 	search "github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/blevesearch"
 	"github.com/stackrox/rox/pkg/search/postgres"
-	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
-
-func init() {
-	mapping.RegisterCategoryToTable(v1.SearchCategory_NETWORK_BASELINE, schema)
-}
 
 // NewIndexer returns new indexer for `storage.NetworkBaseline`.
 func NewIndexer(db *pgxpool.Pool) *indexerImpl {

--- a/central/networkgraph/entity/datastore/internal/store/postgres/index.go
+++ b/central/networkgraph/entity/datastore/internal/store/postgres/index.go
@@ -13,12 +13,7 @@ import (
 	search "github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/blevesearch"
 	"github.com/stackrox/rox/pkg/search/postgres"
-	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
-
-func init() {
-	mapping.RegisterCategoryToTable(v1.SearchCategory_NETWORK_ENTITY, schema)
-}
 
 // NewIndexer returns new indexer for `storage.NetworkEntity`.
 func NewIndexer(db *pgxpool.Pool) *indexerImpl {

--- a/central/networkpolicies/datastore/internal/store/postgres/index.go
+++ b/central/networkpolicies/datastore/internal/store/postgres/index.go
@@ -13,12 +13,7 @@ import (
 	search "github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/blevesearch"
 	"github.com/stackrox/rox/pkg/search/postgres"
-	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
-
-func init() {
-	mapping.RegisterCategoryToTable(v1.SearchCategory_NETWORK_POLICIES, schema)
-}
 
 // NewIndexer returns new indexer for `storage.NetworkPolicy`.
 func NewIndexer(db *pgxpool.Pool) *indexerImpl {

--- a/central/node/datastore/store/postgres/index.go
+++ b/central/node/datastore/store/postgres/index.go
@@ -16,10 +16,6 @@ import (
 	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
 
-func init() {
-	mapping.RegisterCategoryToTable(v1.SearchCategory_NODES, schema)
-}
-
 // NewIndexer returns new indexer for `storage.Node`.
 func NewIndexer(db *pgxpool.Pool) *indexerImpl {
 	return &indexerImpl{

--- a/central/node/datastore/store/postgres/index.go
+++ b/central/node/datastore/store/postgres/index.go
@@ -13,7 +13,6 @@ import (
 	search "github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/blevesearch"
 	"github.com/stackrox/rox/pkg/search/postgres"
-	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
 
 // NewIndexer returns new indexer for `storage.Node`.

--- a/central/nodecomponent/datastore/store/postgres/index.go
+++ b/central/nodecomponent/datastore/store/postgres/index.go
@@ -13,12 +13,7 @@ import (
 	search "github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/blevesearch"
 	"github.com/stackrox/rox/pkg/search/postgres"
-	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
-
-func init() {
-	mapping.RegisterCategoryToTable(v1.SearchCategory_NODE_COMPONENTS, schema)
-}
 
 // NewIndexer returns new indexer for `storage.NodeComponent`.
 func NewIndexer(db *pgxpool.Pool) *indexerImpl {

--- a/central/nodecomponentcveedge/datastore/store/postgres/index.go
+++ b/central/nodecomponentcveedge/datastore/store/postgres/index.go
@@ -13,12 +13,7 @@ import (
 	search "github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/blevesearch"
 	"github.com/stackrox/rox/pkg/search/postgres"
-	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
-
-func init() {
-	mapping.RegisterCategoryToTable(v1.SearchCategory_NODE_COMPONENT_CVE_EDGE, schema)
-}
 
 // NewIndexer returns new indexer for `storage.NodeComponentCVEEdge`.
 func NewIndexer(db *pgxpool.Pool) *indexerImpl {

--- a/central/nodecomponentedge/store/postgres/index.go
+++ b/central/nodecomponentedge/store/postgres/index.go
@@ -13,12 +13,7 @@ import (
 	search "github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/blevesearch"
 	"github.com/stackrox/rox/pkg/search/postgres"
-	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
-
-func init() {
-	mapping.RegisterCategoryToTable(v1.SearchCategory_NODE_COMPONENT_EDGE, schema)
-}
 
 // NewIndexer returns new indexer for `storage.NodeComponentEdge`.
 func NewIndexer(db *pgxpool.Pool) *indexerImpl {

--- a/central/pod/store/postgres/index.go
+++ b/central/pod/store/postgres/index.go
@@ -13,12 +13,7 @@ import (
 	search "github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/blevesearch"
 	"github.com/stackrox/rox/pkg/search/postgres"
-	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
-
-func init() {
-	mapping.RegisterCategoryToTable(v1.SearchCategory_PODS, schema)
-}
 
 // NewIndexer returns new indexer for `storage.Pod`.
 func NewIndexer(db *pgxpool.Pool) *indexerImpl {

--- a/central/policy/store/postgres/index.go
+++ b/central/policy/store/postgres/index.go
@@ -13,12 +13,7 @@ import (
 	search "github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/blevesearch"
 	"github.com/stackrox/rox/pkg/search/postgres"
-	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
-
-func init() {
-	mapping.RegisterCategoryToTable(v1.SearchCategory_POLICIES, schema)
-}
 
 // NewIndexer returns new indexer for `storage.Policy`.
 func NewIndexer(db *pgxpool.Pool) *indexerImpl {

--- a/central/policy/store/postgres/store.go
+++ b/central/policy/store/postgres/store.go
@@ -597,7 +597,7 @@ func CreateTableAndNewStore(ctx context.Context, db *pgxpool.Pool, gormDB *gorm.
 	return New(db)
 }
 
-// // Stubs for satisfying legacy interfaces
+//// Stubs for satisfying legacy interfaces
 func (s *storeImpl) RenamePolicyCategory(request *v1.RenamePolicyCategoryRequest) error {
 	return errors.New("unimplemented")
 }

--- a/central/policy/store/postgres/store.go
+++ b/central/policy/store/postgres/store.go
@@ -597,7 +597,7 @@ func CreateTableAndNewStore(ctx context.Context, db *pgxpool.Pool, gormDB *gorm.
 	return New(db)
 }
 
-//// Stubs for satisfying legacy interfaces
+// // Stubs for satisfying legacy interfaces
 func (s *storeImpl) RenamePolicyCategory(request *v1.RenamePolicyCategoryRequest) error {
 	return errors.New("unimplemented")
 }

--- a/central/policycategory/store/postgres/index.go
+++ b/central/policycategory/store/postgres/index.go
@@ -13,12 +13,7 @@ import (
 	search "github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/blevesearch"
 	"github.com/stackrox/rox/pkg/search/postgres"
-	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
-
-func init() {
-	mapping.RegisterCategoryToTable(v1.SearchCategory_POLICY_CATEGORIES, schema)
-}
 
 // NewIndexer returns new indexer for `storage.PolicyCategory`.
 func NewIndexer(db *pgxpool.Pool) *indexerImpl {

--- a/central/processbaseline/store/postgres/index.go
+++ b/central/processbaseline/store/postgres/index.go
@@ -13,12 +13,7 @@ import (
 	search "github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/blevesearch"
 	"github.com/stackrox/rox/pkg/search/postgres"
-	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
-
-func init() {
-	mapping.RegisterCategoryToTable(v1.SearchCategory_PROCESS_BASELINES, schema)
-}
 
 // NewIndexer returns new indexer for `storage.ProcessBaseline`.
 func NewIndexer(db *pgxpool.Pool) *indexerImpl {

--- a/central/processbaselineresults/datastore/internal/store/postgres/index.go
+++ b/central/processbaselineresults/datastore/internal/store/postgres/index.go
@@ -13,12 +13,7 @@ import (
 	search "github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/blevesearch"
 	"github.com/stackrox/rox/pkg/search/postgres"
-	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
-
-func init() {
-	mapping.RegisterCategoryToTable(v1.SearchCategory_PROCESS_BASELINE_RESULTS, schema)
-}
 
 // NewIndexer returns new indexer for `storage.ProcessBaselineResults`.
 func NewIndexer(db *pgxpool.Pool) *indexerImpl {

--- a/central/processindicator/store/postgres/index.go
+++ b/central/processindicator/store/postgres/index.go
@@ -13,12 +13,7 @@ import (
 	search "github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/blevesearch"
 	"github.com/stackrox/rox/pkg/search/postgres"
-	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
-
-func init() {
-	mapping.RegisterCategoryToTable(v1.SearchCategory_PROCESS_INDICATORS, schema)
-}
 
 // NewIndexer returns new indexer for `storage.ProcessIndicator`.
 func NewIndexer(db *pgxpool.Pool) *indexerImpl {

--- a/central/rbac/k8srole/internal/store/postgres/index.go
+++ b/central/rbac/k8srole/internal/store/postgres/index.go
@@ -13,12 +13,7 @@ import (
 	search "github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/blevesearch"
 	"github.com/stackrox/rox/pkg/search/postgres"
-	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
-
-func init() {
-	mapping.RegisterCategoryToTable(v1.SearchCategory_ROLES, schema)
-}
 
 // NewIndexer returns new indexer for `storage.K8SRole`.
 func NewIndexer(db *pgxpool.Pool) *indexerImpl {

--- a/central/rbac/k8srolebinding/internal/store/postgres/index.go
+++ b/central/rbac/k8srolebinding/internal/store/postgres/index.go
@@ -13,12 +13,7 @@ import (
 	search "github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/blevesearch"
 	"github.com/stackrox/rox/pkg/search/postgres"
-	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
-
-func init() {
-	mapping.RegisterCategoryToTable(v1.SearchCategory_ROLEBINDINGS, schema)
-}
 
 // NewIndexer returns new indexer for `storage.K8SRoleBinding`.
 func NewIndexer(db *pgxpool.Pool) *indexerImpl {

--- a/central/reportconfigurations/store/postgres/index.go
+++ b/central/reportconfigurations/store/postgres/index.go
@@ -13,12 +13,7 @@ import (
 	search "github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/blevesearch"
 	"github.com/stackrox/rox/pkg/search/postgres"
-	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
-
-func init() {
-	mapping.RegisterCategoryToTable(v1.SearchCategory_REPORT_CONFIGURATIONS, schema)
-}
 
 // NewIndexer returns new indexer for `storage.ReportConfiguration`.
 func NewIndexer(db *pgxpool.Pool) *indexerImpl {

--- a/central/resourcecollection/datastore/store/postgres/index.go
+++ b/central/resourcecollection/datastore/store/postgres/index.go
@@ -13,12 +13,7 @@ import (
 	search "github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/blevesearch"
 	"github.com/stackrox/rox/pkg/search/postgres"
-	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
-
-func init() {
-	mapping.RegisterCategoryToTable(v1.SearchCategory_COLLECTIONS, schema)
-}
 
 // NewIndexer returns new indexer for `storage.ResourceCollection`.
 func NewIndexer(db *pgxpool.Pool) *indexerImpl {

--- a/central/risk/datastore/internal/store/postgres/index.go
+++ b/central/risk/datastore/internal/store/postgres/index.go
@@ -13,12 +13,7 @@ import (
 	search "github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/blevesearch"
 	"github.com/stackrox/rox/pkg/search/postgres"
-	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
-
-func init() {
-	mapping.RegisterCategoryToTable(v1.SearchCategory_RISKS, schema)
-}
 
 // NewIndexer returns new indexer for `storage.Risk`.
 func NewIndexer(db *pgxpool.Pool) *indexerImpl {

--- a/central/secret/internal/store/postgres/index.go
+++ b/central/secret/internal/store/postgres/index.go
@@ -13,12 +13,7 @@ import (
 	search "github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/blevesearch"
 	"github.com/stackrox/rox/pkg/search/postgres"
-	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
-
-func init() {
-	mapping.RegisterCategoryToTable(v1.SearchCategory_SECRETS, schema)
-}
 
 // NewIndexer returns new indexer for `storage.Secret`.
 func NewIndexer(db *pgxpool.Pool) *indexerImpl {

--- a/central/serviceaccount/internal/store/postgres/index.go
+++ b/central/serviceaccount/internal/store/postgres/index.go
@@ -13,12 +13,7 @@ import (
 	search "github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/blevesearch"
 	"github.com/stackrox/rox/pkg/search/postgres"
-	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
-
-func init() {
-	mapping.RegisterCategoryToTable(v1.SearchCategory_SERVICE_ACCOUNTS, schema)
-}
 
 // NewIndexer returns new indexer for `storage.ServiceAccount`.
 func NewIndexer(db *pgxpool.Pool) *indexerImpl {

--- a/central/vulnerabilityrequest/datastore/internal/store/postgres/index.go
+++ b/central/vulnerabilityrequest/datastore/internal/store/postgres/index.go
@@ -13,12 +13,7 @@ import (
 	search "github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/blevesearch"
 	"github.com/stackrox/rox/pkg/search/postgres"
-	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
-
-func init() {
-	mapping.RegisterCategoryToTable(v1.SearchCategory_VULN_REQUEST, schema)
-}
 
 // NewIndexer returns new indexer for `storage.VulnerabilityRequest`.
 func NewIndexer(db *pgxpool.Pool) *indexerImpl {

--- a/pkg/postgres/schema/active_components.go
+++ b/pkg/postgres/schema/active_components.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
 
 var (
@@ -42,6 +43,7 @@ var (
 		})
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory_ACTIVE_COMPONENT, "activecomponent", (*storage.ActiveComponent)(nil)))
 		RegisterTable(schema, CreateTableActiveComponentsStmt)
+		mapping.RegisterCategoryToTable(v1.SearchCategory_ACTIVE_COMPONENT, schema)
 		return schema
 	}()
 )

--- a/pkg/postgres/schema/alerts.go
+++ b/pkg/postgres/schema/alerts.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
 
 var (
@@ -30,6 +31,7 @@ var (
 		schema = walker.Walk(reflect.TypeOf((*storage.Alert)(nil)), "alerts")
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory_ALERTS, "alert", (*storage.Alert)(nil)))
 		RegisterTable(schema, CreateTableAlertsStmt)
+		mapping.RegisterCategoryToTable(v1.SearchCategory_ALERTS, schema)
 		return schema
 	}()
 )

--- a/pkg/postgres/schema/cluster_cve_edges.go
+++ b/pkg/postgres/schema/cluster_cve_edges.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
 
 var (
@@ -42,6 +43,7 @@ var (
 			v1.SearchCategory_CLUSTERS,
 		}...)
 		RegisterTable(schema, CreateTableClusterCveEdgesStmt)
+		mapping.RegisterCategoryToTable(v1.SearchCategory_CLUSTER_VULN_EDGE, schema)
 		return schema
 	}()
 )

--- a/pkg/postgres/schema/cluster_cves.go
+++ b/pkg/postgres/schema/cluster_cves.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
 
 var (
@@ -34,6 +35,7 @@ var (
 			v1.SearchCategory_CLUSTERS,
 		}...)
 		RegisterTable(schema, CreateTableClusterCvesStmt)
+		mapping.RegisterCategoryToTable(v1.SearchCategory_CLUSTER_VULNERABILITIES, schema)
 		return schema
 	}()
 )

--- a/pkg/postgres/schema/cluster_health_statuses.go
+++ b/pkg/postgres/schema/cluster_health_statuses.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
 
 var (
@@ -37,6 +38,7 @@ var (
 		})
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory_CLUSTER_HEALTH, "clusterhealthstatus", (*storage.ClusterHealthStatus)(nil)))
 		RegisterTable(schema, CreateTableClusterHealthStatusesStmt)
+		mapping.RegisterCategoryToTable(v1.SearchCategory_CLUSTER_HEALTH, schema)
 		return schema
 	}()
 )

--- a/pkg/postgres/schema/clusters.go
+++ b/pkg/postgres/schema/clusters.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
 
 var (
@@ -28,6 +29,7 @@ var (
 		schema = walker.Walk(reflect.TypeOf((*storage.Cluster)(nil)), "clusters")
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory_CLUSTERS, "cluster", (*storage.Cluster)(nil)))
 		RegisterTable(schema, CreateTableClustersStmt)
+		mapping.RegisterCategoryToTable(v1.SearchCategory_CLUSTERS, schema)
 		return schema
 	}()
 )

--- a/pkg/postgres/schema/collections.go
+++ b/pkg/postgres/schema/collections.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
 
 var (
@@ -33,6 +34,7 @@ var (
 		schema = walker.Walk(reflect.TypeOf((*storage.ResourceCollection)(nil)), "collections")
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory_COLLECTIONS, "resourcecollection", (*storage.ResourceCollection)(nil)))
 		RegisterTable(schema, CreateTableCollectionsStmt)
+		mapping.RegisterCategoryToTable(v1.SearchCategory_COLLECTIONS, schema)
 		return schema
 	}()
 )

--- a/pkg/postgres/schema/compliance_domains.go
+++ b/pkg/postgres/schema/compliance_domains.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
 
 var (
@@ -28,6 +29,7 @@ var (
 		schema = walker.Walk(reflect.TypeOf((*storage.ComplianceDomain)(nil)), "compliance_domains")
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory_COMPLIANCE_DOMAIN, "compliancedomain", (*storage.ComplianceDomain)(nil)))
 		RegisterTable(schema, CreateTableComplianceDomainsStmt)
+		mapping.RegisterCategoryToTable(v1.SearchCategory_COMPLIANCE_DOMAIN, schema)
 		return schema
 	}()
 )

--- a/pkg/postgres/schema/compliance_run_metadata.go
+++ b/pkg/postgres/schema/compliance_run_metadata.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
 
 var (
@@ -29,6 +30,7 @@ var (
 		schema = walker.Walk(reflect.TypeOf((*storage.ComplianceRunMetadata)(nil)), "compliance_run_metadata")
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory_COMPLIANCE_METADATA, "compliancerunmetadata", (*storage.ComplianceRunMetadata)(nil)))
 		RegisterTable(schema, CreateTableComplianceRunMetadataStmt)
+		mapping.RegisterCategoryToTable(v1.SearchCategory_COMPLIANCE_METADATA, schema)
 		return schema
 	}()
 )

--- a/pkg/postgres/schema/compliance_run_results.go
+++ b/pkg/postgres/schema/compliance_run_results.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
 
 var (
@@ -29,6 +30,7 @@ var (
 		schema = walker.Walk(reflect.TypeOf((*storage.ComplianceRunResults)(nil)), "compliance_run_results")
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory_COMPLIANCE_RESULTS, "compliancerunresults", (*storage.ComplianceRunResults)(nil)))
 		RegisterTable(schema, CreateTableComplianceRunResultsStmt)
+		mapping.RegisterCategoryToTable(v1.SearchCategory_COMPLIANCE_RESULTS, schema)
 		return schema
 	}()
 )

--- a/pkg/postgres/schema/deployments.go
+++ b/pkg/postgres/schema/deployments.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
 
 var (
@@ -78,6 +79,7 @@ var (
 			v1.SearchCategory_PROCESS_INDICATORS,
 		}...)
 		RegisterTable(schema, CreateTableDeploymentsStmt)
+		mapping.RegisterCategoryToTable(v1.SearchCategory_DEPLOYMENTS, schema)
 		return schema
 	}()
 )

--- a/pkg/postgres/schema/image_component_cve_edges.go
+++ b/pkg/postgres/schema/image_component_cve_edges.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
 
 var (
@@ -48,6 +49,7 @@ var (
 			v1.SearchCategory_CLUSTERS,
 		}...)
 		RegisterTable(schema, CreateTableImageComponentCveEdgesStmt)
+		mapping.RegisterCategoryToTable(v1.SearchCategory_COMPONENT_VULN_EDGE, schema)
 		return schema
 	}()
 )

--- a/pkg/postgres/schema/image_component_edges.go
+++ b/pkg/postgres/schema/image_component_edges.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
 
 var (
@@ -48,6 +49,7 @@ var (
 			v1.SearchCategory_CLUSTERS,
 		}...)
 		RegisterTable(schema, CreateTableImageComponentEdgesStmt)
+		mapping.RegisterCategoryToTable(v1.SearchCategory_IMAGE_COMPONENT_EDGE, schema)
 		return schema
 	}()
 )

--- a/pkg/postgres/schema/image_components.go
+++ b/pkg/postgres/schema/image_components.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
 
 var (
@@ -39,6 +40,7 @@ var (
 			v1.SearchCategory_CLUSTERS,
 		}...)
 		RegisterTable(schema, CreateTableImageComponentsStmt)
+		mapping.RegisterCategoryToTable(v1.SearchCategory_IMAGE_COMPONENTS, schema)
 		return schema
 	}()
 )

--- a/pkg/postgres/schema/image_cve_edges.go
+++ b/pkg/postgres/schema/image_cve_edges.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
 
 var (
@@ -49,6 +50,7 @@ var (
 			v1.SearchCategory_CLUSTERS,
 		}...)
 		RegisterTable(schema, CreateTableImageCveEdgesStmt)
+		mapping.RegisterCategoryToTable(v1.SearchCategory_IMAGE_VULN_EDGE, schema)
 		return schema
 	}()
 )

--- a/pkg/postgres/schema/image_cves.go
+++ b/pkg/postgres/schema/image_cves.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
 
 var (
@@ -40,6 +41,7 @@ var (
 			v1.SearchCategory_CLUSTERS,
 		}...)
 		RegisterTable(schema, CreateTableImageCvesStmt)
+		mapping.RegisterCategoryToTable(v1.SearchCategory_IMAGE_VULNERABILITIES, schema)
 		return schema
 	}()
 )

--- a/pkg/postgres/schema/image_integrations.go
+++ b/pkg/postgres/schema/image_integrations.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
 
 var (
@@ -28,6 +29,7 @@ var (
 		schema = walker.Walk(reflect.TypeOf((*storage.ImageIntegration)(nil)), "image_integrations")
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory_IMAGE_INTEGRATIONS, "imageintegration", (*storage.ImageIntegration)(nil)))
 		RegisterTable(schema, CreateTableImageIntegrationsStmt)
+		mapping.RegisterCategoryToTable(v1.SearchCategory_IMAGE_INTEGRATIONS, schema)
 		return schema
 	}()
 )

--- a/pkg/postgres/schema/images.go
+++ b/pkg/postgres/schema/images.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
 
 var (
@@ -46,6 +47,7 @@ var (
 			v1.SearchCategory_CLUSTERS,
 		}...)
 		RegisterTable(schema, CreateTableImagesStmt)
+		mapping.RegisterCategoryToTable(v1.SearchCategory_IMAGES, schema)
 		return schema
 	}()
 )

--- a/pkg/postgres/schema/k8s_roles.go
+++ b/pkg/postgres/schema/k8s_roles.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
 
 var (
@@ -28,6 +29,7 @@ var (
 		schema = walker.Walk(reflect.TypeOf((*storage.K8SRole)(nil)), "k8s_roles")
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory_ROLES, "k8srole", (*storage.K8SRole)(nil)))
 		RegisterTable(schema, CreateTableK8sRolesStmt)
+		mapping.RegisterCategoryToTable(v1.SearchCategory_ROLES, schema)
 		return schema
 	}()
 )

--- a/pkg/postgres/schema/namespaces.go
+++ b/pkg/postgres/schema/namespaces.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
 
 var (
@@ -47,6 +48,7 @@ var (
 			v1.SearchCategory_CLUSTERS,
 		}...)
 		RegisterTable(schema, CreateTableNamespacesStmt)
+		mapping.RegisterCategoryToTable(v1.SearchCategory_NAMESPACES, schema)
 		return schema
 	}()
 )

--- a/pkg/postgres/schema/network_baselines.go
+++ b/pkg/postgres/schema/network_baselines.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
 
 var (
@@ -28,6 +29,7 @@ var (
 		schema = walker.Walk(reflect.TypeOf((*storage.NetworkBaseline)(nil)), "network_baselines")
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory_NETWORK_BASELINE, "networkbaseline", (*storage.NetworkBaseline)(nil)))
 		RegisterTable(schema, CreateTableNetworkBaselinesStmt)
+		mapping.RegisterCategoryToTable(v1.SearchCategory_NETWORK_BASELINE, schema)
 		return schema
 	}()
 )

--- a/pkg/postgres/schema/network_entities.go
+++ b/pkg/postgres/schema/network_entities.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
 
 var (
@@ -28,6 +29,7 @@ var (
 		schema = walker.Walk(reflect.TypeOf((*storage.NetworkEntity)(nil)), "network_entities")
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory_NETWORK_ENTITY, "networkentity", (*storage.NetworkEntity)(nil)))
 		RegisterTable(schema, CreateTableNetworkEntitiesStmt)
+		mapping.RegisterCategoryToTable(v1.SearchCategory_NETWORK_ENTITY, schema)
 		return schema
 	}()
 )

--- a/pkg/postgres/schema/networkpolicies.go
+++ b/pkg/postgres/schema/networkpolicies.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
 
 var (
@@ -28,6 +29,7 @@ var (
 		schema = walker.Walk(reflect.TypeOf((*storage.NetworkPolicy)(nil)), "networkpolicies")
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory_NETWORK_POLICIES, "networkpolicy", (*storage.NetworkPolicy)(nil)))
 		RegisterTable(schema, CreateTableNetworkpoliciesStmt)
+		mapping.RegisterCategoryToTable(v1.SearchCategory_NETWORK_POLICIES, schema)
 		return schema
 	}()
 )

--- a/pkg/postgres/schema/node_component_edges.go
+++ b/pkg/postgres/schema/node_component_edges.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
 
 var (
@@ -45,6 +46,7 @@ var (
 			v1.SearchCategory_CLUSTERS,
 		}...)
 		RegisterTable(schema, CreateTableNodeComponentEdgesStmt)
+		mapping.RegisterCategoryToTable(v1.SearchCategory_NODE_COMPONENT_EDGE, schema)
 		return schema
 	}()
 )

--- a/pkg/postgres/schema/node_components.go
+++ b/pkg/postgres/schema/node_components.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
 
 var (
@@ -36,6 +37,7 @@ var (
 			v1.SearchCategory_CLUSTERS,
 		}...)
 		RegisterTable(schema, CreateTableNodeComponentsStmt)
+		mapping.RegisterCategoryToTable(v1.SearchCategory_NODE_COMPONENTS, schema)
 		return schema
 	}()
 )

--- a/pkg/postgres/schema/node_components_cves_edges.go
+++ b/pkg/postgres/schema/node_components_cves_edges.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
 
 var (
@@ -45,6 +46,7 @@ var (
 			v1.SearchCategory_CLUSTERS,
 		}...)
 		RegisterTable(schema, CreateTableNodeComponentsCvesEdgesStmt)
+		mapping.RegisterCategoryToTable(v1.SearchCategory_NODE_COMPONENT_CVE_EDGE, schema)
 		return schema
 	}()
 )

--- a/pkg/postgres/schema/node_cves.go
+++ b/pkg/postgres/schema/node_cves.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
 
 var (
@@ -37,6 +38,7 @@ var (
 			v1.SearchCategory_CLUSTERS,
 		}...)
 		RegisterTable(schema, CreateTableNodeCvesStmt)
+		mapping.RegisterCategoryToTable(v1.SearchCategory_NODE_VULNERABILITIES, schema)
 		return schema
 	}()
 )

--- a/pkg/postgres/schema/nodes.go
+++ b/pkg/postgres/schema/nodes.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
 
 var (
@@ -50,6 +51,7 @@ var (
 			v1.SearchCategory_CLUSTERS,
 		}...)
 		RegisterTable(schema, CreateTableNodesStmt)
+		mapping.RegisterCategoryToTable(v1.SearchCategory_NODES, schema)
 		return schema
 	}()
 )

--- a/pkg/postgres/schema/pods.go
+++ b/pkg/postgres/schema/pods.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
 
 var (
@@ -41,6 +42,7 @@ var (
 		})
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory_PODS, "pod", (*storage.Pod)(nil)))
 		RegisterTable(schema, CreateTablePodsStmt)
+		mapping.RegisterCategoryToTable(v1.SearchCategory_PODS, schema)
 		return schema
 	}()
 )

--- a/pkg/postgres/schema/policies.go
+++ b/pkg/postgres/schema/policies.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
 
 var (
@@ -30,6 +31,7 @@ var (
 		schema = walker.Walk(reflect.TypeOf((*storage.Policy)(nil)), "policies")
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory_POLICIES, "policy", (*storage.Policy)(nil)))
 		RegisterTable(schema, CreateTablePoliciesStmt)
+		mapping.RegisterCategoryToTable(v1.SearchCategory_POLICIES, schema)
 		return schema
 	}()
 )

--- a/pkg/postgres/schema/policy_categories.go
+++ b/pkg/postgres/schema/policy_categories.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
 
 var (
@@ -28,6 +29,7 @@ var (
 		schema = walker.Walk(reflect.TypeOf((*storage.PolicyCategory)(nil)), "policy_categories")
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory_POLICY_CATEGORIES, "policycategory", (*storage.PolicyCategory)(nil)))
 		RegisterTable(schema, CreateTablePolicyCategoriesStmt)
+		mapping.RegisterCategoryToTable(v1.SearchCategory_POLICY_CATEGORIES, schema)
 		return schema
 	}()
 )

--- a/pkg/postgres/schema/process_baseline_results.go
+++ b/pkg/postgres/schema/process_baseline_results.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
 
 var (
@@ -28,6 +29,7 @@ var (
 		schema = walker.Walk(reflect.TypeOf((*storage.ProcessBaselineResults)(nil)), "process_baseline_results")
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory_PROCESS_BASELINE_RESULTS, "processbaselineresults", (*storage.ProcessBaselineResults)(nil)))
 		RegisterTable(schema, CreateTableProcessBaselineResultsStmt)
+		mapping.RegisterCategoryToTable(v1.SearchCategory_PROCESS_BASELINE_RESULTS, schema)
 		return schema
 	}()
 )

--- a/pkg/postgres/schema/process_baselines.go
+++ b/pkg/postgres/schema/process_baselines.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
 
 var (
@@ -28,6 +29,7 @@ var (
 		schema = walker.Walk(reflect.TypeOf((*storage.ProcessBaseline)(nil)), "process_baselines")
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory_PROCESS_BASELINES, "processbaseline", (*storage.ProcessBaseline)(nil)))
 		RegisterTable(schema, CreateTableProcessBaselinesStmt)
+		mapping.RegisterCategoryToTable(v1.SearchCategory_PROCESS_BASELINES, schema)
 		return schema
 	}()
 )

--- a/pkg/postgres/schema/process_indicators.go
+++ b/pkg/postgres/schema/process_indicators.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
 
 var (
@@ -36,6 +37,7 @@ var (
 		})
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory_PROCESS_INDICATORS, "processindicator", (*storage.ProcessIndicator)(nil)))
 		RegisterTable(schema, CreateTableProcessIndicatorsStmt)
+		mapping.RegisterCategoryToTable(v1.SearchCategory_PROCESS_INDICATORS, schema)
 		return schema
 	}()
 )

--- a/pkg/postgres/schema/report_configurations.go
+++ b/pkg/postgres/schema/report_configurations.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
 
 var (
@@ -28,6 +29,7 @@ var (
 		schema = walker.Walk(reflect.TypeOf((*storage.ReportConfiguration)(nil)), "report_configurations")
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory_REPORT_CONFIGURATIONS, "reportconfiguration", (*storage.ReportConfiguration)(nil)))
 		RegisterTable(schema, CreateTableReportConfigurationsStmt)
+		mapping.RegisterCategoryToTable(v1.SearchCategory_REPORT_CONFIGURATIONS, schema)
 		return schema
 	}()
 )

--- a/pkg/postgres/schema/risks.go
+++ b/pkg/postgres/schema/risks.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
 
 var (
@@ -28,6 +29,7 @@ var (
 		schema = walker.Walk(reflect.TypeOf((*storage.Risk)(nil)), "risks")
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory_RISKS, "risk", (*storage.Risk)(nil)))
 		RegisterTable(schema, CreateTableRisksStmt)
+		mapping.RegisterCategoryToTable(v1.SearchCategory_RISKS, schema)
 		return schema
 	}()
 )

--- a/pkg/postgres/schema/role_bindings.go
+++ b/pkg/postgres/schema/role_bindings.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
 
 var (
@@ -33,6 +34,7 @@ var (
 		schema = walker.Walk(reflect.TypeOf((*storage.K8SRoleBinding)(nil)), "role_bindings")
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory_ROLEBINDINGS, "k8srolebinding", (*storage.K8SRoleBinding)(nil)))
 		RegisterTable(schema, CreateTableRoleBindingsStmt)
+		mapping.RegisterCategoryToTable(v1.SearchCategory_ROLEBINDINGS, schema)
 		return schema
 	}()
 )

--- a/pkg/postgres/schema/secrets.go
+++ b/pkg/postgres/schema/secrets.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
 
 var (
@@ -39,6 +40,7 @@ var (
 		schema = walker.Walk(reflect.TypeOf((*storage.Secret)(nil)), "secrets")
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory_SECRETS, "secret", (*storage.Secret)(nil)))
 		RegisterTable(schema, CreateTableSecretsStmt)
+		mapping.RegisterCategoryToTable(v1.SearchCategory_SECRETS, schema)
 		return schema
 	}()
 )

--- a/pkg/postgres/schema/service_accounts.go
+++ b/pkg/postgres/schema/service_accounts.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
 
 var (
@@ -28,6 +29,7 @@ var (
 		schema = walker.Walk(reflect.TypeOf((*storage.ServiceAccount)(nil)), "service_accounts")
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory_SERVICE_ACCOUNTS, "serviceaccount", (*storage.ServiceAccount)(nil)))
 		RegisterTable(schema, CreateTableServiceAccountsStmt)
+		mapping.RegisterCategoryToTable(v1.SearchCategory_SERVICE_ACCOUNTS, schema)
 		return schema
 	}()
 )

--- a/pkg/postgres/schema/test_child1.go
+++ b/pkg/postgres/schema/test_child1.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
 
 var (
@@ -28,6 +29,7 @@ var (
 		schema = walker.Walk(reflect.TypeOf((*storage.TestChild1)(nil)), "test_child1")
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory(63), "testchild1", (*storage.TestChild1)(nil)))
 		RegisterTable(schema, CreateTableTestChild1Stmt)
+		mapping.RegisterCategoryToTable(v1.SearchCategory(63), schema)
 		return schema
 	}()
 )

--- a/pkg/postgres/schema/test_child1.go
+++ b/pkg/postgres/schema/test_child1.go
@@ -27,9 +27,9 @@ var (
 			return schema
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.TestChild1)(nil)), "test_child1")
-		schema.SetOptionsMap(search.Walk(v1.SearchCategory(63), "testchild1", (*storage.TestChild1)(nil)))
+		schema.SetOptionsMap(search.Walk(v1.SearchCategory(102), "testchild1", (*storage.TestChild1)(nil)))
 		RegisterTable(schema, CreateTableTestChild1Stmt)
-		mapping.RegisterCategoryToTable(v1.SearchCategory(63), schema)
+		mapping.RegisterCategoryToTable(v1.SearchCategory(102), schema)
 		return schema
 	}()
 )

--- a/pkg/postgres/schema/test_child1_p4.go
+++ b/pkg/postgres/schema/test_child1_p4.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
 
 var (
@@ -39,6 +40,7 @@ var (
 			v1.SearchCategory(74),
 		}...)
 		RegisterTable(schema, CreateTableTestChild1P4Stmt)
+		mapping.RegisterCategoryToTable(v1.SearchCategory(74), schema)
 		return schema
 	}()
 )

--- a/pkg/postgres/schema/test_child1_p4.go
+++ b/pkg/postgres/schema/test_child1_p4.go
@@ -37,7 +37,7 @@ var (
 		})
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory(103), "testchild1p4", (*storage.TestChild1P4)(nil)))
 		schema.SetSearchScope([]v1.SearchCategory{
-			v1.SearchCategory(74),
+			v1.SearchCategory(103),
 		}...)
 		RegisterTable(schema, CreateTableTestChild1P4Stmt)
 		mapping.RegisterCategoryToTable(v1.SearchCategory(103), schema)

--- a/pkg/postgres/schema/test_child1_p4.go
+++ b/pkg/postgres/schema/test_child1_p4.go
@@ -35,12 +35,12 @@ var (
 		schema.ResolveReferences(func(messageTypeName string) *walker.Schema {
 			return referencedSchemas[fmt.Sprintf("storage.%s", messageTypeName)]
 		})
-		schema.SetOptionsMap(search.Walk(v1.SearchCategory(74), "testchild1p4", (*storage.TestChild1P4)(nil)))
+		schema.SetOptionsMap(search.Walk(v1.SearchCategory(103), "testchild1p4", (*storage.TestChild1P4)(nil)))
 		schema.SetSearchScope([]v1.SearchCategory{
 			v1.SearchCategory(74),
 		}...)
 		RegisterTable(schema, CreateTableTestChild1P4Stmt)
-		mapping.RegisterCategoryToTable(v1.SearchCategory(74), schema)
+		mapping.RegisterCategoryToTable(v1.SearchCategory(103), schema)
 		return schema
 	}()
 )

--- a/pkg/postgres/schema/test_child2.go
+++ b/pkg/postgres/schema/test_child2.go
@@ -36,9 +36,9 @@ var (
 		schema.ResolveReferences(func(messageTypeName string) *walker.Schema {
 			return referencedSchemas[fmt.Sprintf("storage.%s", messageTypeName)]
 		})
-		schema.SetOptionsMap(search.Walk(v1.SearchCategory(70), "testchild2", (*storage.TestChild2)(nil)))
+		schema.SetOptionsMap(search.Walk(v1.SearchCategory(104), "testchild2", (*storage.TestChild2)(nil)))
 		RegisterTable(schema, CreateTableTestChild2Stmt)
-		mapping.RegisterCategoryToTable(v1.SearchCategory(70), schema)
+		mapping.RegisterCategoryToTable(v1.SearchCategory(104), schema)
 		return schema
 	}()
 )

--- a/pkg/postgres/schema/test_child2.go
+++ b/pkg/postgres/schema/test_child2.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
 
 var (
@@ -37,6 +38,7 @@ var (
 		})
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory(70), "testchild2", (*storage.TestChild2)(nil)))
 		RegisterTable(schema, CreateTableTestChild2Stmt)
+		mapping.RegisterCategoryToTable(v1.SearchCategory(70), schema)
 		return schema
 	}()
 )

--- a/pkg/postgres/schema/test_g2_grand_child1.go
+++ b/pkg/postgres/schema/test_g2_grand_child1.go
@@ -36,9 +36,9 @@ var (
 		schema.ResolveReferences(func(messageTypeName string) *walker.Schema {
 			return referencedSchemas[fmt.Sprintf("storage.%s", messageTypeName)]
 		})
-		schema.SetOptionsMap(search.Walk(v1.SearchCategory(66), "testg2grandchild1", (*storage.TestG2GrandChild1)(nil)))
+		schema.SetOptionsMap(search.Walk(v1.SearchCategory(105), "testg2grandchild1", (*storage.TestG2GrandChild1)(nil)))
 		RegisterTable(schema, CreateTableTestG2GrandChild1Stmt)
-		mapping.RegisterCategoryToTable(v1.SearchCategory(66), schema)
+		mapping.RegisterCategoryToTable(v1.SearchCategory(105), schema)
 		return schema
 	}()
 )

--- a/pkg/postgres/schema/test_g2_grand_child1.go
+++ b/pkg/postgres/schema/test_g2_grand_child1.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
 
 var (
@@ -37,6 +38,7 @@ var (
 		})
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory(66), "testg2grandchild1", (*storage.TestG2GrandChild1)(nil)))
 		RegisterTable(schema, CreateTableTestG2GrandChild1Stmt)
+		mapping.RegisterCategoryToTable(v1.SearchCategory(66), schema)
 		return schema
 	}()
 )

--- a/pkg/postgres/schema/test_g3_grand_child1.go
+++ b/pkg/postgres/schema/test_g3_grand_child1.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
 
 var (
@@ -28,6 +29,7 @@ var (
 		schema = walker.Walk(reflect.TypeOf((*storage.TestG3GrandChild1)(nil)), "test_g3_grand_child1")
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory(67), "testg3grandchild1", (*storage.TestG3GrandChild1)(nil)))
 		RegisterTable(schema, CreateTableTestG3GrandChild1Stmt)
+		mapping.RegisterCategoryToTable(v1.SearchCategory(67), schema)
 		return schema
 	}()
 )

--- a/pkg/postgres/schema/test_g3_grand_child1.go
+++ b/pkg/postgres/schema/test_g3_grand_child1.go
@@ -27,9 +27,9 @@ var (
 			return schema
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.TestG3GrandChild1)(nil)), "test_g3_grand_child1")
-		schema.SetOptionsMap(search.Walk(v1.SearchCategory(67), "testg3grandchild1", (*storage.TestG3GrandChild1)(nil)))
+		schema.SetOptionsMap(search.Walk(v1.SearchCategory(106), "testg3grandchild1", (*storage.TestG3GrandChild1)(nil)))
 		RegisterTable(schema, CreateTableTestG3GrandChild1Stmt)
-		mapping.RegisterCategoryToTable(v1.SearchCategory(67), schema)
+		mapping.RegisterCategoryToTable(v1.SearchCategory(106), schema)
 		return schema
 	}()
 )

--- a/pkg/postgres/schema/test_g_grand_child1.go
+++ b/pkg/postgres/schema/test_g_grand_child1.go
@@ -27,9 +27,9 @@ var (
 			return schema
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.TestGGrandChild1)(nil)), "test_g_grand_child1")
-		schema.SetOptionsMap(search.Walk(v1.SearchCategory(65), "testggrandchild1", (*storage.TestGGrandChild1)(nil)))
+		schema.SetOptionsMap(search.Walk(v1.SearchCategory(107), "testggrandchild1", (*storage.TestGGrandChild1)(nil)))
 		RegisterTable(schema, CreateTableTestGGrandChild1Stmt)
-		mapping.RegisterCategoryToTable(v1.SearchCategory(65), schema)
+		mapping.RegisterCategoryToTable(v1.SearchCategory(107), schema)
 		return schema
 	}()
 )

--- a/pkg/postgres/schema/test_g_grand_child1.go
+++ b/pkg/postgres/schema/test_g_grand_child1.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
 
 var (
@@ -28,6 +29,7 @@ var (
 		schema = walker.Walk(reflect.TypeOf((*storage.TestGGrandChild1)(nil)), "test_g_grand_child1")
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory(65), "testggrandchild1", (*storage.TestGGrandChild1)(nil)))
 		RegisterTable(schema, CreateTableTestGGrandChild1Stmt)
+		mapping.RegisterCategoryToTable(v1.SearchCategory(65), schema)
 		return schema
 	}()
 )

--- a/pkg/postgres/schema/test_grand_child1.go
+++ b/pkg/postgres/schema/test_grand_child1.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
 
 var (
@@ -37,6 +38,7 @@ var (
 		})
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory(64), "testgrandchild1", (*storage.TestGrandChild1)(nil)))
 		RegisterTable(schema, CreateTableTestGrandChild1Stmt)
+		mapping.RegisterCategoryToTable(v1.SearchCategory(64), schema)
 		return schema
 	}()
 )

--- a/pkg/postgres/schema/test_grand_child1.go
+++ b/pkg/postgres/schema/test_grand_child1.go
@@ -36,9 +36,9 @@ var (
 		schema.ResolveReferences(func(messageTypeName string) *walker.Schema {
 			return referencedSchemas[fmt.Sprintf("storage.%s", messageTypeName)]
 		})
-		schema.SetOptionsMap(search.Walk(v1.SearchCategory(64), "testgrandchild1", (*storage.TestGrandChild1)(nil)))
+		schema.SetOptionsMap(search.Walk(v1.SearchCategory(108), "testgrandchild1", (*storage.TestGrandChild1)(nil)))
 		RegisterTable(schema, CreateTableTestGrandChild1Stmt)
-		mapping.RegisterCategoryToTable(v1.SearchCategory(64), schema)
+		mapping.RegisterCategoryToTable(v1.SearchCategory(108), schema)
 		return schema
 	}()
 )

--- a/pkg/postgres/schema/test_grandparents.go
+++ b/pkg/postgres/schema/test_grandparents.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
 
 var (
@@ -38,6 +39,7 @@ var (
 		schema = walker.Walk(reflect.TypeOf((*storage.TestGrandparent)(nil)), "test_grandparents")
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory(61), "testgrandparent", (*storage.TestGrandparent)(nil)))
 		RegisterTable(schema, CreateTableTestGrandparentsStmt)
+		mapping.RegisterCategoryToTable(v1.SearchCategory(61), schema)
 		return schema
 	}()
 )

--- a/pkg/postgres/schema/test_grandparents.go
+++ b/pkg/postgres/schema/test_grandparents.go
@@ -37,9 +37,9 @@ var (
 			return schema
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.TestGrandparent)(nil)), "test_grandparents")
-		schema.SetOptionsMap(search.Walk(v1.SearchCategory(61), "testgrandparent", (*storage.TestGrandparent)(nil)))
+		schema.SetOptionsMap(search.Walk(v1.SearchCategory(109), "testgrandparent", (*storage.TestGrandparent)(nil)))
 		RegisterTable(schema, CreateTableTestGrandparentsStmt)
-		mapping.RegisterCategoryToTable(v1.SearchCategory(61), schema)
+		mapping.RegisterCategoryToTable(v1.SearchCategory(109), schema)
 		return schema
 	}()
 )

--- a/pkg/postgres/schema/test_multi_key_structs.go
+++ b/pkg/postgres/schema/test_multi_key_structs.go
@@ -34,9 +34,9 @@ var (
 			return schema
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.TestMultiKeyStruct)(nil)), "test_multi_key_structs")
-		schema.SetOptionsMap(search.Walk(v1.SearchCategory_SEARCH_UNSET, "testmultikeystruct", (*storage.TestMultiKeyStruct)(nil)))
+		schema.SetOptionsMap(search.Walk(v1.SearchCategory(101), "testmultikeystruct", (*storage.TestMultiKeyStruct)(nil)))
 		RegisterTable(schema, CreateTableTestMultiKeyStructsStmt)
-		mapping.RegisterCategoryToTable(v1.SearchCategory_SEARCH_UNSET, schema)
+		mapping.RegisterCategoryToTable(v1.SearchCategory(101), schema)
 		return schema
 	}()
 )

--- a/pkg/postgres/schema/test_multi_key_structs.go
+++ b/pkg/postgres/schema/test_multi_key_structs.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
 
 var (
@@ -35,6 +36,7 @@ var (
 		schema = walker.Walk(reflect.TypeOf((*storage.TestMultiKeyStruct)(nil)), "test_multi_key_structs")
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory_SEARCH_UNSET, "testmultikeystruct", (*storage.TestMultiKeyStruct)(nil)))
 		RegisterTable(schema, CreateTableTestMultiKeyStructsStmt)
+		mapping.RegisterCategoryToTable(v1.SearchCategory_SEARCH_UNSET, schema)
 		return schema
 	}()
 )

--- a/pkg/postgres/schema/test_parent1.go
+++ b/pkg/postgres/schema/test_parent1.go
@@ -41,9 +41,9 @@ var (
 		schema.ResolveReferences(func(messageTypeName string) *walker.Schema {
 			return referencedSchemas[fmt.Sprintf("storage.%s", messageTypeName)]
 		})
-		schema.SetOptionsMap(search.Walk(v1.SearchCategory(62), "testparent1", (*storage.TestParent1)(nil)))
+		schema.SetOptionsMap(search.Walk(v1.SearchCategory(110), "testparent1", (*storage.TestParent1)(nil)))
 		RegisterTable(schema, CreateTableTestParent1Stmt)
-		mapping.RegisterCategoryToTable(v1.SearchCategory(62), schema)
+		mapping.RegisterCategoryToTable(v1.SearchCategory(110), schema)
 		return schema
 	}()
 )

--- a/pkg/postgres/schema/test_parent1.go
+++ b/pkg/postgres/schema/test_parent1.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
 
 var (
@@ -42,6 +43,7 @@ var (
 		})
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory(62), "testparent1", (*storage.TestParent1)(nil)))
 		RegisterTable(schema, CreateTableTestParent1Stmt)
+		mapping.RegisterCategoryToTable(v1.SearchCategory(62), schema)
 		return schema
 	}()
 )

--- a/pkg/postgres/schema/test_parent2.go
+++ b/pkg/postgres/schema/test_parent2.go
@@ -35,9 +35,9 @@ var (
 		schema.ResolveReferences(func(messageTypeName string) *walker.Schema {
 			return referencedSchemas[fmt.Sprintf("storage.%s", messageTypeName)]
 		})
-		schema.SetOptionsMap(search.Walk(v1.SearchCategory(68), "testparent2", (*storage.TestParent2)(nil)))
+		schema.SetOptionsMap(search.Walk(v1.SearchCategory(111), "testparent2", (*storage.TestParent2)(nil)))
 		RegisterTable(schema, CreateTableTestParent2Stmt)
-		mapping.RegisterCategoryToTable(v1.SearchCategory(68), schema)
+		mapping.RegisterCategoryToTable(v1.SearchCategory(111), schema)
 		return schema
 	}()
 )

--- a/pkg/postgres/schema/test_parent2.go
+++ b/pkg/postgres/schema/test_parent2.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
 
 var (
@@ -36,6 +37,7 @@ var (
 		})
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory(68), "testparent2", (*storage.TestParent2)(nil)))
 		RegisterTable(schema, CreateTableTestParent2Stmt)
+		mapping.RegisterCategoryToTable(v1.SearchCategory(68), schema)
 		return schema
 	}()
 )

--- a/pkg/postgres/schema/test_parent3.go
+++ b/pkg/postgres/schema/test_parent3.go
@@ -35,9 +35,9 @@ var (
 		schema.ResolveReferences(func(messageTypeName string) *walker.Schema {
 			return referencedSchemas[fmt.Sprintf("storage.%s", messageTypeName)]
 		})
-		schema.SetOptionsMap(search.Walk(v1.SearchCategory(69), "testparent3", (*storage.TestParent3)(nil)))
+		schema.SetOptionsMap(search.Walk(v1.SearchCategory(112), "testparent3", (*storage.TestParent3)(nil)))
 		RegisterTable(schema, CreateTableTestParent3Stmt)
-		mapping.RegisterCategoryToTable(v1.SearchCategory(69), schema)
+		mapping.RegisterCategoryToTable(v1.SearchCategory(112), schema)
 		return schema
 	}()
 )

--- a/pkg/postgres/schema/test_parent3.go
+++ b/pkg/postgres/schema/test_parent3.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
 
 var (
@@ -36,6 +37,7 @@ var (
 		})
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory(69), "testparent3", (*storage.TestParent3)(nil)))
 		RegisterTable(schema, CreateTableTestParent3Stmt)
+		mapping.RegisterCategoryToTable(v1.SearchCategory(69), schema)
 		return schema
 	}()
 )

--- a/pkg/postgres/schema/test_parent4.go
+++ b/pkg/postgres/schema/test_parent4.go
@@ -35,13 +35,13 @@ var (
 		schema.ResolveReferences(func(messageTypeName string) *walker.Schema {
 			return referencedSchemas[fmt.Sprintf("storage.%s", messageTypeName)]
 		})
-		schema.SetOptionsMap(search.Walk(v1.SearchCategory(72), "testparent4", (*storage.TestParent4)(nil)))
+		schema.SetOptionsMap(search.Walk(v1.SearchCategory(113), "testparent4", (*storage.TestParent4)(nil)))
 		schema.SetSearchScope([]v1.SearchCategory{
 			v1.SearchCategory(61),
 			v1.SearchCategory(74),
 		}...)
 		RegisterTable(schema, CreateTableTestParent4Stmt)
-		mapping.RegisterCategoryToTable(v1.SearchCategory(72), schema)
+		mapping.RegisterCategoryToTable(v1.SearchCategory(113), schema)
 		return schema
 	}()
 )

--- a/pkg/postgres/schema/test_parent4.go
+++ b/pkg/postgres/schema/test_parent4.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
 
 var (
@@ -40,6 +41,7 @@ var (
 			v1.SearchCategory(74),
 		}...)
 		RegisterTable(schema, CreateTableTestParent4Stmt)
+		mapping.RegisterCategoryToTable(v1.SearchCategory(72), schema)
 		return schema
 	}()
 )

--- a/pkg/postgres/schema/test_parent4.go
+++ b/pkg/postgres/schema/test_parent4.go
@@ -37,8 +37,8 @@ var (
 		})
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory(113), "testparent4", (*storage.TestParent4)(nil)))
 		schema.SetSearchScope([]v1.SearchCategory{
-			v1.SearchCategory(61),
-			v1.SearchCategory(74),
+			v1.SearchCategory(109),
+			v1.SearchCategory(103),
 		}...)
 		RegisterTable(schema, CreateTableTestParent4Stmt)
 		mapping.RegisterCategoryToTable(v1.SearchCategory(113), schema)

--- a/pkg/postgres/schema/test_short_circuits.go
+++ b/pkg/postgres/schema/test_short_circuits.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
 
 var (
@@ -37,6 +38,7 @@ var (
 		})
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory(71), "testshortcircuit", (*storage.TestShortCircuit)(nil)))
 		RegisterTable(schema, CreateTableTestShortCircuitsStmt)
+		mapping.RegisterCategoryToTable(v1.SearchCategory(71), schema)
 		return schema
 	}()
 )

--- a/pkg/postgres/schema/test_short_circuits.go
+++ b/pkg/postgres/schema/test_short_circuits.go
@@ -36,9 +36,9 @@ var (
 		schema.ResolveReferences(func(messageTypeName string) *walker.Schema {
 			return referencedSchemas[fmt.Sprintf("storage.%s", messageTypeName)]
 		})
-		schema.SetOptionsMap(search.Walk(v1.SearchCategory(71), "testshortcircuit", (*storage.TestShortCircuit)(nil)))
+		schema.SetOptionsMap(search.Walk(v1.SearchCategory(114), "testshortcircuit", (*storage.TestShortCircuit)(nil)))
 		RegisterTable(schema, CreateTableTestShortCircuitsStmt)
-		mapping.RegisterCategoryToTable(v1.SearchCategory(71), schema)
+		mapping.RegisterCategoryToTable(v1.SearchCategory(114), schema)
 		return schema
 	}()
 )

--- a/pkg/postgres/schema/test_single_key_structs.go
+++ b/pkg/postgres/schema/test_single_key_structs.go
@@ -29,9 +29,9 @@ var (
 			return schema
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.TestSingleKeyStruct)(nil)), "test_single_key_structs")
-		schema.SetOptionsMap(search.Walk(v1.SearchCategory_SEARCH_UNSET, "testsinglekeystruct", (*storage.TestSingleKeyStruct)(nil)))
+		schema.SetOptionsMap(search.Walk(v1.SearchCategory(100), "testsinglekeystruct", (*storage.TestSingleKeyStruct)(nil)))
 		RegisterTable(schema, CreateTableTestSingleKeyStructsStmt)
-		mapping.RegisterCategoryToTable(v1.SearchCategory_SEARCH_UNSET, schema)
+		mapping.RegisterCategoryToTable(v1.SearchCategory(100), schema)
 		return schema
 	}()
 )

--- a/pkg/postgres/schema/test_single_key_structs.go
+++ b/pkg/postgres/schema/test_single_key_structs.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
 
 var (
@@ -30,6 +31,7 @@ var (
 		schema = walker.Walk(reflect.TypeOf((*storage.TestSingleKeyStruct)(nil)), "test_single_key_structs")
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory_SEARCH_UNSET, "testsinglekeystruct", (*storage.TestSingleKeyStruct)(nil)))
 		RegisterTable(schema, CreateTableTestSingleKeyStructsStmt)
+		mapping.RegisterCategoryToTable(v1.SearchCategory_SEARCH_UNSET, schema)
 		return schema
 	}()
 )

--- a/pkg/postgres/schema/test_single_uuid_key_structs.go
+++ b/pkg/postgres/schema/test_single_uuid_key_structs.go
@@ -29,9 +29,9 @@ var (
 			return schema
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.TestSingleUUIDKeyStruct)(nil)), "test_single_uuid_key_structs")
-		schema.SetOptionsMap(search.Walk(v1.SearchCategory_SEARCH_UNSET, "testsingleuuidkeystruct", (*storage.TestSingleUUIDKeyStruct)(nil)))
+		schema.SetOptionsMap(search.Walk(v1.SearchCategory(115), "testsingleuuidkeystruct", (*storage.TestSingleUUIDKeyStruct)(nil)))
 		RegisterTable(schema, CreateTableTestSingleUuidKeyStructsStmt)
-		mapping.RegisterCategoryToTable(v1.SearchCategory_SEARCH_UNSET, schema)
+		mapping.RegisterCategoryToTable(v1.SearchCategory(115), schema)
 		return schema
 	}()
 )

--- a/pkg/postgres/schema/test_single_uuid_key_structs.go
+++ b/pkg/postgres/schema/test_single_uuid_key_structs.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
 
 var (
@@ -30,6 +31,7 @@ var (
 		schema = walker.Walk(reflect.TypeOf((*storage.TestSingleUUIDKeyStruct)(nil)), "test_single_uuid_key_structs")
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory_SEARCH_UNSET, "testsingleuuidkeystruct", (*storage.TestSingleUUIDKeyStruct)(nil)))
 		RegisterTable(schema, CreateTableTestSingleUuidKeyStructsStmt)
+		mapping.RegisterCategoryToTable(v1.SearchCategory_SEARCH_UNSET, schema)
 		return schema
 	}()
 )

--- a/pkg/postgres/schema/vulnerability_requests.go
+++ b/pkg/postgres/schema/vulnerability_requests.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
 
 var (
@@ -39,6 +40,7 @@ var (
 		schema = walker.Walk(reflect.TypeOf((*storage.VulnerabilityRequest)(nil)), "vulnerability_requests")
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory_VULN_REQUEST, "vulnerabilityrequest", (*storage.VulnerabilityRequest)(nil)))
 		RegisterTable(schema, CreateTableVulnerabilityRequestsStmt)
+		mapping.RegisterCategoryToTable(v1.SearchCategory_VULN_REQUEST, schema)
 		return schema
 	}()
 )

--- a/pkg/search/scoped/postgres/searcher_test.go
+++ b/pkg/search/scoped/postgres/searcher_test.go
@@ -4,12 +4,20 @@ import (
 	"testing"
 
 	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/pkg/postgres/schema"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 	"github.com/stackrox/rox/pkg/search/scoped"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestScoping(t *testing.T) {
+	if mapping.GetTableFromCategory(v1.SearchCategory_CLUSTERS) == nil {
+		mapping.RegisterCategoryToTable(v1.SearchCategory_CLUSTERS, schema.ClustersSchema)
+	}
+	if mapping.GetTableFromCategory(v1.SearchCategory_NAMESPACES) == nil {
+		mapping.RegisterCategoryToTable(v1.SearchCategory_NAMESPACES, schema.NamespacesSchema)
+	}
 	query := search.NewQueryBuilder().AddExactMatches(search.DeploymentName, "dep").ProtoQuery()
 	scopes := []scoped.Scope{
 		{

--- a/pkg/search/scoped/postgres/searcher_test.go
+++ b/pkg/search/scoped/postgres/searcher_test.go
@@ -4,17 +4,12 @@ import (
 	"testing"
 
 	v1 "github.com/stackrox/rox/generated/api/v1"
-	"github.com/stackrox/rox/pkg/postgres/schema"
 	"github.com/stackrox/rox/pkg/search"
-	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 	"github.com/stackrox/rox/pkg/search/scoped"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestScoping(t *testing.T) {
-	mapping.RegisterCategoryToTable(v1.SearchCategory_CLUSTERS, schema.ClustersSchema)
-	mapping.RegisterCategoryToTable(v1.SearchCategory_NAMESPACES, schema.NamespacesSchema)
-
 	query := search.NewQueryBuilder().AddExactMatches(search.DeploymentName, "dep").ProtoQuery()
 	scopes := []scoped.Scope{
 		{

--- a/proto/api/v1/search_service.proto
+++ b/proto/api/v1/search_service.proto
@@ -58,6 +58,8 @@ enum SearchCategory {
     POLICY_CATEGORIES         = 46;
     IMAGE_INTEGRATIONS        = 47;
     COLLECTIONS               = 48;
+
+    // tags 100-150 are used for test protos.
 }
 
 enum SearchDataType {

--- a/tools/generate-helpers/pg-table-bindings/index.go.tpl
+++ b/tools/generate-helpers/pg-table-bindings/index.go.tpl
@@ -10,16 +10,11 @@ import (
 	storage "github.com/stackrox/rox/generated/storage"
 	ops "github.com/stackrox/rox/pkg/metrics"
 	search "github.com/stackrox/rox/pkg/search"
-	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 	"github.com/stackrox/rox/pkg/search/postgres"
 	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/stackrox/rox/pkg/search/blevesearch"
 	"github.com/stackrox/rox/pkg/postgres/walker"
 )
-
-func init() {
-	mapping.RegisterCategoryToTable(v1.{{.SearchCategory}}, schema)
-}
 
 // NewIndexer returns new indexer for `{{.Type}}`.
 func NewIndexer(db *pgxpool.Pool) *indexerImpl {

--- a/tools/generate-helpers/pg-table-bindings/multitest/postgres/gen.go
+++ b/tools/generate-helpers/pg-table-bindings/multitest/postgres/gen.go
@@ -1,3 +1,3 @@
 package postgres
 
-//go:generate pg-table-bindings-wrapper --type=storage.TestMultiKeyStruct --search-category SEARCH_UNSET
+//go:generate pg-table-bindings-wrapper --type=storage.TestMultiKeyStruct --search-category 101

--- a/tools/generate-helpers/pg-table-bindings/multitest/postgres/index.go
+++ b/tools/generate-helpers/pg-table-bindings/multitest/postgres/index.go
@@ -29,13 +29,13 @@ type indexerImpl struct {
 func (b *indexerImpl) Count(ctx context.Context, q *v1.Query, opts ...blevesearch.SearchOption) (int, error) {
 	defer metrics.SetIndexOperationDurationTime(time.Now(), ops.Count, "TestMultiKeyStruct")
 
-	return postgres.RunCountRequest(ctx, v1.SearchCategory_SEARCH_UNSET, q, b.db)
+	return postgres.RunCountRequest(ctx, v1.SearchCategory(101), q, b.db)
 }
 
 func (b *indexerImpl) Search(ctx context.Context, q *v1.Query, opts ...blevesearch.SearchOption) ([]search.Result, error) {
 	defer metrics.SetIndexOperationDurationTime(time.Now(), ops.Search, "TestMultiKeyStruct")
 
-	return postgres.RunSearchRequest(ctx, v1.SearchCategory_SEARCH_UNSET, q, b.db)
+	return postgres.RunSearchRequest(ctx, v1.SearchCategory(101), q, b.db)
 }
 
 //// Stubs for satisfying interfaces

--- a/tools/generate-helpers/pg-table-bindings/multitest/postgres/index.go
+++ b/tools/generate-helpers/pg-table-bindings/multitest/postgres/index.go
@@ -13,12 +13,7 @@ import (
 	search "github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/blevesearch"
 	"github.com/stackrox/rox/pkg/search/postgres"
-	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
-
-func init() {
-	mapping.RegisterCategoryToTable(v1.SearchCategory_SEARCH_UNSET, schema)
-}
 
 // NewIndexer returns new indexer for `storage.TestMultiKeyStruct`.
 func NewIndexer(db *pgxpool.Pool) *indexerImpl {

--- a/tools/generate-helpers/pg-table-bindings/schema.go.tpl
+++ b/tools/generate-helpers/pg-table-bindings/schema.go.tpl
@@ -15,6 +15,7 @@ import (
     "github.com/stackrox/rox/pkg/postgres"
     "github.com/stackrox/rox/pkg/postgres/walker"
     "github.com/stackrox/rox/pkg/search"
+    "github.com/stackrox/rox/pkg/search/postgres/mapping"
     "github.com/stackrox/rox/pkg/uuid"
 )
 
@@ -70,6 +71,9 @@ var (
         {{- end }}
         {{- if .RegisterSchema }}
         RegisterTable(schema, {{template "createTableStmtVar" .Schema }})
+            {{- if .SearchCategory }}
+                mapping.RegisterCategoryToTable(v1.{{.SearchCategory}}, schema)
+            {{- end}}
         {{- end}}
         return schema
     }()

--- a/tools/generate-helpers/pg-table-bindings/test/postgres/gen.go
+++ b/tools/generate-helpers/pg-table-bindings/test/postgres/gen.go
@@ -1,3 +1,3 @@
 package postgres
 
-//go:generate pg-table-bindings-wrapper --type=storage.TestSingleKeyStruct --search-category SEARCH_UNSET --get-all-func
+//go:generate pg-table-bindings-wrapper --type=storage.TestSingleKeyStruct --search-category 100 --get-all-func

--- a/tools/generate-helpers/pg-table-bindings/test/postgres/index.go
+++ b/tools/generate-helpers/pg-table-bindings/test/postgres/index.go
@@ -29,13 +29,13 @@ type indexerImpl struct {
 func (b *indexerImpl) Count(ctx context.Context, q *v1.Query, opts ...blevesearch.SearchOption) (int, error) {
 	defer metrics.SetIndexOperationDurationTime(time.Now(), ops.Count, "TestSingleKeyStruct")
 
-	return postgres.RunCountRequest(ctx, v1.SearchCategory_SEARCH_UNSET, q, b.db)
+	return postgres.RunCountRequest(ctx, v1.SearchCategory(100), q, b.db)
 }
 
 func (b *indexerImpl) Search(ctx context.Context, q *v1.Query, opts ...blevesearch.SearchOption) ([]search.Result, error) {
 	defer metrics.SetIndexOperationDurationTime(time.Now(), ops.Search, "TestSingleKeyStruct")
 
-	return postgres.RunSearchRequest(ctx, v1.SearchCategory_SEARCH_UNSET, q, b.db)
+	return postgres.RunSearchRequest(ctx, v1.SearchCategory(100), q, b.db)
 }
 
 //// Stubs for satisfying interfaces

--- a/tools/generate-helpers/pg-table-bindings/test/postgres/index.go
+++ b/tools/generate-helpers/pg-table-bindings/test/postgres/index.go
@@ -13,12 +13,7 @@ import (
 	search "github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/blevesearch"
 	"github.com/stackrox/rox/pkg/search/postgres"
-	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
-
-func init() {
-	mapping.RegisterCategoryToTable(v1.SearchCategory_SEARCH_UNSET, schema)
-}
 
 // NewIndexer returns new indexer for `storage.TestSingleKeyStruct`.
 func NewIndexer(db *pgxpool.Pool) *indexerImpl {

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/gen.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/gen.go
@@ -1,3 +1,3 @@
 package postgres
 
-//go:generate pg-table-bindings-wrapper --type=storage.TestChild1 --search-category 63
+//go:generate pg-table-bindings-wrapper --type=storage.TestChild1 --search-category 102

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/index.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/index.go
@@ -29,13 +29,13 @@ type indexerImpl struct {
 func (b *indexerImpl) Count(ctx context.Context, q *v1.Query, opts ...blevesearch.SearchOption) (int, error) {
 	defer metrics.SetIndexOperationDurationTime(time.Now(), ops.Count, "TestChild1")
 
-	return postgres.RunCountRequest(ctx, v1.SearchCategory(63), q, b.db)
+	return postgres.RunCountRequest(ctx, v1.SearchCategory(102), q, b.db)
 }
 
 func (b *indexerImpl) Search(ctx context.Context, q *v1.Query, opts ...blevesearch.SearchOption) ([]search.Result, error) {
 	defer metrics.SetIndexOperationDurationTime(time.Now(), ops.Search, "TestChild1")
 
-	return postgres.RunSearchRequest(ctx, v1.SearchCategory(63), q, b.db)
+	return postgres.RunSearchRequest(ctx, v1.SearchCategory(102), q, b.db)
 }
 
 //// Stubs for satisfying interfaces

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/index.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/index.go
@@ -13,12 +13,7 @@ import (
 	search "github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/blevesearch"
 	"github.com/stackrox/rox/pkg/search/postgres"
-	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
-
-func init() {
-	mapping.RegisterCategoryToTable(v1.SearchCategory(63), schema)
-}
 
 // NewIndexer returns new indexer for `storage.TestChild1`.
 func NewIndexer(db *pgxpool.Pool) *indexerImpl {

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1p4/gen.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1p4/gen.go
@@ -1,3 +1,3 @@
 package postgres
 
-//go:generate pg-table-bindings-wrapper --type=storage.TestChild1P4 --search-category 103 --references storage.TestParent4 --search-scope 74
+//go:generate pg-table-bindings-wrapper --type=storage.TestChild1P4 --search-category 103 --references storage.TestParent4 --search-scope 103

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1p4/gen.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1p4/gen.go
@@ -1,3 +1,3 @@
 package postgres
 
-//go:generate pg-table-bindings-wrapper --type=storage.TestChild1P4 --search-category 74 --references storage.TestParent4 --search-scope 74
+//go:generate pg-table-bindings-wrapper --type=storage.TestChild1P4 --search-category 103 --references storage.TestParent4 --search-scope 74

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1p4/index.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1p4/index.go
@@ -29,13 +29,13 @@ type indexerImpl struct {
 func (b *indexerImpl) Count(ctx context.Context, q *v1.Query, opts ...blevesearch.SearchOption) (int, error) {
 	defer metrics.SetIndexOperationDurationTime(time.Now(), ops.Count, "TestChild1P4")
 
-	return postgres.RunCountRequest(ctx, v1.SearchCategory(74), q, b.db)
+	return postgres.RunCountRequest(ctx, v1.SearchCategory(103), q, b.db)
 }
 
 func (b *indexerImpl) Search(ctx context.Context, q *v1.Query, opts ...blevesearch.SearchOption) ([]search.Result, error) {
 	defer metrics.SetIndexOperationDurationTime(time.Now(), ops.Search, "TestChild1P4")
 
-	return postgres.RunSearchRequest(ctx, v1.SearchCategory(74), q, b.db)
+	return postgres.RunSearchRequest(ctx, v1.SearchCategory(103), q, b.db)
 }
 
 //// Stubs for satisfying interfaces

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1p4/index.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1p4/index.go
@@ -13,12 +13,7 @@ import (
 	search "github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/blevesearch"
 	"github.com/stackrox/rox/pkg/search/postgres"
-	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
-
-func init() {
-	mapping.RegisterCategoryToTable(v1.SearchCategory(74), schema)
-}
 
 // NewIndexer returns new indexer for `storage.TestChild1P4`.
 func NewIndexer(db *pgxpool.Pool) *indexerImpl {

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild2/gen.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild2/gen.go
@@ -1,3 +1,3 @@
 package postgres
 
-//go:generate pg-table-bindings-wrapper --type=storage.TestChild2 --search-category 70 --references storage.TestParent2,storage.TestGrandparent
+//go:generate pg-table-bindings-wrapper --type=storage.TestChild2 --search-category 104 --references storage.TestParent2,storage.TestGrandparent

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild2/index.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild2/index.go
@@ -13,12 +13,7 @@ import (
 	search "github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/blevesearch"
 	"github.com/stackrox/rox/pkg/search/postgres"
-	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
-
-func init() {
-	mapping.RegisterCategoryToTable(v1.SearchCategory(70), schema)
-}
 
 // NewIndexer returns new indexer for `storage.TestChild2`.
 func NewIndexer(db *pgxpool.Pool) *indexerImpl {

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild2/index.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild2/index.go
@@ -29,13 +29,13 @@ type indexerImpl struct {
 func (b *indexerImpl) Count(ctx context.Context, q *v1.Query, opts ...blevesearch.SearchOption) (int, error) {
 	defer metrics.SetIndexOperationDurationTime(time.Now(), ops.Count, "TestChild2")
 
-	return postgres.RunCountRequest(ctx, v1.SearchCategory(70), q, b.db)
+	return postgres.RunCountRequest(ctx, v1.SearchCategory(104), q, b.db)
 }
 
 func (b *indexerImpl) Search(ctx context.Context, q *v1.Query, opts ...blevesearch.SearchOption) ([]search.Result, error) {
 	defer metrics.SetIndexOperationDurationTime(time.Now(), ops.Search, "TestChild2")
 
-	return postgres.RunSearchRequest(ctx, v1.SearchCategory(70), q, b.db)
+	return postgres.RunSearchRequest(ctx, v1.SearchCategory(104), q, b.db)
 }
 
 //// Stubs for satisfying interfaces

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testg2grandchild1/gen.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testg2grandchild1/gen.go
@@ -1,3 +1,3 @@
 package postgres
 
-//go:generate pg-table-bindings-wrapper --type=storage.TestG2GrandChild1 --search-category 66 --references storage.TestGGrandChild1,storage.TestG3GrandChild1
+//go:generate pg-table-bindings-wrapper --type=storage.TestG2GrandChild1 --search-category 105 --references storage.TestGGrandChild1,storage.TestG3GrandChild1

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testg2grandchild1/index.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testg2grandchild1/index.go
@@ -29,13 +29,13 @@ type indexerImpl struct {
 func (b *indexerImpl) Count(ctx context.Context, q *v1.Query, opts ...blevesearch.SearchOption) (int, error) {
 	defer metrics.SetIndexOperationDurationTime(time.Now(), ops.Count, "TestG2GrandChild1")
 
-	return postgres.RunCountRequest(ctx, v1.SearchCategory(66), q, b.db)
+	return postgres.RunCountRequest(ctx, v1.SearchCategory(105), q, b.db)
 }
 
 func (b *indexerImpl) Search(ctx context.Context, q *v1.Query, opts ...blevesearch.SearchOption) ([]search.Result, error) {
 	defer metrics.SetIndexOperationDurationTime(time.Now(), ops.Search, "TestG2GrandChild1")
 
-	return postgres.RunSearchRequest(ctx, v1.SearchCategory(66), q, b.db)
+	return postgres.RunSearchRequest(ctx, v1.SearchCategory(105), q, b.db)
 }
 
 //// Stubs for satisfying interfaces

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testg2grandchild1/index.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testg2grandchild1/index.go
@@ -13,12 +13,7 @@ import (
 	search "github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/blevesearch"
 	"github.com/stackrox/rox/pkg/search/postgres"
-	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
-
-func init() {
-	mapping.RegisterCategoryToTable(v1.SearchCategory(66), schema)
-}
 
 // NewIndexer returns new indexer for `storage.TestG2GrandChild1`.
 func NewIndexer(db *pgxpool.Pool) *indexerImpl {

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/gen.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/gen.go
@@ -1,3 +1,3 @@
 package postgres
 
-//go:generate pg-table-bindings-wrapper --type=storage.TestG3GrandChild1 --search-category 67
+//go:generate pg-table-bindings-wrapper --type=storage.TestG3GrandChild1 --search-category 106

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/index.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/index.go
@@ -29,13 +29,13 @@ type indexerImpl struct {
 func (b *indexerImpl) Count(ctx context.Context, q *v1.Query, opts ...blevesearch.SearchOption) (int, error) {
 	defer metrics.SetIndexOperationDurationTime(time.Now(), ops.Count, "TestG3GrandChild1")
 
-	return postgres.RunCountRequest(ctx, v1.SearchCategory(67), q, b.db)
+	return postgres.RunCountRequest(ctx, v1.SearchCategory(106), q, b.db)
 }
 
 func (b *indexerImpl) Search(ctx context.Context, q *v1.Query, opts ...blevesearch.SearchOption) ([]search.Result, error) {
 	defer metrics.SetIndexOperationDurationTime(time.Now(), ops.Search, "TestG3GrandChild1")
 
-	return postgres.RunSearchRequest(ctx, v1.SearchCategory(67), q, b.db)
+	return postgres.RunSearchRequest(ctx, v1.SearchCategory(106), q, b.db)
 }
 
 //// Stubs for satisfying interfaces

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/index.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/index.go
@@ -13,12 +13,7 @@ import (
 	search "github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/blevesearch"
 	"github.com/stackrox/rox/pkg/search/postgres"
-	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
-
-func init() {
-	mapping.RegisterCategoryToTable(v1.SearchCategory(67), schema)
-}
 
 // NewIndexer returns new indexer for `storage.TestG3GrandChild1`.
 func NewIndexer(db *pgxpool.Pool) *indexerImpl {

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/gen.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/gen.go
@@ -1,3 +1,3 @@
 package postgres
 
-//go:generate pg-table-bindings-wrapper --type=storage.TestGGrandChild1 --search-category 65
+//go:generate pg-table-bindings-wrapper --type=storage.TestGGrandChild1 --search-category 107

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/index.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/index.go
@@ -29,13 +29,13 @@ type indexerImpl struct {
 func (b *indexerImpl) Count(ctx context.Context, q *v1.Query, opts ...blevesearch.SearchOption) (int, error) {
 	defer metrics.SetIndexOperationDurationTime(time.Now(), ops.Count, "TestGGrandChild1")
 
-	return postgres.RunCountRequest(ctx, v1.SearchCategory(65), q, b.db)
+	return postgres.RunCountRequest(ctx, v1.SearchCategory(107), q, b.db)
 }
 
 func (b *indexerImpl) Search(ctx context.Context, q *v1.Query, opts ...blevesearch.SearchOption) ([]search.Result, error) {
 	defer metrics.SetIndexOperationDurationTime(time.Now(), ops.Search, "TestGGrandChild1")
 
-	return postgres.RunSearchRequest(ctx, v1.SearchCategory(65), q, b.db)
+	return postgres.RunSearchRequest(ctx, v1.SearchCategory(107), q, b.db)
 }
 
 //// Stubs for satisfying interfaces

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/index.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/index.go
@@ -13,12 +13,7 @@ import (
 	search "github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/blevesearch"
 	"github.com/stackrox/rox/pkg/search/postgres"
-	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
-
-func init() {
-	mapping.RegisterCategoryToTable(v1.SearchCategory(65), schema)
-}
 
 // NewIndexer returns new indexer for `storage.TestGGrandChild1`.
 func NewIndexer(db *pgxpool.Pool) *indexerImpl {

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandchild1/gen.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandchild1/gen.go
@@ -1,3 +1,3 @@
 package postgres
 
-//go:generate pg-table-bindings-wrapper --type=storage.TestGrandChild1 --search-category 64 --references storage.TestChild1,storage.TestGGrandChild1
+//go:generate pg-table-bindings-wrapper --type=storage.TestGrandChild1 --search-category 108 --references storage.TestChild1,storage.TestGGrandChild1

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandchild1/index.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandchild1/index.go
@@ -29,13 +29,13 @@ type indexerImpl struct {
 func (b *indexerImpl) Count(ctx context.Context, q *v1.Query, opts ...blevesearch.SearchOption) (int, error) {
 	defer metrics.SetIndexOperationDurationTime(time.Now(), ops.Count, "TestGrandChild1")
 
-	return postgres.RunCountRequest(ctx, v1.SearchCategory(64), q, b.db)
+	return postgres.RunCountRequest(ctx, v1.SearchCategory(108), q, b.db)
 }
 
 func (b *indexerImpl) Search(ctx context.Context, q *v1.Query, opts ...blevesearch.SearchOption) ([]search.Result, error) {
 	defer metrics.SetIndexOperationDurationTime(time.Now(), ops.Search, "TestGrandChild1")
 
-	return postgres.RunSearchRequest(ctx, v1.SearchCategory(64), q, b.db)
+	return postgres.RunSearchRequest(ctx, v1.SearchCategory(108), q, b.db)
 }
 
 //// Stubs for satisfying interfaces

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandchild1/index.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandchild1/index.go
@@ -13,12 +13,7 @@ import (
 	search "github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/blevesearch"
 	"github.com/stackrox/rox/pkg/search/postgres"
-	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
-
-func init() {
-	mapping.RegisterCategoryToTable(v1.SearchCategory(64), schema)
-}
 
 // NewIndexer returns new indexer for `storage.TestGrandChild1`.
 func NewIndexer(db *pgxpool.Pool) *indexerImpl {

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/gen.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/gen.go
@@ -1,3 +1,3 @@
 package postgres
 
-//go:generate pg-table-bindings-wrapper --type=storage.TestGrandparent --search-category 61
+//go:generate pg-table-bindings-wrapper --type=storage.TestGrandparent --search-category 109

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/index.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/index.go
@@ -13,12 +13,7 @@ import (
 	search "github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/blevesearch"
 	"github.com/stackrox/rox/pkg/search/postgres"
-	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
-
-func init() {
-	mapping.RegisterCategoryToTable(v1.SearchCategory(61), schema)
-}
 
 // NewIndexer returns new indexer for `storage.TestGrandparent`.
 func NewIndexer(db *pgxpool.Pool) *indexerImpl {

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/index.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/index.go
@@ -29,13 +29,13 @@ type indexerImpl struct {
 func (b *indexerImpl) Count(ctx context.Context, q *v1.Query, opts ...blevesearch.SearchOption) (int, error) {
 	defer metrics.SetIndexOperationDurationTime(time.Now(), ops.Count, "TestGrandparent")
 
-	return postgres.RunCountRequest(ctx, v1.SearchCategory(61), q, b.db)
+	return postgres.RunCountRequest(ctx, v1.SearchCategory(109), q, b.db)
 }
 
 func (b *indexerImpl) Search(ctx context.Context, q *v1.Query, opts ...blevesearch.SearchOption) ([]search.Result, error) {
 	defer metrics.SetIndexOperationDurationTime(time.Now(), ops.Search, "TestGrandparent")
 
-	return postgres.RunSearchRequest(ctx, v1.SearchCategory(61), q, b.db)
+	return postgres.RunSearchRequest(ctx, v1.SearchCategory(109), q, b.db)
 }
 
 //// Stubs for satisfying interfaces

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent1/gen.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent1/gen.go
@@ -1,3 +1,3 @@
 package postgres
 
-//go:generate pg-table-bindings-wrapper --type=storage.TestParent1 --search-category 62 --references storage.TestGrandparent,storage.TestChild1
+//go:generate pg-table-bindings-wrapper --type=storage.TestParent1 --search-category 110 --references storage.TestGrandparent,storage.TestChild1

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent1/index.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent1/index.go
@@ -29,13 +29,13 @@ type indexerImpl struct {
 func (b *indexerImpl) Count(ctx context.Context, q *v1.Query, opts ...blevesearch.SearchOption) (int, error) {
 	defer metrics.SetIndexOperationDurationTime(time.Now(), ops.Count, "TestParent1")
 
-	return postgres.RunCountRequest(ctx, v1.SearchCategory(62), q, b.db)
+	return postgres.RunCountRequest(ctx, v1.SearchCategory(110), q, b.db)
 }
 
 func (b *indexerImpl) Search(ctx context.Context, q *v1.Query, opts ...blevesearch.SearchOption) ([]search.Result, error) {
 	defer metrics.SetIndexOperationDurationTime(time.Now(), ops.Search, "TestParent1")
 
-	return postgres.RunSearchRequest(ctx, v1.SearchCategory(62), q, b.db)
+	return postgres.RunSearchRequest(ctx, v1.SearchCategory(110), q, b.db)
 }
 
 //// Stubs for satisfying interfaces

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent1/index.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent1/index.go
@@ -13,12 +13,7 @@ import (
 	search "github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/blevesearch"
 	"github.com/stackrox/rox/pkg/search/postgres"
-	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
-
-func init() {
-	mapping.RegisterCategoryToTable(v1.SearchCategory(62), schema)
-}
 
 // NewIndexer returns new indexer for `storage.TestParent1`.
 func NewIndexer(db *pgxpool.Pool) *indexerImpl {

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent2/gen.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent2/gen.go
@@ -1,3 +1,3 @@
 package postgres
 
-//go:generate pg-table-bindings-wrapper --type=storage.TestParent2 --search-category 68 --references storage.TestGrandparent
+//go:generate pg-table-bindings-wrapper --type=storage.TestParent2 --search-category 111 --references storage.TestGrandparent

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent2/index.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent2/index.go
@@ -13,12 +13,7 @@ import (
 	search "github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/blevesearch"
 	"github.com/stackrox/rox/pkg/search/postgres"
-	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
-
-func init() {
-	mapping.RegisterCategoryToTable(v1.SearchCategory(68), schema)
-}
 
 // NewIndexer returns new indexer for `storage.TestParent2`.
 func NewIndexer(db *pgxpool.Pool) *indexerImpl {

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent2/index.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent2/index.go
@@ -29,13 +29,13 @@ type indexerImpl struct {
 func (b *indexerImpl) Count(ctx context.Context, q *v1.Query, opts ...blevesearch.SearchOption) (int, error) {
 	defer metrics.SetIndexOperationDurationTime(time.Now(), ops.Count, "TestParent2")
 
-	return postgres.RunCountRequest(ctx, v1.SearchCategory(68), q, b.db)
+	return postgres.RunCountRequest(ctx, v1.SearchCategory(111), q, b.db)
 }
 
 func (b *indexerImpl) Search(ctx context.Context, q *v1.Query, opts ...blevesearch.SearchOption) ([]search.Result, error) {
 	defer metrics.SetIndexOperationDurationTime(time.Now(), ops.Search, "TestParent2")
 
-	return postgres.RunSearchRequest(ctx, v1.SearchCategory(68), q, b.db)
+	return postgres.RunSearchRequest(ctx, v1.SearchCategory(111), q, b.db)
 }
 
 //// Stubs for satisfying interfaces

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent3/gen.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent3/gen.go
@@ -1,3 +1,3 @@
 package postgres
 
-//go:generate pg-table-bindings-wrapper --type=storage.TestParent3 --search-category 69 --references storage.TestGrandparent
+//go:generate pg-table-bindings-wrapper --type=storage.TestParent3 --search-category 112 --references storage.TestGrandparent

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent3/index.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent3/index.go
@@ -13,12 +13,7 @@ import (
 	search "github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/blevesearch"
 	"github.com/stackrox/rox/pkg/search/postgres"
-	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
-
-func init() {
-	mapping.RegisterCategoryToTable(v1.SearchCategory(69), schema)
-}
 
 // NewIndexer returns new indexer for `storage.TestParent3`.
 func NewIndexer(db *pgxpool.Pool) *indexerImpl {

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent3/index.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent3/index.go
@@ -29,13 +29,13 @@ type indexerImpl struct {
 func (b *indexerImpl) Count(ctx context.Context, q *v1.Query, opts ...blevesearch.SearchOption) (int, error) {
 	defer metrics.SetIndexOperationDurationTime(time.Now(), ops.Count, "TestParent3")
 
-	return postgres.RunCountRequest(ctx, v1.SearchCategory(69), q, b.db)
+	return postgres.RunCountRequest(ctx, v1.SearchCategory(112), q, b.db)
 }
 
 func (b *indexerImpl) Search(ctx context.Context, q *v1.Query, opts ...blevesearch.SearchOption) ([]search.Result, error) {
 	defer metrics.SetIndexOperationDurationTime(time.Now(), ops.Search, "TestParent3")
 
-	return postgres.RunSearchRequest(ctx, v1.SearchCategory(69), q, b.db)
+	return postgres.RunSearchRequest(ctx, v1.SearchCategory(112), q, b.db)
 }
 
 //// Stubs for satisfying interfaces

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent4/gen.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent4/gen.go
@@ -1,3 +1,3 @@
 package postgres
 
-//go:generate pg-table-bindings-wrapper --type=storage.TestParent4 --search-category 113 --references storage.TestGrandparent --search-scope 61,74
+//go:generate pg-table-bindings-wrapper --type=storage.TestParent4 --search-category 113 --references storage.TestGrandparent --search-scope 109,103

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent4/gen.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent4/gen.go
@@ -1,3 +1,3 @@
 package postgres
 
-//go:generate pg-table-bindings-wrapper --type=storage.TestParent4 --search-category 72 --references storage.TestGrandparent --search-scope 61,74
+//go:generate pg-table-bindings-wrapper --type=storage.TestParent4 --search-category 113 --references storage.TestGrandparent --search-scope 61,74

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent4/index.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent4/index.go
@@ -29,13 +29,13 @@ type indexerImpl struct {
 func (b *indexerImpl) Count(ctx context.Context, q *v1.Query, opts ...blevesearch.SearchOption) (int, error) {
 	defer metrics.SetIndexOperationDurationTime(time.Now(), ops.Count, "TestParent4")
 
-	return postgres.RunCountRequest(ctx, v1.SearchCategory(72), q, b.db)
+	return postgres.RunCountRequest(ctx, v1.SearchCategory(113), q, b.db)
 }
 
 func (b *indexerImpl) Search(ctx context.Context, q *v1.Query, opts ...blevesearch.SearchOption) ([]search.Result, error) {
 	defer metrics.SetIndexOperationDurationTime(time.Now(), ops.Search, "TestParent4")
 
-	return postgres.RunSearchRequest(ctx, v1.SearchCategory(72), q, b.db)
+	return postgres.RunSearchRequest(ctx, v1.SearchCategory(113), q, b.db)
 }
 
 //// Stubs for satisfying interfaces

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent4/index.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent4/index.go
@@ -13,12 +13,7 @@ import (
 	search "github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/blevesearch"
 	"github.com/stackrox/rox/pkg/search/postgres"
-	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
-
-func init() {
-	mapping.RegisterCategoryToTable(v1.SearchCategory(72), schema)
-}
 
 // NewIndexer returns new indexer for `storage.TestParent4`.
 func NewIndexer(db *pgxpool.Pool) *indexerImpl {

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testshortcircuit/gen.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testshortcircuit/gen.go
@@ -1,3 +1,3 @@
 package postgres
 
-//go:generate pg-table-bindings-wrapper --type=storage.TestShortCircuit --search-category 71 --references storage.TestChild1,storage.TestG2GrandChild1
+//go:generate pg-table-bindings-wrapper --type=storage.TestShortCircuit --search-category 114 --references storage.TestChild1,storage.TestG2GrandChild1

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testshortcircuit/index.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testshortcircuit/index.go
@@ -13,12 +13,7 @@ import (
 	search "github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/blevesearch"
 	"github.com/stackrox/rox/pkg/search/postgres"
-	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
-
-func init() {
-	mapping.RegisterCategoryToTable(v1.SearchCategory(71), schema)
-}
 
 // NewIndexer returns new indexer for `storage.TestShortCircuit`.
 func NewIndexer(db *pgxpool.Pool) *indexerImpl {

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testshortcircuit/index.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testshortcircuit/index.go
@@ -29,13 +29,13 @@ type indexerImpl struct {
 func (b *indexerImpl) Count(ctx context.Context, q *v1.Query, opts ...blevesearch.SearchOption) (int, error) {
 	defer metrics.SetIndexOperationDurationTime(time.Now(), ops.Count, "TestShortCircuit")
 
-	return postgres.RunCountRequest(ctx, v1.SearchCategory(71), q, b.db)
+	return postgres.RunCountRequest(ctx, v1.SearchCategory(114), q, b.db)
 }
 
 func (b *indexerImpl) Search(ctx context.Context, q *v1.Query, opts ...blevesearch.SearchOption) ([]search.Result, error) {
 	defer metrics.SetIndexOperationDurationTime(time.Now(), ops.Search, "TestShortCircuit")
 
-	return postgres.RunSearchRequest(ctx, v1.SearchCategory(71), q, b.db)
+	return postgres.RunSearchRequest(ctx, v1.SearchCategory(114), q, b.db)
 }
 
 //// Stubs for satisfying interfaces

--- a/tools/generate-helpers/pg-table-bindings/testuuidkey/postgres/gen.go
+++ b/tools/generate-helpers/pg-table-bindings/testuuidkey/postgres/gen.go
@@ -1,3 +1,3 @@
 package postgres
 
-//go:generate pg-table-bindings-wrapper --type=storage.TestSingleUUIDKeyStruct --search-category SEARCH_UNSET --get-all-func
+//go:generate pg-table-bindings-wrapper --type=storage.TestSingleUUIDKeyStruct --search-category 115 --get-all-func

--- a/tools/generate-helpers/pg-table-bindings/testuuidkey/postgres/index.go
+++ b/tools/generate-helpers/pg-table-bindings/testuuidkey/postgres/index.go
@@ -13,12 +13,7 @@ import (
 	search "github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/blevesearch"
 	"github.com/stackrox/rox/pkg/search/postgres"
-	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
-
-func init() {
-	mapping.RegisterCategoryToTable(v1.SearchCategory_SEARCH_UNSET, schema)
-}
 
 // NewIndexer returns new indexer for `storage.TestSingleUUIDKeyStruct`.
 func NewIndexer(db *pgxpool.Pool) *indexerImpl {

--- a/tools/generate-helpers/pg-table-bindings/testuuidkey/postgres/index.go
+++ b/tools/generate-helpers/pg-table-bindings/testuuidkey/postgres/index.go
@@ -29,13 +29,13 @@ type indexerImpl struct {
 func (b *indexerImpl) Count(ctx context.Context, q *v1.Query, opts ...blevesearch.SearchOption) (int, error) {
 	defer metrics.SetIndexOperationDurationTime(time.Now(), ops.Count, "TestSingleUUIDKeyStruct")
 
-	return postgres.RunCountRequest(ctx, v1.SearchCategory_SEARCH_UNSET, q, b.db)
+	return postgres.RunCountRequest(ctx, v1.SearchCategory(115), q, b.db)
 }
 
 func (b *indexerImpl) Search(ctx context.Context, q *v1.Query, opts ...blevesearch.SearchOption) ([]search.Result, error) {
 	defer metrics.SetIndexOperationDurationTime(time.Now(), ops.Search, "TestSingleUUIDKeyStruct")
 
-	return postgres.RunSearchRequest(ctx, v1.SearchCategory_SEARCH_UNSET, q, b.db)
+	return postgres.RunSearchRequest(ctx, v1.SearchCategory(115), q, b.db)
 }
 
 //// Stubs for satisfying interfaces


### PR DESCRIPTION
## Description

Moved the schema registration to search category to the location where schema is init. 
Uncovered an incorrect test setup so fixed that as well.

With this change indexer is truly just an indirection layer which will removed in future releases.

## Checklist
- [ ] Investigated and inspected CI test results
- ~Unit test and regression tests added~
- ~Evaluated and added CHANGELOG entry if required~
- ~Determined and documented upgrade steps~
- ~Documented user facing changes ~
If any of these don't apply, please comment below.

## Testing Performed
CI+Manually tested product UI