### PR TITLE
Pull image details hook body into hook file

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesImageSinglePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesImageSinglePage.tsx
@@ -20,7 +20,6 @@ import {
     Tooltip,
 } from '@patternfly/react-core';
 import { CopyIcon, ExclamationCircleIcon } from '@patternfly/react-icons';
-import { useQuery } from '@apollo/client';
 import { useParams } from 'react-router-dom';
 
 import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
@@ -31,11 +30,7 @@ import ImageSingleVulnerabilities from './ImageSingleVulnerabilities';
 import ImageSingleResources from './ImageSingleResources';
 import { detailsTabValues } from './types';
 import { getOverviewCvesPath } from './searchUtils';
-import {
-    ImageDetailsResponse,
-    ImageDetailsVariables,
-    imageDetailsQuery,
-} from './hooks/useImageDetails';
+import useImageDetails, { ImageDetailsResponse } from './hooks/useImageDetails';
 
 const workloadCveOverviewImagePath = getOverviewCvesPath({
     cveStatusTab: 'Observed',
@@ -96,13 +91,7 @@ function ImageDetailBadges({ imageData }: { imageData: ImageDetailsResponse['ima
 
 function WorkloadCvesImageSinglePage() {
     const { imageId } = useParams();
-    const { data, error } = useQuery<ImageDetailsResponse, ImageDetailsVariables>(
-        imageDetailsQuery,
-        {
-            variables: { id: imageId },
-        }
-    );
-
+    const { data, error } = useImageDetails(imageId);
     const [activeTabKey, setActiveTabKey] = useURLStringUnion('detailsTab', detailsTabValues);
 
     const imageData = data && data.image;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/hooks/useImageDetails.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/hooks/useImageDetails.ts
@@ -1,4 +1,4 @@
-import { gql } from '@apollo/client';
+import { gql, useQuery } from '@apollo/client';
 
 export type ImageDetailsVariables = {
     id: string;
@@ -54,4 +54,8 @@ export const imageDetailsQuery = gql`
     }
 `;
 
-export default function useImageDetails() {}
+export default function useImageDetails(imageId: string) {
+    return useQuery<ImageDetailsResponse, ImageDetailsVariables>(imageDetailsQuery, {
+        variables: { id: imageId },
+    });
+}


### PR DESCRIPTION
## Description

Apparently when I pulled the query and types into a custom hook, I never actually pulled the hook body in and just exported an empty, unused function...

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Manual testing of image page load.
