### PR TITLE
ROX-15334: Use non-blocking locks in Postgres upserts

### DIFF
--- a/central/activecomponent/datastore/internal/store/postgres/store.go
+++ b/central/activecomponent/datastore/internal/store/postgres/store.go
@@ -70,7 +70,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -353,12 +353,15 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ActiveCompon
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations
+		if len(objs) < batchAfter {
+			s.mutex.RLock()
+			defer s.mutex.RUnlock()
+
+			return s.upsert(ctx, objs...)
+		}
 		s.mutex.Lock()
 		defer s.mutex.Unlock()
 
-		if len(objs) < batchAfter {
-			return s.upsert(ctx, objs...)
-		}
 		return s.copyFrom(ctx, objs...)
 	})
 }

--- a/central/alert/datastore/internal/store/postgres/store.go
+++ b/central/alert/datastore/internal/store/postgres/store.go
@@ -71,7 +71,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -412,12 +412,15 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Alert) error
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations
+		if len(objs) < batchAfter {
+			s.mutex.RLock()
+			defer s.mutex.RUnlock()
+
+			return s.upsert(ctx, objs...)
+		}
 		s.mutex.Lock()
 		defer s.mutex.Unlock()
 
-		if len(objs) < batchAfter {
-			return s.upsert(ctx, objs...)
-		}
 		return s.copyFrom(ctx, objs...)
 	})
 }

--- a/central/apitoken/datastore/internal/store/postgres/store.go
+++ b/central/apitoken/datastore/internal/store/postgres/store.go
@@ -68,7 +68,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -254,12 +254,15 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TokenMetadat
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations
+		if len(objs) < batchAfter {
+			s.mutex.RLock()
+			defer s.mutex.RUnlock()
+
+			return s.upsert(ctx, objs...)
+		}
 		s.mutex.Lock()
 		defer s.mutex.Unlock()
 
-		if len(objs) < batchAfter {
-			return s.upsert(ctx, objs...)
-		}
 		return s.copyFrom(ctx, objs...)
 	})
 }

--- a/central/authprovider/datastore/internal/store/postgres/store.go
+++ b/central/authprovider/datastore/internal/store/postgres/store.go
@@ -69,7 +69,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -260,12 +260,15 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.AuthProvider
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations
+		if len(objs) < batchAfter {
+			s.mutex.RLock()
+			defer s.mutex.RUnlock()
+
+			return s.upsert(ctx, objs...)
+		}
 		s.mutex.Lock()
 		defer s.mutex.Unlock()
 
-		if len(objs) < batchAfter {
-			return s.upsert(ctx, objs...)
-		}
 		return s.copyFrom(ctx, objs...)
 	})
 }

--- a/central/cluster/store/cluster/postgres/store.go
+++ b/central/cluster/store/cluster/postgres/store.go
@@ -71,7 +71,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/cluster/store/clusterhealth/postgres/store.go
+++ b/central/cluster/store/clusterhealth/postgres/store.go
@@ -70,7 +70,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -286,12 +286,15 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ClusterHealt
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations
+		if len(objs) < batchAfter {
+			s.mutex.RLock()
+			defer s.mutex.RUnlock()
+
+			return s.upsert(ctx, objs...)
+		}
 		s.mutex.Lock()
 		defer s.mutex.Unlock()
 
-		if len(objs) < batchAfter {
-			return s.upsert(ctx, objs...)
-		}
 		return s.copyFrom(ctx, objs...)
 	})
 }

--- a/central/clustercveedge/datastore/store/postgres/store.go
+++ b/central/clustercveedge/datastore/store/postgres/store.go
@@ -62,7 +62,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/clusterinit/store/postgres/store.go
+++ b/central/clusterinit/store/postgres/store.go
@@ -66,7 +66,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -254,12 +254,15 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.InitBundleMe
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations
+		if len(objs) < batchAfter {
+			s.mutex.RLock()
+			defer s.mutex.RUnlock()
+
+			return s.upsert(ctx, objs...)
+		}
 		s.mutex.Lock()
 		defer s.mutex.Unlock()
 
-		if len(objs) < batchAfter {
-			return s.upsert(ctx, objs...)
-		}
 		return s.copyFrom(ctx, objs...)
 	})
 }

--- a/central/compliance/datastore/internal/store/postgres/domain/store.go
+++ b/central/compliance/datastore/internal/store/postgres/domain/store.go
@@ -70,7 +70,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -256,12 +256,15 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceDo
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations
+		if len(objs) < batchAfter {
+			s.mutex.RLock()
+			defer s.mutex.RUnlock()
+
+			return s.upsert(ctx, objs...)
+		}
 		s.mutex.Lock()
 		defer s.mutex.Unlock()
 
-		if len(objs) < batchAfter {
-			return s.upsert(ctx, objs...)
-		}
 		return s.copyFrom(ctx, objs...)
 	})
 }

--- a/central/compliance/datastore/internal/store/postgres/metadata/store.go
+++ b/central/compliance/datastore/internal/store/postgres/metadata/store.go
@@ -71,7 +71,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -282,12 +282,15 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceRu
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations
+		if len(objs) < batchAfter {
+			s.mutex.RLock()
+			defer s.mutex.RUnlock()
+
+			return s.upsert(ctx, objs...)
+		}
 		s.mutex.Lock()
 		defer s.mutex.Unlock()
 
-		if len(objs) < batchAfter {
-			return s.upsert(ctx, objs...)
-		}
 		return s.copyFrom(ctx, objs...)
 	})
 }

