### PR TITLE
Jv rox 16074 process listening on ports e2e test to check for closed ports

### DIFF
--- a/qa-tests-backend/src/test/groovy/ProcessesListeningOnPortsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ProcessesListeningOnPortsTest.groovy
@@ -4,7 +4,6 @@ import objects.Deployment
 import objects.K8sServiceAccount
 import objects.Service
 import util.Env
-import util.Helpers
 
 import spock.lang.IgnoreIf
 import spock.lang.Shared
@@ -21,6 +20,7 @@ class ProcessesListeningOnPortsTest extends BaseSpecification {
     // Deployment names
     static final private String TCPCONNECTIONTARGET1 = "tcp-connection-target-1"
     static final private String TCPCONNECTIONTARGET2 = "tcp-connection-target-2"
+    static final private String TCPCONNECTIONTARGET3 = "tcp-connection-target-3"
 
     // Other namespace
     static final private String OTHER_NAMESPACE = "qa2"
@@ -51,6 +51,16 @@ class ProcessesListeningOnPortsTest extends BaseSpecification {
                     .setExposeAsService(true)
                     .setCommand(["/bin/sh", "-c",])
                     .setArgs(["(socat "+SOCAT_DEBUG+" TCP-LISTEN:8081,fork STDOUT)" as String,]),
+            new Deployment()
+                    .setName(TCPCONNECTIONTARGET3)
+                    .setImage("quay.io/rhacs-eng/qa:socat")
+                    .addPort(8082, "TCP")
+                    .addLabel("app", TCPCONNECTIONTARGET3)
+                    .setExposeAsService(true)
+                    .setCommand(["/bin/sh", "-c",])
+                    .setArgs(["(socat "+SOCAT_DEBUG+" TCP-LISTEN:8082,fork STDOUT & " +
+                            "sleep 90 && pkill socat && sleep 3600)" as String,]),
+                    // The 8082 port is opened. 90 seconds later the process is killed. After that we sleep forever
         ]
     }
 
@@ -79,6 +89,7 @@ class ProcessesListeningOnPortsTest extends BaseSpecification {
                 )
         )
 
+        destroyDeployments()
         createDeployments()
     }
 
@@ -99,34 +110,17 @@ class ProcessesListeningOnPortsTest extends BaseSpecification {
         destroyDeployments()
     }
 
