### PR TITLE
Dashrews/ROX-15786 migration timeouts

### DIFF
--- a/central/networkgraph/flow/datastore/internal/store/postgres/store.go
+++ b/central/networkgraph/flow/datastore/internal/store/postgres/store.go
@@ -50,13 +50,13 @@ const (
 
 	deleteStmt         = "DELETE FROM network_flows_v2 WHERE Props_SrcEntity_Type = $1 AND Props_SrcEntity_Id = $2 AND Props_DstEntity_Type = $3 AND Props_DstEntity_Id = $4 AND Props_DstPort = $5 AND Props_L4Protocol = $6 AND ClusterId = $7"
 	deleteStmtWithTime = "DELETE FROM network_flows_v2 WHERE Props_SrcEntity_Type = $1 AND Props_SrcEntity_Id = $2 AND Props_DstEntity_Type = $3 AND Props_DstEntity_Id = $4 AND Props_DstPort = $5 AND Props_L4Protocol = $6 AND ClusterId = $7 AND LastSeenTimestamp = $8"
-	walkStmt           = "SELECT nf.Props_SrcEntity_Type, nf.Props_SrcEntity_Id, nf.Props_DstEntity_Type, nf.Props_DstEntity_Id, nf.Props_DstPort, nf.Props_L4Protocol, nf.LastSeenTimestamp, nf.ClusterId::text FROM %s nf " + joinStmt + " WHERE nf.ClusterId = $1"
+	walkStmt           = "SELECT nf.Props_SrcEntity_Type, nf.Props_SrcEntity_Id, nf.Props_DstEntity_Type, nf.Props_DstEntity_Id, nf.Props_DstPort, nf.Props_L4Protocol, nf.LastSeenTimestamp, nf.ClusterId::text FROM %s nf " + joinStmt
 
 	// These mimic how the RocksDB version of the flow store work
 	getSinceStmt = `SELECT nf.Props_SrcEntity_Type, nf.Props_SrcEntity_Id, nf.Props_DstEntity_Type, 
 	nf.Props_DstEntity_Id, nf.Props_DstPort, nf.Props_L4Protocol, nf.LastSeenTimestamp, nf.ClusterId::text 
 	FROM %s nf ` + joinStmt +
-		` WHERE (nf.LastSeenTimestamp >= $1 OR nf.LastSeenTimestamp IS NULL) AND nf.ClusterId = $2`
+		` WHERE (nf.LastSeenTimestamp >= $1 OR nf.LastSeenTimestamp IS NULL)`
 	deleteSrcDeploymentStmt = "DELETE FROM network_flows_v2 WHERE ClusterId = $1 AND Props_SrcEntity_Type = 1 AND Props_SrcEntity_Id = $2"
 	deleteDstDeploymentStmt = "DELETE FROM network_flows_v2 WHERE ClusterId = $1 AND Props_DstEntity_Type = 1 AND Props_DstEntity_Id = $2"
 
@@ -72,7 +72,6 @@ const (
 	pruneStaleNetworkFlowsStmt = `DELETE FROM %s a USING (
       SELECT MAX(flow_id) as Max_Flow, Props_SrcEntity_Type, Props_SrcEntity_Id, Props_DstEntity_Type, Props_DstEntity_Id, Props_DstPort, Props_L4Protocol, ClusterId
         FROM %s
-		WHERE ClusterId = $1
         GROUP BY Props_SrcEntity_Type, Props_SrcEntity_Id, Props_DstEntity_Type, Props_DstEntity_Id, Props_DstPort, Props_L4Protocol, ClusterId
 		HAVING COUNT(*) > 1
       ) b
@@ -424,10 +423,10 @@ func (s *flowStoreImpl) retryableGetAllFlows(ctx context.Context, since *types.T
 	// handling case when since is nil.  Assumption is we want everything in that case vs when date is not null
 	if since == nil {
 		partitionWalkStmt := fmt.Sprintf(walkStmt, s.partitionName, s.partitionName)
-		rows, err = s.db.Query(ctx, partitionWalkStmt, s.clusterID)
+		rows, err = s.db.Query(ctx, partitionWalkStmt)
 	} else {
 		partitionSinceStmt := fmt.Sprintf(getSinceStmt, s.partitionName, s.partitionName)
-		rows, err = s.db.Query(ctx, partitionSinceStmt, pgutils.NilOrTime(since), s.clusterID)
+		rows, err = s.db.Query(ctx, partitionSinceStmt, pgutils.NilOrTime(since))
 	}
 	if err != nil {
 		return nil, nil, pgutils.ErrNilIfNoRows(err)
@@ -461,10 +460,10 @@ func (s *flowStoreImpl) retryableGetMatchingFlows(ctx context.Context, pred func
 	// handling case when since is nil.  Assumption is we want everything in that case vs when date is not null
 	if since == nil {
 		partitionWalkStmt := fmt.Sprintf(walkStmt, s.partitionName, s.partitionName)
-		rows, err = s.db.Query(ctx, partitionWalkStmt, s.clusterID)
+		rows, err = s.db.Query(ctx, partitionWalkStmt)
 	} else {
 		partitionSinceStmt := fmt.Sprintf(getSinceStmt, s.partitionName, s.partitionName)
-		rows, err = s.db.Query(ctx, partitionSinceStmt, pgutils.NilOrTime(since), s.clusterID)
+		rows, err = s.db.Query(ctx, partitionSinceStmt, pgutils.NilOrTime(since))
 	}
 
 	if err != nil {
@@ -579,7 +578,7 @@ func (s *flowStoreImpl) retryableRemoveMatchingFlows(ctx context.Context, keyMat
 	// of when flow is created vs a deployment deleted that may also make that problematic.
 	if keyMatchFn != nil {
 		partitionWalkStmt := fmt.Sprintf(walkStmt, s.partitionName, s.partitionName)
-		rows, err := conn.Query(ctx, partitionWalkStmt, s.clusterID)
+		rows, err := conn.Query(ctx, partitionWalkStmt)
 		if err != nil {
 			return err
 		}
@@ -635,7 +634,7 @@ func (s *flowStoreImpl) RemoveStaleFlows(ctx context.Context) error {
 	// This is purposefully not retried as this is an optimization and not a requirement
 	// It is also currently prone to statement timeouts
 	prune := fmt.Sprintf(pruneStaleNetworkFlowsStmt, s.partitionName, s.partitionName)
-	_, err = conn.Exec(ctx, prune, s.clusterID)
+	_, err = conn.Exec(ctx, prune)
 	return err
 }
 

--- a/central/networkgraph/flow/datastore/internal/store/postgres/store.go
+++ b/central/networkgraph/flow/datastore/internal/store/postgres/store.go
@@ -491,8 +491,8 @@ func (s *flowStoreImpl) retryableGetFlowsForDeployment(ctx context.Context, depl
 	var rows pgx.Rows
 	var err error
 
-	partitionDeploymentDeleteStmt := fmt.Sprintf(getByDeploymentStmt, s.partitionName, s.partitionName, s.partitionName, s.partitionName)
-	rows, err = s.db.Query(ctx, partitionDeploymentDeleteStmt, deploymentID)
+	partitionGetByDeploymentStmt := fmt.Sprintf(getByDeploymentStmt, s.partitionName, s.partitionName, s.partitionName, s.partitionName)
+	rows, err = s.db.Query(ctx, partitionGetByDeploymentStmt, deploymentID)
 	if err != nil {
 		return nil, pgutils.ErrNilIfNoRows(err)
 	}

--- a/central/networkgraph/flow/datastore/internal/store/postgres/store.go
+++ b/central/networkgraph/flow/datastore/internal/store/postgres/store.go
@@ -62,12 +62,12 @@ const (
 
 	getByDeploymentStmt = `SELECT nf.Props_SrcEntity_Type, nf.Props_SrcEntity_Id, nf.Props_DstEntity_Type, 
 	nf.Props_DstEntity_Id, nf.Props_DstPort, nf.Props_L4Protocol, nf.LastSeenTimestamp, nf.ClusterId::text
-	FROM network_flows_v2 nf ` + joinStmt +
-		`WHERE nf.Props_SrcEntity_Type = 1 AND nf.Props_SrcEntity_Id = $1 AND nf.ClusterId = $2
+	FROM %s nf ` + joinStmt +
+		`WHERE nf.Props_SrcEntity_Type = 1 AND nf.Props_SrcEntity_Id = $1
 	UNION ALL
 	SELECT nf.Props_SrcEntity_Type, nf.Props_SrcEntity_Id, nf.Props_DstEntity_Type, nf.Props_DstEntity_Id, nf.Props_DstPort, nf.Props_L4Protocol, nf.LastSeenTimestamp, nf.ClusterId::text
-	FROM network_flows_v2 nf ` + joinStmt +
-		`WHERE nf.Props_DstEntity_Type = 1 AND nf.Props_DstEntity_Id = $1 AND nf.ClusterId = $2`
+	FROM %s nf ` + joinStmt +
+		`WHERE nf.Props_DstEntity_Type = 1 AND nf.Props_DstEntity_Id = $1`
 
 	pruneStaleNetworkFlowsStmt = `DELETE FROM %s a USING (
       SELECT MAX(flow_id) as Max_Flow, Props_SrcEntity_Type, Props_SrcEntity_Id, Props_DstEntity_Type, Props_DstEntity_Id, Props_DstPort, Props_L4Protocol, ClusterId
@@ -491,8 +491,8 @@ func (s *flowStoreImpl) retryableGetFlowsForDeployment(ctx context.Context, depl
 	var rows pgx.Rows
 	var err error
 
-	partitionDeploymentDeleteStmt := fmt.Sprintf(getByDeploymentStmt, s.partitionName, s.partitionName)
-	rows, err = s.db.Query(ctx, partitionDeploymentDeleteStmt, deploymentID, s.clusterID)
+	partitionDeploymentDeleteStmt := fmt.Sprintf(getByDeploymentStmt, s.partitionName, s.partitionName, s.partitionName, s.partitionName)
+	rows, err = s.db.Query(ctx, partitionDeploymentDeleteStmt, deploymentID)
 	if err != nil {
 		return nil, pgutils.ErrNilIfNoRows(err)
 	}

--- a/migrator/clone/postgres/db_clone_manager_impl.go
+++ b/migrator/clone/postgres/db_clone_manager_impl.go
@@ -281,7 +281,7 @@ func (d *dbCloneManagerImpl) doPersist(cloneName string, prev string) error {
 
 	err = pgadmin.AnalyzeDatabase(d.adminConfig, CurrentClone)
 	if err != nil {
-		log.Warnf("unable to force analyze restore database:  %v", err)
+		log.Warnf("unable to force analyze restore database: %v", err)
 	}
 
 	return nil

--- a/migrator/clone/postgres/db_clone_manager_impl.go
+++ b/migrator/clone/postgres/db_clone_manager_impl.go
@@ -279,6 +279,11 @@ func (d *dbCloneManagerImpl) doPersist(cloneName string, prev string) error {
 		}
 	}
 
+	err = pgadmin.AnalyzeDatabase(d.adminConfig, CurrentClone)
+	if err != nil {
+		log.Warnf("unable to force analyze restore database:  %v", err)
+	}
+
 	return nil
 }
 

--- a/migrator/migrations/m_172_to_m_173_network_flows_partition/migration.go
+++ b/migrator/migrations/m_172_to_m_173_network_flows_partition/migration.go
@@ -153,7 +153,7 @@ func getPreviousCount(parentCtx context.Context, store previous.FlowStore) (int,
 	defer cancel()
 
 	deadline, _ := ctx.Deadline()
-	log.WriteToStderrf("SHREWS -- context deadline %t", deadline)
+	log.WriteToStderrf("SHREWS -- context deadline %q", deadline.String())
 
 	return store.Count(ctx)
 }

--- a/migrator/migrations/m_172_to_m_173_network_flows_partition/migration.go
+++ b/migrator/migrations/m_172_to_m_173_network_flows_partition/migration.go
@@ -39,8 +39,10 @@ var (
 
 // MigrateToPartitions updates the btree network flow indexes to be hash
 func MigrateToPartitions(gormDB *gorm.DB, db *postgres.DB) error {
+	parentCtx := context.Background()
+
 	// First get the distinct clusters in the network_flows table
-	clusters, err := getClusters(db)
+	clusters, err := getClusters(parentCtx, db)
 	if err != nil {
 		log.WriteToStderrf("unable to retrieve clusters from network_flows, %v", err)
 		return err
@@ -48,13 +50,13 @@ func MigrateToPartitions(gormDB *gorm.DB, db *postgres.DB) error {
 
 	// Now apply the updated schema to create a partition table with updated index types.  The
 	// individual partitions will be created on a per cluster basis as the store is created.
-	pgutils.CreateTableFromModel(context.Background(), gormDB, updatedSchema.CreateTableNetworkFlowsStmt)
+	pgutils.CreateTableFromModel(parentCtx, gormDB, updatedSchema.CreateTableNetworkFlowsStmt)
 
 	// Create the partition and move the data
 	for _, cluster := range clusters {
 		sourceStore := previous.New(db, cluster)
 
-		previousCount, err := sourceStore.Count(context.Background())
+		previousCount, err := getPreviousCount(parentCtx, sourceStore)
 		if err != nil {
 			return err
 		}
@@ -63,13 +65,13 @@ func MigrateToPartitions(gormDB *gorm.DB, db *postgres.DB) error {
 		// Create the updated store which will create the partiion
 		destinationStore := updated.New(db, cluster)
 
-		err = migrateData(db, cluster)
+		err = migrateData(parentCtx, db, cluster)
 		if err != nil {
 			log.WriteToStderrf("unable to move data for cluster %q, %v", cluster, err)
 			return err
 		}
 
-		migratedCount, err := destinationStore.Count(context.Background())
+		migratedCount, err := getDestinationCount(parentCtx, destinationStore)
 		if err != nil {
 			return err
 		}
@@ -81,12 +83,12 @@ func MigrateToPartitions(gormDB *gorm.DB, db *postgres.DB) error {
 		// Ideally this would have been done on the source.  However, the reason we are implementing
 		// this change is because removing the stale flows was becoming problematic with large amounts of data.
 		// So we will copy it all over and then remove the stale data once it is migrated.
-		err = destinationStore.RemoveStaleFlows(context.Background())
+		err = cleanupDestinationPartition(parentCtx, destinationStore)
 		if err != nil {
 			return err
 		}
 
-		migratedCount, err = destinationStore.Count(context.Background())
+		migratedCount, err = getDestinationCount(parentCtx, destinationStore)
 		if err != nil {
 			return err
 		}
@@ -103,11 +105,41 @@ func MigrateToPartitions(gormDB *gorm.DB, db *postgres.DB) error {
 	return nil
 }
 
-func getClusters(db *postgres.DB) ([]string, error) {
+func getPreviousCount(parentCtx context.Context, store previous.FlowStore) (int, error) {
+	// Due to heavy load with network flows, each call to the store could take a long time so we will
+	// pass a context with the migration timeout to them.
+	ctx, cancel := context.WithTimeout(parentCtx, types.DefaultMigrationTimeout)
+	defer cancel()
+
+	return store.Count(ctx)
+}
+
+func getDestinationCount(parentCtx context.Context, store updated.FlowStore) (int, error) {
+	// Due to heavy load with network flows, each call to the store could take a long time so we will
+	// pass a context with the migration timeout to them.
+	ctx, cancel := context.WithTimeout(parentCtx, types.DefaultMigrationTimeout)
+	defer cancel()
+
+	return store.Count(ctx)
+}
+
+func cleanupDestinationPartition(parentCtx context.Context, store updated.FlowStore) error {
+	// Due to heavy load with network flows, each call to the store could take a long time so we will
+	// pass a context with the migration timeout to them.
+	ctx, cancel := context.WithTimeout(parentCtx, types.DefaultMigrationTimeout)
+	defer cancel()
+
+	return store.RemoveStaleFlows(ctx)
+}
+
+func getClusters(parentCtx context.Context, db *postgres.DB) ([]string, error) {
+	ctx, cancel := context.WithTimeout(parentCtx, types.DefaultMigrationTimeout)
+	defer cancel()
+
 	var clusters []string
 	getClustersStmt := "select distinct id from clusters;"
 
-	rows, err := db.Query(context.Background(), getClustersStmt)
+	rows, err := db.Query(ctx, getClustersStmt)
 	if err != nil {
 		return nil, err
 	}
@@ -125,17 +157,21 @@ func getClusters(db *postgres.DB) ([]string, error) {
 	return clusters, rows.Err()
 }
 
-func migrateData(db *postgres.DB, cluster string) error {
+func migrateData(parentCtx context.Context, db *postgres.DB, cluster string) error {
 	clusterUUID, err := uuid.FromString(cluster)
 	if err != nil {
 		return err
 	}
 
 	partitionPostFix := strings.ReplaceAll(cluster, "-", "_")
+
+	ctx, cancel := context.WithTimeout(parentCtx, types.DefaultMigrationTimeout)
+	defer cancel()
+
 	// Skip the serial ID
 	moveDataStmt := fmt.Sprintf("INSERT INTO network_flows_v2_%s (Props_SrcEntity_Type, Props_SrcEntity_Id, Props_DstEntity_Type, Props_DstEntity_Id, Props_DstPort, Props_L4Protocol, LastSeenTimestamp, ClusterId) SELECT Props_SrcEntity_Type, Props_SrcEntity_Id, Props_DstEntity_Type, Props_DstEntity_Id, Props_DstPort, Props_L4Protocol, LastSeenTimestamp, ClusterId FROM network_flows WHERE ClusterId = $1", partitionPostFix)
 
-	_, err = db.Exec(context.Background(), moveDataStmt, clusterUUID)
+	_, err = db.Exec(ctx, moveDataStmt, clusterUUID)
 	if err != nil {
 		return err
 	}

--- a/migrator/migrations/m_172_to_m_173_network_flows_partition/migration.go
+++ b/migrator/migrations/m_172_to_m_173_network_flows_partition/migration.go
@@ -104,37 +104,37 @@ func MigrateToPartitions(gormDB *gorm.DB, db *postgres.DB) error {
 
 	// Now deal with all the indexes
 	// First the parent indexes
-	for _, statement := range updatedSchema.ParentIndexStmts {
-		if err := executeStatementWithContext(parentCtx, db, statement); err != nil {
-			return err
-		}
-	}
+	//for _, statement := range updatedSchema.ParentIndexStmts {
+	//	if err := executeStatementWithContext(parentCtx, db, statement); err != nil {
+	//		return err
+	//	}
+	//}
 
 	// Now the children
-	for idx, partition := range partitionNames {
-		// Add the index for the cluster
-		for _, index := range updatedSchema.PartitionIndexes {
-			namePart := clusters[idx]
-			difference := 64 - len(index.IndexName) - 2 + len(clusters[idx])
-
-			if difference < 0 {
-				namePart = clusters[idx][:64+difference]
-			}
-
-			officialName := fmt.Sprintf(index.IndexName, strings.ReplaceAll(namePart, "-", "_"))
-			createIndex := fmt.Sprintf("CREATE INDEX IF NOT EXISTS %s ON %s USING %s(%s)", officialName, partition, index.IndexType, index.IndexField)
-			log.WriteToStderrf("SHREWS -- %q", createIndex)
-			if err := executeStatementWithContext(parentCtx, db, createIndex); err != nil {
-				return err
-			}
-
-			attachIndex := fmt.Sprintf("alter index %s ATTACH PARTITION %s", index.ParentName, officialName)
-			log.WriteToStderrf("SHREWS -- %q", attachIndex)
-			if err := executeStatementWithContext(parentCtx, db, attachIndex); err != nil {
-				return err
-			}
-		}
-	}
+	//for idx, partition := range partitionNames {
+	//	// Add the index for the cluster
+	//	for _, index := range updatedSchema.PartitionIndexes {
+	//		namePart := clusters[idx]
+	//		difference := 64 - len(index.IndexName) - 2 + len(clusters[idx])
+	//
+	//		if difference < 0 {
+	//			namePart = clusters[idx][:64+difference]
+	//		}
+	//
+	//		officialName := fmt.Sprintf(index.IndexName, strings.ReplaceAll(namePart, "-", "_"))
+	//		createIndex := fmt.Sprintf("CREATE INDEX IF NOT EXISTS %s ON %s USING %s(%s)", officialName, partition, index.IndexType, index.IndexField)
+	//		log.WriteToStderrf("SHREWS -- %q", createIndex)
+	//		if err := executeStatementWithContext(parentCtx, db, createIndex); err != nil {
+	//			return err
+	//		}
+	//
+	//		attachIndex := fmt.Sprintf("alter index %s ATTACH PARTITION %s", index.ParentName, officialName)
+	//		log.WriteToStderrf("SHREWS -- %q", attachIndex)
+	//		if err := executeStatementWithContext(parentCtx, db, attachIndex); err != nil {
+	//			return err
+	//		}
+	//	}
+	//}
 
 	// Drop the old table
 	err = gormDB.Migrator().DropTable("network_flows")

--- a/migrator/migrations/m_172_to_m_173_network_flows_partition/migration.go
+++ b/migrator/migrations/m_172_to_m_173_network_flows_partition/migration.go
@@ -121,7 +121,7 @@ func MigrateToPartitions(gormDB *gorm.DB, db *postgres.DB) error {
 				namePart = clusters[idx][:64+difference]
 			}
 
-			officialName := fmt.Sprintf(index.IndexName, namePart)
+			officialName := fmt.Sprintf(index.IndexName, strings.ReplaceAll(namePart, "-", "_"))
 			createIndex := fmt.Sprintf("CREATE INDEX IF NOT EXISTS %s ON %s USING %s(%s)", officialName, partition, index.IndexType, index.IndexField)
 			log.WriteToStderrf("SHREWS -- %q", createIndex)
 			if err := executeStatementWithContext(parentCtx, db, createIndex); err != nil {

--- a/migrator/migrations/m_172_to_m_173_network_flows_partition/migration.go
+++ b/migrator/migrations/m_172_to_m_173_network_flows_partition/migration.go
@@ -111,6 +111,9 @@ func getPreviousCount(parentCtx context.Context, store previous.FlowStore) (int,
 	ctx, cancel := context.WithTimeout(parentCtx, types.DefaultMigrationTimeout)
 	defer cancel()
 
+	deadline, _ := ctx.Deadline()
+	log.WriteToStderrf("SHREWS -- context deadline %t", deadline)
+
 	return store.Count(ctx)
 }
 

--- a/migrator/migrations/m_172_to_m_173_network_flows_partition/migration_test.go
+++ b/migrator/migrations/m_172_to_m_173_network_flows_partition/migration_test.go
@@ -55,9 +55,10 @@ func (s *networkFlowsMigrationTestSuite) TearDownTest() {
 func (s *networkFlowsMigrationTestSuite) TestMigration() {
 	// Add some data to the original tables via the old stores.
 	s.addSomeOldData()
-	_, err := s.db.DB.exec(context.Background, "insert into clusters (id) values ($1)", cluster1)
+
+	_, err := s.db.DB.Exec(context.Background(), "insert into clusters (id) values ($1)", cluster1)
 	s.NoError(err)
-	_, err = s.db.DB.exec(context.Background, "insert into clusters (id) values ($1)", cluster2)
+	_, err = s.db.DB.Exec(context.Background(), "insert into clusters (id) values ($1)", cluster2)
 	s.NoError(err)
 
 	dbs := &types.Databases{

--- a/migrator/migrations/m_172_to_m_173_network_flows_partition/migration_test.go
+++ b/migrator/migrations/m_172_to_m_173_network_flows_partition/migration_test.go
@@ -42,6 +42,7 @@ func TestMigration(t *testing.T) {
 func (s *networkFlowsMigrationTestSuite) SetupTest() {
 	s.db = pghelper.ForT(s.T(), true)
 	pgutils.CreateTableFromModel(context.Background(), s.db.GetGormDB(), oldSchema.CreateTableNetworkFlowsStmt)
+	pgutils.CreateTableFromModel(context.Background(), s.db.GetGormDB(), oldSchema.CreateTableClustersStmt)
 
 	s.oldStore1 = previous.New(s.db.DB, cluster1)
 	s.oldStore2 = previous.New(s.db.DB, cluster2)
@@ -54,6 +55,10 @@ func (s *networkFlowsMigrationTestSuite) TearDownTest() {
 func (s *networkFlowsMigrationTestSuite) TestMigration() {
 	// Add some data to the original tables via the old stores.
 	s.addSomeOldData()
+	_, err := s.db.DB.exec(context.Background, "insert into clusters (id) values ($1)", cluster1)
+	s.NoError(err)
+	_, err = s.db.DB.exec(context.Background, "insert into clusters (id) values ($1)", cluster2)
+	s.NoError(err)
 
 	dbs := &types.Databases{
 		PostgresDB: s.db.DB,

--- a/migrator/migrations/m_172_to_m_173_network_flows_partition/schema/network_flows_v2.go
+++ b/migrator/migrations/m_172_to_m_173_network_flows_partition/schema/network_flows_v2.go
@@ -30,10 +30,39 @@ var (
 			) PARTITION BY LIST (ClusterId)`,
 		Partition: true,
 		PostStmts: []string{
-			//"CREATE INDEX IF NOT EXISTS network_flows_src_v2 ON network_flows_v2 USING hash(props_srcentity_Id)",
-			//"CREATE INDEX IF NOT EXISTS network_flows_dst_v2 ON network_flows_v2 USING hash(props_dstentity_Id)",
-			//"CREATE INDEX IF NOT EXISTS network_flows_cluster_v2 ON network_flows_v2 USING hash(clusterid)",
-			//"CREATE INDEX IF NOT EXISTS network_flows_lastseentimestamp_v2 ON network_flows_v2 USING brin (lastseentimestamp)",
+			// Using ON ONLY for migrations so that child indexes won't impact moving data.  Will add them as part
+			// of the migration
+			"CREATE INDEX IF NOT EXISTS network_flows_src_v2 ON ONLY network_flows_v2 USING hash(props_srcentity_Id)",
+			"CREATE INDEX IF NOT EXISTS network_flows_dst_v2 ON ONLY network_flows_v2 USING hash(props_dstentity_Id)",
+			"CREATE INDEX IF NOT EXISTS network_flows_cluster_v2 ON ONLY network_flows_v2 USING hash(clusterid)",
+			"CREATE INDEX IF NOT EXISTS network_flows_lastseentimestamp_v2 ON ONLY network_flows_v2 USING brin (lastseentimestamp)",
+		},
+	}
+
+	PartitionIndexes = []PartitionIndex{
+		{
+			IndexField: "props_srcentity_Id",
+			IndexType:  "hash",
+			IndexName:  "network_flows_v2_%s_props_srcentity_id_idx",
+			ParentName: "network_flows_src_v2",
+		},
+		{
+			IndexField: "props_dstentity_Id",
+			IndexType:  "hash",
+			IndexName:  "network_flows_v2_%s_props_dstentity_id_idx",
+			ParentName: "network_flows_dst_v2",
+		},
+		{
+			IndexField: "clusterid",
+			IndexType:  "hash",
+			IndexName:  "network_flows_v2_%s_clusterid_idx",
+			ParentName: "network_flows_cluster_v2",
+		},
+		{
+			IndexField: "lastseentimestamp",
+			IndexType:  "brin",
+			IndexName:  "network_flows_v2_%s_lastseentimestamp_idx",
+			ParentName: "network_flows_lastseentimestamp_v2",
 		},
 	}
 )
