### PR TITLE
Set ownership of CI dirs to CI team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -31,3 +31,4 @@ tests/upgrade/*     @stackrox/data-shepherds
 
 .github/**/* @stackrox/circleci
 .openshift-ci/**/* @stackrox/circleci
+scripts/ci/** @stackrox/circleci

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -29,6 +29,6 @@ migrator/**/*       @stackrox/data-shepherds
 pkg/postgres/**/*   @stackrox/data-shepherds
 tests/upgrade/*     @stackrox/data-shepherds
 
-.github/**/* @stackrox/circleci
-.openshift-ci/**/* @stackrox/circleci
-scripts/ci/** @stackrox/circleci
+.github/**/* @stackrox/ci
+.openshift-ci/**/* @stackrox/ci
+scripts/ci/** @stackrox/ci

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -28,3 +28,6 @@ pkg/images/defaults/**/* @stackrox/maple
 migrator/**/*       @stackrox/data-shepherds
 pkg/postgres/**/*   @stackrox/data-shepherds
 tests/upgrade/*     @stackrox/data-shepherds
+
+.github/**/* @stackrox/circleci
+.openshift-ci/**/* @stackrox/circleci


### PR DESCRIPTION
## Description

To keep consistent CI configs we should automatically add owners to review. 
