### PR TITLE
Detect in deploy scripts if openshift or k8s is used

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ Run the following in your working directory of choice:
 ```
 git clone git@github.com:stackrox/stackrox.git
 cd stackrox
-MAIN_IMAGE_TAG=VERSION_TO_USE ./deploy/k8s/deploy.sh
+MAIN_IMAGE_TAG=VERSION_TO_USE ./deploy/deploy.sh
 ```
 
 After a few minutes, all resources should be deployed.
@@ -224,7 +224,7 @@ Run the following in your working directory of choice:
 ```
 git clone git@github.com:stackrox/stackrox.git
 cd stackrox
-MAIN_IMAGE_TAG=VERSION_TO_USE ./deploy/openshift/deploy.sh
+MAIN_IMAGE_TAG=VERSION_TO_USE ./deploy/deploy.sh
 ```
 
 After a few minutes, all resources should be deployed. The process will complete with this message.
@@ -244,7 +244,7 @@ Run the following in your working directory of choice:
 ```
 git clone git@github.com:stackrox/stackrox.git
 cd stackrox
-MAIN_IMAGE_TAG=latest ./deploy/k8s/deploy-local.sh
+MAIN_IMAGE_TAG=latest ./deploy/deploy-local.sh
 ```
 
 After a few minutes, all resources should be deployed.
@@ -377,7 +377,7 @@ $ export SKIP_UI_BUILD=1
 $ roxkubectx
 
 # To deploy locally, call:
-$ ./deploy/k8s/deploy-local.sh
+$ ./deploy/deploy-local.sh
 
 # Now you can access StackRox dashboard at https://localhost:8000
 # or simply call another workflow script:

--- a/deploy/central.sh
+++ b/deploy/central.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -e
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
+source "${DIR}/detect.sh"
+
+if is_openshift; then
+    "${DIR}/openshift/central.sh"
+else
+    "${DIR}/k8s/central.sh"
+fi

--- a/deploy/deploy-local.sh
+++ b/deploy/deploy-local.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -e
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
+source "${DIR}/detect.sh"
+
+if is_openshift; then
+    "${DIR}/openshift/deploy-local.sh"
+else
+    "${DIR}/k8s/deploy-local.sh"
+fi

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -e
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
+source "${DIR}/detect.sh"
+
+if is_openshift; then
+    "${DIR}/openshift/deploy.sh"
+else
+    "${DIR}/k8s/deploy.sh"
+fi

--- a/deploy/detect.sh
+++ b/deploy/detect.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -e
+
+function is_openshift {
+    kubectl get scc > /dev/null 2>&1
+}

--- a/deploy/sensor.sh
+++ b/deploy/sensor.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -e
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
+source "${DIR}/detect.sh"
+
+if is_openshift; then
+    "${DIR}/openshift/sensor.sh"
+else
+    "${DIR}/k8s/sensor.sh"
+fi

--- a/scripts/style/shellcheck_skip.txt
+++ b/scripts/style/shellcheck_skip.txt
@@ -1,10 +1,10 @@
+deploy/central.sh
 deploy/common/docker-auth.sh
 deploy/common/k8sbased.sh
-deploy/openshift/deploy-local.sh
-deploy/openshift/deploy.sh
-deploy/central.sh
 deploy/deploy-local.sh
 deploy/deploy.sh
+deploy/openshift/deploy-local.sh
+deploy/openshift/deploy.sh
 deploy/sensor.sh
 dev-tools/add-host-alias.sh
 dev-tools/enable-hotreload.sh

--- a/scripts/style/shellcheck_skip.txt
+++ b/scripts/style/shellcheck_skip.txt
@@ -2,6 +2,10 @@ deploy/common/docker-auth.sh
 deploy/common/k8sbased.sh
 deploy/openshift/deploy-local.sh
 deploy/openshift/deploy.sh
+deploy/central.sh
+deploy/deploy-local.sh
+deploy/deploy.sh
+deploy/sensor.sh
 dev-tools/add-host-alias.sh
 dev-tools/enable-hotreload.sh
 dev-tools/roxctl.sh


### PR DESCRIPTION
## Description

I have used deploy/k8s/deploy.sh a million times on an OpenShift cluster. Add a new script that detects if it's k8s or openshift and then use the right script

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Ran on Openshift and GKE
