### PR TITLE
ROX-14253: Do not allow upgrades when Sensor version is ahead of Central for Helm based installation  

### DIFF
--- a/central/sensor/service/connection/upgradecontroller/register_connection.go
+++ b/central/sensor/service/connection/upgradecontroller/register_connection.go
@@ -55,16 +55,16 @@ func determineUpgradabilityFromVersionInfoAndConn(sensorVersion string, conn Sen
 	if sensorVersion == version.GetMainVersion() {
 		return storage.ClusterUpgradeStatus_UP_TO_DATE, "sensor is running the same version as Central"
 	}
+
+	// Check if the connection supports auto-upgrade.
+	if err := conn.CheckAutoUpgradeSupport(); err != nil {
+		return storage.ClusterUpgradeStatus_MANUAL_UPGRADE_REQUIRED, err.Error()
+	}
 	cmp := version.CompareReleaseVersions(sensorVersion, version.GetMainVersion())
 	// The sensor is newer! See comments on the below enum value in the proto file
 	// for more details on how we handle this case.
 	if cmp > 0 {
 		return storage.ClusterUpgradeStatus_SENSOR_VERSION_HIGHER, fmt.Sprintf("sensor is running a newer version (%s)", sensorVersion)
-	}
-
-	// Check if the connection supports auto-upgrade.
-	if err := conn.CheckAutoUpgradeSupport(); err != nil {
-		return storage.ClusterUpgradeStatus_MANUAL_UPGRADE_REQUIRED, err.Error()
 	}
 
 	// We don't differentiate between cmp == -1 and cmp == 0.

--- a/central/sensor/service/connection/upgradecontroller/register_connection_test.go
+++ b/central/sensor/service/connection/upgradecontroller/register_connection_test.go
@@ -1,0 +1,94 @@
+package upgradecontroller
+
+import (
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/version/testutils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUpgradability(t *testing.T) {
+	type testCase struct {
+		centralVersion       string
+		sensorVersion        string
+		expectedStatus       storage.ClusterUpgradeStatus_Upgradability
+		autoUpgradeSupported bool
+	}
+
+	cases := map[string]testCase{
+		"sensor version is empty": {
+			centralVersion:       "3.73.0",
+			sensorVersion:        "",
+			expectedStatus:       storage.ClusterUpgradeStatus_MANUAL_UPGRADE_REQUIRED,
+			autoUpgradeSupported: true,
+		},
+		"sensor and central versions are equal": {
+			centralVersion:       "3.73.0",
+			sensorVersion:        "3.73.0",
+			expectedStatus:       storage.ClusterUpgradeStatus_UP_TO_DATE,
+			autoUpgradeSupported: true,
+		},
+		"sensor version is lower than central": {
+			centralVersion:       "3.73.0",
+			sensorVersion:        "3.72.3",
+			expectedStatus:       storage.ClusterUpgradeStatus_AUTO_UPGRADE_POSSIBLE,
+			autoUpgradeSupported: true,
+		},
+		"sensor version is higher than central": {
+			centralVersion:       "3.73.0",
+			sensorVersion:        "3.73.1",
+			expectedStatus:       storage.ClusterUpgradeStatus_SENSOR_VERSION_HIGHER,
+			autoUpgradeSupported: true,
+		},
+		"sensor version is lower than central when sensor does not support autoupgrade": {
+			centralVersion:       "3.73.0",
+			sensorVersion:        "3.72.3",
+			expectedStatus:       storage.ClusterUpgradeStatus_MANUAL_UPGRADE_REQUIRED,
+			autoUpgradeSupported: false,
+		},
+		"sensor version is higher than central when sensor does not support autoupgrade": {
+			centralVersion:       "3.73.0",
+			sensorVersion:        "3.73.1",
+			expectedStatus:       storage.ClusterUpgradeStatus_MANUAL_UPGRADE_REQUIRED,
+			autoUpgradeSupported: false,
+		},
+	}
+
+	for desc, tc := range cases {
+		t.Run(desc, func(t *testing.T) {
+			testutils.SetMainVersion(t, tc.centralVersion)
+			connection := fakeConnection{
+				sensorVersion:        tc.sensorVersion,
+				autoUpgradeSupported: tc.autoUpgradeSupported,
+			}
+			upgradability, _ := determineUpgradabilityFromVersionInfoAndConn(tc.sensorVersion, connection)
+			assert.Equal(t, tc.expectedStatus, upgradability)
+		})
+	}
+}
+
+var _ SensorConn = fakeConnection{}
+
+type fakeConnection struct {
+	autoUpgradeSupported bool
+	sensorVersion        string
+}
+
+func (f fakeConnection) InjectMessage(_ concurrency.Waitable, _ *central.MsgToSensor) error {
+	panic("not implemented")
+}
+
+func (f fakeConnection) CheckAutoUpgradeSupport() error {
+	if f.autoUpgradeSupported {
+		return nil
+	}
+	return errors.New("Test error")
+}
+
+func (f fakeConnection) SensorVersion() string {
+	return f.sensorVersion
+}

--- a/central/sensor/service/connection/upgradecontroller/register_connection_test.go
+++ b/central/sensor/service/connection/upgradecontroller/register_connection_test.go
@@ -15,46 +15,46 @@ func TestUpgradability(t *testing.T) {
 	type testCase struct {
 		centralVersion       string
 		sensorVersion        string
-		expectedStatus       storage.ClusterUpgradeStatus_Upgradability
 		autoUpgradeSupported bool
+		expectedStatus       storage.ClusterUpgradeStatus_Upgradability
 	}
 
 	cases := map[string]testCase{
 		"sensor version is empty": {
 			centralVersion:       "3.73.0",
 			sensorVersion:        "",
-			expectedStatus:       storage.ClusterUpgradeStatus_MANUAL_UPGRADE_REQUIRED,
 			autoUpgradeSupported: true,
+			expectedStatus:       storage.ClusterUpgradeStatus_MANUAL_UPGRADE_REQUIRED,
 		},
 		"sensor and central versions are equal": {
 			centralVersion:       "3.73.0",
 			sensorVersion:        "3.73.0",
-			expectedStatus:       storage.ClusterUpgradeStatus_UP_TO_DATE,
 			autoUpgradeSupported: true,
+			expectedStatus:       storage.ClusterUpgradeStatus_UP_TO_DATE,
 		},
 		"sensor version is lower than central": {
 			centralVersion:       "3.73.0",
 			sensorVersion:        "3.72.3",
-			expectedStatus:       storage.ClusterUpgradeStatus_AUTO_UPGRADE_POSSIBLE,
 			autoUpgradeSupported: true,
+			expectedStatus:       storage.ClusterUpgradeStatus_AUTO_UPGRADE_POSSIBLE,
 		},
 		"sensor version is higher than central": {
 			centralVersion:       "3.73.0",
 			sensorVersion:        "3.73.1",
-			expectedStatus:       storage.ClusterUpgradeStatus_SENSOR_VERSION_HIGHER,
 			autoUpgradeSupported: true,
+			expectedStatus:       storage.ClusterUpgradeStatus_SENSOR_VERSION_HIGHER,
 		},
 		"sensor version is lower than central when sensor does not support autoupgrade": {
 			centralVersion:       "3.73.0",
 			sensorVersion:        "3.72.3",
-			expectedStatus:       storage.ClusterUpgradeStatus_MANUAL_UPGRADE_REQUIRED,
 			autoUpgradeSupported: false,
+			expectedStatus:       storage.ClusterUpgradeStatus_MANUAL_UPGRADE_REQUIRED,
 		},
 		"sensor version is higher than central when sensor does not support autoupgrade": {
 			centralVersion:       "3.73.0",
 			sensorVersion:        "3.73.1",
-			expectedStatus:       storage.ClusterUpgradeStatus_MANUAL_UPGRADE_REQUIRED,
 			autoUpgradeSupported: false,
+			expectedStatus:       storage.ClusterUpgradeStatus_MANUAL_UPGRADE_REQUIRED,
 		},
 	}
 


### PR DESCRIPTION
## Description
For non-helm installations there's a special case when sensor is ahead of Central. In this case automatic upgrade is not possible, but we still allow user to "upgrade" it by clicking the link. Technically it will be a "downgrade," but we don't distinguish that in the UI. The operator/helm installation type was not taken into account in this special case and we're wrongly suggesting an upgrade as for another installations.

We should show the same message as we show when sensor version is below Central.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed
- unit tests
- ~manual test on ACSCS with the Secured Cluster running on Infra~ Unable to verify on non-release version 
