### PR TITLE
ROX-15406: Do not show filter tool bar when there is no cluster/namespace is selected

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
@@ -264,58 +264,65 @@ function NetworkGraphPage() {
                 </Toolbar>
             </PageSection>
             <Divider component="div" />
-            <PageSection variant="light" padding={{ default: 'noPadding' }}>
-                <Toolbar data-testid="network-graph-toolbar">
-                    <ToolbarContent>
-                        <ToolbarGroup variant="filter-group">
-                            <ToolbarItem>
-                                <EdgeStateSelect
-                                    edgeState={edgeState}
-                                    setEdgeState={setEdgeState}
-                                    isDisabled={!hasClusterNamespaceSelected}
-                                />
-                            </ToolbarItem>
-                            <ToolbarItem>
-                                <TimeWindowSelector
-                                    activeTimeWindow={timeWindow}
-                                    setActiveTimeWindow={setTimeWindow}
-                                    isDisabled={isLoading || !hasClusterNamespaceSelected}
-                                />
-                            </ToolbarItem>
-                        </ToolbarGroup>
-                        <Divider orientation={{ default: 'vertical' }} />
-                        <ToolbarGroup className="pf-u-flex-grow-1">
-                            <ToolbarItem className="pf-u-flex-grow-1">
-                                <NetworkSearch
-                                    selectedCluster={clusterFromUrl}
-                                    selectedNamespaces={namespacesFromUrl}
-                                    selectedDeployments={deploymentsFromUrl}
-                                    isDisabled={!hasClusterNamespaceSelected}
-                                />
-                            </ToolbarItem>
-                            <ToolbarItem>
-                                <DisplayOptionsSelect
-                                    selectedOptions={displayOptions}
-                                    setSelectedOptions={setDisplayOptions}
-                                    isDisabled={!hasClusterNamespaceSelected}
-                                />
-                            </ToolbarItem>
-                        </ToolbarGroup>
-                        <ToolbarGroup alignment={{ default: 'alignRight' }}>
-                            <Divider component="div" orientation={{ default: 'vertical' }} />
-                            <ToolbarItem className="pf-u-color-200">
-                                <NodeUpdateSection
-                                    isLoading={isLoading}
-                                    lastUpdatedTime={lastUpdatedTime}
-                                    nodeUpdatesCount={nodeUpdatesCount}
-                                    updateNetworkNodes={updateNetworkNodes}
-                                />
-                            </ToolbarItem>
-                        </ToolbarGroup>
-                    </ToolbarContent>
-                </Toolbar>
-            </PageSection>
-            <Divider component="div" />
+            {hasClusterNamespaceSelected && (
+                <>
+                    <PageSection variant="light" padding={{ default: 'noPadding' }}>
+                        <Toolbar data-testid="network-graph-toolbar">
+                            <ToolbarContent>
+                                <ToolbarGroup variant="filter-group">
+                                    <ToolbarItem>
+                                        <EdgeStateSelect
+                                            edgeState={edgeState}
+                                            setEdgeState={setEdgeState}
+                                            isDisabled={!hasClusterNamespaceSelected}
+                                        />
+                                    </ToolbarItem>
+                                    <ToolbarItem>
+                                        <TimeWindowSelector
+                                            activeTimeWindow={timeWindow}
+                                            setActiveTimeWindow={setTimeWindow}
+                                            isDisabled={isLoading || !hasClusterNamespaceSelected}
+                                        />
+                                    </ToolbarItem>
+                                </ToolbarGroup>
+                                <Divider orientation={{ default: 'vertical' }} />
+                                <ToolbarGroup className="pf-u-flex-grow-1">
+                                    <ToolbarItem className="pf-u-flex-grow-1">
+                                        <NetworkSearch
+                                            selectedCluster={clusterFromUrl}
+                                            selectedNamespaces={namespacesFromUrl}
+                                            selectedDeployments={deploymentsFromUrl}
+                                            isDisabled={!hasClusterNamespaceSelected}
+                                        />
+                                    </ToolbarItem>
+                                    <ToolbarItem>
+                                        <DisplayOptionsSelect
+                                            selectedOptions={displayOptions}
+                                            setSelectedOptions={setDisplayOptions}
+                                            isDisabled={!hasClusterNamespaceSelected}
+                                        />
+                                    </ToolbarItem>
+                                </ToolbarGroup>
+                                <ToolbarGroup alignment={{ default: 'alignRight' }}>
+                                    <Divider
+                                        component="div"
+                                        orientation={{ default: 'vertical' }}
+                                    />
+                                    <ToolbarItem className="pf-u-color-200">
+                                        <NodeUpdateSection
+                                            isLoading={isLoading}
+                                            lastUpdatedTime={lastUpdatedTime}
+                                            nodeUpdatesCount={nodeUpdatesCount}
+                                            updateNetworkNodes={updateNetworkNodes}
+                                        />
+                                    </ToolbarItem>
+                                </ToolbarGroup>
+                            </ToolbarContent>
+                        </Toolbar>
+                    </PageSection>
+                    <Divider component="div" />
+                </>
+            )}
             <PageSection
                 className="network-graph"
                 variant={hasClusterNamespaceSelected ? 'default' : 'light'}


### PR DESCRIPTION
## Description

This PR hides the filters, time window selector, edge state selectors until a cluster and namespace is selected

<img width="1440" alt="Screenshot 2023-03-02 at 12 57 09 PM" src="https://user-images.githubusercontent.com/4805485/222554588-5c9a8e4c-baf2-40cd-97d4-57f4b5b7cdb3.png">


## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~