### PR TITLE
Report secured cluster identity on initialization

### DIFF
--- a/central/cluster/datastore/telemetry.go
+++ b/central/cluster/datastore/telemetry.go
@@ -33,6 +33,7 @@ func trackClusterInitialized(cluster *storage.Cluster) {
 	}
 }
 
+// Gather the number of clusters.
 var Gather phonehome.GatherFunc = func(ctx context.Context) (map[string]any, error) {
 	ctx = sac.WithGlobalAccessScopeChecker(ctx,
 		sac.AllowFixedScopes(

--- a/central/cluster/datastore/telemetry.go
+++ b/central/cluster/datastore/telemetry.go
@@ -23,13 +23,20 @@ func trackClusterRegistered(cluster *storage.Cluster) {
 
 func trackClusterInitialized(cluster *storage.Cluster) {
 	if cfg := centralclient.InstanceConfig(); cfg.Enabled() {
-		props := map[string]any{
-			"Health":       cluster.GetHealthStatus().OverallHealthStatus.String(),
-			"Cluster Type": cluster.GetType().String(),
-			"Cluster ID":   cluster.GetId(),
-			"Managed By":   cluster.GetManagedBy().String(),
-		}
-		cfg.Telemeter().Track("Secured Cluster Initialized", cfg.ClientID, props)
+		cfg.Telemeter().Group(cfg.GroupID, cluster.GetId(), nil)
+		cfg.Telemeter().Identify(cluster.GetId(), map[string]any{
+			"Main Image":           cluster.GetMainImage(),
+			"Admission Controller": cluster.GetAdmissionController(),
+			"Collection Method":    cluster.GetCollectionMethod().String(),
+			"Collector Image":      cluster.GetCollectorImage(),
+			"Managed By":           cluster.GetManagedBy().String(),
+			"Priority":             cluster.GetPriority(),
+			"Cluster Type":         cluster.GetType().String(),
+			"Slim Collector":       cluster.GetSlimCollector(),
+		})
+		cfg.Telemeter().Track("Secured Cluster Initialized", cluster.GetId(), map[string]any{
+			"Health": cluster.GetHealthStatus().OverallHealthStatus.String(),
+		})
 	}
 }
 

--- a/central/cluster/datastore/telemetry.go
+++ b/central/cluster/datastore/telemetry.go
@@ -1,8 +1,13 @@
 package datastore
 
 import (
+	"context"
+
+	"github.com/stackrox/rox/central/role/resources"
 	"github.com/stackrox/rox/central/telemetry/centralclient"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stackrox/rox/pkg/telemetry/phonehome"
 )
 
 func trackClusterRegistered(cluster *storage.Cluster) {
@@ -26,4 +31,17 @@ func trackClusterInitialized(cluster *storage.Cluster) {
 		}
 		cfg.Telemeter().Track("Secured Cluster Initialized", cfg.ClientID, props)
 	}
+}
+
+var Gather phonehome.GatherFunc = func(ctx context.Context) (map[string]any, error) {
+	ctx = sac.WithGlobalAccessScopeChecker(ctx,
+		sac.AllowFixedScopes(
+			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
+			sac.ResourceScopeKeys(resources.Cluster)))
+
+	props := make(map[string]any, 1)
+	if err := phonehome.AddTotal(ctx, props, "Secured Clusters", Singleton().CountClusters); err != nil {
+		return nil, err
+	}
+	return props, nil
 }

--- a/central/main.go
+++ b/central/main.go
@@ -431,6 +431,7 @@ func servicesToRegister(registry authproviders.Registry, authzTraceSink observe.
 		gs.AddGatherer(authProviderDS.Gather)
 		gs.AddGatherer(signatureIntegrationDS.Gather)
 		gs.AddGatherer(roleDataStore.Gather)
+		gs.AddGatherer(clusterDataStore.Gather)
 	}
 	return servicesToRegister
 }


### PR DESCRIPTION
## Description

Follow-up of #4406.

Continuation on the work for secured cluster creation journey.

Two events are tracked:

1. Secured Cluster Registered — issued as a central event (userID is set to central ID);
2. Secured Cluster Initialized — issued as a secured cluster event.

This PR adds a secured cluster identity message and changes the issuer of the second event. Central takes responsibility of adding the secured cluster to the tenant group.

Future development may bring other events coming from secured clusters.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed
Local testing.

### Example messages:

#### Secured Cluster Registered

```json
{
  "context": {
    "Client ID": "db05eef0-41f8-4dac-952b-c9d244bbdb88",
    "Client Name": "Central",
    "library": {
      "name": "analytics-go",
      "version": "3.0.0"
    }
  },
  "event": "Secured Cluster Registered",
  "integrations": {},
  "messageId": "2d42bfe8-966c-47cf-8fe0-c1aecafbd5ab",
  "originalTimestamp": "2023-01-16T09:51:43.378417779Z",
  "properties": {
    "Cluster ID": "809fb814-13cb-4573-bd3f-7b44c450b6c5",
    "Cluster Type": "KUBERNETES_CLUSTER",
    "Managed By": "MANAGER_TYPE_UNKNOWN"
  },
  "receivedAt": "2023-01-16T09:52:11.389Z",
  "sentAt": "2023-01-16T09:52:10.681Z",
  "timestamp": "2023-01-16T09:51:44.086Z",
  "type": "track",
  "userId": "db05eef0-41f8-4dac-952b-c9d244bbdb88",
  "writeKey": "..."
}
```

#### Adding secured cluster to the tenant group

```json
{
  "context": {
    "Client ID": "db05eef0-41f8-4dac-952b-c9d244bbdb88",
    "Client Name": "Central",
    "library": {
      "name": "analytics-go",
      "version": "3.0.0"
    }
  },
  "groupId": "db05eef0-41f8-4dac-952b-c9d244bbdb88",
  "integrations": {},
  "messageId": "3195aa2f-4024-46d6-ad3f-554636283d7d",
  "originalTimestamp": "2023-01-16T09:54:24.895625654Z",
  "receivedAt": "2023-01-16T09:55:11.628Z",
  "sentAt": "2023-01-16T09:55:10.681Z",
  "timestamp": "2023-01-16T09:54:25.842Z",
  "traits": null,
  "type": "group",
  "userId": "809fb814-13cb-4573-bd3f-7b44c450b6c5",
  "writeKey": "..."
}
```

#### Secured cluster identity

```json
{
  "context": {
    "Client ID": "db05eef0-41f8-4dac-952b-c9d244bbdb88",
    "Client Name": "Central",
    "library": {
      "name": "analytics-go",
      "version": "3.0.0"
    }
  },
  "integrations": {},
  "messageId": "063a89e7-0073-4108-bfc2-fefe21d7eea6",
  "originalTimestamp": "2023-01-16T09:54:24.895639234Z",
  "receivedAt": "2023-01-16T09:55:11.628Z",
  "sentAt": "2023-01-16T09:55:10.681Z",
  "timestamp": "2023-01-16T09:54:25.842Z",
  "traits": {
    "Admission Controller": false,
    "Cluster Type": "KUBERNETES_CLUSTER",
    "Collection Method": "EBPF",
    "Collector Image": "quay.io/stackrox-io/collector",
    "Main Image": "quay.io/stackrox-io/main",
    "Managed By": "MANAGER_TYPE_UNKNOWN",
    "Priority": 0,
    "Slim Collector": true
  },
  "type": "identify",
  "userId": "809fb814-13cb-4573-bd3f-7b44c450b6c5",
  "writeKey": "..."
}
```

#### Secured Cluster Initialized

```json
{
  "context": {
    "Client ID": "db05eef0-41f8-4dac-952b-c9d244bbdb88",
    "Client Name": "Central",
    "library": {
      "name": "analytics-go",
      "version": "3.0.0"
    }
  },
  "event": "Secured Cluster Initialized",
  "integrations": {},
  "messageId": "de8ae662-fd53-465d-8da3-02e5c9b02ca2",
  "originalTimestamp": "2023-01-16T09:54:24.895642412Z",
  "properties": {
    "Health": "UNHEALTHY"
  },
  "receivedAt": "2023-01-16T09:55:11.628Z",
  "sentAt": "2023-01-16T09:55:10.681Z",
  "timestamp": "2023-01-16T09:54:25.842Z",
  "type": "track",
  "userId": "809fb814-13cb-4573-bd3f-7b44c450b6c5",
  "writeKey": "..."
}
```