### PR TITLE
Upgrade TypeScript 5.0.2 devDependencies in ui

### DIFF
--- a/ui/apps/platform/package.json
+++ b/ui/apps/platform/package.json
@@ -170,7 +170,7 @@
         "redux-immutable-state-invariant": "^2.1.0",
         "redux-saga-test-plan": "^3.7.0",
         "tailwindcss": "^2.0.3",
-        "typescript": "^4.9.3"
+        "typescript": "^5.0.2"
     },
     "browserslist": [
         ">0.2%",

--- a/ui/packages/ui-components/package.json
+++ b/ui/packages/ui-components/package.json
@@ -79,6 +79,6 @@
         "react-dom": "^17.0.2",
         "tailwindcss": "^2.0.3",
         "ts-jest": "^26.5.6",
-        "typescript": "^4.9.3"
+        "typescript": "^5.0.2"
     }
 }

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -18899,10 +18899,10 @@ typeface-open-sans@^1.1.13:
   resolved "https://registry.yarnpkg.com/typeface-open-sans/-/typeface-open-sans-1.1.13.tgz#32a09ebd7df59601e01ad81216f98ce641eeafd1"
   integrity sha512-lVGVHvYl7UJDFB9vN8r7NHw3sVm7Rjeow6b9AeABc/J+2mDaCkmcdVtw3QZnsJW39P+xm5zeggIj9gLHYGn9Iw==
 
-typescript@^4.9.3:
-  version "4.9.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.3.tgz#3aea307c1746b8c384435d8ac36b8a2e580d85db"
-  integrity sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==
+typescript@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.2.tgz#891e1a90c5189d8506af64b9ef929fca99ba1ee5"
+  integrity sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==
 
 uglify-js@^3.1.4:
   version "3.13.7"


### PR DESCRIPTION
## Description

https://github.com/microsoft/TypeScript/releases/tag/v5.0.2

https://devblogs.microsoft.com/typescript/announcing-typescript-5-0/

> 5.0 is not a disruptive release, and everything you know is still applicable. While TypeScript 5.0 includes correctness changes and some deprecations for infrequently-used options, we believe most developers will have an upgrade experience similar to previous releases.

Selected items:

1. https://devblogs.microsoft.com/typescript/announcing-typescript-5-0/#const-type-parameters

    > In TypeScript 5.0, you can now add a `const` modifier to a type parameter declaration to cause `const`-like inference to be the default.

    > A better definition of this function should use `readonly string[]`

    The second quote sounded more useful on skim reading.

2. https://devblogs.microsoft.com/typescript/announcing-typescript-5-0/#case-insensitive-import-sorting-in-editors

    > In editors like Visual Studio and VS Code, TypeScript powers the experience for organizing and sorting imports and exports. Often though, there can be different interpretations of when a list is "sorted".

    > TypeScript now detects case sensitivity by default. This means that TypeScript and tools like ESLint typically won’t "fight" each other over how to best sort imports.

    Personally, I find it useful that case-sensitive sort separates types and elements from constants and functions.

3. https://devblogs.microsoft.com/typescript/announcing-typescript-5-0/#exhaustive-switch-case-completions

    > When writing a `switch` statement, TypeScript now detects when the value being checked has a literal type. If so, it will offer a completion that scaffolds out each uncovered `case`.

    Here is a lesson: this change outside of the core language might seem like the most delightful improvement to many people.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

1. `yarn build` in ui
2. `wc build/static/js/*.js` in ui
    * branch - master: 0 = 11685364 - 11685364
        Although it surprised me at first, same code generation implies maturity and stability of TypeScript.
3. `yarn start` in ui