### PR TITLE
ROX-14148: Prefactor Configuration interface for declarative configurations

### DIFF
--- a/pkg/declarativeconfig/access_scope.go
+++ b/pkg/declarativeconfig/access_scope.go
@@ -13,6 +13,11 @@ type AccessScope struct {
 	Rules       Rules  `yaml:"rules,omitempty"`
 }
 
+// Type returns the AccessScopeConfiguration type.
+func (a *AccessScope) Type() ConfigurationType {
+	return AccessScopeConfiguration
+}
+
 // Operator is representation of storage.SetBasedLabelSelector_Operator that supports transformation from YAML.
 type Operator storage.SetBasedLabelSelector_Operator
 

--- a/pkg/declarativeconfig/auth_provider.go
+++ b/pkg/declarativeconfig/auth_provider.go
@@ -80,3 +80,8 @@ type AuthProvider struct {
 	UserpkiConfig      *UserpkiConfig      `yaml:"userpki,omitempty"`
 	OpenshiftConfig    *OpenshiftConfig    `yaml:"openshift,omitempty"`
 }
+
+// Type returns the AuthProviderConfiguration type.
+func (a *AuthProvider) Type() ConfigurationType {
+	return AuthProviderConfiguration
+}

--- a/pkg/declarativeconfig/configuration.go
+++ b/pkg/declarativeconfig/configuration.go
@@ -1,0 +1,17 @@
+package declarativeconfig
+
+// ConfigurationType specifies the type of declarative configuration.
+type ConfigurationType = string
+
+// The list of currently supported and implemented declarative configuration types.
+const (
+	AuthProviderConfiguration  ConfigurationType = "auth-provider"
+	AccessScopeConfiguration   ConfigurationType = "access-scope"
+	PermissionSetConfiguration ConfigurationType = "permission-set"
+	RoleConfiguration          ConfigurationType = "role"
+)
+
+// Configuration specifies a declarative configuration.
+type Configuration interface {
+	Type() ConfigurationType
+}

--- a/pkg/declarativeconfig/permission_set.go
+++ b/pkg/declarativeconfig/permission_set.go
@@ -13,6 +13,11 @@ type PermissionSet struct {
 	Resources   []ResourceWithAccess `yaml:"resources,omitempty"`
 }
 
+// Type returns the PermissionSetConfiguration type.
+func (p *PermissionSet) Type() ConfigurationType {
+	return PermissionSetConfiguration
+}
+
 // Access is representation of storage.Access that supports transformation from YAML.
 type Access storage.Access
 

--- a/pkg/declarativeconfig/role.go
+++ b/pkg/declarativeconfig/role.go
@@ -7,3 +7,8 @@ type Role struct {
 	AccessScope   string `yaml:"accessScope,omitempty"`
 	PermissionSet string `yaml:"permissionSet,omitempty"`
 }
+
+// Type returns the RoleConfiguration type.
+func (r *Role) Type() ConfigurationType {
+	return RoleConfiguration
+}


### PR DESCRIPTION
## Description

This PR is a prefactor for [ROX-14148](https://issues.redhat.com/browse/ROX-14148), which shall add the transformation logic for each specific declarative configuration type.

We introduce a new interface `Configuration`, which will be used to abstract all different types of declarative configuration such as `Access Scope, AuthProvider, Permission Set, Role`.

For now, the interface exposes only a single method, which is `Type()` to return a string enum which specifies the type of the declarative configuration.

This will later on be used to differentiate between the configurations when transforming them.

Later on, this interface will most likely also be extended to support a `Validate()` method, validating the contents of the YAMLs.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

- no testing required.
