### PR TITLE
Try enable unit tests in race condition detection mode

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -16,6 +16,7 @@ jobs:
     strategy:
       matrix:
         gotags: [ 'GOTAGS=""', 'GOTAGS=release' ]
+        race: [ '', 'RACE=true' ]
     runs-on: ubuntu-latest
     container:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.55
@@ -34,12 +35,13 @@ jobs:
       uses: ./.github/actions/cache-go-dependencies
 
     - name: Go Unit Tests
-      run: ${{ matrix.gotags }} make go-unit-tests
+      run: ${{ matrix.gotags }} ${{ matrix.race }} make go-unit-tests
 
   go-postgres:
     strategy:
       matrix:
         gotags: [ 'GOTAGS=""', 'GOTAGS=release' ]
+        race: [ '', 'RACE=true' ]
     runs-on: ubuntu-latest
     container:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.55
@@ -66,7 +68,7 @@ jobs:
       run: pg_isready -h 127.0.0.1
 
     - name: Go Unit Tests
-      run: ${{ matrix.gotags }} make go-postgres-unit-tests
+      run: ${{ matrix.gotags }} ${{ matrix.race }} make go-postgres-unit-tests
 
   ui:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

`go-test.sh`/`go-tool.sh` has a flag to enable race testing:
https://github.com/stackrox/stackrox/blob/0a85a60f4601e93af5b9a8bb760992f540c73dc1/scripts/go-tool.sh#L67-L71

This leverages Go race detector https://go.dev/blog/race-detector

The idea of this change is to enable a dimension with race condition detection and see if anything fails. Inspired by https://issues.redhat.com/browse/ROX-14477 where race detection happened by itself although it wasn't explicitly requested.

## Checklist
- [ ] Investigated and inspected CI test results

None of these are needed:
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

* CI should be green.
