### PR TITLE
Extend timeout when waiting for initial route

### DIFF
--- a/qa-tests-backend/src/test/groovy/RoutesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/RoutesTest.groovy
@@ -40,7 +40,7 @@ class RoutesTest extends BaseSpecification {
 
         then:
         "Fetch deployment, it shouldn't have a route"
-        withRetry(10, 5) {
+        withRetry(20, 5) {
             def routes = getRoutes()
             assert routes.size() == 0
         }


### PR DESCRIPTION
## Description

This route test breaks itself when it doesn't wait long enough for the initial route. Should be debugged when the route is removed

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

CI