### PR TITLE
Add default timeouts to Postgres via context and not via statement_timeout

### DIFF
--- a/pkg/contextutil/timeout.go
+++ b/pkg/contextutil/timeout.go
@@ -1,0 +1,15 @@
+package contextutil
+
+import (
+	"context"
+	"time"
+)
+
+// ContextWithTimeoutIfNotExists returns a context with a timeout if one does not exist
+func ContextWithTimeoutIfNotExists(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	_, ok := ctx.Deadline()
+	if ok {
+		return ctx, func() {}
+	}
+	return context.WithTimeout(ctx, timeout)
+}

--- a/pkg/env/postgres_default_timeout.go
+++ b/pkg/env/postgres_default_timeout.go
@@ -1,0 +1,11 @@
+package env
+
+import "time"
+
+var (
+	// PostgresDefaultStatementTimeout sets the default timeout for Postgres statements
+	PostgresDefaultStatementTimeout = registerDurationSetting("ROX_POSTGRES_DEFAULT_TIMEOUT", 60*time.Second)
+
+	// PostgresDefaultCursorTimeout sets the default timeout for Postgres cursor statements
+	PostgresDefaultCursorTimeout = registerDurationSetting("ROX_POSTGRES_DEFAULT_CURSOR_TIMEOUT", 10*time.Minute)
+)

--- a/pkg/postgres/batch.go
+++ b/pkg/postgres/batch.go
@@ -1,0 +1,20 @@
+package postgres
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v4"
+)
+
+// BatchResults wraps pgx.BatchResults
+type BatchResults struct {
+	pgx.BatchResults
+	cancel context.CancelFunc
+}
+
+// Close wraps pgx.BatchResults Close
+func (b *BatchResults) Close() error {
+	defer b.cancel()
+
+	return b.BatchResults.Close()
+}

--- a/pkg/postgres/conn.go
+++ b/pkg/postgres/conn.go
@@ -37,11 +37,18 @@ func (c *Conn) Exec(ctx context.Context, sql string, args ...interface{}) (pgcon
 }
 
 // Query wraps pgxpool.Conn Query
