### PR TITLE
ROX-14582: Wire up network graph polling

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
@@ -32,6 +32,7 @@ import useURLParameter from 'hooks/useURLParameter';
 import NetworkGraphContainer, { Models } from './NetworkGraphContainer';
 import EmptyUnscopedState from './components/EmptyUnscopedState';
 import NetworkBreadcrumbs from './components/NetworkBreadcrumbs';
+import NodeUpdateSection from './components/NodeUpdateSection';
 import NetworkSearch from './components/NetworkSearch';
 import SimulateNetworkPolicyButton from './simulation/SimulateNetworkPolicyButton';
 import EdgeStateSelect, { EdgeState } from './components/EdgeStateSelect';
@@ -79,7 +80,7 @@ function NetworkGraphPage() {
     const [pollEpoch, setPollEpoch] = useState(0);
     const [isLoading, setIsLoading] = useState(false);
     const [timeWindow, setTimeWindow] = useState<typeof timeWindows[number]>(timeWindows[0]);
-    const [lastUpdatedTime, setLastUpdatedTime] = useState<string>('never');
+    const [lastUpdatedTime, setLastUpdatedTime] = useState<string>('');
     const [isCIDRBlockFormOpen, setIsCIDRBlockFormOpen] = useState(false);
 
     const { searchFilter } = useURLSearch();
@@ -106,17 +107,9 @@ function NetworkGraphPage() {
     const selectedClusterId = clusters.find((cl) => cl.name === clusterFromUrl)?.id;
     const selectedCluster = { name: clusterFromUrl, id: selectedClusterId };
     const { deploymentCount } = useFetchDeploymentCount(selectedClusterId || '');
-    console.log({ deploymentCount });
 
     const [prevEpochCount, setPrevEpochCount] = useState(0);
     const [currentEpochCount, setCurrentEpochCount] = useState(0);
-
-    // useEffect(() => {
-    //     if (selectedClusterId) {
-    //         console.log({ selectedClusterId });
-    //         console.log({ prevEpochCount });
-    //     }
-    // }, [selectedClusterId, prevEpochCount]);
 
     // We will update the poll epoch after 30 seconds to update the node count for a cluster
     useInterval(() => {
@@ -124,16 +117,16 @@ function NetworkGraphPage() {
     }, 30000);
 
     useEffect(() => {
-        if (selectedClusterId) {
+        if (selectedClusterId && namespacesFromUrl.length > 0) {
             fetchNodeUpdates(selectedClusterId)
                 .then((result) => {
                     setCurrentEpochCount(result?.response?.epoch || 0);
                 })
-                .catch((err) => {
-                    console.warn(err);
+                .catch(() => {
+                    // failure to update the node count is not critical
                 });
         }
-    }, [selectedClusterId, pollEpoch]);
+    }, [selectedClusterId, namespacesFromUrl.length, pollEpoch]);
 
     useDeepCompareEffect(() => {
         // check that user is finished adding a complete filter
@@ -143,8 +136,8 @@ function NetworkGraphPage() {
         const isClusterNamespaceSelected =
             clusterFromUrl && namespacesFromUrl.length > 0 && deploymentCount;
 
-        if (isQueryFilterComplete && isClusterNamespaceSelected) {
-            if (selectedClusterId) {
+        if (isQueryFilterComplete && selectedClusterId && isClusterNamespaceSelected) {
+            if (currentEpochCount === 0) {
                 setIsLoading(true);
 
                 const queryToUse = queryService.objectToWhereClause(remainingQuery);
@@ -171,11 +164,11 @@ function NetworkGraphPage() {
                     ),
                 ])
                     .then((values) => {
-                        // get policy nodes from api response
+                        // get policy nodes, and the starting epoch, from policy graph API response
                         const { nodes: policyNodes, epoch } = values[1].response;
                         // transform policy data to DataModel
                         const { policyDataModel, policyNodeMap } = transformPolicyData(policyNodes);
-                        // get active nodes from api response
+                        // get active nodes from network flow graph API response
                         const { nodes: activeNodes } = values[0].response;
                         // transform active data to DataModel
                         const { activeDataModel, activeEdgeMap, activeNodeMap } =
@@ -216,11 +209,19 @@ function NetworkGraphPage() {
         remainingQuery,
         timeWindow,
         deploymentCount,
+        prevEpochCount,
+        currentEpochCount,
     ]);
 
     function toggleCIDRBlockForm() {
         setIsCIDRBlockFormOpen(!isCIDRBlockFormOpen);
     }
+
+    function updateNetworkNodes() {
+        setCurrentEpochCount(0);
+    }
+
+    const nodeUpdatesCount = currentEpochCount - prevEpochCount;
 
     return (
         <>
@@ -303,7 +304,12 @@ function NetworkGraphPage() {
                         <ToolbarGroup alignment={{ default: 'alignRight' }}>
                             <Divider component="div" orientation={{ default: 'vertical' }} />
                             <ToolbarItem className="pf-u-color-200">
-                                <em>Last updated at {lastUpdatedTime}</em>
+                                <NodeUpdateSection
+                                    isLoading={isLoading}
+                                    lastUpdatedTime={lastUpdatedTime}
+                                    nodeUpdatesCount={nodeUpdatesCount}
+                                    updateNetworkNodes={updateNetworkNodes}
+                                />
                             </ToolbarItem>
                         </ToolbarGroup>
                     </ToolbarContent>

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/NodeUpdateSection.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/NodeUpdateSection.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import pluralize from 'pluralize';
+import { Button, ButtonVariant } from '@patternfly/react-core';
+
+type NodeUpdateSectionProps = {
+    isLoading: boolean;
+    lastUpdatedTime: string;
+    nodeUpdatesCount: number;
+    updateNetworkNodes: () => void;
+};
+
+const NodesUpdateSection = ({
+    isLoading,
+    lastUpdatedTime,
+    nodeUpdatesCount,
+    updateNetworkNodes,
+}: NodeUpdateSectionProps) => {
+    if (!isLoading && nodeUpdatesCount > 0) {
+        return (
+            <Button
+                variant={ButtonVariant.secondary}
+                onClick={updateNetworkNodes}
+                aria-label="Click to refresh the graph"
+            >
+                {nodeUpdatesCount} {pluralize('update', nodeUpdatesCount)} available
+            </Button>
+        );
+    }
+
+    return <em>Last updated {lastUpdatedTime ? `at ${lastUpdatedTime}` : 'never'}</em>;
+};
+
+export default NodesUpdateSection;


### PR DESCRIPTION
## Description

This implements the "nodes-were-added-click-to-update" functionality of the old Network Graph, on the new Network Graph.

There were no mocks for how this should look in the new format. On the old graph, there was a floating rectangle near the upper-right corner of the graph, with the timestamp when the graph was last updated. If the number of nodes available for the graph changed, a count of the difference of nodes was added below the timestamp, and the whole thing became a clickable area to force a graph update.

On the new graph layout, the mocks show the timestamp in the far right of the lowest toolbar. There is no mock for the 

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

Steps to test
(shown in the screen recording attached below)
1. I selected the Production cluster, and the backend and default namespaces, on staging.
2. I deployed a new deployment, `nginx`, in that default NS.
3. I waited about 30 seconds for the polling to happen, and then I observed the timestamp changed changed to a button labeled "1 update available".
4. I deployed the Kubernetes `shell-demo` in that default NS.
5. I waited another 30 seconds for the polling to happen, and then I observed the button labeled change from "1 update available" to "2 updates available".
6. I clicked that update, and the graph updated to show the 2 new deployments in the default NS and a new timestamp in place of the button.
7. I deleted the shell-demo pod.
8. I waited about 30 seconds for the polling to happen, and then I observed the timestamp changed changed to a button labeled "1 update available".
9. I clicked that update, and the graph updated to show the shell-demo deployment gone in the default NS and a new timestamp in place of the button.


https://user-images.githubusercontent.com/715729/217105928-4f4f972c-25fa-4977-9ef2-01c4ce25893f.mov

