### PR TITLE
Dashrews/ROX-14169 add central-db configuration information to diagnostic bundle

### DIFF
--- a/central/debug/service/db_diagnostics.go
+++ b/central/debug/service/db_diagnostics.go
@@ -10,22 +10,20 @@ import (
 )
 
 const (
-	unableToGetConnectionInfo = "Unable to get the connection string"
+	databaseType = "PostgresDB"
 )
 
 func buildDBDiagnosticData(ctx context.Context, dbConfig *pgxpool.Config, dbPool *pgxpool.Pool) centralDBDiagnosticData {
 	diagnosticData := centralDBDiagnosticData{}
 
 	// Add the database version if Postgres
-	diagnosticData.Database = "PostgresDB"
+	diagnosticData.Database = databaseType
 	diagnosticData.DatabaseServerVersion = globaldb.GetPostgresVersion(ctx, dbPool)
 	// Get client software version
 	diagnosticData.DatabaseClientVersion = getDBClientVersion()
 	// Get extensions
 	if dbConfig != nil {
 		diagnosticData.DatabaseConnectString = strings.TrimSpace(strings.Replace(dbConfig.ConnString(), dbConfig.ConnConfig.Password, "REDACTED", -1))
-	} else {
-		diagnosticData.DatabaseConnectString = unableToGetConnectionInfo
 	}
 	diagnosticData.DatabaseExtensions = getPostgresExtensions(ctx, dbPool)
 
@@ -39,7 +37,7 @@ func getDBClientVersion() string {
 
 	clientVersion, err := exec.Command("pg_dump", options...).Output()
 	if err != nil {
-		log.Errorf("Unable to get client version:  %v", err)
+		log.Errorf("Unable to get Postgres client version:  %v", err)
 		return ""
 	}
 
@@ -53,7 +51,7 @@ func getPostgresExtensions(ctx context.Context, dbPool *pgxpool.Pool) []dbExtens
 	defer cancel()
 	row, err := dbPool.Query(ctx, extensionQuery)
 	if err != nil {
-		log.Errorf("error fetching object counts: %v", err)
+		log.Errorf("error fetching Postgres extensions: %v", err)
 		return nil
 	}
 

--- a/central/debug/service/db_diagnostics.go
+++ b/central/debug/service/db_diagnostics.go
@@ -1,0 +1,79 @@
+package service
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+
+	"github.com/stackrox/rox/central/globaldb"
+	"github.com/stackrox/rox/pkg/postgres/pgconfig"
+)
+
+func buildDBDiagnosticData(ctx context.Context) centralDBDiagnosticData {
+	diagnosticData := centralDBDiagnosticData{}
+	_, dbConfig, err := pgconfig.GetPostgresConfig()
+	if err != nil {
+		log.Warnf("Could not parse postgres config: %v", err)
+		return centralDBDiagnosticData{}
+	}
+
+	// Add the database version if Postgres
+	diagnosticData.Database = "PostgresDB"
+	diagnosticData.DatabaseServerVersion = globaldb.GetPostgresVersion(ctx, globaldb.GetPostgres())
+	// Get client software version
+	diagnosticData.DatabaseClientVersion = getDBClientVersion()
+	// Get extensions
+	diagnosticData.DatabaseConnectString = strings.Replace(dbConfig.ConnString(), dbConfig.ConnConfig.Password, "REDACTED", -1)
+	diagnosticData.DatabaseExtensions = getPostgresExtensions(ctx)
+
+	return diagnosticData
+}
+
+func getDBClientVersion() string {
+	options := []string{
+		"-V",
+	}
+
+	clientVersion, err := exec.Command("pg_dump", options...).Output()
+	if err != nil {
+		log.Errorf("Unable to get client version:  %v", err)
+		return ""
+	}
+
+	return strings.TrimSpace(string(clientVersion))
+}
+
+func getPostgresExtensions(ctx context.Context) []dbExtension {
+	extensionQuery := "SELECT extname, extversion FROM pg_extension;"
+
+	ctx, cancel := context.WithTimeout(ctx, globaldb.PostgresQueryTimeout)
+	defer cancel()
+	row, err := globaldb.GetPostgres().Query(ctx, extensionQuery)
+	if err != nil {
+		log.Errorf("error fetching object counts: %v", err)
+		return nil
+	}
+
+	extSlice := make([]dbExtension, 0)
+
+	defer row.Close()
+	for row.Next() {
+		var (
+			extName    string
+			extVersion string
+		)
+		if err := row.Scan(&extName, &extVersion); err != nil {
+			log.Errorf("error extension row: %v", err)
+			return nil
+		}
+
+		dbExt := dbExtension{
+			ExtensionName:    extName,
+			ExtensionVersion: extVersion,
+		}
+
+		extSlice = append(extSlice, dbExt)
+	}
+
+	return extSlice
+}

--- a/central/debug/service/db_diagnostics_test.go
+++ b/central/debug/service/db_diagnostics_test.go
@@ -1,0 +1,74 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v4/pgxpool"
+	"github.com/stackrox/rox/pkg/env"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
+	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stretchr/testify/suite"
+)
+
+func TestDBDiagnostic(t *testing.T) {
+	suite.Run(t, new(DBDiagnosticTestSuite))
+}
+
+type DBDiagnosticTestSuite struct {
+	suite.Suite
+
+	ctx      context.Context
+	dbConfig *pgxpool.Config
+	dbPool   *pgxpool.Pool
+}
+
+func (s *DBDiagnosticTestSuite) SetupSuite() {
+	if !env.PostgresDatastoreEnabled.BooleanSetting() {
+		s.T().Skip("Skip legacy db test.  Postgres only.")
+		s.T().SkipNow()
+	}
+
+	ctx := sac.WithAllAccess(context.Background())
+
+	source := pgtest.GetConnectionString(s.T())
+	config, err := pgxpool.ParseConfig(source)
+	s.Require().NoError(err)
+	pool, err := pgxpool.ConnectConfig(ctx, config)
+	s.Require().NoError(err)
+
+	s.ctx = ctx
+	s.dbPool = pool
+	s.dbConfig = config
+}
+
+func (s *DBDiagnosticTestSuite) TearSuite() {
+	if s.dbPool != nil {
+		// Clean up
+		s.dbPool.Close()
+	}
+}
+
+func (s *DBDiagnosticTestSuite) TestClientVersion() {
+	version := getDBClientVersion()
+	s.NotEmpty(version)
+}
+
+func (s *DBDiagnosticTestSuite) TestExtensions() {
+	extensions := getPostgresExtensions(s.ctx, s.dbPool)
+	s.True(len(extensions) > 0)
+}
+
+func (s *DBDiagnosticTestSuite) TestBuildDiagnosticData() {
+	diagnosticData := buildDBDiagnosticData(s.ctx, s.dbConfig, s.dbPool)
+	s.True(len(diagnosticData.DatabaseExtensions) > 0)
+	s.NotEmpty(diagnosticData.Database)
+	s.NotEmpty(diagnosticData.DatabaseClientVersion)
+	s.NotEmpty(diagnosticData.DatabaseServerVersion)
+	s.NotEmpty(diagnosticData.DatabaseConnectString)
+	s.Contains(diagnosticData.DatabaseConnectString, "REDACTED")
+
+	// Drive some error cases
+	diagnosticData = buildDBDiagnosticData(s.ctx, nil, s.dbPool)
+	s.Equal(diagnosticData.DatabaseConnectString, unableToGetConnectionInfo)
+}

