### PR TITLE
fix GHA: set correct quay.io credentials for verify-release workflow

### DIFF
--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -73,8 +73,8 @@ jobs:
         uses: docker/login-action@v2
         with:
           registry: quay.io
-          username: ${{ secrets.QUAY_REGISTRY_USERNAME_RO }}
-          password: ${{ secrets.QUAY_REGISTRY_PASSWORD_RO }}
+          username: ${{ secrets.QUAY_RHACS_ENG_RO_USERNAME }}
+          password: ${{ secrets.QUAY_RHACS_ENG_RO_PASSWORD }}
 
       - name: Login to registry.redhat.io
         uses: docker/login-action@v2


### PR DESCRIPTION
## Description

Failed (Username and password required): https://github.com/stackrox/stackrox/actions/runs/4104924661
"Successful" (expected failure): https://github.com/stackrox/stackrox/actions/runs/4104983573

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient.