### PR TITLE
Dashrews/ROX-15162 helm example files should match shape

### DIFF
--- a/image/templates/helm/stackrox-central/values-private.yaml.example
+++ b/image/templates/helm/stackrox-central/values-private.yaml.example
@@ -130,21 +130,22 @@
 #   dbPassword:
 #     value: <central database password value>
 #
-# db:
-#   password:
-#     # The plaintext value of the administrator password.
-#     value: <pre-configured administrator password>
-#   # Internal "central-db.stackrox.svc" service TLS certificate for the Central DB deployment.
-#   # Omit to auto-generate (initial deployment) or use existing (upgrade).
-#   serviceTLS:
-#     cert: |
-#       -----BEGIN CERTIFICATE-----
-#       <PEM-encoded Central DB certificate>
-#       -----END CERTIFICATE-----
-#     key: |
-#       -----BEGIN RSA PRIVATE KEY-----
-#       <PEM-encoded Central DB cert private key>
-#       -----END RSA PRIVATE KEY-----
+#   # Secret configuration options for the StackRox Central DB deployment.
+#   db:
+#     password:
+#       # The plaintext value of the administrator password.
+#       value: <pre-configured administrator password>
+#     # Internal "central-db.stackrox.svc" service TLS certificate for the Central DB deployment.
+#     # Omit to auto-generate (initial deployment) or use existing (upgrade).
+#     serviceTLS:
+#       cert: |
+#         -----BEGIN CERTIFICATE-----
+#         <PEM-encoded Central DB certificate>
+#         -----END CERTIFICATE-----
+#       key: |
+#         -----BEGIN RSA PRIVATE KEY-----
+#         <PEM-encoded Central DB cert private key>
+#         -----END RSA PRIVATE KEY-----
 #
 # # Secret configuration options for the StackRox Central deployment.
 # scanner:

--- a/image/templates/helm/stackrox-central/values-public.yaml.example.htpl
+++ b/image/templates/helm/stackrox-central/values-public.yaml.example.htpl
@@ -241,85 +241,85 @@
 #       mount:
 #         mountPath: /etc/my-config-data
 #
-# # Public configuration options for the StackRox Central DB:
-# db:
-#   # If you want to enforce StackRox Central DB to only run on certain nodes, you can specify
-#   # a node selector here to make sure Central can only be scheduled on Nodes with the
-#   # given label. This is particular relevant for the "hostPath" persistence type.
-#   nodeSelector:
-#     # This can contain arbitrary `label-key: label-value` pairs.
-#     role: stackrox-central-db
+#   # Public configuration options for the StackRox Central DB:
+#   db:
+#     # If you want to enforce StackRox Central DB to only run on certain nodes, you can specify
+#     # a node selector here to make sure Central can only be scheduled on Nodes with the
+#     # given label. This is particular relevant for the "hostPath" persistence type.
+#     nodeSelector:
+#       # This can contain arbitrary `label-key: label-value` pairs.
+#       role: stackrox-central-db
 #
-#   # If the nodes selected by the node selector are tainted, you can specify the corresponding taint tolerations here.
-#   tolerations:
-#     - effect: NoSchedule
-#       key: infra
-#       value: reserved
-#     - effect: NoExecute
-#       key: infra
-#       value: reserved
+#     # If the nodes selected by the node selector are tainted, you can specify the corresponding taint tolerations here.
+#     tolerations:
+#       - effect: NoSchedule
+#         key: infra
+#         value: reserved
+#       - effect: NoExecute
+#         key: infra
+#         value: reserved
 #
-#   # Customized Central DB source configurations to connect to Postgres database.
-#   # Default configurations are applied if the configurations are omitted.
-#   source:
-#     # ConnectionString should not be specified if the Central DB deployment is being managed by the helm chart
-#     # The connection string must be in the format described here https://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-CONNSTRING
-#     # Do NOT use a connection string with a password field. Instead specify the value below in the password section in values-private.yaml.
-#     connectionString: "host=central-db.stackrox port=5432 user=postgres sslmode=verify-full"
-#     minConns: 10
-#     maxConns: 90
-#     statementTimeoutMs: 1200000
+#     # Customized Central DB source configurations to connect to Postgres database.
+#     # Default configurations are applied if the configurations are omitted.
+#     source:
+#       # ConnectionString should not be specified if the Central DB deployment is being managed by the helm chart
+#       # The connection string must be in the format described here https://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-CONNSTRING
+#       # Do NOT use a connection string with a password field. Instead specify the value below in the password section in values-private.yaml.
+#       connectionString: "host=central-db.stackrox port=5432 user=postgres sslmode=verify-full"
+#       minConns: 10
+#       maxConns: 90
+#       statementTimeoutMs: 1200000
 #
