### PR TITLE
fix: network graph bug - port configuration text fix

### DIFF
--- a/ui/apps/platform/src/Components/DeploymentPortConfig.tsx
+++ b/ui/apps/platform/src/Components/DeploymentPortConfig.tsx
@@ -25,7 +25,7 @@ function DeploymentPortConfig({ port }: DeploymentPortConfigProps) {
     };
 
     const toggleText = port.name
-        ? `${port.name} - ${port.containerPort}/${port.protocol}`
+        ? `${port.name} — ${port.containerPort}/${port.protocol}`
         : `${port.containerPort}/${port.protocol}`;
 
     return (

--- a/ui/apps/platform/src/Components/DeploymentPortConfig.tsx
+++ b/ui/apps/platform/src/Components/DeploymentPortConfig.tsx
@@ -24,9 +24,13 @@ function DeploymentPortConfig({ port }: DeploymentPortConfigProps) {
         setIsExpanded(_isExpanded);
     };
 
+    const toggleText = port.name
+        ? `${port.name} - ${port.containerPort}/${port.protocol}`
+        : `${port.containerPort}/${port.protocol}`;
+
     return (
         <ExpandableSection
-            toggleText={port.name}
+            toggleText={toggleText}
             onToggle={onToggle}
             isExpanded={isExpanded}
             displaySize="large"


### PR DESCRIPTION
## Description

This PR fixes the following issue in the new network graph:


* When I click on a specific deployment, details popup on the right. I scrolled down and found Port configurations. I see two boxes I can expand, but when collapsed, they seem blank

<img width="1552" alt="Screenshot 2023-01-27 at 3 34 10 PM" src="https://user-images.githubusercontent.com/4805485/215225517-765cb6e0-dfd8-4f14-a78e-75a0677e6c3a.png">
<img width="1552" alt="Screenshot 2023-01-27 at 3 34 31 PM" src="https://user-images.githubusercontent.com/4805485/215225527-897436ce-db79-4fd2-9761-e013e601dda2.png">

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~