### PR TITLE
Don't use deprecated GHA output

### DIFF
--- a/.github/actions/cache-go-dependencies/action.yaml
+++ b/.github/actions/cache-go-dependencies/action.yaml
@@ -6,8 +6,8 @@ runs:
     - name: Determine Go cache paths
       id: cache-paths
       run: |
-        echo "::set-output name=GOCACHE::$(go env GOCACHE)"
-        echo "::set-output name=GOMODCACHE::$(go env GOMODCACHE)"
+        echo "GOCACHE=$(go env GOCACHE)" >> "$GITHUB_OUTPUT"
+        echo "GOMODCACHE=$(go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
       shell: bash
 
     - name: Cache Go Dependencies


### PR DESCRIPTION
## Description

Avoid deprecated constructs in GHA

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/