### PR TITLE
Jv plop e2e test only for gke postgres qa e2e tests

### DIFF
--- a/qa-tests-backend/src/test/groovy/ProcessesListeningOnPortsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ProcessesListeningOnPortsTest.groovy
@@ -13,7 +13,8 @@ import spock.lang.Stepwise
 import services.ProcessesListeningOnPortsService
 
 @Stepwise
-@IgnoreIf({ !Env.get("ROX_POSTGRES_DATASTORE", null) })
+// TODO: Solve the flake and change back to @IgnoreIf({ !Env.get("ROX_POSTGRES_DATASTORE", null) })
+@IgnoreIf({ !Env.CI_JOBNAME.contains("postgres") })
 class ProcessesListeningOnPortsTest extends BaseSpecification {
 
     // Deployment names


### PR DESCRIPTION
## Description

The processes listening on ports test should only run for gke-postgres-qa-e2e-tests

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient.