### PR TITLE
ROX-14036: Emit JUnit output for operator test steps.

### DIFF
--- a/.openshift-ci/ci_tests.py
+++ b/.openshift-ci/ci_tests.py
@@ -141,6 +141,7 @@ class OperatorE2eTest(BaseTest):
                 "-C",
                 "operator",
                 "bundle-test-image",
+                "non-existent-target",
             ],
             OperatorE2eTest.SCORECARD_TEST_TIMEOUT_SEC,
         )

--- a/.openshift-ci/ci_tests.py
+++ b/.openshift-ci/ci_tests.py
@@ -141,7 +141,6 @@ class OperatorE2eTest(BaseTest):
                 "-C",
                 "operator",
                 "bundle-test-image",
-                "non-existent-target",
             ],
             OperatorE2eTest.SCORECARD_TEST_TIMEOUT_SEC,
         )

--- a/operator/hack/junit_wrap.sh
+++ b/operator/hack/junit_wrap.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -euo pipefail
+
+if [[ "$#" -lt 4 ]]; then
+    echo >&2 "missing args. usage: $0 <class> <description> <failure_message> <command> [ args ]"
+    exit 1
+fi
+declare -r class="$1"; shift
+declare -r description="$1"; shift
+declare -r failure_message="$1"; shift
+
+ROOT_DIR="$(dirname "${BASH_SOURCE[0]}")/../.."
+readonly ROOT_DIR
+
+if "$@"; then
+    "${ROOT_DIR}/scripts/ci/lib.sh" "save_junit_success" "${class}" "${description}"
+else
+    declare -r ret_code="$?"
+    "${ROOT_DIR}/scripts/ci/lib.sh" "save_junit_failure" "${class}" "${description}" "${failure_message}"
+    exit ${ret_code}
+fi


### PR DESCRIPTION
## Description

Provide some JUnit output to make failures easier to inspect.

Ideally we'd capture the stdout/err and show it in the junit output but:
- I'm not sure how to do that without piping throught something like `tee` which will prevent timely output when watching logs, due to bufferring.
- I'm afraid long output might not be that useful
- I'm not sure how to safely quote such output to embed in an XML file

So a generic message will need to do for now.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

Relying on CI. Including a forced failure in the first iteration of this change to see how it behaves.