### PR TITLE
ROX-15911: Reassess policies in retry for ImageSignatureVerificationTests

### DIFF
--- a/qa-tests-backend/src/test/groovy/ImageSignatureVerificationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageSignatureVerificationTest.groovy
@@ -229,7 +229,7 @@ QC+pUMTUP/ZmrvmKaA+pi55F+w3LqVJ17zwXKjaOEiEpn/+lntl/ieweeQ==
 
     def cleanupSpec() {
         // Delete all deployments.
-        DEPLOYMENTS.each { orchestrator.deleteDeployment(it) }
+        DEPLOYMENTS.each { orchestrator.deleteAndWaitForDeploymentDeletion(it) }
 
         // Delete all created policies.
         CREATED_POLICY_IDS.each { PolicyService.deletePolicy(it) }
@@ -241,6 +241,12 @@ QC+pUMTUP/ZmrvmKaA+pi55F+w3LqVJ17zwXKjaOEiEpn/+lntl/ieweeQ==
         orchestrator.deleteNamespace(SIGNATURE_TESTING_NAMESPACE)
     }
 
+    def setup() {
+        // Reassessing policies will trigger a re-enrichment of images, ensuring we cover potential timeouts occurred
+        // during enriching images.
+        PolicyService.reassessPolicies()
+    }
+
     @Unroll
     @SuppressWarnings('LineLength')
     @Tag("BAT")
@@ -249,7 +255,7 @@ QC+pUMTUP/ZmrvmKaA+pi55F+w3LqVJ17zwXKjaOEiEpn/+lntl/ieweeQ==
         expect:
         "Verify deployment has expected violations"
         if (expectViolations) {
-            assert waitForViolation(deployment.name, policyName, 5)
+            assert waitForViolation(deployment.name, policyName)
         } else {
             assert checkForNoViolations(deployment.name, policyName, 15)
         }


### PR DESCRIPTION
## Description

Currently, sporadically, the image signature verification tests fail due to timeout issues when fetching the metadata of the image:
```log
image/service: 2023/03/13 15:57:04.735695 service_impl.go:285: Error: error enriching image \"quay.io/rhacs-eng/qa-signatures@sha256:5bc15c838843506f6aaa6fa8d03b8d83f15b936a0362d6732afa0f45135fcf54\": image enrichment error: error getting metadata for image: 
quay.io/rhacs-eng/qa-signatures@sha256:5bc15c838843506f6aaa6fa8d03b8d83f15b936a0362d6732afa0f45135fcf54 errors: [getting metadata from registry: \"core quay\": Failed to get the manifest digest : Head 
\"https://quay.io/v2/rhacs-eng/qa-signatures/manifests/sha256:5bc15c838843506f6aaa6fa8d03b8d83f15b936a0362d6732afa0f45135fcf54\": context deadline exceeded (Client.Timeout exceeded while awaiting headers), getting metadata from registry: \"Autogenerated https://quay.io for cluster remote\": Get 
\"https://quay.io/v2/rhacs-eng/qa-signatures/manifests/sha256:5bc15c838843506f6aaa6fa8d03b8d83f15b936a0362d6732afa0f45135fcf54\": context deadline exceeded (Client.Timeout exceeded while awaiting headers), getting metadata from registry: \"Public Quay.io\": Failed to get the manifest digest : Head 
\"https://quay.io/v2/rhacs-eng/qa-signatures/manifests/sha256:5bc15c838843506f6aaa6fa8d03b8d83f15b936a0362d6732afa0f45135fcf54\": http: non-successful response (status=401 body=\"\")]
```

Within the current tests, the tests will be retried, but no reassessment of the policies will be triggered, since we only have `setup/cleanupSpec` defined.

Now, defined a `setup` which calls `reassessPolicies`, which internally will trigger a re-enrichment of images, possibly avoiding the timeout issue we run into beforehand.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

- see CI passing.
