### PR TITLE
Add status tabs and summary card shells to images single page.

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageSingleVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageSingleVulnerabilities.tsx
@@ -1,13 +1,208 @@
-import React from 'react';
-import { PageSection, Text, Divider } from '@patternfly/react-core';
+import React, { ReactNode } from 'react';
+import {
+    Bullseye,
+    Divider,
+    EmptyState,
+    EmptyStateBody,
+    EmptyStateIcon,
+    EmptyStateVariant,
+    Grid,
+    GridItem,
+    PageSection,
+    Spinner,
+    Tab,
+    TabTitleText,
+    Tabs,
+    TabsComponent,
+    TabsProps,
+    Text,
+    Title,
+} from '@patternfly/react-core';
+import { ExclamationCircleIcon } from '@patternfly/react-icons';
+import { gql, useQuery } from '@apollo/client';
 
-function ImageSingleVulnerabilities() {
+import { VulnerabilitySeverity } from 'types/cve.proto';
+import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
+import { FixableStatus, isValidCveStatusTab } from './types';
+import useCveStatusTabParameter from './hooks/useCveStatusTabParameter';
+import WorkloadTableToolbar from './WorkloadTableToolbar';
+import BySeveritySummaryCard from './SummaryCards/BySeveritySummaryCard';
+import CvesByStatusSummaryCard from './SummaryCards/CvesByStatusSummaryCard';
+
+function severityCountsFromImageVulnerabilities(
+    imageVulnerabilities: ImageVulnerabilitiesResponse['image']['imageVulnerabilities']
+): Record<VulnerabilitySeverity, number> {
+    const severityCounts = {
+        LOW_VULNERABILITY_SEVERITY: 0,
+        MODERATE_VULNERABILITY_SEVERITY: 0,
+        IMPORTANT_VULNERABILITY_SEVERITY: 0,
+        CRITICAL_VULNERABILITY_SEVERITY: 0,
+    };
+
+    imageVulnerabilities.forEach(({ severity }) => {
+        severityCounts[severity] += 1;
+    });
+
+    return severityCounts;
+}
+
+function statusCountsFromImageVulnerabilities(
+    imageVulnerabilities: ImageVulnerabilitiesResponse['image']['imageVulnerabilities']
+): Record<FixableStatus, number> {
+    const statusCounts = {
+        Fixable: 0,
+        'Not fixable': 0,
+    };
+
+    imageVulnerabilities.forEach(({ isFixable }) => {
+        if (isFixable) {
+            statusCounts.Fixable += 1;
+        } else {
+            statusCounts['Not fixable'] += 1;
+        }
+    });
+
+    return statusCounts;
+}
+
+export type ImageVulnerabilitiesVariables = {
+    id: string;
+};
+
+export type ImageVulnerabilitiesResponse = {
+    image: {
+        imageVulnerabilities: {
+            severity: string;
+            isFixable: boolean;
+        }[];
+    };
+};
+
+export const imageVulnerabilitiesQuery = gql`
+    query getImageVulnerabilities($id: ID!) {
+        image(id: $id) {
+            id
+            imageVulnerabilities {
+                severity
+                isFixable
+            }
+        }
+    }
+`;
+
+export type ImageSingleVulnerabilitiesProps = {
+    imageId: string;
+};
+
+function ImageSingleVulnerabilities({ imageId }: ImageSingleVulnerabilitiesProps) {
+    // TODO Needs integration with URL search filter
+    const { data, loading, error } = useQuery<
+        ImageVulnerabilitiesResponse,
+        ImageVulnerabilitiesVariables
+    >(imageVulnerabilitiesQuery, {
+        variables: { id: imageId },
+    });
+
+    const [activeTabKey, setActiveTabKey] = useCveStatusTabParameter();
+
+    const handleTabClick: TabsProps['onSelect'] = (e, tabKey) => {
+        if (isValidCveStatusTab(tabKey)) {
+            setActiveTabKey(tabKey);
+        }
+    };
+
+    let mainContent: ReactNode | null = null;
+
+    if (error) {
+        mainContent = (
+            <Bullseye>
+                <EmptyState variant={EmptyStateVariant.large}>
+                    <EmptyStateIcon
+                        className="pf-u-danger-color-100"
+                        icon={ExclamationCircleIcon}
+                    />
+                    <Title headingLevel="h2">{getAxiosErrorMessage(error)}</Title>
+                    <EmptyStateBody>Adjust your filters and try again</EmptyStateBody>
+                </EmptyState>
+            </Bullseye>
+        );
+    } else if (loading && !data) {
+        mainContent = (
+            <Bullseye>
+                <Spinner isSVG />
+            </Bullseye>
+        );
+    } else if (data) {
+        const vulnerabilities = data.image.imageVulnerabilities;
+        const severityCounts = severityCountsFromImageVulnerabilities(vulnerabilities);
+        const cveStatusCounts = statusCountsFromImageVulnerabilities(vulnerabilities);
+        // TODO Integrate these with page search filters
+        const hiddenSeverities = new Set<VulnerabilitySeverity>(['LOW_VULNERABILITY_SEVERITY']);
+        const hiddenStatuses = new Set<FixableStatus>([]);
+
+        mainContent = (
+            <>
+                <Grid hasGutter>
+                    <GridItem sm={12} md={6} xl2={4}>
+                        <BySeveritySummaryCard
+                            title="CVEs by severity"
+                            severityCounts={severityCounts}
+                            hiddenSeverities={hiddenSeverities}
+                        />
+                    </GridItem>
+                    <GridItem sm={12} md={6} xl2={4}>
+                        <CvesByStatusSummaryCard
+                            cveStatusCounts={cveStatusCounts}
+                            hiddenStatuses={hiddenStatuses}
+                        />
+                    </GridItem>
+                </Grid>
+            </>
+        );
+    }
+
     return (
         <>
-            <PageSection variant="light" className="pf-u-py-md pf-u-px-xl">
+            <PageSection component="div" variant="light" className="pf-u-py-md pf-u-px-xl">
                 <Text>Review and triage vulnerability data scanned on this image</Text>
             </PageSection>
             <Divider component="div" />
+            <PageSection
+                className="pf-u-display-flex pf-u-flex-direction-column pf-u-flex-grow-1"
+                component="div"
+            >
+                <Tabs
+                    activeKey={activeTabKey}
+                    onSelect={handleTabClick}
+                    component={TabsComponent.nav}
+                    mountOnEnter
+                    unmountOnExit
+                    isBox
+                >
+                    <Tab
+                        className="pf-u-display-flex pf-u-flex-direction-column pf-u-flex-grow-1"
+                        eventKey="Observed"
+                        title={<TabTitleText>Observed CVEs</TabTitleText>}
+                    >
+                        <PageSection variant="light" component="div" isFilled>
+                            <WorkloadTableToolbar />
+                            {mainContent}
+                        </PageSection>
+                    </Tab>
+                    <Tab
+                        className="pf-u-display-flex pf-u-flex-direction-column pf-u-flex-grow-1"
+                        eventKey="Deferred"
+                        title={<TabTitleText>Deferrals</TabTitleText>}
+                        isDisabled
+                    />
+                    <Tab
+                        className="pf-u-display-flex pf-u-flex-direction-column pf-u-flex-grow-1"
+                        eventKey="False Positive"
+                        title={<TabTitleText>False positives</TabTitleText>}
+                        isDisabled
+                    />
+                </Tabs>
+            </PageSection>
         </>
     );
 }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageSingleVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageSingleVulnerabilities.tsx
@@ -29,6 +29,19 @@ import WorkloadTableToolbar from './WorkloadTableToolbar';
 import BySeveritySummaryCard from './SummaryCards/BySeveritySummaryCard';
 import CvesByStatusSummaryCard from './SummaryCards/CvesByStatusSummaryCard';
 
+export type ImageVulnerabilitiesVariables = {
+    id: string;
+};
+
+export type ImageVulnerabilitiesResponse = {
+    image: {
+        imageVulnerabilities: {
+            severity: string;
+            isFixable: boolean;
+        }[];
+    };
+};
+
 function severityCountsFromImageVulnerabilities(
     imageVulnerabilities: ImageVulnerabilitiesResponse['image']['imageVulnerabilities']
 ): Record<VulnerabilitySeverity, number> {
@@ -64,19 +77,6 @@ function statusCountsFromImageVulnerabilities(
 
     return statusCounts;
 }
-
-export type ImageVulnerabilitiesVariables = {
-    id: string;
-};
-
-export type ImageVulnerabilitiesResponse = {
-    image: {
-        imageVulnerabilities: {
-            severity: string;
-            isFixable: boolean;
-        }[];
-    };
-};
 
 export const imageVulnerabilitiesQuery = gql`
     query getImageVulnerabilities($id: ID!) {
@@ -137,27 +137,25 @@ function ImageSingleVulnerabilities({ imageId }: ImageSingleVulnerabilitiesProps
         const severityCounts = severityCountsFromImageVulnerabilities(vulnerabilities);
         const cveStatusCounts = statusCountsFromImageVulnerabilities(vulnerabilities);
         // TODO Integrate these with page search filters
-        const hiddenSeverities = new Set<VulnerabilitySeverity>(['LOW_VULNERABILITY_SEVERITY']);
+        const hiddenSeverities = new Set<VulnerabilitySeverity>([]);
         const hiddenStatuses = new Set<FixableStatus>([]);
 
         mainContent = (
-            <>
-                <Grid hasGutter>
-                    <GridItem sm={12} md={6} xl2={4}>
-                        <BySeveritySummaryCard
-                            title="CVEs by severity"
-                            severityCounts={severityCounts}
-                            hiddenSeverities={hiddenSeverities}
-                        />
-                    </GridItem>
-                    <GridItem sm={12} md={6} xl2={4}>
-                        <CvesByStatusSummaryCard
-                            cveStatusCounts={cveStatusCounts}
-                            hiddenStatuses={hiddenStatuses}
-                        />
-                    </GridItem>
-                </Grid>
-            </>
+            <Grid hasGutter>
+                <GridItem sm={12} md={6} xl2={4}>
+                    <BySeveritySummaryCard
+                        title="CVEs by severity"
+                        severityCounts={severityCounts}
+                        hiddenSeverities={hiddenSeverities}
+                    />
+                </GridItem>
+                <GridItem sm={12} md={6} xl2={4}>
+                    <CvesByStatusSummaryCard
+                        cveStatusCounts={cveStatusCounts}
+                        hiddenStatuses={hiddenStatuses}
+                    />
+                </GridItem>
+            </Grid>
         );
     }
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/SummaryCards/BySeveritySummaryCard.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/SummaryCards/BySeveritySummaryCard.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { Card, CardBody, CardTitle, Grid, GridItem } from '@patternfly/react-core';
+
+import { VulnerabilitySeverity } from 'types/cve.proto';
+import { vulnerabilitySeverityLabels } from 'messages/common';
+
+export type BySeveritySummaryCardProps = {
+    title: string;
+    severityCounts: Record<VulnerabilitySeverity, number>;
+    hiddenSeverities: Set<VulnerabilitySeverity>;
+};
+
+const severitiesCriticalToLow = [
+    'CRITICAL_VULNERABILITY_SEVERITY',
+    'IMPORTANT_VULNERABILITY_SEVERITY',
+    'MODERATE_VULNERABILITY_SEVERITY',
+    'LOW_VULNERABILITY_SEVERITY',
+] as const;
+
+function BySeveritySummaryCard({
+    title,
+    severityCounts,
+    hiddenSeverities,
+}: BySeveritySummaryCardProps) {
+    return (
+        <Card>
+            <CardTitle>{title}</CardTitle>
+            <CardBody>
+                <Grid hasGutter>
+                    {severitiesCriticalToLow.map((severity) => (
+                        <GridItem key={severity} span={6}>
+                            {hiddenSeverities.has(severity)
+                                ? 'Results hidden'
+                                : `${severityCounts[severity]} ${vulnerabilitySeverityLabels[severity]}`}
+                        </GridItem>
+                    ))}
+                </Grid>
+            </CardBody>
+        </Card>
+    );
+}
+
+export default BySeveritySummaryCard;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/SummaryCards/CvesByStatusSummaryCard.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/SummaryCards/CvesByStatusSummaryCard.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { Card, CardTitle, CardBody, Flex } from '@patternfly/react-core';
+
+import { FixableStatus } from '../types';
+
+export type CvesByStatusSummaryCardProps = {
+    cveStatusCounts: Record<FixableStatus, number | 'hidden'>;
+    hiddenStatuses: Set<FixableStatus>;
+};
+
+function CvesByStatusSummaryCard({
+    cveStatusCounts,
+    hiddenStatuses,
+}: CvesByStatusSummaryCardProps) {
+    return (
+        <Card>
+            <CardTitle>CVEs by status</CardTitle>
+            <CardBody>
+                <Flex direction={{ default: 'column' }}>
+                    <div>
+                        {hiddenStatuses.has('Fixable')
+                            ? 'Results hidden'
+                            : `${cveStatusCounts.Fixable} vulnerabilities with available fixes`}
+                    </div>
+                    <div>
+                        {hiddenStatuses.has('Not fixable')
+                            ? 'Results hidden'
+                            : `${cveStatusCounts['Not fixable']} vulnerabilities without fixes`}
+                    </div>
+                </Flex>
+            </CardBody>
+        </Card>
+    );
+}
+
+export default CvesByStatusSummaryCard;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesImageSinglePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesImageSinglePage.tsx
@@ -41,7 +41,7 @@ const workloadCveOverviewImagePath = getOverviewCvesPath({
 function ImageDetailBadges({ imageData }: { imageData: ImageDetailsResponse['image'] }) {
     const [hasSuccessfulCopy, setHasSuccessfulCopy] = useState(false);
 
-    const { deploymentCount, operatingSystem, metadata, scan } = imageData;
+    const { deploymentCount, operatingSystem, metadata, dataSource, scanTime } = imageData;
     const created = metadata?.v1?.created;
     const sha = metadata?.v1?.digest;
     const isActive = deploymentCount > 0;
@@ -68,10 +68,9 @@ function ImageDetailBadges({ imageData }: { imageData: ImageDetailsResponse['ima
             {created && (
                 <Label isCompact>Age: {getDistanceStrictAsPhrase(created, new Date())}</Label>
             )}
-            {scan && (
+            {scanTime && (
                 <Label isCompact>
-                    Scan time: {getDateTime(scan.scanTime)} by{' '}
-                    {scan?.dataSource?.name ?? 'Unknown Scanner'}
+                    Scan time: {getDateTime(scanTime)} by {dataSource?.name ?? 'Unknown Scanner'}
                 </Label>
             )}
             {sha && (
@@ -108,11 +107,8 @@ export type ImageDetailsResponse = {
                 digest: string;
             } | null;
         } | null;
-
-        scan: {
-            dataSource: { name: string } | null;
-            scanTime: Date | null;
-        };
+        dataSource: { name: string } | null;
+        scanTime: Date | null;
     };
 };
 
@@ -131,12 +127,10 @@ export const imageDetailsQuery = gql`
                     digest
                 }
             }
