### PR TITLE
Declarative configuration: forbid overriding resource origin

### DIFF
--- a/central/authprovider/datastore/datastore_impl.go
+++ b/central/authprovider/datastore/datastore_impl.go
@@ -60,12 +60,15 @@ func (b *datastoreImpl) UpdateAuthProvider(ctx context.Context, authProvider *st
 
 	// Currently, the data store does not support forcing updates.
 	// If we want to add a force flag to the respective API methods, we might need to revisit this.
-	ap, err := b.verifyExistsAndMutable(ctx, authProvider.GetId(), false)
+	existingProvider, err := b.verifyExistsAndMutable(ctx, authProvider.GetId(), false)
 	if err != nil {
 		return err
 	}
-	if err = verifyAuthProviderOriginMatches(ctx, ap); err != nil {
-		return err
+	if err = verifyAuthProviderOriginMatches(ctx, existingProvider); err != nil {
+		return errors.Wrap(err, "origin didn't match for existing auth provider")
+	}
+	if err = verifyAuthProviderOriginMatches(ctx, authProvider); err != nil {
+		return errors.Wrap(err, "origin didn't match for new auth provider")
 	}
 	return b.storage.Upsert(ctx, authProvider)
 }

--- a/central/group/datastore/datastore_impl.go
+++ b/central/group/datastore/datastore_impl.go
@@ -291,7 +291,10 @@ func (ds *dataStoreImpl) validateAndPrepGroupForUpdateNoLock(ctx context.Context
 		return err
 	}
 	if err = verifyGroupOriginMatches(ctx, existingGroup); err != nil {
-		return err
+		return errors.Wrap(err, "origin didn't match for existing group")
+	}
+	if err = verifyGroupOriginMatches(ctx, group); err != nil {
+		return errors.Wrap(err, "origin didn't match for new group")
 	}
 
 	defaultGroup, err := ds.getDefaultGroupForProps(ctx, group.GetProps())


### PR DESCRIPTION
## Description

Follow up on https://issues.redhat.com/browse/ROX-14182. Let's also ensure that you can't turn imperative resource into declarative and vice versa.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Unit tests run
