### PR TITLE
Ensure the UIEndpoint for declarative auth providers is given without scheme

### DIFF
--- a/pkg/declarativeconfig/auth_provider.go
+++ b/pkg/declarativeconfig/auth_provider.go
@@ -69,8 +69,10 @@ type OpenshiftConfig struct {
 type AuthProvider struct {
 	Name string `yaml:"name,omitempty"`
 	// TODO: ROX-14148 if left empty, no default group should be created
-	MinimumRoleName    string              `yaml:"minimumRole,omitempty"`
-	UIEndpoint         string              `yaml:"uiEndpoint,omitempty"`
+	MinimumRoleName string `yaml:"minimumRole,omitempty"`
+	// The UIEndpoint should be given without scheme (http:// | https://) but including the port, e.g. localhost:443
+	UIEndpoint string `yaml:"uiEndpoint,omitempty"`
+	// The ExtraUIEndpoints should be given without scheme (http:// | https://) but including the port, e.g. localhost:443
 	ExtraUIEndpoints   []string            `yaml:"extraUIEndpoints,omitempty"`
 	Groups             []Group             `yaml:"groups,omitempty"`
 	RequiredAttributes []RequiredAttribute `yaml:"requiredAttributes,omitempty"`

--- a/pkg/declarativeconfig/auth_provider_test.go
+++ b/pkg/declarativeconfig/auth_provider_test.go
@@ -14,8 +14,8 @@ requiredAttributes:
 - key: "groups"
   value: "stackrox"
 minimumRole: "None"
-uiEndpoint: "https://localhost:8000"
-extraUIEndpoints: ["https://localhost:8001"]
+uiEndpoint: "localhost:8000"
+extraUIEndpoints: ["localhost:8001"]
 groups:
 - key: "email"
   value: "admin@stackrox.com"
@@ -25,7 +25,7 @@ groups:
   role: "Analyst"
 oidc:
   issuer: "https://stackrox.com"
-  mode: "auto select"
+  mode: "auto"
   clientID: "some-client-id"
   clientSecret: "some-client-secret"
   disableOfflineAccessScope: true
@@ -36,10 +36,10 @@ oidc:
 	assert.NoError(t, err)
 	assert.Equal(t, "test-name", ap.Name)
 	assert.Equal(t, "None", ap.MinimumRoleName)
-	assert.Equal(t, "https://localhost:8000", ap.UIEndpoint)
+	assert.Equal(t, "localhost:8000", ap.UIEndpoint)
 
 	assert.Len(t, ap.ExtraUIEndpoints, 1)
-	assert.Equal(t, "https://localhost:8001", ap.ExtraUIEndpoints[0])
+	assert.Equal(t, "localhost:8001", ap.ExtraUIEndpoints[0])
 
 	assert.Len(t, ap.Groups, 2)
 	assert.Equal(t, "email", ap.Groups[0].AttributeKey)
@@ -60,7 +60,7 @@ oidc:
 	assert.NotNil(t, ap.OIDCConfig)
 	assert.Equal(t, "some-client-id", ap.OIDCConfig.ClientID)
 	assert.Equal(t, "some-client-secret", ap.OIDCConfig.ClientSecret)
-	assert.Equal(t, "auto select", ap.OIDCConfig.CallbackMode)
+	assert.Equal(t, "auto", ap.OIDCConfig.CallbackMode)
 	assert.Equal(t, "https://stackrox.com", ap.OIDCConfig.Issuer)
 	assert.True(t, ap.OIDCConfig.DisableOfflineAccessScope)
 }


### PR DESCRIPTION
## Description

During the testing of the creation of declarative configurations we found out that we currently, by mistake, provide the scheme for the `UIEndpoint / ExtraUIEndpoints` fields.

When doing that, the auth provider will be come unusable, as these fields are meant to be filled in the form of <host>:<port> _without_ the scheme.

Adjusted the comments within the struct as well as the test cases, were we used invalid values for the `UIEndpoint, ExtraUIEndpoints, Mode` fields.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

- documentation change without requiring additional tests.
