### PR TITLE
ROX-15341: Fix for default function prop causing useEffect loop

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnmanagement/entitypages.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/entitypages.test.js
@@ -330,7 +330,6 @@ describe('Entities single views', () => {
             cy.get(`${selectors.tableRows}`).eq(1).click();
         }, entitiesKey);
 
-        cy.get('button:contains("Fixable CVEs")').click();
         cy.wait('@getFixableCvesForEntity');
         cy.get(`${selectors.sidePanel} ${selectors.tableRows}:contains("CVE-2021-20231")`).contains(
             'Active'

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/TableModal.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/TableModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import {
     Button,
     ButtonVariant,
@@ -36,10 +36,13 @@ function TableModal({
 }: TableModalProps): React.ReactElement {
     const [isModalOpen, setIsModalOpen] = useState(false);
 
+    const isPreSelected = useCallback(
+        (row) => (value.arrayValue ? (value.arrayValue.includes(row.id) as boolean) : false),
+        [value]
+    );
+
     const { selected, onSelect, onSelectAll, allRowsSelected, onResetAll, getSelectedIds } =
-        useTableSelection(rows, (row) => {
-            return value.arrayValue ? (value.arrayValue.includes(row.id) as boolean) : false;
-        });
+        useTableSelection(rows, isPreSelected);
 
     function onCloseModalHandler() {
         onResetAll();

--- a/ui/apps/platform/src/hooks/useTableSelection.ts
+++ b/ui/apps/platform/src/hooks/useTableSelection.ts
@@ -20,10 +20,12 @@ type Base = {
     id: string;
 };
 
+const defaultPreSelectedFunc = () => false;
+
 function useTableSelection<T extends Base>(
     data: T[],
     // determines whether value should be pre-selected or not
-    preSelectedFunc: (T) => boolean = () => false
+    preSelectedFunc: (T) => boolean = defaultPreSelectedFunc
 ): UseTableSelection {
     const [selected, setSelected] = React.useState(data.map(preSelectedFunc));
     const allRowsSelected = selected.length !== 0 && selected.every((val) => val);
@@ -32,7 +34,7 @@ function useTableSelection<T extends Base>(
 
     React.useEffect(() => {
         setSelected(data.map(preSelectedFunc));
-    }, [data]);
+    }, [data, preSelectedFunc]);
 
     const onClearAll = () => {
         setSelected(data.map(() => false));

--- a/ui/apps/platform/src/hooks/useTableSelection.ts
+++ b/ui/apps/platform/src/hooks/useTableSelection.ts
@@ -20,10 +20,12 @@ type Base = {
     id: string;
 };
 
+const defaultPreSelectedFunc = () => false;
+
 function useTableSelection<T extends Base>(
     data: T[],
     // determines whether value should be pre-selected or not
-    preSelectedFunc: (T) => boolean = () => false
+    preSelectedFunc: (T) => boolean = defaultPreSelectedFunc
 ): UseTableSelection {
     const [selected, setSelected] = React.useState(data.map(preSelectedFunc));
     const allRowsSelected = selected.length !== 0 && selected.every((val) => val);

--- a/ui/apps/platform/src/hooks/useTableSelection.ts
+++ b/ui/apps/platform/src/hooks/useTableSelection.ts
@@ -20,12 +20,10 @@ type Base = {
     id: string;
 };
 
-const defaultPreSelectedFunc = () => false;
-
 function useTableSelection<T extends Base>(
     data: T[],
     // determines whether value should be pre-selected or not
-    preSelectedFunc: (T) => boolean = defaultPreSelectedFunc
+    preSelectedFunc: (T) => boolean = () => false
 ): UseTableSelection {
     const [selected, setSelected] = React.useState(data.map(preSelectedFunc));
     const allRowsSelected = selected.length !== 0 && selected.every((val) => val);
@@ -34,7 +32,7 @@ function useTableSelection<T extends Base>(
 
     React.useEffect(() => {
         setSelected(data.map(preSelectedFunc));
-    }, [data, preSelectedFunc]);
+    }, [data]);
 
     const onClearAll = () => {
         setSelected(data.map(() => false));


### PR DESCRIPTION
## Description

Due to defining a default function within the React custom hook, the reference keeps changing and triggers the useEffect, resulting in an infinite loop. Defining the function outside of the hook fixes this issue. The TableModal.tsx file has a similar problem with a passed-in function. However, this issue can be fixed by using the useCallback hook.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Manually tested violations and policy management tables