### PR TITLE
ROX-14987: Fix wrong info for anomalous external flows count

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/networkGraphUtils.test.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/networkGraphUtils.test.ts
@@ -1,0 +1,106 @@
+import { CustomEdgeModel } from '../types/topology.type';
+import { getNumFlowsFromEdge } from './networkGraphUtils';
+
+describe('networkGraphUtils', () => {
+    describe('getNumFlowsFromEdge', () => {
+        it('should get number of flows for a non-bidirectional edge with one port/protocol', () => {
+            const edge: CustomEdgeModel = {
+                id: 'edge-1',
+                type: 'edge',
+                visible: true,
+                source: 'node-1',
+                target: 'node-2',
+                data: {
+                    isBidirectional: false,
+                    portProtocolLabel: '8080 TCP',
+                    sourceToTargetProperties: [
+                        {
+                            port: 8080,
+                            protocol: 'L4_PROTOCOL_TCP',
+                            lastActiveTimestamp: '2023-02-08T18:24:50.470158762Z',
+                        },
+                    ],
+                    tag: '8080 TCP',
+                },
+            };
+
+            const numFlows = getNumFlowsFromEdge(edge);
+
+            expect(numFlows).toEqual(1);
+        });
+
+        it('should get number of flows for a non-bidirectional edge with multiple ports/protocols', () => {
+            const edge: CustomEdgeModel = {
+                id: 'edge-1',
+                type: 'edge',
+                visible: true,
+                source: 'node-1',
+                target: 'node-2',
+                data: {
+                    isBidirectional: false,
+                    portProtocolLabel: '2',
+                    sourceToTargetProperties: [
+                        {
+                            port: 8080,
+                            protocol: 'L4_PROTOCOL_TCP',
+                            lastActiveTimestamp: '2023-02-08T18:24:50.470158762Z',
+                        },
+                        {
+                            port: 80,
+                            protocol: 'L4_PROTOCOL_TCP',
+                            lastActiveTimestamp: '2023-02-08T18:24:50.470158762Z',
+                        },
+                    ],
+                    tag: '2',
+                },
+            };
+
+            const numFlows = getNumFlowsFromEdge(edge);
+
+            expect(numFlows).toEqual(2);
+        });
+
+        it('should get number of flows for a bidirectional edge', () => {
+            const edge: CustomEdgeModel = {
+                id: 'edge-1',
+                type: 'edge',
+                visible: true,
+                source: 'node-1',
+                target: 'node-2',
+                data: {
+                    isBidirectional: true,
+                    portProtocolLabel: '4',
+                    sourceToTargetProperties: [
+                        {
+                            port: 8080,
+                            protocol: 'L4_PROTOCOL_TCP',
+                            lastActiveTimestamp: '2023-02-08T18:24:50.470158762Z',
+                        },
+                        {
+                            port: 80,
+                            protocol: 'L4_PROTOCOL_TCP',
+                            lastActiveTimestamp: '2023-02-08T18:24:50.470158762Z',
+                        },
+                    ],
+                    targetToSourceProperties: [
+                        {
+                            port: 8080,
+                            protocol: 'L4_PROTOCOL_TCP',
+                            lastActiveTimestamp: '2023-02-08T18:24:50.470158762Z',
+                        },
+                        {
+                            port: 80,
+                            protocol: 'L4_PROTOCOL_TCP',
+                            lastActiveTimestamp: '2023-02-08T18:24:50.470158762Z',
+                        },
+                    ],
+                    tag: '4',
+                },
+            };
+
+            const numFlows = getNumFlowsFromEdge(edge);
+
+            expect(numFlows).toEqual(4);
+        });
+    });
+});

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/networkGraphUtils.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/networkGraphUtils.ts
@@ -37,6 +37,14 @@ export function getNodeById(
 
 /* edge helper functions */
 
+export function getNumFlowsFromEdge(edge: CustomEdgeModel): number {
+    let numFlows = edge.data.sourceToTargetProperties.length;
+    if (edge.data.isBidirectional) {
+        numFlows += edge.data.targetToSourceProperties?.length || 0;
+    }
+    return numFlows;
+}
+
 export function getNumInternalFlows(
     nodes: CustomNodeModel[],
     edges: CustomEdgeModel[],
@@ -49,7 +57,8 @@ export function getNumInternalFlows(
                 (edge.source === deploymentId && !externalNodeIds.includes(edge.target || '')) ||
                 (edge.target === deploymentId && !externalNodeIds.includes(edge.source || ''))
             ) {
-                return acc + 1;
+                const numFlows = getNumFlowsFromEdge(edge);
+                return acc + numFlows;
             }
             return acc;
         }, 0) || 0;
@@ -68,7 +77,8 @@ export function getNumExternalFlows(
                 (edge.source === deploymentId && externalNodeIds.includes(edge.target || '')) ||
                 (edge.target === deploymentId && externalNodeIds.includes(edge.source || ''))
             ) {
-                return acc + 1;
+                const numFlows = getNumFlowsFromEdge(edge);
+                return acc + numFlows;
             }
             return acc;
         }, 0) || 0;


### PR DESCRIPTION
## Description

This PR fixes an issue with the deployment details tab showing the wrong info for the number of external flows for this deployment


<img width="1552" alt="Screenshot 2023-02-08 at 10 30 06 AM" src="https://user-images.githubusercontent.com/4805485/217620530-080845b5-da05-4191-90b7-615ab494d6d1.png">


## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~
