### PR TITLE
ROX-13418: Use real data for network policy rules section

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentDetails.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentDetails.tsx
@@ -26,14 +26,21 @@ import pluralize from 'pluralize';
 import { Deployment } from 'types/deployment.proto';
 import { ListenPort } from 'types/networkFlow.proto';
 import { getDateTime } from 'utils/dateUtils';
+import { NetworkPolicyState } from 'Containers/NetworkGraph/types/topology.type';
 
 import DeploymentPortConfig from 'Components/DeploymentPortConfig';
+
+import { ReactComponent as BothPolicyRules } from 'images/network-graph/both-policy-rules.svg';
+import { ReactComponent as EgressOnly } from 'images/network-graph/egress-only.svg';
+import { ReactComponent as IngressOnly } from 'images/network-graph/ingress-only.svg';
+import { ReactComponent as NoPolicyRules } from 'images/network-graph/no-policy-rules.svg';
 
 type DeploymentDetailsProps = {
     deployment: Deployment;
     numExternalFlows: number;
     numInternalFlows: number;
     listenPorts: ListenPort[];
+    networkPolicyState: NetworkPolicyState;
 };
 
 function DetailSection({ title, children }) {
@@ -65,6 +72,7 @@ function DeploymentDetails({
     numExternalFlows,
     numInternalFlows,
     listenPorts,
+    networkPolicyState,
 }: DeploymentDetailsProps) {
     return (
         <div className="pf-u-h-100 pf-u-p-md">
@@ -105,25 +113,58 @@ function DeploymentDetails({
                             <DescriptionListGroup>
                                 <DescriptionListTerm>Network policy rules</DescriptionListTerm>
                                 <DescriptionListDescription>
-                                    <Flex
-                                        direction={{ default: 'row' }}
-                                        alignItems={{ default: 'alignItemsCenter' }}
-                                    >
-                                        <FlexItem>
+                                    {networkPolicyState === 'both' && (
+                                        <Label
+                                            variant="outline"
+                                            color="blue"
+                                            icon={<BothPolicyRules width="22px" height="22px" />}
+                                        >
+                                            1 or more policies regulating bidirectional traffic
+                                        </Label>
+                                    )}
+                                    {networkPolicyState === 'egress' && (
+                                        <LabelGroup>
                                             <Label
                                                 variant="outline"
-                                                color="gold"
-                                                icon={<ExclamationCircleIcon />}
+                                                color="red"
+                                                icon={<NoPolicyRules width="22px" height="22px" />}
                                             >
-                                                0 egress, allowing 325 flows
+                                                A missing policy is allowing all ingress traffic
                                             </Label>
-                                        </FlexItem>
-                                        <FlexItem>
-                                            <Label variant="outline" color="blue">
-                                                1 egress
+                                            <Label
+                                                variant="outline"
+                                                color="blue"
+                                                icon={<EgressOnly width="22px" height="22px" />}
+                                            >
+                                                1 or more policies regulating egress traffic
                                             </Label>
-                                        </FlexItem>
-                                    </Flex>
+                                        </LabelGroup>
+                                    )}
+                                    {networkPolicyState === 'ingress' && (
+                                        <LabelGroup>
+                                            <Label
+                                                variant="outline"
+                                                icon={<NoPolicyRules width="22px" height="22px" />}
+                                            >
+                                                A missing policy is allowing all egress traffic
+                                            </Label>
+                                            <Label
+                                                variant="outline"
+                                                color="blue"
+                                                icon={<IngressOnly width="22px" height="22px" />}
+                                            >
+                                                1 or more policies regulating ingress traffic
+                                            </Label>
+                                        </LabelGroup>
+                                    )}
+                                    {networkPolicyState === 'none' && (
+                                        <Label
+                                            variant="outline"
+                                            icon={<NoPolicyRules width="22px" height="22px" />}
+                                        >
+                                            A missing policy is allowing all network traffic
+                                        </Label>
+                                    )}
                                 </DescriptionListDescription>
                             </DescriptionListGroup>
                             <DescriptionListGroup>

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentSideBar.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentSideBar.tsx
@@ -65,6 +65,10 @@ function DeploymentSideBar({ deploymentId, nodes, edges, edgeState }: Deployment
     const listenPorts = getListenPorts(nodes, deploymentId);
     const deploymentPolicyIds =
         deploymentNode?.data.type === 'DEPLOYMENT' ? deploymentNode?.data?.policyIds : [];
+    const networkPolicyState =
+        deploymentNode?.data.type === 'DEPLOYMENT'
+            ? deploymentNode.data.networkPolicyState
+            : 'none';
 
     if (isLoading) {
         return (
@@ -150,6 +154,7 @@ function DeploymentSideBar({ deploymentId, nodes, edges, edgeState }: Deployment
                                     numExternalFlows={numExternalFlows}
                                     numInternalFlows={numInternalFlows}
                                     listenPorts={listenPorts}
+                                    networkPolicyState={networkPolicyState}
                                 />
                             )}
                         </TabContent>


### PR DESCRIPTION
## Description

This PR shows the network policy rules for a deployment

<img width="1552" alt="Screenshot 2023-01-25 at 4 14 50 PM" src="https://user-images.githubusercontent.com/4805485/214723561-dc134502-df07-4897-a369-7e3421a657cc.png">
<img width="1552" alt="Screenshot 2023-01-25 at 4 14 54 PM" src="https://user-images.githubusercontent.com/4805485/214723570-75a76245-a586-41cf-800a-a7dabf6ba03f.png">


## Checklist
- [x] Investigated and inspected CI test results (ui-e2e-test failures are unrelated flakes)
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~
