### PR TITLE
Telemetry: Use Track instead of Identify

### DIFF
--- a/central/cluster/datastore/telemetry.go
+++ b/central/cluster/datastore/telemetry.go
@@ -30,13 +30,12 @@ func trackClusterRegistered(ctx context.Context, cluster *storage.Cluster) {
 
 		cfg.Telemeter().Track("Secured Cluster Registered", props, telemeter.WithUserID(userID), groups)
 
-		client := telemeter.WithClient(cluster.GetId(), securedClusterClient)
-
-		// Add the secured cluster 'user' to the Tenant group:
-		cfg.Telemeter().Group(nil, client, groups)
-
-		// Update the secured cluster identity from its name:
-		cfg.Telemeter().Identify(makeClusterProperties(cluster), client, groups)
+		// Update the secured cluster identity from its name and add the secured
+		// cluster 'user' to the Tenant group:
+		cfg.Telemeter().Track("Secured Cluster Static Properties", nil,
+			telemeter.WithTraits(makeClusterProperties(cluster)),
+			telemeter.WithClient(cluster.GetId(), securedClusterClient),
+			groups)
 	}
 }
 
@@ -111,8 +110,8 @@ func UpdateSecuredClusterIdentity(ctx context.Context, clusterID string, metrics
 		opts := []telemeter.Option{
 			telemeter.WithClient(cluster.GetId(), securedClusterClient),
 			telemeter.WithGroups(cfg.GroupType, cfg.GroupID),
+			telemeter.WithTraits(props),
 		}
-		cfg.Telemeter().Identify(props, opts...)
 		cfg.Telemeter().Track("Updated Secured Cluster Identity", nil, opts...)
 	}
 }

--- a/pkg/telemetry/phonehome/gatherer.go
+++ b/pkg/telemetry/phonehome/gatherer.go
@@ -76,9 +76,8 @@ func (g *gatherer) identify() {
 	defer g.gathering.Unlock()
 	data := g.gather()
 	if !reflect.DeepEqual(g.lastData, data) {
-		g.telemeter.Identify(data, g.opts...)
 		// Issue an event so that the new data become visible on analytics:
-		g.telemeter.Track("Updated "+g.clientType+" Identity", nil, g.opts...)
+		g.telemeter.Track("Updated "+g.clientType+" Identity", nil, append(g.opts, telemeter.WithTraits(data))...)
 	}
 	g.lastData = data
 }

--- a/pkg/telemetry/phonehome/gatherer_test.go
+++ b/pkg/telemetry/phonehome/gatherer_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
+	"github.com/stackrox/rox/pkg/telemetry/phonehome/telemeter"
 	"github.com/stackrox/rox/pkg/telemetry/phonehome/telemeter/mocks"
 	"github.com/stretchr/testify/suite"
 )
