### PR TITLE
ROX-14066 Fix sorting of client side attached collection cache

### DIFF
--- a/ui/apps/platform/src/Containers/Collections/hooks/useEmbeddedCollections.ts
+++ b/ui/apps/platform/src/Containers/Collections/hooks/useEmbeddedCollections.ts
@@ -196,6 +196,10 @@ function compareNameLowercase(search: string): (item: { name: string }) => boole
     return ({ name }) => name.toLowerCase().startsWith(search.toLowerCase());
 }
 
+function byNameCaseInsensitive(collection: Collection) {
+    return collection.name.toLowerCase();
+}
+
 const initialState = {
     page: 1,
     hasMore: true,
@@ -298,8 +302,12 @@ export default function useEmbeddedCollections(
     };
 
     return {
-        attached: sortBy(Object.values(attached), 'name').filter(compareNameLowercase(search)),
-        detached: sortBy(Object.values(detached), 'name').filter(compareNameLowercase(search)),
+        attached: sortBy(Object.values(attached), byNameCaseInsensitive).filter(
+            compareNameLowercase(search)
+        ),
+        detached: sortBy(Object.values(detached), byNameCaseInsensitive).filter(
+            compareNameLowercase(search)
+        ),
         attach: (id: string) => dispatch({ type: 'attachCollection', id }),
         detach: (id: string) => dispatch({ type: 'detachCollection', id }),
         hasMore,

--- a/ui/apps/platform/src/Containers/VulnMgmt/Reports/Form/CollectionSelection.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Reports/Form/CollectionSelection.tsx
@@ -72,7 +72,9 @@ function CollectionSelection({
         // This is inefficient due to the multiple loops and the fact that we are already tracking
         // uniqueness for the _server side_ values, but need to do it twice to handle possible client
         // side values. However, 'N' should be small here and we are memoizing the result.
-        const sorted = sortBy(data.flat().concat(createdCollections), ['name']);
+        const sorted = sortBy(data.flat().concat(createdCollections), ({ name }) =>
+            name.toLowerCase()
+        );
         return uniqBy(sorted, 'id');
     }, [data, createdCollections]);
 


### PR DESCRIPTION
## Description

When moving collections between the "attached" and "available" lists, sort the resulting lists by name, case insensitive, to match the expected order from the BE API.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Manual testing:
View the available collections list and verify that the collections are sorted by name, case insensitive.
![image](https://user-images.githubusercontent.com/1292638/213758266-d6fcde1e-f426-45a7-940f-4b9be86bd2d9.png)

Verify that clicking "view more" loads new collections that are alphabetically after the ones that currently appear in the list:
![image](https://user-images.githubusercontent.com/1292638/213758563-df27b8be-b558-4835-8c26-3106741bde9d.png)
![image](https://user-images.githubusercontent.com/1292638/213758600-d4107b6e-8d2e-44a1-9fba-badc4242efcf.png)

Add multiple collections to the "attached" list. Verify that the sort order remains consistent regardless of the order that the items are added.
![image](https://user-images.githubusercontent.com/1292638/213758901-ff028ebc-d5e1-4937-b30f-802fa3cf5c8b.png)

