### PR TITLE
Add scroll in Cypress test to debug collection failures

### DIFF
--- a/ui/apps/platform/cypress/integration/collections/deploymentMatching.test.js
+++ b/ui/apps/platform/cypress/integration/collections/deploymentMatching.test.js
@@ -96,6 +96,10 @@ describe('Collection deployment matching', () => {
         // View more and ensure the next page loads
         cy.get(`${selectors.resultsPanel} > div:last-child`).scrollTo('bottom');
         cy.get(selectors.viewMoreResultsButton).click();
+        // Scroll to the bottom once the view more has completed
+        cy.get(`${selectors.viewMoreResultsButton}.pf-m-in-progress`);
+        cy.get(`${selectors.viewMoreResultsButton}:not(.pf-m-in-progress)`);
+        cy.get(`${selectors.resultsPanel} > div:last-child`).scrollTo('bottom');
         assertDeploymentsAreMatched(['kube-dns']);
 
         // Restrict collection to two specific deployments

--- a/ui/apps/platform/src/Containers/Collections/CollectionResults.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionResults.tsx
@@ -94,15 +94,22 @@ function CollectionResults({
         (page: number) => fetchMatchingDeployments(dryRunConfig, page, filterText, selected),
         [dryRunConfig, filterText, selected]
     );
-    const { data, fetchNextPage, resetPages, clearPages, isEndOfResults, isRefreshingResults } =
-        usePaginatedQuery(queryFn, 10, {
-            debounceRate: 800,
-            manualFetch: true,
-            dedupKeyFn: ({ id }) => id,
-            onError: (err) => {
-                setConfigError?.(parseConfigError(err));
-            },
-        });
+    const {
+        data,
+        fetchNextPage,
+        resetPages,
+        clearPages,
+        isEndOfResults,
+        isFetchingNextPage,
+        isRefreshingResults,
+    } = usePaginatedQuery(queryFn, 10, {
+        debounceRate: 800,
+        manualFetch: true,
+        dedupKeyFn: ({ id }) => id,
+        onError: (err) => {
+            setConfigError?.(parseConfigError(err));
+        },
+    });
 
     const selectorRulesExist =
         dryRunConfig.resourceSelectors?.[0]?.rules?.length > 0 ||
@@ -215,6 +222,7 @@ function CollectionResults({
                                     variant="link"
                                     isInline
                                     className="pf-u-text-align-center"
+                                    isLoading={isFetchingNextPage || isRefreshingResults}
                                     onClick={() => fetchNextPage(true)}
                                 >
                                     View more

--- a/ui/apps/platform/src/hooks/usePaginatedQuery.ts
+++ b/ui/apps/platform/src/hooks/usePaginatedQuery.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useMemo } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import { debounce } from 'lodash';
 
 function filterNextPage<Item, ItemKey>(
@@ -136,7 +136,7 @@ export function usePaginatedQuery<Item, ItemKey>(
     // we know that we want to fetch the data _now_.
     // (e.g. We would want to debounce for text input `keypress` events, but a single
     // "View more" button that is immediately disabled once clicked can fetch without delay.)
-    const pageFetcher = useMemo(() => {
+    const pageFetcher = useCallback(() => {
         setIsFetchingNextPage(true);
         return {
             debounced: debounce(fetchPageHandler, debounceRate ?? 0),
@@ -147,9 +147,9 @@ export function usePaginatedQuery<Item, ItemKey>(
     const fetchNextPage = useCallback(
         (immediate = false) => {
             if (immediate) {
-                return pageFetcher.immediate(queryFn, page, itemKeys);
+                return pageFetcher().immediate(queryFn, page, itemKeys);
             }
-            return pageFetcher.debounced(queryFn, page, itemKeys);
+            return pageFetcher().debounced(queryFn, page, itemKeys);
         },
         [pageFetcher, queryFn, page, itemKeys]
     );
@@ -167,7 +167,7 @@ export function usePaginatedQuery<Item, ItemKey>(
         setIsFetchingNextPage(true);
         // Error handling and state setting already complete, so ignore this error
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        pageFetcher.debounced(queryFn, 0, new Set());
+        pageFetcher().debounced(queryFn, 0, new Set());
     }, [clearPages, pageFetcher, queryFn]);
 
     useEffect(() => {


### PR DESCRIPTION
## Description

This adds another scroll in the collections sidebar to aid in test failure debugging. Naturally, the addition of this scroll seems to make the error disappear as well...

As part of this change I noticed that the "isFetching" state was set incorrectly for the sidebar (only ever set once), so that is fixed as well.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Manual testing of sidebar, CI check.
