### PR TITLE
Telemetry: add BatchSize configuration parameter

### DIFF
--- a/pkg/telemetry/phonehome/client_config.go
+++ b/pkg/telemetry/phonehome/client_config.go
@@ -41,6 +41,7 @@ type Config struct {
 	StorageKey   string
 	Endpoint     string
 	PushInterval time.Duration
+	BatchSize    int
 
 	// The period of identity gathering. Default is 1 hour.
 	GatherPeriod time.Duration
@@ -93,7 +94,8 @@ func (cfg *Config) Telemeter() telemeter.Telemeter {
 				cfg.Endpoint,
 				cfg.ClientID,
 				cfg.ClientName,
-				cfg.PushInterval)
+				cfg.PushInterval,
+				cfg.BatchSize)
 		} else {
 			cfg.telemeter = &nilTelemeter{}
 		}

--- a/pkg/telemetry/phonehome/segment/segment.go
+++ b/pkg/telemetry/phonehome/segment/segment.go
@@ -46,10 +46,12 @@ func (*logOnFailure) Failure(msg segment.Message, err error) {
 }
 
 // NewTelemeter creates and initializes a Segment telemeter instance.
-func NewTelemeter(key, endpoint, clientID, clientType string, interval time.Duration) *segmentTelemeter {
+// Default interval is 5s, default batch size is 250.
+func NewTelemeter(key, endpoint, clientID, clientType string, interval time.Duration, batchSize int) *segmentTelemeter {
 	segmentConfig := segment.Config{
 		Endpoint:  endpoint,
 		Interval:  interval,
+		BatchSize: batchSize,
 		Transport: proxy.RoundTripper(),
 		Logger:    &logWrapper{internal: log},
 		Callback:  &logOnFailure{},


### PR DESCRIPTION
## Description

This change allows for setting the max batch size parameter for Segment client. We'll set it to 1 in Fleet Manager, so that Group and Track events go in different batches, as otherwise they're more likely to be processed in the wrong order by Segment.

This setting was suggested in the [Segment support ticket 500793](https://segment.zendesk.com/hc/en-us/requests/500793).

## Checklist
- [x] Investigated and inspected CI test results
- [ ] ~Unit test and regression tests added~
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

This is an internal Segment SDK setting.