### PR TITLE
Add an OCP option for UI e2e tests

### DIFF
--- a/scripts/ci/jobs/ocp_ui_e2e_tests.py
+++ b/scripts/ci/jobs/ocp_ui_e2e_tests.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env -S python3 -u
+
+"""
+Run the UI e2e test in a OCP cluster provided via an openshift/release hive cluster_claim.
+"""
+import os
+from runners import ClusterTestRunner
+from clusters import OpenShiftScaleWorkersCluster
+from pre_tests import PreSystemTests
+from ci_tests import UIE2eTest
+from post_tests import PostClusterTest, FinalPost
+
+# set required test parameters
+os.environ["DEPLOY_STACKROX_VIA_OPERATOR"] = "true"
+os.environ["OPENSHIFT_CI_CLUSTER_CLAIM"] = "openshift-4"
+os.environ["ORCHESTRATOR_FLAVOR"] = "openshift"
+os.environ["ROX_POSTGRES_DATASTORE"] = "false"
+
+# Scale up the cluster to support postgres
+cluster = OpenShiftScaleWorkersCluster(increment=1)
+
+ClusterTestRunner(
+    cluster=cluster,
+    pre_test=PreSystemTests(),
+    test=UIE2eTest(),
+    post_test=PostClusterTest(
+        check_stackrox_logs=True,
+    ),
+    final_post=FinalPost(),
+).run()

--- a/scripts/ci/jobs/openshift_penultimate_qa_e2e_tests.py
+++ b/scripts/ci/jobs/openshift_penultimate_qa_e2e_tests.py
@@ -4,11 +4,8 @@
 Run qa-tests-backend in a openshift 4 cluster provided via a hive cluster_claim.
 """
 import os
-from runners import ClusterTestRunner
+from base_qa_e2e_test import make_qa_e2e_test_runner
 from clusters import OpenShiftScaleWorkersCluster
-from pre_tests import PreSystemTests
-from ci_tests import UIE2eTest
-from post_tests import PostClusterTest, FinalPost
 
 # set required test parameters
 os.environ["DEPLOY_STACKROX_VIA_OPERATOR"] = "true"
@@ -19,12 +16,4 @@ os.environ["ROX_POSTGRES_DATASTORE"] = "false"
 # Scale up the cluster to support postgres
 cluster = OpenShiftScaleWorkersCluster(increment=1)
 
-ClusterTestRunner(
-    cluster=cluster,
-    pre_test=PreSystemTests(),
-    test=UIE2eTest(),
-    post_test=PostClusterTest(
-        check_stackrox_logs=True,
-    ),
-    final_post=FinalPost(),
-).run()
+make_qa_e2e_test_runner(cluster=cluster).run()

--- a/scripts/ci/jobs/openshift_penultimate_qa_e2e_tests.py
+++ b/scripts/ci/jobs/openshift_penultimate_qa_e2e_tests.py
@@ -4,8 +4,11 @@
 Run qa-tests-backend in a openshift 4 cluster provided via a hive cluster_claim.
 """
 import os
-from base_qa_e2e_test import make_qa_e2e_test_runner
+from runners import ClusterTestRunner
 from clusters import OpenShiftScaleWorkersCluster
+from pre_tests import PreSystemTests
+from ci_tests import UIE2eTest
+from post_tests import PostClusterTest, FinalPost
 
 # set required test parameters
 os.environ["DEPLOY_STACKROX_VIA_OPERATOR"] = "true"
@@ -16,4 +19,12 @@ os.environ["ROX_POSTGRES_DATASTORE"] = "false"
 # Scale up the cluster to support postgres
 cluster = OpenShiftScaleWorkersCluster(increment=1)
 
-make_qa_e2e_test_runner(cluster=cluster).run()
+ClusterTestRunner(
+    cluster=cluster,
+    pre_test=PreSystemTests(),
+    test=UIE2eTest(),
+    post_test=PostClusterTest(
+        check_stackrox_logs=True,
+    ),
+    final_post=FinalPost(),
+).run()

--- a/tests/e2e/run-ui-e2e.sh
+++ b/tests/e2e/run-ui-e2e.sh
@@ -16,7 +16,7 @@ test_ui_e2e() {
     require_environment "ORCHESTRATOR_FLAVOR"
     require_environment "KUBECONFIG"
 
-    DEPLOY_DIR="deploy/${ORCHESTRATOR_FLAVOR}"
+    export DEPLOY_DIR="deploy/${ORCHESTRATOR_FLAVOR}"
 
     export_test_environment
 
@@ -31,6 +31,12 @@ test_ui_e2e() {
 
 run_ui_e2e_tests() {
     info "Running UI e2e tests"
+
+    touch /tmp/hold
+    while [[ -e /tmp/hold ]]; do
+        info "Holding this job for debug"
+        sleep 60
+    done
 
     if [[ "${LOAD_BALANCER}" == "lb" ]]; then
         local hostname

--- a/tests/e2e/run-ui-e2e.sh
+++ b/tests/e2e/run-ui-e2e.sh
@@ -16,6 +16,8 @@ test_ui_e2e() {
     require_environment "ORCHESTRATOR_FLAVOR"
     require_environment "KUBECONFIG"
 
+    DEPLOY_DIR="deploy/${ORCHESTRATOR_FLAVOR}"
+
     export_test_environment
 
     setup_deployment_env false false


### PR DESCRIPTION
## Description

This will allow UI e2e tests to run in an OSCI OCP 4.12 cluster via `/test ocp-ui-e2e-tests`. At present they will not pass and that is a separate WIP. 

Companion to https://github.com/openshift/release/pull/36201

## Checklist

- [ ] Investigated and inspected CI test results

## Testing Performed

CI is sufficient