### PR TITLE
Prepare Role resource grouping with Access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 ### Deprecated Features
 - ROX-12620: We continue to simplify access control management by grouping some permissions in permission sets. As a result:
   - The permission `WorkflowAdministration` will deprecate the permissions `Policy, VulnerabilityReports`.
+- ROX-14398: We continue to simplify access control management by grouping some permissions in permission sets. As a result:
+  - The permission `Access` will deprecate the permissions `Role`.
+  - The default role `Scope Manager` will be removed.
 
 - ROX-14400: product `BuildDate` attribute is deprecated and will be removed in `3.75` release. It won't be returned by
 `/debug/versions.json` endpoint and `roxctl version --json` command.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,14 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
   During the migration of the permission sets within the 3.76, the `WorfklowAdministration` permission will have the lowest access permission granted for either `Policy` or `VulnerabilityReports`.
   As an example, a permission set with `WRITE Policy` and `READ VulnerabilityReports` access will have `READ WorkflowAdministration` access after the migration within the 3.76 release, leading to
   potentially unwanted side-effects and missing access if you did not update your permission sets beforehand.
+- The permission `Access` will replace `Role` in permission sets starting with the 3.76 release. You should preemptively start replacing
+  the `Role` resource within your permission sets in favor of `Access`. During the migration of the permission sets within the 3.76, the 
+  `Access` permission will have the lowest access permission granted for either `Access` or `Role`. As an example, a permission set with 
+  `READ Access` and `WRITE Role` will have `READ Access` after the migration, leading to potentially unwanted side-effects and missing access
+  if the permission sets were not updated beforehand.
+- The default `ScopeManager` role will be removed starting with release 3.76. During the migration, Authentication provider rules referencing that role
+  will be updated to use the `None` role. Should Authentication Provider rules reference the `ScopeManager` role for other purposes than
+  Vulnerability Report management, a similar role should be manually created and referenced in the Authentication provider rules instead of `ScopeManager`.
 
 - ROX-13814: The "Public Kubernetes GCR" image integration is now deprecated in line with
   [upstream](https://kubernetes.io/blog/2022/11/28/registry-k8s-io-faster-cheaper-ga/).

--- a/central/debug/service/service.go
+++ b/central/debug/service/service.go
@@ -406,6 +406,7 @@ func (s *serviceImpl) getRoles(_ context.Context) (interface{}, error) {
 	accessRolesCtx := sac.WithGlobalAccessScopeChecker(context.Background(),
 		sac.AllowFixedScopes(
 			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
+			// TODO: ROX-14398 Replace Role with Access
 			sac.ResourceScopeKeys(resources.Role)))
 
 	roles, errGetRoles := s.roleDataStore.GetAllRoles(accessRolesCtx)

--- a/central/graphql/resolvers/resolver.go
+++ b/central/graphql/resolvers/resolver.go
@@ -194,7 +194,8 @@ var (
 	readNetPolicies          = readAuth(resources.NetworkPolicy)
 	readNodes                = readAuth(resources.Node)
 	// TODO: ROX-13888 Replace Policy with WorkflowAdministration.
-	readPolicies                         = readAuth(resources.Policy)
+	readPolicies = readAuth(resources.Policy)
+	// TODO: ROX-14398 Replace Role with Access
 	readRoles                            = readAuth(resources.Role)
 	readK8sRoles                         = readAuth(resources.K8sRole)
 	readK8sRoleBindings                  = readAuth(resources.K8sRoleBinding)

--- a/central/reportconfigurations/service/service_impl.go
+++ b/central/reportconfigurations/service/service_impl.go
@@ -38,6 +38,7 @@ var (
 			"/v1.ReportConfigurationService/CountReportConfigurations",
 		},
 		// TODO: ROX-13888 Replace VulnerabilityReports with WorkflowAdministration.
+		// TODO: ROX-14398 Replace Role with Access
 		or.Or(
 			user.With(permissions.Modify(resources.VulnerabilityReports), permissions.View(resources.Integration), permissions.View(resources.Role)),
 			user.With(permissions.Modify(resources.WorkflowAdministration), permissions.View(resources.Integration))): {

--- a/central/reports/service/service_impl.go
+++ b/central/reports/service/service_impl.go
@@ -22,6 +22,7 @@ import (
 var (
 	authorizer = perrpc.FromMap(map[authz.Authorizer][]string{
 		// TODO: ROX-13888 Replace VulnerabilityReports with WorkflowAdministration.
+		// TODO: ROX-14398 Replace Role with Access
 		user.With(permissions.View(resources.VulnerabilityReports), permissions.View(resources.Integration), permissions.View(resources.Role), permissions.View(resources.Image)): {
 			"/v1.ReportService/RunReport",
 		},

--- a/central/role/datastore/datastore_impl.go
+++ b/central/role/datastore/datastore_impl.go
@@ -17,6 +17,7 @@ import (
 )
 
 var (
+	// TODO: ROX-14398 Replace Role with Access
 	roleSAC = sac.ForResource(resources.Role)
 
 	log = logging.LoggerForModule()

--- a/central/role/datastore/datastore_test.go
+++ b/central/role/datastore/datastore_test.go
@@ -87,10 +87,12 @@ func (s *roleDataStoreTestSuite) SetupTest() {
 	s.hasReadCtx = sac.WithGlobalAccessScopeChecker(context.Background(),
 		sac.AllowFixedScopes(
 			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
+			// TODO: ROX-14398 Replace Role with Access
 			sac.ResourceScopeKeys(resources.Role)))
 	s.hasWriteCtx = sac.WithGlobalAccessScopeChecker(context.Background(),
 		sac.AllowFixedScopes(
 			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+			// TODO: ROX-14398 Replace Role with Access
 			sac.ResourceScopeKeys(resources.Role)))
 
 	s.initDataStore()

--- a/central/role/datastore/permissionset_ids.go
+++ b/central/role/datastore/permissionset_ids.go
@@ -8,9 +8,10 @@ const (
 	analystPermissionSetID               = "ffffffff-ffff-fff4-f5ff-fffffffffffe"
 	continuousIntegrationPermissionSetID = "ffffffff-ffff-fff4-f5ff-fffffffffffd"
 	nonePermissionSetID                  = "ffffffff-ffff-fff4-f5ff-fffffffffffc"
-	scopeManagerPermissionSetID          = "ffffffff-ffff-fff4-f5ff-fffffffffffb"
-	sensorCreatorPermissionSetID         = "ffffffff-ffff-fff4-f5ff-fffffffffffa"
-	vulnMgmtApproverPermissionSetID      = "ffffffff-ffff-fff4-f5ff-fffffffffff9"
-	vulnMgmtRequesterPermissionSetID     = "ffffffff-ffff-fff4-f5ff-fffffffffff8"
-	vulnReporterPermissionSetID          = "ffffffff-ffff-fff4-f5ff-fffffffffff7"
+	// TODO: ROX-14398 Remove ScopeManager default role
+	scopeManagerPermissionSetID      = "ffffffff-ffff-fff4-f5ff-fffffffffffb"
+	sensorCreatorPermissionSetID     = "ffffffff-ffff-fff4-f5ff-fffffffffffa"
+	vulnMgmtApproverPermissionSetID  = "ffffffff-ffff-fff4-f5ff-fffffffffff9"
+	vulnMgmtRequesterPermissionSetID = "ffffffff-ffff-fff4-f5ff-fffffffffff8"
+	vulnReporterPermissionSetID      = "ffffffff-ffff-fff4-f5ff-fffffffffff7"
 )

--- a/central/role/datastore/singleton.go
+++ b/central/role/datastore/singleton.go
@@ -107,6 +107,7 @@ var defaultRoles = map[string]roleAttributes{
 		postgresID:  nonePermissionSetID,
 		description: "For users: use it to provide no read and write access to any resource",
 	},
+	// TODO: ROX-14398 Remove ScopeManager default role
 	rolePkg.ScopeManager: {
 		idSuffix:    "scopemanager",
 		postgresID:  scopeManagerPermissionSetID,
@@ -152,6 +153,7 @@ var defaultRoles = map[string]roleAttributes{
 
 // TODO ROX-13888 when we migrate to WorkflowAdministration we can remove VulnerabilityReports and Role resources
 var vulnReportingDefaultRoles = map[string]roleAttributes{
+	// TODO: ROX-14398 Remove Role permission from default role VulnReporter
 	rolePkg.VulnReporter: {
 		idSuffix:    "vulnreporter",
 		postgresID:  vulnReporterPermissionSetID,

--- a/central/role/datastore/telemetry.go
+++ b/central/role/datastore/telemetry.go
@@ -16,6 +16,7 @@ var Gather phonehome.GatherFunc = func(ctx context.Context) (map[string]any, err
 	ctx = sac.WithGlobalAccessScopeChecker(ctx,
 		sac.AllowFixedScopes(
 			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
+			// TODO: ROX-14398 Replace Role with Access
 			sac.ResourceScopeKeys(resources.Role)))
 
 	totals := make(map[string]any)

--- a/central/role/default.go
+++ b/central/role/default.go
@@ -32,9 +32,11 @@ const (
 	// VulnMgmtRequester is a role that has the minimal privileges required to request vulnerability deferrals or false positives.
 	VulnMgmtRequester = "Vulnerability Management Requester"
 
+	// TODO: ROX-14398 Remove default role VulnReporter
 	// VulnReporter is a role that has the minimal privileges required to create and manage vulnerability reporting configurations.
 	VulnReporter = "Vulnerability Report Creator"
 
+	// TODO: ROX-14398 Remove ScopeManager default role
 	// ScopeManager is a role that has the minimal privileges to view and modify scopes for use in access control, vulnerability reporting etc.
 	ScopeManager = "Scope Manager"
 )

--- a/central/role/resources/list.go
+++ b/central/role/resources/list.go
@@ -64,7 +64,6 @@ var (
 	NetworkPolicy  = newResourceMetadata("NetworkPolicy", permissions.NamespaceScope)
 	Node           = newResourceMetadata("Node", permissions.ClusterScope)
 
-	Role                             = newResourceMetadata("Role", permissions.GlobalScope)
 	Secret                           = newResourceMetadata("Secret", permissions.NamespaceScope)
 	ServiceAccount                   = newResourceMetadata("ServiceAccount", permissions.NamespaceScope)
 	VulnerabilityManagementApprovals = newResourceMetadata("VulnerabilityManagementApprovals",
@@ -98,6 +97,8 @@ var (
 	// To-be-deprecated in 3.75 with ROX-12750 (deprecation notice in 3.73).
 	ProbeUpload = newDeprecatedResourceMetadata("ProbeUpload", permissions.GlobalScope,
 		Administration)
+	// To-be-deprecated in 3.76 with ROX-14398 (deprecation notice in 3.74).
+	Role = newDeprecatedResourceMetadata("Role", permissions.GlobalScope, Access)
 	// To-be-deprecated in 3.75 with ROX-12750 (deprecation notice in 3.73).
 	ScannerBundle = newDeprecatedResourceMetadata("ScannerBundle",
 		permissions.GlobalScope, Administration)

--- a/central/role/service/service_impl.go
+++ b/central/role/service/service_impl.go
@@ -27,6 +27,7 @@ import (
 
 var (
 	authorizer = perrpc.FromMap(map[authz.Authorizer][]string{
+		// TODO: ROX-14398 Replace Role with Access
 		user.With(permissions.View(resources.Role)): {
 			"/v1.RoleService/GetRoles",
 			"/v1.RoleService/GetRole",
@@ -35,9 +36,11 @@ var (
 			"/v1.RoleService/ListSimpleAccessScopes",
 			"/v1.RoleService/GetSimpleAccessScope",
 		},
+		// TODO: ROX-14398 Replace Role with Access
 		user.With(permissions.View(resources.Role), permissions.View(resources.Cluster), permissions.View(resources.Namespace)): {
 			"/v1.RoleService/ComputeEffectiveAccessScope",
 		},
+		// TODO: ROX-14398 Replace Role with Access
 		user.With(permissions.Modify(resources.Role)): {
 			"/v1.RoleService/CreateRole",
 			"/v1.RoleService/SetDefaultRole",

--- a/tools/generate-helpers/pg-table-bindings/list.go
+++ b/tools/generate-helpers/pg-table-bindings/list.go
@@ -60,8 +60,9 @@ func init() {
 		&storage.NodeComponentEdge{}:                            resources.Node,
 		&storage.NodeCVE{}:                                      resources.Node,
 		&storage.Notifier{}:                                     resources.Integration,
-		&storage.PermissionSet{}:                                resources.Role,
-		&storage.Pod{}:                                          resources.Deployment,
+		// TODO: ROX-14398 Replace Role with Access
+		&storage.PermissionSet{}: resources.Role,
+		&storage.Pod{}:           resources.Deployment,
 		// TODO: ROX-13888 Replace Policy with WorkflowAdministration.
 		&storage.Policy{}:                 resources.Policy,
 		&storage.PolicyCategory{}:         resources.Policy,
@@ -73,14 +74,16 @@ func init() {
 		// TODO: ROX-13888 Replace VulnerabilityReports with WorkflowAdministration.
 		&storage.ReportConfiguration{}: resources.VulnerabilityReports,
 		&storage.Risk{}:                resources.DeploymentExtension,
-		&storage.Role{}:                resources.Role,
+		// TODO: ROX-14398 Replace Role with Access
+		&storage.Role{}: resources.Role,
 		// TODO: ROX-12750 Replace SensorUpgradeConfig with Administration.
 		&storage.SensorUpgradeConfig{}: resources.SensorUpgradeConfig,
 		// TODO: ROX-12750 Replace ServiceIdentity with Administration.
 		&storage.ServiceIdentity{}:      resources.ServiceIdentity,
 		&storage.SignatureIntegration{}: resources.Integration,
-		&storage.SimpleAccessScope{}:    resources.Role,
-		&storage.StoredLicenseKey{}:     resources.Access,
+		// TODO: ROX-14398 Replace Role with Access
+		&storage.SimpleAccessScope{}: resources.Role,
+		&storage.StoredLicenseKey{}:  resources.Access,
 		// TODO: ROX-12750 Replace DebugLogs with Administration.
 		&storage.TelemetryConfiguration{}: resources.DebugLogs,
 		&storage.TokenMetadata{}:          resources.Integration,

--- a/ui/apps/platform/src/Containers/AccessControl/AccessControl.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessControl.tsx
@@ -51,6 +51,9 @@ function AccessControl(): ReactElement {
                         </p>
                         <List>
                             <ListItem>
+                                <b>Access</b> will replace <b>Role</b>
+                            </ListItem>
+                            <ListItem>
                                 <b>Administration</b> will replace{' '}
                                 <b>
                                     AllComments, Config, DebugLogs, NetworkGraphConfig, ProbeUpload,


### PR DESCRIPTION
## Description

As part of the effort to simplify the permission management in the product, the `Role` resource will be grouped with the `Access` one.
This change announces the grouping and flags the code portions to alter in order to make this change happen.

## Checklist
- [ ] Investigated and inspected CI test results
~~- [ ] Unit test and regression tests added~~
- [ ] Evaluated and added CHANGELOG entry if required
~~- [ ] Determined and documented upgrade steps~~
~~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

Mostly comment addition in the code.
CI should be enough.
