### PR TITLE
ROX-15157: increase clustermetrics test timeout

### DIFF
--- a/sensor/kubernetes/clustermetrics/cluster_metrics_test.go
+++ b/sensor/kubernetes/clustermetrics/cluster_metrics_test.go
@@ -16,7 +16,7 @@ import (
 const (
 	// Must be larger than defaultInterval. You may want to increase it if you plan
 	// to step through the code with a debugger.
-	metricsTimeout = 100 * time.Millisecond
+	metricsTimeout = 300 * time.Millisecond
 )
 
 func TestClusterMetrics(t *testing.T) {
@@ -31,7 +31,7 @@ type ClusterMetricsTestSuite struct {
 
 func (s *ClusterMetricsTestSuite) SetupTest() {
 	s.client = fake.NewSimpleClientset()
-	defaultInterval = 1 * time.Millisecond
+	defaultInterval = 10 * time.Millisecond
 }
 
 func (s *ClusterMetricsTestSuite) TestZeroNodes() {
@@ -39,7 +39,7 @@ func (s *ClusterMetricsTestSuite) TestZeroNodes() {
 
 	metrics := s.getClusterMetrics()
 
-	s.Equal(metrics, expected)
+	s.Equal(expected, metrics)
 }
 
 func (s *ClusterMetricsTestSuite) TestSingleNode() {
@@ -48,7 +48,7 @@ func (s *ClusterMetricsTestSuite) TestSingleNode() {
 
 	metrics := s.getClusterMetrics()
 
-	s.Equal(metrics, expected)
+	s.Equal(expected, metrics)
 }
 
 func (s *ClusterMetricsTestSuite) TestMultipleNodes() {
@@ -59,7 +59,7 @@ func (s *ClusterMetricsTestSuite) TestMultipleNodes() {
 
 	metrics := s.getClusterMetrics()
 
-	s.Equal(metrics, expected)
+	s.Equal(expected, metrics)
 }
 
 func (s *ClusterMetricsTestSuite) getClusterMetrics() *central.ClusterMetrics {


### PR DESCRIPTION
## Description

The test timeout was hit in CI run https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/branch-ci-stackrox-stackrox-master-merge-go-unit-tests-release/1626246342575656960 as detailed in ROX-15157. I could not reproduce the issue, I therefore increased the test timeout to make an accidental hit less likely.

I also noticed that expected and actual result in the assertions were swapped.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~