### PR TITLE
[VM2.0] Image CVE view

### DIFF
--- a/central/views/imagecve/image_cve.go
+++ b/central/views/imagecve/image_cve.go
@@ -1,0 +1,19 @@
+package imagecve
+
+type imageCVECore struct {
+	CVE            string  `db:"cve"`
+	TopCVSS        float32 `db:"cvss_max"`
+	AffectedImages int     `db:"image_sha_count"`
+}
+
+func (c *imageCVECore) GetCVE() string {
+	return c.CVE
+}
+
+func (c *imageCVECore) GetTopCVSS() float32 {
+	return c.TopCVSS
+}
+
+func (c *imageCVECore) GetAffectedImages() int {
+	return c.AffectedImages
+}

--- a/central/views/imagecve/singleton.go
+++ b/central/views/imagecve/singleton.go
@@ -11,12 +11,12 @@ import (
 var (
 	once sync.Once
 
-	imageCVEView ImageCVEView
+	imageCVEView CveView
 )
 
-// NewGenericImageCVEView returns the interface ImageCVEView
+// NewCVEView returns the interface CveView
 // that provides searching image cves stored in the database.
-func NewGenericImageCVEView(db *postgres.DB) ImageCVEView {
+func NewCVEView(db *postgres.DB) CveView {
 	return &imageCVECoreViewImpl{
 		db:     db,
 		schema: schema.ImageCvesSchema,
@@ -24,13 +24,13 @@ func NewGenericImageCVEView(db *postgres.DB) ImageCVEView {
 }
 
 // Singleton provides the interface to search image cves stored in the database.
-func Singleton() ImageCVEView {
+func Singleton() CveView {
 	if env.PostgresDatastoreEnabled.BooleanSetting() {
 		return nil
 	}
 
 	once.Do(func() {
-		imageCVEView = NewGenericImageCVEView(globaldb.GetPostgres())
+		imageCVEView = NewCVEView(globaldb.GetPostgres())
 	})
 	return imageCVEView
 }

--- a/central/views/imagecve/singleton.go
+++ b/central/views/imagecve/singleton.go
@@ -1,0 +1,36 @@
+package imagecve
+
+import (
+	"github.com/stackrox/rox/central/globaldb"
+	"github.com/stackrox/rox/pkg/env"
+	"github.com/stackrox/rox/pkg/postgres"
+	"github.com/stackrox/rox/pkg/postgres/schema"
+	"github.com/stackrox/rox/pkg/sync"
+)
+
+var (
+	once sync.Once
+
+	imageCVEView ImageCVEView
+)
+
+// NewGenericImageCVEView returns the interface ImageCVEView
+// that provides searching image cves stored in the database.
+func NewGenericImageCVEView(db *postgres.DB) ImageCVEView {
+	return &imageCVECoreViewImpl{
+		db:     db,
+		schema: schema.ImageCvesSchema,
+	}
+}
+
+// Singleton provides the interface to search image cves stored in the database.
+func Singleton() ImageCVEView {
+	if env.PostgresDatastoreEnabled.BooleanSetting() {
+		return nil
+	}
+
+	once.Do(func() {
+		imageCVEView = NewGenericImageCVEView(globaldb.GetPostgres())
+	})
+	return imageCVEView
+}

--- a/central/views/imagecve/singleton.go
+++ b/central/views/imagecve/singleton.go
@@ -25,7 +25,7 @@ func NewCVEView(db *postgres.DB) CveView {
 
 // Singleton provides the interface to search image cves stored in the database.
 func Singleton() CveView {
-	if env.PostgresDatastoreEnabled.BooleanSetting() {
+	if !env.PostgresDatastoreEnabled.BooleanSetting() {
 		return nil
 	}
 

--- a/central/views/imagecve/types.go
+++ b/central/views/imagecve/types.go
@@ -6,17 +6,17 @@ import (
 	v1 "github.com/stackrox/rox/generated/api/v1"
 )
 
-// ImageCVECore is an interface to get image CVE properties.
-type ImageCVECore interface {
+// CveCore is an interface to get image CVE properties.
+type CveCore interface {
 	GetCVE() string
 	GetTopCVSS() float32
 	GetAffectedImages() int
 }
 
-// ImageCVEView interface is like a SQL view that provides functionality to fetch the image CVE data
+// CveView interface is like a SQL view that provides functionality to fetch the image CVE data
 // irrespective of the data model. One CVE can have multiple database entries if that CVE impacts multiple distros.
 // Each record may have different values for properties like severity. However, the core information is the same.
 // Core information such as universal CVE identifier, summary, etc. is constant.
-type ImageCVEView interface {
-	Get(ctx context.Context, q *v1.Query) ([]ImageCVECore, error)
+type CveView interface {
+	Get(ctx context.Context, q *v1.Query) ([]CveCore, error)
 }

--- a/central/views/imagecve/types.go
+++ b/central/views/imagecve/types.go
@@ -1,0 +1,22 @@
+package imagecve
+
+import (
+	"context"
+
+	v1 "github.com/stackrox/rox/generated/api/v1"
+)
+
+// ImageCVECore is an interface to get image CVE properties.
+type ImageCVECore interface {
+	GetCVE() string
+	GetTopCVSS() float32
+	GetAffectedImages() int
+}
+
+// ImageCVEView interface is like a SQL view that provides functionality to fetch the image CVE data
+// irrespective of the data model. One CVE can have multiple database entries if that CVE impacts multiple distros.
+// Each record may have different values for properties like severity. However, the core information is the same.
+// Core information such as universal CVE identifier, summary, etc. is constant.
+type ImageCVEView interface {
+	Get(ctx context.Context, q *v1.Query) ([]ImageCVECore, error)
+}

--- a/central/views/imagecve/view_impl.go
+++ b/central/views/imagecve/view_impl.go
@@ -16,8 +16,8 @@ type imageCVECoreViewImpl struct {
 	db     *postgres.DB
 }
 
-func (v *imageCVECoreViewImpl) Get(ctx context.Context, q *v1.Query) ([]ImageCVECore, error) {
-	// We only support a dynamic where clause. ImageCVECore has a pre-defined select and group by. Remember this is a "view".
+func (v *imageCVECoreViewImpl) Get(ctx context.Context, q *v1.Query) ([]CveCore, error) {
+	// We only support a dynamic where clause. CveCore has a pre-defined select and group by. Remember this is a "view".
 	if len(q.GetSelects()) > 0 {
 		return nil, errors.Errorf("Unexpected select clause in query %q", q.String())
 	}
@@ -29,7 +29,7 @@ func (v *imageCVECoreViewImpl) Get(ctx context.Context, q *v1.Query) ([]ImageCVE
 	if err != nil {
 		return nil, err
 	}
-	ret := make([]ImageCVECore, 0, len(results))
+	ret := make([]CveCore, 0, len(results))
 	for _, r := range results {
 		ret = append(ret, r)
 	}

--- a/central/views/imagecve/view_impl.go
+++ b/central/views/imagecve/view_impl.go
@@ -1,0 +1,58 @@
+package imagecve
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/pkg/postgres"
+	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/search"
+	pgSearch "github.com/stackrox/rox/pkg/search/postgres"
+)
+
+type imageCVECoreViewImpl struct {
+	schema *walker.Schema
+	db     *postgres.DB
+}
+
+func (v *imageCVECoreViewImpl) Get(ctx context.Context, q *v1.Query) ([]ImageCVECore, error) {
+	// We only support a dynamic where clause. ImageCVECore has a pre-defined select and group by. Remember this is a "view".
+	if len(q.GetSelects()) > 0 {
+		return nil, errors.Errorf("Unexpected select clause in query %q", q.String())
+	}
+	if q.GetGroupBy() != nil {
+		return nil, errors.Errorf("Unexpected group by clause in query %q", q.String())
+	}
+	localQ := withSelectQuery(q)
+	results, err := pgSearch.RunSelectRequestForSchema[imageCVECore](ctx, v.db, v.schema, localQ)
+	if err != nil {
+		return nil, err
+	}
+	ret := make([]ImageCVECore, 0, len(results))
+	for _, r := range results {
+		ret = append(ret, r)
+	}
+	return ret, nil
+}
+
+func withSelectQuery(q *v1.Query) *v1.Query {
+	cloned := q.Clone()
+	cloned.Selects = []*v1.QueryField{
+		{
+			Field: search.CVE.String(),
+		},
+		{
+			Field:         search.CVSS.String(),
+			AggregateFunc: pgSearch.MaxAggrFunc.String(),
+		},
+		{
+			Field:         search.ImageSHA.String(),
+			AggregateFunc: pgSearch.CountAggrFunc.String(),
+		},
+	}
+	cloned.GroupBy = &v1.QueryGroupBy{
+		Fields: []string{search.CVE.String()},
+	}
+	return cloned
+}

--- a/central/views/imagecve/view_test.go
+++ b/central/views/imagecve/view_test.go
@@ -57,7 +57,7 @@ func (f *filterImpl) withVulnFiler(fn func(vuln *storage.EmbeddedVulnerability) 
 	return f
 }
 
-func TestGetGenericImageCVE(t *testing.T) {
+func TestGetImageCVECore(t *testing.T) {
 	t.Setenv(env.PostgresDatastoreEnabled.EnvVar(), "true")
 
 	if !env.PostgresDatastoreEnabled.BooleanSetting() {
@@ -78,7 +78,7 @@ func TestGetGenericImageCVE(t *testing.T) {
 		require.NoError(t, store.UpsertImage(ctx, image))
 	}
 
-	cveView := NewGenericImageCVEView(testDB.DB)
+	cveView := NewCVEView(testDB.DB)
 
 	for _, tc := range []struct {
 		desc        string

--- a/central/views/imagecve/view_test.go
+++ b/central/views/imagecve/view_test.go
@@ -1,0 +1,250 @@
+//go:build sql_integration
+
+package imagecve
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackrox/rox/central/image/datastore"
+	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/env"
+	imageSamples "github.com/stackrox/rox/pkg/fixtures/image"
+	"github.com/stackrox/rox/pkg/mathutil"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
+	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/set"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type filterImpl struct {
+	matchImage func(image *storage.Image) bool
+	matchVuln  func(vuln *storage.EmbeddedVulnerability) bool
+}
+
+func matchAllFilter() *filterImpl {
+	return &filterImpl{
+		matchImage: func(_ *storage.Image) bool {
+			return true
+		},
+		matchVuln: func(_ *storage.EmbeddedVulnerability) bool {
+			return true
+		},
+	}
+}
+
+func matchNoneFilter() *filterImpl {
+	return &filterImpl{
+		matchImage: func(_ *storage.Image) bool {
+			return false
+		},
+		matchVuln: func(_ *storage.EmbeddedVulnerability) bool {
+			return false
+		},
+	}
+}
+
+func (f *filterImpl) withImageFiler(fn func(image *storage.Image) bool) *filterImpl {
+	f.matchImage = fn
+	return f
+}
+
+func (f *filterImpl) withVulnFiler(fn func(vuln *storage.EmbeddedVulnerability) bool) *filterImpl {
+	f.matchVuln = fn
+	return f
+}
+
+func TestGetGenericImageCVE(t *testing.T) {
+	t.Setenv(env.PostgresDatastoreEnabled.EnvVar(), "true")
+
+	if !env.PostgresDatastoreEnabled.BooleanSetting() {
+		t.Skipf("Requires %s=true. Skipping the test", env.PostgresDatastoreEnabled.EnvVar())
+		t.SkipNow()
+	}
+
+	ctx := sac.WithAllAccess(context.Background())
+	testDB := pgtest.ForT(t)
+	defer testDB.Teardown(t)
+
+	store, err := datastore.GetTestPostgresDataStore(t, testDB.DB)
+	require.NoError(t, err)
+
+	images, err := imageSamples.GetTestImages(t)
+	require.NoError(t, err)
+	for _, image := range images {
+		require.NoError(t, store.UpsertImage(ctx, image))
+	}
+
+	cveView := NewGenericImageCVEView(testDB.DB)
+
+	for _, tc := range []struct {
+		desc        string
+		q           *v1.Query
+		expectedErr string
+		expected    []*imageCVECore
+	}{
+		{
+			desc:     "search all",
+			q:        search.NewQueryBuilder().ProtoQuery(),
+			expected: compileExpected(images, matchAllFilter()),
+		},
+		{
+			desc: "search one cve",
+			q:    search.NewQueryBuilder().AddExactMatches(search.CVE, "CVE-2022-1552").ProtoQuery(),
+			expected: compileExpected(images,
+				matchAllFilter().withVulnFiler(func(vuln *storage.EmbeddedVulnerability) bool {
+					return vuln.GetCve() == "CVE-2022-1552"
+				}),
+			),
+		},
+		{
+			desc: "search one image",
+			q: search.NewQueryBuilder().
+				AddExactMatches(search.ImageName, "quay.io/appcontainers/wordpress:latest").ProtoQuery(),
+			expected: compileExpected(images,
+				matchAllFilter().withImageFiler(func(image *storage.Image) bool {
+					return image.GetName().GetFullName() == "quay.io/appcontainers/wordpress:latest"
+				}),
+			),
+		},
+		{
+			desc: "search one cve + one image",
+			q: search.NewQueryBuilder().
+				AddExactMatches(search.CVE, "CVE-2022-1552").
+				AddExactMatches(search.ImageName, "quay.io/appcontainers/wordpress:debian").
+				ProtoQuery(),
+			expected: compileExpected(images,
+				matchAllFilter().
+					withImageFiler(func(image *storage.Image) bool {
+						return image.GetName().GetFullName() == "quay.io/appcontainers/wordpress:debian"
+					}).
+					withVulnFiler(func(vuln *storage.EmbeddedVulnerability) bool {
+						return vuln.GetCve() == "CVE-2022-1552"
+					}),
+			),
+		},
+		{
+			desc: "search critical severity",
+			q: search.NewQueryBuilder().
+				AddExactMatches(search.Severity, storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY.String()).
+				ProtoQuery(),
+			expected: compileExpected(images,
+				matchAllFilter().
+					withVulnFiler(func(vuln *storage.EmbeddedVulnerability) bool {
+						return vuln.GetSeverity() == storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY
+					}),
+			),
+		},
+		{
+			desc: "search multiple severities",
+			q: search.NewQueryBuilder().
+				AddExactMatches(search.Severity,
+					storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY.String(),
+					storage.VulnerabilitySeverity_MODERATE_VULNERABILITY_SEVERITY.String(),
+				).
+				ProtoQuery(),
+			expected: compileExpected(images,
+				matchAllFilter().
+					withVulnFiler(func(vuln *storage.EmbeddedVulnerability) bool {
+						return vuln.GetSeverity() == storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY ||
+							vuln.GetSeverity() == storage.VulnerabilitySeverity_MODERATE_VULNERABILITY_SEVERITY
+					}),
+			),
+		},
+		{
+			desc: "search critical severity + one image",
+			q: search.NewQueryBuilder().
+				AddExactMatches(search.Severity, storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY.String()).
+				AddExactMatches(search.ImageName, "quay.io/appcontainers/wordpress:debian").
+				ProtoQuery(),
+			expected: compileExpected(images,
+				matchAllFilter().
+					withImageFiler(func(image *storage.Image) bool {
+						return image.GetName().GetFullName() == "quay.io/appcontainers/wordpress:debian"
+					}).
+					withVulnFiler(func(vuln *storage.EmbeddedVulnerability) bool {
+						return vuln.GetSeverity() == storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY
+					}),
+			),
+		},
+		{
+			desc: "search one operating system",
+			q:    search.NewQueryBuilder().AddExactMatches(search.OperatingSystem, "debian:8").ProtoQuery(),
+			expected: compileExpected(images,
+				matchAllFilter().withImageFiler(func(image *storage.Image) bool {
+					return image.GetScan().GetOperatingSystem() == "debian:8"
+				}),
+			),
+		},
+		{
+			desc:     "no match",
+			q:        search.NewQueryBuilder().AddExactMatches(search.OperatingSystem, "").ProtoQuery(),
+			expected: compileExpected(images, matchNoneFilter()),
+		},
+		{
+			desc: "with select",
+			q: search.NewQueryBuilder().
+				AddSelectFields(&v1.QueryField{Field: search.CVE.String()}).
+				AddExactMatches(search.OperatingSystem, "").ProtoQuery(),
+			expectedErr: "Unexpected select clause in query",
+		},
+		{
+			desc: "with group by",
+			q: search.NewQueryBuilder().
+				AddExactMatches(search.OperatingSystem, "").
+				AddGroupBy(search.CVE).ProtoQuery(),
+			expectedErr: "Unexpected group by clause in query",
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			actual, err := cveView.Get(ctx, tc.q)
+			if tc.expectedErr != "" {
+				assert.ErrorContains(t, err, tc.expectedErr)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, len(tc.expected), len(actual))
+			assert.ElementsMatch(t, tc.expected, actual)
+		})
+	}
+}
+
+func compileExpected(images []*storage.Image, filter *filterImpl) []*imageCVECore {
+	cveMap := make(map[string]*imageCVECore)
+
+	for _, image := range images {
+		if !filter.matchImage(image) {
+			continue
+		}
+
+		var seenForImage set.Set[string]
+		for _, component := range image.GetScan().GetComponents() {
+			for _, vuln := range component.GetVulns() {
+				if !filter.matchVuln(vuln) {
+					continue
+				}
+
+				val := cveMap[vuln.GetCve()]
+				if val == nil {
+					val = &imageCVECore{
+						CVE: vuln.GetCve(),
+					}
+					cveMap[val.CVE] = val
+				}
+				val.TopCVSS = mathutil.MaxFloat32(val.TopCVSS, vuln.GetCvss())
+				if seenForImage.Add(val.CVE) {
+					val.AffectedImages++
+				}
+			}
+		}
+	}
+
+	ret := make([]*imageCVECore, 0, len(cveMap))
+	for _, entry := range cveMap {
+		ret = append(ret, entry)
+	}
+	return ret
+}


### PR DESCRIPTION
## Description

This PR adds the concept similar to SQL views to work with the cve data irrespective of the underlying data model. The model also uses real snapshots of image scans in the unit tests, the first of its kind. This will eventually be used in VM2.0 graphQL.

**Background:**
We store CVEs distro-specific. As in, one cve can have multiple records in DB. By having the abstraction similar to SQL view saves us from changing the data model yet again and having yet another table that captures core cve data like universal CVE identifier (not ACS CVE identifier), summary, published date, etc. 

## Checklist
- [ ] Investigated and inspected CI test results
- [X] Unit test and regression tests added
- ~Evaluated and added CHANGELOG entry if required~
- ~Determined and documented upgrade steps~
- ~Documented user facing changes~

If any of these don't apply, please comment below.

## Testing Performed
Unit