### PR TITLE
Fix make go-generated-srcs

### DIFF
--- a/central/policycategoryedge/store/postgres/store.go
+++ b/central/policycategoryedge/store/postgres/store.go
@@ -45,19 +45,22 @@ var (
 	targetResource = resources.Policy
 )
 
+// Store is the interface to interact with the storage for storage.PolicyCategoryEdge
 type Store interface {
-	Count(ctx context.Context) (int, error)
-	Exists(ctx context.Context, id string) (bool, error)
-	Get(ctx context.Context, id string) (*storage.PolicyCategoryEdge, bool, error)
-	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.PolicyCategoryEdge, error)
-	GetAll(ctx context.Context) ([]*storage.PolicyCategoryEdge, error)
 	Upsert(ctx context.Context, obj *storage.PolicyCategoryEdge) error
 	UpsertMany(ctx context.Context, objs []*storage.PolicyCategoryEdge) error
 	Delete(ctx context.Context, id string) error
 	DeleteByQuery(ctx context.Context, q *v1.Query) error
+	DeleteMany(ctx context.Context, identifiers []string) error
+
+	Count(ctx context.Context) (int, error)
+	Exists(ctx context.Context, id string) (bool, error)
+
+	Get(ctx context.Context, id string) (*storage.PolicyCategoryEdge, bool, error)
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.PolicyCategoryEdge, error)
+	GetMany(ctx context.Context, identifiers []string) ([]*storage.PolicyCategoryEdge, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
-	GetMany(ctx context.Context, ids []string) ([]*storage.PolicyCategoryEdge, []int, error)
-	DeleteMany(ctx context.Context, ids []string) error
+	GetAll(ctx context.Context) ([]*storage.PolicyCategoryEdge, error)
 
 	Walk(ctx context.Context, fn func(obj *storage.PolicyCategoryEdge) error) error
 
@@ -76,6 +79,8 @@ func New(db *pgxpool.Pool) Store {
 		db: db,
 	}
 }
+
+//// Helper functions
 
 func insertIntoPolicyCategoryEdges(ctx context.Context, batch *pgx.Batch, obj *storage.PolicyCategoryEdge) error {
 
@@ -121,7 +126,9 @@ func (s *storeImpl) copyFromPolicyCategoryEdges(ctx context.Context, tx pgx.Tx, 
 
 	for idx, obj := range objs {
 		// Todo: ROX-9499 Figure out how to more cleanly template around this issue.
-		log.Debugf("This is here for now because there is an issue with pods_TerminatedInstances where the obj in the loop is not used as it only consists of the parent id and the idx.  Putting this here as a stop gap to simply use the object.  %s", obj)
+		log.Debugf("This is here for now because there is an issue with pods_TerminatedInstances where the obj "+
+			"in the loop is not used as it only consists of the parent ID and the index.  Putting this here as a stop gap "+
+			"to simply use the object.  %s", obj)
 
 		serialized, marshalErr := obj.Marshal()
 		if marshalErr != nil {
@@ -139,7 +146,7 @@ func (s *storeImpl) copyFromPolicyCategoryEdges(ctx context.Context, tx pgx.Tx, 
 			serialized,
 		})
 
-		// Add the id to be deleted.
+		// Add the ID to be deleted.
 		deletes = append(deletes, obj.GetId())
 
 		// if we hit our batch size we need to push the data
@@ -165,6 +172,15 @@ func (s *storeImpl) copyFromPolicyCategoryEdges(ctx context.Context, tx pgx.Tx, 
 	}
 
 	return err
+}
+
+func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*pgxpool.Conn, func(), error) {
+	defer metrics.SetAcquireDBConnDuration(time.Now(), op, typ)
+	conn, err := s.db.Acquire(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	return conn, conn.Release, nil
 }
 
 func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.PolicyCategoryEdge) error {
@@ -219,6 +235,11 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.PolicyCategoryE
 	return nil
 }
 
+//// Helper functions - END
+
+//// Interface functions
+
+// Upsert saves the current state of an object in storage.
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.PolicyCategoryEdge) error {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Upsert, "PolicyCategoryEdge")
 
@@ -232,6 +253,7 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.PolicyCategoryEdge)
 	})
 }
 
+// UpsertMany saves the state of multiple objects in the storage.
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.PolicyCategoryEdge) error {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.UpdateMany, "PolicyCategoryEdge")
 
@@ -249,13 +271,90 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.PolicyCatego
 
 		if len(objs) < batchAfter {
 			return s.upsert(ctx, objs...)
-		} else {
-			return s.copyFrom(ctx, objs...)
 		}
