### PR TITLE
ROX-15164: Reconciliation loop for declarative configuration

### DIFF
--- a/central/declarativeconfig/manager.go
+++ b/central/declarativeconfig/manager.go
@@ -2,5 +2,5 @@ package declarativeconfig
 
 // Manager manages reconciling declarative configuration.
 type Manager interface {
-	WatchDeclarativeConfigDir()
+	ReconcileDeclarativeConfigurations()
 }

--- a/central/declarativeconfig/manager_impl.go
+++ b/central/declarativeconfig/manager_impl.go
@@ -8,39 +8,51 @@ import (
 	"time"
 
 	"github.com/gogo/protobuf/proto"
+	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/declarativeconfig"
 	"github.com/stackrox/rox/pkg/declarativeconfig/transform"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/k8scfgwatch"
+	"github.com/stackrox/rox/pkg/maputil"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/pkg/utils"
 )
 
 const (
-	watchInterval        = 5 * time.Second
 	declarativeConfigDir = "/run/stackrox.io/declarative-configuration"
 )
 
-var (
-	// Set Force to true, so we explicitly retry watching the files within the directory and not stop on the first
-	// error occurred.
-	watchOpts = k8scfgwatch.Options{Interval: watchInterval, Force: true}
-)
+type protoMessagesByType = map[reflect.Type][]proto.Message
 
 type managerImpl struct {
-	once                 sync.Once
+	once sync.Once
+
 	universalTransformer transform.Transformer
+
+	transformedMessagesByHandler map[string]protoMessagesByType
+	transformedMessagesMutex     sync.RWMutex
+
+	reconciliationTickerDuration time.Duration
+	watchIntervalDuration        time.Duration
+
+	reconciliationTicker     *time.Ticker
+	reconciliationInProgress concurrency.Flag
+	shortCircuitSignal       concurrency.Signal
 }
 
 // New creates a new instance of Manager.
 // Note that it will not watch the declarative configuration directories when created, only after
-// WatchDeclarativeConfigDir has been called.
+// ReconcileDeclarativeConfigurations has been called.
 func New() Manager {
 	return &managerImpl{
-		universalTransformer: transform.New(),
+		universalTransformer:         transform.New(),
+		transformedMessagesByHandler: map[string]protoMessagesByType{},
+		reconciliationTickerDuration: env.DeclarativeConfigReconcileInterval.DurationSetting(),
+		watchIntervalDuration:        env.DeclarativeConfigWatchInterval.DurationSetting(),
 	}
 }
 
