### PR TITLE
Add retry to vuln report E2E test when fetching email

### DIFF
--- a/qa-tests-backend/src/test/groovy/VulnReportingTest.groovy
+++ b/qa-tests-backend/src/test/groovy/VulnReportingTest.groovy
@@ -96,9 +96,11 @@ class VulnReportingTest extends BaseSpecification  {
 
         then:
         "the email server should've gotten an email with the report"
-
-        def emails = mailServer.findEmailsByToEmail(Constants.EMAIL_NOTIFER_SENDER)
-        assert emails.size() == 1
+        List emails = []
+        withRetry(4, 3) {
+            emails = mailServer.findEmailsByToEmail(Constants.EMAIL_NOTIFER_SENDER)
+            assert emails.size() == 1
+        }
 
         def email = emails[0]
         def emailId = (String) email["id"]
@@ -121,15 +123,19 @@ class VulnReportingTest extends BaseSpecification  {
         "Cleanup resources"
         if (report) {
             VulnReportService.deleteVulnReportConfig(report.id)
+            log.info "[Cleanup] Deleted vulnerability report config"
         }
         if (collection) {
             CollectionsService.deleteCollection(collection.id)
+            log.info "[Cleanup] Deleted collection"
         }
         if (notifier) {
             notifier.deleteNotifier()
+            log.info "[Cleanup] Deleted email notifier"
         }
         if (email) {
             mailServer.deleteEmail(emailId)
+            log.info "[Cleanup] Deleted email from mail server"
         }
     }
 


### PR DESCRIPTION
## Description

It might take some time for email to show up so add retries. 

Also add logs when cleaning up because it seems the cleanup might be failing at times

## Checklist
- [ ] Investigated and inspected CI test results
~[ ] Unit test and regression tests added~
~[ ] Evaluated and added CHANGELOG entry if required~
~[ ] Determined and documented upgrade steps~
~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

this is the test

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
