### PR TITLE
Describe the upcoming `stable` operator channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 
 ### Technical Changes
 - ROX-12967: Re-introduce `rpm` to the main image in order to be able parse installed packages on RHCOS nodes (from Compliance container)
+- ROX-14280: ACS operator default channel changes from `latest` to `stable`. Users of older versions must follow the upgrade procedure in order to preserve ACS data in case of issues with the upgrade.
 
 ## [3.73.1]
 

--- a/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
@@ -727,24 +727,35 @@ spec:
     \ and remediation using the rich context Kubernetes provides.\n1. Increases scalability\
     \ and portability.\n1. Provides scalability and resiliency native to Kubernetes,\
     \ avoiding operational conflict and complexity that can result from out-of-band\
-    \ security controls.\n\n## Using the RHACS Operator\n\n**RHACS comes with two\
-    \ custom resources:**\n\n1. **Central Services** - Central is a deployment required\
-    \ on only one cluster in your environment. Users interact with RHACS via the user\
-    \ interface or APIs on Central. Central also sends notifications for violations\
-    \ and interacts with integrations. Users may select exposures for Central that\
-    \ best meet their environment.\n\n2. **Secured Cluster Services** - Secured cluster\
-    \ services are placed on each cluster you manage and report back to Central. These\
-    \ services allow users to enforce policies and monitor your OpenShift and Kubernetes\
-    \ clusters. Secured Cluster Services come as two Deployments (Sensor and Admission\
-    \ Controller) and one DaemonSet (Collector).\n\n### Central Services Explained\n\
-    \n| Service                          | Deployment Type | Description     |\n|\
-    \ :------------------------------- | :-------------- | :-------------- |\n| Central\
-    \                          | Deployment      | Users interact with Red Hat Advanced\
-    \ Cluster Security through the user interface or APIs on Central. Central also\
-    \ sends notifications for violations and interacts with integrations. |\n| Scanner\
-    \                          | Deployment      | Scanner is a Red Hat developed\
-    \ and certified image scanner. Scanner analyzes and reports vulnerabilities for\
-    \ images. Scanner uses HPA to scale the number of replicas based on workload.\
+    \ security controls.\n\n## Using the RHACS Operator\n\n**RHACS Operator channels:**\n\
+    \nRHACS Operator is provided through the following update Channels in the Red\
+    \ Hat Operator catalog:\n\n* `stable` - provides the most recent version and patches\
+    \ to the most recent versions.\n  Using the `stable` channel and configuring Automatic\
+    \ operator upgrades will ensure that most recent RHACS version is deployed.\n\
+    * `rhacs-x.yy` (e.g. `rhacs-3.74`) - channels follow a specific RHACS version\
+    \ and include all patches to that version (e.g. `3.74.0`, `3.74.1`, ...)\n\nNote\
+    \ that the `latest` channel is deprecated and will not get updates after the version\
+    \ 3.73.\n\n**RHACS comes with two custom resources:**\n\n1. **Central Services**\
+    \ - Central is a deployment required on only one cluster in your environment.\
+    \ Users interact with RHACS via the user interface or APIs on Central. Central\
+    \ also sends notifications for violations and interacts with integrations. Users\
+    \ may select exposures for Central that best meet their environment.\n\n2. **Secured\
+    \ Cluster Services** - Secured cluster services are placed on each cluster you\
+    \ manage and report back to Central. These services allow users to enforce policies\
+    \ and monitor your OpenShift and Kubernetes clusters. Secured Cluster Services\
+    \ come as two Deployments (Sensor and Admission Controller) and one DaemonSet\
+    \ (Collector).\n\n### Central Services Explained\n\n| Service                \
+    \          | Deployment Type | Description     |\n| :-------------------------------\
+    \ | :-------------- | :-------------- |\n| Central                          |\
+    \ Deployment      | Users interact with Red Hat Advanced Cluster Security through\
+    \ the user interface or APIs on Central. Central also sends notifications for\
+    \ violations and interacts with integrations. |\n| Central DB                \
+    \       | Deployment      | Central DB is a PostgreSQL-based persistent storage\
+    \ for the data collected and managed by Central. RHACS can be configured to use\
+    \ external PostgreSQL database instead of the operator-managed Central DB deployment.\
+    \ |\n| Scanner                          | Deployment      | Scanner is a Red Hat\
+    \ developed and certified image scanner. Scanner analyzes and reports vulnerabilities\
+    \ for images. Scanner uses HPA to scale the number of replicas based on workload.\
     \ |\n| Scanner DB                       | Deployment      | Scanner DB is a cache\
     \ for vulnerability definitions to serve vulnerability scanning use cases throughout\
     \ the software development life cycle. |\n\n### Secured Cluster Services Explained\n\

