### PR TITLE
ROX-14783: Fix SearchRawPolicies to populate policy categories from new store when postgres is enabled

### DIFF
--- a/central/policy/datastore/datastore_impl_postgres_test.go
+++ b/central/policy/datastore/datastore_impl_postgres_test.go
@@ -211,3 +211,21 @@ func (s *PolicyPostgresDataStoreTestSuite) TestSearchPolicyCategoryFeatureDisabl
 	s.Len(results, 1)
 	s.Equal(policy.GetId(), results[0].ID)
 }
+
+func (s *PolicyPostgresDataStoreTestSuite) TestSearchRawPolicies() {
+	policy := fixtures.GetPolicy()
+
+	ctx := sac.WithGlobalAccessScopeChecker(context.Background(), sac.AllowFixedScopes(
+		sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+		sac.ResourceScopeKeys(resources.Policy, resources.Cluster),
+	))
+
+	// Add policy.
+	_, err := s.datastore.AddPolicy(ctx, policy)
+	s.NoError(err)
+
+	policies, err := s.datastore.SearchRawPolicies(ctx, pkgSearch.EmptyQuery())
+	s.NoError(err)
+	s.Len(policies, 1)
+	s.Len(policies[0].Categories, 3)
+}


### PR DESCRIPTION
## Description
The Configuration Management Dashboard -> Policy Violations by severity widget stopped working with the introduction of categories. This is because the graphql API for that widget uses the `SearchRawPolicies` method in the policy datastore which had not accounted for populating policies with categories using the new way in the postgres world. Fixed it to do exactly that.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed
![Screenshot 2023-02-02 at 1 34 38 PM](https://user-images.githubusercontent.com/42253461/216454895-feb6241e-e5ee-4847-b831-474a031b2545.png)


Manual, on infra cluster.