@@ -30,11 +31,8 @@ func (s *gathererTestSuite) TestNilGatherer() {
 func (s *gathererTestSuite) TestGatherer() {
 	t := mocks.NewMockTelemeter(gomock.NewController(s.T()))
 
-	// Identify and Track should be called once as there's no change in the
-	// identity:
-	t.EXPECT().Identify(gomock.Eq(map[string]any{"key": "value"})).Times(1)
-
-	t.EXPECT().Track("Updated Test Identity", nil).Times(1)
+	t.EXPECT().Track("Updated Test Identity", nil,
+		matchOptions(telemeter.WithTraits(map[string]any{"key": "value"}))).Times(1)
 
 	props := make(map[string]any)
 	var i int64

--- a/pkg/telemetry/phonehome/segment/segment.go
+++ b/pkg/telemetry/phonehome/segment/segment.go
@@ -202,14 +202,16 @@ func (t *segmentTelemeter) Group(props map[string]any, opts ...telemeter.Option)
 		if err := t.client.Enqueue(group); err != nil {
 			log.Error("Cannot enqueue Segment group event: ", err)
 		}
-		if len(props) > 0 {
-			// Track the group properties update with the same device ID
-			// to ensure following events get the properties attached. This is
-			// due to Amplitude partioning by device ID.
-			t.client.Enqueue(segment.Track{
-				Event:   "Group Properties Updated",
-				Context: dctx,
-			})
+	}
+	if len(props) > 0 {
+		// Track the group properties update with the same device ID
+		// to ensure following events get the properties attached. This is
+		// due to Amplitude partioning by device ID.
+		if err := t.client.Enqueue(segment.Track{
+			Event:   "Group Properties Updated",
+			Context: dctx,
+		}); err != nil {
+			log.Error("Cannot enqueue Segment track event: ", err)
 		}
 	}
 }

--- a/pkg/telemetry/phonehome/segment/segment_test.go
+++ b/pkg/telemetry/phonehome/segment/segment_test.go
@@ -17,7 +17,7 @@ func Test_getMessageType(t *testing.T) {
 	assert.Equal(t, "Track", getMessageType(track))
 }
 
-func Test_makeDeviceContext(t *testing.T) {
+func Test_makeContext(t *testing.T) {
 	opts := telemeter.ApplyOptions([]telemeter.Option{
 		telemeter.WithUserID("userID"),
 		telemeter.WithClient("clientID", "clientType"),
@@ -28,7 +28,7 @@ func Test_makeDeviceContext(t *testing.T) {
 
 	s := segmentTelemeter{clientType: "test"}
 
-	ctx := s.makeDeviceContext(opts)
+	ctx := s.makeContext(opts)
 	assert.Equal(t, "clientID", ctx.Device.Id)
 	assert.Equal(t, "clientType", ctx.Device.Type)
 
@@ -38,10 +38,10 @@ func Test_makeDeviceContext(t *testing.T) {
 	groups := ctx.Extra["groups"].(map[string][]string)
 	assert.ElementsMatch(t, []string{"groupA_id1", "groupA_id2"}, groups["groupA"])
 
-	ctx = s.makeDeviceContext(telemeter.ApplyOptions([]telemeter.Option{}))
+	ctx = s.makeContext(telemeter.ApplyOptions([]telemeter.Option{}))
 	assert.Equal(t, "test Server", ctx.Device.Type)
 
-	ctx = s.makeDeviceContext(telemeter.ApplyOptions([]telemeter.Option{
+	ctx = s.makeContext(telemeter.ApplyOptions([]telemeter.Option{
 		telemeter.WithClient("clientID", "clientType")}))
 	assert.Equal(t, "clientType Server", ctx.Device.Type)
 }

--- a/pkg/telemetry/phonehome/telemeter/telemeter.go
+++ b/pkg/telemetry/phonehome/telemeter/telemeter.go
@@ -9,6 +9,8 @@ type CallOptions struct {
 
 	// [group type: [group id]]
 	Groups map[string][]string
+	// User properties to be updated:
+	Traits map[string]any
 }
 
 // Option modifies the provided CallOptions structure.
@@ -49,6 +51,13 @@ func WithGroups(groupType string, groupID string) Option {
 			o.Groups = make(map[string][]string, 1)
 		}
 		o.Groups[groupType] = append(o.Groups[groupType], groupID)
+	}
+}
+
+// WithTraits sets the user properties to be updated with the call.
+func WithTraits(traits map[string]any) Option {
+	return func(o *CallOptions) {
+		o.Traits = traits
 	}
 }
 


### PR DESCRIPTION
## Description

* New `WithTraits` option, that allows for passing User properties to events;
* Removed `Identify` calls in favor of `Track(... WithTraits)`.

This change ensures the user properties are updated on Amplitude even when passing through Segment.
An according mapping has been setup in the Amplitude destination to take the Segment event `traits` from `context` and put to `user_properties` Amplitude event field.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

Example of an event with traits seen on Segment:
```json
{
  "anonymousId": "1677cf97-e8b2-4ec6-96fd-71427cc40b16",
  "context": {
    "device": {
      "id": "1677cf97-e8b2-4ec6-96fd-71427cc40b16",
      "type": "Secured Cluster"
    },
    "groups": {
      "Tenant": [
        "062c26b6-85d7-4ee8-b690-1e21e94657f3"
      ]
    },
    "library": {
      "name": "analytics-go",
      "version": "3.0.0"
    },
    "traits": {
      "Admission Controller": true,
      "CPU Capacity": 8,
      "Cluster Type": "KUBERNETES_CLUSTER",
      "Collection Method": "EBPF",
      "Collector Image": "quay.io/stackrox-io/collector",
      "Main Image": "quay.io/stackrox-io/main:3.74.x-243-gc5c4db7a63-dirty",
      "Managed By": "MANAGER_TYPE_MANUAL",
      "Priority": 1,
      "Slim Collector": true,
      "Total Nodes": 1
    }
  },
  "event": "Updated Secured Cluster Identity",
  "integrations": {},
  "messageId": "7e170f97-58ca-4b43-bc7b-67f7422d1d0c",
  "originalTimestamp": "2023-03-02T18:06:46.4738029Z",
  "receivedAt": "2023-03-02T18:07:24.535Z",
  "sentAt": "2023-03-02T18:07:23.874Z",
  "timestamp": "2023-03-02T18:06:47.133Z",
  "type": "track",
  "writeKey": "..."
}
```
This event [on Amplitude](https://analytics.amplitude.com/redhat/project/424524/search/amplitude_id%3D585297693707?sessionHandle=-B_YajgVNd_IhGdgwL_BnpM_1677cf97-e8b2-4ec6-96fd-71427cc40b16&eventId=d27c833c-b36a-4800-990f-d9e442c6f345):
```json
{
  "$insert_id": "13ae6d5f-f698-419b-be87-991cfb55318e",
  "$insert_key": "018b91fcd6576a4340b51e2a52240a2eef#938",
  "$schema": 13,
  "_time": 1677780407133,
  "adid": null,
  "amplitude_attribution_ids": [
    "3248c7c6c150f76fee61e21712842dc0"
  ],
  "amplitude_event_type": null,
  "amplitude_id": 585297693707,
  "app": 424524,
  "city": null,
  "client_event_time": "2023-03-02 18:06:47.133000",
  "client_upload_time": "2023-03-02 18:07:26.869000",
  "country": null,
  "data": {
    "group_first_event": {
    },
    "group_ids": {
      "260245": [
        13187659195
      ]
    }
  },
  "data_type": "event",
  "device_brand": null,
  "device_carrier": null,
  "device_family": null,
  "device_id": "1677cf97-e8b2-4ec6-96fd-71427cc40b16",
  "device_manufacturer": null,
  "device_model": null,
  "device_type": null,
  "display_name": "Updated Secured Cluster Identity",
  "dma": null,
  "event_id": 627718334,
  "event_properties": {
  },
  "event_time": "2023-03-02 18:06:47.133000",
  "event_type": "Updated Secured Cluster Identity",
  "global_user_properties": {
  },
  "group_properties": {
    "Tenant": {
      "062c26b6-85d7-4ee8-b690-1e21e94657f3": {
      }
    }
  },
  "groups": {
    "Tenant": [
      "062c26b6-85d7-4ee8-b690-1e21e94657f3"
    ]
  },
  "idfa": null,
  "ip_address": null,
  "is_attribution_event": false,
  "language": null,
  "library": "segment",
  "location_lat": null,
  "location_lng": null,
  "os": "",
  "os_name": null,
  "os_version": null,
  "partner_id": null,
  "paying": null,
  "plan": {
  },
  "platform": "Secured Cluster",
  "region": null,
  "sample_rate": null,
  "server_received_time": "2023-03-02 18:07:26.869000",
  "server_upload_time": "2023-03-02 18:07:26.871000",
  "session_id": -1,
  "source_id": null,
  "start_version": null,
  "timeline_hidden": false,
  "user_creation_time": "2023-03-02 13:36:20.687000",
  "user_id": null,
  "user_properties": {
    "Admission Controller": true,
    "CPU Capacity": 8,
    "Cluster Type": "KUBERNETES_CLUSTER",
    "Collection Method": "EBPF",
    "Collector Image": "quay.io/stackrox-io/collector",
    "Main Image": "quay.io/stackrox-io/main:3.74.x-243-gc5c4db7a63-dirty",
    "Managed By": "MANAGER_TYPE_MANUAL",
    "Priority": 1,
    "Slim Collector": true,
    "Total Nodes": 1
  },
  "uuid": "d27c833c-b36a-4800-990f-d9e442c6f345",
  "version_name": null
}
```
