### PR TITLE
ROX-16032: Add handling for new CVE types in page header UI code

### DIFF
--- a/ui/apps/platform/src/utils/getEntityName.js
+++ b/ui/apps/platform/src/utils/getEntityName.js
@@ -13,6 +13,9 @@ const entityNameKeyMap = {
         return version ? `${name} ${version}` : name;
     },
     [entityTypes.CVE]: (data) => resolvePath(data, 'vulnerability.cve'),
+    [entityTypes.IMAGE_CVE]: (data) => resolvePath(data, 'vulnerability.cve'),
+    [entityTypes.NODE_CVE]: (data) => resolvePath(data, 'vulnerability.cve'),
+    [entityTypes.CLUSTER_CVE]: (data) => resolvePath(data, 'vulnerability.cve'),
     [entityTypes.DEPLOYMENT]: (data) => resolvePath(data, 'deployment.name'),
     [entityTypes.NAMESPACE]: (data) => resolvePath(data, 'namespace.metadata.name'),
     [entityTypes.ROLE]: (data) => {


### PR DESCRIPTION
## Description

Add code to handle the name for the new Postgres-enabled CVE types to `getEntityName` hook, in file `ui/apps/platform/src/utils/getEntityName.js`

### This fixes:
UI crash on a postgreSQL 3.74 install. It's pretty consistent, navigating from a particular CVE to the related entities like Deployment. 
nav path is VM Dashboard -> Select #3 image in "Top Riskiest" -> Click on CVE-2014-9761 -> 4 Deployments

### Analysis
When we split the CVE types for Postgres, an edge case opened in the page heading code, which picks the "name" field based on type. I forgot to add the new CVE types to the header code.

Doesn't matter, except that the fallback of generic name tries to print the image's name, which is nested in an object, as the page transitions from the single image view to the deployment list for a CVE, as one view goes out of scope and the other comes in.

(That's why going straight to the link works--there's no old image view to transition away from.)

## Checklist
- [ ] Investigated and inspected CI test results


## Testing Performed

Screen recording of this code path working with this code change


https://user-images.githubusercontent.com/715729/226064802-589b769d-2a80-4449-aa59-449b131ec82b.mov

