### PR TITLE
ROX-14137: auth provider declarative config

### DIFF
--- a/pkg/declarativeconfig/auth_provider.go
+++ b/pkg/declarativeconfig/auth_provider.go
@@ -1,0 +1,49 @@
+package declarativeconfig
+
+type RequiredAttribute struct {
+	AttributeKey   string `yaml:"key,omitempty"`
+	AttributeValue string `yaml:"value,omitempty"`
+}
+
+type ClaimMapping struct {
+	PathToClaim    string `yaml:"pathToClaim,omitempty"`
+	MapToClaimName string `yaml:"mapTo,omitempty"`
+}
+
+type OIDCConfig struct {
+	Issuer                    string `yaml:"issuer,omitempty"`
+	CallbackMode              string `yaml:"mode,omitempty"`
+	ClientID                  string `yaml:"clientID,omitempty"`
+	ClientSecret              string `yaml:"clientSecret,omitempty"`
+	DisableOfflineAccessScope bool   `yaml:"disableOfflineAccessScope,omitempty"`
+	DontUseClientSecretConfig bool   `yaml:"dontUseClientSecretConfig,omitempty"`
+}
+
+type SAMLConfig struct {
+	// TODO: add more fields
+	// "sp_issuer"
+	// "idp_metadata_url"
+	// "idp_cert_pem"
+	// "idp_sso_url"
+	// "idp_nameid_format"
+	SPIssuer string `yaml:"spIssuer,omitempty"`
+}
+
+// AuthProvider is representation of storage.PermissionSet that supports transformation from YAML.
+type AuthProvider struct {
+	Name               string              `yaml:"name,omitempty"`
+	MinimumRoleName    string              `yaml:"minimumRole,omitempty"`
+	UIEndpoint         string              `yaml:"uiEndpoint,omitempty"`
+	ExtraUIEndpoints   []string            `yaml:"extraUIEndpoints,omitempty"`
+	Groups             []Group             `yaml:"groups,omitempty"`
+	RequiredAttributes []RequiredAttribute `yaml:"requiredAttributes,omitempty"`
+	ClaimMappings      []ClaimMapping      `yaml:"claimMappings,omitempty"`
+	OIDCConfig         *OIDCConfig         `yaml:"oidc,omitempty"`
+	SAMLConfig         *SAMLConfig         `yaml:"saml,omitempty"`
+}
+
+type Group struct {
+	AttributeKey   string `yaml:"key,omitempty"`
+	AttributeValue string `yaml:"value,omitempty"`
+	RoleName       string `yaml:"role,omitempty"`
+}

--- a/pkg/declarativeconfig/auth_provider.go
+++ b/pkg/declarativeconfig/auth_provider.go
@@ -12,23 +12,38 @@ type ClaimMapping struct {
 	Name string `yaml:"name,omitempty"`
 }
 
