### PR TITLE
Fix VM reporting to allow changing between weekly and monthly intervals

### DIFF
--- a/ui/apps/platform/src/Containers/VulnMgmt/Reports/VulnMgmtReportForm.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Reports/VulnMgmtReportForm.tsx
@@ -193,12 +193,15 @@ function VulnMgmtReportForm({
     }
 
     function onScheduledRepeatChange(_id, selection) {
-        // zero out the days selected list if changing interval type
-        if (selection !== values.schedule.intervalType) {
-            void setFieldValue('schedule.interval.days', []);
-        }
+        const intervalDayKey = selection === 'WEEKLY' ? 'daysOfWeek' : 'daysOfMonth';
+        const nextSchedule = {
+            hour: values.schedule.hour,
+            minute: values.schedule.minute,
+            intervalType: selection,
+            [intervalDayKey]: {},
+        };
 
-        void setFieldValue('schedule.intervalType', selection);
+        void setFieldValue('schedule', nextSchedule);
     }
 
     function onScheduledDaysChange(id, selection) {


### PR DESCRIPTION
## Description

This fixes a bug where a vm report is unable to be changed from "monthly" to "weekly" due to multiple mutually-exclusive fields being set on the JSON request object at the same time. The backend proto only supports one of the fields, and will default to using `daysOfMonth` if both it and `daysOfWeek` are set. If this happens when the intervalType is "WEEKLY", the BE will throw an error.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Create a VM report config and save it with a "Monthly" interval, setting any value for the days.
![image](https://user-images.githubusercontent.com/1292638/215588285-6df63283-1f49-4778-94eb-944543d1a0a4.png)

Reload this config in edit mode and update the interval to "Weekly", verifying that it saves correctly.
![image](https://user-images.githubusercontent.com/1292638/215588354-437e4a67-e6ba-4e74-bb38-d83604869e30.png)
![image](https://user-images.githubusercontent.com/1292638/215588386-6bdfd8d0-6f6a-45a1-862a-cd19105ed20e.png)
