### PR TITLE
ROX-14583: Make NS and Deployment dropdowns stay open

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/components/DeploymentSelector.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/DeploymentSelector.tsx
@@ -18,11 +18,7 @@ function DeploymentSelector({
     searchFilter,
     setSearchFilter,
 }: DeploymentSelectorProps) {
-    const {
-        isOpen: isDeploymentOpen,
-        toggleSelect: toggleIsDeploymentOpen,
-        closeSelect: closeDeploymentSelect,
-    } = useSelectToggle();
+    const { isOpen: isDeploymentOpen, toggleSelect: toggleIsDeploymentOpen } = useSelectToggle();
 
     const onFilterDeployments = useCallback(
         (_, filterValue: string) => {
@@ -48,8 +44,6 @@ function DeploymentSelector({
     );
 
     const onDeploymentSelect = (_, selected) => {
-        closeDeploymentSelect();
-
         const newSelection = selectedDeployments.find((nsFilter) => nsFilter === selected)
             ? selectedDeployments.filter((nsFilter) => nsFilter !== selected)
             : selectedDeployments.concat(selected);

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/NamespaceSelector.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/NamespaceSelector.tsx
@@ -36,11 +36,7 @@ function NamespaceSelector({
     searchFilter,
     setSearchFilter,
 }: NamespaceSelectorProps) {
-    const {
-        isOpen: isNamespaceOpen,
-        toggleSelect: toggleIsNamespaceOpen,
-        closeSelect: closeNamespaceSelect,
-    } = useSelectToggle();
+    const { isOpen: isNamespaceOpen, toggleSelect: toggleIsNamespaceOpen } = useSelectToggle();
 
     const onFilterNamespaces = useCallback(
         (e: ChangeEvent<HTMLInputElement> | null, filterValue: string) =>
@@ -68,8 +64,6 @@ function NamespaceSelector({
     }, {});
 
     const onNamespaceSelect = (_, selected) => {
-        closeNamespaceSelect();
-
         const newSelection = selectedNamespaces.find((nsFilter) => nsFilter === selected)
             ? selectedNamespaces.filter((nsFilter) => nsFilter !== selected)
             : selectedNamespaces.concat(selected);


### PR DESCRIPTION
## Description

This fixes a workflow considered a blocker.

## Checklist
- [x] Investigated and inspected CI test results (Postgres ui-e2e-tests failures are unrelated flakes)

## Testing Performed

Look ma, open menus!

https://user-images.githubusercontent.com/715729/214975381-794b3c16-04ac-4cd5-8d82-f401df004751.mov

