### PR TITLE
Sets default filters to empty for images single page

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageSingleVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageSingleVulnerabilities.tsx
@@ -90,11 +90,6 @@ export const imageVulnerabilitiesQuery = gql`
     }
 `;
 
-const emptyDefaultFilters = {
-    Severity: [],
-    Fixable: [],
-};
-
 export type ImageSingleVulnerabilitiesProps = {
     imageId: string;
 };
@@ -188,10 +183,7 @@ function ImageSingleVulnerabilities({ imageId }: ImageSingleVulnerabilitiesProps
                         title={<TabTitleText>Observed CVEs</TabTitleText>}
                     >
                         <PageSection variant="light" component="div" isFilled>
-                            <WorkloadTableToolbar
-                                // Default filters do not apply to singles pages
-                                defaultFilters={emptyDefaultFilters}
-                            />
+                            <WorkloadTableToolbar />
                             {mainContent}
                         </PageSection>
                     </Tab>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageSingleVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageSingleVulnerabilities.tsx
@@ -90,6 +90,11 @@ export const imageVulnerabilitiesQuery = gql`
     }
 `;
 
+const emptyDefaultFilters = {
+    Severity: [],
+    Fixable: [],
+};
+
 export type ImageSingleVulnerabilitiesProps = {
     imageId: string;
 };
@@ -184,11 +189,8 @@ function ImageSingleVulnerabilities({ imageId }: ImageSingleVulnerabilitiesProps
                     >
                         <PageSection variant="light" component="div" isFilled>
                             <WorkloadTableToolbar
-                                // TODO: wire up the actual default filters in this component
-                                defaultFilters={{
-                                    Severity: ['Critical'],
-                                    Fixable: ['Fixable'],
-                                }}
+                                // Default filters do not apply to singles pages
+                                defaultFilters={emptyDefaultFilters}
                             />
                             {mainContent}
                         </PageSection>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadTableToolbar.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadTableToolbar.tsx
@@ -22,14 +22,22 @@ import CVEStatusDropdown from './CVEStatusDropdown';
 
 import './WorkloadTableToolbar.css';
 
+const emptyDefaultFilters = {
+    Severity: [],
+    Fixable: [],
+};
+
 type FilterType = 'resource' | 'Severity' | 'Fixable';
 
 type WorkloadTableToolbarProps = {
-    defaultFilters: DefaultFilters;
+    defaultFilters?: DefaultFilters;
     resourceContext?: Resource;
 };
 
-function WorkloadTableToolbar({ defaultFilters, resourceContext }: WorkloadTableToolbarProps) {
+function WorkloadTableToolbar({
+    defaultFilters = emptyDefaultFilters,
+    resourceContext,
+}: WorkloadTableToolbarProps) {
     const { searchFilter, setSearchFilter } = useURLSearch();
     const severityFilterChips: ToolbarChip[] = [];
     const fixableFilterChips: ToolbarChip[] = [];


### PR DESCRIPTION
## Description

Follow up to quick fix https://github.com/stackrox/stackrox/pull/5170.

Workload CVE single pages do not use default filters, so we set the value to a constant empty `DefaultFilters` object. @alwayshooin you'll want to rebase on top of this once merged since the quick fix causes a useEffect render loop (just for us, only has an impact when rendering Workload CVE pages).

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
