### PR TITLE
ROX-14514: Add functionality to get simulated baselines

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/api/useFetchSimulatedBaselines.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/api/useFetchSimulatedBaselines.ts
@@ -1,0 +1,114 @@
+import { useEffect, useState } from 'react';
+
+import { fetchBaselineComparison } from 'services/NetworkService';
+import { GroupedDiffFlows, DiffFlowsResponse } from 'types/networkPolicyService';
+import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
+import { Flow } from '../types/flow.type';
+import { createFlowsFromGroupedDiffFlows } from '../utils/flowUtils';
+
+type Result = {
+    isLoading: boolean;
+    data: { simulatedBaselines: Flow[] };
+    error: string;
+};
+
+type FetchSimulatedBaselinesResult = {
+    refetchSimulatedBaselines: () => void;
+} & Result;
+
+const defaultResultState = {
+    isLoading: true,
+    data: { simulatedBaselines: [] },
+    error: '',
+};
+
+function useFetchSimulatedBaselines(deploymentId): FetchSimulatedBaselinesResult {
+    const [result, setResult] = useState<Result>(defaultResultState);
+
+    function fetchSimulatedBaselines() {
+        fetchBaselineComparison({ deploymentId })
+            .then((response: DiffFlowsResponse) => {
+                let simulatedBaselines: Flow[] = [];
+
+                // get added baselines
+                const addedBaselines = response.added.reduce((acc, currGroupedDiffFlow) => {
+                    const flows = createFlowsFromGroupedDiffFlows(currGroupedDiffFlow, 'ADDED');
+                    return [...acc, ...flows];
+                }, [] as Flow[]);
+
+                // get removed baselines
+                const removedBaselines = response.removed.reduce((acc, currGroupedDiffFlow) => {
+                    const flows = createFlowsFromGroupedDiffFlows(currGroupedDiffFlow, 'REMOVED');
+                    return [...acc, ...flows];
+                }, [] as Flow[]);
+
+                // get reconciled baselines
+                const reconciledBaselines = response.reconciled.reduce(
+                    (acc, currReconciledDiffFlow) => {
+                        const { entity, added, removed, unchanged } = currReconciledDiffFlow;
+
+                        const addedGroupedDiffFlow: GroupedDiffFlows = {
+                            entity,
+                            properties: added,
+                        };
+                        const removedGroupedDiffFlow: GroupedDiffFlows = {
+                            entity,
+                            properties: removed,
+                        };
+                        const unchangedGroupedDiffFlow: GroupedDiffFlows = {
+                            entity,
+                            properties: unchanged,
+                        };
+
+                        const addedFlows = createFlowsFromGroupedDiffFlows(
+                            addedGroupedDiffFlow,
+                            'ADDED'
+                        );
+                        const removedFlows = createFlowsFromGroupedDiffFlows(
+                            removedGroupedDiffFlow,
+                            'REMOVED'
+                        );
+                        const unchangedFlows = createFlowsFromGroupedDiffFlows(
+                            unchangedGroupedDiffFlow,
+                            'UNCHANGED'
+                        );
+
+                        return [...acc, ...addedFlows, ...removedFlows, ...unchangedFlows];
+                    },
+                    [] as Flow[]
+                );
+
+                simulatedBaselines = [
+                    ...addedBaselines,
+                    ...removedBaselines,
+                    ...reconciledBaselines,
+                ];
+
+                setResult({
+                    isLoading: false,
+                    data: { simulatedBaselines },
+                    error: '',
+                });
+            })
+            .catch((error) => {
+                const message = getAxiosErrorMessage(error);
+                const errorMessage =
+                    message || 'An unknown error occurred while getting the list of clusters';
+
+                setResult({
+                    isLoading: false,
+                    data: { simulatedBaselines: [] },
+                    error: errorMessage,
+                });
+            });
+    }
+
+    useEffect(() => {
+        fetchSimulatedBaselines();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [deploymentId]);
+
+    return { ...result, refetchSimulatedBaselines: fetchSimulatedBaselines };
+}
+
+export default useFetchSimulatedBaselines;

--- a/ui/apps/platform/src/Containers/NetworkGraph/common/FlowsTable.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/common/FlowsTable.tsx
@@ -10,10 +10,10 @@ import {
     Thead,
     Tr,
 } from '@patternfly/react-table';
-import { Flex, FlexItem, Text, TextContent, TextVariants } from '@patternfly/react-core';
-import { ExclamationCircleIcon } from '@patternfly/react-icons';
+import { Flex, FlexItem, Text, TextContent, TextVariants, Tooltip } from '@patternfly/react-core';
+import { ExclamationCircleIcon, MinusIcon, PlusIcon } from '@patternfly/react-icons';
 
-import { Flow } from '../types/flow.type';
+import { BaselineSimulationDiffState, Flow } from '../types/flow.type';
 import { protocolLabel } from '../utils/flowUtils';
 
 type FlowsTableProps = {
@@ -27,6 +27,7 @@ type FlowsTableProps = {
     isEditable?: boolean;
     addToBaseline?: (flow: Flow) => void;
     markAsAnomalous?: (flow: Flow) => void;
+    isBaselineSimulation?: boolean;
 };
 
 const columnNames = {
@@ -35,6 +36,20 @@ const columnNames = {
     // @TODO: This would be a good point to update with i18n translation ability
     portAndProtocol: 'Port / protocol',
 };
+
+function getBaselineSimulatedRowStyle(
+    baselineSimulationDiffState: BaselineSimulationDiffState | undefined
+): React.CSSProperties {
+    let customStyle: React.CSSProperties;
+    if (baselineSimulationDiffState === 'ADDED') {
+        customStyle = { backgroundColor: 'var(--pf-global--palette--green-50)' };
+    } else if (baselineSimulationDiffState === 'REMOVED') {
+        customStyle = { backgroundColor: 'var(--pf-global--palette--red-50)' };
+    } else {
+        customStyle = {};
+    }
+    return customStyle;
+}
 
 function FlowsTable({
     label,
@@ -47,6 +62,7 @@ function FlowsTable({
     isEditable = false,
     addToBaseline,
     markAsAnomalous,
+    isBaselineSimulation = false,
 }: FlowsTableProps): ReactElement {
     // getter functions
     const isRowExpanded = (row: Flow) => expandedRows?.includes(row.id);
@@ -90,6 +106,7 @@ function FlowsTable({
                             }}
                         />
                     )}
+                    {isBaselineSimulation && <Th />}
                     <Th width={40}>{columnNames.entity}</Th>
                     <Th>{columnNames.direction}</Th>
                     <Th>{columnNames.portAndProtocol}</Th>
@@ -118,9 +135,12 @@ function FlowsTable({
                                     },
                           ]
                         : [];
+                const baselineSimulatedRowStyle = getBaselineSimulatedRowStyle(
+                    row.baselineSimulationDiffState
+                );
 
                 return (
-                    <Tbody key={row.id} isExpanded={isExpanded}>
+                    <Tbody key={row.id} isExpanded={isExpanded} style={baselineSimulatedRowStyle}>
                         <Tr>
                             <Td
                                 expand={
@@ -148,6 +168,26 @@ function FlowsTable({
                                             : undefined
                                     }
                                 />
+                            )}
+                            {isBaselineSimulation && (
+                                <Td dataLabel={columnNames.direction}>
+                                    {row.baselineSimulationDiffState === 'ADDED' && (
+                                        <Tooltip content={<div>Baseline added</div>}>
+                                            <PlusIcon
+                                                size="sm"
+                                                className="pf-u-success-color-200"
+                                            />
+                                        </Tooltip>
+                                    )}
+                                    {row.baselineSimulationDiffState === 'REMOVED' && (
+                                        <Tooltip content={<div>Baseline removed</div>}>
+                                            <MinusIcon
+                                                size="sm"
+                                                className="pf-u-danger-color-200"
+                                            />
+                                        </Tooltip>
+                                    )}
+                                </Td>
                             )}
                             <Td dataLabel={columnNames.entity}>
                                 <Flex direction={{ default: 'row' }}>

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentSideBar.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentSideBar.tsx
@@ -102,67 +102,76 @@ function DeploymentSideBar({ deploymentId, nodes, edges }: DeploymentSideBarProp
                     </FlexItem>
                 </Flex>
             </StackItem>
-            <StackItem>
-                <Tabs activeKey={activeKeyTab} onSelect={onSelectTab}>
-                    <Tab
-                        eventKey="Details"
-                        tabContentId="Details"
-                        title={<TabTitleText>Details</TabTitleText>}
-                        disabled={isBaselineSimulationOn}
-                    />
-                    <Tab
-                        eventKey="Flows"
-                        tabContentId="Flows"
-                        title={<TabTitleText>Flows</TabTitleText>}
-                        disabled={isBaselineSimulationOn}
-                    />
-                    <Tab
-                        eventKey="Baselines"
-                        tabContentId="Baselines"
-                        title={<TabTitleText>Baselines</TabTitleText>}
-                    />
-                    <Tab
-                        eventKey="Network policies"
-                        tabContentId="Network policies"
-                        title={<TabTitleText>Network policies</TabTitleText>}
-                        disabled={isBaselineSimulationOn}
-                    />
-                </Tabs>
-            </StackItem>
-            <StackItem isFilled style={{ overflow: 'auto' }}>
-                <TabContent eventKey="Details" id="Details" hidden={activeKeyTab !== 'Details'}>
-                    {deployment && (
-                        <DeploymentDetails
-                            deployment={deployment}
-                            numExternalFlows={numExternalFlows}
-                            numInternalFlows={numInternalFlows}
-                            listenPorts={listenPorts}
-                        />
-                    )}
-                </TabContent>
-                <TabContent eventKey="Flows" id="Flows" hidden={activeKeyTab !== 'Flows'}>
-                    <DeploymentFlows edges={edges} deploymentId={deploymentId} />
-                </TabContent>
-                <TabContent
-                    eventKey="Baselines"
-                    id="Baselines"
-                    hidden={activeKeyTab !== 'Baselines'}
-                    className="pf-u-h-100"
-                >
-                    {isBaselineSimulationOn ? (
-                        <DeploymentBaselinesSimulated deploymentId={deploymentId} />
-                    ) : (
-                        <DeploymentBaselines deploymentId={deploymentId} />
-                    )}
-                </TabContent>
-                <TabContent
-                    eventKey="Network policies"
-                    id="Network policies"
-                    hidden={activeKeyTab !== 'Network policies'}
-                >
-                    <NetworkPolicies policyIds={deploymentPolicyIds} />
-                </TabContent>
-            </StackItem>
+            {isBaselineSimulationOn && (
+                <StackItem isFilled style={{ overflow: 'auto' }} className="pf-u-h-100">
+                    <DeploymentBaselinesSimulated deploymentId={deploymentId} />
+                </StackItem>
+            )}
+            {!isBaselineSimulationOn && (
+                <>
+                    <StackItem>
+                        <Tabs activeKey={activeKeyTab} onSelect={onSelectTab}>
+                            <Tab
+                                eventKey="Details"
+                                tabContentId="Details"
+                                title={<TabTitleText>Details</TabTitleText>}
+                                disabled={isBaselineSimulationOn}
+                            />
+                            <Tab
+                                eventKey="Flows"
+                                tabContentId="Flows"
+                                title={<TabTitleText>Flows</TabTitleText>}
+                                disabled={isBaselineSimulationOn}
+                            />
+                            <Tab
+                                eventKey="Baselines"
+                                tabContentId="Baselines"
+                                title={<TabTitleText>Baselines</TabTitleText>}
+                            />
+                            <Tab
+                                eventKey="Network policies"
+                                tabContentId="Network policies"
+                                title={<TabTitleText>Network policies</TabTitleText>}
+                                disabled={isBaselineSimulationOn}
+                            />
+                        </Tabs>
+                    </StackItem>
+                    <StackItem isFilled style={{ overflow: 'auto' }}>
+                        <TabContent
+                            eventKey="Details"
+                            id="Details"
+                            hidden={activeKeyTab !== 'Details'}
+                        >
+                            {deployment && (
+                                <DeploymentDetails
+                                    deployment={deployment}
+                                    numExternalFlows={numExternalFlows}
+                                    numInternalFlows={numInternalFlows}
+                                    listenPorts={listenPorts}
+                                />
+                            )}
+                        </TabContent>
+                        <TabContent eventKey="Flows" id="Flows" hidden={activeKeyTab !== 'Flows'}>
+                            <DeploymentFlows edges={edges} deploymentId={deploymentId} />
+                        </TabContent>
+                        <TabContent
+                            eventKey="Baselines"
+                            id="Baselines"
+                            hidden={activeKeyTab !== 'Baselines'}
+                            className="pf-u-h-100"
+                        >
+                            <DeploymentBaselines deploymentId={deploymentId} />
+                        </TabContent>
+                        <TabContent
+                            eventKey="Network policies"
+                            id="Network policies"
+                            hidden={activeKeyTab !== 'Network policies'}
+                        >
+                            <NetworkPolicies policyIds={deploymentPolicyIds} />
+                        </TabContent>
+                    </StackItem>
+                </>
+            )}
         </Stack>
     );
 }

--- a/ui/apps/platform/src/Containers/NetworkGraph/types/flow.type.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/types/flow.type.ts
@@ -6,6 +6,8 @@ export type FlowEntityType = 'DEPLOYMENT' | 'EXTERNAL_ENTITIES' | 'CIDR_BLOCK';
 
 export type BaselineStatusType = 'ANOMALOUS' | 'BASELINE';
 
+export type BaselineSimulationDiffState = 'ADDED' | 'REMOVED' | 'UNCHANGED';
+
 export type IndividualFlow = {
     id: string;
     type: FlowEntityType;
@@ -17,6 +19,7 @@ export type IndividualFlow = {
     protocol: L4Protocol;
     isAnomalous: boolean;
     children?: undefined;
+    baselineSimulationDiffState?: BaselineSimulationDiffState;
 };
 
 export type AggregatedFlow = {
@@ -30,6 +33,7 @@ export type AggregatedFlow = {
     protocol: L4Protocol;
     isAnomalous: boolean;
     children: IndividualFlow[];
+    baselineSimulationDiffState?: BaselineSimulationDiffState;
 };
 
 export type Entity = {

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/flowUtils.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/flowUtils.ts
@@ -1,9 +1,11 @@
 import { Controller } from '@patternfly/react-topology';
-import { EntityType } from 'Containers/Network/networkTypes';
 import { uniq } from 'lodash';
+
+import { EntityType } from 'Containers/Network/networkTypes';
 import { L4Protocol } from 'types/networkFlow.proto';
+import { GroupedDiffFlows } from 'types/networkPolicyService';
 import { AdvancedFlowsFilterType } from '../common/AdvancedFlowsFilter/types';
-import { Flow, Peer } from '../types/flow.type';
+import { BaselineSimulationDiffState, Flow, FlowEntityType, Peer } from '../types/flow.type';
 import { CustomEdgeModel, CustomSingleNodeData } from '../types/topology.type';
 
 export const protocolLabel = {
@@ -35,7 +37,7 @@ export function getNumFlows(flows: Flow[]): number {
     return numFlows;
 }
 
-function createUniqueFlowId({
+export function createUniqueFlowId({
     entityId,
     direction,
     port,
@@ -260,4 +262,49 @@ export function transformFlowsToPeers(flows: Flow[]): Peer[] {
         };
         return peer;
     });
+}
+
+export function createFlowsFromGroupedDiffFlows(
+    groupedDiffFlow: GroupedDiffFlows,
+    baselineSimulationDiffState: BaselineSimulationDiffState
+): Flow[] {
+    const { entity, properties } = groupedDiffFlow;
+    const flows = properties.map(({ ingress, port, protocol }) => {
+        const direction = ingress ? 'Ingress' : 'Egress';
+        let entityName = '';
+        let namespace = '';
+        let type: FlowEntityType = 'DEPLOYMENT';
+        if (entity.type === 'DEPLOYMENT') {
+            entityName = entity.deployment.name;
+            namespace = entity.deployment.namespace;
+            type = 'DEPLOYMENT';
+        } else if (entity.type === 'INTERNET') {
+            entityName = 'External entities';
+            type = 'EXTERNAL_ENTITIES';
+        } else if (entity.type === 'EXTERNAL_SOURCE') {
+            entityName = entity.externalSource.name;
+            type = 'CIDR_BLOCK';
+        }
+        const id = createUniqueFlowId({
+            entityId: entity.id,
+            direction,
+            port: String(port),
+            protocol,
+        });
+        const flow: Flow = {
+            id,
+            type,
+            entity: entityName,
+            entityId: entity.id,
+            namespace,
+            direction,
+            port: String(port),
+            protocol,
+            isAnomalous: false,
+            children: [],
+            baselineSimulationDiffState,
+        };
+        return flow;
+    });
+    return flows;
 }

--- a/ui/apps/platform/src/types/networkPolicyService.ts
+++ b/ui/apps/platform/src/types/networkPolicyService.ts
@@ -1,0 +1,22 @@
+// Some types in this file were modified for readability.
+// Check out proto/api/v1/network_policy_service.proto for the proper names
+import { NetworkBaselineConnectionProperties } from './networkBaseline.proto';
+import { NetworkEntityInfo } from './networkFlow.proto';
+
+export type ReconciledDiffFlows = {
+    entity: NetworkEntityInfo;
+    added: NetworkBaselineConnectionProperties[];
+    removed: NetworkBaselineConnectionProperties[];
+    unchanged: NetworkBaselineConnectionProperties[];
+};
+
+export type GroupedDiffFlows = {
+    entity: NetworkEntityInfo;
+    properties: NetworkBaselineConnectionProperties[];
+};
+
+export type DiffFlowsResponse = {
+    added: GroupedDiffFlows[];
+    removed: GroupedDiffFlows[];
+    reconciled: ReconciledDiffFlows[];
+};


### PR DESCRIPTION
## Description

This PR adds functionality to get simulated baselines. Baselines that are added are marked as green and have a +. Baselines that are removed are marked as red and have a -. I also added filters.

<img width="1552" alt="Screenshot 2023-01-24 at 3 25 09 PM" src="https://user-images.githubusercontent.com/4805485/214443432-2d1c89ff-8ca7-4eb1-9119-5f3caac721c0.png">

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~
