### PR TITLE
Make unit tests pass with ROX_POSTGRES_DATASTORE flag both on and off

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -483,7 +483,7 @@ go-postgres-unit-tests: build-prep test-prep
 	@# The -p 1 passed to go test is required to ensure that tests of different packages are not run in parallel, so as to avoid conflicts when interacting with the DB.
 	set -o pipefail ; \
 	CGO_ENABLED=1 GODEBUG=cgocheck=2 MUTEX_WATCHDOG_TIMEOUT_SECS=30 ROX_POSTGRES_DATASTORE=true GOTAGS=$(GOTAGS),test,sql_integration scripts/go-test.sh -p 1 -race -cover -coverprofile test-output/coverage.out -v \
-		$(shell git ls-files -- '*postgres/*_test.go' '*postgres_test.go' '*datastore_sac_test.go' '*clone_test.go' 'migrator/migrations/n_*/migration_test.go' '*pruning_test.go' '*reprocessor_test.go' '*enricher_impl_test.go' '*v2/parts_test.go' '*version/ensure_test.go' '*version/store/store_impl_test.go' '*activecomponent/updater/updater_impl_test.go' '*role/validate_test.go' '*search/service/service_impl_test.go' '*deployment/service/service_impl_test.go' '*metadata/service/service_impl_test.go' '*systeminfo/listener/listener_test.go' | sed -e 's@^@./@g' | xargs -n 1 dirname | sort | uniq | xargs go list| grep -v '^github.com/stackrox/rox/tests$$' | grep -Ev $(UNIT_TEST_IGNORE)) \
+		$(shell git ls-files -- '*_test.go' | sed -e 's@^@./@g' | xargs -n 1 dirname | sort | uniq | xargs go list| grep -v '^github.com/stackrox/rox/tests$$' | grep -Ev $(UNIT_TEST_IGNORE)) \
 		| tee $(GO_TEST_OUTPUT_PATH)
 
 .PHONY: shell-unit-tests

--- a/Makefile
+++ b/Makefile
@@ -483,7 +483,7 @@ go-postgres-unit-tests: build-prep test-prep
 	@# The -p 1 passed to go test is required to ensure that tests of different packages are not run in parallel, so as to avoid conflicts when interacting with the DB.
 	set -o pipefail ; \
 	CGO_ENABLED=1 GODEBUG=cgocheck=2 MUTEX_WATCHDOG_TIMEOUT_SECS=30 ROX_POSTGRES_DATASTORE=true GOTAGS=$(GOTAGS),test,sql_integration scripts/go-test.sh -p 1 -race -cover -coverprofile test-output/coverage.out -v \
-		$(shell git ls-files -- '*_test.go' | sed -e 's@^@./@g' | xargs -n 1 dirname | sort | uniq | xargs go list| grep -v '^github.com/stackrox/rox/tests$$' | grep -Ev $(UNIT_TEST_IGNORE)) \
+		$(shell git ls-files -- '*postgres/*_test.go' '*postgres_test.go' '*datastore_sac_test.go' '*clone_test.go' 'migrator/migrations/n_*/migration_test.go' '*pruning_test.go' '*reprocessor_test.go' '*enricher_impl_test.go' '*v2/parts_test.go' '*version/ensure_test.go' '*version/store/store_impl_test.go' '*activecomponent/updater/updater_impl_test.go' '*role/validate_test.go' '*search/service/service_impl_test.go' '*deployment/service/service_impl_test.go' '*metadata/service/service_impl_test.go' '*systeminfo/listener/listener_test.go' | sed -e 's@^@./@g' | xargs -n 1 dirname | sort | uniq | xargs go list| grep -v '^github.com/stackrox/rox/tests$$' | grep -Ev $(UNIT_TEST_IGNORE)) \
 		| tee $(GO_TEST_OUTPUT_PATH)
 
 .PHONY: shell-unit-tests

--- a/central/activecomponent/datastore/index/indexer_impl_test.go
+++ b/central/activecomponent/datastore/index/indexer_impl_test.go
@@ -9,12 +9,15 @@ import (
 	"github.com/stackrox/rox/central/activecomponent/dackbox"
 	"github.com/stackrox/rox/central/globalindex"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stretchr/testify/suite"
 )
 
 func TestActiveComponentIndex(t *testing.T) {
+	pgtest.SkipIfPostgresEnabled(t)
+
 	suite.Run(t, new(ActiveComponentIndexTestSuite))
 }
 

