### PR TITLE
Network graph: PF polish bugs

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
@@ -220,7 +220,7 @@ function NetworkGraphPage() {
                 <Toolbar data-testid="network-graph-toolbar">
                     <ToolbarContent>
                         <ToolbarGroup variant="filter-group">
-                            <ToolbarItem spacer={{ default: 'spacerMd' }}>
+                            <ToolbarItem>
                                 <EdgeStateSelect
                                     edgeState={edgeState}
                                     setEdgeState={setEdgeState}
@@ -235,6 +235,7 @@ function NetworkGraphPage() {
                                 />
                             </ToolbarItem>
                         </ToolbarGroup>
+                        <Divider orientation={{ default: 'vertical' }} />
                         <ToolbarGroup className="pf-u-flex-grow-1">
                             <ToolbarItem className="pf-u-flex-grow-1">
                                 <NetworkSearch

--- a/ui/apps/platform/src/Containers/NetworkGraph/Topology.css
+++ b/ui/apps/platform/src/Containers/NetworkGraph/Topology.css
@@ -74,3 +74,20 @@
 .pf-c-tab-content[hidden] {
     display: none !important;
 }
+
+g.pf-topology__edge {
+    cursor: default;
+}
+
+.pf-topology-control-bar .pf-c-toolbar__group {
+    display: flex;
+    align-self: stretch;
+}
+
+.pf-topology-control-bar .pf-c-toolbar__item, .pf-topology-control-bar button {
+    height: 100%;
+}
+
+ul#edge-state-select {
+    width: 275px;
+}

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/EdgeStateSelect.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/EdgeStateSelect.tsx
@@ -28,6 +28,7 @@ function EdgeStateSelect({ edgeState, setEdgeState, isDisabled }: EdgeStateSelec
             onSelect={onSelect}
             selections={edgeState}
             isDisabled={isDisabled}
+            id="edge-state-select"
         >
             <SelectOption
                 value="active"


### PR DESCRIPTION
* made all buttons same height for the topology control bar (not sure why there weren't the appropriate height before since it looks like they should be according to the topology demo) 
* <img width="200" alt="image" src="https://user-images.githubusercontent.com/10412893/215895256-6f8facea-e0a5-401f-8be7-d768677aaf17.png">
* made cursor to be default on edge hover
* <img width="464" alt="image" src="https://user-images.githubusercontent.com/10412893/215895463-88b78b13-1593-4bf7-9c8a-01c16ea172b4.png">
* visually merged the filters and added a vertical bar between them and the deployment filters 
* <img width="355" alt="image" src="https://user-images.githubusercontent.com/10412893/215895614-53418bb4-1410-4fa7-ae05-25691bd66396.png">
* made the edge select dropdown container wider 
* <img width="305" alt="image" src="https://user-images.githubusercontent.com/10412893/215895754-626217c7-7003-4d13-baaa-e9843f665fba.png">


