### PR TITLE
ROX-14694: Prefactor datastores used in declarative config to include filter functions

### DIFF
--- a/central/authprovider/datastore/datastore_impl.go
+++ b/central/authprovider/datastore/datastore_impl.go
@@ -25,7 +25,10 @@ type datastoreImpl struct {
 
 // GetAllAuthProviders retrieves authProviders.
 func (b *datastoreImpl) GetAllAuthProviders(ctx context.Context) ([]*storage.AuthProvider, error) {
-	// No SAC checks here because all users need to be able to read auth providers in order to authenticate.
+	if err := sac.VerifyAuthzOK(accessSAC.ReadAllowed(ctx)); err != nil {
+		return nil, err
+	}
+
 	return b.storage.GetAll(ctx)
 }
 
@@ -34,7 +37,7 @@ func (b *datastoreImpl) GetAuthProvidersFiltered(ctx context.Context,
 	if err := sac.VerifyAuthzOK(accessSAC.ReadAllowed(ctx)); err != nil {
 		return nil, err
 	}
-	// TODO(ROX-XXXXX): The store currently doesn't provide a Walk function. This is mostly due to us supporting the
+	// TODO(ROX-15902): The store currently doesn't provide a Walk function. This is mostly due to us supporting the
 	// old bolt store. Once we deprecate old store solutions with the 4.0.0 release, this should be changed to use
 	// store.Walk.
 	authProviders, err := b.storage.GetAll(ctx)

--- a/central/authprovider/datastore/datastore_impl_test.go
+++ b/central/authprovider/datastore/datastore_impl_test.go
@@ -142,6 +142,26 @@ func (s *authProviderDataStoreTestSuite) TestErrorOnAdd() {
 	s.Error(err)
 }
 
+func (s *authProviderDataStoreTestSuite) TestGetFiltered() {
+	authProviders := []*storage.AuthProvider{
+		{
+			Id:   "some-id-1",
+			Name: "some-name-1",
+		},
+		{
+			Id:   "some-id-2",
+			Name: "some-name-2",
+		},
+	}
+	s.storage.EXPECT().GetAll(gomock.Any()).Return(authProviders, nil)
+
+	filteredAuthProviders, err := s.dataStore.GetAuthProvidersFiltered(s.hasReadCtx, func(authProvider *storage.AuthProvider) bool {
+		return authProvider.GetName() == "some-name-1"
+	})
+	s.NoError(err)
+	s.ElementsMatch(filteredAuthProviders, []*storage.AuthProvider{authProviders[0]})
+}
+
 func (s *authProviderDataStoreTestSuite) TestAllowsUpdate() {
 	s.storage.EXPECT().Upsert(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 	s.storage.EXPECT().Get(gomock.Any(), gomock.Any()).Return(&storage.AuthProvider{}, true, nil).Times(1)

--- a/central/authprovider/datastore/datastore_impl_test.go
+++ b/central/authprovider/datastore/datastore_impl_test.go
@@ -55,6 +55,19 @@ func (s *authProviderDataStoreEnforceTestSuite) TearDownTest() {
 	s.mockCtrl.Finish()
 }
 
+func (s *authProviderDataStoreEnforceTestSuite) TestEnforcesGetAll() {
+	s.storage.EXPECT().GetAll(gomock.Any()).Return(nil, nil).AnyTimes()
+
+	_, err := s.dataStore.GetAllAuthProviders(s.hasNoneCtx)
+	s.ErrorIs(err, sac.ErrResourceAccessDenied)
+
+	_, err = s.dataStore.GetAllAuthProviders(s.hasReadCtx)
+	s.NoError(err)
+
+	_, err = s.dataStore.GetAllAuthProviders(s.hasWriteCtx)
+	s.NoError(err)
+}
+
 func (s *authProviderDataStoreEnforceTestSuite) TestEnforcesAdd() {
 	s.storage.EXPECT().Upsert(gomock.Any(), gomock.Any()).Times(0)
 
@@ -159,6 +172,7 @@ func (s *authProviderDataStoreTestSuite) TestGetFiltered() {
 		return authProvider.GetName() == "some-name-1"
 	})
 	s.NoError(err)
+	s.Len(filteredAuthProviders, 1)
 	s.ElementsMatch(filteredAuthProviders, []*storage.AuthProvider{authProviders[0]})
 }
 

--- a/central/declarativeconfig/manager_impl.go
+++ b/central/declarativeconfig/manager_impl.go
@@ -241,7 +241,6 @@ func (m *managerImpl) reconcileTransformedMessages(transformedMessagesByHandler 
 			}
 		}
 	}
-	// TODO(ROX-14694): Add deletion of resources.
 	log.Debugf("Deleting all proto messages that have traits.Origin==DECLARATIVE but are not contained"+
 		" within the current list of transformed messages: %+v", transformedMessagesByHandler)
 }

