### PR TITLE
ROX-15774: Deprecation changelog entry for expiration field in Excluxion proto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,10 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 - ROX-14336: product `BuildDate` attribute was removed. It won't be returned by
 `/debug/versions.json` endpoint and `roxctl version --json` command.
 
-### Deprecated Fatures
+### Deprecated Features
 - Deprecated `/v1/telemetry/configure` service.
+- The `expiration` field in the `Exclusion` proto will be deprecated in future releases. 
+If you have questions about this change, please contact the Red Hat support team at support@redhat.com.
 
 ### Technical Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 
 ### Deprecated Features
 - Deprecated `/v1/telemetry/configure` service.
-- The `expiration` field in the `Exclusion` proto will be deprecated in future releases. 
-If you have questions about this change, please contact the Red Hat support team at support@redhat.com.
-
+- The `expiration` field in the `Exclusion` proto has been deprecated and will be removed in a future release.
 ### Technical Changes
 
 ## [3.74.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 ### Deprecated Features
 - Deprecated `/v1/telemetry/configure` service.
 - The `expiration` field in the `Exclusion` proto has been deprecated and will be removed in a future release.
+
 ### Technical Changes
 
 ## [3.74.0]


### PR DESCRIPTION

## Description
API only field, no UI for it, reason/context/history for its existence unknown.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Eyeball only