### PR TITLE
ROX-14702: Display origin in permission sets UI

### DIFF
--- a/ui/apps/platform/src/Containers/AccessControl/PermissionSets/PermissionSetForm.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/PermissionSets/PermissionSetForm.tsx
@@ -17,13 +17,14 @@ import {
     ToolbarItem,
 } from '@patternfly/react-core';
 
-import { defaultMinimalReadAccessResources, originLabelColours } from 'constants/accessControl';
-import { getTraitsOriginLabel, PermissionSet } from 'services/RolesService';
+import { defaultMinimalReadAccessResources } from 'constants/accessControl';
+import { PermissionSet } from 'services/RolesService';
 
 import { AccessControlQueryAction } from '../accessControlPaths';
 
 import PermissionsTable from './PermissionsTable';
 import usePermissions from '../../../hooks/usePermissions';
+import { TraitsOriginLabel } from '../TraitsOriginLabel';
 
 export type PermissionSetFormProps = {
     isActionable: boolean;
@@ -126,13 +127,7 @@ function PermissionSetForm({
                     </ToolbarItem>
                     {action !== 'create' && (
                         <ToolbarItem>
-                            <Label
-                                color={
-                                    originLabelColours[getTraitsOriginLabel(permissionSet.traits)]
-                                }
-                            >
-                                {getTraitsOriginLabel(permissionSet.traits)}
-                            </Label>
+                            <TraitsOriginLabel traits={permissionSet.traits} />
                         </ToolbarItem>
                     )}
                     {action !== 'create' && (

--- a/ui/apps/platform/src/Containers/AccessControl/PermissionSets/PermissionSetForm.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/PermissionSets/PermissionSetForm.tsx
@@ -17,8 +17,8 @@ import {
     ToolbarItem,
 } from '@patternfly/react-core';
 
-import { defaultMinimalReadAccessResources } from 'constants/accessControl';
-import { PermissionSet } from 'services/RolesService';
+import { defaultMinimalReadAccessResources, originLabelColours } from 'constants/accessControl';
+import { getTraitsOriginLabel, PermissionSet } from 'services/RolesService';
 
 import { AccessControlQueryAction } from '../accessControlPaths';
 
@@ -124,6 +124,17 @@ function PermissionSetForm({
                             {action === 'create' ? 'Create permission set' : permissionSet.name}
                         </Title>
                     </ToolbarItem>
+                    {action !== 'create' && (
+                        <ToolbarItem>
+                            <Label
+                                color={
+                                    originLabelColours[getTraitsOriginLabel(permissionSet.traits)]
+                                }
+                            >
+                                {getTraitsOriginLabel(permissionSet.traits)}
+                            </Label>
+                        </ToolbarItem>
+                    )}
                     {action !== 'create' && (
                         <ToolbarGroup variant="button-group" alignment={{ default: 'alignRight' }}>
                             <ToolbarItem>

--- a/ui/apps/platform/src/Containers/AccessControl/PermissionSets/PermissionSets.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/PermissionSets/PermissionSets.tsx
@@ -22,7 +22,6 @@ import {
     fetchResources,
     fetchRolesAsArray,
     updatePermissionSet,
-    isUserResource,
 } from 'services/RolesService';
 
 import AccessControlDescription from '../AccessControlDescription';
@@ -37,6 +36,7 @@ import AccessControlBreadcrumbs from '../AccessControlBreadcrumbs';
 import AccessControlHeading from '../AccessControlHeading';
 import AccessControlNoPermission from '../AccessControlNoPermission';
 import usePermissions from '../../../hooks/usePermissions';
+import { isUserResource } from '../traits';
 
 const entityType = 'PERMISSION_SET';
 

--- a/ui/apps/platform/src/Containers/AccessControl/PermissionSets/PermissionSets.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/PermissionSets/PermissionSets.tsx
@@ -13,7 +13,6 @@ import {
 } from '@patternfly/react-core';
 
 import NotFoundMessage from 'Components/NotFoundMessage';
-import { getIsDefaultRoleName } from 'constants/accessControl';
 import {
     PermissionSet,
     Role,
@@ -23,6 +22,7 @@ import {
     fetchResources,
     fetchRolesAsArray,
     updatePermissionSet,
+    isUserResource,
 } from 'services/RolesService';
 
 import AccessControlDescription from '../AccessControlDescription';
@@ -244,7 +244,7 @@ function PermissionSets(): ReactElement {
                     />
                 ) : (
                     <PermissionSetForm
-                        isActionable={!permissionSet || !getIsDefaultRoleName(permissionSet.name)}
+                        isActionable={!permissionSet || isUserResource(permissionSet.traits)}
                         action={action}
                         permissionSet={
                             permissionSet

--- a/ui/apps/platform/src/Containers/AccessControl/PermissionSets/PermissionSetsList.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/PermissionSets/PermissionSetsList.tsx
@@ -3,7 +3,6 @@ import {
     Alert,
     AlertVariant,
     Button,
-    Label,
     Modal,
     ModalVariant,
     PageSection,
@@ -12,11 +11,12 @@ import {
 } from '@patternfly/react-core';
 import { TableComposable, Tbody, Td, Thead, Th, Tr } from '@patternfly/react-table';
 
-import { getTraitsOriginLabel, isUserResource, PermissionSet, Role } from 'services/RolesService';
+import { PermissionSet, Role } from 'services/RolesService';
 
 import { AccessControlEntityLink, RolesLink } from '../AccessControlLinks';
 import usePermissions from '../../../hooks/usePermissions';
-import { originLabelColours } from '../../../constants/accessControl';
+import { TraitsOriginLabel } from '../TraitsOriginLabel';
+import { isUserResource } from '../traits';
 
 const entityType = 'PERMISSION_SET';
 
@@ -78,10 +78,10 @@ function PermissionSetsList({
                 <TableComposable variant="compact" isStickyHeader>
                     <Thead>
                         <Tr>
-                            <Th width={20}>Name</Th>
+                            <Th width={15}>Name</Th>
                             <Th width={15}>Origin</Th>
-                            <Th width={30}>Description</Th>
-                            <Th width={40}>Roles</Th>
+                            <Th width={25}>Description</Th>
+                            <Th width={35}>Roles</Th>
                             <Th width={10} aria-label="Row actions" />
                         </Tr>
                     </Thead>
@@ -96,9 +96,7 @@ function PermissionSetsList({
                                     />
                                 </Td>
                                 <Td dataLabel="Origin">
-                                    <Label color={originLabelColours[getTraitsOriginLabel(traits)]}>
-                                        {getTraitsOriginLabel(traits)}
-                                    </Label>
+                                    <TraitsOriginLabel traits={traits} />
                                 </Td>
                                 <Td dataLabel="Description">{description}</Td>
                                 <Td dataLabel="Roles">

--- a/ui/apps/platform/src/Containers/AccessControl/PermissionSets/PermissionSetsList.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/PermissionSets/PermissionSetsList.tsx
@@ -3,6 +3,7 @@ import {
     Alert,
     AlertVariant,
     Button,
+    Label,
     Modal,
     ModalVariant,
     PageSection,
@@ -11,10 +12,11 @@ import {
 } from '@patternfly/react-core';
 import { TableComposable, Tbody, Td, Thead, Th, Tr } from '@patternfly/react-table';
 
-import { PermissionSet, Role } from 'services/RolesService';
+import { getTraitsOriginLabel, PermissionSet, Role } from 'services/RolesService';
 
 import { AccessControlEntityLink, RolesLink } from '../AccessControlLinks';
 import usePermissions from '../../../hooks/usePermissions';
+import { originLabelColours } from '../../../constants/accessControl';
 
 const entityType = 'PERMISSION_SET';
 
@@ -77,13 +79,14 @@ function PermissionSetsList({
                     <Thead>
                         <Tr>
                             <Th width={20}>Name</Th>
+                            <Th width={15}>Origin</Th>
                             <Th width={30}>Description</Th>
                             <Th width={40}>Roles</Th>
                             <Th width={10} aria-label="Row actions" />
                         </Tr>
                     </Thead>
                     <Tbody>
-                        {permissionSets.map(({ id, name, description }) => (
+                        {permissionSets.map(({ id, name, description, traits }) => (
                             <Tr key={id}>
                                 <Td dataLabel="Name">
                                     <AccessControlEntityLink
@@ -91,6 +94,11 @@ function PermissionSetsList({
                                         entityId={id}
                                         entityName={name}
                                     />
+                                </Td>
+                                <Td dataLabel="Origin">
+                                    <Label color={originLabelColours[getTraitsOriginLabel(traits)]}>
+                                        {getTraitsOriginLabel(traits)}
+                                    </Label>
                                 </Td>
                                 <Td dataLabel="Description">{description}</Td>
                                 <Td dataLabel="Roles">

--- a/ui/apps/platform/src/Containers/AccessControl/PermissionSets/PermissionSetsList.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/PermissionSets/PermissionSetsList.tsx
@@ -12,7 +12,7 @@ import {
 } from '@patternfly/react-core';
 import { TableComposable, Tbody, Td, Thead, Th, Tr } from '@patternfly/react-table';
 
-import { getTraitsOriginLabel, PermissionSet, Role } from 'services/RolesService';
+import { getTraitsOriginLabel, isUserResource, PermissionSet, Role } from 'services/RolesService';
 
 import { AccessControlEntityLink, RolesLink } from '../AccessControlLinks';
 import usePermissions from '../../../hooks/usePermissions';
@@ -115,6 +115,7 @@ function PermissionSetsList({
                                         disable:
                                             !hasWriteAccessForPage ||
                                             idDeleting === id ||
+                                            !isUserResource(traits) ||
                                             roles.some(
                                                 ({ permissionSetId }) => permissionSetId === id
                                             ),

--- a/ui/apps/platform/src/Containers/AccessControl/TraitsOriginLabel.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/TraitsOriginLabel.tsx
@@ -1,0 +1,16 @@
+import React, { ReactElement } from 'react';
+import { Label } from '@patternfly/react-core';
+import { Traits } from 'types/traits.proto';
+import { originLabelColours, traitsOriginLabels } from './traits';
+
+export type TraitsOriginLabelProps = {
+    traits?: Traits;
+};
+
+export function TraitsOriginLabel({ traits }: TraitsOriginLabelProps): ReactElement {
+    const originLabel =
+        traits && traits.origin && traitsOriginLabels[traits.origin]
+            ? traitsOriginLabels[traits.origin]
+            : 'User';
+    return <Label color={originLabelColours[originLabel]}>{originLabel}</Label>;
+}

--- a/ui/apps/platform/src/Containers/AccessControl/traits.ts
+++ b/ui/apps/platform/src/Containers/AccessControl/traits.ts
@@ -1,0 +1,17 @@
+import { Traits } from '../../types/traits.proto';
+
+export function isUserResource(traits?: Traits): boolean {
+    return traits == null || traits.origin === 'IMPERATIVE';
+}
+
+export const traitsOriginLabels = {
+    DEFAULT: 'System',
+    IMPERATIVE: 'User',
+    DECLARATIVE: 'Declarative',
+};
+
+export const originLabelColours = {
+    System: 'grey',
+    User: 'green',
+    Declarative: 'blue',
+};

--- a/ui/apps/platform/src/constants/accessControl.ts
+++ b/ui/apps/platform/src/constants/accessControl.ts
@@ -141,4 +141,16 @@ export const replacedResourceMapping = new Map<ResourceName, string>([
     ['VulnerabilityReports', 'WorkflowAdministration'],
 ]);
 
+export const traitsOriginLabels = {
+    DEFAULT: 'System',
+    IMPERATIVE: 'User',
+    DECLARATIVE: 'Declarative',
+};
+
+export const originLabelColours = {
+    System: 'grey',
+    User: 'green',
+    Declarative: 'blue',
+};
+
 export const deprecatedResourceRowStyle = { backgroundColor: 'rgb(255,250,205)' };

--- a/ui/apps/platform/src/constants/accessControl.ts
+++ b/ui/apps/platform/src/constants/accessControl.ts
@@ -141,16 +141,4 @@ export const replacedResourceMapping = new Map<ResourceName, string>([
     ['VulnerabilityReports', 'WorkflowAdministration'],
 ]);
 
-export const traitsOriginLabels = {
-    DEFAULT: 'System',
-    IMPERATIVE: 'User',
-    DECLARATIVE: 'Declarative',
-};
-
-export const originLabelColours = {
-    System: 'grey',
-    User: 'green',
-    Declarative: 'blue',
-};
-
 export const deprecatedResourceRowStyle = { backgroundColor: 'rgb(255,250,205)' };

--- a/ui/apps/platform/src/services/AuthService/AuthService.ts
+++ b/ui/apps/platform/src/services/AuthService/AuthService.ts
@@ -4,7 +4,7 @@ import store from 'store';
 import axios from 'services/instance';
 import queryString from 'qs';
 
-import { Role } from 'services/RolesService';
+import { Role, Traits } from 'services/RolesService';
 
 import { Empty } from 'services/types';
 import AccessTokenManager from './AccessTokenManager';
@@ -77,12 +77,6 @@ export type AuthProvider = {
     requiredAttributes: AuthProviderRequiredAttributes[];
     traits?: Traits;
 };
-
-export type Traits = {
-    mutabilityMode: MutabilityMode;
-};
-
-export type MutabilityMode = 'ALLOW_MUTATE' | 'ALLOW_MUTATE_FORCED';
 
 export type AuthProviderInfo = {
     label: string;

--- a/ui/apps/platform/src/services/AuthService/AuthService.ts
+++ b/ui/apps/platform/src/services/AuthService/AuthService.ts
@@ -4,7 +4,7 @@ import store from 'store';
 import axios from 'services/instance';
 import queryString from 'qs';
 
-import { Role, Traits } from 'services/RolesService';
+import { Role } from 'services/RolesService';
 
 import { Empty } from 'services/types';
 import AccessTokenManager from './AccessTokenManager';
@@ -12,6 +12,7 @@ import addTokenRefreshInterceptors, {
     doNotStallRequestConfig,
 } from './addTokenRefreshInterceptors';
 import { authProviderLabels } from '../../constants/accessControl';
+import { Traits } from '../../types/traits.proto';
 
 const authProvidersUrl = '/v1/authProviders';
 const authLoginProvidersUrl = '/v1/login/authproviders';

--- a/ui/apps/platform/src/services/RolesService.ts
+++ b/ui/apps/platform/src/services/RolesService.ts
@@ -1,6 +1,6 @@
+import { Traits } from 'types/traits.proto';
 import axios from './instance';
 import { Empty } from './types';
-import { traitsOriginLabels } from '../constants/accessControl';
 
 const resourcesUrl = '/v1/resources';
 
@@ -80,14 +80,6 @@ export function fetchUserRolePermissions(): Promise<{ response: Role }> {
 
 const permissionSetsUrl = '/v1/permissionsets';
 
-export type Traits = {
-    mutabilityMode: MutabilityMode;
-    origin?: Origin;
-};
-
-export type MutabilityMode = 'ALLOW_MUTATE' | 'ALLOW_MUTATE_FORCED';
-export type Origin = 'IMPERATIVE' | 'DECLARATIVE' | 'DEFAULT';
-
 export type PermissionSet = {
     id: string;
     name: string;
@@ -95,16 +87,6 @@ export type PermissionSet = {
     resourceToAccess: PermissionsMap;
     traits?: Traits;
 };
-
-export function getTraitsOriginLabel(traits?: Traits): string {
-    return traits && traits.origin && traitsOriginLabels[traits.origin]
-        ? traitsOriginLabels[traits.origin]
-        : 'User';
-}
-
-export function isUserResource(traits?: Traits): boolean {
-    return traits == null || traits.origin === 'IMPERATIVE';
-}
 
 /*
  * Fetch entities and return array of objects.

--- a/ui/apps/platform/src/services/RolesService.ts
+++ b/ui/apps/platform/src/services/RolesService.ts
@@ -1,5 +1,6 @@
 import axios from './instance';
 import { Empty } from './types';
+import { traitsOriginLabels } from '../constants/accessControl';
 
 const resourcesUrl = '/v1/resources';
 
@@ -79,12 +80,27 @@ export function fetchUserRolePermissions(): Promise<{ response: Role }> {
 
 const permissionSetsUrl = '/v1/permissionsets';
 
+export type Traits = {
+    mutabilityMode: MutabilityMode;
+    origin?: Origin;
+};
+
+export type MutabilityMode = 'ALLOW_MUTATE' | 'ALLOW_MUTATE_FORCED';
+export type Origin = 'IMPERATIVE' | 'DECLARATIVE' | 'DEFAULT';
+
 export type PermissionSet = {
     id: string;
     name: string;
     description: string;
     resourceToAccess: PermissionsMap;
+    traits?: Traits;
 };
+
+export function getTraitsOriginLabel(traits?: Traits) {
+    return traits && traits.origin && traitsOriginLabels[traits.origin]
+        ? traitsOriginLabels[traits.origin]
+        : 'User';
+}
 
 /*
  * Fetch entities and return array of objects.

--- a/ui/apps/platform/src/services/RolesService.ts
+++ b/ui/apps/platform/src/services/RolesService.ts
@@ -96,10 +96,14 @@ export type PermissionSet = {
     traits?: Traits;
 };
 
-export function getTraitsOriginLabel(traits?: Traits) {
+export function getTraitsOriginLabel(traits?: Traits): string {
     return traits && traits.origin && traitsOriginLabels[traits.origin]
         ? traitsOriginLabels[traits.origin]
         : 'User';
+}
+
+export function isUserResource(traits?: Traits): boolean {
+    return traits == null || traits.origin === 'IMPERATIVE';
 }
 
 /*

--- a/ui/apps/platform/src/types/traits.proto.ts
+++ b/ui/apps/platform/src/types/traits.proto.ts
@@ -1,0 +1,7 @@
+export type Traits = {
+    mutabilityMode: TraitsMutabilityMode;
+    origin?: TraitsOrigin;
+};
+
+export type TraitsMutabilityMode = 'ALLOW_MUTATE' | 'ALLOW_MUTATE_FORCED';
+export type TraitsOrigin = 'IMPERATIVE' | 'DECLARATIVE' | 'DEFAULT';


### PR DESCRIPTION
## Description

Display origin(System, User or Declarative) in the permission set list view.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

<img width="1496" alt="Screenshot 2023-02-15 at 21 42 34" src="https://user-images.githubusercontent.com/78353299/219206870-18483e08-3472-4c65-a5a7-dd27f0d43f1a.png">

