### PR TITLE
Dashrews/ROX-15846-postgres restore rollback rocks

### DIFF
--- a/central/globaldb/v2backuprestore/common/context.go
+++ b/central/globaldb/v2backuprestore/common/context.go
@@ -13,6 +13,7 @@ type RestoreProcessContext interface {
 	ResolvePath(relativePath string) (string, error)
 	OpenFile(relativePath string, flags int, perm os.FileMode) (*os.File, error)
 	Mkdir(relativePath string, perm os.FileMode) (string, error)
+	IsPostgresBundle() bool
 }
 
 // RestoreFileContext is the context active during the restoration of a single file from a database export.

--- a/central/globaldb/v2backuprestore/common/migration_version.go
+++ b/central/globaldb/v2backuprestore/common/migration_version.go
@@ -17,6 +17,11 @@ var (
 
 // RestoreMigrationVersion - restores the migration version file
 func RestoreMigrationVersion(ctx RestoreFileContext, fileReader io.Reader, _ int64) error {
+	// Skip this if processing a Postgres bundle.
+	if ctx.IsPostgresBundle() {
+		return nil
+	}
+
 	versionFile, err := ctx.OpenFile(migrations.MigrationVersionFile, os.O_CREATE|os.O_RDWR, 0644)
 	if err != nil {
 		return errors.Wrap(err, "could not create migration version file")

--- a/central/globaldb/v2backuprestore/manager/manager.go
+++ b/central/globaldb/v2backuprestore/manager/manager.go
@@ -130,6 +130,7 @@ func (m *manager) LaunchRestoreProcess(ctx context.Context, id string, requestHe
 		return nil, err
 	}
 
+	// Create the paths for the restore directory
 	finalOutputDir := m.finalOutputDir()
 	tempOutputDir := filepath.Join(m.outputRoot, fmt.Sprintf(".restore-%s", process.Metadata().GetId()))
 

--- a/central/globaldb/v2backuprestore/manager/restore_context.go
+++ b/central/globaldb/v2backuprestore/manager/restore_context.go
@@ -17,13 +17,16 @@ type restoreProcessContext struct {
 
 	numAsyncChecks int
 	asyncErrorsC   chan error
+
+	postgresBundle bool
 }
 
-func newRestoreProcessContext(ctx context.Context, outputDir string) *restoreProcessContext {
+func newRestoreProcessContext(ctx context.Context, outputDir string, postgresBundle bool) *restoreProcessContext {
 	return &restoreProcessContext{
-		Context:      ctx,
-		outputDir:    strings.TrimRight(outputDir, "/") + "/",
-		asyncErrorsC: make(chan error),
+		Context:        ctx,
+		outputDir:      strings.TrimRight(outputDir, "/") + "/",
+		asyncErrorsC:   make(chan error),
+		postgresBundle: postgresBundle,
 	}
 }
 
@@ -56,6 +59,10 @@ func (c *restoreProcessContext) Mkdir(relativePath string, perm os.FileMode) (st
 		return "", err
 	}
 	return path, nil
+}
+
+func (c *restoreProcessContext) IsPostgresBundle() bool {
+	return c.postgresBundle
 }
 
 func (c *restoreProcessContext) dispatchAsyncCheck(checkFn func(ctx common.RestoreProcessContext) error, fileName string) {

--- a/central/globaldb/v2backuprestore/manager/restore_process.go
+++ b/central/globaldb/v2backuprestore/manager/restore_process.go
@@ -83,11 +83,10 @@ func newRestoreProcess(ctx context.Context, id string, header *v1.DBRestoreReque
 	if len(mfFiles) != len(handlerFuncs) {
 		return nil, utils.ShouldErr(errors.Errorf("mismatch: %d handler functions provided for %d files in the manifest", len(handlerFuncs), len(mfFiles)))
 	}
-	log.Infof("SHREWS -- mFiles %v", mfFiles)
 
 	files := make([]*restoreFile, 0, len(mfFiles))
 	for i, manifestFile := range mfFiles {
-		log.Infof("SHREWS -- manifestFile %v", manifestFile.GetName())
+		// Check to see if we are processing a postgres bundle
 		if manifestFile.GetName() == postgresDumpFileName {
 			postgresBundle = true
 		}
@@ -162,7 +161,7 @@ func (p *restoreProcess) run(tempOutputDir, finalDir string) {
 }
 
 func (p *restoreProcess) doRun(ctx context.Context, tempOutputDir, finalDir string) error {
-	// If postgres bundle, skip
+	// If processing a postgres bundle, do not create the restore directories
 	if !p.postgresBundle {
 		if err := os.MkdirAll(tempOutputDir, 0700); err != nil {
 			return errors.Wrapf(err, "could not create temporary output directory %s", tempOutputDir)
@@ -180,7 +179,7 @@ func (p *restoreProcess) doRun(ctx context.Context, tempOutputDir, finalDir stri
 		return err
 	}
 
-	// If postgres bundle, skip
+	// If processing a postgres bundle, do not update the restore symlink
 	if !p.postgresBundle {
 		if err := os.Symlink(filepath.Base(tempOutputDir), finalDir); err != nil {
 			return errors.Wrapf(err, "failed to atomically create a symbolic link to restore directory %s", tempOutputDir)

--- a/central/globaldb/v2backuprestore/manager/restore_process.go
+++ b/central/globaldb/v2backuprestore/manager/restore_process.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/central/globaldb/v2backuprestore/common"
 	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/pkg/backup"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/grpc/authn"
 	"github.com/stackrox/rox/pkg/ioutils"
@@ -23,8 +24,6 @@ import (
 
 const (
 	defaultReattachTimeout = 24 * time.Hour
-
-	postgresDumpFileName = "postgres.dump"
 )
 
 // RestoreProcess provides a handle to ongoing database restore processes.
@@ -87,7 +86,7 @@ func newRestoreProcess(ctx context.Context, id string, header *v1.DBRestoreReque
 	files := make([]*restoreFile, 0, len(mfFiles))
 	for i, manifestFile := range mfFiles {
 		// Check to see if we are processing a postgres bundle
-		if manifestFile.GetName() == postgresDumpFileName {
+		if manifestFile.GetName() == backup.PostgresFileName {
 			postgresBundle = true
 		}
 		files = append(files, &restoreFile{


### PR DESCRIPTION
## Description

Updates to not write the .restore directories and symlinks if we are processing a postgres backup.

## Checklist
- [x] Investigated and inspected CI test results
~- [ ] Unit test and regression tests added~
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed
BEFORE the fix, notice there is a clone named .restore
```
clone/rocksdb: 2023/03/10 10:57:36.687614 db_clone_manager_impl.go:61: Info: Found clone .restore -> .restore-3895bf87-8a4f-4213-bfbd-d19beb45902a
clone/rocksdb: 2023/03/10 10:57:36.688117 db_clone_manager_impl.go:61: Info: Found clone current -> .db-init
clone/rocksdb: 2023/03/10 10:57:36.688325 db_clone_manager_impl.go:116: Info: Database clones:
clone/rocksdb: 2023/03/10 10:57:36.688535 db_clone_manager_impl.go:118: Info: .restore -> &{/var/lib/stackrox/.restore 0 0 0001-01-01 00:00:00 +0000 UTC}
clone/rocksdb: 2023/03/10 10:57:36.688716 db_clone_manager_impl.go:118: Info: current -> &{/var/lib/stackrox/current 0 0 0001-01-01 00:00:00 +0000 UTC}
...
Migrator: 2023/03/10 10:57:37.036624 log.go:18: Info: Migration version from DB = seq_num:168 version:"3.73.3" last_persisted:<seconds:1678382596 nanos:541519000 > .
clone/postgres: 2023/03/10 10:57:37.037999 db_clone_manager_impl.go:58: Info: clone central_restore is of version &{ 3.73.3 168 2023-03-09 17:23:16.541519 +0000 UTC}
clone/postgres: 2023/03/10 10:57:37.038087 db_clone_manager_impl.go:112: Info: Postgres Database clones:
clone/postgres: 2023/03/10 10:57:37.038170 db_clone_manager_impl.go:114: Info: central_restore -> &{ 3.73.3 168 2023-03-09 17:23:16.541519 +0000 UTC}
clone/postgres: 2023/03/10 10:57:37.038220 db_clone_manager_impl.go:114: Info: central_active -> &{ 3.74.x-343-g6abf7816ba 174 2023-03-10 10:55:39.641177 +0000 UTC}
clone/postgres: 2023/03/10 10:57:37.038253 db_clone_manager_impl.go:144: Info: GetCloneToMigrate
clone/rocksdb: 2023/03/10 10:57:37.038308 db_clone_manager_impl.go:139: Info: Database restore directory found. Migrating restored database files.
Migrator: 2023/03/10 10:57:37.038371 log.go:18: Info: Clone to Migrate ".restore", "central_restore"
```
Notice how there is a restore directory and all it has is a migration version yaml because we were not actually processing a rocksdb bundle in the restore we were processing a postgres bundle:
```
bash-4.4$ cd /var/lib/stackrox
bash-4.4$ ls -al
total 36
drwxrwxrwx 7 root root 4096 Mar 10 10:57 .
drwxr-xr-x 1 root root 4096 Mar 10 10:50 ..
lrwxrwxrwx 1 4000 root    8 Mar 10 10:57 .backup -> .db-init
drwxr-xr-x 2 4000 root 4096 Mar 10 10:55 .db-init
drwx------ 2 4000 root 4096 Mar 10 10:57 .restore-3895bf87-8a4f-4213-bfbd-d19beb45902a
lrwxrwxrwx 1 4000 root   45 Mar 10 10:57 current -> .restore-3895bf87-8a4f-4213-bfbd-d19beb45902a
bash-4.4$ ls -al .restore-3895bf87-8a4f-4213-bfbd-d19beb45902a/
total 12
drwx------ 2 4000 root 4096 Mar 10 10:57 .
drwxrwxrwx 7 root root 4096 Mar 10 10:57 ..
-rw-r--r-- 1 4000 root   64 Mar 10 10:57 migration_version.yaml
bash-4.4$ 
```

====================================================================================
Results of a restore of a postgres bundle AFTER this change.  Notice there is not clone found named .restore:
```
clone/rocksdb: 2023/03/10 10:26:10.955440 db_clone_manager_impl.go:61: Info: Found clone current -> .db-init
clone/rocksdb: 2023/03/10 10:26:10.955514 db_clone_manager_impl.go:116: Info: Database clones:
clone/rocksdb: 2023/03/10 10:26:10.955591 db_clone_manager_impl.go:118: Info: current -> &{/var/lib/stackrox/current 0 0 0001-01-01 00:00:00 +0000 UTC}
...
Migrator: 2023/03/10 10:26:11.221040 log.go:18: Info: Migration version from DB = seq_num:168 version:"3.73.3" last_persisted:<seconds:1678382596 nanos:541519000 > .
clone/postgres: 2023/03/10 10:26:11.221854 db_clone_manager_impl.go:58: Info: clone central_restore is of version &{ 3.73.3 168 2023-03-09 17:23:16.541519 +0000 UTC}
clone/postgres: 2023/03/10 10:26:11.221940 db_clone_manager_impl.go:112: Info: Postgres Database clones:
clone/postgres: 2023/03/10 10:26:11.221987 db_clone_manager_impl.go:114: Info: central_restore -> &{ 3.73.3 168 2023-03-09 17:23:16.541519 +0000 UTC}
clone/postgres: 2023/03/10 10:26:11.222036 db_clone_manager_impl.go:114: Info: central_active -> &{ 3.74.x-331-gb2011ee830-dirty 174 2023-03-10 10:22:03.062993 +0000 UTC}
clone/postgres: 2023/03/10 10:26:11.222084 db_clone_manager_impl.go:144: Info: GetCloneToMigrate
Migrator: 2023/03/10 10:26:11.222133 log.go:18: Info: Clone to Migrate "", "central_restore"
```
Directory structure AFTER:
```
bash-4.4$ cd /var/lib/stackrox
bash-4.4$ ls -al
total 32
drwxrwxrwx 6 root root 4096 Mar 10 10:24 .
drwxr-xr-x 1 root root 4096 Mar  9 20:24 ..
drwxr-xr-x 2 4000 root 4096 Mar 10 10:21 .db-init
-rw-r--r-- 1 4000 root   64 Mar 10 10:26 checksum
lrwxrwxrwx 1 4000 root   26 Mar 10 10:21 current -> /var/lib/stackrox/.db-init
drwxr--r-- 3 4000 root 4096 Mar 10 10:22 cve
drwxr-xr-x 2 4000 root 4096 Mar 10 10:21 migration_log
drwx------ 2 4000 root 4096 Mar 10 10:22 probe-uploads
```
Results of sending in a Rocks backup bundle AFTER the change.  Notice we found a clone of .restore:
```
pkg/migrations: 2023/03/10 10:30:41.646865 migration_version.go:60: Info: Migration version of database at /var/lib/stackrox/.restore: &{/var/lib/stackrox/.restore 3.72.x-602-g2ec1e59031 111 0001-01-01 00:00:00 +0000 UTC}
clone/rocksdb: 2023/03/10 10:30:41.646965 db_clone_manager_impl.go:61: Info: Found clone .restore -> .restore-fbb46e6f-0d01-435b-bd0a-6eadd67e28c3
clone/rocksdb: 2023/03/10 10:30:41.647054 db_clone_manager_impl.go:61: Info: Found clone current -> .db-init
clone/rocksdb: 2023/03/10 10:30:41.647129 db_clone_manager_impl.go:116: Info: Database clones:
clone/rocksdb: 2023/03/10 10:30:41.647199 db_clone_manager_impl.go:118: Info: current -> &{/var/lib/stackrox/current 0 0 0001-01-01 00:00:00 +0000 UTC}
clone/rocksdb: 2023/03/10 10:30:41.647258 db_clone_manager_impl.go:118: Info: .restore -> &{/var/lib/stackrox/.restore 3.72.x-602-g2ec1e59031 111 0001-01-01 00:00:00 +0000 UTC}
...
clone/postgres: 2023/03/10 10:30:41.798226 db_clone_manager_impl.go:112: Info: Postgres Database clones:
clone/postgres: 2023/03/10 10:30:41.798284 db_clone_manager_impl.go:114: Info: central_active -> &{ 3.74.x-331-gb2011ee830-dirty 174 2023-03-10 10:26:20.395028 +0000 UTC}
clone/postgres: 2023/03/10 10:30:41.798333 db_clone_manager_impl.go:144: Info: GetCloneToMigrate
clone/rocksdb: 2023/03/10 10:30:41.798466 db_clone_manager_impl.go:139: Info: Database restore directory found. Migrating restored database files.
Migrator: 2023/03/10 10:30:41.798577 log.go:18: Info: Clone to Migrate ".restore", "central_restore"
```