### PR TITLE
Refactoring: shared Telemeter interface package

### DIFF
--- a/central/cluster/datastore/telemetry.go
+++ b/central/cluster/datastore/telemetry.go
@@ -26,7 +26,7 @@ func trackClusterRegistered(ctx context.Context, cluster *storage.Cluster) {
 			"Cluster ID":   cluster.GetId(),
 			"Managed By":   cluster.GetManagedBy().String(),
 		}
-		cfg.Telemeter().TrackUserAs(userID, "", "", "Secured Cluster Registered", props)
+		cfg.Telemeter().Track("Secured Cluster Registered", props, telemeter.WithUserID(userID))
 
 		// Add the secured cluster 'user' to the Tenant group:
 		cfg.Telemeter().Group(cfg.GroupID, nil, telemeter.WithUserID(cluster.GetId()))

--- a/central/cluster/datastore/telemetry.go
+++ b/central/cluster/datastore/telemetry.go
@@ -27,7 +27,7 @@ func trackClusterRegistered(ctx context.Context, cluster *storage.Cluster) {
 		}
 		cfg.Telemeter().TrackUserAs(userID, "", "", "Secured Cluster Registered", props)
 
-		clusterUser := cfg.Telemeter().With(cluster.GetId())
+		clusterUser := cfg.Telemeter().User(cluster.GetId())
 
 		// Add the secured cluster 'user' to the Tenant group:
 		clusterUser.Group(cfg.GroupID, nil)
