### PR TITLE
Reduce the number of confusing instances of `stackrox.io` in charts

### DIFF
--- a/image/templates/README.md
+++ b/image/templates/README.md
@@ -3,7 +3,7 @@
 The currently maintained helm charts consists of the `stackrox-central-services`
 and `stackrox-secured-cluster-services` charts.
 
-Helm charts are distributed by `https://charts.stackrox.io` and [stackrox/helm-charts](https://github.com/stackrox/helm-charts).
+Helm charts are distributed by `https://mirror.openshift.com/pub/rhacs/charts/`, `https://charts.stackrox.io` and [stackrox/helm-charts](https://github.com/stackrox/helm-charts).
 The [stackrox/release-artifacts](https://github.com/stackrox/release-artifacts) repository takes care of the publishing automation.
 
 ## StackRox central services

--- a/image/templates/helm/stackrox-central/values-public.yaml.example.htpl
+++ b/image/templates/helm/stackrox-central/values-public.yaml.example.htpl
@@ -11,9 +11,8 @@
 # The most notable exception is the `imagePullSecrets` section, which needs to be configured
 # according to the registry access in your environment.
 #
-# Other than that, the following are sections that are the most likely to require custom
-# configuration:
-# - `image.registry`: if you are pulling images from a registry other than `stackrox.io`.
+# Other than that, the following are sections most likely require custom configuration:
+# - `image.registry`: if you are pulling images from a registry other than `[< required "" .MainRegistry >]`.
 # - `env.offlineMode`: if you want to run StackRox in offline mode.
 # - `central.endpointsConfig`: if you want to expose additional endpoints (such as endpoints
 #   without TLS) in Central.
@@ -44,12 +43,12 @@
 #   useFromDefaultServiceAccount: true
 #
 # image:
-#   # The registry relative to which all image references are resolved, if no more
-#   # specify registry is specified for the workloads (see `central.image`, `db.image`, ``scanner.image`,
-#   # and `scanner.dbImage` below).
+#   # The registry relative to which all image references are resolved, unless
+#   # a specific registry is provided for particular workloads which takes precedence
+#   # (see `central.image`, `db.image`, `scanner.image`, and `scanner.dbImage` below).
 #   # This can be just a registry hostname such as `stackrox.io`, or a registry hostname with
 #   # a "remote" component such as `us.gcr.io/my-stackrox-mirror`.
-#   registry: stackrox.io
+#   registry: us.gcr.io/my-stackrox-mirror
 #
 # env:
 #   # Treat the environment as an OpenShift cluster. Leave this unset to use auto-detection

--- a/image/templates/helm/stackrox-central/values.yaml.htpl
+++ b/image/templates/helm/stackrox-central/values.yaml.htpl
@@ -58,7 +58,7 @@
 #image:
 #  # The image registry to use. Unless overridden in the more specific configs, this
 #  # determines the base registry for each image referenced in this config file.
-#  registry: stackrox.io
+#  registry: [< required "" .MainRegistry >]
 #
 ## Settings regarding the installation environment
 #env:

--- a/image/templates/helm/stackrox-secured-cluster/internal/defaults/50-images.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/internal/defaults/50-images.yaml.htpl
@@ -24,7 +24,7 @@ image:
   main:
     registry: {{ ._rox.image.registry }}
   collector:
-    registry: {{ if or (eq ._rox.image.registry "stackrox.io") (eq ._rox.image.registry "registry.connect.redhat.com") }}collector.stackrox.io{{ else }}{{ ._rox.image.registry }}{{ end }}
+    registry: {{ ._rox.image.registry }}
   [< if (not .KubectlOutput) >]
   scanner:
     registry: {{ ._rox.image.registry }}

--- a/image/templates/helm/stackrox-secured-cluster/internal/defaults/50-images.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/internal/defaults/50-images.yaml.htpl
@@ -24,7 +24,7 @@ image:
   main:
     registry: {{ ._rox.image.registry }}
   collector:
-    registry: {{ ._rox.image.registry }}
+    registry: {{ if or (eq ._rox.image.registry "stackrox.io") (eq ._rox.image.registry "registry.connect.redhat.com") }}collector.stackrox.io{{ else }}{{ ._rox.image.registry }}{{ end }}
   [< if (not .KubectlOutput) >]
   scanner:
     registry: {{ ._rox.image.registry }}


### PR DESCRIPTION
## Description

@BradLugo got confused seeing `registry: stackrox.io` in the generated Helm values.
While that confusion is fair, Helm values files are meant to be examples illustrating usage rather than the set of currently selected values. I myself would prefer helm value files to give **actual** defaults, but this can easily make this change XL-sized.
Instead, I simply get rid of `stackrox.io` mentions where they may be confusing.

Context thread
https://srox.slack.com/archives/CELUQKESC/p1675462004575229?thread_ts=1675459102.811779&cid=CELUQKESC

## Checklist
- [ ] Investigated and inspected CI test results

None of these needed:
- [ ] Unit test and regression tests added - the change does not deserve ones since values files are examples and not executables.
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

* Manually:
```bash
$ make cli
$ rm -rf stackrox-central-services-chart
$ rm -rf stackrox-secured-cluster-services-chart
$ roxctl helm output central-services --image-defaults=rhacs

$ grep -F '#image:' -B1 -A4 stackrox-central-services-chart/values.yaml
## Common settings for all image properties
#image:
#  # The image registry to use. Unless overridden in the more specific configs, this
#  # determines the base registry for each image referenced in this config file.
#  registry: registry.redhat.io/advanced-cluster-security
#

$ grep -F '# image:' -A7 stackrox-central-services-chart/values-public.yaml.example
# image:
#   # The registry relative to which all image references are resolved, unless
#   # a specific registry is provided for particular workloads which takes precedence
#   # (see `central.image`, `db.image`, `scanner.image`, and `scanner.dbImage` below).
#   # This can be just a registry hostname such as `stackrox.io`, or a registry hostname with
#   # a "remote" component such as `us.gcr.io/my-stackrox-mirror`.
#   registry: us.gcr.io/my-stackrox-mirror
#

$ grep -F '`image.registry`:' stackrox-central-services-chart/values-public.yaml.example
# - `image.registry`: if you are pulling images from a registry other than `registry.redhat.io/advanced-cluster-security`.

$ roxctl helm output secured-cluster-services --image-defaults=rhacs
$ grep -F '# Add registry defaults' -A6 stackrox-secured-cluster-services-chart/internal/defaults/50-images.yaml
# Add registry defaults
image:
  main:
    registry: {{ ._rox.image.registry }}
  collector:
    registry: {{ ._rox.image.registry }}
```