### PR TITLE
ROX-15279: Ensure central client respects proxy

### DIFF
--- a/sensor/common/centralclient/client.go
+++ b/sensor/common/centralclient/client.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stackrox/rox/pkg/clientconn"
 	"github.com/stackrox/rox/pkg/cryptoutils"
 	"github.com/stackrox/rox/pkg/httputil"
+	"github.com/stackrox/rox/pkg/httputil/proxy"
 	"github.com/stackrox/rox/pkg/jsonutil"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/mtls"
@@ -84,8 +85,11 @@ func NewClient(endpoint string) (*Client, error) {
 		},
 	}
 	httpClient := &http.Client{
-		Transport: &http.Transport{TLSClientConfig: tlsConf},
-		Timeout:   requestTimeout,
+		Transport: &http.Transport{
+			TLSClientConfig: tlsConf,
+			Proxy:           proxy.FromConfig(),
+		},
+		Timeout: requestTimeout,
 	}
 
 	return &Client{


### PR DESCRIPTION
## Description

With the introduction of ACSCS, one common environment setup we have seen is a proxy between sensor and central, since central will now not be deployed within the customers environment anymore.

During the initial setup of the secured cluster, sensor will reach out to central to a) retrieve metadata of central via the `/v1/metadata` service and b) retrieve the certificates. Afterwards, the gRPC connection will be established between central and sensor.

Now, when a egress proxy shall be used by sensor to establish communication with central, the following occurs:
```log
common/centralclient: 2023/02/28 18:05:34.041615 grpc_connection.go:79: Info: Check Central status failed: receiving Central metadata: calling https://central-url:443/v1/metadata: Get "https://central-url:443/v1/metadata": context deadline exceeded. Retrying after 900ms...
common/centralclient: 2023/02/28 18:05:44.942851 grpc_connection.go:79: Info: Check Central status failed: receiving Central metadata: calling https://central-url:443/v1/metadata: Get "https://central-url:443/v1/metadata": context deadline exceeded. Retrying after 1.212s...
common/centralclient: 2023/02/28 18:05:56.157872 grpc_connection.go:79: Info: Check Central status failed: receiving Central metadata: calling https://central-url:443/v1/metadata: Get "https://central-url:443/v1/metadata": context deadline exceeded. Retrying after 1.933s...
```

Looking within the code, the `http.Transport` used does not include the `proxy.FromConfig()` we use to set the proxy configuration either from environment variables or our `proxy-config.yaml` file.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

1. Create two OpenShift / K8S clusters (one of the clusters will be the central cluster, the other the secured service cluster).
2. On the central cluster, do the following:
- install the RHACS operator.
- create a central CR with default settings.
- once central is up and running, create a cluster init bundle.
3. On the secured cluster, do the following _before_ installing the secured cluster CR:
- Deploy an egress proxy (in this example squid, but feel free to use any other proxy solution):
```bash
kubectl create -n stackrox -f egress-proxy.yaml
```

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: egress-proxy-config
  labels:
    app.kubernetes.io/component: egress-proxy
data:
  squid.conf: |
    # Squid proxy configuration
    
    # Catch-all rule for everything
    http_access allow all

    # Serve on standard port 3128
    http_port 3128

    # Disable caching and most logging
    cache deny all
    cache_log /dev/null
    access_log none all
    debug_options ALL,0
    pid_filename none
    shutdown_lifetime 0
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: egress-proxy
  labels:
    app.kubernetes.io/component: egress-proxy
spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/component: egress-proxy
  template:
    metadata:
      labels:
        app.kubernetes.io/component: egress-proxy
    spec:
      containers:
      - name: egress-proxy
        image: "ubuntu/squid:5.2-22.04_beta"
        command:
        - "squid"
        - "-N"
        - "-f"
        - "/etc/squid/squid.conf"
        ports:
        - containerPort: 3128
          protocol: TCP
          name: egress-proxy
        volumeMounts:
        - name: config-volume
          mountPath: /etc/squid/squid.conf
          subPath: squid.conf
          readOnly: true
      volumes:
      - name: config-volume
        configMap:
          name: egress-proxy-config
---
apiVersion: v1
kind: Service
metadata:
  name: egress-proxy
  labels:
    app.kubernetes.io/component: egress-proxy
spec:
  selector:
    app.kubernetes.io/component: egress-proxy
  ports:
  - port: 3128
    protocol: TCP
    targetPort: 3128
  type: ClusterIP
```
- Create network policies limiting the egress traffic from sensor, admission-control, scanner, and collector to only cluster internal traffic
```bash
kubectl create -n stackrox -f networkpolicies.yaml
```
```yaml
apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
  name: default-deny-egress-sensor
spec:
  podSelector:
    matchLabels:
      app: sensor
  policyTypes:
  - Egress
  egress:
  - to:
    - namespaceSelector: {}
---
apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
  name: default-deny-egress-admission-control
spec:
  podSelector:
    matchLabels:
      app: admission-control
  policyTypes:
  - Egress
  egress:
  - to:
    - namespaceSelector: {}
---
apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
  name: default-deny-egress-collector
spec:
  podSelector:
    matchLabels:
      app: collector
  policyTypes:
  - Egress
  egress:
  - to:
    - namespaceSelector: {}
---
apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
  name: default-deny-egress-scanner
spec:
  podSelector:
    matchLabels:
      app: scanner
  policyTypes:
  - Egress
  egress:
  - to:
    - namespaceSelector: {}
```

4. Now, install the secured cluster CR in second OpenShift / K8S cluster, ensuring you specify the following within the CR:
```yaml
customize:
  HTTP_PROXY: http://egress-proxy.stackrox.svc:3128
  HTTPS_PROXY: http://egress-proxy.stackrox.svc:3128
  NO_PROXY: .stackrox.svc
```
5. Observe that the secured cluster components (sensor, admission-control, scanner, collector) are connecting and logs do not indicate errors / timeouts.
6. Run the bat-tests to verify everything works as expected:
```bash
cd qa-tests-backend && make bat-test
```

