### PR TITLE
Auto-merge dependabot PRs when all checks pass

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -27,6 +27,7 @@ updates:
     labels:
       - "ci-all-qa-tests"
       - "dependencies"
+      - "auto-merge"
     reviewers:
       - "stackrox/backend-dep-updaters"
 
@@ -38,6 +39,7 @@ updates:
     labels:
       - "ci-all-qa-tests"
       - "dependencies"
+      - "auto-merge"
     reviewers:
       - "stackrox/backend-dep-updaters"
     ignore:
@@ -52,6 +54,7 @@ updates:
     open-pull-requests-limit: 3
     labels:
     - "dependencies"
+    - "auto-merge"
     reviewers:
       - "stackrox/backend-dep-updaters"
 
@@ -63,6 +66,7 @@ updates:
     open-pull-requests-limit: 3
     labels:
     - "dependencies"
+    - "auto-merge"
     reviewers:
       - "stackrox/backend-dep-updaters"
 

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,16 @@
+name: auto-merge
+
+on:
+  pull_request_target:
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+    - uses: ahmadnassri/action-dependabot-auto-merge@v2.6
+      with:
+        github-token: '${{ secrets.ROBOT_ROX_GITHUB_TOKEN }}'
+        command: "squash and merge"
+        approve: true
+        target: minor

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -2,11 +2,13 @@ name: auto-merge
 
 on:
   pull_request_target:
+    types:
+    - labeled
 
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]'
+    if: github.actor == 'dependabot[bot]' && github.event.label.name == 'auto-merge'
     steps:
     - uses: ahmadnassri/action-dependabot-auto-merge@v2.6
       with:


### PR DESCRIPTION
## Description

Currently @dependabot PRs are handled by @stackrox/ui-dep-updaters  and @stackrox/backend-dep-updaters this is fine but many times updates are small and could be automatically merged. 
This PR adds automation that will approve and post `@dependabot squash and merge` comment. PR will be merged if all checks pass (not only required ones).

Example: https://github.com/mdn/content/pull/25142#pullrequestreview-1328710625

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Tested it on kube-linter
- https://github.com/stackrox/kube-linter/pull/508