### PR TITLE
ROX-7026: Improvements around `AdmissionControllerTest`

### DIFF
--- a/qa-tests-backend/src/main/groovy/common/Constants.groovy
+++ b/qa-tests-backend/src/main/groovy/common/Constants.groovy
@@ -1,18 +1,18 @@
 package common
 
 class Constants {
-    static final ORCHESTRATOR_NAMESPACE = "qa"
-    static final STACKROX_NAMESPACE = "stackrox"
-    static final SCHEDULES_SUPPORTED = false
-    static final CHECK_CVES_IN_COMPLIANCE = false
-    static final RUN_FLAKEY_TESTS = false
-    static final EMAIL_NOTIFER_FROM = "stackrox"
-    static final EMAIL_NOTIFER_SENDER = "${UUID.randomUUID()}@stackrox.com"
-    static final EMAIL_NOTIFER_FULL_FROM = "${EMAIL_NOTIFER_FROM} <${EMAIL_NOTIFER_SENDER}>"
-    static final EMAIL_NOTIFIER_RECIPIENT = "stackrox.qa@gmail.com"
+    static final String ORCHESTRATOR_NAMESPACE = "qa"
+    static final String STACKROX_NAMESPACE = "stackrox"
+    static final boolean SCHEDULES_SUPPORTED = false
+    static final boolean CHECK_CVES_IN_COMPLIANCE = false
+    static final boolean RUN_FLAKEY_TESTS = false
+    static final String EMAIL_NOTIFER_FROM = "stackrox"
+    static final String EMAIL_NOTIFER_SENDER = "${UUID.randomUUID()}@stackrox.com"
+    static final String EMAIL_NOTIFER_FULL_FROM = "${EMAIL_NOTIFER_FROM} <${EMAIL_NOTIFER_SENDER}>"
+    static final String EMAIL_NOTIFIER_RECIPIENT = "stackrox.qa@gmail.com"
     static final FAILURE_DEBUG_LIMIT = 10
-    static final AUTO_REGISTERED_STACKROX_SCANNER_INTEGRATION = "Stackrox Scanner"
-    static final ANY_FIXED_VULN_POLICY = "any-fixed-vulnerabilities"
+    static final String AUTO_REGISTERED_STACKROX_SCANNER_INTEGRATION = "Stackrox Scanner"
+    static final String ANY_FIXED_VULN_POLICY = "any-fixed-vulnerabilities"
     static final Map<String, String> CSV_COLUMN_MAPPING = [
             "Standard" : "standard",
             "Cluster" : "cluster",

--- a/qa-tests-backend/src/main/groovy/objects/K8sRbacObjects.groovy
+++ b/qa-tests-backend/src/main/groovy/objects/K8sRbacObjects.groovy
@@ -11,11 +11,11 @@ class K8sRole {
 }
 
 class K8sPolicyRule {
-    def verbs
-    def apiGroups
-    def resources
-    def nonResourceUrls
-    def resourceNames
+    List<String> verbs
+    List<String> apiGroups
+    List<String> resources
+    List<String> nonResourceUrls
+    List<String> resourceNames
 }
 
 class K8sRoleBinding  {

--- a/qa-tests-backend/src/main/groovy/objects/K8sServiceAccount.groovy
+++ b/qa-tests-backend/src/main/groovy/objects/K8sServiceAccount.groovy
@@ -6,6 +6,6 @@ class K8sServiceAccount {
     Map<String, String> labels = [:]
     Map<String, String> annotations = [:]
     def automountToken
-    def secrets = []
+    List<io.fabric8.kubernetes.api.model.ObjectReference> secrets = []
     String[] imagePullSecrets = []
 }

--- a/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
@@ -135,7 +135,7 @@ class Kubernetes implements OrchestratorMain {
         // "any namespace" requests to be scoped to the default project.
         this.client.configuration.namespace = null
         this.client.configuration.setRollingTimeout(60 * 60 * 1000)
-        this.client.configuration.setRequestTimeout(20*1000)
+        this.client.configuration.setRequestTimeout(32*1000)
         this.client.configuration.setConnectionTimeout(20*1000)
         this.client.configuration.setWebsocketTimeout(20*1000)
         this.deployments = this.client.apps().deployments()

--- a/qa-tests-backend/src/main/groovy/orchestratormanager/OpenShift.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/OpenShift.groovy
@@ -82,7 +82,7 @@ class OpenShift extends Kubernetes {
     */
 
     @Override
-    def getDeploymentCount(String ns) {
+    List<String> getDeploymentCount(String ns) {
         return oClient.apps().deployments().inNamespace(ns).list().getItems().collect { it.metadata.name } +
                 oClient.deploymentConfigs().inNamespace(ns).list().getItems().collect { it.metadata.name }
     }

--- a/qa-tests-backend/src/main/groovy/orchestratormanager/OrchestratorMain.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/OrchestratorMain.groovy
@@ -34,6 +34,7 @@ interface OrchestratorMain {
     def waitForPodRestart(String ns, String name, int prevRestartCount, int retries, int intervalSeconds)
     String getPodLog(String ns, String name)
     def copyFileToPod(String fromPath, String ns, String podName, String toPath)
+    boolean podReady(Pod pod)
 
     //Deployments
     io.fabric8.kubernetes.api.model.apps.Deployment getOrchestratorDeployment(String ns, String name)

--- a/qa-tests-backend/src/main/groovy/util/ChaosMonkey.groovy
+++ b/qa-tests-backend/src/main/groovy/util/ChaosMonkey.groovy
@@ -1,18 +1,21 @@
 package util
 
 import common.Constants
+import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import io.fabric8.kubernetes.api.model.Pod
 import orchestratormanager.OrchestratorMain
 
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.locks.Condition
 import java.util.concurrent.locks.ReentrantLock
 
+@CompileStatic
 @Slf4j
 class ChaosMonkey {
-    def stopFlag = new AtomicBoolean()
-    def lock = new ReentrantLock()
-    def effectCond = lock.newCondition()
+    AtomicBoolean stopFlag = new AtomicBoolean()
+    ReentrantLock lock = new ReentrantLock()
+    Condition effectCond = lock.newCondition()
 
     Thread thread
     OrchestratorMain orchestrator
@@ -27,7 +30,7 @@ class ChaosMonkey {
         this.minReadyReplicas = minReadyReplicas
         this.gracePeriod = gracePeriod
 
-        def pods = orchestrator.getPods(Constants.STACKROX_NAMESPACE, ADMISSION_CONTROLLER_APP_NAME)
+        List<Pod> pods = orchestrator.getPods(Constants.STACKROX_NAMESPACE, ADMISSION_CONTROLLER_APP_NAME)
         assert pods.size() > 0, "There are no ${ADMISSION_CONTROLLER_APP_NAME} pods. " +
                 "Did you enable ADMISSION_CONTROLLER when deploying?"
     }

--- a/qa-tests-backend/src/main/groovy/util/ChaosMonkey.groovy
+++ b/qa-tests-backend/src/main/groovy/util/ChaosMonkey.groovy
@@ -39,6 +39,9 @@ class ChaosMonkey {
                 // Get the current ready, non-deleted pod replicas
                 def admCtrlPods = new ArrayList<Pod>(orchestrator.getPods(
                         Constants.STACKROX_NAMESPACE, ADMISSION_CONTROLLER_APP_NAME))
+                admCtrlPods.forEach {
+                    log.info "Encountered pod ${it.metadata.name}, ready=${orchestrator.podReady(it)}."
+                }
                 admCtrlPods.removeIf { Pod p -> !orchestrator.podReady(p) }
 
                 if (admCtrlPods.size() < minReadyReplicas) {

--- a/qa-tests-backend/src/main/groovy/util/ChaosMonkey.groovy
+++ b/qa-tests-backend/src/main/groovy/util/ChaosMonkey.groovy
@@ -16,17 +16,24 @@ class ChaosMonkey {
 
     Thread thread
     OrchestratorMain orchestrator
+    int minReadyReplicas
+    Long gracePeriod
 
     static final private String ADMISSION_CONTROLLER_APP_NAME = "admission-control"
     static final private int ADMISSION_CONTROLLER_EXPECTED_PODS = 3
 
     ChaosMonkey(OrchestratorMain client, int minReadyReplicas, Long gracePeriod) {
         orchestrator = client
+        this.minReadyReplicas = minReadyReplicas
+        this.gracePeriod = gracePeriod
 
         def pods = orchestrator.getPods(Constants.STACKROX_NAMESPACE, ADMISSION_CONTROLLER_APP_NAME)
         assert pods.size() > 0, "There are no ${ADMISSION_CONTROLLER_APP_NAME} pods. " +
                 "Did you enable ADMISSION_CONTROLLER when deploying?"
+    }
 
+    void start() {
+        assert thread == null, "Already started, call stop() first."
         thread = Thread.start {
             while (!stopFlag.get()) {
                 // Get the current ready, non-deleted pod replicas
@@ -59,8 +66,11 @@ class ChaosMonkey {
     }
 
     void stop() {
-        stopFlag.set(true)
-        thread.join()
+        if (thread) {
+            stopFlag.set(true)
+            thread.join()
+            thread = null
+        }
     }
 
     def waitForEffect() {

--- a/qa-tests-backend/src/main/groovy/util/ChaosMonkey.groovy
+++ b/qa-tests-backend/src/main/groovy/util/ChaosMonkey.groovy
@@ -40,8 +40,8 @@ class ChaosMonkey {
         thread = Thread.start {
             while (!stopFlag.get()) {
                 // Get the current ready, non-deleted pod replicas
-                def admCtrlPods = new ArrayList<Pod>(orchestrator.getPods(
-                        Constants.STACKROX_NAMESPACE, ADMISSION_CONTROLLER_APP_NAME))
+                def admCtrlPods = orchestrator.getPods(
+                        Constants.STACKROX_NAMESPACE, ADMISSION_CONTROLLER_APP_NAME)
                 admCtrlPods.forEach {
                     log.info "Encountered pod ${it.metadata.name}, ready=${orchestrator.podReady(it)}."
                 }

--- a/sensor/admission-control/manager/evaluate_deploytime.go
+++ b/sensor/admission-control/manager/evaluate_deploytime.go
@@ -156,5 +156,6 @@ func (m *manager) evaluateAdmissionRequest(s *state, req *admission.AdmissionReq
 		go m.filterAndPutAttemptedAlertsOnChan(req.Operation, alerts...)
 	}
 
+	log.Debugf("Violated policies: %d, rejecting %s request on %s/%s [%s]", len(alerts), req.Operation, req.Namespace, req.Name, req.Kind)
 	return fail(req.UID, message(alerts, !s.GetClusterConfig().GetAdmissionControllerConfig().GetDisableBypass())), nil
 }


### PR DESCRIPTION
## Description

These are the parts of #4775 which are generally useful for troubleshooting `AdmissionControllerTest` (and other tests too), even if we do not decide to re-enable `ChaosMonkey`. See individual commits' descriptions for more info.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

CI should be sufficient.