### PR TITLE
roxctl interactive mode: handle order change after Go update

### DIFF
--- a/tests/roxctl/bats-tests/local/expect/flavor-interactive-dummy.expect.tcl
+++ b/tests/roxctl/bats-tests/local/expect/flavor-interactive-dummy.expect.tcl
@@ -23,28 +23,27 @@ if {[llength $argv] != 2} {
 
 spawn {*}"$binary" central generate interactive
 
-expect "Enter path to the backup bundle from which to restore keys and certificates*" { send "\n" }
-expect "Enter read templates from local filesystem*" { send "\n" }
-expect "Enter path to helm templates on your local filesystem*" { send "\n" }
-expect "Enter PEM cert bundle file*" { send "\n" }
-expect "Enter Create PodSecurityPolicy resources*" { send "\n" }
-expect "Enter administrator password*" { send "\n" }
-expect "Enter orchestrator (k8s, openshift)*" { send "k8s\n" }
-expect "Enter the directory to output the deployment bundle to*" { send "$out_dir\n" }
+expect "Enter path to the backup bundle from which to restore keys and certificates*: " { send "\n" }
+expect "Enter read templates from local filesystem*:*: " { send "\n" }
+expect "Enter path to helm templates on your local filesystem*:*: " { send "\n" }
+expect "Enter PEM cert bundle file*: " { send "\n" }
+expect "Enter Create PodSecurityPolicy resources*:*: " { send "\n" }
+expect "Enter administrator password*:*: " { send "\n" }
+expect "Enter orchestrator (k8s, openshift)*: " { send "k8s\n" }
 # Sending invalid value
-expect "Enter default container images settings*" { send "dummy\n" }
+expect "Enter default container images settings*:*:" { send "dummy\n" }
 
 expect {
   "Unexpected value 'dummy', allowed values are*" {
     send "rhacs\n"
     # ensure that the next question is correct after providing a valid answer
-    expect "Enter the method of exposing Central*" {
+    expect "Enter the directory to output*" {
       exit 0
     }
     send_user "\nERROR: roxctl accepted 'rhacs' as flavor and generated unexpected question afterwards\n"
     exit 2
   }
-  "Enter the method of exposing Central*" {
+  "Enter the directory to output*" {
     send_user "\nERROR: roxctl accepted 'dummy' as flavor and did not ask for correction immediately\n"
     exit 1
   }

--- a/tests/roxctl/bats-tests/local/expect/flavor-interactive-postgres.expect.tcl
+++ b/tests/roxctl/bats-tests/local/expect/flavor-interactive-postgres.expect.tcl
@@ -38,6 +38,7 @@ expect "Enter Create PodSecurityPolicy resources*:*: " { send "\n" }
 expect "Enter administrator password*:*: " { send "\n" }
 expect "Enter orchestrator (k8s, openshift)*: " { send "k8s\n" }
 expect "Enter default container images settings*:*: " { send "$flavor\n" }
+expect "Enter the directory to output the deployment bundle to*:*: " { send "$out_dir\n" }
 
 # Enter central-db image to use (default: "docker.io/stackrox/central-db:2.21.0-15-g448f2dc8fa"):
 # Enter central-db image to use (default: "stackrox.io/central-db:3.67.x-296-g56df6a892d"):
@@ -63,6 +64,7 @@ expect {
   }
 }
 
+expect "Enter whether to enable telemetry*:*: " { send "\n" }
 expect "Enter the method of exposing Central*:*: " { send "none\n" }
 
 # Enter main image to use (default: "docker.io/stackrox/main:3.67.x-296-g56df6a892d"):
@@ -91,7 +93,6 @@ expect {
 
 
 expect "Enter whether to run StackRox in offline mode, which avoids reaching out to the Internet*" { send "\n" }
-expect "Enter whether to enable telemetry*:*: " { send "\n" }
 expect "Enter the deployment tool to use (kubectl, helm, helm-values)*:" { send "\n" }
 expect "Enter Istio version when deploying into an Istio-enabled cluster*:" { send "\n" }
 

--- a/tests/roxctl/bats-tests/local/expect/flavor-interactive-postgres.expect.tcl
+++ b/tests/roxctl/bats-tests/local/expect/flavor-interactive-postgres.expect.tcl
@@ -30,15 +30,14 @@ if {[llength $argv] != 4} {
 
 spawn {*}"$binary" central generate interactive
 
-expect "Enter path to the backup bundle from which to restore keys and certificates*" { send "\n" }
-expect "Enter read templates from local filesystem*" { send "\n" }
-expect "Enter path to helm templates on your local filesystem*" { send "\n" }
-expect "Enter PEM cert bundle file*" { send "\n" }
-expect "Enter Create PodSecurityPolicy resources*" { send "\n" }
-expect "Enter administrator password*" { send "\n" }
-expect "Enter orchestrator (k8s, openshift)*" { send "k8s\n" }
-expect "Enter the directory to output the deployment bundle to*" { send "$out_dir\n" }
-expect "Enter default container images settings*" { send "$flavor\n" }
+expect "Enter path to the backup bundle from which to restore keys and certificates*: " { send "\n" }
+expect "Enter read templates from local filesystem*:*: " { send "\n" }
+expect "Enter path to helm templates on your local filesystem*:*: " { send "\n" }
+expect "Enter PEM cert bundle file*: " { send "\n" }
+expect "Enter Create PodSecurityPolicy resources*:*: " { send "\n" }
+expect "Enter administrator password*:*: " { send "\n" }
+expect "Enter orchestrator (k8s, openshift)*: " { send "k8s\n" }
+expect "Enter default container images settings*:*: " { send "$flavor\n" }
 
 # Enter central-db image to use (default: "docker.io/stackrox/central-db:2.21.0-15-g448f2dc8fa"):
 # Enter central-db image to use (default: "stackrox.io/central-db:3.67.x-296-g56df6a892d"):
@@ -64,7 +63,8 @@ expect {
   }
 }
 
-expect "Enter the method of exposing Central*" { send "none\n" }
+expect "Enter the method of exposing Central*:*: " { send "none\n" }
+
 # Enter main image to use (default: "docker.io/stackrox/main:3.67.x-296-g56df6a892d"):
 # Enter main image to use (default: "stackrox.io/main:3.67.x-296-g56df6a892d")
 # Enter main image to use (default: "registry.redhat.io/advanced-cluster-security/rhacs-main-rhel8:3.68.x-30-g516b4e7a6c-dirty"):
@@ -91,7 +91,7 @@ expect {
 
 
 expect "Enter whether to run StackRox in offline mode, which avoids reaching out to the Internet*" { send "\n" }
-expect "Enter whether to enable telemetry*" { send "\n" }
+expect "Enter whether to enable telemetry*:*: " { send "\n" }
 expect "Enter the deployment tool to use (kubectl, helm, helm-values)*:" { send "\n" }
 expect "Enter Istio version when deploying into an Istio-enabled cluster*:" { send "\n" }
 

--- a/tests/roxctl/bats-tests/local/expect/flavor-interactive.expect.tcl
+++ b/tests/roxctl/bats-tests/local/expect/flavor-interactive.expect.tcl
@@ -33,16 +33,17 @@ if {[llength $argv] != 4} {
 
 spawn {*}"$binary" central generate interactive
 
-expect "Enter path to the backup bundle from which to restore keys and certificates*" { send "\n" }
-expect "Enter read templates from local filesystem*" { send "\n" }
-expect "Enter path to helm templates on your local filesystem*" { send "\n" }
-expect "Enter PEM cert bundle file*" { send "\n" }
-expect "Enter Create PodSecurityPolicy resources*" { send "\n" }
-expect "Enter administrator password*" { send "\n" }
-expect "Enter orchestrator (k8s, openshift)*" { send "k8s\n" }
-expect "Enter the directory to output the deployment bundle to*" { send "$out_dir\n" }
-expect "Enter default container images settings*" { send "$flavor\n" }
-expect "Enter the method of exposing Central*" { send "none\n" }
+expect "Enter path to the backup bundle from which to restore keys and certificates*: " { send "\n" }
+expect "Enter read templates from local filesystem*:*: " { send "\n" }
+expect "Enter path to helm templates on your local filesystem*:*: " { send "\n" }
+expect "Enter PEM cert bundle file*: " { send "\n" }
+expect "Enter Create PodSecurityPolicy resources*:*: " { send "\n" }
+expect "Enter administrator password*:*: " { send "\n" }
+expect "Enter orchestrator (k8s, openshift)*: " { send "k8s\n" }
+expect "Enter default container images settings*:*: " { send "$flavor\n" }
+expect "Enter the directory to output the deployment bundle to*:*: " { send "$out_dir\n" }
+expect "Enter whether to enable telemetry*:*: " { send "\n" }
+expect "Enter the method of exposing Central*:*: " { send "none\n" }
 
 # Enter main image to use (default: "docker.io/stackrox/main:3.67.x-296-g56df6a892d"):
 # Enter main image to use (default: "stackrox.io/main:3.67.x-296-g56df6a892d")
@@ -68,7 +69,6 @@ expect {
   }
 }
 expect "Enter whether to run StackRox in offline mode, which avoids reaching out to the Internet*" { send "\n" }
-expect "Enter whether to enable telemetry*" { send "\n" }
 expect "Enter the deployment tool to use (kubectl, helm, helm-values)*:" { send "\n" }
 expect "Enter Istio version when deploying into an Istio-enabled cluster*:" { send "\n" }
 


### PR DESCRIPTION
## Description

Handle the change to prompt order after Go 1.18->1.19. This PR also makes the prompt match more strict as I noticed that some expect calls would silently timeout. As to wether the new order is correct is up for discussion.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient