### PR TITLE
ROX-14335: PVC extension should not touch PVCs that are not its target

### DIFF
--- a/operator/pkg/central/extensions/common.go
+++ b/operator/pkg/central/extensions/common.go
@@ -21,7 +21,7 @@ var (
 func wrapExtension(runFn func(ctx context.Context, central *platform.Central, client ctrlClient.Client, statusUpdater func(statusFunc updateStatusFunc), log logr.Logger) error, client ctrlClient.Client) extensions.ReconcileExtension {
 	return func(ctx context.Context, u *unstructured.Unstructured, statusUpdater func(extensions.UpdateStatusFunc), log logr.Logger) error {
 		if u.GroupVersionKind() != platform.CentralGVK {
-			log.Error(errUnexpectedGVK, "unable to reconcile central TLS secrets", "expectedGVK", platform.CentralGVK, "actualGVK", u.GroupVersionKind())
+			log.Error(errUnexpectedGVK, "unable to reconcile central", "expectedGVK", platform.CentralGVK, "actualGVK", u.GroupVersionKind())
 			return errUnexpectedGVK
 		}
 

--- a/operator/pkg/central/extensions/reconcile_pvc.go
+++ b/operator/pkg/central/extensions/reconcile_pvc.go
@@ -113,7 +113,7 @@ func reconcilePVC(ctx context.Context, central *platform.Central, persistence *p
 		persistence:      persistence,
 		target:           target,
 		defaultClaimName: defaultClaimName,
-		log:              log,
+		log:              log.WithValues("pvcReconciler", target),
 	}
 
 	return ext.Execute()

--- a/operator/pkg/central/extensions/reconcile_pvc.go
+++ b/operator/pkg/central/extensions/reconcile_pvc.go
@@ -186,7 +186,7 @@ func (r *reconcilePVCExtensionRun) Execute() error {
 }
 
 func (r *reconcilePVCExtensionRun) handleDelete() error {
-	ownedPVCs, err := r.getOwnedPVC()
+	ownedPVCs, err := r.getOwnedPVCsForCurrentTarget()
 	if err != nil {
 		return errors.Wrap(err, "fetching operator owned PVCs")
 	}
@@ -275,52 +275,53 @@ func parseResourceQuantityOr(qStrPtr *string, d resource.Quantity) (resource.Qua
 	return q, nil
 }
 
-func (r *reconcilePVCExtensionRun) getOwnedPVC() ([]*corev1.PersistentVolumeClaim, error) {
+func (r *reconcilePVCExtensionRun) getOwnedPVCsForCurrentTarget() ([]*corev1.PersistentVolumeClaim, error) {
 	pvcList := &corev1.PersistentVolumeClaimList{}
 
 	if err := r.client.List(r.ctx, pvcList, ctrlClient.InNamespace(r.namespace)); err != nil {
 		return nil, errors.Wrapf(err, "receiving list PVC list for %s %s", r.centralObj.GroupVersionKind(), r.centralObj.GetName())
 	}
 
-	var ownedPVCs []*corev1.PersistentVolumeClaim
+	var pvcs []*corev1.PersistentVolumeClaim
 	for i := range pvcList.Items {
-		item := pvcList.Items[i]
-		if metav1.IsControlledBy(&item, r.centralObj) {
-			tmp := item
-			ownedPVCs = append(ownedPVCs, &tmp)
+		pvc := pvcList.Items[i]
+		if r.getTargetLabelValue(&pvc) == string(r.target) {
+			pvcs = append(pvcs, &pvc)
 		}
 	}
 
-	return ownedPVCs, nil
+	return pvcs, nil
+}
+
+func (r *reconcilePVCExtensionRun) getTargetLabelValue(pvc *corev1.PersistentVolumeClaim) string {
+	// If the PCV is not owned by the Central we're reconciling, do not make any assumptions about the target.
+	if !metav1.IsControlledBy(pvc, r.centralObj) {
+		return ""
+	}
+	if val, ok := pvc.Labels[pvcTargetLabelKey]; ok {
+		return val
+	}
+	// If the target annotation is not set, assume this (owned) PVC is a Central PVC for backwards compatibility.
+	return string(PVCTargetCentral)
 }
 
 func (r *reconcilePVCExtensionRun) getUniqueOwnedPVCForCurrentTarget() (*corev1.PersistentVolumeClaim, error) {
-	pvcList, err := r.getOwnedPVC()
+	pvcList, err := r.getOwnedPVCsForCurrentTarget()
 	if err != nil {
 		return nil, err
 	}
 
-	// Filter PVC List by current PVC Claim Name
-	filtered := make([]*corev1.PersistentVolumeClaim, 0, len(pvcList))
-	for _, pvc := range pvcList {
-		// If the target annotation is empty, default to Central for backwards compatibility
-		if val, ok := pvc.Labels[pvcTargetLabelKey]; !ok && r.target == PVCTargetCentral {
-			filtered = append(filtered, pvc)
-		} else if val == string(r.target) {
-			filtered = append(filtered, pvc)
-		}
-	}
 	// If no previously created managed PVC was found everything is ok.
-	if len(filtered) == 0 {
+	if len(pvcList) == 0 {
 		return nil, nil
 	}
-	if len(filtered) > 1 {
-		names := sliceutils.Map(filtered, (*corev1.PersistentVolumeClaim).GetName)
+	if len(pvcList) > 1 {
+		names := sliceutils.Map(pvcList, (*corev1.PersistentVolumeClaim).GetName)
 		sort.Strings(names)
 
 		return nil, errors.Wrapf(errMultipleOwnedPVCs,
 			"multiple owned PVCs were found for %s, please remove not used ones or delete their OwnerReferences. Found PVCs: %s", r.target, strings.Join(names, ", "))
 	}
 
-	return filtered[0], nil
+	return pvcList[0], nil
 }

--- a/operator/pkg/central/extensions/reconcile_pvc_test.go
+++ b/operator/pkg/central/extensions/reconcile_pvc_test.go
@@ -47,7 +47,9 @@ func verifyMultiple(funcs ...pvcVerifyFunc) pvcVerifyFunc {
 func ownedBy(central *platform.Central) pvcVerifyFunc {
 	return func(t *testing.T, pvc *corev1.PersistentVolumeClaim) {
 		require.NotNil(t, pvc)
-		assert.True(t, metav1.IsControlledBy(pvc, central))
+		assert.True(t, metav1.IsControlledBy(pvc, central),
+			"expected PVC to be owned by central %q, but its owner references were %q",
+			central.UID, pvc.OwnerReferences)
 	}
 }
 
@@ -351,6 +353,15 @@ func TestReconcilePVCExtension(t *testing.T) {
 				testPVCName: verifyMultiple(ownedBy(changedPVCConfigCentralDB), withSize(resource.MustParse("500Gi")), withStorageClass("new-storage-class")),
 			},
 		},
+		"central-pvc-should-not-lose-owner-refs-if-central-db-persistence-disabled": {
+			Central:      emptyNotDeletedCentral,
+			DefaultClaim: DefaultCentralDBPVCName,
+			Target:       PVCTargetCentralDB,
+			ExistingPVCs: []*corev1.PersistentVolumeClaim{makePVC(emptyNotDeletedCentral, testPVCName, defaultPVCSize, emptyStorageClass, nil)},
+			ExpectedPVCs: map[string]pvcVerifyFunc{
+				testPVCName: ownedBy(emptyNotDeletedCentral),
+			},
+		},
 	}
 
 	for name, tc := range cases {
@@ -401,7 +412,7 @@ func executeAndVerify(t *testing.T, testCase pvcReconciliationTestCase, r reconc
 	err = r.client.List(context.TODO(), pvcList)
 	require.NoError(t, err)
 
-	// check pvcs which should exist in cluster
+	// Check pvcs which should exist in cluster.
 	for i := range pvcList.Items {
 		pvc := pvcList.Items[i]
 		pvf := pvcsToVerify[pvc.GetName()]
@@ -410,7 +421,7 @@ func executeAndVerify(t *testing.T, testCase pvcReconciliationTestCase, r reconc
 		delete(pvcsToVerify, pvc.GetName())
 	}
 
-	// Check pvs which should not exit in cluster
+	// Check pvs which should not exist in cluster.
 	for _, pvf := range pvcsToVerify {
 		pvf(t, nil)
 	}

--- a/operator/tests/central/basic/10-assert.yaml
+++ b/operator/tests/central/basic/10-assert.yaml
@@ -67,6 +67,11 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: stackrox-db
+  ownerReferences:
+  - apiVersion: platform.stackrox.io/v1alpha1
+    kind: Central
+    name: stackrox-central-services
+    controller: true
 spec:
   accessModes:
   - ReadWriteOnce


### PR DESCRIPTION
## Description

Each instance of the `ReconcilePVCExtension` should only care about the PVC resources which match its target (where matching is in broad sense, for backwards compatibility reasons). This was mostly true, except for the `handleDelete()` case, which lead to unintended removal of owner references from **all owned** PVCs.

See [more detailed description in the ticket](https://issues.redhat.com/browse/ROX-14335?focusedCommentId=21590623&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-21590623).

This changes:
- `handleDelete()` to ignore PVCs that are not for the current target,
- adds a unit test and a kuttl test for this case
- improves logging a bit
- fixes some typos

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

This definitely requires some user-facing communication, since some repair actions would be necessary for almost all 3.73.x operator users if they want to re-gain full functionality. Still need to investigate how to best approach this.

## Testing Performed

Ran the new unit tests which failed on old codebase. Depending on CI otherwise.