### PR TITLE
Telemetry: `WithGroups` option

### DIFF
--- a/central/cluster/datastore/telemetry.go
+++ b/central/cluster/datastore/telemetry.go
@@ -60,7 +60,8 @@ func trackClusterInitialized(cluster *storage.Cluster) {
 				"Health": cluster.GetHealthStatus().GetOverallHealthStatus().String(),
 			},
 				telemeter.WithUserID(cluster.GetId()),
-				telemeter.WithClient(cluster.GetId(), securedClusterClient))
+				telemeter.WithClient(cluster.GetId(), securedClusterClient),
+				telemeter.WithGroup("Tenant", cfg.GroupID))
 	}
 }
 

--- a/central/cluster/datastore/telemetry.go
+++ b/central/cluster/datastore/telemetry.go
@@ -61,7 +61,7 @@ func trackClusterInitialized(cluster *storage.Cluster) {
 			},
 				telemeter.WithUserID(cluster.GetId()),
 				telemeter.WithClient(cluster.GetId(), securedClusterClient),
-				telemeter.WithGroup("Tenant", cfg.GroupID))
+				telemeter.WithGroupProperties("Tenant", cfg.GroupID, nil))
 	}
 }
 

--- a/central/cluster/datastore/telemetry.go
+++ b/central/cluster/datastore/telemetry.go
@@ -61,7 +61,7 @@ func trackClusterInitialized(cluster *storage.Cluster) {
 			},
 				telemeter.WithUserID(cluster.GetId()),
 				telemeter.WithClient(cluster.GetId(), securedClusterClient),
-				telemeter.WithGroupProperties("Tenant", cfg.GroupID, nil))
+				telemeter.WithGroups("Tenant", cfg.GroupID))
 	}
 }
 

