### PR TITLE
sensor integration test helper refactor

### DIFF
--- a/sensor/tests/resource/helper.go
+++ b/sensor/tests/resource/helper.go
@@ -233,7 +233,7 @@ func (c *TestContext) GetFakeCentral() *centralDebug.FakeService {
 	return c.fakeCentral
 }
 
-// run calls the proper test function depending on the configuration of the testRun.
+// run calls the test function depending on the configuration of the testRun.
 // For example, if permutation is set to true, it will run call runWithResourcesPermutation.
 func (c *TestContext) run(t *testRun) {
 	if t.resources == nil {

--- a/sensor/tests/resource/helper.go
+++ b/sensor/tests/resource/helper.go
@@ -152,6 +152,41 @@ func NewContextWithConfig(t *testing.T, config CentralConfig) (*TestContext, err
 	}, nil
 }
 
+// WithName sets the name of test
+func WithName(name string) TestRunFunc {
+	return func(t *testRun) {
+		t.name = name
+	}
+}
+
+// WithPermutation sets whether the test should run with permutations
+func WithPermutation() TestRunFunc {
+	return func(t *testRun) {
+		t.permutation = true
+	}
+}
+
+// WithResources sets the resources to be created by the test
+func WithResources(resources []K8sResourceInfo) TestRunFunc {
+	return func(t *testRun) {
+		t.resources = resources
+	}
+}
+
+// WithTestCase sets the TestCallback function to be run
+func WithTestCase(test TestCallback) TestRunFunc {
+	return func(t *testRun) {
+		t.testCase = test
+	}
+}
+
+// WithRetryCallback sets the RetryCallback function
+func WithRetryCallback(retryCallback RetryCallback) TestRunFunc {
+	return func(t *testRun) {
+		t.retryCallback = retryCallback
+	}
+}
+
 // NewRun runs a test case. Fails the test if the testRun cannot be created.
 func (c *TestContext) NewRun(options ...TestRunFunc) {
 	tr, err := newTestRun(options...)
@@ -725,36 +760,6 @@ type testRun struct {
 	testCase      TestCallback
 	retryCallback RetryCallback
 	permutation   bool
-}
-
-func WithName(name string) TestRunFunc {
-	return func(t *testRun) {
-		t.name = name
-	}
-}
-
-func WithPermutation() TestRunFunc {
-	return func(t *testRun) {
-		t.permutation = true
-	}
-}
-
-func WithResources(resources []K8sResourceInfo) TestRunFunc {
-	return func(t *testRun) {
-		t.resources = resources
-	}
-}
-
-func WithTestCase(test TestCallback) TestRunFunc {
-	return func(t *testRun) {
-		t.testCase = test
-	}
-}
-
-func WithRetryCallback(retryCallback RetryCallback) TestRunFunc {
-	return func(t *testRun) {
-		t.retryCallback = retryCallback
-	}
 }
 
 func (t *testRun) validate() error {

--- a/sensor/tests/resource/helper.go
+++ b/sensor/tests/resource/helper.go
@@ -606,7 +606,7 @@ func (c *TestContext) ApplyResource(ctx context.Context, ns string, resource *K8
 			err := c.r.Create(ctx, obj)
 			if err != nil && retryFn != nil {
 				if retryErr := retryFn(err, obj); retryErr != nil {
-					c.t.Fatal(errors.Wrapf(err, "error in retry callback: %s", retryErr)) // TODO: check this wrap
+					c.t.Fatal(errors.Wrapf(err, "error in retry callback: %s", retryErr))
 				}
 			}
 			return err

--- a/sensor/tests/resource/networkpolicy/networkpolicy_test.go
+++ b/sensor/tests/resource/networkpolicy/networkpolicy_test.go
@@ -61,7 +61,7 @@ func checkIfAlertsHaveViolation(result *central.AlertResults, name string) bool 
 }
 
 func (s *NetworkPolicySuite) Test_DeploymentShouldNotHaveViolation() {
-	s.testContext.NewRun(
+	s.testContext.RunTest(
 		resource.WithResources([]resource.K8sResourceInfo{
 			NginxDeployment, NetpolAllow443,
 		}),
@@ -81,7 +81,7 @@ func (s *NetworkPolicySuite) Test_DeploymentShouldNotHaveViolation() {
 }
 
 func (s *NetworkPolicySuite) Test_DeploymentShouldHaveViolation() {
-	s.testContext.NewRun(
+	s.testContext.RunTest(
 		resource.WithResources([]resource.K8sResourceInfo{
 			NginxDeployment,
 		}),

--- a/sensor/tests/resource/pod/pod_test.go
+++ b/sensor/tests/resource/pod/pod_test.go
@@ -21,8 +21,8 @@ import (
 )
 
 var (
-	NginxDeployment = resource.YamlTestFile{Kind: "Deployment", File: "nginx.yaml"}
-	NginxPod        = resource.YamlTestFile{Kind: "Pod", File: "nginx-pod.yaml"}
+	NginxDeployment = resource.K8sResourceInfo{Kind: "Deployment", YamlFile: "nginx.yaml"}
+	NginxPod        = resource.K8sResourceInfo{Kind: "Pod", YamlFile: "nginx-pod.yaml"}
 )
 
 type PodHierarchySuite struct {
@@ -77,115 +77,127 @@ func assertDeploymentContainerImages(images ...string) resource.AssertFunc {
 }
 
 func (s *PodHierarchySuite) Test_ContainerSpecOnDeployment() {
-	s.testContext.RunWithResources([]resource.YamlTestFile{
-		NginxDeployment,
-	}, func(t *testing.T, testC *resource.TestContext, objects map[string]k8s.Object) {
-		// wait until pods are created
-		err := wait.For(conditions.New(testC.Resources()).ResourceMatch(objects[NginxDeployment.File], func(object k8s.Object) bool {
-			d := object.(*appsv1.Deployment)
-			return d.Status.AvailableReplicas == 3 && d.Status.ReadyReplicas == 3
-		}), wait.WithTimeout(time.Second*10))
+	s.testContext.NewRun(
+		resource.WithResources([]resource.K8sResourceInfo{
+			NginxDeployment,
+		}),
+		resource.WithTestCase(func(t *testing.T, testC *resource.TestContext, objects map[string]k8s.Object) {
+			// wait until pods are created
+			err := wait.For(conditions.New(testC.Resources()).ResourceMatch(objects[NginxDeployment.YamlFile], func(object k8s.Object) bool {
+				d := object.(*appsv1.Deployment)
+				return d.Status.AvailableReplicas == 3 && d.Status.ReadyReplicas == 3
+			}), wait.WithTimeout(time.Second*10))
 
-		s.Require().NoError(err)
+			s.Require().NoError(err)
 
-		testC.LastDeploymentState("nginx-deployment",
-			assertDeploymentContainerImages("docker.io/library/nginx:1.14.2"),
-			"nginx deployment should have a single container with nginx:1.14.2 image")
+			testC.LastDeploymentState("nginx-deployment",
+				assertDeploymentContainerImages("docker.io/library/nginx:1.14.2"),
+				"nginx deployment should have a single container with nginx:1.14.2 image")
 
-		messages := testC.GetFakeCentral().GetAllMessages()
-		uniquePodNames := resource.GetUniquePodNamesFromPrefix(messages, "sensor-integration", "nginx-")
-		s.Require().Len(uniquePodNames, 3, "Should have received three different pod events")
-	})
+			messages := testC.GetFakeCentral().GetAllMessages()
+			uniquePodNames := resource.GetUniquePodNamesFromPrefix(messages, "sensor-integration", "nginx-")
+			s.Require().Len(uniquePodNames, 3, "Should have received three different pod events")
+		}),
+	)
 }
 
 func (s *PodHierarchySuite) Test_ParentlessPodsAreTreatedAsDeployments() {
-	s.testContext.RunWithResources([]resource.YamlTestFile{
-		NginxDeployment,
-		NginxPod,
-	}, func(t *testing.T, testC *resource.TestContext, objects map[string]k8s.Object) {
-		// wait until pods are created
-		err := wait.For(conditions.New(testC.Resources()).ResourceMatch(objects[NginxDeployment.File], func(object k8s.Object) bool {
-			d := object.(*appsv1.Deployment)
-			return d.Status.AvailableReplicas == 3 && d.Status.ReadyReplicas == 3
-		}), wait.WithTimeout(time.Second*10))
+	s.testContext.NewRun(
+		resource.WithResources([]resource.K8sResourceInfo{
+			NginxDeployment,
+			NginxPod,
+		}),
+		resource.WithTestCase(func(t *testing.T, testC *resource.TestContext, objects map[string]k8s.Object) {
+			// wait until pods are created
+			err := wait.For(conditions.New(testC.Resources()).ResourceMatch(objects[NginxDeployment.YamlFile], func(object k8s.Object) bool {
+				d := object.(*appsv1.Deployment)
+				return d.Status.AvailableReplicas == 3 && d.Status.ReadyReplicas == 3
+			}), wait.WithTimeout(time.Second*10))
 
-		s.Require().NoError(err)
+			s.Require().NoError(err)
 
-		testC.LastDeploymentState("nginx-rogue",
-			assertDeploymentContainerImages("docker.io/library/nginx:1.14.1"),
-			"nginx standalone pod should have a single container with nginx:1.14.1 image")
+			testC.LastDeploymentState("nginx-rogue",
+				assertDeploymentContainerImages("docker.io/library/nginx:1.14.1"),
+				"nginx standalone pod should have a single container with nginx:1.14.1 image")
 
-		messages := testC.GetFakeCentral().GetAllMessages()
-		uniqueDeployments := resource.GetUniqueDeploymentNames(messages, "sensor-integration")
-		s.Contains(uniqueDeployments, "nginx-deployment",
-			"Should have receiving at least one deployment with nginx-deployment name")
-		s.Contains(uniqueDeployments, "nginx-rogue",
-			"Should have receiving at least one deployment with nginx-rogue name")
+			messages := testC.GetFakeCentral().GetAllMessages()
+			uniqueDeployments := resource.GetUniqueDeploymentNames(messages, "sensor-integration")
+			s.Contains(uniqueDeployments, "nginx-deployment",
+				"Should have receiving at least one deployment with nginx-deployment name")
+			s.Contains(uniqueDeployments, "nginx-rogue",
+				"Should have receiving at least one deployment with nginx-rogue name")
 
-		uniquePodNames := resource.GetUniquePodNamesFromPrefix(messages, "sensor-integration", "nginx-")
-		s.Require().Len(uniquePodNames, 4,
-			"Should have received four different pod events (3 from nginx-deployment and 1 from nginx-rouge")
-	})
+			uniquePodNames := resource.GetUniquePodNamesFromPrefix(messages, "sensor-integration", "nginx-")
+			s.Require().Len(uniquePodNames, 4,
+				"Should have received four different pod events (3 from nginx-deployment and 1 from nginx-rouge")
+		}),
+	)
 }
 
 func (s *PodHierarchySuite) Test_DeleteDeployment() {
-	s.testContext.RunBare("Removing a deployment should send empty violation", func(t *testing.T, testC *resource.TestContext, _ map[string]k8s.Object) {
-		var id string
-		k8sDeployment := &appsv1.Deployment{}
-		deleteDep, err := testC.ApplyFile(context.Background(), resource.DefaultNamespace, NginxDeployment, k8sDeployment)
-		require.NoError(t, err)
-		id = string(k8sDeployment.GetUID())
-		// Check the deployment is processed
-		testC.WaitForDeploymentEvent("nginx-deployment")
-		testC.GetFakeCentral().ClearReceivedBuffer()
+	s.testContext.NewRun(
+		resource.WithName("Removing a deployment should send empty violation"),
+		resource.WithTestCase(func(t *testing.T, testC *resource.TestContext, _ map[string]k8s.Object) {
+			var id string
+			k8sDeployment := &appsv1.Deployment{}
+			deleteDep, err := testC.ApplyResource(context.Background(), resource.DefaultNamespace, &NginxDeployment, k8sDeployment, nil)
+			require.NoError(t, err)
+			id = string(k8sDeployment.GetUID())
+			// Check the deployment is processed
+			testC.WaitForDeploymentEvent("nginx-deployment")
+			testC.GetFakeCentral().ClearReceivedBuffer()
 
-		// Delete the deployment
-		require.NoError(t, deleteDep())
+			// Delete the deployment
+			require.NoError(t, deleteDep())
 
-		// Check deployment and action
-		testC.LastDeploymentStateWithTimeout("nginx-deployment", func(_ *storage.Deployment, action central.ResourceAction) error {
-			if action != central.ResourceAction_REMOVE_RESOURCE {
-				return errors.New("ResourceAction should be REMOVE_RESOURCE")
-			}
-			return nil
-		}, "deployment should be deleted", 5*time.Minute)
-		testC.LastViolationStateByID(id, func(alertResults *central.AlertResults) error {
-			if alertResults.GetAlerts() != nil {
-				return errors.New("AlertResults should be empty")
-			}
-			return nil
-		}, "Should have an empty violation", true)
-		testC.GetFakeCentral().ClearReceivedBuffer()
-	})
+			// Check deployment and action
+			testC.LastDeploymentStateWithTimeout("nginx-deployment", func(_ *storage.Deployment, action central.ResourceAction) error {
+				if action != central.ResourceAction_REMOVE_RESOURCE {
+					return errors.New("ResourceAction should be REMOVE_RESOURCE")
+				}
+				return nil
+			}, "deployment should be deleted", 5*time.Minute)
+			testC.LastViolationStateByIDWithTimeout(id, func(alertResults *central.AlertResults) error {
+				if alertResults.GetAlerts() != nil {
+					return errors.New("AlertResults should be empty")
+				}
+				return nil
+			}, "Should have an empty violation", true, 5*time.Minute)
+			testC.GetFakeCentral().ClearReceivedBuffer()
+		}),
+	)
 }
 
 func (s *PodHierarchySuite) Test_DeletePod() {
-	s.testContext.RunBare("Removing a rogue pod should send empty violation", func(t *testing.T, testC *resource.TestContext, _ map[string]k8s.Object) {
-		var id string
-		k8sPod := &v1.Pod{}
-		deletePod, err := testC.ApplyFile(context.Background(), resource.DefaultNamespace, NginxPod, k8sPod)
-		require.NoError(t, err)
-		id = string(k8sPod.GetUID())
-		// Check the pod is processed
-		testC.WaitForDeploymentEvent("nginx-rogue")
-		testC.GetFakeCentral().ClearReceivedBuffer()
+	s.testContext.NewRun(
+		resource.WithName("Removing a rogue pod should send empty violation"),
+		resource.WithTestCase(func(t *testing.T, testC *resource.TestContext, _ map[string]k8s.Object) {
+			var id string
+			k8sPod := &v1.Pod{}
+			deletePod, err := testC.ApplyResource(context.Background(), resource.DefaultNamespace, &NginxPod, k8sPod, nil)
+			require.NoError(t, err)
+			id = string(k8sPod.GetUID())
+			// Check the pod is processed
+			testC.WaitForDeploymentEvent("nginx-rogue")
+			testC.GetFakeCentral().ClearReceivedBuffer()
 
-		// Delete the pod
-		require.NoError(t, deletePod())
+			// Delete the pod
+			require.NoError(t, deletePod())
 
-		// Check pod and action
-		testC.LastDeploymentStateWithTimeout("nginx-rogue", func(_ *storage.Deployment, action central.ResourceAction) error {
-			if action != central.ResourceAction_REMOVE_RESOURCE {
-				return errors.New("ResourceAction should be REMOVE_RESOURCE")
-			}
-			return nil
-		}, "rogue pod should be deleted", 5*time.Minute)
-		testC.LastViolationStateByID(id, func(alertResults *central.AlertResults) error {
-			if alertResults.GetAlerts() != nil {
-				return errors.New("AlertResults should be empty")
-			}
-			return nil
-		}, "Should have an empty violation", true)
-		testC.GetFakeCentral().ClearReceivedBuffer()
-	})
+			// Check pod and action
+			testC.LastDeploymentStateWithTimeout("nginx-rogue", func(_ *storage.Deployment, action central.ResourceAction) error {
+				if action != central.ResourceAction_REMOVE_RESOURCE {
+					return errors.New("ResourceAction should be REMOVE_RESOURCE")
+				}
+				return nil
+			}, "rogue pod should be deleted", 5*time.Minute)
+			testC.LastViolationStateByIDWithTimeout(id, func(alertResults *central.AlertResults) error {
+				if alertResults.GetAlerts() != nil {
+					return errors.New("AlertResults should be empty")
+				}
+				return nil
+			}, "Should have an empty violation", true, 5*time.Minute)
+			testC.GetFakeCentral().ClearReceivedBuffer()
+		}),
+	)
 }

--- a/sensor/tests/resource/pod/pod_test.go
+++ b/sensor/tests/resource/pod/pod_test.go
@@ -77,7 +77,7 @@ func assertDeploymentContainerImages(images ...string) resource.AssertFunc {
 }
 
 func (s *PodHierarchySuite) Test_ContainerSpecOnDeployment() {
-	s.testContext.NewRun(
+	s.testContext.RunTest(
 		resource.WithResources([]resource.K8sResourceInfo{
 			NginxDeployment,
 		}),
@@ -102,7 +102,7 @@ func (s *PodHierarchySuite) Test_ContainerSpecOnDeployment() {
 }
 
 func (s *PodHierarchySuite) Test_ParentlessPodsAreTreatedAsDeployments() {
-	s.testContext.NewRun(
+	s.testContext.RunTest(
 		resource.WithResources([]resource.K8sResourceInfo{
 			NginxDeployment,
 			NginxPod,
@@ -135,7 +135,7 @@ func (s *PodHierarchySuite) Test_ParentlessPodsAreTreatedAsDeployments() {
 }
 
 func (s *PodHierarchySuite) Test_DeleteDeployment() {
-	s.testContext.NewRun(
+	s.testContext.RunTest(
 		resource.WithTestCase(func(t *testing.T, testC *resource.TestContext, _ map[string]k8s.Object) {
 			var id string
 			k8sDeployment := &appsv1.Deployment{}
@@ -168,7 +168,7 @@ func (s *PodHierarchySuite) Test_DeleteDeployment() {
 }
 
 func (s *PodHierarchySuite) Test_DeletePod() {
-	s.testContext.NewRun(
+	s.testContext.RunTest(
 		resource.WithTestCase(func(t *testing.T, testC *resource.TestContext, _ map[string]k8s.Object) {
 			var id string
 			k8sPod := &v1.Pod{}

--- a/sensor/tests/resource/pod/pod_test.go
+++ b/sensor/tests/resource/pod/pod_test.go
@@ -136,7 +136,6 @@ func (s *PodHierarchySuite) Test_ParentlessPodsAreTreatedAsDeployments() {
 
 func (s *PodHierarchySuite) Test_DeleteDeployment() {
 	s.testContext.NewRun(
-		resource.WithName("Removing a deployment should send empty violation"),
 		resource.WithTestCase(func(t *testing.T, testC *resource.TestContext, _ map[string]k8s.Object) {
 			var id string
 			k8sDeployment := &appsv1.Deployment{}
@@ -170,7 +169,6 @@ func (s *PodHierarchySuite) Test_DeleteDeployment() {
 
 func (s *PodHierarchySuite) Test_DeletePod() {
 	s.testContext.NewRun(
-		resource.WithName("Removing a rogue pod should send empty violation"),
 		resource.WithTestCase(func(t *testing.T, testC *resource.TestContext, _ map[string]k8s.Object) {
 			var id string
 			k8sPod := &v1.Pod{}

--- a/sensor/tests/resource/role/role_test.go
+++ b/sensor/tests/resource/role/role_test.go
@@ -100,7 +100,6 @@ func matchBinding(namespace, id string) resource.MatchResource {
 
 func (s *RoleDependencySuite) Test_BindingHasNoRoleId() {
 	s.testContext.NewRun(
-		resource.WithName("Binding should get an update if role gets created after"),
 		resource.WithTestCase(func(t *testing.T, testC *resource.TestContext, _ map[string]k8s.Object) {
 			deleteDep, err := testC.ApplyResourceNoObject(context.Background(), "sensor-integration", NginxDeployment, nil)
 			defer utils.IgnoreError(deleteDep)
@@ -163,7 +162,6 @@ func (s *RoleDependencySuite) Test_PermissionLevelIsNone() {
 
 func (s *RoleDependencySuite) Test_MultipleDeploymentUpdates() {
 	s.testContext.NewRun(
-		resource.WithName("Update permission level"),
 		resource.WithTestCase(func(t *testing.T, testC *resource.TestContext, _ map[string]k8s.Object) {
 			deleteDep, err := testC.ApplyResourceNoObject(context.Background(), "sensor-integration", NginxDeployment, nil)
 			defer utils.IgnoreError(deleteDep)

--- a/sensor/tests/resource/role/role_test.go
+++ b/sensor/tests/resource/role/role_test.go
@@ -73,7 +73,7 @@ func assertBindingHasRoleID(roleID string) resource.AssertFuncAny {
 
 func (s *RoleDependencySuite) Test_PermutationTest() {
 	s.testContext.GetFakeCentral().ClearReceivedBuffer()
-	s.testContext.NewRun(
+	s.testContext.RunTest(
 		resource.WithResources([]resource.K8sResourceInfo{
 			NginxDeployment,
 			NginxRole,
@@ -99,7 +99,7 @@ func matchBinding(namespace, id string) resource.MatchResource {
 }
 
 func (s *RoleDependencySuite) Test_BindingHasNoRoleId() {
-	s.testContext.NewRun(
+	s.testContext.RunTest(
 		resource.WithTestCase(func(t *testing.T, testC *resource.TestContext, _ map[string]k8s.Object) {
 			deleteDep, err := testC.ApplyResourceNoObject(context.Background(), "sensor-integration", NginxDeployment, nil)
 			defer utils.IgnoreError(deleteDep)
@@ -125,7 +125,7 @@ func (s *RoleDependencySuite) Test_BindingHasNoRoleId() {
 }
 
 func (s *RoleDependencySuite) Test_GroupSubjects() {
-	s.testContext.NewRun(
+	s.testContext.RunTest(
 		resource.WithResources([]resource.K8sResourceInfo{
 			NginxDeployment,
 			NginxRole,
@@ -146,7 +146,7 @@ func (s *RoleDependencySuite) Test_GroupSubjects() {
 }
 
 func (s *RoleDependencySuite) Test_PermissionLevelIsNone() {
-	s.testContext.NewRun(
+	s.testContext.RunTest(
 		resource.WithResources([]resource.K8sResourceInfo{
 			NginxDeployment,
 			NginxRole,
@@ -161,7 +161,7 @@ func (s *RoleDependencySuite) Test_PermissionLevelIsNone() {
 }
 
 func (s *RoleDependencySuite) Test_MultipleDeploymentUpdates() {
-	s.testContext.NewRun(
+	s.testContext.RunTest(
 		resource.WithTestCase(func(t *testing.T, testC *resource.TestContext, _ map[string]k8s.Object) {
 			deleteDep, err := testC.ApplyResourceNoObject(context.Background(), "sensor-integration", NginxDeployment, nil)
 			defer utils.IgnoreError(deleteDep)

--- a/sensor/tests/resource/role/role_test.go
+++ b/sensor/tests/resource/role/role_test.go
@@ -16,10 +16,10 @@ import (
 )
 
 var (
-	NginxDeployment       = resource.YamlTestFile{Kind: "Deployment", File: "nginx.yaml"}
-	NginxRole             = resource.YamlTestFile{Kind: "Role", File: "nginx-role.yaml"}
-	NginxRoleBinding      = resource.YamlTestFile{Kind: "Binding", File: "nginx-binding.yaml"}
-	NginxRoleGroupBinding = resource.YamlTestFile{Kind: "Binding", File: "nginx-binding-group.yaml"}
+	NginxDeployment       = resource.K8sResourceInfo{Kind: "Deployment", YamlFile: "nginx.yaml"}
+	NginxRole             = resource.K8sResourceInfo{Kind: "Role", YamlFile: "nginx-role.yaml"}
+	NginxRoleBinding      = resource.K8sResourceInfo{Kind: "Binding", YamlFile: "nginx-binding.yaml"}
+	NginxRoleGroupBinding = resource.K8sResourceInfo{Kind: "Binding", YamlFile: "nginx-binding-group.yaml"}
 )
 
 type RoleDependencySuite struct {
@@ -73,17 +73,19 @@ func assertBindingHasRoleID(roleID string) resource.AssertFuncAny {
 
 func (s *RoleDependencySuite) Test_PermutationTest() {
 	s.testContext.GetFakeCentral().ClearReceivedBuffer()
-	s.testContext.RunWithResourcesPermutation(
-		[]resource.YamlTestFile{
+	s.testContext.NewRun(
+		resource.WithResources([]resource.K8sResourceInfo{
 			NginxDeployment,
 			NginxRole,
 			NginxRoleBinding,
-		}, "RoleDependency", func(t *testing.T, testC *resource.TestContext, objects map[string]k8s.Object) {
+		}),
+		resource.WithPermutation(),
+		resource.WithTestCase(func(t *testing.T, testC *resource.TestContext, objects map[string]k8s.Object) {
 			testC.LastDeploymentState("nginx-deployment",
 				assertPermissionLevel(storage.PermissionLevel_ELEVATED_IN_NAMESPACE),
 				"Permission level has to be elevated in namespace")
 			testC.GetFakeCentral().ClearReceivedBuffer()
-		},
+		}),
 	)
 }
 
@@ -97,37 +99,40 @@ func matchBinding(namespace, id string) resource.MatchResource {
 }
 
 func (s *RoleDependencySuite) Test_BindingHasNoRoleId() {
-	s.testContext.RunBare("Binding should get an update if role gets created after", func(t *testing.T, testC *resource.TestContext, _ map[string]k8s.Object) {
-		deleteDep, err := testC.ApplyFileNoObject(context.Background(), "sensor-integration", NginxDeployment)
-		defer utils.IgnoreError(deleteDep)
-		require.NoError(t, err)
+	s.testContext.NewRun(
+		resource.WithName("Binding should get an update if role gets created after"),
+		resource.WithTestCase(func(t *testing.T, testC *resource.TestContext, _ map[string]k8s.Object) {
+			deleteDep, err := testC.ApplyResourceNoObject(context.Background(), "sensor-integration", NginxDeployment, nil)
+			defer utils.IgnoreError(deleteDep)
+			require.NoError(t, err)
 
-		var binding v12.RoleBinding
-		deleteRoleBinding, err := testC.ApplyFile(context.Background(), "sensor-integration", NginxRoleBinding, &binding)
-		defer utils.IgnoreError(deleteRoleBinding)
-		require.NoError(t, err)
+			var binding v12.RoleBinding
+			deleteRoleBinding, err := testC.ApplyResource(context.Background(), "sensor-integration", &NginxRoleBinding, &binding, nil)
+			defer utils.IgnoreError(deleteRoleBinding)
+			require.NoError(t, err)
 
-		testC.LastResourceState(matchBinding(binding.GetNamespace(), string(binding.GetUID())), assertBindingHasRoleID(""), "No RoleID")
+			testC.LastResourceState(matchBinding(binding.GetNamespace(), string(binding.GetUID())), assertBindingHasRoleID(""), "No RoleID")
 
-		var role v12.Role
-		deleteRole, err := testC.ApplyFile(context.Background(), "sensor-integration", NginxRole, &role)
-		defer utils.IgnoreError(deleteRole)
-		require.NoError(t, err)
+			var role v12.Role
+			deleteRole, err := testC.ApplyResource(context.Background(), "sensor-integration", &NginxRole, &role, nil)
+			defer utils.IgnoreError(deleteRole)
+			require.NoError(t, err)
 
-		testC.LastResourceState(matchBinding(binding.GetNamespace(), string(binding.GetUID())), assertBindingHasRoleID(string(role.GetUID())), "Has RoleID")
+			testC.LastResourceState(matchBinding(binding.GetNamespace(), string(binding.GetUID())), assertBindingHasRoleID(string(role.GetUID())), "Has RoleID")
 
-		testC.GetFakeCentral().ClearReceivedBuffer()
-	})
+			testC.GetFakeCentral().ClearReceivedBuffer()
+		}),
+	)
 }
 
 func (s *RoleDependencySuite) Test_GroupSubjects() {
-	s.testContext.RunWithResources(
-		[]resource.YamlTestFile{
+	s.testContext.NewRun(
+		resource.WithResources([]resource.K8sResourceInfo{
 			NginxDeployment,
 			NginxRole,
 			NginxRoleGroupBinding,
-		},
-		func(t *testing.T, testC *resource.TestContext, _ map[string]k8s.Object) {
+		}),
+		resource.WithTestCase(func(t *testing.T, testC *resource.TestContext, _ map[string]k8s.Object) {
 			// This test expects that a reference to a non-ServiceAccount subject (i.e. Group or User) does not
 			// reference any deployments and thus a deployment object should not be updated. However, Groups can be
 			// used to reference a set of ServiceAccounts, see: https://kubernetes.io/docs/reference/access-authn-authz/rbac/#role-binding-examples
@@ -137,49 +142,54 @@ func (s *RoleDependencySuite) Test_GroupSubjects() {
 				assertPermissionLevel(storage.PermissionLevel_NONE),
 				"Group / User permission levels should be ignored")
 			testC.GetFakeCentral().ClearReceivedBuffer()
-		},
+		}),
 	)
 }
 
 func (s *RoleDependencySuite) Test_PermissionLevelIsNone() {
-	s.testContext.RunWithResources(
-		[]resource.YamlTestFile{
+	s.testContext.NewRun(
+		resource.WithResources([]resource.K8sResourceInfo{
 			NginxDeployment,
 			NginxRole,
-		}, func(t *testing.T, testC *resource.TestContext, _ map[string]k8s.Object) {
+		}),
+		resource.WithTestCase(func(t *testing.T, testC *resource.TestContext, _ map[string]k8s.Object) {
 			testC.LastDeploymentState("nginx-deployment",
 				assertPermissionLevel(storage.PermissionLevel_NONE),
 				"Permission level has to be none if role binding is missing")
 			testC.GetFakeCentral().ClearReceivedBuffer()
-		})
+		}),
+	)
 }
 
 func (s *RoleDependencySuite) Test_MultipleDeploymentUpdates() {
-	s.testContext.RunBare("Update permission level", func(t *testing.T, testC *resource.TestContext, _ map[string]k8s.Object) {
-		deleteDep, err := testC.ApplyFileNoObject(context.Background(), "sensor-integration", NginxDeployment)
-		defer utils.IgnoreError(deleteDep)
-		require.NoError(t, err)
+	s.testContext.NewRun(
+		resource.WithName("Update permission level"),
+		resource.WithTestCase(func(t *testing.T, testC *resource.TestContext, _ map[string]k8s.Object) {
+			deleteDep, err := testC.ApplyResourceNoObject(context.Background(), "sensor-integration", NginxDeployment, nil)
+			defer utils.IgnoreError(deleteDep)
+			require.NoError(t, err)
 
-		deleteRoleBinding, err := testC.ApplyFileNoObject(context.Background(), "sensor-integration", NginxRoleBinding)
-		defer utils.IgnoreError(deleteRoleBinding)
-		require.NoError(t, err)
+			deleteRoleBinding, err := testC.ApplyResourceNoObject(context.Background(), "sensor-integration", NginxRoleBinding, nil)
+			defer utils.IgnoreError(deleteRoleBinding)
+			require.NoError(t, err)
 
-		deleteRole, err := testC.ApplyFileNoObject(context.Background(), "sensor-integration", NginxRole)
+			deleteRole, err := testC.ApplyResourceNoObject(context.Background(), "sensor-integration", NginxRole, nil)
 
-		defer utils.IgnoreError(deleteRole)
-		require.NoError(t, err)
+			defer utils.IgnoreError(deleteRole)
+			require.NoError(t, err)
 
-		testC.LastDeploymentState("nginx-deployment",
-			assertPermissionLevel(storage.PermissionLevel_ELEVATED_IN_NAMESPACE),
-			"Permission level has to be elevated in namespace")
-		testC.GetFakeCentral().ClearReceivedBuffer()
+			testC.LastDeploymentState("nginx-deployment",
+				assertPermissionLevel(storage.PermissionLevel_ELEVATED_IN_NAMESPACE),
+				"Permission level has to be elevated in namespace")
+			testC.GetFakeCentral().ClearReceivedBuffer()
 
-		utils.IgnoreError(deleteRole)
-		utils.IgnoreError(deleteRoleBinding)
+			utils.IgnoreError(deleteRole)
+			utils.IgnoreError(deleteRoleBinding)
 
-		testC.LastDeploymentState("nginx-deployment",
-			assertPermissionLevel(storage.PermissionLevel_NONE),
-			"Permission level has to be none after deleting role and binding")
-		testC.GetFakeCentral().ClearReceivedBuffer()
-	})
+			testC.LastDeploymentState("nginx-deployment",
+				assertPermissionLevel(storage.PermissionLevel_NONE),
+				"Permission level has to be none after deleting role and binding")
+			testC.GetFakeCentral().ClearReceivedBuffer()
+		}),
+	)
 }

--- a/sensor/tests/resource/service/service_test.go
+++ b/sensor/tests/resource/service/service_test.go
@@ -146,7 +146,7 @@ func (s *DeploymentExposureSuite) SetupSuite() {
 }
 
 func (s *DeploymentExposureSuite) Test_ClusterIpPermutation() {
-	s.testContext.NewRun(
+	s.testContext.RunTest(
 		resource.WithResources([]resource.K8sResourceInfo{
 			NginxDeployment,
 			NginxServiceClusterIP,
@@ -217,7 +217,7 @@ func (s *DeploymentExposureSuite) Test_NodePortPermutation() {
 		},
 	}
 	for _, c := range cases {
-		s.testContext.NewRun(
+		s.testContext.RunTest(
 			resource.WithResources(c.orderedResources),
 			resource.WithTestCase(func(t *testing.T, testC *resource.TestContext, _ map[string]k8s.Object) {
 				// Test context already takes care of creating and destroying resources
@@ -286,7 +286,7 @@ func (s *DeploymentExposureSuite) Test_LoadBalancerPermutation() {
 		},
 	}
 	for _, c := range cases {
-		s.testContext.NewRun(
+		s.testContext.RunTest(
 			resource.WithResources(c.orderedResources),
 			resource.WithTestCase(func(t *testing.T, testC *resource.TestContext, _ map[string]k8s.Object) {
 				// Test context already takes care of creating and destroying resources
@@ -326,7 +326,7 @@ func (s *DeploymentExposureSuite) Test_LoadBalancerPermutation() {
 }
 
 func (s *DeploymentExposureSuite) Test_NoExposure() {
-	s.testContext.NewRun(
+	s.testContext.RunTest(
 		resource.WithResources([]resource.K8sResourceInfo{
 			NginxDeployment,
 		}),
@@ -362,7 +362,7 @@ func (s *DeploymentExposureSuite) Test_MultipleDeploymentUpdates() {
 	// We need to use different ports in each NodePort/LoadBalancer test otherwise k8s could throw an error when the service is being created (provided port is already allocated).
 	// Waiting for the resources to get Deleted is not enough, k8s reports that the resource has been deleted but on creation sometimes we still get the same error.
 	// Adding retries on creation helped a lot, but it's still not enough.
-	s.testContext.NewRun(
+	s.testContext.RunTest(
 		resource.WithTestCase(func(t *testing.T, testC *resource.TestContext, _ map[string]k8s.Object) {
 			deleteDep, err := testC.ApplyResourceNoObject(context.Background(), resource.DefaultNamespace, NginxDeployment, nil)
 			defer utils.IgnoreError(deleteDep)
@@ -475,7 +475,7 @@ func (s *DeploymentExposureSuite) Test_NodePortPermutationWithPod() {
 		},
 	}
 	for _, c := range cases {
-		s.testContext.NewRun(
+		s.testContext.RunTest(
 			resource.WithResources(c.orderedResources),
 			resource.WithTestCase(func(t *testing.T, testC *resource.TestContext, _ map[string]k8s.Object) {
 				// Test context already takes care of creating and destroying resources

--- a/sensor/tests/resource/service/service_test.go
+++ b/sensor/tests/resource/service/service_test.go
@@ -363,7 +363,6 @@ func (s *DeploymentExposureSuite) Test_MultipleDeploymentUpdates() {
 	// Waiting for the resources to get Deleted is not enough, k8s reports that the resource has been deleted but on creation sometimes we still get the same error.
 	// Adding retries on creation helped a lot, but it's still not enough.
 	s.testContext.NewRun(
-		resource.WithName("Update Port Exposure"),
 		resource.WithTestCase(func(t *testing.T, testC *resource.TestContext, _ map[string]k8s.Object) {
 			deleteDep, err := testC.ApplyResourceNoObject(context.Background(), resource.DefaultNamespace, NginxDeployment, nil)
 			defer utils.IgnoreError(deleteDep)


### PR DESCRIPTION
## Description

Refactor the helper functions used in the `sensor-integration-test`

* Enables the helper functions to create resources based on structs.
* Adds the `testRun` struct to hold all the information regarding a test run.
* Adds a `RetryCallback` that will be called (if set) when the creation of a resource fails.

**Note to the reviewers**: Consider reviewing the PR commit by commit.


## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

* CI
* `make sensor-integration-test`