@@ -53,7 +53,7 @@ func makeClusterProperties(cluster *storage.Cluster) map[string]any {
 func trackClusterInitialized(cluster *storage.Cluster) {
 	if cfg := centralclient.InstanceConfig(); cfg.Enabled() {
 		// Issue an event that makes the secured cluster identity effective:
-		cfg.Telemeter().With(cluster.GetId()).As(cluster.GetId(), securedClusterClient).
+		cfg.Telemeter().User(cluster.GetId()).As(cluster.GetId(), securedClusterClient).
 			Track("Secured Cluster Initialized", map[string]any{
 				"Health": cluster.GetHealthStatus().GetOverallHealthStatus().String(),
 			})
@@ -90,7 +90,7 @@ func UpdateSecuredClusterIdentity(ctx context.Context, clusterID string, metrics
 		props := makeClusterProperties(cluster)
 		props["Total Nodes"] = metrics.NodeCount
 		props["CPU Capacity"] = metrics.CpuCapacity
-		t := cfg.Telemeter().With(cluster.GetId()).As(cluster.GetId(), securedClusterClient)
+		t := cfg.Telemeter().User(cluster.GetId()).As(cluster.GetId(), securedClusterClient)
 		t.Identify(props)
 		t.Track("Updated Secured Cluster Identity", nil)
 	}

--- a/central/role/mapper/telemetry.go
+++ b/central/role/mapper/telemetry.go
@@ -3,12 +3,13 @@ package mapper
 import (
 	"github.com/stackrox/rox/central/telemetry/centralclient"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/telemetry/phonehome/telemeter"
 )
 
 // addUserToTenantGroup adds the given user to the central tenant group so that
 // such users could be segmented by tenant properties.
 func addUserToTenantGroup(user *storage.User) {
 	if cfg := centralclient.InstanceConfig(); cfg.Enabled() {
-		cfg.Telemeter().User(cfg.HashUserID(user.GetId(), user.GetAuthProviderId())).Group(cfg.GroupID, nil)
+		cfg.Telemeter().Group(cfg.GroupID, nil, telemeter.WithUserID(cfg.HashUserID(user.GetId(), user.GetAuthProviderId())))
 	}
 }

--- a/central/role/mapper/telemetry.go
+++ b/central/role/mapper/telemetry.go
@@ -9,6 +9,6 @@ import (
 // such users could be segmented by tenant properties.
 func addUserToTenantGroup(user *storage.User) {
 	if cfg := centralclient.InstanceConfig(); cfg.Enabled() {
-		cfg.Telemeter().With(cfg.HashUserID(user.GetId(), user.GetAuthProviderId())).Group(cfg.GroupID, nil)
+		cfg.Telemeter().User(cfg.HashUserID(user.GetId(), user.GetAuthProviderId())).Group(cfg.GroupID, nil)
 	}
 }

--- a/central/role/mapper/telemetry.go
+++ b/central/role/mapper/telemetry.go
@@ -9,6 +9,6 @@ import (
 // such users could be segmented by tenant properties.
 func addUserToTenantGroup(user *storage.User) {
 	if cfg := centralclient.InstanceConfig(); cfg.Enabled() {
-		cfg.Telemeter().GroupUserAs(cfg.HashUserID(user.GetId(), user.GetAuthProviderId()), "", "", cfg.GroupID, nil)
+		cfg.Telemeter().With(cfg.HashUserID(user.GetId(), user.GetAuthProviderId())).Group(cfg.GroupID, nil)
 	}
 }

--- a/central/telemetry/centralclient/instance_config.go
+++ b/central/telemetry/centralclient/instance_config.go
@@ -129,7 +129,7 @@ func RegisterCentralClient(config grpc.Config, basicAuthProviderID string) {
 	}
 	registerInterceptors(config)
 	// Central adds itself to the tenant group, with no group properties:
-	cfg.Telemeter().GroupUserAs(cfg.ClientID, "", "", cfg.GroupID, nil)
+	cfg.Telemeter().With(cfg.ClientID).Group(cfg.GroupID, nil)
 	registerAdminUser(basicAuthProviderID)
 }
 
@@ -147,12 +147,12 @@ func registerAdminUser(basicAuthProviderID string) {
 
 	// Add the basic authorization ID form ('admin'):
 	adminHash := cfg.HashUserID(basic.DefaultUsername, basicAuthProviderID)
-	cfg.Telemeter().GroupUserAs(adminHash, "", "", cfg.GroupID, nil)
+	cfg.Telemeter().With(adminHash).Group(cfg.GroupID, nil)
 
 	// Add the token based ID form ('sso:<provider id>:admin'):
 	adminTokenHash := cfg.HashUserID(
 		tokenbased.FormatUserID(basic.DefaultUsername, basicAuthProviderID),
 		basicAuthProviderID,
 	)
-	cfg.Telemeter().GroupUserAs(adminTokenHash, "", "", cfg.GroupID, nil)
+	cfg.Telemeter().With(adminTokenHash).Group(cfg.GroupID, nil)
 }

--- a/central/telemetry/centralclient/instance_config.go
+++ b/central/telemetry/centralclient/instance_config.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/pkg/telemetry/phonehome"
+	"github.com/stackrox/rox/pkg/telemetry/phonehome/telemeter"
 	"github.com/stackrox/rox/pkg/version"
 	k8sVersion "k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/kubernetes"
@@ -129,7 +130,7 @@ func RegisterCentralClient(config grpc.Config, basicAuthProviderID string) {
 	}
 	registerInterceptors(config)
 	// Central adds itself to the tenant group, with no group properties:
-	cfg.Telemeter().User(cfg.ClientID).Group(cfg.GroupID, nil)
+	cfg.Telemeter().Group(cfg.GroupID, nil, telemeter.WithUserID(cfg.ClientID))
 	registerAdminUser(basicAuthProviderID)
 }
 
@@ -147,12 +148,12 @@ func registerAdminUser(basicAuthProviderID string) {
 
 	// Add the basic authorization ID form ('admin'):
 	adminHash := cfg.HashUserID(basic.DefaultUsername, basicAuthProviderID)
-	cfg.Telemeter().User(adminHash).Group(cfg.GroupID, nil)
+	cfg.Telemeter().Group(cfg.GroupID, nil, telemeter.WithUserID(adminHash))
 
 	// Add the token based ID form ('sso:<provider id>:admin'):
 	adminTokenHash := cfg.HashUserID(
 		tokenbased.FormatUserID(basic.DefaultUsername, basicAuthProviderID),
 		basicAuthProviderID,
 	)
-	cfg.Telemeter().User(adminTokenHash).Group(cfg.GroupID, nil)
+	cfg.Telemeter().Group(cfg.GroupID, nil, telemeter.WithUserID(adminTokenHash))
 }

--- a/central/telemetry/centralclient/instance_config.go
+++ b/central/telemetry/centralclient/instance_config.go
@@ -129,7 +129,7 @@ func RegisterCentralClient(config grpc.Config, basicAuthProviderID string) {
 	}
 	registerInterceptors(config)
 	// Central adds itself to the tenant group, with no group properties:
-	cfg.Telemeter().With(cfg.ClientID).Group(cfg.GroupID, nil)
+	cfg.Telemeter().User(cfg.ClientID).Group(cfg.GroupID, nil)
 	registerAdminUser(basicAuthProviderID)
 }
 
@@ -147,12 +147,12 @@ func registerAdminUser(basicAuthProviderID string) {
 
 	// Add the basic authorization ID form ('admin'):
 	adminHash := cfg.HashUserID(basic.DefaultUsername, basicAuthProviderID)
-	cfg.Telemeter().With(adminHash).Group(cfg.GroupID, nil)
+	cfg.Telemeter().User(adminHash).Group(cfg.GroupID, nil)
 
 	// Add the token based ID form ('sso:<provider id>:admin'):
 	adminTokenHash := cfg.HashUserID(
 		tokenbased.FormatUserID(basic.DefaultUsername, basicAuthProviderID),
 		basicAuthProviderID,
 	)
-	cfg.Telemeter().With(adminTokenHash).Group(cfg.GroupID, nil)
+	cfg.Telemeter().User(adminTokenHash).Group(cfg.GroupID, nil)
 }

--- a/pkg/telemetry/phonehome/client_config.go
+++ b/pkg/telemetry/phonehome/client_config.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/pkg/telemetry/phonehome/segment"
+	"github.com/stackrox/rox/pkg/telemetry/phonehome/telemeter"
 	"google.golang.org/grpc"
 )
 
@@ -42,7 +43,7 @@ type Config struct {
 	// The period of identity gathering. Default is 1 hour.
 	GatherPeriod time.Duration
 
-	telemeter Telemeter
+	telemeter telemeter.Telemeter
 	gatherer  Gatherer
 
 	onceTelemeter sync.Once
@@ -79,7 +80,7 @@ func (cfg *Config) Gatherer() Gatherer {
 }
 
 // Telemeter returns the instance of the telemeter.
-func (cfg *Config) Telemeter() Telemeter {
+func (cfg *Config) Telemeter() telemeter.Telemeter {
 	if cfg == nil {
 		return &nilTelemeter{}
 	}

--- a/pkg/telemetry/phonehome/gatherer.go
+++ b/pkg/telemetry/phonehome/gatherer.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/sync"
+	"github.com/stackrox/rox/pkg/telemetry/phonehome/telemeter"
 )
 
 // GatherFunc returns properties gathered by a data source.
@@ -28,7 +29,7 @@ func (*nilGatherer) AddGatherer(GatherFunc) {}
 
 type gatherer struct {
 	clientType  string
-	telemeter   Telemeter
+	telemeter   telemeter.Telemeter
 	period      time.Duration
 	stopSig     concurrency.Signal
 	ctx         context.Context
@@ -38,7 +39,7 @@ type gatherer struct {
 	lastData    map[string]any
 }
 
-func newGatherer(clientType string, t Telemeter, p time.Duration) *gatherer {
+func newGatherer(clientType string, t telemeter.Telemeter, p time.Duration) *gatherer {
 	return &gatherer{
 		clientType: clientType,
 		telemeter:  t,

--- a/pkg/telemetry/phonehome/gatherer_test.go
+++ b/pkg/telemetry/phonehome/gatherer_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
-	"github.com/stackrox/rox/pkg/telemetry/phonehome/mocks"
+	"github.com/stackrox/rox/pkg/telemetry/phonehome/telemeter/mocks"
 	"github.com/stretchr/testify/suite"
 )
 

--- a/pkg/telemetry/phonehome/gatherer_test.go
+++ b/pkg/telemetry/phonehome/gatherer_test.go
@@ -2,7 +2,6 @@ package phonehome
 
 import (
 	"context"
-	"fmt"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -28,38 +27,12 @@ func (s *gathererTestSuite) TestNilGatherer() {
 	nilgatherer.Stop()  // noop
 }
 
-type mapMatcher struct {
-	expected map[string]any
-}
-
-var _ gomock.Matcher = (*mapMatcher)(nil)
-
-func (m *mapMatcher) String() string {
-	return fmt.Sprint(m.expected)
-}
-
-func (m *mapMatcher) Matches(x any) bool {
-	givenMap, ok := x.(map[string]any)
-	if !ok {
-		return false
-	}
-	for key, want := range m.expected {
-		found, ok := givenMap[key]
-		if !ok || !gomock.Eq(want).Matches(found) {
-			return false
-		}
-	}
-	return true
-}
-
 func (s *gathererTestSuite) TestGatherer() {
 	t := mocks.NewMockTelemeter(gomock.NewController(s.T()))
 
 	// Identify and Track should be called once as there's no change in the
 	// identity:
-	t.EXPECT().Identify(&mapMatcher{map[string]any{
-		"key": "value",
-	}}).Times(1)
+	t.EXPECT().Identify(gomock.Eq(map[string]any{"key": "value"})).Times(1)
 
 	t.EXPECT().Track("Updated Test Identity", nil).Times(1)
 

--- a/pkg/telemetry/phonehome/interceptor.go
+++ b/pkg/telemetry/phonehome/interceptor.go
@@ -27,7 +27,7 @@ func (cfg *Config) track(rp *RequestParams) {
 			}
 		}
 		if ok {
-			cfg.telemeter.TrackUserAs(id, "", "", event, props)
+			cfg.telemeter.With(id).Track(event, props)
 		}
 	}
 }

--- a/pkg/telemetry/phonehome/interceptor.go
+++ b/pkg/telemetry/phonehome/interceptor.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/pkg/grpc/authn"
 	grpcError "github.com/stackrox/rox/pkg/grpc/errors"
 	"github.com/stackrox/rox/pkg/grpc/requestinfo"
+	"github.com/stackrox/rox/pkg/telemetry/phonehome/telemeter"
 )
 
 const grpcGatewayUserAgentHeader = runtime.MetadataPrefix + "User-Agent"
@@ -27,7 +28,7 @@ func (cfg *Config) track(rp *RequestParams) {
 			}
 		}
 		if ok {
-			cfg.telemeter.User(id).Track(event, props)
+			cfg.telemeter.Track(event, props, telemeter.WithUserID(id))
 		}
 	}
 }

--- a/pkg/telemetry/phonehome/interceptor.go
+++ b/pkg/telemetry/phonehome/interceptor.go
@@ -27,7 +27,7 @@ func (cfg *Config) track(rp *RequestParams) {
 			}
 		}
 		if ok {
-			cfg.telemeter.With(id).Track(event, props)
+			cfg.telemeter.User(id).Track(event, props)
 		}
 	}
 }

