### PR TITLE
Dashrews/ROX-14207 update migrator tools to ensure jsonpb unmarshal has AllowUnknownFields set to true

### DIFF
--- a/migrator/migrations/policymigrationhelper/policy_migrator.go
+++ b/migrator/migrations/policymigrationhelper/policy_migrator.go
@@ -1,20 +1,19 @@
 package policymigrationhelper
 
 import (
-	"bytes"
 	"embed"
 	"fmt"
 	"path/filepath"
 	"reflect"
 	"strings"
 
-	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/proto"
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/migrator/bolthelpers"
 	"github.com/stackrox/rox/migrator/log"
+	"github.com/stackrox/rox/pkg/jsonutil"
 	"github.com/stackrox/rox/pkg/set"
 	bolt "go.etcd.io/bbolt"
 )
@@ -188,7 +187,7 @@ func ReadPolicyFromFile(fs embed.FS, filePath string) (*storage.Policy, error) {
 		return nil, errors.Wrapf(err, "unable to read file %s", filePath)
 	}
 	var policy storage.Policy
-	err = jsonpb.Unmarshal(bytes.NewReader(contents), &policy)
+	err = jsonutil.JSONBytesToProto(contents, &policy)
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to unmarshal policy json at path %s", filePath)
 	}

--- a/migrator/migrations/policymigrationhelper/test_helpers.go
+++ b/migrator/migrations/policymigrationhelper/test_helpers.go
@@ -1,7 +1,6 @@
 package policymigrationhelper
 
 import (
-	"bytes"
 	"embed"
 	"fmt"
 	"io/fs"
@@ -11,9 +10,9 @@ import (
 	"testing"
 
 	"github.com/gogo/protobuf/proto"
-	"github.com/golang/protobuf/jsonpb"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/migrator/bolthelpers"
+	"github.com/stackrox/rox/pkg/jsonutil"
 	"github.com/stackrox/rox/pkg/sliceutils"
 	"github.com/stackrox/rox/pkg/testutils"
 	"github.com/stretchr/testify/assert"
@@ -203,7 +202,7 @@ func (suite *TestSuite) SetupSuite() {
 		suite.NoError(err)
 
 		var policy storage.Policy
-		err = jsonpb.Unmarshal(bytes.NewReader(contents), &policy)
+		err = jsonutil.JSONBytesToProto(contents, &policy)
 		suite.NoError(err)
 
 		suite.ExpectedPolicies[policy.Id] = &policy
@@ -245,7 +244,7 @@ func (suite *TestSuite) testUnmodifiedPolicies(migrationFunc func(db *bolt.DB) e
 		policyBytes, err := suite.PreMigPoliciesFS.ReadFile(fmt.Sprintf("%s/%s.json", suite.PreMigPoliciesDir, policyID))
 		suite.Require().NoError(err)
 		var policy storage.Policy
-		err = jsonpb.Unmarshal(bytes.NewReader(policyBytes), &policy)
+		err = jsonutil.JSONBytesToProto(policyBytes, &policy)
 		suite.Require().NoError(err)
 		insertPolicy(suite.T(), bucket, &policy)
 	}
@@ -270,7 +269,7 @@ func (suite *TestSuite) testModifiedPolicies(migrationFunc func(db *bolt.DB) err
 		policyBytes, err := suite.PreMigPoliciesFS.ReadFile(fmt.Sprintf("%s/%s.json", suite.PreMigPoliciesDir, policyID))
 		suite.Require().NoError(err)
 		var policy storage.Policy
-		err = jsonpb.Unmarshal(bytes.NewReader(policyBytes), &policy)
+		err = jsonutil.JSONBytesToProto(policyBytes, &policy)
 		suite.Require().NoError(err)
 		modifiedPolicy := policy.Clone()
 		modifiedPolicy.PolicySections[0].PolicyGroups[0].Values[0].Value = "assfasdf"

--- a/tools/roxvet/analyzers/validateimports/analyzer.go
+++ b/tools/roxvet/analyzers/validateimports/analyzer.go
@@ -210,6 +210,7 @@ func verifyImportsFromAllowedPackagesOnly(pass *analysis.Pass, imports []*ast.Im
 			"pkg/fsutils",
 			"pkg/grpc/routes",
 			"pkg/images/types",
+			"pkg/jsonutil",
 			"pkg/logging",
 			"pkg/metrics",
 			"pkg/migrations",


### PR DESCRIPTION
## Description

Trying to trickle these through as they are fairly quick after https://github.com/stackrox/stackrox/pull/4316. Simply use the JSONUnmarshaler instead of jsonpb directly to ensure that AllowUnknownFields is set for unmarshaling to avoid compatibility issues.

## Checklist
- [x] Investigated and inspected CI test results
~- [ ] Unit test and regression tests added~
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Simply using a method that is already tested in pkg/jsonutil/conversion_test.go.
