### PR TITLE
Dashrews/ROX-14618 external backup test flakes

### DIFF
--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -40,10 +40,16 @@ test_e2e() {
     store_test_results "roxctl-test-output" "roxctl-test-output"
     [[ ! -f FAIL ]] || die "roxctl e2e tests failed"
 
+    # Give some time for previous tests to finish up
+    wait_for_api
+
     info "E2E API tests"
     make -C tests || touch FAIL
     store_test_results "tests/all-tests-results" "all-tests-results"
     [[ ! -f FAIL ]] || die "e2e API tests failed"
+
+    # Give some time for previous tests to finish up
+    wait_for_api
 
     info "Sensor k8s integration tests"
     make sensor-integration-test || touch FAIL
@@ -53,17 +59,25 @@ test_e2e() {
     store_test_results "test-output/test.log" "sensor-integration"
     [[ ! -f FAIL ]] || die "sensor-integration e2e tests failed"
 
+    # Give some time for previous tests to finish up
+    wait_for_api
+
     setup_proxy_tests "localhost"
     run_proxy_tests "localhost"
     cd "$ROOT"
 
     collect_and_check_stackrox_logs "/tmp/e2e-test-logs" "initial_tests"
 
+    # Give some time for previous tests to finish up
+    wait_for_api
+
     info "E2E destructive tests"
     make -C tests destructive-tests || touch FAIL
     store_test_results "tests/destructive-tests-results" "destructive-tests-results"
     [[ ! -f FAIL ]] || die "destructive e2e tests failed"
 
+    # Give some time for previous tests to finish up
+    wait_for_api
     restore_56_1_backup
     wait_for_api
 

--- a/tests/external_backup_test.go
+++ b/tests/external_backup_test.go
@@ -92,7 +92,7 @@ func TestGCSExternalBackup(t *testing.T) {
 	},
 		retry.Tries(10),
 		retry.BetweenAttempts(func(_ int) {
-			time.Sleep(1 * time.Second)
+			time.Sleep(10 * time.Second)
 		}),
 		retry.OnFailedAttempts(func(err error) {
 			log.Error(err.Error())

--- a/tests/external_backup_test.go
+++ b/tests/external_backup_test.go
@@ -100,7 +100,7 @@ func TestGCSExternalBackup(t *testing.T) {
 	)
 	assert.NoError(t, err)
 
-	ctx, cancel = context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	backup, err := service.PostExternalBackup(ctx, externalBackup)
 	assert.NoError(t, err)
 	cancel()


### PR DESCRIPTION
## Description

This doesn't happen all that often considering how frequently the tests runs so it is not something I was able to reproduce.  That said, after looking at the logs, it appears that central is simply not ready as it looks like it is in the middle of a restore from a previous test when this is encountered.  So my theory is it just needs time.  I took 2 approaches.  I added some checks between the tests to make sure central is ready.  Additionally I put the first call to test the backups in a retry.  No need to put the others in a retry as if the first one fails the test fails and likely all the other attempts will fail.  I'm open to other ideas.

## Checklist
- [x] Investigated and inspected CI test results
~- [ ] Unit test and regression tests added~
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

this is a test
