### PR TITLE
Jv rox 15187 fix processes listening on ports test flake retry plop

### DIFF
--- a/central/processlisteningonport/datastore/datastore_impl.go
+++ b/central/processlisteningonport/datastore/datastore_impl.go
@@ -46,7 +46,9 @@ func convertPlopFromStorageToPlopFromSensor(plopStorage *storage.ProcessListenin
 		Protocol:	plopStorage.Protocol,
 		Process:	plopStorage.Process,
 		CloseTimestamp:	plopStorage.CloseTimestamp,
-		//ClusterId:	plopStorage.ClusterId,
+		// Storage does not have ClusterId which PlopFromSensor has, but this does not seem
+		// to be a problem. Might want to examine this more.
+		// ClusterId:	plopStorage.ClusterId,
 	}
 }
 
@@ -74,6 +76,9 @@ func (ds *datastoreImpl) addUnmatchedProcesses(ctx context.Context, portProcesse
 		portProcesses = append(portProcesses, plop)
 	}
 
+	// Unmatched plop objects are deleted and added back in to avoid duplicate rows.
+	// Deleting unmatched plops is not the most efficient solution.
+	// Instead plopObjects should be set correctly in AddProcessListeningOnPort.
 	ds.storage.DeleteMany(ctx, unmatchedIds)
 
 	return portProcesses

--- a/central/processlisteningonport/datastore/datastore_impl.go
+++ b/central/processlisteningonport/datastore/datastore_impl.go
@@ -40,6 +40,80 @@ func newDatastoreImpl(
 	}
 }
 
