### PR TITLE
Don't reuse violation time sort option pointer

### DIFF
--- a/central/alert/datastore/datastore_impl.go
+++ b/central/alert/datastore/datastore_impl.go
@@ -96,7 +96,7 @@ func (ds *datastoreImpl) ListAlerts(ctx context.Context, request *v1.ListAlertsR
 	}
 
 	paginated.FillPagination(q, request.GetPagination(), math.MaxInt32)
-	q = paginated.FillDefaultSortOption(q, paginated.ViolationTimeSortOption)
+	q = paginated.FillDefaultSortOption(q, paginated.GetViolationTimeSortOption())
 
 	alerts, err := ds.SearchListAlerts(ctx, q)
 	if err != nil {

--- a/central/graphql/resolvers/deploymentevents.go
+++ b/central/graphql/resolvers/deploymentevents.go
@@ -349,7 +349,7 @@ func (resolver *Resolver) getPolicyViolationEvents(ctx context.Context, query *v
 		return nil, err
 	}
 
-	query = paginated.FillDefaultSortOption(query, paginated.ViolationTimeSortOption)
+	query = paginated.FillDefaultSortOption(query, paginated.GetViolationTimeSortOption())
 	alerts, err := resolver.ViolationsDataStore.SearchRawAlerts(ctx, query)
 	if err != nil {
 		return nil, errors.Wrap(err, "retrieving alerts from search")

--- a/central/graphql/resolvers/deployments.go
+++ b/central/graphql/resolvers/deployments.go
@@ -204,7 +204,7 @@ func (resolver *deploymentResolver) DeployAlerts(ctx context.Context, args Pagin
 
 	nested.Pagination = pagination
 
-	nested = paginated.FillDefaultSortOption(nested, paginated.ViolationTimeSortOption)
+	nested = paginated.FillDefaultSortOption(nested, paginated.GetViolationTimeSortOption())
 	return resolver.root.wrapAlerts(
 		resolver.root.ViolationsDataStore.SearchRawAlerts(ctx, nested))
 }
@@ -317,7 +317,7 @@ func (resolver *deploymentResolver) FailingPolicies(ctx context.Context, args Pa
 	pagination := q.GetPagination()
 	q.Pagination = &v1.QueryPagination{SortOptions: pagination.GetSortOptions()}
 
-	q = paginated.FillDefaultSortOption(q, paginated.ViolationTimeSortOption)
+	q = paginated.FillDefaultSortOption(q, paginated.GetViolationTimeSortOption())
 	alerts, err := resolver.root.ViolationsDataStore.SearchRawAlerts(ctx, q)
 	if err != nil {
 		return nil, err

--- a/central/graphql/resolvers/namespaces.go
+++ b/central/graphql/resolvers/namespaces.go
@@ -512,7 +512,7 @@ func (resolver *namespaceResolver) getActiveDeployAlerts(ctx context.Context, q 
 			AddExactMatches(search.Namespace, namespace.GetMetadata().GetName()).
 			AddExactMatches(search.ViolationState, storage.ViolationState_ACTIVE.String()).
 			AddExactMatches(search.LifecycleStage, storage.LifecycleStage_DEPLOY.String()).ProtoQuery())
-	q = paginated.FillDefaultSortOption(q, paginated.ViolationTimeSortOption)
+	q = paginated.FillDefaultSortOption(q, paginated.GetViolationTimeSortOption())
 
 	return resolver.root.ViolationsDataStore.SearchListAlerts(ctx, q)
 }

--- a/central/graphql/resolvers/policies.go
+++ b/central/graphql/resolvers/policies.go
@@ -184,7 +184,7 @@ func (resolver *policyResolver) failingDeployments(ctx context.Context, q *v1.Qu
 	alertsQuery := search.ConjunctionQuery(resolver.getPolicyQuery(),
 		search.NewQueryBuilder().AddExactMatches(search.ViolationState, storage.ViolationState_ACTIVE.String()).ProtoQuery())
 
-	alertsQuery = paginated.FillDefaultSortOption(alertsQuery, paginated.ViolationTimeSortOption)
+	alertsQuery = paginated.FillDefaultSortOption(alertsQuery, paginated.GetViolationTimeSortOption())
 	listAlerts, err := resolver.root.ViolationsDataStore.SearchListAlerts(ctx, alertsQuery)
 	if err != nil {
 		return nil, err

--- a/central/graphql/resolvers/violations.go
+++ b/central/graphql/resolvers/violations.go
@@ -35,7 +35,7 @@ func (resolver *Resolver) Violations(ctx context.Context, args PaginatedQuery) (
 		return nil, err
 	}
 
-	q = paginated.FillDefaultSortOption(q, paginated.ViolationTimeSortOption)
+	q = paginated.FillDefaultSortOption(q, paginated.GetViolationTimeSortOption())
 	return resolver.wrapListAlerts(
 		resolver.ViolationsDataStore.SearchListAlerts(ctx, q))
 }

--- a/central/graphql/resolvers/vul_mgmt_widgets.go
+++ b/central/graphql/resolvers/vul_mgmt_widgets.go
@@ -100,7 +100,7 @@ func deploymentsWithMostSevereViolations(ctx context.Context, resolver *Resolver
 		return nil, err
 	}
 
-	q = paginated.FillDefaultSortOption(q, paginated.ViolationTimeSortOption)
+	q = paginated.FillDefaultSortOption(q, paginated.GetViolationTimeSortOption())
 	alerts, err := resolver.ViolationsDataStore.SearchListAlerts(ctx, q)
 	if err != nil {
 		return nil, err

--- a/pkg/search/paginated/options.go
+++ b/pkg/search/paginated/options.go
@@ -5,10 +5,10 @@ import (
 	"github.com/stackrox/rox/pkg/search"
 )
 
-var (
-	// ViolationTimeSortOption is a search options for alerts
-	ViolationTimeSortOption = &v1.QuerySortOption{
+// GetViolationTimeSortOption returns the commonly used violation time sort option
+func GetViolationTimeSortOption() *v1.QuerySortOption {
+	return &v1.QuerySortOption{
 		Field:    search.ViolationTime.String(),
 		Reversed: true,
 	}
-)
+}


### PR DESCRIPTION
## Description

Always return a fresh copy of the sort option which can be modified in many places

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Hopefully run race tests