### PR TITLE
[ROX-14516] Standardize postgres search query parser steps

### DIFF
--- a/pkg/postgres/walker/schema.go
+++ b/pkg/postgres/walker/schema.go
@@ -488,7 +488,7 @@ type Field struct {
 // DerivedSearchField represents a search field that's derived.
 // It includes the name of the derived field, as well as the derivation type.
 type DerivedSearchField struct {
-	FieldName      string
+	DerivedFrom    string
 	DerivationType search.DerivationType
 }
 

--- a/pkg/postgres/walker/walker.go
+++ b/pkg/postgres/walker/walker.go
@@ -273,7 +273,7 @@ func getSearchOptions(ctx context, searchTag string) (SearchField, []DerivedSear
 		derivedSearchFields = make([]DerivedSearchField, 0, len(derivedSearchFieldsMap))
 		for fieldName, derivationType := range derivedSearchFieldsMap {
 			derivedSearchFields = append(derivedSearchFields, DerivedSearchField{
-				FieldName:      fieldName,
+				DerivedFrom:    fieldName,
 				DerivationType: derivationType,
 			})
 		}

--- a/pkg/search/postgres/joins.go
+++ b/pkg/search/postgres/joins.go
@@ -149,7 +149,7 @@ func getJoinsAndFields(src *walker.Schema, q *v1.Query) ([]innerJoin, map[string
 
 			for _, derivedF := range field.DerivedSearchFields {
 				derivedField := derivedF
-				lowerCaseDerivedName := strings.ToLower(derivedField.FieldName)
+				lowerCaseDerivedName := strings.ToLower(derivedField.DerivedFrom)
 				if unreachedFields.Remove(lowerCaseDerivedName) {
 					reachableFields[lowerCaseDerivedName] = searchFieldMetadata{
 						baseField:       &field,


### PR DESCRIPTION
## Description

This PR standardizes a few steps in search query parsing. This is split out from the GROUP BY clause POC that I am working on.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed
Unit tests cover the refactor