### PR TITLE
ROX-15277: Report unique CVEs in image scan output

### DIFF
--- a/roxctl/image/scan/cve_test.go
+++ b/roxctl/image/scan/cve_test.go
@@ -86,6 +86,74 @@ func TestNewCVESummaryForPrinting(t *testing.T) {
 				},
 			},
 		},
+		"duplicated CVEs across multiple components": {
+			scan: &storage.ImageScan{
+				Components: []*storage.EmbeddedImageScanComponent{
+					{
+						Name:    "dbus",
+						Version: "1:1.12.20-6.el9.x86_64",
+						Vulns: []*storage.EmbeddedVulnerability{
+							{
+								Cve:      "CVE-2022-42010",
+								Severity: storage.VulnerabilitySeverity_MODERATE_VULNERABILITY_SEVERITY,
+							},
+						},
+					},
+					{
+						Name:    "dbus-common",
+						Version: "1:1.12.20-6.el9.noarch",
+						Vulns: []*storage.EmbeddedVulnerability{
+							{
+								Cve:      "CVE-2022-42010",
+								Severity: storage.VulnerabilitySeverity_MODERATE_VULNERABILITY_SEVERITY,
+							},
+						},
+					},
+					{
+						Name:    "dbus-libs",
+						Version: "1:1.12.20-6.el9.x86_64",
+						Vulns: []*storage.EmbeddedVulnerability{
+							{
+								Cve:      "CVE-2022-42010",
+								Severity: storage.VulnerabilitySeverity_MODERATE_VULNERABILITY_SEVERITY,
+							},
+						},
+					},
+				},
+			},
+			expectedOutput: &cveJSONResult{
+				Result: cveJSONStructure{
+					Summary: map[string]int{
+						"TOTAL-VULNERABILITIES": 1,
+						"TOTAL-COMPONENTS":      3,
+						"LOW":                   0,
+						"MODERATE":              1,
+						"IMPORTANT":             0,
+						"CRITICAL":              0,
+					},
+					Vulnerabilities: []cveVulnerabilityJSON{
+						{
+							CveID:            "CVE-2022-42010",
+							CveSeverity:      "MODERATE",
+							ComponentName:    "dbus",
+							ComponentVersion: "1:1.12.20-6.el9.x86_64",
+						},
+						{
+							CveID:            "CVE-2022-42010",
+							CveSeverity:      "MODERATE",
+							ComponentName:    "dbus-common",
+							ComponentVersion: "1:1.12.20-6.el9.noarch",
+						},
+						{
+							CveID:            "CVE-2022-42010",
+							CveSeverity:      "MODERATE",
+							ComponentName:    "dbus-libs",
+							ComponentVersion: "1:1.12.20-6.el9.x86_64",
+						},
+					},
+				},
+			},
+		},
 		"components with vulnerabilities of all severity": {
 			scan: &storage.ImageScan{
 				Components: []*storage.EmbeddedImageScanComponent{
@@ -126,12 +194,12 @@ func TestNewCVESummaryForPrinting(t *testing.T) {
 			expectedOutput: &cveJSONResult{
 				Result: cveJSONStructure{
 					Summary: map[string]int{
-						"TOTAL-VULNERABILITIES": 13,
+						"TOTAL-VULNERABILITIES": 5,
 						"TOTAL-COMPONENTS":      4,
-						"LOW":                   3,
-						"MODERATE":              3,
-						"IMPORTANT":             3,
-						"CRITICAL":              4,
+						"LOW":                   1,
+						"MODERATE":              1,
+						"IMPORTANT":             1,
+						"CRITICAL":              2,
 					},
 					Vulnerabilities: append(expectedVulnsComponentA, append(expectedVulnsComponentB, append(expectedVulnsComponentC, expectedVulnsComponentD...)...)...),
 				},

--- a/roxctl/image/scan/scan.go
+++ b/roxctl/image/scan/scan.go
@@ -247,7 +247,7 @@ func printCVESummary(image string, cveSummary map[string]int, out logger.Logger)
 // print warning with amount of CVEs found in components
 func printCVEWarning(numOfVulns int, numOfComponents int, out logger.Logger) {
 	if numOfVulns != 0 {
-		out.WarnfLn("A total of %d vulnerabilities were found in %d components",
+		out.WarnfLn("A total of %d unique vulnerabilities were found in %d components",
 			numOfVulns, numOfComponents)
 	}
 }

--- a/roxctl/image/scan/scan_test.go
+++ b/roxctl/image/scan/scan_test.go
@@ -446,8 +446,8 @@ func (s *imageScanTestSuite) TestScan_TableOutput() {
 		"should render default output with merged cells and additional verbose output": {
 			components:                   testComponents,
 			expectedOutput:               "testComponents.txt",
-			expectedErrorOutput:          "WARN:\tA total of 17 vulnerabilities were found in 5 components\n",
-			expectedErrorOutputColorized: "\x1b[95mWARN:\tA total of 17 vulnerabilities were found in 5 components\n\x1b[0m",
+			expectedErrorOutput:          "WARN:\tA total of 11 unique vulnerabilities were found in 5 components\n",
+			expectedErrorOutputColorized: "\x1b[95mWARN:\tA total of 11 unique vulnerabilities were found in 5 components\n\x1b[0m",
 		},
 		"should print only headers with empty components in image scan": {
 			expectedOutput: "empty.txt",

--- a/roxctl/image/scan/testdata/color_testComponents.json
+++ b/roxctl/image/scan/testdata/color_testComponents.json
@@ -1,12 +1,12 @@
 {
   "result": {
     "summary": {
-      "[31;1mCRITICAL[0m": 5,
-      "[31mIMPORTANT[0m": 4,
-      "[34;2mLOW[0m": 3,
-      "MODERATE": 5,
+      "[31;1mCRITICAL[0m": 3,
+      "[31mIMPORTANT[0m": 3,
+      "[34;2mLOW[0m": 2,
+      "MODERATE": 3,
       "TOTAL-COMPONENTS": 5,
-      "TOTAL-VULNERABILITIES": 17
+      "TOTAL-VULNERABILITIES": 11
     },
     "vulnerabilities": [
       {

--- a/roxctl/image/scan/testdata/color_testComponents.txt
+++ b/roxctl/image/scan/testdata/color_testComponents.txt
@@ -1,5 +1,5 @@
 Scan results for image: nginx:test
-(TOTAL-COMPONENTS: 5, TOTAL-VULNERABILITIES: 17, [34;2mLOW[0m: 3, MODERATE: 0, [31mIMPORTANT[0m: 4, [31;1mCRITICAL[0m: 5)
+(TOTAL-COMPONENTS: 5, TOTAL-VULNERABILITIES: 11, [34;2mLOW[0m: 2, MODERATE: 0, [31mIMPORTANT[0m: 3, [31;1mCRITICAL[0m: 3)
 
 +-----------+------------+--------------+-----------+--------------------+
 | COMPONENT |  VERSION   |     CVE      | SEVERITY  |        LINK        |

--- a/roxctl/image/scan/testdata/testComponents.json
+++ b/roxctl/image/scan/testdata/testComponents.json
@@ -1,12 +1,12 @@
 {
   "result": {
     "summary": {
-      "CRITICAL": 5,
-      "IMPORTANT": 4,
-      "LOW": 3,
-      "MODERATE": 5,
+      "CRITICAL": 3,
+      "IMPORTANT": 3,
+      "LOW": 2,
+      "MODERATE": 3,
       "TOTAL-COMPONENTS": 5,
-      "TOTAL-VULNERABILITIES": 17
+      "TOTAL-VULNERABILITIES": 11
     },
     "vulnerabilities": [
       {

--- a/roxctl/image/scan/testdata/testComponents.txt
+++ b/roxctl/image/scan/testdata/testComponents.txt
@@ -1,5 +1,5 @@
 Scan results for image: nginx:test
-(TOTAL-COMPONENTS: 5, TOTAL-VULNERABILITIES: 17, LOW: 3, MODERATE: 0, IMPORTANT: 4, CRITICAL: 5)
+(TOTAL-COMPONENTS: 5, TOTAL-VULNERABILITIES: 11, LOW: 2, MODERATE: 0, IMPORTANT: 3, CRITICAL: 3)
 
 +-----------+------------+--------------+-----------+--------------------+
 | COMPONENT |  VERSION   |     CVE      | SEVERITY  |        LINK        |


### PR DESCRIPTION
## Description

The API of `image scan` will return the number of _unique_ CVEs found within the scanned image.

Currently, the "new" output formats `json,table` output the list of _all_ CVEs found, counting duplicates as well.
This caused confusion when comparing the API response to the output of roxctl.

To avoid this confusion, the following has been done:
- count the _unique_ number of CVEs found within the image scan and report this within `json,table` output for roxctl.
- within the warning message, add "unique vulnerabilities" to the output to make things more clear.

Note:
Within the same feedback from customers, there also was initial confusion regarding the number of components: the API responds with the _total_ number of components, whilst roxctl shows the number of vulnerable components.
However, this isn't really of concern, but we should think about making this a bit more obvious, either within documentation or within the flags / log messages.


Related documents:
- [CLI improvments: Usability Enhancements (which describes the "design" of the new output formats)](https://docs.google.com/document/d/15svIZ2yYoGrGwY8M7D7dvK6HocmEkfql3rvaImduB4A/edit#heading=h.jg572fhr4zbz)

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

- see adjusted unit tests.
