### PR TITLE
[VM2.0][ROX-13854] GraphQL resolver for resource count by cve severity

### DIFF
--- a/central/graphql/resolvers/image_cve_core.go
+++ b/central/graphql/resolvers/image_cve_core.go
@@ -20,7 +20,7 @@ func init() {
 		schema.AddType("ImageCVECore",
 			[]string{
 				"affectedImages: Int!",
-
+				"affectedImagesBySeverity: ResourceCountByCVESeverity",
 				"cve: String!",
 				"firstDiscoveredInSystem: Time",
 				"topCVSS: Float!",
@@ -94,16 +94,20 @@ func (resolver *imageCVECoreResolver) AffectedImages(_ context.Context) int32 {
 	return int32(resolver.data.GetAffectedImages())
 }
 
-func (resolver *imageCVECoreResolver) CVE(_ context.Context) string {
-	return resolver.data.GetCVE()
+func (resolver *imageCVECoreResolver) AffectedImagesBySeverity(ctx context.Context) (*resourceCountBySeverityResolver, error) {
+	return resolver.root.wrapResourceCountByCVESeverityWithContext(ctx, resolver.data.GetImagesBySeverity(), nil)
 }
 
-func (resolver *imageCVECoreResolver) TopCVSS(_ context.Context) float64 {
-	return float64(resolver.data.GetTopCVSS())
+func (resolver *imageCVECoreResolver) CVE(_ context.Context) string {
+	return resolver.data.GetCVE()
 }
 
 func (resolver *imageCVECoreResolver) FirstDiscoveredInSystem(_ context.Context) *graphql.Time {
 	return &graphql.Time{
 		Time: resolver.data.GetFirstDiscoveredInSystem(),
 	}
+}
+
+func (resolver *imageCVECoreResolver) TopCVSS(_ context.Context) float64 {
+	return float64(resolver.data.GetTopCVSS())
 }

--- a/central/graphql/resolvers/resource_count_by_severity.go
+++ b/central/graphql/resolvers/resource_count_by_severity.go
@@ -1,0 +1,53 @@
+package resolvers
+
+import (
+	"context"
+
+	"github.com/stackrox/rox/central/views/imagecve"
+	"github.com/stackrox/rox/pkg/utils"
+)
+
+func init() {
+	schema := getBuilder()
+	utils.Must(
+		schema.AddType("ResourceCountByCVESeverity", []string{
+			"critical: Int!",
+			"important: Int!",
+			"moderate: Int!",
+			"low: Int!",
+		}),
+	)
+}
+
+type resourceCountBySeverityResolver struct {
+	ctx  context.Context
+	root *Resolver
+	data *imagecve.ResourceCountByCVESeverity
+}
+
+func (resolver *Resolver) wrapResourceCountByCVESeverityWithContext(ctx context.Context, value *imagecve.ResourceCountByCVESeverity, err error) (*resourceCountBySeverityResolver, error) {
+	if err != nil || value == nil {
+		return nil, err
+	}
+	return &resourceCountBySeverityResolver{ctx: ctx, root: resolver, data: value}, nil
+}
+
+// Critical returns the number of resource with low CVE impact.
+func (resolver *resourceCountBySeverityResolver) Critical(_ context.Context) int {
+	return resolver.data.CriticalSeverityCount
+}
+
+// Important returns the number of resource with important CVE impact.
+func (resolver *resourceCountBySeverityResolver) Important(_ context.Context) int {
+	return resolver.data.ImportantSeverityCount
+}
+
+// Moderate returns the number of resource with moderate CVE impact.
+func (resolver *resourceCountBySeverityResolver) Moderate(_ context.Context) int {
+	return resolver.data.ModerateSeverityCount
+}
+
+// Low returns the number of resource with low CVE impact.
+func (resolver *resourceCountBySeverityResolver) Low(_ context.Context) int {
+	return resolver.data.LowSeverityCount
+}

--- a/central/graphql/resolvers/resource_count_by_severity.go
+++ b/central/graphql/resolvers/resource_count_by_severity.go
@@ -26,28 +26,31 @@ type resourceCountBySeverityResolver struct {
 }
 
 func (resolver *Resolver) wrapResourceCountByCVESeverityWithContext(ctx context.Context, value *imagecve.ResourceCountByCVESeverity, err error) (*resourceCountBySeverityResolver, error) {
-	if err != nil || value == nil {
+	if err != nil {
 		return nil, err
+	}
+	if value == nil {
+		value = &imagecve.ResourceCountByCVESeverity{}
 	}
 	return &resourceCountBySeverityResolver{ctx: ctx, root: resolver, data: value}, nil
 }
 
 // Critical returns the number of resource with low CVE impact.
-func (resolver *resourceCountBySeverityResolver) Critical(_ context.Context) int {
-	return resolver.data.CriticalSeverityCount
+func (resolver *resourceCountBySeverityResolver) Critical(_ context.Context) int32 {
+	return int32(resolver.data.CriticalSeverityCount)
 }
 
 // Important returns the number of resource with important CVE impact.
-func (resolver *resourceCountBySeverityResolver) Important(_ context.Context) int {
-	return resolver.data.ImportantSeverityCount
+func (resolver *resourceCountBySeverityResolver) Important(_ context.Context) int32 {
+	return int32(resolver.data.ImportantSeverityCount)
 }
 
 // Moderate returns the number of resource with moderate CVE impact.
-func (resolver *resourceCountBySeverityResolver) Moderate(_ context.Context) int {
-	return resolver.data.ModerateSeverityCount
+func (resolver *resourceCountBySeverityResolver) Moderate(_ context.Context) int32 {
+	return int32(resolver.data.ModerateSeverityCount)
 }
 
 // Low returns the number of resource with low CVE impact.
-func (resolver *resourceCountBySeverityResolver) Low(_ context.Context) int {
-	return resolver.data.LowSeverityCount
+func (resolver *resourceCountBySeverityResolver) Low(_ context.Context) int32 {
+	return int32(resolver.data.LowSeverityCount)
 }

--- a/central/views/imagecve/image_cve.go
+++ b/central/views/imagecve/image_cve.go
@@ -5,14 +5,27 @@ import (
 )
 
 type imageCVECore struct {
-	CVE                     string    `db:"cve"`
-	TopCVSS                 float32   `db:"cvss_max"`
-	AffectedImages          int       `db:"image_sha_count"`
-	FirstDiscoveredInSystem time.Time `db:"cve_created_time_min"`
+	CVE                         string    `db:"cve"`
+	ImagesWithCriticalSeverity  int       `db:"images_with_critical_severity"`
+	ImagesWithImportantSeverity int       `db:"images_with_important_severity"`
+	ImagesWithModerateSeverity  int       `db:"images_with_moderate_severity"`
+	ImagesWithLowSeverity       int       `db:"images_with_low_severity"`
+	TopCVSS                     float32   `db:"cvss_max"`
+	AffectedImages              int       `db:"image_sha_count"`
+	FirstDiscoveredInSystem     time.Time `db:"cve_created_time_min"`
 }
 
 func (c *imageCVECore) GetCVE() string {
 	return c.CVE
+}
+
+func (c *imageCVECore) GetImagesBySeverity() *ResourceCountByCVESeverity {
+	return &ResourceCountByCVESeverity{
+		CriticalSeverityCount:  c.ImagesWithCriticalSeverity,
+		ImportantSeverityCount: c.ImagesWithImportantSeverity,
+		ModerateSeverityCount:  c.ImagesWithModerateSeverity,
+		LowSeverityCount:       c.ImagesWithLowSeverity,
+	}
 }
 
 func (c *imageCVECore) GetTopCVSS() float32 {

--- a/central/views/imagecve/mocks/types.go
+++ b/central/views/imagecve/mocks/types.go
@@ -79,6 +79,20 @@ func (mr *MockCveCoreMockRecorder) GetFirstDiscoveredInSystem() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFirstDiscoveredInSystem", reflect.TypeOf((*MockCveCore)(nil).GetFirstDiscoveredInSystem))
 }
 
+// GetImagesBySeverity mocks base method.
+func (m *MockCveCore) GetImagesBySeverity() *imagecve.ResourceCountByCVESeverity {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetImagesBySeverity")
+	ret0, _ := ret[0].(*imagecve.ResourceCountByCVESeverity)
+	return ret0
+}
+
+// GetImagesBySeverity indicates an expected call of GetImagesBySeverity.
+func (mr *MockCveCoreMockRecorder) GetImagesBySeverity() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetImagesBySeverity", reflect.TypeOf((*MockCveCore)(nil).GetImagesBySeverity))
+}
+
 // GetTopCVSS mocks base method.
 func (m *MockCveCore) GetTopCVSS() float32 {
 	m.ctrl.T.Helper()

--- a/central/views/imagecve/types.go
+++ b/central/views/imagecve/types.go
@@ -29,6 +29,7 @@ type CveView interface {
 	Get(ctx context.Context, q *v1.Query) ([]CveCore, error)
 }
 
+// ResourceCountByCVESeverity is the count of resources affected by cve distributed over severity.
 type ResourceCountByCVESeverity struct {
 	CriticalSeverityCount  int
 	ImportantSeverityCount int

--- a/central/views/imagecve/types.go
+++ b/central/views/imagecve/types.go
@@ -12,6 +12,7 @@ import (
 //go:generate mockgen-wrapper
 type CveCore interface {
 	GetCVE() string
+	GetImagesBySeverity() *ResourceCountByCVESeverity
 	GetTopCVSS() float32
 	GetAffectedImages() int
 	GetFirstDiscoveredInSystem() time.Time
@@ -26,4 +27,11 @@ type CveCore interface {
 type CveView interface {
 	Count(ctx context.Context, q *v1.Query) (int, error)
 	Get(ctx context.Context, q *v1.Query) ([]CveCore, error)
+}
+
+type ResourceCountByCVESeverity struct {
+	CriticalSeverityCount  int
+	ImportantSeverityCount int
+	ModerateSeverityCount  int
+	LowSeverityCount       int
 }

--- a/central/views/imagecve/view_impl.go
+++ b/central/views/imagecve/view_impl.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/pkg/errors"
 	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
 	"github.com/stackrox/rox/pkg/search"
@@ -66,6 +67,42 @@ func withSelectQuery(q *v1.Query) *v1.Query {
 	cloned := q.Clone()
 	cloned.Selects = []*v1.QuerySelect{
 		search.NewQuerySelect(search.CVE).Proto(),
+		search.NewQuerySelect(search.ImageSHA).
+			AggrFunc(aggregatefunc.Count).
+			Filter("images_with_critical_severity",
+				search.NewQueryBuilder().
+					AddExactMatches(
+						search.Severity,
+						storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY.String(),
+					).ProtoQuery(),
+			).Proto(),
+		search.NewQuerySelect(search.ImageSHA).
+			AggrFunc(aggregatefunc.Count).
+			Filter("images_with_important_severity",
+				search.NewQueryBuilder().
+					AddExactMatches(
+						search.Severity,
+						storage.VulnerabilitySeverity_IMPORTANT_VULNERABILITY_SEVERITY.String(),
+					).ProtoQuery(),
+			).Proto(),
+		search.NewQuerySelect(search.ImageSHA).
+			AggrFunc(aggregatefunc.Count).
+			Filter("images_with_moderate_severity",
+				search.NewQueryBuilder().
+					AddExactMatches(
+						search.Severity,
+						storage.VulnerabilitySeverity_MODERATE_VULNERABILITY_SEVERITY.String(),
+					).ProtoQuery(),
+			).Proto(),
+		search.NewQuerySelect(search.ImageSHA).
+			AggrFunc(aggregatefunc.Count).
+			Filter("images_with_low_severity",
+				search.NewQueryBuilder().
+					AddExactMatches(
+						search.Severity,
+						storage.VulnerabilitySeverity_LOW_VULNERABILITY_SEVERITY.String(),
+					).ProtoQuery(),
+			).Proto(),
 		search.NewQuerySelect(search.CVSS).AggrFunc(aggregatefunc.Max).Proto(),
 		search.NewQuerySelect(search.ImageSHA).AggrFunc(aggregatefunc.Count).Proto(),
 		search.NewQuerySelect(search.CVECreatedTime).AggrFunc(aggregatefunc.Min).Proto(),

--- a/central/views/imagecve/view_test.go
+++ b/central/views/imagecve/view_test.go
@@ -302,6 +302,17 @@ func compileExpected(images []*storage.Image, filter *filterImpl) []*imageCVECor
 
 				if seenForImage.Add(val.CVE) {
 					val.AffectedImages++
+
+					switch vuln.GetSeverity() {
+					case storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY:
+						val.ImagesWithCriticalSeverity++
+					case storage.VulnerabilitySeverity_IMPORTANT_VULNERABILITY_SEVERITY:
+						val.ImagesWithImportantSeverity++
+					case storage.VulnerabilitySeverity_MODERATE_VULNERABILITY_SEVERITY:
+						val.ImagesWithModerateSeverity++
+					case storage.VulnerabilitySeverity_LOW_VULNERABILITY_SEVERITY:
+						val.ImagesWithLowSeverity++
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## Description

- Added a generic resource count by severity resolver
- Added `affectedImagesBySeverity` field to cve list resolver

## Checklist
- [ ] Investigated and inspected CI test results
- [X] Unit test and regression tests added
- ~Evaluated and added CHANGELOG entry if required~
- ~Determined and documented upgrade steps~
- ~Documented user facing changes~

If any of these don't apply, please comment below.

## Testing Performed

<img width="1080" alt="image" src="https://user-images.githubusercontent.com/9895898/222814012-509f5054-aabc-420a-b3a4-8e1a6ac91136.png">
