### PR TITLE
fix ImageScanningTest (no matching image registries found)

### DIFF
--- a/qa-tests-backend/src/test/groovy/ImageScanningTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageScanningTest.groovy
@@ -654,7 +654,7 @@ class ImageScanningTest extends BaseSpecification {
 
         where:
         image                                              | registry
-        "registry.k8s.io/ip-masq-agent-amd64:v2.4.1"       | "gcr registry"
+        "k8s.gcr.io/ip-masq-agent-amd64:v2.4.1"            | "gcr registry"
         "quay.io/rhacs-eng/qa:alpine-3.16.0"               | "quay registry"
         "quay.io/stackrox-io/scanner:2.27.3"               | "quay registry"
         "gke.gcr.io/heapster:v1.7.2"                       | "one from gke"


### PR DESCRIPTION
## Description

Fixes the `openshift-penultimate-qa-e2e-tests` by reverting one cherry-pick from https://github.com/stackrox/stackrox/commit/b5b80a3e97568a74af68c03ecee3b184e11c8824. 

Failed test: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/branch-ci-stackrox-stackrox-release-3.73-merge-openshift-penultimate-qa-e2e-tests/1621467481371578368. 

## Checklist
- [ ] Investigated and inspected CI test results

If any of these don't apply, please comment below.

## Testing Performed

CI is sufficient.