### PR TITLE
Propagate storage class options to Central-DB

### DIFF
--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -179,10 +179,16 @@ function launch_central {
 
     if [[ -n $STORAGE_CLASS ]]; then
         add_storage_args "--storage-class=$STORAGE_CLASS"
+        if [[ "${ROX_POSTGRES_DATASTORE}" == "true" ]]; then
+            add_storage_args "--db-storage-class=$STORAGE_CLASS"
+        fi
     fi
 
     if [[ "${STORAGE}" == "pvc" && -n "${STORAGE_SIZE}" ]]; then
 	      add_storage_args "--size=${STORAGE_SIZE}"
+        if [[ "${ROX_POSTGRES_DATASTORE}" == "true" ]]; then
+            add_storage_args "--db-size=${STORAGE_SIZE}"
+        fi
     fi
 
     if [[ -n "${ROXDEPLOY_CONFIG_FILE_MAP}" ]]; then


### PR DESCRIPTION
## Description

Prior to this change, we wouldn't propagate the env var variables so Postgres was running on standard storage class when on GKE. This will allow it to run with SSD to do comparisons

```
NAME                  STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
central-db            Bound    pvc-b29f98d3-26fd-4ee1-9276-9f0188e78490   100Gi      RWO            faster         17s
stackrox-db           Bound    pvc-efbcabe9-85e5-4494-b154-ca127a410ecb   100Gi      RWO            faster         17s
```

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Ran it locally