### PR TITLE
ROX-15823: Investigate non-groovy test timeout

### DIFF
--- a/.openshift-ci/ci_tests.py
+++ b/.openshift-ci/ci_tests.py
@@ -223,7 +223,7 @@ class UIE2eTest(BaseTest):
 
 
 class NonGroovyE2e(BaseTest):
-    TEST_TIMEOUT = 90 * 60
+    TEST_TIMEOUT = 2 * 60 * 60
     TEST_OUTPUT_DIR = "/tmp/e2e-test-logs"
 
     def run(self):


### PR DESCRIPTION
## Description

WIP

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

### With v1.25

- [first run](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/stackrox_stackrox/5262/pull-ci-stackrox-stackrox-master-gke-nongroovy-e2e-tests/1636071455433166848) ~53 minutes
- [second run](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/stackrox_stackrox/5262/pull-ci-stackrox-stackrox-master-gke-nongroovy-e2e-tests/1636135390698016768) ~33 minutes
- [third run](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/stackrox_stackrox/5262/pull-ci-stackrox-stackrox-master-gke-nongroovy-e2e-tests/1636152554935029760) ~48 minutes
- [fifth](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/stackrox_stackrox/5262/pull-ci-stackrox-stackrox-master-gke-nongroovy-e2e-tests/1636324814379552768) ~51m

### With v1.26 (rapid channel)

- [first run](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/stackrox_stackrox/5262/pull-ci-stackrox-stackrox-master-gke-nongroovy-e2e-tests/1636384702577250304) ~48 mins :green_circle: 
- [second run](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/stackrox_stackrox/5262/pull-ci-stackrox-stackrox-master-gke-nongroovy-e2e-tests/1636410992021737472) ~50 mins :green_circle: 
- [third run](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/stackrox_stackrox/5262/pull-ci-stackrox-stackrox-master-gke-nongroovy-e2e-tests/1636438514109255680) also < 60 mins and :green_circle: 