### PR TITLE
Fix styles in PF network graph filters

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.css
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.css
@@ -11,6 +11,12 @@
     height: calc(100vh - var(--pf-c-page__header--MinHeight) - var(--pf-c-page__header--MinHeight) - var(--pf-c-page__header--MinHeight));
 }
 
+/* Create a stacking context that is higher than the context for the network-graph-toolbar component
+   that is rendered below this toolbar, so that the hierarchy dropdowns will render above everything when open */
+.network-graph-selector-bar {
+    z-index: 350;
+}
+
 /* Create a stacking context that is higher than the context for the react-topology component
    that is rendered below the toolbar, so that the search filter dropdown will render above the graph when open */
 [data-testid="network-graph-toolbar"] {

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/NetworkSearch.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/NetworkSearch.tsx
@@ -58,7 +58,7 @@ function NetworkSearch({
 
     return (
         <SearchFilterInput
-            className="pf-u-w-100 pf-search-shim"
+            className="pf-u-w-100 theme-light pf-search-shim"
             placeholder="Add one or more deployment filters"
             searchFilter={searchFilter}
             searchCategory="DEPLOYMENTS"


### PR DESCRIPTION
## Description

Fixes a couple of style ooopsies for new PatternFly Network Graph.
1. Classic key-value filter looked dark in dark mode. Used same forced `theme-light` solution as we have used in other new PF sections, until we get the PF dark mode piece in. (Thanks to @dvail for showing me this.)
2. Adding an even higher stacking context for the hierarchy selector dropdowns, so they don't run "under" the toolbar, which has a stacking context "over" the graph itself.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

Fixed filter search bar in dark mode
<img width="1533" alt="Screen Shot 2023-01-23 at 10 38 27 AM" src="https://user-images.githubusercontent.com/715729/214083500-9a31a4a5-0de2-4d8d-8ebb-6687ad6e5388.png">

Fixed hierarchy dropdowns stacking order
<img width="1533" alt="Screen Shot 2023-01-23 at 10 38 13 AM" src="https://user-images.githubusercontent.com/715729/214083559-ffb8a149-09d6-4f16-92bd-faac0c538410.png">
