### PR TITLE
Disable trouble collections e2e tests

### DIFF
--- a/ui/apps/platform/cypress/integration/collections/deploymentMatching.test.js
+++ b/ui/apps/platform/cypress/integration/collections/deploymentMatching.test.js
@@ -73,7 +73,7 @@ describe('Collection deployment matching', () => {
 
     // This test relies on the creation of a collection in the previous test in order to check
     // the resolution of deployments with embedded collections.
-    it('should preview deployments using embedded collections', () => {
+    it.skip('should preview deployments using embedded collections', () => {
         // Cleanup from potential previous test runs
         tryDeleteCollection(withEmbeddedCollectionName);
         visitCollections();
@@ -149,7 +149,7 @@ describe('Collection deployment matching', () => {
         cy.get(`td[data-label="Collection"] a:contains("${withEmbeddedCollectionName}")`);
     });
 
-    it('should filter deployment results in the sidebar', () => {
+    it.skip('should filter deployment results in the sidebar', () => {
         visitCollections();
         cy.get(`td[data-label="Collection"] a:contains("${withEmbeddedCollectionName}")`).click();
 


### PR DESCRIPTION
## Description

Disabling these until I can find a better way to debug and fix the flakes.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

CI run that passes e2e tests 🤞 
