### PR TITLE
ROX-14175: Wait for deployments to be deleted before trying to delete namespace in RiskTests

### DIFF
--- a/qa-tests-backend/src/test/groovy/RiskTest.groovy
+++ b/qa-tests-backend/src/test/groovy/RiskTest.groovy
@@ -74,7 +74,7 @@ class RiskTest extends BaseSpecification {
 
     def cleanupSpec() {
         for (Deployment deployment : DEPLOYMENTS) {
-            orchestrator.deleteDeployment(deployment)
+            orchestrator.deleteAndWaitForDeploymentDeletion(deployment)
         }
         orchestrator.deleteNamespace(TEST_NAMESPACE)
     }


### PR DESCRIPTION
## Description

This was the proposed solution, with the assumption being that the namespace failing deletion is causing failures and could be avoided by ensuring that the namespace is empty at the time the deletion is attempted.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

As this is a flake, reproduction will be difficult. This change will be done and then monitored for any persistent issues. Further solutions will be explored in the case that this does not solve the issue at hand.
