### PR TITLE
Enable alerts to use GetByQuery instead of Search and GetMany

### DIFF
--- a/central/alert/datastore/datastore_impl.go
+++ b/central/alert/datastore/datastore_impl.go
@@ -96,6 +96,7 @@ func (ds *datastoreImpl) ListAlerts(ctx context.Context, request *v1.ListAlertsR
 	}
 
 	paginated.FillPagination(q, request.GetPagination(), math.MaxInt32)
+	q = paginated.FillDefaultSortOption(q, paginated.ViolationTimeSortOption)
 
 	alerts, err := ds.SearchListAlerts(ctx, q)
 	if err != nil {

--- a/central/alert/datastore/internal/store/mocks/store.go
+++ b/central/alert/datastore/internal/store/mocks/store.go
@@ -9,6 +9,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	storage "github.com/stackrox/rox/generated/storage"
 )
 
@@ -96,6 +97,21 @@ func (m *MockStore) Get(ctx context.Context, id string) (*storage.Alert, bool, e
 func (mr *MockStoreMockRecorder) Get(ctx, id interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockStore)(nil).Get), ctx, id)
+}
+
+// GetByQuery mocks base method.
+func (m *MockStore) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.Alert, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetByQuery", ctx, query)
+	ret0, _ := ret[0].([]*storage.Alert)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetByQuery indicates an expected call of GetByQuery.
+func (mr *MockStoreMockRecorder) GetByQuery(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByQuery", reflect.TypeOf((*MockStore)(nil).GetByQuery), ctx, query)
 }
 
 // GetIDs mocks base method.

--- a/central/alert/datastore/internal/store/store.go
+++ b/central/alert/datastore/internal/store/store.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 )
 
@@ -14,6 +15,7 @@ type Store interface {
 	GetIDs(ctx context.Context) ([]string, error)
 	Get(ctx context.Context, id string) (*storage.Alert, bool, error)
 	GetMany(ctx context.Context, ids []string) ([]*storage.Alert, []int, error)
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.Alert, error)
 	Upsert(ctx context.Context, alert *storage.Alert) error
 	UpsertMany(ctx context.Context, alerts []*storage.Alert) error
 	Delete(ctx context.Context, id string) error

--- a/central/graphql/resolvers/deploymentevents.go
+++ b/central/graphql/resolvers/deploymentevents.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/containerid"
 	processBaselinePkg "github.com/stackrox/rox/pkg/processbaseline"
+	"github.com/stackrox/rox/pkg/search/paginated"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/utils"
 )
@@ -348,6 +349,7 @@ func (resolver *Resolver) getPolicyViolationEvents(ctx context.Context, query *v
 		return nil, err
 	}
 
