### PR TITLE
Change future release references from 3.75 and 3.76 to 4.0 and 4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,21 +34,21 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
   - The permission `Access` will deprecate the permissions `Role`.
   - The default role `Scope Manager` will be removed.
 
-- ROX-14400: product `BuildDate` attribute is deprecated and will be removed in `3.75` release. It won't be returned by
+- ROX-14400: product `BuildDate` attribute is deprecated and will be removed in `4.0` release. It won't be returned by
 `/debug/versions.json` endpoint and `roxctl version --json` command.
 
 ### Required Actions
-- The permission `WorkflowAdministration` will replace `Policy, VulnerabilityReports` in permission sets starting with the 3.76 release.
+- The permission `WorkflowAdministration` will replace `Policy, VulnerabilityReports` in permission sets starting with the 4.1 release.
   You should preemptively start replacing the `Policy` and `VulnerabilityReports` resources within your permission sets in favor of `WorkflowAdministration`.
-  During the migration of the permission sets within the 3.76, the `WorfklowAdministration` permission will have the lowest access permission granted for either `Policy` or `VulnerabilityReports`.
-  As an example, a permission set with `WRITE Policy` and `READ VulnerabilityReports` access will have `READ WorkflowAdministration` access after the migration within the 3.76 release, leading to
+  During the migration of the permission sets within the 4.1, the `WorfklowAdministration` permission will have the lowest access permission granted for either `Policy` or `VulnerabilityReports`.
+  As an example, a permission set with `WRITE Policy` and `READ VulnerabilityReports` access will have `READ WorkflowAdministration` access after the migration within the 4.1 release, leading to
   potentially unwanted side-effects and missing access if you did not update your permission sets beforehand.
-- The permission `Access` will replace `Role` in permission sets starting with the 3.76 release. You should preemptively start replacing
-  the `Role` resource within your permission sets in favor of `Access`. During the migration of the permission sets within the 3.76, the
+- The permission `Access` will replace `Role` in permission sets starting with the 4.1 release. You should preemptively start replacing
+  the `Role` resource within your permission sets in favor of `Access`. During the migration of the permission sets within the 4.1, the
   `Access` permission will have the lowest access permission granted for either `Access` or `Role`. As an example, a permission set with
   `READ Access` and `WRITE Role` will have `READ Access` after the migration, leading to potentially unwanted side-effects and missing access
   if the permission sets were not updated beforehand.
-- The default `ScopeManager` role will be removed starting with release 3.76. During the migration, Authentication provider rules referencing that role
+- The default `ScopeManager` role will be removed starting with release 4.1. During the migration, Authentication provider rules referencing that role
   will be updated to use the `None` role. Should Authentication Provider rules reference the `ScopeManager` role for other purposes than
   Vulnerability Report management, a similar role should be manually created and referenced in the Authentication provider rules instead of `ScopeManager`.
 

