### PR TITLE
ROX-14148: Add transforming of declarative config to proto for Access Scopes

### DIFF
--- a/pkg/declarativeconfig/transform/access_scope.go
+++ b/pkg/declarativeconfig/transform/access_scope.go
@@ -1,8 +1,6 @@
 package transform
 
 import (
-	"context"
-
 	"github.com/gogo/protobuf/proto"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/declarativeconfig"
@@ -17,7 +15,7 @@ func newAccessScopeTransform() *accessScopeTransform {
 	return &accessScopeTransform{}
 }
 
-func (a *accessScopeTransform) Transform(ctx context.Context, configuration declarativeconfig.Configuration) ([]proto.Message, error) {
+func (a *accessScopeTransform) Transform(configuration declarativeconfig.Configuration) ([]proto.Message, error) {
 	scopeConfig, ok := configuration.(*declarativeconfig.AccessScope)
 	if !ok {
 		return nil, errox.InvalidArgs.Newf("invalid configuration type received for access scope: %T", configuration)

--- a/pkg/declarativeconfig/transform/access_scope.go
+++ b/pkg/declarativeconfig/transform/access_scope.go
@@ -1,0 +1,101 @@
+package transform
+
+import (
+	"context"
+
+	"github.com/gogo/protobuf/proto"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/declarativeconfig"
+	"github.com/stackrox/rox/pkg/errox"
+)
+
+var _ Transformer = (*accessScopeTransform)(nil)
+
+type accessScopeTransform struct{}
+
+func newAccessScopeTransform() *accessScopeTransform {
+	return &accessScopeTransform{}
+}
+
+func (a *accessScopeTransform) Transform(ctx context.Context, configuration declarativeconfig.Configuration) ([]proto.Message, error) {
+	scopeConfig, ok := configuration.(*declarativeconfig.AccessScope)
+	if !ok {
+		return nil, errox.InvalidArgs.Newf("invalid configuration type received for access scope: %T", configuration)
+	}
+	scopeProto := &storage.SimpleAccessScope{
+		Id:          declarativeconfig.NewDeclarativeAccessScopeUUID(scopeConfig.Name).String(),
+		Name:        scopeConfig.Name,
+		Description: scopeConfig.Description,
+		Rules:       rulesFromScopeConfig(scopeConfig),
+		Traits: &storage.Traits{
+			Origin: storage.Traits_DECLARATIVE,
+		},
+	}
+	return []proto.Message{scopeProto}, nil
+}
+
+func rulesFromScopeConfig(scope *declarativeconfig.AccessScope) *storage.SimpleAccessScope_Rules {
+	return &storage.SimpleAccessScope_Rules{
+		IncludedClusters:        includedClustersFromScopeConfig(scope),
+		IncludedNamespaces:      includedNamespacesFromScopeConfig(scope),
+		ClusterLabelSelectors:   clusterLabelSelectorsFromScopeConfig(scope),
+		NamespaceLabelSelectors: namespaceLabelSelectorsFromScopeConfig(scope),
+	}
+}
+
+func includedClustersFromScopeConfig(scope *declarativeconfig.AccessScope) []string {
+	clusters := make([]string, 0, len(scope.Rules.IncludedObjects))
+	for _, obj := range scope.Rules.IncludedObjects {
+		clusters = append(clusters, obj.Cluster)
+	}
+	return clusters
+}
+
+func includedNamespacesFromScopeConfig(scope *declarativeconfig.AccessScope) []*storage.SimpleAccessScope_Rules_Namespace {
+	var namespaces []*storage.SimpleAccessScope_Rules_Namespace
+	for _, obj := range scope.Rules.IncludedObjects {
+		for _, namespace := range obj.Namespaces {
+			namespaces = append(namespaces, &storage.SimpleAccessScope_Rules_Namespace{
+				ClusterName:   obj.Cluster,
+				NamespaceName: namespace,
+			})
+		}
+	}
+	return namespaces
+}
+
+func clusterLabelSelectorsFromScopeConfig(scope *declarativeconfig.AccessScope) []*storage.SetBasedLabelSelector {
+	var clusterLabelSelectors []*storage.SetBasedLabelSelector
+	for _, cl := range scope.Rules.ClusterLabelSelectors {
+		reqs := make([]*storage.SetBasedLabelSelector_Requirement, 0, len(cl.Requirements))
+		for _, req := range cl.Requirements {
+			reqs = append(reqs, &storage.SetBasedLabelSelector_Requirement{
+				Key:    req.Key,
+				Op:     storage.SetBasedLabelSelector_Operator(req.Operator),
+				Values: req.Values,
+			})
+		}
+		clusterLabelSelectors = append(clusterLabelSelectors, &storage.SetBasedLabelSelector{
+			Requirements: reqs,
+		})
+	}
+	return clusterLabelSelectors
+}
+
+func namespaceLabelSelectorsFromScopeConfig(scope *declarativeconfig.AccessScope) []*storage.SetBasedLabelSelector {
+	var namespaceLabelSelector []*storage.SetBasedLabelSelector
+	for _, nl := range scope.Rules.NamespaceLabelSelectors {
+		reqs := make([]*storage.SetBasedLabelSelector_Requirement, 0, len(nl.Requirements))
+		for _, req := range nl.Requirements {
+			reqs = append(reqs, &storage.SetBasedLabelSelector_Requirement{
+				Key:    req.Key,
+				Op:     storage.SetBasedLabelSelector_Operator(req.Operator),
+				Values: req.Values,
+			})
+		}
+		namespaceLabelSelector = append(namespaceLabelSelector, &storage.SetBasedLabelSelector{
+			Requirements: reqs,
+		})
+	}
+	return namespaceLabelSelector
+}

--- a/pkg/declarativeconfig/transform/access_scope_test.go
+++ b/pkg/declarativeconfig/transform/access_scope_test.go
@@ -1,0 +1,275 @@
+package transform
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/declarativeconfig"
+	"github.com/stackrox/rox/pkg/errox"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWrongConfigurationTypeTransform(t *testing.T) {
+	at := newAccessScopeTransform()
+	msgs, err := at.Transform(context.TODO(), &declarativeconfig.AuthProvider{})
+	assert.Nil(t, msgs)
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, errox.InvalidArgs)
+}
+
+func TestTransformAccessScope(t *testing.T) {
+	at := newAccessScopeTransform()
+
+	// 1. Access scope with empty rules mimicking an unrestricted scope.
+	scopeConfig := &declarativeconfig.AccessScope{
+		Name:        "test-scope",
+		Description: "test description",
+		Rules:       declarativeconfig.Rules{},
+	}
+
+	msgs, err := at.Transform(context.TODO(), scopeConfig)
+	assert.NoError(t, err)
+	require.Len(t, msgs, 1)
+	msg := msgs[0]
+	scopeProto, ok := msg.(*storage.SimpleAccessScope)
+	require.True(t, ok)
+	assert.Equal(t, scopeConfig.Name, scopeProto.GetName())
+	assert.Equal(t, scopeConfig.Description, scopeProto.GetDescription())
+	assert.Equal(t, storage.Traits_DECLARATIVE, scopeProto.GetTraits().GetOrigin())
+	assert.Empty(t, scopeProto.GetRules().GetIncludedClusters())
+	assert.Empty(t, scopeProto.GetRules().GetNamespaceLabelSelectors())
+	assert.Empty(t, scopeProto.GetRules().GetClusterLabelSelectors())
+
+	// 2. Access scope with cluster label selectors.
+	scopeConfig = &declarativeconfig.AccessScope{
+		Name:        "test-scope",
+		Description: "test description",
+		Rules: declarativeconfig.Rules{
+			ClusterLabelSelectors: []declarativeconfig.LabelSelector{
+				{Requirements: []declarativeconfig.Requirement{
+					{
+						Key:      "a",
+						Operator: 1,
+						Values:   []string{"a", "b", "c"}}}}}},
+	}
+	msgs, err = at.Transform(context.TODO(), scopeConfig)
+	assert.NoError(t, err)
+	require.Len(t, msgs, 1)
+	msg = msgs[0]
+	scopeProto, ok = msg.(*storage.SimpleAccessScope)
+	require.True(t, ok)
+	assert.Equal(t, scopeConfig.Name, scopeProto.GetName())
+	assert.Equal(t, scopeConfig.Description, scopeProto.GetDescription())
+	assert.Equal(t, storage.Traits_DECLARATIVE, scopeProto.GetTraits().GetOrigin())
+	compareClusterLabelSelectors(t, scopeConfig, scopeProto)
+	assert.Empty(t, scopeProto.GetRules().GetIncludedClusters())
+	assert.Empty(t, scopeProto.GetRules().GetNamespaceLabelSelectors())
+	assert.Empty(t, scopeProto.GetRules().GetIncludedNamespaces())
+
+	// 3. Access scope with namespace label selectors.
+	scopeConfig = &declarativeconfig.AccessScope{
+		Name:        "test-scope",
+		Description: "test description",
+		Rules: declarativeconfig.Rules{
+			NamespaceLabelSelectors: []declarativeconfig.LabelSelector{
+				{Requirements: []declarativeconfig.Requirement{
+					{
+						Key:      "a",
+						Operator: 1,
+						Values:   []string{"a", "b", "c"}}}}}},
+	}
+	msgs, err = at.Transform(context.TODO(), scopeConfig)
+	assert.NoError(t, err)
+	require.Len(t, msgs, 1)
+	msg = msgs[0]
+	scopeProto, ok = msg.(*storage.SimpleAccessScope)
+	require.True(t, ok)
+	assert.Equal(t, scopeConfig.Name, scopeProto.GetName())
+	assert.Equal(t, scopeConfig.Description, scopeProto.GetDescription())
+	assert.Equal(t, storage.Traits_DECLARATIVE, scopeProto.GetTraits().GetOrigin())
+	compareNamespaceLabelSelectors(t, scopeConfig, scopeProto)
+	assert.Empty(t, scopeProto.GetRules().GetIncludedClusters())
+	assert.Empty(t, scopeProto.GetRules().GetClusterLabelSelectors())
+	assert.Empty(t, scopeProto.GetRules().GetIncludedNamespaces())
+
+	// 4. Access scope with cluster and label selectors.
+	scopeConfig = &declarativeconfig.AccessScope{
+		Name:        "test-scope",
+		Description: "test description",
+		Rules: declarativeconfig.Rules{
+			ClusterLabelSelectors: []declarativeconfig.LabelSelector{
+				{Requirements: []declarativeconfig.Requirement{{
+					Key:      "a",
+					Operator: 1,
+					Values:   []string{"a", "b", "c"},
+				}}},
+			},
+			NamespaceLabelSelectors: []declarativeconfig.LabelSelector{
+				{Requirements: []declarativeconfig.Requirement{
+					{
+						Key:      "a",
+						Operator: 1,
+						Values:   []string{"a", "b", "c"}}}}}},
+	}
+	msgs, err = at.Transform(context.TODO(), scopeConfig)
+	assert.NoError(t, err)
+	require.Len(t, msgs, 1)
+	msg = msgs[0]
+	scopeProto, ok = msg.(*storage.SimpleAccessScope)
+	require.True(t, ok)
+	assert.Equal(t, scopeConfig.Name, scopeProto.GetName())
+	assert.Equal(t, scopeConfig.Description, scopeProto.GetDescription())
+	assert.Equal(t, storage.Traits_DECLARATIVE, scopeProto.GetTraits().GetOrigin())
+	compareNamespaceLabelSelectors(t, scopeConfig, scopeProto)
+	compareClusterLabelSelectors(t, scopeConfig, scopeProto)
+	assert.Empty(t, scopeProto.GetRules().GetIncludedClusters())
+	assert.Empty(t, scopeProto.GetRules().GetIncludedNamespaces())
+
+	// 5. Access scope with included clusters.
+	scopeConfig = &declarativeconfig.AccessScope{
+		Name:        "test-scope",
+		Description: "test description",
+		Rules: declarativeconfig.Rules{
+			IncludedObjects: []declarativeconfig.IncludedObject{
+				{Cluster: "clusterA"},
+				{Cluster: "clusterB"},
+				{Cluster: "clusterC"},
+			},
+		},
+	}
+	msgs, err = at.Transform(context.TODO(), scopeConfig)
+	assert.NoError(t, err)
+	require.Len(t, msgs, 1)
+	msg = msgs[0]
+	scopeProto, ok = msg.(*storage.SimpleAccessScope)
+	require.True(t, ok)
+	assert.Equal(t, scopeConfig.Name, scopeProto.GetName())
+	assert.Equal(t, scopeConfig.Description, scopeProto.GetDescription())
+	assert.Equal(t, storage.Traits_DECLARATIVE, scopeProto.GetTraits().GetOrigin())
+	assert.Empty(t, scopeProto.GetRules().GetClusterLabelSelectors())
+	assert.Empty(t, scopeProto.GetRules().GetNamespaceLabelSelectors())
+	assert.ElementsMatch(t, []string{"clusterA", "clusterB", "clusterC"}, scopeProto.GetRules().GetIncludedClusters())
+
+	// 6. Access scope with included clusters and namespaces.
+	scopeConfig = &declarativeconfig.AccessScope{
+		Name:        "test-scope",
+		Description: "test description",
+		Rules: declarativeconfig.Rules{
+			IncludedObjects: []declarativeconfig.IncludedObject{
+				{Cluster: "clusterA", Namespaces: []string{"NamespaceA", "NamespaceB"}},
+				{Cluster: "clusterB", Namespaces: []string{"NamespaceC", "NamespaceD"}},
+			},
+		},
+	}
+	msgs, err = at.Transform(context.TODO(), scopeConfig)
+	assert.NoError(t, err)
+	require.Len(t, msgs, 1)
+	msg = msgs[0]
+	scopeProto, ok = msg.(*storage.SimpleAccessScope)
+	require.True(t, ok)
+	assert.Equal(t, scopeConfig.Name, scopeProto.GetName())
+	assert.Equal(t, scopeConfig.Description, scopeProto.GetDescription())
+	assert.Equal(t, storage.Traits_DECLARATIVE, scopeProto.GetTraits().GetOrigin())
+	assert.Empty(t, scopeProto.GetRules().GetClusterLabelSelectors())
+	assert.Empty(t, scopeProto.GetRules().GetNamespaceLabelSelectors())
+	assert.Equal(t, []string{"clusterA", "clusterB"}, scopeProto.GetRules().GetIncludedClusters())
+	expectedNamespaces := []*storage.SimpleAccessScope_Rules_Namespace{
+		{
+			ClusterName:   "clusterA",
+			NamespaceName: "NamespaceA",
+		},
+		{
+			ClusterName:   "clusterA",
+			NamespaceName: "NamespaceB",
+		},
+		{
+			ClusterName:   "clusterB",
+			NamespaceName: "NamespaceC",
+		},
+		{
+			ClusterName:   "clusterB",
+			NamespaceName: "NamespaceD",
+		},
+	}
+	assert.ElementsMatch(t, expectedNamespaces, scopeProto.GetRules().GetIncludedNamespaces())
+
+	// 7. Access scope with "everything-and-the-kitchen-sink", i.e. cluster/namespace label selectors, clusters, and
+	//    namespaces
+	scopeConfig = &declarativeconfig.AccessScope{
+		Name:        "test-scope",
+		Description: "test description",
+		Rules: declarativeconfig.Rules{
+			IncludedObjects: []declarativeconfig.IncludedObject{
+				{Cluster: "clusterA", Namespaces: []string{"NamespaceA", "NamespaceB"}},
+				{Cluster: "clusterB", Namespaces: []string{"NamespaceC", "NamespaceD"}},
+			},
+			ClusterLabelSelectors: []declarativeconfig.LabelSelector{
+				{Requirements: []declarativeconfig.Requirement{{
+					Key:      "a",
+					Operator: 1,
+					Values:   []string{"a", "b", "c"},
+				}}},
+			},
+			NamespaceLabelSelectors: []declarativeconfig.LabelSelector{
+				{Requirements: []declarativeconfig.Requirement{
+					{
+						Key:      "a",
+						Operator: 1,
+						Values:   []string{"a", "b", "c"}}}}}},
+	}
+	msgs, err = at.Transform(context.TODO(), scopeConfig)
+	assert.NoError(t, err)
+	require.Len(t, msgs, 1)
+	msg = msgs[0]
+	scopeProto, ok = msg.(*storage.SimpleAccessScope)
+	require.True(t, ok)
+	assert.Equal(t, scopeConfig.Name, scopeProto.GetName())
+	assert.Equal(t, scopeConfig.Description, scopeProto.GetDescription())
+	assert.Equal(t, storage.Traits_DECLARATIVE, scopeProto.GetTraits().GetOrigin())
+	compareNamespaceLabelSelectors(t, scopeConfig, scopeProto)
+	compareClusterLabelSelectors(t, scopeConfig, scopeProto)
+	assert.Equal(t, []string{"clusterA", "clusterB"}, scopeProto.GetRules().GetIncludedClusters())
+	expectedNamespaces = []*storage.SimpleAccessScope_Rules_Namespace{
+		{
+			ClusterName:   "clusterA",
+			NamespaceName: "NamespaceA",
+		},
+		{
+			ClusterName:   "clusterA",
+			NamespaceName: "NamespaceB",
+		},
+		{
+			ClusterName:   "clusterB",
+			NamespaceName: "NamespaceC",
+		},
+		{
+			ClusterName:   "clusterB",
+			NamespaceName: "NamespaceD",
+		},
+	}
+	assert.ElementsMatch(t, expectedNamespaces, scopeProto.GetRules().GetIncludedNamespaces())
+}
+
+func compareClusterLabelSelectors(t *testing.T, scopeConfig *declarativeconfig.AccessScope, scopeProto *storage.SimpleAccessScope) {
+	for clID, cl := range scopeConfig.Rules.ClusterLabelSelectors {
+		for reqID, req := range cl.Requirements {
+			protoReq := scopeProto.GetRules().GetClusterLabelSelectors()[clID].GetRequirements()[reqID]
+			assert.Equal(t, req.Key, protoReq.GetKey())
+			assert.Equal(t, storage.SetBasedLabelSelector_Operator(req.Operator), protoReq.GetOp())
+			assert.Equal(t, req.Values, protoReq.GetValues())
+		}
+	}
+}
+
+func compareNamespaceLabelSelectors(t *testing.T, scopeConfig *declarativeconfig.AccessScope, scopeProto *storage.SimpleAccessScope) {
+	for nlID, nl := range scopeConfig.Rules.NamespaceLabelSelectors {
+		for reqID, req := range nl.Requirements {
+			protoReq := scopeProto.GetRules().GetNamespaceLabelSelectors()[nlID].GetRequirements()[reqID]
+			assert.Equal(t, req.Key, protoReq.GetKey())
+			assert.Equal(t, storage.SetBasedLabelSelector_Operator(req.Operator), protoReq.GetOp())
+			assert.Equal(t, req.Values, protoReq.GetValues())
+		}
+	}
+}

--- a/pkg/declarativeconfig/transform/access_scope_test.go
+++ b/pkg/declarativeconfig/transform/access_scope_test.go
@@ -70,7 +70,7 @@ func TestTransformAccessScope(t *testing.T) {
 	assert.Equal(t, scopeConfig.Name, scopeProto.GetName())
 	assert.Equal(t, scopeConfig.Description, scopeProto.GetDescription())
 	assert.Equal(t, storage.Traits_DECLARATIVE, scopeProto.GetTraits().GetOrigin())
-	compareClusterLabelSelectors(t, scopeConfig, scopeProto)
+	compareLabelSelectors(t, scopeConfig.Rules.ClusterLabelSelectors, scopeProto.GetRules().GetClusterLabelSelectors())
 	assert.Empty(t, scopeProto.GetRules().GetIncludedClusters())
 	assert.Empty(t, scopeProto.GetRules().GetNamespaceLabelSelectors())
 	assert.Empty(t, scopeProto.GetRules().GetIncludedNamespaces())
@@ -98,7 +98,7 @@ func TestTransformAccessScope(t *testing.T) {
 	assert.Equal(t, scopeConfig.Name, scopeProto.GetName())
 	assert.Equal(t, scopeConfig.Description, scopeProto.GetDescription())
 	assert.Equal(t, storage.Traits_DECLARATIVE, scopeProto.GetTraits().GetOrigin())
-	compareNamespaceLabelSelectors(t, scopeConfig, scopeProto)
+	compareLabelSelectors(t, scopeConfig.Rules.NamespaceLabelSelectors, scopeProto.GetRules().GetNamespaceLabelSelectors())
 	assert.Empty(t, scopeProto.GetRules().GetIncludedClusters())
 	assert.Empty(t, scopeProto.GetRules().GetClusterLabelSelectors())
 	assert.Empty(t, scopeProto.GetRules().GetIncludedNamespaces())
@@ -133,8 +133,8 @@ func TestTransformAccessScope(t *testing.T) {
 	assert.Equal(t, scopeConfig.Name, scopeProto.GetName())
 	assert.Equal(t, scopeConfig.Description, scopeProto.GetDescription())
 	assert.Equal(t, storage.Traits_DECLARATIVE, scopeProto.GetTraits().GetOrigin())
-	compareNamespaceLabelSelectors(t, scopeConfig, scopeProto)
-	compareClusterLabelSelectors(t, scopeConfig, scopeProto)
+	compareLabelSelectors(t, scopeConfig.Rules.ClusterLabelSelectors, scopeProto.GetRules().GetClusterLabelSelectors())
+	compareLabelSelectors(t, scopeConfig.Rules.NamespaceLabelSelectors, scopeProto.GetRules().GetNamespaceLabelSelectors())
 	assert.Empty(t, scopeProto.GetRules().GetIncludedClusters())
 	assert.Empty(t, scopeProto.GetRules().GetIncludedNamespaces())
 
@@ -246,8 +246,8 @@ func TestTransformAccessScope(t *testing.T) {
 	assert.Equal(t, scopeConfig.Name, scopeProto.GetName())
 	assert.Equal(t, scopeConfig.Description, scopeProto.GetDescription())
 	assert.Equal(t, storage.Traits_DECLARATIVE, scopeProto.GetTraits().GetOrigin())
-	compareNamespaceLabelSelectors(t, scopeConfig, scopeProto)
-	compareClusterLabelSelectors(t, scopeConfig, scopeProto)
+	compareLabelSelectors(t, scopeConfig.Rules.ClusterLabelSelectors, scopeProto.GetRules().GetClusterLabelSelectors())
+	compareLabelSelectors(t, scopeConfig.Rules.NamespaceLabelSelectors, scopeProto.GetRules().GetNamespaceLabelSelectors())
 	assert.Equal(t, []string{"clusterC"}, scopeProto.GetRules().GetIncludedClusters())
 	expectedNamespaces = []*storage.SimpleAccessScope_Rules_Namespace{
 		{
@@ -270,21 +270,10 @@ func TestTransformAccessScope(t *testing.T) {
 	assert.ElementsMatch(t, expectedNamespaces, scopeProto.GetRules().GetIncludedNamespaces())
 }
 
-func compareClusterLabelSelectors(t *testing.T, scopeConfig *declarativeconfig.AccessScope, scopeProto *storage.SimpleAccessScope) {
-	for clID, cl := range scopeConfig.Rules.ClusterLabelSelectors {
-		for reqID, req := range cl.Requirements {
-			protoReq := scopeProto.GetRules().GetClusterLabelSelectors()[clID].GetRequirements()[reqID]
-			assert.Equal(t, req.Key, protoReq.GetKey())
-			assert.Equal(t, storage.SetBasedLabelSelector_Operator(req.Operator), protoReq.GetOp())
-			assert.Equal(t, req.Values, protoReq.GetValues())
-		}
-	}
-}
-
-func compareNamespaceLabelSelectors(t *testing.T, scopeConfig *declarativeconfig.AccessScope, scopeProto *storage.SimpleAccessScope) {
-	for nlID, nl := range scopeConfig.Rules.NamespaceLabelSelectors {
-		for reqID, req := range nl.Requirements {
-			protoReq := scopeProto.GetRules().GetNamespaceLabelSelectors()[nlID].GetRequirements()[reqID]
+func compareLabelSelectors(t *testing.T, labelSelectors []declarativeconfig.LabelSelector, protoLabelSelectors []*storage.SetBasedLabelSelector) {
+	for labelID, labelSelector := range labelSelectors {
+		for reqID, req := range labelSelector.Requirements {
+			protoReq := protoLabelSelectors[labelID].GetRequirements()[reqID]
 			assert.Equal(t, req.Key, protoReq.GetKey())
 			assert.Equal(t, storage.SetBasedLabelSelector_Operator(req.Operator), protoReq.GetOp())
 			assert.Equal(t, req.Values, protoReq.GetValues())

--- a/pkg/declarativeconfig/transform/access_scope_test.go
+++ b/pkg/declarativeconfig/transform/access_scope_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestWrongConfigurationTypeTransform(t *testing.T) {
+func TestWrongConfigurationTypeTransformAccessScope(t *testing.T) {
 	at := newAccessScopeTransform()
 	msgs, err := at.Transform(&declarativeconfig.AuthProvider{})
 	assert.Nil(t, msgs)

--- a/pkg/declarativeconfig/transform/access_scope_test.go
+++ b/pkg/declarativeconfig/transform/access_scope_test.go
@@ -1,7 +1,6 @@
 package transform
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stackrox/rox/generated/storage"
@@ -13,7 +12,7 @@ import (
 
 func TestWrongConfigurationTypeTransform(t *testing.T) {
 	at := newAccessScopeTransform()
-	msgs, err := at.Transform(context.TODO(), &declarativeconfig.AuthProvider{})
+	msgs, err := at.Transform(&declarativeconfig.AuthProvider{})
 	assert.Nil(t, msgs)
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, errox.InvalidArgs)
@@ -29,7 +28,7 @@ func TestTransformAccessScope(t *testing.T) {
 		Rules:       declarativeconfig.Rules{},
 	}
 
-	msgs, err := at.Transform(context.TODO(), scopeConfig)
+	msgs, err := at.Transform(scopeConfig)
 	assert.NoError(t, err)
 	require.Len(t, msgs, 1)
 	msg := msgs[0]
@@ -54,7 +53,7 @@ func TestTransformAccessScope(t *testing.T) {
 						Operator: 1,
 						Values:   []string{"a", "b", "c"}}}}}},
 	}
-	msgs, err = at.Transform(context.TODO(), scopeConfig)
+	msgs, err = at.Transform(scopeConfig)
 	assert.NoError(t, err)
 	require.Len(t, msgs, 1)
 	msg = msgs[0]
@@ -80,7 +79,7 @@ func TestTransformAccessScope(t *testing.T) {
 						Operator: 1,
 						Values:   []string{"a", "b", "c"}}}}}},
 	}
-	msgs, err = at.Transform(context.TODO(), scopeConfig)
+	msgs, err = at.Transform(scopeConfig)
 	assert.NoError(t, err)
 	require.Len(t, msgs, 1)
 	msg = msgs[0]
@@ -113,7 +112,7 @@ func TestTransformAccessScope(t *testing.T) {
 						Operator: 1,
 						Values:   []string{"a", "b", "c"}}}}}},
 	}
-	msgs, err = at.Transform(context.TODO(), scopeConfig)
+	msgs, err = at.Transform(scopeConfig)
 	assert.NoError(t, err)
 	require.Len(t, msgs, 1)
 	msg = msgs[0]
@@ -139,7 +138,7 @@ func TestTransformAccessScope(t *testing.T) {
 			},
 		},
 	}
-	msgs, err = at.Transform(context.TODO(), scopeConfig)
+	msgs, err = at.Transform(scopeConfig)
 	assert.NoError(t, err)
 	require.Len(t, msgs, 1)
 	msg = msgs[0]
@@ -163,7 +162,7 @@ func TestTransformAccessScope(t *testing.T) {
 			},
 		},
 	}
-	msgs, err = at.Transform(context.TODO(), scopeConfig)
+	msgs, err = at.Transform(scopeConfig)
 	assert.NoError(t, err)
 	require.Len(t, msgs, 1)
 	msg = msgs[0]
@@ -219,7 +218,7 @@ func TestTransformAccessScope(t *testing.T) {
 						Operator: 1,
 						Values:   []string{"a", "b", "c"}}}}}},
 	}
-	msgs, err = at.Transform(context.TODO(), scopeConfig)
+	msgs, err = at.Transform(scopeConfig)
 	assert.NoError(t, err)
 	require.Len(t, msgs, 1)
 	msg = msgs[0]

--- a/pkg/declarativeconfig/transform/access_scope_test.go
+++ b/pkg/declarativeconfig/transform/access_scope_test.go
@@ -1,6 +1,7 @@
 package transform
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/stackrox/rox/generated/storage"
@@ -21,6 +22,8 @@ func TestWrongConfigurationTypeTransform(t *testing.T) {
 func TestTransformAccessScope(t *testing.T) {
 	at := newAccessScopeTransform()
 
+	simpleAccessScopeType := reflect.TypeOf((*storage.SimpleAccessScope)(nil))
+
 	// 1. Access scope with empty rules mimicking an unrestricted scope.
 	scopeConfig := &declarativeconfig.AccessScope{
 		Name:        "test-scope",
@@ -31,13 +34,16 @@ func TestTransformAccessScope(t *testing.T) {
 	msgs, err := at.Transform(scopeConfig)
 	assert.NoError(t, err)
 	require.Len(t, msgs, 1)
-	msg := msgs[0]
-	scopeProto, ok := msg.(*storage.SimpleAccessScope)
+	assert.Contains(t, msgs, simpleAccessScopeType)
+	msg := msgs[simpleAccessScopeType]
+	require.Len(t, msg, 1)
+	scopeProto, ok := msg[0].(*storage.SimpleAccessScope)
 	require.True(t, ok)
 	assert.Equal(t, scopeConfig.Name, scopeProto.GetName())
 	assert.Equal(t, scopeConfig.Description, scopeProto.GetDescription())
 	assert.Equal(t, storage.Traits_DECLARATIVE, scopeProto.GetTraits().GetOrigin())
 	assert.Empty(t, scopeProto.GetRules().GetIncludedClusters())
+	assert.Empty(t, scopeProto.GetRules().GetIncludedNamespaces())
 	assert.Empty(t, scopeProto.GetRules().GetNamespaceLabelSelectors())
 	assert.Empty(t, scopeProto.GetRules().GetClusterLabelSelectors())
 
@@ -50,14 +56,16 @@ func TestTransformAccessScope(t *testing.T) {
 				{Requirements: []declarativeconfig.Requirement{
 					{
 						Key:      "a",
-						Operator: 1,
+						Operator: declarativeconfig.Operator(storage.LabelSelector_IN),
 						Values:   []string{"a", "b", "c"}}}}}},
 	}
 	msgs, err = at.Transform(scopeConfig)
 	assert.NoError(t, err)
 	require.Len(t, msgs, 1)
-	msg = msgs[0]
-	scopeProto, ok = msg.(*storage.SimpleAccessScope)
+	assert.Contains(t, msgs, simpleAccessScopeType)
+	msg = msgs[simpleAccessScopeType]
+	require.Len(t, msg, 1)
+	scopeProto, ok = msg[0].(*storage.SimpleAccessScope)
 	require.True(t, ok)
 	assert.Equal(t, scopeConfig.Name, scopeProto.GetName())
 	assert.Equal(t, scopeConfig.Description, scopeProto.GetDescription())
@@ -76,14 +84,16 @@ func TestTransformAccessScope(t *testing.T) {
 				{Requirements: []declarativeconfig.Requirement{
 					{
 						Key:      "a",
-						Operator: 1,
+						Operator: declarativeconfig.Operator(storage.LabelSelector_IN),
 						Values:   []string{"a", "b", "c"}}}}}},
 	}
 	msgs, err = at.Transform(scopeConfig)
 	assert.NoError(t, err)
 	require.Len(t, msgs, 1)
-	msg = msgs[0]
-	scopeProto, ok = msg.(*storage.SimpleAccessScope)
+	assert.Contains(t, msgs, simpleAccessScopeType)
+	msg = msgs[simpleAccessScopeType]
+	require.Len(t, msg, 1)
+	scopeProto, ok = msg[0].(*storage.SimpleAccessScope)
 	require.True(t, ok)
 	assert.Equal(t, scopeConfig.Name, scopeProto.GetName())
 	assert.Equal(t, scopeConfig.Description, scopeProto.GetDescription())
@@ -101,7 +111,7 @@ func TestTransformAccessScope(t *testing.T) {
 			ClusterLabelSelectors: []declarativeconfig.LabelSelector{
 				{Requirements: []declarativeconfig.Requirement{{
 					Key:      "a",
-					Operator: 1,
+					Operator: declarativeconfig.Operator(storage.LabelSelector_IN),
 					Values:   []string{"a", "b", "c"},
 				}}},
 			},
@@ -109,14 +119,16 @@ func TestTransformAccessScope(t *testing.T) {
 				{Requirements: []declarativeconfig.Requirement{
 					{
 						Key:      "a",
-						Operator: 1,
+						Operator: declarativeconfig.Operator(storage.LabelSelector_IN),
 						Values:   []string{"a", "b", "c"}}}}}},
 	}
 	msgs, err = at.Transform(scopeConfig)
 	assert.NoError(t, err)
 	require.Len(t, msgs, 1)
