### PR TITLE
ROX-14568: Add download baseline as network policy button

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/api/useFetchBaselineNetworkPolicy.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/api/useFetchBaselineNetworkPolicy.ts
@@ -1,0 +1,65 @@
+import { useState } from 'react';
+
+import { fetchBaselineGeneratedNetworkPolicy } from 'services/NetworkService';
+import { NetworkPolicyModification } from 'Containers/Network/networkTypes';
+import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
+
+export type FetchBaselineNetworkPolicyParams = {
+    deploymentId: string;
+    includePorts: boolean;
+};
+
+export type Result = {
+    isLoading: boolean;
+    data: {
+        modification: NetworkPolicyModification | null;
+    };
+    error: string;
+};
+
+type FetchBaselineNetworkPolicyResult = {
+    fetchBaselineNetworkPolicy: (
+        onSuccessCallback: (modification: NetworkPolicyModification) => void
+    ) => void;
+} & Result;
+
+const defaultResultState = {
+    isLoading: false,
+    data: { modification: null },
+    error: '',
+};
+
+function useFetchBaselineNetworkPolicy({
+    deploymentId,
+    includePorts,
+}: FetchBaselineNetworkPolicyParams): FetchBaselineNetworkPolicyResult {
+    const [result, setResult] = useState<Result>(defaultResultState);
+
+    function fetchBaselineNetworkPolicy(onSuccessCallback) {
+        setResult({ data: { modification: null }, isLoading: true, error: '' });
+        fetchBaselineGeneratedNetworkPolicy({ deploymentId, includePorts })
+            .then((response) => {
+                setResult({
+                    isLoading: false,
+                    data: response,
+                    error: '',
+                });
+                onSuccessCallback(response?.modification);
+            })
+            .catch((error) => {
+                const message = getAxiosErrorMessage(error);
+                const errorMessage =
+                    message || 'An unknown error occurred while getting the list of clusters';
+
+                setResult({
+                    isLoading: false,
+                    data: { modification: null },
+                    error: errorMessage,
+                });
+            });
+    }
+
+    return { ...result, fetchBaselineNetworkPolicy };
+}
+
+export default useFetchBaselineNetworkPolicy;

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentBaselines.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentBaselines.tsx
@@ -3,6 +3,7 @@ import {
     Alert,
     AlertVariant,
     Bullseye,
+    Button,
     Checkbox,
     Divider,
     Flex,
@@ -18,6 +19,9 @@ import {
 } from '@patternfly/react-core';
 import { HelpIcon } from '@patternfly/react-icons';
 
+import download from 'utils/download';
+import { Deployment } from 'types/deployment.proto';
+import { NetworkPolicyModification } from 'Containers/Network/networkTypes';
 import { AdvancedFlowsFilterType } from '../common/AdvancedFlowsFilter/types';
 import { filterNetworkFlows, getAllUniquePorts, getNumFlows } from '../utils/flowUtils';
 
@@ -32,13 +36,14 @@ import useFetchNetworkBaselines from '../api/useFetchNetworkBaselines';
 import { Flow } from '../types/flow.type';
 import useModifyBaselineStatuses from '../api/useModifyBaselineStatuses';
 import useToggleAlertingOnBaselineViolation from '../api/useToggleAlertingOnBaselineViolation';
-import SimulateBaselinesButton from './SimulateBaselinesButton';
+import useFetchBaselineNetworkPolicy from '../api/useFetchBaselineNetworkPolicy';
 
 type DeploymentBaselinesProps = {
+    deployment: Deployment;
     deploymentId: string;
 };
 
-function DeploymentBaselines({ deploymentId }: DeploymentBaselinesProps) {
+function DeploymentBaselines({ deployment, deploymentId }: DeploymentBaselinesProps) {
     // component state
     const [isExcludingPortsAndProtocols, setIsExcludingPortsAndProtocols] =
         React.useState<boolean>(false);
@@ -63,6 +68,15 @@ function DeploymentBaselines({ deploymentId }: DeploymentBaselinesProps) {
         error: toggleError,
         toggleAlertingOnBaselineViolation,
     } = useToggleAlertingOnBaselineViolation(deploymentId);
+    const {
+        isLoading: isLoadingNetworkPolicy,
+        error: networkPolicyError,
+        fetchBaselineNetworkPolicy,
+    } = useFetchBaselineNetworkPolicy({
+        deploymentId,
+        includePorts: !isExcludingPortsAndProtocols,
+    });
+
     const filteredNetworkBaselines = filterNetworkFlows(
         networkBaselines,
         entityNameFilter,
@@ -78,6 +92,7 @@ function DeploymentBaselines({ deploymentId }: DeploymentBaselinesProps) {
     // derived data
     const numBaselines = getNumFlows(filteredNetworkBaselines);
     const allUniquePorts = getAllUniquePorts(filteredNetworkBaselines);
+    const errorMessage = networkPolicyError || fetchError || modifyError || toggleError;
 
     function addToBaseline(flow: Flow) {
         modifyBaselineStatuses([flow], 'BASELINE', refetchBaselines);
@@ -105,6 +120,19 @@ function DeploymentBaselines({ deploymentId }: DeploymentBaselinesProps) {
         toggleAlertingOnBaselineViolation(!isAlertingOnBaselineViolation, refetchBaselines);
     }
 
+    function downloadBaselineNetworkPolicy(baselineModification: NetworkPolicyModification) {
+        const currentDateString = new Date().toISOString();
+        download(
+            `${deployment.name}-network-policy-${currentDateString}.yaml`,
+            baselineModification.applyYaml,
+            'yaml'
+        );
+    }
+
+    function downloadBaselineNetworkPolicyHandler() {
+        fetchBaselineNetworkPolicy(downloadBaselineNetworkPolicy);
+    }
+
     if (isLoading || isModifying || isToggling) {
         return (
             <Bullseye>
@@ -115,11 +143,11 @@ function DeploymentBaselines({ deploymentId }: DeploymentBaselinesProps) {
 
     return (
         <div className="pf-u-h-100">
-            {(fetchError || modifyError || toggleError) && (
+            {errorMessage && (
                 <Alert
                     isInline
                     variant={AlertVariant.danger}
-                    title={fetchError || modifyError || toggleError}
+                    title={errorMessage}
                     className="pf-u-mb-sm"
                 />
             )}
@@ -217,7 +245,13 @@ function DeploymentBaselines({ deploymentId }: DeploymentBaselinesProps) {
                             />
                         </FlexItem>
                         <FlexItem>
-                            <SimulateBaselinesButton />
+                            <Button
+                                variant="primary"
+                                onClick={downloadBaselineNetworkPolicyHandler}
+                                isLoading={isLoadingNetworkPolicy}
+                            >
+                                Download baseline as network policy
+                            </Button>
                         </FlexItem>
                     </Flex>
                 </StackItem>

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentSideBar.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentSideBar.tsx
@@ -109,7 +109,7 @@ function DeploymentSideBar({ deploymentId, nodes, edges, edgeState }: Deployment
                     <DeploymentBaselinesSimulated deploymentId={deploymentId} />
                 </StackItem>
             )}
-            {!isBaselineSimulationOn && (
+            {!isBaselineSimulationOn && deployment && (
                 <>
                     <StackItem>
                         <Tabs activeKey={activeKeyTab} onSelect={onSelectTab}>
@@ -167,7 +167,10 @@ function DeploymentSideBar({ deploymentId, nodes, edges, edgeState }: Deployment
                             hidden={activeKeyTab !== 'Baselines'}
                             className="pf-u-h-100"
                         >
-                            <DeploymentBaselines deploymentId={deploymentId} />
+                            <DeploymentBaselines
+                                deployment={deployment}
+                                deploymentId={deploymentId}
+                            />
                         </TabContent>
                         <TabContent
                             eventKey="Network policies"


### PR DESCRIPTION
## Description

This PR adds the "Download baseline as network policy button" as discussed in this conversation https://srox.slack.com/archives/C02PA0VVB46/p1674764670668319

This will download the network policy YAML instead of going into the simulation mode. Since UX needs time to discuss that flow, this is our temporary solution.

https://user-images.githubusercontent.com/4805485/215165800-0a67e705-712b-485d-bd21-9fb699ebe46e.mov

## Checklist
- [ ] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~