--- a/central/role/resources/list.go
+++ b/central/role/resources/list.go
@@ -77,41 +77,41 @@ var (
 	// Policy, VulnerabilityReports.
 	WorkflowAdministration = newResourceMetadata("WorkflowAdministration", permissions.GlobalScope)
 
-	// To-be-deprecated in 3.75 with ROX-12750 (deprecation notice in 3.73).
+	// To-be-deprecated in 4.0 with ROX-12750 (deprecation notice in 3.73).
 	AllComments = newDeprecatedResourceMetadata("AllComments", permissions.GlobalScope,
 		Administration)
-	// To-be-deprecated in 3.75 with ROX-12750 (deprecation notice in 3.73).
+	// To-be-deprecated in 4.0 with ROX-12750 (deprecation notice in 3.73).
 	ComplianceRuns = newDeprecatedResourceMetadata("ComplianceRuns", permissions.ClusterScope,
 		Compliance)
-	// To-be-deprecated in 3.75 with ROX-12750 (deprecation notice in 3.73).
+	// To-be-deprecated in 4.0 with ROX-12750 (deprecation notice in 3.73).
 	Config = newDeprecatedResourceMetadata("Config", permissions.GlobalScope,
 		Administration)
-	// To-be-deprecated in 3.75 with ROX-12750 (deprecation notice in 3.73).
+	// To-be-deprecated in 4.0 with ROX-12750 (deprecation notice in 3.73).
 	DebugLogs = newDeprecatedResourceMetadata("DebugLogs", permissions.GlobalScope,
 		Administration)
-	// To-be-deprecated in 3.75 with ROX-12750 (deprecation notice in 3.73).
+	// To-be-deprecated in 4.0 with ROX-12750 (deprecation notice in 3.73).
 	NetworkGraphConfig = newDeprecatedResourceMetadata("NetworkGraphConfig",
 		permissions.GlobalScope, Administration)
-	// To-be-deprecated in 3.76 with ROX-13888 (deprecation notice in 3.74).
+	// To-be-deprecated in 4.1 with ROX-13888 (deprecation notice in 3.74).
 	Policy = newDeprecatedResourceMetadata("Policy", permissions.GlobalScope, WorkflowAdministration)
-	// To-be-deprecated in 3.75 with ROX-12750 (deprecation notice in 3.73).
+	// To-be-deprecated in 4.0 with ROX-12750 (deprecation notice in 3.73).
 	ProbeUpload = newDeprecatedResourceMetadata("ProbeUpload", permissions.GlobalScope,
 		Administration)
-	// To-be-deprecated in 3.76 with ROX-14398 (deprecation notice in 3.74).
+	// To-be-deprecated in 4.1 with ROX-14398 (deprecation notice in 3.74).
 	Role = newDeprecatedResourceMetadata("Role", permissions.GlobalScope, Access)
-	// To-be-deprecated in 3.75 with ROX-12750 (deprecation notice in 3.73).
+	// To-be-deprecated in 4.0 with ROX-12750 (deprecation notice in 3.73).
 	ScannerBundle = newDeprecatedResourceMetadata("ScannerBundle",
 		permissions.GlobalScope, Administration)
-	// To-be-deprecated in 3.75 with ROX-12750 (deprecation notice in 3.73).
+	// To-be-deprecated in 4.0 with ROX-12750 (deprecation notice in 3.73).
 	ScannerDefinitions = newDeprecatedResourceMetadata("ScannerDefinitions",
 		permissions.GlobalScope, Administration)
-	// To-be-deprecated in 3.75 with ROX-12750 (deprecation notice in 3.73).
+	// To-be-deprecated in 4.0 with ROX-12750 (deprecation notice in 3.73).
 	SensorUpgradeConfig = newDeprecatedResourceMetadata("SensorUpgradeConfig",
 		permissions.GlobalScope, Administration)
-	// To-be-deprecated in 3.75 with ROX-12750 (deprecation notice in 3.73).
+	// To-be-deprecated in 4.0 with ROX-12750 (deprecation notice in 3.73).
 	ServiceIdentity = newDeprecatedResourceMetadata("ServiceIdentity",
 		permissions.GlobalScope, Administration)
-	// To-be-deprecated in 3.76 with ROX-13888 (deprecation notice in 3.74).
+	// To-be-deprecated in 4.1 with ROX-13888 (deprecation notice in 3.74).
 	VulnerabilityReports = newDeprecatedResourceMetadata("VulnerabilityReports", permissions.GlobalScope,
 		WorkflowAdministration)
 

--- a/pkg/buildinfo/buildinfo.go
+++ b/pkg/buildinfo/buildinfo.go
@@ -22,7 +22,7 @@ const (
 // BuildTimestamp returns the time when this build was created.
 // CAVEAT: This function panics if no build timestamp information is available.
 //
-// Deprecated: It will be removed in 3.75. Please do not use it.
+// Deprecated: It will be removed in 4.0. Please do not use it.
 // TODO(ROX-14336): delete it
 func BuildTimestamp() time.Time {
 	if timestamp.BuildTimestampParsingErr != nil {

--- a/pkg/buildinfo/internal/timestamp/timestamp.go
+++ b/pkg/buildinfo/internal/timestamp/timestamp.go
@@ -9,11 +9,11 @@ var (
 	buildTimestampUnixSecs string //XDef:BUILD_TIMESTAMP
 
 	// BuildTimestamp is the time when this binary was built.
-	// Deprecated: It will be removed in 3.75. Please do not use it.
+	// Deprecated: It will be removed in 4.0. Please do not use it.
 	// TODO(ROX-14336): delete it
 	BuildTimestamp time.Time
 	// BuildTimestampParsingErr is the error encountered when parsing the build timestamp (if any).
-	// Deprecated: It will be removed in 3.75. Please do not use it.
+	// Deprecated: It will be removed in 4.0. Please do not use it.
 	// TODO(ROX-14336): delete it
 	BuildTimestampParsingErr error
 )

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -29,7 +29,7 @@ func getCollectorVersion() string {
 
 // Versions represents a collection of various pieces of version information.
 type Versions struct {
-	// Deprecated: BuildDate will be removed in 3.75. Please do not use it.
+	// Deprecated: BuildDate will be removed in 4.0. Please do not use it.
 	// TODO(ROX-14336): delete it
 	BuildDate time.Time `json:"BuildDate"`
 	// CollectorVersion is exported for compatibility with users that depend on `roxctl version --json` output.

--- a/ui/apps/platform/src/constants/accessControl.ts
+++ b/ui/apps/platform/src/constants/accessControl.ts
@@ -110,17 +110,17 @@ export const resourceSubstitutions: Record<string, string[]> = {
 // TODO: ROX-13888 Remove Policy, VulnerabilityReports.
 // TODO: ROX-12750 update with new list of replaced/deprecated resources
 export const resourceRemovalReleaseVersions = new Map<ResourceName, string>([
-    ['AllComments', '3.75'],
-    ['ComplianceRuns', '3.75'],
-    ['Config', '3.75'],
-    ['DebugLogs', '3.75'],
-    ['NetworkGraphConfig', '3.75'],
-    ['ProbeUpload', '3.75'],
-    ['ScannerBundle', '3.75'],
-    ['ScannerDefinitions', '3.75'],
-    ['SensorUpgradeConfig', '3.75'],
-    ['ServiceIdentity', '3.75'],
-    ['VulnerabilityReports', '3.76'],
+    ['AllComments', '4.0'],
+    ['ComplianceRuns', '4.0'],
+    ['Config', '4.0'],
+    ['DebugLogs', '4.0'],
+    ['NetworkGraphConfig', '4.0'],
+    ['ProbeUpload', '4.0'],
+    ['ScannerBundle', '4.0'],
+    ['ScannerDefinitions', '4.0'],
+    ['SensorUpgradeConfig', '4.0'],
+    ['ServiceIdentity', '4.0'],
+    ['VulnerabilityReports', '4.1'],
 ]);
 
 // TODO(ROX-11453): Remove this mapping once the old resources are fully deprecated.


### PR DESCRIPTION
## Description

Following the name change of the future releases, references to these was updated in Changelog, UI and code comments.

## Checklist
- [ ] Investigated and inspected CI test results
~~- [ ] Unit test and regression tests added~~
~~- [ ] Evaluated and added CHANGELOG entry if required~~
~~- [ ] Determined and documented upgrade steps~~
~~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

Manual testing:
- Open the Changelog and check for references to future releases by their versions.

- Deploy an instance, open the UI on Access Control, view an existing permission set, create another one, and check the permission deprecation releases.