### PR TITLE
ROX-14487: Improvements of Group and Identify messages

### DIFF
--- a/central/cluster/datastore/telemetry.go
+++ b/central/cluster/datastore/telemetry.go
@@ -19,6 +19,13 @@ func trackClusterRegistered(cluster *storage.Cluster) {
 			"Managed By":   cluster.GetManagedBy().String(),
 		}
 		cfg.Telemeter().Track("Secured Cluster Registered", props)
+
+		// Add the secured cluster 'user' to the Tenant group:
+		cfg.Telemeter().GroupUserAs(cluster.GetId(), "", "", cfg.GroupID, nil)
+
+		// Update the secured cluster identity from its name:
+		cfg.Telemeter().IdentifyUserAs(cluster.GetId(), cluster.GetId(), "Secured Cluster",
+			makeClusterProperties(cluster))
 	}
 }
 
@@ -37,14 +44,7 @@ func makeClusterProperties(cluster *storage.Cluster) map[string]any {
 
 func trackClusterInitialized(cluster *storage.Cluster) {
 	if cfg := centralclient.InstanceConfig(); cfg.Enabled() {
-		// Add the secured cluster 'user' to the Tenant group:
-		cfg.Telemeter().GroupUserAs(cluster.GetId(), "", "", cfg.GroupID, nil)
-
-		// Update the secured cluster identity from its name:
-		cfg.Telemeter().IdentifyUserAs(cluster.GetId(), cluster.GetId(), "Secured Cluster",
-			makeClusterProperties(cluster))
-
-		// Issue an event that makes the identity effective:
+		// Issue an event that makes the secured cluster identity effective:
 		cfg.Telemeter().TrackUserAs(cluster.GetId(), cluster.GetId(), "Secured Cluster",
 			"Secured Cluster Initialized", map[string]any{
 				"Health": cluster.GetHealthStatus().GetOverallHealthStatus().String(),

--- a/central/cluster/datastore/telemetry.go
+++ b/central/cluster/datastore/telemetry.go
@@ -38,7 +38,7 @@ func makeClusterProperties(cluster *storage.Cluster) map[string]any {
 func trackClusterInitialized(cluster *storage.Cluster) {
 	if cfg := centralclient.InstanceConfig(); cfg.Enabled() {
 		cfg.Telemeter().Group(cfg.GroupID, cluster.GetId(), nil)
-		cfg.Telemeter().Identify(cluster.GetId(), makeClusterProperties(cluster))
+		cfg.Telemeter().Identify(cluster.GetId(), "Secured Cluster", makeClusterProperties(cluster))
 		cfg.Telemeter().Track("Secured Cluster Initialized", cluster.GetId(), map[string]any{
 			"Health": cluster.GetHealthStatus().GetOverallHealthStatus().String(),
 		})
@@ -75,7 +75,7 @@ func UpdateSecuredClusterIdentity(ctx context.Context, clusterID string, metrics
 		props := makeClusterProperties(cluster)
 		props["Total Nodes"] = metrics.NodeCount
 		props["CPU Capacity"] = metrics.CpuCapacity
-		cfg.Telemeter().Identify(cluster.GetId(), props)
-		cfg.Telemeter().Track("Secured Cluster Identity Update", cluster.GetId(), nil)
+		cfg.Telemeter().Identify(cluster.GetId(), "Secured Cluster", props)
+		cfg.Telemeter().Track("Updated Secured Cluster Identity", cluster.GetId(), nil)
 	}
 }

--- a/central/main.go
+++ b/central/main.go
@@ -542,9 +542,9 @@ func startGRPCServer() {
 		config.HTTPInterceptors = append(config.HTTPInterceptors, cfg.GetHTTPInterceptor())
 		config.UnaryInterceptors = append(config.UnaryInterceptors, cfg.GetGRPCInterceptor())
 		// Central adds itself to the tenant group, with no group properties:
-		cfg.Telemeter().Group(cfg.GroupID, cfg.ClientID, nil)
+		cfg.Telemeter().GroupUserAs(cfg.ClientID, "", "", cfg.GroupID, nil)
 		// Add the local admin user as well, with no extra group properties:
-		cfg.Telemeter().Group(cfg.GroupID, cfg.HashUserID(basic.DefaultUsername, basicAuthProvider.ID()), nil)
+		cfg.Telemeter().GroupUserAs(cfg.HashUserID(basic.DefaultUsername, basicAuthProvider.ID()), "", "", cfg.GroupID, nil)
 	}
 
 	// Before authorization is checked, we want to inject the sac client into the context.

--- a/central/role/mapper/telemetry.go
+++ b/central/role/mapper/telemetry.go
@@ -9,6 +9,6 @@ import (
 // such users could be segmented by tenant properties.
 func addUserToTenantGroup(user *storage.User) {
 	if cfg := centralclient.InstanceConfig(); cfg.Enabled() {
-		cfg.Telemeter().Group(cfg.GroupID, cfg.HashUserID(user.GetId(), user.GetAuthProviderId()), nil)
+		cfg.Telemeter().GroupUserAs(cfg.HashUserID(user.GetId(), user.GetAuthProviderId()), cfg.GroupID, "", "", nil)
 	}
 }

--- a/pkg/telemetry/phonehome/client_config.go
+++ b/pkg/telemetry/phonehome/client_config.go
@@ -70,7 +70,7 @@ func (cfg *Config) Gatherer() Gatherer {
 			if cfg.GatherPeriod.Nanoseconds() == 0 {
 				period = 1 * time.Hour
 			}
-			cfg.gatherer = newGatherer(cfg.ClientID, cfg.ClientName, cfg.Telemeter(), period)
+			cfg.gatherer = newGatherer(cfg.ClientName, cfg.Telemeter(), period)
 		} else {
 			cfg.gatherer = &nilGatherer{}
 		}

--- a/pkg/telemetry/phonehome/client_config.go
+++ b/pkg/telemetry/phonehome/client_config.go
@@ -70,7 +70,7 @@ func (cfg *Config) Gatherer() Gatherer {
 			if cfg.GatherPeriod.Nanoseconds() == 0 {
 				period = 1 * time.Hour
 			}
-			cfg.gatherer = newGatherer(cfg.ClientID, cfg.Telemeter(), period)
+			cfg.gatherer = newGatherer(cfg.ClientID, cfg.ClientName, cfg.Telemeter(), period)
 		} else {
 			cfg.gatherer = &nilGatherer{}
 		}

--- a/pkg/telemetry/phonehome/gatherer.go
+++ b/pkg/telemetry/phonehome/gatherer.go
@@ -28,6 +28,7 @@ func (*nilGatherer) AddGatherer(GatherFunc) {}
 
 type gatherer struct {
 	clientID    string
+	clientKind  string
 	telemeter   Telemeter
 	period      time.Duration
 	stopSig     concurrency.Signal
@@ -38,11 +39,12 @@ type gatherer struct {
 	lastData    map[string]any
 }
 
-func newGatherer(clientID string, t Telemeter, p time.Duration) *gatherer {
+func newGatherer(clientID, kind string, t Telemeter, p time.Duration) *gatherer {
 	return &gatherer{
-		clientID:  clientID,
-		telemeter: t,
-		period:    p,
+		clientID:   clientID,
+		clientKind: kind,
+		telemeter:  t,
+		period:     p,
 	}
 }
 
@@ -74,9 +76,9 @@ func (g *gatherer) identify() {
 	defer g.gathering.Unlock()
 	data := g.gather()
 	if !reflect.DeepEqual(g.lastData, data) {
-		g.telemeter.Identify(g.clientID, data)
+		g.telemeter.Identify(g.clientID, g.clientKind, data)
 		// Issue an event so that the new data become visible on analytics:
-		g.telemeter.Track("Updated Identity", g.clientID, nil)
+		g.telemeter.Track("Updated "+g.clientKind+" Identity", g.clientID, nil)
 	}
 	g.lastData = data
 }

--- a/pkg/telemetry/phonehome/gatherer.go
+++ b/pkg/telemetry/phonehome/gatherer.go
@@ -27,8 +27,7 @@ func (*nilGatherer) Stop()                  {}
 func (*nilGatherer) AddGatherer(GatherFunc) {}
 
 type gatherer struct {
-	clientID    string
-	clientKind  string
+	clientType  string
 	telemeter   Telemeter
 	period      time.Duration
 	stopSig     concurrency.Signal
@@ -39,10 +38,9 @@ type gatherer struct {
 	lastData    map[string]any
 }
 
-func newGatherer(clientID, kind string, t Telemeter, p time.Duration) *gatherer {
+func newGatherer(clientType string, t Telemeter, p time.Duration) *gatherer {
 	return &gatherer{
-		clientID:   clientID,
-		clientKind: kind,
+		clientType: clientType,
 		telemeter:  t,
 		period:     p,
 	}
@@ -76,9 +74,9 @@ func (g *gatherer) identify() {
 	defer g.gathering.Unlock()
 	data := g.gather()
 	if !reflect.DeepEqual(g.lastData, data) {
-		g.telemeter.Identify(g.clientID, g.clientKind, data)
+		g.telemeter.Identify(data)
 		// Issue an event so that the new data become visible on analytics:
-		g.telemeter.Track("Updated "+g.clientKind+" Identity", g.clientID, nil)
+		g.telemeter.Track("Updated "+g.clientType+" Identity", nil)
 	}
 	g.lastData = data
 }

--- a/pkg/telemetry/phonehome/gatherer_test.go
+++ b/pkg/telemetry/phonehome/gatherer_test.go
@@ -57,15 +57,16 @@ func (s *gathererTestSuite) TestGatherer() {
 
 	// Identify and Track should be called once as there's no change in the
 	// identity:
-	t.EXPECT().Identify("test", "Test", &mapMatcher{map[string]any{
+	t.EXPECT().Identify(&mapMatcher{map[string]any{
 		"key": "value",
 	}}).Times(1)
-	t.EXPECT().Track("Updated Test Identity", "test", nil).Times(1)
+
+	t.EXPECT().Track("Updated Test Identity", nil).Times(1)
 
 	props := make(map[string]any)
 	var i int64
 
-	g := newGatherer("test", "Test", t, 24*time.Hour)
+	g := newGatherer("Test", t, 24*time.Hour)
 	g.AddGatherer(func(context.Context) (map[string]any, error) {
 		atomic.AddInt64(&i, 1)
 		props["key"] = "value"

--- a/pkg/telemetry/phonehome/interceptor.go
+++ b/pkg/telemetry/phonehome/interceptor.go
@@ -27,7 +27,7 @@ func (cfg *Config) track(rp *RequestParams) {
 			}
 		}
 		if ok {
-			cfg.telemeter.Track(event, id, props)
+			cfg.telemeter.TrackUserAs(id, "", "", event, props)
 		}
 	}
 }

--- a/pkg/telemetry/phonehome/interceptor_test.go
+++ b/pkg/telemetry/phonehome/interceptor_test.go
@@ -63,7 +63,7 @@ func (s *interceptorTestSuite) TestAddGrpcInterceptor() {
 		return true
 	})
 
-	s.mockTelemeter.EXPECT().Track("TestEvent", cfg.HashUserAuthID(nil), map[string]any{
+	s.mockTelemeter.EXPECT().TrackUserAs(cfg.HashUserAuthID(nil), "", "", "TestEvent", map[string]any{
 		"Property": "test value",
 	}).Times(1)
 
@@ -95,7 +95,7 @@ func (s *interceptorTestSuite) TestAddHttpInterceptor() {
 
 	mockID.EXPECT().ExternalAuthProvider().Return(nil).Times(2)
 	mockID.EXPECT().UID().Return("id").Times(2)
-	s.mockTelemeter.EXPECT().Track("TestEvent", cfg.HashUserAuthID(mockID), map[string]any{
+	s.mockTelemeter.EXPECT().TrackUserAs(cfg.HashUserAuthID(mockID), "", "", "TestEvent", map[string]any{
 		"Property": "test_value",
 	}).Times(1)
 

--- a/pkg/telemetry/phonehome/mocks/telemeter.go
+++ b/pkg/telemetry/phonehome/mocks/telemeter.go
@@ -34,27 +34,51 @@ func (m *MockTelemeter) EXPECT() *MockTelemeterMockRecorder {
 }
 
 // Group mocks base method.
-func (m *MockTelemeter) Group(groupID, userID string, props map[string]any) {
+func (m *MockTelemeter) Group(groupID string, props map[string]any) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Group", groupID, userID, props)
+	m.ctrl.Call(m, "Group", groupID, props)
 }
 
 // Group indicates an expected call of Group.
-func (mr *MockTelemeterMockRecorder) Group(groupID, userID, props interface{}) *gomock.Call {
+func (mr *MockTelemeterMockRecorder) Group(groupID, props interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Group", reflect.TypeOf((*MockTelemeter)(nil).Group), groupID, userID, props)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Group", reflect.TypeOf((*MockTelemeter)(nil).Group), groupID, props)
+}
+
+// GroupUserAs mocks base method.
+func (m *MockTelemeter) GroupUserAs(userID, clientID, clientType, groupID string, props map[string]any) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "GroupUserAs", userID, clientID, clientType, groupID, props)
+}
+
+// GroupUserAs indicates an expected call of GroupUserAs.
+func (mr *MockTelemeterMockRecorder) GroupUserAs(userID, clientID, clientType, groupID, props interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GroupUserAs", reflect.TypeOf((*MockTelemeter)(nil).GroupUserAs), userID, clientID, clientType, groupID, props)
 }
 
 // Identify mocks base method.
-func (m *MockTelemeter) Identify(userID, userKind string, props map[string]any) {
+func (m *MockTelemeter) Identify(props map[string]any) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Identify", userID, userKind, props)
+	m.ctrl.Call(m, "Identify", props)
 }
 
 // Identify indicates an expected call of Identify.
-func (mr *MockTelemeterMockRecorder) Identify(userID, userKind, props interface{}) *gomock.Call {
+func (mr *MockTelemeterMockRecorder) Identify(props interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Identify", reflect.TypeOf((*MockTelemeter)(nil).Identify), userID, userKind, props)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Identify", reflect.TypeOf((*MockTelemeter)(nil).Identify), props)
+}
+
+// IdentifyUserAs mocks base method.
+func (m *MockTelemeter) IdentifyUserAs(userID, clientID, clientType string, props map[string]any) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "IdentifyUserAs", userID, clientID, clientType, props)
+}
+
+// IdentifyUserAs indicates an expected call of IdentifyUserAs.
+func (mr *MockTelemeterMockRecorder) IdentifyUserAs(userID, clientID, clientType, props interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IdentifyUserAs", reflect.TypeOf((*MockTelemeter)(nil).IdentifyUserAs), userID, clientID, clientType, props)
 }
 
 // Stop mocks base method.
@@ -70,13 +94,25 @@ func (mr *MockTelemeterMockRecorder) Stop() *gomock.Call {
 }
 
 // Track mocks base method.
-func (m *MockTelemeter) Track(event, userID string, props map[string]any) {
+func (m *MockTelemeter) Track(event string, props map[string]any) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Track", event, userID, props)
+	m.ctrl.Call(m, "Track", event, props)
 }
 
 // Track indicates an expected call of Track.
-func (mr *MockTelemeterMockRecorder) Track(event, userID, props interface{}) *gomock.Call {
+func (mr *MockTelemeterMockRecorder) Track(event, props interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Track", reflect.TypeOf((*MockTelemeter)(nil).Track), event, userID, props)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Track", reflect.TypeOf((*MockTelemeter)(nil).Track), event, props)
+}
+
+// TrackUserAs mocks base method.
+func (m *MockTelemeter) TrackUserAs(userID, clientID, clientType, event string, props map[string]any) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "TrackUserAs", userID, clientID, clientType, event, props)
+}
+
+// TrackUserAs indicates an expected call of TrackUserAs.
+func (mr *MockTelemeterMockRecorder) TrackUserAs(userID, clientID, clientType, event, props interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TrackUserAs", reflect.TypeOf((*MockTelemeter)(nil).TrackUserAs), userID, clientID, clientType, event, props)
 }

--- a/pkg/telemetry/phonehome/mocks/telemeter.go
+++ b/pkg/telemetry/phonehome/mocks/telemeter.go
@@ -46,15 +46,15 @@ func (mr *MockTelemeterMockRecorder) Group(groupID, userID, props interface{}) *
 }
 
 // Identify mocks base method.
-func (m *MockTelemeter) Identify(userID string, props map[string]any) {
+func (m *MockTelemeter) Identify(userID, userKind string, props map[string]any) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Identify", userID, props)
+	m.ctrl.Call(m, "Identify", userID, userKind, props)
 }
 
 // Identify indicates an expected call of Identify.
-func (mr *MockTelemeterMockRecorder) Identify(userID, props interface{}) *gomock.Call {
+func (mr *MockTelemeterMockRecorder) Identify(userID, userKind, props interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Identify", reflect.TypeOf((*MockTelemeter)(nil).Identify), userID, props)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Identify", reflect.TypeOf((*MockTelemeter)(nil).Identify), userID, userKind, props)
 }
 
 // Stop mocks base method.

--- a/pkg/telemetry/phonehome/segment/segment.go
+++ b/pkg/telemetry/phonehome/segment/segment.go
@@ -18,17 +18,17 @@ type segmentTelemeter struct {
 
 func getMessageType(msg segment.Message) string {
 	switch m := msg.(type) {
-	case *segment.Alias:
+	case segment.Alias:
 		return m.Type
-	case *segment.Group:
+	case segment.Group:
 		return m.Type
-	case *segment.Identify:
+	case segment.Identify:
 		return m.Type
-	case *segment.Page:
+	case segment.Page:
 		return m.Type
-	case *segment.Screen:
+	case segment.Screen:
 		return m.Type
-	case *segment.Track:
+	case segment.Track:
 		return m.Type
 	default:
 		return ""

--- a/pkg/telemetry/phonehome/segment/segment.go
+++ b/pkg/telemetry/phonehome/segment/segment.go
@@ -89,11 +89,14 @@ func (t *segmentTelemeter) Stop() {
 	}
 }
 
-func (t *segmentTelemeter) Identify(userID string, props map[string]any) {
+func (t *segmentTelemeter) Identify(userID, userKind string, props map[string]any) {
 	if t == nil {
 		return
 	}
 	traits := segment.NewTraits()
+	if userKind != "" {
+		traits.Set("Kind", userKind)
+	}
 	identity := segment.Identify{
 		UserId: userID,
 		Traits: traits,

--- a/pkg/telemetry/phonehome/segment/segment.go
+++ b/pkg/telemetry/phonehome/segment/segment.go
@@ -14,6 +14,7 @@ var (
 
 type segmentTelemeter struct {
 	client segment.Client
+	userID string
 }
 
 func getMessageType(msg segment.Message) string {
@@ -43,7 +44,7 @@ func (*logOnFailure) Failure(msg segment.Message, err error) {
 }
 
 // NewTelemeter creates and initializes a Segment telemeter instance.
-func NewTelemeter(key, endpoint, userID, clientName string, interval time.Duration) *segmentTelemeter {
+func NewTelemeter(key, endpoint, clientID, clientType string, interval time.Duration) *segmentTelemeter {
 	segmentConfig := segment.Config{
 		Endpoint:  endpoint,
 		Interval:  interval,
@@ -51,9 +52,9 @@ func NewTelemeter(key, endpoint, userID, clientName string, interval time.Durati
 		Logger:    &logWrapper{internal: log},
 		Callback:  &logOnFailure{},
 		DefaultContext: &segment.Context{
-			Extra: map[string]any{
-				"Client ID":   userID,
-				"Client Name": clientName,
+			Device: segment.DeviceInfo{
+				Id:   clientID,
+				Type: clientType,
 			},
 		},
 	}
@@ -64,9 +65,7 @@ func NewTelemeter(key, endpoint, userID, clientName string, interval time.Durati
 		return nil
 	}
 
-	return &segmentTelemeter{
-		client: client,
-	}
+	return &segmentTelemeter{client: client, userID: clientID}
 }
 
 type logWrapper struct {
@@ -89,17 +88,32 @@ func (t *segmentTelemeter) Stop() {
 	}
 }
 
-func (t *segmentTelemeter) Identify(userID, userKind string, props map[string]any) {
+func (t *segmentTelemeter) Identify(props map[string]any) {
+	t.IdentifyUserAs("", "", "", props)
+}
+
+func (t *segmentTelemeter) IdentifyUserAs(userID, clientID, clientType string, props map[string]any) {
 	if t == nil {
 		return
 	}
 	traits := segment.NewTraits()
-	if userKind != "" {
-		traits.Set("Kind", userKind)
-	}
+
 	identity := segment.Identify{
-		UserId: userID,
+		UserId: t.userID,
 		Traits: traits,
+	}
+
+	if userID == "" {
+		identity.UserId = t.userID
+	}
+
+	if clientID != "" {
+		identity.Context = &segment.Context{
+			Device: segment.DeviceInfo{
+				Id:   clientID,
+				Type: clientType,
+			},
+		}
 	}
 
 	for k, v := range props {
@@ -110,15 +124,32 @@ func (t *segmentTelemeter) Identify(userID, userKind string, props map[string]an
 	}
 }
 
-func (t *segmentTelemeter) Group(groupID, userID string, props map[string]any) {
+func (t *segmentTelemeter) Group(groupID string, props map[string]any) {
+	t.GroupUserAs("", "", "", groupID, props)
+}
+
+func (t *segmentTelemeter) GroupUserAs(userID, clientID, clientType, groupID string, props map[string]any) {
 	if t == nil {
 		return
 	}
 
 	group := segment.Group{
 		GroupId: groupID,
-		UserId:  userID,
+		UserId:  t.userID,
 		Traits:  props,
+	}
+
+	if userID == "" {
+		group.UserId = t.userID
+	}
+
+	if clientID != "" {
+		group.Context = &segment.Context{
+			Device: segment.DeviceInfo{
+				Id:   clientID,
+				Type: clientType,
+			},
+		}
 	}
 
 	if err := t.client.Enqueue(group); err != nil {
@@ -126,7 +157,11 @@ func (t *segmentTelemeter) Group(groupID, userID string, props map[string]any) {
 	}
 }
 
-func (t *segmentTelemeter) Track(event, userID string, props map[string]any) {
+func (t *segmentTelemeter) Track(event string, props map[string]any) {
+	t.TrackUserAs("", "", "", event, props)
+}
+
+func (t *segmentTelemeter) TrackUserAs(userID, clientID, clientType, event string, props map[string]any) {
 	if t == nil {
 		return
 	}
@@ -135,6 +170,19 @@ func (t *segmentTelemeter) Track(event, userID string, props map[string]any) {
 		UserId:     userID,
 		Event:      event,
 		Properties: props,
+	}
+
+	if userID == "" {
+		track.UserId = t.userID
+	}
+
+	if clientID != "" {
+		track.Context = &segment.Context{
+			Device: segment.DeviceInfo{
+				Id:   clientID,
+				Type: clientType,
+			},
+		}
 	}
 
 	if err := t.client.Enqueue(track); err != nil {

--- a/pkg/telemetry/phonehome/segment/segment.go
+++ b/pkg/telemetry/phonehome/segment/segment.go
@@ -88,7 +88,7 @@ func (t *segmentTelemeter) Stop() {
 	}
 }
 
-func (t *segmentTelemeter) overwriteId(id string) string {
+func (t *segmentTelemeter) overwriteID(id string) string {
 	if id == "" {
 		return t.userID
 	}
@@ -118,7 +118,7 @@ func (t *segmentTelemeter) IdentifyUserAs(userID, clientID, clientType string, p
 	traits := segment.NewTraits()
 
 	identity := segment.Identify{
-		UserId:  t.overwriteId(userID),
+		UserId:  t.overwriteID(userID),
 		Traits:  traits,
 		Context: makeDeviceContext(clientID, clientType),
 	}
@@ -142,7 +142,7 @@ func (t *segmentTelemeter) GroupUserAs(userID, clientID, clientType, groupID str
 
 	group := segment.Group{
 		GroupId: groupID,
-		UserId:  t.overwriteId(userID),
+		UserId:  t.overwriteID(userID),
 		Traits:  props,
 		Context: makeDeviceContext(clientID, clientType),
 	}
@@ -162,7 +162,7 @@ func (t *segmentTelemeter) TrackUserAs(userID, clientID, clientType, event strin
 	}
 
 	track := segment.Track{
-		UserId:     t.overwriteId(userID),
+		UserId:     t.overwriteID(userID),
 		Event:      event,
 		Properties: props,
 		Context:    makeDeviceContext(clientID, clientType),

--- a/pkg/telemetry/phonehome/segment/segment_test.go
+++ b/pkg/telemetry/phonehome/segment/segment_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func Test_getMessageType(t *testing.T) {
-	track := &segment.Track{
+	track := segment.Track{
 		Type: "Track",
 	}
 

--- a/pkg/telemetry/phonehome/telemeter.go
+++ b/pkg/telemetry/phonehome/telemeter.go
@@ -8,7 +8,7 @@ type Telemeter interface {
 	// the buffers.
 	Stop()
 	// Identify updates the user traits.
-	Identify(userID string, props map[string]any)
+	Identify(userID, userKind string, props map[string]any)
 	// Track registers an event, caused by the user.
 	Track(event, userID string, props map[string]any)
 	// Group adds the user to a group, supplying group specific properties.
@@ -17,7 +17,7 @@ type Telemeter interface {
 
 type nilTelemeter struct{}
 
-func (t *nilTelemeter) Stop()                                              {}
-func (t *nilTelemeter) Identify(userID string, props map[string]any)       {}
-func (t *nilTelemeter) Track(event, userID string, props map[string]any)   {}
-func (t *nilTelemeter) Group(groupID, userID string, props map[string]any) {}
+func (t *nilTelemeter) Stop()                                                  {}
+func (t *nilTelemeter) Identify(userID, userKind string, props map[string]any) {}
+func (t *nilTelemeter) Track(event, userID string, props map[string]any)       {}
+func (t *nilTelemeter) Group(groupID, userID string, props map[string]any)     {}

--- a/pkg/telemetry/phonehome/telemeter.go
+++ b/pkg/telemetry/phonehome/telemeter.go
@@ -8,16 +8,27 @@ type Telemeter interface {
 	// the buffers.
 	Stop()
 	// Identify updates the user traits.
-	Identify(userID, userKind string, props map[string]any)
+	Identify(props map[string]any)
 	// Track registers an event, caused by the user.
-	Track(event, userID string, props map[string]any)
+	Track(event string, props map[string]any)
 	// Group adds the user to a group, supplying group specific properties.
-	Group(groupID, userID string, props map[string]any)
+	Group(groupID string, props map[string]any)
+
+	// IdentifyUserAs updates the user traits.
+	IdentifyUserAs(userID, clientID, clientType string, props map[string]any)
+	// TrackUserAs registers an event, caused by the user.
+	TrackUserAs(userID, clientID, clientType, event string, props map[string]any)
+	// GroupUserAs adds the user to a group, supplying group specific properties.
+	GroupUserAs(userID, clientID, clientType, groupID string, props map[string]any)
 }
 
 type nilTelemeter struct{}
 
-func (t *nilTelemeter) Stop()                                                  {}
-func (t *nilTelemeter) Identify(userID, userKind string, props map[string]any) {}
-func (t *nilTelemeter) Track(event, userID string, props map[string]any)       {}
-func (t *nilTelemeter) Group(groupID, userID string, props map[string]any)     {}
+func (t *nilTelemeter) Stop()                            {}
+func (t *nilTelemeter) Identify(_ map[string]any)        {}
+func (t *nilTelemeter) Track(_ string, _ map[string]any) {}
+func (t *nilTelemeter) Group(_ string, _ map[string]any) {}
+
+func (t *nilTelemeter) IdentifyUserAs(_, _, _ string, _ map[string]any) {}
+func (t *nilTelemeter) TrackUserAs(_, _, _, _ string, _ map[string]any) {}
+func (t *nilTelemeter) GroupUserAs(_, _, _, _ string, _ map[string]any) {}


### PR DESCRIPTION
## Description

* Add `*UserAs` methods to `Telemeter` interface, to alter UserID and/or set device context for a particular call. This way a central could Identify a secured cluster from its name.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~


## Testing Performed

### Central identity
```json
{
  "context": {
    "Client ID": "6393af03-28ac-4f5f-bf35-b0d10be9f99f",
    "Client Name": "Central",
    "library": {
      "name": "analytics-go",
      "version": "3.0.0"
    }
  },
  "integrations": {},
  "messageId": "97377717-545e-4a41-bbe4-01d29a536c43",
  "originalTimestamp": "2023-01-23T17:51:39.924036459Z",
  "receivedAt": "2023-01-23T17:52:40.666Z",
  "sentAt": "2023-01-23T17:52:39.745Z",
  "timestamp": "2023-01-23T17:51:40.844Z",
  "traits": {
    "Auth Providers": null,
    "Central version": "3.73.x-505-g211a07a034-dirty",
    "Chart version": "73.0.505-g211a07a034-dirty",
    "Kind": "Central",
    "Kubernetes version": "v1.25.3",
    "Orchestrator": "KUBERNETES_CLUSTER",
    "Total Access Scopes": 2,
    "Total PermissionSets": 9,
    "Total Roles": 9,
    "Total Secured Clusters": 1,
    "Total Signature Integrations": 0
  },
  "type": "identify",
  "userId": "6393af03-28ac-4f5f-bf35-b0d10be9f99f",
  "writeKey": "..."
}
```

### Secured Cluster identity
```json
{
  "context": {
    "Client ID": "6393af03-28ac-4f5f-bf35-b0d10be9f99f",
    "Client Name": "Central",
    "library": {
      "name": "analytics-go",
      "version": "3.0.0"
    }
  },
  "integrations": {},
  "messageId": "0b6bf669-4361-435b-ad79-9528a8e84684",
  "originalTimestamp": "2023-01-23T18:01:18.199106737Z",
  "receivedAt": "2023-01-23T18:01:40.408Z",
  "sentAt": "2023-01-23T18:01:39.745Z",
  "timestamp": "2023-01-23T18:01:18.861Z",
  "traits": {
    "Admission Controller": true,
    "CPU Capacity": 8,
    "Cluster Type": "KUBERNETES_CLUSTER",
    "Collection Method": "EBPF",
    "Collector Image": "quay.io/stackrox-io/collector",
    "Kind": "Secured Cluster",
    "Main Image": "quay.io/stackrox-io/main:3.73.x-505-g211a07a034-dirty",
    "Managed By": "MANAGER_TYPE_MANUAL",
    "Priority": 1,
    "Slim Collector": true,
    "Total Nodes": 1
  },
  "type": "identify",
  "userId": "5b72c54b-bd81-416a-86fc-15e63069f969",
  "writeKey": "..."
}
```