### PR TITLE
ROX-14953: Fix invalid kubectl files within roxctl generate

### DIFF
--- a/pkg/renderer/kubernetes.go
+++ b/pkg/renderer/kubernetes.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stackrox/rox/pkg/images/defaults"
 	imageUtils "github.com/stackrox/rox/pkg/images/utils"
 	kubernetesPkg "github.com/stackrox/rox/pkg/kubernetes"
+	"github.com/stackrox/rox/pkg/sliceutils"
 	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/rox/pkg/zip"
 )
@@ -102,6 +103,15 @@ func postProcessConfig(c *Config, mode mode, imageFlavor defaults.ImageFlavor) e
 			return err
 		}
 	}
+
+	// Currently, when the K8S config is generated through interactive mode, the configuration flags will be called twice.
+	// This doesn't affect single value configurations, like booleans and strings, but slices.
+	// TODO(ROX-14956):Once the duplication of flag values is removed, this can be removed.
+	c.K8sConfig.DeclarativeConfigMounts.ConfigMaps = sliceutils.Unique(c.K8sConfig.DeclarativeConfigMounts.ConfigMaps)
+	c.K8sConfig.DeclarativeConfigMounts.Secrets = sliceutils.Unique(c.K8sConfig.DeclarativeConfigMounts.Secrets)
+	// Additionally, the default value used by the configuration for empty arrays is "[]", which we will have to remove.
+	c.K8sConfig.DeclarativeConfigMounts.ConfigMaps = sliceutils.Without(c.K8sConfig.DeclarativeConfigMounts.ConfigMaps, []string{"[]"})
+	c.K8sConfig.DeclarativeConfigMounts.Secrets = sliceutils.Without(c.K8sConfig.DeclarativeConfigMounts.Secrets, []string{"[]"})
 
 	return nil
 }

--- a/pkg/renderer/render_test.go
+++ b/pkg/renderer/render_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -145,6 +146,158 @@ func TestRenderWithDeclarativeConfig(t *testing.T) {
 	}
 }
 
