### PR TITLE
ROX-14766: Add olm-rollback-test

### DIFF
--- a/operator/hack/common.sh
+++ b/operator/hack/common.sh
@@ -114,42 +114,6 @@ function approve_install_plan() {
   retry 3 5 kubectl -n "${operator_ns}" patch installplan "${install_plan_name}" --type merge -p '{"spec":{"approved":true}}'
 }
 
-function csv_version_tag() {
-  local -r operator_ns="$1"
-  echo $(kubectl -n "${operator_ns}" get csv  -l operators.coreos.com/rhacs-operator.operators -o json | jq -r '.items[].spec.version' | sort | tail -n 1)
-}
-
-function nurse_olm_upgrade() {
-  local -r operator_ns="$1"
-  local -r initial_version_tag="$2"
-  local -r desired_version_tag="$3"
-
-  echo current_version_tag
-  local current_version_tag="$(csv_version_tag ${operator_ns})"
-  echo ${current_version_tag}
-
-  # Wait until a new CSV has been created
-  while [[ "${current_version_tag}" == "${initial_version_tag}" ]]; do
-      sleep 1
-      current_version_tag="$(csv_version_tag ${operator_ns})"
-  done
-
-  # Nurse the deployment for each intermediate CSV
-  while [[ "${current_version_tag}" != "${desired_version_tag}" ]]; do
-      echo Current: ${current_version_tag}
-      echo Desired: ${desired_version_tag}
-      nurse_deployment_until_available ${operator_ns} ${current_version_tag}
-      while [[ "$(csv_version_tag ${operator_ns})" == "${current_version_tag}" ]]; do
-          # Wait until the new CSV is created
-          sleep 10
-      done
-      current_version_tag="$(csv_version_tag ${operator_ns})"
-  done
-
-  # Nurse the deployment for the final CSV
-  nurse_deployment_until_available ${operator_ns} ${desired_version_tag}
-}
-
 function nurse_deployment_until_available() {
   local -r operator_ns="$1"
   local -r version_tag="$2"

--- a/operator/hack/olm-rollback-test.sh
+++ b/operator/hack/olm-rollback-test.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/bash
+
+source "$(dirname "$0")/common.sh"
+
+image_spec_prefix=quay.io/rhacs-eng/stackrox-operator-index
+old_version=3.72.0
+operator_ns=operators
+central_ns=acs
+
+if [ $(kubectl get deploy -n olm -o json | jq '.items | length') == 3 ]; then
+    log OLM is already installed
+else
+    log Installing OLM
+    # Download operator-sdk binary here:
+    # https://github.com/operator-framework/operator-sdk/releases/tag/v1.25.4
+    operator-sdk olm install
+fi
+
+kubectl create ns ${operator_ns}
+
+create_pull_secret "${operator_ns}" "quay.io"
+
+cat <<EOF | kubectl apply -n ${operator_ns} -f -
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: cert-manager
+spec:
+  channel: stable
+  name: cert-manager
+  source: operatorhubio-catalog
+  sourceNamespace: olm
+  installPlanApproval: Automatic
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: rhacs
+spec:
+  displayName: Advanced Cluster Security
+  grpcPodConfig:
+    securityContextConfig: restricted
+  image: ${image_spec_prefix}:v${old_version}
+  publisher: Red Hat
+  secrets:
+  - operator-pull-secret
+  sourceType: grpc
+  updateStrategy:
+    registryPoll:
+      interval: 60m
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: rhacs
+spec:
+  channel: latest
+  name: rhacs-operator
+  source: rhacs
+  sourceNamespace: ${operator_ns}
+  installPlanApproval: Automatic  # Choosing automatic to emulate how most customers configure subscriptions (afiact)
+  config:
+    env:
+    # use a test value for NO_PROXY. This will not have any impact
+    # on the services at runtime, but we can test if it gets piped
+    # through correctly.
+    - name: NO_PROXY
+      value: "127.1.2.3/8"
+EOF
+
+if [ $? != 0 ];then
+    log Failed to apply operators manifest
+    exit 1
+fi
+
+nurse_deployment_until_available "${operator_ns}" "${old_version}"
+
+kubectl create ns ${central_ns}
+
+create_pull_secret "${central_ns}" "quay.io"
+
+cat <<EOF | kubectl apply -n ${central_ns} -f -
+---
+apiVersion: platform.stackrox.io/v1alpha1
+kind: Central
+metadata:
+  name: stackrox-central-services
+spec:
+  imagePullSecrets:
+  - name: operator-pull-secret
+  central:
+    adminPasswordSecret:
+      name: admin-pass
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: admin-pass
+data:
+  # letmein
+  password: bGV0bWVpbg==
+EOF
+
+function test() {
+  kubectl -n ${central_ns} wait --for=condition=Deployed --timeout=5m central/stackrox-central-services
+  kubectl -n ${central_ns} wait --for=condition=Available --timeout=5m deploy/central
+
+  kubectl -n ${central_ns} port-forward svc/central 44444:443 &
+  sleep 2 # allow for port forward to get set up
+  test_result=$(curl -k -u 'admin:letmein' https://localhost:44444/api/docs/swagger -s | jq -r .info.title)
+  kill %1
+
+  if [ "${test_result}" != "API Reference" ]; then
+      log Failed to query API
+      exit 1
+  fi
+}
+
+test
+
+new_version=3.74.0-13-gc76ca946d4 # perhaps `make tag` would make this dyanmic?
+
+kubectl -n ${operator_ns} patch catalogsource/rhacs --type merge -p '{"spec":{"image":"'"${image_spec_prefix}"':v'"${new_version}"'"}}'
+
+nurse_olm_upgrade "${operator_ns}" "${old_version}" "${new_version}"
+
+"${KUTTL}" assert --timeout 300 --namespace ${central_ns} /dev/stdin <<-END
+apiVersion: platform.stackrox.io/v1alpha1
+kind: Central
+metadata:
+  name: stackrox-central-services
+status:
+  productVersion:  $(echo ${new_version} | sed s/\.0-/.x-/)
+END
+
+test
+
+# Remove operator and OLM subscription
+kubectl -n ${operator_ns} delete csv rhacs-operator.v${new_version}
+kubectl -n ${operator_ns} delete subscription rhacs
+
+# Rollback
+kubectl -n ${operator_ns} patch catalogsource/rhacs --type merge -p '{"spec":{"image":"'"${image_spec_prefix}"':v'"${old_version}"'"}}'
+
+cat <<EOF | kubectl apply -n ${operator_ns} -f -
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: rhacs
+spec:
+  channel: latest
+  name: rhacs-operator
+  source: rhacs
+  sourceNamespace: ${operator_ns}
+  installPlanApproval: Automatic
+  config:
+    env:
+    # use a test value for NO_PROXY. This will not have any impact
+    # on the services at runtime, but we can test if it gets piped
+    # through correctly.
+    - name: NO_PROXY
+      value: "127.1.2.3/8"
+EOF
+
+nurse_deployment_until_available "${operator_ns}" "${old_version}"
+
+"${KUTTL}" assert --timeout 300 --namespace ${central_ns} /dev/stdin <<-END
+apiVersion: platform.stackrox.io/v1alpha1
+kind: Central
+metadata:
+  name: stackrox-central-services
+status:
+  productVersion:  ${old_version}
+END

--- a/operator/hack/olm-rollback-test.sh
+++ b/operator/hack/olm-rollback-test.sh
@@ -1,26 +1,38 @@
 #!/usr/bin/bash
 
+set -e
+
 source "$(dirname "$0")/common.sh"
 
-image_spec_prefix=quay.io/rhacs-eng/stackrox-operator-index
-old_version=3.72.0
-operator_ns=operators
-central_ns=acs
+function install_olm() {
+  if [ $(kubectl get deploy -n olm -o json | jq '.items | length') == 3 ]; then
+      log OLM is already installed
+  else
+      log Installing OLM
+      # Download operator-sdk binary here:
+      # https://github.com/operator-framework/operator-sdk/releases/tag/v1.25.4
+      operator-sdk olm install
+  fi
+}
 
-if [ $(kubectl get deploy -n olm -o json | jq '.items | length') == 3 ]; then
-    log OLM is already installed
-else
-    log Installing OLM
-    # Download operator-sdk binary here:
-    # https://github.com/operator-framework/operator-sdk/releases/tag/v1.25.4
-    operator-sdk olm install
-fi
+function init() {
+  install_olm
 
-kubectl create ns ${operator_ns}
+  ns_list=$(kubectl get ns --no-headers)
 
-create_pull_secret "${operator_ns}" "quay.io"
+  log "Installing pull secrets in namespaces"
+  create_pull_secret "${operator_ns}" "quay.io"
 
-cat <<EOF | kubectl apply -n ${operator_ns} -f -
+  if [ "$(echo \"$ns_list\" | grep ${central_ns})" == "" ]; then
+    kubectl create ns ${central_ns}
+  fi
+
+  create_pull_secret "${central_ns}" "quay.io"
+}
+
+function install_cert_manager() {
+  log "Installing cert manager"
+  cat <<EOF | kubectl apply -n ${operator_ns} -f -
 ---
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
@@ -32,6 +44,13 @@ spec:
   source: operatorhubio-catalog
   sourceNamespace: olm
   installPlanApproval: Automatic
+EOF
+}
+
+function install_acs_catalog_source {
+  version=$1
+  log "Installing ACS CatalogSource at version ${version}"
+  cat <<EOF | kubectl apply -n ${operator_ns} -f -
 ---
 apiVersion: operators.coreos.com/v1alpha1
 kind: CatalogSource
@@ -41,7 +60,7 @@ spec:
   displayName: Advanced Cluster Security
   grpcPodConfig:
     securityContextConfig: restricted
-  image: ${image_spec_prefix}:v${old_version}
+  image: ${image_spec_prefix}:v${version}
   publisher: Red Hat
   secrets:
   - operator-pull-secret
@@ -49,6 +68,13 @@ spec:
   updateStrategy:
     registryPoll:
       interval: 60m
+EOF
+}
+
+function install_acs_operator {
+  log "Installing ACS operator"
+  version=$1
+  cat <<EOF | kubectl apply -n ${operator_ns} -f -
 ---
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
@@ -69,18 +95,29 @@ spec:
       value: "127.1.2.3/8"
 EOF
 
-if [ $? != 0 ];then
-    log Failed to apply operators manifest
-    exit 1
-fi
+  nurse_deployment_until_available "${operator_ns}" "${version}"
+}
 
-nurse_deployment_until_available "${operator_ns}" "${old_version}"
+function install_central() {
+  # NOTE: Use helm or some templating tool if this gets any more complicated
+  log "Installing Central CR"
+  if [[ "$force_postgres" == true ]]; then
+    read -d '' central_spec << EOF || true
+  central:
+    db:
+      isEnabled: Enabled
+    adminPasswordSecret:
+      name: admin-pass
+EOF
+  else
+    read -d '' central_spec << EOF || true
+  central:
+    adminPasswordSecret:
+      name: admin-pass
+EOF
+  fi
 
-kubectl create ns ${central_ns}
-
-create_pull_secret "${central_ns}" "quay.io"
-
-cat <<EOF | kubectl apply -n ${central_ns} -f -
+  cat <<EOF | kubectl apply -n ${central_ns} -f -
 ---
 apiVersion: platform.stackrox.io/v1alpha1
 kind: Central
@@ -89,9 +126,7 @@ metadata:
 spec:
   imagePullSecrets:
   - name: operator-pull-secret
-  central:
-    adminPasswordSecret:
-      name: admin-pass
+  ${central_spec}
 ---
 apiVersion: v1
 kind: Secret
@@ -101,11 +136,14 @@ data:
   # letmein
   password: bGV0bWVpbg==
 EOF
+}
 
-function test() {
+function test_central_api() {
+  log "Waiting for Central to be ready"
   kubectl -n ${central_ns} wait --for=condition=Deployed --timeout=5m central/stackrox-central-services
   kubectl -n ${central_ns} wait --for=condition=Available --timeout=5m deploy/central
 
+  log "Valiating that Central API is available"
   kubectl -n ${central_ns} port-forward svc/central 44444:443 &
   sleep 2 # allow for port forward to get set up
   test_result=$(curl -k -u 'admin:letmein' https://localhost:44444/api/docs/swagger -s | jq -r .info.title)
@@ -117,60 +155,180 @@ function test() {
   fi
 }
 
-test
+function update_acs_catalog_source() {
+  version=$1
 
-new_version=3.74.0-13-gc76ca946d4 # perhaps `make tag` would make this dyanmic?
+  log "Updating ACS CatalogSource to ${version}"
+  kubectl -n ${operator_ns} patch catalogsource/rhacs --type merge -p '{"spec":{"image":"'"${image_spec_prefix}"':v'"${version}"'"}}'
 
-kubectl -n ${operator_ns} patch catalogsource/rhacs --type merge -p '{"spec":{"image":"'"${image_spec_prefix}"':v'"${new_version}"'"}}'
+  sleep 5
 
-nurse_olm_upgrade "${operator_ns}" "${old_version}" "${new_version}"
+  log "Waiting for CatalogSource to be ready"
+  new_pod=$(kubectl get pod -n ${operator_ns} -l olm.catalogSource=rhacs -o json | \
+    jq -r '.items[] | select(.metadata.deletionTimestamp == null) | .metadata.name')
 
-"${KUTTL}" assert --timeout 300 --namespace ${central_ns} /dev/stdin <<-END
-apiVersion: platform.stackrox.io/v1alpha1
-kind: Central
-metadata:
-  name: stackrox-central-services
-status:
-  productVersion:  $(echo ${new_version} | sed s/\.0-/.x-/)
-END
+  kubectl -n ${operator_ns} wait \
+    --timeout=300s \
+    --for=condition=Ready \
+    pod/${new_pod}
 
-test
-
-# Remove operator and OLM subscription
-kubectl -n ${operator_ns} delete csv rhacs-operator.v${new_version}
-kubectl -n ${operator_ns} delete subscription rhacs
-
-# Rollback
-kubectl -n ${operator_ns} patch catalogsource/rhacs --type merge -p '{"spec":{"image":"'"${image_spec_prefix}"':v'"${old_version}"'"}}'
-
-cat <<EOF | kubectl apply -n ${operator_ns} -f -
----
+  "${KUTTL}" assert --timeout 300 --namespace ${operator_ns} /dev/stdin <<-END
 apiVersion: operators.coreos.com/v1alpha1
-kind: Subscription
+kind: CatalogSource
 metadata:
   name: rhacs
-spec:
-  channel: latest
-  name: rhacs-operator
-  source: rhacs
-  sourceNamespace: ${operator_ns}
-  installPlanApproval: Automatic
-  config:
-    env:
-    # use a test value for NO_PROXY. This will not have any impact
-    # on the services at runtime, but we can test if it gets piped
-    # through correctly.
-    - name: NO_PROXY
-      value: "127.1.2.3/8"
-EOF
+status:
+  connectionState:
+    lastObservedState: READY
+END
+}
 
-nurse_deployment_until_available "${operator_ns}" "${old_version}"
+function get_previous_db_version() {
+  log "Querying Central pod for previous DB version"
+  pod_name=$(kubectl -n acs get pod -l app=central -o name)
+  prev_db_v=$(kubectl -n ${central_ns} exec $pod_name -- \
+     cat /var/lib/stackrox/.previous/migration_version.yaml | \
+     grep '^image:' | \
+     cut -f 2 -d : | \
+     tr -d ' ')
+  echo $prev_db_v
+}
 
-"${KUTTL}" assert --timeout 300 --namespace ${central_ns} /dev/stdin <<-END
+function patch_db_rollback_version() {
+  version=$1
+  log "Patching central-config: forceRollbackVersion: ${version}"
+
+  kubectl -n ${central_ns} get configmap central-config -o yaml | \
+    sed -e "s/forceRollbackVersion: none/forceRollbackVersion: ${version}/" | \
+    kubectl -n ${central_ns} apply -f -
+
+  kubectl -n ${central_ns} delete $(kubectl -n ${central_ns} get pod -l app=central -o name)
+}
+
+function remove_acs_operator() {
+  version=$1
+  log "Removing ACS CSV and Subscription"
+  kubectl -n ${operator_ns} delete csv rhacs-operator.v${version}
+  kubectl -n ${operator_ns} delete subscription rhacs
+}
+
+function ensure_central_at_version() {
+  version=$1
+  log "Waiting for Central to be upgraded to version ${version}"
+  "${KUTTL}" assert --timeout 300 --namespace ${central_ns} /dev/stdin <<-END
 apiVersion: platform.stackrox.io/v1alpha1
 kind: Central
 metadata:
   name: stackrox-central-services
 status:
-  productVersion:  ${old_version}
+  productVersion:  $(echo ${version} | sed s/\.0-/.x-/)
 END
+}
+
+function csv_version_tag() {
+  echo $(kubectl -n "${operator_ns}" get csv  -l operators.coreos.com/rhacs-operator.operators -o json | jq -r '.items[].spec.version' | sort | tail -n 1)
+}
+
+function nurse_olm_upgrade() {
+  initial_version_tag="$1"
+  desired_version_tag="$2"
+
+  local current_version_tag="$(csv_version_tag)"
+
+  # Wait until a new CSV has been created
+  while [[ "${current_version_tag}" == "${initial_version_tag}" ]]; do
+      sleep 1
+      current_version_tag="$(csv_version_tag)"
+  done
+
+  # Nurse the deployment for each intermediate CSV
+  while [[ "${current_version_tag}" != "${desired_version_tag}" ]]; do
+      echo Current: ${current_version_tag}
+      echo Desired: ${desired_version_tag}
+      nurse_deployment_until_available ${operator_ns} ${current_version_tag}
+      while [[ "$(csv_version_tag)" == "${current_version_tag}" ]]; do
+          # Wait until the new CSV is created
+          sleep 10
+      done
+      current_version_tag="$(csv_version_tag)"
+  done
+
+  # Nurse the deployment for the final CSV
+  nurse_deployment_until_available ${operator_ns} ${desired_version_tag}
+}
+
+function main() {
+  POSITIONAL_ARGS=()
+  force_postgres=false
+  openshift=false
+  image_spec_prefix=quay.io/rhacs-eng/stackrox-operator-index
+  operator_ns=operators
+  central_ns=acs
+
+  while [[ $# -gt 0 ]]; do
+    case $1 in
+      -p|--force-postgres)
+        force_postgres=true
+        shift
+        ;;
+      -o|--openshift)
+        openshift=true
+        shift
+        ;;
+      -i|--image-spec-prefix)
+        image_spec_prefix="$2"
+        shift
+        shift
+        ;;
+      -*|--*)
+        echo "Unknown option $1"
+        exit 1
+        ;;
+      *)
+        POSITIONAL_ARGS+=("$1") # save positional arg
+        shift # past argument
+        ;;
+    esac
+  done
+
+  set -- "${POSITIONAL_ARGS[@]}" # restore positional parameters
+
+  old_version="${1:-}"
+  new_version="${2:-}"
+
+  if [[ "$old_version" == "" || "$new_version" == "" ]]; then
+      echo "Usage:   $0 [-poi] <old_version> <new_version>"
+      echo "Example: $0 3.73.0 3.74.0-91-gacfe66b6fa"
+      exit 1
+  fi
+
+  if [[ "$openshift" == true ]]; then
+    echo "Openshift option is not available yet"
+    exit 1
+  fi
+
+  init
+  install_cert_manager
+  install_acs_catalog_source ${old_version}
+  install_acs_operator ${old_version}
+  install_central
+  test_central_api
+  update_acs_catalog_source ${new_version}
+  nurse_olm_upgrade "${old_version}" "${new_version}"
+  test_central_api
+
+  # rollback
+  previous_db_version="$(get_previous_db_version)"
+  log "Previous version: ${previous_db_version}"
+  remove_acs_operator "${new_version}"
+  update_acs_catalog_source "${previous_db_version}"
+  install_acs_operator "${previous_db_version}"
+  ensure_central_at_version "${previous_db_version}"
+  remove_acs_operator "${previous_db_version}"
+  patch_db_rollback_version "${previous_db_version}"
+  test_central_api
+  install_acs_operator "${previous_db_version}"
+  test_central_api
+}
+
+main "$@"


### PR DESCRIPTION
Goals:

* Validate an OLM upgrade that has at least one intermediate upgrade
  * Example: 3.72.0 -> 3.74.0 has an intermediate upgrade of 3.73.0
* Figure out how to perform a rollback with the operator

Current high level steps this test performs:

1. Deploy OLM if not present
2. Deploy verion 3.72.0 of the operator
3. Deploy a Central and do very basic API validation
4. Upgrade operator to 3.74.x
5. Wait for Central to upgrade and do very basic API validation
6. Downgrade operator back to 3.72 and wait for Central to get downgraded

A few points:

* Test uses rhacs-eng images to test upgrade to unreleased version
* Install plans are configured to be automatically approved because this is how most customers have it configured (afaik)
* Rollback test is currently incomplete.
* Testing has been performed on default-gke k8s clusters

Questions:

* Does it make sense to keep an upgrade test like this in the repo?
* Should this script be refactored into an existing test suite (e.g. kuttl)?

## Description

A detailed explanation of the changes in your PR.

Feel free to remove this section if it is overkill for your PR, and the title of your PR is sufficiently descriptive.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.
