### PR TITLE
Increase memory resource limit to 3Gi

### DIFF
--- a/operator/config/manager/manager.yaml
+++ b/operator/config/manager/manager.yaml
@@ -67,7 +67,7 @@ spec:
         resources:
           limits:
             cpu: 200m
-            memory: 1Gi
+            memory: 3Gi
           requests:
             cpu: 100m
             memory: 200Mi


### PR DESCRIPTION
Large clusters with lots of nodes, pods, network policies, etc. can cause Kubernetes to OOM kill the rhacs-operator during initial startup.  Increasing the memory Limit to 3Gi should alleviate this.

## Description

A detailed explanation of the changes in your PR.

Feel free to remove this section if it is overkill for your PR, and the title of your PR is sufficiently descriptive.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
