### PR TITLE
ROX-15345: remove 'Apply network policy' option from UI

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraph.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraph.tsx
@@ -34,11 +34,10 @@ function NetworkGraph({
         newController.registerComponentFactory(stylesComponentFactory);
         return newController;
     }, []);
-    const { simulator, setNetworkPolicyModification, applyNetworkPolicyModification } =
-        useNetworkPolicySimulator({
-            simulation,
-            clusterId: selectedClusterId,
-        });
+    const { simulator, setNetworkPolicyModification } = useNetworkPolicySimulator({
+        simulation,
+        clusterId: selectedClusterId,
+    });
 
     const isSimulating =
         simulator.state === 'GENERATED' ||
@@ -56,7 +55,6 @@ function NetworkGraph({
                     simulator={simulator}
                     selectedNode={selectedNode}
                     setNetworkPolicyModification={setNetworkPolicyModification}
-                    applyNetworkPolicyModification={applyNetworkPolicyModification}
                     edgeState={edgeState}
                 />
             </VisualizationProvider>

--- a/ui/apps/platform/src/Containers/NetworkGraph/TopologyComponent.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/TopologyComponent.tsx
@@ -28,7 +28,6 @@ import { Simulation } from './utils/getSimulation';
 import LegendContent from './components/LegendContent';
 
 import {
-    ApplyNetworkPolicyModification,
     NetworkPolicySimulator,
     SetNetworkPolicyModification,
 } from './hooks/useNetworkPolicySimulator';
@@ -58,7 +57,6 @@ export type TopologyComponentProps = {
     selectedNode?: CustomNodeModel;
     simulator: NetworkPolicySimulator;
     setNetworkPolicyModification: SetNetworkPolicyModification;
-    applyNetworkPolicyModification: ApplyNetworkPolicyModification;
     edgeState: EdgeState;
 };
 

--- a/ui/apps/platform/src/Containers/NetworkGraph/TopologyComponent.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/TopologyComponent.tsx
@@ -77,7 +77,6 @@ const TopologyComponent = ({
     selectedNode,
     simulator,
     setNetworkPolicyModification,
-    applyNetworkPolicyModification,
     edgeState,
 }: TopologyComponentProps) => {
     const firstRenderRef = useRef(true);
@@ -178,7 +177,6 @@ const TopologyComponent = ({
                             selectedClusterId={selectedClusterId}
                             simulator={simulator}
                             setNetworkPolicyModification={setNetworkPolicyModification}
-                            applyNetworkPolicyModification={applyNetworkPolicyModification}
                         />
                     )}
                     {selectedNode && selectedNode?.data?.type === 'NAMESPACE' && (

--- a/ui/apps/platform/src/Containers/NetworkGraph/hooks/useNetworkPolicySimulator.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/hooks/useNetworkPolicySimulator.ts
@@ -23,8 +23,6 @@ export type NetworkPolicySimulator =
 
 export type SetNetworkPolicyModification = (action: SetNetworkPolicyModificationAction) => void;
 
-export type ApplyNetworkPolicyModification = () => void;
-
 type SetNetworkPolicyModificationAction =
     | {
           state: 'ACTIVE';
@@ -71,7 +69,6 @@ const defaultResultState = {
 function useNetworkPolicySimulator({ simulation, clusterId }: UseNetworkPolicySimulatorParams): {
     simulator: NetworkPolicySimulator;
     setNetworkPolicyModification: SetNetworkPolicyModification;
-    applyNetworkPolicyModification: ApplyNetworkPolicyModification;
 } {
     const [simulator, setSimulator] = useState<NetworkPolicySimulator>(defaultResultState);
 
@@ -197,42 +194,7 @@ function useNetworkPolicySimulator({ simulation, clusterId }: UseNetworkPolicySi
         }
     }
 
-    function applyNetworkPolicyModification() {
-        if (simulator.state === 'ACTIVE') {
-            return;
-        }
-        setSimulator({
-            state: simulator.state,
-            modification: simulator.modification,
-            error: '',
-            isLoading: true,
-        });
-        networkService
-            .applyNetworkPolicyModification(clusterId, simulator.modification)
-            .then(() => {
-                setNetworkPolicyModification({
-                    state: 'ACTIVE',
-                    options: {
-                        clusterId,
-                        searchQuery: '',
-                    },
-                });
-            })
-            .catch((error) => {
-                const message = getAxiosErrorMessage(error);
-                const errorMessage =
-                    message || 'An unknown error occurred while applying the network policies';
-
-                setSimulator({
-                    state: simulator.state,
-                    modification: simulator.modification,
-                    error: errorMessage,
-                    isLoading: false,
-                });
-            });
-    }
-
-    return { simulator, setNetworkPolicyModification, applyNetworkPolicyModification };
+    return { simulator, setNetworkPolicyModification };
 }
 
 export default useNetworkPolicySimulator;

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPolicySimulatorSidePanel.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPolicySimulatorSidePanel.tsx
@@ -22,7 +22,6 @@ import {
 import useTabs from 'hooks/patternfly/useTabs';
 import ViewActiveYAMLs from './ViewActiveYAMLs';
 import {
-    ApplyNetworkPolicyModification,
     NetworkPolicySimulator,
     SetNetworkPolicyModification,
 } from '../hooks/useNetworkPolicySimulator';
@@ -36,7 +35,6 @@ type NetworkPolicySimulatorSidePanelProps = {
     selectedClusterId: string;
     simulator: NetworkPolicySimulator;
     setNetworkPolicyModification: SetNetworkPolicyModification;
-    applyNetworkPolicyModification: ApplyNetworkPolicyModification;
 };
 
 const tabs = {
@@ -48,9 +46,8 @@ function NetworkPolicySimulatorSidePanel({
     selectedClusterId,
     simulator,
     setNetworkPolicyModification,
-    applyNetworkPolicyModification,
 }: NetworkPolicySimulatorSidePanelProps) {
-    const { activeKeyTab, onSelectTab, setActiveKeyTab } = useTabs({
+    const { activeKeyTab, onSelectTab } = useTabs({
         defaultTab: tabs.SIMULATE_NETWORK_POLICIES,
     });
     const [isExcludingPortsAndProtocols, setIsExcludingPortsAndProtocols] =
@@ -118,11 +115,6 @@ function NetworkPolicySimulatorSidePanel({
         });
     }
 
-    function applyNetworkPolicies() {
-        applyNetworkPolicyModification();
-        setActiveKeyTab(tabs.VIEW_ACTIVE_YAMLS);
-    }
-
     function openNotifyYAMLModal() {
         setIsNotifyModalOpen(true);
     }
@@ -174,7 +166,6 @@ function NetworkPolicySimulatorSidePanel({
                             generateNetworkPolicies={generateNetworkPolicies}
                             undoNetworkPolicies={undoNetworkPolicies}
                             onFileInputChange={handleFileInputChange}
-                            applyNetworkPolicies={applyNetworkPolicies}
                             openNotifyYAMLModal={openNotifyYAMLModal}
                         />
                     </StackItem>
@@ -229,7 +220,6 @@ function NetworkPolicySimulatorSidePanel({
                             generateNetworkPolicies={generateNetworkPolicies}
                             undoNetworkPolicies={undoNetworkPolicies}
                             onFileInputChange={handleFileInputChange}
-                            applyNetworkPolicies={applyNetworkPolicies}
                             openNotifyYAMLModal={openNotifyYAMLModal}
                         />
                     </StackItem>
@@ -281,7 +271,6 @@ function NetworkPolicySimulatorSidePanel({
                             generateNetworkPolicies={generateNetworkPolicies}
                             undoNetworkPolicies={undoNetworkPolicies}
                             onFileInputChange={handleFileInputChange}
-                            applyNetworkPolicies={applyNetworkPolicies}
                             openNotifyYAMLModal={openNotifyYAMLModal}
                         />
                     </StackItem>

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkSimulatorActions.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkSimulatorActions.tsx
@@ -16,7 +16,6 @@ type NetworkSimulatorActionsProps = {
         _event: React.ChangeEvent<HTMLInputElement> | React.DragEvent<HTMLElement>,
         file: File
     ) => void;
-    applyNetworkPolicies?: () => void;
     openNotifyYAMLModal?: () => void;
 };
 
@@ -25,7 +24,6 @@ const actionsDropdownId = 'network-simulator-actions-dropdown';
 const labels = {
     generate: 'Rebuild rules from active traffic',
     undo: 'Revert rules to previously applied YAML',
-    apply: 'Apply network policies',
     notify: 'Share YAML with notifiers',
 };
 
@@ -33,7 +31,6 @@ function NetworkSimulatorActions({
     generateNetworkPolicies,
     undoNetworkPolicies,
     onFileInputChange,
-    applyNetworkPolicies,
     openNotifyYAMLModal,
 }: NetworkSimulatorActionsProps) {
     const [isActionsOpen, setIsActionsOpen] = React.useState(false);
@@ -65,14 +62,6 @@ function NetworkSimulatorActions({
         actionsDropdownItems.unshift(
             <DropdownItem key="notify" tooltip="" onClick={openNotifyYAMLModal}>
                 {labels.notify}
-            </DropdownItem>
-        );
-    }
-
-    if (applyNetworkPolicies) {
-        actionsDropdownItems.unshift(
-            <DropdownItem key="apply" tooltip="" onClick={applyNetworkPolicies}>
-                {labels.apply}
             </DropdownItem>
         );
     }


### PR DESCRIPTION
## Description

This PR removes the "Apply network policy" option as suggested by Boaz. See https://issues.redhat.com/browse/ROX-15345

<img width="1440" alt="Screenshot 2023-02-27 at 11 49 15 AM" src="https://user-images.githubusercontent.com/4805485/221670280-e118a49b-7773-4e8a-86ac-c9d7f2e21b39.png">


## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~
