### PR TITLE
Do not change modules on lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,6 +4,7 @@ run:
   - pkg/complianceoperator/api
   build-tags:
   - sql_integration
+  modules-download-mode: readonly
 
 output:
   format: "junit-xml:report.xml,colored-line-number"

--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,7 @@ $(call go-tool, PROTOLOCK_BIN, github.com/nilslice/protolock/cmd/protolock, tool
 .PHONY: style
 style: golangci-lint roxvet blanks newlines check-service-protos no-large-files storage-protos-compatible ui-lint qa-tests-style shell-style
 
-.PHONY: golangci-lint
+.PHONY: golangci-lint deps
 golangci-lint: $(GOLANGCILINT_BIN)
 ifdef CI
 	@echo '+ $@'

--- a/Makefile
+++ b/Makefile
@@ -132,8 +132,8 @@ $(call go-tool, PROTOLOCK_BIN, github.com/nilslice/protolock/cmd/protolock, tool
 .PHONY: style
 style: golangci-lint roxvet blanks newlines check-service-protos no-large-files storage-protos-compatible ui-lint qa-tests-style shell-style
 
-.PHONY: golangci-lint deps
-golangci-lint: $(GOLANGCILINT_BIN)
+.PHONY: golangci-lint
+golangci-lint: $(GOLANGCILINT_BIN) deps
 ifdef CI
 	@echo '+ $@'
 	@echo 'The environment indicates we are in CI; running linters in check mode.'


### PR DESCRIPTION
## Description

Currently modules could be changed by linter. This PR disable this and require modules to be downloaded before.

> If set we pass it to "go list -mod={option}". From "go help modules":
> If invoked with -mod=readonly, the go command is disallowed from the implicit
> automatic updating of go.mod described above. Instead, it fails when any changes
>  to go.mod are needed. This setting is most useful to check that go.mod does
> not need updates, such as in a continuous integration and testing system.
> If invoked with -mod=vendor, the go command assumes that the vendor
> directory holds the correct copies of dependencies and ignores
> the dependency descriptions in go.mod.
https://golangci-lint.run/usage/configuration/
## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

CI