### PR TITLE
ROX-15061: Enable retry on grpc client

### DIFF
--- a/qa-tests-backend/src/main/groovy/services/BaseService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/BaseService.groovy
@@ -121,6 +121,7 @@ class BaseService {
 
             transportChannel = NettyChannelBuilder
                     .forAddress(Env.mustGetHostname(), Env.mustGetPort())
+                    .enableRetry()
                     .negotiationType(NegotiationType.TLS)
                     .sslContext(sslContext)
                     .build()


### PR DESCRIPTION
## Description

To prevent QA test failures due to network errors (like below), enable retries.
 > io.grpc.StatusRuntimeException: UNAVAILABLE: Network closed for unknown reason

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

CI