### PR TITLE
Query cancellation or timeout should not be transient

### DIFF
--- a/image/templates/helm/stackrox-central/internal/defaults.yaml.htpl
+++ b/image/templates/helm/stackrox-central/internal/defaults.yaml.htpl
@@ -46,7 +46,7 @@ defaults:
       source:
         minConns: 10
         maxConns: 90
-        statementTimeoutMs: 60000
+        statementTimeoutMs: 120000
 
       postgresConfig: "@config/centraldb/postgresql.conf|config/centraldb/postgresql.conf.default"
       hbaConfig: "@config/centraldb/pg_hba.conf|config/centraldb/pg_hba.conf.default"

--- a/image/templates/helm/stackrox-central/values-public.yaml.example.htpl
+++ b/image/templates/helm/stackrox-central/values-public.yaml.example.htpl
@@ -269,7 +269,7 @@
 #     connectionString: "host=central-db.stackrox port=5432 user=postgres sslmode=verify-full"
 #     minConns: 10
 #     maxConns: 90
-#     statementTimeoutMs: 60000
+#     statementTimeoutMs: 120000
 #
 #   # Configures the Central DB image to be used. Most users will only need to configure a
 #   # custom registry (if any) at the global scope, and do not require any settings here.

--- a/image/templates/helm/stackrox-central/values.yaml.htpl
+++ b/image/templates/helm/stackrox-central/values.yaml.htpl
@@ -204,7 +204,7 @@
 #      connectionString: null
 #      minConns: 10
 #      maxConns: 90
-#      statementTimeoutMs: 60000
+#      statementTimeoutMs: 120000
 #
 #  # The admin password setting for communication with Central's DB.
 #  # When a value is set explicitly, this is always used, even on upgrade.

--- a/pkg/postgres/pgtest/conn/conn.go
+++ b/pkg/postgres/pgtest/conn/conn.go
@@ -27,7 +27,7 @@ func GetConnectionString(_ testing.TB) string {
 	pass := env.GetString("POSTGRES_PASSWORD", "")
 	host := env.GetString("POSTGRES_HOST", "localhost")
 	port := env.GetString("POSTGRES_PORT", "5432")
-	src := fmt.Sprintf("host=%s port=%s user=%s sslmode=disable statement_timeout=600000 client_encoding=UTF8", host, port, user)
+	src := fmt.Sprintf("host=%s port=%s user=%s sslmode=disable statement_timeout=5000 client_encoding=UTF8", host, port, user)
 	if pass != "" {
 		src += fmt.Sprintf(" password=%s", pass)
 	}

--- a/pkg/postgres/pgutils/error.go
+++ b/pkg/postgres/pgutils/error.go
@@ -36,7 +36,9 @@ var transientPGCodes = set.NewFrozenStringSet(
 
 	// Class 57 — Operator Intervention
 	"57000", // operator_intervention
-	"57014", // query_canceled
+
+	// "57014", // query_canceled - this means there is a statement timeout and retrying will most likely not result in greater success
+
 	"57P01", // admin_shutdown
 	"57P02", // crash_shutdown
 	"57P03", // cannot_connect_now


### PR DESCRIPTION
## Description

If we run into a particular circumstance where we are hitting statement timeout, then we should protect ourselves from crashing because the issue is most likely not transient.

Follow up will be to add a notification to the user that we're experiencing unexpected query times

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
