### PR TITLE
Skip reconciliation of declarative config for no changes

### DIFF
--- a/central/declarativeconfig/manager_impl_test.go
+++ b/central/declarativeconfig/manager_impl_test.go
@@ -244,10 +244,10 @@ func TestReconcileTransformedMessages_ErrorPropagatedToReporter(t *testing.T) {
 		ErrorMessage: "test error",
 	}))
 
-	mockUpdater.EXPECT().DeleteResources(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	mockUpdater.EXPECT().DeleteResources(gomock.Any(), gomock.Any()).Return(nil, nil).Times(5)
 
 	reporter.EXPECT().RetrieveIntegrationHealths(storage.IntegrationHealth_DECLARATIVE_CONFIG).
-		Return(nil, nil).AnyTimes()
+		Return(nil, nil).Times(1)
 
 	m := newTestManager(t)
 	m.updaters = map[reflect.Type]updater.ResourceUpdater{

--- a/pkg/env/declarative_config.go
+++ b/pkg/env/declarative_config.go
@@ -5,7 +5,9 @@ import "time"
 var (
 	// DeclarativeConfigWatchInterval will set the duration for when to check for changes in declarative configuration
 	// watch handlers.
-	DeclarativeConfigWatchInterval = registerDurationSetting("ROX_DECLARATIVE_CONFIG_WATCH_INTERVAL", 5*time.Second)
+	DeclarativeConfigWatchInterval = registerDurationSetting("ROX_DECLARATIVE_CONFIG_WATCH_INTERVAL",
+		5*time.Second)
 	// DeclarativeConfigReconcileInterval will set the duration for when to reconcile declarative configurations.
-	DeclarativeConfigReconcileInterval = registerDurationSetting("ROX_DECLARATIVE_CONFIG_RECONCILE_INTERVAL", time.Minute)
+	DeclarativeConfigReconcileInterval = registerDurationSetting("ROX_DECLARATIVE_CONFIG_RECONCILE_INTERVAL",
+		20*time.Second)
 )

--- a/qa-tests-backend/src/test/groovy/DeclarativeConfigTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DeclarativeConfigTest.groovy
@@ -217,7 +217,7 @@ oidc:
         // It may take some time until a) the config map contents are mapped within the pod b) the reconciliation
         // has been triggered.
         // If the tests are flaky, we have to increase this value.
-        withRetry(5, 30) {
+        withRetry(5, 60) {
             def response = IntegrationHealthService.getDeclarativeConfigHealthInfo()
             // Expect 6 integration health status for the created resources and one for the config map.
             assert response.integrationHealthCount == CREATED_RESOURCES + 1
@@ -257,7 +257,7 @@ oidc:
         // Verify the integration health for the permission set is unhealthy and contains an error message.
         // The errors will be surface after at least three consecutive occurrences, hence we need to retry multiple
         // times here.
-        withRetry(5, 30) {
+        withRetry(5, 60) {
             def response = IntegrationHealthService.getDeclarativeConfigHealthInfo()
             def permissionSetHealth = response.getIntegrationHealthList().find {
                 it.getName().contains(PERMISSION_SET_KEY)
@@ -278,7 +278,7 @@ oidc:
         // Verify the integration health for the access scope is unhealthy and contains an error message.
         // The errors will be surface after at least three consecutive occurrences, hence we need to retry multiple
         // times here.
-        withRetry(5, 30) {
+        withRetry(5, 60) {
             def response = IntegrationHealthService.getDeclarativeConfigHealthInfo()
             def accessScopeHealth = response.getIntegrationHealthList().find {
                 it.getName().contains(ACCESS_SCOPE_KEY)
@@ -297,7 +297,7 @@ oidc:
 
         then:
         // Verify the integration health for the role is unhealthy and contains an error message.
-        withRetry(5, 30) {
+        withRetry(5, 60) {
             def response = IntegrationHealthService.getDeclarativeConfigHealthInfo()
             def roleHealth = response.getIntegrationHealthList().find {
                 it.getName().contains(ROLE_KEY)
@@ -318,7 +318,7 @@ oidc:
         // Verify the integration health for the auth provider is unhealthy and contains an error message.
         // The errors will be surface after at least three consecutive occurrences, hence we need to retry multiple
         // times here.
-        withRetry(5, 30) {
+        withRetry(5, 60) {
             def response = IntegrationHealthService.getDeclarativeConfigHealthInfo()
             def roleHealth = response.getIntegrationHealthList().find {
                 it.getName().contains(AUTH_PROVIDER_KEY)
@@ -342,7 +342,7 @@ oidc:
         orchestrator.deleteConfigMap(CONFIGMAP_NAME, DEFAULT_NAMESPACE)
 
         then:
-        withRetry(5, 30) {
+        withRetry(5, 60) {
             def response = IntegrationHealthService.getDeclarativeConfigHealthInfo()
             assert response.getIntegrationHealthCount() == 1
             def configMapHealth = response.getIntegrationHealth(0)
@@ -400,7 +400,7 @@ oidc:
                 ], DEFAULT_NAMESPACE)
 
         then:
-        withRetry(10, 60) {
+        withRetry(5, 60) {
             def response = IntegrationHealthService.getDeclarativeConfigHealthInfo()
             // Expect 6 integration health status for the created resources and one for the config map.
             assert response.integrationHealthCount == CREATED_RESOURCES + 1

--- a/qa-tests-backend/src/test/groovy/DeclarativeConfigTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DeclarativeConfigTest.groovy
@@ -217,7 +217,7 @@ oidc:
         // It may take some time until a) the config map contents are mapped within the pod b) the reconciliation
         // has been triggered.
         // If the tests are flaky, we have to increase this value.
-        withRetry(5, 60) {
+        withRetry(5, 30) {
             def response = IntegrationHealthService.getDeclarativeConfigHealthInfo()
             // Expect 6 integration health status for the created resources and one for the config map.
             assert response.integrationHealthCount == CREATED_RESOURCES + 1
@@ -255,9 +255,9 @@ oidc:
 
         then:
         // Verify the integration health for the permission set is unhealthy and contains an error message.
-        // The errors will be surface after at least five consecutive occurrences, hence we need to retry multiple
+        // The errors will be surface after at least three consecutive occurrences, hence we need to retry multiple
         // times here.
-        withRetry(10, 60) {
+        withRetry(5, 30) {
             def response = IntegrationHealthService.getDeclarativeConfigHealthInfo()
             def permissionSetHealth = response.getIntegrationHealthList().find {
                 it.getName().contains(PERMISSION_SET_KEY)
@@ -276,9 +276,9 @@ oidc:
 
         then:
         // Verify the integration health for the access scope is unhealthy and contains an error message.
-        // The errors will be surface after at least five consecutive occurrences, hence we need to retry multiple
+        // The errors will be surface after at least three consecutive occurrences, hence we need to retry multiple
         // times here.
-        withRetry(10, 60) {
+        withRetry(5, 30) {
             def response = IntegrationHealthService.getDeclarativeConfigHealthInfo()
             def accessScopeHealth = response.getIntegrationHealthList().find {
                 it.getName().contains(ACCESS_SCOPE_KEY)
@@ -297,7 +297,7 @@ oidc:
 
         then:
         // Verify the integration health for the role is unhealthy and contains an error message.
-        withRetry(10, 60) {
+        withRetry(5, 30) {
             def response = IntegrationHealthService.getDeclarativeConfigHealthInfo()
             def roleHealth = response.getIntegrationHealthList().find {
                 it.getName().contains(ROLE_KEY)
@@ -316,9 +316,9 @@ oidc:
 
         then:
         // Verify the integration health for the auth provider is unhealthy and contains an error message.
-        // The errors will be surface after at least five consecutive occurrences, hence we need to retry multiple
+        // The errors will be surface after at least three consecutive occurrences, hence we need to retry multiple
         // times here.
-        withRetry(10, 60) {
+        withRetry(5, 30) {
             def response = IntegrationHealthService.getDeclarativeConfigHealthInfo()
             def roleHealth = response.getIntegrationHealthList().find {
                 it.getName().contains(AUTH_PROVIDER_KEY)
@@ -342,7 +342,7 @@ oidc:
         orchestrator.deleteConfigMap(CONFIGMAP_NAME, DEFAULT_NAMESPACE)
 
         then:
-        withRetry(5, 60) {
+        withRetry(5, 30) {
             def response = IntegrationHealthService.getDeclarativeConfigHealthInfo()
             assert response.getIntegrationHealthCount() == 1
             def configMapHealth = response.getIntegrationHealth(0)


### PR DESCRIPTION
## Description

This PR addresses some improvements mentioned within #5186, specifically regarding the reconciliation.

In short, the following has been improved:
- reconciliation will be skipped if a) no changes to messages compared to the previous run b) the previous upsert did not include an error c) the previous deletion did not include an error.
- if the previous upsert included an error, but no changes are indicated in the reconciled messages, only upserts will be retried, deletions will be skipped.
- if the previous deletion included an error, but no changes are indicated in the reconciled messages, only deletion will be retried, upserts will be skipped.

Regarding the change of the reconciliation:
We will retry reconciliation if no changes are made due to the fact that errors have to reach a certain threshold before they will be propagated to the user. If we were to only execute the reconciliation based off the fact if changes are contained within messages, we would currently not surface any errors within the integration health API.

The deletion part is the "costly" part about reconciliation: within deletions, the datastores will be searched for messages with specific properties (i.e. the origin declarative). We should avoid querying the datastores if possible, hence deletion will only be done when necessary, i.e. the messages to reconcile have changed compared to the previous run or an error occurred during deletion.

There may be an additional improvement we can do in the future:
Instead of upserting / deleting _all_ resources, only attempt to upsert / delete resources which indicated a failure. Currently, when a previous reconciliation included an error _all_ resources will be attempted to be upserted / deleted. While the number of resources is most likely not significant for the MVP, it would be worthwhile in the future to only upsert / delete the required ones.

Additional changes:
- Since the reconciliation has been improved, I lowered the interval for reconciliations to 20 seconds from 1 minute. This will improve UX, since errors will be surface in 1 minute, instead of 3 minutes (given that errors are persistent across reconciliation runs).

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

- see tests passing in CI.


