### PR TITLE
assume cloud provider is not AWS if metadata service unreachable

### DIFF
--- a/pkg/cloudproviders/aws/metadata.go
+++ b/pkg/cloudproviders/aws/metadata.go
@@ -43,7 +43,7 @@ func GetMetadata(ctx context.Context) (*storage.ProviderMetadata, error) {
 		HTTPClient: httpClient,
 	})
 	if !mdClient.Available() {
-		return nil, errors.New("metadata service unavailable")
+		return nil, nil
 	}
 
 	errs := errorhelpers.NewErrorList("retrieving AWS EC2 metadata")


### PR DESCRIPTION
## Description

If we cannot reach the AWS metadata server, we should just assume the cloud provider is not AWS. That is [what we used to do](https://github.com/stackrox/stackrox/commit/2f9cedecd9c31d024f990bed89d63fbc0bc6492e#diff-871049363fb616b0ce9f980b95e7030b5adb464e0341e686460237c0dcd22661R21). #5201 decided to return this as an error, but it should not be an error because it's possible this is not an AWS environment. This PR reverts the returned error.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

Ensure no suspicious logs exist. After #5201, we kept seeing `pkg/providers: 2023/03/18 17:45:39.979396 metadata.go:40: Error: getting cloud provider metadata error: AWS: metadata service unavailable`.
