### PR TITLE
Set min width for new network drawer

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.css
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.css
@@ -11,6 +11,11 @@
     height: calc(100vh - var(--pf-c-page__header--MinHeight) - var(--pf-c-page__header--MinHeight) - var(--pf-c-page__header--MinHeight));
 }
 
+.pf-c-drawer__panel.pf-m-resizable {
+    /* simple solution to prevent user from making sidebar too narrow */
+    min-width: 420px !important;
+}
+
 /* Create a stacking context that is higher than the context for the network-graph-toolbar component
    that is rendered below this toolbar, so that the hierarchy dropdowns will render above everything when open */
 .network-graph-selector-bar {

--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.css
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.css
@@ -11,9 +11,18 @@
     height: calc(100vh - var(--pf-c-page__header--MinHeight) - var(--pf-c-page__header--MinHeight) - var(--pf-c-page__header--MinHeight));
 }
 
+/* simple solution to prevent user from making sidebar too narrow */
 .pf-c-drawer__panel.pf-m-resizable {
-    /* simple solution to prevent user from making sidebar too narrow */
     min-width: 420px !important;
+}
+
+/* minimize the space used by the kabob menu as much as possible so that other columns do not become squished / truncated */
+.pf-c-drawer__panel .pf-c-table.pf-m-compact tr:not(.pf-c-table__expandable-row)>*:last-child {
+    padding-right: 0 !important;
+}
+.pf-c-drawer__panel .pf-c-dropdown__toggle.pf-m-plain:not(.pf-m-text) {
+    padding-left: var(--pf-global--spacer--xs) !important;
+    padding-right: var(--pf-global--spacer--xs) !important;
 }
 
 /* Create a stacking context that is higher than the context for the network-graph-toolbar component

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentDetails.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentDetails.tsx
@@ -55,7 +55,7 @@ function DetailSection({ title, children }) {
             onToggle={onToggle}
             toggleContent={
                 <TextContent>
-                    <Text component={TextVariants.h1} className="pf-u-font-size-xl">
+                    <Text component={TextVariants.h1} className="pf-u-font-size-lg">
                         {title}
                     </Text>
                 </TextContent>


### PR DESCRIPTION
## Description

Res ipsa loquitur

1. There is a minimum width to the resizeable side panel before the layout and content within it start to look broken.
2. The sidepanel space is fairly limited. To optimize readability, it would be valuable to minimize the space used by the kabob menu as much as possible so that other columns do not become squished / truncated. 
3. The header used in the Details section is the wrong size and inconsistent with the Flows and baseline panelsl. It should use the pf-u-font-size-lg class

## Checklist
- [x] Investigated and inspected CI test results (ui-e2e test failures are unrelated flakes)


## Testing Performed

No smaller than this
![Screen Shot 2023-01-31 at 4 30 27 PM](https://user-images.githubusercontent.com/715729/215888319-bb473380-2cb5-4b68-9105-3b887da8e31d.png)

Also, extra whitespace around kebab minimized, while still allowing some padding for accessible click target
![Screen Shot 2023-01-31 at 4 42 09 PM](https://user-images.githubusercontent.com/715729/215890535-d8afa37d-330e-4178-89af-5f9741d699eb.png)

Smaller subhead font size
![Screen Shot 2023-01-31 at 4 58 22 PM](https://user-images.githubusercontent.com/715729/215893351-d0630780-a625-4a7b-8f63-9175ab76387e.png)

