### PR TITLE
ROX-12632: Add vulnerability report with collections E2E test

### DIFF
--- a/qa-tests-backend/src/main/groovy/services/CollectionsService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/CollectionsService.groovy
@@ -1,0 +1,60 @@
+package services
+
+import groovy.util.logging.Slf4j
+
+import io.stackrox.proto.api.v1.CollectionServiceGrpc
+import io.stackrox.proto.api.v1.Common
+import io.stackrox.proto.api.v1.ResourceCollectionService
+import io.stackrox.proto.storage.PolicyOuterClass
+import io.stackrox.proto.storage.ResourceCollectionOuterClass
+
+@Slf4j
+class CollectionsService extends BaseService {
+
+    static getClient() {
+        return CollectionServiceGrpc.newBlockingStub(getChannel())
+    }
+
+    // Create a collection that matches the chosen deployment in the chosen namespaces
+    // If no deployments or ns are provided, select all.
+    // TODO: support embedded, regex, labels
+    static ResourceCollectionOuterClass.ResourceCollection createCollection(List<String> deployments,
+                                                                            List<String> namespaces) {
+        def selector = ResourceCollectionOuterClass.ResourceSelector.newBuilder()
+
+        if (deployments.size() > 0) {
+            def rule = ResourceCollectionOuterClass.SelectorRule.newBuilder()
+                    .setFieldName("Deployment")
+                    .setOperator(PolicyOuterClass.BooleanOperator.OR)
+            deployments.each {
+                rule.addValues(
+                        ResourceCollectionOuterClass.RuleValue.newBuilder().setValue(it)
+                                .setMatchType(ResourceCollectionOuterClass.MatchType.EXACT)
+                )
+            }
+            selector.addRules(rule)
+        }
+
+        if (namespaces.size() > 0) {
+            def rule = ResourceCollectionOuterClass.SelectorRule.newBuilder()
+                    .setFieldName("Namespace")
+                    .setOperator(PolicyOuterClass.BooleanOperator.OR)
+            namespaces.each {
+                rule.addValues(
+                        ResourceCollectionOuterClass.RuleValue.newBuilder().setValue(it)
+                                .setMatchType(ResourceCollectionOuterClass.MatchType.EXACT)
+                )
+            }
+            selector.addRules(rule)
+        }
+
+        def req = ResourceCollectionService.CreateCollectionRequest.newBuilder()
+                .setName("Test Collections")
+                .addResourceSelectors(selector)
+        return getClient().createCollection(req.build()).getCollection()
+    }
+
+    static deleteCollection(String collectionId) {
+        getClient().deleteCollection(Common.ResourceByID.newBuilder().setId(collectionId).build())
+    }
+}

--- a/qa-tests-backend/src/main/groovy/services/VulnReportService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/VulnReportService.groovy
@@ -1,0 +1,71 @@
+package services
+
+import groovy.util.logging.Slf4j
+
+import io.stackrox.proto.api.v1.Common
+import io.stackrox.proto.api.v1.ReportConfigurationServiceGrpc
+import io.stackrox.proto.api.v1.ReportConfigurationServiceOuterClass
+import io.stackrox.proto.api.v1.ReportServiceGrpc
+import io.stackrox.proto.storage.Cve
+import io.stackrox.proto.storage.ReportConfigurationOuterClass
+import io.stackrox.proto.storage.ScheduleOuterClass
+
+import common.Constants
+
+@Slf4j
+class VulnReportService extends BaseService {
+
+    private static final ALL_SEVERITIES = [
+            Cve.VulnerabilitySeverity.CRITICAL_VULNERABILITY_SEVERITY,
+            Cve.VulnerabilitySeverity.IMPORTANT_VULNERABILITY_SEVERITY,
+            Cve.VulnerabilitySeverity.MODERATE_VULNERABILITY_SEVERITY,
+            Cve.VulnerabilitySeverity.LOW_VULNERABILITY_SEVERITY,
+    ]
+
+    static getConfigClient() {
+        return ReportConfigurationServiceGrpc.newBlockingStub(getChannel())
+    }
+
+    static getReportSvcClient() {
+        return ReportServiceGrpc.newBlockingStub(getChannel())
+    }
+
+    // Create a vulnerability report config whose scope is the specified collection
+    // and uses the specified notifier to send the report
+    static ReportConfigurationOuterClass.ReportConfiguration createVulnReportConfig(
+            String collectionId,
+            String notifierId) {
+        def req = ReportConfigurationServiceOuterClass.PostReportConfigurationRequest.newBuilder()
+        .setReportConfig(ReportConfigurationOuterClass.ReportConfiguration.newBuilder()
+                .setName("Test Vuln Report")
+                .setType(ReportConfigurationOuterClass.ReportConfiguration.ReportType.VULNERABILITY)
+                .setVulnReportFilters(ReportConfigurationOuterClass.VulnerabilityReportFilters.newBuilder()
+                    .setFixability(ReportConfigurationOuterClass.VulnerabilityReportFilters.Fixability.BOTH)
+                    .setSinceLastReport(false)
+                    .addAllSeverities(ALL_SEVERITIES))
+                .setScopeId(collectionId)
+                .setEmailConfig(ReportConfigurationOuterClass.EmailNotifierConfiguration.newBuilder()
+                    .setNotifierId(notifierId)
+                    .addMailingLists(Constants.EMAIL_NOTIFER_SENDER))
+                .setSchedule(ScheduleOuterClass.Schedule.newBuilder()
+                    .setIntervalType(ScheduleOuterClass.Schedule.IntervalType.WEEKLY)
+                    .setHour(0)
+                    .setMinute(0)
+                    .setDaysOfWeek(ScheduleOuterClass.Schedule.DaysOfWeek.newBuilder().addDays(1)))
+        )
+        return getConfigClient().postReportConfiguration(req.build()).getReportConfig()
+    }
+
+    static deleteVulnReportConfig(String reportId) {
+        getConfigClient().deleteReportConfiguration(Common.ResourceByID.newBuilder().setId(reportId).build())
+    }
+
+    static boolean runReport(String reportConfigId) {
+        try {
+            getReportSvcClient().runReport(Common.ResourceByID.newBuilder().setId(reportConfigId).build())
+        } catch (Exception e) {
+            log.error("error running report with id " + reportConfigId, e)
+            return false
+        }
+    }
+}

