### PR TITLE
ROX-14973: Use batch/v1 in 3.72 for compatibility with OCP 4.12

### DIFF
--- a/central/detection/service/service_impl_test.go
+++ b/central/detection/service/service_impl_test.go
@@ -530,19 +530,44 @@ spec:
   adminPortalCredentialsRef:
     name: asecretname
 `
+const cronYaml = `
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: example
+  namespace: sst-etcd-backup
+spec:
+  schedule: '@daily'
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: hello
+              image: busybox
+              args:
+                - /bin/sh
+                - '-c'
+                - date; echo Hello from the Kubernetes cluster
+          restartPolicy: OnFailure
+`
 
 func TestParseList_Success(t *testing.T) {
-	_, _, err := getObjectsFromYAML(listYAML)
-	require.NoError(t, err)
-
-	_, _, err = getObjectsFromYAML(openshiftDeploymentConfigYaml)
-	require.NoError(t, err)
-
-	_, _, err = getObjectsFromYAML(multiYaml)
-	require.NoError(t, err)
-
-	_, _, err = getObjectsFromYAML(openshiftDeploymentConfigYaml)
-	require.NoError(t, err)
+	for name, yaml := range map[string]string{
+		"listYaml":                          listYAML,
+		"openshiftDeploymentConfigYaml":     openshiftDeploymentConfigYaml,
+		"multiYaml":                         multiYaml,
+		"openshiftDeployConfMultiYaml":      openshiftDeploymentConfigYaml,
+		"operatorCRDMultiYaml":              operatorCRDMultiYaml,
+		"operatorCRDYaml":                   operatorCRDYaml,
+		"openshiftRouteWithOperatorCRDYaml": openshiftRouteWithOperatorCRDYaml,
+		"cronYaml":                          cronYaml,
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, _, err := getObjectsFromYAML(yaml)
+			require.NoError(t, err)
+		})
+	}
 }
 
 func TestParseList_ConversionToOpenshiftObjects(t *testing.T) {

--- a/pkg/protoconv/resources/resources.go
+++ b/pkg/protoconv/resources/resources.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stackrox/rox/pkg/stringutils"
 	"github.com/stackrox/rox/pkg/timestamp"
 	"github.com/stackrox/rox/pkg/utils"
+	batchV1 "k8s.io/api/batch/v1"
 	batchV1beta1 "k8s.io/api/batch/v1beta1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -122,6 +123,9 @@ func newWrap(meta metav1.Object, kind, clusterID, registryOverride string) *Depl
 // SpecToPodTemplateSpec turns a top level spec into a podTemplateSpec
 func SpecToPodTemplateSpec(spec reflect.Value) (v1.PodTemplateSpec, error) {
 	templateInterface := spec.FieldByName("Template")
+	if !doesFieldExist(templateInterface) {
+		return v1.PodTemplateSpec{}, errors.Errorf("obj %+v does not have a Template field", spec)
+	}
 	if templateInterface.Type().Kind() == reflect.Ptr && !templateInterface.IsNil() {
 		templateInterface = templateInterface.Elem()
 	}
@@ -237,7 +241,10 @@ func (w *DeploymentWrap) populateFields(obj interface{}) {
 		// types do. So, we need to directly access the Pod's Spec field,
 		// instead of looking for it inside a PodTemplate.
 		podSpec = o.Spec
+	// batch/v1beta1 CronJob is deprecated in v1.21+, unavailable in v1.25+.
 	case *batchV1beta1.CronJob:
+		podSpec = o.Spec.JobTemplate.Spec.Template.Spec
+	case *batchV1.CronJob:
 		podSpec = o.Spec.JobTemplate.Spec.Template.Spec
 	default:
 		podTemplate, err := SpecToPodTemplateSpec(spec)

--- a/pkg/protoconv/resources/resources_test.go
+++ b/pkg/protoconv/resources/resources_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	appsV1 "k8s.io/api/apps/v1"
 	appsV1beta2 "k8s.io/api/apps/v1beta2"
+	batchV1 "k8s.io/api/batch/v1"
+	batchV1beta1 "k8s.io/api/batch/v1beta1"
 	v1 "k8s.io/api/core/v1"
 	extV1beta1 "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -101,6 +103,42 @@ func TestDaemonSetReplicas(t *testing.T) {
 	}
 	deploymentWrap.populateReplicas(reflect.Value{}, daemonSet4)
 	assert.Equal(t, int(deploymentWrap.Replicas), 0)
+}
+
+func TestCronJobPopulateSpec(t *testing.T) {
+	deploymentWrap := &DeploymentWrap{
+		Deployment: &storage.Deployment{
+			Type: kubernetes.CronJob,
+		},
+	}
+
+	cronJob1 := &batchV1.CronJob{
+		Spec: batchV1.CronJobSpec{
+			JobTemplate: batchV1.JobTemplateSpec{
+				Spec: batchV1.JobSpec{
+					Template: v1.PodTemplateSpec{
+						Spec: v1.PodSpec{Containers: []v1.Container{{Name: "container1"}}},
+					},
+				},
+			},
+		},
+	}
+	deploymentWrap.populateFields(cronJob1)
+	assert.Equal(t, deploymentWrap.Containers[0].Name, "container1")
+
+	cronJob2 := &batchV1beta1.CronJob{
+		Spec: batchV1beta1.CronJobSpec{
+			JobTemplate: batchV1beta1.JobTemplateSpec{
+				Spec: batchV1.JobSpec{
+					Template: v1.PodTemplateSpec{
+						Spec: v1.PodSpec{Containers: []v1.Container{{Name: "container2"}}},
+					},
+				},
+			},
+		},
+	}
+	deploymentWrap.populateFields(cronJob2)
+	assert.Equal(t, deploymentWrap.Containers[0].Name, "container2")
 }
 
 func TestIsTrackedReference(t *testing.T) {

--- a/sensor/kubernetes/listener/resource_event_handler.go
+++ b/sensor/kubernetes/listener/resource_event_handler.go
@@ -202,7 +202,7 @@ func (k *listenerImpl) handleAllEvents() {
 	handle(resyncingSif.Apps().V1().DaemonSets().Informer(), dispatchers.ForDeployments(kubernetes.DaemonSet), k.eventsC, &syncingResources, wg, stopSignal, &eventLock)
 	handle(resyncingSif.Apps().V1().Deployments().Informer(), dispatchers.ForDeployments(kubernetes.Deployment), k.eventsC, &syncingResources, wg, stopSignal, &eventLock)
 	handle(resyncingSif.Apps().V1().StatefulSets().Informer(), dispatchers.ForDeployments(kubernetes.StatefulSet), k.eventsC, &syncingResources, wg, stopSignal, &eventLock)
-	handle(resyncingSif.Batch().V1beta1().CronJobs().Informer(), dispatchers.ForDeployments(kubernetes.CronJob), k.eventsC, &syncingResources, wg, stopSignal, &eventLock)
+	handle(resyncingSif.Batch().V1().CronJobs().Informer(), dispatchers.ForDeployments(kubernetes.CronJob), k.eventsC, &syncingResources, wg, stopSignal, &eventLock)
 
 	if osAppsFactory != nil {
 		handle(osAppsFactory.Apps().V1().DeploymentConfigs().Informer(), dispatchers.ForDeployments(kubernetes.DeploymentConfig), k.eventsC, &syncingResources, wg, stopSignal, &eventLock)

--- a/sensor/kubernetes/listener/resources/convert.go
+++ b/sensor/kubernetes/listener/resources/convert.go
@@ -21,7 +21,7 @@ import (
 	"github.com/stackrox/rox/sensor/common/registry"
 	"github.com/stackrox/rox/sensor/kubernetes/listener/resources/references"
 	"github.com/stackrox/rox/sensor/kubernetes/orchestratornamespaces"
-	"k8s.io/api/batch/v1beta1"
+	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -187,7 +187,7 @@ func (w *deploymentWrap) populateNonStaticFields(obj interface{}, action *centra
 		// instead of looking for it inside a PodTemplate.
 		podLabels = o.Labels
 		labelSelector = w.populateK8sComponentIfNecessary(o, hierarchy)
-	case *v1beta1.CronJob:
+	case *batchv1.CronJob:
 		// Cron jobs have a Job spec that then have a Pod Template underneath
 		podLabels = o.Spec.JobTemplate.Spec.Template.GetLabels()
 		podSpec = o.Spec.JobTemplate.Spec.Template.Spec


### PR DESCRIPTION
## Description

Brings in the changes from here https://github.com/stackrox/stackrox/pull/3854 to 3.72 to fix https://issues.redhat.com/browse/ROX-14973

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Confirmed that the issue was fixed

## Testing Performed
Planned testing

infractl create openshift-4 jouko-0208-ocp-4-12-1 --description "Testing bug with k8s 1.25" --arg openshift-version=ocp/4.12.1

export CENTRAL_IMAGE_REGISTRY=quay.io/stackrox-io
export CENTRAL_IMAGE_NAME=main
export CENTRAL_IMAGE_TAG=3.72.3

export SCANNER_DBIMAGE_REGISTRY=quay.io/stackrox-io
export SCANNER_DBIMAGE_NAME=scanner-db
export SCANNER_DBIMAGE_TAG=2.26.2

export IMAGE_MAIN_REGISTRY=quay.io/stackrox-io
export IMAGE_MAIN_NAME=main
export IMAGE_MAIN_TAG=3.72.3

collector_image_tag=3.11.2

Deploy using helm. Confirm that the NetworkGraph is not correct. Switch to patch version and confirm that it working correctly.