### PR TITLE
ROX-10242: Remove the offline-mode flag for scanner generate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 ### Deprecated Features
 - Deprecated `/v1/telemetry/configure` service.
 - The `expiration` field in the `Exclusion` proto has been deprecated and will be removed in a future release.
+- The `--offline-mode` flag for the `roxctl scanner generate` command is deprecated, as Scanner's default behavior is
+  to fetch vulnerability updates from Central. The flag will be removed as part of the 4.2.0 release.
 
 ### Technical Changes
 

--- a/roxctl/scanner/generate/generate.go
+++ b/roxctl/scanner/generate/generate.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stackrox/rox/pkg/apiparams"
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/istioutils"
+	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/rox/roxctl/common"
 	"github.com/stackrox/rox/roxctl/common/environment"
 	"github.com/stackrox/rox/roxctl/common/flags"
@@ -106,14 +107,17 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 	c.PersistentFlags().Var(clustertype.Value(storage.ClusterType_KUBERNETES_CLUSTER), "cluster-type", "Type of cluster the scanner will run on (k8s, openshift)")
 
 	c.Flags().StringVar(&scannerGenerateCmd.outputDir, "output-dir", "", "Output directory for scanner bundle (leave blank for default)")
-	c.Flags().BoolVar(&scannerGenerateCmd.apiParams.OfflineMode, "offline-mode", false, "Whether to run the scanner in offline mode (so "+
-		"it doesn't reach out to the internet for updates)")
 	c.Flags().StringVar(&scannerGenerateCmd.apiParams.ScannerImage, flags.FlagNameScannerImage, "", "Scanner image to use (leave blank to use server default)")
 	c.Flags().StringVar(&scannerGenerateCmd.apiParams.IstioVersion, istioSupportArg, "",
 		fmt.Sprintf(
 			"Generate deployment files supporting the given Istio version. Valid versions: %s",
 			strings.Join(istioutils.ListKnownIstioVersions(), ", ")))
 	c.PersistentFlags().BoolVar(&scannerGenerateCmd.enablePodSecurityPolicies, "enable-pod-security-policies", true, "Create PodSecurityPolicy resources (for pre-v1.25 Kubernetes)")
+
+	// TODO(ROX-15868): Remove the offline-mode flag after the deprecation notice has passed.
+	c.Flags().BoolVar(&scannerGenerateCmd.apiParams.OfflineMode, "offline-mode", false, "Whether to run the scanner in offline mode (so "+
+		"it doesn't reach out to the internet for updates)")
+	utils.Must(c.Flags().MarkDeprecated("offline-mode", "The offline mode option has been deprecated, scanner will reach out to central for updates"))
 
 	return c
 }


### PR DESCRIPTION
## Description

The PR announces the deprecation of the `--offline-mode` flag within the `roxctl scanner generate` command, as the default behavior for scanner is to retrieve updates via Central anyways.

Created [ROX-15868](https://issues.redhat.com/browse/ROX-15868) as a follow-up to remove the flag within the 4.2.0 release, 2 release after announcing that the flag is deprecated.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed
