### PR TITLE
Network graph: Patternfly -- adding unselect on same node click

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/TopologyComponent.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/TopologyComponent.tsx
@@ -90,7 +90,9 @@ const TopologyComponent = ({
     function onNodeClick(ids: string[]) {
         const newSelectedId = ids?.[0] || '';
         const newSelectedEntity = getNodeById(model?.nodes, newSelectedId);
-        if (newSelectedEntity) {
+        if (selectedNode && !newSelectedId) {
+            closeSidebar();
+        } else if (newSelectedEntity) {
             const { data, id } = newSelectedEntity;
             const [newDetailType, newDetailId] = getUrlParamsForEntity(data.type, id);
             const queryString = clearSimulationQuery(history.location.search);


### PR DESCRIPTION
adding unselect (close sidebar) function to same node click to mitigate confusion on how to unselect a node & for consistency between the visuals (highlighted node) on the graph vs the side panel state.

everything should still work the same otherwise