### PR TITLE
ROX-15086: Junitify pod log checks

### DIFF
--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -1400,7 +1400,7 @@ save_junit_failure() {
     cat << EOF > "${ARTIFACT_DIR}/junit-${class}.xml"
 <testsuite name="${class}" tests="1" skipped="0" failures="1" errors="0">
     <testcase name="${description}" classname="${class}">
-        <failure>${details}</failure>
+        <failure><![CDATA[${details}]]></failure>
     </testcase>
 </testsuite>
 EOF

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -1374,8 +1374,10 @@ save_junit_success() {
 
     local class="$1"
     local description="$2"
+    local timestamp
+    timestamp="$(date -u +"%s.%N")"
 
-    cat << EOF > "${ARTIFACT_DIR}/junit-${class}.xml"
+    cat << EOF > "${ARTIFACT_DIR}/junit-${class}-${timestamp}.xml"
 <testsuite name="${class}" tests="1" skipped="0" failures="0" errors="0">
     <testcase name="${description}" classname="${class}">
     </testcase>
@@ -1396,8 +1398,10 @@ save_junit_failure() {
     local class="$1"
     local description="$2"
     local details="$3"
+    local timestamp
+    timestamp="$(date -u +"%s.%N")"
 
-    cat << EOF > "${ARTIFACT_DIR}/junit-${class}.xml"
+    cat << EOF > "${ARTIFACT_DIR}/junit-${class}-${timestamp}.xml"
 <testsuite name="${class}" tests="1" skipped="0" failures="1" errors="0">
     <testcase name="${description}" classname="${class}">
         <failure><![CDATA[${details}]]></failure>

--- a/scripts/ci/logcheck/blocklist-patterns
+++ b/scripts/ci/logcheck/blocklist-patterns
@@ -4,6 +4,7 @@
 # Lines starting with a `#` as well as blank lines are ignored, but a `#` in the middle of a line is matched as-is.
 # If you want to match on a pattern starting with `#`, write `\#`.
 
+stackrox
 unexpected(?! EOF)
 panic
 fatal

--- a/scripts/ci/logcheck/blocklist-patterns
+++ b/scripts/ci/logcheck/blocklist-patterns
@@ -4,7 +4,6 @@
 # Lines starting with a `#` as well as blank lines are ignored, but a `#` in the middle of a line is matched as-is.
 # If you want to match on a pattern starting with `#`, write `\#`.
 
-stackrox
 unexpected(?! EOF)
 panic
 fatal

--- a/scripts/ci/logcheck/check.sh
+++ b/scripts/ci/logcheck/check.sh
@@ -20,6 +20,6 @@ IFS=$'\n' read -d '' -r -a allowlist_subpatterns < <(egrep -v '^(#.*|\s*)$' "${A
 
 allowlist_pattern="$(join_by '|' "${allowlist_subpatterns[@]}")"
 
-grep -vP "$allowlist_pattern" "$@" | grep >&2 -Pni "$blocklist_pattern" && exit 1
+grep -vP "$allowlist_pattern" "$@" | grep -Pni "$blocklist_pattern" && exit 1
 
 exit 0

--- a/tests/e2e/bats/check_for_stackrox_OOMs.bats
+++ b/tests/e2e/bats/check_for_stackrox_OOMs.bats
@@ -14,12 +14,12 @@ function setup() {
 
     run check_for_stackrox_OOMs "${BATS_TEST_TMPDIR}/oom-test"
 
-    with_oomkilled_test="${ARTIFACT_DIR}/junit-OOMCheck-central-84bf956f94-bg6hr.xml"
+    with_oomkilled_test="$(ls ${ARTIFACT_DIR}/junit-OOMCheck-central-84bf956f94-bg6hr-*.xml)"
     assert [ -f "$with_oomkilled_test" ]
     run grep -q "was OOMKilled" "$with_oomkilled_test"
     assert_success
 
-    without_oomkilled_test="${ARTIFACT_DIR}/junit-OOMCheck-sensor-67d98c67bf-v688m.xml"
+    without_oomkilled_test="$(ls ${ARTIFACT_DIR}/junit-OOMCheck-sensor-67d98c67bf-v688m-*.xml)"
     assert [ -f "$without_oomkilled_test" ]
     run grep -q "was not OOMKilled" "$without_oomkilled_test"
     assert_success

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -458,6 +458,8 @@ check_for_errors_in_stackrox_logs() {
         # shellcheck disable=SC2086
         if ! check_out="$(scripts/ci/logcheck/check.sh $filtered)"; then
             save_junit_failure "SuspiciousLog" "Suspicious entries in log file(s)" "$check_out"
+            sleep 1
+            save_junit_failure "SuspiciousLog" "Suspicious entries in log file(s)" "$check_out"
             die "ERROR: Found at least one suspicious log file entry."
         else
             save_junit_success "SuspiciousLog" "Suspicious entries in log file(s)"

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -454,9 +454,13 @@ check_for_errors_in_stackrox_logs() {
     # shellcheck disable=SC2010,SC2086
     filtered=$(ls $logs | grep -Ev "(previous|_describe).log$" || true)
     if [[ -n "$filtered" ]]; then
+        local check_out=""
         # shellcheck disable=SC2086
-        if ! scripts/ci/logcheck/check.sh $filtered; then
+        if ! check_out="$(scripts/ci/logcheck/check.sh $filtered)"; then
+            save_junit_failure "SuspiciousLog" "Suspicious entries in log file(s)" "$check_out"
             die "ERROR: Found at least one suspicious log file entry."
+        else
+            save_junit_success "SuspiciousLog" "Suspicious entries in log file(s)"
         fi
     fi
 }

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -458,8 +458,6 @@ check_for_errors_in_stackrox_logs() {
         # shellcheck disable=SC2086
         if ! check_out="$(scripts/ci/logcheck/check.sh $filtered)"; then
             save_junit_failure "SuspiciousLog" "Suspicious entries in log file(s)" "$check_out"
-            sleep 1
-            save_junit_failure "SuspiciousLog" "Suspicious entries in log file(s)" "$check_out"
             die "ERROR: Found at least one suspicious log file entry."
         else
             save_junit_success "SuspiciousLog" "Suspicious entries in log file(s)"


### PR DESCRIPTION
## Description

Failures from the script that checks pod logs for suspicious entries are hidden in CI output. This PR creates a JUnit record for them.

## Checklist
- [x] Investigated and inspected CI test results
  - how it looks now (testing with a check for stackrox in logs :raised_eyebrow:): https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/stackrox_stackrox/4917/pull-ci-stackrox-stackrox-master-gke-nongroovy-e2e-tests/1626659698134487040
 
## Testing Performed

CI is sufficient