### PR TITLE
ROX-15017 Add routing and stubbed page components for Workload CVEs

### DIFF
--- a/ui/apps/platform/src/Containers/MainPage/Body.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Body.tsx
@@ -28,6 +28,7 @@ import {
     configManagementPath,
     vulnManagementRiskAcceptancePath,
     collectionsPath,
+    vulnerabilitiesWorkloadCvesPath,
 } from 'routePaths';
 import { useTheme } from 'Containers/ThemeProvider';
 
@@ -78,6 +79,9 @@ const AsyncSystemConfigPage = asyncComponent(
     () => import('Containers/SystemConfig/SystemConfigPage')
 );
 const AsyncConfigManagementPage = asyncComponent(() => import('Containers/ConfigManagement/Page'));
+const AsyncWorkloadCvesPage = asyncComponent(
+    () => import('Containers/Vulnerabilities/WorkloadCves/WorkloadCvesPage')
+);
 const AsyncVulnMgmtReports = asyncComponent(
     () => import('Containers/VulnMgmt/Reports/VulnMgmtReports')
 );
@@ -104,8 +108,11 @@ function Body({ hasReadAccess, isFeatureFlagEnabled }: BodyProps): ReactElement 
     const { isDarkMode } = useTheme();
 
     const isSystemHealthPatternFlyEnabled = isFeatureFlagEnabled('ROX_SYSTEM_HEALTH_PF');
-    const isCollectionsEnabled = isFeatureFlagEnabled('ROX_POSTGRES_DATASTORE');
+    const isPostgresEnabled = isFeatureFlagEnabled('ROX_POSTGRES_DATASTORE');
+    const isCollectionsEnabled = isPostgresEnabled;
     const isNetworkGraphPatternflyEnabled = isFeatureFlagEnabled('ROX_NETWORK_GRAPH_PATTERNFLY');
+    const isVulnMgmtWorkloadCvesEnabled =
+        isFeatureFlagEnabled('ROX_VULN_MGMT_WORKLOAD_CVES') && isPostgresEnabled;
 
     const hasVulnerabilityReportsPermission = hasReadAccess('VulnerabilityReports');
     const hasCollectionsPermission = hasReadAccess('WorkflowAdministration');
@@ -140,6 +147,12 @@ function Body({ hasReadAccess, isFeatureFlagEnabled }: BodyProps): ReactElement 
                     <Route path={apidocsPath} component={AsyncApiDocsPage} />
                     <Route path={userBasePath} component={AsyncUserPage} />
                     <Route path={systemConfigPath} component={AsyncSystemConfigPage} />
+                    {isVulnMgmtWorkloadCvesEnabled && (
+                        <Route
+                            path={vulnerabilitiesWorkloadCvesPath}
+                            component={AsyncWorkloadCvesPage}
+                        />
+                    )}
                     {hasVulnerabilityReportsPermission && (
                         <Route path={vulnManagementReportsPath} component={AsyncVulnMgmtReports} />
                     )}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesDeploymentSinglePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesDeploymentSinglePage.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { useParams } from 'react-router-dom';
+
+function WorkloadCvesDeploymentSinglePage() {
+    const { deploymentId } = useParams();
+    return <>Workload CVE Deployment Single Page: {deploymentId}</>;
+}
+
+export default WorkloadCvesDeploymentSinglePage;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesImageSinglePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesImageSinglePage.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { useParams } from 'react-router-dom';
+
+function WorkloadCvesImageSinglePage() {
+    const { imageId } = useParams();
+    return <>Workload CVE Image Single Page: {imageId}</>;
+}
+
+export default WorkloadCvesImageSinglePage;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesOverviewPage.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+function WorkloadCvesOverviewPage() {
+    return <>Workload CVEs Overview</>;
+}
+
+export default WorkloadCvesOverviewPage;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesPage.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { Route, Switch } from 'react-router-dom';
+import { PageSection } from '@patternfly/react-core';
+
+import PageNotFound from 'Components/PageNotFound';
+import PageTitle from 'Components/PageTitle';
+
+import {
+    vulnerabilitiesWorkloadCveDeploymentSinglePath,
+    vulnerabilitiesWorkloadCveImageSinglePath,
+    vulnerabilitiesWorkloadCveSinglePath,
+    vulnerabilitiesWorkloadCvesPath,
+} from 'routePaths';
+import WorkloadCvesDeploymentSinglePage from './WorkloadCvesDeploymentSinglePage';
+import WorkloadCvesImageSinglePage from './WorkloadCvesImageSinglePage';
+import WorkloadCvesOverviewPage from './WorkloadCvesOverviewPage';
+import WorkloadCvesSinglePage from './WorkloadCvesSinglePage';
+
+function WorkloadCvesPage() {
+    return (
+        <Switch>
+            <Route path={vulnerabilitiesWorkloadCveSinglePath} component={WorkloadCvesSinglePage} />
+            <Route
+                path={vulnerabilitiesWorkloadCveImageSinglePath}
+                component={WorkloadCvesImageSinglePage}
+            />
+            <Route
+                path={vulnerabilitiesWorkloadCveDeploymentSinglePath}
+                component={WorkloadCvesDeploymentSinglePage}
+            />
+            <Route
+                exact
+                path={vulnerabilitiesWorkloadCvesPath}
+                component={WorkloadCvesOverviewPage}
+            />
+            <Route>
+                <PageSection variant="light">
+                    <PageTitle title="Workload CVEs - Not Found" />
+                    <PageNotFound />
+                </PageSection>
+            </Route>
+        </Switch>
+    );
+}
+
+export default WorkloadCvesPage;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesSinglePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesSinglePage.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { useParams } from 'react-router-dom';
+
+function WorkloadCvesSinglePage() {
+    const { cveId } = useParams();
+    return <>Workload CVE Single Page: {cveId}</>;
+}
+
+export default WorkloadCvesSinglePage;


### PR DESCRIPTION
## Description

Adds route handling and almost empty page shells for the four main pages of the Workload CVEs section.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

With feature flag enabled

Visit the main Workload CVEs page via the sidebar link or by direct entry of the URL:
<img width="1677" alt="image" src="https://user-images.githubusercontent.com/1292638/219090225-8bce0df9-cf5e-47e2-b2fc-02c69c07f85a.png">

Visit the cve, image, and deployment single pages via direct entry of the URL:
<img width="1677" alt="image" src="https://user-images.githubusercontent.com/1292638/219090939-8ff83774-2a4f-4601-b300-5bc1fc07b111.png">
<img width="1677" alt="image" src="https://user-images.githubusercontent.com/1292638/219091578-990851b1-d394-48b8-89f8-67d913dcfe37.png">
<img width="1677" alt="image" src="https://user-images.githubusercontent.com/1292638/219091721-7144b51b-8b14-4c95-9e88-668e77115891.png">

Visiting a workload cve route that is not the base URL, or a valid entity with an `id` part of the path results in a 404 page:
<img width="1677" alt="image" src="https://user-images.githubusercontent.com/1292638/219092046-920b23c7-5525-4908-994f-ae0eb3642edc.png">
<img width="1677" alt="image" src="https://user-images.githubusercontent.com/1292638/219092326-9f739b4b-f31c-463e-9cd4-267f3709ec08.png">

With feature flag **disabled** - manually verify that all of the above URLs return the standard 404 page.
<img width="1677" alt="image" src="https://user-images.githubusercontent.com/1292638/219103934-2fbc2de2-dad8-41a6-81a6-7565e67c4a48.png">

