### PR TITLE
ROX-14996 - Add retry in verify syslog test

### DIFF
--- a/qa-tests-backend/src/test/groovy/IntegrationsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/IntegrationsTest.groovy
@@ -184,8 +184,8 @@ class IntegrationsTest extends BaseSpecification {
 
     @Unroll
     @Tag("Integration")
-    // splunk is not supported on P/Z
     @IgnoreIf({ Env.REMOTE_CLUSTER_ARCH == "ppc64le" || Env.REMOTE_CLUSTER_ARCH == "s390x" })
+    // splunk is not supported on P/Z
     def "Verify Splunk Integration (legacy mode: #legacy)"() {
         given:
         "the integration is tested"
@@ -755,13 +755,13 @@ class IntegrationsTest extends BaseSpecification {
         }       | StatusRuntimeException | /PermissionDenied/ | "incorrect project"
     }
 
-    @Unroll
     @Tag("Integration")
     @Tag("BAT")
     def "Verify syslog notifier"() {
        given:
        "syslog server is created"
        def syslog = SyslogServer.createRsyslog(orchestrator, Constants.ORCHESTRATOR_NAMESPACE)
+       sleep 15 * 1000 // wait 15s for service to start
 
         when:
         "call the grpc API for the syslog notifier integration."
@@ -769,8 +769,9 @@ class IntegrationsTest extends BaseSpecification {
 
         then:
         "Verify syslog connection is successful"
-        assert notifier.testNotifier()
-
+        withRetry(3, 10) {
+            assert notifier.testNotifier()
+        }
         cleanup:
         "remove syslog notifier integration"
         syslog.tearDown(orchestrator)

--- a/qa-tests-backend/src/test/groovy/IntegrationsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/IntegrationsTest.groovy
@@ -757,6 +757,7 @@ class IntegrationsTest extends BaseSpecification {
 
     @Unroll
     @Tag("Integration")
+    @Tag("BAT")
     def "Verify syslog notifier"() {
        given:
        "syslog server is created"

--- a/qa-tests-backend/src/test/groovy/IntegrationsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/IntegrationsTest.groovy
@@ -184,8 +184,8 @@ class IntegrationsTest extends BaseSpecification {
 
     @Unroll
     @Tag("Integration")
-    @IgnoreIf({ Env.REMOTE_CLUSTER_ARCH == "ppc64le" || Env.REMOTE_CLUSTER_ARCH == "s390x" })
     // splunk is not supported on P/Z
+    @IgnoreIf({ Env.REMOTE_CLUSTER_ARCH == "ppc64le" || Env.REMOTE_CLUSTER_ARCH == "s390x" })
     def "Verify Splunk Integration (legacy mode: #legacy)"() {
         given:
         "the integration is tested"
@@ -756,7 +756,6 @@ class IntegrationsTest extends BaseSpecification {
     }
 
     @Tag("Integration")
-    @Tag("BAT")
     def "Verify syslog notifier"() {
        given:
        "syslog server is created"


### PR DESCRIPTION
## Description
Verify syslog notifier is intermittently failing in CI with connection error. Added retry in assert test syslog section to give some time for syslog service to come up after deployment. 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Ran test few times locally to make sure there are no failures.
