### PR TITLE
ROX-14670: Remove shadow number on Policy Wizard steps

### DIFF
--- a/ui/apps/platform/src/css/trumps.css
+++ b/ui/apps/platform/src/css/trumps.css
@@ -151,6 +151,11 @@ button.pf-c-tree-view__node {
     list-style: decimal;
 }
 
+/* Override the preceding override for PatternFly Wizard */
+.pf-c-page__main-section ol.pf-c-wizard__nav-list {
+    list-style: none;
+}
+
 /*
  * Override disabled checkbox styles when the input element is in a PF table
  */


### PR DESCRIPTION
## Description

Fix unintended side effect of #2611

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

### incorrect without override rule

stagingdb with `list-style: decimal;`
![decimal-stagingdb](https://user-images.githubusercontent.com/11862657/215891503-81bb4bd2-bfe6-4d69-b3fc-b674d694ea50.png)

local with `list-style: decimal;`
![decimal-local](https://user-images.githubusercontent.com/11862657/215891534-045c28d6-3376-4f74-a8a7-7cb6a5a229a9.png)

### correct with override rule

local with `list-style: none;`
![none-local](https://user-images.githubusercontent.com/11862657/215891559-d87af1cd-4150-4732-9486-a38a0fcafbbc.png)
