### PR TITLE
ROX-14775 Delete the status field if present when encoding NeworkPolicies to YAML

### DIFF
--- a/central/networkpolicies/service/service_impl.go
+++ b/central/networkpolicies/service/service_impl.go
@@ -45,7 +45,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 )
 
 var (
@@ -116,16 +115,12 @@ func (s *serviceImpl) AuthFuncOverride(ctx context.Context, fullMethodName strin
 }
 
 func populateYAML(np *storage.NetworkPolicy) {
-	k8sNetworkPolicy := networkPolicyConversion.RoxNetworkPolicyWrap{NetworkPolicy: np}.ToKubernetesNetworkPolicy()
-	encoder := json.NewYAMLSerializer(json.DefaultMetaFactory, nil, nil)
-
-	stringBuilder := &strings.Builder{}
-	err := encoder.Encode(k8sNetworkPolicy, stringBuilder)
+	yaml, err := networkPolicyConversion.RoxNetworkPolicyWrap{NetworkPolicy: np}.ToYaml()
 	if err != nil {
 		np.Yaml = fmt.Sprintf("Could not render Network Policy YAML: %s", err)
 		return
 	}
-	np.Yaml = stringBuilder.String()
+	np.Yaml = yaml
 }
 
 func (s *serviceImpl) GetNetworkPolicy(ctx context.Context, request *v1.ResourceByID) (*storage.NetworkPolicy, error) {

--- a/pkg/protoconv/networkpolicy/conversion_test.go
+++ b/pkg/protoconv/networkpolicy/conversion_test.go
@@ -11,246 +11,229 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-func TestNetworkPolicyConversion(t *testing.T) {
-	port := intstr.FromInt(5978)
-	protocol := coreV1.ProtocolTCP
-	cases := []struct {
-		name string
-		np   *v1.NetworkPolicy
-	}{
-		{
-			// Test empty to empty - this is actually very important as it ensures an empty list is different from a list not specified
-			// Kubernetes is very picky about a nil slice vs a non nil slice in terms of the implication in a network policy
-			name: "Empty to Empty",
-			np: &v1.NetworkPolicy{
-				TypeMeta: metav1.TypeMeta{
-					Kind: "NetworkPolicy",
-				},
-				Spec: v1.NetworkPolicySpec{
-					PolicyTypes: []v1.PolicyType{
-						v1.PolicyTypeIngress,
-						v1.PolicyTypeEgress,
-					},
+var (
+	port     = intstr.FromInt(5978)
+	protocol = coreV1.ProtocolTCP
+
+	cases = map[string]*v1.NetworkPolicy{
+		// Test empty to empty - this is actually very important as it ensures an empty list is different from a list not specified
+		// Kubernetes is very picky about a nil slice vs a non nil slice in terms of the implication in a network policy
+		"Empty to Empty": {
+			TypeMeta: metav1.TypeMeta{
+				Kind: "NetworkPolicy",
+			},
+			Spec: v1.NetworkPolicySpec{
+				PolicyTypes: []v1.PolicyType{
+					v1.PolicyTypeIngress,
+					v1.PolicyTypeEgress,
 				},
 			},
 		},
-		{
-			name: "Empty",
-			np: &v1.NetworkPolicy{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: "networking.k8s.io/v1",
-					Kind:       "NetworkPolicy",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-np",
-				},
-				Spec: v1.NetworkPolicySpec{
-					PolicyTypes: []v1.PolicyType{
-						v1.PolicyTypeIngress,
-						v1.PolicyTypeEgress,
-					},
+		"Empty": {
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "networking.k8s.io/v1",
+				Kind:       "NetworkPolicy",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-np",
+			},
+			Spec: v1.NetworkPolicySpec{
+				PolicyTypes: []v1.PolicyType{
+					v1.PolicyTypeIngress,
+					v1.PolicyTypeEgress,
 				},
 			},
 		},
-		{
-			name: "Ingress",
-			np: &v1.NetworkPolicy{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: "networking.k8s.io/v1",
-					Kind:       "NetworkPolicy",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-np",
-				},
-				Spec: v1.NetworkPolicySpec{
-					PolicyTypes: []v1.PolicyType{
-						v1.PolicyTypeIngress,
-					},
-					Ingress: []v1.NetworkPolicyIngressRule{
-						{
-							From: []v1.NetworkPolicyPeer{
-								{
-									IPBlock: &v1.IPBlock{
-										CIDR:   "172.17.0.0/16",
-										Except: []string{"172.17.1.0/24"},
-									},
-									NamespaceSelector: &metav1.LabelSelector{
-										MatchLabels: map[string]string{
-											"project": "myproject",
-										},
-										MatchExpressions: []metav1.LabelSelectorRequirement{
-											{
-												Key:      "environment",
-												Operator: metav1.LabelSelectorOpNotIn,
-												Values:   []string{"testing", "staging"},
-											},
-										},
-									},
-									PodSelector: &metav1.LabelSelector{
-										MatchLabels: map[string]string{
-											"role": "frontend",
-										},
-										MatchExpressions: []metav1.LabelSelectorRequirement{
-											{
-												Key:      "status",
-												Operator: metav1.LabelSelectorOpIn,
-												Values:   []string{"active"},
-											},
-										},
-									},
-								},
-							},
-							Ports: []v1.NetworkPolicyPort{
-								{
-									Protocol: &protocol,
-									Port:     &port,
-								},
-							},
-						},
-					},
-				},
+		"Ingress": {
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "networking.k8s.io/v1",
+				Kind:       "NetworkPolicy",
 			},
-		},
-		{
-			name: "Egress",
-			np: &v1.NetworkPolicy{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: "networking.k8s.io/v1",
-					Kind:       "NetworkPolicy",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-np",
-				},
-				Spec: v1.NetworkPolicySpec{
-					PolicyTypes: []v1.PolicyType{
-						v1.PolicyTypeEgress,
-					},
-					Egress: []v1.NetworkPolicyEgressRule{
-						{
-							To: []v1.NetworkPolicyPeer{
-								{
-									NamespaceSelector: &metav1.LabelSelector{
-										MatchLabels: map[string]string{
-											"project": "myproject",
-										},
-									},
-									IPBlock: &v1.IPBlock{
-										CIDR:   "172.17.0.0/16",
-										Except: []string{"172.17.1.0/24"},
-									},
-									PodSelector: &metav1.LabelSelector{
-										MatchLabels: map[string]string{
-											"role": "frontend",
-										},
-									},
-								},
-							},
-							Ports: []v1.NetworkPolicyPort{
-								{
-									Protocol: &protocol,
-									Port:     &port,
-								},
-							},
-						},
-					},
-				},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-np",
 			},
-		},
-		{
-			name: "Ingress and Egress",
-			np: &v1.NetworkPolicy{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: "network.k8s.io/v1",
-					Kind:       "NetworkPolicy",
+			Spec: v1.NetworkPolicySpec{
+				PolicyTypes: []v1.PolicyType{
+					v1.PolicyTypeIngress,
 				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-network-policy",
-					Namespace: "default",
-				},
-				Spec: v1.NetworkPolicySpec{
-					PodSelector: metav1.LabelSelector{
-						MatchLabels: map[string]string{
-							"role": "db",
-						},
-						MatchExpressions: []metav1.LabelSelectorRequirement{
+				Ingress: []v1.NetworkPolicyIngressRule{
+					{
+						From: []v1.NetworkPolicyPeer{
 							{
-								Key:      "status",
-								Operator: metav1.LabelSelectorOpNotIn,
-								Values:   []string{"disabled", "suspended"},
+								IPBlock: &v1.IPBlock{
+									CIDR:   "172.17.0.0/16",
+									Except: []string{"172.17.1.0/24"},
+								},
+								NamespaceSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										"project": "myproject",
+									},
+									MatchExpressions: []metav1.LabelSelectorRequirement{
+										{
+											Key:      "environment",
+											Operator: metav1.LabelSelectorOpNotIn,
+											Values:   []string{"testing", "staging"},
+										},
+									},
+								},
+								PodSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										"role": "frontend",
+									},
+									MatchExpressions: []metav1.LabelSelectorRequirement{
+										{
+											Key:      "status",
+											Operator: metav1.LabelSelectorOpIn,
+											Values:   []string{"active"},
+										},
+									},
+								},
+							},
+						},
+						Ports: []v1.NetworkPolicyPort{
+							{
+								Protocol: &protocol,
+								Port:     &port,
 							},
 						},
 					},
-					PolicyTypes: []v1.PolicyType{
-						v1.PolicyTypeIngress,
-						v1.PolicyTypeEgress,
-					},
-					Ingress: []v1.NetworkPolicyIngressRule{
-						{
-							From: []v1.NetworkPolicyPeer{
-								{
-									IPBlock: &v1.IPBlock{
-										CIDR:   "172.17.0.0/16",
-										Except: []string{"172.17.1.0/24"},
-									},
-									NamespaceSelector: &metav1.LabelSelector{
-										MatchLabels: map[string]string{
-											"project": "myproject",
-										},
-										MatchExpressions: []metav1.LabelSelectorRequirement{
-											{
-												Key:      "environment",
-												Operator: metav1.LabelSelectorOpNotIn,
-												Values:   []string{"testing", "staging"},
-											},
-										},
-									},
-									PodSelector: &metav1.LabelSelector{
-										MatchLabels: map[string]string{
-											"role": "frontend",
-										},
-										MatchExpressions: []metav1.LabelSelectorRequirement{
-											{
-												Key:      "status",
-												Operator: metav1.LabelSelectorOpIn,
-												Values:   []string{"active"},
-											},
-										},
+				},
+			},
+		},
+		"Egress": {
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "networking.k8s.io/v1",
+				Kind:       "NetworkPolicy",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-np",
+			},
+			Spec: v1.NetworkPolicySpec{
+				PolicyTypes: []v1.PolicyType{
+					v1.PolicyTypeEgress,
+				},
+				Egress: []v1.NetworkPolicyEgressRule{
+					{
+						To: []v1.NetworkPolicyPeer{
+							{
+								NamespaceSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										"project": "myproject",
 									},
 								},
-							},
-							Ports: []v1.NetworkPolicyPort{
-								{
-									Protocol: &protocol,
-									Port:     &port,
+								IPBlock: &v1.IPBlock{
+									CIDR:   "172.17.0.0/16",
+									Except: []string{"172.17.1.0/24"},
+								},
+								PodSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										"role": "frontend",
+									},
 								},
 							},
 						},
+						Ports: []v1.NetworkPolicyPort{
+							{
+								Protocol: &protocol,
+								Port:     &port,
+							},
+						},
 					},
-					Egress: []v1.NetworkPolicyEgressRule{
+				},
+			},
+		},
+		"Ingress and Egress": {
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "network.k8s.io/v1",
+				Kind:       "NetworkPolicy",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-network-policy",
+				Namespace: "default",
+			},
+			Spec: v1.NetworkPolicySpec{
+				PodSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"role": "db",
+					},
+					MatchExpressions: []metav1.LabelSelectorRequirement{
 						{
-							To: []v1.NetworkPolicyPeer{
-								{
-									IPBlock: &v1.IPBlock{
-										CIDR:   "172.17.0.0/16",
-										Except: []string{"172.17.1.0/24"},
+							Key:      "status",
+							Operator: metav1.LabelSelectorOpNotIn,
+							Values:   []string{"disabled", "suspended"},
+						},
+					},
+				},
+				PolicyTypes: []v1.PolicyType{
+					v1.PolicyTypeIngress,
+					v1.PolicyTypeEgress,
+				},
+				Ingress: []v1.NetworkPolicyIngressRule{
+					{
+						From: []v1.NetworkPolicyPeer{
+							{
+								IPBlock: &v1.IPBlock{
+									CIDR:   "172.17.0.0/16",
+									Except: []string{"172.17.1.0/24"},
+								},
+								NamespaceSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										"project": "myproject",
 									},
-									NamespaceSelector: &metav1.LabelSelector{
-										MatchLabels: map[string]string{
-											"project": "myproject",
+									MatchExpressions: []metav1.LabelSelectorRequirement{
+										{
+											Key:      "environment",
+											Operator: metav1.LabelSelectorOpNotIn,
+											Values:   []string{"testing", "staging"},
 										},
 									},
-									PodSelector: &metav1.LabelSelector{
-										MatchLabels: map[string]string{
-											"role": "frontend",
+								},
+								PodSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										"role": "frontend",
+									},
+									MatchExpressions: []metav1.LabelSelectorRequirement{
+										{
+											Key:      "status",
+											Operator: metav1.LabelSelectorOpIn,
+											Values:   []string{"active"},
 										},
 									},
 								},
 							},
-							Ports: []v1.NetworkPolicyPort{
-								{
-									Protocol: &protocol,
-									Port:     &port,
+						},
+						Ports: []v1.NetworkPolicyPort{
+							{
+								Protocol: &protocol,
+								Port:     &port,
+							},
+						},
+					},
+				},
+				Egress: []v1.NetworkPolicyEgressRule{
+					{
+						To: []v1.NetworkPolicyPeer{
+							{
+								IPBlock: &v1.IPBlock{
+									CIDR:   "172.17.0.0/16",
+									Except: []string{"172.17.1.0/24"},
 								},
+								NamespaceSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										"project": "myproject",
+									},
+								},
+								PodSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										"role": "frontend",
+									},
+								},
+							},
+						},
+						Ports: []v1.NetworkPolicyPort{
+							{
+								Protocol: &protocol,
+								Port:     &port,
 							},
 						},
 					},
@@ -258,15 +241,18 @@ func TestNetworkPolicyConversion(t *testing.T) {
 			},
 		},
 	}
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
+)
+
+func TestNetworkPolicyConversion(t *testing.T) {
+	for name, np := range cases {
+		t.Run(name, func(t *testing.T) {
 			// Test k8s conversion is correct
-			protoNetworkPolicy := KubernetesNetworkPolicyWrap{NetworkPolicy: c.np}.ToRoxNetworkPolicy()
+			protoNetworkPolicy := KubernetesNetworkPolicyWrap{NetworkPolicy: np}.ToRoxNetworkPolicy()
 			k8sPolicy := RoxNetworkPolicyWrap{NetworkPolicy: protoNetworkPolicy}.ToKubernetesNetworkPolicy()
-			assert.Equal(t, c.np, k8sPolicy)
+			assert.Equal(t, np, k8sPolicy)
 
 			// Test `status` field is not present in the generated yaml
-			yaml, err := KubernetesNetworkPolicyWrap{c.np}.ToYaml()
+			yaml, err := KubernetesNetworkPolicyWrap{np}.ToYaml()
 			assert.NoError(t, err)
 			uObj, err := k8sutil.UnstructuredFromYAML(yaml)
 			assert.NoError(t, err, "yaml generation should succeed")
@@ -283,7 +269,7 @@ func TestNetworkPolicyConversion(t *testing.T) {
 			k8sPolicies, err := YamlWrap{Yaml: yaml}.ToKubernetesNetworkPolicies()
 			assert.NoError(t, err, "k8s policy generation should succeed")
 			assert.Equal(t, 1, len(k8sPolicies), "expected one policy from the yaml")
-			assert.Equal(t, c.np, k8sPolicies[0])
+			assert.Equal(t, np, k8sPolicies[0])
 
 			// Generation from yaml to roxNetworkPolicy
 			protoNetworkPolicies, err := YamlWrap{Yaml: yaml}.ToRoxNetworkPolicies()
@@ -291,7 +277,7 @@ func TestNetworkPolicyConversion(t *testing.T) {
 			assert.Equal(t, 1, len(protoNetworkPolicies), "expected one policy from the yaml")
 
 			// Check that yaml->rox, and k8s->rox creates the same network policy
-			protoNetworkPolicyFromK8s := KubernetesNetworkPolicyWrap{c.np}.ToRoxNetworkPolicy()
+			protoNetworkPolicyFromK8s := KubernetesNetworkPolicyWrap{np}.ToRoxNetworkPolicy()
 			assert.Equal(t, protoNetworkPolicyFromK8s, protoNetworkPolicies[0])
 		})
 	}

--- a/pkg/protoconv/networkpolicy/conversion_test.go
+++ b/pkg/protoconv/networkpolicy/conversion_test.go
@@ -3,6 +3,7 @@ package networkpolicy
 import (
 	"testing"
 
+	"github.com/stackrox/rox/pkg/k8sutil"
 	"github.com/stretchr/testify/assert"
 	coreV1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/networking/v1"
@@ -11,139 +12,287 @@ import (
 )
 
 func TestNetworkPolicyConversion(t *testing.T) {
-	// Test empty to empty - this is actually very important as it ensure an empty list is different than a list not specified
-	// Kubernetes is very picky about a nil slice vs a non nil slice in terms of the implication in a network policy
-	np := &v1.NetworkPolicy{
-		TypeMeta: metav1.TypeMeta{
-			Kind: "NetworkPolicy",
-		},
-		Spec: v1.NetworkPolicySpec{
-			PolicyTypes: []v1.PolicyType{
-				v1.PolicyTypeIngress,
-				v1.PolicyTypeEgress,
-			},
-		},
-	}
-
-	protoNetworkPolicy := KubernetesNetworkPolicyWrap{NetworkPolicy: np}.ToRoxNetworkPolicy()
-	k8sPolicy := RoxNetworkPolicyWrap{NetworkPolicy: protoNetworkPolicy}.ToKubernetesNetworkPolicy()
-	assert.Equal(t, np, k8sPolicy)
-
-	// This is the network policy from the k8s example
 	port := intstr.FromInt(5978)
 	protocol := coreV1.ProtocolTCP
-	np = &v1.NetworkPolicy{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "network.k8s.io/v1",
-			Kind:       "NetworkPolicy",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-network-policy",
-			Namespace: "default",
-		},
-		Spec: v1.NetworkPolicySpec{
-			PodSelector: metav1.LabelSelector{
-				MatchLabels: map[string]string{
-					"role": "db",
+	cases := []struct {
+		name string
+		np   *v1.NetworkPolicy
+	}{
+		{
+			// Test empty to empty - this is actually very important as it ensures an empty list is different from a list not specified
+			// Kubernetes is very picky about a nil slice vs a non nil slice in terms of the implication in a network policy
+			name: "Empty to Empty",
+			np: &v1.NetworkPolicy{
+				TypeMeta: metav1.TypeMeta{
+					Kind: "NetworkPolicy",
 				},
-				MatchExpressions: []metav1.LabelSelectorRequirement{
-					{
-						Key:      "status",
-						Operator: metav1.LabelSelectorOpNotIn,
-						Values:   []string{"disabled", "suspended"},
+				Spec: v1.NetworkPolicySpec{
+					PolicyTypes: []v1.PolicyType{
+						v1.PolicyTypeIngress,
+						v1.PolicyTypeEgress,
 					},
 				},
 			},
-			PolicyTypes: []v1.PolicyType{
-				v1.PolicyTypeIngress,
-				v1.PolicyTypeEgress,
+		},
+		{
+			name: "Empty",
+			np: &v1.NetworkPolicy{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "networking.k8s.io/v1",
+					Kind:       "NetworkPolicy",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-np",
+				},
+				Spec: v1.NetworkPolicySpec{
+					PolicyTypes: []v1.PolicyType{
+						v1.PolicyTypeIngress,
+						v1.PolicyTypeEgress,
+					},
+				},
 			},
-			Ingress: []v1.NetworkPolicyIngressRule{
-				{
-					From: []v1.NetworkPolicyPeer{
+		},
+		{
+			name: "Ingress",
+			np: &v1.NetworkPolicy{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "networking.k8s.io/v1",
+					Kind:       "NetworkPolicy",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-np",
+				},
+				Spec: v1.NetworkPolicySpec{
+					PolicyTypes: []v1.PolicyType{
+						v1.PolicyTypeIngress,
+					},
+					Ingress: []v1.NetworkPolicyIngressRule{
 						{
-							IPBlock: &v1.IPBlock{
-								CIDR:   "172.17.0.0/16",
-								Except: []string{"172.17.1.0/24"},
-							},
-							NamespaceSelector: &metav1.LabelSelector{
-								MatchLabels: map[string]string{
-									"project": "myproject",
-								},
-								MatchExpressions: []metav1.LabelSelectorRequirement{
-									{
-										Key:      "environment",
-										Operator: metav1.LabelSelectorOpNotIn,
-										Values:   []string{"testing", "staging"},
+							From: []v1.NetworkPolicyPeer{
+								{
+									IPBlock: &v1.IPBlock{
+										CIDR:   "172.17.0.0/16",
+										Except: []string{"172.17.1.0/24"},
+									},
+									NamespaceSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"project": "myproject",
+										},
+										MatchExpressions: []metav1.LabelSelectorRequirement{
+											{
+												Key:      "environment",
+												Operator: metav1.LabelSelectorOpNotIn,
+												Values:   []string{"testing", "staging"},
+											},
+										},
+									},
+									PodSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"role": "frontend",
+										},
+										MatchExpressions: []metav1.LabelSelectorRequirement{
+											{
+												Key:      "status",
+												Operator: metav1.LabelSelectorOpIn,
+												Values:   []string{"active"},
+											},
+										},
 									},
 								},
 							},
-							PodSelector: &metav1.LabelSelector{
-								MatchLabels: map[string]string{
-									"role": "frontend",
-								},
-								MatchExpressions: []metav1.LabelSelectorRequirement{
-									{
-										Key:      "status",
-										Operator: metav1.LabelSelectorOpIn,
-										Values:   []string{"active"},
-									},
+							Ports: []v1.NetworkPolicyPort{
+								{
+									Protocol: &protocol,
+									Port:     &port,
 								},
 							},
-						},
-					},
-					Ports: []v1.NetworkPolicyPort{
-						{
-							Protocol: &protocol,
-							Port:     &port,
 						},
 					},
 				},
 			},
-			Egress: []v1.NetworkPolicyEgressRule{
-				{
-					To: []v1.NetworkPolicyPeer{
+		},
+		{
+			name: "Egress",
+			np: &v1.NetworkPolicy{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "networking.k8s.io/v1",
+					Kind:       "NetworkPolicy",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-np",
+				},
+				Spec: v1.NetworkPolicySpec{
+					PolicyTypes: []v1.PolicyType{
+						v1.PolicyTypeEgress,
+					},
+					Egress: []v1.NetworkPolicyEgressRule{
 						{
-							IPBlock: &v1.IPBlock{
-								CIDR:   "172.17.0.0/16",
-								Except: []string{"172.17.1.0/24"},
-							},
-							NamespaceSelector: &metav1.LabelSelector{
-								MatchLabels: map[string]string{
-									"project": "myproject",
+							To: []v1.NetworkPolicyPeer{
+								{
+									NamespaceSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"project": "myproject",
+										},
+									},
+									IPBlock: &v1.IPBlock{
+										CIDR:   "172.17.0.0/16",
+										Except: []string{"172.17.1.0/24"},
+									},
+									PodSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"role": "frontend",
+										},
+									},
 								},
 							},
-							PodSelector: &metav1.LabelSelector{
-								MatchLabels: map[string]string{
-									"role": "frontend",
+							Ports: []v1.NetworkPolicyPort{
+								{
+									Protocol: &protocol,
+									Port:     &port,
 								},
 							},
 						},
 					},
-					Ports: []v1.NetworkPolicyPort{
+				},
+			},
+		},
+		{
+			name: "Ingress and Egress",
+			np: &v1.NetworkPolicy{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "network.k8s.io/v1",
+					Kind:       "NetworkPolicy",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-network-policy",
+					Namespace: "default",
+				},
+				Spec: v1.NetworkPolicySpec{
+					PodSelector: metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"role": "db",
+						},
+						MatchExpressions: []metav1.LabelSelectorRequirement{
+							{
+								Key:      "status",
+								Operator: metav1.LabelSelectorOpNotIn,
+								Values:   []string{"disabled", "suspended"},
+							},
+						},
+					},
+					PolicyTypes: []v1.PolicyType{
+						v1.PolicyTypeIngress,
+						v1.PolicyTypeEgress,
+					},
+					Ingress: []v1.NetworkPolicyIngressRule{
 						{
-							Protocol: &protocol,
-							Port:     &port,
+							From: []v1.NetworkPolicyPeer{
+								{
+									IPBlock: &v1.IPBlock{
+										CIDR:   "172.17.0.0/16",
+										Except: []string{"172.17.1.0/24"},
+									},
+									NamespaceSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"project": "myproject",
+										},
+										MatchExpressions: []metav1.LabelSelectorRequirement{
+											{
+												Key:      "environment",
+												Operator: metav1.LabelSelectorOpNotIn,
+												Values:   []string{"testing", "staging"},
+											},
+										},
+									},
+									PodSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"role": "frontend",
+										},
+										MatchExpressions: []metav1.LabelSelectorRequirement{
+											{
+												Key:      "status",
+												Operator: metav1.LabelSelectorOpIn,
+												Values:   []string{"active"},
+											},
+										},
+									},
+								},
+							},
+							Ports: []v1.NetworkPolicyPort{
+								{
+									Protocol: &protocol,
+									Port:     &port,
+								},
+							},
+						},
+					},
+					Egress: []v1.NetworkPolicyEgressRule{
+						{
+							To: []v1.NetworkPolicyPeer{
+								{
+									IPBlock: &v1.IPBlock{
+										CIDR:   "172.17.0.0/16",
+										Except: []string{"172.17.1.0/24"},
+									},
+									NamespaceSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"project": "myproject",
+										},
+									},
+									PodSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"role": "frontend",
+										},
+									},
+								},
+							},
+							Ports: []v1.NetworkPolicyPort{
+								{
+									Protocol: &protocol,
+									Port:     &port,
+								},
+							},
 						},
 					},
 				},
 			},
 		},
 	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			// Test k8s conversion is correct
+			protoNetworkPolicy := KubernetesNetworkPolicyWrap{NetworkPolicy: c.np}.ToRoxNetworkPolicy()
+			k8sPolicy := RoxNetworkPolicyWrap{NetworkPolicy: protoNetworkPolicy}.ToKubernetesNetworkPolicy()
+			assert.Equal(t, c.np, k8sPolicy)
 
-	yamlPolicy, err := KubernetesNetworkPolicyWrap{NetworkPolicy: np}.ToYaml()
-	assert.NoError(t, err, "yaml generation should succeed")
+			// Test `status` field is not present in the generated yaml
+			yaml, err := KubernetesNetworkPolicyWrap{c.np}.ToYaml()
+			assert.NoError(t, err)
+			uObj, err := k8sutil.UnstructuredFromYAML(yaml)
+			assert.NoError(t, err, "yaml generation should succeed")
+			_, ok := uObj.Object["status"]
+			assert.False(t, ok, "The generate yaml file should not have the 'status' field")
+			yaml, err = RoxNetworkPolicyWrap{NetworkPolicy: protoNetworkPolicy}.ToYaml()
+			assert.NoError(t, err, "yaml generation should succeed")
+			uObj, err = k8sutil.UnstructuredFromYAML(yaml)
+			assert.NoError(t, err)
+			_, ok = uObj.Object["status"]
+			assert.False(t, ok, "The generate yaml file should not have the 'status' field")
 
-	k8sPolicies, err := YamlWrap{Yaml: yamlPolicy}.ToKubernetesNetworkPolicies()
-	assert.NoError(t, err, "k8s policy generation should succeed")
-	assert.Equal(t, 1, len(k8sPolicies), "expected one policy from the yaml")
-	assert.Equal(t, np, k8sPolicies[0])
+			// Generation from yaml k8sNetworkPolicy
+			k8sPolicies, err := YamlWrap{Yaml: yaml}.ToKubernetesNetworkPolicies()
+			assert.NoError(t, err, "k8s policy generation should succeed")
+			assert.Equal(t, 1, len(k8sPolicies), "expected one policy from the yaml")
+			assert.Equal(t, c.np, k8sPolicies[0])
 
-	protoNetworkPolicies, err := YamlWrap{Yaml: yamlPolicy}.ToRoxNetworkPolicies()
-	assert.NoError(t, err, "k8s policy generation should succeed")
-	assert.Equal(t, 1, len(protoNetworkPolicies), "expected one policy from the yaml")
+			// Generation from yaml to roxNetworkPolicy
+			protoNetworkPolicies, err := YamlWrap{Yaml: yaml}.ToRoxNetworkPolicies()
+			assert.NoError(t, err, "k8s policy generation should succeed")
+			assert.Equal(t, 1, len(protoNetworkPolicies), "expected one policy from the yaml")
 
-	// Check that yaml->rox, and k8s->rox creates the same network policy
-	protoNetworkPolicyFromK8s := KubernetesNetworkPolicyWrap{np}.ToRoxNetworkPolicy()
-	assert.Equal(t, protoNetworkPolicyFromK8s, protoNetworkPolicies[0])
+			// Check that yaml->rox, and k8s->rox creates the same network policy
+			protoNetworkPolicyFromK8s := KubernetesNetworkPolicyWrap{c.np}.ToRoxNetworkPolicy()
+			assert.Equal(t, protoNetworkPolicyFromK8s, protoNetworkPolicies[0])
+		})
+	}
 }

--- a/pkg/protoconv/networkpolicy/conversion_test.go
+++ b/pkg/protoconv/networkpolicy/conversion_test.go
@@ -243,7 +243,7 @@ var (
 	}
 )
 
-func TestToRoxNetworkPolicyRoundtrip(t *testing.T) {
+func TestToRoxNetworkPolicyRoundTrip(t *testing.T) {
 	for name, np := range cases {
 		t.Run(name, func(t *testing.T) {
 			protoNetworkPolicy := KubernetesNetworkPolicyWrap{NetworkPolicy: np}.ToRoxNetworkPolicy()

--- a/pkg/protoconv/networkpolicy/k8s.go
+++ b/pkg/protoconv/networkpolicy/k8s.go
@@ -24,14 +24,6 @@ type KubernetesNetworkPolicyWrap struct {
 
 // ToYaml produces a string holding a JSON formatted yaml for the network policy.
 func (np KubernetesNetworkPolicyWrap) ToYaml() (string, error) {
-	uObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(np.NetworkPolicy)
-	if err != nil {
-		return "", err
-	}
-	encoder := json.NewSerializerWithOptions(json.DefaultMetaFactory, nil, nil, json.SerializerOptions{
-		Yaml: true,
-	})
-
 	// Kubernetes added a 'status' field for NetworkPolicies in 1.24. See:
 	// * (https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.24.md#api-change-3)
 	// * (https://github.com/kubernetes/kubernetes/pull/107963)
@@ -41,7 +33,15 @@ func (np KubernetesNetworkPolicyWrap) ToYaml() (string, error) {
 	// This code might not be necessary in the future since the feature was withdrawn by the sig-network. See:
 	// * (https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/2943-networkpolicy-status#implementation-history)
 	// * (https://github.com/kubernetes/kubernetes/pull/107963#issuecomment-1400220883)
+	uObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(np.NetworkPolicy)
+	if err != nil {
+		return "", err
+	}
 	delete(uObj, "status")
+
+	encoder := json.NewSerializerWithOptions(json.DefaultMetaFactory, nil, nil, json.SerializerOptions{
+		Yaml: true,
+	})
 
 	stringBuilder := &strings.Builder{}
 	err = encoder.Encode(&unstructured.Unstructured{Object: uObj}, stringBuilder)

--- a/pkg/protoconv/networkpolicy/k8s.go
+++ b/pkg/protoconv/networkpolicy/k8s.go
@@ -11,6 +11,8 @@ import (
 	k8sCoreV1 "k8s.io/api/core/v1"
 	networkingV1 "k8s.io/api/networking/v1"
 	k8sMetaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -22,10 +24,27 @@ type KubernetesNetworkPolicyWrap struct {
 
 // ToYaml produces a string holding a JSON formatted yaml for the network policy.
 func (np KubernetesNetworkPolicyWrap) ToYaml() (string, error) {
-	encoder := json.NewYAMLSerializer(json.DefaultMetaFactory, nil, nil)
+	uObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(np.NetworkPolicy)
+	if err != nil {
+		return "", err
+	}
+	encoder := json.NewSerializerWithOptions(json.DefaultMetaFactory, nil, nil, json.SerializerOptions{
+		Yaml: true,
+	})
+
+	// Kubernetes added a 'status' field for NetworkPolicies in 1.24. See:
+	// * (https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.24.md#api-change-3)
+	// * (https://github.com/kubernetes/kubernetes/pull/107963)
+	// Using the `NewSerializerWithOptions` from `k8s.io/apimachinery/pkg/runtime/serializer/json` with a `v1.NetworkPolicy` will return the `status` field.
+	// The problem is: Old cluster using kubernetes < 1.24 will fail to apply NetworkPolicies generated this way.
+	// Since the `status` field is not handled by ACS, we delete the field manually if present here.
+	// This code might not be necessary in the future since the feature was withdrawn by the sig-network. See:
+	// * (https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/2943-networkpolicy-status#implementation-history)
+	// * (https://github.com/kubernetes/kubernetes/pull/107963#issuecomment-1400220883)
+	delete(uObj, "status")
 
 	stringBuilder := &strings.Builder{}
-	err := encoder.Encode(np, stringBuilder)
+	err = encoder.Encode(&unstructured.Unstructured{Object: uObj}, stringBuilder)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/protoconv/networkpolicy/rox.go
+++ b/pkg/protoconv/networkpolicy/rox.go
@@ -1,6 +1,7 @@
 package networkpolicy
 
 import (
+	"encoding/json"
 	"strings"
 
 	"github.com/stackrox/rox/generated/storage"
@@ -10,9 +11,9 @@ import (
 	k8sCoreV1 "k8s.io/api/core/v1"
 	k8sV1 "k8s.io/api/networking/v1"
 	k8sMetaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/yaml"
 )
 
 var (
@@ -27,13 +28,38 @@ type RoxNetworkPolicyWrap struct {
 // ToYaml produces a string holding a JSON formatted yaml for the network policy.
 func (np RoxNetworkPolicyWrap) ToYaml() (string, error) {
 	k8sNetworkPolicy := np.ToKubernetesNetworkPolicy()
-	encoder := json.NewYAMLSerializer(json.DefaultMetaFactory, nil, nil)
-
-	stringBuilder := &strings.Builder{}
-	err := encoder.Encode(k8sNetworkPolicy, stringBuilder)
+	jsonData, err := json.Marshal(k8sNetworkPolicy)
 	if err != nil {
 		return "", err
 	}
+	stringBuilder := &strings.Builder{}
+	// Kubernetes added a 'status' field for NetworkPolicies in 1.24. See:
+	// * (https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.24.md#api-change-3)
+	// * (https://github.com/kubernetes/kubernetes/pull/107963)
+	// Using the `NewSerializerWithOptions` from `k8s.io/apimachinery/pkg/runtime/serializer/json` will return the `status` field.
+	// The problem is: Old cluster using kubernetes < 1.24 will fail to apply NetworkPolicies generated with this function.
+	// Since the `status` field is not necessary for the creation of resources, we delete the field manually if present here.
+	// This code might not be necessary in the future since the feature was withdrawn by the sig-network. See:
+	// * (https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/2943-networkpolicy-status#implementation-history)
+	// * (https://github.com/kubernetes/kubernetes/pull/107963#issuecomment-1400220883)
+	data := make(map[string]interface{})
+	if err := json.Unmarshal(jsonData, &data); err != nil {
+		return "", err
+	}
+	delete(data, "status")
+	jsonData, err = json.Marshal(data)
+	if err != nil {
+		return "", err
+	}
+
+	yamlData, err := yaml.JSONToYAML(jsonData)
+	if err != nil {
+		return "", err
+	}
+	if _, err := stringBuilder.Write(yamlData); err != nil {
+		return "", err
+	}
+
 	return stringBuilder.String(), nil
 }
 


### PR DESCRIPTION
## Description

Kubernetes added a 'status' field for NetworkPolicies in 1.24. See: [v1.24 Changelog](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.24.md#api-change-3)

Using the `NewSerializerWithOptions` from `k8s.io/apimachinery/pkg/runtime/serializer/json` with a `v1.NetworkPolicy` will return the `status` field even if the status is empty. This is because the type `Status` is defined as a value instead of a pointer so it always gets serialized in json.

The problem is: Old cluster using kubernetes < 1.24 will fail to apply NetworkPolicies generated this way. See: [ROX-14775](https://issues.redhat.com/browse/ROX-14775)

Since the `status` field is not handled by ACS, we can delete the field manually if present.

Note: This might not be necessary in the future since the feature was withdrawn by the sig-network. See: [NetworkPolicy Status](https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/2943-networkpolicy-status#implementation-history)

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

* [x] CI
* [x] Unit tests for this case have been added
* [x] Manual testing `roxctl generate netpol`
* [x] Manual testing `Simulate network policy` in the UI