--- a/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
@@ -728,57 +728,58 @@ spec:
     \ and portability.\n1. Provides scalability and resiliency native to Kubernetes,\
     \ avoiding operational conflict and complexity that can result from out-of-band\
     \ security controls.\n\n## Using the RHACS Operator\n\n**RHACS Operator channels:**\n\
-    \nRHACS Operator is provided through the following update Channels in the Red\
-    \ Hat Operator catalog:\n\n* `stable` - provides the most recent version and patches\
-    \ to the most recent versions.\n  Using the `stable` channel and configuring Automatic\
-    \ operator upgrades will ensure that most recent RHACS version is deployed.\n\
-    * `rhacs-x.yy` (e.g. `rhacs-3.74`) - channels follow a specific RHACS version\
-    \ and include all patches to that version (e.g. `3.74.0`, `3.74.1`, ...)\n\nNote\
-    \ that the `latest` channel is deprecated and will not get updates after the version\
-    \ 3.73.\n\n**RHACS comes with two custom resources:**\n\n1. **Central Services**\
-    \ - Central is a deployment required on only one cluster in your environment.\
-    \ Users interact with RHACS via the user interface or APIs on Central. Central\
-    \ also sends notifications for violations and interacts with integrations. Users\
-    \ may select exposures for Central that best meet their environment.\n\n2. **Secured\
-    \ Cluster Services** - Secured cluster services are placed on each cluster you\
-    \ manage and report back to Central. These services allow users to enforce policies\
-    \ and monitor your OpenShift and Kubernetes clusters. Secured Cluster Services\
-    \ come as two Deployments (Sensor and Admission Controller) and one DaemonSet\
-    \ (Collector).\n\n### Central Services Explained\n\n| Service                \
-    \          | Deployment Type | Description     |\n| :-------------------------------\
-    \ | :-------------- | :-------------- |\n| Central                          |\
-    \ Deployment      | Users interact with Red Hat Advanced Cluster Security through\
-    \ the user interface or APIs on Central. Central also sends notifications for\
-    \ violations and interacts with integrations. |\n| Central DB                \
-    \       | Deployment      | Central DB is a PostgreSQL-based persistent storage\
-    \ for the data collected and managed by Central. |\n| Scanner                \
-    \          | Deployment      | Scanner is a Red Hat developed and certified image\
-    \ scanner. Scanner analyzes and reports vulnerabilities for images. Scanner uses\
-    \ HPA to scale the number of replicas based on workload. |\n| Scanner DB     \
-    \                  | Deployment      | Scanner DB is a cache for vulnerability\
-    \ definitions to serve vulnerability scanning use cases throughout the software\
-    \ development life cycle. |\n\n### Secured Cluster Services Explained\n\n| Service\
-    \                          | Deployment Type | Description     |\n| :-------------------------------\
-    \ | :-------------- | :-------------- |\n| Sensor                           |\
-    \ Deployment      | Sensor analyzes and monitors Kubernetes in secured clusters.\
-    \ |\n| Collector                        | DaemonSet       | Analyzes and monitors\
-    \ container activity on Kubernetes nodes.|\n| Admission Controller           \
-    \  | Deployment      | ValidatingWebhookConfiguration for enforcing policies in\
-    \ the deploy lifecycle. |\n\n### Central Custom Resource\n\nCentral Services is\
-    \ the configuration template for RHACS Central deployment. For all customization\
-    \ options, please visit the RHACS documentation.\n\n### SecuredCluster Custom\
-    \ Resource\n\nSecuredCluster is the configuration template for the RHACS Secured\
-    \ Cluster services.\n\n#### Installation Prerequisites\n\nBefore deploying a SecuredCluster\
-    \ resource, you need to create a cluster init bundle secret.\n\n- **Through the\
-    \ RHACS UI:** To create a cluster init bundle secret through the RHACS UI, navigate\
-    \ to `Platform Configuration > Clusters`, and then click `Manage Tokens` in the\
-    \ top-right corner. Select `Cluster Init Bundle`, and click `Generate Bundle`.\
-    \ Select `Download Kubernetes secrets file`, and store the file under a name of\
-    \ your choice (for example, `cluster-init-secrets.yaml`).\n- **Through the `roxctl`\
-    \ CLI:** To create a cluster init bundle secret through the `roxctl` command-line\
-    \ interface, run `roxctl central init-bundles generate <name> --output-secrets\
-    \ <file name>`. Choose any `name` and `file name` that you like.\n\nRun `oc project`\
-    \ and check that it reports the correct namespace where you intend to deploy SecuredCluster.\
+    \nThe RHACS Operator is provided through the following update channels in the\
+    \ Red Hat Operator catalog:\n\n* `stable`: Provides the most recent version and\
+    \ patches to the most recent versions.\n  Using the `stable` channel and configuring\
+    \ automatic operator upgrades ensures that the most recent RHACS version is deployed.\n\
+    * `rhacs-x.yy` (for example, `rhacs-3.73`): Channels follow a specific RHACS version\
+    \ and include all patches to that version (e.g. `3.73.0`, `3.73.1`, ...).\n\n\
+    Note that the `latest` channel is deprecated and is not updated after RHACS version\
+    \ 3.73. Newer versions are published to the `stable` channel.\n\n**RHACS comes\
+    \ with two custom resources:**\n\n1. **Central Services** - Central is a deployment\
+    \ required on only one cluster in your environment. Users interact with RHACS\
+    \ via the user interface or APIs on Central. Central also sends notifications\
+    \ for violations and interacts with integrations. Users may select exposures for\
+    \ Central that best meet their environment.\n\n2. **Secured Cluster Services**\
+    \ - Secured cluster services are placed on each cluster you manage and report\
+    \ back to Central. These services allow users to enforce policies and monitor\
+    \ your OpenShift and Kubernetes clusters. Secured Cluster Services come as two\
+    \ Deployments (Sensor and Admission Controller) and one DaemonSet (Collector).\n\
+    \n### Central Services Explained\n\n| Service                          | Deployment\
+    \ Type | Description     |\n| :------------------------------- | :--------------\
+    \ | :-------------- |\n| Central                          | Deployment      |\
+    \ Users interact with Red Hat Advanced Cluster Security through the user interface\
+    \ or APIs on Central. Central also sends notifications for violations and interacts\
+    \ with integrations. |\n| Central DB                       | Deployment      |\
+    \ Central DB is a PostgreSQL-based persistent storage for the data collected and\
+    \ managed by Central. |\n| Scanner                          | Deployment     \
+    \ | Scanner is a Red Hat developed and certified image scanner. Scanner analyzes\
+    \ and reports vulnerabilities for images. Scanner uses HPA to scale the number\
+    \ of replicas based on workload. |\n| Scanner DB                       | Deployment\
+    \      | Scanner DB is a cache for vulnerability definitions to serve vulnerability\
+    \ scanning use cases throughout the software development life cycle. |\n\n###\
+    \ Secured Cluster Services Explained\n\n| Service                          | Deployment\
+    \ Type | Description     |\n| :------------------------------- | :--------------\
+    \ | :-------------- |\n| Sensor                           | Deployment      |\
+    \ Sensor analyzes and monitors Kubernetes in secured clusters. |\n| Collector\
+    \                        | DaemonSet       | Analyzes and monitors container activity\
+    \ on Kubernetes nodes.|\n| Admission Controller             | Deployment     \
+    \ | ValidatingWebhookConfiguration for enforcing policies in the deploy lifecycle.\
+    \ |\n\n### Central Custom Resource\n\nCentral Services is the configuration template\
+    \ for RHACS Central deployment. For all customization options, please visit the\
+    \ RHACS documentation.\n\n### SecuredCluster Custom Resource\n\nSecuredCluster\
+    \ is the configuration template for the RHACS Secured Cluster services.\n\n####\
+    \ Installation Prerequisites\n\nBefore deploying a SecuredCluster resource, you\
+    \ need to create a cluster init bundle secret.\n\n- **Through the RHACS UI:**\
+    \ To create a cluster init bundle secret through the RHACS UI, navigate to `Platform\
+    \ Configuration > Clusters`, and then click `Manage Tokens` in the top-right corner.\
+    \ Select `Cluster Init Bundle`, and click `Generate Bundle`. Select `Download\
+    \ Kubernetes secrets file`, and store the file under a name of your choice (for\
+    \ example, `cluster-init-secrets.yaml`).\n- **Through the `roxctl` CLI:** To create\
+    \ a cluster init bundle secret through the `roxctl` command-line interface, run\
+    \ `roxctl central init-bundles generate <name> --output-secrets <file name>`.\
+    \ Choose any `name` and `file name` that you like.\n\nRun `oc project` and check\
+    \ that it reports the correct namespace where you intend to deploy SecuredCluster.\
     \ In case you want to install SecuredCluster to a different namespace, select\
     \ it by running `oc project <namespace>`.\nThen, run `oc create -f init-bundle.yaml`.\
     \ If you have chosen a name other than `init-bundle.yaml`, specify that file name\

