### PR TITLE
ROX-15395: Service Account and Role pagination fix

### DIFF
--- a/central/graphql/resolvers/k8sroles.go
+++ b/central/graphql/resolvers/k8sroles.go
@@ -57,26 +57,16 @@ func (resolver *k8SRoleResolver) Cluster(ctx context.Context) (*clusterResolver,
 // K8sRoles return k8s roles based on a query
 func (resolver *Resolver) K8sRoles(ctx context.Context, arg PaginatedQuery) ([]*k8SRoleResolver, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Root, "K8sRoles")
-
 	if err := readK8sRoles(ctx); err != nil {
 		return nil, err
 	}
+
 	query, err := arg.AsV1QueryOrEmpty()
 	if err != nil {
 		return nil, err
 	}
 
-	k8sRoles, err := resolver.K8sRoleStore.SearchRawRoles(ctx, query)
-	if err != nil {
-		return nil, err
-	}
-
-	var k8SRoleResolvers []*k8SRoleResolver
-	for _, k8srole := range k8sRoles {
-		k8SRoleResolvers = append(k8SRoleResolvers, &k8SRoleResolver{root: resolver, data: k8srole})
-	}
-
-	return paginate(query.Pagination, k8SRoleResolvers, nil)
+	return resolver.wrapK8SRoles(resolver.K8sRoleStore.SearchRawRoles(ctx, query))
 }
 
 // K8sRoleCount returns count of all k8s roles across infrastructure

--- a/central/graphql/resolvers/service_accounts.go
+++ b/central/graphql/resolvers/service_accounts.go
@@ -60,8 +60,7 @@ func (resolver *Resolver) ServiceAccounts(ctx context.Context, args PaginatedQue
 		return nil, err
 	}
 
-	serviceAccountResolvers, err := resolver.wrapServiceAccounts(resolver.ServiceAccountsDataStore.SearchRawServiceAccounts(ctx, query))
-	return paginate(query.GetPagination(), serviceAccountResolvers, err)
+	return resolver.wrapServiceAccounts(resolver.ServiceAccountsDataStore.SearchRawServiceAccounts(ctx, query))
 }
 
 // ServiceAccountCount returns count of all service accounts across infrastructure


### PR DESCRIPTION
## Description

Don't double paginate the Service Account and Role endpoints in GraphQL.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added

## Testing Performed

Deployed and manually verified that data is correctly returned.
