### PR TITLE
Fix collection dropdown in VM reporting to always use id as scopeId parameter

### DIFF
--- a/ui/apps/platform/src/Containers/VulnMgmt/Reports/Form/CollectionSelection.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Reports/Form/CollectionSelection.tsx
@@ -140,6 +140,10 @@ function CollectionSelection({
                             onTypeaheadInputChanged={setSearch}
                             loadingVariant={selectLoadingVariant}
                             onBlur={() => setSearch('')}
+                            style={{
+                                maxHeight: '275px',
+                                overflowY: 'auto',
+                            }}
                             validated={
                                 isLegacyReportScopeSelected
                                     ? ValidatedOptions.error

--- a/ui/apps/platform/src/Containers/VulnMgmt/Reports/Form/CollectionSelection.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Reports/Form/CollectionSelection.tsx
@@ -139,7 +139,7 @@ function CollectionSelection({
                             onToggle={onToggle}
                             onTypeaheadInputChanged={setSearch}
                             loadingVariant={selectLoadingVariant}
-                            isInputValuePersisted
+                            onBlur={() => setSearch('')}
                             validated={
                                 isLegacyReportScopeSelected
                                     ? ValidatedOptions.error


### PR DESCRIPTION
## Description

Bug discovered by Van during team testing.

### To reproduce:

Go to VM reporting and configure a report. Before saving click into the typeahead area of the collections dropdown and then click back out. It is not necessary to enter a search filter, but that also will reproduce the issue. Saving the report gives an error:
```
Failure
Collection <collection_name> not found. Error: %!s(<nil>): not found
```
This error is from the BE due to the FE sending the collection **name** and not the collection id as the `scopeId` parameter.

### The cause:

PatternFly's `<Select>` component has an `onSelect` callback prop that fires when the value of the dropdown is changed. However this callback also fires when all of the following are true:
- the user is toggling the dropdown closed
- the `isInputValuePersisted` prop is set to true
- an `onSelect` callback has been defined
```typescript
    if (!isExpanded && isInputValuePersisted && onSelect) {
      onSelect(undefined, this.inputRef.current ? this.inputRef.current.value : '');
    }
```
When the callback fires in this way, it passes the value of the _input_ element as the new selected value. The mismatch comes from users searching for a collection by name in this input, while we are using `<SelectOption>` components that display the collection name while using an id as the backing value.

### The fix:

- Remove the `isInputValuePersisted` prop
- Add an onBlur callback to reset the search, which ensures that the selected collection will appear in the dropdown and the name of the collection will be displayed in the closed `<Select>` element.

The downside of this fix is that there might be a brief moment where the UUID is displayed in the dropdown while the new search request is made to the BE.

An alternative fix that does not have this drawback would be to trap for an `undefined` event in our `onSelect` callback, but that felt like opaque reliance on PF internal behavior that may or may not change in the future.

## Bonus:

Adds a max height to prevent overly long dropdown lists.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Manual testing of the reproduction method described above.

Verify in the network tab that the UUID is sent for `scopeId`, instead of the value of the select typeahead input.

Verify that saving the report config does not result in an error.
