### PR TITLE
[ROX-13659] : Allow subject searcher to search by roleBinding fields

### DIFF
--- a/central/graphql/resolvers/node_vulnerabilities_postgres_test.go
+++ b/central/graphql/resolvers/node_vulnerabilities_postgres_test.go
@@ -1,3 +1,6 @@
+//go:build sql_integration
+// +build sql_integration
+
 package resolvers
 
 import (

--- a/central/graphql/resolvers/node_vulnerabilities_postgres_test.go
+++ b/central/graphql/resolvers/node_vulnerabilities_postgres_test.go
@@ -1,10 +1,8 @@
-//go:build sql_integration
-// +build sql_integration
-
 package resolvers
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -16,6 +14,7 @@ import (
 	nodePostgres "github.com/stackrox/rox/central/node/datastore/store/postgres"
 	nodeComponentPostgres "github.com/stackrox/rox/central/nodecomponent/datastore/store/postgres"
 	nodeComponentCVEEdgePostgres "github.com/stackrox/rox/central/nodecomponentcveedge/datastore/store/postgres"
+	k8sRoleBindingDataStore "github.com/stackrox/rox/central/rbac/k8srolebinding/datastore"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/env"
@@ -23,6 +22,7 @@ import (
 	"github.com/stackrox/rox/pkg/grpc/authz/allow"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/pgtest"
+	postgresSchema "github.com/stackrox/rox/pkg/postgres/schema"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search/scoped"
 	"github.com/stretchr/testify/suite"
@@ -64,14 +64,46 @@ func (s *GraphQLNodeVulnerabilityTestSuite) SetupSuite() {
 	s.db, s.gormDB = SetupTestPostgresConn(s.T())
 
 	s.nodeDatastore = CreateTestNodeDatastore(s.T(), s.db, s.gormDB, mockCtrl)
+
+	s.dropTable(postgresSchema.RoleBindingsTableName)
+	s.dropTable(postgresSchema.RoleBindingsSubjectsTableName)
+	//	postgresSchema.ApplySchemaForTable(s.ctx, s.gormDB, postgresSchema.RoleBindingsSubjectsTableName)
+	postgresSchema.ApplySchemaForTable(s.ctx, s.gormDB, postgresSchema.RoleBindingsTableName)
+
+	k8sRoleBindingDatastore, err := k8sRoleBindingDataStore.GetTestPostgresDataStore(s.T(), s.db)
+	s.NoError(err)
 	resolver, _ := SetupTestResolver(s.T(),
 		CreateTestNodeCVEDatastore(s.T(), s.db, s.gormDB),
 		CreateTestNodeComponentDatastore(s.T(), s.db, s.gormDB, mockCtrl),
 		s.nodeDatastore,
 		CreateTestNodeComponentCveEdgeDatastore(s.T(), s.db, s.gormDB),
 		CreateTestClusterDatastore(s.T(), s.db, s.gormDB, mockCtrl, nil, nil, s.nodeDatastore),
+		k8sRoleBindingDatastore,
 	)
 	s.resolver = resolver
+
+	roleBindings := testK8sRoleBindings()
+	for _, roleBinding := range roleBindings {
+		err = k8sRoleBindingDatastore.UpsertRoleBinding(s.ctx, roleBinding)
+		s.NoError(err)
+	}
+
+	req := searchRequest{
+		Query:      "Cluster:c1",
+		Categories: &[]string{"SUBJECTS"},
+	}
+	allowAllCtx := SetAuthorizerOverride(s.ctx, allow.Anonymous())
+	results, err := resolver.SearchAutocomplete(allowAllCtx, req)
+	s.NoError(err)
+	fmt.Printf("%v\n", results)
+
+	req = searchRequest{
+		Query:      "Subject:subjectID1",
+		Categories: &[]string{"SUBJECTS"},
+	}
+	results, err = resolver.SearchAutocomplete(allowAllCtx, req)
+	s.NoError(err)
+	fmt.Printf("%v\n", results)
 
 	// Add test data to DataStores
 	testClusters, testNodes := testClustersWithNodes()
@@ -479,4 +511,61 @@ func (s *GraphQLNodeVulnerabilityTestSuite) TestTopNodeVulnerability() {
 	topVuln, err = node.TopNodeVulnerability(ctx, RawQuery{})
 	s.NoError(err)
 	s.Nil(topVuln)
+}
+
+func testK8sRoleBindings() []*storage.K8SRoleBinding {
+	return []*storage.K8SRoleBinding{
+		{
+			Id:          fixtureconsts.RoleBinding1,
+			Name:        "rb1",
+			ClusterName: "c1",
+			ClusterId:   fixtureconsts.Cluster1,
+			ClusterRole: true,
+			Subjects: []*storage.Subject{
+				{
+					Id:          "subjectID1",
+					Name:        "subjectID1",
+					Kind:        storage.SubjectKind_USER,
+					ClusterId:   fixtureconsts.Cluster1,
+					ClusterName: "c1",
+				},
+				{
+					Id:          "subjectID2",
+					Name:        "subjectID2",
+					Kind:        storage.SubjectKind_USER,
+					ClusterId:   fixtureconsts.Cluster1,
+					ClusterName: "c1",
+				},
+			},
+		},
+		{
+			Id:          fixtureconsts.RoleBinding2,
+			Name:        "rb2",
+			ClusterName: "c2",
+			ClusterId:   fixtureconsts.Cluster2,
+			ClusterRole: true,
+			Subjects: []*storage.Subject{
+				{
+					Id:          "subjectID3",
+					Name:        "subjectID3",
+					Kind:        storage.SubjectKind_USER,
+					ClusterId:   fixtureconsts.Cluster1,
+					ClusterName: "c2",
+				},
+				{
+					Id:          "subjectID4",
+					Name:        "subjectID4",
+					Kind:        storage.SubjectKind_USER,
+					ClusterId:   fixtureconsts.Cluster1,
+					ClusterName: "c2",
+				},
+			},
+		},
+	}
+}
+
+func (s *GraphQLNodeVulnerabilityTestSuite) dropTable(name string) {
+	sql := fmt.Sprintf("DROP TABLE IF EXISTS %s CASCADE", name)
+	_, err := s.db.Exec(s.ctx, sql)
+	s.NoError(err)
 }

--- a/central/graphql/resolvers/node_vulnerabilities_postgres_test.go
+++ b/central/graphql/resolvers/node_vulnerabilities_postgres_test.go
@@ -2,7 +2,6 @@ package resolvers
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -478,10 +477,4 @@ func (s *GraphQLNodeVulnerabilityTestSuite) TestTopNodeVulnerability() {
 	topVuln, err = node.TopNodeVulnerability(ctx, RawQuery{})
 	s.NoError(err)
 	s.Nil(topVuln)
-}
-
-func (s *GraphQLNodeVulnerabilityTestSuite) dropTable(name string) {
-	sql := fmt.Sprintf("DROP TABLE IF EXISTS %s CASCADE", name)
-	_, err := s.db.Exec(s.ctx, sql)
-	s.NoError(err)
 }

--- a/central/graphql/resolvers/search_test.go
+++ b/central/graphql/resolvers/search_test.go
@@ -1,6 +1,8 @@
 package resolvers
 
 import (
+	"context"
+	"fmt"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -11,6 +13,7 @@ import (
 	imageCVEMocks "github.com/stackrox/rox/central/cve/image/datastore/mocks"
 	nodeCVEMocks "github.com/stackrox/rox/central/cve/node/datastore/mocks"
 	deploymentMocks "github.com/stackrox/rox/central/deployment/datastore/mocks"
+	"github.com/stackrox/rox/central/graphql/resolvers/loaders"
 	imageMocks "github.com/stackrox/rox/central/image/datastore/mocks"
 	imageComponentMocks "github.com/stackrox/rox/central/imagecomponent/datastore/mocks"
 	namespaceMocks "github.com/stackrox/rox/central/namespace/datastore/mocks"
@@ -20,13 +23,19 @@ import (
 	policyMocks "github.com/stackrox/rox/central/policy/datastore/mocks"
 	policyCategoryMocks "github.com/stackrox/rox/central/policycategory/datastore/mocks"
 	k8sroleMocks "github.com/stackrox/rox/central/rbac/k8srole/datastore/mocks"
+	k8sRoleBindingDataStore "github.com/stackrox/rox/central/rbac/k8srolebinding/datastore"
 	k8srolebindingMocks "github.com/stackrox/rox/central/rbac/k8srolebinding/datastore/mocks"
 	globalSearch "github.com/stackrox/rox/central/search"
 	secretMocks "github.com/stackrox/rox/central/secret/datastore/mocks"
 	serviceAccountMocks "github.com/stackrox/rox/central/serviceaccount/datastore/mocks"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/pkg/env"
+	"github.com/stackrox/rox/pkg/fixtures"
+	"github.com/stackrox/rox/pkg/grpc/authz/allow"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
+	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSearchCategories(t *testing.T) {
@@ -88,5 +97,87 @@ func TestSearchCategories(t *testing.T) {
 		default:
 			assert.True(t, searchFuncs[category] != nil, "search category %s does not have a search func", category.String())
 		}
+	}
+}
+
+func TestSubjectAutocompleteSearch(t *testing.T) {
+	t.Setenv(env.PostgresDatastoreEnabled.EnvVar(), "true")
+
+	if !env.PostgresDatastoreEnabled.BooleanSetting() {
+		t.Skip("Skip postgres store tests")
+		t.SkipNow()
+	}
+
+	testDB := pgtest.ForT(t)
+	testGormDB := testDB.GetGormDB(t)
+	defer pgtest.CloseGormDB(t, testGormDB)
+	defer testDB.Teardown(t)
+
+	roleBindingDatastore, err := k8sRoleBindingDataStore.GetTestPostgresDataStore(t, testDB.DB)
+	require.NoError(t, err)
+
+	ctx := loaders.WithLoaderContext(sac.WithAllAccess(context.Background()))
+	roleBindings := fixtures.GetMultipleK8sRoleBindings(2, 3)
+	for _, roleBinding := range roleBindings {
+		err = roleBindingDatastore.UpsertRoleBinding(ctx, roleBinding)
+		require.NoError(t, err)
+	}
+
+	resolver, _ := SetupTestResolver(t, roleBindingDatastore)
+	allowAllCtx := SetAuthorizerOverride(ctx, allow.Anonymous())
+
+	testCases := []struct {
+		desc     string
+		request  searchRequest
+		expected []string
+	}{
+		{
+			desc: "Search by subject name",
+			request: searchRequest{
+				Query:      fmt.Sprintf("Subject:%s", roleBindings[0].Subjects[1].Name),
+				Categories: &[]string{"SUBJECTS"},
+			},
+			expected: []string{roleBindings[0].Subjects[1].Name},
+		},
+		{
+			desc: "Search by subject kind",
+			request: searchRequest{
+				Query:      "Subject Kind:",
+				Categories: &[]string{"SUBJECTS"},
+			},
+			expected: []string{"user", "group"},
+		},
+		{
+			desc: "Search by cluster name",
+			request: searchRequest{
+				Query:      fmt.Sprintf("Cluster:%s", roleBindings[1].ClusterName),
+				Categories: &[]string{"SUBJECTS"},
+			},
+			expected: []string{roleBindings[1].ClusterName},
+		},
+		{
+			desc: "Search by cluster role",
+			request: searchRequest{
+				Query:      "Cluster Role:tr",
+				Categories: &[]string{"SUBJECTS"},
+			},
+			expected: []string{"true"},
+		},
+		{
+			desc: "Search by cluster name and subject name",
+			request: searchRequest{
+				Query:      fmt.Sprintf("Cluster:%s+Subject:", roleBindings[0].ClusterName),
+				Categories: &[]string{"SUBJECTS"},
+			},
+			expected: []string{roleBindings[0].Subjects[1].Name, roleBindings[0].Subjects[2].Name},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			results, err := resolver.SearchAutocomplete(allowAllCtx, tc.request)
+			require.NoError(t, err)
+			require.ElementsMatch(t, tc.expected, results)
+		})
 	}
 }

--- a/central/graphql/resolvers/search_test.go
+++ b/central/graphql/resolvers/search_test.go
@@ -132,7 +132,7 @@ func TestSubjectAutocompleteSearch(t *testing.T) {
 		expected []string
 	}{
 		{
-			desc: "Search by subject name",
+			desc: "Subject name autocomplete",
 			request: searchRequest{
 				Query:      fmt.Sprintf("Subject:%s", roleBindings[0].Subjects[1].Name),
 				Categories: &[]string{"SUBJECTS"},
@@ -140,7 +140,7 @@ func TestSubjectAutocompleteSearch(t *testing.T) {
 			expected: []string{roleBindings[0].Subjects[1].Name},
 		},
 		{
-			desc: "Search by subject kind",
+			desc: "Subject Kind autocomplete",
 			request: searchRequest{
 				Query:      "Subject Kind:",
 				Categories: &[]string{"SUBJECTS"},
@@ -148,7 +148,7 @@ func TestSubjectAutocompleteSearch(t *testing.T) {
 			expected: []string{"user", "group"},
 		},
 		{
-			desc: "Search by cluster name",
+			desc: "Cluster name autocomplete",
 			request: searchRequest{
 				Query:      fmt.Sprintf("Cluster:%s", roleBindings[1].ClusterName),
 				Categories: &[]string{"SUBJECTS"},
@@ -156,7 +156,7 @@ func TestSubjectAutocompleteSearch(t *testing.T) {
 			expected: []string{roleBindings[1].ClusterName},
 		},
 		{
-			desc: "Search by cluster role",
+			desc: "Cluster role autocomplete",
 			request: searchRequest{
 				Query:      "Cluster Role:tr",
 				Categories: &[]string{"SUBJECTS"},
@@ -164,7 +164,7 @@ func TestSubjectAutocompleteSearch(t *testing.T) {
 			expected: []string{"true"},
 		},
 		{
-			desc: "Search by cluster name and subject name",
+			desc: "Cluster name + Subject name autocomplete",
 			request: searchRequest{
 				Query:      fmt.Sprintf("Cluster:%s+Subject:", roleBindings[0].ClusterName),
 				Categories: &[]string{"SUBJECTS"},

--- a/central/graphql/resolvers/search_test.go
+++ b/central/graphql/resolvers/search_test.go
@@ -173,6 +173,14 @@ func TestSubjectAutocompleteSearch(t *testing.T) {
 			},
 			expected: []string{roleBindings[0].Subjects[1].Name, roleBindings[0].Subjects[2].Name},
 		},
+		{
+			desc: "Autocomplete on unsupported option",
+			request: searchRequest{
+				Query:      fmt.Sprintf("Deployment:d1"),
+				Categories: &[]string{"SUBJECTS"},
+			},
+			expected: []string{},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/central/graphql/resolvers/search_test.go
+++ b/central/graphql/resolvers/search_test.go
@@ -1,3 +1,5 @@
+//go:build sql_integration
+
 package resolvers
 
 import (

--- a/central/graphql/resolvers/search_test.go
+++ b/central/graphql/resolvers/search_test.go
@@ -176,7 +176,7 @@ func TestSubjectAutocompleteSearch(t *testing.T) {
 		{
 			desc: "Autocomplete on unsupported option",
 			request: searchRequest{
-				Query:      fmt.Sprintf("Deployment:d1"),
+				Query:      "Deployment:d1",
 				Categories: &[]string{"SUBJECTS"},
 			},
 			expected: []string{},

--- a/central/graphql/resolvers/test_setup_utils.go
+++ b/central/graphql/resolvers/test_setup_utils.go
@@ -50,6 +50,7 @@ import (
 	nodeComponentCVEEdgeSearch "github.com/stackrox/rox/central/nodecomponentcveedge/datastore/search"
 	nodeComponentCVEEdgePostgres "github.com/stackrox/rox/central/nodecomponentcveedge/datastore/store/postgres"
 	"github.com/stackrox/rox/central/ranking"
+	k8srolebindingStore "github.com/stackrox/rox/central/rbac/k8srolebinding/datastore"
 	mockRisks "github.com/stackrox/rox/central/risk/datastore/mocks"
 	connMgrMocks "github.com/stackrox/rox/central/sensor/service/connection/mocks"
 	"github.com/stackrox/rox/central/views/imagecve"
@@ -116,6 +117,8 @@ func SetupTestResolver(t testing.TB, datastores ...interface{}) (*Resolver, *gra
 			resolver.ComponentCVEEdgeDataStore = ds
 		case nodeComponentCVEEdgeDataStore.DataStore:
 			resolver.NodeComponentCVEEdgeDataStore = ds
+		case k8srolebindingStore.DataStore:
+			resolver.K8sRoleBindingStore = ds
 
 		case imagecve.CveView:
 			resolver.ImageCVEView = ds

--- a/central/rbac/service/list_subjects.go
+++ b/central/rbac/service/list_subjects.go
@@ -186,6 +186,9 @@ func (s *SubjectSearcher) Count(ctx context.Context, q *v1.Query) (int, error) {
 		return 0, err
 	}
 
+	q = search.ConjunctionQuery(q, search.NewQueryBuilder().
+		AddStrings(search.SubjectKind, storage.SubjectKind_USER.String(), storage.SubjectKind_GROUP.String()).
+		ProtoQuery())
 	bindings, err := s.k8sRoleBindingDatastore.SearchRawRoleBindings(ctx, q)
 	if err != nil {
 		return 0, err
@@ -211,6 +214,9 @@ func (s *SubjectSearcher) SearchSubjects(ctx context.Context, q *v1.Query) ([]*v
 		return nil, err
 	}
 
+	q = search.ConjunctionQuery(q, search.NewQueryBuilder().
+		AddStrings(search.SubjectKind, storage.SubjectKind_USER.String(), storage.SubjectKind_GROUP.String()).
+		ProtoQuery())
 	bindings, err := s.k8sRoleBindingDatastore.SearchRawRoleBindings(ctx, q)
 	if err != nil {
 		return nil, err

--- a/central/rbac/service/list_subjects.go
+++ b/central/rbac/service/list_subjects.go
@@ -153,9 +153,6 @@ func (s *SubjectSearcher) Search(ctx context.Context, q *v1.Query) ([]search.Res
 		return nil, err
 	}
 
-	q = search.ConjunctionQuery(q, search.NewQueryBuilder().
-		AddStrings(search.SubjectKind, storage.SubjectKind_USER.String(), storage.SubjectKind_GROUP.String()).
-		ProtoQuery())
 	bindings, err := s.k8sRoleBindingDatastore.SearchRawRoleBindings(ctx, q)
 	if err != nil {
 		return nil, err
@@ -186,9 +183,6 @@ func (s *SubjectSearcher) Count(ctx context.Context, q *v1.Query) (int, error) {
 		return 0, err
 	}
 
-	q = search.ConjunctionQuery(q, search.NewQueryBuilder().
-		AddStrings(search.SubjectKind, storage.SubjectKind_USER.String(), storage.SubjectKind_GROUP.String()).
-		ProtoQuery())
 	bindings, err := s.k8sRoleBindingDatastore.SearchRawRoleBindings(ctx, q)
 	if err != nil {
 		return 0, err
@@ -213,10 +207,7 @@ func (s *SubjectSearcher) SearchSubjects(ctx context.Context, q *v1.Query) ([]*v
 	if err != nil {
 		return nil, err
 	}
-
-	q = search.ConjunctionQuery(q, search.NewQueryBuilder().
-		AddStrings(search.SubjectKind, storage.SubjectKind_USER.String(), storage.SubjectKind_GROUP.String()).
-		ProtoQuery())
+	
 	bindings, err := s.k8sRoleBindingDatastore.SearchRawRoleBindings(ctx, q)
 	if err != nil {
 		return nil, err

--- a/central/rbac/service/list_subjects.go
+++ b/central/rbac/service/list_subjects.go
@@ -207,7 +207,7 @@ func (s *SubjectSearcher) SearchSubjects(ctx context.Context, q *v1.Query) ([]*v
 	if err != nil {
 		return nil, err
 	}
-	
+
 	bindings, err := s.k8sRoleBindingDatastore.SearchRawRoleBindings(ctx, q)
 	if err != nil {
 		return nil, err

--- a/central/rbac/service/list_subjects_test.go
+++ b/central/rbac/service/list_subjects_test.go
@@ -386,13 +386,13 @@ func (s *SubjectSearcherTestSuite) testCases() []testCase {
 				{
 					ID: s.testBindings[0].Subjects[1].Name,
 					Matches: map[string][]string{
-						"k8srolebinding.cluster_role": []string{"true"},
+						"k8srolebinding.cluster_role": {"true"},
 					},
 				},
 				{
 					ID: s.testBindings[0].Subjects[2].Name,
 					Matches: map[string][]string{
-						"k8srolebinding.cluster_role": []string{"true"},
+						"k8srolebinding.cluster_role": {"true"},
 					},
 				},
 			},

--- a/central/rbac/service/list_subjects_test.go
+++ b/central/rbac/service/list_subjects_test.go
@@ -367,13 +367,13 @@ func (s *SubjectSearcherTestSuite) testCases() []testCase {
 				{
 					ID: s.testBindings[1].Subjects[1].Name,
 					Matches: map[string][]string{
-						"k8srolebinding.cluster_name": []string{s.testBindings[1].ClusterName},
+						"k8srolebinding.cluster_name": {s.testBindings[1].ClusterName},
 					},
 				},
 				{
 					ID: s.testBindings[1].Subjects[2].Name,
 					Matches: map[string][]string{
-						"k8srolebinding.cluster_name": []string{s.testBindings[1].ClusterName},
+						"k8srolebinding.cluster_name": {s.testBindings[1].ClusterName},
 					},
 				},
 			},

--- a/central/rbac/service/list_subjects_test.go
+++ b/central/rbac/service/list_subjects_test.go
@@ -1,13 +1,19 @@
 package service
 
 import (
+	"context"
 	"testing"
 
+	"github.com/golang/mock/gomock"
+	roleBindingMocks "github.com/stackrox/rox/central/rbac/k8srolebinding/datastore/mocks"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/fixtures"
+	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 )
 
 func getSubjects() []*storage.Subject {
@@ -248,4 +254,169 @@ func TestGetFiltered(t *testing.T) {
 			assert.Equal(t, c.expectedSubjects, filteredSubjects)
 		})
 	}
+}
+
+func TestSubjectSearcher(t *testing.T) {
+	suite.Run(t, new(SubjectSearcherTestSuite))
+}
+
+type testCase struct {
+	desc             string
+	query            *v1.Query
+	expectedBindings []*storage.K8SRoleBinding
+	expected         []search.Result
+}
+
+type SubjectSearcherTestSuite struct {
+	suite.Suite
+
+	mockCtrl *gomock.Controller
+
+	ctx               context.Context
+	mockBindingsStore *roleBindingMocks.MockDataStore
+	subjectSearcher   *SubjectSearcher
+	testBindings      []*storage.K8SRoleBinding
+}
+
+func (s *SubjectSearcherTestSuite) SetupTest() {
+	s.ctx = sac.WithAllAccess(context.Background())
+
+	s.mockCtrl = gomock.NewController(s.T())
+	s.mockBindingsStore = roleBindingMocks.NewMockDataStore(s.mockCtrl)
+	s.subjectSearcher = NewSubjectSearcher(s.mockBindingsStore)
+	s.testBindings = fixtures.GetMultipleK8sRoleBindings(2, 3)
+}
+
+func (s *SubjectSearcherTestSuite) TearDownTest() {
+	s.mockCtrl.Finish()
+}
+
+func (s *SubjectSearcherTestSuite) TestSearcher() {
+	for _, tc := range s.testCases() {
+		s.T().Run(tc.desc, func(t *testing.T) {
+			expectedQ := search.ConjunctionQuery(tc.query, search.NewQueryBuilder().
+				AddStrings(search.SubjectKind, storage.SubjectKind_USER.String(), storage.SubjectKind_GROUP.String()).
+				ProtoQuery())
+			s.mockBindingsStore.EXPECT().SearchRawRoleBindings(s.ctx, expectedQ).Times(3).Return(tc.expectedBindings, nil)
+			results, err := s.subjectSearcher.Search(s.ctx, tc.query)
+			s.NoError(err)
+			s.ElementsMatch(tc.expected, s.standardizeResults(results))
+
+			count, err := s.subjectSearcher.Count(s.ctx, tc.query)
+			s.NoError(err)
+			s.Equal(len(tc.expected), count)
+
+			v1SearchResults, err := s.subjectSearcher.SearchSubjects(s.ctx, tc.query)
+			s.NoError(err)
+			s.ElementsMatch(s.resultsToV1SearchResults(tc.expected), v1SearchResults)
+		})
+	}
+}
+
+func (s *SubjectSearcherTestSuite) testCases() []testCase {
+	return []testCase{
+		{
+			desc:             "Search by subject name",
+			query:            search.NewQueryBuilder().AddStrings(search.SubjectName, s.testBindings[0].Subjects[1].Name).ProtoQuery(),
+			expectedBindings: []*storage.K8SRoleBinding{s.testBindings[0]},
+			expected: []search.Result{
+				{
+					ID: s.testBindings[0].Subjects[1].Name,
+					Matches: map[string][]string{
+						"subject.name": {s.testBindings[0].Subjects[1].Name},
+					},
+				},
+			},
+		},
+		{
+			desc:             "Search by subject kind",
+			query:            search.NewQueryBuilder().AddStrings(search.SubjectKind, "").ProtoQuery(),
+			expectedBindings: []*storage.K8SRoleBinding{s.testBindings[0], s.testBindings[1]},
+			expected: []search.Result{
+				{
+					ID: s.testBindings[0].Subjects[1].Name,
+					Matches: map[string][]string{
+						"subject.kind": {"user"},
+					},
+				},
+				{
+					ID: s.testBindings[0].Subjects[2].Name,
+					Matches: map[string][]string{
+						"subject.kind": {"group"},
+					},
+				},
+				{
+					ID: s.testBindings[1].Subjects[1].Name,
+					Matches: map[string][]string{
+						"subject.kind": {"user"},
+					},
+				},
+				{
+					ID: s.testBindings[1].Subjects[2].Name,
+					Matches: map[string][]string{
+						"subject.kind": {"group"},
+					},
+				},
+			},
+		},
+		{
+			desc:             "Search by cluster name",
+			query:            search.NewQueryBuilder().AddStrings(search.Cluster, s.testBindings[1].ClusterName).ProtoQuery(),
+			expectedBindings: []*storage.K8SRoleBinding{s.testBindings[1]},
+			expected: []search.Result{
+				{
+					ID: s.testBindings[1].Subjects[1].Name,
+					Matches: map[string][]string{
+						"k8srolebinding.cluster_name": []string{s.testBindings[1].ClusterName},
+					},
+				},
+				{
+					ID: s.testBindings[1].Subjects[2].Name,
+					Matches: map[string][]string{
+						"k8srolebinding.cluster_name": []string{s.testBindings[1].ClusterName},
+					},
+				},
+			},
+		},
+		{
+			desc:             "Search by cluster role",
+			query:            search.NewQueryBuilder().AddStrings(search.ClusterRole, "tr").ProtoQuery(),
+			expectedBindings: []*storage.K8SRoleBinding{s.testBindings[0]},
+			expected: []search.Result{
+				{
+					ID: s.testBindings[0].Subjects[1].Name,
+					Matches: map[string][]string{
+						"k8srolebinding.cluster_role": []string{"true"},
+					},
+				},
+				{
+					ID: s.testBindings[0].Subjects[2].Name,
+					Matches: map[string][]string{
+						"k8srolebinding.cluster_role": []string{"true"},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (s *SubjectSearcherTestSuite) resultsToV1SearchResults(results []search.Result) []*v1.SearchResult {
+	v1SearchResults := make([]*v1.SearchResult, 0, len(results))
+	for _, r := range results {
+		v1SearchResults = append(v1SearchResults, &v1.SearchResult{
+			Id:       r.ID,
+			Name:     r.ID,
+			Category: v1.SearchCategory_SUBJECTS,
+		})
+	}
+	return v1SearchResults
+}
+
+func (s *SubjectSearcherTestSuite) standardizeResults(results []search.Result) []search.Result {
+	newResults := make([]search.Result, 0, len(results))
+	for _, r := range results {
+		r.Fields = nil
+		newResults = append(newResults, r)
+	}
+	return newResults
 }

--- a/pkg/fixtures/role_bindings.go
+++ b/pkg/fixtures/role_bindings.go
@@ -1,7 +1,11 @@
 package fixtures
 
 import (
+	"fmt"
+
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/k8srbac"
+	"github.com/stackrox/rox/pkg/uuid"
 )
 
 // GetScopedK8SRoleBinding returns a mock K8SRoleBinding belonging to the input scope.
@@ -11,4 +15,60 @@ func GetScopedK8SRoleBinding(id string, clusterID string, namespace string) *sto
 		ClusterId: clusterID,
 		Namespace: namespace,
 	}
+}
+
+// GetK8sRoleBindingWithSubjects returns a K8sRoleBinding with given number of subjects
+// SubjectKind will round-robin between service_account, user and group
+func GetK8sRoleBindingWithSubjects(id, name, clusterID, clusterName, namespace string, clusterRole bool, numSubjects int) *storage.K8SRoleBinding {
+	binding := &storage.K8SRoleBinding{
+		Id:          id,
+		Name:        name,
+		ClusterName: clusterName,
+		ClusterId:   clusterID,
+		Namespace:   namespace,
+		ClusterRole: clusterRole,
+	}
+	subjectKinds := []storage.SubjectKind{storage.SubjectKind_SERVICE_ACCOUNT, storage.SubjectKind_USER, storage.SubjectKind_GROUP}
+	currKind := 0
+	binding.Subjects = make([]*storage.Subject, 0, numSubjects)
+	for i := 0; i < numSubjects; i++ {
+		subjectName := fmt.Sprintf("%s_subject%d", name, i)
+		subject := &storage.Subject{
+			Id:          k8srbac.CreateSubjectID(clusterID, subjectName),
+			Name:        subjectName,
+			Kind:        subjectKinds[currKind],
+			ClusterId:   clusterID,
+			ClusterName: clusterName,
+			Namespace:   namespace,
+		}
+		binding.Subjects = append(binding.Subjects, subject)
+		currKind++
+		if currKind >= len(subjectKinds) {
+			currKind = 0
+		}
+	}
+	return binding
+}
+
+// GetMultipleK8sRoleBindings returns given number of roleBindings, each with given number of subjects
+// ClusterRole will toggle between true and false
+func GetMultipleK8sRoleBindings(numBindings, numSubjectsPerBinding int) []*storage.K8SRoleBinding {
+	clusterRole := true
+	bindings := make([]*storage.K8SRoleBinding, 0, numBindings)
+	for i := 0; i < numBindings; i++ {
+		name := fmt.Sprintf("k8sRoleBinding%d", i)
+		clusterName := fmt.Sprintf("cluster%d", i)
+		namespace := fmt.Sprintf("namespace%d", i)
+		bindings = append(bindings,
+			GetK8sRoleBindingWithSubjects(
+				uuid.NewV4().String(),
+				name,
+				uuid.NewV4().String(),
+				clusterName,
+				namespace,
+				clusterRole,
+				numSubjectsPerBinding))
+		clusterRole = !clusterRole
+	}
+	return bindings
 }


### PR DESCRIPTION
## Description

Subject's search options were updated [#3682](https://github.com/stackrox/stackrox/pull/3682) to include K8sRoleBindings fields as well. However, subject searcher did not allow matching those extra fields and because of this, autocomplete for subjects did not work on role bindings fields. This PR fixes subject searcher to allow matching K8sRoleBinding fields.

Note: This fix is tied to postgres schema for RoleBindings and will only work correctly on postgres. On rocksDB, the search results for role bindings fields will still come out empty.

## Checklist
- [X] Investigated and inspected CI test results
- [X] Unit test and regression tests added
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

Unit tests added

Manual testing
![BAF8DBD5-BF42-4451-B6A6-420973426807](https://user-images.githubusercontent.com/101146970/222524973-38d15064-0a37-4afa-a077-29508950d32f.jpeg)

![12C222C7-19B9-4352-89C5-FBBA244AB103](https://user-images.githubusercontent.com/101146970/222121239-1452a572-6409-4e10-93cc-45284234606c.jpeg)
