### PR TITLE
ROX-14495: Skip broken test

### DIFF
--- a/tests/admctrl_configmap_test.go
+++ b/tests/admctrl_configmap_test.go
@@ -20,6 +20,7 @@ import (
 )
 
 func TestAdmissionControllerConfigMap(t *testing.T) {
+	t.Skip("ROX-14495: This test is not working.")
 	k8sClient := createK8sClient(t)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)


### PR DESCRIPTION
## Description

Per title. TestAdmissionControllerConfigMap is broken.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient