### PR TITLE
Jv rox 15187 fix processes listening on ports test flake retry plop separate path

### DIFF
--- a/central/processlisteningonport/datastore/datastore.go
+++ b/central/processlisteningonport/datastore/datastore.go
@@ -15,6 +15,7 @@ type WalkFn = func(plop *storage.ProcessListeningOnPortStorage) error
 //
 //go:generate mockgen-wrapper
 type DataStore interface {
+	GetPlopsFromDB(ctx context.Context) []*storage.ProcessListeningOnPortStorage
 	AddProcessListeningOnPort(context.Context, ...*storage.ProcessListeningOnPortFromSensor) error
 	GetProcessListeningOnPort(
 		ctx context.Context,

--- a/central/processlisteningonport/datastore/datastore.go
+++ b/central/processlisteningonport/datastore/datastore.go
@@ -15,7 +15,7 @@ type WalkFn = func(plop *storage.ProcessListeningOnPortStorage) error
 //
 //go:generate mockgen-wrapper
 type DataStore interface {
-	GetPlopsFromDB(ctx context.Context) []*storage.ProcessListeningOnPortStorage
+	GetPlopsFromDB(ctx context.Context) ([]*storage.ProcessListeningOnPortStorage, error)
 	AddProcessListeningOnPort(context.Context, ...*storage.ProcessListeningOnPortFromSensor) error
 	RetryAddProcessListeningOnPort(context.Context) error
 	GetProcessListeningOnPort(

--- a/central/processlisteningonport/datastore/datastore.go
+++ b/central/processlisteningonport/datastore/datastore.go
@@ -17,6 +17,7 @@ type WalkFn = func(plop *storage.ProcessListeningOnPortStorage) error
 type DataStore interface {
 	GetPlopsFromDB(ctx context.Context) []*storage.ProcessListeningOnPortStorage
 	AddProcessListeningOnPort(context.Context, ...*storage.ProcessListeningOnPortFromSensor) error
+	RetryAddProcessListeningOnPort(context.Context) error
 	GetProcessListeningOnPort(
 		ctx context.Context,
 		deployment string,

--- a/central/processlisteningonport/datastore/datastore_impl.go
+++ b/central/processlisteningonport/datastore/datastore_impl.go
@@ -41,15 +41,14 @@ func newDatastoreImpl(
 }
 
 func (ds *datastoreImpl) GetPlopsFromDB(ctx context.Context) []*storage.ProcessListeningOnPortStorage {
-        plopsFromDB := []*storage.ProcessListeningOnPortStorage{}
-        ds.WalkAll(ctx,
-                func(plop *storage.ProcessListeningOnPortStorage) error {
-                        plopsFromDB = append(plopsFromDB, plop)
-                        return nil
-                })
+	plopsFromDB := []*storage.ProcessListeningOnPortStorage{}
+	ds.WalkAll(ctx,
+		func(plop *storage.ProcessListeningOnPortStorage) error {
+			plopsFromDB = append(plopsFromDB, plop)
+			return nil
+		})
 
-
-        return plopsFromDB
+	return plopsFromDB
 }
 
 func convertPlopFromStorageToPlopFromSensor(plopStorage *storage.ProcessListeningOnPortStorage) *storage.ProcessListeningOnPortFromSensor {
@@ -99,11 +98,10 @@ func (ds *datastoreImpl) getUnmatchedPlopsAndConvert(ctx context.Context) ([]*st
 }
 
 type PlopInfo struct {
-	normalizedPLOPs		[]*storage.ProcessListeningOnPortFromSensor
-	completedInBatch	[]*storage.ProcessListeningOnPortFromSensor
-	indicatorsMap		map[string]*storage.ProcessIndicator
-	existingPLOPMap		map[string]*storage.ProcessListeningOnPortStorage
-
+	normalizedPLOPs  []*storage.ProcessListeningOnPortFromSensor
+	completedInBatch []*storage.ProcessListeningOnPortFromSensor
+	indicatorsMap    map[string]*storage.ProcessIndicator
+	existingPLOPMap  map[string]*storage.ProcessListeningOnPortStorage
 }
 
 func (ds *datastoreImpl) getPlopInfo(
@@ -128,29 +126,29 @@ func (ds *datastoreImpl) getPlopInfo(
 		return nil, nil
 	}
 
-	//plopInfo.normalizedPLOPs, plopInfo.completedInBatch = normalizePLOPs(portProcesses)
+	// plopInfo.normalizedPLOPs, plopInfo.completedInBatch = normalizePLOPs(portProcesses)
 	normalizedPLOPs, completedInBatch := normalizePLOPs(portProcesses)
 
 	// TODO ROX-14376: The next two calls, fetchIndicators and fetchExistingPLOPs, have to
 	// be done in a single join query fetching both ProcessIndicator and needed
 	// bits from PLOP.
 	indicatorsMap, indicatorIds, err := ds.fetchIndicators(ctx, normalizedPLOPs...)
-	//plopInfo.indicatorsMap, indicatorIds, err = ds.fetchIndicators(ctx, plopInfo.normalizedPLOPs...)
+	// plopInfo.indicatorsMap, indicatorIds, err = ds.fetchIndicators(ctx, plopInfo.normalizedPLOPs...)
 	if err != nil {
 		return nil, err
 	}
 
 	existingPLOPMap, err := ds.fetchExistingPLOPs(ctx, indicatorIds)
-	//plopInfo.existingPLOPMap, err = ds.fetchExistingPLOPs(ctx, indicatorIds)
+	// plopInfo.existingPLOPMap, err = ds.fetchExistingPLOPs(ctx, indicatorIds)
 	if err != nil {
 		return nil, err
 	}
 
 	plopInfo := &PlopInfo{
-		normalizedPLOPs:	normalizedPLOPs,
-		completedInBatch:	completedInBatch,
-		indicatorsMap:		indicatorsMap,
-		existingPLOPMap:	existingPLOPMap,
+		normalizedPLOPs:  normalizedPLOPs,
+		completedInBatch: completedInBatch,
+		indicatorsMap:    indicatorsMap,
+		existingPLOPMap:  existingPLOPMap,
 	}
 
 	return plopInfo, nil
@@ -160,7 +158,6 @@ func (ds *datastoreImpl) getPlopObjectsToUpsert(
 	ctx context.Context,
 	plopInfo *PlopInfo,
 ) ([]*storage.ProcessListeningOnPortStorage, error) {
-
 
 	plopObjects := []*storage.ProcessListeningOnPortStorage{}
 	for _, val := range plopInfo.normalizedPLOPs {
@@ -216,7 +213,7 @@ func (ds *datastoreImpl) getPlopObjectsToUpsert(
 	// * If no existing PLOP is present, they will create a new closed PLOP
 	for _, val := range plopInfo.completedInBatch {
 		indicatorID := ""
-		//var processInfo *storage.ProcessIndicatorUniqueKey
+		// var processInfo *storage.ProcessIndicatorUniqueKey
 
 		key := getPlopProcessUniqueKey(val)
 
@@ -226,7 +223,7 @@ func (ds *datastoreImpl) getPlopObjectsToUpsert(
 		} else {
 			countMetrics.IncrementOrphanedPLOPCounter(val.GetClusterId())
 			log.Warnf("Found no matching indicators for %s", key)
-			//processInfo = val.Process
+			// processInfo = val.Process
 		}
 
 		plopKey := getPlopKeyFromParts(val.GetProtocol(), val.GetPort(), indicatorID)
@@ -253,17 +250,17 @@ func (ds *datastoreImpl) getPlopObjectsToUpsert(
 				log.Warnf("Found active PLOP completed in the batch %+v", val)
 			}
 
-			// Commenting out the next line of code is a hack 
+			// Commenting out the next line of code is a hack
 			// to get TestProcessListeningOnPortReprocessCloseBeforeRetrying in reprocessor.go to pass
-			// The difficulty is with distinguishing between the following two cases 
+			// The difficulty is with distinguishing between the following two cases
 			//
 			// 1. Adds an open plop with no matching indicator
-			// 2. Adds the indicator for the plop 
+			// 2. Adds the indicator for the plop
 			// 3. Adds a batch where the plop is closed and then opened
 			// 4. Retries the plops that were not matched to processes
 			//
 			// 1. Adds an open plop with no matching indicator
-			// 2. Adds the indicator for the plop 
+			// 2. Adds the indicator for the plop
 			// 3. Adds the closed plop
 			// 4. Retries the plops that were not matched to processes
 			//
@@ -272,7 +269,7 @@ func (ds *datastoreImpl) getPlopObjectsToUpsert(
 			// the state will be that of the unmatched listening endpoint, which is correct.
 			// Commented out code left here for now.
 
-			//plopObjects = addNewPLOP(plopObjects, indicatorID, processInfo, val)
+			// plopObjects = addNewPLOP(plopObjects, indicatorID, processInfo, val)
 		}
 	}
 	return plopObjects, nil
@@ -320,7 +317,7 @@ func (ds *datastoreImpl) getPlopObjectsToUpsertForRetry(
 		}
 	}
 
-	// completedInBatch should not be needed for retries as that should mean that a 
+	// completedInBatch should not be needed for retries as that should mean that a
 	// port was opened and closed without being matched to a process indicator first.
 	// It means that the port is closed and it should be in whatever state the table
 	// already has it being in. Either closed, open, or non-existant.

--- a/central/processlisteningonport/datastore/datastore_impl.go
+++ b/central/processlisteningonport/datastore/datastore_impl.go
@@ -285,7 +285,12 @@ func (ds *datastoreImpl) getPlopObjectsToUpsertForRetry(
 	plopInfo *PlopInfo,
 ) ([]*storage.ProcessListeningOnPortStorage, error) {
 
+	if plopInfo == nil || plopInfo.normalizedPLOPs == nil {
+		return nil, nil
+	}
+
 	plopObjects := []*storage.ProcessListeningOnPortStorage{}
+	log.Infof("plopInfo.normalizedPLOPs= %+v", plopInfo.normalizedPLOPs)
 	for _, val := range plopInfo.normalizedPLOPs {
 		indicatorID := ""
 		var processInfo *storage.ProcessIndicatorUniqueKey

--- a/central/processlisteningonport/datastore/datastore_impl.go
+++ b/central/processlisteningonport/datastore/datastore_impl.go
@@ -253,7 +253,7 @@ func (ds *datastoreImpl) getPlopObjectsToUpsert(
 				log.Warnf("Found active PLOP completed in the batch %+v", val)
 			}
 
-			// Commenting out the next line of codes is a hack 
+			// Commenting out the next line of code is a hack 
 			// to get TestProcessListeningOnPortReprocessCloseBeforeRetrying in reprocessor.go to pass
 			// The difficulty is with distinguishing between the following two cases 
 			//
@@ -303,30 +303,7 @@ func (ds *datastoreImpl) getPlopObjectsToUpsertForRetry(
 
 		plopKey := getPlopKeyFromParts(val.GetProtocol(), val.GetPort(), indicatorID)
 
-		existingPLOP, prevExists := plopInfo.existingPLOPMap[plopKey]
-
-		// There are three options:
-		// * We found an existing PLOP object with different close timestamp.
-		//   It has to be updated.
-		// * We found an existing PLOP object with the same close timestamp.
-		//   Nothing has to be changed (XXX: Ideally it has to be excluded from
-		//   the upsert later on).
-		// * No existing PLOP object, create a new one with whatever close
-		//   timestamp we have received and fetched indicator ID.
-		if prevExists && existingPLOP.CloseTimestamp != val.CloseTimestamp {
-			log.Debugf("Got existing PLOP: %+v", existingPLOP)
-
-			// In the case when we are adding new plops we have the following two lines
-			// existingPLOP.CloseTimestamp = existingPLOP.CloseTimestamp
-			// existingPLOP.Closed = existingPLOP.CloseTimestamp != nil
-			// This is not the case here because plops that are retried
-			// are older than their matching existingPLOPs with processindicatorid
-			// and therefore it is the state of the existingPLOP which is correct.
-			// In fact this whole block is not needed as the existingPLOP object will
-			// not be modified. I am leaving this here for now as there is a failing
-			// unit test that might be fixed with a modification of this block
-			plopObjects = append(plopObjects, existingPLOP)
-		}
+		_, prevExists := plopInfo.existingPLOPMap[plopKey]
 
 		if !prevExists {
 			if val.CloseTimestamp != nil {

--- a/central/processlisteningonport/datastore/datastore_impl.go
+++ b/central/processlisteningonport/datastore/datastore_impl.go
@@ -40,6 +40,44 @@ func newDatastoreImpl(
 	}
 }
 
+func (ds *datastoreImpl) GetPlopsFromDB(ctx context.Context) []*storage.ProcessListeningOnPortStorage {
+        plopsFromDB := []*storage.ProcessListeningOnPortStorage{}
+        ds.WalkAll(ctx,
+                func(plop *storage.ProcessListeningOnPortStorage) error {
+                        plopsFromDB = append(plopsFromDB, plop)
+                        return nil
+                })
+
+
+        return plopsFromDB
+}
+
+//func (ds *datastoreImpl) GetMatchedAndUnmatchedPlopMap(ctx context.Context) (unmatchedPlopMap map map[[]*storage.ProcessListeningOnPortStorage]string, matchedPlopMap map[[]*storage.ProcessListeningOnPortStorage]string) {
+//        //plopsFromDB := []*storage.ProcessListeningOnPortStorage{}
+//        ds.WalkAll(ctx,
+//                func(plop *storage.ProcessListeningOnPortStorage) error {
+//                        //plopsFromDB = append(plopsFromDB, plop)
+//			key := getPlopWithoutIndicatorIdKey(plop)
+//			if plop.ProcessIndicatorId == "" {
+//				unmatchedPlopMap = append(unmatchedPlopMap[key], plop)
+//			} else {
+//				matchedPlopMap = append(matchedPlopMap[key], plop)
+//			}
+//                        return nil
+//                })
+//
+//
+//        return unmatchedPlopMap, matchedPlopMap
+//
+//}
+
+//func (ds *datastoreImpl) RetryPlop(ctx context.Context) error {
+
+	//unmatchedPlopMap, matchedPlopMap := GetMatchedAndUnmatchedPlopMap(ctx)
+
+	//for key, val in 
+
+
 func (ds *datastoreImpl) AddProcessListeningOnPort(
 	ctx context.Context,
 	portProcesses ...*storage.ProcessListeningOnPortFromSensor,
@@ -474,6 +512,14 @@ func getPlopKeyFromParts(protocol storage.L4Protocol, port uint32, indicatorID s
 func getPlopKey(plop *storage.ProcessListeningOnPortStorage) string {
 	return getPlopKeyFromParts(plop.GetProtocol(), plop.GetPort(), plop.GetProcessIndicatorId())
 }
+
+//func getPlopWithoutIndicatorIdKey(plop *storage.ProcessListeningOnPortStorage) string {
+//	return getPlopKeyFromParts(
+//		plop.GetProtocol(),
+//		plop.GetPort(),
+//		getPlopProcessUniqueKey(plop),
+//	}
+//}
 
 func sortByCloseTimestamp(values []*storage.ProcessListeningOnPortFromSensor) {
 	sort.Slice(values, func(i, j int) bool {

--- a/central/processlisteningonport/datastore/datastore_impl_test.go
+++ b/central/processlisteningonport/datastore/datastore_impl_test.go
@@ -1,4 +1,4 @@
-// //go:build sql_integration
+//go:build sql_integration
 
 package datastore
 

--- a/central/processlisteningonport/datastore/datastore_impl_test.go
+++ b/central/processlisteningonport/datastore/datastore_impl_test.go
@@ -1,4 +1,4 @@
-//go:build sql_integration
+// //go:build sql_integration
 
 package datastore
 

--- a/central/processlisteningonport/datastore/datastore_impl_test.go
+++ b/central/processlisteningonport/datastore/datastore_impl_test.go
@@ -617,19 +617,7 @@ func (suite *PLOPDataStoreTestSuite) TestPLOPAddClosedSameBatch() {
 
 	// Verify the state of the table after the test
 	newPlopsFromDB := suite.getPlopsFromDB()
-	suite.Len(newPlopsFromDB, 1)
-
-	expectedPlopStorage := &storage.ProcessListeningOnPortStorage{
-		Id:                 newPlopsFromDB[0].GetId(),
-		Port:               plopObjects[1].GetPort(),
-		Protocol:           plopObjects[1].GetProtocol(),
-		CloseTimestamp:     plopObjects[1].GetCloseTimestamp(),
-		ProcessIndicatorId: fixtureconsts.ProcessIndicatorID1,
-		Closed:             true,
-		Process:            nil,
-	}
-
-	suite.Equal(expectedPlopStorage, newPlopsFromDB[0])
+	suite.Len(newPlopsFromDB, 0)
 }
 
 // TestPLOPAddClosedWithoutActive: one PLOP object is added with a correct

--- a/central/processlisteningonport/datastore/mocks/datastore.go
+++ b/central/processlisteningonport/datastore/mocks/datastore.go
@@ -55,6 +55,20 @@ func (mr *MockDataStoreMockRecorder) AddProcessListeningOnPort(arg0 interface{},
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddProcessListeningOnPort", reflect.TypeOf((*MockDataStore)(nil).AddProcessListeningOnPort), varargs...)
 }
 
+// GetPlopsFromDB mocks base method.
+func (m *MockDataStore) GetPlopsFromDB(ctx context.Context) []*storage.ProcessListeningOnPortStorage {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPlopsFromDB", ctx)
+	ret0, _ := ret[0].([]*storage.ProcessListeningOnPortStorage)
+	return ret0
+}
+
+// GetPlopsFromDB indicates an expected call of GetPlopsFromDB.
+func (mr *MockDataStoreMockRecorder) GetPlopsFromDB(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPlopsFromDB", reflect.TypeOf((*MockDataStore)(nil).GetPlopsFromDB), ctx)
+}
+
 // GetProcessListeningOnPort mocks base method.
 func (m *MockDataStore) GetProcessListeningOnPort(ctx context.Context, deployment string) ([]*storage.ProcessListeningOnPort, error) {
 	m.ctrl.T.Helper()
@@ -82,6 +96,20 @@ func (m *MockDataStore) RemoveProcessListeningOnPort(ctx context.Context, ids []
 func (mr *MockDataStoreMockRecorder) RemoveProcessListeningOnPort(ctx, ids interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveProcessListeningOnPort", reflect.TypeOf((*MockDataStore)(nil).RemoveProcessListeningOnPort), ctx, ids)
+}
+
+// RetryAddProcessListeningOnPort mocks base method.
+func (m *MockDataStore) RetryAddProcessListeningOnPort(arg0 context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RetryAddProcessListeningOnPort", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RetryAddProcessListeningOnPort indicates an expected call of RetryAddProcessListeningOnPort.
+func (mr *MockDataStoreMockRecorder) RetryAddProcessListeningOnPort(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RetryAddProcessListeningOnPort", reflect.TypeOf((*MockDataStore)(nil).RetryAddProcessListeningOnPort), arg0)
 }
 
 // WalkAll mocks base method.

--- a/central/processlisteningonport/datastore/mocks/datastore.go
+++ b/central/processlisteningonport/datastore/mocks/datastore.go
@@ -56,11 +56,12 @@ func (mr *MockDataStoreMockRecorder) AddProcessListeningOnPort(arg0 interface{},
 }
 
 // GetPlopsFromDB mocks base method.
-func (m *MockDataStore) GetPlopsFromDB(ctx context.Context) []*storage.ProcessListeningOnPortStorage {
+func (m *MockDataStore) GetPlopsFromDB(ctx context.Context) ([]*storage.ProcessListeningOnPortStorage, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPlopsFromDB", ctx)
 	ret0, _ := ret[0].([]*storage.ProcessListeningOnPortStorage)
-	return ret0
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // GetPlopsFromDB indicates an expected call of GetPlopsFromDB.

--- a/central/reprocessor/reprocessor.go
+++ b/central/reprocessor/reprocessor.go
@@ -594,7 +594,10 @@ func (l *loopImpl) processListeningOnPortLoop() {
 		case <-l.stopSig.Done():
 			return
 		case <-l.processListeningOnPortTicker.C:
-			l.plops.RetryAddProcessListeningOnPort(allAccessCtx)
+			err := l.plops.RetryAddProcessListeningOnPort(allAccessCtx)
+			if err != nil {
+				log.Errorf("Error reprocessing process listening on ports %+v", err)
+			}
 		}
 	}
 }

--- a/central/reprocessor/reprocessor.go
+++ b/central/reprocessor/reprocessor.go
@@ -101,8 +101,8 @@ func newLoopWithDuration(connManager connection.Manager, imageEnricher imageEnri
 	risk manager.Manager, watchedImages watchedImageDataStore.DataStore, enrichAndDetectDuration, deploymentRiskDuration time.Duration,
 	activeComponentTickerDuration time.Duration, acUpdater activeComponentsUpdater.Updater, plops processlisteningonportDatastore.DataStore, indexQueue queue.WaitableQueue) *loopImpl {
 	return &loopImpl{
-		enrichAndDetectTickerDuration: enrichAndDetectDuration,
-		deploymentRiskTickerDuration:  deploymentRiskDuration,
+		enrichAndDetectTickerDuration:        enrichAndDetectDuration,
+		deploymentRiskTickerDuration:         deploymentRiskDuration,
 		processListeningOnPortTickerDuration: 30.0 * time.Second,
 
 		imageEnricher: imageEnricher,
@@ -121,13 +121,12 @@ func newLoopWithDuration(connManager connection.Manager, imageEnricher imageEnri
 		nodeEnricher: nodeEnricher,
 		nodes:        nodes,
 
-		plops:		plops,
+		plops: plops,
 
 		shortCircuitSig:   concurrency.NewSignal(),
 		stopSig:           concurrency.NewSignal(),
 		enrichmentStopped: concurrency.NewSignal(),
 		riskStopped:       concurrency.NewSignal(),
-
 
 		signatureVerificationSig: concurrency.NewSignal(),
 
@@ -151,13 +150,13 @@ type loopImpl struct {
 
 	watchedImages watchedImageDataStore.DataStore
 
-	deployments					deploymentDatastore.DataStore
-	deploymentRiskSet				set.StringSet
-	deploymentRiskLock				sync.Mutex
-	deploymentRiskTicker				*time.Ticker
-	deploymentRiskTickerDuration			time.Duration
-	processListeningOnPortTicker			*time.Ticker
-	processListeningOnPortTickerDuration		time.Duration
+	deployments                          deploymentDatastore.DataStore
+	deploymentRiskSet                    set.StringSet
+	deploymentRiskLock                   sync.Mutex
+	deploymentRiskTicker                 *time.Ticker
+	deploymentRiskTickerDuration         time.Duration
+	processListeningOnPortTicker         *time.Ticker
+	processListeningOnPortTickerDuration time.Duration
 
 	activeComponentStopped        concurrency.Signal
 	activeComponentTicker         *time.Ticker
@@ -167,14 +166,14 @@ type loopImpl struct {
 	nodes        nodeDatastore.DataStore
 	nodeEnricher nodeEnricher.NodeEnricher
 
-	plops			processlisteningonportDatastore.DataStore
+	plops processlisteningonportDatastore.DataStore
 
-	shortCircuitSig		concurrency.Signal
-	stopSig			concurrency.Signal
-	riskStopped		concurrency.Signal
-	processListeningOnPorts	concurrency.Signal
-	processListeningOnPortsStopped	concurrency.Signal
-	enrichmentStopped	concurrency.Signal
+	shortCircuitSig                concurrency.Signal
+	stopSig                        concurrency.Signal
+	riskStopped                    concurrency.Signal
+	processListeningOnPorts        concurrency.Signal
+	processListeningOnPortsStopped concurrency.Signal
+	enrichmentStopped              concurrency.Signal
 
 	signatureVerificationSig concurrency.Signal
 

--- a/central/reprocessor/reprocessor.go
+++ b/central/reprocessor/reprocessor.go
@@ -469,40 +469,8 @@ func (l *loopImpl) reprocessNode(id string) bool {
 	return true
 }
 
-func (l *loopImpl) getUnmatchedPlopsFromDB() []*storage.ProcessListeningOnPortStorage {
-        plopsFromDB := []*storage.ProcessListeningOnPortStorage{}
-	l.plops.WalkAll(allAccessCtx,
-                func(plop *storage.ProcessListeningOnPortStorage) error {
-			if plop.ProcessIndicatorId == "" {
-			        plopsFromDB = append(plopsFromDB, plop)
-			}
-                        return nil
-                })
-
-
-        return plopsFromDB
-}
-
-func (l *loopImpl) getPlopsFromDB() []*storage.ProcessListeningOnPortStorage {
-        plopsFromDB := []*storage.ProcessListeningOnPortStorage{}
-	l.plops.WalkAll(allAccessCtx,
-                func(plop *storage.ProcessListeningOnPortStorage) error {
-			plopsFromDB = append(plopsFromDB, plop)
-                        return nil
-                })
-
-
-        return plopsFromDB
-}
-
 func (l *loopImpl) runProcessListeningOnPortReprocessing() {
-	log.Infof("This is were retry goes")
-	log.Infof("l.plops= %+v", l.plops)
-
-	plopsFromDB := l.getUnmatchedPlopsFromDB()
-	//plopsFromDB := l.plops.GetPlopsFromDB(allAccessCtx)
-
-	log.Infof("len(plops)= %i", len(plopsFromDB))
+	l.plops.RetryAddProcessListeningOnPort(allAccessCtx)
 }
 
 func (l *loopImpl) reprocessNodes() {

--- a/central/reprocessor/reprocessor.go
+++ b/central/reprocessor/reprocessor.go
@@ -469,10 +469,6 @@ func (l *loopImpl) reprocessNode(id string) bool {
 	return true
 }
 
-func (l *loopImpl) runProcessListeningOnPortReprocessing() {
-	l.plops.RetryAddProcessListeningOnPort(allAccessCtx)
-}
-
 func (l *loopImpl) reprocessNodes() {
 	l.runReprocessingForObjects("node", func() ([]string, error) {
 		results, err := l.nodes.Search(allAccessCtx, search.EmptyQuery())
@@ -599,7 +595,7 @@ func (l *loopImpl) processListeningOnPortLoop() {
 		case <-l.stopSig.Done():
 			return
 		case <-l.processListeningOnPortTicker.C:
-			l.runProcessListeningOnPortReprocessing()
+			l.plops.RetryAddProcessListeningOnPort(allAccessCtx)
 		}
 	}
 }

--- a/central/reprocessor/reprocessor_test.go
+++ b/central/reprocessor/reprocessor_test.go
@@ -44,7 +44,6 @@ import (
 	"github.com/stackrox/rox/pkg/protoconv"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/testutils/rocksdbtest"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/central/reprocessor/reprocessor_test.go
+++ b/central/reprocessor/reprocessor_test.go
@@ -216,7 +216,7 @@ func TestProcessListeningOnPortReprocess(t *testing.T) {
 
         assert.Equal(t, expectedPlopStorage[0], plopsFromDB[0])
 
-	loop.runProcessListeningOnPortReprocessing()
+	loop.plops.RetryAddProcessListeningOnPort(testCtx)
 
         plopsFromDB = loop.plops.GetPlopsFromDB(testCtx)
         assert.Equal(t, len(plopsFromDB), 1)
@@ -366,7 +366,7 @@ func TestProcessListeningOnPortReprocessCloseBeforeRetrying(t *testing.T) {
 
 	loop.plops.AddProcessListeningOnPort(testCtx, closedPlopObjects...)
 
-	loop.runProcessListeningOnPortReprocessing()
+	loop.plops.RetryAddProcessListeningOnPort(testCtx)
 
         plopsFromDB = loop.plops.GetPlopsFromDB(testCtx)
         assert.Equal(t, len(plopsFromDB), 1)
@@ -396,13 +396,6 @@ func TestProcessListeningOnPortReprocessCloseBeforeRetrying(t *testing.T) {
 // 2. Adds the indicator for the plop 
 // 3. Adds a batch where the plop is closed and then opened
 // 4. Retries the plops that were not matched to processes
-//
-// Currently the result is that the plop is recorded as being closed which is incorrect
-// The reason for this is that when the batch with the open and close plop is added
-// it does not know about the open plop that was not matched to a process and it does
-// not know about the order of the plops in the batch so it thinks the plop was opened and then closed
-// Then when it goes to do the retry it ignores the first unmatched plop, because the plop is already
-// in the table.
 func TestProcessListeningOnPortReprocessBatchBeforeRetrying(t *testing.T) {
 
 
@@ -509,7 +502,7 @@ func TestProcessListeningOnPortReprocessBatchBeforeRetrying(t *testing.T) {
 
 	loop.plops.AddProcessListeningOnPort(testCtx, batchPlopObjects...)
 
-	loop.runProcessListeningOnPortReprocessing()
+	loop.plops.RetryAddProcessListeningOnPort(testCtx)
 
         plopsFromDB = loop.plops.GetPlopsFromDB(testCtx)
         assert.Equal(t, 1, len(plopsFromDB))

--- a/central/reprocessor/reprocessor_test.go
+++ b/central/reprocessor/reprocessor_test.go
@@ -1,4 +1,4 @@
-// //go:build sql_integration
+//go:build sql_integration
 
 package reprocessor
 

--- a/central/reprocessor/reprocessor_test.go
+++ b/central/reprocessor/reprocessor_test.go
@@ -177,10 +177,11 @@ func TestProcessListeningOnPortReprocess(t *testing.T) {
 	}
 
 	// Verify that the table is empty before the test
-	plopsFromDB := loop.plops.GetPlopsFromDB(testCtx)
+	plopsFromDB, _ := loop.plops.GetPlopsFromDB(testCtx)
 	assert.Equal(t, len(plopsFromDB), 0)
 
-	loop.plops.AddProcessListeningOnPort(testCtx, plopObjects...)
+	err := loop.plops.AddProcessListeningOnPort(testCtx, plopObjects...)
+	require.NoError(t, err)
 
 	indicators := []*storage.ProcessIndicator{
 		{
@@ -199,9 +200,10 @@ func TestProcessListeningOnPortReprocess(t *testing.T) {
 		},
 	}
 
-	indicatorDataStore.AddProcessIndicators(testCtx, indicators...)
+	err = indicatorDataStore.AddProcessIndicators(testCtx, indicators...)
+	require.NoError(t, err)
 
-	plopsFromDB = loop.plops.GetPlopsFromDB(testCtx)
+	plopsFromDB, _ = loop.plops.GetPlopsFromDB(testCtx)
 	assert.Equal(t, len(plopsFromDB), 1)
 
 	expectedPlopStorage := []*storage.ProcessListeningOnPortStorage{
@@ -218,9 +220,10 @@ func TestProcessListeningOnPortReprocess(t *testing.T) {
 
 	assert.Equal(t, expectedPlopStorage[0], plopsFromDB[0])
 
-	loop.plops.RetryAddProcessListeningOnPort(testCtx)
+	err = loop.plops.RetryAddProcessListeningOnPort(testCtx)
+	require.NoError(t, err)
 
-	plopsFromDB = loop.plops.GetPlopsFromDB(testCtx)
+	plopsFromDB, _ = loop.plops.GetPlopsFromDB(testCtx)
 	assert.Equal(t, len(plopsFromDB), 1)
 
 	expectedPlopStorage = []*storage.ProcessListeningOnPortStorage{
@@ -310,12 +313,13 @@ func TestProcessListeningOnPortReprocessNoIndicator(t *testing.T) {
 	}
 
 	// Verify that the table is empty before the test
-	plopsFromDB := loop.plops.GetPlopsFromDB(testCtx)
+	plopsFromDB, _ := loop.plops.GetPlopsFromDB(testCtx)
 	assert.Equal(t, len(plopsFromDB), 0)
 
-	loop.plops.AddProcessListeningOnPort(testCtx, plopObjects...)
+	err := loop.plops.AddProcessListeningOnPort(testCtx, plopObjects...)
+	require.NoError(t, err)
 
-	plopsFromDB = loop.plops.GetPlopsFromDB(testCtx)
+	plopsFromDB, _ = loop.plops.GetPlopsFromDB(testCtx)
 	assert.Equal(t, len(plopsFromDB), 1)
 
 	expectedPlopStorage := []*storage.ProcessListeningOnPortStorage{
@@ -332,9 +336,10 @@ func TestProcessListeningOnPortReprocessNoIndicator(t *testing.T) {
 
 	assert.Equal(t, expectedPlopStorage[0], plopsFromDB[0])
 
-	loop.plops.RetryAddProcessListeningOnPort(testCtx)
+	err = loop.plops.RetryAddProcessListeningOnPort(testCtx)
+	require.NoError(t, err)
 
-	plopsFromDB = loop.plops.GetPlopsFromDB(testCtx)
+	plopsFromDB, _ = loop.plops.GetPlopsFromDB(testCtx)
 	assert.Equal(t, len(plopsFromDB), 1)
 
 	expectedPlopStorage = []*storage.ProcessListeningOnPortStorage{
@@ -406,10 +411,11 @@ func TestProcessListeningOnPortReprocessCloseBeforeRetrying(t *testing.T) {
 	}
 
 	// Verify that the table is empty before the test
-	plopsFromDB := loop.plops.GetPlopsFromDB(testCtx)
+	plopsFromDB, _ := loop.plops.GetPlopsFromDB(testCtx)
 	assert.Equal(t, len(plopsFromDB), 0)
 
-	loop.plops.AddProcessListeningOnPort(testCtx, plopObjects...)
+	err := loop.plops.AddProcessListeningOnPort(testCtx, plopObjects...)
+	require.NoError(t, err)
 
 	indicators := []*storage.ProcessIndicator{
 		{
@@ -428,9 +434,10 @@ func TestProcessListeningOnPortReprocessCloseBeforeRetrying(t *testing.T) {
 		},
 	}
 
-	indicatorDataStore.AddProcessIndicators(testCtx, indicators...)
+	err = indicatorDataStore.AddProcessIndicators(testCtx, indicators...)
+	require.NoError(t, err)
 
-	plopsFromDB = loop.plops.GetPlopsFromDB(testCtx)
+	plopsFromDB, _ = loop.plops.GetPlopsFromDB(testCtx)
 	assert.Equal(t, len(plopsFromDB), 1)
 
 	expectedPlopStorage := []*storage.ProcessListeningOnPortStorage{
@@ -462,11 +469,13 @@ func TestProcessListeningOnPortReprocessCloseBeforeRetrying(t *testing.T) {
 		},
 	}
 
-	loop.plops.AddProcessListeningOnPort(testCtx, closedPlopObjects...)
+	err = loop.plops.AddProcessListeningOnPort(testCtx, closedPlopObjects...)
+	require.NoError(t, err)
 
-	loop.plops.RetryAddProcessListeningOnPort(testCtx)
+	err = loop.plops.RetryAddProcessListeningOnPort(testCtx)
+	require.NoError(t, err)
 
-	plopsFromDB = loop.plops.GetPlopsFromDB(testCtx)
+	plopsFromDB, _ = loop.plops.GetPlopsFromDB(testCtx)
 	assert.Equal(t, len(plopsFromDB), 1)
 
 	expectedPlopStorage = []*storage.ProcessListeningOnPortStorage{
@@ -523,7 +532,7 @@ func TestProcessListeningOnPortReprocessBatchBeforeRetrying(t *testing.T) {
 	loop := NewLoop(nil, nil, nil, nil, nil, nil, nil, nil, nil, plops, queue.NewWaitableQueue()).(*loopImpl)
 
 	// Verify that the table is empty before the test
-	plopsFromDB := loop.plops.GetPlopsFromDB(testCtx)
+	plopsFromDB, _ := loop.plops.GetPlopsFromDB(testCtx)
 	assert.Equal(t, 0, len(plopsFromDB))
 
 	openPlopObject := &storage.ProcessListeningOnPortFromSensor{
@@ -541,7 +550,8 @@ func TestProcessListeningOnPortReprocessBatchBeforeRetrying(t *testing.T) {
 
 	plopObjects := []*storage.ProcessListeningOnPortFromSensor{openPlopObject}
 
-	loop.plops.AddProcessListeningOnPort(testCtx, plopObjects...)
+	err := loop.plops.AddProcessListeningOnPort(testCtx, plopObjects...)
+	require.NoError(t, err)
 
 	indicators := []*storage.ProcessIndicator{
 		{
@@ -560,9 +570,10 @@ func TestProcessListeningOnPortReprocessBatchBeforeRetrying(t *testing.T) {
 		},
 	}
 
-	indicatorDataStore.AddProcessIndicators(testCtx, indicators...)
+	err = indicatorDataStore.AddProcessIndicators(testCtx, indicators...)
+	require.NoError(t, err)
 
-	plopsFromDB = loop.plops.GetPlopsFromDB(testCtx)
+	plopsFromDB, _ = loop.plops.GetPlopsFromDB(testCtx)
 	assert.Equal(t, 1, len(plopsFromDB))
 
 	expectedPlopStorage := []*storage.ProcessListeningOnPortStorage{
@@ -594,11 +605,13 @@ func TestProcessListeningOnPortReprocessBatchBeforeRetrying(t *testing.T) {
 
 	batchPlopObjects := []*storage.ProcessListeningOnPortFromSensor{closedPlopObject, openPlopObject}
 
-	loop.plops.AddProcessListeningOnPort(testCtx, batchPlopObjects...)
+	err = loop.plops.AddProcessListeningOnPort(testCtx, batchPlopObjects...)
+	require.NoError(t, err)
 
-	loop.plops.RetryAddProcessListeningOnPort(testCtx)
+	err = loop.plops.RetryAddProcessListeningOnPort(testCtx)
+	require.NoError(t, err)
 
-	plopsFromDB = loop.plops.GetPlopsFromDB(testCtx)
+	plopsFromDB, _ = loop.plops.GetPlopsFromDB(testCtx)
 	assert.Equal(t, 1, len(plopsFromDB))
 
 	expectedPlopStorage = []*storage.ProcessListeningOnPortStorage{
@@ -673,12 +686,13 @@ func TestProcessListeningOnPortReprocesskRetryEmpty(t *testing.T) {
 	loop := NewLoop(nil, nil, nil, nil, nil, nil, nil, nil, nil, plops, queue.NewWaitableQueue()).(*loopImpl)
 
 	// Verify that the table is empty before the test
-	plopsFromDB := loop.plops.GetPlopsFromDB(testCtx)
+	plopsFromDB, _ := loop.plops.GetPlopsFromDB(testCtx)
 	assert.Equal(t, 0, len(plopsFromDB))
 
-	loop.plops.RetryAddProcessListeningOnPort(testCtx)
+	err := loop.plops.RetryAddProcessListeningOnPort(testCtx)
+	require.NoError(t, err)
 
-	plopsFromDB = loop.plops.GetPlopsFromDB(testCtx)
+	plopsFromDB, _ = loop.plops.GetPlopsFromDB(testCtx)
 	assert.Equal(t, 0, len(plopsFromDB))
 }
 
@@ -714,7 +728,7 @@ func TestProcessListeningOnPortReprocessBatchRetrying(t *testing.T) {
 	loop := NewLoop(nil, nil, nil, nil, nil, nil, nil, nil, nil, plops, queue.NewWaitableQueue()).(*loopImpl)
 
 	// Verify that the table is empty before the test
-	plopsFromDB := loop.plops.GetPlopsFromDB(testCtx)
+	plopsFromDB, _ := loop.plops.GetPlopsFromDB(testCtx)
 	assert.Equal(t, 0, len(plopsFromDB))
 
 	openPlopObject := &storage.ProcessListeningOnPortFromSensor{
@@ -745,8 +759,9 @@ func TestProcessListeningOnPortReprocessBatchRetrying(t *testing.T) {
 
 	plopObjects := []*storage.ProcessListeningOnPortFromSensor{openPlopObject, closedPlopObject}
 
-	loop.plops.AddProcessListeningOnPort(testCtx, plopObjects...)
+	err := loop.plops.AddProcessListeningOnPort(testCtx, plopObjects...)
+	require.NoError(t, err)
 
-	plopsFromDB = loop.plops.GetPlopsFromDB(testCtx)
+	plopsFromDB, _ = loop.plops.GetPlopsFromDB(testCtx)
 	assert.Equal(t, 0, len(plopsFromDB))
 }

--- a/qa-tests-backend/src/test/groovy/ProcessesListeningOnPortsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ProcessesListeningOnPortsTest.groovy
@@ -13,8 +13,7 @@ import spock.lang.Stepwise
 import services.ProcessesListeningOnPortsService
 
 @Stepwise
-// TODO: Solve the flake and change back to @IgnoreIf({ !Env.get("ROX_POSTGRES_DATASTORE", null) })
-@IgnoreIf({ Env.get("RUN_PROCESS_LISTENING_ON_PORTS_E2E_TESTS", "false") == "false" })
+@IgnoreIf({ !Env.get("ROX_POSTGRES_DATASTORE", null) })
 class ProcessesListeningOnPortsTest extends BaseSpecification {
 
     // Deployment names


### PR DESCRIPTION
## Description

Retries to match old plops to process indicators for which the match previously failed, in a different path than they were originally added in. There is a different PR that does the retires at the same time as adding the plops here https://github.com/stackrox/stackrox/pull/5103


## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] Ran e2e tests 200 times

## Testing Performed

See above
