### PR TITLE
ROX-15102: Prefactoring, add Enable and Disable functions

### DIFF
--- a/central/main.go
+++ b/central/main.go
@@ -182,7 +182,6 @@ import (
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/sac/observe"
 	"github.com/stackrox/rox/pkg/sync"
-	"github.com/stackrox/rox/pkg/telemetry/phonehome/telemeter"
 	"github.com/stackrox/rox/pkg/utils"
 	pkgVersion "github.com/stackrox/rox/pkg/version"
 )
@@ -319,10 +318,6 @@ func startServices() {
 	gatherer.Singleton().Start()
 	vulnRequestManager.Singleton().Start()
 
-	if cfg := centralclient.InstanceConfig(); cfg.Enabled() {
-		cfg.Gatherer().Start(telemeter.WithGroups(cfg.GroupType, cfg.GroupID))
-	}
-
 	go registerDelayedIntegrations(iiStore.DelayedIntegrations)
 }
 
@@ -426,13 +421,6 @@ func servicesToRegister(registry authproviders.Registry, authzTraceSink observe.
 		servicesToRegister = append(servicesToRegister, developmentService.Singleton())
 	}
 
-	if cfg := centralclient.InstanceConfig(); cfg.Enabled() {
-		gs := cfg.Gatherer()
-		gs.AddGatherer(authProviderDS.Gather)
-		gs.AddGatherer(signatureIntegrationDS.Gather)
-		gs.AddGatherer(roleDataStore.Gather)
-		gs.AddGatherer(clusterDataStore.Gather)
-	}
 	return servicesToRegister
 }
 
@@ -541,12 +529,19 @@ func startGRPCServer() {
 	)
 	config.HTTPInterceptors = append(config.HTTPInterceptors, observe.AuthzTraceHTTPInterceptor(authzTraceSink))
 
-	centralclient.RegisterCentralClient(&config, basicAuthProvider.ID())
-
 	// Before authorization is checked, we want to inject the sac client into the context.
 	config.PreAuthContextEnrichers = append(config.PreAuthContextEnrichers,
 		centralSAC.GetEnricher().GetPreAuthContextEnricher(authzTraceSink),
 	)
+
+	if cfg := centralclient.Enable(); cfg.Enabled() {
+		centralclient.RegisterCentralClient(&config, basicAuthProvider.ID())
+		gs := cfg.Gatherer()
+		gs.AddGatherer(authProviderDS.Gather)
+		gs.AddGatherer(signatureIntegrationDS.Gather)
+		gs.AddGatherer(roleDataStore.Gather)
+		gs.AddGatherer(clusterDataStore.Gather)
+	}
 
 	server := pkgGRPC.NewAPI(config)
 	server.Register(servicesToRegister(registry, authzTraceSink)...)

--- a/central/telemetry/centralclient/instance_config.go
+++ b/central/telemetry/centralclient/instance_config.go
@@ -28,6 +28,9 @@ var (
 	config *phonehome.Config
 	once   sync.Once
 	log    = logging.LoggerForModule()
+
+	startMux sync.RWMutex
+	enabled  bool
 )
 
 func getInstanceConfig() (*phonehome.Config, map[string]any, error) {
@@ -108,43 +111,81 @@ func InstanceConfig() *phonehome.Config {
 		log.Info("Tenant ID: ", config.GroupID)
 		log.Info("API path telemetry enabled for: ", trackedPaths)
 
-		for event, funcs := range interceptors {
-			for _, f := range funcs {
-				config.AddInterceptorFunc(event, f)
-			}
-		}
-
 		config.Gatherer().AddGatherer(func(ctx context.Context) (map[string]any, error) {
 			return props, nil
 		})
 	})
+	startMux.RLock()
+	defer startMux.RUnlock()
+	if !enabled {
+		// This will make InstanceConfig().Enabled() to return false, while
+		// keeping the config configured for eventual Start().
+		return nil
+	}
 	return config
 }
 
 // RegisterCentralClient adds call interceptors, adds central and admin user
 // to the tenant group.
