### PR TITLE
Disable Clair v4 automated tests and move Clair to Quay

### DIFF
--- a/qa-tests-backend/scripts/run-part-1.sh
+++ b/qa-tests-backend/scripts/run-part-1.sh
@@ -41,7 +41,8 @@ config_part_1() {
     deploy_default_psp
     deploy_webhook_server "$ROOT/$DEPLOY_DIR/webhook_server_certs"
     get_ECR_docker_pull_password
-    deploy_clair_v4
+    # TODO(ROX-14759): Re-enable once image pulling is fixed.
+    #deploy_clair_v4
 }
 
 reuse_config_part_1() {

--- a/qa-tests-backend/src/main/groovy/objects/ImageIntegration.groovy
+++ b/qa-tests-backend/src/main/groovy/objects/ImageIntegration.groovy
@@ -92,7 +92,7 @@ class ClairV4ScannerIntegration implements ImageIntegration {
     static String name() { "Clair v4 Scanner" }
 
     static Boolean isTestable() {
-        return true
+        return Env.get("CLAIR_V4_ENDPOINT") != null
     }
 
     static ImageIntegrationOuterClass.ImageIntegration.Builder getCustomBuilder(Map customArgs = [:]) {

--- a/scripts/ci/clairv4/clairv4-kubernetes.yaml
+++ b/scripts/ci/clairv4/clairv4-kubernetes.yaml
@@ -15,7 +15,7 @@ spec:
       containers:
       - name: clairv4
         # This image is based on registry.redhat.io/quay/clair-rhel8:v3.8.0-10
-        image: us.gcr.io/stackrox-ci/clair:v4.5.1
+        image: quay.io/rhacs-eng/qa:clair-v4.5.1
         env:
         - name: CLAIR_CONF
           value: /clair/config.yaml
@@ -76,7 +76,7 @@ spec:
       - name: postgres
         # Generic PostgreSQL 12 image used for online-mode.
         # image: us.gcr.io/stackrox-ci/postgres:12.13
-        image: us.gcr.io/stackrox-ci/clairv4-postgres:12.13
+        image: quay.io/rhacs-eng/qa:clairv4-postgres-12.13
         env:
         - name: POSTGRES_USER
           value: "postgres"


### PR DESCRIPTION
## Description

Use Quay image instead of GCR, but also disable the test, as the images cannot be pulled at this time

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

CI
