### PR TITLE
Add expandable section for image vulnerability components table

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageSingleVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageSingleVulnerabilities.tsx
@@ -37,6 +37,7 @@ import SingleEntityVulnerabilitiesTable from './Tables/SingleEntityVulnerabiliti
 import useImageVulnerabilities, {
     ImageVulnerabilitiesResponse,
 } from './hooks/useImageVulnerabilities';
+import { ImageDetailsResponse } from './hooks/useImageDetails';
 
 function severityCountsFromImageVulnerabilities(
     imageVulnerabilities: ImageVulnerabilitiesResponse['image']['imageVulnerabilities']
@@ -76,9 +77,10 @@ function statusCountsFromImageVulnerabilities(
 
 export type ImageSingleVulnerabilitiesProps = {
     imageId: string;
+    imageData: ImageDetailsResponse['image'] | undefined;
 };
 
-function ImageSingleVulnerabilities({ imageId }: ImageSingleVulnerabilitiesProps) {
+function ImageSingleVulnerabilities({ imageId, imageData }: ImageSingleVulnerabilitiesProps) {
     const { searchFilter } = useURLSearch();
     // TODO Still need to properly integrate search filter with query
     const { data, loading, error } = useImageVulnerabilities(imageId, {});
@@ -156,6 +158,7 @@ function ImageSingleVulnerabilities({ imageId }: ImageSingleVulnerabilitiesProps
                         <SplitItem>TODO Pagination</SplitItem>
                     </Split>
                     <SingleEntityVulnerabilitiesTable
+                        image={imageData}
                         imageVulnerabilities={data.image.imageVulnerabilities}
                     />
                 </div>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageComponentsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageComponentsTable.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { CodeBlock, CodeBlockCode } from '@patternfly/react-core';
+import { TableComposable, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
+
+import { ImageVulnerabilityComponent } from '../hooks/useImageVulnerabilities';
+import { ImageDetailsResponse } from '../hooks/useImageDetails';
+
+export type ImageComponentsTableProps = {
+    image: ImageDetailsResponse['image'] | undefined;
+    imageComponents: ImageVulnerabilityComponent[];
+};
+
+function ImageComponentsTable({ image, imageComponents }: ImageComponentsTableProps) {
+    const layers = image?.metadata?.v1?.layers ?? [];
+    return (
+        <TableComposable borders={false}>
+            <Thead>
+                <Tr>
+                    <Th>Component</Th>
+                    <Th>Version</Th>
+                    <Th>Fixed in</Th>
+                    <Th>Location</Th>
+                </Tr>
+            </Thead>
+            {imageComponents.map(({ id, name, version, fixedIn, location, layerIndex }) => {
+                let dockerfileText = `* Dockerfile layer information is not available *`;
+
+                if (layerIndex !== null) {
+                    const layer = layers[layerIndex];
+                    if (layer) {
+                        dockerfileText = `${layer.instruction} ${layer.value}`;
+                    }
+                }
+                return (
+                    <Tbody
+                        key={id}
+                        style={{
+                            borderBottom: '1px solid var(--pf-c-table--BorderColor)',
+                        }}
+                    >
+                        <Tr>
+                            <Td>{name}</Td>
+                            <Td>{version}</Td>
+                            <Td>{fixedIn || 'TODO - why empty'}</Td>
+                            <Td>{location || 'TODO - why empty'}</Td>
+                        </Tr>
+                        <Tr>
+                            <Td colSpan={4} className="pf-u-pt-0">
+                                <CodeBlock>
+                                    <CodeBlockCode>{dockerfileText}</CodeBlockCode>
+                                </CodeBlock>
+                            </Td>
+                        </Tr>
+                    </Tbody>
+                );
+            })}
+        </TableComposable>
+    );
+}
+
+export default ImageComponentsTable;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageComponentsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageComponentsTable.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { CodeBlock, CodeBlockCode } from '@patternfly/react-core';
-import { TableComposable, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
+import { TableComposable, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
 import { ImageVulnerabilityComponent } from '../hooks/useImageVulnerabilities';
 import { ImageDetailsResponse } from '../hooks/useImageDetails';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/SingleEntityVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/SingleEntityVulnerabilitiesTable.tsx
@@ -1,44 +1,69 @@
 import React from 'react';
 import { Button, ButtonVariant } from '@patternfly/react-core';
-import { TableComposable, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
+import {
+    TableComposable,
+    Thead,
+    Tr,
+    Th,
+    Tbody,
+    Td,
+    ExpandableRowContent,
+} from '@patternfly/react-table';
 import { CheckCircleIcon, ExclamationCircleIcon } from '@patternfly/react-icons';
 import { SVGIconProps } from '@patternfly/react-icons/dist/js/createIcon';
 
 import LinkShim from 'Components/PatternFly/LinkShim';
 import SeverityIcons from 'Components/PatternFly/SeverityIcons';
+import useSet from 'hooks/useSet';
 import { vulnerabilitySeverityLabels } from 'messages/common';
 import { getDistanceStrictAsPhrase } from 'utils/dateUtils';
 import { ImageVulnerabilitiesResponse } from '../hooks/useImageVulnerabilities';
 import { getEntityPagePath } from '../searchUtils';
+import ImageComponentsTable from './ImageComponentsTable';
+import { ImageDetailsResponse } from '../hooks/useImageDetails';
 
 export type SingleEntityVulnerabilitiesTableProps = {
+    image: ImageDetailsResponse['image'] | undefined;
     imageVulnerabilities: ImageVulnerabilitiesResponse['image']['imageVulnerabilities'];
 };
 
 function SingleEntityVulnerabilitiesTable({
+    image,
     imageVulnerabilities,
 }: SingleEntityVulnerabilitiesTableProps) {
+    const expandedRowSet = useSet<string>();
     return (
         <TableComposable>
             <Thead>
                 <Tr>
+                    <Th>{/* Header for expanded column */}</Th>
                     <Th>CVE</Th>
                     <Th>Severity</Th>
-                    <Th>CVE Status</Th>
+                    <Th>CVE status</Th>
                     <Th>Affected components</Th>
                     <Th>First discovered</Th>
                 </Tr>
             </Thead>
-            <Tbody>
-                {imageVulnerabilities.map(
-                    ({ cve, severity, isFixable, imageComponents, discoveredAtImage }) => {
-                        const SeverityIcon: React.FC<SVGIconProps> | undefined =
-                            SeverityIcons[severity];
-                        const severityLabel: string | undefined =
-                            vulnerabilitySeverityLabels[severity];
+            {imageVulnerabilities.map(
+                (
+                    { cve, severity, summary, isFixable, imageComponents, discoveredAtImage },
+                    rowIndex
+                ) => {
+                    const SeverityIcon: React.FC<SVGIconProps> | undefined =
+                        SeverityIcons[severity];
+                    const severityLabel: string | undefined = vulnerabilitySeverityLabels[severity];
+                    const isExpanded = expandedRowSet.has(cve);
 
-                        return (
-                            <Tr key={cve}>
+                    return (
+                        <Tbody key={cve} isExpanded={isExpanded}>
+                            <Tr>
+                                <Td
+                                    expand={{
+                                        rowIndex,
+                                        isExpanded,
+                                        onToggle: () => expandedRowSet.toggle(cve),
+                                    }}
+                                />
                                 <Td dataLabel="CVE">
                                     <Button
                                         variant={ButtonVariant.link}
@@ -87,10 +112,29 @@ function SingleEntityVulnerabilitiesTable({
                                     {getDistanceStrictAsPhrase(discoveredAtImage, new Date())}
                                 </Td>
                             </Tr>
-                        );
-                    }
-                )}
-            </Tbody>
+                            <Tr isExpanded={isExpanded}>
+                                <Td />
+                                <Td colSpan={5}>
+                                    <ExpandableRowContent>
+                                        <p>{summary}</p>
+                                        <div
+                                            className="pf-u-p-md pf-u-mt-md"
+                                            style={{
+                                                border: '1px solid var(--pf-c-table--BorderColor)',
+                                            }}
+                                        >
+                                            <ImageComponentsTable
+                                                image={image}
+                                                imageComponents={imageComponents}
+                                            />
+                                        </div>
+                                    </ExpandableRowContent>
+                                </Td>
+                            </Tr>
+                        </Tbody>
+                    );
+                }
+            )}
         </TableComposable>
     );
 }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/SingleEntityVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/SingleEntityVulnerabilitiesTable.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import { Button, ButtonVariant } from '@patternfly/react-core';
 import {
+    ExpandableRowContent,
     TableComposable,
-    Thead,
-    Tr,
-    Th,
     Tbody,
     Td,
-    ExpandableRowContent,
+    Th,
+    Thead,
+    Tr,
 } from '@patternfly/react-table';
 import { CheckCircleIcon, ExclamationCircleIcon } from '@patternfly/react-icons';
 import { SVGIconProps } from '@patternfly/react-icons/dist/js/createIcon';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesImageSinglePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesImageSinglePage.tsx
@@ -163,7 +163,7 @@ function WorkloadCvesImageSinglePage() {
                             eventKey="Vulnerabilities"
                             title={<TabTitleText>Vulnerabilities</TabTitleText>}
                         >
-                            <ImageSingleVulnerabilities imageId={imageId} />
+                            <ImageSingleVulnerabilities imageId={imageId} imageData={imageData} />
                         </Tab>
                         <Tab
                             className="pf-u-display-flex pf-u-flex-direction-column pf-u-flex-grow-1"

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/hooks/useImageVulnerabilities.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/hooks/useImageVulnerabilities.ts
@@ -7,6 +7,15 @@ export type ImageVulnerabilitiesVariables = {
     vulnQuery: string;
 };
 
+export type ImageVulnerabilityComponent = {
+    id: string;
+    name: string;
+    version: string;
+    fixedIn: string;
+    location: string;
+    layerIndex: number | null;
+};
+
 export type ImageVulnerabilitiesResponse = {
     image: {
         id: string;
@@ -16,14 +25,7 @@ export type ImageVulnerabilitiesResponse = {
             cve: string;
             summary: string;
             discoveredAtImage: Date | null;
-            imageComponents: {
-                id: string;
-                name: string;
-                version: string;
-                fixedIn: string;
-                location: string;
-                layerIndex: number | null;
-            }[];
+            imageComponents: ImageVulnerabilityComponent[];
         }[];
     };
 };

--- a/ui/apps/platform/src/hooks/useSet.test.ts
+++ b/ui/apps/platform/src/hooks/useSet.test.ts
@@ -1,0 +1,52 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+import useSet from './useSet';
+
+test('useSet should accept a starting set', () => {
+    // Membership is based on reference equality
+    const objA = { test: 'test' };
+    const objB = { test: 'test' };
+
+    const { result } = renderHook(() => {
+        const set = useSet(new Set([objA]));
+        return set;
+    });
+
+    expect(result.current.has(objA)).toBeTruthy();
+    expect(result.current.has(objB)).toBeFalsy();
+
+    act(() => {
+        result.current.toggle(objA);
+        result.current.toggle(objB);
+    });
+
+    expect(result.current.has(objA)).toBeFalsy();
+    expect(result.current.has(objB)).toBeTruthy();
+});
+
+test('useSet should correctly toggle items and report their membership', () => {
+    const { result } = renderHook(() => {
+        const set = useSet<string>();
+        return set;
+    });
+
+    expect(result.current.has('')).toBeFalsy();
+    expect(result.current.has('test')).toBeFalsy();
+    expect(result.current.has('test-2')).toBeFalsy();
+
+    act(() => {
+        result.current.toggle('test');
+    });
+
+    expect(result.current.has('')).toBeFalsy();
+    expect(result.current.has('test')).toBeTruthy();
+    expect(result.current.has('test-2')).toBeFalsy();
+
+    act(() => {
+        result.current.toggle('test-2');
+        result.current.toggle('test');
+    });
+
+    expect(result.current.has('')).toBeFalsy();
+    expect(result.current.has('test')).toBeFalsy();
+    expect(result.current.has('test-2')).toBeTruthy();
+});

--- a/ui/apps/platform/src/hooks/useSet.ts
+++ b/ui/apps/platform/src/hooks/useSet.ts
@@ -1,0 +1,39 @@
+import { useState } from 'react';
+
+/**
+ * Hook that wraps a native `Set` for easier immutable usage as React component state
+ *
+ * Note that the API is intentionally limited - we should add more `Set` methods as use
+ * cases require them.
+ */
+export default function useSet<T>(initialSet: Set<T> = new Set()) {
+    const [itemSet, setItemSet] = useState(initialSet);
+
+    function has(key: T): boolean {
+        return itemSet.has(key);
+    }
+
+    /**
+     * Adds or removes an item from the set
+     *
+     * @param key
+     *      The item to toggle
+     * @param isOn
+     *      Force the item to exist or not exist in the set. If this param is
+     *      omitted the item will be toggled to the opposite of its current state
+     */
+    function toggle(key: T, isOn?: boolean) {
+        setItemSet((prevSet) => {
+            const nextSet = new Set(prevSet);
+            const shouldAdd = typeof isOn === 'undefined' ? !itemSet.has(key) : isOn;
+            if (shouldAdd) {
+                nextSet.add(key);
+            } else {
+                nextSet.delete(key);
+            }
+            return nextSet;
+        });
+    }
+
+    return { has, toggle };
+}


### PR DESCRIPTION
## Description

Adds the expandable section to image single page table rows. This section contains another table with details on all image components that are affected by this CVE.

## Follow ups

- Figure out why `fixedIn` and `location` fields always return empty strings (BE bug?)
- Figure out why `layerIndex` is always null (BE bug?)
- Reset the expanded/collapsed state on all rows when the table is sorted or paginated (depends on https://github.com/stackrox/stackrox/pull/5258) 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Load an image single page and see that expandable arrows are now present.
![image](https://user-images.githubusercontent.com/1292638/225426686-9488168f-fbcd-43d3-9c73-0ac417451252.png)

Expand a row by clicking on the expand arrow on the left side of the table.
![image](https://user-images.githubusercontent.com/1292638/225427133-0c50b28d-eff3-4873-b047-080ed99b95a0.png)
Collapse the row by clicking the arrow again.
![image](https://user-images.githubusercontent.com/1292638/225427194-0a0ea4e0-6f75-4d12-bbb6-a7fd5e3e1aa2.png)

Verify that multiple rows can be expanded at the same time.
![image](https://user-images.githubusercontent.com/1292638/225427304-55d5d6c9-5376-4ce2-bfad-c0a77cba0e2d.png)

Verify that a row with multiple components contains the correct number of rows in the embedded table.
![image](https://user-images.githubusercontent.com/1292638/225427450-d01a80ec-4e94-4b05-bf89-d7766e368771.png)


