### PR TITLE
Minor UI fixes for collections

### DIFF
--- a/ui/apps/platform/src/Components/PatternFly/BacklogListSelector.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/BacklogListSelector.tsx
@@ -10,14 +10,7 @@ import {
 } from '@patternfly/react-core';
 import { CubesIcon, MinusCircleIcon, PlusCircleIcon } from '@patternfly/react-icons';
 
-import {
-    BaseCellProps,
-    TableComposable,
-    TableVariant,
-    Tbody,
-    Td,
-    Tr,
-} from '@patternfly/react-table';
+import { BaseCellProps, TableComposable, Tbody, Td, Tr } from '@patternfly/react-table';
 
 type BacklogTableProps<Item> = {
     type: 'selected' | 'deselected';
@@ -64,7 +57,7 @@ function BacklogTable<Item>({
             }
         >
             {items.length > 0 ? (
-                <TableComposable aria-label={label} variant={TableVariant.compact}>
+                <TableComposable aria-label={label}>
                     <Tbody>
                         {items.map((item) => (
                             <Tr key={rowKey(item)}>

--- a/ui/apps/platform/src/Containers/Collections/CollectionForm.css
+++ b/ui/apps/platform/src/Containers/Collections/CollectionForm.css
@@ -4,11 +4,13 @@
 }
 
 .collection-form-expandable-section button.pf-c-expandable-section__toggle {
-  align-items: center;
   color: inherit;
   font-weight: inherit;
   font-size: inherit;
-  text-align: left;
+}
+
+.collection-form-expandable-section button.pf-c-expandable-section__toggle svg {
+  vertical-align: middle !important;
 }
 
 .collection-form-expandable-section button.pf-c-expandable-section__toggle:focus {

--- a/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useEffect } from 'react';
+import React, { CSSProperties, ReactElement, useEffect } from 'react';
 import {
     Alert,
     Badge,
@@ -299,7 +299,14 @@ function CollectionForm({
     const ruleCount = getRuleCount(values.resourceSelector);
 
     return (
-        <Form className="pf-u-background-color-200">
+        <Form
+            className="pf-u-background-color-200"
+            style={
+                {
+                    '--pf-c-form--GridGap': 0,
+                } as CSSProperties
+            }
+        >
             <Flex
                 className="pf-u-p-lg"
                 spaceItems={{ default: 'spaceItemsMd' }}

--- a/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
@@ -67,7 +67,7 @@ function AttachedCollectionTable({
             </Tbody>
         </TableComposable>
     ) : (
-        <EmptyState variant={EmptyStateVariant.xs}>
+        <EmptyState>
             <EmptyStateIcon icon={CubesIcon} />
             <p>There are no other collections attached to this collection</p>
         </EmptyState>
@@ -461,7 +461,6 @@ function CollectionForm({
                         isExpanded={isAttachmentSectionOpen}
                     >
                         <Flex
-                            className="pf-u-p-md"
                             direction={{ default: 'column' }}
                             spaceItems={{ default: 'spaceItemsMd' }}
                         >
@@ -483,7 +482,7 @@ function CollectionForm({
                                     collectionTableCells={collectionTableCells}
                                 />
                             ) : (
-                                <>
+                                <div className="pf-u-p-md">
                                     <CollectionAttacher
                                         excludedCollectionId={
                                             action.type === 'edit' ? action.collectionId : null
@@ -492,7 +491,7 @@ function CollectionForm({
                                         onSelectionChange={onEmbeddedCollectionsChange}
                                         collectionTableCells={collectionTableCells}
                                     />
-                                </>
+                                </div>
                             )}
                         </Flex>
                     </ExpandableSection>

--- a/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
@@ -410,7 +410,7 @@ function CollectionForm({
                                 validationErrors={errors.resourceSelector?.Deployment}
                                 isDisabled={isReadOnly}
                             />
-                            <Label variant="outline" isCompact className="pf-u-align-self-center">
+                            <Label className="pf-u-px-md pf-u-font-size-md pf-u-align-self-center">
                                 in
                             </Label>
                             <RuleSelector
@@ -421,7 +421,7 @@ function CollectionForm({
                                 validationErrors={errors.resourceSelector?.Namespace}
                                 isDisabled={isReadOnly}
                             />
-                            <Label variant="outline" isCompact className="pf-u-align-self-center">
+                            <Label className="pf-u-px-md pf-u-font-size-md pf-u-align-self-center">
                                 in
                             </Label>
                             <RuleSelector

--- a/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
@@ -5,7 +5,6 @@ import {
     Button,
     EmptyState,
     EmptyStateIcon,
-    EmptyStateVariant,
     ExpandableSection,
     ExpandableSectionToggle,
     Flex,
@@ -17,7 +16,7 @@ import {
     Title,
 } from '@patternfly/react-core';
 import { CubesIcon } from '@patternfly/react-icons';
-import { TableComposable, TableVariant, Tbody, Tr, Td } from '@patternfly/react-table';
+import { TableComposable, Tbody, Tr, Td } from '@patternfly/react-table';
 import { useFormik } from 'formik';
 import * as yup from 'yup';
 
@@ -53,7 +52,7 @@ function AttachedCollectionTable({
     collectionTableCells: CollectionAttacherProps['collectionTableCells'];
 }) {
     return collections.length > 0 ? (
-        <TableComposable aria-label="Attached collections" variant={TableVariant.compact}>
+        <TableComposable aria-label="Attached collections">
             <Tbody>
                 {collections.map((collection) => (
                     <Tr key={collection.name}>

--- a/ui/apps/platform/src/Containers/Collections/CollectionFormDrawer.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionFormDrawer.tsx
@@ -71,6 +71,7 @@ function CollectionFormDrawer({
                         <DrawerPanelContent
                             style={{
                                 borderLeft: 'var(--pf-global--BorderColor--100) 1px solid',
+                                maxWidth: isInlineDrawer ? '40%' : 'unset',
                             }}
                         >
                             <CollectionResults

--- a/ui/apps/platform/src/Containers/Collections/CollectionFormModal.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionFormModal.tsx
@@ -70,13 +70,13 @@ function CollectionsFormModal({
     configError,
     setConfigError,
 }: CollectionsFormModalProps) {
-    const isLargeScreen = useMediaQuery({ query: '(min-width: 992px)' }); // --pf-global--breakpoint--lg
+    const isXLargeScreen = useMediaQuery({ query: '(min-width: 1200px)' }); // --pf-global--breakpoint--xl
     const {
         isOpen: isDrawerOpen,
         toggleSelect: toggleDrawer,
         closeSelect: closeDrawer,
         openSelect: openDrawer,
-    } = useSelectToggle(isLargeScreen);
+    } = useSelectToggle(isXLargeScreen);
 
     const { data, loading, error } = useCollection(
         modalAction.type === 'view' ? modalAction.collectionId : undefined
@@ -106,7 +106,7 @@ function CollectionsFormModal({
                 hasWriteAccessForCollections={hasWriteAccessForCollections}
                 action={modalAction}
                 collectionData={data}
-                isInlineDrawer={isLargeScreen}
+                isInlineDrawer={isXLargeScreen}
                 isDrawerOpen={isDrawerOpen}
                 toggleDrawer={toggleDrawer}
                 onSubmit={onSubmit}

--- a/ui/apps/platform/src/Containers/Collections/CollectionResults.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionResults.tsx
@@ -64,7 +64,7 @@ function DeploymentResult({ deployment }: { deployment: ListDeployment }) {
             </FlexItem>
             <FlexItem>
                 <div>{deployment.name}</div>
-                <span className="pf-u-color-400 pf-u-font-size-xs">
+                <span className="pf-u-color-300 pf-u-font-size-xs">
                     In &quot;{deployment.cluster} / {deployment.namespace}
                     &quot;
                 </span>
@@ -220,7 +220,7 @@ function CollectionResults({
                                     View more
                                 </Button>
                             ) : (
-                                <span className="pf-u-color-400 pf-u-text-align-center pf-u-font-size-sm">
+                                <span className="pf-u-color-300 pf-u-text-align-center pf-u-font-size-sm">
                                     end of results
                                 </span>
                             )}

--- a/ui/apps/platform/src/Containers/Collections/CollectionResults.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionResults.tsx
@@ -182,14 +182,14 @@ function CollectionResults({
                             <SelectOption value="Cluster">Cluster</SelectOption>
                         </Select>
                     </FlexItem>
-                    <FlexItem grow={{ default: 'grow' }}>
+                    <div className="pf-u-flex-grow-1 pf-u-flex-basis-0">
                         <SearchInput
                             aria-label="Filter by name"
                             placeholder="Filter by name"
                             value={filterText}
                             onChange={setFilterText}
                         />
-                    </FlexItem>
+                    </div>
                 </Flex>
                 <Flex
                     direction={{ default: 'column' }}

--- a/ui/apps/platform/src/Containers/Collections/CollectionResults.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionResults.tsx
@@ -135,23 +135,18 @@ function CollectionResults({
 
     if (configError) {
         content = (
-            <Flex className="pf-u-h-100" alignContent={{ default: 'alignContentCenter' }}>
-                <EmptyState variant={EmptyStateVariant.xs}>
-                    <EmptyStateIcon
-                        style={{ color: 'var(--pf-global--danger-color--200)' }}
-                        icon={ExclamationCircleIcon}
-                    />
-                    <Flex
-                        spaceItems={{ default: 'spaceItemsMd' }}
-                        direction={{ default: 'column' }}
-                    >
-                        <Title headingLevel="h2" size="md">
-                            {configError.message}
-                        </Title>
-                        <p className="pf-u-text-align-left">{configError.details}</p>
-                    </Flex>
-                </EmptyState>
-            </Flex>
+            <EmptyState variant={EmptyStateVariant.xs}>
+                <EmptyStateIcon
+                    style={{ color: 'var(--pf-global--danger-color--200)' }}
+                    icon={ExclamationCircleIcon}
+                />
+                <Flex spaceItems={{ default: 'spaceItemsMd' }} direction={{ default: 'column' }}>
+                    <Title headingLevel="h2" size="md">
+                        {configError.message}
+                    </Title>
+                    <p>{configError.details}</p>
+                </Flex>
+            </EmptyState>
         );
     } else if (!selectorRulesExist) {
         content = (

--- a/ui/apps/platform/src/Containers/Collections/CollectionsFormPage.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionsFormPage.tsx
@@ -353,7 +353,7 @@ function CollectionsFormPage({
             </AlertGroup>
             <ConfirmationModal
                 ariaLabel="Confirm delete"
-                confirmText="Delete"
+                confirmText="Delete collection"
                 isLoading={isDeleting}
                 isOpen={deleteId !== null}
                 onConfirm={onConfirmDeleteCollection}

--- a/ui/apps/platform/src/Containers/Collections/CollectionsFormPage.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionsFormPage.tsx
@@ -63,7 +63,7 @@ function CollectionsFormPage({
     pageAction,
 }: CollectionsFormPageProps) {
     const history = useHistory();
-    const isLargeScreen = useMediaQuery({ query: '(min-width: 992px)' }); // --pf-global--breakpoint--lg
+    const isXLargeScreen = useMediaQuery({ query: '(min-width: 1200px)' }); // --pf-global--breakpoint--xl
     const collectionId = pageAction.type !== 'create' ? pageAction.collectionId : undefined;
 
     const { data, loading, error } = useCollection(collectionId);
@@ -88,7 +88,7 @@ function CollectionsFormPage({
         toggleSelect: toggleDrawer,
         closeSelect: closeDrawer,
         openSelect: openDrawer,
-    } = useSelectToggle(isLargeScreen);
+    } = useSelectToggle(isXLargeScreen);
 
     function onEditCollection(id: string) {
         history.push({
@@ -196,7 +196,7 @@ function CollectionsFormPage({
                 hasWriteAccessForCollections={hasWriteAccessForCollections}
                 action={pageAction}
                 collectionData={data}
-                isInlineDrawer={isLargeScreen}
+                isInlineDrawer={isXLargeScreen}
                 isDrawerOpen={isDrawerOpen}
                 toggleDrawer={toggleDrawer}
                 onSubmit={(collection) =>

--- a/ui/apps/platform/src/Containers/Collections/CollectionsTable.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionsTable.tsx
@@ -202,7 +202,7 @@ function CollectionsTable({
             {collectionToDelete && (
                 <ConfirmationModal
                     ariaLabel="Confirm delete"
-                    confirmText="Delete"
+                    confirmText="Delete collection"
                     isLoading={isDeleting}
                     isOpen
                     onConfirm={() => onConfirmDeleteCollection(collectionToDelete)}

--- a/ui/apps/platform/src/Containers/Collections/CollectionsTable.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionsTable.tsx
@@ -13,7 +13,7 @@ import {
     Truncate,
 } from '@patternfly/react-core';
 import { SearchIcon } from '@patternfly/react-icons';
-import { TableComposable, TableVariant, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import { TableComposable, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import debounce from 'lodash/debounce';
 
 import ConfirmationModal from 'Components/PatternFly/ConfirmationModal';
@@ -129,7 +129,7 @@ function CollectionsTable({
                     </ToolbarItem>
                 </ToolbarContent>
             </Toolbar>
-            <TableComposable variant={TableVariant.compact}>
+            <TableComposable>
                 <Thead>
                     <Tr>
                         <Th modifier="wrap" sort={getEnabledSortParams('Collection Name')}>

--- a/ui/apps/platform/src/Containers/Collections/RuleSelector/ByNameSelector.tsx
+++ b/ui/apps/platform/src/Containers/Collections/RuleSelector/ByNameSelector.tsx
@@ -104,32 +104,34 @@ function ByNameSelector({
                                     <SelectOption value="REGEX">A regex value of</SelectOption>
                                 </NameMatchTypeSelect>
                             </div>
-                            {matchType === 'REGEX' ? (
-                                <TextInput
-                                    id={inputId}
-                                    aria-label={inputAriaLabel}
-                                    placeholder={`^${placeholder}$`}
-                                    className={inputClassName}
-                                    onChange={inputOnChange}
-                                    validated={inputValidated}
-                                    value={value}
-                                    isDisabled={isDisabled}
-                                />
-                            ) : (
-                                <AutoCompleteSelect
-                                    id={inputId}
-                                    entityType={entityType}
-                                    typeAheadAriaLabel={inputAriaLabel}
-                                    className={inputClassName}
-                                    onChange={inputOnChange}
-                                    placeholder={placeholder}
-                                    validated={inputValidated}
-                                    selectedOption={value}
-                                    isDisabled={isDisabled}
-                                    collection={collection}
-                                    autocompleteField={entityType}
-                                />
-                            )}
+                            <div className="rule-selector-name-value-input">
+                                {matchType === 'REGEX' ? (
+                                    <TextInput
+                                        id={inputId}
+                                        aria-label={inputAriaLabel}
+                                        placeholder={`^${placeholder}$`}
+                                        className={inputClassName}
+                                        onChange={inputOnChange}
+                                        validated={inputValidated}
+                                        value={value}
+                                        isDisabled={isDisabled}
+                                    />
+                                ) : (
+                                    <AutoCompleteSelect
+                                        id={inputId}
+                                        entityType={entityType}
+                                        typeAheadAriaLabel={inputAriaLabel}
+                                        className={inputClassName}
+                                        onChange={inputOnChange}
+                                        placeholder={placeholder}
+                                        validated={inputValidated}
+                                        selectedOption={value}
+                                        isDisabled={isDisabled}
+                                        collection={collection}
+                                        autocompleteField={entityType}
+                                    />
+                                )}
+                            </div>
                             {!isDisabled && (
                                 <Button
                                     aria-label={`Delete ${value}`}

--- a/ui/apps/platform/src/Containers/Collections/RuleSelector/RuleSelector.css
+++ b/ui/apps/platform/src/Containers/Collections/RuleSelector/RuleSelector.css
@@ -4,6 +4,24 @@
   border: 1px solid var(--pf-global--BorderColor--100);
 }
 
+/* Allows rule form elements to shrink further to avoid overlap in constrained screen sizes */
+.rule-selector .pf-c-select__toggle-typeahead {
+  flex-basis: unset;
+  min-width: unset;
+}
+
+.rule-selector .rule-selector-match-type-select {
+  width: 180px;
+}
+
+.rule-selector .rule-selector-name-value-input {
+  flex: 1;
+}
+
+.rule-selector .rule-selector-name-value-input > * {
+  width: 100% !important;
+}
+
 .rule-selector-list {
   border-left: solid 1px var(--pf-global--BorderColor--100);
   margin-left: var(--rule-selector-spacer);
@@ -40,8 +58,4 @@
   flex: 1 1 0;
   content: "";
   display: inline-block;
-}
-
-.rule-selector-match-type-select {
-  width: 180px;
 }

--- a/ui/apps/platform/src/Containers/Collections/RuleSelector/RuleSelector.css
+++ b/ui/apps/platform/src/Containers/Collections/RuleSelector/RuleSelector.css
@@ -44,7 +44,7 @@
 }
 
 .rule-selector-add-value-button {
-  padding: var(--rule-selector-spacer) 0 0 calc(var(--rule-selector-spacer) * 2);
+  margin: var(--rule-selector-spacer) 0 0 var(--rule-selector-spacer);
 }
 
 .rule-selector-label-rule-separator {

--- a/ui/apps/platform/src/css/acs.css
+++ b/ui/apps/platform/src/css/acs.css
@@ -49,16 +49,6 @@
 }
 
 /*
- * Disabled primary Dropdown needs same colors as Button.
- */
-.pf-c-dropdown__toggle.pf-m-primary[disabled] {
-    background-color: var(--pf-global--disabled-color--200);
-    color: var(--pf-global--disabled-color--100);
-}
-
-/* See also style rule to override classic opacity. */
-
-/*
  * ToggleGroupItem button that is disabled needs lighter background like any other form control.
  */
  button.pf-c-toggle-group__button:disabled {

--- a/ui/apps/platform/src/css/trumps.css
+++ b/ui/apps/platform/src/css/trumps.css
@@ -54,8 +54,8 @@ body {
     border-color: var(--pf-c-form-control--disabled--BorderColor) !important;
 }
 
-/* Override classic opacity: 0.5 for disabled toggle group buttons so they match disabled input elements. */
-button.pf-c-toggle-group__button:disabled {
+/* Override classic opacity: 0.5 for disabled buttons so they match disabled input elements. */
+.pf-c-page__main-section button:disabled {
     opacity: inherit;
 }
 


### PR DESCRIPTION
## Description

Small UI tweaks - one commit should be equal to one change. Details in testing section below: 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Collection tables have been updated to use the regular variant, instead of the compact variant:
![image](https://user-images.githubusercontent.com/1292638/212389374-76fc10bc-0319-477a-9a20-d80807bc4cea.png)
![image](https://user-images.githubusercontent.com/1292638/212389427-a04116b7-7484-476b-82b6-d3c741adc8d7.png)

Fix spacing of "OR" button to use margin instead of padding to prevent misshapen blue highlight.
<img width="838" alt="image" src="https://user-images.githubusercontent.com/1292638/212400066-d705a59a-a416-4cb2-ab63-d208b6fe315f.png">

Increased size and contrast of "In" separator labels:
![image](https://user-images.githubusercontent.com/1292638/212400226-4da9d483-0475-4cae-8be7-dccdfc350cbf.png)

Align expandable section chevrons with header text instead of centering (see above screenshot).

Align error state in results panel at top center of container:
![image](https://user-images.githubusercontent.com/1292638/212400542-a7b9b57d-af76-4b20-9e1b-2812f8698749.png)

Change "Delete" text to "Delete Collection" in modals:
![image](https://user-images.githubusercontent.com/1292638/212400630-1f7b2fe0-c466-4a8b-8250-61864b7a8cb1.png)

Increase contrast of "location" cluster/namespace text in results panel. (Note that these styles were taken from Violations - should we update styling there as well?)
![image](https://user-images.githubusercontent.com/1292638/212400813-3a677897-7c69-4a99-a652-19a4d63cd7fc.png)

Prevent line wrapping for empty state text in attachment section. (Note that 1200px is the screen size that constrains the center column the most).
![image](https://user-images.githubusercontent.com/1292638/212401707-890e29a7-8cc6-4a25-ae3a-16cf9fa41f31.png)

Update breakpoints to allow better sizing of components. This changes the cutoff for when the drawer overlaps to 1200px instead of the 992px, as well as adjusting sizing of smaller sub-components to allow for less cramped layout.  The sidebar has also been changed from a max width of 50% to a max width of 40%. The worst-case window size on desktop is now 1200px:
![image](https://user-images.githubusercontent.com/1292638/212409170-da9a4c05-74fa-4795-bd05-7a4e97641660.png)
Mobile view:
<img src="https://user-images.githubusercontent.com/1292638/212409278-fff43d90-60ad-4dc3-873b-0dabe0c37307.png" width="400px" />


Update global opacity override to avoid conflicts. This makes the disabled select dropdowns match the documented styles on the PatternFly site.
After this change:
![image](https://user-images.githubusercontent.com/1292638/212407219-3e6e9c4c-010e-48aa-ba80-cbd31962c68d.png)
Before this change:
![image](https://user-images.githubusercontent.com/1292638/212407283-572448a6-e768-443a-a038-fe73f575d6cc.png)
Disabled Policy "bulk action" dropdown after this change:
![image](https://user-images.githubusercontent.com/1292638/212407902-16ef71a9-1b1e-4729-ba89-e7f0056d030b.png)
Disabled Policy "bulk action" dropdown before this change:
![image](https://user-images.githubusercontent.com/1292638/212408092-8b3d10c3-3e5a-4f32-be1c-514210aca786.png)





