### PR TITLE
Telemetry: Always add WithGroups to Track calls

### DIFF
--- a/central/cluster/datastore/telemetry.go
+++ b/central/cluster/datastore/telemetry.go
@@ -26,14 +26,17 @@ func trackClusterRegistered(ctx context.Context, cluster *storage.Cluster) {
 			"Cluster ID":   cluster.GetId(),
 			"Managed By":   cluster.GetManagedBy().String(),
 		}
-		cfg.Telemeter().Track("Secured Cluster Registered", props, telemeter.WithUserID(userID))
+		groups := telemeter.WithGroups(cfg.GroupName, cfg.GroupID)
 
-		opts := telemeter.WithClient(cluster.GetId(), securedClusterClient)
+		cfg.Telemeter().Track("Secured Cluster Registered", props, telemeter.WithUserID(userID), groups)
+
+		client := telemeter.WithClient(cluster.GetId(), securedClusterClient)
+
 		// Add the secured cluster 'user' to the Tenant group:
-		cfg.Telemeter().Group(cfg.GroupID, nil, opts)
+		cfg.Telemeter().Group(nil, client, groups)
 
 		// Update the secured cluster identity from its name:
-		cfg.Telemeter().Identify(makeClusterProperties(cluster), opts)
+		cfg.Telemeter().Identify(makeClusterProperties(cluster), client, groups)
 	}
 }
 
@@ -58,7 +61,7 @@ func trackClusterInitialized(cluster *storage.Cluster) {
 				"Health": cluster.GetHealthStatus().GetOverallHealthStatus().String(),
 			},
 				telemeter.WithClient(cluster.GetId(), securedClusterClient),
-				telemeter.WithGroups("Tenant", cfg.GroupID))
+				telemeter.WithGroups(cfg.GroupName, cfg.GroupID))
 	}
 }
 
@@ -95,6 +98,7 @@ func UpdateSecuredClusterIdentity(ctx context.Context, clusterID string, metrics
 
 		opts := []telemeter.Option{
 			telemeter.WithClient(cluster.GetId(), securedClusterClient),
+			telemeter.WithGroups(cfg.GroupName, cfg.GroupID),
 		}
 		cfg.Telemeter().Identify(props, opts...)
 		cfg.Telemeter().Track("Updated Secured Cluster Identity", nil, opts...)

--- a/central/cluster/datastore/telemetry.go
+++ b/central/cluster/datastore/telemetry.go
@@ -26,7 +26,7 @@ func trackClusterRegistered(ctx context.Context, cluster *storage.Cluster) {
 			"Cluster ID":   cluster.GetId(),
 			"Managed By":   cluster.GetManagedBy().String(),
 		}
-		groups := telemeter.WithGroups(cfg.GroupName, cfg.GroupID)
+		groups := telemeter.WithGroups(cfg.GroupType, cfg.GroupID)
 
 		cfg.Telemeter().Track("Secured Cluster Registered", props, telemeter.WithUserID(userID), groups)
 
@@ -61,7 +61,7 @@ func trackClusterInitialized(cluster *storage.Cluster) {
 				"Health": cluster.GetHealthStatus().GetOverallHealthStatus().String(),
 			},
 				telemeter.WithClient(cluster.GetId(), securedClusterClient),
-				telemeter.WithGroups(cfg.GroupName, cfg.GroupID))
+				telemeter.WithGroups(cfg.GroupType, cfg.GroupID))
 	}
 }
 
