### PR TITLE
Optimise usage of Go cache in GHA

### DIFF
--- a/.github/actions/cache-go-dependencies/action.yaml
+++ b/.github/actions/cache-go-dependencies/action.yaml
@@ -11,16 +11,12 @@ runs:
       shell: bash
 
     - name: Cache Go Dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
-          ${{ steps.cache-paths.outputs.GOCACHE }}
           ${{ steps.cache-paths.outputs.GOMODCACHE }}
-          /github/home/.cache/go-build
-          /github/home/.cache/golangci-lint
-          /github/home/.cache/staticcheck
-        key: go-v2-${{ hashFiles('**/go.sum') }}-${{ github.job }}
+          ${{ steps.cache-paths.outputs.GOCACHE }}
+        key: go-v3-${{ github.job }}-${{ hashFiles('**/go.sum') }}
         restore-keys: |
-          go-v2-${{ hashFiles('**/go.sum') }}-${{ github.job }}
-          go-v2-${{ hashFiles('**/go.sum') }}-
-          go-v2-
+          go-v3-${{ github.job }}-${{ hashFiles('**/go.sum') }}
+          go-v3-${{ github.job }}-

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -91,6 +91,15 @@ jobs:
       - name: Cache Go dependencies
         uses: ./.github/actions/cache-go-dependencies
 
+      - name: Cache golangci-lint
+        uses: actions/cache@v3
+        with:
+          path: /github/home/.cache/golangci-lint
+          key: go-lint-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            go-lint-${{ hashFiles('**/go.sum') }}
+            go-lint-
+
       - uses: ./.github/actions/create-concatenated-ui-monorepo-lock
 
       - name: Cache UI dependencies


### PR DESCRIPTION
## Description

This pull request aims to improve the caching process for golangci-lint by separating it from the Go cache. Additionally, the keys used to access the Go cache have been modified to prioritize cache entries from the same job, even if they were created later. Previously, unrelated jobs were occasionally downloading unnecessary cache data, which resulted in "no disk space" errors. By implementing this new approach, we expect to make better use of cached entries since there are infrequent instances where the entire cache needs to be invalidated for the same job. 

- https://github.com/golangci/golangci-lint/discussions/1920

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

CI