### PR TITLE
CI: Fix image integration test

### DIFF
--- a/qa-tests-backend/src/main/groovy/objects/ImageIntegration.groovy
+++ b/qa-tests-backend/src/main/groovy/objects/ImageIntegration.groovy
@@ -196,7 +196,7 @@ class QuayImageIntegration implements ImageIntegration {
                 endpoint: "quay.io",
                 includeScanner: true,
                 insecure: false,
-                oauthToken: Env.mustGet("QUAY_BEARER_TOKEN"),
+                oauthToken: Env.mustGet("QUAY_RHACS_ENG_BEARER_TOKEN"),
         ]
         Map args = defaultArgs + customArgs
 


### PR DESCRIPTION
## Description

Fix for: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/branch-ci-stackrox-stackrox-master-merge-gke-qa-e2e-tests/1612962970139103232
Switch the default token to a known valid one.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

`all-qa-tests` to run the IntegrationsTest