### PR TITLE
ROX-14313:  Use real data for External entities side panel

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/externalEntities/ExternalEntitiesSideBar.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/externalEntities/ExternalEntitiesSideBar.tsx
@@ -13,10 +13,15 @@ import {
     ToolbarItem,
 } from '@patternfly/react-core';
 
+import { useVisualizationController } from '@patternfly/react-topology';
 import { getNodeById } from '../utils/networkGraphUtils';
-import { getAllUniquePorts, getNumFlows } from '../utils/flowUtils';
+import {
+    filterNetworkFlows,
+    getAllUniquePorts,
+    getNetworkFlows,
+    getNumFlows,
+} from '../utils/flowUtils';
 import { AdvancedFlowsFilterType } from '../common/AdvancedFlowsFilter/types';
-import { Flow } from '../types/flow.type';
 import { CustomEdgeModel, CustomNodeModel } from '../types/topology.type';
 
 import { ExternalEntitiesIcon } from '../common/NetworkGraphIcons';
@@ -33,71 +38,17 @@ type ExternalEntitiesSideBarProps = {
     edges: CustomEdgeModel[];
 };
 
-const flows: Flow[] = [
-    {
-        id: 'Deployment 1-naples-Ingress-Many-TCP',
-        type: 'Deployment',
-        entity: 'Deployment 1',
-        namespace: 'naples',
-        direction: 'Bi-directional',
-        port: 'MANY',
-        protocol: 'TCP',
-        isAnomalous: true,
-        children: [
-            {
-                id: 'Deployment 1-naples-Ingress-Many-TCP',
-                type: 'Deployment',
-                entity: 'Deployment 1',
-                namespace: 'naples',
-                direction: 'Egress',
-                port: '9000',
-                protocol: 'TCP',
-                isAnomalous: true,
-            },
-            {
-                id: 'Deployment 1-naples-Ingress-Many-TCP',
-                type: 'Deployment',
-                entity: 'Deployment 1',
-                namespace: 'naples',
-                direction: 'Ingress',
-                port: '8000',
-                protocol: 'TCP',
-                isAnomalous: true,
-            },
-        ],
-    },
-    {
-        id: 'Deployment 2-naples-Ingress-Many-UDP',
-        type: 'Deployment',
-        entity: 'Deployment 2',
-        namespace: 'naples',
-        direction: 'Ingress',
-        port: '8080',
-        protocol: 'UDP',
-        isAnomalous: true,
-        children: [],
-    },
-    {
-        id: 'Deployment 3-naples-Egress-7777-UDP',
-        type: 'Deployment',
-        entity: 'Deployment 3',
-        namespace: 'naples',
-        direction: 'Egress',
-        port: '7777',
-        protocol: 'UDP',
-        isAnomalous: true,
-        children: [],
-    },
-];
-
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 function ExternalEntitiesSideBar({ id, nodes, edges }: ExternalEntitiesSideBarProps): ReactElement {
+    const controller = useVisualizationController();
     // component state
     const [entityNameFilter, setEntityNameFilter] = React.useState<string>('');
     const [advancedFilters, setAdvancedFilters] = React.useState<AdvancedFlowsFilterType>(
         defaultAdvancedFlowsFilters
     );
-    const initialExpandedRows = flows
+    const flows = getNetworkFlows(edges, controller, id);
+    const filteredFlows = filterNetworkFlows(flows, entityNameFilter, advancedFilters);
+    const initialExpandedRows = filteredFlows
         .filter((row) => row.children && !!row.children.length)
         .map((row) => row.id); // Default to all expanded
     const [expandedRows, setExpandedRows] = React.useState<string[]>(initialExpandedRows);
@@ -105,8 +56,8 @@ function ExternalEntitiesSideBar({ id, nodes, edges }: ExternalEntitiesSideBarPr
 
     // derived data
     const externalEntitiesNode = getNodeById(nodes, id);
-    const numFlows = getNumFlows(flows);
-    const allUniquePorts = getAllUniquePorts(flows);
+    const numFlows = getNumFlows(filteredFlows);
+    const allUniquePorts = getAllUniquePorts(filteredFlows);
 
     return (
         <Stack>
@@ -164,7 +115,7 @@ function ExternalEntitiesSideBar({ id, nodes, edges }: ExternalEntitiesSideBarPr
                     <StackItem>
                         <FlowsTable
                             label="External entities flows"
-                            flows={flows}
+                            flows={filteredFlows}
                             numFlows={numFlows}
                             expandedRows={expandedRows}
                             setExpandedRows={setExpandedRows}


### PR DESCRIPTION
## Description

This PR uses real data for the External entities side panel. This uses the functions introduced in this PR https://github.com/stackrox/stackrox/pull/4354 to create network flows from edges and allows filtering those network flows

<img width="1439" alt="Screenshot 2023-01-11 at 12 45 50 PM" src="https://user-images.githubusercontent.com/4805485/211914181-8c0b6c97-aa67-4302-8fff-5777d7cc552a.png">

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~