--- a/pkg/telemetry/phonehome/interceptor_test.go
+++ b/pkg/telemetry/phonehome/interceptor_test.go
@@ -45,10 +45,9 @@ type optionsMatcher struct {
 	opts *telemeter.CallOptions
 }
 
-func (m *optionsMatcher) Matches(x interface{}) bool {
+func (m *optionsMatcher) Matches(x any) bool {
 	if o, ok := x.([]telemeter.Option); ok {
-		opts := telemeter.ApplyOptions(o)
-		return opts == m.opts || *opts == *m.opts
+		return gomock.Eq(m.opts).Matches(telemeter.ApplyOptions(o))
 	}
 	return false
 }

--- a/pkg/telemetry/phonehome/interceptor_test.go
+++ b/pkg/telemetry/phonehome/interceptor_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stackrox/rox/pkg/grpc/authn"
 	idmocks "github.com/stackrox/rox/pkg/grpc/authn/mocks"
 	"github.com/stackrox/rox/pkg/grpc/requestinfo"
-	"github.com/stackrox/rox/pkg/telemetry/phonehome/mocks"
+	"github.com/stackrox/rox/pkg/telemetry/phonehome/telemeter/mocks"
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/peer"
@@ -63,7 +63,8 @@ func (s *interceptorTestSuite) TestAddGrpcInterceptor() {
 		return true
 	})
 
