### PR TITLE
ROX-15411: De-emphasizing the unconnected nodes

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphContainer.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphContainer.tsx
@@ -160,10 +160,14 @@ function fadeOutUnconnectedNodes(
     nodes: CustomNodeModel[],
     edges: CustomEdgeModel[],
     selectedNodeId: string | undefined
-) {
-    const connectedNodeIds = getConnectedNodeIds(nodes, edges, selectedNodeId);
+): CustomNodeModel[] {
+    if (!selectedNodeId) {
+        return nodes;
+    }
+    const connectedNodeIds = getConnectedNodeIds(edges, selectedNodeId);
     const modifiedNodes: CustomNodeModel[] = nodes.map((node) => {
         const { data } = node;
+        // We only want to fade out nodes (not groups), so we target node types specifically
         if (
             data.type === 'DEPLOYMENT' ||
             data.type === 'CIDR_BLOCK' ||
@@ -171,10 +175,7 @@ function fadeOutUnconnectedNodes(
         ) {
             const isConnectedToSelectedNode = connectedNodeIds.includes(node.id);
             const isSelectedNode = node.id === selectedNodeId;
-            const isNodeSelected = !!selectedNodeId;
-            const isFadedOut = isNodeSelected
-                ? !isConnectedToSelectedNode && !isSelectedNode
-                : false;
+            const isFadedOut = !isConnectedToSelectedNode && !isSelectedNode;
             return {
                 ...node,
                 data: {

--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.css
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.css
@@ -49,3 +49,7 @@
 div#topology-resize-panel table td {
     vertical-align: inherit;
 }
+
+.pf-topology-node-faded {
+    opacity: 30%;
+}

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/StyleNode.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/StyleNode.tsx
@@ -189,10 +189,15 @@ const StyleNode: React.FunctionComponent<StyleNodeProps> = ({
     }, [detailsLevel, onHideCreateConnector]);
 
     const LabelIcon = passedData.labelIcon;
+
+    // @TODO: If multiple classes need to be stringed together, then we need a more systematic way to generate those here
+    const className = `${passedData?.isFadedOut ? 'pf-topology-node-faded' : ''}`;
+
     return (
         <Layer id={hover ? TOP_LAYER : DEFAULT_LAYER}>
             <g ref={hoverRef as React.LegacyRef<SVGGElement>}>
                 <DefaultNode
+                    className={className}
                     element={element}
                     scaleLabel={detailsLevel !== ScaleDetailsLevel.high}
                     scaleNode={hover && detailsLevel === ScaleDetailsLevel.low}

--- a/ui/apps/platform/src/Containers/NetworkGraph/types/topology.type.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/types/topology.type.ts
@@ -74,6 +74,7 @@ export type DeploymentData = {
     showPolicyState: boolean;
     isExternallyConnected: boolean;
     showExternalState: boolean;
+    isFadedOut: boolean;
 };
 
 export type ExternalGroupData = {
@@ -86,6 +87,7 @@ export type ExternalEntitiesData = {
     type: 'EXTERNAL_ENTITIES';
     id: string;
     outEdges: OutEdges;
+    isFadedOut: boolean;
 };
 
 export type CIDRBlockData = {
@@ -97,6 +99,7 @@ export type CIDRBlockData = {
         name: string;
     };
     outEdges: OutEdges;
+    isFadedOut: boolean;
 };
 
 export type ExtraneousData = {

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/flowUtils.test.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/flowUtils.test.ts
@@ -238,6 +238,7 @@ describe('flowUtils', () => {
                         showPolicyState: true,
                         isExternallyConnected: false,
                         showExternalState: false,
+                        isFadedOut: false,
                     },
                 },
                 {
@@ -258,6 +259,7 @@ describe('flowUtils', () => {
                         showPolicyState: true,
                         isExternallyConnected: false,
                         showExternalState: false,
+                        isFadedOut: false,
                     },
                 },
             ];
@@ -548,6 +550,7 @@ describe('flowUtils', () => {
                         showPolicyState: true,
                         isExternallyConnected: false,
                         showExternalState: false,
+                        isFadedOut: false,
                     },
                 },
                 {
@@ -588,6 +591,7 @@ describe('flowUtils', () => {
                         showPolicyState: true,
                         isExternallyConnected: false,
                         showExternalState: false,
+                        isFadedOut: false,
                     },
                 },
             ];
@@ -619,6 +623,7 @@ describe('flowUtils', () => {
                         showPolicyState: true,
                         isExternallyConnected: false,
                         showExternalState: false,
+                        isFadedOut: false,
                     },
                 },
                 {
@@ -659,6 +664,7 @@ describe('flowUtils', () => {
                         showPolicyState: true,
                         isExternallyConnected: false,
                         showExternalState: false,
+                        isFadedOut: false,
                     },
                 },
             ];

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/modelUtils.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/modelUtils.tsx
@@ -99,6 +99,7 @@ function getDeploymentNodeModel(
             showPolicyState: true,
             isExternallyConnected,
             showExternalState: true,
+            isFadedOut: false,
         },
     };
 }
@@ -114,14 +115,14 @@ function getExternalNodeModel(
                 ...baseNode,
                 shape: NodeShape.rect,
                 label: 'External Entities',
-                data: { ...entity, type: 'EXTERNAL_ENTITIES', outEdges },
+                data: { ...entity, type: 'EXTERNAL_ENTITIES', outEdges, isFadedOut: false },
             };
         case 'EXTERNAL_SOURCE':
             return {
                 ...baseNode,
                 shape: NodeShape.rect,
                 label: entity.externalSource.name,
-                data: { ...entity, type: 'CIDR_BLOCK', outEdges },
+                data: { ...entity, type: 'CIDR_BLOCK', outEdges, isFadedOut: false },
             };
         default:
             return ensureExhaustive(entity);
@@ -604,4 +605,25 @@ export function createExtraneousEdges(selectedNodeId: string): {
         },
     };
     return { extraneousEgressEdge, extraneousIngressEdge };
+}
+
+// This function returns the ids of nodes that are connected to the selected node
+export function getConnectedNodeIds(
+    nodes: CustomNodeModel[],
+    edges: CustomEdgeModel[],
+    selectedNodeId: string | undefined
+) {
+    if (!selectedNodeId) {
+        return [];
+    }
+    const connectedNodeIds = edges.reduce((acc, curr) => {
+        if (curr.source === selectedNodeId) {
+            return [...acc, curr.target];
+        }
+        if (curr.target === selectedNodeId) {
+            return [...acc, curr.source];
+        }
+        return acc;
+    }, [] as string[]);
+    return connectedNodeIds;
 }

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/modelUtils.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/modelUtils.tsx
@@ -608,14 +608,7 @@ export function createExtraneousEdges(selectedNodeId: string): {
 }
 
 // This function returns the ids of nodes that are connected to the selected node
-export function getConnectedNodeIds(
-    nodes: CustomNodeModel[],
-    edges: CustomEdgeModel[],
-    selectedNodeId: string | undefined
-) {
-    if (!selectedNodeId) {
-        return [];
-    }
+export function getConnectedNodeIds(edges: CustomEdgeModel[], selectedNodeId: string) {
     const connectedNodeIds = edges.reduce((acc, curr) => {
         if (curr.source === selectedNodeId) {
             return [...acc, curr.target];


### PR DESCRIPTION
## Description

This PR adds styling to the nodes to fade out unconnected nodes when a specific node is selected

<img width="1440" alt="Screenshot 2023-03-06 at 11 59 15 AM" src="https://user-images.githubusercontent.com/4805485/223494312-b90b7769-bcaa-46b6-a8ab-0aff1ece9e1d.png">
<img width="1440" alt="Screenshot 2023-03-06 at 11 59 25 AM" src="https://user-images.githubusercontent.com/4805485/223494315-dd6ce8bf-34cb-4a56-a00e-7a1ff8d4b0a6.png">
<img width="1440" alt="Screenshot 2023-03-06 at 11 59 33 AM" src="https://user-images.githubusercontent.com/4805485/223494318-cf63952d-d0c8-4884-9563-583873bbecff.png">


## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~