--- a/qa-tests-backend/src/test/groovy/VulnReportingTest.groovy
+++ b/qa-tests-backend/src/test/groovy/VulnReportingTest.groovy
@@ -110,7 +110,7 @@ class VulnReportingTest extends BaseSpecification  {
 
         // Since this is a BAT test, keep it simple and only validate we got the attachment and it's not 0 bytes
         Object[] attachments = email["attachments"]
-        assert attachments.size() >= 2
+        assert attachments.size() >= 2 // First attachment is the logo image, 2nd is the report
 
         def csvAttachmentMetadata = attachments.find {
             it["fileName"] =~ /(StackRox|RHACS)_Vulnerability_Report_(\d+)_(.*)_(\d+).zip/

--- a/qa-tests-backend/src/test/groovy/VulnReportingTest.groovy
+++ b/qa-tests-backend/src/test/groovy/VulnReportingTest.groovy
@@ -1,0 +1,171 @@
+import java.util.zip.ZipEntry
+import java.util.zip.ZipInputStream
+
+import com.opencsv.CSVReader
+
+import io.stackrox.proto.storage.NotifierOuterClass
+
+import common.Constants
+import objects.Deployment
+import objects.EmailNotifier
+import services.CollectionsService
+import services.FeatureFlagService
+import services.VulnReportService
+import util.MailServer
+
+import org.junit.Assume
+import spock.lang.Shared
+import spock.lang.Tag
+
+class VulnReportingTest extends BaseSpecification  {
+
+    static final private String SECONDARY_NAMESPACE = "vulnreport-2nd-namespace"
+    static final private List<Deployment> DEPLOYMENTS = [
+            new Deployment()
+                    .setName("struts-deployment")
+                    .setNamespace(Constants.ORCHESTRATOR_NAMESPACE)
+                    .setImage("quay.io/rhacs-eng/qa:struts-app")
+                    .addLabel("app", "struts-test"),
+            new Deployment()
+                    .setName("registry-deployment")
+                    .setNamespace(SECONDARY_NAMESPACE)
+                    .setImage("quay.io/rhacs-eng/qa:registry-image-0-4")
+                    .addLabel("app", "registry-image-test")
+            // Use these if you want to actually test what the value of the report CSV is
+//            new Deployment()
+//                    .setName("nginx-deployment")
+//                    .setNamespace(Constants.ORCHESTRATOR_NAMESPACE)
+//                    .setImage("quay.io/rhacs-eng/qa:nginx-1-9")
+//                    .addLabel("app", "nginx-test"),
+//            new Deployment()
+//                    .setName("nginx-deployment")
+//                    .setNamespace(SECONDARY_NAMESPACE)
+//                    .setImage("quay.io/rhacs-eng/qa:nginx-1-9")
+//                    .addLabel("app", "nginx-test"),
+    ]
+
+    @Shared
+    private MailServer mailServer
+
+    def setupSpec() {
+        mailServer = MailServer.createMailServer(orchestrator, true, false)
+        sleep 15 * 1000 // wait 15s for service to start
+
+        orchestrator.ensureNamespaceExists(SECONDARY_NAMESPACE)
+        orchestrator.batchCreateDeployments(DEPLOYMENTS)
+        DEPLOYMENTS.each { Services.waitForDeployment(it) }
+    }
+
+    def cleanupSpec() {
+        if (mailServer) {
+            mailServer.teardown(orchestrator)
+        }
+
+        DEPLOYMENTS.each { orchestrator.deleteDeployment(it) }
+        orchestrator.deleteNamespace(SECONDARY_NAMESPACE)
+    }
+
+    @Tag("BAT")
+    def "Verify vulnerability generated using a collection sends an email with a valid report attachment"() {
+        given:
+        "Collections feature is enabled and is central running on postgres"
+        Assume.assumeTrue(FeatureFlagService.isFeatureFlagEnabled("ROX_OBJECT_COLLECTIONS"))
+        Assume.assumeTrue(isPostgresRun())
+
+        and:
+        "a an email notifier is configured"
+        EmailNotifier notifier = new EmailNotifier("Vuln Reports Notifier",
+                mailServer.smtpUrl(),
+                true, true, NotifierOuterClass.Email.AuthMethod.DISABLED)
+        notifier.createNotifier()
+        assert notifier.id
+
+        and:
+        "a collection is created"
+        def collection = CollectionsService.createCollection(["struts-deployment"],
+                [Constants.ORCHESTRATOR_NAMESPACE])
+        assert collection.id
+
+        and:
+        "a report is configured"
+        def report = VulnReportService.createVulnReportConfig(collection.id, notifier.id)
+        assert report.id
+
+        when:
+        "a report is generated"
+        assert VulnReportService.runReport(report.id)
+
+        then:
+        "the email server should've gotten an email with the report"
+
+        def emails = mailServer.findEmailsByToEmail(Constants.EMAIL_NOTIFER_SENDER)
+        assert emails.size() == 1
+
+        def email = emails[0]
+        def emailId = (String) email["id"]
+
+        assert emailId
+        assert email["subject"] =~ /(StackRox|RHACS) Image Vulnerability Report for (\d+)-(.*)-(\d+)/
+        assert email["html"] =~ /has found vulnerabilities/
+
+        // Since this is a BAT test, keep it simple and only validate we got the attachment and it's not 0 bytes
+        Object[] attachments = email["attachments"]
+        assert attachments.size() >= 2
+
+        def csvAttachmentMetadata = attachments.find {
+            it["fileName"] =~ /(StackRox|RHACS)_Vulnerability_Report_(\d+)_(.*)_(\d+).zip/
+        }
+        assert csvAttachmentMetadata["fileName"]
+        assert csvAttachmentMetadata["length"] > 0
+
+        cleanup:
+        "Cleanup resources"
+        if (email) {
+            mailServer.deleteEmail(emailId)
+        }
+        if (notifier) {
+            notifier.deleteNotifier()
+        }
+        if (collection) {
+            CollectionsService.deleteCollection(collection.id)
+        }
+        if (report) {
+            VulnReportService.deleteVulnReportConfig(report.id)
+        }
+    }
+
+    private List<String[]> getReportCSVFromAttachments(Object csvAttachmentMetadata, String emailId) {
+        def csv = mailServer.downloadEmailAttachment(emailId, (String) csvAttachmentMetadata["fileName"])
+
+        byte[] csvData
+        try (def zis = new ZipInputStream(csv)) {
+            ZipEntry entry
+            while ((entry = zis.nextEntry) != null) {
+                log.info "Found file ${entry.name}"
+                if (entry.name =~ /(StackRox|RHACS)_Vulnerability_Report_(\d+)_(.*)_(\d+).csv/) {
+                    try (def csvByteStream = new ByteArrayOutputStream()) {
+                        for (int c = zis.read(); c != -1; c = zis.read()) {
+                            csvByteStream.write(c)
+                        }
+                        csvData = csvByteStream.toByteArray()
+                    } catch (Exception e) {
+                        log.error("Could not extract csv from zip", e)
+                    }
+                }
+            }
+        } catch (Exception e) {
+            log.error("Could not extract csv from zip", e)
+        }
+        assert csvData && csvData.size() > 0
+
+        List<String[]> lines = []
+        try (def bis = new ByteArrayInputStream(csvData);
+             def isr = new InputStreamReader(bis);
+             def reader = new CSVReader(isr)) {
+            lines = reader.readAll()
+        } catch (Exception e) {
+            log.error("Could not read attachment as CSV", e)
+        }
+        lines
+    }
+}

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -87,6 +87,7 @@ export_test_environment() {
     ci_export ROX_SEARCH_PAGE_UI "${ROX_SEARCH_PAGE_UI:-true}"
     ci_export ROX_SYSTEM_HEALTH_PF "${ROX_SYSTEM_HEALTH_PF:-true}"
     ci_export ROX_SYSLOG_EXTRA_FIELDS "${ROX_SYSLOG_EXTRA_FIELDS:-true}"
+    ci_export ROX_OBJECT_COLLECTIONS "${ROX_OBJECT_COLLECTIONS:-true}"
 }
 
 deploy_central() {


### PR DESCRIPTION
## Description

Adds a simple E2E test that tests that vuln reports generates a report given a collection and sends an email with it the report attached as a CVE. For now it just verifies the email was sent and has an attachment to keep the BAT tests simple and fast. Another test (or more) can be added later that'll run only in the nightlies which would actually parse the CSV.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
~[ ] Evaluated and added CHANGELOG entry if required~
~[ ] Determined and documented upgrade steps~
~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

this is a test

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
