### PR TITLE
Encapsulate version string in HelpMenu component

### DIFF
--- a/ui/apps/platform/src/Containers/MainPage/Header/HelpMenu.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Header/HelpMenu.tsx
@@ -12,7 +12,7 @@ import useMetadata from 'hooks/useMetadata';
 import { apidocsPath, productDocsPath } from 'routePaths';
 
 function HelpMenu(): ReactElement {
-    const metadata = useMetadata();
+    const { releaseBuild, version } = useMetadata();
     const [isHelpMenuOpen, setIsHelpMenuOpen] = useState(false);
 
     function onToggleHelpMenu() {
@@ -28,18 +28,22 @@ function HelpMenu(): ReactElement {
                     </Link>
                 }
             />
-            <ApplicationLauncherItem
-                href={productDocsPath}
-                isExternal
-                target="_blank"
-                rel="noopener noreferrer"
-            >
-                Help Center
-            </ApplicationLauncherItem>
-            <ApplicationLauncherSeparator />
-            <ApplicationLauncherItem isDisabled>
-                <span>{metadata.versionString}</span>
-            </ApplicationLauncherItem>
+            {version && (
+                <>
+                    <ApplicationLauncherItem
+                        href={productDocsPath}
+                        isExternal
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
+                        Help Center
+                    </ApplicationLauncherItem>
+                    <ApplicationLauncherSeparator />
+                    <ApplicationLauncherItem isDisabled>
+                        {`v${version}${releaseBuild ? '' : ' [DEV BUILD]'}`}
+                    </ApplicationLauncherItem>
+                </>
+            )}
         </ApplicationLauncherGroup>,
     ];
 

--- a/ui/apps/platform/src/hooks/useMetadata.ts
+++ b/ui/apps/platform/src/hooks/useMetadata.ts
@@ -1,5 +1,6 @@
 import { useSelector } from 'react-redux';
 import { createSelector } from 'reselect';
+
 import { selectors } from 'reducers';
 import { Metadata } from 'types/metadataService.proto';
 
@@ -7,11 +8,6 @@ const selectMetadata = createSelector([selectors.getMetadata], (metadata: Metada
 
 function useMetadata(): Metadata {
     const metadata: Metadata = useSelector(selectMetadata);
-
-    const versionSuffix = metadata.releaseBuild === false ? ' [DEV BUILD]' : '';
-    const versionString = `v${metadata.version}${versionSuffix}`;
-
-    metadata.versionString = versionString;
 
     return metadata;
 }

--- a/ui/apps/platform/src/types/metadataService.proto.ts
+++ b/ui/apps/platform/src/types/metadataService.proto.ts
@@ -3,5 +3,4 @@ export type Metadata = {
     buildFlavor: string;
     releaseBuild: boolean;
     licenseStatus: string;
-    versionString?: string;
 };


### PR DESCRIPTION
## Description

Prerequisite to replace backend redirect for /docs/product with frontend link to OpenShift docs page.

### Changed files

1. Edit src/Containers/MainPage/Header/HelpMenu.tsx
    * Conditionally render elements that depend on version.
    * Adapt template literal for version string from hook.

2. Edit src/hooks/useMetadata.ts
    * Delete impure assignment to `versionString` property.

3. Edit src/types/metadataService.proto.ts
    * Delete `versionString` property which is not in /v1/metadata response.
        https://github.com/stackrox/stackrox/blob/master/proto/api/v1/metadata_service.proto#L11-L26

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed