### PR TITLE
ROX-15113: Add support to suspend a CrobJob while enforcing a deploy time policy

### DIFF
--- a/sensor/kubernetes/enforcer/cronjob/suspend.go
+++ b/sensor/kubernetes/enforcer/cronjob/suspend.go
@@ -1,0 +1,87 @@
+package cronjob
+
+import (
+	"context"
+
+	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stackrox/rox/pkg/branding"
+	kubernetesPkg "github.com/stackrox/rox/pkg/kubernetes"
+	"github.com/stackrox/rox/pkg/retry"
+	"github.com/stackrox/rox/sensor/utils"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/json"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	batchV1      = "batch/v1"
+	batchV1beta1 = "batch/v1beta1"
+)
+
+// Suspend suspends the cron job
+func Suspend(ctx context.Context, client kubernetes.Interface, deploymentInfo *central.DeploymentEnforcement) (err error) {
+	forcePatch := true
+
+	if ok, apiErr := utils.HasAPI(client, batchV1, kubernetesPkg.CronJob); ok && apiErr == nil {
+		patch := map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"name": deploymentInfo.GetDeploymentName(),
+			},
+			"kind":       deploymentInfo.GetDeploymentType(),
+			"apiVersion": batchV1,
+			"spec": map[string]interface{}{
+				"suspend": true,
+			},
+		}
+		patchBytes, err := json.Marshal(patch)
+		if err != nil {
+			return err
+		}
+
+		_, err = client.BatchV1().CronJobs(deploymentInfo.GetNamespace()).Patch(ctx, deploymentInfo.GetDeploymentName(),
+			types.ApplyPatchType,
+			patchBytes,
+			metav1.PatchOptions{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       deploymentInfo.GetDeploymentType(),
+					APIVersion: batchV1,
+				},
+				FieldManager: branding.GetProductName(),
+				Force:        &forcePatch,
+			})
+		if err != nil {
+			return retry.MakeRetryable(err)
+		}
+	} else {
+		patch := map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"name": deploymentInfo.GetDeploymentName(),
+			},
+			"kind":       deploymentInfo.GetDeploymentType(),
+			"apiVersion": batchV1beta1,
+			"spec": map[string]interface{}{
+				"suspend": true,
+			},
+		}
+		patchBytes, err := json.Marshal(patch)
+		if err != nil {
+			return err
+		}
+
+		_, err = client.BatchV1beta1().CronJobs(deploymentInfo.GetNamespace()).Patch(ctx, deploymentInfo.GetDeploymentName(), types.ApplyPatchType,
+			patchBytes,
+			metav1.PatchOptions{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       deploymentInfo.GetDeploymentType(),
+					APIVersion: batchV1beta1,
+				},
+				FieldManager: branding.GetProductName(),
+				Force:        &forcePatch,
+			})
+		if err != nil {
+			return retry.MakeRetryable(err)
+		}
+	}
+	return nil
+}

--- a/sensor/kubernetes/enforcer/cronjob/suspend.go
+++ b/sensor/kubernetes/enforcer/cronjob/suspend.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/stackrox/rox/generated/internalapi/central"
-	"github.com/stackrox/rox/pkg/branding"
 	kubernetesPkg "github.com/stackrox/rox/pkg/kubernetes"
 	"github.com/stackrox/rox/pkg/retry"
 	"github.com/stackrox/rox/sensor/utils"
