### PR TITLE
[ROX-11612] : Use correct struts image to scan for debug logging

### DIFF
--- a/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
@@ -191,7 +191,7 @@ class DefaultPoliciesTest extends BaseSpecification {
         }
         //TODO ROX-11612 debugging to see if the test fails due to incomplete scan
         if (policyName == "Apache Struts: CVE-2017-5638") {
-            def image = ImageService.scanImage("library/nginx:1.10", true)
+            def image = ImageService.scanImage(STRUTS_DEPLOYMENT.getImage(), true)
             if (!hasApacheStrutsVuln(image)) {
                 log.warn("[ROX-11612] CVE-2017-5638 is absent from image scan")
             }


### PR DESCRIPTION
## Description

Changed the image that was getting scanned to generate debug logs to investigate test failure.

## Checklist
- [ ] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

Not needed

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
