### PR TITLE
ROX-14436 route handler sends deploymentReference to the resolver

### DIFF
--- a/sensor/kubernetes/listener/resources/route.go
+++ b/sensor/kubernetes/listener/resources/route.go
@@ -44,7 +44,10 @@ func (r *routeDispatcher) ProcessEvent(obj, _ interface{}, action central.Resour
 	if existingService == nil {
 		return nil
 	}
+	// If re-sync is disabled, we do not call UpdateExposuresForMatchingDeployments,
+	// and instead we send all matching deployments to reprocess.
 	if env.ResyncDisabled.BooleanSetting() {
+		// We do not append any Route event here because Routes, just like Services, are not tracked by central.
 		event := component.NewEvent()
 		event.AddDeploymentReference(resolver.ResolveDeploymentLabels(existingService.GetNamespace(), existingService.selector), central.ResourceAction_UPDATE_RESOURCE, false)
 		return event


### PR DESCRIPTION
## Description

The route handler sends related deploymentReferences to the resolver.

* ~Depends on: #5250~

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

* Manual tests in an OCP cluster
* e2e tests running in CI
* e2e tests will be enhanced in #5250
