### PR TITLE
Dashrews/ROX-14794 updates to handle issues when rocksdb to Postgres migration fails in the middle

### DIFF
--- a/migrator/clone/mock_central.go
+++ b/migrator/clone/mock_central.go
@@ -126,11 +126,11 @@ func (m *mockCentral) upgradeCentral(ver *versionPair, breakpoint string) {
 
 	if env.PostgresDatastoreEnabled.BooleanSetting() && m.runBoth {
 		if version.CompareVersions(curVer.version, "3.0.57.0") >= 0 {
-			if pgadmin.CheckIfDBExists(m.adminConfig, postgres.PreviousClone) {
-				m.verifyClonePostgres(postgres.PreviousClone, curVer)
+			if pgadmin.CheckIfDBExists(m.adminConfig, postgres.TempClone) {
+				m.verifyClonePostgres(postgres.TempClone, curVer)
 			}
 		} else {
-			assert.False(m.t, pgadmin.CheckIfDBExists(m.adminConfig, postgres.PreviousClone))
+			assert.False(m.t, pgadmin.CheckIfDBExists(m.adminConfig, postgres.TempClone))
 		}
 	} else if env.PostgresDatastoreEnabled.BooleanSetting() {
 		if version.CompareVersions(curVer.version, "3.0.57.0") >= 0 {

--- a/migrator/clone/postgres/db_clone_manager_impl_test.go
+++ b/migrator/clone/postgres/db_clone_manager_impl_test.go
@@ -219,9 +219,9 @@ func (s *PostgresCloneManagerSuite) TestGetCloneMigrateRocks() {
 		LastPersisted: time.Now(),
 	}
 
-	// No central_active exists so we return that as the clone to use and migrate to rocks
+	// No central_active exists so we return the temp clone to use and migrate to rocks
 	clone, migrateRocks, err := dbm.GetCloneToMigrate(rocksVersion, false)
-	s.Equal(clone, CurrentClone)
+	s.Equal(clone, TempClone)
 	s.True(migrateRocks)
 	s.Nil(err)
 
@@ -230,7 +230,7 @@ func (s *PostgresCloneManagerSuite) TestGetCloneMigrateRocks() {
 
 	// Still migrate from Rocks because no version in Postgres meaning it is empty
 	clone, migrateRocks, err = dbm.GetCloneToMigrate(rocksVersion, false)
-	s.Equal(clone, CurrentClone)
+	s.Equal(clone, TempClone)
 	s.True(migrateRocks)
 	s.Nil(err)
 


### PR DESCRIPTION
## Description

If a migration from RocksDB to Postgres failed in the middle, the migrator would think that Postgres was the database of choice when starting back up and thus have no handles to RocksDB resulting in crashes. This change will check to see if Postgres has completed the RocksDB to Postgres migration before determining whether to ignore RocksDB or not. If we have determined that the migration failed in the middle, we will start over with the RocksDB to Postgres migration by moving what we have processed thus far to central_temp and starting central_active from scratch.  We accomplish this by using central_temp as the initial clone.  If central_temp is never persisted, it will be cleaned up as a left over artifact the next restart and that will start fresh.  Once migrations are successfully completed, central_temp will be renamed to central_active and central will start as normal.  

Initially the plan was to pick up where the migration failed. This turned out to be riskier than I initially thought so I felt it best to simply re-run the migrations. The reasons I felt this was safer are:

The case where RocksDB migrations have to be executed as well caused additional logic paths to be introduced. For example going from 3.72 -> 3.74 results in RocksDB migrations being executed but those are not persisted until the end. So those cases need to start over regardless.
The other case is that in testing I was running into migration issues were Postgres was complaining about unique key violations on the primary key when starting with a partially filled Postgres. Those would crash central and eventually resolve themselves. With the number of migrations involved, it felt more prudent to simply start from scratch for this one time migration than to debug and test those cases in each migration.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Updated unit and integration tests. Additionally tested manually but starting 3.72, 3.73, and 3.74 in RocksDB mode with a sizeable workload such that the migration would take a few minutes. After some time to get data populated, I would upgrade to 3.74 in Postgres mode. Watching the logs, I would kill the pod at various times during the RocksDB -> Postgres migration to ensure that the migration would start over and complete.
