### PR TITLE
ROX-14952: Fix page crash when search results include policy categories

### DIFF
--- a/ui/apps/platform/src/Containers/Search/FilterLinks.tsx
+++ b/ui/apps/platform/src/Containers/Search/FilterLinks.tsx
@@ -20,9 +20,9 @@ function FilterLinks({
     resultCategory,
     searchFilter,
 }: FilterLinksProps): ReactElement {
-    const { filterOn } = searchResultCategoryMap[resultCategory];
+    const { filterOn } = searchResultCategoryMap[resultCategory] ?? {};
 
-    if (filterOn !== null) {
+    if (filterOn) {
         const { filterCategory, filterLinks } = filterOn;
 
         const queryString = getUrlQueryStringForSearchFilter({

--- a/ui/apps/platform/src/Containers/Search/SearchTable.tsx
+++ b/ui/apps/platform/src/Containers/Search/SearchTable.tsx
@@ -30,20 +30,36 @@ function SearchTable({ navCategory, searchFilter, searchResults }: SearchTablePr
     const hasCategoryColumn = navCategory === 'SEARCH_UNSET';
     const hasViewLinkColumn =
         navCategory === 'SEARCH_UNSET' ||
-        searchResultCategoryMap[navCategory].viewLinks.length !== 0;
+        Boolean(searchResultCategoryMap[navCategory]?.viewLinks?.length);
     const hasFilterLinkColumn =
-        navCategory === 'SEARCH_UNSET' || !!searchResultCategoryMap[navCategory].filterOn;
+        navCategory === 'SEARCH_UNSET' || Boolean(searchResultCategoryMap[navCategory]?.filterOn);
 
     const searchResultsFilteredAndSorted =
         navCategory === 'SEARCH_UNSET'
-            ? [...searchResults].sort((a: SearchResult, b: SearchResult) => {
-                  const byName = a.name.localeCompare(b.name);
-                  if (byName === 0) {
+            ? [...searchResults].sort(
+                  (
+                      { name: namePrev, category: categoryPrev }: SearchResult,
+                      { name: nameNext, category: categoryNext }: SearchResult
+                  ) => {
+                      if (namePrev < nameNext) {
+                          return -1;
+                      }
+                      if (namePrev > nameNext) {
+                          return 1;
+                      }
+
                       // If equal by name, secondary sort by category text.
-                      return searchNavMap[a.category].localeCompare(searchNavMap[b.category]);
+                      const categoryNavPrev = searchNavMap[categoryPrev] ?? categoryPrev;
+                      const categoryNavNext = searchNavMap[categoryNext] ?? categoryNext;
+                      if (categoryNavPrev < categoryNavNext) {
+                          return -1;
+                      }
+                      if (categoryNavPrev > categoryNavNext) {
+                          return 1;
+                      }
+                      return 0;
                   }
-                  return byName;
-              })
+              )
             : searchResults
                   .filter(({ category }) => category === navCategory)
                   .sort((a: SearchResult, b: SearchResult) => a.name.localeCompare(b.name));
@@ -84,7 +100,7 @@ function SearchTable({ navCategory, searchFilter, searchResults }: SearchTablePr
                             )}
                             {hasCategoryColumn && (
                                 <Td dataLabel="Category" modifier="nowrap">
-                                    {searchNavMap[category]}
+                                    {searchNavMap[category] ?? category}
                                 </Td>
                             )}
                             {hasViewLinkColumn && (

--- a/ui/apps/platform/src/Containers/Search/ViewLinks.tsx
+++ b/ui/apps/platform/src/Containers/Search/ViewLinks.tsx
@@ -13,9 +13,9 @@ type ViewLinksProps = {
 };
 
 function ViewLinks({ id, resultCategory }: ViewLinksProps): ReactElement {
-    const { viewLinks } = searchResultCategoryMap[resultCategory];
+    const { viewLinks } = searchResultCategoryMap[resultCategory] ?? {};
 
-    if (viewLinks.length !== 0) {
+    if (viewLinks?.length) {
         return (
             <Flex spaceItems={{ default: 'spaceItemsMd' }}>
                 {viewLinks.map(({ basePath, linkText }) => (

--- a/ui/apps/platform/src/Containers/Search/searchCategories.ts
+++ b/ui/apps/platform/src/Containers/Search/searchCategories.ts
@@ -127,6 +127,11 @@ export const searchResultCategoryMap: Record<
             },
         ],
     },
+    POLICY_CATEGORIES: {
+        resourceName: 'Policy',
+        filterOn: null,
+        viewLinks: [],
+    },
     ROLES: {
         resourceName: 'K8sRole',
         filterOn: null,
@@ -182,6 +187,7 @@ export const searchNavMap: Record<SearchNavCategory, string> = {
     NAMESPACES: 'Namespaces',
     NODES: 'Nodes',
     POLICIES: 'Policies',
+    POLICY_CATEGORIES: 'Policy categories',
     ROLES: 'Roles',
     ROLEBINDINGS: 'Role bindings',
     SECRETS: 'Secrets',

--- a/ui/apps/platform/src/services/SearchService.ts
+++ b/ui/apps/platform/src/services/SearchService.ts
@@ -73,6 +73,7 @@ export type SearchResultCategory =
     | 'NAMESPACES'
     | 'NODES'
     | 'POLICIES'
+    | 'POLICY_CATEGORIES'
     | 'ROLES'
     | 'ROLEBINDINGS'
     | 'SECRETS'


### PR DESCRIPTION
## Description

### Problem

Thanks to Boaz for finding sooner rather than later.

Search results can now include `category: POLICY_CATEGORIES` for which there is no property in UI data structures.

Console
![Console](https://user-images.githubusercontent.com/11862657/217292336-76d18096-4ef5-4be6-acf3-ff3bae960b8b.png)

Network
![Network](https://user-images.githubusercontent.com/11862657/217292360-a6616abd-6590-4b73-b826-70b9f423391d.png)

### Solution

1. Test optional chaining and so on without property in data structures to verify that new categories will not cause the page to crash in the future.

2. Add property for policy categories to data structures.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

Manual testing in comparison to stagingdb

Search page does not crash for undefined category
![undefined](https://user-images.githubusercontent.com/11862657/217292539-d47ea6c2-9879-4b8c-9be0-55c91c3debd5.png)

Search page displays defined category
![defined](https://user-images.githubusercontent.com/11862657/217292565-2b6b0f0a-5c32-4c7c-b45e-316f962aff0f.png)
