### PR TITLE
Fix GitHub actions to allow for external contributions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -84,7 +84,6 @@ jobs:
         with:
           name: cli-build
           path: cli-build.tgz
-
   pre-build-go-binaries:
     runs-on: ubuntu-latest
     container:
@@ -123,7 +122,6 @@ jobs:
         with:
           name: go-binaries-build
           path: go-binaries-build.tgz
-
   pre-build-go-binaries-rcd:
     runs-on: ubuntu-latest
     container:
@@ -165,7 +163,6 @@ jobs:
       with:
         name: go-binaries-build-rcd
         path: go-binaries-build-rcd.tgz
-
   pre-build-docs:
     runs-on: ubuntu-latest
     container:
@@ -273,8 +270,11 @@ jobs:
       - name: Generate OSS notice
         run: make ossls-notice
 
+      # Check if we actually need this, or we can skip this and only do if after make docker-build-image.
       # needed for docs ensure_image.sh initial pull with RHACS_BRANDING
       - name: Docker login
+        # Skip for external contributions.
+        if: github.event.pull_request.head.repo.full_name == github.repository
         run: |
             docker login -u "${QUAY_RHACS_ENG_RO_USERNAME}" --password-stdin quay.io <<<"${QUAY_RHACS_ENG_RO_PASSWORD}"
 
@@ -288,6 +288,8 @@ jobs:
         run: make docker-build-roxctl-image
 
       - name: Push images
+        # Skip for external contributions.
+        if: github.event.pull_request.head.repo.full_name == github.repository
         run: |
             source ./scripts/ci/lib.sh
             echo "Will determin context from: ${{ github.event_name }} & ${{ github.ref_name }}"
@@ -298,11 +300,15 @@ jobs:
             push_main_image_set "$push_context" "${{ env.ROX_PRODUCT_BRANDING }}"
 
       - name: Push matching collector and scanner images
+        # Skip for external contributions.
+        if: github.event.pull_request.head.repo.full_name == github.repository
         run: |
             source ./scripts/ci/lib.sh
             push_matching_collector_scanner_images "${{ env.ROX_PRODUCT_BRANDING }}"
 
       - name: Comment on the PR
+        # Skip for external contributions.
+        if: github.event.pull_request.head.repo.full_name == github.repository
         env:
           GITHUB_TOKEN: "${{ secrets.ROBOT_ROX_GITHUB_TOKEN }}"
         run: |
@@ -379,18 +385,25 @@ jobs:
         echo "TAG=$(make --quiet tag)" >> "$GITHUB_OUTPUT"
 
     - name: Set up Docker Buildx
+      # Skip for external contributions.
+      if: github.event.pull_request.head.repo.full_name == github.repository
       uses: docker/setup-buildx-action@v2
     - name: Login to quay.io/rhacs-eng
+      # Skip for external contributions.
+      if: github.event.pull_request.head.repo.full_name == github.repository
       uses: docker/login-action@v2
       with:
         registry: quay.io
         username: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
         password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
 
+    # Is this required to be run _after_ docker login? If not, let's move it before doing docker login.
     - name: Build main images
       run: make docker-build-main-image
 
     - name: Push to quay.io/rhacs-eng
+      # Skip for external contributions.
+      if: github.event.pull_request.head.repo.full_name == github.repository
       uses: docker/build-push-action@v4
       with:
         context: image/rhel
@@ -438,8 +451,10 @@ jobs:
       - name: Setup Go build environment
         if: contains(github.event.pull_request.labels.*.name, 'ci-release-build')
         run: echo "GOTAGS=release" >> "$GITHUB_ENV"
-
+      # Is this required to be run before building the bundle image? If not, let's move it afterwards.
       - name: Docker login
+        # Skip for external contributions.
+        if: github.event.pull_request.head.repo.full_name == github.repository
         run: |
             docker login -u "${QUAY_RHACS_ENG_RW_USERNAME}" --password-stdin quay.io <<<"${QUAY_RHACS_ENG_RW_PASSWORD}"
 
@@ -454,15 +469,21 @@ jobs:
         run: docker run --rm "quay.io/rhacs-eng/stackrox-operator:$(make --quiet -C operator tag)" --help
 
       - name: Push images
+        # Skip for external contributions.
+        if: github.event.pull_request.head.repo.full_name == github.repository
         run: |
           make -C operator/ docker-push docker-push-bundle | cat
 
       # Index image can only be built once bundle was pushed
       - name: Build index
+        # Skip for external contributions as the build relies on the previous image to be pushed.
+        if: github.event.pull_request.head.repo.full_name == github.repository
         run: |
           make -C operator/ index-build
 
       - name: Push index image
+        # Skip for external contributions.
+        if: github.event.pull_request.head.repo.full_name == github.repository
         run: |
           make -C operator/ docker-push-index | cat
 
@@ -496,9 +517,13 @@ jobs:
       run: make mock-grpc-server-image
 
     - name: Set up Docker Buildx
+      # Skip for external contributions.
+      if: github.event.pull_request.head.repo.full_name == github.repository
       uses: docker/setup-buildx-action@v2
 
     - name: Login to quay.io/rhacs-eng
