### PR TITLE
ROX-16015: Change the label background color to purple for the 'External to cluster' group

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.css
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.css
@@ -53,3 +53,7 @@ div#topology-resize-panel table td {
 .pf-topology-node-faded {
     opacity: 30%;
 }
+
+[data-id="External to cluster"] .pf-topology__group__label .pf-topology__node__label__background {
+    fill: #6853ae
+}


### PR DESCRIPTION
## Description

This PR changes the background label color to purple for the `External to cluster` group

![Screenshot 2023-03-16 at 4 52 31 PM](https://user-images.githubusercontent.com/4805485/225777610-05cd12dd-a149-4f0e-8844-1ce554f540c3.png)
