### PR TITLE
ROX-130643: Show popover with link to troubleshooting collector for unhealthy cluster

### DIFF
--- a/ui/apps/platform/src/Containers/Clusters/Components/ClusterStatus.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/ClusterStatus.tsx
@@ -3,6 +3,8 @@ import { Button, Popover, PopoverPosition } from '@patternfly/react-core';
 import { ExclamationCircleIcon, ExternalLinkAltIcon } from '@patternfly/react-icons/dist/esm/icons';
 
 import { healthStatusLabels } from 'messages/common';
+import useMetadata from 'hooks/useMetadata';
+import { getVersionedDocs } from 'utils/versioning';
 import HealthStatus from './HealthStatus';
 import ClusterStatusPill from './ClusterStatusPill';
 import { healthStatusStyles } from '../cluster.helpers';
@@ -20,15 +22,20 @@ type ClusterStatusProps = {
 };
 
 function ClusterStatus({ healthStatus, isList = false }: ClusterStatusProps): ReactElement {
+    const { version } = useMetadata();
+
     const { overallHealthStatus } = healthStatus;
     const { Icon, bgColor, fgColor } = healthStatusStyles[overallHealthStatus];
     const icon = <Icon className={`${isList ? 'inline' : ''} h-4 w-4`} />;
 
     const unhealthyClusterDetailAvailable = overallHealthStatus === 'UNHEALTHY';
-    const bodyContent = (
+    const bodyContent = version ? (
         <Button
             component="a"
-            href="https://docs.openshift.com/acs/installing/installing_cloud_ocp/prerequisites-cloud-ocp.html#collector-prerequisites_prerequisites-cloud-ocp"
+            href={getVersionedDocs(
+                version,
+                'troubleshooting/retrieving-and-analyzing-the-collector-logs-and-pod-status.html'
+            )}
             variant="link"
             target="_blank"
             rel="noopener noreferrer"
@@ -38,6 +45,8 @@ function ClusterStatus({ healthStatus, isList = false }: ClusterStatusProps): Re
         >
             Troubleshooting collector
         </Button>
+    ) : (
+        <span>Documentation not available; version missing</span>
     );
 
     return (


### PR DESCRIPTION
## Description

Final UX design is from last comments of this ticket, https://issues.redhat.com/browse/ROX-13389

I tested the suggestion documentation link,
https://docs.openshift.com/acs/installing/installing_cloud_ocp/prerequisites-cloud-ocp.html#collector-prerequisites_prerequisites-cloud-ocp

and it successfully redirects to the current version of that page,
https://docs.openshift.com/acs/3.73/installing/installing_cloud_ocp/prerequisites-cloud-ocp.html#collector-prerequisites_prerequisites-cloud-ocp

## Checklist
- [x] Investigated and inspected CI test results (Go test failure is a flake)

## Testing Performed

I had to simulate a single cluster response with unhealthy cluster data to test this, so it is not easily reproducible.
(Local code change shown below screenshot)

![Screen Shot 2023-01-16 at 11 56 54 AM](https://user-images.githubusercontent.com/715729/212732235-991935c4-dfdf-4f98-a49c-7a0b9f208e07.png)


```diff
diff --git a/ui/apps/platform/src/services/ClustersService.ts b/ui/apps/platform/src/services/ClustersService.ts
index c640d9428e..ba9891b277 100644
--- a/ui/apps/platform/src/services/ClustersService.ts
+++ b/ui/apps/platform/src/services/ClustersService.ts
@@ -91,9 +91,150 @@ export function fetchClustersWithRetentionInfo(
 /*
  * Fetch secured cluster and its retention information.
  */
-export function fetchClusterWithRetentionInformation(id: string): Promise<ClusterResponse> {
-    return axios.get<ClusterResponse>(`${clustersUrl}/${id}`).then((response) => {
-        return response.data;
+export function fetchClusterWithRetentionInformation(id: string): Promise<any> {
+    return axios.get<any>(`${clustersUrl}/${id}`).then((response) => {
+        return {
+            cluster: {
+                id: '2a226ad1-9f7a-eb6d-b0e5-a0db4ad68161',
+                name: 'eta-7',
+                type: 'KUBERNETES_CLUSTER',
+                labels: {},
+                mainImage: 'stackrox/main:latest',
+                collectorImage: 'stackrox/collector',
+                centralApiEndpoint: 'central.stackrox:443',
+                runtimeSupport: false,
+                collectionMethod: 'KERNEL_MODULE',
+                admissionController: false,
+                admissionControllerUpdates: false,
+                admissionControllerEvents: true,
+                status: {
+                    sensorVersion: '3.0.50.0',
+                    providerMetadata: {
+                        region: 'us-west1',
+                        google: {},
+                    },
+                    orchestratorMetadata: {
+                        version: 'v1.14.8',
+                        buildDate: '2019-10-15T12:02:12Z',
+                        apiVersions: [],
+                    },
+                    upgradeStatus: {
+                        upgradability: 'UP_TO_DATE',
+                        upgradabilityStatusReason: 'sensor is running the same version as Central',
+                        mostRecentProcess: null,
+                    },
+                    certExpiryStatus: {
+                        sensorCertExpiry: '2020-09-29T13:01:00Z',
+                    },
+                },
+                dynamicConfig: {
+                    admissionControllerConfig: {
+                        enabled: false,
+                        timeoutSeconds: 3,
+                        scanInline: false,
+                        disableBypass: false,
+                    },
+                    registryOverride: '',
+                    disableAuditLogs: true,
+                },
+                tolerationsConfig: {
+                    disabled: false,
+                },
+                priority: '1',
+                healthStatus: {
+                    collectorHealthInfo: {
+                        totalDesiredPods: 5,
+                        totalReadyPods: 3,
+                        totalRegisteredNodes: 6,
+                    },
+                    admissionControlHealthInfo: {
+                        totalDesiredPods: 3,
+                        totalReadyPods: 1,
+                    },
+                    sensorHealthStatus: 'HEALTHY',
+                    collectorHealthStatus: 'UNHEALTHY',
+                    overallHealthStatus: 'UNHEALTHY',
+                    admissionControlHealthStatus: 'UNHEALTHY',
+                    lastContact: '2020-08-31T13:00:59Z',
+                    healthInfoComplete: true,
+                },
+                slimCollector: false,
+                helmConfig: {
+                    clusterName: 'eta-7',
+                    initToken: null,
+                    centralEndpoint: 'central.stackrox:443',
+                    imagePullSecrets: {
+                        useExisting: ['stackrox'],
+                    },
+                    image: {
+                        registry: 'stackrox.io',
+                    },
+                    env: {
+                        openshift: true,
+                    },
+                    sensor: {
+                        resources: {
+                            requests: {
+                                memory: '1Gi',
+                                cpu: '1',
+                            },
+                            limits: {
+                                memory: '4Gi',
+                                cpu: '2',
+                            },
+                        },
+                    },
+                    admissionControl: {
+                        enable: false,
+                        listenOnUpdates: false,
+                        enforceOnUpdates: false,
+                        dynamic: {
+                            enforce: false,
+                            scanInline: false,
+                            disableBypass: false,
+                            timeout: 3,
+                        },
+                        resources: {
+                            requests: {
+                                memory: '100Mi',
+                                cpu: '50m',
+                            },
+                            limits: {
+                                memory: '500Mi',
+                                cpu: '500m',
+                            },
+                        },
+                    },
+                    collector: {
+                        collectionMethod: 'KERNEL_MODULE',
+                        disableTaintTolerations: false,
+                        slimMode: true,
+                        resources: {
+                            requests: {
+                                memory: '320Mi',
+                                cpu: '50m',
+                            },
+                            limits: {
+                                memory: '1Gi',
+                                cpu: '750m',
+                            },
+                        },
+                        complianceResources: {
+                            requests: {
+                                memory: '10Mi',
+                                cpu: '10m',
+                            },
+                            limits: {
+                                memory: '2Gi',
+                                cpu: '1',
+                            },
+                        },
+                    },
+                },
+                managedBy: 'MANAGER_TYPE_KUBERNETES_OPERATOR',
+            },
+        };
+        // return response.data;
     });
 }
 

```