### PR TITLE
ROX-12750: Resource grouping - central part for AllComments, ComplianceRuns, ProbeUpload and SensorUpgradeConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 
 - ROX-14336: product `BuildDate` attribute was removed. It won't be returned by
 `/debug/versions.json` endpoint and `roxctl version --json` command.
-- ROX-11101: As announced in 3.73.0 (ROX-11101), some permissions for permission sets are being grouped for simplification. The deprecation process will remove and replace the deprecated permissions with the replacing permission as listed below. The access level granted to the replacing permission will be the lowest among all access levels of the replaced permissions. 
+- ROX-12750: As announced in 3.73.0 (ROX-11101), some permissions for permission sets are being grouped for simplification. The deprecation process will remove and replace the deprecated permissions with the replacing permission as listed below. The access level granted to the replacing permission will be the lowest among all access levels of the replaced permissions. 
   - Permission `Administration` replaces the deprecated permissions `AllComments, Config, DebugLogs, NetworkGraphConfig, ProbeUpload, ScannerBundle, ScannerDefinitions, SensorUpgradeConfig, ServiceIdentity`.
   - Permission `Compliance` replaces the deprecated permission `ComplianceRuns`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 
 - ROX-14336: product `BuildDate` attribute was removed. It won't be returned by
 `/debug/versions.json` endpoint and `roxctl version --json` command.
+- ROX-11101: As announced in 3.73.0 (ROX-11101), some permissions for permission sets are being grouped for simplification. The deprecation process will remove and replace the deprecated permissions with the replacing permission as listed below. The access level granted to the replacing permission will be the lowest among all access levels of the replaced permissions. 
+  - Permission `Administration` replaces the deprecated permissions `AllComments, Config, DebugLogs, NetworkGraphConfig, ProbeUpload, ScannerBundle, ScannerDefinitions, SensorUpgradeConfig, ServiceIdentity`.
+  - Permission `Compliance` replaces the deprecated permission `ComplianceRuns`.
+
 
 ### Deprecated Features
 - Deprecated `/v1/telemetry/configure` service.