-func (m *managerImpl) WatchDeclarativeConfigDir() {
+func (m *managerImpl) ReconcileDeclarativeConfigurations() {
 	m.once.Do(func() {
 		// For each directory within the declarative configuration path, create a watch handler.
 		// The reason we need multiple watch handlers and cannot simply watch the root directory is that
@@ -54,23 +66,33 @@ func (m *managerImpl) WatchDeclarativeConfigDir() {
 			utils.Should(err)
 			return
 		}
+
+		var startedWatchHandler bool
 		for _, entry := range entries {
 			if !entry.IsDir() {
 				continue
 			}
 			log.Infof("Start watch handler for declarative configuration for path %s",
 				path.Join(declarativeConfigDir, entry.Name()))
-			wh := newWatchHandler(m)
+			wh := newWatchHandler(entry.Name(), m)
+			// Set Force to true, so we explicitly retry watching the files within the directory and not stop on the first
+			// error occurred.
+			watchOpts := k8scfgwatch.Options{Interval: m.watchIntervalDuration, Force: true}
 			_ = k8scfgwatch.WatchConfigMountDir(context.Background(), declarativeConfigDir,
 				k8scfgwatch.DeduplicateWatchErrors(wh), watchOpts)
+			startedWatchHandler = true
+		}
+
+		// Only start the reconciliation loop if at least one watch handler has been started.
+		if startedWatchHandler {
+			log.Info("Start the reconciliation loop for declarative configurations")
+			m.startReconciliationLoop()
 		}
 	})
 }
 
-// ReconcileDeclarativeConfigs will take the file contents and transform these to declarative configurations.
-// TODO(ROX-14693): Add upserting transformed resources.
-// TODO(ROX-14694): Add deletion of resources.
-func (m *managerImpl) ReconcileDeclarativeConfigs(contents [][]byte) {
+// UpdateDeclarativeConfigContents will take the file contents and transform these to declarative configurations.
+func (m *managerImpl) UpdateDeclarativeConfigContents(handlerID string, contents [][]byte) {
 	configurations, err := declarativeconfig.ConfigurationFromRawBytes(contents...)
 	if err != nil {
 		log.Errorf("Error during unmarshalling of declarative configuration files: %+v", err)
@@ -87,5 +109,64 @@ func (m *managerImpl) ReconcileDeclarativeConfigs(contents [][]byte) {
 			transformedConfigurations[protoType] = append(transformedConfigurations[protoType], protoMessages...)
 		}
 	}
-	// No-op, see the TODOs within the function comment.
+
+	m.transformedMessagesMutex.Lock()
+	defer m.transformedMessagesMutex.Unlock()
+	m.transformedMessagesByHandler[handlerID] = transformedConfigurations
+	m.shortCircuitReconciliationLoop()
+}
+
+// shortCircuitReconciliationLoop will short circuit the reconciliation loop and trigger a reconciliation loop run.
+// Note that the reconciliation loop will not be run if:
+//   - the short circuit loop signal has not been reset yet and is de-duped.
+//   - a current reconciliation loop run is in progress.
+func (m *managerImpl) shortCircuitReconciliationLoop() {
+	// In case the signal is already triggered, the current call (and the Signal() call) will be effectively de-duped.
+	m.shortCircuitSignal.Signal()
+}
+
+func (m *managerImpl) startReconciliationLoop() {
+	m.reconciliationTicker = time.NewTicker(m.reconciliationTickerDuration)
+
+	go m.reconciliationLoop()
+}
+
+func (m *managerImpl) reconciliationLoop() {
+	// While we currently do not have an exist in the form of "stopping" the reconciliation, still, ensure that
+	// the ticker is stopped when we stop running the reconciliation.
+	defer m.reconciliationTicker.Stop()
+	for {
+		select {
+		case <-m.shortCircuitSignal.Done():
+			m.shortCircuitSignal.Reset()
+			m.runReconciliation()
+		case <-m.reconciliationTicker.C:
+			m.runReconciliation()
+		}
+	}
+}
+
+func (m *managerImpl) runReconciliation() {
+	// We shouldn't trigger a parallel reconciliation run, hence we should ensure that the flag is not set to true.
+	if m.reconciliationInProgress.TestAndSet(true) {
+		return
+	}
+	defer m.reconciliationInProgress.Set(false)
+	m.transformedMessagesMutex.RLock()
+	transformedMessagesByHandler := maputil.ShallowClone(m.transformedMessagesByHandler)
+	m.transformedMessagesMutex.RUnlock()
+	m.reconcileTransformedMessages(transformedMessagesByHandler)
+}
+
+func (m *managerImpl) reconcileTransformedMessages(transformedMessagesByHandler map[string]protoMessagesByType) {
+	for handler, protoMessagesByType := range transformedMessagesByHandler {
+		for protoType, protoMessages := range protoMessagesByType {
+			// TODO(ROX-14693): Add upserting transformed resources.
+			log.Debugf("Upserting transformed messages of type %s from file %s: %+v",
+				protoType.Name(), handler, protoMessages)
+		}
+	}
+	// TODO(ROX-14694): Add deletion of resources.
+	log.Debugf("Deleting all proto messages that have traits.Origin==DECLARATIVE but are not contained"+
+		" within the current list of transformed messages: %+v", transformedMessagesByHandler)
 }

--- a/central/declarativeconfig/mocks/watch_handler.go
+++ b/central/declarativeconfig/mocks/watch_handler.go
@@ -10,37 +10,37 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
-// MockdeclarativeConfigReconciler is a mock of declarativeConfigReconciler interface.
-type MockdeclarativeConfigReconciler struct {
+// MockdeclarativeConfigContentUpdater is a mock of declarativeConfigContentUpdater interface.
+type MockdeclarativeConfigContentUpdater struct {
 	ctrl     *gomock.Controller
-	recorder *MockdeclarativeConfigReconcilerMockRecorder
+	recorder *MockdeclarativeConfigContentUpdaterMockRecorder
 }
 
-// MockdeclarativeConfigReconcilerMockRecorder is the mock recorder for MockdeclarativeConfigReconciler.
-type MockdeclarativeConfigReconcilerMockRecorder struct {
-	mock *MockdeclarativeConfigReconciler
+// MockdeclarativeConfigContentUpdaterMockRecorder is the mock recorder for MockdeclarativeConfigContentUpdater.
+type MockdeclarativeConfigContentUpdaterMockRecorder struct {
+	mock *MockdeclarativeConfigContentUpdater
 }
 
-// NewMockdeclarativeConfigReconciler creates a new mock instance.
-func NewMockdeclarativeConfigReconciler(ctrl *gomock.Controller) *MockdeclarativeConfigReconciler {
-	mock := &MockdeclarativeConfigReconciler{ctrl: ctrl}
-	mock.recorder = &MockdeclarativeConfigReconcilerMockRecorder{mock}
+// NewMockdeclarativeConfigContentUpdater creates a new mock instance.
+func NewMockdeclarativeConfigContentUpdater(ctrl *gomock.Controller) *MockdeclarativeConfigContentUpdater {
+	mock := &MockdeclarativeConfigContentUpdater{ctrl: ctrl}
+	mock.recorder = &MockdeclarativeConfigContentUpdaterMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockdeclarativeConfigReconciler) EXPECT() *MockdeclarativeConfigReconcilerMockRecorder {
+func (m *MockdeclarativeConfigContentUpdater) EXPECT() *MockdeclarativeConfigContentUpdaterMockRecorder {
 	return m.recorder
 }
 
-// ReconcileDeclarativeConfigs mocks base method.
-func (m *MockdeclarativeConfigReconciler) ReconcileDeclarativeConfigs(fileContents [][]byte) {
+// UpdateDeclarativeConfigContents mocks base method.
+func (m *MockdeclarativeConfigContentUpdater) UpdateDeclarativeConfigContents(id string, fileContents [][]byte) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "ReconcileDeclarativeConfigs", fileContents)
+	m.ctrl.Call(m, "UpdateDeclarativeConfigContents", id, fileContents)
 }
 
-// ReconcileDeclarativeConfigs indicates an expected call of ReconcileDeclarativeConfigs.
-func (mr *MockdeclarativeConfigReconcilerMockRecorder) ReconcileDeclarativeConfigs(fileContents interface{}) *gomock.Call {
+// UpdateDeclarativeConfigContents indicates an expected call of UpdateDeclarativeConfigContents.
+func (mr *MockdeclarativeConfigContentUpdaterMockRecorder) UpdateDeclarativeConfigContents(id, fileContents interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReconcileDeclarativeConfigs", reflect.TypeOf((*MockdeclarativeConfigReconciler)(nil).ReconcileDeclarativeConfigs), fileContents)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDeclarativeConfigContents", reflect.TypeOf((*MockdeclarativeConfigContentUpdater)(nil).UpdateDeclarativeConfigContents), id, fileContents)
 }

--- a/central/declarativeconfig/singleton.go
+++ b/central/declarativeconfig/singleton.go
@@ -1,6 +1,9 @@
 package declarativeconfig
 
-import "github.com/stackrox/rox/pkg/sync"
+import (
+	"github.com/stackrox/rox/pkg/env"
+	"github.com/stackrox/rox/pkg/sync"
+)
 
 var (
 	once     sync.Once
@@ -10,7 +13,7 @@ var (
 // ManagerSingleton provides the instance of Manager to use.
 func ManagerSingleton() Manager {
 	once.Do(func() {
-		instance = New()
+		instance = New(env.DeclarativeConfigReconcileInterval.DurationSetting(), env.DeclarativeConfigWatchInterval.DurationSetting())
 	})
 	return instance
 }

--- a/central/declarativeconfig/watch_handler_test.go
+++ b/central/declarativeconfig/watch_handler_test.go
@@ -122,9 +122,9 @@ func TestWatchHandler_CheckForDeletedFiles(t *testing.T) {
 
 func TestWatchHandler_WithEmptyDirectory(t *testing.T) {
 	// 0. Create a watch handler with a lower interval.
-	updaterMock := mocks.NewMockdeclarativeConfigReconciler(gomock.NewController(t))
+	updaterMock := mocks.NewMockdeclarativeConfigContentUpdater(gomock.NewController(t))
 
-	wh := newWatchHandler(updaterMock)
+	wh := newWatchHandler("empty-directory", updaterMock)
 	opts := k8scfgwatch.Options{
 		Interval: 10 * time.Millisecond,
 	}
@@ -146,7 +146,7 @@ func TestWatchHandler_WithEmptyDirectory(t *testing.T) {
 	require.NoError(t, err)
 
 	// 2.1 Set the expected calls to the updater.
-	updaterMock.EXPECT().ReconcileDeclarativeConfigs([][]byte{yamlBytes})
+	updaterMock.EXPECT().UpdateDeclarativeConfigContents("empty-directory", [][]byte{yamlBytes})
 
 	filePath := path.Join(dirToWatch, "role")
 	f, err := os.Create(filePath)
@@ -169,9 +169,9 @@ func TestWatchHandler_WithEmptyDirectory(t *testing.T) {
 
 func TestWatchHandler_WithPrefilledDirectory(t *testing.T) {
 	// 0. Create a watch handler with a lower interval.
-	updaterMock := mocks.NewMockdeclarativeConfigReconciler(gomock.NewController(t))
+	updaterMock := mocks.NewMockdeclarativeConfigContentUpdater(gomock.NewController(t))
 
-	wh := newWatchHandler(updaterMock)
+	wh := newWatchHandler("prefilled-directory", updaterMock)
 	opts := k8scfgwatch.Options{
 		Interval: 10 * time.Millisecond,
 	}
@@ -189,7 +189,7 @@ func TestWatchHandler_WithPrefilledDirectory(t *testing.T) {
 	require.NoError(t, err)
 
 	// 1.1 Set the expected calls to the updater.
-	updaterMock.EXPECT().ReconcileDeclarativeConfigs([][]byte{roleBytes})
+	updaterMock.EXPECT().UpdateDeclarativeConfigContents("prefilled-directory", [][]byte{roleBytes})
 
 	rolePath := path.Join(dirToWatch, "role")
 	roleF, err := os.Create(rolePath)
@@ -224,7 +224,10 @@ func TestWatchHandler_WithPrefilledDirectory(t *testing.T) {
 	require.NoError(t, err)
 
 	// 4.1 Set the expected calls to the updater.
-	updaterMock.EXPECT().ReconcileDeclarativeConfigs(gomock.InAnyOrder([][]byte{permissionSetBytes, roleBytes}))
+	updaterMock.EXPECT().UpdateDeclarativeConfigContents(
+		"prefilled-directory",
+		gomock.InAnyOrder([][]byte{permissionSetBytes, roleBytes}),
+	)
 
 	permissionSetPath := path.Join(dirToWatch, "permission-set")
 	permissionSetF, err := os.Create(permissionSetPath)
@@ -248,9 +251,9 @@ func TestWatchHandler_WithPrefilledDirectory(t *testing.T) {
 
 func TestWatchHandler_WithRemovedFiles(t *testing.T) {
 	// 0. Create a watch handler with a lower interval.
-	updaterMock := mocks.NewMockdeclarativeConfigReconciler(gomock.NewController(t))
+	updaterMock := mocks.NewMockdeclarativeConfigContentUpdater(gomock.NewController(t))
 
-	wh := newWatchHandler(updaterMock)
+	wh := newWatchHandler("removed-files", updaterMock)
 	opts := k8scfgwatch.Options{
 		Interval: 10 * time.Millisecond,
 	}
@@ -272,7 +275,7 @@ func TestWatchHandler_WithRemovedFiles(t *testing.T) {
 	require.NoError(t, err)
 
 	// 2.1 Set the expected calls to the updater.
-	updaterMock.EXPECT().ReconcileDeclarativeConfigs([][]byte{yamlBytes})
+	updaterMock.EXPECT().UpdateDeclarativeConfigContents("removed-files", [][]byte{yamlBytes})
 
 	filePath := path.Join(dirToWatch, "role")
 	f, err := os.Create(filePath)
@@ -293,7 +296,7 @@ func TestWatchHandler_WithRemovedFiles(t *testing.T) {
 	}, 100*time.Millisecond, 10*time.Millisecond)
 
 	// 4.Set the expected calls to the updater.
-	updaterMock.EXPECT().ReconcileDeclarativeConfigs([][]byte{})
+	updaterMock.EXPECT().UpdateDeclarativeConfigContents("removed-files", [][]byte{})
 
 	// 5. Remove the previously added YAML file.
 	err = os.Remove(filePath)

--- a/central/main.go
+++ b/central/main.go
@@ -482,7 +482,7 @@ func startGRPCServer() {
 	basicAuthProvider := userpass.RegisterAuthProviderOrPanic(authProviderRegisteringCtx, basicAuthMgr, registry)
 
 	if features.DeclarativeConfiguration.Enabled() {
-		declarativeconfig.ManagerSingleton().WatchDeclarativeConfigDir()
+		declarativeconfig.ManagerSingleton().ReconcileDeclarativeConfigurations()
 	}
 
 	clusterInitBackend := backend.Singleton()

--- a/pkg/env/declarative_config.go
+++ b/pkg/env/declarative_config.go
@@ -1,0 +1,11 @@
+package env
+
+import "time"
+
+var (
+	// DeclarativeConfigWatchInterval will set the duration for when to check for changes in declarative configuration
+	// watch handlers.
+	DeclarativeConfigWatchInterval = registerDurationSetting("ROX_DECLARATIVE_CONFIG_WATCH_INTERVAL", 5*time.Second)
+	// DeclarativeConfigReconcileInterval will set the duration for when to reconcile declarative configurations.
+	DeclarativeConfigReconcileInterval = registerDurationSetting("ROX_DECLARATIVE_CONFIG_RECONCILE_INTERVAL", time.Minute)
+)


### PR DESCRIPTION
## Description

This PR adds the reconciliation loop for declarative configurations.

After the contents of the declarative configuration mounts will be watched by multiple watch handlers (introduced within [ROX-14147](https://issues.redhat.com/browse/ROX-14147), the next step is to start with the reconciliation of the transformed proto messages.

This includes the following:
- Creating a "complete" view of all transformed proto messages, keyed by their respective watch handler directory.
- Creating a loop that will continously iterate over the transformed proto messages and allow for upserting proto messages as well as deleting proto messages.

Besides these two points, the following was done as well:
- Instead of specifying the watch handler intervals as well as the reconciliation loop interval as `const`s, exposed environment variables for these two settings for further customization if required in some environments.
- The reconciliation loop includes a short-circuit functionality, bypassing the reconciliation loop interval to trigger the reconciliation when changes are reported by the watch handlers.

As follow-ups, the following will be required:
- Handle the upsertion of proto messages within the reconciliation step, covered by [ROX-14693](https://issues.redhat.com/browse/ROX-14693).
- Handle the deletion of proto messages within the reconciliation step, covered by [ROX-14694](https://issues.redhat.com/browse/ROX-14694).

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
