### PR TITLE
Fix protoc download arch on arm64

### DIFF
--- a/make/protogen.mk
+++ b/make/protogen.mk
@@ -42,7 +42,7 @@ endif
 ifeq ($(UNAME_S),Darwin)
 PROTOC_OS = osx
 endif
-PROTOC_ARCH=$(shell case $$(uname -m) in (aarch64) echo armv6 ;; (*) uname -m ;; esac)
+PROTOC_ARCH=$(shell case $$(uname -m) in (arm64) echo aarch_64 ;; (*) uname -m ;; esac)
 
 PROTO_PRIVATE_DIR := $(BASE_PATH)/.proto
 


### PR DESCRIPTION
## Description

The arch packages is in the format of aarch_64 instead of arm64. This PR fix the protoc download for Apple M1 local building.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on ([openshift/openshift-docs](https://github.com/openshift/openshift-docs))) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~
If any of these don't apply, please comment below.

## Testing Performed
Local build on Apple M1 Monterey

![Screen Shot 2023-01-11 at 3 45 30 PM](https://user-images.githubusercontent.com/19808978/211943745-9a28e440-70a8-4b7b-9c73-13ec03e38bd1.png)
