### PR TITLE
ROX-14655: Add token-based admin user ID to the tenant Group

### DIFF
--- a/central/telemetry/centralclient/instance_config.go
+++ b/central/telemetry/centralclient/instance_config.go
@@ -9,6 +9,9 @@ import (
 	"github.com/stackrox/rox/central/role/resources"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/env"
+	"github.com/stackrox/rox/pkg/grpc"
+	"github.com/stackrox/rox/pkg/grpc/authn/tokenbased"
+	"github.com/stackrox/rox/pkg/grpc/client/authn/basic"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/sync"
@@ -115,4 +118,41 @@ func InstanceConfig() *phonehome.Config {
 		})
 	})
 	return config
+}
+
+// RegisterCentralClient adds call interceptors, adds central and admin user
+// to the tenant group.
+func RegisterCentralClient(config grpc.Config, basicAuthProviderID string) {
+	cfg := InstanceConfig()
+	if !cfg.Enabled() {
+		return
+	}
+	registerInterceptors(config)
+	// Central adds itself to the tenant group, with no group properties:
+	cfg.Telemeter().GroupUserAs(cfg.ClientID, "", "", cfg.GroupID, nil)
+	registerAdminUser(basicAuthProviderID)
+}
+
+func registerInterceptors(config grpc.Config) {
+	cfg := InstanceConfig()
+	config.HTTPInterceptors = append(config.HTTPInterceptors, cfg.GetHTTPInterceptor())
+	config.UnaryInterceptors = append(config.UnaryInterceptors, cfg.GetGRPCInterceptor())
+}
+
+// registerAdminUser adds the local admin user to the tenant group.
+// This user is not added to the datastore like other users, so we need to add
+// it to the tenant group specifically.
+func registerAdminUser(basicAuthProviderID string) {
+	cfg := InstanceConfig()
+
+	// Add the basic authorization ID form ('admin'):
+	adminHash := cfg.HashUserID(basic.DefaultUsername, basicAuthProviderID)
+	cfg.Telemeter().GroupUserAs(adminHash, "", "", cfg.GroupID, nil)
+
+	// Add the token based ID form ('sso:<provider id>:admin'):
+	adminTokenHash := cfg.HashUserID(
+		tokenbased.FormatUserID(basic.DefaultUsername, basicAuthProviderID),
+		basicAuthProviderID,
+	)
+	cfg.Telemeter().GroupUserAs(adminTokenHash, "", "", cfg.GroupID, nil)
 }

--- a/pkg/grpc/authn/tokenbased/extractor.go
+++ b/pkg/grpc/authn/tokenbased/extractor.go
@@ -149,7 +149,7 @@ func (e *extractor) withExternalUser(ctx context.Context, token *tokens.TokenInf
 
 func createRoleBasedIdentity(roles []permissions.ResolvedRole, token *tokens.TokenInfo, authProvider authproviders.Provider) *roleBasedIdentity {
 	id := &roleBasedIdentity{
-		uid:           fmt.Sprintf("sso:%s:%s", token.Sources[0].ID(), token.ExternalUser.UserID),
+		uid:           FormatUserID(token.Sources[0].ID(), token.ExternalUser.UserID),
 		username:      token.ExternalUser.Email,
 		friendlyName:  token.ExternalUser.FullName,
 		fullName:      token.ExternalUser.FullName,
@@ -168,4 +168,9 @@ func createRoleBasedIdentity(roles []permissions.ResolvedRole, token *tokens.Tok
 		id.friendlyName += fmt.Sprintf(" (%s)", token.ExternalUser.Email)
 	}
 	return id
+}
+
+// FormatUserID returns a compound identity of the source and the user.
+func FormatUserID(sourceID string, userID string) string {
+	return fmt.Sprintf("sso:%s:%s", sourceID, userID)
 }


### PR DESCRIPTION
## Description

This PR makes central add the token-auth admin user ID to the tenant group in addition to the basic-auth ID.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

Local testing.