### PR TITLE
Add queue length metric for process indicators

### DIFF
--- a/central/detection/lifecycle/manager_impl.go
+++ b/central/detection/lifecycle/manager_impl.go
@@ -209,8 +209,11 @@ func (m *managerImpl) addToIndicatorQueue(indicator *storage.ProcessIndicator) {
 	m.indicatorQueueLock.Lock()
 	defer m.indicatorQueueLock.Unlock()
 
-	centralMetrics.ModifyProcessQueueLength(1)
+	previousSize := len(m.queuedIndicators)
 	m.queuedIndicators[indicator.GetId()] = indicator
+	if len(m.queuedIndicators) != previousSize {
+		centralMetrics.ModifyProcessQueueLength(1)
+	}
 }
 
 func (m *managerImpl) addBaseline(deploymentID string) {

--- a/central/detection/lifecycle/manager_impl.go
+++ b/central/detection/lifecycle/manager_impl.go
@@ -180,6 +180,7 @@ func (m *managerImpl) flushIndicatorQueue() {
 	if len(copiedQueue) == 0 {
 		return
 	}
+	defer centralMetrics.ModifyProcessQueueLength(-len(copiedQueue))
 
 	defer centralMetrics.SetFunctionSegmentDuration(time.Now(), "FlushingIndicatorQueue")
 
@@ -208,6 +209,7 @@ func (m *managerImpl) addToIndicatorQueue(indicator *storage.ProcessIndicator) {
 	m.indicatorQueueLock.Lock()
 	defer m.indicatorQueueLock.Unlock()
 
+	centralMetrics.ModifyProcessQueueLength(1)
 	m.queuedIndicators[indicator.GetId()] = indicator
 }
 

--- a/central/metrics/central.go
+++ b/central/metrics/central.go
@@ -185,6 +185,13 @@ var (
 		Name:      "orphaned_plop_total",
 		Help:      "A counter of the total number of PLOP objects without a reference to a ProcessIndicator",
 	}, []string{"ClusterID"})
+
+	processQueueLengthGauge = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.CentralSubsystem.String(),
+		Name:      "process_queue_length",
+		Help:      "A gauge that indicates the current number of processes that have not been flushed",
+	})
 )
 
 func startTimeToMS(t time.Time) float64 {
@@ -307,4 +314,9 @@ func SetClusterMetrics(clusterID string, clusterMetrics *central.ClusterMetrics)
 // received at all. This type of situations require investigation.
 func IncrementOrphanedPLOPCounter(clusterID string) {
 	totalOrphanedPLOPCounter.With(prometheus.Labels{"ClusterID": clusterID}).Inc()
+}
+
+// ModifyProcessQueueLength modifies the metric for the number of processes that have not been flushed
+func ModifyProcessQueueLength(delta int) {
+	processQueueLengthGauge.Add(float64(delta))
 }

--- a/central/metrics/init.go
+++ b/central/metrics/init.go
@@ -34,5 +34,6 @@ func init() {
 		clusterMetricsNodeCountGaugeVec,
 		clusterMetricsCPUCapacityGaugeVec,
 		totalOrphanedPLOPCounter,
+		processQueueLengthGauge,
 	)
 }


### PR DESCRIPTION
## Description

Adds a metric that tracks how many indicators have yet to be flushed. This is not available in sensor_event_queue because of the batching

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Will run this on GKE once it builds and should prometheus metric
