### PR TITLE
ROX-14674: Fix duplicate baselines

### DIFF
--- a/central/networkbaseline/manager/manager_impl.go
+++ b/central/networkbaseline/manager/manager_impl.go
@@ -202,7 +202,12 @@ func (m *manager) sendNetworkBaselinesToSensor(baselines []*storage.NetworkBasel
 	}
 }
 
-func (m *manager) lookUpPeerName(entity networkgraph.Entity) string {
+type peerInfo struct {
+	name      string
+	cidrBlock string
+}
+
+func (m *manager) lookUpPeerInfo(entity networkgraph.Entity) peerInfo {
 	switch entity.Type {
 	case storage.NetworkEntityInfo_DEPLOYMENT:
 		// If the peer is a deployment, just look it up from the baselines
@@ -215,28 +220,32 @@ func (m *manager) lookUpPeerName(entity networkgraph.Entity) string {
 			// - created baseline for B
 			// Returning an empty string with a log
 			log.Warnf("baseline for deployment peer does not exist: %q", entity.ID)
-			return ""
+			return peerInfo{}
 		}
-		return peerBaseline.DeploymentName
+		return peerInfo{name: peerBaseline.DeploymentName}
 	case storage.NetworkEntityInfo_EXTERNAL_SOURCE:
 		// Look it up from datastore since as of now the external source name can change without ID changing.
 		networkEntity, found, err := m.networkEntities.GetEntity(managerCtx, entity.ID)
 		if err != nil {
 			log.Warnf("failed to get network entity for its name: %v", err)
-			return ""
+			return peerInfo{}
 		}
 		if !found {
 			// Unexpected. Network entity can only be captured in a flow when it is in the DS
 			log.Warnf("network entity peer %q not found", entity.ID)
-			return ""
+			return peerInfo{}
 		}
-		return networkEntity.GetInfo().GetExternalSource().GetName()
+		externalSource := networkEntity.GetInfo().GetExternalSource()
+		return peerInfo{
+			name:      externalSource.GetName(),
+			cidrBlock: externalSource.GetCidr(),
+		}
 	case storage.NetworkEntityInfo_INTERNET:
-		return networkgraph.InternetExternalSourceName
+		return peerInfo{name: networkgraph.InternetExternalSourceName}
 	default:
 		// Unsupported type.
 		log.Warnf("unsupported entity type in network baseline: %v", entity)
-		return ""
+		return peerInfo{}
 	}
 }
 
@@ -247,24 +256,25 @@ func (m *manager) processFlowUpdate(flows map[networkgraph.NetworkConnIndicator]
 			continue
 		}
 		if conn.SrcEntity.Type == storage.NetworkEntityInfo_DEPLOYMENT {
-			peerName := m.lookUpPeerName(conn.DstEntity)
-			if peerName != "" {
+			info := m.lookUpPeerInfo(conn.DstEntity)
+			if info.name != "" {
 				m.maybeAddPeer(conn.SrcEntity.ID, &networkbaseline.Peer{
 					IsIngress: false,
 					Entity:    conn.DstEntity,
-					Name:      peerName,
+					Name:      info.name,
 					DstPort:   conn.DstPort,
 					Protocol:  conn.Protocol,
+					CidrBlock: info.cidrBlock,
 				}, modifiedDeploymentIDs)
 			}
 		}
 		if conn.DstEntity.Type == storage.NetworkEntityInfo_DEPLOYMENT {
-			peerName := m.lookUpPeerName(conn.SrcEntity)
-			if peerName != "" {
+			peerInfo := m.lookUpPeerInfo(conn.SrcEntity)
+			if peerInfo.name != "" {
 				m.maybeAddPeer(conn.DstEntity.ID, &networkbaseline.Peer{
 					IsIngress: true,
 					Entity:    conn.SrcEntity,
-					Name:      peerName,
+					Name:      peerInfo.name,
 					DstPort:   conn.DstPort,
 					Protocol:  conn.Protocol,
 				}, modifiedDeploymentIDs)
@@ -430,12 +440,12 @@ func (m *manager) ProcessBaselineStatusUpdate(ctx context.Context, modifyRequest
 	modifiedDeploymentIDs := set.NewStringSet()
 	for _, peerAndStatus := range modifyRequest.GetPeers() {
 		v1Peer := peerAndStatus.GetPeer()
-		peerName := m.lookUpPeerName(
+		info := m.lookUpPeerInfo(
 			networkgraph.Entity{
 				Type: v1Peer.GetEntity().GetType(),
 				ID:   v1Peer.GetEntity().GetId(),
 			})
-		peer := networkbaseline.PeerFromV1Peer(v1Peer, peerName)
+		peer := networkbaseline.PeerFromV1Peer(v1Peer, info.name, info.cidrBlock)
 		_, inBaseline := baseline.BaselinePeers[peer]
 		_, inForbidden := baseline.ForbiddenPeers[peer]
 		switch peerAndStatus.GetStatus() {

--- a/central/networkbaseline/manager/manager_impl.go
+++ b/central/networkbaseline/manager/manager_impl.go
@@ -256,25 +256,25 @@ func (m *manager) processFlowUpdate(flows map[networkgraph.NetworkConnIndicator]
 			continue
 		}
 		if conn.SrcEntity.Type == storage.NetworkEntityInfo_DEPLOYMENT {
-			info := m.lookUpPeerInfo(conn.DstEntity)
-			if info.name != "" {
+			peer := m.lookUpPeerInfo(conn.DstEntity)
+			if peer.name != "" {
 				m.maybeAddPeer(conn.SrcEntity.ID, &networkbaseline.Peer{
 					IsIngress: false,
 					Entity:    conn.DstEntity,
-					Name:      info.name,
+					Name:      peer.name,
 					DstPort:   conn.DstPort,
 					Protocol:  conn.Protocol,
-					CidrBlock: info.cidrBlock,
+					CidrBlock: peer.cidrBlock,
 				}, modifiedDeploymentIDs)
 			}
 		}
 		if conn.DstEntity.Type == storage.NetworkEntityInfo_DEPLOYMENT {
-			peerInfo := m.lookUpPeerInfo(conn.SrcEntity)
-			if peerInfo.name != "" {
+			peer := m.lookUpPeerInfo(conn.SrcEntity)
+			if peer.name != "" {
 				m.maybeAddPeer(conn.DstEntity.ID, &networkbaseline.Peer{
 					IsIngress: true,
 					Entity:    conn.SrcEntity,
-					Name:      peerInfo.name,
+					Name:      peer.name,
 					DstPort:   conn.DstPort,
 					Protocol:  conn.Protocol,
 				}, modifiedDeploymentIDs)

--- a/central/networkbaseline/manager/manager_impl_test.go
+++ b/central/networkbaseline/manager/manager_impl_test.go
@@ -231,7 +231,8 @@ func (suite *ManagerTestSuite) TestFlowsUpdateForOtherEntityTypes() {
 				Id:   extSrcID(10),
 				Desc: &storage.NetworkEntityInfo_ExternalSource_{
 					ExternalSource: &storage.NetworkEntityInfo_ExternalSource{
-						Name: extSrcName(10),
+						Name:   extSrcName(10),
+						Source: &storage.NetworkEntityInfo_ExternalSource_Cidr{Cidr: "11.0.0.0/32"},
 					},
 				},
 			},
@@ -298,7 +299,8 @@ func (suite *ManagerTestSuite) TestFlowsUpdateForOtherEntityTypes() {
 					Id:   extSrcID(10),
 					Desc: &storage.NetworkEntityInfo_ExternalSource_{
 						ExternalSource: &storage.NetworkEntityInfo_ExternalSource{
-							Name: extSrcName(10),
+							Name:   extSrcName(10),
+							Source: &storage.NetworkEntityInfo_ExternalSource_Cidr{Cidr: "11.0.0.0/32"},
 						},
 					},
 				}},

--- a/central/networkbaseline/manager/manager_impl_test.go
+++ b/central/networkbaseline/manager/manager_impl_test.go
@@ -565,7 +565,7 @@ func (suite *ManagerTestSuite) TestDeleteWithExtSrcPeer() {
 		baselineWithPeers(
 			1,
 			depPeer(2, properties(false, 52)),
-			extSrcPeer(3, properties(false, 443)),
+			extSrcPeer(3, "11.0.0.0/32", properties(false, 443)),
 		),
 		baselineWithPeers(2, depPeer(1, properties(true, 52))),
 	)
@@ -573,13 +573,13 @@ func (suite *ManagerTestSuite) TestDeleteWithExtSrcPeer() {
 		baselineWithPeers(
 			1,
 			depPeer(2, properties(false, 52)),
-			extSrcPeer(3, properties(false, 443)),
+			extSrcPeer(3, "11.0.0.0/32", properties(false, 443)),
 		),
 		baselineWithPeers(2, depPeer(1, properties(true, 52))),
 	)
 	// Make sure deleting a deployment does not trigger an error even if we have ext src peer
 	suite.Nil(suite.m.ProcessDeploymentDelete(depID(2)))
-	suite.assertBaselinesAre(baselineWithPeers(1, extSrcPeer(3, properties(false, 443))))
+	suite.assertBaselinesAre(baselineWithPeers(1, extSrcPeer(3, "11.0.0.0/32", properties(false, 443))))
 }
 
 func (suite *ManagerTestSuite) TestValidEntityTypesMatch() {
@@ -881,7 +881,7 @@ func depPeer(id int, properties ...*storage.NetworkBaselineConnectionProperties)
 	}
 }
 
-func extSrcPeer(id int, properties ...*storage.NetworkBaselineConnectionProperties) *storage.NetworkBaselinePeer {
+func extSrcPeer(id int, cidr string, properties ...*storage.NetworkBaselineConnectionProperties) *storage.NetworkBaselinePeer {
 	return &storage.NetworkBaselinePeer{
 		Entity: &storage.NetworkEntity{
 			Info: &storage.NetworkEntityInfo{
@@ -889,7 +889,8 @@ func extSrcPeer(id int, properties ...*storage.NetworkBaselineConnectionProperti
 				Id:   extSrcID(id),
 				Desc: &storage.NetworkEntityInfo_ExternalSource_{
 					ExternalSource: &storage.NetworkEntityInfo_ExternalSource{
-						Name: extSrcName(id),
+						Name:   extSrcName(id),
+						Source: &storage.NetworkEntityInfo_ExternalSource_Cidr{Cidr: cidr},
 					},
 				},
 			}},

--- a/central/networkbaseline/service/service_impl.go
+++ b/central/networkbaseline/service/service_impl.go
@@ -77,7 +77,7 @@ func (s *serviceImpl) GetNetworkBaselineStatusForFlows(
 	return &v1.NetworkBaselineStatusResponse{Statuses: statuses}, nil
 }
 
-// GetNetworkBaseline -- gets the network baseline assocated with the deployment.
+// GetNetworkBaseline gets the network baseline associated with the deployment.
 func (s *serviceImpl) GetNetworkBaseline(
 	ctx context.Context,
 	request *v1.ResourceByID,

--- a/pkg/networkgraph/networkbaseline/peer.go
+++ b/pkg/networkgraph/networkbaseline/peer.go
@@ -47,6 +47,10 @@ type Peer struct {
 	Name      string
 	DstPort   uint32
 	Protocol  storage.L4Protocol
+
+	// CidrBlock is specific to external source peers. This should only be filled when the underlying entity
+	// is an external source. This is needed in order to differentiate baselines that are created to the same
+	// provider/region but for different CIDR blocks. Check (https://github.com/stackrox/stackrox/pull/5194)
 	CidrBlock string
 }
 

--- a/pkg/networkgraph/networkbaseline/peer.go
+++ b/pkg/networkgraph/networkbaseline/peer.go
@@ -11,22 +11,23 @@ import (
 
 var (
 	// EntityTypeToEntityInfoDesc collects the functions to get names from corresponding network entity types
-	EntityTypeToEntityInfoDesc = map[storage.NetworkEntityInfo_Type]func(name string, info *storage.NetworkEntityInfo){
-		storage.NetworkEntityInfo_DEPLOYMENT: func(name string, info *storage.NetworkEntityInfo) {
+	EntityTypeToEntityInfoDesc = map[storage.NetworkEntityInfo_Type]func(name string, info *storage.NetworkEntityInfo, customProperties EntityProperties){
+		storage.NetworkEntityInfo_DEPLOYMENT: func(name string, info *storage.NetworkEntityInfo, _ EntityProperties) {
 			info.Desc = &storage.NetworkEntityInfo_Deployment_{
 				Deployment: &storage.NetworkEntityInfo_Deployment{
 					Name: name,
 				},
 			}
 		},
-		storage.NetworkEntityInfo_EXTERNAL_SOURCE: func(name string, info *storage.NetworkEntityInfo) {
+		storage.NetworkEntityInfo_EXTERNAL_SOURCE: func(name string, info *storage.NetworkEntityInfo, custom EntityProperties) {
 			info.Desc = &storage.NetworkEntityInfo_ExternalSource_{
 				ExternalSource: &storage.NetworkEntityInfo_ExternalSource{
-					Name: name,
+					Name:   name,
+					Source: &storage.NetworkEntityInfo_ExternalSource_Cidr{Cidr: custom.CIDRBlock},
 				},
 			}
 		},
-		storage.NetworkEntityInfo_INTERNET: func(name string, info *storage.NetworkEntityInfo) {
+		storage.NetworkEntityInfo_INTERNET: func(name string, info *storage.NetworkEntityInfo, _ EntityProperties) {
 			// No-op.
 		},
 	}
@@ -46,11 +47,19 @@ type Peer struct {
 	Name      string
 	DstPort   uint32
 	Protocol  storage.L4Protocol
+	CidrBlock string
 }
 
 type entityWithName struct {
 	networkgraph.Entity
 	Name string
+}
+
+// EntityProperties represents the properties of a peer entity for the baseline.
+type EntityProperties struct {
+	// CIDRBlock will only be filled if the peer entity is an External Source.
+	CIDRBlock            string
+	ConnectionProperties []*storage.NetworkBaselineConnectionProperties
 }
 
 // ConvertPeersFromProto converts proto NetworkBaselinePeer to its in memory representation
@@ -66,6 +75,12 @@ func ConvertPeersFromProto(protoPeers []*storage.NetworkBaselinePeer) (map[Peer]
 			return nil, errors.Errorf("unsupported entity type in network baseline: %q", entity.Type)
 		}
 
+		// CIDR block is only set if the peer is of type External Source.
+		var cidr string
+		if entity.Type == storage.NetworkEntityInfo_EXTERNAL_SOURCE {
+			cidr = protoPeer.GetEntity().GetInfo().GetExternalSource().GetCidr()
+		}
+
 		name := nameFn(protoPeer.GetEntity().GetInfo())
 		for _, props := range protoPeer.GetProperties() {
 			out[Peer{
@@ -74,6 +89,7 @@ func ConvertPeersFromProto(protoPeers []*storage.NetworkBaselinePeer) (map[Peer]
 				Name:      name,
 				DstPort:   props.GetPort(),
 				Protocol:  props.GetProtocol(),
+				CidrBlock: cidr,
 			}] = struct{}{}
 		}
 	}
@@ -85,28 +101,34 @@ func ConvertPeersToProto(peerSet map[Peer]struct{}) ([]*storage.NetworkBaselineP
 	if len(peerSet) == 0 {
 		return nil, nil
 	}
-	propertiesByEntity := make(map[entityWithName][]*storage.NetworkBaselineConnectionProperties)
+	propertiesByEntity := make(map[entityWithName]EntityProperties)
 	for peer := range peerSet {
 		entity := entityWithName{
 			Entity: peer.Entity,
 			Name:   peer.Name,
 		}
-		propertiesByEntity[entity] = append(propertiesByEntity[entity], &storage.NetworkBaselineConnectionProperties{
-			Ingress:  peer.IsIngress,
-			Port:     peer.DstPort,
-			Protocol: peer.Protocol,
-		})
+		propertiesByEntity[entity] = EntityProperties{
+			CIDRBlock: peer.CidrBlock,
+			ConnectionProperties: []*storage.NetworkBaselineConnectionProperties{
+				{
+					Ingress:  peer.IsIngress,
+					Port:     peer.DstPort,
+					Protocol: peer.Protocol,
+				},
+			},
+		}
 	}
+
 	out := make([]*storage.NetworkBaselinePeer, 0, len(propertiesByEntity))
 	for entity, properties := range propertiesByEntity {
-		sort.Slice(properties, func(i, j int) bool {
-			if properties[i].Ingress != properties[j].Ingress {
-				return properties[i].Ingress
+		sort.Slice(properties.ConnectionProperties, func(i, j int) bool {
+			if properties.ConnectionProperties[i].Ingress != properties.ConnectionProperties[j].Ingress {
+				return properties.ConnectionProperties[i].Ingress
 			}
-			if properties[i].Protocol != properties[j].Protocol {
-				return properties[i].Protocol < properties[j].Protocol
+			if properties.ConnectionProperties[i].Protocol != properties.ConnectionProperties[j].Protocol {
+				return properties.ConnectionProperties[i].Protocol < properties.ConnectionProperties[j].Protocol
 			}
-			return properties[i].Port < properties[j].Port
+			return properties.ConnectionProperties[i].Port < properties.ConnectionProperties[j].Port
 		})
 
 		// Get corresponding entity proto
@@ -121,10 +143,10 @@ func ConvertPeersToProto(peerSet map[Peer]struct{}) ([]*storage.NetworkBaselineP
 		}
 
 		// Fill desc of info
-		infoDescFn(entity.Name, entityInfo)
+		infoDescFn(entity.Name, entityInfo, EntityProperties{CIDRBlock: properties.CIDRBlock})
 		out = append(out, &storage.NetworkBaselinePeer{
 			Entity:     &storage.NetworkEntity{Info: entityInfo},
-			Properties: properties,
+			Properties: properties.ConnectionProperties,
 		})
 	}
 	sort.Slice(out, func(i, j int) bool {
@@ -134,16 +156,17 @@ func ConvertPeersToProto(peerSet map[Peer]struct{}) ([]*storage.NetworkBaselineP
 }
 
 // PeerFromV1Peer converts peer within v1 request to in-memory representation form
-func PeerFromV1Peer(v1Peer *v1.NetworkBaselineStatusPeer, peerName string) Peer {
+func PeerFromV1Peer(v1Peer *v1.NetworkBaselineStatusPeer, peerName, cidrBlock string) Peer {
 	return Peer{
 		IsIngress: v1Peer.GetIngress(),
 		Entity: networkgraph.Entity{
 			Type: v1Peer.GetEntity().GetType(),
 			ID:   v1Peer.GetEntity().GetId(),
 		},
-		Name:     peerName,
-		DstPort:  v1Peer.GetPort(),
-		Protocol: v1Peer.GetProtocol(),
+		Name:      peerName,
+		DstPort:   v1Peer.GetPort(),
+		Protocol:  v1Peer.GetProtocol(),
+		CidrBlock: cidrBlock,
 	}
 }
 


### PR DESCRIPTION
## Description

Network Baseline info does not show CIDR blocks when the peer is an external source. This PR aims to add that information to the baseline entry, which can be consumed by the FE.

- [x] Figure out how to upgrade from clusters that already have baseline entries without a CIDR block. 

A: It **does** need a migration. I'm working on it on a separate PR that has to be merged before the release. I'm splitting in different PRs because (1) this PR already unblocks the FE for new installations; (2) not having a migration won't crash central, it just won't show the CIDR block for existing baselines (existing behavior); (3) the migration code could be reviewed by people that have more knowledge on the Postgres migration. 

**Update:** here's the PR with the migration: #5252

For more context on the issue, check [this decision doc](https://docs.google.com/document/d/1Tw3mf6dbd_-fwlKwP55xUK7OWVr4fePp8XkzvV2yWxE/edit?usp=sharing).

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] ~~Evaluated and added CHANGELOG entry if required~~ Maybe this will only be needed after the FE implements the change
- [ ] ~~Determined and documented upgrade steps~~ Depends if `4.0` will only have new installations.
- [ ] ~~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~ Probably not needed now either.

## Testing Performed

- [x] Existing unit tests
- [x] E2E Tests
- [x] Check payload contains CIDR block on newly generated baselines

For the example in the ticket, now the response with baselines shows the `CIDR` blocks when the entity is an external source.

![image](https://user-images.githubusercontent.com/6811076/224664192-e90084e6-29bd-4bd4-bee6-1e5ebb550e28.png)
