### PR TITLE
ROX-13190,ROX-14595,ROX-15073,ROX-15311: Admission controller e2e test fixes

### DIFF
--- a/qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy
+++ b/qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy
@@ -1,5 +1,4 @@
 import io.stackrox.proto.api.v1.Common
-import io.stackrox.proto.api.v1.PolicyServiceOuterClass
 import io.stackrox.proto.storage.ClusterOuterClass.AdmissionControllerConfig
 import io.stackrox.proto.storage.PolicyOuterClass
 import io.stackrox.proto.storage.PolicyOuterClass.PolicyGroup
@@ -13,6 +12,7 @@ import objects.GCRImageIntegration
 import services.CVEService
 import services.ClusterService
 import services.ImageIntegrationService
+import services.ImageService
 import services.PolicyService
 import util.ChaosMonkey
 import util.Env
@@ -82,6 +82,9 @@ class AdmissionControllerTest extends BaseSpecification {
         ImageIntegrationService.deleteStackRoxScannerIntegrationIfExists()
         gcrId = GCRImageIntegration.createDefaultIntegration()
         assert gcrId != ""
+
+        // Pre run scan to avoid timeouts with inline scans in the tests below
+        ImageService.scanImage(GCR_NGINX)
     }
 
     def setup() {
@@ -179,7 +182,10 @@ class AdmissionControllerTest extends BaseSpecification {
         prepareChaosMonkey()
 
         and:
-         "Create policy looking for a specific CVE"
+        "Scan image"
+        ImageService.scanImage(image)
+
+        "Create policy looking for a specific CVE"
         // We don't want to block on SEVERITY
         Services.updatePolicyEnforcement(
                 SEVERITY,
@@ -202,24 +208,23 @@ class AdmissionControllerTest extends BaseSpecification {
                 .setBooleanOperator(PolicyOuterClass.BooleanOperator.AND)
         policyGroup.addAllValues([PolicyValue.newBuilder().setValue("CVE-2019-3462").build(),])
 
+        String policyName = "Matching CVE (CVE-2019-3462)"
         PolicyOuterClass.Policy policy = PolicyOuterClass.Policy.newBuilder()
-                .setName("Matching CVE (CVE-2019-3462)")
+                .setName(policyName)
                 .addLifecycleStages(PolicyOuterClass.LifecycleStage.DEPLOY)
-                .addCategories("Testing")
+                .addCategories("DevOps Best Practices")
                 .setSeverity(PolicyOuterClass.Severity.HIGH_SEVERITY)
                 .addEnforcementActions(PolicyOuterClass.EnforcementAction.SCALE_TO_ZERO_ENFORCEMENT)
                 .addPolicySections(
                         PolicySection.newBuilder().addPolicyGroups(policyGroup.build()).build())
                 .build()
-        policy = PolicyService.policyClient.postPolicy(
-                PolicyServiceOuterClass.PostPolicyRequest.newBuilder()
-                        .setPolicy(policy)
-                        .build()
-        )
+
+        String policyID = PolicyService.createNewPolicy(policy)
+        assert policyID
 
         log.info("Policy created to scale-to-zero deployments with CVE-2019-3462")
         // Maximum time to wait for propagation to sensor
-        Helpers.sleepWithRetryBackoff(5000 * (ClusterService.isOpenShift4() ? 4 : 1))
+        Helpers.sleepWithRetryBackoff(15000 * (ClusterService.isOpenShift4() ? 4 : 1))
         log.info("Sensor and admission-controller _should_ have the policy update")
 
         def deployment = new Deployment()
@@ -279,15 +284,14 @@ class AdmissionControllerTest extends BaseSpecification {
 
         and:
         "Delete policy"
-        PolicyService.policyClient.deletePolicy(Common.ResourceByID.newBuilder().setId(policy.id).build())
+        PolicyService.policyClient.deletePolicy(Common.ResourceByID.newBuilder().setId(policyID).build())
 
         if (created) {
             deleteDeploymentWithCaution(deployment)
         }
 
         // Add back enforcement
-        Services.updatePolicyEnforcement(
-                SEVERITY,
+        Services.updatePolicyEnforcement(SEVERITY,
                 [PolicyOuterClass.EnforcementAction.SCALE_TO_ZERO_ENFORCEMENT,]
         )
 


### PR DESCRIPTION
## Description

The "Verify CVE snoozing applies to images scanned by admission controller us.gcr.io/stackrox-ci/nginx:1.10.1" was failing because the policy creation itself was failing - because the policy category being used does not exist.
Changed to use a pre existing category for the new policy, and asserting on the policy create being successful, before running the actual testcase  scenario.

A bunch of other inline scan related tests were failing because of possible timing issues with the scan. Added a force scan for the image in question in the setup stage to avoid the scan related timing issues.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed
CI failure, hence CI only.