### PR TITLE
Refactor compliance connection to sensor

### DIFF
--- a/compliance/collection/main.go
+++ b/compliance/collection/main.go
@@ -146,7 +146,6 @@ func manageSendToSensor(ctx context.Context, cli sensor.ComplianceService_Commun
 	for {
 		select {
 		case <-ctx.Done():
-			log.Infof("Child context cancelled. Stopping manageSendToSensor")
 			return
 		case sc := <-sensorC:
 			if err := cli.Send(sc); err != nil {


### PR DESCRIPTION
## Description

In the current state, compliance calls the `Communicate` function every time it wants to send something. This will orphan the gRPC stub created in `manageReceivedStream`, thus making sensor unable to send any messages to compliance.

This PR aims to solve this problem by reusing the same gRPC stub for receiving and sending messages from/to sensor (tracked in [ROX-15100](https://issues.redhat.com/browse/ROX-15100)).

See: 
* [ROX-13383](https://issues.redhat.com/browse/ROX-13383)

## Checklist
- [ ] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

* Manual testing in a maple team mob session
    * Build ACS with the following variables:
     ```
     ROX_POSTGRES_DATASTORE         = true
     ROX_RHCOS_FAKE_NODE_INVENTORY  = true
     ROX_NODE_RESCAN_INTERVAL       = 10s
     ROX_RHCOS_NODE_SCANNING        = true
     ```
    * Deploy with ACS with `deploy/k8s/deploy-local.sh`
    * Set the re-scan interval with: `kubectl -n stackrox set env ds/collector ROX_NODE_RESCAN_INTERVAL=$ROX_NODE_RESCAN_INTERVAL`
    * We should see logs in sensor and compliance of the scans being done.
    * In the UI go to `Compliance` and click on `Scan Environment`
    * We should see logs in sensor and compliance of the `scrape` being started.
    * Kill sensor and check everything should recover.
    * Kill compliance and check everything should recover.
