### PR TITLE
Clear the models when cluster selection changes

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
@@ -67,6 +67,10 @@ function NetworkGraphPage() {
         activeModel: emptyModel,
         extraneousModel: emptyModel,
     });
+    const [previouslySelectedCluster, setPreviouslySelectedCluster] = useState<string | undefined>(
+        undefined
+    );
+
     const [isLoading, setIsLoading] = useState(false);
     const [timeWindow, setTimeWindow] = useState<typeof timeWindows[number]>(timeWindows[0]);
     const [lastUpdatedTime, setLastUpdatedTime] = useState<string>('never');
@@ -74,6 +78,7 @@ function NetworkGraphPage() {
 
     const { searchFilter } = useURLSearch();
     const [simulationQueryValue] = useURLParameter('simulation', undefined);
+    const simulation = getSimulation(simulationQueryValue);
 
     const {
         cluster: clusterFromUrl,
@@ -81,7 +86,13 @@ function NetworkGraphPage() {
         deployments: deploymentsFromUrl,
         remainingQuery,
     } = getScopeHierarchyFromSearch(searchFilter);
-    const simulation = getSimulation(simulationQueryValue);
+    if (clusterFromUrl !== previouslySelectedCluster) {
+        setModels({
+            activeModel: emptyModel,
+            extraneousModel: emptyModel,
+        });
+        setPreviouslySelectedCluster(clusterFromUrl);
+    }
 
     const hasClusterNamespaceSelected = Boolean(clusterFromUrl && namespacesFromUrl.length);
 


### PR DESCRIPTION
## Description

The bug report said this happened only when changing to a cluster that had no namespaces; however, it actually happens on any namespace change.

## Checklist
- [x] Investigated and inspected CI test results (ui-e2e failure is unrelated)

## Testing Performed

Manual testing