+		return s.copyFrom(ctx, objs...)
 	})
 }
 
-// Count returns the number of objects in the store
+// Delete removes the object associated to the specified ID from the store.
+func (s *storeImpl) Delete(ctx context.Context, id string) error {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Remove, "PolicyCategoryEdge")
+
+	var sacQueryFilter *v1.Query
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_WRITE_ACCESS).Resource(targetResource)
+	if !scopeChecker.IsAllowed() {
+		return sac.ErrResourceAccessDenied
+	}
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+}
+
+// DeleteByQuery removes the objects from the store based on the passed query.
+func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Remove, "PolicyCategoryEdge")
+
+	var sacQueryFilter *v1.Query
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_WRITE_ACCESS).Resource(targetResource)
+	if !scopeChecker.IsAllowed() {
+		return sac.ErrResourceAccessDenied
+	}
+
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
+	)
+
+	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
+}
+
+// DeleteMany removes the objects associated to the specified IDs from the store.
+func (s *storeImpl) DeleteMany(ctx context.Context, identifiers []string) error {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.RemoveMany, "PolicyCategoryEdge")
+
+	var sacQueryFilter *v1.Query
+
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_WRITE_ACCESS).Resource(targetResource)
+	if !scopeChecker.IsAllowed() {
+		return sac.ErrResourceAccessDenied
+	}
+
+	// Batch the deletes
+	localBatchSize := deleteBatchSize
+	numRecordsToDelete := len(identifiers)
+	for {
+		if len(identifiers) == 0 {
+			break
+		}
+
+		if len(identifiers) < localBatchSize {
+			localBatchSize = len(identifiers)
+		}
+
+		identifierBatch := identifiers[:localBatchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(identifierBatch...).ProtoQuery(),
+		)
+
+		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(identifiers), numRecordsToDelete)
+			log.Error(err)
+			return err
+		}
+
+		// Move the slice forward to start the next batch
+		identifiers = identifiers[localBatchSize:]
+	}
+
+	return nil
+}
+
+// Count returns the number of objects in the store.
 func (s *storeImpl) Count(ctx context.Context) (int, error) {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Count, "PolicyCategoryEdge")
 
@@ -269,7 +368,7 @@ func (s *storeImpl) Count(ctx context.Context) (int, error) {
 	return postgres.RunCountRequestForSchema(ctx, schema, sacQueryFilter, s.db)
 }
 
-// Exists returns if the id exists in the store
+// Exists returns if the ID exists in the store.
 func (s *storeImpl) Exists(ctx context.Context, id string) (bool, error) {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Exists, "PolicyCategoryEdge")
 
@@ -290,7 +389,7 @@ func (s *storeImpl) Exists(ctx context.Context, id string) (bool, error) {
 	return count > 0, err
 }
 
-// Get returns the object, if it exists from the store
+// Get returns the object, if it exists from the store.
 func (s *storeImpl) Get(ctx context.Context, id string) (*storage.PolicyCategoryEdge, bool, error) {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Get, "PolicyCategoryEdge")
 
@@ -313,133 +412,8 @@ func (s *storeImpl) Get(ctx context.Context, id string) (*storage.PolicyCategory
 
 	return data, true, nil
 }
-func (s *storeImpl) GetAll(ctx context.Context) ([]*storage.PolicyCategoryEdge, error) {
-	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetAll, "PolicyCategoryEdge")
 
