### PR TITLE
ROX-14377 Orphaned PLOP metric.

### DIFF
--- a/central/metrics/central.go
+++ b/central/metrics/central.go
@@ -182,7 +182,7 @@ var (
 	totalOrphanedPLOPCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: metrics.PrometheusNamespace,
 		Subsystem: metrics.CentralSubsystem.String(),
-		Name:      "total_orphaned_plop_counter",
+		Name:      "orphaned_plop_total",
 		Help:      "A counter of the total number of PLOP objects without a reference to a ProcessIndicator",
 	}, []string{"ClusterID"})
 )

--- a/central/metrics/central.go
+++ b/central/metrics/central.go
@@ -178,6 +178,13 @@ var (
 		Name:      "cluster_metrics_cpu_capacity",
 		Help:      "Total Kubernetes cpu capacity of all nodes in a secured cluster",
 	}, []string{"ClusterID"})
+
+	totalOrphanedPLOPCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.CentralSubsystem.String(),
+		Name:      "total_orphaned_plop_counter",
+		Help:      "A counter of the total number of PLOP objects without a reference to a ProcessIndicator",
+	}, []string{"ClusterID"})
 )
 
 func startTimeToMS(t time.Time) float64 {
@@ -292,4 +299,12 @@ func SetClusterMetrics(clusterID string, clusterMetrics *central.ClusterMetrics)
 		Set(float64(clusterMetrics.GetNodeCount()))
 	clusterMetricsCPUCapacityGaugeVec.With(prometheus.Labels{"ClusterID": clusterID}).
 		Set(float64(clusterMetrics.GetCpuCapacity()))
+}
+
+// IncrementOrphanedPLOPCounter increments the counter for orphaned PLOP
+// objects. An orphaned PLOP objects indicates that something is not quite
+// right, e.g. process information is received after the endpoint, or not
+// received at all. This type of situations require investigation.
+func IncrementOrphanedPLOPCounter(clusterID string) {
+	totalOrphanedPLOPCounter.With(prometheus.Labels{"ClusterID": clusterID}).Inc()
 }

--- a/central/metrics/init.go
+++ b/central/metrics/init.go
@@ -33,5 +33,6 @@ func init() {
 		acquireDBConnHistogramVec,
 		clusterMetricsNodeCountGaugeVec,
 		clusterMetricsCPUCapacityGaugeVec,
+		totalOrphanedPLOPCounter,
 	)
 }

--- a/central/processlisteningonport/datastore/datastore_impl.go
+++ b/central/processlisteningonport/datastore/datastore_impl.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/stackrox/rox/central/metrics"
+	countMetrics "github.com/stackrox/rox/central/metrics"
 	processIndicatorStore "github.com/stackrox/rox/central/processindicator/datastore"
 	"github.com/stackrox/rox/central/processlisteningonport/store"
 	"github.com/stackrox/rox/central/role/resources"
@@ -87,7 +88,7 @@ func (ds *datastoreImpl) AddProcessListeningOnPort(
 			indicatorID = indicator.GetId()
 			log.Debugf("Got indicator %s: %+v", indicatorID, indicator)
 		} else {
-			// TODO ROX-14377: Create a metric for this
+			countMetrics.IncrementOrphanedPLOPCounter(val.GetClusterId())
 			log.Warnf("Found no matching indicators for %s", key)
 			processInfo = val.Process
 		}
@@ -138,7 +139,7 @@ func (ds *datastoreImpl) AddProcessListeningOnPort(
 			indicatorID = indicator.GetId()
 			log.Debugf("Got indicator %s: %+v", indicatorID, indicator)
 		} else {
-			// TODO ROX-14377: Create a metric for this
+			countMetrics.IncrementOrphanedPLOPCounter(val.GetClusterId())
 			log.Warnf("Found no matching indicators for %s", key)
 			processInfo = val.Process
 		}


### PR DESCRIPTION
## Description

Add counter to monitor orphaned PLOP objects. A PLOP object not referencing a ProcessIndicator is not a valid situation and has to be monitored.

## Checklist
- [ ] Investigated and inspected CI test results
~- [ ] Unit test and regression tests added~
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

Local testing to make sure the metric is present in the output.