### PR TITLE
Add pagination and sorting to image single table

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageSingleVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageSingleVulnerabilities.tsx
@@ -11,6 +11,7 @@ import {
     GridItem,
     Label,
     PageSection,
+    Pagination,
     pluralize,
     Spinner,
     Split,
@@ -28,52 +29,24 @@ import { VulnerabilitySeverity } from 'types/cve.proto';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import useURLStringUnion from 'hooks/useURLStringUnion';
 import useURLSearch from 'hooks/useURLSearch';
+import useURLPagination from 'hooks/useURLPagination';
+import useURLSort, { UseURLSortProps } from 'hooks/useURLSort';
 import { getHasSearchApplied } from 'utils/searchUtils';
 import { cveStatusTabValues, FixableStatus } from './types';
 import WorkloadTableToolbar from './WorkloadTableToolbar';
 import BySeveritySummaryCard from './SummaryCards/BySeveritySummaryCard';
 import CvesByStatusSummaryCard from './SummaryCards/CvesByStatusSummaryCard';
 import SingleEntityVulnerabilitiesTable from './Tables/SingleEntityVulnerabilitiesTable';
-import useImageVulnerabilities, {
-    ImageVulnerabilitiesResponse,
-} from './hooks/useImageVulnerabilities';
 import { ImageDetailsResponse } from './hooks/useImageDetails';
+import useImageVulnerabilities from './hooks/useImageVulnerabilities';
 
-function severityCountsFromImageVulnerabilities(
-    imageVulnerabilities: ImageVulnerabilitiesResponse['image']['imageVulnerabilities']
-): Record<VulnerabilitySeverity, number> {
-    const severityCounts = {
-        LOW_VULNERABILITY_SEVERITY: 0,
-        MODERATE_VULNERABILITY_SEVERITY: 0,
-        IMPORTANT_VULNERABILITY_SEVERITY: 0,
-        CRITICAL_VULNERABILITY_SEVERITY: 0,
-    };
-
-    imageVulnerabilities.forEach(({ severity }) => {
-        severityCounts[severity] += 1;
-    });
-
-    return severityCounts;
-}
-
-function statusCountsFromImageVulnerabilities(
-    imageVulnerabilities: ImageVulnerabilitiesResponse['image']['imageVulnerabilities']
-): Record<FixableStatus, number> {
-    const statusCounts = {
-        Fixable: 0,
-        'Not fixable': 0,
-    };
-
-    imageVulnerabilities.forEach(({ isFixable }) => {
-        if (isFixable) {
-            statusCounts.Fixable += 1;
-        } else {
-            statusCounts['Not fixable'] += 1;
-        }
-    });
-
-    return statusCounts;
-}
+const defaultSortOptions: UseURLSortProps = {
+    sortFields: ['CVE', 'Severity', 'Fixable'],
+    defaultSortOption: {
+        field: 'Severity',
+        direction: 'desc',
+    },
+};
 
 export type ImageSingleVulnerabilitiesProps = {
     imageId: string;
@@ -82,12 +55,22 @@ export type ImageSingleVulnerabilitiesProps = {
 
 function ImageSingleVulnerabilities({ imageId, imageData }: ImageSingleVulnerabilitiesProps) {
     const { searchFilter } = useURLSearch();
+    const { page, perPage, setPage, setPerPage } = useURLPagination(50);
+    // TODO Need to reset current page at the same time sorting changes
+    const { sortOption, getSortParams } = useURLSort(defaultSortOptions);
     // TODO Still need to properly integrate search filter with query
-    const { data, loading, error } = useImageVulnerabilities(imageId, {});
+    const pagination = {
+        offset: (page - 1) * perPage,
+        limit: perPage,
+        sortOption,
+    };
+    const { data, previousData, loading, error } = useImageVulnerabilities(imageId, {}, pagination);
 
     const [activeTabKey, setActiveTabKey] = useURLStringUnion('cveStatus', cveStatusTabValues);
 
     let mainContent: ReactNode | null = null;
+
+    const vulnerabilityData = data || previousData;
 
     if (error) {
         mainContent = (
@@ -102,19 +85,20 @@ function ImageSingleVulnerabilities({ imageId, imageData }: ImageSingleVulnerabi
                 </EmptyState>
             </Bullseye>
         );
-    } else if (loading && !data) {
+    } else if (loading && !vulnerabilityData) {
         mainContent = (
             <Bullseye>
                 <Spinner isSVG />
             </Bullseye>
         );
-    } else if (data) {
-        const vulnerabilities = data.image.imageVulnerabilities;
-        const severityCounts = severityCountsFromImageVulnerabilities(vulnerabilities);
-        const cveStatusCounts = statusCountsFromImageVulnerabilities(vulnerabilities);
+    } else if (vulnerabilityData) {
+        const vulnerabilities = vulnerabilityData.image.imageVulnerabilities;
+
         // TODO Integrate these with page search filters
         const hiddenSeverities = new Set<VulnerabilitySeverity>([]);
         const hiddenStatuses = new Set<FixableStatus>([]);
+
+        const totalVulnerabilityCount = vulnerabilityData.image.imageVulnerabilityCounter.all.total;
 
         mainContent = (
             <>
@@ -123,13 +107,13 @@ function ImageSingleVulnerabilities({ imageId, imageData }: ImageSingleVulnerabi
                         <GridItem sm={12} md={6} xl2={4}>
                             <BySeveritySummaryCard
                                 title="CVEs by severity"
-                                severityCounts={severityCounts}
+                                severityCounts={vulnerabilityData.image.imageVulnerabilityCounter}
                                 hiddenSeverities={hiddenSeverities}
                             />
                         </GridItem>
                         <GridItem sm={12} md={6} xl2={4}>
                             <CvesByStatusSummaryCard
-                                cveStatusCounts={cveStatusCounts}
+                                cveStatusCounts={vulnerabilityData.image.imageVulnerabilityCounter}
                                 hiddenStatuses={hiddenStatuses}
                             />
                         </GridItem>
@@ -141,12 +125,7 @@ function ImageSingleVulnerabilities({ imageId, imageData }: ImageSingleVulnerabi
                         <SplitItem isFilled>
                             <Flex alignContent={{ default: 'alignContentCenter' }}>
                                 <Title headingLevel="h2">
-                                    {pluralize(
-                                        data.image.imageVulnerabilities.length,
-                                        'result',
-                                        'results'
-                                    )}{' '}
-                                    found
+                                    {pluralize(totalVulnerabilityCount, 'result', 'results')} found
                                 </Title>
                                 {getHasSearchApplied(searchFilter) && (
                                     <Label isCompact color="blue" icon={<InfoCircleIcon />}>
@@ -155,11 +134,26 @@ function ImageSingleVulnerabilities({ imageId, imageData }: ImageSingleVulnerabi
                                 )}
                             </Flex>
                         </SplitItem>
-                        <SplitItem>TODO Pagination</SplitItem>
+                        <SplitItem>
+                            <Pagination
+                                isCompact
+                                itemCount={totalVulnerabilityCount}
+                                page={page}
+                                perPage={perPage}
+                                onSetPage={(_, newPage) => setPage(newPage)}
+                                onPerPageSelect={(_, newPerPage) => {
+                                    if (totalVulnerabilityCount < (page - 1) * newPerPage) {
+                                        setPage(1);
+                                    }
+                                    setPerPage(newPerPage);
+                                }}
+                            />
+                        </SplitItem>
                     </Split>
                     <SingleEntityVulnerabilitiesTable
                         image={imageData}
-                        imageVulnerabilities={data.image.imageVulnerabilities}
+                        imageVulnerabilities={vulnerabilities}
+                        getSortParams={getSortParams}
                     />
                 </div>
             </>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageSingleVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageSingleVulnerabilities.tsx
@@ -70,7 +70,7 @@ function ImageSingleVulnerabilities({ imageId, imageData }: ImageSingleVulnerabi
 
     let mainContent: ReactNode | null = null;
 
-    const vulnerabilityData = data || previousData;
+    const vulnerabilityData = data ?? previousData;
 
     if (error) {
         mainContent = (

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/SummaryCards/BySeveritySummaryCard.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/SummaryCards/BySeveritySummaryCard.tsx
@@ -5,19 +5,26 @@ import SeverityIcons from 'Components/PatternFly/SeverityIcons';
 
 import { VulnerabilitySeverity } from 'types/cve.proto';
 import { vulnerabilitySeverityLabels } from 'messages/common';
+import { SVGIconProps } from '@patternfly/react-icons/dist/esm/createIcon';
+import {
+    ImageVulnerabilityCounter,
+    ImageVulnerabilityCounterKey,
+} from '../hooks/useImageVulnerabilities';
 
 export type BySeveritySummaryCardProps = {
     title: string;
-    severityCounts: Record<VulnerabilitySeverity, number>;
+    severityCounts: ImageVulnerabilityCounter;
     hiddenSeverities: Set<VulnerabilitySeverity>;
 };
 
-const severitiesCriticalToLow = [
-    'CRITICAL_VULNERABILITY_SEVERITY',
-    'IMPORTANT_VULNERABILITY_SEVERITY',
-    'MODERATE_VULNERABILITY_SEVERITY',
-    'LOW_VULNERABILITY_SEVERITY',
-] as const;
+const vulnCounterToSeverity: Record<ImageVulnerabilityCounterKey, VulnerabilitySeverity> = {
+    low: 'LOW_VULNERABILITY_SEVERITY',
+    moderate: 'MODERATE_VULNERABILITY_SEVERITY',
+    important: 'IMPORTANT_VULNERABILITY_SEVERITY',
+    critical: 'CRITICAL_VULNERABILITY_SEVERITY',
+} as const;
+
+const severitiesCriticalToLow = ['critical', 'important', 'moderate', 'low'] as const;
 
 const disabledColor100 = 'var(--pf-global--disabled-color--100)';
 const disabledColor200 = 'var(--pf-global--disabled-color--200)';
@@ -34,11 +41,12 @@ function BySeveritySummaryCard({
                 <Grid className="pf-u-pl-sm">
                     {severitiesCriticalToLow.map((severity) => {
                         const count = severityCounts[severity];
-                        const hasNoResults = count === 0;
-                        const isHidden = hiddenSeverities.has(severity);
+                        const hasNoResults = count.total === 0;
+                        const vulnSeverity = vulnCounterToSeverity[severity];
+                        const isHidden = hiddenSeverities.has(vulnSeverity);
 
                         let textColor = '';
-                        let text = `${count} ${vulnerabilitySeverityLabels[severity]}`;
+                        let text = `${count.total} ${vulnerabilitySeverityLabels[vulnSeverity]}`;
 
                         if (isHidden) {
                             textColor = disabledColor100;
@@ -48,16 +56,17 @@ function BySeveritySummaryCard({
                             text = 'No results';
                         }
 
-                        const Icon = SeverityIcons[severity];
+                        const Icon: React.FC<SVGIconProps> | undefined =
+                            SeverityIcons[vulnSeverity];
 
                         return (
-                            <GridItem key={severity} span={6}>
+                            <GridItem key={vulnSeverity} span={6}>
                                 <Flex
                                     className="pf-u-pt-sm"
                                     spaceItems={{ default: 'spaceItemsSm' }}
                                     alignItems={{ default: 'alignItemsCenter' }}
                                 >
-                                    <Icon color={hasNoResults ? textColor : undefined} />
+                                    {Icon && <Icon color={hasNoResults ? textColor : undefined} />}
                                     <Text style={{ color: textColor }}>{text}</Text>
                                 </Flex>
                             </GridItem>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/SummaryCards/CvesByStatusSummaryCard.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/SummaryCards/CvesByStatusSummaryCard.tsx
@@ -3,9 +3,13 @@ import { Card, CardTitle, CardBody, Flex, Text, Grid, GridItem } from '@patternf
 
 import { CheckCircleIcon, ExclamationCircleIcon } from '@patternfly/react-icons';
 import { FixableStatus } from '../types';
+import {
+    ImageVulnerabilityCounter,
+    imageVulnerabilityCounterKeys,
+} from '../hooks/useImageVulnerabilities';
 
 export type CvesByStatusSummaryCardProps = {
-    cveStatusCounts: Record<FixableStatus, number | 'hidden'>;
+    cveStatusCounts: ImageVulnerabilityCounter;
     hiddenStatuses: Set<FixableStatus>;
 };
 
@@ -14,15 +18,25 @@ const statusDisplays = [
         status: 'Fixable',
         Icon: CheckCircleIcon,
         iconColor: 'var(--pf-global--success-color--100)',
-        text: (counts: CvesByStatusSummaryCardProps['cveStatusCounts']) =>
-            `${counts.Fixable} vulnerabilities with available fixes`,
+        text: (counts: ImageVulnerabilityCounter) => {
+            let count = 0;
+            imageVulnerabilityCounterKeys.forEach((key) => {
+                count += counts[key].fixable;
+            });
+            return `${count} vulnerabilities with available fixes`;
+        },
     },
     {
         status: 'Not fixable',
         Icon: ExclamationCircleIcon,
         iconColor: 'var(--pf-global--danger-color--100)',
-        text: (counts: CvesByStatusSummaryCardProps['cveStatusCounts']) =>
-            `${counts['Not fixable']} vulnerabilities without fixes`,
+        text: (counts: ImageVulnerabilityCounter) => {
+            let count = 0;
+            imageVulnerabilityCounterKeys.forEach((key) => {
+                count += counts[key].total - counts[key].fixable;
+            });
+            return `${count} vulnerabilities without fixes`;
+        },
     },
 ] as const;
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/SummaryCards/CvesByStatusSummaryCard.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/SummaryCards/CvesByStatusSummaryCard.tsx
@@ -1,5 +1,14 @@
 import React from 'react';
-import { Card, CardTitle, CardBody, Flex, Text, Grid, GridItem } from '@patternfly/react-core';
+import {
+    Card,
+    CardTitle,
+    CardBody,
+    Flex,
+    Grid,
+    GridItem,
+    pluralize,
+    Text,
+} from '@patternfly/react-core';
 
 import { CheckCircleIcon, ExclamationCircleIcon } from '@patternfly/react-icons';
 import { FixableStatus } from '../types';
@@ -23,7 +32,7 @@ const statusDisplays = [
             imageVulnerabilityCounterKeys.forEach((key) => {
                 count += counts[key].fixable;
             });
-            return `${count} vulnerabilities with available fixes`;
+            return `${pluralize(count, 'vulnerability', 'vulnerabilities')} with available fixes`;
         },
     },
     {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/SingleEntityVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/SingleEntityVulnerabilitiesTable.tsx
@@ -17,6 +17,7 @@ import SeverityIcons from 'Components/PatternFly/SeverityIcons';
 import useSet from 'hooks/useSet';
 import { vulnerabilitySeverityLabels } from 'messages/common';
 import { getDistanceStrictAsPhrase } from 'utils/dateUtils';
+import { UseURLSortResult } from 'hooks/useURLSort';
 import { ImageVulnerabilitiesResponse } from '../hooks/useImageVulnerabilities';
 import { getEntityPagePath } from '../searchUtils';
 import ImageComponentsTable from './ImageComponentsTable';
@@ -25,11 +26,13 @@ import { ImageDetailsResponse } from '../hooks/useImageDetails';
 export type SingleEntityVulnerabilitiesTableProps = {
     image: ImageDetailsResponse['image'] | undefined;
     imageVulnerabilities: ImageVulnerabilitiesResponse['image']['imageVulnerabilities'];
+    getSortParams: UseURLSortResult['getSortParams'];
 };
 
 function SingleEntityVulnerabilitiesTable({
     image,
     imageVulnerabilities,
+    getSortParams,
 }: SingleEntityVulnerabilitiesTableProps) {
     const expandedRowSet = useSet<string>();
     return (
@@ -37,9 +40,10 @@ function SingleEntityVulnerabilitiesTable({
             <Thead>
                 <Tr>
                     <Th>{/* Header for expanded column */}</Th>
-                    <Th>CVE</Th>
-                    <Th>Severity</Th>
-                    <Th>CVE status</Th>
+                    <Th sort={getSortParams('CVE')}>CVE</Th>
+                    <Th sort={getSortParams('Severity')}>Severity</Th>
+                    <Th sort={getSortParams('Fixable')}>CVE Status</Th>
+                    {/* TODO Add sorting for these columns once aggregate sorting is available in BE */}
                     <Th>Affected components</Th>
                     <Th>First discovered</Th>
                 </Tr>

--- a/ui/apps/platform/src/hooks/useURLSort.ts
+++ b/ui/apps/platform/src/hooks/useURLSort.ts
@@ -6,12 +6,12 @@ import { isParsedQs } from 'utils/queryStringUtils';
 
 export type GetSortParams = (field: string) => ThProps['sort'] | undefined;
 
-type UseTableSortProps = {
+export type UseURLSortProps = {
     sortFields: string[];
     defaultSortOption: SortOption;
 };
 
-type UseTableSortResult = {
+export type UseURLSortResult = {
     sortOption: ApiSortOption;
     getSortParams: GetSortParams;
 };
@@ -27,7 +27,7 @@ function isDirection(val: unknown): val is 'asc' | 'desc' {
     return val === 'asc' || val === 'desc';
 }
 
-function useURLSort({ sortFields, defaultSortOption }: UseTableSortProps): UseTableSortResult {
+function useURLSort({ sortFields, defaultSortOption }: UseURLSortProps): UseURLSortResult {
     const [sortOption, setSortOption] = useURLParameter('sortOption', defaultSortOption);
 
     // get the parsed sort option values from the URL, if available


### PR DESCRIPTION
## Description

Adds server side sorting and pagination to the image single page table.

## Follow ups

- Add appropriate sorting for all fields on the BE is complete and documented in the collab doc

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Visit an image single page and verify that a single page worth's of data has loaded. The default sorting of the table should be by Severity, descending.
![image](https://user-images.githubusercontent.com/1292638/225421992-58ccd3ce-2502-4ac0-bbc0-360cad97a27d.png)

Use the pagination forward/back buttons to verify that pages of data are changed correctly.
![image](https://user-images.githubusercontent.com/1292638/225422122-6fbed833-d04d-4fdc-a482-ab2ae7b4533a.png)

Update the number of items per page and verify that the number of items is changed correctly.
![image](https://user-images.githubusercontent.com/1292638/225422381-d2ae23a4-b6f8-4555-aa64-d8ef1ceaa96d.png)

Test that sorting by CVE, Severity, and CVE Status work correctly.
![image](https://user-images.githubusercontent.com/1292638/225422682-80bede59-0def-4c19-8a43-65cc35a525d3.png)
![image](https://user-images.githubusercontent.com/1292638/225422709-4ad76894-78a6-4732-8262-fbd03413250e.png)
![image](https://user-images.githubusercontent.com/1292638/225422742-8ab86f24-bc19-4171-b297-e81c53d38643.png)
![image](https://user-images.githubusercontent.com/1292638/225422761-b0512389-8e0b-4b62-b12d-0b4f251b9966.png)
![image](https://user-images.githubusercontent.com/1292638/225422782-fa99f6a4-9a4d-460c-886b-62092a0d8aef.png)

Verify that the CVEs by severity and CVEs by status cards have a total count matching that displayed at the top of the table.
