### PR TITLE
Add gql client merge function for image metadata field

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageSingleVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageSingleVulnerabilities.tsx
@@ -36,7 +36,6 @@ import WorkloadTableToolbar from './WorkloadTableToolbar';
 import BySeveritySummaryCard from './SummaryCards/BySeveritySummaryCard';
 import CvesByStatusSummaryCard from './SummaryCards/CvesByStatusSummaryCard';
 import SingleEntityVulnerabilitiesTable from './Tables/SingleEntityVulnerabilitiesTable';
-import { ImageDetailsResponse } from './hooks/useImageDetails';
 import useImageVulnerabilities from './hooks/useImageVulnerabilities';
 import { DynamicTableLabel } from './DynamicIcon';
 
@@ -50,10 +49,9 @@ const defaultSortOptions: UseURLSortProps = {
 
 export type ImageSingleVulnerabilitiesProps = {
     imageId: string;
-    imageData: ImageDetailsResponse['image'] | undefined;
 };
 
-function ImageSingleVulnerabilities({ imageId, imageData }: ImageSingleVulnerabilitiesProps) {
+function ImageSingleVulnerabilities({ imageId }: ImageSingleVulnerabilitiesProps) {
     const { searchFilter } = useURLSearch();
     const { page, perPage, setPage, setPerPage } = useURLPagination(50);
     // TODO Need to reset current page at the same time sorting changes
@@ -94,8 +92,6 @@ function ImageSingleVulnerabilities({ imageId, imageData }: ImageSingleVulnerabi
             </Bullseye>
         );
     } else if (vulnerabilityData) {
-        const vulnerabilities = vulnerabilityData.image.imageVulnerabilities;
-
         // TODO Integrate these with page search filters
         const hiddenSeverities = new Set<VulnerabilitySeverity>([]);
         const hiddenStatuses = new Set<FixableStatus>([]);
@@ -149,8 +145,7 @@ function ImageSingleVulnerabilities({ imageId, imageData }: ImageSingleVulnerabi
                         </SplitItem>
                     </Split>
                     <SingleEntityVulnerabilitiesTable
-                        image={imageData}
-                        imageVulnerabilities={vulnerabilities}
+                        image={vulnerabilityData.image}
                         getSortParams={getSortParams}
                         isFiltered={isFiltered}
                     />

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageComponentsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageComponentsTable.tsx
@@ -2,16 +2,14 @@ import React from 'react';
 import { CodeBlock, CodeBlockCode } from '@patternfly/react-core';
 import { TableComposable, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
-import { ImageVulnerabilityComponent } from '../hooks/useImageVulnerabilities';
-import { ImageDetailsResponse } from '../hooks/useImageDetails';
+import { ImageMetadataLayer, ImageVulnerabilityComponent } from '../hooks/useImageVulnerabilities';
 
 export type ImageComponentsTableProps = {
-    image: ImageDetailsResponse['image'] | undefined;
+    layers: ImageMetadataLayer[];
     imageComponents: ImageVulnerabilityComponent[];
 };
 
-function ImageComponentsTable({ image, imageComponents }: ImageComponentsTableProps) {
-    const layers = image?.metadata?.v1?.layers ?? [];
+function ImageComponentsTable({ layers, imageComponents }: ImageComponentsTableProps) {
     return (
         <TableComposable borders={false}>
             <Thead>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/SingleEntityVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/SingleEntityVulnerabilitiesTable.tsx
@@ -21,19 +21,16 @@ import { UseURLSortResult } from 'hooks/useURLSort';
 import { ImageVulnerabilitiesResponse } from '../hooks/useImageVulnerabilities';
 import { getEntityPagePath } from '../searchUtils';
 import ImageComponentsTable from './ImageComponentsTable';
-import { ImageDetailsResponse } from '../hooks/useImageDetails';
 import { DynamicColumnIcon } from '../DynamicIcon';
 
 export type SingleEntityVulnerabilitiesTableProps = {
-    image: ImageDetailsResponse['image'] | undefined;
-    imageVulnerabilities: ImageVulnerabilitiesResponse['image']['imageVulnerabilities'];
+    image: ImageVulnerabilitiesResponse['image'];
     getSortParams: UseURLSortResult['getSortParams'];
     isFiltered: boolean;
 };
 
 function SingleEntityVulnerabilitiesTable({
     image,
-    imageVulnerabilities,
     getSortParams,
     isFiltered,
 }: SingleEntityVulnerabilitiesTableProps) {
@@ -58,7 +55,7 @@ function SingleEntityVulnerabilitiesTable({
                     <Th>First discovered</Th>
                 </Tr>
             </Thead>
-            {imageVulnerabilities.map(
+            {image.imageVulnerabilities.map(
                 (
                     { cve, severity, summary, isFixable, imageComponents, discoveredAtImage },
                     rowIndex
@@ -138,7 +135,7 @@ function SingleEntityVulnerabilitiesTable({
                                             }}
                                         >
                                             <ImageComponentsTable
-                                                image={image}
+                                                layers={image.metadata?.v1?.layers ?? []}
                                                 imageComponents={imageComponents}
                                             />
                                         </div>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesImageSinglePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesImageSinglePage.tsx
@@ -152,7 +152,7 @@ function WorkloadCvesImageSinglePage() {
                             eventKey="Vulnerabilities"
                             title={<TabTitleText>Vulnerabilities</TabTitleText>}
                         >
-                            <ImageSingleVulnerabilities imageId={imageId} imageData={imageData} />
+                            <ImageSingleVulnerabilities imageId={imageId} />
                         </Tab>
                         <Tab
                             className="pf-u-display-flex pf-u-flex-direction-column pf-u-flex-grow-1"

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/hooks/useImageDetails.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/hooks/useImageDetails.ts
@@ -16,13 +16,9 @@ export type ImageDetailsResponse = {
             v1: {
                 created: Date | null;
                 digest: string;
-                layers: {
-                    instruction: string;
-                    value: string;
-                }[];
             } | null;
         } | null;
-        dataSource: { name: string } | null;
+        dataSource: { id: string; name: string } | null;
         scanTime: Date | null;
     };
 };
@@ -40,13 +36,10 @@ export const imageDetailsQuery = gql`
                 v1 {
                     created
                     digest
-                    layers {
-                        instruction
-                        value
-                    }
                 }
             }
             dataSource {
+                id
                 name
             }
             scanTime

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/hooks/useImageVulnerabilities.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/hooks/useImageVulnerabilities.ts
@@ -9,6 +9,11 @@ export type ImageVulnerabilitiesVariables = {
     pagination: Pagination;
 };
 
+export type ImageMetadataLayer = {
+    instruction: string;
+    value: string;
+};
+
 export type ImageVulnerabilityComponent = {
     id: string;
     name: string;
@@ -30,8 +35,14 @@ export type ImageVulnerabilityCounter = Record<
 export type ImageVulnerabilitiesResponse = {
     image: {
         id: string;
+        metadata: {
+            v1: {
+                layers: ImageMetadataLayer[];
+            } | null;
+        } | null;
         imageVulnerabilityCounter: ImageVulnerabilityCounter;
         imageVulnerabilities: {
+            id: string;
             severity: string;
             isFixable: boolean;
             cve: string;
@@ -46,6 +57,14 @@ export const imageVulnerabilitiesQuery = gql`
     query getImageVulnerabilities($id: ID!, $vulnQuery: String!, $pagination: Pagination!) {
         image(id: $id) {
             id
+            metadata {
+                v1 {
+                    layers {
+                        instruction
+                        value
+                    }
+                }
+            }
             imageVulnerabilityCounter(query: $vulnQuery) {
                 all {
                     total
@@ -69,6 +88,7 @@ export const imageVulnerabilitiesQuery = gql`
                 }
             }
             imageVulnerabilities(query: $vulnQuery, pagination: $pagination) {
+                id
                 severity
                 isFixable
                 cve

--- a/ui/apps/platform/src/configureApolloClient.js
+++ b/ui/apps/platform/src/configureApolloClient.js
@@ -1,5 +1,6 @@
 import { ApolloClient, HttpLink, InMemoryCache, defaultDataIdFromObject } from '@apollo/client';
 import { buildAxiosFetch } from '@lifeomic/axios-fetch';
+import merge from 'lodash/merge';
 
 import axios from 'services/instance';
 import possibleTypes from './possibleTypes.json'; // see `scripts/generate-graphql-possible-types.js` file
@@ -44,6 +45,18 @@ export default function configureApolloClient() {
                     return `${object.clusterID}/${object.id}`;
                 }
                 return defaultDataIdFromObject(object);
+            },
+            typePolicies: {
+                Image: {
+                    fields: {
+                        metadata: {
+                            // Recursively merge image->metadata fields. This is required since the
+                            // metadata object does not have a reliable unique ID and subsequent queries to
+                            // the resolver will cause duplicate requests and lost cache data.
+                            merge: (existing, incoming) => merge({}, existing, incoming),
+                        },
+                    },
+                },
             },
         }),
     });


### PR DESCRIPTION
## Description

This reverts a previous change in how the queries were structured and moves the images->metadata->v1->layers part of the resolver back to the `imageVulnerabilities` query that is used for the table data. The original change was put in place to avoid an extra request being sent that was due to part of the graphql cache being overwritten, which fixed the extra request but not the overwritten data.

The problem was due to a handful of things:
- The `ImageMetadata` type does not have a unique id, so it cannot be normalized by Apollo's cache
- Since it can't be normalized, it is embedded directly on the `Image` type when a request returns
- When merging items in the cache, Apollo does not recursively merge them, so every returned value of `image->metadata` was replacing the entire `metadata` object, regardless of what subfields were included. This was causing cache data loss and in some cases extra, redundant queries to fire

The fix:
- Manually define a merge function for the `metadata` field on the `Image` type. This function will do a deep merge on image metadata whenever multiple queries for the subresolver return a subset of the metadata fields.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Manually test workload CVE image page and ensure data loads correctly, only sending the two required requests.
<img width="1676" alt="image" src="https://user-images.githubusercontent.com/1292638/226624179-4e62d411-ab69-4134-97f9-4d553b553bdb.png">

