### PR TITLE
GHA Release automation: fix start-release after image build migration from OSCI to GHA

### DIFF
--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -195,12 +195,6 @@ jobs:
             "$CFG_DIR/stackrox-stackrox-master.yaml" \
             > "$CFG_DIR/stackrox-$BRANCH.yaml"
 
-          # Duplicate the opensource images config and keep only postsubmit jobs.
-          yq "del(.tests[] | select(.postsubmit != true or has(\"cron\"))) |
-              .promotion.tag=\"$RELEASE-stackrox-branding\" |
-              .zz_generated_metadata.branch=\"release-$RELEASE\"" \
-            "$CFG_DIR/stackrox-stackrox-master__stackrox_branding.yaml" \
-            > "$CFG_DIR/stackrox-${BRANCH}__stackrox_branding.yaml"
       - name: Make update
         if: steps.check-existing.outputs.branch-exists == 'false'
         run: |

--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -190,7 +190,6 @@ jobs:
         run: |
           # Duplicate the main config and keep only postsubmit jobs.
           yq "del(.tests[] | select(.postsubmit != true or has(\"cron\"))) |
-              .promotion.tag=\"$RELEASE\" |
               .zz_generated_metadata.branch=\"release-$RELEASE\"" \
             "$CFG_DIR/stackrox-stackrox-master.yaml" \
             > "$CFG_DIR/stackrox-$BRANCH.yaml"


### PR DESCRIPTION
## Description

Failed start-release dry-run:
https://github.com/stackrox/stackrox/actions/runs/4084494113

Original error: OSCI config validation failed because `promotion.namespace` field was missing.

* Successful dry-run with the fix:
https://github.com/stackrox/stackrox/actions/runs/4084825496/jobs/7042004995


Rationale behind this change is that we do not build images with OSCI anymore (removed in https://github.com/openshift/release/pull/35278 and https://github.com/openshift/release/pull/35943).

The release automation expected the `promotion` block and set the tag there (e.g. https://github.com/openshift/release/blob/master/ci-operator/config/stackrox/stackrox/stackrox-stackrox-release-3.73.yaml#L106-L113).

This stanza controls which images are published: https://docs.ci.openshift.org/docs/getting-started/examples/#publishing-an-image-for-reuse.

Since we don't publish any image with OSCI, we don't need to include or update the `promotion` in the 3.74 (or other future releases) configuration. 

Also removing the Opensource image config, as again we don't build images on OSCI anymore 🎉 🙂 

## Checklist
- [ ] Investigated and inspected CI test result.

If any of these don't apply, please comment below.

## Testing Performed

Successful dry-run for start-release https://github.com/stackrox/stackrox/actions/runs/4084825496/jobs/7042004995
