### PR TITLE
ROX-14372: Add PF version of time window dropdown

### DIFF
--- a/ui/apps/platform/src/Containers/Network/Header/TimeWindowSelector.tsx
+++ b/ui/apps/platform/src/Containers/Network/Header/TimeWindowSelector.tsx
@@ -9,8 +9,8 @@ import { timeWindows } from 'constants/timeWindows';
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
 
 type TimeWindowSelectorProps = {
-    setActivityTimeWindow: (timeWindow) => void;
-    activityTimeWindow: string;
+    setActivityTimeWindow: (timeWindow: typeof timeWindows[number]) => void;
+    activityTimeWindow: typeof timeWindows[number];
     isDisabled?: boolean;
 };
 
@@ -33,9 +33,9 @@ function TimeWindowSelector({
             selections={activityTimeWindow}
             isDisabled={isDisabled}
         >
-            {timeWindows.map((window) => (
-                <SelectOption key={window} value={window}>
-                    {window}
+            {timeWindows.map((tw) => (
+                <SelectOption key={tw} value={tw}>
+                    {tw}
                 </SelectOption>
             ))}
         </Select>

--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
@@ -308,7 +308,9 @@ function NetworkGraphPage() {
                         </ToolbarGroup>
                         <ToolbarGroup alignment={{ default: 'alignRight' }}>
                             <Divider component="div" orientation={{ default: 'vertical' }} />
-                            <ToolbarItem>Last updated at {lastUpdatedTime}</ToolbarItem>
+                            <ToolbarItem className="pf-u-color-200">
+                                <em>Last updated at {lastUpdatedTime}</em>
+                            </ToolbarItem>
                         </ToolbarGroup>
                     </ToolbarContent>
                 </Toolbar>

--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
@@ -13,6 +13,7 @@ import {
 } from '@patternfly/react-core';
 import useDeepCompareEffect from 'use-deep-compare-effect';
 
+import { timeWindows } from 'constants/timeWindows';
 import useFetchClusters from 'hooks/useFetchClusters';
 import useFetchDeploymentCount from 'hooks/useFetchDeploymentCount';
 import useURLSearch from 'hooks/useURLSearch';
@@ -29,6 +30,7 @@ import NetworkSearch from './components/NetworkSearch';
 import SimulateNetworkPolicyButton from './simulation/SimulateNetworkPolicyButton';
 import EdgeStateSelect, { EdgeState } from './components/EdgeStateSelect';
 import DisplayOptionsSelect, { DisplayOption } from './components/DisplayOptionsSelect';
+import TimeWindowSelector from './components/TimeWindowSelector';
 import NetworkGraph from './NetworkGraph';
 import {
     transformPolicyData,
@@ -52,9 +54,6 @@ const emptyModel = {
     nodes: [],
     edges: [],
 };
-
-// TODO: get real time window from user input
-const timeWindow = 'Past hour';
 // TODO: get real includePorts flag from user input
 const includePorts = true;
 
@@ -72,6 +71,7 @@ function NetworkGraphPage() {
     const [extraneousFlowsModel, setExtraneousFlowsModel] = useState<CustomModel>(emptyModel);
     const [model, setModel] = useState<CustomModel>(emptyModel);
     const [isLoading, setIsLoading] = useState(false);
+    const [timeWindow, setTimeWindow] = useState<typeof timeWindows[number]>(timeWindows[0]);
     const [lastUpdatedTime, setLastUpdatedTime] = useState<string>('never');
 
     const { searchFilter } = useURLSearch();
@@ -164,7 +164,14 @@ function NetworkGraphPage() {
                     .finally(() => setIsLoading(false));
             }
         }
-    }, [clusterFromUrl, namespacesFromUrl, deploymentsFromUrl, deploymentCount, remainingQuery]);
+    }, [
+        clusterFromUrl,
+        namespacesFromUrl,
+        deploymentsFromUrl,
+        deploymentCount,
+        remainingQuery,
+        timeWindow,
+    ]);
 
     const setModelByEdgeState = useCallback(() => {
         if (edgeState === 'active') {
@@ -270,13 +277,19 @@ function NetworkGraphPage() {
                 <Toolbar data-testid="network-graph-toolbar">
                     <ToolbarContent>
                         <ToolbarGroup variant="filter-group">
-                            <ToolbarItem>
+                            <ToolbarItem spacer={{ default: 'spacerMd' }}>
                                 <EdgeStateSelect
                                     edgeState={edgeState}
                                     setEdgeState={setEdgeState}
                                 />
                             </ToolbarItem>
-                            <ToolbarItem>in the past hour</ToolbarItem>
+                            <ToolbarItem>
+                                <TimeWindowSelector
+                                    activeTimeWindow={timeWindow}
+                                    setActiveTimeWindow={setTimeWindow}
+                                    isDisabled={isLoading}
+                                />
+                            </ToolbarItem>
                         </ToolbarGroup>
                         <ToolbarGroup className="pf-u-flex-grow-1">
                             <ToolbarItem className="pf-u-flex-grow-1">

--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
@@ -72,6 +72,8 @@ function NetworkGraphPage() {
     const [extraneousFlowsModel, setExtraneousFlowsModel] = useState<CustomModel>(emptyModel);
     const [model, setModel] = useState<CustomModel>(emptyModel);
     const [isLoading, setIsLoading] = useState(false);
+    const [lastUpdatedTime, setLastUpdatedTime] = useState<string>('never');
+
     const { searchFilter } = useURLSearch();
     const [simulationQueryValue] = useURLParameter('simulation', undefined);
 
@@ -147,6 +149,14 @@ function NetworkGraphPage() {
                         );
                         setActiveModel(activeDataModel);
                         setExtraneousFlowsModel(extraneousFlowsDataModel);
+
+                        const newUpdatedTimestamp = new Date();
+                        // show only hours and minutes, use options with the default locale - use an empty array
+                        const lastUpdatedDisplayTime = newUpdatedTimestamp.toLocaleTimeString([], {
+                            hour: '2-digit',
+                            minute: '2-digit',
+                        });
+                        setLastUpdatedTime(lastUpdatedDisplayTime);
                     })
                     .catch(() => {
                         // TODO
@@ -284,8 +294,8 @@ function NetworkGraphPage() {
                             </ToolbarItem>
                         </ToolbarGroup>
                         <ToolbarGroup alignment={{ default: 'alignRight' }}>
-                            <Divider component="div" isVertical />
-                            <ToolbarItem>Last updated at 12:34PM</ToolbarItem>
+                            <Divider component="div" orientation={{ default: 'vertical' }} />
+                            <ToolbarItem>Last updated at {lastUpdatedTime}</ToolbarItem>
                         </ToolbarGroup>
                     </ToolbarContent>
                 </Toolbar>

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/TimeWindowSelector.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/TimeWindowSelector.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { Select, SelectOption } from '@patternfly/react-core';
+
+import { timeWindows } from 'constants/timeWindows';
+import useSelectToggle from 'hooks/patternfly/useSelectToggle';
+
+type TimeWindowSelectorProps = {
+    setActiveTimeWindow: (timeWindow) => void;
+    activeTimeWindow: string;
+    isDisabled?: boolean;
+};
+
+function TimeWindowSelector({
+    setActiveTimeWindow,
+    activeTimeWindow,
+    isDisabled = false,
+}: TimeWindowSelectorProps) {
+    const { closeSelect, isOpen, onToggle } = useSelectToggle();
+    function selectTimeWindow(_event, selection) {
+        closeSelect();
+        setActiveTimeWindow(selection);
+    }
+
+    return (
+        <Select
+            isOpen={isOpen}
+            onToggle={onToggle}
+            onSelect={selectTimeWindow}
+            selections={activeTimeWindow}
+            isDisabled={isDisabled}
+        >
+            {timeWindows.map((window) => (
+                <SelectOption key={window} value={window}>
+                    {window}
+                </SelectOption>
+            ))}
+        </Select>
+    );
+}
+
+export default TimeWindowSelector;

--- a/ui/apps/platform/src/constants/timeWindows.ts
+++ b/ui/apps/platform/src/constants/timeWindows.ts
@@ -5,14 +5,14 @@ export const timeWindows = [
     'Past week',
     'Past month',
     'All time',
-];
+] as const;
 
 export const snoozeDurations = {
     DAY: '1 Day',
     WEEK: '1 Week',
     MONTH: '1 Month',
     UNSET: 'Indefinite',
-};
+} as const;
 
 export const durations = {
     HOUR: '1h',
@@ -20,4 +20,4 @@ export const durations = {
     WEEK: '168h',
     MONTH: '720h',
     UNSET: '0',
-};
+} as const;


### PR DESCRIPTION
## Description

This includes two related items:
1. Adding and wiring up a PF version of the Time Window dropdown to the new Network Graph toolbar
2. Adding the Last Updated time to the right side of the toolbar, as per the new mock, https://docs.google.com/presentation/d/1DdKZ0PoLk6yDyV9vFM4Q-HpB0N_lXwJ53G-CYAc56Sc/edit#slide=id.g1669bc43c7d_13_62 

## Checklist
- [x] Investigated and inspected CI test results (Go unit test failure on last run is test runner flake)

## Testing Performed

Default time window
<img width="1856" alt="Screen Shot 2023-01-20 at 2 24 46 PM" src="https://user-images.githubusercontent.com/715729/213788706-b4599e6c-27e8-4dcd-9574-cef8dc134420.png">

Changing to a new value
<img width="1856" alt="Screen Shot 2023-01-20 at 2 25 08 PM" src="https://user-images.githubusercontent.com/715729/213788738-eb514f8e-0812-4a26-b968-40a81cbee3f5.png">