-	msg = msgs[0]
-	scopeProto, ok = msg.(*storage.SimpleAccessScope)
+	assert.Contains(t, msgs, simpleAccessScopeType)
+	msg = msgs[simpleAccessScopeType]
+	require.Len(t, msg, 1)
+	scopeProto, ok = msg[0].(*storage.SimpleAccessScope)
 	require.True(t, ok)
 	assert.Equal(t, scopeConfig.Name, scopeProto.GetName())
 	assert.Equal(t, scopeConfig.Description, scopeProto.GetDescription())
@@ -141,8 +153,10 @@ func TestTransformAccessScope(t *testing.T) {
 	msgs, err = at.Transform(scopeConfig)
 	assert.NoError(t, err)
 	require.Len(t, msgs, 1)
-	msg = msgs[0]
-	scopeProto, ok = msg.(*storage.SimpleAccessScope)
+	assert.Contains(t, msgs, simpleAccessScopeType)
+	msg = msgs[simpleAccessScopeType]
+	require.Len(t, msg, 1)
+	scopeProto, ok = msg[0].(*storage.SimpleAccessScope)
 	require.True(t, ok)
 	assert.Equal(t, scopeConfig.Name, scopeProto.GetName())
 	assert.Equal(t, scopeConfig.Description, scopeProto.GetDescription())
@@ -165,15 +179,17 @@ func TestTransformAccessScope(t *testing.T) {
 	msgs, err = at.Transform(scopeConfig)
 	assert.NoError(t, err)
 	require.Len(t, msgs, 1)
-	msg = msgs[0]
-	scopeProto, ok = msg.(*storage.SimpleAccessScope)
+	assert.Contains(t, msgs, simpleAccessScopeType)
+	msg = msgs[simpleAccessScopeType]
+	require.Len(t, msg, 1)
+	scopeProto, ok = msg[0].(*storage.SimpleAccessScope)
 	require.True(t, ok)
 	assert.Equal(t, scopeConfig.Name, scopeProto.GetName())
 	assert.Equal(t, scopeConfig.Description, scopeProto.GetDescription())
 	assert.Equal(t, storage.Traits_DECLARATIVE, scopeProto.GetTraits().GetOrigin())
 	assert.Empty(t, scopeProto.GetRules().GetClusterLabelSelectors())
 	assert.Empty(t, scopeProto.GetRules().GetNamespaceLabelSelectors())
-	assert.Equal(t, []string{"clusterA", "clusterB"}, scopeProto.GetRules().GetIncludedClusters())
+	assert.Empty(t, scopeProto.GetRules().GetIncludedClusters())
 	expectedNamespaces := []*storage.SimpleAccessScope_Rules_Namespace{
 		{
 			ClusterName:   "clusterA",
@@ -203,11 +219,12 @@ func TestTransformAccessScope(t *testing.T) {
 			IncludedObjects: []declarativeconfig.IncludedObject{
 				{Cluster: "clusterA", Namespaces: []string{"NamespaceA", "NamespaceB"}},
 				{Cluster: "clusterB", Namespaces: []string{"NamespaceC", "NamespaceD"}},
+				{Cluster: "clusterC"},
 			},
 			ClusterLabelSelectors: []declarativeconfig.LabelSelector{
 				{Requirements: []declarativeconfig.Requirement{{
 					Key:      "a",
-					Operator: 1,
+					Operator: declarativeconfig.Operator(storage.LabelSelector_IN),
 					Values:   []string{"a", "b", "c"},
 				}}},
 			},
@@ -215,21 +232,23 @@ func TestTransformAccessScope(t *testing.T) {
 				{Requirements: []declarativeconfig.Requirement{
 					{
 						Key:      "a",
-						Operator: 1,
+						Operator: declarativeconfig.Operator(storage.LabelSelector_IN),
 						Values:   []string{"a", "b", "c"}}}}}},
 	}
 	msgs, err = at.Transform(scopeConfig)
 	assert.NoError(t, err)
 	require.Len(t, msgs, 1)
-	msg = msgs[0]
-	scopeProto, ok = msg.(*storage.SimpleAccessScope)
+	assert.Contains(t, msgs, simpleAccessScopeType)
+	msg = msgs[simpleAccessScopeType]
+	require.Len(t, msg, 1)
+	scopeProto, ok = msg[0].(*storage.SimpleAccessScope)
 	require.True(t, ok)
 	assert.Equal(t, scopeConfig.Name, scopeProto.GetName())
 	assert.Equal(t, scopeConfig.Description, scopeProto.GetDescription())
 	assert.Equal(t, storage.Traits_DECLARATIVE, scopeProto.GetTraits().GetOrigin())
 	compareNamespaceLabelSelectors(t, scopeConfig, scopeProto)
 	compareClusterLabelSelectors(t, scopeConfig, scopeProto)
-	assert.Equal(t, []string{"clusterA", "clusterB"}, scopeProto.GetRules().GetIncludedClusters())
+	assert.Equal(t, []string{"clusterC"}, scopeProto.GetRules().GetIncludedClusters())
 	expectedNamespaces = []*storage.SimpleAccessScope_Rules_Namespace{
 		{
 			ClusterName:   "clusterA",

--- a/pkg/declarativeconfig/transform/transformer.go
+++ b/pkg/declarativeconfig/transform/transformer.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stackrox/rox/pkg/errox"
 )
 
-var _ Transformer = (*defaultTransformer)(nil)
+var _ Transformer = (*universalTransformer)(nil)
 
 // Transformer transforms a declarativeconfig.Configuration to proto.Message(s).
 type Transformer interface {

--- a/pkg/declarativeconfig/transform/transformer.go
+++ b/pkg/declarativeconfig/transform/transformer.go
@@ -8,6 +8,8 @@ import (
 	"github.com/stackrox/rox/pkg/errox"
 )
 
+var _ Transformer = (*defaultTransformer)(nil)
+
 // Transformer transforms a declarativeconfig.Configuration to proto.Message(s).
 type Transformer interface {
 	Transform(config declarativeconfig.Configuration) (map[reflect.Type][]proto.Message, error)
@@ -17,7 +19,7 @@ type Transformer interface {
 func New() Transformer {
 	return &universalTransformer{configurationTransformers: map[string]Transformer{
 		declarativeconfig.AuthProviderConfiguration:  nil,
-		declarativeconfig.AccessScopeConfiguration:   nil,
+		declarativeconfig.AccessScopeConfiguration:   newAccessScopeTransform(),
 		declarativeconfig.RoleConfiguration:          nil,
 		declarativeconfig.PermissionSetConfiguration: newPermissionSetTransform(),
 	}}


### PR DESCRIPTION
## Description

This PR adds logic to transform a declarative configuration, specifically the `Access Scope` one, to its related proto message.

Within the transformation logic, the proto fields will be filled as well as a deterministic UUID based on the name of the access scope will be created.

For now, within the transformation logic, no validation of the transformed proto message is done (e.g. about conformity, name uniqueness etc.). These additional checks may be added at a latter point in a follow-up.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

- added unit tests.
