### PR TITLE
ROX-15780: set file modification date in diagnostic bundle

### DIFF
--- a/central/debug/service/diagnostics.go
+++ b/central/debug/service/diagnostics.go
@@ -218,12 +218,8 @@ func (s *serviceImpl) pullSensorMetrics(ctx context.Context, zipWriter *zip.Writ
 			if !ok {
 				return nil
 			}
-			fullPath := path.Join("sensor-metrics", file.Path)
-			fileWriter, err := zipWriter.Create(fullPath)
+			err := writePrefixedFileToZip(zipWriter, "sensor-metrics", file)
 			if err != nil {
-				return err
-			}
-			if _, err := fileWriter.Write(file.Contents); err != nil {
 				return err
 			}
 		}
@@ -291,12 +287,8 @@ func (s *serviceImpl) getK8sDiagnostics(ctx context.Context, zipWriter *zip.Writ
 			if !ok {
 				return nil
 			}
-			fullPath := path.Join("kubernetes", file.Path)
-			fileWriter, err := zipWriter.Create(fullPath)
+			err := writePrefixedFileToZip(zipWriter, "kubernetes", file)
 			if err != nil {
-				return err
-			}
-			if _, err := fileWriter.Write(file.Contents); err != nil {
 				return err
 			}
 		}

