### PR TITLE
ROX-14490: Fix data race in `TestNetworkEntityDataStore`

### DIFF
--- a/central/networkgraph/entity/datastore/datastore_impl_test.go
+++ b/central/networkgraph/entity/datastore/datastore_impl_test.go
@@ -401,12 +401,12 @@ func (suite *NetworkEntityDataStoreTestSuite) TestSAC() {
 	suite.treeMgr.EXPECT().GetNetworkTree(gomock.Any(), cluster1).Return(trees[cluster1])
 	pushSig := suite.expectPushExternalNetworkEntitiesToSensor(cluster1)
 	suite.ds.RegisterCluster(context.Background(), cluster1)
-	// TODO: wait for pushSig
+	suite.True(concurrency.WaitWithTimeout(&pushSig, time.Second))
 
 	suite.treeMgr.EXPECT().GetNetworkTree(gomock.Any(), cluster2).Return(trees[cluster2])
 	pushSig = suite.expectPushExternalNetworkEntitiesToSensor(cluster2)
 	suite.ds.RegisterCluster(context.Background(), cluster2)
-	// TODO: wait for pushSig
+	suite.True(concurrency.WaitWithTimeout(&pushSig, time.Second))
 
 	// Success-upsert default
 	suite.treeMgr.EXPECT().GetNetworkTree(gomock.Any(), "").Return(trees[""])

--- a/central/networkgraph/entity/datastore/datastore_impl_test.go
+++ b/central/networkgraph/entity/datastore/datastore_impl_test.go
@@ -25,10 +25,13 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-var (
+const (
 	cluster1 = "cluster1"
 	cluster2 = "cluster2"
-	trees    = map[string]tree.NetworkTree{
+)
+
+var (
+	trees = map[string]tree.NetworkTree{
 		"":       tree.NewDefaultNetworkTreeWrapper(),
 		cluster1: tree.NewDefaultNetworkTreeWrapper(),
 		cluster2: tree.NewDefaultNetworkTreeWrapper(),
@@ -58,7 +61,8 @@ type NetworkEntityDataStoreTestSuite struct {
 
 func (suite *NetworkEntityDataStoreTestSuite) SetupSuite() {
 	suite.elevatedCtx = sac.WithGlobalAccessScopeChecker(context.Background(),
-		sac.AllowFixedScopes(sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+		sac.AllowFixedScopes(
+			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
 			sac.ResourceScopeKeys(resources.NetworkGraph)))
 	suite.noAccessCtx = sac.WithNoAccess(context.Background())
 	suite.globalReadAccessCtx = sac.WithGlobalAccessScopeChecker(context.Background(),


### PR DESCRIPTION
## Description

It is best to review this change by individual commits because there's bigg-ish prefactoring, but the actual fix is small.

I think the problem is with the test, rather than with the main code (which I did not dig enough).
I wasn't able to reproduce the test failure locally but I hope that my fix (explained below) should be able to address the issue.

In other words, my approach is to do the best effort, merge the change, close the ticket and wait the ticket to re-appear again on any subsequent test failures in case I wasn't able to resolve the root cause.

### Background info

The related ticket has three failures:

- https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/branch-ci-stackrox-stackrox-master-merge-go-unit-tests-release/1617573217029853184
```
=== RUN   TestNetworkEntityDataStore
=== RUN   TestNetworkEntityDataStore/TestDefaultGraphSetting
=== RUN   TestNetworkEntityDataStore/TestNetworkEntities
=== RUN   TestNetworkEntityDataStore/TestNetworkEntitiesBatchOps
=== RUN   TestNetworkEntityDataStore/TestSAC
=== CONT  TestNetworkEntityDataStore
    controller.go:231: missing call(s) to *mocks.MockManager.PushExternalNetworkEntitiesToAllSensors(is equal to context.Background.WithValue(type sac.globalAccessScopeContextKey, val <not Stringer>) (*context.valueCtx)) /go/src/github.com/stackrox/stackrox/central/networkgraph/entity/datastore/datastore_impl_test.go:589
    controller.go:231: aborting test due to missing call(s)
--- FAIL: TestNetworkEntityDataStore (0.12s)
    --- PASS: TestNetworkEntityDataStore/TestDefaultGraphSetting (0.00s)
    --- PASS: TestNetworkEntityDataStore/TestNetworkEntities (0.03s)
    --- PASS: TestNetworkEntityDataStore/TestNetworkEntitiesBatchOps (0.00s)
    --- PASS: TestNetworkEntityDataStore/TestSAC (0.01s)
FAIL
```

and
- https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/branch-ci-stackrox-stackrox-master-merge-go-unit-tests-release/1618037816581689344
- https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/branch-ci-stackrox-stackrox-master-merge-go-unit-tests/1618935478076051456

```
=== RUN   TestNetworkEntityDataStore
=== RUN   TestNetworkEntityDataStore/TestDefaultGraphSetting
=== RUN   TestNetworkEntityDataStore/TestNetworkEntities
=== RUN   TestNetworkEntityDataStore/TestNetworkEntitiesBatchOps
=== RUN   TestNetworkEntityDataStore/TestSAC
pkg/rocksdb: 2023/01/25 00:26:56.363831 rocksdb.go:59: Info: Signaling RocksDB to close
pkg/rocksdb: 2023/01/25 00:26:56.364013 rocksdb.go:72: Info: Closing RocksDB now that all operations have completed
==================
WARNING: DATA RACE
Read at 0x00c00115fd40 by goroutine 61:
  github.com/stackrox/rox/central/networkgraph/entity/datastore.(*NetworkEntityDataStoreTestSuite).TestSAC.func2()
      /go/src/github.com/stackrox/stackrox/central/networkgraph/entity/datastore/datastore_impl_test.go:437 +0x92
  runtime.call32()
      /usr/local/go/src/runtime/asm_amd64.s:702 +0x48
  reflect.Value.Call()
      /usr/local/go/src/reflect/value.go:339 +0xd7
  github.com/golang/mock/gomock.(*Call).DoAndReturn.func1()
      /go/pkg/mod/github.com/golang/mock@v1.7.0-rc.1/gomock/call.go:138 +0x969
  github.com/golang/mock/gomock.(*Controller).Call()
      /go/pkg/mod/github.com/golang/mock@v1.7.0-rc.1/gomock/controller.go:213 +0x123
  github.com/stackrox/rox/central/sensor/service/connection/mocks.(*MockManager).PushExternalNetworkEntitiesToSensor()
      /go/src/github.com/stackrox/stackrox/central/sensor/service/connection/mocks/manager.go:155 +0x1a4
  github.com/stackrox/rox/central/networkgraph/entity/datastore.(*dataStoreImpl).doPushExternalNetworkEntitiesToSensor()
      /go/src/github.com/stackrox/stackrox/central/networkgraph/entity/datastore/datastore_impl.go:483 +0x68b
  github.com/stackrox/rox/central/networkgraph/entity/datastore.(*dataStoreImpl).DeleteExternalNetworkEntity.func2()
      /go/src/github.com/stackrox/stackrox/central/networkgraph/entity/datastore/datastore_impl.go:399 +0x75

Previous write at 0x00c00115fd40 by goroutine 55:
  github.com/stretchr/testify/suite.(*Suite).SetT()
      /go/pkg/mod/github.com/stretchr/testify@v1.8.1/suite/suite.go:42 +0x148
  github.com/stackrox/rox/central/networkgraph/entity/datastore.(*NetworkEntityDataStoreTestSuite).SetT()
      <autogenerated>:1 +0x44
  github.com/stretchr/testify/suite.Run.func1.1()
      /go/pkg/mod/github.com/stretchr/testify@v1.8.1/suite/suite.go:160 +0x330
  runtime.deferreturn()
      /usr/local/go/src/runtime/panic.go:436 +0x32
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1439 +0x213
  testing.(*T).Run.func1()
      /usr/local/go/src/testing/testing.go:1486 +0x47

Goroutine 61 (running) created at:
  github.com/stackrox/rox/central/networkgraph/entity/datastore.(*dataStoreImpl).DeleteExternalNetworkEntity()
      /go/src/github.com/stackrox/stackrox/central/networkgraph/entity/datastore/datastore_impl.go:399 +0x3d6
  github.com/stackrox/rox/central/networkgraph/entity/datastore.(*NetworkEntityDataStoreTestSuite).TestSAC()
      /go/src/github.com/stackrox/stackrox/central/networkgraph/entity/datastore/datastore_impl_test.go:559 +0x526d
  runtime.call16()
      /usr/local/go/src/runtime/asm_amd64.s:701 +0x48
  reflect.Value.Call()
      /usr/local/go/src/reflect/value.go:339 +0xd7
  github.com/stretchr/testify/suite.Run.func1()
      /go/pkg/mod/github.com/stretchr/testify@v1.8.1/suite/suite.go:175 +0x6dc
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1439 +0x213
  testing.(*T).Run.func1()
      /usr/local/go/src/testing/testing.go:1486 +0x47

Goroutine 55 (finished) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:1486 +0x724
  github.com/stretchr/testify/suite.runTests()
      /go/pkg/mod/github.com/stretchr/testify@v1.8.1/suite/suite.go:220 +0x198
  github.com/stretchr/testify/suite.Run()
      /go/pkg/mod/github.com/stretchr/testify@v1.8.1/suite/suite.go:193 +0x969
  github.com/stackrox/rox/central/networkgraph/entity/datastore.TestNetworkEntityDataStore()
      /go/src/github.com/stackrox/stackrox/central/networkgraph/entity/datastore/datastore_impl_test.go:39 +0x44
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1439 +0x213
  testing.(*T).Run.func1()
      /usr/local/go/src/testing/testing.go:1486 +0x47
==================
==================
WARNING: DATA RACE
Read at 0x00c0011cc8b0 by goroutine 61:
  github.com/stretchr/testify/assert.(*Assertions).Equal()
      /go/pkg/mod/github.com/stretchr/testify@v1.8.1/assert/assertion_forward.go:128 +0x64
  github.com/stackrox/rox/central/networkgraph/entity/datastore.(*NetworkEntityDataStoreTestSuite).TestSAC.func2()
      /go/src/github.com/stackrox/stackrox/central/networkgraph/entity/datastore/datastore_impl_test.go:437 +0xbc
  runtime.call32()
      /usr/local/go/src/runtime/asm_amd64.s:702 +0x48
  reflect.Value.Call()
      /usr/local/go/src/reflect/value.go:339 +0xd7
  github.com/golang/mock/gomock.(*Call).DoAndReturn.func1()
      /go/pkg/mod/github.com/golang/mock@v1.7.0-rc.1/gomock/call.go:138 +0x969
  github.com/golang/mock/gomock.(*Controller).Call()
      /go/pkg/mod/github.com/golang/mock@v1.7.0-rc.1/gomock/controller.go:213 +0x123
  github.com/stackrox/rox/central/sensor/service/connection/mocks.(*MockManager).PushExternalNetworkEntitiesToSensor()
      /go/src/github.com/stackrox/stackrox/central/sensor/service/connection/mocks/manager.go:155 +0x1a4
  github.com/stackrox/rox/central/networkgraph/entity/datastore.(*dataStoreImpl).doPushExternalNetworkEntitiesToSensor()
      /go/src/github.com/stackrox/stackrox/central/networkgraph/entity/datastore/datastore_impl.go:483 +0x68b
  github.com/stackrox/rox/central/networkgraph/entity/datastore.(*dataStoreImpl).DeleteExternalNetworkEntity.func2()
      /go/src/github.com/stackrox/stackrox/central/networkgraph/entity/datastore/datastore_impl.go:399 +0x75

Previous write at 0x00c0011cc8b0 by goroutine 55:
  github.com/stretchr/testify/assert.New()
      /go/pkg/mod/github.com/stretchr/testify@v1.8.1/assert/forward_assertions.go:12 +0x104
  github.com/stretchr/testify/suite.(*Suite).SetT()
      /go/pkg/mod/github.com/stretchr/testify@v1.8.1/suite/suite.go:42 +0x13c
  github.com/stackrox/rox/central/networkgraph/entity/datastore.(*NetworkEntityDataStoreTestSuite).SetT()
      <autogenerated>:1 +0x44
  github.com/stretchr/testify/suite.Run.func1.1()
      /go/pkg/mod/github.com/stretchr/testify@v1.8.1/suite/suite.go:160 +0x330
  runtime.deferreturn()
      /usr/local/go/src/runtime/panic.go:436 +0x32
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1439 +0x213
  testing.(*T).Run.func1()
      /usr/local/go/src/testing/testing.go:1486 +0x47

Goroutine 61 (running) created at:
  github.com/stackrox/rox/central/networkgraph/entity/datastore.(*dataStoreImpl).DeleteExternalNetworkEntity()
      /go/src/github.com/stackrox/stackrox/central/networkgraph/entity/datastore/datastore_impl.go:399 +0x3d6
  github.com/stackrox/rox/central/networkgraph/entity/datastore.(*NetworkEntityDataStoreTestSuite).TestSAC()
      /go/src/github.com/stackrox/stackrox/central/networkgraph/entity/datastore/datastore_impl_test.go:559 +0x526d
  runtime.call16()
      /usr/local/go/src/runtime/asm_amd64.s:701 +0x48
  reflect.Value.Call()
      /usr/local/go/src/reflect/value.go:339 +0xd7
  github.com/stretchr/testify/suite.Run.func1()
      /go/pkg/mod/github.com/stretchr/testify@v1.8.1/suite/suite.go:175 +0x6dc
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1439 +0x213
  testing.(*T).Run.func1()
      /usr/local/go/src/testing/testing.go:1486 +0x47

Goroutine 55 (finished) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:1486 +0x724
  github.com/stretchr/testify/suite.runTests()
      /go/pkg/mod/github.com/stretchr/testify@v1.8.1/suite/suite.go:220 +0x198
  github.com/stretchr/testify/suite.Run()
      /go/pkg/mod/github.com/stretchr/testify@v1.8.1/suite/suite.go:193 +0x969
  github.com/stackrox/rox/central/networkgraph/entity/datastore.TestNetworkEntityDataStore()
      /go/src/github.com/stackrox/stackrox/central/networkgraph/entity/datastore/datastore_impl_test.go:39 +0x44
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1439 +0x213
  testing.(*T).Run.func1()
      /usr/local/go/src/testing/testing.go:1486 +0x47
==================
pkg/rocksdb: 2023/01/25 00:26:56.406188 rocksdb.go:78: Info: Closed RocksDB
=== CONT  TestNetworkEntityDataStore
    testing.go:1312: race detected during execution of test
--- FAIL: TestNetworkEntityDataStore (0.13s)
    --- PASS: TestNetworkEntityDataStore/TestDefaultGraphSetting (0.00s)
    --- PASS: TestNetworkEntityDataStore/TestNetworkEntities (0.01s)
    --- PASS: TestNetworkEntityDataStore/TestNetworkEntitiesBatchOps (0.00s)
    --- PASS: TestNetworkEntityDataStore/TestSAC (0.01s)
=== CONT  
    testing.go:1312: race detected during execution of test
FAIL
```

I find the data race one more indicative. The race happens between this fragment
https://github.com/stackrox/stackrox/blob/2ab87afd8928a8421cda1524d60e71bdb8098282/central/networkgraph/entity/datastore/datastore_impl_test.go#L432-L441
which makes `Read` at the line `437`
and
```
Previous write at 0x00c00115fd40 by goroutine 55:
  github.com/stretchr/testify/suite.(*Suite).SetT()
      /go/pkg/mod/github.com/stretchr/testify@v1.8.1/suite/suite.go:42 +0x148
```
where goroutine 55 is initiated from here (line 39)
https://github.com/stackrox/stackrox/blob/2ab87afd8928a8421cda1524d60e71bdb8098282/central/networkgraph/entity/datastore/datastore_impl_test.go#L38-L40

The code responsible for starting the Read goroutine is this https://github.com/stackrox/stackrox/blob/61f03dc82936b8caea37b51ec1bc7764535fb2f9/central/networkgraph/entity/datastore/datastore_impl.go#L116-L120

It took me a while to realize **what** is the actual element that's being raced upon in this line `suite.Equal(cluster1, clusterID)`. It is `suite`.

In fact, the write to `suite` that happens in ` github.com/stretchr/testify/suite.(*Suite).SetT()` is done **after the test function completes**. I verified this with debugger.

My interpretation of this is that `SetT()` changes the `suite` (as part of post-test cleanup), whereas the goroutine that's started by `PushExternalNetworkEntitiesToSensor` and captured the `suite` in closure starts running **after** that.

Why does the Read goroutine start after the test ends? Simply, unlike in other cases, we forgot to wait for `pushSig` to be signaled in the test code in these instructions (notice no `concurrency.WaitWithTimeout(&pushSig`)
https://github.com/stackrox/stackrox/blob/2ab87afd8928a8421cda1524d60e71bdb8098282/central/networkgraph/entity/datastore/datastore_impl_test.go#L432-L451

Obviously, it's a rare condition when these goroutines are so slow that they begin after the test ends, that's why we haven't seen the test failing more often.

I don't have a good explanation to the first test failure where the call to `PushExternalNetworkEntitiesToAllSensors` is missing. My hypothesis is that one of earlier `PushExternalNetworkEntitiesToAllSensors` calls gets consumed due to one of these two "unhandled" `pushSig.Signal()` calls being caught by one of `concurrency.WaitWithTimeout(&pushSig, ...)` instructions.
I changed the code so that we construct brand new `Signal` structure every time we expect Push...Sensor(s) so I hope it should help prevent unblock waiting by another goroutine.
tl;dr: I w.r.t. the test failing not due to data race, I suggest merge this PR and wait to see if fixes help there too.

## Checklist
- [x] Investigated and inspected CI test results

None of these will be checked:
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

* Expecting green CI. Will re-run unit tests 5 times.