### PR TITLE
Don't crash on query timeouts and add env var to not crash in case of misattributed error code

### DIFF
--- a/pkg/env/postgres_crash_on_error.go
+++ b/pkg/env/postgres_crash_on_error.go
@@ -1,0 +1,6 @@
+package env
+
+var (
+	// PostgresCrashOnError crashes if a retryable error exceeds its retries
+	PostgresCrashOnError = RegisterBooleanSetting("ROX_POSTGRES_CRASH_ON_ERROR", true)
+)

--- a/pkg/postgres/pgutils/error.go
+++ b/pkg/postgres/pgutils/error.go
@@ -12,6 +12,8 @@ import (
 	"github.com/stackrox/rox/pkg/set"
 )
 
+const queryCancelledCode = "57014"
+
 var transientPGCodes = set.NewFrozenStringSet(
 	// Class 08 — Connection Exception
 	"08000", // connection_exception
@@ -46,6 +48,14 @@ var transientPGCodes = set.NewFrozenStringSet(
 	"58000", // system_error
 	"58030", // io_error
 )
+
+// IsQueryTimeoutError specifies if the error is a statement timeout error
+func isQueryTimeoutError(err error) bool {
+	if pgErr := (*pgconn.PgError)(nil); errors.As(err, &pgErr) && pgErr.Code == queryCancelledCode {
+		return true
+	}
+	return false
+}
 
 // IsTransientError specifies if the passed error is transient and should be retried
 func IsTransientError(err error) bool {


### PR DESCRIPTION
## Description

Statement timeouts should not crash Central as they are unlikely to resolve if we just retry them; however, we may have misattributed an error code so adding an env var to protect against that if necessary

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

CI and will try to cause some cases