-func (c *Conn) Query(ctx context.Context, sql string, args ...interface{}) (pgx.Rows, error) {
+func (c *Conn) Query(ctx context.Context, sql string, args ...interface{}) (*Rows, error) {
 	ctx, cancel := contextutil.ContextWithTimeoutIfNotExists(ctx, defaultTimeout)
-	defer cancel()
 
-	return c.Conn.Query(ctx, sql, args...)
+	rows, err := c.Conn.Query(ctx, sql, args...)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Rows{
+		Rows:       rows,
+		cancelFunc: cancel,
+	}, nil
 }
 
 // QueryRow wraps pgxpool.Conn QueryRow

--- a/pkg/postgres/conn.go
+++ b/pkg/postgres/conn.go
@@ -52,11 +52,13 @@ func (c *Conn) Query(ctx context.Context, sql string, args ...interface{}) (*Row
 }
 
 // QueryRow wraps pgxpool.Conn QueryRow
-func (c *Conn) QueryRow(ctx context.Context, sql string, args ...interface{}) pgx.Row {
+func (c *Conn) QueryRow(ctx context.Context, sql string, args ...interface{}) *Row {
 	ctx, cancel := contextutil.ContextWithTimeoutIfNotExists(ctx, defaultTimeout)
-	defer cancel()
 
-	return c.Conn.QueryRow(ctx, sql, args...)
+	return &Row{
+		Row:        c.Conn.QueryRow(ctx, sql, args...),
+		cancelFunc: cancel,
+	}
 }
 
 // SendBatch wraps pgxpool.Conn SendBatch

--- a/pkg/postgres/conn.go
+++ b/pkg/postgres/conn.go
@@ -6,6 +6,7 @@ import (
 	"github.com/jackc/pgconn"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
+	"github.com/stackrox/rox/pkg/contextutil"
 )
 
 // Conn is a wrapper around pgxpool.Conn
@@ -15,31 +16,48 @@ type Conn struct {
 
 // Begin wraps pgxpool.Conn Begin
 func (c *Conn) Begin(ctx context.Context) (*Tx, error) {
+	ctx, cancel := contextutil.ContextWithTimeoutIfNotExists(ctx, defaultTimeout)
+
 	tx, err := c.Conn.Begin(ctx)
 	if err != nil {
 		return nil, err
 	}
 	return &Tx{
-		Tx: tx,
+		Tx:         tx,
+		cancelFunc: cancel,
 	}, nil
 }
 
 // Exec wraps pgxpool.Conn Exec
 func (c *Conn) Exec(ctx context.Context, sql string, args ...interface{}) (pgconn.CommandTag, error) {
+	ctx, cancel := contextutil.ContextWithTimeoutIfNotExists(ctx, defaultTimeout)
+	defer cancel()
+
 	return c.Conn.Exec(ctx, sql, args...)
 }
 
 // Query wraps pgxpool.Conn Query
 func (c *Conn) Query(ctx context.Context, sql string, args ...interface{}) (pgx.Rows, error) {
+	ctx, cancel := contextutil.ContextWithTimeoutIfNotExists(ctx, defaultTimeout)
+	defer cancel()
+
 	return c.Conn.Query(ctx, sql, args...)
 }
 
 // QueryRow wraps pgxpool.Conn QueryRow
 func (c *Conn) QueryRow(ctx context.Context, sql string, args ...interface{}) pgx.Row {
+	ctx, cancel := contextutil.ContextWithTimeoutIfNotExists(ctx, defaultTimeout)
+	defer cancel()
+
 	return c.Conn.QueryRow(ctx, sql, args...)
 }
 
 // SendBatch wraps pgxpool.Conn SendBatch
-func (c *Conn) SendBatch(ctx context.Context, b *pgx.Batch) pgx.BatchResults {
-	return c.Conn.SendBatch(ctx, b)
+func (c *Conn) SendBatch(ctx context.Context, b *pgx.Batch) *BatchResults {
+	ctx, cancel := contextutil.ContextWithTimeoutIfNotExists(ctx, defaultTimeout)
+
+	return &BatchResults{
+		BatchResults: c.Conn.SendBatch(ctx, b),
+		cancel:       cancel,
+	}
 }

--- a/pkg/postgres/pool.go
+++ b/pkg/postgres/pool.go
@@ -75,14 +75,14 @@ func (d *DB) Exec(ctx context.Context, sql string, args ...interface{}) (pgconn.
 // Query wraps pgxpool.Pool Query
 func (d *DB) Query(ctx context.Context, sql string, args ...interface{}) (*Rows, error) {
 	ctx, cancel := contextutil.ContextWithTimeoutIfNotExists(ctx, defaultTimeout)
-	defer cancel()
 
 	rows, err := d.Pool.Query(ctx, sql, args...)
 	if err != nil {
 		return nil, err
 	}
 	return &Rows{
-		Rows: rows,
+		cancelFunc: cancel,
+		Rows:       rows,
 	}, nil
 }
 
@@ -96,9 +96,6 @@ func (d *DB) QueryRow(ctx context.Context, sql string, args ...interface{}) pgx.
 
 // Acquire wraps pgxpool.Acquire
 func (d *DB) Acquire(ctx context.Context) (*Conn, error) {
-	ctx, cancel := contextutil.ContextWithTimeoutIfNotExists(ctx, defaultTimeout)
-	defer cancel()
-
 	conn, err := d.Pool.Acquire(ctx)
 	if err != nil {
 		return nil, err

--- a/pkg/postgres/pool.go
+++ b/pkg/postgres/pool.go
@@ -89,9 +89,11 @@ func (d *DB) Query(ctx context.Context, sql string, args ...interface{}) (*Rows,
 // QueryRow wraps pgxpool.Pool QueryRow
 func (d *DB) QueryRow(ctx context.Context, sql string, args ...interface{}) pgx.Row {
 	ctx, cancel := contextutil.ContextWithTimeoutIfNotExists(ctx, defaultTimeout)
-	defer cancel()
 
-	return d.Pool.QueryRow(ctx, sql, args...)
+	return &Row{
+		Row:        d.Pool.QueryRow(ctx, sql, args...),
+		cancelFunc: cancel,
+	}
 }
 
 // Acquire wraps pgxpool.Acquire

--- a/pkg/postgres/postgres.go
+++ b/pkg/postgres/postgres.go
@@ -14,6 +14,7 @@ import (
 
 var (
 	queryThreshold = env.PostgresQueryTracerQueryThreshold.DurationSetting()
+	defaultTimeout = env.PostgresDefaultStatementTimeout.DurationSetting()
 )
 
 type queryTracerKey struct{}

--- a/pkg/postgres/rows.go
+++ b/pkg/postgres/rows.go
@@ -6,6 +6,19 @@ import (
 	"github.com/jackc/pgx/v4"
 )
 
+// Row wraps pgx.Row
+type Row struct {
+	pgx.Row
+	cancelFunc context.CancelFunc
+}
+
+// Scan wraps pgx.Row Scan
+func (r *Row) Scan(dest ...interface{}) error {
+	defer r.cancelFunc()
+
+	return r.Row.Scan(dest...)
+}
+
 // Rows wraps pgx.Rows
 type Rows struct {
 	rowsScanned int

--- a/pkg/postgres/rows.go
+++ b/pkg/postgres/rows.go
@@ -1,6 +1,8 @@
 package postgres
 
 import (
+	"context"
+
 	"github.com/jackc/pgx/v4"
 )
 
@@ -8,10 +10,13 @@ import (
 type Rows struct {
 	rowsScanned int
 	pgx.Rows
+	cancelFunc context.CancelFunc
 }
 
 // Close wraps pgx.Rows Close
 func (r *Rows) Close() {
+	defer r.cancelFunc()
+
 	// Eventually extended for metrics to report number of returned rows
 	r.Rows.Close()
 }

--- a/pkg/postgres/tx.go
+++ b/pkg/postgres/tx.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/jackc/pgconn"
 	"github.com/jackc/pgx/v4"
-	"github.com/stackrox/rox/pkg/contextutil"
 )
 
 // Tx wraps pgx.Tx
@@ -16,17 +15,11 @@ type Tx struct {
 
 // Exec wraps pgx.Tx Exec
 func (t *Tx) Exec(ctx context.Context, sql string, args ...interface{}) (commandTag pgconn.CommandTag, err error) {
-	ctx, cancel := contextutil.ContextWithTimeoutIfNotExists(ctx, defaultTimeout)
-	defer cancel()
-
 	return t.Tx.Exec(ctx, sql, args...)
 }
 
 // Query wraps pgx.Tx Query
 func (t *Tx) Query(ctx context.Context, sql string, args ...interface{}) (*Rows, error) {
-	ctx, cancel := contextutil.ContextWithTimeoutIfNotExists(ctx, defaultTimeout)
-	defer cancel()
-
 	rows, err := t.Tx.Query(ctx, sql, args...)
 	if err != nil {
 		return nil, err
@@ -38,9 +31,6 @@ func (t *Tx) Query(ctx context.Context, sql string, args ...interface{}) (*Rows,
 
 // QueryRow wraps pgx.Tx QueryRow
 func (t *Tx) QueryRow(ctx context.Context, sql string, args ...interface{}) pgx.Row {
-	ctx, cancel := contextutil.ContextWithTimeoutIfNotExists(ctx, defaultTimeout)
-	defer cancel()
-
 	return t.Tx.QueryRow(ctx, sql, args...)
 }
 

--- a/pkg/postgres/tx.go
+++ b/pkg/postgres/tx.go
@@ -25,7 +25,8 @@ func (t *Tx) Query(ctx context.Context, sql string, args ...interface{}) (*Rows,
 		return nil, err
 	}
 	return &Rows{
-		Rows: rows,
+		cancelFunc: func() {},
+		Rows:       rows,
 	}, nil
 }
 

--- a/pkg/postgres/tx.go
+++ b/pkg/postgres/tx.go
@@ -5,20 +5,28 @@ import (
 
 	"github.com/jackc/pgconn"
 	"github.com/jackc/pgx/v4"
+	"github.com/stackrox/rox/pkg/contextutil"
 )
 
 // Tx wraps pgx.Tx
 type Tx struct {
 	pgx.Tx
+	cancelFunc context.CancelFunc
 }
 
 // Exec wraps pgx.Tx Exec
 func (t *Tx) Exec(ctx context.Context, sql string, args ...interface{}) (commandTag pgconn.CommandTag, err error) {
+	ctx, cancel := contextutil.ContextWithTimeoutIfNotExists(ctx, defaultTimeout)
+	defer cancel()
+
 	return t.Tx.Exec(ctx, sql, args...)
 }
 
 // Query wraps pgx.Tx Query
 func (t *Tx) Query(ctx context.Context, sql string, args ...interface{}) (*Rows, error) {
+	ctx, cancel := contextutil.ContextWithTimeoutIfNotExists(ctx, defaultTimeout)
+	defer cancel()
+
 	rows, err := t.Tx.Query(ctx, sql, args...)
 	if err != nil {
 		return nil, err
@@ -30,5 +38,22 @@ func (t *Tx) Query(ctx context.Context, sql string, args ...interface{}) (*Rows,
 
 // QueryRow wraps pgx.Tx QueryRow
 func (t *Tx) QueryRow(ctx context.Context, sql string, args ...interface{}) pgx.Row {
+	ctx, cancel := contextutil.ContextWithTimeoutIfNotExists(ctx, defaultTimeout)
+	defer cancel()
+
 	return t.Tx.QueryRow(ctx, sql, args...)
+}
+
+// Commit wraps pgx.Tx Commit
+func (t *Tx) Commit(ctx context.Context) error {
+	defer t.cancelFunc()
+
+	return t.Tx.Commit(ctx)
+}
+
+// Rollback wraps pgx.Tx Rollback
+func (t *Tx) Rollback(ctx context.Context) error {
+	defer t.cancelFunc()
+
+	return t.Tx.Rollback(ctx)
 }


### PR DESCRIPTION
## Description

Add default timeouts if one doesn't exist on the context

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