-    def rebuildForRetries() {
-        if (Helpers.getAttemptCount() > 1) {
-            log.info ">>>> Recreating test deployments prior to retest <<<<<"
-            destroyDeployments()
-            createDeployments()
-            log.info ">>>> Done <<<<<"
-        }
-    }
-
     @Tag("BAT")
     def "Verify networking endpoints with processes appear in API at the deployment level"() {
         given:
         "Two deployments that listen on ports are started up"
 
-        rebuildForRetries()
+        setupSpec()
 
-        String deploymentId1 = targetDeployments[0].getDeploymentUid()
-        String deploymentId2 = targetDeployments[1].getDeploymentUid()
+        String deploymentId1 = targetDeployments.find { it.name == TCPCONNECTIONTARGET1 }?.deploymentUid
+        String deploymentId2 = targetDeployments.find { it.name == TCPCONNECTIONTARGET2 }?.deploymentUid
 
-        def gotCorrectNumElements = waitForResponseToHaveNumElements(2, deploymentId1, 240)
-
-        assert gotCorrectNumElements
-
-        def processesListeningOnPorts = evaluateWithRetry(10, 10) {
-                def temp = ProcessesListeningOnPortsService
-                        .getProcessesListeningOnPortsResponse(deploymentId1)
-                return temp
-        }
+        def processesListeningOnPorts = waitForResponseToHaveNumElements(2, deploymentId1, 240)
 
         assert processesListeningOnPorts
 
@@ -153,15 +147,7 @@ class ProcessesListeningOnPortsTest extends BaseSpecification {
         assert endpoint2.signal.execFilePath == "/usr/bin/socat"
         assert endpoint2.signal.args == "-d -d -v TCP-LISTEN:8080,fork STDOUT"
 
-        gotCorrectNumElements = waitForResponseToHaveNumElements(1, deploymentId2, 240)
-
-        assert gotCorrectNumElements
-
-        processesListeningOnPorts = evaluateWithRetry(10, 10) {
-                def temp = ProcessesListeningOnPortsService
-                        .getProcessesListeningOnPortsResponse(deploymentId2)
-                return temp
-        }
+        processesListeningOnPorts = waitForResponseToHaveNumElements(1, deploymentId2, 240)
 
         assert processesListeningOnPorts
 
@@ -180,35 +166,98 @@ class ProcessesListeningOnPortsTest extends BaseSpecification {
 
         destroyDeployments()
 
-        gotCorrectNumElements = waitForResponseToHaveNumElements(0, deploymentId1, 240)
-
-        assert gotCorrectNumElements
-
-        processesListeningOnPorts = evaluateWithRetry(10, 10) {
-                def temp = ProcessesListeningOnPortsService
-                        .getProcessesListeningOnPortsResponse(deploymentId1)
-                return temp
-        }
+        processesListeningOnPorts = waitForResponseToHaveNumElements(0, deploymentId1, 240)
 
         assert processesListeningOnPorts
 
         def list2 = processesListeningOnPorts.listeningEndpointsList
         assert list2.size() == 0
 
-        gotCorrectNumElements = waitForResponseToHaveNumElements(0, deploymentId2, 240)
-
-        assert gotCorrectNumElements
-
-        processesListeningOnPorts = evaluateWithRetry(10, 10) {
-                def temp = ProcessesListeningOnPortsService
-                        .getProcessesListeningOnPortsResponse(deploymentId2)
-                return temp
-        }
+        processesListeningOnPorts = waitForResponseToHaveNumElements(0, deploymentId2, 240)
 
         assert processesListeningOnPorts
 
         def list3 = processesListeningOnPorts.listeningEndpointsList
         assert list3.size() == 0
+
+        destroyDeployments()
+    }
+
+    @Tag("BAT")
+    def "Verify networking endpoints disappear when process is terminated"() {
+        given:
+        "When a deployment listening on a port is created and then the process is terminated"
+
+        setupSpec()
+
+        String deploymentId3 = targetDeployments.find { it.name == TCPCONNECTIONTARGET3 }?.deploymentUid
+
+        def processesListeningOnPorts = waitForResponseToHaveNumElements(1, deploymentId3, 240)
+
+        // First check that the listening endpoint appears in the API
+        assert processesListeningOnPorts
+
+        def list = processesListeningOnPorts.listeningEndpointsList
+        assert list.size() == 1
+
+        def endpoint = list.find { it.endpoint.port == 8082 }
+
+        assert endpoint
+        assert endpoint.deploymentId
+        assert endpoint.podId
+        assert endpoint.containerName == TCPCONNECTIONTARGET3
+        assert endpoint.signal.name == "socat"
+        assert endpoint.signal.execFilePath == "/usr/bin/socat"
+        assert endpoint.signal.args == "-d -d -v TCP-LISTEN:8082,fork STDOUT"
+
+        processesListeningOnPorts = waitForResponseToHaveNumElements(0, deploymentId3, 180)
+
+        // Allow enough time for the process and port to close and check that it is not in the API response
+        assert processesListeningOnPorts
+
+        destroyDeployments()
+    }
+
+    @Tag("BAT")
+    def "Verify networking endpoint doesn't disappear when port stays open"() {
+        given:
+        "A deployment listening on a port is brought up and it is checked twice that the port is found"
+
+        setupSpec()
+        def clusterId = ClusterService.getClusterId()
+
+        String deploymentId2 = targetDeployments.find { it.name == TCPCONNECTIONTARGET2 }?.deploymentUid
+
+        def processesListeningOnPorts = waitForResponseToHaveNumElements(1, deploymentId2, 240)
+
+        // First check that the listening endpoint appears in the API
+        assert processesListeningOnPorts
+
+        def list = processesListeningOnPorts.listeningEndpointsList
+        assert list.size() == 1
+
+        def endpoint = list.find { it.endpoint.port == 8081 }
+
+        assert endpoint
+        assert endpoint.deploymentId
+        assert endpoint.podId
+        assert endpoint.containerName == TCPCONNECTIONTARGET2
+        assert endpoint.signal.name == "socat"
+        assert endpoint.signal.execFilePath == "/usr/bin/socat"
+        assert endpoint.signal.args == "-d -d -v TCP-LISTEN:8081,fork STDOUT"
+
+        sleep 65000 // Sleep for 65 seconds
+        processesListeningOnPorts = evaluateWithRetry(10, 10) {
+               def temp = ProcessesListeningOnPortsService
+                       .getProcessesListeningOnPortsResponse(deploymentId2)
+               return temp
+        }
+
+        // Confirm that the listening endpoint still appears in the API 65 seconds later
+        list = processesListeningOnPorts.listeningEndpointsList
+        assert list.size() == 1
+
+        destroyDeployments()
     }
 
     private waitForResponseToHaveNumElements(int numElements,
@@ -216,6 +265,7 @@ class ProcessesListeningOnPortsTest extends BaseSpecification {
 
         int intervalSeconds = 1
         int waitTime
+
         for (waitTime = 0; waitTime <= timeoutSeconds / intervalSeconds; waitTime++) {
             def processesListeningOnPorts = evaluateWithRetry(10, 10) {
                     def temp = ProcessesListeningOnPortsService
@@ -226,11 +276,11 @@ class ProcessesListeningOnPortsTest extends BaseSpecification {
             def list = processesListeningOnPorts.listeningEndpointsList
 
             if (list.size() == numElements) {
-                return true
+                return processesListeningOnPorts
             }
             sleep intervalSeconds * 1000
         }
         log.info "Timedout waiting for response to have {$numElements} elements"
-        return false
+        return null
     }
 }

--- a/qa-tests-backend/src/test/groovy/ProcessesListeningOnPortsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ProcessesListeningOnPortsTest.groovy
@@ -223,7 +223,6 @@ class ProcessesListeningOnPortsTest extends BaseSpecification {
         "A deployment listening on a port is brought up and it is checked twice that the port is found"
 
         setupSpec()
-        def clusterId = ClusterService.getClusterId()
 
         String deploymentId2 = targetDeployments.find { it.name == TCPCONNECTIONTARGET2 }?.deploymentUid
 

--- a/qa-tests-backend/src/test/groovy/ProcessesListeningOnPortsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ProcessesListeningOnPortsTest.groovy
@@ -13,8 +13,7 @@ import spock.lang.Stepwise
 import services.ProcessesListeningOnPortsService
 
 @Stepwise
-// TODO: Solve the flake and change back to @IgnoreIf({ !Env.get("ROX_POSTGRES_DATASTORE", null) })
-@IgnoreIf({ Env.get("RUN_PROCESS_LISTENING_ON_PORTS_E2E_TESTS", "false") == "false" })
+@IgnoreIf({ !Env.get("ROX_POSTGRES_DATASTORE", null) })
 class ProcessesListeningOnPortsTest extends BaseSpecification {
 
     // Deployment names

--- a/sensor/common/networkflow/manager/manager_impl.go
+++ b/sensor/common/networkflow/manager/manager_impl.go
@@ -39,6 +39,8 @@ var (
 	// these are "canonical" external addresses sent by collector when we don't care about the precise IP address.
 	externalIPv4Addr = net.ParseIP("255.255.255.255")
 	externalIPv6Addr = net.ParseIP("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff")
+
+	emptyProcessInfo = processInfo{}
 )
 
 type hostConnections struct {
@@ -60,7 +62,13 @@ type hostConnections struct {
 type connStatus struct {
 	firstSeen timestamp.MicroTS
 	lastSeen  timestamp.MicroTS
-	used      bool
+	// used keeps track of if an endpoint has been used by the the networkgraph path.
+	// usedProcess keeps track of if an endpoint has been used by the processes listening on
+	// ports path. If processes listening on ports is used, both must be true to delete the
+	// endpoint. Otherwise the endpoint will not be available to process listening on ports
+	// and it won't report endpoints that it doesn't have access to.
+	used        bool
+	usedProcess bool
 	// rotten implies we expected to correlate the flow with a container, but were unable to
 	rotten bool
 }
@@ -122,7 +130,7 @@ type processListeningIndicator struct {
 	protocol storage.L4Protocol
 }
 
-func (i *processListeningIndicator) toProto(_ timestamp.MicroTS) *storage.ProcessListeningOnPortFromSensor {
+func (i *processListeningIndicator) toProto(ts timestamp.MicroTS) *storage.ProcessListeningOnPortFromSensor {
 	proto := &storage.ProcessListeningOnPortFromSensor{
 		Port:     uint32(i.port),
 		Protocol: i.protocol,
@@ -134,6 +142,10 @@ func (i *processListeningIndicator) toProto(_ timestamp.MicroTS) *storage.Proces
 			ProcessArgs:         i.key.process.processArgs,
 		},
 		DeploymentId: i.key.deploymentID,
+	}
+
+	if ts != timestamp.InfiniteFuture {
+		proto.CloseTimestamp = ts.GogoProtobuf()
 	}
 
 	return proto
@@ -170,7 +182,7 @@ func (p *processInfo) String() string {
 type containerEndpoint struct {
 	endpoint    net.NumericEndpoint
 	containerID string
-	processKey  *processInfo
+	processKey  processInfo
 }
 
 func (e *containerEndpoint) String() string {
@@ -463,7 +475,7 @@ func (m *networkFlowManager) enrichProcessListening(ep *containerEndpoint, statu
 	timeElapsedSinceFirstSeen := timestamp.Now().ElapsedSince(status.firstSeen)
 	isFresh := timeElapsedSinceFirstSeen < clusterEntityResolutionWaitPeriod
 	if !isFresh {
-		status.used = true
+		status.usedProcess = true
 	}
 
 	container, ok := m.clusterEntities.LookupByContainerID(ep.containerID)
@@ -478,24 +490,20 @@ func (m *networkFlowManager) enrichProcessListening(ep *containerEndpoint, statu
 		return
 	}
 
-	status.used = true
+	status.usedProcess = true
 
 	indicator := processListeningIndicator{
 		key: processUniqueKey{
 			podID:         container.PodID,
 			containerName: container.ContainerName,
 			deploymentID:  container.DeploymentID,
-			process:       *ep.processKey,
+			process:       ep.processKey,
 		},
 		port:     ep.endpoint.IPAndPort.Port,
 		protocol: ep.endpoint.L4Proto.ToProtobuf(),
 	}
 
-	// Multiple endpoints from a collector can result in a single enriched endpoint,
-	// hence update the timestamp only if we have a more recent endpoint than the one we have already enriched.
-	if oldTS, found := processesListening[indicator]; !found || oldTS < status.lastSeen {
-		processesListening[indicator] = status.lastSeen
-	}
+	processesListening[indicator] = status.lastSeen
 }
 
 func (m *networkFlowManager) enrichHostConnections(hostConns *hostConnections, enrichedConnections map[networkConnIndicator]timestamp.MicroTS) {
@@ -520,7 +528,9 @@ func (m *networkFlowManager) enrichHostContainerEndpoints(hostConns *hostConnect
 	prevSize := len(hostConns.endpoints)
 	for ep, status := range hostConns.endpoints {
 		m.enrichContainerEndpoint(&ep, status, enrichedEndpoints)
-		if status.used && status.lastSeen != timestamp.InfiniteFuture {
+		// If processes listening on ports is enabled, it has to be used there as well before being deleted.
+		used := status.used && (status.usedProcess || !features.ProcessesListeningOnPort.Enabled())
+		if used && status.lastSeen != timestamp.InfiniteFuture {
 			// endpoints that are no longer active and have already been used can be deleted.
 			delete(hostConns.endpoints, ep)
 		}
@@ -534,14 +544,15 @@ func (m *networkFlowManager) enrichProcessesListening(hostConns *hostConnections
 
 	prevSize := len(hostConns.endpoints)
 	for ep, status := range hostConns.endpoints {
-		if ep.processKey == nil {
+		if ep.processKey == emptyProcessInfo {
 			// No way to update a process if the data isn't there
 			continue
 		}
 
 		m.enrichProcessListening(&ep, status, processesListening)
-		if status.used && status.lastSeen != timestamp.InfiniteFuture {
+		if status.used && status.usedProcess && status.lastSeen != timestamp.InfiniteFuture {
 			// endpoints that are no longer active and have already been used can be deleted.
+			// Before deleting it must be used here and in enrichContainerEndpoints.
 			delete(hostConns.endpoints, ep)
 		}
 	}
@@ -615,13 +626,18 @@ func computeUpdatedProcesses(current map[processListeningIndicator]timestamp.Mic
 
 	for pl, currTS := range current {
 		prevTS, ok := previous[pl]
-		if !ok || currTS > prevTS {
+		if !ok || currTS > prevTS || (prevTS == timestamp.InfiniteFuture && currTS != timestamp.InfiniteFuture) {
 			updates = append(updates, pl.toProto(currTS))
 		}
 	}
 
 	for ep, prevTS := range previous {
 		if _, ok := current[ep]; !ok {
+			// This condition means the deployment was removed before we got the
+			// close timestamp for the endpoint. Use the current timestamp instead.
+			if prevTS == timestamp.InfiniteFuture {
+				prevTS = timestamp.Now()
+			}
 			updates = append(updates, ep.toProto(prevTS))
 		}
 	}
@@ -795,12 +811,12 @@ func (h *hostConnections) Process(networkInfo *sensor.NetworkConnectionInfo, now
 	return nil
 }
 
-func getProcessKey(originator *storage.NetworkProcessUniqueKey) *processInfo {
+func getProcessKey(originator *storage.NetworkProcessUniqueKey) processInfo {
 	if originator == nil {
-		return nil
+		return processInfo{}
 	}
 
-	return &processInfo{
+	return processInfo{
 		processName: originator.ProcessName,
 		processArgs: originator.ProcessArgs,
 		processExec: originator.ProcessExecFilePath,

--- a/sensor/common/networkflow/manager/manager_impl_test.go
+++ b/sensor/common/networkflow/manager/manager_impl_test.go
@@ -1,0 +1,185 @@
+package manager
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stackrox/rox/generated/internalapi/sensor"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/protoconv"
+	"github.com/stackrox/rox/pkg/timestamp"
+	"github.com/stretchr/testify/suite"
+)
+
+var (
+	openNetworkEndpoint = &sensor.NetworkEndpoint{
+		SocketFamily: sensor.SocketFamily_SOCKET_FAMILY_IPV4,
+		Protocol:     storage.L4Protocol_L4_PROTOCOL_TCP,
+		ContainerId:  "FakeContainerId",
+		ListenAddress: &sensor.NetworkAddress{
+			Port: 80,
+		},
+		Originator: &storage.NetworkProcessUniqueKey{
+			ProcessName:         "socat",
+			ProcessExecFilePath: "/usr/bin/socat",
+			ProcessArgs:         "port: 80",
+		},
+	}
+	openNetworkEndpoint81 = &sensor.NetworkEndpoint{
+		SocketFamily: sensor.SocketFamily_SOCKET_FAMILY_IPV4,
+		Protocol:     storage.L4Protocol_L4_PROTOCOL_TCP,
+		ContainerId:  "FakeContainerId",
+		ListenAddress: &sensor.NetworkAddress{
+			Port: 81,
+		},
+		Originator: &storage.NetworkProcessUniqueKey{
+			ProcessName:         "socat",
+			ProcessExecFilePath: "/usr/bin/socat",
+			ProcessArgs:         "port: 81",
+		},
+	}
+	openNetworkEndpointNoOriginator = &sensor.NetworkEndpoint{
+		SocketFamily: sensor.SocketFamily_SOCKET_FAMILY_IPV4,
+		Protocol:     storage.L4Protocol_L4_PROTOCOL_TCP,
+		ContainerId:  "FakeContainerId",
+		ListenAddress: &sensor.NetworkAddress{
+			Port: 80,
+		},
+	}
+	closedNetworkEndpoint = &sensor.NetworkEndpoint{
+		SocketFamily:   sensor.SocketFamily_SOCKET_FAMILY_IPV4,
+		Protocol:       storage.L4Protocol_L4_PROTOCOL_TCP,
+		ContainerId:    "FakeContainerId",
+		CloseTimestamp: protoconv.ConvertTimeToTimestamp(time.Now()),
+		ListenAddress: &sensor.NetworkAddress{
+			Port: 80,
+		},
+		Originator: &storage.NetworkProcessUniqueKey{
+			ProcessName:         "socat",
+			ProcessExecFilePath: "/usr/bin/socat",
+			ProcessArgs:         "port: 80",
+		},
+	}
+)
+
+func TestNetworkflowManager(t *testing.T) {
+	suite.Run(t, new(NetworkflowManagerTestSuite))
+}
+
+type NetworkflowManagerTestSuite struct {
+	suite.Suite
+}
+
+func (suite *NetworkflowManagerTestSuite) TestAddNothing() {
+	h := hostConnections{}
+	h.endpoints = make(map[containerEndpoint]*connStatus)
+
+	networkInfo := &sensor.NetworkConnectionInfo{}
+	nowTimestamp := timestamp.Now()
+	var sequenceID int64
+	err := h.Process(networkInfo, nowTimestamp, sequenceID)
+	suite.NoError(err)
+	suite.Len(h.endpoints, 0)
+}
+
+func (suite *NetworkflowManagerTestSuite) TestAddOpen() {
+	h := hostConnections{}
+	h.endpoints = make(map[containerEndpoint]*connStatus)
+
+	networkInfo := &sensor.NetworkConnectionInfo{
+		UpdatedEndpoints: []*sensor.NetworkEndpoint{openNetworkEndpoint},
+	}
+
+	nowTimestamp := timestamp.Now()
+	var sequenceID int64
+	h.connectionsSequenceID = sequenceID
+	err := h.Process(networkInfo, nowTimestamp, sequenceID)
+	suite.NoError(err)
+	suite.Len(h.endpoints, 1)
+}
+
+func (suite *NetworkflowManagerTestSuite) TestAddOpenAndClosed() {
+	h := hostConnections{}
+	h.endpoints = make(map[containerEndpoint]*connStatus)
+
+	networkInfoOpen := &sensor.NetworkConnectionInfo{
+		UpdatedEndpoints: []*sensor.NetworkEndpoint{openNetworkEndpoint},
+	}
+
+	networkInfoClosed := &sensor.NetworkConnectionInfo{
+		UpdatedEndpoints: []*sensor.NetworkEndpoint{closedNetworkEndpoint},
+	}
+
+	nowTimestamp := timestamp.Now()
+	var sequenceID int64
+	h.connectionsSequenceID = sequenceID
+
+	err := h.Process(networkInfoOpen, nowTimestamp, sequenceID)
+	suite.NoError(err)
+
+	err = h.Process(networkInfoClosed, nowTimestamp, sequenceID)
+	suite.NoError(err)
+
+	suite.Len(h.endpoints, 1)
+}
+
+func (suite *NetworkflowManagerTestSuite) TestAddTwoDifferent() {
+	h := hostConnections{}
+	h.endpoints = make(map[containerEndpoint]*connStatus)
+
+	networkInfoOpen := &sensor.NetworkConnectionInfo{
+		UpdatedEndpoints: []*sensor.NetworkEndpoint{openNetworkEndpoint},
+	}
+
+	networkInfoOpen81 := &sensor.NetworkConnectionInfo{
+		UpdatedEndpoints: []*sensor.NetworkEndpoint{openNetworkEndpoint81},
+	}
+
+	nowTimestamp := timestamp.Now()
+	var sequenceID int64
+	h.connectionsSequenceID = sequenceID
+
+	err := h.Process(networkInfoOpen, nowTimestamp, sequenceID)
+	suite.NoError(err)
+
+	err = h.Process(networkInfoOpen81, nowTimestamp, sequenceID)
+	suite.NoError(err)
+
+	suite.Len(h.endpoints, 2)
+}
+
+func (suite *NetworkflowManagerTestSuite) TestAddTwoDifferentSameBatch() {
+	h := hostConnections{}
+	h.endpoints = make(map[containerEndpoint]*connStatus)
+
+	networkInfoOpen := &sensor.NetworkConnectionInfo{
+		UpdatedEndpoints: []*sensor.NetworkEndpoint{openNetworkEndpoint, openNetworkEndpoint81},
+	}
+
+	nowTimestamp := timestamp.Now()
+	var sequenceID int64
+	h.connectionsSequenceID = sequenceID
+
+	err := h.Process(networkInfoOpen, nowTimestamp, sequenceID)
+	suite.NoError(err)
+
+	suite.Len(h.endpoints, 2)
+}
+
+func (suite *NetworkflowManagerTestSuite) TestAddNoOriginator() {
+	h := hostConnections{}
+	h.endpoints = make(map[containerEndpoint]*connStatus)
+
+	networkInfoOpen := &sensor.NetworkConnectionInfo{
+		UpdatedEndpoints: []*sensor.NetworkEndpoint{openNetworkEndpointNoOriginator},
+	}
+
+	nowTimestamp := timestamp.Now()
+	var sequenceID int64
+	h.connectionsSequenceID = sequenceID
+
+	err := h.Process(networkInfoOpen, nowTimestamp, sequenceID)
+	suite.NoError(err)
+
+	suite.Len(h.endpoints, 1)
+}


### PR DESCRIPTION
## Description

An e2e test where a processes which is listening on a port is killed and there is an assert to check that the listening endpoint no longer appears in the API. Also adds unit tests. These tests revealed some bugs which were fixed by https://github.com/stackrox/stackrox/pull/5358

The above PR was merged into this one.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Ran e2e test locally (Failed as expected)
- [x] Ran unit tests (Failed as expected)

## Testing Performed

### Prerequisites

Deploy stackrox locally or connect to a cluster running stackrox

### Steps

```
cd qa-tests-backend
export ROX_POSTGRES_DATASTORE=true
```

That directory should have a file, qa-test-settings.properties with the following contents

```
export REGISTRY_USERNAME=*********@redhat.com
export REGISTRY_PASSWORD="*******************"
```

If this the first time you are running the tests or you made some changes to the tests or generated files you might or might not need to run the following

```
./scripts/migrate_protos.sh
make clean-generated-srcs
make proto-generated-srcs
```

The test is itself run with the following command

```
./gradlew test --tests=ProcessesListeningOnPortsTest
```

You will also need to either comment out 

```
@IgnoreIf({ Env.get("RUN_PROCESS_LISTENING_ON_PORTS_E2E_TESTS", "false") == "false" })
```

in qa-tests-backend/src/test/groovy/ProcessesListeningOnPortsTest.groovy or set 

```
export=RUN_PROCESS_LISTENING_ON_PORTS_E2E_TESTS =true
```

You may also want to comment out the first test so that you can just test the last two. You may also want to disable retries by commenting out 

```
@Retry(condition = { Helpers.determineRetry(failure) })
```

in qa-tests-backend/src/test/groovy/BaseSpecification.groovy