-	s.mockTelemeter.EXPECT().TrackUserAs(cfg.HashUserAuthID(nil), "", "", "TestEvent", map[string]any{
+	s.mockTelemeter.EXPECT().With(cfg.HashUserAuthID(nil)).Times(1).Return(s.mockTelemeter)
+	s.mockTelemeter.EXPECT().Track("TestEvent", map[string]any{
 		"Property": "test value",
 	}).Times(1)
 
@@ -95,7 +96,8 @@ func (s *interceptorTestSuite) TestAddHttpInterceptor() {
 
 	mockID.EXPECT().ExternalAuthProvider().Return(nil).Times(2)
 	mockID.EXPECT().UID().Return("id").Times(2)
-	s.mockTelemeter.EXPECT().TrackUserAs(cfg.HashUserAuthID(mockID), "", "", "TestEvent", map[string]any{
+	s.mockTelemeter.EXPECT().With(cfg.HashUserAuthID(mockID)).Return(s.mockTelemeter)
+	s.mockTelemeter.EXPECT().Track("TestEvent", map[string]any{
 		"Property": "test_value",
 	}).Times(1)
 

--- a/pkg/telemetry/phonehome/interceptor_test.go
+++ b/pkg/telemetry/phonehome/interceptor_test.go
@@ -3,6 +3,7 @@ package phonehome
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"net"
 	"net/http"
 	"testing"
@@ -11,6 +12,7 @@ import (
 	"github.com/stackrox/rox/pkg/grpc/authn"
 	idmocks "github.com/stackrox/rox/pkg/grpc/authn/mocks"
 	"github.com/stackrox/rox/pkg/grpc/requestinfo"
+	"github.com/stackrox/rox/pkg/telemetry/phonehome/telemeter"
 	"github.com/stackrox/rox/pkg/telemetry/phonehome/telemeter/mocks"
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/grpc/metadata"
@@ -39,6 +41,26 @@ type testRequest struct {
 	value string
 }
 
+type optionsMatcher struct {
+	opts *telemeter.CallOptions
+}
+
+func (m *optionsMatcher) Matches(x interface{}) bool {
+	if o, ok := x.([]telemeter.Option); ok {
+		opts := telemeter.ApplyOptions(o)
+		return opts == m.opts || *opts == *m.opts
+	}
+	return false
+}
+
+func (m *optionsMatcher) String() string {
+	return fmt.Sprint(m.opts)
+}
+
+func matchOptions(opts ...telemeter.Option) gomock.Matcher {
+	return &optionsMatcher{telemeter.ApplyOptions(opts)}
+}
+
 func (s *interceptorTestSuite) TestAddGrpcInterceptor() {
 	testRP := &RequestParams{
 		Path:      "/v1.Abc",
@@ -63,10 +85,9 @@ func (s *interceptorTestSuite) TestAddGrpcInterceptor() {
 		return true
 	})
 
-	s.mockTelemeter.EXPECT().User(cfg.HashUserAuthID(nil)).Times(1).Return(s.mockTelemeter)
 	s.mockTelemeter.EXPECT().Track("TestEvent", map[string]any{
 		"Property": "test value",
-	}).Times(1)
+	}, matchOptions(telemeter.WithUserID(cfg.HashUserAuthID(nil)))).Times(1)
 
 	cfg.track(testRP)
 }
@@ -96,10 +117,9 @@ func (s *interceptorTestSuite) TestAddHttpInterceptor() {
 
 	mockID.EXPECT().ExternalAuthProvider().Return(nil).Times(2)
 	mockID.EXPECT().UID().Return("id").Times(2)
-	s.mockTelemeter.EXPECT().User(cfg.HashUserAuthID(mockID)).Return(s.mockTelemeter)
 	s.mockTelemeter.EXPECT().Track("TestEvent", map[string]any{
 		"Property": "test_value",
-	}).Times(1)
+	}, matchOptions(telemeter.WithUserID(cfg.HashUserAuthID(mockID)))).Times(1)
 
 	cfg.track(testRP)
 }

--- a/pkg/telemetry/phonehome/interceptor_test.go
+++ b/pkg/telemetry/phonehome/interceptor_test.go
@@ -63,7 +63,7 @@ func (s *interceptorTestSuite) TestAddGrpcInterceptor() {
 		return true
 	})
 
-	s.mockTelemeter.EXPECT().With(cfg.HashUserAuthID(nil)).Times(1).Return(s.mockTelemeter)
+	s.mockTelemeter.EXPECT().User(cfg.HashUserAuthID(nil)).Times(1).Return(s.mockTelemeter)
 	s.mockTelemeter.EXPECT().Track("TestEvent", map[string]any{
 		"Property": "test value",
 	}).Times(1)
@@ -96,7 +96,7 @@ func (s *interceptorTestSuite) TestAddHttpInterceptor() {
 
 	mockID.EXPECT().ExternalAuthProvider().Return(nil).Times(2)
 	mockID.EXPECT().UID().Return("id").Times(2)
-	s.mockTelemeter.EXPECT().With(cfg.HashUserAuthID(mockID)).Return(s.mockTelemeter)
+	s.mockTelemeter.EXPECT().User(cfg.HashUserAuthID(mockID)).Return(s.mockTelemeter)
 	s.mockTelemeter.EXPECT().Track("TestEvent", map[string]any{
 		"Property": "test_value",
 	}).Times(1)

--- a/pkg/telemetry/phonehome/segment/segment.go
+++ b/pkg/telemetry/phonehome/segment/segment.go
@@ -91,13 +91,6 @@ func (t *segmentTelemeter) Stop() {
 	}
 }
 
-func (t *segmentTelemeter) overwriteID(id string) string {
-	if id == "" {
-		return t.userID
-	}
-	return id
-}
-
 func makeDeviceContext(clientID, clientType string) *segment.Context {
 	if clientID == "" {
 		return nil
@@ -110,7 +103,7 @@ func makeDeviceContext(clientID, clientType string) *segment.Context {
 	}
 }
 
-func (t *segmentTelemeter) With(userID string) telemeter.Telemeter {
+func (t *segmentTelemeter) User(userID string) telemeter.Telemeter {
 	return &segmentTelemeter{client: t.client, userID: userID, ctx: t.ctx}
 }
 

--- a/pkg/telemetry/phonehome/segment/segment.go
+++ b/pkg/telemetry/phonehome/segment/segment.go
@@ -15,9 +15,8 @@ var (
 )
 
 type segmentTelemeter struct {
-	client segment.Client
-	userID string
-	ctx    *segment.Context
+	client   segment.Client
+	clientID string
 }
 
 func getMessageType(msg segment.Message) string {
@@ -68,7 +67,7 @@ func NewTelemeter(key, endpoint, clientID, clientType string, interval time.Dura
 		return nil
 	}
 
-	return &segmentTelemeter{client: client, userID: clientID}
+	return &segmentTelemeter{client: client, clientID: clientID}
 }
 
 type logWrapper struct {
@@ -95,7 +94,7 @@ func (t *segmentTelemeter) overrideUserID(o *telemeter.CallOptions) string {
 	if o.UserID != "" {
 		return o.UserID
 	}
-	return t.userID
+	return t.clientID
 }
 
 func makeDeviceContext(o *telemeter.CallOptions) *segment.Context {

--- a/pkg/telemetry/phonehome/telemeter.go
+++ b/pkg/telemetry/phonehome/telemeter.go
@@ -8,10 +8,7 @@ type nilTelemeter struct{}
 
 var _ telemeter.Telemeter = (*nilTelemeter)(nil)
 
-func (t *nilTelemeter) Stop()                            {}
-func (t *nilTelemeter) Identify(_ map[string]any)        {}
-func (t *nilTelemeter) Track(_ string, _ map[string]any) {}
-func (t *nilTelemeter) Group(_ string, _ map[string]any) {}
-
-func (t *nilTelemeter) User(userID string) telemeter.Telemeter                    { return nil }
-func (t *nilTelemeter) As(clientID string, clientType string) telemeter.Telemeter { return nil }
+func (t *nilTelemeter) Stop()                                                   {}
+func (t *nilTelemeter) Identify(_ map[string]any, _ ...telemeter.Option)        {}
+func (t *nilTelemeter) Track(_ string, _ map[string]any, _ ...telemeter.Option) {}
+func (t *nilTelemeter) Group(_ string, _ map[string]any, _ ...telemeter.Option) {}

--- a/pkg/telemetry/phonehome/telemeter.go
+++ b/pkg/telemetry/phonehome/telemeter.go
@@ -1,34 +1,17 @@
 package phonehome
 
-// Telemeter defines a common interface for telemetry gatherers.
-//
-//go:generate mockgen-wrapper
-type Telemeter interface {
-	// Stop gracefully shutdowns the implementation, potentially flushing
-	// the buffers.
-	Stop()
-	// Identify updates the user traits.
-	Identify(props map[string]any)
-	// Track registers an event, caused by the user.
-	Track(event string, props map[string]any)
-	// Group adds the user to a group, supplying group specific properties.
-	Group(groupID string, props map[string]any)
-
-	// IdentifyUserAs updates the user traits.
-	IdentifyUserAs(userID, clientID, clientType string, props map[string]any)
-	// TrackUserAs registers an event, caused by the user.
-	TrackUserAs(userID, clientID, clientType, event string, props map[string]any)
-	// GroupUserAs adds the user to a group, supplying group specific properties.
-	GroupUserAs(userID, clientID, clientType, groupID string, props map[string]any)
-}
+import (
+	"github.com/stackrox/rox/pkg/telemetry/phonehome/telemeter"
+)
 
 type nilTelemeter struct{}
+
+var _ telemeter.Telemeter = (*nilTelemeter)(nil)
 
 func (t *nilTelemeter) Stop()                            {}
 func (t *nilTelemeter) Identify(_ map[string]any)        {}
 func (t *nilTelemeter) Track(_ string, _ map[string]any) {}
 func (t *nilTelemeter) Group(_ string, _ map[string]any) {}
 
-func (t *nilTelemeter) IdentifyUserAs(_, _, _ string, _ map[string]any) {}
-func (t *nilTelemeter) TrackUserAs(_, _, _, _ string, _ map[string]any) {}
-func (t *nilTelemeter) GroupUserAs(_, _, _, _ string, _ map[string]any) {}
+func (t *nilTelemeter) With(userID string) telemeter.Telemeter                    { return nil }
+func (t *nilTelemeter) As(clientID string, clientType string) telemeter.Telemeter { return nil }

--- a/pkg/telemetry/phonehome/telemeter.go
+++ b/pkg/telemetry/phonehome/telemeter.go
@@ -13,5 +13,5 @@ func (t *nilTelemeter) Identify(_ map[string]any)        {}
 func (t *nilTelemeter) Track(_ string, _ map[string]any) {}
 func (t *nilTelemeter) Group(_ string, _ map[string]any) {}
 
-func (t *nilTelemeter) With(userID string) telemeter.Telemeter                    { return nil }
+func (t *nilTelemeter) User(userID string) telemeter.Telemeter                    { return nil }
 func (t *nilTelemeter) As(clientID string, clientType string) telemeter.Telemeter { return nil }

--- a/pkg/telemetry/phonehome/telemeter/mocks/telemeter.go
+++ b/pkg/telemetry/phonehome/telemeter/mocks/telemeter.go
@@ -8,6 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
+	telemeter "github.com/stackrox/rox/pkg/telemetry/phonehome/telemeter"
 )
 
 // MockTelemeter is a mock of Telemeter interface.
@@ -33,6 +34,20 @@ func (m *MockTelemeter) EXPECT() *MockTelemeterMockRecorder {
 	return m.recorder
 }
 
+// As mocks base method.
+func (m *MockTelemeter) As(clientID, clientType string) telemeter.Telemeter {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "As", clientID, clientType)
+	ret0, _ := ret[0].(telemeter.Telemeter)
+	return ret0
+}
+
+// As indicates an expected call of As.
+func (mr *MockTelemeterMockRecorder) As(clientID, clientType interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "As", reflect.TypeOf((*MockTelemeter)(nil).As), clientID, clientType)
+}
+
 // Group mocks base method.
 func (m *MockTelemeter) Group(groupID string, props map[string]any) {
 	m.ctrl.T.Helper()
@@ -45,18 +60,6 @@ func (mr *MockTelemeterMockRecorder) Group(groupID, props interface{}) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Group", reflect.TypeOf((*MockTelemeter)(nil).Group), groupID, props)
 }
 
-// GroupUserAs mocks base method.
-func (m *MockTelemeter) GroupUserAs(userID, clientID, clientType, groupID string, props map[string]any) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "GroupUserAs", userID, clientID, clientType, groupID, props)
-}
-
-// GroupUserAs indicates an expected call of GroupUserAs.
-func (mr *MockTelemeterMockRecorder) GroupUserAs(userID, clientID, clientType, groupID, props interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GroupUserAs", reflect.TypeOf((*MockTelemeter)(nil).GroupUserAs), userID, clientID, clientType, groupID, props)
-}
-
 // Identify mocks base method.
 func (m *MockTelemeter) Identify(props map[string]any) {
 	m.ctrl.T.Helper()
@@ -67,18 +70,6 @@ func (m *MockTelemeter) Identify(props map[string]any) {
 func (mr *MockTelemeterMockRecorder) Identify(props interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Identify", reflect.TypeOf((*MockTelemeter)(nil).Identify), props)
-}
-
-// IdentifyUserAs mocks base method.
-func (m *MockTelemeter) IdentifyUserAs(userID, clientID, clientType string, props map[string]any) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "IdentifyUserAs", userID, clientID, clientType, props)
-}
-
-// IdentifyUserAs indicates an expected call of IdentifyUserAs.
-func (mr *MockTelemeterMockRecorder) IdentifyUserAs(userID, clientID, clientType, props interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IdentifyUserAs", reflect.TypeOf((*MockTelemeter)(nil).IdentifyUserAs), userID, clientID, clientType, props)
 }
 
 // Stop mocks base method.
