### PR TITLE
ROX-15809: Removing unecessary validation logic that is leading to an incorrect error to validate run time policies.

### DIFF
--- a/central/policy/service/service_impl_test.go
+++ b/central/policy/service/service_impl_test.go
@@ -621,12 +621,12 @@ func (s *PolicyServiceTestSuite) TestScopeClusterRegex() {
 func (s *PolicyServiceTestSuite) TestRuntimeLifecycle() {
 	s.testLifecycles("CVE:abcd+Process Name:123", storage.LifecycleStage_RUNTIME)
 	// Note that kube events/audit logs fields are simply dropped instead of being returned as unconvertableFields, since they are not searchable.
-	s.testLifecycles("CVE:abcd+Kubernetes Resource:PODS_EXEC", storage.LifecycleStage_BUILD, storage.LifecycleStage_DEPLOY)
-	s.testLifecycles("CVE:abcd+Kubernetes Resource:PODS_EXEC+Is Impersonated User:true", storage.LifecycleStage_BUILD, storage.LifecycleStage_DEPLOY)
+	s.testLifecycles("CVE:abcd+Kubernetes Resource:PODS_EXEC", storage.LifecycleStage_BUILD, storage.LifecycleStage_DEPLOY, storage.LifecycleStage_RUNTIME)
+	s.testLifecycles("CVE:abcd+Kubernetes Resource:PODS_EXEC+Is Impersonated User:true", storage.LifecycleStage_BUILD, storage.LifecycleStage_DEPLOY, storage.LifecycleStage_RUNTIME)
 }
 
-func (s *PolicyServiceTestSuite) TestBuildAndDeployLifecycles() {
-	s.testLifecycles("CVE:abcd", storage.LifecycleStage_DEPLOY, storage.LifecycleStage_BUILD)
+func (s *PolicyServiceTestSuite) TestBuildAndDeployAndRuntimeLifecycles() {
+	s.testLifecycles("CVE:abcd", storage.LifecycleStage_DEPLOY, storage.LifecycleStage_BUILD, storage.LifecycleStage_RUNTIME)
 }
 
 func (s *PolicyServiceTestSuite) TestOnePolicyField() {
@@ -771,7 +771,7 @@ func (s *PolicyServiceTestSuite) TestEnvironmentXLifecycle() {
 	s.False(response.GetHasNestedFields())
 	s.Empty(response.GetAlteredSearchTerms())
 	s.ElementsMatch(expectedPolicyGroup, response.GetPolicy().GetPolicySections()[0].GetPolicyGroups())
-	expectedLifecycleStages := []storage.LifecycleStage{storage.LifecycleStage_DEPLOY}
+	expectedLifecycleStages := []storage.LifecycleStage{storage.LifecycleStage_DEPLOY, storage.LifecycleStage_RUNTIME}
 	s.ElementsMatch(expectedLifecycleStages, response.GetPolicy().GetLifecycleStages())
 }
 

--- a/central/policy/service/validator.go
+++ b/central/policy/service/validator.go
@@ -359,10 +359,6 @@ func (s *policyValidator) compilesForRunTime(policy *storage.Policy, options ...
 		return errors.Wrap(err, "policy configuration is invalid for runtime")
 	}
 
-	if !booleanpolicy.ContainsRuntimeFields(policy) {
-		return errors.New("run time policy must contain runtime specific constraints")
-	}
-
 	if !booleanpolicy.ContainsDiscreteRuntimeFieldCategorySections(policy) {
 		return errors.New("a run time policy section must not contain both process and kubernetes event constraints")
 	}

--- a/central/policy/service/validator_test.go
+++ b/central/policy/service/validator_test.go
@@ -345,7 +345,7 @@ func (s *PolicyValidatorTestSuite) TestValidateLifeCycle() {
 					fieldnames.ImageTag:   "latest",
 					fieldnames.VolumeName: "BLAH",
 				}),
-			errExpected: true,
+			errExpected: false,
 		},
 		{
 			description: "Valid Run time with just process fields",


### PR DESCRIPTION

## Description
A runtime policy can have only image related criteria as well. In that case, the check for `ContainsRuntimeFields` is not required since the checks above and below it are sufficient to validate that the policy contains a valid set of run time critieria and invalid criteria combinations are not allowed.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed
TBD on cluster. Steps to reproduce in ROX-15809 and creating other runtime policies with valid and invalid criteria to see that the operation is successful or receives a validation error on the review screen respectively.
