### PR TITLE
ROX-11612 - fix image scan debug file truncation

### DIFF
--- a/qa-tests-backend/src/main/groovy/util/Helpers.groovy
+++ b/qa-tests-backend/src/main/groovy/util/Helpers.groovy
@@ -148,6 +148,9 @@ class Helpers {
             if (proc.exitValue() != 0) {
                 log.warn "Failed to scan the image. Exit: ${proc.exitValue()}\nStderr: $serr"
             }
+
+            // closing the FileWriter will ensure internal buffer is flushed to file
+            sout.close()
         }
         catch (Exception e) {
             log.error("Could not collect image details", e)


### PR DESCRIPTION
## Description
The contents of [`default-policies-test-struts-app.json`](https://github.com/stackrox/stackrox/blob/ebcfa1d0dde8813aef1d4e94cda4676565d45f3c/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy#L152) were being truncated during CI runs - reducing troubleshooting confidence.

The cause of the truncation was the associated Groovy/Java FileWriter's internal buffer was not being flushed. Calling `.close()` on the FileWriter will force a flush of the internal buffer.

This was noticed while investigating `ROX-11612`

## Checklist
- [x] Investigated and inspected CI test results
- [ ] ~Unit test and regression tests added~
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.



## Testing Performed
Testing locally by creating a Groovy / Spock framework testing sandbox.

A test data file was created via `seq 1 500000 > lotta.txt`

A modified version of the `Helper.collectImageScanForDebug()` was created to reproduce the issue and verify fix

```groovy
static void collectImageScanForDebug() {
    try {
        Path imageScans = Paths.get("./image-scans")

        def cmd = ["/bin/bash", "-c", "cat ./lotta.txt"]
        Process proc = cmd.execute()
        String output = imageScans.resolve("test.txt").toAbsolutePath()
        FileWriter sout = new FileWriter(output)
        StringBuilder serr = new StringBuilder()

        proc.waitForProcessOutput(sout, serr)
        proc.waitFor()
        println serr
        sout.close()
    }
    catch (Exception e) {
        println "Could not collect image details", e
    }
}
```
Without the `sout.close()` the output file `./image-scans/test.txt` was truncated as expected, with `sout.close()` the full contents were written.