### PR TITLE
Provide aria-label for classic Pagination buttons

### DIFF
--- a/ui/apps/platform/cypress/constants/TablePagination.js
+++ b/ui/apps/platform/cypress/constants/TablePagination.js
@@ -6,8 +6,8 @@ export const selectors = {
     configure: `${navigationSelectors.navExpandable}:contains("Platform Configuration")`,
     navLink: `${navigationSelectors.navLinks}:contains("System Policies")`,
     paginationHeader: '[data-testid="pagination-header"]',
-    prevPageButton: '[data-testid="prev-page-button"]',
-    nextPageButton: '[data-testid="next-page-button"]',
+    prevPageButton: '[aria-label="Go to previous page"]',
+    nextPageButton: '[aria-label="Go to next page"]',
     pageNumberInput: '[data-testid="page-number-input"]',
     tableFirstRow: '.rt-tr-group:first-child .rt-tr',
 };

--- a/ui/apps/platform/cypress/selectors/pagination.js
+++ b/ui/apps/platform/cypress/selectors/pagination.js
@@ -3,8 +3,8 @@
  */
 
 const pagination = {
-    previousPage: '[data-testid="previous-page-button"]',
-    nextPage: '[data-testid="next-page-button"]',
+    previousPage: '[aria-label="Go to previous page"]',
+    nextPage: '[aria-label="Go to next page"]',
 };
 
 export default pagination;

--- a/ui/apps/platform/src/Components/Pagination/NextPaginationButton/NextPaginationButton.js
+++ b/ui/apps/platform/src/Components/Pagination/NextPaginationButton/NextPaginationButton.js
@@ -15,7 +15,7 @@ const NextPaginationButton = ({ className, currentPage, totalSize, pageSize, onC
             className={className}
             onClick={onNextPage}
             disabled={currentPage === totalPages || totalPages === 1}
-            data-testid="next-page-button"
+            aria-label="Go to next page"
         >
             <ChevronRight className="h-6 w-6" />
         </button>

--- a/ui/apps/platform/src/Components/Pagination/NextPaginationButton/NextPaginationButton.test.js
+++ b/ui/apps/platform/src/Components/Pagination/NextPaginationButton/NextPaginationButton.test.js
@@ -26,9 +26,13 @@ const MockPagination = ({ defaultPage = 1 }) => {
     );
 };
 
+const options = {
+    name: 'Go to next page', // aria-label attribute
+};
+
 test('can press the next button when on the first page', async () => {
     render(<MockPagination defaultPage={1} />);
-    const button = screen.getByTestId('next-page-button');
+    const button = screen.getByRole('button', options);
 
     // button should not be disabled
     expect(button).not.toHaveAttribute('disabled');
@@ -36,7 +40,7 @@ test('can press the next button when on the first page', async () => {
 
 test('can not press the next button when on the last page', async () => {
     render(<MockPagination defaultPage={5} />);
-    const button = screen.getByTestId('next-page-button');
+    const button = screen.getByRole('button', options);
 
     // button should be disabled
     expect(button).toHaveAttribute('disabled');
@@ -45,7 +49,7 @@ test('can not press the next button when on the last page', async () => {
 test('pressing the button increases the page count', async () => {
     const currentPage = 1;
     render(<MockPagination defaultPage={currentPage} />);
-    const button = screen.getByTestId('next-page-button');
+    const button = screen.getByRole('button', options);
     const input = screen.getByTestId('pagination-input');
 
     fireEvent.click(button);

--- a/ui/apps/platform/src/Components/Pagination/PrevPaginationButton/PrevPaginationButton.js
+++ b/ui/apps/platform/src/Components/Pagination/PrevPaginationButton/PrevPaginationButton.js
@@ -15,7 +15,7 @@ const PrevPaginationButton = ({ className, currentPage, totalSize, pageSize, onC
             className={className}
             onClick={onPreviousPage}
             disabled={currentPage <= 1}
-            data-testid="prev-page-button"
+            aria-label="Go to previous page"
         >
             <ChevronLeft className="h-6 w-6" />
         </button>

--- a/ui/apps/platform/src/Components/Pagination/PrevPaginationButton/PrevPaginationButton.test.js
+++ b/ui/apps/platform/src/Components/Pagination/PrevPaginationButton/PrevPaginationButton.test.js
@@ -26,9 +26,13 @@ const MockPagination = ({ defaultPage = 1 }) => {
     );
 };
 
+const options = {
+    name: 'Go to previous page', // aria-label attribute
+};
+
 test('can not press the previous button when on the first page', async () => {
     render(<MockPagination defaultPage={1} />);
-    const button = screen.getByTestId('prev-page-button');
+    const button = screen.getByRole('button', options);
 
     // button should be disabled
     expect(button).toHaveAttribute('disabled');
@@ -36,7 +40,7 @@ test('can not press the previous button when on the first page', async () => {
 
 test('can press the previous button when on the last page', async () => {
     render(<MockPagination defaultPage={5} />);
-    const button = screen.getByTestId('prev-page-button');
+    const button = screen.getByRole('button', options);
 
     // button should not be disabled
     expect(button).not.toHaveAttribute('disabled');
@@ -45,7 +49,7 @@ test('can press the previous button when on the last page', async () => {
 test('pressing the button decreases the page count', async () => {
     const currentPage = 3;
     render(<MockPagination defaultPage={currentPage} />);
-    const button = screen.getByTestId('prev-page-button');
+    const button = screen.getByRole('button', options);
     const input = screen.getByTestId('pagination-input');
 
     fireEvent.click(button);

--- a/ui/apps/platform/src/Components/TablePagination.js
+++ b/ui/apps/platform/src/Components/TablePagination.js
@@ -93,7 +93,7 @@ const TablePagination = ({ dataLength, setPage, page, pageSize }) => {
                     className="flex items-center rounded-full hover:bg-primary-200 hover:text-primary-600 mr-1 p-1"
                     onClick={previousPage}
                     disabled={page <= 0}
-                    data-testid="prev-page-button"
+                    aria-label="Go to previous page"
                 >
                     <Icon.ChevronLeft className="h-6 w-6" />
                 </button>
@@ -102,7 +102,7 @@ const TablePagination = ({ dataLength, setPage, page, pageSize }) => {
                     className="flex items-center rounded-full text-base-600 hover:bg-primary-200 hover:text-primary-600 p-1"
                     onClick={nextPage}
                     disabled={page >= totalPages - 1}
-                    data-testid="next-page-button"
+                    aria-label="Go to next page"
                 >
                     <Icon.ChevronRight className="h-6 w-6" />
                 </button>


### PR DESCRIPTION
## Description

### Problem

Solve critical issue from axe DevTools:

> Button must have discernable text

### Analysis

Pagination buttons need `aria-label` attribute.

### Solution

1. Add `aria-label` prop that follows the precedent of PatternFly Pagination element.
    * Go to previous page
    * Go to next page
2. Use `aria-label` instead of `data-testid` for integration tests.

### Residue

1. Classic pagination also has color contrast issue.

2. Maybe a moot point that there seems like redundant pagination for classic StackRox:
    * src/Components/Pagination/PrevPaginationButton/PrevPaginationButton.js
    * src/Components/Pagination/NextPaginationButton/NextPaginationButton.js
    * src/Components/TablePagination.js

3. Ditto for integration tests:
    * cypress/constants/TablePagination.js
    * cypress/selectors/pagination.js

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited unit and integration tests

## Testing Performed

1. axe DevTools
2. `yarn test` in ui/apps/platform