### PR TITLE
ROX-14563: Show network policies data in the deployments side panel

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/common/NetworkPolicies.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/common/NetworkPolicies.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import {
     Alert,
     AlertVariant,
@@ -36,6 +36,11 @@ function NetworkPolicies({ policyIds }: NetworkPoliciesProps): React.ReactElemen
     const [selectedNetworkPolicy, setSelectedNetworkPolicy] = React.useState<
         NetworkPolicy | undefined
     >(networkPolicies?.[0]);
+
+    useEffect(() => {
+        setSelectedNetworkPolicy(networkPolicies[0]);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [networkPolicies]);
 
     function onToggleDarkMode() {
         setCustomDarkMode((prevValue) => !prevValue);

--- a/ui/apps/platform/src/Containers/NetworkGraph/namespace/NamespaceSideBar.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/namespace/NamespaceSideBar.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import {
     Flex,
     FlexItem,
+    Stack,
+    StackItem,
     Tab,
     TabContent,
     Tabs,
@@ -12,6 +14,7 @@ import {
 } from '@patternfly/react-core';
 
 import useTabs from 'hooks/patternfly/useTabs';
+import { uniq } from 'lodash';
 import { getDeploymentNodesInNamespace, getNumDeploymentFlows } from '../utils/networkGraphUtils';
 import { CustomEdgeModel, CustomNodeModel } from '../types/topology.type';
 
@@ -45,30 +48,33 @@ function NamespaceSideBar({ namespaceId, nodes, edges }: NamespaceSideBarProps) 
         const policyIds: string[] = curr?.data?.policyIds || [];
         return [...acc, ...policyIds];
     }, [] as string[]);
+    const uniqueNamespacePolicyIds = uniq(namespacePolicyIds);
 
     return (
-        <Flex direction={{ default: 'column' }} flex={{ default: 'flex_1' }} className="pf-u-h-100">
-            <Flex direction={{ default: 'row' }} className="pf-u-p-md pf-u-mb-0">
-                <FlexItem>
-                    <NamespaceIcon />
-                </FlexItem>
-                <FlexItem>
-                    <TextContent>
-                        <Text component={TextVariants.h1} className="pf-u-font-size-xl">
-                            stackrox
-                        </Text>
-                    </TextContent>
-                    <TextContent>
-                        <Text
-                            component={TextVariants.h2}
-                            className="pf-u-font-size-sm pf-u-color-200"
-                        >
-                            in &quot;remote&quot;
-                        </Text>
-                    </TextContent>
-                </FlexItem>
-            </Flex>
-            <FlexItem flex={{ default: 'flex_1' }}>
+        <Stack>
+            <StackItem>
+                <Flex direction={{ default: 'row' }} className="pf-u-p-md pf-u-mb-0">
+                    <FlexItem>
+                        <NamespaceIcon />
+                    </FlexItem>
+                    <FlexItem>
+                        <TextContent>
+                            <Text component={TextVariants.h1} className="pf-u-font-size-xl">
+                                stackrox
+                            </Text>
+                        </TextContent>
+                        <TextContent>
+                            <Text
+                                component={TextVariants.h2}
+                                className="pf-u-font-size-sm pf-u-color-200"
+                            >
+                                in &quot;remote&quot;
+                            </Text>
+                        </TextContent>
+                    </FlexItem>
+                </Flex>
+            </StackItem>
+            <StackItem>
                 <Tabs activeKey={activeKeyTab} onSelect={onSelectTab}>
                     <Tab
                         eventKey="Deployments"
@@ -81,6 +87,8 @@ function NamespaceSideBar({ namespaceId, nodes, edges }: NamespaceSideBarProps) 
                         title={<TabTitleText>Network policies</TabTitleText>}
                     />
                 </Tabs>
+            </StackItem>
+            <StackItem isFilled style={{ overflow: 'auto' }}>
                 <TabContent
                     eventKey="Deployments"
                     id="Deployments"
@@ -94,10 +102,10 @@ function NamespaceSideBar({ namespaceId, nodes, edges }: NamespaceSideBarProps) 
                     hidden={activeKeyTab !== 'Network policies'}
                     className="pf-u-h-100"
                 >
-                    <NetworkPolicies policyIds={namespacePolicyIds} />
+                    <NetworkPolicies policyIds={uniqueNamespacePolicyIds} />
                 </TabContent>
-            </FlexItem>
-        </Flex>
+            </StackItem>
+        </Stack>
     );
 }
 

--- a/ui/apps/platform/src/Containers/NetworkGraph/namespace/NamespaceSideBar.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/namespace/NamespaceSideBar.tsx
@@ -15,7 +15,11 @@ import {
 
 import useTabs from 'hooks/patternfly/useTabs';
 import { uniq } from 'lodash';
-import { getDeploymentNodesInNamespace, getNumDeploymentFlows } from '../utils/networkGraphUtils';
+import {
+    getDeploymentNodesInNamespace,
+    getNodeById,
+    getNumDeploymentFlows,
+} from '../utils/networkGraphUtils';
 import { CustomEdgeModel, CustomNodeModel } from '../types/topology.type';
 
 import { NamespaceIcon } from '../common/NetworkGraphIcons';
@@ -35,7 +39,9 @@ function NamespaceSideBar({ namespaceId, nodes, edges }: NamespaceSideBarProps) 
     });
 
     // derived state