--- a/central/compliance/datastore/internal/store/postgres/results/store.go
+++ b/central/compliance/datastore/internal/store/postgres/results/store.go
@@ -71,7 +71,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -282,12 +282,15 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceRu
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations
+		if len(objs) < batchAfter {
+			s.mutex.RLock()
+			defer s.mutex.RUnlock()
+
+			return s.upsert(ctx, objs...)
+		}
 		s.mutex.Lock()
 		defer s.mutex.Unlock()
 
-		if len(objs) < batchAfter {
-			return s.upsert(ctx, objs...)
-		}
 		return s.copyFrom(ctx, objs...)
 	})
 }

--- a/central/compliance/datastore/internal/store/postgres/strings/store.go
+++ b/central/compliance/datastore/internal/store/postgres/strings/store.go
@@ -69,7 +69,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -255,12 +255,15 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceSt
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations
+		if len(objs) < batchAfter {
+			s.mutex.RLock()
+			defer s.mutex.RUnlock()
+
+			return s.upsert(ctx, objs...)
+		}
 		s.mutex.Lock()
 		defer s.mutex.Unlock()
 
-		if len(objs) < batchAfter {
-			return s.upsert(ctx, objs...)
-		}
 		return s.copyFrom(ctx, objs...)
 	})
 }

--- a/central/complianceoperator/checkresults/store/postgres/store.go
+++ b/central/complianceoperator/checkresults/store/postgres/store.go
@@ -68,7 +68,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -254,12 +254,15 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceOp
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations
+		if len(objs) < batchAfter {
+			s.mutex.RLock()
+			defer s.mutex.RUnlock()
+
+			return s.upsert(ctx, objs...)
+		}
 		s.mutex.Lock()
 		defer s.mutex.Unlock()
 
-		if len(objs) < batchAfter {
-			return s.upsert(ctx, objs...)
-		}
 		return s.copyFrom(ctx, objs...)
 	})
 }

--- a/central/complianceoperator/profiles/store/postgres/store.go
+++ b/central/complianceoperator/profiles/store/postgres/store.go
@@ -68,7 +68,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -254,12 +254,15 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceOp
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations
+		if len(objs) < batchAfter {
+			s.mutex.RLock()
+			defer s.mutex.RUnlock()
+
+			return s.upsert(ctx, objs...)
+		}
 		s.mutex.Lock()
 		defer s.mutex.Unlock()
 
-		if len(objs) < batchAfter {
-			return s.upsert(ctx, objs...)
-		}
 		return s.copyFrom(ctx, objs...)
 	})
 }

--- a/central/complianceoperator/rules/store/postgres/store.go
+++ b/central/complianceoperator/rules/store/postgres/store.go
@@ -68,7 +68,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -254,12 +254,15 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceOp
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations
+		if len(objs) < batchAfter {
+			s.mutex.RLock()
+			defer s.mutex.RUnlock()
+
+			return s.upsert(ctx, objs...)
+		}
 		s.mutex.Lock()
 		defer s.mutex.Unlock()
 
-		if len(objs) < batchAfter {
-			return s.upsert(ctx, objs...)
-		}
 		return s.copyFrom(ctx, objs...)
 	})
 }

--- a/central/complianceoperator/scans/store/postgres/store.go
+++ b/central/complianceoperator/scans/store/postgres/store.go
@@ -68,7 +68,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -254,12 +254,15 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceOp
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations
+		if len(objs) < batchAfter {
+			s.mutex.RLock()
+			defer s.mutex.RUnlock()
+
+			return s.upsert(ctx, objs...)
+		}
 		s.mutex.Lock()
 		defer s.mutex.Unlock()
 
-		if len(objs) < batchAfter {
-			return s.upsert(ctx, objs...)
-		}
 		return s.copyFrom(ctx, objs...)
 	})
 }

--- a/central/complianceoperator/scansettingbinding/store/postgres/store.go
+++ b/central/complianceoperator/scansettingbinding/store/postgres/store.go
@@ -68,7 +68,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -254,12 +254,15 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ComplianceOp
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations
+		if len(objs) < batchAfter {
+			s.mutex.RLock()
+			defer s.mutex.RUnlock()
+
+			return s.upsert(ctx, objs...)
+		}
 		s.mutex.Lock()
 		defer s.mutex.Unlock()
 
-		if len(objs) < batchAfter {
-			return s.upsert(ctx, objs...)
-		}
 		return s.copyFrom(ctx, objs...)
 	})
 }

--- a/central/componentcveedge/datastore/store/postgres/store.go
+++ b/central/componentcveedge/datastore/store/postgres/store.go
@@ -62,7 +62,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/cve/cluster/datastore/store/postgres/store.go
+++ b/central/cve/cluster/datastore/store/postgres/store.go
@@ -70,7 +70,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -301,12 +301,15 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ClusterCVE) 
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations
+		if len(objs) < batchAfter {
+			s.mutex.RLock()
+			defer s.mutex.RUnlock()
+
+			return s.upsert(ctx, objs...)
+		}
 		s.mutex.Lock()
 		defer s.mutex.Unlock()
 
-		if len(objs) < batchAfter {
-			return s.upsert(ctx, objs...)
-		}
 		return s.copyFrom(ctx, objs...)
 	})
 }

--- a/central/cve/image/datastore/store/postgres/store.go
+++ b/central/cve/image/datastore/store/postgres/store.go
@@ -70,7 +70,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -301,12 +301,15 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ImageCVE) er
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations
+		if len(objs) < batchAfter {
+			s.mutex.RLock()
+			defer s.mutex.RUnlock()
+
+			return s.upsert(ctx, objs...)
+		}
 		s.mutex.Lock()
 		defer s.mutex.Unlock()
 
-		if len(objs) < batchAfter {
-			return s.upsert(ctx, objs...)
-		}
 		return s.copyFrom(ctx, objs...)
 	})
 }