@@ -105,14 +96,16 @@ func (mr *MockTelemeterMockRecorder) Track(event, props interface{}) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Track", reflect.TypeOf((*MockTelemeter)(nil).Track), event, props)
 }
 
-// TrackUserAs mocks base method.
-func (m *MockTelemeter) TrackUserAs(userID, clientID, clientType, event string, props map[string]any) {
+// With mocks base method.
+func (m *MockTelemeter) With(userID string) telemeter.Telemeter {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "TrackUserAs", userID, clientID, clientType, event, props)
+	ret := m.ctrl.Call(m, "With", userID)
+	ret0, _ := ret[0].(telemeter.Telemeter)
+	return ret0
 }
 
-// TrackUserAs indicates an expected call of TrackUserAs.
-func (mr *MockTelemeterMockRecorder) TrackUserAs(userID, clientID, clientType, event, props interface{}) *gomock.Call {
+// With indicates an expected call of With.
+func (mr *MockTelemeterMockRecorder) With(userID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TrackUserAs", reflect.TypeOf((*MockTelemeter)(nil).TrackUserAs), userID, clientID, clientType, event, props)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "With", reflect.TypeOf((*MockTelemeter)(nil).With), userID)
 }

--- a/pkg/telemetry/phonehome/telemeter/mocks/telemeter.go
+++ b/pkg/telemetry/phonehome/telemeter/mocks/telemeter.go
@@ -96,16 +96,16 @@ func (mr *MockTelemeterMockRecorder) Track(event, props interface{}) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Track", reflect.TypeOf((*MockTelemeter)(nil).Track), event, props)
 }
 
