### PR TITLE
Specify toggleAriaLabel prop for Select elements in Network Graph

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/common/AdvancedFlowsFilter/AdvancedFlowsFilter.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/common/AdvancedFlowsFilter/AdvancedFlowsFilter.tsx
@@ -98,7 +98,7 @@ function AdvancedFlowsFilter({
                 <Select
                     className="pf-u-px-md"
                     variant={SelectVariant.typeaheadMulti}
-                    aria-label="Select ports"
+                    toggleAriaLabel="Select ports"
                     onToggle={onTogglePortsSelect}
                     onSelect={onSelectPorts}
                     selections={filters.ports}

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/ClusterSelector.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/ClusterSelector.tsx
@@ -51,7 +51,7 @@ function ClusterSelector({
                     <span style={{ position: 'relative', top: '1px' }}>Cluster</span>
                 </span>
             }
-            aria-label="Select a cluster"
+            toggleAriaLabel="Select a cluster"
             onToggle={toggleIsClusterOpen}
             onSelect={onClusterSelect}
             isOpen={isClusterOpen}

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/DeploymentSelector.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/DeploymentSelector.tsx
@@ -84,6 +84,7 @@ function DeploymentSelector({
                     <span style={{ position: 'relative', top: '1px' }}>Deployments</span>
                 </span>
             }
+            toggleAriaLabel="Select deployments"
             isDisabled={deploymentsByNamespace.length === 0}
             selections={selectedDeployments}
             variant={SelectVariant.checkbox}

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/DisplayOptionsSelect.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/DisplayOptionsSelect.tsx
@@ -37,6 +37,7 @@ function DisplayOptionsSelect({ selectedOptions, setSelectedOptions }: DisplayOp
             onSelect={onSelect}
             selections={selectedOptions}
             placeholderText="Display options"
+            toggleAriaLabel="Select display options"
             isGrouped
             id="display-options-dropdown"
         >

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/NamespaceSelector.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/NamespaceSelector.tsx
@@ -117,6 +117,7 @@ function NamespaceSelector({
                     <span style={{ position: 'relative', top: '1px' }}>Namespaces</span>
                 </span>
             }
+            toggleAriaLabel="Select namespaces"
             isDisabled={namespaceSelectOptions.length === 0}
             selections={selectedNamespaces}
             variant={SelectVariant.checkbox}


### PR DESCRIPTION
## Description

An `aria-label` attribute is prerequisite for integration tests.

### Problem

All of the `Select` elements have default `aria-label="Options menu"` attribute.

Although the doc page is not especially clear about which of the various props for which of the various types of `Select` element, `aria-label="Select a cluster"` did not work.

https://www.patternfly.org/v4/components/select#select

### Solution

By reading PatternFly Select.tsx file, verifying the change, and also finding the corresponding props in collections:

1. AdvancedFlowsFilter.tsx
    * Outer element **residue** needs label from someone who knows more than me
    * Inner element `toggleAriaLabel="Select ports"`
2. ClusterSelector.tsx `toggleAriaLabel="Select a cluster"`
3. DeploymentSelector.tsx `toggleAriaLabel="Select deployments"`
4. DisplayOptionsSelect.tsx `toggleAriaLabel="Select display options"`
5. EdgeStateSelect.tsx **residue** needs label from someone who knows more than me
6. NamespaceSelector.tsx `toggleAriaLabel="Select namespaces"`

## Checklist
- [ ] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

Browser Elements panel

Before change with `aria-label` prop:
![aria-label_Options_menu](https://user-images.githubusercontent.com/11862657/214159691-b239a3f4-cdd9-4527-839f-7e54dda4b5c3.png)

After change with `toggleAriaLabel` prop:
![aria-label_Select_a_cluster](https://user-images.githubusercontent.com/11862657/214159678-ee4e2756-8003-41ff-a590-f22b7c3cc506.png)
