### PR TITLE
ROX-14137: Permission Set declarative config Go struct

### DIFF
--- a/pkg/declarativeconfig/permission_set.go
+++ b/pkg/declarativeconfig/permission_set.go
@@ -1,0 +1,33 @@
+package declarativeconfig
+
+import (
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/generated/storage"
+	"gopkg.in/yaml.v3"
+)
+
+type PermissionSet struct {
+	Name             string              `yaml:"name,omitempty"`
+	Description      string              ` yaml:"description,omitempty"`
+	ResourceToAccess map[string]DCAccess `yaml:"resource_to_access,omitempty"`
+}
+
+type DCAccess storage.Access
+
+func (a DCAccess) MarshalYAML() ([]byte, error) {
+	protoAccess := storage.Access(a)
+	return []byte(protoAccess.String()), nil
+}
+
+func (a *DCAccess) UnmarshalYAML(value *yaml.Node) error {
+	var v string
+	if err := value.Decode(&v); err != nil {
+		return err
+	}
+	i, ok := storage.Access_value[v]
+	if !ok {
+		return errors.New("not found")
+	}
+	*a = DCAccess(i)
+	return nil
+}

--- a/pkg/declarativeconfig/permission_set.go
+++ b/pkg/declarativeconfig/permission_set.go
@@ -6,24 +6,29 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// PermissionSet is representation of storage.PermissionSet that supports transformation from YAML.
 type PermissionSet struct {
 	Name             string               `yaml:"name,omitempty"`
 	Description      string               `yaml:"description,omitempty"`
 	ResourceToAccess []ResourceWithAccess `yaml:"resources,omitempty"`
 }
 
+// Access is representation of storage.Access that supports transformation from YAML.
 type Access storage.Access
 
+// ResourceWithAccess unites resource name and corresponding access level.
 type ResourceWithAccess struct {
 	Resource string `yaml:"resource,omitempty"`
 	Access   Access `yaml:"access,omitempty"`
 }
 
+// MarshalYAML transforms Access to YAML format.
 func (a Access) MarshalYAML() ([]byte, error) {
 	protoAccess := storage.Access(a)
 	return []byte(protoAccess.String()), nil
 }
 
