### PR TITLE
ROX-14632: migrate slack notice

### DIFF
--- a/.github/workflows/release-ci.yaml
+++ b/.github/workflows/release-ci.yaml
@@ -5,6 +5,7 @@ on:
     - 'release-*'
     tags-ignore:
     - '*-nightly-*'
+    - 'gavin-*'
 
 jobs:
   run-parameters:

--- a/.github/workflows/release-ci.yaml
+++ b/.github/workflows/release-ci.yaml
@@ -5,7 +5,6 @@ on:
     - 'release-*'
     tags-ignore:
     - '*-nightly-*'
-    - 'gavin-*'
 
 jobs:
   run-parameters:

--- a/.github/workflows/tagged-ci.yaml
+++ b/.github/workflows/tagged-ci.yaml
@@ -14,7 +14,11 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.ref_name }}
-      - id: is_release_check
+      - name: Slack
+        env:
+          NIGHTLY_WORKFLOW_NOTIFY_WEBHOOK: ${{ secrets.NIGHTLY_WORKFLOW_NOTIFY_WEBHOOK }}
+          RELEASE_WORKFLOW_NOTIFY_WEBHOOK: ${{ secrets.RELEASE_WORKFLOW_NOTIFY_WEBHOOK }}
+          SLACK_MAIN_WEBHOOK: ${{ secrets.SLACK_MAIN_WEBHOOK }}
         run: |
           source scripts/ci/lib.sh
           slack_prow_notice "${{ github.ref_name }}"

--- a/.github/workflows/tagged-ci.yaml
+++ b/.github/workflows/tagged-ci.yaml
@@ -1,0 +1,13 @@
+name: Tagged CI
+on:
+  push:
+    tags:
+    - '*'
+
+jobs:
+  slack-tagged-notice:
+    name: Slack Tagged Notice
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "Ref: ${{ github.ref_name }}"

--- a/.github/workflows/tagged-ci.yaml
+++ b/.github/workflows/tagged-ci.yaml
@@ -9,5 +9,12 @@ jobs:
     name: Slack Tagged Notice
     runs-on: ubuntu-latest
     steps:
-      - run: |
-          echo "Ref: ${{ github.ref_name }}"
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: ${{ github.ref_name }}
+      - id: is_release_check
+        run: |
+          source scripts/ci/lib.sh
+          slack_prow_notice "${{ github.ref_name }}"

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -1465,7 +1465,7 @@ handle_gha_tagged_build() {
 }
 
 slack_prow_notice() {
-    info "Slack a build notice"
+    info "Slack a notice that prow tests have started"
 
     if [[ "$#" -lt 1 ]]; then
         die "missing arg. usage: slack_prow_notice <tag>"

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -1464,6 +1464,51 @@ handle_gha_tagged_build() {
     fi
 }
 
+slack_prow_notice() {
+    info "Slack a build notice"
+
+    if [[ "$#" -lt 1 ]]; then
+        die "missing arg. usage: slack_prow_notice <tag>"
+    fi
+
+    local tag="$1"
+
+    [[ "$tag" =~ $RELEASE_RC_TAG_BASH_REGEX ]] || is_nightly_run || {
+        info "Skipping step as this is not a release, RC or nightly build"
+        return 0
+    }
+
+    local build_url
+    local webhook_url
+    if [[ "$tag" =~ $RELEASE_RC_TAG_BASH_REGEX ]]; then
+        local release
+        release="$(get_release_stream "$tag")"
+        build_url="https://prow.ci.openshift.org/?repo=stackrox%2Fstackrox&job=*release-$release*"
+        if is_release_test_stream "$tag"; then
+            # send to #slack-test when testing the release process
+            webhook_url="${SLACK_MAIN_WEBHOOK}"
+        else
+            # send to #eng-release
+            webhook_url="${RELEASE_WORKFLOW_NOTIFY_WEBHOOK}"
+        fi
+    elif is_nightly_run; then
+        build_url="https://prow.ci.openshift.org/?repo=stackrox%2Fstackrox&job=*stackrox*night*"
+        # send to #nightly-ci-runs
+        webhook_url="${NIGHTLY_WORKFLOW_NOTIFY_WEBHOOK}"
+    else
+        die "unexpected"
+    fi
+
+    local github_url="https://github.com/stackrox/stackrox/releases/tag/$tag"
+
+    jq -n \
+    --arg build_url "$build_url" \
+    --arg tag "$tag" \
+    --arg github_url "$github_url" \
+    '{"text": ":prow: Prow CI for tag <\($github_url)|\($tag)> started! Check the status of the tests under the following URL: \($build_url)"}' \
+| curl -XPOST -d @- -H 'Content-Type: application/json' "$webhook_url"
+}
+
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
     if [[ "$#" -lt 1 ]]; then
         die "When invoked at the command line a method is required."


### PR DESCRIPTION
## Description

We currently slack a notice that builds have started for RCs, releases and nightlies. This PR aims to move that task out of openshift/release. This will enable the removal of the stackrox branded builds from the openshift/release config.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

- [x] other tags are skipped https://github.com/stackrox/stackrox/actions/runs/4067229135
- [x] rcs generate a message
    - https://srox.slack.com/archives/C740BUV25/p1675274772169069
    - https://github.com/stackrox/stackrox/actions/runs/4067323894/jobs/7004533567