### PR TITLE
Disable resync only in vanilla k8s

### DIFF
--- a/deploy/k8s/deploy.sh
+++ b/deploy/k8s/deploy.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -e
 
+# Enable new event pipeline without re-sync for k8s deployments
+export ROX_RESYNC_DISABLED="true"
+
 K8S_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 # shellcheck source=/dev/null
 source "${K8S_DIR}/central.sh"

--- a/deploy/k8s/sensor.sh
+++ b/deploy/k8s/sensor.sh
@@ -24,7 +24,4 @@ if [[ -z "$ROX_ADMIN_PASSWORD" && -f "${K8S_DIR}/central-deploy/password" ]]; th
 	export ROX_ADMIN_PASSWORD
 fi
 
-# Enable new event pipeline without re-sync for k8s deployments
-export ROX_RESYNC_DISABLED="true"
-
 launch_sensor "$K8S_DIR"


### PR DESCRIPTION
## Description

Resync was disabled by mistake in the `deploy/openshift` scripts. #4721 set `ROX_RESYNC_DISABLED="true"` in `deploy/k8s/sensor.sh`. The problem is: `deploy/openshift/sensor.sh` is a link to `deploy/k8s/sensor.sh` so by disabling the resync in `k8s/sensor.sh` it was also being disabled in `openshift/sensor.sh`

This PR should disable resync only for `deploy/k8s`.

This should also fix the the test failure `RoutesTest / Verify that routes are detected correctly` (See [ROX-14004](https://issues.redhat.com/browse/ROX-14004))

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

* CI
* Tested by deploying on OCP and GKE infra clusters.
