### PR TITLE
Bump kustomize version to 4.5.7

### DIFF
--- a/operator/Makefile
+++ b/operator/Makefile
@@ -167,11 +167,11 @@ CONTROLLER_GEN = $(PROJECT_DIR)/bin/controller-gen-$(CONTROLLER_GEN_VERSION)
 controller-gen: ## Download controller-gen locally if necessary.
 	$(call go-get-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v$(CONTROLLER_GEN_VERSION))
 
-KUSTOMIZE_VERSION = 3.8.7
+KUSTOMIZE_VERSION = 4.5.7
 KUSTOMIZE = $(PROJECT_DIR)/bin/kustomize-$(KUSTOMIZE_VERSION)
 .PHONY: kustomize
 kustomize: ## Download kustomize locally if necessary.
-	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v3@v$(KUSTOMIZE_VERSION))
+	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v4@v$(KUSTOMIZE_VERSION))
 
 OPERATOR_SDK_VERSION = 1.20.1
 OPERATOR_SDK = $(PROJECT_DIR)/bin/operator-sdk-$(OPERATOR_SDK_VERSION)

--- a/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
@@ -881,24 +881,6 @@ spec:
             spec:
               containers:
               - args:
-                - --secure-listen-address=0.0.0.0:8443
-                - --upstream=http://127.0.0.1:8080/
-                - --logtostderr=true
-                - --v=0
-                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
-                name: kube-rbac-proxy
-                ports:
-                - containerPort: 8443
-                  name: https
-                  protocol: TCP
-                resources:
-                  limits:
-                    cpu: 500m
-                    memory: 128Mi
-                  requests:
-                    cpu: 5m
-                    memory: 64Mi
-              - args:
                 - --health-probe-bind-address=:8081
                 - --metrics-bind-address=127.0.0.1:8080
                 - --leader-elect
@@ -945,6 +927,24 @@ spec:
                     memory: 200Mi
                 securityContext:
                   allowPrivilegeEscalation: false
+              - args:
+                - --secure-listen-address=0.0.0.0:8443
+                - --upstream=http://127.0.0.1:8080/
+                - --logtostderr=true
+                - --v=0
+                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+                name: kube-rbac-proxy
+                ports:
+                - containerPort: 8443
+                  name: https
+                  protocol: TCP
+                resources:
+                  limits:
+                    cpu: 500m
+                    memory: 128Mi
+                  requests:
+                    cpu: 5m
+                    memory: 64Mi
               securityContext:
                 runAsNonRoot: true
               serviceAccountName: rhacs-operator-controller-manager

--- a/operator/config/manifests/kustomization.yaml
+++ b/operator/config/manifests/kustomization.yaml
@@ -18,7 +18,7 @@ patchesJson6902:
     # Remove the manager container's "cert" volumeMount, since OLM will create and mount a set of certs.
     # Update the indices in this path if adding or removing containers/volumeMounts in the manager's Deployment.
     - op: remove
-      path: /spec/template/spec/containers/1/volumeMounts/0
+      path: /spec/template/spec/containers/0/volumeMounts/0
     # Remove the "cert" volume, since OLM will create and mount a set of certs.
     # Update the indices in this path if adding or removing volumes in the manager's Deployment.
     - op: remove


### PR DESCRIPTION
## Description
Currently it is not possible to install kustomize on MacOS with go 1.18:
```
# golang.org/x/sys/unix
/Users/ykovalev/go/pkg/mod/golang.org/x/sys@v0.0.0-20200323222414-85ca7c5b95cd/unix/syscall_darwin.1_13.go:25:3: //go:linkname must refer to declared function or variable
/Users/ykovalev/go/pkg/mod/golang.org/x/sys@v0.0.0-20200323222414-85ca7c5b95cd/unix/zsyscall_darwin_amd64.1_13.go:27:3: //go:linkname must refer to declared function or variable
/Users/ykovalev/go/pkg/mod/golang.org/x/sys@v0.0.0-20200323222414-85ca7c5b95cd/unix/zsyscall_darwin_amd64.1_13.go:40:3: //go:linkname must refer to declared function or variable
/Users/ykovalev/go/pkg/mod/golang.org/x/sys@v0.0.0-20200323222414-85ca7c5b95cd/unix/zsyscall_darwin_amd64.go:28:3: //go:linkname must refer to declared function or variable
/Users/ykovalev/go/pkg/mod/golang.org/x/sys@v0.0.0-20200323222414-85ca7c5b95cd/unix/zsyscall_darwin_amd64.go:43:3: //go:linkname must refer to declared function or variable
/Users/ykovalev/go/pkg/mod/golang.org/x/sys@v0.0.0-20200323222414-85ca7c5b95cd/unix/zsyscall_darwin_amd64.go:59:3: //go:linkname must refer to declared function or variable
/Users/ykovalev/go/pkg/mod/golang.org/x/sys@v0.0.0-20200323222414-85ca7c5b95cd/unix/zsyscall_darwin_amd64.go:75:3: //go:linkname must refer to declared function or variable
/Users/ykovalev/go/pkg/mod/golang.org/x/sys@v0.0.0-20200323222414-85ca7c5b95cd/unix/zsyscall_darwin_amd64.go:90:3: //go:linkname must refer to declared function or variable
/Users/ykovalev/go/pkg/mod/golang.org/x/sys@v0.0.0-20200323222414-85ca7c5b95cd/unix/zsyscall_darwin_amd64.go:105:3: //go:linkname must refer to declared function or variable
/Users/ykovalev/go/pkg/mod/golang.org/x/sys@v0.0.0-20200323222414-85ca7c5b95cd/unix/zsyscall_darwin_amd64.go:121:3: //go:linkname must refer to declared function or variable
/Users/ykovalev/go/pkg/mod/golang.org/x/sys@v0.0.0-20200323222414-85ca7c5b95cd/unix/zsyscall_darwin_amd64.go:121:3: too many errors
make: *** [kustomize] Error 2
```
Looks like this problem is specific for darwin and go versions > 1.17. On CI it is working fine.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed
Relying on CI 😅
