### PR TITLE
ROX-13413 move the eventPipeline's queue size initialization to CreateOptions

### DIFF
--- a/pkg/env/sensor.go
+++ b/pkg/env/sensor.go
@@ -20,8 +20,8 @@ var (
 	// LocalImageScanningEnabled is used to specify if Sensor should attempt to scan images via a local Scanner.
 	LocalImageScanningEnabled = RegisterBooleanSetting("ROX_LOCAL_IMAGE_SCANNING_ENABLED", false)
 
-	// EventPipelineOutputQueueSize is used to specify the size of the eventPipeline's output queue
-	EventPipelineOutputQueueSize = RegisterIntegerSetting("ROX_EVENT_PIPELINE_OUTPUT_QUEUE_SIZE", 100)
+	// EventPipelineQueueSize is used to specify the size of the eventPipeline's queues
+	EventPipelineQueueSize = RegisterIntegerSetting("ROX_EVENT_PIPELINE_QUEUE_SIZE", 100)
 
 	// ResyncDisabled disables the resync behavior of the kubernetes listeners in sensor
 	ResyncDisabled = RegisterBooleanSetting("ROX_RESYNC_DISABLED", false)

--- a/sensor/kubernetes/eventpipeline/pipeline.go
+++ b/sensor/kubernetes/eventpipeline/pipeline.go
@@ -19,13 +19,12 @@ import (
 )
 
 // New instantiates the eventPipeline component
-func New(client client.Interface, configHandler config.Handler, detector detector.Detector, nodeName string, resyncPeriod time.Duration, traceWriter io.Writer, storeProvider *resources.InMemoryStoreProvider) common.SensorComponent {
-	// TODO(ROX-13413): Move this env.EventPipelineOutputQueueSize to CreateOptions
-	outputQueue := output.New(detector, env.EventPipelineOutputQueueSize.IntegerSetting())
+func New(client client.Interface, configHandler config.Handler, detector detector.Detector, nodeName string, resyncPeriod time.Duration, traceWriter io.Writer, storeProvider *resources.InMemoryStoreProvider, queueSize int) common.SensorComponent {
+	outputQueue := output.New(detector, queueSize)
 	var depResolver component.Resolver
 	var resourceListener component.PipelineComponent
 	if env.ResyncDisabled.BooleanSetting() {
-		depResolver = resolver.New(outputQueue, storeProvider)
+		depResolver = resolver.New(outputQueue, storeProvider, queueSize)
 		resourceListener = listener.New(client, configHandler, nodeName, resyncPeriod, traceWriter, depResolver, storeProvider)
 	} else {
 		resourceListener = listener.New(client, configHandler, nodeName, resyncPeriod, traceWriter, outputQueue, storeProvider)

--- a/sensor/kubernetes/eventpipeline/resolver/resolver.go
+++ b/sensor/kubernetes/eventpipeline/resolver/resolver.go
@@ -6,10 +6,10 @@ import (
 )
 
 // New instantiates a Resolver component
-func New(outputQueue component.OutputQueue, provider store.Provider) component.Resolver {
+func New(outputQueue component.OutputQueue, provider store.Provider, queueSize int) component.Resolver {
 	return &resolverImpl{
 		outputQueue:   outputQueue,
-		innerQueue:    make(chan *component.ResourceEvent),
+		innerQueue:    make(chan *component.ResourceEvent, queueSize),
 		storeProvider: provider,
 	}
 }

--- a/sensor/kubernetes/eventpipeline/resolver/resolver_test.go
+++ b/sensor/kubernetes/eventpipeline/resolver/resolver_test.go
@@ -59,7 +59,7 @@ func (s *resolverSuite) SetupTest() {
 		serviceStore:    s.mockServiceStore,
 		rbacStore:       s.mockRBACStore,
 		endpointManager: s.mockEndpointManager,
-	})
+	}, 100)
 }
 
 func (s *resolverSuite) Test_MessageSentToOutput() {

--- a/sensor/kubernetes/sensor/options.go
+++ b/sensor/kubernetes/sensor/options.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"time"
 
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/sensor/common/centralclient"
 	"github.com/stackrox/rox/sensor/kubernetes/client"
 	"github.com/stackrox/rox/sensor/kubernetes/fake"
@@ -12,12 +13,13 @@ import (
 // CreateOptions represents the custom configuration that can be provided when creating sensor
 // using CreateSensor.
 type CreateOptions struct {
-	workloadManager    *fake.WorkloadManager
-	centralConnFactory centralclient.CentralConnectionFactory
-	localSensor        bool
-	resyncPeriod       time.Duration
-	k8sClient          client.Interface
-	traceWriter        io.Writer
+	workloadManager        *fake.WorkloadManager
+	centralConnFactory     centralclient.CentralConnectionFactory
+	localSensor            bool
+	resyncPeriod           time.Duration
+	k8sClient              client.Interface
+	traceWriter            io.Writer
+	eventPipelineQueueSize int
 }
 
 // ConfigWithDefaults creates a new config object with default properties.
@@ -28,12 +30,13 @@ type CreateOptions struct {
 // before running CreateSensor.
 func ConfigWithDefaults() *CreateOptions {
 	return &CreateOptions{
-		workloadManager:    nil,
-		centralConnFactory: nil,
-		k8sClient:          nil,
-		localSensor:        false,
-		resyncPeriod:       1 * time.Minute,
-		traceWriter:        nil,
+		workloadManager:        nil,
+		centralConnFactory:     nil,
+		k8sClient:              nil,
+		localSensor:            false,
+		resyncPeriod:           1 * time.Minute,
+		traceWriter:            nil,
+		eventPipelineQueueSize: env.EventPipelineQueueSize.IntegerSetting(),
 	}
 }
 
@@ -70,6 +73,13 @@ func (cfg *CreateOptions) WithLocalSensor(flag bool) *CreateOptions {
 // Default: 1 minute
 func (cfg *CreateOptions) WithResyncPeriod(duration time.Duration) *CreateOptions {
 	cfg.resyncPeriod = duration
+	return cfg
+}
+
+// WithEventPipelineQueueSize sets the size of the eventPipeline's queue.
+// Default: 100
+func (cfg *CreateOptions) WithEventPipelineQueueSize(size int) *CreateOptions {
+	cfg.eventPipelineQueueSize = size
 	return cfg
 }
 

--- a/sensor/kubernetes/sensor/sensor.go
+++ b/sensor/kubernetes/sensor/sensor.go
@@ -106,7 +106,7 @@ func CreateSensor(cfg *CreateOptions) (*sensor.Sensor, error) {
 
 	imageCache := expiringcache.NewExpiringCache(env.ReprocessInterval.DurationSetting())
 	policyDetector := detector.New(enforcer, admCtrlSettingsMgr, resources.DeploymentStoreSingleton(), resources.ServiceAccountStoreSingleton(), imageCache, auditLogEventsInput, auditLogCollectionManager, resources.NetworkPolicySingleton())
-	pipeline := eventpipeline.New(cfg.k8sClient, configHandler, policyDetector, k8sNodeName.Setting(), cfg.resyncPeriod, cfg.traceWriter, storeProvider)
+	pipeline := eventpipeline.New(cfg.k8sClient, configHandler, policyDetector, k8sNodeName.Setting(), cfg.resyncPeriod, cfg.traceWriter, storeProvider, cfg.eventPipelineQueueSize)
 	admCtrlMsgForwarder := admissioncontroller.NewAdmCtrlMsgForwarder(admCtrlSettingsMgr, pipeline)
 
 	imageService := image.NewService(imageCache, registry.Singleton())


### PR DESCRIPTION
## Description

This PR moves the `eventPipeline`'s queue sizes initialization to the `CreateOptions`.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

* The CI should be enough