-// OIDCConfig contains config values for OIDC auth provider.
-type OIDCConfig struct {
-	Issuer                    string `yaml:"issuer,omitempty"`
-	CallbackMode              string `yaml:"mode,omitempty"`
-	ClientID                  string `yaml:"clientID,omitempty"`
-	ClientSecret              string `yaml:"clientSecret,omitempty"`
-	DisableOfflineAccessScope bool   `yaml:"disableOfflineAccessScope,omitempty"`
-	DontUseClientSecretConfig bool   `yaml:"dontUseClientSecretConfig,omitempty"`
+// Group is representation of storage.Group that supports transformation from YAML.
+type Group struct {
+	AttributeKey   string `yaml:"key,omitempty"`
+	AttributeValue string `yaml:"value,omitempty"`
+	RoleName       string `yaml:"role,omitempty"`
 }
 
-// SAMLConfig contains config values for SAML auth provider.
+// OIDCConfig contains config values for OIDC auth provider.
+type OIDCConfig struct {
+	Issuer string `yaml:"issuer,omitempty"`
+	// Depending on callback mode, different OAuth 2.0 would be preferred.
+	// Possible values are: auto, post, query, fragment.
+	CallbackMode string `yaml:"mode,omitempty"`
+	ClientID     string `yaml:"clientID,omitempty"`
+	ClientSecret string `yaml:"clientSecret,omitempty"`
+	// Disables request for "offline_access" scope from OIDC identity provider.
+	DisableOfflineAccessScope bool `yaml:"disableOfflineAccessScope,omitempty"`
+	// Disables request for "offline_access" scope from OIDC identity provider.
+	DontUseClientSecretConfig bool `yaml:"dontUseClientSecretConfig,omitempty"`
+}
+
+// SAMLConfig contains config values for SAML 2.0 auth provider.
+// There are two ways to configure SAML: static and dynamic.
+// For dynamic configuration, you only need to specify spIssuer and metadataURL.
+// For static configuration, specify spIssuer, certPEM, ssoURL and nameIdFormat.
 type SAMLConfig struct {
-	SpIssuer     string `yaml:"spIssuer,omitempty"`
-	MetadataURL  string `yaml:"metadataURL,omitempty"`
-	CertPEM      string `yaml:"certPEM,omitempty"`
+	SpIssuer    string `yaml:"spIssuer,omitempty"`
+	MetadataURL string `yaml:"metadataURL,omitempty"`
+	// SAML 2.0 IdP Certificate in PEM format
+	Cert         string `yaml:"cert,omitempty"`
 	SsoURL       string `yaml:"ssoURL,omitempty"`
-	NameidFormat string `yaml:"nameIdFormat,omitempty"`
+	NameIDFormat string `yaml:"nameIdFormat,omitempty"`
 }
 
 // IAPConfig contains config values for IAP auth provider.
@@ -38,7 +53,15 @@ type IAPConfig struct {
 
 // UserpkiConfig contains config values for User Certificates auth provider.
 type UserpkiConfig struct {
-	Keys string `yaml:"keys,omitempty"`
+	// Certificate authorities in PEM format
+	CertificateAuthorities string `yaml:"certificateAuthorities,omitempty"`
+}
+
+// OpenshiftConfig contains config values for Openshift auth provider.
+// The only value "enable" is a flag which can only be set to true.
+// If you don't want auth provider to be Openshift auth provider, don't specify "openshift" section.
+type OpenshiftConfig struct {
+	Enable bool `yaml:"enable,omitempty"`
 }
 
 // AuthProvider is representation of storage.AuthProvider that supports transformation from YAML.
@@ -56,12 +79,5 @@ type AuthProvider struct {
 	SAMLConfig         *SAMLConfig         `yaml:"saml,omitempty"`
 	IAPConfig          *IAPConfig          `yaml:"iap,omitempty"`
 	UserpkiConfig      *UserpkiConfig      `yaml:"userpki,omitempty"`
-	EnableOpenshift    bool                `yaml:"enableOpenshift,omitempty"`
-}
-
-// Group is representation of storage.Group that supports transformation from YAML.
-type Group struct {
-	AttributeKey   string `yaml:"key,omitempty"`
-	AttributeValue string `yaml:"value,omitempty"`
-	RoleName       string `yaml:"role,omitempty"`
+	OpenshiftConfig    *OpenshiftConfig    `yaml:"openshift,omitempty"`
 }

--- a/pkg/declarativeconfig/auth_provider.go
+++ b/pkg/declarativeconfig/auth_provider.go
@@ -1,15 +1,18 @@
 package declarativeconfig
 
+// RequiredAttribute is representation of storage.AuthProvider_RequiredAttribute that supports transformation from YAML.
 type RequiredAttribute struct {
 	AttributeKey   string `yaml:"key,omitempty"`
 	AttributeValue string `yaml:"value,omitempty"`
 }
 
+// ClaimMapping represents a single entry in "claim_mappings" field in auth provider proto.
 type ClaimMapping struct {
-	PathToClaim    string `yaml:"pathToClaim,omitempty"`
-	MapToClaimName string `yaml:"mapTo,omitempty"`
+	Path string `yaml:"path,omitempty"`
+	Name string `yaml:"name,omitempty"`
 }
 
+// OIDCConfig contains config values for OIDC auth provider.
 type OIDCConfig struct {
 	Issuer                    string `yaml:"issuer,omitempty"`
 	CallbackMode              string `yaml:"mode,omitempty"`
@@ -19,17 +22,28 @@ type OIDCConfig struct {
 	DontUseClientSecretConfig bool   `yaml:"dontUseClientSecretConfig,omitempty"`
 }
 
+// SAMLConfig contains config values for SAML auth provider.
 type SAMLConfig struct {
-	// TODO: add more fields
-	// "sp_issuer"
-	// "idp_metadata_url"
-	// "idp_cert_pem"
-	// "idp_sso_url"
-	// "idp_nameid_format"
-	SPIssuer string `yaml:"spIssuer,omitempty"`
+	SpIssuer     string `yaml:"spIssuer,omitempty"`
+	MetadataURL  string `yaml:"metadataURL,omitempty"`
+	CertPEM      string `yaml:"certPEM,omitempty"`
+	SsoURL       string `yaml:"ssoURL,omitempty"`
+	NameidFormat string `yaml:"nameIdFormat,omitempty"`
 }
 
-// AuthProvider is representation of storage.PermissionSet that supports transformation from YAML.
+// IAPConfig contains config values for IAP auth provider.
+type IAPConfig struct {
+	Audience string `yaml:"audience,omitempty"`
+}
+
+// UserpkiConfig contains config values for User Certificates auth provider.
+type UserpkiConfig struct {
+	Keys string `yaml:"keys,omitempty"`
+}
+
+// AuthProvider is representation of storage.AuthProvider that supports transformation from YAML.
+// To specify auth provider type, you need to either specify oidc, saml, iap, userpki config or
+// set enableOpenshift variable to true.
 type AuthProvider struct {
 	Name               string              `yaml:"name,omitempty"`
 	MinimumRoleName    string              `yaml:"minimumRole,omitempty"`
@@ -40,8 +54,12 @@ type AuthProvider struct {
 	ClaimMappings      []ClaimMapping      `yaml:"claimMappings,omitempty"`
 	OIDCConfig         *OIDCConfig         `yaml:"oidc,omitempty"`
 	SAMLConfig         *SAMLConfig         `yaml:"saml,omitempty"`
+	IAPConfig          *IAPConfig          `yaml:"iap,omitempty"`
+	UserpkiConfig      *UserpkiConfig      `yaml:"userpki,omitempty"`
+	EnableOpenshift    bool                `yaml:"enableOpenshift,omitempty"`
 }
 
+// Group is representation of storage.Group that supports transformation from YAML.
 type Group struct {
 	AttributeKey   string `yaml:"key,omitempty"`
 	AttributeValue string `yaml:"value,omitempty"`

--- a/pkg/declarativeconfig/auth_provider.go
+++ b/pkg/declarativeconfig/auth_provider.go
@@ -29,14 +29,12 @@ type OIDCConfig struct {
 	ClientSecret string `yaml:"clientSecret,omitempty"`
 	// Disables request for "offline_access" scope from OIDC identity provider.
 	DisableOfflineAccessScope bool `yaml:"disableOfflineAccessScope,omitempty"`
-	// Disables request for "offline_access" scope from OIDC identity provider.
-	DontUseClientSecretConfig bool `yaml:"dontUseClientSecretConfig,omitempty"`
 }
 
 // SAMLConfig contains config values for SAML 2.0 auth provider.
 // There are two ways to configure SAML: static and dynamic.
 // For dynamic configuration, you only need to specify spIssuer and metadataURL.
-// For static configuration, specify spIssuer, certPEM, ssoURL and nameIdFormat.
+// For static configuration, specify spIssuer, cert, ssoURL and nameIdFormat.
 type SAMLConfig struct {
 	SpIssuer    string `yaml:"spIssuer,omitempty"`
 	MetadataURL string `yaml:"metadataURL,omitempty"`
@@ -68,7 +66,8 @@ type OpenshiftConfig struct {
 // To specify auth provider type, you need to either specify oidc, saml, iap, userpki config or
 // set enableOpenshift variable to true.
 type AuthProvider struct {
-	Name               string              `yaml:"name,omitempty"`
+	Name string `yaml:"name,omitempty"`
+	// TODO: ROX-14148 if left empty, no default group should be created
 	MinimumRoleName    string              `yaml:"minimumRole,omitempty"`
 	UIEndpoint         string              `yaml:"uiEndpoint,omitempty"`
 	ExtraUIEndpoints   []string            `yaml:"extraUIEndpoints,omitempty"`

--- a/pkg/declarativeconfig/auth_provider_test.go
+++ b/pkg/declarativeconfig/auth_provider_test.go
@@ -1,0 +1,66 @@
+package declarativeconfig
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
+)
+
+func TestAuthProviderYAMLTransformation(t *testing.T) {
+	data := []byte(`
+name: test-name
+requiredAttributes:
+- key: "groups"
+  value: "stackrox"
+minimumRole: "None"
+uiEndpoint: "https://localhost:8000"
+extraUIEndpoints: ["https://localhost:8001"]
+groups:
+- key: "email"
+  value: "admin@stackrox.com"
+  role: "Admin"
+- key: "email"
+  value: "someone@stackrox.com"
+  role: "Analyst"
+oidc:
+  issuer: "https://stackrox.com"
+  mode: "auto select"
+  clientID: "some-client-id"
+  clientSecret: "some-client-secret"
+  disableOfflineAccessScope: true
+`)
+	ap := AuthProvider{}
+
+	err := yaml.Unmarshal(data, &ap)
+	assert.NoError(t, err)
+	assert.Equal(t, "test-name", ap.Name)
+	assert.Equal(t, "None", ap.MinimumRoleName)
+	assert.Equal(t, "https://localhost:8000", ap.UIEndpoint)
+
+	assert.Len(t, ap.ExtraUIEndpoints, 1)
+	assert.Equal(t, "https://localhost:8001", ap.ExtraUIEndpoints[0])
+
+	assert.Len(t, ap.Groups, 2)
+	assert.Equal(t, "email", ap.Groups[0].AttributeKey)
+	assert.Equal(t, "admin@stackrox.com", ap.Groups[0].AttributeValue)
+	assert.Equal(t, "Admin", ap.Groups[0].RoleName)
+
+	assert.Equal(t, "email", ap.Groups[1].AttributeKey)
+	assert.Equal(t, "someone@stackrox.com", ap.Groups[1].AttributeValue)
+	assert.Equal(t, "Analyst", ap.Groups[1].RoleName)
+
+	assert.Len(t, ap.RequiredAttributes, 1)
+	assert.Equal(t, "groups", ap.RequiredAttributes[0].AttributeKey)
+	assert.Equal(t, "stackrox", ap.RequiredAttributes[0].AttributeValue)
+
+	assert.Len(t, ap.ClaimMappings, 0)
+	assert.Nil(t, ap.SAMLConfig)
+
+	assert.NotNil(t, ap.OIDCConfig)
+	assert.Equal(t, "some-client-id", ap.OIDCConfig.ClientID)
+	assert.Equal(t, "some-client-secret", ap.OIDCConfig.ClientSecret)
+	assert.Equal(t, "auto select", ap.OIDCConfig.CallbackMode)
+	assert.Equal(t, "https://stackrox.com", ap.OIDCConfig.Issuer)
+	assert.True(t, ap.OIDCConfig.DisableOfflineAccessScope)
+}


### PR DESCRIPTION
## Description

Auth provider struct which will be used to transform from YAML declarative config to Go struct.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Unit test added
