### PR TITLE
ROX-7026: `AdmissionControllerTest` troubleshooting improvements

### DIFF
--- a/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
@@ -135,7 +135,7 @@ class Kubernetes implements OrchestratorMain {
         // "any namespace" requests to be scoped to the default project.
         this.client.configuration.namespace = null
         this.client.configuration.setRollingTimeout(60 * 60 * 1000)
-        this.client.configuration.setRequestTimeout(20*1000)
+        this.client.configuration.setRequestTimeout(32*1000)
         this.client.configuration.setConnectionTimeout(20*1000)
         this.client.configuration.setWebsocketTimeout(20*1000)
         this.deployments = this.client.apps().deployments()

--- a/qa-tests-backend/src/main/groovy/util/ChaosMonkey.groovy
+++ b/qa-tests-backend/src/main/groovy/util/ChaosMonkey.groovy
@@ -39,6 +39,9 @@ class ChaosMonkey {
                 // Get the current ready, non-deleted pod replicas
                 def admCtrlPods = new ArrayList<Pod>(orchestrator.getPods(
                         Constants.STACKROX_NAMESPACE, ADMISSION_CONTROLLER_APP_NAME))
+                admCtrlPods.forEach {
+                    log.info "Encountered pod ${it.metadata.name}, ready=${orchestrator.podReady(it)}."
+                }
                 admCtrlPods.removeIf { Pod p -> !orchestrator.podReady(p) }
 
                 if (admCtrlPods.size() < minReadyReplicas) {

--- a/qa-tests-backend/src/main/groovy/util/ChaosMonkey.groovy
+++ b/qa-tests-backend/src/main/groovy/util/ChaosMonkey.groovy
@@ -16,17 +16,24 @@ class ChaosMonkey {
 
     Thread thread
     OrchestratorMain orchestrator
+    int minReadyReplicas
+    Long gracePeriod
 
     static final private String ADMISSION_CONTROLLER_APP_NAME = "admission-control"
     static final private int ADMISSION_CONTROLLER_EXPECTED_PODS = 3
 
     ChaosMonkey(OrchestratorMain client, int minReadyReplicas, Long gracePeriod) {
         orchestrator = client
+        this.minReadyReplicas = minReadyReplicas
+        this.gracePeriod = gracePeriod
 
         def pods = orchestrator.getPods(Constants.STACKROX_NAMESPACE, ADMISSION_CONTROLLER_APP_NAME)
         assert pods.size() > 0, "There are no ${ADMISSION_CONTROLLER_APP_NAME} pods. " +
                 "Did you enable ADMISSION_CONTROLLER when deploying?"
+    }
 
+    void start() {
+        assert thread == null, "Already started, call stop() first."
         thread = Thread.start {
             while (!stopFlag.get()) {
                 // Get the current ready, non-deleted pod replicas
@@ -59,8 +66,11 @@ class ChaosMonkey {
     }
 
     void stop() {
-        stopFlag.set(true)
-        thread.join()
+        if (thread) {
+            stopFlag.set(true)
+            thread.join()
+            thread = null
+        }
     }
 
     def waitForEffect() {

--- a/qa-tests-backend/src/main/groovy/util/ChaosMonkey.groovy
+++ b/qa-tests-backend/src/main/groovy/util/ChaosMonkey.groovy
@@ -37,8 +37,8 @@ class ChaosMonkey {
         thread = Thread.start {
             while (!stopFlag.get()) {
                 // Get the current ready, non-deleted pod replicas
-                def admCtrlPods = new ArrayList<Pod>(orchestrator.getPods(
-                        Constants.STACKROX_NAMESPACE, ADMISSION_CONTROLLER_APP_NAME))
+                def admCtrlPods = orchestrator.getPods(
+                        Constants.STACKROX_NAMESPACE, ADMISSION_CONTROLLER_APP_NAME)
                 admCtrlPods.forEach {
                     log.info "Encountered pod ${it.metadata.name}, ready=${orchestrator.podReady(it)}."
                 }

--- a/sensor/admission-control/manager/evaluate_deploytime.go
+++ b/sensor/admission-control/manager/evaluate_deploytime.go
@@ -156,5 +156,6 @@ func (m *manager) evaluateAdmissionRequest(s *state, req *admission.AdmissionReq
 		go m.filterAndPutAttemptedAlertsOnChan(req.Operation, alerts...)
 	}
 
+	log.Debugf("Violated policies: %d, rejecting %s request on %s/%s [%s]", len(alerts), req.Operation, req.Namespace, req.Name, req.Kind)
 	return fail(req.UID, message(alerts, !s.GetClusterConfig().GetAdmissionControllerConfig().GetDisableBypass())), nil
 }


### PR DESCRIPTION
## Description

These are the parts of #4775 which are generally useful for troubleshooting `AdmissionControllerTest` (and potentially other tests too), even if we do not decide to re-enable `ChaosMonkey`, but do not include the `@CompileStatic` changes which are in separate PR #5024 due to their size.

See individual commits' descriptions for more info on each change.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

CI should be sufficient.