### PR TITLE
Restore CentralDBEnabledPtr

### DIFF
--- a/operator/apis/platform/v1alpha1/central_types.go
+++ b/operator/apis/platform/v1alpha1/central_types.go
@@ -220,6 +220,13 @@ const (
 	CentralDBEnabledTrue CentralDBEnabled = "Enabled"
 )
 
+// CentralDBEnabledPtr return a pointer for the given CentralDBEnabled value
+func CentralDBEnabledPtr(c CentralDBEnabled) *CentralDBEnabled {
+	ptr := new(CentralDBEnabled)
+	*ptr = c
+	return ptr
+}
+
 // GetPasswordSecret provides a way to retrieve the admin password that is safe to use on a nil receiver object.
 func (c *CentralDBSpec) GetPasswordSecret() *LocalSecretReference {
 	if c == nil {


### PR DESCRIPTION
## Description

The function `CentralDBEnabledPtr()` is still used by `acs-fleet-manager` and should have not been removed, as long as the field `IsEnabled` still exists and must be set to `Enabled` in ACSCS.

## Checklist
- [ ] Investigated and inspected CI test results
~~- [ ] Unit test and regression tests added~~
~~- [ ] Evaluated and added CHANGELOG entry if required~~
~~- [ ] Determined and documented upgrade steps~~
~~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

CI should be sufficient, this just restores a function deleted in this PR https://github.com/stackrox/stackrox/pull/4372
