### PR TITLE
FOX-14426: Fix CVE exports in Findings sections

### DIFF
--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/TableWidgetFixableCves.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/TableWidgetFixableCves.js
@@ -55,23 +55,27 @@ const TableWidgetFixableCves = ({
     let queryVulnsFieldName = showVMUpdates ? 'imageVulnerabilities' : 'vulns';
     let queryCVEFieldsName = showVMUpdates ? 'imageCVEFields' : 'cveFields';
     let queryFragment = showVMUpdates ? IMAGE_CVE_LIST_FRAGMENT : VULN_CVE_LIST_FRAGMENT;
+    let exportType = entityTypes.CVE;
 
     if (vulnType === entityTypes.CLUSTER_CVE) {
         queryVulnCounterFieldName = 'clusterVulnerabilityCounter';
         queryVulnsFieldName = 'clusterVulnerabilities';
         queryCVEFieldsName = 'clusterCVEFields';
         queryFragment = CLUSTER_CVE_LIST_FRAGMENT;
+        exportType = entityTypes.CLUSTER_CVE;
     } else if (vulnType === entityTypes.NODE_CVE) {
         queryVulnCounterFieldName = 'nodeVulnerabilityCounter';
         queryVulnsFieldName = 'nodeVulnerabilities';
         queryCVEFieldsName = 'nodeCVEFields';
         queryFragment = NODE_CVE_LIST_FRAGMENT;
+        exportType = entityTypes.NODE_CVE;
     } else if (entityType === entityTypes.IMAGE_COMPONENT || vulnType === entityTypes.IMAGE_CVE) {
         // TODO: after the split of CVE types is released, make this the default
         queryVulnCounterFieldName = 'imageVulnerabilityCounter';
         queryVulnsFieldName = 'imageVulnerabilities';
         queryCVEFieldsName = 'imageCVEFields';
         queryFragment = IMAGE_CVE_LIST_FRAGMENT;
+        exportType = entityTypes.IMAGE_CVE;
     }
 
     // `id` field is not needed in result,
@@ -130,6 +134,7 @@ const TableWidgetFixableCves = ({
             disabled={!fixableCount}
             workflowState={workflowState}
             entityName={name}
+            exportType={exportType}
         />
     );
 

--- a/ui/apps/platform/src/Containers/VulnMgmt/VulnMgmtComponents/FixableCveExportButton.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/VulnMgmtComponents/FixableCveExportButton.js
@@ -5,7 +5,7 @@ import Button from 'Components/Button';
 import { exportCvesAsCsv } from 'services/VulnerabilitiesService';
 import { getCveExportName } from 'utils/vulnerabilityUtils';
 
-const FixableCveExportButton = ({ workflowState, entityName, disabled }) => {
+const FixableCveExportButton = ({ workflowState, entityName, disabled, exportType }) => {
     const [isLoading, setIsLoading] = useState(false);
 
     function clickHandler() {
@@ -16,7 +16,7 @@ const FixableCveExportButton = ({ workflowState, entityName, disabled }) => {
         const stateWithFixable = workflowState.setSearch({ Fixable: 'true' });
         setIsLoading(true);
 
-        exportCvesAsCsv(csvName, stateWithFixable).finally(() => {
+        exportCvesAsCsv(csvName, stateWithFixable, exportType).finally(() => {
             setIsLoading(false);
         });
     }

--- a/ui/apps/platform/src/services/VulnerabilitiesService.js
+++ b/ui/apps/platform/src/services/VulnerabilitiesService.js
@@ -93,8 +93,20 @@ export function exportCvesAsCsv(fileName, workflowState, cveType) {
         return { ...{ [key]: fullEntityContext[key] } };
     }, {});
 
+    const currentSearchState = workflowState.getCurrentSearchState();
+
+    // TODO: remove after Postgres is required for all installations
+    // kludge to make Findings sections CSV export of CVEs work until Postgres is on
+    if (cveType === entityTypes.CVE && !currentSearchState['CVE Type']) {
+        if (fullEntityContext.NODE) {
+            currentSearchState['CVE Type'] = 'NODE_CVE';
+        } else {
+            currentSearchState['CVE Type'] = 'IMAGE_CVE';
+        }
+    }
+
     const query = queryService.objectToWhereClause({
-        ...workflowState.getCurrentSearchState(),
+        ...currentSearchState,
         ...queryService.entityContextToQueryObject(lastEntityCtx),
     });
 


### PR DESCRIPTION
## Description

Earlier work to vary the CSV export of CVEs by type for Postgres missed passing down the type to the export functionality fo the Fixable CVE tables in the Findings sections of individual entities.

1. One change passes that CVE type down when Postgres is enabled.
2. Another change adds a fallback when Postgres is not enabled, so that the best approximate CVE_Type filter is added for an individual entity when exporting. (Note, the non-Postgres API does not support multiple filter values, so Cluster export will just get image CVEs. Asking for an API improvement for a datastore that will be removed in 9 weeks is not worth the effort.)

## Checklist
- [x] Investigated and inspected CI test results (ui-e2e test failures are unrelated flakes)

## Testing Performed

Manually testing on:

1. Postgres (stagingdb)
2. Non-Postgres (staging)