### PR TITLE
ROX-11808: Stop setting obsolete env variables.

### DIFF
--- a/operator/hack/common.sh
+++ b/operator/hack/common.sh
@@ -41,8 +41,6 @@ function apply_operator_manifests() {
   env -i PATH="${PATH}" \
     INDEX_VERSION="${index_version}" OPERATOR_VERSION="${operator_version}" NAMESPACE="${operator_ns}" \
     IMAGE_TAG_BASE="${image_tag_base}" \
-    `# TODO(ROX-11808): IMAGE_REGISTRY is provided for compatibility with versions 71 and older. Remove after we release 72.` \
-    IMAGE_REGISTRY="${image_tag_base%/*}" \
     envsubst < "${ROOT_DIR}/operator/hack/operator.envsubst.yaml" \
     | kubectl -n "${operator_ns}" apply -f -
 }

--- a/operator/hack/operator.envsubst.yaml
+++ b/operator/hack/operator.envsubst.yaml
@@ -27,11 +27,6 @@ spec:
   startingCSV: rhacs-operator.v${OPERATOR_VERSION}
   config:
     env:
-    # TODO(ROX-11808): these are provided for compatibility with versions 71 and older. Remove after we release 72.
-    - name: ROX_OPERATOR_MAIN_REGISTRY
-      value: "${IMAGE_REGISTRY}"
-    - name: ROX_OPERATOR_COLLECTOR_REGISTRY
-      value: "${IMAGE_REGISTRY}"
     # use a test value for NO_PROXY. This will not have any impact
     # on the services at runtime, but we can test if it gets piped
     # through correctly.


### PR DESCRIPTION
## Description

Remove code that sets environment variables that are no longer meaningful for the operator since release 3.72.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

CI should be sufficient.
Operator tests are passing and logs show that `rhacs-eng` images are being used, which is all that matters.