### PR TITLE
ROX-14631: Stackrox branded images on GHA

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,9 +12,6 @@ on:
     - reopened
     - synchronize
 
-env:
-  ROX_PRODUCT_BRANDING: RHACS_BRANDING
-
 jobs:
   pre-build-ui:
     strategy:
@@ -314,6 +311,11 @@ jobs:
     - pre-build-cli
     - pre-build-go-binaries-rcd
     - pre-build-docs
+    strategy:
+      matrix:
+        branding: [ RHACS_BRANDING ]
+    env:
+      ROX_PRODUCT_BRANDING: ${{ matrix.branding }}
     container:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.55
     steps:
@@ -400,6 +402,11 @@ jobs:
       env:
         QUAY_RHACS_ENG_RW_USERNAME: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
         QUAY_RHACS_ENG_RW_PASSWORD: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
+    strategy:
+      matrix:
+        branding: [ RHACS_BRANDING ]
+    env:
+      ROX_PRODUCT_BRANDING: ${{ matrix.branding }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Compared images from OSCI and GHA
```
-----File-----

These entries have been added to quay.io/stackrox-io/main:3.73.x-567-g0abd2704e6: None

These entries have been deleted from quay.io/stackrox-io/main:3.73.x-567-g0abd2704e6: None

These entries have been changed between quay.io/stackrox-io/main:3.73.x-567-g0abd2704e6 and quay.io/stackrox-io/main:3.73.x-566-gdcee8a3334:
FILE                                                                 SIZE1         SIZE2
/stackrox/central                                                    163.5M        163.5M
/stackrox/bin/kubernetes-sensor                                      80M           80M
/assets/downloads/cli/roxctl-darwin-amd64                            73.1M         73.1M
/assets/downloads/cli/roxctl-linux-s390x                             68.3M         68.3M
/assets/downloads/cli/roxctl-windows-amd64.exe                       65.2M         65.2M
/assets/downloads/cli/roxctl-linux-amd64                             64.6M         64.6M
/assets/downloads/cli/roxctl-linux-ppc64le                           63.2M         63.2M
/stackrox/bin/admission-control                                      63.2M         63.2M
/stackrox/bin/sensor-upgrader                                        62.7M         62.7M
/stackrox/bin/compliance                                             49.8M         49.8M
/stackrox/bin/migrator                                               46.9M         46.9M
/var/lib/rpm/Packages                                                5.4M          5.4M
/var/lib/rpm/__db.003                                                1.3M          1.3M
/var/lib/dnf/history.sqlite-wal                                      676K          676K
/var/lib/rpm/__db.001                                                280K          280K
/stackrox/static-data/external-networks/external-networks.zip        134.2K        134.2K
/var/lib/dnf/history.sqlite                                          116K          116K
/var/lib/rpm/__db.002                                                88K           88K
/var/lib/dnf/history.sqlite-shm                                      32K           32K
/var/cache/ldconfig/aux-cache                                        9K            9K
/var/lib/rpm/Installtid                                              8K            8K


-----Metadata-----

Image metadata differences between quay.io/stackrox-io/main:3.73.x-567-g0abd2704e6 and quay.io/stackrox-io/main:3.73.x-566-gdcee8a3334:

quay.io/stackrox-io/main:3.73.x-567-g0abd2704e6
-Env: container=oci,BUILD_LOGLEVEL=0,PATH=/stackrox:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin,ROX_ROXCTL_IN_MAIN_IMAGE=true,ROX_IMAGE_FLAVOR=opensource,ROX_PRODUCT_BRANDING=STACKROX_BRANDING,OPENSHIFT_BUILD_NAME=main,OPENSHIFT_BUILD_NAMESPACE=ci-op-6lks5pdf
-Labels: architecture:x86_64 build-date:2023-01-06T04:00:07 com.redhat.component:ubi8-minimal-container com.redhat.license_terms:https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI description:This image contains components required to operate the StackRox Kubernetes Security Platform. distribution-scope:public io.buildah.version:1.26.4 io.k8s.description:The Universal Base Image Minimal is a stripped down image that uses microdnf as a package manager. This base image is freely redistributable, but Red Hat only supports Red Hat technologies through subscriptions for Red Hat products. This image is maintained by Red Hat and updated regularly. io.k8s.display-name:Red Hat Universal Base Image 8 Minimal io.openshift.build.commit.author: io.openshift.build.commit.date: io.openshift.build.commit.id: io.openshift.build.commit.message: io.openshift.build.commit.ref: io.openshift.build.name: io.openshift.build.namespace: io.openshift.build.source-context-dir: io.openshift.build.source-location: io.openshift.ci.from.ubi-minimal:sha256:ea45d758af925c7f3ec858f34d0f2ae9f513461f33087423a81af928dd9188aa io.openshift.expose-services: io.openshift.tags:minimal rhel8 maintainer:support@stackrox.com name:main quay.expires-after:13w release:3.73.x-566-gdcee8a3334 summary:The StackRox Kubernetes Security Platform url:https://access.redhat.com/containers/#/registry.access.redhat.com/ubi8-minimal/images/8.7-1049 vcs-ref: vcs-type: vcs-url: vendor:StackRox version:3.73.x-566-gdcee8a3334


quay.io/stackrox-io/main:3.73.x-566-gdcee8a3334
-Env: container=oci,BUILD_LOGLEVEL=0,PATH=/stackrox:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin,ROX_ROXCTL_IN_MAIN_IMAGE=true,ROX_IMAGE_FLAVOR=opensource,ROX_PRODUCT_BRANDING=STACKROX_BRANDING,OPENSHIFT_BUILD_NAME=main,OPENSHIFT_BUILD_NAMESPACE=ci-op-qdlntz3p
-Labels: architecture:x86_64 build-date:2023-01-06T04:00:07 com.redhat.component:ubi8-minimal-container com.redhat.license_terms:https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI description:This image contains components required to operate the StackRox Kubernetes Security Platform. distribution-scope:public io.buildah.version:1.26.4 io.k8s.description:The Universal Base Image Minimal is a stripped down image that uses microdnf as a package manager. This base image is freely redistributable, but Red Hat only supports Red Hat technologies through subscriptions for Red Hat products. This image is maintained by Red Hat and updated regularly. io.k8s.display-name:Red Hat Universal Base Image 8 Minimal io.openshift.build.commit.author: io.openshift.build.commit.date: io.openshift.build.commit.id: io.openshift.build.commit.message: io.openshift.build.commit.ref: io.openshift.build.name: io.openshift.build.namespace: io.openshift.build.source-context-dir: io.openshift.build.source-location: io.openshift.ci.from.ubi-minimal:sha256:1ebe8dfc96d977b46902a3f1b793e3ca1d2e04c85c12b039e48e3c38c17e6a05 io.openshift.expose-services: io.openshift.tags:minimal rhel8 maintainer:support@stackrox.com name:main quay.expires-after:13w release:3.73.x-567-g0abd2704e6 summary:The StackRox Kubernetes Security Platform url:https://access.redhat.com/containers/#/registry.access.redhat.com/ubi8-minimal/images/8.7-1049 vcs-ref: vcs-type: vcs-url: vendor:StackRox version:3.73.x-567-g0abd2704e6


-----SizeLayer-----

Layer size differences between quay.io/stackrox-io/main:3.73.x-567-g0abd2704e6 and quay.io/stackrox-io/main:3.73.x-566-gdcee8a3334: None
```