### PR TITLE
ROX-13343: Use real data for flows tab of deployment side bar

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/api/useFetchNetworkFlows.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/api/useFetchNetworkFlows.ts
@@ -15,7 +15,7 @@ import {
 type Result = {
     isLoading: boolean;
     data: { networkFlows: Flow[] };
-    error: string | null;
+    error: string;
 };
 
 type FetchNetworkFlowsParams = {
@@ -29,7 +29,7 @@ type FetchNetworkFlowsResult = {
 
 const defaultResultState = {
     data: { networkFlows: [] },
-    error: null,
+    error: '',
     isLoading: true,
 };
 
@@ -61,7 +61,7 @@ function useFetchNetworkFlows({
                 setResult({
                     isLoading: false,
                     data: { networkFlows: modifiedFlows },
-                    error: null,
+                    error: '',
                 });
             })
             .catch((error) => {

--- a/ui/apps/platform/src/Containers/NetworkGraph/api/useFetchNetworkFlows.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/api/useFetchNetworkFlows.ts
@@ -1,0 +1,88 @@
+import { useVisualizationController } from '@patternfly/react-topology';
+import { useEffect, useState } from 'react';
+
+import { fetchNetworkBaselineStatuses } from 'services/NetworkService';
+import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
+import { BaselineStatus, BaselineStatusType, Flow } from '../types/flow.type';
+import { CustomEdgeModel } from '../types/topology.type';
+import {
+    getNetworkFlows,
+    getUniqueIdFromFlow,
+    getUniqueIdFromPeer,
+    transformFlowsToPeers,
+} from '../utils/flowUtils';
+
+type Result = {
+    isLoading: boolean;
+    data: { networkFlows: Flow[] };
+    error: string | null;
+};
+
+type FetchNetworkFlowsParams = {
+    edges: CustomEdgeModel[];
+    deploymentId: string;
+};
+
+type FetchNetworkFlowsResult = {
+    refetchFlows: () => void;
+} & Result;
+
+const defaultResultState = {
+    data: { networkFlows: [] },
+    error: null,
+    isLoading: true,
+};
+
+function useFetchNetworkFlows({
+    edges,
+    deploymentId,
+}: FetchNetworkFlowsParams): FetchNetworkFlowsResult {
+    const controller = useVisualizationController();
+    const [result, setResult] = useState<Result>(defaultResultState);
+
+    function fetchFlows() {
+        const flows = getNetworkFlows(edges, controller, deploymentId);
+        const peers = transformFlowsToPeers(flows);
+        fetchNetworkBaselineStatuses({ deploymentId, peers })
+            .then((response: { statuses: BaselineStatus[] }) => {
+                const statusMap = response.statuses.reduce((acc, curr) => {
+                    const id = getUniqueIdFromPeer(curr.peer);
+                    acc[id] = curr.status;
+                    return acc;
+                }, {} as Record<string, BaselineStatusType>);
+                const modifiedFlows = flows.map((flow) => {
+                    const id = getUniqueIdFromFlow(flow);
+                    const modifiedFlow: Flow = {
+                        ...flow,
+                        isAnomalous: statusMap[id] === 'ANOMALOUS',
+                    };
+                    return modifiedFlow;
+                });
+                setResult({
+                    isLoading: false,
+                    data: { networkFlows: modifiedFlows },
+                    error: null,
+                });
+            })
+            .catch((error) => {
+                const message = getAxiosErrorMessage(error);
+                const errorMessage =
+                    message || 'An unknown error occurred while getting the list of clusters';
+
+                setResult({
+                    isLoading: false,
+                    data: { networkFlows: [] },
+                    error: errorMessage,
+                });
+            });
+    }
+
+    useEffect(() => {
+        fetchFlows();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [deploymentId]);
+
+    return { ...result, refetchFlows: fetchFlows };
+}
+
+export default useFetchNetworkFlows;

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentFlows.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentFlows.tsx
@@ -1,8 +1,12 @@
 import React from 'react';
 import {
+    Alert,
+    AlertVariant,
+    Bullseye,
     Divider,
     Flex,
     FlexItem,
+    Spinner,
     Stack,
     StackItem,
     Toolbar,
@@ -11,8 +15,8 @@ import {
 } from '@patternfly/react-core';
 
 import { AdvancedFlowsFilterType } from '../common/AdvancedFlowsFilter/types';
-import { Flow } from '../types/flow.type';
-import { getAllUniquePorts, getNumFlows } from '../utils/flowUtils';
+import { filterNetworkFlows, getAllUniquePorts, getNumFlows } from '../utils/flowUtils';
+import { CustomEdgeModel } from '../types/topology.type';
 
 import AdvancedFlowsFilter, {
     defaultAdvancedFlowsFilters,
@@ -23,99 +27,85 @@ import FlowsTableHeaderText from '../common/FlowsTableHeaderText';
 import FlowsBulkActions from '../common/FlowsBulkActions';
 
 import './DeploymentFlows.css';
+import useFetchNetworkFlows from '../api/useFetchNetworkFlows';
+import useModifyBaselineStatuses from '../api/useModifyBaselineStatuses';
+import { Flow } from '../types/flow.type';
 
-const flows: Flow[] = [
-    {
-        id: 'External Entities-Ingress-Many-TCP',
-        type: 'EXTERNAL_ENTITIES',
-        entity: 'External Entities',
-        entityId: '12345',
-        namespace: '',
-        direction: 'Ingress',
-        port: 'Many',
-        protocol: 'TCP',
-        isAnomalous: true,
-        children: [
-            {
-                id: 'External Entities-Ingress-443-TCP',
-                type: 'EXTERNAL_ENTITIES',
-                entity: 'External Entities',
-                entityId: '12345',
-                namespace: '',
-                direction: 'Ingress',
-                port: '443',
-                protocol: 'TCP',
-                isAnomalous: true,
-            },
-            {
-                id: 'External Entities-Ingress-9443-TCP',
-                type: 'EXTERNAL_ENTITIES',
-                entityId: '12345',
-                entity: 'External Entities',
-                namespace: '',
-                direction: 'Ingress',
-                port: '9443',
-                protocol: 'TCP',
-                isAnomalous: true,
-            },
-        ],
-    },
-    {
-        id: 'Deployment 1-naples-Ingress-Many-TCP',
-        type: 'DEPLOYMENT',
-        entity: 'Deployment 1',
-        entityId: '00000',
-        namespace: 'naples',
-        direction: 'Ingress',
-        port: '9000',
-        protocol: 'TCP',
-        isAnomalous: true,
-        children: [],
-    },
-    {
-        id: 'Deployment 2-naples-Ingress-Many-UDP',
-        type: 'DEPLOYMENT',
-        entity: 'Deployment 2',
-        entityId: '11111',
-        namespace: 'naples',
-        direction: 'Ingress',
-        port: '8080',
-        protocol: 'UDP',
-        isAnomalous: false,
-        children: [],
-    },
-    {
-        id: 'Deployment 3-naples-Egress-7777-UDP',
-        type: 'DEPLOYMENT',
-        entity: 'Deployment 3',
-        entityId: '22222',
-        namespace: 'naples',
-        direction: 'Egress',
-        port: '7777',
-        protocol: 'UDP',
-        isAnomalous: false,
-        children: [],
-    },
-];
+type DeploymentFlowsProps = {
+    deploymentId: string;
+    edges: CustomEdgeModel[];
+};
 
-function DeploymentFlow() {
+function DeploymentFlows({ deploymentId, edges }: DeploymentFlowsProps) {
     // component state
     const [entityNameFilter, setEntityNameFilter] = React.useState<string>('');
     const [advancedFilters, setAdvancedFilters] = React.useState<AdvancedFlowsFilterType>(
         defaultAdvancedFlowsFilters
     );
-    const initialExpandedRows = flows
+
+    const {
+        isLoading,
+        error: fetchError,
+        data: { networkFlows },
+        refetchFlows,
+    } = useFetchNetworkFlows({ edges, deploymentId });
+    const {
+        isModifying,
+        error: modifyError,
+        modifyBaselineStatuses,
+    } = useModifyBaselineStatuses(deploymentId);
+    const filteredFlows = filterNetworkFlows(networkFlows, entityNameFilter, advancedFilters);
+
+    const initialExpandedRows = filteredFlows
         .filter((row) => row.children && !!row.children.length)
         .map((row) => row.id); // Default to all expanded
     const [expandedRows, setExpandedRows] = React.useState<string[]>(initialExpandedRows);
     const [selectedRows, setSelectedRows] = React.useState<string[]>([]);
 
     // derived data
-    const numFlows = getNumFlows(flows);
-    const allUniquePorts = getAllUniquePorts(flows);
+    const numFlows = getNumFlows(filteredFlows);
+    const allUniquePorts = getAllUniquePorts(networkFlows);
+
+    function addToBaseline(flow: Flow) {
+        modifyBaselineStatuses([flow], 'BASELINE', refetchFlows);
+    }
+
+    function markAsAnomalous(flow: Flow) {
+        modifyBaselineStatuses([flow], 'ANOMALOUS', refetchFlows);
+    }
+
+    function addSelectedToBaseline() {
+        const selectedFlows = filteredFlows.filter((networkBaseline) => {
+            return selectedRows.includes(networkBaseline.id);
+        });
+        modifyBaselineStatuses(selectedFlows, 'BASELINE', refetchFlows);
+    }
+
+    function markSelectedAsAnomalous() {
+        const selectedFlows = filteredFlows.filter((networkBaseline) => {
+            return selectedRows.includes(networkBaseline.id);
+        });
+        modifyBaselineStatuses(selectedFlows, 'ANOMALOUS', refetchFlows);
+    }
+
+    if (isLoading || isModifying) {
+        return (
+            <Bullseye>
+                <Spinner isSVG size="lg" />
+            </Bullseye>
+        );
+    }
 
     return (
         <div className="pf-u-h-100 pf-u-p-md">
+            {(fetchError || modifyError) && (
+                <Alert
+                    isInline
+                    variant={AlertVariant.danger}
+                    title={fetchError || modifyError}
+                    className="pf-u-mb-sm"
+                />
+            )}
             <Stack hasGutter>
                 <StackItem>
                     <Flex>
@@ -146,6 +136,8 @@ function DeploymentFlow() {
                                     type="active"
                                     selectedRows={selectedRows}
                                     onClearSelectedRows={() => setSelectedRows([])}
+                                    markSelectedAsAnomalous={markSelectedAsAnomalous}
+                                    addSelectedToBaseline={addSelectedToBaseline}
                                 />
                             </ToolbarItem>
                         </ToolbarContent>
@@ -154,12 +146,14 @@ function DeploymentFlow() {
                 <StackItem>
                     <FlowsTable
                         label="Deployment flows"
-                        flows={flows}
+                        flows={filteredFlows}
                         numFlows={numFlows}
                         expandedRows={expandedRows}
                         setExpandedRows={setExpandedRows}
                         selectedRows={selectedRows}
                         setSelectedRows={setSelectedRows}
+                        addToBaseline={addToBaseline}
+                        markAsAnomalous={markAsAnomalous}
                         isEditable
                     />
                 </StackItem>
@@ -168,4 +162,4 @@ function DeploymentFlow() {
     );
 }
 
-export default DeploymentFlow;
+export default DeploymentFlows;

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentSideBar.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentSideBar.tsx
@@ -128,7 +128,7 @@ function DeploymentSideBar({ deploymentId, nodes, edges }: DeploymentSideBarProp
                     )}
                 </TabContent>
                 <TabContent eventKey="Flows" id="Flows" hidden={activeKeyTab !== 'Flows'}>
-                    <DeploymentFlows />
+                    <DeploymentFlows edges={edges} deploymentId={deploymentId} />
                 </TabContent>
                 <TabContent
                     eventKey="Baselines"

--- a/ui/apps/platform/src/Containers/NetworkGraph/types/flow.type.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/types/flow.type.ts
@@ -1,4 +1,10 @@
+import { L4Protocol } from 'types/networkFlow.proto';
+
+export type EntityType = 'DEPLOYMENT' | 'INTERNET' | 'EXTERNAL_SOURCE';
+
 export type FlowEntityType = 'DEPLOYMENT' | 'EXTERNAL_ENTITIES' | 'CIDR_BLOCK';
+
+export type BaselineStatusType = 'ANOMALOUS' | 'BASELINE';
 
 export type IndividualFlow = {
     id: string;
@@ -8,7 +14,7 @@ export type IndividualFlow = {
     namespace: string;
     direction: string;
     port: string;
-    protocol: string;
+    protocol: L4Protocol;
     isAnomalous: boolean;
     children?: undefined;
 };
@@ -21,9 +27,28 @@ export type AggregatedFlow = {
     namespace: string;
     direction: string;
     port: string;
-    protocol: string;
+    protocol: L4Protocol;
     isAnomalous: boolean;
     children: IndividualFlow[];
+};
+
+export type Entity = {
+    id: string;
+    type: EntityType;
+    name: string;
+    namespace: string;
+};
+
+export type Peer = {
+    entity: Entity;
+    port: string;
+    protocol: L4Protocol;
+    ingress: boolean;
+};
+
+export type BaselineStatus = {
+    peer: Peer;
+    status: BaselineStatusType;
 };
 
 export type Flow = IndividualFlow | AggregatedFlow;

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/flowUtils.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/flowUtils.ts
@@ -1,6 +1,7 @@
 import { Controller } from '@patternfly/react-topology';
 import { EntityType } from 'Containers/Network/networkTypes';
 import { uniq } from 'lodash';
+import { L4Protocol } from 'types/networkFlow.proto';
 import { AdvancedFlowsFilterType } from '../common/AdvancedFlowsFilter/types';
 import { Flow, Peer } from '../types/flow.type';
 import { CustomEdgeModel, CustomSingleNodeData } from '../types/topology.type';
@@ -34,9 +35,23 @@ export function getNumFlows(flows: Flow[]): number {
     return numFlows;
 }
 
+function createUniqueFlowId({
+    entityId,
+    direction,
+    port,
+    protocol,
+}: {
+    entityId: string;
+    direction: string;
+    port: string;
+    protocol: L4Protocol;
+}) {
+    return `${entityId}-${direction}-${port}-${protocol}`;
+}
+
 export function getUniqueIdFromFlow(flow: Flow) {
     const { entityId, direction, port, protocol } = flow;
-    const id = `${entityId}-${direction}-${port}-${protocol}`;
+    const id = createUniqueFlowId({ entityId, direction, port, protocol });
     return id;
 }
 
@@ -45,7 +60,7 @@ export function getUniqueIdFromPeer(peer: Peer) {
     const direction = peer.ingress ? 'Ingress' : 'Egress';
     const { port } = peer;
     const { protocol } = peer;
-    const id = `${entityId}-${direction}-${port}-${protocol}`;
+    const id = createUniqueFlowId({ entityId, direction, port, protocol });
     return id;
 }
 


### PR DESCRIPTION
## Description

This PR shows network flows in the `Flows` tab of the deployment details side panel

https://user-images.githubusercontent.com/4805485/213250784-3b8557d7-a081-42fb-9bff-d6c699e07c48.mov

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~
