### PR TITLE
Dashrews/ROX-14271 metric active db connections

### DIFF
--- a/central/globaldb/metrics/metrics.go
+++ b/central/globaldb/metrics/metrics.go
@@ -56,7 +56,6 @@ func init() {
 		PostgresDBSize,
 		PostgresTotalSize,
 		PostgresConnected,
-		PostgresActiveConnections,
 		PostgresTotalConnections,
 		PostgresMaximumConnections,
 	)
@@ -208,13 +207,6 @@ var (
 		Name:      "postgres_connected",
 		Help:      "flag indicating if central is connected to the Postgres Database. 0 NOT connected, 1 connected",
 	})
-
-	PostgresActiveConnections = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Namespace: metrics.PrometheusNamespace,
-		Subsystem: metrics.CentralSubsystem.String(),
-		Name:      "postgres_active_db_connections",
-		Help:      "number of active connections to Postgres by database name",
-	}, []string{"database"})
 
 	PostgresTotalConnections = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: metrics.PrometheusNamespace,

--- a/central/globaldb/metrics/metrics.go
+++ b/central/globaldb/metrics/metrics.go
@@ -56,6 +56,9 @@ func init() {
 		PostgresDBSize,
 		PostgresTotalSize,
 		PostgresConnected,
+		PostgresActiveConnections,
+		PostgresTotalConnections,
+		PostgresMaximumConnections,
 	)
 }
 
@@ -204,6 +207,27 @@ var (
 		Subsystem: metrics.CentralSubsystem.String(),
 		Name:      "postgres_connected",
 		Help:      "flag indicating if central is connected to the Postgres Database. 0 NOT connected, 1 connected",
+	})
+
+	PostgresActiveConnections = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.CentralSubsystem.String(),
+		Name:      "postgres_active_db_connections",
+		Help:      "number of active connections to Postgres by database name",
+	}, []string{"database"})
+
+	PostgresTotalConnections = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.CentralSubsystem.String(),
+		Name:      "postgres_total_connections",
+		Help:      "number of total connections to Postgres by state",
+	}, []string{"state"})
+
+	PostgresMaximumConnections = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.CentralSubsystem.String(),
+		Name:      "postgres_maximum_db_connections",
+		Help:      "number of total connections allowed to the Postgres database server",
 	})
 )
 

--- a/central/globaldb/postgres.go
+++ b/central/globaldb/postgres.go
@@ -57,6 +57,12 @@ SELECT TABLE_NAME
 ) a;`
 
 	versionQuery = `SHOW server_version;`
+
+	connectionQuery = `SELECT datname, COUNT(datid) FROM pg_stat_activity WHERE state <> 'idle' AND datname IS NOT NULL GROUP BY datname;`
+
+	totalConnectionQuery = `SELECT state, COUNT(datid) FROM pg_stat_activity WHERE state IS NOT NULL GROUP BY state;`
+
+	maxConnectionQuery = `SELECT current_setting('max_connections')::int;`
 )
 
 var (
@@ -235,11 +241,99 @@ func CollectPostgresDatabaseStats(postgresConfig *postgres.Config) {
 	metrics.PostgresTotalSize.Set(float64(totalSize))
 }
 
+// CollectPostgresConnectionStats -- collect connection stats for Postgres
+func CollectPostgresConnectionStats(ctx context.Context, db *postgres.DB) {
+	// Get the active connections by database
+	getActiveConnections(ctx, db)
+
+	// Get the total connections by database
+	getTotalConnections(ctx, db)
+
+	// Get the max connections for Postgres
+	getMaxConnections(ctx, db)
+}
+
+// getActiveConnections -- gets the active connections by database
+func getActiveConnections(ctx context.Context, db *postgres.DB) {
+	ctx, cancel := context.WithTimeout(ctx, PostgresQueryTimeout)
+	defer cancel()
+
+	rows, err := db.Query(ctx, connectionQuery)
+	if err != nil {
+		log.Errorf("error fetching active connection information: %v", err)
+		return
+	}
+
+	defer rows.Close()
+
+	processConnectionCountRow(metrics.PostgresActiveConnections, rows)
+}
+
+// getTotalConnections -- gets the total connections by database
+func getTotalConnections(ctx context.Context, db *postgres.DB) {
+	ctx, cancel := context.WithTimeout(ctx, PostgresQueryTimeout)
+	defer cancel()
+
+	rows, err := db.Query(ctx, totalConnectionQuery)
+	if err != nil {
+		log.Errorf("error fetching total connection information: %v", err)
+		return
+	}
+
+	defer rows.Close()
+
+	for rows.Next() {
+		var (
+			state           string
+			connectionCount int
+		)
+		if err := rows.Scan(&state, &connectionCount); err != nil {
+			log.Errorf("error scanning row for connection data: %v", err)
+			return
+		}
+
+		stateLabel := prometheus.Labels{"state": state}
+		metrics.PostgresTotalConnections.With(stateLabel).Set(float64(connectionCount))
+	}
+}
+
+// getMaxConnections -- gets maximum number of connections to Postgres server
+func getMaxConnections(ctx context.Context, db *postgres.DB) {
+	ctx, cancel := context.WithTimeout(ctx, PostgresQueryTimeout)
+	defer cancel()
+
+	row := db.QueryRow(ctx, maxConnectionQuery)
+	var connectionCount int
+	if err := row.Scan(&connectionCount); err != nil {
+		log.Errorf("error fetching max connection information: %v", err)
+		return
+	}
+
+	metrics.PostgresMaximumConnections.Set(float64(connectionCount))
+}
+
+func processConnectionCountRow(metric *prometheus.GaugeVec, rows postgres.Rows) {
+	for rows.Next() {
+		var (
+			databaseName    string
+			connectionCount int
+		)
+		if err := rows.Scan(&databaseName, &connectionCount); err != nil {
+			log.Errorf("error scanning row for connection data: %v", err)
+			return
+		}
+
+		databaseLabel := prometheus.Labels{"database": databaseName}
+		metric.With(databaseLabel).Set(float64(connectionCount))
+	}
+}
+
 func startMonitoringPostgres(ctx context.Context, db *postgres.DB, postgresConfig *postgres.Config) {
 	t := time.NewTicker(1 * time.Minute)
 	defer t.Stop()
 	for range t.C {
 		_ = CollectPostgresStats(ctx, db)
 		CollectPostgresDatabaseStats(postgresConfig)
+		CollectPostgresConnectionStats(ctx, db)
 	}
 }


### PR DESCRIPTION
## Description

Adds a metric for active database connections by database.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Ran and inspected the metrics files from the diagnostic and debug bundles.

From metrics-1:
```
# HELP rox_central_postgres_total_connections number of total connections to Postgres by state
# TYPE rox_central_postgres_total_connections gauge
rox_central_postgres_total_connections{state="active"} 1
rox_central_postgres_total_connections{state="idle"} 81
...
# HELP rox_central_postgres_maximum_db_connections number of total connections allowed to the Postgres database server
# TYPE rox_central_postgres_maximum_db_connections gauge
rox_central_postgres_maximum_db_connections 200
```
