### PR TITLE
Dashrews/ROX-14210 update central to ensure jsonpb unmarshal has AllowUnknownFields set to true

### DIFF
--- a/central/cluster/datastore/datastore_impl_test.go
+++ b/central/cluster/datastore/datastore_impl_test.go
@@ -1,14 +1,12 @@
 package datastore
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"testing"
 	"time"
 
 	"github.com/golang/mock/gomock"
-	"github.com/golang/protobuf/jsonpb"
 	"github.com/pkg/errors"
 	alertMocks "github.com/stackrox/rox/central/alert/datastore/mocks"
 	clusterIndexMocks "github.com/stackrox/rox/central/cluster/index/mocks"
@@ -40,6 +38,7 @@ import (
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/images/defaults"
+	"github.com/stackrox/rox/pkg/jsonutil"
 	"github.com/stackrox/rox/pkg/protoconv"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
@@ -610,10 +609,10 @@ func (suite *ClusterDataStoreTestSuite) TestLookupOrCreateClusterFromConfig() {
 		LastContact:        ts,
 	}
 
-	err := jsonpb.Unmarshal(bytes.NewReader([]byte(someHelmConfigJSON)), &someHelmConfig)
+	err := jsonutil.JSONToProto(someHelmConfigJSON, &someHelmConfig)
 	suite.NoError(err)
 
-	err = jsonpb.Unmarshal(bytes.NewReader([]byte(differentConfigFPHelmConfigJSON)), &differentConfigFPHelmConfig)
+	err = jsonutil.JSONToProto(differentConfigFPHelmConfigJSON, &differentConfigFPHelmConfig)
 	suite.NoError(err)
 
 	someClusterWithManagerType := func(managerType storage.ManagerType, helmConfig *storage.CompleteClusterConfig) *storage.Cluster {

--- a/central/externalbackups/manager/backup_from_config_manager.go
+++ b/central/externalbackups/manager/backup_from_config_manager.go
@@ -7,11 +7,11 @@ import (
 	"time"
 
 	"github.com/ghodss/yaml"
-	"github.com/golang/protobuf/jsonpb"
 	"github.com/pkg/errors"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/jsonutil"
 	"github.com/stackrox/rox/pkg/k8scfgwatch"
 	"github.com/stackrox/rox/pkg/sac"
 )
@@ -59,7 +59,7 @@ func getConfig(filename string) (*v1.IntegrationAsConfiguration, error) {
 		return nil, errors.Wrap(err, "converting to json")
 	}
 	var config v1.IntegrationAsConfiguration
-	err = jsonpb.UnmarshalString(string(jsonBytes), &config)
+	err = jsonutil.JSONBytesToProto(jsonBytes, &config)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error unmarshaling proto from secret %q", filename)
 	}

--- a/central/notifiers/pagerduty/pagerduty.go
+++ b/central/notifiers/pagerduty/pagerduty.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/httputil/proxy"
 	imagesTypes "github.com/stackrox/rox/pkg/images/types"
+	"github.com/stackrox/rox/pkg/jsonutil"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/uuid"
 )
@@ -198,5 +199,5 @@ func (a *marshalableAlert) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON unmarshals alert JSON bytes into an Alert object, following jsonpb rules.
 func (a *marshalableAlert) UnmarshalJSON(data []byte) error {
-	return jsonpb.Unmarshal(bytes.NewReader(data), (*storage.Alert)(a))
+	return jsonutil.JSONBytesToProto(data, (*storage.Alert)(a))
 }


### PR DESCRIPTION
## Description

Trying to trickle these through as they are fairly quick after https://github.com/stackrox/stackrox/pull/4316. Simply use the JSONUnmarshaler instead of jsonpb directly to ensure that AllowUnknownFields is set for unmarshaling to avoid compatibility issues.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Simply using a method that is already tested in pkg/jsonutil/conversion_test.go
