### PR TITLE
ROX-15823 Fix deferred call in the sensor integration tests

### DIFF
--- a/sensor/tests/resource/helper.go
+++ b/sensor/tests/resource/helper.go
@@ -253,10 +253,10 @@ func (c *TestContext) run(t *testRun) {
 // If it is set, the RetryCallback will be called if the application of a resource fails.
 func (c *TestContext) runWithResources(resources []K8sResourceInfo, testCase TestCallback, retryFn RetryCallback) error {
 	_, removeNamespace, err := c.createTestNs(context.Background(), DefaultNamespace)
-	defer utils.IgnoreError(removeNamespace)
 	if err != nil {
 		return errors.Errorf("failed to create namespace: %s", err)
 	}
+	defer utils.IgnoreError(removeNamespace)
 	var removeFunctions []func() error
 	fileToObj := map[string]k8s.Object{}
 	for i := range resources {


### PR DESCRIPTION
## Description

We need to defer the call to the `removeNamespace` function to after the namespace is created without error, otherwise `removeNamespace` will be `nil` and the tests will panic in the deferred call.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

TODO
