### PR TITLE
ROX-12900: Add filter autocomplete to PR Network Graph

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.css
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.css
@@ -14,11 +14,11 @@
 /* Create a stacking context that is higher than the context for the react-topology component
    that is rendered below the toolbar, so that the search filter dropdown will render above the graph when open */
 [data-testid="network-graph-toolbar"] {
-    z-index: 150;
+    z-index: 250;
 }
 [data-testid="network-graph-toolbar"] .pf-search-shim,
 [data-testid="network-graph-toolbar"] .react-select__menu {
-    z-index: 150;
+    z-index: 250;
 }
 
 /* Remove gray background from plain PF Select trigger button when disabled */

--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.css
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.css
@@ -6,11 +6,20 @@
 }
 
 .pf-topology-resizable-side-bar {
-    /* we use the page header min height thrice to account for: nav header + page header + secondary header */ 
+    /* we use the page header min height thrice to account for: nav header + page header + secondary header */
     /* @TODO: Consider a more future-proof way of doing this. See https://github.com/stackrox/stackrox/pull/3703#discussion_r1014292340 */
     height: calc(100vh - var(--pf-c-page__header--MinHeight) - var(--pf-c-page__header--MinHeight) - var(--pf-c-page__header--MinHeight));
 }
 
+/* Create a stacking context that is higher than the context for the react-topology component
+   that is rendered below the toolbar, so that the search filter dropdown will render above the graph when open */
+[data-testid="network-graph-toolbar"] {
+    z-index: 150;
+}
+[data-testid="network-graph-toolbar"] .pf-search-shim,
+[data-testid="network-graph-toolbar"] .react-select__menu {
+    z-index: 150;
+}
 
 /* Remove gray background from plain PF Select trigger button when disabled */
 .network-graph-selector-bar .pf-c-select__toggle.pf-m-disabled,

--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
@@ -19,6 +19,7 @@ import useURLSearch from 'hooks/useURLSearch';
 import { fetchNetworkFlowGraph, fetchNetworkPolicyGraph } from 'services/NetworkService';
 import { getQueryString } from 'utils/queryStringUtils';
 import timeWindowToDate from 'utils/timeWindows';
+import { isCompleteSearchFilter } from 'utils/searchUtils';
 
 import PageTitle from 'Components/PageTitle';
 import useURLParameter from 'hooks/useURLParameter';
