### PR TITLE
Dashrews/ROX-14424 properly set migration yaml on pg upgrade

### DIFF
--- a/pkg/migrations/migration_version.go
+++ b/pkg/migrations/migration_version.go
@@ -61,11 +61,11 @@ func Read(dbPath string) (*MigrationVersion, error) {
 
 // SetCurrent update the database migration version of a database directory.
 func SetCurrent(dbPath string) {
-	if curr, err := Read(dbPath); err != nil || curr.MainVersion != version.GetMainVersion() || curr.SeqNum != CurrentDBVersionSeqNum() {
+	if curr, err := Read(dbPath); err != nil || curr.MainVersion != version.GetMainVersion() || curr.SeqNum != LastRocksDBVersionSeqNum() {
 		newVersion := &MigrationVersion{
 			dbPath:      dbPath,
 			MainVersion: version.GetMainVersion(),
-			SeqNum:      CurrentDBVersionSeqNum(),
+			SeqNum:      LastRocksDBVersionSeqNum(), // Most recent possible RocksDB version
 		}
 		err := newVersion.atomicWrite()
 		if err != nil {


### PR DESCRIPTION
## Description

After the migrations are executed we need to set the version of the rocksdb instance so it remains consistent in the event we need to rollback to it.  Previously we were updating the sequence number in a way that if we were in postgres mode we would set it to the max sequence number instead of the max rocksdb sequence number.  This resolves that AND should allow us to in some instances to switch from Postgres back to Rocksdb by changing the env var.

## Checklist
- [ ] Investigated and inspected CI test results
~- [ ] Unit test and regression tests added~
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Manual testing, but will test more thoroughly once #4499 is merged.
