### PR TITLE
ROX-14020: Remove policy table from namespace in vuln mgmt

### DIFF
--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Namespace/VulnMgmtNamespaceOverview.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Namespace/VulnMgmtNamespaceOverview.js
@@ -1,25 +1,20 @@
 import React, { useContext } from 'react';
 import { Link } from 'react-router-dom';
-import pluralize from 'pluralize';
 
 import CollapsibleSection from 'Components/CollapsibleSection';
 import StatusChip from 'Components/StatusChip';
 import RiskScore from 'Components/RiskScore';
 import Metadata from 'Components/Metadata';
-import BinderTabs from 'Components/BinderTabs';
-import Tab from 'Components/Tab';
 import entityTypes from 'constants/entityTypes';
 import workflowStateContext from 'Containers/workflowStateContext';
 import TopRiskyEntitiesByVulnerabilities from 'Containers/VulnMgmt/widgets/TopRiskyEntitiesByVulnerabilities';
 import RecentlyDetectedImageVulnerabilities from 'Containers/VulnMgmt/widgets/RecentlyDetectedImageVulnerabilities';
 import TopRiskiestEntities from 'Containers/VulnMgmt/widgets/TopRiskiestEntities';
-import { getPolicyTableColumns } from 'Containers/VulnMgmt/List/Policies/VulnMgmtListPolicies';
 import { entityGridContainerClassName } from 'Containers/Workflow/WorkflowEntityPage';
 import useFeatureFlags from 'hooks/useFeatureFlags';
 
 import RelatedEntitiesSideList from '../RelatedEntitiesSideList';
 import TableWidgetFixableCves from '../TableWidgetFixableCves';
-import TableWidget from '../TableWidget';
 
 const emptyNamespace = {
     deploymentCount: 0,
@@ -59,7 +54,7 @@ const VulnMgmtNamespaceOverview = ({ data, entityContext }) => {
     }
 
     const { clusterName, clusterId, priority, labels, id } = metadata;
-    const { failingPolicies, status } = policyStatus;
+    const { status } = policyStatus;
     const metadataKeyValuePairs = [];
 
     if (!entityContext[entityTypes.CLUSTER]) {
@@ -117,34 +112,14 @@ const VulnMgmtNamespaceOverview = ({ data, entityContext }) => {
                 </CollapsibleSection>
                 <CollapsibleSection title="Namespace findings">
                     <div className="flex pdf-page pdf-stretch pdf-new relative rounded mb-4 ml-4 mr-4">
-                        <BinderTabs>
-                            <Tab title="Policies">
-                                <TableWidget
-                                    header={`${failingPolicies.length} failing ${pluralize(
-                                        entityTypes.POLICY,
-                                        failingPolicies.length
-                                    )} across this namespace`}
-                                    entityType={entityTypes.POLICY}
-                                    rows={failingPolicies}
-                                    noDataText="No failing policies"
-                                    className="bg-base-100"
-                                    columns={getPolicyTableColumns(workflowState)}
-                                    idAttribute="id"
-                                />
-                            </Tab>
-                            <Tab title="Fixable CVEs">
-                                <TableWidgetFixableCves
-                                    workflowState={workflowState}
-                                    entityContext={entityContext}
-                                    entityType={entityTypes.NAMESPACE}
-                                    name={safeData?.metadata?.name}
-                                    id={safeData?.metadata?.id}
-                                    vulnType={
-                                        showVMUpdates ? entityTypes.IMAGE_CVE : entityTypes.CVE
-                                    }
-                                />
-                            </Tab>
-                        </BinderTabs>
+                        <TableWidgetFixableCves
+                            workflowState={workflowState}
+                            entityContext={entityContext}
+                            entityType={entityTypes.NAMESPACE}
+                            name={safeData?.metadata?.name}
+                            id={safeData?.metadata?.id}
+                            vulnType={showVMUpdates ? entityTypes.IMAGE_CVE : entityTypes.CVE}
+                        />
                     </div>
                 </CollapsibleSection>
             </div>


### PR DESCRIPTION
## Description

Remove the policies table from namespace in vulnerability management.

The table on its own doesn't provide as much context as the violations page. The same information can be found on the violations page, which the field team confirmed can be confusing to customers.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

![Screenshot 2023-02-22 at 1 10 49 PM](https://user-images.githubusercontent.com/61400697/220741149-4a508c04-e699-492c-b474-30e02835b51e.png)
