### PR TITLE
CI: Fix openshift e2e

### DIFF
--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -306,6 +306,12 @@ function launch_central {
         )
       fi
 
+      if [[ "$ROX_POSTGRES_DATASTORE" == "true" ]]; then
+        helm_args+=(
+          --set central.db.enabled=true
+        )
+      fi
+
       if [[ -n "$CI" ]]; then
         helm lint "$unzip_dir/chart"
         helm lint "$unzip_dir/chart" -n stackrox

--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -306,12 +306,6 @@ function launch_central {
         )
       fi
 
-      if [[ "$ROX_POSTGRES_DATASTORE" == "true" ]]; then
-        helm_args+=(
-          --set central.db.enabled=true
-        )
-      fi
-
       if [[ -n "$CI" ]]; then
         helm lint "$unzip_dir/chart"
         helm lint "$unzip_dir/chart" -n stackrox

--- a/operator/tests/e2e/central-cr.envsubst.yaml
+++ b/operator/tests/e2e/central-cr.envsubst.yaml
@@ -7,8 +7,6 @@ spec:
   central:
     adminPasswordSecret:
       name: central-admin-pass
-    db:
-      isEnabled: $central_db_isEnabled
     defaultTLSSecret:
       name: central-default-tls-secret
     exposure:

--- a/qa-tests-backend/src/test/groovy/K8sRbacTest.groovy
+++ b/qa-tests-backend/src/test/groovy/K8sRbacTest.groovy
@@ -11,9 +11,12 @@ import objects.K8sRole
 import objects.K8sRoleBinding
 import objects.K8sServiceAccount
 import objects.K8sSubject
+import orchestratormanager.OrchestratorTypes
 import services.RbacService
 import services.ServiceAccountService
+import util.Env
 
+import spock.lang.IgnoreIf
 import spock.lang.Stepwise
 import spock.lang.Tag
 
