### PR TITLE
Removed ManagedFields at the informer level to save on memory

### DIFF
--- a/sensor/kubernetes/listener/resource_event_handler.go
+++ b/sensor/kubernetes/listener/resource_event_handler.go
@@ -11,11 +11,13 @@ import (
 	"github.com/stackrox/rox/pkg/features"
 	kubernetesPkg "github.com/stackrox/rox/pkg/kubernetes"
 	"github.com/stackrox/rox/pkg/sync"
+	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/rox/sensor/common/clusterid"
 	"github.com/stackrox/rox/sensor/common/processfilter"
 	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/component"
 	"github.com/stackrox/rox/sensor/kubernetes/listener/resources"
 	"github.com/stackrox/rox/sensor/kubernetes/orchestratornamespaces"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/informers"
@@ -48,6 +50,17 @@ func startAndWait(stopSignal *concurrency.Signal, wg *concurrency.WaitGroup, sta
 		start.Start(stopSignal.Done())
 	}
 	return concurrency.WaitInContext(wg, stopSignal)
+}
+
+func managedFieldsTransformer(obj interface{}) (interface{}, error) {
+	if obj == nil {
+		return obj, nil
+	}
+	if managedFieldsSetter, ok := obj.(interface{ SetManagedFields([]v1.ManagedFieldsEntry) }); ok {
+		// Managed fields are unused by Sensor so clear them out to avoid them hitting the cache
+		managedFieldsSetter.SetManagedFields(nil)
+	}
+	return obj, nil
 }
 
 func (k *listenerImpl) handleAllEvents() {
@@ -252,7 +265,7 @@ func (k *listenerImpl) handleAllEvents() {
 	// Finally, run the pod informer, and process pod events.
 	podWaitGroup := &concurrency.WaitGroup{}
 	handle(podInformer.Informer(), dispatchers.ForDeployments(kubernetesPkg.Pod), k.outputQueue, &syncingResources, podWaitGroup, stopSignal, &eventLock)
-	if !startAndWait(stopSignal, podWaitGroup, sif) {
+	if !startAndWait(stopSignal, podWaitGroup, resyncingSif) {
 		return
 	}
 
@@ -294,6 +307,9 @@ func handle(
 		missingInitialIDs:          nil,
 	}
 	informer.AddEventHandler(handlerImpl)
+	if err := informer.SetTransform(managedFieldsTransformer); err != nil {
+		utils.Should(err)
+	}
 	wg.Add(1)
 	go func() {
 		defer wg.Add(-1)

--- a/sensor/kubernetes/listener/resource_event_handler.go
+++ b/sensor/kubernetes/listener/resource_event_handler.go
@@ -307,8 +307,10 @@ func handle(
 		missingInitialIDs:          nil,
 	}
 	informer.AddEventHandler(handlerImpl)
-	if err := informer.SetTransform(managedFieldsTransformer); err != nil {
-		utils.Should(err)
+	if !informer.HasSynced() {
+		if err := informer.SetTransform(managedFieldsTransformer); err != nil {
+			utils.Should(err)
+		}
 	}
 	wg.Add(1)
 	go func() {


### PR DESCRIPTION
## Description

Informers have a SetTransformFunc that mutates an object before it hits the cache. Generically, we can set the managed fields entries to nil

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
