### PR TITLE
Add query duration and query error metrics for query times in pgxpool wrapper

### DIFF
--- a/pkg/postgres/batch.go
+++ b/pkg/postgres/batch.go
@@ -16,5 +16,9 @@ type BatchResults struct {
 func (b *BatchResults) Close() error {
 	defer b.cancel()
 
-	return b.BatchResults.Close()
+	if err := b.BatchResults.Close(); err != nil {
+		incQueryErrors("batch", err)
+		return err
+	}
+	return nil
 }

--- a/pkg/postgres/metrics.go
+++ b/pkg/postgres/metrics.go
@@ -38,6 +38,7 @@ func setQueryDuration(t time.Time, scope, query string) {
 	if strings.HasPrefix(query, "FETCH") {
 		query = stringutils.GetUpTo(query, "_")
 	}
+	query = strings.ReplaceAll(query, "\n", " ")
 	queryDuration.With(prometheus.Labels{"scope": scope, "query": query}).Observe(float64(time.Since(t).Milliseconds()))
 }
 

--- a/pkg/postgres/metrics.go
+++ b/pkg/postgres/metrics.go
@@ -1,0 +1,40 @@
+package postgres
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stackrox/rox/pkg/metrics"
+)
+
+func init() {
+	prometheus.MustRegister(
+		queryDuration,
+		queryErrors,
+	)
+}
+
+var (
+	queryDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.CentralSubsystem.String(),
+		Name:      "postgres_query_duration",
+		Help:      "Time in ms for a query to execute",
+		Buckets:   prometheus.ExponentialBuckets(4, 2, 16),
+	}, []string{"scope", "query"})
+
+	queryErrors = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.CentralSubsystem.String(),
+		Name:      "postgres_query_errors",
+		Help:      "Counter of errors occurring Postgres",
+	}, []string{"scope", "query", "error"})
+)
+
+func setQueryDuration(t time.Time, scope, query string) {
+	queryDuration.With(prometheus.Labels{"scope": scope, "query": query}).Observe(float64(time.Since(t).Milliseconds()))
+}
+
+func incQueryErrors(query string, err error) {
+	queryErrors.With(prometheus.Labels{"query": query, "error": err.Error()}).Inc()
+}

