### PR TITLE
ROX-14427: set PSPs for CI to false for k8s version 1.25 and higher

### DIFF
--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -87,6 +87,7 @@ function local_dev {
 }
 
 function launch_central {
+    POD_SECURITY_POLICIES="${POD_SECURITY_POLICIES:-false}"
     local k8s_dir="$1"
     local common_dir="${k8s_dir}/../common"
 

--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -87,7 +87,6 @@ function local_dev {
 }
 
 function launch_central {
-    POD_SECURITY_POLICIES="${POD_SECURITY_POLICIES:-false}"
     local k8s_dir="$1"
     local common_dir="${k8s_dir}/../common"
 

--- a/qa-tests-backend/scripts/lib.sh
+++ b/qa-tests-backend/scripts/lib.sh
@@ -8,7 +8,11 @@ set -euo pipefail
 
 deploy_default_psp() {
     info "Deploy Default PSP for stackrox namespace"
-    "${ROOT}/scripts/ci/create-default-psp.sh"
+    if [[ "$POD_SECURITY_POLICIES" != "false" ]]; then
+        "${ROOT}/scripts/ci/create-default-psp.sh"
+    else
+        info "POD_SECURITY_POLICIES is false, skip Deploy Default PSP for stackrox namespace"
+    fi
 }
 
 get_ECR_docker_pull_password() {

--- a/qa-tests-backend/scripts/run-compatibility.sh
+++ b/qa-tests-backend/scripts/run-compatibility.sh
@@ -29,6 +29,7 @@ compatibility_test() {
             info "Not running on CI: skipping cluster setup make sure cluster is already available"
         fi
 
+        setup_podsecuritypolicies_config
         setup_deployment_env false false
         remove_existing_stackrox_resources
         setup_default_TLS_certs
@@ -37,7 +38,10 @@ compatibility_test() {
         echo "Stackrox deployed"
         kubectl -n stackrox get deploy,ds -o wide
 
-        deploy_default_psp
+        if [[ "$POD_SECURITY_POLICIES" ]]; then
+            deploy_default_psp
+        fi
+
         deploy_webhook_server
         get_ECR_docker_pull_password
     fi

--- a/qa-tests-backend/scripts/run-compatibility.sh
+++ b/qa-tests-backend/scripts/run-compatibility.sh
@@ -38,9 +38,7 @@ compatibility_test() {
         echo "Stackrox deployed"
         kubectl -n stackrox get deploy,ds -o wide
 
-        if [[ "$POD_SECURITY_POLICIES" ]]; then
-            deploy_default_psp
-        fi
+        deploy_default_psp
 
         deploy_webhook_server
         get_ECR_docker_pull_password

--- a/qa-tests-backend/scripts/run-compatibility.sh
+++ b/qa-tests-backend/scripts/run-compatibility.sh
@@ -29,8 +29,8 @@ compatibility_test() {
             info "Not running on CI: skipping cluster setup make sure cluster is already available"
         fi
 
-        setup_podsecuritypolicies_config
         setup_deployment_env false false
+        setup_podsecuritypolicies_config
         remove_existing_stackrox_resources
         setup_default_TLS_certs
 
@@ -39,7 +39,6 @@ compatibility_test() {
         kubectl -n stackrox get deploy,ds -o wide
 
         deploy_default_psp
-
         deploy_webhook_server
         get_ECR_docker_pull_password
     fi

--- a/qa-tests-backend/scripts/run-part-1.sh
+++ b/qa-tests-backend/scripts/run-part-1.sh
@@ -32,6 +32,7 @@ config_part_1() {
 
     setup_gcp
     setup_deployment_env false false
+    setup_podsecuritypolicies_config
     remove_existing_stackrox_resources
     setup_default_TLS_certs "$ROOT/$DEPLOY_DIR/default_TLS_certs"
 

--- a/qa-tests-backend/scripts/run-part-1.sh
+++ b/qa-tests-backend/scripts/run-part-1.sh
@@ -39,7 +39,6 @@ config_part_1() {
     deploy_stackrox "$ROOT/$DEPLOY_DIR/client_TLS_certs"
 
     deploy_default_psp
-
     deploy_webhook_server "$ROOT/$DEPLOY_DIR/webhook_server_certs"
     get_ECR_docker_pull_password
 }

--- a/qa-tests-backend/scripts/run-part-1.sh
+++ b/qa-tests-backend/scripts/run-part-1.sh
@@ -38,9 +38,7 @@ config_part_1() {
 
     deploy_stackrox "$ROOT/$DEPLOY_DIR/client_TLS_certs"
 
-    if [[ "$POD_SECURITY_POLICIES" ]]; then
-            deploy_default_psp
-    fi
+    deploy_default_psp
 
     deploy_webhook_server "$ROOT/$DEPLOY_DIR/webhook_server_certs"
     get_ECR_docker_pull_password

--- a/qa-tests-backend/scripts/run-part-1.sh
+++ b/qa-tests-backend/scripts/run-part-1.sh
@@ -38,7 +38,10 @@ config_part_1() {
 
     deploy_stackrox "$ROOT/$DEPLOY_DIR/client_TLS_certs"
 
-    deploy_default_psp
+    if [[ "$POD_SECURITY_POLICIES" ]]; then
+            deploy_default_psp
+    fi
+
     deploy_webhook_server "$ROOT/$DEPLOY_DIR/webhook_server_certs"
     get_ECR_docker_pull_password
 }

--- a/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
@@ -2344,7 +2344,6 @@ class Kubernetes implements OrchestratorMain {
         return evaluateWithRetry(2, 3) {
             Namespace namespace = newNamespace(ns)
             def namespaceId = client.namespaces().createOrReplace(namespace).metadata.getUid()
-
             defaultPspForNamespace(ns)
             return namespaceId
         }

--- a/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
@@ -1678,7 +1678,6 @@ class Kubernetes implements OrchestratorMain {
             createClusterRole(generatePspRole())
             createClusterRoleBinding(generatePspRoleBinding(namespace))
         }
-        
     }
 
     /*

--- a/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
@@ -1655,8 +1655,7 @@ class Kubernetes implements OrchestratorMain {
     }
 
     protected defaultPspForNamespace(String namespace) {
-        def pspEnabled = Env.get("POD_SECURITY_POLICIES")
-        if pspEnabled != "false" {
+        if (Env.get("POD_SECURITY_POLICIES") != "false") {
             PodSecurityPolicy psp = new PodSecurityPolicyBuilder().withNewMetadata()
                 .withName("allow-all-for-test")
                 .endMetadata()

--- a/scripts/ci/clair/deploy.sh
+++ b/scripts/ci/clair/deploy.sh
@@ -45,7 +45,7 @@ if kubectl get ns "${namespace}"; then
     kubectl delete ns "${namespace}" # handle CI re-runs
 fi
 kubectl create ns "${namespace}"
-if [ "$POD_SECURITY_POLICIES" ]; then
+if [[ "$POD_SECURITY_POLICIES" ]]; then
     kubectl -n "${namespace}" apply -f "${DIR}/psp.yaml"
 fi
 

--- a/scripts/ci/clair/deploy.sh
+++ b/scripts/ci/clair/deploy.sh
@@ -45,7 +45,9 @@ if kubectl get ns "${namespace}"; then
     kubectl delete ns "${namespace}" # handle CI re-runs
 fi
 kubectl create ns "${namespace}"
-kubectl -n "${namespace}" apply -f "${DIR}/psp.yaml"
+if [ "$POD_SECURITY_POLICIES" ]; then
+    kubectl -n "${namespace}" apply -f "${DIR}/psp.yaml"
+fi
 
 export POSTGRES_PASSWORD="${CLAIR_DB_PASSWORD}"
 kubectl -n "${namespace}" create secret generic clairsecret --from-file="${DIR}/config.yaml"

--- a/scripts/ci/clair/deploy.sh
+++ b/scripts/ci/clair/deploy.sh
@@ -45,7 +45,7 @@ if kubectl get ns "${namespace}"; then
     kubectl delete ns "${namespace}" # handle CI re-runs
 fi
 kubectl create ns "${namespace}"
-if [[ "$POD_SECURITY_POLICIES" ]]; then
+if [[ "$POD_SECURITY_POLICIES" != "false" ]]; then
     kubectl -n "${namespace}" apply -f "${DIR}/psp.yaml"
 fi
 

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -217,7 +217,7 @@ setup_generated_certs_for_test() {
 setup_podsecuritypolicies_config() {
     info "Set POD_SECURITY_POLYCIES variable based on kubernetes version"
     local version
-    version=(kubectl version --output json)
+    version=$(kubectl version --output json)
     local majorVersion
     majorVersion=$(echo "$version" | jq -r .serverVersion.major)
     local minorVersion

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -215,7 +215,7 @@ setup_generated_certs_for_test() {
 }
 
 setup_podsecuritypolicies_config() {
-    info "Set POD_SECURITY_POLYCIES variable based on kubernetes version"
+    info "Set POD_SECURITY_POLICIES variable based on kubernetes version"
     local version
     version=$(kubectl version --output json)
     local majorVersion
@@ -226,7 +226,7 @@ setup_podsecuritypolicies_config() {
     # PodSecurityPolicy was removed in version 1.25
     if (( "$majorVersion" >= 1 && "$minorVersion" >= 25 )); then
         ci_export "POD_SECURITY_POLICIES" "false"
-        info "POD_SECURITY_POLIECIES set to false"
+        info "POD_SECURITY_POLICIES set to false"
     fi
 }
 

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -15,12 +15,13 @@ export PORT_FORWARD_LOGS="/tmp/port-forward-logs"
 
 # shellcheck disable=SC2120
 deploy_stackrox() {
+    setup_podsecuritypolicies_config
+    
     deploy_central
 
     get_central_basic_auth_creds
     wait_for_api
     setup_client_TLS_certs "${1:-}"
-    setup_podsecuritypolicies_config
 
     deploy_sensor
     echo "Sensor deployed. Waiting for sensor to be up"
@@ -40,13 +41,13 @@ deploy_stackrox_with_custom_sensor() {
         die "expected sensor chart version as parameter in deploy_stackrox_with_custom_sensor"
     fi
     target_version="$1"
+    setup_podsecuritypolicies_config
 
     deploy_central
 
     get_central_basic_auth_creds
     wait_for_api
     setup_client_TLS_certs "${2:-}"
-    setup_podsecuritypolicies_config
 
     # generate init bundle
     password_file="$ROOT/deploy/$ORCHESTRATOR_FLAVOR/central-deploy/password"

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -16,7 +16,7 @@ export PORT_FORWARD_LOGS="/tmp/port-forward-logs"
 # shellcheck disable=SC2120
 deploy_stackrox() {
     setup_podsecuritypolicies_config
-    
+
     deploy_central
 
     get_central_basic_auth_creds
@@ -216,11 +216,12 @@ setup_generated_certs_for_test() {
 
 setup_podsecuritypolicies_config() {
     info "Set POD_SECURITY_POLYCIES variable based on kubernetes version"
-    local version=$(kubectl version --output json)
+    local version
+    version=(kubectl version --output json)
     local majorVersion
-    majorVersion=$(echo $version | jq -r .serverVersion.major)
+    majorVersion=$(echo "$version" | jq -r .serverVersion.major)
     local minorVersion
-    minorVersion=$(echo $version | jq -r .serverVersion.minor)
+    minorVersion=$(echo "$version" | jq -r .serverVersion.minor)
 
     # PodSecurityPolicy was removed in version 1.25
     if (( "$majorVersion" >= 1 && "$minorVersion" >= 25 )); then

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -216,12 +216,15 @@ setup_generated_certs_for_test() {
 setup_podsecuritypolicies_config() {
     info "Set POD_SECURITY_POLYCIES variable based on kubernetes version"
     local version=$(kubectl version --output json)
-    local majorVersion=$(echo $version | jq -r .serverVersion.major)
-    local minorVersion=$(echo $version | jq -r .serverVersion.minor)
-    echo $majorVersion $minorVersion
+    local majorVersion
+    majorVersion=$(echo $version | jq -r .serverVersion.major)
+    local minorVersion
+    minorVersion=$(echo $version | jq -r .serverVersion.minor)
+
     # PodSecurityPolicy was removed in version 1.25
     if (( "$majorVersion" >= 1 && "$minorVersion" >= 25 )); then
-        ci_export POD_SECURITY_POLICIES "false"
+        ci_export "POD_SECURITY_POLICIES" "false"
+        info "POD_SECURITY_POLIECIES set to false"
     fi
 }
 

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -227,6 +227,9 @@ setup_podsecuritypolicies_config() {
     if (( "$majorVersion" >= 1 && "$minorVersion" >= 25 )); then
         ci_export "POD_SECURITY_POLICIES" "false"
         info "POD_SECURITY_POLICIES set to false"
+    else
+        ci_export "POD_SECURITY_POLICIES" "true"
+        info "POD_SECURITY_POLICIES set to true"
     fi
 }
 


### PR DESCRIPTION
## Description

We've had CI Failures like [this](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/branch-ci-stackrox-stackrox-nightlies-osd-gcp-qa-e2e-tests/1615576493528715264), because the bundle installation method tries to install a PodSecurityPolicy for central by default if the env variable `POD_SECURITY_POLICIES` is not set or set to `true`. PodSecurityPolicy was removed from Kubernetes 1.25 and upwards, which is why the test setup is failing.

This PR changes the deploy scripts to query the Kubernetes server version and set `POD_SECURITY_POLICIES` to false if it detects a version >= 1.25.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

Tested with commenting `/test osd-gcp-qa-e2e-tests`

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
