### PR TITLE
ROX-14507: Fix validation check getting skipped on missing daysOfWeek in reportConfig

### DIFF
--- a/central/reportconfigurations/service/service_impl.go
+++ b/central/reportconfigurations/service/service_impl.go
@@ -172,7 +172,7 @@ func (s *serviceImpl) validateReportConfiguration(ctx context.Context, config *s
 	case storage.Schedule_DAILY:
 		return errors.Wrap(errox.InvalidArgs, "Report configuration must have a valid schedule type")
 	case storage.Schedule_WEEKLY:
-		if schedule.GetDaysOfWeek() == nil {
+		if schedule.GetDaysOfWeek() == nil || len(schedule.GetDaysOfWeek().GetDays()) == 0 {
 			return errors.Wrap(errox.InvalidArgs, "Report configuration must specify days of week for the schedule")
 		}
 		for _, day := range schedule.GetDaysOfWeek().GetDays() {
@@ -181,7 +181,7 @@ func (s *serviceImpl) validateReportConfiguration(ctx context.Context, config *s
 			}
 		}
 	case storage.Schedule_MONTHLY:
-		if schedule.GetDaysOfMonth() == nil || schedule.GetDaysOfMonth().GetDays() == nil {
+		if schedule.GetDaysOfMonth() == nil || len(schedule.GetDaysOfMonth().GetDays()) == 0 {
 			return errors.Wrap(errox.InvalidArgs, "Report configuration must specify days of the month for the schedule")
 		}
 		for _, day := range schedule.GetDaysOfMonth().GetDays() {

--- a/central/reportconfigurations/service/service_impl_test.go
+++ b/central/reportconfigurations/service/service_impl_test.go
@@ -87,6 +87,18 @@ func (s *TestReportConfigurationServiceTestSuite) TestAddInvalidValidReportConfi
 	})
 	s.Error(err)
 
+	missingDaysOfWeekReportConfig := fixtures.GetInvalidReportConfigurationMissingDaysOfWeek()
+	_, err = s.service.PostReportConfiguration(ctx, &v1.PostReportConfigurationRequest{
+		ReportConfig: missingDaysOfWeekReportConfig,
+	})
+	s.Error(err)
+
+	missingDaysOfMonthReportConfig := fixtures.GetInvalidReportConfigurationMissingDaysOfMonth()
+	_, err = s.service.PostReportConfiguration(ctx, &v1.PostReportConfigurationRequest{
+		ReportConfig: missingDaysOfMonthReportConfig,
+	})
+	s.Error(err)
+
 	incorrectEmailReportConfig := fixtures.GetInvalidReportConfigurationIncorrectEmail()
 	_, err = s.service.PostReportConfiguration(ctx, &v1.PostReportConfigurationRequest{
 		ReportConfig: incorrectEmailReportConfig,

--- a/pkg/fixtures/report_configuration.go
+++ b/pkg/fixtures/report_configuration.go
@@ -66,6 +66,36 @@ func GetInvalidReportConfigurationMissingSchedule() *storage.ReportConfiguration
 	return rc
 }
 
+// GetInvalidReportConfigurationMissingDaysOfWeek returns a mock report configuration with an invalid schedule that is
+// missing days of week
+func GetInvalidReportConfigurationMissingDaysOfWeek() *storage.ReportConfiguration {
+	rc := GetValidReportConfiguration()
+	rc.Schedule = &storage.Schedule{
+		IntervalType: storage.Schedule_WEEKLY,
+		Interval: &storage.Schedule_DaysOfWeek_{
+			DaysOfWeek: &storage.Schedule_DaysOfWeek{
+				Days: []int32{},
+			},
+		},
+	}
+	return rc
+}
+
+// GetInvalidReportConfigurationMissingDaysOfMonth returns a mock report configuration with an invalid schedule that is
+// missing days of month
+func GetInvalidReportConfigurationMissingDaysOfMonth() *storage.ReportConfiguration {
+	rc := GetValidReportConfiguration()
+	rc.Schedule = &storage.Schedule{
+		IntervalType: storage.Schedule_MONTHLY,
+		Interval: &storage.Schedule_DaysOfMonth_{
+			DaysOfMonth: &storage.Schedule_DaysOfMonth{
+				Days: nil,
+			},
+		},
+	}
+	return rc
+}
+
 // GetInvalidReportConfigurationIncorrectEmail returns a mock report configuration with incorrect email
 func GetInvalidReportConfigurationIncorrectEmail() *storage.ReportConfiguration {
 	rc := GetValidReportConfiguration()


### PR DESCRIPTION
## Description

The validation check for daysOfWeek in reportConfig schedule was getting skipped when the days was non-nil empty array. This PR fixes the validation by adding an extra check on the length of days slice.

## Checklist
- [ ] Investigated and inspected CI test results
- [X] Unit test and regression tests added
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

Added unit tests

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
