### PR TITLE
ROX-13379: Fix bug when typing new page number among CVE types

### DIFF
--- a/ui/apps/platform/src/Components/TablePagination.js
+++ b/ui/apps/platform/src/Components/TablePagination.js
@@ -27,10 +27,7 @@ const TablePagination = ({ dataLength, setPage, page, pageSize }) => {
     const [localPage, setLocalPage] = useState(page + 1);
 
     // 2. debounce the setPage callback to delay the setPage call when typing
-    const delayedSetPage = useCallback(
-        debounce((newPage) => setPage(newPage), TYPING_DELAY),
-        []
-    );
+    const delayedSetPage = debounce((newPage) => setPage(newPage), TYPING_DELAY);
 
     useEffect(() => {
         setLocalPage(page + 1);

--- a/ui/apps/platform/src/Components/TablePagination.js
+++ b/ui/apps/platform/src/Components/TablePagination.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import * as Icon from 'react-feather';
 import { withRouter } from 'react-router-dom';


### PR DESCRIPTION
## Description

After a lot of dead-ends, I finally tracked down this bug.

Immediate cause: 
- The `stateStack` property of the "workflowState" is what we use to capture the infinite possible levels of the Vulnerability section.
- Now that the CVE type has been split into 3 separate types for Postgres, we still use the same template option for all CVEs, but varying the rendering options based on the new CVE type.
- Since the whole render tree from the root template was no longer changing when going directly from one CVE type to another, the Pagination component was not getting re-created.
- Surprise! the part of the pagination component where you can type any page number to go directly to that page of the results, besides being wrapped in a "debounce" function to prevent a flurry of API calls when typing, was then wrapped a React `useCallback` hook, to save recreating that function on re-render.
- Ooops! that useCallback had a side-effect of saving the old saved context of the workflow state, which causes a redirect to the wrong CVE type when typing a page number

Simple solution:
Don't wrap the curried debounce function in a `useCallback`. This is trivially less efficient because that function then gets redefined on each re-render, but since there should be only one pagination component on the screen at one time, and it's a one-line function with small set of identifiers in its closure, this seems a worthwhile trade-off to fix the React bug.

## Checklist
- [x] Investigated and inspected CI test results. (non-Postgres ui-e2e tests aren't running right now)


## Testing Performed

Tested without the fix, a page outside the scope of the previous CVE type's page range shows a crash (as an example of the CVE type changing unexpectedly)
<img width="1612" alt="Screen Shot 2023-02-10 at 12 44 01 PM" src="https://user-images.githubusercontent.com/715729/218160819-7b048f07-4cda-439a-adcb-6502e3f4a30e.png">

With this change, the CVE type does not change when entering a page number directly
<img width="1612" alt="Screen Shot 2023-02-10 at 12 42 52 PM" src="https://user-images.githubusercontent.com/715729/218160894-e0d949b1-96ac-4e70-acb8-34333f3f8ee7.png">
