### PR TITLE
Change acs documentation links to include major minor version

### DIFF
--- a/ui/apps/platform/src/Containers/Clusters/Components/CredentialExpiration.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/CredentialExpiration.tsx
@@ -5,6 +5,8 @@ import { differenceInDays } from 'date-fns';
 import { Tooltip, TooltipOverlay } from '@stackrox/ui-components';
 import { getTime, getDate, getDayOfWeek, getDistanceStrictAsPhrase } from 'utils/dateUtils';
 
+import useMetadata from 'hooks/useMetadata';
+import { getVersionedDocs } from 'utils/versioning';
 import HealthStatus from './HealthStatus';
 import HealthStatusNotApplicable from './HealthStatusNotApplicable';
 import { getCredentialExpirationStatus, healthStatusStyles } from '../cluster.helpers';
@@ -21,6 +23,8 @@ function CredentialExpiration({
     certExpiryStatus,
     isList = false,
 }: CredentialExpirationProps): ReactElement {
+    const { version } = useMetadata();
+
     if (!certExpiryStatus?.sensorCertExpiry) {
         return <HealthStatusNotApplicable testId={testId} />;
     }
@@ -79,20 +83,25 @@ function CredentialExpiration({
             ) : (
                 <div>
                     {expirationElement}
-                    <div className="flex flex-row items-end leading-tight text-tertiary-700">
-                        <a
-                            href="/docs/product/rhacs/latest/configuration/reissue-internal-certificates.html#reissue-internal-certificates-secured-clusters"
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="underline"
-                            data-testid="reissueCertificatesLink"
-                        >
-                            Re-issue internal certificates
-                        </a>
-                        <span className="flex-shrink-0 ml-2">
-                            <ExternalLink className="h-4 w-4" />
-                        </span>
-                    </div>
+                    {version && (
+                        <div className="flex flex-row items-end leading-tight text-tertiary-700">
+                            <a
+                                href={getVersionedDocs(
+                                    version,
+                                    'configuration/reissue-internal-certificates.html#reissue-internal-certificates-secured-clusters'
+                                )}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="underline"
+                                data-testid="reissueCertificatesLink"
+                            >
+                                Re-issue internal certificates
+                            </a>
+                            <span className="flex-shrink-0 ml-2">
+                                <ExternalLink className="h-4 w-4" />
+                            </span>
+                        </div>
+                    )}
                 </div>
             )}
         </HealthStatus>

--- a/ui/apps/platform/src/Containers/MainPage/Header/HelpMenu.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Header/HelpMenu.tsx
@@ -9,7 +9,8 @@ import {
 import { QuestionCircleIcon } from '@patternfly/react-icons';
 
 import useMetadata from 'hooks/useMetadata';
-import { apidocsPath, productDocsPath } from 'routePaths';
+import { apidocsPath } from 'routePaths';
+import { getVersionedDocs } from 'utils/versioning';
 
 function HelpMenu(): ReactElement {
     const { releaseBuild, version } = useMetadata();
@@ -32,7 +33,7 @@ function HelpMenu(): ReactElement {
             {version && (
                 <>
                     <ApplicationLauncherItem
-                        href={productDocsPath}
+                        href={getVersionedDocs(version)}
                         isExternal
                         target="_blank"
                         rel="noopener noreferrer"

--- a/ui/apps/platform/src/Containers/SystemHealth/Components/DiagnosticBundleDialogBox.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/Components/DiagnosticBundleDialogBox.tsx
@@ -11,6 +11,8 @@ import { fetchClustersAsArray } from 'services/ClustersService';
 import downloadDiagnostics from 'services/DebugService';
 
 import { Alert, AlertVariant } from '@patternfly/react-core';
+import useMetadata from 'hooks/useMetadata';
+import { getVersionedDocs } from 'utils/versioning';
 import FilterByStartingTimeValidationMessage from './FilterByStartingTimeValidationMessage';
 
 // Recommended format:
@@ -71,6 +73,8 @@ const DiagnosticBundleDialogBox = (): ReactElement => {
     const [currentTimeObject, setCurrentTimeObject] = useState<Date | null>(null); // for pure message
 
     const [alertDownload, setAlertDownload] = useState<ReactElement | null>(null);
+
+    const { version } = useMetadata();
 
     useEffect(() => {
         fetchClustersAsArray()
@@ -219,19 +223,24 @@ const DiagnosticBundleDialogBox = (): ReactElement => {
                         dataTestId="download-diagnostic-bundle-button"
                         text="Download Diagnostic Bundle"
                     />
-                    <div className="inline-flex flex-row text-tertiary-700">
-                        <a
-                            href="/docs/product/rhacs/latest/configuration/generate-diagnostic-bundle.html"
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="underline"
-                        >
-                            Generate a diagnostic bundle
-                        </a>
-                        <span className="flex-shrink-0 ml-2">
-                            <ExternalLink className="h-4 w-4" />
-                        </span>
-                    </div>
+                    {version && (
+                        <div className="inline-flex flex-row text-tertiary-700">
+                            <a
+                                href={getVersionedDocs(
+                                    version,
+                                    'configuration/generate-diagnostic-bundle.html'
+                                )}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="underline"
+                            >
+                                Generate a diagnostic bundle
+                            </a>
+                            <span className="flex-shrink-0 ml-2">
+                                <ExternalLink className="h-4 w-4" />
+                            </span>
+                        </div>
+                    )}
                 </div>
             </form>
         </div>

--- a/ui/apps/platform/src/Containers/SystemHealth/PatternFly/Components/GenerateDiagnosticBundle.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/PatternFly/Components/GenerateDiagnosticBundle.tsx
@@ -10,6 +10,8 @@ import { useFormik } from 'formik';
 import { parse } from 'date-fns';
 
 import downloadDiagnostics, { DiagnosticBundleRequest } from 'services/DebugService';
+import useMetadata from 'hooks/useMetadata';
+import { getVersionedDocs } from 'utils/versioning';
 import DiagnosticBundleForm from './DiagnosticBundleForm';
 import { getQueryString, startingTimeRegExp } from '../utils/diagnosticBundleUtils';
 
@@ -23,6 +25,7 @@ function GenerateDiagnosticBundle(): ReactElement {
     const [startingTimeObject, setStartingTimeObject] = useState<Date | null>(null); // parsed from text
     const [isStartingTimeValid, setIsStartingTimeValid] = useState<boolean>(true);
     const [currentTimeObject, setCurrentTimeObject] = useState<Date | null>(null); // for pure message
+    const { version } = useMetadata();
 
     function onChangeStartingTime(event: React.FormEvent<HTMLInputElement>): void {
         const trimmedText = event.currentTarget.value.trim();
@@ -80,22 +83,27 @@ function GenerateDiagnosticBundle(): ReactElement {
             >
                 Download diagnostic bundle
             </Button>
-            <Button
-                variant="link"
-                isInline
-                component="a"
-                href="/docs/product/rhacs/latest/configuration/generate-diagnostic-bundle.html"
-                target="_blank"
-                rel="noopener noreferrer"
-            >
-                <Flex
-                    alignItems={{ default: 'alignItemsCenter' }}
-                    spaceItems={{ default: 'spaceItemsSm' }}
+            {version && (
+                <Button
+                    variant="link"
+                    isInline
+                    component="a"
+                    href={getVersionedDocs(
+                        version,
+                        'configuration/generate-diagnostic-bundle.html'
+                    )}
+                    target="_blank"
+                    rel="noopener noreferrer"
                 >
-                    <span>Generate a diagnostic bundle</span>
-                    <ExternalLinkAltIcon color="var(--pf-global--link--Color)" />
-                </Flex>
-            </Button>
+                    <Flex
+                        alignItems={{ default: 'alignItemsCenter' }}
+                        spaceItems={{ default: 'spaceItemsSm' }}
+                    >
+                        <span>Generate a diagnostic bundle</span>
+                        <ExternalLinkAltIcon color="var(--pf-global--link--Color)" />
+                    </Flex>
+                </Button>
+            )}
         </Flex>
     );
 

--- a/ui/apps/platform/src/routePaths.js
+++ b/ui/apps/platform/src/routePaths.js
@@ -48,7 +48,6 @@ export const systemHealthPath = `${mainPath}/system-health`;
 export const systemHealthPathPF = `${mainPath}/system-health-pf`;
 export const collectionsBasePath = `${mainPath}/collections`;
 export const collectionsPath = `${mainPath}/collections/:collectionId?`;
-export const productDocsPath = '/docs/product';
 
 // Configuration Management
 
@@ -156,7 +155,6 @@ export const basePathToLabelMap = {
     [configManagementPath]: 'Configuration Management',
     [riskBasePath]: 'Risk',
     [apidocsPath]: 'API Reference',
-    [productDocsPath]: 'Help Center',
     [clustersBasePath]: 'Clusters',
     [policyManagementBasePath]: 'Policy Management',
     [policiesBasePath]: 'Policy Management',

--- a/ui/apps/platform/src/utils/versioning.test.ts
+++ b/ui/apps/platform/src/utils/versioning.test.ts
@@ -1,0 +1,43 @@
+import { getVersionMajorMinor, getVersionedDocs } from './versioning';
+
+describe('versioning utilities', () => {
+    describe('getVersionMajorMinor', () => {
+        it('only returns the major and minor version as a string when the given a valid version', () => {
+            expect(getVersionMajorMinor('3.73.x')).toBe('3.73');
+            expect(getVersionMajorMinor('3.73.123')).toBe('3.73');
+            expect(getVersionMajorMinor('3.73.123.1')).toBe('3.73');
+            expect(getVersionMajorMinor('3.73-beta.123')).toBe('3.73');
+            expect(getVersionMajorMinor('3.73.123-beta')).toBe('3.73');
+            expect(getVersionMajorMinor('3.73')).toBe('3.73');
+            expect(getVersionMajorMinor('4.0.0')).toBe('4.0');
+        });
+
+        it('returns an empty string when given an invalid version', () => {
+            expect(getVersionMajorMinor('3')).toBe('');
+            expect(getVersionMajorMinor('a.b')).toBe('');
+            expect(getVersionMajorMinor('a.b.c-d')).toBe('');
+            expect(getVersionMajorMinor('')).toBe('');
+            expect(getVersionMajorMinor('3a.4b')).toBe('');
+        });
+    });
+
+    describe('getVersionedDocs', () => {
+        it('returns the correct url for acs documentation', () => {
+            expect(getVersionedDocs('3.73', 'sub-path')).toBe(
+                'https://docs.openshift.com/acs/3.73/sub-path'
+            );
+        });
+
+        it('returns only the major and minor version in the url', () => {
+            expect(getVersionedDocs('3.73.123')).toMatch(/.*\/3\.73\//);
+        });
+
+        it('the url ends with the given subPath', () => {
+            expect(getVersionedDocs('3.73.123', 'sub-path#anchor')).toMatch(/.*\/sub-path#anchor/);
+        });
+
+        it('the url ends with the default subpath welcome/index.html when the subpath is not given', () => {
+            expect(getVersionedDocs('3.73.123')).toMatch(/.*\/welcome\/index\.html/);
+        });
+    });
+});

--- a/ui/apps/platform/src/utils/versioning.ts
+++ b/ui/apps/platform/src/utils/versioning.ts
@@ -1,0 +1,17 @@
+function getVersionMajorMinor(version: string): string {
+    if (version) {
+        const results = /^(\d+)\.(\d+)/.exec(version);
+        if (Array.isArray(results) && results.length === 3) {
+            const [, versionMajor, versionMinor] = results;
+            return `${versionMajor}.${versionMinor}`;
+        }
+    }
+    return '';
+}
+
+// we may have to consider the release build in the future, where the version may be ahead of documentation that has not yet been created
+function getVersionedDocs(completeVersion: string, subPath = 'welcome/index.html'): string {
+    return `https://docs.openshift.com/acs/${getVersionMajorMinor(completeVersion)}/${subPath}`;
+}
+
+export { getVersionMajorMinor, getVersionedDocs };


### PR DESCRIPTION
## Description

ACS documentation will now include the major/minor versioning in the url.

One thing to consider is we don't have the current version until metadata is fetched so to counter that we won't be displaying the documentation links until we have a version

## Testing Performed

Unit tests and manual testing

Using the version 3.73.x-277-gdd1804181d the following links take you to acs documentation with 3.73 in the url:
* `Help Center` under the information icon on the main header bar
* `Re-issue internal certificates` in a clusters modal when credentials have expired
* `Generate a diagnostic bundle` under the `Generate Diagnostic bundle` in System Health
