### PR TITLE
Dashrews/ROX-14524 delete decommission rocks code for safety

### DIFF
--- a/migrator/clone/db_clone_manager_impl.go
+++ b/migrator/clone/db_clone_manager_impl.go
@@ -123,24 +123,7 @@ func (d *dbCloneManagerImpl) Persist(cloneName string, pgClone string, persistBo
 			}
 		}
 
-		err := d.dbmPostgres.Persist(pgClone)
-		if err != nil {
-			return err
-		}
-
-		// Now that updated Postgres was persisted we can decommission RocksDB if necessary
-		if !persistBoth {
-			rocksVersion := d.dbmRocks.GetVersion(rocksdb.CurrentClone)
-			currentPostgresVersion := d.dbmPostgres.GetCurrentVersion()
-			log.Infof("Current PG => %v", currentPostgresVersion)
-
-			// If the versions do not match, we have updated another time with Postgres,
-			// so we can no longer roll back to RocksDB.
-			if rocksVersion != nil && currentPostgresVersion != nil && rocksVersion.MainVersion != currentPostgresVersion.MainVersion {
-				d.dbmRocks.DecommissionRocksDB()
-			}
-		}
-		return nil
+		return d.dbmPostgres.Persist(pgClone)
 	}
 	return d.dbmRocks.Persist(cloneName)
 }

--- a/migrator/clone/metadata/db_clone_impl.go
+++ b/migrator/clone/metadata/db_clone_impl.go
@@ -29,9 +29,6 @@ kubectl -n stackrox set env deploy/central ROX_DONT_COMPARE_DEV_BUILDS=true
 
 	// ErrUnableToRestore -- cannot restore upgraded backup to a downgraded central
 	ErrUnableToRestore = "The backup bundle being restored is from an upgraded version of central and thus cannot applied.  The restored version %s, current version %s"
-
-	// ErrUnsupportedDatabase -- cannot use this database as it is stale after previous upgrades to Postgres
-	ErrUnsupportedDatabase = "Central has previously underwent multiple upgrades to Postgres.  This version of RocksDB is stale and not supported."
 )
 
 // DBClone -- holds information related to DB clones

--- a/migrator/clone/mock_central.go
+++ b/migrator/clone/mock_central.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/stackrox/rox/generated/storage"
-	"github.com/stackrox/rox/migrator/clone/metadata"
 	"github.com/stackrox/rox/migrator/clone/postgres"
 	"github.com/stackrox/rox/migrator/clone/rocksdb"
 	migGorm "github.com/stackrox/rox/migrator/postgres/gorm"
@@ -190,10 +189,6 @@ func (m *mockCentral) runMigrator(breakPoint string, forceRollback string, unsup
 	err := dbm.Scan()
 	if err != nil {
 		log.Info(err)
-	}
-	if unsupportedRocks {
-		require.Error(m.t, err, metadata.ErrUnsupportedDatabase)
-		return
 	}
 	require.NoError(m.t, err)
 	if breakPoint == breakAfterScan {

--- a/migrator/clone/rocksdb/db_clone_manager.go
+++ b/migrator/clone/rocksdb/db_clone_manager.go
@@ -58,9 +58,6 @@ type DBCloneManager interface {
 	// GetDirName - gets the directory name of the clone
 	GetDirName(cloneName string) string
 
-	// DecommissionRocksDB -- removes RocksDB from central
-	DecommissionRocksDB()
-
 	// CheckForRestore -- checks to see if a restore from a RocksDB is requested
 	CheckForRestore() bool
 }


### PR DESCRIPTION
## Description

There is no great reason to remove the RocksDB after multiple upgrades to Postgres.  For safety and emergencies decided to remove that code to ensure RocksDB remains.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

tests had to be updated to match the change and removal of the error message.
