### PR TITLE
Fix race crash when refreshing page, visiting link

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/flowUtils.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/flowUtils.ts
@@ -127,44 +127,47 @@ export function getNetworkFlows(
         const sourceNode = controller.getNodeById(edge.source);
         const targetNode = controller.getNodeById(edge.target);
 
-        const sourceNodeData: CustomSingleNodeData = sourceNode?.getData();
-        const targetNodeData: CustomSingleNodeData = targetNode?.getData();
+        if (sourceNode && targetNode) {
+            const sourceNodeData: CustomSingleNodeData = sourceNode?.getData();
+            const targetNodeData: CustomSingleNodeData = targetNode?.getData();
 
-        const newFlows = edge.data.sourceToTargetProperties.map(({ port, protocol }): Flow => {
-            const direction: string = isSourceNodeSelected ? 'Egress' : 'Ingress';
-            const flow = createFlow({
-                sourceNodeData,
-                targetNodeData,
-                direction,
-                port,
-                protocol,
-                isSourceNodeSelected,
+            const newFlows = edge.data.sourceToTargetProperties.map(({ port, protocol }): Flow => {
+                const direction: string = isSourceNodeSelected ? 'Egress' : 'Ingress';
+                const flow = createFlow({
+                    sourceNodeData,
+                    targetNodeData,
+                    direction,
+                    port,
+                    protocol,
+                    isSourceNodeSelected,
+                });
+                return flow;
             });
-            return flow;
-        });
 
-        const newReverseFlows = edge.data.targetToSourceProperties
-            ? edge.data.targetToSourceProperties.map(({ port, protocol }): Flow => {
-                  const direction: string = isSourceNodeSelected ? 'Ingress' : 'Egress';
-                  const flow = createFlow({
-                      sourceNodeData,
-                      targetNodeData,
-                      direction,
-                      port,
-                      protocol,
-                      isSourceNodeSelected,
-                  });
-                  return flow;
-              })
-            : [];
+            const newReverseFlows = edge.data.targetToSourceProperties
+                ? edge.data.targetToSourceProperties.map(({ port, protocol }): Flow => {
+                      const direction: string = isSourceNodeSelected ? 'Ingress' : 'Egress';
+                      const flow = createFlow({
+                          sourceNodeData,
+                          targetNodeData,
+                          direction,
+                          port,
+                          protocol,
+                          isSourceNodeSelected,
+                      });
+                      return flow;
+                  })
+                : [];
 
-        return [...acc, ...newFlows, ...newReverseFlows] as Flow[];
+            return [...acc, ...newFlows, ...newReverseFlows] as Flow[];
+        }
+        return [...acc];
     }, [] as Flow[]);
     return networkFlows;
 }
 
 /*
-  This function takes network flows and filters the data based on a text search value 
+  This function takes network flows and filters the data based on a text search value
   for entity name and some advanced filters specific to network flows. These include:
   flow types, directionality, protocols, and ports
 */


### PR DESCRIPTION
## Description

Building the network flows for the External Entities node, after the user refreshes the page or visits a link with that node selected, results in a race condition where we tried to build the flows for the sidebar _before_ the node with the data was in the topology graph.

This solves it by short-circuiting the flows-building until the node is available.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

Navigating manually
![Screen Shot 2023-01-31 at 11 39 13 AM](https://user-images.githubusercontent.com/715729/215829090-1b1a9691-c700-4d53-a5d4-585cef20844a.png)

Same state, from that URL
![Screen Shot 2023-01-31 at 11 39 27 AM](https://user-images.githubusercontent.com/715729/215829112-ffa35e7b-8ca4-48fa-a92e-0c7e8e8dc930.png)
