### PR TITLE
ROX-13840: Remove opacity-75 from SubHeader for sufficient color contrast

### DIFF
--- a/ui/apps/platform/src/Components/SubHeader/SubHeader.js
+++ b/ui/apps/platform/src/Components/SubHeader/SubHeader.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const SubHeader = ({ text, capitalize }) => {
-    return <div className={`mt-1 italic opacity-75 ${capitalize ? 'capitalize' : ''}`}>{text}</div>;
+    return <div className={`mt-1 italic ${capitalize ? 'capitalize' : ''}`}>{text}</div>;
 };
 
 SubHeader.propTypes = {


### PR DESCRIPTION
## Description

Follow up issues found during manual testing of #5263

For your enjoyment, compare the title to the number of the pull request ;)

### Problem

Solve critical issue from axe DevTools:

> Elements must have sufficient color contrast

### Analysis

Because classic StackRox text has such a light color, there is not enough contrast available for a lighter version, at least via opacity.

PatternFly provides sufficient color contrast for placeholders and disabled elements. Thankfully, we are reducing the number of application-specific distinctions between regular and lighter text color.

### Solution

SubHeader has several stylistic distinctions, even without opacity:
* font-size: 13px font-weight: 700 text-transform: uppercase
* font-size: 12px font-weight: 600 text-transform: capitalize font-style: italic ~opacity: 0.75~

### Residue

Most of these classic pages also have insufficient color contrast because of:
* Search input placeholder
* Table pagination element

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

Insufficient color contrast with opacity-75 class
![Compliance_with_opacity](https://user-images.githubusercontent.com/11862657/225708108-8c712c89-d56c-4166-8d80-9b968c450d65.png)

Sufficient color contrast without opacity-75 class
![Compliance_without_opacity](https://user-images.githubusercontent.com/11862657/225708145-0869b3f6-b0e6-49a8-8410-c395a291ff11.png)
