### PR TITLE
Always show value of the ROX_POSTGRES_DATASTORE flag in feature flag API

### DIFF
--- a/central/featureflags/service/service_impl.go
+++ b/central/featureflags/service/service_impl.go
@@ -37,7 +37,7 @@ func (s *serviceImpl) GetFeatureFlags(context.Context, *v1.Empty) (*v1.GetFeatur
 	}
 
 	// HACK: Inject in the postgres env var as a feature flag response so that the UI can work as-is without modifications
-	// TODO: When GA'ing postgresm remove this hack (and all conditional checks). https://issues.redhat.com/browse/ROX-12848
+	// TODO: When GA'ing postgres remove this hack (and all conditional checks). https://issues.redhat.com/browse/ROX-12848
 	resp.FeatureFlags = append(resp.FeatureFlags, &v1.FeatureFlag{
 		Name:    "Enable Postgres Datastore",
 		EnvVar:  env.PostgresDatastoreEnabled.EnvVar(),

--- a/central/featureflags/service/service_impl.go
+++ b/central/featureflags/service/service_impl.go
@@ -38,13 +38,11 @@ func (s *serviceImpl) GetFeatureFlags(context.Context, *v1.Empty) (*v1.GetFeatur
 
 	// HACK: Inject in the postgres env var as a feature flag response so that the UI can work as-is without modifications
 	// TODO: When GA'ing postgresm remove this hack (and all conditional checks). https://issues.redhat.com/browse/ROX-12848
-	if env.PostgresDatastoreEnabled.BooleanSetting() {
-		resp.FeatureFlags = append(resp.FeatureFlags, &v1.FeatureFlag{
-			Name:    "Enable Postgres Datastore",
-			EnvVar:  env.PostgresDatastoreEnabled.EnvVar(),
-			Enabled: true,
-		})
-	}
+	resp.FeatureFlags = append(resp.FeatureFlags, &v1.FeatureFlag{
+		Name:    "Enable Postgres Datastore",
+		EnvVar:  env.PostgresDatastoreEnabled.EnvVar(),
+		Enabled: env.PostgresDatastoreEnabled.BooleanSetting(),
+	})
 
 	sort.Slice(resp.FeatureFlags, func(i, j int) bool {
 		return resp.FeatureFlags[i].GetName() < resp.FeatureFlags[j].GetName()

--- a/tests/feature_flag_test.go
+++ b/tests/feature_flag_test.go
@@ -45,10 +45,8 @@ func TestFeatureFlagSettings(t *testing.T) {
 		actualFlagVals[flag.GetEnvVar()] = flag.GetEnabled()
 	}
 
-	// TODO(ROX-12848): Remove this with environment variable
-	if env.PostgresDatastoreEnabled.BooleanSetting() {
-		delete(actualFlagVals, env.PostgresDatastoreEnabled.EnvVar())
-	}
+	// TODO(ROX-12848 and ROX-12848): Remove this with environment variable
+	delete(actualFlagVals, env.PostgresDatastoreEnabled.EnvVar())
 
 	assert.Equal(t, expectedFlagVals, actualFlagVals, "mismatch between expected and actual feature flag settings")
 }


### PR DESCRIPTION
## Description

Feature flag API apparently shows all values, even disabled values in the API response

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
