### PR TITLE
Dashrews/gke postgres upgrade test collector

### DIFF
--- a/tests/upgrade/postgres_run.sh
+++ b/tests/upgrade/postgres_run.sh
@@ -133,12 +133,14 @@ test_upgrade_paths() {
     info "Bouncing central"
     kubectl -n stackrox delete po "$(kubectl -n stackrox get po -l app=central -o=jsonpath='{.items[0].metadata.name}')" --grace-period=0
     wait_for_api
-    # Bounce collectors to avoid restarts on if central is down long enough so sensor restarts
-    kubectl -n stackrox delete pod -l app=collector --grace-period=0
+    sensor_wait
 
     # Verify data is still there
     checkForRocksAccessScopes
     checkForPostgresAccessScopes
+
+    # Bounce collectors to avoid restarts on if central is down long enough so sensor restarts
+    kubectl -n stackrox delete pod -l app=collector --grace-period=0
 
     validate_upgrade "01-bounce-after-upgrade" "bounce after postgres upgrade" "268c98c6-e983-4f4e-95d2-9793cebddfd7"
     collect_and_check_stackrox_logs "$log_output_dir" "01_post_bounce"

--- a/tests/upgrade/postgres_run.sh
+++ b/tests/upgrade/postgres_run.sh
@@ -139,6 +139,7 @@ test_upgrade_paths() {
     kubectl -n stackrox delete po "$(kubectl -n stackrox get po -l app=central -o=jsonpath='{.items[0].metadata.name}')" --grace-period=0
     wait_for_api
     sensor_wait
+    wait_for_collectors_to_be_operational
 
     # Verify data is still there
     checkForRocksAccessScopes
@@ -223,6 +224,7 @@ test_upgrade_paths() {
         "compliance=$REGISTRY/main:$CURRENT_TAG"
 
     sensor_wait
+    wait_for_collectors_to_be_operational
 
     wait_for_central_reconciliation
 
@@ -307,6 +309,7 @@ deploy_scaled_workload() {
     ./deploy/k8s/sensor.sh
 
     sensor_wait
+    wait_for_collectors_to_be_operational
 
     ./scale/launch_workload.sh scale-test
 

--- a/tests/upgrade/postgres_run.sh
+++ b/tests/upgrade/postgres_run.sh
@@ -144,9 +144,6 @@ test_upgrade_paths() {
     checkForRocksAccessScopes
     checkForPostgresAccessScopes
 
-    # Bounce collectors to avoid restarts on if central is down long enough so sensor restarts
-    kubectl -n stackrox delete pod -l app=collector --grace-period=0
-
     validate_upgrade "01-bounce-after-upgrade" "bounce after postgres upgrade" "268c98c6-e983-4f4e-95d2-9793cebddfd7"
     collect_and_check_stackrox_logs "$log_output_dir" "01_post_bounce"
 

--- a/tests/upgrade/postgres_run.sh
+++ b/tests/upgrade/postgres_run.sh
@@ -119,6 +119,8 @@ test_upgrade_paths() {
     helm_upgrade_to_postgres
     wait_for_api
     wait_for_scanner_to_be_ready
+    # Bounce collectors to avoid restarts on initial module pull
+    kubectl -n stackrox delete pod -l app=collector --grace-period=0
 
     # Upgraded to Postgres via helm.  Validate the upgrade.
     validate_upgrade "00_upgrade" "central upgrade to postgres" "268c98c6-e983-4f4e-95d2-9793cebddfd7"
@@ -139,7 +141,8 @@ test_upgrade_paths() {
     kubectl -n stackrox delete po "$(kubectl -n stackrox get po -l app=central -o=jsonpath='{.items[0].metadata.name}')" --grace-period=0
     wait_for_api
     sensor_wait
-    wait_for_collectors_to_be_operational
+    # Bounce collectors to avoid restarts on initial module pull
+    kubectl -n stackrox delete pod -l app=collector --grace-period=0
 
     # Verify data is still there
     checkForRocksAccessScopes
@@ -224,7 +227,8 @@ test_upgrade_paths() {
         "compliance=$REGISTRY/main:$CURRENT_TAG"
 
     sensor_wait
-    wait_for_collectors_to_be_operational
+    # Bounce collectors to avoid restarts on initial module pull
+    kubectl -n stackrox delete pod -l app=collector --grace-period=0
 
     wait_for_central_reconciliation
 
@@ -309,7 +313,6 @@ deploy_scaled_workload() {
     ./deploy/k8s/sensor.sh
 
     sensor_wait
-    wait_for_collectors_to_be_operational
 
     ./scale/launch_workload.sh scale-test
 


### PR DESCRIPTION
## Description

The nature of this tests involves lots of upgrades and restarts.  So pods are coming up and down fairly regularly by design.  So when some of those restarts are slow we can get into situations where something like sensor takes too long to come back up so collector may have an unallowed restart because sensor took too long to come back up.  For this test, things like that are not really an issue.  So for this test only we will allow such restarts of collector.

This solves the issues where the tests gets flagged for collector having a previous.  Not the issue where the test cannot get metadata if it gets rotated to a 1.24 cluster.

## Checklist
- [ ] Investigated and inspected CI test results
~- [ ] Unit test and regression tests added~
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

All about this test.
