### PR TITLE
GHA: prepare the migration of release logic from OSCI to GHA

### DIFF
--- a/.github/workflows/release-ci.yaml
+++ b/.github/workflows/release-ci.yaml
@@ -1,0 +1,16 @@
+name: Release CI
+on:
+  push:
+    branches:
+    - 'release-*'
+    tags-ignore:
+    - 'nightly-*'
+
+jobs:
+  run-parameters:
+    name: Run parameters
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "Event: ${{ github.event_name }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "Ref: ${{ github.ref_name }}" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Description

Adds a release-ci workflow to prepare the migration of the release logic from OSCI to GHA. This is required to test the new workflow in a separate branch.

## Checklist
- ~[ ] Investigated and inspected CI test results~
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

Nothing to test here.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
