### PR TITLE
ROX-15101 nack to compliance if central connection is not ready

### DIFF
--- a/sensor/common/admissioncontroller/alert_handler.go
+++ b/sensor/common/admissioncontroller/alert_handler.go
@@ -28,6 +28,8 @@ func (h *alertHandlerImpl) Stop(_ error) {
 	h.stopSig.Signal()
 }
 
+func (h *alertHandlerImpl) NotifyReady() {}
+
 func (h *alertHandlerImpl) Capabilities() []centralsensor.SensorCapability {
 	return nil
 }

--- a/sensor/common/admissioncontroller/alert_handler.go
+++ b/sensor/common/admissioncontroller/alert_handler.go
@@ -28,7 +28,7 @@ func (h *alertHandlerImpl) Stop(_ error) {
 	h.stopSig.Signal()
 }
 
-func (h *alertHandlerImpl) NotifyReady() {}
+func (h *alertHandlerImpl) Notify(common.SensorComponentEvent) {}
 
 func (h *alertHandlerImpl) Capabilities() []centralsensor.SensorCapability {
 	return nil

--- a/sensor/common/admissioncontroller/message_forwarder.go
+++ b/sensor/common/admissioncontroller/message_forwarder.go
@@ -52,7 +52,7 @@ func (h *admCtrlMsgForwarderImpl) Stop(err error) {
 	h.stopper.Client().Stop()
 }
 
-func (h *admCtrlMsgForwarderImpl) NotifyReady() {}
+func (h *admCtrlMsgForwarderImpl) Notify(common.SensorComponentEvent) {}
 
 func (h *admCtrlMsgForwarderImpl) Capabilities() []centralsensor.SensorCapability {
 	return nil

--- a/sensor/common/admissioncontroller/message_forwarder.go
+++ b/sensor/common/admissioncontroller/message_forwarder.go
@@ -52,6 +52,8 @@ func (h *admCtrlMsgForwarderImpl) Stop(err error) {
 	h.stopper.Client().Stop()
 }
 
+func (c *admCtrlMsgForwarderImpl) NotifyReady() {}
+
 func (h *admCtrlMsgForwarderImpl) Capabilities() []centralsensor.SensorCapability {
 	return nil
 }

--- a/sensor/common/admissioncontroller/message_forwarder.go
+++ b/sensor/common/admissioncontroller/message_forwarder.go
@@ -52,7 +52,7 @@ func (h *admCtrlMsgForwarderImpl) Stop(err error) {
 	h.stopper.Client().Stop()
 }
 
-func (c *admCtrlMsgForwarderImpl) NotifyReady() {}
+func (h *admCtrlMsgForwarderImpl) NotifyReady() {}
 
 func (h *admCtrlMsgForwarderImpl) Capabilities() []centralsensor.SensorCapability {
 	return nil

--- a/sensor/common/compliance/auditlog_manager_impl.go
+++ b/sensor/common/compliance/auditlog_manager_impl.go
@@ -48,6 +48,8 @@ func (a *auditLogCollectionManagerImpl) Stop(_ error) {
 	a.stopSig.Signal()
 }
 
+func (a *auditLogCollectionManagerImpl) NotifyReady() {}
+
 func (a *auditLogCollectionManagerImpl) Capabilities() []centralsensor.SensorCapability {
 	return []centralsensor.SensorCapability{centralsensor.AuditLogEventsCap}
 }

--- a/sensor/common/compliance/auditlog_manager_impl.go
+++ b/sensor/common/compliance/auditlog_manager_impl.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/protoutils"
 	"github.com/stackrox/rox/pkg/sync"
+	"github.com/stackrox/rox/sensor/common"
 )
 
 const (
@@ -48,7 +49,7 @@ func (a *auditLogCollectionManagerImpl) Stop(_ error) {
 	a.stopSig.Signal()
 }
 
-func (a *auditLogCollectionManagerImpl) NotifyReady() {}
+func (a *auditLogCollectionManagerImpl) Notify(common.SensorComponentEvent) {}
 
 func (a *auditLogCollectionManagerImpl) Capabilities() []centralsensor.SensorCapability {
 	return []centralsensor.SensorCapability{centralsensor.AuditLogEventsCap}

--- a/sensor/common/compliance/command_handler_impl.go
+++ b/sensor/common/compliance/command_handler_impl.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stackrox/rox/pkg/centralsensor"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/logging"
+	"github.com/stackrox/rox/sensor/common"
 )
 
 var (
@@ -43,7 +44,7 @@ func (c *commandHandlerImpl) Stop(_ error) {
 	c.stopper.Client().Stop()
 }
 
-func (c *commandHandlerImpl) NotifyReady() {}
+func (c *commandHandlerImpl) Notify(common.SensorComponentEvent) {}
 
 func (c *commandHandlerImpl) Stopped() concurrency.ReadOnlyErrorSignal {
 	return c.stopper.Client().Stopped()

--- a/sensor/common/compliance/command_handler_impl.go
+++ b/sensor/common/compliance/command_handler_impl.go
@@ -43,6 +43,8 @@ func (c *commandHandlerImpl) Stop(_ error) {
 	c.stopper.Client().Stop()
 }
 
+func (c *commandHandlerImpl) NotifyReady() {}
+
 func (c *commandHandlerImpl) Stopped() concurrency.ReadOnlyErrorSignal {
 	return c.stopper.Client().Stopped()
 }

--- a/sensor/common/compliance/mocks/auditlog_manager.go
+++ b/sensor/common/compliance/mocks/auditlog_manager.go
@@ -12,6 +12,7 @@ import (
 	sensor "github.com/stackrox/rox/generated/internalapi/sensor"
 	storage "github.com/stackrox/rox/generated/storage"
 	centralsensor "github.com/stackrox/rox/pkg/centralsensor"
+	common "github.com/stackrox/rox/sensor/common"
 )
 
 // MockAuditLogCollectionManager is a mock of AuditLogCollectionManager interface.
@@ -113,16 +114,16 @@ func (mr *MockAuditLogCollectionManagerMockRecorder) ForceUpdate() *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ForceUpdate", reflect.TypeOf((*MockAuditLogCollectionManager)(nil).ForceUpdate))
 }
 
-// NotifyReady mocks base method.
-func (m *MockAuditLogCollectionManager) NotifyReady() {
+// Notify mocks base method.
+func (m *MockAuditLogCollectionManager) Notify(arg0 common.SensorComponentEvent) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "NotifyReady")
+	m.ctrl.Call(m, "Notify", arg0)
 }
 
-// NotifyReady indicates an expected call of NotifyReady.
-func (mr *MockAuditLogCollectionManagerMockRecorder) NotifyReady() *gomock.Call {
+// Notify indicates an expected call of Notify.
+func (mr *MockAuditLogCollectionManagerMockRecorder) Notify(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NotifyReady", reflect.TypeOf((*MockAuditLogCollectionManager)(nil).NotifyReady))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Notify", reflect.TypeOf((*MockAuditLogCollectionManager)(nil).Notify), arg0)
 }
 
 // ProcessMessage mocks base method.

--- a/sensor/common/compliance/mocks/auditlog_manager.go
+++ b/sensor/common/compliance/mocks/auditlog_manager.go
@@ -113,6 +113,18 @@ func (mr *MockAuditLogCollectionManagerMockRecorder) ForceUpdate() *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ForceUpdate", reflect.TypeOf((*MockAuditLogCollectionManager)(nil).ForceUpdate))
 }
 
+// NotifyReady mocks base method.
+func (m *MockAuditLogCollectionManager) NotifyReady() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "NotifyReady")
+}
+
+// NotifyReady indicates an expected call of NotifyReady.
+func (mr *MockAuditLogCollectionManagerMockRecorder) NotifyReady() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NotifyReady", reflect.TypeOf((*MockAuditLogCollectionManager)(nil).NotifyReady))
+}
+
 // ProcessMessage mocks base method.
 func (m *MockAuditLogCollectionManager) ProcessMessage(arg0 *central.MsgToSensor) error {
 	m.ctrl.T.Helper()

--- a/sensor/common/compliance/node_inventory_handler.go
+++ b/sensor/common/compliance/node_inventory_handler.go
@@ -17,13 +17,12 @@ var _ nodeInventoryHandler = (*nodeInventoryHandlerImpl)(nil)
 
 // NewNodeInventoryHandler returns a new instance of a NodeInventoryHandler
 func NewNodeInventoryHandler(ch <-chan *storage.NodeInventory, matcher NodeIDMatcher) *nodeInventoryHandlerImpl {
-	sig := concurrency.NewSignal()
 	return &nodeInventoryHandlerImpl{
-		inventories: ch,
-		toCentral:   nil,
-		lock:        &sync.Mutex{},
-		stopper:     concurrency.NewStopper(),
-		nodeMatcher: matcher,
-		sigReady:    &sig,
+		inventories:  ch,
+		toCentral:    nil,
+		lock:         &sync.Mutex{},
+		stopper:      concurrency.NewStopper(),
+		nodeMatcher:  matcher,
+		centralReady: concurrency.NewSignal(),
 	}
 }

--- a/sensor/common/compliance/node_inventory_handler.go
+++ b/sensor/common/compliance/node_inventory_handler.go
@@ -17,11 +17,13 @@ var _ nodeInventoryHandler = (*nodeInventoryHandlerImpl)(nil)
 
 // NewNodeInventoryHandler returns a new instance of a NodeInventoryHandler
 func NewNodeInventoryHandler(ch <-chan *storage.NodeInventory, matcher NodeIDMatcher) *nodeInventoryHandlerImpl {
+	sig := concurrency.NewSignal()
 	return &nodeInventoryHandlerImpl{
 		inventories: ch,
 		toCentral:   nil,
 		lock:        &sync.Mutex{},
 		stopper:     concurrency.NewStopper(),
 		nodeMatcher: matcher,
+		sigReady:    &sig,
 	}
 }

--- a/sensor/common/compliance/node_inventory_handler_test.go
+++ b/sensor/common/compliance/node_inventory_handler_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/uuid"
+	"github.com/stackrox/rox/sensor/common"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/goleak"
 )