--- a/central/cve/node/datastore/store/postgres/store.go
+++ b/central/cve/node/datastore/store/postgres/store.go
@@ -70,7 +70,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -301,12 +301,15 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NodeCVE) err
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations
+		if len(objs) < batchAfter {
+			s.mutex.RLock()
+			defer s.mutex.RUnlock()
+
+			return s.upsert(ctx, objs...)
+		}
 		s.mutex.Lock()
 		defer s.mutex.Unlock()
 
-		if len(objs) < batchAfter {
-			return s.upsert(ctx, objs...)
-		}
 		return s.copyFrom(ctx, objs...)
 	})
 }

--- a/central/deployment/store/postgres/store.go
+++ b/central/deployment/store/postgres/store.go
@@ -71,7 +71,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -968,12 +968,15 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Deployment) 
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations
+		if len(objs) < batchAfter {
+			s.mutex.RLock()
+			defer s.mutex.RUnlock()
+
+			return s.upsert(ctx, objs...)
+		}
 		s.mutex.Lock()
 		defer s.mutex.Unlock()
 
-		if len(objs) < batchAfter {
-			return s.upsert(ctx, objs...)
-		}
 		return s.copyFrom(ctx, objs...)
 	})
 }

--- a/central/detection/lifecycle/manager_impl.go
+++ b/central/detection/lifecycle/manager_impl.go
@@ -198,7 +198,9 @@ func (m *managerImpl) flushIndicatorQueue() {
 		log.Errorf("Error adding process indicators: %v", err)
 	}
 
+	now := time.Now()
 	m.processAggregator.Add(indicatorSlice)
+	centralMetrics.SetFunctionSegmentDuration(now, "AddProcessToAggregator")
 
 	defer centralMetrics.SetFunctionSegmentDuration(time.Now(), "CheckAndUpdateBaseline")
 

--- a/central/externalbackups/internal/store/postgres/store.go
+++ b/central/externalbackups/internal/store/postgres/store.go
@@ -69,7 +69,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -255,12 +255,15 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ExternalBack
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations
+		if len(objs) < batchAfter {
+			s.mutex.RLock()
+			defer s.mutex.RUnlock()
+
+			return s.upsert(ctx, objs...)
+		}
 		s.mutex.Lock()
 		defer s.mutex.Unlock()
 
-		if len(objs) < batchAfter {
-			return s.upsert(ctx, objs...)
-		}
 		return s.copyFrom(ctx, objs...)
 	})
 }

--- a/central/group/datastore/internal/store/postgres/store.go
+++ b/central/group/datastore/internal/store/postgres/store.go
@@ -69,7 +69,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -255,12 +255,15 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Group) error
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations
+		if len(objs) < batchAfter {
+			s.mutex.RLock()
+			defer s.mutex.RUnlock()
+
+			return s.upsert(ctx, objs...)
+		}
 		s.mutex.Lock()
 		defer s.mutex.Unlock()
 
-		if len(objs) < batchAfter {
-			return s.upsert(ctx, objs...)
-		}
 		return s.copyFrom(ctx, objs...)
 	})
 }

--- a/central/imagecomponent/datastore/store/postgres/store.go
+++ b/central/imagecomponent/datastore/store/postgres/store.go
@@ -70,7 +70,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -291,12 +291,15 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ImageCompone
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations
+		if len(objs) < batchAfter {
+			s.mutex.RLock()
+			defer s.mutex.RUnlock()
+
+			return s.upsert(ctx, objs...)
+		}
 		s.mutex.Lock()
 		defer s.mutex.Unlock()
 
-		if len(objs) < batchAfter {
-			return s.upsert(ctx, objs...)
-		}
 		return s.copyFrom(ctx, objs...)
 	})
 }

--- a/central/imagecomponentedge/datastore/internal/store/postgres/store.go
+++ b/central/imagecomponentedge/datastore/internal/store/postgres/store.go
@@ -62,7 +62,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/imagecveedge/datastore/postgres/store.go
+++ b/central/imagecveedge/datastore/postgres/store.go
@@ -62,7 +62,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/imageintegration/store/postgres/store.go
+++ b/central/imageintegration/store/postgres/store.go
@@ -70,7 +70,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -266,12 +266,15 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ImageIntegra
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations
+		if len(objs) < batchAfter {
+			s.mutex.RLock()
+			defer s.mutex.RUnlock()
+
+			return s.upsert(ctx, objs...)
+		}
 		s.mutex.Lock()
 		defer s.mutex.Unlock()
 
-		if len(objs) < batchAfter {
-			return s.upsert(ctx, objs...)
-		}
 		return s.copyFrom(ctx, objs...)
 	})
 }

--- a/central/integrationhealth/store/postgres/store.go
+++ b/central/integrationhealth/store/postgres/store.go
@@ -68,7 +68,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -254,12 +254,15 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.IntegrationH
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations
+		if len(objs) < batchAfter {
+			s.mutex.RLock()
+			defer s.mutex.RUnlock()
+
+			return s.upsert(ctx, objs...)
+		}
 		s.mutex.Lock()
 		defer s.mutex.Unlock()
 
-		if len(objs) < batchAfter {
-			return s.upsert(ctx, objs...)
-		}
 		return s.copyFrom(ctx, objs...)
 	})
 }

--- a/central/logimbue/store/postgres/store.go
+++ b/central/logimbue/store/postgres/store.go
@@ -69,7 +69,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -255,12 +255,15 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.LogImbue) er
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations
+		if len(objs) < batchAfter {
+			s.mutex.RLock()
+			defer s.mutex.RUnlock()
+
+			return s.upsert(ctx, objs...)
+		}
 		s.mutex.Lock()
 		defer s.mutex.Unlock()
 
