### PR TITLE
Dashrews/rox 15450 query errors

### DIFF
--- a/central/cve/cluster/datastore/store/postgres/full_store.go
+++ b/central/cve/cluster/datastore/store/postgres/full_store.go
@@ -278,7 +278,7 @@ func getCVEs(ctx context.Context, tx *postgres.Tx, cveIDs []string) (map[string]
 		}
 		idToCVEMap[msg.GetId()] = msg
 	}
-	return idToCVEMap, nil
+	return idToCVEMap, rows.Err()
 }
 
 func getClusterCVEEdgeIDs(ctx context.Context, tx *postgres.Tx, cveType storage.CVE_CVEType, clusterIDs []string) (set.StringSet, error) {
@@ -298,7 +298,7 @@ func getClusterCVEEdgeIDs(ctx context.Context, tx *postgres.Tx, cveType storage.
 		}
 		ids = append(ids, id)
 	}
-	return set.NewStringSet(ids...), nil
+	return set.NewStringSet(ids...), rows.Err()
 }
 
 func removeOrphanedImageCVEEdges(ctx context.Context, tx *postgres.Tx, orphanedEdgeIDs []string) error {

--- a/central/debug/service/db_diagnostics.go
+++ b/central/debug/service/db_diagnostics.go
@@ -54,6 +54,7 @@ func getPostgresExtensions(ctx context.Context, dbPool *postgres.DB) []dbExtensi
 		log.Errorf("error fetching Postgres extensions: %v", err)
 		return nil
 	}
+	defer rows.Close()
 
 	extSlice := make([]dbExtension, 0)
 
@@ -75,7 +76,6 @@ func getPostgresExtensions(ctx context.Context, dbPool *postgres.DB) []dbExtensi
 		extSlice = append(extSlice, dbExt)
 	}
 
-	rows.Close()
 	if rows.Err() != nil {
 		log.Errorf("error getting complete extension information: %v", rows.Err())
 	}

--- a/central/debug/service/db_diagnostics.go
+++ b/central/debug/service/db_diagnostics.go
@@ -76,8 +76,8 @@ func getPostgresExtensions(ctx context.Context, dbPool *postgres.DB) []dbExtensi
 		extSlice = append(extSlice, dbExt)
 	}
 
-	if rows.Err() != nil {
-		log.Errorf("error getting complete extension information: %v", rows.Err())
+	if err := rows.Err(); err != nil {
+		log.Errorf("error getting complete extension information: %v", err)
 	}
 
 	return extSlice

--- a/central/globaldb/postgres.go
+++ b/central/globaldb/postgres.go
@@ -187,8 +187,8 @@ func CollectPostgresStats(ctx context.Context, db *postgres.DB) *stats.DatabaseS
 		statsSlice = append(statsSlice, tableStat)
 	}
 
