### PR TITLE
Bump node scan timeouts to 1 minute

### DIFF
--- a/pkg/scanners/clairify/clairify.go
+++ b/pkg/scanners/clairify/clairify.go
@@ -45,7 +45,7 @@ const (
 
 	// nodeScanClientTimeout is used for node scanning operations, it is shorter than
 	// the default because we expect it to have only the database on its path.
-	nodeScanClientTimeout = 10 * time.Second
+	nodeScanClientTimeout = 1 * time.Minute
 
 	defaultMaxConcurrentScans = int64(30)
 )


### PR DESCRIPTION
## Description

When deploying Central to OCP-4.12 and multiple Secured Clusters (OCP 4.8 - 4.11) using Helm without modifying the default resource attribution and with 2 scanner instances, we got Scanner going up to >10s fairly at 1m at p99:

![image](https://user-images.githubusercontent.com/291493/226473857-e5e4b4ae-26a9-49e1-ae89-18cdd63a68f7.png)

I want to accommodate those spikes since we don't currently retry Node Inventory, and customers might need to wait up to 4hs, by default, if a timeout like that occurs.

## Checklist
- [ ] Investigated and inspected CI test results

### N/A

- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

CI.
