### PR TITLE
ROX-14101: Detect central installed on Openshift

### DIFF
--- a/central/telemetry/centralclient/instance_config.go
+++ b/central/telemetry/centralclient/instance_config.go
@@ -79,6 +79,7 @@ func getInstanceConfig() (*phonehome.Config, map[string]any, error) {
 			"Chart version":      version.GetChartVersion(),
 			"Orchestrator":       orchestrator,
 			"Kubernetes version": v.GitVersion,
+			"Managed":            env.ManagedCentral.BooleanSetting(),
 		}, nil
 }
 

--- a/central/telemetry/centralclient/instance_config.go
+++ b/central/telemetry/centralclient/instance_config.go
@@ -46,7 +46,7 @@ func getInstanceConfig() (*phonehome.Config, map[string]any, error) {
 	trackedPaths = strings.Split(apiWhiteList.Setting(), ",")
 
 	orchestrator := storage.ClusterType_KUBERNETES_CLUSTER.String()
-	if env.OpenshiftAPI.BooleanSetting() {
+	if env.Openshift.BooleanSetting() {
 		orchestrator = storage.ClusterType_OPENSHIFT_CLUSTER.String()
 	}
 

--- a/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml
+++ b/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml
@@ -109,7 +109,7 @@ spec:
           value: "true"
         {{- end }}
         {{- if ._rox.env.openshift }}
-        - name: ROX_OPENSHIFT_API
+        - name: ROX_OPENSHIFT
           value: "true"
         {{- end }}
         {{- if ._rox.env.managedServices }}

--- a/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml
+++ b/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml
@@ -108,6 +108,10 @@ spec:
         - name: ROX_ENABLE_OPENSHIFT_AUTH
           value: "true"
         {{- end }}
+        {{- if ._rox.env.openshift }}
+        - name: ROX_OPENSHIFT_API
+          value: "true"
+        {{- end }}
         {{- if ._rox.env.managedServices }}
         - name: ROX_MANAGED_CENTRAL
           value: "true"

--- a/operator/tests/central/basic/80-assert.yaml
+++ b/operator/tests/central/basic/80-assert.yaml
@@ -21,7 +21,7 @@ spec:
               value: "false"
             - name: ROX_ENABLE_OPENSHIFT_AUTH
               value: "true"
-            - name: ROX_OPENSHIFT_API
+            - name: ROX_OPENSHIFT
               value: "true"
             - name: ROX_POSTGRES_DATASTORE
               value: "true"

--- a/operator/tests/central/basic/80-assert.yaml
+++ b/operator/tests/central/basic/80-assert.yaml
@@ -21,6 +21,8 @@ spec:
               value: "false"
             - name: ROX_ENABLE_OPENSHIFT_AUTH
               value: "true"
+            - name: ROX_OPENSHIFT_API
+              value: "true"
             - name: ROX_POSTGRES_DATASTORE
               value: "true"
             - name: NO_PROXY

--- a/operator/tests/central/basic/81-assert.yaml
+++ b/operator/tests/central/basic/81-assert.yaml
@@ -17,6 +17,8 @@ spec:
               value: "false"
             - name: ROX_ENABLE_OPENSHIFT_AUTH
               value: "true"
+            - name: ROX_OPENSHIFT_API
+              value: "true"
             - name: ROX_POSTGRES_DATASTORE
               value: "true"
             - name: NO_PROXY

--- a/operator/tests/central/basic/81-assert.yaml
+++ b/operator/tests/central/basic/81-assert.yaml
@@ -17,7 +17,7 @@ spec:
               value: "false"
             - name: ROX_ENABLE_OPENSHIFT_AUTH
               value: "true"
-            - name: ROX_OPENSHIFT_API
+            - name: ROX_OPENSHIFT
               value: "true"
             - name: ROX_POSTGRES_DATASTORE
               value: "true"

--- a/pkg/env/openshift.go
+++ b/pkg/env/openshift.go
@@ -10,4 +10,7 @@ var (
 	// switching this on is not enough because extra steps are required to
 	// configure Central as an OAuth client.
 	EnableOpenShiftAuth = RegisterBooleanSetting("ROX_ENABLE_OPENSHIFT_AUTH", false)
+
+	// Openshift specifies whether Openshift is the orchestrator.
+	Openshift = RegisterBooleanSetting("ROX_OPENSHIFT", false)
 )

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/central.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/central.test.yaml
@@ -73,7 +73,7 @@ tests:
     .rolebindings["central-use-scc"] | assertThat(. == null)
     .deployments["central"].spec.template.spec.affinity.nodeAffinity | .preferredDuringSchedulingIgnoredDuringExecution | assertThat(length == 5)
     verifyNodeAffinities(.deployments["central"])
-    envVars(.deployments.central; "central") | assertThat(has("ROX_OPENSHIFT_API") == true)
+    envVars(.deployments.central; "central") | assertThat(has("ROX_OPENSHIFT") == true)
 
 - name: "central with OpenShift 4 and disabled SCCs"
   server:
@@ -92,14 +92,14 @@ tests:
     .securitycontextconstraints["stackrox-central"] | assertThat(. == null)
     .deployments["central"].spec.template.spec.affinity.nodeAffinity | .preferredDuringSchedulingIgnoredDuringExecution | assertThat(length == 5)
     verifyNodeAffinities(.deployments["central"])
-    envVars(.deployments.central; "central") | assertThat(has("ROX_OPENSHIFT_API") == true)
+    envVars(.deployments.central; "central") | assertThat(has("ROX_OPENSHIFT") == true)
 
 - name: "central with Kubernetes 1.20"
   server:
     visibleSchemas:
     - kubernetes-1.20.2
   expect: |
-    envVars(.deployments.central; "central") | assertThat(has("ROX_OPENSHIFT_API") == false)
+    envVars(.deployments.central; "central") | assertThat(has("ROX_OPENSHIFT") == false)
 
 - name: Tenant ID should be set when env.managedServices is true
   set:

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/central.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/central.test.yaml
@@ -73,6 +73,7 @@ tests:
     .rolebindings["central-use-scc"] | assertThat(. == null)
     .deployments["central"].spec.template.spec.affinity.nodeAffinity | .preferredDuringSchedulingIgnoredDuringExecution | assertThat(length == 5)
     verifyNodeAffinities(.deployments["central"])
+    envVars(.deployments.central; "central") | assertThat(has("ROX_OPENSHIFT_API") == true)
 
 - name: "central with OpenShift 4 and disabled SCCs"
   server:
@@ -91,6 +92,14 @@ tests:
     .securitycontextconstraints["stackrox-central"] | assertThat(. == null)
     .deployments["central"].spec.template.spec.affinity.nodeAffinity | .preferredDuringSchedulingIgnoredDuringExecution | assertThat(length == 5)
     verifyNodeAffinities(.deployments["central"])
+    envVars(.deployments.central; "central") | assertThat(has("ROX_OPENSHIFT_API") == true)
+
+- name: "central with Kubernetes 1.20"
+  server:
+    visibleSchemas:
+    - kubernetes-1.20.2
+  expect: |
+    envVars(.deployments.central; "central") | assertThat(has("ROX_OPENSHIFT_API") == false)
 
 - name: Tenant ID should be set when env.managedServices is true
   set:


### PR DESCRIPTION
## Description

Set the `ROX_OPENSHIFT_API` environment variable to the central deployment for Openshift installations, so that the telemetry code could identify Openshift as the platform on which the central is running:

https://github.com/stackrox/stackrox/blob/8f9fe014022f45953861e70ef55e4bcbc6c741dd/pkg/env/openshift.go#L5-L6

https://github.com/stackrox/stackrox/blob/8f9fe014022f45953861e70ef55e4bcbc6c741dd/central/telemetry/centralclient/instance_config.go#L49-L51

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

```
$ kubectl describe deployment central
...
    Environment:                                                                                                  
      ROX_NAMESPACE:            (v1:metadata.namespace)
      ROX_OFFLINE_MODE:        false                                                                              
      ROX_OPENSHIFT_API:       true                                                                               
      ROX_POSTGRES_DATASTORE:  true                                                                               
      ROX_DEVELOPMENT_BUILD:   true                                                                               
      ROX_HOTRELOAD:           false
      ROX_MANAGED_CENTRAL:     false
      ROX_NETWORK_ACCESS_LOG:  false
      ROX_POSTGRES_DATASTORE:  true
```