### PR TITLE
ROX-14345: Added ability to toggle alerting on baseline violations

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/api/useFetchNetworkBaselines.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/api/useFetchNetworkBaselines.ts
@@ -7,7 +7,7 @@ import { Flow, FlowEntityType } from '../types/flow.type';
 
 type Result = {
     isLoading: boolean;
-    data: { networkBaselines: Flow[]; isAlertingEnabled: boolean };
+    data: { networkBaselines: Flow[]; isAlertingOnBaselineViolation: boolean };
     error: string | null;
 };
 
@@ -16,7 +16,7 @@ type FetchNetworkBaselinesResult = {
 } & Result;
 
 const defaultResultState = {
-    data: { networkBaselines: [], isAlertingEnabled: false },
+    data: { networkBaselines: [], isAlertingOnBaselineViolation: false },
     error: null,
     isLoading: true,
 };
@@ -32,7 +32,7 @@ function useFetchNetworkBaselines(deploymentId): FetchNetworkBaselinesResult {
         fetchNetworkBaselines({ deploymentId })
             .then((response: NetworkBaseline) => {
                 const { peers, locked, namespace } = response;
-                const isAlertingEnabled = locked;
+                const isAlertingOnBaselineViolation = locked;
                 const networkBaselines = peers.reduce((acc, currPeer) => {
                     const currPeerType = currPeer.entity.info.type;
                     const entityId = currPeer.entity.info.id;
@@ -72,7 +72,7 @@ function useFetchNetworkBaselines(deploymentId): FetchNetworkBaselinesResult {
                 }, [] as Flow[]);
                 setResult({
                     isLoading: false,
-                    data: { networkBaselines, isAlertingEnabled },
+                    data: { networkBaselines, isAlertingOnBaselineViolation },
                     error: null,
                 });
             })
@@ -83,7 +83,7 @@ function useFetchNetworkBaselines(deploymentId): FetchNetworkBaselinesResult {
 
                 setResult({
                     isLoading: false,
-                    data: { networkBaselines: [], isAlertingEnabled: false },
+                    data: { networkBaselines: [], isAlertingOnBaselineViolation: false },
                     error: errorMessage,
                 });
             });

--- a/ui/apps/platform/src/Containers/NetworkGraph/api/useToggleAlertingOnBaselineViolation.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/api/useToggleAlertingOnBaselineViolation.ts
@@ -1,0 +1,47 @@
+import { useState } from 'react';
+import { toggleAlertBaselineViolations } from 'services/NetworkService';
+import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
+
+type Result = {
+    isToggling: boolean;
+    error: string;
+};
+
+type ToggleAlertingOnBaselineViolation = {
+    toggleAlertingOnBaselineViolation: (enable: boolean, onSuccessCallback: () => void) => void;
+} & Result;
+
+const defaultResult = {
+    isToggling: false,
+    error: '',
+};
+
+function useToggleAlertingOnBaselineViolation(deploymentId): ToggleAlertingOnBaselineViolation {
+    const [result, setResult] = useState<Result>(defaultResult);
+
+    function toggleAlertingOnBaselineViolation(enable: boolean, onSuccessCallback: () => void) {
+        setResult({ isToggling: true, error: '' });
+        toggleAlertBaselineViolations({
+            deploymentId,
+            enable,
+        })
+            .then(() => {
+                setResult({ isToggling: false, error: '' });
+                onSuccessCallback();
+            })
+            .catch((error) => {
+                const message = getAxiosErrorMessage(error);
+                const errorMessage =
+                    message || 'An unknown error occurred while getting the list of clusters';
+
+                setResult({ isToggling: false, error: errorMessage });
+            });
+    }
+
+    return {
+        ...result,
+        toggleAlertingOnBaselineViolation,
+    };
+}
+
+export default useToggleAlertingOnBaselineViolation;


### PR DESCRIPTION
## Description

This PR adds the ability to toggle alerting on baseline violations within the deployment baselines tab

https://user-images.githubusercontent.com/4805485/212948012-2a0105db-f731-48d1-95b0-eb984c0b6fc4.mov

Note: Flickering happens because we're loading and we show a spinner, but it's pretty quick. I feel like maybe it would be better if the table becomes disabled and we show an overlay with a spinner, but not sure that is consistent with our other tables. Although, I feel like it would feel smoother

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps`
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~
