### PR TITLE
ROX-14477: Fix data race in `poller_test.go`

### DIFF
--- a/pkg/concurrency/poller_test.go
+++ b/pkg/concurrency/poller_test.go
@@ -50,12 +50,11 @@ func TestPollWithTimeout(t *testing.T) {
 	assert.False(t, PollWithTimeout(func() bool {
 		return false
 	}, 5*time.Millisecond, 50*time.Millisecond))
-	var ctr int
+	var ctr int32
 	assert.True(t, PollWithTimeout(func() bool {
-		ctr++
-		return ctr > 2
+		return atomic.AddInt32(&ctr, 1) > 2
 	}, 5*time.Millisecond, 50*time.Millisecond))
-	assert.Equal(t, 3, ctr)
+	assert.Equal(t, int32(3), atomic.LoadInt32(&ctr))
 }
 
 func TestPollerStops(t *testing.T) {


### PR DESCRIPTION
## Description

See the output in the related ticket https://issues.redhat.com/browse/ROX-14477

The case seems to be a very simple example of the data race. Despite that, I wasn't able to reproduce the original failure locally. Maybe the runner machine had some special condition.

The implementation of the `Poller` (struct under test) seems legit, at least I wasn't able to spot anything obviously broken.

## Checklist
- [x] Investigated and inspected CI test results

None of the following is needed:
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

* Will merge if CI passes.
* Ran it successfully locally with `GOTAGS=release RACE=true scripts/go-test.sh -v -count=1000 -run TestPollWithTimeout ./pkg/concurrency`. However, as I mentioned above, even the original failure did not get reproduced this way.