@@ -42,3 +71,10 @@ const (
 	// NetworkFlowsTableName holds the database table name
 	NetworkFlowsTableName = "network_flows_v2"
 )
+
+type PartitionIndex struct {
+	IndexField string
+	IndexType  string
+	IndexName  string
+	ParentName string
+}

--- a/migrator/migrations/m_172_to_m_173_network_flows_partition/schema/network_flows_v2.go
+++ b/migrator/migrations/m_172_to_m_173_network_flows_partition/schema/network_flows_v2.go
@@ -29,14 +29,16 @@ var (
 					PRIMARY KEY(ClusterId, Flow_id)
 			) PARTITION BY LIST (ClusterId)`,
 		Partition: true,
-		PostStmts: []string{
-			// Using ON ONLY for migrations so that child indexes won't impact moving data.  Will add them as part
-			// of the migration
-			"CREATE INDEX IF NOT EXISTS network_flows_src_v2 ON ONLY network_flows_v2 USING hash(props_srcentity_Id)",
-			"CREATE INDEX IF NOT EXISTS network_flows_dst_v2 ON ONLY network_flows_v2 USING hash(props_dstentity_Id)",
-			"CREATE INDEX IF NOT EXISTS network_flows_cluster_v2 ON ONLY network_flows_v2 USING hash(clusterid)",
-			"CREATE INDEX IF NOT EXISTS network_flows_lastseentimestamp_v2 ON ONLY network_flows_v2 USING brin (lastseentimestamp)",
-		},
+		PostStmts: []string{},
+	}
+
+	ParentIndexStmts = []string{
+		// Using ON ONLY for migrations so that child indexes won't impact moving data.  Will add them as part
+		// of the migration
+		"CREATE INDEX IF NOT EXISTS network_flows_src_v2 ON ONLY network_flows_v2 USING hash(props_srcentity_Id)",
+		"CREATE INDEX IF NOT EXISTS network_flows_dst_v2 ON ONLY network_flows_v2 USING hash(props_dstentity_Id)",
+		"CREATE INDEX IF NOT EXISTS network_flows_cluster_v2 ON ONLY network_flows_v2 USING hash(clusterid)",
+		"CREATE INDEX IF NOT EXISTS network_flows_lastseentimestamp_v2 ON ONLY network_flows_v2 USING brin (lastseentimestamp)",
 	}
 
 	PartitionIndexes = []PartitionIndex{

--- a/migrator/migrations/m_172_to_m_173_network_flows_partition/schema/network_flows_v2.go
+++ b/migrator/migrations/m_172_to_m_173_network_flows_partition/schema/network_flows_v2.go
@@ -29,41 +29,10 @@ var (
 					PRIMARY KEY(ClusterId, Flow_id)
 			) PARTITION BY LIST (ClusterId)`,
 		Partition: true,
