### PR TITLE
Update Central DB signal handling to default to fast shutdown

### DIFF
--- a/image/postgres/scripts/docker-entrypoint.sh
+++ b/image/postgres/scripts/docker-entrypoint.sh
@@ -346,7 +346,7 @@ _main() {
 
 	"$@" &
 	child=$!
-	echo "Waiting for child process to exit"
+	echo "Waiting for child process $child to exit"
 	wait "$child"
 }
 

--- a/image/postgres/scripts/docker-entrypoint.sh
+++ b/image/postgres/scripts/docker-entrypoint.sh
@@ -3,6 +3,12 @@
 set -Eeo pipefail
 # TODO swap to -Eeuo pipefail above (after handling all potentially-unset variables)
 
+shutdown() {
+  pg_ctl -D /var/lib/postgresql/data/pgdata stop -m fast
+}
+
+trap shutdown SIGINT SIGTERM
+
 # usage: file_env VAR [DEFAULT]
 #    ie: file_env 'XYZ_DB_PASSWORD' 'example'
 # (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
@@ -338,7 +344,10 @@ _main() {
 		fi
 	fi
 
-	exec "$@"
+	"$@" &
+	child=$!
+	echo "Waiting for child process to exit"
+	wait "$child"
 }
 
 if ! _is_sourced; then

--- a/image/templates/helm/stackrox-central/templates/01-central-12-central-db.yaml
+++ b/image/templates/helm/stackrox-central/templates/01-central-12-central-db.yaml
@@ -71,6 +71,7 @@ spec:
               - key: node-role.kubernetes.io/control-plane
                 operator: DoesNotExist
       serviceAccountName: central-db
+      terminationGracePeriodSeconds: 120
       initContainers:
       - name: init-db
         image: {{ ._rox.central.db.image.fullRef | quote }}


### PR DESCRIPTION
## Description

Default to fast shutdown, which kills all in flight txns and rolls them back. This will allow for faster shutdown and less likely sigkills in the middle of termination

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Ran the equivalent in a chaos test for several days
