### PR TITLE
ROX-14619: fix metadata retrieval errors in scan time test

### DIFF
--- a/qa-tests-backend/src/test/groovy/ImageScanningTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageScanningTest.groovy
@@ -655,8 +655,8 @@ class ImageScanningTest extends BaseSpecification {
         where:
         image                                              | registry
         "registry.k8s.io/ip-masq-agent-amd64:v2.4.1"       | "gcr registry"
-        "docker.io/jenkins/jenkins:lts"                    | "docker registry"
-        "docker.io/jenkins/jenkins:2.220-alpine"           | "docker registry"
+        "quay.io/rhacs-eng/qa:alpine-3.16.0"               | "quay registry"
+        "quay.io/stackrox-io/scanner:2.27.3"               | "quay registry"
         "gke.gcr.io/heapster:v1.7.2"                       | "one from gke"
         "mcr.microsoft.com/dotnet/core/runtime:2.1-alpine" | "one from mcr"
     }


### PR DESCRIPTION
## Description

Update the DockerHub images to Quay.io images, as these tests may be failing due to DockerHub rate-limiting. The purpose of these tests is to ensure the "scan time" is not "null", so it really is not important which images are used.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

CI
