### PR TITLE
ROX-15886: Skip UI e2e tests that are not relevant for OpenShift

### DIFF
--- a/ui/apps/platform/cypress/helpers/features.js
+++ b/ui/apps/platform/cypress/helpers/features.js
@@ -9,3 +9,7 @@ export default (flag, desiredValue) => {
 export function hasFeatureFlag(flag) {
     return Cypress.env(flag) || false;
 }
+
+export function hasOrchestratorFlavor(value) {
+    return Cypress.env('ORCHESTRATOR_FLAVOR') === value;
+}

--- a/ui/apps/platform/cypress/helpers/features.js
+++ b/ui/apps/platform/cypress/helpers/features.js
@@ -1,8 +1,3 @@
-export default (flag, desiredValue) => {
-    const flagToCheck = Cypress.env(flag) || false;
-    return flagToCheck === desiredValue;
-};
-
 /*
  * Return whether or not the testing environment has a feature flag.
  */

--- a/ui/apps/platform/cypress/integration/vulnmanagement/clusterCves.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/clusterCves.test.js
@@ -1,6 +1,6 @@
 import { selectors } from '../../constants/VulnManagementPage';
 import withAuth from '../../helpers/basicAuth';
-import { hasFeatureFlag } from '../../helpers/features';
+import { hasFeatureFlag, hasOrchestratorFlavor } from '../../helpers/features';
 import {
     assertSortedItems,
     callbackForPairOfAscendingNumberValuesFromElements,
@@ -42,7 +42,11 @@ describe('Vulnerability Management Cluster (Platform) CVEs', () => {
         ]);
     });
 
