### PR TITLE
ROX-12423: Fix Artifactory Integration EOF Error

### DIFF
--- a/pkg/registries/artifactory/artifactory.go
+++ b/pkg/registries/artifactory/artifactory.go
@@ -34,7 +34,7 @@ func newRegistry(integration *storage.ImageIntegration) (types.Registry, error) 
 
 // Test implements a valid Test function for Artifactory
 func (r *registry) Test() error {
-	_, err := r.Client.Repositories()
+	err := r.Client.Ping()
 	if err != nil {
 		logger.Errorf("error testing Artifactory integration: %v", err)
 	}

--- a/pkg/registries/artifactory/artifactory.go
+++ b/pkg/registries/artifactory/artifactory.go
@@ -9,7 +9,6 @@ import (
 // Creator provides the type and registries.Creator to add to the registry of image registries.
 func Creator() (string, func(integration *storage.ImageIntegration) (types.Registry, error)) {
 	return "artifactory", func(integration *storage.ImageIntegration) (types.Registry, error) {
-		reg, err := docker.NewDockerRegistry(integration)
-		return reg, err
+		return docker.NewDockerRegistry(integration)
 	}
 }

--- a/pkg/registries/artifactory/artifactory.go
+++ b/pkg/registries/artifactory/artifactory.go
@@ -2,41 +2,14 @@ package artifactory
 
 import (
 	"github.com/stackrox/rox/generated/storage"
-	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/registries/docker"
 	"github.com/stackrox/rox/pkg/registries/types"
 )
 
-var (
-	logger = logging.LoggerForModule()
-)
-
 // Creator provides the type and registries.Creator to add to the registry of image registries.
 func Creator() (string, func(integration *storage.ImageIntegration) (types.Registry, error)) {
-	return "artifactory", newRegistry
-}
-
-var _ types.Registry = (*registry)(nil)
-
-type registry struct {
-	*docker.Registry
-}
-
-func newRegistry(integration *storage.ImageIntegration) (types.Registry, error) {
-	dockerRegistry, err := docker.NewDockerRegistry(integration)
-	if err != nil {
-		return nil, err
+	return "artifactory", func(integration *storage.ImageIntegration) (types.Registry, error) {
+		reg, err := docker.NewDockerRegistry(integration)
+		return reg, err
 	}
-	return &registry{
-		Registry: dockerRegistry,
-	}, nil
-}
-
-// Test implements a valid Test function for Artifactory
-func (r *registry) Test() error {
-	err := r.Client.Ping()
-	if err != nil {
-		logger.Errorf("error testing Artifactory integration: %v", err)
-	}
-	return err
 }


### PR DESCRIPTION
## Description
Setting up a new `JFrog Artifactory` integration in Stackrox when Artifactory is configured to use the `Repository Path` Docker Access Method will trigger an error: `registry integration: EOF: invalid arguments: invalid arguments`, this error does not occur when using the `Generic Docker` integration.

The Artifactory and Docker integrations differ only in the method which performs the initial test; this is rumored to be due to Artifactory historically not implementing the endpoint called by [docker-registry-client's `Ping()`](https://github.com/stackrox/docker-registry-client/blob/3c566c2fa4277f181f06167309eb6f4b02de9b77/registry/registry.go#L119-L120) method. 

This PR changes the Artifactory integration's `Test()` method to mimic that of the Docker integration

## Checklist
- [x] Investigated and inspected CI test results
- [ ] ~Unit test and regression tests added~
- [X] Evaluated and added CHANGELOG entry if required
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

No additional unit or regression tests were added - that would require setting up multiple private instances of Artifactory during test execution.  Additionally, not all settings necessary to re-create the appropriate test conditions can be  automated easily during Artifactory setup.

CHANGELOG was not updated as it appears bug fixes are not applicable based on reviewing recent past.

There are no changes to upgrade steps or user documentation necessary as part of this PR

## Testing Performed

Different versions of [JFrog Container Registry](https://www.jfrog.com/confluence/display/JFROG/JFrog+Container+Registry) (Artifactory) were installed and settings modified to duplicate the error as well as learn conditions under which the error would not occur. Based on testing it was determined the Artifactory [Docker Access Method](https://www.jfrog.com/confluence/display/RTF6X/Getting+Started+with+Artifactory+as+a+Docker+Registry#GettingStartedwithArtifactoryasaDockerRegistry-ConfiguringArtifactory.1) has a direct impact on the occurrence of this error. No other settings tested had an impact

Repository Path Access Method | Sub Domain Access Method
--- | --- 
![image](https://user-images.githubusercontent.com/119438707/212942208-d4a336b7-cc79-4be0-ac14-522cab765516.png) | ![image](https://user-images.githubusercontent.com/119438707/212942643-25c789d2-747d-439f-8fe9-51e404060e09.png)

The oldest (`v7.23.3`) and newest (`v7.49.5`) supported versions of JFrog Container Registry (JCR), per [End of Life](https://www.jfrog.com/confluence/display/JFROG/Artifactory+End+of+Life) doc, were installed and tested with the different access methods.

Installation of JCR was performed via the official [JFrog Container Registry Helm Chart](https://artifacthub.io/packages/helm/jfrog/artifactory-jcr) using the following values:

```yaml
artifactory:
  ingress:
    enabled: false
    hosts:
    - "arti.local"
    - "docker.arti.local"
  postgresql:
    enabled: false
  artifactory:
    persistence:
      enabled: false
  nginx:
    tlsSecretName: "nginx-tls"
```
`hosts` files were modified to enable resolution of `arti.local` and `docker.arti.local` as well as custom certs created/setup to allow for TLS validation (via `openssl`)

Integration setup was re-tested post change:

Repository Path Access Method | Sub Domain Access Method
--- | --- 
![image](https://user-images.githubusercontent.com/119438707/212952056-ecf12f7e-5323-457e-9a86-b8489bd73027.png) | ![image](https://user-images.githubusercontent.com/119438707/212952097-108e2f29-cc6e-4acf-bdbe-234e6c49f11a.png)

Additionally `roxctl image scan` was executed for various images for each of the Docker Access Methods - which worked as expected.