+    const namespaceNode = getNodeById(nodes, namespaceId);
     const deploymentNodes = getDeploymentNodesInNamespace(nodes, namespaceId);
+    const cluster = namespaceNode?.data.type === 'NAMESPACE' ? namespaceNode.data.cluster : '';
 
     const deployments = deploymentNodes.map((deploymentNode) => {
         const numFlows = getNumDeploymentFlows(edges, deploymentNode.id);
@@ -60,7 +66,7 @@ function NamespaceSideBar({ namespaceId, nodes, edges }: NamespaceSideBarProps) 
                     <FlexItem>
                         <TextContent>
                             <Text component={TextVariants.h1} className="pf-u-font-size-xl">
-                                stackrox
+                                {namespaceNode?.label}
                             </Text>
                         </TextContent>
                         <TextContent>
@@ -68,7 +74,9 @@ function NamespaceSideBar({ namespaceId, nodes, edges }: NamespaceSideBarProps) 
                                 component={TextVariants.h2}
                                 className="pf-u-font-size-sm pf-u-color-200"
                             >
-                                in &quot;remote&quot;
+                                in &quot;
+                                {cluster}
+                                &quot;
                             </Text>
                         </TextContent>
                     </FlexItem>

--- a/ui/apps/platform/src/Containers/NetworkGraph/types/topology.type.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/types/topology.type.ts
@@ -42,6 +42,8 @@ export type NamespaceData = {
     type: 'NAMESPACE';
     collapsible: boolean;
     showContextMenu: boolean;
+    namespace: string;
+    cluster: string;
 };
 
 export type NetworkPolicyState = 'none' | 'both' | 'ingress' | 'egress';

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/modelUtils.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/modelUtils.tsx
@@ -197,13 +197,14 @@ export function transformActiveData(
     const deploymentNodes: Record<string, DeploymentNodeModel> = {};
     const activeEdgeMap: Record<string, CustomEdgeModel> = {};
 
-    nodes.forEach(({ entity, policyIds, outEdges }) => {
+    nodes.forEach(({ entity, outEdges }) => {
         const { type, id } = entity;
         const { networkPolicyState } = policyNodeMap[id]?.data || {};
         const isExternallyConnected = Object.keys(outEdges).some((nodeIdx) => {
             const { entity: targetEntity } = nodes[nodeIdx];
             return targetEntity.type === 'EXTERNAL_SOURCE' || targetEntity.type === 'INTERNET';
         });
+        const policyIds = policyNodeMap[id]?.data.policyIds || [];
 
         // to group deployments into namespaces
         if (type === 'DEPLOYMENT') {

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/modelUtils.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/modelUtils.tsx
@@ -42,11 +42,17 @@ function getBaseNode(id: string): CustomNodeModel {
     } as CustomNodeModel;
 }
 
-function getNamespaceNode(namespace: string, deploymentId: string): NamespaceNodeModel {
+function getNamespaceNode(
+    namespace: string,
+    cluster: string,
+    deploymentId: string
+): NamespaceNodeModel {
     const namespaceData: NamespaceData = {
         collapsible: true,
         showContextMenu: false,
         type: 'NAMESPACE',
+        namespace,
+        cluster,
     };
     return {
         id: namespace,
@@ -208,12 +214,12 @@ export function transformActiveData(
 
         // to group deployments into namespaces
         if (type === 'DEPLOYMENT') {
-            const { namespace } = entity.deployment;
+            const { namespace, cluster } = entity.deployment;
             const namespaceNode = namespaceNodes[namespace];
             if (namespaceNode && namespaceNode?.children) {
                 namespaceNode?.children.push(id);
             } else {
-                namespaceNodes[namespace] = getNamespaceNode(namespace, id);
+                namespaceNodes[namespace] = getNamespaceNode(namespace, cluster, id);
             }
 
             // creating deployment nodes
@@ -498,12 +504,12 @@ export function createExtraneousFlowsModel(
         // to group deployments into namespaces
         if (type === 'DEPLOYMENT') {
             const { deployment, id } = data;
-            const { namespace } = deployment;
+            const { namespace, cluster } = deployment;
             const namespaceNode = namespaceNodes[namespace];
             if (namespaceNode && namespaceNode?.children) {
                 namespaceNode?.children.push(id);
             } else {
-                namespaceNodes[namespace] = getNamespaceNode(namespace, id);
+                namespaceNodes[namespace] = getNamespaceNode(namespace, cluster, id);
             }
         }
 


### PR DESCRIPTION
## Description

This PR shows the network policies for deployments and namespaces

<img width="1552" alt="Screenshot 2023-01-25 at 3 10 55 PM" src="https://user-images.githubusercontent.com/4805485/214712755-3748d8a1-97a6-4cb0-b368-81778435544c.png">
<img width="1552" alt="Screenshot 2023-01-25 at 3 11 05 PM" src="https://user-images.githubusercontent.com/4805485/214712771-19adb65e-0758-4bda-9b1f-8740acb39b09.png">


## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~