+func TestRenderDeclarativeConfigEmpty(t *testing.T) {
+	flavor := testutils.MakeImageFlavorForTest(t)
+	cases := map[string]Config{
+		"empty declarative config mounts": {
+			SecretsByteMap: map[string][]byte{
+				"ca.pem":              []byte("CA"),
+				"ca-key.pem":          []byte("CAKey"),
+				"cert.pem":            []byte("CentralCert"),
+				"key.pem":             []byte("CentralKey"),
+				"scanner-cert.pem":    []byte("ScannerCert"),
+				"scanner-key.pem":     []byte("ScannerKey"),
+				"scanner-db-cert.pem": []byte("ScannerDBCert"),
+				"scanner-db-key.pem":  []byte("ScannerDBKey"),
+				"jwt-key.pem":         []byte("JWTKey"),
+			},
+			K8sConfig: &K8sConfig{
+				CommonConfig: CommonConfig{
+					MainImage:      flavor.MainImage(),
+					ScannerImage:   flavor.ScannerImage(),
+					ScannerDBImage: flavor.ScannerDBImage(),
+				},
+				DeploymentFormat: v1.DeploymentFormat_KUBECTL,
+			},
+		},
+		"empty literal [] in declarative config mounts": {
+			SecretsByteMap: map[string][]byte{
+				"ca.pem":              []byte("CA"),
+				"ca-key.pem":          []byte("CAKey"),
+				"cert.pem":            []byte("CentralCert"),
+				"key.pem":             []byte("CentralKey"),
+				"scanner-cert.pem":    []byte("ScannerCert"),
+				"scanner-key.pem":     []byte("ScannerKey"),
+				"scanner-db-cert.pem": []byte("ScannerDBCert"),
+				"scanner-db-key.pem":  []byte("ScannerDBKey"),
+				"jwt-key.pem":         []byte("JWTKey"),
+			},
+			K8sConfig: &K8sConfig{
+				CommonConfig: CommonConfig{
+					MainImage:      flavor.MainImage(),
+					ScannerImage:   flavor.ScannerImage(),
+					ScannerDBImage: flavor.ScannerDBImage(),
+				},
+				DeploymentFormat: v1.DeploymentFormat_KUBECTL,
+			},
+		},
+		"nil array in declarative config mounts": {
+			SecretsByteMap: map[string][]byte{
+				"ca.pem":              []byte("CA"),
+				"ca-key.pem":          []byte("CAKey"),
+				"cert.pem":            []byte("CentralCert"),
+				"key.pem":             []byte("CentralKey"),
+				"scanner-cert.pem":    []byte("ScannerCert"),
+				"scanner-key.pem":     []byte("ScannerKey"),
+				"scanner-db-cert.pem": []byte("ScannerDBCert"),
+				"scanner-db-key.pem":  []byte("ScannerDBKey"),
+				"jwt-key.pem":         []byte("JWTKey"),
+			},
+			K8sConfig: &K8sConfig{
+				CommonConfig: CommonConfig{
+					MainImage:      flavor.MainImage(),
+					ScannerImage:   flavor.ScannerImage(),
+					ScannerDBImage: flavor.ScannerDBImage(),
+				},
+				DeploymentFormat: v1.DeploymentFormat_KUBECTL,
+				DeclarativeConfigMounts: DeclarativeConfigMounts{
+					ConfigMaps: nil,
+					Secrets:    nil,
+				},
+			},
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			files, err := render(c, renderAll, flavor)
+			assert.NoError(t, err)
+
+			centralFile := filterCentralFile(files)
+			require.NotNil(t, centralFile)
+
+			deployment := getCentralDeployment(t, centralFile)
+
+			// We currently assume only a single container is part of the central deployment.
+			volumeMounts := deployment.Spec.Template.Spec.Containers[0].VolumeMounts
+
+			volumes := deployment.Spec.Template.Spec.Volumes
+
+			// Previously, the literal value of "[]" was used as mount name.
+			volumeNames := make([]string, 0, len(volumes))
+			for _, volume := range volumes {
+				volumeNames = append(volumeNames, volume.Name)
+			}
+			assert.NotContains(t, volumeNames, "[]")
+
+			// No volume mount should exist that starts with the declarative confiugration mount path.
+			for _, mount := range volumeMounts {
+				assert.False(t, strings.HasPrefix(mount.MountPath, "/run/stackrox.io/declarative-configuration"))
+			}
+		})
+	}
+}
+
+func TestDeclarativeConfigDuplicateValues(t *testing.T) {
+	flavor := testutils.MakeImageFlavorForTest(t)
+	config := Config{
+		SecretsByteMap: map[string][]byte{
+			"ca.pem":              []byte("CA"),
+			"ca-key.pem":          []byte("CAKey"),
+			"cert.pem":            []byte("CentralCert"),
+			"key.pem":             []byte("CentralKey"),
+			"scanner-cert.pem":    []byte("ScannerCert"),
+			"scanner-key.pem":     []byte("ScannerKey"),
+			"scanner-db-cert.pem": []byte("ScannerDBCert"),
+			"scanner-db-key.pem":  []byte("ScannerDBKey"),
+			"jwt-key.pem":         []byte("JWTKey"),
+		},
+		K8sConfig: &K8sConfig{
+			CommonConfig: CommonConfig{
+				MainImage:      flavor.MainImage(),
+				ScannerImage:   flavor.ScannerImage(),
+				ScannerDBImage: flavor.ScannerDBImage(),
+			},
+			DeploymentFormat: v1.DeploymentFormat_KUBECTL,
+			DeclarativeConfigMounts: DeclarativeConfigMounts{
+				ConfigMaps: []string{"cm-1", "cm-1", "cm-3", "cm-4"},
+				Secrets:    []string{"sec-1", "sec-2", "sec-3", "sec-3"},
+			},
+		},
+	}
+
+	files, err := render(config, renderAll, flavor)
+	assert.NoError(t, err)
+
+	centralFile := filterCentralFile(files)
+	require.NotNil(t, centralFile)
+
+	deployment := getCentralDeployment(t, centralFile)
+
+	volumes, mounts := getDeclarativeConfigVolumes(deployment)
+
+	expectedVolumes := []string{"cm-1", "cm-3", "cm-4", "sec-1", "sec-2", "sec-3"}
+
+	assert.Equal(t, volumes, len(expectedVolumes))
+	assert.Equal(t, mounts, len(expectedVolumes))
+	for _, mount := range mounts {
+		assert.Contains(t, expectedVolumes, mount.Name)
+	}
+	for _, volume := range volumes {
+		assert.Contains(t, expectedVolumes, volume.Name)
+	}
+}
+
 func filterCentralFile(files []*zip.File) *zip.File {
 	for _, f := range files {
 		if f.Name == "central/01-central-13-deployment.yaml" {
@@ -152,4 +305,30 @@ func filterCentralFile(files []*zip.File) *zip.File {
 		}
 	}
 	return nil
+}
+
+func getCentralDeployment(t *testing.T, centralFile *zip.File) *appsv1.Deployment {
+	unstructuredObj, err := k8sutil.UnstructuredFromYAML(string(centralFile.Content))
+	require.NoError(t, err)
+	deployment := &appsv1.Deployment{}
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredObj.UnstructuredContent(), deployment)
+	require.NoError(t, err)
+	return deployment
+}
+
+func getDeclarativeConfigVolumes(deployment *appsv1.Deployment) ([]corev1.Volume, []corev1.VolumeMount) {
+	volumes := make(map[string]corev1.Volume, len(deployment.Spec.Template.Spec.Volumes))
+	for _, v := range deployment.Spec.Template.Spec.Volumes {
+		volumes[v.Name] = v
+	}
+	var declarativeVolumeMounts []corev1.VolumeMount
+	var declarativeVolumes []corev1.Volume
+	// We currently assume only a single container is part of the central deployment.
+	for _, mount := range deployment.Spec.Template.Spec.Containers[0].VolumeMounts {
+		if strings.HasPrefix(mount.MountPath, "/run/stackrox.io/declarative-configuration") {
+			declarativeVolumeMounts = append(declarativeVolumeMounts, mount)
+			declarativeVolumes = append(declarativeVolumes, volumes[mount.Name])
+		}
+	}
+	return declarativeVolumes, declarativeVolumeMounts
 }

