### PR TITLE
ROX-15158, ROX-15360, ROX-15361: make jira issue check optional, collector released versions idempotent & fix publish-helm-charts

### DIFF
--- a/.github/workflows/cut-rc.yml
+++ b/.github/workflows/cut-rc.yml
@@ -31,6 +31,11 @@ on:
         required: true
         default: true
         type: boolean
+      check-jira-issues:
+        description: Check Jira issues for current release
+        required: true
+        default: true
+        type: boolean
 
 env:
   main_branch: ${{github.event.repository.default_branch}}
@@ -89,6 +94,7 @@ jobs:
 
   check-jira:
     name: Check Jira tickets for release
+    if: github.event.inputs.check-jira-issues == 'true'
     needs: [variables, properties]
     runs-on: ubuntu-latest
     steps:

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -646,7 +646,7 @@ mark_collector_release() {
     # We need to make sure the file ends with a newline so as not to corrupt it when appending.
     [[ ! -f RELEASED_VERSIONS ]] || sed --in-place -e '$a'\\ RELEASED_VERSIONS
     if grep -q "${tag}" RELEASED_VERSIONS; then
-        echo "Skip RELEASED_VERSIONS file update, already up to date ..." >> "${GITHUB_STEP_SUMMARY}"
+        echo "Skip RELEASED_VERSIONS file change, already up to date ..." >> "${GITHUB_STEP_SUMMARY}"
     else
         echo "Update RELEASED_VERSIONS file ..." >> "${GITHUB_STEP_SUMMARY}"
         echo "${collector_version} ${tag}  # Rox release ${tag} by ${username} at $(date)" \

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -645,10 +645,14 @@ mark_collector_release() {
 
     # We need to make sure the file ends with a newline so as not to corrupt it when appending.
     [[ ! -f RELEASED_VERSIONS ]] || sed --in-place -e '$a'\\ RELEASED_VERSIONS
-    if ! grep -Fxq "${tag}" RELEASED_VERSIONS; then
+    if grep -q "${tag}" RELEASED_VERSIONS; then
+        echo "Skip RELEASED_VERSIONS file update, already up to date..." >> "${GITHUB_STEP_SUMMARY}"
+    else
+        echo "Update RELEASED_VERSIONS file ..." >> "${GITHUB_STEP_SUMMARY}"
         echo "${collector_version} ${tag}  # Rox release ${tag} by ${username} at $(date)" \
             >>RELEASED_VERSIONS
     fi
+
     gitbot add RELEASED_VERSIONS
     gitbot commit --allow-empty -m "Automatic update of RELEASED_VERSIONS file for Rox release ${tag}"
     gitbot push origin "${branch_name}"

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -646,7 +646,7 @@ mark_collector_release() {
     # We need to make sure the file ends with a newline so as not to corrupt it when appending.
     [[ ! -f RELEASED_VERSIONS ]] || sed --in-place -e '$a'\\ RELEASED_VERSIONS
     if grep -q "${tag}" RELEASED_VERSIONS; then
-        echo "Skip RELEASED_VERSIONS file update, already up to date..." >> "${GITHUB_STEP_SUMMARY}"
+        echo "Skip RELEASED_VERSIONS file update, already up to date ..." >> "${GITHUB_STEP_SUMMARY}"
     else
         echo "Update RELEASED_VERSIONS file ..." >> "${GITHUB_STEP_SUMMARY}"
         echo "${collector_version} ${tag}  # Rox release ${tag} by ${username} at $(date)" \

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -651,11 +651,10 @@ mark_collector_release() {
         echo "Update RELEASED_VERSIONS file ..." >> "${GITHUB_STEP_SUMMARY}"
         echo "${collector_version} ${tag}  # Rox release ${tag} by ${username} at $(date)" \
             >>RELEASED_VERSIONS
+        gitbot add RELEASED_VERSIONS
+        gitbot commit -m "Automatic update of RELEASED_VERSIONS file for Rox release ${tag}"
+        gitbot push origin "${branch_name}"
     fi
-
-    gitbot add RELEASED_VERSIONS
-    gitbot commit --allow-empty -m "Automatic update of RELEASED_VERSIONS file for Rox release ${tag}"
-    gitbot push origin "${branch_name}"
 
     PRs=$(gh pr list -s open \
     --head "${branch_name}" \

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -657,9 +657,9 @@ mark_collector_release() {
     fi
 
     PRs=$(gh pr list -s open \
-    --head "${branch_name}" \
-    --json number \
-    --jq length)
+            --head "${branch_name}" \
+            --json number \
+            --jq length)
     if [ "$PRs" -eq 0 ]; then
         echo "Create a PR for collector to add this release to its RELEASED_VERSIONS file" >> "${GITHUB_STEP_SUMMARY}"
         gh pr create \

--- a/scripts/ci/publish-helm-charts.sh
+++ b/scripts/ci/publish-helm-charts.sh
@@ -73,9 +73,7 @@ gitbot -C "$tmp_remote_repository" add -A
 gitbot -C "$tmp_remote_repository" commit -m "Publish Helm Charts for version ${version}"
 gitbot -C "$tmp_remote_repository" push origin "$branch_name"
 
-pr_response_file="$(mktemp)"
-
-message="Hello Release Artifact Publishers!
+message="Hello Release Managers!
 
 Engineering has signed off on release **${version}**! The new Helm charts are ready to be published.
 Once the version is GA, please complete the publishing by merging this PR using the 'Squash and Merge' option.
@@ -84,7 +82,6 @@ Once the version is GA, please complete the publishing by merging this PR using 
 to an unreleased version."
 
 curl -sS --fail \
-	-o "$pr_response_file" \
 	-X POST \
 	-H "Authorization: token ${GITHUB_TOKEN}" \
 	'https://api.github.com/repos/stackrox/release-artifacts/pulls' \
@@ -94,21 +91,3 @@ curl -sS --fail \
 	\"head\": \"${branch_name}\",
 	\"base\": \"main\"
 }" || die "Failed to create GitHub PR"
-
-pr_number="$(jq <"$pr_response_file" -r '.number')"
-
-[[ -n "$pr_number" ]] || die "Failed to determine PR number"
-
-curl -sS --fail \
-	-X POST \
-	-H "Authorization: token ${GITHUB_TOKEN}" \
-	"https://api.github.com/repos/stackrox/release-artifacts/pulls/${pr_number}/requested_reviewers" \
-	-d'{
-	"team_reviewers": ["release-artifact-publishers"]
-}' || die "Failed to assign release-artifact-publishers for review"
-
-jq -n \
-    --arg version "$version" \
-    --arg pr_number "$pr_number" \
-    '{"text": "Hey <!subteam^S01DE67NT7V|release-publishers>! A pull request for the *\($version)* release artifacts has been prepared. Once this version is GA, please _approve and merge_ this pull request in order to publish the artifacts: https://github.com/stackrox/release-artifacts/pull/\($pr_number)"}' \
-  | curl -XPOST -d @- -H 'Content-Type: application/json' "${webhook_url}" || die "Failed to send Slack message!"


### PR DESCRIPTION
## Description

* Make check for open Jira issues in ongoing release optional. This was helpful during 3.74.0 release, when there were known open issues for documentation while cutting release candidates
* `mark_collector_release` is now idempotent. Previously, when re-running the automation, it would push the same lines multiple times into the RELEASED_VERSIONS file. Later it could fail because the PR already existed. fyi @Molter73 
* `push_helm_charts` does not request review from the obsolete `release-artifact-publishers` group anymore. Reviewing and merging the Helm charts is task of the upstream release engineer and mentioned in the release tracker, therefore the Slack message is not required anymore as well.



## Checklist
- [x] Investigated and inspected CI test results



If any of these don't apply, please comment below.

## Testing Performed

CI is sufficient.