### PR TITLE
ROX-13710: Move the search modal to the body

### DIFF
--- a/ui/apps/platform/src/Containers/MainPage/Body.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Body.tsx
@@ -1,6 +1,10 @@
 import React, { ReactElement } from 'react';
-import { Redirect, Route, Switch } from 'react-router-dom';
+import { Redirect, Route, Switch, useHistory } from 'react-router-dom';
 import { PageSection } from '@patternfly/react-core';
+import { createStructuredSelector } from 'reselect';
+import { selectors } from 'reducers';
+import { actions as globalSearchActions } from 'reducers/globalSearch';
+import { useDispatch, useSelector } from 'react-redux';
 
 import {
     mainPath,
@@ -35,6 +39,7 @@ import asyncComponent from 'Components/AsyncComponent';
 import PageNotFound from 'Components/PageNotFound';
 import PageTitle from 'Components/PageTitle';
 import ErrorBoundary from 'Containers/ErrorBoundary';
+import SearchModal from 'Containers/Search/SearchModal';
 import { HasReadAccess } from 'hooks/usePermissions';
 import { IsFeatureFlagEnabled } from 'hooks/useFeatureFlags';
 
@@ -94,7 +99,21 @@ type BodyProps = {
     isFeatureFlagEnabled: IsFeatureFlagEnabled;
 };
 
+const bodySelector = createStructuredSelector({
+    isGlobalSearchView: selectors.getGlobalSearchView,
+});
+
 function Body({ hasReadAccess, isFeatureFlagEnabled }: BodyProps): ReactElement {
+    const { isGlobalSearchView } = useSelector(bodySelector);
+    // Follow-up: Replace SearchModal with path like /main/search and component like GlobalSearchPage.
+    const dispatch = useDispatch();
+    const history = useHistory();
+    function onCloseGlobalSearchModal(toURL) {
+        dispatch(globalSearchActions.toggleGlobalSearchView());
+        if (typeof toURL === 'string') {
+            history.push(toURL);
+        }
+    }
     const { isDarkMode } = useTheme();
 
     const isSystemHealthPatternFlyEnabled = isFeatureFlagEnabled('ROX_SYSTEM_HEALTH_PF');
@@ -111,6 +130,7 @@ function Body({ hasReadAccess, isFeatureFlagEnabled }: BodyProps): ReactElement 
                 isDarkMode ? 'bg-base-0' : 'bg-base-100'
             }`}
         >
+            {isGlobalSearchView && <SearchModal onClose={onCloseGlobalSearchModal} />}
             <ErrorBoundary>
                 <Switch>
                     <Route path="/" exact render={() => <Redirect to={dashboardPath} />} />

--- a/ui/apps/platform/src/Containers/MainPage/MainPage.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/MainPage.tsx
@@ -1,16 +1,14 @@
 import React, { ReactElement } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import { createStructuredSelector } from 'reselect';
 import { Page } from '@patternfly/react-core';
 import { gql, useQuery } from '@apollo/client';
 
 import { selectors } from 'reducers';
-import { actions as globalSearchActions } from 'reducers/globalSearch';
 
 import LoadingSection from 'Components/PatternFly/LoadingSection';
 import Notifications from 'Containers/Notifications';
-import SearchModal from 'Containers/Search/SearchModal';
 import UnreachableWarning from 'Containers/UnreachableWarning';
 import AppWrapper from 'Containers/AppWrapper';
 import Body from 'Containers/MainPage/Body';
@@ -43,7 +41,6 @@ const CLUSTER_COUNT = gql`
 
 function MainPage(): ReactElement {
     const {
-        isGlobalSearchView,
         metadata = {
             stale: false,
         },
@@ -51,15 +48,7 @@ function MainPage(): ReactElement {
         serverState,
     } = useSelector(mainPageSelector);
 
-    // Follow-up: Replace SearchModal with path like /main/search and component like GlobalSearchPage.
-    const dispatch = useDispatch();
     const history = useHistory();
-    function onCloseGlobalSearchModal(toURL) {
-        dispatch(globalSearchActions.toggleGlobalSearchView());
-        if (typeof toURL === 'string') {
-            history.push(toURL);
-        }
-    }
 
     const { isFeatureFlagEnabled, isLoadingFeatureFlags } = useFeatureFlags();
     const { hasReadAccess, hasReadWriteAccess, isLoadingPermissions } = usePermissions();
@@ -116,7 +105,6 @@ function MainPage(): ReactElement {
                         isFeatureFlagEnabled={isFeatureFlagEnabled}
                     />
                 </Page>
-                {isGlobalSearchView && <SearchModal onClose={onCloseGlobalSearchModal} />}
             </div>
         </AppWrapper>
     );

--- a/ui/apps/platform/src/Containers/Search/SearchModal.js
+++ b/ui/apps/platform/src/Containers/Search/SearchModal.js
@@ -76,7 +76,7 @@ class SearchModal extends Component {
 const SearchModalContainer = (props) => {
     const EnhancedSearchModal = onClickOutside(SearchModal);
     return (
-        <div className="search-modal w-full z-md-300 pf-u-background-color-100">
+        <div className="z-md-300 absolute w-full h-full pf-u-background-color-100">
             <EnhancedSearchModal {...props} />
         </div>
     );

--- a/ui/apps/platform/src/app.tw.css
+++ b/ui/apps/platform/src/app.tw.css
@@ -242,13 +242,6 @@ h6 {
     width: 270px;
 }
 
-.search-modal {
-    position: absolute;
-    left: 0;
-    top: 76px;
-    height: calc(100% - 76px);
-}
-
 /* Collapsible CSS */
 
 .Collapsible__trigger.is-open + .Collapsible__contentOuter {


### PR DESCRIPTION
## Description

The search modal currently covers up all header menu items due to the z-index. 
<img src="https://user-images.githubusercontent.com/61400697/215905742-32e86146-6aff-4d10-8cf3-330d0de9eef9.png" width="600">


Decreasing the z-index resolves the menu issue, but if there's a certificate expiration banner, the static positioning causes incorrect search bar placement and it becomes covered
<img src="https://user-images.githubusercontent.com/61400697/215906836-4fe6b0e9-0dbc-4f57-bb5b-e7913ae74b98.png" width="600">


Option 2: Move the search modal to `Body.tsx` ([Option 1 here](https://github.com/stackrox/stackrox/pull/4641))
Pros:
* Menu items no longer hidden and the navigation toggle becomes usable while the search modal is open
* Simple in terms of css

Cons:
* When the search modal is open, the navigation menu remains open if it was already open. (could be seen as a pro or con)

Result:
<img src="https://user-images.githubusercontent.com/61400697/215907636-9852f1f2-a492-46df-9bb7-a784ff995b64.png" width="600">


Higher effort potential alternatives:
* Switch the search modal to a search page like what @pedrottimark implemented in [ROX-12190](https://github.com/stackrox/stackrox/pull/2689)
* Place the side panel navigation state in Redux or Context, and move the search modal to `Body.tsx`. When the search modal is opened, it will close the side panel, but the side panel can still open alongside the search modal.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Manual testing performed
