### PR TITLE
Network Graph PF edge perf improvement and refactor

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraph.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraph.tsx
@@ -2,6 +2,7 @@
 import React, { useMemo } from 'react';
 import { useHistory, useParams } from 'react-router-dom';
 import { action } from 'mobx';
+import intersectionWith from 'lodash/intersectionWith';
 import { Popover } from '@patternfly/react-core';
 import {
     SELECTION_EVENT,
@@ -274,24 +275,47 @@ TopologyComponentProps) => {
         // removeExtraneousEdges();
         console.log('TopologyComponent: setEdges');
         if (detailId) {
-            // const selectedNode = controller.getNodeById(detailId);
-            // if (selectedNode?.isGroup()) {
-            //     selectedNode.getAllNodeChildren().forEach((child) => {
-            //         // set visible edges
-            //         setVisibleEdges(getNodeEdges(child));
-            //     });
-            // } else if (selectedNode) {
-            //     // set visible edges
-            //     setVisibleEdges(getNodeEdges(selectedNode));
-            // }
+            const nodeEdges: CustomEdgeModel[] = [];
+            const selectedNode = getNodeById(model.nodes, detailId);
+            if (selectedNode?.type === 'group') {
+                // need to find the edges that have a source or target that equal to the child id
+                model.edges.forEach((edge) => {
+                    const isSource = selectedNode?.children?.includes(edge.source);
+                    const isTarget = selectedNode?.children?.includes(edge.target);
+                    if (isSource || isTarget) {
+                        nodeEdges.push({ ...edge, visible: true });
+                    }
+                });
+                console.log(nodeEdges);
+                // controller.fromModel({ ...model, edges: nodeEdges });
 
+                // const nodeEdges = intersectionWith(
+                //     [model.edges, selectedNode?.children],
+                //     (modelEdge, childNode) =>
+                //         modelEdge.source === childNode.id || modelEdge.target === childNode.id
+                // );
+
+                //    .forEach((child) => {
+                //         // set visible edges
+                //         model.edges.filter((edge) => edge.)
+                //         // setVisibleEdges(getNodeEdges(child));
+                //     });
+            } else if (selectedNode) {
+                // set visible edges
+                const nodeEdges = getNodeEdges(selectedNode);
+                nodeEdges.forEach((edge) => {
+                    const edgeData = edge.getData();
+                    edge.setData({ ...edgeData, visible: true });
+                });
+                // setVisibleEdges(getNodeEdges(selectedNode));
+            }
             // // setting extraneous edges
             // if (edgeState === 'extraneous') {
             //     setExtraneousEdges();
             // }
 
-            // jeff's solution
-            showNodeEdges(controller, detailId);
+            // // jeff's solution
+            // showNodeEdges(controller, detailId);
         }
     }
 