-		if len(objs) < batchAfter {
-			return s.upsert(ctx, objs...)
-		}
 		return s.copyFrom(ctx, objs...)
 	})
 }

--- a/central/namespace/store/postgres/store.go
+++ b/central/namespace/store/postgres/store.go
@@ -71,7 +71,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -292,12 +292,15 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NamespaceMet
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations
+		if len(objs) < batchAfter {
+			s.mutex.RLock()
+			defer s.mutex.RUnlock()
+
+			return s.upsert(ctx, objs...)
+		}
 		s.mutex.Lock()
 		defer s.mutex.Unlock()
 
-		if len(objs) < batchAfter {
-			return s.upsert(ctx, objs...)
-		}
 		return s.copyFrom(ctx, objs...)
 	})
 }

--- a/central/networkbaseline/store/postgres/store.go
+++ b/central/networkbaseline/store/postgres/store.go
@@ -71,7 +71,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -277,12 +277,15 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NetworkBasel
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations
+		if len(objs) < batchAfter {
+			s.mutex.RLock()
+			defer s.mutex.RUnlock()
+
+			return s.upsert(ctx, objs...)
+		}
 		s.mutex.Lock()
 		defer s.mutex.Unlock()
 
-		if len(objs) < batchAfter {
-			return s.upsert(ctx, objs...)
-		}
 		return s.copyFrom(ctx, objs...)
 	})
 }

--- a/central/networkgraph/config/datastore/internal/store/postgres/store.go
+++ b/central/networkgraph/config/datastore/internal/store/postgres/store.go
@@ -68,7 +68,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -254,12 +254,15 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NetworkGraph
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations
+		if len(objs) < batchAfter {
+			s.mutex.RLock()
+			defer s.mutex.RUnlock()
+
+			return s.upsert(ctx, objs...)
+		}
 		s.mutex.Lock()
 		defer s.mutex.Unlock()
 
-		if len(objs) < batchAfter {
-			return s.upsert(ctx, objs...)
-		}
 		return s.copyFrom(ctx, objs...)
 	})
 }

--- a/central/networkgraph/entity/datastore/internal/store/postgres/store.go
+++ b/central/networkgraph/entity/datastore/internal/store/postgres/store.go
@@ -67,7 +67,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -260,12 +260,15 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NetworkEntit
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations
+		if len(objs) < batchAfter {
+			s.mutex.RLock()
+			defer s.mutex.RUnlock()
+
+			return s.upsert(ctx, objs...)
+		}
 		s.mutex.Lock()
 		defer s.mutex.Unlock()
 
-		if len(objs) < batchAfter {
-			return s.upsert(ctx, objs...)
-		}
 		return s.copyFrom(ctx, objs...)
 	})
 }

--- a/central/networkpolicies/datastore/internal/store/postgres/store.go
+++ b/central/networkpolicies/datastore/internal/store/postgres/store.go
@@ -71,7 +71,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -277,12 +277,15 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NetworkPolic
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations
+		if len(objs) < batchAfter {
+			s.mutex.RLock()
+			defer s.mutex.RUnlock()
+
+			return s.upsert(ctx, objs...)
+		}
 		s.mutex.Lock()
 		defer s.mutex.Unlock()
 
-		if len(objs) < batchAfter {
-			return s.upsert(ctx, objs...)
-		}
 		return s.copyFrom(ctx, objs...)
 	})
 }

--- a/central/networkpolicies/datastore/internal/undodeploymentstore/postgres/store.go
+++ b/central/networkpolicies/datastore/internal/undodeploymentstore/postgres/store.go
@@ -69,7 +69,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -255,12 +255,15 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NetworkPolic
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations
+		if len(objs) < batchAfter {
+			s.mutex.RLock()
+			defer s.mutex.RUnlock()
+
+			return s.upsert(ctx, objs...)
+		}
 		s.mutex.Lock()
 		defer s.mutex.Unlock()
 
-		if len(objs) < batchAfter {
-			return s.upsert(ctx, objs...)
-		}
 		return s.copyFrom(ctx, objs...)
 	})
 }

--- a/central/networkpolicies/datastore/internal/undostore/postgres/store.go
+++ b/central/networkpolicies/datastore/internal/undostore/postgres/store.go
@@ -69,7 +69,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -255,12 +255,15 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NetworkPolic
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations
+		if len(objs) < batchAfter {
+			s.mutex.RLock()
+			defer s.mutex.RUnlock()
+
+			return s.upsert(ctx, objs...)
+		}
 		s.mutex.Lock()
 		defer s.mutex.Unlock()
 
-		if len(objs) < batchAfter {
-			return s.upsert(ctx, objs...)
-		}
 		return s.copyFrom(ctx, objs...)
 	})
 }

--- a/central/nodecomponent/datastore/store/postgres/store.go
+++ b/central/nodecomponent/datastore/store/postgres/store.go
@@ -70,7 +70,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -286,12 +286,15 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.NodeComponen
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations
+		if len(objs) < batchAfter {
+			s.mutex.RLock()
+			defer s.mutex.RUnlock()
+
+			return s.upsert(ctx, objs...)
+		}
 		s.mutex.Lock()
 		defer s.mutex.Unlock()
 
-		if len(objs) < batchAfter {
-			return s.upsert(ctx, objs...)
-		}
 		return s.copyFrom(ctx, objs...)
 	})
 }

--- a/central/nodecomponentcveedge/datastore/store/postgres/store.go
+++ b/central/nodecomponentcveedge/datastore/store/postgres/store.go
@@ -62,7 +62,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/nodecomponentedge/store/postgres/store.go
+++ b/central/nodecomponentedge/store/postgres/store.go
@@ -62,7 +62,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/central/notifier/datastore/internal/store/postgres/store.go
+++ b/central/notifier/datastore/internal/store/postgres/store.go
@@ -69,7 +69,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -260,12 +260,15 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Notifier) er
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations
+		if len(objs) < batchAfter {
+			s.mutex.RLock()
+			defer s.mutex.RUnlock()
+
+			return s.upsert(ctx, objs...)
+		}
 		s.mutex.Lock()
 		defer s.mutex.Unlock()
 
