### PR TITLE
ROX-15812: Propagate `$POD_SECURITY_POLICIES` to `roxctl` when installing sensor.

### DIFF
--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -476,6 +476,10 @@ function launch_sensor {
       extra_config+=("--timeout=$ROXCTL_TIMEOUT")
     fi
 
+    if [[ -n "$POD_SECURITY_POLICIES" ]]; then
+        extra_config+=("--enable-pod-security-policies=${POD_SECURITY_POLICIES}")
+    fi
+
     # Delete path
     rm -rf "$k8s_dir/sensor-deploy"
 


### PR DESCRIPTION
## Description

Looks like this was missed in https://github.com/stackrox/stackrox/pull/3230

## Checklist
- [ ] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

CI should be sufficient. Let me figure out how to run this on recent k8s...
/test help