### PR TITLE
ROX-14137: access scope YAML format for declarative config

### DIFF
--- a/pkg/declarativeconfig/access_scope.go
+++ b/pkg/declarativeconfig/access_scope.go
@@ -19,13 +19,13 @@ type Namespace struct {
 
 type Operator storage.SetBasedLabelSelector_Operator
 
-// MarshalYAML transforms Access to YAML format.
+// MarshalYAML transforms Operator to YAML format.
 func (a Operator) MarshalYAML() ([]byte, error) {
 	protoAccess := storage.SetBasedLabelSelector_Operator(a)
 	return []byte(protoAccess.String()), nil
 }
 
-// UnmarshalYAML makes transformation from YAML to Access.
+// UnmarshalYAML makes transformation from YAML to Operator.
 func (a *Operator) UnmarshalYAML(value *yaml.Node) error {
 	var v string
 	if err := value.Decode(&v); err != nil {

--- a/pkg/declarativeconfig/access_scope.go
+++ b/pkg/declarativeconfig/access_scope.go
@@ -6,17 +6,14 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// AccessScope is representation of storage.AccessScope that supports transformation from YAML.
 type AccessScope struct {
 	Name        string `yaml:"name,omitempty"`
 	Description string `yaml:"description,omitempty"`
 	Rules       Rules  `yaml:"rules,omitempty"`
 }
 
-type Namespace struct {
-	Cluster   string `yaml:"cluster,omitempty"`
-	Namespace string `yaml:"namespace,omitempty"`
-}
-
+// Operator is representation of storage.SetBasedLabelSelector_Operator that supports transformation from YAML.
 type Operator storage.SetBasedLabelSelector_Operator
 
 // MarshalYAML transforms Operator to YAML format.
@@ -39,19 +36,28 @@ func (a *Operator) UnmarshalYAML(value *yaml.Node) error {
 	return nil
 }
 
+// Requirement is representation of storage.SetBasedLabelSelector_Requirement that supports transformation from YAML.
 type Requirement struct {
 	Key      string   `yaml:"key,omitempty"`
 	Operator Operator `yaml:"operator,omitempty"`
 	Values   []string `yaml:"values,omitempty"`
 }
 
+// LabelSelector is representation of storage.SetBasedLabelSelector that supports transformation from YAML.
 type LabelSelector struct {
 	Requirements []Requirement `yaml:"requirements,omitempty"`
 }
 
+// IncludedObject represents list of included into access scope namespaces within the specified cluster.
+// If namespaces list is empty, that means the whole cluster is included into access scope.
+type IncludedObject struct {
+	Cluster    string   `yaml:"cluster,omitempty"`
+	Namespaces []string `yaml:"namespaces,omitempty"`
+}
+
+// Rules is representation of storage.SimpleAccessScope_Rules that supports transformation from YAML.
 type Rules struct {
-	IncludedClusters        []string        `yaml:"includedClusters,omitempty"`
-	IncludedNamespaces      []Namespace     `yaml:"includedNamespaces,omitempty"`
-	ClusterLabelSelectors   []LabelSelector `yaml:"clusterLabelSelectors,omitempty"`
-	NamespaceLabelSelectors []LabelSelector `yaml:"namespaceLabelSelectors,omitempty"`
+	IncludedObjects         []IncludedObject `yaml:"included,omitempty"`
+	ClusterLabelSelectors   []LabelSelector  `yaml:"clusterLabelSelectors,omitempty"`
+	NamespaceLabelSelectors []LabelSelector  `yaml:"namespaceLabelSelectors,omitempty"`
 }

--- a/pkg/declarativeconfig/access_scope.go
+++ b/pkg/declarativeconfig/access_scope.go
@@ -1,0 +1,10 @@
+package declarativeconfig
+
+import "github.com/stackrox/rox/generated/storage"
+
+// TODO: currently it does not correspond to YAML format described in access_scope_test
+type AccessScope struct {
+	Name        string                           `yaml:"name,omitempty"`
+	Description string                           `yaml:"description,omitempty"`
+	Rules       *storage.SimpleAccessScope_Rules `yaml:"rules,omitempty"`
+}

--- a/pkg/declarativeconfig/access_scope.go
+++ b/pkg/declarativeconfig/access_scope.go
@@ -1,10 +1,57 @@
 package declarativeconfig
 
-import "github.com/stackrox/rox/generated/storage"
+import (
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/generated/storage"
+	"gopkg.in/yaml.v3"
+)
 
-// TODO: currently it does not correspond to YAML format described in access_scope_test
 type AccessScope struct {
-	Name        string                           `yaml:"name,omitempty"`
-	Description string                           `yaml:"description,omitempty"`
-	Rules       *storage.SimpleAccessScope_Rules `yaml:"rules,omitempty"`
+	Name        string `yaml:"name,omitempty"`
+	Description string `yaml:"description,omitempty"`
+	Rules       Rules  `yaml:"rules,omitempty"`
+}
+
+type Namespace struct {
+	Cluster   string `yaml:"cluster,omitempty"`
+	Namespace string `yaml:"namespace,omitempty"`
+}
+
+type Operator storage.SetBasedLabelSelector_Operator
+
+// MarshalYAML transforms Access to YAML format.
+func (a Operator) MarshalYAML() ([]byte, error) {
+	protoAccess := storage.SetBasedLabelSelector_Operator(a)
+	return []byte(protoAccess.String()), nil
+}
+
+// UnmarshalYAML makes transformation from YAML to Access.
+func (a *Operator) UnmarshalYAML(value *yaml.Node) error {
+	var v string
+	if err := value.Decode(&v); err != nil {
+		return err
+	}
+	i, ok := storage.SetBasedLabelSelector_Operator_value[v]
+	if !ok {
+		return errors.Errorf("Operator value %s not found", v)
+	}
+	*a = Operator(i)
+	return nil
+}
+
+type Requirement struct {
+	Key      string   `yaml:"key,omitempty"`
+	Operator Operator `yaml:"operator,omitempty"`
+	Values   []string `yaml:"values,omitempty"`
+}
+
+type LabelSelector struct {
+	Requirements []Requirement `yaml:"requirements,omitempty"`
+}
+
+type Rules struct {
+	IncludedClusters        []string        `yaml:"includedClusters,omitempty"`
+	IncludedNamespaces      []Namespace     `yaml:"includedNamespaces,omitempty"`
+	ClusterLabelSelectors   []LabelSelector `yaml:"clusterLabelSelectors,omitempty"`
+	NamespaceLabelSelectors []LabelSelector `yaml:"namespaceLabelSelectors,omitempty"`
 }

--- a/pkg/declarativeconfig/access_scope_test.go
+++ b/pkg/declarativeconfig/access_scope_test.go
@@ -3,23 +3,22 @@ package declarativeconfig
 import (
 	"testing"
 
+	"github.com/stackrox/rox/generated/storage"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v3"
 )
 
-func TestPermissionSetYAMLTransformation(t *testing.T) {
+func TestAccessScopeYAMLTransformation(t *testing.T) {
 	data := []byte(`
 name: test-name
 description: test-description
 rules:
-  includedClusters:
-    - clusterA
-    - clusterB
-  includedNamespaces:
-    - cluster: clusterC
-      namespace: namespaceC
-    - cluster: clusterD
-      namespace: namespaceD
+  included:
+    - cluster: clusterA
+      namespaces:
+      - namespaceA1
+      - namespaceA2
+    - cluster: clusterB
   clusterLabelSelectors:
     - requirements:
       - key: a
@@ -40,7 +39,35 @@ rules:
 
 	err := yaml.Unmarshal(data, &as)
 	assert.NoError(t, err)
-	// TODO: more asserts
 	assert.Equal(t, "test-name", as.Name)
 	assert.Equal(t, "test-description", as.Description)
+
+	assert.Len(t, as.Rules.IncludedObjects, 2)
+	assert.Equal(t, as.Rules.IncludedObjects[0].Cluster, "clusterA")
+	assert.Len(t, as.Rules.IncludedObjects[0].Namespaces, 2)
+	assert.Equal(t, as.Rules.IncludedObjects[0].Namespaces[0], "namespaceA1")
+	assert.Equal(t, as.Rules.IncludedObjects[0].Namespaces[1], "namespaceA2")
+	assert.Equal(t, as.Rules.IncludedObjects[1].Cluster, "clusterB")
+	assert.Len(t, as.Rules.IncludedObjects[1].Namespaces, 0)
+
+	assert.Len(t, as.Rules.ClusterLabelSelectors, 2)
+	assert.Len(t, as.Rules.ClusterLabelSelectors[0].Requirements, 2)
+	operator := as.Rules.ClusterLabelSelectors[0].Requirements[0].Operator
+	assert.Equal(t, storage.SetBasedLabelSelector_Operator(operator), storage.SetBasedLabelSelector_IN)
+	assert.Equal(t, as.Rules.ClusterLabelSelectors[0].Requirements[0].Key, "a")
+	assert.Equal(t, as.Rules.ClusterLabelSelectors[0].Requirements[0].Values, []string{"a", "b", "c"})
+	operator = as.Rules.ClusterLabelSelectors[0].Requirements[1].Operator
+	assert.Equal(t, storage.SetBasedLabelSelector_Operator(operator), storage.SetBasedLabelSelector_NOT_IN)
+	assert.Equal(t, as.Rules.ClusterLabelSelectors[0].Requirements[1].Key, "b")
+	assert.Equal(t, as.Rules.ClusterLabelSelectors[0].Requirements[1].Values, []string{"b", "d"})
+
+	operator = as.Rules.ClusterLabelSelectors[1].Requirements[0].Operator
+	assert.Equal(t, storage.SetBasedLabelSelector_Operator(operator), storage.SetBasedLabelSelector_IN)
+	assert.Equal(t, as.Rules.ClusterLabelSelectors[1].Requirements[0].Key, "c")
+	assert.Equal(t, as.Rules.ClusterLabelSelectors[1].Requirements[0].Values, []string{"d", "e", "f"})
+	operator = as.Rules.ClusterLabelSelectors[1].Requirements[1].Operator
+	assert.Equal(t, storage.SetBasedLabelSelector_Operator(operator), storage.SetBasedLabelSelector_NOT_IN)
+	assert.Equal(t, as.Rules.ClusterLabelSelectors[1].Requirements[1].Key, "d")
+	assert.Equal(t, as.Rules.ClusterLabelSelectors[1].Requirements[1].Values, []string{"x", "y", "z"})
+	assert.Len(t, as.Rules.NamespaceLabelSelectors, 0)
 }

--- a/pkg/declarativeconfig/access_scope_test.go
+++ b/pkg/declarativeconfig/access_scope_test.go
@@ -1,0 +1,46 @@
+package declarativeconfig
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
+)
+
+func TestPermissionSetYAMLTransformation(t *testing.T) {
+	data := []byte(`
+name: test-name
+description: test-description
+rules:
+  includedClusters:
+    - clusterA
+    - clusterB
+  includedNamespaces:
+    - cluster: clusterC
+      namespace: namespaceC
+    - cluster: clusterD
+    - namespace: namespaceD
+  clusterLabelSelectors:
+  	- requirements:
+      - key: a
+        operator: In
+        values: [a, b, c]
+      - key: b
+        operator: NotIn
+        values: [b, d]
+    - requirements:
+       - key: c
+        operator: In
+        values: [d, e, f]
+      - key: d
+        operator: NotIn
+        values: [x, y, z]
+`)
+	as := AccessScope{}
+
+	err := yaml.Unmarshal(data, &as)
+	assert.NoError(t, err)
+	assert.Equal(t, "test-name", as.Name)
+	assert.Equal(t, "test-description", as.Description)
+
+}

--- a/pkg/declarativeconfig/access_scope_test.go
+++ b/pkg/declarativeconfig/access_scope_test.go
@@ -19,28 +19,28 @@ rules:
     - cluster: clusterC
       namespace: namespaceC
     - cluster: clusterD
-    - namespace: namespaceD
+      namespace: namespaceD
   clusterLabelSelectors:
-  	- requirements:
+    - requirements:
       - key: a
-        operator: In
+        operator: IN
         values: [a, b, c]
       - key: b
-        operator: NotIn
+        operator: NOT_IN
         values: [b, d]
     - requirements:
-       - key: c
-        operator: In
+      - key: c
+        operator: IN
         values: [d, e, f]
       - key: d
-        operator: NotIn
+        operator: NOT_IN
         values: [x, y, z]
 `)
 	as := AccessScope{}
 
 	err := yaml.Unmarshal(data, &as)
 	assert.NoError(t, err)
+	// TODO: more asserts
 	assert.Equal(t, "test-name", as.Name)
 	assert.Equal(t, "test-description", as.Description)
-
 }


### PR DESCRIPTION
## Description

Go struct which will be used for YAML -> Go struct transformation of declarative Access Scope.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Unit test added