-// With mocks base method.
-func (m *MockTelemeter) With(userID string) telemeter.Telemeter {
+// User mocks base method.
+func (m *MockTelemeter) User(userID string) telemeter.Telemeter {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "With", userID)
+	ret := m.ctrl.Call(m, "User", userID)
 	ret0, _ := ret[0].(telemeter.Telemeter)
 	return ret0
 }
 
-// With indicates an expected call of With.
-func (mr *MockTelemeterMockRecorder) With(userID interface{}) *gomock.Call {
+// User indicates an expected call of User.
+func (mr *MockTelemeterMockRecorder) User(userID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "With", reflect.TypeOf((*MockTelemeter)(nil).With), userID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "User", reflect.TypeOf((*MockTelemeter)(nil).User), userID)
 }

--- a/pkg/telemetry/phonehome/telemeter/mocks/telemeter.go
+++ b/pkg/telemetry/phonehome/telemeter/mocks/telemeter.go
@@ -34,42 +34,38 @@ func (m *MockTelemeter) EXPECT() *MockTelemeterMockRecorder {
 	return m.recorder
 }
 
-// As mocks base method.
-func (m *MockTelemeter) As(clientID, clientType string) telemeter.Telemeter {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "As", clientID, clientType)
-	ret0, _ := ret[0].(telemeter.Telemeter)
-	return ret0
-}
-
-// As indicates an expected call of As.
-func (mr *MockTelemeterMockRecorder) As(clientID, clientType interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "As", reflect.TypeOf((*MockTelemeter)(nil).As), clientID, clientType)
-}
-
 // Group mocks base method.
