### PR TITLE
ROX-14600: Clear NS and Deploy dropdown when selected cluster changes

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
@@ -38,7 +38,7 @@ import {
     createExtraneousFlowsModel,
     graphModel,
 } from './utils/modelUtils';
-import getScopeHierarchy from './utils/getScopeHierarchy';
+import { getScopeHierarchyFromSearch } from './utils/hierarchyUtils';
 import getSimulation from './utils/getSimulation';
 
 import './NetworkGraphPage.css';
@@ -80,7 +80,7 @@ function NetworkGraphPage() {
         namespaces: namespacesFromUrl,
         deployments: deploymentsFromUrl,
         remainingQuery,
-    } = getScopeHierarchy(searchFilter);
+    } = getScopeHierarchyFromSearch(searchFilter);
     const simulation = getSimulation(simulationQueryValue);
 
     const hasClusterNamespaceSelected = Boolean(clusterFromUrl && namespacesFromUrl.length);

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/ClusterSelector.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/ClusterSelector.tsx
@@ -30,6 +30,8 @@ function ClusterSelector({
         if (value !== selectedClusterName) {
             const modifiedSearchObject = { ...searchFilter };
             modifiedSearchObject.Cluster = value;
+            delete modifiedSearchObject.Namespace;
+            delete modifiedSearchObject.Deployment;
             setSearchFilter(modifiedSearchObject);
         }
     };

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/NamespaceSelector.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/NamespaceSelector.tsx
@@ -5,6 +5,7 @@ import useSelectToggle from 'hooks/patternfly/useSelectToggle';
 import { Namespace } from 'hooks/useFetchClusterNamespaces';
 import { NamespaceWithDeployments } from 'hooks/useFetchNamespaceDeployments';
 import { NamespaceIcon } from '../common/NetworkGraphIcons';
+import { getDeploymentLookupMap } from '../utils/hierarchyUtils';
 
 function filterElementsWithValueProp(
     filterValue: string,
@@ -58,10 +59,7 @@ function NamespaceSelector({
         [namespaces]
     );
 
-    const deploymentLookup: Record<string, string[]> = deploymentsByNamespace.reduce((acc, ns) => {
-        const deployments = ns.deployments.map((deployment) => deployment.name);
-        return { ...acc, [ns.metadata.name]: deployments };
-    }, {});
+    const deploymentLookupMap = getDeploymentLookupMap(deploymentsByNamespace);
 
     const onNamespaceSelect = (_, selected) => {
         const newSelection = selectedNamespaces.find((nsFilter) => nsFilter === selected)
@@ -69,7 +67,7 @@ function NamespaceSelector({
             : selectedNamespaces.concat(selected);
 
         const newDeploymentLookup = Object.fromEntries(
-            Object.entries(deploymentLookup).filter(([key]) => newSelection.includes(key))
+            Object.entries(deploymentLookupMap).filter(([key]) => newSelection.includes(key))
         );
         const allowedDeployments = Object.values(newDeploymentLookup).flat(1);
 

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/NamespaceSelector.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/NamespaceSelector.tsx
@@ -5,7 +5,7 @@ import useSelectToggle from 'hooks/patternfly/useSelectToggle';
 import { Namespace } from 'hooks/useFetchClusterNamespaces';
 import { NamespaceWithDeployments } from 'hooks/useFetchNamespaceDeployments';
 import { NamespaceIcon } from '../common/NetworkGraphIcons';
-import { getDeploymentLookupMap } from '../utils/hierarchyUtils';
+import { getDeploymentLookupMap, getDeploymentsAllowedByNamespaces } from '../utils/hierarchyUtils';
 
 function filterElementsWithValueProp(
     filterValue: string,
@@ -66,10 +66,10 @@ function NamespaceSelector({
             ? selectedNamespaces.filter((nsFilter) => nsFilter !== selected)
             : selectedNamespaces.concat(selected);
 
-        const newDeploymentLookup = Object.fromEntries(
-            Object.entries(deploymentLookupMap).filter(([key]) => newSelection.includes(key))
+        const allowedDeployments = getDeploymentsAllowedByNamespaces(
+            deploymentLookupMap,
+            newSelection
         );
-        const allowedDeployments = Object.values(newDeploymentLookup).flat(1);
 
         const filteredSelectedDeployments = selectedDeployments.filter((deployment) =>
             allowedDeployments.includes(deployment)

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/hierarchyUtils.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/hierarchyUtils.ts
@@ -1,6 +1,6 @@
 import { SearchFilter } from 'types/search';
 
-export default function getScopeHierarchyFromSearch(searchFilter: SearchFilter) {
+export function getScopeHierarchyFromSearch(searchFilter: SearchFilter) {
     const workingQuery = { ...searchFilter };
     const hierarchy: {
         cluster: string | undefined;
@@ -34,3 +34,7 @@ export default function getScopeHierarchyFromSearch(searchFilter: SearchFilter) 
 
     return hierarchy;
 }
+
+export default {
+    getScopeHierarchyFromSearch,
+};

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/hierarchyUtils.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/hierarchyUtils.ts
@@ -1,4 +1,5 @@
 import { SearchFilter } from 'types/search';
+import { NamespaceWithDeployments } from 'hooks/useFetchNamespaceDeployments';
 
 export function getScopeHierarchyFromSearch(searchFilter: SearchFilter) {
     const workingQuery = { ...searchFilter };
@@ -35,6 +36,16 @@ export function getScopeHierarchyFromSearch(searchFilter: SearchFilter) {
     return hierarchy;
 }
 
+export function getDeploymentLookupMap(
+    deploymentsByNamespace: NamespaceWithDeployments[]
+): Record<string, string[]> {
+    return deploymentsByNamespace.reduce<Record<string, string[]>>((acc, ns) => {
+        const deployments = ns.deployments.map((deployment) => deployment.name);
+        return { ...acc, [ns.metadata.name]: deployments };
+    }, {});
+}
+
 export default {
     getScopeHierarchyFromSearch,
+    getDeploymentLookupMap,
 };

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/hierarchyUtils.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/hierarchyUtils.ts
@@ -45,6 +45,18 @@ export function getDeploymentLookupMap(
     }, {});
 }
 
+export function getDeploymentsAllowedByNamespaces(
+    deploymentLookupMap: Record<string, string[]>,
+    namespaceSelection: string[]
+) {
+    const newDeploymentLookup = Object.fromEntries(
+        Object.entries(deploymentLookupMap).filter(([key]) => namespaceSelection.includes(key))
+    );
+    const allowedDeployments = Object.values(newDeploymentLookup).flat(1);
+
+    return allowedDeployments;
+}
+
 export default {
     getScopeHierarchyFromSearch,
     getDeploymentLookupMap,

--- a/ui/apps/platform/src/hooks/useFetchNamespaceDeployments.ts
+++ b/ui/apps/platform/src/hooks/useFetchNamespaceDeployments.ts
@@ -50,10 +50,10 @@ function useFetchNamespaceDeployments(selectedNamespaceIds: string[]) {
 
     useEffect(() => {
         if (!data || !data.results) {
-            return;
+            setAvailableNamespaces([]);
+        } else {
+            setAvailableNamespaces(data.results);
         }
-
-        setAvailableNamespaces(data.results);
     }, [data]);
 
     return {


### PR DESCRIPTION
## Description

With query-string parameters, all things are possible.


## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

1. Select a cluster, some namespaces, and some deployments
![Screen Shot 2023-01-27 at 6 02 44 PM](https://user-images.githubusercontent.com/715729/215223734-e3274946-9055-46b9-bb47-6530e9777fab.png)


2. Change the selected cluster, and watch the namespace list update to the new cluster's NS with none selected, and the deployment list go empty (with no deployments selected)
![Screen Shot 2023-01-27 at 6 02 49 PM](https://user-images.githubusercontent.com/715729/215223724-a6c26799-1476-4956-9c32-739c8869731d.png)
