### PR TITLE
Dashrews/rox 15123 fix clone test to use rocks too

### DIFF
--- a/migrator/clone/clone_test.go
+++ b/migrator/clone/clone_test.go
@@ -817,7 +817,7 @@ func TestRacingConditionInPersist(t *testing.T) {
 }
 
 func TestUpgradeFromLastRocksDB(t *testing.T) {
-	t.Skip("ROX-15123: Skip Rollback to RocksDB test")
+	//t.Skip("ROX-15123: Skip Rollback to RocksDB test")
 	if buildinfo.ReleaseBuild {
 		return
 	}

--- a/migrator/clone/clone_test.go
+++ b/migrator/clone/clone_test.go
@@ -48,7 +48,6 @@ func setVersion(t *testing.T, ver *versionPair) {
 }
 
 func TestCloneMigration(t *testing.T) {
-	//t.Skip("ROX-15123: Skip Rollback to RocksDB test")
 	if env.PostgresDatastoreEnabled.BooleanSetting() {
 		currVer = releaseVer
 		doTestCloneMigration(t, false)
@@ -62,7 +61,6 @@ func TestCloneMigration(t *testing.T) {
 }
 
 func TestCloneMigrationRocksToPostgres(t *testing.T) {
-	//t.Skip("ROX-15123: Skip Rollback to RocksDB test")
 	// Run tests with both Rocks and Postgres to make sure migration clone is correctly determined.
 	if env.PostgresDatastoreEnabled.BooleanSetting() {
 		currVer = releaseVer
@@ -197,8 +195,6 @@ func createAndRunCentralStartRocks(t *testing.T, ver *versionPair, runBoth bool)
 	// First get a Rocks up and current.  This way when we do the next upgrade we should get a previous rocks.
 	require.NoError(t, os.Setenv(env.PostgresDatastoreEnabled.EnvVar(), strconv.FormatBool(false)))
 
-	mock.legacyUpgrade(t, ver, nil)
-
 	mock.runMigrator("", "")
 	mock.runCentral()
 
@@ -208,7 +204,6 @@ func createAndRunCentralStartRocks(t *testing.T, ver *versionPair, runBoth bool)
 }
 
 func TestCloneMigrationFailureAndReentry(t *testing.T) {
-	//t.Skip("ROX-15123: Skip Rollback to RocksDB test")
 	currVer = releaseVer
 	doTestCloneMigrationFailureAndReentry(t)
 	currVer = devVer
@@ -277,7 +272,6 @@ func doTestCloneMigrationFailureAndReentry(t *testing.T) {
 }
 
 func TestCloneRestore(t *testing.T) {
-	//t.Skip("ROX-15123: Skip Rollback to RocksDB test")
 	// This will test restore for Rocks -> Rocks or Postgres -> Postgres depending on
 	// the test is executed with the Postgres env variable set or not.
 	testCloneRestore(t, false)
@@ -363,7 +357,6 @@ func testCloneRestore(t *testing.T, rocksToPostgres bool) {
 }
 
 func TestForceRollbackFailure(t *testing.T) {
-	//t.Skip("ROX-15123: Skip Rollback to RocksDB test")
 	currVer = releaseVer
 	doTestForceRollbackFailure(t)
 	currVer = devVer
@@ -474,7 +467,6 @@ func doTestForceRollbackFailure(t *testing.T) {
 }
 
 func TestForceRollbackRocksToPostgresFailure(t *testing.T) {
-	//t.Skip("ROX-15123: Skip Rollback to RocksDB test")
 	if env.PostgresDatastoreEnabled.BooleanSetting() {
 		currVer = releaseVer
 		doTestForceRollbackRocksToPostgresFailure(t)
@@ -587,7 +579,6 @@ func doTestForceRollbackRocksToPostgresFailure(t *testing.T) {
 }
 
 func TestRollback(t *testing.T) {
-	//t.Skip("ROX-15123: Skip Rollback to RocksDB test")
 	currVer = releaseVer
 	doTestRollback(t)
 	currVer = devVer
@@ -677,7 +668,6 @@ func doTestRollback(t *testing.T) {
 
 // TestRollbackPostgresToRocks - set of tests that will test rolling back to Rocks from Postgres.
 func TestRollbackPostgresToRocks(t *testing.T) {
-	//t.Skip("ROX-15123: Skip Rollback to RocksDB test")
 	// Run tests with both Rocks and Postgres to make sure migration clone is correctly determined.
 	if env.PostgresDatastoreEnabled.BooleanSetting() {
 		currVer = releaseVer
@@ -779,7 +769,6 @@ func doTestRollbackPostgresToRocks(t *testing.T) {
 // This is a completely white box test to cover the racing condition while persisting changes.
 // These conditions are theoretically possible but chance is very slim but we should handle that.
 func TestRacingConditionInPersist(t *testing.T) {
-	//t.Skip("ROX-15123: Skip Rollback to RocksDB test")
 	if buildinfo.ReleaseBuild {
 		return
 	}
@@ -828,7 +817,6 @@ func TestRacingConditionInPersist(t *testing.T) {
 }
 
 func TestUpgradeFromLastRocksDB(t *testing.T) {
-	////t.Skip("ROX-15123: Skip Rollback to RocksDB test")
 	if buildinfo.ReleaseBuild {
 		return
 	}

--- a/migrator/clone/clone_test.go
+++ b/migrator/clone/clone_test.go
@@ -196,6 +196,7 @@ func createAndRunCentralStartRocks(t *testing.T, ver *versionPair, runBoth bool)
 	mock.setVersion(t, ver)
 	// First get a Rocks up and current.  This way when we do the next upgrade we should get a previous rocks.
 	require.NoError(t, os.Setenv(env.PostgresDatastoreEnabled.EnvVar(), strconv.FormatBool(false)))
+	log.Infof("SHREWS -- Should be false = %t", env.PostgresDatastoreEnabled.BooleanSetting())
 
 	mock.runMigrator("", "")
 	mock.runCentral()
@@ -873,9 +874,9 @@ func TestUpgradeFromLastRocksDB(t *testing.T) {
 			mock.setVersion = setVersion
 
 			// Doesn't make sense to run this on the fresh install case
-			if c.fromRocks {
-				mock.legacyUpgrade(t, c.fromVersion)
-			}
+			//if c.fromRocks {
+			//	mock.legacyUpgrade(t, c.fromVersion, c.previousVerion)
+			//}
 
 			mock.upgradeCentral(c.toVersion, "")
 			mock.verifyCurrent()

--- a/migrator/clone/clone_test.go
+++ b/migrator/clone/clone_test.go
@@ -48,7 +48,7 @@ func setVersion(t *testing.T, ver *versionPair) {
 }
 
 func TestCloneMigration(t *testing.T) {
-	t.Skip("ROX-15123: Skip Rollback to RocksDB test")
+	//t.Skip("ROX-15123: Skip Rollback to RocksDB test")
 	if env.PostgresDatastoreEnabled.BooleanSetting() {
 		currVer = releaseVer
 		doTestCloneMigration(t, false)
@@ -62,7 +62,7 @@ func TestCloneMigration(t *testing.T) {
 }
 
 func TestCloneMigrationRocksToPostgres(t *testing.T) {
-	t.Skip("ROX-15123: Skip Rollback to RocksDB test")
+	//t.Skip("ROX-15123: Skip Rollback to RocksDB test")
 	// Run tests with both Rocks and Postgres to make sure migration clone is correctly determined.
 	if env.PostgresDatastoreEnabled.BooleanSetting() {
 		currVer = releaseVer
@@ -196,7 +196,8 @@ func createAndRunCentralStartRocks(t *testing.T, ver *versionPair, runBoth bool)
 	mock.setVersion(t, ver)
 	// First get a Rocks up and current.  This way when we do the next upgrade we should get a previous rocks.
 	require.NoError(t, os.Setenv(env.PostgresDatastoreEnabled.EnvVar(), strconv.FormatBool(false)))
-	log.Infof("SHREWS -- Should be false = %t", env.PostgresDatastoreEnabled.BooleanSetting())
+
+	mock.legacyUpgrade(t, ver, nil)
 
 	mock.runMigrator("", "")
 	mock.runCentral()
@@ -207,7 +208,7 @@ func createAndRunCentralStartRocks(t *testing.T, ver *versionPair, runBoth bool)
 }
 
 func TestCloneMigrationFailureAndReentry(t *testing.T) {
-	t.Skip("ROX-15123: Skip Rollback to RocksDB test")
+	//t.Skip("ROX-15123: Skip Rollback to RocksDB test")
 	currVer = releaseVer
 	doTestCloneMigrationFailureAndReentry(t)
 	currVer = devVer
@@ -276,7 +277,7 @@ func doTestCloneMigrationFailureAndReentry(t *testing.T) {
 }
 
 func TestCloneRestore(t *testing.T) {
-	t.Skip("ROX-15123: Skip Rollback to RocksDB test")
+	//t.Skip("ROX-15123: Skip Rollback to RocksDB test")
 	// This will test restore for Rocks -> Rocks or Postgres -> Postgres depending on
 	// the test is executed with the Postgres env variable set or not.
 	testCloneRestore(t, false)
@@ -362,7 +363,7 @@ func testCloneRestore(t *testing.T, rocksToPostgres bool) {
 }
 
 func TestForceRollbackFailure(t *testing.T) {
-	t.Skip("ROX-15123: Skip Rollback to RocksDB test")
+	//t.Skip("ROX-15123: Skip Rollback to RocksDB test")
 	currVer = releaseVer
 	doTestForceRollbackFailure(t)
 	currVer = devVer
@@ -473,7 +474,7 @@ func doTestForceRollbackFailure(t *testing.T) {
 }
 
 func TestForceRollbackRocksToPostgresFailure(t *testing.T) {
-	t.Skip("ROX-15123: Skip Rollback to RocksDB test")
+	//t.Skip("ROX-15123: Skip Rollback to RocksDB test")
 	if env.PostgresDatastoreEnabled.BooleanSetting() {
 		currVer = releaseVer
 		doTestForceRollbackRocksToPostgresFailure(t)
@@ -586,7 +587,7 @@ func doTestForceRollbackRocksToPostgresFailure(t *testing.T) {
 }
 
 func TestRollback(t *testing.T) {
-	t.Skip("ROX-15123: Skip Rollback to RocksDB test")
+	//t.Skip("ROX-15123: Skip Rollback to RocksDB test")
 	currVer = releaseVer
 	doTestRollback(t)
 	currVer = devVer
@@ -676,7 +677,7 @@ func doTestRollback(t *testing.T) {
 
 // TestRollbackPostgresToRocks - set of tests that will test rolling back to Rocks from Postgres.
 func TestRollbackPostgresToRocks(t *testing.T) {
-	t.Skip("ROX-15123: Skip Rollback to RocksDB test")
+	//t.Skip("ROX-15123: Skip Rollback to RocksDB test")
 	// Run tests with both Rocks and Postgres to make sure migration clone is correctly determined.
 	if env.PostgresDatastoreEnabled.BooleanSetting() {
 		currVer = releaseVer
@@ -778,7 +779,7 @@ func doTestRollbackPostgresToRocks(t *testing.T) {
 // This is a completely white box test to cover the racing condition while persisting changes.
 // These conditions are theoretically possible but chance is very slim but we should handle that.
 func TestRacingConditionInPersist(t *testing.T) {
-	t.Skip("ROX-15123: Skip Rollback to RocksDB test")
+	//t.Skip("ROX-15123: Skip Rollback to RocksDB test")
 	if buildinfo.ReleaseBuild {
 		return
 	}
@@ -827,7 +828,7 @@ func TestRacingConditionInPersist(t *testing.T) {
 }
 
 func TestUpgradeFromLastRocksDB(t *testing.T) {
-	//t.Skip("ROX-15123: Skip Rollback to RocksDB test")
+	////t.Skip("ROX-15123: Skip Rollback to RocksDB test")
 	if buildinfo.ReleaseBuild {
 		return
 	}
@@ -869,15 +870,22 @@ func TestUpgradeFromLastRocksDB(t *testing.T) {
 			if c.previousVerion != nil {
 				startVer = c.previousVerion
 			}
-			mock := createAndRunCentralStartRocks(t, startVer, true)
+			mock := createCentral(t, true)
 			defer mock.destroyCentral()
 			mock.setVersion = setVersion
+			mock.setVersion(t, startVer)
 
 			// Doesn't make sense to run this on the fresh install case
-			//if c.fromRocks {
-			//	mock.legacyUpgrade(t, c.fromVersion, c.previousVerion)
-			//}
+			if c.fromRocks {
+				// With the flag permanently set now we are no longer able to toggle it.
+				// So we need to explicitly update RocksDB
+				// if we want tests to work as if RocksDB was the original DB.
+				mock.legacyUpgrade(t, c.fromVersion, c.previousVerion)
+			}
 
+			mock.setVersion(t, c.toVersion)
+			mock.runMigrator("", "")
+			mock.runCentral()
 			mock.upgradeCentral(c.toVersion, "")
 			mock.verifyCurrent()
 

--- a/migrator/clone/clone_test.go
+++ b/migrator/clone/clone_test.go
@@ -887,6 +887,9 @@ func TestUpgradeFromLastRocksDB(t *testing.T) {
 				if c.previousVerion != nil {
 					mock.verifyClone(rocksdb.PreviousClone, &versionPair{version: c.previousVerion.version, seqNum: c.previousVerion.seqNum})
 				}
+			} else {
+				// Rocks should have then empty version if we fresh installed Postgres.
+				mock.verifyClone(rocksdb.CurrentClone, &versionPair{version: "0", seqNum: 0})
 			}
 		})
 	}

--- a/migrator/clone/mock_central.go
+++ b/migrator/clone/mock_central.go
@@ -119,7 +119,12 @@ func (m *mockCentral) migrateWithVersion(ver *versionPair, breakpoint string, fo
 func (m *mockCentral) legacyUpgrade(t *testing.T, ver *versionPair) {
 	log.Infof("SHREWS -- legacyUpgrade -- runBoth %t, updateBoth %t, version %v", m.runBoth, m.updateBoth, ver)
 
-	m.setMigrationVersion(filepath.Join(migrations.CurrentPath(), "db"), ver)
+	//m.setMigrationVersion(filepath.Join(m.mountPath, rocksdb.CurrentClone), ver)
+
+	path := filepath.Join(m.mountPath, rocksdb.CurrentClone)
+	require.NoError(m.t, os.WriteFile(filepath.Join(path, "db"), []byte(fmt.Sprintf("%d", ver.seqNum)), 0644))
+
+	m.setMigrationVersion(path, ver)
 
 	//require.NoError(t, os.Setenv(env.PostgresDatastoreEnabled.EnvVar(), strconv.FormatBool(false)))
 	//m.setVersion(t, ver)

--- a/migrator/clone/mock_central.go
+++ b/migrator/clone/mock_central.go
@@ -351,7 +351,6 @@ func (m *mockCentral) verifyClone(clone string, ver *versionPair) {
 		require.NoFileExists(m.t, filepath.Join(dbPath, migrations.MigrationVersionFile))
 		m.verifyMigrationVersion(dbPath, &versionPair{version: "0", seqNum: 0})
 	}
-	//m.verifyDBVersion(dbPath, ver.seqNum)
 }
 
 func (m *mockCentral) verifyClonePostgres(clone string, ver *versionPair) {

--- a/pkg/postgres/pgadmin/admin_utils.go
+++ b/pkg/postgres/pgadmin/admin_utils.go
@@ -342,7 +342,7 @@ func getAvailablePostgresCapacity(postgresConfig *postgres.Config) (int64, error
 
 	// We should only get the header row and the row for the size of $PGDATA.  If we
 	// get more than that, then $PGDATA is not defined
-	if len(rawCapacityInfo) != 2 {
+	if len(rawCapacityInfo) < 2 {
 		if err := tx.Rollback(ctx); err != nil {
 			return 0, err
 		}


### PR DESCRIPTION
## Description

Now that the setting of the Postgres flag is automatic and most importantly permanent, we must be more deliberate in setting up RocksDB for these upgrade tests.  So the updates here are to specifically set the version in Rocks to what we want it to be before executing the migrator.  This will have the Rocks in the state we want it and ready for the migrator run.

## Checklist
- [ ] Investigated and inspected CI test results
~- [ ] Unit test and regression tests added~
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

It is a test.
