### PR TITLE
ROX-14381: Add nodes and cpu capacity to the secured cluster identity

### DIFF
--- a/central/cluster/datastore/telemetry.go
+++ b/central/cluster/datastore/telemetry.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stackrox/rox/central/role/resources"
 	"github.com/stackrox/rox/central/telemetry/centralclient"
+	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/telemetry/phonehome"
@@ -21,19 +22,23 @@ func trackClusterRegistered(cluster *storage.Cluster) {
 	}
 }
 
+func makeClusterProperties(cluster *storage.Cluster) map[string]any {
+	return map[string]any{
+		"Main Image":           cluster.GetMainImage(),
+		"Admission Controller": cluster.GetAdmissionController(),
+		"Collection Method":    cluster.GetCollectionMethod().String(),
+		"Collector Image":      cluster.GetCollectorImage(),
+		"Managed By":           cluster.GetManagedBy().String(),
+		"Priority":             cluster.GetPriority(),
+		"Cluster Type":         cluster.GetType().String(),
+		"Slim Collector":       cluster.GetSlimCollector(),
+	}
+}
+
 func trackClusterInitialized(cluster *storage.Cluster) {
 	if cfg := centralclient.InstanceConfig(); cfg.Enabled() {
 		cfg.Telemeter().Group(cfg.GroupID, cluster.GetId(), nil)
-		cfg.Telemeter().Identify(cluster.GetId(), map[string]any{
-			"Main Image":           cluster.GetMainImage(),
-			"Admission Controller": cluster.GetAdmissionController(),
-			"Collection Method":    cluster.GetCollectionMethod().String(),
-			"Collector Image":      cluster.GetCollectorImage(),
-			"Managed By":           cluster.GetManagedBy().String(),
-			"Priority":             cluster.GetPriority(),
-			"Cluster Type":         cluster.GetType().String(),
-			"Slim Collector":       cluster.GetSlimCollector(),
-		})
+		cfg.Telemeter().Identify(cluster.GetId(), makeClusterProperties(cluster))
 		cfg.Telemeter().Track("Secured Cluster Initialized", cluster.GetId(), map[string]any{
 			"Health": cluster.GetHealthStatus().OverallHealthStatus.String(),
 		})
@@ -52,4 +57,24 @@ var Gather phonehome.GatherFunc = func(ctx context.Context) (map[string]any, err
 		return nil, err
 	}
 	return props, nil
+}
+
+// UpdateSecuredClusterIdentity is called by the clustermetrics pipeline on
+// the reception of the cluster metrics from a sensor.
+func UpdateSecuredClusterIdentity(ctx context.Context, clusterID string, metrics *central.ClusterMetrics) {
+	if cfg := centralclient.InstanceConfig(); cfg.Enabled() {
+		ctx = sac.WithGlobalAccessScopeChecker(ctx,
+			sac.AllowFixedScopes(
+				sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
+				sac.ResourceScopeKeys(resources.Cluster)))
+
+		cluster, ok, err := Singleton().GetCluster(ctx, clusterID)
+		if err != nil || !ok {
+			return
+		}
+		props := makeClusterProperties(cluster)
+		props["Total Nodes"] = metrics.NodeCount
+		props["CPU Capacity"] = metrics.CpuCapacity
+		cfg.Telemeter().Identify(cluster.GetId(), makeClusterProperties(cluster))
+	}
 }

--- a/central/cluster/datastore/telemetry.go
+++ b/central/cluster/datastore/telemetry.go
@@ -75,6 +75,6 @@ func UpdateSecuredClusterIdentity(ctx context.Context, clusterID string, metrics
 		props := makeClusterProperties(cluster)
 		props["Total Nodes"] = metrics.NodeCount
 		props["CPU Capacity"] = metrics.CpuCapacity
-		cfg.Telemeter().Identify(cluster.GetId(), makeClusterProperties(cluster))
+		cfg.Telemeter().Identify(cluster.GetId(), props)
 	}
 }

