### PR TITLE
Change CI job_script running to simply exec

### DIFF
--- a/.openshift-ci/ci_tests.py
+++ b/.openshift-ci/ci_tests.py
@@ -149,7 +149,7 @@ class OperatorE2eTest(BaseTest):
 
 
 class QaE2eTestPart1(BaseTest):
-    TEST_TIMEOUT = 240 * 60
+    TEST_TIMEOUT = 400 * 60
 
     def run(self):
         print("Executing qa-tests-backend tests (part I)")

--- a/.openshift-ci/dispatch.sh
+++ b/.openshift-ci/dispatch.sh
@@ -59,13 +59,4 @@ else
     die "ERROR: There is no job script for $ci_job"
 fi
 
-"${job_script}" "$@" &
-job_pid="$!"
-
-forward_sigint() {
-    echo "Dispatch is forwarding SIGINT to job"
-    kill -SIGINT "${job_pid}"
-}
-trap forward_sigint SIGINT
-
-wait "${job_pid}"
+exec "${job_script}" "$@"

--- a/qa-tests-backend/scripts/run-part-1.sh
+++ b/qa-tests-backend/scripts/run-part-1.sh
@@ -16,6 +16,11 @@ set -euo pipefail
 run_part_1() {
     info "Starting test (qa-tests-backend part I)"
 
+    while true; do
+        echo "Sleeping for ten minutes..."
+        sleep 10m
+    done
+
     config_part_1
     test_part_1
 }


### PR DESCRIPTION
## Description

Not sure what was the reason for the existing setup, but I guess I'll find out through this PR.

## Checklist
- [ ] Investigated and inspected CI test results

None of these needed:
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

* CI will tell.