### PR TITLE
Remove an unused duplicate db password in public value example

### DIFF
--- a/image/templates/helm/stackrox-central/values-private.yaml.example
+++ b/image/templates/helm/stackrox-central/values-private.yaml.example
@@ -123,18 +123,15 @@
 #     htpasswd: |
 #       admin:<bcrypt hash>
 #
-#   # The password to be used for authenticating central database access IF USING POSTGRES.
-#   # This is not user-relevant and only serves to properly secure the database with a
-#   # pre-shared secret. If this setting is omitted, a password will be automatically generated
-#   # upon initial deployment, and the existing password will be used upon upgrades.
-#   dbPassword:
-#     value: <central database password value>
-#
 #   # Secret configuration options for the StackRox Central DB deployment.
 #   db:
+#     # The password to be used for authenticating central database access IF USING POSTGRES.
+#     # This is not user-relevant and only serves to properly secure the database with a
+#     # pre-shared secret. If this setting is omitted, a password will be automatically generated
+#     # upon initial deployment, and the existing password will be used upon upgrades.
 #     password:
 #       # The plaintext value of the administrator password.
-#       value: <pre-configured administrator password>
+#       value: <central database password value>
 #     # Internal "central-db.stackrox.svc" service TLS certificate for the Central DB deployment.
 #     # Omit to auto-generate (initial deployment) or use existing (upgrade).
 #     serviceTLS:


### PR DESCRIPTION
## Description

Found this entry of dbPassword is not in use as of now. It seems to be a leftover from previous solution.
So remove it from public facing doc.

## Checklist
- [ ] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

Went through git search for dbPassword and all existing usage is for scanner.
