### PR TITLE
fix: correct nightly tag pattern in GH workflows, as release-ci should not trigger for nightly tags

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,7 +3,7 @@ on:
   workflow_call:
   push:
     tags:
-    - 'nightly-*'
+    - '*-nightly-*'
     branches:
     - master
   pull_request:

--- a/.github/workflows/release-ci.yaml
+++ b/.github/workflows/release-ci.yaml
@@ -4,7 +4,7 @@ on:
     branches:
     - 'release-*'
     tags-ignore:
-    - 'nightly-*'
+    - '*-nightly-*'
 
 jobs:
   run-parameters:


### PR DESCRIPTION
## Description

The pattern for ignoring nightly tags was wrong. 
Nightly tags are: `X.Y.x-nightly-yyyymmdd`, e.g. `3.73.x-nightly-20220120`.
The "correct" pattern therefore should be `*-nightly-*`, as it was in the build.yaml before https://github.com/stackrox/stackrox/pull/4434 (which mistakenly changed build.yaml).  

## Checklist
- ~[ ] Investigated and inspected CI test results~
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

Nothing to test.
