### PR TITLE
Implement better error handling for collections form

### DIFF
--- a/ui/apps/platform/cypress/integration/collections/collectionsCrudWorkflow.test.js
+++ b/ui/apps/platform/cypress/integration/collections/collectionsCrudWorkflow.test.js
@@ -19,7 +19,7 @@ describe('Create collection', () => {
     });
 
     const collectionName = 'Financial deployments';
-    const clonedName = `${collectionName} (COPY)`;
+    const clonedName = `${collectionName} -COPY-`;
 
     it('should allow creation of a new collection', () => {
         // Cleanup from potential previous test runs

--- a/ui/apps/platform/cypress/integration/vulnmanagement/reporting/reportingForm.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/reporting/reportingForm.test.js
@@ -138,10 +138,10 @@ describe('Vulnerability Management Reporting form', () => {
         // TODO Remove this once the feature is in
         cy.intercept('/v1/collections/autocomplete', {});
 
-        const reportName = 'report config [e2e test]';
+        const reportName = 'report config -e2e test-';
         const reportDescription = 'ui e2e test report';
-        const collectionName = 'stackrox ns collection [e2e test]';
-        const emailNotifierName = 'report config email notifier [e2e test]';
+        const collectionName = 'stackrox ns collection -e2e test-';
+        const emailNotifierName = 'report config email notifier -e2e test-';
         const integrationsSource = 'notifiers';
 
         // Delete collection from previous calls, if present

--- a/ui/apps/platform/src/Containers/Collections/CollectionAttacher.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionAttacher.tsx
@@ -5,6 +5,7 @@ import BacklogListSelector, {
     BacklogListSelectorProps,
 } from 'Components/PatternFly/BacklogListSelector';
 import { Collection } from 'services/CollectionsService';
+import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import useEmbeddedCollections from './hooks/useEmbeddedCollections';
 
 export type CollectionAttacherProps = {
@@ -69,7 +70,9 @@ function CollectionAttacher({
                     variant="danger"
                     isInline
                     title="There was an error loading more collections"
-                />
+                >
+                    {getAxiosErrorMessage(fetchMoreError)}
+                </Alert>
             )}
             {hasMore && (
                 <Button

--- a/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
@@ -250,7 +250,7 @@ function CollectionForm({
             create: '',
             view: initialData.name,
             edit: initialData.name,
-            clone: `${initialData.name} (COPY)`,
+            clone: `${initialData.name} -COPY-`,
         }[action.type];
 
         setFieldValue('name', nameValue).catch(() => {

--- a/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
@@ -170,7 +170,14 @@ function yupResourceSelectorObject() {
 }
 
 const validationSchema = yup.object({
-    name: yup.string().trim().required(),
+    name: yup
+        .string()
+        .trim()
+        .matches(
+            /^[a-zA-Z0-9 .-]*$/,
+            'Only letters, numbers, dot, dash, and space characters are allowed in collection names'
+        )
+        .required(),
     description: yup.string(),
     embeddedCollectionIds: yup.array(yup.string().trim().required()),
     resourceSelector: yup.object().shape({

--- a/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
@@ -229,6 +229,7 @@ function CollectionForm({
         setFieldValue,
         submitForm,
         isSubmitting,
+        isValid,
     } = useFormik({
         initialValues: initialData,
         onSubmit: (collection, { setSubmitting }) => {
@@ -508,7 +509,7 @@ function CollectionForm({
                     <Button
                         className="pf-u-mr-md"
                         onClick={submitForm}
-                        isDisabled={isSubmitting || !!configError}
+                        isDisabled={isSubmitting || !!configError || !isValid}
                         isLoading={isSubmitting}
                     >
                         Save

--- a/ui/apps/platform/src/Containers/Collections/CollectionFormModal.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionFormModal.tsx
@@ -89,7 +89,10 @@ function CollectionsFormModal({
     if (error) {
         content = (
             <Bullseye className="pf-u-p-2xl">
-                <CollectionLoadError error={error} />
+                <CollectionLoadError
+                    title="There was an error loading this collection"
+                    error={error}
+                />
             </Bullseye>
         );
         modalTitle = 'Collection error';

--- a/ui/apps/platform/src/Containers/Collections/CollectionLoadError.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionLoadError.tsx
@@ -7,6 +7,7 @@ import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
 export type CollectionLoadErrorProps = {
+    title: string;
     error: Error;
 };
 
@@ -19,14 +20,10 @@ function ErrorIcon(props: SVGIconProps) {
     );
 }
 
-function CollectionLoadError({ error }: CollectionLoadErrorProps) {
+function CollectionLoadError({ title, error }: CollectionLoadErrorProps) {
     return (
         <Bullseye>
-            <EmptyStateTemplate
-                title="There was an error loading this collection"
-                headingLevel="h2"
-                icon={ErrorIcon}
-            >
+            <EmptyStateTemplate title={title} headingLevel="h2" icon={ErrorIcon}>
                 <Title headingLevel="h3">{getAxiosErrorMessage(error)}</Title>
             </EmptyStateTemplate>
         </Bullseye>

--- a/ui/apps/platform/src/Containers/Collections/CollectionResults.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionResults.tsx
@@ -165,71 +165,41 @@ function CollectionResults({
     } else {
         content = (
             <Flex
-                spaceItems={{ default: 'spaceItemsNone' }}
-                alignItems={{ default: 'alignItemsStretch' }}
                 direction={{ default: 'column' }}
+                grow={{ default: 'grow' }}
+                className="pf-u-mt-lg"
             >
-                <Flex spaceItems={{ default: 'spaceItemsNone' }}>
-                    <FlexItem>
-                        <Select
-                            toggleAriaLabel="Select an entity type to filter the results by"
-                            isOpen={isOpen}
-                            onToggle={onToggle}
-                            selections={selected}
-                            onSelect={onRuleOptionSelect}
-                            isDisabled={false}
-                        >
-                            <SelectOption value="Deployment">Deployment</SelectOption>
-                            <SelectOption value="Namespace">Namespace</SelectOption>
-                            <SelectOption value="Cluster">Cluster</SelectOption>
-                        </Select>
-                    </FlexItem>
-                    <div className="pf-u-flex-grow-1 pf-u-flex-basis-0">
-                        <SearchInput
-                            aria-label="Filter by name"
-                            placeholder="Filter by name"
-                            value={filterText}
-                            onChange={setFilterText}
-                        />
-                    </div>
-                </Flex>
-                <Flex
-                    direction={{ default: 'column' }}
-                    grow={{ default: 'grow' }}
-                    className="pf-u-mt-lg"
-                >
-                    {isRefreshingResults ? (
-                        <>
-                            {Array.from(Array(10).keys()).map((index: number) => (
-                                <DeploymentSkeleton key={`refreshing-deployment-${index}`} />
-                            ))}
-                            <Spinner className="pf-u-align-self-center" size="lg" />
-                        </>
-                    ) : (
-                        <>
-                            {data.map((page) =>
-                                page.map((deployment: ListDeployment) => (
-                                    <DeploymentResult key={deployment.id} deployment={deployment} />
-                                ))
-                            )}
-                            {!isEndOfResults ? (
-                                <Button
-                                    variant="link"
-                                    isInline
-                                    className="pf-u-text-align-center"
-                                    isLoading={isFetchingNextPage || isRefreshingResults}
-                                    onClick={() => fetchNextPage(true)}
-                                >
-                                    View more
-                                </Button>
-                            ) : (
-                                <span className="pf-u-color-300 pf-u-text-align-center pf-u-font-size-sm">
-                                    end of results
-                                </span>
-                            )}
-                        </>
-                    )}
-                </Flex>
+                {isRefreshingResults ? (
+                    <>
+                        {Array.from(Array(10).keys()).map((index: number) => (
+                            <DeploymentSkeleton key={`refreshing-deployment-${index}`} />
+                        ))}
+                        <Spinner className="pf-u-align-self-center" size="lg" />
+                    </>
+                ) : (
+                    <>
+                        {data.map((page) =>
+                            page.map((deployment: ListDeployment) => (
+                                <DeploymentResult key={deployment.id} deployment={deployment} />
+                            ))
+                        )}
+                        {!isEndOfResults ? (
+                            <Button
+                                variant="link"
+                                isInline
+                                className="pf-u-text-align-center"
+                                isLoading={isFetchingNextPage || isRefreshingResults}
+                                onClick={() => fetchNextPage(true)}
+                            >
+                                View more
+                            </Button>
+                        ) : (
+                            <span className="pf-u-color-300 pf-u-text-align-center pf-u-font-size-sm">
+                                end of results
+                            </span>
+                        )}
+                    </>
+                )}
             </Flex>
         );
     }
@@ -253,7 +223,37 @@ function CollectionResults({
             </div>
             <Divider />
             <div className="pf-u-h-100 pf-u-p-lg" style={{ overflow: 'auto' }}>
-                {content}
+                <Flex
+                    spaceItems={{ default: 'spaceItemsNone' }}
+                    alignItems={{ default: 'alignItemsStretch' }}
+                    direction={{ default: 'column' }}
+                >
+                    <Flex spaceItems={{ default: 'spaceItemsNone' }}>
+                        <FlexItem>
+                            <Select
+                                toggleAriaLabel="Select an entity type to filter the results by"
+                                isOpen={isOpen}
+                                onToggle={onToggle}
+                                selections={selected}
+                                onSelect={onRuleOptionSelect}
+                                isDisabled={false}
+                            >
+                                <SelectOption value="Deployment">Deployment</SelectOption>
+                                <SelectOption value="Namespace">Namespace</SelectOption>
+                                <SelectOption value="Cluster">Cluster</SelectOption>
+                            </Select>
+                        </FlexItem>
+                        <div className="pf-u-flex-grow-1 pf-u-flex-basis-0">
+                            <SearchInput
+                                aria-label="Filter by name"
+                                placeholder="Filter by name"
+                                value={filterText}
+                                onChange={setFilterText}
+                            />
+                        </div>
+                    </Flex>
+                    {content}
+                </Flex>
             </div>
         </>
     );

--- a/ui/apps/platform/src/Containers/Collections/CollectionsFormPage.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionsFormPage.tsx
@@ -180,7 +180,10 @@ function CollectionsFormPage({
                     <BreadcrumbItemLink to={collectionsBasePath}>Collections</BreadcrumbItemLink>
                 </Breadcrumb>
                 <Divider component="div" />
-                <CollectionLoadError error={error} />
+                <CollectionLoadError
+                    title="There was an error loading this collection"
+                    error={error}
+                />
             </>
         );
     } else if (loading) {

--- a/ui/apps/platform/src/Containers/Collections/CollectionsTablePage.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionsTablePage.tsx
@@ -9,8 +9,6 @@ import {
     ButtonVariant,
     Divider,
     Alert,
-    Bullseye,
-    Spinner,
     AlertActionCloseButton,
     AlertGroup,
 } from '@patternfly/react-core';
@@ -67,8 +65,7 @@ function CollectionsTablePage({ hasWriteAccessForCollections }: CollectionsTable
         refetch: countRefetch,
     } = useRestQuery(countQuery);
 
-    const isDataAvailable = typeof listData !== 'undefined' && typeof countData !== 'undefined';
-    const isLoading = !isDataAvailable && (listLoading || countLoading);
+    const isLoading = listLoading || countLoading;
     const loadError = listError || countError;
 
     function onCollectionDelete({ id, name }: Collection) {
@@ -84,44 +81,6 @@ function CollectionsTablePage({ hasWriteAccessForCollections }: CollectionsTable
                 const error = getAxiosErrorMessage(err);
                 addToast(`Could not delete collection '${name}'`, 'danger', error);
             });
-    }
-
-    let pageContent = (
-        <PageSection variant="light" isFilled>
-            <Bullseye>
-                <Spinner isSVG />
-            </Bullseye>
-        </PageSection>
-    );
-
-    if (loadError) {
-        pageContent = (
-            <PageSection variant="light" isFilled>
-                <Bullseye>
-                    <Alert variant="danger" title={loadError.message} />
-                </Bullseye>
-            </PageSection>
-        );
-    }
-
-    if (isDataAvailable && !isLoading && !loadError) {
-        pageContent = (
-            <PageSection>
-                <CollectionsTable
-                    collections={listData}
-                    collectionsCount={countData}
-                    pagination={pagination}
-                    searchFilter={searchFilter}
-                    setSearchFilter={(value) => {
-                        setPage(1);
-                        setSearchFilter(value);
-                    }}
-                    getSortParams={getSortParams}
-                    onCollectionDelete={onCollectionDelete}
-                    hasWriteAccess={hasWriteAccessForCollections}
-                />
-            </PageSection>
-        );
     }
 
     return (
@@ -149,7 +108,23 @@ function CollectionsTablePage({ hasWriteAccessForCollections }: CollectionsTable
                 </Flex>
             </PageSection>
             <Divider component="div" />
-            {pageContent}
+            <PageSection>
+                <CollectionsTable
+                    isLoading={isLoading}
+                    error={loadError}
+                    collections={listData ?? []}
+                    collectionsCount={countData ?? 0}
+                    pagination={pagination}
+                    searchFilter={searchFilter}
+                    setSearchFilter={(value) => {
+                        setPage(1);
+                        setSearchFilter(value);
+                    }}
+                    getSortParams={getSortParams}
+                    onCollectionDelete={onCollectionDelete}
+                    hasWriteAccess={hasWriteAccessForCollections}
+                />
+            </PageSection>
             <AlertGroup isToast isLiveRegion>
                 {toasts.map(({ key, variant, title, children }: Toast) => (
                     <Alert


### PR DESCRIPTION
## Description

This PR makes the following enhancements to collection form error handling:

- Updates the error and loading state of the main collection table and results panel to be more resilient to errors, allowing the user to change search criteria if a request results in an error. Previously if there was an error during a request, the entire page contents (including the search bar) became inaccessible.
- Adds client side validation to ensure that the collection name only includes alphanumeric characters, dash, dot, or space.
- Disables the "Save" button when it is detected that the form is invalid

Since most of the code change is moving the nesting level of component blocks, this is easier to visualize with "Hide whitespace" on.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Load the collections table and see that the loading spinner is now contained within the table display.
![image](https://user-images.githubusercontent.com/1292638/212722484-90629948-bb28-4181-9640-cc8b9656eb73.png)

Enter an invalid search value `,` and see that the error state is contained within the table display, with the table toolbar still accessible.
![image](https://user-images.githubusercontent.com/1292638/212722580-9a7f0982-a38d-4f1d-b8a9-5fb3af6794e1.png)

Edit the search filter and replace it with a valid value, or clear the filters, and ensure new data loads correctly.
![image](https://user-images.githubusercontent.com/1292638/212722761-204947f4-63fd-444e-9037-1a75c7083ea7.png)

Perform the same test against the results panel sidebar.

Data loading:
![image](https://user-images.githubusercontent.com/1292638/212723716-408511b0-dba0-4009-96d6-fb09cb385eb3.png)

On error:
![image](https://user-images.githubusercontent.com/1292638/212723765-89aa470a-2455-4e0d-aff5-8cceb7c4ef28.png)

A valid search clears the error:
![image](https://user-images.githubusercontent.com/1292638/212723854-75f98fe4-7466-4505-a403-3f7a38f9757d.png)

Enter an invalid character into the collection name field:
![image](https://user-images.githubusercontent.com/1292638/212724204-8ab44251-48e8-4aef-9c31-9d2d31565e17.png)

Edit the collection name to only include valid characters:
![image](https://user-images.githubusercontent.com/1292638/212724303-7d43de77-76ef-4fac-afd8-51bdd61c98fb.png)

