### PR TITLE
ROX-14659 Update Cypress collection test to delete report config before collection

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnmanagement/reporting/reportingForm.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/reporting/reportingForm.test.js
@@ -143,9 +143,9 @@ describe('Vulnerability Management Reporting form', () => {
         const integrationsSource = 'notifiers';
 
         // Delete collection from previous calls, if present
+        tryDeleteVMReportConfigs(reportName);
         tryDeleteCollection(collectionName);
         tryDeleteIntegration(integrationsSource, emailNotifierName);
-        tryDeleteVMReportConfigs(reportName);
 
         visitVulnerabilityReportingToCreate({}, isCollectionsEnabled);
 
@@ -232,9 +232,18 @@ describe('Vulnerability Management Reporting form', () => {
         // Verify that we have landed on the correct collection page
         cy.get(`h1:contains("${collectionName}")`);
 
+        // Attempt to delete the collection while it is in use by the VM report config
+        cy.intercept('DELETE', '/v1/collections/*').as('delete-collection');
+        cy.get(`button:contains("Actions")`).click();
+        cy.get(`button:contains("Delete collection")`).click();
+        cy.get('*[role="dialog"] button:contains("Delete")').click();
+        cy.get('*:contains("Failed to delete collection")');
+        // Expect the server to return an error response (4xx or 5xx) due to the collection being in use
+        cy.wait('@delete-collection').its('response.statusCode').should('be.at.least', 400);
+
         // Self cleanup
+        tryDeleteVMReportConfigs(reportName);
         tryDeleteCollection(collectionName);
         tryDeleteIntegration(integrationsSource, emailNotifierName);
-        tryDeleteVMReportConfigs(reportName);
     });
 });

--- a/ui/apps/platform/cypress/integration/vulnmanagement/reporting/reportingForm.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/reporting/reportingForm.test.js
@@ -233,13 +233,10 @@ describe('Vulnerability Management Reporting form', () => {
         cy.get(`h1:contains("${collectionName}")`);
 
         // Attempt to delete the collection while it is in use by the VM report config
-        cy.intercept('DELETE', '/v1/collections/*').as('delete-collection');
         cy.get(`button:contains("Actions")`).click();
         cy.get(`button:contains("Delete collection")`).click();
         cy.get('*[role="dialog"] button:contains("Delete")').click();
         cy.get('*:contains("Failed to delete collection")');
-        // Expect the server to return an error response (4xx or 5xx) due to the collection being in use
-        cy.wait('@delete-collection').its('response.statusCode').should('be.at.least', 400);
 
         // Self cleanup
         tryDeleteVMReportConfigs(reportName);


### PR DESCRIPTION
## Description

Fixes broken VM reporting config e2e test on master by making sure to delete the report config _before_ the collection during cleanup.

As a bonus, I've added a check in the test that a collection cannot be deleted when in use by a report config.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Local Cypress testing
Awaiting CI results