@@ -90,8 +91,14 @@ function NetworkGraphPage() {
     const { deploymentCount } = useFetchDeploymentCount(selectedClusterId || '');
 
     useDeepCompareEffect(() => {
+        // check that user is finished adding a complete filter
+        const isQueryFilterComplete = isCompleteSearchFilter(remainingQuery);
+
         // only refresh the graph data from the API if both a cluster and at least one namespace are selected
-        if (clusterFromUrl && namespacesFromUrl.length > 0 && deploymentCount) {
+        const isClusterNamespaceSelected =
+            clusterFromUrl && namespacesFromUrl.length > 0 && deploymentCount;
+
+        if (isQueryFilterComplete && isClusterNamespaceSelected) {
             if (selectedClusterId) {
                 setIsLoading(true);
 
@@ -174,7 +181,7 @@ function NetworkGraphPage() {
                     .finally(() => setIsLoading(false));
             }
         }
-    }, [clusters, clusterFromUrl, namespacesFromUrl, deploymentsFromUrl, deploymentCount]);
+    }, [clusterFromUrl, namespacesFromUrl, deploymentsFromUrl, deploymentCount, remainingQuery]);
 
     useEffect(() => {
         if (edgeState === 'active') {
@@ -256,7 +263,11 @@ function NetworkGraphPage() {
                         </ToolbarGroup>
                         <ToolbarGroup className="pf-u-flex-grow-1">
                             <ToolbarItem className="pf-u-flex-grow-1">
-                                <NetworkSearch />
+                                <NetworkSearch
+                                    selectedCluster={clusterFromUrl}
+                                    selectedNamespaces={namespacesFromUrl}
+                                    selectedDeployments={deploymentsFromUrl}
+                                />
                             </ToolbarItem>
                             <ToolbarItem>
                                 <DisplayOptionsSelect

--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
@@ -17,7 +17,7 @@ import useFetchClusters from 'hooks/useFetchClusters';
 import useFetchDeploymentCount from 'hooks/useFetchDeploymentCount';
 import useURLSearch from 'hooks/useURLSearch';
 import { fetchNetworkFlowGraph, fetchNetworkPolicyGraph } from 'services/NetworkService';
-import { getQueryString } from 'utils/queryStringUtils';
+import queryService from 'utils/queryService';
 import timeWindowToDate from 'utils/timeWindows';
 import { isCompleteSearchFilter } from 'utils/searchUtils';
 
@@ -102,7 +102,7 @@ function NetworkGraphPage() {
             if (selectedClusterId) {
                 setIsLoading(true);
 
-                const queryToUse = getQueryString(remainingQuery).slice(1);
+                const queryToUse = queryService.objectToWhereClause(remainingQuery);
                 const timestampToUse = timeWindowToDate(timeWindow);
 
                 Promise.all([

--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
@@ -24,6 +24,7 @@ import PageTitle from 'Components/PageTitle';
 import useURLParameter from 'hooks/useURLParameter';
 import EmptyUnscopedState from './components/EmptyUnscopedState';
 import NetworkBreadcrumbs from './components/NetworkBreadcrumbs';
+import NetworkSearch from './components/NetworkSearch';
 import SimulateNetworkPolicyButton from './simulation/SimulateNetworkPolicyButton';
 import EdgeStateSelect, { EdgeState } from './components/EdgeStateSelect';
 import DisplayOptionsSelect, { DisplayOption } from './components/DisplayOptionsSelect';
@@ -253,8 +254,10 @@ function NetworkGraphPage() {
                             </ToolbarItem>
                             <ToolbarItem>in the past hour</ToolbarItem>
                         </ToolbarGroup>
-                        <ToolbarGroup>
-                            <ToolbarItem>Add one or more deployment filters</ToolbarItem>
+                        <ToolbarGroup className="pf-u-flex-grow-1">
+                            <ToolbarItem className="pf-u-flex-grow-1">
+                                <NetworkSearch />
+                            </ToolbarItem>
                             <ToolbarItem>
                                 <DisplayOptionsSelect
                                     selectedOptions={displayOptions}

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/NetworkSearch.css
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/NetworkSearch.css
@@ -1,0 +1,52 @@
+/*
+* This is a transitional stylesheet to make the classic search component 
+* look closer to the PatternFly style. This should be removed when an equivalent
+* PatternFly component can be built.
+*/
+
+.pf-search-shim.react-select--is-disabled {
+  /* 
+  * Note that this opacity change is a result of Tailwind styles that are applied
+  * throughout the app and *not* something that comes from PatternFly. When we are 
+  * fully migrated to PatternFly this rule should be removed.
+  */
+  opacity: 0.5;
+}
+
+.pf-search-shim.react-select--is-disabled > div {
+  background-color: var(--pf-global--disabled-color--300) !important;
+}
+
+.pf-search-shim * {
+  font-family: var(--pf-global--FontFamily--sans-serif) !important;
+}
+
+.pf-search-shim > div > span,
+.pf-search-shim > div .react-select__value-container * {
+  color: var(--pf-global--Color--100) !important;
+  font-weight: var(--pf-global--FontWeight--normal) !important;
+}
+
+.pf-search-shim > div .react-select__value-container span {
+  font-size: var(--pf-global--FontSize--md) !important;
+}
+
+.pf-search-shim svg {
+  fill: var(--pf-global--Color--100);
+}
+
+.pf-search-shim > .react-select__control {
+  border-radius: 0 !important;
+  border-width: var(--pf-global--BorderWidth--sm) !important;
+  border-bottom-color: var(	--pf-global--BorderColor--200) !important;
+  min-height: 36px !important;
+}
+
+.pf-search-shim .react-select__indicator-separator {
+  display: none;
+}
+
+.pf-search-shim .react-select__multi-value__label {
+  color: var(--pf-global--Color--100) !important;
+  font-size: var(--pf-global--FontSize--xs) !important;
+}

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/NetworkSearch.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/NetworkSearch.tsx
@@ -1,14 +1,10 @@
 import React, { useEffect, useState } from 'react';
-import { useHistory } from 'react-router-dom';
 
 import SearchFilterInput from 'Components/SearchFilterInput';
 import useURLSearch from 'hooks/useURLSearch';
 import searchOptionsToQuery from 'services/searchOptionsToQuery';
 import { getSearchOptionsForCategory } from 'services/SearchService';
-import { isCompleteSearchFilter } from 'utils/searchUtils';
-import {
-    orchestratorComponentsOption,
-} from 'utils/orchestratorComponents';
+import { orchestratorComponentsOption } from 'utils/orchestratorComponents';
 
 import './NetworkSearch.css';
 
@@ -32,7 +28,6 @@ function NetworkSearch({
     selectedNamespaces = [],
     selectedDeployments = [],
 }: NetworkSearchsProps) {
-    const history = useHistory();
     const [searchOptions, setSearchOptions] = useState<string[]>([]);
     const { searchFilter, setSearchFilter } = useURLSearch();
 
@@ -51,14 +46,12 @@ function NetworkSearch({
     }, [setSearchOptions]);
 
     function onSearch(options) {
-        options.Cluster = selectedCluster;
-        options.Namespace = selectedNamespaces;
-        options.Deployment = selectedDeployments;
+        const newOptions = { ...options };
+        newOptions.Cluster = selectedCluster;
+        newOptions.Namespace = selectedNamespaces;
+        newOptions.Deployment = selectedDeployments;
 
-        setSearchFilter(options);
-        if (isCompleteSearchFilter(options)) {
-            history.push(`/main/network-graph${history.location.search as string}`);
-        }
+        setSearchFilter(newOptions);
     }
 
     const prependAutocompleteQuery = [...orchestratorComponentsOption];

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/NetworkSearch.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/NetworkSearch.tsx
@@ -54,7 +54,7 @@ function NetworkSearch() {
     function onSearch(options) {
         setSearchFilter(options);
         if (isCompleteSearchFilter(options)) {
-            history.push(`/main/network${history.location.search as string}`);
+            history.push(`/main/network-graph${history.location.search as string}`);
         }
     }
 

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/NetworkSearch.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/NetworkSearch.tsx
@@ -1,0 +1,73 @@
+import React, { useEffect, useState } from 'react';
+import { useHistory } from 'react-router-dom';
+
+import useURLSearch from 'hooks/useURLSearch';
+import searchOptionsToQuery from 'services/searchOptionsToQuery';
+import { getSearchOptionsForCategory } from 'services/SearchService';
+import { isCompleteSearchFilter } from 'utils/searchUtils';
+import { SearchEntry, SearchFilter } from 'types/search';
+import SearchFilterInput from 'Components/SearchFilterInput';
+
+import './NetworkSearch.css';
+
+function searchFilterToSearchEntries(searchFilter): SearchEntry[] {
+    const entries: SearchEntry[] = [];
+    Object.entries(searchFilter).forEach(([key, value]) => {
+        entries.push({ label: `${key}:`, value: `${key}:`, type: 'categoryOption' });
+        if (value !== '') {
+            const values = Array.isArray(value) ? value : [value];
+            const valueOptions = values.map((v) => ({ label: v, value: v }));
+            entries.push(...valueOptions);
+        }
+    });
+    return entries;
+}
+
+const searchCategory = 'DEPLOYMENTS';
+const searchOptionExclusions = [
+    'Cluster',
+    'Deployment',
+    'Namespace',
+    'Namespace ID',
+    'Orchestrator Component',
+];
+
+function NetworkSearch() {
+    const history = useHistory();
+    const [searchOptions, setSearchOptions] = useState<string[]>([]);
+    const { searchFilter, setSearchFilter } = useURLSearch();
+
+    useEffect(() => {
+        const { request, cancel } = getSearchOptionsForCategory(searchCategory);
+        request
+            .then((options) => {
+                const filteredOptions = options.filter((o) => !searchOptionExclusions.includes(o));
+                setSearchOptions(filteredOptions);
+            })
+            .catch(() => {
+                // A request error will disable the search filter.
+            });
+
+        return cancel;
+    }, [setSearchOptions]);
+
+    function onSearch(options) {
+        setSearchFilter(options);
+        if (isCompleteSearchFilter(options)) {
+            history.push(`/main/network${history.location.search as string}`);
+        }
+    }
+
+    return (
+        <SearchFilterInput
+            className="pf-u-w-100 pf-search-shim"
+            placeholder="Add one or more deployment filters"
+            searchFilter={searchFilter}
+            searchCategory="DEPLOYMENTS"
+            searchOptions={searchOptions}
+            handleChangeSearchFilter={onSearch}
+        />
+    );
+}
+
+export default NetworkSearch;

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/NetworkSearch.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/NetworkSearch.tsx
@@ -1,27 +1,16 @@
 import React, { useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 
+import SearchFilterInput from 'Components/SearchFilterInput';
 import useURLSearch from 'hooks/useURLSearch';
 import searchOptionsToQuery from 'services/searchOptionsToQuery';
 import { getSearchOptionsForCategory } from 'services/SearchService';
 import { isCompleteSearchFilter } from 'utils/searchUtils';
-import { SearchEntry, SearchFilter } from 'types/search';
-import SearchFilterInput from 'Components/SearchFilterInput';
+import {
+    orchestratorComponentsOption,
+} from 'utils/orchestratorComponents';
 
 import './NetworkSearch.css';
-
-function searchFilterToSearchEntries(searchFilter): SearchEntry[] {
-    const entries: SearchEntry[] = [];
-    Object.entries(searchFilter).forEach(([key, value]) => {
-        entries.push({ label: `${key}:`, value: `${key}:`, type: 'categoryOption' });
-        if (value !== '') {
-            const values = Array.isArray(value) ? value : [value];
-            const valueOptions = values.map((v) => ({ label: v, value: v }));
-            entries.push(...valueOptions);
-        }
-    });
-    return entries;
-}
 
 const searchCategory = 'DEPLOYMENTS';
 const searchOptionExclusions = [
@@ -32,7 +21,17 @@ const searchOptionExclusions = [
     'Orchestrator Component',
 ];
 
-function NetworkSearch() {
+type NetworkSearchsProps = {
+    selectedCluster?: string;
+    selectedNamespaces?: string[];
+    selectedDeployments?: string[];
+};
+
+function NetworkSearch({
+    selectedCluster = '',
+    selectedNamespaces = [],
+    selectedDeployments = [],
+}: NetworkSearchsProps) {
     const history = useHistory();
     const [searchOptions, setSearchOptions] = useState<string[]>([]);
     const { searchFilter, setSearchFilter } = useURLSearch();
@@ -52,11 +51,17 @@ function NetworkSearch() {
     }, [setSearchOptions]);
 
     function onSearch(options) {
+        options.Cluster = selectedCluster;
+        options.Namespace = selectedNamespaces;
+        options.Deployment = selectedDeployments;
+
         setSearchFilter(options);
         if (isCompleteSearchFilter(options)) {
             history.push(`/main/network-graph${history.location.search as string}`);
         }
     }
+
+    const prependAutocompleteQuery = [...orchestratorComponentsOption];
 
     return (
         <SearchFilterInput
@@ -65,6 +70,7 @@ function NetworkSearch() {
             searchFilter={searchFilter}
             searchCategory="DEPLOYMENTS"
             searchOptions={searchOptions}
+            autocompleteQueryPrefix={searchOptionsToQuery(prependAutocompleteQuery)}
             handleChangeSearchFilter={onSearch}
         />
     );


### PR DESCRIPTION
## Description

This adds the existing Network Graph filter autocomplete key-value input, already given a veneer of PatternFly style last year by Dave Vail, to the new PatternFly version of Network Graph.

As we were already doing in classic Network Graph, we remove the Cluster and Namespace categories, but here we also remove the Deployment category as well.

Two ancillary changes to call out:
1. I had to override some z-index styles to get the autocomplete dropdown to show up above the live area of the graph. This includes adding a high z-index on the toolbar parent, to create a new stacking context. (see https://web.dev/learn/css/z-index/#stacking-context for why we need a separate stacking context)
2. I had to change the query-object-to-query-string helper function we were using from the newer `{ getQueryString } from 'utils/queryStringUtils`, to the older `queryService from 'utils/queryService'`, because the newer function was causing incorrect handling of the nested query properties. For instance,`'Deployment Label': 'app=central'` was being parsed into `Deployment%20Label=app=central` instead of what the API expected, `Deployment%20Label:app=central`

## Checklist
- [x] Investigated and inspected CI test results (unrelated flakes because of test infrastructure network connection drop out)

## Testing Performed

Without a query filter
![Screen Shot 2023-01-18 at 1 40 47 PM](https://user-images.githubusercontent.com/715729/213273827-342692f8-7831-4784-85cd-e861265a5321.png)

With a query filter applied
![Screen Shot 2023-01-18 at 1 39 19 PM](https://user-images.githubusercontent.com/715729/213273871-50e92923-9093-4841-958a-caa184e125d1.png)