--- a/central/debug/service/db_diagnostics_test.go
+++ b/central/debug/service/db_diagnostics_test.go
@@ -70,5 +70,5 @@ func (s *DBDiagnosticTestSuite) TestBuildDiagnosticData() {
 
 	// Drive some error cases
 	diagnosticData = buildDBDiagnosticData(s.ctx, nil, s.dbPool)
-	s.Equal(diagnosticData.DatabaseConnectString, unableToGetConnectionInfo)
+	s.Equal(diagnosticData.DatabaseConnectString, "")
 }

--- a/central/debug/service/service.go
+++ b/central/debug/service/service.go
@@ -491,6 +491,7 @@ type debugDumpOptions struct {
 	withAccessControl bool
 	withNotifiers     bool
 	withCentral       bool
+	withCentralDB     bool
 	clusters          []string
 	since             time.Time
 }
@@ -617,6 +618,7 @@ func (s *serviceImpl) getDebugDump(w http.ResponseWriter, r *http.Request) {
 		withAccessControl: true,
 		withNotifiers:     true,
 		withCentral:       env.EnableCentralDiagnostics.BooleanSetting(),
+		withCentralDB:     env.EnableCentralDatabaseDiagnostics.BooleanSetting(),
 		telemetryMode:     0,
 	}
 