--- a/central/cluster/datastore/telemetry.go
+++ b/central/cluster/datastore/telemetry.go
@@ -40,7 +40,7 @@ func trackClusterInitialized(cluster *storage.Cluster) {
 		cfg.Telemeter().Group(cfg.GroupID, cluster.GetId(), nil)
 		cfg.Telemeter().Identify(cluster.GetId(), makeClusterProperties(cluster))
 		cfg.Telemeter().Track("Secured Cluster Initialized", cluster.GetId(), map[string]any{
-			"Health": cluster.GetHealthStatus().OverallHealthStatus.String(),
+			"Health": cluster.GetHealthStatus().GetOverallHealthStatus().String(),
 		})
 	}
 }
@@ -76,5 +76,6 @@ func UpdateSecuredClusterIdentity(ctx context.Context, clusterID string, metrics
 		props["Total Nodes"] = metrics.NodeCount
 		props["CPU Capacity"] = metrics.CpuCapacity
 		cfg.Telemeter().Identify(cluster.GetId(), props)
+		cfg.Telemeter().Track("Secured Cluster Identity Update", cluster.GetId(), nil)
 	}
 }

--- a/central/sensor/service/pipeline/clustermetrics/pipeline.go
+++ b/central/sensor/service/pipeline/clustermetrics/pipeline.go
@@ -3,6 +3,7 @@ package clustermetrics
 import (
 	"context"
 
+	clusterTelemetry "github.com/stackrox/rox/central/cluster/datastore"
 	"github.com/stackrox/rox/central/metrics"
 	"github.com/stackrox/rox/central/sensor/service/common"
 	"github.com/stackrox/rox/central/sensor/service/pipeline"
@@ -17,6 +18,7 @@ var log = logging.LoggerForModule()
 //////////////////////////////////////////////////////////////////////////////////////
 
 // MetricsStore persists a measurement of ClusterMetrics.
+//
 //go:generate mockgen-wrapper
 type MetricsStore interface {
 	Set(string, *central.ClusterMetrics)
@@ -62,6 +64,8 @@ func (p *pipelineImpl) Run(
 	_ common.MessageInjector,
 ) error {
 	p.metricsStore.Set(clusterID, msg.GetClusterMetrics())
+
+	clusterTelemetry.UpdateSecuredClusterIdentity(ctx, clusterID, msg.GetClusterMetrics())
 	return nil
 }
 


### PR DESCRIPTION
## Description

Leverage sensor billing reporting for secured cluster identity gathering.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

Example message, where `b78a20fe-e528-4b1e-8b75-2adc812706a8` (see userId) is the secured cluster ID:
```json
{
  "context": {
    "Client ID": "c7bff33d-3b79-4741-9606-5f0fc5c0e8b3",
    "Client Name": "Central",
    "library": {
      "name": "analytics-go",
      "version": "3.0.0"
    }
  },
  "integrations": {},
  "messageId": "1c118ece-406d-4292-b270-b8ca17a4dafa",
  "originalTimestamp": "2023-01-17T13:01:01.789850923Z",
  "receivedAt": "2023-01-17T13:01:07.729Z",
  "sentAt": "2023-01-17T13:01:07.066Z",
  "timestamp": "2023-01-17T13:01:02.451Z",
  "traits": {
    "Admission Controller": true,
    "CPU Capacity": 8,
    "Cluster Type": "KUBERNETES_CLUSTER",
    "Collection Method": "EBPF",
    "Collector Image": "quay.io/stackrox-io/collector",
    "Main Image": "quay.io/stackrox-io/main:3.73.x-410-g99218f3310",
    "Managed By": "MANAGER_TYPE_MANUAL",
    "Priority": 1,
    "Slim Collector": true,
    "Total Nodes": 1
  },
  "type": "identify",
  "userId": "b78a20fe-e528-4b1e-8b75-2adc812706a8",
  "writeKey": "..."
}
```