### PR TITLE
ROX-15138: Change the links from NWG 1.0 to NWG 2.0

### DIFF
--- a/ui/apps/platform/src/Containers/Dashboard/Widgets/DeploymentsAtMostRiskTable.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/Widgets/DeploymentsAtMostRiskTable.tsx
@@ -4,9 +4,10 @@ import { Truncate } from '@patternfly/react-core';
 import { TableComposable, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
 
 import { ListDeployment } from 'types/deployment.proto';
-import { networkBasePath, riskBasePath } from 'routePaths';
+import { networkBasePathPF, riskBasePath } from 'routePaths';
 import { SearchFilter } from 'types/search';
 import { getUrlQueryStringForSearchFilter } from 'utils/searchUtils';
+import { getQueryString } from 'utils/queryStringUtils';
 
 const columnNames = {
     deployment: 'Deployment',
@@ -43,31 +44,41 @@ function DeploymentsAtMostRiskTable({
                 </Tr>
             </Thead>
             <Tbody>
-                {deployments.map(({ id, name, cluster, namespace, priority }) => (
-                    <Tr key={id}>
-                        <Td className="pf-u-pl-0" dataLabel={columnNames.deployment}>
-                            <Link to={riskPageLinkToDeployment(id, name, searchFilter)}>
-                                <Truncate position="middle" content={name} />
-                            </Link>
-                        </Td>
-                        <Td width={45} dataLabel={columnNames.resourceLocation}>
-                            <span>
-                                in &ldquo;
-                                <Link
-                                    to={`${networkBasePath}/${id}`}
-                                >{`${cluster} / ${namespace}`}</Link>
-                                &rdquo;
-                            </span>
-                        </Td>
-                        <Td
-                            width={20}
-                            className="pf-u-pr-0 pf-u-text-align-center-on-md"
-                            dataLabel={columnNames.riskPriority}
-                        >
-                            {priority}
-                        </Td>
-                    </Tr>
-                ))}
+                {deployments.map(({ id, name, cluster, namespace, priority }) => {
+                    // @TODO: Consider a more secure approach to creating links to the network graph so that
+                    // areas outside of the Network Graph don't need to know the URL architecture of that feature
+                    // Reference to discussion: https://github.com/stackrox/stackrox/pull/4955#discussion_r1112450278
+                    const queryString = getQueryString({
+                        s: {
+                            Cluster: cluster,
+                            Namespace: namespace,
+                        },
+                    });
+                    const networkGraphLink = `${networkBasePathPF}/deployment/${id}${queryString}`;
+                    return (
+                        <Tr key={id}>
+                            <Td className="pf-u-pl-0" dataLabel={columnNames.deployment}>
+                                <Link to={riskPageLinkToDeployment(id, name, searchFilter)}>
+                                    <Truncate position="middle" content={name} />
+                                </Link>
+                            </Td>
+                            <Td width={45} dataLabel={columnNames.resourceLocation}>
+                                <span>
+                                    in &ldquo;
+                                    <Link to={networkGraphLink}>{`${cluster} / ${namespace}`}</Link>
+                                    &rdquo;
+                                </span>
+                            </Td>
+                            <Td
+                                width={20}
+                                className="pf-u-pr-0 pf-u-text-align-center-on-md"
+                                dataLabel={columnNames.riskPriority}
+                            >
+                                {priority}
+                            </Td>
+                        </Tr>
+                    );
+                })}
             </Tbody>
         </TableComposable>
     );

--- a/ui/apps/platform/src/Containers/Risk/RiskSidePanelContent.js
+++ b/ui/apps/platform/src/Containers/Risk/RiskSidePanelContent.js
@@ -7,6 +7,8 @@ import Tabs from 'Components/Tabs';
 import Tab from 'Components/Tab';
 import Loader from 'Components/Loader';
 
+import { getQueryString } from 'utils/queryStringUtils';
+import { networkBasePathPF } from 'routePaths';
 import RiskDetails from './RiskDetails';
 import DeploymentDetails from './DeploymentDetails';
 import ProcessDetails from './Process/Details';
@@ -39,13 +41,25 @@ function RiskSidePanelContent({ isFetching, selectedDeployment, deploymentRisk, 
         { text: 'Deployment Details' },
         { text: 'Process Discovery' },
     ];
+
+    // @TODO: Consider a more secure approach to creating links to the network graph so that
+    // areas outside of the Network Graph don't need to know the URL architecture of that feature
+    // Reference to discussion: https://github.com/stackrox/stackrox/pull/4955#discussion_r1112450278
+    const queryString = getQueryString({
+        s: {
+            Cluster: selectedDeployment.clusterName,
+            Namespace: selectedDeployment.namespace,
+        },
+    });
+    const networkGraphLink = `${networkBasePathPF}/deployment/${selectedDeployment.id}${queryString}`;
+
     return (
         <Tabs headers={riskPanelTabs}>
             <Tab>
                 <div className="flex flex-col pb-5">
                     <Link
                         className="btn btn-base h-10 no-underline mt-4 ml-3 mr-3"
-                        to={`/main/network/${selectedDeployment.id}`}
+                        to={networkGraphLink}
                         data-testid="view-deployments-in-network-graph-button"
                     >
                         View Deployment in Network Graph
@@ -88,6 +102,8 @@ RiskSidePanelContent.propTypes = {
     isFetching: PropTypes.bool.isRequired,
     selectedDeployment: PropTypes.shape({
         id: PropTypes.string.isRequired,
+        clusterName: PropTypes.string.isRequired,
+        namespace: PropTypes.string.isRequired,
     }),
     deploymentRisk: PropTypes.shape({}),
     processGroup: PropTypes.shape({


### PR DESCRIPTION
## Description

This PR changes links from the old Network Graph to the new Network Graph. The following are areas where I found links to the Network Graph:

1. The "Deployments at most risk" widget in the Dashboard section
2. Under the "Risk Indicators" tab in the Risk section

If there are any other areas I might have missed, let me know 

https://user-images.githubusercontent.com/4805485/220225102-402cef2f-ba27-46e5-a32d-5fe8dbac27fc.mov

https://user-images.githubusercontent.com/4805485/220225130-371b5ba5-8226-4295-83f2-1f5f58cfb01a.mov

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

