### PR TITLE
ROX-14944: CI: Fix openshift e2e nightly tests

### DIFF
--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -156,9 +156,9 @@ deploy_central_via_operator() {
     customize_envVars=""
     if [[ "${CGO_CHECKS:-}" == "true" ]]; then
         customize_envVars+=$'\n      - name: GODEBUG'
-        customize_envVars+=$'\n        value: 2'
+        customize_envVars+=$'\n        value: "2"'
         customize_envVars+=$'\n      - name: MUTEX_WATCHDOG_TIMEOUT_SECS'
-        customize_envVars+=$'\n        value: 15'
+        customize_envVars+=$'\n        value: "15"'
     fi
     customize_envVars+=$'\n      - name: ROX_BASELINE_GENERATION_DURATION'
     customize_envVars+=$'\n        value: '"${ROX_BASELINE_GENERATION_DURATION}"


### PR DESCRIPTION
## Description

`openshift-*-qa-e2e-tests` have `CGO_CHECKS` enabled. This caused an invalid env var setting.

## Checklist
- [x] Investigated and inspected CI test results - openshift-newest-qa-e2e-tests fail but this is after central is deployed and the same issue as https://srox.slack.com/archives/C030MTTE1S5/p1675771269871469

## Testing Performed

- [x] verify cause with `ci-race-tests` label [broken](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/stackrox_stackrox/4757/pull-ci-stackrox-stackrox-master-openshift-newest-qa-e2e-tests/1622981124189851648)
- [x] fixed