### PR TITLE
ROX-15103 Correctly handle different alert types on dashboard widget

### DIFF
--- a/ui/apps/platform/src/Components/PatternFly/ResourceIcon/ResourceIcon.css
+++ b/ui/apps/platform/src/Components/PatternFly/ResourceIcon/ResourceIcon.css
@@ -21,3 +21,16 @@
 .resource-icon-deployment {
   background-color: var(--color-resource-deployment);
 }
+
+.resource-icon-configmap {
+  background-color: var(--color-resource-configmap);
+}
+
+.resource-icon-secret {
+  background-color: var(--color-resource-secret);
+}
+
+.resource-icon-unknown {
+  background-color: var(--color-resource-unknown);
+}
+

--- a/ui/apps/platform/src/Components/PatternFly/ResourceIcon/ResourceIcon.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/ResourceIcon/ResourceIcon.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import './ResourceIcon.css';
 
-type K8sResourceKind = 'Cluster' | 'Namespace' | 'Deployment';
+type K8sResourceKind = 'Cluster' | 'ConfigMap' | 'Deployment' | 'Namespace' | 'Secret' | 'Unknown';
 
 export type ResourceIconProps = {
     className?: string;
@@ -11,8 +11,11 @@ export type ResourceIconProps = {
 
 const IconAttributes: Record<K8sResourceKind, { text: string; classNameSuffix: string }> = {
     Cluster: { text: 'CL', classNameSuffix: 'cluster' },
-    Namespace: { text: 'NS', classNameSuffix: 'namespace' },
+    ConfigMap: { text: 'CM', classNameSuffix: 'configmap' },
     Deployment: { text: 'D', classNameSuffix: 'deployment' },
+    Namespace: { text: 'NS', classNameSuffix: 'namespace' },
+    Secret: { text: 'S', classNameSuffix: 'secret' },
+    Unknown: { text: '?', classNameSuffix: 'unknown' },
 } as const;
 
 /**

--- a/ui/apps/platform/src/Containers/Dashboard/Widgets/MostRecentViolations.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/Widgets/MostRecentViolations.tsx
@@ -5,14 +5,14 @@ import { TableComposable, Tbody, Tr, Td } from '@patternfly/react-table';
 import { SecurityIcon } from '@patternfly/react-icons';
 
 import ResourceIcon from 'Components/PatternFly/ResourceIcon';
-import { DeploymentAlert } from 'types/alert.proto';
+import { Alert, isDeploymentAlert, isResourceAlert } from 'types/alert.proto';
 import { violationsBasePath } from 'routePaths';
 import { severityColors } from 'constants/visuals/colors';
 import { getDateTime } from 'utils/dateUtils';
 import NoDataEmptyState from './NoDataEmptyState';
 
 export type MostRecentViolationsProps = {
-    alerts: DeploymentAlert[];
+    alerts: Alert[];
 };
 
 function MostRecentViolations({ alerts }: MostRecentViolationsProps) {
@@ -24,37 +24,59 @@ function MostRecentViolations({ alerts }: MostRecentViolationsProps) {
             {alerts.length > 0 ? (
                 <TableComposable variant="compact" borders={false}>
                     <Tbody>
-                        {alerts.map(({ id, time, deployment, policy }) => (
-                            <Tr key={id}>
-                                <Td className="pf-u-p-0" dataLabel="Severity icon">
-                                    <SecurityIcon
-                                        className="pf-u-display-inline"
-                                        color={severityColors[policy.severity]}
-                                    />
-                                </Td>
-                                <Td dataLabel="Violation name">
-                                    <Link to={`${violationsBasePath}/${id}`}>
-                                        <Truncate content={policy.name} />
-                                    </Link>
-                                </Td>
-                                <Td dataLabel="Deployment in violation">
-                                    <Flex
-                                        direction={{ default: 'row' }}
-                                        flexWrap={{ default: 'nowrap' }}
+                        {alerts.map((alert) => {
+                            const { id, time, policy } = alert;
+
+                            // The "Unknown" case should never occur, but we use it here as a safety fallback
+                            let icon = <ResourceIcon className="pf-u-mr-sm" kind="Unknown" />;
+                            let name = <Truncate content="Unknown Violation" />;
+
+                            if (isDeploymentAlert(alert)) {
+                                icon = <ResourceIcon className="pf-u-mr-sm" kind="Deployment" />;
+                                name = <Truncate content={alert.deployment.name} />;
+                            } else if (isResourceAlert(alert)) {
+                                const resourceTypeToKind = {
+                                    UNKNOWN: 'Unknown',
+                                    SECRETS: 'Secret',
+                                    CONFIGMAPS: 'ConfigMap',
+                                } as const;
+                                const kind = resourceTypeToKind[alert.resource.resourceType];
+                                icon = <ResourceIcon className="pf-u-mr-sm" kind={kind} />;
+                                name = <Truncate content={alert.resource.name} />;
+                            }
+
+                            return (
+                                <Tr key={id}>
+                                    <Td className="pf-u-p-0" dataLabel="Severity icon">
+                                        <SecurityIcon
+                                            className="pf-u-display-inline"
+                                            color={severityColors[policy.severity]}
+                                        />
+                                    </Td>
+                                    <Td dataLabel="Violation name">
+                                        <Link to={`${violationsBasePath}/${id}`}>
+                                            <Truncate content={policy.name} />
+                                        </Link>
+                                    </Td>
+                                    <Td dataLabel="Deployment in violation">
+                                        <Flex
+                                            direction={{ default: 'row' }}
+                                            flexWrap={{ default: 'nowrap' }}
+                                        >
+                                            {icon}
+                                            {name}
+                                        </Flex>
+                                    </Td>
+                                    <Td
+                                        width={35}
+                                        className="pf-u-pr-0 pf-u-text-align-right-on-md"
+                                        dataLabel="Time of last violation occurrence"
                                     >
-                                        <ResourceIcon className="pf-u-mr-sm" kind="Deployment" />
-                                        <Truncate content={deployment.name} />
-                                    </Flex>
-                                </Td>
-                                <Td
-                                    width={35}
-                                    className="pf-u-pr-0 pf-u-text-align-right-on-md"
-                                    dataLabel="Time of last violation occurrence"
-                                >
-                                    {getDateTime(time)}
-                                </Td>
-                            </Tr>
-                        ))}
+                                        {getDateTime(time)}
+                                    </Td>
+                                </Tr>
+                            );
+                        })}
                     </Tbody>
                 </TableComposable>
             ) : (

--- a/ui/apps/platform/src/Containers/Dashboard/Widgets/ViolationsByPolicySeverity.test.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/Widgets/ViolationsByPolicySeverity.test.tsx
@@ -17,6 +17,7 @@ const mockAlerts = [
         id: '1',
         time: '2022-06-24T00:35:42.299667447Z',
         deployment: { clusterName: 'production', namespace: 'kube-system', name: 'kube-proxy' },
+        resource: null,
         policy: { name: 'Ubuntu Package Manager in Image', severity: 'CRITICAL_SEVERITY' },
     },
 ];

--- a/ui/apps/platform/src/Containers/Dashboard/Widgets/ViolationsByPolicySeverity.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/Widgets/ViolationsByPolicySeverity.tsx
@@ -6,7 +6,7 @@ import LinkShim from 'Components/PatternFly/LinkShim';
 import useURLSearch from 'hooks/useURLSearch';
 import { violationsBasePath } from 'routePaths';
 import { SearchFilter } from 'types/search';
-import { DeploymentAlert } from 'types/alert.proto';
+import { Alert } from 'types/alert.proto';
 import { getQueryString } from 'utils/queryStringUtils';
 import { getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
 
@@ -36,8 +36,10 @@ export const mostRecentAlertsQuery = gql`
             id
             time
             deployment {
-                clusterName
-                namespace
+                name
+            }
+            resource {
+                resourceType
                 name
             }
             policy {
@@ -95,7 +97,7 @@ function ViolationsByPolicySeverity() {
         previousData: previousRecentAlertsData,
         loading: recentAlertsLoading,
         error: recentAlertsError,
-    } = useQuery<{ alerts: DeploymentAlert[] }>(mostRecentAlertsQuery, {
+    } = useQuery<{ alerts: Alert[] }>(mostRecentAlertsQuery, {
         variables: { query: searchQueryBySeverity(severities.CRITICAL_SEVERITY, searchFilter) },
     });
 

--- a/ui/apps/platform/src/css/acs.css
+++ b/ui/apps/platform/src/css/acs.css
@@ -10,6 +10,10 @@
     --color-resource-cluster: var(--pf-global--palette--purple-600);
     --color-resource-namespace: var(--pf-global--palette--green-600);
     --color-resource-deployment: var(--pf-global--palette--blue-500);
+    --color-resource-secret: var(--pf-global--palette--orange-400);
+    --color-resource-configmap: var(--pf-global--palette--purple-600);
+    /* unknown has no openshift equivalent */
+    --color-resource-unknown: var(--pf-global--palette--black-500);
 
     --color-severity-low: var(--pf-global--palette--black-500);
     --color-severity-medium: var(--pf-global--palette--gold-300);

--- a/ui/apps/platform/src/types/alert.proto.ts
+++ b/ui/apps/platform/src/types/alert.proto.ts
@@ -44,6 +44,18 @@ export type ResourceAlert = {
 
 export type AlertResourceType = 'UNKNOWN' | 'SECRETS' | 'CONFIGMAPS';
 
+export function isDeploymentAlert(alert: Alert): alert is DeploymentAlert {
+    return 'deployment' in alert && Boolean(alert.deployment);
+}
+
+export function isImageAlert(alert: Alert): alert is ImageAlert {
+    return 'image' in alert && Boolean(alert.image);
+}
+
+export function isResourceAlert(alert: Alert): alert is ResourceAlert {
+    return 'resource' in alert && Boolean(alert.resource);
+}
+
 export type BaseAlert = {
     id: string;
     policy: Policy;


### PR DESCRIPTION
## Description

Correctly handles the response type for the `alerts` graphql queries in the dashboard widget.

The query was incorrectly types as a `DeploymentAlert` when the true response type is `Alert`, which could be a `DeploymentAlert`, `ImageAlert`, or `ResourceAlert`, each of which has different `null` fields. This caused the dashboard to crash when the most recent alert was from a `ResourceAlert` type, which I believe only occurs when the user creates a custom policy for k8s audit logs and sets the severity to critical.

This may be easier to review with "Hide whitespace" on.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Load the widget with violations of a custom policy tracking the `configmap` type.
![image](https://user-images.githubusercontent.com/1292638/218566399-2087e34b-841f-4f64-b291-29fbea14c8f0.png)

Load the widget with violations of a custom policy tracking the `secrets` type.
![image](https://user-images.githubusercontent.com/1292638/218567093-dd22c1e0-722a-47ba-b81c-47ae96a205da.png)

Load the widget with violations that don't match any of our expectations. This should never happen, but like most things, sometimes they do.
![image](https://user-images.githubusercontent.com/1292638/218569528-695abcc3-693a-4fa0-b5db-177c41872ffa.png)

