### PR TITLE
ROX-14428: Create stub manager for declarative configuration

### DIFF
--- a/central/declarativeconfig/manager.go
+++ b/central/declarativeconfig/manager.go
@@ -1,6 +1,6 @@
 package declarativeconfig
 
-// Manager manages reconciling declarative configurations.
+// Manager manages reconciling declarative configuration.
 type Manager interface {
 	WatchDeclarativeConfigDir()
 }

--- a/central/declarativeconfig/manager.go
+++ b/central/declarativeconfig/manager.go
@@ -1,0 +1,6 @@
+package declarativeconfig
+
+// Manager manages reconciling declarative configurations.
+type Manager interface {
+	WatchDeclarativeConfigDir()
+}

--- a/central/declarativeconfig/manager_impl.go
+++ b/central/declarativeconfig/manager_impl.go
@@ -1,0 +1,41 @@
+package declarativeconfig
+
+import (
+	"context"
+	"time"
+
+	"github.com/stackrox/rox/pkg/k8scfgwatch"
+	"github.com/stackrox/rox/pkg/logging"
+	"github.com/stackrox/rox/pkg/sync"
+)
+
+const (
+	watchInterval        = 5 * time.Second
+	declarativeConfigDir = "/run/stackrox.io/declarative-configuration"
+)
+
+var (
+	log = logging.LoggerForModule()
+)
+
+type managerImpl struct {
+	once sync.Once
+}
+
+// New creates a new instance of Manager.
+// Note that it will not watch the declarative configuration directories when creaeted, only after
+// WatchDeclarativeConfigDir has been called.
+func New() Manager {
+	return &managerImpl{}
+}
+
+func (m *managerImpl) WatchDeclarativeConfigDir() {
+	m.once.Do(func() {
+		wh := &watchHandler{m: m}
+		// Set Force to true, so we explicitly retry watching the files within the directory and not stop on the first
+		// error occurred.
+		watchOpts := k8scfgwatch.Options{Interval: watchInterval, Force: true}
+		_ = k8scfgwatch.WatchConfigMountDir(context.Background(), declarativeConfigDir,
+			k8scfgwatch.DeduplicateWatchErrors(wh), watchOpts)
+	})
+}

--- a/central/declarativeconfig/manager_impl.go
+++ b/central/declarativeconfig/manager_impl.go
@@ -23,7 +23,7 @@ type managerImpl struct {
 }
 
 // New creates a new instance of Manager.
-// Note that it will not watch the declarative configuration directories when creaeted, only after
+// Note that it will not watch the declarative configuration directories when created, only after
 // WatchDeclarativeConfigDir has been called.
 func New() Manager {
 	return &managerImpl{}

--- a/central/declarativeconfig/manager_impl.go
+++ b/central/declarativeconfig/manager_impl.go
@@ -5,17 +5,12 @@ import (
 	"time"
 
 	"github.com/stackrox/rox/pkg/k8scfgwatch"
-	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/sync"
 )
 
 const (
 	watchInterval        = 5 * time.Second
 	declarativeConfigDir = "/run/stackrox.io/declarative-configuration"
-)
-
-var (
-	log = logging.LoggerForModule()
 )
 
 type managerImpl struct {

--- a/central/declarativeconfig/singleton.go
+++ b/central/declarativeconfig/singleton.go
@@ -1,0 +1,16 @@
+package declarativeconfig
+
+import "github.com/stackrox/rox/pkg/sync"
+
+var (
+	once     sync.Once
+	instance Manager
+)
+
+// Singleton provides the instance of Manager to use.
+func Singleton() Manager {
+	once.Do(func() {
+		instance = New()
+	})
+	return instance
+}

--- a/central/declarativeconfig/singleton.go
+++ b/central/declarativeconfig/singleton.go
@@ -7,8 +7,8 @@ var (
 	instance Manager
 )
 
-// Singleton provides the instance of Manager to use.
-func Singleton() Manager {
+// ManagerSingleton provides the instance of Manager to use.
+func ManagerSingleton() Manager {
 	once.Do(func() {
 		instance = New()
 	})

--- a/central/declarativeconfig/watch_handler.go
+++ b/central/declarativeconfig/watch_handler.go
@@ -1,0 +1,17 @@
+package declarativeconfig
+
+// TODO(ROX-14147): Add reconciliation of declarative configuration to the watch handler.
+
+type watchHandler struct {
+	m *managerImpl
+}
+
+func (w *watchHandler) OnChange(dir string) (interface{}, error) {
+	return nil, nil
+}
+
+func (w *watchHandler) OnStableUpdate(val interface{}, err error) {
+}
+
+func (w *watchHandler) OnWatchError(err error) {
+}

--- a/central/declarativeconfig/watch_handler.go
+++ b/central/declarativeconfig/watch_handler.go
@@ -1,6 +1,11 @@
 package declarativeconfig
 
+import "github.com/stackrox/rox/pkg/logging"
+
 // TODO(ROX-14147): Add reconciliation of declarative configuration to the watch handler.
+var (
+	log = logging.LoggerForModule()
+)
 
 type watchHandler struct {
 	m *managerImpl

--- a/central/declarativeconfig/watch_handler.go
+++ b/central/declarativeconfig/watch_handler.go
@@ -14,4 +14,5 @@ func (w *watchHandler) OnStableUpdate(val interface{}, err error) {
 }
 
 func (w *watchHandler) OnWatchError(err error) {
+	log.Errorf("Error watching declarative configuration directory: %+v", err)
 }

--- a/central/main.go
+++ b/central/main.go
@@ -45,6 +45,7 @@ import (
 	cveService "github.com/stackrox/rox/central/cve/service"
 	"github.com/stackrox/rox/central/cve/suppress"
 	debugService "github.com/stackrox/rox/central/debug/service"
+	"github.com/stackrox/rox/central/declarativeconfig"
 	deploymentDatastore "github.com/stackrox/rox/central/deployment/datastore"
 	deploymentService "github.com/stackrox/rox/central/deployment/service"
 	detectionService "github.com/stackrox/rox/central/detection/service"
@@ -485,6 +486,10 @@ func startGRPCServer() {
 	}
 
 	basicAuthProvider := userpass.RegisterAuthProviderOrPanic(authProviderRegisteringCtx, basicAuthMgr, registry)
+
+	if features.DeclarativeConfiguration.Enabled() {
+		declarativeconfig.Singleton().WatchDeclarativeConfigDir()
+	}
 
 	clusterInitBackend := backend.Singleton()
 	serviceMTLSExtractor, err := service.NewExtractorWithCertValidation(clusterInitBackend)

--- a/central/main.go
+++ b/central/main.go
@@ -488,7 +488,7 @@ func startGRPCServer() {
 	basicAuthProvider := userpass.RegisterAuthProviderOrPanic(authProviderRegisteringCtx, basicAuthMgr, registry)
 
 	if features.DeclarativeConfiguration.Enabled() {
-		declarativeconfig.Singleton().WatchDeclarativeConfigDir()
+		declarativeconfig.ManagerSingleton().WatchDeclarativeConfigDir()
 	}
 
 	clusterInitBackend := backend.Singleton()


### PR DESCRIPTION
## Description

This PR is a pre-factor for future PRs for the declarative config feature.

It will create a coarse structure of a manager that starts a watch on a specific directory.
Additionally, the watch will be conditionally started in the main routine _iff_ the feature flag is enabled.

In future PRs, the manager implementation will be expanded to also cover the reading file contents from the directory, marshalling these YAMLs to structs, transforming the structs to proto messages, and reconciling the proto messages within the stores.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