-	if rows.Err() != nil {
-		log.Errorf("error getting complete table statistic information: %v", rows.Err())
+	if err := rows.Err(); err != nil {
+		log.Errorf("error getting complete table statistic information: %v", err)
 	}
 
 	dbStats.Tables = statsSlice

--- a/central/globaldb/postgres.go
+++ b/central/globaldb/postgres.go
@@ -146,7 +146,7 @@ func CollectPostgresStats(ctx context.Context, db *postgres.DB) *stats.DatabaseS
 	metrics.PostgresConnected.Set(float64(1))
 	dbStats.DatabaseAvailable = true
 
-	row, err := db.Query(ctx, tableQuery)
+	rows, err := db.Query(ctx, tableQuery)
 	if err != nil {
 		log.Errorf("error fetching object counts: %v", err)
 		return dbStats
@@ -154,8 +154,7 @@ func CollectPostgresStats(ctx context.Context, db *postgres.DB) *stats.DatabaseS
 
 	statsSlice := make([]*stats.TableStats, 0)
 
-	defer row.Close()
-	for row.Next() {
+	for rows.Next() {
 		var (
 			tableName   string
 			rowEstimate int
@@ -164,7 +163,7 @@ func CollectPostgresStats(ctx context.Context, db *postgres.DB) *stats.DatabaseS
 			toastSize   int
 			tableSize   int
 		)
-		if err := row.Scan(&tableName, &rowEstimate, &totalSize, &indexSize, &toastSize, &tableSize); err != nil {
+		if err := rows.Scan(&tableName, &rowEstimate, &totalSize, &indexSize, &toastSize, &tableSize); err != nil {
 			log.Errorf("error scanning row for table %s: %v", tableName, err)
 			return nil
 		}
@@ -185,6 +184,11 @@ func CollectPostgresStats(ctx context.Context, db *postgres.DB) *stats.DatabaseS
 		}
 
 		statsSlice = append(statsSlice, tableStat)
+	}
+
+	rows.Close()
+	if rows.Err() != nil {
+		log.Errorf("error getting complete table statistic information: %v", rows.Err())
 	}
 
 	dbStats.Tables = statsSlice

--- a/central/globaldb/postgres.go
+++ b/central/globaldb/postgres.go
@@ -151,6 +151,7 @@ func CollectPostgresStats(ctx context.Context, db *postgres.DB) *stats.DatabaseS
 		log.Errorf("error fetching object counts: %v", err)
 		return dbStats
 	}
+	defer rows.Close()
 
 	statsSlice := make([]*stats.TableStats, 0)
 
@@ -186,7 +187,6 @@ func CollectPostgresStats(ctx context.Context, db *postgres.DB) *stats.DatabaseS
 		statsSlice = append(statsSlice, tableStat)
 	}
 
-	rows.Close()
 	if rows.Err() != nil {
 		log.Errorf("error getting complete table statistic information: %v", rows.Err())
 	}

--- a/central/image/datastore/store/postgres/store.go
+++ b/central/image/datastore/store/postgres/store.go
@@ -790,7 +790,7 @@ func getImageComponentEdges(ctx context.Context, tx *postgres.Tx, imageID string
 		}
 		componentIDToEdgeMap[msg.GetImageComponentId()] = msg
 	}
-	return componentIDToEdgeMap, nil
+	return componentIDToEdgeMap, rows.Err()
 }
 
 func getImageCVEEdgeIDs(ctx context.Context, tx *postgres.Tx, imageID string) (set.StringSet, error) {
@@ -827,7 +827,7 @@ func getImageCVEEdges(ctx context.Context, tx *postgres.Tx, imageID string) (map
 		}
 		cveIDToEdgeMap[msg.GetImageCveId()] = msg
 	}
-	return cveIDToEdgeMap, nil
+	return cveIDToEdgeMap, rows.Err()
 }
 
 func getImageComponents(ctx context.Context, tx *postgres.Tx, componentIDs []string) (map[string]*storage.ImageComponent, error) {
@@ -850,7 +850,7 @@ func getImageComponents(ctx context.Context, tx *postgres.Tx, componentIDs []str
 		}
 		idToComponentMap[msg.GetId()] = msg
 	}
-	return idToComponentMap, nil
+	return idToComponentMap, rows.Err()
 }
 
 func getComponentCVEEdges(ctx context.Context, tx *postgres.Tx, componentIDs []string) (map[string][]*storage.ComponentCVEEdge, error) {
@@ -873,7 +873,7 @@ func getComponentCVEEdges(ctx context.Context, tx *postgres.Tx, componentIDs []s
 		}
 		componentIDToEdgeMap[msg.GetImageComponentId()] = append(componentIDToEdgeMap[msg.GetImageComponentId()], msg)
 	}
-	return componentIDToEdgeMap, nil
+	return componentIDToEdgeMap, rows.Err()
 }
 
 func getCVEs(ctx context.Context, tx *postgres.Tx, cveIDs []string) (map[string]*storage.ImageCVE, error) {
@@ -896,7 +896,7 @@ func getCVEs(ctx context.Context, tx *postgres.Tx, cveIDs []string) (map[string]
 		}
 		idToCVEMap[msg.GetId()] = msg
 	}
-	return idToCVEMap, nil
+	return idToCVEMap, rows.Err()
 }
 
 // Delete removes the specified ID from the store.
@@ -1233,5 +1233,5 @@ func scanIDs(rows pgx.Rows) ([]string, error) {
 		}
 		ids = append(ids, id)
 	}
-	return ids, nil
+	return ids, rows.Err()
 }

--- a/central/networkgraph/flow/datastore/internal/store/postgres/store.go
+++ b/central/networkgraph/flow/datastore/internal/store/postgres/store.go
@@ -452,6 +452,9 @@ func (s *flowStoreImpl) retryableGetMatchingFlows(ctx context.Context, pred func
 	defer rows.Close()
 
 	flows, err := s.readRows(rows, pred)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	return flows, lastUpdateTS, rows.Err()
 }

