### PR TITLE
ROX-14396: ignore kubectl outputs when checking logs

### DIFF
--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -302,7 +302,7 @@ check_for_errors_in_stackrox_logs() {
     logs=$(ls "$dir"/stackrox/pods/*.log)
     local filtered
     # shellcheck disable=SC2010,SC2086
-    filtered=$(ls $logs | grep -v "previous.log" || true)
+    filtered=$(ls $logs | grep -Ev "(previous|_describe).log$" || true)
     if [[ -n "$filtered" ]]; then
         # shellcheck disable=SC2086
         if ! scripts/ci/logcheck/check.sh $filtered; then


### PR DESCRIPTION
## Description

See detailed rationale in the ticket.

Note this also tightens the expression a bit to only look at the trailing part of filenames.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

Ran a manual test like this:

```
$ ls
admission-control-9cc8464cb-7k479-admission-control.log  admission-control-9cc8464cb-dg6px-admission-control.log  central-69bcff5c8f-48lkh-central.log
admission-control-9cc8464cb-7k479_describe.log           admission-control-9cc8464cb-dg6px_describe.log           central-69bcff5c8f-48lkh-central_previous.log
$ filtered=$(ls $logs | grep -Ev "(previous|_describe).log$" || true)
$ echo $filtered
admission-control-9cc8464cb-7k479-admission-control.log admission-control-9cc8464cb-dg6px-admission-control.log central-69bcff5c8f-48lkh-central.log
```