### PR TITLE
ROX-14912 load testing for processes listening on ports

### DIFF
--- a/sensor/kubernetes/fake/deployment.go
+++ b/sensor/kubernetes/fake/deployment.go
@@ -6,17 +6,83 @@ import (
 	"math/rand"
 	"time"
 
+	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/containerid"
 	"github.com/stackrox/rox/pkg/fixtures"
 	"github.com/stackrox/rox/pkg/k8sutil"
 	"github.com/stackrox/rox/pkg/kubernetes"
 	"github.com/stackrox/rox/pkg/pointers"
+	"github.com/stackrox/rox/pkg/sync"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+var (
+	processPool = newProcessPool()
+)
+
+// ProcessPool stores processes by containerID using a map
+type ProcessPool struct {
+	Processes map[string][]*storage.ProcessSignal
+	Capacity  int
+	lock      sync.RWMutex
+}
+
+func newProcessPool() *ProcessPool {
+	return &ProcessPool{
+		Processes: make(map[string][]*storage.ProcessSignal),
+		Capacity:  10000,
+	}
+}
+
+func (p *ProcessPool) getProcessPoolSize() int {
+	size := 0
+
+	for _, processes := range p.Processes {
+		size += len(processes)
+	}
+
+	return size
+}
+
+func (p *ProcessPool) add(val *storage.ProcessSignal) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	size := p.getProcessPoolSize()
+	if size < p.Capacity {
+		p.Processes[val.ContainerId] = append(p.Processes[val.ContainerId], val)
+	} else {
+		nprocess := len(p.Processes[val.ContainerId])
+		if nprocess > 0 {
+			randIdx := rand.Intn(nprocess)
+			p.Processes[val.ContainerId][randIdx] = val
+		}
+	}
+}
+
+func (p *ProcessPool) remove(containerID string) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	delete(p.Processes, containerID)
+}
+
+func (p *ProcessPool) getRandomProcess(containerID string) *storage.ProcessSignal {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	size := len(p.Processes[containerID])
+	if size > 0 {
+		randIdx := rand.Intn(size)
+		return p.Processes[containerID][randIdx]
+	}
+
+	return nil
+}
 
 type deploymentResourcesToBeManaged struct {
 	workload DeploymentWorkload
@@ -491,13 +557,16 @@ func (w *WorkloadManager) manageProcessesForPod(podSig *concurrency.Signal, podW
 			if processWorkload.ActiveProcesses {
 				for _, process := range getActiveProcesses(containerID) {
 					w.processes.Process(process)
+					processPool.add(process)
 				}
 			} else {
 				// If less than the rate, then it's a bad process
 				if rand.Float32() < processWorkload.AlertRate {
 					w.processes.Process(getBadProcess(containerID))
 				} else {
-					w.processes.Process(getGoodProcess(containerID))
+					goodProcess := getGoodProcess(containerID)
+					w.processes.Process(goodProcess)
+					processPool.add(goodProcess)
 				}
 			}
 		case <-podSig.Done():

--- a/sensor/kubernetes/fake/deployment.go
+++ b/sensor/kubernetes/fake/deployment.go
@@ -28,6 +28,7 @@ var (
 type ProcessPool struct {
 	Processes map[string][]*storage.ProcessSignal
 	Capacity  int
+	Size      int
 	lock      sync.RWMutex
 }
 

--- a/sensor/kubernetes/fake/flows.go
+++ b/sensor/kubernetes/fake/flows.go
@@ -13,7 +13,6 @@ import (
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/pkg/timestamp"
-	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/rox/sensor/common/networkflow/manager"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -51,6 +50,7 @@ func (p *pool) remove(val string) {
 	defer p.lock.Unlock()
 
 	p.pool.Remove(val)
+	processPool.remove(val)
 }
 
 func (p *pool) randomElem() (string, bool) {
@@ -102,6 +102,96 @@ func (w *WorkloadManager) getRandomHostConnection(ctx context.Context) (manager.
 	return registeredHostConnections[rand.Intn(len(registeredHostConnections))], true
 }
 
+func getNetworkProcessUniqueKeyFromProcess(process *storage.ProcessSignal) *storage.NetworkProcessUniqueKey {
+	if process != nil {
+		return &storage.NetworkProcessUniqueKey{
+			ProcessName:         process.Name,
+			ProcessExecFilePath: process.ExecFilePath,
+			ProcessArgs:         process.Args,
+		}
+	}
+
+	return nil
+}
+
+func getRandomOriginator(containerID string) *storage.NetworkProcessUniqueKey {
+	process := processPool.getRandomProcess(containerID)
+
+	return getNetworkProcessUniqueKeyFromProcess(process)
+}
+
+func getNetworkEndpointFromConnectionAndOriginator(conn *sensor.NetworkConnection, originator *storage.NetworkProcessUniqueKey) *sensor.NetworkEndpoint {
+	return &sensor.NetworkEndpoint{
+		SocketFamily:   conn.SocketFamily,
+		Protocol:       conn.Protocol,
+		ListenAddress:  conn.LocalAddress,
+		ContainerId:    conn.ContainerId,
+		CloseTimestamp: nil,
+		Originator:     originator,
+	}
+}
+
+func makeNetworkConnection(src string, dst string, containerID string, closeTS *types.Timestamp) *sensor.NetworkConnection {
+	return &sensor.NetworkConnection{
+		SocketFamily: sensor.SocketFamily_SOCKET_FAMILY_IPV4,
+		LocalAddress: &sensor.NetworkAddress{
+			AddressData: net.ParseIP(src).AsNetIP(),
+			Port:        rand.Uint32() % 63556,
+		},
+		RemoteAddress: &sensor.NetworkAddress{
+			AddressData: net.ParseIP(dst).AsNetIP(),
+			Port:        rand.Uint32() % 63556,
+		},
+		Protocol:       storage.L4Protocol_L4_PROTOCOL_TCP,
+		Role:           sensor.ClientServerRole_ROLE_CLIENT,
+		ContainerId:    containerID,
+		CloseTimestamp: closeTS,
+	}
+}
+
+func (w *WorkloadManager) getFakeNetworkConnectionInfo(workload NetworkWorkload) *sensor.NetworkConnectionInfo {
+	conns := make([]*sensor.NetworkConnection, 0, workload.BatchSize)
+	networkEndpoints := make([]*sensor.NetworkEndpoint, 0, workload.BatchSize)
+	for i := 0; i < workload.BatchSize; i++ {
+		src, ok := ipPool.randomElem()
+		if !ok {
+			log.Error("found no IPs in pool")
+			continue
+		}
+		dst, ok := ipPool.randomElem()
+		if !ok {
+			log.Error("found no IPs in pool")
+			continue
+		}
+
+		containerID, ok := containerPool.randomElem()
+		if !ok {
+			log.Error("found no containers in pool")
+			continue
+		}
+
+		closeTS, err := types.TimestampProto(time.Now().Add(-5 * time.Second))
+		if err != nil {
+			log.Errorf("Unable to set closeTS %+v", err)
+		}
+
+		conn := makeNetworkConnection(src, dst, containerID, closeTS)
+
+		originator := getRandomOriginator(containerID)
+
+		networkEndpoint := getNetworkEndpointFromConnectionAndOriginator(conn, originator)
+
+		conns = append(conns, conn)
+		networkEndpoints = append(networkEndpoints, networkEndpoint)
+	}
+
+	return &sensor.NetworkConnectionInfo{
+		UpdatedConnections: conns,
+		UpdatedEndpoints:   networkEndpoints,
+		Time:               types.TimestampNow(),
+	}
+}
+
 // manageFlows should be called via `go manageFlows` as it will run forever
 func (w *WorkloadManager) manageFlows(ctx context.Context, workload NetworkWorkload) {
 	if workload.FlowInterval == 0 {
@@ -118,53 +208,13 @@ func (w *WorkloadManager) manageFlows(ctx context.Context, workload NetworkWorkl
 		case <-ticker.C:
 		}
 
-		conns := make([]*sensor.NetworkConnection, 0, workload.BatchSize)
-		for i := 0; i < workload.BatchSize; i++ {
-			src, ok := ipPool.randomElem()
-			if !ok {
-				log.Error("found no IPs in pool")
-				continue
-			}
-			dst, ok := ipPool.randomElem()
-			if !ok {
-				log.Error("found no IPs in pool")
-				continue
-			}
-
-			containerID, ok := containerPool.randomElem()
-			if !ok {
-				log.Error("found no containers in pool")
-				continue
-			}
-
-			closeTS, err := types.TimestampProto(time.Now().Add(-5 * time.Second))
-			utils.CrashOnError(err)
-
-			conn := &sensor.NetworkConnection{
-				SocketFamily: sensor.SocketFamily_SOCKET_FAMILY_IPV4,
-				LocalAddress: &sensor.NetworkAddress{
-					AddressData: net.ParseIP(src).AsNetIP(),
-					Port:        rand.Uint32() % 63556,
-				},
-				RemoteAddress: &sensor.NetworkAddress{
-					AddressData: net.ParseIP(dst).AsNetIP(),
-					Port:        rand.Uint32() % 63556,
-				},
-				Protocol:       storage.L4Protocol_L4_PROTOCOL_TCP,
-				Role:           sensor.ClientServerRole_ROLE_CLIENT,
-				ContainerId:    containerID,
-				CloseTimestamp: closeTS,
-			}
-			conns = append(conns, conn)
-		}
+		networkConnectionInfo := w.getFakeNetworkConnectionInfo(workload)
 		hostConn, ok := w.getRandomHostConnection(ctx)
 		if !ok {
 			continue
 		}
-		err := hostConn.Process(&sensor.NetworkConnectionInfo{
-			UpdatedConnections: conns,
-			Time:               types.TimestampNow(),
-		}, timestamp.Now(), 1)
+
+		err := hostConn.Process(networkConnectionInfo, timestamp.Now(), 1)
 		if err != nil {
 			log.Error(err)
 		}


### PR DESCRIPTION
## Description

Adds container endpoints to the fake sensor data. These endpoints also have information about the fake processes that "launched" them. The purpose of this is to do load testing of processes listening on ports.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Saw entries in process_listening_on_ports table
- [x] Used to do load testing
- [x] Ran scale tests in CI

## Testing Performed

Load testing results and how they were done can be found here https://docs.google.com/document/d/1Es96w-jqYXxxmWDt8Sekm5VN8iMLDqBIkoPmDHwOvH8/edit#

How to see entries in process_listening_on_ports table

Started load similar to https://docs.engineering.redhat.com/display/StackRox/Long-running+cluster with the largest change being that the cluster was not set to run for a long time

Got the postgres password with 
kubectl -n stackrox get secret central-db-password -o yaml

Login to postgres
ks exec -it central-db-<pod-name> -- psql
Use password obtained above

Use the correct database
\c central_active

Count the number of rows
select count(*) from process_listening_on_ports ;

or see the rows themselves
select * from process_listening_on_ports ;