### PR TITLE
Cherry-pick Operator test fix: Drop PodSecurityPolicy from errors files. (#4774)

### DIFF
--- a/operator/tests/common/delete-central-errors-cluster.envsubst.yaml
+++ b/operator/tests/common/delete-central-errors-cluster.envsubst.yaml
@@ -17,16 +17,6 @@ kind: ClusterRole
 metadata:
   name: stackrox-${NAMESPACE}-scanner-psp
 ---
-apiVersion: policy/v1beta1
-kind: PodSecurityPolicy
-metadata:
-  name: stackrox-${NAMESPACE}-central
----
-apiVersion: policy/v1beta1
-kind: PodSecurityPolicy
-metadata:
-  name: stackrox-${NAMESPACE}-scanner
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/operator/tests/common/delete-securedcluster-errors.yaml
+++ b/operator/tests/common/delete-securedcluster-errors.yaml
@@ -93,21 +93,6 @@ kind: ClusterRole
 metadata:
   name: stackrox:view-cluster
 ---
-apiVersion: policy/v1beta1
-kind: PodSecurityPolicy
-metadata:
-  name: stackrox-admission-control
----
-apiVersion: policy/v1beta1
-kind: PodSecurityPolicy
-metadata:
-  name: stackrox-collector
----
-apiVersion: policy/v1beta1
-kind: PodSecurityPolicy
-metadata:
-  name: stackrox-sensor
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:


### PR DESCRIPTION
## Description

Cherry-picking an operator test fix to the release branch. 

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

CI is sufficient. 