### PR TITLE
fix: don't cache operator go dependencies

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -419,9 +419,6 @@ jobs:
           # Prevent fatal error "detected dubious ownership in repository" from recent git.
           git config --global --add safe.directory "$(pwd)"
 
-      - name: Cache Go dependencies
-        uses: ./.github/actions/cache-go-dependencies
-
       - uses: ./.github/actions/handle-tagged-build
 
       - name: Resolve mods for protos
@@ -437,6 +434,7 @@ jobs:
       - name: Docker login
         run: |
             docker login -u "${QUAY_RHACS_ENG_RW_USERNAME}" --password-stdin quay.io <<<"${QUAY_RHACS_ENG_RW_PASSWORD}"
+            docker system prune --force
 
       - name: Build Operator Bundle image
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -434,7 +434,6 @@ jobs:
       - name: Docker login
         run: |
             docker login -u "${QUAY_RHACS_ENG_RW_USERNAME}" --password-stdin quay.io <<<"${QUAY_RHACS_ENG_RW_PASSWORD}"
-            docker system prune --force
 
       - name: Build Operator Bundle image
         run: |


### PR DESCRIPTION
## Description

Disable Go dependency caching for operator due to `no space left on device` problems: https://redhat-internal.slack.com/archives/C04KE8ES1MG/p1677507508664539

Also do a forced docker system prune before building to make everything nice and clean...

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
