### PR TITLE
ROX-15449: Enhance description for Alert on Baseline toggle

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentBaseline.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentBaseline.tsx
@@ -172,7 +172,10 @@ function DeploymentBaselines({ deployment, deploymentId, onNodeSelect }: Deploym
                             <Tooltip
                                 content={
                                     <div>
-                                        Trigger violations for network policies not in the baseline
+                                        Trigger violations for traffic not in the baseline. This
+                                        offers soak time for finalizing your network policies, where
+                                        ACS can alert you on unexpected traffic, while that traffic
+                                        is not blocked by a network policy.
                                     </div>
                                 }
                             >


### PR DESCRIPTION
## Description

Current description is misleading:

"Trigger violations for network policies not in the baseline"

It should be replaced by:

"Trigger violations for traffic not in the baseline. This offers soak time for finalizing your network policies, where ACS can alert you on unexpected traffic, while that traffic is not blocked by a network policy"

## Checklist
- [x] Investigated and inspected CI test results (ui-e2e test failures are known flakes)


## Testing Performed

A picture is worth 1,000 words
<img width="1495" alt="Screen Shot 2023-03-17 at 7 30 10 PM" src="https://user-images.githubusercontent.com/715729/226069810-b3b7e4ec-dff6-4778-a0ed-b9a4b0fef6b6.png">
