### PR TITLE
CI: Less spam

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -29,8 +29,4 @@ migrator/**/*       @stackrox/data-shepherds
 pkg/postgres/**/*   @stackrox/data-shepherds
 tests/upgrade/*     @stackrox/data-shepherds
 
-.github/**/* @stackrox/ci
-.openshift-ci/**/* @stackrox/ci
-scripts/ci/** @stackrox/ci
-
 operator/**/* @stackrox/draco


### PR DESCRIPTION
## Description

Being in CODEOWNERs means getting review emails for PRs that are WIP. I'd rather not. If other members of the stackrox/ci group like the spam I can remove myself from the group.

## Checklist
- n/a

## Testing Performed
- n/a