### PR TITLE
Use GetByQuery in process indicator searcher

### DIFF
--- a/central/processindicator/datastore/datastore_sac_test.go
+++ b/central/processindicator/datastore/datastore_sac_test.go
@@ -210,7 +210,7 @@ func (s *processIndicatorDatastoreSACSuite) TestUnrestrictedSearchRaw() {
 
 func (s *processIndicatorDatastoreSACSuite) runSearchRawTest(c sacTestUtils.SACSearchTestCase) {
 	ctx := s.testContexts[c.ScopeKey]
-	results, err := s.datastore.SearchRawProcessIndicators(ctx, nil)
+	results, err := s.datastore.SearchRawProcessIndicators(ctx, searchPkg.NewQueryBuilder().AddStrings(searchPkg.ProcessID, searchPkg.WildcardString).ProtoQuery())
 	s.Require().NoError(err)
 	resultObjs := make([]sac.NamespaceScopedObject, 0, len(results))
 	for i := range results {

--- a/central/processindicator/search/searcher_impl.go
+++ b/central/processindicator/search/searcher_impl.go
@@ -27,6 +27,9 @@ type searcherImpl struct {
 
 // SearchRawProcessIndicators retrieves Policies from the indexer and storage
 func (s *searcherImpl) SearchRawProcessIndicators(ctx context.Context, q *v1.Query) ([]*storage.ProcessIndicator, error) {
+	if env.PostgresDatastoreEnabled.BooleanSetting() {
+		return s.storage.GetByQuery(ctx, q)
+	}
 	results, err := s.Search(ctx, q)
 	if err != nil {
 		return nil, err

--- a/central/processindicator/search/searcher_impl_test.go
+++ b/central/processindicator/search/searcher_impl_test.go
@@ -81,8 +81,7 @@ func (suite *IndicatorSearchTestSuite) TestAllowsSearch() {
 }
 
 func (suite *IndicatorSearchTestSuite) TestEnforcesSearchRaw() {
-	suite.indexer.EXPECT().Search(gomock.Any(), gomock.Any()).Return([]search.Result{{ID: "hgdskdf"}}, nil)
-	suite.storage.EXPECT().GetMany(gomock.Any(), gomock.Any()).Return([]*storage.ProcessIndicator{}, []int{}, nil)
+	suite.storage.EXPECT().GetByQuery(gomock.Any(), gomock.Any()).Return([]*storage.ProcessIndicator{}, nil)
 
 	processIndicators, err := suite.searcher.SearchRawProcessIndicators(suite.hasNoneCtx, search.EmptyQuery())
 	suite.NoError(err, "expected no error, should return nil without access")
@@ -90,15 +89,13 @@ func (suite *IndicatorSearchTestSuite) TestEnforcesSearchRaw() {
 }
 
 func (suite *IndicatorSearchTestSuite) TestAllowsSearchRaw() {
-	suite.indexer.EXPECT().Search(gomock.Any(), gomock.Any()).Return([]search.Result{{ID: ""}}, nil)
-	suite.storage.EXPECT().GetMany(gomock.Any(), gomock.Any()).Return([]*storage.ProcessIndicator{{}}, []int{}, nil)
+	suite.storage.EXPECT().GetByQuery(gomock.Any(), gomock.Any()).Return([]*storage.ProcessIndicator{{}}, nil)
 
 	processIndicators, err := suite.searcher.SearchRawProcessIndicators(suite.hasReadCtx, search.EmptyQuery())
 	suite.NoError(err, "expected no error trying to read with permissions")
 	suite.NotEmpty(processIndicators)
 
-	suite.indexer.EXPECT().Search(gomock.Any(), gomock.Any()).Return([]search.Result{{ID: "hgdskdf"}}, nil)
-	suite.storage.EXPECT().GetMany(gomock.Any(), gomock.Any()).Return([]*storage.ProcessIndicator{{}}, []int{}, nil)
+	suite.storage.EXPECT().GetByQuery(gomock.Any(), gomock.Any()).Return([]*storage.ProcessIndicator{{}}, nil)
 
 	processIndicators, err = suite.searcher.SearchRawProcessIndicators(suite.hasWriteCtx, search.EmptyQuery())
 	suite.NoError(err, "expected no error trying to read with permissions")

--- a/central/processindicator/store/mocks/store.go
+++ b/central/processindicator/store/mocks/store.go
@@ -99,6 +99,21 @@ func (mr *MockStoreMockRecorder) Get(ctx, id interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockStore)(nil).Get), ctx, id)
 }
 
+// GetByQuery mocks base method.
+func (m *MockStore) GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.ProcessIndicator, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetByQuery", ctx, q)
+	ret0, _ := ret[0].([]*storage.ProcessIndicator)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetByQuery indicates an expected call of GetByQuery.
+func (mr *MockStoreMockRecorder) GetByQuery(ctx, q interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByQuery", reflect.TypeOf((*MockStore)(nil).GetByQuery), ctx, q)
+}
+
 // GetKeysToIndex mocks base method.
 func (m *MockStore) GetKeysToIndex(ctx context.Context) ([]string, error) {
 	m.ctrl.T.Helper()

--- a/central/processindicator/store/store.go
+++ b/central/processindicator/store/store.go
@@ -12,6 +12,7 @@ import (
 //go:generate mockgen-wrapper
 type Store interface {
 	Get(ctx context.Context, id string) (*storage.ProcessIndicator, bool, error)
+	GetByQuery(ctx context.Context, q *v1.Query) ([]*storage.ProcessIndicator, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.ProcessIndicator, []int, error)
 
 	UpsertMany(context.Context, []*storage.ProcessIndicator) error


### PR DESCRIPTION
## Description

Process indicators getting is very expensive. This at least consolidates a couple of these queries, but there is still more to be done to reduce the number of times we're querying
```
 13464.446300000001 |  25307 |      35 | 1875541589 | 22945144 | select process_indicators.Id::text as Process_ID from process_indicators where process_indicators.DeploymentId = $1
 3308.4725166666667 |   3213 |       9 | 1906889509 | 23272478 | select "process_indicators".serialized from process_indicators where process_indicators.Id = ANY($1::uuid[])
 ```

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

CI