--- a/pkg/renderer/render_test.go
+++ b/pkg/renderer/render_test.go
@@ -288,8 +288,8 @@ func TestDeclarativeConfigDuplicateValues(t *testing.T) {
 
 	expectedVolumes := []string{"cm-1", "cm-3", "cm-4", "sec-1", "sec-2", "sec-3"}
 
-	assert.Equal(t, volumes, len(expectedVolumes))
-	assert.Equal(t, mounts, len(expectedVolumes))
+	assert.Len(t, volumes, len(expectedVolumes))
+	assert.Len(t, mounts, len(expectedVolumes))
 	for _, mount := range mounts {
 		assert.Contains(t, expectedVolumes, mount.Name)
 	}

--- a/roxctl/central/generate/k8s.go
+++ b/roxctl/central/generate/k8s.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/errox"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/istioutils"
 	"github.com/stackrox/rox/pkg/renderer"
 	"github.com/stackrox/rox/pkg/roxctl"
@@ -107,13 +108,14 @@ func k8sBasedOrchestrator(cliEnvironment environment.Environment, k8sConfig *ren
 	}
 	flagWrap.StringVar(&k8sConfig.ScannerImage, flags.FlagNameScannerImage, "", "scanner image to use"+defaultImageHelp, "scanner")
 	flagWrap.StringVar(&k8sConfig.ScannerDBImage, flags.FlagNameScannerDBImage, "", "scanner-db image to use"+defaultImageHelp, "scanner")
-
 	flagWrap.BoolVar(&k8sConfig.Telemetry.Enabled, "enable-telemetry", false, "whether to enable telemetry", "central")
 
-	flagWrap.StringSliceVar(&k8sConfig.DeclarativeConfigMounts.ConfigMaps, "declarative-config-config-maps", []string{},
-		"list of config maps to add as declarative configuration mounts in central", "central")
-	flagWrap.StringSliceVar(&k8sConfig.DeclarativeConfigMounts.Secrets, "declarative-config-secrets", []string{},
-		"list of secrets to add as declarative configuration mounts in central", "central")
+	if features.DeclarativeConfiguration.Enabled() {
+		flagWrap.StringSliceVar(&k8sConfig.DeclarativeConfigMounts.ConfigMaps, "declarative-config-config-maps", nil,
+			"list of config maps to add as declarative configuration mounts in central", "central")
+		flagWrap.StringSliceVar(&k8sConfig.DeclarativeConfigMounts.Secrets, "declarative-config-secrets", nil,
+			"list of secrets to add as declarative configuration mounts in central", "central")
+	}
 
 	k8sConfig.EnableCentralDB = env.PostgresDatastoreEnabled.BooleanSetting()
 

--- a/tests/roxctl/bats-tests/helpers.bash
+++ b/tests/roxctl/bats-tests/helpers.bash
@@ -126,16 +126,6 @@ assert_helm_template_central_registry() {
   assert_components_registry "$out_dir/rendered/stackrox-central-services/templates" "$registry_slug" "$version_regex" "$@"
 }
 
-assert_declarative_config_mount_exist() {
-  local out_dir="${1}"; shift;
-
-  for mount in "${@}"; do
-    run yq e "select(documentIndex == 0) | .spec.template.spec.containers[] | select(.name == \"central\").volumeMounts[] | select(.name == \"${mount}\")" "${out_dir}/01-central-13-deployment.yaml"
-    assert_output --partial "mountPath: /run/stackrox.io/declarative-configuration/${mount}"
-  done
-}
-
-
 wait_20s_for() {
   local file="$1"; shift
   local args=("${@}")

--- a/tests/roxctl/bats-tests/local/central-generate-development.bats
+++ b/tests/roxctl/bats-tests/local/central-generate-development.bats
@@ -138,10 +138,3 @@ teardown() {
   assert_failure
   assert_output --partial "no such file or directory"
 }
-
-@test "roxctl-development central generate k8s --declarative-config should contain correct mounts" {
-  run_image_defaults_registry_test roxctl-development k8s 'quay.io/rhacs-eng' 'quay.io/rhacs-eng' \
-    '--declarative-config-config-maps' 'config-map-1,config-map-2' \
-    '--declarative-config-secrets' 'secret-1,secret-2'
-  assert_declarative_config_mount_exist "${out_dir}/central" 'config-map-1' 'config-map-2' 'secret-1' 'secret-2'
-}

--- a/tests/roxctl/bats-tests/local/expect/flavor-interactive-dummy.expect.tcl
+++ b/tests/roxctl/bats-tests/local/expect/flavor-interactive-dummy.expect.tcl
@@ -38,13 +38,13 @@ expect {
   "Unexpected value 'dummy', allowed values are*" {
     send "rhacs\n"
     # ensure that the next question is correct after providing a valid answer
-    expect "Enter list*" {
+    expect "Enter the method of exposing Central*" {
       exit 0
     }
     send_user "\nERROR: roxctl accepted 'rhacs' as flavor and generated unexpected question afterwards\n"
     exit 2
   }
-  "Enter list*" {
+  "Enter the method of exposing Central*" {
     send_user "\nERROR: roxctl accepted 'dummy' as flavor and did not ask for correction immediately\n"
     exit 1
   }

--- a/tests/roxctl/bats-tests/local/expect/flavor-interactive-postgres.expect.tcl
+++ b/tests/roxctl/bats-tests/local/expect/flavor-interactive-postgres.expect.tcl
@@ -37,8 +37,8 @@ expect "Enter PEM cert bundle file*" { send "\n" }
 expect "Enter Create PodSecurityPolicy resources*" { send "\n" }
 expect "Enter administrator password*" { send "\n" }
 expect "Enter orchestrator (k8s, openshift)*" { send "k8s\n" }
-expect "Enter default container images settings*" { send "$flavor\n" }
 expect "Enter the directory to output the deployment bundle to*" { send "$out_dir\n" }
+expect "Enter default container images settings*" { send "$flavor\n" }
 
 # Enter central-db image to use (default: "docker.io/stackrox/central-db:2.21.0-15-g448f2dc8fa"):
 # Enter central-db image to use (default: "stackrox.io/central-db:3.67.x-296-g56df6a892d"):
@@ -63,10 +63,8 @@ expect {
     send "\n"
   }
 }
-expect "Enter whether to enable telemetry*" { send "\n" }
-expect "Enter list of secrets*" { send "\n" }
-expect "Enter the method of exposing Central*" { send "none\n" }
 
+expect "Enter the method of exposing Central*" { send "none\n" }
 # Enter main image to use (default: "docker.io/stackrox/main:3.67.x-296-g56df6a892d"):
 # Enter main image to use (default: "stackrox.io/main:3.67.x-296-g56df6a892d")
 # Enter main image to use (default: "registry.redhat.io/advanced-cluster-security/rhacs-main-rhel8:3.68.x-30-g516b4e7a6c-dirty"):
@@ -90,8 +88,10 @@ expect {
     send "\n"
   }
 }
+
+
 expect "Enter whether to run StackRox in offline mode, which avoids reaching out to the Internet*" { send "\n" }
-expect "Enter list of config maps*" { send "\n" }
+expect "Enter whether to enable telemetry*" { send "\n" }
 expect "Enter the deployment tool to use (kubectl, helm, helm-values)*:" { send "\n" }
 expect "Enter Istio version when deploying into an Istio-enabled cluster*:" { send "\n" }
 

--- a/tests/roxctl/bats-tests/local/expect/flavor-interactive.expect.tcl
+++ b/tests/roxctl/bats-tests/local/expect/flavor-interactive.expect.tcl
@@ -42,10 +42,6 @@ expect "Enter administrator password*" { send "\n" }
 expect "Enter orchestrator (k8s, openshift)*" { send "k8s\n" }
 expect "Enter the directory to output the deployment bundle to*" { send "$out_dir\n" }
 expect "Enter default container images settings*" { send "$flavor\n" }
-# Enter list of config maps for declarative configuration.
-# Enter list of secrets for declarative configuration
-expect "Enter list of config maps*" { send "\n"}
-expect "Enter list of secrets*" { send "\n"}
 expect "Enter the method of exposing Central*" { send "none\n" }
 
 # Enter main image to use (default: "docker.io/stackrox/main:3.67.x-296-g56df6a892d"):


### PR DESCRIPTION
## Description

This PR fixes an issue when trying to generate kubectl files for central and using the default values.

Specifically, the declarative configuration default values are the culprit.

Leaving the values as:
```
Enter list of config maps to add as declarative configuration mounts in central (default: "[]"):
Enter list of secrets to add as declarative configuration mounts in central (default: "[]"):
```

will lead to the following created mounts:
```
name: []
mountPath: /run/stackrox.io/declarative-configuration/[]
readOnly: true
name: []
mountPath: /run/stackrox.io/declarative-configuration/[]
readOnly: true
name: []
mountPath: /run/stackrox.io/declarative-configuration/[]
readOnly: true
name: []
mountPath: /run/stackrox.io/declarative-configuration/[]
readOnly: true
```

These are invalid names, hence applying the bundle fails.

_Note: this only applies to the kubectl format, the Helm format works as expected_

Additionally, during investigation, I noticed that in interactive mode + kubectl format, the values of the array values were duplicated. I've created [ROX-14956](https://issues.redhat.com/browse/ROX-14956) as a follow-up to address this, and for now de-duplicated the values.

Last but not least, the flags should have been behind the feature flag from the beginning, so this was done in this PR as well, including adjusting the `interactive` roxctl tests to reflect this.
 
## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed
- additional unit tests.
- e2e interactive tests adjusted for the removed flags.