### PR TITLE
Fix handling empty string matches

### DIFF
--- a/pkg/search/parser.go
+++ b/pkg/search/parser.go
@@ -225,7 +225,7 @@ forloop:
 			trimmedValue = strings.ToLower(trimmedValue[len(RegexPrefix):])
 			queryModifiers = append(queryModifiers, Regex)
 			break forloop // Once we see that it's a regex, we don't check for special-characters in the rest of the string.
-		case strings.HasPrefix(trimmedValue, EqualityPrefixSuffix) && strings.HasSuffix(trimmedValue, EqualityPrefixSuffix) && len(trimmedValue) > 2*len(EqualityPrefixSuffix):
+		case strings.HasPrefix(trimmedValue, EqualityPrefixSuffix) && strings.HasSuffix(trimmedValue, EqualityPrefixSuffix) && len(trimmedValue) >= 2*len(EqualityPrefixSuffix):
 			trimmedValue = trimmedValue[len(EqualityPrefixSuffix) : len(trimmedValue)-len(EqualityPrefixSuffix)]
 			queryModifiers = append(queryModifiers, Equality)
 			break forloop // Once it's within quotes, we take the value inside as is, and don't try to extract modifiers.

--- a/pkg/search/parser_test.go
+++ b/pkg/search/parser_test.go
@@ -124,3 +124,45 @@ func TestParsePairs(t *testing.T) {
 		})
 	}
 }
+
+func TestValueAndModifierFromString(t *testing.T) {
+	cases := []struct {
+		value            string
+		expectedValue    string
+		expectedModifier []QueryModifier
+	}{
+		{
+			value:            "test",
+			expectedValue:    "test",
+			expectedModifier: nil,
+		},
+		{
+			value:            "\"test\"",
+			expectedValue:    "test",
+			expectedModifier: []QueryModifier{Equality},
+		},
+		{
+			value:            "\"\"",
+			expectedValue:    "",
+			expectedModifier: []QueryModifier{Equality},
+		},
+		{
+			value:            "\"",
+			expectedValue:    "\"",
+			expectedModifier: nil,
+		},
+		{
+			value:            "\"test",
+			expectedValue:    "\"test",
+			expectedModifier: nil,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.value, func(t *testing.T) {
+			value, modifier := GetValueAndModifiersFromString(c.value)
+			assert.Equal(t, c.expectedValue, value)
+			assert.Equal(t, c.expectedModifier, modifier)
+		})
+	}
+}

--- a/pkg/search/postgres/query/string_query.go
+++ b/pkg/search/postgres/query/string_query.go
@@ -1,7 +1,6 @@
 package pgsearch
 
 import (
-	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -19,10 +18,6 @@ func newStringQuery(ctx *queryAndFieldContext) (*QueryEntry, error) {
 }
 
 func newStringQueryWhereClause(columnName string, value string, queryModifiers ...pkgSearch.QueryModifier) (WhereClause, error) {
-	if len(value) == 0 {
-		return WhereClause{}, errors.New("value in search query cannot be empty")
-	}
-
 	if len(queryModifiers) == 0 {
 		return WhereClause{
 			Query:  fmt.Sprintf("%s ilike $$", columnName),

--- a/pkg/search/postgres/query/string_query_test.go
+++ b/pkg/search/postgres/query/string_query_test.go
@@ -1,0 +1,38 @@
+package pgsearch
+
+import (
+	"testing"
+
+	pkgSearch "github.com/stackrox/rox/pkg/search"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStringQuery(t *testing.T) {
+	const colName = "blah"
+	cases := []struct {
+		value               string
+		expectedWhereClause string
+		expectedValues      []interface{}
+		expectErr           bool
+	}{
+		{value: "test", expectedWhereClause: "blah = $$", expectedValues: []interface{}{"test"}},
+		{value: "", expectedWhereClause: "blah = $$", expectedValues: []interface{}{""}},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.value, func(t *testing.T) {
+			actual, err := newStringQuery(&queryAndFieldContext{
+				qualifiedColumnName: colName,
+				value:               testCase.value,
+				queryModifiers:      []pkgSearch.QueryModifier{pkgSearch.Equality},
+			})
+			if testCase.expectErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, testCase.expectedWhereClause, actual.Where.Query)
+			assert.Equal(t, testCase.expectedValues, actual.Where.Values)
+		})
+	}
+}


### PR DESCRIPTION
## Description

Trimming values and building new string query do not handle empty strings correctly.

The first one is missing out to extract it out of double quotes due to the length condition (an empty string is `""`, which is exactly the same lenght as 2 * `"`, where the `"` is EqualityPrefixSuffix). This leads to an empty string being represented as `\"\"` along the way, producing incorrect search results.

The second one assumes that an empty string is something incorrect, although it's totally fine to search for values equal empty string.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] Evaluated and added CHANGELOG entry if required
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

Local testing via running a unit-test with an empty string search query.