--- a/central/alert/datastore/datastore_sac_test.go
+++ b/central/alert/datastore/datastore_sac_test.go
@@ -1,3 +1,5 @@
+//go:build sql_integration
+
 package datastore
 
 import (

--- a/central/alert/service/service_test.go
+++ b/central/alert/service/service_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"math"
+	"strconv"
 	"testing"
 	"time"
 
@@ -16,6 +17,7 @@ import (
 	baselineMocks "github.com/stackrox/rox/central/processbaseline/datastore/mocks"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stretchr/testify/assert"
@@ -393,7 +395,7 @@ func (s *getAlertsCountsTests) TestGetAlertsCountsWhenAlertsAreNotGrouped() {
 		{
 			ID: "id1",
 			Matches: map[string][]string{
-				severityField.GetFieldPath(): {"1"},
+				severityField.GetFieldPath(): {flagAwareSeverity(1)},
 				categoryField.GetFieldPath(): {"Image Assurance"},
 				clusterField.GetFieldPath():  {"test"},
 			},
@@ -401,7 +403,7 @@ func (s *getAlertsCountsTests) TestGetAlertsCountsWhenAlertsAreNotGrouped() {
 		{
 			ID: "id2",
 			Matches: map[string][]string{
-				severityField.GetFieldPath(): {"4"},
+				severityField.GetFieldPath(): {flagAwareSeverity(4)},
 				categoryField.GetFieldPath(): {"Container Configuration"},
 				clusterField.GetFieldPath():  {"test"},
 			},
@@ -409,7 +411,7 @@ func (s *getAlertsCountsTests) TestGetAlertsCountsWhenAlertsAreNotGrouped() {
 		{
 			ID: "id3",
 			Matches: map[string][]string{
-				severityField.GetFieldPath(): {"1"},
+				severityField.GetFieldPath(): {flagAwareSeverity(1)},
 				categoryField.GetFieldPath(): {"Image Assurance"},
 				clusterField.GetFieldPath():  {"prod"},
 			},
@@ -417,7 +419,7 @@ func (s *getAlertsCountsTests) TestGetAlertsCountsWhenAlertsAreNotGrouped() {
 		{
 			ID: "id4",
 			Matches: map[string][]string{
-				severityField.GetFieldPath(): {"2"},
+				severityField.GetFieldPath(): {flagAwareSeverity(2)},
 				categoryField.GetFieldPath(): {"Privileges Capabilities"},
 				clusterField.GetFieldPath():  {"prod"},
 			},
@@ -425,7 +427,7 @@ func (s *getAlertsCountsTests) TestGetAlertsCountsWhenAlertsAreNotGrouped() {
 		{
 			ID: "id5",
 			Matches: map[string][]string{
-				severityField.GetFieldPath(): {"3"},
+				severityField.GetFieldPath(): {flagAwareSeverity(3)},
 				categoryField.GetFieldPath(): {"Image Assurance", "Container Configuration"},
 				clusterField.GetFieldPath():  {"prod"},
 			},
@@ -433,7 +435,7 @@ func (s *getAlertsCountsTests) TestGetAlertsCountsWhenAlertsAreNotGrouped() {
 		{
 			ID: "id6",
 			Matches: map[string][]string{
-				severityField.GetFieldPath(): {"3"},
+				severityField.GetFieldPath(): {flagAwareSeverity(3)},
 				categoryField.GetFieldPath(): {"Image Assurance", "Container Configuration"},
 				clusterField.GetFieldPath():  {"test"},
 			},
@@ -469,6 +471,13 @@ func (s *getAlertsCountsTests) TestGetAlertsCountsWhenAlertsAreNotGrouped() {
 	s.testGetAlertCounts(fakeSearchResultsSlice, v1.GetAlertsCountsRequest_UNSET, expected)
 }
 
+func flagAwareSeverity(i int) string {
+	if env.PostgresDatastoreEnabled.BooleanSetting() {
+		return storage.Severity_name[int32(i)]
+	}
+	return strconv.Itoa(i)
+}
+
 func (s *getAlertsCountsTests) TestGetAlertsCountsForAlertsGroupedByCategory() {
 	severityField, _ := mappings.OptionsMap.Get(search.Severity.String())
 	categoryField, _ := mappings.OptionsMap.Get(search.Category.String())
@@ -478,7 +487,7 @@ func (s *getAlertsCountsTests) TestGetAlertsCountsForAlertsGroupedByCategory() {
 		{
 			ID: "id1",
 			Matches: map[string][]string{
-				severityField.GetFieldPath(): {"1"},
+				severityField.GetFieldPath(): {flagAwareSeverity(1)},
 				categoryField.GetFieldPath(): {"Image Assurance"},
 				clusterField.GetFieldPath():  {"test"},
 			},
@@ -486,7 +495,7 @@ func (s *getAlertsCountsTests) TestGetAlertsCountsForAlertsGroupedByCategory() {
 		{
 			ID: "id2",
 			Matches: map[string][]string{
-				severityField.GetFieldPath(): {"4"},
+				severityField.GetFieldPath(): {flagAwareSeverity(4)},
 				categoryField.GetFieldPath(): {"Container Configuration"},
 				clusterField.GetFieldPath():  {"test"},
 			},
@@ -494,7 +503,7 @@ func (s *getAlertsCountsTests) TestGetAlertsCountsForAlertsGroupedByCategory() {
 		{
 			ID: "id3",
 			Matches: map[string][]string{
-				severityField.GetFieldPath(): {"1"},
+				severityField.GetFieldPath(): {flagAwareSeverity(1)},
 				categoryField.GetFieldPath(): {"Image Assurance"},
 				clusterField.GetFieldPath():  {"prod"},
 			},
@@ -502,7 +511,7 @@ func (s *getAlertsCountsTests) TestGetAlertsCountsForAlertsGroupedByCategory() {
 		{
 			ID: "id4",
 			Matches: map[string][]string{
-				severityField.GetFieldPath(): {"2"},
+				severityField.GetFieldPath(): {flagAwareSeverity(2)},
 				categoryField.GetFieldPath(): {"Privileges Capabilities"},
 				clusterField.GetFieldPath():  {"prod"},
 			},
@@ -510,7 +519,7 @@ func (s *getAlertsCountsTests) TestGetAlertsCountsForAlertsGroupedByCategory() {
 		{
 			ID: "id5",
 			Matches: map[string][]string{
-				severityField.GetFieldPath(): {"3"},
+				severityField.GetFieldPath(): {flagAwareSeverity(3)},
 				categoryField.GetFieldPath(): {"Image Assurance", "Container Configuration"},
 				clusterField.GetFieldPath():  {"prod"},
 			},
@@ -518,7 +527,7 @@ func (s *getAlertsCountsTests) TestGetAlertsCountsForAlertsGroupedByCategory() {
 		{
 			ID: "id6",
 			Matches: map[string][]string{
-				severityField.GetFieldPath(): {"3"},
+				severityField.GetFieldPath(): {flagAwareSeverity(3)},
 				categoryField.GetFieldPath(): {"Image Assurance", "Container Configuration"},
 				clusterField.GetFieldPath():  {"test"},
 			},
@@ -577,7 +586,7 @@ func (s *getAlertsCountsTests) TestGetAlertsCountsForAlertsGroupedByCluster() {
 		{
 			ID: "id1",
 			Matches: map[string][]string{
-				severityField.GetFieldPath(): {"1"},
+				severityField.GetFieldPath(): {flagAwareSeverity(1)},
 				categoryField.GetFieldPath(): {"Image Assurance"},
 				clusterField.GetFieldPath():  {"test"},
 			},
@@ -585,7 +594,7 @@ func (s *getAlertsCountsTests) TestGetAlertsCountsForAlertsGroupedByCluster() {
 		{
 			ID: "id2",
 			Matches: map[string][]string{
-				severityField.GetFieldPath(): {"4"},
+				severityField.GetFieldPath(): {flagAwareSeverity(4)},
 				categoryField.GetFieldPath(): {"Container Configuration"},
 				clusterField.GetFieldPath():  {"test"},
 			},
@@ -593,7 +602,7 @@ func (s *getAlertsCountsTests) TestGetAlertsCountsForAlertsGroupedByCluster() {
 		{
 			ID: "id3",
 			Matches: map[string][]string{
-				severityField.GetFieldPath(): {"1"},
+				severityField.GetFieldPath(): {flagAwareSeverity(1)},
 				categoryField.GetFieldPath(): {"Image Assurance"},
 				clusterField.GetFieldPath():  {"prod"},
 			},
@@ -601,7 +610,7 @@ func (s *getAlertsCountsTests) TestGetAlertsCountsForAlertsGroupedByCluster() {
 		{
 			ID: "id4",
 			Matches: map[string][]string{
-				severityField.GetFieldPath(): {"2"},
+				severityField.GetFieldPath(): {flagAwareSeverity(2)},
 				categoryField.GetFieldPath(): {"Privileges Capabilities"},
 				clusterField.GetFieldPath():  {"prod"},
 			},
@@ -609,7 +618,7 @@ func (s *getAlertsCountsTests) TestGetAlertsCountsForAlertsGroupedByCluster() {
 		{
 			ID: "id5",
 			Matches: map[string][]string{
-				severityField.GetFieldPath(): {"3"},
+				severityField.GetFieldPath(): {flagAwareSeverity(3)},
 				categoryField.GetFieldPath(): {"Image Assurance", "Container Configuration"},
 				clusterField.GetFieldPath():  {"prod"},
 			},
@@ -617,7 +626,7 @@ func (s *getAlertsCountsTests) TestGetAlertsCountsForAlertsGroupedByCluster() {
 		{
 			ID: "id6",
 			Matches: map[string][]string{
-				severityField.GetFieldPath(): {"3"},
+				severityField.GetFieldPath(): {flagAwareSeverity(3)},
 				categoryField.GetFieldPath(): {"Image Assurance", "Container Configuration"},
 				clusterField.GetFieldPath():  {"test"},
 			},
@@ -688,7 +697,7 @@ func (s *getAlertsCountsTests) TestGetAlertsCountsWhenTheGroupIsUnknown() {
 		{
 			ID: "id1",
 			Matches: map[string][]string{
-				severityField.GetFieldPath(): {"1"},
+				severityField.GetFieldPath(): {flagAwareSeverity(1)},
 				categoryField.GetFieldPath(): {"Image Assurance"},
 				clusterField.GetFieldPath():  {"test"},
 			},
@@ -696,7 +705,7 @@ func (s *getAlertsCountsTests) TestGetAlertsCountsWhenTheGroupIsUnknown() {
 		{
 			ID: "id2",
 			Matches: map[string][]string{
-				severityField.GetFieldPath(): {"4"},
+				severityField.GetFieldPath(): {flagAwareSeverity(4)},
 				categoryField.GetFieldPath(): {"Container Configuration"},
 				clusterField.GetFieldPath():  {"test"},
 			},
@@ -704,7 +713,7 @@ func (s *getAlertsCountsTests) TestGetAlertsCountsWhenTheGroupIsUnknown() {
 		{
 			ID: "id3",
 			Matches: map[string][]string{
-				severityField.GetFieldPath(): {"1"},
+				severityField.GetFieldPath(): {flagAwareSeverity(1)},
 				categoryField.GetFieldPath(): {"Image Assurance"},
 				clusterField.GetFieldPath():  {"prod"},
 			},
@@ -712,7 +721,7 @@ func (s *getAlertsCountsTests) TestGetAlertsCountsWhenTheGroupIsUnknown() {
 		{
 			ID: "id4",
 			Matches: map[string][]string{
-				severityField.GetFieldPath(): {"2"},
+				severityField.GetFieldPath(): {flagAwareSeverity(2)},
 				categoryField.GetFieldPath(): {"Privileges Capabilities"},
 				clusterField.GetFieldPath():  {"prod"},
 			},
@@ -720,7 +729,7 @@ func (s *getAlertsCountsTests) TestGetAlertsCountsWhenTheGroupIsUnknown() {
 		{
 			ID: "id5",
 			Matches: map[string][]string{
-				severityField.GetFieldPath(): {"3"},
+				severityField.GetFieldPath(): {flagAwareSeverity(3)},
 				categoryField.GetFieldPath(): {"Image Assurance", "Container Configuration"},
 				clusterField.GetFieldPath():  {"prod"},
 			},
@@ -728,7 +737,7 @@ func (s *getAlertsCountsTests) TestGetAlertsCountsWhenTheGroupIsUnknown() {
 		{
 			ID: "id6",
 			Matches: map[string][]string{
-				severityField.GetFieldPath(): {"3"},
+				severityField.GetFieldPath(): {flagAwareSeverity(3)},
 				categoryField.GetFieldPath(): {"Image Assurance", "Container Configuration"},
 				clusterField.GetFieldPath():  {"test"},
 			},

--- a/central/cluster/datastore/datastore_sac_test.go
+++ b/central/cluster/datastore/datastore_sac_test.go
@@ -1,3 +1,5 @@
+//go:build sql_integration
+
 package datastore
 
 import (

--- a/central/clustercveedge/datastoretest/datastore_sac_test.go
+++ b/central/clustercveedge/datastoretest/datastore_sac_test.go
@@ -1,3 +1,5 @@
+//go:build sql_integration
+
 package datastore
 
 import (

--- a/central/clustercveedge/datastoretest/test.go
+++ b/central/clustercveedge/datastoretest/test.go
@@ -1,0 +1,3 @@
+package datastore
+
+// Make the compiler happy

--- a/central/componentcveedge/datastore/datastore_sac_test.go
+++ b/central/componentcveedge/datastore/datastore_sac_test.go
@@ -1,3 +1,5 @@
+//go:build sql_integration
+
 package datastore
 
 import (

--- a/central/cve/cluster/datastoretest/datastore_sac_test.go
+++ b/central/cve/cluster/datastoretest/datastore_sac_test.go
@@ -1,3 +1,5 @@
+//go:build sql_integration
+
 package datastoretest
 
 import (

--- a/central/cve/cluster/datastoretest/test.go
+++ b/central/cve/cluster/datastoretest/test.go
@@ -1,0 +1,3 @@
+package datastoretest
+
+// Make the compiler happy

--- a/central/cve/datastoretest/datastore_sac_test.go
+++ b/central/cve/datastoretest/datastore_sac_test.go
@@ -1,3 +1,5 @@
+//go:build sql_integration
+
 package datastoretest
 
 import (

--- a/central/cve/node/datastore/datastore_impl_test.go
+++ b/central/cve/node/datastore/datastore_impl_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/cve"
 	"github.com/stackrox/rox/pkg/dackbox/concurrency"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
 	"github.com/stackrox/rox/pkg/sac"
 	searchPkg "github.com/stackrox/rox/pkg/search"
 	"github.com/stretchr/testify/suite"
@@ -26,6 +27,8 @@ var (
 )
 
 func TestNodeCVEDataStore(t *testing.T) {
+	pgtest.SkipIfPostgresEnabled(t)
+
 	suite.Run(t, new(NodeCVEDataStoreSuite))
 }
 

--- a/central/cve/node/datastore/datastore_impl_test.go
+++ b/central/cve/node/datastore/datastore_impl_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/cve"
 	"github.com/stackrox/rox/pkg/dackbox/concurrency"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
 	"github.com/stackrox/rox/pkg/sac"
 	searchPkg "github.com/stackrox/rox/pkg/search"
 	"github.com/stretchr/testify/suite"
@@ -26,6 +27,8 @@ var (
 )
 
 func TestNodeCVEDataStore(t *testing.T) {
+	pgtest.SkipIfPostgresDisabled(t)
+
 	suite.Run(t, new(NodeCVEDataStoreSuite))
 }
 

--- a/central/cve/node/datastore/datastore_impl_test.go
+++ b/central/cve/node/datastore/datastore_impl_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/cve"
 	"github.com/stackrox/rox/pkg/dackbox/concurrency"
-	"github.com/stackrox/rox/pkg/postgres/pgtest"
 	"github.com/stackrox/rox/pkg/sac"
 	searchPkg "github.com/stackrox/rox/pkg/search"
 	"github.com/stretchr/testify/suite"
@@ -27,8 +26,6 @@ var (
 )
 
 func TestNodeCVEDataStore(t *testing.T) {
-	pgtest.SkipIfPostgresEnabled(t)
-
 	suite.Run(t, new(NodeCVEDataStoreSuite))
 }
 
@@ -132,7 +129,7 @@ func (suite *NodeCVEDataStoreSuite) TestSuppressionCacheForNodes() {
 	// No apply these to the image
 	node := getNodeWithCVEs("CVE-ABC", "CVE-DEF", "CVE-GHI")
 	suite.datastore.EnrichNodeWithSuppressedCVEs(node)
-	suite.verifySuppressionStateNode(node, []string{"CVE-ABC", "CVE-DEF"}, []string{"CVE-GHI"})
+	suite.verifySuppressionStateNode(node, []string{"CVE-ABC#", "CVE-DEF#"}, []string{"CVE-GHI#"})
 
 	start := types.TimestampNow()
 	duration := types.DurationProto(10 * time.Minute)
@@ -165,7 +162,7 @@ func (suite *NodeCVEDataStoreSuite) TestSuppressionCacheForNodes() {
 	err = suite.datastore.Suppress(testAllAccessContext, start, duration, "CVE-GHI")
 	suite.NoError(err)
 	suite.datastore.EnrichNodeWithSuppressedCVEs(node)
-	suite.verifySuppressionStateNode(node, []string{"CVE-ABC", "CVE-DEF", "CVE-GHI"}, nil)
+	suite.verifySuppressionStateNode(node, []string{"CVE-ABC#", "CVE-DEF#", "CVE-GHI#"}, nil)
 
 	// Clear image before unsupressing
 	node = getNodeWithCVEs("CVE-ABC", "CVE-DEF", "CVE-GHI")
@@ -176,5 +173,5 @@ func (suite *NodeCVEDataStoreSuite) TestSuppressionCacheForNodes() {
 	err = suite.datastore.Unsuppress(testAllAccessContext, "CVE-GHI")
 	suite.NoError(err)
 	suite.datastore.EnrichNodeWithSuppressedCVEs(node)
-	suite.verifySuppressionStateNode(node, []string{"CVE-ABC", "CVE-DEF"}, []string{"CVE-GHI"})
+	suite.verifySuppressionStateNode(node, []string{"CVE-ABC#", "CVE-DEF#"}, []string{"CVE-GHI#"})
 }

--- a/central/debug/service/db_diagnostics_test.go
+++ b/central/debug/service/db_diagnostics_test.go
@@ -1,3 +1,5 @@
+//go:build sql_integration
+
 package service
 
 import (

--- a/central/deployment/datastoretest/datastore_sac_test.go
+++ b/central/deployment/datastoretest/datastore_sac_test.go
@@ -1,3 +1,5 @@
+//go:build sql_integration
+
 package datastore
 
 import (

--- a/central/deployment/datastoretest/test.go
+++ b/central/deployment/datastoretest/test.go
@@ -1,0 +1,3 @@
+package datastore
+
+// Make the compiler happy

--- a/central/deployment/index/indexer_impl_test.go
+++ b/central/deployment/index/indexer_impl_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/fixtures"
 	"github.com/stackrox/rox/pkg/images/types"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/blevesearch"
 	"github.com/stackrox/rox/pkg/search/paginated"
@@ -24,6 +25,8 @@ import (
 )
 
 func TestDeploymentIndex(t *testing.T) {
+	pgtest.SkipIfPostgresEnabled(t)
+
 	suite.Run(t, new(DeploymentIndexTestSuite))
 }
 

--- a/central/deployment/index/search_comparison_test.go
+++ b/central/deployment/index/search_comparison_test.go
@@ -10,6 +10,7 @@ import (
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/fixtures"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/predicate"
@@ -33,6 +34,8 @@ func compareResults(t *testing.T, matches bool, predResult *search.Result, searc
 }
 
 func TestImageSearchResults(t *testing.T) {
+	pgtest.SkipIfPostgresEnabled(t)
+
 	cases := []struct {
 		image *storage.Image
 		query *v1.Query

--- a/central/deployment/service/service_impl_test.go
+++ b/central/deployment/service/service_impl_test.go
@@ -1,3 +1,5 @@
+//go:build sql_integration
+
 package service
 
 import (

--- a/central/globaldb/postgres_test.go
+++ b/central/globaldb/postgres_test.go
@@ -1,3 +1,5 @@
+//go:build sql_integration
+
 package globaldb
 
 import (

--- a/central/globalindex/bleveindex_test.go
+++ b/central/globalindex/bleveindex_test.go
@@ -7,11 +7,14 @@ import (
 	bleveMapping "github.com/blevesearch/bleve/mapping"
 	"github.com/stackrox/rox/central/globalindex/mapping"
 	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestCompareMapping(t *testing.T) {
+	pgtest.SkipIfPostgresEnabled(t)
+
 	indexMapping := mapping.GetIndexMapping()
 
 	tmpDir := t.TempDir()

--- a/central/graphql/resolvers/loaders/images_test.go
+++ b/central/graphql/resolvers/loaders/images_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stackrox/rox/central/image/datastore/mocks"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stretchr/testify/suite"
 )
@@ -35,6 +36,7 @@ func (suite *ImageLoaderTestSuite) SetupTest() {
 	suite.ctx = context.Background()
 
 	suite.mockCtrl = gomock.NewController(suite.T())
+	pgtest.SkipIfPostgresEnabled(suite.T())
 	suite.mockDataStore = mocks.NewMockDataStore(suite.mockCtrl)
 }
 

--- a/central/image/datastore/store/common/parts_test.go
+++ b/central/image/datastore/store/common/parts_test.go
@@ -6,11 +6,14 @@ import (
 	timestamp "github.com/gogo/protobuf/types"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/dackbox/edges"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
 	"github.com/stackrox/rox/pkg/scancomponent"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestSplitAndMergeImage(t *testing.T) {
+	pgtest.SkipIfPostgresEnabled(t)
+
 	ts := timestamp.TimestampNow()
 	image := &storage.Image{
 		Id: "sha",

--- a/central/image/datastore/store/dackbox/store_impl_test.go
+++ b/central/image/datastore/store/dackbox/store_impl_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stackrox/rox/pkg/dackbox"
 	"github.com/stackrox/rox/pkg/dackbox/concurrency"
 	"github.com/stackrox/rox/pkg/dackbox/edges"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
 	"github.com/stackrox/rox/pkg/rocksdb"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/testutils/rocksdbtest"
@@ -21,6 +22,8 @@ import (
 )
 
 func TestImageStore(t *testing.T) {
+	pgtest.SkipIfPostgresEnabled(t)
+
 	suite.Run(t, new(ImageStoreTestSuite))
 }
 

--- a/central/image/datastoretest/datastore_sac_test.go
+++ b/central/image/datastoretest/datastore_sac_test.go
@@ -1,3 +1,5 @@
+//go:build sql_integration
+
 package datastoretest
 
 import (

--- a/central/image/datastoretest/test.go
+++ b/central/image/datastoretest/test.go
@@ -1,0 +1,3 @@
+package datastoretest
+
+// Make the compiler happy

--- a/central/image/index/indexer_impl_test.go
+++ b/central/image/index/indexer_impl_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stackrox/rox/central/globalindex"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/pkg/fixtures"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stretchr/testify/suite"
 )
@@ -31,6 +32,8 @@ type ImageIndexTestSuite struct {
 }
 
 func (suite *ImageIndexTestSuite) SetupSuite() {
+	pgtest.SkipIfPostgresEnabled(suite.T())
+
 	tmpIndex, err := globalindex.TempInitializeIndices("")
 	suite.Require().NoError(err)
 

--- a/central/imagecomponent/datastoretest/datastore_sac_test.go
+++ b/central/imagecomponent/datastoretest/datastore_sac_test.go
@@ -1,3 +1,5 @@
+//go:build sql_integration
+
 package datastoretest
 
 import (

--- a/central/imagecomponentedge/datastore/datastore_sac_test.go
+++ b/central/imagecomponentedge/datastore/datastore_sac_test.go
@@ -1,3 +1,5 @@
+//go:build sql_integration
+
 package datastore
 
 import (

--- a/central/imagecveedge/datastore/datastore_sac_test.go
+++ b/central/imagecveedge/datastore/datastore_sac_test.go
@@ -1,3 +1,5 @@
+//go:build sql_integration
+
 package datastore
 
 import (

--- a/central/imageintegration/datastore/datastore_impl_test.go
+++ b/central/imageintegration/datastore/datastore_impl_test.go
@@ -17,6 +17,7 @@ import (
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/bolthelper"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/testutils"
@@ -27,6 +28,8 @@ import (
 )
 
 func TestImageIntegrationDataStore(t *testing.T) {
+	pgtest.SkipIfPostgresEnabled(t)
+
 	suite.Run(t, new(ImageIntegrationDataStoreTestSuite))
 }
 

--- a/central/metadata/service/service_impl_test.go
+++ b/central/metadata/service/service_impl_test.go
@@ -1,3 +1,5 @@
+//go:build sql_integration
+
 package service
 
 import (

--- a/central/namespace/datastore/datastore_sac_test.go
+++ b/central/namespace/datastore/datastore_sac_test.go
@@ -1,3 +1,5 @@
+//go:build sql_integration
+
 package datastore
 
 import (

--- a/central/namespace/index/indexer_impl_test.go
+++ b/central/namespace/index/indexer_impl_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/blevesearch/bleve"
 	"github.com/stackrox/rox/central/globalindex"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stretchr/testify/suite"
@@ -17,6 +18,8 @@ var (
 )
 
 func TestNamespaceIndex(t *testing.T) {
+	pgtest.SkipIfPostgresEnabled(t)
+
 	suite.Run(t, new(NamespaceIndexTestSuite))
 }
 

--- a/central/networkbaseline/datastore/datastore_impl_test.go
+++ b/central/networkbaseline/datastore/datastore_impl_test.go
@@ -1,3 +1,5 @@
+//go:build sql_integration
+
 package datastore
 
 import (

--- a/central/networkbaseline/datastore/datastore_sac_test.go
+++ b/central/networkbaseline/datastore/datastore_sac_test.go
@@ -1,3 +1,5 @@
+//go:build sql_integration
+
 package datastore
 
 import (

--- a/central/networkgraph/flow/datastore/internal/store/postgres/store_test.go
+++ b/central/networkgraph/flow/datastore/internal/store/postgres/store_test.go
@@ -1,3 +1,5 @@
+//go:build sql_integration
+
 package postgres
 
 import (

--- a/central/networkpolicies/datastore/datastore_sac_test.go
+++ b/central/networkpolicies/datastore/datastore_sac_test.go
@@ -1,3 +1,5 @@
+//go:build sql_integration
+
 package store
 
 import (

--- a/central/node/datastore/datastore_sac_test.go
+++ b/central/node/datastore/datastore_sac_test.go
@@ -1,3 +1,5 @@
+//go:build sql_integration
+
 package datastore
 
 import (

--- a/central/node/datastore/store/common/parts_test.go
+++ b/central/node/datastore/store/common/parts_test.go
@@ -6,11 +6,14 @@ import (
 	timestamp "github.com/gogo/protobuf/types"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/dackbox/edges"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
 	"github.com/stackrox/rox/pkg/scancomponent"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestSplitAndMergeNode(t *testing.T) {
+	pgtest.SkipIfPostgresEnabled(t)
+
 	ts := timestamp.TimestampNow()
 	node := &storage.Node{
 		Id:   "id",

--- a/central/node/datastore/store/common/v2/parts_test.go
+++ b/central/node/datastore/store/common/v2/parts_test.go
@@ -6,15 +6,17 @@ import (
 	timestamp "github.com/gogo/protobuf/types"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/cve"
-	"github.com/stackrox/rox/pkg/postgres/pgtest"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/scancomponent"
 	"github.com/stackrox/rox/pkg/search/postgres"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestSplitAndMergeNode(t *testing.T) {
-	pgtest.SkipIfPostgresEnabled(t)
-
+	if !env.PostgresDatastoreEnabled.BooleanSetting() {
+		t.Skip("Skip postgres tests")
+		t.SkipNow()
+	}
 	ts := timestamp.TimestampNow()
 	node := &storage.Node{
 		Id:   "id",

--- a/central/node/datastore/store/common/v2/parts_test.go
+++ b/central/node/datastore/store/common/v2/parts_test.go
@@ -6,19 +6,14 @@ import (
 	timestamp "github.com/gogo/protobuf/types"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/cve"
-	"github.com/stackrox/rox/pkg/env"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
 	"github.com/stackrox/rox/pkg/scancomponent"
 	"github.com/stackrox/rox/pkg/search/postgres"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestSplitAndMergeNode(t *testing.T) {
-	t.Setenv(env.PostgresDatastoreEnabled.EnvVar(), "true")
-
-	if !env.PostgresDatastoreEnabled.BooleanSetting() {
-		t.Skip("Skip postgres tests")
-		t.SkipNow()
-	}
+	pgtest.SkipIfPostgresEnabled(t)
 
 	ts := timestamp.TimestampNow()
 	node := &storage.Node{

--- a/central/node/datastore/store/dackbox/store_impl_test.go
+++ b/central/node/datastore/store/dackbox/store_impl_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/dackbox"
 	"github.com/stackrox/rox/pkg/dackbox/concurrency"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
 	"github.com/stackrox/rox/pkg/rocksdb"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/testutils/rocksdbtest"
@@ -18,6 +19,8 @@ import (
 )
 
 func TestNodeStore(t *testing.T) {
+	pgtest.SkipIfPostgresEnabled(t)
+
 	suite.Run(t, new(NodeStoreTestSuite))
 }
 

--- a/central/nodecomponentcveedge/datastore/datastore_sac_test.go
+++ b/central/nodecomponentcveedge/datastore/datastore_sac_test.go
@@ -1,3 +1,5 @@
+//go:build sql_integration
+
 package datastore
 
 import (

--- a/central/nodecomponentedge/datastore/datastore_sac_test.go
+++ b/central/nodecomponentedge/datastore/datastore_sac_test.go
@@ -1,3 +1,5 @@
+//go:build sql_integration
+
 package datastore
 
 import (

--- a/central/pod/datastore/datastore_sac_test.go
+++ b/central/pod/datastore/datastore_sac_test.go
@@ -1,3 +1,5 @@
+//go:build sql_integration
+
 package datastore
 
 import (

--- a/central/postgres/pruning_test.go
+++ b/central/postgres/pruning_test.go
@@ -1,3 +1,5 @@
+//go:build sql_integration
+
 package postgres
 
 import (

--- a/central/processbaseline/datastore/datastore_impl_test.go
+++ b/central/processbaseline/datastore/datastore_impl_test.go
@@ -1,3 +1,5 @@
+//go:build sql_integration
+
 package datastore
 
 import (

--- a/central/processbaseline/datastore/datastore_sac_test.go
+++ b/central/processbaseline/datastore/datastore_sac_test.go
@@ -1,3 +1,5 @@
+//go:build sql_integration
+
 package datastore
 
 import (

--- a/central/processbaseline/index/indexer_impl_test.go
+++ b/central/processbaseline/index/indexer_impl_test.go
@@ -9,6 +9,7 @@ import (
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/fixtures"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stretchr/testify/suite"
@@ -19,6 +20,8 @@ var (
 )
 
 func TestProcessBaselineIndex(t *testing.T) {
+	pgtest.SkipIfPostgresEnabled(t)
+
 	suite.Run(t, new(ProcessBaselineIndexTestSuite))
 }
 

--- a/central/processbaseline/search/searcher_impl_test.go
+++ b/central/processbaseline/search/searcher_impl_test.go
@@ -10,6 +10,7 @@ import (
 	mockStore "github.com/stackrox/rox/central/processbaseline/store/mocks"
 	"github.com/stackrox/rox/central/role/resources"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/fixtures"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
@@ -55,7 +56,9 @@ func (suite *ProcessBaselineSearchTestSuite) SetupTest() {
 	suite.controller = gomock.NewController(suite.T())
 	suite.indexer = mockIndex.NewMockIndexer(suite.controller)
 	suite.store = mockStore.NewMockStore(suite.controller)
-	suite.store.EXPECT().Walk(gomock.Any(), gomock.Any()).Return(nil)
+	if !env.PostgresDatastoreEnabled.BooleanSetting() {
+		suite.store.EXPECT().Walk(gomock.Any(), gomock.Any()).Return(nil)
+	}
 	searcher, err := New(suite.store, suite.indexer)
 
 	suite.NoError(err)

--- a/central/processbaseline/service/service_impl_test.go
+++ b/central/processbaseline/service/service_impl_test.go
@@ -20,6 +20,7 @@ import (
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/fixtures"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
 	"github.com/stackrox/rox/pkg/rocksdb"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/set"
@@ -78,6 +79,8 @@ func getIndicators(key *storage.ProcessBaselineKey) []*storage.ProcessIndicator 
 }
 
 func TestProcessBaselineService(t *testing.T) {
+	pgtest.SkipIfPostgresEnabled(t)
+
 	suite.Run(t, new(ProcessBaselineServiceTestSuite))
 }
 

--- a/central/processbaselineresults/datastore/datastore_sac_test.go
+++ b/central/processbaselineresults/datastore/datastore_sac_test.go
@@ -1,3 +1,5 @@
+//go:build sql_integration
+
 package datastore
 
 import (

--- a/central/processindicator/datastore/datastore_impl_test.go
+++ b/central/processindicator/datastore/datastore_impl_test.go
@@ -1,3 +1,5 @@
+//go:build sql_integration
+
 package datastore
 
 import (

--- a/central/processindicator/datastore/datastore_sac_test.go
+++ b/central/processindicator/datastore/datastore_sac_test.go
@@ -1,3 +1,5 @@
+//go:build sql_integration
+
 package datastore
 
 import (

--- a/central/processindicator/index/indexer_impl_test.go
+++ b/central/processindicator/index/indexer_impl_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stackrox/rox/central/globalindex"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/pkg/fixtures"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stretchr/testify/assert"
@@ -21,6 +22,8 @@ var (
 )
 
 func TestIndicatorIndex(t *testing.T) {
+	pgtest.SkipIfPostgresEnabled(t)
+
 	suite.Run(t, new(IndicatorIndexTestSuite))
 }
 

--- a/central/processindicator/search/searcher_impl_test.go
+++ b/central/processindicator/search/searcher_impl_test.go
@@ -9,6 +9,7 @@ import (
 	storeMock "github.com/stackrox/rox/central/processindicator/store/mocks"
 	"github.com/stackrox/rox/central/role/resources"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stretchr/testify/suite"
@@ -57,6 +58,7 @@ func (suite *IndicatorSearchTestSuite) TearDownSuite() {
 }
 
 func (suite *IndicatorSearchTestSuite) TestEnforcesSearch() {
+	pgtest.SkipIfPostgresEnabled(suite.T())
 	suite.indexer.EXPECT().Search(gomock.Any(), gomock.Any()).Return([]search.Result{{ID: "hgdskdf"}}, nil)
 
 	processIndicators, err := suite.searcher.Search(suite.hasNoneCtx, search.EmptyQuery())

--- a/central/processlisteningonport/datastore/datastore_impl_test.go
+++ b/central/processlisteningonport/datastore/datastore_impl_test.go
@@ -1,3 +1,5 @@
+//go:build sql_integration
+
 package datastore
 
 import (
@@ -21,8 +23,6 @@ import (
 )
 
 func TestPLOPDataStore(t *testing.T) {
-	pgtest.SkipIfPostgresEnabled(t)
-
 	suite.Run(t, new(PLOPDataStoreTestSuite))
 }
 

--- a/central/processlisteningonport/datastore/datastore_impl_test.go
+++ b/central/processlisteningonport/datastore/datastore_impl_test.go
@@ -21,6 +21,8 @@ import (
 )
 
 func TestPLOPDataStore(t *testing.T) {
+	pgtest.SkipIfPostgresEnabled(t)
+
 	suite.Run(t, new(PLOPDataStoreTestSuite))
 }
 

--- a/central/pruning/pruning_test.go
+++ b/central/pruning/pruning_test.go
@@ -1,3 +1,5 @@
+//go:build sql_integration
+
 package pruning
 
 import (
@@ -1167,10 +1169,6 @@ func (s *PruningTestSuite) TestAlertPruning() {
 			require.NoError(t, err)
 		})
 	}
-}
-
-func timestampNowMinus(t time.Duration) *protoTypes.Timestamp {
-	return protoconv.ConvertTimeToTimestamp(time.Now().Add(-t))
 }
 
 func timeBeforeDays(days int) *protoTypes.Timestamp {

--- a/central/pruning/pruning_vuln_req_test.go
+++ b/central/pruning/pruning_vuln_req_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	protoTypes "github.com/gogo/protobuf/types"
 	configDS "github.com/stackrox/rox/central/config/datastore"
 	"github.com/stackrox/rox/central/globalindex"
 	"github.com/stackrox/rox/central/vulnerabilityrequest/cache"
@@ -11,13 +12,20 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/postgres/pgtest"
+	"github.com/stackrox/rox/pkg/protoconv"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/testutils/rocksdbtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
+func timestampNowMinus(t time.Duration) *protoTypes.Timestamp {
+	return protoconv.ConvertTimeToTimestamp(time.Now().Add(-t))
+}
+
 func TestExpiredVulnReqsPruning(t *testing.T) {
+	pgtest.SkipIfPostgresEnabled(t)
+
 	db := rocksdbtest.RocksDBForT(t)
 	defer rocksdbtest.TearDownRocksDB(db)
 

--- a/central/rbac/k8srole/datastore/datastore_sac_test.go
+++ b/central/rbac/k8srole/datastore/datastore_sac_test.go
@@ -1,3 +1,5 @@
+//go:build sql_integration
+
 package datastore
 
 import (

--- a/central/rbac/k8srolebinding/datastore/datastore_sac_test.go
+++ b/central/rbac/k8srolebinding/datastore/datastore_sac_test.go
@@ -1,3 +1,5 @@
+//go:build sql_integration
+
 package datastore
 
 import (

--- a/central/reportconfigurations/service/service_impl_test.go
+++ b/central/reportconfigurations/service/service_impl_test.go
@@ -30,11 +30,11 @@ type TestReportConfigurationServiceTestSuite struct {
 }
 
 func (s *TestReportConfigurationServiceTestSuite) SetupTest() {
+	s.mockCtrl = gomock.NewController(s.T())
 	if env.PostgresDatastoreEnabled.BooleanSetting() {
 		s.T().Skip("Skip test when postgres is enabled")
 		s.T().SkipNow()
 	}
-	s.mockCtrl = gomock.NewController(s.T())
 	s.reportConfigDatastore = mocks.NewMockDataStore(s.mockCtrl)
 	s.notifierDatastore = notifierMocks.NewMockDataStore(s.mockCtrl)
 	s.accessScopeStore = accessScopeMocks.NewMockDataStore(s.mockCtrl)

--- a/central/reprocessor/reprocessor_test.go
+++ b/central/reprocessor/reprocessor_test.go
@@ -1,3 +1,5 @@
+//go:build sql_integration
+
 package reprocessor
 
 import (

--- a/central/risk/datastore/datastore_sac_test.go
+++ b/central/risk/datastore/datastore_sac_test.go
@@ -1,3 +1,5 @@
+//go:build sql_integration
+
 package datastore
 
 import (

--- a/central/risk/multipliers/component/node/vulnerabilities_test.go
+++ b/central/risk/multipliers/component/node/vulnerabilities_test.go
@@ -29,6 +29,8 @@ func TestVulnerabilitiesScore(t *testing.T) {
 	// Set both severity to unknown and then there should be a nil RiskResult
 	nodes[0].GetScan().GetComponents()[0].GetVulns()[0].Severity = storage.VulnerabilitySeverity_UNKNOWN_VULNERABILITY_SEVERITY
 	nodes[0].GetScan().GetComponents()[1].GetVulns()[0].Severity = storage.VulnerabilitySeverity_UNKNOWN_VULNERABILITY_SEVERITY
+	nodes[0].GetScan().GetComponents()[0].GetVulnerabilities()[0].Severity = storage.VulnerabilitySeverity_UNKNOWN_VULNERABILITY_SEVERITY
+	nodes[0].GetScan().GetComponents()[1].GetVulnerabilities()[0].Severity = storage.VulnerabilitySeverity_UNKNOWN_VULNERABILITY_SEVERITY
 
 	for _, nodeComponent := range nodes[0].GetScan().GetComponents() {
 		result = mult.Score(ctx, scancomponent.NewFromNodeComponent(nodeComponent))

--- a/central/risk/multipliers/deployment/service_account_permissions_test.go
+++ b/central/risk/multipliers/deployment/service_account_permissions_test.go
@@ -10,12 +10,15 @@ import (
 	"github.com/stackrox/rox/central/risk/multipliers"
 	saMocks "github.com/stackrox/rox/central/serviceaccount/datastore/mocks"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestPermissionScore(t *testing.T) {
+	pgtest.SkipIfPostgresEnabled(t)
+
 	deployment := multipliers.GetMockDeployment()
 	clusterCases := []struct {
 		name     string

--- a/central/risk/multipliers/node/vulnerabilities_test.go
+++ b/central/risk/multipliers/node/vulnerabilities_test.go
@@ -28,6 +28,8 @@ func TestVulnerabilitiesScore(t *testing.T) {
 	// Set both severity ratings to unknown and then there should be a nil RiskResult
 	nodes[0].GetScan().GetComponents()[0].GetVulns()[0].Severity = storage.VulnerabilitySeverity_UNKNOWN_VULNERABILITY_SEVERITY
 	nodes[0].GetScan().GetComponents()[1].GetVulns()[0].Severity = storage.VulnerabilitySeverity_UNKNOWN_VULNERABILITY_SEVERITY
+	nodes[0].GetScan().GetComponents()[0].GetVulnerabilities()[0].Severity = storage.VulnerabilitySeverity_UNKNOWN_VULNERABILITY_SEVERITY
+	nodes[0].GetScan().GetComponents()[1].GetVulnerabilities()[0].Severity = storage.VulnerabilitySeverity_UNKNOWN_VULNERABILITY_SEVERITY
 	result = mult.Score(ctx, nodes[0])
 	assert.Nil(t, result)
 }

--- a/central/risk/multipliers/test_utils.go
+++ b/central/risk/multipliers/test_utils.go
@@ -150,6 +150,15 @@ func GetMockNodes() []*storage.Node {
 								Severity:     storage.VulnerabilitySeverity_MODERATE_VULNERABILITY_SEVERITY,
 							},
 						},
+						Vulnerabilities: []*storage.NodeVulnerability{
+							{
+								CveBaseInfo: &storage.CVEInfo{
+									Cve: "CVE-2020-8558",
+								},
+								Cvss:     5.4,
+								Severity: storage.VulnerabilitySeverity_MODERATE_VULNERABILITY_SEVERITY,
+							},
+						},
 					},
 					{
 						Name:    "kube-proxy",
@@ -160,6 +169,15 @@ func GetMockNodes() []*storage.Node {
 								Cvss:         5.4,
 								ScoreVersion: storage.EmbeddedVulnerability_V3,
 								Severity:     storage.VulnerabilitySeverity_MODERATE_VULNERABILITY_SEVERITY,
+							},
+						},
+						Vulnerabilities: []*storage.NodeVulnerability{
+							{
+								CveBaseInfo: &storage.CVEInfo{
+									Cve: "CVE-2020-8558",
+								},
+								Cvss:     5.4,
+								Severity: storage.VulnerabilitySeverity_MODERATE_VULNERABILITY_SEVERITY,
 							},
 						},
 					},

--- a/central/risk/scorer/component/node/scorer_test.go
+++ b/central/risk/scorer/component/node/scorer_test.go
@@ -21,6 +21,9 @@ func TestScore(t *testing.T) {
 	nodeComponent.GetVulns()[0].Severity = storage.VulnerabilitySeverity_LOW_VULNERABILITY_SEVERITY
 	nodeComponent.GetVulns()[1].ScoreVersion = storage.EmbeddedVulnerability_V3
 	nodeComponent.GetVulns()[1].Severity = storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY
+	nodeComponent.GetVulnerabilities()[0].Severity = storage.VulnerabilitySeverity_LOW_VULNERABILITY_SEVERITY
+	nodeComponent.GetVulnerabilities()[1].CveBaseInfo.ScoreVersion = storage.CVEInfo_V3
+	nodeComponent.GetVulnerabilities()[1].Severity = storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY
 	nodeScorer := NewNodeComponentScorer()
 
 	// Without user defined function

--- a/central/risk/scorer/deployment/scorer_test.go
+++ b/central/risk/scorer/deployment/scorer_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stackrox/rox/central/risk/scorer/image"
 	saMocks "github.com/stackrox/rox/central/serviceaccount/datastore/mocks"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -100,16 +101,17 @@ func TestScore(t *testing.T) {
 		},
 	}
 
-	mockServiceAccounts.EXPECT().SearchRawServiceAccounts(ctx, gomock.Any()).Return(nil, nil)
-
+	if !env.PostgresDatastoreEnabled.BooleanSetting() {
+		mockServiceAccounts.EXPECT().SearchRawServiceAccounts(ctx, gomock.Any()).Return(nil, nil)
+	}
 	actualRisk := scorer.Score(ctx, deployment, getMockImagesRisk())
 	assert.Equal(t, expectedRiskResults, actualRisk.GetResults())
 	assert.InDelta(t, expectedRiskScore, actualRisk.GetScore(), 0.0001)
 
 	expectedRiskScore = 12.1794405
-
-	mockServiceAccounts.EXPECT().SearchRawServiceAccounts(ctx, gomock.Any()).Return(nil, nil)
-
+	if !env.PostgresDatastoreEnabled.BooleanSetting() {
+		mockServiceAccounts.EXPECT().SearchRawServiceAccounts(ctx, gomock.Any()).Return(nil, nil)
+	}
 	actualRisk = scorer.Score(ctx, deployment, getMockImagesRisk())
 	assert.Equal(t, expectedRiskResults, actualRisk.GetResults())
 	assert.InDelta(t, expectedRiskScore, actualRisk.GetScore(), 0.0001)

--- a/central/risk/scorer/test_utils.go
+++ b/central/risk/scorer/test_utils.go
@@ -132,6 +132,22 @@ func GetMockNode() *storage.Node {
 							Severity: storage.VulnerabilitySeverity_LOW_VULNERABILITY_SEVERITY,
 						},
 					},
+					Vulnerabilities: []*storage.NodeVulnerability{
+						{
+							CveBaseInfo: &storage.CVEInfo{
+								Cve: "CVE-2019-0001",
+							},
+							Cvss:     5,
+							Severity: storage.VulnerabilitySeverity_MODERATE_VULNERABILITY_SEVERITY,
+						},
+						{
+							CveBaseInfo: &storage.CVEInfo{
+								Cve: "CVE-2019-0002",
+							},
+							Cvss:     5,
+							Severity: storage.VulnerabilitySeverity_LOW_VULNERABILITY_SEVERITY,
+						},
+					},
 				},
 			},
 		},

--- a/central/role/datastore/datastore_test.go
+++ b/central/role/datastore/datastore_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/bolthelper"
 	"github.com/stackrox/rox/pkg/errox"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
 	"github.com/stackrox/rox/pkg/rocksdb"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/testutils"
@@ -56,6 +57,8 @@ func TestAnalystRoleDoesNotContainDebugLogs(t *testing.T) {
 }
 
 func TestRoleDataStore(t *testing.T) {
+	pgtest.SkipIfPostgresEnabled(t)
+
 	t.Parallel()
 	suite.Run(t, new(roleDataStoreTestSuite))
 }

--- a/central/search/service/service_impl_test.go
+++ b/central/search/service/service_impl_test.go
@@ -1,3 +1,5 @@
+//go:build sql_integration
+
 package service
 
 import (

--- a/central/secret/datastore/datastore_sac_test.go
+++ b/central/secret/datastore/datastore_sac_test.go
@@ -1,3 +1,5 @@
+//go:build sql_integration
+
 package datastore
 
 import (

--- a/central/serviceaccount/datastore/datastore_impl_test.go
+++ b/central/serviceaccount/datastore/datastore_impl_test.go
@@ -1,3 +1,5 @@
+//go:build sql_integration
+
 package datastore
 
 import (

--- a/central/serviceaccount/datastore/datastore_sac_test.go
+++ b/central/serviceaccount/datastore/datastore_sac_test.go
@@ -1,3 +1,5 @@
+//go:build sql_integration
+
 package datastore
 
 import (

--- a/central/splunk/violations_test.go
+++ b/central/splunk/violations_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stackrox/rox/central/alert/datastore"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/booleanpolicy/violationmessages/printer"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/utils"
@@ -624,6 +625,8 @@ func mustParseTime(timeStr string) time.Time {
 }
 
 func TestViolations(t *testing.T) {
+	pgtest.SkipIfPostgresEnabled(t)
+
 	suite.Run(t, &violationsTestSuite{})
 }
 

--- a/central/systeminfo/listener/listener_test.go
+++ b/central/systeminfo/listener/listener_test.go
@@ -1,3 +1,5 @@
+//go:build sql_integration
+
 package listener
 
 import (

--- a/central/telemetry/gatherers/gatherer_test.go
+++ b/central/telemetry/gatherers/gatherer_test.go
@@ -1,3 +1,5 @@
+//go:build sql_integration
+
 package gatherers
 
 import (

--- a/central/version/ensure_test.go
+++ b/central/version/ensure_test.go
@@ -1,3 +1,5 @@
+//go:build sql_integration
+
 package version
 
 import (

--- a/central/version/store/store_impl_test.go
+++ b/central/version/store/store_impl_test.go
@@ -1,3 +1,5 @@
+//go:build sql_integration
+
 package store
 
 import (

--- a/central/vulnerabilityrequest/manager/requestmgr/manager_impl_test.go
+++ b/central/vulnerabilityrequest/manager/requestmgr/manager_impl_test.go
@@ -62,6 +62,7 @@ import (
 	"github.com/stackrox/rox/pkg/dackbox/indexer"
 	"github.com/stackrox/rox/pkg/dackbox/utils/queue"
 	"github.com/stackrox/rox/pkg/fixtures"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
 	"github.com/stackrox/rox/pkg/protoconv"
 	"github.com/stackrox/rox/pkg/rocksdb"
 	"github.com/stackrox/rox/pkg/sac"
@@ -76,6 +77,8 @@ var (
 )
 
 func TestVulnRequestManager(t *testing.T) {
+	pgtest.SkipIfPostgresEnabled(t)
+
 	t.Parallel()
 	suite.Run(t, new(VulnRequestManagerTestSuite))
 }

--- a/migrator/clone/clone_test.go
+++ b/migrator/clone/clone_test.go
@@ -1,3 +1,5 @@
+//go:build sql_integration
+
 package clone
 
 import (

--- a/migrator/clone/postgres/db_clone_manager_impl_test.go
+++ b/migrator/clone/postgres/db_clone_manager_impl_test.go
@@ -1,3 +1,5 @@
+//go:build sql_integration
+
 package postgres
 
 import (
@@ -48,8 +50,6 @@ type PostgresCloneManagerSuite struct {
 }
 
 func TestManagerSuite(t *testing.T) {
-	pgtest.SkipIfPostgresEnabled(t)
-
 	suite.Run(t, new(PostgresCloneManagerSuite))
 }
 

--- a/migrator/clone/postgres/db_clone_manager_impl_test.go
+++ b/migrator/clone/postgres/db_clone_manager_impl_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stackrox/rox/migrator/clone/metadata"
 	migGorm "github.com/stackrox/rox/migrator/postgres/gorm"
 	migVer "github.com/stackrox/rox/migrator/version"
-	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/migrations"
 	migrationtestutils "github.com/stackrox/rox/pkg/migrations/testutils"
 	"github.com/stackrox/rox/pkg/postgres/pgadmin"
@@ -49,17 +48,12 @@ type PostgresCloneManagerSuite struct {
 }
 
 func TestManagerSuite(t *testing.T) {
+	pgtest.SkipIfPostgresEnabled(t)
+
 	suite.Run(t, new(PostgresCloneManagerSuite))
 }
 
 func (s *PostgresCloneManagerSuite) SetupTest() {
-	if !env.PostgresDatastoreEnabled.BooleanSetting() {
-		s.T().Skip("Skip postgres store tests")
-		s.T().SkipNow()
-	}
-
-	s.T().Setenv(env.PostgresDatastoreEnabled.EnvVar(), "true")
-
 	ctx := sac.WithAllAccess(context.Background())
 
 	source := pgtest.GetConnectionString(s.T())

--- a/pkg/migrations/migration_version_test.go
+++ b/pkg/migrations/migration_version_test.go
@@ -38,7 +38,7 @@ func TestMigrationVersion_Read(t *testing.T) {
 			},
 			shouldFail:  true,
 			expectedVer: version.GetMainVersion(),
-			expectedSeq: CurrentDBVersionSeqNum(),
+			expectedSeq: LastRocksDBVersionSeqNum(),
 		},
 		{
 			description: "Migration version exists",
@@ -47,7 +47,7 @@ func TestMigrationVersion_Read(t *testing.T) {
 			},
 			shouldFail:  false,
 			expectedVer: version.GetMainVersion(),
-			expectedSeq: CurrentDBVersionSeqNum(),
+			expectedSeq: LastRocksDBVersionSeqNum(),
 		},
 	}
 
@@ -124,7 +124,7 @@ func TestMigrationVersion_Write(t *testing.T) {
 			require.NoError(t, err)
 
 			assert.Equal(t, version.GetMainVersion(), ver.MainVersion)
-			assert.Equal(t, CurrentDBVersionSeqNum(), ver.SeqNum)
+			assert.Equal(t, LastRocksDBVersionSeqNum(), ver.SeqNum)
 			assert.Equal(t, dir, ver.dbPath)
 		})
 	}

--- a/pkg/postgres/pgadmin/admin_utils_test.go
+++ b/pkg/postgres/pgadmin/admin_utils_test.go
@@ -1,3 +1,5 @@
+//go:build sql_integration
+
 package pgadmin
 
 import (

--- a/pkg/postgres/pgtest/postgres.go
+++ b/pkg/postgres/pgtest/postgres.go
@@ -166,3 +166,11 @@ func SkipIfPostgresEnabled(t testing.TB) {
 		t.SkipNow()
 	}
 }
+
+// SkipIfPostgresDisabled skips the tests if the Postgres flag is off
+func SkipIfPostgresDisabled(t testing.TB) {
+	if !pkgEnv.PostgresDatastoreEnabled.BooleanSetting() {
+		t.Skip("Skipping test because Postgres is disabled")
+		t.SkipNow()
+	}
+}

--- a/pkg/postgres/pgtest/postgres.go
+++ b/pkg/postgres/pgtest/postgres.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/jackc/pgx/v4/pgxpool"
+	pkgEnv "github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/postgres/pgtest/conn"
 	pkgSchema "github.com/stackrox/rox/pkg/postgres/schema"
 	"github.com/stackrox/rox/pkg/random"
@@ -156,4 +157,12 @@ func OpenGormDB(t testing.TB, source string) *gorm.DB {
 // CloseGormDB closes connection to a Gorm DB
 func CloseGormDB(t testing.TB, db *gorm.DB) {
 	conn.CloseGormDB(t, db)
+}
+
+// SkipIfPostgresEnabled skips the tests if the Postgres flag is on
+func SkipIfPostgresEnabled(t testing.TB) {
+	if pkgEnv.PostgresDatastoreEnabled.BooleanSetting() {
+		t.Skip("Skipping test because Postgres is enabled")
+		t.SkipNow()
+	}
 }

--- a/pkg/scanners/clairify/convert_test.go
+++ b/pkg/scanners/clairify/convert_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/fixtures"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
 	"github.com/stackrox/rox/pkg/scanners/clairify/mock"
 	v1 "github.com/stackrox/scanner/generated/scanner/api/v1"
 	"github.com/stretchr/testify/assert"
@@ -265,6 +266,7 @@ func TestConvertNodeVulnerabilities(t *testing.T) {
 }
 
 func TestConvertFeatures(t *testing.T) {
+	pgtest.SkipIfPostgresEnabled(t)
 	// metadata is based on the fixture used below.
 	metadata := &storage.ImageMetadata{
 		V1: &storage.V1Metadata{


### PR DESCRIPTION
## Description

Split out the code changes that would not need to be reverted based on the flag flip from https://github.com/stackrox/stackrox/pull/4690

These tests need to be ported over to using Postgres as they test functionality not dependent on RocksDB

Central/deployment/index/search_comparison_test.go
Central/splunk/violations_test
TestImageLoader - graphql/resolvers/loaders/images_test.go
TestImageIntegrationDataStore - central/imageintegration/datastore/datastore_impl.go
TestProcessBaselineService - central/processbaseline/service/service_impl_test.go
Role/datastore/datastore_test.go

Once merged, will create JIRAs

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Unit tests :)