### PR TITLE
Network graph: PF - panning node into view on deployment select from side panel

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/TopologyComponent.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/TopologyComponent.tsx
@@ -131,7 +131,13 @@ const TopologyComponent = ({
 
     useEffect(() => {
         controller.fromModel(model);
-    }, [controller, model]);
+        if (selectedNode) {
+            const selectedNodeElement = controller.getNodeById(selectedNode.id);
+            if (selectedNodeElement) {
+                controller.getGraph().panIntoView(selectedNodeElement);
+            }
+        }
+    }, [controller, model, selectedNode]);
 
     const selectedIds = selectedNode ? [selectedNode.id] : [];
 


### PR DESCRIPTION
When clicking on a deployment from the side panel that is not in view on the graph, the view should pan the node into view

<img width="1214" alt="image" src="https://user-images.githubusercontent.com/10412893/215648095-d0a33b0d-4559-41fa-b43a-916c81b60626.png">
<img width="491" alt="image" src="https://user-images.githubusercontent.com/10412893/215648131-06037d02-7d5e-48b7-957f-8a3ba7f60557.png">
<img width="1214" alt="image" src="https://user-images.githubusercontent.com/10412893/215648227-72fdcf9f-0051-4a11-a801-4b3c58cb25b1.png">
 