### PR TITLE
ROX-15963: Adding new items to network graph legend

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/components/LegendContent.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/LegendContent.tsx
@@ -1,6 +1,11 @@
 import React from 'react';
 import { Flex, FlexItem, Title } from '@patternfly/react-core';
-import { PficonNetworkRangeIcon, BuilderImageIcon } from '@patternfly/react-icons';
+import {
+    PficonNetworkRangeIcon,
+    BuilderImageIcon,
+    CodeBranchIcon,
+    FilterIcon,
+} from '@patternfly/react-icons';
 
 import DescriptionListItem from 'Components/DescriptionListItem';
 import DescriptionListCompact from 'Components/DescriptionListCompact';
@@ -27,6 +32,15 @@ function LegendContent() {
                             term={<PficonNetworkRangeIcon />}
                             desc="External CIDR block"
                         />
+                    </DescriptionListCompact>
+                </FlexItem>
+                <FlexItem>
+                    <Title headingLevel="h5" className="pf-u-pb-sm">
+                        Namespace types
+                    </Title>
+                    <DescriptionListCompact isHorizontal termWidth="20px" className="pf-u-pl-md">
+                        <DescriptionListItem term={<CodeBranchIcon />} desc="Derived namespace" />
+                        <DescriptionListItem term={<FilterIcon />} desc="Filtered namespace" />
                     </DescriptionListCompact>
                 </FlexItem>
                 <FlexItem>


### PR DESCRIPTION
## Description

This PR adds the `filtered namespace` and `derived namespace` items to the network graph legend

![Screenshot 2023-03-16 at 3 33 13 PM](https://user-images.githubusercontent.com/4805485/225768833-1791c85d-a335-4eac-a9a6-d95a81a09b23.png)
