### PR TITLE
ROX-14357: Correct the No Clusters message when empty results in cluster search

### DIFF
--- a/ui/apps/platform/src/Containers/Clusters/ClustersTablePanel.js
+++ b/ui/apps/platform/src/Containers/Clusters/ClustersTablePanel.js
@@ -23,7 +23,7 @@ import {
     upgradeCluster,
 } from 'services/ClustersService';
 import { toggleRow, toggleSelectAll } from 'utils/checkboxUtils';
-import { filterAllowedSearch, convertToRestSearch } from 'utils/searchUtils';
+import { filterAllowedSearch, convertToRestSearch, getHasSearchApplied } from 'utils/searchUtils';
 
 import AutoUpgradeToggle from './Components/AutoUpgradeToggle';
 import { clusterTablePollingInterval, getUpgradeableClusters } from './cluster.helpers';
@@ -258,6 +258,8 @@ function ClustersTablePanel({ selectedClusterId, setSelectedClusterId, searchOpt
     const pageSize =
         currentClusters.length <= DEFAULT_PAGE_SIZE ? DEFAULT_PAGE_SIZE : currentClusters.length;
 
+    const hasSearchApplied = getHasSearchApplied(filteredSearch);
+
     return (
         <div className="overflow-hidden w-full">
             <PanelNew testid="panel">
@@ -271,28 +273,29 @@ function ClustersTablePanel({ selectedClusterId, setSelectedClusterId, searchOpt
                             {messages}
                         </div>
                     )}
-                    {(!fetchingClusters || pollingCount > 0) && currentClusters.length <= 0 && (
-                        <AddClusterPrompt />
-                    )}
-                    {(!fetchingClusters || pollingCount > 0) && currentClusters.length > 0 && (
-                        <div data-testid="clusters-table" className="h-full w-full">
-                            <CheckboxTable
-                                ref={(table) => {
-                                    setTableRef(table);
-                                }}
-                                rows={currentClusters}
-                                columns={clusterColumns}
-                                onRowClick={setSelectedClusterId}
-                                toggleRow={toggleCluster}
-                                toggleSelectAll={toggleAllClusters}
-                                selection={checkedClusterIds}
-                                selectedRowId={selectedClusterId}
-                                noDataText="No clusters to show."
-                                minRows={20}
-                                pageSize={pageSize}
-                            />
-                        </div>
-                    )}
+                    {(!fetchingClusters || pollingCount > 0) &&
+                        currentClusters.length <= 0 &&
+                        !hasSearchApplied && <AddClusterPrompt />}
+                    {(!fetchingClusters || pollingCount > 0) &&
+                        (currentClusters.length > 0 || hasSearchApplied) && (
+                            <div data-testid="clusters-table" className="h-full w-full">
+                                <CheckboxTable
+                                    ref={(table) => {
+                                        setTableRef(table);
+                                    }}
+                                    rows={currentClusters}
+                                    columns={clusterColumns}
+                                    onRowClick={setSelectedClusterId}
+                                    toggleRow={toggleCluster}
+                                    toggleSelectAll={toggleAllClusters}
+                                    selection={checkedClusterIds}
+                                    selectedRowId={selectedClusterId}
+                                    noDataText="No clusters to show."
+                                    minRows={20}
+                                    pageSize={pageSize}
+                                />
+                            </div>
+                        )}
                 </PanelBody>
             </PanelNew>
             <Dialog

--- a/ui/apps/platform/src/Containers/VulnMgmt/Reports/VulnMgmtReportTablePage.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Reports/VulnMgmtReportTablePage.tsx
@@ -29,7 +29,7 @@ import useTableSort from 'hooks/useTableSort';
 import { vulnManagementReportsPath } from 'routePaths';
 import { deleteReport, runReport } from 'services/ReportsService';
 import { SearchFilter } from 'types/search';
-import { filterAllowedSearch } from 'utils/searchUtils';
+import { filterAllowedSearch, getHasSearchApplied } from 'utils/searchUtils';
 import { getQueryString } from 'utils/queryStringUtils';
 import VulnMgmtReportTablePanel from './VulnMgmtReportTablePanel';
 import VulnMgmtReportTableColumnDescriptor from './VulnMgmtReportTableColumnDescriptor';
@@ -110,6 +110,9 @@ function ReportTablePage({ query }: ReportTablePageProps): ReactElement {
             triggerRefresh();
         });
     }
+
+    const hasSearchApplied = getHasSearchApplied(filteredSearch);
+
     return (
         <>
             <PageSection variant={PageSectionVariants.light}>
@@ -156,7 +159,7 @@ function ReportTablePage({ query }: ReportTablePageProps): ReactElement {
                     </Bullseye>
                 </PageSection>
             )}
-            {!isLoading && (reports?.length || Boolean(Object.keys(filteredSearch).length)) && (
+            {!isLoading && (reports?.length || hasSearchApplied) && (
                 <VulnMgmtReportTablePanel
                     reports={reports || []}
                     reportCount={reportCount}
@@ -175,7 +178,7 @@ function ReportTablePage({ query }: ReportTablePageProps): ReactElement {
                     onDeleteReports={onDeleteReports}
                 />
             )}
-            {!isLoading && !reports?.length && !Object.keys(filteredSearch).length && (
+            {!isLoading && !reports?.length && !hasSearchApplied && (
                 <PageSection variant={PageSectionVariants.light} isFilled>
                     <EmptyStateTemplate
                         title="No reports are currently configured."

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ApprovedDeferrals/ApprovedDeferrals.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ApprovedDeferrals/ApprovedDeferrals.tsx
@@ -1,9 +1,10 @@
 import React, { ReactElement } from 'react';
+import { PageSection, PageSectionVariants } from '@patternfly/react-core';
 
 import usePagination from 'hooks/patternfly/usePagination';
 import queryService from 'utils/queryService';
+import { getHasSearchApplied } from 'utils/searchUtils';
 import useURLSearch from 'hooks/useURLSearch';
-import { PageSection, PageSectionVariants } from '@patternfly/react-core';
 import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';
 import useVulnerabilityRequests from '../useVulnerabilityRequests';
 import ApprovedDeferralsTable from './ApprovedDeferralsTable';
@@ -39,8 +40,9 @@ function ApprovedDeferrals(): ReactElement {
 
     const rows = data?.vulnerabilityRequests || [];
     const itemCount = data?.vulnerabilityRequestsCount || 0;
+    const hasSearchApplied = getHasSearchApplied(searchFilter);
 
-    if (!isLoading && rows && rows.length === 0 && !Object.keys(searchFilter).length) {
+    if (!isLoading && rows && rows.length === 0 && !hasSearchApplied) {
         return (
             <PageSection variant={PageSectionVariants.light} isFilled>
                 <EmptyStateTemplate title="No deferral requests were approved." headingLevel="h2" />

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ApprovedFalsePositives/ApprovedFalsePositives.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/ApprovedFalsePositives/ApprovedFalsePositives.tsx
@@ -1,9 +1,10 @@
 import React, { ReactElement } from 'react';
+import { PageSection, PageSectionVariants } from '@patternfly/react-core';
 
 import usePagination from 'hooks/patternfly/usePagination';
 import queryService from 'utils/queryService';
+import { getHasSearchApplied } from 'utils/searchUtils';
 import useURLSearch from 'hooks/useURLSearch';
-import { PageSection, PageSectionVariants } from '@patternfly/react-core';
 import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';
 import useVulnerabilityRequests from '../useVulnerabilityRequests';
 import ApprovedFalsePositivesTable from './ApprovedFalsePositivesTable';
@@ -38,8 +39,9 @@ function ApprovedFalsePositives(): ReactElement {
 
     const rows = data?.vulnerabilityRequests || [];
     const itemCount = data?.vulnerabilityRequestsCount || 0;
+    const hasSearchApplied = getHasSearchApplied(searchFilter);
 
-    if (!isLoading && rows && rows.length === 0 && !Object.keys(searchFilter).length) {
+    if (!isLoading && rows && rows.length === 0 && !hasSearchApplied) {
         return (
             <PageSection variant={PageSectionVariants.light} isFilled>
                 <EmptyStateTemplate

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/PendingApprovals/PendingApprovals.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/PendingApprovals/PendingApprovals.tsx
@@ -1,10 +1,11 @@
 import React, { ReactElement } from 'react';
+import { PageSection, PageSectionVariants } from '@patternfly/react-core';
 
 import usePagination from 'hooks/patternfly/usePagination';
 import queryService from 'utils/queryService';
+import { getHasSearchApplied } from 'utils/searchUtils';
 import useURLSearch from 'hooks/useURLSearch';
 import { SearchFilter } from 'types/search';
-import { PageSection, PageSectionVariants } from '@patternfly/react-core';
 import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';
 import PendingApprovalsTable from './PendingApprovalsTable';
 import useVulnerabilityRequests from '../useVulnerabilityRequests';
@@ -48,8 +49,9 @@ function PendingApprovals(): ReactElement {
 
     const rows = data?.vulnerabilityRequests || [];
     const itemCount = data?.vulnerabilityRequestsCount || 0;
+    const hasSearchApplied = getHasSearchApplied(searchFilter);
 
-    if (!isLoading && rows && rows.length === 0 && !Object.keys(searchFilter).length) {
+    if (!isLoading && rows && rows.length === 0 && !hasSearchApplied) {
         return (
             <PageSection variant={PageSectionVariants.light} isFilled>
                 <EmptyStateTemplate title="No pending requests to approve." headingLevel="h2" />

--- a/ui/apps/platform/src/utils/searchUtils.ts
+++ b/ui/apps/platform/src/utils/searchUtils.ts
@@ -151,6 +151,17 @@ export function getUrlQueryStringForSearchFilter(
 }
 
 /**
+ * Helper function to determine if any search has been applied.
+ *
+ * @param searchFilter The `SearchFilter` value to check.
+ *
+ * @returns boolean, true if there are any search params
+ */
+export function getHasSearchApplied(searchFilter: SearchFilter): boolean {
+    return Boolean(Object.keys(searchFilter).length);
+}
+
+/**
  * Helper function to flatten the value from a `SearchFilter` into a single Array.
  * Array state values stored in the URL are coerced into a singular `string` if they contain
  * one item, or are `undefined` if the key is not part of the `SearchFilter`.


### PR DESCRIPTION
## Description

Mandar noticed the same confusion in a clusters list with no search results, but some number of clusters when unfiltered, that had already been addressed in VM Reports and VM Risk Acceptance lists.

In order to make all these fixes more readable, I extracted the logic to a semantically named function, and updated all the places it is used.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

Manually tested this new fix (screenshot below) and all the existing fixes.

Filtered Clusters list
![Screen Shot 2023-01-19 at 1 05 34 PM](https://user-images.githubusercontent.com/715729/213532929-c8361cc2-bf11-4b81-8e25-b6cfe38feb2d.png)


Unfiltered Clusters list
![Screen Shot 2023-01-19 at 1 05 39 PM](https://user-images.githubusercontent.com/715729/213532834-ba256aed-819c-46c9-8b29-ad0a00bc42eb.png)
