### PR TITLE
ROX-14284 add resync environment variable

### DIFF
--- a/pkg/env/sensor.go
+++ b/pkg/env/sensor.go
@@ -24,5 +24,5 @@ var (
 	EventPipelineOutputQueueSize = RegisterIntegerSetting("ROX_EVENT_PIPELINE_OUTPUT_QUEUE_SIZE", 100)
 
 	// ResyncDisabled is used to specify if Sensor should have re-sync disabled or not
-	ResyncDisabled = RegisterBooleanSetting("ROX_RESYNC_DISABLED", false)
+	ResyncDisabled = RegisterBooleanSetting("ROX_RESYNC_DISABLED", true)
 )

--- a/pkg/env/sensor.go
+++ b/pkg/env/sensor.go
@@ -22,4 +22,7 @@ var (
 
 	// EventPipelineOutputQueueSize is used to specify the size of the eventPipeline's output queue
 	EventPipelineOutputQueueSize = RegisterIntegerSetting("ROX_EVENT_PIPELINE_OUTPUT_QUEUE_SIZE", 100)
+
+	// ResyncDisabled is used to specify if Sensor should have re-sync disabled or not
+	ResyncDisabled = RegisterBooleanSetting("ROX_RESYNC_DISABLED", false)
 )

--- a/pkg/env/sensor.go
+++ b/pkg/env/sensor.go
@@ -24,5 +24,5 @@ var (
 	EventPipelineOutputQueueSize = RegisterIntegerSetting("ROX_EVENT_PIPELINE_OUTPUT_QUEUE_SIZE", 100)
 
 	// ResyncDisabled is used to specify if Sensor should have re-sync disabled or not
-	ResyncDisabled = RegisterBooleanSetting("ROX_RESYNC_DISABLED", true)
+	ResyncDisabled = RegisterBooleanSetting("ROX_RESYNC_DISABLED", false)
 )

--- a/pkg/env/sensor.go
+++ b/pkg/env/sensor.go
@@ -23,6 +23,6 @@ var (
 	// EventPipelineOutputQueueSize is used to specify the size of the eventPipeline's output queue
 	EventPipelineOutputQueueSize = RegisterIntegerSetting("ROX_EVENT_PIPELINE_OUTPUT_QUEUE_SIZE", 100)
 
-	// ResyncDisabled is used to specify if Sensor should have re-sync disabled or not
+	// ResyncDisabled disables the resync behavior of the kubernetes listeners in sensor
 	ResyncDisabled = RegisterBooleanSetting("ROX_RESYNC_DISABLED", false)
 )