--- a/pkg/telemetry/phonehome/segment/segment.go
+++ b/pkg/telemetry/phonehome/segment/segment.go
@@ -100,13 +100,22 @@ func (t *segmentTelemeter) overrideUserID(o *telemeter.CallOptions) string {
 func makeDeviceContext(o *telemeter.CallOptions) *segment.Context {
 	var ctx *segment.Context
 
-	if len(o.Groups) > 0 {
+	if len(o.GroupProperties) > 0 {
+		// [group name: [group id...]]
+		groups := make(map[string][]string)
+		for gname, gprops := range o.GroupProperties {
+			for gid := range gprops {
+				groups[gname] = append(groups[gname], gid)
+			}
+		}
+
 		// Add groups to the context. Requires a mapping configuration for
 		// setting the according Amplitude event field.
 		ctx = &segment.Context{
-			Extra: make(map[string]any),
+			Extra: map[string]any{
+				"groups": groups,
+			},
 		}
-		ctx.Extra["groups"] = o.Groups
 	}
 	// Segment does not support attaching group properties.
 

--- a/pkg/telemetry/phonehome/segment/segment.go
+++ b/pkg/telemetry/phonehome/segment/segment.go
@@ -98,15 +98,28 @@ func (t *segmentTelemeter) overrideUserID(o *telemeter.CallOptions) string {
 }
 
 func makeDeviceContext(o *telemeter.CallOptions) *segment.Context {
-	if o.ClientID == "" {
-		return nil
+	var ctx *segment.Context
+
+	if len(o.Groups) > 0 {
+		// Add groups to the context. Requires a mapping configuration for
+		// setting the according Amplitude event field.
+		ctx = &segment.Context{
+			Extra: make(map[string]any),
+		}
+		ctx.Extra["groups"] = o.Groups
 	}
-	return &segment.Context{
-		Device: segment.DeviceInfo{
+	// Segment does not support attaching group properties.
+
+	if o.ClientID != "" {
+		if ctx == nil {
+			ctx = &segment.Context{}
+		}
+		ctx.Device = segment.DeviceInfo{
 			Id:   o.ClientID,
 			Type: o.ClientType,
-		},
+		}
 	}
+	return ctx
 }
 
 func (t *segmentTelemeter) Identify(props map[string]any, opts ...telemeter.Option) {

--- a/pkg/telemetry/phonehome/segment/segment.go
+++ b/pkg/telemetry/phonehome/segment/segment.go
@@ -100,22 +100,11 @@ func (t *segmentTelemeter) overrideUserID(o *telemeter.CallOptions) string {
 func makeDeviceContext(o *telemeter.CallOptions) *segment.Context {
 	var ctx *segment.Context
 
-	if len(o.GroupProperties) > 0 {
-		// [group name: [group id...]]
-		groups := make(map[string][]string)
-		for gname, gprops := range o.GroupProperties {
-			for gid := range gprops {
-				groups[gname] = append(groups[gname], gid)
-			}
-		}
-
+	if len(o.Groups) > 0 {
 		// Add groups to the context. Requires a mapping configuration for
 		// setting the according Amplitude event field.
 		ctx = &segment.Context{
-			Extra: map[string]any{
-				"groups": groups,
-				// Segment does not support attaching group properties.
-			},
+			Extra: map[string]any{"groups": o.Groups},
 		}
 	}
 

--- a/pkg/telemetry/phonehome/segment/segment.go
+++ b/pkg/telemetry/phonehome/segment/segment.go
@@ -114,10 +114,10 @@ func makeDeviceContext(o *telemeter.CallOptions) *segment.Context {
 		ctx = &segment.Context{
 			Extra: map[string]any{
 				"groups": groups,
+				// Segment does not support attaching group properties.
 			},
 		}
 	}
-	// Segment does not support attaching group properties.
 
 	if o.ClientID != "" {
 		if ctx == nil {

--- a/pkg/telemetry/phonehome/segment/segment_test.go
+++ b/pkg/telemetry/phonehome/segment/segment_test.go
@@ -4,7 +4,9 @@ import (
 	"testing"
 
 	segment "github.com/segmentio/analytics-go/v3"
+	"github.com/stackrox/rox/pkg/telemetry/phonehome/telemeter"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_getMessageType(t *testing.T) {
@@ -13,4 +15,24 @@ func Test_getMessageType(t *testing.T) {
 	}
 
 	assert.Equal(t, "Track", getMessageType(track))
+}
+
+func Test_makeDeviceContext(t *testing.T) {
+	opts := telemeter.ApplyOptions([]telemeter.Option{
+		telemeter.WithUserID("userID"),
+		telemeter.WithClient("clientID", "clientType"),
+		telemeter.WithGroupProperties("groupA", "groupA_id1", map[string]any{"key1": "value1"}),
+		telemeter.WithGroupProperties("groupA", "groupA_id2", map[string]any{"key2": "value2"}),
+		telemeter.WithGroupProperties("groupB", "groupB_id", map[string]any{"key3": "value3"}),
+	})
+
+	ctx := makeDeviceContext(opts)
+	assert.Equal(t, "clientID", ctx.Device.Id)
+	assert.Equal(t, "clientType", ctx.Device.Type)
+
+	require.Contains(t, ctx.Extra, "groups")
+	require.Contains(t, ctx.Extra["groups"], "groupA")
+	assert.Contains(t, ctx.Extra["groups"], "groupB")
+	groups := ctx.Extra["groups"].(map[string][]string)
+	assert.ElementsMatch(t, []string{"groupA_id1", "groupA_id2"}, groups["groupA"])
 }

--- a/pkg/telemetry/phonehome/segment/segment_test.go
+++ b/pkg/telemetry/phonehome/segment/segment_test.go
@@ -21,9 +21,9 @@ func Test_makeDeviceContext(t *testing.T) {
 	opts := telemeter.ApplyOptions([]telemeter.Option{
 		telemeter.WithUserID("userID"),
 		telemeter.WithClient("clientID", "clientType"),
-		telemeter.WithGroupProperties("groupA", "groupA_id1", map[string]any{"key1": "value1"}),
-		telemeter.WithGroupProperties("groupA", "groupA_id2", map[string]any{"key2": "value2"}),
-		telemeter.WithGroupProperties("groupB", "groupB_id", map[string]any{"key3": "value3"}),
+		telemeter.WithGroups("groupA", "groupA_id1"),
+		telemeter.WithGroups("groupA", "groupA_id2"),
+		telemeter.WithGroups("groupB", "groupB_id"),
 	})
 
 	ctx := makeDeviceContext(opts)

--- a/pkg/telemetry/phonehome/telemeter/telemeter.go
+++ b/pkg/telemetry/phonehome/telemeter/telemeter.go
@@ -6,8 +6,8 @@ type CallOptions struct {
 	ClientID   string
 	ClientType string
 
-	// [group name: [group id: [key: value]]]
-	GroupProperties map[string]map[string]map[string]any
+	// [group name: [group id]]
+	Groups map[string][]string
 }
 
 // Option modifies the provided CallOptions structure.
@@ -37,19 +37,13 @@ func WithClient(clientID string, clientType string) Option {
 	}
 }
 
-// WithGroupProperties appends the groups and sets the optional group properties
-// for an event.
-func WithGroupProperties(groupName string, groupID string, groupProperties map[string]any) Option {
+// WithGroups appends the groups for an event.
+func WithGroups(groupName string, groupID string) Option {
 	return func(o *CallOptions) {
-		if o.GroupProperties == nil {
-			o.GroupProperties = make(map[string]map[string]map[string]any)
+		if o.Groups == nil {
+			o.Groups = make(map[string][]string, 1)
 		}
-		gn, ok := o.GroupProperties[groupName]
-		if !ok {
-			gn = make(map[string]map[string]any)
-			o.GroupProperties[groupName] = gn
-		}
-		gn[groupID] = groupProperties
+		o.Groups[groupName] = append(o.Groups[groupName], groupID)
 	}
 }
 

--- a/pkg/telemetry/phonehome/telemeter/telemeter.go
+++ b/pkg/telemetry/phonehome/telemeter/telemeter.go
@@ -5,6 +5,11 @@ type CallOptions struct {
 	UserID     string
 	ClientID   string
 	ClientType string
+
+	// [group name: group id]
+	Groups map[string][]string
+	// [group id: [key: value]]
+	GroupProperties map[string]map[string]any
 }
 
 // Option modifies the provided CallOptions structure.
@@ -31,6 +36,26 @@ func WithClient(clientID string, clientType string) Option {
 	return func(o *CallOptions) {
 		o.ClientID = clientID
 		o.ClientType = clientType
+	}
+}
+
+// WithGroup appends a group association to an event.
+func WithGroup(groupName string, groupID string) Option {
+	return func(o *CallOptions) {
+		if o.Groups == nil {
+			o.Groups = make(map[string][]string, 1)
+		}
+		o.Groups[groupName] = append(o.Groups[groupName], groupID)
+	}
+}
+
+// WithGroupProperties sets the group properties of an event.
+func WithGroupProperties(groupID string, groupProperties map[string]any) Option {
+	return func(o *CallOptions) {
+		if o.GroupProperties == nil {
+			o.GroupProperties = make(map[string]map[string]any)
+		}
+		o.GroupProperties[groupID] = groupProperties
 	}
 }
 

--- a/pkg/telemetry/phonehome/telemeter/telemeter.go
+++ b/pkg/telemetry/phonehome/telemeter/telemeter.go
@@ -6,10 +6,8 @@ type CallOptions struct {
 	ClientID   string
 	ClientType string
 
-	// [group name: group id]
-	Groups map[string][]string
-	// [group id: [key: value]]
-	GroupProperties map[string]map[string]any
+	// [group name: [group id: [key: value]]]
+	GroupProperties map[string]map[string]map[string]any
 }
 
 // Option modifies the provided CallOptions structure.
@@ -39,23 +37,19 @@ func WithClient(clientID string, clientType string) Option {
 	}
 }
 
-// WithGroup appends a group association to an event.
-func WithGroup(groupName string, groupID string) Option {
-	return func(o *CallOptions) {
-		if o.Groups == nil {
-			o.Groups = make(map[string][]string, 1)
-		}
-		o.Groups[groupName] = append(o.Groups[groupName], groupID)
-	}
-}
-
-// WithGroupProperties sets the group properties of an event.
-func WithGroupProperties(groupID string, groupProperties map[string]any) Option {
+// WithGroupProperties appends the groups and sets the optional group properties
+// for an event.
+func WithGroupProperties(groupName string, groupID string, groupProperties map[string]any) Option {
 	return func(o *CallOptions) {
 		if o.GroupProperties == nil {
-			o.GroupProperties = make(map[string]map[string]any)
+			o.GroupProperties = make(map[string]map[string]map[string]any)
 		}
-		o.GroupProperties[groupID] = groupProperties
+		gn, ok := o.GroupProperties[groupName]
+		if !ok {
+			gn = make(map[string]map[string]any)
+			o.GroupProperties[groupName] = gn
+		}
+		gn[groupID] = groupProperties
 	}
 }
 

--- a/pkg/telemetry/phonehome/telemeter/telemeter_test.go
+++ b/pkg/telemetry/phonehome/telemeter/telemeter_test.go
@@ -10,24 +10,18 @@ func TestWith(t *testing.T) {
 	opts := ApplyOptions([]Option{
 		WithUserID("userID"),
 		WithClient("clientID", "clientType"),
-		WithGroupProperties("groupA", "groupA_id1", map[string]any{"key1": "value1"}),
-		WithGroupProperties("groupA", "groupA_id2", map[string]any{"key-": "value-"}),
-		WithGroupProperties("groupA", "groupA_id2", map[string]any{"key2": "value2"}),
-		WithGroupProperties("groupB", "groupB_id", map[string]any{"key3": "value3"}),
+		WithGroups("groupA", "groupA_id1"),
+		WithGroups("groupA", "groupA_id2"),
+		WithGroups("groupB", "groupB_id"),
 	},
 	)
 	assert.Equal(t, "userID", opts.UserID)
 	assert.Equal(t, "clientID", opts.ClientID)
 	assert.Equal(t, "clientType", opts.ClientType)
 
-	props := map[string]map[string]map[string]any{
-		"groupA": {
-			"groupA_id1": {"key1": "value1"},
-			"groupA_id2": {"key2": "value2"},
-		},
-		"groupB": {
-			"groupB_id": {"key3": "value3"},
-		},
+	props := map[string][]string{
+		"groupA": {"groupA_id1", "groupA_id2"},
+		"groupB": {"groupB_id"},
 	}
-	assert.Equal(t, props, opts.GroupProperties)
+	assert.Equal(t, props, opts.Groups)
 }

--- a/pkg/telemetry/phonehome/telemeter/telemeter_test.go
+++ b/pkg/telemetry/phonehome/telemeter/telemeter_test.go
@@ -10,21 +10,24 @@ func TestWith(t *testing.T) {
 	opts := ApplyOptions([]Option{
 		WithUserID("userID"),
 		WithClient("clientID", "clientType"),
-		WithGroup("groupA", "groupA_id1"),
-		WithGroup("groupA", "groupA_id2"),
-		WithGroupProperties("groupA_id", map[string]any{"key1": "value1"}),
-		WithGroupProperties("groupB_id", map[string]any{"key2": "value2"}),
+		WithGroupProperties("groupA", "groupA_id1", map[string]any{"key1": "value1"}),
+		WithGroupProperties("groupA", "groupA_id2", map[string]any{"key-": "value-"}),
+		WithGroupProperties("groupA", "groupA_id2", map[string]any{"key2": "value2"}),
+		WithGroupProperties("groupB", "groupB_id", map[string]any{"key3": "value3"}),
 	},
 	)
 	assert.Equal(t, "userID", opts.UserID)
 	assert.Equal(t, "clientID", opts.ClientID)
 	assert.Equal(t, "clientType", opts.ClientType)
-	assert.Len(t, opts.Groups, 1)
-	assert.Len(t, opts.Groups["groupA"], 2)
-	assert.Equal(t, "groupA_id1", opts.Groups["groupA"][0])
-	assert.Equal(t, "groupA_id2", opts.Groups["groupA"][1])
-	assert.Len(t, opts.GroupProperties["groupA_id"], 1)
-	assert.Len(t, opts.GroupProperties["groupB_id"], 1)
-	assert.Equal(t, "value1", opts.GroupProperties["groupA_id"]["key1"])
-	assert.Equal(t, "value2", opts.GroupProperties["groupB_id"]["key2"])
+
+	props := map[string]map[string]map[string]any{
+		"groupA": {
+			"groupA_id1": {"key1": "value1"},
+			"groupA_id2": {"key2": "value2"},
+		},
+		"groupB": {
+			"groupB_id": {"key3": "value3"},
+		},
+	}
+	assert.Equal(t, props, opts.GroupProperties)
 }

--- a/pkg/telemetry/phonehome/telemeter/telemeter_test.go
+++ b/pkg/telemetry/phonehome/telemeter/telemeter_test.go
@@ -10,9 +10,21 @@ func TestWith(t *testing.T) {
 	opts := ApplyOptions([]Option{
 		WithUserID("userID"),
 		WithClient("clientID", "clientType"),
+		WithGroup("groupA", "groupA_id1"),
+		WithGroup("groupA", "groupA_id2"),
+		WithGroupProperties("groupA_id", map[string]any{"key1": "value1"}),
+		WithGroupProperties("groupB_id", map[string]any{"key2": "value2"}),
 	},
 	)
 	assert.Equal(t, "userID", opts.UserID)
 	assert.Equal(t, "clientID", opts.ClientID)
 	assert.Equal(t, "clientType", opts.ClientType)
+	assert.Len(t, opts.Groups, 1)
+	assert.Len(t, opts.Groups["groupA"], 2)
+	assert.Equal(t, "groupA_id1", opts.Groups["groupA"][0])
+	assert.Equal(t, "groupA_id2", opts.Groups["groupA"][1])
+	assert.Len(t, opts.GroupProperties["groupA_id"], 1)
+	assert.Len(t, opts.GroupProperties["groupB_id"], 1)
+	assert.Equal(t, "value1", opts.GroupProperties["groupA_id"]["key1"])
+	assert.Equal(t, "value2", opts.GroupProperties["groupB_id"]["key2"])
 }


### PR DESCRIPTION
## Description

This PR adds support for Amplitude API feature: `groups` field of Track events.

* `groups` is a mapping of group names to group IDs, e.g.
  ```json
  "groups": { "Tenant": ["tenant-id1", "tenant-id2"] }
  ```

Considerations:
* Segment supports `groups` property mapping from a random context object. The PR suggests `context.groups`;
* Neither Segment nor Amplitude support `group_properties`.

The mapping configuration for the Amplitude destination on Segment side is set up like this:
![image](https://user-images.githubusercontent.com/20665445/216581158-5e4d1c17-8fdc-49d1-8a12-f28a7a685f4d.png)

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

Unit tests, local testing.

"Secured Cluster Initialized" event supplied with the Tenant group on Segment:
```json
{
  "context": {
    "device": {
      "id": "97fc111c-f1bc-418f-85ef-0fa2d15aa973",
      "type": "Secured Cluster"
    },
    "groups": {
      "Tenant": [
        "fa7bb897-a17c-4de6-a035-759a05598a77"
      ]
    },
    "library": {
      "name": "analytics-go",
      "version": "3.0.0"
    }
  },
  "event": "Secured Cluster Initialized",
  "integrations": {},
  "messageId": "3c2ea323-8038-4e46-949d-e140b89173b7",
  "originalTimestamp": "2023-02-03T11:00:06.675835925Z",
  "properties": {
    "Health": "UNHEALTHY"
  },
  "receivedAt": "2023-02-03T11:00:17.980Z",
  "sentAt": "2023-02-03T11:00:17.339Z",
  "timestamp": "2023-02-03T11:00:07.315Z",
  "type": "track",
  "userId": "97fc111c-f1bc-418f-85ef-0fa2d15aa973",
  "writeKey": "..."
}
```

Same event on Amplitude got:
```json
  "event_time": "2023-02-03 11:00:07.315000",
  "event_type": "Secured Cluster Initialized",
  "global_user_properties": {
  },
  "group_properties": {
    "Tenant": {
      "fa7bb897-a17c-4de6-a035-759a05598a77": {
      }
    }
  },
  "groups": {
    "Tenant": [
      "fa7bb897-a17c-4de6-a035-759a05598a77"
    ]
  }
```