### PR TITLE
Add CVE severity and status icons to image page summary cards

### DIFF
--- a/ui/apps/platform/src/Components/PatternFly/SeverityIcons.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/SeverityIcons.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import {
+    AngleDoubleDownIcon,
+    AngleDoubleUpIcon,
+    CriticalRiskIcon,
+    EqualsIcon,
+} from '@patternfly/react-icons';
+import { SVGIconProps } from '@patternfly/react-icons/dist/esm/createIcon';
+
+import { VulnerabilitySeverity } from 'types/cve.proto';
+import { vulnSeverityIconColors } from 'constants/visuals/colors';
+
+// Defines the default PF icons that represent a CVE severity, and sets the default colors for the icons.
+// Color can be overridden by passing the standard `color` prop to the icon component.
+const SeverityIcons: Record<VulnerabilitySeverity, React.FC<SVGIconProps>> = {
+    CRITICAL_VULNERABILITY_SEVERITY: (props) => (
+        <CriticalRiskIcon
+            {...props}
+            color={props.color ?? vulnSeverityIconColors.CRITICAL_VULNERABILITY_SEVERITY}
+        />
+    ),
+    IMPORTANT_VULNERABILITY_SEVERITY: (props) => (
+        <AngleDoubleUpIcon
+            {...props}
+            color={props.color ?? vulnSeverityIconColors.IMPORTANT_VULNERABILITY_SEVERITY}
+        />
+    ),
+    MODERATE_VULNERABILITY_SEVERITY: (props) => (
+        <EqualsIcon
+            {...props}
+            color={props.color ?? vulnSeverityIconColors.MODERATE_VULNERABILITY_SEVERITY}
+        />
+    ),
+    LOW_VULNERABILITY_SEVERITY: (props) => (
+        <AngleDoubleDownIcon
+            {...props}
+            color={props.color ?? vulnSeverityIconColors.LOW_VULNERABILITY_SEVERITY}
+        />
+    ),
+};
+
+export default SeverityIcons;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageSingleVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageSingleVulnerabilities.tsx
@@ -134,21 +134,23 @@ function ImageSingleVulnerabilities({ imageId }: ImageSingleVulnerabilitiesProps
         const hiddenStatuses = new Set<FixableStatus>([]);
 
         mainContent = (
-            <Grid hasGutter>
-                <GridItem sm={12} md={6} xl2={4}>
-                    <BySeveritySummaryCard
-                        title="CVEs by severity"
-                        severityCounts={severityCounts}
-                        hiddenSeverities={hiddenSeverities}
-                    />
-                </GridItem>
-                <GridItem sm={12} md={6} xl2={4}>
-                    <CvesByStatusSummaryCard
-                        cveStatusCounts={cveStatusCounts}
-                        hiddenStatuses={hiddenStatuses}
-                    />
-                </GridItem>
-            </Grid>
+            <div className="pf-u-px-lg pf-u-pb-lg">
+                <Grid hasGutter>
+                    <GridItem sm={12} md={6} xl2={4}>
+                        <BySeveritySummaryCard
+                            title="CVEs by severity"
+                            severityCounts={severityCounts}
+                            hiddenSeverities={hiddenSeverities}
+                        />
+                    </GridItem>
+                    <GridItem sm={12} md={6} xl2={4}>
+                        <CvesByStatusSummaryCard
+                            cveStatusCounts={cveStatusCounts}
+                            hiddenStatuses={hiddenStatuses}
+                        />
+                    </GridItem>
+                </Grid>
+            </div>
         );
     }
 
