### PR TITLE
Indicate when select cluster has no namespaces

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.css
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.css
@@ -26,3 +26,8 @@
 [data-testid="network-graph-toolbar"] .react-select__menu {
     z-index: 250;
 }
+
+/* Restore grayed out background for disabled checkboxes */
+.network-graph-selector-bar .pf-c-check__input:disabled {
+    background-color: rgba(59, 59, 59, 0.3);
+}

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/NamespaceSelector.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/NamespaceSelector.tsx
@@ -59,6 +59,9 @@ function NamespaceSelector({
         [namespaces]
     );
 
+    const clusterSelected = Boolean(searchFilter?.Cluster);
+    const isEmptyCluster = clusterSelected && namespaces.length === 0;
+
     const deploymentLookupMap = getDeploymentLookupMap(deploymentsByNamespace);
 
     const onNamespaceSelect = (_, selected) => {
@@ -106,7 +109,9 @@ function NamespaceSelector({
             placeholderText={
                 <span>
                     <NamespaceIcon className="pf-u-mr-xs" />{' '}
-                    <span style={{ position: 'relative', top: '1px' }}>Namespaces</span>
+                    <span style={{ position: 'relative', top: '1px' }}>
+                        {isEmptyCluster ? 'No namespaces' : 'Namespaces'}
+                    </span>
                 </span>
             }
             toggleAriaLabel="Select namespaces"


### PR DESCRIPTION
## Description

From all-hands bug bash:
> If a cluster is empty (no namespaces) there should be something to let the user realize that. Currently Namespaces will simply not have any dropdown which may feel like it’s stuck or something.
> Consider feedback text appearing in the “Namespaces” selection, or some other form of feedback

Decision: show ‘No namespaces’ when the dropdown is disabled so it is obvious why disabled


## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

When no cluster selected, unsullied state
![Screen Shot 2023-01-31 at 3 24 33 PM](https://user-images.githubusercontent.com/715729/215875599-6dffa267-a31d-4676-837c-2c2de4c7c0f8.png)


Cluster with no namespaces is selected -> Namespace dropdown shows why it is disabled
![Screen Shot 2023-01-31 at 3 24 39 PM](https://user-images.githubusercontent.com/715729/215875695-a393949c-1462-487b-8baa-3e23fd1eee49.png)

Switch to a cluster with namespaces -> back to normal
![Screen Shot 2023-01-31 at 3 24 46 PM](https://user-images.githubusercontent.com/715729/215875777-05b878e7-e2cc-4a06-85b6-928a1e64f917.png)

Bonus: restore grayed background for disabled checkboxes
![Screen Shot 2023-01-31 at 3 24 54 PM](https://user-images.githubusercontent.com/715729/215875967-af4d2909-0a43-425e-8c85-431ad132babc.png)
 (which had been whited out by Tailwind reset)
