### PR TITLE
Telemetry: add "Server" suffix to the Platform for backends

### DIFF
--- a/pkg/telemetry/phonehome/segment/segment.go
+++ b/pkg/telemetry/phonehome/segment/segment.go
@@ -15,8 +15,9 @@ var (
 )
 
 type segmentTelemeter struct {
-	client   segment.Client
-	clientID string
+	client     segment.Client
+	clientID   string
+	clientType string
 }
 
 func getMessageType(msg segment.Message) string {
@@ -67,7 +68,7 @@ func NewTelemeter(key, endpoint, clientID, clientType string, interval time.Dura
 		return nil
 	}
 
-	return &segmentTelemeter{client: client, clientID: clientID}
+	return &segmentTelemeter{client: client, clientID: clientID, clientType: clientType}
 }
 
 type logWrapper struct {
@@ -110,7 +111,7 @@ func (t *segmentTelemeter) getAnonymousID(o *telemeter.CallOptions) string {
 	return t.clientID
 }
 
-func makeDeviceContext(o *telemeter.CallOptions) *segment.Context {
+func (t *segmentTelemeter) makeDeviceContext(o *telemeter.CallOptions) *segment.Context {
 	var ctx *segment.Context
 
 	if len(o.Groups) > 0 {
@@ -130,6 +131,17 @@ func makeDeviceContext(o *telemeter.CallOptions) *segment.Context {
 			Type: o.ClientType,
 		}
 	}
+
+	if o.UserID == "" {
+		// Add "Server" suffix to the platform of the backend initiated events:
+		if ctx == nil {
+			ctx = &segment.Context{}
+		}
+		if ctx.Device.Type == "" {
+			ctx.Device.Type = t.clientType
+		}
+		ctx.Device.Type += " Server"
+	}
 	return ctx
 }
 
@@ -146,7 +158,7 @@ func (t *segmentTelemeter) Identify(props map[string]any, opts ...telemeter.Opti
 		UserId:      t.getUserID(options),
 		AnonymousId: t.getAnonymousID(options),
 		Traits:      traits,
-		Context:     makeDeviceContext(options),
+		Context:     t.makeDeviceContext(options),
 	}
 
 	for k, v := range props {
@@ -168,7 +180,7 @@ func (t *segmentTelemeter) Group(props map[string]any, opts ...telemeter.Option)
 		UserId:      t.getUserID(options),
 		AnonymousId: t.getAnonymousID(options),
 		Traits:      props,
-		Context:     makeDeviceContext(options),
+		Context:     t.makeDeviceContext(options),
 	}
 
 	for _, ids := range options.Groups {
@@ -198,7 +210,7 @@ func (t *segmentTelemeter) Track(event string, props map[string]any, opts ...tel
 		AnonymousId: t.getAnonymousID(options),
 		Event:       event,
 		Properties:  props,
-		Context:     makeDeviceContext(options),
+		Context:     t.makeDeviceContext(options),
 	}
 
 	if err := t.client.Enqueue(track); err != nil {

--- a/pkg/telemetry/phonehome/segment/segment_test.go
+++ b/pkg/telemetry/phonehome/segment/segment_test.go
@@ -26,7 +26,9 @@ func Test_makeDeviceContext(t *testing.T) {
 		telemeter.WithGroups("groupB", "groupB_id"),
 	})
 
-	ctx := makeDeviceContext(opts)
+	s := segmentTelemeter{clientType: "test"}
+
+	ctx := s.makeDeviceContext(opts)
 	assert.Equal(t, "clientID", ctx.Device.Id)
 	assert.Equal(t, "clientType", ctx.Device.Type)
 
@@ -35,6 +37,13 @@ func Test_makeDeviceContext(t *testing.T) {
 	assert.Contains(t, ctx.Extra["groups"], "groupB")
 	groups := ctx.Extra["groups"].(map[string][]string)
 	assert.ElementsMatch(t, []string{"groupA_id1", "groupA_id2"}, groups["groupA"])
+
+	ctx = s.makeDeviceContext(telemeter.ApplyOptions([]telemeter.Option{}))
+	assert.Equal(t, "test Server", ctx.Device.Type)
+
+	ctx = s.makeDeviceContext(telemeter.ApplyOptions([]telemeter.Option{
+		telemeter.WithClient("clientID", "clientType")}))
+	assert.Equal(t, "clientType Server", ctx.Device.Type)
 }
 
 func Test_getIDs(t *testing.T) {


### PR DESCRIPTION
## Description

Amplitude, apparently, requires User ID for proper event attribution, and so the idea of missing user ID for backend initiated events didn't work.

This PR modifies the Platform field for events initiated by backends (i.e. if there's no User ID) by adding ` Server` to it (that will be, e.g., "Central Server" for periodic central events), so that we can identify such "users" and events on Amplitude.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed
```json
{
  "anonymousId": "062c26b6-85d7-4ee8-b690-1e21e94657f3",
  "context": {
    "device": {
      "id": "062c26b6-85d7-4ee8-b690-1e21e94657f3",
      "type": "Central Server"
    },
    "library": {
      "name": "analytics-go",
      "version": "3.0.0"
    }
  },
  "event": "Telemetry Disabled",
  "integrations": {},
  "messageId": "e6b60a12-68f2-48ac-939d-206021e18c1b",
  "originalTimestamp": "2023-03-03T14:45:18.813492105Z",
  "receivedAt": "2023-03-03T14:45:54.995Z",
  "sentAt": "2023-03-03T14:45:54.311Z",
  "timestamp": "2023-03-03T14:45:19.497Z",
  "type": "track",
  "writeKey": "..."
}
```

---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>


> 
> #### What changed
> - Added a new field `clientType` to the `segmentTelemeter` struct
> - Added a check to see if the `UserID` is empty in `makeDeviceContext`
> - Added a suffix of "Server" to the `Device.Type` in `makeDeviceContext`
> - Updated the `Identify`, `Group` and `Track` functions to use the new `makeDeviceContext`
> 
> #### Impact
> This diff adds a `clientType` field to the `segmentTelemeter` struct, and uses this field to add a "Server" suffix to the `Device.Type` when the `UserID` is empty.
> 
> #### Testing
> This diff should be tested by ensuring that the correct `Device.Type` is being sent in the segment API calls when the `UserID` is empty.
</details>