### PR TITLE
ROX-14148: Add transforming of declarative config to proto for Auth providers & groups

### DIFF
--- a/pkg/auth/authproviders/oidc/backend_factory_impl.go
+++ b/pkg/auth/authproviders/oidc/backend_factory_impl.go
@@ -76,9 +76,9 @@ func (f *factory) ResolveProviderAndClientState(state string) (string, string, e
 }
 
 func (f *factory) RedactConfig(config map[string]string) map[string]string {
-	if config[clientSecretConfigKey] != "" {
+	if config[ClientSecretConfigKey] != "" {
 		config = maputil.ShallowClone(config)
-		config[clientSecretConfigKey] = "*****"
+		config[ClientSecretConfigKey] = "*****"
 	}
 	return config
 }
@@ -89,8 +89,8 @@ func (f *factory) MergeConfig(newCfg, oldCfg map[string]string) map[string]strin
 	// we will take the client secret from the stored config and put it into the merged config.
 	// We only put secret into the merged config if the new config says it wants to use a client secret, AND the client
 	// secret is not specified in the request.
-	if mergedCfg[dontUseClientSecretConfigKey] == "false" && mergedCfg[clientSecretConfigKey] == "" {
-		mergedCfg[clientSecretConfigKey] = oldCfg[clientSecretConfigKey]
+	if mergedCfg[DontUseClientSecretConfigKey] == "false" && mergedCfg[ClientSecretConfigKey] == "" {
+		mergedCfg[ClientSecretConfigKey] = oldCfg[ClientSecretConfigKey]
 	}
 	return mergedCfg
 }

--- a/pkg/auth/authproviders/oidc/backend_impl.go
+++ b/pkg/auth/authproviders/oidc/backend_impl.go
@@ -26,16 +26,17 @@ import (
 	"golang.org/x/oauth2"
 )
 
+// Specifies the constants used for the auth provider configuration.
 const (
 	fragmentCallbackURLPath = "/auth/response/oidc"
 
-	issuerConfigKey       = "issuer"
-	clientIDConfigKey     = "client_id"
-	clientSecretConfigKey = "client_secret"
+	IssuerConfigKey       = "issuer"
+	ClientIDConfigKey     = "client_id"
+	ClientSecretConfigKey = "client_secret"
 	//#nosec G101 -- This is a false positive
-	dontUseClientSecretConfigKey       = "do_not_use_client_secret"
-	modeConfigKey                      = "mode"
-	disableOfflineAccessScopeConfigKey = "disable_offline_access_scope"
+	DontUseClientSecretConfigKey       = "do_not_use_client_secret"
+	ModeConfigKey                      = "mode"
+	DisableOfflineAccessScopeConfigKey = "disable_offline_access_scope"
 
 	userInfoExpiration = 5 * time.Minute
 
@@ -223,12 +224,12 @@ func newBackend(ctx context.Context, id string, uiEndpoints []string, callbackUR
 		return nil, errors.New("OIDC requires a default UI endpoint")
 	}
 
-	clientID := config[clientIDConfigKey]
+	clientID := config[ClientIDConfigKey]
 	if clientID == "" {
 		return nil, errNoClientIDProvided
 	}
 
-	issuerHelper, err := endpoint.NewHelper(config[issuerConfigKey])
+	issuerHelper, err := endpoint.NewHelper(config[IssuerConfigKey])
 	if err != nil {
 		return nil, err
 	}
@@ -252,9 +253,9 @@ func newBackend(ctx context.Context, id string, uiEndpoints []string, callbackUR
 		Scheme: "https",
 	}
 
-	clientSecret := config[clientSecretConfigKey]
+	clientSecret := config[ClientSecretConfigKey]
 
-	mode := strings.ToLower(config[modeConfigKey])
+	mode := strings.ToLower(config[ModeConfigKey])
 	if mode == "auto" {
 		mode, err = provider.SelectResponseMode(clientSecret != "")
 		if err != nil {
@@ -268,7 +269,7 @@ func newBackend(ctx context.Context, id string, uiEndpoints []string, callbackUR
 		mode = "fragment" // legacy setting
 	}
 
-	if clientSecret == "" && config[dontUseClientSecretConfigKey] == "false" {
+	if clientSecret == "" && config[DontUseClientSecretConfigKey] == "false" {
 		if mode == "query" {
 			return nil, errQueryWithoutClientSecret
 		}
@@ -306,7 +307,7 @@ func newBackend(ctx context.Context, id string, uiEndpoints []string, callbackUR
 
 	b.idTokenVerifier = provider.Verifier(&oidc.Config{ClientID: clientID})
 
-	disableOfflineAccessScope := config[disableOfflineAccessScopeConfigKey] == "true"
+	disableOfflineAccessScope := config[DisableOfflineAccessScopeConfigKey] == "true"
 	b.baseOauthConfig, err = createBaseOAuthConfig(
 		clientID,
 		clientSecret,
@@ -319,13 +320,13 @@ func newBackend(ctx context.Context, id string, uiEndpoints []string, callbackUR
 	}
 
 	b.config = map[string]string{
-		issuerConfigKey:       issuerHelper.Issuer(),
-		clientIDConfigKey:     clientID,
-		clientSecretConfigKey: clientSecret,
-		modeConfigKey:         mode,
+		IssuerConfigKey:       issuerHelper.Issuer(),
+		ClientIDConfigKey:     clientID,
+		ClientSecretConfigKey: clientSecret,
+		ModeConfigKey:         mode,
 	}
 	if disableOfflineAccessScope {
-		b.config[disableOfflineAccessScopeConfigKey] = "true"
+		b.config[DisableOfflineAccessScopeConfigKey] = "true"
 	}
 
 	return b, nil

--- a/pkg/auth/authproviders/oidc/backend_impl_test.go
+++ b/pkg/auth/authproviders/oidc/backend_impl_test.go
@@ -35,44 +35,44 @@ func TestMerge(t *testing.T) {
 		{
 			"old config with client secret, new config wants to use client secret but is empty",
 			map[string]string{
-				dontUseClientSecretConfigKey: "false",
-				clientSecretConfigKey:        "SECRET",
+				DontUseClientSecretConfigKey: "false",
+				ClientSecretConfigKey:        "SECRET",
 			},
 			map[string]string{
-				dontUseClientSecretConfigKey: "false",
+				DontUseClientSecretConfigKey: "false",
 			},
 			map[string]string{
-				dontUseClientSecretConfigKey: "false",
-				clientSecretConfigKey:        "SECRET",
+				DontUseClientSecretConfigKey: "false",
+				ClientSecretConfigKey:        "SECRET",
 			},
 		},
 		{
 			"old config with client secret, new config wants to use client secret and specifies a new one",
 			map[string]string{
-				dontUseClientSecretConfigKey: "false",
-				clientSecretConfigKey:        "SECRET",
+				DontUseClientSecretConfigKey: "false",
+				ClientSecretConfigKey:        "SECRET",
 			},
 			map[string]string{
-				dontUseClientSecretConfigKey: "false",
-				clientSecretConfigKey:        "NEWSECRET",
+				DontUseClientSecretConfigKey: "false",
+				ClientSecretConfigKey:        "NEWSECRET",
 			},
 			map[string]string{
-				dontUseClientSecretConfigKey: "false",
-				clientSecretConfigKey:        "NEWSECRET",
+				DontUseClientSecretConfigKey: "false",
+				ClientSecretConfigKey:        "NEWSECRET",
 			},
 		},
 		{
 			"old config with no client secret, new config wants to use client secret",
 			map[string]string{
-				dontUseClientSecretConfigKey: "true",
+				DontUseClientSecretConfigKey: "true",
 			},
 			map[string]string{
-				dontUseClientSecretConfigKey: "false",
-				clientSecretConfigKey:        "NEWSECRET",
+				DontUseClientSecretConfigKey: "false",
+				ClientSecretConfigKey:        "NEWSECRET",
 			},
 			map[string]string{
-				dontUseClientSecretConfigKey: "false",
-				clientSecretConfigKey:        "NEWSECRET",
+				DontUseClientSecretConfigKey: "false",
+				ClientSecretConfigKey:        "NEWSECRET",
 			},
 		},
 	} {
@@ -180,39 +180,39 @@ func TestBackend(t *testing.T) {
 	}{
 		"no client id": {
 			config: map[string]string{
-				clientIDConfigKey:     "",
-				clientSecretConfigKey: "testsecret",
-				issuerConfigKey:       "some-issuer",
-				modeConfigKey:         "post",
+				ClientIDConfigKey:     "",
+				ClientSecretConfigKey: "testsecret",
+				IssuerConfigKey:       "some-issuer",
+				ModeConfigKey:         "post",
 			},
 			wantBackendErr: errNoClientIDProvided,
 		},
 		"bad issuer": {
 			config: map[string]string{
-				clientIDConfigKey:     "testclientid",
-				clientSecretConfigKey: "testsecret",
-				issuerConfigKey:       "",
-				modeConfigKey:         "post",
+				ClientIDConfigKey:     "testclientid",
+				ClientSecretConfigKey: "testsecret",
+				IssuerConfigKey:       "",
+				ModeConfigKey:         "post",
 			},
 			wantBackendErr: endpoint.ErrNoIssuerProvided,
 		},
 		"transient backend error": {
 			config: map[string]string{
-				clientIDConfigKey:     "testclientid",
-				clientSecretConfigKey: "testsecret",
-				issuerConfigKey:       "test-issuer",
-				modeConfigKey:         "post",
+				ClientIDConfigKey:     "testclientid",
+				ClientSecretConfigKey: "testsecret",
+				IssuerConfigKey:       "test-issuer",
+				ModeConfigKey:         "post",
 			},
 			oidcProvider:   nil,
 			wantBackendErr: transientError,
 		},
 		"no client secret and no confirmation": {
 			config: map[string]string{
-				clientIDConfigKey:            "testclientid",
-				clientSecretConfigKey:        "",
-				dontUseClientSecretConfigKey: "false",
-				issuerConfigKey:              "test-issuer",
-				modeConfigKey:                "post",
+				ClientIDConfigKey:            "testclientid",
+				ClientSecretConfigKey:        "",
+				DontUseClientSecretConfigKey: "false",
+				IssuerConfigKey:              "test-issuer",
+				ModeConfigKey:                "post",
 			},
 			oidcProvider: &mockOIDCProvider{
 				responseTypesSupported: allResponseTypes,
@@ -222,11 +222,11 @@ func TestBackend(t *testing.T) {
 		},
 		"no client secret and no confirmation in query mode": {
 			config: map[string]string{
-				clientIDConfigKey:            "testclientid",
-				clientSecretConfigKey:        "",
-				dontUseClientSecretConfigKey: "false",
-				issuerConfigKey:              "test-issuer",
-				modeConfigKey:                "query",
+				ClientIDConfigKey:            "testclientid",
+				ClientSecretConfigKey:        "",
+				DontUseClientSecretConfigKey: "false",
+				IssuerConfigKey:              "test-issuer",
+				ModeConfigKey:                "query",
 			},
 			oidcProvider: &mockOIDCProvider{
 				responseTypesSupported: allResponseTypes,
@@ -236,10 +236,10 @@ func TestBackend(t *testing.T) {
 		},
 		"insecure client mode form post": {
 			config: map[string]string{
-				clientIDConfigKey:     "testclientid",
-				clientSecretConfigKey: "testsecret",
-				issuerConfigKey:       "https+insecure://test-issuer",
-				modeConfigKey:         "post",
+				ClientIDConfigKey:     "testclientid",
+				ClientSecretConfigKey: "testsecret",
+				IssuerConfigKey:       "https+insecure://test-issuer",
+				ModeConfigKey:         "post",
 			},
 			oidcProvider: &mockOIDCProvider{
 				responseTypesSupported: allResponseTypes,
@@ -250,10 +250,10 @@ func TestBackend(t *testing.T) {
 				responseMode:  "form_post",
 				responseTypes: []string{"code"},
 				config: map[string]string{
-					clientIDConfigKey:     "testclientid",
-					clientSecretConfigKey: "testsecret",
-					issuerConfigKey:       "https+insecure://test-issuer",
-					modeConfigKey:         "post",
+					ClientIDConfigKey:     "testclientid",
+					ClientSecretConfigKey: "testsecret",
+					IssuerConfigKey:       "https+insecure://test-issuer",
+					ModeConfigKey:         "post",
 				},
 			},
 			issueNonce: true,
@@ -264,10 +264,10 @@ func TestBackend(t *testing.T) {
 		},
 		"mode form post": {
 			config: map[string]string{
-				clientIDConfigKey:     "testclientid",
-				clientSecretConfigKey: "testsecret",
-				issuerConfigKey:       "https://test-issuer",
-				modeConfigKey:         "post",
+				ClientIDConfigKey:     "testclientid",
+				ClientSecretConfigKey: "testsecret",
+				IssuerConfigKey:       "https://test-issuer",
+				ModeConfigKey:         "post",
 			},
 			oidcProvider: &mockOIDCProvider{
 				responseTypesSupported: allResponseTypes,
@@ -277,10 +277,10 @@ func TestBackend(t *testing.T) {
 				responseMode:  "form_post",
 				responseTypes: []string{"code"},
 				config: map[string]string{
-					clientIDConfigKey:     "testclientid",
-					clientSecretConfigKey: "testsecret",
-					issuerConfigKey:       "https://test-issuer",
-					modeConfigKey:         "post",
+					ClientIDConfigKey:     "testclientid",
+					ClientSecretConfigKey: "testsecret",
+					IssuerConfigKey:       "https://test-issuer",
+					ModeConfigKey:         "post",
 				},
 			},
 			issueNonce: true,
@@ -291,10 +291,10 @@ func TestBackend(t *testing.T) {
 		},
 		"mode form post and mismatching idp response": {
 			config: map[string]string{
-				clientIDConfigKey:     "testclientid",
-				clientSecretConfigKey: "testsecret",
-				issuerConfigKey:       "https://test-issuer",
-				modeConfigKey:         "post",
+				ClientIDConfigKey:     "testclientid",
+				ClientSecretConfigKey: "testsecret",
+				IssuerConfigKey:       "https://test-issuer",
+				ModeConfigKey:         "post",
 			},
 			oidcProvider: &mockOIDCProvider{
 				responseTypesSupported: []string{"code"},
@@ -304,10 +304,10 @@ func TestBackend(t *testing.T) {
 				responseMode:  "form_post",
 				responseTypes: []string{"code"},
 				config: map[string]string{
-					clientIDConfigKey:     "testclientid",
-					clientSecretConfigKey: "testsecret",
-					issuerConfigKey:       "https://test-issuer",
-					modeConfigKey:         "post",
+					ClientIDConfigKey:     "testclientid",
+					ClientSecretConfigKey: "testsecret",
+					IssuerConfigKey:       "https://test-issuer",
+					ModeConfigKey:         "post",
 				},
 			},
 			issueNonce: true,
@@ -318,10 +318,10 @@ func TestBackend(t *testing.T) {
 		},
 		"mode form post with bad nonce": {
 			config: map[string]string{
-				clientIDConfigKey:     "testclientid",
-				clientSecretConfigKey: "testsecret",
-				issuerConfigKey:       "https://test-issuer",
-				modeConfigKey:         "post",
+				ClientIDConfigKey:     "testclientid",
+				ClientSecretConfigKey: "testsecret",
+				IssuerConfigKey:       "https://test-issuer",
+				ModeConfigKey:         "post",
 			},
 			oidcProvider: &mockOIDCProvider{
 				responseTypesSupported: allResponseTypes,
@@ -331,10 +331,10 @@ func TestBackend(t *testing.T) {
 				responseMode:  "form_post",
 				responseTypes: []string{"code"},
 				config: map[string]string{
-					clientIDConfigKey:     "testclientid",
-					clientSecretConfigKey: "testsecret",
-					issuerConfigKey:       "https://test-issuer",
-					modeConfigKey:         "post",
+					ClientIDConfigKey:     "testclientid",
+					ClientSecretConfigKey: "testsecret",
+					IssuerConfigKey:       "https://test-issuer",
+					ModeConfigKey:         "post",
 				},
 			},
 			issueNonce: false,
@@ -346,10 +346,10 @@ func TestBackend(t *testing.T) {
 		},
 		"mode query": {
 			config: map[string]string{
-				clientIDConfigKey:     "testclientid",
-				clientSecretConfigKey: "testsecret",
-				issuerConfigKey:       "test-issuer",
-				modeConfigKey:         "query",
+				ClientIDConfigKey:     "testclientid",
+				ClientSecretConfigKey: "testsecret",
+				IssuerConfigKey:       "test-issuer",
+				ModeConfigKey:         "query",
 			},
 			oidcProvider: &mockOIDCProvider{
 				responseTypesSupported: allResponseTypes,
@@ -359,10 +359,10 @@ func TestBackend(t *testing.T) {
 				responseMode:  "query",
 				responseTypes: []string{"code"},
 				config: map[string]string{
-					clientIDConfigKey:     "testclientid",
-					clientSecretConfigKey: "testsecret",
-					issuerConfigKey:       "https://test-issuer",
-					modeConfigKey:         "query",
+					ClientIDConfigKey:     "testclientid",
+					ClientSecretConfigKey: "testsecret",
+					IssuerConfigKey:       "https://test-issuer",
+					ModeConfigKey:         "query",
 				},
 			},
 			issueNonce: true,
@@ -373,10 +373,10 @@ func TestBackend(t *testing.T) {
 		},
 		"mode fragment with access_token only": {
 			config: map[string]string{
-				clientIDConfigKey:     "testclientid",
-				clientSecretConfigKey: "testsecret",
-				issuerConfigKey:       "https://test-issuer",
-				modeConfigKey:         "fragment",
+				ClientIDConfigKey:     "testclientid",
+				ClientSecretConfigKey: "testsecret",
+				IssuerConfigKey:       "https://test-issuer",
+				ModeConfigKey:         "fragment",
 			},
 			oidcProvider: &mockOIDCProvider{
 				responseTypesSupported:     allResponseTypes,
@@ -388,10 +388,10 @@ func TestBackend(t *testing.T) {
 				responseMode:  "fragment",
 				responseTypes: []string{"token", "id_token"},
 				config: map[string]string{
-					clientIDConfigKey:     "testclientid",
-					clientSecretConfigKey: "testsecret",
-					issuerConfigKey:       "https://test-issuer",
-					modeConfigKey:         "fragment",
+					ClientIDConfigKey:     "testclientid",
+					ClientSecretConfigKey: "testsecret",
+					IssuerConfigKey:       "https://test-issuer",
+					ModeConfigKey:         "fragment",
 				},
 			},
 			idpResponseTemplate: map[string]responseValueProvider{
@@ -400,10 +400,10 @@ func TestBackend(t *testing.T) {
 		},
 		"mode fragment with access_token only fails on userinfo endpoint failure": {
 			config: map[string]string{
-				clientIDConfigKey:     "testclientid",
-				clientSecretConfigKey: "testsecret",
-				issuerConfigKey:       "https://test-issuer",
-				modeConfigKey:         "fragment",
+				ClientIDConfigKey:     "testclientid",
+				ClientSecretConfigKey: "testsecret",
+				IssuerConfigKey:       "https://test-issuer",
+				ModeConfigKey:         "fragment",
 			},
 			oidcProvider: &mockOIDCProvider{
 				responseTypesSupported:     allResponseTypes,
@@ -416,10 +416,10 @@ func TestBackend(t *testing.T) {
 				responseMode:  "fragment",
 				responseTypes: []string{"token", "id_token"},
 				config: map[string]string{
-					clientIDConfigKey:     "testclientid",
-					clientSecretConfigKey: "testsecret",
-					issuerConfigKey:       "https://test-issuer",
-					modeConfigKey:         "fragment",
+					ClientIDConfigKey:     "testclientid",
+					ClientSecretConfigKey: "testsecret",
+					IssuerConfigKey:       "https://test-issuer",
+					ModeConfigKey:         "fragment",
 				},
 			},
 			idpResponseTemplate: map[string]responseValueProvider{
@@ -429,10 +429,10 @@ func TestBackend(t *testing.T) {
 		},
 		"mode fragment with id_token only": {
 			config: map[string]string{
-				clientIDConfigKey:     "testclientid",
-				clientSecretConfigKey: "testsecret",
-				issuerConfigKey:       "test-issuer",
-				modeConfigKey:         "fragment",
+				ClientIDConfigKey:     "testclientid",
+				ClientSecretConfigKey: "testsecret",
+				IssuerConfigKey:       "test-issuer",
+				ModeConfigKey:         "fragment",
 			},
 			oidcProvider: &mockOIDCProvider{
 				responseTypesSupported: allResponseTypes,
@@ -449,10 +449,10 @@ func TestBackend(t *testing.T) {
 		},
 		"mode fragment with id_token only and bad nonce": {
 			config: map[string]string{
-				clientIDConfigKey:     "testclientid",
-				clientSecretConfigKey: "testsecret",
-				issuerConfigKey:       "test-issuer",
-				modeConfigKey:         "fragment",
+				ClientIDConfigKey:     "testclientid",
+				ClientSecretConfigKey: "testsecret",
+				IssuerConfigKey:       "test-issuer",
+				ModeConfigKey:         "fragment",
 			},
 			oidcProvider: &mockOIDCProvider{
 				responseTypesSupported: allResponseTypes,
@@ -470,10 +470,10 @@ func TestBackend(t *testing.T) {
 		},
 		"mode fragment with both token and id_token": {
 			config: map[string]string{
-				clientIDConfigKey:     "testclientid",
-				clientSecretConfigKey: "testsecret",
-				issuerConfigKey:       "test-issuer",
-				modeConfigKey:         "fragment",
+				ClientIDConfigKey:     "testclientid",
+				ClientSecretConfigKey: "testsecret",
+				IssuerConfigKey:       "test-issuer",
+				ModeConfigKey:         "fragment",
 			},
 			oidcProvider: &mockOIDCProvider{
 				responseTypesSupported:     allResponseTypes,
@@ -493,10 +493,10 @@ func TestBackend(t *testing.T) {
 		},
 		"mode fragment with both token and id_token and invalid expires_in": {
 			config: map[string]string{
-				clientIDConfigKey:     "testclientid",
-				clientSecretConfigKey: "testsecret",
-				issuerConfigKey:       "test-issuer",
-				modeConfigKey:         "fragment",
+				ClientIDConfigKey:     "testclientid",
+				ClientSecretConfigKey: "testsecret",
+				IssuerConfigKey:       "test-issuer",
+				ModeConfigKey:         "fragment",
 			},
 			oidcProvider: &mockOIDCProvider{
 				responseTypesSupported:     allResponseTypes,
@@ -517,10 +517,10 @@ func TestBackend(t *testing.T) {
 		},
 		"mode fragment with both token and id_token and long expires_in": {
 			config: map[string]string{
-				clientIDConfigKey:     "testclientid",
-				clientSecretConfigKey: "testsecret",
-				issuerConfigKey:       "test-issuer",
-				modeConfigKey:         "fragment",
+				ClientIDConfigKey:     "testclientid",
+				ClientSecretConfigKey: "testsecret",
+				IssuerConfigKey:       "test-issuer",
+				ModeConfigKey:         "fragment",
 			},
 			oidcProvider: &mockOIDCProvider{
 				responseTypesSupported:     allResponseTypes,
@@ -541,10 +541,10 @@ func TestBackend(t *testing.T) {
 		},
 		"mode fragment with both token and id_token and short expires_in": {
 			config: map[string]string{
-				clientIDConfigKey:     "testclientid",
-				clientSecretConfigKey: "testsecret",
-				issuerConfigKey:       "test-issuer",
-				modeConfigKey:         "fragment",
+				ClientIDConfigKey:     "testclientid",
+				ClientSecretConfigKey: "testsecret",
+				IssuerConfigKey:       "test-issuer",
+				ModeConfigKey:         "fragment",
 			},
 			oidcProvider: &mockOIDCProvider{
 				responseTypesSupported:     allResponseTypes,
@@ -565,10 +565,10 @@ func TestBackend(t *testing.T) {
 		},
 		"mode fragment with both token and id_token, and userinfo endpoint failure": {
 			config: map[string]string{
-				clientIDConfigKey:     "testclientid",
-				clientSecretConfigKey: "testsecret",
-				issuerConfigKey:       "test-issuer",
-				modeConfigKey:         "fragment",
+				ClientIDConfigKey:     "testclientid",
+				ClientSecretConfigKey: "testsecret",
+				IssuerConfigKey:       "test-issuer",
+				ModeConfigKey:         "fragment",
 			},
 			oidcProvider: &mockOIDCProvider{
 				responseTypesSupported:     allResponseTypes,
@@ -589,10 +589,10 @@ func TestBackend(t *testing.T) {
 		},
 		"legacy no mode setting, equal to fragment, with access token only": {
 			config: map[string]string{
-				clientIDConfigKey:     "testclientid",
-				clientSecretConfigKey: "testsecret",
-				issuerConfigKey:       "test-issuer",
-				modeConfigKey:         "",
+				ClientIDConfigKey:     "testclientid",
+				ClientSecretConfigKey: "testsecret",
+				IssuerConfigKey:       "test-issuer",
+				ModeConfigKey:         "",
 			},
 			oidcProvider: &mockOIDCProvider{
 				responseTypesSupported:     allResponseTypes,
@@ -604,10 +604,10 @@ func TestBackend(t *testing.T) {
 				responseMode:  "fragment",
 				responseTypes: []string{"token", "id_token"},
 				config: map[string]string{
-					clientIDConfigKey:     "testclientid",
-					clientSecretConfigKey: "testsecret",
-					issuerConfigKey:       "https://test-issuer",
-					modeConfigKey:         "fragment",
+					ClientIDConfigKey:     "testclientid",
+					ClientSecretConfigKey: "testsecret",
+					IssuerConfigKey:       "https://test-issuer",
+					ModeConfigKey:         "fragment",
 				},
 			},
 			idpResponseTemplate: map[string]responseValueProvider{
@@ -616,10 +616,10 @@ func TestBackend(t *testing.T) {
 		},
 		"mode auto, error due to no response types": {
 			config: map[string]string{
-				clientIDConfigKey:     "testclientid",
-				clientSecretConfigKey: "testsecret",
-				issuerConfigKey:       "test-issuer",
-				modeConfigKey:         "auto",
+				ClientIDConfigKey:     "testclientid",
+				ClientSecretConfigKey: "testsecret",
+				IssuerConfigKey:       "test-issuer",
+				ModeConfigKey:         "auto",
 			},
 			oidcProvider: &mockOIDCProvider{
 				responseTypesSupported: []string{"code"},
@@ -629,10 +629,10 @@ func TestBackend(t *testing.T) {
 		},
 		"mode auto, with client secret, form post mode result": {
 			config: map[string]string{
-				clientIDConfigKey:     "testclientid",
-				clientSecretConfigKey: "testsecret",
-				issuerConfigKey:       "test-issuer",
-				modeConfigKey:         "auto",
+				ClientIDConfigKey:     "testclientid",
+				ClientSecretConfigKey: "testsecret",
+				IssuerConfigKey:       "test-issuer",
+				ModeConfigKey:         "auto",
 			},
 			oidcProvider: &mockOIDCProvider{
 				responseTypesSupported: allResponseTypes,
@@ -642,10 +642,10 @@ func TestBackend(t *testing.T) {
 				responseMode:  "form_post",
 				responseTypes: []string{"code"},
 				config: map[string]string{
-					clientIDConfigKey:     "testclientid",
-					clientSecretConfigKey: "testsecret",
-					issuerConfigKey:       "https://test-issuer",
-					modeConfigKey:         "post",
+					ClientIDConfigKey:     "testclientid",
+					ClientSecretConfigKey: "testsecret",
+					IssuerConfigKey:       "https://test-issuer",
+					ModeConfigKey:         "post",
 				},
 			},
 			issueNonce: true,
@@ -656,10 +656,10 @@ func TestBackend(t *testing.T) {
 		},
 		"mode auto, with client secret, non-code and non-post mode result": {
 			config: map[string]string{
-				clientIDConfigKey:     "testclientid",
-				clientSecretConfigKey: "testsecret",
-				issuerConfigKey:       "test-issuer",
-				modeConfigKey:         "auto",
+				ClientIDConfigKey:     "testclientid",
+				ClientSecretConfigKey: "testsecret",
+				IssuerConfigKey:       "test-issuer",
+				ModeConfigKey:         "auto",
 			},
 			oidcProvider: &mockOIDCProvider{
 				responseTypesSupported:     []string{"token", "id_token", "token id_token"},
@@ -671,10 +671,10 @@ func TestBackend(t *testing.T) {
 				responseMode:  "fragment",
 				responseTypes: []string{"token", "id_token"},
 				config: map[string]string{
-					clientIDConfigKey:     "testclientid",
-					clientSecretConfigKey: "testsecret",
-					issuerConfigKey:       "https://test-issuer",
-					modeConfigKey:         "fragment",
+					ClientIDConfigKey:     "testclientid",
+					ClientSecretConfigKey: "testsecret",
+					IssuerConfigKey:       "https://test-issuer",
+					ModeConfigKey:         "fragment",
 				},
 			},
 			idpResponseTemplate: map[string]responseValueProvider{
@@ -683,10 +683,10 @@ func TestBackend(t *testing.T) {
 		},
 		"mode auto, with client secret, code with non-post mode result": {
 			config: map[string]string{
-				clientIDConfigKey:     "testclientid",
-				clientSecretConfigKey: "testsecret",
-				issuerConfigKey:       "test-issuer",
-				modeConfigKey:         "auto",
+				ClientIDConfigKey:     "testclientid",
+				ClientSecretConfigKey: "testsecret",
+				IssuerConfigKey:       "test-issuer",
+				ModeConfigKey:         "auto",
 			},
 			oidcProvider: &mockOIDCProvider{
 				responseTypesSupported:     []string{"code", "token", "id_token", "token id_token"},
@@ -698,10 +698,10 @@ func TestBackend(t *testing.T) {
 				responseMode:  "query",
 				responseTypes: []string{"code"},
 				config: map[string]string{
-					clientIDConfigKey:     "testclientid",
-					clientSecretConfigKey: "testsecret",
-					issuerConfigKey:       "https://test-issuer",
-					modeConfigKey:         "query",
+					ClientIDConfigKey:     "testclientid",
+					ClientSecretConfigKey: "testsecret",
+					IssuerConfigKey:       "https://test-issuer",
+					ModeConfigKey:         "query",
 				},
 				baseOauthConfig: &oauth2.Config{
 					ClientID:     "testclientid",
@@ -722,11 +722,11 @@ func TestBackend(t *testing.T) {
 		},
 		"mode auto, no client secret": {
 			config: map[string]string{
-				clientIDConfigKey:            "testclientid",
-				clientSecretConfigKey:        "",
-				dontUseClientSecretConfigKey: "true",
-				issuerConfigKey:              "https://test-issuer",
-				modeConfigKey:                "",
+				ClientIDConfigKey:            "testclientid",
+				ClientSecretConfigKey:        "",
+				DontUseClientSecretConfigKey: "true",
+				IssuerConfigKey:              "https://test-issuer",
+				ModeConfigKey:                "",
 			},
 			oidcProvider: &mockOIDCProvider{
 				responseTypesSupported:     allResponseTypes,
@@ -744,11 +744,11 @@ func TestBackend(t *testing.T) {
 		},
 		"mode auto, with client secret, disable offline_access scope": {
 			config: map[string]string{
-				clientIDConfigKey:                  "testclientid",
-				clientSecretConfigKey:              "testsecret",
-				issuerConfigKey:                    "https://test-issuer",
-				modeConfigKey:                      "",
-				disableOfflineAccessScopeConfigKey: "true",
+				ClientIDConfigKey:                  "testclientid",
+				ClientSecretConfigKey:              "testsecret",
+				IssuerConfigKey:                    "https://test-issuer",
+				ModeConfigKey:                      "",
+				DisableOfflineAccessScopeConfigKey: "true",
 			},
 			oidcProvider: &mockOIDCProvider{
 				responseTypesSupported:     allResponseTypes,
@@ -776,11 +776,11 @@ func TestBackend(t *testing.T) {
 		},
 		"unauthorized client error from idp": {
 			config: map[string]string{
-				clientIDConfigKey:            "testclientid",
-				clientSecretConfigKey:        "testsecret",
-				dontUseClientSecretConfigKey: "true",
-				issuerConfigKey:              "https://test-issuer",
-				modeConfigKey:                "auto",
+				ClientIDConfigKey:            "testclientid",
+				ClientSecretConfigKey:        "testsecret",
+				DontUseClientSecretConfigKey: "true",
+				IssuerConfigKey:              "https://test-issuer",
+				ModeConfigKey:                "auto",
 			},
 			oidcProvider: &mockOIDCProvider{
 				responseTypesSupported: allResponseTypes,
@@ -800,11 +800,11 @@ func TestBackend(t *testing.T) {
 		},
 		"error from idp without description": {
 			config: map[string]string{
-				clientIDConfigKey:            "testclientid",
-				clientSecretConfigKey:        "testsecret",
-				dontUseClientSecretConfigKey: "true",
-				issuerConfigKey:              "https://test-issuer",
-				modeConfigKey:                "auto",
+				ClientIDConfigKey:            "testclientid",
+				ClientSecretConfigKey:        "testsecret",
+				DontUseClientSecretConfigKey: "true",
+				IssuerConfigKey:              "https://test-issuer",
+				ModeConfigKey:                "auto",
 			},
 			oidcProvider: &mockOIDCProvider{
 				responseTypesSupported: allResponseTypes,
@@ -821,11 +821,11 @@ func TestBackend(t *testing.T) {
 		},
 		"error from idp with description": {
 			config: map[string]string{
-				clientIDConfigKey:            "testclientid",
-				clientSecretConfigKey:        "testsecret",
-				dontUseClientSecretConfigKey: "true",
-				issuerConfigKey:              "https://test-issuer",
-				modeConfigKey:                "auto",
+				ClientIDConfigKey:            "testclientid",
+				ClientSecretConfigKey:        "testsecret",
+				DontUseClientSecretConfigKey: "true",
+				IssuerConfigKey:              "https://test-issuer",
+				ModeConfigKey:                "auto",
 			},
 			oidcProvider: &mockOIDCProvider{
 				responseTypesSupported: allResponseTypes,

--- a/pkg/declarativeconfig/auth_provider.go
+++ b/pkg/declarativeconfig/auth_provider.go
@@ -34,7 +34,7 @@ type OIDCConfig struct {
 // SAMLConfig contains config values for SAML 2.0 auth provider.
 // There are two ways to configure SAML: static and dynamic.
 // For dynamic configuration, you only need to specify spIssuer and metadataURL.
-// For static configuration, specify spIssuer, cert, ssoURL and nameIdFormat.
+// For static configuration, specify spIssuer, cert, ssoURL, idpIssuer, and nameIdFormat.
 type SAMLConfig struct {
 	SpIssuer    string `yaml:"spIssuer,omitempty"`
 	MetadataURL string `yaml:"metadataURL,omitempty"`
@@ -42,6 +42,7 @@ type SAMLConfig struct {
 	Cert         string `yaml:"cert,omitempty"`
 	SsoURL       string `yaml:"ssoURL,omitempty"`
 	NameIDFormat string `yaml:"nameIdFormat,omitempty"`
+	IDPIssuer    string `yaml:"idpIssuer,omitempty"`
 }
 
 // IAPConfig contains config values for IAP auth provider.

--- a/pkg/declarativeconfig/transform/auth_provider.go
+++ b/pkg/declarativeconfig/transform/auth_provider.go
@@ -1,0 +1,151 @@
+package transform
+
+import (
+	"fmt"
+	"reflect"
+	"strconv"
+
+	"github.com/gogo/protobuf/proto"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/auth/authproviders/iap"
+	"github.com/stackrox/rox/pkg/auth/authproviders/oidc"
+	"github.com/stackrox/rox/pkg/auth/authproviders/openshift"
+	"github.com/stackrox/rox/pkg/auth/authproviders/saml"
+	"github.com/stackrox/rox/pkg/auth/authproviders/userpki"
+	"github.com/stackrox/rox/pkg/declarativeconfig"
+	"github.com/stackrox/rox/pkg/errox"
+)
+
+var _ Transformer = (*authProviderTransform)(nil)
+
+type authProviderTransform struct{}
+
+func newAuthProviderTransformer() *authProviderTransform {
+	return &authProviderTransform{}
+}
+
+func (a *authProviderTransform) Transform(configuration declarativeconfig.Configuration) (map[reflect.Type][]proto.Message, error) {
+	authProviderConfig, ok := configuration.(*declarativeconfig.AuthProvider)
+	if !ok {
+		return nil, errox.InvalidArgs.Newf("invalid configuration type received for auth provider: %T", configuration)
+	}
+	authProviderProto := &storage.AuthProvider{
+		Id:                 declarativeconfig.NewDeclarativeAuthProviderUUID(authProviderConfig.Name).String(),
+		Name:               authProviderConfig.Name,
+		Type:               getType(authProviderConfig),
+		UiEndpoint:         authProviderConfig.UIEndpoint,
+		Enabled:            true,
+		Config:             getConfig(authProviderConfig),
+		LoginUrl:           "/sso/login/" + declarativeconfig.NewDeclarativeAuthProviderUUID(authProviderConfig.Name).String(),
+		Active:             true,
+		RequiredAttributes: getRequiredAttributes(authProviderConfig.RequiredAttributes),
+		Traits: &storage.Traits{
+			Origin: storage.Traits_DECLARATIVE,
+		},
+		ClaimMappings: getClaimMappings(authProviderConfig.ClaimMappings),
+	}
+	return map[reflect.Type][]proto.Message{
+		reflect.TypeOf((*storage.AuthProvider)(nil)): {authProviderProto},
+		reflect.TypeOf((*storage.Group)(nil)):        getGroups(authProviderProto.Id, authProviderConfig),
+	}, nil
+}
+
+func getType(authProviderConfig *declarativeconfig.AuthProvider) string {
+	switch {
+	case authProviderConfig.OIDCConfig != nil:
+		return oidc.TypeName
+	case authProviderConfig.IAPConfig != nil:
+		return iap.TypeName
+	case authProviderConfig.SAMLConfig != nil:
+		return saml.TypeName
+	case authProviderConfig.UserpkiConfig != nil:
+		return userpki.TypeName
+	case authProviderConfig.OpenshiftConfig != nil && authProviderConfig.OpenshiftConfig.Enable:
+		return openshift.TypeName
+	default:
+		return ""
+	}
+}
+
+func getConfig(authProviderConfig *declarativeconfig.AuthProvider) map[string]string {
+	switch getType(authProviderConfig) {
+	case oidc.TypeName:
+		return map[string]string{
+			oidc.IssuerConfigKey:                    authProviderConfig.OIDCConfig.Issuer,
+			oidc.ModeConfigKey:                      authProviderConfig.OIDCConfig.CallbackMode,
+			oidc.ClientIDConfigKey:                  authProviderConfig.OIDCConfig.ClientID,
+			oidc.ClientSecretConfigKey:              authProviderConfig.OIDCConfig.ClientSecret,
+			oidc.DisableOfflineAccessScopeConfigKey: strconv.FormatBool(authProviderConfig.OIDCConfig.DisableOfflineAccessScope),
+		}
+	case iap.TypeName:
+		return map[string]string{
+			iap.AudienceConfigKey: authProviderConfig.IAPConfig.Audience,
+		}
+	case saml.TypeName:
+		return map[string]string{
+			saml.SpIssuerConfigKey:        authProviderConfig.SAMLConfig.SpIssuer,
+			saml.IDPMetadataURLConfigKey:  authProviderConfig.SAMLConfig.MetadataURL,
+			saml.IDPSSOUrlConfigKey:       authProviderConfig.SAMLConfig.SsoURL,
+			saml.IDPIssuerConfigKey:       authProviderConfig.SAMLConfig.IDPIssuer,
+			saml.IDPCertPemConfigKey:      authProviderConfig.SAMLConfig.Cert,
+			saml.IDPNameIDFormatConfigKey: authProviderConfig.SAMLConfig.NameIDFormat,
+		}
+	case userpki.TypeName:
+		return map[string]string{
+			userpki.ConfigKeys: authProviderConfig.UserpkiConfig.CertificateAuthorities,
+		}
+	case openshift.TypeName:
+		return map[string]string{}
+	default:
+		return nil
+	}
+}
+
+func getRequiredAttributes(requiredAttributesConfig []declarativeconfig.RequiredAttribute) []*storage.AuthProvider_RequiredAttribute {
+	requiredAttributes := make([]*storage.AuthProvider_RequiredAttribute, 0, len(requiredAttributesConfig))
+	for _, req := range requiredAttributesConfig {
+		requiredAttributes = append(requiredAttributes, &storage.AuthProvider_RequiredAttribute{
+			AttributeKey:   req.AttributeKey,
+			AttributeValue: req.AttributeValue,
+		})
+	}
+	return requiredAttributes
+}
+
+func getClaimMappings(claimMappingsConfig []declarativeconfig.ClaimMapping) map[string]string {
+	claimMappings := make(map[string]string, len(claimMappingsConfig))
+	for _, mapping := range claimMappingsConfig {
+		claimMappings[mapping.Name] = mapping.Path
+	}
+	return claimMappings
+}
+
+func getGroups(authProviderID string, authProviderConfig *declarativeconfig.AuthProvider) []proto.Message {
+	groups := make([]proto.Message, 0, len(authProviderConfig.Groups)+1)
+
+	groups = append(groups, &storage.Group{
+		Props: &storage.GroupProperties{
+			Id:             declarativeconfig.NewDeclarativeGroupUUID(authProviderConfig.Name + "default").String(),
+			Traits:         &storage.Traits{Origin: storage.Traits_DECLARATIVE},
+			AuthProviderId: authProviderID,
+			Key:            "",
+			Value:          "",
+		},
+		RoleName: authProviderConfig.MinimumRoleName,
+	})
+
+	for id, group := range authProviderConfig.Groups {
+		groups = append(groups, &storage.Group{
+			Props: &storage.GroupProperties{
+				Id:             declarativeconfig.NewDeclarativeGroupUUID(fmt.Sprintf("%s%d", authProviderConfig.Name, id)).String(),
+				Traits:         &storage.Traits{Origin: storage.Traits_DECLARATIVE},
+				AuthProviderId: authProviderID,
+				Key:            group.AttributeKey,
+				Value:          group.AttributeValue,
+			},
+			RoleName: group.RoleName,
+		})
+	}
+
+	return groups
+}

--- a/pkg/declarativeconfig/transform/auth_provider_test.go
+++ b/pkg/declarativeconfig/transform/auth_provider_test.go
@@ -1,0 +1,296 @@
+package transform
+
+import (
+	"fmt"
+	"reflect"
+	"strconv"
+	"testing"
+
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/auth/authproviders/iap"
+	"github.com/stackrox/rox/pkg/auth/authproviders/oidc"
+	"github.com/stackrox/rox/pkg/auth/authproviders/openshift"
+	"github.com/stackrox/rox/pkg/auth/authproviders/saml"
+	"github.com/stackrox/rox/pkg/auth/authproviders/userpki"
+	"github.com/stackrox/rox/pkg/declarativeconfig"
+	"github.com/stackrox/rox/pkg/errox"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWrongConfigurationTypeTransform(t *testing.T) {
+	at := newAuthProviderTransformer()
+	msgs, err := at.Transform(&declarativeconfig.AccessScope{})
+	assert.Nil(t, msgs)
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, errox.InvalidArgs)
+}
+
+func TestGetType(t *testing.T) {
+	cases := map[string]struct {
+		cfg *declarativeconfig.AuthProvider
+		typ string
+	}{
+		"oidc != nil -> oidc type": {
+			cfg: &declarativeconfig.AuthProvider{OIDCConfig: &declarativeconfig.OIDCConfig{}},
+			typ: oidc.TypeName,
+		},
+		"iap != nil -> iap type": {
+			cfg: &declarativeconfig.AuthProvider{IAPConfig: &declarativeconfig.IAPConfig{}},
+			typ: iap.TypeName,
+		},
+		"saml != nil -> saml type": {
+			cfg: &declarativeconfig.AuthProvider{SAMLConfig: &declarativeconfig.SAMLConfig{}},
+			typ: saml.TypeName,
+		},
+		"userpki != nil -> userpki type": {
+			cfg: &declarativeconfig.AuthProvider{UserpkiConfig: &declarativeconfig.UserpkiConfig{}},
+			typ: userpki.TypeName,
+		},
+		"openshift != nil && enabled -> openshift type": {
+			cfg: &declarativeconfig.AuthProvider{OpenshiftConfig: &declarativeconfig.OpenshiftConfig{Enable: true}},
+			typ: openshift.TypeName,
+		},
+		"openshift != nil && !enabled -> empty type": {
+			cfg: &declarativeconfig.AuthProvider{OpenshiftConfig: &declarativeconfig.OpenshiftConfig{}},
+		},
+		"no type set -> empty type": {
+			cfg: &declarativeconfig.AuthProvider{},
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			typ := getType(c.cfg)
+			assert.Equal(t, c.typ, typ)
+		})
+	}
+}
+
+func TestConfig(t *testing.T) {
+	cases := map[string]struct {
+		authProvider *declarativeconfig.AuthProvider
+		cfg          map[string]string
+	}{
+		"no config set -> nil map": {
+			authProvider: &declarativeconfig.AuthProvider{},
+		},
+		"openshift -> empty map": {
+			authProvider: &declarativeconfig.AuthProvider{OpenshiftConfig: &declarativeconfig.OpenshiftConfig{Enable: true}},
+			cfg:          map[string]string{},
+		},
+		"userpki config": {
+			authProvider: &declarativeconfig.AuthProvider{
+				UserpkiConfig: &declarativeconfig.UserpkiConfig{CertificateAuthorities: "some-value"},
+			},
+			cfg: map[string]string{userpki.ConfigKeys: "some-value"},
+		},
+		"saml config with metadata url": {
+			authProvider: &declarativeconfig.AuthProvider{
+				SAMLConfig: &declarativeconfig.SAMLConfig{
+					SpIssuer:    "some-issuer",
+					MetadataURL: "some-metadata-url",
+				},
+			},
+			cfg: map[string]string{
+				saml.SpIssuerConfigKey:        "some-issuer",
+				saml.IDPMetadataURLConfigKey:  "some-metadata-url",
+				saml.IDPSSOUrlConfigKey:       "",
+				saml.IDPIssuerConfigKey:       "",
+				saml.IDPCertPemConfigKey:      "",
+				saml.IDPNameIDFormatConfigKey: "",
+			},
+		},
+		"saml config without metadata url": {
+			authProvider: &declarativeconfig.AuthProvider{
+				SAMLConfig: &declarativeconfig.SAMLConfig{
+					SpIssuer:     "some-issuer",
+					Cert:         "some-cert",
+					SsoURL:       "some-sso-url",
+					NameIDFormat: "some-format",
+					IDPIssuer:    "some-idp-issuer",
+				},
+			},
+			cfg: map[string]string{
+				saml.SpIssuerConfigKey:        "some-issuer",
+				saml.IDPMetadataURLConfigKey:  "",
+				saml.IDPSSOUrlConfigKey:       "some-sso-url",
+				saml.IDPIssuerConfigKey:       "some-idp-issuer",
+				saml.IDPCertPemConfigKey:      "some-cert",
+				saml.IDPNameIDFormatConfigKey: "some-format",
+			},
+		},
+		"iap config": {
+			authProvider: &declarativeconfig.AuthProvider{
+				IAPConfig: &declarativeconfig.IAPConfig{Audience: "some-audience"},
+			},
+			cfg: map[string]string{
+				iap.AudienceConfigKey: "some-audience",
+			},
+		},
+		"oidc config": {
+			authProvider: &declarativeconfig.AuthProvider{
+				OIDCConfig: &declarativeconfig.OIDCConfig{
+					Issuer:                    "some-issuer",
+					CallbackMode:              "auto",
+					ClientID:                  "some-client-id",
+					ClientSecret:              "some-client-secret",
+					DisableOfflineAccessScope: true,
+				},
+			},
+			cfg: map[string]string{
+				oidc.IssuerConfigKey:                    "some-issuer",
+				oidc.ModeConfigKey:                      "auto",
+				oidc.ClientIDConfigKey:                  "some-client-id",
+				oidc.ClientSecretConfigKey:              "some-client-secret",
+				oidc.DisableOfflineAccessScopeConfigKey: "true",
+			},
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			cfg := getConfig(c.authProvider)
+			assert.Equal(t, c.cfg, cfg)
+		})
+	}
+}
+
+func TestTransform(t *testing.T) {
+	// Set everything and the kitchen sink:
+	// - OIDC with all values given.
+	// - multiple required attributes.
+	// - multiple claim mappings.
+	// - multiple groups.
+	authProvider := &declarativeconfig.AuthProvider{
+		Name:            "test-auth-provider",
+		MinimumRoleName: "Analyst",
+		UIEndpoint:      "localhost:8000",
+		Groups: []declarativeconfig.Group{
+			{
+				AttributeKey:   "email",
+				AttributeValue: "someone@something.com",
+				RoleName:       "Admin",
+			},
+			{
+				AttributeKey:   "email",
+				AttributeValue: "somewhere@something.com",
+				RoleName:       "Scope Manager",
+			},
+			{
+				AttributeKey:   "userid",
+				AttributeValue: "12333",
+				RoleName:       "Continous Integration",
+			},
+		},
+		RequiredAttributes: []declarativeconfig.RequiredAttribute{
+			{
+				AttributeKey:   "orgid",
+				AttributeValue: "12345",
+			},
+			{
+				AttributeKey:   "custom_thing",
+				AttributeValue: "some-company",
+			},
+		},
+		ClaimMappings: []declarativeconfig.ClaimMapping{
+			{
+				Path: "some.nested.claim",
+				Name: "custom_thing",
+			},
+			{
+				Path: "another.one",
+				Name: "another_thing",
+			},
+		},
+		OIDCConfig: &declarativeconfig.OIDCConfig{
+			Issuer:                    "http://some-issuer",
+			CallbackMode:              "auto",
+			ClientID:                  "some-client-id",
+			ClientSecret:              "some-client-secret",
+			DisableOfflineAccessScope: true,
+		},
+	}
+	expectedAuthProviderID := declarativeconfig.NewDeclarativeAuthProviderUUID(authProvider.Name).String()
+	expectedConfig := map[string]string{
+		oidc.IssuerConfigKey:                    authProvider.OIDCConfig.Issuer,
+		oidc.ModeConfigKey:                      authProvider.OIDCConfig.CallbackMode,
+		oidc.ClientIDConfigKey:                  authProvider.OIDCConfig.ClientID,
+		oidc.ClientSecretConfigKey:              authProvider.OIDCConfig.ClientSecret,
+		oidc.DisableOfflineAccessScopeConfigKey: strconv.FormatBool(authProvider.OIDCConfig.DisableOfflineAccessScope),
+	}
+	expectedClaimMappings := map[string]string{
+		authProvider.ClaimMappings[0].Name: authProvider.ClaimMappings[0].Path,
+		authProvider.ClaimMappings[1].Name: authProvider.ClaimMappings[1].Path,
+	}
+	expectedRequiredAttributes := []*storage.AuthProvider_RequiredAttribute{
+		{
+			AttributeKey:   authProvider.RequiredAttributes[0].AttributeKey,
+			AttributeValue: authProvider.RequiredAttributes[0].AttributeValue,
+		},
+		{
+			AttributeKey:   authProvider.RequiredAttributes[1].AttributeKey,
+			AttributeValue: authProvider.RequiredAttributes[1].AttributeValue,
+		},
+	}
+
+	transformer := newAuthProviderTransformer()
+	protos, err := transformer.Transform(authProvider)
+	assert.NoError(t, err)
+
+	authProviderType := reflect.TypeOf((*storage.AuthProvider)(nil))
+	require.Contains(t, protos, authProviderType)
+	require.Len(t, protos[authProviderType], 1)
+	authProviderProto, ok := protos[authProviderType][0].(*storage.AuthProvider)
+	require.True(t, ok)
+
+	assert.Equal(t, storage.Traits_DECLARATIVE, authProviderProto.GetTraits().GetOrigin())
+
+	assert.Equal(t, expectedAuthProviderID, authProviderProto.GetId())
+	assert.Equal(t, authProvider.Name, authProviderProto.GetName())
+
+	assert.Equal(t, authProvider.UIEndpoint, authProviderProto.GetUiEndpoint())
+
+	assert.Equal(t, "/sso/login/"+expectedAuthProviderID, authProviderProto.GetLoginUrl())
+
+	assert.Nil(t, authProviderProto.GetExtraUiEndpoints())
+
+	assert.True(t, authProviderProto.GetEnabled())
+	assert.True(t, authProviderProto.GetActive())
+
+	assert.Equal(t, oidc.TypeName, authProviderProto.GetType())
+	assert.Equal(t, expectedConfig, authProviderProto.GetConfig())
+
+	assert.Equal(t, expectedClaimMappings, authProviderProto.GetClaimMappings())
+
+	assert.ElementsMatch(t, expectedRequiredAttributes, authProviderProto.GetRequiredAttributes())
+
+	groupType := reflect.TypeOf((*storage.Group)(nil))
+	require.Contains(t, protos, groupType)
+	require.Len(t, protos[groupType], 4)
+	groupsProto := protos[groupType]
+
+	defaultGroupProto := groupsProto[0]
+	defaultGroup, ok := defaultGroupProto.(*storage.Group)
+	require.True(t, ok)
+	assert.Equal(t, declarativeconfig.NewDeclarativeGroupUUID(authProvider.Name+"default").String(),
+		defaultGroup.GetProps().GetId())
+	assert.Equal(t, authProvider.MinimumRoleName, defaultGroup.GetRoleName())
+	assert.Equal(t, expectedAuthProviderID, defaultGroup.GetProps().GetAuthProviderId())
+	assert.Empty(t, defaultGroup.GetProps().GetKey())
+	assert.Empty(t, defaultGroup.GetProps().GetValue())
+
+	groupsProto = groupsProto[1:]
+
+	for id, groupProto := range groupsProto {
+		group, ok := groupProto.(*storage.Group)
+		require.True(t, ok)
+
+		assert.Equal(t, declarativeconfig.NewDeclarativeGroupUUID(fmt.Sprintf("%s%d", authProvider.Name, id)).String(),
+			group.GetProps().GetId())
+		assert.Equal(t, authProvider.Groups[id].RoleName, group.GetRoleName())
+		assert.Equal(t, expectedAuthProviderID, group.GetProps().GetAuthProviderId())
+		assert.Equal(t, authProvider.Groups[id].AttributeKey, group.GetProps().GetKey())
+		assert.Equal(t, authProvider.Groups[id].AttributeValue, group.GetProps().GetValue())
+	}
+}

--- a/pkg/declarativeconfig/transform/auth_provider_test.go
+++ b/pkg/declarativeconfig/transform/auth_provider_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestWrongConfigurationTypeTransform(t *testing.T) {
+func TestWrongConfigurationTypeTransformAuthProvider(t *testing.T) {
 	at := newAuthProviderTransformer()
 	msgs, err := at.Transform(&declarativeconfig.AccessScope{})
 	assert.Nil(t, msgs)
@@ -24,7 +24,7 @@ func TestWrongConfigurationTypeTransform(t *testing.T) {
 	assert.ErrorIs(t, err, errox.InvalidArgs)
 }
 
-func TestGetType(t *testing.T) {
+func TestGetAuthProviderType(t *testing.T) {
 	cases := map[string]struct {
 		cfg *declarativeconfig.AuthProvider
 		typ string
@@ -74,7 +74,7 @@ func TestGetType(t *testing.T) {
 	}
 }
 
-func TestConfig(t *testing.T) {
+func TestAuthProviderConfig(t *testing.T) {
 	cases := map[string]struct {
 		authProvider *declarativeconfig.AuthProvider
 		cfg          map[string]string
@@ -164,7 +164,7 @@ func TestConfig(t *testing.T) {
 	}
 }
 
-func TestTransform(t *testing.T) {
+func TestTransformAuthProvider(t *testing.T) {
 	// Set everything and the kitchen sink:
 	// - OIDC with all values given.
 	// - multiple required attributes.

--- a/pkg/declarativeconfig/transform/permission_set_test.go
+++ b/pkg/declarativeconfig/transform/permission_set_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestWrongConfigurationTypeTransform(t *testing.T) {
+func TestWrongConfigurationTypeTransformPermissionSet(t *testing.T) {
 	pt := newPermissionSetTransform()
 	protos, err := pt.Transform(&declarativeconfig.AuthProvider{})
 	assert.Nil(t, protos)
@@ -18,7 +18,7 @@ func TestWrongConfigurationTypeTransform(t *testing.T) {
 	assert.ErrorIs(t, err, errox.InvalidArgs)
 }
 
-func TestTransform(t *testing.T) {
+func TestTransformPermissionSet(t *testing.T) {
 	permissionSet := &declarativeconfig.PermissionSet{
 		Name:        "some-permission-set",
 		Description: "with a nice description",

--- a/pkg/declarativeconfig/transform/transformer.go
+++ b/pkg/declarativeconfig/transform/transformer.go
@@ -18,8 +18,8 @@ type Transformer interface {
 // New creates a Transformer that can handle transforming all currently supported declarativeconfig.Configuration.
 func New() Transformer {
 	return &universalTransformer{configurationTransformers: map[string]Transformer{
-		declarativeconfig.AuthProviderConfiguration:  nil,
 		declarativeconfig.AccessScopeConfiguration:   newAccessScopeTransform(),
+		declarativeconfig.AuthProviderConfiguration:  newAuthProviderTransformer(),
 		declarativeconfig.RoleConfiguration:          nil,
 		declarativeconfig.PermissionSetConfiguration: newPermissionSetTransform(),
 	}}


### PR DESCRIPTION
## Description

This PR adds logic to transform a decalartive configuration, specifically the `Auth provider`, to its related proto message.

The `Auth Provider` declarative configuration is unique in the sense that it specifies the `Auth Provider` as well as the `Groups` proto messages.

The `Auth Provider` transformation logic had a few caveats:
- The `config` for each auth provider is a `map[string]string`, however based on the type, different keys should be populated. Some refactorings were required to share the config keys between the transformation logic and the specific auth provider backend.
- The UUID is created deterministically from the name of the auth provider. This will need to be reused in the login URL for the auth provider.
- The `Groups` which are associated with the auth provider will receive their own ID: its a combination of the `Auth provider name` + the `index` of the group in the declarative configuration. The default group is an exception, since it will have the "default" suffix.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

- see unit tests.
