### PR TITLE
Improve operator basic central test.

### DIFF
--- a/operator/tests/central/basic/40-assert.yaml
+++ b/operator/tests/central/basic/40-assert.yaml
@@ -1,3 +1,10 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app=central
+  tail: -1
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/operator/tests/central/basic/50-assert.yaml
+++ b/operator/tests/central/basic/50-assert.yaml
@@ -1,3 +1,10 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app=central
+  tail: -1
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/operator/tests/central/basic/61-assert.yaml
+++ b/operator/tests/central/basic/61-assert.yaml
@@ -1,3 +1,16 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app=central
+  tail: -1
+- type: pod
+  selector: app=scanner
+  tail: -1
+- type: pod
+  selector: app=scanner-db
+  tail: -1
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/operator/tests/central/basic/62-assert.yaml
+++ b/operator/tests/central/basic/62-assert.yaml
@@ -1,3 +1,16 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app=central
+  tail: -1
+- type: pod
+  selector: app=scanner
+  tail: -1
+- type: pod
+  selector: app=scanner-db
+  tail: -1
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/operator/tests/central/basic/76-assert.yaml
+++ b/operator/tests/central/basic/76-assert.yaml
@@ -4,6 +4,22 @@ collectors:
 - type: pod
   selector: app=central-db
   tail: -1
+- type: pod
+  selector: app=central
+  tail: -1
+- type: pod
+  selector: app=scanner
+  tail: -1
+- type: pod
+  selector: app=scanner-db
+  tail: -1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: central
+status:
+  availableReplicas: 1
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/operator/tests/central/basic/80-assert.yaml
+++ b/operator/tests/central/basic/80-assert.yaml
@@ -1,3 +1,10 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app=central
+  tail: -1
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/operator/tests/central/basic/81-assert.yaml
+++ b/operator/tests/central/basic/81-assert.yaml
@@ -1,3 +1,10 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app=central
+  tail: -1
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:


### PR DESCRIPTION
## Description

Operator test [recently](https://github.com/stackrox/stackrox/commit/82a3731cef4f7a499b94902a9d263090039f1e86) started failing on the step that enables telemetry. @theencee noticed this on [his PR](https://github.com/stackrox/stackrox/commit/c78a8d60490ec11dc192be9e8da5e58638babfdf) and was kind to look into the cause and ping me.

I suspect the issue is actually in an earlier step which ignores the error, and the telemetry step is the first in line which does assert the central pod health and therefore fails. However the failure is not very informative, because we do not collect pod logs in that step.

So this change:
1. asserts deployment health in step 76 (`switch-central-db-to-internal`, which is the one I suspect to be the culprit)
2. collect pod logs in every step which asserts deployment health, for debugging purposes

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

CI should be sufficient.