### PR TITLE
Disable Prom metrics if monitoring is not set

### DIFF
--- a/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml
@@ -91,9 +91,11 @@ spec:
       - command:
         - stackrox/compliance
         env:
-        {{- if ._rox.collector.exposeMonitoring }}
         - name: ROX_METRICS_PORT
+        {{- if ._rox.collector.exposeMonitoring }}
           value: ":9091"
+        {{- else}}
+          value: "disabled"
         {{- end }}
         - name: ROX_NODE_NAME
           valueFrom:


### PR DESCRIPTION
## Description

The prom metrics server is started, even when monitoring is not explicitly exposed.
Therefore, we get port clashes in that case as well.
This PR disables the Compliance port completely if monitoring is not enabled, and sets it to a non-standard port if enabled, eliminating all clashes.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] ~~Unit test and regression tests added~~
- [ ] ~~Evaluated and added CHANGELOG entry if required~~
- [ ] ~~Determined and documented upgrade steps~~
- [ ] ~~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
