### PR TITLE
Pass contexts instead of copying them to honor context cancellations

### DIFF
--- a/operator/tests/central/basic/81-assert.yaml
+++ b/operator/tests/central/basic/81-assert.yaml
@@ -26,8 +26,6 @@ spec:
               value: "true"
             - name: ROX_OPENSHIFT
               value: "true"
-            - name: ROX_POSTGRES_DATASTORE
-              value: "true"
             - name: NO_PROXY
               valueFrom:
                 secretKeyRef:

--- a/operator/tests/central/basic/81-assert.yaml
+++ b/operator/tests/central/basic/81-assert.yaml
@@ -26,6 +26,8 @@ spec:
               value: "true"
             - name: ROX_OPENSHIFT
               value: "true"
+            - name: ROX_POSTGRES_DATASTORE
+              value: "true"
             - name: NO_PROXY
               valueFrom:
                 secretKeyRef:

--- a/pkg/search/postgres/common.go
+++ b/pkg/search/postgres/common.go
@@ -1092,7 +1092,6 @@ func RunCursorQueryForSchema[T any, PT unmarshaler[T]](ctx context.Context, sche
 	}
 	closer = func() {
 		if err := tx.Commit(ctx); err != nil {
-			debug.PrintStack()
 			log.Errorf("error committing cursor transaction: %v", err)
 		}
 	}

--- a/pkg/search/postgres/common.go
+++ b/pkg/search/postgres/common.go
@@ -985,7 +985,6 @@ func RunSelectRequestForSchema[T any](ctx context.Context, db *pgxpool.Pool, sch
 		return nil, nil
 	}
 	return pgutils.Retry2(func() ([]*T, error) {
-		ctx := contextutil.WithValuesFrom(context.Background(), ctx)
 		return retryableRunSelectRequestForSchema[T](ctx, db, query)
 	})
 }

--- a/pkg/search/postgres/common.go
+++ b/pkg/search/postgres/common.go
@@ -1093,6 +1093,7 @@ func RunCursorQueryForSchema[T any, PT unmarshaler[T]](ctx context.Context, sche
 	}
 	closer = func() {
 		if err := tx.Commit(ctx); err != nil {
+			debug.PrintStack()
 			log.Errorf("error committing cursor transaction: %v", err)
 		}
 	}

--- a/pkg/search/postgres/common.go
+++ b/pkg/search/postgres/common.go
@@ -16,7 +16,6 @@ import (
 	"github.com/pkg/errors"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/pkg/buildinfo"
-	"github.com/stackrox/rox/pkg/contextutil"
 	"github.com/stackrox/rox/pkg/devbuild"
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/logging"
@@ -806,7 +805,7 @@ func RunSearchRequest(ctx context.Context, category v1.SearchCategory, q *v1.Que
 	schema := mapping.GetTableFromCategory(category)
 
 	return pgutils.Retry2(func() ([]searchPkg.Result, error) {
-		ctx := contextutil.WithValuesFrom(context.Background(), ctx)
+
 		return RunSearchRequestForSchema(ctx, schema, q, db)
 	})
 }
@@ -951,7 +950,7 @@ func RunSearchRequestForSchema(ctx context.Context, schema *walker.Schema, q *v1
 		return nil, nil
 	}
 	return pgutils.Retry2(func() ([]searchPkg.Result, error) {
-		ctx := contextutil.WithValuesFrom(context.Background(), ctx)
+
 		return retryableRunSearchRequestForSchema(ctx, query, schema, db)
 	})
 }
@@ -996,7 +995,7 @@ func RunCountRequest(ctx context.Context, category v1.SearchCategory, q *v1.Quer
 	schema := mapping.GetTableFromCategory(category)
 
 	return pgutils.Retry2(func() (int, error) {
-		ctx := contextutil.WithValuesFrom(context.Background(), ctx)
+
 		return RunCountRequestForSchema(ctx, schema, q, db)
 	})
 }
@@ -1010,7 +1009,7 @@ func RunCountRequestForSchema(ctx context.Context, schema *walker.Schema, q *v1.
 	queryStr := query.AsSQL()
 
 	return pgutils.Retry2(func() (int, error) {
-		ctx := contextutil.WithValuesFrom(context.Background(), ctx)
+
 		var count int
 		row := tracedQueryRow(ctx, db, queryStr, query.Data...)
 		if err := row.Scan(&count); err != nil {
@@ -1043,7 +1042,7 @@ func RunGetQueryForSchema[T any, PT unmarshaler[T]](ctx context.Context, schema 
 	queryStr := query.AsSQL()
 
 	return pgutils.Retry2(func() (*T, error) {
-		ctx := contextutil.WithValuesFrom(context.Background(), ctx)
+
 		row := tracedQueryRow(ctx, db, queryStr, query.Data...)
 		return unmarshal[T, PT](row)
 	})
@@ -1071,7 +1070,7 @@ func RunGetManyQueryForSchema[T any, PT unmarshaler[T]](ctx context.Context, sch
 	}
 
 	return pgutils.Retry2(func() ([]*T, error) {
-		ctx := contextutil.WithValuesFrom(context.Background(), ctx)
+
 		return retryableRunGetManyQueryForSchema[T, PT](ctx, query, db)
 	})
 }
@@ -1128,7 +1127,7 @@ func RunDeleteRequestForSchema(ctx context.Context, schema *walker.Schema, q *v1
 	}
 
 	return pgutils.Retry(func() error {
-		ctx := contextutil.WithValuesFrom(context.Background(), ctx)
+
 		_, err = db.Exec(ctx, query.AsSQL(), query.Data...)
 		if err != nil {
 			return errors.Wrapf(err, "could not delete from %q", schema.Table)

--- a/pkg/search/postgres/common.go
+++ b/pkg/search/postgres/common.go
@@ -985,6 +985,7 @@ func RunSelectRequestForSchema[T any](ctx context.Context, db *pgxpool.Pool, sch
 		return nil, nil
 	}
 	return pgutils.Retry2(func() ([]*T, error) {
+		ctx := contextutil.WithValuesFrom(context.Background(), ctx)
 		return retryableRunSelectRequestForSchema[T](ctx, db, query)
 	})
 }


### PR DESCRIPTION
## Description

We should pass the contexts correctly. Just looked at all the of logs and don't have one related to pg context timeouts

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Check of logs from runs
