### PR TITLE
Fix feature_flag test by accounting for active vuln mgmt

### DIFF
--- a/tests/feature_flag_test.go
+++ b/tests/feature_flag_test.go
@@ -47,6 +47,7 @@ func TestFeatureFlagSettings(t *testing.T) {
 
 	// TODO(ROX-14939): Remove this with environment variable
 	delete(actualFlagVals, env.PostgresDatastoreEnabled.EnvVar())
+	delete(actualFlagVals, env.ActiveVulnMgmt.EnvVar())
 
 	assert.Equal(t, expectedFlagVals, actualFlagVals, "mismatch between expected and actual feature flag settings")
 }

--- a/tests/feature_flag_test.go
+++ b/tests/feature_flag_test.go
@@ -45,7 +45,7 @@ func TestFeatureFlagSettings(t *testing.T) {
 		actualFlagVals[flag.GetEnvVar()] = flag.GetEnabled()
 	}
 
-	// TODO(ROX-14939): Remove this with environment variable
+	// TODO(ROX-14939): Refactor feature flag logic to include environment variables
 	delete(actualFlagVals, env.PostgresDatastoreEnabled.EnvVar())
 	delete(actualFlagVals, env.ActiveVulnMgmt.EnvVar())
 


### PR DESCRIPTION
## Description

Feature flag test broke when I added active vuln mgmt to the flags returned to the UI

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Test should pass? Not sure how to get it to run actually
