### PR TITLE
ROX-14286: Prevent VM report form submission when no days selected

### DIFF
--- a/ui/apps/platform/src/Components/PatternFly/DayPickerDropdown.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/DayPickerDropdown.tsx
@@ -38,7 +38,7 @@ function DayPickerDropdown({
     const selectOptions =
         intervalType === 'WEEKLY'
             ? [
-                  <SelectOption key="sunday" value="1">
+                  <SelectOption key="monday" value="1">
                       Monday
                   </SelectOption>,
                   <SelectOption key="tuesday" value="2">

--- a/ui/apps/platform/src/Containers/VulnMgmt/Reports/VulnMgmtReportForm.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Reports/VulnMgmtReportForm.tsx
@@ -202,9 +202,21 @@ function VulnMgmtReportForm({
         void setFieldValue(id, selection);
     }
 
+    // need a bespoke check that days are selected, because the way the PatternFly Select component is written,
+    // we cannot easily use the built-in Formik onBlur handler to update the Yup validation status
+    const areDaysSelected =
+        values.schedule.intervalType === 'WEEKLY'
+            ? Boolean(values.schedule?.daysOfWeek?.days?.length)
+            : Boolean(values.schedule?.daysOfMonth?.days?.length);
+
     return (
         <>
-            <PageSection variant={PageSectionVariants.light} isFilled hasOverflowScroll>
+            <PageSection
+                variant={PageSectionVariants.light}
+                isFilled
+                hasOverflowScroll
+                aria-label="Vulnerability Management Report Form"
+            >
                 <FormMessage message={message} />
                 <Form>
                     <Grid hasGutter>
@@ -410,7 +422,7 @@ function VulnMgmtReportForm({
                             variant={ButtonVariant.primary}
                             onClick={submitForm}
                             data-testid="create-btn"
-                            isDisabled={!dirty || !isValid || isSubmitting}
+                            isDisabled={!dirty || !isValid || isSubmitting || !areDaysSelected}
                             isLoading={isSubmitting}
                         >
                             {values.id ? 'Save' : 'Create'}


### PR DESCRIPTION
## Description

I thought it was just awkward to validate PatternFly Select, but after a while of looking for workarounds, I remembered why we didn't add validate to the Days option originally: PF Select with checkboxes fire events on the individual checkbox, instead of the parent Select component. Trying to build a workaround turned into a widening spiral of convoluted code.

So, this is the punt.

Just manually checking that the appropriate `days` array has at least one item selected, and using the result as an additional "validation" variable for disabling the form submission button.

(The check is based on different parts of the form values object, because that is how different day arrays are represented in our protobuf, depending on whether the interval is WEEKLY or MONTHLY.)

(Note: I also fixed two warnings that showed up in the browser console:
1. a key error in the list of weekdays
2. an accessibility warning about the PatternFly PageSection component)

## Checklist
- [x] Investigated and inspected CI test results

~Unit test and regression tests added~ 
See comment in `ui/apps/platform/cypress/integration/vulnmanagement/reporting/reportingForm.test.js` about how the same issue with PatternFly that prevents easy validation of the checkbox select, also prevents easy automated browser testing of it, too.

## Testing Performed

WEEKLY, no days selected, the submission button is disabled
![Screen Shot 2023-01-11 at 2 15 07 PM](https://user-images.githubusercontent.com/715729/211899887-ac9b97a3-8ff4-47d7-a53b-bd4f8dbdd719.png)

WEEKLY, with a day selected, the submission button is enabled
![Screen Shot 2023-01-11 at 2 15 12 PM](https://user-images.githubusercontent.com/715729/211899898-d03fc115-ef9b-42fb-af52-9756ae54449b.png)

MONTHLY, no days selected, the submission button is disabled
![Screen Shot 2023-01-11 at 2 14 51 PM](https://user-images.githubusercontent.com/715729/211899917-8a533789-bdc4-421a-a453-057e477a145d.png)

MONTHLY, with a day selected, the submission button is enabled
![Screen Shot 2023-01-11 at 2 14 58 PM](https://user-images.githubusercontent.com/715729/211899936-00ae7334-6eb8-42db-909d-1bf7474a19bb.png)

