### PR TITLE
Run 'podman run' in user namespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -375,7 +375,6 @@ build-volumes:
 	$(SILENT)mkdir -p $(CURDIR)/linux-gocache
 	$(SILENT)docker volume inspect $(GOPATH_VOLUME_NAME) >/dev/null 2>&1 || docker volume create $(GOPATH_VOLUME_NAME)
 	$(SILENT)docker volume inspect $(GOCACHE_VOLUME_NAME) >/dev/null 2>&1 || docker volume create $(GOCACHE_VOLUME_NAME)
-	$(SILENT)docker run $(DOCKER_USER) --rm $(LOCAL_VOLUME_ARGS) $(BUILD_IMAGE) chown -R "$(shell id -u)" /linux-gocache /go
 
 .PHONY: main-builder-image
 main-builder-image: build-volumes

--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,7 @@ TESTFLAGS=-race -p 4
 BASE_DIR=$(CURDIR)
 
 DOCKER_VERSION=$(shell docker --version)
-ifeq ($(findstring podman,$(DOCKER_VERSION)),podman)
-DOCKER_USER=--user "$(shell id -u)" --userns=keep-id
-else
+ifeq (,$(findstring podman,$(DOCKER_VERSION)))
 DOCKER_USER=--user "$(shell id -u)"
 endif
 
@@ -377,6 +375,7 @@ build-volumes:
 	$(SILENT)mkdir -p $(CURDIR)/linux-gocache
 	$(SILENT)docker volume inspect $(GOPATH_VOLUME_NAME) >/dev/null 2>&1 || docker volume create $(GOPATH_VOLUME_NAME)
 	$(SILENT)docker volume inspect $(GOCACHE_VOLUME_NAME) >/dev/null 2>&1 || docker volume create $(GOCACHE_VOLUME_NAME)
+	$(SILENT)docker run $(DOCKER_USER) --rm $(LOCAL_VOLUME_ARGS) $(BUILD_IMAGE) chown -R "$(shell id -u)" /linux-gocache /go
 
 .PHONY: main-builder-image
 main-builder-image: build-volumes

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,7 @@ ROX_PROJECT=apollo
 TESTFLAGS=-race -p 4
 BASE_DIR=$(CURDIR)
 
-DOCKER_VERSION=$(shell docker --version)
-ifeq (,$(findstring podman,$(DOCKER_VERSION)))
+ifeq (,$(findstring podman,$(shell docker --version 2>/dev/null)))
 DOCKER_USER=--user "$(shell id -u)"
 endif
 

--- a/make/protogen.mk
+++ b/make/protogen.mk
@@ -235,7 +235,7 @@ $(MERGED_API_SWAGGER_SPEC): $(BASE_PATH)/scripts/mergeswag.sh $(GENERATED_API_SW
 # Generate the docs from the merged swagger specs.
 $(GENERATED_API_DOCS): $(MERGED_API_SWAGGER_SPEC) $(PROTOC_GEN_GRPC_GATEWAY)
 	@echo "+ $@"
-	docker run --rm -v $(CURDIR)/$(GENERATED_DOC_PATH):/tmp/$(GENERATED_DOC_PATH) swaggerapi/swagger-codegen-cli generate -l html2 -i /tmp/$< -o /tmp/$@
+	docker run $(DOCKER_USER) --rm -v $(CURDIR)/$(GENERATED_DOC_PATH):/tmp/$(GENERATED_DOC_PATH) swaggerapi/swagger-codegen-cli generate -l html2 -i /tmp/$< -o /tmp/$@
 
 # Nukes pretty much everything that goes into building protos.
 # You should not have to run this day-to-day, but it occasionally is useful

--- a/make/protogen.mk
+++ b/make/protogen.mk
@@ -235,7 +235,7 @@ $(MERGED_API_SWAGGER_SPEC): $(BASE_PATH)/scripts/mergeswag.sh $(GENERATED_API_SW
 # Generate the docs from the merged swagger specs.
 $(GENERATED_API_DOCS): $(MERGED_API_SWAGGER_SPEC) $(PROTOC_GEN_GRPC_GATEWAY)
 	@echo "+ $@"
-	docker run --user $(shell id -u) --rm -v $(CURDIR)/$(GENERATED_DOC_PATH):/tmp/$(GENERATED_DOC_PATH) swaggerapi/swagger-codegen-cli generate -l html2 -i /tmp/$< -o /tmp/$@
+	docker run --rm -v $(CURDIR)/$(GENERATED_DOC_PATH):/tmp/$(GENERATED_DOC_PATH) swaggerapi/swagger-codegen-cli generate -l html2 -i /tmp/$< -o /tmp/$@
 
 # Nukes pretty much everything that goes into building protos.
 # You should not have to run this day-to-day, but it occasionally is useful


### PR DESCRIPTION
## Description

Podman runs containers as the current user, and uses the user namespace by default.
This PR removes user substitution (`--user ...`) for podman users, but keeps it for docker users.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] ~Unit test and regression tests added~
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

`make image`