### PR TITLE
ROX-15385: Clicking on multi-network cidr block nodes should show the side panel

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphContainer.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphContainer.tsx
@@ -184,7 +184,8 @@ function NetworkGraphContainer({
 
     // 2. selectedNode/edgeState data model filtering ------------------------------------
     // selected node state is stored in the URL
-    const { detailId } = useParams();
+    const { detailId: encodedDetailId } = useParams();
+    const detailId = decodeURIComponent(encodedDetailId);
     const selectedNode = getNodeById(baseModel?.nodes, detailId);
     // extraneous catch-all in/egress flows nodes to add/remove from extraneous nodes model
     const extraneousNodes = createExtraneousNodes(clusterDeploymentCount);

--- a/ui/apps/platform/src/Containers/NetworkGraph/TopologyComponent.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/TopologyComponent.tsx
@@ -101,7 +101,10 @@ const TopologyComponent = ({
             const queryString = clearSimulationQuery(history.location.search);
             // if found, and it's not the logical grouping of all external sources, then trigger URL update
             if (newDetailId !== 'EXTERNAL') {
-                history.push(`${networkBasePathPF}/${newDetailType}/${newDetailId}${queryString}`);
+                const newURL = `${networkBasePathPF}/${newDetailType}/${encodeURIComponent(
+                    newDetailId
+                )}${queryString}`;
+                history.push(newURL);
             } else {
                 // otherwise, return to the graph-only state
                 history.push(`${networkBasePathPF}${queryString}`);


### PR DESCRIPTION
## Description

This PR fixes an issue where clicking on a multi-network cidr block node would not show the side panel. The issue happened because the `id` had a `/` in it that confused our URL state. The fix includes encoding/decoding the id

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~
