### PR TITLE
Fix lint warning about no explicit any in clusters ProviderMetadata type

### DIFF
--- a/ui/apps/platform/src/Containers/Clusters/cluster.helpers.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/cluster.helpers.tsx
@@ -12,6 +12,7 @@ import {
     TimesCircleIcon,
 } from '@patternfly/react-icons';
 
+import { ClusterProviderMetadata } from 'types/cluster.proto';
 import { getDate } from 'utils/dateUtils';
 import { CertExpiryStatus } from './clusterTypes';
 
@@ -302,26 +303,19 @@ export function formatBuildDate(orchestratorMetadata) {
         : 'Not available';
 }
 
-type ProviderMetadata = {
-    region: string;
-    aws?: any;
-    azure?: any;
-    google?: any;
-};
-
-export function formatCloudProvider(providerMetadata: ProviderMetadata) {
+export function formatCloudProvider(providerMetadata: ClusterProviderMetadata) {
     if (providerMetadata) {
         const { region } = providerMetadata;
 
-        if (providerMetadata.aws) {
+        if ('aws' in providerMetadata) {
             return `AWS ${region}`;
         }
 
-        if (providerMetadata.azure) {
+        if ('azure' in providerMetadata) {
             return `Azure ${region}`;
         }
 
-        if (providerMetadata.google) {
+        if ('google' in providerMetadata) {
             return `GCP ${region}`;
         }
     }

--- a/ui/apps/platform/src/types/cluster.proto.ts
+++ b/ui/apps/platform/src/types/cluster.proto.ts
@@ -30,7 +30,7 @@ export type AWSProviderMetadata = {
 
 export type ClusterAzureProviderMetadata = {
     azure: AzureProviderMetadata;
-};
+} & ClusterBaseProviderMetadata;
 
 export type AzureProviderMetadata = {
     subscriptionId: string;


### PR DESCRIPTION
## Description

1. Import type from frontend proto file.
2. Replace property dot with `in` operator, which TypeScript prefers for case analysis in this situation.
3. Add missing type intersection in frontend proto file.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

1. `yarn lint` in ui
2. `yarn build` in ui
3. `yarn cypress-open` in ui/apps/platform
    * clusters/clustersHealthStatus.test.js