### PR TITLE
Telemetry: set anonymousId for events where user is not provided

### DIFF
--- a/central/cluster/datastore/telemetry.go
+++ b/central/cluster/datastore/telemetry.go
@@ -29,11 +29,11 @@ func trackClusterRegistered(ctx context.Context, cluster *storage.Cluster) {
 		cfg.Telemeter().Track("Secured Cluster Registered", props, telemeter.WithUserID(userID))
 
 		// Add the secured cluster 'user' to the Tenant group:
-		cfg.Telemeter().Group(cfg.GroupID, nil, telemeter.WithUserID(cluster.GetId()))
+		cfg.Telemeter().Group(cfg.GroupID, nil, telemeter.WithAnonymousID(cluster.GetId()))
 
 		// Update the secured cluster identity from its name:
 		cfg.Telemeter().Identify(makeClusterProperties(cluster),
-			telemeter.WithUserID(cluster.GetId()),
+			telemeter.WithAnonymousID(cluster.GetId()),
 			telemeter.WithClient(cluster.GetId(), securedClusterClient),
 		)
 	}
@@ -59,7 +59,7 @@ func trackClusterInitialized(cluster *storage.Cluster) {
 			Track("Secured Cluster Initialized", map[string]any{
 				"Health": cluster.GetHealthStatus().GetOverallHealthStatus().String(),
 			},
-				telemeter.WithUserID(cluster.GetId()),
+				telemeter.WithAnonymousID(cluster.GetId()),
 				telemeter.WithClient(cluster.GetId(), securedClusterClient),
 				telemeter.WithGroups("Tenant", cfg.GroupID))
 	}
@@ -97,7 +97,7 @@ func UpdateSecuredClusterIdentity(ctx context.Context, clusterID string, metrics
 		props["CPU Capacity"] = metrics.CpuCapacity
 
 		opts := []telemeter.Option{
-			telemeter.WithUserID(cluster.GetId()),
+			telemeter.WithAnonymousID(cluster.GetId()),
 			telemeter.WithClient(cluster.GetId(), securedClusterClient),
 		}
 		cfg.Telemeter().Identify(props, opts...)

--- a/central/cluster/datastore/telemetry.go
+++ b/central/cluster/datastore/telemetry.go
@@ -28,14 +28,12 @@ func trackClusterRegistered(ctx context.Context, cluster *storage.Cluster) {
 		}
 		cfg.Telemeter().Track("Secured Cluster Registered", props, telemeter.WithUserID(userID))
 
+		opts := telemeter.WithClient(cluster.GetId(), securedClusterClient)
 		// Add the secured cluster 'user' to the Tenant group:
-		cfg.Telemeter().Group(cfg.GroupID, nil, telemeter.WithAnonymousID(cluster.GetId()))
+		cfg.Telemeter().Group(cfg.GroupID, nil, opts)
 
 		// Update the secured cluster identity from its name:
-		cfg.Telemeter().Identify(makeClusterProperties(cluster),
-			telemeter.WithAnonymousID(cluster.GetId()),
-			telemeter.WithClient(cluster.GetId(), securedClusterClient),
-		)
+		cfg.Telemeter().Identify(makeClusterProperties(cluster), opts)
 	}
 }
 
@@ -59,7 +57,6 @@ func trackClusterInitialized(cluster *storage.Cluster) {
 			Track("Secured Cluster Initialized", map[string]any{
 				"Health": cluster.GetHealthStatus().GetOverallHealthStatus().String(),
 			},
-				telemeter.WithAnonymousID(cluster.GetId()),
 				telemeter.WithClient(cluster.GetId(), securedClusterClient),
 				telemeter.WithGroups("Tenant", cfg.GroupID))
 	}
@@ -97,7 +94,6 @@ func UpdateSecuredClusterIdentity(ctx context.Context, clusterID string, metrics
 		props["CPU Capacity"] = metrics.CpuCapacity
 
 		opts := []telemeter.Option{
-			telemeter.WithAnonymousID(cluster.GetId()),
 			telemeter.WithClient(cluster.GetId(), securedClusterClient),
 		}
 		cfg.Telemeter().Identify(props, opts...)

--- a/central/telemetry/centralclient/instance_config.go
+++ b/central/telemetry/centralclient/instance_config.go
@@ -130,7 +130,7 @@ func RegisterCentralClient(config grpc.Config, basicAuthProviderID string) {
 	}
 	registerInterceptors(config)
 	// Central adds itself to the tenant group, with no group properties:
-	cfg.Telemeter().Group(cfg.GroupID, nil, telemeter.WithAnonymousID(cfg.ClientID))
+	cfg.Telemeter().Group(cfg.GroupID, nil)
 	registerAdminUser(basicAuthProviderID)
 }
 

