### PR TITLE
Add "Total Secured Clusters" property

### DIFF
--- a/central/cluster/datastore/telemetry.go
+++ b/central/cluster/datastore/telemetry.go
@@ -33,6 +33,7 @@ func trackClusterInitialized(cluster *storage.Cluster) {
 	}
 }
 
+// Gather the number of clusters.
 var Gather phonehome.GatherFunc = func(ctx context.Context) (map[string]any, error) {
 	ctx = sac.WithGlobalAccessScopeChecker(ctx,
 		sac.AllowFixedScopes(

--- a/central/cluster/datastore/telemetry.go
+++ b/central/cluster/datastore/telemetry.go
@@ -1,8 +1,13 @@
 package datastore
 
 import (
+	"context"
+
+	"github.com/stackrox/rox/central/role/resources"
 	"github.com/stackrox/rox/central/telemetry/centralclient"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stackrox/rox/pkg/telemetry/phonehome"
 )
 
 func trackClusterRegistered(cluster *storage.Cluster) {
@@ -26,4 +31,17 @@ func trackClusterInitialized(cluster *storage.Cluster) {
 		}
 		cfg.Telemeter().Track("Secured Cluster Initialized", cfg.ClientID, props)
 	}
+}
+
+var Gather phonehome.GatherFunc = func(ctx context.Context) (map[string]any, error) {
+	ctx = sac.WithGlobalAccessScopeChecker(ctx,
+		sac.AllowFixedScopes(
+			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
+			sac.ResourceScopeKeys(resources.Cluster)))
+
+	props := make(map[string]any, 1)
+	if err := phonehome.AddTotal(ctx, props, "Secured Clusters", Singleton().CountClusters); err != nil {
+		return nil, err
+	}
+	return props, nil
 }

--- a/central/main.go
+++ b/central/main.go
@@ -431,6 +431,7 @@ func servicesToRegister(registry authproviders.Registry, authzTraceSink observe.
 		gs.AddGatherer(authProviderDS.Gather)
 		gs.AddGatherer(signatureIntegrationDS.Gather)
 		gs.AddGatherer(roleDataStore.Gather)
+		gs.AddGatherer(clusterDataStore.Gather)
 	}
 	return servicesToRegister
 }


### PR DESCRIPTION
## Description

Augment the central identity properties with the number of controlled secured clusters.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] ~Unit test and regression tests added~
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

Local testing. Example message on Segment:
```json
{
  "context": {
    "Client ID": "db05eef0-41f8-4dac-952b-c9d244bbdb88",
    "Client Name": "Central",
    "library": {
      "name": "analytics-go",
      "version": "3.0.0"
    }
  },
  "integrations": {},
  "messageId": "aec55e36-7e71-435d-bf17-f2d3f64f468f",
  "originalTimestamp": "2023-01-16T09:08:02.605104126Z",
  "receivedAt": "2023-01-16T09:09:02.715Z",
  "sentAt": "2023-01-16T09:09:01.571Z",
  "timestamp": "2023-01-16T09:08:03.748Z",
  "traits": {
    "Auth Providers": null,
    "Central version": "3.73.x-406-gb13b50dad4-dirty",
    "Chart version": "73.0.406-gb13b50dad4-dirty",
    "Kubernetes version": "v1.25.3",
    "Orchestrator": "KUBERNETES_CLUSTER",
    "Total Access Scopes": 2,
    "Total PermissionSets": 9,
    "Total Roles": 9,
    "Total Secured Clusters": 1,
    "Total Signature Integrations": 0
  },
  "type": "identify",
  "userId": "db05eef0-41f8-4dac-952b-c9d244bbdb88",
  "writeKey": "xxx"
}
```