--- a/central/declarativeconfig/updater/updater.go
+++ b/central/declarativeconfig/updater/updater.go
@@ -14,7 +14,6 @@ import (
 
 // ResourceUpdater handles updates of proto resources within declarative config reconciliation routine.
 // Each ResourceUpdater is responsible for updates of specific proto type.
-// TODO(ROX-14694): Extend interface with methods necessary for resource deletion.
 //
 //go:generate mockgen-wrapper
 type ResourceUpdater interface {

--- a/central/group/datastore/datastore_impl.go
+++ b/central/group/datastore/datastore_impl.go
@@ -54,7 +54,13 @@ func (ds *dataStoreImpl) Get(ctx context.Context, props *storage.GroupProperties
 		return nil, errox.InvalidArgs.CausedBy(err)
 	}
 
-	group, _, err := ds.storage.Get(ctx, props.GetId())
+	group, exists, err := ds.storage.Get(ctx, props.GetId())
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, errox.NotFound.Newf("could not find group %s", props.GetId())
+	}
 	return group, err
 }
 

--- a/central/group/datastore/datastore_impl_test.go
+++ b/central/group/datastore/datastore_impl_test.go
@@ -84,12 +84,12 @@ func (s *groupDataStoreTestSuite) TestEnforcesGet() {
 }
 
 func (s *groupDataStoreTestSuite) TestAllowsGet() {
-	s.storage.EXPECT().Get(gomock.Any(), gomock.Any()).Return(nil, false, nil)
+	s.storage.EXPECT().Get(gomock.Any(), gomock.Any()).Return(nil, true, nil)
 
 	_, err := s.dataStore.Get(s.hasReadCtx, &storage.GroupProperties{Id: "1", AuthProviderId: "something"})
 	s.NoError(err, "expected no error trying to read with permissions")
 
-	s.storage.EXPECT().Get(gomock.Any(), gomock.Any()).Return(nil, false, nil).Times(1)
+	s.storage.EXPECT().Get(gomock.Any(), gomock.Any()).Return(nil, true, nil).Times(1)
 
 	_, err = s.dataStore.Get(s.hasWriteCtx, &storage.GroupProperties{Id: "1", AuthProviderId: "something"})
 	s.NoError(err, "expected no error trying to read with permissions")

--- a/central/group/datastore/datastore_impl_test.go
+++ b/central/group/datastore/datastore_impl_test.go
@@ -97,13 +97,19 @@ func (s *groupDataStoreTestSuite) TestAllowsGet() {
 
 func (s *groupDataStoreTestSuite) TestGet() {
 	group := fixtures.GetGroup()
-	s.storage.EXPECT().Get(gomock.Any(), group.GetProps().GetId()).Return(group, true, nil)
+	s.storage.EXPECT().Get(gomock.Any(), group.GetProps().GetId()).Return(group, true, nil).Times(1)
 
 	// Test that can fetch by id
 	g, err := s.dataStore.Get(s.hasReadCtx, &storage.GroupProperties{Id: group.GetProps().GetId(),
 		AuthProviderId: group.GetProps().GetAuthProviderId()})
 	s.NoError(err)
 	s.Equal(group, g)
+
+	// Test that a non-existing group will yield errox.NotFound.
+	s.storage.EXPECT().Get(gomock.Any(), group.GetProps().GetId()).Return(nil, false, nil).Times(1)
+	g, err = s.dataStore.Get(s.hasReadCtx, group.GetProps())
+	s.Nil(g)
+	s.ErrorIs(err, errox.NotFound)
 }
 
 func (s *groupDataStoreTestSuite) TestGetWithoutID() {

--- a/central/role/datastore/datastore.go
+++ b/central/role/datastore/datastore.go
@@ -15,6 +15,7 @@ import (
 type DataStore interface {
 	GetRole(ctx context.Context, name string) (*storage.Role, bool, error)
 	GetAllRoles(ctx context.Context) ([]*storage.Role, error)
+	GetRolesFiltered(ctx context.Context, filter func(role *storage.Role) bool) ([]*storage.Role, error)
 	CountRoles(ctx context.Context) (int, error)
 	AddRole(ctx context.Context, role *storage.Role) error
 	UpdateRole(ctx context.Context, role *storage.Role) error
@@ -22,6 +23,7 @@ type DataStore interface {
 
 	GetPermissionSet(ctx context.Context, id string) (*storage.PermissionSet, bool, error)
 	GetAllPermissionSets(ctx context.Context) ([]*storage.PermissionSet, error)
+	GetPermissionSetsFiltered(ctx context.Context, filter func(permissionSet *storage.PermissionSet) bool) ([]*storage.PermissionSet, error)
 	CountPermissionSets(ctx context.Context) (int, error)
 	AddPermissionSet(ctx context.Context, permissionSet *storage.PermissionSet) error
 	UpdatePermissionSet(ctx context.Context, permissionSet *storage.PermissionSet) error
@@ -30,6 +32,7 @@ type DataStore interface {
 
 	GetAccessScope(ctx context.Context, id string) (*storage.SimpleAccessScope, bool, error)
 	GetAllAccessScopes(ctx context.Context) ([]*storage.SimpleAccessScope, error)
+	GetAccessScopesFiltered(ctx context.Context, filter func(accessScope *storage.SimpleAccessScope) bool) ([]*storage.SimpleAccessScope, error)
 	CountAccessScopes(ctx context.Context) (int, error)
 	AddAccessScope(ctx context.Context, scope *storage.SimpleAccessScope) error
 	UpdateAccessScope(ctx context.Context, scope *storage.SimpleAccessScope) error

--- a/central/role/datastore/datastore_impl.go
+++ b/central/role/datastore/datastore_impl.go
@@ -144,23 +144,21 @@ func (ds *dataStoreImpl) UpsertAccessScope(ctx context.Context, newScope *storag
 }
 
 func (ds *dataStoreImpl) GetRole(ctx context.Context, name string) (*storage.Role, bool, error) {
-	if ok, err := roleSAC.ReadAllowed(ctx); !ok || err != nil {
+	if err := sac.VerifyAuthzOK(roleSAC.ReadAllowed(ctx)); err != nil {
 		return nil, false, err
 	}
-
 	return ds.roleStorage.Get(ctx, name)
 }
 
 func (ds *dataStoreImpl) GetAllRoles(ctx context.Context) ([]*storage.Role, error) {
-	if ok, err := roleSAC.ReadAllowed(ctx); !ok || err != nil {
+	if err := sac.VerifyAuthzOK(roleSAC.ReadAllowed(ctx)); err != nil {
 		return nil, err
 	}
-
 	return ds.getAllRolesNoScopeCheck(ctx)
 }
 
 func (ds *dataStoreImpl) GetRolesFiltered(ctx context.Context, filter func(role *storage.Role) bool) ([]*storage.Role, error) {
-	if ok, err := roleSAC.ReadAllowed(ctx); !ok || err != nil {
+	if err := sac.VerifyAuthzOK(roleSAC.ReadAllowed(ctx)); err != nil {
 		return nil, err
 	}
 
@@ -181,7 +179,7 @@ func (ds *dataStoreImpl) GetRolesFiltered(ctx context.Context, filter func(role 
 }
 
 func (ds *dataStoreImpl) CountRoles(ctx context.Context) (int, error) {
-	if ok, err := roleSAC.ReadAllowed(ctx); !ok || err != nil {
+	if err := sac.VerifyAuthzOK(roleSAC.ReadAllowed(ctx)); err != nil {
 		return 0, err
 	}
 
@@ -288,18 +286,16 @@ func verifyRoleOrigin(ctx context.Context, role *storage.Role) error {
 //                                                                            //
 
 func (ds *dataStoreImpl) GetPermissionSet(ctx context.Context, id string) (*storage.PermissionSet, bool, error) {
-	if ok, err := roleSAC.ReadAllowed(ctx); !ok || err != nil {
+	if err := sac.VerifyAuthzOK(roleSAC.ReadAllowed(ctx)); err != nil {
 		return nil, false, err
 	}
-
 	return ds.permissionSetStorage.Get(ctx, id)
 }
 
 func (ds *dataStoreImpl) GetAllPermissionSets(ctx context.Context) ([]*storage.PermissionSet, error) {
-	if ok, err := roleSAC.ReadAllowed(ctx); !ok || err != nil {
+	if err := sac.VerifyAuthzOK(roleSAC.ReadAllowed(ctx)); err != nil {
 		return nil, err
 	}
-
 	var permissionSets []*storage.PermissionSet
 	walkFn := func() error {
 		permissionSets = permissionSets[:0]
@@ -317,10 +313,9 @@ func (ds *dataStoreImpl) GetAllPermissionSets(ctx context.Context) ([]*storage.P
 
 func (ds *dataStoreImpl) GetPermissionSetsFiltered(ctx context.Context,
 	filter func(permissionSet *storage.PermissionSet) bool) ([]*storage.PermissionSet, error) {
-	if ok, err := roleSAC.ReadAllowed(ctx); !ok || err != nil {
+	if err := sac.VerifyAuthzOK(roleSAC.ReadAllowed(ctx)); err != nil {
 		return nil, err
 	}
-
 	var filteredPermissionSets []*storage.PermissionSet
 	walkFn := func() error {
 		filteredPermissionSets = filteredPermissionSets[:0]
@@ -339,10 +334,9 @@ func (ds *dataStoreImpl) GetPermissionSetsFiltered(ctx context.Context,
 }
 
 func (ds *dataStoreImpl) CountPermissionSets(ctx context.Context) (int, error) {
-	if ok, err := roleSAC.ReadAllowed(ctx); !ok || err != nil {
+	if err := sac.VerifyAuthzOK(roleSAC.ReadAllowed(ctx)); err != nil {
 		return 0, err
 	}
-
 	return ds.permissionSetStorage.Count(ctx)
 }
 
@@ -463,18 +457,16 @@ func verifyPermissionSetOrigin(ctx context.Context, ps *storage.PermissionSet) e
 //                                                                            //
 
 func (ds *dataStoreImpl) GetAccessScope(ctx context.Context, id string) (*storage.SimpleAccessScope, bool, error) {
-	if ok, err := roleSAC.ReadAllowed(ctx); !ok || err != nil {
+	if err := sac.VerifyAuthzOK(roleSAC.ReadAllowed(ctx)); err != nil {
 		return nil, false, err
 	}
-
 	return ds.accessScopeStorage.Get(ctx, id)
 }
 
 func (ds *dataStoreImpl) GetAllAccessScopes(ctx context.Context) ([]*storage.SimpleAccessScope, error) {
-	if ok, err := roleSAC.ReadAllowed(ctx); !ok || err != nil {
+	if err := sac.VerifyAuthzOK(roleSAC.ReadAllowed(ctx)); err != nil {
 		return nil, err
 	}
-
 	var scopes []*storage.SimpleAccessScope
 	walkFn := func() error {
 		scopes = scopes[:0]
@@ -492,10 +484,9 @@ func (ds *dataStoreImpl) GetAllAccessScopes(ctx context.Context) ([]*storage.Sim
 
 func (ds *dataStoreImpl) GetAccessScopesFiltered(ctx context.Context,
 	filter func(accessScope *storage.SimpleAccessScope) bool) ([]*storage.SimpleAccessScope, error) {
-	if ok, err := roleSAC.ReadAllowed(ctx); !ok || err != nil {
+	if err := sac.VerifyAuthzOK(roleSAC.ReadAllowed(ctx)); err != nil {
 		return nil, err
 	}
-
 	var filteredScopes []*storage.SimpleAccessScope
 	walkFn := func() error {
 		filteredScopes = filteredScopes[:0]
@@ -514,10 +505,9 @@ func (ds *dataStoreImpl) GetAccessScopesFiltered(ctx context.Context,
 }
 
 func (ds *dataStoreImpl) CountAccessScopes(ctx context.Context) (int, error) {
-	if ok, err := roleSAC.ReadAllowed(ctx); !ok || err != nil {
+	if err := sac.VerifyAuthzOK(roleSAC.ReadAllowed(ctx)); err != nil {
 		return 0, err
 	}
-
 	return ds.accessScopeStorage.Count(ctx)
 }
 
@@ -627,7 +617,7 @@ func (ds *dataStoreImpl) RemoveAccessScope(ctx context.Context, id string) error
 }
 
 func (ds *dataStoreImpl) GetAndResolveRole(ctx context.Context, name string) (permissions.ResolvedRole, error) {
-	if ok, err := roleSAC.ReadAllowed(ctx); !ok || err != nil {
+	if err := sac.VerifyAuthzOK(roleSAC.ReadAllowed(ctx)); err != nil {
 		return nil, err
 	}
 

--- a/central/role/datastore/datastore_impl_test.go
+++ b/central/role/datastore/datastore_impl_test.go
@@ -186,17 +186,17 @@ func (s *roleDataStoreTestSuite) TestRolePermissions() {
 	badRole := getInvalidRole("new invalid role")
 
 	role, found, err := s.dataStore.GetRole(s.hasNoneCtx, s.existingRole.GetName())
-	s.NoError(err, "no access for Get*() is not an error")
+	s.ErrorIs(err, sac.ErrResourceAccessDenied)
 	s.False(found, "not found")
 	s.Nil(role)
 
 	role, found, err = s.dataStore.GetRole(s.hasNoneCtx, goodRole.GetName())
-	s.NoError(err, "no error even if the object does not exist")
+	s.ErrorIs(err, sac.ErrResourceAccessDenied)
 	s.False(found, "not found")
 	s.Nil(role)
 
 	roles, err := s.dataStore.GetAllRoles(s.hasNoneCtx)
-	s.NoError(err, "no access for GetAll*() is not an error")
+	s.ErrorIs(err, sac.ErrResourceAccessDenied)
 	s.Empty(roles)
 
 	err = s.dataStore.AddRole(s.hasNoneCtx, goodRole)
@@ -396,17 +396,17 @@ func (s *roleDataStoreTestSuite) TestPermissionSetPermissions() {
 	badPermissionSet := getInvalidPermissionSet("permissionset.invalid", "new invalid permission set")
 
 	permissionSet, found, err := s.dataStore.GetPermissionSet(s.hasNoneCtx, s.existingPermissionSet.GetId())
-	s.NoError(err, "no access for Get*() is not an error")
+	s.ErrorIs(err, sac.ErrResourceAccessDenied)
 	s.False(found)
 	s.Nil(permissionSet)
 
 	permissionSet, found, err = s.dataStore.GetPermissionSet(s.hasNoneCtx, goodPermissionSet.GetId())
-	s.NoError(err, "no error even if the object does not exist")
+	s.ErrorIs(err, sac.ErrResourceAccessDenied)
 	s.False(found)
 	s.Nil(permissionSet)
 
 	permissionSets, err := s.dataStore.GetAllPermissionSets(s.hasNoneCtx)
-	s.NoError(err, "no access for Get*() is not an error")
+	s.ErrorIs(err, sac.ErrResourceAccessDenied)
 	s.Empty(permissionSets)
 
 	err = s.dataStore.AddPermissionSet(s.hasNoneCtx, goodPermissionSet)
@@ -637,17 +637,17 @@ func (s *roleDataStoreTestSuite) TestAccessScopePermissions() {
 	badScope := getInvalidAccessScope("scope.invalid", "new invalid scope")
 
 	scope, found, err := s.dataStore.GetAccessScope(s.hasNoneCtx, s.existingScope.GetId())
-	s.NoError(err, "no access for Get*() is not an error")
+	s.ErrorIs(err, sac.ErrResourceAccessDenied)
 	s.False(found)
 	s.Nil(scope)
 
 	scope, found, err = s.dataStore.GetAccessScope(s.hasNoneCtx, goodScope.GetId())
-	s.NoError(err, "no error even if the object does not exist")
+	s.ErrorIs(err, sac.ErrResourceAccessDenied)
 	s.False(found)
 	s.Nil(scope)
 
 	scopes, err := s.dataStore.GetAllAccessScopes(s.hasNoneCtx)
-	s.NoError(err, "no access for Get*() is not an error")
+	s.ErrorIs(err, sac.ErrResourceAccessDenied)
 	s.Empty(scopes)
 
 	err = s.dataStore.AddAccessScope(s.hasNoneCtx, goodScope)
@@ -891,7 +891,7 @@ func (s *roleDataStoreTestSuite) TestGetAndResolveRole() {
 	noScopeRole := getValidRole("role without a scope", s.existingPermissionSet.GetId(), "")
 
 	resolvedRole, err := s.dataStore.GetAndResolveRole(s.hasNoneCtx, s.existingRole.GetName())
-	s.NoError(err, "no access for GetAndResolveRole() is not an error")
+	s.ErrorIs(err, sac.ErrResourceAccessDenied)
 	s.Nil(resolvedRole)
 
 	resolvedRole, err = s.dataStore.GetAndResolveRole(s.hasReadCtx, noScopeRole.GetName())

--- a/central/role/datastore/datastore_impl_test.go
+++ b/central/role/datastore/datastore_impl_test.go
@@ -241,6 +241,19 @@ func (s *roleDataStoreTestSuite) TestRoleReadOperations() {
 	roles, err := s.dataStore.GetAllRoles(s.hasReadCtx)
 	s.NoError(err)
 	s.Len(roles, 1, "with READ access all objects are returned")
+
+	roles, err = s.dataStore.GetRolesFiltered(s.hasReadCtx, func(role *storage.Role) bool {
+		return role.GetName() == s.existingRole.GetName()
+	})
+	s.NoError(err)
+	s.Len(roles, 1)
+	s.ElementsMatch(roles, []*storage.Role{role})
+
+	roles, err = s.dataStore.GetRolesFiltered(s.hasReadCtx, func(role *storage.Role) bool {
+		return role.GetName() == "non-existing-role"
+	})
+	s.NoError(err)
+	s.Empty(roles)
 }
 
 func (s *roleDataStoreTestSuite) TestRoleWriteOperations() {
@@ -440,6 +453,19 @@ func (s *roleDataStoreTestSuite) TestPermissionSetReadOperations() {
 	permissionSets, err := s.dataStore.GetAllPermissionSets(s.hasReadCtx)
 	s.NoError(err)
 	s.Len(permissionSets, 1, "with READ access all objects are returned")
+
+	permissionSets, err = s.dataStore.GetPermissionSetsFiltered(s.hasReadCtx, func(permissionSet *storage.PermissionSet) bool {
+		return permissionSet.GetId() == s.existingPermissionSet.GetId()
+	})
+	s.NoError(err)
+	s.Len(permissionSets, 1)
+	s.ElementsMatch(permissionSets, []*storage.PermissionSet{s.existingPermissionSet})
+
+	permissionSets, err = s.dataStore.GetPermissionSetsFiltered(s.hasReadCtx, func(permissionSet *storage.PermissionSet) bool {
+		return permissionSet.GetId() == "non-existing permission set"
+	})
+	s.NoError(err)
+	s.Empty(permissionSets)
 }
 
 func (s *roleDataStoreTestSuite) TestPermissionSetWriteOperations() {
@@ -668,6 +694,19 @@ func (s *roleDataStoreTestSuite) TestAccessScopeReadOperations() {
 	scopes, err := s.dataStore.GetAllAccessScopes(s.hasReadCtx)
 	s.NoError(err)
 	s.Len(scopes, 1, "with READ access all objects are returned")
+
+	scopes, err = s.dataStore.GetAccessScopesFiltered(s.hasReadCtx, func(accessScope *storage.SimpleAccessScope) bool {
+		return accessScope.GetId() == s.existingScope.GetId()
+	})
+	s.NoError(err)
+	s.Len(scopes, 1)
+	s.ElementsMatch(scopes, []*storage.SimpleAccessScope{s.existingScope})
+
+	scopes, err = s.dataStore.GetAccessScopesFiltered(s.hasReadCtx, func(accessScope *storage.SimpleAccessScope) bool {
+		return accessScope.GetId() == "non-existing scope"
+	})
+	s.NoError(err)
+	s.Empty(scopes)
 }
 
 func (s *roleDataStoreTestSuite) TestAccessScopeWriteOperations() {

--- a/central/role/datastore/mocks/datastore.go
+++ b/central/role/datastore/mocks/datastore.go
@@ -139,6 +139,21 @@ func (mr *MockDataStoreMockRecorder) GetAccessScope(ctx, id interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAccessScope", reflect.TypeOf((*MockDataStore)(nil).GetAccessScope), ctx, id)
 }
 
+// GetAccessScopesFiltered mocks base method.
+func (m *MockDataStore) GetAccessScopesFiltered(ctx context.Context, filter func(*storage.SimpleAccessScope) bool) ([]*storage.SimpleAccessScope, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAccessScopesFiltered", ctx, filter)
+	ret0, _ := ret[0].([]*storage.SimpleAccessScope)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAccessScopesFiltered indicates an expected call of GetAccessScopesFiltered.
+func (mr *MockDataStoreMockRecorder) GetAccessScopesFiltered(ctx, filter interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAccessScopesFiltered", reflect.TypeOf((*MockDataStore)(nil).GetAccessScopesFiltered), ctx, filter)
+}
+
 // GetAllAccessScopes mocks base method.
 func (m *MockDataStore) GetAllAccessScopes(ctx context.Context) ([]*storage.SimpleAccessScope, error) {
 	m.ctrl.T.Helper()
@@ -215,6 +230,21 @@ func (mr *MockDataStoreMockRecorder) GetPermissionSet(ctx, id interface{}) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPermissionSet", reflect.TypeOf((*MockDataStore)(nil).GetPermissionSet), ctx, id)
 }
 
+// GetPermissionSetsFiltered mocks base method.
+func (m *MockDataStore) GetPermissionSetsFiltered(ctx context.Context, filter func(*storage.PermissionSet) bool) ([]*storage.PermissionSet, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPermissionSetsFiltered", ctx, filter)
+	ret0, _ := ret[0].([]*storage.PermissionSet)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetPermissionSetsFiltered indicates an expected call of GetPermissionSetsFiltered.
+func (mr *MockDataStoreMockRecorder) GetPermissionSetsFiltered(ctx, filter interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPermissionSetsFiltered", reflect.TypeOf((*MockDataStore)(nil).GetPermissionSetsFiltered), ctx, filter)
+}
+
 // GetRole mocks base method.
 func (m *MockDataStore) GetRole(ctx context.Context, name string) (*storage.Role, bool, error) {
 	m.ctrl.T.Helper()
@@ -229,6 +259,21 @@ func (m *MockDataStore) GetRole(ctx context.Context, name string) (*storage.Role
 func (mr *MockDataStoreMockRecorder) GetRole(ctx, name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRole", reflect.TypeOf((*MockDataStore)(nil).GetRole), ctx, name)
+}
+
+// GetRolesFiltered mocks base method.
+func (m *MockDataStore) GetRolesFiltered(ctx context.Context, filter func(*storage.Role) bool) ([]*storage.Role, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRolesFiltered", ctx, filter)
+	ret0, _ := ret[0].([]*storage.Role)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetRolesFiltered indicates an expected call of GetRolesFiltered.
+func (mr *MockDataStoreMockRecorder) GetRolesFiltered(ctx, filter interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRolesFiltered", reflect.TypeOf((*MockDataStore)(nil).GetRolesFiltered), ctx, filter)
 }
 
 // RemoveAccessScope mocks base method.

--- a/pkg/auth/authproviders/registry_httphandler_test.go
+++ b/pkg/auth/authproviders/registry_httphandler_test.go
@@ -406,6 +406,10 @@ func (*tstAuthProviderStore) GetAllAuthProviders(_ context.Context) ([]*storage.
 	return []*storage.AuthProvider{mockAuthProvider, mockAuthProviderWithAttributes}, nil
 }
 
+func (*tstAuthProviderStore) GetAuthProvidersFiltered(_ context.Context, _ func(provider *storage.AuthProvider) bool) ([]*storage.AuthProvider, error) {
+	return nil, nil
+}
+
 func (*tstAuthProviderStore) AddAuthProvider(_ context.Context, _ *storage.AuthProvider) error {
 	return nil
 }

--- a/pkg/auth/authproviders/store.go
+++ b/pkg/auth/authproviders/store.go
@@ -9,7 +9,7 @@ import (
 // Store provides storage functionality for auth providers.
 type Store interface {
 	GetAllAuthProviders(ctx context.Context) ([]*storage.AuthProvider, error)
-
+	GetAuthProvidersFiltered(ctx context.Context, filter func(authProvider *storage.AuthProvider) bool) ([]*storage.AuthProvider, error)
 	AddAuthProvider(ctx context.Context, authProvider *storage.AuthProvider) error
 	UpdateAuthProvider(ctx context.Context, authProvider *storage.AuthProvider) error
 	RemoveAuthProvider(ctx context.Context, id string, force bool) error


### PR DESCRIPTION
## Description

This PR is a prefactor for adding deletion to the declarative configuration reconciliation.

Each datastore that will be used during the reconciliation will be updated to implement a `Get...Filtered` function.

This will allow us later do to the following:
- Filter out all resources that are declarative via their `GetTraits().GetOrigin()`
- Filter out all resources that should exist declaratively via their respective IDs.

Note that the group datastore already provides such functionality, thus it was skipped within this prefactor.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

- see added unit tests on each datastore.
