### PR TITLE
Re-enable collections e2e test for deployment matching

### DIFF
--- a/ui/apps/platform/cypress/integration/collections/deploymentMatching.test.js
+++ b/ui/apps/platform/cypress/integration/collections/deploymentMatching.test.js
@@ -86,8 +86,14 @@ describe('Collection deployment matching', () => {
         assertDeploymentsAreMatched(['calico-node']);
         assertDeploymentsAreNotMatched(['kube-dns']);
 
-        // View more and ensure the next page loads
+        // target `kube-dns` deployment is on the second or third page of results, so load three pages
+        // to ensure it is visible
         cy.get(selectors.viewMoreResultsButton).scrollIntoView();
+
+        // load second page of results
+        cy.get(selectors.viewMoreResultsButton).click();
+        cy.get(`${selectors.viewMoreResultsButton}:not(.pf-m-in-progress)`).scrollIntoView();
+        // load third page of results
         cy.get(selectors.viewMoreResultsButton).click();
         cy.get(`${selectors.viewMoreResultsButton}:not(.pf-m-in-progress)`).scrollIntoView();
         assertDeploymentsAreMatched(['kube-dns']);

--- a/ui/apps/platform/cypress/integration/collections/deploymentMatching.test.js
+++ b/ui/apps/platform/cypress/integration/collections/deploymentMatching.test.js
@@ -67,7 +67,7 @@ describe('Collection deployment matching', () => {
 
     // This test relies on the creation of a collection in the previous test in order to check
     // the resolution of deployments with embedded collections.
-    it.skip('should preview deployments using embedded collections', () => {
+    it('should preview deployments using embedded collections', () => {
         // Cleanup from potential previous test runs
         tryDeleteCollection(withEmbeddedCollectionName);
         visitCollections();
@@ -87,12 +87,9 @@ describe('Collection deployment matching', () => {
         assertDeploymentsAreNotMatched(['kube-dns']);
 
         // View more and ensure the next page loads
-        cy.get(`${selectors.resultsPanel} > div:last-child`).scrollTo('bottom');
+        cy.get(selectors.viewMoreResultsButton).scrollIntoView();
         cy.get(selectors.viewMoreResultsButton).click();
-        // Scroll to the bottom once the view more has completed
-        cy.get(`${selectors.viewMoreResultsButton}.pf-m-in-progress`);
-        cy.get(`${selectors.viewMoreResultsButton}:not(.pf-m-in-progress)`);
-        cy.get(`${selectors.resultsPanel} > div:last-child`).scrollTo('bottom');
+        cy.get(`${selectors.viewMoreResultsButton}:not(.pf-m-in-progress)`).scrollIntoView();
         assertDeploymentsAreMatched(['kube-dns']);
 
         // Restrict collection to two specific deployments
@@ -140,7 +137,7 @@ describe('Collection deployment matching', () => {
         cy.get(`td[data-label="Collection"] a:contains("${withEmbeddedCollectionName}")`);
     });
 
-    it.skip('should filter deployment results in the sidebar', () => {
+    it('should filter deployment results in the sidebar', () => {
         visitCollections();
         cy.get(`td[data-label="Collection"] a:contains("${withEmbeddedCollectionName}")`).click();
 

--- a/ui/apps/platform/src/Containers/Collections/CollectionResults.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionResults.tsx
@@ -11,7 +11,6 @@ import {
     SearchInput,
     SelectOption,
     Skeleton,
-    Spinner,
     Text,
     Title,
 } from '@patternfly/react-core';

--- a/ui/apps/platform/src/Containers/Collections/CollectionResults.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionResults.tsx
@@ -178,7 +178,6 @@ function CollectionResults({
                         {Array.from(Array(10).keys()).map((index: number) => (
                             <DeploymentSkeleton key={`refreshing-deployment-${index}`} />
                         ))}
-                        <Spinner className="pf-u-align-self-center" size="lg" />
                     </>
                 ) : (
                     <>
@@ -192,7 +191,7 @@ function CollectionResults({
                                 variant="link"
                                 isInline
                                 className="pf-u-text-align-center"
-                                isLoading={isFetchingNextPage || isRefreshingResults}
+                                isLoading={isFetchingNextPage}
                                 onClick={() => fetchNextPage(true)}
                             >
                                 View more


### PR DESCRIPTION
## Description

Simplifies the selector assertions for deployment matching tests that were causing test flakes.

Additionally, this removes a couple of pieces of the code that were redundant in the collection results sidebar.

- [x] Note to self - check central logs after e2e run.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Verify CI results.