--- a/central/debug/service/service.go
+++ b/central/debug/service/service.go
@@ -253,7 +253,7 @@ func fetchAndAddJSONToZip(ctx context.Context, zipWriter *zip.Writer, fileName s
 }
 
 func addJSONToZip(zipWriter *zip.Writer, fileName string, jsonObj interface{}) error {
-	w, err := zipWriter.Create(fileName)
+	w, err := zipWriterWithCurrentTimestamp(zipWriter, fileName)
 	if err != nil {
 		return errors.Wrapf(err, "unable to create zip file %q", fileName)
 	}
@@ -265,7 +265,7 @@ func addJSONToZip(zipWriter *zip.Writer, fileName string, jsonObj interface{}) e
 }
 
 func zipPrometheusMetrics(zipWriter *zip.Writer, name string) error {
-	metricsWriter, err := zipWriter.Create(name)
+	metricsWriter, err := zipWriterWithCurrentTimestamp(zipWriter, name)
 	if err != nil {
 		return err
 	}
@@ -273,7 +273,7 @@ func zipPrometheusMetrics(zipWriter *zip.Writer, name string) error {
 }
 
 func getMemory(zipWriter *zip.Writer) error {
-	w, err := zipWriter.Create("heap.tar.gz")
+	w, err := zipWriterWithCurrentTimestamp(zipWriter, "heap.tar.gz")
 	if err != nil {
 		return err
 	}
@@ -281,7 +281,7 @@ func getMemory(zipWriter *zip.Writer) error {
 }
 
 func getCPU(ctx context.Context, zipWriter *zip.Writer, duration time.Duration) error {
-	w, err := zipWriter.Create("cpu.tar.gz")
+	w, err := zipWriterWithCurrentTimestamp(zipWriter, "cpu.tar.gz")
 	if err != nil {
 		return err
 	}
@@ -297,7 +297,7 @@ func getCPU(ctx context.Context, zipWriter *zip.Writer, duration time.Duration) 
 }
 
 func getBlock(zipWriter *zip.Writer) error {
-	w, err := zipWriter.Create("block.tar.gz")
+	w, err := zipWriterWithCurrentTimestamp(zipWriter, "block.tar.gz")
 	if err != nil {
 		return err
 	}
@@ -306,7 +306,7 @@ func getBlock(zipWriter *zip.Writer) error {
 }
 
 func getMutex(zipWriter *zip.Writer) error {
-	w, err := zipWriter.Create("mutex.tar.gz")
+	w, err := zipWriterWithCurrentTimestamp(zipWriter, "mutex.tar.gz")
 	if err != nil {
 		return err
 	}
@@ -315,7 +315,7 @@ func getMutex(zipWriter *zip.Writer) error {
 }
 
 func getGoroutines(zipWriter *zip.Writer) error {
-	w, err := zipWriter.Create("goroutine.txt")
+	w, err := zipWriterWithCurrentTimestamp(zipWriter, "goroutine.txt")
 	if err != nil {
 		return err
 	}
@@ -334,7 +334,7 @@ func getLogs(zipWriter *zip.Writer) error {
 }
 
 func getLogFile(zipWriter *zip.Writer, targetPath string, sourcePath string) error {
-	w, err := zipWriter.Create(targetPath)
+	w, err := zipWriterWithCurrentTimestamp(zipWriter, targetPath)
 	if err != nil {
 		return err
 	}
@@ -390,7 +390,7 @@ func getCentralDBData(ctx context.Context, zipWriter *zip.Writer) error {
 }
 
 func (s *serviceImpl) getLogImbue(ctx context.Context, zipWriter *zip.Writer) error {
-	w, err := zipWriter.Create("logimbue-data.json")
+	w, err := zipWriterWithCurrentTimestamp(zipWriter, "logimbue-data.json")
 	if err != nil {
 		return err
 	}

--- a/central/debug/service/zip.go
+++ b/central/debug/service/zip.go
@@ -1,0 +1,35 @@
+package service
+
+import (
+	"archive/zip"
+	"io"
+	"path"
+	"time"
+
+	"github.com/stackrox/rox/pkg/k8sintrospect"
+)
+
+var now = func() time.Time {
+	return time.Now()
+}
+
+func writePrefixedFileToZip(zipWriter *zip.Writer, prefix string, file k8sintrospect.File) error {
+	fullPath := path.Join(prefix, file.Path)
+	fileWriter, err := zipWriterWithCurrentTimestamp(zipWriter, fullPath)
+	if err != nil {
+		return err
+	}
+	if _, err := fileWriter.Write(file.Contents); err != nil {
+		return err
+	}
+	return nil
+}
+
+func zipWriterWithCurrentTimestamp(zipWriter *zip.Writer, fileName string) (io.Writer, error) {
+	header := &zip.FileHeader{
+		Name:     fileName,
+		Method:   zip.Deflate,
+		Modified: now(),
+	}
+	return zipWriter.CreateHeader(header)
+}

--- a/central/debug/service/zip.go
+++ b/central/debug/service/zip.go
@@ -6,6 +6,7 @@ import (
 	"path"
 	"time"
 
+	"github.com/pkg/errors"
 	"github.com/stackrox/rox/pkg/k8sintrospect"
 )
 
@@ -20,7 +21,7 @@ func writePrefixedFileToZip(zipWriter *zip.Writer, prefix string, file k8sintros
 		return err
 	}
 	if _, err := fileWriter.Write(file.Contents); err != nil {
-		return err
+		return errors.Wrapf(err, "unable to write to %q", fullPath)
 	}
 	return nil
 }
@@ -31,5 +32,9 @@ func zipWriterWithCurrentTimestamp(zipWriter *zip.Writer, fileName string) (io.W
 		Method:   zip.Deflate,
 		Modified: now(),
 	}
-	return zipWriter.CreateHeader(header)
+	writer, err := zipWriter.CreateHeader(header)
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to create zip file %q", fileName)
+	}
+	return writer, nil
 }

--- a/qa-tests-backend/src/test/groovy/DiagnosticBundleTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DiagnosticBundleTest.groovy
@@ -117,7 +117,7 @@ class DiagnosticBundleTest extends BaseSpecification {
             try {
                 ZipEntry entry
                 while ((entry = zis.nextEntry) != null) {
-                    log.info "Found file ${entry.name} ${entry.lastModifiedTime}"
+                    log.info "Found file ${entry.name} modified at ${entry.lastModifiedTime}"
                     assert modifiedAfter.isBefore(entry.lastModifiedTime.toInstant())
                     if (entry.name == ("kubernetes/" + ClusterService.DEFAULT_CLUSTER_NAME +
                             "/stackrox/sensor/deployment-sensor.yaml")) {

--- a/qa-tests-backend/src/test/groovy/DiagnosticBundleTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DiagnosticBundleTest.groovy
@@ -1,5 +1,6 @@
 import static io.restassured.RestAssured.given
 
+import java.time.Instant
 import java.util.zip.ZipEntry
 import java.util.zip.ZipInputStream
 
@@ -74,6 +75,9 @@ class DiagnosticBundleTest extends BaseSpecification {
 
     @Unroll
     def "Test that diagnostic bundle download #desc"() {
+        given:
+        Instant modifiedAfter = (new Date()).toInstant().minusSeconds(1)
+
         when:
         "Making a request for the diagnostic bundle"
 
@@ -113,7 +117,8 @@ class DiagnosticBundleTest extends BaseSpecification {
             try {
                 ZipEntry entry
                 while ((entry = zis.nextEntry) != null) {
-                    log.info "Found file ${entry.name}"
+                    log.info "Found file ${entry.name} ${entry.lastModifiedTime}"
+                    assert modifiedAfter.isBefore(entry.lastModifiedTime.toInstant())
                     if (entry.name == ("kubernetes/" + ClusterService.DEFAULT_CLUSTER_NAME +
                             "/stackrox/sensor/deployment-sensor.yaml")) {
                         foundK8sInfo = true


### PR DESCRIPTION
## Description

Currently we do not set any time in diagnostic bundle files. This result with using 1980 as a default which is confusing for users as they expect current date. This PR fixes it by setting current timestamp. 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
