### PR TITLE
Update value during UpdateRole call instead of reusing the same one

### DIFF
--- a/central/role/datastore/datastore_impl.go
+++ b/central/role/datastore/datastore_impl.go
@@ -114,11 +114,11 @@ func (ds *dataStoreImpl) UpdateRole(ctx context.Context, role *storage.Role) err
 	defer ds.lock.Unlock()
 
 	// Verify storage constraints.
-	role, err := ds.verifyRoleNameExists(ctx, role.GetName())
+	existingRole, err := ds.verifyRoleNameExists(ctx, role.GetName())
 	if err != nil {
 		return err
 	}
-	if err = verifyRoleOriginMatches(ctx, role); err != nil {
+	if err = verifyRoleOriginMatches(ctx, existingRole); err != nil {
 		return err
 	}
 	if err = ds.verifyRoleReferencesExist(ctx, role); err != nil {


### PR DESCRIPTION
## Description

The bug introduced within https://github.com/stackrox/stackrox/pull/4762 made it impossible to update roles via `datastore_impl#UpdateRole` - it was always reusing old value instead of new one.

This is a quick fix to correct the bug. Planning follow up PR to add similar test cases for access scopes and permission sets

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

1. Unit test added