@@ -175,10 +177,12 @@ function ImageSingleVulnerabilities({ imageId }: ImageSingleVulnerabilitiesProps
                         eventKey="Observed"
                         title={<TabTitleText>Observed CVEs</TabTitleText>}
                     >
-                        <PageSection variant="light" component="div" isFilled>
+                        <div className="pf-u-px-sm pf-u-background-color-100">
                             <WorkloadTableToolbar />
+                        </div>
+                        <div className="pf-u-flex-grow-1 pf-u-background-color-100">
                             {mainContent}
-                        </PageSection>
+                        </div>
                     </Tab>
                     <Tab
                         className="pf-u-display-flex pf-u-flex-direction-column pf-u-flex-grow-1"

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/SummaryCards/BySeveritySummaryCard.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/SummaryCards/BySeveritySummaryCard.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
-import { Card, CardBody, CardTitle, Grid, GridItem } from '@patternfly/react-core';
+import { Card, CardBody, CardTitle, Flex, Grid, GridItem, Text } from '@patternfly/react-core';
+
+import SeverityIcons from 'Components/PatternFly/SeverityIcons';
 
 import { VulnerabilitySeverity } from 'types/cve.proto';
 import { vulnerabilitySeverityLabels } from 'messages/common';
@@ -17,23 +19,50 @@ const severitiesCriticalToLow = [
     'LOW_VULNERABILITY_SEVERITY',
 ] as const;
 
+const disabledColor100 = 'var(--pf-global--disabled-color--100)';
+const disabledColor200 = 'var(--pf-global--disabled-color--200)';
+
 function BySeveritySummaryCard({
     title,
     severityCounts,
     hiddenSeverities,
 }: BySeveritySummaryCardProps) {
     return (
-        <Card>
+        <Card isCompact>
             <CardTitle>{title}</CardTitle>
             <CardBody>
-                <Grid hasGutter>
-                    {severitiesCriticalToLow.map((severity) => (
-                        <GridItem key={severity} span={6}>
-                            {hiddenSeverities.has(severity)
-                                ? 'Results hidden'
-                                : `${severityCounts[severity]} ${vulnerabilitySeverityLabels[severity]}`}
-                        </GridItem>
-                    ))}
+                <Grid className="pf-u-pl-sm">
+                    {severitiesCriticalToLow.map((severity) => {
+                        const count = severityCounts[severity];
+                        const hasNoResults = count === 0;
+                        const isHidden = hiddenSeverities.has(severity);
+
+                        let textColor = '';
+                        let text = `${count} ${vulnerabilitySeverityLabels[severity]}`;
+
+                        if (isHidden) {
+                            textColor = disabledColor100;
+                            text = 'Results hidden';
+                        } else if (hasNoResults) {
+                            textColor = disabledColor200;
+                            text = 'No results';
+                        }
+
+                        const Icon = SeverityIcons[severity];
+
+                        return (
+                            <GridItem key={severity} span={6}>
+                                <Flex
+                                    className="pf-u-pt-sm"
+                                    spaceItems={{ default: 'spaceItemsSm' }}
+                                    alignItems={{ default: 'alignItemsCenter' }}
+                                >
+                                    <Icon color={hasNoResults ? textColor : undefined} />
+                                    <Text style={{ color: textColor }}>{text}</Text>
+                                </Flex>
+                            </GridItem>
+                        );
+                    })}
                 </Grid>
             </CardBody>
         </Card>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/SummaryCards/CvesByStatusSummaryCard.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/SummaryCards/CvesByStatusSummaryCard.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { Card, CardTitle, CardBody, Flex } from '@patternfly/react-core';
+import { Card, CardTitle, CardBody, Flex, Text, Grid, GridItem } from '@patternfly/react-core';
 
+import { CheckCircleIcon, ExclamationCircleIcon } from '@patternfly/react-icons';
 import { FixableStatus } from '../types';
 
 export type CvesByStatusSummaryCardProps = {
@@ -8,26 +9,56 @@ export type CvesByStatusSummaryCardProps = {
     hiddenStatuses: Set<FixableStatus>;
 };
 
+const statusDisplays = [
+    {
+        status: 'Fixable',
+        Icon: CheckCircleIcon,
+        iconColor: 'var(--pf-global--success-color--100)',
+        text: (counts: CvesByStatusSummaryCardProps['cveStatusCounts']) =>
+            `${counts.Fixable} vulnerabilities with available fixes`,
+    },
+    {
+        status: 'Not fixable',
+        Icon: ExclamationCircleIcon,
+        iconColor: 'var(--pf-global--danger-color--100)',
+        text: (counts: CvesByStatusSummaryCardProps['cveStatusCounts']) =>
+            `${counts['Not fixable']} vulnerabilities without fixes`,
+    },
+] as const;
+
+const disabledColor100 = 'var(--pf-global--disabled-color--100)';
+
 function CvesByStatusSummaryCard({
     cveStatusCounts,
     hiddenStatuses,
 }: CvesByStatusSummaryCardProps) {
     return (
-        <Card>
+        <Card isCompact>
             <CardTitle>CVEs by status</CardTitle>
             <CardBody>
-                <Flex direction={{ default: 'column' }}>
-                    <div>
-                        {hiddenStatuses.has('Fixable')
-                            ? 'Results hidden'
-                            : `${cveStatusCounts.Fixable} vulnerabilities with available fixes`}
-                    </div>
-                    <div>
-                        {hiddenStatuses.has('Not fixable')
-                            ? 'Results hidden'
-                            : `${cveStatusCounts['Not fixable']} vulnerabilities without fixes`}
-                    </div>
-                </Flex>
+                <Grid className="pf-u-pl-sm">
+                    {statusDisplays.map(({ status, Icon, iconColor, text }) => {
+                        const isHidden = hiddenStatuses.has(status);
+                        return (
+                            <GridItem key={status} span={12}>
+                                <Flex
+                                    className="pf-u-pt-sm"
+                                    spaceItems={{ default: 'spaceItemsSm' }}
+                                    alignItems={{ default: 'alignItemsCenter' }}
+                                >
+                                    <Icon color={iconColor} />
+                                    <Text
+                                        style={{
+                                            color: isHidden ? disabledColor100 : 'inherit',
+                                        }}
+                                    >
+                                        {isHidden ? 'Results hidden' : text(cveStatusCounts)}
+                                    </Text>
+                                </Flex>
+                            </GridItem>
+                        );
+                    })}
+                </Grid>
             </CardBody>
         </Card>
     );

--- a/ui/apps/platform/src/constants/visuals/colors.ts
+++ b/ui/apps/platform/src/constants/visuals/colors.ts
@@ -1,3 +1,4 @@
+import { VulnerabilitySeverity } from 'types/cve.proto';
 import { PolicySeverity } from 'types/policy.proto';
 
 const colors = [
@@ -32,6 +33,13 @@ export const severityColors: Record<PolicySeverity, string> = {
     MEDIUM_SEVERITY: 'var(--color-severity-medium)',
     HIGH_SEVERITY: 'var(--color-severity-important)',
     CRITICAL_SEVERITY: 'var(--color-severity-critical)',
+};
+
+export const vulnSeverityIconColors: Record<VulnerabilitySeverity, string> = {
+    LOW_VULNERABILITY_SEVERITY: 'var(--pf-global--palette--blue-300)',
+    MODERATE_VULNERABILITY_SEVERITY: 'var(--pf-global--palette--gold-300)',
+    IMPORTANT_VULNERABILITY_SEVERITY: 'var(--pf-global--palette--orange-200)',
+    CRITICAL_VULNERABILITY_SEVERITY: 'var(--pf-global--palette--red-100)',
 };
 
 export default colors;


### PR DESCRIPTION
## Description

Adds new colored icons for vuln severities/statuses and implements them in the summary card for the image single page.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

View summary card with all data available and no data hidden:
![image](https://user-images.githubusercontent.com/1292638/223510585-69bb7690-2941-4b63-bf6d-f09497cd973c.png)


View summary cards with severity results for Important/Moderate, zero results for Critical, and Low being manually disabled. Status card has "Fixable" manually disabled.
![image](https://user-images.githubusercontent.com/1292638/223783782-4cb1883b-2927-495d-9b54-dba563d347ec.png)
