### PR TITLE
Delete unneeded actions and selectors in apitokens clusterInitBundles integrations

### DIFF
--- a/ui/apps/platform/src/reducers/apitokens.js
+++ b/ui/apps/platform/src/reducers/apitokens.js
@@ -3,22 +3,14 @@ import isEqual from 'lodash/isEqual';
 
 import { createFetchingActionTypes, createFetchingActions } from 'utils/fetchingReduxRoutines';
 
-export const apiTokenFormId = 'api-token-form-id';
-
 export const types = {
     FETCH_API_TOKENS: createFetchingActionTypes('apitokens/FETCH_API_TOKENS'),
-    GENERATE_API_TOKEN: createFetchingActionTypes('apitokens/GENERATE_API_TOKEN'),
     REVOKE_API_TOKENS: 'apitokens/REVOKE_API_TOKENS',
-    START_TOKEN_GENERATION_WIZARD: 'apitokens/START_TOKEN_GENERATION_WIZARD',
-    CLOSE_TOKEN_GENERATION_WIZARD: 'apitokens/CLOSE_TOKEN_GENERATION_WIZARD',
 };
 
 export const actions = {
     fetchAPITokens: createFetchingActions(types.FETCH_API_TOKENS),
-    generateAPIToken: createFetchingActions(types.GENERATE_API_TOKEN),
     revokeAPITokens: (ids) => ({ type: types.REVOKE_API_TOKENS, ids }),
-    startTokenGenerationWizard: () => ({ type: types.START_TOKEN_GENERATION_WIZARD }),
-    closeTokenGenerationWizard: () => ({ type: types.CLOSE_TOKEN_GENERATION_WIZARD }),
 };
 
 const apiTokens = (state = [], action) => {
@@ -28,36 +20,14 @@ const apiTokens = (state = [], action) => {
     return state;
 };
 
-const tokenGenerationWizard = (state = null, { type, response }) => {
-    switch (type) {
-        case types.START_TOKEN_GENERATION_WIZARD:
-            return { token: '', metadata: null };
-        case types.CLOSE_TOKEN_GENERATION_WIZARD:
-            return null;
-        case types.GENERATE_API_TOKEN.SUCCESS:
-            return { token: response.token, metadata: response.metadata };
-        default:
-            return state;
-    }
-};
-
 const reducer = combineReducers({
     apiTokens,
-    tokenGenerationWizard,
 });
 
 const getAPITokens = (state) => state.apiTokens;
-const tokenGenerationWizardOpen = (state) => !!state.tokenGenerationWizard;
-const getCurrentGeneratedToken = (state) =>
-    state.tokenGenerationWizard ? state.tokenGenerationWizard.token : null;
-const getCurrentGeneratedTokenMetadata = (state) =>
-    state.tokenGenerationWizard ? state.tokenGenerationWizard.metadata : null;
 
 export const selectors = {
     getAPITokens,
-    tokenGenerationWizardOpen,
-    getCurrentGeneratedToken,
-    getCurrentGeneratedTokenMetadata,
 };
 
 export default reducer;

--- a/ui/apps/platform/src/reducers/clusterInitBundles.js
+++ b/ui/apps/platform/src/reducers/clusterInitBundles.js
@@ -3,34 +3,14 @@ import isEqual from 'lodash/isEqual';
 
 import { createFetchingActionTypes, createFetchingActions } from 'utils/fetchingReduxRoutines';
 
-export const clusterInitBundleFormId = 'cluster-init-bundle-form-id';
-
 export const types = {
     FETCH_CLUSTER_INIT_BUNDLES: createFetchingActionTypes(
         'clusterInitBundles/FETCH_CLUSTER_INIT_BUNDLES'
     ),
-    GENERATE_CLUSTER_INIT_BUNDLE: createFetchingActionTypes(
-        'clusterInitBundles/GENERATE_CLUSTER_INIT_BUNDLE'
-    ),
-    // Note: REVOKE_CLUSTER_INIT_BUNDLES does not appear in reducers
-    //       because FETCH_CLUSTER_INIT_BUNDLES is side-effect of saga, if revoke is successful.
-    REVOKE_CLUSTER_INIT_BUNDLES: 'clusterInitBundles/REVOKE_CLUSTER_INIT_BUNDLES',
-    START_CLUSTER_INIT_BUNDLE_GENERATION_WIZARD:
-        'clusterInitBundles/START_CLUSTER_INIT_BUNDLE_GENERATION_WIZARD',
-    CLOSE_CLUSTER_INIT_BUNDLE_GENERATION_WIZARD:
-        'clusterInitBundles/CLOSE_CLUSTER_INIT_BUNDLE_GENERATION_WIZARD',
 };
 
 export const actions = {
     fetchClusterInitBundles: createFetchingActions(types.FETCH_CLUSTER_INIT_BUNDLES),
-    generateClusterInitBundle: createFetchingActions(types.GENERATE_CLUSTER_INIT_BUNDLE),
-    revokeClusterInitBundles: (ids) => ({ type: types.REVOKE_CLUSTER_INIT_BUNDLES, ids }),
-    startClusterInitBundleGenerationWizard: () => ({
-        type: types.START_CLUSTER_INIT_BUNDLE_GENERATION_WIZARD,
-    }),
-    closeClusterInitBundleGenerationWizard: () => ({
-        type: types.CLOSE_CLUSTER_INIT_BUNDLE_GENERATION_WIZARD,
-    }),
 };
 
 const clusterInitBundles = (state = [], action) => {
@@ -40,49 +20,14 @@ const clusterInitBundles = (state = [], action) => {
     return state;
 };
 
-const clusterInitBundleGenerationWizard = (state = null, { type, response }) => {
-    switch (type) {
-        case types.START_CLUSTER_INIT_BUNDLE_GENERATION_WIZARD:
-            return { clusterInitBundle: '', helmValuesBundle: null, kubectlBundle: null };
-        case types.CLOSE_CLUSTER_INIT_BUNDLE_GENERATION_WIZARD:
-            return null;
-        case types.GENERATE_CLUSTER_INIT_BUNDLE.SUCCESS:
-            return {
-                clusterInitBundle: response.meta,
-                helmValuesBundle: response.helmValuesBundle,
-                kubectlBundle: response.kubectlBundle,
-            };
-        default:
-            return state;
-    }
-};
-
 const reducer = combineReducers({
     clusterInitBundles,
-    clusterInitBundleGenerationWizard,
 });
 
 const getClusterInitBundles = (state) => state.clusterInitBundles;
-const clusterInitBundleGenerationWizardOpen = (state) => !!state.clusterInitBundleGenerationWizard;
-const getCurrentGeneratedClusterInitBundle = (state) =>
-    state.clusterInitBundleGenerationWizard
-        ? state.clusterInitBundleGenerationWizard.clusterInitBundle
-        : null;
-const getCurrentGeneratedHelmValuesBundle = (state) =>
-    state.clusterInitBundleGenerationWizard
-        ? state.clusterInitBundleGenerationWizard.helmValuesBundle
-        : null;
-const getCurrentGeneratedKubectlBundle = (state) =>
-    state.clusterInitBundleGenerationWizard
-        ? state.clusterInitBundleGenerationWizard.kubectlBundle
-        : null;
 
 export const selectors = {
     getClusterInitBundles,
-    clusterInitBundleGenerationWizardOpen,
-    getCurrentGeneratedClusterInitBundle,
-    getCurrentGeneratedHelmValuesBundle,
-    getCurrentGeneratedKubectlBundle,
 };
 
 export default reducer;

--- a/ui/apps/platform/src/reducers/integrations.js
+++ b/ui/apps/platform/src/reducers/integrations.js
@@ -15,10 +15,7 @@ export const types = {
     FETCH_SIGNATURE_INTEGRATIONS: createFetchingActionTypes(
         'signatureIntegrations/FETCH_SIGNATURE_INTEGRATIONS'
     ),
-    TEST_INTEGRATION: 'integrations/TEST_INTEGRATION',
     DELETE_INTEGRATIONS: 'integrations/DELETE_INTEGRATIONS',
-    SAVE_INTEGRATION: createFetchingActionTypes('integrations/SAVE_INTEGRATION'),
-    SET_CREATE_STATE: 'integrations/SET_CREATE_STATE',
 };
 
 // Actions
@@ -28,12 +25,6 @@ export const actions = {
     fetchBackups: createFetchingActions(types.FETCH_BACKUPS),
     fetchImageIntegrations: createFetchingActions(types.FETCH_IMAGE_INTEGRATIONS),
     fetchSignatureIntegrations: createFetchingActions(types.FETCH_SIGNATURE_INTEGRATIONS),
-    testIntegration: (source, integration, options) => ({
-        type: types.TEST_INTEGRATION,
-        source,
-        integration,
-        options,
-    }),
     deleteIntegrations: (source, sourceType, ids) => ({
         type: types.DELETE_INTEGRATIONS,
         source,
@@ -43,11 +34,6 @@ export const actions = {
     triggerBackup: (id) => ({
         type: types.TRIGGER_BACKUP,
         id,
-    }),
-    saveIntegration: createFetchingActions(types.SAVE_INTEGRATION),
-    setCreateState: (state) => ({
-        type: types.SET_CREATE_STATE,
-        state,
     }),
 };
 
@@ -83,19 +69,11 @@ const signatureIntegrations = (state = [], action) => {
     return state;
 };
 
-const isCreating = (state = false, action) => {
-    if (action.type === types.SET_CREATE_STATE) {
-        return action.state;
-    }
-    return state;
-};
-
 const reducer = combineReducers({
     backups,
     notifiers,
     imageIntegrations,
     signatureIntegrations,
-    isCreating,
 });
 
 // Selectors
@@ -103,14 +81,12 @@ const reducer = combineReducers({
 const getBackups = (state) => state.backups;
 const getNotifiers = (state) => state.notifiers;
 const getImageIntegrations = (state) => state.imageIntegrations;
-const getCreationState = (state) => state.isCreating;
 const getSignatureIntegrations = (state) => state.signatureIntegrations;
 
 export const selectors = {
     getBackups,
     getNotifiers,
     getImageIntegrations,
-    getCreationState,
     getSignatureIntegrations,
 };
 

--- a/ui/apps/platform/src/sagas/apiTokenSagas.js
+++ b/ui/apps/platform/src/sagas/apiTokenSagas.js
@@ -1,12 +1,10 @@
-import { all, take, takeLatest, call, fork, put, select } from 'redux-saga/effects';
+import { all, take, takeLatest, call, fork, put } from 'redux-saga/effects';
 
 import { integrationsPath } from 'routePaths';
 import * as service from 'services/APITokensService';
-import { actions, types, apiTokenFormId } from 'reducers/apitokens';
-import { actions as roleActions } from 'reducers/roles';
+import { actions, types } from 'reducers/apitokens';
 import { actions as notificationActions } from 'reducers/notifications';
 import { takeEveryNewlyMatchedLocation } from 'utils/sagaEffects';
-import { getFormValues } from 'redux-form';
 
 function* getAPITokens() {
     try {
@@ -14,22 +12,6 @@ function* getAPITokens() {
         yield put(actions.fetchAPITokens.success(result.response));
     } catch (error) {
         yield put(actions.fetchAPITokens.failure(error));
-    }
-}
-
-function* generateAPIToken() {
-    try {
-        const formData = yield select(getFormValues(apiTokenFormId));
-        // TODO: Remove this once we allow assigning multiple roles to a token.
-        const modifiedFormData = { ...formData, roles: [formData.role], role: null };
-        const result = yield call(service.generateAPIToken, modifiedFormData);
-        yield put(actions.generateAPIToken.success(result.response));
-    } catch (error) {
-        if (error.response) {
-            yield put(notificationActions.addNotification(error.response.data.error));
-            yield put(notificationActions.removeOldestNotification());
-        }
-        yield put(actions.generateAPIToken.failure(error));
     }
 }
 
@@ -57,33 +39,15 @@ function* watchLocation() {
 
 function* watchFetchRequest() {
     while (true) {
-        yield take([types.FETCH_API_TOKENS.REQUEST, types.GENERATE_API_TOKEN.SUCCESS]);
+        yield take([types.FETCH_API_TOKENS.REQUEST]);
         yield fork(getAPITokens);
     }
-}
-
-function* watchGenerateRequest() {
-    yield takeLatest(types.GENERATE_API_TOKEN.REQUEST, generateAPIToken);
 }
 
 function* watchRevokeRequest() {
     yield takeLatest(types.REVOKE_API_TOKENS, revokeAPITokens);
 }
 
-function* requestFetchRoles() {
-    yield put(roleActions.fetchRoles.request());
-}
-
-function* watchModalOpen() {
-    yield takeLatest(types.START_TOKEN_GENERATION_WIZARD, requestFetchRoles);
-}
-
 export default function* integrations() {
-    yield all([
-        fork(watchLocation),
-        fork(watchFetchRequest),
-        fork(watchGenerateRequest),
-        fork(watchRevokeRequest),
-        fork(watchModalOpen),
-    ]);
+    yield all([fork(watchLocation), fork(watchFetchRequest), fork(watchRevokeRequest)]);
 }

--- a/ui/apps/platform/src/sagas/clusterInitBundleSagas.js
+++ b/ui/apps/platform/src/sagas/clusterInitBundleSagas.js
@@ -1,12 +1,9 @@
-import { all, take, takeLatest, call, fork, put, select } from 'redux-saga/effects';
+import { all, take, call, fork, put } from 'redux-saga/effects';
 
 import { integrationsPath } from 'routePaths';
 import * as service from 'services/ClustersService';
-import { actions, types, clusterInitBundleFormId } from 'reducers/clusterInitBundles';
-import { actions as roleActions } from 'reducers/roles';
-import { actions as notificationActions } from 'reducers/notifications';
+import { actions, types } from 'reducers/clusterInitBundles';
 import { takeEveryNewlyMatchedLocation } from 'utils/sagaEffects';
-import { getFormValues } from 'redux-form';
 
 function* getClusterInitBundles() {
     try {
@@ -17,51 +14,17 @@ function* getClusterInitBundles() {
     }
 }
 
-function* generateClusterInitBundle() {
-    try {
-        const formData = yield select(getFormValues(clusterInitBundleFormId));
-        const result = yield call(service.generateClusterInitBundle, formData);
-        yield put(actions.generateClusterInitBundle.success(result.response));
-    } catch (error) {
-        if (error.response) {
-            yield put(notificationActions.addNotification(error.response.data.error));
-            yield put(notificationActions.removeOldestNotification());
-        }
-        yield put(actions.generateClusterInitBundle.failure(error));
-    }
-}
-
 function* watchLocation() {
     yield takeEveryNewlyMatchedLocation(integrationsPath, getClusterInitBundles);
 }
 
 function* watchFetchRequest() {
     while (true) {
-        yield take([
-            types.FETCH_CLUSTER_INIT_BUNDLES.REQUEST,
-            types.GENERATE_CLUSTER_INIT_BUNDLE.SUCCESS,
-        ]);
+        yield take([types.FETCH_CLUSTER_INIT_BUNDLES.REQUEST]);
         yield fork(getClusterInitBundles);
     }
 }
 
-function* watchGenerateRequest() {
-    yield takeLatest(types.GENERATE_CLUSTER_INIT_BUNDLE.REQUEST, generateClusterInitBundle);
-}
-
-function* requestFetchRoles() {
-    yield put(roleActions.fetchRoles.request());
-}
-
-function* watchModalOpen() {
-    yield takeLatest(types.START_CLUSTER_INIT_BUNDLE_GENERATION_WIZARD, requestFetchRoles);
-}
-
 export default function* integrations() {
-    yield all([
-        fork(watchLocation),
-        fork(watchFetchRequest),
-        fork(watchGenerateRequest),
-        fork(watchModalOpen),
-    ]);
+    yield all([fork(watchLocation), fork(watchFetchRequest)]);
 }


### PR DESCRIPTION
## Description

Another warm up exercise after returning from week away from code. The following analysis from November 2022.

Found while researching minimum unneeded code in #3759

One more step toward deleting sagas for integrations.

### Analysis of reducers/apitokens.js

Find dispatch of actions:
* fetchAPITokens: useFetchIntegrations dispatches action
* generateAPIToken: 0 results for `request` action
* revokeAPITokens: IntegrationsListPage dispatches action
* startTokenGenerationWizard: 0 results
* closeTokenGenerationWizard: 0 results

Find reference to selectors:
* getAPITokens: useIntegrations and IntegrationTilesPage
* tokenGenerationWizardOpen: 0 results
* getCurrentGeneratedToken: 0 results
* getCurrentGeneratedTokenMetadata: 0 results

### Analysis of reducers/clusterInitBundles.js

Find dispatch of actions:
* fetchClusterInitBundles: useFetchIntegrations and IntegrationsListPage dispatch action
* generateClusterInitBundle: 0 results for `request` action
* revokeClusterInitBundles: 0 results
* startClusterInitBundleGenerationWizard: 0 results
* closeClusterInitBundleGenerationWizard: 0 results

Find reference to selectors
* getClusterInitBundles: useIntegrations and IntegrationTilesPage
* clusterInitBundleGenerationWizardOpen: 0 results
* getCurrentGeneratedClusterInitBundle: 0 results
* getCurrentGeneratedHelmValuesBundle: 0 results
* getCurrentGeneratedKubectlBundle: 0 results

### Analysis of reducers/integrations

Find dispatch of actions:
* fetchNotifiers: useFetchIntegrations
* fetchBackups: useFetchIntegrations
* fetchImageIntegrations: useFetchIntegrations
* fetchSignatureIntegrations: useFetchIntegrations
* testIntegration: 0 results
* deleteIntegrations: IntegrationsListPage
* triggerBackup: IntegrationsListPage
* saveIntegration: 0 results
* setCreateState: 0 results

Find reference to selectors:
* getBackups: useIntegrations and IntegrationTilesPage
* getNotifiers: useIntegrations and IntegrationTilesPage plus 5 in Network container
* getImageIntegrations: useIntegrations and IntegrationTilesPage
* getCreationState: 0 results
* getSignatureIntegrations: useIntegrations and IntegrationTilesPage

### Interpretation for reducers

Integrations container code:

1. does dispatch fetch actions.

2. does dispatch revoke action for API Token

3. does **not** dispatch revoke action for Cluster Init Bundle:
    * `DeleteClusterInitBundleConfirmationModal` component calls the service function.

4. does **not** dispatch generate actions:
    * `useIntegrationActions` hook calls the service functions

5. does **not** dispatch `testIntegration` nor `saveIntegration` actions
    * `useIntegrationActions` hook calls the service functions

6. does **not** dispatch any Wizard or Create actions

7. does refer to get selectors

8. does **not** refer to any Wizard or Current or CreateState selectors

### Interpretation for sagas/apiTokenSagas.js

1. Delete `generateAPIToken` and `watchGenerateRequest` because:
    * no dispatch for action
    * no results for form id: api-token-form-id

2. Delete `types.GENERATE_API_TOKEN.SUCCESS` for `getAPITokens` because:
    * no dispatch for action

3. Delete `watchModalOpen` because:
    * no dispatch for action

### Interpretation for sagas/clusterInitBundleSagas.js

1. Delete `generateClusterInitBundle` and `watchGenerateRequest` because:
    * no dispatch for action
    * no results for form id: cluster-init-bundle-form-id

2. Delete `types.GENERATE_CLUSTER_INIT_BUNDLE` for `getClusterInitBundles` because:
    * no dispatch for action

3. Delete `requestFetchRoles` and `watchModalOpen` because:
    * no dispatch for action, especially because Cluster Init Bundle does not have role

### Interpretation for sagas/integrationSagas.js

Everything is needed.

### Analysis of integration tests

* apiTokens.test.js: generate, refetch, revoke
* clusterInitBundles.test.js: generate, refetch, revoke
* externalBackups.test.js: save and refetch and delete and test (with mock response)
* general.test.js: fetch
* imageIntegrations.test.js: save (with mock response) and refetch and delete and test
* notifiers.test.js: save (with mock response for Jira) and refetch and delete and test (with mock response)
* signatureIntegrations.test.js: save, refetch, delete

### Residue

1. Replace `revokeAPIToken` action with service function call in parallel with `revokeClusterInitBundle` within Integrations container code.
2. Replace apiTokenSagas and clusterInitBundleSagas with dispatch of get actions from Integrations container code. That is, delete sagas, but keep reducers (see step 4).
3. Explore possible solutions to `useFetchIntegrations` behavior to request both apitokens and clusterinitbundles when only one or the other changed.
4. Replace in integrationsSagas everything except get for classic Network Graph
    * dispatch get actions (or thunks) from Integrations container code
    * replace delete and trigger actions with service function calls similar to save and test
5. Too bad, so sad: to replace get actions and reducer store with service function calls and component state within Integrations probably depends on routing change from unified page of all integration types at /main/integrations with tabs for types and separate pages analogous to Access Control.


## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

1. `yarn lint` in ui

2. `yarn build` in ui

3. `wc build/static/js/*.js` in ui
    * branch - master: -6381 = 11678027 - 11684348 because webpack does not know that code is obsolete

4. `yarn cypress-open` in ui/apps/platform
    * apitokens.test.js
    * clusterInitBundles.test.js
    * externalBackups.test.js
    * general.test.js
    * imageIntegrations.test.js
    * notifiers.test.js
    * signatureIntegrations.test.js