-func (m *MockTelemeter) Group(groupID string, props map[string]any) {
+func (m *MockTelemeter) Group(groupID string, props map[string]any, opts ...telemeter.Option) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Group", groupID, props)
+	varargs := []interface{}{groupID, props}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	m.ctrl.Call(m, "Group", varargs...)
 }
 
 // Group indicates an expected call of Group.
-func (mr *MockTelemeterMockRecorder) Group(groupID, props interface{}) *gomock.Call {
+func (mr *MockTelemeterMockRecorder) Group(groupID, props interface{}, opts ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Group", reflect.TypeOf((*MockTelemeter)(nil).Group), groupID, props)
+	varargs := append([]interface{}{groupID, props}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Group", reflect.TypeOf((*MockTelemeter)(nil).Group), varargs...)
 }
 
 // Identify mocks base method.
-func (m *MockTelemeter) Identify(props map[string]any) {
+func (m *MockTelemeter) Identify(props map[string]any, opts ...telemeter.Option) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Identify", props)
+	varargs := []interface{}{props}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	m.ctrl.Call(m, "Identify", varargs...)
 }
 
 // Identify indicates an expected call of Identify.
-func (mr *MockTelemeterMockRecorder) Identify(props interface{}) *gomock.Call {
+func (mr *MockTelemeterMockRecorder) Identify(props interface{}, opts ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Identify", reflect.TypeOf((*MockTelemeter)(nil).Identify), props)
+	varargs := append([]interface{}{props}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Identify", reflect.TypeOf((*MockTelemeter)(nil).Identify), varargs...)
 }
 
 // Stop mocks base method.
@@ -85,27 +81,18 @@ func (mr *MockTelemeterMockRecorder) Stop() *gomock.Call {
 }
 
 // Track mocks base method.
-func (m *MockTelemeter) Track(event string, props map[string]any) {
+func (m *MockTelemeter) Track(event string, props map[string]any, opts ...telemeter.Option) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Track", event, props)
+	varargs := []interface{}{event, props}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	m.ctrl.Call(m, "Track", varargs...)
 }
 
 // Track indicates an expected call of Track.
-func (mr *MockTelemeterMockRecorder) Track(event, props interface{}) *gomock.Call {
+func (mr *MockTelemeterMockRecorder) Track(event, props interface{}, opts ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Track", reflect.TypeOf((*MockTelemeter)(nil).Track), event, props)
-}
-
-// User mocks base method.
-func (m *MockTelemeter) User(userID string) telemeter.Telemeter {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "User", userID)
-	ret0, _ := ret[0].(telemeter.Telemeter)
-	return ret0
-}
-
-// User indicates an expected call of User.
-func (mr *MockTelemeterMockRecorder) User(userID interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "User", reflect.TypeOf((*MockTelemeter)(nil).User), userID)
+	varargs := append([]interface{}{event, props}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Track", reflect.TypeOf((*MockTelemeter)(nil).Track), varargs...)
 }

--- a/pkg/telemetry/phonehome/telemeter/telemeter.go
+++ b/pkg/telemetry/phonehome/telemeter/telemeter.go
@@ -1,5 +1,34 @@
 package telemeter
 
+type CallOptions struct {
+	UserID     string
+	ClientID   string
+	ClientType string
+}
+
+type Option func(*CallOptions)
+
+func ApplyOptions(opts []Option) *CallOptions {
+	o := &CallOptions{}
+	for _, opt := range opts {
+		opt(o)
+	}
+	return o
+}
+
+func WithUserID(userID string) Option {
+	return func(o *CallOptions) {
+		o.UserID = userID
+	}
+}
+
+func WithClient(clientID string, clientType string) Option {
+	return func(o *CallOptions) {
+		o.ClientID = clientID
+		o.ClientType = clientType
+	}
+}
+
 // Telemeter defines a common interface for telemetry gatherers.
 //
 //go:generate mockgen-wrapper
@@ -8,14 +37,9 @@ type Telemeter interface {
 	// the buffers.
 	Stop()
 	// Identify updates the user traits.
-	Identify(props map[string]any)
+	Identify(props map[string]any, opts ...Option)
 	// Track registers an event, caused by the user.
-	Track(event string, props map[string]any)
+	Track(event string, props map[string]any, opts ...Option)
 	// Group adds the user to a group, supplying group specific properties.
-	Group(groupID string, props map[string]any)
-
-	// User set's the user for the calls on the returned Telemeter.
-	User(userID string) Telemeter
-	// As overrides the device context for the calls on the returned Telemeter.
-	As(clientID string, clientType string) Telemeter
+	Group(groupID string, props map[string]any, opts ...Option)
 }

--- a/pkg/telemetry/phonehome/telemeter/telemeter.go
+++ b/pkg/telemetry/phonehome/telemeter/telemeter.go
@@ -14,6 +14,8 @@ type Telemeter interface {
 	// Group adds the user to a group, supplying group specific properties.
 	Group(groupID string, props map[string]any)
 
-	With(userID string) Telemeter
+	// User set's the user for the calls on the returned Telemeter.
+	User(userID string) Telemeter
+	// As overrides the device context for the calls on the returned Telemeter.
 	As(clientID string, clientType string) Telemeter
 }

--- a/pkg/telemetry/phonehome/telemeter/telemeter.go
+++ b/pkg/telemetry/phonehome/telemeter/telemeter.go
@@ -1,0 +1,19 @@
+package telemeter
+
+// Telemeter defines a common interface for telemetry gatherers.
+//
+//go:generate mockgen-wrapper
+type Telemeter interface {
+	// Stop gracefully shutdowns the implementation, potentially flushing
+	// the buffers.
+	Stop()
+	// Identify updates the user traits.
+	Identify(props map[string]any)
+	// Track registers an event, caused by the user.
+	Track(event string, props map[string]any)
+	// Group adds the user to a group, supplying group specific properties.
+	Group(groupID string, props map[string]any)
+
+	With(userID string) Telemeter
+	As(clientID string, clientType string) Telemeter
+}

--- a/pkg/telemetry/phonehome/telemeter/telemeter.go
+++ b/pkg/telemetry/phonehome/telemeter/telemeter.go
@@ -1,13 +1,16 @@
 package telemeter
 
+// CallOptions defines optional features for a Telemeter call.
 type CallOptions struct {
 	UserID     string
 	ClientID   string
 	ClientType string
 }
 
+// Option modifies the provided CallOptions structure.
 type Option func(*CallOptions)
 
+// ApplyOptions returns an instance of CallOptions modified by provided opts.
 func ApplyOptions(opts []Option) *CallOptions {
 	o := &CallOptions{}
 	for _, opt := range opts {
@@ -16,12 +19,14 @@ func ApplyOptions(opts []Option) *CallOptions {
 	return o
 }
 
+// WithUserID allows for modifying the UserID call option.
 func WithUserID(userID string) Option {
 	return func(o *CallOptions) {
 		o.UserID = userID
 	}
 }
 
+// WithClient allows for modifying the ClientID and ClientType call options.
 func WithClient(clientID string, clientType string) Option {
 	return func(o *CallOptions) {
 		o.ClientID = clientID
@@ -36,10 +41,10 @@ type Telemeter interface {
 	// Stop gracefully shutdowns the implementation, potentially flushing
 	// the buffers.
 	Stop()
-	// Identify updates the user traits.
+	// Identify updates user traits.
 	Identify(props map[string]any, opts ...Option)
-	// Track registers an event, caused by the user.
+	// Track registers an event, caused by a user.
 	Track(event string, props map[string]any, opts ...Option)
-	// Group adds the user to a group, supplying group specific properties.
+	// Group adds a user to a group, supplying group specific properties.
 	Group(groupID string, props map[string]any, opts ...Option)
 }

--- a/pkg/telemetry/phonehome/telemeter/telemeter_test.go
+++ b/pkg/telemetry/phonehome/telemeter/telemeter_test.go
@@ -1,0 +1,18 @@
+package telemeter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWith(t *testing.T) {
+	opts := ApplyOptions([]Option{
+		WithUserID("userID"),
+		WithClient("clientID", "clientType"),
+	},
+	)
+	assert.Equal(t, "userID", opts.UserID)
+	assert.Equal(t, "clientID", opts.ClientID)
+	assert.Equal(t, "clientType", opts.ClientType)
+}


### PR DESCRIPTION
## Description

A suggestion for a refactoring:
* `Telemeter.With` overrides the User ID for which the following call is addressed;
* `Telemeter.As` overrides the device context to impersonate the device which sends the messages.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

Unit tests.