### PR TITLE
[ROX-15808] : Fix for watched images not getting scanned more than once

### DIFF
--- a/pkg/images/enricher/enricher_impl.go
+++ b/pkg/images/enricher/enricher_impl.go
@@ -215,6 +215,9 @@ func setImageNotes(image *storage.Image, imageNoteSet map[storage.Image_Note]str
 // depending on whether the values exist and the given FetchOption allows using existing values.
 // It will return a bool indicating whether existing values from database will be used for the signature.
 func (e *enricherImpl) updateImageFromDatabase(ctx context.Context, img *storage.Image, option FetchOption) bool {
+	if option == IgnoreExistingImages {
+		return false
+	}
 	existingImg, exists := e.fetchFromDatabase(ctx, img, option)
 	// Short-circuit if no image exists or the FetchOption specifies to not use existing values.
 	if !exists {

--- a/pkg/images/enricher/enricher_impl_test.go
+++ b/pkg/images/enricher/enricher_impl_test.go
@@ -48,6 +48,10 @@ func imageGetterFromImage(image *storage.Image) ImageGetter {
 	}
 }
 
+func imageGetterPanicOnCall(_ context.Context, _ string) (*storage.Image, bool, error) {
+	panic("Unexpected call to imageGetter")
+}
+
 var _ signatures.SignatureFetcher = (*fakeSigFetcher)(nil)
 
 type fakeSigFetcher struct {
@@ -368,6 +372,7 @@ func TestEnricherFlow(t *testing.T) {
 				Names: []*storage.ImageName{{Registry: "reg"}},
 				Scan:  &storage.ImageScan{},
 			},
+			imageGetter: imageGetterPanicOnCall,
 			fsr: newFakeRegistryScanner(opts{
 				requestedMetadata: true,
 				requestedScan:     true,
@@ -384,7 +389,7 @@ func TestEnricherFlow(t *testing.T) {
 			},
 			inMetadataCache:      true,
 			shortCircuitRegistry: false,
-			shortCircuitScanner:  true,
+			shortCircuitScanner:  false,
 			image: &storage.Image{
 				Id:       "id",
 				Metadata: &storage.ImageMetadata{},
@@ -392,14 +397,10 @@ func TestEnricherFlow(t *testing.T) {
 				Name:     &storage.ImageName{Registry: "reg"},
 				Names:    []*storage.ImageName{{Registry: "reg"}},
 			},
-			imageGetter: imageGetterFromImage(&storage.Image{
-				Id:       "id",
-				Metadata: &storage.ImageMetadata{},
-				Scan:     &storage.ImageScan{},
-			}),
+			imageGetter: imageGetterPanicOnCall,
 			fsr: newFakeRegistryScanner(opts{
 				requestedMetadata: false,
-				requestedScan:     false,
+				requestedScan:     true,
 			}),
 			result: EnrichmentResult{
 				ImageUpdated: true,


### PR DESCRIPTION
## Description
In `pkg/images/enricher/enricher_impl.go`, func `EnrichImage` gets called for enriching watched images with option `IgnoreExistingImages`. When this option is set, we should not look for existing image in database to populate the image scan. However, we were not checking for that option in `updateImageFromDatabase` . Due to this, watched images were rescanned only when their SHA changed instead of getting rescanned every 4 hours. The fix is to check for `IgnoreExistingImages` in `updateImageFromDatabase` and return without doing db lookup if the option is set. This will force fresh scan, signature and signature verification of image every 4 hours.


## Checklist
- [X] Investigated and inspected CI test results
- [X] Unit test and regression tests added
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

Unit tests

Manual tests

![FB6370EA-4692-4B42-8F85-4BC88B95C8A5_1_105_c](https://user-images.githubusercontent.com/101146970/226409200-f63971d1-a091-4e27-952f-cb3c75d0493f.jpeg)

![4A34361A-5102-4678-AEFC-49BB499123F7_1_105_c](https://user-images.githubusercontent.com/101146970/226409238-fde62a61-15bc-4a79-8e5a-8e36c308adc4.jpeg)


In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
