### PR TITLE
Dashrews/ROX-14209 update sensor to ensure jsonpb unmarshal has AllowUnknownFields set to true

### DIFF
--- a/pkg/jsonutil/conversion.go
+++ b/pkg/jsonutil/conversion.go
@@ -2,6 +2,7 @@ package jsonutil
 
 import (
 	"bytes"
+	"io"
 	"regexp"
 	"strings"
 
@@ -40,6 +41,11 @@ func JSONToProto(json string, m proto.Message) error {
 // JSONBytesToProto converts bytes containing JSON into a proto message.
 func JSONBytesToProto(contents []byte, m proto.Message) error {
 	return JSONUnmarshaler().Unmarshal(bytes.NewReader(contents), m)
+}
+
+// JSONReaderToProto converts bytes from a reader containing JSON into a proto message.
+func JSONReaderToProto(reader io.Reader, m proto.Message) error {
+	return JSONUnmarshaler().Unmarshal(reader, m)
 }
 
 // ProtoToJSON converts a proto message into a string containing JSON.

--- a/pkg/jsonutil/conversion.go
+++ b/pkg/jsonutil/conversion.go
@@ -35,12 +35,12 @@ func JSONUnmarshaler() *jsonpb.Unmarshaler {
 
 // JSONToProto converts a string containing JSON into a proto message.
 func JSONToProto(json string, m proto.Message) error {
-	return JSONUnmarshaler().Unmarshal(strings.NewReader(json), m)
+	return JSONReaderToProto(strings.NewReader(json), m)
 }
 
 // JSONBytesToProto converts bytes containing JSON into a proto message.
 func JSONBytesToProto(contents []byte, m proto.Message) error {
-	return JSONUnmarshaler().Unmarshal(bytes.NewReader(contents), m)
+	return JSONReaderToProto(bytes.NewReader(contents), m)
 }
 
 // JSONReaderToProto converts bytes from a reader containing JSON into a proto message.

--- a/pkg/jsonutil/conversion_test.go
+++ b/pkg/jsonutil/conversion_test.go
@@ -1,6 +1,7 @@
 package jsonutil
 
 import (
+	"bytes"
 	"fmt"
 	"testing"
 
@@ -111,7 +112,13 @@ func TestNoErrorOnUnknownAttribute(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "6500", proto.GetId())
 
-	err = JSONBytesToProto([]byte(json), &proto)
+	jsonBytes := []byte(json)
+	err = JSONBytesToProto(jsonBytes, &proto)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "6500", proto.GetId())
+
+	err = JSONReaderToProto(bytes.NewReader(jsonBytes), &proto)
 
 	assert.NoError(t, err)
 	assert.Equal(t, "6500", proto.GetId())

--- a/pkg/jsonutil/conversion_test.go
+++ b/pkg/jsonutil/conversion_test.go
@@ -108,18 +108,16 @@ func TestNoErrorOnUnknownAttribute(t *testing.T) {
 	var proto v1.ResourceByID
 
 	err := JSONToProto(json, &proto)
-
 	assert.NoError(t, err)
 	assert.Equal(t, "6500", proto.GetId())
 
 	jsonBytes := []byte(json)
-	err = JSONBytesToProto(jsonBytes, &proto)
 
+	err = JSONBytesToProto(jsonBytes, &proto)
 	assert.NoError(t, err)
 	assert.Equal(t, "6500", proto.GetId())
 
 	err = JSONReaderToProto(bytes.NewReader(jsonBytes), &proto)
-
 	assert.NoError(t, err)
 	assert.Equal(t, "6500", proto.GetId())
 }

--- a/sensor/common/centralclient/client.go
+++ b/sensor/common/centralclient/client.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/proto"
 	"github.com/pkg/errors"
 	v1 "github.com/stackrox/rox/generated/api/v1"
@@ -19,6 +18,7 @@ import (
 	"github.com/stackrox/rox/pkg/clientconn"
 	"github.com/stackrox/rox/pkg/cryptoutils"
 	"github.com/stackrox/rox/pkg/httputil"
+	"github.com/stackrox/rox/pkg/jsonutil"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/mtls"
 	"github.com/stackrox/rox/pkg/mtls/verifier"
@@ -104,7 +104,7 @@ func (c *Client) GetMetadata(ctx context.Context) (*v1.Metadata, error) {
 	defer utils.IgnoreError(resp.Body.Close)
 
 	var metadata v1.Metadata
-	err = jsonpb.Unmarshal(resp.Body, &metadata)
+	err = jsonutil.JSONReaderToProto(resp.Body, &metadata)
 	if err != nil {
 		return nil, errors.Wrapf(err, "parsing Central %s response with status code %d", metadataRoute, resp.StatusCode)
 	}
@@ -222,7 +222,7 @@ func (c *Client) doTLSChallengeRequest(ctx context.Context, req *v1.TLSChallenge
 	defer utils.IgnoreError(resp.Body.Close)
 
 	tlsChallengeResp := &v1.TLSChallengeResponse{}
-	err = jsonpb.Unmarshal(resp.Body, tlsChallengeResp)
+	err = jsonutil.JSONReaderToProto(resp.Body, tlsChallengeResp)
 	if err != nil {
 		return nil, peerCertificates, errors.Wrap(err, "parsing Central response")
 	}

--- a/sensor/common/sensor/helmconfig/load.go
+++ b/sensor/common/sensor/helmconfig/load.go
@@ -1,14 +1,13 @@
 package helmconfig
 
 import (
-	"bytes"
 	"os"
 	"strings"
 
 	"github.com/ghodss/yaml"
-	"github.com/golang/protobuf/jsonpb"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stackrox/rox/pkg/jsonutil"
 )
 
 const (
@@ -32,7 +31,7 @@ func load(data []byte) (*central.HelmManagedConfigInit, error) {
 	}
 
 	var config central.HelmManagedConfigInit
-	if err := jsonpb.Unmarshal(bytes.NewReader(contentsJSON), &config); err != nil {
+	if err := jsonutil.JSONBytesToProto(contentsJSON, &config); err != nil {
 		return nil, errors.Wrap(err, "unmarshaling config proto")
 	}
 

--- a/sensor/testutils/policies.go
+++ b/sensor/testutils/policies.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/golang/protobuf/jsonpb"
 	"github.com/stackrox/rox/generated/storage"
 	localSensor "github.com/stackrox/rox/generated/tools/local-sensor"
 	"github.com/stackrox/rox/pkg/errorhelpers"
+	"github.com/stackrox/rox/pkg/jsonutil"
 )
 
 // GetPoliciesFromFile reads a file containing storage.Policy. Return a slice of storage.Policy with the content of the file
@@ -25,7 +25,7 @@ func GetPoliciesFromFile(fileName string) (policies []*storage.Policy, retError 
 		retError = errorList.ToError()
 	}()
 	var policiesMsg localSensor.LocalSensorPolicies
-	if err := jsonpb.Unmarshal(file, &policiesMsg); err != nil {
+	if err := jsonutil.JSONReaderToProto(file, &policiesMsg); err != nil {
 		errorList.AddStringf("error unmarshaling %s: %s\n", fileName, err)
 		return
 	}


### PR DESCRIPTION
## Description

Trying to trickle these through as they are fairly quick after https://github.com/stackrox/stackrox/pull/4316. Simply use the JSONUnmarshaler instead of jsonpb directly to ensure that AllowUnknownFields is set for unmarshaling to avoid compatibility issues.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Simply using a method that is already tested in pkg/jsonutil/conversion_test.go.  Added test to the additional wrapper method