+      # Skip for external contributions.
+      if: github.event.pull_request.head.repo.full_name == github.repository
       uses: docker/login-action@v2
       with:
         registry: quay.io
@@ -506,6 +531,8 @@ jobs:
         password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
 
     - name: Push to quay.io/rhacs-eng
+      # Skip for external contributions.
+      if: github.event.pull_request.head.repo.full_name == github.repository
       uses: docker/build-push-action@v4
       with:
         context: integration-tests/mock-grpc-server/image

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -270,14 +270,6 @@ jobs:
       - name: Generate OSS notice
         run: make ossls-notice
 
-      # Check if we actually need this, or we can skip this and only do if after make docker-build-image.
-      # needed for docs ensure_image.sh initial pull with RHACS_BRANDING
-      - name: Docker login
-        # Skip for external contributions.
-        if: github.event.pull_request.head.repo.full_name == github.repository
-        run: |
-            docker login -u "${QUAY_RHACS_ENG_RO_USERNAME}" --password-stdin quay.io <<<"${QUAY_RHACS_ENG_RO_PASSWORD}"
-
       - name: Build main images
         run: make docker-build-main-image
 
@@ -286,6 +278,13 @@ jobs:
 
       - name: Build roxctl image
         run: make docker-build-roxctl-image
+
+      # needed for docs ensure_image.sh initial pull with RHACS_BRANDING
+      - name: Docker login
+        # Skip for external contributions.
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        run: |
+          docker login -u "${QUAY_RHACS_ENG_RO_USERNAME}" --password-stdin quay.io <<<"${QUAY_RHACS_ENG_RO_PASSWORD}"
 
       - name: Push images
         # Skip for external contributions.
@@ -385,11 +384,13 @@ jobs:
         echo "TAG=$(make --quiet tag)" >> "$GITHUB_OUTPUT"
 
     - name: Set up Docker Buildx
-      # Skip for external contributions.
-      if: github.event.pull_request.head.repo.full_name == github.repository
       uses: docker/setup-buildx-action@v2
+
+    - name: Build main images
+      run: make docker-build-main-image
+
     - name: Login to quay.io/rhacs-eng
-      # Skip for external contributions.
+
       if: github.event.pull_request.head.repo.full_name == github.repository
       uses: docker/login-action@v2
       with:
@@ -397,17 +398,12 @@ jobs:
         username: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
         password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
 
-    # Is this required to be run _after_ docker login? If not, let's move it before doing docker login.
-    - name: Build main images
-      run: make docker-build-main-image
-
     - name: Push to quay.io/rhacs-eng
-      # Skip for external contributions.
-      if: github.event.pull_request.head.repo.full_name == github.repository
       uses: docker/build-push-action@v4
       with:
         context: image/rhel
-        push: true
+        # Skip for external contributions.
+        push: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         build-args: |
           ROX_PRODUCT_BRANDING=${{ env.ROX_PRODUCT_BRANDING }}
         file: image/rhel/Dockerfile.gen
@@ -451,7 +447,7 @@ jobs:
       - name: Setup Go build environment
         if: contains(github.event.pull_request.labels.*.name, 'ci-release-build')
         run: echo "GOTAGS=release" >> "$GITHUB_ENV"
-      # Is this required to be run before building the bundle image? If not, let's move it afterwards.
+
       - name: Docker login
         # Skip for external contributions.
         if: github.event.pull_request.head.repo.full_name == github.repository
@@ -531,12 +527,11 @@ jobs:
         password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
 
     - name: Push to quay.io/rhacs-eng
-      # Skip for external contributions.
-      if: github.event.pull_request.head.repo.full_name == github.repository
       uses: docker/build-push-action@v4
       with:
         context: integration-tests/mock-grpc-server/image
-        push: true
+        # Skip for external contributions.
+        push: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         tags: |
           quay.io/rhacs-eng/grpc-server:${{ steps.tag.outputs.TAG }}
 


### PR DESCRIPTION
## Description

Currently, external contributors won't be able to provide mergable PRs that fulfill all required steps within GitHub actions, due to us currently requiring to push the container image within the build step.

Since external contributors (or, to be more specific, PRs from forks) do not have access to CI secrets, they currently are failing the push step, specifically the docker login part.

Instead of requiring the build step for external contributors to include the push part, I've skipped this for them (for "internal" PRs, i.e. originating from the same repository, the images will still be pushed).

This has the following consequences:
- the workflow will succeed and the PR can be merged.
- all subsequent E2E tests triggered from this PR will fail, due to the image not being available. If the desire is to run these tests, one would have to mirror the branch to an internal branch, build + push the image via CI, and re-trigger E2E tests.

Alternatives considered:
Instead of skipping parts of the current jobs, split out the build and push parts as separate jobs.
I've decided against this due to:
- the build part currently (for most resources) includes doing a docker build. As a consequence, we would have to upload the docker archive as artifact to share between jobs. This would further increase the build time.
- some parts of the build require images being pushed prior. Specifically, the `index-build` step when building the operator images.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

https://github.com/dhaus67/stackrox/actions/runs/4468859918
