### PR TITLE
ROX-14339: Telemetry: Try to get user before adding it to the tenant group

### DIFF
--- a/central/role/mapper/store_based_mapper_impl.go
+++ b/central/role/mapper/store_based_mapper_impl.go
@@ -34,10 +34,6 @@ func (rm *storeBasedMapperImpl) FromUserDescriptor(ctx context.Context, user *pe
 func (rm *storeBasedMapperImpl) recordUser(ctx context.Context, descriptor *permissions.UserDescriptor) {
 	user := rm.createUser(descriptor)
 
-	// Telemetry logic: add the first time logging in users to the group of
-	// other players like central and fleet manager under the tenant group, so
-	// that the users share the common tenant properties like organization ID
-	// available for analytics purposes:
 	if existing, _ := rm.users.GetUser(ctx, user.GetId()); existing == nil && user != nil {
 		addUserToTenantGroup(user)
 	}

--- a/central/role/mapper/store_based_mapper_impl.go
+++ b/central/role/mapper/store_based_mapper_impl.go
@@ -7,7 +7,6 @@ import (
 	"github.com/pkg/errors"
 	groupDataStore "github.com/stackrox/rox/central/group/datastore"
 	roleDataStore "github.com/stackrox/rox/central/role/datastore"
-	"github.com/stackrox/rox/central/telemetry/centralclient"
 	userDataStore "github.com/stackrox/rox/central/user/datastore"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/auth/permissions"
@@ -34,13 +33,14 @@ func (rm *storeBasedMapperImpl) FromUserDescriptor(ctx context.Context, user *pe
 
 func (rm *storeBasedMapperImpl) recordUser(ctx context.Context, descriptor *permissions.UserDescriptor) {
 	user := rm.createUser(descriptor)
+
+	if existing, _ := rm.users.GetUser(ctx, user.GetId()); existing == nil && user != nil {
+		addUserToTenantGroup(user)
+	}
+
 	if err := rm.users.Upsert(ctx, user); err != nil {
 		// Just log since we don't actually need the user information.
 		log.Errorf("unable to log user: %s: %v", proto.MarshalTextString(user), err)
-	}
-	if cfg := centralclient.InstanceConfig(); user != nil && cfg.Enabled() {
-		// Add the user to the tenant group.
-		cfg.Telemeter().Group(cfg.GroupID, cfg.HashUserID(user.GetId(), user.GetAuthProviderId()), nil)
 	}
 }
 

--- a/central/role/mapper/store_based_mapper_impl.go
+++ b/central/role/mapper/store_based_mapper_impl.go
@@ -38,7 +38,7 @@ func (rm *storeBasedMapperImpl) recordUser(ctx context.Context, descriptor *perm
 	// other players like central and fleet manager under the tenant group, so
 	// that the users share the common tenant properties like organization ID
 	// available for analytics purposes:
-	if existing, _ := rm.users.GetUser(ctx, user.GetId()); existing == nil && user != nil {
+	if existing, _ := rm.users.GetUser(ctx, user.GetId()); existing == nil {
 		addUserToTenantGroup(user)
 	}
 

--- a/central/role/mapper/store_based_mapper_impl.go
+++ b/central/role/mapper/store_based_mapper_impl.go
@@ -34,6 +34,10 @@ func (rm *storeBasedMapperImpl) FromUserDescriptor(ctx context.Context, user *pe
 func (rm *storeBasedMapperImpl) recordUser(ctx context.Context, descriptor *permissions.UserDescriptor) {
 	user := rm.createUser(descriptor)
 
+	// Telemetry logic: add the first time logging in users to the group of
+	// other players like central and fleet manager under the tenant group, so
+	// that the users share the common tenant properties like organization ID
+	// available for analytics purposes:
 	if existing, _ := rm.users.GetUser(ctx, user.GetId()); existing == nil && user != nil {
 		addUserToTenantGroup(user)
 	}

--- a/central/role/mapper/store_based_mapper_impl_test.go
+++ b/central/role/mapper/store_based_mapper_impl_test.go
@@ -73,6 +73,7 @@ func (s *MapperTestSuite) TestMapperSuccessForRoleAbsence() {
 			},
 		},
 	}
+	s.mockUsers.EXPECT().GetUser(s.requestContext, expectedUser.Id).Times(1).Return(nil, nil)
 	s.mockUsers.EXPECT().Upsert(s.requestContext, expectedUser).Times(1).Return(nil)
 
 	expectedAttributes := map[string][]string{
@@ -107,6 +108,7 @@ func (s *MapperTestSuite) TestMapperSuccessForSingleRole() {
 			},
 		},
 	}
+	s.mockUsers.EXPECT().GetUser(s.requestContext, expectedUser.Id).Times(1).Return(nil, nil)
 	s.mockUsers.EXPECT().Upsert(s.requestContext, expectedUser).Times(1).Return(nil)
 
 	// Expect the user to have a group mapping for a role.
@@ -160,6 +162,7 @@ func (s *MapperTestSuite) TestMapperSuccessForOnlyNoneRole() {
 			},
 		},
 	}
+	s.mockUsers.EXPECT().GetUser(s.requestContext, expectedUser.Id).Times(1).Return(nil, nil)
 	s.mockUsers.EXPECT().Upsert(s.requestContext, expectedUser).Times(1).Return(nil)
 
 	// Expect the user to have a group mapping to the None role.
@@ -213,6 +216,7 @@ func (s *MapperTestSuite) TestMapperSuccessForMultiRole() {
 			},
 		},
 	}
+	s.mockUsers.EXPECT().GetUser(s.requestContext, expectedUser.Id).Times(1).Return(nil, nil)
 	s.mockUsers.EXPECT().Upsert(s.requestContext, expectedUser).Times(1).Return(nil)
 
 	// Expect the user to have a two group mappings for two roles.
@@ -284,6 +288,7 @@ func (s *MapperTestSuite) TestMapperSuccessForMultipleRolesIncludingNone() {
 			},
 		},
 	}
