### PR TITLE
ROX-14555: Show extraneous flows and allowed ingress/egress flows

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraph.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraph.tsx
@@ -11,14 +11,22 @@ import './Topology.css';
 import useNetworkPolicySimulator from './hooks/useNetworkPolicySimulator';
 import SimulationFrame from './simulation/SimulationFrame';
 import TopologyComponent from './TopologyComponent';
+import { EdgeState } from './components/EdgeStateSelect';
 
 export type NetworkGraphProps = {
     model: CustomModel;
     simulation: Simulation;
     selectedNode?: CustomNodeModel;
     selectedClusterId: string;
+    edgeState: EdgeState;
 };
-function NetworkGraph({ model, simulation, selectedClusterId, selectedNode }: NetworkGraphProps) {
+function NetworkGraph({
+    model,
+    simulation,
+    selectedClusterId,
+    selectedNode,
+    edgeState,
+}: NetworkGraphProps) {
     const controller = useMemo(() => new Visualization(), []);
     controller.registerLayoutFactory(defaultLayoutFactory);
     controller.registerComponentFactory(defaultComponentFactory);
@@ -47,6 +55,7 @@ function NetworkGraph({ model, simulation, selectedClusterId, selectedNode }: Ne
                     selectedNode={selectedNode}
                     setNetworkPolicyModification={setNetworkPolicyModification}
                     applyNetworkPolicyModification={applyNetworkPolicyModification}
+                    edgeState={edgeState}
                 />
             </VisualizationProvider>
         </SimulationFrame>

--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphContainer.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphContainer.tsx
@@ -226,6 +226,7 @@ function NetworkGraphContainer({
             simulation={simulation}
             selectedClusterId={selectedClusterId || ''}
             selectedNode={selectedNode}
+            edgeState={edgeState}
         />
     );
 }

--- a/ui/apps/platform/src/Containers/NetworkGraph/TopologyComponent.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/TopologyComponent.tsx
@@ -32,6 +32,7 @@ import {
     NetworkPolicySimulator,
     SetNetworkPolicyModification,
 } from './hooks/useNetworkPolicySimulator';
+import { EdgeState } from './components/EdgeStateSelect';
 
 // TODO: move these type defs to a central location
 export const UrlDetailType = {
@@ -57,6 +58,7 @@ export type TopologyComponentProps = {
     simulator: NetworkPolicySimulator;
     setNetworkPolicyModification: SetNetworkPolicyModification;
     applyNetworkPolicyModification: ApplyNetworkPolicyModification;
+    edgeState: EdgeState;
 };
 
 // @TODO: Consider a better approach to managing the side panel related state (simulation + URL path for entities)
@@ -75,6 +77,7 @@ const TopologyComponent = ({
     simulator,
     setNetworkPolicyModification,
     applyNetworkPolicyModification,
+    edgeState,
 }: TopologyComponentProps) => {
     const history = useHistory();
     const controller = useVisualizationController();
@@ -149,6 +152,7 @@ const TopologyComponent = ({
                             deploymentId={selectedNode.id}
                             nodes={model?.nodes || []}
                             edges={model?.edges || []}
+                            edgeState={edgeState}
                         />
                     )}
                     {selectedNode && selectedNode?.data?.type === 'EXTERNAL_GROUP' && (

--- a/ui/apps/platform/src/Containers/NetworkGraph/api/useFetchNetworkFlows.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/api/useFetchNetworkFlows.ts
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 
 import { fetchNetworkBaselineStatuses } from 'services/NetworkService';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
+import { EdgeState } from '../components/EdgeStateSelect';
 import { BaselineStatus, BaselineStatusType, Flow } from '../types/flow.type';
 import { CustomEdgeModel } from '../types/topology.type';
 import {
@@ -21,6 +22,7 @@ type Result = {
 type FetchNetworkFlowsParams = {
     edges: CustomEdgeModel[];
     deploymentId: string;
+    edgeState: EdgeState;
 };
 
 type FetchNetworkFlowsResult = {
@@ -36,11 +38,13 @@ const defaultResultState = {
 function useFetchNetworkFlows({
     edges,
     deploymentId,
+    edgeState,
 }: FetchNetworkFlowsParams): FetchNetworkFlowsResult {
     const controller = useVisualizationController();
     const [result, setResult] = useState<Result>(defaultResultState);
 
     function fetchFlows() {
+        setResult({ data: { networkFlows: [] }, isLoading: true, error: '' });
         const flows = getNetworkFlows(edges, controller, deploymentId);
         const peers = transformFlowsToPeers(flows);
         fetchNetworkBaselineStatuses({ deploymentId, peers })
@@ -80,7 +84,7 @@ function useFetchNetworkFlows({
     useEffect(() => {
         fetchFlows();
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [deploymentId]);
+    }, [deploymentId, edgeState]);
 
     return { ...result, refetchFlows: fetchFlows };
 }

--- a/ui/apps/platform/src/Containers/NetworkGraph/common/FlowsTable.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/common/FlowsTable.tsx
@@ -28,6 +28,8 @@ type FlowsTableProps = {
     addToBaseline?: (flow: Flow) => void;
     markAsAnomalous?: (flow: Flow) => void;
     isBaselineSimulation?: boolean;
+    numAllowedEgressFlows?: number;
+    numAllowedIngressFlows?: number;
 };
 
 const columnNames = {
@@ -63,6 +65,8 @@ function FlowsTable({
     addToBaseline,
     markAsAnomalous,
     isBaselineSimulation = false,
+    numAllowedEgressFlows = 0,
+    numAllowedIngressFlows = 0,
 }: FlowsTableProps): ReactElement {
     // getter functions
     const isRowExpanded = (row: Flow) => expandedRows?.includes(row.id);
@@ -289,6 +293,54 @@ function FlowsTable({
                     </Tbody>
                 );
             })}
+            {numAllowedEgressFlows > 0 && (
+                <Tbody>
+                    <Tr>
+                        <Td />
+                        {isEditable && <Td />}
+                        <Td dataLabel={columnNames.entity}>
+                            <Flex direction={{ default: 'row' }}>
+                                <FlexItem>
+                                    <div>+ {numAllowedEgressFlows} allowed flows</div>
+                                    <div>
+                                        <TextContent>
+                                            <Text component={TextVariants.small}>
+                                                Across this cluster
+                                            </Text>
+                                        </TextContent>
+                                    </div>
+                                </FlexItem>
+                            </Flex>
+                        </Td>
+                        <Td dataLabel={columnNames.direction}>Egress</Td>
+                        <Td dataLabel={columnNames.portAndProtocol}>Any / Any</Td>
+                    </Tr>
+                </Tbody>
+            )}
+            {numAllowedIngressFlows > 0 && (
+                <Tbody>
+                    <Tr>
+                        <Td />
+                        {isEditable && <Td />}
+                        <Td dataLabel={columnNames.entity}>
+                            <Flex direction={{ default: 'row' }}>
+                                <FlexItem>
+                                    <div>+ {numAllowedIngressFlows} allowed flows</div>
+                                    <div>
+                                        <TextContent>
+                                            <Text component={TextVariants.small}>
+                                                Across this cluster
+                                            </Text>
+                                        </TextContent>
+                                    </div>
+                                </FlexItem>
+                            </Flex>
+                        </Td>
+                        <Td dataLabel={columnNames.direction}>Ingress</Td>
+                        <Td dataLabel={columnNames.portAndProtocol}>Any / Any</Td>
+                    </Tr>
+                </Tbody>
+            )}
         </TableComposable>
     );
 }

--- a/ui/apps/platform/src/Containers/NetworkGraph/common/FlowsTable.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/common/FlowsTable.tsx
@@ -28,8 +28,8 @@ type FlowsTableProps = {
     addToBaseline?: (flow: Flow) => void;
     markAsAnomalous?: (flow: Flow) => void;
     isBaselineSimulation?: boolean;
-    numAllowedEgressFlows?: number;
-    numAllowedIngressFlows?: number;
+    numExtraneousEgressFlows?: number;
+    numExtraneousIngressFlows?: number;
 };
 
 const columnNames = {
@@ -53,6 +53,39 @@ function getBaselineSimulatedRowStyle(
     return customStyle;
 }
 
+function ExtraneousFlowsRow({
+    isEditable,
+    numExtraneousEgressFlows,
+    direction,
+}: {
+    isEditable: boolean;
+    numExtraneousEgressFlows: number;
+    direction: 'Ingress' | 'Egress';
+}) {
+    return (
+        <Tbody>
+            <Tr>
+                <Td />
+                {isEditable && <Td />}
+                <Td dataLabel={columnNames.entity}>
+                    <Flex direction={{ default: 'row' }}>
+                        <FlexItem>
+                            <div>+ {numExtraneousEgressFlows} allowed flows</div>
+                            <div>
+                                <TextContent>
+                                    <Text component={TextVariants.small}>Across this cluster</Text>
+                                </TextContent>
+                            </div>
+                        </FlexItem>
+                    </Flex>
+                </Td>
+                <Td dataLabel={columnNames.direction}>{direction}</Td>
+                <Td dataLabel={columnNames.portAndProtocol}>Any / Any</Td>
+            </Tr>
+        </Tbody>
+    );
+}
+
 function FlowsTable({
     label,
     flows,
@@ -65,8 +98,8 @@ function FlowsTable({
     addToBaseline,
     markAsAnomalous,
     isBaselineSimulation = false,
-    numAllowedEgressFlows = 0,
-    numAllowedIngressFlows = 0,
+    numExtraneousEgressFlows = 0,
+    numExtraneousIngressFlows = 0,
 }: FlowsTableProps): ReactElement {
     // getter functions
     const isRowExpanded = (row: Flow) => expandedRows?.includes(row.id);
@@ -293,53 +326,19 @@ function FlowsTable({
                     </Tbody>
                 );
             })}
-            {numAllowedEgressFlows > 0 && (
-                <Tbody>
-                    <Tr>
-                        <Td />
-                        {isEditable && <Td />}
-                        <Td dataLabel={columnNames.entity}>
-                            <Flex direction={{ default: 'row' }}>
-                                <FlexItem>
-                                    <div>+ {numAllowedEgressFlows} allowed flows</div>
-                                    <div>
-                                        <TextContent>
-                                            <Text component={TextVariants.small}>
-                                                Across this cluster
-                                            </Text>
-                                        </TextContent>
-                                    </div>
-                                </FlexItem>
-                            </Flex>
-                        </Td>
-                        <Td dataLabel={columnNames.direction}>Egress</Td>
-                        <Td dataLabel={columnNames.portAndProtocol}>Any / Any</Td>
-                    </Tr>
-                </Tbody>
+            {numExtraneousEgressFlows > 0 && (
+                <ExtraneousFlowsRow
+                    isEditable
+                    numExtraneousEgressFlows={numExtraneousEgressFlows}
+                    direction="Egress"
+                />
             )}
-            {numAllowedIngressFlows > 0 && (
-                <Tbody>
-                    <Tr>
-                        <Td />
-                        {isEditable && <Td />}
-                        <Td dataLabel={columnNames.entity}>
-                            <Flex direction={{ default: 'row' }}>
-                                <FlexItem>
-                                    <div>+ {numAllowedIngressFlows} allowed flows</div>
-                                    <div>
-                                        <TextContent>
-                                            <Text component={TextVariants.small}>
-                                                Across this cluster
-                                            </Text>
-                                        </TextContent>
-                                    </div>
-                                </FlexItem>
-                            </Flex>
-                        </Td>
-                        <Td dataLabel={columnNames.direction}>Ingress</Td>
-                        <Td dataLabel={columnNames.portAndProtocol}>Any / Any</Td>
-                    </Tr>
-                </Tbody>
+            {numExtraneousIngressFlows > 0 && (
+                <ExtraneousFlowsRow
+                    isEditable
+                    numExtraneousEgressFlows={numExtraneousIngressFlows}
+                    direction="Ingress"
+                />
             )}
         </TableComposable>
     );

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentFlows.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentFlows.tsx
@@ -18,8 +18,8 @@ import { AdvancedFlowsFilterType } from '../common/AdvancedFlowsFilter/types';
 import {
     filterNetworkFlows,
     getAllUniquePorts,
-    getNumAllowedEgressFlows,
-    getNumAllowedIngressFlows,
+    getNumExtraneousEgressFlows,
+    getNumExtraneousIngressFlows,
     getNumFlows,
 } from '../utils/flowUtils';
 import { CustomEdgeModel, CustomNodeModel } from '../types/topology.type';
@@ -74,9 +74,9 @@ function DeploymentFlows({ deploymentId, nodes, edges, edgeState }: DeploymentFl
     // derived data
     const numFlows = getNumFlows(filteredFlows);
     const allUniquePorts = getAllUniquePorts(networkFlows);
-    const numAllowedEgressFlows = getNumAllowedEgressFlows(nodes);
-    const numAllowedIngressFlows = getNumAllowedIngressFlows(nodes);
-    const totalFlows = numFlows + numAllowedEgressFlows + numAllowedIngressFlows;
+    const numExtraneousEgressFlows = getNumExtraneousEgressFlows(nodes);
+    const numExtraneousIngressFlows = getNumExtraneousIngressFlows(nodes);
+    const totalFlows = numFlows + numExtraneousEgressFlows + numExtraneousIngressFlows;
 
     function addToBaseline(flow: Flow) {
         modifyBaselineStatuses([flow], 'BASELINE', refetchFlows);
@@ -166,8 +166,8 @@ function DeploymentFlows({ deploymentId, nodes, edges, edgeState }: DeploymentFl
                         setSelectedRows={setSelectedRows}
                         addToBaseline={addToBaseline}
                         markAsAnomalous={markAsAnomalous}
-                        numAllowedEgressFlows={numAllowedEgressFlows}
-                        numAllowedIngressFlows={numAllowedIngressFlows}
+                        numExtraneousEgressFlows={numExtraneousEgressFlows}
+                        numExtraneousIngressFlows={numExtraneousIngressFlows}
                         isEditable
                     />
                 </StackItem>

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentSideBar.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentSideBar.tsx
@@ -34,14 +34,16 @@ import DeploymentBaselines from './DeploymentBaselines';
 import NetworkPolicies from '../common/NetworkPolicies';
 import useSimulation from '../hooks/useSimulation';
 import DeploymentBaselinesSimulated from './DeploymentBaselinesSimulated';
+import { EdgeState } from '../components/EdgeStateSelect';
 
 type DeploymentSideBarProps = {
     deploymentId: string;
     nodes: CustomNodeModel[];
     edges: CustomEdgeModel[];
+    edgeState: EdgeState;
 };
 
-function DeploymentSideBar({ deploymentId, nodes, edges }: DeploymentSideBarProps) {
+function DeploymentSideBar({ deploymentId, nodes, edges, edgeState }: DeploymentSideBarProps) {
     // component state
     const { deployment, isLoading, error } = useFetchDeployment(deploymentId);
     const { activeKeyTab, onSelectTab, setActiveKeyTab } = useTabs({
@@ -152,7 +154,12 @@ function DeploymentSideBar({ deploymentId, nodes, edges }: DeploymentSideBarProp
                             )}
                         </TabContent>
                         <TabContent eventKey="Flows" id="Flows" hidden={activeKeyTab !== 'Flows'}>
-                            <DeploymentFlows edges={edges} deploymentId={deploymentId} />
+                            <DeploymentFlows
+                                nodes={nodes}
+                                edges={edges}
+                                deploymentId={deploymentId}
+                                edgeState={edgeState}
+                            />
                         </TabContent>
                         <TabContent
                             eventKey="Baselines"

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/flowUtils.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/flowUtils.ts
@@ -6,7 +6,7 @@ import { L4Protocol } from 'types/networkFlow.proto';
 import { GroupedDiffFlows } from 'types/networkPolicyService';
 import { AdvancedFlowsFilterType } from '../common/AdvancedFlowsFilter/types';
 import { BaselineSimulationDiffState, Flow, FlowEntityType, Peer } from '../types/flow.type';
-import { CustomEdgeModel, CustomSingleNodeData } from '../types/topology.type';
+import { CustomEdgeModel, CustomNodeModel, CustomSingleNodeData } from '../types/topology.type';
 
 export const protocolLabel = {
     L4_PROTOCOL_UNKNOWN: 'UNKNOWN',
@@ -302,4 +302,30 @@ export function createFlowsFromGroupedDiffFlows(
         return flow;
     });
     return flows;
+}
+
+export function getNumAllowedEgressFlows(nodes: CustomNodeModel[]): number {
+    const extraneousEgressNode = nodes.find((node) => {
+        return node.id === 'extraneous-egress-flows';
+    });
+    if (!extraneousEgressNode || extraneousEgressNode.visible === false) {
+        return 0;
+    }
+    const numAllowedEgressFlows =
+        extraneousEgressNode?.data.type === 'EXTRANEOUS' ? extraneousEgressNode?.data.numFlows : 0;
+    return numAllowedEgressFlows;
+}
+
+export function getNumAllowedIngressFlows(nodes: CustomNodeModel[]): number {
+    const extraneousIngressNode = nodes.find((node) => {
+        return node.id === 'extraneous-ingress-flows';
+    });
+    if (!extraneousIngressNode || extraneousIngressNode.visible === false) {
+        return 0;
+    }
+    const numAllowedIngressFlows =
+        extraneousIngressNode?.data.type === 'EXTRANEOUS'
+            ? extraneousIngressNode?.data.numFlows
+            : 0;
+    return numAllowedIngressFlows;
 }

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/flowUtils.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/flowUtils.ts
@@ -304,7 +304,7 @@ export function createFlowsFromGroupedDiffFlows(
     return flows;
 }
 
-export function getNumAllowedEgressFlows(nodes: CustomNodeModel[]): number {
+export function getNumExtraneousEgressFlows(nodes: CustomNodeModel[]): number {
     const extraneousEgressNode = nodes.find((node) => {
         return node.id === 'extraneous-egress-flows';
     });
@@ -316,7 +316,7 @@ export function getNumAllowedEgressFlows(nodes: CustomNodeModel[]): number {
     return numAllowedEgressFlows;
 }
 
-export function getNumAllowedIngressFlows(nodes: CustomNodeModel[]): number {
+export function getNumExtraneousIngressFlows(nodes: CustomNodeModel[]): number {
     const extraneousIngressNode = nodes.find((node) => {
         return node.id === 'extraneous-ingress-flows';
     });


### PR DESCRIPTION
## Description

This PR shows the extraneous flows in the flows table when we switch the view using the selector. The extraneous egress/ingress flows will show up in the table as the last row

<img width="1552" alt="Screenshot 2023-01-25 at 10 40 07 AM" src="https://user-images.githubusercontent.com/4805485/214653633-d9f108d9-8906-4837-a05f-664fc7d3bb7e.png">

https://user-images.githubusercontent.com/4805485/214653717-9debc9c8-3890-4c3c-bc9d-29a3b9033287.mov

## Checklist
- [ ] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~