### PR TITLE
ROX-8277 Fix malformed operator k8s client user-agent

### DIFF
--- a/operator/main.go
+++ b/operator/main.go
@@ -94,14 +94,16 @@ func run() error {
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
-	mgr, err := ctrl.NewManager(utils.GetRHACSConfigOrDie(), ctrl.Options{
+	restConfig := utils.GetRHACSConfigOrDie()
+
+	mgr, err := ctrl.NewManager(restConfig, ctrl.Options{
 		Scheme:                 scheme,
 		MetricsBindAddress:     metricsAddr,
 		Port:                   9443,
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "bf7ea6a2.stackrox.io",
-		LeaderElectionConfig:   utils.GetRHACSConfigOrDie(),
+		LeaderElectionConfig:   restConfig,
 	})
 	if err != nil {
 		return errors.Wrap(err, "unable to create manager")

--- a/operator/main.go
+++ b/operator/main.go
@@ -37,10 +37,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/rest"
-	"sigs.k8s.io/controller-runtime/pkg/cache"
-	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
@@ -105,12 +101,7 @@ func run() error {
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "bf7ea6a2.stackrox.io",
-		NewClient: func(cache cache.Cache, config *rest.Config, options ctrlClient.Options, uncachedObjects ...ctrlClient.Object) (ctrlClient.Client, error) {
-			if config != nil {
-				config.UserAgent = utils.GetRHACSUserAgent()
-			}
-			return cluster.DefaultNewClient(cache, config, options, uncachedObjects...)
-		},
+		LeaderElectionConfig:   utils.GetRHACSConfigOrDie(),
 	})
 	if err != nil {
 		return errors.Wrap(err, "unable to create manager")

--- a/operator/pkg/utils/rest_config.go
+++ b/operator/pkg/utils/rest_config.go
@@ -13,15 +13,6 @@ import (
 // GetRHACSConfigOrDie returns the default *rest.Config for the operator's kubernetes client with configured UserAgent
 func GetRHACSConfigOrDie() *rest.Config {
 	config := ctrl.GetConfigOrDie()
-	config.UserAgent = GetRHACSUserAgent()
+	config.UserAgent = fmt.Sprintf("%s/v%s %s (%s/%s)", "rhacs-operator", version.GetMainVersion(), defaults.GetImageFlavorNameFromEnv(), runtime.GOOS, runtime.GOARCH)
 	return config
-}
-
-func GetRHACSUserAgent() string {
-	return fmt.Sprintf("%s/v%s %s (%s/%s)",
-		"rhacs-operator",
-		version.GetMainVersion(),
-		defaults.GetImageFlavorNameFromEnv(),
-		runtime.GOOS,
-		runtime.GOARCH)
 }

--- a/operator/pkg/utils/rest_config.go
+++ b/operator/pkg/utils/rest_config.go
@@ -13,6 +13,15 @@ import (
 // GetRHACSConfigOrDie returns the default *rest.Config for the operator's kubernetes client with configured UserAgent
 func GetRHACSConfigOrDie() *rest.Config {
 	config := ctrl.GetConfigOrDie()
-	config.UserAgent = fmt.Sprintf("%s/v%s %s (%s/%s)", "rhacs-operator", version.GetMainVersion(), defaults.GetImageFlavorNameFromEnv(), runtime.GOOS, runtime.GOARCH)
+	config.UserAgent = GetRHACSUserAgent()
 	return config
+}
+
+func GetRHACSUserAgent() string {
+	return fmt.Sprintf("%s/v%s %s (%s/%s)",
+		"rhacs-operator",
+		version.GetMainVersion(),
+		defaults.GetImageFlavorNameFromEnv(),
+		runtime.GOOS,
+		runtime.GOARCH)
 }


### PR DESCRIPTION
## Description

In certain cases, the UserAgent string sent by the operator to the kubernetes API is malformed. e.g.

```
"userAgent": "stackrox-operator/v0.0.0 (linux/amd64) kubernetes/$Format/leader-election"
```
^ see the `$Format/...` suffix 

It seems that the operator controller-runtime k8s client config is not used for *all* clients. For example, it seems that there is another k8s client instantiated for the leader election, which does not use the specified userAgent. 