### PR TITLE
ROX-13754: Trim fields in Policy Wizard form

### DIFF
--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step1/PolicyMetadataFormSection.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step1/PolicyMetadataFormSection.tsx
@@ -5,11 +5,21 @@ import { Field, useFormikContext } from 'formik';
 import PolicyCategoriesSelectField from './PolicyCategoriesSelectField';
 
 function PolicyMetadataFormSection(): ReactElement {
-    const { handleChange } = useFormikContext();
+    const { handleChange, setFieldValue } = useFormikContext();
 
     function onChange(_value, event) {
         handleChange(event);
     }
+
+    function onChangeWithTrim(valueUntrimmed, event) {
+        const name = event.target.id ?? event.target.name;
+        if (name) {
+            setFieldValue(name, valueUntrimmed.trim());
+        } else {
+            onChange(valueUntrimmed, event);
+        }
+    }
+
     return (
         <Form>
             <Field name="name">
@@ -99,7 +109,7 @@ function PolicyMetadataFormSection(): ReactElement {
                             id={field.name}
                             name={field.name}
                             value={field.value}
-                            onChange={onChange}
+                            onChange={onChangeWithTrim}
                         />
                     </FormGroup>
                 )}
@@ -115,7 +125,7 @@ function PolicyMetadataFormSection(): ReactElement {
                             id={field.name}
                             name={field.name}
                             value={field.value}
-                            onChange={onChange}
+                            onChange={onChangeWithTrim}
                         />
                     </FormGroup>
                 )}
@@ -131,7 +141,7 @@ function PolicyMetadataFormSection(): ReactElement {
                             id={field.name}
                             name={field.name}
                             value={field.value}
-                            onChange={onChange}
+                            onChange={onChangeWithTrim}
                         />
                     </FormGroup>
                 )}

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicySection.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicySection.tsx
@@ -33,8 +33,13 @@ function PolicySection({ sectionIndex, descriptors, readOnly = false }: PolicySe
     const { values, setFieldValue, handleChange } = useFormikContext<Policy>();
     const { sectionName, policyGroups } = values.policySections[sectionIndex];
 
-    function onEditSectionName(_, e) {
-        handleChange(e);
+    function onEditSectionName(valueUntrimmed, event) {
+        const name = event.target.id ?? event.target.name;
+        if (name) {
+            setFieldValue(name, valueUntrimmed.trim());
+        } else {
+            handleChange(event);
+        }
     }
 
     function onDeleteSection() {

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step4/PolicyScopeCard.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step4/PolicyScopeCard.tsx
@@ -45,41 +45,46 @@ function PolicyScopeCard({
     const { scope } = value || {};
     const { setValue } = helper;
 
-    function handleChangeCluster(e, val) {
+    function handleChangeCluster(e, clusterUntrimmed) {
+        const clusterTrimmed = clusterUntrimmed.trim();
         setIsClusterSelectOpen(false);
         if (type === 'exclusion') {
-            setValue({ ...value, scope: { ...scope, cluster: val } });
+            setValue({ ...value, scope: { ...scope, cluster: clusterTrimmed } });
         } else {
-            setValue({ ...value, cluster: val });
+            setValue({ ...value, cluster: clusterTrimmed });
         }
     }
 
-    function handleChangeDeployment(e, val) {
+    function handleChangeDeployment(e, deploymentUntrimmed) {
+        const deploymentTrimmed = deploymentUntrimmed.trim();
         setIsDeploymentSelectOpen(false);
-        setValue({ ...value, name: val });
+        setValue({ ...value, name: deploymentTrimmed });
     }
 
-    function handleChangeLabelKey(key) {
+    function handleChangeLabelKey(keyUntrimmed) {
+        const keyTrimmed = keyUntrimmed.trim();
         if (type === 'exclusion') {
             const { label } = scope || {};
-            setValue({ ...value, scope: { ...scope, label: { ...label, key } } });
+            setValue({ ...value, scope: { ...scope, label: { ...label, key: keyTrimmed } } });
         } else {
             const { label } = value || {};
-            setValue({ ...value, label: { ...label, key } });
+            setValue({ ...value, label: { ...label, key: keyTrimmed } });
         }
     }
 
-    function handleChangeLabelValue(val) {
+    function handleChangeLabelValue(valueUntrimmed) {
+        const valueTrimmed = valueUntrimmed.trim();
         if (type === 'exclusion') {
             const { label } = scope || {};
-            setValue({ ...value, scope: { ...scope, label: { ...label, value: val } } });
+            setValue({ ...value, scope: { ...scope, label: { ...label, value: valueTrimmed } } });
         } else {
             const { label } = value || {};
-            setValue({ ...value, label: { ...label, value: val } });
+            setValue({ ...value, label: { ...label, value: valueTrimmed } });
         }
     }
 
-    function handleChangeNamespace(namespace) {
+    function handleChangeNamespace(namespaceUntrimmed) {
+        const namespace = namespaceUntrimmed.trim();
         if (type === 'exclusion') {
             setValue({ ...value, scope: { ...scope, namespace } });
         } else {


### PR DESCRIPTION
## Description

Although I thought about trim in **pre** or **post** processing, it might cause subtle misunderstandings, especially related to effect of `value` property on dry run results:
* For trim in **pre** processing, what if changes are not saved after verifying preview?
* For trim in **post** processing, there might be changes after verifying preview.

Instead, trim only on change:
* Prevent leading or trailing spaces in fields during create of new policy.
* Remove leading or trailing spaces in changed fields during clone or edit of existing policy.

1. Policy details
    * `name` deferred see **Residue** 3
    * `description`
    * `rationale`
    * `guidance`
2. Policy behavior
3. Policy criteria
    * `sectionName`
    * `value` deferred see **Residue** 4
4. Policy scope
    * `cluster`
    * `name` of deployment
    * `key`
    * `value`
    * `namespace`
5. Review policy

### Residue

1. Investigate annoying interaction for trim space at beginning of text input moves insertion point to the end.
2. Investigate console error for change from uncontrolled to controlled element when `value` prop was undefined.
3. Think more carefully about policy name. For example, trim seems safe for clone or edit.
4. Policy criteria `value` deserves extra special care to make sure it does not regress.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

See presence or absence of spaces in payload of /v1/policies/dryrunjob request at Step 5