### PR TITLE
Reduce permissions of integration health reporter

### DIFF
--- a/central/integrationhealth/datastore/datastore_impl.go
+++ b/central/integrationhealth/datastore/datastore_impl.go
@@ -63,11 +63,8 @@ func (ds *datastoreImpl) GetDeclarativeConfigs(ctx context.Context) ([]*storage.
 }
 
 func (ds *datastoreImpl) UpsertIntegrationHealth(ctx context.Context, integrationHealth *storage.IntegrationHealth) error {
-	if ok, err := integrationSAC.WriteAllowed(ctx); err != nil {
-		return errors.Errorf("failed to update health for integration %s: %v",
-			integrationHealth.Id, err)
-	} else if !ok {
-		return nil
+	if err := sac.VerifyAuthzOK(integrationSAC.WriteAllowed(ctx)); err != nil {
+		return errors.Wrapf(err, "failed to update health for integration %s", integrationHealth.GetId())
 	}
 
 	if err := validateIntegrationHealthType(integrationHealth.GetType()); err != nil {
@@ -78,10 +75,8 @@ func (ds *datastoreImpl) UpsertIntegrationHealth(ctx context.Context, integratio
 }
 
 func (ds *datastoreImpl) RemoveIntegrationHealth(ctx context.Context, id string) error {
-	if ok, err := integrationSAC.WriteAllowed(ctx); err != nil {
-		return errors.Errorf("failed to remove health for integration %s: %v", id, err)
-	} else if !ok {
-		return nil
+	if err := sac.VerifyAuthzOK(integrationSAC.WriteAllowed(ctx)); err != nil {
+		return errors.Wrapf(err, "failed to remove health for integration %s", id)
 	}
 	_, exists, err := ds.GetIntegrationHealth(ctx, id)
 	if err != nil {


### PR DESCRIPTION
\+ fail on lack of permissions in upsert/remove integration health operations

## Description

Minor improvements to integration health reporter + integration health datastore include:
* replacement of unrestricted access context with context with `Integration`write access
* actively failing on lack of permissions in upsert/delete operations in integration health datastore(thanks @dhaus67 for looking into it first)

The reasons for the last change:
* `UpsertIntegrationHealth` is not called from the UI - all errors will be logged within `health_reporter_impl.go`; if not logged there is no way to notice a lack of permissions
* `RemoveIntegrationHealth` is called when user removes notifier/image integration/backup via UI or API. The reason we assume it is safe to change this behaviour is because:
		1.  Deletion of notifier already fails on lack of permission to delete notifier itself - we just make behaviour more consistent
		2. Same for backups
		3. Removal of image integration ignores deletion errors either way: https://github.com/stackrox/stackrox/blob/8fe36a099ed2dca602d0921353fe5cff8449694b/pkg/images/integration/set_impl.go#L79-L91

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Tested manually that `System Health` page still works + no errors in central logs