### PR TITLE
[ROX-15198] Do not panic when unexpected process violations are received

### DIFF
--- a/central/detection/alertmanager/alert_manager_impl_test.go
+++ b/central/detection/alertmanager/alert_manager_impl_test.go
@@ -602,6 +602,20 @@ func TestMergeRunTimeAlerts(t *testing.T) {
 			expectedOutput: true,
 		},
 		{
+			desc:           "Empty old alert; non-empty new alert",
+			old:            getFakeRuntimeAlert(),
+			new:            getFakeRuntimeAlert(yesterdayProcess),
+			expectedNew:    appendViolations(getFakeRuntimeAlert(yesterdayProcess)),
+			expectedOutput: true,
+		},
+		{
+			desc:           "Empty old alert; non-empty new alert; again",
+			old:            getFakeRuntimeAlert(),
+			new:            getFakeRuntimeAlert(yesterdayProcess, nowProcess),
+			expectedNew:    appendViolations(getFakeRuntimeAlert(yesterdayProcess, nowProcess)),
+			expectedOutput: true,
+		},
+		{
 			desc:           "No process; no event",
 			old:            getFakeRuntimeAlert(),
 			new:            getFakeRuntimeAlert(),


### PR DESCRIPTION
## Description

This PR logs error instead of panicking when an unexpected runtime process alert is encountered by Central.

## Checklist
- [ ] Investigated and inspected CI test results
- [X] Unit test and regression tests added
- ~Evaluated and added CHANGELOG entry if required~
- ~Determined and documented upgrade steps~
- ~Documented user facing changes~

If any of these don't apply, please comment below.

## Testing Performed
Unit