### PR TITLE
ROX-13754: Trim fields in Policy Wizard form before dryrun and save

### DIFF
--- a/ui/apps/platform/src/Containers/Policies/policies.utils.ts
+++ b/ui/apps/platform/src/Containers/Policies/policies.utils.ts
@@ -532,21 +532,21 @@ function trimPolicyScope(scope: PolicyScope) {
 }
 
 function trimClientWizardPolicy(policyUntrimmed: ClientPolicy): ClientPolicy {
-    const policyTrimmed = cloneDeep(policyUntrimmed);
+    const policy = cloneDeep(policyUntrimmed);
 
     // Policy details
 
-    policyTrimmed.name = policyUntrimmed.name.trim();
-    policyTrimmed.description = policyUntrimmed.description.trim();
-    policyTrimmed.rationale = policyUntrimmed.rationale.trim();
-    policyTrimmed.remediation = policyUntrimmed.remediation.trim();
+    policy.name = policy.name.trim();
+    policy.description = policy.description.trim();
+    policy.rationale = policy.rationale.trim();
+    policy.remediation = policy.remediation.trim();
 
     // Policy criteria
 
-    if (Array.isArray(policyTrimmed.policySections)) {
+    if (Array.isArray(policy.policySections)) {
         // for instead of forEach to work around no-param-reassign lint error.
-        for (let iSection = 0; iSection !== policyTrimmed.policySections.length; iSection += 1) {
-            const policySection = policyTrimmed.policySections[iSection];
+        for (let iSection = 0; iSection !== policy.policySections.length; iSection += 1) {
+            const policySection = policy.policySections[iSection];
 
             policySection.sectionName = policySection.sectionName.trim();
 
@@ -575,17 +575,17 @@ function trimClientWizardPolicy(policyUntrimmed: ClientPolicy): ClientPolicy {
 
     // Policy scope
 
-    if (Array.isArray(policyTrimmed.scope)) {
+    if (Array.isArray(policy.scope)) {
         // for instead of forEach to work around no-param-reassign lint error.
-        for (let i = 0; i !== policyTrimmed.scope.length; i += 1) {
-            trimPolicyScope(policyTrimmed.scope[i]);
+        for (let i = 0; i !== policy.scope.length; i += 1) {
+            trimPolicyScope(policy.scope[i]);
         }
     }
 
-    if (Array.isArray(policyTrimmed.excludedDeploymentScopes)) {
+    if (Array.isArray(policy.excludedDeploymentScopes)) {
         // for instead of forEach to work around no-param-reassign lint error.
-        for (let i = 0; i !== policyTrimmed.excludedDeploymentScopes.length; i += 1) {
-            const excludedDeploymentScope = policyTrimmed.excludedDeploymentScopes[i];
+        for (let i = 0; i !== policy.excludedDeploymentScopes.length; i += 1) {
+            const excludedDeploymentScope = policy.excludedDeploymentScopes[i];
 
             if (excludedDeploymentScope.scope) {
                 trimPolicyScope(excludedDeploymentScope.scope);
@@ -597,13 +597,13 @@ function trimClientWizardPolicy(policyUntrimmed: ClientPolicy): ClientPolicy {
         }
     }
 
-    if (Array.isArray(policyTrimmed.excludedImageNames)) {
-        policyTrimmed.excludedImageNames = policyTrimmed.excludedImageNames.map(
-            (excludedImageName) => excludedImageName.trim()
+    if (Array.isArray(policy.excludedImageNames)) {
+        policy.excludedImageNames = policy.excludedImageNames.map((excludedImageName) =>
+            excludedImageName.trim()
         );
     }
 
-    return policyTrimmed;
+    return policy;
 }
 
 export function getClientWizardPolicy(policy: Policy): ClientPolicy {
@@ -615,8 +615,8 @@ export function getClientWizardPolicy(policy: Policy): ClientPolicy {
 
 // Called before POST dryrunjob request and before POST or PUT policies request for Save.
 export function getServerPolicy(policyUntrimmed: ClientPolicy): Policy {
-    const policyTrimmed = trimClientWizardPolicy(policyUntrimmed);
-    let serverPolicy = postFormatExclusionField(policyTrimmed);
+    const policy = trimClientWizardPolicy(policyUntrimmed);
+    let serverPolicy = postFormatExclusionField(policy);
     serverPolicy = postFormatImageSigningPolicyGroup(serverPolicy as ClientPolicy);
     serverPolicy = postFormatNestedPolicyFields(serverPolicy as ClientPolicy);
     return serverPolicy;

--- a/ui/apps/platform/src/Containers/Policies/policies.utils.ts
+++ b/ui/apps/platform/src/Containers/Policies/policies.utils.ts
@@ -18,6 +18,7 @@ import {
     ClientPolicyValue,
     PolicyDeploymentExclusion,
     PolicyImageExclusion,
+    PolicyScope,
 } from 'types/policy.proto';
 import { SearchFilter } from 'types/search';
 import { ExtendedPageAction } from 'utils/queryStringUtils';
@@ -502,6 +503,108 @@ export function postFormatImageSigningPolicyGroup(policy: ClientPolicy): Policy 
     return serverPolicy;
 }
 
+// Impure function assumes caller has cloned the scope!
+function trimPolicyScope(scope: PolicyScope) {
+    /* eslint-disable no-param-reassign */
+    if (typeof scope.cluster === 'string') {
+        scope.cluster = scope.cluster.trim();
+    }
+
+    if (typeof scope.namespace === 'string') {
+        scope.namespace = scope.namespace.trim();
+    }
+
+    // TODO label key and value: make sure about empty string versus undefined.
+    /*
+    if (scope.label) {
+        if (typeof scope.label.key === 'string') {
+            scope.label.key = scope.label.key.trim();
+        }
+
+        if (typeof scope.label.value === 'string') {
+            scope.label.value = scope.label.value.trim();
+        }
+    }
+    */
+
+    return scope;
+}
+
+function trimClientWizardPolicy(policyUntrimmed: ClientPolicy): ClientPolicy {
+    const policyTrimmed = cloneDeep(policyUntrimmed);
+
+    // Policy details
+
+    policyTrimmed.name = policyUntrimmed.name.trim();
+    policyTrimmed.description = policyUntrimmed.description.trim();
+    policyTrimmed.rationale = policyUntrimmed.rationale.trim();
+    policyTrimmed.remediation = policyUntrimmed.remediation.trim();
+
+    // Policy criteria
+
+    if (Array.isArray(policyTrimmed.policySections)) {
+        // for instead of forEach to work around no-param-reassign lint error.
+        for (let iSection = 0; iSection !== policyTrimmed.policySections.length; iSection += 1) {
+            const policySection = policyTrimmed.policySections[iSection];
+
+            policySection.sectionName = policySection.sectionName.trim();
+
+            // TODO value: make sure about empty string versus undefined.
+            /*
+            if (Array.isArray(policySection.policyGroups)) {
+                for (let iGroup = 0; iGroup !== policySection.policyGroups.length; iGroup += 1) {
+                    const policyGroup = policySection.policyGroups[iGroup];
+
+                    if (Array.isArray(policyGroup.values)) {
+                        for (let iValue = 0; iValue !== policyGroup.values.length; iValue += 1) {
+                            const valueObject = policyGroup.values[iValue];
+
+                            if (typeof valueObject.value === 'string') {
+                                // TODO Investigate ValueObj for ClientPolicyValue.
+                                // TS2339 Property does not exist on type never.
+                                valueObject.value = valueObject.value.trim();
+                            }
+                        }
+                    }
+                }
+            }
+            */
+        }
+    }
+
+    // Policy scope
+
+    if (Array.isArray(policyTrimmed.scope)) {
+        // for instead of forEach to work around no-param-reassign lint error.
+        for (let i = 0; i !== policyTrimmed.scope.length; i += 1) {
+            trimPolicyScope(policyTrimmed.scope[i]);
+        }
+    }
+
+    if (Array.isArray(policyTrimmed.excludedDeploymentScopes)) {
+        // for instead of forEach to work around no-param-reassign lint error.
+        for (let i = 0; i !== policyTrimmed.excludedDeploymentScopes.length; i += 1) {
+            const excludedDeploymentScope = policyTrimmed.excludedDeploymentScopes[i];
+
+            if (excludedDeploymentScope.scope) {
+                trimPolicyScope(excludedDeploymentScope.scope);
+            }
+
+            if (typeof excludedDeploymentScope.name === 'string') {
+                excludedDeploymentScope.name = excludedDeploymentScope.name.trim();
+            }
+        }
+    }
+
+    if (Array.isArray(policyTrimmed.excludedImageNames)) {
+        policyTrimmed.excludedImageNames = policyTrimmed.excludedImageNames.map(
+            (excludedImageName) => excludedImageName.trim()
+        );
+    }
+
+    return policyTrimmed;
+}
+
 export function getClientWizardPolicy(policy: Policy): ClientPolicy {
     let formattedPolicy = preFormatExclusionField(policy);
     formattedPolicy = preFormatNestedPolicyFields(formattedPolicy);
@@ -509,8 +612,10 @@ export function getClientWizardPolicy(policy: Policy): ClientPolicy {
     return formattedPolicy;
 }
 
-export function getServerPolicy(policy: ClientPolicy): Policy {
-    let serverPolicy = postFormatExclusionField(policy);
+// Called before POST dryrunjob request and before POST or PUT policies request for Save.
+export function getServerPolicy(policyUntrimmed: ClientPolicy): Policy {
+    const policyTrimmed = trimClientWizardPolicy(policyUntrimmed);
+    let serverPolicy = postFormatExclusionField(policyTrimmed);
     serverPolicy = postFormatImageSigningPolicyGroup(serverPolicy as ClientPolicy);
     serverPolicy = postFormatNestedPolicyFields(serverPolicy as ClientPolicy);
     return serverPolicy;

--- a/ui/apps/platform/src/Containers/Policies/policies.utils.ts
+++ b/ui/apps/platform/src/Containers/Policies/policies.utils.ts
@@ -526,6 +526,7 @@ function trimPolicyScope(scope: PolicyScope) {
         }
     }
     */
+    /* eslint-enable no-param-reassign */
 
     return scope;
 }


### PR DESCRIPTION
## Description

Trim in `getServerPolicy` function which is called:
* Before POST /v1/dryrunjub request in Review Policy step.
* Before POST or PUT /v1/policies request on click Save button.

### Residue

1. Possibly add frontend validation for `name` length and allowed characters.
2. Policy criteria `value` deserves extra special care to make sure it does not regress.
3. Policy scope `key` and `value` of label deserve extra special care to make sure it does not regress.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

1. Temporary console.log to compare client and server policy.
2. See presence or absence of spaces:
    * in payload of POST /v1/policies/dryrunjob request at Step 5
    * in response of GET /v1/policies/id after save