### PR TITLE
Provide labels for cluster and namespace filter input elements

### DIFF
--- a/ui/apps/platform/src/Containers/AccessControl/AccessScopes/EffectiveAccessScopeTable.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessScopes/EffectiveAccessScopeTable.tsx
@@ -243,10 +243,16 @@ function EffectiveAccessScopeTable({
             <Flex className="pf-u-pt-sm pf-u-pb-sm pf-u-pl-lg">
                 <Flex spaceItems={{ default: 'spaceItemsSm' }} className="pf-u-pb-sm">
                     <FlexItem>
-                        <span className="pf-u-font-size-sm pf-u-text-nowrap">Cluster filter:</span>
+                        <label
+                            htmlFor="Cluster_filter"
+                            className="pf-u-font-size-sm pf-u-text-nowrap"
+                        >
+                            Cluster filter:
+                        </label>
                     </FlexItem>
                     <FlexItem>
                         <TextInput
+                            id="Cluster_filter"
                             value={clusterNameFilter}
                             onChange={setClusterNameFilter}
                             className="pf-m-small"
@@ -258,12 +264,16 @@ function EffectiveAccessScopeTable({
                 </Flex>
                 <Flex spaceItems={{ default: 'spaceItemsSm' }} className="pf-u-pb-sm">
                     <FlexItem>
-                        <span className="pf-u-font-size-sm pf-u-text-nowrap">
+                        <label
+                            htmlFor="Namespace_filter"
+                            className="pf-u-font-size-sm pf-u-text-nowrap"
+                        >
                             Namespace filter:
-                        </span>
+                        </label>
                     </FlexItem>
                     <FlexItem>
                         <TextInput
+                            id="Namespace_filter"
                             value={namespaceNameFilter}
                             onChange={setNamespaceNameFilter}
                             className="pf-m-small"


### PR DESCRIPTION
## Description

See pictures under Testing Performed

Friendly reviewers, what are pro and con of `id` pattern that replaces space (or punctuation) with underscore? It is a pattern that I found clear and effective for a tech doc team to relate file name from page title and `h1` text of Help topics.

Although we use camelCase in code, it feels awkward here:

| Label text | id with underscore | id as camelCase |
| :--- | :--- | :--- |
| Cluster name | `id="Cluster_name"` | `id="clusterName"` |
| Namespace name | `id="Namespace_name"` | `id="namespaceName"` |

### Residue

1. Investigate react-hooks/exhaustive-deps warning in AccessScopeForm

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

1. Visit /main/access-control/access-scopes and then click **Create access scope**

2. Click scan in axe DevTools panel

    * Form elements must have labels

        ```html
        <input class="pf-c-form-control pf-m-small" type="text" aria-invalid="false" data-ouia-component-type="PF4/TextInput" data-ouia-safe="true" data-ouia-component-id="OUIA-Generated-TextInputBase-3" value="">
        ```

    * Form elements must have labels

        ```html
        <input class="pf-c-form-control pf-m-small" type="text" aria-invalid="false" data-ouia-component-type="PF4/TextInput" data-ouia-safe="true" data-ouia-component-id="OUIA-Generated-TextInputBase-4" value="">
        ```

    Picture with warnings for `span` elements
    ![with_warnings](https://user-images.githubusercontent.com/11862657/224800096-e89b4d25-ad21-4bc6-85a5-58d405b6eeb7.png)

    Picture without warnings for `label` elements
    ![without_warnings](https://user-images.githubusercontent.com/11862657/224800125-2fd6a5b7-99e8-45bb-bb2c-dd5d069cc8a8.png)