--- a/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
@@ -730,7 +730,7 @@ spec:
     \ security controls.\n\n## Using the RHACS Operator\n\n**RHACS Operator channels:**\n\
     \nThe RHACS Operator is provided through the following update channels in the\
     \ Red Hat Operator catalog:\n\n* `stable`: Provides the most recent version and\
-    \ patches to the most recent versions.\n  Using the `stable` channel and configuring\
+    \ patches to the most recent version.\n  Using the `stable` channel and configuring\
     \ automatic operator upgrades ensures that the most recent RHACS version is deployed.\n\
     * `rhacs-x.yy` (for example, `rhacs-3.73`): Channels follow a specific RHACS version\
     \ and include all patches to that version (e.g. `3.73.0`, `3.73.1`, ...).\n\n\

--- a/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
@@ -728,9 +728,9 @@ spec:
     \ and portability.\n1. Provides scalability and resiliency native to Kubernetes,\
     \ avoiding operational conflict and complexity that can result from out-of-band\
     \ security controls.\n\n## Using the RHACS Operator\n\n**RHACS Operator channels:**\n\
-    \nThe RHACS Operator is provided through the following update channels in the\
-    \ Red Hat Operator catalog:\n\n* `stable`: Provides the most recent version and\
-    \ patches to the most recent version.\n  Using the `stable` channel and configuring\
+    \nRed Hat provides the RHACS Operator by using the following update channels in\
+    \ the Red Hat Operator catalog:\n\n* `stable`: Provides the most recent version\
+    \ and patches to the most recent version.\n  Using the `stable` channel and configuring\
     \ automatic operator upgrades ensures that the most recent RHACS version is deployed.\n\
     * `rhacs-x.yy` (for example, `rhacs-3.73`): Channels follow a specific RHACS version\
     \ and include all patches to that version (e.g. `3.73.0`, `3.73.1`, ...).\n\n\