--- a/central/node/datastore/store/postgres/store.go
+++ b/central/node/datastore/store/postgres/store.go
@@ -747,7 +747,7 @@ func getNodeComponentEdges(ctx context.Context, tx *postgres.Tx, nodeID string) 
 		}
 		componentIDToEdgeMap[msg.GetNodeComponentId()] = msg
 	}
-	return componentIDToEdgeMap, nil
+	return componentIDToEdgeMap, rows.Err()
 }
 
 func getNodeComponents(ctx context.Context, tx *postgres.Tx, componentIDs []string) (map[string]*storage.NodeComponent, error) {
@@ -770,7 +770,7 @@ func getNodeComponents(ctx context.Context, tx *postgres.Tx, componentIDs []stri
 		}
 		idToComponentMap[msg.GetId()] = msg
 	}
-	return idToComponentMap, nil
+	return idToComponentMap, rows.Err()
 }
 
 func getComponentCVEEdges(ctx context.Context, tx *postgres.Tx, componentIDs []string) (map[string][]*storage.NodeComponentCVEEdge, error) {
@@ -793,7 +793,7 @@ func getComponentCVEEdges(ctx context.Context, tx *postgres.Tx, componentIDs []s
 		}
 		componentIDToEdgesMap[msg.GetNodeComponentId()] = append(componentIDToEdgesMap[msg.GetNodeComponentId()], msg)
 	}
-	return componentIDToEdgesMap, nil
+	return componentIDToEdgesMap, rows.Err()
 }
 
 func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*postgres.Conn, func(), error) {
@@ -1049,7 +1049,7 @@ func getCVEs(ctx context.Context, tx *postgres.Tx, cveIDs []string) (map[string]
 		}
 		idToCVEMap[msg.GetId()] = msg
 	}
-	return idToCVEMap, nil
+	return idToCVEMap, rows.Err()
 }
 
 func gatherKeys(parts *nodePartsAsSlice) [][]byte {

--- a/central/processlisteningonport/store/postgres/full_store.go
+++ b/central/processlisteningonport/store/postgres/full_store.go
@@ -73,7 +73,12 @@ func (s *fullStoreImpl) retryableGetPLOP(
 	}
 	defer rows.Close()
 
-	return s.readRows(rows)
+	results, err := s.readRows(rows)
+	if err != nil {
+		return nil, err
+	}
+
+	return results, rows.Err()
 }
 
 // Manual converting of raw data from SQL query to ProcessListeningOnPort (not

--- a/migrator/migrations/n_04_to_n_05_postgres_images/postgres/store.go
+++ b/migrator/migrations/n_04_to_n_05_postgres_images/postgres/store.go
@@ -720,7 +720,7 @@ func getImageComponentEdges(ctx context.Context, tx *postgres.Tx, imageID string
 		}
 		componentIDToEdgeMap[msg.GetImageComponentId()] = msg
 	}
-	return componentIDToEdgeMap, nil
+	return componentIDToEdgeMap, rows.Err()
 }
 
 func getImageCVEEdgeIDs(ctx context.Context, tx *postgres.Tx, imageID string) (set.StringSet, error) {
@@ -737,7 +737,7 @@ func getImageCVEEdgeIDs(ctx context.Context, tx *postgres.Tx, imageID string) (s
 		}
 		ids.Add(id)
 	}
-	return ids, nil
+	return ids, rows.Err()
 }
 
 func getImageCVEEdges(ctx context.Context, tx *postgres.Tx, imageID string) (map[string]*storage.ImageCVEEdge, error) {
@@ -758,7 +758,7 @@ func getImageCVEEdges(ctx context.Context, tx *postgres.Tx, imageID string) (map
 		}
 		cveIDToEdgeMap[msg.GetImageCveId()] = msg
 	}
-	return cveIDToEdgeMap, nil
+	return cveIDToEdgeMap, rows.Err()
 }
 
 func getImageComponents(ctx context.Context, tx *postgres.Tx, componentIDs []string) (map[string]*storage.ImageComponent, error) {
@@ -779,7 +779,7 @@ func getImageComponents(ctx context.Context, tx *postgres.Tx, componentIDs []str
 		}
 		idToComponentMap[msg.GetId()] = msg
 	}
