### PR TITLE
ROX-14229: Deterministic UUIDs for declarative config resources

### DIFF
--- a/pkg/declarativeconfig/uuid.go
+++ b/pkg/declarativeconfig/uuid.go
@@ -1,0 +1,34 @@
+package declarativeconfig
+
+import "github.com/stackrox/rox/pkg/uuid"
+
+const (
+	authProviderNS  string = "auth-provider"
+	groupNS         string = "group"
+	permissionSetNS string = "permission-set"
+	accessScopeNS   string = "access-scope"
+)
+
+// NewDeclarativeAuthProviderUUID creates a UUID from the name of a declarative auth provider configuration.
+// The returned UUID will be deterministic.
+func NewDeclarativeAuthProviderUUID(name string) uuid.UUID {
+	return uuid.NewV5FromNonUUIDs(authProviderNS, name)
+}
+
+// NewDeclarativeGroupUUID creates a UUID from the name of a declarative group configuration.
+// The returned UUID will be deterministic.
+func NewDeclarativeGroupUUID(name string) uuid.UUID {
+	return uuid.NewV5FromNonUUIDs(groupNS, name)
+}
+
+// NewDeclarativePermissionSetUUID creates a UUID from the name of a declarative permission set configuration.
+// The returned UUID will be deterministic.
+func NewDeclarativePermissionSetUUID(name string) uuid.UUID {
+	return uuid.NewV5FromNonUUIDs(permissionSetNS, name)
+}
+
+// NewDeclarativeAccessScopeUUID creates a UUID from the name of a declarative access scope configuration.
+// The returned UUID will be deterministic.
+func NewDeclarativeAccessScopeUUID(name string) uuid.UUID {
+	return uuid.NewV5FromNonUUIDs(accessScopeNS, name)
+}

--- a/pkg/declarativeconfig/uuid.go
+++ b/pkg/declarativeconfig/uuid.go
@@ -3,32 +3,32 @@ package declarativeconfig
 import "github.com/stackrox/rox/pkg/uuid"
 
 const (
-	authProviderNS  string = "auth-provider"
-	groupNS         string = "group"
-	permissionSetNS string = "permission-set"
-	accessScopeNS   string = "access-scope"
+	authProviderUUIDNS  string = "auth-provider"
+	groupUUIDNS         string = "group"
+	permissionSetUUIDNS string = "permission-set"
+	accessScopeUUIDNS   string = "access-scope"
 )
 
 // NewDeclarativeAuthProviderUUID creates a UUID from the name of a declarative auth provider configuration.
 // The returned UUID will be deterministic.
 func NewDeclarativeAuthProviderUUID(name string) uuid.UUID {
-	return uuid.NewV5FromNonUUIDs(authProviderNS, name)
+	return uuid.NewV5FromNonUUIDs(authProviderUUIDNS, name)
 }
 
 // NewDeclarativeGroupUUID creates a UUID from the name of a declarative group configuration.
 // The returned UUID will be deterministic.
 func NewDeclarativeGroupUUID(name string) uuid.UUID {
-	return uuid.NewV5FromNonUUIDs(groupNS, name)
+	return uuid.NewV5FromNonUUIDs(groupUUIDNS, name)
 }
 
 // NewDeclarativePermissionSetUUID creates a UUID from the name of a declarative permission set configuration.
 // The returned UUID will be deterministic.
 func NewDeclarativePermissionSetUUID(name string) uuid.UUID {
-	return uuid.NewV5FromNonUUIDs(permissionSetNS, name)
+	return uuid.NewV5FromNonUUIDs(permissionSetUUIDNS, name)
 }
 
 // NewDeclarativeAccessScopeUUID creates a UUID from the name of a declarative access scope configuration.
 // The returned UUID will be deterministic.
 func NewDeclarativeAccessScopeUUID(name string) uuid.UUID {
-	return uuid.NewV5FromNonUUIDs(accessScopeNS, name)
+	return uuid.NewV5FromNonUUIDs(accessScopeUUIDNS, name)
 }

--- a/pkg/declarativeconfig/uuid_test.go
+++ b/pkg/declarativeconfig/uuid_test.go
@@ -1,0 +1,37 @@
+package declarativeconfig
+
+import (
+	"testing"
+
+	"github.com/stackrox/rox/pkg/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDeterministicUUIDs(t *testing.T) {
+	declarativeUUIDFuncs := []func(string) uuid.UUID{
+		NewDeclarativeAuthProviderUUID,
+		NewDeclarativeGroupUUID,
+		NewDeclarativePermissionSetUUID,
+		NewDeclarativeAccessScopeUUID,
+	}
+	dummyName := "dummy-resource"
+
+	// 1. Test that using the same name will lead to the same UUID being created.
+	for _, f := range declarativeUUIDFuncs {
+		firstID := f(dummyName)
+		secondID := f(dummyName)
+		assert.Equal(t, firstID, secondID)
+	}
+
+	// 2. Test that using the same name won't lead to clashes within the different namespaces.
+	for i, f := range declarativeUUIDFuncs {
+		id := f(dummyName)
+		for j, f := range declarativeUUIDFuncs {
+			if j == i {
+				continue
+			}
+			otherID := f(dummyName)
+			assert.NotEqual(t, id, otherID)
+		}
+	}
+}

--- a/pkg/declarativeconfig/uuid_test.go
+++ b/pkg/declarativeconfig/uuid_test.go
@@ -34,4 +34,12 @@ func TestDeterministicUUIDs(t *testing.T) {
 			assert.NotEqual(t, id, otherID)
 		}
 	}
+
+	// 3. Test that using different names in the same namespace will lead to different UUIDs being created.
+	secondDummyName := "another-dummy-resource"
+	for _, f := range declarativeUUIDFuncs {
+		firstID := f(dummyName)
+		secondID := f(secondDummyName)
+		assert.NotEqual(t, firstID, secondID)
+	}
 }


### PR DESCRIPTION
## Description

This PR is a pre-factor for the declarative configuration project.

For declarative configuration, we allow users to specify resources in a declarative manner by providing YAML configuration via config map / secret mounts within central.

The YAML-based configuration will not be using any UUIDs, but instead will be uniquely identified by their name.
To support this, we need to make sure we map those names internally to UUIDs, since datastores typically work with UUIDs as unique identifiers, as well as make sure that we will be able to create the UUIDs deterministic, since the same _named declarative configuration_ should only create _a single set of resources_.

For this, we re-use the `uuid.NewV5FromNonUUID`, which under hood are `v5 UUIDs`, which are meant for generating UUIDs from names (for more info, you can read up [the RFC for UUIDs](https://www.rfc-editor.org/rfc/rfc4122#section-4.3)).

The newly created package contains helper functions to create UUIDs for all of the resources we envision for the first MVP of declarative configuration, including their namespaces.

Note that the `Role` resource has been omitted, since it is one of the few exceptions where no generated IDs are used for unique identification, but rather the name. Hence, we won't need any deterministic UUIDs for those resources.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

- see CI (added unit tests).