### PR TITLE
Switch collections table search to use an explicit submit button instead of debouncing

### DIFF
--- a/ui/apps/platform/cypress/integration/collections/Collections.selectors.js
+++ b/ui/apps/platform/cypress/integration/collections/Collections.selectors.js
@@ -25,6 +25,7 @@ const resultsPanelFilterEntitySelect = `${resultsPanel} button[aria-label="Selec
 const resultsPanelFilterEntitySelectOption = (entity) =>
     `${resultsPanel} *[role="listbox"] button:contains("${entity}")`;
 const resultsPanelFilterInput = `${resultsPanel} input[aria-label="Filter by name"]`;
+const resultsPanelFilterSearch = `${resultsPanel} button[aria-label="Search"]`;
 
 export const collectionSelectors = {
     tableLinkByName: (name) => `td[data-label="Collection"] a:contains("${name}")`,
@@ -41,4 +42,5 @@ export const collectionSelectors = {
     resultsPanelFilterEntitySelect,
     resultsPanelFilterEntitySelectOption,
     resultsPanelFilterInput,
+    resultsPanelFilterSearch,
 };

--- a/ui/apps/platform/cypress/integration/collections/deploymentMatching.test.js
+++ b/ui/apps/platform/cypress/integration/collections/deploymentMatching.test.js
@@ -155,6 +155,7 @@ describe('Collection deployment matching', () => {
 
         // Filter to deployments with deployment name matching
         cy.get(selectors.resultsPanelFilterInput).type('c');
+        cy.get(selectors.resultsPanelFilterSearch).click();
 
         assertDeploymentsAreMatchedExactly(['calico-node-vertical-autoscaler', 'collector']);
 
@@ -162,6 +163,7 @@ describe('Collection deployment matching', () => {
         cy.get(selectors.resultsPanelFilterEntitySelect).click();
         cy.get(selectors.resultsPanelFilterEntitySelectOption('Namespace')).click();
         cy.get(selectors.resultsPanelFilterInput).type('stackrox');
+        cy.get(selectors.resultsPanelFilterSearch).click();
 
         // Test that only stackrox deployments are visible
         assertDeploymentsAreMatchedExactly(['collector', 'sensor']);

--- a/ui/apps/platform/src/Containers/Collections/CollectionAttacher.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionAttacher.tsx
@@ -1,5 +1,5 @@
-import React, { useMemo, useState } from 'react';
-import { Alert, Button, debounce, Flex, SearchInput } from '@patternfly/react-core';
+import React, { useState } from 'react';
+import { Alert, Button, Flex, SearchInput } from '@patternfly/react-core';
 
 import BacklogListSelector, {
     BacklogListSelectorProps,
@@ -17,10 +17,6 @@ export type CollectionAttacherProps = {
     collectionTableCells: BacklogListSelectorProps<Collection>['cells'];
 };
 
-function compareNameLowercase(search: string): (item: { name: string }) => boolean {
-    return ({ name }) => name.toLowerCase().includes(search.toLowerCase());
-}
-
 function CollectionAttacher({
     excludedCollectionId,
     initialEmbeddedCollections,
@@ -32,29 +28,22 @@ function CollectionAttacher({
     const { attached, detached, attach, detach, hasMore, fetchMore, onSearch } = embedded;
     const { isFetchingMore, fetchMoreError } = embedded;
 
-    const onSearchInputChange = useMemo(
-        () =>
-            debounce((value: string) => {
-                setSearch(value);
-                onSearch(value);
-            }, 800),
-        [onSearch]
-    );
-
-    const selectedOptions = attached.filter(compareNameLowercase(search));
-    const deselectedOptions = detached.filter(compareNameLowercase(search));
-
     return (
         <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsXl' }}>
             <SearchInput
                 aria-label="Filter by name"
                 placeholder="Filter by name"
                 value={search}
-                onChange={onSearchInputChange}
+                onChange={setSearch}
+                onSearch={() => onSearch(search)}
+                onClear={() => {
+                    setSearch('');
+                    onSearch('');
+                }}
             />
             <BacklogListSelector
-                selectedOptions={selectedOptions}
-                deselectedOptions={deselectedOptions}
+                selectedOptions={attached}
+                deselectedOptions={detached}
                 onSelectItem={({ id }) => attach(id)}
                 onDeselectItem={({ id }) => detach(id)}
                 onSelectionChange={onSelectionChange}

--- a/ui/apps/platform/src/Containers/Collections/CollectionResults.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionResults.tsx
@@ -89,10 +89,13 @@ function CollectionResults({
 }: CollectionResultsProps) {
     const { isOpen, onToggle, closeSelect } = useSelectToggle();
     const [selected, setSelected] = useState<SelectorEntityType>('Deployment');
-    const [filterText, setFilterText] = useState<string>('');
+    // This state controls the value of the text in the SearchInput component separately from the value sent via query
+    const [filterInput, setFilterInput] = useState('');
+    // This state controls the filter value that we want to use for queries, and is set by manual user interaction.
+    const [filterValue, setFilterValue] = useState('');
     const queryFn = useCallback(
-        (page: number) => fetchMatchingDeployments(dryRunConfig, page, filterText, selected),
-        [dryRunConfig, filterText, selected]
+        (page: number) => fetchMatchingDeployments(dryRunConfig, page, filterValue, selected),
+        [dryRunConfig, filterValue, selected]
     );
     const {
         data,
@@ -117,7 +120,8 @@ function CollectionResults({
 
     function onRuleOptionSelect(_, value): void {
         setSelected(value);
-        setFilterText('');
+        setFilterInput('');
+        setFilterValue('');
         closeSelect();
     }
 
@@ -247,8 +251,13 @@ function CollectionResults({
                             <SearchInput
                                 aria-label="Filter by name"
                                 placeholder="Filter by name"
-                                value={filterText}
-                                onChange={setFilterText}
+                                value={filterInput}
+                                onChange={setFilterInput}
+                                onSearch={() => setFilterValue(filterInput)}
+                                onClear={() => {
+                                    setFilterInput('');
+                                    setFilterValue('');
+                                }}
                             />
                         </div>
                     </Flex>

--- a/ui/apps/platform/src/Containers/Collections/hooks/useEmbeddedCollections.ts
+++ b/ui/apps/platform/src/Containers/Collections/hooks/useEmbeddedCollections.ts
@@ -145,6 +145,7 @@ type UseEmbeddedCollectionsState = {
     fetchMoreError: Error | null;
     attached: CollectionMap;
     detached: CollectionMap;
+    search: string;
 };
 
 type ReducerPayload =
@@ -153,7 +154,7 @@ type ReducerPayload =
     | { type: 'fetchMoreError'; error: Error }
     | { type: 'attachCollection'; id: string }
     | { type: 'detachCollection'; id: string }
-    | { type: 'resetDetachedList' };
+    | { type: 'resetDetachedList'; search: string };
 
 function embeddedCollectionsReducer(
     state: UseEmbeddedCollectionsState,
@@ -182,10 +183,17 @@ function embeddedCollectionsReducer(
             return { ...state, attached, detached };
         }
         case 'resetDetachedList':
-            return { ...state, page: 1, hasMore: true, detached: {} };
+            return { ...state, search: payload.search, page: 1, hasMore: true, detached: {} };
         default:
             return ensureExhaustive(payload);
     }
+}
+
+// We need to use `startsWith` instead of `includes` here, since search values sent to the API use
+// a prefix match. If we filter by substring, collections matching the substring will appear in
+// the "attached" list, but not in the "available" list, since the former are cached client side.
+function compareNameLowercase(search: string): (item: { name: string }) => boolean {
+    return ({ name }) => name.toLowerCase().startsWith(search.toLowerCase());
 }
 
 const initialState = {
@@ -194,6 +202,7 @@ const initialState = {
     isFetchingMore: false,
     fetchMoreError: null,
     detached: {},
+    search: '',
 };
 
 export type UseEmbeddedCollectionsReturn = {
@@ -270,7 +279,7 @@ export default function useEmbeddedCollections(
         attached: arrayToMap(initialAttachedCollections),
     }));
 
-    const { attached, detached, page, hasMore, isFetchingMore, fetchMoreError } = state;
+    const { attached, detached, page, hasMore, isFetchingMore, fetchMoreError, search } = state;
 
     useEffect(() => {
         return fetchMore(
@@ -283,18 +292,18 @@ export default function useEmbeddedCollections(
         );
     }, [excludedCollectionId, initialAttachedCollections]);
 
-    const onSearch = (search: string) => {
-        dispatch({ type: 'resetDetachedList' });
-        fetchMore(excludedCollectionId, attached, {}, search, 1, dispatch);
+    const onSearch = (newSearch: string) => {
+        dispatch({ type: 'resetDetachedList', search: newSearch });
+        fetchMore(excludedCollectionId, attached, {}, newSearch, 1, dispatch);
     };
 
     return {
-        attached: sortBy(Object.values(attached), 'name'),
-        detached: sortBy(Object.values(detached), 'name'),
+        attached: sortBy(Object.values(attached), 'name').filter(compareNameLowercase(search)),
+        detached: sortBy(Object.values(detached), 'name').filter(compareNameLowercase(search)),
         attach: (id: string) => dispatch({ type: 'attachCollection', id }),
         detach: (id: string) => dispatch({ type: 'detachCollection', id }),
         hasMore,
-        fetchMore: (search: string) =>
+        fetchMore: () =>
             fetchMore(excludedCollectionId, attached, detached, search, page, dispatch),
         onSearch,
         isFetchingMore,


### PR DESCRIPTION
## Description

To avoid issues with users typing an invalid character that gets sent to the server when the debounced input is slowed, as well as to avoid sending too many requests to the server in general, the search-as-you-type inputs in the collection section have been changed to use a search input with button as described in the [PF docs](https://www.patternfly.org/v4/guidelines/filters#text-entry-filters).

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

On the main collection's table, enter a value in the search bar and stop typing. The results should not immediately update.
<img width="1676" alt="image" src="https://user-images.githubusercontent.com/1292638/212738028-f76cdc97-9195-483f-885e-923b293be011.png">

Pressing the "enter" key, or clicking the arrow search icon attached to the input will trigger the search:
<img width="1676" alt="image" src="https://user-images.githubusercontent.com/1292638/212738103-8dbe4830-fe25-4902-a92e-677827c2c94e.png">

The input can be fully cleared and the search reset by clicking the "X" close button attached to the input, which then disappears after click.
<img width="1676" alt="image" src="https://user-images.githubusercontent.com/1292638/212738236-0d7cd3b7-2390-42d6-9c99-8a53ce39aebb.png">

The collection attachment table will use the same search functionality:
<img width="1676" alt="image" src="https://user-images.githubusercontent.com/1292638/212738313-fcedb8b2-6dcd-451f-b1de-ca253738e10b.png">
<img width="1676" alt="image" src="https://user-images.githubusercontent.com/1292638/212738329-c6c1ce9c-677f-45ce-96c1-43270f16b1b5.png">
<img width="1676" alt="image" src="https://user-images.githubusercontent.com/1292638/212738346-d68980bb-56df-4ba6-b652-0a67d24f16b0.png">

The results panel will use the same search functionality:
<img width="1676" alt="image" src="https://user-images.githubusercontent.com/1292638/212738437-3fd83dde-c20b-46a5-8d3c-c8b4fa5d3c1d.png">
<img width="1676" alt="image" src="https://user-images.githubusercontent.com/1292638/212738460-82ec3917-4642-4089-bc94-d9000e007a7a.png">
<img width="1676" alt="image" src="https://user-images.githubusercontent.com/1292638/212738476-9e3d7832-8de5-485a-8801-b44586a2f1d6.png">



