### PR TITLE
ROX-15313: Add clear selections option for network graph namespace and deployment selectors

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/components/DeploymentSelector.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/DeploymentSelector.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react';
-import { Select, SelectGroup, SelectOption, SelectVariant } from '@patternfly/react-core';
+import { Button, Select, SelectGroup, SelectOption, SelectVariant } from '@patternfly/react-core';
 
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
 import { NamespaceWithDeployments } from 'hooks/useFetchNamespaceDeployments';
@@ -18,7 +18,11 @@ function DeploymentSelector({
     searchFilter,
     setSearchFilter,
 }: DeploymentSelectorProps) {
-    const { isOpen: isDeploymentOpen, toggleSelect: toggleIsDeploymentOpen } = useSelectToggle();
+    const {
+        isOpen: isDeploymentOpen,
+        toggleSelect: toggleIsDeploymentOpen,
+        closeSelect,
+    } = useSelectToggle();
 
     const onFilterDeployments = useCallback(
         (_, filterValue: string) => {
@@ -50,6 +54,13 @@ function DeploymentSelector({
 
         const modifiedSearchObject = { ...searchFilter };
         modifiedSearchObject.Deployment = newSelection;
+        setSearchFilter(modifiedSearchObject);
+    };
+
+    const onClearSelections = () => {
+        const modifiedSearchObject = { ...searchFilter };
+        delete modifiedSearchObject.Deployment;
+        closeSelect();
         setSearchFilter(modifiedSearchObject);
     };
 
@@ -86,6 +97,11 @@ function DeploymentSelector({
             hasInlineFilter
             isGrouped
             isPlain
+            footer={
+                <Button variant="link" isInline onClick={onClearSelections}>
+                    Clear selections
+                </Button>
+            }
         >
             {deploymentSelectOptions}
         </Select>

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/NamespaceSelector.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/NamespaceSelector.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, ChangeEvent } from 'react';
-import { Badge, Select, SelectOption, SelectVariant } from '@patternfly/react-core';
+import { Badge, Button, Select, SelectOption, SelectVariant } from '@patternfly/react-core';
 
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
 import { Namespace } from 'hooks/useFetchClusterNamespaces';
@@ -37,7 +37,11 @@ function NamespaceSelector({
     searchFilter,
     setSearchFilter,
 }: NamespaceSelectorProps) {
-    const { isOpen: isNamespaceOpen, toggleSelect: toggleIsNamespaceOpen } = useSelectToggle();
+    const {
+        isOpen: isNamespaceOpen,
+        toggleSelect: toggleIsNamespaceOpen,
+        closeSelect,
+    } = useSelectToggle();
 
     const onFilterNamespaces = useCallback(
         (e: ChangeEvent<HTMLInputElement> | null, filterValue: string) =>
@@ -84,6 +88,14 @@ function NamespaceSelector({
         setSearchFilter(modifiedSearchObject);
     };
 
+    const onClearSelections = () => {
+        const modifiedSearchObject = { ...searchFilter };
+        delete modifiedSearchObject.Namespace;
+        delete modifiedSearchObject.Deployment;
+        closeSelect();
+        setSearchFilter(modifiedSearchObject);
+    };
+
     const namespaceSelectOptions: JSX.Element[] = namespaces.map((namespace) => {
         return (
             <SelectOption
@@ -121,6 +133,11 @@ function NamespaceSelector({
             maxHeight="275px"
             hasInlineFilter
             isPlain
+            footer={
+                <Button variant="link" isInline onClick={onClearSelections}>
+                    Clear selections
+                </Button>
+            }
         >
             {namespaceSelectOptions}
         </Select>


### PR DESCRIPTION
## Description

This PR adds a "clear selections" option for network graph namespace and deployment selectors

https://user-images.githubusercontent.com/4805485/221949799-fa0ee7ec-606e-4581-9d78-bcf7678b1743.mov

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~
