### PR TITLE
Add key prop in ApplicationLauncherGroup of HelpMenu

### DIFF
--- a/ui/apps/platform/src/Containers/MainPage/Header/HelpMenu.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Header/HelpMenu.tsx
@@ -19,7 +19,7 @@ function HelpMenu(): ReactElement {
         setIsHelpMenuOpen(!isHelpMenuOpen);
     }
 
-    // React requires key (even empty string is enough) to render array of elements.
+    // React requires key to render an item in an array of elements.
     const appLauncherItems = [
         <ApplicationLauncherGroup key="">
             <ApplicationLauncherItem

--- a/ui/apps/platform/src/Containers/MainPage/Header/HelpMenu.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Header/HelpMenu.tsx
@@ -19,8 +19,9 @@ function HelpMenu(): ReactElement {
         setIsHelpMenuOpen(!isHelpMenuOpen);
     }
 
+    // React requires key (even empty string is enough) to render array of elements.
     const appLauncherItems = [
-        <ApplicationLauncherGroup>
+        <ApplicationLauncherGroup key="">
             <ApplicationLauncherItem
                 component={
                     <Link className="pf-c-app-launcher__menu-item" to={apidocsPath}>


### PR DESCRIPTION
## Description

Dave, thank you for finding the error in the browser console:

![key](https://user-images.githubusercontent.com/11862657/213736083-4265257c-8ec9-4e42-a70e-298c9d62e9a6.png)

My bad to omit `key` prop when I merged two groups in #4418

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

Manual testing with browser console.