-	var objs []*storage.PolicyCategoryEdge
-	err := s.Walk(ctx, func(obj *storage.PolicyCategoryEdge) error {
-		objs = append(objs, obj)
-		return nil
-	})
-	return objs, err
-}
-
-func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*pgxpool.Conn, func(), error) {
-	defer metrics.SetAcquireDBConnDuration(time.Now(), op, typ)
-	conn, err := s.db.Acquire(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	return conn, conn.Release, nil
-}
-
-// Delete removes the specified ID from the store
-func (s *storeImpl) Delete(ctx context.Context, id string) error {
-	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Remove, "PolicyCategoryEdge")
-
-	var sacQueryFilter *v1.Query
-	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_WRITE_ACCESS).Resource(targetResource)
-	if !scopeChecker.IsAllowed() {
-		return sac.ErrResourceAccessDenied
-	}
-
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
-	)
-
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
-}
-
-// DeleteByQuery removes the objects based on the passed query
-func (s *storeImpl) DeleteByQuery(ctx context.Context, query *v1.Query) error {
-	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Remove, "PolicyCategoryEdge")
-
-	var sacQueryFilter *v1.Query
-	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_WRITE_ACCESS).Resource(targetResource)
-	if !scopeChecker.IsAllowed() {
-		return sac.ErrResourceAccessDenied
-	}
-
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		query,
-	)
-
-	return postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db)
-}
-
-// GetIDs returns all the IDs for the store
-func (s *storeImpl) GetIDs(ctx context.Context) ([]string, error) {
-	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetAll, "storage.PolicyCategoryEdgeIDs")
-	var sacQueryFilter *v1.Query
-
-	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_ACCESS).Resource(targetResource)
-	if !scopeChecker.IsAllowed() {
-		return nil, nil
-	}
-	result, err := postgres.RunSearchRequestForSchema(ctx, schema, sacQueryFilter, s.db)
-	if err != nil {
-		return nil, err
-	}
-
-	ids := make([]string, 0, len(result))
-	for _, entry := range result {
-		ids = append(ids, entry.ID)
-	}
-
-	return ids, nil
-}
-
-// GetMany returns the objects specified by the IDs or the index in the missing indices slice
-func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.PolicyCategoryEdge, []int, error) {
-	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetMany, "PolicyCategoryEdge")
-
-	if len(ids) == 0 {
-		return nil, nil, nil
-	}
-
-	var sacQueryFilter *v1.Query
-
-	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_ACCESS).Resource(targetResource)
-	if !scopeChecker.IsAllowed() {
-		return nil, nil, nil
-	}
-	q := search.ConjunctionQuery(
-		sacQueryFilter,
-		search.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery(),
-	)
-
-	rows, err := postgres.RunGetManyQueryForSchema[storage.PolicyCategoryEdge](ctx, schema, q, s.db)
-	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			missingIndices := make([]int, 0, len(ids))
-			for i := range ids {
-				missingIndices = append(missingIndices, i)
-			}
-			return nil, missingIndices, nil
-		}
-		return nil, nil, err
-	}
-	resultsByID := make(map[string]*storage.PolicyCategoryEdge, len(rows))
-	for _, msg := range rows {
-		resultsByID[msg.GetId()] = msg
-	}
-	missingIndices := make([]int, 0, len(ids)-len(resultsByID))
-	// It is important that the elems are populated in the same order as the input ids
-	// slice, since some calling code relies on that to maintain order.
-	elems := make([]*storage.PolicyCategoryEdge, 0, len(resultsByID))
-	for i, id := range ids {
-		if result, ok := resultsByID[id]; !ok {
-			missingIndices = append(missingIndices, i)
-		} else {
-			elems = append(elems, result)
-		}
-	}
-	return elems, missingIndices, nil
-}
-
-// GetByQuery returns the objects matching the query
+// GetByQuery returns the objects from the store matching the query.
 func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.PolicyCategoryEdge, error) {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetByQuery, "PolicyCategoryEdge")
 
@@ -464,49 +438,89 @@ func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage
 	return rows, nil
 }
 
-// Delete removes the specified IDs from the store
-func (s *storeImpl) DeleteMany(ctx context.Context, ids []string) error {
-	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.RemoveMany, "PolicyCategoryEdge")
+// GetMany returns the objects specified by the IDs from the store as well as the index in the missing indices slice.
+func (s *storeImpl) GetMany(ctx context.Context, identifiers []string) ([]*storage.PolicyCategoryEdge, []int, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetMany, "PolicyCategoryEdge")
+
+	if len(identifiers) == 0 {
+		return nil, nil, nil
+	}
 
 	var sacQueryFilter *v1.Query
 
-	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_WRITE_ACCESS).Resource(targetResource)
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_ACCESS).Resource(targetResource)
 	if !scopeChecker.IsAllowed() {
-		return sac.ErrResourceAccessDenied
+		return nil, nil, nil
 	}
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		search.NewQueryBuilder().AddDocIDs(identifiers...).ProtoQuery(),
+	)
 