-		if len(objs) < batchAfter {
-			return s.upsert(ctx, objs...)
-		}
 		return s.copyFrom(ctx, objs...)
 	})
 }

--- a/central/pod/store/postgres/store.go
+++ b/central/pod/store/postgres/store.go
@@ -71,7 +71,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -369,12 +369,15 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Pod) error {
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations
+		if len(objs) < batchAfter {
+			s.mutex.RLock()
+			defer s.mutex.RUnlock()
+
+			return s.upsert(ctx, objs...)
+		}
 		s.mutex.Lock()
 		defer s.mutex.Unlock()
 
-		if len(objs) < batchAfter {
-			return s.upsert(ctx, objs...)
-		}
 		return s.copyFrom(ctx, objs...)
 	})
 }

--- a/central/policy/store/postgres/store.go
+++ b/central/policy/store/postgres/store.go
@@ -70,7 +70,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -311,12 +311,15 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Policy) erro
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations
+		if len(objs) < batchAfter {
+			s.mutex.RLock()
+			defer s.mutex.RUnlock()
+
+			return s.upsert(ctx, objs...)
+		}
 		s.mutex.Lock()
 		defer s.mutex.Unlock()
 
-		if len(objs) < batchAfter {
-			return s.upsert(ctx, objs...)
-		}
 		return s.copyFrom(ctx, objs...)
 	})
 }

--- a/central/policycategory/store/postgres/store.go
+++ b/central/policycategory/store/postgres/store.go
@@ -70,7 +70,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -261,12 +261,15 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.PolicyCatego
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations
+		if len(objs) < batchAfter {
+			s.mutex.RLock()
+			defer s.mutex.RUnlock()
+
+			return s.upsert(ctx, objs...)
+		}
 		s.mutex.Lock()
 		defer s.mutex.Unlock()
 
-		if len(objs) < batchAfter {
-			return s.upsert(ctx, objs...)
-		}
 		return s.copyFrom(ctx, objs...)
 	})
 }

--- a/central/policycategoryedge/store/postgres/store.go
+++ b/central/policycategoryedge/store/postgres/store.go
@@ -70,7 +70,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -266,12 +266,15 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.PolicyCatego
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations
+		if len(objs) < batchAfter {
+			s.mutex.RLock()
+			defer s.mutex.RUnlock()
+
+			return s.upsert(ctx, objs...)
+		}
 		s.mutex.Lock()
 		defer s.mutex.Unlock()
 
-		if len(objs) < batchAfter {
-			return s.upsert(ctx, objs...)
-		}
 		return s.copyFrom(ctx, objs...)
 	})
 }

--- a/central/processbaseline/store/postgres/store.go
+++ b/central/processbaseline/store/postgres/store.go
@@ -71,7 +71,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -282,12 +282,15 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ProcessBasel
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations
+		if len(objs) < batchAfter {
+			s.mutex.RLock()
+			defer s.mutex.RUnlock()
+
+			return s.upsert(ctx, objs...)
+		}
 		s.mutex.Lock()
 		defer s.mutex.Unlock()
 
-		if len(objs) < batchAfter {
-			return s.upsert(ctx, objs...)
-		}
 		return s.copyFrom(ctx, objs...)
 	})
 }

--- a/central/processbaselineresults/datastore/internal/store/postgres/store.go
+++ b/central/processbaselineresults/datastore/internal/store/postgres/store.go
@@ -71,7 +71,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -277,12 +277,15 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ProcessBasel
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations
+		if len(objs) < batchAfter {
+			s.mutex.RLock()
+			defer s.mutex.RUnlock()
+
+			return s.upsert(ctx, objs...)
+		}
 		s.mutex.Lock()
 		defer s.mutex.Unlock()
 
-		if len(objs) < batchAfter {
-			return s.upsert(ctx, objs...)
-		}
 		return s.copyFrom(ctx, objs...)
 	})
 }

--- a/central/processindicator/store/postgres/store.go
+++ b/central/processindicator/store/postgres/store.go
@@ -72,7 +72,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -323,12 +323,15 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ProcessIndic
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations
+		if len(objs) < batchAfter {
+			s.mutex.RLock()
+			defer s.mutex.RUnlock()
+
+			return s.upsert(ctx, objs...)
+		}
 		s.mutex.Lock()
 		defer s.mutex.Unlock()
 
-		if len(objs) < batchAfter {
-			return s.upsert(ctx, objs...)
-		}
 		return s.copyFrom(ctx, objs...)
 	})
 }

--- a/central/processlisteningonport/store/postgres/store.go
+++ b/central/processlisteningonport/store/postgres/store.go
@@ -70,7 +70,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -276,12 +276,15 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ProcessListe
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations
+		if len(objs) < batchAfter {
+			s.mutex.RLock()
+			defer s.mutex.RUnlock()
+
+			return s.upsert(ctx, objs...)
+		}
 		s.mutex.Lock()
 		defer s.mutex.Unlock()
 
-		if len(objs) < batchAfter {
-			return s.upsert(ctx, objs...)
-		}
 		return s.copyFrom(ctx, objs...)
 	})
 }

--- a/central/rbac/k8srole/internal/store/postgres/store.go
+++ b/central/rbac/k8srole/internal/store/postgres/store.go
@@ -71,7 +71,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -302,12 +302,15 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.K8SRole) err
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations
+		if len(objs) < batchAfter {
+			s.mutex.RLock()
+			defer s.mutex.RUnlock()
+
+			return s.upsert(ctx, objs...)
+		}
 		s.mutex.Lock()
 		defer s.mutex.Unlock()
 