-	return idToComponentMap, nil
+	return idToComponentMap, rows.Err()
 }
 
 func getComponentCVEEdges(ctx context.Context, tx *postgres.Tx, componentIDs []string) (map[string][]*storage.ComponentCVEEdge, error) {
@@ -800,7 +800,7 @@ func getComponentCVEEdges(ctx context.Context, tx *postgres.Tx, componentIDs []s
 		}
 		componentIDToEdgeMap[msg.GetImageComponentId()] = append(componentIDToEdgeMap[msg.GetImageComponentId()], msg)
 	}
-	return componentIDToEdgeMap, nil
+	return componentIDToEdgeMap, rows.Err()
 }
 
 func getCVEs(ctx context.Context, tx *postgres.Tx, cveIDs []string) (map[string]*storage.ImageCVE, error) {
@@ -821,7 +821,7 @@ func getCVEs(ctx context.Context, tx *postgres.Tx, cveIDs []string) (map[string]
 		}
 		idToCVEMap[msg.GetId()] = msg
 	}
-	return idToCVEMap, nil
+	return idToCVEMap, rows.Err()
 }
 
 // GetIDs returns all the IDs for the store
@@ -845,7 +845,7 @@ func (s *storeImpl) retryableGetIDs(ctx context.Context) ([]string, error) {
 		}
 		ids = append(ids, id)
 	}
-	return ids, nil
+	return ids, rows.Err()
 }
 
 // GetMany returns the objects specified by the IDs or the index in the missing indices slice

--- a/migrator/migrations/n_30_to_n_31_postgres_network_flows/postgres/flow_impl.go
+++ b/migrator/migrations/n_30_to_n_31_postgres_network_flows/postgres/flow_impl.go
@@ -343,7 +343,7 @@ func (s *flowStoreImpl) Walk(ctx context.Context, fn func(obj *storage.NetworkFl
 			return err
 		}
 	}
-	return nil
+	return rows.Err()
 }
 
 // RemoveFlowsForDeployment removes all flows where the source OR destination match the deployment id
@@ -408,7 +408,7 @@ func (s *flowStoreImpl) retryableGetAllFlows(ctx context.Context, since *types.T
 		return nil, nil, pgutils.ErrNilIfNoRows(err)
 	}
 
-	return flows, lastUpdateTS, nil
+	return flows, lastUpdateTS, rows.Err()
 }
 
 // GetMatchingFlows iterates over all of the objects in the store and applies the closure
@@ -438,6 +438,9 @@ func (s *flowStoreImpl) retryableGetMatchingFlows(ctx context.Context, pred func
 	defer rows.Close()
 
 	flows, err := s.readRows(rows, pred)
+	if err != nil {
+		return nil, nil, err
+	}
 
-	return flows, lastUpdateTS, err
+	return flows, lastUpdateTS, rows.Err()
 }

--- a/migrator/migrations/n_35_to_n_36_postgres_nodes/postgres/store_impl.go
+++ b/migrator/migrations/n_35_to_n_36_postgres_nodes/postgres/store_impl.go
@@ -663,7 +663,7 @@ func getNodeComponentEdges(ctx context.Context, tx *postgres.Tx, nodeID string) 
 		}
 		componentIDToEdgeMap[msg.GetNodeComponentId()] = msg
 	}
-	return componentIDToEdgeMap, nil
+	return componentIDToEdgeMap, rows.Err()
 }
 
 func getNodeComponents(ctx context.Context, tx *postgres.Tx, componentIDs []string) (map[string]*storage.NodeComponent, error) {
@@ -684,7 +684,7 @@ func getNodeComponents(ctx context.Context, tx *postgres.Tx, componentIDs []stri
 		}
 		idToComponentMap[msg.GetId()] = msg
 	}
-	return idToComponentMap, nil
+	return idToComponentMap, rows.Err()
 }
 
 func getComponentCVEEdges(ctx context.Context, tx *postgres.Tx, componentIDs []string) (map[string][]*storage.NodeComponentCVEEdge, error) {
@@ -705,7 +705,7 @@ func getComponentCVEEdges(ctx context.Context, tx *postgres.Tx, componentIDs []s
 		}
 		componentIDToEdgesMap[msg.GetNodeComponentId()] = append(componentIDToEdgesMap[msg.GetNodeComponentId()], msg)
 	}
