### PR TITLE
Postgres connection string replace UTF-8 with UTF8

### DIFF
--- a/migrator/postgres/gorm/config.go
+++ b/migrator/postgres/gorm/config.go
@@ -50,7 +50,7 @@ func getConfig() (*gormConfig, error) {
 		return nil, errors.Wrapf(err, "pgsql: could not load password file %q", pgconfig.DBPasswordFile)
 	}
 	// Add the password to the source to pass to get the pool config
-	source := fmt.Sprintf("%s password=%s client_encoding=UTF-8", centralConfig.CentralDB.Source, password)
+	source := fmt.Sprintf("%s password=%s client_encoding=UTF8", centralConfig.CentralDB.Source, password)
 	source = pgutils.PgxpoolDsnToPgxDsn(source)
 	gConfig = &gormConfig{source: source, password: string(password)}
 	return gConfig, nil

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -19,7 +19,7 @@ var (
 var (
 	defaultBucketFillFraction = 0.5
 	defaultCompactionState    = true
-	defaultDBSource           = "host=central-db.stackrox port=5432 user=postgres sslmode=verify-full statement_timeout=600000 pool_min_conns=1 pool_max_conns=90 client_encoding=UTF-8"
+	defaultDBSource           = "host=central-db.stackrox port=5432 user=postgres sslmode=verify-full statement_timeout=600000 pool_min_conns=1 pool_max_conns=90 client_encoding=UTF8"
 	defaultDatabase           = "central"
 
 	once   sync.Once

--- a/pkg/postgres/pgtest/conn/conn.go
+++ b/pkg/postgres/pgtest/conn/conn.go
@@ -27,7 +27,7 @@ func GetConnectionString(_ testing.TB) string {
 	pass := env.GetString("POSTGRES_PASSWORD", "")
 	host := env.GetString("POSTGRES_HOST", "localhost")
 	port := env.GetString("POSTGRES_PORT", "5432")
-	src := fmt.Sprintf("host=%s port=%s user=%s sslmode=disable statement_timeout=600000 client_encoding=UTF-8", host, port, user)
+	src := fmt.Sprintf("host=%s port=%s user=%s sslmode=disable statement_timeout=600000 client_encoding=UTF8", host, port, user)
 	if pass != "" {
 		src += fmt.Sprintf(" password=%s", pass)
 	}


### PR DESCRIPTION
## Description

For some reason we used `UTF-8` instead of `UTF8`. This was introduced by me in https://github.com/stackrox/stackrox/pull/2615#issuecomment-1206308628
This PR changes encoding to one supported by Postgres.

- https://github.com/stackrox/stackrox/issues/4481

