### PR TITLE
Telemetry: Assign API user to the Secured Cluster Registered event

### DIFF
--- a/central/cluster/datastore/datastore_impl.go
+++ b/central/cluster/datastore/datastore_impl.go
@@ -330,7 +330,7 @@ func (ds *datastoreImpl) addClusterNoLock(ctx context.Context, cluster *storage.
 		return "", err
 	}
 
-	trackClusterRegistered(cluster)
+	trackClusterRegistered(ctx, cluster)
 
 	// Temporarily elevate permissions to create network flow store for the cluster.
 	networkGraphElevatedCtx := sac.WithGlobalAccessScopeChecker(context.Background(),

--- a/central/cluster/datastore/telemetry.go
+++ b/central/cluster/datastore/telemetry.go
@@ -17,8 +17,7 @@ const securedClusterClient = "Secured Cluster"
 func trackClusterRegistered(ctx context.Context, cluster *storage.Cluster) {
 	if cfg := centralclient.InstanceConfig(); cfg.Enabled() {
 		userID := cfg.ClientID
-		id, err := authn.IdentityFromContext(ctx)
-		if err != nil {
+		if id, err := authn.IdentityFromContext(ctx); err == nil {
 			userID = cfg.HashUserAuthID(id)
 		}
 		props := map[string]any{


### PR DESCRIPTION
## Description

Make the "Secured Cluster Registered" come from the API user who requested the cluster.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

Adding a secured cluster with the local `admin` user (i.e. `sso:4df1b98c-24ed-4073-a9ad-356aec6bb62d:admin`), and central ID=`3b23fcfc-70a2-4064-9f67-20611b1457b0`:
```sh
$ print -n "3b23fcfc-70a2-4064-9f67-20611b1457b0:4df1b98c-24ed-4073-a9ad-356aec6bb62d:sso:4df1b98c-24ed-4073-a9ad-356aec6bb62d:admin" | sha256sum | xxd -r -p | base64
dn7LN2rq3t5svLVxI4j9pakjOKWoqQoapsxbqBJm6GY=
```
the following event has been tracked tracked:
```json
{
  "context": {
    "device": {
      "id": "3b23fcfc-70a2-4064-9f67-20611b1457b0",
      "type": "Central"
    },
    "library": {
      "name": "analytics-go",
      "version": "3.0.0"
    }
  },
  "event": "Secured Cluster Registered",
  "integrations": {},
  "messageId": "40ad76ec-ea3f-4ae2-856f-7055445a9335",
  "originalTimestamp": "2023-01-31T12:08:13.552038648Z",
  "properties": {
    "Cluster ID": "16a410db-85f1-43de-b480-b2664ebc6457",
    "Cluster Type": "KUBERNETES_CLUSTER",
    "Managed By": "MANAGER_TYPE_UNKNOWN"
  },
  "receivedAt": "2023-01-31T12:09:07.379Z",
  "sentAt": "2023-01-31T12:09:07.286Z",
  "timestamp": "2023-01-31T12:08:13.645Z",
  "type": "track",
  "userId": "dn7LN2rq3t5svLVxI4j9pakjOKWoqQoapsxbqBJm6GY=",
  "writeKey": "..."
}
```