### PR TITLE
Fix tagged CI Slack notification for nightly builds: add GITHUB_REF to is_nightly_run check

### DIFF
--- a/.github/workflows/tagged-ci.yaml
+++ b/.github/workflows/tagged-ci.yaml
@@ -20,5 +20,6 @@ jobs:
           RELEASE_WORKFLOW_NOTIFY_WEBHOOK: ${{ secrets.RELEASE_WORKFLOW_NOTIFY_WEBHOOK }}
           SLACK_MAIN_WEBHOOK: ${{ secrets.SLACK_MAIN_WEBHOOK }}
         run: |
+          set -euo pipefail
           source scripts/ci/lib.sh
           slack_prow_notice "${{ github.ref_name }}"

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -660,7 +660,7 @@ is_tagged() {
 }
 
 is_nightly_run() {
-    [[ "${CIRCLE_TAG:-}" =~ -nightly- ]]
+    [[ "${CIRCLE_TAG:-}" =~ -nightly- ]] || [[ "${GITHUB_REF:-}" =~ nightly- ]]
 }
 
 is_in_PR_context() {


### PR DESCRIPTION
## Description

Fix for https://github.com/stackrox/stackrox/pull/4660, failed job: https://github.com/stackrox/stackrox/actions/runs/4071433861/jobs/7013232229.  

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

CI is sufficient.