### PR TITLE
ROX-10744: Add test login to OpenShift auth provider

### DIFF
--- a/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviderForm.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviderForm.tsx
@@ -69,7 +69,12 @@ function getRuleAttributes(type, availableProviderTypes) {
 }
 
 function testModeSupported(provider) {
-    return provider.type === 'auth0' || provider.type === 'oidc' || provider.type === 'saml';
+    return (
+        provider.type === 'auth0' ||
+        provider.type === 'oidc' ||
+        provider.type === 'saml' ||
+        provider.type === 'openshift'
+    );
 }
 
 function AuthProviderForm({


### PR DESCRIPTION
## Description

While answering a question about which specific value to use for a group mapping for OpenShift auth provider (`userid` vs `name`), I realized we currently do not expose the `Test login` functionality for the auth provider.

This is typically useful to test the values received from the IdP and adjust the groups mapping based on that.

Now, the test login has been enabled for the OpenShift auth provider.

## Checklist
- [x] Investigated and inspected CI test results
~~- [ ] Unit test and regression tests added~~
~~- [ ] Evaluated and added CHANGELOG entry if required~~
~~- [ ] Determined and documented upgrade steps~~
~~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

Manual tests (tested with `ocp/stable`, which is `4.12.2`):
- Verified login with OpenShift auth provider still works.
- Verified the test login functionality with the `kube-admin` user works:
![Screenshot 2023-02-17 at 10 22 07](https://user-images.githubusercontent.com/89904305/219605295-2c716ef4-23ea-44ff-85b6-13019fd88dc4.png)
- Verified the test login functionality with a non `kube-admin` user from a different IdP configured in OpenShift auth (i.e. [the HTPasswd IdP](https://docs.openshift.com/container-platform/4.12/authentication/identity_providers/configuring-htpasswd-identity-provider.html)) works:
![Screenshot 2023-02-17 at 10 27 59](https://user-images.githubusercontent.com/89904305/219606023-5af7f2a1-4bf9-44bd-b0a2-17bbc55ecaaf.png)