+//type ProcessListeningOnPortStorage struct {
+//        // Ideally it has to be GENERATED ALWAYS AS IDENTITY, which will make it a
+//        // bigint with a sequence. Unfortunately at the moment some bits of store
+//        // generator assume an id has to be a string.
+//        Id                 string           `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" sql:"pk,type(uuid)"`
+//        Port               uint32           `protobuf:"varint,2,opt,name=port,proto3" json:"port,omitempty" search:"Port,store"`
+//        Protocol           L4Protocol       `protobuf:"varint,3,opt,name=protocol,proto3,enum=storage.L4Protocol" json:"protocol,omitempty" search:"Port Protocol,store"`
+//        CloseTimestamp     *types.Timestamp `protobuf:"bytes,4,opt,name=close_timestamp,json=closeTimestamp,proto3" json:"close_timestamp,omitempty"`
+//        ProcessIndicatorId string           `protobuf:"bytes,5,opt,name=process_indicator_id,json=processIndicatorId,proto3" json:"process_indicator_id,omitempty" search:"Process ID,store" sql:"fk(ProcessIndicator:id),no-fk-constraint,index=btree,type(uuid)"`
+//        // XXX: Make it a partial index on only active, not closed, PLOP
+//        Closed bool `protobuf:"varint,6,opt,name=closed,proto3" json:"closed,omitempty" search:"Closed,store" sql:"index=btree"`
+//        // ProcessIndicator will be not empty only for those cases when we were not
+//        // able to find references process in the database
+//        Process              *ProcessIndicatorUniqueKey `protobuf:"bytes,7,opt,name=process,proto3" json:"process,omitempty"`
+//        XXX_NoUnkeyedLiteral struct{}                   `json:"-"`
+//        XXX_unrecognized     []byte                     `json:"-"`
+//        XXX_sizecache        int32                      `json:"-"`
+//}
+
+//type ProcessListeningOnPortFromSensor struct {
+//        Port                 uint32                     `protobuf:"varint,1,opt,name=port,proto3" json:"port,omitempty"`
+//        Protocol             L4Protocol                 `protobuf:"varint,2,opt,name=protocol,proto3,enum=storage.L4Protocol" json:"protocol,omitempty"`
+//        Process              *ProcessIndicatorUniqueKey `protobuf:"bytes,3,opt,name=process,proto3" json:"process,omitempty"`
+//        CloseTimestamp       *types.Timestamp           `protobuf:"bytes,4,opt,name=close_timestamp,json=closeTimestamp,proto3" json:"close_timestamp,omitempty"`
+//        ClusterId            string                     `protobuf:"bytes,6,opt,name=cluster_id,json=clusterId,proto3" json:"cluster_id,omitempty"`
+//        XXX_NoUnkeyedLiteral struct{}                   `json:"-"`
+//        XXX_unrecognized     []byte                     `json:"-"`
+//        XXX_sizecache        int32                      `json:"-"`
+//}
+
+
+func convertPlopFromStorageToPlopFromSensor(plopStorage *storage.ProcessListeningOnPortStorage) *storage.ProcessListeningOnPortFromSensor {
+	return &storage.ProcessListeningOnPortFromSensor{
+		Port:		plopStorage.Port,
+		Protocol:	plopStorage.Protocol,
+		Process:	plopStorage.Process,
+		CloseTimestamp:	plopStorage.CloseTimestamp,
+		//ClusterId:	plopStorage.ClusterId,
+	}
+}
+
+func (ds *datastoreImpl) getUnmatchedPlopsFromDB(ctx context.Context) []*storage.ProcessListeningOnPortStorage {
+        plopsFromDB := []*storage.ProcessListeningOnPortStorage{}
+        ds.WalkAll(ctx,
+                func(plop *storage.ProcessListeningOnPortStorage) error {
+			if plop.ProcessIndicatorId == "" {
+				plopsFromDB = append(plopsFromDB, plop)
+			}
+                        return nil
+                })
+
+        return plopsFromDB
+}
+
+func (ds *datastoreImpl) addUnmatchedProcesses(ctx context.Context, portProcesses []*storage.ProcessListeningOnPortFromSensor) ([]*storage.ProcessListeningOnPortFromSensor, map[string]bool) {
+
+	unmatchedIds := make([]string, 0)
+	unmatchedPLOPs := ds.getUnmatchedPlopsFromDB(ctx)
+	keys := make(map[string]bool) // Very strangely golang does not have sets so using a map instead
+
+	for _, val := range unmatchedPLOPs {
+		unmatchedIds = append(unmatchedIds, val.Id)
+		plop := convertPlopFromStorageToPlopFromSensor(val)
+		log.Infof("In addUnmatchedProcesses. Retrying %+v", plop)
+		portProcesses = append(portProcesses, plop)
+		//key := getPlopWithoutIndicatorIdKey(val)
+		//keys[key] = true
+	}
+
+	ds.storage.DeleteMany(ctx, unmatchedIds)
+
+	return portProcesses, keys
+}
+
 func (ds *datastoreImpl) AddProcessListeningOnPort(
 	ctx context.Context,
 	portProcesses ...*storage.ProcessListeningOnPortFromSensor,
@@ -50,6 +124,7 @@ func (ds *datastoreImpl) AddProcessListeningOnPort(
 		"AddProcessListeningOnPort",
 	)
 
+	log.Infof("In AddProcessListeningOnPort")
 	if !env.PostgresDatastoreEnabled.BooleanSetting() {
 		// PLOP is a Postgres-only feature, do nothing.
 		log.Warnf("Tried to add PLOP not on Postgres, ignore: %+v", portProcesses)
@@ -62,7 +137,8 @@ func (ds *datastoreImpl) AddProcessListeningOnPort(
 		return sac.ErrResourceAccessDenied
 	}
 
-	normalizedPLOPs, completedInBatch := normalizePLOPs(portProcesses)
+	newAndUnmatchedPortProcesses, _ := ds.addUnmatchedProcesses(ctx, portProcesses)
+	normalizedPLOPs, completedInBatch := normalizePLOPs(newAndUnmatchedPortProcesses)
 
 	// TODO ROX-14376: The next two calls, fetchIndicators and fetchExistingPLOPs, have to
 	// be done in a single join query fetching both ProcessIndicator and needed
@@ -84,12 +160,14 @@ func (ds *datastoreImpl) AddProcessListeningOnPort(
 
 		key := getPlopProcessUniqueKey(val)
 
+		log.Debugf("AddProcessListeningOnPort val= %+v", val)
 		if indicator, ok := indicatorsMap[key]; ok {
 			indicatorID = indicator.GetId()
+			log.Debugf("Got indicator key %s", key)
 			log.Debugf("Got indicator %s: %+v", indicatorID, indicator)
 		} else {
 			countMetrics.IncrementOrphanedPLOPCounter(val.GetClusterId())
-			log.Warnf("Found no matching indicators for %s", key)
+			log.Warnf("Found no matching indicators for key %s", key)
 			processInfo = val.Process
 		}
 
@@ -202,6 +280,18 @@ func (ds *datastoreImpl) GetProcessListeningOnPort(
 	return processesListeningOnPorts, nil
 }
 
+func (ds *datastoreImpl) getProcessIndicatorsFromDB(ctx context.Context) []*storage.ProcessIndicator {
+        indicatorsFromDB := []*storage.ProcessIndicator{}
+        ds.indicatorDataStore.WalkAll(ctx,
+                func(processIndicator *storage.ProcessIndicator) error {
+                        indicatorsFromDB = append(indicatorsFromDB, processIndicator)
+                        return nil
+                })
+
+
+        return indicatorsFromDB
+}
+
 func (ds *datastoreImpl) WalkAll(ctx context.Context, fn WalkFn) error {
 	if ok, err := plopSAC.ReadAllowed(ctx); err != nil {
 		return err
@@ -312,8 +402,28 @@ func (ds *datastoreImpl) fetchIndicators(
 		return nil, nil, err
 	}
 
+
+	allIndicators := ds.getProcessIndicatorsFromDB(ctx)
+
+	log.Infof("")
+	log.Infof("")
+	log.Infof("")
+	log.Infof("")
+	for _, indicator := range allIndicators {
+		key := getProcessUniqueKey(indicator)
+		log.Infof("In fetchIndicator all key: %s", key)
+		log.Infof("In fetchIndicator all indicator: %+v:", indicator)
+	}
+	log.Infof("")
+	log.Infof("")
+	log.Infof("")
+	log.Infof("")
+
+
 	for _, val := range indicators {
 		key := getProcessUniqueKey(val)
+		log.Infof("In fetchIndicator key: %s", key)
+		log.Infof("In fetchIndicator indicator: %+v:", val)
 
 		// A bit of paranoia is always good
 		if old, ok := indicatorsMap[key]; ok {
@@ -324,6 +434,10 @@ func (ds *datastoreImpl) fetchIndicators(
 		indicatorsMap[key] = val
 		indicatorIds = append(indicatorIds, val.GetId())
 	}
+	log.Infof("")
+	log.Infof("")
+	log.Infof("")
+	log.Infof("")
 
 	return indicatorsMap, indicatorIds, nil
 }
@@ -372,6 +486,7 @@ func normalizePLOPs(
 	completedEvents = []*storage.ProcessListeningOnPortFromSensor{}
 
 	for _, val := range plops {
+		//key := getPlopWithoutIndicatorIdKey(val)
 		key := getPlopKeyFromParts(
 			val.GetProtocol(),
 			val.GetPort(),
@@ -474,6 +589,14 @@ func getPlopKeyFromParts(protocol storage.L4Protocol, port uint32, indicatorID s
 func getPlopKey(plop *storage.ProcessListeningOnPortStorage) string {
 	return getPlopKeyFromParts(plop.GetProtocol(), plop.GetPort(), plop.GetProcessIndicatorId())
 }
+
+//func getPlopWithoutIndicatorIdKey(plop *storage.ProcessListeningOnPortStorage) string {
+//	return getPlopKeyFromParts(
+//		plop.GetProtocol(),
+//		plop.GetPort(),
+//		getPlopProcessUniqueKey(plop),
+//	)
+//}
 
 func sortByCloseTimestamp(values []*storage.ProcessListeningOnPortFromSensor) {
 	sort.Slice(values, func(i, j int) bool {

--- a/central/processlisteningonport/datastore/datastore_impl.go
+++ b/central/processlisteningonport/datastore/datastore_impl.go
@@ -57,7 +57,7 @@ func (ds *datastoreImpl) getUnmatchedPlopsFromDB(ctx context.Context) []*storage
 			if plop.ProcessIndicatorId == "" {
 				plopsFromDB = append(plopsFromDB, plop)
 			}
-                        return nil
+			return nil
                 })
 
         return plopsFromDB

--- a/central/processlisteningonport/datastore/datastore_impl_test.go
+++ b/central/processlisteningonport/datastore/datastore_impl_test.go
@@ -1,4 +1,4 @@
-//go:build sql_integratio
+//go:build sql_integration
 
 package datastore
 

--- a/central/processlisteningonport/datastore/datastore_impl_test.go
+++ b/central/processlisteningonport/datastore/datastore_impl_test.go
@@ -1,3 +1,5 @@
+//go:build sql_integratio
+
 package datastore
 
 import (

--- a/central/sensor/service/pipeline/processlisteningonport/pipeline.go
+++ b/central/sensor/service/pipeline/processlisteningonport/pipeline.go
@@ -52,16 +52,18 @@ func (s *pipelineImpl) Run(
 	defer countMetrics.IncrementResourceProcessedCounter(
 		pipeline.ActionToOperation(msg.GetEvent().GetAction()), metrics.ProcessListeningOnPort)
 
+	log.Infof("In processlisteningonport/pipeline.go")
 	update := msg.GetProcessListeningOnPortUpdate()
 	if s.dataStore != nil && update != nil {
 		portProcesses := update.GetProcessesListeningOnPorts()
 
-		if portProcesses != nil {
-			log.Debugf("Store PLOP object: %+v", portProcesses)
+		//if portProcesses != nil {
+			//log.Debugf("Store PLOP object: %+v", portProcesses)
 			if err := s.dataStore.AddProcessListeningOnPort(ctx, portProcesses...); err != nil {
 				return err
 			}
-		}
+		//}
+
 	} else {
 		if s.dataStore == nil {
 			log.Warnf("Cannot process PLOP event: data store is nil")

--- a/central/sensor/service/pipeline/processlisteningonport/pipeline.go
+++ b/central/sensor/service/pipeline/processlisteningonport/pipeline.go
@@ -52,17 +52,14 @@ func (s *pipelineImpl) Run(
 	defer countMetrics.IncrementResourceProcessedCounter(
 		pipeline.ActionToOperation(msg.GetEvent().GetAction()), metrics.ProcessListeningOnPort)
 
-	log.Infof("In processlisteningonport/pipeline.go")
 	update := msg.GetProcessListeningOnPortUpdate()
 	if s.dataStore != nil && update != nil {
 		portProcesses := update.GetProcessesListeningOnPorts()
 
-		//if portProcesses != nil {
-			//log.Debugf("Store PLOP object: %+v", portProcesses)
-			if err := s.dataStore.AddProcessListeningOnPort(ctx, portProcesses...); err != nil {
-				return err
-			}
-		//}
+		log.Debugf("Store PLOP object: %+v", portProcesses)
+		if err := s.dataStore.AddProcessListeningOnPort(ctx, portProcesses...); err != nil {
+			return err
+		}
 
 	} else {
 		if s.dataStore == nil {

--- a/qa-tests-backend/src/test/groovy/ProcessesListeningOnPortsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ProcessesListeningOnPortsTest.groovy
@@ -14,7 +14,7 @@ import services.ProcessesListeningOnPortsService
 
 @Stepwise
 // TODO: Solve the flake and change back to @IgnoreIf({ !Env.get("ROX_POSTGRES_DATASTORE", null) })
-@IgnoreIf({ Env.get("RUN_PROCESS_LISTENING_ON_PORTS_E2E_TESTS", "false") == "false" })
+@IgnoreIf({ !Env.get("ROX_POSTGRES_DATASTORE", null) })
 class ProcessesListeningOnPortsTest extends BaseSpecification {
 
     // Deployment names

--- a/qa-tests-backend/src/test/groovy/ProcessesListeningOnPortsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ProcessesListeningOnPortsTest.groovy
@@ -13,7 +13,6 @@ import spock.lang.Stepwise
 import services.ProcessesListeningOnPortsService
 
 @Stepwise
-// TODO: Solve the flake and change back to @IgnoreIf({ !Env.get("ROX_POSTGRES_DATASTORE", null) })
 @IgnoreIf({ !Env.get("ROX_POSTGRES_DATASTORE", null) })
 class ProcessesListeningOnPortsTest extends BaseSpecification {
 

--- a/sensor/common/networkflow/manager/manager_impl.go
+++ b/sensor/common/networkflow/manager/manager_impl.go
@@ -297,10 +297,6 @@ func (m *networkFlowManager) enrichAndSendProcesses() {
 
 	m.enrichedProcessesLastSentState = currentProcesses
 
-	if len(updatedProcesses) == 0 {
-		return
-	}
-
 	processesToSend := &central.ProcessListeningOnPortsUpdate{
 		ProcessesListeningOnPorts: updatedProcesses,
 		Time:                      types.TimestampNow(),


### PR DESCRIPTION
## Description

See https://github.com/stackrox/stackrox/pull/5159 for an improved version of this. The difference there is that old unmatched listening endpoints are removed in that PR. Also rows are not deleted and inserted back. Instead they are upserted.

Retries to match old plops to process indicators for which the match previously failed, in the same loop in which new plops are added. This fixes the flakiness in the e2e test for plop. There will be another attempted solution in which the retries are not done in the same path as where new plops are added. That PR can be found here https://github.com/stackrox/stackrox/pull/5143

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [x] Ran e2e tests 200 times

## Testing Performed

See above
