### PR TITLE
ROX-14995: Fetch central-db logs too.

### DIFF
--- a/operator/tests/common/central-cr-assert.yaml
+++ b/operator/tests/common/central-cr-assert.yaml
@@ -4,6 +4,9 @@ collectors:
 - type: pod
   selector: app=central
   tail: -1
+- type: pod
+  selector: app=central-db
+  tail: -1
 ---
 apiVersion: platform.stackrox.io/v1alpha1
 kind: Central


### PR DESCRIPTION
## Description

When central does not become healthy, then fetch central-db logs too, for troubleshooting.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

CI is sufficient.