### PR TITLE
ROX-14642: Add dismissible postgres announcement banner

### DIFF
--- a/ui/apps/platform/src/Containers/MainPage/AnnouncementBanner.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/AnnouncementBanner.tsx
@@ -1,0 +1,42 @@
+import React, { ReactElement, useEffect, useState } from 'react';
+import { AlertVariant, Banner, Button } from '@patternfly/react-core';
+
+const ANNOUNCEMENT_BANNER_KEY = 'postgresAnnouncementBannerDismissed';
+
+function AnnouncementBanner(): ReactElement | null {
+    const [isDisplayed, setIsDisplayed] = useState(false);
+
+    useEffect(() => {
+        const localStorageValue = localStorage.getItem(ANNOUNCEMENT_BANNER_KEY);
+        const isBannerDismissed = localStorageValue
+            ? Boolean(JSON.parse(localStorageValue))
+            : false;
+        setIsDisplayed(!isBannerDismissed);
+    }, []);
+
+    function handleDismissClick() {
+        localStorage.setItem(ANNOUNCEMENT_BANNER_KEY, JSON.stringify(true));
+        setIsDisplayed(false);
+    }
+
+    if (isDisplayed) {
+        return (
+            <Banner
+                className="pf-u-display-flex pf-u-justify-content-center pf-u-align-items-center"
+                isSticky
+                variant={AlertVariant.info}
+            >
+                <span className="pf-u-text-align-center">
+                    The next version of this product will switch to using Postgres for its data
+                    store. The version number will increase to 4.0.0.
+                </span>
+                <Button className="pf-u-ml-md" onClick={handleDismissClick} variant="link" isInline>
+                    dismiss
+                </Button>
+            </Banner>
+        );
+    }
+    return null;
+}
+
+export default AnnouncementBanner;

--- a/ui/apps/platform/src/Containers/MainPage/MainPage.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/MainPage.tsx
@@ -21,6 +21,7 @@ import { clustersBasePath } from 'routePaths';
 import CredentialExpiryBanner from './CredentialExpiryBanner';
 import VersionOutOfDate from './VersionOutOfDate';
 import DatabaseBanner from './DatabaseBanner';
+import AnnouncementBanner from './AnnouncementBanner';
 import Masthead from './Header/Masthead';
 import NavigationSidebar from './Sidebar/NavigationSidebar';
 
@@ -88,6 +89,7 @@ function MainPage(): ReactElement {
     return (
         <AppWrapper publicConfig={publicConfig}>
             <div className="flex flex-1 flex-col h-full relative">
+                <AnnouncementBanner />
                 <UnreachableWarning serverState={serverState} />
                 <Notifications />
                 <CredentialExpiryBanner


### PR DESCRIPTION
## Description

This adds a dismissible announcement banner to indicate 4.0.0 will be our next version and Postgres will be used. The dismissible aspect will be kept in local storage.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Manual testing performed
![Screenshot 2023-02-01 at 1 03 33 PM](https://user-images.githubusercontent.com/61400697/216140100-3f9565cd-4e41-432c-a377-794f053c9a65.png)


Alternative dismiss button
<img src="https://user-images.githubusercontent.com/61400697/216140222-4c8f44bb-94ad-41da-9e24-1e142814e878.png" width="400"> <img src="https://user-images.githubusercontent.com/61400697/216140246-135244c6-da61-4e54-bb96-376d0f8045a0.png" width="400">

