### PR TITLE
ROX-7026: `@CompileStatic` some files related to `AdmissionControllerTest`

### DIFF
--- a/qa-tests-backend/src/main/groovy/common/Constants.groovy
+++ b/qa-tests-backend/src/main/groovy/common/Constants.groovy
@@ -1,18 +1,18 @@
 package common
 
 class Constants {
-    static final ORCHESTRATOR_NAMESPACE = "qa"
-    static final STACKROX_NAMESPACE = "stackrox"
-    static final SCHEDULES_SUPPORTED = false
-    static final CHECK_CVES_IN_COMPLIANCE = false
-    static final RUN_FLAKEY_TESTS = false
-    static final EMAIL_NOTIFER_FROM = "stackrox"
-    static final EMAIL_NOTIFER_SENDER = "${UUID.randomUUID()}@stackrox.com"
-    static final EMAIL_NOTIFER_FULL_FROM = "${EMAIL_NOTIFER_FROM} <${EMAIL_NOTIFER_SENDER}>"
-    static final EMAIL_NOTIFIER_RECIPIENT = "stackrox.qa@gmail.com"
+    static final String ORCHESTRATOR_NAMESPACE = "qa"
+    static final String STACKROX_NAMESPACE = "stackrox"
+    static final boolean SCHEDULES_SUPPORTED = false
+    static final boolean CHECK_CVES_IN_COMPLIANCE = false
+    static final boolean RUN_FLAKEY_TESTS = false
+    static final String EMAIL_NOTIFER_FROM = "stackrox"
+    static final String EMAIL_NOTIFER_SENDER = "${UUID.randomUUID()}@stackrox.com"
+    static final String EMAIL_NOTIFER_FULL_FROM = "${EMAIL_NOTIFER_FROM} <${EMAIL_NOTIFER_SENDER}>"
+    static final String EMAIL_NOTIFIER_RECIPIENT = "stackrox.qa@gmail.com"
     static final FAILURE_DEBUG_LIMIT = 10
-    static final AUTO_REGISTERED_STACKROX_SCANNER_INTEGRATION = "Stackrox Scanner"
-    static final ANY_FIXED_VULN_POLICY = "any-fixed-vulnerabilities"
+    static final String AUTO_REGISTERED_STACKROX_SCANNER_INTEGRATION = "Stackrox Scanner"
+    static final String ANY_FIXED_VULN_POLICY = "any-fixed-vulnerabilities"
     static final Map<String, String> CSV_COLUMN_MAPPING = [
             "Standard" : "standard",
             "Cluster" : "cluster",

--- a/qa-tests-backend/src/main/groovy/objects/K8sRbacObjects.groovy
+++ b/qa-tests-backend/src/main/groovy/objects/K8sRbacObjects.groovy
@@ -11,11 +11,11 @@ class K8sRole {
 }
 
 class K8sPolicyRule {
-    def verbs
-    def apiGroups
-    def resources
-    def nonResourceUrls
-    def resourceNames
+    List<String> verbs
+    List<String> apiGroups
+    List<String> resources
+    List<String> nonResourceUrls
+    List<String> resourceNames
 }
 
 class K8sRoleBinding  {

--- a/qa-tests-backend/src/main/groovy/objects/K8sServiceAccount.groovy
+++ b/qa-tests-backend/src/main/groovy/objects/K8sServiceAccount.groovy
@@ -6,6 +6,6 @@ class K8sServiceAccount {
     Map<String, String> labels = [:]
     Map<String, String> annotations = [:]
     def automountToken
-    def secrets = []
+    List<io.fabric8.kubernetes.api.model.ObjectReference> secrets = []
     String[] imagePullSecrets = []
 }

--- a/qa-tests-backend/src/main/groovy/objects/K8sServiceAccount.groovy
+++ b/qa-tests-backend/src/main/groovy/objects/K8sServiceAccount.groovy
@@ -1,11 +1,13 @@
 package objects
 
+import io.fabric8.kubernetes.api.model.ObjectReference
+
 class K8sServiceAccount {
     String name
     String namespace
     Map<String, String> labels = [:]
     Map<String, String> annotations = [:]
     def automountToken
-    List<io.fabric8.kubernetes.api.model.ObjectReference> secrets = []
+    List<ObjectReference> secrets = []
     String[] imagePullSecrets = []
 }

--- a/qa-tests-backend/src/main/groovy/objects/Notifiers.groovy
+++ b/qa-tests-backend/src/main/groovy/objects/Notifiers.groovy
@@ -1,5 +1,7 @@
 package objects
 
+import static util.Helpers.withRetry
+
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
 import groovy.json.JsonSlurper

--- a/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
@@ -109,6 +109,9 @@ import util.Helpers
 import util.Timer
 import util.Env
 
+import static Helpers.withRetry
+import static Helpers.evaluateWithRetry
+
 @CompileStatic
 @Slf4j
 class Kubernetes implements OrchestratorMain {
@@ -277,7 +280,7 @@ class Kubernetes implements OrchestratorMain {
     List<Pod> getPodsByLabel(String ns, Map<String, String> label) {
         def selector = new LabelSelector()
         selector.matchLabels = label
-        PodList list = Helpers.evaluateWithRetry(null, 2, 3) {
+        PodList list = evaluateWithRetry(null, 2, 3) {
             return client.pods().inNamespace(ns).withLabelSelector(selector).list()
         }
         return list.getItems()
@@ -299,11 +302,11 @@ class Kubernetes implements OrchestratorMain {
     void deleteAllPodsAndWait(String ns, Map<String, String> labels) {
         log.debug "Will delete all pods in ${ns} with labels ${labels} and wait for deletion"
 
-        List<Pod> beforePods = Helpers.evaluateWithRetry(null, 2, 3) {
+        List<Pod> beforePods = evaluateWithRetry(null, 2, 3) {
             client.pods().inNamespace(ns).withLabels(labels).list().getItems()
         }
         beforePods.each { pod ->
-            Helpers.evaluateWithRetry(null, 2, 3) {
+            evaluateWithRetry(null, 2, 3) {
                 client.pods().inNamespace(ns).withName(pod.metadata.name).delete()
             }
         }
@@ -313,7 +316,7 @@ class Kubernetes implements OrchestratorMain {
         while (!allDeleted && t.IsValid()) {
             allDeleted = true
             beforePods.each { deleted ->
-                Pod pod = Helpers.evaluateWithRetry(null, 2, 3) {
+                Pod pod = evaluateWithRetry(null, 2, 3) {
                     client.pods().inNamespace(ns).withName(deleted.metadata.name).get()
                 }
                 if (pod == null) {
@@ -512,7 +515,7 @@ class Kubernetes implements OrchestratorMain {
     }
 
     List<String> getDeployments(String ns) {
-        return Helpers.evaluateWithRetry(null, 2, 3) {
+        return evaluateWithRetry(null, 2, 3) {
             this.deployments.inNamespace(ns).list().getItems().collect { it.metadata.name }
         }
     }
@@ -747,7 +750,7 @@ class Kubernetes implements OrchestratorMain {
     */
 
     def deleteContainer(String containerName, String namespace = this.namespace) {
-        Helpers.withRetry(null, 2, 3) {
+        withRetry(null, 2, 3) {
             client.pods().inNamespace(namespace).withName(containerName).delete()
         }
     }
@@ -777,7 +780,7 @@ class Kubernetes implements OrchestratorMain {
     }
 
     def isKubeDashboardRunning() {
-        return Helpers.evaluateWithRetry(null, 2, 3) {
+        return evaluateWithRetry(null, 2, 3) {
             PodList pods = client.pods().inAnyNamespace().list()
             List<Pod> kubeDashboards = pods.getItems().findAll {
                 it.getSpec().getContainers().find {
@@ -793,7 +796,7 @@ class Kubernetes implements OrchestratorMain {
     }
 
     Set<String> getStaticPodCount(String ns = null) {
-        return Helpers.evaluateWithRetry(null, 2, 3) {
+        return evaluateWithRetry(null, 2, 3) {
             // This method assumes that a static pod name will contain the node name that the pod is running on
             def nodeNames = client.nodes().list().items.collect { it.metadata.name }
             Set<String> staticPods = [] as Set
@@ -814,7 +817,7 @@ class Kubernetes implements OrchestratorMain {
     */
 
     def createService(Deployment deployment) {
-        Helpers.withRetry(null, 2, 3) {
+        withRetry(null, 2, 3) {
             Service service = new Service(
                     metadata: new ObjectMeta(
                             name: deployment.serviceName ? deployment.serviceName : deployment.name,
@@ -850,7 +853,7 @@ class Kubernetes implements OrchestratorMain {
     }
 
     def createService(objects.Service s) {
-        Helpers.withRetry(null, 2, 3) {
+        withRetry(null, 2, 3) {
             Service service = new Service(
                     metadata: new ObjectMeta(
                             name: s.name,
@@ -890,7 +893,7 @@ class Kubernetes implements OrchestratorMain {
     }
 
     def deleteService(String name, String namespace = this.namespace) {
-        Helpers.withRetry(null, 2, 3) {
+        withRetry(null, 2, 3) {
             log.debug "${name}: Service deleting..."
             client.services().inNamespace(namespace).withName(name).delete()
         }
@@ -922,7 +925,7 @@ class Kubernetes implements OrchestratorMain {
     def addOrUpdateServiceLabel(String serviceName, String ns, String name, String value) {
         Map<String, String> label = [:]
         label.put(name, value)
-        Helpers.evaluateWithRetry(null, 2, 3) {
+        evaluateWithRetry(null, 2, 3) {
             client.services().inNamespace(ns).withName(serviceName).edit {
                 s ->
                     new ServiceBuilder(s).editMetadata().addToLabels(label).endMetadata().build()
@@ -1053,7 +1056,7 @@ class Kubernetes implements OrchestratorMain {
     }
 
     String createSecret(String name, String namespace = this.namespace) {
-        return Helpers.evaluateWithRetry(null, 2, 3) {
+        return evaluateWithRetry(null, 2, 3) {
             Map<String, String> data = new HashMap<String, String>()
             data.put("username", "YWRtaW4=")
             data.put("password", "MWYyZDFlMmU2N2Rm")
@@ -1082,13 +1085,13 @@ class Kubernetes implements OrchestratorMain {
     }
 
     def updateSecret(K8sSecret secret) {
-        Helpers.withRetry(null, 2, 3) {
+        withRetry(null, 2, 3) {
             client.secrets().inNamespace(secret.metadata.namespace).createOrReplace(secret)
         }
     }
 
     def deleteSecret(String name, String namespace = this.namespace) {
-        Helpers.withRetry(null, 2, 3) {
+        withRetry(null, 2, 3) {
             client.secrets().inNamespace(namespace).withName(name).delete()
         }
         sleep(sleepDurationSeconds * 1000)
@@ -1096,7 +1099,7 @@ class Kubernetes implements OrchestratorMain {
     }
 
     int getSecretCount(String ns) {
-        return Helpers.evaluateWithRetry(null, 2, 3) {
+        return evaluateWithRetry(null, 2, 3) {
             return client.secrets().inNamespace(ns).list().getItems().findAll {
                 !it.type.startsWith("kubernetes.io/service-account-token")
             }.size()
@@ -1104,7 +1107,7 @@ class Kubernetes implements OrchestratorMain {
     }
 
     int getSecretCount() {
-        return Helpers.evaluateWithRetry(null, 2, 3) {
+        return evaluateWithRetry(null, 2, 3) {
             return client.secrets().list().getItems().findAll {
                 !it.type.startsWith("kubernetes.io/service-account-token")
             }.size()
@@ -1112,7 +1115,7 @@ class Kubernetes implements OrchestratorMain {
     }
 
     K8sSecret getSecret(String name, String namespace) {
-        return Helpers.evaluateWithRetry(null, 2, 3) {
+        return evaluateWithRetry(null, 2, 3) {
             return client.secrets().inNamespace(namespace).withName(name).get()
         }
     }
@@ -1122,7 +1125,7 @@ class Kubernetes implements OrchestratorMain {
     */
 
     String applyNetworkPolicy(NetworkPolicy policy) {
-        return Helpers.evaluateWithRetry(null, 2, 3) {
+        return evaluateWithRetry(null, 2, 3) {
             io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicy networkPolicy =
                     createNetworkPolicyObject(policy)
 
@@ -1139,7 +1142,7 @@ class Kubernetes implements OrchestratorMain {
     }
 
     boolean deleteNetworkPolicy(NetworkPolicy policy) {
-        return Helpers.evaluateWithRetry(null, 2, 3) {
+        return evaluateWithRetry(null, 2, 3) {
             Boolean status = client.network().networkPolicies()
                     .inNamespace(policy.namespace ? policy.namespace : this.namespace)
                     .withName(policy.name)
@@ -1154,13 +1157,13 @@ class Kubernetes implements OrchestratorMain {
     }
 
     def getNetworkPolicyCount(String ns) {
-        return Helpers.evaluateWithRetry(null, 2, 3) {
+        return evaluateWithRetry(null, 2, 3) {
             return client.network().networkPolicies().inNamespace(ns).list().items.size()
         }
     }
 
     def getAllNetworkPoliciesNamesByNamespace(Boolean ignoreUndoneStackroxGenerated = false) {
-        return Helpers.evaluateWithRetry(null, 2, 3) {
+        return evaluateWithRetry(null, 2, 3) {
             Map<String, List<String>> networkPolicies = [:]
             client.network().networkPolicies().inAnyNamespace().list().items.each {
                 boolean skip = false
@@ -1182,13 +1185,13 @@ class Kubernetes implements OrchestratorMain {
      */
 
     def getNodeCount() {
-        return Helpers.evaluateWithRetry(null, 2, 3) {
+        return evaluateWithRetry(null, 2, 3) {
             return client.nodes().list().getItems().size()
         }
     }
 
     List<Node> getNodeDetails() {
-        return Helpers.evaluateWithRetry(null, 2, 3) {
+        return evaluateWithRetry(null, 2, 3) {
             return client.nodes().list().items.collect {
                 new Node(
                         uid: it.metadata.uid,
@@ -1208,7 +1211,7 @@ class Kubernetes implements OrchestratorMain {
     }
 
     def isGKE() {
-        return Helpers.evaluateWithRetry(null, 2, 3) {
+        return evaluateWithRetry(null, 2, 3) {
             List<Node> gkeNodes = client.nodes().list().getItems().findAll {
                 it.getStatus().getNodeInfo().getKubeletVersion().contains("gke")
             } as List<Node>
@@ -1221,7 +1224,7 @@ class Kubernetes implements OrchestratorMain {
      */
 
     List<objects.Namespace> getNamespaceDetails() {
-        return Helpers.evaluateWithRetry(null, 2, 3) {
+        return evaluateWithRetry(null, 2, 3) {
             return client.namespaces().list().items.collect {
                 new objects.Namespace(
                         uid: it.metadata.uid,
@@ -1248,7 +1251,7 @@ class Kubernetes implements OrchestratorMain {
     }
 
     List<String> getNamespaces() {
-        return Helpers.evaluateWithRetry(null, 2, 3) {
+        return evaluateWithRetry(null, 2, 3) {
             return client.namespaces().list().items.collect {
                 it.metadata.name
             }
@@ -1260,7 +1263,7 @@ class Kubernetes implements OrchestratorMain {
      */
 
     List<K8sServiceAccount> getServiceAccounts() {
-        return Helpers.evaluateWithRetry(null, 1, 2) {
+        return evaluateWithRetry(null, 1, 2) {
             List<K8sServiceAccount> serviceAccounts = []
             client.serviceAccounts().inAnyNamespace().list().items.each {
                 // Ingest the K8s service account to a K8sServiceAccount() in a manner similar to the SR product.
@@ -1284,7 +1287,7 @@ class Kubernetes implements OrchestratorMain {
     }
 
     def createServiceAccount(K8sServiceAccount serviceAccount) {
-        Helpers.withRetry(null, 1, 2) {
+        withRetry(null, 1, 2) {
             ServiceAccount sa = new ServiceAccount(
                     metadata: new ObjectMeta(
                             name: serviceAccount.name,
@@ -1301,13 +1304,13 @@ class Kubernetes implements OrchestratorMain {
     }
 
     def deleteServiceAccount(K8sServiceAccount serviceAccount) {
-        Helpers.withRetry(null, 1, 2) {
+        withRetry(null, 1, 2) {
             client.serviceAccounts().inNamespace(serviceAccount.namespace).withName(serviceAccount.name).delete()
         }
     }
 
     def addServiceAccountImagePullSecret(String accountName, String secretName, String namespace = this.namespace) {
-        Helpers.withRetry(null, 1, 2) {
+        withRetry(null, 1, 2) {
             ServiceAccount serviceAccount = client.serviceAccounts()
                     .inNamespace(namespace)
                     .withName(accountName)
@@ -1390,7 +1393,7 @@ class Kubernetes implements OrchestratorMain {
      */
 
     List<K8sRole> getRoles() {
-        return Helpers.evaluateWithRetry(null, 1, 2) {
+        return evaluateWithRetry(null, 1, 2) {
             List<K8sRole> roles = []
             client.rbac().roles().inAnyNamespace().list().items.each {
                 roles.add(new K8sRole(
@@ -1415,7 +1418,7 @@ class Kubernetes implements OrchestratorMain {
     }
 
     def createRole(K8sRole role) {
-        Helpers.withRetry(null, 1, 2) {
+        withRetry(null, 1, 2) {
             Role r = new Role(
                     metadata: new ObjectMeta(
                             name: role.name,
@@ -1438,7 +1441,7 @@ class Kubernetes implements OrchestratorMain {
     }
 
     def deleteRole(K8sRole role) {
-        Helpers.withRetry(null, 1, 2) {
+        withRetry(null, 1, 2) {
             client.rbac().roles().inNamespace(role.namespace).withName(role.name).delete()
         }
     }
@@ -1448,7 +1451,7 @@ class Kubernetes implements OrchestratorMain {
      */
 
     List<K8sRoleBinding> getRoleBindings() {
-        return Helpers.evaluateWithRetry(null, 2, 3) {
+        return evaluateWithRetry(null, 2, 3) {
             List<K8sRoleBinding> bindings = []
             client.rbac().roleBindings().inAnyNamespace().list().items.each {
                 def b = new K8sRoleBinding(
@@ -1476,7 +1479,7 @@ class Kubernetes implements OrchestratorMain {
     }
 
     def createRoleBinding(K8sRoleBinding roleBinding) {
-        Helpers.withRetry(null, 1, 2) {
+        withRetry(null, 1, 2) {
             RoleBinding r = new RoleBinding(
                     metadata: new ObjectMeta(
                             name: roleBinding.name,
@@ -1497,7 +1500,7 @@ class Kubernetes implements OrchestratorMain {
     }
 
     def deleteRoleBinding(K8sRoleBinding roleBinding) {
-        Helpers.withRetry(null, 1, 2) {
+        withRetry(null, 1, 2) {
             client.rbac().roleBindings()
                     .inNamespace(roleBinding.namespace)
                     .withName(roleBinding.name)
@@ -1510,7 +1513,7 @@ class Kubernetes implements OrchestratorMain {
      */
 
     List<K8sRole> getClusterRoles() {
-        return Helpers.evaluateWithRetry(null, 2, 3) {
+        return evaluateWithRetry(null, 2, 3) {
             List<K8sRole> clusterRoles = []
             client.rbac().clusterRoles().list().items.each {
                 clusterRoles.add(new K8sRole(
@@ -1535,7 +1538,7 @@ class Kubernetes implements OrchestratorMain {
     }
 
     def createClusterRole(K8sRole role) {
-        Helpers.withRetry(null, 2, 3) {
+        withRetry(null, 2, 3) {
             ClusterRole r = new ClusterRole(
                     metadata: new ObjectMeta(
                             name: role.name,
@@ -1557,7 +1560,7 @@ class Kubernetes implements OrchestratorMain {
     }
 
     def deleteClusterRole(K8sRole role) {
-        Helpers.withRetry(null, 2, 3) {
+        withRetry(null, 2, 3) {
             client.rbac().clusterRoles().withName(role.name).delete()
         }
     }
@@ -1567,7 +1570,7 @@ class Kubernetes implements OrchestratorMain {
      */
 
     List<K8sRoleBinding> getClusterRoleBindings() {
-        return Helpers.evaluateWithRetry(null, 2, 3) {
+        return evaluateWithRetry(null, 2, 3) {
             List<K8sRoleBinding> clusterBindings = []
             client.rbac().clusterRoleBindings().list().items.each {
                 def b = new K8sRoleBinding(
@@ -1594,7 +1597,7 @@ class Kubernetes implements OrchestratorMain {
     }
 
     def createClusterRoleBinding(K8sRoleBinding roleBinding) {
-        Helpers.withRetry(null, 2, 3) {
+        withRetry(null, 2, 3) {
             ClusterRoleBinding r = new ClusterRoleBinding(
                     metadata: new ObjectMeta(
                             name: roleBinding.name,
@@ -1614,7 +1617,7 @@ class Kubernetes implements OrchestratorMain {
     }
 
     def deleteClusterRoleBinding(K8sRoleBinding roleBinding) {
-        Helpers.withRetry(null, 2, 3) {
+        withRetry(null, 2, 3) {
             client.rbac().clusterRoleBindings().withName(roleBinding.name).delete()
         }
     }
@@ -1683,13 +1686,13 @@ class Kubernetes implements OrchestratorMain {
      */
 
     List<String> getJobCount(String ns) {
-        return Helpers.evaluateWithRetry(null, 2, 3) {
+        return evaluateWithRetry(null, 2, 3) {
             return client.batch().v1().jobs().inNamespace(ns).list().getItems().collect { it.metadata.name }
         }
     }
 
     List<String> getJobCount() {
-        return Helpers.evaluateWithRetry(null, 2, 3) {
+        return evaluateWithRetry(null, 2, 3) {
             return client.batch().v1().jobs().list().getItems().collect { it.metadata.name }
         }
     }
@@ -1722,7 +1725,7 @@ class Kubernetes implements OrchestratorMain {
     }
 
     ConfigMap getConfigMap(String name, String namespace) {
-        return Helpers.evaluateWithRetry(null, 2, 3) {
+        return evaluateWithRetry(null, 2, 3) {
             K8sConfigMap conf = client.configMaps().inNamespace(namespace).withName(name).get()
             return new ConfigMap(
                     name: conf.metadata.name,
@@ -1733,7 +1736,7 @@ class Kubernetes implements OrchestratorMain {
     }
 
     def deleteConfigMap(String name, String namespace) {
-        Helpers.withRetry(null, 2, 3) {
+        withRetry(null, 2, 3) {
             client.configMaps().inNamespace(namespace).withName(name).delete()
         }
         sleep(sleepDurationSeconds * 1000)
@@ -1865,7 +1868,7 @@ class Kubernetes implements OrchestratorMain {
     }
 
     String getSensorContainerName() {
-        return Helpers.evaluateWithRetry(null, 2, 3) {
+        return evaluateWithRetry(null, 2, 3) {
             return client.pods().inNamespace("stackrox").list().items.find {
                 it.metadata.name.startsWith("sensor")
             }.metadata.name
@@ -2228,7 +2231,7 @@ class Kubernetes implements OrchestratorMain {
     def updateDeploymentDetails(Deployment deployment) {
         // Filtering pod query by using the "name=<name>" because it should always be present in the deployment
         // object - IF this is ever missing, it may cause problems fetching pod details
-        def deployedPods = Helpers.evaluateWithRetry(null, 2, 3) {
+        def deployedPods = evaluateWithRetry(null, 2, 3) {
             return client.pods().inNamespace(deployment.namespace).withLabel("name", deployment.name).list()
         }
         for (Pod pod : deployedPods.getItems()) {
@@ -2340,7 +2343,7 @@ class Kubernetes implements OrchestratorMain {
      * Note that createNamespace does not provision service account.
      */
     String createNamespace(String ns) {
-        return Helpers.evaluateWithRetry(null, 2, 3) {
+        return evaluateWithRetry(null, 2, 3) {
             Namespace namespace = newNamespace(ns)
             def namespaceId = client.namespaces().createOrReplace(namespace).metadata.getUid()
             defaultPspForNamespace(ns)
@@ -2358,7 +2361,7 @@ class Kubernetes implements OrchestratorMain {
     }
 
     def deleteNamespace(String ns, Boolean waitForDeletion = true) {
-        Helpers.withRetry(null, 2, 3) {
+        withRetry(null, 2, 3) {
             client.namespaces().withName(ns).delete()
         }
         if (waitForDeletion) {

--- a/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
@@ -1407,7 +1407,7 @@ class Kubernetes implements OrchestratorMain {
                         clusterRole: false,
                         labels: it.metadata.labels ? it.metadata.labels : [:],
                         annotations: it.metadata.annotations ? it.metadata.annotations : [:],
-                        rules: it.rules.collect {
+                        rules: it.rules ? it.rules.collect {
                             new K8sPolicyRule(
                                     verbs: it.verbs,
                                     apiGroups: it.apiGroups,
@@ -1415,7 +1415,7 @@ class Kubernetes implements OrchestratorMain {
                                     nonResourceUrls: it.nonResourceURLs,
                                     resourceNames: it.resourceNames
                             )
-                        }
+                        } : [],
                 ))
             }
             return roles

--- a/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
@@ -1231,7 +1231,11 @@ class Kubernetes implements OrchestratorMain {
                         uid: it.metadata.uid,
                         name: it.metadata.name,
                         labels: it.metadata.labels,
-                        deploymentCount: getAllDeploymentTypesCount(it.metadata.name),
+                        deploymentCount: getDeploymentCount(it.metadata.name) +
+                                getDaemonSetCount(it.metadata.name) +
+                                getStaticPodCount(it.metadata.name) +
+                                getStatefulSetCount(it.metadata.name) +
+                                getJobCount(it.metadata.name),
                         secretsCount: getSecretCount(it.metadata.name),
                         networkPolicyCount: getNetworkPolicyCount(it.metadata.name)
                 )

--- a/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
@@ -1,5 +1,9 @@
 package orchestratormanager
 
+import static util.Helpers.evaluateWithRetry
+import static util.Helpers.withK8sClientRetry
+import static util.Helpers.withRetry
+
 import java.nio.file.Paths
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
@@ -105,13 +109,9 @@ import objects.NetworkPolicyTypes
 import objects.Node
 import objects.Secret
 import objects.SecretKeyRef
+import util.Env
 import util.Helpers
 import util.Timer
-import util.Env
-
-import static Helpers.evaluateWithRetry
-import static Helpers.withRetry
-import static Helpers.withK8sClientRetry
 
 @CompileStatic
 @Slf4j
@@ -1277,7 +1277,7 @@ class Kubernetes implements OrchestratorMain {
                         namespace: it.metadata.namespace,
                         labels: it.metadata.labels ? it.metadata.labels : [:],
                         annotations: annotations ?: [:],
-                        secrets: it.secrets*.name,
+                        secrets: it.secrets,
                         imagePullSecrets: it.imagePullSecrets*.name,
                         automountToken: it.automountServiceAccountToken == null
                                 ? true : it.automountServiceAccountToken,
@@ -1809,7 +1809,7 @@ class Kubernetes implements OrchestratorMain {
             final List<String> result = new ArrayList()
             result.add(it.getExecutable())
             result.addAll(it.getArguments())
-            return result.toArray()
+            return result as String[]
         }
         log.debug("Exec-ing the following command in pod {}: {}", name, cmd)
         try {

--- a/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
@@ -1407,7 +1407,7 @@ class Kubernetes implements OrchestratorMain {
                         clusterRole: false,
                         labels: it.metadata.labels ? it.metadata.labels : [:],
                         annotations: it.metadata.annotations ? it.metadata.annotations : [:],
-                        rules: it.rules ? it.rules.collect {
+                        rules: it?.rules ? it.rules.collect {
                             new K8sPolicyRule(
                                     verbs: it.verbs,
                                     apiGroups: it.apiGroups,
@@ -1527,7 +1527,7 @@ class Kubernetes implements OrchestratorMain {
                         clusterRole: true,
                         labels: it.metadata.labels ? it.metadata.labels : [:],
                         annotations: it.metadata.annotations ? it.metadata.annotations : [:],
-                        rules: it.rules.collect {
+                        rules: it?.rules ? it.rules.collect {
                             new K8sPolicyRule(
                                     verbs: it.verbs,
                                     apiGroups: it.apiGroups,
@@ -1535,7 +1535,7 @@ class Kubernetes implements OrchestratorMain {
                                     nonResourceUrls: it.nonResourceURLs,
                                     resourceNames: it.resourceNames
                             )
-                        }
+                        } : [],
                 ))
             }
             return clusterRoles

--- a/qa-tests-backend/src/main/groovy/orchestratormanager/OpenShift.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/OpenShift.groovy
@@ -82,7 +82,7 @@ class OpenShift extends Kubernetes {
     */
 
     @Override
-    def getDeploymentCount(String ns) {
+    List<String> getDeploymentCount(String ns) {
         return oClient.apps().deployments().inNamespace(ns).list().getItems().collect { it.metadata.name } +
                 oClient.deploymentConfigs().inNamespace(ns).list().getItems().collect { it.metadata.name }
     }

--- a/qa-tests-backend/src/main/groovy/orchestratormanager/OpenShift.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/OpenShift.groovy
@@ -1,5 +1,7 @@
 package orchestratormanager
 
+import static util.Helpers.withRetry
+
 import groovy.util.logging.Slf4j
 import io.fabric8.kubernetes.client.KubernetesClientException
 import io.fabric8.openshift.api.model.ProjectRequest

--- a/qa-tests-backend/src/main/groovy/orchestratormanager/OrchestratorMain.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/OrchestratorMain.groovy
@@ -34,6 +34,7 @@ interface OrchestratorMain {
     def waitForPodRestart(String ns, String name, int prevRestartCount, int retries, int intervalSeconds)
     String getPodLog(String ns, String name)
     def copyFileToPod(String fromPath, String ns, String podName, String toPath)
+    boolean podReady(Pod pod)
 
     //Deployments
     io.fabric8.kubernetes.api.model.apps.Deployment getOrchestratorDeployment(String ns, String name)

--- a/qa-tests-backend/src/main/groovy/services/ImageService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/ImageService.groovy
@@ -1,5 +1,7 @@
 package services
 
+import static util.Helpers.withRetry
+
 import groovy.util.logging.Slf4j
 import io.stackrox.proto.api.v1.EmptyOuterClass
 import io.stackrox.proto.api.v1.ImageServiceGrpc

--- a/qa-tests-backend/src/main/groovy/services/NetworkPolicyService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/NetworkPolicyService.groovy
@@ -1,21 +1,25 @@
 package services
 
+import static util.Helpers.evaluateWithRetry
+
 import groovy.util.logging.Slf4j
 import io.grpc.StatusRuntimeException
+
 import io.stackrox.proto.api.v1.Common.ResourceByID
 import io.stackrox.proto.api.v1.NetworkGraphServiceOuterClass.NetworkGraphScope
 import io.stackrox.proto.api.v1.NetworkPolicyServiceGrpc
 import io.stackrox.proto.api.v1.NetworkPolicyServiceOuterClass.ApplyNetworkPolicyYamlRequest
 import io.stackrox.proto.api.v1.NetworkPolicyServiceOuterClass.GenerateNetworkPoliciesRequest
 import io.stackrox.proto.api.v1.NetworkPolicyServiceOuterClass.GenerateNetworkPoliciesRequest.DeleteExistingPoliciesMode
-import io.stackrox.proto.api.v1.NetworkPolicyServiceOuterClass.GetNetworkPoliciesRequest
 import io.stackrox.proto.api.v1.NetworkPolicyServiceOuterClass.GetNetworkGraphRequest
+import io.stackrox.proto.api.v1.NetworkPolicyServiceOuterClass.GetNetworkPoliciesRequest
 import io.stackrox.proto.api.v1.NetworkPolicyServiceOuterClass.GetUndoModificationRequest
+import io.stackrox.proto.api.v1.NetworkPolicyServiceOuterClass.SendNetworkPolicyYamlRequest
 import io.stackrox.proto.api.v1.NetworkPolicyServiceOuterClass.SimulateNetworkGraphRequest
+import io.stackrox.proto.storage.NetworkPolicyOuterClass.NetworkPolicy
 import io.stackrox.proto.storage.NetworkPolicyOuterClass.NetworkPolicyModification
 import io.stackrox.proto.storage.NetworkPolicyOuterClass.NetworkPolicyReference
-import io.stackrox.proto.api.v1.NetworkPolicyServiceOuterClass.SendNetworkPolicyYamlRequest
-import io.stackrox.proto.storage.NetworkPolicyOuterClass.NetworkPolicy
+
 import util.Timer
 
 @Slf4j

--- a/qa-tests-backend/src/main/groovy/util/ChaosMonkey.groovy
+++ b/qa-tests-backend/src/main/groovy/util/ChaosMonkey.groovy
@@ -1,18 +1,21 @@
 package util
 
 import common.Constants
+import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import io.fabric8.kubernetes.api.model.Pod
 import orchestratormanager.OrchestratorMain
 
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.locks.Condition
 import java.util.concurrent.locks.ReentrantLock
 
+@CompileStatic
 @Slf4j
 class ChaosMonkey {
-    def stopFlag = new AtomicBoolean()
-    def lock = new ReentrantLock()
-    def effectCond = lock.newCondition()
+    AtomicBoolean stopFlag = new AtomicBoolean()
+    ReentrantLock lock = new ReentrantLock()
+    Condition effectCond = lock.newCondition()
 
     Thread thread
     OrchestratorMain orchestrator
@@ -27,7 +30,7 @@ class ChaosMonkey {
         this.minReadyReplicas = minReadyReplicas
         this.gracePeriod = gracePeriod
 
-        def pods = orchestrator.getPods(Constants.STACKROX_NAMESPACE, ADMISSION_CONTROLLER_APP_NAME)
+        List<Pod> pods = orchestrator.getPods(Constants.STACKROX_NAMESPACE, ADMISSION_CONTROLLER_APP_NAME)
         assert pods.size() > 0, "There are no ${ADMISSION_CONTROLLER_APP_NAME} pods. " +
                 "Did you enable ADMISSION_CONTROLLER when deploying?"
     }

--- a/qa-tests-backend/src/main/groovy/util/Helpers.groovy
+++ b/qa-tests-backend/src/main/groovy/util/Helpers.groovy
@@ -15,7 +15,7 @@ class Helpers {
     private static final int MAX_RETRY_ATTEMPTS = 2
     private static int retryAttempt = 0
 
-    static <V> V evaluateWithRetry(Object ignored, int retries, int pauseSecs, Closure<V> closure) {
+    static <V> V evaluateWithRetry(int retries, int pauseSecs, Closure<V> closure) {
         for (int i = 0; i < retries; i++) {
             try {
                 return closure()
@@ -27,11 +27,11 @@ class Helpers {
         return closure()
     }
 
-    static <V> void withRetry(Object ignored, int retries, int pauseSecs, Closure<V> closure) {
-        evaluateWithRetry(ignored, retries, pauseSecs, closure)
+    static <V> void withRetry(int retries, int pauseSecs, Closure<V> closure) {
+        evaluateWithRetry(retries, pauseSecs, closure)
     }
 
-    static <V> V evaluateWithK8sClientRetry(Object ignored, int retries, int pauseSecs, Closure<V> closure) {
+    static <V> V evaluateWithK8sClientRetry(int retries, int pauseSecs, Closure<V> closure) {
         for (int i = 0; i < retries; i++) {
             try {
                 return closure()
@@ -43,8 +43,8 @@ class Helpers {
         return closure()
     }
 
-    static <V> void withK8sClientRetry(Object ignored, int retries, int pauseSecs, Closure<V> closure) {
-        evaluateWithK8sClientRetry(ignored, retries, pauseSecs, closure)
+    static <V> void withK8sClientRetry(int retries, int pauseSecs, Closure<V> closure) {
+        evaluateWithK8sClientRetry(retries, pauseSecs, closure)
     }
 
     static boolean determineRetry(Throwable failure) {

--- a/qa-tests-backend/src/main/groovy/util/SplunkUtil.groovy
+++ b/qa-tests-backend/src/main/groovy/util/SplunkUtil.groovy
@@ -1,23 +1,24 @@
 package util
 
 import static io.restassured.RestAssured.given
+import static util.Helpers.withRetry
 
+import com.google.gson.Gson
+import com.google.gson.GsonBuilder
 import groovy.transform.TupleConstructor
 import groovy.util.logging.Slf4j
 import io.fabric8.kubernetes.client.LocalPortForward
+import io.restassured.response.Response
+import orchestratormanager.OrchestratorMain
+
 import objects.Deployment
 import objects.Service
 import objects.SplunkAlert
 import objects.SplunkAlertRaw
 import objects.SplunkAlerts
 import objects.SplunkSearch
-import orchestratormanager.OrchestratorMain
 
 import org.junit.AssumptionViolatedException
-
-import com.google.gson.Gson
-import com.google.gson.GsonBuilder
-import io.restassured.response.Response
 
 @Slf4j
 class SplunkUtil {

--- a/qa-tests-backend/src/test/groovy/AttemptedAlertsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/AttemptedAlertsTest.groovy
@@ -1,3 +1,7 @@
+import static util.Helpers.withRetry
+
+import orchestratormanager.OrchestratorTypes
+
 import io.stackrox.proto.storage.AlertOuterClass.ListAlert
 import io.stackrox.proto.storage.AlertOuterClass.ViolationState
 import io.stackrox.proto.storage.ClusterOuterClass.AdmissionControllerConfig
@@ -5,7 +9,6 @@ import io.stackrox.proto.storage.PolicyOuterClass.EnforcementAction
 import io.stackrox.proto.storage.PolicyOuterClass.Policy
 
 import objects.Deployment
-import orchestratormanager.OrchestratorTypes
 import services.AlertService
 import services.ClusterService
 import util.Env

--- a/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
+++ b/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
@@ -35,6 +35,8 @@ import spock.lang.Retry
 import spock.lang.Shared
 import spock.lang.Specification
 
+import static Helpers.withRetry
+
 @Retry(condition = { Helpers.determineRetry(failure) })
 @OnFailure(handler = { Helpers.collectDebugForFailure(delegate as Throwable) })
 class BaseSpecification extends Specification {

--- a/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
+++ b/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
@@ -1,3 +1,5 @@
+import static util.Helpers.withRetry
+
 import java.security.SecureRandom
 import java.util.concurrent.TimeUnit
 
@@ -34,8 +36,6 @@ import org.junit.rules.Timeout
 import spock.lang.Retry
 import spock.lang.Shared
 import spock.lang.Specification
-
-import static Helpers.withRetry
 
 @Retry(condition = { Helpers.determineRetry(failure) })
 @OnFailure(handler = { Helpers.collectDebugForFailure(delegate as Throwable) })

--- a/qa-tests-backend/src/test/groovy/CSVTest.groovy
+++ b/qa-tests-backend/src/test/groovy/CSVTest.groovy
@@ -1,4 +1,5 @@
 import static io.restassured.RestAssured.given
+import static util.Helpers.withRetry
 
 import com.opencsv.CSVReader
 import groovy.transform.EqualsAndHashCode

--- a/qa-tests-backend/src/test/groovy/CertRotationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/CertRotationTest.groovy
@@ -1,3 +1,5 @@
+import static util.Helpers.withRetry
+
 import java.nio.charset.Charset
 import java.security.cert.X509Certificate
 
@@ -17,11 +19,11 @@ import services.ClusterService
 import services.DirectHTTPService
 import services.SensorUpgradeService
 import util.Cert
+import util.Env
 
 import org.junit.Assume
-import spock.lang.Tag
 import spock.lang.IgnoreIf
-import util.Env
+import spock.lang.Tag
 
 @Tag("BAT")
 // ROX-14228 skipping tests for 1st release on power & z

--- a/qa-tests-backend/src/test/groovy/ComplianceTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ComplianceTest.groovy
@@ -3,6 +3,7 @@ import static io.stackrox.proto.api.v1.ComplianceServiceOuterClass.ComplianceSta
 import static io.stackrox.proto.storage.RoleOuterClass.Access.READ_WRITE_ACCESS
 import static io.stackrox.proto.storage.RoleOuterClass.SimpleAccessScope.newBuilder
 import static services.ClusterService.DEFAULT_CLUSTER_NAME
+import static util.Helpers.withRetry
 
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files

--- a/qa-tests-backend/src/test/groovy/DeploymentEventGraphQLTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DeploymentEventGraphQLTest.groovy
@@ -1,5 +1,6 @@
 import static Services.getPolicies
 import static Services.waitForViolation
+import static util.Helpers.withRetry
 
 import java.util.stream.Collectors
 

--- a/qa-tests-backend/src/test/groovy/GlobalSearch.groovy
+++ b/qa-tests-backend/src/test/groovy/GlobalSearch.groovy
@@ -1,10 +1,12 @@
 import static Services.getSearchResponse
 import static Services.waitForViolation
+import static util.Helpers.withRetry
 
 import io.stackrox.proto.api.v1.SearchServiceOuterClass
 
 import objects.Deployment
 import util.Env
+
 import spock.lang.IgnoreIf
 import spock.lang.Tag
 import spock.lang.Unroll

--- a/qa-tests-backend/src/test/groovy/ImageManagementTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageManagementTest.groovy
@@ -1,3 +1,5 @@
+import static util.Helpers.withRetry
+
 import io.stackrox.proto.api.v1.Common
 import io.stackrox.proto.api.v1.PolicyServiceOuterClass
 import io.stackrox.proto.storage.PolicyOuterClass

--- a/qa-tests-backend/src/test/groovy/ImageScanningTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageScanningTest.groovy
@@ -1,4 +1,5 @@
 import static services.ClusterService.DEFAULT_CLUSTER_NAME
+import static util.Helpers.withRetry
 
 import io.grpc.StatusRuntimeException
 import orchestratormanager.OrchestratorTypes

--- a/qa-tests-backend/src/test/groovy/ImageScanningTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageScanningTest.groovy
@@ -825,8 +825,9 @@ class ImageScanningTest extends BaseSpecification {
     private static ImageOuterClass.Image expectDigestedImage(String imageName, String source) {
         def imageDigest
         withRetry(30, 2) {
-            imageDigest = ImageService.getImages().find { it.name == imageName }
-            assert imageDigest?.id
+            def images = ImageService.getImages()
+            imageDigest = images.find { it.name == imageName }
+            assert imageDigest?.id, "image ${imageName} not found among ${images.collect { it.name }}"
         }
         ImageOuterClass.Image imageDetail = ImageService.getImage(imageDigest?.id)
         validateImageMetadata(imageDetail, source)

--- a/qa-tests-backend/src/test/groovy/ImageScanningTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageScanningTest.groovy
@@ -827,7 +827,7 @@ class ImageScanningTest extends BaseSpecification {
         withRetry(30, 2) {
             def images = ImageService.getImages()
             imageDigest = images.find { it.name == imageName }
-            assert imageDigest?.id, "image ${imageName} not found among ${images.collect { it.name }}"
+            assert imageDigest?.id, "image ${imageName} not found among ${images*.name}"
         }
         ImageOuterClass.Image imageDetail = ImageService.getImage(imageDigest?.id)
         validateImageMetadata(imageDetail, source)

--- a/qa-tests-backend/src/test/groovy/IntegrationsSplunkViolationsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/IntegrationsSplunkViolationsTest.groovy
@@ -14,6 +14,7 @@ import objects.Deployment
 import services.AlertService
 import services.ApiTokenService
 import services.NetworkBaselineService
+import util.Env
 import util.NetworkGraphUtil
 import util.SplunkUtil
 import util.SplunkUtil.SplunkDeployment
@@ -21,9 +22,8 @@ import util.Timer
 
 import org.junit.Rule
 import org.junit.rules.Timeout
-import spock.lang.Tag
 import spock.lang.IgnoreIf
-import util.Env
+import spock.lang.Tag
 
 // ROX-14228 skipping tests for 1st release on power & z
 @IgnoreIf({ Env.REMOTE_CLUSTER_ARCH == "ppc64le" || Env.REMOTE_CLUSTER_ARCH == "s390x" })

--- a/qa-tests-backend/src/test/groovy/IntegrationsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/IntegrationsTest.groovy
@@ -1,3 +1,5 @@
+import static util.Helpers.withRetry
+
 import java.util.concurrent.TimeUnit
 
 import io.grpc.StatusRuntimeException
@@ -21,9 +23,9 @@ import objects.NetworkPolicyTypes
 import objects.Notifier
 import objects.QuayImageIntegration
 import objects.SlackNotifier
-import objects.SyslogNotifier
 import objects.SplunkNotifier
 import objects.StackroxScannerIntegration
+import objects.SyslogNotifier
 import services.ClusterService
 import services.ExternalBackupService
 import services.ImageIntegrationService
@@ -32,15 +34,15 @@ import services.NotifierService
 import services.PolicyService
 import util.Env
 import util.MailServer
-import util.SyslogServer
 import util.SplunkUtil
+import util.SyslogServer
 
 import org.junit.Assume
 import org.junit.Rule
 import org.junit.rules.Timeout
+import spock.lang.IgnoreIf
 import spock.lang.Tag
 import spock.lang.Unroll
-import spock.lang.IgnoreIf
 
 class IntegrationsTest extends BaseSpecification {
     static final private String NOTIFIERDEPLOYMENT = "netpol-notification-test-deployment"

--- a/qa-tests-backend/src/test/groovy/K8sEventDetectionTest.groovy
+++ b/qa-tests-backend/src/test/groovy/K8sEventDetectionTest.groovy
@@ -1,3 +1,5 @@
+import static util.Helpers.withRetry
+
 import orchestratormanager.OrchestratorTypes
 
 import io.stackrox.proto.storage.AlertOuterClass

--- a/qa-tests-backend/src/test/groovy/K8sRbacTest.groovy
+++ b/qa-tests-backend/src/test/groovy/K8sRbacTest.groovy
@@ -1,4 +1,7 @@
+import static util.Helpers.withRetry
+
 import com.google.common.base.CaseFormat
+import orchestratormanager.OrchestratorTypes
 
 import io.stackrox.proto.api.v1.RbacServiceOuterClass
 import io.stackrox.proto.api.v1.ServiceAccountServiceOuterClass
@@ -11,7 +14,6 @@ import objects.K8sRole
 import objects.K8sRoleBinding
 import objects.K8sServiceAccount
 import objects.K8sSubject
-import orchestratormanager.OrchestratorTypes
 import services.RbacService
 import services.ServiceAccountService
 import util.Env

--- a/qa-tests-backend/src/test/groovy/NetworkBaselineTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NetworkBaselineTest.groovy
@@ -1,3 +1,5 @@
+import static util.Helpers.evaluateWithRetry
+
 import com.google.protobuf.Timestamp
 
 import io.stackrox.proto.storage.NetworkBaselineOuterClass

--- a/qa-tests-backend/src/test/groovy/NetworkSimulator.groovy
+++ b/qa-tests-backend/src/test/groovy/NetworkSimulator.groovy
@@ -8,12 +8,12 @@ import objects.NetworkPolicyTypes
 import objects.SlackNotifier
 import services.NetworkGraphService
 import services.NetworkPolicyService
+import util.Env
 import util.NetworkGraphUtil
 
+import spock.lang.IgnoreIf
 import spock.lang.Tag
 import spock.lang.Unroll
-import spock.lang.IgnoreIf
-import util.Env
 
 class NetworkSimulator extends BaseSpecification {
 

--- a/qa-tests-backend/src/test/groovy/PolicyConfigurationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/PolicyConfigurationTest.groovy
@@ -1,5 +1,6 @@
 import static Services.checkForNoViolations
 import static Services.waitForViolation
+import static util.Helpers.withRetry
 
 import io.stackrox.proto.api.v1.PolicyServiceOuterClass.DryRunResponse
 import io.stackrox.proto.api.v1.SearchServiceOuterClass

--- a/qa-tests-backend/src/test/groovy/ProcessBaselinesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ProcessBaselinesTest.groovy
@@ -1,5 +1,6 @@
 import static Services.waitForSuspiciousProcessInRiskIndicators
 import static Services.waitForViolation
+import static util.Helpers.evaluateWithRetry
 
 import org.apache.commons.lang3.StringUtils
 

--- a/qa-tests-backend/src/test/groovy/ProcessesListeningOnPortsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ProcessesListeningOnPortsTest.groovy
@@ -1,3 +1,5 @@
+import static util.Helpers.evaluateWithRetry
+
 import objects.Deployment
 import objects.K8sServiceAccount
 import objects.Service

--- a/qa-tests-backend/src/test/groovy/ReconciliationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ReconciliationTest.groovy
@@ -1,5 +1,7 @@
 import static Services.getViolationsWithTimeout
 
+import static util.Helpers.withRetry
+
 import orchestratormanager.OrchestratorTypes
 
 import io.fabric8.kubernetes.api.model.Pod

--- a/qa-tests-backend/src/test/groovy/RoutesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/RoutesTest.groovy
@@ -1,3 +1,5 @@
+import static util.Helpers.withRetry
+
 import orchestratormanager.OrchestratorTypes
 
 import io.stackrox.proto.storage.DeploymentOuterClass

--- a/qa-tests-backend/src/test/groovy/SACTest.groovy
+++ b/qa-tests-backend/src/test/groovy/SACTest.groovy
@@ -4,6 +4,7 @@ import static io.stackrox.proto.storage.RoleOuterClass.Access.READ_ACCESS
 import static io.stackrox.proto.storage.RoleOuterClass.Access.READ_WRITE_ACCESS
 import static io.stackrox.proto.storage.RoleOuterClass.SimpleAccessScope.newBuilder
 import static services.ClusterService.DEFAULT_CLUSTER_NAME
+import static util.Helpers.withRetry
 
 import orchestratormanager.OrchestratorTypes
 

--- a/qa-tests-backend/src/test/groovy/SecretsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/SecretsTest.groovy
@@ -1,3 +1,5 @@
+import static util.Helpers.withRetry
+
 import io.stackrox.proto.storage.SecretOuterClass.Secret
 
 import objects.Deployment

--- a/qa-tests-backend/src/test/groovy/SummaryTest.groovy
+++ b/qa-tests-backend/src/test/groovy/SummaryTest.groovy
@@ -1,3 +1,5 @@
+import static util.Helpers.withRetry
+
 import org.javers.core.Javers
 import org.javers.core.JaversBuilder
 import org.javers.core.diff.ListCompareAlgorithm

--- a/qa-tests-backend/src/test/groovy/TLSChallengeTest.groovy
+++ b/qa-tests-backend/src/test/groovy/TLSChallengeTest.groovy
@@ -1,4 +1,5 @@
 import static io.stackrox.proto.storage.ClusterOuterClass.ClusterHealthStatus.HealthStatusLabel
+import static util.Helpers.withRetry
 
 import java.nio.file.Files
 import java.nio.file.Paths

--- a/qa-tests-backend/src/test/groovy/VulnReportingTest.groovy
+++ b/qa-tests-backend/src/test/groovy/VulnReportingTest.groovy
@@ -1,3 +1,5 @@
+import static util.Helpers.withRetry
+
 import io.stackrox.proto.storage.NotifierOuterClass
 
 import common.Constants


### PR DESCRIPTION
## Description

Initially I enabled static compilation of `Kubernetes` and `ChaosMonkey` hoping it will help uncover the cause of some unexpected behaviour of `ChaosMonkey` in the context of #4775, but the bug later turned out to be a logic error.

However I feel this is generally useful for writing correct code, even if we do not decide to re-enable `ChaosMonkey`.

Changes in this PR to files other than the aforementioned ones were necessary for the compilation to pass. :shrug:

See also #5038 for related improvements to tests.

## Checklist
- [x] Investigated and inspected CI test results using `ci-all-qa-tests` and default (non-release) behaviour (just 3 unrelated flakes)
- [x] Investigated and inspected CI test results using `ci-all-qa-tests` and `ci-release-build`(two cluster creation failures and one unrelated flake)
- [x] Unit test and regression tests added
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

CI should be sufficient, see above.