### PR TITLE
ROX-13684: Add deprecation warning to Clair v2 integration form

### DIFF
--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ClairIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ClairIntegrationForm.tsx
@@ -99,7 +99,10 @@ function ClairIntegrationForm({
                     isInline
                     className="pf-u-mb-lg"
                 >
-                    <Text>CoreOS Clair v2 integration will be removed in Red Hat Advanced Cluster Security 4.x release.</Text>
+                    <Text>
+                        CoreOS Clair v2 integration will be removed in Red Hat Advanced Cluster
+                        Security 4.1 release.
+                    </Text>
                     <Text>Use Clair v4 integration instead.</Text>
                 </Alert>
                 <FormMessage message={message} />

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ClairIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ClairIntegrationForm.tsx
@@ -1,5 +1,13 @@
 import React, { ReactElement } from 'react';
-import { TextInput, PageSection, Form, Checkbox } from '@patternfly/react-core';
+import {
+    Alert,
+    AlertVariant,
+    Checkbox,
+    Form,
+    PageSection,
+    Text,
+    TextInput,
+} from '@patternfly/react-core';
 import * as yup from 'yup';
 
 import { ImageIntegrationBase } from 'services/ImageIntegrationsService';
@@ -85,6 +93,15 @@ function ClairIntegrationForm({
     return (
         <>
             <PageSection variant="light" isFilled hasOverflowScroll>
+                <Alert
+                    title="Deprecation notice"
+                    variant={AlertVariant.warning}
+                    isInline
+                    className="pf-u-mb-lg"
+                >
+                    <Text>CoreOS Clair v2 integration will be removed in Red Hat Advanced Cluster Security 4.x release.</Text>
+                    <Text>Use Clair v4 integration instead.</Text>
+                </Alert>
                 <FormMessage message={message} />
                 <Form isWidthLimited>
                     <FormLabelGroup


### PR DESCRIPTION
## Description

Specify margin-bottom to separate from **Integration name** with same spacing as form elements.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

![Clair_Deprecation_notice_4_1](https://user-images.githubusercontent.com/11862657/215609928-efda1462-90ac-48bb-9919-edee4551b190.png)