### PR TITLE
ROX-15109: Replace tippy with PatternFly tooltip

### DIFF
--- a/ui/apps/platform/cypress/constants/RiskPage.js
+++ b/ui/apps/platform/cypress/constants/RiskPage.js
@@ -118,7 +118,7 @@ export const selectors = {
     eventTimelineOverviewButton: 'button[data-testid="event-timeline-overview"]',
     tooltip: {
         ...tooltipSelectors,
-        legendContents: `${tooltipSelectors.overlay} > div`,
+        legendContents: `${tooltipSelectors.overlay} .pf-c-tooltip__content`,
         legendContent: {
             event: eventSelectors,
         },

--- a/ui/apps/platform/cypress/integration/risk/deploymentTimeline.test.js
+++ b/ui/apps/platform/cypress/integration/risk/deploymentTimeline.test.js
@@ -550,37 +550,43 @@ describe('Risk Page Deployment Event Timeline', () => {
             cy.get(selectors.eventTimeline.legend).click();
 
             // make sure the process activity icon and text shows up
-            cy.get(`${selectors.tooltip.legendContents}:eq(0):contains("Process Activity")`);
             cy.get(
-                `${selectors.tooltip.legendContents}:eq(0) ${selectors.tooltip.legendContent.event.processActivity}`
+                `${selectors.tooltip.legendContents} [data-testid="timeline-legend-items"] div:eq(0):contains("Process Activity")`
+            );
+            cy.get(
+                `${selectors.tooltip.legendContents} [data-testid="timeline-legend-items"] div:eq(0) ${selectors.tooltip.legendContent.event.processActivity}`
             );
 
             // make sure the policy violation icon and text shows up
             cy.get(
-                `${selectors.tooltip.legendContents}:eq(1):contains("Process Activity with Violation")`
+                `${selectors.tooltip.legendContents} [data-testid="timeline-legend-items"] div:eq(1):contains("Process Activity with Violation")`
             );
             cy.get(
-                `${selectors.tooltip.legendContents}:eq(1) ${selectors.tooltip.legendContent.event.policyViolation}`
+                `${selectors.tooltip.legendContents} [data-testid="timeline-legend-items"] div:eq(1) ${selectors.tooltip.legendContent.event.policyViolation}`
             );
 
             // make sure the process in baseline activity icon and text shows up
             cy.get(
-                `${selectors.tooltip.legendContents}:eq(2):contains("Baseline Process Activity")`
+                `${selectors.tooltip.legendContents} [data-testid="timeline-legend-items"] div:eq(2):contains("Baseline Process Activity")`
             );
             cy.get(
-                `${selectors.tooltip.legendContents}:eq(2) ${selectors.tooltip.legendContent.event.processInBaselineActivity}`
+                `${selectors.tooltip.legendContents} [data-testid="timeline-legend-items"] div:eq(2) ${selectors.tooltip.legendContent.event.processInBaselineActivity}`
             );
 
             // make sure the container restart icon and text shows up
-            cy.get(`${selectors.tooltip.legendContents}:eq(3):contains("Container Restart")`);
             cy.get(
-                `${selectors.tooltip.legendContents}:eq(3) ${selectors.tooltip.legendContent.event.restart}`
+                `${selectors.tooltip.legendContents} [data-testid="timeline-legend-items"] div:eq(3):contains("Container Restart")`
+            );
+            cy.get(
+                `${selectors.tooltip.legendContents} [data-testid="timeline-legend-items"] div:eq(3) ${selectors.tooltip.legendContent.event.restart}`
             );
 
             // make sure the container termination icon and text shows up
-            cy.get(`${selectors.tooltip.legendContents}:eq(4):contains("Container Termination")`);
             cy.get(
-                `${selectors.tooltip.legendContents}:eq(4) ${selectors.tooltip.legendContent.event.termination}`
+                `${selectors.tooltip.legendContents} [data-testid="timeline-legend-items"] div:eq(4):contains("Container Termination")`
+            );
+            cy.get(
+                `${selectors.tooltip.legendContents} [data-testid="timeline-legend-items"] div:eq(4) ${selectors.tooltip.legendContent.event.termination}`
             );
         });
     });

--- a/ui/apps/platform/cypress/integration/risk/podTimeline.test.js
+++ b/ui/apps/platform/cypress/integration/risk/podTimeline.test.js
@@ -459,35 +459,39 @@ describe('Risk Page Pod Event Timeline', () => {
             // make sure the process activity icon and text shows up
             cy.get(`${selectors.tooltip.legendContents}:eq(0):contains("Process Activity")`);
             cy.get(
-                `${selectors.tooltip.legendContents}:eq(0) ${selectors.tooltip.legendContent.event.processActivity}`
+                `${selectors.tooltip.legendContents} [data-testid="timeline-legend-items"] div:eq(0) ${selectors.tooltip.legendContent.event.processActivity}`
             );
 
             // make sure the policy violation icon and text shows up
             cy.get(
-                `${selectors.tooltip.legendContents}:eq(1):contains("Process Activity with Violation")`
+                `${selectors.tooltip.legendContents} [data-testid="timeline-legend-items"] div:eq(1):contains("Process Activity with Violation")`
             );
             cy.get(
-                `${selectors.tooltip.legendContents}:eq(1) ${selectors.tooltip.legendContent.event.policyViolation}`
+                `${selectors.tooltip.legendContents} [data-testid="timeline-legend-items"] div:eq(1) ${selectors.tooltip.legendContent.event.policyViolation}`
             );
 
             // make sure the process in baseline activity icon and text shows up
             cy.get(
-                `${selectors.tooltip.legendContents}:eq(2):contains("Baseline Process Activity")`
+                `${selectors.tooltip.legendContents} [data-testid="timeline-legend-items"] div:eq(2):contains("Baseline Process Activity")`
             );
             cy.get(
-                `${selectors.tooltip.legendContents}:eq(2) ${selectors.tooltip.legendContent.event.processInBaselineActivity}`
+                `${selectors.tooltip.legendContents} [data-testid="timeline-legend-items"] div:eq(2) ${selectors.tooltip.legendContent.event.processInBaselineActivity}`
             );
 
             // make sure the container restart icon and text shows up
-            cy.get(`${selectors.tooltip.legendContents}:eq(3):contains("Container Restart")`);
             cy.get(
-                `${selectors.tooltip.legendContents}:eq(3) ${selectors.tooltip.legendContent.event.restart}`
+                `${selectors.tooltip.legendContents} [data-testid="timeline-legend-items"] div:eq(3):contains("Container Restart")`
+            );
+            cy.get(
+                `${selectors.tooltip.legendContents} [data-testid="timeline-legend-items"] div:eq(3) ${selectors.tooltip.legendContent.event.restart}`
             );
 
             // make sure the container termination icon and text shows up
-            cy.get(`${selectors.tooltip.legendContents}:eq(4):contains("Container Termination")`);
             cy.get(
-                `${selectors.tooltip.legendContents}:eq(4) ${selectors.tooltip.legendContent.event.termination}`
+                `${selectors.tooltip.legendContents} [data-testid="timeline-legend-items"] div:eq(4):contains("Container Termination")`
+            );
+            cy.get(
+                `${selectors.tooltip.legendContents} [data-testid="timeline-legend-items"] div:eq(4) ${selectors.tooltip.legendContent.event.termination}`
             );
         });
     });

--- a/ui/apps/platform/cypress/selectors/tooltip.js
+++ b/ui/apps/platform/cypress/selectors/tooltip.js
@@ -5,7 +5,7 @@
 const tooltip = {
     title: '[data-testid="tooltip-title"]',
     body: '[data-testid="tooltip-body"]',
-    overlay: '.rox-tooltip-overlay',
+    overlay: '.pf-c-tooltip',
 };
 
 export default tooltip;

