### PR TITLE
ROX-15399: Add metrics for panics in pipelines

### DIFF
--- a/central/metrics/init.go
+++ b/central/metrics/init.go
@@ -22,6 +22,7 @@ func init() {
 	}
 
 	prometheus.MustRegister(
+		pipelinePanicCounter,
 		graphQLOperationHistogramVec,
 		graphQLQueryHistogramVec,
 		indexOperationHistogramVec,

--- a/central/sensor/service/connection/connection_impl.go
+++ b/central/sensor/service/connection/connection_impl.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/central/localscanner"
+	"github.com/stackrox/rox/central/metrics"
 	"github.com/stackrox/rox/central/networkpolicies/graph"
 	"github.com/stackrox/rox/central/scrape"
 	"github.com/stackrox/rox/central/sensor/networkentities"
@@ -162,6 +163,7 @@ func (c *sensorConnection) handleMessages(ctx context.Context, queue *dedupingQu
 			}
 		})
 		if err != nil {
+			metrics.IncPipelinePanics(msg)
 			log.Errorf("panic in handle message: %v", err)
 		}
 	}

--- a/central/sensor/service/connection/connection_impl.go
+++ b/central/sensor/service/connection/connection_impl.go
@@ -163,7 +163,7 @@ func (c *sensorConnection) handleMessages(ctx context.Context, queue *dedupingQu
 			}
 		})
 		if err != nil {
-			metrics.IncPipelinePanics(msg)
+			metrics.IncrementPipelinePanics(msg)
 			log.Errorf("panic in handle message: %v", err)
 		}
 	}

--- a/central/sensor/service/pipeline/all/pipeline.go
+++ b/central/sensor/service/pipeline/all/pipeline.go
@@ -59,7 +59,7 @@ func (s *pipelineImpl) Run(ctx context.Context, msg *central.MsgFromSensor, inje
 				errorList.AddError(fragment.Run(ctx, s.clusterID, msg, injector))
 			})
 			if err != nil {
-				metrics.IncPipelinePanics(msg)
+				metrics.IncrementPipelinePanics(msg)
 				log.Errorf("panic in pipeline execution: %v", err)
 			}
 		}

--- a/central/sensor/service/pipeline/all/pipeline.go
+++ b/central/sensor/service/pipeline/all/pipeline.go
@@ -59,6 +59,7 @@ func (s *pipelineImpl) Run(ctx context.Context, msg *central.MsgFromSensor, inje
 				errorList.AddError(fragment.Run(ctx, s.clusterID, msg, injector))
 			})
 			if err != nil {
+				metrics.IncPipelinePanics(msg)
 				log.Errorf("panic in pipeline execution: %v", err)
 			}
 		}


### PR DESCRIPTION
## Description

Follow up to the safe code

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

```
pipeline_panics resource=AlertResults                                            24
pipeline_panics resource=Binding                                                 164
pipeline_panics resource=ClusterHealthInfo                                       6
pipeline_panics resource=ClusterStatusUpdate                                     4
pipeline_panics resource=Deployment                                              32
pipeline_panics resource=ImageIntegration                                        2
pipeline_panics resource=Namespace                                               20
pipeline_panics resource=NetworkPolicy                                           22
pipeline_panics resource=Node                                                    2
pipeline_panics resource=Pod                                                     42
pipeline_panics resource=ReprocessDeployment                                     30
pipeline_panics resource=Role                                                    184
pipeline_panics resource=Secret                                                  60
pipeline_panics resource=ServiceAccount                                          108
pipeline_panics resource=Synced                                                  1
```
