### PR TITLE
Tune collect-infrastructure-logs.sh timeout.

### DIFF
--- a/.openshift-ci/post_tests.py
+++ b/.openshift-ci/post_tests.py
@@ -13,6 +13,7 @@ from typing import List
 class PostTestsConstants:
     API_TIMEOUT = 5 * 60
     COLLECT_TIMEOUT = 10 * 60
+    COLLECT_INFRA_TIMEOUT = 12 * 60
     CHECK_TIMEOUT = 5 * 60
     STORE_TIMEOUT = 5 * 60
     FIXUP_TIMEOUT = 5 * 60
@@ -167,7 +168,7 @@ class PostClusterTest(StoreArtifacts):
                 "scripts/ci/collect-infrastructure-logs.sh",
                 PostTestsConstants.K8S_LOG_DIR,
             ],
-            timeout=PostTestsConstants.COLLECT_TIMEOUT,
+            timeout=PostTestsConstants.COLLECT_INFRA_TIMEOUT,
         )
         self.data_to_store.append(PostTestsConstants.K8S_LOG_DIR)
 

--- a/scripts/ci/collect-infrastructure-logs.sh
+++ b/scripts/ci/collect-infrastructure-logs.sh
@@ -25,8 +25,10 @@ fi
 
 # This will attempt to collect kube API server audit logs on OpenShift.
 # It would be great to do the same on other cluster types but that would be much harder do in a portable way.
-(cd "${log_dir}" && oc version && oc adm must-gather -- /usr/bin/gather_audit_logs && du -sh must-gather*) || true
+echo "$(date) Attempting to collect kube API server audit logs"
+(cd "${log_dir}" && oc version && oc adm must-gather --timeout=7m -- /usr/bin/gather_audit_logs && du -sh must-gather*) || true
 
+echo "$(date) Attempting to collect kube API server log"
 kubectl proxy &
 proxy_pid=$!
 


### PR DESCRIPTION
## Description

This timed out too early in [a PR](https://github.com/stackrox/stackrox/pull/4775#issuecomment-1427831543) for me on a cluster where `oc adm` is non-functional.

- Bump the outer timeout by 2 minutes
- Shrink the must-gather timeout by 3 minutes
- Print some timestamped messages to figure out how long `must-gather` actually takes (edit: seems like below 20s)

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

Relying on CI.