### PR TITLE
Network graph: PF - External to cluster url and page title fixes

### DIFF
--- a/ui/apps/platform/src/Containers/MainPage/Sidebar/NavigationSidebar.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Sidebar/NavigationSidebar.tsx
@@ -1,6 +1,14 @@
 import React, { ReactElement } from 'react';
 import { useLocation, Location } from 'react-router-dom';
-import { Nav, NavList, NavExpandable, PageSidebar } from '@patternfly/react-core';
+import {
+    Nav,
+    NavList,
+    NavExpandable,
+    PageSidebar,
+    Flex,
+    FlexItem,
+    Badge,
+} from '@patternfly/react-core';
 
 import { IsFeatureFlagEnabled } from 'hooks/useFeatureFlags';
 import { HasReadAccess } from 'hooks/usePermissions';
@@ -80,7 +88,20 @@ function NavigationSidebar({
                     <LeftNavItem
                         isActive={location.pathname.includes(networkBasePathPF)}
                         path={networkBasePathPF}
-                        title={basePathToLabelMap[networkBasePathPF]}
+                        title={
+                            <Flex>
+                                <FlexItem>Network Graph</FlexItem>
+                                <FlexItem>
+                                    <Badge
+                                        style={{
+                                            backgroundColor: 'var(--pf-global--palette--cyan-400)',
+                                        }}
+                                    >
+                                        2.0 preview
+                                    </Badge>
+                                </FlexItem>
+                            </Flex>
+                        }
                     />
                 )}
                 <LeftNavItem

--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
@@ -188,7 +188,7 @@ function NetworkGraphPage() {
 
     return (
         <>
-            <PageTitle title="Network Graph" />
+            <PageTitle title="Network Graph (2.0 preview)" />
             <PageSection variant="light" padding={{ default: 'noPadding' }}>
                 <Toolbar
                     className="network-graph-selector-bar"

--- a/ui/apps/platform/src/Containers/NetworkGraph/TopologyComponent.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/TopologyComponent.tsx
@@ -41,7 +41,7 @@ export const UrlDetailType = {
     DEPLOYMENT: 'deployment',
     CIDR_BLOCK: 'cidr',
     EXTERNAL_ENTITIES: 'internet',
-    EXTERNAL: 'external',
+    EXTERNAL_GROUP: 'external',
 } as const;
 export type UrlDetailTypeKey = keyof typeof UrlDetailType;
 export type UrlDetailTypeValue = typeof UrlDetailType[UrlDetailTypeKey];

--- a/ui/apps/platform/src/constants/useCaseTypes.js
+++ b/ui/apps/platform/src/constants/useCaseTypes.js
@@ -27,6 +27,7 @@ const useCaseTypes = {
     VIOLATIONS: 'violations',
     POLICIES: 'policies',
     NETWORK: 'network',
+    NETWORK_GRAPH: 'network-graph',
     USER: 'user',
 };
 

--- a/ui/apps/platform/src/messages/useCase.js
+++ b/ui/apps/platform/src/messages/useCase.js
@@ -6,6 +6,7 @@ const legacyPageLabels = {
     [useCaseTypes.VIOLATIONS]: 'Violations',
     [useCaseTypes.POLICIES]: 'System Policies',
     [useCaseTypes.NETWORK]: 'Network Graph',
+    [useCaseTypes.NETWORK_GRAPH]: 'Network Graph',
     [useCaseTypes.USER]: 'User Profile',
     [useCaseTypes.ACCESS_CONTROL]: 'Access Control',
 };

--- a/ui/apps/platform/src/routePaths.js
+++ b/ui/apps/platform/src/routePaths.js
@@ -151,16 +151,7 @@ const vulnManagementPathToLabelMap = {
 export const basePathToLabelMap = {
     [dashboardPath]: 'Dashboard',
     [networkBasePath]: 'Network Graph (1.0)',
-    [networkBasePathPF]: (
-        <Flex>
-            <FlexItem>Network Graph</FlexItem>
-            <FlexItem>
-                <Badge style={{ backgroundColor: 'var(--pf-global--palette--cyan-400)' }}>
-                    2.0 preview
-                </Badge>
-            </FlexItem>
-        </Flex>
-    ),
+    [networkBasePathPF]: 'Network Graph (2.0 preview)',
     [violationsBasePath]: 'Violations',
     [complianceBasePath]: 'Compliance',
     ...vulnManagementPathToLabelMap,

--- a/ui/apps/platform/src/routePaths.js
+++ b/ui/apps/platform/src/routePaths.js
@@ -2,9 +2,6 @@
  * Application route paths constants.
  */
 
-import React from 'react';
-import { Badge, Flex, FlexItem } from '@patternfly/react-core';
-
 import { resourceTypes, standardEntityTypes, rbacConfigTypes } from 'constants/entityTypes';
 
 export const mainPath = '/main';


### PR DESCRIPTION
* adding proper page titles to NG 2.0
* going to a namespace in the NG and hitting refresh should not show `undefined` momentarily in the page title
* going to the NG and refreshing the page (on an unselected state) should not show `[object Object]` in the page title
* clicking on `External to cluster` group node in the NG should now show `https://localhost:3000/main/network-graph/external/External%20to%20cluster?s[Cluster]=production&s[Namespace][0]=stackrox`