### PR TITLE
ROX-10998: Verify role references in groups before deletion

### DIFF
--- a/central/group/datastore/datastore.go
+++ b/central/group/datastore/datastore.go
@@ -13,7 +13,7 @@ import (
 type DataStore interface {
 	Get(ctx context.Context, props *storage.GroupProperties) (*storage.Group, error)
 	GetAll(ctx context.Context) ([]*storage.Group, error)
-	GetFiltered(ctx context.Context, filter func(*storage.GroupProperties) bool) ([]*storage.Group, error)
+	GetFiltered(ctx context.Context, filter func(*storage.Group) bool) ([]*storage.Group, error)
 
 	Walk(ctx context.Context, authProviderID string, attributes map[string][]string) ([]*storage.Group, error)
 

--- a/central/group/datastore/datastore_impl_test.go
+++ b/central/group/datastore/datastore_impl_test.go
@@ -145,7 +145,7 @@ func (s *groupDataStoreTestSuite) TestAllowsGetAll() {
 func (s *groupDataStoreTestSuite) TestEnforcesGetFiltered() {
 	s.storage.EXPECT().Walk(gomock.Any(), gomock.Any()).Times(0)
 
-	groups, err := s.dataStore.GetFiltered(s.hasNoneCtx, func(_ *storage.GroupProperties) bool { return true })
+	groups, err := s.dataStore.GetFiltered(s.hasNoneCtx, func(_ *storage.Group) bool { return true })
 	s.NoError(err, "expected no error, should return nil without access")
 	s.Nil(groups, "expected return value to be nil")
 }
@@ -153,12 +153,12 @@ func (s *groupDataStoreTestSuite) TestEnforcesGetFiltered() {
 func (s *groupDataStoreTestSuite) TestAllowsGetFiltered() {
 	s.storage.EXPECT().Walk(gomock.Any(), gomock.Any()).Return(nil)
 
-	_, err := s.dataStore.GetFiltered(s.hasReadCtx, func(_ *storage.GroupProperties) bool { return true })
+	_, err := s.dataStore.GetFiltered(s.hasReadCtx, func(_ *storage.Group) bool { return true })
 	s.NoError(err, "expected no error trying to read with permissions")
 
 	s.storage.EXPECT().Walk(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 
-	_, err = s.dataStore.GetFiltered(s.hasWriteCtx, func(_ *storage.GroupProperties) bool { return true })
+	_, err = s.dataStore.GetFiltered(s.hasWriteCtx, func(_ *storage.Group) bool { return true })
 	s.NoError(err, "expected no error trying to read with permissions")
 }
 
@@ -166,13 +166,13 @@ func (s *groupDataStoreTestSuite) TestGetFiltered() {
 	groups := fixtures.GetGroups()
 	s.storage.EXPECT().Walk(gomock.Any(), gomock.Any()).Times(2).DoAndReturn(walkMockFunc(groups))
 
-	actualGroups, err := s.dataStore.GetFiltered(s.hasWriteCtx, func(*storage.GroupProperties) bool { return false })
+	actualGroups, err := s.dataStore.GetFiltered(s.hasWriteCtx, func(*storage.Group) bool { return false })
 	s.NoError(err)
 	s.Empty(actualGroups)
 
 	// Test with a selective filter
-	actualGroups, err = s.dataStore.GetFiltered(s.hasWriteCtx, func(props *storage.GroupProperties) bool {
-		return props.GetAuthProviderId() == "authProvider1" || props.GetKey() == "Attribute2"
+	actualGroups, err = s.dataStore.GetFiltered(s.hasWriteCtx, func(group *storage.Group) bool {
+		return group.GetProps().GetAuthProviderId() == "authProvider1" || group.GetProps().GetKey() == "Attribute2"
 	})
 	expectedGroups := []*storage.Group{
 		groups[1], groups[2], groups[3], groups[4], groups[6],

--- a/central/group/datastore/mocks/datastore.go
+++ b/central/group/datastore/mocks/datastore.go
@@ -80,7 +80,7 @@ func (mr *MockDataStoreMockRecorder) GetAll(ctx interface{}) *gomock.Call {
 }
 
 // GetFiltered mocks base method.
-func (m *MockDataStore) GetFiltered(ctx context.Context, filter func(*storage.GroupProperties) bool) ([]*storage.Group, error) {
+func (m *MockDataStore) GetFiltered(ctx context.Context, filter func(*storage.Group) bool) ([]*storage.Group, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetFiltered", ctx, filter)
 	ret0, _ := ret[0].([]*storage.Group)

--- a/central/group/service/service_impl.go
+++ b/central/group/service/service_impl.go
@@ -67,19 +67,19 @@ func (s *serviceImpl) GetGroups(ctx context.Context, req *v1.GetGroupsRequest) (
 		id = &m.Id
 	}
 
-	var filter func(*storage.GroupProperties) bool
+	var filter func(*storage.Group) bool
 	if authProvider != nil || key != nil || value != nil || id != nil {
-		filter = func(props *storage.GroupProperties) bool {
-			if authProvider != nil && *authProvider != props.GetAuthProviderId() {
+		filter = func(group *storage.Group) bool {
+			if authProvider != nil && *authProvider != group.GetProps().GetAuthProviderId() {
 				return false
 			}
-			if key != nil && *key != props.GetKey() {
+			if key != nil && *key != group.GetProps().GetKey() {
 				return false
 			}
-			if value != nil && *value != props.GetValue() {
+			if value != nil && *value != group.GetProps().GetValue() {
 				return false
 			}
-			if id != nil && *id != props.GetId() {
+			if id != nil && *id != group.GetProps().GetId() {
 				return false
 			}
 			return true

--- a/central/role/datastore/datastore.go
+++ b/central/role/datastore/datastore.go
@@ -3,6 +3,7 @@ package datastore
 import (
 	"context"
 
+	groupDS "github.com/stackrox/rox/central/group/datastore"
 	rocksDBStore "github.com/stackrox/rox/central/role/store"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/auth/permissions"
@@ -40,10 +41,12 @@ type DataStore interface {
 }
 
 // New returns a new DataStore instance.
-func New(roleStorage rocksDBStore.RoleStore, permissionSetStore rocksDBStore.PermissionSetStore, accessScopeStore rocksDBStore.SimpleAccessScopeStore) DataStore {
+func New(roleStorage rocksDBStore.RoleStore, permissionSetStore rocksDBStore.PermissionSetStore,
+	accessScopeStore rocksDBStore.SimpleAccessScopeStore, groupStore groupDS.DataStore) DataStore {
 	return &dataStoreImpl{
 		roleStorage:          roleStorage,
 		permissionSetStorage: permissionSetStore,
 		accessScopeStorage:   accessScopeStore,
+		groupStorage:         groupStore,
 	}
 }

--- a/central/role/datastore/datastore_test.go
+++ b/central/role/datastore/datastore_test.go
@@ -357,11 +357,6 @@ func (s *roleDataStoreTestSuite) TestRoleWriteOperations() {
 	s.ErrorIs(err, errox.InvalidArgs, "invalid scope for Upsert*() yields an error(declarative resource)")
 }
 
-func (s *roleDataStoreTestSuite) TestRoleGroupReferences() {
-	// 1. If a group is returned, deletion should not be possible for the group.
-
-}
-
 ////////////////////////////////////////////////////////////////////////////////
 // Permission sets                                                            //
 //                                                                            //

--- a/central/role/datastore/datastore_test_constructors.go
+++ b/central/role/datastore/datastore_test_constructors.go
@@ -3,6 +3,8 @@ package datastore
 import (
 	"testing"
 
+	"github.com/golang/mock/gomock"
+	groupMock "github.com/stackrox/rox/central/group/datastore/mocks"
 	permissionSetPostgresStore "github.com/stackrox/rox/central/role/store/permissionset/postgres"
 	permissionSetRocksDBStore "github.com/stackrox/rox/central/role/store/permissionset/rocksdb"
 	rolePostgresStore "github.com/stackrox/rox/central/role/store/role/postgres"
@@ -14,16 +16,17 @@ import (
 )
 
 // GetTestPostgresDataStore provides a datastore connected to postgres for testing purposes.
-func GetTestPostgresDataStore(_ *testing.T, pool *postgres.DB) (DataStore, error) {
+func GetTestPostgresDataStore(t *testing.T, pool *postgres.DB) (DataStore, error) {
 	permissionStore := permissionSetPostgresStore.New(pool)
 	roleStore := rolePostgresStore.New(pool)
 	scopeStore := accessScopePostgresStore.New(pool)
+	groupsDataStore := groupMock.NewMockDataStore(gomock.NewController(t))
 
-	return New(roleStore, permissionStore, scopeStore), nil
+	return New(roleStore, permissionStore, scopeStore, groupsDataStore), nil
 }
 
 // GetTestRocksBleveDataStore provides a datastore connected to rocksdb and bleve for testing purposes.
-func GetTestRocksBleveDataStore(_ *testing.T, rocksengine *rocksdbBase.RocksDB) (DataStore, error) {
+func GetTestRocksBleveDataStore(t *testing.T, rocksengine *rocksdbBase.RocksDB) (DataStore, error) {
 	permissionStore, err := permissionSetRocksDBStore.New(rocksengine)
 	if err != nil {
 		return nil, err
@@ -36,6 +39,7 @@ func GetTestRocksBleveDataStore(_ *testing.T, rocksengine *rocksdbBase.RocksDB) 
 	if err != nil {
 		return nil, err
 	}
+	groupsDataStore := groupMock.NewMockDataStore(gomock.NewController(t))
 
-	return New(roleStore, permissionStore, scopeStore), nil
+	return New(roleStore, permissionStore, scopeStore, groupsDataStore), nil
 }

--- a/central/role/datastore/singleton.go
+++ b/central/role/datastore/singleton.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/stackrox/rox/central/globaldb"
+	groupDS "github.com/stackrox/rox/central/group/datastore"
 	rolePkg "github.com/stackrox/rox/central/role"
 	"github.com/stackrox/rox/central/role/resources"
 	"github.com/stackrox/rox/central/role/store"
@@ -47,7 +48,7 @@ func Singleton() DataStore {
 			utils.CrashOnError(err)
 		}
 		// Which role format is used is determined solely by the feature flag.
-		ds = New(roleStorage, permissionSetStorage, accessScopeStorage)
+		ds = New(roleStorage, permissionSetStorage, accessScopeStorage, groupDS.Singleton())
 
 		for r, a := range vulnReportingDefaultRoles {
 			defaultRoles[r] = a


### PR DESCRIPTION
## Description

Previously, it was possible to delete role that were referenced by groups in auth providers (potentially also the minimum access role), leading to breaking auth provider's behavior when deleting such a role.

Now, before deleting a role, it will be first checked whether this role is referenced by any groups. If that's the case, an error will be returned indicating the number of groups that reference the role.

Note that this required a minor refactoring in the group datastore: instead of having the filter in `GetFiltered` filter on `storage.GroupProperties`, the filter now works on `storage.Group` (which it should have in the first place).

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

- see CI (added unit tests, adjusted existing ones).
