### PR TITLE
Network Graph Bug Fixes for Monday

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/TopologyComponent.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/TopologyComponent.tsx
@@ -88,7 +88,7 @@ const TopologyComponent = ({
         history.push(`${networkBasePathPF}${queryString}`);
     }
 
-    function onSelect(ids: string[]) {
+    function onNodeClick(ids: string[]) {
         const newSelectedId = ids?.[0] || '';
         const newSelectedEntity = getNodeById(model?.nodes, newSelectedId);
         if (newSelectedEntity) {
@@ -103,6 +103,10 @@ const TopologyComponent = ({
                 history.push(`${networkBasePathPF}${queryString}`);
             }
         }
+    }
+
+    function onNodeSelect(id: string) {
+        onNodeClick([id]);
     }
 
     function zoomInCallback() {
@@ -123,7 +127,7 @@ const TopologyComponent = ({
     }
 
     useEventListener<SelectionEventListener>(SELECTION_EVENT, (ids) => {
-        onSelect(ids);
+        onNodeClick(ids);
     });
 
     const selectedIds = selectedNode ? [selectedNode.id] : [];
@@ -145,6 +149,7 @@ const TopologyComponent = ({
                             namespaceId={selectedNode.id}
                             nodes={model?.nodes || []}
                             edges={model?.edges || []}
+                            onNodeSelect={onNodeSelect}
                         />
                     )}
                     {selectedNode && selectedNode?.data?.type === 'DEPLOYMENT' && (
@@ -153,6 +158,7 @@ const TopologyComponent = ({
                             nodes={model?.nodes || []}
                             edges={model?.edges || []}
                             edgeState={edgeState}
+                            onNodeSelect={onNodeSelect}
                         />
                     )}
                     {selectedNode && selectedNode?.data?.type === 'EXTERNAL_GROUP' && (
@@ -160,6 +166,7 @@ const TopologyComponent = ({
                             id={selectedNode.id}
                             nodes={model?.nodes || []}
                             edges={model?.edges || []}
+                            onNodeSelect={onNodeSelect}
                         />
                     )}
                     {selectedNode && selectedNode?.data?.type === 'CIDR_BLOCK' && (
@@ -167,6 +174,7 @@ const TopologyComponent = ({
                             id={selectedNode.id}
                             nodes={model?.nodes || []}
                             edges={model?.edges || []}
+                            onNodeSelect={onNodeSelect}
                         />
                     )}
                     {selectedNode && selectedNode?.data?.type === 'EXTERNAL_ENTITIES' && (
@@ -174,6 +182,7 @@ const TopologyComponent = ({
                             id={selectedNode.id}
                             nodes={model?.nodes || []}
                             edges={model?.edges || []}
+                            onNodeSelect={onNodeSelect}
                         />
                     )}
                 </TopologySideBar>

--- a/ui/apps/platform/src/Containers/NetworkGraph/cidr/CidrBlockSideBar.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/cidr/CidrBlockSideBar.tsx
@@ -36,10 +36,11 @@ type CidrBlockSideBarProps = {
     id: string;
     nodes: CustomNodeModel[];
     edges: CustomEdgeModel[];
+    onNodeSelect: (id: string) => void;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-function CidrBlockSideBar({ id, nodes, edges }: CidrBlockSideBarProps): ReactElement {
+function CidrBlockSideBar({ id, nodes, edges, onNodeSelect }: CidrBlockSideBarProps): ReactElement {
     const controller = useVisualizationController();
     // component state
     const [entityNameFilter, setEntityNameFilter] = React.useState<string>('');
@@ -58,6 +59,10 @@ function CidrBlockSideBar({ id, nodes, edges }: CidrBlockSideBarProps): ReactEle
     const cidrBlockNode = getNodeById(nodes, id) as CIDRBlockNodeModel;
     const numFlows = getNumFlows(filteredFlows);
     const allUniquePorts = getAllUniquePorts(filteredFlows);
+
+    const onSelectFlow = (entityId: string) => {
+        onNodeSelect(entityId);
+    };
 
     return (
         <Stack>
@@ -121,6 +126,7 @@ function CidrBlockSideBar({ id, nodes, edges }: CidrBlockSideBarProps): ReactEle
                             setExpandedRows={setExpandedRows}
                             selectedRows={selectedRows}
                             setSelectedRows={setSelectedRows}
+                            onSelectFlow={onSelectFlow}
                         />
                     </StackItem>
                 </Stack>

--- a/ui/apps/platform/src/Containers/NetworkGraph/common/FlowsTable.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/common/FlowsTable.tsx
@@ -10,7 +10,15 @@ import {
     Thead,
     Tr,
 } from '@patternfly/react-table';
-import { Flex, FlexItem, Text, TextContent, TextVariants, Tooltip } from '@patternfly/react-core';
+import {
+    Button,
+    Flex,
+    FlexItem,
+    Text,
+    TextContent,
+    TextVariants,
+    Tooltip,
+} from '@patternfly/react-core';
 import { ExclamationCircleIcon, MinusIcon, PlusIcon } from '@patternfly/react-icons';
 
 import { BaselineSimulationDiffState, Flow, FlowEntityType } from '../types/flow.type';
@@ -30,6 +38,7 @@ type FlowsTableProps = {
     isBaselineSimulation?: boolean;
     numExtraneousEgressFlows?: number;
     numExtraneousIngressFlows?: number;
+    onSelectFlow: (entityId: string) => void;
 };
 
 const columnNames = {
@@ -115,6 +124,7 @@ function FlowsTable({
     isBaselineSimulation = false,
     numExtraneousEgressFlows = 0,
     numExtraneousIngressFlows = 0,
+    onSelectFlow,
 }: FlowsTableProps): ReactElement {
     // getter functions
     const isRowExpanded = (row: Flow) => expandedRows?.includes(row.id);
@@ -143,6 +153,10 @@ function FlowsTable({
             return setSelectedRows?.(newSelectedRows);
         }
         return setSelectedRows?.([]);
+    };
+
+    const onSelectFlowHandler = (flow: Flow) => () => {
+        onSelectFlow(flow.entityId);
     };
 
     return (
@@ -244,7 +258,15 @@ function FlowsTable({
                             <Td dataLabel={columnNames.entity}>
                                 <Flex direction={{ default: 'row' }}>
                                     <FlexItem>
-                                        <div>{row.entity}</div>
+                                        <div>
+                                            <Button
+                                                variant="link"
+                                                isInline
+                                                onClick={onSelectFlowHandler(row)}
+                                            >
+                                                {row.entity}
+                                            </Button>
+                                        </div>
                                         <div>
                                             <TextContent>
                                                 <Text component={TextVariants.small}>
@@ -311,7 +333,15 @@ function FlowsTable({
                                         <Td>
                                             <ExpandableRowContent>
                                                 <Flex direction={{ default: 'row' }}>
-                                                    <FlexItem>{child.entity}</FlexItem>
+                                                    <FlexItem>
+                                                        <Button
+                                                            variant="link"
+                                                            isInline
+                                                            onClick={onSelectFlowHandler(child)}
+                                                        >
+                                                            {child.entity}
+                                                        </Button>
+                                                    </FlexItem>
                                                     {child.isAnomalous && (
                                                         <FlexItem>
                                                             <AnomalousIcon type={child.type} />

--- a/ui/apps/platform/src/Containers/NetworkGraph/common/FlowsTable.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/common/FlowsTable.tsx
@@ -13,7 +13,7 @@ import {
 import { Flex, FlexItem, Text, TextContent, TextVariants, Tooltip } from '@patternfly/react-core';
 import { ExclamationCircleIcon, MinusIcon, PlusIcon } from '@patternfly/react-icons';
 
-import { BaselineSimulationDiffState, Flow } from '../types/flow.type';
+import { BaselineSimulationDiffState, Flow, FlowEntityType } from '../types/flow.type';
 import { protocolLabel } from '../utils/flowUtils';
 
 type FlowsTableProps = {
@@ -83,6 +83,21 @@ function ExtraneousFlowsRow({
                 <Td dataLabel={columnNames.portAndProtocol}>Any / Any</Td>
             </Tr>
         </Tbody>
+    );
+}
+
+function AnomalousIcon({ type }: { type: FlowEntityType }) {
+    if (type === 'CIDR_BLOCK' || type === 'EXTERNAL_ENTITIES') {
+        return (
+            <Tooltip content={<div>Anomalous external flow</div>}>
+                <ExclamationCircleIcon className="pf-u-danger-color-100" />
+            </Tooltip>
+        );
+    }
+    return (
+        <Tooltip content={<div>Anomalous internal flow</div>}>
+            <ExclamationCircleIcon className="pf-u-warning-color-100" />
+        </Tooltip>
     );
 }
 
@@ -242,7 +257,7 @@ function FlowsTable({
                                     </FlexItem>
                                     {row.isAnomalous && (
                                         <FlexItem>
-                                            <ExclamationCircleIcon className="pf-u-danger-color-100" />
+                                            <AnomalousIcon type={row.type} />
                                         </FlexItem>
                                     )}
                                 </Flex>
@@ -297,9 +312,9 @@ function FlowsTable({
                                             <ExpandableRowContent>
                                                 <Flex direction={{ default: 'row' }}>
                                                     <FlexItem>{child.entity}</FlexItem>
-                                                    {row.isAnomalous && (
+                                                    {child.isAnomalous && (
                                                         <FlexItem>
-                                                            <ExclamationCircleIcon className="pf-u-danger-color-100" />
+                                                            <AnomalousIcon type={child.type} />
                                                         </FlexItem>
                                                     )}
                                                 </Flex>

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentBaselines.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentBaselines.tsx
@@ -41,9 +41,10 @@ import useFetchBaselineNetworkPolicy from '../api/useFetchBaselineNetworkPolicy'
 type DeploymentBaselinesProps = {
     deployment: Deployment;
     deploymentId: string;
+    onNodeSelect: (id: string) => void;
 };
 
-function DeploymentBaselines({ deployment, deploymentId }: DeploymentBaselinesProps) {
+function DeploymentBaselines({ deployment, deploymentId, onNodeSelect }: DeploymentBaselinesProps) {
     // component state
     const [isExcludingPortsAndProtocols, setIsExcludingPortsAndProtocols] =
         React.useState<boolean>(false);
@@ -93,6 +94,10 @@ function DeploymentBaselines({ deployment, deploymentId }: DeploymentBaselinesPr
     const numBaselines = getNumFlows(filteredNetworkBaselines);
     const allUniquePorts = getAllUniquePorts(filteredNetworkBaselines);
     const errorMessage = networkPolicyError || fetchError || modifyError || toggleError;
+
+    const onSelectFlow = (entityId: string) => {
+        onNodeSelect(entityId);
+    };
 
     function addToBaseline(flow: Flow) {
         modifyBaselineStatuses([flow], 'BASELINE', refetchBaselines);
@@ -226,6 +231,7 @@ function DeploymentBaselines({ deployment, deploymentId }: DeploymentBaselinesPr
                         addToBaseline={addToBaseline}
                         markAsAnomalous={markAsAnomalous}
                         isEditable
+                        onSelectFlow={onSelectFlow}
                     />
                 </StackItem>
                 <StackItem>

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentBaselinesSimulated.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentBaselinesSimulated.tsx
@@ -27,10 +27,14 @@ import EntityNameSearchInput from '../common/EntityNameSearchInput';
 
 type DeploymentBaselinesSimulatedProps = {
     deploymentId: string;
+    onNodeSelect: (id: string) => void;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-function DeploymentBaselinesSimulated({ deploymentId }: DeploymentBaselinesSimulatedProps) {
+function DeploymentBaselinesSimulated({
+    deploymentId,
+    onNodeSelect,
+}: DeploymentBaselinesSimulatedProps) {
     // component state
     const {
         isLoading,
@@ -58,6 +62,10 @@ function DeploymentBaselinesSimulated({ deploymentId }: DeploymentBaselinesSimul
     // derived data
     const numBaselines = getNumFlows(filteredSimulatedBaselines);
     const allUniquePorts = getAllUniquePorts(filteredSimulatedBaselines);
+
+    const onSelectFlow = (entityId: string) => {
+        onNodeSelect(entityId);
+    };
 
     if (isLoading) {
         return (
@@ -120,6 +128,7 @@ function DeploymentBaselinesSimulated({ deploymentId }: DeploymentBaselinesSimul
                         setSelectedRows={setSelectedRows}
                         isEditable={false}
                         isBaselineSimulation
+                        onSelectFlow={onSelectFlow}
                     />
                 </StackItem>
             </Stack>

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentDetails.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentDetails.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import {
-    Button,
     DescriptionList,
     DescriptionListDescription,
     DescriptionListGroup,
@@ -204,9 +203,7 @@ function DeploymentDetails({
                                     <DescriptionListGroup>
                                         <DescriptionListTerm>Name</DescriptionListTerm>
                                         <DescriptionListDescription>
-                                            <Button variant="link" isInline>
-                                                {deployment.name}
-                                            </Button>
+                                            {deployment.name}
                                         </DescriptionListDescription>
                                     </DescriptionListGroup>
                                     <DescriptionListGroup>
@@ -218,33 +215,25 @@ function DeploymentDetails({
                                     <DescriptionListGroup>
                                         <DescriptionListTerm>Cluster</DescriptionListTerm>
                                         <DescriptionListDescription>
-                                            <Button variant="link" isInline>
-                                                {deployment.clusterName}
-                                            </Button>
+                                            {deployment.clusterName}
                                         </DescriptionListDescription>
                                     </DescriptionListGroup>
                                     <DescriptionListGroup>
                                         <DescriptionListTerm>Namespace</DescriptionListTerm>
                                         <DescriptionListDescription>
-                                            <Button variant="link" isInline>
-                                                {deployment.namespace}
-                                            </Button>
+                                            {deployment.namespace}
                                         </DescriptionListDescription>
                                     </DescriptionListGroup>
                                     <DescriptionListGroup>
                                         <DescriptionListTerm>Replicas</DescriptionListTerm>
                                         <DescriptionListDescription>
-                                            <Button variant="link" isInline>
-                                                {deployment.replicas}
-                                            </Button>
+                                            {deployment.replicas}
                                         </DescriptionListDescription>
                                     </DescriptionListGroup>
                                     <DescriptionListGroup>
                                         <DescriptionListTerm>Service account</DescriptionListTerm>
                                         <DescriptionListDescription>
-                                            <Button variant="link" isInline>
-                                                {deployment.serviceAccount}
-                                            </Button>
+                                            {deployment.serviceAccount}
                                         </DescriptionListDescription>
                                     </DescriptionListGroup>
                                 </DescriptionList>

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentFlows.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentFlows.tsx
@@ -43,9 +43,16 @@ type DeploymentFlowsProps = {
     nodes: CustomNodeModel[];
     edges: CustomEdgeModel[];
     edgeState: EdgeState;
+    onNodeSelect: (id: string) => void;
 };
 
-function DeploymentFlows({ deploymentId, nodes, edges, edgeState }: DeploymentFlowsProps) {
+function DeploymentFlows({
+    deploymentId,
+    nodes,
+    edges,
+    edgeState,
+    onNodeSelect,
+}: DeploymentFlowsProps) {
     // component state
     const [entityNameFilter, setEntityNameFilter] = React.useState<string>('');
     const [advancedFilters, setAdvancedFilters] = React.useState<AdvancedFlowsFilterType>(
@@ -77,6 +84,10 @@ function DeploymentFlows({ deploymentId, nodes, edges, edgeState }: DeploymentFl
     const numExtraneousEgressFlows = getNumExtraneousEgressFlows(nodes);
     const numExtraneousIngressFlows = getNumExtraneousIngressFlows(nodes);
     const totalFlows = numFlows + numExtraneousEgressFlows + numExtraneousIngressFlows;
+
+    const onSelectFlow = (entityId: string) => {
+        onNodeSelect(entityId);
+    };
 
     function addToBaseline(flow: Flow) {
         modifyBaselineStatuses([flow], 'BASELINE', refetchFlows);
@@ -169,6 +180,7 @@ function DeploymentFlows({ deploymentId, nodes, edges, edgeState }: DeploymentFl
                         numExtraneousEgressFlows={numExtraneousEgressFlows}
                         numExtraneousIngressFlows={numExtraneousIngressFlows}
                         isEditable
+                        onSelectFlow={onSelectFlow}
                     />
                 </StackItem>
             </Stack>

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentSideBar.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentSideBar.tsx
@@ -41,9 +41,16 @@ type DeploymentSideBarProps = {
     nodes: CustomNodeModel[];
     edges: CustomEdgeModel[];
     edgeState: EdgeState;
+    onNodeSelect: (id: string) => void;
 };
 
-function DeploymentSideBar({ deploymentId, nodes, edges, edgeState }: DeploymentSideBarProps) {
+function DeploymentSideBar({
+    deploymentId,
+    nodes,
+    edges,
+    edgeState,
+    onNodeSelect,
+}: DeploymentSideBarProps) {
     // component state
     const { deployment, isLoading, error } = useFetchDeployment(deploymentId);
     const { activeKeyTab, onSelectTab, setActiveKeyTab } = useTabs({
@@ -110,7 +117,10 @@ function DeploymentSideBar({ deploymentId, nodes, edges, edgeState }: Deployment
             </StackItem>
             {isBaselineSimulationOn && (
                 <StackItem isFilled style={{ overflow: 'auto' }} className="pf-u-h-100">
-                    <DeploymentBaselinesSimulated deploymentId={deploymentId} />
+                    <DeploymentBaselinesSimulated
+                        deploymentId={deploymentId}
+                        onNodeSelect={onNodeSelect}
+                    />
                 </StackItem>
             )}
             {!isBaselineSimulationOn && deployment && (
@@ -164,6 +174,7 @@ function DeploymentSideBar({ deploymentId, nodes, edges, edgeState }: Deployment
                                 edges={edges}
                                 deploymentId={deploymentId}
                                 edgeState={edgeState}
+                                onNodeSelect={onNodeSelect}
                             />
                         </TabContent>
                         <TabContent
@@ -175,6 +186,7 @@ function DeploymentSideBar({ deploymentId, nodes, edges, edgeState }: Deployment
                             <DeploymentBaselines
                                 deployment={deployment}
                                 deploymentId={deploymentId}
+                                onNodeSelect={onNodeSelect}
                             />
                         </TabContent>
                         <TabContent

--- a/ui/apps/platform/src/Containers/NetworkGraph/external/ExternalGroupSideBar.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/external/ExternalGroupSideBar.tsx
@@ -1,5 +1,6 @@
 import React, { ReactElement } from 'react';
 import {
+    Button,
     Divider,
     Flex,
     FlexItem,
@@ -30,6 +31,7 @@ type ExternalGroupSideBarProps = {
     id: string;
     nodes: CustomNodeModel[];
     edges: CustomEdgeModel[];
+    onNodeSelect: (id: string) => void;
 };
 
 const columnNames = {
@@ -39,7 +41,12 @@ const columnNames = {
 };
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-function ExternalGroupSideBar({ id, nodes, edges }: ExternalGroupSideBarProps): ReactElement {
+function ExternalGroupSideBar({
+    id,
+    nodes,
+    edges,
+    onNodeSelect,
+}: ExternalGroupSideBarProps): ReactElement {
     // component state
     const [entityNameFilter, setEntityNameFilter] = React.useState<string>('');
 
@@ -48,6 +55,11 @@ function ExternalGroupSideBar({ id, nodes, edges }: ExternalGroupSideBarProps): 
     const externalNodes = nodes.filter(
         (node) => node.data.type === 'CIDR_BLOCK' || node.data.type === 'EXTERNAL_ENTITIES'
     ) as (ExternalEntitiesNodeModel | CIDRBlockNodeModel)[];
+
+    const onNodeSelectHandler =
+        (externalNode: ExternalEntitiesNodeModel | CIDRBlockNodeModel) => () => {
+            onNodeSelect(externalNode.id);
+        };
 
     const filteredExternalNodes = entityNameFilter
         ? externalNodes.filter((externalNode) => {
@@ -133,7 +145,17 @@ function ExternalGroupSideBar({ id, nodes, edges }: ExternalGroupSideBarProps): 
                                             <Td dataLabel={columnNames.entity}>
                                                 <Flex>
                                                     <FlexItem>{entityIcon}</FlexItem>
-                                                    <FlexItem>{entityName}</FlexItem>
+                                                    <FlexItem>
+                                                        <Button
+                                                            variant="link"
+                                                            isInline
+                                                            onClick={onNodeSelectHandler(
+                                                                externalNode
+                                                            )}
+                                                        >
+                                                            {entityName}
+                                                        </Button>
+                                                    </FlexItem>
                                                 </Flex>
                                             </Td>
                                             <Td dataLabel={columnNames.address}>{address}</Td>

--- a/ui/apps/platform/src/Containers/NetworkGraph/externalEntities/ExternalEntitiesSideBar.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/externalEntities/ExternalEntitiesSideBar.tsx
@@ -36,10 +36,16 @@ type ExternalEntitiesSideBarProps = {
     id: string;
     nodes: CustomNodeModel[];
     edges: CustomEdgeModel[];
+    onNodeSelect: (id: string) => void;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-function ExternalEntitiesSideBar({ id, nodes, edges }: ExternalEntitiesSideBarProps): ReactElement {
+function ExternalEntitiesSideBar({
+    id,
+    nodes,
+    edges,
+    onNodeSelect,
+}: ExternalEntitiesSideBarProps): ReactElement {
     const controller = useVisualizationController();
     // component state
     const [entityNameFilter, setEntityNameFilter] = React.useState<string>('');
@@ -58,6 +64,10 @@ function ExternalEntitiesSideBar({ id, nodes, edges }: ExternalEntitiesSideBarPr
     const externalEntitiesNode = getNodeById(nodes, id);
     const numFlows = getNumFlows(filteredFlows);
     const allUniquePorts = getAllUniquePorts(filteredFlows);
+
+    const onSelectFlow = (entityId: string) => {
+        onNodeSelect(entityId);
+    };
 
     return (
         <Stack>
@@ -121,6 +131,7 @@ function ExternalEntitiesSideBar({ id, nodes, edges }: ExternalEntitiesSideBarPr
                             setExpandedRows={setExpandedRows}
                             selectedRows={selectedRows}
                             setSelectedRows={setSelectedRows}
+                            onSelectFlow={onSelectFlow}
                         />
                     </StackItem>
                 </Stack>

--- a/ui/apps/platform/src/Containers/NetworkGraph/namespace/NamespaceDeployments.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/namespace/NamespaceDeployments.tsx
@@ -12,7 +12,6 @@ import {
 } from '@patternfly/react-core';
 import { TableComposable, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import usePagination from 'hooks/patternfly/usePagination';
-import { DeploymentIcon } from '../common/NetworkGraphIcons';
 
 const columnNames = {
     DEPLOYMENT: 'Deployment',
@@ -20,15 +19,20 @@ const columnNames = {
 };
 
 type NamespaceDeploymentsProps = {
-    deployments: { name: string; numFlows: number }[];
+    deployments: { id: string; name: string; numFlows: number }[];
+    onNodeSelect: (id: string) => void;
 };
 
-function NamespaceDeployments({ deployments }: NamespaceDeploymentsProps) {
+function NamespaceDeployments({ deployments, onNodeSelect }: NamespaceDeploymentsProps) {
     const [searchValue, setSearchValue] = React.useState('');
     const { page, perPage, onSetPage, onPerPageSelect } = usePagination();
 
     const onChange = (newValue: string) => {
         setSearchValue(newValue);
+    };
+
+    const onNodeSelectHandler = (deployment) => () => {
+        onNodeSelect(deployment.id);
     };
 
     const filteredDeployments = deployments.filter((deployment) => {
@@ -38,6 +42,14 @@ function NamespaceDeployments({ deployments }: NamespaceDeploymentsProps) {
     return (
         <div className="pf-u-h-100 pf-u-p-md">
             <Stack hasGutter>
+                <StackItem>
+                    <SearchInput
+                        placeholder="Find by deployment name"
+                        value={searchValue}
+                        onChange={onChange}
+                        onClear={() => onChange('')}
+                    />
+                </StackItem>
                 <StackItem>
                     <Flex
                         direction={{ default: 'row' }}
@@ -63,14 +75,6 @@ function NamespaceDeployments({ deployments }: NamespaceDeploymentsProps) {
                     </Flex>
                 </StackItem>
                 <StackItem>
-                    <SearchInput
-                        placeholder="Find by deployment name"
-                        value={searchValue}
-                        onChange={onChange}
-                        onClear={() => onChange('')}
-                    />
-                </StackItem>
-                <StackItem>
                     <TableComposable aria-label="Simple table" variant="compact">
                         <Thead>
                             <Tr>
@@ -80,18 +84,15 @@ function NamespaceDeployments({ deployments }: NamespaceDeploymentsProps) {
                         </Thead>
                         <Tbody>
                             {filteredDeployments.map((deployment) => (
-                                <Tr key={deployment.name}>
+                                <Tr key={deployment.id}>
                                     <Td dataLabel={columnNames.DEPLOYMENT}>
-                                        <Flex spaceItems={{ default: 'spaceItemsMd' }}>
-                                            <FlexItem>
-                                                <DeploymentIcon />
-                                            </FlexItem>
-                                            <FlexItem>
-                                                <Button variant="link" isInline>
-                                                    {deployment.name}
-                                                </Button>
-                                            </FlexItem>
-                                        </Flex>
+                                        <Button
+                                            variant="link"
+                                            isInline
+                                            onClick={onNodeSelectHandler(deployment)}
+                                        >
+                                            {deployment.name}
+                                        </Button>
                                     </Td>
                                     <Td dataLabel={columnNames.ACTIVE_TRAFFIC}>
                                         {deployment.numFlows} flows

--- a/ui/apps/platform/src/Containers/NetworkGraph/namespace/NamespaceSideBar.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/namespace/NamespaceSideBar.tsx
@@ -30,9 +30,10 @@ type NamespaceSideBarProps = {
     namespaceId: string;
     nodes: CustomNodeModel[];
     edges: CustomEdgeModel[];
+    onNodeSelect: (id: string) => void;
 };
 
-function NamespaceSideBar({ namespaceId, nodes, edges }: NamespaceSideBarProps) {
+function NamespaceSideBar({ namespaceId, nodes, edges, onNodeSelect }: NamespaceSideBarProps) {
     // component state
     const { activeKeyTab, onSelectTab } = useTabs({
         defaultTab: 'Deployments',
@@ -46,6 +47,7 @@ function NamespaceSideBar({ namespaceId, nodes, edges }: NamespaceSideBarProps) 
     const deployments = deploymentNodes.map((deploymentNode) => {
         const numFlows = getNumDeploymentFlows(edges, deploymentNode.id);
         return {
+            id: deploymentNode.id,
             name: deploymentNode.label as string,
             numFlows,
         };
@@ -102,7 +104,7 @@ function NamespaceSideBar({ namespaceId, nodes, edges }: NamespaceSideBarProps) 
                     id="Deployments"
                     hidden={activeKeyTab !== 'Deployments'}
                 >
-                    <NamespaceDeployments deployments={deployments} />
+                    <NamespaceDeployments deployments={deployments} onNodeSelect={onNodeSelect} />
                 </TabContent>
                 <TabContent
                     eventKey="Network policies"


### PR DESCRIPTION
## Description

This PR fixes two issues:
1. We want to show a yellow indicator when there is an anomalous flow that is not external and a red indicator when it is external

<img width="1552" alt="Screenshot 2023-01-30 at 10 49 31 AM" src="https://user-images.githubusercontent.com/4805485/215575657-7357d1e3-c76d-43cc-bc5b-8b6207d268e3.png">

2. We want to be able to click on the table entity names to simulate clicking that entity node

https://user-images.githubusercontent.com/4805485/215576170-126cf14b-5ba9-40f8-b439-d4001dd4cf9a.mov




## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~