@@ -662,6 +664,7 @@ func (s *serviceImpl) getDiagnosticDump(w http.ResponseWriter, r *http.Request) 
 		withLogImbue:      true,
 		withAccessControl: true,
 		withCentral:       env.EnableCentralDiagnostics.BooleanSetting(),
+		withCentralDB:     env.EnableCentralDatabaseDiagnostics.BooleanSetting(),
 		withNotifiers:     true,
 	}
 

--- a/central/debug/service/service.go
+++ b/central/debug/service/service.go
@@ -43,6 +43,7 @@ import (
 	"github.com/stackrox/rox/pkg/httputil"
 	"github.com/stackrox/rox/pkg/k8sintrospect"
 	"github.com/stackrox/rox/pkg/logging"
+	"github.com/stackrox/rox/pkg/postgres/pgconfig"
 	"github.com/stackrox/rox/pkg/prometheusutil"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/sac/observe"
@@ -379,7 +380,13 @@ type centralDBDiagnosticData struct {
 }
 
 func getCentralDBData(ctx context.Context, zipWriter *zip.Writer) error {
-	dbDiagnosticData := buildDBDiagnosticData(ctx)
+	_, dbConfig, err := pgconfig.GetPostgresConfig()
+	if err != nil {
+		log.Warnf("Could not parse postgres config: %v", err)
+		return err
+	}
+
+	dbDiagnosticData := buildDBDiagnosticData(ctx, dbConfig, globaldb.GetPostgres())
 
 	return addJSONToZip(zipWriter, "central-db.json", dbDiagnosticData)
 }

--- a/pkg/env/central_diagnostics.go
+++ b/pkg/env/central_diagnostics.go
@@ -3,7 +3,4 @@ package env
 var (
 	// EnableCentralDiagnostics is set to true to signal that diagnostic bundles or dumps should contain information about central or the environment that central runs in.
 	EnableCentralDiagnostics = RegisterBooleanSetting("ROX_ENABLE_CENTRAL_DIAGNOSTICS", true)
-
-	// EnableCentralDatabaseDiagnostics is set to true to signal that diagnostic bundles or dumps should contain information about central database or the environment that central runs in.
-	EnableCentralDatabaseDiagnostics = RegisterBooleanSetting("ROX_ENABLE_CENTRAL_DATABASE_DIAGNOSTICS", true)
 )

--- a/pkg/env/central_diagnostics.go
+++ b/pkg/env/central_diagnostics.go
@@ -3,4 +3,7 @@ package env
 var (
 	// EnableCentralDiagnostics is set to true to signal that diagnostic bundles or dumps should contain information about central or the environment that central runs in.
 	EnableCentralDiagnostics = RegisterBooleanSetting("ROX_ENABLE_CENTRAL_DIAGNOSTICS", true)
+
+	// EnableCentralDatabaseDiagnostics is set to true to signal that diagnostic bundles or dumps should contain information about central database or the environment that central runs in.
+	EnableCentralDatabaseDiagnostics = RegisterBooleanSetting("ROX_ENABLE_CENTRAL_DATABASE_DIAGNOSTICS", true)
 )


### PR DESCRIPTION
## Description

Added some information for central-db to the diagnostic bundle.  This will be populated if we are pulling the diagnostics for central and of course in Postgres mode.  Meaning this will not be pulled for ACSCS, which makes sense as we should know what that configuration is.  The new file in the bundle will be `central-db.json`.  Example contents:

```
{
  "Database": "PostgresDB",
  "DatabaseClientVersion": "pg_dump (PostgreSQL) 13.9",
  "DatabaseServerVersion": "13.9",
  "DatabaseExtensions": [
    {
      "ExtensionName": "plpgsql",
      "ExtensionVersion": "1.0"
    },
    {
      "ExtensionName": "pg_stat_statements",
      "ExtensionVersion": "1.8"
    }
  ],
  "DatabaseConnectString": "host=central-db.stackrox.svc port=5432 user=postgres sslmode=verify-full sslrootcert=/run/secrets/stackrox.io/certs/ca.pem statement_timeout=60000 pool_min_conns=10 pool_max_conns=90 password=REDACTED"
}
```

If we think of anything that is missing, I recommend we add them as separate tickets to ROX-14165 unless we deem them immediate concerns.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Added a unit test to go along with the data that is being put together.