@@ -370,6 +394,7 @@ TopologyComponentProps) => {
                         },
                         fitToScreenCallback: () => {
                             controller.getGraph().fit(80);
+                            resetGraphToDefault();
                         },
                         resetViewCallback: () => {
                             controller.getGraph().reset();

--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraph.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraph.tsx
@@ -1,283 +1,57 @@
-/* eslint-disable @typescript-eslint/no-unsafe-return */
 import React, { useMemo } from 'react';
-import { useHistory, useParams } from 'react-router-dom';
-import { Popover } from '@patternfly/react-core';
-import {
-    SELECTION_EVENT,
-    SelectionEventListener,
-    useEventListener,
-    TopologySideBar,
-    TopologyView,
-    createTopologyControlButtons,
-    defaultControlButtonsOptions,
-    TopologyControlBar,
-    useVisualizationController,
-    Visualization,
-    VisualizationSurface,
-    VisualizationProvider,
-    Edge,
-    Controller,
-} from '@patternfly/react-topology';
+import { Visualization, VisualizationProvider } from '@patternfly/react-topology';
 
-import { networkBasePathPF } from 'routePaths';
-import { getQueryObject, getQueryString } from 'utils/queryStringUtils';
 import stylesComponentFactory from './components/stylesComponentFactory';
 import defaultLayoutFactory from './layouts/defaultLayoutFactory';
 import defaultComponentFactory from './components/defaultComponentFactory';
-import DeploymentSideBar from './deployment/DeploymentSideBar';
-import NamespaceSideBar from './namespace/NamespaceSideBar';
-import CidrBlockSideBar from './cidr/CidrBlockSideBar';
-import ExternalEntitiesSideBar from './externalEntities/ExternalEntitiesSideBar';
-import ExternalGroupSideBar from './external/ExternalGroupSideBar';
-import NetworkPolicySimulatorSidePanel from './simulation/NetworkPolicySimulatorSidePanel';
-import { getNodeById } from './utils/networkGraphUtils';
 import { CustomModel, CustomNodeModel } from './types/topology.type';
 import { Simulation } from './utils/getSimulation';
-import LegendContent from './components/LegendContent';
 
 import './Topology.css';
-import useNetworkPolicySimulator, {
-    ApplyNetworkPolicyModification,
-    NetworkPolicySimulator,
-    SetNetworkPolicyModification,
-} from './hooks/useNetworkPolicySimulator';
+import useNetworkPolicySimulator from './hooks/useNetworkPolicySimulator';
 import SimulationFrame from './simulation/SimulationFrame';
-
-// TODO: move these type defs to a central location
-export const UrlDetailType = {
-    NAMESPACE: 'namespace',
-    DEPLOYMENT: 'deployment',
-    CIDR_BLOCK: 'cidr',
-    EXTERNAL_ENTITIES: 'internet',
-    EXTERNAL: 'external',
-} as const;
-export type UrlDetailTypeKey = keyof typeof UrlDetailType;
-export type UrlDetailTypeValue = typeof UrlDetailType[UrlDetailTypeKey];
-
-function getUrlParamsForEntity(type, id): [UrlDetailTypeValue, string] {
-    return [UrlDetailType[type], id];
-}
+import TopologyComponent from './TopologyComponent';
 
 export type NetworkGraphProps = {
     model: CustomModel;
     simulation: Simulation;
     selectedNode?: CustomNodeModel;
     selectedClusterId: string;
-    updateCount: number;
 };
+function NetworkGraph({ model, simulation, selectedClusterId, selectedNode }: NetworkGraphProps) {
+    const controller = useMemo(() => new Visualization(), []);
+    controller.registerLayoutFactory(defaultLayoutFactory);
+    controller.registerComponentFactory(defaultComponentFactory);
+    controller.registerComponentFactory(stylesComponentFactory);
 
-export type TopologyComponentProps = {
-    model: CustomModel;
-    simulation: Simulation;
-    selectedClusterId: string;
-    selectedNode?: CustomNodeModel;
-    simulator: NetworkPolicySimulator;
-    setNetworkPolicyModification: SetNetworkPolicyModification;
-    applyNetworkPolicyModification: ApplyNetworkPolicyModification;
-};
+    const { simulator, setNetworkPolicyModification, applyNetworkPolicyModification } =
+        useNetworkPolicySimulator({
+            simulation,
+            clusterId: selectedClusterId,
+        });
 
-// @TODO: Consider a better approach to managing the side panel related state (simulation + URL path for entities)
-function clearSimulationQuery(search: string): string {
-    const modifiedSearchFilter = getQueryObject(search);
-    delete modifiedSearchFilter.simulation;
-    const queryString = getQueryString(modifiedSearchFilter);
-    return queryString;
-}
-
-const TopologyComponent = ({
-    model,
-    simulation,
-    selectedClusterId,
-    selectedNode,
-    simulator,
-    setNetworkPolicyModification,
-    applyNetworkPolicyModification,
-}: TopologyComponentProps) => {
-    const history = useHistory();
-    const controller = useVisualizationController();
-    console.log('TopologyComponent', selectedNode?.data);
-
-    function closeSidebar() {
-        const queryString = clearSimulationQuery(history.location.search);
-        history.push(`${networkBasePathPF}${queryString}`);
-    }
-
-    function onSelect(ids: string[]) {
-        console.log('TopologyComponent: onSelect');
-        const newSelectedId = ids?.[0] || '';
-        const newSelectedEntity = getNodeById(model?.nodes, newSelectedId);
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        if (newSelectedEntity) {
-            const { data, id } = newSelectedEntity;
-            const [newDetailType, newDetailId] = getUrlParamsForEntity(data.type, id);
-            const queryString = clearSimulationQuery(history.location.search);
-            // if found, and it's not the logical grouping of all external sources, then trigger URL update
-            if (newDetailId !== 'EXTERNAL') {
-                history.push(`${networkBasePathPF}/${newDetailType}/${newDetailId}${queryString}`);
-            } else {
-                // otherwise, return to the graph-only state
-                history.push(`${networkBasePathPF}${queryString}`);
-            }
-        }
-    }
-
-    function zoomInCallback() {
-        controller.getGraph().scaleBy(4 / 3);
-    }
-
-    function zoomOutCallback() {
-        controller.getGraph().scaleBy(0.75);
-    }
-
-    function fitToScreenCallback() {
-        controller.getGraph().fit(80);
-    }
-
-    function resetViewCallback() {
-        controller.getGraph().reset();
-        controller.getGraph().layout();
-    }
-
-    React.useEffect(() => {
-        console.log('TopologyComponent: useEffect [model]');
-        controller.fromModel(model, true);
-    }, [model]);
-
-    useEventListener<SelectionEventListener>(SELECTION_EVENT, (ids) => {
-        console.log('TopologyComponent: useEventListener');
-        onSelect(ids);
-    });
-
-    const selectedIds = selectedNode ? [selectedNode.id] : [];
+    const isSimulating =
+        simulator.state === 'GENERATED' ||
+        simulator.state === 'UNDO' ||
+        simulator.state === 'UPLOAD' ||
+        (simulation.isOn && simulation.type === 'baseline');
 
     return (
-        <TopologyView
-            sideBar={
-                <TopologySideBar resizable onClose={closeSidebar}>
-                    {simulation.isOn && simulation.type === 'networkPolicy' && (
-                        <NetworkPolicySimulatorSidePanel
-                            selectedClusterId={selectedClusterId}
-                            simulator={simulator}
-                            setNetworkPolicyModification={setNetworkPolicyModification}
-                            applyNetworkPolicyModification={applyNetworkPolicyModification}
-                        />
-                    )}
-                    {selectedNode && selectedNode?.data?.type === 'NAMESPACE' && (
-                        <NamespaceSideBar
-                            namespaceId={selectedNode.id}
-                            nodes={model?.nodes || []}
-                            edges={model?.edges || []}
-                        />
-                    )}
-                    {selectedNode && selectedNode?.data?.type === 'DEPLOYMENT' && (
-                        <DeploymentSideBar
-                            deploymentId={selectedNode.id}
-                            nodes={model?.nodes || []}
-                            edges={model?.edges || []}
-                        />
-                    )}
-                    {selectedNode && selectedNode?.data?.type === 'EXTERNAL_GROUP' && (
-                        <ExternalGroupSideBar
-                            id={selectedNode.id}
-                            nodes={model?.nodes || []}
-                            edges={model?.edges || []}
-                        />
-                    )}
-                    {selectedNode && selectedNode?.data?.type === 'CIDR_BLOCK' && (
-                        <CidrBlockSideBar
-                            id={selectedNode.id}
-                            nodes={model?.nodes || []}
-                            edges={model?.edges || []}
-                        />
-                    )}
-                    {selectedNode && selectedNode?.data?.type === 'EXTERNAL_ENTITIES' && (
-                        <ExternalEntitiesSideBar
-                            id={selectedNode.id}
-                            nodes={model?.nodes || []}
-                            edges={model?.edges || []}
-                        />
-                    )}
-                </TopologySideBar>
-            }
-            sideBarOpen={!!selectedNode || simulation.isOn}
-            sideBarResizable
-            controlBar={
-                <TopologyControlBar
-                    controlButtons={createTopologyControlButtons({
-                        ...defaultControlButtonsOptions,
-                        zoomInCallback,
-                        zoomOutCallback,
-                        fitToScreenCallback,
-                        resetViewCallback,
-                    })}
+        <SimulationFrame simulator={simulator}>
+            <VisualizationProvider controller={controller}>
+                <TopologyComponent
+                    model={model}
+                    simulation={simulation}
+                    selectedClusterId={selectedClusterId}
+                    simulator={simulator}
+                    selectedNode={selectedNode}
+                    setNetworkPolicyModification={setNetworkPolicyModification}
+                    applyNetworkPolicyModification={applyNetworkPolicyModification}
                 />
-            }
-        >
-            <VisualizationSurface state={{ selectedIds }} />
-            <Popover
-                aria-label="Network graph legend"
-                bodyContent={<LegendContent />}
-                hasAutoWidth
-                reference={() => document.getElementById('legend') as HTMLButtonElement}
-            />
-        </TopologyView>
-    );
-};
-
-function compareModels(prevProps, nextProps) {
-    console.log(
-        'NetworkGraph: compareModels prevProps nextProps',
-        prevProps.updateCount,
-        nextProps.updateCount
-    );
-    return (
-        prevProps.updateCount === nextProps.updateCount &&
-        prevProps.simulation.isOn === nextProps.simulation.isOn &&
-        prevProps.simulation.type === nextProps.simulation.type
+            </VisualizationProvider>
+        </SimulationFrame>
     );
 }
-
-const NetworkGraph = React.memo<NetworkGraphProps>(
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    ({ model, simulation, selectedClusterId, selectedNode, updateCount }) => {
-        const controller = useMemo(() => new Visualization(), []);
-        controller.registerLayoutFactory(defaultLayoutFactory);
-        controller.registerComponentFactory(defaultComponentFactory);
-        controller.registerComponentFactory(stylesComponentFactory);
-
-        const { simulator, setNetworkPolicyModification, applyNetworkPolicyModification } =
-            useNetworkPolicySimulator({
-                simulation,
-                clusterId: selectedClusterId,
-            });
-
-        console.log('NetworkGraph');
-
-        const isSimulating =
-            simulator.state === 'GENERATED' ||
-            simulator.state === 'UNDO' ||
-            simulator.state === 'UPLOAD' ||
-            (simulation.isOn && simulation.type === 'baseline');
-
-        return (
-            <SimulationFrame simulator={simulator}>
-                <VisualizationProvider controller={controller}>
-                    <TopologyComponent
-                        model={model}
-                        simulation={simulation}
-                        selectedClusterId={selectedClusterId}
-                        simulator={simulator}
-                        selectedNode={selectedNode}
-                        setNetworkPolicyModification={setNetworkPolicyModification}
-                        applyNetworkPolicyModification={applyNetworkPolicyModification}
-                    />
-                </VisualizationProvider>
-            </SimulationFrame>
-        );
-    },
-    compareModels
-);
 
 NetworkGraph.displayName = 'NetworkGraph';
 

--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraph.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraph.tsx
@@ -37,7 +37,7 @@ function NetworkGraph({ model, simulation, selectedClusterId, selectedNode }: Ne
         (simulation.isOn && simulation.type === 'baseline');
 
     return (
-        <SimulationFrame simulator={simulator}>
+        <SimulationFrame isSimulating={isSimulating}>
             <VisualizationProvider controller={controller}>
                 <TopologyComponent
                     model={model}

--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphContainer.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphContainer.tsx
@@ -36,6 +36,8 @@ function getFilteredEdges(
                 if (children?.includes(source) || children?.includes(target)) {
                     filteredEdges.push({ ...edge, visible: true });
                 }
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
             } else if (source === selectedNode.data?.id || target === selectedNode.data?.id) {
                 filteredEdges.push({ ...edge, visible: true });
             }

--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphContainer.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphContainer.tsx
@@ -1,0 +1,108 @@
+import React, { useState, useEffect, useRef } from 'react';
+
+import NetworkGraph from './NetworkGraph';
+import {
+    CustomEdgeModel,
+    CustomModel,
+    CustomNodeModel,
+    DeploymentData,
+} from './types/topology.type';
+import { EdgeState } from './components/EdgeStateSelect';
+import { DisplayOption } from './components/DisplayOptionsSelect';
+import { Simulation } from './utils/getSimulation';
+
+type NetworkGraphContainerProps = {
+    models: {
+        active: CustomModel;
+        extraneous: CustomModel;
+    };
+    edgeState: EdgeState;
+    displayOptions: DisplayOption[];
+    simulation: Simulation;
+    selectedClusterId: string;
+};
+
+function NetworkGraphContainer({
+    models,
+    edgeState,
+    displayOptions,
+    simulation,
+    selectedClusterId,
+}: NetworkGraphContainerProps) {
+    const { active, extraneous } = models;
+    const [model, setModel] = useState(active);
+    const updateCount = useRef(0);
+
+    function increaseUpdateCount() {
+        updateCount.current += 1;
+    }
+
+    useEffect(() => {
+        const showPolicyState = !!displayOptions.includes('policyStatusBadge');
+        const showExternalState = !!displayOptions.includes('externalBadge');
+        const showEdgeLabels = !!displayOptions.includes('edgeLabel');
+        let updatedNodes: CustomNodeModel[] = model.nodes;
+        let updatedEdges: CustomEdgeModel[] = model.edges;
+
+        // if all display options are true, set back to existing default data model
+        if (showPolicyState && showExternalState && showEdgeLabels) {
+            increaseUpdateCount();
+            setModel(edgeState === 'active' ? active : extraneous);
+        } else {
+            // this is to update the display options visually for deployment nodes on the graph
+            if (model.nodes?.length) {
+                // need to improve perf to only perform this if policyStatusBadge OR externalBadge has changed
+                updatedNodes = model.nodes.map((node) => {
+                    const { data } = node;
+                    if (data.type === 'DEPLOYMENT') {
+                        return {
+                            ...node,
+                            data: {
+                                ...data,
+                                showPolicyState,
+                                showExternalState,
+                            } as DeploymentData,
+                        };
+                    }
+                    return node;
+                });
+            }
+
+            if (model.edges?.length) {
+                // need to improve perf to only perform this if edgeLabel has changed
+                updatedEdges = model.edges.map((edge) => {
+                    const { data } = edge;
+                    const { properties } = data;
+                    return {
+                        ...edge,
+                        data: {
+                            ...data,
+                            properties,
+                            tag: showEdgeLabels ? data.portProtocolLabel : undefined,
+                        },
+                    };
+                });
+            }
+
+            const updatedModel: CustomModel = {
+                ...model,
+                nodes: updatedNodes,
+                edges: updatedEdges,
+            };
+            increaseUpdateCount();
+            setModel(updatedModel);
+        }
+    }, [displayOptions]);
+
+    return (
+        <NetworkGraph
+            model={model}
+            edgeState={edgeState}
+            simulation={simulation}
+            selectedClusterId={selectedClusterId || ''}
+            updateCount={updateCount.current}
+        />
+    );
+}
+
+export default NetworkGraphContainer;

--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphContainer.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphContainer.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
+import { useParams } from 'react-router-dom';
 
 import NetworkGraph from './NetworkGraph';
 import {
@@ -6,10 +7,47 @@ import {
     CustomModel,
     CustomNodeModel,
     DeploymentData,
+    DeploymentNodeModel,
 } from './types/topology.type';
 import { EdgeState } from './components/EdgeStateSelect';
 import { DisplayOption } from './components/DisplayOptionsSelect';
 import { Simulation } from './utils/getSimulation';
+import { getNodeById } from './utils/networkGraphUtils';
+
+function getFilteredEdges(edges: CustomEdgeModel[], detailId: string): CustomEdgeModel[] {
+    const filteredEdges: CustomEdgeModel[] = [];
+    // edges.forEach((edge) => {
+    //     const { source, target } = edge;
+    //     if (source === detailId || target === detailId) {
+    //         filteredEdges.push({ ...edge, visible: true });
+    //     }
+    // });
+    return filteredEdges;
+}
+
+// function getFilteredNodes(nodes: CustomNodeModel[], selectedNode: CustomNodeModel, edgeState: EdgeState): CustomNodeModel[] {
+//     const { data } = selectedNode || {};
+//     const updatedNodes = nodes;
+//     if (edgeState === 'extraneous') {
+//         if (data?.type === 'DEPLOYMENT') {
+//             const { networkPolicyState } = data || {};
+//             const extraneousIngressNode = nodes.find(({ id }) => id === 'extraneous-ingress');
+//             const extraneousEgressNode = nodes.find(({ id }) => id === 'extraneous-egress');
+//             if (networkPolicyState === 'ingress') {
+//                 // if the node has ingress policies from policy graph, show extraneous egress node
+//                 extraneousEgressNode?.setVisible(true);
+//             } else if (networkPolicyState === 'egress') {
+//                 // if the node has egress policies from policy graph, show extraneous ingress node
+//                 extraneousIngressNode?.setVisible(true);
+//             } else if (networkPolicyState === 'none') {
+//                 // if the node has no policies, show both extraneous ingress and egress nodes
+//                 extraneousEgressNode?.setVisible(true);
+//                 extraneousIngressNode?.setVisible(true);
+//             }
+//         }
+//     }
+//     return updatedNodes;
+// }
 
 type NetworkGraphContainerProps = {
     models: {
@@ -29,30 +67,54 @@ function NetworkGraphContainer({
     simulation,
     selectedClusterId,
 }: NetworkGraphContainerProps) {
+    // these are the unfiltered, unmodified data models
     const { active, extraneous } = models;
+    // this is the current filtered and/or modified model that is represented in the graph
     const [model, setModel] = useState(active);
+    // this is a count to improve performance (we only rerender children when updateCount changes)
     const updateCount = useRef(0);
+    // selected node state is stored in the URL
+    const { detailId } = useParams();
+    const selectedNode = getNodeById(model?.nodes, detailId);
+
+    console.log('NetworkGraphContainer', detailId);
 
     function increaseUpdateCount() {
         updateCount.current += 1;
     }
 
     useEffect(() => {
+        console.log(
+            'NetworkGraphContainer: useEffect [displayOptions, detailId, edgeState, active, extraneous]'
+        );
         const showPolicyState = !!displayOptions.includes('policyStatusBadge');
         const showExternalState = !!displayOptions.includes('externalBadge');
         const showEdgeLabels = !!displayOptions.includes('edgeLabel');
-        let updatedNodes: CustomNodeModel[] = model.nodes;
-        const updatedEdges: CustomEdgeModel[] = model.edges;
+        const unfilteredModel = edgeState === 'active' ? active : extraneous;
+        let updatedNodes: CustomNodeModel[] = unfilteredModel.nodes;
+        let updatedEdges: CustomEdgeModel[] = getFilteredEdges(unfilteredModel.edges, detailId);
 
         // if all display options are true, set back to existing default data model
         if (showPolicyState && showExternalState && showEdgeLabels) {
             increaseUpdateCount();
-            setModel(edgeState === 'active' ? active : extraneous);
+            setModel({
+                ...unfilteredModel,
+                edges: updatedEdges,
+            });
         } else {
-            // this is to update the display options visually for deployment nodes on the graph
-            if (model.nodes?.length) {
-                // need to improve perf to only perform this if policyStatusBadge OR externalBadge has changed
-                updatedNodes = model.nodes.map((node) => {
+            // sample test to see if node policy/external state is already showing
+            const sampleDeployment = model.nodes.find(
+                (node) => node.data.type === 'DEPLOYMENT'
+            ) as DeploymentNodeModel;
+            const isShowingPolicyState = sampleDeployment.data.showPolicyState;
+            const isShowingExternalState = sampleDeployment.data.showExternalState;
+            // to improve perf to only perform this if policyStatusBadge OR externalBadge has changed
+            if (
+                isShowingPolicyState !== showPolicyState ||
+                isShowingExternalState !== showExternalState
+            ) {
+                // update the display options visually for deployment nodes on the graph
+                updatedNodes = unfilteredModel.nodes.map((node) => {
                     const { data } = node;
                     if (data.type === 'DEPLOYMENT') {
                         return {
@@ -68,21 +130,25 @@ function NetworkGraphContainer({
                 });
             }
 
-            // if (model.edges?.length) {
-            //     // need to improve perf to only perform this if edgeLabel has changed
-            //     updatedEdges = model.edges.map((edge) => {
-            //         const { data } = edge;
-            //         const { properties } = data;
-            //         return {
-            //             ...edge,
-            //             data: {
-            //                 ...data,
-            //                 properties,
-            //                 tag: showEdgeLabels ? data.portProtocolLabel : undefined,
-            //             },
-            //         };
-            //     });
-            // }
+            // sample test to see if the edge labels are already showing in the current model in the graph
+            const isShowingEdgeLabels = !!model.edges[0].data.tag;
+            // to improve perf to only perform this if showEdgeLabels has changed
+            if (isShowingEdgeLabels !== showEdgeLabels) {
+                // update the display options visually for edges on the graph
+                updatedEdges = updatedEdges.map((edge) => {
+                    const { data } = edge;
+                    const { properties } = data;
+                    return {
+                        ...edge,
+                        visible: true,
+                        data: {
+                            ...data,
+                            properties,
+                            tag: showEdgeLabels ? data.portProtocolLabel : undefined,
+                        },
+                    };
+                });
+            }
 
             const updatedModel: CustomModel = {
                 ...model,
@@ -92,12 +158,7 @@ function NetworkGraphContainer({
             increaseUpdateCount();
             setModel(updatedModel);
         }
-    }, [displayOptions]);
-
-    useEffect(() => {
-        increaseUpdateCount();
-        setModel(edgeState === 'active' ? active : extraneous);
-    }, [edgeState, active, extraneous]);
+    }, [displayOptions, detailId, edgeState, active, extraneous]);
 
     return (
         <NetworkGraph
@@ -106,6 +167,7 @@ function NetworkGraphContainer({
             simulation={simulation}
             selectedClusterId={selectedClusterId || ''}
             updateCount={updateCount.current}
+            selectedNode={selectedNode}
         />
     );
 }

--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphContainer.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphContainer.tsx
@@ -42,7 +42,7 @@ function NetworkGraphContainer({
         const showExternalState = !!displayOptions.includes('externalBadge');
         const showEdgeLabels = !!displayOptions.includes('edgeLabel');
         let updatedNodes: CustomNodeModel[] = model.nodes;
-        let updatedEdges: CustomEdgeModel[] = model.edges;
+        const updatedEdges: CustomEdgeModel[] = model.edges;
 
         // if all display options are true, set back to existing default data model
         if (showPolicyState && showExternalState && showEdgeLabels) {
@@ -68,21 +68,21 @@ function NetworkGraphContainer({
                 });
             }
 
-            if (model.edges?.length) {
-                // need to improve perf to only perform this if edgeLabel has changed
-                updatedEdges = model.edges.map((edge) => {
-                    const { data } = edge;
-                    const { properties } = data;
-                    return {
-                        ...edge,
-                        data: {
-                            ...data,
-                            properties,
-                            tag: showEdgeLabels ? data.portProtocolLabel : undefined,
-                        },
-                    };
-                });
-            }
+            // if (model.edges?.length) {
+            //     // need to improve perf to only perform this if edgeLabel has changed
+            //     updatedEdges = model.edges.map((edge) => {
+            //         const { data } = edge;
+            //         const { properties } = data;
+            //         return {
+            //             ...edge,
+            //             data: {
+            //                 ...data,
+            //                 properties,
+            //                 tag: showEdgeLabels ? data.portProtocolLabel : undefined,
+            //             },
+            //         };
+            //     });
+            // }
 
             const updatedModel: CustomModel = {
                 ...model,
@@ -93,6 +93,11 @@ function NetworkGraphContainer({
             setModel(updatedModel);
         }
     }, [displayOptions]);
+
+    useEffect(() => {
+        increaseUpdateCount();
+        setModel(edgeState === 'active' ? active : extraneous);
+    }, [edgeState, active, extraneous]);
 
     return (
         <NetworkGraph

--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphContainer.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphContainer.tsx
@@ -137,13 +137,11 @@ function getDisplayNodes(
 function getDisplayEdges(edges: CustomEdgeModel[], showEdgeLabels: boolean): CustomEdgeModel[] {
     return edges.map((edge) => {
         const { data } = edge;
-        const { properties } = data;
         return {
             ...edge,
             visible: true,
             data: {
                 ...data,
-                properties,
                 tag: showEdgeLabels ? data.portProtocolLabel : undefined,
             },
         };

--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
@@ -24,7 +24,7 @@ import { isCompleteSearchFilter } from 'utils/searchUtils';
 
 import PageTitle from 'Components/PageTitle';
 import useURLParameter from 'hooks/useURLParameter';
-import NetworkGraphContainer from './NetworkGraphContainer';
+import NetworkGraphContainer, { Models } from './NetworkGraphContainer';
 import EmptyUnscopedState from './components/EmptyUnscopedState';
 import NetworkBreadcrumbs from './components/NetworkBreadcrumbs';
 import NetworkSearch from './components/NetworkSearch';
@@ -40,7 +40,6 @@ import {
 } from './utils/modelUtils';
 import getScopeHierarchy from './utils/getScopeHierarchy';
 import getSimulation from './utils/getSimulation';
-import { CustomModel } from './types/topology.type';
 
 import './NetworkGraphPage.css';
 
@@ -50,10 +49,6 @@ const emptyModel = {
     edges: [],
 };
 
-type Models = {
-    active: CustomModel;
-    extraneous: CustomModel;
-};
 // TODO: get real includePorts flag from user input
 const includePorts = true;
 
@@ -134,10 +129,7 @@ function NetworkGraphPage() {
                         // get policy nodes from api response
                         const { nodes: policyNodes } = values[1].response;
                         // transform policy data to DataModel
-                        const { policyDataModel, policyNodeMap } = transformPolicyData(
-                            policyNodes,
-                            deploymentCount || 0
-                        );
+                        const { policyDataModel, policyNodeMap } = transformPolicyData(policyNodes);
                         // get active nodes from api response
                         const { nodes: activeNodes } = values[0].response;
                         // transform active data to DataModel
@@ -269,6 +261,7 @@ function NetworkGraphPage() {
                             displayOptions={displayOptions}
                             simulation={simulation}
                             selectedClusterId={selectedClusterId || ''}
+                            clusterDeploymentCount={deploymentCount || 0}
                         />
                     )}
                 {isLoading && (

--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
@@ -24,6 +24,7 @@ import { isCompleteSearchFilter } from 'utils/searchUtils';
 
 import PageTitle from 'Components/PageTitle';
 import useURLParameter from 'hooks/useURLParameter';
+import NetworkGraphContainer from './NetworkGraphContainer';
 import EmptyUnscopedState from './components/EmptyUnscopedState';
 import NetworkBreadcrumbs from './components/NetworkBreadcrumbs';
 import NetworkSearch from './components/NetworkSearch';
@@ -31,7 +32,6 @@ import SimulateNetworkPolicyButton from './simulation/SimulateNetworkPolicyButto
 import EdgeStateSelect, { EdgeState } from './components/EdgeStateSelect';
 import DisplayOptionsSelect, { DisplayOption } from './components/DisplayOptionsSelect';
 import TimeWindowSelector from './components/TimeWindowSelector';
-import NetworkGraph from './NetworkGraph';
 import {
     transformPolicyData,
     transformActiveData,
@@ -40,12 +40,7 @@ import {
 } from './utils/modelUtils';
 import getScopeHierarchy from './utils/getScopeHierarchy';
 import getSimulation from './utils/getSimulation';
-import {
-    CustomEdgeModel,
-    CustomModel,
-    CustomNodeModel,
-    DeploymentData,
-} from './types/topology.type';
+import { CustomModel } from './types/topology.type';
 
 import './NetworkGraphPage.css';
 
@@ -53,7 +48,11 @@ const emptyModel = {
     graph: graphModel,
     nodes: [],
     edges: [],
-    updateCount: 0,
+};
+
+type Models = {
+    active: CustomModel;
+    extraneous: CustomModel;
 };
 // TODO: get real includePorts flag from user input
 const includePorts = true;
@@ -68,9 +67,10 @@ function NetworkGraphPage() {
         'externalBadge',
         'edgeLabel',
     ]);
-    const [activeModel, setActiveModel] = useState<CustomModel>(emptyModel);
-    const [extraneousFlowsModel, setExtraneousFlowsModel] = useState<CustomModel>(emptyModel);
-    const [model, setModel] = useState<CustomModel>(emptyModel);
+    const [models, setModels] = useState<Models>({
+        active: emptyModel,
+        extraneous: emptyModel,
+    });
     const [isLoading, setIsLoading] = useState(false);
     const [timeWindow, setTimeWindow] = useState<typeof timeWindows[number]>(timeWindows[0]);
     const [lastUpdatedTime, setLastUpdatedTime] = useState<string>('never');
@@ -92,6 +92,8 @@ function NetworkGraphPage() {
     const selectedClusterId = clusters.find((cl) => cl.name === clusterFromUrl)?.id;
     const selectedCluster = { name: clusterFromUrl, id: selectedClusterId };
     const { deploymentCount } = useFetchDeploymentCount(selectedClusterId || '');
+
+    console.log('NetworkGraphPage');
 
     useDeepCompareEffect(() => {
         // check that user is finished adding a complete filter
@@ -148,8 +150,6 @@ function NetworkGraphPage() {
                             activeNodeMap,
                             activeEdgeMap
                         );
-                        setActiveModel(activeDataModel);
-                        setExtraneousFlowsModel(extraneousFlowsDataModel);
 
                         const newUpdatedTimestamp = new Date();
                         // show only hours and minutes, use options with the default locale - use an empty array
@@ -158,6 +158,11 @@ function NetworkGraphPage() {
                             minute: '2-digit',
                         });
                         setLastUpdatedTime(lastUpdatedDisplayTime);
+
+                        setModels({
+                            active: activeDataModel,
+                            extraneous: extraneousFlowsDataModel,
+                        });
                     })
                     .catch(() => {
                         // TODO
@@ -173,73 +178,6 @@ function NetworkGraphPage() {
         remainingQuery,
         timeWindow,
     ]);
-
-    const setModelByEdgeState = useCallback(() => {
-        if (edgeState === 'active') {
-            setModel({ ...activeModel, updateCount: model.updateCount + 1 });
-        } else if (edgeState === 'extraneous') {
-            setModel({ ...extraneousFlowsModel, updateCount: model.updateCount + 1 });
-        }
-    }, [edgeState, activeModel, extraneousFlowsModel]);
-
-    useEffect(() => {
-        setModelByEdgeState();
-    }, [setModelByEdgeState]);
-
-    useEffect(() => {
-        const showPolicyState = !!displayOptions.includes('policyStatusBadge');
-        const showExternalState = !!displayOptions.includes('externalBadge');
-        const showEdgeLabels = !!displayOptions.includes('edgeLabel');
-        let updatedNodes: CustomNodeModel[] = model.nodes;
-        let updatedEdges: CustomEdgeModel[] = model.edges;
-
-        // if all display options are true, set back to existing default data model
-        if (showPolicyState && showExternalState && showEdgeLabels) {
-            setModelByEdgeState();
-        } else {
-            // this is to update the display options visually for deployment nodes on the graph
-            if (model.nodes?.length) {
-                // need to improve perf to only perform this if policyStatusBadge OR externalBadge has changed
-                updatedNodes = model.nodes.map((node) => {
-                    const { data } = node;
-                    if (data.type === 'DEPLOYMENT') {
-                        return {
-                            ...node,
-                            data: {
-                                ...data,
-                                showPolicyState,
-                                showExternalState,
-                            } as DeploymentData,
-                        };
-                    }
-                    return node;
-                });
-            }
-
-            if (model.edges?.length) {
-                // need to improve perf to only perform this if edgeLabel has changed
-                updatedEdges = model.edges.map((edge) => {
-                    const { data } = edge;
-                    return {
-                        ...edge,
-                        data: {
-                            ...data,
-                            tag: showEdgeLabels ? data.portProtocolLabel : undefined,
-                        },
-                    };
-                });
-            }
-
-            const updatedModel: CustomModel = {
-                ...model,
-                nodes: updatedNodes,
-                edges: updatedEdges,
-                updateCount: model.updateCount + 1,
-            };
-            setModel(updatedModel);
-        }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [displayOptions]);
 
     return (
         <>
@@ -322,14 +260,17 @@ function NetworkGraphPage() {
                 padding={{ default: 'noPadding' }}
             >
                 {!hasClusterNamespaceSelected && <EmptyUnscopedState />}
-                {model.nodes.length > 0 && !isLoading && (
-                    <NetworkGraph
-                        model={model}
-                        edgeState={edgeState}
-                        simulation={simulation}
-                        selectedClusterId={selectedClusterId || ''}
-                    />
-                )}
+                {models.active.nodes.length > 0 &&
+                    models.extraneous.nodes.length > 0 &&
+                    !isLoading && (
+                        <NetworkGraphContainer
+                            models={models}
+                            edgeState={edgeState}
+                            displayOptions={displayOptions}
+                            simulation={simulation}
+                            selectedClusterId={selectedClusterId || ''}
+                        />
+                    )}
                 {isLoading && (
                     <Bullseye>
                         <Spinner isSVG />

--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState } from 'react';
 import {
     PageSection,
     Title,
@@ -63,8 +63,8 @@ function NetworkGraphPage() {
         'edgeLabel',
     ]);
     const [models, setModels] = useState<Models>({
-        active: emptyModel,
-        extraneous: emptyModel,
+        activeModel: emptyModel,
+        extraneousModel: emptyModel,
     });
     const [isLoading, setIsLoading] = useState(false);
     const [timeWindow, setTimeWindow] = useState<typeof timeWindows[number]>(timeWindows[0]);
@@ -87,8 +87,6 @@ function NetworkGraphPage() {
     const selectedClusterId = clusters.find((cl) => cl.name === clusterFromUrl)?.id;
     const selectedCluster = { name: clusterFromUrl, id: selectedClusterId };
     const { deploymentCount } = useFetchDeploymentCount(selectedClusterId || '');
-
-    console.log('NetworkGraphPage');
 
     useDeepCompareEffect(() => {
         // check that user is finished adding a complete filter
@@ -152,8 +150,8 @@ function NetworkGraphPage() {
                         setLastUpdatedTime(lastUpdatedDisplayTime);
 
                         setModels({
-                            active: activeDataModel,
-                            extraneous: extraneousFlowsDataModel,
+                            activeModel: activeDataModel,
+                            extraneousModel: extraneousFlowsDataModel,
                         });
                     })
                     .catch(() => {
@@ -252,8 +250,8 @@ function NetworkGraphPage() {
                 padding={{ default: 'noPadding' }}
             >
                 {!hasClusterNamespaceSelected && <EmptyUnscopedState />}
-                {models.active.nodes.length > 0 &&
-                    models.extraneous.nodes.length > 0 &&
+                {models.activeModel.nodes.length > 0 &&
+                    models.extraneousModel.nodes.length > 0 &&
                     !isLoading && (
                         <NetworkGraphContainer
                             models={models}

--- a/ui/apps/platform/src/Containers/NetworkGraph/TopologyComponent.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/TopologyComponent.tsx
@@ -1,0 +1,202 @@
+import React from 'react';
+import { useHistory } from 'react-router-dom';
+import { Popover } from '@patternfly/react-core';
+import {
+    SELECTION_EVENT,
+    SelectionEventListener,
+    useEventListener,
+    TopologySideBar,
+    TopologyView,
+    createTopologyControlButtons,
+    defaultControlButtonsOptions,
+    TopologyControlBar,
+    useVisualizationController,
+    VisualizationSurface,
+} from '@patternfly/react-topology';
+
+import { networkBasePathPF } from 'routePaths';
+import { getQueryObject, getQueryString } from 'utils/queryStringUtils';
+import DeploymentSideBar from './deployment/DeploymentSideBar';
+import NamespaceSideBar from './namespace/NamespaceSideBar';
+import CidrBlockSideBar from './cidr/CidrBlockSideBar';
+import ExternalEntitiesSideBar from './externalEntities/ExternalEntitiesSideBar';
+import ExternalGroupSideBar from './external/ExternalGroupSideBar';
+import NetworkPolicySimulatorSidePanel from './simulation/NetworkPolicySimulatorSidePanel';
+import { getNodeById } from './utils/networkGraphUtils';
+import { CustomModel, CustomNodeModel } from './types/topology.type';
+import { Simulation } from './utils/getSimulation';
+import LegendContent from './components/LegendContent';
+
+import {
+    ApplyNetworkPolicyModification,
+    NetworkPolicySimulator,
+    SetNetworkPolicyModification,
+} from './hooks/useNetworkPolicySimulator';
+
+// TODO: move these type defs to a central location
+export const UrlDetailType = {
+    NAMESPACE: 'namespace',
+    DEPLOYMENT: 'deployment',
+    CIDR_BLOCK: 'cidr',
+    EXTERNAL_ENTITIES: 'internet',
+    EXTERNAL: 'external',
+} as const;
+export type UrlDetailTypeKey = keyof typeof UrlDetailType;
+export type UrlDetailTypeValue = typeof UrlDetailType[UrlDetailTypeKey];
+
+function getUrlParamsForEntity(type, id): [UrlDetailTypeValue, string] {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+    return [UrlDetailType[type], id];
+}
+
+export type TopologyComponentProps = {
+    model: CustomModel;
+    simulation: Simulation;
+    selectedClusterId: string;
+    selectedNode?: CustomNodeModel;
+    simulator: NetworkPolicySimulator;
+    setNetworkPolicyModification: SetNetworkPolicyModification;
+    applyNetworkPolicyModification: ApplyNetworkPolicyModification;
+};
+
+// @TODO: Consider a better approach to managing the side panel related state (simulation + URL path for entities)
+function clearSimulationQuery(search: string): string {
+    const modifiedSearchFilter = getQueryObject(search);
+    delete modifiedSearchFilter.simulation;
+    const queryString = getQueryString(modifiedSearchFilter);
+    return queryString;
+}
+
+const TopologyComponent = ({
+    model,
+    simulation,
+    selectedClusterId,
+    selectedNode,
+    simulator,
+    setNetworkPolicyModification,
+    applyNetworkPolicyModification,
+}: TopologyComponentProps) => {
+    const history = useHistory();
+    const controller = useVisualizationController();
+    controller.fromModel(model, true);
+
+    function closeSidebar() {
+        const queryString = clearSimulationQuery(history.location.search);
+        history.push(`${networkBasePathPF}${queryString}`);
+    }
+
+    function onSelect(ids: string[]) {
+        const newSelectedId = ids?.[0] || '';
+        const newSelectedEntity = getNodeById(model?.nodes, newSelectedId);
+        if (newSelectedEntity) {
+            const { data, id } = newSelectedEntity;
+            const [newDetailType, newDetailId] = getUrlParamsForEntity(data.type, id);
+            const queryString = clearSimulationQuery(history.location.search);
+            // if found, and it's not the logical grouping of all external sources, then trigger URL update
+            if (newDetailId !== 'EXTERNAL') {
+                history.push(`${networkBasePathPF}/${newDetailType}/${newDetailId}${queryString}`);
+            } else {
+                // otherwise, return to the graph-only state
+                history.push(`${networkBasePathPF}${queryString}`);
+            }
+        }
+    }
+
+    function zoomInCallback() {
+        controller.getGraph().scaleBy(4 / 3);
+    }
+
+    function zoomOutCallback() {
+        controller.getGraph().scaleBy(0.75);
+    }
+
+    function fitToScreenCallback() {
+        controller.getGraph().fit(80);
+    }
+
+    function resetViewCallback() {
+        controller.getGraph().reset();
+        controller.getGraph().layout();
+    }
+
+    useEventListener<SelectionEventListener>(SELECTION_EVENT, (ids) => {
+        onSelect(ids);
+    });
+
+    const selectedIds = selectedNode ? [selectedNode.id] : [];
+
+    return (
+        <TopologyView
+            sideBar={
+                <TopologySideBar resizable onClose={closeSidebar}>
+                    {simulation.isOn && simulation.type === 'networkPolicy' && (
+                        <NetworkPolicySimulatorSidePanel
+                            selectedClusterId={selectedClusterId}
+                            simulator={simulator}
+                            setNetworkPolicyModification={setNetworkPolicyModification}
+                            applyNetworkPolicyModification={applyNetworkPolicyModification}
+                        />
+                    )}
+                    {selectedNode && selectedNode?.data?.type === 'NAMESPACE' && (
+                        <NamespaceSideBar
+                            namespaceId={selectedNode.id}
+                            nodes={model?.nodes || []}
+                            edges={model?.edges || []}
+                        />
+                    )}
+                    {selectedNode && selectedNode?.data?.type === 'DEPLOYMENT' && (
+                        <DeploymentSideBar
+                            deploymentId={selectedNode.id}
+                            nodes={model?.nodes || []}
+                            edges={model?.edges || []}
+                        />
+                    )}
+                    {selectedNode && selectedNode?.data?.type === 'EXTERNAL_GROUP' && (
+                        <ExternalGroupSideBar
+                            id={selectedNode.id}
+                            nodes={model?.nodes || []}
+                            edges={model?.edges || []}
+                        />
+                    )}
+                    {selectedNode && selectedNode?.data?.type === 'CIDR_BLOCK' && (
+                        <CidrBlockSideBar
+                            id={selectedNode.id}
+                            nodes={model?.nodes || []}
+                            edges={model?.edges || []}
+                        />
+                    )}
+                    {selectedNode && selectedNode?.data?.type === 'EXTERNAL_ENTITIES' && (
+                        <ExternalEntitiesSideBar
+                            id={selectedNode.id}
+                            nodes={model?.nodes || []}
+                            edges={model?.edges || []}
+                        />
+                    )}
+                </TopologySideBar>
+            }
+            sideBarOpen={!!selectedNode || simulation.isOn}
+            sideBarResizable
+            controlBar={
+                <TopologyControlBar
+                    controlButtons={createTopologyControlButtons({
+                        ...defaultControlButtonsOptions,
+                        zoomInCallback,
+                        zoomOutCallback,
+                        fitToScreenCallback,
+                        resetViewCallback,
+                    })}
+                />
+            }
+        >
+            <VisualizationSurface state={{ selectedIds }} />
+            <Popover
+                aria-label="Network graph legend"
+                bodyContent={<LegendContent />}
+                hasAutoWidth
+                reference={() => document.getElementById('legend') as HTMLButtonElement}
+            />
+        </TopologyView>
+    );
+};
+
+export default TopologyComponent;

--- a/ui/apps/platform/src/Containers/NetworkGraph/types/topology.type.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/types/topology.type.ts
@@ -3,10 +3,7 @@ import { EdgeModel, EdgeTerminalType, Model, NodeModel } from '@patternfly/react
 import { EdgeProperties, ListenPort, OutEdges } from 'types/networkFlow.proto';
 import { Override } from 'utils/type.utils';
 
-export type CustomModel = Override<
-    Model,
-    { nodes: CustomNodeModel[]; edges: CustomEdgeModel[]; updateCount: number }
->;
+export type CustomModel = Override<Model, { nodes: CustomNodeModel[]; edges: CustomEdgeModel[] }>;
 
 // Node types
 

--- a/ui/apps/platform/src/Containers/NetworkGraph/types/topology.type.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/types/topology.type.ts
@@ -101,7 +101,10 @@ export type ExtraneousData = {
 
 // Edge types
 
-export type CustomEdgeModel = Override<EdgeModel, { data: EdgeData }>;
+export type CustomEdgeModel = Override<
+    EdgeModel,
+    { source: string; target: string; data: EdgeData }
+>;
 
 export type EdgeData = {
     // the edge label shows up when this exists

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/flowUtils.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/flowUtils.ts
@@ -120,11 +120,6 @@ export function getNetworkFlows(
     id: string
 ): Flow[] {
     const networkFlows: Flow[] = edges.reduce((acc, edge) => {
-        // filter out edges not connected to node with selected id
-        if ((edge.source !== id && edge.target !== id) || !edge.source || !edge.target) {
-            return acc;
-        }
-
         const isSourceNodeSelected = edge.source === id;
 
         const sourceNode = controller.getNodeById(edge.source);

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/modelUtils.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/modelUtils.tsx
@@ -340,8 +340,8 @@ function getNetworkPolicyState(
 const POLICY_NODE_EXTERNALLY_CONNECTED_VALUE = false;
 
 export function transformPolicyData(
-    nodes: Node[],
-    flows: number
+    nodes: Node[]
+    // flows: number
 ): { policyDataModel: CustomModel; policyNodeMap: Record<string, DeploymentNodeModel> } {
     const policyDataModel: CustomModel = {
         graph: graphModel,
@@ -418,9 +418,9 @@ export function transformPolicyData(
             }
         });
     });
-    const { extraneousEgressNode, extraneousIngressNode } = createExtraneousNodes(flows);
-    policyDataModel.nodes.push(extraneousEgressNode);
-    policyDataModel.nodes.push(extraneousIngressNode);
+    // const { extraneousEgressNode, extraneousIngressNode } = createExtraneousNodes(flows);
+    // policyDataModel.nodes.push(extraneousEgressNode);
+    // policyDataModel.nodes.push(extraneousIngressNode);
     policyDataModel.edges.push(...Object.values(policyEdgeMap));
     return { policyDataModel, policyNodeMap };
 }
@@ -457,7 +457,7 @@ export function createExtraneousFlowsModel(
     // only add to extraneous flows model when policy edge is not in the active graph
     policyDataModel.edges?.forEach((policyEdge) => {
         const { id: policyEdgeId, source, target } = policyEdge;
-        const reversePolicyEdgeId = `${target as string}-${source as string}`;
+        const reversePolicyEdgeId = `${target}-${source}`;
         const activeEdge = activeEdgeMap[policyEdgeId];
         const activeReverseEdge = activeEdgeMap[reversePolicyEdgeId];
 
@@ -532,11 +532,11 @@ export function createExtraneousFlowsModel(
 }
 
 export function createExtraneousNodes(numFlows: number): {
-    extraneousEgressNode: ExtraneousNodeModel;
-    extraneousIngressNode: ExtraneousNodeModel;
+    egressFlowsNode: ExtraneousNodeModel;
+    ingressFlowsNode: ExtraneousNodeModel;
 } {
-    const extraneousEgressNode: ExtraneousNodeModel = {
-        id: 'extraneous-egress',
+    const egressFlowsNode: ExtraneousNodeModel = {
+        id: 'extraneous-egress-flows',
         type: 'fakeGroup',
         width: 75,
         height: 75,
@@ -549,8 +549,8 @@ export function createExtraneousNodes(numFlows: number): {
             numFlows,
         },
     };
-    const extraneousIngressNode: ExtraneousNodeModel = {
-        id: 'extraneous-ingress',
+    const ingressFlowsNode: ExtraneousNodeModel = {
+        id: 'extraneous-ingress-flows',
         type: 'fakeGroup',
         width: 75,
         height: 75,
@@ -563,7 +563,7 @@ export function createExtraneousNodes(numFlows: number): {
             numFlows,
         },
     };
-    return { extraneousEgressNode, extraneousIngressNode };
+    return { egressFlowsNode, ingressFlowsNode };
 }
 
 export function createExtraneousEdges(selectedNodeId: string): {
@@ -574,7 +574,7 @@ export function createExtraneousEdges(selectedNodeId: string): {
         id: 'extraneous-egress-edge',
         type: 'edge',
         source: selectedNodeId,
-        target: 'extraneous-egress',
+        target: 'extraneous-egress-flows',
         visible: true,
         edgeStyle: EdgeStyle.dashed,
         data: {
@@ -586,7 +586,7 @@ export function createExtraneousEdges(selectedNodeId: string): {
     const extraneousIngressEdge = {
         id: 'extraneous-ingress-edge',
         type: 'edge',
-        source: 'extraneous-ingress',
+        source: 'extraneous-ingress-flows',
         target: selectedNodeId,
         visible: true,
         edgeStyle: EdgeStyle.dashed,

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/modelUtils.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/modelUtils.tsx
@@ -190,7 +190,6 @@ export function transformActiveData(
         graph: graphModel,
         nodes: [] as CustomNodeModel[],
         edges: [] as CustomEdgeModel[],
-        updateCount: 0,
     };
 
     const namespaceNodes: Record<string, NamespaceNodeModel> = {};
@@ -348,7 +347,6 @@ export function transformPolicyData(
         graph: graphModel,
         nodes: [] as CustomNodeModel[],
         edges: [] as CustomEdgeModel[],
-        updateCount: 0,
     };
     // set policyNodeMap to be able to cross reference nodes by id to enhance active node data
     const policyNodeMap: Record<string, DeploymentNodeModel> = {};
@@ -436,7 +434,6 @@ export function createExtraneousFlowsModel(
         graph: graphModel,
         nodes: [] as CustomNodeModel[],
         edges: [] as CustomEdgeModel[],
-        updateCount: 0,
     };
     const namespaceNodes: Record<string, NamespaceNodeModel> = {};
     let externalNode: ExternalGroupNodeModel | null = null;

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/modelUtils.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/modelUtils.tsx
@@ -339,10 +339,10 @@ function getNetworkPolicyState(
 // external connections can only be active, so this is hard coded to false
 const POLICY_NODE_EXTERNALLY_CONNECTED_VALUE = false;
 
-export function transformPolicyData(
-    nodes: Node[]
-    // flows: number
-): { policyDataModel: CustomModel; policyNodeMap: Record<string, DeploymentNodeModel> } {
+export function transformPolicyData(nodes: Node[]): {
+    policyDataModel: CustomModel;
+    policyNodeMap: Record<string, DeploymentNodeModel>;
+} {
     const policyDataModel: CustomModel = {
         graph: graphModel,
         nodes: [] as CustomNodeModel[],
@@ -418,9 +418,6 @@ export function transformPolicyData(
             }
         });
     });
-    // const { extraneousEgressNode, extraneousIngressNode } = createExtraneousNodes(flows);
-    // policyDataModel.nodes.push(extraneousEgressNode);
-    // policyDataModel.nodes.push(extraneousIngressNode);
     policyDataModel.edges.push(...Object.values(policyEdgeMap));
     return { policyDataModel, policyNodeMap };
 }


### PR DESCRIPTION
as it states in the title --
* refactored the data filtering/modifying to be in its own layer (`NetworkGraphContainer`)
* also separated out `TopologyComponent` into its own file and simplified it so that it simply renders whatever the model it is given
* this greatly improves performance of toggling display options when a side panel is open (you should not notice any performance issues)
* display options should persist between selecting a node on the graph and also between edge states
