### PR TITLE
Fix ClusterInitBundleTest and DiagnosticBundleTest tests

### DIFF
--- a/qa-tests-backend/src/test/groovy/ClusterInitBundleTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ClusterInitBundleTest.groovy
@@ -50,7 +50,7 @@ class ClusterInitBundleTest extends BaseSpecification {
         assert response.initBundleRevokedIdsCount == 0
         and:
         "impacted cluster is listed"
-        assert response.initBundleRevocationErrorsList.first().impactedClustersList*.id.contains(clusterId)
+        assert response.initBundleRevocationErrorsList.first().impactedClustersList*.id.contains(cluster.id)
     }
 
     def "Test that cluster init bundle can be revoked when it has no impacted clusters"() {

--- a/qa-tests-backend/src/test/groovy/DiagnosticBundleTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DiagnosticBundleTest.groovy
@@ -10,6 +10,7 @@ import io.stackrox.proto.api.v1.ApiTokenService.GenerateTokenResponse
 import io.stackrox.proto.storage.RoleOuterClass
 import io.stackrox.proto.storage.RoleOuterClass.Role
 
+import services.ClusterService
 import services.RoleService
 import util.Env
 
@@ -115,7 +116,8 @@ class DiagnosticBundleTest extends BaseSpecification {
                 ZipEntry entry
                 while ((entry = zis.nextEntry) != null) {
                     log.info "Found file ${entry.name}"
-                    if (entry.name == "kubernetes/remote/stackrox/sensor/deployment-sensor.yaml") {
+                    if (entry.name == ("kubernetes/" + ClusterService.DEFAULT_CLUSTER_NAME +
+                            "/stackrox/sensor/deployment-sensor.yaml")) {
                         foundK8sInfo = true
                     }
                 }


### PR DESCRIPTION
## Description

This PR intends to fix issues mentioned below with following tests.

1. ClusterInitBundleTest
```
ClusterInitBundleTest > Test that revoke cluster init bundle requires impacted clusters FAILED
    Condition failed with Exception:

    response.initBundleRevocationErrorsList.first().impactedClustersList*.id.contains(clusterId)
    |        |                              |       |                     |           |
    |        |                              |       |                     |           groovy.lang.MissingPropertyException: No such property: clusterId for class: ClusterInitBundleTest
    |        |                              |       |                     |           	at ClusterInitBundleTest.Test that revoke cluster init bundle requires impacted clusters(ClusterInitBundleTest.groovy:53)
```
2. DiagnosticBundleTest
```
DiagnosticBundleTest > Test that diagnostic bundle download #desc > DiagnosticBundleTest.Test that diagnostic bundle download succeeds with debug logs reader token FAILED
    Condition not satisfied:

    foundK8sInfo
    |
    false
        at DiagnosticBundleTest.Test that diagnostic bundle download #desc(DiagnosticBundleTest.groovy:125)
```

Changes are verified manually using `./gradlew test --tests=TestName`