@@ -98,7 +98,7 @@ func UpdateSecuredClusterIdentity(ctx context.Context, clusterID string, metrics
 
 		opts := []telemeter.Option{
 			telemeter.WithClient(cluster.GetId(), securedClusterClient),
-			telemeter.WithGroups(cfg.GroupName, cfg.GroupID),
+			telemeter.WithGroups(cfg.GroupType, cfg.GroupID),
 		}
 		cfg.Telemeter().Identify(props, opts...)
 		cfg.Telemeter().Track("Updated Secured Cluster Identity", nil, opts...)

--- a/central/main.go
+++ b/central/main.go
@@ -181,6 +181,7 @@ import (
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/sac/observe"
 	"github.com/stackrox/rox/pkg/sync"
+	"github.com/stackrox/rox/pkg/telemetry/phonehome/telemeter"
 	"github.com/stackrox/rox/pkg/utils"
 	pkgVersion "github.com/stackrox/rox/pkg/version"
 )
@@ -316,7 +317,10 @@ func startServices() {
 	pruning.Singleton().Start()
 	gatherer.Singleton().Start()
 	vulnRequestManager.Singleton().Start()
-	centralclient.InstanceConfig().Gatherer().Start()
+
+	if cfg := centralclient.InstanceConfig(); cfg.Enabled() {
+		cfg.Gatherer().Start(telemeter.WithGroups(cfg.GroupName, cfg.GroupID))
+	}
 
 	go registerDelayedIntegrations(iiStore.DelayedIntegrations)
 }

--- a/central/main.go
+++ b/central/main.go
@@ -319,7 +319,7 @@ func startServices() {
 	vulnRequestManager.Singleton().Start()
 
 	if cfg := centralclient.InstanceConfig(); cfg.Enabled() {
-		cfg.Gatherer().Start(telemeter.WithGroups(cfg.GroupName, cfg.GroupID))
+		cfg.Gatherer().Start(telemeter.WithGroups(cfg.GroupType, cfg.GroupID))
 	}
 
 	go registerDelayedIntegrations(iiStore.DelayedIntegrations)

--- a/central/role/mapper/telemetry.go
+++ b/central/role/mapper/telemetry.go
@@ -10,6 +10,7 @@ import (
 // such users could be segmented by tenant properties.
 func addUserToTenantGroup(user *storage.User) {
 	if cfg := centralclient.InstanceConfig(); cfg.Enabled() {
-		cfg.Telemeter().Group(cfg.GroupID, nil, telemeter.WithUserID(cfg.HashUserID(user.GetId(), user.GetAuthProviderId())))
+		cfg.Telemeter().Group(nil, telemeter.WithUserID(cfg.HashUserID(user.GetId(), user.GetAuthProviderId())),
+			telemeter.WithGroups(cfg.GroupName, cfg.GroupID))
 	}
 }

--- a/central/role/mapper/telemetry.go
+++ b/central/role/mapper/telemetry.go
@@ -11,6 +11,6 @@ import (
 func addUserToTenantGroup(user *storage.User) {
 	if cfg := centralclient.InstanceConfig(); cfg.Enabled() {
 		cfg.Telemeter().Group(nil, telemeter.WithUserID(cfg.HashUserID(user.GetId(), user.GetAuthProviderId())),
-			telemeter.WithGroups(cfg.GroupName, cfg.GroupID))
+			telemeter.WithGroups(cfg.GroupType, cfg.GroupID))
 	}
 }

--- a/central/telemetry/centralclient/instance_config.go
+++ b/central/telemetry/centralclient/instance_config.go
@@ -73,7 +73,7 @@ func getInstanceConfig() (*phonehome.Config, map[string]any, error) {
 	return &phonehome.Config{
 			ClientID:     centralID,
 			ClientName:   "Central",
-			GroupName:    "Tenant",
+			GroupType:    "Tenant",
 			GroupID:      tenantID,
 			StorageKey:   key,
 			Endpoint:     env.TelemetryEndpoint.Setting(),
@@ -130,7 +130,7 @@ func RegisterCentralClient(config grpc.Config, basicAuthProviderID string) {
 	}
 	registerInterceptors(config)
 	// Central adds itself to the tenant group, with no group properties:
-	cfg.Telemeter().Group(nil, telemeter.WithGroups(cfg.GroupName, cfg.GroupID))
+	cfg.Telemeter().Group(nil, telemeter.WithGroups(cfg.GroupType, cfg.GroupID))
 	registerAdminUser(basicAuthProviderID)
 }
 
@@ -146,5 +146,5 @@ func registerInterceptors(config grpc.Config) {
 func registerAdminUser(basicAuthProviderID string) {
 	cfg := InstanceConfig()
 	adminHash := cfg.HashUserID(basic.DefaultUsername, basicAuthProviderID)
-	cfg.Telemeter().Group(nil, telemeter.WithUserID(adminHash), telemeter.WithGroups(cfg.GroupName, cfg.GroupID))
+	cfg.Telemeter().Group(nil, telemeter.WithUserID(adminHash), telemeter.WithGroups(cfg.GroupType, cfg.GroupID))
 }

--- a/central/telemetry/centralclient/instance_config.go
+++ b/central/telemetry/centralclient/instance_config.go
@@ -73,6 +73,7 @@ func getInstanceConfig() (*phonehome.Config, map[string]any, error) {
 	return &phonehome.Config{
 			ClientID:     centralID,
 			ClientName:   "Central",
+			GroupName:    "Tenant",
 			GroupID:      tenantID,
 			StorageKey:   key,
 			Endpoint:     env.TelemetryEndpoint.Setting(),
@@ -129,7 +130,7 @@ func RegisterCentralClient(config grpc.Config, basicAuthProviderID string) {
 	}
 	registerInterceptors(config)
 	// Central adds itself to the tenant group, with no group properties:
-	cfg.Telemeter().Group(cfg.GroupID, nil)
+	cfg.Telemeter().Group(nil, telemeter.WithGroups(cfg.GroupName, cfg.GroupID))
 	registerAdminUser(basicAuthProviderID)
 }
 
@@ -145,5 +146,5 @@ func registerInterceptors(config grpc.Config) {
 func registerAdminUser(basicAuthProviderID string) {
 	cfg := InstanceConfig()
 	adminHash := cfg.HashUserID(basic.DefaultUsername, basicAuthProviderID)
-	cfg.Telemeter().Group(cfg.GroupID, nil, telemeter.WithUserID(adminHash))
+	cfg.Telemeter().Group(nil, telemeter.WithUserID(adminHash), telemeter.WithGroups(cfg.GroupName, cfg.GroupID))
 }

--- a/pkg/telemetry/phonehome/client_config.go
+++ b/pkg/telemetry/phonehome/client_config.go
@@ -33,7 +33,9 @@ type Config struct {
 	ClientID string
 	// ClientName tells what kind of client is sending data.
 	ClientName string
-	// GroupID identifies the main group to which the client belongs.
+	// GroupName identifies the main group name to which the client belongs.
+	GroupName string
+	// GroupID identifies the ID of the GroupName group.
 	GroupID string
 
 	StorageKey   string

--- a/pkg/telemetry/phonehome/client_config.go
+++ b/pkg/telemetry/phonehome/client_config.go
@@ -33,9 +33,9 @@ type Config struct {
 	ClientID string
 	// ClientName tells what kind of client is sending data.
 	ClientName string
-	// GroupName identifies the main group name to which the client belongs.
-	GroupName string
-	// GroupID identifies the ID of the GroupName group.
+	// GroupType identifies the main group type to which the client belongs.
+	GroupType string
+	// GroupID identifies the ID of the GroupType group.
 	GroupID string
 
 	StorageKey   string

--- a/pkg/telemetry/phonehome/gatherer.go
+++ b/pkg/telemetry/phonehome/gatherer.go
@@ -106,7 +106,11 @@ func (g *gatherer) Start(opts ...telemeter.Option) {
 	defer g.mu.Unlock()
 	if g.stopSig.IsDone() {
 		g.reset()
-		g.opts = opts
+		{
+			g.gathering.Lock()
+			g.opts = opts
+			g.gathering.Unlock()
+		}
 		go g.loop()
 	}
 }

--- a/pkg/telemetry/phonehome/interceptor.go
+++ b/pkg/telemetry/phonehome/interceptor.go
@@ -28,7 +28,7 @@ func (cfg *Config) track(rp *RequestParams) {
 			}
 		}
 		if ok {
-			cfg.telemeter.Track(event, props, telemeter.WithUserID(id), telemeter.WithGroups(cfg.GroupName, cfg.GroupID))
+			cfg.telemeter.Track(event, props, telemeter.WithUserID(id), telemeter.WithGroups(cfg.GroupType, cfg.GroupID))
 		}
 	}
 }

--- a/pkg/telemetry/phonehome/interceptor.go
+++ b/pkg/telemetry/phonehome/interceptor.go
@@ -28,7 +28,7 @@ func (cfg *Config) track(rp *RequestParams) {
 			}
 		}
 		if ok {
-			cfg.telemeter.Track(event, props, telemeter.WithUserID(id))
+			cfg.telemeter.Track(event, props, telemeter.WithUserID(id), telemeter.WithGroups(cfg.GroupName, cfg.GroupID))
 		}
 	}
 }

--- a/pkg/telemetry/phonehome/interceptor_test.go
+++ b/pkg/telemetry/phonehome/interceptor_test.go
@@ -72,6 +72,7 @@ func (s *interceptorTestSuite) TestAddGrpcInterceptor() {
 	}
 	cfg := &Config{
 		ClientID:  "test",
+		GroupName: "TEST",
 		telemeter: s.mockTelemeter,
 	}
 
@@ -86,7 +87,7 @@ func (s *interceptorTestSuite) TestAddGrpcInterceptor() {
 
 	s.mockTelemeter.EXPECT().Track("TestEvent", map[string]any{
 		"Property": "test value",
-	}, matchOptions(telemeter.WithUserID(cfg.HashUserAuthID(nil)))).Times(1)
+	}, matchOptions(telemeter.WithUserID(cfg.HashUserAuthID(nil)), telemeter.WithGroups("TEST", ""))).Times(1)
 
 	cfg.track(testRP)
 }
@@ -104,6 +105,7 @@ func (s *interceptorTestSuite) TestAddHttpInterceptor() {
 	testRP.HTTPReq = req
 	cfg := &Config{
 		ClientID:  "test",
+		GroupName: "TEST",
 		telemeter: s.mockTelemeter,
 	}
 
@@ -118,7 +120,7 @@ func (s *interceptorTestSuite) TestAddHttpInterceptor() {
 	mockID.EXPECT().UID().Return("id").Times(2)
 	s.mockTelemeter.EXPECT().Track("TestEvent", map[string]any{
 		"Property": "test_value",
-	}, matchOptions(telemeter.WithUserID(cfg.HashUserAuthID(mockID)))).Times(1)
+	}, matchOptions(telemeter.WithUserID(cfg.HashUserAuthID(mockID)), telemeter.WithGroups("TEST", ""))).Times(1)
 
 	cfg.track(testRP)
 }

