### PR TITLE
ROX-13963: Third time the charm for showing banner when DB unavailable

### DIFF
--- a/ui/apps/platform/src/Containers/MainPage/DatabaseBanner.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/DatabaseBanner.tsx
@@ -1,0 +1,19 @@
+import React, { ReactElement } from 'react';
+import { AlertVariant, Banner } from '@patternfly/react-core';
+
+function DatabaseBanner(): ReactElement {
+    const message = (
+        <span className="pf-u-text-align-center">
+            The database is currently not available. If this problem persists, please contact
+            support.
+        </span>
+    );
+
+    return (
+        <Banner className="pf-u-text-align-center" isSticky variant={AlertVariant.danger}>
+            {message}
+        </Banner>
+    );
+}
+
+export default DatabaseBanner;

--- a/ui/apps/platform/src/Containers/MainPage/DatabaseBanner.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/DatabaseBanner.tsx
@@ -1,19 +1,46 @@
-import React, { ReactElement } from 'react';
+import React, { useState, useEffect, ReactElement } from 'react';
 import { AlertVariant, Banner } from '@patternfly/react-core';
 
-function DatabaseBanner(): ReactElement {
-    const message = (
-        <span className="pf-u-text-align-center">
-            The database is currently not available. If this problem persists, please contact
-            support.
-        </span>
-    );
+import useInterval from 'hooks/useInterval';
+import { fetchDatabaseStatus } from 'services/DatabaseService';
 
-    return (
-        <Banner className="pf-u-text-align-center" isSticky variant={AlertVariant.danger}>
-            {message}
-        </Banner>
-    );
+export type DatabaseBannerProps = {
+    isApiReachable: boolean;
+};
+
+function DatabaseBanner({ isApiReachable }: DatabaseBannerProps): ReactElement | null {
+    // To handle database status refreshing.
+    const [pollEpoch, setPollEpoch] = useState(0);
+    const [databaseAvailable, setDatabaseAvailable] = useState(true);
+
+    // We will update the poll epoch after 60 seconds to force a refresh of the database status
+    useInterval(() => {
+        setPollEpoch(pollEpoch + 1);
+    }, 60000);
+
+    useEffect(() => {
+        fetchDatabaseStatus()
+            .then((response) => {
+                setDatabaseAvailable(Boolean(response?.databaseAvailable));
+            })
+            .catch(() => {
+                setDatabaseAvailable(false);
+            });
+    }, [pollEpoch]);
+
+    const showDatabaseWarning = isApiReachable && !databaseAvailable;
+
+    if (showDatabaseWarning) {
+        return (
+            <Banner className="pf-u-text-align-center" isSticky variant={AlertVariant.danger}>
+                <span className="pf-u-text-align-center">
+                    The database is currently not available. If this problem persists, please
+                    contact support.
+                </span>
+            </Banner>
+        );
+    }
+    return null;
 }
 
 export default DatabaseBanner;

--- a/ui/apps/platform/src/Containers/MainPage/MainPage.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/MainPage.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react';
+import React, { useState, useEffect, ReactElement } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import { createStructuredSelector } from 'reselect';
@@ -16,10 +16,13 @@ import AppWrapper from 'Containers/AppWrapper';
 import Body from 'Containers/MainPage/Body';
 import useFeatureFlags from 'hooks/useFeatureFlags';
 import usePermissions from 'hooks/usePermissions';
+import useInterval from 'hooks/useInterval';
 import { clustersBasePath } from 'routePaths';
+import { fetchDatabaseStatus } from 'services/DatabaseService';
 
 import CredentialExpiryBanner from './CredentialExpiryBanner';
 import VersionOutOfDate from './VersionOutOfDate';
+import DatabaseBanner from './DatabaseBanner';
 import Masthead from './Header/Masthead';
 import NavigationSidebar from './Sidebar/NavigationSidebar';
 
@@ -50,6 +53,10 @@ function MainPage(): ReactElement {
         serverState,
     } = useSelector(mainPageSelector);
 
+    // To handle database status refreshing.
+    const [pollEpoch, setPollEpoch] = useState(0);
+    const [databaseAvailable, setDatabaseAvailable] = useState(true);
+
     // Follow-up: Replace SearchModal with path like /main/search and component like GlobalSearchPage.
     const dispatch = useDispatch();
     const history = useHistory();
@@ -59,6 +66,21 @@ function MainPage(): ReactElement {
             history.push(toURL);
         }
     }
+
+    // We will update the poll epoch after 60 seconds to force a refresh of the database status
+    useInterval(() => {
+        setPollEpoch(pollEpoch + 1);
+    }, 60000);
+
+    useEffect(() => {
+        fetchDatabaseStatus()
+            .then((response) => {
+                setDatabaseAvailable(Boolean(response?.databaseAvailable));
+            })
+            .catch(() => {
+                setDatabaseAvailable(false);
+            });
+    }, [pollEpoch]);
 
     const { isFeatureFlagEnabled, isLoadingFeatureFlags } = useFeatureFlags();
     const { hasReadAccess, hasReadWriteAccess, isLoadingPermissions } = usePermissions();
