### PR TITLE
Don't register some Bolt and RocksDB metrics when Postgres is enabled

### DIFF
--- a/central/globaldb/metrics/metrics.go
+++ b/central/globaldb/metrics/metrics.go
@@ -4,46 +4,50 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/metrics"
 )
 
 const bucketKey = "Bucket"
 
 func init() {
+	if !env.PostgresDatastoreEnabled.BooleanSetting() {
+		prometheus.MustRegister(
+			FreePageN,
+			PendingPageN,
+			FreeAlloc,
+			FreelistInuse,
+			TxN,
+			OpenTxN,
+			TxStatsPageCount,
+			TxStatsPageAlloc,
+			TxStatsCursorCount,
+			TxStatsNodeCount,
+			TxStatsNodeDeref,
+			TxStatsRebalance,
+			TxStatsRebalanceSeconds,
+			TxStatsSplit,
+			TxStatsSpill,
+			TxStatsSpillSeconds,
+			TxStatsWrite,
+			TxStatsWriteTime,
+			BranchPageN,
+			BranchOverflowN,
+			LeafPageN,
+			LeafOverflowN,
+			KeyN,
+			Depth,
+			BranchAlloc,
+			BranchInuse,
+			LeafAlloc,
+			LeafInuse,
+			BucketN,
+			InlineBucketN,
+			InlineBucketInuse,
+		)
+	}
+
 	prometheus.MustRegister(
-		FreePageN,
-		PendingPageN,
-		FreeAlloc,
-		FreelistInuse,
-		TxN,
-		OpenTxN,
-		TxStatsPageCount,
-		TxStatsPageAlloc,
-		TxStatsCursorCount,
-		TxStatsNodeCount,
-		TxStatsNodeDeref,
-		TxStatsRebalance,
-		TxStatsRebalanceSeconds,
-		TxStatsSplit,
-		TxStatsSpill,
-		TxStatsSpillSeconds,
-		TxStatsWrite,
-		TxStatsWriteTime,
-		BranchPageN,
-		BranchOverflowN,
-		LeafPageN,
-		LeafOverflowN,
-		KeyN,
-		Depth,
-		BranchAlloc,
-		BranchInuse,
-		LeafAlloc,
-		LeafInuse,
-		BucketN,
-		InlineBucketN,
-		InlineBucketInuse,
-		BoltDBSize,
-		RocksDBSize,
 		PostgresTableCounts,
 		PostgresIndexSize,
 		PostgresTableTotalSize,

--- a/central/globalindex/metrics.go
+++ b/central/globalindex/metrics.go
@@ -6,13 +6,16 @@ import (
 	"github.com/blevesearch/bleve"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/fileutils"
 	"github.com/stackrox/rox/pkg/metrics"
 	"github.com/stackrox/rox/pkg/sync"
 )
 
 func init() {
-	prometheus.MustRegister(bleveDiskUsage)
+	if !env.PostgresDatastoreEnabled.BooleanSetting() {
+		prometheus.MustRegister(bleveDiskUsage)
+	}
 }
 
 const (

--- a/central/metrics/init.go
+++ b/central/metrics/init.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/logging"
 )
 
@@ -11,10 +12,16 @@ var (
 
 func init() {
 	// general
+
+	if !env.PostgresDatastoreEnabled.BooleanSetting() {
+		prometheus.MustRegister(
+			boltOperationHistogramVec,
+			rocksDBOperationHistogramVec,
+			dackboxOperationHistogramVec,
+		)
+	}
+
 	prometheus.MustRegister(
-		boltOperationHistogramVec,
-		rocksDBOperationHistogramVec,
-		dackboxOperationHistogramVec,
 		graphQLOperationHistogramVec,
 		graphQLQueryHistogramVec,
 		indexOperationHistogramVec,

--- a/pkg/dackbox/indexer/metrics.go
+++ b/pkg/dackbox/indexer/metrics.go
@@ -2,6 +2,7 @@ package indexer
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stackrox/rox/pkg/env"
 	pkgMetrics "github.com/stackrox/rox/pkg/metrics"
 )
 
@@ -21,8 +22,10 @@ var (
 )
 
 func init() {
-	prometheus.MustRegister(
-		indexObjectsDeduped,
-		indexObjectsIndexed,
-	)
+	if !env.PostgresDatastoreEnabled.BooleanSetting() {
+		prometheus.MustRegister(
+			indexObjectsDeduped,
+			indexObjectsIndexed,
+		)
+	}
 }


### PR DESCRIPTION
## Description

Declutter prometheus

<img width="919" alt="Screenshot 2023-03-01 at 12 29 31 PM" src="https://user-images.githubusercontent.com/2565181/222258222-86a32b41-5ce2-4d85-9bdc-8d8d41d10fb4.png">

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

CI will tell me if I tried to double register something