### PR TITLE
Delete obsolete accessControlPath in UI

### DIFF
--- a/ui/apps/platform/src/Containers/AccessControl/AccessControl.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessControl.tsx
@@ -1,8 +1,10 @@
 import React, { ReactElement } from 'react';
 import { Redirect, Route, Switch } from 'react-router-dom';
-
 import { Alert, List, ListItem } from '@patternfly/react-core';
-import { accessControlBasePath, accessControlPath, getEntityPath } from './accessControlPaths';
+
+import { accessControlBasePath, accessControlPath } from 'routePaths';
+
+import { getEntityPath } from './accessControlPaths';
 
 import AccessControlRouteNotFound from './AccessControlRouteNotFound';
 import AccessScopes from './AccessScopes/AccessScopes';

--- a/ui/apps/platform/src/Containers/AccessControl/accessControlPaths.ts
+++ b/ui/apps/platform/src/Containers/AccessControl/accessControlPaths.ts
@@ -1,12 +1,9 @@
 import { History } from 'react-router-dom';
 import qs from 'qs';
 
-import { accessControlBasePathV2, accessControlPathV2 } from 'routePaths'; // import { accessControlPath } from 'routePaths';
+import { accessControlBasePath } from 'routePaths';
 import { AccessControlEntityType } from 'constants/entityTypes';
 import { BasePageAction, getQueryObject as baseGetQueryObject } from 'utils/queryStringUtils';
-
-export const accessControlBasePath = accessControlBasePathV2; // export { accessControlBasePath };
-export const accessControlPath = accessControlPathV2; // export { accessControlPath };
 
 export type AccessControlQueryAction = BasePageAction;
 

--- a/ui/apps/platform/src/Containers/MainPage/Body.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Body.tsx
@@ -18,7 +18,7 @@ import {
     riskPath,
     searchPath,
     apidocsPath,
-    accessControlPathV2,
+    accessControlPath,
     userBasePath,
     systemConfigPath,
     systemHealthPath,
@@ -142,7 +142,7 @@ function Body({ hasReadAccess, isFeatureFlagEnabled }: BodyProps): ReactElement 
                         <Route path={collectionsPath} component={AsyncCollectionsPage} />
                     )}
                     <Route path={riskPath} component={AsyncRiskPage} />
-                    <Route path={accessControlPathV2} component={AsyncAccessControlPageV2} />
+                    <Route path={accessControlPath} component={AsyncAccessControlPageV2} />
                     <Route path={searchPath} component={AsyncSearchPage} />
                     <Route path={apidocsPath} component={AsyncApiDocsPage} />
                     <Route path={userBasePath} component={AsyncUserPage} />

--- a/ui/apps/platform/src/Containers/MainPage/Sidebar/NavigationSidebar.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Sidebar/NavigationSidebar.tsx
@@ -28,7 +28,7 @@ import {
     clustersBasePath,
     policyManagementBasePath,
     integrationsPath,
-    accessControlBasePathV2,
+    accessControlBasePath,
     systemConfigPath,
     systemHealthPath,
     collectionsBasePath,
@@ -63,7 +63,7 @@ function NavigationSidebar({
         clustersBasePath,
         policyManagementBasePath,
         integrationsPath,
-        accessControlBasePathV2,
+        accessControlBasePath,
         systemConfigPath,
         systemHealthPath,
     ];

--- a/ui/apps/platform/src/routePaths.js
+++ b/ui/apps/platform/src/routePaths.js
@@ -35,9 +35,8 @@ export const riskPath = `${riskBasePath}/:deploymentId?`;
 export const secretsPath = `${mainPath}/configmanagement/secrets/:secretId?`;
 export const searchPath = `${mainPath}/search`;
 export const apidocsPath = `${mainPath}/apidocs`;
-export const accessControlPath = `${mainPath}/access`;
-export const accessControlBasePathV2 = `${mainPath}/access-control`;
-export const accessControlPathV2 = `${accessControlBasePathV2}/:entitySegment?/:entityId?`;
+export const accessControlBasePath = `${mainPath}/access-control`;
+export const accessControlPath = `${accessControlBasePath}/:entitySegment?/:entityId?`;
 export const userBasePath = `${mainPath}/user`;
 export const userRolePath = `${userBasePath}/roles/:roleName`;
 export const systemConfigPath = `${mainPath}/systemconfig`;
@@ -175,7 +174,7 @@ export const basePathToLabelMap = {
     [collectionsBasePath]: 'Collections',
     [integrationsPath]: 'Integrations',
     [accessControlPath]: 'Access Control',
-    [accessControlBasePathV2]: 'Access Control',
+    [accessControlBasePath]: 'Access Control',
     [systemConfigPath]: 'System Configuration',
     [systemHealthPath]: 'System Health',
     [loginPath]: 'Log In',

--- a/ui/apps/platform/src/utils/URLParser.ts
+++ b/ui/apps/platform/src/utils/URLParser.ts
@@ -16,7 +16,7 @@ import {
     policiesPath,
     networkPath,
     userRolePath,
-    accessControlPathV2,
+    accessControlPath,
 } from '../routePaths';
 
 type ParamsWithContext = {
@@ -31,7 +31,7 @@ const nonWorkflowUseCasePathEntries = Object.entries({
     POLICIES: policiesPath,
     NETWORK: networkPath,
     USER: userRolePath, // however, it matches workflow list path
-    ACCESS_CONTROL: accessControlPathV2,
+    ACCESS_CONTROL: accessControlPath,
 });
 
 function getNonWorkflowParams(pathname): ParamsWithContext {


### PR DESCRIPTION
## Description

Besser spät als nie: residue from #5199

Delete before descriptive route configuration.

### Changed files

1. Edit src/Containers/AccessControl/AccessControl.tsx
    * Import paths from routePaths.js file.

2. Edit src/Containers/AccessControl/accessControlPaths.ts
    * Rename `accessControlBasePathV2` as `accessControlBasePath`
    * Delete re-export of renamed paths.

3. Edit src/Containers/MainPage/Body.tsx
    * Rename `accessControlPathV2` as `accessControlPath`

4. Edit src/Containers/MainPage/Sidebar/NavigationSidebar.tsx
    * Rename `accessControlBasePathV2` as `accessControlBasePath`

5. Edit src/routePaths.js
    * Delete obsolete path variable.
    * Rename 2 path variables.

    ```js
    export const accessControlPath = `${mainPath}/access`;
    export const accessControlBasePathV2 = `${mainPath}/access-control`;
    export const accessControlPathV2 = `${accessControlBasePathV2}/:entitySegment?/:entityId?`;
    ```

6. Edit src/utils/URLParser.ts
    * Rename `accessControlPathV2` as `accessControlPath`

### Residue

1. Remove unneeded `nonWorkflowUseCasePathEntries` from URLParser.ts to remove another invisible global dependency (which might not even be used).

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

1. `yarn lint` in ui
2. `yarn build` in ui
3. `yarn cypress-open` in ui/apps/platform
    * accessControlAccessScopes.test.js
    * accessControlAuthProviders.test.js
    * accessControlOrigin.test.js
    * accessControlPermissionSets.test.js
    * accessControlRoles.test.js