--- a/central/compliance/manager/service/service_impl.go
+++ b/central/compliance/manager/service/service_impl.go
@@ -20,13 +20,11 @@ import (
 
 var (
 	authorizer = perrpc.FromMap(map[authz.Authorizer][]string{
-		// TODO: ROX-12750 Replace ComplianceRuns with Compliance
-		user.With(permissions.View(resources.ComplianceRuns)): {
+		user.With(permissions.View(resources.Compliance)): {
 			"/v1.ComplianceManagementService/GetRecentRuns",
 			"/v1.ComplianceManagementService/GetRunStatuses",
 		},
-		// TODO: ROX-12750 Replace ComplianceRuns with Compliance
-		user.With(permissions.Modify(resources.ComplianceRuns)): {
+		user.With(permissions.Modify(resources.Compliance)): {
 			"/v1.ComplianceManagementService/TriggerRun",
 			"/v1.ComplianceManagementService/TriggerRuns",
 		},

--- a/central/compliance/manager/test/manager_test.go
+++ b/central/compliance/manager/test/manager_test.go
@@ -126,13 +126,11 @@ func (s *managerTestSuite) SetupTest() {
 	s.testCtx = sac.WithGlobalAccessScopeChecker(context.Background(),
 		sac.AllowFixedScopes(
 			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
-			// TODO: ROX-12750 Replace ComplianceRuns with Compliance
-			sac.ResourceScopeKeys(resources.ComplianceRuns)))
+			sac.ResourceScopeKeys(resources.Compliance)))
 	s.readOnlyCtx = sac.WithGlobalAccessScopeChecker(context.Background(),
 		sac.AllowFixedScopes(
 			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
-			// TODO: ROX-12750 Replace ComplianceRuns with Compliance
-			sac.ResourceScopeKeys(resources.ComplianceRuns)))
+			sac.ResourceScopeKeys(resources.Compliance)))
 	s.mockCtrl = gomock.NewController(s.T())
 	var err error
 	s.standardRegistry, err = standards.NewRegistry(nil, nil)

--- a/central/graphql/resolvers/compliance_management.go
+++ b/central/graphql/resolvers/compliance_management.go
@@ -21,8 +21,7 @@ func init() {
 
 // ComplianceTriggerRuns is a mutation to trigger compliance runs on a specific cluster and standard (or all clusters/all standards)
 func (resolver *Resolver) ComplianceTriggerRuns(ctx context.Context, args struct{ ClusterID, StandardID graphql.ID }) ([]*complianceRunResolver, error) {
-	// TODO: ROX-12750 Replace writeComplianceRuns with writeCompliance
-	if err := writeComplianceRuns(ctx); err != nil {
+	if err := writeCompliance(ctx); err != nil {
 		return nil, err
 	}
 	resp, err := resolver.ComplianceManagementService.TriggerRuns(ctx, &v1.TriggerComplianceRunsRequest{
@@ -36,8 +35,7 @@ func (resolver *Resolver) ComplianceTriggerRuns(ctx context.Context, args struct
 
 // ComplianceRunStatuses is a query to obtain the statuses of a list of compliance runs.
 func (resolver *Resolver) ComplianceRunStatuses(ctx context.Context, args struct{ Ids []graphql.ID }) (*getComplianceRunStatusesResponseResolver, error) {
-	// TODO: ROX-12750 Replace readComplianceRuns with readCompliance
-	if err := readComplianceRuns(ctx); err != nil {
+	if err := readCompliance(ctx); err != nil {
 		return nil, err
 	}
 	idStrings := make([]string, len(args.Ids))
@@ -57,8 +55,7 @@ func (resolver *Resolver) ComplianceRecentRuns(
 		ClusterID, StandardID *graphql.ID
 		Since                 *graphql.Time
 	}) ([]*complianceRunResolver, error) {
-	// TODO: ROX-12750 Replace readComplianceRuns with readCompliance
-	if err := readComplianceRuns(ctx); err != nil {
+	if err := readCompliance(ctx); err != nil {
 		return nil, err
 	}
 	req := &v1.GetRecentComplianceRunsRequest{}
@@ -84,8 +81,7 @@ func (resolver *Resolver) ComplianceRecentRuns(
 
 // ComplianceRun returns a specific compliance run, if it exists
 func (resolver *Resolver) ComplianceRun(ctx context.Context, args struct{ graphql.ID }) (*complianceRunResolver, error) {
-	// TODO: ROX-12750 Replace readComplianceRuns with readCompliance
-	if err := readComplianceRuns(ctx); err != nil {
+	if err := readCompliance(ctx); err != nil {
 		return nil, err
 	}
 	run, err := resolver.ComplianceManager.GetRecentRun(ctx, string(args.ID))

--- a/central/graphql/resolvers/resolver.go
+++ b/central/graphql/resolvers/resolver.go
@@ -194,12 +194,10 @@ func New() *Resolver {
 
 //lint:file-ignore U1000 It's okay for some of the variables below to be unused.
 var (
-	readAccess     = readAuth(resources.Access)
-	readAlerts     = readAuth(resources.Alert)
-	readClusters   = readAuth(resources.Cluster)
-	readCompliance = readAuth(resources.Compliance)
-	// TODO: ROX-12750 Remove readComplianceRuns
-	readComplianceRuns       = readAuth(resources.ComplianceRuns)
+	readAccess               = readAuth(resources.Access)
+	readAlerts               = readAuth(resources.Alert)
+	readClusters             = readAuth(resources.Cluster)
+	readCompliance           = readAuth(resources.Compliance)
 	readCVEs                 = readAuth(resources.CVE)
 	readDeployments          = readAuth(resources.Deployment)
 	readDeploymentExtensions = readAuth(resources.DeploymentExtension)
@@ -219,10 +217,8 @@ var (
 	readServiceAccounts                  = readAuth(resources.ServiceAccount)
 	readVulnerabilityRequestsOrApprovals = anyReadAuth(resources.VulnerabilityManagementRequests, resources.VulnerabilityManagementApprovals)
 
-	writeAlerts     = writeAuth(resources.Alert)
-	writeCompliance = writeAuth(resources.Compliance)
-	// TODO: ROX-12750 Remove writeComplianceRuns
-	writeComplianceRuns                   = writeAuth(resources.ComplianceRuns)
+	writeAlerts                           = writeAuth(resources.Alert)
+	writeCompliance                       = writeAuth(resources.Compliance)
 	writeIndicators                       = writeAuth(resources.DeploymentExtension)
 	writeVulnerabilityRequests            = writeAuth(resources.VulnerabilityManagementRequests)
 	writeVulnerabilityApprovals           = writeAuth(resources.VulnerabilityManagementApprovals)

--- a/central/main.go
+++ b/central/main.go
@@ -254,7 +254,6 @@ func main() {
 	devmode.StartOnDevBuilds("central")
 
 	log.Infof("Running StackRox Version: %s", pkgVersion.GetMainVersion())
-	// TODO: ROX-12750 update with new list of replaced/deprecated resources
 	log.Warn("The following permission resources have been replaced:\n" +
 		"	Access replaces AuthProvider, Group, Licenses, and User\n" +
 		"	Administration replaces AllComments, Config, DebugLogs, NetworkGraphConfig, ProbeUpload, ScannerBundle, ScannerDefinitions, SensorUpgradeConfig, and ServiceIdentity\n" +

--- a/central/probeupload/manager/manager_impl.go
+++ b/central/probeupload/manager/manager_impl.go
@@ -37,8 +37,7 @@ const (
 var (
 	log = logging.LoggerForModule()
 
-	// TODO: ROX-12750 Replace ProbeUpload with Administration and rename the variable.
-	probeUploadSAC = sac.ForResource(resources.ProbeUpload)
+	administrationSAC = sac.ForResource(resources.Administration)
 )
 
 type manager struct {
@@ -192,7 +191,7 @@ func (m *manager) getFileInfo(file string) (*v1.ProbeUploadManifest_File, error)
 }
 
 func (m *manager) GetExistingProbeFiles(ctx context.Context, files []string) ([]*v1.ProbeUploadManifest_File, error) {
-	if ok, err := probeUploadSAC.ReadAllowed(ctx); !ok || err != nil {
+	if ok, err := administrationSAC.ReadAllowed(ctx); !ok || err != nil {
 		return nil, err
 	}
 
@@ -210,7 +209,7 @@ func (m *manager) GetExistingProbeFiles(ctx context.Context, files []string) ([]
 }
 
 func (m *manager) StoreFile(ctx context.Context, file string, data io.Reader, size int64, crc32Sum uint32) error {
-	if ok, err := probeUploadSAC.WriteAllowed(ctx); err != nil {
+	if ok, err := administrationSAC.WriteAllowed(ctx); err != nil {
 		return err
 	} else if !ok {
 		return sac.ErrResourceAccessDenied

--- a/central/probeupload/service/service_impl.go
+++ b/central/probeupload/service/service_impl.go
@@ -30,8 +30,7 @@ import (
 
 var (
 	authorizer = perrpc.FromMap(map[authz.Authorizer][]string{
-		// TODO: ROX-12750 Replace ProbeUpload with Administration
-		user.With(permissions.View(resources.ProbeUpload)): {
+		user.With(permissions.View(resources.Administration)): {
 			"/v1.ProbeUploadService/GetExistingProbes",
 		},
 	})
@@ -80,9 +79,8 @@ func (s *service) GetExistingProbes(ctx context.Context, req *v1.GetExistingProb
 func (s *service) CustomRoutes() []routes.CustomRoute {
 	return []routes.CustomRoute{
 		{
-			Route: "/api/extensions/probeupload",
-			// TODO: ROX-12750 Replace ProbeUpload with Administration.
-			Authorizer: user.With(permissions.Modify(resources.ProbeUpload)),
+			Route:      "/api/extensions/probeupload",
+			Authorizer: user.With(permissions.Modify(resources.Administration)),
 			ServerHandler: utils.IfThenElse[http.Handler](
 				env.EnableKernelPackageUpload.BooleanSetting(), http.HandlerFunc(s.handleProbeUpload),
 				httputil.NotImplementedHandler("api is not supported because kernel package upload is disabled.")),

--- a/central/role/resources/list.go
+++ b/central/role/resources/list.go
@@ -77,22 +77,10 @@ var (
 	// Policy, VulnerabilityReports.
 	WorkflowAdministration = newResourceMetadata("WorkflowAdministration", permissions.GlobalScope)
 
-	// To-be-deprecated in 4.0 with ROX-12750 (deprecation notice in 3.73).
-	AllComments = newDeprecatedResourceMetadata("AllComments", permissions.GlobalScope,
-		Administration)
-	// To-be-deprecated in 4.0 with ROX-12750 (deprecation notice in 3.73).
-	ComplianceRuns = newDeprecatedResourceMetadata("ComplianceRuns", permissions.ClusterScope,
-		Compliance)
 	// To-be-deprecated in 4.1 with ROX-13888 (deprecation notice in 3.74).
 	Policy = newDeprecatedResourceMetadata("Policy", permissions.GlobalScope, WorkflowAdministration)
-	// To-be-deprecated in 4.0 with ROX-12750 (deprecation notice in 3.73).
-	ProbeUpload = newDeprecatedResourceMetadata("ProbeUpload", permissions.GlobalScope,
-		Administration)
 	// To-be-deprecated in 4.1 with ROX-14398 (deprecation notice in 3.74).
 	Role = newDeprecatedResourceMetadata("Role", permissions.GlobalScope, Access)
-	// To-be-deprecated in 4.0 with ROX-12750 (deprecation notice in 3.73).
-	SensorUpgradeConfig = newDeprecatedResourceMetadata("SensorUpgradeConfig",
-		permissions.GlobalScope, Administration)
 	// To-be-deprecated in 4.1 with ROX-13888 (deprecation notice in 3.74).
 	VulnerabilityReports = newDeprecatedResourceMetadata("VulnerabilityReports", permissions.GlobalScope,
 		WorkflowAdministration)

--- a/central/sac/authorizer/builtin_scoped_authorizer_test.go
+++ b/central/sac/authorizer/builtin_scoped_authorizer_test.go
@@ -94,13 +94,6 @@ func TestBuiltInScopeAuthorizerWithTracing(t *testing.T) {
 			results:   []bool{false, false, true},
 		},
 		{
-			name:  "allow read from compliance with replacing resource permissions",
-			roles: []permissions.ResolvedRole{role(complianceEdit, withAccessTo1Cluster())}, // TODO: ROX-12750 Replace ComplianceRuns with Compliance.
-
-			scopeKeys: readCluster(firstClusterID, resources.ComplianceRuns.Resource),
-			results:   []bool{false, false, true},
-		},
-		{
 			name: "allow read from namespace with multiple roles",
 			roles: []permissions.ResolvedRole{
 				role(allResourcesView, withAccessTo1Namespace()),
@@ -434,17 +427,15 @@ func TestEffectiveAccessScope(t *testing.T) {
 			resultEAS: effectiveaccessscope.DenyAllEffectiveAccessScope(),
 		},
 		{
-			name:  "Access to replaced resource (read-only) for unrestricted scope gives unrestricted scope tree for the resource and any access (case read cluster)",
-			roles: []permissions.ResolvedRole{role(complianceEdit, rolePkg.AccessScopeIncludeAll)},
-			// TODO: ROX-12750 Replace ComplianceRuns with Compliance.
-			resource:  resourceWithAccess(storage.Access_READ_ACCESS, resources.ComplianceRuns),
+			name:      "Access to resource (read-only) for unrestricted scope gives unrestricted scope tree for the resource and any access (case read cluster)",
+			roles:     []permissions.ResolvedRole{role(complianceEdit, rolePkg.AccessScopeIncludeAll)},
+			resource:  resourceWithAccess(storage.Access_READ_ACCESS, resources.Compliance),
 			resultEAS: effectiveaccessscope.UnrestrictedEffectiveAccessScope(),
 		},
 		{
-			name:  "Access to replaced resource (read-write) for unrestricted scope gives unrestricted scope tree for the resource and any access (case write cluster)",
-			roles: []permissions.ResolvedRole{role(complianceEdit, rolePkg.AccessScopeIncludeAll)},
-			// TODO: ROX-12750 Replace ComplianceRuns with Compliance.
-			resource:  resourceWithAccess(storage.Access_READ_WRITE_ACCESS, resources.ComplianceRuns),
+			name:      "Access to resource (read-write) for unrestricted scope gives unrestricted scope tree for the resource and any access (case write cluster)",
+			roles:     []permissions.ResolvedRole{role(complianceEdit, rolePkg.AccessScopeIncludeAll)},
+			resource:  resourceWithAccess(storage.Access_READ_WRITE_ACCESS, resources.Compliance),
 			resultEAS: effectiveaccessscope.UnrestrictedEffectiveAccessScope(),
 		},
 		{
@@ -577,45 +568,41 @@ func TestEffectiveAccessScope(t *testing.T) {
 			resultEAS: effectiveaccessscope.DenyAllEffectiveAccessScope(),
 		},
 		{
-			name:  "Access to specific replaced resource (read-only) for namespace scope gives namespace scope tree for the resource and any access (case read cluster)",
-			roles: []permissions.ResolvedRole{role(complianceEdit, withAccessTo1Namespace())},
-			// TODO: ROX-12750 Replace ComplianceRuns with Compliance.
-			resource:  resourceWithAccess(storage.Access_READ_ACCESS, resources.ComplianceRuns),
+			name:      "Access to specific resource (read-only) for namespace scope gives namespace scope tree for the resource and any access (case read cluster)",
+			roles:     []permissions.ResolvedRole{role(complianceEdit, withAccessTo1Namespace())},
+			resource:  resourceWithAccess(storage.Access_READ_ACCESS, resources.Compliance),
 			resultEAS: oneNamespaceEffectiveScope,
 		},
 		{
-			name:  "Access to specific replaced resource (read-write) for namespace scope gives namespace scope tree for the resource and any access (case write cluster)",
-			roles: []permissions.ResolvedRole{role(complianceEdit, withAccessTo1Namespace())},
-			// TODO: ROX-12750 Replace ComplianceRuns with Compliance.
-			resource:  resourceWithAccess(storage.Access_READ_WRITE_ACCESS, resources.ComplianceRuns),
+			name:      "Access to specific resource (read-write) for namespace scope gives namespace scope tree for the resource and any access (case write cluster)",
+			roles:     []permissions.ResolvedRole{role(complianceEdit, withAccessTo1Namespace())},
+			resource:  resourceWithAccess(storage.Access_READ_WRITE_ACCESS, resources.Compliance),
 			resultEAS: oneNamespaceEffectiveScope,
 		},
 		{
-			name:      "Access to specific replaced resource (read-only) for namespace scope gives deny-all scope tree for any other resource and access (case read namespace)",
+			name:      "Access to specific resource (read-only) for namespace scope gives deny-all scope tree for any other resource and access (case read namespace)",
 			roles:     []permissions.ResolvedRole{role(complianceEdit, withAccessTo1Namespace())},
 			resource:  resourceWithAccess(storage.Access_READ_ACCESS, resources.Cluster),
 			resultEAS: effectiveaccessscope.DenyAllEffectiveAccessScope(),
 		},
 		{
-			name:      "Access to specific replaced resource (read-write) for namespace scope gives deny-all scope tree for any other resource and access (case write namespace)",
+			name:      "Access to specific resource (read-write) for namespace scope gives deny-all scope tree for any other resource and access (case write namespace)",
 			roles:     []permissions.ResolvedRole{role(complianceEdit, withAccessTo1Namespace())},
 			resource:  resourceWithAccess(storage.Access_READ_WRITE_ACCESS, resources.Cluster),
 			resultEAS: effectiveaccessscope.DenyAllEffectiveAccessScope(),
 		},
 		{
-			name: "Access to specific replaced resource (read-only) for mixed scope gives union scope tree for the resource and any access (case read cluster)",
+			name: "Access to specific resource (read-only) for mixed scope gives union scope tree for the resource and any access (case read cluster)",
 			roles: []permissions.ResolvedRole{
 				role(complianceEdit, withAccessTo1Namespace()), role(complianceEdit, withAccessTo2Cluster())},
-			// TODO: ROX-12750 Replace ComplianceRuns with Compliance.
-			resource:  resourceWithAccess(storage.Access_READ_ACCESS, resources.ComplianceRuns),
+			resource:  resourceWithAccess(storage.Access_READ_ACCESS, resources.Compliance),
 			resultEAS: mixedEffectiveScope,
 		},
 		{
-			name: "Access to specific replaced resource (read-write) for mixed scope gives union scope tree for the resource and any access (case write cluster)",
+			name: "Access to specific resource (read-write) for mixed scope gives union scope tree for the resource and any access (case write cluster)",
 			roles: []permissions.ResolvedRole{
 				role(complianceEdit, withAccessTo1Namespace()), role(complianceEdit, withAccessTo2Cluster())},
-			// TODO: ROX-12750 Replace ComplianceRuns with Compliance.
-			resource:  resourceWithAccess(storage.Access_READ_WRITE_ACCESS, resources.ComplianceRuns),
+			resource:  resourceWithAccess(storage.Access_READ_WRITE_ACCESS, resources.Compliance),
 			resultEAS: mixedEffectiveScope,
 		},
 		{

--- a/central/sensorupgrade/service/service_impl.go
+++ b/central/sensorupgrade/service/service_impl.go
@@ -23,12 +23,10 @@ import (
 
 var (
 	authorizer = perrpc.FromMap(map[authz.Authorizer][]string{
-		// TODO: ROX-12750 Replace SensorUpgradeConfig with Administration.
-		user.With(permissions.View(resources.SensorUpgradeConfig)): {
+		user.With(permissions.View(resources.Administration)): {
 			"/v1.SensorUpgradeService/GetSensorUpgradeConfig",
 		},
-		// TODO: ROX-12750 Replace SensorUpgradeConfig with Administration.
-		user.With(permissions.Modify(resources.SensorUpgradeConfig)): {
+		user.With(permissions.Modify(resources.Administration)): {
 			"/v1.SensorUpgradeService/UpdateSensorUpgradeConfig",
 		},
 		user.With(permissions.Modify(resources.Cluster)): {

--- a/central/sensorupgradeconfig/datastore/datastore_impl.go
+++ b/central/sensorupgradeconfig/datastore/datastore_impl.go
@@ -14,8 +14,7 @@ type dataStore struct {
 }
 
 var (
-	// TODO: ROX-12750 Replace SensorUpgradeConfig with Administration.
-	sacHelper = sac.ForResource(resources.SensorUpgradeConfig)
+	sacHelper = sac.ForResource(resources.Administration)
 )
 
 func (d *dataStore) GetSensorUpgradeConfig(ctx context.Context) (*storage.SensorUpgradeConfig, error) {

--- a/central/sensorupgradeconfig/datastore/datastore_test.go
+++ b/central/sensorupgradeconfig/datastore/datastore_test.go
@@ -23,8 +23,6 @@ type sensorUpgradeConfigDataStoreTestSuite struct {
 	hasNoneCtx  context.Context
 	hasReadCtx  context.Context
 	hasWriteCtx context.Context
-	// TODO: ROX-12750 Remove hasWriteAdministrationCtx variable.
-	hasWriteAdministrationCtx context.Context
 
 	dataStore DataStore
 	storage   *storeMocks.MockStore
@@ -37,15 +35,8 @@ func (s *sensorUpgradeConfigDataStoreTestSuite) SetupTest() {
 	s.hasReadCtx = sac.WithGlobalAccessScopeChecker(context.Background(),
 		sac.AllowFixedScopes(
 			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
-			// TODO: ROX-12750 Replace SensorUpgradeConfig with Administration.
-			sac.ResourceScopeKeys(resources.SensorUpgradeConfig)))
+			sac.ResourceScopeKeys(resources.Administration)))
 	s.hasWriteCtx = sac.WithGlobalAccessScopeChecker(context.Background(),
-		sac.AllowFixedScopes(
-			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
-			// TODO: ROX-12750 Replace SensorUpgradeConfig with Administration.
-			sac.ResourceScopeKeys(resources.SensorUpgradeConfig)))
-	// TODO: ROX-12750 Remove hasWriteAdministrationCtx variable.
-	s.hasWriteAdministrationCtx = sac.WithGlobalAccessScopeChecker(context.Background(),
 		sac.AllowFixedScopes(
 			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
 			sac.ResourceScopeKeys(resources.Administration)))
@@ -73,15 +64,11 @@ func (s *sensorUpgradeConfigDataStoreTestSuite) TestAllowsGet() {
 	_, err := s.dataStore.GetSensorUpgradeConfig(s.hasReadCtx)
 	s.NoError(err, "expected no error trying to read with permissions")
 
-	// TODO: ROX-12750 Adjust the expected call count.
-	s.storage.EXPECT().Get(gomock.Any()).Return(nil, false, nil).Times(2)
+	s.storage.EXPECT().Get(gomock.Any()).Return(nil, false, nil).Times(1)
 
 	_, err = s.dataStore.GetSensorUpgradeConfig(s.hasWriteCtx)
 	s.NoError(err, "expected no error trying to read with permissions")
 
-	// TODO: ROX-12750 Remove test with hasWriteAdministrationCtx variable.
-	_, err = s.dataStore.GetSensorUpgradeConfig(s.hasWriteAdministrationCtx)
-	s.NoError(err, "expected no error trying to read with Administration permissions")
 }
 
 func (s *sensorUpgradeConfigDataStoreTestSuite) TestEnforcesUpdate() {
@@ -95,13 +82,9 @@ func (s *sensorUpgradeConfigDataStoreTestSuite) TestEnforcesUpdate() {
 }
 
 func (s *sensorUpgradeConfigDataStoreTestSuite) TestAllowsUpdate() {
-	// TODO: ROX-12750 Adjust the expected call count.
-	s.storage.EXPECT().Upsert(gomock.Any(), gomock.Any()).Return(nil).Times(2)
+	s.storage.EXPECT().Upsert(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 
 	err := s.dataStore.UpsertSensorUpgradeConfig(s.hasWriteCtx, &storage.SensorUpgradeConfig{})
 	s.NoError(err, "expected no error trying to write with permissions")
 
-	// TODO: ROX-12750 Remove test with hasWriteAdministrationCtx variable.
-	err = s.dataStore.UpsertSensorUpgradeConfig(s.hasWriteAdministrationCtx, &storage.SensorUpgradeConfig{})
-	s.NoError(err, "expected no error trying to write with Administration permissions")
 }

--- a/central/sensorupgradeconfig/datastore/internal/store/postgres/store.go
+++ b/central/sensorupgradeconfig/datastore/internal/store/postgres/store.go
@@ -27,7 +27,7 @@ const (
 var (
 	log            = logging.LoggerForModule()
 	schema         = pkgSchema.SensorUpgradeConfigsSchema
-	targetResource = resources.SensorUpgradeConfig
+	targetResource = resources.Administration
 )
 
 // Store is the interface to interact with the storage for storage.SensorUpgradeConfig

--- a/tools/generate-helpers/pg-table-bindings/list.go
+++ b/tools/generate-helpers/pg-table-bindings/list.go
@@ -73,9 +73,8 @@ func init() {
 		&storage.ReportConfiguration{}: resources.VulnerabilityReports,
 		&storage.Risk{}:                resources.DeploymentExtension,
 		// TODO: ROX-14398 Replace Role with Access
-		&storage.Role{}: resources.Role,
-		// TODO: ROX-12750 Replace SensorUpgradeConfig with Administration.
-		&storage.SensorUpgradeConfig{}:  resources.SensorUpgradeConfig,
+		&storage.Role{}:                 resources.Role,
+		&storage.SensorUpgradeConfig{}:  resources.Administration,
 		&storage.ServiceIdentity{}:      resources.Administration,
 		&storage.SignatureIntegration{}: resources.Integration,
 		// TODO: ROX-14398 Replace Role with Access


### PR DESCRIPTION
## Description

The set resources used for access control is being simplified. A number of resources has been deprecated.

The goal here is to get rid of the deprecated resources, both in the database and in the codebase (UI, QA, central, DB).
This PR focuses on the AllComments, ComplianceRuns, ProbeUpload and SensorUpgradeConfig resources in central.

## Checklist
- [ ] Investigated and inspected CI test results
~~- [ ] Unit test and regression tests added~~
~~- [ ] Evaluated and added CHANGELOG entry if required~~
~~- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

CI should be sufficient