### PR TITLE
Do not install recomended packages

### DIFF
--- a/image/postgres/Dockerfile.envsubst
+++ b/image/postgres/Dockerfile.envsubst
@@ -28,18 +28,18 @@ COPY --from=extracted_bundle /bundle/postgres.rpm /bundle/postgres-libs.rpm /bun
 
 RUN microdnf upgrade -y --nobest && \
     # groupadd is in shadow-utils package that is not installed by default.
-    microdnf install -y shadow-utils && \
+    microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y shadow-utils && \
     groupadd -g 70 postgres && \
     adduser postgres -u 70 -g 70 -d /var/lib/postgresql -s /bin/sh && \
     rpm --import RPM-GPG-KEY-PGDG-13 && \
-    microdnf install -y \
+    microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y \
         ca-certificates libicu systemd-sysv \
         glibc-locale-source glibc-langpack-en \
         perl-libs libxslt && \
     rpm -i /tmp/postgres-libs.rpm /tmp/postgres-server.rpm /tmp/postgres.rpm /tmp/postgres-contrib.rpm && \
     # Restore /usr/share/zoneinfo that's empty in ubi-minimal because postgres reads timezone data from it.
     # https://access.redhat.com/solutions/5616681
-    microdnf reinstall tzdata && \
+    microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs reinstall tzdata && \
     microdnf clean all && \
     rpm -e --nodeps $(rpm -qa curl '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*') && \
     rm -rf /var/cache/dnf /var/cache/yum && \

--- a/image/rhel/Dockerfile.envsubst
+++ b/image/rhel/Dockerfile.envsubst
@@ -51,7 +51,7 @@ RUN ln -s entrypoint-wrapper.sh /stackrox/admission-control && \
     rpm -i /tmp/snappy.rpm && \
     rpm -i --nodeps /tmp/postgres-libs.rpm && \
     rpm -i --nodeps /tmp/postgres.rpm && \
-    microdnf install lz4 bzip2 util-linux && \
+    microdnf install --setopt=install_weak_deps=0 --setopt=tsflags=nodocs lz4 bzip2 util-linux && \
     microdnf clean all && \
     rm /tmp/snappy.rpm /tmp/postgres.rpm /tmp/postgres-libs.rpm RPM-GPG-KEY-CentOS-Official && \
     # (Optional) Remove line below to keep package management utilities


### PR DESCRIPTION
## Description

This PR prevents installation of recommended packages resulting in removal (or not installing) 14 packages in central-db.
- #3879

```diff
# microdnf repoquery --installed
23d22
< diffutils-3.6-6.el8.x86_64
100d98
< libxkbcommon-0.9.1-1.el8.x86_64
115d112
< openssl-1:1.1.1k-7.el8_6.x86_64
123,125d119
< perl-Data-Dumper-2.167-399.el8.x86_64
< perl-Digest-1.17-395.el8.noarch
< perl-Digest-MD5-2.55-396.el8.x86_64
134,135d127
< perl-IO-Socket-IP-0.39-5.el8.noarch
< perl-IO-Socket-SSL-2.066-4.module+el8.3.0+6446+594cad75.noarch
137,138d128
< perl-Mozilla-CA-20160104-7.module+el8.3.0+6498+9eecfe51.noarch
< perl-Net-SSLeay-1.88-2.module+el8.6.0+13392+f0897f98.x86_64
152d141
< perl-URI-1.73-3.el8.noarch
156d144
< perl-libnet-3.11-3.el8.noarch
183d170
< xkeyboard-config-2.28-1.el8.noarch
```

## Testing Performed

CI