### PR TITLE
ROX-16029: Provide aria-label from placeholder for classic search input elements in UI

### DIFF
--- a/ui/apps/platform/cypress/integration/risk/risk.test.js
+++ b/ui/apps/platform/cypress/integration/risk/risk.test.js
@@ -152,7 +152,7 @@ describe('Risk page', () => {
             viewRiskDeploymentInNetworkGraph();
         });
 
-        const searchPlaceholderText = 'Add one or more resource filters';
+        const searchPlaceholderText = 'Filter deployments';
 
         it('should not have anything in search bar when URL has no search params', () => {
             visitRiskDeployments();

--- a/ui/apps/platform/src/Components/EntityList/EntityList.js
+++ b/ui/apps/platform/src/Components/EntityList/EntityList.js
@@ -79,6 +79,9 @@ const EntityList = ({
         rowData.length
     )}`;
 
+    // Occurrences in Vulnerability Management do not require alternatives 'results' and headerText above.
+    const placeholder = `Filter ${pluralize(entityLabels[entityType])}`;
+
     // need `useLayoutEffect` here to solve an edge case,
     //   where the use have navigated to a single-page sublist,
     //   then clicked "Open in current window",
@@ -96,6 +99,7 @@ const EntityList = ({
         <>
             <div className="flex flex-1 justify-start">
                 <URLSearchInput
+                    placeholder={placeholder}
                     className="w-full"
                     categoryOptions={searchOptions}
                     categories={availableCategories}

--- a/ui/apps/platform/src/Components/SearchInput/SearchInput.js
+++ b/ui/apps/platform/src/Components/SearchInput/SearchInput.js
@@ -17,7 +17,7 @@ import searchOptionsToQuery from 'services/searchOptionsToQuery';
 
 export const searchInputPropTypes = {
     className: PropTypes.string,
-    placeholder: PropTypes.string,
+    placeholder: PropTypes.string.isRequired,
     searchOptions: PropTypes.arrayOf(PropTypes.object),
     searchModifiers: PropTypes.arrayOf(PropTypes.object),
     setSearchOptions: PropTypes.func.isRequired,
@@ -43,7 +43,6 @@ export const searchInputPropTypes = {
 };
 
 export const searchInputDefaultProps = {
-    placeholder: 'Add one or more resource filters',
     className: '',
     searchOptions: [],
     searchModifiers: [],
@@ -222,6 +221,7 @@ class SearchInput extends Component {
         const suggestions = this.getSuggestions();
         const hideDropdown = suggestions.length ? '' : 'hide-dropdown';
         const props = {
+            'aria-label': this.props.placeholder,
             isDisabled,
             className: `${className} ${hideDropdown}`,
             components: { ValueContainer, Option, Placeholder, MultiValue },

--- a/ui/apps/platform/src/Components/URLSearchInput.js
+++ b/ui/apps/platform/src/Components/URLSearchInput.js
@@ -44,6 +44,7 @@ const URLSearchInput = ({ categories, ...props }) => {
 };
 
 URLSearchInput.propTypes = {
+    placeholder: PropTypes.string.isRequired,
     categories: PropTypes.arrayOf(PropTypes.string),
 };
 

--- a/ui/apps/platform/src/Components/URLSearchInputWithAutocomplete.js
+++ b/ui/apps/platform/src/Components/URLSearchInputWithAutocomplete.js
@@ -295,6 +295,7 @@ const URLSearchInputWithAutocomplete = ({
             input && searchOptions.length > 0 && !inputMatchesTopOption(input, availableOptions),
         formatCreateLabel: (inputValue) => inputValue,
         createOptionPosition,
+        placeholder,
         ...rest,
     };
     return <Creatable {...creatableProps} components={{ ...creatableProps.components }} />;
@@ -302,7 +303,7 @@ const URLSearchInputWithAutocomplete = ({
 
 URLSearchInputWithAutocomplete.propTypes = {
     className: PropTypes.string,
-    placeholder: PropTypes.string,
+    placeholder: PropTypes.string.isRequired,
     categoryOptions: PropTypes.arrayOf(PropTypes.string),
     autoCompleteResults: PropTypes.arrayOf(PropTypes.string),
     location: ReactRouterPropTypes.location.isRequired,
@@ -319,7 +320,6 @@ URLSearchInputWithAutocomplete.propTypes = {
 
 URLSearchInputWithAutocomplete.defaultProps = {
     className: '',
-    placeholder: 'Add one or more filters',
     categoryOptions: [],
     autoCompleteResults: [],
     fetchAutocomplete: null,

--- a/ui/apps/platform/src/Components/URLSearchInputWithAutocomplete.js
+++ b/ui/apps/platform/src/Components/URLSearchInputWithAutocomplete.js
@@ -280,6 +280,7 @@ const URLSearchInputWithAutocomplete = ({
     const hideDropdown = options.length ? '' : 'hide-dropdown';
     const isFocused = document.activeElement.id === 'url-search-input';
     const creatableProps = {
+        'aria-label': placeholder,
         className: `${className} ${hideDropdown}`,
         components: { ValueContainer, Option, Placeholder, MultiValue },
         options,
@@ -295,7 +296,6 @@ const URLSearchInputWithAutocomplete = ({
             input && searchOptions.length > 0 && !inputMatchesTopOption(input, availableOptions),
         formatCreateLabel: (inputValue) => inputValue,
         createOptionPosition,
-        placeholder,
         ...rest,
     };
     return <Creatable {...creatableProps} components={{ ...creatableProps.components }} />;

--- a/ui/apps/platform/src/Containers/Clusters/ClustersPage.js
+++ b/ui/apps/platform/src/Containers/Clusters/ClustersPage.js
@@ -63,7 +63,7 @@ const ClustersPage = ({
                     searchFilter={searchFilter}
                     searchOptions={searchOptions}
                     searchCategory="CLUSTERS"
-                    placeholder="Add one or more filters"
+                    placeholder="Filter clusters"
                     handleChangeSearchFilter={setSearchFilter}
                 />
                 <div className="flex items-center ml-4 mr-3">

--- a/ui/apps/platform/src/Containers/Compliance/ComplianceSearchInput.js
+++ b/ui/apps/platform/src/Containers/Compliance/ComplianceSearchInput.js
@@ -16,7 +16,7 @@ const addComplianceStateOption = (searchOptions) => {
     return modifiedSearchOptions;
 };
 
-const ComplianceListSearchInput = ({ categories, shouldAddComplianceState }) => (
+const ComplianceSearchInput = ({ placeholder, categories, shouldAddComplianceState }) => (
     <Query query={SEARCH_OPTIONS_QUERY} action="list" variables={{ categories }}>
         {({ data }) => {
             if (!data) {
@@ -28,6 +28,7 @@ const ComplianceListSearchInput = ({ categories, shouldAddComplianceState }) => 
             }
             return (
                 <URLSearchInput
+                    placeholder={placeholder}
                     className="w-full"
                     categoryOptions={searchOptions}
                     categories={categories}
@@ -37,14 +38,15 @@ const ComplianceListSearchInput = ({ categories, shouldAddComplianceState }) => 
     </Query>
 );
 
-ComplianceListSearchInput.propTypes = {
+ComplianceSearchInput.propTypes = {
+    placeholder: PropTypes.string.isRequired,
     categories: PropTypes.arrayOf(PropTypes.string),
     shouldAddComplianceState: PropTypes.bool,
 };
 
-ComplianceListSearchInput.defaultProps = {
+ComplianceSearchInput.defaultProps = {
     categories: [],
     shouldAddComplianceState: false,
 };
 
-export default ComplianceListSearchInput;
+export default ComplianceSearchInput;

--- a/ui/apps/platform/src/Containers/Compliance/Entity/Standard.js
+++ b/ui/apps/platform/src/Containers/Compliance/Entity/Standard.js
@@ -4,7 +4,7 @@ import BackdropExporting from 'Components/PatternFly/BackdropExporting';
 import entityTypes from 'constants/entityTypes';
 import ComplianceList from 'Containers/Compliance/List/List';
 import { entityPagePropTypes, entityPageDefaultProps } from 'constants/entityPageProps';
-import SearchInput from '../SearchInput';
+import ComplianceSearchInput from '../ComplianceSearchInput';
 import Header from '../List/Header';
 
 const StandardPage = ({
@@ -24,7 +24,11 @@ const StandardPage = ({
             <Header
                 entityType={entityTypes.CONTROL}
                 searchComponent={
-                    <SearchInput categories={['COMPLIANCE']} shouldAddComplianceState />
+                    <ComplianceSearchInput
+                        placeholder="Filter standards"
+                        categories={['COMPLIANCE']}
+                        shouldAddComplianceState
+                    />
                 }
                 isExporting={isExporting}
                 setIsExporting={setIsExporting}

--- a/ui/apps/platform/src/Containers/Compliance/List/List.js
+++ b/ui/apps/platform/src/Containers/Compliance/List/List.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useHistory, useLocation, useRouteMatch } from 'react-router-dom';
+import lowerCase from 'lodash/lowerCase';
+import pluralize from 'pluralize';
 
 import URLService from 'utils/URLService';
 import { PageBody } from 'Components/Panel';
@@ -12,7 +14,7 @@ import ListTable from './Table';
 // TODO: this exception will be unnecessary once Compliance pages are re-structured like Config Management
 /* eslint-disable-next-line import/no-cycle */
 import SidePanel from './SidePanel';
-import SearchInput from '../SearchInput';
+import ComplianceSearchInput from '../ComplianceSearchInput';
 
 const ComplianceList = ({ entityType, query, selectedRowId, noSearch }) => {
     const history = useHistory();
@@ -27,8 +29,13 @@ const ComplianceList = ({ entityType, query, selectedRowId, noSearch }) => {
         history.push(url);
     }
 
+    const placeholder = `Filter ${pluralize(lowerCase(entityType))}`;
+
     const searchComponent = noSearch ? null : (
-        <SearchInput categories={[searchCategoryTypes[entityType]]} />
+        <ComplianceSearchInput
+            placeholder={placeholder}
+            categories={[searchCategoryTypes[entityType]]}
+        />
     );
 
     return (

--- a/ui/apps/platform/src/Containers/Compliance/List/Page.js
+++ b/ui/apps/platform/src/Containers/Compliance/List/Page.js
@@ -2,11 +2,14 @@ import React, { useContext, useState } from 'react';
 import PropTypes from 'prop-types';
 import { withRouter } from 'react-router-dom';
 import ReactRouterPropTypes from 'react-router-prop-types';
+import lowerCase from 'lodash/lowerCase';
+import pluralize from 'pluralize';
+
 import URLService from 'utils/URLService';
 import BackdropExporting from 'Components/PatternFly/BackdropExporting';
 import ComplianceList from 'Containers/Compliance/List/List';
 import searchContext from 'Containers/searchContext';
-import SearchInput from '../SearchInput';
+import ComplianceSearchInput from '../ComplianceSearchInput';
 import Header from './Header';
 
 const ComplianceListPage = ({ match, location }) => {
@@ -15,13 +18,18 @@ const ComplianceListPage = ({ match, location }) => {
     const searchParam = useContext(searchContext);
     const query = { ...params.query[searchParam] };
     const { pageEntityListType, entityId1, entityType2, entityListType2, entityId2 } = params;
+    const placeholder = `Filter ${pluralize(lowerCase(pageEntityListType))}`;
     return (
         <>
             <section className="flex flex-col h-full relative" id="capture-list">
                 <Header
                     entityType={pageEntityListType}
                     searchComponent={
-                        <SearchInput categories={['COMPLIANCE']} shouldAddComplianceState />
+                        <ComplianceSearchInput
+                            placeholder={placeholder}
+                            categories={['COMPLIANCE']}
+                            shouldAddComplianceState
+                        />
                     }
                     standard={query.Standard || query.standard}
                     isExporting={isExporting}

--- a/ui/apps/platform/src/Containers/ConfigManagement/List/List.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/List/List.js
@@ -60,6 +60,7 @@ const List = ({
     }
 
     const categories = [searchCategoryTypes[entityType]];
+    const placeholder = `Filter ${pluralize(entityLabels[entityType])}`;
 
     function getRenderComponents(headerComponents, tableRows, totalCount) {
         const header = `${totalCount} ${pluralize(
@@ -124,6 +125,7 @@ const List = ({
                                     : [];
                             return (
                                 <URLSearchInput
+                                    placeholder={placeholder}
                                     className="w-full"
                                     categoryOptions={searchOptions}
                                     categories={categories}

--- a/ui/apps/platform/src/Containers/ConfigManagement/List/ListFrontendPaginated.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/List/ListFrontendPaginated.js
@@ -47,6 +47,7 @@ const ListFrontendPaginated = ({
     }
 
     const categories = [searchCategoryTypes[entityType]];
+    const placeholder = `Filter ${pluralize(entityLabels[entityType])}`;
 
     function getRenderComponents(headerComponents, tableRows) {
         const header = `${tableRows.length} ${pluralize(
@@ -89,6 +90,7 @@ const ListFrontendPaginated = ({
                                     : [];
                             return (
                                 <URLSearchInput
+                                    placeholder={placeholder}
                                     className="w-full"
                                     categoryOptions={searchOptions}
                                     categories={categories}

--- a/ui/apps/platform/src/Containers/Network/Header/NetworkSearch.js
+++ b/ui/apps/platform/src/Containers/Network/Header/NetworkSearch.js
@@ -85,7 +85,7 @@ function NetworkSearch({
     return (
         <SearchFilterInput
             className="pf-u-w-100 pf-search-shim"
-            placeholder="Add one or more deployment filters"
+            placeholder="Filter deployments"
             searchFilter={searchFilter}
             searchCategory="DEPLOYMENTS"
             searchOptions={searchOptions}

--- a/ui/apps/platform/src/Containers/Network/SidePanel/Details/NetworkFlows/NetworkFlowsSearch.js
+++ b/ui/apps/platform/src/Containers/Network/SidePanel/Details/NetworkFlows/NetworkFlowsSearch.js
@@ -31,7 +31,7 @@ const NetworkFlowsSearch = ({ networkFlows, searchOptions, setSearchOptions }) =
             searchModifiers={networkFlowSearchModifiers}
             setSearchOptions={setSearchOptions}
             autoCompleteResults={autoCompleteResults}
-            placeholder="Add one or more resource filters"
+            placeholder="Filter deployments"
         />
     );
 };

--- a/ui/apps/platform/src/Containers/Network/SidePanel/NetworkDeploymentOverlay/BaselineSimulation/BaselineSimulationSearch.js
+++ b/ui/apps/platform/src/Containers/Network/SidePanel/NetworkDeploymentOverlay/BaselineSimulation/BaselineSimulationSearch.js
@@ -57,7 +57,7 @@ function BaselineSimulationSearch({ networkBaselines, searchOptions, setSearchOp
             searchModifiers={networkFlowSearchModifiers}
             setSearchOptions={setSearchOptions}
             autoCompleteResults={autoCompleteResults}
-            placeholder="Add one or more resource filters"
+            placeholder="Filter deployments"
         />
     );
 }

--- a/ui/apps/platform/src/Containers/Network/SidePanel/NetworkDeploymentOverlay/Flows/NetworkBaselines/NetworkBaselinesSearch.js
+++ b/ui/apps/platform/src/Containers/Network/SidePanel/NetworkDeploymentOverlay/Flows/NetworkBaselines/NetworkBaselinesSearch.js
@@ -63,7 +63,7 @@ function NetworkBaselinesSearch({
             searchModifiers={networkFlowSearchModifiers}
             setSearchOptions={setSearchOptions}
             autoCompleteResults={autoCompleteResults}
-            placeholder="Add one or more resource filters"
+            placeholder="Filter deployments"
         />
     );
 }

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/NetworkSearch.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/NetworkSearch.tsx
@@ -61,7 +61,7 @@ function NetworkSearch({
     return (
         <SearchFilterInput
             className="pf-u-w-100 theme-light pf-search-shim"
-            placeholder="Add one or more deployment filters"
+            placeholder="Filter deployments"
             searchFilter={searchFilter}
             searchCategory="DEPLOYMENTS"
             searchOptions={searchOptions}

--- a/ui/apps/platform/src/Containers/Risk/RiskPageHeader.js
+++ b/ui/apps/platform/src/Containers/Risk/RiskPageHeader.js
@@ -27,7 +27,7 @@ function RiskPageHeader({ isViewFiltered, searchOptions }) {
                 searchFilter={searchFilter}
                 searchOptions={searchOptions}
                 searchCategory={autoCompleteCategory}
-                placeholder="Add one or more resource filters"
+                placeholder="Filter deployments"
                 handleChangeSearchFilter={(filter) => setSearchFilter(filter, 'push')}
                 autocompleteQueryPrefix={searchOptionsToQuery(prependAutocompleteQuery)}
             />


### PR DESCRIPTION
## Description

### Problem

Solve critical issue from axe DevTools:

> Form elements must have labels

### Analysis

> Element has no placeholder attribute

Indeed, although React Select (or maybe more accurate to say, our use of it) renders a placeholder, `input` element does not have a `placeholder` attribute.

For interest, although not practicality, I verified that React Select 5 might have solved the problem with the `placeholder` prop:

> Placeholder text is now announced.

### Solution

1. Render `placeholder` prop as `aria-label` attribute in and component that renders an element from ReactSelect, like `SearchInput` component.
2. Pass `placeholder` prop through all levels of application select components.
3. Replace generic default placeholder with specific placeholder that follows the majority **Filter whatevers** grammar pattern, because that seems clear and concise for screen reader.

### Residue

1. I did not yet search whether placeholders for PatternFly select elements follow the grammar pattern.
2. Fix critical accessibility issues on most of the classic pages under Testing Performed:
    * Buttons must have discernable text
    * Elements must have sufficient color contrast

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

Manual testing to visit pages for components:
* See placeholder in search filter input.
* Verify absence of issue in axe DevTools.

### SearchFilterInput

1. src/Containers/Clusters/ClustersPage.js
    Visit /main/clusters and see **Filter clusters**

2. src/Containers/Network/Header/NetworkSearch.js
    Visit /main/network and see **Filter deployments**

3. src/Containers/NetworkGraph/components/NetworkSearch.tsx
    Visit /main/network-graph and see **Filter deployments**

4. src/Containers/Policies/Table/PoliciesTable.tsx
    Visit /main/policy-management/policies and see **Filter policies**

5. src/Containers/Risk/RiskPageHeader.js
    Visit /main/risk and see **Filter deployments**

6. src/Containers/Search/SearchPage.tsx
    Visit /main/search and see **Filter resources**

7. src/Containers/Violations/ViolationsTablePage.tsx
    Visit /main/violations and see **Filter violations**

### SearchInput

1. src/Containers/Compliance/Entity/Standard.js
    It seems like this is an orphan because **View standard** links to /main/compliance/controls which renders the following components:

2. Hard to say which occurence of `ComplianceSearchInput` is rendered
    * src/Containers/Compliance/List/List.js
    * src/Containers/Compliance/List/Page.js

    Visit /main/compliance/clusters and see **Filter clusters**
    Visit /main/compliance/deployments and see **Filter deployments**
    Visit /main/compliance/namespaces amd see **Filter namespaces**
    Visit /main/compliance/nodes and see **Filter nodes**

    We could multiple the case analysis with lists on tabs of single pages

3. Hard (for me) to say how to render the baseline simulation search filter.
    * src/Containers/Network/SidePanel/Details/NetworkFlows/NetworkFlowsSearch.js
    * src/Containers/Network/SidePanel/NetworkDeploymentOverlay/BaselineSimulation/BaselineSimulationSearch.js
    * src/Containers/Network/SidePanel/NetworkDeploymentOverlay/Flows/NetworkBaselines/NetworkBaselinesSearch.js

    Vist /main/network/id and see **Filter deployments** in **Network flows** and **Baseline settings** tabs of side panel

### URLSearchInput

For Configuration Managment and Vulnerability Management (see below).

1. src/Components/URLSearchInput.js

2. src/Components/URLSearchInputWithAutocomplete.js

### Configuration Management

1. src/Containers/ConfigManagement/List/List.js
    src/Containers/ConfigManagement/List/ListFrontendPaginated.js

    Visit /main/configmanagement/clusters and see **Filter clusters**
    Visit /main/configmanagement/controls and see **Filter controls**
    Visit /main/configmanagement/deployments and see **Filter deployments**
    Visit /main/configmanagement/images and see **Filter images**
    Visit /main/configmanagement/namespaces and see **Filter namespaces**
    Visit /main/configmanagement/nodes and see **Filter nodes**
    Visit /main/configmanagement/policies and see **Filter policies**
    Visit /main/configmanagement/secrets and see **Filter secrets**

    We could multiple the case analysis with lists on tabs of single pages

### Vulnerability Management

1. src/Components/EntityList/EntityList.js

    Visit /main/vulnerability-management/clusters and see **Filter clusters**
    Visit /main/vulnerability-management/deployments and see **Filter deployments**
    Visit /main/vulnerability-management/images and see **Filter images**
    Visit /main/vulnerability-management/image-components and see **Filter image components**
    Visit /main/vulnerability-management/namespaces and see **Filter namespaces**
    Visit /main/vulnerability-management/nodes and see **Filter nodes**
    Visit /main/vulnerability-management/node-components and see **Filter node components**
    Visit /main/vulnerability-management/policies and see **Filter policies**

    The following 3 differ in capitalization convention, as I had noticed when writing integration tests:

    Visit /main/vulnerability-management/image-cves and see **Filter Image CVES**
    Visit /main/vulnerability-management/node-cves and see **Filter Node CVES**
    Visit /main/vulnerability-management/cluster-cves and see **Filter Platform CVES**

    We could multiple the case analysis with lists on tabs of single pages