--- a/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
@@ -751,45 +751,44 @@ spec:
     \ the user interface or APIs on Central. Central also sends notifications for\
     \ violations and interacts with integrations. |\n| Central DB                \
     \       | Deployment      | Central DB is a PostgreSQL-based persistent storage\
-    \ for the data collected and managed by Central. RHACS can be configured to use\
-    \ external PostgreSQL database instead of the operator-managed Central DB deployment.\
-    \ |\n| Scanner                          | Deployment      | Scanner is a Red Hat\
-    \ developed and certified image scanner. Scanner analyzes and reports vulnerabilities\
-    \ for images. Scanner uses HPA to scale the number of replicas based on workload.\
-    \ |\n| Scanner DB                       | Deployment      | Scanner DB is a cache\
-    \ for vulnerability definitions to serve vulnerability scanning use cases throughout\
-    \ the software development life cycle. |\n\n### Secured Cluster Services Explained\n\
-    \n| Service                          | Deployment Type | Description     |\n|\
-    \ :------------------------------- | :-------------- | :-------------- |\n| Sensor\
-    \                           | Deployment      | Sensor analyzes and monitors Kubernetes\
-    \ in secured clusters. |\n| Collector                        | DaemonSet     \
-    \  | Analyzes and monitors container activity on Kubernetes nodes.|\n| Admission\
-    \ Controller             | Deployment      | ValidatingWebhookConfiguration for\
-    \ enforcing policies in the deploy lifecycle. |\n\n### Central Custom Resource\n\
-    \nCentral Services is the configuration template for RHACS Central deployment.\
-    \ For all customization options, please visit the RHACS documentation.\n\n###\
-    \ SecuredCluster Custom Resource\n\nSecuredCluster is the configuration template\
-    \ for the RHACS Secured Cluster services.\n\n#### Installation Prerequisites\n\
-    \nBefore deploying a SecuredCluster resource, you need to create a cluster init\
-    \ bundle secret.\n\n- **Through the RHACS UI:** To create a cluster init bundle\
-    \ secret through the RHACS UI, navigate to `Platform Configuration > Clusters`,\
-    \ and then click `Manage Tokens` in the top-right corner. Select `Cluster Init\
-    \ Bundle`, and click `Generate Bundle`. Select `Download Kubernetes secrets file`,\
-    \ and store the file under a name of your choice (for example, `cluster-init-secrets.yaml`).\n\
-    - **Through the `roxctl` CLI:** To create a cluster init bundle secret through\
-    \ the `roxctl` command-line interface, run `roxctl central init-bundles generate\
-    \ <name> --output-secrets <file name>`. Choose any `name` and `file name` that\
-    \ you like.\n\nRun `oc project` and check that it reports the correct namespace\
-    \ where you intend to deploy SecuredCluster. In case you want to install SecuredCluster\
-    \ to a different namespace, select it by running `oc project <namespace>`.\nThen,\
-    \ run `oc create -f init-bundle.yaml`. If you have chosen a name other than `init-bundle.yaml`,\
-    \ specify that file name instead.\n\n#### Required Fields\n\nThe following attributes\
-    \ are required to be specified. For all customization options, please visit the\
-    \ RHACS documentation.\n\n| Parameter          | Description     |\n| :-----------------\
-    \ | :-------------- |\n| `clusterName`      | The name given to this secured cluster.\
-    \ The cluster will appear with this name in RHACS user interface. |\n| `centralEndpoint`\
-    \  | This field should specify the address of the Central endpoint, including\
-    \ the port number. `centralEndpoint` may be omitted if this SecuredCluster Custom\
+    \ for the data collected and managed by Central. |\n| Scanner                \
+    \          | Deployment      | Scanner is a Red Hat developed and certified image\
+    \ scanner. Scanner analyzes and reports vulnerabilities for images. Scanner uses\
+    \ HPA to scale the number of replicas based on workload. |\n| Scanner DB     \
+    \                  | Deployment      | Scanner DB is a cache for vulnerability\
+    \ definitions to serve vulnerability scanning use cases throughout the software\
+    \ development life cycle. |\n\n### Secured Cluster Services Explained\n\n| Service\
+    \                          | Deployment Type | Description     |\n| :-------------------------------\
+    \ | :-------------- | :-------------- |\n| Sensor                           |\
+    \ Deployment      | Sensor analyzes and monitors Kubernetes in secured clusters.\
+    \ |\n| Collector                        | DaemonSet       | Analyzes and monitors\
+    \ container activity on Kubernetes nodes.|\n| Admission Controller           \
+    \  | Deployment      | ValidatingWebhookConfiguration for enforcing policies in\
+    \ the deploy lifecycle. |\n\n### Central Custom Resource\n\nCentral Services is\
+    \ the configuration template for RHACS Central deployment. For all customization\
+    \ options, please visit the RHACS documentation.\n\n### SecuredCluster Custom\
+    \ Resource\n\nSecuredCluster is the configuration template for the RHACS Secured\
+    \ Cluster services.\n\n#### Installation Prerequisites\n\nBefore deploying a SecuredCluster\
+    \ resource, you need to create a cluster init bundle secret.\n\n- **Through the\
+    \ RHACS UI:** To create a cluster init bundle secret through the RHACS UI, navigate\
+    \ to `Platform Configuration > Clusters`, and then click `Manage Tokens` in the\
+    \ top-right corner. Select `Cluster Init Bundle`, and click `Generate Bundle`.\
+    \ Select `Download Kubernetes secrets file`, and store the file under a name of\
+    \ your choice (for example, `cluster-init-secrets.yaml`).\n- **Through the `roxctl`\
+    \ CLI:** To create a cluster init bundle secret through the `roxctl` command-line\
+    \ interface, run `roxctl central init-bundles generate <name> --output-secrets\
+    \ <file name>`. Choose any `name` and `file name` that you like.\n\nRun `oc project`\
+    \ and check that it reports the correct namespace where you intend to deploy SecuredCluster.\
+    \ In case you want to install SecuredCluster to a different namespace, select\
+    \ it by running `oc project <namespace>`.\nThen, run `oc create -f init-bundle.yaml`.\
+    \ If you have chosen a name other than `init-bundle.yaml`, specify that file name\
+    \ instead.\n\n#### Required Fields\n\nThe following attributes are required to\
+    \ be specified. For all customization options, please visit the RHACS documentation.\n\
+    \n| Parameter          | Description     |\n| :----------------- | :--------------\
+    \ |\n| `clusterName`      | The name given to this secured cluster. The cluster\
+    \ will appear with this name in RHACS user interface. |\n| `centralEndpoint` \
+    \ | This field should specify the address of the Central endpoint, including the\
+    \ port number. `centralEndpoint` may be omitted if this SecuredCluster Custom\
     \ Resource is in the same cluster and namespace as Central. |\n"
   displayName: Advanced Cluster Security for Kubernetes
   icon:

--- a/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
@@ -722,7 +722,7 @@ spec:
 
     The RHACS Operator is provided through the following update channels in the Red Hat Operator catalog:
 
-    * `stable`: Provides the most recent version and patches to the most recent versions.
+    * `stable`: Provides the most recent version and patches to the most recent version.
       Using the `stable` channel and configuring automatic operator upgrades ensures that the most recent RHACS version is deployed.
     * `rhacs-x.yy` (for example, `rhacs-3.73`): Channels follow a specific RHACS version and include all patches to that version (e.g. `3.73.0`, `3.73.1`, ...).
 

--- a/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
@@ -739,7 +739,7 @@ spec:
     | Service                          | Deployment Type | Description     |
     | :------------------------------- | :-------------- | :-------------- |
     | Central                          | Deployment      | Users interact with Red Hat Advanced Cluster Security through the user interface or APIs on Central. Central also sends notifications for violations and interacts with integrations. |
-    | Central DB                       | Deployment      | Central DB is a PostgreSQL-based persistent storage for the data collected and managed by Central. RHACS can be configured to use external PostgreSQL database instead of the operator-managed Central DB deployment. |
+    | Central DB                       | Deployment      | Central DB is a PostgreSQL-based persistent storage for the data collected and managed by Central. |
     | Scanner                          | Deployment      | Scanner is a Red Hat developed and certified image scanner. Scanner analyzes and reports vulnerabilities for images. Scanner uses HPA to scale the number of replicas based on workload. |
     | Scanner DB                       | Deployment      | Scanner DB is a cache for vulnerability definitions to serve vulnerability scanning use cases throughout the software development life cycle. |
 