@@ -17,6 +16,7 @@ import (
 const (
 	batchV1      = "batch/v1"
 	batchV1beta1 = "batch/v1beta1"
+	fieldManager = "StackRox"
 )
 
 // Suspend suspends the cron job
@@ -47,7 +47,7 @@ func Suspend(ctx context.Context, client kubernetes.Interface, deploymentInfo *c
 					Kind:       deploymentInfo.GetDeploymentType(),
 					APIVersion: batchV1,
 				},
-				FieldManager: branding.GetProductName(),
+				FieldManager: fieldManager,
 				Force:        &forcePatch,
 			})
 		if err != nil {
@@ -76,7 +76,7 @@ func Suspend(ctx context.Context, client kubernetes.Interface, deploymentInfo *c
 					Kind:       deploymentInfo.GetDeploymentType(),
 					APIVersion: batchV1beta1,
 				},
-				FieldManager: branding.GetProductName(),
+				FieldManager: fieldManager,
 				Force:        &forcePatch,
 			})
 		if err != nil {

--- a/sensor/kubernetes/enforcer/zero_replica.go
+++ b/sensor/kubernetes/enforcer/zero_replica.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stackrox/rox/generated/internalapi/central"
 	pkgKubernetes "github.com/stackrox/rox/pkg/kubernetes"
 	"github.com/stackrox/rox/sensor/kubernetes/enforcer/common"
+	"github.com/stackrox/rox/sensor/kubernetes/enforcer/cronjob"
 	"github.com/stackrox/rox/sensor/kubernetes/enforcer/daemonset"
 	"github.com/stackrox/rox/sensor/kubernetes/enforcer/deployment"
 	"github.com/stackrox/rox/sensor/kubernetes/enforcer/deploymentconfig"
@@ -48,6 +49,10 @@ func (e *enforcerImpl) scaleToZero(ctx context.Context, enforcement *central.Sen
 	case pkgKubernetes.StatefulSet:
 		function = func(ctx context.Context) error {
 			return statefulset.EnforceZeroReplica(ctx, e.client.Kubernetes(), deploymentInfo)
+		}
+	case pkgKubernetes.CronJob:
+		function = func(ctx context.Context) error {
+			return cronjob.Suspend(ctx, e.client.Kubernetes(), deploymentInfo)
 		}
 	default:
 		return fmt.Errorf("unknown type: %s", deploymentInfo.GetDeploymentType())

--- a/sensor/kubernetes/listener/resource_event_handler.go
+++ b/sensor/kubernetes/listener/resource_event_handler.go
@@ -17,26 +17,13 @@ import (
 	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/component"
 	"github.com/stackrox/rox/sensor/kubernetes/listener/resources"
 	"github.com/stackrox/rox/sensor/kubernetes/orchestratornamespaces"
+	sensorUtils "github.com/stackrox/rox/sensor/utils"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/informers"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 )
-
-func hasAPI(client kubernetes.Interface, gv, kind string) (bool, error) {
-	apiResourceList, err := client.Discovery().ServerResourcesForGroupVersion(gv)
-	if err != nil {
-		return false, err
-	}
-	for _, apiResource := range apiResourceList.APIResources {
-		if apiResource.Kind == kind {
-			return true, nil
-		}
-	}
-	return false, nil
-}
 
 type startable interface {
 	Start(stopCh <-chan struct{})
@@ -244,7 +231,7 @@ func (k *listenerImpl) handleAllEvents() {
 	handle(resyncingSif.Apps().V1().Deployments().Informer(), dispatchers.ForDeployments(kubernetesPkg.Deployment), k.outputQueue, &syncingResources, wg, stopSignal, &eventLock)
 	handle(resyncingSif.Apps().V1().StatefulSets().Informer(), dispatchers.ForDeployments(kubernetesPkg.StatefulSet), k.outputQueue, &syncingResources, wg, stopSignal, &eventLock)
 
-	if ok, err := hasAPI(k.client.Kubernetes(), "batch/v1", kubernetesPkg.CronJob); err != nil {
+	if ok, err := sensorUtils.HasAPI(k.client.Kubernetes(), "batch/v1", kubernetesPkg.CronJob); err != nil {
 		log.Errorf("error determining API version to use for CronJobs: %v", err)
 	} else if ok {
 		handle(resyncingSif.Batch().V1().CronJobs().Informer(), dispatchers.ForDeployments(kubernetesPkg.CronJob), k.outputQueue, &syncingResources, wg, stopSignal, &eventLock)

--- a/sensor/utils/utils.go
+++ b/sensor/utils/utils.go
@@ -4,7 +4,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-// HasAPI checks whether the kubernetes client supports the groupVersion API for the specified kind
+// HasAPI checks whether the kubernetes server supports the groupVersion API for the specified kind
 func HasAPI(client kubernetes.Interface, groupVersion, kind string) (bool, error) {
 	apiResourceList, err := client.Discovery().ServerResourcesForGroupVersion(groupVersion)
 	if err != nil {

--- a/sensor/utils/utils.go
+++ b/sensor/utils/utils.go
@@ -1,0 +1,19 @@
+package utils
+
+import (
+	"k8s.io/client-go/kubernetes"
+)
+
+// HasAPI checks whether the kubernetes client supports the groupVersion API for the specified kind
+func HasAPI(client kubernetes.Interface, groupVersion, kind string) (bool, error) {
+	apiResourceList, err := client.Discovery().ServerResourcesForGroupVersion(groupVersion)
+	if err != nil {
+		return false, err
+	}
+	for _, apiResource := range apiResourceList.APIResources {
+		if apiResource.Kind == kind {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/tools/roxvet/analyzers/validateimports/analyzer.go
+++ b/tools/roxvet/analyzers/validateimports/analyzer.go
@@ -39,6 +39,7 @@ var (
 		"sensor/tests",
 		"sensor/testutils",
 		"sensor/upgrader",
+		"sensor/utils",
 		"tools",
 		"webhookserver",
 	)
@@ -303,6 +304,7 @@ func verifyImportsFromAllowedPackagesOnly(pass *analysis.Pass, imports []*ast.Im
 
 	if validImportRoot == "sensor/kubernetes" {
 		allowedPackages = appendPackageWithChildren(allowedPackages, "sensor/common")
+		allowedPackages = appendPackageWithChildren(allowedPackages, "sensor/utils")
 	}
 
 	// Allow scale tests to import some constants from central, to be more DRY.


### PR DESCRIPTION
## Description

RHACS falsely claimed that it enforced policies on CronJobs by setting "replicas to 0". However with cron one can only suspend the `CronJob`. Added support to enforce deploy time policies on `CronJob`.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed
Manually, on GKE and Openshift 4.6 by following steps to reproduce in the JIRA (thanks @msugakov !)
```common/enforcer: 2023/02/20 22:01:55.964640 enforcer.go:135: Info: enforcement successful. action enforcement: SCALE_TO_ZERO_ENFORCEMENTSCALE_TO_ZERO_ENFORCEMENT
deployment: <
  deployment_id: "06c8224d-9271-49ad-bc82-25d664d9fda5"
  deployment_name: "hello"
  deployment_type: "CronJob"
  namespace: "boo-test"
  alert_id: "dc23ac02-10f3-4807-b8a9-ae30bd3fe934"
  policy_name: "Boo Test policy"
>
```
```
ksanchet@ksanchet-mac:~/go/src/github.com/stackrox/stackrox$ kc get cronjobs/hello -n boo-test
NAME    SCHEDULE    SUSPEND   ACTIVE   LAST SCHEDULE   AGE
hello   * * * * *   True      0        <none>          9s
```