-	return componentIDToEdgesMap, nil
+	return componentIDToEdgesMap, rows.Err()
 }
 
 func (s *storeImpl) acquireConn(ctx context.Context) (*postgres.Conn, func(), error) {
@@ -755,5 +755,5 @@ func getCVEs(ctx context.Context, tx *postgres.Tx, cveIDs []string) (map[string]
 		}
 		idToCVEMap[msg.GetId()] = msg
 	}
-	return idToCVEMap, nil
+	return idToCVEMap, rows.Err()
 }

--- a/pkg/postgres/pgadmin/admin_utils.go
+++ b/pkg/postgres/pgadmin/admin_utils.go
@@ -322,6 +322,7 @@ func getAvailablePostgresCapacity(postgresConfig *postgres.Config) (int64, error
 		}
 		return 0, err
 	}
+	defer rows.Close()
 
 	for rows.Next() {
 		var info string
@@ -363,7 +364,7 @@ func getAvailablePostgresCapacity(postgresConfig *postgres.Config) (int64, error
 		return 0, err
 	}
 
-	return availableCapacity, nil
+	return availableCapacity, rows.Err()
 }
 
 // GetRemainingCapacity - retrieves the amount of space left in Postgres

--- a/pkg/search/postgres/common.go
+++ b/pkg/search/postgres/common.go
@@ -762,6 +762,10 @@ func (t *tracedRows) CommandTag() pgconn.CommandTag {
 	return t.Rows.CommandTag()
 }
 
+func (t *tracedRows) Err() error {
+	return t.Rows.Err()
+}
+
 func tracedQuery(ctx context.Context, pool *postgres.DB, sql string, args ...interface{}) (*tracedRows, error) {
 	t := time.Now()
 	rows, err := pool.Query(ctx, sql, args...)
@@ -862,7 +866,7 @@ func retryableRunSearchRequestForSchema(ctx context.Context, query *query, schem
 		}
 		searchResults[idx] = result
 	}
-	return searchResults, nil
+	return searchResults, rows.Err()
 }
 
 func retryableRunSelectRequestForSchema[T any](ctx context.Context, db *postgres.DB, query *query) ([]*T, error) {
@@ -882,7 +886,7 @@ func retryableRunSelectRequestForSchema[T any](ctx context.Context, db *postgres
 	if err := pgxscan.ScanAll(&scannedRows, rows); err != nil {
 		return nil, err
 	}
-	return scannedRows, nil
+	return scannedRows, rows.Err()
 }
 
 // RunSearchRequestForSchema executes a request against the database for given schema
@@ -1012,7 +1016,12 @@ func retryableRunGetManyQueryForSchema[T any, PT unmarshaler[T]](ctx context.Con
 	}
 	defer rows.Close()
 
-	return scanRows[T, PT](rows)
+	results, err := scanRows[T, PT](rows)
+	if err != nil {
+		return nil, err
+	}
+
+	return results, rows.Err()
 }
 
 // RunGetManyQueryForSchema executes a request for just the search against the database and unmarshal it to given type.
@@ -1071,7 +1080,12 @@ func RunCursorQueryForSchema[T any, PT unmarshaler[T]](ctx context.Context, sche
 		}
 		defer rows.Close()
 
-		return scanRows[T, PT](rows)
+		results, err := scanRows[T, PT](rows)
+		if err != nil {
+			return nil, err
+		}
+
+		return results, rows.Err()
 	}, closer, nil
 }
 


### PR DESCRIPTION
## Description

Errors occurring during the execution of a query launched by the pgx`Query` function were not being returned.  The call to `Query` will return an error if it cannot execute the query at all BUT it will not if there is an error in the processing of the query.  Such as a math function that results in division by 0 or a timeout, those errors will not be returned in the call to `Query`.  In order to get those errors we have to check `rows.Err()` AFTER the rows are closed.  I found this running a large migration that migrated nothing because the call to Query silently timed out because we were not checking `rows.Err()`.  in this instance it simply returned 0 rows and no error.  So these updates are to use/return `rows.Err()` so that we are aware of errors that occurred during query execution.

For reference: https://pkg.go.dev/github.com/jackc/pgx/v4#Conn.Query

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

CI should tell us what we need to know.
