### PR TITLE
Reset current page for images table when a column is sorted

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageSingleVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageSingleVulnerabilities.tsx
@@ -40,13 +40,7 @@ import SingleEntityVulnerabilitiesTable from './Tables/SingleEntityVulnerabiliti
 import { ImageDetailsResponse } from './hooks/useImageDetails';
 import useImageVulnerabilities from './hooks/useImageVulnerabilities';
 
-const defaultSortOptions: UseURLSortProps = {
-    sortFields: ['CVE', 'Severity', 'Fixable'],
-    defaultSortOption: {
-        field: 'Severity',
-        direction: 'desc',
-    },
-};
+const defaultSortFields = ['CVE', 'Severity', 'Fixable'];
 
 export type ImageSingleVulnerabilitiesProps = {
     imageId: string;
@@ -56,8 +50,14 @@ export type ImageSingleVulnerabilitiesProps = {
 function ImageSingleVulnerabilities({ imageId, imageData }: ImageSingleVulnerabilitiesProps) {
     const { searchFilter } = useURLSearch();
     const { page, perPage, setPage, setPerPage } = useURLPagination(50);
-    // TODO Need to reset current page at the same time sorting changes
-    const { sortOption, getSortParams } = useURLSort(defaultSortOptions);
+    const { sortOption, getSortParams } = useURLSort({
+        sortFields: defaultSortFields,
+        defaultSortOption: {
+            field: 'Severity',
+            direction: 'desc',
+        },
+        onSort: () => setPage(1),
+    });
     // TODO Still need to properly integrate search filter with query
     const pagination = {
         offset: (page - 1) * perPage,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageSingleVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageSingleVulnerabilities.tsx
@@ -30,7 +30,7 @@ import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import useURLStringUnion from 'hooks/useURLStringUnion';
 import useURLSearch from 'hooks/useURLSearch';
 import useURLPagination from 'hooks/useURLPagination';
-import useURLSort, { UseURLSortProps } from 'hooks/useURLSort';
+import useURLSort from 'hooks/useURLSort';
 import { getHasSearchApplied } from 'utils/searchUtils';
 import { cveStatusTabValues, FixableStatus } from './types';
 import WorkloadTableToolbar from './WorkloadTableToolbar';

--- a/ui/apps/platform/src/hooks/useURLSort.ts
+++ b/ui/apps/platform/src/hooks/useURLSort.ts
@@ -9,6 +9,7 @@ export type GetSortParams = (field: string) => ThProps['sort'] | undefined;
 export type UseURLSortProps = {
     sortFields: string[];
     defaultSortOption: SortOption;
+    onSort?: (newSortOption: SortOption) => void;
 };
 
 export type UseURLSortResult = {
@@ -27,7 +28,7 @@ function isDirection(val: unknown): val is 'asc' | 'desc' {
     return val === 'asc' || val === 'desc';
 }
 
-function useURLSort({ sortFields, defaultSortOption }: UseURLSortProps): UseURLSortResult {
+function useURLSort({ sortFields, defaultSortOption, onSort }: UseURLSortProps): UseURLSortResult {
     const [sortOption, setSortOption] = useURLParameter('sortOption', defaultSortOption);
 
     // get the parsed sort option values from the URL, if available
@@ -74,6 +75,9 @@ function useURLSort({ sortFields, defaultSortOption }: UseURLSortProps): UseURLS
                     field,
                     direction,
                 };
+                if (onSort) {
+                    onSort(newSortOption);
+                }
                 setSortOption(newSortOption);
             },
             columnIndex: index,


### PR DESCRIPTION
## Description

Adds an optional callback option to the `useURLSort` hook so that we can reset the current table page when a column is sorted.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Visit the image page and increment the page of the data table.
![image](https://user-images.githubusercontent.com/1292638/226400930-ae2f1ac3-9f46-443f-b167-73c9650cd463.png)

Sort a column and ensure the table page returns to 1.
![image](https://user-images.githubusercontent.com/1292638/226401013-829af5da-afd2-413c-9cf1-026793e73be9.png)

