### PR TITLE
Fix dir to watch in declarative configuration.

### DIFF
--- a/central/declarativeconfig/manager_impl.go
+++ b/central/declarativeconfig/manager_impl.go
@@ -70,13 +70,15 @@ func (m *managerImpl) ReconcileDeclarativeConfigurations() {
 			if !entry.IsDir() {
 				continue
 			}
+
+			dirToWatch := path.Join(declarativeConfigDir, entry.Name())
 			log.Infof("Start watch handler for declarative configuration for path %s",
-				path.Join(declarativeConfigDir, entry.Name()))
-			wh := newWatchHandler(entry.Name(), m)
+				dirToWatch)
+			wh := newWatchHandler(dirToWatch, m)
 			// Set Force to true, so we explicitly retry watching the files within the directory and not stop on the first
 			// error occurred.
 			watchOpts := k8scfgwatch.Options{Interval: m.watchIntervalDuration, Force: true}
-			_ = k8scfgwatch.WatchConfigMountDir(context.Background(), declarativeConfigDir,
+			_ = k8scfgwatch.WatchConfigMountDir(context.Background(), dirToWatch,
 				k8scfgwatch.DeduplicateWatchErrors(wh), watchOpts)
 			startedWatchHandler = true
 		}


### PR DESCRIPTION
## Description

We mistakenly only started watches for the "root" directory of declarative configuration (`/run/stackrox.io/declarative-configuration`) instead of watching each specific entry within the directory.

This lead to not receiving any updates within directory.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

- manual tests were performed to verify that updates are working properly (see [this PR's description](https://github.com/stackrox/stackrox/pull/5018))
