### PR TITLE
Fix inconsistent data state after using embedded collection filter

### DIFF
--- a/ui/apps/platform/cypress/integration/collections/deploymentMatching.test.js
+++ b/ui/apps/platform/cypress/integration/collections/deploymentMatching.test.js
@@ -4,6 +4,7 @@ import {
     assertDeploymentsAreMatched,
     assertDeploymentsAreMatchedExactly,
     assertDeploymentsAreNotMatched,
+    tryCreateCollection,
     tryDeleteCollection,
     visitCollections,
 } from './Collections.helpers';
@@ -141,10 +142,6 @@ describe('Collection deployment matching', () => {
         cy.get('button:contains("Save")').click();
 
         cy.get(`td[data-label="Collection"] a:contains("${withEmbeddedCollectionName}")`);
-    });
-
-    it('should correctly handle embedded collections with filters applied', () => {
-        // TODO - Ensure filtering the embedded collections list doesn't bork the data
     });
 
     it('should filter deployment results in the sidebar', () => {

--- a/ui/apps/platform/cypress/integration/collections/deploymentMatching.test.js
+++ b/ui/apps/platform/cypress/integration/collections/deploymentMatching.test.js
@@ -143,6 +143,10 @@ describe('Collection deployment matching', () => {
         cy.get(`td[data-label="Collection"] a:contains("${withEmbeddedCollectionName}")`);
     });
 
+    it('should correctly handle embedded collections with filters applied', () => {
+        // TODO - Ensure filtering the embedded collections list doesn't bork the data
+    });
+
     it('should filter deployment results in the sidebar', () => {
         visitCollections();
         cy.get(`td[data-label="Collection"] a:contains("${withEmbeddedCollectionName}")`).click();

--- a/ui/apps/platform/cypress/integration/collections/deploymentMatching.test.js
+++ b/ui/apps/platform/cypress/integration/collections/deploymentMatching.test.js
@@ -4,7 +4,6 @@ import {
     assertDeploymentsAreMatched,
     assertDeploymentsAreMatchedExactly,
     assertDeploymentsAreNotMatched,
-    tryCreateCollection,
     tryDeleteCollection,
     visitCollections,
 } from './Collections.helpers';

--- a/ui/apps/platform/src/Components/PatternFly/BacklogListSelector.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/BacklogListSelector.tsx
@@ -24,6 +24,7 @@ type BacklogTableProps<Item> = {
         width?: BaseCellProps['width'];
     }[];
     buttonText: string;
+    searchFilter?: (item: Item) => boolean;
     showBadge: boolean;
 };
 
@@ -35,6 +36,7 @@ function BacklogTable<Item>({
     rowKey,
     cells,
     buttonText,
+    searchFilter = () => true,
     showBadge,
 }: BacklogTableProps<Item>) {
     const actionIcon =
@@ -43,6 +45,9 @@ function BacklogTable<Item>({
         ) : (
             <PlusCircleIcon color="var(--pf-global--primary-color--100)" />
         );
+
+    const itemsToDisplay = items.filter(searchFilter);
+
     return (
         <FormGroup
             label={
@@ -56,10 +61,10 @@ function BacklogTable<Item>({
                 </>
             }
         >
-            {items.length > 0 ? (
+            {itemsToDisplay.length > 0 ? (
                 <TableComposable aria-label={label}>
                     <Tbody>
-                        {items.map((item) => (
+                        {itemsToDisplay.map((item) => (
                             <Tr key={rowKey(item)}>
                                 {cells.map(({ name, width, render }) => (
                                     <Td key={name} dataLabel={name} width={width}>
@@ -107,6 +112,7 @@ export type BacklogListSelectorProps<Item> = {
     deselectedLabel?: string;
     selectButtonText?: string;
     deselectButtonText?: string;
+    searchFilter?: (item: Item) => boolean;
     showBadge?: boolean;
 };
 
@@ -122,6 +128,7 @@ function BacklogListSelector<Item>({
     deselectedLabel = 'Deselected items',
     selectButtonText = 'Add',
     deselectButtonText = 'Remove',
+    searchFilter,
     showBadge = false,
 }: BacklogListSelectorProps<Item>) {
     function onSelect(item: Item) {
@@ -150,6 +157,7 @@ function BacklogListSelector<Item>({
                 buttonText={deselectButtonText}
                 rowKey={rowKey}
                 cells={cells}
+                searchFilter={searchFilter}
                 showBadge={showBadge}
             />
             <BacklogTable
@@ -160,6 +168,7 @@ function BacklogListSelector<Item>({
                 rowKey={rowKey}
                 buttonText={selectButtonText}
                 cells={cells}
+                searchFilter={searchFilter}
                 showBadge={showBadge}
             />
         </Flex>

--- a/ui/apps/platform/src/Containers/Collections/hooks/useEmbeddedCollections.ts
+++ b/ui/apps/platform/src/Containers/Collections/hooks/useEmbeddedCollections.ts
@@ -188,14 +188,6 @@ function embeddedCollectionsReducer(
             return ensureExhaustive(payload);
     }
 }
-
-// We need to use `startsWith` instead of `includes` here, since search values sent to the API use
-// a prefix match. If we filter by substring, collections matching the substring will appear in
-// the "attached" list, but not in the "available" list, since the former are cached client side.
-function compareNameLowercase(search: string): (item: { name: string }) => boolean {
-    return ({ name }) => name.toLowerCase().startsWith(search.toLowerCase());
-}
-
 function byNameCaseInsensitive(collection: Collection) {
     return collection.name.toLowerCase();
 }
@@ -302,12 +294,8 @@ export default function useEmbeddedCollections(
     };
 
     return {
-        attached: sortBy(Object.values(attached), byNameCaseInsensitive).filter(
-            compareNameLowercase(search)
-        ),
-        detached: sortBy(Object.values(detached), byNameCaseInsensitive).filter(
-            compareNameLowercase(search)
-        ),
+        attached: sortBy(Object.values(attached), byNameCaseInsensitive),
+        detached: sortBy(Object.values(detached), byNameCaseInsensitive),
         attach: (id: string) => dispatch({ type: 'attachCollection', id }),
         detach: (id: string) => dispatch({ type: 'detachCollection', id }),
         hasMore,


### PR DESCRIPTION
## Description

A logic error in when the embedded collection data was filtered was leading to cases where the client side form state would be invalid.

If the user took the following steps:
1. Attached a collection
2. Filtered the available collection list in a way that the first collection was not visible
3. Attached a second collection, and cleared the search filter

This would result in both of the collections being displayed in the "attached" section of the UI, but the underlying form data would only contain the second collection, which impacted dry-run requests as well as saving the collection.

The fix was to move the search filtering from the `useEmbeddedCollections` hook that fetches the data to the component that displayed the data via a filtering callback.

## Follow ups

- Cover this case in e2e tests


## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Attach a collection and view the updated results in the side panel.
![image](https://user-images.githubusercontent.com/1292638/215499502-94412eee-5c12-4c78-9263-c4ebe1c8c797.png)

Filter the collection lists so that the attach collection is not visible.
![image](https://user-images.githubusercontent.com/1292638/215499574-4a383f71-7df7-40e8-8b58-b1732be17dc2.png)


Attach a second collection and view the updated results in the side panel and ensure that deployments from both embedded collections are displayed.
![image](https://user-images.githubusercontent.com/1292638/215499626-d67312d4-0534-443d-ace5-d260391597d1.png)


Save the collection, and revisit the collection page to ensure both embedded collections are saved correctly.
![image](https://user-images.githubusercontent.com/1292638/215499685-6ca062b6-d4c7-40dd-892d-7fbe69ecadbd.png)