--- a/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
@@ -724,9 +724,9 @@ spec:
 
     * `stable`: Provides the most recent version and patches to the most recent versions.
       Using the `stable` channel and configuring automatic operator upgrades ensures that the most recent RHACS version is deployed.
-    * `rhacs-x.yy` (for example, `rhacs-3.74`): Channels follow a specific RHACS version and include all patches to that version (e.g. `3.74.0`, `3.74.1`, ...).
+    * `rhacs-x.yy` (for example, `rhacs-3.73`): Channels follow a specific RHACS version and include all patches to that version (e.g. `3.73.0`, `3.73.1`, ...).
 
-    Note that the `latest` channel is deprecated and is not updated after RHACS version 3.73.
+    Note that the `latest` channel is deprecated and is not updated after RHACS version 3.73. Newer versions are published to the `stable` channel.
 
     **RHACS comes with two custom resources:**
 

--- a/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
@@ -718,6 +718,16 @@ spec:
 
     ## Using the RHACS Operator
 
+    **RHACS Operator channels:**
+
+    RHACS Operator is provided through the following update Channels in the Red Hat Operator catalog:
+
+    * `stable` - provides the most recent version and patches to the most recent versions.
+      Using the `stable` channel and configuring Automatic operator upgrades will ensure that most recent RHACS version is deployed.
+    * `rhacs-x.yy` (e.g. `rhacs-3.74`) - channels follow a specific RHACS version and include all patches to that version (e.g. `3.74.0`, `3.74.1`, ...)
+
+    Note that the `latest` channel is deprecated and will not get updates after the version 3.73.
+
     **RHACS comes with two custom resources:**
 
     1. **Central Services** - Central is a deployment required on only one cluster in your environment. Users interact with RHACS via the user interface or APIs on Central. Central also sends notifications for violations and interacts with integrations. Users may select exposures for Central that best meet their environment.