@@ -98,6 +120,7 @@ function MainPage(): ReactElement {
                     hasServiceIdentityWritePermission={hasServiceIdentityWritePermission}
                 />
                 {metadata?.stale && <VersionOutOfDate />}
+                {!databaseAvailable && <DatabaseBanner />}
                 <Page
                     mainContainerId="main-page-container"
                     header={<Masthead />}

--- a/ui/apps/platform/src/Containers/MainPage/MainPage.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/MainPage.tsx
@@ -99,7 +99,7 @@ function MainPage(): ReactElement {
                     hasServiceIdentityWritePermission={hasServiceIdentityWritePermission}
                 />
                 {metadata?.stale && <VersionOutOfDate />}
-                 <DatabaseBanner isApiReachable={serverState && serverState !== 'UNREACHABLE'} />
+                <DatabaseBanner isApiReachable={serverState && serverState !== 'UNREACHABLE'} />
                 <Page
                     mainContainerId="main-page-container"
                     header={<Masthead />}

--- a/ui/apps/platform/src/services/DatabaseService.ts
+++ b/ui/apps/platform/src/services/DatabaseService.ts
@@ -2,7 +2,7 @@ import { DatabaseStatus } from 'types/databaseService.proto';
 
 import axios from './instance';
 
-const databaseUrl = '/v1/database-status';
+const databaseUrl = '/v1/database/status';
 
 /**
  * Fetches database.

--- a/ui/apps/platform/src/services/DatabaseService.ts
+++ b/ui/apps/platform/src/services/DatabaseService.ts
@@ -1,0 +1,14 @@
+import { DatabaseStatus } from 'types/databaseService.proto';
+
+import axios from './instance';
+
+const databaseUrl = '/v1/database-status';
+
+/**
+ * Fetches database.
+ * TODO return Promise<DatabaseStatus> when component calls directly instead of indirectly via saga.
+ */
+
+export function fetchDatabaseStatus(): Promise<DatabaseStatus> {
+    return axios.get<DatabaseStatus>(databaseUrl).then((response) => response.data);
+}

--- a/ui/apps/platform/src/services/DatabaseService.ts
+++ b/ui/apps/platform/src/services/DatabaseService.ts
@@ -5,10 +5,8 @@ import axios from './instance';
 const databaseUrl = '/v1/database/status';
 
 /**
- * Fetches database.
- * TODO return Promise<DatabaseStatus> when component calls directly instead of indirectly via saga.
+ * Fetches database status.
  */
-
 export function fetchDatabaseStatus(): Promise<DatabaseStatus> {
     return axios.get<DatabaseStatus>(databaseUrl).then((response) => response.data);
 }

--- a/ui/apps/platform/src/types/databaseService.proto.ts
+++ b/ui/apps/platform/src/types/databaseService.proto.ts
@@ -1,0 +1,5 @@
+export type DatabaseStatus = {
+    databaseAvailable: boolean;
+    databaseType?: string | null;
+    databaseVersion?: string | null;
+};

--- a/ui/apps/platform/src/types/databaseService.proto.ts
+++ b/ui/apps/platform/src/types/databaseService.proto.ts
@@ -1,5 +1,5 @@
 export type DatabaseStatus = {
     databaseAvailable: boolean;
-    databaseType?: string | null;
-    databaseVersion?: string | null;
+    databaseType?: string;
+    databaseVersion?: string;
 };


### PR DESCRIPTION
## Description

Take 3 on showing a warning banner in the UI when the Postgres-compatible DB is unavailable.

This version uses the new /database-status endpoint to get its info.

This version incorporates some of Mark's suggestions from an earlier PR, too.


Note: this is similar to #4369,  I had to open another branch with cherry-picked commits, because the last branch got in a bind with merge conflicts.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed


Blocking the endpoint to test the banner:
![Screen Shot 2023-01-11 at 5 56 53 PM](https://user-images.githubusercontent.com/715729/211937680-7dc9cb05-05c2-4a71-ae7d-cb9c6182e0bb.png)

And then unblocking the endpoint, and waiting no more than 60 seconds for the API call to poll:
![Screen Shot 2023-01-11 at 5 57 54 PM](https://user-images.githubusercontent.com/715729/211937741-b7ea9235-7971-491d-9dd1-d8158cc04a38.png)

If the whole server is unreachable, I do not bother to show this banner.
![Screen Shot 2023-01-13 at 1 59 41 PM](https://user-images.githubusercontent.com/715729/212409049-6b2ba2d4-5e6e-413e-a997-11aa644fa51a.png)
