### PR TITLE
Add an uptime metric to default prometheus server

### DIFF
--- a/central/main.go
+++ b/central/main.go
@@ -290,7 +290,7 @@ func main() {
 	}
 
 	// Start the prometheus metrics server
-	pkgMetrics.NewDefaultHTTPServer().RunForever()
+	pkgMetrics.NewDefaultHTTPServer(pkgMetrics.CentralSubsystem).RunForever()
 	pkgMetrics.GatherThrottleMetricsForever(pkgMetrics.CentralSubsystem.String())
 
 	go startGRPCServer()

--- a/compliance/collection/main.go
+++ b/compliance/collection/main.go
@@ -258,7 +258,7 @@ func main() {
 
 	if features.RHCOSNodeScanning.Enabled() {
 		// Start the prometheus metrics server
-		metrics.NewDefaultHTTPServer().RunForever()
+		metrics.NewDefaultHTTPServer(metrics.ComplianceSubsystem).RunForever()
 		metrics.GatherThrottleMetricsForever(metrics.ComplianceSubsystem.String())
 	}
 

--- a/pkg/metrics/http_server.go
+++ b/pkg/metrics/http_server.go
@@ -46,7 +46,8 @@ func NewDefaultHTTPServer(subsystem Subsystem) *HTTPServer {
 		Name:      "uptime_seconds",
 		Help:      "Total number of seconds that the service has been up",
 	})
-	prometheus.MustRegister(uptimeMetric)
+	// Allow the metric to be registered multiple times for tests
+	_ = prometheus.Register(uptimeMetric)
 
 	return &HTTPServer{
 		Address:      env.MetricsSetting.Setting(),

--- a/pkg/metrics/http_server.go
+++ b/pkg/metrics/http_server.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
@@ -21,13 +22,14 @@ var (
 
 // HTTPServer is a HTTP server for exporting Prometheus metrics.
 type HTTPServer struct {
-	Address     string
-	Gatherer    prometheus.Gatherer
-	HandlerOpts promhttp.HandlerOpts
+	Address      string
+	Gatherer     prometheus.Gatherer
+	HandlerOpts  promhttp.HandlerOpts
+	uptimeMetric prometheus.Gauge
 }
 
 // NewDefaultHTTPServer creates and returns a new metrics http server with configured settings.
-func NewDefaultHTTPServer() *HTTPServer {
+func NewDefaultHTTPServer(subsystem Subsystem) *HTTPServer {
 	if err := env.ValidateMetricsSetting(); err != nil {
 		utils.Should(errors.Wrap(err, "invalid metrics port setting"))
 		log.Error(errors.Wrap(err, "metrics server is disabled"))
@@ -38,9 +40,18 @@ func NewDefaultHTTPServer() *HTTPServer {
 		return nil
 	}
 
+	uptimeMetric := prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: PrometheusNamespace,
+		Subsystem: subsystem.String(),
+		Name:      "uptime_seconds",
+		Help:      "Total number of seconds that the service has been up",
+	})
+	prometheus.MustRegister(uptimeMetric)
+
 	return &HTTPServer{
-		Address:  env.MetricsSetting.Setting(),
-		Gatherer: prometheus.DefaultGatherer,
+		Address:      env.MetricsSetting.Setting(),
+		Gatherer:     prometheus.DefaultGatherer,
+		uptimeMetric: uptimeMetric,
 	}
 }
 
@@ -56,6 +67,14 @@ func (s *HTTPServer) RunForever() {
 		Handler: mux,
 	}
 	go runForever(httpServer)
+	go gatherUptimeMetricForever(time.Now(), s.uptimeMetric)
+}
+
+func gatherUptimeMetricForever(startTime time.Time, uptimeMetric prometheus.Gauge) {
+	t := time.NewTicker(5 * time.Second)
+	for range t.C {
+		uptimeMetric.Set(time.Since(startTime).Seconds())
+	}
 }
 
 func runForever(server *http.Server) {

--- a/pkg/metrics/http_server_test.go
+++ b/pkg/metrics/http_server_test.go
@@ -10,12 +10,12 @@ import (
 
 func TestNewDefaultHTTPServer_default_port(t *testing.T) {
 	t.Setenv(env.MetricsSetting.EnvVar(), "")
-	assert.NotNil(t, NewDefaultHTTPServer())
+	assert.NotNil(t, NewDefaultHTTPServer(CentralSubsystem))
 }
 
 func TestNewDefaultHTTPServer_with_port(t *testing.T) {
 	t.Setenv(env.MetricsSetting.EnvVar(), ":8008")
-	assert.NotNil(t, NewDefaultHTTPServer())
+	assert.NotNil(t, NewDefaultHTTPServer(CentralSubsystem))
 }
 
 func TestNewDefaultHTTPServer_dev_panic(t *testing.T) {
@@ -23,7 +23,7 @@ func TestNewDefaultHTTPServer_dev_panic(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Setenv(env.MetricsSetting.EnvVar(), "error")
-	assert.Panics(t, func() { NewDefaultHTTPServer() })
+	assert.Panics(t, func() { NewDefaultHTTPServer(CentralSubsystem) })
 }
 
 func TestNewDefaultHTTPServer_release_nil(t *testing.T) {
@@ -31,5 +31,5 @@ func TestNewDefaultHTTPServer_release_nil(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Setenv(env.MetricsSetting.EnvVar(), "error")
-	assert.Nil(t, NewDefaultHTTPServer())
+	assert.Nil(t, NewDefaultHTTPServer(CentralSubsystem))
 }

--- a/sensor/kubernetes/main.go
+++ b/sensor/kubernetes/main.go
@@ -32,7 +32,7 @@ func main() {
 	log.Infof("Running StackRox Version: %s", version.GetMainVersion())
 
 	// Start the prometheus metrics server
-	metrics.NewDefaultHTTPServer().RunForever()
+	metrics.NewDefaultHTTPServer(metrics.SensorSubsystem).RunForever()
 	metrics.GatherThrottleMetricsForever(metrics.SensorSubsystem.String())
 
 	sigs := make(chan os.Signal, 1)

--- a/tools/local-sensor/main.go
+++ b/tools/local-sensor/main.go
@@ -239,7 +239,7 @@ func main() {
 	localConfig := mustGetCommandLineArgs()
 	if localConfig.WithMetrics {
 		// Start the prometheus metrics server
-		metrics.NewDefaultHTTPServer().RunForever()
+		metrics.NewDefaultHTTPServer(metrics.SensorSubsystem).RunForever()
 		metrics.GatherThrottleMetricsForever(metrics.SensorSubsystem.String())
 	}
 	var fakeClient client.Interface


### PR DESCRIPTION
## Description

uptime_seconds metric

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

```
uptime_seconds                                                                   4850
```

From QA tests
