### PR TITLE
[WIP] ROX-14660: Resolve the overwriting problem

### DIFF
--- a/central/dackbox/testutils/datastore.go
+++ b/central/dackbox/testutils/datastore.go
@@ -324,12 +324,12 @@ func (s *dackboxTestDataStoreImpl) PushNodeToVulnerabilitiesGraph(waitForIndexin
 	ctx := sac.WithAllAccess(context.Background())
 	testNode1 := fixtures.GetScopedNode1(uuid.NewV4().String(), testconsts.Cluster1)
 	testNode2 := fixtures.GetScopedNode2(uuid.NewV4().String(), testconsts.Cluster2)
-	err = s.nodeStore.UpsertNode(ctx, testNode1)
+	err = s.nodeStore.UpsertNode(ctx, testNode1, false)
 	if err != nil {
 		return err
 	}
 	s.storedNodes = append(s.storedNodes, testNode1.GetId())
-	err = s.nodeStore.UpsertNode(ctx, testNode2)
+	err = s.nodeStore.UpsertNode(ctx, testNode2, false)
 	if err != nil {
 		return err
 	}

--- a/central/graphql/resolvers/node_components_postgres_test.go
+++ b/central/graphql/resolvers/node_components_postgres_test.go
@@ -70,7 +70,7 @@ func (s *GraphQLNodeComponentTestSuite) SetupSuite() {
 		s.NoError(err)
 	}
 	for _, node := range testNodes {
-		err := nodeDS.UpsertNode(s.ctx, node)
+		err := nodeDS.UpsertNode(s.ctx, node, false)
 		s.NoError(err)
 	}
 }

