### PR TITLE
Increase alert parallelism and cleanup unused functions

### DIFF
--- a/central/alert/datastore/bench_postgres_test.go
+++ b/central/alert/datastore/bench_postgres_test.go
@@ -92,14 +92,6 @@ func BenchmarkAlertDatabaseOps(b *testing.B) {
 		}
 	})
 
-	b.Run("markStale", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
-			for _, id := range ids {
-				require.NoError(b, datastore.MarkAlertStale(ctx, id))
-			}
-		}
-	})
-
 	b.Run("markStaleBatch", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			_, err := datastore.MarkAlertStaleBatch(ctx, ids...)

--- a/central/alert/datastore/bench_test.go
+++ b/central/alert/datastore/bench_test.go
@@ -57,14 +57,6 @@ func BenchmarkDBs(b *testing.B) {
 		}
 	})
 
-	b.Run("markStale", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
-			for _, id := range ids {
-				require.NoError(b, datastore.MarkAlertStale(ctx, id))
-			}
-		}
-	})
-
 	b.Run("markStaleBatch", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			_, err := datastore.MarkAlertStaleBatch(ctx, ids...)

--- a/central/alert/datastore/mocks/datastore.go
+++ b/central/alert/datastore/mocks/datastore.go
@@ -117,20 +117,6 @@ func (mr *MockDataStoreMockRecorder) ListAlerts(ctx, request interface{}) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAlerts", reflect.TypeOf((*MockDataStore)(nil).ListAlerts), ctx, request)
 }
 
-// MarkAlertStale mocks base method.
-func (m *MockDataStore) MarkAlertStale(ctx context.Context, id string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MarkAlertStale", ctx, id)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// MarkAlertStale indicates an expected call of MarkAlertStale.
-func (mr *MockDataStoreMockRecorder) MarkAlertStale(ctx, id interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkAlertStale", reflect.TypeOf((*MockDataStore)(nil).MarkAlertStale), ctx, id)
-}
-
 // MarkAlertStaleBatch mocks base method.
 func (m *MockDataStore) MarkAlertStaleBatch(ctx context.Context, id ...string) ([]*storage.Alert, error) {
 	m.ctrl.T.Helper()

--- a/central/pruning/pruning_test.go
+++ b/central/pruning/pruning_test.go
@@ -403,7 +403,6 @@ func (s *PruningTestSuite) generateClusterDataStructures() (configDatastore.Data
 	podDataStore.EXPECT().Search(gomock.Any(), gomock.Any()).AnyTimes().Return(nil, nil)
 	imageIntegrationDataStore.EXPECT().Search(gomock.Any(), gomock.Any()).AnyTimes().Return(nil, nil)
 	alertDataStore.EXPECT().SearchRawAlerts(gomock.Any(), gomock.Any()).AnyTimes().Return(nil, nil)
-	alertDataStore.EXPECT().MarkAlertStale(gomock.Any(), gomock.Any()).AnyTimes().Return(nil)
 	notifierMock.EXPECT().ProcessAlert(gomock.Any(), gomock.Any()).AnyTimes().Return()
 	podDataStore.EXPECT().RemovePod(gomock.Any(), gomock.Any()).AnyTimes().Return(nil)
 	imageIntegrationDataStore.EXPECT().RemoveImageIntegration(gomock.Any(), gomock.Any()).AnyTimes().Return(nil)


### PR DESCRIPTION
## Description

Increase alert parallelism due to mutex profile showing lots of slowness
<img width="588" alt="Screenshot 2023-02-23 at 1 41 50 PM" src="https://user-images.githubusercontent.com/2565181/221037121-bcfa0134-26b4-4f6d-849e-91a37776d58a.png">

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Will run in a scaled cluster