-		if len(objs) < batchAfter {
-			return s.upsert(ctx, objs...)
-		}
 		return s.copyFrom(ctx, objs...)
 	})
 }

--- a/central/rbac/k8srolebinding/internal/store/postgres/store.go
+++ b/central/rbac/k8srolebinding/internal/store/postgres/store.go
@@ -71,7 +71,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -394,12 +394,15 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.K8SRoleBindi
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations
+		if len(objs) < batchAfter {
+			s.mutex.RLock()
+			defer s.mutex.RUnlock()
+
+			return s.upsert(ctx, objs...)
+		}
 		s.mutex.Lock()
 		defer s.mutex.Unlock()
 
-		if len(objs) < batchAfter {
-			return s.upsert(ctx, objs...)
-		}
 		return s.copyFrom(ctx, objs...)
 	})
 }

--- a/central/reportconfigurations/store/postgres/store.go
+++ b/central/reportconfigurations/store/postgres/store.go
@@ -69,7 +69,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -265,12 +265,15 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ReportConfig
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations
+		if len(objs) < batchAfter {
+			s.mutex.RLock()
+			defer s.mutex.RUnlock()
+
+			return s.upsert(ctx, objs...)
+		}
 		s.mutex.Lock()
 		defer s.mutex.Unlock()
 
-		if len(objs) < batchAfter {
-			return s.upsert(ctx, objs...)
-		}
 		return s.copyFrom(ctx, objs...)
 	})
 }

--- a/central/resourcecollection/datastore/store/postgres/store.go
+++ b/central/resourcecollection/datastore/store/postgres/store.go
@@ -69,7 +69,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -352,12 +352,15 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ResourceColl
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations
+		if len(objs) < batchAfter {
+			s.mutex.RLock()
+			defer s.mutex.RUnlock()
+
+			return s.upsert(ctx, objs...)
+		}
 		s.mutex.Lock()
 		defer s.mutex.Unlock()
 
-		if len(objs) < batchAfter {
-			return s.upsert(ctx, objs...)
-		}
 		return s.copyFrom(ctx, objs...)
 	})
 }

--- a/central/risk/datastore/internal/store/postgres/store.go
+++ b/central/risk/datastore/internal/store/postgres/store.go
@@ -71,7 +71,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -287,12 +287,15 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Risk) error 
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations
+		if len(objs) < batchAfter {
+			s.mutex.RLock()
+			defer s.mutex.RUnlock()
+
+			return s.upsert(ctx, objs...)
+		}
 		s.mutex.Lock()
 		defer s.mutex.Unlock()
 
-		if len(objs) < batchAfter {
-			return s.upsert(ctx, objs...)
-		}
 		return s.copyFrom(ctx, objs...)
 	})
 }

--- a/central/role/store/permissionset/postgres/store.go
+++ b/central/role/store/permissionset/postgres/store.go
@@ -68,7 +68,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -259,12 +259,15 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.PermissionSe
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations
+		if len(objs) < batchAfter {
+			s.mutex.RLock()
+			defer s.mutex.RUnlock()
+
+			return s.upsert(ctx, objs...)
+		}
 		s.mutex.Lock()
 		defer s.mutex.Unlock()
 
-		if len(objs) < batchAfter {
-			return s.upsert(ctx, objs...)
-		}
 		return s.copyFrom(ctx, objs...)
 	})
 }

--- a/central/role/store/role/postgres/store.go
+++ b/central/role/store/role/postgres/store.go
@@ -68,7 +68,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -254,12 +254,15 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Role) error 
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations
+		if len(objs) < batchAfter {
+			s.mutex.RLock()
+			defer s.mutex.RUnlock()
+
+			return s.upsert(ctx, objs...)
+		}
 		s.mutex.Lock()
 		defer s.mutex.Unlock()
 
-		if len(objs) < batchAfter {
-			return s.upsert(ctx, objs...)
-		}
 		return s.copyFrom(ctx, objs...)
 	})
 }

--- a/central/role/store/simpleaccessscope/postgres/store.go
+++ b/central/role/store/simpleaccessscope/postgres/store.go
@@ -68,7 +68,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -259,12 +259,15 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.SimpleAccess
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations
+		if len(objs) < batchAfter {
+			s.mutex.RLock()
+			defer s.mutex.RUnlock()
+
+			return s.upsert(ctx, objs...)
+		}
 		s.mutex.Lock()
 		defer s.mutex.Unlock()
 
-		if len(objs) < batchAfter {
-			return s.upsert(ctx, objs...)
-		}
 		return s.copyFrom(ctx, objs...)
 	})
 }

--- a/central/secret/internal/store/postgres/store.go
+++ b/central/secret/internal/store/postgres/store.go
@@ -71,7 +71,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -466,12 +466,15 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Secret) erro
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations
+		if len(objs) < batchAfter {
+			s.mutex.RLock()
+			defer s.mutex.RUnlock()
+
+			return s.upsert(ctx, objs...)
+		}
 		s.mutex.Lock()
 		defer s.mutex.Unlock()
 
-		if len(objs) < batchAfter {
-			return s.upsert(ctx, objs...)
-		}
 		return s.copyFrom(ctx, objs...)
 	})
 }

--- a/central/serviceaccount/internal/store/postgres/store.go
+++ b/central/serviceaccount/internal/store/postgres/store.go
@@ -71,7 +71,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -297,12 +297,15 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ServiceAccou
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations
+		if len(objs) < batchAfter {
+			s.mutex.RLock()
+			defer s.mutex.RUnlock()
+
+			return s.upsert(ctx, objs...)
+		}
 		s.mutex.Lock()
 		defer s.mutex.Unlock()
 
