### PR TITLE
ROX-15020: Adding Workload CVE Overview page scaffolding

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/CveStatusTabNavigation.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/CveStatusTabNavigation.tsx
@@ -1,0 +1,70 @@
+import React, { useState } from 'react';
+import {
+    Tabs,
+    Tab,
+    TabTitleText,
+    TabsComponent,
+    PageSection,
+    Card,
+    CardBody,
+} from '@patternfly/react-core';
+
+import { vulnerabilitiesWorkloadCvesPath } from 'routePaths';
+import { getQueryString } from 'utils/queryStringUtils';
+import WorkloadTableToolbar from './WorkloadTableToolbar';
+import EntityTypeToggleGroup from './EntityTypeToggleGroup';
+import { WorkloadCvesSearch } from './searchUtils';
+
+const observedCvesQueryString = getQueryString<WorkloadCvesSearch>({ cveStatusTab: 'Observed' });
+const observedCvesPath = `${vulnerabilitiesWorkloadCvesPath}${observedCvesQueryString}`;
+
+function CveStatusTabNavigation() {
+    const [activeTabKey, setActiveTabKey] = useState(0);
+
+    function handleTabClick(e, tabIndex) {
+        setActiveTabKey(tabIndex);
+    }
+
+    return (
+        <Tabs
+            activeKey={activeTabKey}
+            onSelect={handleTabClick}
+            component={TabsComponent.nav}
+            className="pf-u-pl-lg pf-u-background-color-100"
+        >
+            <Tab
+                eventKey={0}
+                title={<TabTitleText>Observed CVEs</TabTitleText>}
+                href={observedCvesPath}
+            >
+                <PageSection isCenterAligned>
+                    <Card>
+                        <CardBody>
+                            <WorkloadTableToolbar />
+                            <EntityTypeToggleGroup />
+                            cve overview table here
+                        </CardBody>
+                    </Card>
+                </PageSection>
+            </Tab>
+            <Tab
+                eventKey={1}
+                title={<TabTitleText>Deferrals</TabTitleText>}
+                href={observedCvesPath}
+                isDisabled
+            >
+                deferrals tbd
+            </Tab>
+            <Tab
+                eventKey={2}
+                title={<TabTitleText>False Positives</TabTitleText>}
+                href={observedCvesPath}
+                isDisabled
+            >
+                False-positives tbd
+            </Tab>
+        </Tabs>
+    );
+}
+
+export default CveStatusTabNavigation;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/EntityTypeToggleGroup.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/EntityTypeToggleGroup.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+function EntityTypeToggleGroup() {
+    return <>Entity type toggle group</>;
+}
+
+export default EntityTypeToggleGroup;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesOverviewPage.tsx
@@ -1,7 +1,44 @@
 import React from 'react';
+import {
+    PageSection,
+    Title,
+    Divider,
+    Toolbar,
+    ToolbarItem,
+    Flex,
+    FlexItem,
+} from '@patternfly/react-core';
+
+import PageTitle from 'Components/PageTitle';
+import CveStatusTabNavigation from './CveStatusTabNavigation';
 
 function WorkloadCvesOverviewPage() {
-    return <>Workload CVEs Overview</>;
+    return (
+        <>
+            <PageTitle title="Workload CVEs Overview" />
+            <PageSection variant="light" padding={{ default: 'noPadding' }}>
+                <Toolbar>
+                    <ToolbarItem alignment={{ default: 'alignRight' }}>
+                        <div>Default vulnerability filters</div>
+                    </ToolbarItem>
+                </Toolbar>
+            </PageSection>
+            <Divider component="div" />
+            <PageSection variant="light" padding={{ default: 'noPadding' }}>
+                <Flex direction={{ default: 'column' }} className="pf-u-py-lg pf-u-pl-lg">
+                    <FlexItem>
+                        <Title headingLevel="h1">Workload CVEs</Title>
+                    </FlexItem>
+                    <FlexItem>
+                        Prioritize and manage scanned CVEs across images and deployments
+                    </FlexItem>
+                </Flex>
+            </PageSection>
+            <PageSection padding={{ default: 'noPadding' }}>
+                <CveStatusTabNavigation />
+            </PageSection>
+        </>
+    );
 }
 
 export default WorkloadCvesOverviewPage;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadTableToolbar.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadTableToolbar.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+function WorkloadTableToolbar() {
+    return (
+        <>
+            filter category dropdown, filter autocomplete input, cve severity dropdown, cve status
+            dropdown, applied filter chips
+        </>
+    );
+}
+
+export default WorkloadTableToolbar;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/searchUtils.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/searchUtils.tsx
@@ -1,0 +1,27 @@
+import qs from 'qs';
+import { SearchFilter } from 'types/search';
+
+export type CveStatusTab = 'Observed' | 'Deferred' | 'False Positive';
+export type EntityTab = 'CVE' | 'Image' | 'Deployment';
+
+export type WorkloadCvesSearch = {
+    cveStatusTab: CveStatusTab;
+    entityTab?: EntityTab;
+    s?: SearchFilter;
+};
+
+function isValidCveStatusTab(cveStatusTab: unknown): cveStatusTab is CveStatusTab {
+    return (
+        cveStatusTab === 'Observed' ||
+        cveStatusTab === 'Deferred' ||
+        cveStatusTab === 'False Positive'
+    );
+}
+
+export function parseWorkloadCvesOverviewSearchString(search: string): WorkloadCvesSearch {
+    const { cveStatusTab } = qs.parse(search, { ignoreQueryPrefix: true });
+
+    return {
+        cveStatusTab: isValidCveStatusTab(cveStatusTab) ? cveStatusTab : 'Observed',
+    };
+}


### PR DESCRIPTION
following the description in the ticket (https://issues.redhat.com/browse/ROX-15020)
just adding scaffolding and url state management for the tabs for now
<img width="1219" alt="image" src="https://user-images.githubusercontent.com/10412893/220796207-d1102c3c-b9d3-42e9-869e-2046ccb5c8a9.png">

