### PR TITLE
Replace arrow function in conditional skip for vulnmanagement policies test

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnmanagement/policies.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/policies.test.js
@@ -84,7 +84,7 @@ describe('Vulnerability Management Policies', () => {
 
     // Some tests might fail in local deployment.
 
-    it('should display links for failing deployments', () => {
+    it('should display links for failing deployments', function () {
         if (hasOrchestratorFlavor('openshift')) {
             this.skip();
         }


### PR DESCRIPTION
## Description

Oops, how did I miss the following error in #5216

> TypeError: Cannot read properties of undefined (reading 'skip')

For arrow function, `this` is at module scope, therefore `undefined` here!

```diff
-     it('should display links for failing deployments', () => {
+     it('should display links for failing deployments', function () {
         if (hasOrchestratorFlavor('openshift')) {
             this.skip();
         }
```

P.S. Although TypeScript would have reported this as an error, pardon pun, integration tests are in JavaScript. Sadly, ESLint rule `no-invalid-this` would have reported the correct `function` as an error, because makes such restrictive assumptions about where `this` is valid.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration test

## Testing Performed