### PR TITLE
DO NOT REVIEW Dashrews/ROX-14794 updates to handle issues when rocksdb to Postgres migration has issue in the middle

### DIFF
--- a/migrator/main.go
+++ b/migrator/main.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/pkg/errors"
@@ -36,6 +37,7 @@ func main() {
 	startProfilingServer()
 	if err := run(); err != nil {
 		log.WriteToStderrf("Migrator failed: %s", err)
+		time.Sleep(30 * time.Minute)
 		os.Exit(1)
 	}
 }

--- a/pkg/migrations/internal/seq_num.go
+++ b/pkg/migrations/internal/seq_num.go
@@ -8,4 +8,7 @@ var (
 
 	// LastRocksDBVersionSeqNum is the sequence number for the last RocksDB version.
 	LastRocksDBVersionSeqNum = 112
+
+	// LastRocksToPostgresDBVersionSeqNum is the sequence number for the last legacy to Postgres migration
+	LastRocksToPostgresDBVersionSeqNum = 168
 )

--- a/pkg/migrations/seq_num.go
+++ b/pkg/migrations/seq_num.go
@@ -27,3 +27,8 @@ func BasePostgresDBVersionSeqNum() int {
 func LastRocksDBVersionSeqNum() int {
 	return internal.LastRocksDBVersionSeqNum
 }
+
+// LastRocksToPostgresDBVersionSeqNum is the sequence number for the last RocksDB to Postgres version.
+func LastRocksToPostgresDBVersionSeqNum() int {
+	return internal.LastRocksToPostgresDBVersionSeqNum
+}


### PR DESCRIPTION
## Description
Hold off.  I'm working on another solution that is actually much simpler and fits the migrator framework better.

If a migration from RocksDB to Postgres failed in the middle, the migrator would think that Postgres was the database of choice when starting back up and thus have no handles to RocksDB resulting in crashes.  This change will check to see if Postgres has completed the RocksDB to Postgres migration before determining whether to ignore RocksDB or not.  If we have determined that the migration failed in the middle, we will start over with the RocksDB to Postgres migration by moving what we have processed thus far to `central_temp` and starting `central_active` from scratch.  

Initially the plan was to pick up where the migration failed.  This turned out to be riskier than I initially thought so I felt it best to simply re-run the migrations.  The reasons I felt this was safer are:
1. The case where RocksDB migrations have to be executed as well caused additional logic paths to be introduced.  For example going from 3.72 -> 3.74 results in RocksDB migrations being executed but those are not persisted until the end.  So those cases need to start over regardless.
2.  The other case is that in testing I was running into migration issues were Postgres was complaining about unique key violations on the primary key when starting with a partially filled Postgres.  Those would crash central and eventually resolve themselves.  With the number of migrations involved, it felt more prudent to simply start from scratch for this one time migration than to debug and test those cases in each migration.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Updated unit and integration tests.  Additionally tested manually but starting 3.72, 3.73, and 3.74 in RocksDB mode with a sizeable workload such that the migration would take a few minutes.  After some time to get data populated, I would upgrade to 3.74 in Postgres mode.  Watching the logs, I would kill the pod at various times during the RocksDB -> Postgres migration to ensure that the migration would start over and complete.