--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -53,9 +53,6 @@ var (
 	// ProcessesListeningOnPort enables the NetworkFlow code to also update the processes that are listening on ports
 	ProcessesListeningOnPort = registerFeature("Enable Processes Listening on Port", "ROX_PROCESSES_LISTENING_ON_PORT", false)
 
-	// ResyncDisabled disables the resync behavior of the kubernetes listeners in sensor
-	ResyncDisabled = registerFeature("Disable the re-sync", "ROX_RESYNC_DISABLED", false)
-
 	// ClairV4Scanner enables Clair v4 as an Image Integration option
 	ClairV4Scanner = registerFeature("Enable Clair v4 as an Image Integration option", "ROX_CLAIR_V4_SCANNING", false)
 

--- a/sensor/kubernetes/eventpipeline/pipeline.go
+++ b/sensor/kubernetes/eventpipeline/pipeline.go
@@ -7,7 +7,6 @@ import (
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/env"
-	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/sensor/common"
 	"github.com/stackrox/rox/sensor/common/config"
 	"github.com/stackrox/rox/sensor/common/detector"
@@ -25,7 +24,7 @@ func New(client client.Interface, configHandler config.Handler, detector detecto
 	outputQueue := output.New(detector, env.EventPipelineOutputQueueSize.IntegerSetting())
 	var depResolver component.Resolver
 	var resourceListener component.PipelineComponent
-	if features.ResyncDisabled.Enabled() {
+	if env.ResyncDisabled.BooleanSetting() {
 		depResolver = resolver.New(outputQueue, storeProvider)
 		resourceListener = listener.New(client, configHandler, nodeName, resyncPeriod, traceWriter, depResolver, storeProvider)
 	} else {

--- a/sensor/kubernetes/eventpipeline/pipeline_impl.go
+++ b/sensor/kubernetes/eventpipeline/pipeline_impl.go
@@ -4,7 +4,7 @@ import (
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/pkg/centralsensor"
 	"github.com/stackrox/rox/pkg/concurrency"
-	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/component"
 )
@@ -45,7 +45,7 @@ func (p *eventPipeline) Start() error {
 		return err
 	}
 
-	if features.ResyncDisabled.Enabled() {
+	if env.ResyncDisabled.BooleanSetting() {
 		if err := p.resolver.Start(); err != nil {
 			return err
 		}
@@ -65,7 +65,7 @@ func (p *eventPipeline) Stop(_ error) {
 	// The order is important here, we need to stop the components
 	// that send messages to other components first
 	p.listener.Stop(nil)
-	if features.ResyncDisabled.Enabled() {
+	if env.ResyncDisabled.BooleanSetting() {
 		p.resolver.Stop(nil)
 	}
 	p.output.Stop(nil)

--- a/sensor/kubernetes/listener/resource_event_handler.go
+++ b/sensor/kubernetes/listener/resource_event_handler.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/pkg/complianceoperator"
 	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/kubernetes"
 	"github.com/stackrox/rox/pkg/sync"
@@ -24,7 +25,7 @@ import (
 func (k *listenerImpl) handleAllEvents() {
 	// TODO(ROX-14194): remove resyncingSif once all resources are adapted
 	var resyncingSif informers.SharedInformerFactory
-	if features.ResyncDisabled.Enabled() {
+	if env.ResyncDisabled.BooleanSetting() {
 		resyncingSif = informers.NewSharedInformerFactory(k.client.Kubernetes(), noResyncPeriod)
 	} else {
 		resyncingSif = informers.NewSharedInformerFactory(k.client.Kubernetes(), k.resyncPeriod)

--- a/sensor/kubernetes/listener/resources/deployments.go
+++ b/sensor/kubernetes/listener/resources/deployments.go
@@ -7,7 +7,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
-	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/process/filter"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/utils"
@@ -178,7 +178,7 @@ func (d *deploymentHandler) processWithType(obj, oldObj interface{}, action cent
 
 	events = d.appendIntegrationsOnCredentials(action, deploymentWrap.GetContainers(), events)
 
-	if features.ResyncDisabled.Enabled() {
+	if env.ResyncDisabled.BooleanSetting() {
 		if action == central.ResourceAction_REMOVE_RESOURCE {
 			// TODO(ROX-14309): move this logic to the resolver
 			// We need to do this here since the resolver relies on the deploymentStore to have the wrap

--- a/sensor/kubernetes/listener/resources/networkpolicy.go
+++ b/sensor/kubernetes/listener/resources/networkpolicy.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/features"
 	networkPolicyConversion "github.com/stackrox/rox/pkg/protoconv/networkpolicy"
 	"github.com/stackrox/rox/sensor/common/selector"
@@ -45,7 +46,7 @@ func (h *networkPolicyDispatcher) ProcessEvent(obj, old interface{}, action cent
 			h.netpolStore.Upsert(roxNetpol)
 		}
 
-		if features.ResyncDisabled.Enabled() {
+		if env.ResyncDisabled.BooleanSetting() {
 			events = component.NewDeploymentRefEvent(resolver.ResolveDeploymentLabels(roxNetpol.GetNamespace(), sel), central.ResourceAction_UPDATE_RESOURCE, true)
 			events = component.MergeResourceEvents(events, component.NewResourceEvent(
 				[]*central.SensorEvent{

--- a/sensor/kubernetes/listener/resources/networkpolicy_test.go
+++ b/sensor/kubernetes/listener/resources/networkpolicy_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/protoconv"
 	networkPolicyConversion "github.com/stackrox/rox/pkg/protoconv/networkpolicy"
@@ -399,7 +400,7 @@ func (suite *NetworkPolicyDispatcherSuite) Test_ProcessEvent() {
 			events := suite.dispatcher.ProcessEvent(c.netpol, c.oldNetpol, c.action)
 			deps := set.NewStringSet()
 			require.NotNil(t, events)
-			if !features.ResyncDisabled.Enabled() {
+			if !env.ResyncDisabled.BooleanSetting() {
 				// If re-sync is disabled we don't send the CompatibilityReprocess in the dispatcher
 				deps.AddAll(events.CompatibilityReprocessDeployments...)
 				for _, d := range c.expectedDeployments {

--- a/sensor/kubernetes/listener/resources/rbac/dispatcher.go
+++ b/sensor/kubernetes/listener/resources/rbac/dispatcher.go
@@ -3,7 +3,7 @@ package rbac
 import (
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
-	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/sensor/common/store/resolver"
 	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/component"
@@ -115,14 +115,14 @@ func (r *Dispatcher) processEvent(obj interface{}, action central.ResourceAction
 }
 
 func (r *Dispatcher) findSubjectForBinding(binding metav1.Object) []namespacedSubject {
-	if features.ResyncDisabled.Enabled() {
+	if env.ResyncDisabled.BooleanSetting() {
 		return r.store.FindSubjectForBindingID(binding.GetNamespace(), binding.GetName(), string(binding.GetUID()))
 	}
 	return nil
 }
 
 func (r *Dispatcher) findSubjectForRole(role metav1.Object) []namespacedSubject {
-	if features.ResyncDisabled.Enabled() {
+	if env.ResyncDisabled.BooleanSetting() {
 		return r.store.FindSubjectForRole(role.GetNamespace(), role.GetName())
 	}
 	return nil
@@ -130,7 +130,7 @@ func (r *Dispatcher) findSubjectForRole(role metav1.Object) []namespacedSubject 
 
 func (r *Dispatcher) mustGenerateRelatedEvents(obj metav1.Object, roleID string, isClusterRole bool) []*central.SensorEvent {
 	// Only generate related binding events if re-sync is not enabled. Otherwise, binding events will be reprocessed every minute.
-	if features.ResyncDisabled.Enabled() {
+	if env.ResyncDisabled.BooleanSetting() {
 		relatedBindings := r.store.FindBindingForNamespacedRole(obj.GetNamespace(), obj.GetName())
 		events, err := r.fetcher.generateManyDependentEvents(relatedBindings, roleID, isClusterRole)
 		if err != nil {

--- a/sensor/kubernetes/listener/resources/rbac/store_impl_test.go
+++ b/sensor/kubernetes/listener/resources/rbac/store_impl_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
-	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/protoconv"
 	"github.com/stackrox/rox/pkg/uuid"
 	"github.com/stackrox/rox/sensor/common/store/mocks"
@@ -23,11 +22,7 @@ import (
 
 func TestStore_DispatcherEvents(t *testing.T) {
 	// Run these tests only with feature flag enabled. Changes to the old path should be avoided whenever possible.
-	// TODO(ROX-14284): Re-enable this tests setting the custom env rather than the feature flag
 	t.Setenv("ROX_RESYNC_DISABLED", "true")
-	if !features.ResyncDisabled.Enabled() {
-		t.Skipf("Tests will fail if the new resyncless pass is disabled. E.g. in release tests")
-	}
 	// Namespace: n1
 	// Role: r1
 	// Bindings:
@@ -431,11 +426,7 @@ func TestStore_DispatcherEvents(t *testing.T) {
 
 func TestStore_DeploymentRelationship(t *testing.T) {
 	// Run these tests only with feature flag enabled. Changes to the old path should be avoided whenever possible.
-	// TODO(ROX-14284): Re-enable this tests setting the custom env rather than the feature flag
 	t.Setenv("ROX_RESYNC_DISABLED", "true")
-	if !features.ResyncDisabled.Enabled() {
-		t.Skipf("Tests will fail if the new resyncless pass is disabled. E.g. in release tests")
-	}
 	roles := []*v1.Role{
 		{
 			ObjectMeta: metav1.ObjectMeta{

--- a/sensor/kubernetes/listener/resources/route_test.go
+++ b/sensor/kubernetes/listener/resources/route_test.go
@@ -5,7 +5,7 @@ import (
 
 	routeV1 "github.com/openshift/api/route/v1"
 	"github.com/stackrox/rox/generated/internalapi/central"
-	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/uuid"
 	"github.com/stackrox/rox/sensor/common/selector"
 	"github.com/stretchr/testify/suite"
@@ -135,7 +135,7 @@ func (suite *RouteAndServiceDispatcherTestSuite) SetupTest() {
 }
 
 func (suite *RouteAndServiceDispatcherTestSuite) TestServiceCreateNoRoute() {
-	if features.ResyncDisabled.Enabled() {
+	if env.ResyncDisabled.BooleanSetting() {
 		// TODO(ROX-14310): remove the test
 		suite.T().Skip("If re-sync is disabled we don't call EndpointManager for CREATE and UPDATE events in the dispatcher")
 	}
@@ -151,7 +151,7 @@ func (suite *RouteAndServiceDispatcherTestSuite) TestServiceCreateNoRoute() {
 }
 
 func (suite *RouteAndServiceDispatcherTestSuite) TestServiceCreateWithPreexistingRoute() {
-	if features.ResyncDisabled.Enabled() {
+	if env.ResyncDisabled.BooleanSetting() {
 		// TODO(ROX-14310): remove the test
 		suite.T().Skip("If re-sync is disabled we don't call EndpointManager for CREATE and UPDATE events in the dispatcher")
 	}
@@ -169,7 +169,7 @@ func (suite *RouteAndServiceDispatcherTestSuite) TestServiceCreateWithPreexistin
 }
 
 func (suite *RouteAndServiceDispatcherTestSuite) TestManyRoutesMatchingAndDeletions() {
-	if features.ResyncDisabled.Enabled() {
+	if env.ResyncDisabled.BooleanSetting() {
 		// TODO(ROX-14310): remove the test
 		suite.T().Skip("If re-sync is disabled we don't call EndpointManager for CREATE and UPDATE events in the dispatcher")
 	}

--- a/sensor/kubernetes/listener/resources/service.go
+++ b/sensor/kubernetes/listener/resources/service.go
@@ -4,7 +4,7 @@ import (
 	routeV1 "github.com/openshift/api/route/v1"
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
-	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/sensor/common/selector"
 	"github.com/stackrox/rox/sensor/common/service"
 	"github.com/stackrox/rox/sensor/common/store/resolver"
@@ -171,7 +171,7 @@ func (sh *serviceDispatcher) ProcessEvent(obj, _ interface{}, action central.Res
 
 func (sh *serviceDispatcher) updateDeploymentsFromStore(namespace string, sel selector.Selector) *component.ResourceEvent {
 	var message *component.ResourceEvent
-	if features.ResyncDisabled.Enabled() {
+	if env.ResyncDisabled.BooleanSetting() {
 		message = component.NewDeploymentRefEvent(resolver.ResolveDeploymentLabels(namespace, sel), central.ResourceAction_UPDATE_RESOURCE, false)
 	} else {
 		message = component.NewResourceEvent(sh.portExposureReconciler.UpdateExposuresForMatchingDeployments(namespace, sel), nil, nil)
@@ -184,7 +184,7 @@ func (sh *serviceDispatcher) processCreate(svc *v1.Service) *component.ResourceE
 	svcWrap := wrapService(svc)
 	sh.serviceStore.addOrUpdateService(svcWrap)
 	var message *component.ResourceEvent
-	if features.ResyncDisabled.Enabled() {
+	if env.ResyncDisabled.BooleanSetting() {
 		message = component.NewDeploymentRefEvent(resolver.ResolveDeploymentLabels(svc.GetNamespace(), svcWrap.selector), central.ResourceAction_UPDATE_RESOURCE, false)
 	} else {
 		events := sh.portExposureReconciler.UpdateExposureOnServiceCreate(serviceWithRoutes{


### PR DESCRIPTION
## Description

Swaps the ResyncDisabled feature flag to an environment variable.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

* CI with and without `ROX_RESYNC_DISABLED`
  * Two runs with resync enabled [cfe931b](https://prow.ci.openshift.org/pr-history/?org=stackrox&repo=stackrox&pr=4431)
  * Two runs with resync disabled [9b7b7f2](https://prow.ci.openshift.org/pr-history/?org=stackrox&repo=stackrox&pr=4431)
