### PR TITLE
ROX-3208: Env variables for some roxctl flags

### DIFF
--- a/pkg/env/api.go
+++ b/pkg/env/api.go
@@ -1,6 +1,0 @@
-package env
-
-var (
-	// TokenEnv is the variable that clients can source for commandline operations
-	TokenEnv = RegisterSetting("ROX_API_TOKEN")
-)

--- a/pkg/env/roxctl.go
+++ b/pkg/env/roxctl.go
@@ -1,0 +1,12 @@
+package env
+
+var (
+	// EndpointEnv specifies the central endpoint to use for commandline operations.
+	EndpointEnv = RegisterSetting("ROX_ENDPOINT")
+
+	// PasswordEnv specifies the central admin password to use for commandline operations.
+	PasswordEnv = RegisterSetting("ROX_ADMIN_PASSWORD")
+
+	// TokenEnv is the variable that clients can source for commandline operations.
+	TokenEnv = RegisterSetting("ROX_API_TOKEN")
+)

--- a/roxctl/common/flags/api_token_file.go
+++ b/roxctl/common/flags/api_token_file.go
@@ -19,7 +19,7 @@ func AddAPITokenFile(c *cobra.Command) {
 		"token-file",
 		"",
 		"",
-		"Use the API token in the provided file to authenticate")
+		"Use the API token in the provided file to authenticate. Alternatively, set the token via the ROX_API_TOKEN environment variable")
 }
 
 // APITokenFile returns the currently specified API token file name.

--- a/roxctl/common/flags/env_flag.go
+++ b/roxctl/common/flags/env_flag.go
@@ -1,0 +1,19 @@
+package flags
+
+import (
+	"github.com/stackrox/rox/pkg/env"
+)
+
+// flagOrSettingValue will either return the following:
+//   - the flag value, if the flag value is not the default value (i.e. flagChanged != false).
+//   - the setting's value, if the flag value is the default value (i.e. flag changed == false) _and_ the setting's value is non-empty.
+//   - the default value, if the flag value is the default value (i.e. flag changed != false) and the setting's value
+//     is empty.
+func flagOrSettingValue(flagValue string, flagChanged bool, setting env.Setting) string {
+	if !flagChanged {
+		if setting.Setting() != "" {
+			return setting.Setting()
+		}
+	}
+	return flagValue
+}

--- a/roxctl/common/flags/env_flag_test.go
+++ b/roxctl/common/flags/env_flag_test.go
@@ -1,0 +1,31 @@
+package flags
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFlagOrSettingValue(t *testing.T) {
+	// 1. Default, unchanged flag value and setting not set should lead to the default value being returned.
+	cmd := &cobra.Command{}
+
+	AddPassword(cmd)
+
+	assert.Empty(t, Password())
+
+	// 2. Change the flag value. The changed flag value should be returned, irrespective of whether the setting is set.
+	t.Setenv("ROX_ADMIN_PASSWORD", "some-test-value")
+	cmd = &cobra.Command{}
+	AddPassword(cmd)
+	err := cmd.PersistentFlags().Set("password", "some-other-test-value")
+	assert.NoError(t, err)
+	assert.Equal(t, "some-other-test-value", Password())
+
+	// 3. Default flag value and setting's value set should return the settings value instead.
+	t.Setenv("ROX_ADMIN_PASSWORD", "some-test-value")
+	cmd = &cobra.Command{}
+	AddPassword(cmd)
+	assert.Equal(t, "some-test-value", Password())
+}

--- a/roxctl/common/flags/password.go
+++ b/roxctl/common/flags/password.go
@@ -2,18 +2,22 @@ package flags
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/stackrox/rox/pkg/env"
 )
 
 var (
-	password string
+	password        string
+	passwordChanged *bool
 )
 
 // AddPassword adds the password flag to the base command.
 func AddPassword(c *cobra.Command) {
-	c.PersistentFlags().StringVarP(&password, "password", "p", "", "password for basic auth")
+	c.PersistentFlags().StringVarP(&password, "password", "p", "",
+		"password for basic auth. Alternatively, set the password via the ROX_ADMIN_PASSWORD environment variable")
+	passwordChanged = &c.PersistentFlags().Lookup("password").Changed
 }
 
 // Password returns the set password.
 func Password() string {
-	return password
+	return flagOrSettingValue(password, *passwordChanged, env.PasswordEnv)
 }


### PR DESCRIPTION
## Description

This PR adds two environment variables to set roxctl flag values, specifically:
- `ROX_ADMIN_PASSWORD` for the `--password` flag.
- `ROX_ENDPOINT` for the `--endpoint` flag.

The logic of when to use the environment variable and when the flag value is as follows:
- Prefer the flag value over the environment variable, if the flag is explicitly set to a non-default value.
- If the default value for the flag is given, and has not been changed, prefer the environment variable.
- If neither the environment variable is set nor the flag is changed, use the default value.


For now, the current principles of the `flags` package have been re-use, but it may be worthwhile to do the following within a follow-up:
- split up the `flags` package either into separate sub-packages or a more generic package.
- generalize the `Changed` approach for all commands, and move away from package scoped global variables.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

- added unit tests.