+// UnmarshalYAML makes transformation from YAML to Access.
 func (a *Access) UnmarshalYAML(value *yaml.Node) error {
 	var v string
 	if err := value.Decode(&v); err != nil {

--- a/pkg/declarativeconfig/permission_set.go
+++ b/pkg/declarativeconfig/permission_set.go
@@ -8,9 +8,9 @@ import (
 
 // PermissionSet is representation of storage.PermissionSet that supports transformation from YAML.
 type PermissionSet struct {
-	Name             string               `yaml:"name,omitempty"`
-	Description      string               `yaml:"description,omitempty"`
-	ResourceToAccess []ResourceWithAccess `yaml:"resources,omitempty"`
+	Name        string               `yaml:"name,omitempty"`
+	Description string               `yaml:"description,omitempty"`
+	Resources   []ResourceWithAccess `yaml:"resources,omitempty"`
 }
 
 // Access is representation of storage.Access that supports transformation from YAML.

--- a/pkg/declarativeconfig/permission_set.go
+++ b/pkg/declarativeconfig/permission_set.go
@@ -7,19 +7,24 @@ import (
 )
 
 type PermissionSet struct {
-	Name             string              `yaml:"name,omitempty"`
-	Description      string              ` yaml:"description,omitempty"`
-	ResourceToAccess map[string]DCAccess `yaml:"resource_to_access,omitempty"`
+	Name             string               `yaml:"name,omitempty"`
+	Description      string               `yaml:"description,omitempty"`
+	ResourceToAccess []ResourceWithAccess `yaml:"resources,omitempty"`
 }
 
-type DCAccess storage.Access
+type Access storage.Access
 
-func (a DCAccess) MarshalYAML() ([]byte, error) {
+type ResourceWithAccess struct {
+	Resource string `yaml:"resource,omitempty"`
+	Access   Access `yaml:"access,omitempty"`
+}
+
+func (a Access) MarshalYAML() ([]byte, error) {
 	protoAccess := storage.Access(a)
 	return []byte(protoAccess.String()), nil
 }
 
-func (a *DCAccess) UnmarshalYAML(value *yaml.Node) error {
+func (a *Access) UnmarshalYAML(value *yaml.Node) error {
 	var v string
 	if err := value.Decode(&v); err != nil {
 		return err
@@ -28,6 +33,6 @@ func (a *DCAccess) UnmarshalYAML(value *yaml.Node) error {
 	if !ok {
 		return errors.New("not found")
 	}
-	*a = DCAccess(i)
+	*a = Access(i)
 	return nil
 }

--- a/pkg/declarativeconfig/permission_set_test.go
+++ b/pkg/declarativeconfig/permission_set_test.go
@@ -1,0 +1,32 @@
+package declarativeconfig
+
+import (
+	"testing"
+
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
+)
+
+func TestPermissionSetYAMLTransformation(t *testing.T) {
+	data := []byte(`
+name: test-name
+description: test-description
+resource_to_access:
+  a: READ_ACCESS
+  b: READ_WRITE_ACCESS
+`)
+	ps := PermissionSet{}
+
+	err := yaml.Unmarshal(data, &ps)
+	assert.NoError(t, err)
+	assert.Equal(t, "test-name", ps.Name)
+	assert.Equal(t, "test-description", ps.Description)
+	accessValueForA, hasA := ps.ResourceToAccess["a"]
+	accessValueForB, hasB := ps.ResourceToAccess["b"]
+	assert.True(t, hasA)
+	assert.True(t, hasB)
+	assert.Len(t, ps.ResourceToAccess, 2)
+	assert.Equal(t, storage.Access_READ_ACCESS, storage.Access(accessValueForA))
+	assert.Equal(t, storage.Access_READ_WRITE_ACCESS, storage.Access(accessValueForB))
+}

--- a/pkg/declarativeconfig/permission_set_test.go
+++ b/pkg/declarativeconfig/permission_set_test.go
@@ -12,9 +12,11 @@ func TestPermissionSetYAMLTransformation(t *testing.T) {
 	data := []byte(`
 name: test-name
 description: test-description
-resource_to_access:
-  a: READ_ACCESS
-  b: READ_WRITE_ACCESS
+resources:
+- resource: a
+  access: READ_ACCESS
+- resource: b
+  access: READ_WRITE_ACCESS
 `)
 	ps := PermissionSet{}
 
@@ -22,11 +24,11 @@ resource_to_access:
 	assert.NoError(t, err)
 	assert.Equal(t, "test-name", ps.Name)
 	assert.Equal(t, "test-description", ps.Description)
-	accessValueForA, hasA := ps.ResourceToAccess["a"]
-	accessValueForB, hasB := ps.ResourceToAccess["b"]
-	assert.True(t, hasA)
-	assert.True(t, hasB)
 	assert.Len(t, ps.ResourceToAccess, 2)
-	assert.Equal(t, storage.Access_READ_ACCESS, storage.Access(accessValueForA))
-	assert.Equal(t, storage.Access_READ_WRITE_ACCESS, storage.Access(accessValueForB))
+	resourceA := ps.ResourceToAccess[0]
+	resourceB := ps.ResourceToAccess[1]
+	assert.Equal(t, "a", resourceA.Resource)
+	assert.Equal(t, "b", resourceB.Resource)
+	assert.Equal(t, storage.Access_READ_ACCESS, storage.Access(resourceA.Access))
+	assert.Equal(t, storage.Access_READ_WRITE_ACCESS, storage.Access(resourceB.Access))
 }

--- a/pkg/declarativeconfig/permission_set_test.go
+++ b/pkg/declarativeconfig/permission_set_test.go
@@ -24,9 +24,9 @@ resources:
 	assert.NoError(t, err)
 	assert.Equal(t, "test-name", ps.Name)
 	assert.Equal(t, "test-description", ps.Description)
-	assert.Len(t, ps.ResourceToAccess, 2)
-	resourceA := ps.ResourceToAccess[0]
-	resourceB := ps.ResourceToAccess[1]
+	assert.Len(t, ps.Resources, 2)
+	resourceA := ps.Resources[0]
+	resourceB := ps.Resources[1]
 	assert.Equal(t, "a", resourceA.Resource)
 	assert.Equal(t, "b", resourceB.Resource)
 	assert.Equal(t, storage.Access_READ_ACCESS, storage.Access(resourceA.Access))


### PR DESCRIPTION
## Description

This solution is based on re-using existing proto enums within new Go structs.

Alternatives:
1. Introduce a new struct replacing `storage.Access`proto enum within this Go struct + conversion function
2. Convert from YAML to JSON first, then to proto

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
