### PR TITLE
ROX-13813: fail in a visible way when scanner protos cannot be found

### DIFF
--- a/make/protogen.mk
+++ b/make/protogen.mk
@@ -23,11 +23,12 @@ GENERATED_API_GW_SRCS = $(SERVICE_PROTOS_REL:%.proto=$(GENERATED_BASE_PATH)/%.pb
 GENERATED_API_SWAGGER_SPECS = $(API_SERVICE_PROTOS:%.proto=$(GENERATED_BASE_PATH)/%.swagger.json)
 
 SCANNER_DIR = $(shell go list -f '{{.Dir}}' -m github.com/stackrox/scanner)
-ifneq ($(SCANNER_DIR),)
+ifeq ($(SCANNER_DIR),)
+$(error Cached directory of scanner dependency not found, run 'go mod tidy')
+endif
 SCANNER_PROTO_BASE_PATH = $(SCANNER_DIR)/proto
 ALL_SCANNER_PROTOS = $(shell find $(SCANNER_PROTO_BASE_PATH) -name '*.proto')
 ALL_SCANNER_PROTOS_REL = $(ALL_SCANNER_PROTOS:$(SCANNER_PROTO_BASE_PATH)/%=%)
-endif
 
 ##############
 ## Protobuf ##

--- a/make/protogen.mk
+++ b/make/protogen.mk
@@ -23,12 +23,11 @@ GENERATED_API_GW_SRCS = $(SERVICE_PROTOS_REL:%.proto=$(GENERATED_BASE_PATH)/%.pb
 GENERATED_API_SWAGGER_SPECS = $(API_SERVICE_PROTOS:%.proto=$(GENERATED_BASE_PATH)/%.swagger.json)
 
 SCANNER_DIR = $(shell go list -f '{{.Dir}}' -m github.com/stackrox/scanner)
-ifeq ($(SCANNER_DIR),)
-$(error Cached directory of scanner dependency not found, run 'go mod tidy')
-endif
+ifneq ($(SCANNER_DIR),)
 SCANNER_PROTO_BASE_PATH = $(SCANNER_DIR)/proto
 ALL_SCANNER_PROTOS = $(shell find $(SCANNER_PROTO_BASE_PATH) -name '*.proto')
 ALL_SCANNER_PROTOS_REL = $(ALL_SCANNER_PROTOS:$(SCANNER_PROTO_BASE_PATH)/%=%)
+endif
 
 ##############
 ## Protobuf ##
@@ -188,6 +187,9 @@ $(GENERATED_DOC_PATH):
 # files change.
 $(GENERATED_BASE_PATH)/%.pb.go: $(PROTO_BASE_PATH)/%.proto $(PROTO_DEPS) $(PROTOC_GEN_GRPC_GATEWAY) $(PROTOC_GEN_GO_BIN) $(ALL_PROTOS)
 	@echo "+ $@"
+ifeq ($(SCANNER_DIR),)
+	$(error Cached directory of scanner dependency not found, run 'go mod tidy')
+endif
 	$(SILENT)mkdir -p $(dir $@)
 	$(SILENT)PATH=$(PROTO_GOBIN) $(PROTOC) \
 		-I$(GOGO_DIR) \
@@ -203,6 +205,9 @@ $(GENERATED_BASE_PATH)/%.pb.go: $(PROTO_BASE_PATH)/%.proto $(PROTO_DEPS) $(PROTO
 # .proto files change.
 $(GENERATED_BASE_PATH)/%_service.pb.gw.go: $(PROTO_BASE_PATH)/%_service.proto $(GENERATED_BASE_PATH)/%_service.pb.go $(ALL_PROTOS)
 	@echo "+ $@"
+ifeq ($(SCANNER_DIR),)
+	$(error Cached directory of scanner dependency not found, run 'go mod tidy')
+endif
 	$(SILENT)mkdir -p $(dir $@)
 	$(SILENT)PATH=$(PROTO_GOBIN) $(PROTOC) \
 		-I$(PROTOC_INCLUDES) \
@@ -218,6 +223,9 @@ $(GENERATED_BASE_PATH)/%_service.pb.gw.go: $(PROTO_BASE_PATH)/%_service.proto $(
 # .proto files change.
 $(GENERATED_BASE_PATH)/%.swagger.json: $(PROTO_BASE_PATH)/%.proto $(PROTO_DEPS) $(PROTOC_GEN_GRPC_GATEWAY) $(PROTOC_GEN_SWAGGER) $(ALL_PROTOS)
 	@echo "+ $@"
+ifeq ($(SCANNER_DIR),)
+	$(error Cached directory of scanner dependency not found, run 'go mod tidy')
+endif
 	$(SILENT)PATH=$(PROTO_GOBIN) $(PROTOC) \
 		-I$(GOGO_DIR) \
 		-I$(PROTOC_INCLUDES) \


### PR DESCRIPTION
## Description

Previously, if one did not fetch the dependencies since the scanner dep was bumped you'd get a cryptic error such as:

```
[mowsiany@mowsiany operator]$ make generate
make -C .. proto-generated-srcs
make[1]: Entering directory '/home/mowsiany/go/src/github.com/stackrox/stackrox'
+ Checking if github.com/grpc-ecosystem/grpc-gateway is up-to-date
+ Checking if github.com/gogo/protobuf is up-to-date
+ /home/mowsiany/go/src/github.com/stackrox/stackrox/generated/api/integrations/splunk_service.pb.go
Missing value for flag: -I
make[1]: *** [make/protogen.mk:191: /home/mowsiany/go/src/github.com/stackrox/stackrox/generated/api/integrations/splunk_service.pb.go] Error 1
make[1]: Leaving directory '/home/mowsiany/go/src/github.com/stackrox/stackrox'
make: *** [Makefile:197: parent-proto-generate] Error 2
```

The root cause is that `go list -f '{{.Dir}}' -m github.com/stackrox/scanner` in such situation returns an empty string.

This change detects this situation earlier and fails with a more helpful message:

```
[mowsiany@mowsiany operator]$ make generate
make -C .. proto-generated-srcs
make[1]: Entering directory '/home/mowsiany/go/src/github.com/stackrox/stackrox'
make/protogen.mk:27: *** Cached directory of scanner dependency not found, run 'go mod tidy'.  Stop.
make[1]: Leaving directory '/home/mowsiany/go/src/github.com/stackrox/stackrox'
make: *** [Makefile:197: parent-proto-generate] Error 2
```

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

Ran `make -C operator generate` before and after `go mod tidy`.
