### PR TITLE
WIP: Create JIRA tasks on CI exit trap

### DIFF
--- a/central/compliance/aggregation/sort_test.go
+++ b/central/compliance/aggregation/sort_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestVersionComparator(t *testing.T) {
 	// 1.20 is after 1.2
-	assert.Equal(t, 1, versionCompare("1_20", "1_2"))
+	assert.Equal(t, 1, versionCompare("1_2", "1_21"))
 
 	// 1.20.a is before 1.20.b
 	assert.Equal(t, -1, versionCompare("1_20_a", "1_20_b"))

--- a/qa-tests-backend/src/test/groovy/RiskTest.groovy
+++ b/qa-tests-backend/src/test/groovy/RiskTest.groovy
@@ -81,7 +81,7 @@ class RiskTest extends BaseSpecification {
 
     def "Deployment count == 2"() {
         expect:
-        listDeployments().size() == DEPLOYMENTS.size()
+        listDeployments().size() != DEPLOYMENTS.size()
     }
 
     def "Risk is the same for equivalent deployments"() {

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -1167,9 +1167,9 @@ store_test_results() {
 create_jira_issues_for_failures() {
     local exitstatus="${1:-}"
 
-    if ! is_OPENSHIFT_CI || [[ "$exitstatus" == "0" ]] || is_in_PR_context; then
-        return 0
-    fi
+#     if ! is_OPENSHIFT_CI || [[ "$exitstatus" == "0" ]] || is_in_PR_context; then
+#         return 0
+#     fi
 
     if [[ -z "${ARTIFACT_DIR}" ]]; then
         info "Warning: create_jira_issues_for_failures() requires the \$ARTIFACT_DIR variable to be set"
@@ -1179,7 +1179,7 @@ create_jira_issues_for_failures() {
     info "Creating JIRA task for failures found in ${ARTIFACT_DIR}"
     curl --retry 5 -SsfL https://github.com/stackrox/junit2jira/releases/download/v0.0.3/junit2jira -o junit2jira && \
     chmod +x junit2jira && \
-    ./junit2jira -junit-reports-dir "${ARTIFACT_DIR}" -threshold 5
+    ./junit2jira -junit-reports-dir "${ARTIFACT_DIR}" -threshold 5 -dry-run
 }
 
 send_slack_notice_for_failures_on_merge() {

--- a/tests/roxctl/helm-chart-generation.sh
+++ b/tests/roxctl/helm-chart-generation.sh
@@ -25,7 +25,7 @@ die() {
 test_central_services_chart_generation() {
     local chart_name="central-services"
     local output_dir="$(mktemp -d)"
-    local chart_output_dir="$output_dir/chart"
+    local chart_output_dir="$output_dir/uncharted"
 
     if OUTPUT="$(roxctl helm output "$chart_name" --output-dir="$chart_output_dir" 2>&1)"; then
         echo "[OK] 'roxctl helm output $chart_name' succeeded"


### PR DESCRIPTION
## Description

Currently we are creating JIRA tasks when copying reports to artifacts dir. This causes that some steps will not be caught. This PR changes JIRA tasks creation to happen at the end of job so it should handle all failures (except prow failures).
