### PR TITLE
ROX-14902: Fix rc.0 milestone

### DIFF
--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -253,24 +253,24 @@ jobs:
     needs: [variables]
     runs-on: ubuntu-latest
     steps:
-      - name: Create ${{needs.variables.outputs.milestone}} milestone
+      - name: Create ${{needs.variables.outputs.next-milestone}} milestone
         if: env.DRY_RUN == 'false'
         run: |
           set -u
           if ! http_code=$(gh api --silent -X POST \
             "repos/${{github.repository}}/milestones" \
-            -f title="${{needs.variables.outputs.milestone}}" \
+            -f title="${{needs.variables.outputs.next-milestone}}" \
             2>&1); then
 
             if grep "HTTP 422" <<< "$http_code"; then
-              echo ":arrow_right: Milestone ${{needs.variables.outputs.milestone}} already exists." \
+              echo ":arrow_right: Milestone ${{needs.variables.outputs.next-milestone}} already exists." \
                 "**Close it once it's finished.**" >> "$GITHUB_STEP_SUMMARY"
             else
-              echo "::error::Couldn't create milestone ${{needs.variables.outputs.milestone}}: $http_code"
+              echo "::error::Couldn't create milestone ${{needs.variables.outputs.next-milestone}}: $http_code"
               exit 1
             fi
           else
-            echo ":arrow_right: Milestone ${{needs.variables.outputs.milestone}} has been created." \
+            echo ":arrow_right: Milestone ${{needs.variables.outputs.next-milestone}} has been created." \
               "**Close it once it's finished.**" >> "$GITHUB_STEP_SUMMARY"
           fi
 
@@ -296,7 +296,7 @@ jobs:
 
             { "type": "section", "text": { "type": "mrkdwn", "text":
             "Branch `${{needs.variables.outputs.branch}}`
-            and milestone `${{needs.variables.outputs.milestone}}`
+            and milestone `${{needs.variables.outputs.next-milestone}}`
             have been created.\n\nPRs merged to the ${{env.main_branch}} branch
             and assigned to RC milestones will be cherry-picked when closing the respective milestones.
             For the urgent fixes that must go exclusively to this release
@@ -324,7 +324,7 @@ jobs:
             has been triggered on <${{github.server_url}}/${{github.repository}}|${{github.repository}}> by ${{ github.event.sender.login }}.*" }},
 
             { "type": "section", "text": { "type": "mrkdwn", "text":
-            "Milestone `${{needs.variables.outputs.milestone}}`
+            "Milestone `${{needs.variables.outputs.next-milestone}}`
             has been created.\n\nPRs merged to the ${{env.main_branch}} branch
             and assigned to RC milestones will be cherry-picked when closing the respective milestones.
             For the urgent fixes that must go exclusively to this release


### PR DESCRIPTION
## Description

The workflow created an `rc.0` milestone: https://github.com/stackrox/stackrox/actions/runs/4084959446

Start Release should rather create `next-milestone`, as `milestone` will be 0, as there should be no `-rc.` in the version provided for a release.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] ~Unit test and regression tests added~
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

https://github.com/stackrox/stackrox/actions/runs/4101883067
