### PR TITLE
ROX-14335: Remediate bug and verify in operator upgrade test

### DIFF
--- a/operator/tests/common/upgrade-assert.envsubst.yaml
+++ b/operator/tests/common/upgrade-assert.envsubst.yaml
@@ -23,6 +23,22 @@ metadata:
 status:
   availableReplicas: 1
 ---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: stackrox-db
+  ownerReferences:
+  - apiVersion: platform.stackrox.io/v1alpha1
+    kind: Central
+    name: stackrox-central-services
+    controller: true
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Gi
+---
 apiVersion: platform.stackrox.io/v1alpha1
 kind: SecuredCluster
 metadata:

--- a/operator/tests/upgrade/upgrade/20-upgrade-operator.yaml
+++ b/operator/tests/upgrade/upgrade/20-upgrade-operator.yaml
@@ -18,5 +18,7 @@ commands:
       | jq '{"metadata":{"ownerReferences": [{"apiVersion": "platform.stackrox.io/v1alpha1","blockOwnerDeletion": true,"controller": true,"kind": "Central","name": .metadata.name, "uid": .metadata.uid}]}}' \
       > "${patch_file}"
     jq . < "${patch_file}" # make sure it looks sane
+    echo Before patch: && kubectl get -n "${ns}" pvc "${pvc_name}" -o json  # Additional debug output
     kubectl patch -n "${ns}" pvc "${pvc_name}" --patch-file="${patch_file}"
+    echo After patch:  && kubectl get -n "${ns}" pvc "${pvc_name}" -o json  # Additional debug output
     rm "${patch_file}"

--- a/operator/tests/upgrade/upgrade/20-upgrade-operator.yaml
+++ b/operator/tests/upgrade/upgrade/20-upgrade-operator.yaml
@@ -5,3 +5,16 @@ commands:
 # from the parent make: the namespace and operator version string (which are arguments to upgrade script).
 - script: make -C ../../.. upgrade-via-olm
   timeout: 600
+# Recover from ROX-14335:
+# Can be removed well after release 3.73.x is not supported.
+- script: |
+    ns=$NAMESPACE
+    # From 05-central-cr.yaml:
+    central_name="stackrox-central-services"
+
+    patch_file="$(mktemp)"
+    pvc_name="$(kubectl get -n "${ns}" central.platform.stackrox.io "${central_name}" -o json | jq -r '.spec?.central?.persistence?.persistentVolumeClaim?.claimName // "stackrox-db"'
+    kubectl get -n "${ns}" central.platform.stackrox.io "${central_name}" -o json | jq '{"metadata":{"ownerReferences": [{"apiVersion": "platform.stackrox.io/v1alpha1","blockOwnerDeletion": true,"controller": true,"kind": "Central","name": .metadata.name, "uid": .metadata.uid}]}}' > "${patch_file}"
+    jq . < "${patch_file}" # make sure it looks sane
+    kubectl patch -n "${ns}" pvc "${pvc_name}" --patch-file="${patch_file}"
+    rm "${patch_file}"

--- a/operator/tests/upgrade/upgrade/20-upgrade-operator.yaml
+++ b/operator/tests/upgrade/upgrade/20-upgrade-operator.yaml
@@ -13,7 +13,7 @@ commands:
     central_name="stackrox-central-services"
 
     patch_file="$(mktemp)"
-    pvc_name="$(kubectl get -n "${ns}" central.platform.stackrox.io "${central_name}" -o json | jq -r '.spec?.central?.persistence?.persistentVolumeClaim?.claimName // "stackrox-db"'
+    pvc_name="$(kubectl get -n "${ns}" central.platform.stackrox.io "${central_name}" -o json | jq -r '.spec?.central?.persistence?.persistentVolumeClaim?.claimName // "stackrox-db"')"
     kubectl get -n "${ns}" central.platform.stackrox.io "${central_name}" -o json \
       | jq '{"metadata":{"ownerReferences": [{"apiVersion": "platform.stackrox.io/v1alpha1","blockOwnerDeletion": true,"controller": true,"kind": "Central","name": .metadata.name, "uid": .metadata.uid}]}}' \
       > "${patch_file}"

--- a/operator/tests/upgrade/upgrade/20-upgrade-operator.yaml
+++ b/operator/tests/upgrade/upgrade/20-upgrade-operator.yaml
@@ -14,7 +14,9 @@ commands:
 
     patch_file="$(mktemp)"
     pvc_name="$(kubectl get -n "${ns}" central.platform.stackrox.io "${central_name}" -o json | jq -r '.spec?.central?.persistence?.persistentVolumeClaim?.claimName // "stackrox-db"'
-    kubectl get -n "${ns}" central.platform.stackrox.io "${central_name}" -o json | jq '{"metadata":{"ownerReferences": [{"apiVersion": "platform.stackrox.io/v1alpha1","blockOwnerDeletion": true,"controller": true,"kind": "Central","name": .metadata.name, "uid": .metadata.uid}]}}' > "${patch_file}"
+    kubectl get -n "${ns}" central.platform.stackrox.io "${central_name}" -o json \
+      | jq '{"metadata":{"ownerReferences": [{"apiVersion": "platform.stackrox.io/v1alpha1","blockOwnerDeletion": true,"controller": true,"kind": "Central","name": .metadata.name, "uid": .metadata.uid}]}}' \
+      > "${patch_file}"
     jq . < "${patch_file}" # make sure it looks sane
     kubectl patch -n "${ns}" pvc "${pvc_name}" --patch-file="${patch_file}"
     rm "${patch_file}"


### PR DESCRIPTION
## Description

Followup to #4508 that tests the manual remediation instructions.
In a separate PR at least for now, since this can be iterated on as a followup from the fix.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Checked the debug output in the remediation step to make sure the PVC is as expected before and after the patch
- [x] Unit test and regression tests added
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] Determined and documented upgrade steps
- [x] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

Actually the remediation commands are a no-op, because 3.74.x was still not tagged, and thus the "previous version" is still considered to be 3.72 which does not have the bug. But this will change as soon as the 3.74.x tag is created.

The last two checkboxes are being discussed in the ticket.

## Testing Performed

Ran the script manually and inspected output.
Otherwise CI plus the check mentioned above should be sufficient.