### PR TITLE
ROX-14790: Enable log checks on nongroovy test

### DIFF
--- a/scripts/ci/jobs/gke_nongroovy_e2e_tests.py
+++ b/scripts/ci/jobs/gke_nongroovy_e2e_tests.py
@@ -21,7 +21,7 @@ ClusterTestRunner(
     pre_test=PreSystemTests(),
     test=NonGroovyE2e(),
     post_test=PostClusterTest(
-        check_stackrox_logs=False,
+        check_stackrox_logs=True,
     ),
     final_post=FinalPost(
         store_qa_test_debug_logs=False,

--- a/scripts/ci/jobs/gke_postgres_nongroovy_e2e_tests.py
+++ b/scripts/ci/jobs/gke_postgres_nongroovy_e2e_tests.py
@@ -21,7 +21,7 @@ ClusterTestRunner(
     pre_test=PreSystemTests(),
     test=NonGroovyE2e(),
     post_test=PostClusterTest(
-        check_stackrox_logs=False,
+        check_stackrox_logs=True,
     ),
     final_post=FinalPost(
         store_qa_test_debug_logs=False,

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -440,8 +440,7 @@ wait_for_api() {
     set +e
     NUM_SUCCESSES_IN_A_ROW=0
     SUCCESSES_NEEDED_IN_A_ROW=3
-    # shellcheck disable=SC2034
-    for i in $(seq 1 40); do
+    for _ in $(seq 1 40); do
         metadata="$(curl -sk --connect-timeout 5 --max-time 10 "${METADATA_URL}")"
         metadata_exitstatus="$?"
         status="$(echo "$metadata" | jq '.licenseStatus' -r)"


### PR DESCRIPTION
## Description

Sets `check_stackrox_logs=True` in the openshift PostClusterTest for the nongroovy jobs to enable checking stackrox logs.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

TBD