-	// Batch the deletes
-	localBatchSize := deleteBatchSize
-	numRecordsToDelete := len(ids)
-	for {
-		if len(ids) == 0 {
-			break
+	rows, err := postgres.RunGetManyQueryForSchema[storage.PolicyCategoryEdge](ctx, schema, q, s.db)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			missingIndices := make([]int, 0, len(identifiers))
+			for i := range identifiers {
+				missingIndices = append(missingIndices, i)
+			}
+			return nil, missingIndices, nil
 		}
-
-		if len(ids) < localBatchSize {
-			localBatchSize = len(ids)
-		}
-
-		idBatch := ids[:localBatchSize]
-		q := search.ConjunctionQuery(
-			sacQueryFilter,
-			search.NewQueryBuilder().AddDocIDs(idBatch...).ProtoQuery(),
-		)
-
-		if err := postgres.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
-			err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
-			log.Error(err)
-			return err
-		}
-
-		// Move the slice forward to start the next batch
-		ids = ids[localBatchSize:]
+		return nil, nil, err
 	}
-
-	return nil
+	resultsByID := make(map[string]*storage.PolicyCategoryEdge, len(rows))
+	for _, msg := range rows {
+		resultsByID[msg.GetId()] = msg
+	}
+	missingIndices := make([]int, 0, len(identifiers)-len(resultsByID))
+	// It is important that the elems are populated in the same order as the input identifiers
+	// slice, since some calling code relies on that to maintain order.
+	elems := make([]*storage.PolicyCategoryEdge, 0, len(resultsByID))
+	for i, identifier := range identifiers {
+		if result, ok := resultsByID[identifier]; !ok {
+			missingIndices = append(missingIndices, i)
+		} else {
+			elems = append(elems, result)
+		}
+	}
+	return elems, missingIndices, nil
 }
 
-// Walk iterates over all of the objects in the store and applies the closure
+// GetIDs returns all the IDs for the store.
+func (s *storeImpl) GetIDs(ctx context.Context) ([]string, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetAll, "storage.PolicyCategoryEdgeIDs")
+	var sacQueryFilter *v1.Query
+
+	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_ACCESS).Resource(targetResource)
+	if !scopeChecker.IsAllowed() {
+		return nil, nil
+	}
+	result, err := postgres.RunSearchRequestForSchema(ctx, schema, sacQueryFilter, s.db)
+	if err != nil {
+		return nil, err
+	}
+
+	identifiers := make([]string, 0, len(result))
+	for _, entry := range result {
+		identifiers = append(identifiers, entry.ID)
+	}
+
+	return identifiers, nil
+}
+
+// GetAll retrieves all objects from the store.
+func (s *storeImpl) GetAll(ctx context.Context) ([]*storage.PolicyCategoryEdge, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.GetAll, "PolicyCategoryEdge")
+
+	var objs []*storage.PolicyCategoryEdge
+	err := s.Walk(ctx, func(obj *storage.PolicyCategoryEdge) error {
+		objs = append(objs, obj)
+		return nil
+	})
+	return objs, err
+}
+
+// Walk iterates over all of the objects in the store and applies the closure.
 func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.PolicyCategoryEdge) error) error {
 	var sacQueryFilter *v1.Query
 	scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_ACCESS).Resource(targetResource)
@@ -535,31 +549,36 @@ func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.PolicyCategor
 	return nil
 }
 
+//// Stubs for satisfying legacy interfaces
+
+// AckKeysIndexed acknowledges the passed keys were indexed.
+func (s *storeImpl) AckKeysIndexed(ctx context.Context, keys ...string) error {
+	return nil
+}
+
+// GetKeysToIndex returns the keys that need to be indexed.
+func (s *storeImpl) GetKeysToIndex(ctx context.Context) ([]string, error) {
+	return nil, nil
+}
+
+//// Interface functions - END
+
 //// Used for testing
+
+// CreateTableAndNewStore returns a new Store instance for testing.
+func CreateTableAndNewStore(ctx context.Context, db *pgxpool.Pool, gormDB *gorm.DB) Store {
+	pkgSchema.ApplySchemaForTable(ctx, gormDB, baseTable)
+	return New(db)
+}
+
+// Destroy drops the tables associated with the target object type.
+func Destroy(ctx context.Context, db *pgxpool.Pool) {
+	dropTablePolicyCategoryEdges(ctx, db)
+}
 
 func dropTablePolicyCategoryEdges(ctx context.Context, db *pgxpool.Pool) {
 	_, _ = db.Exec(ctx, "DROP TABLE IF EXISTS policy_category_edges CASCADE")
 
 }
 
