### PR TITLE
ROX-14619: fix metadata retrieval errors in scan time test

### DIFF
--- a/qa-tests-backend/src/test/groovy/ImageScanningTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageScanningTest.groovy
@@ -654,9 +654,9 @@ class ImageScanningTest extends BaseSpecification {
 
         where:
         image                                              | registry
-        "k8s.gcr.io/ip-masq-agent-amd64:v2.4.1"            | "gcr registry"
-        "docker.io/jenkins/jenkins:lts"                    | "docker registry"
-        "docker.io/jenkins/jenkins:2.220-alpine"           | "docker registry"
+        "registry.k8s.io/ip-masq-agent-amd64:v2.4.1"       | "gcr registry"
+        "quay.io/rhacs-eng/qa:alpine-3.16.0"               | "quay registry"
+        "quay.io/stackrox-io/scanner:2.27.3"               | "quay registry"
         "gke.gcr.io/heapster:v1.7.2"                       | "one from gke"
         "mcr.microsoft.com/dotnet/core/runtime:2.1-alpine" | "one from mcr"
     }


### PR DESCRIPTION
Manually cherry-picking d10b00fc6ac882d4a251bcaf1b625a1289fc31b0.

https://github.com/stackrox/stackrox/pull/4635