### PR TITLE
ROX-13710: Dynamically set search modal position 

### DIFF
--- a/ui/apps/platform/src/Containers/Search/SearchModal.js
+++ b/ui/apps/platform/src/Containers/Search/SearchModal.js
@@ -75,8 +75,12 @@ class SearchModal extends Component {
 
 const SearchModalContainer = (props) => {
     const EnhancedSearchModal = onClickOutside(SearchModal);
+    const { top } = document.getElementById('main-page-container').getBoundingClientRect();
     return (
-        <div className="search-modal w-full z-md-300 pf-u-background-color-100">
+        <div
+            className="search-modal fixed w-full z-sm-200 pf-u-background-color-100"
+            style={{ top, height: `calc(100% - ${top}px)` }}
+        >
             <EnhancedSearchModal {...props} />
         </div>
     );

--- a/ui/apps/platform/src/app.tw.css
+++ b/ui/apps/platform/src/app.tw.css
@@ -242,13 +242,6 @@ h6 {
     width: 270px;
 }
 
-.search-modal {
-    position: absolute;
-    left: 0;
-    top: 76px;
-    height: calc(100% - 76px);
-}
-
 /* Collapsible CSS */
 
 .Collapsible__trigger.is-open + .Collapsible__contentOuter {


### PR DESCRIPTION
## Description

The search modal currently covers up all header menu items due to the z-index. 
<img src="https://user-images.githubusercontent.com/61400697/215905742-32e86146-6aff-4d10-8cf3-330d0de9eef9.png" width="600">


Decreasing the z-index resolves the menu issue, but if there's a certificate expiration banner, the static positioning causes incorrect search bar placement and it becomes covered
<img src="https://user-images.githubusercontent.com/61400697/215906836-4fe6b0e9-0dbc-4f57-bb5b-e7913ae74b98.png" width="600">


Option 1: Lower the z-index and set the position/height using the position of `#main-page-container`. ([Option 2 here](https://github.com/stackrox/stackrox/pull/4643))

Pros:
* Minimal change required
* Covers entire width of the page

Cons:
* Uses javascript to get the correct positioning
* Still makes nav toggle and stockrox logo in the header appear unusable

Result:
<img src="https://user-images.githubusercontent.com/61400697/215907636-9852f1f2-a492-46df-9bb7-a784ff995b64.png" width="600">


Higher effort potential alternatives:
* Switch the search modal to a search page like what @pedrottimark implemented in [ROX-12190](https://github.com/stackrox/stackrox/pull/2689)
* Place the side panel navigation state in Redux or Context, and move the search modal to `Body.tsx`. When the search modal is opened, it will close the side panel, but the side panel can still open alongside the search modal.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Manual testing performed