@@ -51,6 +54,8 @@ class K8sRbacTest extends BaseSpecification {
 
     @Tag("BAT")
     @Tag("COMPATIBILITY")
+    // TODO(ROX-14666): This test times out under openshift
+    @IgnoreIf({ Env.mustGetOrchestratorType() == OrchestratorTypes.OPENSHIFT })
     def "Verify scraped service accounts"() {
         given:
         List<K8sServiceAccount> orchestratorSAs = null

--- a/scripts/ci/jobs/openshift_oldest_qa_e2e_tests.py
+++ b/scripts/ci/jobs/openshift_oldest_qa_e2e_tests.py
@@ -5,13 +5,16 @@ Run qa-tests-backend in a openshift 4 cluster provided via a hive cluster_claim.
 """
 import os
 from base_qa_e2e_test import make_qa_e2e_test_runner
-from clusters import NullCluster
+from clusters import OpenShiftScaleWorkersCluster
 
 # set required test parameters
 os.environ["DEPLOY_STACKROX_VIA_OPERATOR"] = "false"
 os.environ["OPENSHIFT_CI_CLUSTER_CLAIM"] = "openshift-4"
 os.environ["ORCHESTRATOR_FLAVOR"] = "openshift"
 os.environ["OUTPUT_FORMAT"] = "helm"
-os.environ["ROX_POSTGRES_DATASTORE"] = "false"
+os.environ["ROX_POSTGRES_DATASTORE"] = "true"
 
-make_qa_e2e_test_runner(cluster=NullCluster()).run()
+# Scale up the cluster to support postgres
+cluster = OpenShiftScaleWorkersCluster(increment=1)
+
+make_qa_e2e_test_runner(cluster=cluster).run()

--- a/scripts/ci/jobs/openshift_oldest_qa_e2e_tests.py
+++ b/scripts/ci/jobs/openshift_oldest_qa_e2e_tests.py
@@ -12,7 +12,7 @@ os.environ["DEPLOY_STACKROX_VIA_OPERATOR"] = "false"
 os.environ["OPENSHIFT_CI_CLUSTER_CLAIM"] = "openshift-4"
 os.environ["ORCHESTRATOR_FLAVOR"] = "openshift"
 os.environ["OUTPUT_FORMAT"] = "helm"
-os.environ["ROX_POSTGRES_DATASTORE"] = "true"
+os.environ["ROX_POSTGRES_DATASTORE"] = "false"
 
 # Scale up the cluster to support postgres
 cluster = OpenShiftScaleWorkersCluster(increment=1)

--- a/scripts/ci/jobs/openshift_penultimate_qa_e2e_tests.py
+++ b/scripts/ci/jobs/openshift_penultimate_qa_e2e_tests.py
@@ -11,7 +11,7 @@ from clusters import OpenShiftScaleWorkersCluster
 os.environ["DEPLOY_STACKROX_VIA_OPERATOR"] = "true"
 os.environ["OPENSHIFT_CI_CLUSTER_CLAIM"] = "openshift-4"
 os.environ["ORCHESTRATOR_FLAVOR"] = "openshift"
-os.environ["ROX_POSTGRES_DATASTORE"] = "true"
+os.environ["ROX_POSTGRES_DATASTORE"] = "false"
 
 # Scale up the cluster to support postgres
 cluster = OpenShiftScaleWorkersCluster(increment=1)

--- a/scripts/ci/jobs/openshift_penultimate_qa_e2e_tests.py
+++ b/scripts/ci/jobs/openshift_penultimate_qa_e2e_tests.py
@@ -5,12 +5,15 @@ Run qa-tests-backend in a openshift 4 cluster provided via a hive cluster_claim.
 """
 import os
 from base_qa_e2e_test import make_qa_e2e_test_runner
-from clusters import NullCluster
+from clusters import OpenShiftScaleWorkersCluster
 
 # set required test parameters
 os.environ["DEPLOY_STACKROX_VIA_OPERATOR"] = "true"
 os.environ["OPENSHIFT_CI_CLUSTER_CLAIM"] = "openshift-4"
 os.environ["ORCHESTRATOR_FLAVOR"] = "openshift"
-os.environ["ROX_POSTGRES_DATASTORE"] = "false"
+os.environ["ROX_POSTGRES_DATASTORE"] = "true"
 
-make_qa_e2e_test_runner(cluster=NullCluster()).run()
+# Scale up the cluster to support postgres
+cluster = OpenShiftScaleWorkersCluster(increment=1)
+
+make_qa_e2e_test_runner(cluster=cluster).run()

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -146,11 +146,6 @@ deploy_central_via_operator() {
     centralDefaultTlsSecretKeyBase64="$(base64 -w0 < "${ROX_DEFAULT_TLS_KEY_FILE}")"
     centralDefaultTlsSecretCertBase64="$(base64 -w0 < "${ROX_DEFAULT_TLS_CERT_FILE}")"
 
-    case "${ROX_POSTGRES_DATASTORE}" in
-    "true") central_db_isEnabled="Enabled" ;;
-    *) central_db_isEnabled="Default" ;;
-    esac
-
     central_exposure_loadBalancer_enabled="false"
     central_exposure_route_enabled="false"
     case "${LOAD_BALANCER}" in
@@ -178,7 +173,6 @@ deploy_central_via_operator() {
       centralAdminPasswordBase64="$centralAdminPasswordBase64" \
       centralDefaultTlsSecretKeyBase64="$centralDefaultTlsSecretKeyBase64" \
       centralDefaultTlsSecretCertBase64="$centralDefaultTlsSecretCertBase64" \
-      central_db_isEnabled="$central_db_isEnabled" \
       central_exposure_loadBalancer_enabled="$central_exposure_loadBalancer_enabled" \
       central_exposure_route_enabled="$central_exposure_route_enabled" \
       customize_envVars="$customize_envVars" \


### PR DESCRIPTION
## Description

This PR:
- Skips K8sRbacTest under openshift where it is flaky (ROX-14666).
- Increases the node count for openshift e2e clusters by 1.
  - This is required for the `openshift-penultimate-qa-e2e-tests` test because the operator now installs `central-db` by default.
- Removes the operator `central.db.isEnabled` setting as that is now obsolete.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient - with 3 openshift e2e flavors.