### PR TITLE
ROX-10999: Fix panic in roxctl central db restore when no file is given

### DIFF
--- a/roxctl/central/db/restore/v2.go
+++ b/roxctl/central/db/restore/v2.go
@@ -95,9 +95,18 @@ func (cmd *centralDbRestoreCommand) validate() error {
 	if cmd.file == "" {
 		return errox.InvalidArgs.New("file to restore from must be specified")
 	}
-	if _, err := os.Stat(cmd.file); os.IsNotExist(err) {
-		return errox.NotFound.Newf("file %q could not be found", cmd.file)
+	fi, err := os.Stat(cmd.file)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return errox.NotFound.Newf("file %q could not be found", cmd.file)
+		}
+		return errox.InvalidArgs.Newf("opening file %q", cmd.file)
 	}
+
+	if fi.IsDir() {
+		return errox.InvalidArgs.Newf("expected a file not a directory for path %s", cmd.file)
+	}
+
 	return nil
 }
 

--- a/roxctl/central/db/restore/v2_test.go
+++ b/roxctl/central/db/restore/v2_test.go
@@ -1,0 +1,36 @@
+package restore
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stackrox/rox/pkg/errox"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCentralDBRestore_Validate(t *testing.T) {
+	cmd := &centralDbRestoreCommand{}
+
+	// 1. If file is unset, expect an InvalidArgs error.
+	err := cmd.validate()
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, errox.InvalidArgs)
+
+	// 2. If file is set, but does not exist, expect an NotFound error.
+	cmd.file = "some-non-existent-file"
+	err = cmd.validate()
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, errox.NotFound)
+
+	// 3. If file is set, and exists, no error should be returned.
+	tmpDir := t.TempDir()
+	testFile := path.Join(tmpDir, "test-file")
+	_, err = os.Create(testFile)
+	require.NoError(t, err)
+
+	cmd.file = testFile
+	err = cmd.validate()
+	assert.NoError(t, err)
+}

--- a/roxctl/central/db/restore/v2_test.go
+++ b/roxctl/central/db/restore/v2_test.go
@@ -44,7 +44,7 @@ func TestCentralDBRestore_Validate(t *testing.T) {
 			err := tc.cmd.validate()
 			if tc.err != nil {
 				assert.Error(t, err)
-				assert.ErrorIs(t, err, c.err)
+				assert.ErrorIs(t, err, tc.err)
 			} else {
 				assert.NoError(t, err)
 			}

--- a/roxctl/central/db/restore/v2_test.go
+++ b/roxctl/central/db/restore/v2_test.go
@@ -38,10 +38,11 @@ func TestCentralDBRestore_Validate(t *testing.T) {
 		},
 	}
 	for name, c := range cases {
+		tc := c
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			err := c.cmd.validate()
-			if c.err != nil {
+			err := tc.cmd.validate()
+			if tc.err != nil {
 				assert.Error(t, err)
 				assert.ErrorIs(t, err, c.err)
 			} else {


### PR DESCRIPTION
## Description

This PR fixes a panic that occurs when no file is given within the positional args for `roxctl central db restore`.

The following has changed within the PR:
- Instead of using custom validation of the positional argument, use `cobra.ExactArgs()` instead.
- Mark the previously only _commented_ deprecated `--file` flag as _actually_ deprecated.
- Within the `validate()` step, ensure that its also validated that the file exists.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

- see added unit tests.
