### PR TITLE
ROX-14240: Implement dropdown for Add Cluster options

### DIFF
--- a/ui/apps/platform/src/Components/Menu.tsx
+++ b/ui/apps/platform/src/Components/Menu.tsx
@@ -25,13 +25,14 @@ interface MenuProps {
     buttonIcon?: ReactElement;
     menuClassName?: string;
     className?: string;
-    options: GroupedMenuOptions | MenuOption[];
+    options?: GroupedMenuOptions | MenuOption[];
     disabled?: boolean;
     // TODO the `grouped` prop should be deprecated in favor of type narrowing once all dependent files are moved to TypeScript
     grouped?: boolean;
     tooltip?: string;
     dataTestId?: string;
     hideCaret?: boolean;
+    customMenuContent?: ReactElement;
 }
 
 const Menu = ({
@@ -47,6 +48,7 @@ const Menu = ({
     dataTestId = 'menu-button',
     hideCaret = false,
     buttonTextClassName = '',
+    customMenuContent,
 }: MenuProps) => {
     const [isMenuOpen, setMenuState] = useState(false);
 
@@ -104,13 +106,15 @@ const Menu = ({
 
     function renderGroupedOptions(formattedOptions: GroupedMenuOptions) {
         return Object.keys(formattedOptions).map((group) => {
-            return (
+            return options ? (
                 <React.Fragment key={group}>
                     <div className="uppercase font-condensed p-3 border-b border-primary-300 text-lg">
                         {group}
                     </div>
                     <div className="px-2">{renderOptions(options[group])}</div>
                 </React.Fragment>
+            ) : (
+                []
             );
         });
     }
@@ -137,16 +141,18 @@ const Menu = ({
                             ))}
                     </div>
                 </button>
-                {isMenuOpen && (
-                    <div
-                        className={`absolute flex flex-col flex-nowrap menu right-0 z-10 min-w-32 bg-base-100 shadow border border-base-400 ${menuClassName}`}
-                        data-testid="menu-list"
-                    >
-                        {grouped
-                            ? renderGroupedOptions(options as GroupedMenuOptions)
-                            : renderOptions(options as MenuOption[])}
-                    </div>
-                )}
+                {isMenuOpen &&
+                    // if `customMenuContent is provided, show it; otherwise, loop over the options
+                    (customMenuContent || (
+                        <div
+                            className={`absolute flex flex-col flex-nowrap menu right-0 z-10 min-w-32 bg-base-100 shadow border border-base-400 ${menuClassName}`}
+                            data-testid="menu-list"
+                        >
+                            {grouped
+                                ? renderGroupedOptions(options as GroupedMenuOptions)
+                                : renderOptions(options as MenuOption[])}
+                        </div>
+                    ))}
             </div>
         </Tooltip>
     );

--- a/ui/apps/platform/src/Containers/Clusters/ClustersTablePanel.js
+++ b/ui/apps/platform/src/Containers/Clusters/ClustersTablePanel.js
@@ -105,15 +105,21 @@ function ClustersTablePanel({ selectedClusterId, setSelectedClusterId, searchOpt
     const { version } = metadata;
 
     const installMenuOptions = [
-        <DropdownItem
-            key="link"
-            description="Cluster installation guides"
-            href={getVersionedDocs(version, 'installing/acs-installation-platforms.html')}
-            target="_blank"
-            rel="noopener noreferrer"
-        >
-            View instructions
-        </DropdownItem>,
+        version ? (
+            <DropdownItem
+                key="link"
+                description="Cluster installation guides"
+                href={getVersionedDocs(version, 'installing/acs-installation-platforms.html')}
+                target="_blank"
+                rel="noopener noreferrer"
+            >
+                View instructions
+            </DropdownItem>
+        ) : (
+            <DropdownItem key="version-missing" isPlainText>
+                Instructions unavailable; version missing
+            </DropdownItem>
+        ),
         <DropdownItem key="add" onClick={onAddCluster}>
             New cluster
         </DropdownItem>,

--- a/ui/apps/platform/src/Containers/Clusters/ClustersTablePanel.js
+++ b/ui/apps/platform/src/Containers/Clusters/ClustersTablePanel.js
@@ -25,6 +25,7 @@ import {
 } from 'services/ClustersService';
 import { toggleRow, toggleSelectAll } from 'utils/checkboxUtils';
 import { filterAllowedSearch, convertToRestSearch, getHasSearchApplied } from 'utils/searchUtils';
+import { getVersionedDocs } from 'utils/versioning';
 
 import AutoUpgradeToggle from './Components/AutoUpgradeToggle';
 import { clusterTablePollingInterval, getUpgradeableClusters } from './cluster.helpers';
@@ -101,12 +102,13 @@ function ClustersTablePanel({ selectedClusterId, setSelectedClusterId, searchOpt
         </div>
     ));
 
+    const { version } = metadata;
+
     const installMenuOptions = [
         <DropdownItem
             key="link"
-            isExternalLink
             description="Cluster installation guides"
-            href="https://docs.openshift.com/acs/installing/acs-installation-platforms.html"
+            href={getVersionedDocs(version, 'installing/acs-installation-platforms.html')}
             target="_blank"
             rel="noopener noreferrer"
         >

--- a/ui/apps/platform/src/Containers/Clusters/ClustersTablePanel.js
+++ b/ui/apps/platform/src/Containers/Clusters/ClustersTablePanel.js
@@ -1,8 +1,9 @@
 import React, { useState, useReducer } from 'react';
 import PropTypes from 'prop-types';
 import useDeepCompareEffect from 'use-deep-compare-effect';
-import { DownloadCloud, Plus, Trash2 } from 'react-feather';
+import { DownloadCloud, Trash2 } from 'react-feather';
 import get from 'lodash/get';
+import { Dropdown, DropdownItem, DropdownPosition, DropdownToggle } from '@patternfly/react-core';
 
 import CheckboxTable from 'Components/CheckboxTable';
 import CloseButton from 'Components/CloseButton';
@@ -37,6 +38,21 @@ function ClustersTablePanel({ selectedClusterId, setSelectedClusterId, searchOpt
     const isDecommissionedClusterRetentionEnabled = isFeatureFlagEnabled(
         'ROX_DECOMMISSIONED_CLUSTER_RETENTION'
     );
+    const [isInstallMenuOpen, setIsInstallMenuOpen] = useState(false);
+
+    function onToggleInstallMenu(newIsInstallMenuOpen) {
+        setIsInstallMenuOpen(newIsInstallMenuOpen);
+    }
+
+    function onFocusInstallMenu() {
+        const element = document.getElementById('toggle-descriptions');
+        element.focus();
+    }
+
+    function onSelectInstallMenuItem() {
+        setIsInstallMenuOpen(false);
+        onFocusInstallMenu();
+    }
 
     const metadata = useMetadata();
 
@@ -84,6 +100,22 @@ function ClustersTablePanel({ selectedClusterId, setSelectedClusterId, searchOpt
             />
         </div>
     ));
+
+    const installMenuOptions = [
+        <DropdownItem
+            key="link"
+            isExternalLink
+            description="Cluster installation guides"
+            href="https://docs.openshift.com/acs/installing/acs-installation-platforms.html"
+            target="_blank"
+            rel="noopener noreferrer"
+        >
+            View instructions
+        </DropdownItem>,
+        <DropdownItem key="add" onClick={onAddCluster}>
+            New cluster
+        </DropdownItem>,
+    ];
 
     function refreshClusterList(restSearch) {
         setFetchingClusters(true);
@@ -192,21 +224,28 @@ function ClustersTablePanel({ selectedClusterId, setSelectedClusterId, searchOpt
             <PanelButton
                 icon={<Trash2 className="h-4 w-4 ml-1" />}
                 tooltip={`Delete (${checkedClusterIds.length})`}
-                className="btn btn-alert ml-2"
+                className="btn btn-alert ml-2 mr-2"
                 onClick={deleteSelectedClusters}
                 disabled={checkedClusterIds.length === 0 || !!selectedClusterId}
             >
                 {`Delete (${checkedClusterIds.length})`}
             </PanelButton>
-            <PanelButton
-                icon={<Plus className="h-4 w-4 ml-1" />}
-                tooltip="New Cluster"
-                className="btn btn-base ml-2 mr-4"
-                onClick={onAddCluster}
-                disabled={!!selectedClusterId}
-            >
-                New Cluster
-            </PanelButton>
+            <Dropdown
+                className="mr-4"
+                onSelect={onSelectInstallMenuItem}
+                toggle={
+                    <DropdownToggle
+                        id="install-toggle"
+                        toggleVariant="secondary"
+                        onToggle={onToggleInstallMenu}
+                    >
+                        Install cluster
+                    </DropdownToggle>
+                }
+                position={DropdownPosition.right}
+                isOpen={isInstallMenuOpen}
+                dropdownItems={installMenuOptions}
+            />
         </>
     );
 


### PR DESCRIPTION
## Description

Implementation for Version 1 from this Jira comment,
https://issues.redhat.com/browse/ROX-13325?focusedCommentId=21420775&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-21420775

Link used for docs from this comment,
https://issues.redhat.com/browse/ROX-13325?focusedCommentId=21608282&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-21608282

Note: I tried re-styling the PF toggle to look more like the classic StackRox buttons, but that gave it more of an "uncanny valley" look than it helped, so I left the default PatternFly style for everything.

(I tried to use the Menu PatternFly component, as having better semantics and functionality, but it turned out to have limitations, including not being able to open a link in a new tab. I filed an issue with PatternFly, .) 

## Checklist
- [x] Investigated and inspected CI test results (ui-e2e test failures are unrelated flakes)


## Testing Performed

Closed option list
<img width="1696" alt="Screen Shot 2023-01-25 at 2 13 20 PM" src="https://user-images.githubusercontent.com/715729/214667680-d660ba07-b458-4cdb-ba78-5595169e67ed.png">

Open, ready to click on link
<img width="1696" alt="Screen Shot 2023-01-25 at 2 13 27 PM" src="https://user-images.githubusercontent.com/715729/214667833-c64033e7-7bde-41d9-90d0-cd97fd054d7c.png">

Linked opened in new tab
<img width="1696" alt="Screen Shot 2023-01-25 at 2 13 32 PM" src="https://user-images.githubusercontent.com/715729/214668040-8c637e74-3a67-41c8-b673-235574f82386.png">

Click on second item acts like former button
<img width="1696" alt="Screen Shot 2023-01-25 at 2 13 52 PM" src="https://user-images.githubusercontent.com/715729/214668194-2ad3d6a6-d9fe-478b-a908-76901a5b8754.png">
