### PR TITLE
ROX-14756: Log slow queries at most once every 30m

### DIFF
--- a/pkg/env/slow_query_threshold.go
+++ b/pkg/env/slow_query_threshold.go
@@ -1,0 +1,8 @@
+package env
+
+import "time"
+
+var (
+	// SlowQueryThreshold determines what should be considered a slow query for logging purposes
+	SlowQueryThreshold = registerDurationSetting("ROX_SLOW_QUERY_THRESHOLD", 30*time.Second)
+)

--- a/pkg/postgres/log.go
+++ b/pkg/postgres/log.go
@@ -3,6 +3,7 @@ package postgres
 import (
 	"time"
 
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/sync"
 	"go.uber.org/atomic"
@@ -10,7 +11,7 @@ import (
 )
 
 var (
-	slowQueryThreshold      = 30 * time.Second
+	slowQueryThreshold      = env.SlowQueryThreshold.DurationSetting()
 	slowQueryLogRate        = rate.Every(30 * time.Minute)
 	slowQueryLock           sync.Mutex
 	slowQueryRateLimiterMap = make(map[string]*slowQueryEntry)

--- a/pkg/postgres/log.go
+++ b/pkg/postgres/log.go
@@ -1,0 +1,50 @@
+package postgres
+
+import (
+	"time"
+
+	"github.com/stackrox/rox/pkg/logging"
+	"github.com/stackrox/rox/pkg/sync"
+	"go.uber.org/atomic"
+	"golang.org/x/time/rate"
+)
+
+var (
+	slowQueryThreshold      = 30 * time.Second
+	slowQueryLogRate        = rate.Every(30 * time.Minute)
+	slowQueryLock           sync.Mutex
+	slowQueryRateLimiterMap = make(map[string]*slowQueryEntry)
+
+	log = logging.LoggerForModule()
+)
+
+type slowQueryEntry struct {
+	limiter  *rate.Limiter
+	numTimes *atomic.Int32
+}
+
+func getRateLimiter(sql string) *slowQueryEntry {
+	slowQueryLock.Lock()
+	defer slowQueryLock.Unlock()
+	if slowQuery, ok := slowQueryRateLimiterMap[sql]; ok {
+		slowQuery.numTimes.Add(1)
+		return slowQuery
+	}
+	slowQuery := &slowQueryEntry{
+		limiter:  rate.NewLimiter(slowQueryLogRate, 1),
+		numTimes: atomic.NewInt32(1),
+	}
+	slowQueryRateLimiterMap[sql] = slowQuery
+	return slowQuery
+}
+
+func logSlowQuery(start time.Time, sql string) {
+	took := time.Since(start)
+	if took < slowQueryThreshold {
+		return
+	}
+	slowQuery := getRateLimiter(sql)
+	if slowQuery.limiter.Allow() {
+		log.Warnf("Slow query detected %d times. Most recent took %0.2f seconds: %s", slowQuery.numTimes.Load(), took.Seconds(), sql)
+	}
+}

--- a/pkg/postgres/metrics.go
+++ b/pkg/postgres/metrics.go
@@ -39,6 +39,9 @@ func setQueryDuration(t time.Time, scope, query string) {
 		query = stringutils.GetUpTo(query, "_")
 	}
 	query = strings.ReplaceAll(query, "\n", " ")
+
+	logSlowQuery(t, query)
+
 	queryDuration.With(prometheus.Labels{"scope": scope, "query": query}).Observe(float64(time.Since(t).Milliseconds()))
 }
 


### PR DESCRIPTION
## Description

If an individual query takes > 30s, then log it. Only log it once per 30m but keep track of how many times it took to long between the log lines

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Will run under scale and see some logs hopefully