--- a/central/telemetry/centralclient/instance_config.go
+++ b/central/telemetry/centralclient/instance_config.go
@@ -130,7 +130,7 @@ func RegisterCentralClient(config grpc.Config, basicAuthProviderID string) {
 	}
 	registerInterceptors(config)
 	// Central adds itself to the tenant group, with no group properties:
-	cfg.Telemeter().Group(cfg.GroupID, nil, telemeter.WithUserID(cfg.ClientID))
+	cfg.Telemeter().Group(cfg.GroupID, nil, telemeter.WithAnonymousID(cfg.ClientID))
 	registerAdminUser(basicAuthProviderID)
 }
 

--- a/pkg/telemetry/phonehome/segment/segment.go
+++ b/pkg/telemetry/phonehome/segment/segment.go
@@ -90,9 +90,16 @@ func (t *segmentTelemeter) Stop() {
 	}
 }
 
-func (t *segmentTelemeter) overrideUserID(o *telemeter.CallOptions) string {
+func (t *segmentTelemeter) getUserID(o *telemeter.CallOptions) string {
+	return o.UserID
+}
+
+func (t *segmentTelemeter) getAnonymousID(o *telemeter.CallOptions) string {
 	if o.UserID != "" {
-		return o.UserID
+		return ""
+	}
+	if o.ClientID != "" {
+		return o.ClientID
 	}
 	return t.clientID
 }
@@ -130,9 +137,10 @@ func (t *segmentTelemeter) Identify(props map[string]any, opts ...telemeter.Opti
 	traits := segment.NewTraits()
 
 	identity := segment.Identify{
-		UserId:  t.overrideUserID(options),
-		Traits:  traits,
-		Context: makeDeviceContext(options),
+		UserId:      t.getUserID(options),
+		AnonymousId: t.getAnonymousID(options),
+		Traits:      traits,
+		Context:     makeDeviceContext(options),
 	}
 
 	for k, v := range props {
@@ -151,10 +159,11 @@ func (t *segmentTelemeter) Group(groupID string, props map[string]any, opts ...t
 	options := telemeter.ApplyOptions(opts)
 
 	group := segment.Group{
-		GroupId: groupID,
-		UserId:  t.overrideUserID(options),
-		Traits:  props,
-		Context: makeDeviceContext(options),
+		GroupId:     groupID,
+		UserId:      t.getUserID(options),
+		AnonymousId: t.getAnonymousID(options),
+		Traits:      props,
+		Context:     makeDeviceContext(options),
 	}
 
 	if err := t.client.Enqueue(group); err != nil {
@@ -170,10 +179,11 @@ func (t *segmentTelemeter) Track(event string, props map[string]any, opts ...tel
 	options := telemeter.ApplyOptions(opts)
 
 	track := segment.Track{
-		UserId:     t.overrideUserID(options),
-		Event:      event,
-		Properties: props,
-		Context:    makeDeviceContext(options),
+		UserId:      t.getUserID(options),
+		AnonymousId: t.getAnonymousID(options),
+		Event:       event,
+		Properties:  props,
+		Context:     makeDeviceContext(options),
 	}
 
 	if err := t.client.Enqueue(track); err != nil {

--- a/pkg/telemetry/phonehome/segment/segment.go
+++ b/pkg/telemetry/phonehome/segment/segment.go
@@ -91,12 +91,18 @@ func (t *segmentTelemeter) Stop() {
 }
 
 func (t *segmentTelemeter) getUserID(o *telemeter.CallOptions) string {
+	if o.AnonymousID != "" {
+		return ""
+	}
 	return o.UserID
 }
 
 func (t *segmentTelemeter) getAnonymousID(o *telemeter.CallOptions) string {
 	if o.UserID != "" {
 		return ""
+	}
+	if o.AnonymousID != "" {
+		return o.AnonymousID
 	}
 	if o.ClientID != "" {
 		return o.ClientID

--- a/pkg/telemetry/phonehome/segment/segment_test.go
+++ b/pkg/telemetry/phonehome/segment/segment_test.go
@@ -37,7 +37,7 @@ func Test_makeDeviceContext(t *testing.T) {
 	assert.ElementsMatch(t, []string{"groupA_id1", "groupA_id2"}, groups["groupA"])
 }
 
-func Test_WithAnonymousId(t *testing.T) {
+func Test_getIDs(t *testing.T) {
 	type result struct {
 		anonymousID string
 		userID      string
@@ -48,14 +48,6 @@ func Test_WithAnonymousId(t *testing.T) {
 		expected result
 	}{
 		{opts: []telemeter.Option{
-			telemeter.WithUserID("userID"),
-			telemeter.WithAnonymousID("anonymousID"),
-		}, expected: result{
-			userID:      "",
-			anonymousID: "anonymousID",
-		}},
-		{opts: []telemeter.Option{
-			telemeter.WithAnonymousID("anonymousID"),
 			telemeter.WithUserID("userID"),
 		}, expected: result{
 			userID:      "userID",
@@ -79,11 +71,11 @@ func Test_WithAnonymousId(t *testing.T) {
 			anonymousID: "",
 		}},
 		{opts: []telemeter.Option{
-			telemeter.WithAnonymousID("anonymousID"),
 			telemeter.WithClient("anotherID", "clientType"),
+			telemeter.WithUserID("userID"),
 		}, expected: result{
-			userID:      "",
-			anonymousID: "anonymousID",
+			userID:      "userID",
+			anonymousID: "",
 		}},
 	}
 

--- a/pkg/telemetry/phonehome/telemeter/telemeter.go
+++ b/pkg/telemetry/phonehome/telemeter/telemeter.go
@@ -31,17 +31,12 @@ func WithUserID(userID string) Option {
 	}
 }
 
-// WithAnonymousID allows for modifying the AnonymousID call option.
-func WithAnonymousID(id string) Option {
-	return func(o *CallOptions) {
-		o.UserID = ""
-		o.AnonymousID = id
-	}
-}
-
 // WithClient allows for modifying the ClientID and ClientType call options.
 func WithClient(clientID string, clientType string) Option {
 	return func(o *CallOptions) {
+		if o.UserID == "" {
+			o.AnonymousID = clientID
+		}
 		o.ClientID = clientID
 		o.ClientType = clientType
 	}

--- a/pkg/telemetry/phonehome/telemeter/telemeter.go
+++ b/pkg/telemetry/phonehome/telemeter/telemeter.go
@@ -2,9 +2,10 @@ package telemeter
 
 // CallOptions defines optional features for a Telemeter call.
 type CallOptions struct {
-	UserID     string
-	ClientID   string
-	ClientType string
+	UserID      string
+	AnonymousID string
+	ClientID    string
+	ClientType  string
 
 	// [group name: [group id]]
 	Groups map[string][]string
@@ -26,6 +27,15 @@ func ApplyOptions(opts []Option) *CallOptions {
 func WithUserID(userID string) Option {
 	return func(o *CallOptions) {
 		o.UserID = userID
+		o.AnonymousID = ""
+	}
+}
+
+// WithAnonymousID allows for modifying the AnonymousID call option.
+func WithAnonymousID(id string) Option {
+	return func(o *CallOptions) {
+		o.UserID = ""
+		o.AnonymousID = id
 	}
 }
 

--- a/pkg/telemetry/phonehome/telemeter/telemeter_test.go
+++ b/pkg/telemetry/phonehome/telemeter/telemeter_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestWith(t *testing.T) {
+func Test_With(t *testing.T) {
 	opts := ApplyOptions([]Option{
 		WithUserID("userID"),
 		WithClient("clientID", "clientType"),


### PR DESCRIPTION
## Description

Set `anonymousId` instead of `userId` for messages without an explicitly assigned user. This allows for distinguishing backends from API users by querying `userId == 'none'`.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

```json
{
  "anonymousId": "fa7bb897-a17c-4de6-a035-759a05598a77",
  "context": {
    "device": {
      "id": "fa7bb897-a17c-4de6-a035-759a05598a77",
      "type": "Central"
    },
    "library": {
      "name": "analytics-go",
      "version": "3.0.0"
    }
  },
  "event": "Updated Central Identity",
  "integrations": {},
  "messageId": "b62fbd3a-c64f-41f8-8dbe-e0f7a08b867c",
  "originalTimestamp": "2023-02-03T15:18:46.173249011Z",
  "receivedAt": "2023-02-03T15:19:46.653Z",
  "sentAt": "2023-02-03T15:19:45.978Z",
  "timestamp": "2023-02-03T15:18:46.848Z",
  "type": "track",
  "writeKey": "..."
}
```