-		PostStmts: []string{},
-	}
-
-	ParentIndexStmts = []string{
-		// Using ON ONLY for migrations so that child indexes won't impact moving data.  Will add them as part
-		// of the migration
-		"CREATE INDEX IF NOT EXISTS network_flows_src_v2 ON network_flows_v2 USING hash(props_srcentity_Id)",
-		"CREATE INDEX IF NOT EXISTS network_flows_dst_v2 ON network_flows_v2 USING hash(props_dstentity_Id)",
-		"CREATE INDEX IF NOT EXISTS network_flows_lastseentimestamp_v2 ON network_flows_v2 USING brin (lastseentimestamp)",
-	}
-
-	PartitionIndexes = []PartitionIndex{
-		{
-			IndexField: "props_srcentity_Id",
-			IndexType:  "hash",
-			IndexName:  "network_flows_v2_%s_props_srcentity_id_idx",
-			ParentName: "network_flows_src_v2",
-		},
-		{
-			IndexField: "props_dstentity_Id",
-			IndexType:  "hash",
-			IndexName:  "network_flows_v2_%s_props_dstentity_id_idx",
-			ParentName: "network_flows_dst_v2",
-		},
-		//{
-		//	IndexField: "clusterid",
-		//	IndexType:  "hash",
-		//	IndexName:  "network_flows_v2_%s_clusterid_idx",
-		//	ParentName: "network_flows_cluster_v2",
-		//},
-		{
-			IndexField: "lastseentimestamp",
-			IndexType:  "brin",
-			IndexName:  "network_flows_v2_%s_lastseentimestamp_idx",
-			ParentName: "network_flows_lastseentimestamp_v2",
+		PostStmts: []string{
+			"CREATE INDEX IF NOT EXISTS network_flows_src_v2 ON network_flows_v2 USING hash(props_srcentity_Id)",
+			"CREATE INDEX IF NOT EXISTS network_flows_dst_v2 ON network_flows_v2 USING hash(props_dstentity_Id)",
+			"CREATE INDEX IF NOT EXISTS network_flows_lastseentimestamp_v2 ON network_flows_v2 USING brin (lastseentimestamp)",
 		},
 	}
 )
