### PR TITLE
ROX-14521: Log user identities which successfully logged in

### DIFF
--- a/central/authprovider/service/service_impl.go
+++ b/central/authprovider/service/service_impl.go
@@ -322,6 +322,9 @@ func (s *serviceImpl) ExchangeToken(ctx context.Context, request *v1.ExchangeTok
 
 	userMetadata, err := authproviders.CreateRoleBasedIdentity(sac.WithAllAccess(ctx), provider, authResponse)
 	if err != nil {
+		if testMode {
+			return nil, errors.Wrap(err, "cannot create role based identity")
+		}
 		log.Warnf("error creating role based identity: %v", err)
 	}
 	userPkg.LogSuccessfulUserLogin(log, userMetadata)

--- a/central/authprovider/service/service_impl.go
+++ b/central/authprovider/service/service_impl.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stackrox/rox/pkg/auth/authproviders/basic"
 	"github.com/stackrox/rox/pkg/auth/authproviders/idputil"
 	"github.com/stackrox/rox/pkg/auth/permissions"
+	userPkg "github.com/stackrox/rox/pkg/auth/user"
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/grpc/authz"
 	"github.com/stackrox/rox/pkg/grpc/authz/allow"
@@ -319,12 +320,13 @@ func (s *serviceImpl) ExchangeToken(ctx context.Context, request *v1.ExchangeTok
 		Test:        testMode,
 	}
 
+	userMetadata, err := authproviders.CreateRoleBasedIdentity(sac.WithAllAccess(ctx), provider, authResponse)
+	if err != nil {
+		log.Warnf("error creating role based identity: %v", err)
+	}
+	userPkg.LogSuccessfulUserLogin(log, userMetadata)
+
 	if testMode {
-		// We need all access for retrieving roles.
-		userMetadata, err := authproviders.CreateRoleBasedIdentity(sac.WithAllAccess(ctx), provider, authResponse)
-		if err != nil {
-			return nil, errors.Wrap(err, "cannot create role based identity")
-		}
 		response.User = userMetadata
 		return response, nil
 	}

--- a/central/authprovider/service/service_impl.go
+++ b/central/authprovider/service/service_impl.go
@@ -325,7 +325,7 @@ func (s *serviceImpl) ExchangeToken(ctx context.Context, request *v1.ExchangeTok
 		if testMode {
 			return nil, errors.Wrap(err, "cannot create role based identity")
 		}
-		log.Warnf("error creating role based identity: %v", err)
+		log.Warnf("Error creating role based identity: %v", err)
 	}
 	userPkg.LogSuccessfulUserLogin(log, userMetadata)
 

--- a/pkg/auth/authproviders/registry_httphandler.go
+++ b/pkg/auth/authproviders/registry_httphandler.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stackrox/rox/pkg/auth"
 	"github.com/stackrox/rox/pkg/auth/authproviders/idputil"
 	"github.com/stackrox/rox/pkg/auth/tokens"
+	userPkg "github.com/stackrox/rox/pkg/auth/user"
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/grpc/requestinfo"
 	"github.com/stackrox/rox/pkg/httputil"
@@ -307,6 +308,8 @@ func (r *registryImpl) providersHTTPHandler(w http.ResponseWriter, req *http.Req
 		r.error(w, err, typ, clientState, testMode)
 		return
 	}
+
+	userPkg.LogSuccessfulUserLogin(log, user)
 
 	if tokenInfo == nil {
 		// Assume the ProcessHTTPRequest already took care of writing a response.

--- a/pkg/auth/permissions/utils/role.go
+++ b/pkg/auth/permissions/utils/role.go
@@ -82,6 +82,15 @@ func RoleNames(roles []permissions.ResolvedRole) []string {
 	return names
 }
 
+// RoleNamesFromUserInfo converts each UserInfo_Role to role name.
+func RoleNamesFromUserInfo(roles []*storage.UserInfo_Role) []string {
+	names := make([]string, 0, len(roles))
+	for _, role := range roles {
+		names = append(names, role.GetName())
+	}
+	return names
+}
+
 // ExtractRolesForUserInfo converts each ResolvedRole to *storage.Role.
 func ExtractRolesForUserInfo(roles []permissions.ResolvedRole) []*storage.UserInfo_Role {
 	result := make([]*storage.UserInfo_Role, 0, len(roles))

--- a/pkg/auth/user/util.go
+++ b/pkg/auth/user/util.go
@@ -41,10 +41,9 @@ func protoToJSON(log *logging.Logger, message proto.Message) string {
 	result, err := jsonutil.ProtoToJSON(message, jsonutil.OptCompact, jsonutil.OptUnEscape)
 	if err != nil {
 		log.Error("Failed to convert proto to JSON: ", err)
-	} else {
-		return result
+		return ""
 	}
-	return ""
+	return result
 }
 
 // LogSuccessfulUserLogin logs user attributes in the specified logger instance.
@@ -55,7 +54,7 @@ func LogSuccessfulUserLogin(log *logging.Logger, user *v1.AuthStatus) {
 		serviceIdStr = protoToJSON(log, user.GetServiceId())
 	}
 	if user.GetUserInfo().GetPermissions() != nil {
-		permissionsStr = protoToJSON(log, user.GetServiceId())
+		permissionsStr = protoToJSON(log, user.GetUserInfo().GetPermissions())
 	}
 	log.Warnw("User successfully logged in with user attributes",
 		zap.String("userID", user.GetUserId()),

--- a/pkg/auth/user/util.go
+++ b/pkg/auth/user/util.go
@@ -4,6 +4,8 @@ import (
 	"sort"
 
 	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/pkg/jsonutil"
+	"github.com/stackrox/rox/pkg/logging"
 )
 
 // ConvertAttributes converts a map of user attributes to v1.UserAttribute
@@ -24,4 +26,15 @@ func ConvertAttributes(attrMap map[string][]string) []*v1.UserAttribute {
 		return result[i].Key < result[j].Key
 	})
 	return result
+}
+
+// LogSuccessfulUserLogin logs user attributes in the specified logger instance.
+func LogSuccessfulUserLogin(log *logging.Logger, user *v1.AuthStatus) {
+	loggableUser := user.Clone()
+	// Auth provider config can contain sensitive data(client secret, certificates etc.) so it shouldn't be logged.
+	if loggableUser != nil {
+		loggableUser.AuthProvider = nil
+	}
+	userJSON, _ := jsonutil.ProtoToJSON(loggableUser)
+	log.Warnf("User successfully logged in with user attributes: %s", userJSON)
 }

--- a/pkg/auth/user/util.go
+++ b/pkg/auth/user/util.go
@@ -34,7 +34,7 @@ func ConvertAttributes(attrMap map[string][]string) []*v1.UserAttribute {
 }
 
 type loggableAuthProvider struct {
-	Id   string
+	ID   string
 	Name string
 	Type string
 }
@@ -57,24 +57,24 @@ func LogSuccessfulUserLogin(log *logging.Logger, user *v1.AuthStatus) {
 // is because log.Warnw accepts ...interface{} and []zap.Field does not convert automatically
 // to []interface{}.
 func extractUserLogFields(user *v1.AuthStatus) []interface{} {
-	serviceIdStr := ""
+	serviceIDStr := ""
 	permissionsStr := ""
 	if user.GetServiceId() != nil {
-		serviceIdStr = protoToJSON(user.GetServiceId())
+		serviceIDStr = protoToJSON(user.GetServiceId())
 	}
 	if user.GetUserInfo().GetPermissions() != nil {
 		permissionsStr = protoToJSON(user.GetUserInfo().GetPermissions())
 	}
 	return []interface{}{
 		zap.String("userID", user.GetUserId()),
-		zap.String("serviceID", serviceIdStr),
+		zap.String("serviceID", serviceIDStr),
 		zap.Any("expires", user.GetExpires()),
 		zap.String("username", user.GetUserInfo().GetUsername()),
 		zap.String("friendlyName", user.GetUserInfo().GetFriendlyName()),
 		zap.Any("roleNames", utils.RoleNamesFromUserInfo(user.GetUserInfo().GetRoles())),
 		zap.String("permissions", permissionsStr),
 		zap.Any("authProvider", &loggableAuthProvider{
-			Id:   user.GetAuthProvider().GetId(),
+			ID:   user.GetAuthProvider().GetId(),
 			Type: user.GetAuthProvider().GetType(),
 			Name: user.GetAuthProvider().GetName(),
 		}),

--- a/pkg/auth/user/util.go
+++ b/pkg/auth/user/util.go
@@ -53,6 +53,9 @@ func LogSuccessfulUserLogin(log *logging.Logger, user *v1.AuthStatus) {
 	log.Warnw("User successfully logged in with user attributes", extractUserLogFields(user)...)
 }
 
+// The reason this function returns []interface{} instead of []zap.Field
+// is because log.Warnw accepts ...interface{} and []zap.Field does not convert automatically
+// to []interface{}.
 func extractUserLogFields(user *v1.AuthStatus) []interface{} {
 	serviceIdStr := ""
 	permissionsStr := ""

--- a/pkg/auth/user/util_test.go
+++ b/pkg/auth/user/util_test.go
@@ -52,7 +52,7 @@ func TestExtractUserLogFields_MainFieldsTransformed(t *testing.T) {
 	assert.True(t, fields[5].(zap.Field).Equals(zap.Any("roleNames", []string{"Admin", "Analyst"})))
 	assert.True(t, fields[6].(zap.Field).Equals(zap.String("permissions", "{\"resourceToAccess\":{\"Close Magic Doors\":\"READ_ACCESS\",\"Open Magic Doors\":\"READ_WRITE_ACCESS\"}}")))
 	assert.True(t, fields[7].(zap.Field).Equals(zap.Any("authProvider", &loggableAuthProvider{
-		Id:   user.GetAuthProvider().GetId(),
+		ID:   user.GetAuthProvider().GetId(),
 		Name: user.GetAuthProvider().GetName(),
 		Type: user.GetAuthProvider().GetType(),
 	})))
@@ -80,7 +80,7 @@ func TestExtractUserLogFields_ServiceIdTransformed(t *testing.T) {
 	assert.True(t, fields[5].(zap.Field).Equals(zap.Any("roleNames", []string{})))
 	assert.True(t, fields[6].(zap.Field).Equals(zap.String("permissions", "")))
 	assert.True(t, fields[7].(zap.Field).Equals(zap.Any("authProvider", &loggableAuthProvider{
-		Id:   "",
+		ID:   "",
 		Name: "",
 		Type: "",
 	})))
@@ -100,7 +100,7 @@ func TestExtractUserLogFields_NilTransformed(t *testing.T) {
 	assert.True(t, fields[5].(zap.Field).Equals(zap.Any("roleNames", []string{})))
 	assert.True(t, fields[6].(zap.Field).Equals(zap.String("permissions", "")))
 	assert.True(t, fields[7].(zap.Field).Equals(zap.Any("authProvider", &loggableAuthProvider{
-		Id:   "",
+		ID:   "",
 		Name: "",
 		Type: "",
 	})))

--- a/pkg/auth/user/util_test.go
+++ b/pkg/auth/user/util_test.go
@@ -1,0 +1,106 @@
+package user
+
+import (
+	"testing"
+	"time"
+
+	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/protoconv"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+func TestExtractUserLogFields(t *testing.T) {
+	// 1. Main fields are transformed properly.
+	user := &v1.AuthStatus{
+		Id: &v1.AuthStatus_UserId{
+			UserId: "UserID",
+		},
+		AuthProvider: &storage.AuthProvider{
+			Id:   "authProviderId",
+			Name: "authProviderName",
+			Type: "authProviderType",
+		},
+		Expires: protoconv.ConvertTimeToTimestampOrNil(time.Now()),
+		UserAttributes: ConvertAttributes(map[string][]string{
+			"a": {"b"},
+		}),
+		UserInfo: &storage.UserInfo{
+			Username:     "DO",
+			FriendlyName: "Door Opener",
+			Permissions: &storage.UserInfo_ResourceToAccess{ResourceToAccess: map[string]storage.Access{
+				"Open Magic Doors":  storage.Access_READ_WRITE_ACCESS,
+				"Close Magic Doors": storage.Access_READ_ACCESS,
+			}},
+			Roles: []*storage.UserInfo_Role{
+				{
+					Name: "Admin",
+				},
+				{
+					Name: "Analyst",
+				},
+			},
+		},
+	}
+	fields := extractUserLogFields(user)
+	assert.Len(t, fields, 9)
+	assert.True(t, fields[0].(zap.Field).Equals(zap.String("userID", user.GetUserId())))
+	assert.True(t, fields[1].(zap.Field).Equals(zap.String("serviceID", "")))
+	assert.True(t, fields[2].(zap.Field).Equals(zap.Any("expires", user.GetExpires())))
+	assert.True(t, fields[3].(zap.Field).Equals(zap.String("username", user.GetUserInfo().GetUsername())))
+	assert.True(t, fields[4].(zap.Field).Equals(zap.String("friendlyName", user.GetUserInfo().GetFriendlyName())))
+	assert.True(t, fields[5].(zap.Field).Equals(zap.Any("roleNames", []string{"Admin", "Analyst"})))
+	assert.True(t, fields[6].(zap.Field).Equals(zap.String("permissions", "{\"resourceToAccess\":{\"Close Magic Doors\":\"READ_ACCESS\",\"Open Magic Doors\":\"READ_WRITE_ACCESS\"}}")))
+	assert.True(t, fields[7].(zap.Field).Equals(zap.Any("authProvider", &loggableAuthProvider{
+		Id:   user.GetAuthProvider().GetId(),
+		Name: user.GetAuthProvider().GetName(),
+		Type: user.GetAuthProvider().GetType(),
+	})))
+	assert.True(t, fields[8].(zap.Field).Equals(zap.Any("userAttributes", user.GetUserAttributes())))
+
+	// 2. Service id is transformed to string properly.
+	user = &v1.AuthStatus{
+		Id: &v1.AuthStatus_ServiceId{
+			ServiceId: &storage.ServiceIdentity{
+				Id:           "id",
+				InitBundleId: "initBundleId",
+				Type:         storage.ServiceType_CENTRAL_SERVICE,
+				SerialStr:    "serialStr",
+			},
+		},
+	}
+	fields = extractUserLogFields(user)
+	assert.Len(t, fields, 9)
+	assert.True(t, fields[0].(zap.Field).Equals(zap.String("userID", "")))
+	assert.True(t, fields[1].(zap.Field).Equals(zap.String("serviceID", "{\"serialStr\":\"serialStr\",\"id\":\"id\",\"type\":\"CENTRAL_SERVICE\",\"initBundleId\":\"initBundleId\"}")))
+	assert.True(t, fields[2].(zap.Field).Equals(zap.Any("expires", user.GetExpires())))
+	assert.True(t, fields[3].(zap.Field).Equals(zap.String("username", "")))
+	assert.True(t, fields[4].(zap.Field).Equals(zap.String("friendlyName", "")))
+	assert.True(t, fields[5].(zap.Field).Equals(zap.Any("roleNames", []string{})))
+	assert.True(t, fields[6].(zap.Field).Equals(zap.String("permissions", "")))
+	assert.True(t, fields[7].(zap.Field).Equals(zap.Any("authProvider", &loggableAuthProvider{
+		Id:   "",
+		Name: "",
+		Type: "",
+	})))
+	assert.True(t, fields[8].(zap.Field).Equals(zap.Any("userAttributes", user.GetUserAttributes())))
+
+	// 3. Nil is handled without panic.
+	user = nil
+	fields = extractUserLogFields(user)
+	assert.Len(t, fields, 9)
+	assert.True(t, fields[0].(zap.Field).Equals(zap.String("userID", "")))
+	assert.True(t, fields[1].(zap.Field).Equals(zap.String("serviceID", "")))
+	assert.True(t, fields[2].(zap.Field).Equals(zap.Any("expires", user.GetExpires())))
+	assert.True(t, fields[3].(zap.Field).Equals(zap.String("username", "")))
+	assert.True(t, fields[4].(zap.Field).Equals(zap.String("friendlyName", "")))
+	assert.True(t, fields[5].(zap.Field).Equals(zap.Any("roleNames", []string{})))
+	assert.True(t, fields[6].(zap.Field).Equals(zap.String("permissions", "")))
+	assert.True(t, fields[7].(zap.Field).Equals(zap.Any("authProvider", &loggableAuthProvider{
+		Id:   "",
+		Name: "",
+		Type: "",
+	})))
+	assert.True(t, fields[8].(zap.Field).Equals(zap.Any("userAttributes", user.GetUserAttributes())))
+}

--- a/pkg/auth/user/util_test.go
+++ b/pkg/auth/user/util_test.go
@@ -44,19 +44,19 @@ func TestExtractUserLogFields_MainFieldsTransformed(t *testing.T) {
 	}
 	fields := extractUserLogFields(user)
 	assert.Len(t, fields, 9)
-	assert.True(t, fields[0].(zap.Field).Equals(zap.String("userID", user.GetUserId())))
-	assert.True(t, fields[1].(zap.Field).Equals(zap.String("serviceID", "")))
-	assert.True(t, fields[2].(zap.Field).Equals(zap.Any("expires", user.GetExpires())))
-	assert.True(t, fields[3].(zap.Field).Equals(zap.String("username", user.GetUserInfo().GetUsername())))
-	assert.True(t, fields[4].(zap.Field).Equals(zap.String("friendlyName", user.GetUserInfo().GetFriendlyName())))
-	assert.True(t, fields[5].(zap.Field).Equals(zap.Any("roleNames", []string{"Admin", "Analyst"})))
-	assert.True(t, fields[6].(zap.Field).Equals(zap.String("permissions", "{\"resourceToAccess\":{\"Close Magic Doors\":\"READ_ACCESS\",\"Open Magic Doors\":\"READ_WRITE_ACCESS\"}}")))
-	assert.True(t, fields[7].(zap.Field).Equals(zap.Any("authProvider", &loggableAuthProvider{
+	assert.Contains(t, fields, zap.String("userID", user.GetUserId()))
+	assert.Contains(t, fields, zap.String("serviceID", ""))
+	assert.Contains(t, fields, zap.Any("expires", user.GetExpires()))
+	assert.Contains(t, fields, zap.String("username", user.GetUserInfo().GetUsername()))
+	assert.Contains(t, fields, zap.String("friendlyName", user.GetUserInfo().GetFriendlyName()))
+	assert.Contains(t, fields, zap.Any("roleNames", []string{"Admin", "Analyst"}))
+	assert.Contains(t, fields, zap.String("permissions", "{\"resourceToAccess\":{\"Close Magic Doors\":\"READ_ACCESS\",\"Open Magic Doors\":\"READ_WRITE_ACCESS\"}}"))
+	assert.Contains(t, fields, zap.Any("authProvider", &loggableAuthProvider{
 		ID:   user.GetAuthProvider().GetId(),
 		Name: user.GetAuthProvider().GetName(),
 		Type: user.GetAuthProvider().GetType(),
-	})))
-	assert.True(t, fields[8].(zap.Field).Equals(zap.Any("userAttributes", user.GetUserAttributes())))
+	}))
+	assert.Contains(t, fields, zap.Any("userAttributes", user.GetUserAttributes()))
 }
 
 func TestExtractUserLogFields_ServiceIdTransformed(t *testing.T) {
@@ -72,19 +72,19 @@ func TestExtractUserLogFields_ServiceIdTransformed(t *testing.T) {
 	}
 	fields := extractUserLogFields(user)
 	assert.Len(t, fields, 9)
-	assert.True(t, fields[0].(zap.Field).Equals(zap.String("userID", "")))
-	assert.True(t, fields[1].(zap.Field).Equals(zap.String("serviceID", "{\"serialStr\":\"serialStr\",\"id\":\"id\",\"type\":\"CENTRAL_SERVICE\",\"initBundleId\":\"initBundleId\"}")))
-	assert.True(t, fields[2].(zap.Field).Equals(zap.Any("expires", user.GetExpires())))
-	assert.True(t, fields[3].(zap.Field).Equals(zap.String("username", "")))
-	assert.True(t, fields[4].(zap.Field).Equals(zap.String("friendlyName", "")))
-	assert.True(t, fields[5].(zap.Field).Equals(zap.Any("roleNames", []string{})))
-	assert.True(t, fields[6].(zap.Field).Equals(zap.String("permissions", "")))
-	assert.True(t, fields[7].(zap.Field).Equals(zap.Any("authProvider", &loggableAuthProvider{
+	assert.Contains(t, fields, zap.String("userID", ""))
+	assert.Contains(t, fields, zap.String("serviceID", "{\"serialStr\":\"serialStr\",\"id\":\"id\",\"type\":\"CENTRAL_SERVICE\",\"initBundleId\":\"initBundleId\"}"))
+	assert.Contains(t, fields, zap.Any("expires", user.GetExpires()))
+	assert.Contains(t, fields, zap.String("username", ""))
+	assert.Contains(t, fields, zap.String("friendlyName", ""))
+	assert.Contains(t, fields, zap.Any("roleNames", []string{}))
+	assert.Contains(t, fields, zap.String("permissions", ""))
+	assert.Contains(t, fields, zap.Any("authProvider", &loggableAuthProvider{
 		ID:   "",
 		Name: "",
 		Type: "",
-	})))
-	assert.True(t, fields[8].(zap.Field).Equals(zap.Any("userAttributes", user.GetUserAttributes())))
+	}))
+	assert.Contains(t, fields, zap.Any("userAttributes", user.GetUserAttributes()))
 
 }
 
@@ -92,17 +92,17 @@ func TestExtractUserLogFields_NilTransformed(t *testing.T) {
 	var user *v1.AuthStatus
 	fields := extractUserLogFields(user)
 	assert.Len(t, fields, 9)
-	assert.True(t, fields[0].(zap.Field).Equals(zap.String("userID", "")))
-	assert.True(t, fields[1].(zap.Field).Equals(zap.String("serviceID", "")))
-	assert.True(t, fields[2].(zap.Field).Equals(zap.Any("expires", user.GetExpires())))
-	assert.True(t, fields[3].(zap.Field).Equals(zap.String("username", "")))
-	assert.True(t, fields[4].(zap.Field).Equals(zap.String("friendlyName", "")))
-	assert.True(t, fields[5].(zap.Field).Equals(zap.Any("roleNames", []string{})))
-	assert.True(t, fields[6].(zap.Field).Equals(zap.String("permissions", "")))
-	assert.True(t, fields[7].(zap.Field).Equals(zap.Any("authProvider", &loggableAuthProvider{
+	assert.Contains(t, fields, zap.String("userID", ""))
+	assert.Contains(t, fields, zap.String("serviceID", ""))
+	assert.Contains(t, fields, zap.Any("expires", user.GetExpires()))
+	assert.Contains(t, fields, zap.String("username", ""))
+	assert.Contains(t, fields, zap.String("friendlyName", ""))
+	assert.Contains(t, fields, zap.Any("roleNames", []string{}))
+	assert.Contains(t, fields, zap.String("permissions", ""))
+	assert.Contains(t, fields, zap.Any("authProvider", &loggableAuthProvider{
 		ID:   "",
 		Name: "",
 		Type: "",
-	})))
-	assert.True(t, fields[8].(zap.Field).Equals(zap.Any("userAttributes", user.GetUserAttributes())))
+	}))
+	assert.Contains(t, fields, zap.Any("userAttributes", user.GetUserAttributes()))
 }

--- a/pkg/auth/user/util_test.go
+++ b/pkg/auth/user/util_test.go
@@ -11,8 +11,7 @@ import (
 	"go.uber.org/zap"
 )
 
-func TestExtractUserLogFields(t *testing.T) {
-	// 1. Main fields are transformed properly.
+func TestExtractUserLogFields_MainFieldsTransformed(t *testing.T) {
 	user := &v1.AuthStatus{
 		Id: &v1.AuthStatus_UserId{
 			UserId: "UserID",
@@ -58,9 +57,10 @@ func TestExtractUserLogFields(t *testing.T) {
 		Type: user.GetAuthProvider().GetType(),
 	})))
 	assert.True(t, fields[8].(zap.Field).Equals(zap.Any("userAttributes", user.GetUserAttributes())))
+}
 
-	// 2. Service id is transformed to string properly.
-	user = &v1.AuthStatus{
+func TestExtractUserLogFields_ServiceIdTransformed(t *testing.T) {
+	user := &v1.AuthStatus{
 		Id: &v1.AuthStatus_ServiceId{
 			ServiceId: &storage.ServiceIdentity{
 				Id:           "id",
@@ -70,7 +70,7 @@ func TestExtractUserLogFields(t *testing.T) {
 			},
 		},
 	}
-	fields = extractUserLogFields(user)
+	fields := extractUserLogFields(user)
 	assert.Len(t, fields, 9)
 	assert.True(t, fields[0].(zap.Field).Equals(zap.String("userID", "")))
 	assert.True(t, fields[1].(zap.Field).Equals(zap.String("serviceID", "{\"serialStr\":\"serialStr\",\"id\":\"id\",\"type\":\"CENTRAL_SERVICE\",\"initBundleId\":\"initBundleId\"}")))
@@ -86,9 +86,11 @@ func TestExtractUserLogFields(t *testing.T) {
 	})))
 	assert.True(t, fields[8].(zap.Field).Equals(zap.Any("userAttributes", user.GetUserAttributes())))
 
-	// 3. Nil is handled without panic.
-	user = nil
-	fields = extractUserLogFields(user)
+}
+
+func TestExtractUserLogFields_NilTransformed(t *testing.T) {
+	var user *v1.AuthStatus
+	fields := extractUserLogFields(user)
 	assert.Len(t, fields, 9)
 	assert.True(t, fields[0].(zap.Field).Equals(zap.String("userID", "")))
 	assert.True(t, fields[1].(zap.Field).Equals(zap.String("serviceID", "")))


### PR DESCRIPTION
## Description

Log user identities so that we can later collect them via CloudWatch and thus detect unauthorized access.
We log `ExchangeToken` results as well as it is used in basic auth in the UI(and potentially can be used with other auth providers)

Example of log record:
```
Warn: User successfully logged in with user attributes {"userID": "", "serviceID": "{\"id\":\"a\",\"initBundleId\":\"b\"}", "expires": "2023-02-27T19:22:16.405955Z", "username": "UserID", "friendlyName": "Madonna Slytherin", "roleNames": ["Admin", "Analyst"], "permissions": "{\"id\":\"a\",\"initBundleId\":\"b\"}", "authProvider": {"Id":"","Name":"authProviderName","Type":""}}
```

P.S. The reason to convert `serviceId` and `permissions` to JSON string is to improve readability of these fields. Compare to raw proto formatting:
```
Warn: User successfully logged in with user attributes {"userID": "", "serviceID": "id:\"a\" init_bundle_id:\"b\" ", "expires": "2023-02-27T20:53:27.559186Z", "username": "UserID", "friendlyName": "Madonna Slytherin", "roleNames": ["Admin", "Analyst"], "permissions": "resource_to_access:<key:\"Close Magic Doors\" value:READ_ACCESS > resource_to_access:<key:\"Open Magic Doors\" value:READ_WRITE_ACCESS > ", "authProvider": {"Id":"","Name":"authProviderName","Type":""}}

```

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

1. Run Central
2. Accessed via OIDC, Certificates and basic auth providers
3. Saw corresponding records in the central logs