@@ -78,7 +79,7 @@ func (s *NodeInventoryHandlerTestSuite) TestStopHandler() {
 	producer := concurrency.NewStopper()
 	h := NewNodeInventoryHandler(inventories, &mockAlwaysHitNodeIDMatcher{})
 	s.NoError(h.Start())
-	h.NotifyReady()
+	h.Notify(common.SensorComponentEventCentralReachable)
 	consumer := consumeAndCount(h.ResponsesC(), 1)
 	// This is a producer that stops the handler after producing the first message and then sends many (29) more messages.
 	go func() {
@@ -106,8 +107,8 @@ func (s *NodeInventoryHandlerTestSuite) TestHandlerRegularRoutine() {
 	ch, producer := s.generateTestInputNoClose(10)
 	defer close(ch)
 	h := NewNodeInventoryHandler(ch, &mockAlwaysHitNodeIDMatcher{})
-	// NotifyReady is called before Start to avoid race between generateTestInputNoClose and the NodeInventoryHandler
-	h.NotifyReady()
+	// Notify is called before Start to avoid race between generateTestInputNoClose and the NodeInventoryHandler
+	h.Notify(common.SensorComponentEventCentralReachable)
 	s.NoError(h.Start())
 	consumer := consumeAndCount(h.ResponsesC(), 10)
 	s.NoError(producer.Stopped().Wait())
@@ -121,8 +122,8 @@ func (s *NodeInventoryHandlerTestSuite) TestHandlerStopIgnoresError() {
 	ch, producer := s.generateTestInputNoClose(10)
 	defer close(ch)
 	h := NewNodeInventoryHandler(ch, &mockAlwaysHitNodeIDMatcher{})
-	// NotifyReady is called before Start to avoid race between generateTestInputNoClose and the NodeInventoryHandler
-	h.NotifyReady()
+	// Notify is called before Start to avoid race between generateTestInputNoClose and the NodeInventoryHandler
+	h.Notify(common.SensorComponentEventCentralReachable)
 	s.NoError(h.Start())
 	consumer := consumeAndCount(h.ResponsesC(), 10)
 	s.NoError(producer.Stopped().Wait())
@@ -181,8 +182,8 @@ func (s *NodeInventoryHandlerTestSuite) TestMultipleStartHandler() {
 	defer close(ch)
 	h := NewNodeInventoryHandler(ch, &mockAlwaysHitNodeIDMatcher{})
 
-	// NotifyReady is called before Start to avoid race between generateTestInputNoClose and the NodeInventoryHandler
-	h.NotifyReady()
+	// Notify is called before Start to avoid race between generateTestInputNoClose and the NodeInventoryHandler
+	h.Notify(common.SensorComponentEventCentralReachable)
 	s.NoError(h.Start())
 	s.ErrorIs(h.Start(), errStartMoreThanOnce)
 
@@ -204,8 +205,8 @@ func (s *NodeInventoryHandlerTestSuite) TestDoubleStopHandler() {
 	ch, producer := s.generateTestInputNoClose(10)
 	defer close(ch)
 	h := NewNodeInventoryHandler(ch, &mockAlwaysHitNodeIDMatcher{})
-	// NotifyReady is called before Start to avoid race between generateTestInputNoClose and the NodeInventoryHandler
-	h.NotifyReady()
+	// Notify is called before Start to avoid race between generateTestInputNoClose and the NodeInventoryHandler
+	h.Notify(common.SensorComponentEventCentralReachable)
 	s.NoError(h.Start())
 	consumer := consumeAndCount(h.ResponsesC(), 10)
 	s.NoError(producer.Stopped().Wait())
@@ -220,8 +221,8 @@ func (s *NodeInventoryHandlerTestSuite) TestDoubleStopHandler() {
 func (s *NodeInventoryHandlerTestSuite) TestInputChannelClosed() {
 	ch, producer := s.generateTestInputNoClose(10)
 	h := NewNodeInventoryHandler(ch, &mockAlwaysHitNodeIDMatcher{})
-	// NotifyReady is called before Start to avoid race between generateTestInputNoClose and the NodeInventoryHandler
-	h.NotifyReady()
+	// Notify is called before Start to avoid race between generateTestInputNoClose and the NodeInventoryHandler
+	h.Notify(common.SensorComponentEventCentralReachable)
 	s.NoError(h.Start())
 	consumer := consumeAndCount(h.ResponsesC(), 10)
 	s.NoError(producer.Stopped().Wait())
@@ -253,8 +254,8 @@ func (s *NodeInventoryHandlerTestSuite) TestHandlerNilInput() {
 	ch, producer := s.generateNilTestInputNoClose(10)
 	defer close(ch)
 	h := NewNodeInventoryHandler(ch, &mockAlwaysHitNodeIDMatcher{})
-	// NotifyReady is called before Start to avoid race between generateNilTestInputNoClose and the NodeInventoryHandler
-	h.NotifyReady()
+	// Notify is called before Start to avoid race between generateNilTestInputNoClose and the NodeInventoryHandler
+	h.Notify(common.SensorComponentEventCentralReachable)
 	s.NoError(h.Start())
 	consumer := consumeAndCount(h.ResponsesC(), 0)
 	s.NoError(producer.Stopped().Wait())
@@ -268,8 +269,8 @@ func (s *NodeInventoryHandlerTestSuite) TestHandlerNodeUnknown() {
 	ch, producer := s.generateTestInputNoClose(10)
 	defer close(ch)
 	h := NewNodeInventoryHandler(ch, &mockNeverHitNodeIDMatcher{})
-	// NotifyReady is called before Start to avoid race between generateTestInputNoClose and the NodeInventoryHandler
-	h.NotifyReady()
+	// Notify is called before Start to avoid race between generateTestInputNoClose and the NodeInventoryHandler
+	h.Notify(common.SensorComponentEventCentralReachable)
 	s.NoError(h.Start())
 	// expect consumer to get 0 messages - sensor should drop inventory when node is not found
 	consumer := consumeAndCount(h.ResponsesC(), 0)

--- a/sensor/common/component.go
+++ b/sensor/common/component.go
@@ -6,12 +6,20 @@ import (
 	"google.golang.org/grpc"
 )
 
+// SensorComponentEvent represents events about which sensor components can be notified
+type SensorComponentEvent string
+
+const (
+	// SensorComponentEventCentralReachable denotes that Sensor-Central connection is up
+	SensorComponentEventCentralReachable SensorComponentEvent = "central-reachable"
+)
+
 // SensorComponent is one of the components that constitute sensor. It supports for receiving messages from central,
 // as well as sending messages back to central.
 type SensorComponent interface {
 	Start() error
 	Stop(err error) // TODO: get rid of err argument as it always seems to be effectively nil.
-	NotifyReady()
+	Notify(e SensorComponentEvent)
 	Capabilities() []centralsensor.SensorCapability
 
 	ProcessMessage(msg *central.MsgToSensor) error

--- a/sensor/common/component.go
+++ b/sensor/common/component.go
@@ -11,6 +11,7 @@ import (
 type SensorComponent interface {
 	Start() error
 	Stop(err error) // TODO: get rid of err argument as it always seems to be effectively nil.
+	NotifyReady()
 	Capabilities() []centralsensor.SensorCapability
 
 	ProcessMessage(msg *central.MsgToSensor) error

--- a/sensor/common/config/handler.go
+++ b/sensor/common/config/handler.go
@@ -59,7 +59,7 @@ func (c *configHandlerImpl) Stop(_ error) {
 	c.stopC.Signal()
 }
 
-func (c *configHandlerImpl) NotifyReady() {}
+func (c *configHandlerImpl) Notify(common.SensorComponentEvent) {}
 
 func (c *configHandlerImpl) Capabilities() []centralsensor.SensorCapability {
 	return nil

--- a/sensor/common/config/handler.go
+++ b/sensor/common/config/handler.go
@@ -59,6 +59,8 @@ func (c *configHandlerImpl) Stop(_ error) {
 	c.stopC.Signal()
 }
 
+func (c *configHandlerImpl) NotifyReady() {}
+
 func (c *configHandlerImpl) Capabilities() []centralsensor.SensorCapability {
 	return nil
 }

--- a/sensor/common/detector/detector.go
+++ b/sensor/common/detector/detector.go
@@ -208,6 +208,8 @@ func (d *detectorImpl) Stop(err error) {
 	_ = d.serializerStopper.Client().Stopped().Wait()
 }
 
+func (d *detectorImpl) NotifyReady() {}
+
 func (d *detectorImpl) Capabilities() []centralsensor.SensorCapability {
 	return []centralsensor.SensorCapability{centralsensor.SensorDetectionCap}
 }

--- a/sensor/common/detector/detector.go
+++ b/sensor/common/detector/detector.go
@@ -208,7 +208,7 @@ func (d *detectorImpl) Stop(err error) {
 	_ = d.serializerStopper.Client().Stopped().Wait()
 }
 
-func (d *detectorImpl) NotifyReady() {}
+func (d *detectorImpl) Notify(common.SensorComponentEvent) {}
 
 func (d *detectorImpl) Capabilities() []centralsensor.SensorCapability {
 	return []centralsensor.SensorCapability{centralsensor.SensorDetectionCap}

--- a/sensor/common/detector/mocks/detector.go
+++ b/sensor/common/detector/mocks/detector.go
@@ -11,6 +11,7 @@ import (
 	central "github.com/stackrox/rox/generated/internalapi/central"
 	storage "github.com/stackrox/rox/generated/storage"
 	centralsensor "github.com/stackrox/rox/pkg/centralsensor"
+	common "github.com/stackrox/rox/sensor/common"
 	grpc "google.golang.org/grpc"
 )
 
@@ -51,16 +52,16 @@ func (mr *MockDetectorMockRecorder) Capabilities() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Capabilities", reflect.TypeOf((*MockDetector)(nil).Capabilities))
 }
 
-// NotifyReady mocks base method.
-func (m *MockDetector) NotifyReady() {
+// Notify mocks base method.
+func (m *MockDetector) Notify(e common.SensorComponentEvent) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "NotifyReady")
+	m.ctrl.Call(m, "Notify", e)
 }
 
-// NotifyReady indicates an expected call of NotifyReady.
-func (mr *MockDetectorMockRecorder) NotifyReady() *gomock.Call {
+// Notify indicates an expected call of Notify.
+func (mr *MockDetectorMockRecorder) Notify(e interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NotifyReady", reflect.TypeOf((*MockDetector)(nil).NotifyReady))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Notify", reflect.TypeOf((*MockDetector)(nil).Notify), e)
 }
 
 // ProcessDeployment mocks base method.

--- a/sensor/common/detector/mocks/detector.go
+++ b/sensor/common/detector/mocks/detector.go
@@ -51,6 +51,18 @@ func (mr *MockDetectorMockRecorder) Capabilities() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Capabilities", reflect.TypeOf((*MockDetector)(nil).Capabilities))
 }
 
+// NotifyReady mocks base method.
+func (m *MockDetector) NotifyReady() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "NotifyReady")
+}
+
+// NotifyReady indicates an expected call of NotifyReady.
+func (mr *MockDetectorMockRecorder) NotifyReady() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NotifyReady", reflect.TypeOf((*MockDetector)(nil).NotifyReady))
+}
+
 // ProcessDeployment mocks base method.
 func (m *MockDetector) ProcessDeployment(deployment *storage.Deployment, action central.ResourceAction) {
 	m.ctrl.T.Helper()

--- a/sensor/common/enforcer/enforcer.go
+++ b/sensor/common/enforcer/enforcer.go
@@ -151,4 +151,4 @@ func (e *enforcer) Stop(_ error) {
 	_ = e.stopper.Client().Stopped().Wait()
 }
 
-func (e *enforcer) NotifyReady() {}
+func (e *enforcer) Notify(common.SensorComponentEvent) {}

--- a/sensor/common/enforcer/enforcer.go
+++ b/sensor/common/enforcer/enforcer.go
@@ -150,3 +150,5 @@ func (e *enforcer) Stop(_ error) {
 	e.stopper.Client().Stop()
 	_ = e.stopper.Client().Stopped().Wait()
 }
+
+func (e *enforcer) NotifyReady() {}

--- a/sensor/common/externalsrcs/handler.go
+++ b/sensor/common/externalsrcs/handler.go
@@ -61,6 +61,8 @@ func (h *handlerImpl) Stop(_ error) {
 	h.stopSig.Signal()
 }
 
+func (h *handlerImpl) NotifyReady() {}
+
 func (h *handlerImpl) Capabilities() []centralsensor.SensorCapability {
 	return []centralsensor.SensorCapability{centralsensor.NetworkGraphExternalSrcsCap}
 }

--- a/sensor/common/externalsrcs/handler.go
+++ b/sensor/common/externalsrcs/handler.go
@@ -61,7 +61,7 @@ func (h *handlerImpl) Stop(_ error) {
 	h.stopSig.Signal()
 }
 
-func (h *handlerImpl) NotifyReady() {}
+func (h *handlerImpl) Notify(common.SensorComponentEvent) {}
 
 func (h *handlerImpl) Capabilities() []centralsensor.SensorCapability {
 	return []centralsensor.SensorCapability{centralsensor.NetworkGraphExternalSrcsCap}

--- a/sensor/common/networkflow/manager/manager_impl.go
+++ b/sensor/common/networkflow/manager/manager_impl.go
@@ -230,6 +230,8 @@ func (m *networkFlowManager) Capabilities() []centralsensor.SensorCapability {
 	return nil
 }
 
+func (m *networkFlowManager) NotifyReady() {}
+
 func (m *networkFlowManager) ResponsesC() <-chan *central.MsgFromSensor {
 	return m.sensorUpdates
 }

--- a/sensor/common/networkflow/manager/manager_impl.go
+++ b/sensor/common/networkflow/manager/manager_impl.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stackrox/rox/pkg/networkgraph"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/pkg/timestamp"
+	"github.com/stackrox/rox/sensor/common"
 	"github.com/stackrox/rox/sensor/common/clusterentities"
 	"github.com/stackrox/rox/sensor/common/detector"
 	"github.com/stackrox/rox/sensor/common/externalsrcs"
@@ -230,7 +231,7 @@ func (m *networkFlowManager) Capabilities() []centralsensor.SensorCapability {
 	return nil
 }
 
-func (m *networkFlowManager) NotifyReady() {}
+func (m *networkFlowManager) Notify(common.SensorComponentEvent) {}
 
 func (m *networkFlowManager) ResponsesC() <-chan *central.MsgFromSensor {
 	return m.sensorUpdates

--- a/sensor/common/reprocessor/handler.go
+++ b/sensor/common/reprocessor/handler.go
@@ -46,6 +46,8 @@ func (h *handlerImpl) Stop(err error) {
 	h.stopSig.SignalWithError(err)
 }
 
+func (h *handlerImpl) NotifyReady() {}
+
 func (h *handlerImpl) Capabilities() []centralsensor.SensorCapability {
 	// A new sensor capability to reprocess deployment has not been added. In case of mismatched upgrades,
 	// the re-processing is discarded, which is fine.

--- a/sensor/common/reprocessor/handler.go
+++ b/sensor/common/reprocessor/handler.go
@@ -46,7 +46,7 @@ func (h *handlerImpl) Stop(err error) {
 	h.stopSig.SignalWithError(err)
 }
 
-func (h *handlerImpl) NotifyReady() {}
+func (h *handlerImpl) Notify(common.SensorComponentEvent) {}
 
 func (h *handlerImpl) Capabilities() []centralsensor.SensorCapability {
 	// A new sensor capability to reprocess deployment has not been added. In case of mismatched upgrades,

--- a/sensor/common/sensor/sensor.go
+++ b/sensor/common/sensor/sensor.go
@@ -220,6 +220,9 @@ func (s *Sensor) Start() {
 		s.stoppedSig.SignalWithErrorWrap(errSig.Err(), "getting connection from connection factory")
 		return
 	case <-okSig.Done():
+		for _, component := range s.components {
+			component.NotifyReady()
+		}
 	case <-s.stoppedSig.Done():
 		return
 	}

--- a/sensor/common/sensor/sensor.go
+++ b/sensor/common/sensor/sensor.go
@@ -221,7 +221,7 @@ func (s *Sensor) Start() {
 		return
 	case <-okSig.Done():
 		for _, component := range s.components {
-			component.NotifyReady()
+			component.Notify(common.SensorComponentEventCentralReachable)
 		}
 	case <-s.stoppedSig.Done():
 		return

--- a/sensor/common/signal/signal_service.go
+++ b/sensor/common/signal/signal_service.go
@@ -47,7 +47,7 @@ func (s *serviceImpl) Start() error {
 
 func (s *serviceImpl) Stop(err error) {}
 
-func (s *serviceImpl) NotifyReady() {}
+func (s *serviceImpl) Notify(common.SensorComponentEvent) {}
 
 func (s *serviceImpl) Capabilities() []centralsensor.SensorCapability {
 	return nil

--- a/sensor/common/signal/signal_service.go
+++ b/sensor/common/signal/signal_service.go
@@ -47,6 +47,8 @@ func (s *serviceImpl) Start() error {
 
 func (s *serviceImpl) Stop(err error) {}
 
+func (s *serviceImpl) NotifyReady() {}
+
 func (s *serviceImpl) Capabilities() []centralsensor.SensorCapability {
 	return nil
 }

--- a/sensor/kubernetes/admissioncontroller/config_map_persister.go
+++ b/sensor/kubernetes/admissioncontroller/config_map_persister.go
@@ -60,7 +60,7 @@ func (p *configMapPersister) Stop(err error) {
 	p.stopSig.SignalWithError(err)
 }
 
-func (p *configMapPersister) NotifyReady() {}
+func (p *configMapPersister) Notify(common.SensorComponentEvent) {}
 
 func (p *configMapPersister) Capabilities() []centralsensor.SensorCapability {
 	return nil

--- a/sensor/kubernetes/admissioncontroller/config_map_persister.go
+++ b/sensor/kubernetes/admissioncontroller/config_map_persister.go
@@ -60,6 +60,8 @@ func (p *configMapPersister) Stop(err error) {
 	p.stopSig.SignalWithError(err)
 }
 
+func (p *configMapPersister) NotifyReady() {}
+
 func (p *configMapPersister) Capabilities() []centralsensor.SensorCapability {
 	return nil
 }

--- a/sensor/kubernetes/clusterhealth/updater.go
+++ b/sensor/kubernetes/clusterhealth/updater.go
@@ -54,7 +54,7 @@ func (u *updaterImpl) Stop(_ error) {
 	u.stopSig.Signal()
 }
 
-func (u *updaterImpl) NotifyReady() {}
+func (u *updaterImpl) Notify(common.SensorComponentEvent) {}
 
 func (u *updaterImpl) Capabilities() []centralsensor.SensorCapability {
 	return []centralsensor.SensorCapability{centralsensor.HealthMonitoringCap}

--- a/sensor/kubernetes/clusterhealth/updater.go
+++ b/sensor/kubernetes/clusterhealth/updater.go
@@ -54,6 +54,8 @@ func (u *updaterImpl) Stop(_ error) {
 	u.stopSig.Signal()
 }
 
+func (u *updaterImpl) NotifyReady() {}
+
 func (u *updaterImpl) Capabilities() []centralsensor.SensorCapability {
 	return []centralsensor.SensorCapability{centralsensor.HealthMonitoringCap}
 }

--- a/sensor/kubernetes/clustermetrics/cluster_metrics.go
+++ b/sensor/kubernetes/clustermetrics/cluster_metrics.go
@@ -56,7 +56,7 @@ func (cm *clusterMetricsImpl) Stop(_ error) {
 	_ = cm.stopper.Client().Stopped().Wait()
 }
 
-func (cm *clusterMetricsImpl) NotifyReady() {}
+func (cm *clusterMetricsImpl) Notify(common.SensorComponentEvent) {}
 
 func (cm *clusterMetricsImpl) Capabilities() []centralsensor.SensorCapability {
 	return []centralsensor.SensorCapability{}

--- a/sensor/kubernetes/clustermetrics/cluster_metrics.go
+++ b/sensor/kubernetes/clustermetrics/cluster_metrics.go
@@ -56,6 +56,8 @@ func (cm *clusterMetricsImpl) Stop(_ error) {
 	_ = cm.stopper.Client().Stopped().Wait()
 }
 
+func (cm *clusterMetricsImpl) NotifyReady() {}
+
 func (cm *clusterMetricsImpl) Capabilities() []centralsensor.SensorCapability {
 	return []centralsensor.SensorCapability{}
 }

--- a/sensor/kubernetes/clusterstatus/updater.go
+++ b/sensor/kubernetes/clusterstatus/updater.go
@@ -51,7 +51,7 @@ func (u *updaterImpl) Stop(_ error) {
 	u.stopSig.Signal()
 }
 
-func (u *updaterImpl) NotifyReady() {}
+func (u *updaterImpl) Notify(common.SensorComponentEvent) {}
 
 func (u *updaterImpl) Capabilities() []centralsensor.SensorCapability {
 	return nil

--- a/sensor/kubernetes/clusterstatus/updater.go
+++ b/sensor/kubernetes/clusterstatus/updater.go
@@ -51,6 +51,8 @@ func (u *updaterImpl) Stop(_ error) {
 	u.stopSig.Signal()
 }
 
+func (u *updaterImpl) NotifyReady() {}
+
 func (u *updaterImpl) Capabilities() []centralsensor.SensorCapability {
 	return nil
 }

--- a/sensor/kubernetes/eventpipeline/pipeline_impl.go
+++ b/sensor/kubernetes/eventpipeline/pipeline_impl.go
@@ -72,6 +72,8 @@ func (p *eventPipeline) Stop(_ error) {
 	p.stopSig.Signal()
 }
 
+func (p *eventPipeline) NotifyReady() {}
+
 // forwardMessages from listener component to responses channel
 func (p *eventPipeline) forwardMessages() {
 	for {

--- a/sensor/kubernetes/eventpipeline/pipeline_impl.go
+++ b/sensor/kubernetes/eventpipeline/pipeline_impl.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/logging"
+	"github.com/stackrox/rox/sensor/common"
 	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/component"
 )
 
@@ -72,7 +73,7 @@ func (p *eventPipeline) Stop(_ error) {
 	p.stopSig.Signal()
 }
 
-func (p *eventPipeline) NotifyReady() {}
+func (p *eventPipeline) Notify(common.SensorComponentEvent) {}
 
 // forwardMessages from listener component to responses channel
 func (p *eventPipeline) forwardMessages() {

--- a/sensor/kubernetes/localscanner/tls_issuer.go
+++ b/sensor/kubernetes/localscanner/tls_issuer.go
@@ -137,6 +137,8 @@ func (i *localScannerTLSIssuerImpl) Stop(_ error) {
 	log.Debug("local scanner TLS issuer stopped.")
 }
 
+func (i *localScannerTLSIssuerImpl) NotifyReady() {}
+
 func (i *localScannerTLSIssuerImpl) Capabilities() []centralsensor.SensorCapability {
 	return []centralsensor.SensorCapability{centralsensor.LocalScannerCredentialsRefresh}
 }

--- a/sensor/kubernetes/localscanner/tls_issuer.go
+++ b/sensor/kubernetes/localscanner/tls_issuer.go
@@ -137,7 +137,7 @@ func (i *localScannerTLSIssuerImpl) Stop(_ error) {
 	log.Debug("local scanner TLS issuer stopped.")
 }
 
-func (i *localScannerTLSIssuerImpl) NotifyReady() {}
+func (i *localScannerTLSIssuerImpl) Notify(common.SensorComponentEvent) {}
 
 func (i *localScannerTLSIssuerImpl) Capabilities() []centralsensor.SensorCapability {
 	return []centralsensor.SensorCapability{centralsensor.LocalScannerCredentialsRefresh}

--- a/sensor/kubernetes/networkpolicies/command_handler.go
+++ b/sensor/kubernetes/networkpolicies/command_handler.go
@@ -51,7 +51,7 @@ func (h *commandHandler) Stop(err error) {
 	h.stopSig.Signal()
 }
 
-func (h *commandHandler) NotifyReady() {}
+func (h *commandHandler) Notify(common.SensorComponentEvent) {}
 
 func (h *commandHandler) Capabilities() []centralsensor.SensorCapability {
 	return nil

--- a/sensor/kubernetes/networkpolicies/command_handler.go
+++ b/sensor/kubernetes/networkpolicies/command_handler.go
@@ -51,6 +51,8 @@ func (h *commandHandler) Stop(err error) {
 	h.stopSig.Signal()
 }
 
+func (h *commandHandler) NotifyReady() {}
+
 func (h *commandHandler) Capabilities() []centralsensor.SensorCapability {
 	return nil
 }

--- a/sensor/kubernetes/telemetry/command_handler.go
+++ b/sensor/kubernetes/telemetry/command_handler.go
@@ -80,7 +80,7 @@ func (h *commandHandler) Stop(err error) {
 	h.stopSig.SignalWithError(err)
 }
 
-func (h *commandHandler) NotifyReady() {}
+func (h *commandHandler) Notify(common.SensorComponentEvent) {}
 
 func (h *commandHandler) ProcessMessage(msg *central.MsgToSensor) error {
 	switch m := msg.GetMsg().(type) {

--- a/sensor/kubernetes/telemetry/command_handler.go
+++ b/sensor/kubernetes/telemetry/command_handler.go
@@ -80,6 +80,8 @@ func (h *commandHandler) Stop(err error) {
 	h.stopSig.SignalWithError(err)
 }
 
+func (h *commandHandler) NotifyReady() {}
+
 func (h *commandHandler) ProcessMessage(msg *central.MsgToSensor) error {
 	switch m := msg.GetMsg().(type) {
 	case *central.MsgToSensor_TelemetryDataRequest:

--- a/sensor/kubernetes/upgrade/command_handler_impl.go
+++ b/sensor/kubernetes/upgrade/command_handler_impl.go
@@ -72,7 +72,7 @@ func (h *commandHandler) Stop(err error) {
 	h.stopSig.Signal()
 }
 
-func (h *commandHandler) NotifyReady() {}
+func (h *commandHandler) Notify(common.SensorComponentEvent) {}
 
 func (h *commandHandler) Capabilities() []centralsensor.SensorCapability {
 	return nil

--- a/sensor/kubernetes/upgrade/command_handler_impl.go
+++ b/sensor/kubernetes/upgrade/command_handler_impl.go
@@ -72,6 +72,8 @@ func (h *commandHandler) Stop(err error) {
 	h.stopSig.Signal()
 }
 
+func (h *commandHandler) NotifyReady() {}
+
 func (h *commandHandler) Capabilities() []centralsensor.SensorCapability {
 	return nil
 }


### PR DESCRIPTION
## Description

The idea is to have a mechanism to notify `SensorComponents` when the connection with central is established.

I'm thinking of making the `NotifyReady` function more generic and have something like `Notify(msg)` so we can reuse this for other types of notifications and not just notifying when the connection with central is ready.

Note to reviewers: Consider reviewing the PR by commit. The second and forth are the most interesting 🙂 

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

* Tested sending node inventories on sensor's startup with a broken connection.
