### PR TITLE
ROX-14579: Ensure ClusterCVE SAC tests wait for indexing of injected data before test cleanup

### DIFF
--- a/central/cve/cluster/datastoretest/datastore_sac_test.go
+++ b/central/cve/cluster/datastoretest/datastore_sac_test.go
@@ -24,8 +24,7 @@ import (
 const (
 	clusterOS = ""
 
-	waitForIndexing     = true
-	dontWaitForIndexing = false
+	waitForIndexing = true
 )
 
 var (
@@ -499,8 +498,8 @@ func (s *clusterCVEDatastoreSACSuite) TestUpsertClusterCVEData() {
 	if !env.PostgresDatastoreEnabled.BooleanSetting() {
 		s.T().Skip("CVE Cluster datastore Upsert is postgres-only")
 	}
-	err := s.dackboxTestStore.PushClusterToVulnerabilitiesGraph(dontWaitForIndexing)
-	defer s.cleanImageToVulnerabilitiesGraph(dontWaitForIndexing)
+	err := s.dackboxTestStore.PushClusterToVulnerabilitiesGraph(waitForIndexing)
+	defer s.cleanImageToVulnerabilitiesGraph(waitForIndexing)
 	s.Require().NoError(err)
 	validClusters := s.dackboxTestStore.GetStoredClusterIDs()
 	s.Require().True(len(validClusters) >= 2)
@@ -572,8 +571,8 @@ func (s *clusterCVEDatastoreSACSuite) TestDeleteClusterCVEData() {
 	if !env.PostgresDatastoreEnabled.BooleanSetting() {
 		s.T().Skip("CVE Cluster datastore Delete is postgres-only")
 	}
-	err := s.dackboxTestStore.PushClusterToVulnerabilitiesGraph(dontWaitForIndexing)
-	defer s.cleanImageToVulnerabilitiesGraph(dontWaitForIndexing)
+	err := s.dackboxTestStore.PushClusterToVulnerabilitiesGraph(waitForIndexing)
+	defer s.cleanImageToVulnerabilitiesGraph(waitForIndexing)
 	s.Require().NoError(err)
 	validClusters := s.dackboxTestStore.GetStoredClusterIDs()
 	s.Require().True(len(validClusters) >= 2)
@@ -641,8 +640,8 @@ func (s *clusterCVEDatastoreSACSuite) TestDeleteClusterCVEData() {
 }
 
 func (s *clusterCVEDatastoreSACSuite) runTestExistCVE(targetCVE string) {
-	err := s.dackboxTestStore.PushClusterToVulnerabilitiesGraph(dontWaitForIndexing)
-	defer s.cleanImageToVulnerabilitiesGraph(dontWaitForIndexing)
+	err := s.dackboxTestStore.PushClusterToVulnerabilitiesGraph(waitForIndexing)
+	defer s.cleanImageToVulnerabilitiesGraph(waitForIndexing)
 	s.Require().NoError(err)
 	validClusters := s.dackboxTestStore.GetStoredClusterIDs()
 	s.Require().True(len(validClusters) >= 2)
@@ -673,8 +672,8 @@ func (s *clusterCVEDatastoreSACSuite) TestExistsSharedCVE() {
 }
 
 func (s *clusterCVEDatastoreSACSuite) runTestGetCVE(targetCVE string, cveObj *storage.EmbeddedVulnerability) {
-	err := s.dackboxTestStore.PushClusterToVulnerabilitiesGraph(dontWaitForIndexing)
-	defer s.cleanImageToVulnerabilitiesGraph(dontWaitForIndexing)
+	err := s.dackboxTestStore.PushClusterToVulnerabilitiesGraph(waitForIndexing)
+	defer s.cleanImageToVulnerabilitiesGraph(waitForIndexing)
 	s.Require().NoError(err)
 	validClusters := s.dackboxTestStore.GetStoredClusterIDs()
 	s.Require().True(len(validClusters) >= 2)
@@ -736,8 +735,8 @@ func (s *clusterCVEDatastoreSACSuite) TestGetSharedCVE() {
 }
 
 func (s *clusterCVEDatastoreSACSuite) TestGetBatch() {
-	err := s.dackboxTestStore.PushClusterToVulnerabilitiesGraph(dontWaitForIndexing)
-	defer s.cleanImageToVulnerabilitiesGraph(dontWaitForIndexing)
+	err := s.dackboxTestStore.PushClusterToVulnerabilitiesGraph(waitForIndexing)
+	defer s.cleanImageToVulnerabilitiesGraph(waitForIndexing)
 	s.Require().NoError(err)
 	validClusters := s.dackboxTestStore.GetStoredClusterIDs()
 	s.Require().True(len(validClusters) >= 2)
@@ -1090,8 +1089,8 @@ func (s *clusterCVEDatastoreSACSuite) checkCVEUnsnoozed(targetCVE string,
 }
 
 func (s *clusterCVEDatastoreSACSuite) runTestSuppressUnsuppressCVE(targetCVE string) {
-	err := s.dackboxTestStore.PushClusterToVulnerabilitiesGraph(dontWaitForIndexing)
-	defer s.cleanImageToVulnerabilitiesGraph(dontWaitForIndexing)
+	err := s.dackboxTestStore.PushClusterToVulnerabilitiesGraph(waitForIndexing)
+	defer s.cleanImageToVulnerabilitiesGraph(waitForIndexing)
 	s.Require().NoError(err)
 	validClusters := s.dackboxTestStore.GetStoredClusterIDs()
 	s.Require().True(len(validClusters) >= 2)


### PR DESCRIPTION
## Description

It seems a data race was detected in some dackbox SAC tests.
The resolution here is to alter the tests to ensure the data is indexed before its cleanup is attempted.

## Checklist
- [ ] Investigated and inspected CI test results
~~- [ ] Unit test and regression tests added~~
~~- [ ] Evaluated and added CHANGELOG entry if required~~
~~- [ ] Determined and documented upgrade steps~~
~~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

The change at hand here is a fix of the existing tests. No functional code change, so no new test.

## Testing Performed

CI is sufficient.