### PR TITLE
Fix error message about multiple mobx instances

### DIFF
--- a/ui/apps/platform/src/index.tsx
+++ b/ui/apps/platform/src/index.tsx
@@ -24,6 +24,7 @@ import '@patternfly/react-styles/css/utilities/Flex/flex.css';
 import '@patternfly/react-styles/css/utilities/Sizing/sizing.css';
 import '@patternfly/react-styles/css/utilities/Spacing/spacing.css';
 import '@patternfly/react-styles/css/utilities/Text/text.css';
+import { configure as mobxConfigure } from 'mobx';
 
 // Advanced Cluster Security extensions to PatternFly styles
 import 'css/acs.css';
@@ -39,6 +40,12 @@ import { ThunkAction, ThunkDispatch } from 'redux-thunk';
 import { fetchFeatureFlagsThunk } from './reducers/featureFlags';
 import { fetchPublicConfigThunk } from './reducers/systemConfig';
 import configureApollo from './configureApolloClient';
+
+// We need to call this MobX utility function, to prevent the error
+//   Uncaught Error: [MobX] There are multiple, different versions of MobX active. Make sure MobX is loaded only once or use `configure({ isolateGlobalState: true })`
+// which occurs because both the PatternFly react-topology component and the Redoc API viewer library
+// both load their own versions of MobX
+mobxConfigure({ isolateGlobalState: true });
 
 installRaven();
 


### PR DESCRIPTION
## Description

Hat-tip to Mark for tracking down this solution to the multiple-MobX error in the browser console.


## Checklist
- [x] Investigated and inspected CI test results (ui-e2e test failure is unrelated Postgres regression)

## Testing Performed

Without this code, error
<img width="1455" alt="Screen Shot 2023-01-26 at 2 08 16 PM" src="https://user-images.githubusercontent.com/715729/214929621-28358fe7-1ff5-4192-8027-d5ac9a87fd55.png">

With this code, no error
<img width="1455" alt="Screen Shot 2023-01-26 at 2 11 29 PM" src="https://user-images.githubusercontent.com/715729/214929645-bfe51d97-94e7-4412-babf-bedea3a026c6.png">