-    it('should sort the CVSS Score column', () => {
+    it('should sort the CVSS Score column', function () {
+        if (hasOrchestratorFlavor('openshift')) {
+            this.skip();
+        }
+
         visitVulnerabilityManagementEntities(entitiesKey);
 
         const thSelector = '.rt-th:contains("CVSS Score")';
@@ -75,7 +79,11 @@ describe('Vulnerability Management Cluster (Platform) CVEs', () => {
 
     // Cluster (Platform) CVEs does not yet have Severity column.
 
-    it('should display vulnerability descriptions', () => {
+    it('should display vulnerability descriptions', function () {
+        if (hasOrchestratorFlavor('openshift')) {
+            this.skip();
+        }
+
         visitVulnerabilityManagementEntities(entitiesKey);
 
         // Balance positive and negative assertions.
@@ -90,7 +98,11 @@ describe('Vulnerability Management Cluster (Platform) CVEs', () => {
 
     // Some tests might fail in local deployment.
 
-    it('should display links for clusters', () => {
+    it('should display links for clusters', function () {
+        if (hasOrchestratorFlavor('openshift')) {
+            this.skip();
+        }
+
         verifySecondaryEntities(entitiesKey, 'clusters', 9, /^\d+ clusters?$/);
     });
 });

--- a/ui/apps/platform/cypress/integration/vulnmanagement/clusters.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/clusters.test.js
@@ -1,5 +1,5 @@
 import withAuth from '../../helpers/basicAuth';
-import { hasFeatureFlag } from '../../helpers/features';
+import { hasFeatureFlag, hasOrchestratorFlavor } from '../../helpers/features';
 import {
     assertSortedItems,
     callbackForPairOfAscendingNumberValuesFromElements,
@@ -113,7 +113,11 @@ describe('Vulnerability Management Clusters', () => {
         );
     });
 
-    it('should display links for all node CVEs', () => {
+    it('should display links for all node CVEs', function () {
+        if (hasOrchestratorFlavor('openshift')) {
+            this.skip();
+        }
+
         verifySecondaryEntities(
             entitiesKey,
             'node-cves',
@@ -123,7 +127,11 @@ describe('Vulnerability Management Clusters', () => {
         );
     });
 
-    it('should display links for all cluster CVEs', () => {
+    it('should display links for all cluster CVEs', function () {
+        if (hasOrchestratorFlavor('openshift')) {
+            this.skip();
+        }
+
         verifySecondaryEntities(
             entitiesKey,
             'cluster-cves',

--- a/ui/apps/platform/cypress/integration/vulnmanagement/clusters.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/clusters.test.js
@@ -103,7 +103,11 @@ describe('Vulnerability Management Clusters', () => {
         );
     });
 
-    it('should display links for fixable image CVEs', () => {
+    it('should display links for fixable image CVEs', function () {
+        if (hasOrchestratorFlavor('openshift')) {
+            this.skip();
+        }
+
         verifyFilteredSecondaryEntitiesLink(
             entitiesKey,
             'image-cves',

--- a/ui/apps/platform/cypress/integration/vulnmanagement/deployments.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/deployments.test.js
@@ -1,4 +1,4 @@
-import { hasFeatureFlag } from '../../helpers/features';
+import { hasFeatureFlag, hasOrchestratorFlavor } from '../../helpers/features';
 import withAuth from '../../helpers/basicAuth';
 import {
     assertSortedItems,
@@ -93,7 +93,11 @@ describe('Vulnerability Management Deployments', () => {
         );
     });
 
-    it('should display links for fixable image CVEs', () => {
+    it('should display links for fixable image CVEs', function () {
+        if (hasOrchestratorFlavor('openshift')) {
+            this.skip();
+        }
+
         verifyFilteredSecondaryEntitiesLink(
             entitiesKey,
             'image-cves',

--- a/ui/apps/platform/cypress/integration/vulnmanagement/entitypages.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/entitypages.test.js
@@ -7,14 +7,18 @@ import {
     interactAndWaitForVulnerabilityManagementSecondaryEntities,
     visitVulnerabilityManagementEntities,
 } from '../../helpers/vulnmanagement/entities';
-import { hasFeatureFlag } from '../../helpers/features';
+import { hasFeatureFlag, hasOrchestratorFlavor } from '../../helpers/features';
 
 describe('Entities single views', () => {
     withAuth();
 
     // Some tests might fail in local deployment.
 
-    it('related entities tile links should unset search params upon navigation', () => {
+    it('related entities tile links should unset search params upon navigation', function () {
+        if (hasOrchestratorFlavor('openshift')) {
+            this.skip();
+        }
+
         const entitiesKey1 = 'clusters';
         const usingVMUpdates = hasFeatureFlag('ROX_POSTGRES_DATASTORE');
 
@@ -50,7 +54,11 @@ describe('Entities single views', () => {
             });
     });
 
-    it('related entities table header should not say "0 entities" or have "page 0 of 0" if there are rows in the table', () => {
+    it('related entities table header should not say "0 entities" or have "page 0 of 0" if there are rows in the table', function () {
+        if (hasOrchestratorFlavor('openshift')) {
+            this.skip();
+        }
+
         const entitiesKey1 = 'policies';
         const entitiesKey2 = 'deployments';
         visitVulnerabilityManagementEntities(entitiesKey1);
@@ -84,7 +92,11 @@ describe('Entities single views', () => {
         });
     });
 
-    it('should scope deployment data based on selected policy from table row click', () => {
+    it('should scope deployment data based on selected policy from table row click', function () {
+        if (hasOrchestratorFlavor('openshift')) {
+            this.skip();
+        }
+
         const entitiesKey1 = 'policies';
         const entitiesKey2 = 'deployments';
         // policy -> related deployments list should scope policy status column by the policy x deployment row
@@ -129,7 +141,11 @@ describe('Entities single views', () => {
             });
     });
 
-    it('should scope deployment data based on selected policy from table count link click', () => {
+    it('should scope deployment data based on selected policy from table count link click', function () {
+        if (hasOrchestratorFlavor('openshift')) {
+            this.skip();
+        }
+
         const entitiesKey1 = 'policies';
         const entitiesKey2 = 'deployments';
         visitVulnerabilityManagementEntities(entitiesKey1);
@@ -149,7 +165,11 @@ describe('Entities single views', () => {
         );
     });
 
-    it('should scope deployment data based on selected policy from entity page tab sublist', () => {
+    it('should scope deployment data based on selected policy from entity page tab sublist', function () {
+        if (hasOrchestratorFlavor('openshift')) {
+            this.skip();
+        }
+
         const entitiesKey1 = 'policies';
         const entitiesKey2 = 'deployments';
         visitVulnerabilityManagementEntities(entitiesKey1);
@@ -249,7 +269,11 @@ describe('Entities single views', () => {
             });
     });
 
-    it('should not filter cluster entity page regardless of entity context', () => {
+    it('should not filter cluster entity page regardless of entity context', function () {
+        if (hasOrchestratorFlavor('openshift')) {
+            this.skip();
+        }
+
         const entitiesKey = 'namespaces';
         visitVulnerabilityManagementEntities(entitiesKey);
 

--- a/ui/apps/platform/cypress/integration/vulnmanagement/imageComponents.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/imageComponents.test.js
@@ -1,5 +1,5 @@
 import withAuth from '../../helpers/basicAuth';
-import { hasFeatureFlag } from '../../helpers/features';
+import { hasFeatureFlag, hasOrchestratorFlavor } from '../../helpers/features';
 import {
     assertSortedItems,
     callbackForPairOfAscendingNumberValuesFromElements,
@@ -134,7 +134,11 @@ describe('Vulnerability Management Image Components', () => {
         );
     });
 
-    it('should display links for fixable image CVEs', () => {
+    it('should display links for fixable image CVEs', function () {
+        if (hasOrchestratorFlavor('openshift')) {
+            this.skip();
+        }
+
         verifyFilteredSecondaryEntitiesLink(
             entitiesKey,
             'image-cves',

--- a/ui/apps/platform/cypress/integration/vulnmanagement/images.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/images.test.js
@@ -1,6 +1,6 @@
 import { selectors } from '../../constants/VulnManagementPage';
 import withAuth from '../../helpers/basicAuth';
-import { hasFeatureFlag } from '../../helpers/features';
+import { hasFeatureFlag, hasOrchestratorFlavor } from '../../helpers/features';
 import {
     assertSortedItems,
     callbackForPairOfAscendingNumberValuesFromElements,
@@ -130,7 +130,11 @@ describe('Vulnerability Management Images', () => {
         );
     });
 
-    it('should display links for fixable image CVEs and also Risk Acceptance tabs', () => {
+    it('should display links for fixable image CVEs and also Risk Acceptance tabs', function () {
+        if (hasOrchestratorFlavor('openshift')) {
+            this.skip();
+        }
+
         verifyFixableCVEsLinkAndRiskAcceptanceTabs(
             entitiesKey,
             'image-cves',

--- a/ui/apps/platform/cypress/integration/vulnmanagement/namespaces.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/namespaces.test.js
@@ -1,5 +1,5 @@
 import withAuth from '../../helpers/basicAuth';
-import { hasFeatureFlag } from '../../helpers/features';
+import { hasFeatureFlag, hasOrchestratorFlavor } from '../../helpers/features';
 import {
     assertSortedItems,
     callbackForPairOfAscendingNumberValuesFromElements,
@@ -93,7 +93,11 @@ describe('Vulnerability Management Namespaces', () => {
         );
     });
 
-    it('should display links for fixable image CVEs', () => {
+    it('should display links for fixable image CVEs', function () {
+        if (hasOrchestratorFlavor('openshift')) {
+            this.skip();
+        }
+
         verifyFilteredSecondaryEntitiesLink(
             entitiesKey,
             'image-cves',

--- a/ui/apps/platform/cypress/integration/vulnmanagement/nodeComponents.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/nodeComponents.test.js
@@ -1,5 +1,5 @@
 import withAuth from '../../helpers/basicAuth';
-import { hasFeatureFlag } from '../../helpers/features';
+import { hasFeatureFlag, hasOrchestratorFlavor } from '../../helpers/features';
 import {
     assertSortedItems,
     callbackForPairOfAscendingNumberValuesFromElements,
@@ -122,7 +122,11 @@ describe('Vulnerability Management Node Components', () => {
 
     // Some tests might fail in local deployment.
 
-    it('should display links for all node CVEs', () => {
+    it('should display links for all node CVEs', function () {
+        if (hasOrchestratorFlavor('openshift')) {
+            this.skip();
+        }
+
         verifySecondaryEntities(
             entitiesKey,
             'node-cves',
@@ -132,7 +136,11 @@ describe('Vulnerability Management Node Components', () => {
         );
     });
 
-    it('should display links for fixable node CVEs', () => {
+    it('should display links for fixable node CVEs', function () {
+        if (hasOrchestratorFlavor('openshift')) {
+            this.skip();
+        }
+
         verifyFilteredSecondaryEntitiesLink(
             entitiesKey,
             'node-cves',

--- a/ui/apps/platform/cypress/integration/vulnmanagement/nodeComponents.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/nodeComponents.test.js
@@ -77,7 +77,11 @@ describe('Vulnerability Management Node Components', () => {
     });
 
     // TODO Investigate whether not yet supported or incorrect field in payload.
-    it.skip('should sort the Top CVSS column', () => {
+    it.skip('should sort the Top CVSS column', function () {
+        if (hasOrchestratorFlavor('openshift')) {
+            this.skip();
+        }
+
         visitVulnerabilityManagementEntities(entitiesKey);
 
         const thSelector = '.rt-th:contains("Top CVSS")';

--- a/ui/apps/platform/cypress/integration/vulnmanagement/nodeCves.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/nodeCves.test.js
@@ -1,6 +1,6 @@
 import { selectors } from '../../constants/VulnManagementPage';
 import withAuth from '../../helpers/basicAuth';
-import { hasFeatureFlag } from '../../helpers/features';
+import { hasFeatureFlag, hasOrchestratorFlavor } from '../../helpers/features';
 import {
     assertSortedItems,
     callbackForPairOfAscendingNumberValuesFromElements,
@@ -46,7 +46,11 @@ describe('Vulnerability Management Node CVEs', () => {
         ]);
     });
 
-    it('should sort the CVSS Score column', () => {
+    it('should sort the CVSS Score column', function () {
+        if (hasOrchestratorFlavor('openshift')) {
+            this.skip();
+        }
+
         visitVulnerabilityManagementEntities(entitiesKey);
 
         const thSelector = '.rt-th:contains("CVSS Score")';
@@ -118,7 +122,11 @@ describe('Vulnerability Management Node CVEs', () => {
         });
     });
 
-    it('should display vulnerability descriptions', () => {
+    it('should display vulnerability descriptions', function () {
+        if (hasOrchestratorFlavor('openshift')) {
+            this.skip();
+        }
+
         visitVulnerabilityManagementEntities(entitiesKey);
 
         // Balance positive and negative assertions.
@@ -133,11 +141,19 @@ describe('Vulnerability Management Node CVEs', () => {
 
     // Some tests might fail in local deployment.
 
-    it('should display links for nodes', () => {
+    it('should display links for nodes', function () {
+        if (hasOrchestratorFlavor('openshift')) {
+            this.skip();
+        }
+
         verifySecondaryEntities(entitiesKey, 'nodes', 10, /^\d+ nodes?$/);
     });
 
-    it('should display links for node-components', () => {
+    it('should display links for node-components', function () {
+        if (hasOrchestratorFlavor('openshift')) {
+            this.skip();
+        }
+
         verifySecondaryEntities(entitiesKey, 'node-components', 10, /^\d+ node components?$/);
     });
 });

--- a/ui/apps/platform/cypress/integration/vulnmanagement/nodeCves.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/nodeCves.test.js
@@ -82,7 +82,11 @@ describe('Vulnerability Management Node CVEs', () => {
     });
 
     // TODO Investigate whether not yet supported or incorrect field in payload.
-    it.skip('should sort the Severity column', () => {
+    it.skip('should sort the Severity column', function () {
+        if (hasOrchestratorFlavor('openshift')) {
+            this.skip();
+        }
+
         visitVulnerabilityManagementEntities(entitiesKey);
 
         const thSelector = '.rt-th:contains("Severity")';

--- a/ui/apps/platform/cypress/integration/vulnmanagement/policies.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/policies.test.js
@@ -1,6 +1,7 @@
 import { selectors } from '../../constants/VulnManagementPage';
 import { selectors as policySelectors } from '../../constants/PoliciesPage';
 import withAuth from '../../helpers/basicAuth';
+import { hasOrchestratorFlavor } from '../../helpers/features';
 import {
     assertSortedItems,
     callbackForPairOfAscendingPolicySeverityValuesFromElements,
@@ -84,6 +85,10 @@ describe('Vulnerability Management Policies', () => {
     // Some tests might fail in local deployment.
 
     it('should display links for failing deployments', () => {
+        if (hasOrchestratorFlavor('openshift')) {
+            this.skip();
+        }
+
         verifyFilteredSecondaryEntitiesLink(
             entitiesKey,
             'deployments',

--- a/ui/apps/platform/scripts/cypress.sh
+++ b/ui/apps/platform/scripts/cypress.sh
@@ -26,6 +26,11 @@ if [[ -n "${UI_BASE_URL}" ]]; then
   export CYPRESS_BASE_URL="${UI_BASE_URL}"
 fi
 
+# be able to skip tests that are not relevant, for example: openshift
+if [[ -n "${ORCHESTRATOR_FLAVOR}" ]]; then
+  export CYPRESS_ORCHESTRATOR_FLAVOR="${ORCHESTRATOR_FLAVOR}"
+fi
+
 if [ $2 == "--spec" ]; then
     if [ $# -ne 3 ]; then
         echo "usage: yarn cypress-spec <spec-file>"

--- a/ui/apps/platform/scripts/cypress.sh
+++ b/ui/apps/platform/scripts/cypress.sh
@@ -27,9 +27,7 @@ if [[ -n "${UI_BASE_URL}" ]]; then
 fi
 
 # be able to skip tests that are not relevant, for example: openshift
-if [[ -n "${ORCHESTRATOR_FLAVOR}" ]]; then
-  export CYPRESS_ORCHESTRATOR_FLAVOR="${ORCHESTRATOR_FLAVOR}"
-fi
+export CYPRESS_ORCHESTRATOR_FLAVOR="${ORCHESTRATOR_FLAVOR}"
 
 if [ $2 == "--spec" ]; then
     if [ $# -ne 3 ]; then


### PR DESCRIPTION
## Description

* Cluster/Platform might not have any CVEs let alone fixable CVEs.
* Node might not have any CVEs let alone fixable CVEs.
* Image might not have fixable CVEs: passed here but had failed in #4817

### Files changed

1. Edit cypress/helpers/features.js
    * Delete unused default export.
    * Add `hasOrchestratorFlavor` function.

2. Edit cypress/integration/vulnmanagement/clusterCves.test.js for 3 / 4 tests:
    * should sort the CVSS Score column
    * should display vulnerability descriptions
    * should display links for clusters

3. Edit cypress/integration/vulnmanagement/clusters.test.js for 3 / 9 tests:
    * should display links for fixable image CVEs
    * should display links for all node CVEs
    * should display links for all cluster CVEs

4. Edit cypress/integration/vulnmanagement/deployments.test.js for 1 / 5 tests:
    * should display links for fixable image CVEs

5. Edit cypress/integration/vulnmanagement/entitypages.test.js for 5 / 11 tests:
    * related entities tile links should unset search params upon navigation
    * related entities table header should not say "0 entities" or have "page 0 of 0" if there are rows in the table
    * should scope deployment data based on selected policy from table row click
    * should scope deployment data based on selected policy from entity page tab sublist
    * should not filter cluster entity page regardless of entity context

6. Edit cypress/integration/vulnmanagement/imageComponents.test.js for 1 / 7 tests:
    * should display links for fixable image CVEs

7. Edit cypress/integration/vulnmanagement/images.test.js for 1 / 9 tests:
    * should display links for fixable image CVEs and also Risk Acceptance tabs

8. Edit cypress/integration/vulnmanagement/namespaces.test.js for 1 / 6 tests:
    * should display links for fixable image CVEs

9. Edit cypress/integration/vulnmanagement/nodeComponents.test.js for 3 / 6 tests:
    * should sort the Top CVSS column
    * should display links for all node CVEs
    * should display links for fixable node CVEs

10. Edit cypress/integration/vulnmanagement/nodeCves.test.js for 4 / 6 tests:
    * should sort the CVSS Score column
    * should display vulnerability descriptions
    * should display links for nodes
    * should display links for node-components

11. Edit cypress/integration/vulnmanagement/policies.test.js for 1 / 4 tests:
    * should display links for failing deployments

12. Edit scripts/cypress.sh
    * Copy `ORCHESTRATOR_FLAVOR` environment variable to the corresponding CYPRESS environment variable

## Checklist
- [x] Investigated and inspected CI test results
- [x] Skipped integration tests that are not relevant

## Testing Performed

* Ran tests locally with `export ORCHESTRATOR_FLAVOR=openshift` to verify conditional skip.
* Compared snapshots of previous failures with videos of recent successes to confirm that number of fixable CVEs is limited at best.