-		if len(objs) < batchAfter {
-			return s.upsert(ctx, objs...)
-		}
 		return s.copyFrom(ctx, objs...)
 	})
 }

--- a/central/serviceidentities/internal/store/postgres/store.go
+++ b/central/serviceidentities/internal/store/postgres/store.go
@@ -69,7 +69,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -255,12 +255,15 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.ServiceIdent
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations
+		if len(objs) < batchAfter {
+			s.mutex.RLock()
+			defer s.mutex.RUnlock()
+
+			return s.upsert(ctx, objs...)
+		}
 		s.mutex.Lock()
 		defer s.mutex.Unlock()
 
-		if len(objs) < batchAfter {
-			return s.upsert(ctx, objs...)
-		}
 		return s.copyFrom(ctx, objs...)
 	})
 }

--- a/central/signatureintegration/store/postgres/store.go
+++ b/central/signatureintegration/store/postgres/store.go
@@ -68,7 +68,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -259,12 +259,15 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.SignatureInt
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations
+		if len(objs) < batchAfter {
+			s.mutex.RLock()
+			defer s.mutex.RUnlock()
+
+			return s.upsert(ctx, objs...)
+		}
 		s.mutex.Lock()
 		defer s.mutex.Unlock()
 
-		if len(objs) < batchAfter {
-			return s.upsert(ctx, objs...)
-		}
 		return s.copyFrom(ctx, objs...)
 	})
 }

--- a/central/vulnerabilityrequest/datastore/internal/store/postgres/store.go
+++ b/central/vulnerabilityrequest/datastore/internal/store/postgres/store.go
@@ -67,7 +67,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -457,12 +457,15 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Vulnerabilit
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations
+		if len(objs) < batchAfter {
+			s.mutex.RLock()
+			defer s.mutex.RUnlock()
+
+			return s.upsert(ctx, objs...)
+		}
 		s.mutex.Lock()
 		defer s.mutex.Unlock()
 
-		if len(objs) < batchAfter {
-			return s.upsert(ctx, objs...)
-		}
 		return s.copyFrom(ctx, objs...)
 	})
 }

--- a/central/watchedimage/datastore/internal/store/postgres/store.go
+++ b/central/watchedimage/datastore/internal/store/postgres/store.go
@@ -68,7 +68,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -254,12 +254,15 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.WatchedImage
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations
+		if len(objs) < batchAfter {
+			s.mutex.RLock()
+			defer s.mutex.RUnlock()
+
+			return s.upsert(ctx, objs...)
+		}
 		s.mutex.Lock()
 		defer s.mutex.Unlock()
 
-		if len(objs) < batchAfter {
-			return s.upsert(ctx, objs...)
-		}
 		return s.copyFrom(ctx, objs...)
 	})
 }

--- a/tools/generate-helpers/pg-table-bindings/multitest/postgres/store.go
+++ b/tools/generate-helpers/pg-table-bindings/multitest/postgres/store.go
@@ -70,7 +70,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -424,12 +424,15 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestMultiKey
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations
+		if len(objs) < batchAfter {
+			s.mutex.RLock()
+			defer s.mutex.RUnlock()
+
+			return s.upsert(ctx, objs...)
+		}
 		s.mutex.Lock()
 		defer s.mutex.Unlock()
 
-		if len(objs) < batchAfter {
-			return s.upsert(ctx, objs...)
-		}
 		return s.copyFrom(ctx, objs...)
 	})
 }

--- a/tools/generate-helpers/pg-table-bindings/test/postgres/store.go
+++ b/tools/generate-helpers/pg-table-bindings/test/postgres/store.go
@@ -71,7 +71,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -307,12 +307,15 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestSingleKe
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations
+		if len(objs) < batchAfter {
+			s.mutex.RLock()
+			defer s.mutex.RUnlock()
+
+			return s.upsert(ctx, objs...)
+		}
 		s.mutex.Lock()
 		defer s.mutex.Unlock()
 
-		if len(objs) < batchAfter {
-			return s.upsert(ctx, objs...)
-		}
 		return s.copyFrom(ctx, objs...)
 	})
 }

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1/store.go
@@ -70,7 +70,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -261,12 +261,15 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestChild1) 
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations
+		if len(objs) < batchAfter {
+			s.mutex.RLock()
+			defer s.mutex.RUnlock()
+
+			return s.upsert(ctx, objs...)
+		}
 		s.mutex.Lock()
 		defer s.mutex.Unlock()
 
-		if len(objs) < batchAfter {
-			return s.upsert(ctx, objs...)
-		}
 		return s.copyFrom(ctx, objs...)
 	})
 }

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1p4/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild1p4/store.go
@@ -70,7 +70,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -266,12 +266,15 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestChild1P4
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations
+		if len(objs) < batchAfter {
+			s.mutex.RLock()
+			defer s.mutex.RUnlock()
+
+			return s.upsert(ctx, objs...)
+		}
 		s.mutex.Lock()
 		defer s.mutex.Unlock()
 
-		if len(objs) < batchAfter {
-			return s.upsert(ctx, objs...)
-		}
 		return s.copyFrom(ctx, objs...)
 	})
 }

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild2/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testchild2/store.go
@@ -70,7 +70,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -271,12 +271,15 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestChild2) 
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations
+		if len(objs) < batchAfter {
+			s.mutex.RLock()
+			defer s.mutex.RUnlock()
+
+			return s.upsert(ctx, objs...)
+		}
 		s.mutex.Lock()
 		defer s.mutex.Unlock()
 
