### PR TITLE
ROX-14427: Drop PodSecurityPolicy from errors files.

### DIFF
--- a/operator/tests/common/delete-central-errors-cluster.envsubst.yaml
+++ b/operator/tests/common/delete-central-errors-cluster.envsubst.yaml
@@ -17,16 +17,6 @@ kind: ClusterRole
 metadata:
   name: stackrox-${NAMESPACE}-scanner-psp
 ---
-apiVersion: policy/v1beta1
-kind: PodSecurityPolicy
-metadata:
-  name: stackrox-${NAMESPACE}-central
----
-apiVersion: policy/v1beta1
-kind: PodSecurityPolicy
-metadata:
-  name: stackrox-${NAMESPACE}-scanner
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/operator/tests/common/delete-securedcluster-errors.yaml
+++ b/operator/tests/common/delete-securedcluster-errors.yaml
@@ -93,21 +93,6 @@ kind: ClusterRole
 metadata:
   name: stackrox:view-cluster
 ---
-apiVersion: policy/v1beta1
-kind: PodSecurityPolicy
-metadata:
-  name: stackrox-admission-control
----
-apiVersion: policy/v1beta1
-kind: PodSecurityPolicy
-metadata:
-  name: stackrox-collector
----
-apiVersion: policy/v1beta1
-kind: PodSecurityPolicy
-metadata:
-  name: stackrox-sensor
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:


### PR DESCRIPTION
## Description

PSPs are not a thing any more in more recent k8s versions.

Unfortunately when `kuttl` is told to [check that a resource of an unknown type is not present, it fails](https://github.com/kudobuilder/kuttl/issues/317).

Keeping this check working on older versions of kubernetes (that still have this type) is probably not worth the effort. So we simply stop checking them.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

- Counting on CI.
- Ran the test suite against an infra openshift 4.12.1 cluster.