### PR TITLE
Collections UI minor fixes

### DIFF
--- a/ui/apps/platform/src/Containers/Collections/CollectionForm.css
+++ b/ui/apps/platform/src/Containers/Collections/CollectionForm.css
@@ -17,3 +17,12 @@
   /* This blue outline on focus is a global problem, but it is especially jarring in this case */
   outline: none;
 }
+
+.collection-form-expandable-section .pf-c-expandable-section__toggle-icon {
+  /*
+    Some conflict with TW styles in production build only is causing this element to be
+    misaligned due to an excessive calculated height. Setting this max prevents it from
+    growing too large. This likely can be removed when we fully migrate to PF.
+  */
+  max-height: 2rem;
+}

--- a/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
@@ -307,7 +307,7 @@ function CollectionForm({
 
     return (
         <Form
-            className="pf-u-background-color-200"
+            className="pf-u-display-flex pf-u-flex-direction-column pf-u-h-100"
             style={
                 {
                     '--pf-c-form--GridGap': 0,
@@ -315,7 +315,7 @@ function CollectionForm({
             }
         >
             <Flex
-                className="pf-u-p-lg"
+                className="pf-u-p-lg pf-u-flex-grow-1 pf-u-background-color-200"
                 spaceItems={{ default: 'spaceItemsMd' }}
                 direction={{ default: 'column' }}
             >


### PR DESCRIPTION
## Description

Two minor UI tweaks:

1. Fixes the misaligned "expandable section icon" in production builds
2. Ensures the Save/Cancel button section of the collection form is always pinned at the bottom of the page

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Icon before:
<img width="1676" alt="image" src="https://user-images.githubusercontent.com/1292638/214865960-3923fea8-7cb0-49da-9cef-48e2618499b4.png">

Icon after:
![image](https://user-images.githubusercontent.com/1292638/214865803-46aa8268-0b6f-472f-9b56-6e9cb7db3dfd.png)

Button toolbar before:
<img width="1676" alt="image" src="https://user-images.githubusercontent.com/1292638/214866052-c963dd9e-2e28-4fd2-b8e8-39f2a5ad39e1.png">

Button toolbar after:
![image](https://user-images.githubusercontent.com/1292638/214866130-c3102e71-a7a0-4854-8083-5f49d57d0c08.png)
