### PR TITLE
ROX-15332: Change statement_timeout to be 20m

### DIFF
--- a/image/templates/helm/stackrox-central/internal/defaults.yaml.htpl
+++ b/image/templates/helm/stackrox-central/internal/defaults.yaml.htpl
@@ -44,7 +44,7 @@ defaults:
       source:
         minConns: 10
         maxConns: 90
-        statementTimeoutMs: 60000
+        statementTimeoutMs: 1200000
 
       postgresConfig: "@config/centraldb/postgresql.conf|config/centraldb/postgresql.conf.default"
       hbaConfig: "@config/centraldb/pg_hba.conf|config/centraldb/pg_hba.conf.default"

--- a/image/templates/helm/stackrox-central/values-public.yaml.example.htpl
+++ b/image/templates/helm/stackrox-central/values-public.yaml.example.htpl
@@ -268,7 +268,7 @@
 #     connectionString: "host=central-db.stackrox port=5432 user=postgres sslmode=verify-full"
 #     minConns: 10
 #     maxConns: 90
-#     statementTimeoutMs: 60000
+#     statementTimeoutMs: 1200000
 #
 #   # Configures the Central DB image to be used. Most users will only need to configure a
 #   # custom registry (if any) at the global scope, and do not require any settings here.

--- a/image/templates/helm/stackrox-central/values.yaml.htpl
+++ b/image/templates/helm/stackrox-central/values.yaml.htpl
@@ -199,7 +199,7 @@
 #      connectionString: null
 #      minConns: 10
 #      maxConns: 90
-#      statementTimeoutMs: 60000
+#      statementTimeoutMs: 1200000
 #
 #  # The admin password setting for communication with Central's DB.
 #  # When a value is set explicitly, this is always used, even on upgrade.


### PR DESCRIPTION
## Description

Push the statement_timeout to be 20m as now the timeouts are done via contexts with a default query timeout of 60s and a default cursor timeout of 10m

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Should have no impact