--- a/central/graphql/resolvers/node_scan_benchmark_test.go
+++ b/central/graphql/resolvers/node_scan_benchmark_test.go
@@ -12,13 +12,13 @@ import (
 const (
 	nodeOnlyQuery = `
  		query getNodes($query: String, $pagination: Pagination) {
- 			nodes(query: $query, pagination: $pagination) { 
+ 			nodes(query: $query, pagination: $pagination) {
  				id
  			}}`
 
 	nodeWithCountsQuery = `
  		query getNodes($query: String, $pagination: Pagination) {
- 			nodes(query: $query, pagination: $pagination) { 
+ 			nodes(query: $query, pagination: $pagination) {
  				id
  				nodeComponentCount
  				nodeVulnerabilityCount
@@ -26,7 +26,7 @@ const (
 
 	nodeWithScanLongQuery = `
  		query getNodes($query: String, $pagination: Pagination) {
- 			nodes(query: $query, pagination: $pagination) { 
+ 			nodes(query: $query, pagination: $pagination) {
  				id
  				scan {
  					nodeComponents {
@@ -42,7 +42,7 @@ const (
 
 	nodeWithoutScanLongQuery = `
  		query getNodes($query: String, $pagination: Pagination) {
- 			nodes(query: $query, pagination: $pagination) { 
+ 			nodes(query: $query, pagination: $pagination) {
  				id
  				nodeComponents {
  					name
@@ -80,7 +80,7 @@ func BenchmarkNodeResolver(b *testing.B) {
 
 	nodes := getTestNodes(100)
 	for _, node := range nodes {
-		require.NoError(b, nodeDS.UpsertNode(ctx, node))
+		require.NoError(b, nodeDS.UpsertNode(ctx, node, false))
 	}
 
 	b.Run("GetNodeComponentsInNodeScanResolver", func(b *testing.B) {

--- a/central/graphql/resolvers/node_vulnerabilities_postgres_test.go
+++ b/central/graphql/resolvers/node_vulnerabilities_postgres_test.go
@@ -80,7 +80,7 @@ func (s *GraphQLNodeVulnerabilityTestSuite) SetupSuite() {
 		s.NoError(err)
 	}
 	for _, node := range testNodes {
-		err := s.nodeDatastore.UpsertNode(s.ctx, node)
+		err := s.nodeDatastore.UpsertNode(s.ctx, node, false)
 		s.NoError(err)
 	}
 }
@@ -472,7 +472,7 @@ func (s *GraphQLNodeVulnerabilityTestSuite) TestTopNodeVulnerability() {
 			},
 		},
 	}
-	err = s.nodeDatastore.UpsertNode(ctx, testNode)
+	err = s.nodeDatastore.UpsertNode(ctx, testNode, false)
 	s.NoError(err)
 
 	node = getNodeResolver(ctx, s.T(), s.resolver, testNode.GetId())

--- a/central/imagecomponent/search/searcher_impl_test.go
+++ b/central/imagecomponent/search/searcher_impl_test.go
@@ -186,7 +186,7 @@ func (suite *ImageComponentSearchTestSuite) TestBasicSearchNode() {
 	suite.Empty(results)
 
 	// Upsert node.
-	suite.NoError(suite.nodeDataStore.UpsertNode(ctx, node))
+	suite.NoError(suite.nodeDataStore.UpsertNode(ctx, node, false))
 
 	// Ensure the CVEs are indexed.
 	indexingDone := concurrency.NewSignal()

--- a/central/node/datastore/datastore.go
+++ b/central/node/datastore/datastore.go
@@ -39,7 +39,7 @@ type DataStore interface {
 	GetNodesBatch(ctx context.Context, ids []string) ([]*storage.Node, error)
 	GetManyNodeMetadata(ctx context.Context, ids []string) ([]*storage.Node, error)
 
-	UpsertNode(ctx context.Context, node *storage.Node) error
+	UpsertNode(ctx context.Context, node *storage.Node, ignoreScan bool) error
 
 	DeleteNodes(ctx context.Context, ids ...string) error
 	DeleteAllNodesForCluster(ctx context.Context, clusterID string) error

--- a/central/node/datastore/datastore_bench_postgres_test.go
+++ b/central/node/datastore/datastore_bench_postgres_test.go
@@ -65,7 +65,7 @@ func BenchmarkGetManyNodes(b *testing.B) {
 	}
 
 	for _, node := range nodes {
-		require.NoError(b, datastore.UpsertNode(ctx, node))
+		require.NoError(b, datastore.UpsertNode(ctx, node, false))
 	}
 
 	b.Run("GetNodesBatch", func(b *testing.B) {

--- a/central/node/datastore/datastore_bench_test.go
+++ b/central/node/datastore/datastore_bench_test.go
@@ -61,14 +61,14 @@ func BenchmarkNodes(b *testing.B) {
 		fakeNode.ClusterName = fmt.Sprintf("c-%d", i)
 		fakeNode.Name = fmt.Sprintf("node-%d", i)
 		nodes[i] = fakeNode
-		require.NoError(b, nodeDS.UpsertNode(ctx, fakeNode))
+		require.NoError(b, nodeDS.UpsertNode(ctx, fakeNode, false))
 	}
 
 	// Stored node is read because it contains new scan.
 	b.Run("upsertNodeWithOldScan", func(b *testing.B) {
 		fakeNode.Scan.ScanTime.Seconds = fakeNode.Scan.ScanTime.Seconds - 500
 		for i := 0; i < b.N; i++ {
-			err = nodeDS.UpsertNode(ctx, fakeNode)
+			err = nodeDS.UpsertNode(ctx, fakeNode, false)
 		}
 		require.NoError(b, err)
 	})
@@ -76,7 +76,7 @@ func BenchmarkNodes(b *testing.B) {
 	b.Run("upsertNodeWithNewScan", func(b *testing.B) {
 		fakeNode.Scan.ScanTime.Seconds = fakeNode.Scan.ScanTime.Seconds + 500
 		for i := 0; i < b.N; i++ {
-			err = nodeDS.UpsertNode(ctx, fakeNode)
+			err = nodeDS.UpsertNode(ctx, fakeNode, false)
 		}
 		require.NoError(b, err)
 	})

--- a/central/node/datastore/datastore_impl_postgres_test.go
+++ b/central/node/datastore/datastore_impl_postgres_test.go
@@ -111,7 +111,7 @@ func (suite *NodePostgresDataStoreTestSuite) TestBasicOps() {
 	allowAllCtx := sac.WithAllAccess(context.Background())
 
 	// Upsert.
-	suite.NoError(suite.datastore.UpsertNode(allowAllCtx, node))
+	suite.NoError(suite.datastore.UpsertNode(allowAllCtx, node, false))
 
 	// Get node.
 	storedNode, exists, err := suite.datastore.GetNode(allowAllCtx, node.Id)
@@ -137,7 +137,7 @@ func (suite *NodePostgresDataStoreTestSuite) TestBasicOps() {
 	// Upsert old scan should not change data (save for node.LastUpdated).
 	olderNode := node.Clone()
 	olderNode.GetScan().GetScanTime().Seconds = olderNode.GetScan().GetScanTime().GetSeconds() - 500
-	suite.NoError(suite.datastore.UpsertNode(allowAllCtx, olderNode))
+	suite.NoError(suite.datastore.UpsertNode(allowAllCtx, olderNode, false))
 	storedNode, exists, err = suite.datastore.GetNode(allowAllCtx, olderNode.Id)
 	suite.True(exists)
 	suite.NoError(err)
@@ -150,7 +150,7 @@ func (suite *NodePostgresDataStoreTestSuite) TestBasicOps() {
 	newNode.Id = fixtureconsts.Node2
 
 	// Upsert new node.
-	suite.NoError(suite.datastore.UpsertNode(allowAllCtx, newNode))
+	suite.NoError(suite.datastore.UpsertNode(allowAllCtx, newNode, false))
 
 	// Exists test.
 	exists, err = suite.datastore.Exists(allowAllCtx, fixtureconsts.Node2)
@@ -200,7 +200,7 @@ func (suite *NodePostgresDataStoreTestSuite) TestBasicSearch() {
 	suite.Empty(results)
 
 	// Upsert node.
-	suite.NoError(suite.datastore.UpsertNode(allowAllCtx, node))
+	suite.NoError(suite.datastore.UpsertNode(allowAllCtx, node, false))
 
 	// Basic unscoped search.
 	results, err = suite.datastore.Search(allowAllCtx, pkgSearch.EmptyQuery())
@@ -242,7 +242,7 @@ func (suite *NodePostgresDataStoreTestSuite) TestBasicSearch() {
 			},
 		},
 	})
-	suite.NoError(suite.datastore.UpsertNode(allowAllCtx, newNode))
+	suite.NoError(suite.datastore.UpsertNode(allowAllCtx, newNode, false))
 
 	// Search multiple nodes.
 	nodes, err = suite.datastore.SearchRawNodes(allowAllCtx, pkgSearch.EmptyQuery())
@@ -385,7 +385,7 @@ func (suite *NodePostgresDataStoreTestSuite) TestSortByComponent() {
 			))
 	}
 
-	suite.NoError(suite.datastore.UpsertNode(ctx, node))
+	suite.NoError(suite.datastore.UpsertNode(ctx, node, false))
 
 	// Verify sort by Component search label is transformed to sort by Component+Version.
 	query := pkgSearch.EmptyQuery()
@@ -434,7 +434,7 @@ func (suite *NodePostgresDataStoreTestSuite) upsertTestNodes(ctx context.Context
 	node := getTestNodeForPostgres(fixtureconsts.Node1, "name1")
 
 	// Upsert node.
-	suite.NoError(suite.datastore.UpsertNode(ctx, node))
+	suite.NoError(suite.datastore.UpsertNode(ctx, node, false))
 
 	// Upsert new node.
 	newNode := getTestNodeForPostgres(fixtureconsts.Node2, "name2")
@@ -449,7 +449,7 @@ func (suite *NodePostgresDataStoreTestSuite) upsertTestNodes(ctx context.Context
 			},
 		},
 	})
-	suite.NoError(suite.datastore.UpsertNode(ctx, newNode))
+	suite.NoError(suite.datastore.UpsertNode(ctx, newNode, false))
 }
 
 func (suite *NodePostgresDataStoreTestSuite) deleteTestNodes(ctx context.Context) {
@@ -462,7 +462,7 @@ func (suite *NodePostgresDataStoreTestSuite) TestOrphanedNodeTreeDeletion() {
 	ctx := sac.WithAllAccess(context.Background())
 	testNode := fixtures.GetNodeWithUniqueComponents(5, 5)
 	converter.MoveNodeVulnsToNewField(testNode)
-	suite.NoError(suite.datastore.UpsertNode(ctx, testNode))
+	suite.NoError(suite.datastore.UpsertNode(ctx, testNode, false))
 
 	storedNode, found, err := suite.datastore.GetNode(ctx, testNode.GetId())
 	suite.NoError(err)
@@ -484,7 +484,7 @@ func (suite *NodePostgresDataStoreTestSuite) TestOrphanedNodeTreeDeletion() {
 			cveIDsSet.Add(pkgCVE.ID(cve.GetCveBaseInfo().GetCve(), testNode.GetScan().GetOperatingSystem()))
 		}
 	}
-	suite.NoError(suite.datastore.UpsertNode(ctx, testNode))
+	suite.NoError(suite.datastore.UpsertNode(ctx, testNode, false))
 
 	// Verify node is built correctly.
 	storedNode, found, err = suite.datastore.GetNode(ctx, testNode.GetId())
@@ -505,7 +505,7 @@ func (suite *NodePostgresDataStoreTestSuite) TestOrphanedNodeTreeDeletion() {
 
 	testNode2 := testNode.Clone()
 	testNode2.Id = fixtureconsts.Node2
-	suite.NoError(suite.datastore.UpsertNode(ctx, testNode2))
+	suite.NoError(suite.datastore.UpsertNode(ctx, testNode2, false))
 	storedNode, found, err = suite.datastore.GetNode(ctx, testNode2.GetId())
 	suite.NoError(err)
 	suite.True(found)
@@ -540,7 +540,7 @@ func (suite *NodePostgresDataStoreTestSuite) TestOrphanedNodeTreeDeletion() {
 	}
 	testNode2.Scan.ScanTime = types.TimestampNow()
 
-	suite.NoError(suite.datastore.UpsertNode(ctx, testNode2))
+	suite.NoError(suite.datastore.UpsertNode(ctx, testNode2, false))
 	storedNode, found, err = suite.datastore.GetNode(ctx, testNode2.GetId())
 	suite.NoError(err)
 	suite.True(found)
@@ -566,7 +566,7 @@ func (suite *NodePostgresDataStoreTestSuite) TestOrphanedNodeTreeDeletion() {
 	// Verify that new scan with less components cleans up the old relations correctly.
 	testNode2.Scan.ScanTime = types.TimestampNow()
 	testNode2.Scan.Components = testNode2.Scan.Components[:len(testNode2.Scan.Components)-1]
-	suite.NoError(suite.datastore.UpsertNode(ctx, testNode2))
+	suite.NoError(suite.datastore.UpsertNode(ctx, testNode2, false))
 
 	// Verify node is built correctly.
 	storedNode, found, err = suite.datastore.GetNode(ctx, testNode2.GetId())
@@ -588,7 +588,7 @@ func (suite *NodePostgresDataStoreTestSuite) TestOrphanedNodeTreeDeletion() {
 	// Verify that new scan with no components and vulns cleans up the old relations correctly.
 	testNode2.Scan.ScanTime = types.TimestampNow()
 	testNode2.Scan.Components = nil
-	suite.NoError(suite.datastore.UpsertNode(ctx, testNode2))
+	suite.NoError(suite.datastore.UpsertNode(ctx, testNode2, false))
 
 	// Verify node is built correctly.
 	storedNode, found, err = suite.datastore.GetNode(ctx, testNode2.GetId())
@@ -621,15 +621,15 @@ func (suite *NodePostgresDataStoreTestSuite) TestGetManyNodeMetadata() {
 	ctx := sac.WithAllAccess(context.Background())
 	testNode1 := fixtures.GetNodeWithUniqueComponents(5, 5)
 	converter.MoveNodeVulnsToNewField(testNode1)
-	suite.NoError(suite.datastore.UpsertNode(ctx, testNode1))
+	suite.NoError(suite.datastore.UpsertNode(ctx, testNode1, false))
 
 	testNode2 := testNode1.Clone()
 	testNode2.Id = fixtureconsts.Node2
-	suite.NoError(suite.datastore.UpsertNode(ctx, testNode2))
+	suite.NoError(suite.datastore.UpsertNode(ctx, testNode2, false))
 
 	testNode3 := testNode1.Clone()
 	testNode3.Id = fixtureconsts.Node3
-	suite.NoError(suite.datastore.UpsertNode(ctx, testNode3))
+	suite.NoError(suite.datastore.UpsertNode(ctx, testNode3, false))
 
 	storedNodes, err := suite.datastore.GetManyNodeMetadata(ctx, []string{testNode1.Id, testNode2.Id, testNode3.Id})
 	suite.NoError(err)

--- a/central/node/datastore/datastore_impl_test.go
+++ b/central/node/datastore/datastore_impl_test.go
@@ -101,7 +101,7 @@ func (suite *NodeDataStoreTestSuite) TestBasicOps() {
 			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
 			sac.ResourceScopeKeys(resources.Node),
 		))
-	suite.Error(suite.datastore.UpsertNode(readCtx, node), "permission denied")
+	suite.Error(suite.datastore.UpsertNode(readCtx, node, false), "permission denied")
 
 	// No permission to write nodes.
 	imgCtx := sac.WithGlobalAccessScopeChecker(context.Background(),
@@ -109,7 +109,7 @@ func (suite *NodeDataStoreTestSuite) TestBasicOps() {
 			sac.AccessModeScopeKeys(storage.Access_READ_WRITE_ACCESS),
 			sac.ResourceScopeKeys(resources.Image),
 		))
-	suite.Error(suite.datastore.UpsertNode(imgCtx, node), "permission denied")
+	suite.Error(suite.datastore.UpsertNode(imgCtx, node, false), "permission denied")
 
 	ctx := sac.WithGlobalAccessScopeChecker(context.Background(), sac.AllowFixedScopes(
 		sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
@@ -117,7 +117,7 @@ func (suite *NodeDataStoreTestSuite) TestBasicOps() {
 	))
 
 	// Upsert node.
-	suite.NoError(suite.datastore.UpsertNode(ctx, node))
+	suite.NoError(suite.datastore.UpsertNode(ctx, node, false))
 
 	// Get node.
 	storedNode, exists, err := suite.datastore.GetNode(ctx, node.Id)
@@ -146,7 +146,7 @@ func (suite *NodeDataStoreTestSuite) TestBasicOps() {
 	olderNode := node.Clone()
 	olderNode.GetScan().GetScanTime().Seconds = olderNode.GetScan().GetScanTime().GetSeconds() - 500
 	olderNode.Scan = &storage.NodeScan{}
-	suite.NoError(suite.datastore.UpsertNode(ctx, olderNode))
+	suite.NoError(suite.datastore.UpsertNode(ctx, olderNode, false))
 	storedNode, exists, err = suite.datastore.GetNode(ctx, olderNode.Id)
 	suite.True(exists)
 	suite.NoError(err)
@@ -160,7 +160,7 @@ func (suite *NodeDataStoreTestSuite) TestBasicOps() {
 	newNode.Id = "id2"
 
 	// Upsert new node.
-	suite.NoError(suite.datastore.UpsertNode(ctx, newNode))
+	suite.NoError(suite.datastore.UpsertNode(ctx, newNode, false))
 
 	// Exists test.
 	exists, err = suite.datastore.Exists(ctx, "id2")
@@ -214,7 +214,7 @@ func (suite *NodeDataStoreTestSuite) TestBasicSearch() {
 	suite.Empty(results)
 
 	// Upsert node.
-	suite.NoError(suite.datastore.UpsertNode(ctx, node))
+	suite.NoError(suite.datastore.UpsertNode(ctx, node, false))
 
 	// Ensure the CVEs are indexed.
 	indexingDone := concurrency.NewSignal()
@@ -263,7 +263,7 @@ func (suite *NodeDataStoreTestSuite) TestBasicSearch() {
 			},
 		},
 	})
-	suite.NoError(suite.datastore.UpsertNode(ctx, newNode))
+	suite.NoError(suite.datastore.UpsertNode(ctx, newNode, false))
 
 	// Ensure the CVEs are indexed.
 	indexingDone = concurrency.NewSignal()
@@ -558,7 +558,7 @@ func (suite *NodeDataStoreTestSuite) upsertTestNodes(ctx context.Context) {
 	node := getTestNode("id1", "name1")
 
 	// Upsert node.
-	suite.NoError(suite.datastore.UpsertNode(ctx, node))
+	suite.NoError(suite.datastore.UpsertNode(ctx, node, false))
 
 	// Upsert new node.
 	newNode := getTestNode("id2", "name2")
@@ -572,7 +572,7 @@ func (suite *NodeDataStoreTestSuite) upsertTestNodes(ctx context.Context) {
 			},
 		},
 	})
-	suite.NoError(suite.datastore.UpsertNode(ctx, newNode))
+	suite.NoError(suite.datastore.UpsertNode(ctx, newNode, false))
 
 	// Ensure the CVEs are indexed.
 	indexingDone := concurrency.NewSignal()

--- a/central/node/datastore/datastore_sac_test.go
+++ b/central/node/datastore/datastore_sac_test.go
@@ -126,7 +126,7 @@ func (s *nodeDatastoreSACSuite) addTestNode(clusterID string) string {
 	node := fixtures.GetScopedNode(nodeID, clusterID)
 	node.Priority = 1
 
-	errUpsert := s.datastore.UpsertNode(s.testContexts[testutils.UnrestrictedReadWriteCtx], node)
+	errUpsert := s.datastore.UpsertNode(s.testContexts[testutils.UnrestrictedReadWriteCtx], node, false)
 	s.Require().NoError(errUpsert)
 	s.testNodeIDs[clusterID] = append(s.testNodeIDs[clusterID], nodeID)
 	s.testNodes[nodeID] = node
@@ -480,7 +480,7 @@ func (s *nodeDatastoreSACSuite) TestUpsertNode() {
 			node := fixtures.GetScopedNode(nodeID, clusterID)
 
 			ctx := s.testContexts[c.ScopeKey]
-			err := s.datastore.UpsertNode(ctx, node)
+			err := s.datastore.UpsertNode(ctx, node, false)
 
 			if c.ExpectError {
 				s.ErrorIs(err, c.ExpectedError)

--- a/central/node/datastore/mocks/datastore.go
+++ b/central/node/datastore/mocks/datastore.go
@@ -207,7 +207,7 @@ func (mr *MockDataStoreMockRecorder) SearchRawNodes(ctx, q interface{}) *gomock.
 }
 
 // UpsertNode mocks base method.
-func (m *MockDataStore) UpsertNode(ctx context.Context, node *storage.Node) error {
+func (m *MockDataStore) UpsertNode(ctx context.Context, node *storage.Node, ignoreScan bool) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpsertNode", ctx, node)
 	ret0, _ := ret[0].(error)

--- a/central/node/datastore/store/dackbox/store_impl.go
+++ b/central/node/datastore/store/dackbox/store_impl.go
@@ -147,7 +147,7 @@ func (b *storeImpl) GetMany(_ context.Context, ids []string) ([]*storage.Node, [
 }
 
 // Upsert writes a node to the DB, overwriting previous data.
-func (b *storeImpl) Upsert(_ context.Context, node *storage.Node) error {
+func (b *storeImpl) Upsert(ctx context.Context, node *storage.Node, ignoreScan bool) error {
 	defer metrics.SetDackboxOperationDurationTime(time.Now(), ops.Upsert, typ)
 
 	iTime := protoTypes.TimestampNow()

--- a/central/node/datastore/store/dackbox/store_impl_test.go
+++ b/central/node/datastore/store/dackbox/store_impl_test.go
@@ -113,7 +113,7 @@ func (suite *NodeStoreTestSuite) TestNodes() {
 
 	// Test Add
 	for _, d := range nodes {
-		suite.NoError(suite.store.Upsert(ctx, d))
+		suite.NoError(suite.store.Upsert(ctx, d, false))
 	}
 
 	for _, d := range nodes {
@@ -145,7 +145,7 @@ func (suite *NodeStoreTestSuite) TestNodes() {
 	}
 
 	for _, d := range nodes {
-		suite.NoError(suite.store.Upsert(ctx, d))
+		suite.NoError(suite.store.Upsert(ctx, d, false))
 	}
 
 	for _, d := range nodes {
@@ -166,7 +166,7 @@ func (suite *NodeStoreTestSuite) TestNodes() {
 	cloned.Name = "newname"
 	cloned.Scan.Components = nil
 	cloned.RiskScore = 100
-	suite.NoError(suite.store.Upsert(ctx, cloned))
+	suite.NoError(suite.store.Upsert(ctx, cloned, false))
 	got, exists, err := suite.store.Get(ctx, cloned.GetId())
 	suite.NoError(err)
 	suite.True(exists)
@@ -197,7 +197,7 @@ func (suite *NodeStoreTestSuite) TestNodes() {
 		},
 	}
 
-	suite.NoError(suite.store.Upsert(ctx, nodes[1]))
+	suite.NoError(suite.store.Upsert(ctx, nodes[1], false))
 
 	got, exists, err = suite.store.Get(ctx, nodes[1].GetId())
 	suite.NoError(err)
@@ -214,7 +214,7 @@ func (suite *NodeStoreTestSuite) TestNodes() {
 			VulnerabilityType: storage.EmbeddedVulnerability_NODE_VULNERABILITY,
 		})
 
-	suite.NoError(suite.store.Upsert(ctx, nodes[0]))
+	suite.NoError(suite.store.Upsert(ctx, nodes[0], false))
 
 	got, exists, err = suite.store.Get(ctx, nodes[0].GetId())
 	suite.NoError(err)
@@ -294,7 +294,7 @@ func (suite *NodeStoreTestSuite) TestNodeUpsert() {
 		RiskScore: 30,
 	}
 
-	suite.NoError(suite.store.Upsert(ctx, node))
+	suite.NoError(suite.store.Upsert(ctx, node, false))
 	storedNode, exists, err := suite.store.Get(ctx, node.GetId())
 	suite.NoError(err)
 	suite.True(exists)
@@ -309,7 +309,7 @@ func (suite *NodeStoreTestSuite) TestNodeUpsert() {
 
 	expectedNode := newNode.Clone()
 
-	suite.NoError(suite.store.Upsert(ctx, newNode))
+	suite.NoError(suite.store.Upsert(ctx, newNode, false))
 	storedNode, exists, err = suite.store.Get(ctx, newNode.GetId())
 	suite.NoError(err)
 	suite.True(exists)
@@ -321,7 +321,7 @@ func (suite *NodeStoreTestSuite) TestNodeUpsert() {
 	node.Scan.ScanTime = types.TimestampNow()
 	expectedNode.Scan.ScanTime = node.GetScan().GetScanTime()
 
-	suite.NoError(suite.store.Upsert(ctx, node))
+	suite.NoError(suite.store.Upsert(ctx, node, false))
 	storedNode, exists, err = suite.store.Get(ctx, node.GetId())
 	suite.NoError(err)
 	suite.True(exists)

--- a/central/node/datastore/store/mocks/store.go
+++ b/central/node/datastore/store/mocks/store.go
@@ -144,7 +144,7 @@ func (mr *MockStoreMockRecorder) GetNodeMetadata(ctx, id interface{}) *gomock.Ca
 }
 
 // Upsert mocks base method.
-func (m *MockStore) Upsert(ctx context.Context, node *storage.Node) error {
+func (m *MockStore) Upsert(ctx context.Context, node *storage.Node, ignoreScan bool) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Upsert", ctx, node)
 	ret0, _ := ret[0].(error)

--- a/central/node/datastore/store/postgres/store_test.go
+++ b/central/node/datastore/store/postgres/store_test.go
@@ -60,7 +60,7 @@ func (s *NodesStoreSuite) TestStore() {
 	s.False(exists)
 	s.Nil(foundNode)
 
-	s.NoError(store.Upsert(ctx, node))
+	s.NoError(store.Upsert(ctx, node, false))
 	foundNode, exists, err = store.Get(ctx, node.GetId())
 	s.NoError(err)
 	s.True(exists)
@@ -80,7 +80,7 @@ func (s *NodesStoreSuite) TestStore() {
 	nodeExists, err := store.Exists(ctx, node.GetId())
 	s.NoError(err)
 	s.True(nodeExists)
-	s.NoError(store.Upsert(ctx, node))
+	s.NoError(store.Upsert(ctx, node, false))
 
 	foundNode, exists, err = store.Get(ctx, node.GetId())
 	s.NoError(err)

--- a/central/node/datastore/store/store.go
+++ b/central/node/datastore/store/store.go
@@ -19,6 +19,6 @@ type Store interface {
 
 	Exists(ctx context.Context, id string) (bool, error)
 
-	Upsert(ctx context.Context, node *storage.Node) error
+	Upsert(ctx context.Context, node *storage.Node, ignoreScan bool) error
 	Delete(ctx context.Context, id string) error
 }

--- a/central/reprocessor/reprocessor.go
+++ b/central/reprocessor/reprocessor.go
@@ -447,7 +447,7 @@ func (l *loopImpl) reprocessNode(id string) bool {
 		return false
 	}
 
-	if err := l.risk.CalculateRiskAndUpsertNode(node); err != nil {
+	if err := l.risk.CalculateRiskAndUpsertNode(node, false); err != nil {
 		log.Errorf("error upserting node %q into datastore: %v", node.GetName(), err)
 		return false
 	}

--- a/central/risk/manager/manager.go
+++ b/central/risk/manager/manager.go
@@ -179,7 +179,7 @@ func (e *managerImpl) calculateAndUpsertNodeRisk(node *storage.Node) error {
 
 func (e *managerImpl) CalculateRiskAndUpsertNode(node *storage.Node, ignoreScan bool) error {
 	defer metrics.ObserveRiskProcessingDuration(time.Now(), "Node")
-	
+
 	if !ignoreScan {
 		// Risk data comes from the scan, so there is no point in recalculating the risk if scan should be ignored
 		if err := e.calculateAndUpsertNodeRisk(node); err != nil {

--- a/central/risk/manager/mocks/manager.go
+++ b/central/risk/manager/mocks/manager.go
@@ -49,7 +49,7 @@ func (mr *MockManagerMockRecorder) CalculateRiskAndUpsertImage(image interface{}
 }
 
 // CalculateRiskAndUpsertNode mocks base method.
-func (m *MockManager) CalculateRiskAndUpsertNode(node *storage.Node) error {
+func (m *MockManager) CalculateRiskAndUpsertNode(node *storage.Node, ignoreScan bool) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CalculateRiskAndUpsertNode", node)
 	ret0, _ := ret[0].(error)

--- a/central/sensor/service/pipeline/nodeinventory/pipeline.go
+++ b/central/sensor/service/pipeline/nodeinventory/pipeline.go
@@ -91,7 +91,7 @@ func (p *pipelineImpl) Run(ctx context.Context, clusterID string, msg *central.M
 
 	// Here NodeInventory stops to matter. All data required for the DB and UI is in node.NodeScan already
 
-	if err := p.riskManager.CalculateRiskAndUpsertNode(node); err != nil {
+	if err := p.riskManager.CalculateRiskAndUpsertNode(node, false); err != nil {
 		err = errors.Wrapf(err, "upserting node %s:%s into datastore", node.GetClusterName(), node.GetName())
 		log.Error(err)
 		return err

--- a/central/sensor/service/pipeline/nodes/pipeline.go
+++ b/central/sensor/service/pipeline/nodes/pipeline.go
@@ -2,6 +2,7 @@ package nodes
 
 import (
 	"context"
+	"strings"
 
 	"github.com/pkg/errors"
 	clusterDataStore "github.com/stackrox/rox/central/cluster/datastore"
@@ -95,13 +96,17 @@ func (p *pipelineImpl) Run(ctx context.Context, clusterID string, msg *central.M
 		log.Warnf("enriching node %s:%s: %v", node.GetClusterName(), node.GetName(), err)
 	}
 
-	if err := p.riskManager.CalculateRiskAndUpsertNode(node); err != nil {
+	if err := p.riskManager.CalculateRiskAndUpsertNode(node, isRHCOS(node.GetOsImage())); err != nil {
 		err = errors.Wrapf(err, "upserting node %s:%s into datastore", node.GetClusterName(), node.GetName())
 		log.Error(err)
 		return err
 	}
 
 	return nil
+}
+
+func isRHCOS(s string) bool {
+	return strings.HasPrefix(strings.ToLower(s), `red hat enterprise linux coreos `)
 }
 
 func (p *pipelineImpl) OnFinish(_ string) {}


### PR DESCRIPTION
## Description

The idea here is to pull up a bool flag to control whether the NodeScan data should ignored or treated the way that it used to be.
The goal is to force-ignore the updates to NodeScan & Risk when the Node is RHCOS and it arrives to the Node Pipeline.

The major open TODO is to handle the `serialized` field properly when upserting.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

- None yet
