### PR TITLE
Force reload the page to clear out segment code when opted out

### DIFF
--- a/ui/apps/platform/src/Containers/Clusters/ClustersPage.js
+++ b/ui/apps/platform/src/Containers/Clusters/ClustersPage.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback } from 'react';
 import ReactRouterPropTypes from 'react-router-prop-types';
 import { useQuery } from '@apollo/client';
 

--- a/ui/apps/platform/src/Containers/SystemConfig/Form/SystemConfigForm.tsx
+++ b/ui/apps/platform/src/Containers/SystemConfig/Form/SystemConfigForm.tsx
@@ -111,6 +111,13 @@ const SystemConfigForm = ({
                         if (data.publicConfig?.telemetry?.enabled && telemetryConfig.storageKeyV1) {
                             initializeSegment(telemetryConfig.storageKeyV1, telemetryConfig.userId);
                         }
+
+                        const isTelemetryEnabledPrev = publicConfig.telemetry?.enabled;
+                        const isTelemetryEnabledCurr = data.publicConfig?.telemetry?.enabled;
+                        if (isTelemetryEnabledPrev && !isTelemetryEnabledCurr) {
+                            window.location.reload();
+                        }
+
                         dispatch(action);
                         setSystemConfig(data);
                         setErrorMessage(null);

--- a/ui/apps/platform/src/Containers/SystemConfig/Form/SystemConfigForm.tsx
+++ b/ui/apps/platform/src/Containers/SystemConfig/Form/SystemConfigForm.tsx
@@ -112,17 +112,17 @@ const SystemConfigForm = ({
                             initializeSegment(telemetryConfig.storageKeyV1, telemetryConfig.userId);
                         }
 
-                        const isTelemetryEnabledPrev = publicConfig.telemetry?.enabled;
-                        const isTelemetryEnabledCurr = data.publicConfig?.telemetry?.enabled;
-                        if (isTelemetryEnabledPrev && !isTelemetryEnabledCurr) {
-                            window.location.reload();
-                        }
-
                         dispatch(action);
                         setSystemConfig(data);
                         setErrorMessage(null);
                         setSubmitting(false);
                         setIsNotEditing();
+
+                        const isTelemetryEnabledPrev = publicConfig.telemetry?.enabled;
+                        const isTelemetryEnabledCurr = data.publicConfig?.telemetry?.enabled;
+                        if (isTelemetryEnabledPrev && !isTelemetryEnabledCurr) {
+                            window.location.reload();
+                        }
                     })
                     .catch((error) => {
                         setSubmitting(false);

--- a/ui/apps/platform/src/index.tsx
+++ b/ui/apps/platform/src/index.tsx
@@ -40,7 +40,6 @@ import installRaven from 'installRaven';
 import { ThunkAction, ThunkDispatch } from 'redux-thunk';
 import { fetchFeatureFlagsThunk } from './reducers/featureFlags';
 import { fetchPublicConfigThunk } from './reducers/publicConfig';
-import { fetchTelemetryConfigThunk } from './reducers/telemetryConfig';
 import configureApollo from './configureApolloClient';
 
 // This enables syntax highlighting for the patternfly code editor


### PR DESCRIPTION
## Description

If a user is opted in to telemetry but later opts out, we can stop emitting events to Segment using the public config flag setup in redux `publicConfig.telemetry.enabled` ([see here](https://github.com/stackrox/stackrox/pull/5247)). However, in this scenario, Segment will still be set up on the page. To completely remove the Segment code at that point, we can reload the page. The new public config telemetry value will prevent Segment from being initialized after the page is refreshed.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

With the flag enabled, you can verify segment is initialized in various ways:
* check segments debugger and look for events
* see if `window.analytics` exists
* look for segment/amplitude script tags

Disabling telemetry in the system config should result in none of the above checks to pass