-		if len(objs) < batchAfter {
-			return s.upsert(ctx, objs...)
-		}
 		return s.copyFrom(ctx, objs...)
 	})
 }

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testg2grandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testg2grandchild1/store.go
@@ -70,7 +70,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -271,12 +271,15 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestG2GrandC
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations
+		if len(objs) < batchAfter {
+			s.mutex.RLock()
+			defer s.mutex.RUnlock()
+
+			return s.upsert(ctx, objs...)
+		}
 		s.mutex.Lock()
 		defer s.mutex.Unlock()
 
-		if len(objs) < batchAfter {
-			return s.upsert(ctx, objs...)
-		}
 		return s.copyFrom(ctx, objs...)
 	})
 }

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testg3grandchild1/store.go
@@ -70,7 +70,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -261,12 +261,15 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestG3GrandC
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations
+		if len(objs) < batchAfter {
+			s.mutex.RLock()
+			defer s.mutex.RUnlock()
+
+			return s.upsert(ctx, objs...)
+		}
 		s.mutex.Lock()
 		defer s.mutex.Unlock()
 
-		if len(objs) < batchAfter {
-			return s.upsert(ctx, objs...)
-		}
 		return s.copyFrom(ctx, objs...)
 	})
 }

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testggrandchild1/store.go
@@ -70,7 +70,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -261,12 +261,15 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestGGrandCh
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations
+		if len(objs) < batchAfter {
+			s.mutex.RLock()
+			defer s.mutex.RUnlock()
+
+			return s.upsert(ctx, objs...)
+		}
 		s.mutex.Lock()
 		defer s.mutex.Unlock()
 
-		if len(objs) < batchAfter {
-			return s.upsert(ctx, objs...)
-		}
 		return s.copyFrom(ctx, objs...)
 	})
 }

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandchild1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandchild1/store.go
@@ -70,7 +70,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -271,12 +271,15 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestGrandChi
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations
+		if len(objs) < batchAfter {
+			s.mutex.RLock()
+			defer s.mutex.RUnlock()
+
+			return s.upsert(ctx, objs...)
+		}
 		s.mutex.Lock()
 		defer s.mutex.Unlock()
 
-		if len(objs) < batchAfter {
-			return s.upsert(ctx, objs...)
-		}
 		return s.copyFrom(ctx, objs...)
 	})
 }

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store.go
@@ -70,7 +70,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -440,12 +440,15 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestGrandpar
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations
+		if len(objs) < batchAfter {
+			s.mutex.RLock()
+			defer s.mutex.RUnlock()
+
+			return s.upsert(ctx, objs...)
+		}
 		s.mutex.Lock()
 		defer s.mutex.Unlock()
 
-		if len(objs) < batchAfter {
-			return s.upsert(ctx, objs...)
-		}
 		return s.copyFrom(ctx, objs...)
 	})
 }

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent1/store.go
@@ -70,7 +70,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -348,12 +348,15 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestParent1)
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations
+		if len(objs) < batchAfter {
+			s.mutex.RLock()
+			defer s.mutex.RUnlock()
+
+			return s.upsert(ctx, objs...)
+		}
 		s.mutex.Lock()
 		defer s.mutex.Unlock()
 
-		if len(objs) < batchAfter {
-			return s.upsert(ctx, objs...)
-		}
 		return s.copyFrom(ctx, objs...)
 	})
 }

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent2/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent2/store.go
@@ -70,7 +70,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -266,12 +266,15 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestParent2)
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations
+		if len(objs) < batchAfter {
+			s.mutex.RLock()
+			defer s.mutex.RUnlock()
+
+			return s.upsert(ctx, objs...)
+		}
 		s.mutex.Lock()
 		defer s.mutex.Unlock()
 
-		if len(objs) < batchAfter {
-			return s.upsert(ctx, objs...)
-		}
 		return s.copyFrom(ctx, objs...)
 	})
 }

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent3/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent3/store.go
@@ -70,7 +70,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -266,12 +266,15 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestParent3)
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations
+		if len(objs) < batchAfter {
+			s.mutex.RLock()
+			defer s.mutex.RUnlock()
+
+			return s.upsert(ctx, objs...)
+		}
 		s.mutex.Lock()
 		defer s.mutex.Unlock()
 
-		if len(objs) < batchAfter {
-			return s.upsert(ctx, objs...)
-		}
 		return s.copyFrom(ctx, objs...)
 	})
 }

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent4/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent4/store.go
@@ -70,7 +70,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -266,12 +266,15 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestParent4)
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations
+		if len(objs) < batchAfter {
+			s.mutex.RLock()
+			defer s.mutex.RUnlock()
+
+			return s.upsert(ctx, objs...)
+		}
 		s.mutex.Lock()
 		defer s.mutex.Unlock()
 
-		if len(objs) < batchAfter {
-			return s.upsert(ctx, objs...)
-		}
 		return s.copyFrom(ctx, objs...)
 	})
 }

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testshortcircuit/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testshortcircuit/store.go
@@ -70,7 +70,7 @@ type Store interface {
 
 type storeImpl struct {
 	db    *postgres.DB
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // New returns a new Store instance using the provided sql instance.
@@ -266,12 +266,15 @@ func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.TestShortCir
 		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
 		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
 		// violations
+		if len(objs) < batchAfter {
+			s.mutex.RLock()
+			defer s.mutex.RUnlock()
+
+			return s.upsert(ctx, objs...)
+		}
 		s.mutex.Lock()
 		defer s.mutex.Unlock()
 
-		if len(objs) < batchAfter {
-			return s.upsert(ctx, objs...)
-		}
 		return s.copyFrom(ctx, objs...)
 	})
 }


### PR DESCRIPTION
## Description

Straight forward, plus a metric for ProcessAggregator

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Will check CI logs to see if any new conflicts are added