### PR TITLE
Sync roles in Sensor prior to role bindings

### DIFF
--- a/sensor/kubernetes/listener/resource_event_handler.go
+++ b/sensor/kubernetes/listener/resource_event_handler.go
@@ -36,6 +36,20 @@ func hasAPI(client kubernetes.Interface, gv, kind string) (bool, error) {
 	return false, nil
 }
 
+type startable interface {
+	Start(stopCh <-chan struct{})
+}
+
+func startManyAndWait(stopSignal *concurrency.Signal, wg *concurrency.WaitGroup, startables ...startable) bool {
+	for _, start := range startables {
+		if start == nil {
+			continue
+		}
+		start.Start(stopSignal.Done())
+	}
+	return concurrency.WaitInContext(wg, stopSignal)
+}
+
 func (k *listenerImpl) handleAllEvents() {
 	// TODO(ROX-14194): remove resyncingSif once all resources are adapted
 	var resyncingSif informers.SharedInformerFactory
@@ -106,26 +120,22 @@ func (k *listenerImpl) handleAllEvents() {
 
 	roleInformer := sif.Rbac().V1().Roles().Informer()
 	clusterRoleInformer := sif.Rbac().V1().ClusterRoles().Informer()
-	roleBindingInformer := resyncingSif.Rbac().V1().RoleBindings().Informer()
-	clusterRoleBindingInformer := resyncingSif.Rbac().V1().ClusterRoleBindings().Informer()
 
-	// prePodWaitGroup
-	prePodWaitGroup := &concurrency.WaitGroup{}
+	// The group that has no other object dependencies
+	noDependencyWaitGroup := &concurrency.WaitGroup{}
 
 	// we will single-thread event processing using this lock
 	var eventLock sync.Mutex
 	stopSignal := &k.stopSig
 
 	// Informers that need to be synced initially
-	handle(namespaceInformer, dispatchers.ForNamespaces(), k.outputQueue, &syncingResources, prePodWaitGroup, stopSignal, &eventLock)
-	handle(secretInformer, dispatchers.ForSecrets(), k.outputQueue, &syncingResources, prePodWaitGroup, stopSignal, &eventLock)
-	handle(saInformer, dispatchers.ForServiceAccounts(), k.outputQueue, &syncingResources, prePodWaitGroup, stopSignal, &eventLock)
+	handle(namespaceInformer, dispatchers.ForNamespaces(), k.outputQueue, &syncingResources, noDependencyWaitGroup, stopSignal, &eventLock)
+	handle(secretInformer, dispatchers.ForSecrets(), k.outputQueue, &syncingResources, noDependencyWaitGroup, stopSignal, &eventLock)
+	handle(saInformer, dispatchers.ForServiceAccounts(), k.outputQueue, &syncingResources, noDependencyWaitGroup, stopSignal, &eventLock)
 
-	// RBAC dispatchers handles multiple sets of data
-	handle(roleInformer, dispatchers.ForRBAC(), k.outputQueue, &syncingResources, prePodWaitGroup, stopSignal, &eventLock)
-	handle(clusterRoleInformer, dispatchers.ForRBAC(), k.outputQueue, &syncingResources, prePodWaitGroup, stopSignal, &eventLock)
-	handle(roleBindingInformer, dispatchers.ForRBAC(), k.outputQueue, &syncingResources, prePodWaitGroup, stopSignal, &eventLock)
-	handle(clusterRoleBindingInformer, dispatchers.ForRBAC(), k.outputQueue, &syncingResources, prePodWaitGroup, stopSignal, &eventLock)
+	// Roles need to be synced before role bindings because role bindings have a reference
+	handle(roleInformer, dispatchers.ForRBAC(), k.outputQueue, &syncingResources, noDependencyWaitGroup, stopSignal, &eventLock)
+	handle(clusterRoleInformer, dispatchers.ForRBAC(), k.outputQueue, &syncingResources, noDependencyWaitGroup, stopSignal, &eventLock)
 
 	var osConfigFactory osConfigExtVersions.SharedInformerFactory
 	if k.client.OpenshiftConfig() != nil {
@@ -140,31 +150,37 @@ func (k *listenerImpl) handleAllEvents() {
 	// For openshift clusters only
 	if osConfigFactory != nil {
 		handle(osConfigFactory.Config().V1().ClusterOperators().Informer(), dispatchers.ForClusterOperators(),
-			k.outputQueue, nil, prePodWaitGroup, stopSignal, &eventLock)
+			k.outputQueue, nil, noDependencyWaitGroup, stopSignal, &eventLock)
 	}
 
 	if crdSharedInformerFactory != nil {
 		log.Info("syncing compliance operator resources")
 		// Handle results, rules, and scan setting bindings first
-		handle(complianceResultInformer, dispatchers.ForComplianceOperatorResults(), k.outputQueue, &syncingResources, prePodWaitGroup, stopSignal, &eventLock)
-		handle(complianceRuleInformer, dispatchers.ForComplianceOperatorRules(), k.outputQueue, &syncingResources, prePodWaitGroup, stopSignal, &eventLock)
-		handle(complianceScanSettingBindingsInformer, dispatchers.ForComplianceOperatorScanSettingBindings(), k.outputQueue, &syncingResources, prePodWaitGroup, stopSignal, &eventLock)
-		handle(complianceScanInformer, dispatchers.ForComplianceOperatorScans(), k.outputQueue, &syncingResources, prePodWaitGroup, stopSignal, &eventLock)
+		handle(complianceResultInformer, dispatchers.ForComplianceOperatorResults(), k.outputQueue, &syncingResources, noDependencyWaitGroup, stopSignal, &eventLock)
+		handle(complianceRuleInformer, dispatchers.ForComplianceOperatorRules(), k.outputQueue, &syncingResources, noDependencyWaitGroup, stopSignal, &eventLock)
+		handle(complianceScanSettingBindingsInformer, dispatchers.ForComplianceOperatorScanSettingBindings(), k.outputQueue, &syncingResources, noDependencyWaitGroup, stopSignal, &eventLock)
+		handle(complianceScanInformer, dispatchers.ForComplianceOperatorScans(), k.outputQueue, &syncingResources, noDependencyWaitGroup, stopSignal, &eventLock)
 	}
 
-	sif.Start(stopSignal.Done())
-	resyncingSif.Start(stopSignal.Done())
-	if osConfigFactory != nil {
-		osConfigFactory.Start(stopSignal.Done())
-	}
-	if crdSharedInformerFactory != nil {
-		crdSharedInformerFactory.Start(stopSignal.Done())
-	}
-
-	if !concurrency.WaitInContext(prePodWaitGroup, stopSignal) {
+	if !startManyAndWait(stopSignal, noDependencyWaitGroup, sif, resyncingSif, osConfigFactory, crdSharedInformerFactory) {
 		return
 	}
-	log.Info("Successfully synced namespaces, secrets, service accounts, roles and role bindings")
+	log.Info("Successfully synced secrets, service accounts and roles")
+
+	// prePodWaitGroup
+	prePodWaitGroup := &concurrency.WaitGroup{}
+
+	roleBindingInformer := resyncingSif.Rbac().V1().RoleBindings().Informer()
+	clusterRoleBindingInformer := resyncingSif.Rbac().V1().ClusterRoleBindings().Informer()
+
+	handle(roleBindingInformer, dispatchers.ForRBAC(), k.outputQueue, &syncingResources, prePodWaitGroup, stopSignal, &eventLock)
+	handle(clusterRoleBindingInformer, dispatchers.ForRBAC(), k.outputQueue, &syncingResources, prePodWaitGroup, stopSignal, &eventLock)
+
+	if !startManyAndWait(stopSignal, prePodWaitGroup, resyncingSif) {
+		return
+	}
+
+	log.Info("Successfully synced role bindings")
 
 	// Wait for the pod informer to sync before processing other types.
 	// This is required because the PodLister is used to populate the image ids of deployments.


### PR DESCRIPTION
## Description

Sync roles prior to role bindings due to dependencies on role id. I saw this when doing some other deduping work and saw that bindings were breaking the deduping logic

Master vs this PR events locally:
```
sensor_event_queue Operation=Add Type=Role (old: 91.00, new 91.00): change: 0.0000%
sensor_event_queue Operation=Add Type=Binding (old: 136.00, new 78.00): change: -42.6471%
```

```
postgres_table_size table=role_bindings                                          78
```

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Should see fewer role bindings events