### PR TITLE
ROX-12750: Resource grouping - central part for ServiceIdentity, ScannerBundle and ScannerDefinitions

### DIFF
--- a/central/certgen/service.go
+++ b/central/certgen/service.go
@@ -35,30 +35,27 @@ func (s *serviceImpl) RegisterServiceHandler(_ context.Context, _ *runtime.Serve
 func (s *serviceImpl) CustomRoutes() []routes.CustomRoute {
 	return []routes.CustomRoute{
 		{
-			Route: "/api/extensions/certgen/central",
-			// TODO: ROX-12750 replace ServiceIdentity with Administration
-			Authorizer:    user.With(permissions.Modify(resources.ServiceIdentity)),
+			Route:         "/api/extensions/certgen/central",
+			Authorizer:    user.With(permissions.Modify(resources.Administration)),
 			ServerHandler: http.HandlerFunc(s.centralHandler),
 			Compression:   false,
 		},
 		{
-			Route: "/api/extensions/certgen/scanner",
-			// TODO: ROX-12750 replace ServiceIdentity with Administration
-			Authorizer:    user.With(permissions.Modify(resources.ServiceIdentity)),
+			Route:         "/api/extensions/certgen/scanner",
+			Authorizer:    user.With(permissions.Modify(resources.Administration)),
 			ServerHandler: http.HandlerFunc(s.scannerHandler),
 			Compression:   false,
 		},
 
 		{
-			Route: "/api/extensions/certgen/cluster",
-			// TODO: ROX-12750 replace ServiceIdentity with Administration
-			Authorizer:    user.With(permissions.Modify(resources.ServiceIdentity)),
+			Route:         "/api/extensions/certgen/cluster",
+			Authorizer:    user.With(permissions.Modify(resources.Administration)),
 			ServerHandler: http.HandlerFunc(s.securedClusterHandler),
 			Compression:   false,
 		},
 		{
 			Route:         "/api/extensions/certgen/centraldb",
-			Authorizer:    user.With(permissions.Modify(resources.ServiceIdentity)),
+			Authorizer:    user.With(permissions.Modify(resources.Administration)),
 			ServerHandler: http.HandlerFunc(s.centralDBHandler),
 			Compression:   false,
 		},

--- a/central/clusterinit/backend/access/access.go
+++ b/central/clusterinit/backend/access/access.go
@@ -12,8 +12,7 @@ import (
 
 // CheckAccess returns nil if requested access level is granted in context.
 func CheckAccess(ctx context.Context, access storage.Access) error {
-	// TODO: ROX-12750 replace ServiceIdentity with Administration
-	helper := sac.ForResources(sac.ForResource(resources.ServiceIdentity), sac.ForResource(resources.Integration))
+	helper := sac.ForResources(sac.ForResource(resources.Administration), sac.ForResource(resources.Integration))
 	if allowed, err := helper.AccessAllowedToAll(ctx, access); err != nil {
 		return errors.Wrap(err, "checking access")
 	} else if !allowed {

--- a/central/clusterinit/backend/backend_test.go
+++ b/central/clusterinit/backend/backend_test.go
@@ -390,43 +390,24 @@ func (s *clusterInitBackendTestSuite) TestCheckAccess() {
 		shouldFail  bool
 		expectedErr error
 	}{
-		// TODO: ROX-12750 replace ServiceIdentity with Administration
-		"read access to both ServiceIdentity and Integration should allow read access": {
-			ctx: sac.WithGlobalAccessScopeChecker(context.Background(), sac.AllowFixedScopes(
-				sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
-				sac.ResourceScopeKeys(resources.ServiceIdentity, resources.Integration))),
-			access: storage.Access_READ_ACCESS,
-		},
-		// TODO: ROX-12750 replace ServiceIdentity with Administration
-		"read access to both ServiceIdentity and Integration should not allow write access": {
-			ctx: sac.WithGlobalAccessScopeChecker(context.Background(), sac.AllowFixedScopes(
-				sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
-				sac.ResourceScopeKeys(resources.ServiceIdentity, resources.Integration))),
-			access:      storage.Access_READ_WRITE_ACCESS,
-			shouldFail:  true,
-			expectedErr: errox.NotAuthorized,
-		},
-		// TODO: ROX-12750 remove this test (duplicate after migration)
 		"read access to both Administration and Integration should allow read access": {
-			ctx: sac.WithGlobalAccessScopeChecker(context.Background(),
-				sac.AllowFixedScopes(sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
-					sac.ResourceScopeKeys(resources.Administration, resources.Integration))),
+			ctx: sac.WithGlobalAccessScopeChecker(context.Background(), sac.AllowFixedScopes(
+				sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
+				sac.ResourceScopeKeys(resources.Administration, resources.Integration))),
 			access: storage.Access_READ_ACCESS,
 		},
-		// TODO: ROX-12750 remove this test (duplicate after migration)
 		"read access to both Administration and Integration should not allow write access": {
-			ctx: sac.WithGlobalAccessScopeChecker(context.Background(),
-				sac.AllowFixedScopes(sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
-					sac.ResourceScopeKeys(resources.Administration, resources.Integration))),
+			ctx: sac.WithGlobalAccessScopeChecker(context.Background(), sac.AllowFixedScopes(
+				sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
+				sac.ResourceScopeKeys(resources.Administration, resources.Integration))),
 			access:      storage.Access_READ_WRITE_ACCESS,
 			shouldFail:  true,
 			expectedErr: errox.NotAuthorized,
 		},
-		// TODO: ROX-12750 replace ServiceIdentity with Administration
-		"read access to only ServiceIdentity should not allow read access": {
+		"read access to only Administration should not allow read access": {
 			ctx: sac.WithGlobalAccessScopeChecker(context.Background(), sac.AllowFixedScopes(
 				sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
-				sac.ResourceScopeKeys(resources.ServiceIdentity))),
+				sac.ResourceScopeKeys(resources.Administration))),
 			access:      storage.Access_READ_ACCESS,
 			shouldFail:  true,
 			expectedErr: errox.NotAuthorized,
@@ -439,26 +420,16 @@ func (s *clusterInitBackendTestSuite) TestCheckAccess() {
 			shouldFail:  true,
 			expectedErr: errox.NotAuthorized,
 		},
-		// TODO: ROX-12750 replace ServiceIdentity with Administration
 		"write access to both should allow write access": {
 			ctx: sac.WithGlobalAccessScopeChecker(context.Background(), sac.AllowFixedScopes(
 				sac.AccessModeScopeKeys(storage.Access_READ_WRITE_ACCESS),
-				sac.ResourceScopeKeys(resources.ServiceIdentity, resources.Integration))),
+				sac.ResourceScopeKeys(resources.Administration, resources.Integration))),
 			access: storage.Access_READ_WRITE_ACCESS,
 		},
-		// TODO: ROX-12750 remove this test (duplicate after migration)
-		"write access to both replacing resources should allow write access": {
-			ctx: sac.WithGlobalAccessScopeChecker(context.Background(),
-				sac.AllowFixedScopes(
-					sac.AccessModeScopeKeys(storage.Access_READ_WRITE_ACCESS),
-					sac.ResourceScopeKeys(resources.Administration, resources.Integration))),
-			access: storage.Access_READ_WRITE_ACCESS,
-		},
-		// TODO: ROX-12750 replace ServiceIdentity with Administration
-		"write access to only ServiceIdentity should not allow write access": {
+		"write access to only Administration should not allow write access": {
 			ctx: sac.WithGlobalAccessScopeChecker(context.Background(), sac.AllowFixedScopes(
 				sac.AccessModeScopeKeys(storage.Access_READ_WRITE_ACCESS),
-				sac.ResourceScopeKeys(resources.ServiceIdentity))),
+				sac.ResourceScopeKeys(resources.Administration))),
 			access:      storage.Access_READ_WRITE_ACCESS,
 			shouldFail:  true,
 			expectedErr: errox.NotAuthorized,

--- a/central/clusters/identity.go
+++ b/central/clusters/identity.go
@@ -23,12 +23,11 @@ func CreateIdentity(clusterID string, serviceType storage.ServiceType, identityS
 		return nil, err
 	}
 	if identityStore != nil {
-		// TODO: ROX-12750 replace ServiceIdentity with Administration
-		srvIDAllAccessCtx := sac.WithGlobalAccessScopeChecker(context.Background(),
+		administrationAllAccessCtx := sac.WithGlobalAccessScopeChecker(context.Background(),
 			sac.AllowFixedScopes(
 				sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
-				sac.ResourceScopeKeys(resources.ServiceIdentity)))
-		if err := identityStore.AddServiceIdentity(srvIDAllAccessCtx, issuedCert.ID); err != nil {
+				sac.ResourceScopeKeys(resources.Administration)))
+		if err := identityStore.AddServiceIdentity(administrationAllAccessCtx, issuedCert.ID); err != nil {
 			return nil, err
 		}
 	}

--- a/central/integrationhealth/service/service_impl.go
+++ b/central/integrationhealth/service/service_impl.go
@@ -24,8 +24,7 @@ var (
 			"/v1.IntegrationHealthService/GetNotifiers",
 			"/v1.IntegrationHealthService/GetDeclarativeConfigs",
 		},
-		// TODO: ROX-12750 Replace ScannerDefinitions with Administration
-		user.With(permissions.View(resources.ScannerDefinitions)): {
+		user.With(permissions.View(resources.Administration)): {
 			"/v1.IntegrationHealthService/GetVulnDefinitionsInfo",
 		},
 	})

--- a/central/main.go
+++ b/central/main.go
@@ -619,16 +619,14 @@ func customRoutes() (customRoutes []routes.CustomRoute) {
 	customRoutes = []routes.CustomRoute{
 		uiRoute(),
 		{
-			Route: "/api/extensions/clusters/zip",
-			// TODO: ROX-12750 Replace ServiceIdentity with Administration.
-			Authorizer:    or.SensorOrAuthorizer(user.With(permissions.View(resources.Cluster), permissions.View(resources.ServiceIdentity))),
+			Route:         "/api/extensions/clusters/zip",
+			Authorizer:    or.SensorOrAuthorizer(user.With(permissions.View(resources.Cluster), permissions.View(resources.Administration))),
 			ServerHandler: clustersZip.Handler(clusterDataStore.Singleton(), siStore.Singleton()),
 			Compression:   false,
 		},
 		{
-			Route: "/api/extensions/scanner/zip",
-			// TODO: ROX-12750 Replace ScannerBundle with Administration.
-			Authorizer:    user.With(permissions.View(resources.ScannerBundle)),
+			Route:         "/api/extensions/scanner/zip",
+			Authorizer:    user.With(permissions.View(resources.Administration)),
 			ServerHandler: scanner.Handler(),
 			Compression:   false,
 		},
@@ -784,12 +782,10 @@ func customRoutes() (customRoutes []routes.CustomRoute) {
 			Authorizer: perrpc.FromMap(map[authz.Authorizer][]string{
 				or.SensorOrAuthorizer(
 					or.ScannerOr(
-						// TODO: ROX-12750 Replace ScannerDefinitions with Administration.
-						user.With(permissions.View(resources.ScannerDefinitions)))): {
+						user.With(permissions.View(resources.Administration)))): {
 					routes.RPCNameForHTTP(scannerDefinitionsRoute, http.MethodGet),
 				},
-				// TODO: ROX-12750 Replace ScannerDefinitions with Administration.
-				user.With(permissions.Modify(resources.ScannerDefinitions)): {
+				user.With(permissions.Modify(resources.Administration)): {
 					routes.RPCNameForHTTP(scannerDefinitionsRoute, http.MethodPost),
 				},
 			}),

--- a/central/role/datastore/singleton.go
+++ b/central/role/datastore/singleton.go
@@ -126,8 +126,7 @@ var defaultRoles = map[string]roleAttributes{
 		resourceWithAccess: []permissions.ResourceWithAccess{
 			permissions.View(resources.Cluster),
 			permissions.Modify(resources.Cluster),
-			// TODO: ROX-12750 Replace ServiceIdentity with Administration.
-			permissions.Modify(resources.ServiceIdentity),
+			permissions.Modify(resources.Administration),
 		},
 	},
 	rolePkg.VulnMgmtApprover: {

--- a/central/role/resources/list.go
+++ b/central/role/resources/list.go
@@ -91,16 +91,7 @@ var (
 	// To-be-deprecated in 4.1 with ROX-14398 (deprecation notice in 3.74).
 	Role = newDeprecatedResourceMetadata("Role", permissions.GlobalScope, Access)
 	// To-be-deprecated in 4.0 with ROX-12750 (deprecation notice in 3.73).
-	ScannerBundle = newDeprecatedResourceMetadata("ScannerBundle",
-		permissions.GlobalScope, Administration)
-	// To-be-deprecated in 4.0 with ROX-12750 (deprecation notice in 3.73).
-	ScannerDefinitions = newDeprecatedResourceMetadata("ScannerDefinitions",
-		permissions.GlobalScope, Administration)
-	// To-be-deprecated in 4.0 with ROX-12750 (deprecation notice in 3.73).
 	SensorUpgradeConfig = newDeprecatedResourceMetadata("SensorUpgradeConfig",
-		permissions.GlobalScope, Administration)
-	// To-be-deprecated in 4.0 with ROX-12750 (deprecation notice in 3.73).
-	ServiceIdentity = newDeprecatedResourceMetadata("ServiceIdentity",
 		permissions.GlobalScope, Administration)
 	// To-be-deprecated in 4.1 with ROX-13888 (deprecation notice in 3.74).
 	VulnerabilityReports = newDeprecatedResourceMetadata("VulnerabilityReports", permissions.GlobalScope,

--- a/central/serviceidentities/datastore/datastore_impl.go
+++ b/central/serviceidentities/datastore/datastore_impl.go
@@ -10,8 +10,7 @@ import (
 )
 
 var (
-	// TODO: ROX-12750 Replace ServiceIdentity with Administration and rename variable.
-	serviceIdentitiesSAC = sac.ForResource(resources.ServiceIdentity)
+	administrationSAC = sac.ForResource(resources.Administration)
 )
 
 type dataStoreImpl struct {
@@ -19,7 +18,7 @@ type dataStoreImpl struct {
 }
 
 func (ds *dataStoreImpl) GetServiceIdentities(ctx context.Context) ([]*storage.ServiceIdentity, error) {
-	if ok, err := serviceIdentitiesSAC.ReadAllowed(ctx); err != nil {
+	if ok, err := administrationSAC.ReadAllowed(ctx); err != nil {
 		return nil, err
 	} else if !ok {
 		return nil, nil
@@ -29,7 +28,7 @@ func (ds *dataStoreImpl) GetServiceIdentities(ctx context.Context) ([]*storage.S
 }
 
 func (ds *dataStoreImpl) AddServiceIdentity(ctx context.Context, identity *storage.ServiceIdentity) error {
-	if ok, err := serviceIdentitiesSAC.WriteAllowed(ctx); err != nil {
+	if ok, err := administrationSAC.WriteAllowed(ctx); err != nil {
 		return err
 	} else if !ok {
 		return sac.ErrResourceAccessDenied

--- a/central/serviceidentities/datastore/datastore_impl_test.go
+++ b/central/serviceidentities/datastore/datastore_impl_test.go
@@ -24,10 +24,6 @@ type serviceIdentityDataStoreTestSuite struct {
 	hasReadCtx  context.Context
 	hasWriteCtx context.Context
 
-	// TODO: ROX-12750 Remove hasReadAdministrationCtx and hasWriteAdministrationCtx variables.
-	hasReadAdministrationCtx  context.Context
-	hasWriteAdministrationCtx context.Context
-
 	dataStore DataStore
 	storage   *storeMocks.MockStore
 
@@ -39,20 +35,8 @@ func (s *serviceIdentityDataStoreTestSuite) SetupTest() {
 	s.hasReadCtx = sac.WithGlobalAccessScopeChecker(context.Background(),
 		sac.AllowFixedScopes(
 			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
-			// TODO: ROX_12750 Replace ServiceIdentity with Administration.
-			sac.ResourceScopeKeys(resources.ServiceIdentity)))
-	// TODO: ROX-12750 Remove hasReadAdministrationCtx and hasWriteAdministrationCtx variables.
-	s.hasReadAdministrationCtx = sac.WithGlobalAccessScopeChecker(context.Background(),
-		sac.AllowFixedScopes(
-			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
 			sac.ResourceScopeKeys(resources.Administration)))
 	s.hasWriteCtx = sac.WithGlobalAccessScopeChecker(context.Background(),
-		sac.AllowFixedScopes(
-			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
-			// TODO: ROX_12750 Replace ServiceIdentity with Administration.
-			sac.ResourceScopeKeys(resources.ServiceIdentity)))
-	// TODO: ROX-12750 Remove hasReadAdministrationCtx and hasWriteAdministrationCtx variables.
-	s.hasWriteAdministrationCtx = sac.WithGlobalAccessScopeChecker(context.Background(),
 		sac.AllowFixedScopes(
 			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
 			sac.ResourceScopeKeys(resources.Administration)))
@@ -71,24 +55,13 @@ func (s *serviceIdentityDataStoreTestSuite) TestAddSrvId() {
 	}
 	allSrvIDs := []*storage.ServiceIdentity{srvID}
 
-	// TODO: ROX-12750 Adapt expected call count.
-	s.storage.EXPECT().GetAll(gomock.Any()).Return(allSrvIDs, nil).Times(2)
-	// TODO: ROX-12750 Adapt expected call count.
-	s.storage.EXPECT().Upsert(gomock.Any(), srvID).Return(nil).Times(2)
+	s.storage.EXPECT().GetAll(gomock.Any()).Return(allSrvIDs, nil).Times(1)
+	s.storage.EXPECT().Upsert(gomock.Any(), srvID).Return(nil).Times(1)
 
 	err := s.dataStore.AddServiceIdentity(s.hasWriteCtx, srvID)
 	s.NoError(err)
 
-	// TODO: ROX-12750 Remove test with hasWriteAdministrationCtx variable.
-	err = s.dataStore.AddServiceIdentity(s.hasWriteAdministrationCtx, srvID)
-	s.NoError(err)
-
 	result, err := s.dataStore.GetServiceIdentities(s.hasReadCtx)
-	s.Equal(allSrvIDs, result)
-	s.NoError(err)
-
-	// TODO: ROX-12750 Remove test with hasReadAdministrationCtx variable.
-	result, err = s.dataStore.GetServiceIdentities(s.hasReadAdministrationCtx)
 	s.Equal(allSrvIDs, result)
 	s.NoError(err)
 }
@@ -102,14 +75,9 @@ func (s *serviceIdentityDataStoreTestSuite) TestEnforcesGet() {
 }
 
 func (s *serviceIdentityDataStoreTestSuite) TestAllowsGet() {
-	// TODO: ROX-12750 Adapt expected call count.
-	s.storage.EXPECT().GetAll(gomock.Any()).Return(nil, nil).Times(2)
+	s.storage.EXPECT().GetAll(gomock.Any()).Return(nil, nil).Times(1)
 
 	_, err := s.dataStore.GetServiceIdentities(s.hasReadCtx)
-	s.NoError(err, "expected no error trying to read with permissions")
-
-	// TODO: ROX-12750 Remove test with hasReadAdministrationCtx variable.
-	_, err = s.dataStore.GetServiceIdentities(s.hasReadAdministrationCtx)
 	s.NoError(err, "expected no error trying to read with permissions")
 }
 
@@ -121,20 +89,11 @@ func (s *serviceIdentityDataStoreTestSuite) TestEnforcesAdd() {
 
 	err = s.dataStore.AddServiceIdentity(s.hasReadCtx, &storage.ServiceIdentity{})
 	s.Error(err, "expected an error trying to write without permissions")
-
-	// TODO: ROX-12750 Remove test with hasReadAdministrationCtx variable.
-	err = s.dataStore.AddServiceIdentity(s.hasReadAdministrationCtx, &storage.ServiceIdentity{})
-	s.Error(err, "expected an error trying to write without permissions")
 }
 
 func (s *serviceIdentityDataStoreTestSuite) TestAllowsAdd() {
-	// TODO: ROX-12750 Adapt expected call count.
-	s.storage.EXPECT().Upsert(gomock.Any(), gomock.Any()).Return(nil).Times(2)
+	s.storage.EXPECT().Upsert(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 
 	err := s.dataStore.AddServiceIdentity(s.hasWriteCtx, &storage.ServiceIdentity{})
 	s.NoError(err, "expected no error trying to write with permissions")
-
-	// TODO: ROX-12750 Remove test with hasWriteAdministrationCtx variable.
-	err = s.dataStore.AddServiceIdentity(s.hasWriteAdministrationCtx, &storage.ServiceIdentity{})
-	s.NoError(err, "expected no error trying to write with Administration permissions")
 }

--- a/central/serviceidentities/internal/store/postgres/store.go
+++ b/central/serviceidentities/internal/store/postgres/store.go
@@ -42,7 +42,7 @@ const (
 var (
 	log            = logging.LoggerForModule()
 	schema         = pkgSchema.ServiceIdentitiesSchema
-	targetResource = resources.ServiceIdentity
+	targetResource = resources.Administration
 )
 
 // Store is the interface to interact with the storage for storage.ServiceIdentity

--- a/central/serviceidentities/service/service_impl.go
+++ b/central/serviceidentities/service/service_impl.go
@@ -20,13 +20,11 @@ import (
 
 var (
 	authorizer = perrpc.FromMap(map[authz.Authorizer][]string{
-		// TODO: ROX-12750 Replace ServiceIdentity with Administration.
-		user.With(permissions.View(resources.ServiceIdentity)): {
+		user.With(permissions.View(resources.Administration)): {
 			"/v1.ServiceIdentityService/GetServiceIdentities",
 			"/v1.ServiceIdentityService/GetAuthorities",
 		},
-		// TODO: ROX-12750 Replace ServiceIdentity with Administration.
-		user.With(permissions.Modify(resources.ServiceIdentity)): {
+		user.With(permissions.Modify(resources.Administration)): {
 			"/v1.ServiceIdentityService/CreateServiceIdentity",
 		},
 	})

--- a/tools/generate-helpers/pg-table-bindings/list.go
+++ b/tools/generate-helpers/pg-table-bindings/list.go
@@ -75,9 +75,8 @@ func init() {
 		// TODO: ROX-14398 Replace Role with Access
 		&storage.Role{}: resources.Role,
 		// TODO: ROX-12750 Replace SensorUpgradeConfig with Administration.
-		&storage.SensorUpgradeConfig{}: resources.SensorUpgradeConfig,
-		// TODO: ROX-12750 Replace ServiceIdentity with Administration.
-		&storage.ServiceIdentity{}:      resources.ServiceIdentity,
+		&storage.SensorUpgradeConfig{}:  resources.SensorUpgradeConfig,
+		&storage.ServiceIdentity{}:      resources.Administration,
 		&storage.SignatureIntegration{}: resources.Integration,
 		// TODO: ROX-14398 Replace Role with Access
 		&storage.SimpleAccessScope{}:      resources.Role,


### PR DESCRIPTION
## Description

The set resources used for access control is being simplified. A number of resources has been deprecated.

The goal here is to get rid of the deprecated resources, both in the database and in the codebase (UI, QA, central, DB).
This PR focuses on the `ScannerBundle`, `ScannerDefinitions` and `ServiceIdentity` resources in central.

## Checklist
- [ ] Investigated and inspected CI test results
~~- [ ] Unit test and regression tests added~~
~~- [ ] Evaluated and added CHANGELOG entry if required~~
~~- [ ] Determined and documented upgrade steps~~
~~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

CI should be sufficient.