### PR TITLE
ROX-14945: make random names more random

### DIFF
--- a/tests/roxctl/bats-tests/cluster/deployment-bundles-psps.bats
+++ b/tests/roxctl/bats-tests/cluster/deployment-bundles-psps.bats
@@ -24,7 +24,7 @@ teardown() {
 sensor_bundle_psp_enabled() {
     local cluster_type="$1"
     shift
-    local sensor_name="sensor-test-${RANDOM}"
+    local sensor_name="sensor-test-${RANDOM}-${RANDOM}-${RANDOM}"
     local bundle_dir="${out_dir}/bundle-${sensor_name}"
     roxctl-release -e "$API_ENDPOINT" -p "$ROX_PASSWORD" sensor generate "${cluster_type}" --name="${sensor_name}" "$@" --output-dir="${bundle_dir}"
     run grep -rq "kind: PodSecurityPolicy" "${bundle_dir}"
@@ -34,7 +34,7 @@ sensor_bundle_psp_enabled() {
 sensor_bundle_psp_disabled() {
     local cluster_type="$1"
     shift
-    local sensor_name="sensor-test-${RANDOM}"
+    local sensor_name="sensor-test-${RANDOM}-${RANDOM}-${RANDOM}"
     local bundle_dir="${out_dir}/bundle-${sensor_name}"
     roxctl-release -e "$API_ENDPOINT" -p "$ROX_PASSWORD" sensor generate "${cluster_type}" --name="${sensor_name}" "$@" --output-dir="${bundle_dir}"
     run grep -rq "kind: PodSecurityPolicy" "${bundle_dir}"

--- a/tests/roxctl/bats-tests/local/deployment-bundles-psps.bats
+++ b/tests/roxctl/bats-tests/local/deployment-bundles-psps.bats
@@ -21,7 +21,7 @@ teardown() {
 central_bundle_psp_enabled() {
     local cluster_type="$1"
     shift
-    local bundle_dir="${out_dir}/bundle-central-$RANDOM"
+    local bundle_dir="${out_dir}/bundle-central-${RANDOM}-${RANDOM}-${RANDOM}"
     roxctl-release central generate "${cluster_type}" pvc "$@" --output-dir="${bundle_dir}"
     run grep -rq "kind: PodSecurityPolicy" "${bundle_dir}"
     assert_success
@@ -30,7 +30,7 @@ central_bundle_psp_enabled() {
 central_bundle_psp_disabled() {
     local cluster_type="$1"
     shift
-    local bundle_dir="${out_dir}/bundle-central-$RANDOM"
+    local bundle_dir="${out_dir}/bundle-central-${RANDOM}-${RANDOM}-${RANDOM}"
     roxctl-release central generate "${cluster_type}" pvc "$@" --output-dir="${bundle_dir}"
     run grep -rq "kind: PodSecurityPolicy" "${bundle_dir}"
     assert_failure

--- a/tests/roxctl/slim-collector.sh
+++ b/tests/roxctl/slim-collector.sh
@@ -50,7 +50,7 @@ test_collector_image_references_in_deployment_bundles() {
     SLIM_COLLECTOR_FLAG="$1"
     EXPECTED_IMAGE_CONDITION="$2"
 
-    CLUSTER_NAME="test-cluster-$RANDOM"
+    CLUSTER_NAME="test-cluster-${RANDOM}-${RANDOM}-${RANDOM}"
     echo "Testing correctness of collector image references for clusters generated with $SLIM_COLLECTOR_FLAG (cluster name is $CLUSTER_NAME)"
 
     # Verify that generating a cluster works.


### PR DESCRIPTION
## Description

Judging from the failure described in the ticket, 16 bit `$RANDOM` can repeat in a single CI run. Try and make this less likely.

## Checklist
- [x] Investigated and inspected CI test results: **the failures seem to be unrelated: known problems on 4.13, a couple of UI timeouts and a schedulability problem in `PolicyFieldsTest`**
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

CI should be sufficient. I'll trigger optional jobs since I'm not sure in what cases this is used.