### PR TITLE
ROX-15095: Adjust Violations chart axis for large counts

### DIFF
--- a/ui/apps/platform/src/Containers/Dashboard/Widgets/ViolationsByPolicyCategoryChart.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/Widgets/ViolationsByPolicyCategoryChart.tsx
@@ -260,7 +260,7 @@ function ViolationsByPolicyCategoryChart({
                 <ChartAxis
                     tickLabelComponent={<LinkableChartLabel linkWith={labelLinkCallback} />}
                 />
-                <ChartAxis dependentAxis tickFormat={String} />
+                <ChartAxis dependentAxis fixLabelOverlap tickFormat={String} />
                 <ChartStack horizontal>{bars}</ChartStack>
             </Chart>
         </div>


### PR DESCRIPTION
## Description

Just a little tidying up

## Checklist
- [ ] Investigated and inspected CI test results


## Testing Performed

Used a scale cluster as backend

Before
<img width="566" alt="chart_axis_labels_overlap_BEFORE" src="https://user-images.githubusercontent.com/715729/218788901-ea5592a8-003e-4a1b-85c3-a95d1fc9ab3c.png">

After this change, at scale
<img width="548" alt="chart_axis_labels_overlap_AFTER" src="https://user-images.githubusercontent.com/715729/218788963-1e433386-9081-46c9-b2a1-f5de68c0753c.png">

Even with this change, smaller scales still behave as before
<img width="547" alt="chart_axis_labels_overlap_CONSISTENT_FOR_SMALLER_TOTAL" src="https://user-images.githubusercontent.com/715729/218789089-988caad2-7496-430a-a27a-4c5cd9b240d0.png">
