### PR TITLE
ROX-15024: Workload CVEs Overview - Default filters modal

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/DefaultFilterModal.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/DefaultFilterModal.tsx
@@ -1,17 +1,131 @@
-import React from 'react';
-import { Modal } from '@patternfly/react-core';
+import React, { useState } from 'react';
+import { Button, Modal, Form, FormGroup, Checkbox } from '@patternfly/react-core';
+import cloneDeep from 'lodash/cloneDeep';
+import { useFormik, FormikProvider } from 'formik';
 
-import useLocalStorage from 'hooks/useLocalStorage';
+import { DefaultFilters, Severity, FixableStatus } from './types';
 
-const emptyStorage = {
-    preferences: {
-        defaultFilters: {},
-    },
-};
+function DefaultFilterModal({ defaultFilters, setLocalStorage }) {
+    const [isOpen, setIsOpen] = useState(false);
 
-function DefaultFilterModal() {
-    const [storedValue, setStoredValue] = useLocalStorage('vulnerabilityManagement', emptyStorage);
-    return <div>Default vulnerability filters</div>;
+    const formik = useFormik({
+        initialValues: cloneDeep(defaultFilters),
+        onSubmit: (values: DefaultFilters) => {
+            setLocalStorage(values);
+            setIsOpen(false);
+        },
+    });
+
+    const { submitForm, values, setFieldValue, setValues } = formik;
+    const severityValues = values.Severity;
+    const fixableValues = values.Fixable;
+
+    function handleModalToggle() {
+        if (isOpen) {
+            setValues(defaultFilters).catch(() => {});
+        }
+        setIsOpen(!isOpen);
+    }
+
+    function handleSeverityChange(severity: Severity, isChecked: boolean) {
+        let newSeverityValues = [...severityValues];
+        if (isChecked) {
+            newSeverityValues.push(severity);
+        } else {
+            newSeverityValues = newSeverityValues.filter((val) => val !== severity);
+        }
+        setFieldValue('Severity', newSeverityValues).catch(() => {});
+    }
+
+    function handleFixableChange(fixable: FixableStatus, isChecked: boolean) {
+        let newFixableValues = [...fixableValues];
+        if (isChecked) {
+            newFixableValues.push(fixable);
+        } else {
+            newFixableValues = newFixableValues.filter((val) => val !== fixable);
+        }
+        setFieldValue('Fixable', newFixableValues).catch(() => {});
+    }
+
+    return (
+        <>
+            <Button variant="link" onClick={handleModalToggle}>
+                Default vulnerability filters
+            </Button>
+            <Modal
+                title="Default vulnerability filters"
+                description="Select default vulnerability filters to be applied across all views."
+                isOpen={isOpen}
+                onClose={handleModalToggle}
+                variant="medium"
+                actions={[
+                    <Button key="apply" variant="primary" onClick={submitForm}>
+                        Apply filters
+                    </Button>,
+                    <Button key="cancel" variant="link" onClick={handleModalToggle}>
+                        Cancel
+                    </Button>,
+                ]}
+            >
+                <FormikProvider value={formik}>
+                    <Form id="default-filter-modal-form">
+                        <FormGroup label="CVE severity" isInline>
+                            <Checkbox
+                                label="Critical"
+                                id="critical-severity"
+                                isChecked={severityValues.includes('Critical')}
+                                onChange={(isChecked) => {
+                                    handleSeverityChange('Critical', isChecked);
+                                }}
+                            />
+                            <Checkbox
+                                label="Important"
+                                id="important-severity"
+                                isChecked={severityValues.includes('Important')}
+                                onChange={(isChecked) => {
+                                    handleSeverityChange('Important', isChecked);
+                                }}
+                            />
+                            <Checkbox
+                                label="Moderate"
+                                id="moderate-severity"
+                                isChecked={severityValues.includes('Moderate')}
+                                onChange={(isChecked) => {
+                                    handleSeverityChange('Moderate', isChecked);
+                                }}
+                            />
+                            <Checkbox
+                                label="Low"
+                                id="low-severity"
+                                isChecked={severityValues.includes('Low')}
+                                onChange={(isChecked) => {
+                                    handleSeverityChange('Low', isChecked);
+                                }}
+                            />
+                        </FormGroup>
+                        <FormGroup label="CVE status" isInline>
+                            <Checkbox
+                                label="Fixable"
+                                id="fixable-status"
+                                isChecked={fixableValues.includes('Fixable')}
+                                onChange={(isChecked) => {
+                                    handleFixableChange('Fixable', isChecked);
+                                }}
+                            />
+                            <Checkbox
+                                label="Not fixable"
+                                id="not-fixable-status"
+                                isChecked={fixableValues.includes('Not fixable')}
+                                onChange={(isChecked) => {
+                                    handleFixableChange('Not fixable', isChecked);
+                                }}
+                            />
+                        </FormGroup>
+                    </Form>
+                </FormikProvider>
+            </Modal>
+        </>
+    );
 }
 
 export default DefaultFilterModal;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/DefaultFilterModal.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/DefaultFilterModal.tsx
@@ -1,12 +1,14 @@
 import React, { useState } from 'react';
-import { Button, Modal, Form, FormGroup, Checkbox } from '@patternfly/react-core';
+import { Button, Badge, Modal, Form, FormGroup, Checkbox, Flex } from '@patternfly/react-core';
 import cloneDeep from 'lodash/cloneDeep';
 import { useFormik, FormikProvider } from 'formik';
+import { Globe } from 'react-feather';
 
 import { DefaultFilters, Severity, FixableStatus } from './types';
 
 function DefaultFilterModal({ defaultFilters, setLocalStorage }) {
     const [isOpen, setIsOpen] = useState(false);
+    const totalFilters = defaultFilters.Severity.length + defaultFilters.Fixable.length;
 
     const formik = useFormik({
         initialValues: cloneDeep(defaultFilters),
@@ -49,8 +51,14 @@ function DefaultFilterModal({ defaultFilters, setLocalStorage }) {
 
     return (
         <>
-            <Button variant="link" onClick={handleModalToggle}>
-                Default vulnerability filters
+            <Button variant="plain" onClick={handleModalToggle}>
+                <Flex alignItems={{ default: 'alignItemsCenter' }}>
+                    <Globe className="pf-u-mr-sm" />
+                    Default vulnerability filters
+                    <Badge key={1} isRead className="pf-u-ml-sm">
+                        {totalFilters}
+                    </Badge>
+                </Flex>
             </Button>
             <Modal
                 title="Default vulnerability filters"

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/DefaultFilterModal.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/DefaultFilterModal.tsx
@@ -4,9 +4,15 @@ import cloneDeep from 'lodash/cloneDeep';
 import { useFormik, FormikProvider } from 'formik';
 import { Globe } from 'react-feather';
 
-import { DefaultFilters, Severity, FixableStatus } from './types';
+import { VulnerabilitySeverity } from 'types/cve.proto';
+import { DefaultFilters, FixableStatus } from './types';
 
-function DefaultFilterModal({ defaultFilters, setLocalStorage }) {
+type DefaultFilterModalProps = {
+    defaultFilters: DefaultFilters;
+    setLocalStorage: (values) => void;
+};
+
+function DefaultFilterModal({ defaultFilters, setLocalStorage }: DefaultFilterModalProps) {
     const [isOpen, setIsOpen] = useState(false);
     const totalFilters = defaultFilters.Severity.length + defaultFilters.Fixable.length;
 
@@ -29,7 +35,7 @@ function DefaultFilterModal({ defaultFilters, setLocalStorage }) {
         setIsOpen(!isOpen);
     }
 
-    function handleSeverityChange(severity: Severity, isChecked: boolean) {
+    function handleSeverityChange(severity: VulnerabilitySeverity, isChecked: boolean) {
         let newSeverityValues = [...severityValues];
         if (isChecked) {
             newSeverityValues.push(severity);
@@ -81,33 +87,48 @@ function DefaultFilterModal({ defaultFilters, setLocalStorage }) {
                             <Checkbox
                                 label="Critical"
                                 id="critical-severity"
-                                isChecked={severityValues.includes('Critical')}
+                                isChecked={severityValues.includes(
+                                    'CRITICAL_VULNERABILITY_SEVERITY'
+                                )}
                                 onChange={(isChecked) => {
-                                    handleSeverityChange('Critical', isChecked);
+                                    handleSeverityChange(
+                                        'CRITICAL_VULNERABILITY_SEVERITY',
+                                        isChecked
+                                    );
                                 }}
                             />
                             <Checkbox
                                 label="Important"
                                 id="important-severity"
-                                isChecked={severityValues.includes('Important')}
+                                isChecked={severityValues.includes(
+                                    'IMPORTANT_VULNERABILITY_SEVERITY'
+                                )}
                                 onChange={(isChecked) => {
-                                    handleSeverityChange('Important', isChecked);
+                                    handleSeverityChange(
+                                        'IMPORTANT_VULNERABILITY_SEVERITY',
+                                        isChecked
+                                    );
                                 }}
                             />
                             <Checkbox
                                 label="Moderate"
                                 id="moderate-severity"
-                                isChecked={severityValues.includes('Moderate')}
+                                isChecked={severityValues.includes(
+                                    'MODERATE_VULNERABILITY_SEVERITY'
+                                )}
                                 onChange={(isChecked) => {
-                                    handleSeverityChange('Moderate', isChecked);
+                                    handleSeverityChange(
+                                        'MODERATE_VULNERABILITY_SEVERITY',
+                                        isChecked
+                                    );
                                 }}
                             />
                             <Checkbox
                                 label="Low"
                                 id="low-severity"
-                                isChecked={severityValues.includes('Low')}
+                                isChecked={severityValues.includes('LOW_VULNERABILITY_SEVERITY')}
                                 onChange={(isChecked) => {
-                                    handleSeverityChange('Low', isChecked);
+                                    handleSeverityChange('LOW_VULNERABILITY_SEVERITY', isChecked);
                                 }}
                             />
                         </FormGroup>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/DefaultFilterModal.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/DefaultFilterModal.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { Modal } from '@patternfly/react-core';
+
+import useLocalStorage from 'hooks/useLocalStorage';
+
+const emptyStorage = {
+    preferences: {
+        defaultFilters: {},
+    },
+};
+
+function DefaultFilterModal() {
+    const [storedValue, setStoredValue] = useLocalStorage('vulnerabilityManagement', emptyStorage);
+    return <div>Default vulnerability filters</div>;
+}
+
+export default DefaultFilterModal;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesOverviewPage.tsx
@@ -11,6 +11,7 @@ import {
 
 import PageTitle from 'Components/PageTitle';
 import CveStatusTabNavigation from './CveStatusTabNavigation';
+import DefaultFilterModal from './DefaultFilterModal';
 
 function WorkloadCvesOverviewPage() {
     return (
@@ -19,7 +20,7 @@ function WorkloadCvesOverviewPage() {
             <PageSection variant="light" padding={{ default: 'noPadding' }}>
                 <Toolbar>
                     <ToolbarItem alignment={{ default: 'alignRight' }}>
-                        <div>Default vulnerability filters</div>
+                        <DefaultFilterModal />
                     </ToolbarItem>
                 </Toolbar>
             </PageSection>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesOverviewPage.tsx
@@ -9,18 +9,42 @@ import {
     FlexItem,
 } from '@patternfly/react-core';
 
+import useLocalStorage from 'hooks/useLocalStorage';
 import PageTitle from 'Components/PageTitle';
 import CveStatusTabNavigation from './CveStatusTabNavigation';
 import DefaultFilterModal from './DefaultFilterModal';
+import { VulnMgmtLocalStorage } from './types';
+
+const emptyStorage: VulnMgmtLocalStorage = {
+    preferences: {
+        defaultFilters: {
+            Severity: [],
+            Fixable: [],
+        },
+    },
+};
 
 function WorkloadCvesOverviewPage() {
+    const [storedValue, setStoredValue] = useLocalStorage('vulnerabilityManagement', emptyStorage);
+
+    function setLocalStorage(values) {
+        setStoredValue({
+            preferences: {
+                defaultFilters: values,
+            },
+        });
+    }
+
     return (
         <>
             <PageTitle title="Workload CVEs Overview" />
             <PageSection variant="light" padding={{ default: 'noPadding' }}>
                 <Toolbar>
                     <ToolbarItem alignment={{ default: 'alignRight' }}>
-                        <DefaultFilterModal />
+                        <DefaultFilterModal
+                            defaultFilters={storedValue.preferences.defaultFilters}
+                            setLocalStorage={setLocalStorage}
+                        />
                     </ToolbarItem>
                 </Toolbar>
             </PageSection>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/types.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/types.ts
@@ -1,0 +1,13 @@
+export type Severity = 'Critical' | 'Important' | 'Moderate' | 'Low';
+export type FixableStatus = 'Fixable' | 'Not fixable';
+
+export type DefaultFilters = {
+    Severity: Severity[];
+    Fixable: FixableStatus[];
+};
+
+export type VulnMgmtLocalStorage = {
+    preferences: {
+        defaultFilters: DefaultFilters;
+    };
+};

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/types.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/types.ts
@@ -1,8 +1,9 @@
-export type Severity = 'Critical' | 'Important' | 'Moderate' | 'Low';
+import { VulnerabilitySeverity } from 'types/cve.proto';
+
 export type FixableStatus = 'Fixable' | 'Not fixable';
 
 export type DefaultFilters = {
-    Severity: Severity[];
+    Severity: VulnerabilitySeverity[];
     Fixable: FixableStatus[];
 };
 


### PR DESCRIPTION
<img width="1499" alt="image" src="https://user-images.githubusercontent.com/10412893/221123700-35ee99f8-8dbe-4fb1-a08f-49b6e7138699.png">
<img width="719" alt="image" src="https://user-images.githubusercontent.com/10412893/221123743-7ee0b694-80cb-4efe-99d3-5ac509339a8c.png">
<img width="338" alt="image" src="https://user-images.githubusercontent.com/10412893/221128293-31c80963-ece6-451f-8996-308a4c595230.png">

* The button at the top right corner of the page should be a button
* The button badge should reflect the number of filters set globally
* Clicking on the button should open the Default filters modal
* The modal should look like the above and populate as empty at first
* Clicking the checkboxes and cancelling should not update local storage
* Clicking the checkboxes and hitting the 'Apply filters' button should save the filters to local storage
* Opening the modal on refresh should load the filters saved from local storage

Implementation notes: 
* I saved the empty state to be ```preferences: {
        defaultFilters: {
            Severity: [],
            Fixable: [],
        },
    },``` because those fields will always exist (vs possibly being empty) and thus it didn't make much sense to omit them in the empty state and end up adding conditionals in the code