### PR TITLE
ROX-14018: Remove policy table from deployment in vuln mgmt

### DIFF
--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Deployment/VulnMgmtDeploymentOverview.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Deployment/VulnMgmtDeploymentOverview.js
@@ -1,27 +1,22 @@
 import React, { useContext } from 'react';
 import { Link } from 'react-router-dom';
-import pluralize from 'pluralize';
 
 import CollapsibleSection from 'Components/CollapsibleSection';
 import Metadata from 'Components/Metadata';
 import RiskScore from 'Components/RiskScore';
 import StatusChip from 'Components/StatusChip';
-import BinderTabs from 'Components/BinderTabs';
-import Tab from 'Components/Tab';
 import entityTypes from 'constants/entityTypes';
 import CvesByCvssScore from 'Containers/VulnMgmt/widgets/CvesByCvssScore';
 import RecentlyDetectedImageVulnerabilities from 'Containers/VulnMgmt/widgets/RecentlyDetectedImageVulnerabilities';
 import MostCommonVulnerabiltiesInDeployment from 'Containers/VulnMgmt/widgets/MostCommonVulnerabiltiesInDeployment';
 import TopRiskiestEntities from 'Containers/VulnMgmt/widgets/TopRiskiestEntities';
 import workflowStateContext from 'Containers/workflowStateContext';
-import { getPolicyTableColumns } from 'Containers/VulnMgmt/List/Policies/VulnMgmtListPolicies';
 import { entityGridContainerClassName } from 'Containers/Workflow/WorkflowEntityPage';
 import ViolationsAcrossThisDeployment from 'Containers/Workflow/widgets/ViolationsAcrossThisDeployment';
 import useFeatureFlags from 'hooks/useFeatureFlags';
 
 import RelatedEntitiesSideList from '../RelatedEntitiesSideList';
 import TableWidgetFixableCves from '../TableWidgetFixableCves';
-import TableWidget from '../TableWidget';
 
 const emptyDeployment = {
     annotations: [],
@@ -51,17 +46,8 @@ const VulnMgmtDeploymentOverview = ({ data, entityContext }) => {
     // guard against incomplete GraphQL-cached data
     const safeData = { ...emptyDeployment, ...data };
 
-    const {
-        id,
-        cluster,
-        priority,
-        namespace,
-        namespaceId,
-        policyStatus,
-        failingPolicies,
-        labels,
-        annotations,
-    } = safeData;
+    const { id, cluster, priority, namespace, namespaceId, policyStatus, labels, annotations } =
+        safeData;
 
     const metadataKeyValuePairs = [];
 
@@ -109,31 +95,14 @@ const VulnMgmtDeploymentOverview = ({ data, entityContext }) => {
     } else {
         deploymentFindingsContent = (
             <div className="flex pdf-page pdf-stretch pdf-new relative rounded mb-4 ml-4 mr-4">
-                <BinderTabs>
-                    <Tab title="Policies">
-                        <TableWidget
-                            header={`${failingPolicies.length} failing ${pluralize(
-                                entityTypes.POLICY,
-                                failingPolicies.length
-                            )} across this deployment`}
-                            rows={failingPolicies}
-                            entityType={entityTypes.POLICY}
-                            noDataText="No failing policies"
-                            className="bg-base-100"
-                            columns={getPolicyTableColumns(workflowState)}
-                        />
-                    </Tab>
-                    <Tab title="Fixable CVEs">
-                        <TableWidgetFixableCves
-                            workflowState={workflowState}
-                            entityContext={entityContext}
-                            entityType={entityTypes.DEPLOYMENT}
-                            name={safeData?.name}
-                            id={safeData?.id}
-                            vulnType={showVMUpdates ? entityTypes.IMAGE_CVE : entityTypes.CVE}
-                        />
-                    </Tab>
-                </BinderTabs>
+                <TableWidgetFixableCves
+                    workflowState={workflowState}
+                    entityContext={entityContext}
+                    entityType={entityTypes.DEPLOYMENT}
+                    name={safeData?.name}
+                    id={safeData?.id}
+                    vulnType={showVMUpdates ? entityTypes.IMAGE_CVE : entityTypes.CVE}
+                />
             </div>
         );
     }


### PR DESCRIPTION
## Description

Remove the policies table from deployment in vulnerability management.

The table on its own doesn't provide as much context as the violations page. The same information can be found on the violations page, which the field team confirmed can be confusing to customers.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

![Screenshot 2023-02-22 at 1 37 47 PM](https://user-images.githubusercontent.com/61400697/220741842-ec7169be-b3d8-4193-b66a-87878a768ebc.png)