-func Destroy(ctx context.Context, db *pgxpool.Pool) {
-	dropTablePolicyCategoryEdges(ctx, db)
-}
-
-// CreateTableAndNewStore returns a new Store instance for testing
-func CreateTableAndNewStore(ctx context.Context, db *pgxpool.Pool, gormDB *gorm.DB) Store {
-	pkgSchema.ApplySchemaForTable(ctx, gormDB, baseTable)
-	return New(db)
-}
-
-//// Stubs for satisfying legacy interfaces
-
-// AckKeysIndexed acknowledges the passed keys were indexed
-func (s *storeImpl) AckKeysIndexed(ctx context.Context, keys ...string) error {
-	return nil
-}
-
-// GetKeysToIndex returns the keys that need to be indexed
-func (s *storeImpl) GetKeysToIndex(ctx context.Context) ([]string, error) {
-	return nil, nil
-}
+//// Used for testing - END

--- a/tools/generate-helpers/pg-table-bindings/list.go
+++ b/tools/generate-helpers/pg-table-bindings/list.go
@@ -65,6 +65,7 @@ func init() {
 		// TODO: ROX-13888 Replace Policy with WorkflowAdministration.
 		&storage.Policy{}:                 resources.Policy,
 		&storage.PolicyCategory{}:         resources.Policy,
+		&storage.PolicyCategoryEdge{}:     resources.Policy,
 		&storage.ProcessBaselineResults{}: resources.DeploymentExtension,
 		&storage.ProcessBaseline{}:        resources.DeploymentExtension,
 		&storage.ProcessIndicator{}:       resources.DeploymentExtension,


### PR DESCRIPTION
## Description

When running `make go-generated-srcs`, I encountered an error:

```
make go-generated-srcs
...
central/policycategoryedge/search/searcher_impl.go
central/policycategoryedge/search/mocks/searcher.go
central/policycategoryedge/store/store.go
central/policycategoryedge/store/postgres/gen.go
pg-table-bindings-wrapper --get-all-func --type=storage.PolicyCategoryEdge --table=policy_category_edges --search-category POLICY_CATEGORY_EDGE --references=policies:storage.Policy,policy_categories:storage.PolicyCategory --search-scope POLICY_CATEGORY_EDGE,POLICY_CATEGORIES
2023-01-25 14:20:44 Generating for storage.PolicyCategoryEdge
Error: template: store.go:74:19: executing "store.go" at <.Obj.IsGloballyScoped>: error calling IsGloballyScoped: unknown resource: PolicyCategoryEdge. Please add the resource to tools/generate-helpers/pg-table-bindings/list.go.
Usage:
  generate store implementations [flags]

Flags:
      --conversion-funcs            indicates that we should generate conversion functions between protobuf types to/from Gorm model
      --cycle string                indicates that there is a cyclical foreign key reference, should be the path to the embedded foreign key
      --get-all-func                if true, generates a GetAll function
  -h, --help                        help for generate
      --no-copy-from                if true, indicates that the store should not use Postgres copyFrom operation
      --permission-checker string   the permission checker that should be used
      --read-only-store             if set to true, creates read-only store
      --references strings          additional foreign key references, comma seperated of <[table_name:]type>
      --registered-type string      the type this is registered in proto as storage.X
      --schema-directory string     the directory in which to generate the schema
      --schema-only                 if true, generates only the schema and not store and index
      --search-category string      the search category to index under
      --search-scope strings        if set, the search is scoped to specified search categories. comma seperated of search categories
      --singleton                   indicates that we should just generate the singleton store
      --singular string             the singular name of the object
      --table string                the logical table of the objects, default to lower snake_case of type
      --type string                 the (Go) name of the object

template: store.go:74:19: executing "store.go" at <.Obj.IsGloballyScoped>: error calling IsGloballyScoped: unknown resource: PolicyCategoryEdge. Please add the resource to tools/generate-helpers/pg-table-bindings/list.go.
exit status 1
central/policycategoryedge/store/postgres/gen.go:3: running "pg-table-bindings-wrapper": exit status 1
central/postgres/pruning.go
central/postgres/pruning_test.go
central/probesources/sources.go
...
tools/roxvet/common/file_filter.go
tools/roxvet/common/file_filters.go
tools/roxvet/common/traverse.go
tools/roxvet/common/traverse_test.go
webhookserver/server.go
make: *** [go-generated-srcs] Error 1
```

So I followed the suggestion and added `PolicyCategoryEdge` to `tools/generate-helpers/pg-table-bindings/list.go`.
The next run of `make go-generated-srcs` went smooth and resulted in changes to `central/policycategoryedge/store/postgres/store.go` which I also committed in this PR. 

## Checklist
- [ ] Investigated and inspected CI test results

### N/A
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

- Run `make go-generated-srcs` locally
- CI step `ci/prow/grouped-static-checks`
