### PR TITLE
Dashrews/ROX-14614 remove code that drops central active when a rocksDB is present

### DIFF
--- a/migrator/clone/db_clone_manager_impl.go
+++ b/migrator/clone/db_clone_manager_impl.go
@@ -81,9 +81,6 @@ func (d *dbCloneManagerImpl) GetCloneToMigrate() (string, string, string, error)
 			rocksVersion = d.dbmRocks.GetVersion(rocksdb.RestoreClone)
 		} else {
 			rocksVersion = d.dbmRocks.GetVersion(rocksdb.CurrentClone)
-			if rocksVersion != nil {
-				rocksVersion.LastPersisted = d.dbmRocks.GetCurrentCloneCreationTime()
-			}
 		}
 
 		pgClone, migrateFromRocks, err = d.dbmPostgres.GetCloneToMigrate(rocksVersion, restoreFromRocks)

--- a/migrator/clone/postgres/db_clone_manager_impl.go
+++ b/migrator/clone/postgres/db_clone_manager_impl.go
@@ -158,9 +158,9 @@ func (d *dbCloneManagerImpl) GetCloneToMigrate(rocksVersion *migrations.Migratio
 	// If the current Postgres version is less than Rocks version then we need to migrate rocks to postgres
 	// If the versions are the same, but rocks has a more recent update then we need to migrate rocks to postgres
 	// Otherwise we roll with Postgres->Postgres
-	if d.rocksExists(rocksVersion) {
+	if d.versionExists(rocksVersion) {
 		log.Infof("A previously used version of Rocks exists -- %v", rocksVersion)
-		if !currExists || currClone.GetMigVersion() == nil {
+		if !currExists || !d.versionExists(currClone.GetMigVersion()) {
 			return CurrentClone, true, nil
 		}
 	}
@@ -210,10 +210,10 @@ func (d *dbCloneManagerImpl) GetCloneToMigrate(rocksVersion *migrations.Migratio
 	return CurrentClone, false, nil
 }
 
-func (d *dbCloneManagerImpl) rocksExists(rocksVersion *migrations.MigrationVersion) bool {
-	if rocksVersion != nil &&
-		rocksVersion.SeqNum != 0 &&
-		rocksVersion.MainVersion != "0" {
+func (d *dbCloneManagerImpl) versionExists(dbVersion *migrations.MigrationVersion) bool {
+	if dbVersion != nil &&
+		dbVersion.SeqNum != 0 &&
+		dbVersion.MainVersion != "0" {
 		return true
 	}
 

--- a/migrator/clone/postgres/db_clone_manager_impl_test.go
+++ b/migrator/clone/postgres/db_clone_manager_impl_test.go
@@ -232,30 +232,16 @@ func (s *PostgresCloneManagerSuite) TestGetCloneMigrateRocks() {
 		LastPersisted: time.Now(),
 	}
 
-	// Need to migrate from Rocks because Rocks is more current.
+	// Need to migrate from Postgres because it exists
 	clone, migrateRocks, err := dbm.GetCloneToMigrate(rocksVersion, false)
-	s.Equal(clone, CurrentClone)
-	s.True(migrateRocks)
-	s.Nil(err)
-
-	rocksVersion = &migrations.MigrationVersion{
-		SeqNum:        currVer.seqNum,
-		MainVersion:   currVer.version,
-		LastPersisted: time.Now().Add(-time.Hour * 24),
-	}
-
-	// Need to migrate from Rocks because Rocks is more current.
-	clone, migrateRocks, err = dbm.GetCloneToMigrate(rocksVersion, false)
 	s.Equal(clone, CurrentClone)
 	s.False(migrateRocks)
 	s.Nil(err)
 
-	// Need to migrate from Rocks because it is newer.
-	rocksVersion = &migrations.MigrationVersion{
-		SeqNum:        currVer.seqNum,
-		MainVersion:   currVer.version,
-		LastPersisted: time.Now().Add(time.Hour * 24),
-	}
+	// Need to migrate from Rocks because Rocks exists and Postgres is fresh.
+	pgtest.DropDatabase(s.T(), migrations.CurrentDatabase)
+	pgtest.CreateDatabase(s.T(), migrations.CurrentDatabase)
+
 	// Need to re-scan to get the clone deletion
 	s.Nil(dbm.Scan())
 	clone, migrateRocks, err = dbm.GetCloneToMigrate(rocksVersion, false)

--- a/migrator/clone/rocksdb/db_clone_manager.go
+++ b/migrator/clone/rocksdb/db_clone_manager.go
@@ -2,7 +2,6 @@ package rocksdb
 
 import (
 	"regexp"
-	"time"
 
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/migrations"
@@ -51,9 +50,6 @@ type DBCloneManager interface {
 
 	// GetVersion -- gets the version of the clone
 	GetVersion(cloneName string) *migrations.MigrationVersion
-
-	// GetCurrentCloneCreationTime - time current clone was created
-	GetCurrentCloneCreationTime() time.Time
 
 	// GetDirName - gets the directory name of the clone
 	GetDirName(cloneName string) string

--- a/migrator/clone/rocksdb/db_clone_manager_impl.go
+++ b/migrator/clone/rocksdb/db_clone_manager_impl.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"time"
 
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/migrator/clone/metadata"
@@ -303,19 +302,6 @@ func (d *dbCloneManagerImpl) GetVersion(cloneName string) *migrations.MigrationV
 		return clone.GetMigVersion()
 	}
 	return nil
-}
-
-// GetCurrentCloneCreationTime - time current clone was created
-func (d *dbCloneManagerImpl) GetCurrentCloneCreationTime() time.Time {
-	path := d.getPath(CurrentClone)
-	fileInfo, err := os.Lstat(path)
-	if err != nil {
-		if env.PostgresDatastoreEnabled.BooleanSetting() {
-			return time.Time{}
-		}
-		log.Panicf("Unable to find current DB path: %v", err)
-	}
-	return fileInfo.ModTime()
 }
 
 // GetDirName - gets the directory name of the clone

--- a/tests/upgrade/postgres_run.sh
+++ b/tests/upgrade/postgres_run.sh
@@ -186,11 +186,6 @@ test_upgrade_paths() {
 
     # Ensure we still have the access scopes added to Rocks
     checkForRocksAccessScopes
-    # The scopes added after the initial upgrade to Postgres should no longer exist.
-    verifyNoPostgresAccessScopes
-
-    # Add the Postgres access scopes back in
-    createPostgresScopes
 
     info "Bouncing central"
     kubectl -n stackrox delete po "$(kubectl -n stackrox get po -l app=central -o=jsonpath='{.items[0].metadata.name}')" --grace-period=0

--- a/tests/upgrade/postgres_run.sh
+++ b/tests/upgrade/postgres_run.sh
@@ -186,6 +186,11 @@ test_upgrade_paths() {
 
     # Ensure we still have the access scopes added to Rocks
     checkForRocksAccessScopes
+    # The scopes added after the initial upgrade to Postgres should no longer exist.
+    verifyNoPostgresAccessScopes
+
+    # Add the Postgres access scopes back in
+    createPostgresScopes
 
     info "Bouncing central"
     kubectl -n stackrox delete po "$(kubectl -n stackrox get po -l app=central -o=jsonpath='{.items[0].metadata.name}')" --grace-period=0


### PR DESCRIPTION
## Description

To reduce risk, this PR removes the code that uses a timestamp to determine if a version of RocksDB was used more recently than Postgres.  Once you have data in Postgres, that will be the data of choice if the Postgres flag is set.  This will keep us from blowing away Postgres data in the event something odd happened with the timestamp with RocksDB.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Unit tests were updated accordingly.  Manual steps from the test matrix were also completed.  E2E tests will come as part of the larger e2e updates per the test matrix.  Additionally since the upgrades behave differently in early versions we need to wait until this version of software becomes not the most recent so we can step wise add tests such as upgrade from Rocks to this version then on to the next version postgres to postgres upgrade.
