### PR TITLE
ROX-13344: Show real baseline flows in table with filtering

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/api/useFetchNetworkBaselines.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/api/useFetchNetworkBaselines.ts
@@ -1,0 +1,89 @@
+import { useEffect, useState } from 'react';
+
+import { fetchNetworkBaselines } from 'services/NetworkService';
+import { NetworkBaseline } from 'types/networkBaseline.proto';
+import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
+import { Flow } from '../types/flow.type';
+import { protocolLabel } from '../utils/flowUtils';
+
+type FetchNetworkBaselinesResult = {
+    isLoading: boolean;
+    data: { networkBaselines: Flow[]; isAlertingEnabled: boolean };
+    error: string | null;
+};
+
+const defaultResultState = {
+    data: { networkBaselines: [], isAlertingEnabled: false },
+    error: null,
+    isLoading: true,
+};
+
+/*
+ * This hook does an API call to the baseline status API to get the baseline status
+ * of the supplied peers
+ */
+function useFetchNetworkBaselines(deploymentId): FetchNetworkBaselinesResult {
+    const [result, setResult] = useState<FetchNetworkBaselinesResult>(defaultResultState);
+
+    useEffect(() => {
+        const networkBaselinesPromise = fetchNetworkBaselines({ deploymentId });
+
+        networkBaselinesPromise
+            .then((response: NetworkBaseline) => {
+                const { peers, locked, namespace } = response;
+                const isAlertingEnabled = locked;
+                const networkBaselines = peers.reduce((acc, currPeer) => {
+                    const currPeerType = currPeer.entity.info.type;
+                    const type = currPeerType === 'DEPLOYMENT' ? 'Deployment' : 'External';
+                    let entity = '';
+                    if (currPeerType === 'DEPLOYMENT') {
+                        entity = currPeer.entity.info.deployment.name;
+                    } else if (currPeerType === 'EXTERNAL_SOURCE') {
+                        entity = currPeer.entity.info.externalSource.name;
+                    } else if (currPeerType === 'INTERNET') {
+                        entity = 'External entities';
+                    }
+                    // we need a unique id for each network flow
+                    const newNetworkBaselines = currPeer.properties.map(
+                        ({ ingress, port, protocol }) => {
+                            const direction = ingress ? 'Ingress' : 'Egress';
+                            const flowId = `${entity}-${namespace}-${direction}-${port}-${protocol}`;
+                            const networkBaseline = {
+                                id: flowId,
+                                type,
+                                entity,
+                                namespace,
+                                direction: ingress ? 'Ingress' : 'Egress',
+                                port: String(port),
+                                protocol: protocolLabel[protocol],
+                                isAnomalous: false,
+                                children: [],
+                            };
+                            return networkBaseline;
+                        }
+                    );
+                    return [...acc, ...newNetworkBaselines] as Flow[];
+                }, [] as Flow[]);
+                setResult({
+                    isLoading: false,
+                    data: { networkBaselines, isAlertingEnabled },
+                    error: null,
+                });
+            })
+            .catch((error) => {
+                const message = getAxiosErrorMessage(error);
+                const errorMessage =
+                    message || 'An unknown error occurred while getting the list of clusters';
+
+                setResult({
+                    isLoading: false,
+                    data: { networkBaselines: [], isAlertingEnabled: false },
+                    error: errorMessage,
+                });
+            });
+    }, [deploymentId]);
+
+    return result;
+}
+
+export default useFetchNetworkBaselines;

--- a/ui/apps/platform/src/Containers/NetworkGraph/common/FlowsBulkActions.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/common/FlowsBulkActions.tsx
@@ -26,18 +26,22 @@ function FlowsBulkActions({
 
     return (
         <BulkActionsDropdown isDisabled={selectedRows.length === 0}>
+            <DropdownItem
+                key="mark_as_anomalous"
+                component="button"
+                onClick={markSelectedAsAnomalous}
+            >
+                Mark as anomalous
+            </DropdownItem>
             {type !== 'baseline' && (
                 <DropdownItem
-                    key="mark_as_anomalous"
+                    key="add_to_baseline"
                     component="button"
-                    onClick={markSelectedAsAnomalous}
+                    onClick={addSelectedToBaseline}
                 >
-                    Mark as anomalous
+                    Add to baseline
                 </DropdownItem>
             )}
-            <DropdownItem key="add_to_baseline" component="button" onClick={addSelectedToBaseline}>
-                Add to baseline
-            </DropdownItem>
         </BulkActionsDropdown>
     );
 }

--- a/ui/apps/platform/src/Containers/NetworkGraph/common/FlowsTable.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/common/FlowsTable.tsx
@@ -45,7 +45,7 @@ function FlowsTable({
 }: FlowsTableProps): ReactElement {
     // getter functions
     const isRowExpanded = (row: Flow) => expandedRows.includes(row.id);
-    const areAllRowsSelected = selectedRows.length === numFlows;
+    const areAllRowsSelected = selectedRows.length !== 0 && selectedRows.length === numFlows;
     const isRowSelected = (row: Flow) => selectedRows.includes(row.id);
 
     // setter functions

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentSideBar.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentSideBar.tsx
@@ -136,7 +136,7 @@ function DeploymentSideBar({ deploymentId, nodes, edges }: DeploymentSideBarProp
                     hidden={activeKeyTab !== 'Baselines'}
                     className="pf-u-h-100"
                 >
-                    <DeploymentBaselines />
+                    <DeploymentBaselines deploymentId={deploymentId} />
                 </TabContent>
                 <TabContent
                     eventKey="Network policies"

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/flowUtils.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/flowUtils.ts
@@ -4,7 +4,7 @@ import { AdvancedFlowsFilterType } from '../common/AdvancedFlowsFilter/types';
 import { Flow } from '../types/flow.type';
 import { CustomEdgeModel, CustomNodeData } from '../types/topology.type';
 
-const protocolLabel = {
+export const protocolLabel = {
     L4_PROTOCOL_UNKNOWN: 'UNKNOWN',
     L4_PROTOCOL_TCP: 'TCP',
     L4_PROTOCOL_UDP: 'UDP',


### PR DESCRIPTION
## Description

This PR adds real data for the baseline flows shown for a deployment. In following PRs I'll do the following:
- [ ] Allow marking baselines as anomalous
- [ ] Simulate baselines as network policies
- [ ] Toggle alerting on baseline violations

<img width="1440" alt="Screenshot 2023-01-12 at 11 23 50 AM" src="https://user-images.githubusercontent.com/4805485/212162741-1062010a-cdcf-4116-bb66-490ce53d1dc6.png">


## Checklist
- [ ] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~