--- a/pkg/telemetry/phonehome/interceptor_test.go
+++ b/pkg/telemetry/phonehome/interceptor_test.go
@@ -72,7 +72,7 @@ func (s *interceptorTestSuite) TestAddGrpcInterceptor() {
 	}
 	cfg := &Config{
 		ClientID:  "test",
-		GroupName: "TEST",
+		GroupType: "TEST",
 		telemeter: s.mockTelemeter,
 	}
 
@@ -105,7 +105,7 @@ func (s *interceptorTestSuite) TestAddHttpInterceptor() {
 	testRP.HTTPReq = req
 	cfg := &Config{
 		ClientID:  "test",
-		GroupName: "TEST",
+		GroupType: "TEST",
 		telemeter: s.mockTelemeter,
 	}
 

--- a/pkg/telemetry/phonehome/segment/segment.go
+++ b/pkg/telemetry/phonehome/segment/segment.go
@@ -176,7 +176,7 @@ func (t *segmentTelemeter) Group(props map[string]any, opts ...telemeter.Option)
 			continue
 		}
 
-		// Segment doesn't understand group Name. The name must be configured
+		// Segment doesn't understand group Type. The type must be configured
 		// in the Amplitude destination mapping.
 		group.GroupId = ids[0]
 

--- a/pkg/telemetry/phonehome/telemeter.go
+++ b/pkg/telemetry/phonehome/telemeter.go
@@ -11,4 +11,4 @@ var _ telemeter.Telemeter = (*nilTelemeter)(nil)
 func (t *nilTelemeter) Stop()                                                   {}
 func (t *nilTelemeter) Identify(_ map[string]any, _ ...telemeter.Option)        {}
 func (t *nilTelemeter) Track(_ string, _ map[string]any, _ ...telemeter.Option) {}
