### PR TITLE
Add dynamic column icon to workload cve images table

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/DynamicIcon.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/DynamicIcon.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Label, Tooltip } from '@patternfly/react-core';
+import { BoltIcon } from '@patternfly/react-icons';
+import { SVGIconProps } from '@patternfly/react-icons/dist/esm/createIcon';
+
+export function DynamicIcon(props: SVGIconProps) {
+    return <BoltIcon color="var(--pf-global--palette--blue-300)" {...props} />;
+}
+
+export function DynamicColumnIcon() {
+    return (
+        <Tooltip content="Data in this column can change according to the applied filters">
+            <DynamicIcon className="pf-u-display-inline pf-u-ml-sm" />
+        </Tooltip>
+    );
+}
+
+export function DynamicTableLabel() {
+    return (
+        <Label isCompact color="blue" icon={<DynamicIcon />}>
+            Filtered view
+        </Label>
+    );
+}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageSingleVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageSingleVulnerabilities.tsx
@@ -9,7 +9,6 @@ import {
     Flex,
     Grid,
     GridItem,
-    Label,
     PageSection,
     Pagination,
     pluralize,
@@ -23,7 +22,7 @@ import {
     Text,
     Title,
 } from '@patternfly/react-core';
-import { ExclamationCircleIcon, InfoCircleIcon } from '@patternfly/react-icons';
+import { ExclamationCircleIcon } from '@patternfly/react-icons';
 
 import { VulnerabilitySeverity } from 'types/cve.proto';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
@@ -39,6 +38,7 @@ import CvesByStatusSummaryCard from './SummaryCards/CvesByStatusSummaryCard';
 import SingleEntityVulnerabilitiesTable from './Tables/SingleEntityVulnerabilitiesTable';
 import { ImageDetailsResponse } from './hooks/useImageDetails';
 import useImageVulnerabilities from './hooks/useImageVulnerabilities';
+import { DynamicTableLabel } from './DynamicIcon';
 
 const defaultSortOptions: UseURLSortProps = {
     sortFields: ['CVE', 'Severity', 'Fixable'],
@@ -67,6 +67,8 @@ function ImageSingleVulnerabilities({ imageId, imageData }: ImageSingleVulnerabi
     const { data, previousData, loading, error } = useImageVulnerabilities(imageId, {}, pagination);
 
     const [activeTabKey, setActiveTabKey] = useURLStringUnion('cveStatus', cveStatusTabValues);
+
+    const isFiltered = getHasSearchApplied(searchFilter);
 
     let mainContent: ReactNode | null = null;
 
@@ -121,17 +123,13 @@ function ImageSingleVulnerabilities({ imageId, imageData }: ImageSingleVulnerabi
                 </div>
                 <Divider />
                 <div className="pf-u-p-lg">
-                    <Split className="pf-u-pb-lg">
+                    <Split className="pf-u-pb-lg pf-u-align-items-baseline">
                         <SplitItem isFilled>
-                            <Flex alignContent={{ default: 'alignContentCenter' }}>
+                            <Flex alignItems={{ default: 'alignItemsCenter' }}>
                                 <Title headingLevel="h2">
                                     {pluralize(totalVulnerabilityCount, 'result', 'results')} found
                                 </Title>
-                                {getHasSearchApplied(searchFilter) && (
-                                    <Label isCompact color="blue" icon={<InfoCircleIcon />}>
-                                        Filtered view
-                                    </Label>
-                                )}
+                                {isFiltered && <DynamicTableLabel />}
                             </Flex>
                         </SplitItem>
                         <SplitItem>
@@ -154,6 +152,7 @@ function ImageSingleVulnerabilities({ imageId, imageData }: ImageSingleVulnerabi
                         image={imageData}
                         imageVulnerabilities={vulnerabilities}
                         getSortParams={getSortParams}
+                        isFiltered={isFiltered}
                     />
                 </div>
             </>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/SingleEntityVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/SingleEntityVulnerabilitiesTable.tsx
@@ -22,19 +22,23 @@ import { ImageVulnerabilitiesResponse } from '../hooks/useImageVulnerabilities';
 import { getEntityPagePath } from '../searchUtils';
 import ImageComponentsTable from './ImageComponentsTable';
 import { ImageDetailsResponse } from '../hooks/useImageDetails';
+import { DynamicColumnIcon } from '../DynamicIcon';
 
 export type SingleEntityVulnerabilitiesTableProps = {
     image: ImageDetailsResponse['image'] | undefined;
     imageVulnerabilities: ImageVulnerabilitiesResponse['image']['imageVulnerabilities'];
     getSortParams: UseURLSortResult['getSortParams'];
+    isFiltered: boolean;
 };
 
 function SingleEntityVulnerabilitiesTable({
     image,
     imageVulnerabilities,
     getSortParams,
+    isFiltered,
 }: SingleEntityVulnerabilitiesTableProps) {
     const expandedRowSet = useSet<string>();
+
     return (
         <TableComposable>
             <Thead>
@@ -42,9 +46,15 @@ function SingleEntityVulnerabilitiesTable({
                     <Th>{/* Header for expanded column */}</Th>
                     <Th sort={getSortParams('CVE')}>CVE</Th>
                     <Th sort={getSortParams('Severity')}>Severity</Th>
-                    <Th sort={getSortParams('Fixable')}>CVE Status</Th>
+                    <Th sort={getSortParams('Fixable')}>
+                        CVE Status
+                        {isFiltered && <DynamicColumnIcon />}
+                    </Th>
                     {/* TODO Add sorting for these columns once aggregate sorting is available in BE */}
-                    <Th>Affected components</Th>
+                    <Th>
+                        Affected components
+                        {isFiltered && <DynamicColumnIcon />}
+                    </Th>
                     <Th>First discovered</Th>
                 </Tr>
             </Thead>


### PR DESCRIPTION
## Description

Adds the dynamic column icon to workload cve table columns that can be impacted by applied data filters.

Includes the "Bolt" icon itself, as well as wrapper components for the most common usages as a label or column header.

Note: The icon in the mocks is titled "Bolt" in font-awesome v6, but the font-awesome v5 bolt that PatternFly uses is slightly different.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

The icon and "Filtered view" badge should not be visible when no filters are applied on the page.
<img width="1675" alt="image" src="https://user-images.githubusercontent.com/1292638/226011813-ba69948d-f6f2-49c3-95db-267399bff961.png">


When a filter is applied, the "filtered view" badge and bolt column header icons should be displayed. 
<img width="1675" alt="image" src="https://user-images.githubusercontent.com/1292638/226011617-c39402d1-88fa-4957-9cb8-99df49388600.png">

