### PR TITLE
ROX-14780: Disable re-sync when deploying ACS with deploy.sh

### DIFF
--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -567,6 +567,12 @@ function launch_sensor {
            kubectl -n stackrox patch deploy/sensor --patch '{"spec":{"template":{"spec":{"containers":[{"name":"sensor","resources":{"limits":{"cpu":"500m","memory":"500Mi"},"requests":{"cpu":"500m","memory":"500Mi"}}}]}}}}'
        fi
     fi
+
+    # TODO(ROX-14310): Remove this patch when re-sync is disabled unconditionally
+    if [[ -n "$ROX_RESYNC_DISABLED" ]]; then
+        kubectl -n stackrox set env deploy/sensor ROX_RESYNC_DISABLED="true"
+    fi
+
     if [[ "$MONITORING_SUPPORT" == "true" || ( "$(local_dev)" != "true" && -z "$MONITORING_SUPPORT" ) ]]; then
       "${COMMON_DIR}/monitoring.sh"
     fi

--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -569,7 +569,7 @@ function launch_sensor {
     fi
 
     # TODO(ROX-14310): Remove this patch when re-sync is disabled unconditionally
-    if [[ -n "$ROX_RESYNC_DISABLED" ]]; then
+    if [[ "$ROX_RESYNC_DISABLED" == "true" ]]; then
         kubectl -n stackrox set env deploy/sensor ROX_RESYNC_DISABLED="true"
     fi
 

--- a/deploy/k8s/sensor.sh
+++ b/deploy/k8s/sensor.sh
@@ -24,4 +24,7 @@ if [[ -z "$ROX_ADMIN_PASSWORD" && -f "${K8S_DIR}/central-deploy/password" ]]; th
 	export ROX_ADMIN_PASSWORD
 fi
 
+# Enable new event pipeline without re-sync for k8s deployments
+ROX_RESYNC_DISABLED="true"
+
 launch_sensor "$K8S_DIR"

--- a/deploy/k8s/sensor.sh
+++ b/deploy/k8s/sensor.sh
@@ -25,6 +25,6 @@ if [[ -z "$ROX_ADMIN_PASSWORD" && -f "${K8S_DIR}/central-deploy/password" ]]; th
 fi
 
 # Enable new event pipeline without re-sync for k8s deployments
-ROX_RESYNC_DISABLED="true"
+export ROX_RESYNC_DISABLED="true"
 
 launch_sensor "$K8S_DIR"

--- a/sensor/kubernetes/sensor/sensor.go
+++ b/sensor/kubernetes/sensor/sensor.go
@@ -57,6 +57,12 @@ var (
 
 // CreateSensor takes in a client interface and returns a sensor instantiation
 func CreateSensor(cfg *CreateOptions) (*sensor.Sensor, error) {
+	if env.ResyncDisabled.BooleanSetting() {
+		log.Infof("Running sensor with Kubernetes re-sync disabled!")
+	} else {
+		log.Infof("Running sesnor with Kubernetes re-sync enabled. Re-sync time: %s", cfg.resyncPeriod.String())
+	}
+
 	admCtrlSettingsMgr := admissioncontroller.NewSettingsManager(resources.DeploymentStoreSingleton(), resources.PodStoreSingleton())
 
 	var helmManagedConfig *central.HelmManagedConfigInit

--- a/sensor/kubernetes/sensor/sensor.go
+++ b/sensor/kubernetes/sensor/sensor.go
@@ -58,7 +58,7 @@ var (
 // CreateSensor takes in a client interface and returns a sensor instantiation
 func CreateSensor(cfg *CreateOptions) (*sensor.Sensor, error) {
 	if env.ResyncDisabled.BooleanSetting() {
-		log.Infof("Running sensor with Kubernetes re-sync disabled!")
+		log.Infof("Running sensor with Kubernetes re-sync disabled")
 	} else {
 		log.Infof("Running sesnor with Kubernetes re-sync enabled. Re-sync time: %s", cfg.resyncPeriod.String())
 	}


### PR DESCRIPTION
## Description

Disable re-sync when deploying ACS using `deploy/k8s` scripts. 

## Checklist
- [x] Investigated and inspected CI test results
- [ ] ~~Unit test and regression tests added~~
- [ ] ~~Evaluated and added CHANGELOG entry if required~~
- [ ] ~~Determined and documented upgrade steps~~
- [ ] ~~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~



## Testing Performed

- [x] Deploying ACS using the updated script and check that resync is really disabled.