### PR TITLE
ROX-14702: Display origin for access scopes, roles, auth providers and groups

### DIFF
--- a/ui/apps/platform/src/Containers/AccessControl/AccessScopes/AccessScopeFormWrapper.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessScopes/AccessScopeFormWrapper.tsx
@@ -24,6 +24,7 @@ import {
 } from './accessScopes.utils';
 import AccessScopeForm from './AccessScopeForm';
 import usePermissions from '../../../hooks/usePermissions';
+import { TraitsOriginLabel } from '../TraitsOriginLabel';
 
 export type AccessScopeFormWrapperProps = {
     isActionable: boolean;
@@ -123,6 +124,11 @@ function AccessScopeFormWrapper({
                             {action === 'create' ? 'Create access scope' : accessScope.name}
                         </Title>
                     </ToolbarItem>
+                    {action !== 'create' && (
+                        <ToolbarItem>
+                            <TraitsOriginLabel traits={accessScope.traits} />
+                        </ToolbarItem>
+                    )}
                     {action !== 'create' && (
                         <ToolbarGroup variant="button-group" alignment={{ default: 'alignRight' }}>
                             <ToolbarItem>

--- a/ui/apps/platform/src/Containers/AccessControl/AccessScopes/AccessScopes.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessScopes/AccessScopes.tsx
@@ -17,7 +17,6 @@ import {
     accessScopeNew,
     createAccessScope,
     deleteAccessScope,
-    getIsDefaultAccessScopeId,
     fetchAccessScopes,
     updateAccessScope,
 } from 'services/AccessScopesService';
@@ -36,6 +35,7 @@ import AccessControlBreadcrumbs from '../AccessControlBreadcrumbs';
 import AccessControlHeaderActionBar from '../AccessControlHeaderActionBar';
 import AccessControlNoPermission from '../AccessControlNoPermission';
 import usePermissions from '../../../hooks/usePermissions';
+import { isUserResource } from '../traits';
 
 const entityType = 'ACCESS_SCOPE';
 
@@ -215,7 +215,7 @@ function AccessScopes(): ReactElement {
                     />
                 ) : (
                     <AccessScopeFormWrapper
-                        isActionable={!accessScope || !getIsDefaultAccessScopeId(entityId)}
+                        isActionable={!accessScope || isUserResource(accessScope.traits)}
                         action={action}
                         accessScope={accessScope ?? accessScopeNew}
                         accessScopes={accessScopes}

--- a/ui/apps/platform/src/Containers/AccessControl/AccessScopes/AccessScopesList.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessScopes/AccessScopesList.tsx
@@ -11,11 +11,13 @@ import {
 } from '@patternfly/react-core';
 import { TableComposable, Tbody, Td, Thead, Th, Tr } from '@patternfly/react-table';
 
-import { AccessScope, getIsDefaultAccessScopeId } from 'services/AccessScopesService';
+import { AccessScope } from 'services/AccessScopesService';
 import { Role } from 'services/RolesService';
 
 import { AccessControlEntityLink, RolesLink } from '../AccessControlLinks';
 import usePermissions from '../../../hooks/usePermissions';
+import { TraitsOriginLabel } from '../TraitsOriginLabel';
+import { isUserResource } from '../traits';
 
 const entityType = 'ACCESS_SCOPE';
 
@@ -75,14 +77,15 @@ function AccessScopesList({
             <TableComposable variant="compact">
                 <Thead>
                     <Tr>
-                        <Th width={20}>Name</Th>
-                        <Th width={30}>Description</Th>
-                        <Th width={40}>Roles</Th>
+                        <Th width={15}>Name</Th>
+                        <Th width={15}>Origin</Th>
+                        <Th width={25}>Description</Th>
+                        <Th width={35}>Roles</Th>
                         <Th width={10} aria-label="Row actions" />
                     </Tr>
                 </Thead>
                 <Tbody>
-                    {accessScopes.map(({ id, name, description }) => (
+                    {accessScopes.map(({ id, name, description, traits }) => (
                         <Tr key={id}>
                             <Td dataLabel="Name">
                                 <AccessControlEntityLink
@@ -90,6 +93,9 @@ function AccessScopesList({
                                     entityId={id}
                                     entityName={name}
                                 />
+                            </Td>
+                            <Td dataLabel="Origin">
+                                <TraitsOriginLabel traits={traits} />
                             </Td>
                             <Td dataLabel="Description">{description}</Td>
                             <Td dataLabel="Roles">
@@ -106,7 +112,7 @@ function AccessScopesList({
                                     disable:
                                         !hasWriteAccessForPage ||
                                         idDeleting === id ||
-                                        getIsDefaultAccessScopeId(id) ||
+                                        !isUserResource(traits) ||
                                         roles.some(({ accessScopeId }) => accessScopeId === id),
                                     items: [
                                         {

--- a/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviderForm.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviderForm.tsx
@@ -39,6 +39,7 @@ import {
     getDefaultRoleByAuthProviderId,
 } from './authProviders.utils';
 import { AccessControlQueryAction } from '../accessControlPaths';
+import { TraitsOriginLabel } from '../TraitsOriginLabel';
 
 export type AuthProviderFormProps = {
     isActionable: boolean;
@@ -262,6 +263,11 @@ function AuthProviderForm({
                     <ToolbarItem>
                         <Title headingLevel="h2">{formTitle}</Title>
                     </ToolbarItem>
+                    {action !== 'create' && (
+                        <ToolbarItem>
+                            <TraitsOriginLabel traits={selectedAuthProvider.traits} />
+                        </ToolbarItem>
+                    )}
                     {isActionable && (
                         <ToolbarGroup
                             alignment={{ default: 'alignRight' }}

--- a/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProvidersList.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProvidersList.tsx
@@ -10,6 +10,7 @@ import { actions as authActions } from 'reducers/auth';
 import { AuthProvider, AuthProviderInfo, getIsAuthProviderImmutable } from 'services/AuthService';
 
 import { AccessControlEntityLink } from '../AccessControlLinks';
+import { TraitsOriginLabel } from '../TraitsOriginLabel';
 
 // TODO import from where?
 const unselectedRowStyle = {};
@@ -59,16 +60,17 @@ function AuthProvidersList({ entityId, authProviders }: AuthProvidersListProps):
             <TableComposable variant="compact">
                 <Thead>
                     <Tr>
-                        <Th width={20}>Name</Th>
+                        <Th width={15}>Name</Th>
+                        <Th width={15}>Origin</Th>
                         <Th width={15}>Type</Th>
                         <Th width={20}>Minimum access role</Th>
-                        <Th width={35}>Assigned rules</Th>
+                        <Th width={25}>Assigned rules</Th>
                         <Th width={10} aria-label="Row actions" />
                     </Tr>
                 </Thead>
                 <Tbody>
                     {authProviders.map((authProvider) => {
-                        const { id, name, type, defaultRole, groups = [] } = authProvider;
+                        const { id, name, type, defaultRole, traits, groups = [] } = authProvider;
                         const typeLabel = getAuthProviderTypeLabel(type, availableProviderTypes);
                         const isImmutable = getIsAuthProviderImmutable(authProvider);
 
@@ -83,6 +85,9 @@ function AuthProvidersList({ entityId, authProviders }: AuthProvidersListProps):
                                         entityId={id}
                                         entityName={name}
                                     />
+                                </Td>
+                                <Td dataLabel="Origin">
+                                    <TraitsOriginLabel traits={traits} />
                                 </Td>
                                 <Td dataLabel="Type">{typeLabel}</Td>
                                 <Td dataLabel="Minimum access role">

--- a/ui/apps/platform/src/Containers/AccessControl/AuthProviders/RuleGroups.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AuthProviders/RuleGroups.tsx
@@ -7,6 +7,7 @@ import { ArrowRightIcon, PlusCircleIcon, TrashIcon } from '@patternfly/react-ico
 import { Group } from 'services/AuthService';
 import { Role } from 'services/RolesService';
 import SelectSingle from 'Components/SelectSingle';
+import { isUserResource } from '../traits';
 
 export type RuleGroupErrors = {
     roleName?: string;
@@ -64,7 +65,8 @@ function RuleGroups({
                 'props' in group &&
                 'traits' in group.props &&
                 group?.props?.traits != null &&
-                group?.props?.traits?.mutabilityMode !== 'ALLOW_MUTATE')
+                (group?.props?.traits?.mutabilityMode !== 'ALLOW_MUTATE' ||
+                    !isUserResource(group?.props?.traits)))
         );
     }
 

--- a/ui/apps/platform/src/Containers/AccessControl/Roles/RoleForm.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/Roles/RoleForm.tsx
@@ -26,6 +26,7 @@ import PermissionSetsTable from './PermissionSetsTable';
 
 import './RoleForm.css';
 import usePermissions from '../../../hooks/usePermissions';
+import { TraitsOriginLabel } from '../TraitsOriginLabel';
 
 export type RoleFormProps = {
     isActionable: boolean;
@@ -118,6 +119,11 @@ function RoleForm({
                             {action === 'create' ? 'Create role' : role.name}
                         </Title>
                     </ToolbarItem>
+                    {action !== 'create' && (
+                        <ToolbarItem>
+                            <TraitsOriginLabel traits={role.traits} />
+                        </ToolbarItem>
+                    )}
                     {action !== 'create' && (
                         <ToolbarGroup variant="button-group" alignment={{ default: 'alignRight' }}>
                             <ToolbarItem>

--- a/ui/apps/platform/src/Containers/AccessControl/Roles/Roles.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/Roles/Roles.tsx
@@ -13,7 +13,6 @@ import {
 } from '@patternfly/react-core';
 
 import NotFoundMessage from 'Components/NotFoundMessage';
-import { getIsDefaultRoleName } from 'constants/accessControl';
 import {
     AccessScope,
     fetchAccessScopes,
@@ -43,6 +42,7 @@ import AccessControlHeading from '../AccessControlHeading';
 import usePermissions from '../../../hooks/usePermissions';
 import AccessControlNoPermission from '../AccessControlNoPermission';
 import useFeatureFlags from '../../../hooks/useFeatureFlags';
+import { isUserResource } from '../traits';
 
 const entityType = 'ROLE';
 
@@ -305,7 +305,7 @@ function Roles(): ReactElement {
                     />
                 ) : (
                     <RoleForm
-                        isActionable={!role || !getIsDefaultRoleName(role.name)}
+                        isActionable={!role || isUserResource(role.traits)}
                         action={action}
                         role={role ?? roleNew}
                         roles={roles}

--- a/ui/apps/platform/src/Containers/AccessControl/Roles/RolesList.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/Roles/RolesList.tsx
@@ -11,7 +11,6 @@ import {
 } from '@patternfly/react-core';
 import { TableComposable, Tbody, Td, Thead, Th, Tr } from '@patternfly/react-table';
 
-import { getIsDefaultRoleName } from 'constants/accessControl';
 import { AccessScope } from 'services/AccessScopesService';
 import { Group } from 'services/AuthService';
 import { PermissionSet, Role } from 'services/RolesService';
@@ -19,6 +18,8 @@ import { PermissionSet, Role } from 'services/RolesService';
 import { AccessControlEntityLink } from '../AccessControlLinks';
 import { AccessControlQueryFilter } from '../accessControlPaths';
 import usePermissions from '../../../hooks/usePermissions';
+import { TraitsOriginLabel } from '../TraitsOriginLabel';
+import { isUserResource } from '../traits';
 
 // Return whether an auth provider rule refers to a role name,
 // therefore need to disable the delete action for the role.
@@ -105,16 +106,17 @@ function RolesList({
                 <TableComposable variant="compact" isStickyHeader>
                     <Thead>
                         <Tr>
-                            <Th width={20}>Name</Th>
-                            <Th width={30}>Description</Th>
-                            <Th width={20}>Permission set</Th>
+                            <Th width={15}>Name</Th>
+                            <Th width={15}>Origin</Th>
+                            <Th width={25}>Description</Th>
+                            <Th width={15}>Permission set</Th>
                             <Th width={20}>Access scope</Th>
                             <Th width={10} aria-label="Row actions" />
                         </Tr>
                     </Thead>
                     <Tbody>
                         {rolesFiltered.map(
-                            ({ name, description, permissionSetId, accessScopeId }) => (
+                            ({ name, description, permissionSetId, accessScopeId, traits }) => (
                                 <Tr key={name}>
                                     <Td dataLabel="Name">
                                         <AccessControlEntityLink
@@ -122,6 +124,9 @@ function RolesList({
                                             entityId={name}
                                             entityName={name}
                                         />
+                                    </Td>
+                                    <Td dataLabel="Origin">
+                                        <TraitsOriginLabel traits={traits} />
                                     </Td>
                                     <Td dataLabel="Description">{description}</Td>
                                     <Td dataLabel="Permission set">
@@ -143,7 +148,7 @@ function RolesList({
                                             disable:
                                                 !hasWriteAccessForPage ||
                                                 nameDeleting === name ||
-                                                getIsDefaultRoleName(name) ||
+                                                !isUserResource(traits) ||
                                                 getHasRoleName(groups, name),
                                             items: [
                                                 {

--- a/ui/apps/platform/src/Containers/AccessControl/traits.ts
+++ b/ui/apps/platform/src/Containers/AccessControl/traits.ts
@@ -1,7 +1,7 @@
 import { Traits } from '../../types/traits.proto';
 
 export function isUserResource(traits?: Traits): boolean {
-    return traits == null || traits.origin === 'IMPERATIVE';
+    return traits == null || traits.origin == null || traits.origin === 'IMPERATIVE';
 }
 
 export const traitsOriginLabels = {

--- a/ui/apps/platform/src/constants/accessControl.ts
+++ b/ui/apps/platform/src/constants/accessControl.ts
@@ -7,22 +7,6 @@ export const READ_WRITE_ACCESS = 'READ_WRITE_ACCESS';
 
 export type AccessLevel = 'NO_ACCESS' | 'READ_ACCESS' | 'READ_WRITE_ACCESS';
 
-const defaultRoles = {
-    Admin: true,
-    Analyst: true,
-    'Continuous Integration': true,
-    None: true,
-    'Scope Manager': true,
-    'Sensor Creator': true,
-    'Vulnerability Management Approver': true,
-    'Vulnerability Management Requester': true,
-    'Vulnerability Report Creator': true,
-};
-
-export function getIsDefaultRoleName(name: string): boolean {
-    return Boolean(defaultRoles[name]);
-}
-
 export const authProviderLabels = {
     auth0: 'Auth0',
     oidc: 'OpenID Connect',

--- a/ui/apps/platform/src/services/AccessScopesService.ts
+++ b/ui/apps/platform/src/services/AccessScopesService.ts
@@ -1,5 +1,6 @@
 import axios from './instance';
 import { Empty } from './types';
+import { Traits } from '../types/traits.proto';
 
 const accessScopessUrl = '/v1/simpleaccessscopes';
 
@@ -61,6 +62,7 @@ export type AccessScope = {
     name: string;
     description: string;
     rules: SimpleAccessScopeRules;
+    traits?: Traits;
 };
 
 export const accessScopeNew: AccessScope = {

--- a/ui/apps/platform/src/services/AccessScopesService.ts
+++ b/ui/apps/platform/src/services/AccessScopesService.ts
@@ -15,6 +15,8 @@ export const defaultAccessScopeIds = {
     DenyAllPostgres: 'ffffffff-ffff-fff4-f5ff-fffffffffffe',
 };
 
+// The only remaining usage of this function is in ResourceScopeSelection.tsx file,
+// which will be deleted when Collections supersede Access Scopes in Vulnerability Reporting.
 export function getIsDefaultAccessScopeId(id: string): boolean {
     return Object.values(defaultAccessScopeIds).includes(id);
 }

--- a/ui/apps/platform/src/services/AuthService/AuthService.ts
+++ b/ui/apps/platform/src/services/AuthService/AuthService.ts
@@ -13,6 +13,7 @@ import addTokenRefreshInterceptors, {
 } from './addTokenRefreshInterceptors';
 import { authProviderLabels } from '../../constants/accessControl';
 import { Traits } from '../../types/traits.proto';
+import { isUserResource } from '../../Containers/AccessControl/traits';
 
 const authProvidersUrl = '/v1/authProviders';
 const authLoginProvidersUrl = '/v1/login/authproviders';
@@ -412,8 +413,11 @@ export function addAuthInterceptors(authHttpErrorHandler): void {
  */
 export function getIsAuthProviderImmutable(authProvider: AuthProvider): boolean {
     return (
-        'traits' in authProvider &&
-        authProvider.traits != null &&
-        authProvider.traits?.mutabilityMode !== 'ALLOW_MUTATE'
+        ('traits' in authProvider &&
+            authProvider.traits != null &&
+            authProvider.traits?.mutabilityMode !== 'ALLOW_MUTATE') ||
+        // Having both these conditions checked allows for seamless transition period
+        // between using mutabilityMode and origin in ACSCS auth provider.
+        !isUserResource(authProvider.traits)
     );
 }

--- a/ui/apps/platform/src/services/RolesService.ts
+++ b/ui/apps/platform/src/services/RolesService.ts
@@ -26,6 +26,7 @@ export type Role = {
     description: string;
     permissionSetId: string;
     accessScopeId: string;
+    traits?: Traits;
 };
 
 /**


### PR DESCRIPTION
## Description

Following up steps and pattern of changes made here https://github.com/stackrox/stackrox/pull/4894, in this PR I add origin field for other resources in the UI: roles, access scopes, auth providers and groups.

As groups are tightly bound to auth provider and are only rendered on the auth provider page, we do not display groups' origin anywhere in the UI. The assumption is that groups and corresponding auth provider always will be of the same type - either both imperative or declarative. The only change made for groups is that groups with `Declarative` origin are impossible to modify or delete within the UI.

For every other resource next changes are introduced:
* `Origin` field is displayed when listing all resources of a certain type
*  Based on `Origin` field resources might be disabled for modification and deletion
*  `Origin` field is added to the resource page

Integration tests will be added in the follow-up PR.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

<img width="1787" alt="Screenshot 2023-02-28 at 17 30 24" src="https://user-images.githubusercontent.com/78353299/221916663-076790ec-25ef-4778-9c23-b19e89b63b31.png">
<img width="1782" alt="Screenshot 2023-02-28 at 17 30 36" src="https://user-images.githubusercontent.com/78353299/221916687-4be0d7c4-410f-462a-bbe5-d126a44522e1.png">

