### PR TITLE
Don't silently fail on junit2jira

### DIFF
--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -1165,18 +1165,18 @@ store_test_results() {
     local from="$1"
     local to="$2"
 
+    info "Copying test results from $from to $to"
+
+    local dest="${ARTIFACT_DIR}/junit-$to"
+
+    cp -a "$from" "$dest" || true # (best effort)
+
     if ! is_in_PR_context; then
         info "Creating JIRA task for failures found in $from"
         curl --retry 5 -SsfL https://github.com/stackrox/junit2jira/releases/download/v0.0.4/junit2jira -o junit2jira && \
         chmod +x junit2jira && \
         ./junit2jira -junit-reports-dir "$from" -threshold 5
     fi
-
-    info "Copying test results from $from to $to"
-
-    local dest="${ARTIFACT_DIR}/junit-$to"
-
-    cp -a "$from" "$dest" || true # (best effort)
 }
 
 send_slack_notice_for_failures_on_merge() {

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -35,6 +35,7 @@ ci_exit_trap() {
     echo "Exit code is: ${exit_code}"
 
     (send_slack_notice_for_failures_on_merge "${exit_code}") || { echo "ERROR: Could not slack a test failure message"; }
+    (create_tasks_for_failures "${exit_code}") || { echo "ERROR: Could not create tasks for test failures"; }
 
     while [[ -e /tmp/hold ]]; do
         info "Holding this job for debug"
@@ -1170,13 +1171,19 @@ store_test_results() {
     local dest="${ARTIFACT_DIR}/junit-$to"
 
     cp -a "$from" "$dest" || true # (best effort)
+}
 
-    if ! is_in_PR_context; then
-        info "Creating JIRA task for failures found in $from"
-        curl --retry 5 -SsfL https://github.com/stackrox/junit2jira/releases/download/v0.0.4/junit2jira -o junit2jira && \
-        chmod +x junit2jira && \
-        ./junit2jira -junit-reports-dir "$from" -threshold 5
+create_tasks_for_failures() {
+    local exitstatus="${1:-}"
+
+    if ! is_OPENSHIFT_CI || [[ "$exitstatus" == "0" ]] || is_in_PR_context; then
+        return 0
     fi
+
+    info "Creating JIRA task for failures found in $from"
+    curl --retry 5 -SsfL https://github.com/stackrox/junit2jira/releases/download/v0.0.4/junit2jira -o junit2jira && \
+    chmod +x junit2jira && \
+    ./junit2jira -junit-reports-dir "${ARTIFACT_DIR}" -threshold 5
 }
 
 send_slack_notice_for_failures_on_merge() {

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -1166,12 +1166,10 @@ store_test_results() {
     local to="$2"
 
     if ! is_in_PR_context; then
-    {
         info "Creating JIRA task for failures found in $from"
         curl --retry 5 -SsfL https://github.com/stackrox/junit2jira/releases/download/v0.0.4/junit2jira -o junit2jira && \
         chmod +x junit2jira && \
         ./junit2jira -junit-reports-dir "$from" -threshold 5
-    } || true
     fi
 
     info "Copying test results from $from to $to"


### PR DESCRIPTION
## Description

Currently when junit2jira fails we skip it and continue normal flow. Since we now rely on this tool for our day to day job let's not ignore failures and get slca notifications for them as a part of CI trap. 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

CI