@@ -72,10 +41,3 @@ const (
 	// NetworkFlowsTableName holds the database table name
 	NetworkFlowsTableName = "network_flows_v2"
 )
-
-type PartitionIndex struct {
-	IndexField string
-	IndexType  string
-	IndexName  string
-	ParentName string
-}

--- a/migrator/migrations/m_172_to_m_173_network_flows_partition/schema/network_flows_v2.go
+++ b/migrator/migrations/m_172_to_m_173_network_flows_partition/schema/network_flows_v2.go
@@ -35,10 +35,9 @@ var (
 	ParentIndexStmts = []string{
 		// Using ON ONLY for migrations so that child indexes won't impact moving data.  Will add them as part
 		// of the migration
-		"CREATE INDEX IF NOT EXISTS network_flows_src_v2 ON ONLY network_flows_v2 USING hash(props_srcentity_Id)",
-		"CREATE INDEX IF NOT EXISTS network_flows_dst_v2 ON ONLY network_flows_v2 USING hash(props_dstentity_Id)",
-		//"CREATE INDEX IF NOT EXISTS network_flows_cluster_v2 ON ONLY network_flows_v2 USING hash(clusterid)",
-		"CREATE INDEX IF NOT EXISTS network_flows_lastseentimestamp_v2 ON ONLY network_flows_v2 USING brin (lastseentimestamp)",
+		"CREATE INDEX IF NOT EXISTS network_flows_src_v2 ON network_flows_v2 USING hash(props_srcentity_Id)",
+		"CREATE INDEX IF NOT EXISTS network_flows_dst_v2 ON network_flows_v2 USING hash(props_dstentity_Id)",
+		"CREATE INDEX IF NOT EXISTS network_flows_lastseentimestamp_v2 ON network_flows_v2 USING brin (lastseentimestamp)",
 	}
 
 	PartitionIndexes = []PartitionIndex{

--- a/migrator/migrations/m_172_to_m_173_network_flows_partition/schema/network_flows_v2.go
+++ b/migrator/migrations/m_172_to_m_173_network_flows_partition/schema/network_flows_v2.go
@@ -37,7 +37,7 @@ var (
 		// of the migration
 		"CREATE INDEX IF NOT EXISTS network_flows_src_v2 ON ONLY network_flows_v2 USING hash(props_srcentity_Id)",
 		"CREATE INDEX IF NOT EXISTS network_flows_dst_v2 ON ONLY network_flows_v2 USING hash(props_dstentity_Id)",
-		"CREATE INDEX IF NOT EXISTS network_flows_cluster_v2 ON ONLY network_flows_v2 USING hash(clusterid)",
+		//"CREATE INDEX IF NOT EXISTS network_flows_cluster_v2 ON ONLY network_flows_v2 USING hash(clusterid)",
 		"CREATE INDEX IF NOT EXISTS network_flows_lastseentimestamp_v2 ON ONLY network_flows_v2 USING brin (lastseentimestamp)",
 	}
 
@@ -54,12 +54,12 @@ var (
 			IndexName:  "network_flows_v2_%s_props_dstentity_id_idx",
 			ParentName: "network_flows_dst_v2",
 		},
-		{
-			IndexField: "clusterid",
-			IndexType:  "hash",
-			IndexName:  "network_flows_v2_%s_clusterid_idx",
-			ParentName: "network_flows_cluster_v2",
-		},
+		//{
+		//	IndexField: "clusterid",
+		//	IndexType:  "hash",
+		//	IndexName:  "network_flows_v2_%s_clusterid_idx",
+		//	ParentName: "network_flows_cluster_v2",
+		//},
 		{
 			IndexField: "lastseentimestamp",
 			IndexType:  "brin",

--- a/migrator/migrations/m_172_to_m_173_network_flows_partition/schema/network_flows_v2.go
+++ b/migrator/migrations/m_172_to_m_173_network_flows_partition/schema/network_flows_v2.go
@@ -30,10 +30,10 @@ var (
 			) PARTITION BY LIST (ClusterId)`,
 		Partition: true,
 		PostStmts: []string{
-			"CREATE INDEX IF NOT EXISTS network_flows_src_v2 ON network_flows_v2 USING hash(props_srcentity_Id)",
-			"CREATE INDEX IF NOT EXISTS network_flows_dst_v2 ON network_flows_v2 USING hash(props_dstentity_Id)",
-			"CREATE INDEX IF NOT EXISTS network_flows_cluster_v2 ON network_flows_v2 USING hash(clusterid)",
-			"CREATE INDEX IF NOT EXISTS network_flows_lastseentimestamp_v2 ON network_flows_v2 USING brin (lastseentimestamp)",
+			//"CREATE INDEX IF NOT EXISTS network_flows_src_v2 ON network_flows_v2 USING hash(props_srcentity_Id)",
+			//"CREATE INDEX IF NOT EXISTS network_flows_dst_v2 ON network_flows_v2 USING hash(props_dstentity_Id)",
+			//"CREATE INDEX IF NOT EXISTS network_flows_cluster_v2 ON network_flows_v2 USING hash(clusterid)",
+			//"CREATE INDEX IF NOT EXISTS network_flows_lastseentimestamp_v2 ON network_flows_v2 USING brin (lastseentimestamp)",
 		},
 	}
 )

--- a/migrator/migrations/m_172_to_m_173_network_flows_partition/stores/updated/store.go
+++ b/migrator/migrations/m_172_to_m_173_network_flows_partition/stores/updated/store.go
@@ -40,13 +40,13 @@ const (
 	nf.Props_DstPort = tmpflow.Props_DstPort AND nf.Props_L4Protocol = tmpflow.Props_L4Protocol AND 
 	nf.ClusterId = tmpflow.ClusterId and nf.Flow_id = tmpflow.MaxFlow `
 
-	walkStmt = "SELECT nf.Props_SrcEntity_Type, nf.Props_SrcEntity_Id, nf.Props_DstEntity_Type, nf.Props_DstEntity_Id, nf.Props_DstPort, nf.Props_L4Protocol, nf.LastSeenTimestamp, nf.ClusterId::text FROM network_flows_v2 nf " + joinStmt + " WHERE nf.ClusterId = $1"
+	walkStmt = "SELECT nf.Props_SrcEntity_Type, nf.Props_SrcEntity_Id, nf.Props_DstEntity_Type, nf.Props_DstEntity_Id, nf.Props_DstPort, nf.Props_L4Protocol, nf.LastSeenTimestamp, nf.ClusterId::text FROM network_flows_v2 nf " + joinStmt
 
 	// These mimic how the RocksDB version of the flow store work
 	getSinceStmt = `SELECT nf.Props_SrcEntity_Type, nf.Props_SrcEntity_Id, nf.Props_DstEntity_Type, 
 	nf.Props_DstEntity_Id, nf.Props_DstPort, nf.Props_L4Protocol, nf.LastSeenTimestamp, nf.ClusterId::text 
 	FROM network_flows_v2 nf ` + joinStmt +
-		` WHERE (nf.LastSeenTimestamp >= $1 OR nf.LastSeenTimestamp IS NULL) AND nf.ClusterId = $2`
+		` WHERE (nf.LastSeenTimestamp >= $1 OR nf.LastSeenTimestamp IS NULL)`
 
 	getByDeploymentStmt = `SELECT nf.Props_SrcEntity_Type, nf.Props_SrcEntity_Id, nf.Props_DstEntity_Type, 
 	nf.Props_DstEntity_Id, nf.Props_DstPort, nf.Props_L4Protocol, nf.LastSeenTimestamp, nf.ClusterId::text
@@ -60,7 +60,6 @@ const (
 	pruneStaleNetworkFlowsStmt = `DELETE FROM %s a USING (
       SELECT MAX(flow_id) as Max_Flow, Props_SrcEntity_Type, Props_SrcEntity_Id, Props_DstEntity_Type, Props_DstEntity_Id, Props_DstPort, Props_L4Protocol, ClusterId
         FROM %s
-		WHERE ClusterId = $1
         GROUP BY Props_SrcEntity_Type, Props_SrcEntity_Id, Props_DstEntity_Type, Props_DstEntity_Id, Props_DstPort, Props_L4Protocol, ClusterId
 		HAVING COUNT(*) > 1
       ) b
@@ -200,10 +199,10 @@ func (s *flowStoreImpl) retryableGetAllFlows(ctx context.Context, since *types.T
 	// handling case when since is nil.  Assumption is we want everything in that case vs when date is not null
 	if since == nil {
 		partitionWalkStmt := fmt.Sprintf(walkStmt, s.partitionName)
-		rows, err = s.db.Query(ctx, partitionWalkStmt, s.clusterID)
+		rows, err = s.db.Query(ctx, partitionWalkStmt)
 	} else {
 		partitionSinceStmt := fmt.Sprintf(getSinceStmt, s.partitionName)
-		rows, err = s.db.Query(ctx, partitionSinceStmt, pgutils.NilOrTime(since), s.clusterID)
+		rows, err = s.db.Query(ctx, partitionSinceStmt, pgutils.NilOrTime(since))
 	}
 	if err != nil {
 		return nil, nil, pgutils.ErrNilIfNoRows(err)
@@ -235,10 +234,10 @@ func (s *flowStoreImpl) retryableGetMatchingFlows(ctx context.Context, pred func
 	// handling case when since is nil.  Assumption is we want everything in that case vs when date is not null
 	if since == nil {
 		partitionWalkStmt := fmt.Sprintf(walkStmt, s.partitionName)
-		rows, err = s.db.Query(ctx, partitionWalkStmt, s.clusterID)
+		rows, err = s.db.Query(ctx, partitionWalkStmt)
 	} else {
 		partitionSinceStmt := fmt.Sprintf(getSinceStmt, s.partitionName)
-		rows, err = s.db.Query(ctx, partitionSinceStmt, pgutils.NilOrTime(since), s.clusterID)
+		rows, err = s.db.Query(ctx, partitionSinceStmt, pgutils.NilOrTime(since))
 	}
 
 	if err != nil {
@@ -303,7 +302,7 @@ func (s *flowStoreImpl) RemoveStaleFlows(ctx context.Context) error {
 	// This is purposefully not retried as this is an optimization and not a requirement
 	// It is also currently prone to statement timeouts
 	prune := fmt.Sprintf(pruneStaleNetworkFlowsStmt, s.partitionName, s.partitionName)
-	_, err = conn.Exec(ctx, prune, s.clusterID)
+	_, err = conn.Exec(ctx, prune)
 	return err
 }
 

--- a/migrator/migrations/m_172_to_m_173_network_flows_partition/stores/updated/store.go
+++ b/migrator/migrations/m_172_to_m_173_network_flows_partition/stores/updated/store.go
@@ -91,6 +91,9 @@ type FlowStore interface {
 
 	// RemoveStaleFlows - remove stale duplicate network flows
 	RemoveStaleFlows(ctx context.Context) error
+
+	// GetPartitionName - returns the partition name
+	GetPartitionName() string
 }
 
 type flowStoreImpl struct {
@@ -302,6 +305,11 @@ func (s *flowStoreImpl) RemoveStaleFlows(ctx context.Context) error {
 	prune := fmt.Sprintf(pruneStaleNetworkFlowsStmt, s.partitionName, s.partitionName)
 	_, err = conn.Exec(ctx, prune, s.clusterID)
 	return err
+}
+
+// GetPartitionName - returns the partition name
+func (s *flowStoreImpl) GetPartitionName() string {
+	return s.partitionName
 }
 
 //// Used for testing

--- a/migrator/postgreshelper/load.go
+++ b/migrator/postgreshelper/load.go
@@ -38,6 +38,7 @@ func Load(databaseName string) (*postgres.DB, *gorm.DB, error) {
 		}
 	}
 	// Waits for central-db ready with retries
+	adminConfig.ConnConfig.RuntimeParams["statement_timeout"] = "0"
 	postgresDB = pgadmin.GetClonePool(adminConfig, databaseName)
 	gormDB, err = gc.ConnectWithRetries(databaseName)
 	if err != nil {

--- a/migrator/postgreshelper/load.go
+++ b/migrator/postgreshelper/load.go
@@ -37,7 +37,9 @@ func Load(databaseName string) (*postgres.DB, *gorm.DB, error) {
 			return nil, nil, err
 		}
 	}
-	// Waits for central-db ready with retries
+	// For migrations we may have long running jobs.  Here we explicitly turn
+	// off the statement timeout for the connection and will rely on the context
+	// timeouts to control this.
 	adminConfig.ConnConfig.RuntimeParams["statement_timeout"] = "0"
 	postgresDB = pgadmin.GetClonePool(adminConfig, databaseName)
 	gormDB, err = gc.ConnectWithRetries(databaseName)

--- a/migrator/types/migration.go
+++ b/migrator/types/migration.go
@@ -2,11 +2,17 @@ package types
 
 import (
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/rocksdb"
 	"github.com/tecbot/gorocksdb"
 	bolt "go.etcd.io/bbolt"
 	"gorm.io/gorm"
+)
+
+var (
+	// DefaultMigrationTimeout -- default timeout for migration postgres statements
+	DefaultMigrationTimeout = env.PostgresDefaultMigrationStatementTimeout.DurationSetting()
 )
 
 // Databases encapsulates all the different databases we are using

--- a/pkg/env/postgres_default_timeout.go
+++ b/pkg/env/postgres_default_timeout.go
@@ -10,5 +10,5 @@ var (
 	PostgresDefaultCursorTimeout = registerDurationSetting("ROX_POSTGRES_DEFAULT_CURSOR_TIMEOUT", 10*time.Minute)
 
 	// PostgresDefaultMigrationStatementTimeout sets the default timeout for Postgres statements during migration
-	PostgresDefaultMigrationStatementTimeout = registerDurationSetting("ROX_POSTGRES_MIGRATION_STATEMENT_TIMEOUT", 10*time.Minute)
+	PostgresDefaultMigrationStatementTimeout = registerDurationSetting("ROX_POSTGRES_MIGRATION_STATEMENT_TIMEOUT", 30*time.Minute)
 )

--- a/pkg/env/postgres_default_timeout.go
+++ b/pkg/env/postgres_default_timeout.go
@@ -8,4 +8,7 @@ var (
 
 	// PostgresDefaultCursorTimeout sets the default timeout for Postgres cursor statements
 	PostgresDefaultCursorTimeout = registerDurationSetting("ROX_POSTGRES_DEFAULT_CURSOR_TIMEOUT", 10*time.Minute)
+
+	// PostgresDefaultMigrationStatementTimeout sets the default timeout for Postgres statements during migration
+	PostgresDefaultMigrationStatementTimeout = registerDurationSetting("ROX_POSTGRES_MIGRATION_STATEMENT_TIMEOUT", 10*time.Minute)
 )

--- a/pkg/env/postgres_default_timeout.go
+++ b/pkg/env/postgres_default_timeout.go
@@ -10,5 +10,5 @@ var (
 	PostgresDefaultCursorTimeout = registerDurationSetting("ROX_POSTGRES_DEFAULT_CURSOR_TIMEOUT", 10*time.Minute)
 
 	// PostgresDefaultMigrationStatementTimeout sets the default timeout for Postgres statements during migration
-	PostgresDefaultMigrationStatementTimeout = registerDurationSetting("ROX_POSTGRES_MIGRATION_STATEMENT_TIMEOUT", 30*time.Minute)
+	PostgresDefaultMigrationStatementTimeout = registerDurationSetting("ROX_POSTGRES_MIGRATION_STATEMENT_TIMEOUT", 20*time.Minute)
 )

--- a/pkg/postgres/pgadmin/admin_utils.go
+++ b/pkg/postgres/pgadmin/admin_utils.go
@@ -47,6 +47,8 @@ const (
 
 	// databaseSizeStmt - gets the size of a specific database within Postgres
 	databaseSizeStmt = "SELECT pg_catalog.pg_database_size($1)"
+
+	analyzeTimeout = 5 * time.Minute
 )
 
 // DropDB - drops a database.
@@ -191,7 +193,7 @@ func AnalyzeDatabase(config *postgres.Config, dbName string) error {
 	// Close the admin connection pool
 	defer connectPool.Close()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), analyzeTimeout)
 	defer cancel()
 	_, err := connectPool.Exec(ctx, "ANALYZE")
 

--- a/pkg/postgres/pgadmin/admin_utils.go
+++ b/pkg/postgres/pgadmin/admin_utils.go
@@ -191,7 +191,9 @@ func AnalyzeDatabase(config *postgres.Config, dbName string) error {
 	// Close the admin connection pool
 	defer connectPool.Close()
 
-	_, err := connectPool.Exec(context.Background(), "ANALYZE")
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	_, err := connectPool.Exec(ctx, "ANALYZE")
 
 	log.Debug("Anaylze done")
 	return err

--- a/pkg/postgres/pgadmin/admin_utils.go
+++ b/pkg/postgres/pgadmin/admin_utils.go
@@ -197,7 +197,7 @@ func AnalyzeDatabase(config *postgres.Config, dbName string) error {
 	defer cancel()
 	_, err := connectPool.Exec(ctx, "ANALYZE")
 
-	log.Debug("Anaylze done")
+	log.Debug("Analyze done")
 	return err
 }
 

--- a/pkg/postgres/schema/network_flows_v2.go
+++ b/pkg/postgres/schema/network_flows_v2.go
@@ -34,7 +34,6 @@ var (
 		PostStmts: []string{
 			"CREATE INDEX IF NOT EXISTS network_flows_src_v2 ON network_flows_v2 USING hash(props_srcentity_Id)",
 			"CREATE INDEX IF NOT EXISTS network_flows_dst_v2 ON network_flows_v2 USING hash(props_dstentity_Id)",
-			//"CREATE INDEX IF NOT EXISTS network_flows_cluster_v2 ON network_flows_v2 USING hash(clusterid)",
 			"CREATE INDEX IF NOT EXISTS network_flows_lastseentimestamp_v2 ON network_flows_v2 USING brin (lastseentimestamp)",
 		},
 	}

--- a/pkg/postgres/schema/network_flows_v2.go
+++ b/pkg/postgres/schema/network_flows_v2.go
@@ -34,7 +34,7 @@ var (
 		PostStmts: []string{
 			"CREATE INDEX IF NOT EXISTS network_flows_src_v2 ON network_flows_v2 USING hash(props_srcentity_Id)",
 			"CREATE INDEX IF NOT EXISTS network_flows_dst_v2 ON network_flows_v2 USING hash(props_dstentity_Id)",
-			"CREATE INDEX IF NOT EXISTS network_flows_cluster_v2 ON network_flows_v2 USING hash(clusterid)",
+			//"CREATE INDEX IF NOT EXISTS network_flows_cluster_v2 ON network_flows_v2 USING hash(clusterid)",
 			"CREATE INDEX IF NOT EXISTS network_flows_lastseentimestamp_v2 ON network_flows_v2 USING brin (lastseentimestamp)",
 		},
 	}


### PR DESCRIPTION
## Description

Some Postgres to Postgres migrations may take a significant amount of time.  The timeout periods need to be extended for those long running jobs.  It was discovered during this effort that the index on clusterid is no longer needed as the partitions take care of that.  Simply eliminating that index greatly improved the performance of the migration without impacting queries because it was essentially indexing the entire partition for no reason.  We effectively accomplish the same thing simply be using the partitions.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Migration tests and lots of scale tests of migrations to see how it performed and if it would succeed at all.  This is how the issue with the clusterid index was discovered.
