### PR TITLE
ROX-14657 Add inline errors for collection form fields

### DIFF
--- a/ui/apps/platform/src/Components/PatternFly/SeverityLabelsList.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/SeverityLabelsList.tsx
@@ -8,10 +8,21 @@ export type SeverityLabelsListProps = {
     severities: VulnerabilitySeverity[];
 };
 
+const vulnerabilitySeverityLabelColors = {
+    CRITICAL_VULNERABILITY_SEVERITY: 'red',
+    IMPORTANT_VULNERABILITY_SEVERITY: 'orange',
+    MODERATE_VULNERABILITY_SEVERITY: 'gold',
+    LOW_VULNERABILITY_SEVERITY: 'grey',
+} as const;
+
 function SeverityLabelsList({ severities }: SeverityLabelsListProps): ReactElement {
     if (severities?.length > 0) {
         const severityLabels = severities.map((fixValue) => (
-            <Label className="pf-u-mr-sm" color="red" isCompact>
+            <Label
+                className="pf-u-mr-sm"
+                color={vulnerabilitySeverityLabelColors[fixValue]}
+                isCompact
+            >
                 {vulnerabilitySeverityLabels[fixValue]}
             </Label>
         ));

--- a/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
@@ -106,10 +106,10 @@ function yupLabelRuleObject({ field }: ByLabelResourceSelector) {
                         yup.object().shape({
                             value: yup
                                 .string()
-                                .required()
+                                .required('This field can not be empty')
                                 .test(
                                     'label-value-k8s-format',
-                                    'Label values must be valid k8s labels',
+                                    'Labels must be valid k8s labels in the form: key=value',
                                     (val) => {
                                         const parts = val.split('=');
                                         if (parts.length !== 2) {
@@ -142,7 +142,7 @@ function yupNameRuleObject({ field }: ByNameResourceSelector) {
                 .of(
                     yup.object().shape({
                         // TODO Add validation for k8s cluster, namespace, and deployment name characters
-                        value: yup.string().trim().required(),
+                        value: yup.string().trim().required('This field can not be empty'),
                         matchType: yup
                             .string()
                             .required()

--- a/ui/apps/platform/src/Containers/Collections/RuleSelector/ByNameSelector.tsx
+++ b/ui/apps/platform/src/Containers/Collections/RuleSelector/ByNameSelector.tsx
@@ -1,5 +1,11 @@
 import React from 'react';
-import { Button, SelectOption, TextInput, ValidatedOptions } from '@patternfly/react-core';
+import {
+    Button,
+    FormGroup,
+    SelectOption,
+    TextInput,
+    ValidatedOptions,
+} from '@patternfly/react-core';
 import { TrashIcon } from '@patternfly/react-icons';
 import cloneDeep from 'lodash/cloneDeep';
 
@@ -12,6 +18,17 @@ import {
     SelectorEntityType,
 } from '../types';
 import { NameMatchTypeSelect } from './MatchTypeSelect';
+
+function parseInlineRuleError(
+    errors: ByNameSelectorProps['validationErrors'],
+    valueIndex: number
+): string | undefined {
+    const valueErrors = errors?.rule?.values?.[valueIndex];
+    if (typeof valueErrors === 'string') {
+        return valueErrors;
+    }
+    return valueErrors?.value;
+}
 
 export type ByNameSelectorProps = {
     entityType: SelectorEntityType;
@@ -84,7 +101,8 @@ function ByNameSelector({
                     } for the ${lowerCaseEntity} name`;
                     const inputClassName = 'pf-u-flex-grow-1 pf-u-w-auto';
                     const inputOnChange = onChangeValue(scopedResourceSelector, index);
-                    const inputValidated = validationErrors?.rule?.values?.[index]
+                    const errorMessage = parseInlineRuleError(validationErrors, index);
+                    const inputValidated = errorMessage
                         ? ValidatedOptions.error
                         : ValidatedOptions.default;
 
@@ -101,21 +119,29 @@ function ByNameSelector({
                                 </NameMatchTypeSelect>
                             </div>
                             <div className="rule-selector-name-value-input">
-                                <TextInput
-                                    id={inputId}
-                                    aria-label={inputAriaLabel}
-                                    placeholder={
-                                        matchType === 'REGEX' ? `^${placeholder}$` : placeholder
-                                    }
-                                    className={inputClassName}
-                                    onChange={inputOnChange}
+                                <FormGroup
+                                    className="rule-selector-name-value-input"
+                                    fieldId={inputId}
+                                    helperTextInvalid={errorMessage}
                                     validated={inputValidated}
-                                    value={value}
-                                    isDisabled={isDisabled}
-                                />
+                                >
+                                    <TextInput
+                                        id={inputId}
+                                        aria-label={inputAriaLabel}
+                                        placeholder={
+                                            matchType === 'REGEX' ? `^${placeholder}$` : placeholder
+                                        }
+                                        className={inputClassName}
+                                        onChange={inputOnChange}
+                                        validated={inputValidated}
+                                        value={value}
+                                        isDisabled={isDisabled}
+                                    />
+                                </FormGroup>
                             </div>
                             {!isDisabled && (
                                 <Button
+                                    className="rule-selector-delete-value-button"
                                     aria-label={`Delete ${value}`}
                                     variant="plain"
                                     onClick={() => onDeleteValue(index)}

--- a/ui/apps/platform/src/Containers/Collections/RuleSelector/RuleSelector.css
+++ b/ui/apps/platform/src/Containers/Collections/RuleSelector/RuleSelector.css
@@ -18,7 +18,7 @@
   flex: 1;
 }
 
-.rule-selector .rule-selector-name-value-input > * {
+.rule-selector .rule-selector-name-value-input  * {
   width: 100% !important;
 }
 
@@ -31,6 +31,7 @@
   position: relative;
   display: flex;
   padding: var(--rule-selector-spacer) 0 0 var(--rule-selector-spacer);
+  align-items: flex-start;
 }
 
 .rule-selector-list-item:before {
@@ -41,6 +42,10 @@
   height: 1px;
   width: var(--rule-selector-spacer);
   background-color: var(--pf-global--BorderColor--100);
+}
+
+.rule-selector-delete-value-button {
+  margin-top: var(--pf-global--spacer--xs);
 }
 
 .rule-selector-add-value-button {


### PR DESCRIPTION
## Description

Note: this is a low risk nice-to-have for 3.74 release, but also relatively low priority.

Adds inline error message to collection form fields that give more information on why the field is in an error state. This wraps existing TextInputs with FormGroups in order to take advantage of the inline error messages provided by the `helperTextInvalid` prop.

Also includes another minor UI fix for the VM report page. The severity labels were all set to red, this updates them to be the correct colors used elsewhere in the app.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

On the collection form, add a "by name" rule and leave the value empty:
![image](https://user-images.githubusercontent.com/1292638/216080827-f41fbdd9-b788-40e5-a104-a61f4faedf9c.png)

Enter a value, and then add another rule line. The second line should be the one containing the error. The error should also apply if the field is set to a regex value.
![image](https://user-images.githubusercontent.com/1292638/216081172-2331467d-94a6-4af7-9e95-6356f8069ad3.png)

Entering a correct value causes the error to go away:
![image](https://user-images.githubusercontent.com/1292638/216081281-3cc0dd36-5889-4061-88a6-9b5eabce8c49.png)

Repeat for label values, adding multiple rules with multiple values. The by label field should give a separate error message for both empty values and invalid label values.
![image](https://user-images.githubusercontent.com/1292638/216081833-4774cbaa-321b-4677-a357-9b4b4f505d77.png)

---

On the VM reporting page, ensure that the severity labels in the table have the correct color.
![image](https://user-images.githubusercontent.com/1292638/216081971-c5f2072b-5f95-48b4-aba3-0f12ae58dcd3.png)

Same on the VM report detail page:
![image](https://user-images.githubusercontent.com/1292638/216082042-f45cf4f2-3948-4d81-8de4-7a207e4d5625.png)

