### PR TITLE
ROX-15260: Add option to show all network policies

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/common/NetworkPolicies.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/common/NetworkPolicies.tsx
@@ -31,6 +31,8 @@ type NetworkPolicyYAML = {
     yaml: string;
 };
 
+const allNetworkPoliciesId = 'network-policy-combined-yaml-pf-key';
+
 function NetworkPolicies({ entityName, policyIds }: NetworkPoliciesProps): React.ReactElement {
     const { networkPolicies, isLoading, error } = useFetchNetworkPolicies(policyIds);
     const { isDarkMode } = useTheme();
@@ -38,7 +40,7 @@ function NetworkPolicies({ entityName, policyIds }: NetworkPoliciesProps): React
 
     const allNetworkPoliciesYAML = useMemo(
         () => ({
-            name: 'all',
+            name: allNetworkPoliciesId,
             yaml: networkPolicies.map((networkPolicy) => networkPolicy.yaml).join('---\n'),
         }),
         [networkPolicies]
@@ -57,7 +59,7 @@ function NetworkPolicies({ entityName, policyIds }: NetworkPoliciesProps): React
     }
 
     function handleSelectedNetworkPolicy(_, value: string) {
-        if (value !== 'all') {
+        if (value !== allNetworkPoliciesId) {
             const newlySelectedNetworkPolicy = networkPolicies.find(
                 (networkPolicy) => networkPolicy.name === value
             );
@@ -70,7 +72,9 @@ function NetworkPolicies({ entityName, policyIds }: NetworkPoliciesProps): React
     function exportYAMLHandler() {
         if (selectedNetworkPolicy) {
             const fileName =
-                selectedNetworkPolicy.name === 'all' ? entityName : selectedNetworkPolicy.name;
+                selectedNetworkPolicy.name === allNetworkPoliciesId
+                    ? entityName
+                    : selectedNetworkPolicy.name;
             const fileContent = selectedNetworkPolicy.yaml;
             download(`${fileName}.yml`, fileContent, 'yml');
         }

--- a/ui/apps/platform/src/Containers/NetworkGraph/common/NetworkPolicies.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/common/NetworkPolicies.tsx
@@ -4,6 +4,7 @@ import {
     AlertVariant,
     Bullseye,
     Button,
+    Divider,
     EmptyState,
     EmptyStateVariant,
     SelectOption,
@@ -115,9 +116,10 @@ function NetworkPolicies({ policyIds }: NetworkPoliciesProps): React.ReactElemen
                         handleSelect={handleSelectedNetworkPolicy}
                         placeholderText="Select a network policy"
                     >
-                        <SelectOption key="All network policies" value="All network policies">
+                        <SelectOption value="All network policies">
                             All network policies
                         </SelectOption>
+                        <Divider component="li" />
                         <>
                             {networkPolicies.map((networkPolicy) => {
                                 return (

--- a/ui/apps/platform/src/Containers/NetworkGraph/common/NetworkPolicies.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/common/NetworkPolicies.tsx
@@ -22,6 +22,7 @@ import { useTheme } from 'Containers/ThemeProvider';
 import useFetchNetworkPolicies from 'hooks/useFetchNetworkPolicies';
 
 type NetworkPoliciesProps = {
+    entityName: string;
     policyIds: string[];
 };
 
@@ -30,18 +31,14 @@ type NetworkPolicyYAML = {
     yaml: string;
 };
 
-const downloadYAMLHandler = (fileName: string, fileContent: string) => () => {
-    download(`${fileName}.yml`, fileContent, 'yml');
-};
-
-function NetworkPolicies({ policyIds }: NetworkPoliciesProps): React.ReactElement {
+function NetworkPolicies({ entityName, policyIds }: NetworkPoliciesProps): React.ReactElement {
     const { networkPolicies, isLoading, error } = useFetchNetworkPolicies(policyIds);
     const { isDarkMode } = useTheme();
     const [customDarkMode, setCustomDarkMode] = React.useState(isDarkMode);
 
     const allNetworkPoliciesYAML = useMemo(
         () => ({
-            name: 'All network policies',
+            name: 'all',
             yaml: networkPolicies.map((networkPolicy) => networkPolicy.yaml).join('---\n'),
         }),
         [networkPolicies]
@@ -60,13 +57,22 @@ function NetworkPolicies({ policyIds }: NetworkPoliciesProps): React.ReactElemen
     }
 
     function handleSelectedNetworkPolicy(_, value: string) {
-        if (value !== 'All network policies') {
+        if (value !== 'all') {
             const newlySelectedNetworkPolicy = networkPolicies.find(
                 (networkPolicy) => networkPolicy.name === value
             );
             setSelectedNetworkPolicy(newlySelectedNetworkPolicy);
         } else {
             setSelectedNetworkPolicy(allNetworkPoliciesYAML);
+        }
+    }
+
+    function exportYAMLHandler() {
+        if (selectedNetworkPolicy) {
+            const fileName =
+                selectedNetworkPolicy.name === 'all' ? entityName : selectedNetworkPolicy.name;
+            const fileContent = selectedNetworkPolicy.yaml;
+            download(`${fileName}.yml`, fileContent, 'yml');
         }
     }
 
@@ -116,9 +122,7 @@ function NetworkPolicies({ policyIds }: NetworkPoliciesProps): React.ReactElemen
                         handleSelect={handleSelectedNetworkPolicy}
                         placeholderText="Select a network policy"
                     >
-                        <SelectOption value="All network policies">
-                            All network policies
-                        </SelectOption>
+                        <SelectOption value="all">All network policies</SelectOption>
                         <Divider component="li" />
                         <>
                             {networkPolicies.map((networkPolicy) => {
@@ -152,14 +156,7 @@ function NetworkPolicies({ policyIds }: NetworkPoliciesProps): React.ReactElemen
                 )}
                 {selectedNetworkPolicy && (
                     <StackItem>
-                        <Button
-                            onClick={downloadYAMLHandler(
-                                selectedNetworkPolicy.name,
-                                selectedNetworkPolicy.yaml
-                            )}
-                        >
-                            Export YAML
-                        </Button>
+                        <Button onClick={exportYAMLHandler}>Export YAML</Button>
                     </StackItem>
                 )}
             </Stack>

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentSideBar.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentSideBar.tsx
@@ -216,7 +216,10 @@ function DeploymentSideBar({
                             id={deploymentTabs.NETWORK_POLICIES}
                             hidden={activeKeyTab !== deploymentTabs.NETWORK_POLICIES}
                         >
-                            <NetworkPolicies policyIds={deploymentPolicyIds} />
+                            <NetworkPolicies
+                                entityName={deployment.name}
+                                policyIds={deploymentPolicyIds}
+                            />
                         </TabContent>
                     </StackItem>
                 </>

--- a/ui/apps/platform/src/Containers/NetworkGraph/namespace/NamespaceSideBar.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/namespace/NamespaceSideBar.tsx
@@ -112,7 +112,10 @@ function NamespaceSideBar({ namespaceId, nodes, edges, onNodeSelect }: Namespace
                     hidden={activeKeyTab !== 'Network policies'}
                     className="pf-u-h-100"
                 >
-                    <NetworkPolicies policyIds={uniqueNamespacePolicyIds} />
+                    <NetworkPolicies
+                        entityName={namespaceNode?.label || ''}
+                        policyIds={uniqueNamespacePolicyIds}
+                    />
                 </TabContent>
             </StackItem>
         </Stack>


### PR DESCRIPTION
## Description

This PR adds an option to show all network policies like in Network Graph 1.0

<img width="1440" alt="Screenshot 2023-03-01 at 10 58 26 AM" src="https://user-images.githubusercontent.com/4805485/222238351-6072f3c3-57a4-4c71-86dc-8a266376ab17.png">
<img width="1440" alt="Screenshot 2023-03-01 at 12 49 31 PM" src="https://user-images.githubusercontent.com/4805485/222261941-1bae1f36-33aa-475b-bff3-c6aeb4e955b6.png">

## Checklist
- [ ] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~