### PR TITLE
Update docs to 3.73.2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "docs/content"]
 	path = docs/content
 	url = https://github.com/openshift/openshift-docs.git
-	branch = rhacs-docs-3.73.1
+	branch = rhacs-docs-3.73.2
 [submodule "docs/tools"]
 	path = docs/tools
 	url = https://github.com/stackrox/docs-tools.git


### PR DESCRIPTION
Update docs branch to 3.73.2 https://github.com/openshift/openshift-docs/commit/d2bac2dd59c40862fff7fafc340ebe2070ffdbd5

It should be done by cut rc step but it was recently removed and I can't use older version as it has issues with tags. 

> ERROR: Expected docs/content submodule to point to branch rhacs-docs-3.73.2, got: rhacs-docs-3.73.1
