### PR TITLE
ROX-14137: Role declarative config struct

### DIFF
--- a/pkg/declarativeconfig/role.go
+++ b/pkg/declarativeconfig/role.go
@@ -1,0 +1,9 @@
+package declarativeconfig
+
+// Role is representation of storage.Role that supports transformation from YAML.
+type Role struct {
+	Name          string `yaml:"name,omitempty"`
+	Description   string `yaml:"description,omitempty"`
+	AccessScope   string `yaml:"accessScope,omitempty"`
+	PermissionSet string `yaml:"permissionSet,omitempty"`
+}

--- a/pkg/declarativeconfig/role_test.go
+++ b/pkg/declarativeconfig/role_test.go
@@ -1,0 +1,25 @@
+package declarativeconfig
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
+)
+
+func TestRoleYAMLTransformation(t *testing.T) {
+	data := []byte(`
+name: test-name
+description: test-description
+accessScope: access-scope
+permissionSet: permission-set
+`)
+	role := Role{}
+
+	err := yaml.Unmarshal(data, &role)
+	assert.NoError(t, err)
+	assert.Equal(t, "test-name", role.Name)
+	assert.Equal(t, "test-description", role.Description)
+	assert.Equal(t, "access-scope", role.AccessScope)
+	assert.Equal(t, "permission-set", role.PermissionSet)
+}


### PR DESCRIPTION
## Description

Go struct which will be used for YAML -> Go struct transformation of declarative Role.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

1. Unit test added
