### PR TITLE
Autogeneration of frozen schema should be off

### DIFF
--- a/migrator/migrations/frozenschema/v73/gen.go
+++ b/migrator/migrations/frozenschema/v73/gen.go
@@ -1,7 +1,7 @@
 package schema
 
 /***
- * Disable frozen schema generation here. Enabling this only when you need to change and backport a schema change to 4.73.x.
+ * Disable frozen schema generation here. Enabling this only when you need to change and backport a schema change to 3.73.x.
  * Auto generation need to stay disabled after the change.
 
 //go:generate pg-schema-migration-helper --type=storage.Alert --search-category ALERTS

--- a/migrator/migrations/frozenschema/v73/gen.go
+++ b/migrator/migrations/frozenschema/v73/gen.go
@@ -1,5 +1,9 @@
 package schema
 
+/***
+ * Disable frozen schema generation here. Enabling this only when you need to change and backport a schema change to 4.73.x.
+ * Auto generation need to stay disabled after the change.
+
 //go:generate pg-schema-migration-helper --type=storage.Alert --search-category ALERTS
 //go:generate pg-schema-migration-helper --type=storage.Pod --search-category PODS --references storage.Deployment
 //go:generate pg-schema-migration-helper --type=storage.WatchedImage
@@ -68,3 +72,4 @@ package schema
 //go:generate pg-schema-migration-helper --type=storage.Policy --search-category POLICIES --get-all-func
 //go:generate pg-schema-migration-helper --type=storage.ComponentCVEEdge --table=image_component_cve_edges --search-category COMPONENT_VULN_EDGE --references=storage.ImageComponent,image_cves:storage.ImageCVE --read-only-store --search-scope IMAGE_VULNERABILITIES,COMPONENT_VULN_EDGE,IMAGE_COMPONENTS,IMAGE_COMPONENT_EDGE,IMAGE_VULN_EDGE,IMAGES,DEPLOYMENTS,NAMESPACES,CLUSTERS
 //go:generate sh -c "rm ./convert_*.go"
+*/

--- a/migrator/migrations/postgreshelper/schema/gen.go
+++ b/migrator/migrations/postgreshelper/schema/gen.go
@@ -16,4 +16,3 @@ package schema
 //go:generate pg-schema-migration-helper --type=storage.TestGrandChild1 --search-category 64 --references storage.TestChild1,storage.TestGGrandChild1
 //go:generate pg-schema-migration-helper --type=storage.TestG3GrandChild1 --search-category 67
 //go:generate pg-schema-migration-helper --type=storage.TestShortCircuit --search-category 71 --references storage.TestChild1,storage.TestG2GrandChild1
-//go:generate pg-schema-migration-helper --type=storage.Image --search-category IMAGES --search-scope IMAGE_VULNERABILITIES,COMPONENT_VULN_EDGE,IMAGE_COMPONENTS,IMAGE_COMPONENT_EDGE,IMAGE_VULN_EDGE,IMAGES,DEPLOYMENTS,NAMESPACES,CLUSTERS


### PR DESCRIPTION
## Description

We do not expect further schema changes backport to 73, so disable the auto generation of frozen schema.

## Checklist
- [ ] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

CI test.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
