### PR TITLE
Skip sub-test from Compliance Test for P/Z

### DIFF
--- a/qa-tests-backend/src/test/groovy/ComplianceTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ComplianceTest.groovy
@@ -53,6 +53,7 @@ import services.PolicyService
 import services.ProcessService
 import services.RoleService
 import util.Timer
+import util.Env
 
 import org.junit.Assume
 import spock.lang.IgnoreIf
@@ -623,6 +624,8 @@ class ComplianceTest extends BaseSpecification {
     */
 
     @Tag("BAT")
+    // skipping tests using SLACK_MAIN_WEBHOOK on P/Z
+    @IgnoreIf({ Env.REMOTE_CLUSTER_ARCH == "ppc64le" || Env.REMOTE_CLUSTER_ARCH == "s390x" })
     def "Verify checks based on Integrations"() {
         def failureEvidence = ["No image scanners are being used in the cluster"]
         def controls = [


### PR DESCRIPTION
## Description

This PR intends to skip 'Verify checks based on Integrations' sub-tests from Compliance Test that are not applicable OR not required to be executed on power & z architectures.
Changes are verified manually using ./gradlew test --tests=TestName
