### PR TITLE
Fix service account test by using a specific query instead of a list

### DIFF
--- a/qa-tests-backend/src/main/groovy/services/ServiceAccountService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/ServiceAccountService.groovy
@@ -28,13 +28,16 @@ class ServiceAccountService extends BaseService {
         }
     }
 
+    static RawQuery getServiceAccountQuery(K8sServiceAccount serviceAccount) {
+        def query = "Namespace:\"${serviceAccount.namespace}\"+Service Account:\"${serviceAccount.name}\""
+        return RawQuery.newBuilder().setQuery(query).build()
+    }
+
     static boolean waitForServiceAccount(K8sServiceAccount serviceAccount) {
         Timer t = new Timer(30, 3)
         while (t.IsValid()) {
             log.debug "Waiting for Service Account"
-            def query = "Namespace:\"${serviceAccount.namespace}\"+Service Account:\"${serviceAccount.name}\""
-            def qb = RawQuery.newBuilder().setQuery(query).build()
-            def serviceAccounts = getServiceAccounts(qb)
+            def serviceAccounts = getServiceAccounts(getServiceAccountQuery(serviceAccount))
             if (serviceAccounts.size() > 0) {
                 return true
             }

--- a/qa-tests-backend/src/main/groovy/services/ServiceAccountService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/ServiceAccountService.groovy
@@ -32,13 +32,10 @@ class ServiceAccountService extends BaseService {
         Timer t = new Timer(30, 3)
         while (t.IsValid()) {
             log.debug "Waiting for Service Account"
-            def serviceAccounts = getServiceAccounts()
-            def sa = serviceAccounts.find {
-                it.getServiceAccount().name == serviceAccount.name &&
-                    it.getServiceAccount().namespace == serviceAccount.namespace
-            }
-
-            if (sa) {
+            def query = "Namespace:\"${serviceAccount.namespace}\"+Service Account:\"${serviceAccount.name}\""
+            def qb = RawQuery.newBuilder().setQuery(query).build()
+            def serviceAccounts = getServiceAccounts(qb)
+            if (serviceAccounts.size() > 0) {
                 return true
             }
         }

--- a/qa-tests-backend/src/test/groovy/K8sRbacTest.groovy
+++ b/qa-tests-backend/src/test/groovy/K8sRbacTest.groovy
@@ -129,7 +129,7 @@ class K8sRbacTest extends BaseSpecification {
 
         expect:
         "SR should have the service account and its relationship to the deployment"
-        def query = getServiceAccountQuery(NEW_SA)
+        def query = ServiceAccountService.getServiceAccountQuery(NEW_SA)
         withRetry(45, 2) {
             def stackroxSAs = ServiceAccountService.getServiceAccounts(query)
             for (ServiceAccountServiceOuterClass.ServiceAccountAndRoles s : stackroxSAs) {

--- a/qa-tests-backend/src/test/groovy/K8sRbacTest.groovy
+++ b/qa-tests-backend/src/test/groovy/K8sRbacTest.groovy
@@ -129,8 +129,9 @@ class K8sRbacTest extends BaseSpecification {
 
         expect:
         "SR should have the service account and its relationship to the deployment"
+        def query = getServiceAccountQuery(NEW_SA)
         withRetry(45, 2) {
-            def stackroxSAs = ServiceAccountService.getServiceAccounts()
+            def stackroxSAs = ServiceAccountService.getServiceAccounts(query)
             for (ServiceAccountServiceOuterClass.ServiceAccountAndRoles s : stackroxSAs) {
                 def sa = s.serviceAccount
                 if (sa.name == NEW_SA.name && sa.namespace == NEW_SA.namespace) {


### PR DESCRIPTION
## Description

On Postgres on Openshift, listing all service accounts can be very slow. We have a different ticket for this: ROX-14666

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

CI
