### PR TITLE
Mitigate panic of compliance monitoring ports

### DIFF
--- a/compliance/collection/main.go
+++ b/compliance/collection/main.go
@@ -252,9 +252,11 @@ func initializeStream(ctx context.Context, cli sensor.ComplianceServiceClient) (
 func main() {
 	log.Infof("Running StackRox Version: %s", version.GetMainVersion())
 
-	// Start the prometheus metrics server
-	metrics.NewDefaultHTTPServer().RunForever()
-	metrics.GatherThrottleMetricsForever(metrics.ComplianceSubsystem.String())
+	if features.RHCOSNodeScanning.Enabled() {
+		// Start the prometheus metrics server
+		metrics.NewDefaultHTTPServer().RunForever()
+		metrics.GatherThrottleMetricsForever(metrics.ComplianceSubsystem.String())
+	}
 
 	clientconn.SetUserAgent(clientconn.Compliance)
 

--- a/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml
@@ -91,8 +91,10 @@ spec:
       - command:
         - stackrox/compliance
         env:
+        {{- if ._rox.collector.exposeMonitoring }}
         - name: ROX_METRICS_PORT
           value: ":9091"
+        {{- end }}
         - name: ROX_NODE_NAME
           valueFrom:
             fieldRef:


### PR DESCRIPTION
## Description

Let's wrap the compliance monitoring with feature flag, as it does not target 3.74. We will fix that for 4.0.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))


## Testing Performed

- None yet
