### PR TITLE
Revert "Bump apollo-ci image to 0.3.56"

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,7 +21,7 @@ jobs:
       ROX_PRODUCT_BRANDING: ${{ matrix.branding }}
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.56
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.55
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -56,7 +56,7 @@ jobs:
   pre-build-cli:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.56
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.55
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -88,7 +88,7 @@ jobs:
   pre-build-go-binaries:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.56
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.55
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -127,7 +127,7 @@ jobs:
   pre-build-go-binaries-rcd:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.56
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.55
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -169,7 +169,7 @@ jobs:
   pre-build-docs:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.56
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.55
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -215,7 +215,7 @@ jobs:
     env:
       ROX_PRODUCT_BRANDING: ${{ matrix.branding }}
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.56
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.55
       env:
         QUAY_RHACS_ENG_RO_USERNAME: ${{ secrets.QUAY_RHACS_ENG_RO_USERNAME }}
         QUAY_RHACS_ENG_RO_PASSWORD: ${{ secrets.QUAY_RHACS_ENG_RO_PASSWORD }}
@@ -317,7 +317,7 @@ jobs:
     env:
       ROX_PRODUCT_BRANDING: ${{ matrix.branding }}
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.56
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.55
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -398,7 +398,7 @@ jobs:
   build-and-push-operator:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.56
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.55
       env:
         QUAY_RHACS_ENG_RW_USERNAME: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
         QUAY_RHACS_ENG_RW_PASSWORD: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
@@ -464,7 +464,7 @@ jobs:
   build-and-push-mock-grpc-server:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.56
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.55
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -514,7 +514,7 @@ jobs:
     needs:
       - build-and-push-main
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.56
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.55
       env:
         STACKROX_CI_INSTANCE_API_KEY: ${{ secrets.STACKROX_CI_INSTANCE_API_KEY }}
         STACKROX_CI_INSTANCE_CENTRAL_HOST: ${{ secrets.STACKROX_CI_INSTANCE_CENTRAL_HOST }}

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -19,7 +19,7 @@ jobs:
   style-check:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.56
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.55
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -18,7 +18,7 @@ jobs:
         gotags: [ 'GOTAGS=""', 'GOTAGS=release' ]
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.56
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.55
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -42,7 +42,7 @@ jobs:
         gotags: [ 'GOTAGS=""', 'GOTAGS=release' ]
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.56
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.55
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -71,7 +71,7 @@ jobs:
   ui:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.56
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.55
     steps:
     - name: Checkout
       uses: actions/checkout@v3

--- a/.openshift-ci/Dockerfile.build_root
+++ b/.openshift-ci/Dockerfile.build_root
@@ -27,4 +27,4 @@
 # For an example, see https://github.com/stackrox/stackrox/pull/2762 and its counterpart
 # https://github.com/openshift/release/pull/31561
 
-FROM quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.56
+FROM quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.55

--- a/.openshift-ci/build/Dockerfile.build-central-db-bundle
+++ b/.openshift-ci/build/Dockerfile.build-central-db-bundle
@@ -1,4 +1,4 @@
-FROM quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.56
+FROM quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.55
 # note the above FROM line is ignored and OpenShift CI uses build_root image instead
 
 ARG ROX_PRODUCT_BRANDING

--- a/.openshift-ci/build/Dockerfile.build-main-and-bundle
+++ b/.openshift-ci/build/Dockerfile.build-main-and-bundle
@@ -1,4 +1,4 @@
-FROM quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.56
+FROM quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.55
 # note the above FROM line is ignored and OpenShift CI uses build_root image instead
 
 ARG ROX_PRODUCT_BRANDING

--- a/.openshift-ci/build/Dockerfile.build-operator-artifacts
+++ b/.openshift-ci/build/Dockerfile.build-operator-artifacts
@@ -1,4 +1,4 @@
-FROM quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.56
+FROM quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.55
 # note the above FROM line is ignored and OpenShift CI uses build_root image instead
 
 ARG ROX_PRODUCT_BRANDING

--- a/BUILD_IMAGE_VERSION
+++ b/BUILD_IMAGE_VERSION
@@ -1,1 +1,1 @@
-stackrox-build-0.3.56
+stackrox-build-0.3.55

--- a/central/processlisteningonport/store/store.go
+++ b/central/processlisteningonport/store/store.go
@@ -8,7 +8,6 @@ import (
 )
 
 // Store provides storage functionality.
-//
 //go:generate mockgen-wrapper
 type Store interface {
 	Upsert(ctx context.Context, obj *storage.ProcessListeningOnPortStorage) error

--- a/scale/signatures/deploy.yaml
+++ b/scale/signatures/deploy.yaml
@@ -11,7 +11,7 @@ spec:
         spec:
           containers:
           - name: update-signature
-            image: quay.io/rhacs-eng/apollo-ci:stackrox-test-0.3.56
+            image: quay.io/rhacs-eng/apollo-ci:stackrox-test-0.3.55
             imagePullPolicy: IfNotPresent
             command:
             - /bin/bash

--- a/tests/e2e/run-e2e-tests.sh
+++ b/tests/e2e/run-e2e-tests.sh
@@ -137,7 +137,7 @@ if [[ ! -f "/i-am-rox-ci-image" ]]; then
       --platform linux/amd64 \
       --rm -it \
       --entrypoint="$0" \
-      quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.56 "$@"
+      quay.io/stackrox-io/apollo-ci:stackrox-test-0.3.55 "$@"
     exit 0
 fi
 


### PR DESCRIPTION
Reverts stackrox/stackrox#4658 which added a `-dirty` tag to operator builds.
https://srox.slack.com/archives/CELUQKESC/p1675807797443359