### PR TITLE
ROX-14352: Bump CI images to latest version.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,7 +20,7 @@ jobs:
   pre-build-ui:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.49
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.55
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -55,7 +55,7 @@ jobs:
   pre-build-cli:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.49
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.55
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -87,7 +87,7 @@ jobs:
   pre-build-go-binaries:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.49
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.55
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -126,7 +126,7 @@ jobs:
   pre-build-go-binaries-rcd:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.49
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.55
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -168,7 +168,7 @@ jobs:
   pre-build-docs:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.49
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.55
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -209,7 +209,7 @@ jobs:
       - pre-build-go-binaries
       - pre-build-docs
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.49
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.55
       env:
         QUAY_RHACS_ENG_RO_USERNAME: ${{ secrets.QUAY_RHACS_ENG_RO_USERNAME }}
         QUAY_RHACS_ENG_RO_PASSWORD: ${{ secrets.QUAY_RHACS_ENG_RO_PASSWORD }}
@@ -306,7 +306,7 @@ jobs:
     - pre-build-go-binaries-rcd
     - pre-build-docs
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.49
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.55
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -387,7 +387,7 @@ jobs:
   build-and-push-operator:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.49
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.55
       env:
         QUAY_RHACS_ENG_RW_USERNAME: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
         QUAY_RHACS_ENG_RW_PASSWORD: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
@@ -448,7 +448,7 @@ jobs:
   build-and-push-mock-grpc-server:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.49
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.55
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -498,7 +498,7 @@ jobs:
     needs:
       - build-and-push-main
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.49
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.55
       env:
         STACKROX_CI_INSTANCE_API_KEY: ${{ secrets.STACKROX_CI_INSTANCE_API_KEY }}
         STACKROX_CI_INSTANCE_CENTRAL_HOST: ${{ secrets.STACKROX_CI_INSTANCE_CENTRAL_HOST }}

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -19,7 +19,7 @@ jobs:
   style-check:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.50
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.55
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -18,7 +18,7 @@ jobs:
         gotags: [ 'GOTAGS=""', 'GOTAGS=release' ]
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.49
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.55
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -37,7 +37,7 @@ jobs:
         gotags: [ 'GOTAGS=""', 'GOTAGS=release' ]
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.49
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.55
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -66,7 +66,7 @@ jobs:
   ui:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.49
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.55
     steps:
     - name: Checkout
       uses: actions/checkout@v3

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -25,6 +25,11 @@ jobs:
       with:
         fetch-depth: 0
 
+    - name: Ignore dubious repository ownership
+      run: |
+        # Prevent fatal error "detected dubious ownership in repository" from recent git.
+        git config --global --add safe.directory "$(pwd)"
+
     - name: Cache Go dependencies
       uses: ./.github/actions/cache-go-dependencies
 

--- a/.openshift-ci/Dockerfile.build_root
+++ b/.openshift-ci/Dockerfile.build_root
@@ -27,4 +27,4 @@
 # For an example, see https://github.com/stackrox/stackrox/pull/2762 and its counterpart
 # https://github.com/openshift/release/pull/31561
 
-FROM quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.49
+FROM quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.55

--- a/.openshift-ci/build/Dockerfile.build-central-db-bundle
+++ b/.openshift-ci/build/Dockerfile.build-central-db-bundle
@@ -1,4 +1,4 @@
-FROM quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.49
+FROM quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.55
 # note the above FROM line is ignored and OpenShift CI uses build_root image instead
 
 ARG ROX_PRODUCT_BRANDING

--- a/.openshift-ci/build/Dockerfile.build-main-and-bundle
+++ b/.openshift-ci/build/Dockerfile.build-main-and-bundle
@@ -1,4 +1,4 @@
-FROM quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.49
+FROM quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.55
 # note the above FROM line is ignored and OpenShift CI uses build_root image instead
 
 ARG ROX_PRODUCT_BRANDING

--- a/.openshift-ci/build/Dockerfile.build-operator-artifacts
+++ b/.openshift-ci/build/Dockerfile.build-operator-artifacts
@@ -1,4 +1,4 @@
-FROM quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.49
+FROM quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.55
 # note the above FROM line is ignored and OpenShift CI uses build_root image instead
 
 ARG ROX_PRODUCT_BRANDING

--- a/BUILD_IMAGE_VERSION
+++ b/BUILD_IMAGE_VERSION
@@ -1,1 +1,1 @@
-stackrox-build-0.3.49
+stackrox-build-0.3.55

--- a/scale/signatures/deploy.yaml
+++ b/scale/signatures/deploy.yaml
@@ -11,7 +11,7 @@ spec:
         spec:
           containers:
           - name: update-signature
-            image: quay.io/rhacs-eng/apollo-ci:stackrox-test-0.3.49
+            image: quay.io/rhacs-eng/apollo-ci:stackrox-test-0.3.55
             imagePullPolicy: IfNotPresent
             command:
             - /bin/bash

--- a/tests/e2e/run-e2e-tests.sh
+++ b/tests/e2e/run-e2e-tests.sh
@@ -137,7 +137,7 @@ if [[ ! -f "/i-am-rox-ci-image" ]]; then
       --platform linux/amd64 \
       --rm -it \
       --entrypoint="$0" \
-      quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.53 "$@"
+      quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.55 "$@"
     exit 0
 fi
 


### PR DESCRIPTION
## Description

The goal is to pick up a new `oc`. It also happens to pick up newer `git` - a fix for its new checks was merged in #4459 

The custom-built ARM image mentioned in the `Makefile` is not bumped. See https://issues.redhat.com/browse/ROX-12064

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

CI should suffice.