### PR TITLE
Dashrews/ROX-15331 do not truncate

### DIFF
--- a/pkg/search/parser.go
+++ b/pkg/search/parser.go
@@ -3,11 +3,9 @@ package search
 import (
 	"strings"
 
-	"github.com/pkg/errors"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/set"
-	"github.com/stackrox/rox/pkg/utils"
 )
 
 var (
@@ -112,7 +110,7 @@ func parsePair(pair string, allowEmpty bool) (key string, values string, valid b
 func queryFromFieldValues(field string, values []string, highlight bool) *v1.Query {
 	// A SQL query can have no more than 65535 parameters.
 	if len(values) > MaxQueryParameters {
-		utils.Should(errors.Errorf("too many parameters %d for a query.  No more than %d parameters allowed in single query", len(values), MaxQueryParameters))
+		log.Errorf("UNEXPECTED: too many parameters %d for a query.  No more than %d parameters allowed in single query", len(values), MaxQueryParameters)
 	}
 	queries := make([]*v1.Query, 0, len(values))
 	for _, value := range values {


### PR DESCRIPTION
## Description

truncating the parameters seems bad.  Best to panic on dev builds.  Not an easy way to return error from here, so the SQL error will occur in release builds and propagate back.    

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

local testing by sending in too many parameters to that call by modifying `central/processindicator/datastore/datastore_impl.go` to have a batch size of 70K to make sure the dev build paniced and crashed.