-            scan {
-                dataSource {
-                    name
-                }
-                scanTime
+            dataSource {
+                name
             }
+            scanTime
         }
     }
 `;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesImageSinglePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesImageSinglePage.tsx
@@ -70,7 +70,8 @@ function ImageDetailBadges({ imageData }: { imageData: ImageDetailsResponse['ima
             )}
             {scan && (
                 <Label isCompact>
-                    Scan time: {getDateTime(scan.scanTime)} by {scan.dataSource.name}
+                    Scan time: {getDateTime(scan.scanTime)} by{' '}
+                    {scan?.dataSource?.name ?? 'Unknown Scanner'}
                 </Label>
             )}
             {sha && (
@@ -109,7 +110,7 @@ export type ImageDetailsResponse = {
         } | null;
 
         scan: {
-            dataSource: { name: string };
+            dataSource: { name: string } | null;
             scanTime: Date | null;
         };
     };
@@ -118,6 +119,7 @@ export type ImageDetailsResponse = {
 export const imageDetailsQuery = gql`
     query getImageDetails($id: ID!) {
         image(id: $id) {
+            id
             deploymentCount
             name {
                 fullName
@@ -197,22 +199,27 @@ function WorkloadCvesImageSinglePage() {
                         </Flex>
                     )}
                 </PageSection>
-                <PageSection variant="light" padding={{ default: 'noPadding' }}>
+                <PageSection
+                    className="pf-u-display-flex pf-u-flex-direction-column pf-u-flex-grow-1"
+                    padding={{ default: 'noPadding' }}
+                >
                     <Tabs
                         activeKey={activeTabKey}
                         onSelect={handleTabClick}
                         component={TabsComponent.nav}
-                        className="pf-u-pl-md"
+                        className="pf-u-pl-md pf-u-background-color-100"
                         mountOnEnter
                         unmountOnExit
                     >
                         <Tab
+                            className="pf-u-display-flex pf-u-flex-direction-column pf-u-flex-grow-1"
                             eventKey="Vulnerabilities"
                             title={<TabTitleText>Vulnerabilities</TabTitleText>}
                         >
-                            <ImageSingleVulnerabilities />
+                            <ImageSingleVulnerabilities imageId={imageId} />
                         </Tab>
                         <Tab
+                            className="pf-u-display-flex pf-u-flex-direction-column pf-u-flex-grow-1"
                             eventKey="Resources"
                             title={<TabTitleText>Resources</TabTitleText>}
                             isDisabled

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/hooks/useCveStatusTabParameter.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/hooks/useCveStatusTabParameter.ts
@@ -1,0 +1,11 @@
+import useURLParameter from 'hooks/useURLParameter';
+
+import { CveStatusTab, isValidCveStatusTab } from '../types';
+
+export type UseCveStatusTabParameterReturn = [CveStatusTab, (newTab: CveStatusTab) => void];
+
+export default function useCveStatusTabParameter(): UseCveStatusTabParameterReturn {
+    const [cveStatusTab, setCveStatusTab] = useURLParameter('cveStatusTab', 'Observed');
+    const tabValue = isValidCveStatusTab(cveStatusTab) ? cveStatusTab : 'Observed';
+    return [tabValue, setCveStatusTab];
+}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/searchUtils.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/searchUtils.tsx
@@ -3,7 +3,8 @@ import { vulnerabilitiesWorkloadCvesPath } from 'routePaths';
 import { SearchFilter } from 'types/search';
 import { getQueryString } from 'utils/queryStringUtils';
 
-export type CveStatusTab = 'Observed' | 'Deferred' | 'False Positive';
+import { CveStatusTab, isValidCveStatusTab } from './types';
+
 export type EntityTab = 'CVE' | 'Image' | 'Deployment';
 
 export type WorkloadCvesSearch = {
@@ -11,14 +12,6 @@ export type WorkloadCvesSearch = {
     entityTab?: EntityTab;
     s?: SearchFilter;
 };
-
-function isValidCveStatusTab(cveStatusTab: unknown): cveStatusTab is CveStatusTab {
-    return (
-        cveStatusTab === 'Observed' ||
-        cveStatusTab === 'Deferred' ||
-        cveStatusTab === 'False Positive'
-    );
-}
 
 export function parseWorkloadCvesOverviewSearchString(search: string): WorkloadCvesSearch {
     const { cveStatusTab } = qs.parse(search, { ignoreQueryPrefix: true });

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/types.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/types.ts
@@ -20,3 +20,11 @@ export type DetailsTab = typeof detailsTabValues[number];
 export function isDetailsTab(value: unknown): value is DetailsTab {
     return detailsTabValues.some((tab) => tab === value);
 }
+
+const cveStatusTabValues = ['Observed', 'Deferred', 'False Positive'] as const;
+
+export type CveStatusTab = typeof cveStatusTabValues[number];
+
+export function isValidCveStatusTab(value: unknown): value is CveStatusTab {
+    return cveStatusTabValues.some((tab) => tab === value);
+}


### PR DESCRIPTION
## Description

Implements the CVE status tab section of the image single page and bare-bones summary cards.

## Follow ups needed for ROX-15384 to be complete

- Implement correct icons and styling for summary cards
- Integrate query with URL search parameters applied by the filter bar
- Integrate summary card "hidden" rendering with URL search parameters

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Error state:
![image](https://user-images.githubusercontent.com/1292638/222759268-9e72cdd5-274f-4749-82eb-11bcabb16aad.png)

Loading state (the blue speck is a spinner):
![image](https://user-images.githubusercontent.com/1292638/222763707-7e8a4d9f-15c8-4a16-acd4-b7c63800f4e5.png)


Rendering at various sizes when the request completes successfully:
![image](https://user-images.githubusercontent.com/1292638/222758730-69a120ca-74e4-462e-bcba-324017dc48a1.png)
![image](https://user-images.githubusercontent.com/1292638/222758827-ac0711be-4e1e-4993-8af8-cbdf2e8434d2.png)
<img width="400" src="https://user-images.githubusercontent.com/1292638/222758903-4416d36d-8f6a-4f6e-85fa-a4a47d16c7e7.png" />


