### PR TITLE
Dashrews/ROX-15331 batch call to delete by query

### DIFF
--- a/central/processindicator/datastore/datastore_impl.go
+++ b/central/processindicator/datastore/datastore_impl.go
@@ -152,26 +152,46 @@ func (ds *datastoreImpl) removeIndicators(ctx context.Context, ids []string) err
 		return err
 	}
 
-	if env.PostgresDatastoreEnabled.BooleanSetting() {
-		// Clean up correlated ProcessListeningOnPort objects. Probably could be
-		// done using a proper FK and CASCADE, but it's usually a thing you would
-		// not like to do automatically. search.ProcessID is not a PID, but UUID of
-		// the record in the table
-		deleteQuery := pkgSearch.NewQueryBuilder().
-			AddStrings(pkgSearch.ProcessID, ids...).
-			ProtoQuery()
-
-		if err := ds.plopStorage.DeleteByQuery(ctx, deleteQuery); err != nil {
-			return err
-		}
-	}
-
 	if err := ds.indexer.DeleteProcessIndicators(ids); err != nil {
 		return err
 	}
 	if err := ds.storage.AckKeysIndexed(ctx, ids...); err != nil {
 		return errors.Wrap(err, "error acknowledging indicator removal")
 	}
+
+	if env.PostgresDatastoreEnabled.BooleanSetting() {
+		// Clean up correlated ProcessListeningOnPort objects. Probably could be
+		// done using a proper FK and CASCADE, but it's usually a thing you would
+		// not like to do automatically. search.ProcessID is not a PID, but UUID of
+		// the record in the table
+
+		// Batch the deletes as scaled pruning can result in many process indicators being deleted.
+		localBatchSize := maxBatchSize
+		numRecordsToDelete := len(ids)
+		for {
+			if len(ids) == 0 {
+				break
+			}
+
+			if len(ids) < localBatchSize {
+				localBatchSize = len(ids)
+			}
+
+			identifierBatch := ids[:localBatchSize]
+			deleteQuery := pkgSearch.NewQueryBuilder().
+				AddStrings(pkgSearch.ProcessID, identifierBatch...).
+				ProtoQuery()
+
+			if err := ds.plopStorage.DeleteByQuery(ctx, deleteQuery); err != nil {
+				err = errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(ids), numRecordsToDelete)
+				return err
+			}
+
+			// Move the slice forward to start the next batch
+			ids = ids[localBatchSize:]
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/search/parser.go
+++ b/pkg/search/parser.go
@@ -108,8 +108,16 @@ func parsePair(pair string, allowEmpty bool) (key string, values string, valid b
 }
 
 func queryFromFieldValues(field string, values []string, highlight bool) *v1.Query {
-	queries := make([]*v1.Query, 0, len(values))
-	for _, value := range values {
+	queryLength := len(values)
+	if queryLength > MaxQueryParameters {
+		queryLength = MaxQueryParameters
+	}
+	queries := make([]*v1.Query, 0, queryLength)
+	for idx, value := range values {
+		if idx == MaxQueryParameters {
+			log.Warnf("the query contained %d parameters and was truncated to %d parameters", len(values), MaxQueryParameters)
+			break
+		}
 		queries = append(queries, MatchFieldQuery(field, value, highlight))
 	}
 

--- a/pkg/search/query_builder.go
+++ b/pkg/search/query_builder.go
@@ -2,6 +2,7 @@ package search
 
 import (
 	"fmt"
+	"math"
 	"sort"
 	"strings"
 
@@ -30,6 +31,9 @@ const (
 
 	// EqualityPrefixSuffix is the prefix for an exact match
 	EqualityPrefixSuffix = `"`
+
+	// MaxQueryParameters is the maximum number of query parameters for a single statement
+	MaxQueryParameters = math.MaxUint16
 )
 
 var (


### PR DESCRIPTION
## Description

SQL only allows a parameter list. up to 65535 items due to constraints within SQL.  In the instance with this ticket there were a large number of process indicators deleted and when we sent that large list of ideas to the delete by query it failed.  In order to resolve this quickly I did 2 things:
1.  batch the calls to delete by query when process indicators are removed.
2. Updated the searcher parser to truncate arguments when there are 65535 arguments.

We may want a follow up ticket to update the search framework to handle and batch these scenarios within the framework itself.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Added a test to test the batching.
