### PR TITLE
ROX-14647-14671: Reduce confusion about policy categories

### DIFF
--- a/ui/apps/platform/src/Containers/PolicyCategories/CreatePolicyCategoryModal.tsx
+++ b/ui/apps/platform/src/Containers/PolicyCategories/CreatePolicyCategoryModal.tsx
@@ -20,7 +20,6 @@ type CreatePolicyCategoryModalType = {
     onClose: () => void;
     addToast: (toast) => void;
     refreshPolicyCategories: () => void;
-    setSelectedCategory: (category: PolicyCategory) => void;
 };
 
 const emptyPolicyCategory = {
@@ -34,15 +33,13 @@ function CreatePolicyCategoryModal({
     onClose,
     addToast,
     refreshPolicyCategories,
-    setSelectedCategory,
 }: CreatePolicyCategoryModalType) {
     const formik = useFormik({
         initialValues: emptyPolicyCategory as PolicyCategory,
         onSubmit: (values, { setSubmitting, resetForm }) => {
             setSubmitting(false);
             postPolicyCategory(values)
-                .then((response) => {
-                    setSelectedCategory(response);
+                .then(() => {
                     setTimeout(refreshPolicyCategories, 200);
                     addToast('Successfully added category');
                 })

--- a/ui/apps/platform/src/Containers/PolicyCategories/PolicyCategoriesPage.tsx
+++ b/ui/apps/platform/src/Containers/PolicyCategories/PolicyCategoriesPage.tsx
@@ -132,7 +132,6 @@ function PolicyCategoriesPage(): React.ReactElement {
                 onClose={() => setIsCreateModalOpen(false)}
                 refreshPolicyCategories={refreshPolicyCategories}
                 addToast={addToast}
-                setSelectedCategory={setSelectedCategory}
             />
         </>
     );

--- a/ui/apps/platform/src/Containers/PolicyCategories/PolicyCategorySidePanel.tsx
+++ b/ui/apps/platform/src/Containers/PolicyCategories/PolicyCategorySidePanel.tsx
@@ -91,15 +91,13 @@ function PolicyCategorySidePanel({
                                 />
                             </FormGroup>
                             <ActionGroup>
-                                <Button
-                                    variant="primary"
-                                    isDisabled={!dirty}
-                                    onClick={() => handleSubmit()}
-                                >
-                                    Save
-                                </Button>
+                                {dirty && (
+                                    <Button variant="primary" onClick={() => handleSubmit()}>
+                                        Save
+                                    </Button>
+                                )}
                                 <Button variant="secondary" onClick={clearSelectedCategory}>
-                                    Cancel
+                                    {dirty ? 'Cancel' : 'Close'}
                                 </Button>
                             </ActionGroup>
                         </Form>

--- a/ui/apps/platform/src/css/trumps.css
+++ b/ui/apps/platform/src/css/trumps.css
@@ -59,6 +59,11 @@ body {
     opacity: inherit;
 }
 
+/* SimpleListItem in policy categories: specify color instead of depending on opacity. */
+.pf-c-simple-list button:disabled {
+    color: var(--pf-global--disabled-color--100);
+}
+
 .pf-c-select__toggle:not(.pf-m-plain)::before {
     position: absolute;
     top: 0;


### PR DESCRIPTION
## Description

Fix a recent regression and mitigate confusion from interactive behavior which was by design.

### Problems

1. When you click a system-default category in the list, nothing happens. Although this is by design, it needs disabled appearance in contrast to customer-defined categories.
2. After you click a customer-defined category, it opens in the side panel.
    * The **Save** button is disabled **until** you make a change.
    * Although it becomes enabled **if** you make a change, it is an implicit **edit** mode.
3. Immediately after you create a customer-defined category, it opens in the side panel. Because of disabled **Save** button in problem 2, it looks like creation of the category via a modal has not yet occurred.

### Analysis

1. System-default categories had visual distinction from customer-defined categories via `opacity: 0.5;` which was overriden as a side-effect of solution to other style problems in #4361.
2. Inconsistent with initial **view** mode which has an explicit **Edit** button like everywhere else.
3. Inconsistent with interaction pattern elsewhere of return to list after creation, so you can create a batch of categories.

### Solution

1. Provide disabled appearance by explicit PatternFly disabled color.
2. Adapt an idea from Van to simulate a distinction between view and edit mode.
    * When there are no unsaved changes, render a **Close** button.
    * When there are unsaved changes, render **Save** enabled and **Cancel** buttons.
3. Follow suggestion by Linda to return to list after creation in modal.

### Changed files

1. Solve problem 1
    * src/css/trumps.css add style rule

2. Solve problem 2
    * src/Containers/PolicyCategories/PolicyCategorySidePanel.tsx conditionally render buttons

3. Solve problem 3
    * src/Containers/PolicyCategories/CreatePolicyCategoryModal.tsx delete `setSelectedCategory` prop
    * src/Containers/PolicyCategories/PolicyCategoriesPage.tsx delete `setSelectedCategory` prop

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

1. Disabled appearance for system-default categories

    * Incorrect: does not have disabled appearance without style rule
        ![opacity-inherit](https://user-images.githubusercontent.com/11862657/216066064-d77436db-5110-4e54-98bc-ef7a7d0c8ab5.png)

    * Correct: does have disabled appearance with style rule
        ![color-disabled](https://user-images.githubusercontent.com/11862657/216066097-8895f1fd-a047-464e-aacc-f4602c79f6bd.png)

2. Buttons

    * Confusing: disabled **Save** until you make a change
        ![Create-Save-Cancel](https://user-images.githubusercontent.com/11862657/216066976-22570304-1af4-4450-911c-95fbe31bf709.png)

    * Clearer: **Close** until you make a change
        ![Close](https://user-images.githubusercontent.com/11862657/216066406-d68455bd-329e-4886-b8d6-46ead2cd8249.png)

    * Clearer: enabled **Save** after you make a change
        ![Save-Cancel](https://user-images.githubusercontent.com/11862657/216067040-435836de-ddbd-47b7-9cad-c13f8b6c5a45.png)

    * Clearer: **Close** again after you save a change
        ![Close-again](https://user-images.githubusercontent.com/11862657/216067228-6d9f48e6-b234-45df-9a41-8a44b7dbc184.png)

3. Create

    * Confusing: created category opens in side panel and **Create category** button is disabled
        ![Create-Save-Cancel](https://user-images.githubusercontent.com/11862657/216067361-771d5c7b-8282-4739-852c-e0cd6573d0d9.png)

    * Clearer: created category appears in list and **Create category** button is enabled
        ![List-after-create](https://user-images.githubusercontent.com/11862657/216068005-61b3f585-feb0-43d4-8a87-be7cd477ba6c.png)
