### PR TITLE
ROX-14352: Prepare for new `git` version

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,6 +26,11 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
 
+      - name: Ignore dubious repository ownership
+        run: |
+          # Prevent fatal error "detected dubious ownership in repository" from recent git.
+          git config --global --add safe.directory "$(pwd)"
+
       - uses: ./.github/actions/create-concatenated-ui-monorepo-lock
 
       - uses: ./.github/actions/cache-ui-dependencies
@@ -56,6 +61,11 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
 
+      - name: Ignore dubious repository ownership
+        run: |
+          # Prevent fatal error "detected dubious ownership in repository" from recent git.
+          git config --global --add safe.directory "$(pwd)"
+
       - name: Cache Go dependencies
         uses: ./.github/actions/cache-go-dependencies
 
@@ -82,6 +92,11 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Ignore dubious repository ownership
+        run: |
+          # Prevent fatal error "detected dubious ownership in repository" from recent git.
+          git config --global --add safe.directory "$(pwd)"
 
       - name: Cache Go dependencies
         uses: ./.github/actions/cache-go-dependencies
@@ -116,6 +131,11 @@ jobs:
       with:
         fetch-depth: 0
         ref: ${{ github.event.pull_request.head.sha }}
+
+    - name: Ignore dubious repository ownership
+      run: |
+        # Prevent fatal error "detected dubious ownership in repository" from recent git.
+        git config --global --add safe.directory "$(pwd)"
 
     - name: Cache Go dependencies
       uses: ./.github/actions/cache-go-dependencies
@@ -153,6 +173,11 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Ignore dubious repository ownership
+        run: |
+          # Prevent fatal error "detected dubious ownership in repository" from recent git.
+          git config --global --add safe.directory "$(pwd)"
 
       - name: Cache Go dependencies
         uses: ./.github/actions/cache-go-dependencies
@@ -196,6 +221,11 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Ignore dubious repository ownership
+        run: |
+          # Prevent fatal error "detected dubious ownership in repository" from recent git.
+          git config --global --add safe.directory "$(pwd)"
 
       - name: Checkout submodules
         run: |
@@ -282,6 +312,11 @@ jobs:
         fetch-depth: 0
         ref: ${{ github.event.pull_request.head.sha }}
 
+    - name: Ignore dubious repository ownership
+      run: |
+        # Prevent fatal error "detected dubious ownership in repository" from recent git.
+        git config --global --add safe.directory "$(pwd)"
+
     - name: Checkout submodules
       run: |
         git submodule update --init
@@ -361,6 +396,11 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
 
+      - name: Ignore dubious repository ownership
+        run: |
+          # Prevent fatal error "detected dubious ownership in repository" from recent git.
+          git config --global --add safe.directory "$(pwd)"
+
       - name: Cache Go dependencies
         uses: ./.github/actions/cache-go-dependencies
 
@@ -414,6 +454,11 @@ jobs:
         fetch-depth: 0
         ref: ${{ github.event.pull_request.head.sha }}
 
+    - name: Ignore dubious repository ownership
+      run: |
+        # Prevent fatal error "detected dubious ownership in repository" from recent git.
+        git config --global --add safe.directory "$(pwd)"
+
     - name: Cache Go dependencies
       uses: ./.github/actions/cache-go-dependencies
 
@@ -461,6 +506,11 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Ignore dubious repository ownership
+        run: |
+          # Prevent fatal error "detected dubious ownership in repository" from recent git.
+          git config --global --add safe.directory "$(pwd)"
 
       - name: Checkout submodules
         run: |

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -24,6 +24,11 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
 
+      - name: Ignore dubious repository ownership
+        run: |
+          # Prevent fatal error "detected dubious ownership in repository" from recent git.
+          git config --global --add safe.directory "$(pwd)"
+
       - name: Cache Go dependencies
         uses: ./.github/actions/cache-go-dependencies
 

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -25,6 +25,11 @@ jobs:
       with:
         fetch-depth: 0
 
+    - name: Ignore dubious repository ownership
+      run: |
+        # Prevent fatal error "detected dubious ownership in repository" from recent git.
+        git config --global --add safe.directory "$(pwd)"
+
     - name: Run Postgres
       run: |
         su postgres -c 'initdb -D /tmp/data'
@@ -46,6 +51,11 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
+
+    - name: Ignore dubious repository ownership
+      run: |
+        # Prevent fatal error "detected dubious ownership in repository" from recent git.
+        git config --global --add safe.directory "$(pwd)"
 
     - name: Create combined mono repo lock file
       uses: ./.github/actions/create-concatenated-ui-monorepo-lock

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -994,6 +994,11 @@ openshift_ci_mods() {
     info "Env A-Z dump:"
     env | sort | grep -E '^[A-Z]' || true
 
+    ensure_writable_home_dir
+
+    # Prevent fatal error "detected dubious ownership in repository" from recent git.
+    git config --global --add safe.directory "$(pwd)"
+
     info "Git log:"
     git log --oneline --decorate -n 20 || true
 
@@ -1010,14 +1015,6 @@ openshift_ci_mods() {
     # These are not set in the binary_build_commands or image build envs.
     export CI=true
     export OPENSHIFT_CI=true
-
-    # Single step test jobs do not have HOME
-    if [[ -z "${HOME:-}" ]] || ! touch "${HOME}/openshift-ci-write-test"; then
-        info "HOME (${HOME:-unset}) is not set or not writeable, using mktemp dir"
-        HOME=$( mktemp -d )
-        export HOME
-        info "HOME is now $HOME"
-    fi
 
     if is_in_PR_context && ! is_openshift_CI_rehearse_PR; then
         local sha
@@ -1052,6 +1049,16 @@ openshift_ci_mods() {
     export STACKROX_BUILD_TAG
 
     info "END OpenShift CI mods"
+}
+
+ensure_writable_home_dir() {
+    # Single step test jobs do not have HOME
+    if [[ -z "${HOME:-}" ]] || ! touch "${HOME}/openshift-ci-write-test"; then
+        info "HOME (${HOME:-unset}) is not set or not writeable, using mktemp dir"
+        HOME=$( mktemp -d )
+        export HOME
+        info "HOME is now $HOME"
+    fi
 }
 
 openshift_ci_import_creds() {


### PR DESCRIPTION
## Description

A newer git provided by impeding test container bump does not like the ownership on the checked out repository both on GHA and OSCI:

```
fatal: detected dubious ownership in repository at '/go/src/github.com/stackrox/stackrox'
To add an exception for this directory, call:
	git config --global --add safe.directory /go/src/github.com/stackrox/stackrox
```

So we need to whitelist the directory.

Moreover, some of the jobs run in environment where `$HOME` is not set, so we need to do the setup before this `git config` invocation, otherwise it fails with:
```
error: could not lock config file //.gitconfig: Permission denied
```

I extracted these changes from the bump PR to keep things simple.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

Ran tests in https://github.com/openshift/release/pull/35471 and https://github.com/stackrox/stackrox/pull/4446 where this change was included.

## Refs:

- https://github.com/actions/checkout/issues/760