### PR TITLE
ROX-15419: Secured cluster provider details telemetry

### DIFF
--- a/central/cluster/datastore/telemetry.go
+++ b/central/cluster/datastore/telemetry.go
@@ -96,6 +96,18 @@ func UpdateSecuredClusterIdentity(ctx context.Context, clusterID string, metrics
 		props["Total Nodes"] = metrics.NodeCount
 		props["CPU Capacity"] = metrics.CpuCapacity
 
+		if pmd := cluster.GetStatus().GetProviderMetadata(); pmd.GetProvider() != nil {
+			props["Provider"] = pmd.GetProvider()
+			props["Provider Region"] = pmd.GetRegion()
+			props["Provider Zone"] = pmd.GetZone()
+		}
+
+		omd := cluster.GetStatus().GetOrchestratorMetadata()
+		if omd.GetIsOpenshift() != nil {
+			props["Openshift"] = omd.GetIsOpenshift()
+		}
+		props["Orchestrator Version"] = omd.GetVersion()
+
 		opts := []telemeter.Option{
 			telemeter.WithClient(cluster.GetId(), securedClusterClient),
 			telemeter.WithGroups(cfg.GroupType, cfg.GroupID),


### PR DESCRIPTION
## Description

Exposing cluster status properties in the secured cluster identity.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] ~Unit test and regression tests added~
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

Tested manually with local secured cluster so far with disabled provider checks, as the values were empty, as there's no cloud provider.
Example event seen on Segment, notice the `Orchestrator Version` trait:
```json
{
  "anonymousId": "1677cf97-e8b2-4ec6-96fd-71427cc40b16",
  "context": {
    "device": {
      "id": "1677cf97-e8b2-4ec6-96fd-71427cc40b16",
      "type": "Secured Cluster Server"
    },
    "groups": {
      "Tenant": [
        "062c26b6-85d7-4ee8-b690-1e21e94657f3"
      ]
    },
    "library": {
      "name": "analytics-go",
      "version": "3.0.0"
    },
    "traits": {
      "Admission Controller": true,
      "CPU Capacity": 8,
      "Cluster Type": "KUBERNETES_CLUSTER",
      "Collection Method": "EBPF",
      "Collector Image": "quay.io/stackrox-io/collector",
      "Main Image": "quay.io/stackrox-io/main:3.74.x-243-gc5c4db7a63-dirty",
      "Managed By": "MANAGER_TYPE_MANUAL",
      "Orchestrator Version": "v1.25.3",
      "Priority": 1,
      "Slim Collector": true,
      "Total Nodes": 1
    }
  },
  "event": "Updated Secured Cluster Identity",
  "integrations": {},
  "messageId": "e811a574-bd0b-401e-8c42-85ad033b7e33",
  "originalTimestamp": "2023-03-03T14:32:54.195323149Z",
  "receivedAt": "2023-03-03T14:32:54.952Z",
  "sentAt": "2023-03-03T14:32:54.312Z",
  "timestamp": "2023-03-03T14:32:54.835Z",
  "type": "track",
  "writeKey": "..."
}
```
