### PR TITLE
Setup link for "penult" operator e2e tests

### DIFF
--- a/scripts/ci/jobs/openshift_penult_operator_e2e_tests.py
+++ b/scripts/ci/jobs/openshift_penult_operator_e2e_tests.py
@@ -1,0 +1,1 @@
+openshift_4_operator_e2e_tests.py


### PR DESCRIPTION
## Description

Setup link for "penult" operator e2e tests in order to be able to run them on merges.
The problem is that OSCI does not like the test name `merge-openshift-penultimate-operator-e2e-tests` as being too long, therefore shortened it to `merge-openshift-penult-operator-e2e-tests` in order to make OSCI happy.

See https://github.com/openshift/release/pull/36268

## Checklist
- [ ] Investigated and inspected CI test results

Won't do these:
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

None.

```
$ pwd
/home/misha/go/src/github.com/stackrox/stackrox/scripts/ci/jobs

$ ls -l openshift_*_operator_e2e_tests.py
-rwxrwxr-x 1 misha misha 497 Okt 31 15:36 openshift_4_operator_e2e_tests.py
lrwxrwxrwx 1 misha misha  33 Okt 31 15:36 openshift_beta_operator_e2e_tests.py -> openshift_4_operator_e2e_tests.py
lrwxrwxrwx 1 misha misha  33 Okt 31 15:36 openshift_newest_operator_e2e_tests.py -> openshift_4_operator_e2e_tests.py
lrwxrwxrwx 1 misha misha  33 Okt 31 15:36 openshift_oldest_operator_e2e_tests.py -> openshift_4_operator_e2e_tests.py
lrwxrwxrwx 1 misha misha  33 Okt 31 15:36 openshift_penultimate_operator_e2e_tests.py -> openshift_4_operator_e2e_tests.py
lrwxrwxrwx 1 misha misha  33 Feb 10 18:32 openshift_penult_operator_e2e_tests.py -> openshift_4_operator_e2e_tests.py
```