--- a/pkg/postgres/pgadmin/admin_utils.go
+++ b/pkg/postgres/pgadmin/admin_utils.go
@@ -165,17 +165,23 @@ func GetDatabaseClones(postgresConfig *postgres.Config) []string {
 	if err != nil {
 		return nil
 	}
+	log.Info("After connect pool")
 	defer rows.Close()
 
 	var clones []string
+	log.Infof("waiting for next")
 	for rows.Next() {
+		log.Infof("inside next")
 		var cloneName string
+		log.Infof("Waiting for scan")
 		if err := rows.Scan(&cloneName); err != nil {
 			return nil
 		}
+		log.Infof("After scan")
 
 		clones = append(clones, cloneName)
 	}
+	log.Infof("After next")
 
 	log.Debugf("database clones => %s", clones)
 

--- a/pkg/postgres/pgadmin/admin_utils.go
+++ b/pkg/postgres/pgadmin/admin_utils.go
@@ -165,23 +165,17 @@ func GetDatabaseClones(postgresConfig *postgres.Config) []string {
 	if err != nil {
 		return nil
 	}
-	log.Info("After connect pool")
 	defer rows.Close()
 
 	var clones []string
-	log.Infof("waiting for next")
 	for rows.Next() {
-		log.Infof("inside next")
 		var cloneName string
-		log.Infof("Waiting for scan")
 		if err := rows.Scan(&cloneName); err != nil {
 			return nil
 		}
-		log.Infof("After scan")
 
 		clones = append(clones, cloneName)
 	}
-	log.Infof("After next")
 
 	log.Debugf("database clones => %s", clones)
 

--- a/pkg/postgres/pool.go
+++ b/pkg/postgres/pool.go
@@ -54,6 +54,7 @@ type DB struct {
 func (d *DB) Begin(ctx context.Context) (*Tx, error) {
 	ctx, cancel := contextutil.ContextWithTimeoutIfNotExists(ctx, defaultTimeout)
 
+	defer setQueryDuration(time.Now(), "pool", "begin")
 	tx, err := d.Pool.Begin(ctx)
 	if err != nil {
 		return nil, err
@@ -69,6 +70,7 @@ func (d *DB) Exec(ctx context.Context, sql string, args ...interface{}) (pgconn.
 	ctx, cancel := contextutil.ContextWithTimeoutIfNotExists(ctx, defaultTimeout)
 	defer cancel()
 
+	defer setQueryDuration(time.Now(), "pool", sql)
 	return d.Pool.Exec(ctx, sql, args...)
 }
 
@@ -76,6 +78,7 @@ func (d *DB) Exec(ctx context.Context, sql string, args ...interface{}) (pgconn.
 func (d *DB) Query(ctx context.Context, sql string, args ...interface{}) (*Rows, error) {
 	ctx, cancel := contextutil.ContextWithTimeoutIfNotExists(ctx, defaultTimeout)
 
+	defer setQueryDuration(time.Now(), "pool", sql)
 	rows, err := d.Pool.Query(ctx, sql, args...)
 	if err != nil {
 		return nil, err
@@ -90,6 +93,7 @@ func (d *DB) Query(ctx context.Context, sql string, args ...interface{}) (*Rows,
 func (d *DB) QueryRow(ctx context.Context, sql string, args ...interface{}) pgx.Row {
 	ctx, cancel := contextutil.ContextWithTimeoutIfNotExists(ctx, defaultTimeout)
 
+	defer setQueryDuration(time.Now(), "pool", sql)
 	return &Row{
 		Row:        d.Pool.QueryRow(ctx, sql, args...),
 		cancelFunc: cancel,

--- a/pkg/postgres/tx.go
+++ b/pkg/postgres/tx.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"context"
+	"time"
 
 	"github.com/jackc/pgconn"
 	"github.com/jackc/pgx/v4"
@@ -15,13 +16,22 @@ type Tx struct {
 
 // Exec wraps pgx.Tx Exec
 func (t *Tx) Exec(ctx context.Context, sql string, args ...interface{}) (commandTag pgconn.CommandTag, err error) {
-	return t.Tx.Exec(ctx, sql, args...)
+	defer setQueryDuration(time.Now(), "tx", sql)
+
+	ct, err := t.Tx.Exec(ctx, sql, args...)
+	if err != nil {
+		incQueryErrors(sql, err)
+	}
+	return ct, err
 }
 
 // Query wraps pgx.Tx Query
 func (t *Tx) Query(ctx context.Context, sql string, args ...interface{}) (*Rows, error) {
+	defer setQueryDuration(time.Now(), "tx", sql)
+
 	rows, err := t.Tx.Query(ctx, sql, args...)
 	if err != nil {
+		incQueryErrors(sql, err)
 		return nil, err
 	}
 	return &Rows{
@@ -32,19 +42,31 @@ func (t *Tx) Query(ctx context.Context, sql string, args ...interface{}) (*Rows,
 
 // QueryRow wraps pgx.Tx QueryRow
 func (t *Tx) QueryRow(ctx context.Context, sql string, args ...interface{}) pgx.Row {
+	defer setQueryDuration(time.Now(), "tx", sql)
+
 	return t.Tx.QueryRow(ctx, sql, args...)
 }
 
 // Commit wraps pgx.Tx Commit
 func (t *Tx) Commit(ctx context.Context) error {
 	defer t.cancelFunc()
+	defer setQueryDuration(time.Now(), "tx", "commit")
 
-	return t.Tx.Commit(ctx)
+	if err := t.Tx.Commit(ctx); err != nil {
+		incQueryErrors("commit", err)
+		return err
+	}
+	return nil
 }
 
 // Rollback wraps pgx.Tx Rollback
 func (t *Tx) Rollback(ctx context.Context) error {
 	defer t.cancelFunc()
+	defer setQueryDuration(time.Now(), "tx", "rollback")
 
-	return t.Tx.Rollback(ctx)
+	if err := t.Tx.Rollback(ctx); err != nil {
+		incQueryErrors("rollback", err)
+		return err
+	}
+	return nil
 }

--- a/pkg/search/postgres/common.go
+++ b/pkg/search/postgres/common.go
@@ -1095,11 +1095,12 @@ func RunCursorQueryForSchema[T any, PT unmarshaler[T]](ctx context.Context, sche
 		}
 	}
 
-	cursor, err := random.GenerateString(16, random.CaseInsensitiveAlpha)
+	cursorSuffix, err := random.GenerateString(16, random.CaseInsensitiveAlpha)
 	if err != nil {
 		closer()
 		return nil, nil, errors.Wrap(err, "creating cursor name")
 	}
+	cursor := stringutils.JoinNonEmpty("_", query.From, cursorSuffix)
 	_, err = tx.Exec(ctx, fmt.Sprintf("DECLARE %s CURSOR FOR %s", cursor, queryStr), query.Data...)
 	if err != nil {
 		closer()


### PR DESCRIPTION
## Description

Add metrics for query durations and also query errors in the pgxpool wrapper. Also skipping durations for things like batch, commit, and begin because we can't do anything actionable without knowing exactly what those txs are trying to do

Duration
```
postgres_query_duration query=delete from deployments where deployments.Id = ANY($1::uuid[]) scope=pool (17/16) 1.062
```

```
postgres_query_errors error=FATAL: terminating connection due to administrator command (SQLSTATE 57P01) query=batch 6
postgres_query_errors error=FATAL: terminating connection due to administrator command (SQLSTATE 57P01) query=begin 1
postgres_query_errors error=FATAL: terminating connection due to administrator command (SQLSTATE 57P01) query=select "cluster_init_bundles".serialized from cluster_init_bundles where cluster_init_bundles.Id = ANY($1::text[]) 3
postgres_query_errors error=context canceled query=select "cluster_init_bundles".serialized from cluster_init_bundles where cluster_init_bundles.Id = ANY($1::text[]) 1
```

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Ran locally