--- a/ui/apps/platform/src/Components/CVEStackedPill/CVEStackedPill.js
+++ b/ui/apps/platform/src/Components/CVEStackedPill/CVEStackedPill.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { AlertTriangle } from 'react-feather';
+import { Tooltip } from '@patternfly/react-core';
 
-import { Tooltip, DetailedTooltipOverlay } from '@stackrox/ui-components';
-
+import DetailedTooltipContent from 'Components/DetailedTooltipContent';
 import FixableCVECount from 'Components/FixableCVECount';
 import SeverityStackedPill from 'Components/visuals/SeverityStackedPill';
 
@@ -84,7 +84,7 @@ const CVEStackedPill = ({
                 <Tooltip
                     type="alert"
                     content={
-                        <DetailedTooltipOverlay
+                        <DetailedTooltipContent
                             extraClassName="text-alert-800"
                             title="CVE Data May Be Inaccurate"
                             subtitle={scanMessage?.header}

--- a/ui/apps/platform/src/Components/DetailedTooltipContent.tsx
+++ b/ui/apps/platform/src/Components/DetailedTooltipContent.tsx
@@ -1,0 +1,42 @@
+import React, { ReactElement, ReactNode } from 'react';
+import { Divider, Text, TextVariants } from '@patternfly/react-core';
+
+export type DetailedTooltipContentProps = {
+    title: string;
+    subtitle?: string;
+    body: ReactNode;
+    footer?: ReactNode;
+    extraClassName?: string;
+};
+
+/**
+ * Alternative to {@link TooltipOverlay} that provides layout for complex tooltip content with
+ * title, subtitle and footer in addition to the main body.
+ */
+function DetailedTooltipContent({
+    title,
+    subtitle,
+    body,
+    footer,
+    extraClassName = '',
+}: DetailedTooltipContentProps): ReactElement | null {
+    if (!title || !body) {
+        return null;
+    }
+
+    return (
+        <div className={extraClassName}>
+            <div>
+                <Text className="pf-u-font-weight-bold" component={TextVariants.h3} data-testid="tooltip-title">
+                    {title}
+                </Text>
+                {!!subtitle && <span data-testid="tooltip-subtitle">{subtitle}</span>}
+            </div>
+            <Divider />
+            <div data-testid="tooltip-body">{body}</div>
+            {!!footer && <footer data-testid="tooltip-footer">{footer}</footer>}
+        </div>
+    );
+}
+
+export default DetailedTooltipContent;

--- a/ui/apps/platform/src/Components/DetailedTooltipContent.tsx
+++ b/ui/apps/platform/src/Components/DetailedTooltipContent.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, ReactNode } from 'react';
+import React, { ReactElement, ReactNode, CSSProperties } from 'react';
 import { Divider, Text, TextVariants } from '@patternfly/react-core';
 
 export type DetailedTooltipContentProps = {
@@ -24,10 +24,19 @@ function DetailedTooltipContent({
         return null;
     }
 
+    const styleConstant = {
+        overflow: 'scroll',
+        '--pf-u-max-height--MaxHeight': '75vh',
+    } as CSSProperties;
+
     return (
-        <div className={extraClassName}>
+        <div className={`pf-u-max-height ${extraClassName}`} style={styleConstant}>
             <div>
-                <Text className="pf-u-font-weight-bold" component={TextVariants.h3} data-testid="tooltip-title">
+                <Text
+                    className="pf-u-font-weight-bold"
+                    component={TextVariants.h3}
+                    data-testid="tooltip-title"
+                >
                     {title}
                 </Text>
                 {!!subtitle && <span data-testid="tooltip-subtitle">{subtitle}</span>}

--- a/ui/apps/platform/src/Components/Menu.tsx
+++ b/ui/apps/platform/src/Components/Menu.tsx
@@ -1,8 +1,7 @@
 import React, { useState, ReactElement } from 'react';
 import { Link } from 'react-router-dom';
 import { ChevronDown, ChevronUp } from 'react-feather';
-
-import { Tooltip, TooltipOverlay } from '@stackrox/ui-components';
+import { Tooltip } from '@patternfly/react-core';
 
 const optionsClass =
     'flex items-center relative text-left px-2 py-3 text-sm border-b border-base-400 hover:bg-base-200 capitalize';
@@ -121,7 +120,7 @@ const Menu = ({
 
     const tooltipClassName = !tooltip || disabled ? 'invisible' : '';
     return (
-        <Tooltip content={<TooltipOverlay>{tooltip}</TooltipOverlay>} className={tooltipClassName}>
+        <Tooltip content={tooltip} className={tooltipClassName}>
             <div className={`${className} inline-block relative z-10`}>
                 <button
                     className={`flex h-full w-full ${buttonClass}`}

--- a/ui/apps/platform/src/Components/NumberedList/NumberedList.js
+++ b/ui/apps/platform/src/Components/NumberedList/NumberedList.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
+import { Tooltip } from '@patternfly/react-core';
 
-import { Tooltip, DetailedTooltipOverlay } from '@stackrox/ui-components';
+import DetailedTooltipContent from 'Components/DetailedTooltipContent';
 
 const leftSideClasses = 'p-2 text-sm text-primary-800 font-600 w-full';
 
@@ -59,8 +60,9 @@ const NumberedList = ({ data, linkLeftOnly }) => {
             <li key={text + subText + url} className={className}>
                 {tooltip && (
                     <Tooltip
+                        isContentLeftAligned
                         content={
-                            <DetailedTooltipOverlay
+                            <DetailedTooltipContent
                                 title={tooltip.title}
                                 body={tooltip.body}
                                 subtitle={tooltip.subtitle}

--- a/ui/apps/platform/src/Components/Panel.js
+++ b/ui/apps/platform/src/Components/Panel.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Tooltip } from '@patternfly/react-core';
 
-import { Tooltip, TooltipOverlay } from '@stackrox/ui-components';
 import CloseButton from './CloseButton';
 
 /*
@@ -39,7 +39,7 @@ export function PanelTitle({ isUpperCase = false, testid = '', breakAll = true, 
             }`}
             data-testid={testid || null}
         >
-            <Tooltip content={<TooltipOverlay>{text}</TooltipOverlay>}>
+            <Tooltip content={text}>
                 <div className={`line-clamp ${breakAll ? 'break-all' : ''}`}>{text}</div>
             </Tooltip>
         </div>
@@ -96,7 +96,7 @@ const Panel = (props) => (
                         }`}
                         data-testid={`${props.id}-header`}
                     >
-                        <Tooltip content={<TooltipOverlay>{props.header}</TooltipOverlay>}>
+                        <Tooltip content={props.header}>
                             <div className="line-clamp break-all">{props.header}</div>
                         </Tooltip>
                     </div>

--- a/ui/apps/platform/src/Components/PanelButton/PanelButton.js
+++ b/ui/apps/platform/src/Components/PanelButton/PanelButton.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-
-import { Tooltip, TooltipOverlay } from '@stackrox/ui-components';
+import { Tooltip } from '@patternfly/react-core';
 
 const PanelButton = ({
     children,
@@ -17,10 +16,7 @@ const PanelButton = ({
     const tooltipContent = tooltip || text;
     const tooltipClassName = !tooltip ? 'visible xl:invisible' : '';
     return (
-        <Tooltip
-            content={<TooltipOverlay>{tooltipContent}</TooltipOverlay>}
-            className={tooltipClassName}
-        >
+        <Tooltip content={tooltipContent} className={tooltipClassName}>
             <button
                 type="button"
                 className={className}

--- a/ui/apps/platform/src/Components/RowActionButton/RowActionButton.js
+++ b/ui/apps/platform/src/Components/RowActionButton/RowActionButton.js
@@ -1,10 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-
-import { Tooltip, TooltipOverlay } from '@stackrox/ui-components';
+import { Tooltip } from '@patternfly/react-core';
 
 const RowActionButton = ({ text, icon, border, className, onClick, dataTestId, disabled }) => (
-    <Tooltip content={<TooltipOverlay>{text}</TooltipOverlay>}>
+    <Tooltip content={text}>
         <button
             type="button"
             className={`p-1 px-4 ${className} ${border}`}

--- a/ui/apps/platform/src/Components/RowActionMenu/RowActionMenu.js
+++ b/ui/apps/platform/src/Components/RowActionMenu/RowActionMenu.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Tooltip } from '@patternfly/react-core';
 
 import Menu from 'Components/Menu';
-import { Tooltip, TooltipOverlay } from '@stackrox/ui-components';
 
 const RowActionMenu = ({
     text,
@@ -14,7 +14,7 @@ const RowActionMenu = ({
     options,
     dataTestId,
 }) => (
-    <Tooltip content={<TooltipOverlay>{text}</TooltipOverlay>}>
+    <Tooltip content={text}>
         <div>
             <Menu
                 className={`${className} ${border}`}

--- a/ui/apps/platform/src/Components/TableHeader.js
+++ b/ui/apps/platform/src/Components/TableHeader.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-
-import { Tooltip, TooltipOverlay } from '@stackrox/ui-components';
+import { Tooltip } from '@patternfly/react-core';
 
 const maxSize = 1000;
 
@@ -24,7 +23,7 @@ const TableHeader = (props) => {
             className="overflow-hidden mx-4 flex text-base-600 items-center tracking-wide leading-normal font-700 uppercase"
             data-testid="filtered-header"
         >
-            <Tooltip content={<TooltipOverlay>{headerText}</TooltipOverlay>}>
+            <Tooltip content={headerText}>
                 <div className="truncate flex-none">{headerText}</div>
             </Tooltip>
         </div>

--- a/ui/apps/platform/src/Components/TimelineGraph/EventsGraph/ClusteredEventMarker/__snapshots__/ClusteredEventMarker.test.tsx.snap
+++ b/ui/apps/platform/src/Components/TimelineGraph/EventsGraph/ClusteredEventMarker/__snapshots__/ClusteredEventMarker.test.tsx.snap
@@ -11,9 +11,7 @@ exports[`should show a clustered container restart event marker 1`] = `
       data-testid="timeline-clustered-event-marker"
       transform="translate(NaN, 12.5)"
     >
-      <g
-        aria-expanded="false"
-      >
+      <g>
         <svg
           class="cursor-pointer"
           clip-rule="evenodd"
@@ -73,9 +71,7 @@ exports[`should show a clustered generic event marker 1`] = `
       data-testid="timeline-clustered-event-marker"
       transform="translate(NaN, 12.5)"
     >
-      <g
-        aria-expanded="false"
-      >
+      <g>
         <svg
           class="cursor-pointer"
           data-testid="clustered-generic-event"
@@ -141,9 +137,7 @@ exports[`should show a clustered policy violation event marker 1`] = `
       data-testid="timeline-clustered-event-marker"
       transform="translate(NaN, 12.5)"
     >
-      <g
-        aria-expanded="false"
-      >
+      <g>
         <svg
           class="cursor-pointer"
           data-testid="clustered-policy-violation-event"
@@ -218,9 +212,7 @@ exports[`should show a clustered process activity event marker 1`] = `
       data-testid="timeline-clustered-event-marker"
       transform="translate(NaN, 12.5)"
     >
-      <g
-        aria-expanded="false"
-      >
+      <g>
         <svg
           class="cursor-pointer"
           data-testid="clustered-process-activity-event"
@@ -286,9 +278,7 @@ exports[`should show a clustered process in baseline activity event marker 1`] =
       data-testid="timeline-clustered-event-marker"
       transform="translate(NaN, 12.5)"
     >
-      <g
-        aria-expanded="false"
-      >
+      <g>
         <svg
           class="cursor-pointer"
           data-testid="clustered-process-in-baseline-activity-event"
@@ -362,9 +352,7 @@ exports[`should show a container termination event marker 1`] = `
       data-testid="timeline-clustered-event-marker"
       transform="translate(NaN, 12.5)"
     >
-      <g
-        aria-expanded="false"
-      >
+      <g>
         <svg
           class="cursor-pointer"
           data-testid="clustered-termination-event"

--- a/ui/apps/platform/src/Components/TimelineGraph/EventsGraph/ClusteredEventsTooltip/ClusteredEventsTooltip.tsx
+++ b/ui/apps/platform/src/Components/TimelineGraph/EventsGraph/ClusteredEventsTooltip/ClusteredEventsTooltip.tsx
@@ -1,7 +1,8 @@
 import React, { ReactElement } from 'react';
 import pluralize from 'pluralize';
-import { Tooltip, DetailedTooltipOverlay } from '@stackrox/ui-components';
+import { Popover, Text, TextVariants } from '@patternfly/react-core';
 
+import DetailedTooltipContent from 'Components/DetailedTooltipContent';
 import { eventTypes } from 'constants/timelineTypes';
 import { Event } from '../eventTypes';
 import getTimeRangeTextOfEvents from './getTimeRangeTextOfEvents';
@@ -75,14 +76,17 @@ const ClusteredEventsTooltip = ({
     const tooltipBody = <ul>{sections}</ul>;
 
     return (
-        <Tooltip
-            trigger="click"
-            interactive
-            appendTo={document.body}
-            content={<DetailedTooltipOverlay title={tooltipTitle} body={tooltipBody} />}
+        <Popover
+            aria-label="Open to see individual processes"
+            headerContent={
+                <Text className="pf-u-font-weight-bold" component={TextVariants.h3}>
+                    Events in this group
+                </Text>
+            }
+            bodyContent={<DetailedTooltipContent title={tooltipTitle} body={tooltipBody} />}
         >
             {children}
-        </Tooltip>
+        </Popover>
     );
 };
 

--- a/ui/apps/platform/src/Components/TimelineGraph/EventsGraph/EventTooltip.tsx
+++ b/ui/apps/platform/src/Components/TimelineGraph/EventsGraph/EventTooltip.tsx
@@ -1,7 +1,8 @@
 import React, { ReactElement } from 'react';
+import { Tooltip } from '@patternfly/react-core';
 
 import { eventTypes } from 'constants/timelineTypes';
-import { Tooltip, DetailedTooltipOverlay } from '@stackrox/ui-components';
+import DetailedTooltipContent from 'Components/DetailedTooltipContent';
 import { Event } from './eventTypes';
 import ProcessActivityTooltipFields from './EventTooltipFields/ProcessActivityTooltipFields';
 import TerminationTooltipFields from './EventTooltipFields/TerminationTooltipFields';
@@ -44,7 +45,10 @@ const EventTooltip = ({
     }
 
     return (
-        <Tooltip content={<DetailedTooltipOverlay title={name} body={tooltipBody} />}>
+        <Tooltip
+            isContentLeftAligned
+            content={<DetailedTooltipContent title={name} body={tooltipBody} />}
+        >
             {children}
         </Tooltip>
     );

--- a/ui/apps/platform/src/Components/TimelineGraph/NameList/DrillDownButton.js
+++ b/ui/apps/platform/src/Components/TimelineGraph/NameList/DrillDownButton.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { ChevronRight } from 'react-feather';
+import { Tooltip } from '@patternfly/react-core';
 
-import { Tooltip, TooltipOverlay } from '@stackrox/ui-components';
 import Button from 'Components/Button';
 
 const DrillDownButton = ({ tooltip, onClick }) => {
@@ -24,7 +24,7 @@ const DrillDownButton = ({ tooltip, onClick }) => {
 
     if (tooltip) {
         drillDownButton = (
-            <Tooltip content={<TooltipOverlay>{tooltip}</TooltipOverlay>}>
+            <Tooltip content={tooltip}>
                 <div className={positionClassName}>{drillDownButton}</div>
             </Tooltip>
         );

--- a/ui/apps/platform/src/Components/TimelineLegend.js
+++ b/ui/apps/platform/src/Components/TimelineLegend.js
@@ -11,7 +11,7 @@ const ICON_SIZE = 15;
 
 const TimelineLegend = () => {
     const content = (
-        <div>
+        <div data-testid="timeline-legend-items">
             <div className="flex items-center mb-2">
                 <ProcessActivityEvent size={ICON_SIZE} />
                 <span className="ml-2">Process Activity</span>

--- a/ui/apps/platform/src/Components/TimelineLegend.js
+++ b/ui/apps/platform/src/Components/TimelineLegend.js
@@ -1,6 +1,6 @@
 import React from 'react';
+import { Tooltip } from '@patternfly/react-core';
 
-import { Tooltip, TooltipOverlay } from '@stackrox/ui-components';
 import Button from 'Components/Button';
 import PolicyViolationEvent from 'Components/TimelineGraph/EventsGraph/EventMarker/PolicyViolationEvent';
 import ProcessActivityEvent from 'Components/TimelineGraph/EventsGraph/EventMarker/ProcessActivityEvent';
@@ -11,7 +11,7 @@ const ICON_SIZE = 15;
 
 const TimelineLegend = () => {
     const content = (
-        <TooltipOverlay>
+        <div>
             <div className="flex items-center mb-2">
                 <ProcessActivityEvent size={ICON_SIZE} />
                 <span className="ml-2">Process Activity</span>
@@ -32,10 +32,10 @@ const TimelineLegend = () => {
                 <TerminationEvent size={ICON_SIZE} />
                 <span className="ml-2">Container Termination</span>
             </div>
-        </TooltipOverlay>
+        </div>
     );
     return (
-        <Tooltip trigger="click" position="right" content={content}>
+        <Tooltip content={content}>
             <div>
                 <Button className="btn btn-base" dataTestId="timeline-legend" text="Show Legend" />
             </div>

--- a/ui/apps/platform/src/Components/TopCvssLabel/TopCvssLabel.js
+++ b/ui/apps/platform/src/Components/TopCvssLabel/TopCvssLabel.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import LabelChip from 'Components/LabelChip';
 import LabelChipSubtext from 'Components/LabelChipSubtext';
 import { getSeverityChipType } from 'utils/vulnerabilityUtils';
-import { Tooltip, TooltipOverlay } from '@stackrox/ui-components';
+import { Tooltip } from '@patternfly/react-core';
 
 const CVSSLabelChip = ({ cvss, expanded }) => {
     const chipType = getSeverityChipType(cvss);
@@ -28,7 +28,7 @@ const TopCvssLabel = ({ cvss, version, expanded }) => {
     const labelElm = expanded ? (
         <CVSSLabelChip cvss={cvss} expanded={expanded} />
     ) : (
-        <Tooltip content={<TooltipOverlay>{extendedVersionText}</TooltipOverlay>}>
+        <Tooltip content={extendedVersionText}>
             <div>
                 <CVSSLabelChip cvss={cvss} expanded={expanded} />
             </div>

--- a/ui/apps/platform/src/Components/visuals/PercentageStackedPill/PercentageStackedPill.js
+++ b/ui/apps/platform/src/Components/visuals/PercentageStackedPill/PercentageStackedPill.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Tooltip } from '@patternfly/react-core';
 
-import { Tooltip, DetailedTooltipOverlay } from '@stackrox/ui-components';
+import DetailedTooltipContent from 'Components/DetailedTooltipContent';
 import { colorTypes, defaultColorType } from 'constants/visuals/colors';
 
 const getBackgroundColor = (colorType) => {
@@ -37,7 +38,10 @@ const PercentageStackedPill = ({ data, tooltip }) => {
         </div>
     );
     return tooltip ? (
-        <Tooltip content={<DetailedTooltipOverlay title={tooltipTitle} body={tooltipBody} />}>
+        <Tooltip
+            isContentLeftAligned
+            content={<DetailedTooltipContent title={tooltipTitle} body={tooltipBody} />}
+        >
             {content}
         </Tooltip>
     ) : (

--- a/ui/apps/platform/src/Containers/Clusters/Components/AdmissionControl/AdmissionControlStatus.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/AdmissionControl/AdmissionControlStatus.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement } from 'react';
+import { Tooltip } from '@patternfly/react-core';
 
-import { Tooltip, DetailedTooltipOverlay } from '@stackrox/ui-components';
-
+import DetailedTooltipContent from 'Components/DetailedTooltipContent';
 import { getDistanceStrictAsPhrase } from 'utils/dateUtils';
 import HealthStatus from '../HealthStatus';
 import {
@@ -87,7 +87,7 @@ function AdmissionControlStatus({
         return isList ? (
             <Tooltip
                 content={
-                    <DetailedTooltipOverlay
+                    <DetailedTooltipContent
                         title="Admission Control Health Information"
                         body={infoElement}
                     />

--- a/ui/apps/platform/src/Containers/Clusters/Components/AdmissionControl/AdmissionControlUnavailableStatus.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/AdmissionControl/AdmissionControlUnavailableStatus.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement } from 'react';
+import { Tooltip } from '@patternfly/react-core';
 
-import { Tooltip, TooltipOverlay } from '@stackrox/ui-components';
 import HealthStatus from '../HealthStatus';
 
 type AdmissionControlUnavailableStatusProps = {
@@ -25,7 +25,7 @@ function AdmissionControlUnavailableStatus({
     );
 
     return isList ? (
-        <Tooltip content={<TooltipOverlay>{reasonUnavailable}</TooltipOverlay>}>
+        <Tooltip content={reasonUnavailable}>
             <div className="inline">{healthStatusElement}</div>
         </Tooltip>
     ) : (

--- a/ui/apps/platform/src/Containers/Clusters/Components/Collector/CollectorStatus.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/Collector/CollectorStatus.tsx
@@ -1,8 +1,8 @@
 import React, { ReactElement } from 'react';
+import { Tooltip } from '@patternfly/react-core';
 
-import { Tooltip, DetailedTooltipOverlay } from '@stackrox/ui-components';
+import DetailedTooltipContent from 'Components/DetailedTooltipContent';
 import { getDistanceStrictAsPhrase } from 'utils/dateUtils';
-
 import HealthStatus from '../HealthStatus';
 import CollectorStatusTotals from './CollectorStatusTotals';
 import CollectorUnavailableStatus from './CollectorUnavailableStatus';
@@ -81,7 +81,7 @@ function CollectorStatus({ healthStatus, isList = false }: CollectorStatusProps)
         return isList ? (
             <Tooltip
                 content={
-                    <DetailedTooltipOverlay
+                    <DetailedTooltipContent
                         title="Collector Health Information"
                         body={infoElement}
                     />

--- a/ui/apps/platform/src/Containers/Clusters/Components/Collector/CollectorUnavailableStatus.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/Collector/CollectorUnavailableStatus.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement } from 'react';
+import { Tooltip } from '@patternfly/react-core';
 
-import { Tooltip, TooltipOverlay } from '@stackrox/ui-components';
 import HealthStatus from '../HealthStatus';
 
 type CollectorUnavailableStatusProps = {
@@ -23,7 +23,7 @@ function CollectorUnavailableStatus({
     );
 
     return isList ? (
-        <Tooltip content={<TooltipOverlay>{reasonUnavailable}</TooltipOverlay>}>
+        <Tooltip content={reasonUnavailable}>
             <div className="inline">
                 <HealthStatus icon={icon} iconColor={fgColor} isList={isList}>
                     {statusElement}

--- a/ui/apps/platform/src/Containers/Clusters/Components/CredentialExpiration.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/CredentialExpiration.tsx
@@ -1,8 +1,8 @@
 import React, { ReactElement } from 'react';
 import { ExternalLink } from 'react-feather';
 import { differenceInDays } from 'date-fns';
+import { Tooltip } from '@patternfly/react-core';
 
-import { Tooltip, TooltipOverlay } from '@stackrox/ui-components';
 import { getTime, getDate, getDayOfWeek, getDistanceStrictAsPhrase } from 'utils/dateUtils';
 
 import useMetadata from 'hooks/useMetadata';
@@ -57,7 +57,7 @@ function CredentialExpiration({
         }
         // A tooltip displays expiration date or time
         expirationElement = (
-            <Tooltip content={<TooltipOverlay>{tooltipText}</TooltipOverlay>}>
+            <Tooltip content={tooltipText}>
                 <div data-testid={testId}>{distanceElement}</div>
             </Tooltip>
         );

--- a/ui/apps/platform/src/Containers/Clusters/Components/HelmIndicator.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/HelmIndicator.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement } from 'react';
+import { Tooltip } from '@patternfly/react-core';
 
-import { Tooltip, TooltipOverlay } from '@stackrox/ui-components';
 import { useTheme } from 'Containers/ThemeProvider';
 import helm from 'images/helm.svg';
 
@@ -9,7 +9,7 @@ function HelmIndicator(): ReactElement {
     const darkModeStyle = isDarkMode ? 'bg-base-800 rounded-full' : '';
 
     return (
-        <Tooltip content={<TooltipOverlay>This cluster is managed by Helm.</TooltipOverlay>}>
+        <Tooltip content="This cluster is managed by Helm.">
             <span className={`w-5 h-5 inline-block ${darkModeStyle}`}>
                 <img className="w-5 h-5" src={helm} alt="Managed by Helm" />
             </span>

--- a/ui/apps/platform/src/Containers/Clusters/Components/OperatorIndicator.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/OperatorIndicator.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement } from 'react';
+import { Tooltip } from '@patternfly/react-core';
 
-import { Tooltip, TooltipOverlay } from '@stackrox/ui-components';
 import { useTheme } from 'Containers/ThemeProvider';
 import operatorLogo from 'images/operator-logo.png';
 
@@ -9,11 +9,7 @@ function OperatorIndicator(): ReactElement {
     const darkModeStyle = isDarkMode ? 'bg-base-800 rounded-full' : '';
 
     return (
-        <Tooltip
-            content={
-                <TooltipOverlay>This cluster is managed by a Kubernetes Operator.</TooltipOverlay>
-            }
-        >
+        <Tooltip content="This cluster is managed by a Kubernetes Operator.">
             <span className={`w-5 h-5 inline-block ${darkModeStyle}`}>
                 <img
                     className="w-5 h-5"

--- a/ui/apps/platform/src/Containers/Clusters/Components/Scanner/ScannerStatus.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/Scanner/ScannerStatus.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
+import { Tooltip } from '@patternfly/react-core';
 
-import { DetailedTooltipOverlay, Tooltip } from '@stackrox/ui-components';
+import DetailedTooltipContent from 'Components/DetailedTooltipContent';
 import { getDistanceStrictAsPhrase } from 'utils/dateUtils';
-
 import { ClusterHealthStatus } from '../../clusterTypes';
 import {
     delayedScannerStatusStyle,
@@ -76,7 +76,7 @@ const ScannerStatus = ({ healthStatus, isList = false }: ScannerStatusProps) => 
         return isList ? (
             <Tooltip
                 content={
-                    <DetailedTooltipOverlay title="Scanner Health Information" body={infoElement} />
+                    <DetailedTooltipContent title="Scanner Health Information" body={infoElement} />
                 }
             >
                 <div className="inline">{healthStatusElement}</div>

--- a/ui/apps/platform/src/Containers/Clusters/Components/Scanner/ScannerUnavailableStatus.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/Scanner/ScannerUnavailableStatus.tsx
@@ -1,5 +1,6 @@
 import React, { ReactElement } from 'react';
-import { Tooltip, TooltipOverlay } from '@stackrox/ui-components';
+import { Tooltip } from '@patternfly/react-core';
+
 import HealthStatus from '../HealthStatus';
 
 type ScannerUnavailableStatusProps = {
@@ -24,7 +25,7 @@ const ScannerUnavailableStatus = ({
     );
 
     return isList ? (
-        <Tooltip content={<TooltipOverlay>{reasonUnavailable}</TooltipOverlay>}>
+        <Tooltip content={reasonUnavailable}>
             <div className="inline">{healthStatusElement}</div>
         </Tooltip>
     ) : (

--- a/ui/apps/platform/src/Containers/Clusters/Components/SensorStatus.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/SensorStatus.tsx
@@ -1,6 +1,5 @@
 import React, { ReactElement } from 'react';
-
-import { Tooltip, TooltipOverlay } from '@stackrox/ui-components';
+import { Tooltip } from '@patternfly/react-core';
 
 import { getDateTime, getDistanceStrict } from 'utils/dateUtils';
 import HealthStatus from './HealthStatus';
@@ -49,11 +48,7 @@ function SensorStatus({ healthStatus, isList = false }: SensorStatusProps): Reac
     if (lastContact) {
         // Tooltip has absolute time (in ISO 8601 format) to find info from logs.
         return (
-            <Tooltip
-                content={
-                    <TooltipOverlay>{`Last contact: ${getDateTime(lastContact)}`}</TooltipOverlay>
-                }
-            >
+            <Tooltip content={`Last contact: ${getDateTime(lastContact)}`}>
                 <div className={`${isList ? 'inline' : ''}`}>{sensorStatus}</div>
             </Tooltip>
         );

--- a/ui/apps/platform/src/Containers/Clusters/Components/SensorUpgrade.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/SensorUpgrade.tsx
@@ -1,10 +1,9 @@
 import React, { ReactElement } from 'react';
-
-import { Tooltip, TooltipOverlay } from '@stackrox/ui-components';
+import { Tooltip } from '@patternfly/react-core';
 
 import HealthStatus from './HealthStatus';
 import HealthStatusNotApplicable from './HealthStatusNotApplicable';
-import { findUpgradeState, formatSensorVersion, sensorUpgradeStyles } from '../cluster.helpers';
+import { findUpgradeState, formatSensorVersion, sensorUpgradeStylesPF } from '../cluster.helpers';
 import { SensorUpgradeStatus } from '../clusterTypes';
 
 const trClassName = 'align-top leading-normal';
@@ -46,7 +45,7 @@ function SensorUpgrade({
             let actionElement: ReactElement | null = null;
 
             if (displayValue) {
-                const { bgColor, fgColor } = sensorUpgradeStyles[type];
+                const { bgColor, fgColor } = sensorUpgradeStylesPF[type];
                 displayElement = (
                     <span className={`${bgColor as string} ${fgColor as string}`}>
                         {displayValue}
@@ -55,7 +54,7 @@ function SensorUpgrade({
             }
 
             if (actionText) {
-                const actionStyle = sensorUpgradeStyles.download;
+                const actionStyle = sensorUpgradeStylesPF.download;
                 if (actionProps) {
                     const { clusterId, upgradeSingleCluster } = actionProps;
                     const onClick = (event) => {
@@ -89,7 +88,7 @@ function SensorUpgrade({
                 </div>
             );
 
-            const { Icon, bgColor, fgColor } = sensorUpgradeStyles[type];
+            const { Icon, bgColor, fgColor } = sensorUpgradeStylesPF[type];
             const icon = <Icon className="h-4 w-4" />;
 
             // Use table instead of TooltipFieldValue to align version numbers.
@@ -152,7 +151,7 @@ function SensorUpgrade({
                 );
 
                 return (
-                    <Tooltip content={<TooltipOverlay>{overlayElement}</TooltipOverlay>}>
+                    <Tooltip content={overlayElement}>
                         <div>
                             <HealthStatus icon={icon} iconColor={fgColor}>
                                 {upgradeElement}

--- a/ui/apps/platform/src/Containers/Clusters/cluster.helpers.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/cluster.helpers.tsx
@@ -208,6 +208,22 @@ export const sensorUpgradeStyles = {
     failure: styleUnhealthy,
 };
 
+export const sensorUpgradeStylesPF = {
+    current: styleHealthyPF,
+    progress: {
+        Icon: InProgressIcon,
+        bgColor: 'bg-tertiary-200',
+        fgColor: 'text-tertiary-700',
+    },
+    download: {
+        Icon: DownloadCloud,
+        bgColor: 'bg-tertiary-200',
+        fgColor: 'text-tertiary-700',
+    },
+    intervention: styleDegradedPF,
+    failure: styleUnhealthyPF,
+};
+
 type UpgradeState = {
     displayValue?: string;
     type: string;

--- a/ui/apps/platform/src/Containers/Compliance/widgets/Labels.js
+++ b/ui/apps/platform/src/Containers/Compliance/widgets/Labels.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-
-import { Tooltip, TooltipOverlay } from '@stackrox/ui-components';
+import { Tooltip } from '@patternfly/react-core';
 
 const truncate = (key) => {
     const index = key.indexOf('/');
@@ -19,13 +18,7 @@ const Labels = ({ labels }) => (
                     pageBreakInside: 'avoid',
                 }}
             >
-                <Tooltip
-                    content={
-                        <TooltipOverlay>
-                            {label.key} : {label.value || '""'}
-                        </TooltipOverlay>
-                    }
-                >
+                <Tooltip content={`${label.key} : ${label.value || '""'}`}>
                     <span className="text-base font-600 word-break truncate">
                         {truncate(label.key)} : {label.value || '""'}
                     </span>

--- a/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/widgets/SecretsMostUsedAcrossDeployments.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/widgets/SecretsMostUsedAcrossDeployments.js
@@ -1,15 +1,16 @@
 import React from 'react';
-import Loader from 'Components/Loader';
 import { Link, withRouter } from 'react-router-dom';
-import { Tooltip, TooltipOverlay } from '@stackrox/ui-components';
-import URLService from 'utils/URLService';
+import ReactRouterPropTypes from 'react-router-prop-types';
 import { gql } from '@apollo/client';
+import pluralize from 'pluralize';
+import dateFns from 'date-fns';
+import { Tooltip } from '@patternfly/react-core';
+
+import Loader from 'Components/Loader';
+import URLService from 'utils/URLService';
 import entityTypes from 'constants/entityTypes';
 import Query from 'Components/ThrowingQuery';
 import Widget from 'Components/Widget';
-import pluralize from 'pluralize';
-import ReactRouterPropTypes from 'react-router-prop-types';
-import dateFns from 'date-fns';
 
 const QUERY = gql`
     query secrets {
@@ -126,7 +127,7 @@ const SecretsMostUsedAcrossDeployments = ({ match, location }) => {
                                                     <span className="pb-2">{item.name}</span>
                                                     <Tooltip
                                                         content={
-                                                            <TooltipOverlay>
+                                                            <div>
                                                                 {`${
                                                                     item.deploymentCount
                                                                 } ${pluralize(
@@ -134,7 +135,7 @@ const SecretsMostUsedAcrossDeployments = ({ match, location }) => {
                                                                     item.deploymentCount
                                                                 )}, `}
                                                                 {getCertificateStatus(item.files)}
-                                                            </TooltipOverlay>
+                                                            </div>
                                                         }
                                                     >
                                                         {item.deploymentCount > 0 && (

--- a/ui/apps/platform/src/Containers/Images/CVETable.js
+++ b/ui/apps/platform/src/Containers/Images/CVETable.js
@@ -1,9 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Table, { defaultHeaderClassName } from 'Components/Table';
+import { Tooltip } from '@patternfly/react-core';
+
 import NoComponentVulnMessage from 'Components/NoComponentVulnMessage';
 import { sortValue } from 'sorters/sorters';
-import { Tooltip, TooltipOverlay } from '@stackrox/ui-components';
 
 import VulnsTable from './VulnsTable';
 
@@ -50,7 +51,7 @@ const CVETable = (props) => {
                 headerClassName:
                     'w-1/4 font-600 border-b border-base-300 border-r-0 bg-primary-200',
                 Cell: ({ value }) => (
-                    <Tooltip content={<TooltipOverlay>{value}</TooltipOverlay>}>
+                    <Tooltip content={value}>
                         <div>{value}</div>
                     </Tooltip>
                 ),

--- a/ui/apps/platform/src/Containers/Images/VulnsTable.js
+++ b/ui/apps/platform/src/Containers/Images/VulnsTable.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Tooltip } from '@patternfly/react-core';
+
 import Table from 'Components/Table';
-import { Tooltip, TooltipOverlay } from '@stackrox/ui-components';
 
 const VulnsTable = ({ vulns, containsFixableCVEs, isOSPkg }) => {
     const columns = [
@@ -33,12 +34,8 @@ const VulnsTable = ({ vulns, containsFixableCVEs, isOSPkg }) => {
                 if (!cvss) {
                     return (
                         <Tooltip
-                            content={
-                                <TooltipOverlay>
-                                    A CVSS value can be pending when the vulnerability has not been
-                                    scored or has been disputed
-                                </TooltipOverlay>
-                            }
+                            content="A CVSS value can be pending when the vulnerability has not been
+                                    scored or has been disputed"
                         >
                             <div>Pending</div>
                         </Tooltip>

--- a/ui/apps/platform/src/Containers/Network/SidePanel/Simulator/Icons/Download.tsx
+++ b/ui/apps/platform/src/Containers/Network/SidePanel/Simulator/Icons/Download.tsx
@@ -2,7 +2,7 @@ import React, { ReactElement } from 'react';
 import { connect } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
 import * as Icon from 'react-feather';
-import { Tooltip, TooltipOverlay } from '@stackrox/ui-components';
+import { Tooltip } from '@patternfly/react-core';
 
 import { selectors } from 'reducers';
 import download from 'utils/download';
@@ -23,7 +23,7 @@ function Download({ modification, modificationName }: DownloadProps): ReactEleme
     }
 
     return (
-        <Tooltip content={<TooltipOverlay>Download YAML</TooltipOverlay>}>
+        <Tooltip content="Download YAML">
             <button
                 type="button"
                 className="inline-block px-2 py-2 border-base-300 cursor-pointer"

--- a/ui/apps/platform/src/Containers/Network/SidePanel/Simulator/Icons/Generate.tsx
+++ b/ui/apps/platform/src/Containers/Network/SidePanel/Simulator/Icons/Generate.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement } from 'react';
 import { connect } from 'react-redux';
-import { Tooltip, TooltipOverlay } from '@stackrox/ui-components';
+import { Tooltip } from '@patternfly/react-core';
 
 import { actions as sidepanelActions } from 'reducers/network/sidepanel';
 import generate from 'images/generate.svg';
@@ -15,7 +15,7 @@ function Generate({ generatePolicyModification }: GenerateProps): ReactElement {
     }
 
     return (
-        <Tooltip content={<TooltipOverlay>Generate a new YAML</TooltipOverlay>}>
+        <Tooltip content="Generate a new YAML">
             <button
                 type="button"
                 className="inline-block px-2 py-2 border-r border-base-300 cursor-pointer"

--- a/ui/apps/platform/src/Containers/Network/SidePanel/Simulator/Icons/Undo.tsx
+++ b/ui/apps/platform/src/Containers/Network/SidePanel/Simulator/Icons/Undo.tsx
@@ -2,7 +2,7 @@ import React, { ReactElement } from 'react';
 import { connect } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
 import * as Icon from 'react-feather';
-import { Tooltip, TooltipOverlay } from '@stackrox/ui-components';
+import { Tooltip } from '@patternfly/react-core';
 
 import { selectors } from 'reducers';
 import { actions as sidepanelActions } from 'reducers/network/sidepanel';
@@ -18,7 +18,7 @@ function Undo({ undoModification, applicationState }: UndoProps): ReactElement {
     }
 
     return (
-        <Tooltip content={<TooltipOverlay>Revert most recently applied YAML</TooltipOverlay>}>
+        <Tooltip content="Revert most recently applied YAML">
             <button
                 type="button"
                 disabled={applicationState === 'REQUEST'}

--- a/ui/apps/platform/src/Containers/Network/SidePanel/Simulator/Icons/Upload.tsx
+++ b/ui/apps/platform/src/Containers/Network/SidePanel/Simulator/Icons/Upload.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, ReactElement } from 'react';
 import { connect } from 'react-redux';
 import * as Icon from 'react-feather';
 import { useDropzone } from 'react-dropzone';
-import { Tooltip, TooltipOverlay } from '@stackrox/ui-components';
+import { Tooltip } from '@patternfly/react-core';
 
 import { actions as sidepanelActions } from 'reducers/network/sidepanel';
 import { actions as notificationActions } from 'reducers/notifications';
@@ -69,7 +69,7 @@ function Upload({
     const { getRootProps, getInputProps } = useDropzone({ onDrop });
 
     return (
-        <Tooltip content={<TooltipOverlay>Upload a new YAML</TooltipOverlay>}>
+        <Tooltip content="Upload a new YAML">
             <div
                 {...getRootProps()}
                 className="inline-block px-2 py-2 border-r border-base-300 cursor-pointer outline-none"

--- a/ui/apps/platform/src/Containers/Risk/Process/DiscoveryCardHeader.js
+++ b/ui/apps/platform/src/Containers/Risk/Process/DiscoveryCardHeader.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import * as Icon from 'react-feather';
-import { Tooltip, TooltipOverlay } from '@stackrox/ui-components';
+import { Tooltip } from '@patternfly/react-core';
+
 import { addDeleteProcesses } from 'services/ProcessesService';
 import { getDeploymentAndProcessIdFromProcessGroup } from 'utils/processUtils';
 
@@ -50,7 +51,7 @@ function ProcessesDiscoveryCardHeader({
             <div className="flex content-center">
                 {suspicious && (
                     <div className="border-l border-r flex items-center justify-center w-16 border-alert-300">
-                        <Tooltip content={<TooltipOverlay>Add to baseline</TooltipOverlay>}>
+                        <Tooltip content="Add to baseline">
                             <button
                                 type="button"
                                 onClick={addBaseline}

--- a/ui/apps/platform/src/Containers/Risk/Process/ProcessBaselineElementList.js
+++ b/ui/apps/platform/src/Containers/Risk/Process/ProcessBaselineElementList.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import * as Icon from 'react-feather';
-import { Tooltip, TooltipOverlay } from '@stackrox/ui-components';
+import { Tooltip } from '@patternfly/react-core';
+
 import { addDeleteProcesses } from 'services/ProcessesService';
 
 const ProcessBaselineElementList = ({ baselineKey, elements, processEpoch, setProcessEpoch }) => {
@@ -29,9 +30,7 @@ const ProcessBaselineElementList = ({ baselineKey, elements, processEpoch, setPr
                     className="py-3 pb-2 leading-normal tracking-normal border-b border-base-300 flex justify-between items-center"
                 >
                     <span>{element.processName}</span>
-                    <Tooltip
-                        content={<TooltipOverlay>Remove process from baseline</TooltipOverlay>}
-                    >
+                    <Tooltip content="Remove process from baseline">
                         <button
                             className="flex p-1 rounded border content-center hover:bg-base-300"
                             type="button"

--- a/ui/apps/platform/src/Containers/Risk/Process/ProcessBaselineList.js
+++ b/ui/apps/platform/src/Containers/Risk/Process/ProcessBaselineList.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import * as Icon from 'react-feather';
-import { Tooltip, TooltipOverlay } from '@stackrox/ui-components';
+import { Tooltip } from '@patternfly/react-core';
+
 import { lockUnlockProcesses } from 'services/ProcessesService';
 
 import ProcessBaselineElementList from './ProcessBaselineElementList';
@@ -50,13 +51,7 @@ const ProcessBaselineList = ({ process, processEpoch, setProcessEpoch }) => {
         >
             <div className="text-base-600 font-700 text-lg flex justify-between items-center border-b border-base-300 p-3">
                 <span>{key.containerName}</span>
-                <Tooltip
-                    content={
-                        <TooltipOverlay>
-                            {isLocked ? unlockTooltipText : lockTooltipText}
-                        </TooltipOverlay>
-                    }
-                >
+                <Tooltip content={isLocked ? unlockTooltipText : lockTooltipText}>
                     <div>
                         <button
                             className={`${buttonClassName} ${

--- a/ui/apps/platform/src/Containers/Risk/riskTableColumnDescriptors.js
+++ b/ui/apps/platform/src/Containers/Risk/riskTableColumnDescriptors.js
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types';
 import * as Icon from 'react-feather';
 import find from 'lodash/find';
 import dateFns from 'date-fns';
+import { Tooltip } from '@patternfly/react-core';
 
-import { Tooltip, TooltipOverlay } from '@stackrox/ui-components';
 import dateTimeFormat from 'constants/dateTimeFormat';
 import { sortValue, sortDate } from 'sorters/sorters';
 
@@ -16,9 +16,7 @@ function DeploymentNameColumn({ original }) {
         <div className="flex items-center">
             <span className="pr-1">
                 {isSuspicious && (
-                    <Tooltip
-                        content={<TooltipOverlay>Abnormal processes discovered</TooltipOverlay>}
-                    >
+                    <Tooltip content="Abnormal processes discovered">
                         <Icon.Circle className="h-2 w-2 text-alert-400" fill="#ffebf1" />
                     </Tooltip>
                 )}

--- a/ui/apps/platform/src/Containers/VulnMgmt/widgets/ClustersWithMostClusterVulnerabilities.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/widgets/ClustersWithMostClusterVulnerabilities.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { gql, useQuery } from '@apollo/client';
 import { HelpCircle, AlertCircle } from 'react-feather';
 import sortBy from 'lodash/sortBy';
+import { Tooltip } from '@patternfly/react-core';
 
 import { checkForPermissionErrorMessage } from 'utils/permissionUtils';
 import queryService from 'utils/queryService';
@@ -17,7 +18,6 @@ import FixableCVECount from 'Components/FixableCVECount';
 import kubeSVG from 'images/kube.svg';
 import istioSVG from 'images/istio.svg';
 import openShiftSVG from 'images/openShift.svg';
-import { Tooltip, TooltipOverlay } from '@stackrox/ui-components';
 import useFeatureFlags from 'hooks/useFeatureFlags';
 
 const CLUSTER_WITH_MOST_ORCHESTRATOR_ISTIO_VULNERABILTIES = gql`
@@ -148,7 +148,7 @@ const processData = (data, workflowState, limit, showVmUpdates) => {
 
             const orchestratorContent = isOpenShiftCluster ? (
                 <div className="flex items-center justify-left mr-8">
-                    <Tooltip content={<TooltipOverlay>OpenShift Vulnerabilities</TooltipOverlay>}>
+                    <Tooltip content="OpenShift Vulnerabilities">
                         <div className="flex">
                             <img src={openShiftSVG} alt="openshift" className="pr-2" />
                             <FixableCVECount
@@ -164,7 +164,7 @@ const processData = (data, workflowState, limit, showVmUpdates) => {
                 </div>
             ) : (
                 <div className="flex flex-1 items-center justify-left mr-8">
-                    <Tooltip content={<TooltipOverlay>Kubernetes Vulnerabilities</TooltipOverlay>}>
+                    <Tooltip content="Kubernetes Vulnerabilities">
                         <div className="flex">
                             <img src={kubeSVG} alt="kube" className="pr-2" />
                             <FixableCVECount
@@ -177,16 +177,14 @@ const processData = (data, workflowState, limit, showVmUpdates) => {
                             />
                         </div>
                     </Tooltip>
-                    <Tooltip content={<TooltipOverlay>{indicationTooltipText}</TooltipOverlay>}>
-                        {indicatorIcon}
-                    </Tooltip>
+                    <Tooltip content={indicationTooltipText}>{indicatorIcon}</Tooltip>
                 </div>
             );
 
             const orchestratorIstioContent = (
                 <div className="flex">
                     {orchestratorContent}
-                    <Tooltip content={<TooltipOverlay>Istio Vulnerabilities</TooltipOverlay>}>
+                    <Tooltip content="Istio Vulnerabilities">
                         <div className="flex items-center justify-left pr-2">
                             <img src={istioSVG} alt="istio" className="pr-2" />
                             <FixableCVECount
@@ -264,9 +262,7 @@ const processDataLegacy = (data, workflowState, limit, showVmUpdates) => {
 
                 const orchestratorContent = isOpenShiftCluster ? (
                     <div className="flex items-center justify-left mr-8">
-                        <Tooltip
-                            content={<TooltipOverlay>OpenShift Vulnerabilities</TooltipOverlay>}
-                        >
+                        <Tooltip content="OpenShift Vulnerabilities">
                             <div className="flex">
                                 <img src={openShiftSVG} alt="openshift" className="pr-2" />
                                 <FixableCVECount
@@ -282,9 +278,7 @@ const processDataLegacy = (data, workflowState, limit, showVmUpdates) => {
                     </div>
                 ) : (
                     <div className="flex flex-1 items-center justify-left mr-8">
-                        <Tooltip
-                            content={<TooltipOverlay>Kubernetes Vulnerabilities</TooltipOverlay>}
-                        >
+                        <Tooltip content="Kubernetes Vulnerabilities">
                             <div className="flex">
                                 <img src={kubeSVG} alt="kube" className="pr-2" />
                                 <FixableCVECount
@@ -297,16 +291,14 @@ const processDataLegacy = (data, workflowState, limit, showVmUpdates) => {
                                 />
                             </div>
                         </Tooltip>
-                        <Tooltip content={<TooltipOverlay>{indicationTooltipText}</TooltipOverlay>}>
-                            {indicatorIcon}
-                        </Tooltip>
+                        <Tooltip content={indicationTooltipText}>{indicatorIcon}</Tooltip>
                     </div>
                 );
 
                 const orchestratorIstioContent = (
                     <div className="flex">
                         {orchestratorContent}
-                        <Tooltip content={<TooltipOverlay>Istio Vulnerabilities</TooltipOverlay>}>
+                        <Tooltip content="Istio Vulnerabilities">
                             <div className="flex items-center justify-left pr-2">
                                 <img src={istioSVG} alt="istio" className="pr-2" />
                                 <FixableCVECount


### PR DESCRIPTION
## Description

This is the first phase of converting all the product's tooltips to PatternFly versions, even if the sections they appear in are not in PatternFly yet.
The impetus for this is to drop our dependence on the Tippy-JS library, which is would need to be upgraded to unblock us from upgrading several other packages. (I discovered this problem while researching upgrades related to https://issues.redhat.com/browse/ROX-15166)

This phase replaces usage of our old StackRox ui-components `Tooltip` component, which wrapped Tippy.

In one case, that of `ClusteredEventsTooltip` in the process timeline, the PatternFly team recommended that I use their `Popover` component instead of their tooltip, because of the frequent need to overflow and scroll its content. See https://patternfly.slack.com/archives/C4FM977N0/p1677005692935099

Note: I have not yet tackled our direct use of Tippy in graphs and charts. That will be solved in part when we remove the old Network Graph code for release 4.1.0. Then, any remaining direct use of Tippy can be migrated.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

Manually tested each tooltip as I migrated it.

![tooltip_timeline_legend](https://user-images.githubusercontent.com/715729/220743807-b930029b-8c66-4d97-916d-33955efe9c35.png)
<img width="1552" alt="tooltip_event_list" src="https://user-images.githubusercontent.com/715729/220743808-c2e795c1-5964-4af5-a8f7-0e4a1fe9c7b8.png">
![tooltip_cve_pill](https://user-images.githubusercontent.com/715729/220743810-063ff0be-68a4-4dc5-be0b-420c001aacf1.png)
![tooltip_numbered_list](https://user-images.githubusercontent.com/715729/220743815-ec2f01d5-ebbf-4fb5-aa92-d67c67ea927f.png)
![tooltip_download_yaml](https://user-images.githubusercontent.com/715729/220743818-84ac39a6-15e3-40d3-9765-10ba983e4c49.png)
![tooltip_config_secrets_widget](https://user-images.githubusercontent.com/715729/220743820-ecc0de2b-1a16-45ee-83b4-06f417b3cc0a.png)
![tooltip_compliance_labels](https://user-images.githubusercontent.com/715729/220743821-fb621283-adcd-4f73-8627-eb5105464b9e.png)
![tooltip_sensor_status](https://user-images.githubusercontent.com/715729/220743823-52f4cf19-1571-464d-8c83-6d29e32fdc90.png)
![tooltip_operator_indicator](https://user-images.githubusercontent.com/715729/220743827-4d7649cb-ec96-4859-b38d-b81077d5f041.png)
![tooltip_helm_indicator](https://user-images.githubusercontent.com/715729/220743828-2fce5fdf-40d8-44c2-83d0-e9b81a559868.png)
![tooltip_credential_expiration](https://user-images.githubusercontent.com/715729/220743831-185f9fc6-27a9-43a4-9e5c-007dfe5d5ab7.png)
![tooltip_top_cvss](https://user-images.githubusercontent.com/715729/220743833-12616083-7456-4ad6-b145-75032c9e5943.png)
![tooltip_drilldown_button](https://user-images.githubusercontent.com/715729/220743836-212591bb-4ea4-49d9-bf52-850aaed80afb.png)
![tooltip_row_action_menu](https://user-images.githubusercontent.com/715729/220743837-c197e55a-16b3-4862-a55a-0a5e8470f185.png)
![tooltip_row_action_button](https://user-images.githubusercontent.com/715729/220743840-e64b306a-e62e-4634-86c4-eb6e05e118c6.png)
![tooltip_table_action_menu](https://user-images.githubusercontent.com/715729/220743842-d902c737-58cc-440e-8012-a5f566bd9542.png)
![tooltip_table_action_button](https://user-images.githubusercontent.com/715729/220743844-915d46c5-da7b-4910-acca-0707b6b89fce.png)
![tooltip_panel_header](https://user-images.githubusercontent.com/715729/220743848-cd6a9d63-c4cf-4acc-8ae5-c29fa3589ee3.png)
![tooltip_table_header](https://user-images.githubusercontent.com/715729/220743850-614cb557-1a1f-40d4-a383-b27f2049e91f.png)
<img width="1552" alt="tooltip_process_item" src="https://user-images.githubusercontent.com/715729/220743851-02293087-7a93-4213-9bde-80d4478ec5f1.png">
![popover_clusteredevents](https://user-images.githubusercontent.com/715729/220743853-edb39e38-19a9-4525-9988-9ad6428d5b88.png)
