### PR TITLE
ROX-10298: Support new policy categories on Policy Wizard step 1

### DIFF
--- a/ui/apps/platform/src/Containers/PolicyManagement/PolicyManagementHeader.tsx
+++ b/ui/apps/platform/src/Containers/PolicyManagement/PolicyManagementHeader.tsx
@@ -13,7 +13,9 @@ type PolicyManagementHeaderProps = {
 function PolicyManagementHeader({ currentTabTitle }: PolicyManagementHeaderProps) {
     const { isFeatureFlagEnabled } = useFeatureFlags();
     const tabLinks = [{ title: 'Policies', href: policiesBasePath }];
-    const isPolicyCategoriesEnabled = isFeatureFlagEnabled('ROX_NEW_POLICY_CATEGORIES');
+    const isPolicyCategoriesEnabled =
+        isFeatureFlagEnabled('ROX_NEW_POLICY_CATEGORIES') &&
+        isFeatureFlagEnabled('ROX_POSTGRES_DATASTORE');
     if (isPolicyCategoriesEnabled) {
         tabLinks.push({ title: 'Policy categories', href: policyCategoriesPath });
     }

--- a/ui/apps/platform/src/Containers/PolicyManagement/PolicyManagementPage.tsx
+++ b/ui/apps/platform/src/Containers/PolicyManagement/PolicyManagementPage.tsx
@@ -8,7 +8,9 @@ import PolicyCategoriesPage from 'Containers/PolicyCategories/PolicyCategoriesPa
 
 function PolicyManagementPage() {
     const { isFeatureFlagEnabled } = useFeatureFlags();
-    const isPolicyCategoriesEnabled = isFeatureFlagEnabled('ROX_NEW_POLICY_CATEGORIES');
+    const isPolicyCategoriesEnabled =
+        isFeatureFlagEnabled('ROX_NEW_POLICY_CATEGORIES') &&
+        isFeatureFlagEnabled('ROX_POSTGRES_DATASTORE');
     return (
         <Switch>
             <Redirect exact from={policyManagementBasePath} to={policiesPath} />


### PR DESCRIPTION
## Description

1. Add `'ROX_POSTGRES_DATASTORE'` in addition to `'ROX_NEW_POLICY_CATEGORIES'` feature flag.

2. Conditionally fetch policy categories.
    * If enabled: call `getPolicyCategories` function from PolicyCategoriesService service.
    * If disabled: call renamed `getPolicyCategoriesNonPostgres` function from Policies service and use `name` as `id` property to keep equivalent `key` prop for select items.

3. Prevent creation of new categories if enabled:
    * `onCreateOption` use default value from PatternFly doc page
        https://www.patternfly.org/v4/components/select#select
    * `isCreatable` is false

### Residue

1. Investigate why duplicate 3 requests before and after /v1/policies/id request in step 2 below

2. Visit /main/policy-management/policy-categories without feature flag
    * See empty page instead of 404 page

3. Visit /main/policy-management/policies
    * See **Policy management - Policy categories** in title on browser tab with or without feature flag

## Checklist
- [ ] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

### With ROX_NEW_POLICY_CATEGORIES and ROX_POSTGRES_DATASTORE

1. Visit /main/policy-management/policy-categories
    * See /v1/policycategories request
        ![1_Policy_categories](https://user-images.githubusercontent.com/11862657/213011754-b9e3d4ef-519d-4816-b527-80823293223b.png)

2. Visit Visit /main/policy-management/policies and then edit a policy
    * See /v1/policycategories request **Residue** question above
        ![2_Edit_policy](https://user-images.githubusercontent.com/11862657/213012093-42027f34-96b6-4e04-a505-57c9a52f8e5c.png)

3. Create a new policy
    * See categories
        ![3_Cteate_Policy](https://user-images.githubusercontent.com/11862657/213012112-6b02a753-7e09-4ac9-a9e7-dbddf0cd7947.png)

4. View created policy
    * See categories
        ![4_View_created](https://user-images.githubusercontent.com/11862657/213012136-268dc00d-8839-4857-b827-01d40fd7d288.png)

5. Edit created policy
    * Remove categories, and then select different category.
    * Type a non-existent category, and then click Enter. Nothing happens.
        ![5_Select_categories](https://user-images.githubusercontent.com/11862657/213012179-d383a4ce-a15a-42be-96e3-639c3cdbfa32.png)

6. Save edited policy
    * See category
        ![6_Save_edited](https://user-images.githubusercontent.com/11862657/213012211-3ecf7165-a2f9-4bb2-a76a-6efe7a1245ea.png)

### Without ROX_NEW_POLICY_CATEGORIES

1. Visit /main/policy-management
    * See no **Policy categories** tab
        ![1_no_categories](https://user-images.githubusercontent.com/11862657/213019233-b4d9cc8d-4918-49d5-8854-210c98d7c23e.png)

2. Visit /main/policy-management/policies and then edit a policy
    * See /v1/policyCategories request **Residue** question above
        ![2_policyCategories](https://user-images.githubusercontent.com/11862657/213019264-6ce34bc6-f8f5-4bcc-9fe2-0249b646cd35.png)

3. Create a new policy
    * See categories
        ![3_Save_created](https://user-images.githubusercontent.com/11862657/213019288-3127b4a6-77f8-4876-9065-1f1ece05f919.png)

4. View created policy
    * See categories
        ![4_View](https://user-images.githubusercontent.com/11862657/213019315-611e4544-f53c-40d9-8b1b-1ca344e26501.png)

5. Edit created policy
    * Remove categories, and then select different category.
    * Type a non-existent category, and then see **Create whatever**. Click to create it.
        ![5_isCreatable](https://user-images.githubusercontent.com/11862657/213019354-4a9a21ee-8166-4cdd-819f-ddf5d94b441f.png)

6. Save edited policy
    * See category in PUT /v1/policies/id payload
        ![6_Save_new_category](https://user-images.githubusercontent.com/11862657/213019377-ef961e23-a489-4201-baae-2192d3bc01a3.png)

7. Click **Edit** again
    * See new category in GET /v1/policyCategories response
        ![7_policyCategories](https://user-images.githubusercontent.com/11862657/213019401-3f6e6597-4552-4bc6-a559-e2ba09306fec.png)
