### PR TITLE
Wait for isLoadingPublicConfig in MainPage

### DIFF
--- a/ui/apps/platform/src/Containers/MainPage/MainPage.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/MainPage.tsx
@@ -1,4 +1,5 @@
 import React, { ReactElement } from 'react';
+import { useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import { Page } from '@patternfly/react-core';
 import { gql, useQuery } from '@apollo/client';
@@ -6,6 +7,7 @@ import { gql, useQuery } from '@apollo/client';
 import LoadingSection from 'Components/PatternFly/LoadingSection';
 import useFeatureFlags from 'hooks/useFeatureFlags';
 import usePermissions from 'hooks/usePermissions';
+import { selectors } from 'reducers';
 import { clustersBasePath } from 'routePaths';
 
 import AnnouncementBanner from './Banners/AnnouncementBanner';
@@ -39,6 +41,7 @@ function MainPage(): ReactElement {
 
     const { isFeatureFlagEnabled, isLoadingFeatureFlags } = useFeatureFlags();
     const { hasReadAccess, hasReadWriteAccess, isLoadingPermissions } = usePermissions();
+    const isLoadingPublicConfig = useSelector(selectors.isLoadingPublicConfigSelector);
 
     // Check for clusters under management
     // if none, and user can admin Clusters, redirect to clusters section
@@ -53,8 +56,11 @@ function MainPage(): ReactElement {
         },
     });
 
-    // Render Body and NavigationSideBar only when feature flags and permissions are available.
-    if (isLoadingFeatureFlags || isLoadingPermissions) {
+    // Prerequisites from initial requests for conditional rendering that affects all authenticated routes:
+    // feature flags: for NavigationSidebar and Body
+    // permissions: for NavigationSidebar and Body
+    // public config: for PublicConfigHeader and PublicConfigFooter and analytics
+    if (isLoadingFeatureFlags || isLoadingPermissions || isLoadingPublicConfig) {
         return <LoadingSection message="Loading..." />;
     }
 


### PR DESCRIPTION
## Description

Add public config as another prerequisite from initial requests for conditional rendering that affects all authenticated routes.

I had debated it for header and footer, but now that it affects **analytics**, wait until information is in Redux store to prevent edge cases.

1. GET /v1/featureflags
2. GET /v1/config/public
3. GET /v1/telemetry/config to be determined if this is also a prerequisite to render routes
4. GET /v1/mypermissions

### Residue

**Brad**: As the implementation of analytics matures with opt-in-out option (what a delightful pun) we need to determine whether frontend **always** makes telemetry config request.

If it **always** makes the request:

1. MainPage might need to wait until availability of analytics is known via response or failure of GET /v1/telemetry/config request.
2. Integration tests helper will need to wait on the request:
    ui/apps/platform/cypress/helpers/visit.js

If it **conditionally** makes the request, then we still need to analyze the preceding bullet points from that viewpoint.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed