### PR TITLE
ROX-13705: Use real data for CIDR block side panel

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraph.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraph.tsx
@@ -13,7 +13,6 @@ import {
     Visualization,
     VisualizationSurface,
     VisualizationProvider,
-    EdgeModel,
 } from '@patternfly/react-topology';
 
 import { networkBasePathPF } from 'routePaths';
@@ -29,7 +28,7 @@ import ExternalGroupSideBar from './external/ExternalGroupSideBar';
 import NetworkPolicySimulatorSidePanel from './simulation/NetworkPolicySimulatorSidePanel';
 import { EdgeState } from './EdgeStateSelect';
 import { getNodeById } from './utils/networkGraphUtils';
-import { CustomModel, CustomNodeModel } from './types/topology.type';
+import { CustomEdgeModel, CustomModel, CustomNodeModel } from './types/topology.type';
 import { createExtraneousEdges } from './utils/modelUtils';
 import { Simulation } from './utils/getSimulation';
 import LegendContent from './components/LegendContent';
@@ -154,7 +153,7 @@ const TopologyComponent = ({
     }
 
     function setExtraneousEdges() {
-        const currentModel = controller.toModel();
+        const currentModel = controller.toModel() as CustomModel;
         const extraneousIngressNode = controller.getElementById('extraneous-ingress');
         const extraneousEgressNode = controller.getElementById('extraneous-egress');
         const { extraneousEgressEdge, extraneousIngressEdge } = createExtraneousEdges(detailId);
@@ -166,7 +165,7 @@ const TopologyComponent = ({
         // TODO: figure out if/how to support namespaces
         if (data?.type === 'DEPLOYMENT') {
             const { networkPolicyState } = data || {};
-            const edges: EdgeModel[] = currentModel.edges || [];
+            const edges: CustomEdgeModel[] = currentModel.edges || [];
             if (networkPolicyState === 'ingress' && extraneousEgressNode) {
                 edges.push(extraneousEgressEdge);
             } else if (networkPolicyState === 'egress' && extraneousIngressNode) {

--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
@@ -11,7 +11,6 @@ import {
     ToolbarGroup,
     ToolbarItem,
 } from '@patternfly/react-core';
-import { EdgeModel } from '@patternfly/react-topology';
 import useDeepCompareEffect from 'use-deep-compare-effect';
 
 import useFetchClusters from 'hooks/useFetchClusters';
@@ -36,12 +35,19 @@ import {
 } from './utils/modelUtils';
 import getScopeHierarchy from './utils/getScopeHierarchy';
 import getSimulation from './utils/getSimulation';
-import { CustomModel, CustomNodeModel, DeploymentNodeModel } from './types/topology.type';
+import {
+    CustomEdgeModel,
+    CustomModel,
+    CustomNodeModel,
+    DeploymentNodeModel,
+} from './types/topology.type';
 
 import './NetworkGraphPage.css';
 
 const emptyModel = {
     graph: graphModel,
+    nodes: [],
+    edges: [],
 };
 
 // TODO: get real time window from user input
@@ -107,7 +113,7 @@ function NetworkGraphPage() {
                 ])
                     .then((values) => {
                         const activeNodeMap: Record<string, CustomNodeModel> = {};
-                        const activeEdgeMap: Record<string, EdgeModel> = {};
+                        const activeEdgeMap: Record<string, CustomEdgeModel> = {};
                         const policyNodeMap: Record<string, DeploymentNodeModel> = {};
 
                         // get policy nodes from api response

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentSideBar.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentSideBar.tsx
@@ -16,7 +16,6 @@ import {
     TextContent,
     TextVariants,
 } from '@patternfly/react-core';
-import { EdgeModel } from '@patternfly/react-topology';
 
 import useTabs from 'hooks/patternfly/useTabs';
 import useFetchDeployment from 'hooks/useFetchDeployment';
@@ -26,7 +25,7 @@ import {
     getNumExternalFlows,
     getNumInternalFlows,
 } from '../utils/networkGraphUtils';
-import { CustomNodeModel } from '../types/topology.type';
+import { CustomEdgeModel, CustomNodeModel } from '../types/topology.type';
 
 import { DeploymentIcon } from '../common/NetworkGraphIcons';
 import DeploymentDetails from './DeploymentDetails';
@@ -37,7 +36,7 @@ import NetworkPolicies from '../common/NetworkPolicies';
 type DeploymentSideBarProps = {
     deploymentId: string;
     nodes: CustomNodeModel[];
-    edges: EdgeModel[];
+    edges: CustomEdgeModel[];
 };
 
 function DeploymentSideBar({ deploymentId, nodes, edges }: DeploymentSideBarProps) {

--- a/ui/apps/platform/src/Containers/NetworkGraph/external/ExternalGroupSideBar.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/external/ExternalGroupSideBar.tsx
@@ -12,12 +12,12 @@ import {
     ToolbarContent,
     ToolbarItem,
 } from '@patternfly/react-core';
-import { EdgeModel } from '@patternfly/react-topology';
 
 import { TableComposable, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { getEdgesByNodeId, getNodeById } from '../utils/networkGraphUtils';
 import {
     CIDRBlockNodeModel,
+    CustomEdgeModel,
     CustomNodeModel,
     ExternalEntitiesNodeModel,
     ExternalGroupNodeModel,
@@ -29,7 +29,7 @@ import EntityNameSearchInput from '../common/EntityNameSearchInput';
 type ExternalGroupSideBarProps = {
     id: string;
     nodes: CustomNodeModel[];
-    edges: EdgeModel[];
+    edges: CustomEdgeModel[];
 };
 
 const columnNames = {

--- a/ui/apps/platform/src/Containers/NetworkGraph/externalEntities/ExternalEntitiesSideBar.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/externalEntities/ExternalEntitiesSideBar.tsx
@@ -12,13 +12,12 @@ import {
     ToolbarContent,
     ToolbarItem,
 } from '@patternfly/react-core';
-import { EdgeModel } from '@patternfly/react-topology';
 
 import { getNodeById } from '../utils/networkGraphUtils';
 import { getAllUniquePorts, getNumFlows } from '../utils/flowUtils';
 import { AdvancedFlowsFilterType } from '../common/AdvancedFlowsFilter/types';
 import { Flow } from '../types/flow.type';
-import { CustomNodeModel } from '../types/topology.type';
+import { CustomEdgeModel, CustomNodeModel } from '../types/topology.type';
 
 import { ExternalEntitiesIcon } from '../common/NetworkGraphIcons';
 import AdvancedFlowsFilter, {
@@ -31,7 +30,7 @@ import FlowsTableHeaderText from '../common/FlowsTableHeaderText';
 type ExternalEntitiesSideBarProps = {
     id: string;
     nodes: CustomNodeModel[];
-    edges: EdgeModel[];
+    edges: CustomEdgeModel[];
 };
 
 const flows: Flow[] = [

--- a/ui/apps/platform/src/Containers/NetworkGraph/namespace/NamespaceSideBar.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/namespace/NamespaceSideBar.tsx
@@ -10,11 +10,10 @@ import {
     TextContent,
     TextVariants,
 } from '@patternfly/react-core';
-import { EdgeModel } from '@patternfly/react-topology';
 
 import useTabs from 'hooks/patternfly/useTabs';
 import { getDeploymentNodesInNamespace, getNumDeploymentFlows } from '../utils/networkGraphUtils';
-import { CustomNodeModel } from '../types/topology.type';
+import { CustomEdgeModel, CustomNodeModel } from '../types/topology.type';
 
 import { NamespaceIcon } from '../common/NetworkGraphIcons';
 import NamespaceDeployments from './NamespaceDeployments';
@@ -23,7 +22,7 @@ import NetworkPolicies from '../common/NetworkPolicies';
 type NamespaceSideBarProps = {
     namespaceId: string;
     nodes: CustomNodeModel[];
-    edges: EdgeModel[];
+    edges: CustomEdgeModel[];
 };
 
 function NamespaceSideBar({ namespaceId, nodes, edges }: NamespaceSideBarProps) {

--- a/ui/apps/platform/src/Containers/NetworkGraph/types/topology.type.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/types/topology.type.ts
@@ -1,9 +1,11 @@
-import { Model, NodeModel } from '@patternfly/react-topology';
+import { EdgeModel, Model, NodeModel } from '@patternfly/react-topology';
 
-import { ListenPort, Edge } from 'types/networkFlow.proto';
+import { EdgeProperties, ListenPort, OutEdges } from 'types/networkFlow.proto';
 import { Override } from 'utils/type.utils';
 
-export type CustomModel = Override<Model, { nodes?: CustomNodeModel[] }>;
+export type CustomModel = Override<Model, { nodes: CustomNodeModel[]; edges: CustomEdgeModel[] }>;
+
+// Node types
 
 export type CustomNodeModel =
     | NamespaceNodeModel
@@ -72,7 +74,7 @@ export type ExternalGroupData = {
 export type ExternalEntitiesData = {
     type: 'EXTERNAL_ENTITIES';
     id: string;
-    outEdges: Edge[];
+    outEdges: OutEdges;
 };
 
 export type CIDRBlockData = {
@@ -83,7 +85,7 @@ export type CIDRBlockData = {
         default: boolean;
         name: string;
     };
-    outEdges: Edge[];
+    outEdges: OutEdges;
 };
 
 export type ExtraneousData = {
@@ -91,4 +93,12 @@ export type ExtraneousData = {
     collapsible: boolean;
     showContextMenu: boolean;
     numFlows: number;
+};
+
+// Edge types
+
+export type CustomEdgeModel = Override<EdgeModel, { data: EdgeData }>;
+
+export type EdgeData = {
+    properties: EdgeProperties[];
 };

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/flowUtils.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/flowUtils.ts
@@ -1,5 +1,18 @@
+import { Controller } from '@patternfly/react-topology';
 import { uniq } from 'lodash';
+import { AdvancedFlowsFilterType } from '../common/AdvancedFlowsFilter/types';
 import { Flow } from '../types/flow.type';
+import { CustomEdgeModel, CustomNodeData } from '../types/topology.type';
+
+const protocolLabel = {
+    L4_PROTOCOL_UNKNOWN: 'UNKNOWN',
+    L4_PROTOCOL_TCP: 'TCP',
+    L4_PROTOCOL_UDP: 'UDP',
+    L4_PROTOCOL_ICMP: 'ICMP',
+    L4_PROTOCOL_RAW: 'RAW',
+    L4_PROTOCOL_SCTP: 'SCTP',
+    L4_PROTOCOL_ANY: 'ANY',
+};
 
 export function getAllUniquePorts(flows: Flow[]): string[] {
     const allPorts = flows.reduce((acc, curr) => {
@@ -18,4 +31,121 @@ export function getNumFlows(flows: Flow[]): number {
         return acc + (curr.children && curr.children.length ? curr.children.length : 1);
     }, 0);
     return numFlows;
+}
+
+/*
+  This function takes edges and a selected id of a node and creates an array of flows
+  which is a structured data type used for showing specific information in the network graph
+  side panels
+*/
+export function getNetworkFlows(
+    edges: CustomEdgeModel[],
+    controller: Controller,
+    id: string
+): Flow[] {
+    const networkFlows: Flow[] = edges.reduce((acc, edge) => {
+        // filter out edges not connected to node with selected id
+        if ((edge.source !== id && edge.target !== id) || !edge.source || !edge.target) {
+            return acc;
+        }
+        const adjacentNodeId = edge.source !== id ? edge.source : edge.target;
+        const adjacentNode = controller.getNodeById(adjacentNodeId);
+        const adjacentNodeData: CustomNodeData = adjacentNode?.getData();
+        const result = edge.data.properties.map(({ port, protocol }): Flow => {
+            const direction: string = edge.source === id ? 'Egress' : 'Ingress';
+            const type = adjacentNodeData.type === 'DEPLOYMENT' ? 'Deployment' : 'External';
+            let entity = '';
+            let namespace = '';
+            if (adjacentNodeData.type === 'DEPLOYMENT') {
+                entity = adjacentNodeData.deployment.name;
+                namespace = adjacentNodeData.deployment.namespace;
+            } else if (adjacentNodeData.type === 'CIDR_BLOCK') {
+                entity = `${adjacentNodeData.externalSource.name}`;
+            } else if (adjacentNodeData.type === 'EXTERNAL_ENTITIES') {
+                entity = 'External entities';
+            }
+            // we need a unique id for each network flow
+            const flowId = `${entity}-${namespace}-${direction}-${port}-${protocol}`;
+            return {
+                id: flowId,
+                type,
+                entity,
+                namespace,
+                direction,
+                port: String(port),
+                protocol: protocolLabel[protocol],
+                // @TODO: Need to set this depending on whether it is in the baseline or not
+                isAnomalous: true,
+                // @TODO: Need to create nesting structure
+                children: [],
+            };
+        });
+        return [...acc, ...result] as Flow[];
+    }, [] as Flow[]);
+    return networkFlows;
+}
+
+/*
+  This function takes network flows and filters the data based on a text search value 
+  for entity name and some advanced filters specific to network flows. These include:
+  flow types, directionality, protocols, and ports
+*/
+export function filterNetworkFlows(
+    flows: Flow[],
+    entityNameFilter: string,
+    advancedFilters: AdvancedFlowsFilterType
+): Flow[] {
+    const filteredFlows = flows.filter((flow) => {
+        let matchedEntityName = false;
+        let matchedFlowType = true;
+        let matchedDirectionality = true;
+        const matchedProtocol = true;
+        let matchedPort = true;
+
+        // check filtering by entity name
+        if (flow.entity.includes(entityNameFilter)) {
+            matchedEntityName = true;
+        }
+
+        // check filtering by flow type
+        if (advancedFilters.flows.length) {
+            const isAnomalousFiltered =
+                advancedFilters.flows.includes('anomalous') && flow.isAnomalous;
+            const isBaselineFiltered =
+                advancedFilters.flows.includes('baseline') && !flow.isAnomalous;
+            matchedFlowType = isAnomalousFiltered || isBaselineFiltered;
+        }
+
+        // check filtering by directionality
+        if (advancedFilters.directionality.length) {
+            const isIngressFiltered =
+                advancedFilters.directionality.includes('ingress') && flow.direction === 'Ingress';
+            const isEgressFiltered =
+                advancedFilters.directionality.includes('egress') && flow.direction === 'Egress';
+            matchedDirectionality = isIngressFiltered || isEgressFiltered;
+        }
+
+        // check filtering by protocols
+        if (advancedFilters.protocols.length) {
+            const isTCPFiltered =
+                advancedFilters.protocols.includes('TCP') && flow.protocol === 'TCP';
+            const isUDPFiltered =
+                advancedFilters.protocols.includes('UDP') && flow.protocol === 'UDP';
+            matchedDirectionality = isTCPFiltered || isUDPFiltered;
+        }
+
+        // check filtering by ports
+        if (advancedFilters.ports.length && !advancedFilters.ports.includes(flow.port)) {
+            matchedPort = false;
+        }
+
+        return (
+            matchedEntityName &&
+            matchedFlowType &&
+            matchedDirectionality &&
+            matchedProtocol &&
+            matchedPort
+        );
+    });
+    return filteredFlows;
 }

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/networkGraphUtils.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/networkGraphUtils.ts
@@ -1,7 +1,5 @@
-import { EdgeModel } from '@patternfly/react-topology';
-
 import { ListenPort } from 'types/networkFlow.proto';
-import { CustomNodeModel, DeploymentNodeModel } from '../types/topology.type';
+import { CustomEdgeModel, CustomNodeModel, DeploymentNodeModel } from '../types/topology.type';
 
 /* node helper functions */
 
@@ -41,7 +39,7 @@ export function getNodeById(
 
 export function getNumInternalFlows(
     nodes: CustomNodeModel[],
-    edges: EdgeModel[],
+    edges: CustomEdgeModel[],
     deploymentId: string
 ): number {
     const externalNodeIds = getExternalNodeIds(nodes);
@@ -60,7 +58,7 @@ export function getNumInternalFlows(
 
 export function getNumExternalFlows(
     nodes: CustomNodeModel[],
-    edges: EdgeModel[],
+    edges: CustomEdgeModel[],
     deploymentId: string
 ): number {
     const externalNodeIds = getExternalNodeIds(nodes);
@@ -77,13 +75,13 @@ export function getNumExternalFlows(
     return numExternalFlows;
 }
 
-export function getEdgesByNodeId(edges: EdgeModel[], id: string): EdgeModel[] {
+export function getEdgesByNodeId(edges: CustomEdgeModel[], id: string): CustomEdgeModel[] {
     return edges.filter((edge) => {
         return edge.source === id || edge.target === id;
     });
 }
 
-export function getNumDeploymentFlows(edges: EdgeModel[], deploymentId: string): number {
+export function getNumDeploymentFlows(edges: CustomEdgeModel[], deploymentId: string): number {
     const numFlows =
         edges?.reduce((acc, edge) => {
             if (edge.source === deploymentId || edge.target === deploymentId) {

--- a/ui/apps/platform/src/types/networkFlow.proto.ts
+++ b/ui/apps/platform/src/types/networkFlow.proto.ts
@@ -100,16 +100,17 @@ export type Node = {
     nonIsolatedIngress: boolean;
     nonIsolatedEgress: boolean;
     queryMatch: boolean;
-    outEdges: Edge[];
+    outEdges: OutEdges;
 };
 
-export type Edge = {
-    [key: string]: {
+export type OutEdges = Record<
+    string,
+    {
         properties: EdgeProperties[];
-    };
-};
+    }
+>;
 
-type EdgeProperties = {
+export type EdgeProperties = {
     port: number;
     protocol: L4Protocol;
     lastActiveTimestamp: string | null;


### PR DESCRIPTION
## Description

This is an iterative approach for using real data in the CIDR Block side panel. Things I still need to do in the future:
- [x] Create network flows using the edges
- [x] Fix typing for out edges
- [x] Change usage of EdgeModel to a new CustomEdgeModel
- [x] Hook up filtering for network flows 
- [ ] Create nested network flows (expandable)
- [ ] Create tests for util functions (is a bit of work since we use a controller in the function)

https://user-images.githubusercontent.com/4805485/211851602-8bcf5e75-8da8-4274-8ccb-fdde11d019c5.mov

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~
