### PR TITLE
Added syslog notifier test to verify syslog connection

### DIFF
--- a/qa-tests-backend/src/main/groovy/objects/Notifiers.groovy
+++ b/qa-tests-backend/src/main/groovy/objects/Notifiers.groovy
@@ -346,24 +346,15 @@ class SplunkNotifier extends Notifier {
 
 @Slf4j
 class SyslogNotifier extends Notifier {
-    def splunkPort // Syslog isn't inherently tied to Splunk, we're just going to test with Splunk
-
-    SyslogNotifier(String serviceName, int port, int splunkPort, String integrationName = "Syslog Test") {
-        this.splunkPort = splunkPort
+    SyslogNotifier(String serviceName, int port, String integrationName = "Syslog Test") {
         notifier = NotifierService.getSyslogIntegrationConfig(serviceName, port, integrationName)
     }
 
     def createNotifier() {
-        log.debug "validating splunk deployment is ready to accept events before creating syslog notifier..."
-        withRetry(20, 2) {
-            SplunkUtil.createSearch(splunkPort)
-        }
         notifier = NotifierService.addNotifier(notifier)
     }
 
-    void validateViolationNotification(Policy policy, Deployment deployment, boolean strictIntegrationTesting) {
-        def response = SplunkUtil.waitForSplunkSyslog(splunkPort, 90)
-        // We must have received at least one syslog message
-        assert response.size() > 0
+    def testNotifier() {
+         return NotifierService.testNotifier(notifier)
     }
 }

--- a/qa-tests-backend/src/main/groovy/util/SyslogServer.groovy
+++ b/qa-tests-backend/src/main/groovy/util/SyslogServer.groovy
@@ -1,0 +1,51 @@
+package util
+
+import groovy.util.logging.Slf4j
+import objects.Deployment
+import objects.Service
+import orchestratormanager.OrchestratorMain
+
+@Slf4j
+class SyslogServer {
+    public static final Integer SYSLOG_PORT = 514
+    private Service syslogSvc
+    private Deployment  deployment
+
+    static SyslogServer createRsyslog(OrchestratorMain orchestrator, String namespace) {
+        def deploymentName = "syslog-${UUID.randomUUID()}"
+        def rsyslog = new SyslogServer()
+        try {
+            rsyslog.deployment =
+                    new Deployment()
+                            .setNamespace(namespace)
+                            .setName(deploymentName)
+                            // The original is at docker.io/rsyslog/syslog_appliance_alpine:8.36.0-3.7
+                            // and https://github.com/rsyslog/rsyslog-docker
+                            .setImage("quay.io/rhacs-eng/qa:rsyslog_appliance_alpine")
+                            .addPort(SYSLOG_PORT)
+                            .addLabel("app", deploymentName)
+            orchestrator.createDeployment(rsyslog.deployment)
+
+            rsyslog.syslogSvc = new Service("rsyslog-service", orchestrator.getNameSpace())
+                                            .addLabel("app", deploymentName)
+                                            .addPort(SYSLOG_PORT , "TCP")
+                                            .setTargetPort(SYSLOG_PORT)
+                                            .setType(Service.Type.CLUSTERIP)
+            orchestrator.createService(rsyslog.syslogSvc)
+        } catch (Exception e) {
+            log.info("error creating syslog deployment or service", e)
+           tearDown(orchestrator)
+            throw e
+        }
+        return rsyslog
+    }
+
+    void tearDown(OrchestratorMain orchestrator) {
+        if (syslogSvc) {
+            orchestrator.deleteService(syslogSvc.name, syslogSvc.namespace)
+        }
+        if (deployment) {
+            orchestrator.deleteDeployment(deployment)
+        }
+    }
+}

--- a/qa-tests-backend/src/main/groovy/util/SyslogServer.groovy
+++ b/qa-tests-backend/src/main/groovy/util/SyslogServer.groovy
@@ -9,7 +9,7 @@ import orchestratormanager.OrchestratorMain
 class SyslogServer {
     public static final Integer SYSLOG_PORT = 514
     private Service syslogSvc
-    private Deployment  deployment
+    private Deployment deployment
 
     static SyslogServer createRsyslog(OrchestratorMain orchestrator, String namespace) {
         def deploymentName = "syslog-${UUID.randomUUID()}"
@@ -32,9 +32,9 @@ class SyslogServer {
                                             .setTargetPort(SYSLOG_PORT)
                                             .setType(Service.Type.CLUSTERIP)
             orchestrator.createService(rsyslog.syslogSvc)
-        } catch (Exception e) {
+        }   catch (Exception e) {
             log.info("error creating syslog deployment or service", e)
-           tearDown(orchestrator)
+            tearDown(orchestrator)
             throw e
         }
         return rsyslog

--- a/qa-tests-backend/src/test/groovy/IntegrationsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/IntegrationsTest.groovy
@@ -759,15 +759,15 @@ class IntegrationsTest extends BaseSpecification {
     @Tag("Integration")
     def "Verify syslog notifier"() {
        given:
-       "the some syslog receiver is created"
+       "syslog server is created"
        def syslog = SyslogServer.createRsyslog(orchestrator, Constants.ORCHESTRATOR_NAMESPACE)
 
         when:
-        "call the grpc API for the syslog integration."
+        "call the grpc API for the syslog notifier integration."
         SyslogNotifier notifier = new SyslogNotifier(syslog.syslogSvc.name, syslog.SYSLOG_PORT)
 
         then:
-        "Verify syslog connecion is successful"
+        "Verify syslog connection is successful"
         assert notifier.testNotifier()
 
         cleanup:

--- a/qa-tests-backend/src/test/groovy/IntegrationsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/IntegrationsTest.groovy
@@ -21,6 +21,7 @@ import objects.NetworkPolicyTypes
 import objects.Notifier
 import objects.QuayImageIntegration
 import objects.SlackNotifier
+import objects.SyslogNotifier
 import objects.SplunkNotifier
 import objects.StackroxScannerIntegration
 import services.ClusterService
@@ -31,6 +32,7 @@ import services.NotifierService
 import services.PolicyService
 import util.Env
 import util.MailServer
+import util.SyslogServer
 import util.SplunkUtil
 
 import org.junit.Assume
@@ -59,13 +61,11 @@ class IntegrationsTest extends BaseSpecification {
     Timeout globalTimeout = new Timeout(1000, TimeUnit.SECONDS)
 
     def setupSpec() {
-        ImageIntegrationService.deleteStackRoxScannerIntegrationIfExists()
         orchestrator.batchCreateDeployments(DEPLOYMENTS)
         DEPLOYMENTS.each { Services.waitForDeployment(it) }
     }
 
     def cleanupSpec() {
-        ImageIntegrationService.addStackroxScannerIntegration()
         DEPLOYMENTS.each { orchestrator.deleteDeployment(it) }
     }
 
@@ -641,6 +641,9 @@ class IntegrationsTest extends BaseSpecification {
     @Unroll
     @Tag("Integration")
     def "Verify #imageIntegration.name() integration - #testAspect"() {
+        setup:
+        ImageIntegrationService.deleteStackRoxScannerIntegrationIfExists()
+
         Assume.assumeTrue(imageIntegration.isTestable())
         Assume.assumeTrue(!testAspect.contains("IAM") || ClusterService.isEKS())
 
@@ -653,6 +656,9 @@ class IntegrationsTest extends BaseSpecification {
         then:
         "verify test integration outcome"
         assert outcome
+
+        cleanup:
+        ImageIntegrationService.addStackroxScannerIntegration()
 
         where:
         "tests are:"
@@ -749,35 +755,25 @@ class IntegrationsTest extends BaseSpecification {
         }       | StatusRuntimeException | /PermissionDenied/ | "incorrect project"
     }
 
-    // TODO disabled due to flaking (ROX-7902), shoudl be re-enabled once reworked (ROX-10310)
-    //@Tag("Integration")
-    //def "Verify syslog notifier"() {
-    //    given:
-    //    "the some syslog receiver is created"
-    //    // Change the local port numbers so we don't conflict with any other splunk instances
-    //    SplunkUtil.SplunkDeployment splunkDeployment = SplunkUtil.createSplunk(orchestrator,
-    //            Constants.ORCHESTRATOR_NAMESPACE, true)
+    @Unroll
+    @Tag("Integration")
+    def "Verify syslog notifier"() {
+       given:
+       "the some syslog receiver is created"
+       def syslog = SyslogServer.createRsyslog(orchestrator, Constants.ORCHESTRATOR_NAMESPACE)
 
-    //    when:
-    //    "call the grpc API for the syslog integration."
-    //    SyslogNotifier notifier = new SyslogNotifier(splunkDeployment.syslogSvc.name, 514,
-    //            splunkDeployment.splunkPortForward.localPort)
-    //    try {
-    //        notifier.createNotifier()
-    //    } catch (Exception e) {
-    //        throw new AssumptionViolatedException("Could not create syslog notifier. Skipping test!", e)
-    //    }
+        when:
+        "call the grpc API for the syslog integration."
+        SyslogNotifier notifier = new SyslogNotifier(syslog.syslogSvc.name, syslog.SYSLOG_PORT)
 
-    //    then:
-    //    "Verify the messages are seen in the json"
-    //    // We should have at least one audit log for the message which created the syslog integration.
-    //    notifier.validateViolationNotification(null, null, false)
+        then:
+        "Verify syslog connecion is successful"
+        assert notifier.testNotifier()
 
-    //    cleanup:
-    //    "remove splunk and syslog notifier integration"
-    //    SplunkUtil.tearDownSplunk(orchestrator, splunkDeployment)
-    //    notifier.deleteNotifier()
-    //}
+        cleanup:
+        "remove syslog notifier integration"
+        syslog.tearDown(orchestrator)
+    }
 
     def uniqueName(String name) {
         return name + RandomStringUtils.randomAlphanumeric(5).toLowerCase()


### PR DESCRIPTION
Added a e2e syslog test that verifies deploys syslog server, creates notifier and verifies connection between syslog and central.

Checklist
- [ ]  Investigated and inspected CI test results - Done
[ ] Unit test and regression tests added
[ ] Evaluated and added CHANGELOG entry if required
[ ] Determined and documented upgrade steps
[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))
If any of these don't apply, please comment below.

Testing Performed:
Verified the test passes locally for syslog notifier. 