@@ -729,6 +739,7 @@ spec:
     | Service                          | Deployment Type | Description     |
     | :------------------------------- | :-------------- | :-------------- |
     | Central                          | Deployment      | Users interact with Red Hat Advanced Cluster Security through the user interface or APIs on Central. Central also sends notifications for violations and interacts with integrations. |
+    | Central DB                       | Deployment      | Central DB is a PostgreSQL-based persistent storage for the data collected and managed by Central. RHACS can be configured to use external PostgreSQL database instead of the operator-managed Central DB deployment. |
     | Scanner                          | Deployment      | Scanner is a Red Hat developed and certified image scanner. Scanner analyzes and reports vulnerabilities for images. Scanner uses HPA to scale the number of replicas based on workload. |
     | Scanner DB                       | Deployment      | Scanner DB is a cache for vulnerability definitions to serve vulnerability scanning use cases throughout the software development life cycle. |
 

--- a/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
@@ -722,7 +722,7 @@ spec:
 
     The RHACS Operator is provided through the following update channels in the Red Hat Operator catalog:
 
-    * `stable` - provides the most recent version and patches to the most recent versions.
+    * `stable`: Provides the most recent version and patches to the most recent versions.
       Using the `stable` channel and configuring automatic operator upgrades ensures that the most recent RHACS version is deployed.
     * `rhacs-x.yy` (for example, `rhacs-3.74`): Channels follow a specific RHACS version and include all patches to that version (e.g. `3.74.0`, `3.74.1`, ...).
 

