### PR TITLE
Update front end check for regex rule message

### DIFF
--- a/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
+++ b/ui/apps/platform/src/Containers/Collections/CollectionForm.tsx
@@ -178,8 +178,8 @@ const validationSchema = yup.object({
             (name) => name?.trim() === name
         )
         .matches(
-            /^[a-zA-Z0-9 .-]*$/,
-            'Only letters, numbers, dot, dash, and space characters are allowed in collection names'
+            /^[a-zA-Z0-9 .-<>]*$/,
+            'Only the following characters are allowed in collection names: a-z A-Z 0-9 < . - >'
         )
         .required(),
     description: yup.string(),

--- a/ui/apps/platform/src/Containers/Collections/errorUtils.ts
+++ b/ui/apps/platform/src/Containers/Collections/errorUtils.ts
@@ -57,7 +57,7 @@ export function parseConfigError(err: Error): CollectionConfigError {
         return { type: 'EmptyName', message: 'A name value is required for a collection' };
     }
 
-    if (/failed to compile rule value regex/.test(rawMessage)) {
+    if (/failed to compile regex/.test(rawMessage)) {
         return {
             type: 'InvalidRule',
             message:


### PR DESCRIPTION
## Description

Updates the FE check to match the new BE error message.

Additionally adds `<` and `>` as supported characters for collection names, as requested by @charmik-redhat due to these characters existing in migrated access scopes.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.
