### PR TITLE
Fix incorrect call to a changed function in tests

### DIFF
--- a/central/graphql/resolvers/node_scan_benchmark_test.go
+++ b/central/graphql/resolvers/node_scan_benchmark_test.go
@@ -65,16 +65,16 @@ func BenchmarkNodeResolver(b *testing.B) {
 
 	mockCtrl := gomock.NewController(b)
 	defer mockCtrl.Finish()
-	db, gormDB := setupPostgresConn(b)
+	db, gormDB := SetupTestPostgresConn(b)
 	defer pgtest.CloseGormDB(b, gormDB)
 	defer db.Close()
 
-	nodeDS := createNodeDatastore(b, db, gormDB, mockCtrl)
-	_, schema := setupResolver(b,
+	nodeDS := CreateTestNodeDatastore(b, db, gormDB, mockCtrl)
+	_, schema := SetupTestResolver(b,
 		nodeDS,
-		createNodeComponentDatastore(b, db, gormDB, mockCtrl),
-		createNodeCVEDatastore(b, db, gormDB),
-		createNodeComponentCveEdgeDatastore(b, db, gormDB))
+		CreateTestNodeComponentDatastore(b, db, gormDB, mockCtrl),
+		CreateTestNodeCVEDatastore(b, db, gormDB),
+		CreateTestNodeComponentCveEdgeDatastore(b, db, gormDB))
 
 	ctx := contextWithNodePerm(b, mockCtrl)
 

--- a/central/graphql/resolvers/node_scan_test.go
+++ b/central/graphql/resolvers/node_scan_test.go
@@ -80,7 +80,7 @@ func (s *NodeScanResolverTestSuite) SetupTest() {
 	s.nodeComponentDataStore = nodeComponentsDSMocks.NewMockDataStore(s.mockCtrl)
 	s.nodeCVEDataStore = nodeCVEsDSMocks.NewMockDataStore(s.mockCtrl)
 
-	s.resolver, s.schema = setupResolver(s.T(), s.nodeDataStore, s.nodeComponentDataStore, s.nodeCVEDataStore, nil)
+	s.resolver, s.schema = SetupTestResolver(s.T(), s.nodeDataStore, s.nodeComponentDataStore, s.nodeCVEDataStore, nil)
 }
 
 func (s *NodeScanResolverTestSuite) TearDownTest() {


### PR DESCRIPTION
## Description

Some test helper function names were changed by a different PR. It caused unit tests to fail after PR [#2926](https://github.com/stackrox/stackrox/pull/2926) merged. Changes in this PR should fix the tests.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
