### PR TITLE
Fix bug where values got overridden incorrectly

### DIFF
--- a/sensor/kubernetes/eventpipeline/component/message.go
+++ b/sensor/kubernetes/eventpipeline/component/message.go
@@ -75,8 +75,12 @@ func MergeResourceEvents(dest, src *ResourceEvent) *ResourceEvent {
 		dest.CompatibilityReprocessDeployments = append(dest.CompatibilityReprocessDeployments, src.CompatibilityReprocessDeployments...)
 		dest.ForwardMessages = append(dest.ForwardMessages, src.ForwardMessages...)
 		dest.CompatibilityDetectionDeployment = append(dest.CompatibilityDetectionDeployment, src.CompatibilityDetectionDeployment...)
-		dest.ParentResourceAction = src.ParentResourceAction
-		dest.DeploymentReference = src.DeploymentReference
+		if src.ParentResourceAction != central.ResourceAction_UNSET_ACTION_RESOURCE {
+			dest.ParentResourceAction = src.ParentResourceAction
+		}
+		if src.DeploymentReference != nil {
+			dest.DeploymentReference = src.DeploymentReference
+		}
 		dest.ForceDetection = src.ForceDetection || dest.ForceDetection
 	}
 	return dest


### PR DESCRIPTION
## Description

The `MergeResourceEvents` has a bug where some values could get overridden  incorrectly.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

* CI
