### PR TITLE
ROX-14973: Use batch/v1 in 3.73 for compatibility with OCP 4.12

### DIFF
--- a/sensor/kubernetes/listener/resource_event_handler.go
+++ b/sensor/kubernetes/listener/resource_event_handler.go
@@ -202,7 +202,7 @@ func (k *listenerImpl) handleAllEvents() {
 	handle(resyncingSif.Apps().V1().DaemonSets().Informer(), dispatchers.ForDeployments(kubernetes.DaemonSet), k.outputQueue, &syncingResources, wg, stopSignal, &eventLock)
 	handle(resyncingSif.Apps().V1().Deployments().Informer(), dispatchers.ForDeployments(kubernetes.Deployment), k.outputQueue, &syncingResources, wg, stopSignal, &eventLock)
 	handle(resyncingSif.Apps().V1().StatefulSets().Informer(), dispatchers.ForDeployments(kubernetes.StatefulSet), k.outputQueue, &syncingResources, wg, stopSignal, &eventLock)
-	handle(resyncingSif.Batch().V1beta1().CronJobs().Informer(), dispatchers.ForDeployments(kubernetes.CronJob), k.outputQueue, &syncingResources, wg, stopSignal, &eventLock)
+	handle(resyncingSif.Batch().V1().CronJobs().Informer(), dispatchers.ForDeployments(kubernetes.CronJob), k.outputQueue, &syncingResources, wg, stopSignal, &eventLock)
 
 	if osAppsFactory != nil {
 		handle(osAppsFactory.Apps().V1().DeploymentConfigs().Informer(), dispatchers.ForDeployments(kubernetes.DeploymentConfig), k.outputQueue, &syncingResources, wg, stopSignal, &eventLock)

--- a/sensor/kubernetes/listener/resources/convert.go
+++ b/sensor/kubernetes/listener/resources/convert.go
@@ -23,7 +23,7 @@ import (
 	"github.com/stackrox/rox/sensor/kubernetes/listener/resources/references"
 	"github.com/stackrox/rox/sensor/kubernetes/orchestratornamespaces"
 	"github.com/stackrox/rox/sensor/kubernetes/selector"
-	"k8s.io/api/batch/v1beta1"
+	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -189,7 +189,7 @@ func (w *deploymentWrap) populateNonStaticFields(obj interface{}, action *centra
 		// instead of looking for it inside a PodTemplate.
 		podLabels = o.Labels
 		labelSelector = w.populateK8sComponentIfNecessary(o, hierarchy)
-	case *v1beta1.CronJob:
+	case *batchv1.CronJob:
 		// Cron jobs have a Job spec that then have a Pod Template underneath
 		podLabels = o.Spec.JobTemplate.Spec.Template.GetLabels()
 		podSpec = o.Spec.JobTemplate.Spec.Template.Spec


### PR DESCRIPTION
## Description

Brings in the changes from here https://github.com/stackrox/stackrox/pull/3854 to 3.73 to fix https://issues.redhat.com/browse/ROX-14973

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Confirmed that the issue was fixed

## Testing Performed
Planned testing

infractl create openshift-4 jouko-0208-ocp-4-12-1 --description "Testing bug with k8s 1.25" --arg openshift-version=ocp/4.12.1

export CENTRAL_IMAGE_REGISTRY=quay.io/stackrox-io
export CENTRAL_IMAGE_NAME=main
export CENTRAL_IMAGE_TAG=3.73.2

export SCANNER_DBIMAGE_REGISTRY=quay.io/stackrox-io
export SCANNER_DBIMAGE_NAME=scanner-db
export SCANNER_DBIMAGE_TAG=2.27.5

export IMAGE_MAIN_REGISTRY=quay.io/stackrox-io
export IMAGE_MAIN_NAME=main
export IMAGE_MAIN_TAG=3.73.2

collector_image_tag=3.12.1

Deploy using helm. Confirm that the NetworkGraph is not correct. Switch to patch version and confirm that it working correctly.
