### PR TITLE
ROX-14148: Prefactor Transformer abstraqction for declarative configuration.

### DIFF
--- a/central/declarativeconfig/manager_impl.go
+++ b/central/declarativeconfig/manager_impl.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/stackrox/rox/central/declarativeconfig/transform"
+	"github.com/stackrox/rox/pkg/declarativeconfig/transform"
 	"github.com/stackrox/rox/pkg/k8scfgwatch"
 	"github.com/stackrox/rox/pkg/sync"
 )

--- a/central/declarativeconfig/manager_impl.go
+++ b/central/declarativeconfig/manager_impl.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/stackrox/rox/central/declarativeconfig/transform"
 	"github.com/stackrox/rox/pkg/k8scfgwatch"
 	"github.com/stackrox/rox/pkg/sync"
 )
@@ -15,13 +16,16 @@ const (
 
 type managerImpl struct {
 	once sync.Once
+	t    transform.Transformer
 }
 
 // New creates a new instance of Manager.
 // Note that it will not watch the declarative configuration directories when created, only after
 // WatchDeclarativeConfigDir has been called.
 func New() Manager {
-	return &managerImpl{}
+	return &managerImpl{
+		t: transform.New(),
+	}
 }
 
 func (m *managerImpl) WatchDeclarativeConfigDir() {

--- a/central/declarativeconfig/transform/transformer.go
+++ b/central/declarativeconfig/transform/transformer.go
@@ -1,0 +1,36 @@
+package transform
+
+import (
+	"context"
+
+	"github.com/gogo/protobuf/proto"
+	"github.com/stackrox/rox/pkg/declarativeconfig"
+	"github.com/stackrox/rox/pkg/errox"
+)
+
+// Transformer transforms a declarativeconfig.Configuration to proto.Message(s).
+type Transformer interface {
+	Transform(ctx context.Context, config declarativeconfig.Configuration) ([]proto.Message, error)
+}
+
+// New creates a Transformer that can handle transforming all currently supported declarativeconfig.Configuration.
+func New() Transformer {
+	return &defaultTransformer{configurationTransformers: map[string]Transformer{
+		declarativeconfig.AuthProviderConfiguration:  nil,
+		declarativeconfig.AccessScopeConfiguration:   nil,
+		declarativeconfig.RoleConfiguration:          nil,
+		declarativeconfig.PermissionSetConfiguration: nil,
+	}}
+}
+
+type defaultTransformer struct {
+	configurationTransformers map[string]Transformer
+}
+
+func (t *defaultTransformer) Transform(ctx context.Context, config declarativeconfig.Configuration) ([]proto.Message, error) {
+	ct, exists := t.configurationTransformers[config.Type()]
+	if !exists {
+		return nil, errox.NotFound.Newf("no transformation logic for declarative config type %s found", config.Type())
+	}
+	return ct.Transform(ctx, config)
+}

--- a/central/declarativeconfig/transform/transformer.go
+++ b/central/declarativeconfig/transform/transformer.go
@@ -1,8 +1,6 @@
 package transform
 
 import (
-	"context"
-
 	"github.com/gogo/protobuf/proto"
 	"github.com/stackrox/rox/pkg/declarativeconfig"
 	"github.com/stackrox/rox/pkg/errox"
@@ -10,7 +8,7 @@ import (
 
 // Transformer transforms a declarativeconfig.Configuration to proto.Message(s).
 type Transformer interface {
-	Transform(ctx context.Context, config declarativeconfig.Configuration) ([]proto.Message, error)
+	Transform(config declarativeconfig.Configuration) ([]proto.Message, error)
 }
 
 // New creates a Transformer that can handle transforming all currently supported declarativeconfig.Configuration.
@@ -27,10 +25,10 @@ type defaultTransformer struct {
 	configurationTransformers map[string]Transformer
 }
 
-func (t *defaultTransformer) Transform(ctx context.Context, config declarativeconfig.Configuration) ([]proto.Message, error) {
+func (t *defaultTransformer) Transform(config declarativeconfig.Configuration) ([]proto.Message, error) {
 	ct, exists := t.configurationTransformers[config.Type()]
 	if !exists {
 		return nil, errox.NotFound.Newf("no transformation logic for declarative config type %s found", config.Type())
 	}
-	return ct.Transform(ctx, config)
+	return ct.Transform(config)
 }


### PR DESCRIPTION
## Description

This PR is a prefactor for [ROX-14148](https://issues.redhat.com/browse/ROX-14148) and adds an abstraction for transforming a declarative configuration to its associated proto message(s).

The previously introduced `ConfigurationType` will be re-used to distinguish which transformer to use.

For now, the default transformer created and used within the declarative configuration manager will not have any transformer implementations associated with it, those will be added at in follow-up PRs in the context of [ROX-14148](https://issues.redhat.com/browse/ROX-14148).

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

- no testing requried.
