### PR TITLE
Skip failing ui-e2e tests temporarily

### DIFF
--- a/ui/apps/platform/cypress/integration/configmanagement/dashboard.test.js
+++ b/ui/apps/platform/cypress/integration/configmanagement/dashboard.test.js
@@ -258,7 +258,8 @@ describe('Configuration Management Dashboard', () => {
     });
 
     // This test might fail in local deployment.
-    it('should show the same number of high severity policies in the "Policy Violations By Severity" widget as it does in the Policies list', () => {
+    // ROX-15985: skip until decision whether valid to assume high severity violations.
+    it.skip('should show the same number of high severity policies in the "Policy Violations By Severity" widget as it does in the Policies list', () => {
         const entitiesKey = 'policies';
 
         visitConfigurationManagementDashboard();

--- a/ui/apps/platform/cypress/integration/vulnmanagement/entitypages.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/entitypages.test.js
@@ -54,7 +54,8 @@ describe('Entities single views', () => {
             });
     });
 
-    it('related entities table header should not say "0 entities" or have "page 0 of 0" if there are rows in the table', function () {
+    // ROX-15888 ROX-15985: skip until decision whether valid to assume high severity violations.
+    it.skip('related entities table header should not say "0 entities" or have "page 0 of 0" if there are rows in the table', function () {
         if (hasOrchestratorFlavor('openshift')) {
             this.skip();
         }
@@ -92,7 +93,9 @@ describe('Entities single views', () => {
         });
     });
 
-    it('should scope deployment data based on selected policy from table row click', function () {
+    // ROX-15985: skip until decision whether valid to assume high severity violations.
+    // TODO if the test survives, rewrite as described below.
+    it.skip('should scope deployment data based on selected policy from table row click', function () {
         if (hasOrchestratorFlavor('openshift')) {
             this.skip();
         }
@@ -141,7 +144,8 @@ describe('Entities single views', () => {
             });
     });
 
-    it('should scope deployment data based on selected policy from table count link click', function () {
+    // ROX-15889 ROX-15985: skip until decision whether valid to assume high severity violations.
+    it.skip('should scope deployment data based on selected policy from table count link click', function () {
         if (hasOrchestratorFlavor('openshift')) {
             this.skip();
         }
@@ -165,7 +169,8 @@ describe('Entities single views', () => {
         );
     });
 
-    it('should scope deployment data based on selected policy from entity page tab sublist', function () {
+    // ROX-15934 ROX-15985: skip until decision whether valid to assume high severity violations.
+    it.skip('should scope deployment data based on selected policy from entity page tab sublist', function () {
         if (hasOrchestratorFlavor('openshift')) {
             this.skip();
         }

--- a/ui/apps/platform/cypress/integration/vulnmanagement/policies.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/policies.test.js
@@ -84,7 +84,8 @@ describe('Vulnerability Management Policies', () => {
 
     // Some tests might fail in local deployment.
 
-    it('should display links for failing deployments', function () {
+    // ROX-15891 ROX-15985: skip until decision whether valid to assume high severity violations.
+    it.skip('should display links for failing deployments', function () {
         if (hasOrchestratorFlavor('openshift')) {
             this.skip();
         }


### PR DESCRIPTION
## Description

### Problem

5 tests fail because of assumption that there are fixable vulnerabilities with severity at least important.

Follow up to understand the problem:
* Is there a backend problem?
* Do tests make assumptions about system state that has been true, but is not always guaranteed to be true?

### Analysis

Thanks to Dave Vail:

> Policy failures for deployments that exist before ACS is installed are not detected after installation. (At least for build/deploy policies “Apache Struts: CVE-2017-5638” and “Fixable Severity of at least Important”).

> Note that running the image after installing ACS will correctly fail the policy, as will disabling/enabling the policy.

I just verified disabling/enabling the policy.

> Deploying ACS on a new GKE cluster installs version v3.23.5 of calico-node which has no vulnerabilities with a severity greater than moderate.

> It looks like they were relying on the RHSA in the older calico-node image.

### Temporary solution

ROX-15985 consists of the following failures. All except 1 have separate issues.

All except 1 already have conditional skip for OpenShift.

1. should show the same number of high severity policies in the "Policy Violations By Severity" widget as it does in the Policies list
    ui/apps/platform/cypress/integration/configmanagement/dashboard.test.js

    screenshot has links for low and medium, but not high severity:
    ![configmanagement](https://user-images.githubusercontent.com/11862657/226391549-f9de4799-0701-40c9-95ae-58d407abcd75.png)

2. ROX-15888: related entities table header should not say "0 entities" or have "page 0 of 0" if there are rows in the table
    ui/apps/platform/cypress/integration/vulnmanagement/entitypages.test.js

    Same problem as 5 below: no links for failing deployments

3. ROX-15889: should scope deployment data based on selected policy from table count link click
    ui/apps/platform/cypress/integration/vulnmanagement/entitypages.test.js

    Same problem as 5 below: no links for failing deployments

4. ROX-15934: should scope deployment data based on selected policy from entity page tab sublist
    ui/apps/platform/cypress/integration/vulnmanagement/entitypages.test.js

    Same problem as 5 below: no links for failing deployments

5. ROX-15891 should display links for failing deployments
    ui/apps/platform/cypress/integration/vulnmanagement/policies.test.js

    ![policies](https://user-images.githubusercontent.com/11862657/226391609-abeea1b3-ef88-4532-a051-fa4ccc246572.png)

### Residue

The following test in entitypages.test.js would probably fail like 3 except for conditional assertion. Evidence of need to rewrite in parallel if the test survives.

should scope deployment data based on selected policy from table row click

```js
        // TODO Replace first row and conditional assertion with first row which has pass?
        // That is, rewrite this test as a counterpart to the following test?
        cy.get(`${selectors.tableBodyRows}:eq(0) ${selectors.statusChips}`)
```

## Checklist
- [x] Investigated and inspected CI test results
- [x] Skipped integration tests

## Testing Performed
