### PR TITLE
ROX-15267: Fixing updating issue with network graph

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
@@ -111,13 +111,15 @@ function NetworkGraphPage() {
     const [prevEpochCount, setPrevEpochCount] = useState(0);
     const [currentEpochCount, setCurrentEpochCount] = useState(0);
 
+    const nodeUpdatesCount = currentEpochCount - prevEpochCount;
+
     // We will update the poll epoch after 30 seconds to update the node count for a cluster
     useInterval(() => {
         setPollEpoch(pollEpoch + 1);
     }, 30000);
 
     useEffect(() => {
-        if (selectedClusterId && namespacesFromUrl.length > 0) {
+        if (selectedClusterId && namespacesFromUrl.length > 0 && pollEpoch !== 0) {
             fetchNodeUpdates(selectedClusterId)
                 .then((result) => {
                     setCurrentEpochCount(result?.response?.epoch || 0);
@@ -137,7 +139,7 @@ function NetworkGraphPage() {
             clusterFromUrl && namespacesFromUrl.length > 0 && deploymentCount;
 
         if (isQueryFilterComplete && selectedClusterId && isClusterNamespaceSelected) {
-            if (currentEpochCount === 0) {
+            if (nodeUpdatesCount === 0) {
                 setIsLoading(true);
 
                 const queryToUse = queryService.objectToWhereClause(remainingQuery);
@@ -209,8 +211,7 @@ function NetworkGraphPage() {
         remainingQuery,
         timeWindow,
         deploymentCount,
-        prevEpochCount,
-        currentEpochCount,
+        nodeUpdatesCount,
     ]);
 
     function toggleCIDRBlockForm() {
@@ -218,10 +219,9 @@ function NetworkGraphPage() {
     }
 
     function updateNetworkNodes() {
+        setPrevEpochCount(0);
         setCurrentEpochCount(0);
     }
-
-    const nodeUpdatesCount = currentEpochCount - prevEpochCount;
 
     return (
         <>


### PR DESCRIPTION
## Description

This PR fixes an issue where the network graph wouldn't update properly. The following issues should be resolved:
1. When you first go to the network graph, you should see the graph and not an empty screen
2. When selecting namespaces/deployments, the graph should now show the graph updating to reflect the data to be presented
3. Modifying the deployments search filter should update the graph as well
4. Clicking on the "node updates" button should update the graph

https://user-images.githubusercontent.com/4805485/222231937-ca476bed-e4de-4159-b764-f20fd929f18e.mov

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~