-func RegisterCentralClient(config *grpc.Config, basicAuthProviderID string) {
-	cfg := InstanceConfig()
+func RegisterCentralClient(gc *grpc.Config, basicAuthProviderID string) {
+	cfg := config
 	if !cfg.Enabled() {
 		return
 	}
-	registerInterceptors(config)
+	registerInterceptors(gc)
 	// Central adds itself to the tenant group, with no group properties:
 	cfg.Telemeter().Group(nil, telemeter.WithGroups(cfg.GroupType, cfg.GroupID))
 	registerAdminUser(basicAuthProviderID)
 }
 
-func registerInterceptors(config *grpc.Config) {
-	cfg := InstanceConfig()
-	config.HTTPInterceptors = append(config.HTTPInterceptors, cfg.GetHTTPInterceptor())
-	config.UnaryInterceptors = append(config.UnaryInterceptors, cfg.GetGRPCInterceptor())
+func registerInterceptors(gc *grpc.Config) {
+	cfg := config
+	gc.HTTPInterceptors = append(gc.HTTPInterceptors, cfg.GetHTTPInterceptor())
+	gc.UnaryInterceptors = append(gc.UnaryInterceptors, cfg.GetGRPCInterceptor())
 }
 
 // registerAdminUser adds the local admin user to the tenant group.
 // This user is not added to the datastore like other users, so we need to add
 // it to the tenant group specifically.
 func registerAdminUser(basicAuthProviderID string) {
-	cfg := InstanceConfig()
+	cfg := config
 	adminHash := cfg.HashUserID(basic.DefaultUsername, basicAuthProviderID)
 	cfg.Telemeter().Group(nil, telemeter.WithUserID(adminHash), telemeter.WithGroups(cfg.GroupType, cfg.GroupID))
+}
+
+// Disable stops and disables the telemetry collection.
+func Disable() {
+	startMux.Lock()
+	defer startMux.Unlock()
+	cfg := config
+	if !enabled || !cfg.Enabled() {
+		return
+	}
+	cfg.Gatherer().Stop()
+	cfg.RemoveInterceptors()
+	enabled = false
+	log.Info("Telemetry collection has been disabled.")
+}
+
+// Enable enables and starts the telemetry collection.
+func Enable() *phonehome.Config {
+	InstanceConfig()
+
+	startMux.Lock()
+	defer startMux.Unlock()
+	// Use config as InstanceConfig may return nil for not yet running instance.
+	cfg := config
+	if enabled || !cfg.Enabled() {
+		return nil
+	}
+	cfg.RemoveInterceptors()
+	for event, funcs := range interceptors {
+		for _, f := range funcs {
+			cfg.AddInterceptorFunc(event, f)
+		}
+	}
+	cfg.Gatherer().Start(telemeter.WithGroups(cfg.GroupType, cfg.GroupID))
+	enabled = true
+	log.Info("Telemetry collection has been enabled.")
+	return cfg
 }

--- a/central/telemetry/centralclient/instance_config.go
+++ b/central/telemetry/centralclient/instance_config.go
@@ -169,14 +169,19 @@ func Disable() {
 
 // Enable enables and starts the telemetry collection.
 func Enable() *phonehome.Config {
+	// Prepare the configuration.
 	InstanceConfig()
 
 	startMux.Lock()
 	defer startMux.Unlock()
-	// Use config as InstanceConfig may return nil for not yet running instance.
+	// Use config as InstanceConfig may return nil for not yet enabled instance.
 	cfg := config
-	if enabled || !cfg.Enabled() {
+	if !cfg.Enabled() {
+		// Cannot enable without proper configuration.
 		return nil
+	}
+	if enabled {
+		return cfg
 	}
 	cfg.RemoveInterceptors()
 	for event, funcs := range interceptors {

--- a/pkg/telemetry/phonehome/client_config.go
+++ b/pkg/telemetry/phonehome/client_config.go
@@ -112,6 +112,13 @@ func (cfg *Config) AddInterceptorFunc(event string, f Interceptor) {
 	cfg.interceptors[event] = append(cfg.interceptors[event], f)
 }
 
+// RemoveInterceptors cleans up the list of telemetry interceptors.
+func (cfg *Config) RemoveInterceptors() {
+	cfg.interceptorsLock.Lock()
+	defer cfg.interceptorsLock.Unlock()
+	cfg.interceptors = nil
+}
+
 // GetGRPCInterceptor returns an API interceptor function for GRPC requests.
 func (cfg *Config) GetGRPCInterceptor() grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {


### PR DESCRIPTION
## Description

This PR adds a functionality to enable or disable (i.e. to use or not to use) a configured central telemetry client.

A telemetry client is configured (`Config.Enabled() == true`) when a storage key is provided via the environment variable.
On top of that, central may decide to not use the configured client if the user tells it so. If there's no key provided, central can not enable the collection.

Following PRs will add an API to trigger the client enablement, and use of a storage to persist the setting.

The envisaged solution is described in more details here: https://docs.engineering.redhat.com/display/StackRox/Opt-out

## Checklist
- [x] Investigated and inspected CI test results
- [ ] ~Unit test and regression tests added~
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~


## Testing Performed

See #4977 for the API test scenario.
