### PR TITLE
Reduce imports from apiEndpoints in integration tests (part 1)

### DIFF
--- a/ui/apps/platform/cypress/constants/GeneralPage.js
+++ b/ui/apps/platform/cypress/constants/GeneralPage.js
@@ -6,8 +6,6 @@ const selectors = {
     },
     leftNavLinks: 'nav.left-navigation li a',
     sidePanel: '.navigation-panel',
-    rhacsLogoImage: 'img[alt="Red Hat Advanced Cluster Security Logo"]',
-    stackroxLogoImage: 'img[alt="StackRox Logo"]',
 };
 
 export default selectors;

--- a/ui/apps/platform/cypress/constants/SystemHealth.js
+++ b/ui/apps/platform/cypress/constants/SystemHealth.js
@@ -4,11 +4,9 @@ export const systemHealthUrl = '/main/system-health';
 
 export const selectors = {
     bundle: {
-        generateDiagnosticBundleButton: 'button:contains("Generate Diagnostic Bundle")',
         filterByClusters: '[data-testid="filter-by-clusters"]',
         filterByStartingTime: '#filter-by-starting-time',
         startingTimeMessage: '[data-testid="starting-time-message"]',
-        downloadDiagnosticBundleButton: 'button:contains("Download Diagnostic Bundle")',
     },
     clusters: {
         categoryCount: '[data-testid="count"]',

--- a/ui/apps/platform/cypress/constants/apiEndpoints.js
+++ b/ui/apps/platform/cypress/constants/apiEndpoints.js
@@ -25,10 +25,6 @@ export const search = {
     },
 };
 
-export const clusters = {
-    list: 'v1/clusters',
-};
-
 export const risks = {
     // The * at the end exists because sometimes we add ?query= at the end.
     riskyDeployments: '/v1/deploymentswithprocessinfo*',
@@ -44,16 +40,6 @@ export const risks = {
         getPodEventTimeline: 'getPodEventTimeline',
     },
 };
-
-export const auth = {
-    availableAuthProviders: '/v1/availableAuthProviders',
-    loginAuthProviders: '/v1/login/authproviders',
-    authProviders: '/v1/authProviders',
-    authStatus: '/v1/auth/status',
-    tokenRefresh: '/sso/session/tokenrefresh',
-};
-
-export const metadata = 'v1/metadata';
 
 export const network = {
     networkBaseline: '/v1/networkbaseline/*', // deployment id
@@ -76,30 +62,6 @@ export const policies = {
     import: '/v1/policies/import',
     reassess: '/v1/policies/reassess',
 };
-
-export const roles = {
-    list: '/v1/roles',
-    mypermissions: 'v1/mypermissions',
-};
-
-export const permissionSets = {
-    list: '/v1/permissionsets',
-};
-
-export const accessScopes = {
-    list: '/v1/simpleaccessscopes',
-};
-
-export const groups = {
-    batch: '/v1/groupsbatch',
-    list: '/v1/groups',
-};
-
-export const userAttributes = {
-    list: '/v1/userattributes/*',
-};
-
-export const featureFlags = '/v1/featureflags';
 
 export const integrationHealth = {
     imageIntegrations: '/v1/integrationhealth/imageintegrations',
@@ -133,12 +95,4 @@ export const riskAcceptance = {
     getImageVulnerabilities: graphql('getImageVulnerabilities'),
     deferVulnerability: graphql('deferVulnerability'),
     markVulnerabilityFalsePositive: graphql('markVulnerabilityFalsePositive'),
-};
-
-export const extensions = {
-    diagnostics: '/api/extensions/diagnostics',
-};
-
-export const permissions = {
-    mypermissions: '/v1/mypermissions',
 };

--- a/ui/apps/platform/cypress/helpers/networkGraph.js
+++ b/ui/apps/platform/cypress/helpers/networkGraph.js
@@ -238,7 +238,7 @@ const routeMatcherMapToVisitNetworkGraph = {
     },
     [clustersAlias]: {
         method: 'GET',
-        url: api.clusters.list,
+        url: '/v1/clusters',
     },
     [networkPoliciesGraphEpochAlias]: {
         method: 'GET',

--- a/ui/apps/platform/cypress/helpers/systemHealth.js
+++ b/ui/apps/platform/cypress/helpers/systemHealth.js
@@ -42,7 +42,7 @@ const routeMatcherMap = {
     },
     clusters: {
         method: 'GET',
-        url: api.clusters.list,
+        url: '/v1/clusters',
     },
     [integrationHealthVulnDefinitionsAlias]: {
         method: 'GET',

--- a/ui/apps/platform/cypress/helpers/systemHealthPatternFly.js
+++ b/ui/apps/platform/cypress/helpers/systemHealthPatternFly.js
@@ -14,7 +14,7 @@ export function setClock(currentDatetime) {
 // visit
 
 export function visitSystemHealthFromLeftNav() {
-    cy.intercept('GET', api.clusters.list).as('getClusters');
+    cy.intercept('GET', '/v1/clusters').as('getClusters');
     cy.intercept('GET', api.integrations.externalBackups).as('getBackupIntegrations');
     cy.intercept('GET', api.integrations.imageIntegrations).as('getImageIntegrations');
     cy.intercept('GET', api.integrations.notifiers).as('getNotifierIntegrations');
@@ -39,7 +39,7 @@ export function visitSystemHealthFromLeftNav() {
 }
 
 export function visitSystemHealth() {
-    // cy.intercept('GET', api.clusters.list).as('getClusters');
+    // cy.intercept('GET', '/v1/clusters').as('getClusters');
     cy.intercept('GET', api.integrations.externalBackups).as('getBackupIntegrations');
     cy.intercept('GET', api.integrations.imageIntegrations).as('getImageIntegrations');
     cy.intercept('GET', api.integrations.notifiers).as('getNotifierIntegrations');
@@ -66,7 +66,7 @@ export function visitSystemHealth() {
 // visit clusters
 
 export function visitSystemHealthWithClustersFixture(fixturePath) {
-    cy.intercept('GET', api.clusters.list, {
+    cy.intercept('GET', '/v1/clusters', {
         fixture: fixturePath,
     }).as('getClusters');
     cy.intercept('GET', api.integrations.externalBackups).as('getBackupIntegrations');
@@ -94,7 +94,7 @@ export function visitSystemHealthWithClustersFixture(fixturePath) {
 
 export function visitSystemHealthWithClustersFixtureFilteredByNames(fixturePath, clusterNames) {
     cy.fixture(fixturePath).then(({ clusters }) => {
-        cy.intercept('GET', api.clusters.list, {
+        cy.intercept('GET', '/v1/clusters', {
             body: { clusters: clusters.filter(({ name }) => clusterNames.includes(name)) },
         }).as('getClusters');
         cy.intercept('GET', api.integrations.externalBackups).as('getBackupIntegrations');
@@ -128,7 +128,7 @@ export function visitSystemHealthWithClustersFixtureFilteredByNames(fixturePath,
 // visit integrations
 
 export function visitSystemHealthWithBackupIntegrations(externalBackups, integrationHealth) {
-    cy.intercept('GET', api.clusters.list).as('getClusters');
+    cy.intercept('GET', '/v1/clusters').as('getClusters');
     cy.intercept('GET', api.integrations.externalBackups, {
         body: { externalBackups },
     }).as('getBackupIntegrations');
@@ -157,7 +157,7 @@ export function visitSystemHealthWithBackupIntegrations(externalBackups, integra
 }
 
 export function visitSystemHealthWithImageIntegrations(integrations, integrationHealth) {
-    cy.intercept('GET', api.clusters.list).as('getClusters');
+    cy.intercept('GET', '/v1/clusters').as('getClusters');
     cy.intercept('GET', api.integrations.externalBackups).as('getBackupIntegrations');
     cy.intercept('GET', api.integrations.imageIntegrations, {
         body: { integrations },
@@ -186,7 +186,7 @@ export function visitSystemHealthWithImageIntegrations(integrations, integration
 }
 
 export function visitSystemHealthWithNotifierIntegrations(notifiers, integrationHealth) {
-    cy.intercept('GET', api.clusters.list).as('getClusters');
+    cy.intercept('GET', '/v1/clusters').as('getClusters');
     cy.intercept('GET', api.integrations.externalBackups).as('getBackupIntegrations');
     cy.intercept('GET', api.integrations.imageIntegrations).as('getImageIntegrations');
     cy.intercept('GET', api.integrations.notifiers, {
@@ -217,7 +217,7 @@ export function visitSystemHealthWithNotifierIntegrations(notifiers, integration
 // visit vulnerability definitions
 
 export function visitSystemHealthWithVulnerabilityDefinitionsTimestamp(lastUpdatedTimestamp) {
-    cy.intercept('GET', api.clusters.list).as('getClusters');
+    cy.intercept('GET', '/v1/clusters').as('getClusters');
     cy.intercept('GET', api.integrations.externalBackups).as('getBackupIntegrations');
     cy.intercept('GET', api.integrations.imageIntegrations).as('getImageIntegrations');
     cy.intercept('GET', api.integrations.notifiers).as('getNotifierIntegrations');

--- a/ui/apps/platform/cypress/helpers/visit.js
+++ b/ui/apps/platform/cypress/helpers/visit.js
@@ -1,5 +1,3 @@
-import * as api from '../constants/apiEndpoints';
-
 import { interceptRequests, waitForResponses } from './request';
 
 // Single source of truth for keys in staticResponseMapForAuthenticatedRoutes object.
@@ -14,19 +12,19 @@ export const authStatusAlias = 'auth/status';
 const routeMatcherMapForAuthenticatedRoutes = {
     [availableAuthProvidersAlias]: {
         method: 'GET',
-        url: api.auth.availableAuthProviders,
+        url: '/v1/availableAuthProviders',
     }, // reducers/auth and sagas/authSagas
     [featureFlagsAlias]: {
         method: 'GET',
-        url: api.featureFlags,
+        url: '/v1/featureflags',
     }, // reducers/featureFlags and sagas/featureFlagSagas
     [loginAuthProvidersAlias]: {
         method: 'GET',
-        url: api.auth.loginAuthProviders,
+        url: '/v1/login/authproviders',
     }, // reducers/auth and sagas/authSagas
     [myPermissionsAlias]: {
         method: 'GET',
-        url: api.roles.mypermissions,
+        url: 'v1/mypermissions',
     }, // hooks/usePermissions and reducers/roles and sagas/authSagas
     [configPublicAlias]: {
         method: 'GET',
@@ -34,7 +32,7 @@ const routeMatcherMapForAuthenticatedRoutes = {
     }, // reducers/systemConfig and sagas/systemConfig
     [authStatusAlias]: {
         method: 'GET',
-        url: api.auth.authStatus,
+        url: '/v1/auth/status',
     }, // sagas/authSagas
     /*
      * Intentionally omit credentialexpiry requests for central and scanner,

--- a/ui/apps/platform/cypress/integration/access.test.js
+++ b/ui/apps/platform/cypress/integration/access.test.js
@@ -1,5 +1,4 @@
 import { selectors, url } from '../constants/AccessPage';
-import * as api from '../constants/apiEndpoints';
 
 import withAuth from '../helpers/basicAuth';
 
@@ -9,7 +8,7 @@ describe.skip('Access Control Page', () => {
     describe('Auth Provider Rules', () => {
         function navigateToThePanel(authProviders = 'fixture:auth/authProviders-id1-id2-id3.json') {
             cy.server();
-            cy.route('GET', api.auth.authProviders, authProviders).as('authProviders');
+            cy.route('GET', '/v1/authProviders', authProviders).as('authProviders');
 
             cy.visit(url);
             cy.get(selectors.tabs.authProviders).click();
@@ -100,7 +99,7 @@ describe.skip('Access Control Page', () => {
             cy.get(leftSidePanel.selectedRowDeleteButton).click({ force: true }); // forcing as its a hover button
 
             // mock now with the second one deleted
-            cy.route('GET', api.auth.authProviders, 'fixture:auth/authProviders-id1-id3.json').as(
+            cy.route('GET', '/v1/authProviders', 'fixture:auth/authProviders-id1-id3.json').as(
                 'authProviders'
             );
 
@@ -122,7 +121,7 @@ describe.skip('Access Control Page', () => {
             cy.get(leftSidePanel.secondRowDeleteButton).click({ force: true }); // forcing as its a hover button
 
             // mock now with the second one deleted
-            cy.route('GET', api.auth.authProviders, 'fixture:auth/authProviders-id1-id3.json').as(
+            cy.route('GET', '/v1/authProviders', 'fixture:auth/authProviders-id1-id3.json').as(
                 'authProviders'
             );
 
@@ -141,7 +140,7 @@ describe.skip('Access Control Page', () => {
             cy.get(leftSidePanel.selectedRowDeleteButton).click({ force: true }); // forcing as its a hover button
 
             // mock now with empty list of providers like nothing is left
-            cy.route('GET', api.auth.authProviders, { authProviders: [] }).as('authProviders');
+            cy.route('GET', '/v1/authProviders', { authProviders: [] }).as('authProviders');
             cy.get(selectors.modal.deleteButton).click();
 
             cy.wait('@authProviders');
@@ -249,9 +248,8 @@ describe.skip('Access Control Page', () => {
             cy.server();
 
             cy.fixture('auth/mypermissionsMinimalAccess.json').as('minimalPermissions');
-            cy.log('api.roles.mypermissions', api.roles.mypermissions);
 
-            cy.route('GET', api.roles.mypermissions, '@minimalPermissions').as('getMyPermissions');
+            cy.route('GET', 'v1/mypermissions', '@minimalPermissions').as('getMyPermissions');
 
             cy.visit(url);
             cy.wait('@getMyPermissions');

--- a/ui/apps/platform/cypress/integration/auth.test.js
+++ b/ui/apps/platform/cypress/integration/auth.test.js
@@ -1,8 +1,8 @@
 import addSeconds from 'date-fns/add_seconds';
 
-import { url as loginUrl, selectors } from '../constants/LoginPage';
+import { selectors } from '../constants/LoginPage';
 
-import * as api from '../constants/apiEndpoints';
+const loginUrl = '/login';
 
 const pagePath = '/main/systemconfig';
 
@@ -11,10 +11,10 @@ const UNAUTHENTICATED = false;
 
 describe.skip('Authentication', () => {
     const setupAuth = (landingUrl, authStatusValid, authStatusResponse = {}) => {
-        cy.intercept('GET', api.auth.loginAuthProviders, { fixture: 'auth/authProviders.json' }).as(
+        cy.intercept('GET', '/v1/login/authproviders', { fixture: 'auth/authProviders.json' }).as(
             'authProviders'
         );
-        cy.intercept('GET', api.auth.authStatus, {
+        cy.intercept('GET', '/v1/auth/status', {
             statusCode: authStatusValid ? 200 : 401,
             body: authStatusResponse,
         }).as('authStatus');
@@ -69,7 +69,7 @@ describe.skip('Authentication', () => {
     // TODO: Fix it, see ROX-4983 for more explanation
     it.skip('should request token refresh 30 sec in advance', () => {
         stubAPIs();
-        cy.intercept('POST', api.auth.tokenRefresh, { body: {} }).as('tokenRefresh');
+        cy.intercept('POST', '/sso/session/tokenrefresh', { body: {} }).as('tokenRefresh');
         localStorage.setItem('access_token', 'my-token'); // authenticated user
 
         const expiryDate = addSeconds(Date.now(), 33); // +3 sec should be enough

--- a/ui/apps/platform/cypress/integration/productBranding.test.js
+++ b/ui/apps/platform/cypress/integration/productBranding.test.js
@@ -1,8 +1,8 @@
 import withAuth from '../helpers/basicAuth';
-import selectors from '../constants/GeneralPage';
-import { url as loginUrl } from '../constants/LoginPage';
-import * as api from '../constants/apiEndpoints';
 import { visitMainDashboard } from '../helpers/main';
+
+const rhacsLogoImage = 'img[alt="Red Hat Advanced Cluster Security Logo"]';
+const stackroxLogoImage = 'img[alt="StackRox Logo"]';
 
 describe('Logo and title product branding checks', () => {
     withAuth();
@@ -11,18 +11,18 @@ describe('Logo and title product branding checks', () => {
 
     it('Should render the login page with matching logo and page title', () => {
         // Ensure that the page title matches the logo branding
-        cy.intercept('GET', api.metadata).as('metadata');
-        cy.visit(loginUrl);
+        cy.intercept('GET', 'v1/metadata').as('metadata');
+        cy.visit('/login');
         cy.wait('@metadata');
 
         cy.title().then((title) => {
             if (title.includes(redHatTitleText)) {
-                cy.get(selectors.rhacsLogoImage);
-                cy.get(selectors.stackroxLogoImage).should('not.exist');
+                cy.get(rhacsLogoImage);
+                cy.get(stackroxLogoImage).should('not.exist');
             } else {
                 expect(title).to.have.string('StackRox');
-                cy.get(selectors.rhacsLogoImage).should('not.exist');
-                cy.get(selectors.stackroxLogoImage);
+                cy.get(rhacsLogoImage).should('not.exist');
+                cy.get(stackroxLogoImage);
             }
         });
     });
@@ -33,12 +33,12 @@ describe('Logo and title product branding checks', () => {
 
         cy.title().then((title) => {
             if (title.includes(redHatTitleText)) {
-                cy.get(selectors.rhacsLogoImage);
-                cy.get(selectors.stackroxLogoImage).should('not.exist');
+                cy.get(rhacsLogoImage);
+                cy.get(stackroxLogoImage).should('not.exist');
             } else {
                 expect(title).to.have.string('StackRox');
-                cy.get(selectors.rhacsLogoImage).should('not.exist');
-                cy.get(selectors.stackroxLogoImage);
+                cy.get(rhacsLogoImage).should('not.exist');
+                cy.get(stackroxLogoImage);
             }
         });
     });


### PR DESCRIPTION
## Description

**Goal**: Because endpoints rarely change, encapsulate them in container subfolders, especially in helpers if multiple tests refer to them.

Now less than 100 lines :)

1. clusters which was missing initial `/` :(
    * helpers/systemHealth.js
    * helpers/systemHealthPatternFly.js
    * systemHealth/bundle.test.js
        * Replace intercept and wait with `interactAndWaitForResponses` call.
    * helpers/networkGraph.js

2. auth
    * helpers/visit.js
    * auth.test.js

3. metadata
    * productBranding.test.js

4. roles
    * access.test.js is skipped, but replace all import endpoints
    * helpers/visit.js

5. permissionSets has already been encapsulated in accessControl.helpers.js

6. accessScopes has already been encapsulated in accessControl.helpers.js and will soon be deleted from reporting.helpers.js

7. groups has already been encapsulated in accessControl.helpers.js

8. userAttributes is not used (pardon pun :)

9. featureFlags is used only in helpers/visit.js

10. extensions
    * systemHealth/bundle.test.js
        * Replace import of 2 unique selectors.
        * Factor out `downloadDiagnosticBundle` function.

11. permissions is not used

### Residue

Reduce when we encapsulate helpers in container folders:

* search
* risks
* network will become obsolete when PatternFly supersedes classic Network Graph
* policies
* integrationHealth
* integrations
* integration
* riskAcceptance

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed