### PR TITLE
ROX-14347: Adding baseline simulation to new network graph

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraph.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraph.tsx
@@ -369,9 +369,14 @@ const NetworkGraph = React.memo<NetworkGraphProps>(
                 simulation,
                 clusterId: selectedClusterId,
             });
+        const isSimulating =
+            simulator.state === 'GENERATED' ||
+            simulator.state === 'UNDO' ||
+            simulator.state === 'UPLOAD' ||
+            (simulation.isOn && simulation.type === 'baseline');
 
         return (
-            <SimulationFrame simulator={simulator}>
+            <SimulationFrame isSimulating={isSimulating}>
                 <VisualizationProvider controller={controller}>
                     <TopologyComponent
                         model={model}

--- a/ui/apps/platform/src/Containers/NetworkGraph/common/FlowsTable.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/common/FlowsTable.tsx
@@ -49,18 +49,18 @@ function FlowsTable({
     markAsAnomalous,
 }: FlowsTableProps): ReactElement {
     // getter functions
-    const isRowExpanded = (row: Flow) => expandedRows.includes(row.id);
-    const areAllRowsSelected = selectedRows.length !== 0 && selectedRows.length === numFlows;
-    const isRowSelected = (row: Flow) => selectedRows.includes(row.id);
+    const isRowExpanded = (row: Flow) => expandedRows?.includes(row.id);
+    const areAllRowsSelected = selectedRows?.length !== 0 && selectedRows?.length === numFlows;
+    const isRowSelected = (row: Flow) => selectedRows?.includes(row.id);
 
     // setter functions
     const setRowExpanded = (row: Flow, isExpanding = true) =>
-        setExpandedRows((prevExpanded) => {
+        setExpandedRows?.((prevExpanded) => {
             const otherExpandedRows = prevExpanded.filter((r) => r !== row.id);
             return isExpanding ? [...otherExpandedRows, row.id] : otherExpandedRows;
         });
     const setRowSelected = (row: Flow, isSelecting = true) =>
-        setSelectedRows((prevSelected) => {
+        setSelectedRows?.((prevSelected) => {
             const otherSelectedRows = prevSelected.filter((r) => r !== row.id);
             return isSelecting ? [...otherSelectedRows, row.id] : otherSelectedRows;
         });
@@ -72,9 +72,9 @@ function FlowsTable({
                 }
                 return [...acc, curr.id];
             }, [] as string[]);
-            return setSelectedRows(newSelectedRows);
+            return setSelectedRows?.(newSelectedRows);
         }
-        return setSelectedRows([]);
+        return setSelectedRows?.([]);
     };
 
     return (

--- a/ui/apps/platform/src/Containers/NetworkGraph/common/FlowsTableHeaderText.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/common/FlowsTableHeaderText.tsx
@@ -2,7 +2,7 @@ import React, { ReactElement } from 'react';
 import { Text, TextContent, TextVariants } from '@patternfly/react-core';
 
 type FlowsTableHeaderTextProps = {
-    type: 'baseline' | 'active' | 'extraneous';
+    type: 'baseline' | 'active' | 'extraneous' | 'baseline simulated';
     numFlows: number;
 };
 

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentBaselines.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentBaselines.tsx
@@ -3,7 +3,6 @@ import {
     Alert,
     AlertVariant,
     Bullseye,
-    Button,
     Checkbox,
     Divider,
     Flex,
@@ -33,6 +32,7 @@ import useFetchNetworkBaselines from '../api/useFetchNetworkBaselines';
 import { Flow } from '../types/flow.type';
 import useModifyBaselineStatuses from '../api/useModifyBaselineStatuses';
 import useToggleAlertingOnBaselineViolation from '../api/useToggleAlertingOnBaselineViolation';
+import SimulateBaselinesButton from './SimulateBaselinesButton';
 
 type DeploymentBaselinesProps = {
     deploymentId: string;
@@ -217,7 +217,7 @@ function DeploymentBaselines({ deploymentId }: DeploymentBaselinesProps) {
                             />
                         </FlexItem>
                         <FlexItem>
-                            <Button variant="primary">Simulate baseline as network policy</Button>
+                            <SimulateBaselinesButton />
                         </FlexItem>
                     </Flex>
                 </StackItem>

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentBaselinesSimulated.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentBaselinesSimulated.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import {
+    Alert,
+    AlertVariant,
+    Bullseye,
+    Divider,
+    Spinner,
+    Stack,
+    StackItem,
+    Toolbar,
+    ToolbarContent,
+    ToolbarItem,
+} from '@patternfly/react-core';
+
+import { getNumFlows } from '../utils/flowUtils';
+
+import FlowsTable from '../common/FlowsTable';
+import FlowsTableHeaderText from '../common/FlowsTableHeaderText';
+import { Flow } from '../types/flow.type';
+
+type DeploymentBaselinesSimulatedProps = {
+    deploymentId: string;
+};
+
+function DeploymentBaselinesSimulated({ deploymentId }: DeploymentBaselinesSimulatedProps) {
+    // component state
+    const networkSimulatedBaselines: Flow[] = [];
+    const isLoading = false;
+    const error = '';
+
+    const initialExpandedRows = networkSimulatedBaselines
+        .filter((row) => row.children && !!row.children.length)
+        .map((row) => row.id); // Default to all expanded
+    const [expandedRows, setExpandedRows] = React.useState<string[]>(initialExpandedRows);
+    const [selectedRows, setSelectedRows] = React.useState<string[]>([]);
+
+    // derived data
+    const numBaselines = getNumFlows(networkSimulatedBaselines);
+
+    if (isLoading) {
+        return (
+            <Bullseye>
+                <Spinner isSVG size="lg" />
+            </Bullseye>
+        );
+    }
+
+    return (
+        <div className="pf-u-h-100">
+            {error && (
+                <Alert
+                    isInline
+                    variant={AlertVariant.danger}
+                    title={error}
+                    className="pf-u-mb-sm"
+                />
+            )}
+            <Stack hasGutter className="pf-u-p-md">
+                <StackItem>
+                    <Toolbar>
+                        <ToolbarContent>
+                            <ToolbarItem>
+                                <FlowsTableHeaderText
+                                    type="baseline simulated"
+                                    numFlows={numBaselines}
+                                />
+                            </ToolbarItem>
+                        </ToolbarContent>
+                    </Toolbar>
+                </StackItem>
+                <Divider component="hr" />
+                <StackItem>
+                    <FlowsTable
+                        label="Deployment simulated baselines"
+                        flows={networkSimulatedBaselines}
+                        numFlows={numBaselines}
+                        expandedRows={expandedRows}
+                        setExpandedRows={setExpandedRows}
+                        selectedRows={selectedRows}
+                        setSelectedRows={setSelectedRows}
+                        isEditable={false}
+                    />
+                </StackItem>
+            </Stack>
+        </div>
+    );
+}
+
+export default DeploymentBaselinesSimulated;

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentBaselinesSimulated.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentBaselinesSimulated.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {
     Alert,
     AlertVariant,
@@ -22,6 +22,7 @@ type DeploymentBaselinesSimulatedProps = {
     deploymentId: string;
 };
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function DeploymentBaselinesSimulated({ deploymentId }: DeploymentBaselinesSimulatedProps) {
     // component state
     const networkSimulatedBaselines: Flow[] = [];
@@ -31,8 +32,8 @@ function DeploymentBaselinesSimulated({ deploymentId }: DeploymentBaselinesSimul
     const initialExpandedRows = networkSimulatedBaselines
         .filter((row) => row.children && !!row.children.length)
         .map((row) => row.id); // Default to all expanded
-    const [expandedRows, setExpandedRows] = React.useState<string[]>(initialExpandedRows);
-    const [selectedRows, setSelectedRows] = React.useState<string[]>([]);
+    const [expandedRows, setExpandedRows] = useState<string[]>(initialExpandedRows);
+    const [selectedRows, setSelectedRows] = useState<string[]>([]);
 
     // derived data
     const numBaselines = getNumFlows(networkSimulatedBaselines);

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentSideBar.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentSideBar.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import {
     Alert,
     AlertVariant,
@@ -32,6 +32,8 @@ import DeploymentDetails from './DeploymentDetails';
 import DeploymentFlows from './DeploymentFlows';
 import DeploymentBaselines from './DeploymentBaselines';
 import NetworkPolicies from '../common/NetworkPolicies';
+import useSimulation from '../hooks/useSimulation';
+import DeploymentBaselinesSimulated from './DeploymentBaselinesSimulated';
 
 type DeploymentSideBarProps = {
     deploymentId: string;
@@ -42,9 +44,17 @@ type DeploymentSideBarProps = {
 function DeploymentSideBar({ deploymentId, nodes, edges }: DeploymentSideBarProps) {
     // component state
     const { deployment, isLoading, error } = useFetchDeployment(deploymentId);
-    const { activeKeyTab, onSelectTab } = useTabs({
+    const { activeKeyTab, onSelectTab, setActiveKeyTab } = useTabs({
         defaultTab: 'Details',
     });
+    const { simulation } = useSimulation();
+    const isBaselineSimulationOn = simulation.isOn && simulation.type === 'baseline';
+
+    useEffect(() => {
+        if (isBaselineSimulationOn) {
+            setActiveKeyTab('Baselines');
+        }
+    }, [isBaselineSimulationOn, setActiveKeyTab]);
 
     // derived values
     const deploymentNode = getNodeById(nodes, deploymentId);
@@ -98,11 +108,13 @@ function DeploymentSideBar({ deploymentId, nodes, edges }: DeploymentSideBarProp
                         eventKey="Details"
                         tabContentId="Details"
                         title={<TabTitleText>Details</TabTitleText>}
+                        disabled={isBaselineSimulationOn}
                     />
                     <Tab
                         eventKey="Flows"
                         tabContentId="Flows"
                         title={<TabTitleText>Flows</TabTitleText>}
+                        disabled={isBaselineSimulationOn}
                     />
                     <Tab
                         eventKey="Baselines"
@@ -113,6 +125,7 @@ function DeploymentSideBar({ deploymentId, nodes, edges }: DeploymentSideBarProp
                         eventKey="Network policies"
                         tabContentId="Network policies"
                         title={<TabTitleText>Network policies</TabTitleText>}
+                        disabled={isBaselineSimulationOn}
                     />
                 </Tabs>
             </StackItem>
@@ -136,7 +149,11 @@ function DeploymentSideBar({ deploymentId, nodes, edges }: DeploymentSideBarProp
                     hidden={activeKeyTab !== 'Baselines'}
                     className="pf-u-h-100"
                 >
-                    <DeploymentBaselines deploymentId={deploymentId} />
+                    {isBaselineSimulationOn ? (
+                        <DeploymentBaselinesSimulated deploymentId={deploymentId} />
+                    ) : (
+                        <DeploymentBaselines deploymentId={deploymentId} />
+                    )}
                 </TabContent>
                 <TabContent
                     eventKey="Network policies"

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/SimulateBaselinesButton.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/SimulateBaselinesButton.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Button } from '@patternfly/react-core';
+
+import useSimulation from '../hooks/useSimulation';
+
+function SimulateBaselinesButton() {
+    const { simulation, setSimulation } = useSimulation();
+
+    function enableBaselineSimulation() {
+        setSimulation('baseline');
+    }
+
+    return (
+        <Button variant="primary" isDisabled={simulation.isOn} onClick={enableBaselineSimulation}>
+            Simulate baseline as network policy
+        </Button>
+    );
+}
+
+export default SimulateBaselinesButton;

--- a/ui/apps/platform/src/Containers/NetworkGraph/hooks/useSimulation.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/hooks/useSimulation.ts
@@ -1,0 +1,23 @@
+import useURLParameter from 'hooks/useURLParameter';
+import getSimulation, { Simulation, SimulationType } from '../utils/getSimulation';
+
+export type UseSimulationResult = {
+    simulation: Simulation;
+    setSimulation: (type: SimulationType) => void;
+};
+
+function useSimulation() {
+    const [simulationQueryValue, setSimulationQueryValue] = useURLParameter(
+        'simulation',
+        undefined
+    );
+    const simulation = getSimulation(simulationQueryValue);
+    return {
+        simulation,
+        setSimulation: (type: SimulationType) => {
+            setSimulationQueryValue(type);
+        },
+    };
+}
+
+export default useSimulation;

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/SimulationFrame.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/SimulationFrame.tsx
@@ -2,19 +2,13 @@ import React from 'react';
 import { ScreenIcon } from '@patternfly/react-icons';
 
 import { Flex, FlexItem } from '@patternfly/react-core';
-import { NetworkPolicySimulator } from '../hooks/useNetworkPolicySimulator';
 
 type SimulationFrameProps = {
-    simulator: NetworkPolicySimulator;
+    isSimulating: boolean;
     children: React.ReactNode;
 };
 
-function SimulationFrame({ simulator, children }: SimulationFrameProps) {
-    const isSimulating =
-        simulator.state === 'GENERATED' ||
-        simulator.state === 'UNDO' ||
-        simulator.state === 'UPLOAD';
-
+function SimulationFrame({ isSimulating, children }: SimulationFrameProps) {
     let style = {};
     if (isSimulating) {
         style = { position: 'relative', border: '5px solid rgb(115,188,247)' };

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/getSimulation.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/getSimulation.ts
@@ -1,8 +1,10 @@
 import { QueryValue } from 'hooks/useURLParameter';
 
+export type SimulationType = 'baseline' | 'networkPolicy';
+
 type SimulationOn = {
     isOn: true;
-    type: 'baseline' | 'networkPolicy';
+    type: SimulationType;
 };
 
 type SimulationOff = {


### PR DESCRIPTION
## Description

This PR starts off the addition of the baseline simulation in the network graph. I've divided the work further so we can merge things in iteratively

<img width="1440" alt="Screenshot 2023-01-23 at 2 54 50 PM" src="https://user-images.githubusercontent.com/4805485/214171205-2a8d94f0-9974-4b25-94bb-bcdef962184b.png">


## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~
