### PR TITLE
Telemetry: "Updated Identity" event to wake up the central analytics

### DIFF
--- a/central/main.go
+++ b/central/main.go
@@ -292,11 +292,6 @@ func main() {
 
 	go startGRPCServer()
 
-	if cfg := centralclient.InstanceConfig(); cfg.Enabled() {
-		// Issue an event so that the central become visible for analytics:
-		cfg.Telemeter().Track("Central is up", cfg.ClientID, nil)
-	}
-
 	waitForTerminationSignal()
 }
 

--- a/central/main.go
+++ b/central/main.go
@@ -292,6 +292,11 @@ func main() {
 
 	go startGRPCServer()
 
+	if cfg := centralclient.InstanceConfig(); cfg.Enabled() {
+		// Issue an event so that the central become visible for analytics:
+		cfg.Telemeter().Track("Central is up", cfg.ClientID, nil)
+	}
+
 	waitForTerminationSignal()
 }
 

--- a/pkg/telemetry/phonehome/gatherer.go
+++ b/pkg/telemetry/phonehome/gatherer.go
@@ -66,6 +66,12 @@ func (g *gatherer) collect() map[string]any {
 }
 
 func (g *gatherer) loop() {
+	// Send initial data on start:
+	go func() {
+		g.telemeter.Identify(g.clientID, g.collect())
+		// Issue an event so that the client become visible for analytics:
+		g.telemeter.Track("Initial Identity", g.clientID, nil)
+	}()
 	ticker := time.NewTicker(g.period)
 	for !g.stopSig.IsDone() {
 		select {


### PR DESCRIPTION
## Description

Amplitude makes use of user traits when there are events from the user. For a user composition chart based on some user properties, there should be an event happened after identity update.

In this PR:
* Record the gathered client identity only if it is different from the one previously collected;
* Send "Updated Identity" event after client identity is recorded;
* Record the initial identity on start up, not waiting for the first timer event.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

ongoing