### PR TITLE
Network graph: PF - tightening policy status badge logic

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/modelUtils.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/modelUtils.tsx
@@ -335,11 +335,11 @@ function getNetworkPolicyState(
 ): NetworkPolicyState {
     let networkPolicyState: NetworkPolicyState = 'none';
 
-    if (!nonIsolatedIngress && !nonIsolatedEgress) {
+    if (!nonIsolatedEgress && !nonIsolatedIngress) {
         networkPolicyState = 'both';
-    } else if (nonIsolatedEgress) {
+    } else if (nonIsolatedEgress && !nonIsolatedIngress) {
         networkPolicyState = 'ingress';
-    } else if (nonIsolatedIngress) {
+    } else if (!nonIsolatedEgress && nonIsolatedIngress) {
         networkPolicyState = 'egress';
     }
     return networkPolicyState;
@@ -361,7 +361,8 @@ export function transformPolicyData(nodes: Node[]): {
     const policyNodeMap: Record<string, DeploymentNodeModel> = {};
     // to reference edges so we don't double merge bidirectional edges
     const policyEdgeMap: Record<string, CustomEdgeModel> = {};
-    nodes.forEach(({ entity, policyIds, outEdges, nonIsolatedEgress, nonIsolatedIngress }) => {
+    nodes.forEach((policyNode) => {
+        const { entity, policyIds, outEdges, nonIsolatedEgress, nonIsolatedIngress } = policyNode;
         const networkPolicyState = getNetworkPolicyState(nonIsolatedEgress, nonIsolatedIngress);
         const node = getNodeModel(
             entity,


### PR DESCRIPTION
as the title states -- now it should actually match up w the policy tab in the deployment side panel

<img width="1216" alt="image" src="https://user-images.githubusercontent.com/10412893/215642438-2af37b8a-1f10-443c-bdfe-5734d1539796.png">
<img width="819" alt="image" src="https://user-images.githubusercontent.com/10412893/215642453-8536d2df-fc05-4d24-863e-56667db194ed.png">

<img width="1216" alt="image" src="https://user-images.githubusercontent.com/10412893/215642485-280ec9a0-223c-448e-8854-6f8be319af1b.png">
<img width="680" alt="image" src="https://user-images.githubusercontent.com/10412893/215642507-323a3c1d-bd98-4eb2-adc8-4464bce304e5.png">

<img width="789" alt="image" src="https://user-images.githubusercontent.com/10412893/215642730-3efccaf4-5335-422f-ab44-eeb0d3b72150.png">
<img width="823" alt="image" src="https://user-images.githubusercontent.com/10412893/215642753-bf996ae5-bd10-4047-b616-b839689403b7.png">
