### PR TITLE
Default to empty DB Spec if unset in CR and update Kuttl tests

### DIFF
--- a/operator/pkg/central/values/translation/translation.go
+++ b/operator/pkg/central/values/translation/translation.go
@@ -204,7 +204,7 @@ func getCentralComponentValues(c *platform.CentralComponentSpec) *translation.Va
 func getCentralDBComponentValues(c *platform.CentralDBSpec) *translation.ValuesBuilder {
 	cv := translation.NewValuesBuilder()
 	if c == nil {
-		return &cv
+		c = &platform.CentralDBSpec{}
 	}
 
 	cv.SetBoolValue("enabled", true)

--- a/operator/pkg/central/values/translation/translation_test.go
+++ b/operator/pkg/central/values/translation/translation_test.go
@@ -63,6 +63,14 @@ func TestTranslate(t *testing.T) {
 							"createClaim": false,
 						},
 					},
+					"db": map[string]interface{}{
+						"enabled": true,
+						"persistence": map[string]interface{}{
+							"persistentVolumeClaim": map[string]interface{}{
+								"createClaim": false,
+							},
+						},
+					},
 				},
 			},
 		},
@@ -298,6 +306,14 @@ func TestTranslate(t *testing.T) {
 					"persistence": map[string]interface{}{
 						"hostPath": "/central/host/path",
 					},
+					"db": map[string]interface{}{
+						"enabled": true,
+						"persistence": map[string]interface{}{
+							"persistentVolumeClaim": map[string]interface{}{
+								"createClaim": false,
+							},
+						},
+					},
 					"resources": map[string]interface{}{
 						"limits": map[string]interface{}{
 							"cpu":    "10",
@@ -444,6 +460,14 @@ func TestTranslate(t *testing.T) {
 							"createClaim": false,
 						},
 					},
+					"db": map[string]interface{}{
+						"enabled": true,
+						"persistence": map[string]interface{}{
+							"persistentVolumeClaim": map[string]interface{}{
+								"createClaim": false,
+							},
+						},
+					},
 				},
 			},
 		},
@@ -471,6 +495,14 @@ func TestTranslate(t *testing.T) {
 					"persistence": map[string]interface{}{
 						"persistentVolumeClaim": map[string]interface{}{
 							"createClaim": false,
+						},
+					},
+					"db": map[string]interface{}{
+						"enabled": true,
+						"persistence": map[string]interface{}{
+							"persistentVolumeClaim": map[string]interface{}{
+								"createClaim": false,
+							},
 						},
 					},
 				},
@@ -509,6 +541,14 @@ func TestTranslate(t *testing.T) {
 							"createClaim": false,
 						},
 					},
+					"db": map[string]interface{}{
+						"enabled": true,
+						"persistence": map[string]interface{}{
+							"persistentVolumeClaim": map[string]interface{}{
+								"createClaim": false,
+							},
+						},
+					},
 				},
 			},
 		},
@@ -525,6 +565,14 @@ func TestTranslate(t *testing.T) {
 					"persistence": map[string]interface{}{
 						"persistentVolumeClaim": map[string]interface{}{
 							"createClaim": false,
+						},
+					},
+					"db": map[string]interface{}{
+						"enabled": true,
+						"persistence": map[string]interface{}{
+							"persistentVolumeClaim": map[string]interface{}{
+								"createClaim": false,
+							},
 						},
 					},
 				},
@@ -551,6 +599,14 @@ func TestTranslate(t *testing.T) {
 					"exposeMonitoring": false,
 					"persistence":      map[string]interface{}{"persistentVolumeClaim": map[string]interface{}{"createClaim": false}},
 					"telemetry":        map[string]interface{}{"enabled": false},
+					"db": map[string]interface{}{
+						"enabled": true,
+						"persistence": map[string]interface{}{
+							"persistentVolumeClaim": map[string]interface{}{
+								"createClaim": false,
+							},
+						},
+					},
 				},
 			},
 		},