+	query = paginated.FillDefaultSortOption(query, paginated.ViolationTimeSortOption)
 	alerts, err := resolver.ViolationsDataStore.SearchRawAlerts(ctx, query)
 	if err != nil {
 		return nil, errors.Wrap(err, "retrieving alerts from search")

--- a/central/graphql/resolvers/deployments.go
+++ b/central/graphql/resolvers/deployments.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stackrox/rox/pkg/features"
 	pkgMetrics "github.com/stackrox/rox/pkg/metrics"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/paginated"
 	"github.com/stackrox/rox/pkg/search/scoped"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/utils"
@@ -203,6 +204,7 @@ func (resolver *deploymentResolver) DeployAlerts(ctx context.Context, args Pagin
 
 	nested.Pagination = pagination
 
+	nested = paginated.FillDefaultSortOption(nested, paginated.ViolationTimeSortOption)
 	return resolver.root.wrapAlerts(
 		resolver.root.ViolationsDataStore.SearchRawAlerts(ctx, nested))
 }
@@ -315,6 +317,7 @@ func (resolver *deploymentResolver) FailingPolicies(ctx context.Context, args Pa
 	pagination := q.GetPagination()
 	q.Pagination = &v1.QueryPagination{SortOptions: pagination.GetSortOptions()}
 
+	q = paginated.FillDefaultSortOption(q, paginated.ViolationTimeSortOption)
 	alerts, err := resolver.root.ViolationsDataStore.SearchRawAlerts(ctx, q)
 	if err != nil {
 		return nil, err
@@ -383,11 +386,11 @@ func (resolver *deploymentResolver) FailingRuntimePolicyCount(ctx context.Contex
 	}
 	query = search.ConjunctionQuery(query,
 		search.NewQueryBuilder().AddExactMatches(search.LifecycleStage, storage.LifecycleStage_RUNTIME.String()).ProtoQuery())
-	alerts, err := resolver.root.ViolationsDataStore.Search(ctx, query)
+	count, err := resolver.root.ViolationsDataStore.Count(ctx, query)
 	if err != nil {
 		return 0, err
 	}
-	return int32(len(alerts)), nil
+	return int32(count), nil
 }
 
 // FailingPolicyCounter returns a policy counter for all the failed policies.

--- a/central/graphql/resolvers/deployments.go
+++ b/central/graphql/resolvers/deployments.go
@@ -359,15 +359,11 @@ func (resolver *deploymentResolver) FailingPolicyCount(ctx context.Context, args
 	if err != nil {
 		return 0, err
 	}
-	alerts, err := resolver.root.ViolationsDataStore.SearchListAlerts(ctx, query)
+	count, err := resolver.root.ViolationsDataStore.Count(ctx, query)
 	if err != nil {
 		return 0, nil
 	}
-	set := set.NewStringSet()
-	for _, alert := range alerts {
-		set.Add(alert.GetPolicy().GetId())
-	}
-	return int32(set.Cardinality()), nil
+	return int32(count), nil
 }
 
 // FailingRuntimePolicyCount returns count of all runtime policies failing on this deployment (not just unique)

--- a/central/graphql/resolvers/policies.go
+++ b/central/graphql/resolvers/policies.go
@@ -13,6 +13,7 @@ import (
 	pkgMetrics "github.com/stackrox/rox/pkg/metrics"
 	"github.com/stackrox/rox/pkg/policyutils"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/paginated"
 	"github.com/stackrox/rox/pkg/search/scoped"
 	"github.com/stackrox/rox/pkg/utils"
 )
@@ -182,6 +183,8 @@ func (resolver *policyResolver) FailingDeployments(ctx context.Context, args Pag
 func (resolver *policyResolver) failingDeployments(ctx context.Context, q *v1.Query) ([]*deploymentResolver, error) {
 	alertsQuery := search.ConjunctionQuery(resolver.getPolicyQuery(),
 		search.NewQueryBuilder().AddExactMatches(search.ViolationState, storage.ViolationState_ACTIVE.String()).ProtoQuery())
+
+	alertsQuery = paginated.FillDefaultSortOption(alertsQuery, paginated.ViolationTimeSortOption)
 	listAlerts, err := resolver.root.ViolationsDataStore.SearchListAlerts(ctx, alertsQuery)
 	if err != nil {
 		return nil, err

--- a/central/graphql/resolvers/violations.go
+++ b/central/graphql/resolvers/violations.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	pkgMetrics "github.com/stackrox/rox/pkg/metrics"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/paginated"
 	"github.com/stackrox/rox/pkg/utils"
 )
 
@@ -33,6 +34,8 @@ func (resolver *Resolver) Violations(ctx context.Context, args PaginatedQuery) (
 	if err != nil {
 		return nil, err
 	}
+
+	q = paginated.FillDefaultSortOption(q, paginated.ViolationTimeSortOption)
 	return resolver.wrapListAlerts(
 		resolver.ViolationsDataStore.SearchListAlerts(ctx, q))
 }

--- a/central/graphql/resolvers/vul_mgmt_widgets.go
+++ b/central/graphql/resolvers/vul_mgmt_widgets.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	pkgMetrics "github.com/stackrox/rox/pkg/metrics"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/paginated"
 	"github.com/stackrox/rox/pkg/utils"
 )
 
@@ -99,6 +100,7 @@ func deploymentsWithMostSevereViolations(ctx context.Context, resolver *Resolver
 		return nil, err
 	}
 
+	q = paginated.FillDefaultSortOption(q, paginated.ViolationTimeSortOption)
 	alerts, err := resolver.ViolationsDataStore.SearchListAlerts(ctx, q)
 	if err != nil {
 		return nil, err

--- a/pkg/search/paginated/options.go
+++ b/pkg/search/paginated/options.go
@@ -1,0 +1,14 @@
+package paginated
+
+import (
+	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/pkg/search"
+)
+
+var (
+	// ViolationTimeSortOption is a search options for alerts
+	ViolationTimeSortOption = &v1.QuerySortOption{
+		Field:    search.ViolationTime.String(),
+		Reversed: true,
+	}
+)


### PR DESCRIPTION
## Description

Couple changes needed to be made to allow this to happen, mostly around the searcher wrappers and also moving sorting into the service layer where it is expected. 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

CI + Scale test