### PR TITLE
Include `.gotools` in the `$PATH` for go code generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -287,7 +287,7 @@ pkg/complianceoperator/api/v1alpha1/zz_generated.deepcopy.go: $(CONTROLLER_GEN_B
 .PHONY: go-generated-srcs
 go-generated-srcs: deps clean-easyjson-srcs go-easyjson-srcs $(MOCKGEN_BIN) $(STRINGER_BIN) pkg/complianceoperator/api/v1alpha1/zz_generated.deepcopy.go
 	@echo "+ $@"
-	PATH="$(PATH):$(BASE_DIR)/tools/generate-helpers" MOCKGEN_BIN="$(MOCKGEN_BIN)" go generate -v -x ./...
+	PATH="$(GOTOOLS_BIN):$(PATH):$(BASE_DIR)/tools/generate-helpers" MOCKGEN_BIN="$(MOCKGEN_BIN)" go generate -v -x ./...
 
 proto-generated-srcs: $(PROTO_GENERATED_SRCS) $(GENERATED_API_SWAGGER_SPECS)
 	@echo "+ $@"


### PR DESCRIPTION
## Description

This should help with `stringer` problems. At least it does solve it for my local problems.

Locally I've been seeing

```
central/graphql/resolvers/active_state.go
stringer -type=ActiveStateEnum
stringer: internal error: package "context" without types was imported from "github.com/stackrox/rox/central/graphql/resolvers"
central/graphql/resolvers/active_state.go:10: running "stringer": exit status 1
```

After some googling, that seems to happen because older `stringer` gets picked up. The obvious hunch is that `stringer` installed via `go-tool` is not visible during Go code generation.

Context: https://srox.slack.com/archives/CELUQKESC/p1674834470778089

## Checklist
- [x] Investigated and inspected CI test results

None of these:
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

* No problems locally after the fix.
* `grouped-static-checks` and `Style / check-generated-files` should remain green.