### PR TITLE
Groovy test changes to add multi-arch support

### DIFF
--- a/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
@@ -1039,6 +1039,7 @@ class Kubernetes implements OrchestratorMain {
         )
 
         def sec = client.secrets().inNamespace(secret.namespace).createOrReplace(k8sSecret)
+        log.debug secret.name + ": Secret created."
         return sec.metadata.uid
     }
 
@@ -1709,6 +1710,7 @@ class Kubernetes implements OrchestratorMain {
         )
 
         def config = client.configMaps().inNamespace(namespace).createOrReplace(configMap)
+        log.debug name + ": ConfigMap created."
         return config.metadata.uid
     }
 

--- a/qa-tests-backend/src/main/groovy/util/MailServer.groovy
+++ b/qa-tests-backend/src/main/groovy/util/MailServer.groovy
@@ -50,7 +50,7 @@ class MailServer {
                             .setName(deploymentName)
                             // The original is at docker.io/maildev/maildev:2.0.5
                             // and https://github.com/maildev/maildev
-                            .setImage("quay.io/rhacs-eng/qa:docker-io-maildev-maildev-2-0-5")
+                            .setImage("quay.io/rhacs-eng/qa-multi-arch:docker-io-maildev-maildev-2-0-5")
                             .addPort(WEB_PORT)
                             .addPort(SMTP_PORT)
                             .setEnv(envVars)

--- a/qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy
+++ b/qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy
@@ -62,7 +62,7 @@ class AdmissionControllerTest extends BaseSpecification {
 
     static final private Deployment MISC_DEPLOYMENT = new Deployment()
         .setName("random-busybox")
-        .setImage("quay.io/rhacs-eng/qa:busybox-1-30")
+        .setImage("quay.io/rhacs-eng/qa-multi-arch:busybox-1-30")
         .addLabel("app", "random-busybox")
 
     def setupSpec() {
@@ -293,7 +293,7 @@ class AdmissionControllerTest extends BaseSpecification {
         and:
         "Create the deployment with a harmless image"
         def modDeployment = deployment.clone()
-        modDeployment.image = "quay.io/rhacs-eng/qa:busybox-1-28"
+        modDeployment.image = "quay.io/rhacs-eng/qa-multi-arch:busybox-1-28"
         def created = orchestrator.createDeploymentNoWait(modDeployment)
         assert created
 

--- a/qa-tests-backend/src/test/groovy/AttemptedAlertsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/AttemptedAlertsTest.groovy
@@ -26,8 +26,8 @@ class AttemptedAlertsTest extends BaseSpecification {
             (DEP_NAMES[1]): createDeployment(DEP_NAMES[1], "nginx:latest"),
             (DEP_NAMES[2]): createDeployment(DEP_NAMES[2], "nginx:latest"),
             (DEP_NAMES[3]): createDeployment(DEP_NAMES[3], "nginx:latest"),
-            (DEP_NAMES[4]): createDeployment(DEP_NAMES[4], "quay.io/rhacs-eng/qa:nginx-1-14-alpine"),
-            (DEP_NAMES[5]): createDeployment(DEP_NAMES[5], "quay.io/rhacs-eng/qa:nginx-1-14-alpine"),
+            (DEP_NAMES[4]): createDeployment(DEP_NAMES[4], "quay.io/rhacs-eng/qa-multi-arch:nginx-1-14-alpine"),
+            (DEP_NAMES[5]): createDeployment(DEP_NAMES[5], "quay.io/rhacs-eng/qa-multi-arch:nginx-1-14-alpine"),
     ]
 
     static final private String LATEST_TAG_POLICY_NAME = "Latest tag"

--- a/qa-tests-backend/src/test/groovy/DeploymentEventGraphQLTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DeploymentEventGraphQLTest.groovy
@@ -18,7 +18,8 @@ class DeploymentEventGraphQLTest extends BaseSpecification {
     private static final String CONTAINER_NAME = "eventnginx"
     private static final Deployment DEPLOYMENT = new Deployment()
             .setName(DEPLOYMENT_NAME)
-            .setImage("quay.io/rhacs-eng/qa:nginx-204a9a8e65061b10b92ad361dd6f406248404fe60efd5d6a8f2595f18bb37aad")
+            .setImage("quay.io/rhacs-eng/qa-multi-arch:nginx-" +
+                    "204a9a8e65061b10b92ad361dd6f406248404fe60efd5d6a8f2595f18bb37aad")
             .addLabel("app", "test")
             .setCommand(["sh", "-c", "apt-get -y clean && sleep 600"])
     private static final POLICY = "Ubuntu Package Manager Execution"

--- a/qa-tests-backend/src/test/groovy/DeploymentTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DeploymentTest.groovy
@@ -32,7 +32,7 @@ class DeploymentTest extends BaseSpecification {
 
     private static final Job JOB = new Job()
             .setName("test-job-pi")
-            .setImage("quay.io/rhacs-eng/qa:perl")
+            .setImage("quay.io/rhacs-eng/qa-multi-arch:perl-5-32-1")
             .addLabel("app", "test")
             .setCommand(["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"])
 

--- a/qa-tests-backend/src/test/groovy/Enforcement.groovy
+++ b/qa-tests-backend/src/test/groovy/Enforcement.groovy
@@ -156,35 +156,35 @@ class Enforcement extends BaseSpecification {
     private final static Map<String, Deployment> DEPLOYMENTS = [
             (KILL_ENFORCEMENT):
                     new Deployment()
-                            .setImage("quay.io/rhacs-eng/qa:nginx")
+                            .setImage("quay.io/rhacs-eng/qa-multi-arch:nginx")
                             .setCommand(["sh", "-c", "while true; do sleep 5; apt-get -y update; done"])
                             .setSkipReplicaWait(true),
             (SCALE_DOWN_ENFORCEMENT):
                     new Deployment()
-                            .setImage("busybox")
+                            .setImage("quay.io/rhacs-eng/qa-multi-arch:busybox-1-33-1")
                             .addPort(22)
                             .setCommand(["sleep", "600"])
                             .setSkipReplicaWait(true),
             (SCALE_DOWN_ENFORCEMENT_BUILD_DEPLOY_IMAGE):
                     new Deployment()
-                            .setImage("quay.io/rhacs-eng/qa:enforcement")
+                            .setImage("quay.io/rhacs-eng/qa-multi-arch:enforcement")
                             .addPort(22)
                             .setSkipReplicaWait(true),
             (SCALE_DOWN_ENFORCEMENT_BUILD_DEPLOY_SEVERITY):
                     new Deployment()
-                            .setImage("us.gcr.io/stackrox-ci/nginx:1.9.1")
+                            .setImage("quay.io/rhacs-eng/qa-multi-arch:nginx-1-12-1")
                             .addPort(22)
                             .setSkipReplicaWait(true)
                             .setCommand(["sleep", "600"]),
             (NODE_CONSTRAINT_ENFORCEMENT):
                     new Deployment()
-                            .setImage("busybox")
+                            .setImage("quay.io/rhacs-eng/qa-multi-arch:busybox-1-33-1")
                             .addPort(22)
                             .setCommand(["sleep", "600"])
                             .setSkipReplicaWait(true),
             (SCALE_DOWN_AND_NODE_CONSTRAINT):
                     new Deployment()
-                            .setImage("busybox")
+                            .setImage("quay.io/rhacs-eng/qa-multi-arch:busybox-1-33-1")
                             .addPort(22)
                             .setCommand(["sleep", "600"])
                             .setSkipReplicaWait(true),
@@ -196,13 +196,13 @@ class Enforcement extends BaseSpecification {
                             .setEnv(["CLUSTER_NAME": "main"]),
             (NO_ENFORCEMENT_ON_UPDATE):
                     new Deployment()
-                            .setImage("busybox")
+                            .setImage("quay.io/rhacs-eng/qa-multi-arch:busybox-1-33-1")
                             .addPort(22)
                             .setCommand(["sleep", "600"])
                             .setSkipReplicaWait(true),
             (NO_ENFORCEMENT_WITH_BYPASS_ANNOTATION):
                     new Deployment()
-                            .setImage("busybox")
+                            .setImage("quay.io/rhacs-eng/qa-multi-arch:busybox-1-33-1")
                             .addPort(22)
                             .setCommand(["sleep", "600"])
                             .addAnnotation("admission.stackrox.io/break-glass", "yay")
@@ -213,7 +213,7 @@ class Enforcement extends BaseSpecification {
             (SCALE_DOWN_AND_NODE_CONSTRAINT_FOR_DS):
                     new DaemonSet()
                             .setName("dset1")
-                            .setImage("busybox")
+                            .setImage("quay.io/rhacs-eng/qa-multi-arch:busybox-1-33-1")
                             .addPort(22)
                             .setCommand(["sleep", "600"])
                             .setSkipReplicaWait(true) as DaemonSet,

--- a/qa-tests-backend/src/test/groovy/ExternalNetworkSourcesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ExternalNetworkSourcesTest.groovy
@@ -27,7 +27,7 @@ class ExternalNetworkSourcesTest extends BaseSpecification {
     static final private Deployment DEP_EXTERNALCONNECTION =
             createAndRegisterDeployment()
                     .setName(EXT_CONN_DEPLOYMENT_NAME)
-                    .setImage("quay.io/rhacs-eng/qa:nginx-1.19-alpine")
+                    .setImage("quay.io/rhacs-eng/qa-multi-arch:nginx-1-19-alpine")
                     .addLabel("app", EXT_CONN_DEPLOYMENT_NAME)
                     .setCommand(["/bin/sh", "-c",])
                     .setArgs(["while sleep ${NetworkGraphUtil.NETWORK_FLOW_UPDATE_CADENCE_IN_SECONDS / 10}; " +

--- a/qa-tests-backend/src/test/groovy/ImageManagementTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageManagementTest.groovy
@@ -202,13 +202,13 @@ class ImageManagementTest extends BaseSpecification {
         when:
         "Scan an image and then grab the image data"
         ImageService.scanImage(
-          "registry.redhat.io/rhel8/mysql-80@sha256:c10fa34c5bcf8cb4ab230aeccd0d2c1cd36505bf551abf67c2a08a53a26f3f60")
+          "mysql@sha256:de2913a0ec53d98ced6f6bd607f487b7ad8fe8d2a86e2128308ebf4be2f92667")
 
         then:
         "Assert that riskScore is non-zero"
         withRetry(10, 3) {
             def image = ImageService.getImage(
-                    "sha256:c10fa34c5bcf8cb4ab230aeccd0d2c1cd36505bf551abf67c2a08a53a26f3f60")
+                    "sha256:de2913a0ec53d98ced6f6bd607f487b7ad8fe8d2a86e2128308ebf4be2f92667")
             assert image != null && image.riskScore != 0
         }
     }
@@ -221,8 +221,7 @@ class ImageManagementTest extends BaseSpecification {
         def deployment = new Deployment()
                 .setName("risk-image")
                 .setReplicas(1)
-                .setImage("registry.redhat.io/rhel8/mysql-80@" +
-                        "sha256:c10fa34c5bcf8cb4ab230aeccd0d2c1cd36505bf551abf67c2a08a53a26f3f60")
+                .setImage("mysql@sha256:f7985e36c668bb862a0e506f4ef9acdd1254cdf690469816f99633898895f7fa")
                 .setCommand(["sleep", "60000"])
                 .setSkipReplicaWait(Env.CI_JOBNAME && Env.CI_JOBNAME.contains("openshift-crio"))
 
@@ -232,7 +231,7 @@ class ImageManagementTest extends BaseSpecification {
         "Assert that riskScore is non-zero"
         withRetry(10, 3) {
             def image = ImageService.getImage(
-                    "sha256:c10fa34c5bcf8cb4ab230aeccd0d2c1cd36505bf551abf67c2a08a53a26f3f60")
+                    "sha256:f7985e36c668bb862a0e506f4ef9acdd1254cdf690469816f99633898895f7fa")
             assert image != null && image.riskScore != 0
         }
 

--- a/qa-tests-backend/src/test/groovy/ImageManagementTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageManagementTest.groovy
@@ -54,11 +54,11 @@ class ImageManagementTest extends BaseSpecification {
         "90-Day Image Age"                | "quay.io"   | "rhacs-eng/qa"            | "struts-app" | ""
         // verify Azure registry
         // "90-Day Image Age"                | "stackroxacr.azurecr.io" | "nginx"                  | "1.12"   | ""
-        "Ubuntu Package Manager in Image" | "quay.io"   | "rhacs-eng/qa"            | "struts-app" | ""
-        "Curl in Image"                   | "quay.io"   | "rhacs-eng/qa"            | "struts-app" | ""
-        "Fixable CVSS >= 7"               | "us.gcr.io"   | "stackrox-ci/nginx"      | "1.11"       | ""
+        "Ubuntu Package Manager in Image" | "quay.io"   | "rhacs-eng/qa-multi-arch"            | "struts-app" | ""
+        "Curl in Image"                   | "quay.io"   | "rhacs-eng/qa-multi-arch"            | "struts-app" | ""
+        "Fixable CVSS >= 7"               | "quay.io"   | "rhacs-eng/qa-multi-arch"            | "nginx-1.12" | ""
         "Wget in Image"                   | "quay.io"   | "rhacs-eng/qa"            | "struts-app" | ""
-        "Apache Struts: CVE-2017-5638"    | "quay.io"   | "rhacs-eng/qa"            | "struts-app" | ""
+        "Apache Struts: CVE-2017-5638"    | "quay.io"   | "rhacs-eng/qa-multi-arch"            | "struts-app" | ""
     }
 
     @Tag("BAT")
@@ -202,13 +202,13 @@ class ImageManagementTest extends BaseSpecification {
         when:
         "Scan an image and then grab the image data"
         ImageService.scanImage(
-          "mysql@sha256:de2913a0ec53d98ced6f6bd607f487b7ad8fe8d2a86e2128308ebf4be2f92667")
+          "registry.redhat.io/rhel8/mysql-80@sha256:c10fa34c5bcf8cb4ab230aeccd0d2c1cd36505bf551abf67c2a08a53a26f3f60")
 
         then:
         "Assert that riskScore is non-zero"
         withRetry(10, 3) {
             def image = ImageService.getImage(
-                    "sha256:de2913a0ec53d98ced6f6bd607f487b7ad8fe8d2a86e2128308ebf4be2f92667")
+                    "sha256:c10fa34c5bcf8cb4ab230aeccd0d2c1cd36505bf551abf67c2a08a53a26f3f60")
             assert image != null && image.riskScore != 0
         }
     }
@@ -221,7 +221,8 @@ class ImageManagementTest extends BaseSpecification {
         def deployment = new Deployment()
                 .setName("risk-image")
                 .setReplicas(1)
-                .setImage("mysql@sha256:f7985e36c668bb862a0e506f4ef9acdd1254cdf690469816f99633898895f7fa")
+                .setImage("registry.redhat.io/rhel8/mysql-80@" +
+                        "sha256:c10fa34c5bcf8cb4ab230aeccd0d2c1cd36505bf551abf67c2a08a53a26f3f60")
                 .setCommand(["sleep", "60000"])
                 .setSkipReplicaWait(Env.CI_JOBNAME && Env.CI_JOBNAME.contains("openshift-crio"))
 
@@ -231,7 +232,7 @@ class ImageManagementTest extends BaseSpecification {
         "Assert that riskScore is non-zero"
         withRetry(10, 3) {
             def image = ImageService.getImage(
-                    "sha256:f7985e36c668bb862a0e506f4ef9acdd1254cdf690469816f99633898895f7fa")
+                    "sha256:c10fa34c5bcf8cb4ab230aeccd0d2c1cd36505bf551abf67c2a08a53a26f3f60")
             assert image != null && image.riskScore != 0
         }
 

--- a/qa-tests-backend/src/test/groovy/K8sRbacTest.groovy
+++ b/qa-tests-backend/src/test/groovy/K8sRbacTest.groovy
@@ -111,7 +111,7 @@ class K8sRbacTest extends BaseSpecification {
                 .setName(DEPLOYMENT_NAME)
                 .setNamespace(Constants.ORCHESTRATOR_NAMESPACE)
                 .setServiceAccountName(SERVICE_ACCOUNT_NAME)
-                .setImage("quay.io/rhacs-eng/qa:nginx-1-15-4-alpine")
+                .setImage("quay.io/rhacs-eng/qa-multi-arch:nginx-1-15-4-alpine")
                 .setSkipReplicaWait(true)
         orchestrator.createDeployment(deployment)
         assert Services.waitForDeployment(deployment)

--- a/qa-tests-backend/src/test/groovy/NetworkBaselineTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NetworkBaselineTest.groovy
@@ -22,7 +22,7 @@ class NetworkBaselineTest extends BaseSpecification {
     static final private String DEFERRED_BASELINED_CLIENT_DEP_NAME = "net-bl-client-deferred-baselined"
     static final private String DEFERRED_POST_LOCK_DEP_NAME = "net-bl-client-post-lock"
 
-    static final private String NGINX_IMAGE = "quay.io/rhacs-eng/qa:nginx-1.19-alpine"
+    static final private String NGINX_IMAGE = "quay.io/rhacs-eng/qa-multi-arch:nginx-1-19-alpine"
 
     // The baseline generation duration must be changed from the default for this test to succeed.
     static final private int EXPECTED_BASELINE_DURATION_SECONDS = 240

--- a/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
@@ -66,7 +66,7 @@ class NetworkFlowTest extends BaseSpecification {
         return [
             new Deployment()
                     .setName(UDPCONNECTIONTARGET)
-                    .setImage("quay.io/rhacs-eng/qa:socat")
+                    .setImage("quay.io/rhacs-eng/qa-multi-arch:socat")
                     .addPort(8080, "UDP")
                     .addLabel("app", UDPCONNECTIONTARGET)
                     .setExposeAsService(true)
@@ -74,7 +74,7 @@ class NetworkFlowTest extends BaseSpecification {
                     .setArgs(["socat "+SOCAT_DEBUG+" UDP-RECV:8080 STDOUT",]),
             new Deployment()
                     .setName(TCPCONNECTIONTARGET)
-                    .setImage("quay.io/rhacs-eng/qa:socat")
+                    .setImage("quay.io/rhacs-eng/qa-multi-arch:socat")
                     .addPort(80)
                     .addPort(8080)
                     .addLabel("app", TCPCONNECTIONTARGET)
@@ -84,7 +84,7 @@ class NetworkFlowTest extends BaseSpecification {
                                       "socat "+SOCAT_DEBUG+" TCP-LISTEN:8080,fork STDOUT)" as String,]),
             new Deployment()
                     .setName(NGINXCONNECTIONTARGET)
-                    .setImage("quay.io/rhacs-eng/qa:nginx")
+                    .setImage("quay.io/rhacs-eng/qa-multi-arch:nginx")
                     .addPort(80)
                     .addLabel("app", NGINXCONNECTIONTARGET)
                     .setExposeAsService(true)
@@ -101,11 +101,11 @@ class NetworkFlowTest extends BaseSpecification {
         return [
             new Deployment()
                     .setName(NOCONNECTIONSOURCE)
-                    .setImage("quay.io/rhacs-eng/qa:nginx")
+                    .setImage("quay.io/rhacs-eng/qa-multi-arch:nginx")
                     .addLabel("app", NOCONNECTIONSOURCE),
             new Deployment()
                     .setName(SHORTCONSISTENTSOURCE)
-                    .setImage("quay.io/rhacs-eng/qa:nginx-1.15.4-alpine")
+                    .setImage("quay.io/rhacs-eng/qa-multi-arch:nginx-1-15-4-alpine")
                     .addLabel("app", SHORTCONSISTENTSOURCE)
                     .setCommand(["/bin/sh", "-c",])
                     .setArgs(["while sleep ${NetworkGraphUtil.NETWORK_FLOW_UPDATE_CADENCE_IN_SECONDS}; " +
@@ -113,14 +113,14 @@ class NetworkFlowTest extends BaseSpecification {
                                       "done" as String,]),
             new Deployment()
                     .setName(SINGLECONNECTIONSOURCE)
-                    .setImage("quay.io/rhacs-eng/qa:nginx-1.15.4-alpine")
+                    .setImage("quay.io/rhacs-eng/qa-multi-arch:nginx-1-15-4-alpine")
                     .addLabel("app", SINGLECONNECTIONSOURCE)
                     .setCommand(["/bin/sh", "-c",])
                     .setArgs(["wget -S -T 2 http://${NGINXCONNECTIONTARGET} && " +
                                       "while sleep 30; do echo hello; done" as String,]),
             new Deployment()
                     .setName(UDPCONNECTIONSOURCE)
-                    .setImage("quay.io/rhacs-eng/qa:socat")
+                    .setImage("quay.io/rhacs-eng/qa-multi-arch:socat")
                     .addLabel("app", UDPCONNECTIONSOURCE)
                     .setCommand(["/bin/sh", "-c",])
                     .setArgs(["while sleep 5; " +
@@ -129,7 +129,7 @@ class NetworkFlowTest extends BaseSpecification {
                                       "done" as String,]),
             new Deployment()
                     .setName(TCPCONNECTIONSOURCE)
-                    .setImage("quay.io/rhacs-eng/qa:socat")
+                    .setImage("quay.io/rhacs-eng/qa-multi-arch:socat")
                     .addLabel("app", TCPCONNECTIONSOURCE)
                     .setCommand(["/bin/sh", "-c",])
                     .setArgs(["while sleep 5; " +
@@ -138,7 +138,7 @@ class NetworkFlowTest extends BaseSpecification {
                                       "done" as String,]),
             new Deployment()
                     .setName(MULTIPLEPORTSCONNECTION)
-                    .setImage("quay.io/rhacs-eng/qa:socat")
+                    .setImage("quay.io/rhacs-eng/qa-multi-arch:socat")
                     .addLabel("app", MULTIPLEPORTSCONNECTION)
                     .setCommand(["/bin/sh", "-c",])
                     .setArgs(["while sleep 5; " +
@@ -149,7 +149,7 @@ class NetworkFlowTest extends BaseSpecification {
                                       "done" as String,]),
             new Deployment()
                     .setName(EXTERNALDESTINATION)
-                    .setImage("quay.io/rhacs-eng/qa:nginx-1.15.4-alpine")
+                    .setImage("quay.io/rhacs-eng/qa-multi-arch:nginx-1-15-4-alpine")
                     .addLabel("app", EXTERNALDESTINATION)
                     .setCommand(["/bin/sh", "-c",])
                     .setArgs(["while sleep ${NetworkGraphUtil.NETWORK_FLOW_UPDATE_CADENCE_IN_SECONDS}; " +
@@ -158,7 +158,7 @@ class NetworkFlowTest extends BaseSpecification {
             new Deployment()
                     .setName("${TCPCONNECTIONSOURCE}-qa2")
                     .setNamespace(OTHER_NAMESPACE)
-                    .setImage("quay.io/rhacs-eng/qa:socat")
+                    .setImage("quay.io/rhacs-eng/qa-multi-arch:socat")
                     .addLabel("app", "${TCPCONNECTIONSOURCE}-qa2")
                     .setCommand(["/bin/sh", "-c",])
                     .setArgs(["while sleep 5; " +
@@ -523,7 +523,7 @@ class NetworkFlowTest extends BaseSpecification {
         "create a new deployment that talks to A via the LB IP"
         def newDeployment = new Deployment()
                 .setName("talk-to-lb-ip")
-                .setImage("quay.io/rhacs-eng/qa:nginx-1.15.4-alpine")
+                .setImage("quay.io/rhacs-eng/qa-multi-arch:nginx-1-15-4-alpine")
                 .addLabel("app", "talk-to-lb-ip")
                 .setCommand(["/bin/sh", "-c",])
                 .setArgs(["while sleep 5; do wget -S -T 2 http://"+deploymentIP+"; done"])

--- a/qa-tests-backend/src/test/groovy/NetworkSimulator.groovy
+++ b/qa-tests-backend/src/test/groovy/NetworkSimulator.groovy
@@ -24,21 +24,21 @@ class NetworkSimulator extends BaseSpecification {
     static final private List<Deployment> DEPLOYMENTS = [
             new Deployment()
                     .setName(WEBDEPLOYMENT)
-                    .setImage("quay.io/rhacs-eng/qa:nginx")
+                    .setImage("quay.io/rhacs-eng/qa-multi-arch:nginx")
                     .addPort(80)
                     .addLabel("app", WEBDEPLOYMENT),
             new Deployment()
                     .setName(WEB2DEPLOYMENT)
-                    .setImage("quay.io/rhacs-eng/qa:nginx")
+                    .setImage("quay.io/rhacs-eng/qa-multi-arch:nginx")
                     .addLabel("app", WEB2DEPLOYMENT),
             new Deployment()
                     .setName(CLIENTDEPLOYMENT)
-                    .setImage("quay.io/rhacs-eng/qa:nginx")
+                    .setImage("quay.io/rhacs-eng/qa-multi-arch:nginx")
                     .addPort(443)
                     .addLabel("app", CLIENTDEPLOYMENT),
             new Deployment()
                     .setName(CLIENT2DEPLOYMENT)
-                    .setImage("quay.io/rhacs-eng/qa:nginx")
+                    .setImage("quay.io/rhacs-eng/qa-multi-arch:nginx")
                     .addLabel("app", CLIENT2DEPLOYMENT),
     ]
 

--- a/qa-tests-backend/src/test/groovy/PaginationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/PaginationTest.groovy
@@ -22,44 +22,44 @@ class PaginationTest extends BaseSpecification {
     static final private List<Deployment> DEPLOYMENTS = [
             new Deployment()
                     .setName("pagination1")
-                    .setImage("quay.io/rhacs-eng/qa:busybox-1-26")
+                    .setImage("quay.io/rhacs-eng/qa-multi-arch:busybox-1-32")
                     .addLabel("app", "pagination1")
                     .setCommand(["sleep", "600"])
                     .addSecretName("p1", SECRETS[0]),
             new Deployment()
                     .setName("pagination2")
-                    .setImage("quay.io/rhacs-eng/qa:busybox-1-25")
+                    .setImage("quay.io/rhacs-eng/qa-multi-arch:busybox-1-31")
                     .addLabel("app", "pagination2")
                     .setCommand(["sleep", "600"])
                     .addSecretName("p2", SECRETS[1]),
             new Deployment()
                     .setName("pagination3")
-                    .setImage("quay.io/rhacs-eng/qa:busybox-1-30")
+                    .setImage("quay.io/rhacs-eng/qa-multi-arch:busybox-1-30")
                     .addLabel("app", "pagination3")
                     .setCommand(["sleep", "600"])
                     .addSecretName("p3", SECRETS[2]),
             new Deployment()
                     .setName("pagination4")
-                    .setImage("quay.io/rhacs-eng/qa:busybox-1-29")
+                    .setImage("quay.io/rhacs-eng/qa-multi-arch:busybox-1-29")
                     .addLabel("app", "pagination4")
                     .setCommand(["sleep", "600"])
                     .addSecretName("p4", SECRETS[3]),
             new Deployment()
                     .setName("pagination5")
-                    .setImage("quay.io/rhacs-eng/qa:busybox-1-28")
+                    .setImage("quay.io/rhacs-eng/qa-multi-arch:busybox-1-28")
                     .addLabel("app", "pagination5")
                     .setCommand(["sleep", "600"])
                     .addSecretName("p5", SECRETS[4]),
             new Deployment()
                     .setName("pagination6")
-                    .setImage("quay.io/rhacs-eng/qa:busybox-1-27")
+                    .setImage("quay.io/rhacs-eng/qa-multi-arch:busybox-1-27")
                     .addLabel("app", "pagination6")
                     .setCommand(["sleep", "600"])
                     .addSecretName("p6", SECRETS[5]),
     ]
 
-    static final private IMAGE_AND_TAGS_QUERY = "Image:quay.io/rhacs-eng/qa+"+
-            "Image Tag:busybox-1-25,busybox-1-26,busybox-1-27,busybox-1-28,busybox-1-29,busybox-1-30"
+    static final private IMAGE_AND_TAGS_QUERY = "Image:quay.io/rhacs-eng/qa-multi-arch+"+
+            "Image Tag:busybox-1-31,busybox-1-32,busybox-1-27,busybox-1-28,busybox-1-29,busybox-1-30"
 
     def setupSpec() {
         for (String secretName : SECRETS.keySet()) {

--- a/qa-tests-backend/src/test/groovy/PolicyFieldsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/PolicyFieldsTest.groovy
@@ -41,7 +41,7 @@ class PolicyFieldsTest extends BaseSpecification {
     static final private Deployment DEP_A =
             createAndRegisterDeployment()
                     .setName("deployment-a")
-                    .setImage("us.gcr.io/stackrox-ci/qa/trigger-policy-violations/more:0.3")
+                    .setImage("quay.io/rhacs-eng/qa-multi-arch:trigger-policy-violations-more")
                     .setCapabilities(["NET_ADMIN", "SYSLOG"], ["IPC_LOCK", "WAKE_ALARM"])
                     .addLimits("cpu", "0.5")
                     .addRequest("cpu", "0.25")
@@ -111,7 +111,7 @@ class PolicyFieldsTest extends BaseSpecification {
     static final private Deployment DEP_B =
             createAndRegisterDeployment()
                     .setName("deployment-b")
-                    .setImage("us.gcr.io/stackrox-ci/qa/trigger-policy-violations/most:0.19")
+                    .setImage("quay.io/rhacs-eng/qa-multi-arch:trigger-policy-violations-most")
                     .setCapabilities(["NET_ADMIN"], ["IPC_LOCK"])
                     .addLimits("cpu", "1")
                     .addRequest("cpu", "0.5")
@@ -183,7 +183,7 @@ class PolicyFieldsTest extends BaseSpecification {
     static final private Deployment DEP_C =
             createAndRegisterDeployment()
                     .setName("deployment-c")
-                    .setImage("us.gcr.io/stackrox-ci/qa/trigger-policy-violations/alpine:0.6")
+                    .setImage("quay.io/rhacs-eng/qa-multi-arch:trigger-policy-violations-alpine")
                     .addAnnotation("im-a-key", "with a different value")
                     .addAnnotation("another-key", "and a value")
                     .addLabel("im-a-key", "with_a_different_value")
@@ -216,7 +216,7 @@ class PolicyFieldsTest extends BaseSpecification {
     static final private Deployment DEP_D =
             createAndRegisterDeployment()
                     .setName("deployment-d")
-                    .setImage("quay.io/rhacs-eng/qa:apache-dns")
+                    .setImage("quay.io/rhacs-eng/qa-multi-arch:apache-dns")
                     .setNamespace(NAMESPACE_D)
 
     static final private WITHOUT_ANNOTATIONS = DEP_D

--- a/qa-tests-backend/src/test/groovy/PolicyFieldsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/PolicyFieldsTest.groovy
@@ -41,7 +41,7 @@ class PolicyFieldsTest extends BaseSpecification {
     static final private Deployment DEP_A =
             createAndRegisterDeployment()
                     .setName("deployment-a")
-                    .setImage("quay.io/rhacs-eng/qa-multi-arch:trigger-policy-violations-more")
+                    .setImage("us.gcr.io/stackrox-ci/qa/trigger-policy-violations/more:0.3")
                     .setCapabilities(["NET_ADMIN", "SYSLOG"], ["IPC_LOCK", "WAKE_ALARM"])
                     .addLimits("cpu", "0.5")
                     .addRequest("cpu", "0.25")
@@ -111,7 +111,7 @@ class PolicyFieldsTest extends BaseSpecification {
     static final private Deployment DEP_B =
             createAndRegisterDeployment()
                     .setName("deployment-b")
-                    .setImage("quay.io/rhacs-eng/qa-multi-arch:trigger-policy-violations-most")
+                    .setImage("us.gcr.io/stackrox-ci/qa/trigger-policy-violations/most:0.19")
                     .setCapabilities(["NET_ADMIN"], ["IPC_LOCK"])
                     .addLimits("cpu", "1")
                     .addRequest("cpu", "0.5")
@@ -183,7 +183,7 @@ class PolicyFieldsTest extends BaseSpecification {
     static final private Deployment DEP_C =
             createAndRegisterDeployment()
                     .setName("deployment-c")
-                    .setImage("quay.io/rhacs-eng/qa-multi-arch:trigger-policy-violations-alpine")
+                    .setImage("us.gcr.io/stackrox-ci/qa/trigger-policy-violations/alpine:0.6")
                     .addAnnotation("im-a-key", "with a different value")
                     .addAnnotation("another-key", "and a value")
                     .addLabel("im-a-key", "with_a_different_value")
@@ -216,7 +216,7 @@ class PolicyFieldsTest extends BaseSpecification {
     static final private Deployment DEP_D =
             createAndRegisterDeployment()
                     .setName("deployment-d")
-                    .setImage("quay.io/rhacs-eng/qa-multi-arch:apache-dns")
+                    .setImage("quay.io/rhacs-eng/qa:apache-dns")
                     .setNamespace(NAMESPACE_D)
 
     static final private WITHOUT_ANNOTATIONS = DEP_D

--- a/qa-tests-backend/src/test/groovy/RoutesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/RoutesTest.groovy
@@ -13,7 +13,7 @@ class RoutesTest extends BaseSpecification {
 
     static final private SERVER_DEP = new Deployment()
         .setName("server")
-        .setImage("quay.io/rhacs-eng/qa:nginx-1.19-alpine")
+        .setImage("quay.io/rhacs-eng/qa-multi-arch:nginx-1-19-alpine")
         .addLabel("app", "server")
         .addPort(80)
         .setExposeAsService(true)

--- a/qa-tests-backend/src/test/groovy/RuntimePolicyTest.groovy
+++ b/qa-tests-backend/src/test/groovy/RuntimePolicyTest.groovy
@@ -19,13 +19,13 @@ class RuntimePolicyTest extends BaseSpecification  {
     static final private List<Deployment> DEPLOYMENTS = [
             new Deployment()
                     .setName (DEPLOYMENTAPTGET)
-                    .setImage ("quay.io/rhacs-eng/qa:nginx-"+
+                    .setImage ("quay.io/rhacs-eng/qa-multi-arch:nginx-"+
                                "204a9a8e65061b10b92ad361dd6f406248404fe60efd5d6a8f2595f18bb37aad")
                     .addLabel ( "app", "test" )
                     .setCommand(["sh" , "-c" , "apt-get -y update && sleep 600"]),
             new Deployment()
                     .setName (DEPLOYMENTAPT)
-                    .setImage ("quay.io/rhacs-eng/qa:redis-"+
+                    .setImage ("quay.io/rhacs-eng/qa-multi-arch:redis-"+
                                "96be1b5b6e4fe74dfe65b2b52a0fee254c443184b34fe448f3b3498a512db99e")
                     .addLabel ( "app", "test" )
                     .setCommand(["sh" , "-c" , "apt -y update && sleep 600"]),
@@ -33,7 +33,8 @@ class RuntimePolicyTest extends BaseSpecification  {
 
     static final private DEPLOYMENTREMOVAL =  new Deployment()
             .setName ("runtimeremoval")
-            .setImage ("quay.io/rhacs-eng/qa:redis-96be1b5b6e4fe74dfe65b2b52a0fee254c443184b34fe448f3b3498a512db99e")
+            .setImage ("quay.io/rhacs-eng/qa-multi-arch:redis-" +
+                    "96be1b5b6e4fe74dfe65b2b52a0fee254c443184b34fe448f3b3498a512db99e")
             .addLabel ( "app", "test" )
             .setCommand(["sh" , "-c" , "apt -y update && sleep 600"])
 

--- a/qa-tests-backend/src/test/groovy/RuntimeViolationLifecycleTest.groovy
+++ b/qa-tests-backend/src/test/groovy/RuntimeViolationLifecycleTest.groovy
@@ -22,7 +22,8 @@ class RuntimeViolationLifecycleTest extends BaseSpecification  {
     static final private String DEPLOYMENTNAME = "runtimeviolationlifecycle"
     static final private Deployment DEPLOYMENT = new Deployment()
         .setName(DEPLOYMENTNAME)
-        .setImage ("quay.io/rhacs-eng/qa:nginx-204a9a8e65061b10b92ad361dd6f406248404fe60efd5d6a8f2595f18bb37aad")
+        .setImage ("quay.io/rhacs-eng/qa-multi-arch:nginx-" +
+                "204a9a8e65061b10b92ad361dd6f406248404fe60efd5d6a8f2595f18bb37aad")
         .addLabel ("app", DEPLOYMENTNAME)
         .setCommand(["sh" , "-c" , "apt-get -y update && sleep 600"])
 

--- a/qa-tests-backend/src/test/groovy/SecretsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/SecretsTest.groovy
@@ -13,7 +13,7 @@ class SecretsTest extends BaseSpecification {
         Deployment deploy = new Deployment()
                 .setName (deploymentName)
                 .setNamespace("qa")
-                .setImage ("quay.io/rhacs-eng/qa:busybox")
+                .setImage ("quay.io/rhacs-eng/qa-multi-arch:busybox-1-33-1")
                 .addLabel ( "app", "test" )
                 .setCommand(["sleep", "600"])
         if (fromEnv) {

--- a/qa-tests-backend/src/test/groovy/TLSChallengeTest.groovy
+++ b/qa-tests-backend/src/test/groovy/TLSChallengeTest.groovy
@@ -192,7 +192,7 @@ class TLSChallengeTest extends BaseSpecification {
         loadBalancerDeployment.setNamespace(PROXY_NAMESPACE)
                 .setName("nginx-loadbalancer")
                 .setExposeAsService(true)
-                .setImage("quay.io/rhacs-eng/qa:nginx-1-17-1")
+                .setImage("quay.io/rhacs-eng/qa-multi-arch:nginx-1-17-1")
                 .addVolumeFromConfigMap(nginxConfigMap, "/etc/nginx/conf.d/")
                 .addVolumeFromSecret(tlsConfSecret, "/run/secrets/tls/")
                 .setTargetPort(8443)


### PR DESCRIPTION
## Description

This PR intends to add multi-arch support for the groovy tests.
Test images used in respective test are changed to use alternate multi-arch images which support 3 platforms viz. `x86_64`, `ppc64le` and `s390x`.

Changes are verified manually using `./gradlew test --tests=TestName`