### PR TITLE
ROX-10901: Fix kustomize image command in operator make deploy target

### DIFF
--- a/operator/Makefile
+++ b/operator/Makefile
@@ -327,7 +327,7 @@ deploy: check-ci-setup manifests kustomize ## Deploy operator image to the K8s c
 		mkdir config/local-deploy-versioned && \
 		cd config/local-deploy-versioned && \
 		$(KUSTOMIZE) create --resources ../default && \
-		$(KUSTOMIZE) edit set image controller=$(IMG)
+		$(KUSTOMIZE) edit set image quay.io/stackrox-io/stackrox-operator=$(IMG)
 	$(KUSTOMIZE) build config/local-deploy-versioned | kubectl create -f -
 
 .PHONY: undeploy


### PR DESCRIPTION
## Description

The `make deploy` target in operators Makefile is always deploying the same image `quay.io/stackrox-io/stackrox-operator:0.0.1`, although it tries to set the image with the `kustomize` CLI tool. It turned out that the `make bundle` stage already replaces the image assumed by the kustomize command executed in `make deploy`. By change the image string asumed by the `make deploy` target it is working properly.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~ only dev tooling affected
- ~[ ] Evaluated and added CHANGELOG entry if required~ 
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

Most checklist items skipped because only dev tooling is affected by this change.

## Testing Performed

- Start a local k8s cluster
- Follow the operator [README.md launch the operator on local cluster section](https://github.com/stackrox/stackrox/tree/master/operator#launch-the-operator-on-the-local-cluster)
- Verify the image after running `make deploy` is the image generated by `make image-tag-base` and `make tag`
