### PR TITLE
ROX-13423: Add UI download items for roxctl for IBM P and Z

### DIFF
--- a/ui/apps/platform/src/Containers/MainPage/Header/CLIDownloadMenu.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Header/CLIDownloadMenu.tsx
@@ -51,6 +51,20 @@ function CLIDownloadMenu({ addToast, removeToast }: CLIDownloadMenuProps): React
             Linux x86_64
         </ApplicationLauncherItem>,
         <ApplicationLauncherItem
+            key="app-launcher-item-cli-linux-ppc64le"
+            component="button"
+            onClick={handleDownloadCLI('linux-ppc64le')}
+        >
+            Linux ppc64le
+        </ApplicationLauncherItem>,
+        <ApplicationLauncherItem
+            key="app-launcher-item-cli-linux-s390x"
+            component="button"
+            onClick={handleDownloadCLI('linux-s390x')}
+        >
+            Linux s390x
+        </ApplicationLauncherItem>,
+        <ApplicationLauncherItem
             key="app-launcher-item-cli-windows-amd64"
             component="button"
             onClick={handleDownloadCLI('windows-amd64')}

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step2/DownloadCLIDropdown.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step2/DownloadCLIDropdown.tsx
@@ -46,6 +46,12 @@ function DownloadCLIDropdown({ hasBuild }) {
                 <DropdownItem value="linux-amd64" component="button">
                     Linux x86_64
                 </DropdownItem>,
+                <DropdownItem value="linux-ppc64le" component="button">
+                    Linux ppc64le
+                </DropdownItem>,
+                <DropdownItem value="linux-s390x" component="button">
+                    Linux s390x
+                </DropdownItem>,
                 <DropdownItem value="windows-amd64" component="button">
                     Windows x86_64
                 </DropdownItem>,


### PR DESCRIPTION
## Description

Simply used find feature to locate where Windows x86_64 was mentioned and added similar items for other two arches.

`roxctl` binaries already exist in the image:

```bash
$ docker run --rm -it --entrypoint=/bin/bash quay.io/stackrox-io/main:3.73.x-565-gd8d7f7074b
bash-4.4$ ls assets/downloads/cli/
roxctl-darwin-amd64  roxctl-linux  roxctl-linux-amd64  roxctl-linux-ppc64le  roxctl-linux-s390x  roxctl-windows-amd64.exe
```

## Checklist
- [x] Investigated and inspected CI test results

Won't do these:
- [ ] Unit test and regression tests added - did not find existing ones, won't add them because feeling too lazy.
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

### Download from the menu
works and files are reported as having correct arch

![image](https://user-images.githubusercontent.com/537715/215995926-dbbe3005-ac64-4204-b102-c37d57377c55.png)

### Download from policies editing
also works and files have proper arch

![image](https://user-images.githubusercontent.com/537715/215996810-31778308-ee1a-4de6-84ce-c0cd6a0710ad.png)