--- a/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
@@ -726,7 +726,7 @@ spec:
       Using the `stable` channel and configuring automatic operator upgrades ensures that the most recent RHACS version is deployed.
     * `rhacs-x.yy` (for example, `rhacs-3.74`): Channels follow a specific RHACS version and include all patches to that version (e.g. `3.74.0`, `3.74.1`, ...).
 
-    Note that the `latest` channel is deprecated and will not get updates after the version 3.73.
+    Note that the `latest` channel is deprecated and is not updated after RHACS version 3.73.
 
     **RHACS comes with two custom resources:**
 

--- a/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
@@ -724,7 +724,7 @@ spec:
 
     * `stable` - provides the most recent version and patches to the most recent versions.
       Using the `stable` channel and configuring automatic operator upgrades ensures that the most recent RHACS version is deployed.
-    * `rhacs-x.yy` (e.g. `rhacs-3.74`) - channels follow a specific RHACS version and include all patches to that version (e.g. `3.74.0`, `3.74.1`, ...)
+    * `rhacs-x.yy` (for example, `rhacs-3.74`): Channels follow a specific RHACS version and include all patches to that version (e.g. `3.74.0`, `3.74.1`, ...).
 
     Note that the `latest` channel is deprecated and will not get updates after the version 3.73.
 

--- a/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
@@ -720,7 +720,7 @@ spec:
 
     **RHACS Operator channels:**
 
-    RHACS Operator is provided through the following update Channels in the Red Hat Operator catalog:
+    The RHACS Operator is provided through the following update channels in the Red Hat Operator catalog:
 
     * `stable` - provides the most recent version and patches to the most recent versions.
       Using the `stable` channel and configuring Automatic operator upgrades will ensure that most recent RHACS version is deployed.

--- a/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
@@ -723,7 +723,7 @@ spec:
     The RHACS Operator is provided through the following update channels in the Red Hat Operator catalog:
 
     * `stable` - provides the most recent version and patches to the most recent versions.
-      Using the `stable` channel and configuring Automatic operator upgrades will ensure that most recent RHACS version is deployed.
+      Using the `stable` channel and configuring automatic operator upgrades ensures that the most recent RHACS version is deployed.
     * `rhacs-x.yy` (e.g. `rhacs-3.74`) - channels follow a specific RHACS version and include all patches to that version (e.g. `3.74.0`, `3.74.1`, ...)
 
     Note that the `latest` channel is deprecated and will not get updates after the version 3.73.

--- a/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
@@ -720,7 +720,7 @@ spec:
 
     **RHACS Operator channels:**
 
-    The RHACS Operator is provided through the following update channels in the Red Hat Operator catalog:
+    Red Hat provides the RHACS Operator by using the following update channels in the Red Hat Operator catalog:
 
     * `stable`: Provides the most recent version and patches to the most recent version.
       Using the `stable` channel and configuring automatic operator upgrades ensures that the most recent RHACS version is deployed.


### PR DESCRIPTION
## Description

This also tells that `latest` is deprecated.

Done as part of https://issues.redhat.com/browse/ROX-14280

## Checklist
- [x] Investigated and inspected CI test results
- [x] Evaluated and added CHANGELOG entry if required

None of these will be done:
- ~~[ ] Unit test and regression tests added~~
- ~~[ ] Determined and documented upgrade steps~~
- ~~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

## Testing Performed

Here's how the operator description looks in the OpenShift console:
(the picture may be stale few commits, will update the screenshot on demand)
![image](https://user-images.githubusercontent.com/537715/212327174-c6a19ae2-506f-4096-a5f9-d58d98b74b5c.png)