-#   # Configures the Central DB image to be used. Most users will only need to configure a
-#   # custom registry (if any) at the global scope, and do not require any settings here.
-#   image:
-#     # A custom registry that will override the global `image.registry` setting for the
-#     # Central DB image.
-#     registry: us.gcr.io/central-db
-#     # A custom image name that will override the default `main`.
-#     name: custom-central-db
-#     # A custom image tag that will override the default tag based on the current
-#     # StackRox version.
-#     tag: custom-version
+#     # Configures the Central DB image to be used. Most users will only need to configure a
+#     # custom registry (if any) at the global scope, and do not require any settings here.
+#     image:
+#       # A custom registry that will override the global `image.registry` setting for the
+#       # Central DB image.
+#       registry: us.gcr.io/central-db
+#       # A custom image name that will override the default `main`.
+#       name: custom-central-db
+#       # A custom image tag that will override the default tag based on the current
+#       # StackRox version.
+#       tag: custom-version
 #
-#   # Custom resource overrides for the Central DB deployment.
-#   resources:
-#     requests:
-#       memory: "1500Mi"
-#       cpu: "1000m"
-#     limits:
-#       memory: "4Gi"
-#       cpu: "2000m"
+#     # Custom resource overrides for the Central DB deployment.
+#     resources:
+#       requests:
+#         memory: "1500Mi"
+#         cpu: "1000m"
+#       limits:
+#         memory: "4Gi"
+#         cpu: "2000m"
 #
-#   # Persistence configuration for the StackRox Central DB.
-#   # Exactly ONE of the nested values should be specified. If none is specified,
-#   # the StackRox Central DB will be configured with the default PVC-based persistence.
-#   persistence:
-#     # The path on the node where to store the StackRox Central DB volume
-#     # when using host path persistence.
-#     hostPath: /var/lib/central-db
-#     # The persistent volume claim details when storing the StackRox database
-#     # on a persistent volume managed by a Kubernetes persistent volume claim (PVC).
-#     persistentVolumeClaim:
-#       # The name of the claim. This defaults to central-db if not set.
-#       claimName: central-db
-#       # Whether to create the claim upon deployment. The default is true; set this to false
-#       # if you have a pre-existing persistent volume claim that you want to use.
-#       createClaim: true
-#       # The storage class of the persistent volume.
-#       storageClass: stackrox-gke-ssd
-#       # The size of the persistent volume managed by the claim, in Gigabytes (or with an
-#       # explicit unit, such as "1Ti"). Defaults to 100Gi.
-#       size: 100
-#       # If you want to bind a preexisting persistent volume, you can specify it here.
-#       volume:
-#         volumeSpec:
-#           # The section includes volume type specific config, the volume type can be:
-#           # gcePersistentDisk, hostpath, filestore(nfs) etc.
-#           gcePersistentDisk:
-#             # Type specific parameters. The specified persistent volume should have
-#             # been created.
-#             pdName: gke-pv
+#     # Persistence configuration for the StackRox Central DB.
+#     # Exactly ONE of the nested values should be specified. If none is specified,
+#     # the StackRox Central DB will be configured with the default PVC-based persistence.
+#     persistence:
+#       # The path on the node where to store the StackRox Central DB volume
+#       # when using host path persistence.
+#       hostPath: /var/lib/central-db
+#       # The persistent volume claim details when storing the StackRox database
+#       # on a persistent volume managed by a Kubernetes persistent volume claim (PVC).
+#       persistentVolumeClaim:
+#         # The name of the claim. This defaults to central-db if not set.
+#         claimName: central-db
+#         # Whether to create the claim upon deployment. The default is true; set this to false
+#         # if you have a pre-existing persistent volume claim that you want to use.
+#         createClaim: true
+#         # The storage class of the persistent volume.
+#         storageClass: stackrox-gke-ssd
+#         # The size of the persistent volume managed by the claim, in Gigabytes (or with an
+#         # explicit unit, such as "1Ti"). Defaults to 100Gi.
+#         size: 100
+#         # If you want to bind a preexisting persistent volume, you can specify it here.
+#         volume:
+#           volumeSpec:
+#             # The section includes volume type specific config, the volume type can be:
+#             # gcePersistentDisk, hostpath, filestore(nfs) etc.
+#             gcePersistentDisk:
+#               # Type specific parameters. The specified persistent volume should have
+#               # been created.
+#               pdName: gke-pv
 #
 # # Public configuration options for the StackRox Scanner.
 # scanner:


### PR DESCRIPTION
## Description

The example files had db as a peer of central instead of a child of central like the shape did.  This PR resolves that.

## Checklist
- [ ] Investigated and inspected CI test results
~- [ ] Unit test and regression tests added~
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Simple updates example values files.  nothing to test.
