### PR TITLE
ROX-12969: Randomize node scanning intervals

### DIFF
--- a/compliance/collection/intervals/intervals.go
+++ b/compliance/collection/intervals/intervals.go
@@ -1,6 +1,7 @@
 package intervals
 
 import (
+	"math"
 	"math/rand"
 	"time"
 
@@ -43,7 +44,8 @@ func NewNodeScanIntervalFromEnv() NodeScanIntervals {
 	i.base = env.NodeScanningInterval.DurationSetting()
 	i.deviation = 0.0
 	if env.NodeScanningIntervalDeviation.IntegerSetting() > 0 {
-		i.deviation = float64(env.NodeScanningIntervalDeviation.IntegerSetting()) / 100.0
+		d := math.Min(float64(env.NodeScanningIntervalDeviation.IntegerSetting()), 100.0)
+		i.deviation = d / 100.0
 	}
 	i.initialMax = env.NodeScanningMaxInitialWait.DurationSetting()
 	log.Infof("scanning intervals: base=%s deviation=%.2f initialMax=%s",

--- a/compliance/collection/intervals/intervals.go
+++ b/compliance/collection/intervals/intervals.go
@@ -1,0 +1,69 @@
+package intervals
+
+import (
+	"math/rand"
+	"time"
+
+	"github.com/stackrox/rox/pkg/env"
+	"github.com/stackrox/rox/pkg/logging"
+)
+
+var (
+	log = logging.LoggerForModule()
+
+	// Used for testing purposes, to mock random values.
+	randFloat64 = rand.Float64
+)
+
+// NodeScanIntervals generates node scanning intervals using randomized values.
+type NodeScanIntervals struct {
+	base       time.Duration
+	deviation  float64
+	initialMax time.Duration
+}
+
+// deviateDuration randomly deviates a duration by a given percentage. Example:
+// duration of 10s with 5% deviation means a random duration between 5s and 15s.
+func deviateDuration(d time.Duration, percentage float64) time.Duration {
+	min, max := 1.0-percentage, 1.0+percentage
+	dev := randFloat64()*(max-min) + min
+	return multiplyDuration(d, dev)
+}
+
+// multiplyDuration multiplies a duration by a float64 and returns the resulting
+// duration.
+func multiplyDuration(d time.Duration, factor float64) time.Duration {
+	return time.Duration(float64(time.Second) * d.Seconds() * factor)
+}
+
+// NewNodeScanIntervalFromEnv creates node scanning intervals from environment
+// variables.
+func NewNodeScanIntervalFromEnv() NodeScanIntervals {
+	i := NodeScanIntervals{}
+	i.base = env.NodeScanningInterval.DurationSetting()
+	i.deviation = 0.0
+	if env.NodeScanningIntervalDeviation.IntegerSetting() > 0 {
+		i.deviation = float64(env.NodeScanningIntervalDeviation.IntegerSetting()) / 100.0
+	}
+	i.initialMax = env.NodeScanningMaxInitialWait.DurationSetting()
+	log.Infof("scanning intervals: base=%s deviation=%.2f initialMax=%s",
+		i.base, i.deviation, i.initialMax)
+	return i
+}
+
+// Initial returns the initial node scanning interval.
+func (i *NodeScanIntervals) Initial() time.Duration {
+	interval := multiplyDuration(i.initialMax, randFloat64())
+	log.Infof("initial scanning in %s", interval)
+	return interval
+}
+
+// Next returns the next node scanning interval.
+func (i *NodeScanIntervals) Next() time.Duration {
+	interval := i.base
+	if i.deviation > 0 {
+		interval = deviateDuration(interval, i.deviation)
+	}
+	log.Infof("next node scan in %s", interval)
+	return interval
+}

--- a/compliance/collection/intervals/intervals_test.go
+++ b/compliance/collection/intervals/intervals_test.go
@@ -1,0 +1,74 @@
+package intervals
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type IntervalsTestSuite struct {
+	suite.Suite
+	randFloat64 func() float64
+}
+
+func TestScanSuite(t *testing.T) {
+	suite.Run(t, new(IntervalsTestSuite))
+}
+
+func (s *IntervalsTestSuite) SetupSuite() {
+	s.randFloat64 = randFloat64
+}
+
+func (s *IntervalsTestSuite) TearDownTest() {
+	randFloat64 = s.randFloat64
+}
+
+func (s *IntervalsTestSuite) Test_Next() {
+	defaultIntervals := NodeScanIntervals{
+		base:      time.Hour * 10,
+		deviation: 0.1,
+	}
+	tests := []struct {
+		name      string
+		intervals NodeScanIntervals
+		rand      float64
+		want      time.Duration
+	}{
+		{
+			name:      "default interval with rand 0",
+			intervals: defaultIntervals,
+			rand:      0,
+			want:      time.Hour * 9,
+		},
+		{
+			name:      "default interval with rand 1",
+			intervals: defaultIntervals,
+			rand:      1,
+			want:      time.Hour * 11,
+		},
+		{
+			name:      "default interval with rand 0.5",
+			intervals: defaultIntervals,
+			rand:      0.25,
+			want:      time.Hour*9 + time.Minute*30,
+		},
+		{
+			name: "deviation set to 0",
+			intervals: NodeScanIntervals{
+				deviation: 0,
+				base:      time.Hour,
+			},
+			rand: 0,
+			want: time.Hour,
+		},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			randFloat64 = func() float64 { return tt.rand }
+			got := tt.intervals.Next()
+			s.Assert().Equal(tt.want, got)
+		})
+	}
+}

--- a/compliance/collection/intervals/intervals_test.go
+++ b/compliance/collection/intervals/intervals_test.go
@@ -85,7 +85,7 @@ func TestNewNodeScanIntervalFromEnv(t *testing.T) {
 		{
 			name:          "when interval, deviation and initial are set then interval is set",
 			envInterval:   "1h",
-			envDeviation:  "50",
+			envDeviation:  "30m",
 			envMaxInitial: "1m",
 			want: NodeScanIntervals{
 				base:       time.Hour,
@@ -94,20 +94,12 @@ func TestNewNodeScanIntervalFromEnv(t *testing.T) {
 			},
 		},
 		{
-			name:         "when deviation greater than 100",
-			envDeviation: "200",
+			name:         "when deviation greater or equal to interval",
+			envInterval:  "4h",
+			envDeviation: "4h",
 			want: NodeScanIntervals{
 				base:       time.Hour * 4,
 				deviation:  1,
-				initialMax: time.Minute * 5,
-			},
-		},
-		{
-			name:         "when deviation lower than 0",
-			envDeviation: "-20",
-			want: NodeScanIntervals{
-				base:       time.Hour * 4,
-				deviation:  0,
 				initialMax: time.Minute * 5,
 			},
 		},

--- a/compliance/collection/main.go
+++ b/compliance/collection/main.go
@@ -167,6 +167,7 @@ func manageNodeScanLoop(ctx context.Context, i intervals.NodeScanIntervals, scan
 			case <-ctx.Done():
 				return
 			case <-t.C:
+				log.Infof("starting a node scan for node %q", nodeName)
 				msg, err := scanNode(nodeName, scanner)
 				if err != nil {
 					log.Errorf("error running scanNode: %v", err)

--- a/pkg/env/node_scan.go
+++ b/pkg/env/node_scan.go
@@ -6,10 +6,9 @@ var (
 	// NodeScanningInterval is the base value of the interval duration between node scans.
 	NodeScanningInterval = registerDurationSetting("ROX_NODE_SCANNING_INTERVAL", 4*time.Hour)
 
-	// NodeScanningIntervalDeviation is the percentage by which each interval
-	// duration between node scans will deviate from the base interval time. A value
-	// equal or lower than zero disables deviation.
-	NodeScanningIntervalDeviation = RegisterIntegerSetting("ROX_NODE_SCANNING_INTERVAL_DEVIATION", 10)
+	// NodeScanningIntervalDeviation is the duration node scans will deviate from the
+	// base interval time. The value is capped by the base interval.
+	NodeScanningIntervalDeviation = registerDurationSetting("ROX_NODE_SCANNING_INTERVAL_DEVIATION", 24*time.Minute)
 
 	// NodeScanningMaxInitialWait is the maximum wait time before the first node
 	// scan, which is randomly generated. Set zero to disable the initial node

--- a/pkg/env/node_scan.go
+++ b/pkg/env/node_scan.go
@@ -3,6 +3,16 @@ package env
 import "time"
 
 var (
-	// NodeRescanInterval will set the duration for when to fetch node inventory to be scanned for vulnerabilities
-	NodeRescanInterval = registerDurationSetting("ROX_NODE_RESCAN_INTERVAL", 4*time.Hour)
+	// NodeScanningInterval is the base value of the interval duration between node scans.
+	NodeScanningInterval = registerDurationSetting("ROX_NODE_SCANNING_INTERVAL", 4*time.Hour)
+
+	// NodeScanningIntervalDeviation is the percentage by which each interval
+	// duration between node scans will deviate from the base interval time. A value
+	// equal or lower than zero disables deviation.
+	NodeScanningIntervalDeviation = RegisterIntegerSetting("ROX_NODE_SCANNING_INTERVAL_DEVIATION", 10)
+
+	// NodeScanningMaxInitialWait is the maximum wait time before the first node
+	// scan, which is randomly generated. Set zero to disable the initial node
+	// scanning wait time.
+	NodeScanningMaxInitialWait = registerDurationSetting("ROX_NODE_SCANNING_MAX_INITIAL_WAIT", 5*time.Minute)
 )


### PR DESCRIPTION
## Description

Use randomized interval durations to determine the initial time to perform first node scanning and subsequent rescanning. Allow these intervals to be configurable through environment variables.

- The initial interval is configurable by a maximum value, uniformly randomized from zero to maximum.

- Rescanning intervals are configurable by "percentage-deviated" random numbers: a base number or average is selected, and a percentage of uniform deviation from that is used. Example: Base 4h. Deviation: 10%. Random interval min to max: 3h36m to 4h24m.
 
The motivation is to reduce the chances of concurrent scanning and distribute the load on the filesystem I/O, network I/O, Sensor, and Central memory.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] Evaluated and added CHANGELOG entry if required
- [x] Determined and documented upgrade steps
- [x] Documented user-facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Manual deployment and the following logs were observed in Collector/Compliance container. See logs below.

```
No certificates found in /usr/local/share/ca-certificates
No certificates found in /etc/pki/injected-ca-trust
main: 2023/03/03 21:08:51.568452 main.go:297: Info: Running StackRox Version: 3.74.x-265-g4a8b8e3145-dirty
pkg/metrics: 2023/03/03 21:08:51.568904 http_server.go:37: Warn: Metrics server is disabled
main: 2023/03/03 21:08:51.571977 main.go:313: Info: Initialized Sensor gRPC stream connection
main: 2023/03/03 21:08:51.572118 main.go:337: Info: Using NodeInventoryCollector
main: 2023/03/03 21:08:51.572233 main.go:187: Info: node scanning interval: base=4h0m0s deviation=0.25 initialMax=5m0s initial=24.870137866s
main: 2023/03/03 21:08:51.644784 main.go:291: Info: Successfully connected to Sensor at sensor.stackrox.svc:443
time="2023-03-03T21:09:16Z" level=info msg="add files from directory" directory=etc/ root=/host
time="2023-03-03T21:09:16Z" level=info msg="add files from directory" directory=usr/share/rpm root=/host
time="2023-03-03T21:09:16Z" level=info msg="add files from directory" directory=var/lib/rpm root=/host
time="2023-03-03T21:09:16Z" level=info msg="add files from directory" directory=usr/share/buildinfo root=/host
collection/nodeinventorizer: 2023/03/03 21:09:19.771792 nodeinventory.go:49: Info: Node inventory has been built with 503 packages and 4 content sets
main: 2023/03/03 21:09:19.772166 main.go:201: Info: node scanning loop: next run is in 3h32m6.950792422s```
