### PR TITLE
ROX-14974: Tune waitForEdgeUpdate time

### DIFF
--- a/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
@@ -626,8 +626,8 @@ class NetworkFlowTest extends BaseSpecification {
 
         then:
         "make sure edge does not get updated"
-        //Use a 20 second buffer to account for additional edges coming in through the data pipeline
-        assert !waitForEdgeUpdate(edges.get(0), 60, 20)
+        //Use one cadence buffer to account for additional edges coming in through the data pipeline
+        assert !waitForEdgeUpdate(edges.get(0), 60, NetworkGraphUtil.NETWORK_FLOW_UPDATE_CADENCE_IN_SECONDS)
 
         cleanup:
         "remove policy"


### PR DESCRIPTION
## Description

Tuning for test flake in `Verify cluster updates can block flow connections from showing` (`NetworkFlowTest.groovy`)

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
