### PR TITLE
Network graph: PF - adding reset graph callback for smooth edge state change

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/TopologyComponent.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/TopologyComponent.tsx
@@ -124,9 +124,9 @@ const TopologyComponent = ({
         controller.getGraph().scaleBy(0.75);
     }
 
-    const fitToScreenCallback = useCallback(() => {
+    function fitToScreenCallback() {
         controller.getGraph().fit(80);
-    }, [controller]);
+    }
 
     const resetViewCallback = useCallback(() => {
         controller.getGraph().reset();
@@ -155,7 +155,7 @@ const TopologyComponent = ({
         } else {
             firstRenderRef.current = false;
         }
-    }, [edgeState, resetViewCallback, fitToScreenCallback]);
+    }, [edgeState, resetViewCallback]);
 
     const selectedIds = selectedNode ? [selectedNode.id] : [];
 

--- a/ui/apps/platform/src/Containers/NetworkGraph/TopologyComponent.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/TopologyComponent.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useCallback, useRef } from 'react';
 import { useHistory } from 'react-router-dom';
 import { Popover } from '@patternfly/react-core';
 import {
@@ -80,6 +80,7 @@ const TopologyComponent = ({
     applyNetworkPolicyModification,
     edgeState,
 }: TopologyComponentProps) => {
+    const firstRenderRef = useRef(true);
     const history = useHistory();
     const controller = useVisualizationController();
     const [defaultDeploymentTab, setDefaultDeploymentTab] = useState(deploymentTabs.DETAILS);
@@ -123,14 +124,14 @@ const TopologyComponent = ({
         controller.getGraph().scaleBy(0.75);
     }
 
-    function fitToScreenCallback() {
+    const fitToScreenCallback = useCallback(() => {
         controller.getGraph().fit(80);
-    }
+    }, [controller]);
 
-    function resetViewCallback() {
+    const resetViewCallback = useCallback(() => {
         controller.getGraph().reset();
         controller.getGraph().layout();
-    }
+    }, [controller]);
 
     useEventListener<SelectionEventListener>(SELECTION_EVENT, (ids) => {
         onNodeClick(ids);
@@ -146,6 +147,15 @@ const TopologyComponent = ({
             }
         }
     }, [controller, model, selectedNode]);
+
+    useEffect(() => {
+        // we don't want to reset view on init
+        if (!firstRenderRef.current) {
+            resetViewCallback();
+        } else {
+            firstRenderRef.current = false;
+        }
+    }, [edgeState, resetViewCallback, fitToScreenCallback]);
 
     const selectedIds = selectedNode ? [selectedNode.id] : [];
 


### PR DESCRIPTION
the current experience causes the layout to be merged oddly on edge state change:

Before:
* active state:
* <img width="1214" alt="image" src="https://user-images.githubusercontent.com/10412893/216143154-8ed08b3b-388c-41f6-9d29-7a3f383fca07.png">
* changing to extraneous state:
* <img width="1215" alt="image" src="https://user-images.githubusercontent.com/10412893/216143251-b3b8b272-9644-4104-97c1-607449ef7531.png">

After:
* active state:
* <img width="1217" alt="image" src="https://user-images.githubusercontent.com/10412893/216143366-a757709f-ed8a-449b-ba08-e36c7f4cec97.png">
* changing to extraneous state:
* <img width="1215" alt="image" src="https://user-images.githubusercontent.com/10412893/216143439-bebf5ff4-015a-4f88-9e97-e61e39f458a2.png">

everything else should work as expected (layout on init, refresh, display options toggling, selected node toggling) -- the layout should _not_ change on any of these and _only_ on edge state change

i also added clearing the URL when the user has a node selected that only exists in the `extraneous` graph and then toggles to the `active` graph
