### PR TITLE
ROX-9120: Improve unauthenticated message in roxctl

### DIFF
--- a/roxctl/common/auth.go
+++ b/roxctl/common/auth.go
@@ -22,11 +22,15 @@ func checkAuthParameters() error {
 		return errox.InvalidArgs.New("cannot use password- and token-based authentication at the same time")
 	}
 	if flags.APITokenFile() == "" && env.TokenEnv.Setting() == "" && flags.Password() == "" {
-		return errox.InvalidArgs.New("no token set via either token file or the environment variable ROX_API_TOKEN")
+		return errox.InvalidArgs.New(authHelp)
 	}
 
 	return nil
 }
+
+const authHelp = `No authentication information is set.
+Either set a token within the token file provided in the --token-file flag, or the environment variable ROX_API_TOKEN.
+Alternatively, you can pass the admin password via the --password/-p flag.`
 
 // #nosec G101 -- This is a false positive
 const userHelpLiteralToken = `There is no token in file %q. The token file should only contain a single authentication token.


### PR DESCRIPTION
## Description

This PR addresses the ambiguous message we currently print when a user is not setting any authentication information via either the token file, the `ROX_API_TOKEN` environment variable, or the `--password/-p` flag.

The original request in the ticket [ROX-9120](https://issues.redhat.com/browse/ROX-9120) to return an error earlier before sending the request has been already achieved through the environment changes. When `env.GRPCConnection()` will be called,
the authentication information will be verified and an error returned, if no sufficient information is set.

Now, the error message is more clear in the different types of authentication information, and how they could be set.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

- manually testing against a central instance without providing any authentication information, e.g.:
```bash
roxctl central whoami
```
