### PR TITLE
ROX-14979: Trim `sso:provider-id:` prefix from user ID

### DIFF
--- a/central/telemetry/centralclient/instance_config.go
+++ b/central/telemetry/centralclient/instance_config.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/grpc"
-	"github.com/stackrox/rox/pkg/grpc/authn/tokenbased"
 	"github.com/stackrox/rox/pkg/grpc/client/authn/basic"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/sac"
@@ -145,15 +144,6 @@ func registerInterceptors(config grpc.Config) {
 // it to the tenant group specifically.
 func registerAdminUser(basicAuthProviderID string) {
 	cfg := InstanceConfig()
-
-	// Add the basic authorization ID form ('admin'):
 	adminHash := cfg.HashUserID(basic.DefaultUsername, basicAuthProviderID)
 	cfg.Telemeter().Group(cfg.GroupID, nil, telemeter.WithUserID(adminHash))
-
-	// Add the token based ID form ('sso:<provider id>:admin'):
-	adminTokenHash := cfg.HashUserID(
-		tokenbased.FormatUserID(basic.DefaultUsername, basicAuthProviderID),
-		basicAuthProviderID,
-	)
-	cfg.Telemeter().Group(cfg.GroupID, nil, telemeter.WithUserID(adminTokenHash))
 }

--- a/pkg/grpc/authn/tokenbased/extractor.go
+++ b/pkg/grpc/authn/tokenbased/extractor.go
@@ -149,7 +149,7 @@ func (e *extractor) withExternalUser(ctx context.Context, token *tokens.TokenInf
 
 func createRoleBasedIdentity(roles []permissions.ResolvedRole, token *tokens.TokenInfo, authProvider authproviders.Provider) *roleBasedIdentity {
 	id := &roleBasedIdentity{
-		uid:           FormatUserID(token.Sources[0].ID(), token.ExternalUser.UserID),
+		uid:           fmt.Sprintf("sso:%s:%s", token.Sources[0].ID(), token.ExternalUser.UserID),
 		username:      token.ExternalUser.Email,
 		friendlyName:  token.ExternalUser.FullName,
 		fullName:      token.ExternalUser.FullName,
@@ -168,9 +168,4 @@ func createRoleBasedIdentity(roles []permissions.ResolvedRole, token *tokens.Tok
 		id.friendlyName += fmt.Sprintf(" (%s)", token.ExternalUser.Email)
 	}
 	return id
-}
-
-// FormatUserID returns a compound identity of the source and the user.
-func FormatUserID(sourceID string, userID string) string {
-	return fmt.Sprintf("sso:%s:%s", sourceID, userID)
 }

--- a/pkg/telemetry/phonehome/hash.go
+++ b/pkg/telemetry/phonehome/hash.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
+	"strings"
 
 	"github.com/stackrox/rox/pkg/grpc/authn"
 )
@@ -38,6 +39,7 @@ func (cfg *Config) HashUserAuthID(id authn.Identity) string {
 		userID = id.UID()
 		if provider := id.ExternalAuthProvider(); provider != nil {
 			providerID = provider.ID()
+			userID = strings.TrimPrefix(userID, "sso:"+providerID+":")
 		}
 	}
 	return cfg.HashUserID(userID, providerID)

--- a/pkg/telemetry/phonehome/hash_test.go
+++ b/pkg/telemetry/phonehome/hash_test.go
@@ -38,6 +38,11 @@ func TestConfig_HashUserAuthID(t *testing.T) {
 	id.EXPECT().ExternalAuthProvider().Return(provider).Times(1)
 	h = cfg.HashUserAuthID(id)
 	assert.Equal(t, hash("test-client:test-provider:test-id"), h)
+
+	id.EXPECT().UID().Return("sso:test-provider:test-id").Times(1)
+	id.EXPECT().ExternalAuthProvider().Return(provider).Times(1)
+	h = cfg.HashUserAuthID(id)
+	assert.Equal(t, hash("test-client:test-provider:test-id"), h)
 }
 
 func TestConfig_HashAdminUserID(t *testing.T) {


### PR DESCRIPTION
## Description

We have 2 points of user identity extractions:
1. when a user logs in for the first time, the central will add the user to the tenant group;
2. when the user calls central, the central may issue an event, with the user ID.

There's apparently a problem in that those two cases produce different user IDs:
1. uses the actual user ID, like `admin` or `test@stackrox.com`;
2. uses the token-based ID, like `sso:3dadd0b0-1649-426e-81d5-cde3fce5e181:test@stackrox.com`.

As the two IDs do not match, the actual events get no assigned tenant group. This explains why we miss the 'Secured Cluster Registered' event in the funnel.

## The change

This PR make the hash function to trim the prefix generated by the tokenbased id extractor, so that 
user IDs extracted from tokens of the requests to central would match the original auth provider id of the user.

Previously, the `admin` user was added to the tenant group in both forms: `admin` and `sso:...:admin`. This is now removed.

Removed also the `FormatUserID` method extraction, now unused.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

"Secured Cluster Registered" event initiated by the admin user via UI shows the user ID in the original form of "admin" without the `sso:` prefix. Compare the user hash here:
```sh
$ print -n "8da267ec-9cc6-443b-ae70-69ecff1b8654:4df1b98c-24ed-4073-a9ad-356aec6bb62d:admin" | sha256sum | xxd -r -p | base64
obWqrhs09AnMESltTmgXWF5VY8BNpcLFFndV1kMwLqY=
```
And there:
```json
{
  "context": {
    "device": {
      "id": "8da267ec-9cc6-443b-ae70-69ecff1b8654",
      "type": "Central"
    },
    "library": {
      "name": "analytics-go",
      "version": "3.0.0"
    }
  },
  "event": "Secured Cluster Registered",
  "integrations": {},
  "messageId": "dfe0b8db-2cf9-4809-ab2b-1a210b6ab424",
  "originalTimestamp": "2023-02-10T10:40:35.590761234Z",
  "properties": {
    "Cluster ID": "6bbb49b6-19d6-4585-b111-2567832299ab",
    "Cluster Type": "KUBERNETES_CLUSTER",
    "Managed By": "MANAGER_TYPE_UNKNOWN"
  },
  "receivedAt": "2023-02-10T10:40:43.778Z",
  "sentAt": "2023-02-10T10:40:43.118Z",
  "timestamp": "2023-02-10T10:40:36.250Z",
  "type": "track",
  "userId": "obWqrhs09AnMESltTmgXWF5VY8BNpcLFFndV1kMwLqY=",
  "writeKey": "..."
}
```
