### PR TITLE
ROX-14025: VulnMgmtSACTest flake additional logging

### DIFF
--- a/qa-tests-backend/Makefile
+++ b/qa-tests-backend/Makefile
@@ -37,7 +37,7 @@ build/generated: src/main/proto
 	@echo "+ $@"
 	$(GRADLE) generateProto generateTestProto
 
-src/main/proto: ../proto
+src/main/proto: $(shell find ../proto)
 	@echo "+ migrate protos"
 	-rm -r src/main/proto
 	@scripts/migrate_protos.sh

--- a/qa-tests-backend/src/test/groovy/VulnMgmtSACTest.groovy
+++ b/qa-tests-backend/src/test/groovy/VulnMgmtSACTest.groovy
@@ -51,6 +51,16 @@ class VulnMgmtSACTest extends BaseSpecification {
     }
     fragment cveFields on ImageVulnerability {
         cve
+        images(pagination: \$pagination) {
+            scannerVersion
+            scanNotes
+            dataSource {
+                id
+                name
+                __typename
+            }
+            __typename
+        }
     }
     """
 
@@ -236,7 +246,7 @@ class VulnMgmtSACTest extends BaseSpecification {
     @Unroll
     def "Verify role based scoping on vuln mgmt: image-role Image:*"() {
         when:
-        "Get Node CVEs and components"
+        "Get Image CVEs and components"
         BaseService.useBasicAuth()
         def gqlService = new GraphQLService()
         def baseQuery = "Image:*"


### PR DESCRIPTION
## Description

Query for additional scanner information when getting Image Vulnerabilities while running in Postgres on the VulnMgmtSACTest. When GraphQL gets queried in the tests, it logs at `Info` level the request and the response. With this change when this flake happens again we will be able to determine which scanner the vulnerability is getting populated by simply by looking back a couple of lines in the build logs of the failing tests.

Fix for the `make proto-generated-sources` rule in the qa-tests-backend Makefile. I wasn't able to get make wildcards work, but using find to expand the files in proto will allow us to detect if proto files have been deleted as well rather than just changed. If we want to narrow it down in scope at some point in the future we can use `-type f` to narrow to files and/or `-name *.proto` to narrow to just proto file changes, but those will also not be able to detect when a file is deleted.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

Manually verified that the test still functions.
