### PR TITLE
Define PrefixedAction type for reducers in TypeScript

### DIFF
--- a/ui/apps/platform/src/Containers/SystemConfig/Form/SystemConfigForm.tsx
+++ b/ui/apps/platform/src/Containers/SystemConfig/Form/SystemConfigForm.tsx
@@ -26,7 +26,7 @@ import { useFormik } from 'formik';
 
 import ColorPicker from 'Components/ColorPicker';
 import ClusterLabelsTable from 'Containers/Clusters/ClusterLabelsTable';
-import { types } from 'reducers/publicConfig';
+import { PublicConfigAction } from 'reducers/publicConfig';
 import { saveSystemConfig } from 'services/SystemConfigService';
 import { PrivateConfig, PublicConfig, SystemConfig } from 'types/config.proto';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
@@ -90,10 +90,15 @@ const SystemConfigForm = ({
                 })
                     .then((data) => {
                         // Simulate fetchPublicConfig response to update Redux state.
-                        dispatch({
-                            type: types.FETCH_PUBLIC_CONFIG.SUCCESS,
-                            response: data.publicConfig,
-                        });
+                        const action: PublicConfigAction = {
+                            type: 'config/FETCH_PUBLIC_CONFIG_SUCCESS',
+                            response: data.publicConfig || {
+                                footer: null,
+                                header: null,
+                                loginNotice: null,
+                            },
+                        };
+                        dispatch(action);
                         setSystemConfig(data);
                         setErrorMessage(null);
                         setSubmitting(false);

--- a/ui/apps/platform/src/utils/fetchingReduxRoutines.ts
+++ b/ui/apps/platform/src/utils/fetchingReduxRoutines.ts
@@ -44,9 +44,24 @@ export function getFetchingActionInfo(type: string): ActionTypeInfo | null {
     return { prefix, fetchingState: FetchingActionState[fetchingState] };
 }
 
+export type PrefixedAction<Prefix extends string, Response> =
+    | {
+          type: `${Prefix}_FAILURE`;
+          error: Error;
+      }
+    | {
+          type: `${Prefix}_REQUEST`;
+      }
+    | {
+          type: `${Prefix}_SUCCESS`;
+          response: Response;
+      };
+
 export type FetchingAction<T extends Record<string, unknown>> = { type: string } & {
     [prop in keyof T]: T[prop];
 };
+
+// Action creator function types
 
 export type RequestAction = <P>(params?: P) => FetchingAction<{ params: P | undefined }>;
 export type SuccessAction = <R, P>(


### PR DESCRIPTION
## Description

First draft of a pattern for reducers in TypeScript.

Ironically, so much effort on action **creator function** types did nothing for actions in reducers :(

Also to support optional `params` which is only in globalSearch that will be deleted in #4855

`PrefixedAction<'whatever/WHATEVER', Response>` type has better type safety than the following classic function calls:
* `createFetchingActionTypes('whatever/WHATEVER')`
* `createFetchingActions(types.WHATEVER)`

If reducer has `switch` instead of `if` statements, then TypeScript reports errors for incorrect property access:
* `type`
* `response`
* `error`

Note that the change in SystemConfigForm reported a problem because of assumption that response is non-null. Bravo!

Notice an ancient copy-pasto: `'notifiers/FETCH_PUBLIC_CONFIG'`

### Residue

1. Initial attempt to use `PublicConfigAction` with types from redux-thunk failed :(

## Checklist
- [ ] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

* ui/apps/platform/cypress/integration/systemConfig/systemConfig.test.js
