### PR TITLE
Jv investigate getting processindicatorid without database lookup

### DIFF
--- a/central/processlisteningonport/datastore/datastore_impl.go
+++ b/central/processlisteningonport/datastore/datastore_impl.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/stackrox/rox/central/metrics"
-	//countMetrics "github.com/stackrox/rox/central/metrics"
 	processIndicatorStore "github.com/stackrox/rox/central/processindicator/datastore"
 	"github.com/stackrox/rox/central/processlisteningonport/store"
 	"github.com/stackrox/rox/central/role/resources"
@@ -89,14 +88,7 @@ func (ds *datastoreImpl) AddProcessListeningOnPort(
 	allPLOPs := append(normalizedPLOPs, completedInBatch...)
 	indicatorIds := getIndicatorIdsForPlops(allPLOPs)
 
-	//// TODO ROX-14376: The next two calls, fetchIndicators and fetchExistingPLOPs, have to
-	//// be done in a single join query fetching both ProcessIndicator and needed
-	//// bits from PLOP.
-	//indicatorsMap, indicatorIds, err := ds.fetchIndicators(ctx, normalizedPLOPs...)
-	//if err != nil {
-	//	return err
-	//}
-
+	// TODO ROX-14376: This ticket might need to be changed, but is not completely obsolete
 	existingPLOPMap, err := ds.fetchExistingPLOPs(ctx, indicatorIds)
 	if err != nil {
 		return err
@@ -104,20 +96,6 @@ func (ds *datastoreImpl) AddProcessListeningOnPort(
 
 	plopObjects := []*storage.ProcessListeningOnPortStorage{}
 	for _, val := range normalizedPLOPs {
-		//indicatorID := ""
-		//var processInfo *storage.ProcessIndicatorUniqueKey
-
-		//key := getPlopProcessUniqueKey(val)
-
-		//if indicator, ok := indicatorsMap[key]; ok {
-		//	indicatorID = indicator.GetId()
-		//	log.Debugf("Got indicator %s: %+v", indicatorID, indicator)
-		//} else {
-		//	countMetrics.IncrementOrphanedPLOPCounter(val.GetClusterId())
-		//	log.Warnf("Found no matching indicators for %s", key)
-		//	processInfo = val.Process
-		//}
-
 		indicatorID := getIndicatorIdForPlop(val)
 		plopKey := getPlopKeyFromParts(val.GetProtocol(), val.GetPort(), indicatorID)
 
@@ -146,7 +124,6 @@ func (ds *datastoreImpl) AddProcessListeningOnPort(
 			}
 
 			plopObjects = addNewPLOP(plopObjects, indicatorID, nil, val)
-			//plopObjects = addNewPLOP(plopObjects, indicatorID, processInfo, val)
 		}
 	}
 
@@ -157,19 +134,6 @@ func (ds *datastoreImpl) AddProcessListeningOnPort(
 	// timestamp
 	// * If no existing PLOP is present, they will create a new closed PLOP
 	for _, val := range completedInBatch {
-		//indicatorID := ""
-		//var processInfo *storage.ProcessIndicatorUniqueKey
-
-		//key := getPlopProcessUniqueKey(val)
-
-		//if indicator, ok := indicatorsMap[key]; ok {
-		//	indicatorID = indicator.GetId()
-		//	log.Debugf("Got indicator %s: %+v", indicatorID, indicator)
-		//} else {
-		//	countMetrics.IncrementOrphanedPLOPCounter(val.GetClusterId())
-		//	log.Warnf("Found no matching indicators for %s", key)
-		//	processInfo = val.Process
-		//}
 
 		indicatorID := getIndicatorIdForPlop(val)
 		plopKey := getPlopKeyFromParts(val.GetProtocol(), val.GetPort(), indicatorID)
@@ -197,7 +161,6 @@ func (ds *datastoreImpl) AddProcessListeningOnPort(
 			}
 
 			plopObjects = addNewPLOP(plopObjects, indicatorID, nil, val)
-			//plopObjects = addNewPLOP(plopObjects, indicatorID, processInfo, val)
 		}
 	}
 

--- a/central/processlisteningonport/datastore/datastore_impl.go
+++ b/central/processlisteningonport/datastore/datastore_impl.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/stackrox/rox/central/metrics"
-	countMetrics "github.com/stackrox/rox/central/metrics"
+	//countMetrics "github.com/stackrox/rox/central/metrics"
 	processIndicatorStore "github.com/stackrox/rox/central/processindicator/datastore"
 	"github.com/stackrox/rox/central/processlisteningonport/store"
 	"github.com/stackrox/rox/central/role/resources"
@@ -15,6 +15,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/logging"
+	"github.com/stackrox/rox/pkg/process/id"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/uuid"
@@ -40,6 +41,28 @@ func newDatastoreImpl(
 	}
 }
 
+func getIndicatorIdForPlop(plop *storage.ProcessListeningOnPortFromSensor) string {
+	if plop == nil {
+		return ""
+	}
+
+	if plop.Process == nil {
+		return ""
+	}
+
+	return id.GetIndicatorIDFromProcessIndicatorUniqueKey(plop.Process)
+}
+
+func getIndicatorIdsForPlops(plops []*storage.ProcessListeningOnPortFromSensor) []string {
+	indicatorIds := make([]string, 0)
+	for _, plop := range plops {
+		indicatorId := getIndicatorIdForPlop(plop)
+		indicatorIds = append(indicatorIds, indicatorId)
+	}
+
+	return indicatorIds
+}
+
 func (ds *datastoreImpl) AddProcessListeningOnPort(
 	ctx context.Context,
 	portProcesses ...*storage.ProcessListeningOnPortFromSensor,
@@ -63,14 +86,16 @@ func (ds *datastoreImpl) AddProcessListeningOnPort(
 	}
 
 	normalizedPLOPs, completedInBatch := normalizePLOPs(portProcesses)
+	allPLOPs := append(normalizedPLOPs, completedInBatch...)
+	indicatorIds := getIndicatorIdsForPlops(allPLOPs)
 
-	// TODO ROX-14376: The next two calls, fetchIndicators and fetchExistingPLOPs, have to
-	// be done in a single join query fetching both ProcessIndicator and needed
-	// bits from PLOP.
-	indicatorsMap, indicatorIds, err := ds.fetchIndicators(ctx, normalizedPLOPs...)
-	if err != nil {
-		return err
-	}
+	//// TODO ROX-14376: The next two calls, fetchIndicators and fetchExistingPLOPs, have to
+	//// be done in a single join query fetching both ProcessIndicator and needed
+	//// bits from PLOP.
+	//indicatorsMap, indicatorIds, err := ds.fetchIndicators(ctx, normalizedPLOPs...)
+	//if err != nil {
+	//	return err
+	//}
 
 	existingPLOPMap, err := ds.fetchExistingPLOPs(ctx, indicatorIds)
 	if err != nil {
@@ -79,20 +104,21 @@ func (ds *datastoreImpl) AddProcessListeningOnPort(
 
 	plopObjects := []*storage.ProcessListeningOnPortStorage{}
 	for _, val := range normalizedPLOPs {
-		indicatorID := ""
-		var processInfo *storage.ProcessIndicatorUniqueKey
+		//indicatorID := ""
+		//var processInfo *storage.ProcessIndicatorUniqueKey
 
-		key := getPlopProcessUniqueKey(val)
+		//key := getPlopProcessUniqueKey(val)
 
-		if indicator, ok := indicatorsMap[key]; ok {
-			indicatorID = indicator.GetId()
-			log.Debugf("Got indicator %s: %+v", indicatorID, indicator)
-		} else {
-			countMetrics.IncrementOrphanedPLOPCounter(val.GetClusterId())
-			log.Warnf("Found no matching indicators for %s", key)
-			processInfo = val.Process
-		}
+		//if indicator, ok := indicatorsMap[key]; ok {
+		//	indicatorID = indicator.GetId()
+		//	log.Debugf("Got indicator %s: %+v", indicatorID, indicator)
+		//} else {
+		//	countMetrics.IncrementOrphanedPLOPCounter(val.GetClusterId())
+		//	log.Warnf("Found no matching indicators for %s", key)
+		//	processInfo = val.Process
+		//}
 
+		indicatorID := getIndicatorIdForPlop(val)
 		plopKey := getPlopKeyFromParts(val.GetProtocol(), val.GetPort(), indicatorID)
 
 		existingPLOP, prevExists := existingPLOPMap[plopKey]
@@ -116,10 +142,11 @@ func (ds *datastoreImpl) AddProcessListeningOnPort(
 		if !prevExists {
 			if val.CloseTimestamp != nil {
 				// We try to close a not existing Endpoint, something is wrong
-				log.Warnf("Found no matching PLOP to close for %s", key)
+				log.Warnf("Found no matching PLOP to close for %+v", val)
 			}
 
-			plopObjects = addNewPLOP(plopObjects, indicatorID, processInfo, val)
+			plopObjects = addNewPLOP(plopObjects, indicatorID, nil, val)
+			//plopObjects = addNewPLOP(plopObjects, indicatorID, processInfo, val)
 		}
 	}
 
@@ -130,20 +157,21 @@ func (ds *datastoreImpl) AddProcessListeningOnPort(
 	// timestamp
 	// * If no existing PLOP is present, they will create a new closed PLOP
 	for _, val := range completedInBatch {
-		indicatorID := ""
-		var processInfo *storage.ProcessIndicatorUniqueKey
+		//indicatorID := ""
+		//var processInfo *storage.ProcessIndicatorUniqueKey
 
-		key := getPlopProcessUniqueKey(val)
+		//key := getPlopProcessUniqueKey(val)
 
-		if indicator, ok := indicatorsMap[key]; ok {
-			indicatorID = indicator.GetId()
-			log.Debugf("Got indicator %s: %+v", indicatorID, indicator)
-		} else {
-			countMetrics.IncrementOrphanedPLOPCounter(val.GetClusterId())
-			log.Warnf("Found no matching indicators for %s", key)
-			processInfo = val.Process
-		}
+		//if indicator, ok := indicatorsMap[key]; ok {
+		//	indicatorID = indicator.GetId()
+		//	log.Debugf("Got indicator %s: %+v", indicatorID, indicator)
+		//} else {
+		//	countMetrics.IncrementOrphanedPLOPCounter(val.GetClusterId())
+		//	log.Warnf("Found no matching indicators for %s", key)
+		//	processInfo = val.Process
+		//}
 
+		indicatorID := getIndicatorIdForPlop(val)
 		plopKey := getPlopKeyFromParts(val.GetProtocol(), val.GetPort(), indicatorID)
 
 		existingPLOP, prevExists := existingPLOPMap[plopKey]
@@ -168,7 +196,8 @@ func (ds *datastoreImpl) AddProcessListeningOnPort(
 				log.Warnf("Found active PLOP completed in the batch %+v", val)
 			}
 
-			plopObjects = addNewPLOP(plopObjects, indicatorID, processInfo, val)
+			plopObjects = addNewPLOP(plopObjects, indicatorID, nil, val)
+			//plopObjects = addNewPLOP(plopObjects, indicatorID, processInfo, val)
 		}
 	}
 

--- a/central/processlisteningonport/datastore/datastore_impl.go
+++ b/central/processlisteningonport/datastore/datastore_impl.go
@@ -40,7 +40,7 @@ func newDatastoreImpl(
 	}
 }
 
-func getIndicatorIdForPlop(plop *storage.ProcessListeningOnPortFromSensor) string {
+func getIndicatorIDForPlop(plop *storage.ProcessListeningOnPortFromSensor) string {
 	if plop == nil {
 		return ""
 	}
@@ -55,8 +55,8 @@ func getIndicatorIdForPlop(plop *storage.ProcessListeningOnPortFromSensor) strin
 func getIndicatorIdsForPlops(plops []*storage.ProcessListeningOnPortFromSensor) []string {
 	indicatorIds := make([]string, 0)
 	for _, plop := range plops {
-		indicatorId := getIndicatorIdForPlop(plop)
-		indicatorIds = append(indicatorIds, indicatorId)
+		indicatorID := getIndicatorIDForPlop(plop)
+		indicatorIds = append(indicatorIds, indicatorID)
 	}
 
 	return indicatorIds
@@ -96,7 +96,7 @@ func (ds *datastoreImpl) AddProcessListeningOnPort(
 
 	plopObjects := []*storage.ProcessListeningOnPortStorage{}
 	for _, val := range normalizedPLOPs {
-		indicatorID := getIndicatorIdForPlop(val)
+		indicatorID := getIndicatorIDForPlop(val)
 		plopKey := getPlopKeyFromParts(val.GetProtocol(), val.GetPort(), indicatorID)
 
 		existingPLOP, prevExists := existingPLOPMap[plopKey]
@@ -135,7 +135,7 @@ func (ds *datastoreImpl) AddProcessListeningOnPort(
 	// * If no existing PLOP is present, they will create a new closed PLOP
 	for _, val := range completedInBatch {
 
-		indicatorID := getIndicatorIdForPlop(val)
+		indicatorID := getIndicatorIDForPlop(val)
 		plopKey := getPlopKeyFromParts(val.GetProtocol(), val.GetPort(), indicatorID)
 
 		existingPLOP, prevExists := existingPLOPMap[plopKey]

--- a/pkg/process/id/id.go
+++ b/pkg/process/id/id.go
@@ -12,10 +12,27 @@ var (
 	processIDNamespace = uuid.FromStringOrPanic("801fcce1-56d3-48bd-b1ac-c41fdc6c3d94")
 )
 
+// GetIndicatorIDFromParts sets the indicator ID based on the stable namespace
+func GetIndicatorIDFromParts(podId string, containerName string, execFilePath string, name string, args string) string {
+	id := uuid.NewV5(processIDNamespace,
+		fmt.Sprintf("%s %s %s %s %s", podId, containerName,
+			execFilePath, name, args)).String()
+
+	return id
+}
+
 // SetIndicatorID sets the indicator ID based on the stable namespace
 func SetIndicatorID(indicator *storage.ProcessIndicator) {
-	id := uuid.NewV5(processIDNamespace,
-		fmt.Sprintf("%s %s %s %s %s", indicator.GetPodId(), indicator.GetContainerName(),
-			indicator.GetSignal().GetExecFilePath(), indicator.GetSignal().GetName(), indicator.GetSignal().GetArgs())).String()
+//	id := uuid.NewV5(processIDNamespace,
+//		fmt.Sprintf("%s %s %s %s %s", indicator.GetPodId(), indicator.GetContainerName(),
+//			indicator.GetSignal().GetExecFilePath(), indicator.GetSignal().GetName(), indicator.GetSignal().GetArgs())).String()
+	id := GetIndicatorIDFromParts(indicator.GetPodId(), indicator.GetContainerName(),
+			indicator.GetSignal().GetExecFilePath(), indicator.GetSignal().GetName(), indicator.GetSignal().GetArgs())
+
 	indicator.Id = id
+}
+
+func GetIndicatorIDFromProcessIndicatorUniqueKey(uniqueKey *storage.ProcessIndicatorUniqueKey) string {
+	return GetIndicatorIDFromParts(uniqueKey.GetPodId(), uniqueKey.GetContainerName(),
+		uniqueKey.GetProcessExecFilePath(), uniqueKey.GetProcessName(), uniqueKey.GetProcessArgs())
 }

--- a/pkg/process/id/id.go
+++ b/pkg/process/id/id.go
@@ -13,9 +13,9 @@ var (
 )
 
 // GetIndicatorIDFromParts gets the indicator ID based on the stable namespace
-func GetIndicatorIDFromParts(podId string, containerName string, execFilePath string, name string, args string) string {
+func GetIndicatorIDFromParts(podID string, containerName string, execFilePath string, name string, args string) string {
 	id := uuid.NewV5(processIDNamespace,
-		fmt.Sprintf("%s %s %s %s %s", podId, containerName,
+		fmt.Sprintf("%s %s %s %s %s", podID, containerName,
 			execFilePath, name, args)).String()
 
 	return id
@@ -24,7 +24,7 @@ func GetIndicatorIDFromParts(podId string, containerName string, execFilePath st
 // SetIndicatorID sets the indicator ID based on the stable namespace
 func SetIndicatorID(indicator *storage.ProcessIndicator) {
 	id := GetIndicatorIDFromParts(indicator.GetPodId(), indicator.GetContainerName(),
-			indicator.GetSignal().GetExecFilePath(), indicator.GetSignal().GetName(), indicator.GetSignal().GetArgs())
+		indicator.GetSignal().GetExecFilePath(), indicator.GetSignal().GetName(), indicator.GetSignal().GetArgs())
 
 	indicator.Id = id
 }

--- a/pkg/process/id/id.go
+++ b/pkg/process/id/id.go
@@ -12,7 +12,7 @@ var (
 	processIDNamespace = uuid.FromStringOrPanic("801fcce1-56d3-48bd-b1ac-c41fdc6c3d94")
 )
 
-// GetIndicatorIDFromParts sets the indicator ID based on the stable namespace
+// GetIndicatorIDFromParts gets the indicator ID based on the stable namespace
 func GetIndicatorIDFromParts(podId string, containerName string, execFilePath string, name string, args string) string {
 	id := uuid.NewV5(processIDNamespace,
 		fmt.Sprintf("%s %s %s %s %s", podId, containerName,
@@ -23,15 +23,13 @@ func GetIndicatorIDFromParts(podId string, containerName string, execFilePath st
 
 // SetIndicatorID sets the indicator ID based on the stable namespace
 func SetIndicatorID(indicator *storage.ProcessIndicator) {
-//	id := uuid.NewV5(processIDNamespace,
-//		fmt.Sprintf("%s %s %s %s %s", indicator.GetPodId(), indicator.GetContainerName(),
-//			indicator.GetSignal().GetExecFilePath(), indicator.GetSignal().GetName(), indicator.GetSignal().GetArgs())).String()
 	id := GetIndicatorIDFromParts(indicator.GetPodId(), indicator.GetContainerName(),
 			indicator.GetSignal().GetExecFilePath(), indicator.GetSignal().GetName(), indicator.GetSignal().GetArgs())
 
 	indicator.Id = id
 }
 
+// GetIndicatorIDFromProcessIndicatorUniqueKey gets the indicator ID from information in the ProcessIndicatorUniqueKey
 func GetIndicatorIDFromProcessIndicatorUniqueKey(uniqueKey *storage.ProcessIndicatorUniqueKey) string {
 	return GetIndicatorIDFromParts(uniqueKey.GetPodId(), uniqueKey.GetContainerName(),
 		uniqueKey.GetProcessExecFilePath(), uniqueKey.GetProcessName(), uniqueKey.GetProcessArgs())

--- a/qa-tests-backend/src/test/groovy/ProcessesListeningOnPortsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ProcessesListeningOnPortsTest.groovy
@@ -15,8 +15,7 @@ import spock.lang.Stepwise
 import services.ProcessesListeningOnPortsService
 
 @Stepwise
-// TODO: Solve the flake and change back to @IgnoreIf({ !Env.get("ROX_POSTGRES_DATASTORE", null) })
-@IgnoreIf({ Env.get("RUN_PROCESS_LISTENING_ON_PORTS_E2E_TESTS", "false") == "false" })
+@IgnoreIf({ !Env.get("ROX_POSTGRES_DATASTORE", null) })
 class ProcessesListeningOnPortsTest extends BaseSpecification {
 
     // Deployment names


### PR DESCRIPTION
## Description

processindicatorid is generated from information in the ProcessListeningOnPortFromSensor object, instead of doing a join.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Performance testing
- [x] e2e tests pass 200 times locally

## Testing Performed

See above
