### PR TITLE
Dashrews/ROX-14966 Update role datastore test to work with postgres

### DIFF
--- a/central/role/datastore/datastore_test.go
+++ b/central/role/datastore/datastore_test.go
@@ -415,9 +415,10 @@ func (s *roleDataStoreTestSuite) TestPermissionSetWriteOperations() {
 	s.ErrorIs(err, errox.AlreadyExists, "adding permission set with an existing ID yields an error")
 
 	err = s.dataStore.AddPermissionSet(s.hasWriteCtx, mimicPermissionSet)
-	assert.Error(s.T(), err)
 	// With postgres the unique constraint catches this.
-	if !env.PostgresDatastoreEnabled.BooleanSetting() {
+	if env.PostgresDatastoreEnabled.BooleanSetting() {
+		assert.ErrorContains(s.T(), err, "violates unique constraint")
+	} else {
 		s.ErrorIs(err, errox.AlreadyExists, "adding permission set with an existing name yields an error")
 	}
 
@@ -590,11 +591,6 @@ func (s *roleDataStoreTestSuite) TestAccessScopeWriteOperations() {
 		Origin: storage.Traits_DECLARATIVE,
 	}
 
-	log.Info("SHREWS --")
-	log.Infof("good = %v", goodScope)
-	log.Infof("bad = %v", badScope)
-	log.Infof("mimic = %v", mimicScope)
-	log.Infof("clone = %v", cloneScope)
 	err := s.dataStore.AddAccessScope(s.hasWriteCtx, badScope)
 	s.ErrorIs(err, errox.InvalidArgs, "invalid scope for Add*() yields an error")
 


### PR DESCRIPTION
## Description

This test was not working with Postgres.  Updated it such that it will execute Postgres backed stores.

## Checklist
- [ ] Investigated and inspected CI test results
~- [ ] Unit test and regression tests added~
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

this is only a test
