### PR TITLE
Scope plain stlying for disabled select to NG header breadcrumbs

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.css
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.css
@@ -10,3 +10,10 @@
     /* @TODO: Consider a more future-proof way of doing this. See https://github.com/stackrox/stackrox/pull/3703#discussion_r1014292340 */
     height: calc(100vh - var(--pf-c-page__header--MinHeight) - var(--pf-c-page__header--MinHeight) - var(--pf-c-page__header--MinHeight));
 }
+
+
+/* Remove gray background from plain PF Select trigger button when disabled */
+.network-graph-selector-bar .pf-c-select__toggle.pf-m-disabled,
+.network-graph-selector-bar .pf-c-select__toggle:disabled {
+    --pf-c-select__toggle--disabled--BackgroundColor: none;
+}

--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
@@ -181,7 +181,10 @@ function NetworkGraphPage() {
         <>
             <PageTitle title="Network Graph" />
             <PageSection variant="light" padding={{ default: 'noPadding' }}>
-                <Toolbar data-testid="network-graph-selector-bar">
+                <Toolbar
+                    className="network-graph-selector-bar"
+                    data-testid="network-graph-selector-bar"
+                >
                     <ToolbarContent>
                         <ToolbarGroup variant="filter-group">
                             <Title headingLevel="h1" className="pf-u-screen-reader">

--- a/ui/apps/platform/src/css/trumps.css
+++ b/ui/apps/platform/src/css/trumps.css
@@ -98,11 +98,6 @@ button.pf-c-toggle-group__button:disabled {
     overflow: visible !important;
 }
 
-/* Remove gray background from plain PF Select trigger button when disabled */
-.pf-c-select__toggle.pf-m-disabled,
-.pf-c-select__toggle:disabled {
-    --pf-c-select__toggle--disabled--BackgroundColor: none;
-}
 
 /* overriding our tailwind config default of display: block for images, because it breaks the patternfly layout */
 .pf-c-button__icon.pf-m-start svg,


### PR DESCRIPTION
## Description

Scopes this style change to be specific to the NG header to avoid conflicts elsewhere when making this consistent across other pages.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Load PF Network Graph and ensure breadcrumb dropdowns still have plain styling.
![image](https://user-images.githubusercontent.com/1292638/212393071-683182c5-42b3-4e54-bd94-056b03f98dc9.png)

