### PR TITLE
Do not refresh collection results if a form value is empty

### DIFF
--- a/ui/apps/platform/src/Containers/Collections/hooks/useDryRunConfiguration.ts
+++ b/ui/apps/platform/src/Containers/Collections/hooks/useDryRunConfiguration.ts
@@ -29,7 +29,14 @@ export default function useDryRunConfiguration(
                 nextConfig.resourceSelectors
             );
             const isNameChange = dryRunConfig.name !== nextConfig.name;
-            if (isEmbeddedCollectionsChanged || isResourceSelectorChanged || isNameChange) {
+            const hasEmptyValue = nextConfig.resourceSelectors
+                .flatMap((rs) => rs.rules)
+                .flatMap((rule) => rule.values)
+                .some(({ value }) => value === '');
+            if (
+                (isEmbeddedCollectionsChanged || isResourceSelectorChanged || isNameChange) &&
+                !hasEmptyValue
+            ) {
                 setDryRunConfig(nextConfig);
             }
         },


### PR DESCRIPTION
## Description

This prevents dry run requests from being sent when there is an empty value in the rules form. There are two situations where this occurs:
- When the user begins adding their first rule, and an empty text input field is added to the UI. (This always matches nothing.)
- When the user adds an additional rule value to an existing rule. (This always matches the same deployments that would be matched without the empty rule.)

Not sending the requests prevents additional work being done on the server, and results in less distraction for the user in the UI.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

From the create collection form, change any rule from "All <entity>" to a by name or by label value. No request will be sent:
<img width="1674" alt="image" src="https://user-images.githubusercontent.com/1292638/211860282-c99371a4-6841-4daa-888b-2657ae01e2b5.png">

Enter a value in the dropdown and ensure a request is sent to the server that returns matching deployments:
<img width="1674" alt="image" src="https://user-images.githubusercontent.com/1292638/211860403-c0c3978a-db3b-4710-9d9a-63770acfef74.png">

Add an additional value field and ensure that a new request is not sent until the field is filled:
<img width="1674" alt="image" src="https://user-images.githubusercontent.com/1292638/211860565-9c7b0dd6-f5d2-4db1-85ab-afaefb14e747.png">
<img width="1674" alt="image" src="https://user-images.githubusercontent.com/1292638/211860611-4e0be63d-753c-4230-ba42-0fd3f43bd34d.png">