+	s.mockUsers.EXPECT().GetUser(s.requestContext, expectedUser.Id).Times(1).Return(nil, nil)
 	s.mockUsers.EXPECT().Upsert(s.requestContext, expectedUser).Times(1).Return(nil)
 
 	// Expect the user to have multiple group mappings for roles including None.
@@ -353,6 +358,7 @@ func (s *MapperTestSuite) TestUserUpsertFailureDoesntMatter() {
 			},
 		},
 	}
+	s.mockUsers.EXPECT().GetUser(s.requestContext, expectedUser.Id).Times(1).Return(nil, nil)
 	s.mockUsers.EXPECT().Upsert(s.requestContext, expectedUser).Times(1).Return(errors.New("error that shouldnt matter"))
 
 	// Expect the user to have a group mapping for a role.
@@ -407,6 +413,7 @@ func (s *MapperTestSuite) TestGroupWalkFailureCausesError() {
 			},
 		},
 	}
+	s.mockUsers.EXPECT().GetUser(s.requestContext, expectedUser.Id).Times(1).Return(nil, nil)
 	s.mockUsers.EXPECT().Upsert(s.requestContext, expectedUser).Times(1).Return(nil)
 
 	// Expect the user to have a group mapping for a role.
@@ -442,6 +449,7 @@ func (s *MapperTestSuite) TestRoleFetchFailureCausesError() {
 			},
 		},
 	}
+	s.mockUsers.EXPECT().GetUser(s.requestContext, expectedUser.Id).Times(1).Return(nil, nil)
 	s.mockUsers.EXPECT().Upsert(s.requestContext, expectedUser).Times(1).Return(nil)
 
 	// Expect the user to have a group mapping for a role.

--- a/central/role/mapper/telemetry.go
+++ b/central/role/mapper/telemetry.go
@@ -1,0 +1,14 @@
+package mapper
+
+import (
+	"github.com/stackrox/rox/central/telemetry/centralclient"
+	"github.com/stackrox/rox/generated/storage"
+)
+
+// addUserToTenantGroup adds the given user to the central tenant group so that
+// such users could be segmented by tenant properties.
+func addUserToTenantGroup(user *storage.User) {
+	if cfg := centralclient.InstanceConfig(); cfg.Enabled() {
+		cfg.Telemeter().Group(cfg.GroupID, cfg.HashUserID(user.GetId(), user.GetAuthProviderId()), nil)
+	}
+}


### PR DESCRIPTION
## Description

Try to `GetUser` before adding it to the tenant group. This should avoid sending duplicates of `Group` messages to segment.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~


## Testing Performed

Local testing by restarting the sensor.