--- a/operator/tests/central/basic/10-assert.yaml
+++ b/operator/tests/central/basic/10-assert.yaml
@@ -5,6 +5,9 @@ collectors:
   selector: app=central
   tail: -1
 - type: pod
+  selector: app=central-db
+  tail: -1
+- type: pod
   selector: app=scanner
   tail: -1
 - type: pod
@@ -32,6 +35,13 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: central
+status:
+  availableReplicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: central-db
 status:
   availableReplicas: 1
 ---

--- a/operator/tests/central/basic/40-assert.yaml
+++ b/operator/tests/central/basic/40-assert.yaml
@@ -10,7 +10,15 @@ kind: Deployment
 metadata:
   name: central
   annotations:
-    post-reconcile: "true"
+    test-step: "40"
 status:
   # Wait for pod to be ready again
   availableReplicas: 1
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    test-step: "40"
+  labels:
+    app: central

--- a/operator/tests/central/basic/40-reconcile.yaml
+++ b/operator/tests/central/basic/40-reconcile.yaml
@@ -5,4 +5,4 @@ metadata:
 spec:
   customize:
     annotations:
-      post-reconcile: "true"
+      test-step: "40"

--- a/operator/tests/central/basic/75-errors.yaml
+++ b/operator/tests/central/basic/75-errors.yaml
@@ -1,0 +1,4 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: central-db

--- a/operator/tests/central/basic/76-assert.yaml
+++ b/operator/tests/central/basic/76-assert.yaml
@@ -18,6 +18,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: central
+  annotations:
+    test-step: "76"
 status:
   availableReplicas: 1
 ---
@@ -40,8 +42,9 @@ spec:
       storage: 100Gi
 ---
 apiVersion: v1
-kind: Secret
+kind: Pod
 metadata:
-  name: central-db-password
-data:
-  password: c2VjcmV0 # "secret" (no trailing newline)
+  annotations:
+    test-step: "76"
+  labels:
+    app: central

--- a/operator/tests/central/basic/76-switch-back-to-internal-central-db.yaml
+++ b/operator/tests/central/basic/76-switch-back-to-internal-central-db.yaml
@@ -4,6 +4,9 @@ kind: Central
 metadata:
   name: stackrox-central-services
 spec:
+  customize:
+    annotations:
+      test-step: "76"
   central:
     db:
       connectionString: null

--- a/operator/tests/central/basic/76-switch-back-zzz-deletes.yaml
+++ b/operator/tests/central/basic/76-switch-back-zzz-deletes.yaml
@@ -1,0 +1,15 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+# Clean up the external DB password secret, we no longer refer to it in this step.
+- apiVersion: v1
+  kind: Secret
+  name: my-central-db-password
+# The previous step (75-switch-to-external-central-db) has caused the initially generated
+# central-db-password secret to be overwritten with a manually specified "external" password.
+# The DB PCV was left behind, but it's difficult to extract the password from there.
+# Instead, we now remove the central DB PVC, to cause the operator create a new one such that
+# it can be populated with a freshly generated DB password.
+- apiVersion: v1
+  kind: PersistentVolumeClaim
+  name: central-db

--- a/operator/tests/central/basic/76-switch-back-zzz-deletes.yaml
+++ b/operator/tests/central/basic/76-switch-back-zzz-deletes.yaml
@@ -7,7 +7,7 @@ delete:
   name: my-central-db-password
 # The previous step (75-switch-to-external-central-db) has caused the initially generated
 # central-db-password secret to be overwritten with a manually specified "external" password.
-# The DB PCV was left behind, but it's difficult to extract the password from there.
+# The DB PVC was left behind, but it's difficult to extract the password from there.
 # Instead, we now remove the central DB PVC, to cause the operator create a new one such that
 # it can be populated with a freshly generated DB password.
 - apiVersion: v1


### PR DESCRIPTION
## Description

This was resulting in is db isEnabled being false

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

The operator e2e tests should pass
