### PR TITLE
Update go version in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stackrox/rox
 
-go 1.18
+go 1.19
 
 require (
 	cloud.google.com/go/compute/metadata v0.2.3

--- a/tools/linters/go.mod
+++ b/tools/linters/go.mod
@@ -1,6 +1,6 @@
 module github.com/stackrox/stackrox/tools/linters
 
-go 1.18
+go 1.19
 
 require (
 	// TODO: remove the github.com/sourcegraph/go-diff replacement once updated.

--- a/tools/test/go.mod
+++ b/tools/test/go.mod
@@ -1,5 +1,5 @@
 module github.com/stackrox/stackrox/tools/test
 
-go 1.18
+go 1.19
 
 require github.com/jstemmer/go-junit-report/v2 v2.0.0


### PR DESCRIPTION
## Description

Tools and linters requires Go 1.19 to work. Go 1.19 is also required by k8s dependencies. This PR bumps required go version in go mod to 1.19

See:
- https://github.com/kubernetes/api/commit/e281bde5048c6909a89c7d14f1b8fd0d80849938
- https://github.com/golangci/golangci-lint/pull/3037
  

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

CI