### PR TITLE
Disallow leading and trailing spaces in collection names

### DIFF
--- a/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
@@ -106,7 +106,6 @@ function yupLabelRuleObject({ field }: ByLabelResourceSelector) {
                         yup.object().shape({
                             value: yup
                                 .string()
-                                .trim()
                                 .required()
                                 .test(
                                     'label-value-k8s-format',
@@ -142,6 +141,7 @@ function yupNameRuleObject({ field }: ByNameResourceSelector) {
                 .array()
                 .of(
                     yup.object().shape({
+                        // TODO Add validation for k8s cluster, namespace, and deployment name characters
                         value: yup.string().trim().required(),
                         matchType: yup
                             .string()
@@ -172,7 +172,11 @@ function yupResourceSelectorObject() {
 const validationSchema = yup.object({
     name: yup
         .string()
-        .trim()
+        .test(
+            'name-is-trimmed',
+            'Leading and trailing spaces are not allowed in collection names',
+            (name) => name?.trim() === name
+        )
         .matches(
             /^[a-zA-Z0-9 .-]*$/,
             'Only letters, numbers, dot, dash, and space characters are allowed in collection names'


### PR DESCRIPTION
## Description

Adds client side validation for leading and trailing spaces in collection names, as well as in label based rules.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Test that entering a leading or trailing space in the collection name displays an inline error, and disables the form submit button.
![image](https://user-images.githubusercontent.com/1292638/215501135-99d97390-7744-4f7b-9847-1143f5a4c1ca.png)
![image](https://user-images.githubusercontent.com/1292638/215501189-1574f946-5158-487a-bc3b-b5586fe75def.png)


Test that entering a leading or trailing space in a label rule displays an invalid field, and disables the form submit button.
![image](https://user-images.githubusercontent.com/1292638/215501342-c2b45f9b-9f56-45ef-ac23-ec452afad552.png)
![image](https://user-images.githubusercontent.com/1292638/215501399-a077b266-a1e5-4008-b916-f0f2b34fe5e2.png)
