### PR TITLE
ROX-14797: Fix bulk Add CVEs to Policy for Postgres

### DIFF
--- a/ui/apps/platform/src/Containers/VulnMgmt/List/Cves/CveBulkActionDialogue.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/Cves/CveBulkActionDialogue.js
@@ -163,11 +163,13 @@ const CveBulkActionDialogue = ({ closeAction, bulkActionCveIds, cveType }) => {
         policyData.results.length &&
         policies.length === 0
     ) {
-        const existingPolicies = policyData.results.map((pol, idx) => ({
-            ...pol,
-            value: idx,
-            label: pol.name,
-        }));
+        const existingPolicies = policyData.results
+            .filter((policyToFilter) => !policyToFilter?.isDefault)
+            .map((policyToMap, idx) => ({
+                ...policyToMap,
+                value: idx,
+                label: policyToMap.name,
+            }));
         setPolicies(existingPolicies);
     }
 

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/Cves/CveBulkActionDialogue.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/Cves/CveBulkActionDialogue.js
@@ -52,11 +52,11 @@ const CveBulkActionDialogue = ({ closeAction, bulkActionCveIds, cveType }) => {
     const [policies, setPolicies] = useState([]);
 
     // use GraphQL to get the (hopefully cached) cve summaries to display in the dialog
-    let cveQuery = '';
+    let CVE_QUERY = '';
 
     switch (cveType) {
         case entityTypes.NODE_CVE: {
-            cveQuery = gql`
+            CVE_QUERY = gql`
                 query getNodeCves($query: String) {
                     results: nodeVulnerabilities(query: $query) {
                         id
@@ -68,7 +68,7 @@ const CveBulkActionDialogue = ({ closeAction, bulkActionCveIds, cveType }) => {
             break;
         }
         case entityTypes.CLUSTER_CVE: {
-            cveQuery = gql`
+            CVE_QUERY = gql`
                 query getClusterCves($query: String) {
                     results: clusterVulnerabilities(query: $query) {
                         id
@@ -80,7 +80,7 @@ const CveBulkActionDialogue = ({ closeAction, bulkActionCveIds, cveType }) => {
             break;
         }
         case entityTypes.IMAGE_CVE: {
-            cveQuery = gql`
+            CVE_QUERY = gql`
                 query getImageCves($query: String) {
                     results: imageVulnerabilities(query: $query) {
                         id
@@ -93,7 +93,7 @@ const CveBulkActionDialogue = ({ closeAction, bulkActionCveIds, cveType }) => {
         }
         case entityTypes.CVE:
         default: {
-            cveQuery = gql`
+            CVE_QUERY = gql`
                 query getCves($query: String) {
                     results: vulnerabilities(query: $query) {
                         id
@@ -110,12 +110,12 @@ const CveBulkActionDialogue = ({ closeAction, bulkActionCveIds, cveType }) => {
     const cvesObj = {
         cve: cvesStr,
     };
-    const cveQueryOptions = {
+    const CVE_QUERY_OPTIONS = {
         variables: {
             query: queryService.objectToWhereClause(cvesObj),
         },
     };
-    const { loading: cveLoading, data: cveData } = useQuery(cveQuery, cveQueryOptions);
+    const { loading: cveLoading, data: cveData } = useQuery(CVE_QUERY, CVE_QUERY_OPTIONS);
     const cveItems =
         !cveLoading && cveData && cveData.results && cveData.results.length ? cveData.results : [];
 

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/Cves/CveBulkActionDialogue.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/Cves/CveBulkActionDialogue.js
@@ -1,6 +1,7 @@
 import React, { useState, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { gql, useQuery } from '@apollo/client';
+import cloneDeep from 'lodash/cloneDeep';
 import get from 'lodash/get';
 import set from 'lodash/set';
 import uniqBy from 'lodash/uniqBy';
@@ -186,7 +187,7 @@ const CveBulkActionDialogue = ({ closeAction, bulkActionCveIds, cveType }) => {
     function setSelectedPolicy(selectedPolicy) {
         // checking if the policy already exists or has already been added to the policy list
         const policyExists = policies && policies.find((pol) => pol.value === selectedPolicy.value);
-        const newPolicy = { ...selectedPolicy };
+        const newPolicy = cloneDeep(selectedPolicy);
         const newCveSection = {
             sectionName: 'CVEs',
             policyGroups: [{ fieldName: 'CVE', values: allowedCvesValues }],
@@ -194,11 +195,11 @@ const CveBulkActionDialogue = ({ closeAction, bulkActionCveIds, cveType }) => {
 
         if (policyExists) {
             // find policySection and policyGroup with CVEs
-            const { policySectionIdx, policyGroupIdx } = findCVEField(
-                selectedPolicy.policySections
-            );
+            const { policySectionIdx, policyGroupIdx } = findCVEField(newPolicy.policySections);
+
             // it matches an existing policy's ID, so must have been selected from existing list
-            const newPolicySections = [...selectedPolicy.policySections];
+            const newPolicySections = [...newPolicy.policySections];
+
             if (policySectionIdx !== null) {
                 newPolicySections[policySectionIdx].policyGroups[policyGroupIdx].values.push(
                     ...allowedCvesValues
@@ -279,12 +280,12 @@ const CveBulkActionDialogue = ({ closeAction, bulkActionCveIds, cveType }) => {
             text=""
             onConfirm={cvesToDisplay.length > 0 ? addToPolicy : null}
             confirmText="Save Policy"
-            confirmDisabled={
+            confirmDisabled={Boolean(
                 messageObj ||
-                policy.name.length < 6 ||
-                !policy.severity ||
-                !policy.lifecycleStages.length
-            }
+                    policy.name.length < 6 ||
+                    !policy.severity ||
+                    !policy.lifecycleStages.length
+            )}
             onCancel={closeWithoutSaving}
         >
             <div className="overflow-auto p-4" ref={dialogueRef}>

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/Cves/CveToPolicyShortForm.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/Cves/CveToPolicyShortForm.js
@@ -238,14 +238,14 @@ CveToPolicyShortForm.propTypes = {
     policies: PropTypes.arrayOf(
         PropTypes.shape({ label: PropTypes.string, value: PropTypes.string })
     ),
-    selectedPolicy: PropTypes.string,
+    selectedPolicy: PropTypes.number,
     setSelectedPolicy: PropTypes.func.isRequired,
     handleChange: PropTypes.func.isRequired,
 };
 
 CveToPolicyShortForm.defaultProps = {
     policies: [],
-    selectedPolicy: '',
+    selectedPolicy: null,
 };
 
 export default CveToPolicyShortForm;

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/Cves/VulnMgmtListCves.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/Cves/VulnMgmtListCves.js
@@ -586,6 +586,7 @@ const VulnMgmtCves = ({
                 <CveBulkActionDialogue
                     closeAction={closeDialog}
                     bulkActionCveIds={bulkActionCveIds}
+                    cveType={cveType}
                 />
             )}
         </>

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/Cves/VulnMgmtListCves.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/Cves/VulnMgmtListCves.js
@@ -471,12 +471,14 @@ const VulnMgmtCves = ({
 
     const renderRowActionButtons = ({ cve }) => (
         <div className="flex border-2 border-r-2 border-base-400 bg-base-100">
-            <RowActionButton
-                text="Add to Policy"
-                onClick={addToPolicy(cve)}
-                date-testid="row-action-add-to-policy"
-                icon={<Icon.Plus className="my-1 h-4 w-4" />}
-            />
+            {(cveType === entityTypes.CVE || cveType === entityTypes.IMAGE_CVE) && (
+                <RowActionButton
+                    text="Add to Policy"
+                    onClick={addToPolicy(cve)}
+                    date-testid="row-action-add-to-policy"
+                    icon={<Icon.Plus className="my-1 h-4 w-4" />}
+                />
+            )}
             {!viewingSuppressed && (
                 <RowActionMenu
                     className="h-full min-w-30"
@@ -504,16 +506,18 @@ const VulnMgmtCves = ({
 
     const tableHeaderComponents = (
         <>
-            <PanelButton
-                icon={<Icon.Plus className="h-4 w-4" />}
-                className="btn-icon btn-tertiary"
-                onClick={addToPolicy()}
-                disabled={selectedCveIds.length === 0}
-                tooltip="Add Selected CVEs to Policy"
-                dataTestId="panel-button-add-cves-to-policy"
-            >
-                Add to Policy
-            </PanelButton>
+            {(cveType === entityTypes.CVE || cveType === entityTypes.IMAGE_CVE) && (
+                <PanelButton
+                    icon={<Icon.Plus className="h-4 w-4" />}
+                    className="btn-icon btn-tertiary"
+                    onClick={addToPolicy()}
+                    disabled={selectedCveIds.length === 0}
+                    tooltip="Add Selected CVEs to Policy"
+                    dataTestId="panel-button-add-cves-to-policy"
+                >
+                    Add to Policy
+                </PanelButton>
+            )}
             {!viewingSuppressed && (
                 <Menu
                     className="h-full min-w-30 ml-2"

--- a/ui/apps/platform/src/utils/vulnerabilityUtils.js
+++ b/ui/apps/platform/src/utils/vulnerabilityUtils.js
@@ -203,6 +203,10 @@ export function parseCVESearch(searchState) {
 export function splitCvesByType(cves = []) {
     return cves.reduce(
         (acc, cve) => {
+            // TODO: remove this whole function and the logic that calls it after RocksDB no longer supported
+            if (!cve.vulnerabilityTypes) {
+                return acc;
+            }
             if (cve.vulnerabilityTypes.includes('IMAGE_CVE')) {
                 acc.IMAGE_CVE.push(cve);
             }


### PR DESCRIPTION
## Description

The main purpose of this change is to fix a gap when migrating to Postgres, where CVEs could no longer be added to a policy from the CVE list pages.

In addition, it cleans up some "drift" in functionality, and some bugs that show this hasn't been a much-used feature.

- It filters out default policies from the list of existing VM policies that CVEs could be added to, because at some point subsequent to this default policies became read-only.
- It fixes a bug where existing non-default (i.e., customer-created) polices could not be selected, because of the way the VM data flow "locks" the JS objects that are passed by reference into this dialog. (The solution is to use a utility function to deep clone the an existing policy object selected as a target. The clone does not have the "locked" state, so the new CVEs can be added to it. In this case, the single policy object is a finite size, so the clone is neither slow nor particularly memory intensive.)
- Fixed several browser console warnings about incorrect React type declarations. (This code is from before we started to use TypeScript.)
- Removed the Add to Policy option from lists of Node and Platform CVEs, because those are not applicable to our polices at this time.

## Checklist
- [x] Investigated and inspected CI test results (failing Go unit tests are flakes)

## Testing Performed

Manual testing
1. Confirmed that we can add CVEs to a new policy
2. Confirmed that only non-default policies now appear in the dropdown list of possible target existing policies.
3. Confirmed that we can add CVEs to an existing non-default policy.

![Screen Shot 2023-02-07 at 12 13 38 PM](https://user-images.githubusercontent.com/715729/217574909-d3e913f2-1133-4636-8dbb-d66a806986e1.png)

![Screen Shot 2023-02-07 at 11 57 46 AM](https://user-images.githubusercontent.com/715729/217574937-4d3c0b29-a987-41bf-9be8-9a4a80ecc796.png)
