### PR TITLE
Increase default max conns to 200 to better support background processes

### DIFF
--- a/image/templates/helm/stackrox-central/config/centraldb/postgresql.conf.default
+++ b/image/templates/helm/stackrox-central/config/centraldb/postgresql.conf.default
@@ -64,7 +64,7 @@ listen_addresses = '*'              	# StackRox customized
 					# defaults to 'localhost'; use '*' for all
 					# (change requires restart)
 #port = 5432				# (change requires restart)
-max_connections = 100			# (change requires restart)
+max_connections = 200			# (change requires restart)
 #superuser_reserved_connections = 3	# (change requires restart)
 #unix_socket_directories = '/var/run/postgresql, /tmp'	# comma-separated list of directories
 					# (change requires restart)


### PR DESCRIPTION
## Description

There are background processes, things like parallel workers, and potentially psql. Central will generate 1-90 conns, but this will help ensure that we don't hit strange overheads without much more additional expected overhead on Postgres

``` 
3309562 | postgres 2023-01-30 18:16:28.881186+00 | 2023-01-30 18:16:28.878071+00 | 2023-01-30 18:16:28.878805+00 | 2023-01-30 18:16:28.886326+00 | active  | 157587413 | select distinct(deployments.Id::text), deployments | parallel worker
```

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Straightforward and found this issue while testing scale
