### PR TITLE
Fix vuln report using collections migration

### DIFF
--- a/migrator/migrations/m_171_to_m_172_move_scope_to_collection_in_report_configurations/migration.go
+++ b/migrator/migrations/m_171_to_m_172_move_scope_to_collection_in_report_configurations/migration.go
@@ -26,6 +26,8 @@ import (
 const (
 	startSeqNum = 171
 
+	accessScopeIDPrefix = "io.stackrox.authz.accessscope."
+
 	embeddedCollectionTemplate = "System-generated embedded collection %d for scope <%s>"
 	rootCollectionTemplate     = "System-generated root collection for scope <%s>"
 )
@@ -45,8 +47,14 @@ var (
 		},
 	}
 
-	scopeIDToConfigNames = make(map[string][]string)
-	idGenerator          func(collectionName string) string
+	scopeIDToConfigs = make(map[string][]*storage.ReportConfiguration)
+	idGenerator      func(collectionName string) string
+
+	// Copied from migrator/migrations/n_52_to_n_53_postgres_simple_access_scopes/migration.go
+	accessScopeIDMapping = map[string]string{
+		"denyall":      "ffffffff-ffff-fff4-f5ff-fffffffffffe",
+		"unrestricted": "ffffffff-ffff-fff4-f5ff-ffffffffffff",
+	}
 )
 
 func buildEmbeddedCollection(scopeName string, index int, rules []*storage.SelectorRule) *storage.ResourceCollection {
@@ -167,26 +175,31 @@ func getCollectionsToEmbed(scope *storage.SimpleAccessScope) ([]*storage.Resourc
 // Creates embedded and root collections for the access scope with ID scopeID.
 // Adds the embedded and root collections to the collection store.
 func createCollectionsForScope(ctx context.Context, scopeID string,
-	accessScopeStore accessScopePostgres.Store, collectionStore collectionPostgres.Store) error {
-	scope, found, err := accessScopeStore.Get(ctx, scopeID)
+	accessScopeStore accessScopePostgres.Store, collectionStore collectionPostgres.Store) (string, bool) {
+	newScopeID, err := getNewRoleAccessScopeID(scopeID)
+	if err != nil {
+		log.Error(errorWithResolutionMsg(errors.Wrapf(err, "Report configuration had an invalid scope id %s.", scopeID), scopeID))
+		return "", false
+	}
+	scope, found, err := accessScopeStore.Get(ctx, newScopeID)
 	if err != nil {
 		log.Error(errorWithResolutionMsg(errors.Wrapf(err, "Failed to fetch scope with id %s. ", scopeID), scopeID))
-		return nil
+		return "", false
 	}
 	if !found {
 		log.Error(errorWithResolutionMsg(errors.Errorf("Scope with id %s not found.", scopeID), scopeID))
-		return nil
+		return "", false
 	}
 
 	collectionsToEmbed, err := getCollectionsToEmbed(scope)
 	if err != nil {
 		log.Error(errorWithResolutionMsg(errors.Wrapf(err, "Failed to create collections for scope <%s>", scope.GetName()), scopeID))
-		return nil
+		return "", false
 	}
 	err = collectionStore.UpsertMany(ctx, collectionsToEmbed)
 	if err != nil {
 		log.Error(errorWithResolutionMsg(errors.Wrapf(err, "Failed to create collections for scope <%s>", scope.GetName()), scopeID))
-		return nil
+		return "", false
 	}
 	embeddedCollections := make([]*storage.ResourceCollection_EmbeddedResourceCollection, 0, len(collectionsToEmbed))
 	for _, collection := range collectionsToEmbed {
@@ -196,7 +209,7 @@ func createCollectionsForScope(ctx context.Context, scopeID string,
 	}
 	timeNow := protoconv.ConvertTimeToTimestamp(time.Now())
 	rootCollection := &storage.ResourceCollection{
-		Id:                  scopeID,
+		Id:                  newScopeID,
 		Name:                fmt.Sprintf(rootCollectionTemplate, scope.GetName()),
 		CreatedAt:           timeNow,
 		LastUpdated:         timeNow,
@@ -204,8 +217,9 @@ func createCollectionsForScope(ctx context.Context, scopeID string,
 	}
 	if err := collectionStore.Upsert(ctx, rootCollection); err != nil {
 		log.Error(errorWithResolutionMsg(errors.Wrapf(err, "Failed to create collections for scope <%s>", scope.GetName()), scopeID))
+		return "", false
 	}
-	return nil
+	return newScopeID, true
 }
 
 func moveScopesInReportsToCollections(gormDB *gorm.DB, db *pgxpool.Pool) error {
@@ -215,29 +229,59 @@ func moveScopesInReportsToCollections(gormDB *gorm.DB, db *pgxpool.Pool) error {
 	accessScopeStore := accessScopePostgres.New(db)
 	collectionStore := collectionPostgres.New(db)
 
+	allConfigs := make(map[string]*storage.ReportConfiguration)
 	err := reportConfigStore.Walk(ctx, func(reportConfig *storage.ReportConfiguration) error {
-		scopeIDToConfigNames[reportConfig.GetScopeId()] = append(scopeIDToConfigNames[reportConfig.GetScopeId()], reportConfig.GetName())
+		scopeIDToConfigs[reportConfig.GetScopeId()] = append(scopeIDToConfigs[reportConfig.GetScopeId()], reportConfig)
+		allConfigs[reportConfig.GetId()] = reportConfig
 		return nil
 	})
 	if err != nil {
 		return err
 	}
 
-	for scopeID := range scopeIDToConfigNames {
-		err = createCollectionsForScope(ctx, scopeID, accessScopeStore, collectionStore)
-		if err != nil {
-			return err
+	for scopeID := range scopeIDToConfigs {
+		newScopeID, created := createCollectionsForScope(ctx, scopeID, accessScopeStore, collectionStore)
+		if created && newScopeID != scopeID {
+			// Update each of the reports with the new scope id.
+			// This is required since the scope id may have changed between RocksDB and Postgres.
+			// See migration n52_to_n53
+			configs := scopeIDToConfigs[scopeID]
+			for _, config := range configs {
+				config.ScopeId = newScopeID
+				// Do it one at a time even though it's not as performant so that at least some reports will get migrated
+				// even if any fail. It should be rare though.
+				if err := reportConfigStore.Upsert(ctx, config); err != nil {
+					log.Error(errorWithResolutionMsg(errors.Wrap(err, "Failed to update report configuration with collections to new scope"), scopeID))
+				}
+			}
 		}
 	}
 	return err
 }
 
 func errorWithResolutionMsg(err error, scopeID string) string {
+	var scopeNames []string
+	for _, config := range scopeIDToConfigs[scopeID] {
+		scopeNames = append(scopeNames, config.GetName())
+	}
 	return err.Error() + "\n" +
 		" The scope is attached to the following report configurations: " +
-		"[" + strings.Join(scopeIDToConfigNames[scopeID], ", ") + "]; " +
+		"[" + strings.Join(scopeNames, ", ") + "]; " +
 		"Please manually create an equivalent collection and attach it to the listed report configurations. " +
 		"Note that reports will not function correctly until a collection is attached."
+}
+
+// Copied from migrator/migrations/n_52_to_n_53_postgres_simple_access_scopes/migration.go
+func getNewRoleAccessScopeID(scopeID string) (string, error) {
+	roleAccessScopeID := strings.TrimPrefix(scopeID, accessScopeIDPrefix)
+	if replacement, found := accessScopeIDMapping[roleAccessScopeID]; found {
+		roleAccessScopeID = replacement
+	}
+	_, accessIDParseErr := uuid.FromString(roleAccessScopeID)
+	if accessIDParseErr != nil {
+		return "", accessIDParseErr
+	}
+	return roleAccessScopeID, nil
 }
 
 func init() {

--- a/migrator/migrations/m_171_to_m_172_move_scope_to_collection_in_report_configurations/migration.go
+++ b/migrator/migrations/m_171_to_m_172_move_scope_to_collection_in_report_configurations/migration.go
@@ -178,27 +178,27 @@ func createCollectionsForScope(ctx context.Context, scopeID string,
 	accessScopeStore accessScopePostgres.Store, collectionStore collectionPostgres.Store) (string, bool) {
 	newScopeID, err := getNewRoleAccessScopeID(scopeID)
 	if err != nil {
-		log.Error(errorWithResolutionMsg(errors.Wrapf(err, "Report configuration had an invalid scope id %s.", scopeID), scopeID))
+		log.Error(errorWithResolutionMsg(errors.Wrapf(err, "Report configuration had an invalid scope id %q.", scopeID), scopeID))
 		return "", false
 	}
 	scope, found, err := accessScopeStore.Get(ctx, newScopeID)
 	if err != nil {
-		log.Error(errorWithResolutionMsg(errors.Wrapf(err, "Failed to fetch scope with id %s. ", scopeID), scopeID))
+		log.Error(errorWithResolutionMsg(errors.Wrapf(err, "Failed to fetch scope with id %q. ", scopeID), scopeID))
 		return "", false
 	}
 	if !found {
-		log.Error(errorWithResolutionMsg(errors.Errorf("Scope with id %s not found.", scopeID), scopeID))
+		log.Error(errorWithResolutionMsg(errors.Errorf("Scope with id %q not found.", scopeID), scopeID))
 		return "", false
 	}
 
 	collectionsToEmbed, err := getCollectionsToEmbed(scope)
 	if err != nil {
-		log.Error(errorWithResolutionMsg(errors.Wrapf(err, "Failed to create collections for scope <%s>", scope.GetName()), scopeID))
+		log.Error(errorWithResolutionMsg(errors.Wrapf(err, "Failed to create collections for scope <%q>", scope.GetName()), scopeID))
 		return "", false
 	}
 	err = collectionStore.UpsertMany(ctx, collectionsToEmbed)
 	if err != nil {
-		log.Error(errorWithResolutionMsg(errors.Wrapf(err, "Failed to create collections for scope <%s>", scope.GetName()), scopeID))
+		log.Error(errorWithResolutionMsg(errors.Wrapf(err, "Failed to create collections for scope <%q>", scope.GetName()), scopeID))
 		return "", false
 	}
 	embeddedCollections := make([]*storage.ResourceCollection_EmbeddedResourceCollection, 0, len(collectionsToEmbed))
@@ -216,7 +216,7 @@ func createCollectionsForScope(ctx context.Context, scopeID string,
 		EmbeddedCollections: embeddedCollections,
 	}
 	if err := collectionStore.Upsert(ctx, rootCollection); err != nil {
-		log.Error(errorWithResolutionMsg(errors.Wrapf(err, "Failed to create collections for scope <%s>", scope.GetName()), scopeID))
+		log.Error(errorWithResolutionMsg(errors.Wrapf(err, "Failed to create collections for scope <%q>", scope.GetName()), scopeID))
 		return "", false
 	}
 	return newScopeID, true

--- a/migrator/migrations/m_171_to_m_172_move_scope_to_collection_in_report_configurations/migration.go
+++ b/migrator/migrations/m_171_to_m_172_move_scope_to_collection_in_report_configurations/migration.go
@@ -229,10 +229,8 @@ func moveScopesInReportsToCollections(gormDB *gorm.DB, db *pgxpool.Pool) error {
 	accessScopeStore := accessScopePostgres.New(db)
 	collectionStore := collectionPostgres.New(db)
 
-	allConfigs := make(map[string]*storage.ReportConfiguration)
 	err := reportConfigStore.Walk(ctx, func(reportConfig *storage.ReportConfiguration) error {
 		scopeIDToConfigs[reportConfig.GetScopeId()] = append(scopeIDToConfigs[reportConfig.GetScopeId()], reportConfig)
-		allConfigs[reportConfig.GetId()] = reportConfig
 		return nil
 	})
 	if err != nil {
@@ -260,13 +258,13 @@ func moveScopesInReportsToCollections(gormDB *gorm.DB, db *pgxpool.Pool) error {
 }
 
 func errorWithResolutionMsg(err error, scopeID string) string {
-	var scopeNames []string
+	var configNames []string
 	for _, config := range scopeIDToConfigs[scopeID] {
-		scopeNames = append(scopeNames, config.GetName())
+		configNames = append(configNames, config.GetName())
 	}
 	return err.Error() + "\n" +
 		" The scope is attached to the following report configurations: " +
-		"[" + strings.Join(scopeNames, ", ") + "]; " +
+		"[" + strings.Join(configNames, ", ") + "]; " +
 		"Please manually create an equivalent collection and attach it to the listed report configurations. " +
 		"Note that reports will not function correctly until a collection is attached."
 }

--- a/migrator/migrations/m_171_to_m_172_move_scope_to_collection_in_report_configurations/migration_test.go
+++ b/migrator/migrations/m_171_to_m_172_move_scope_to_collection_in_report_configurations/migration_test.go
@@ -19,9 +19,11 @@ import (
 )
 
 const (
-	id0 = "A161527B-D34F-42B8-A783-23E39B4DE15A"
-	id1 = "DC04A5F8-6018-46E5-B590-87325FBF1945"
-	id2 = "9C91FA2B-AE95-4C74-98A7-17AF76CC8209"
+	id0   = "A161527B-D34F-42B8-A783-23E39B4DE15A"
+	id1   = "DC04A5F8-6018-46E5-B590-87325FBF1945"
+	id2   = "9C91FA2B-AE95-4C74-98A7-17AF76CC8209"
+	id3   = "DE69BC7B-6331-4125-BC99-23877820DC74"
+	badID = "thisisnotauuid"
 )
 
 var (
@@ -109,23 +111,52 @@ var (
 				},
 			},
 		},
+		{
+			Id:   id3,
+			Name: id3,
+			Rules: &storage.SimpleAccessScope_Rules{
+				IncludedNamespaces: []*storage.SimpleAccessScope_Rules_Namespace{
+					{
+						ClusterName:   "c9",
+						NamespaceName: "ns9",
+					},
+				},
+			},
+		},
 	}
 
 	configIDToReportConfig = map[string]*storage.ReportConfiguration{
 		"config0": {
-			Id:      "config0",
-			Name:    "migratable",
-			ScopeId: id0,
+			Id:   "config0",
+			Name: "migratable",
+			// Report config should have the un-migrated SAC ID due to the original migration (n52_to_n53) not updating it
+			ScopeId: accessScopeIDPrefix + id0,
 		},
 		"config1": {
 			Id:      "config1",
 			Name:    "migratable",
-			ScopeId: id1,
+			ScopeId: accessScopeIDPrefix + id1,
 		},
 		"config2": {
-			Id:      "config2",
+			Id:   "config2",
+			Name: "migratable",
+			// This is a scope that was created after SAC migration, so it should've always been an UUID
+			ScopeId: id3,
+		},
+		"config3": {
+			Id:      "config3",
 			Name:    "unmigratable",
-			ScopeId: id2,
+			ScopeId: accessScopeIDPrefix + id2,
+		},
+		"config4": {
+			Id:      "config4",
+			Name:    "unmigratable",
+			ScopeId: badID,
+		},
+		"config5": {
+			Id:      "config5",
+			Name:    "unmigratable",
+			ScopeId: accessScopeIDPrefix + badID,
 		},
 	}
 
@@ -303,6 +334,37 @@ var (
 				{Id: fmt.Sprintf(embeddedCollectionTemplate, 5, id1)},
 			},
 		},
+		fmt.Sprintf(embeddedCollectionTemplate, 0, id3): {
+			Id:   fmt.Sprintf(embeddedCollectionTemplate, 0, id3),
+			Name: fmt.Sprintf(embeddedCollectionTemplate, 0, id3),
+			ResourceSelectors: []*storage.ResourceSelector{
+				{
+					Rules: []*storage.SelectorRule{
+						{
+							FieldName: search.Cluster.String(),
+							Operator:  storage.BooleanOperator_OR,
+							Values: []*storage.RuleValue{
+								{Value: "c9", MatchType: storage.MatchType_EXACT},
+							},
+						},
+						{
+							FieldName: search.Namespace.String(),
+							Operator:  storage.BooleanOperator_OR,
+							Values: []*storage.RuleValue{
+								{Value: "ns9", MatchType: storage.MatchType_EXACT},
+							},
+						},
+					},
+				},
+			},
+		},
+		fmt.Sprintf(rootCollectionTemplate, id3): {
+			Id:   id3,
+			Name: fmt.Sprintf(rootCollectionTemplate, id3),
+			EmbeddedCollections: []*storage.ResourceCollection_EmbeddedResourceCollection{
+				{Id: fmt.Sprintf(embeddedCollectionTemplate, 0, id3)},
+			},
+		},
 	}
 )
 
@@ -331,7 +393,7 @@ func (s *reportConfigsMigrationTestSuite) SetupTest() {
 
 func (s *reportConfigsMigrationTestSuite) TearDownTest() {
 	s.db.Teardown(s.T())
-	scopeIDToConfigNames = make(map[string][]string)
+	scopeIDToConfigs = make(map[string][]*storage.ReportConfiguration)
 }
 
 func (s *reportConfigsMigrationTestSuite) TestMigration() {
@@ -366,19 +428,26 @@ func (s *reportConfigsMigrationTestSuite) TestMigration() {
 
 	// check all migratable reports have migrated and unmigratable reports remain the same
 	err = s.reportConfigStore.Walk(ctx, func(config *storage.ReportConfiguration) error {
-		// Generated root collection will have the same ID as the scope that was attached to the report before migration.
-		// So, we can use the same config.scopeID to get both the access scope and the collection
-		scope, found, err := s.accessScopeStore.Get(ctx, config.GetScopeId())
-		s.NoError(err)
-		s.True(found)
-
 		collection, found, err := s.collectionStore.Get(ctx, config.GetScopeId())
 		s.NoError(err)
 		if config.GetName() == "migratable" {
 			s.True(found)
+
+			// The scopeId in the report should be updated to remove the prefix and just be a UUID (same as in n52_to_n53).
+			// The generated root collection, original scope and this now converted scopeId should all be the same.
+			// So, we can use the same config.scopeID to get both the access scope and the collection
+			scope, scopeFound, err := s.accessScopeStore.Get(ctx, config.GetScopeId())
+			s.NoError(err)
+			s.True(scopeFound)
+
 			s.Equal(fmt.Sprintf(rootCollectionTemplate, scope.GetName()), collection.GetName())
 		} else {
 			s.False(found)
+
+			// If migration fails, the scopeID is not updated at all
+			_, scopeFound, err := s.accessScopeStore.Get(ctx, config.GetScopeId())
+			s.Error(err)
+			s.False(scopeFound)
 		}
 		return nil
 	})

--- a/migrator/migrations/m_171_to_m_172_move_scope_to_collection_in_report_configurations/reportConfigurationPostgresStore/postgres_plugin.go
+++ b/migrator/migrations/m_171_to_m_172_move_scope_to_collection_in_report_configurations/reportConfigurationPostgresStore/postgres_plugin.go
@@ -20,7 +20,7 @@ import (
 
 // This file is a partial copy of central/reportconfigurations/store/postgres/store.go
 // in the state it had when the migration was written.
-// Only the relevant functions (UpsertMany, DeleteMany and Walk) are kept.
+// Only the relevant functions (Upsert, UpsertMany, DeleteMany and Walk) are kept.
 // The kept functions are stripped from the scoped access control checks.
 
 const (
@@ -44,6 +44,7 @@ var (
 
 // Store is the interface to interact with the storage for storage.ReportConfiguration
 type Store interface {
+	Upsert(ctx context.Context, obj *storage.ReportConfiguration) error
 	UpsertMany(ctx context.Context, objs []*storage.ReportConfiguration) error
 	DeleteMany(ctx context.Context, identifiers []string) error
 
@@ -219,6 +220,13 @@ func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.ReportConfigura
 //// Helper functions - END
 
 //// Interface functions
+
+// Upsert saves the current state of an object in storage.
+func (s *storeImpl) Upsert(ctx context.Context, obj *storage.ReportConfiguration) error {
+	return pgutils.Retry(func() error {
+		return s.upsert(ctx, obj)
+	})
+}
 
 // UpsertMany saves the state of multiple objects in the storage.
 func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ReportConfiguration) error {


### PR DESCRIPTION
## Description

Simple access scopes were migrated in n_52_to_n_53 to change their IDs to UUID format. However, the report configurations that attached the SACs were not updated with new scopeIDs. This fix tries to add new scopeIDs (which are same as equivalent collection IDs) to report config. If a scopeID cannot be migrated, it logs error and moves to another report config.

## Checklist
- [X] Investigated and inspected CI test results
- [X] Unit test and regression tests added
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

- Added unit tests
- Manually tested by creating report configs in v3.72 with RocksDB, then migrated to v3.73.x and enabled Postgres. Verified that collections were generated, report configs were correctly migrated and errors logged for ones that cannot be migrated.
- Manually tested by creating report configs in v3.73.x's older with Postgres to a newer commit in v3.73.x with Postgres. Verified that collections were generated, report configs were correctly migrated and error logged for ones that cannot be migrated.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
