### PR TITLE
Default periodic process pruning via heuristics to false

### DIFF
--- a/central/processindicator/datastore/datastore.go
+++ b/central/processindicator/datastore/datastore.go
@@ -16,6 +16,7 @@ import (
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/postgres"
 	rocksdbBase "github.com/stackrox/rox/pkg/rocksdb"
 	"github.com/stackrox/rox/pkg/sac"
@@ -61,7 +62,10 @@ func New(store store.Store, plopStorage plopStore.Store, indexer index.Indexer, 
 	if err := d.buildIndex(ctx); err != nil {
 		return nil, err
 	}
-	go d.prunePeriodically(ctx)
+
+	if env.ProcessPruningEnabled.BooleanSetting() {
+		go d.prunePeriodically(ctx)
+	}
 	return d, nil
 }
 

--- a/central/processindicator/datastore/datastore_impl_test.go
+++ b/central/processindicator/datastore/datastore_impl_test.go
@@ -306,6 +306,8 @@ func (suite *IndicatorDataStoreTestSuite) TestIndicatorRemovalBatch() {
 }
 
 func (suite *IndicatorDataStoreTestSuite) TestPruning() {
+	suite.T().Setenv(env.ProcessPruningEnabled.EnvVar(), "true")
+
 	const prunePeriod = 100 * time.Millisecond
 	mockPrunerFactory := prunerMocks.NewMockFactory(suite.mockCtrl)
 	mockPrunerFactory.EXPECT().Period().Return(prunePeriod)

--- a/pkg/env/process_pruning.go
+++ b/pkg/env/process_pruning.go
@@ -1,0 +1,8 @@
+package env
+
+var (
+	// ProcessPruningEnabled toggles whether process pruning should be done periodically using heuristics
+	// This may be useful in certain large environments, but is fairly expensive as it requires a full
+	// sweep over the database
+	ProcessPruningEnabled = RegisterBooleanSetting("ROX_PROCESS_PRUNING", false)
+)


### PR DESCRIPTION
## Description

This optimization is very expensive and based on some analysis, it is not particularly useful in many environments. Default it to off, but have a way to turn it back on if needed

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

CI