-func (t *nilTelemeter) Group(_ string, _ map[string]any, _ ...telemeter.Option) {}
+func (t *nilTelemeter) Group(_ map[string]any, _ ...telemeter.Option)           {}

--- a/pkg/telemetry/phonehome/telemeter/mocks/telemeter.go
+++ b/pkg/telemetry/phonehome/telemeter/mocks/telemeter.go
@@ -35,9 +35,9 @@ func (m *MockTelemeter) EXPECT() *MockTelemeterMockRecorder {
 }
 
 // Group mocks base method.
-func (m *MockTelemeter) Group(groupID string, props map[string]any, opts ...telemeter.Option) {
+func (m *MockTelemeter) Group(props map[string]any, opts ...telemeter.Option) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{groupID, props}
+	varargs := []interface{}{props}
 	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
@@ -45,9 +45,9 @@ func (m *MockTelemeter) Group(groupID string, props map[string]any, opts ...tele
 }
 
 // Group indicates an expected call of Group.
-func (mr *MockTelemeterMockRecorder) Group(groupID, props interface{}, opts ...interface{}) *gomock.Call {
+func (mr *MockTelemeterMockRecorder) Group(props interface{}, opts ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{groupID, props}, opts...)
+	varargs := append([]interface{}{props}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Group", reflect.TypeOf((*MockTelemeter)(nil).Group), varargs...)
 }
 

--- a/pkg/telemetry/phonehome/telemeter/telemeter.go
+++ b/pkg/telemetry/phonehome/telemeter/telemeter.go
@@ -7,7 +7,7 @@ type CallOptions struct {
 	ClientID    string
 	ClientType  string
 
-	// [group name: [group id]]
+	// [group type: [group id]]
 	Groups map[string][]string
 }
 
@@ -43,12 +43,12 @@ func WithClient(clientID string, clientType string) Option {
 }
 
 // WithGroups appends the groups for an event.
-func WithGroups(groupName string, groupID string) Option {
+func WithGroups(groupType string, groupID string) Option {
 	return func(o *CallOptions) {
 		if o.Groups == nil {
 			o.Groups = make(map[string][]string, 1)
 		}
-		o.Groups[groupName] = append(o.Groups[groupName], groupID)
+		o.Groups[groupType] = append(o.Groups[groupType], groupID)
 	}
 }
 

--- a/pkg/telemetry/phonehome/telemeter/telemeter.go
+++ b/pkg/telemetry/phonehome/telemeter/telemeter.go
@@ -64,5 +64,6 @@ type Telemeter interface {
 	// Track registers an event, caused by a user.
 	Track(event string, props map[string]any, opts ...Option)
 	// Group adds a user to a group, supplying group specific properties.
-	Group(groupID string, props map[string]any, opts ...Option)
+	// The group must be provided with a WithGroups option.
+	Group(props map[string]any, opts ...Option)
 }


### PR DESCRIPTION
## Description

* added `WithGroups` to all Track calls so that the events are attached to the Tenant;
* made `Group` method read `WithGroups` option for the group ID;
* renamed `groupName` to `groupType` following Amplitude convention, to reduce naming confusion;
* added `groupType` property to the telemetry client configuration;
* modified `Gatherer.Start` method to accept the options for the underlying telemetry calls.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed
