### PR TITLE
Add an explicit sidebar scroll in e2e collections test

### DIFF
--- a/ui/apps/platform/cypress/integration/collections/deploymentMatching.test.js
+++ b/ui/apps/platform/cypress/integration/collections/deploymentMatching.test.js
@@ -93,6 +93,7 @@ describe('Collection deployment matching', () => {
         assertDeploymentsAreNotMatched(['kube-dns']);
 
         // View more and ensure the next page loads
+        cy.get(`${selectors.resultsPanel} > div:last-child`).scrollTo('bottom');
         cy.get(selectors.viewMoreResultsButton).click();
         assertDeploymentsAreMatched(['kube-dns']);
 


### PR DESCRIPTION
## Description

Attempts to help debug why this test failed on `master`. https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/branch-ci-stackrox-stackrox-master-merge-gke-postgres-ui-e2e-tests/1613212206990626816

Video of failure: https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/branch-ci-stackrox-stackrox-master-merge-gke-postgres-ui-e2e-tests/1613212206990626816/artifacts/merge-gke-postgres-ui-e2e-tests/stackrox-e2e/artifacts/videos/collections/deploymentMatching.test.js.mp4

Jira issues:
https://issues.redhat.com/browse/ROX-14307
https://issues.redhat.com/browse/ROX-14308

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Local Cypress run.
