### PR TITLE
ROX-15009 Add navigation item for 'Vulnerabilities' (VM 2.0) section

### DIFF
--- a/ui/apps/platform/src/Containers/MainPage/Sidebar/NavigationSidebar.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Sidebar/NavigationSidebar.tsx
@@ -32,6 +32,7 @@ import {
     systemConfigPath,
     systemHealthPath,
     collectionsBasePath,
+    vulnerabilitiesWorkloadCvesPath,
 } from 'routePaths';
 
 import LeftNavItem from './LeftNavItem';
@@ -75,6 +76,8 @@ function NavigationSidebar({
             collectionsBasePath
         );
     }
+
+    const vulnerabilitiesPaths = [vulnerabilitiesWorkloadCvesPath];
 
     const Navigation = (
         <Nav id="nav-primary-simple">
@@ -122,6 +125,33 @@ function NavigationSidebar({
                     path={complianceBasePath}
                     title={basePathToLabelMap[complianceBasePath]}
                 />
+
+                {isFeatureFlagEnabled('ROX_VULN_MGMT_WORKLOAD_CVES') &&
+                    isFeatureFlagEnabled('ROX_POSTGRES_DATASTORE') && (
+                        // TODO We need to designate this as Tech Preview in a more standard way, based on UX guidance
+                        <NavExpandable
+                            id="Vulnerabilities"
+                            title="Vulnerabilities (preview)"
+                            isActive={vulnerabilitiesPaths.some((path) =>
+                                location.pathname.includes(path)
+                            )}
+                            isExpanded={vulnerabilitiesPaths.some((path) =>
+                                location.pathname.includes(path)
+                            )}
+                        >
+                            {vulnerabilitiesPaths.map((path) => {
+                                const isActive = location.pathname.includes(path);
+                                return (
+                                    <LeftNavItem
+                                        key={path}
+                                        isActive={isActive}
+                                        path={path}
+                                        title={basePathToLabelMap[path]}
+                                    />
+                                );
+                            })}
+                        </NavExpandable>
+                    )}
                 <NavExpandable
                     id="VulnerabilityManagement"
                     title="Vulnerability Management"

--- a/ui/apps/platform/src/routePaths.js
+++ b/ui/apps/platform/src/routePaths.js
@@ -91,6 +91,13 @@ export const vulnManagementPendingApprovalsPath = `${vulnManagementRiskAcceptanc
 export const vulnManagementApprovedDeferralsPath = `${vulnManagementRiskAcceptancePath}/approved-deferrals`;
 export const vulnManagementApprovedFalsePositivesPath = `${vulnManagementRiskAcceptancePath}/approved-false-positives`;
 
+// VM 2.0 "Vulnerabilities" paths
+export const vulnerabilitiesBasePath = `${mainPath}/vulnerabilities`;
+export const vulnerabilitiesWorkloadCvesPath = `${vulnerabilitiesBasePath}/workload-cves`;
+export const vulnerabilitiesWorkloadCveSinglePath = `${vulnerabilitiesBasePath}/workload-cves/cves/:cveId`;
+export const vulnerabilitiesWorkloadCveImageSinglePath = `${vulnerabilitiesBasePath}/workload-cves/images/:imageId`;
+export const vulnerabilitiesWorkloadCveDeploymentSinglePath = `${vulnerabilitiesBasePath}/workload-cves/deployments/:deploymentId`;
+
 /**
  * New Framwork-related route paths
  */
@@ -145,12 +152,18 @@ const vulnManagementPathToLabelMap = {
     [vulnManagementRiskAcceptancePath]: 'Risk Acceptance',
 };
 
+const vulnerabilitiesPathToLabelMap = {
+    [vulnerabilitiesBasePath]: 'Vulnerabilities',
+    [vulnerabilitiesWorkloadCvesPath]: 'Workload CVEs',
+};
+
 export const basePathToLabelMap = {
     [dashboardPath]: 'Dashboard',
     [networkBasePath]: 'Network Graph (1.0)',
     [networkBasePathPF]: 'Network Graph (2.0 preview)',
     [violationsBasePath]: 'Violations',
     [complianceBasePath]: 'Compliance',
+    ...vulnerabilitiesPathToLabelMap,
     ...vulnManagementPathToLabelMap,
     [configManagementPath]: 'Configuration Management',
     [riskBasePath]: 'Risk',


### PR DESCRIPTION
## Description

Adds left hand navigation item for new Vulnerabilities section as well as routes to match the Workload CVE pages:
- Workload CVE Overview
- CVE Single page
- Image Single page
- Deployment Single page

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

The navigation with the feature flag enabled:
![image](https://user-images.githubusercontent.com/1292638/219043878-5c335502-0857-479b-bab2-e259e72fa1d9.png)

The navigation with the feature flag disabled:
![image](https://user-images.githubusercontent.com/1292638/219044495-3cb84573-7008-48f8-a267-5e096530609b.png)

Navigating to any of the Vulnerabilities subpages returns a 404 page, with or without the feature flag. (Route handlers are not implemented in this PR.)
![image](https://user-images.githubusercontent.com/1292638/219044241-a70d070a-d242-4edf-b701-6aac59360db2.png)

