### PR TITLE
Dashrews/ROX-16098 get pool propagate error

### DIFF
--- a/central/centralhealth/service/service_impl.go
+++ b/central/centralhealth/service/service_impl.go
@@ -92,11 +92,9 @@ func (s *serviceImpl) GetUpgradeStatus(ctx context.Context, empty *v1.Empty) (*v
 				// Get a short-lived connection for the purposes of checking the version of the previous clone.
 				pool, err := pgadmin.GetClonePool(adminConfig, migrations.GetPreviousClone())
 				if err != nil {
-					log.Infof("Unable to get previous database, leaving ForceRollbackTo empty.  %v", err)
+					return nil, errors.Wrapf(err, "Failed to retrieve previous database version.  %v", err)
 				}
-				if pool != nil {
-					defer pool.Close()
-				}
+				defer pool.Close()
 
 				// Get rollback to version
 				migVer, err := versionUtils.ReadVersionPostgres(pool)

--- a/central/centralhealth/service/service_impl.go
+++ b/central/centralhealth/service/service_impl.go
@@ -91,9 +91,11 @@ func (s *serviceImpl) GetUpgradeStatus(ctx context.Context, empty *v1.Empty) (*v
 
 				// Get a short-lived connection for the purposes of checking the version of the previous clone.
 				pool, err := pgadmin.GetClonePool(adminConfig, migrations.GetPreviousClone())
-				defer pool.Close()
 				if err != nil {
 					log.Infof("Unable to get previous database, leaving ForceRollbackTo empty.  %v", err)
+				}
+				if pool != nil {
+					defer pool.Close()
 				}
 
 				// Get rollback to version

--- a/central/centralhealth/service/service_impl.go
+++ b/central/centralhealth/service/service_impl.go
@@ -92,7 +92,7 @@ func (s *serviceImpl) GetUpgradeStatus(ctx context.Context, empty *v1.Empty) (*v
 				// Get a short-lived connection for the purposes of checking the version of the previous clone.
 				pool, err := pgadmin.GetClonePool(adminConfig, migrations.GetPreviousClone())
 				if err != nil {
-					return nil, errors.Wrapf(err, "Failed to retrieve previous database version.  %v", err)
+					return nil, errors.Wrap(err, "Failed to retrieve previous database version.")
 				}
 				defer pool.Close()
 

--- a/central/globaldb/postgres.go
+++ b/central/globaldb/postgres.go
@@ -201,9 +201,13 @@ func CollectPostgresStats(ctx context.Context, db *postgres.DB) *stats.DatabaseS
 
 // CollectPostgresDatabaseSizes -- collect database sizing stats for Postgres
 func CollectPostgresDatabaseSizes(postgresConfig *postgres.Config) []*stats.DatabaseDetailsStats {
-	databases := pgadmin.GetAllDatabases(postgresConfig)
-
 	detailsSlice := make([]*stats.DatabaseDetailsStats, 0)
+
+	databases, err := pgadmin.GetAllDatabases(postgresConfig)
+	if err != nil {
+		log.Errorf("unable to get the databases: %v", err)
+		return detailsSlice
+	}
 
 	for _, database := range databases {
 		dbSize, err := pgadmin.GetDatabaseSize(postgresConfig, database)

--- a/central/globaldb/v2backuprestore/restore/postgres.go
+++ b/central/globaldb/v2backuprestore/restore/postgres.go
@@ -84,11 +84,6 @@ func runRestoreStream(fileReader io.Reader, sourceMap map[string]string, config 
 	return nil
 }
 
-// CheckIfRestoreDBExists - checks to see if a restore database exists
-func CheckIfRestoreDBExists(dbConfig *postgres.Config) bool {
-	return pgadmin.CheckIfDBExists(dbConfig, getRestoreDBName())
-}
-
 func getRestoreDBName() string {
 	// Build the active database name for the connection
 	return fmt.Sprintf("%s%s", config.GetConfig().CentralDB.DatabaseName, restoreSuffix)

--- a/migrator/clone/mock_central.go
+++ b/migrator/clone/mock_central.go
@@ -420,9 +420,9 @@ func (m *mockCentral) runMigratorWithBreaksInPersist(breakpoint string) {
 
 		// Connect to different database for admin functions
 		connectPool, err := pgadmin.GetAdminPool(m.adminConfig)
+		assert.NoError(m.t, err)
 		// Close the admin connection pool
 		defer connectPool.Close()
-		assert.NoError(m.t, err)
 
 		log.Infof("runMigratorWithBreaksInPersist, prev = %s", prev)
 		pgtest.DropDatabase(m.t, prev)

--- a/migrator/clone/postgres/db_clone_manager_impl.go
+++ b/migrator/clone/postgres/db_clone_manager_impl.go
@@ -189,6 +189,9 @@ func (d *dbCloneManagerImpl) GetCloneToMigrate(rocksVersion *migrations.Migratio
 			exists, err := d.databaseExists(TempClone)
 			if err != nil {
 				log.Errorf("Unable to create temp clone, will use current clone: %v", err)
+				// If we had an issue checking whether "temp" exists we will proceed with the CurrentClone.
+				// Essentially we treat this the same as if we could not create "temp" and proceed with
+				// the migration.
 				return CurrentClone, false, nil
 			}
 			if !exists {

--- a/migrator/clone/postgres/db_clone_manager_impl.go
+++ b/migrator/clone/postgres/db_clone_manager_impl.go
@@ -41,7 +41,10 @@ func New(forceVersion string, adminConfig *postgres.Config, sourceMap map[string
 // Scan - checks the persistent data of central and gather the clone information
 // from disk.
 func (d *dbCloneManagerImpl) Scan() error {
-	clones := pgadmin.GetDatabaseClones(d.adminConfig)
+	clones, err := pgadmin.GetDatabaseClones(d.adminConfig)
+	if err != nil {
+		return err
+	}
 	ctx := sac.WithAllAccess(context.Background())
 
 	// We use clones to collect all db clones (directory starting with db- or .restore-) matching upgrade or restore pattern.
@@ -134,7 +137,7 @@ func (d *dbCloneManagerImpl) contains(clone string) bool {
 	return ok
 }
 
-func (d *dbCloneManagerImpl) databaseExists(clone string) bool {
+func (d *dbCloneManagerImpl) databaseExists(clone string) (bool, error) {
 	return pgadmin.CheckIfDBExists(d.adminConfig, clone)
 }
 
@@ -183,7 +186,12 @@ func (d *dbCloneManagerImpl) GetCloneToMigrate(rocksVersion *migrations.Migratio
 		if d.hasSpaceForRollback() {
 			// Create a temp clone for processing of current
 			// If such a clone already exists then we were previously in the middle of processing
-			if !d.databaseExists(TempClone) {
+			exists, err := d.databaseExists(TempClone)
+			if err != nil {
+				log.Errorf("Unable to create temp clone, will use current clone: %v", err)
+				return CurrentClone, false, nil
+			}
+			if !exists {
 				err := pgadmin.CreateDB(d.sourceMap, d.adminConfig, CurrentClone, TempClone)
 
 				// If for some reason, we cannot create a temp clone we will need to continue to upgrade
@@ -289,9 +297,12 @@ func (d *dbCloneManagerImpl) doPersist(cloneName string, prev string) error {
 
 func (d *dbCloneManagerImpl) moveClones(previousClone, updatedClone string) error {
 	// Connect to different database for admin functions
-	connectPool := pgadmin.GetAdminPool(d.adminConfig)
+	connectPool, err := pgadmin.GetAdminPool(d.adminConfig)
 	// Close the admin connection pool
 	defer connectPool.Close()
+	if err != nil {
+		return err
+	}
 
 	// Wrap in a transaction so either both renames work or none work
 	ctx, cancel := context.WithTimeout(context.Background(), pgadmin.PostgresQueryTimeout)
@@ -309,7 +320,11 @@ func (d *dbCloneManagerImpl) moveClones(previousClone, updatedClone string) erro
 	}
 
 	// Move the current to the previous clone if it exists
-	if d.databaseExists(CurrentClone) {
+	exists, err := d.databaseExists(CurrentClone)
+	if err != nil {
+		return err
+	}
+	if exists {
 		err = d.renameClone(ctx, tx, CurrentClone, previousClone)
 		if err != nil {
 			return err

--- a/migrator/clone/postgres/db_clone_manager_impl.go
+++ b/migrator/clone/postgres/db_clone_manager_impl.go
@@ -298,11 +298,11 @@ func (d *dbCloneManagerImpl) doPersist(cloneName string, prev string) error {
 func (d *dbCloneManagerImpl) moveClones(previousClone, updatedClone string) error {
 	// Connect to different database for admin functions
 	connectPool, err := pgadmin.GetAdminPool(d.adminConfig)
-	// Close the admin connection pool
-	defer connectPool.Close()
 	if err != nil {
 		return err
 	}
+	// Close the admin connection pool
+	defer connectPool.Close()
 
 	// Wrap in a transaction so either both renames work or none work
 	ctx, cancel := context.WithTimeout(context.Background(), pgadmin.PostgresQueryTimeout)

--- a/pkg/postgres/pgadmin/admin_utils.go
+++ b/pkg/postgres/pgadmin/admin_utils.go
@@ -295,11 +295,11 @@ func getAvailablePostgresCapacity(postgresConfig *postgres.Config) (int64, error
 
 	// Connect to database for admin functions
 	connectPool, err := GetAdminPool(postgresConfig)
-	// Close the admin connection pool
-	defer connectPool.Close()
 	if err != nil {
 		return pgconfig.GetPostgresCapacity(), nil
 	}
+	// Close the admin connection pool
+	defer connectPool.Close()
 
 	// Wrap in a transaction
 	ctx, cancel := context.WithTimeout(context.Background(), PostgresQueryTimeout)
@@ -404,11 +404,11 @@ func GetRemainingCapacity(postgresConfig *postgres.Config) (int64, error) {
 
 	// Connect to database for admin functions
 	connectPool, err := GetAdminPool(postgresConfig)
-	// Close the admin connection pool
-	defer connectPool.Close()
 	if err != nil {
 		return pgconfig.GetPostgresCapacity(), nil
 	}
+	// Close the admin connection pool
+	defer connectPool.Close()
 
 	sizeUsed, err := GetTotalPostgresSize(postgresConfig)
 	if err != nil {
@@ -433,11 +433,11 @@ func GetDatabaseSize(postgresConfig *postgres.Config, dbName string) (int64, err
 
 	// Connect to different database for admin functions
 	connectPool, err := GetAdminPool(postgresConfig)
-	// Close the admin connection pool
-	defer connectPool.Close()
 	if err != nil {
 		return 0, err
 	}
+	// Close the admin connection pool
+	defer connectPool.Close()
 
 	// Create a context with a timeout
 	ctx, cancel := context.WithTimeout(context.Background(), PostgresQueryTimeout)
@@ -460,7 +460,7 @@ func GetTotalPostgresSize(postgresConfig *postgres.Config) (int64, error) {
 	// Close the admin connection pool
 	defer connectPool.Close()
 	if err != nil {
-
+		return 0, err
 	}
 
 	// Create a context with a timeout

--- a/pkg/postgres/pgadmin/admin_utils.go
+++ b/pkg/postgres/pgadmin/admin_utils.go
@@ -457,11 +457,11 @@ func GetDatabaseSize(postgresConfig *postgres.Config, dbName string) (int64, err
 func GetTotalPostgresSize(postgresConfig *postgres.Config) (int64, error) {
 	// Connect to database for admin functions
 	connectPool, err := GetAdminPool(postgresConfig)
-	// Close the admin connection pool
-	defer connectPool.Close()
 	if err != nil {
 		return 0, err
 	}
+	// Close the admin connection pool
+	defer connectPool.Close()
 
 	// Create a context with a timeout
 	ctx, cancel := context.WithTimeout(context.Background(), PostgresQueryTimeout)
@@ -481,11 +481,11 @@ func GetTotalPostgresSize(postgresConfig *postgres.Config) (int64, error) {
 func GetAllDatabases(postgresConfig *postgres.Config) ([]string, error) {
 	// Connect to different database for admin functions
 	connectPool, err := GetAdminPool(postgresConfig)
-	// Close the admin connection pool
-	defer connectPool.Close()
 	if err != nil {
 		return nil, err
 	}
+	// Close the admin connection pool
+	defer connectPool.Close()
 
 	ctx, cancel := context.WithTimeout(context.Background(), PostgresQueryTimeout)
 	defer cancel()

--- a/pkg/postgres/pgadmin/admin_utils.go
+++ b/pkg/postgres/pgadmin/admin_utils.go
@@ -296,7 +296,7 @@ func getAvailablePostgresCapacity(postgresConfig *postgres.Config) (int64, error
 	// Connect to database for admin functions
 	connectPool, err := GetAdminPool(postgresConfig)
 	if err != nil {
-		return pgconfig.GetPostgresCapacity(), nil
+		return 0, err
 	}
 	// Close the admin connection pool
 	defer connectPool.Close()
@@ -401,14 +401,6 @@ func GetRemainingCapacity(postgresConfig *postgres.Config) (int64, error) {
 		// Cannot get managed services capacity via Postgres.  Assume size for now.
 		return pgconfig.GetPostgresCapacity(), nil
 	}
-
-	// Connect to database for admin functions
-	connectPool, err := GetAdminPool(postgresConfig)
-	if err != nil {
-		return pgconfig.GetPostgresCapacity(), nil
-	}
-	// Close the admin connection pool
-	defer connectPool.Close()
 
 	sizeUsed, err := GetTotalPostgresSize(postgresConfig)
 	if err != nil {

--- a/pkg/postgres/pgadmin/admin_utils.go
+++ b/pkg/postgres/pgadmin/admin_utils.go
@@ -125,11 +125,14 @@ func RenameDB(adminPool *postgres.DB, originalDB, newDB string) error {
 }
 
 // CheckIfDBExists - checks to see if a restore database exists
-func CheckIfDBExists(postgresConfig *postgres.Config, dbName string) bool {
+func CheckIfDBExists(postgresConfig *postgres.Config, dbName string) (bool, error) {
 	log.Debugf("CheckIfDBExists - %q", dbName)
 
 	// Connect to different database for admin functions
-	connectPool := GetAdminPool(postgresConfig)
+	connectPool, err := GetAdminPool(postgresConfig)
+	if err != nil {
+		return false, err
+	}
 	// Close the admin connection pool
 	defer connectPool.Close()
 
@@ -142,19 +145,22 @@ func CheckIfDBExists(postgresConfig *postgres.Config, dbName string) bool {
 	row := connectPool.QueryRow(ctx, existsStmt, dbName)
 	var exists bool
 	if err := row.Scan(&exists); err != nil {
-		return false
+		return false, err
 	}
 
 	log.Debugf("%q database exists => %t", dbName, exists)
-	return exists
+	return exists, nil
 }
 
 // GetDatabaseClones - returns list of database clones based off base database
-func GetDatabaseClones(postgresConfig *postgres.Config) []string {
+func GetDatabaseClones(postgresConfig *postgres.Config) ([]string, error) {
 	log.Debug("GetDatabaseClones")
 
 	// Connect to different database for admin functions
-	connectPool := GetAdminPool(postgresConfig)
+	connectPool, err := GetAdminPool(postgresConfig)
+	if err != nil {
+		return nil, err
+	}
 	// Close the admin connection pool
 	defer connectPool.Close()
 
@@ -165,7 +171,7 @@ func GetDatabaseClones(postgresConfig *postgres.Config) []string {
 
 	rows, err := connectPool.Query(ctx, cloneStmt)
 	if err != nil {
-		return nil
+		return nil, err
 	}
 	defer rows.Close()
 
@@ -173,7 +179,7 @@ func GetDatabaseClones(postgresConfig *postgres.Config) []string {
 	for rows.Next() {
 		var cloneName string
 		if err := rows.Scan(&cloneName); err != nil {
-			return nil
+			return nil, err
 		}
 
 		clones = append(clones, cloneName)
@@ -181,7 +187,7 @@ func GetDatabaseClones(postgresConfig *postgres.Config) []string {
 
 	log.Debugf("database clones => %s", clones)
 
-	return clones
+	return clones, nil
 }
 
 // AnalyzeDatabase - runs ANALYZE on the database named dbName
@@ -189,13 +195,16 @@ func AnalyzeDatabase(config *postgres.Config, dbName string) error {
 	log.Debugf("Analyze - %q", dbName)
 
 	// Connect to different database for admin functions
-	connectPool := GetClonePool(config, dbName)
+	connectPool, err := GetClonePool(config, dbName)
+	if err != nil {
+		return err
+	}
 	// Close the admin connection pool
 	defer connectPool.Close()
 
 	ctx, cancel := context.WithTimeout(context.Background(), analyzeTimeout)
 	defer cancel()
-	_, err := connectPool.Exec(ctx, "ANALYZE")
+	_, err = connectPool.Exec(ctx, "ANALYZE")
 
 	log.Debug("Analyze done")
 	return err
@@ -206,11 +215,14 @@ func TerminateConnection(config *postgres.Config, dbName string) error {
 	log.Debugf("TerminateConnection - %q", dbName)
 
 	// Connect to different database for admin functions
-	connectPool := GetAdminPool(config)
+	connectPool, err := GetAdminPool(config)
+	if err != nil {
+		return err
+	}
 	// Close the admin connection pool
 	defer connectPool.Close()
 
-	_, err := connectPool.Exec(context.Background(), terminateConnectionStmt, dbName)
+	_, err = connectPool.Exec(context.Background(), terminateConnectionStmt, dbName)
 
 	log.Debug("TerminateConnection done")
 	return err
@@ -219,22 +231,25 @@ func TerminateConnection(config *postgres.Config, dbName string) error {
 // GetAdminPool - returns a pool to connect to the admin database.
 // This is useful for renaming databases such as a restore to active.
 // THIS POOL SHOULD BE CLOSED ONCE ITS PURPOSE HAS BEEN FULFILLED.
-func GetAdminPool(postgresConfig *postgres.Config) *postgres.DB {
+func GetAdminPool(postgresConfig *postgres.Config) (*postgres.DB, error) {
 	// Clone config to connect to template DB
 	tempConfig := postgresConfig.Copy()
 
 	// Need to connect on a static DB so we can rename the used DBs.
 	tempConfig.ConnConfig.Database = AdminDB
 
-	postgresDB := getPool(tempConfig)
+	postgresDB, err := getPool(tempConfig)
+	if err != nil {
+		return nil, err
+	}
 
 	log.Debugf("Got connection pool for database %q", AdminDB)
-	return postgresDB
+	return postgresDB, nil
 }
 
 // GetClonePool - returns a connection pool for the specified database clone.
 // THIS POOL SHOULD BE CLOSED ONCE ITS PURPOSE HAS BEEN FULFILLED.
-func GetClonePool(postgresConfig *postgres.Config, clone string) *postgres.DB {
+func GetClonePool(postgresConfig *postgres.Config, clone string) (*postgres.DB, error) {
 	log.Debugf("GetClonePool -- %q", clone)
 
 	// Clone config to connect to template DB
@@ -243,14 +258,17 @@ func GetClonePool(postgresConfig *postgres.Config, clone string) *postgres.DB {
 	// Need to connect on a static DB so we can rename the used DBs.
 	tempConfig.ConnConfig.Database = clone
 
-	postgresDB := getPool(tempConfig)
+	postgresDB, err := getPool(tempConfig)
+	if err != nil {
+		return nil, err
+	}
 
 	log.Debugf("Got connection pool for database %q", clone)
 
-	return postgresDB
+	return postgresDB, nil
 }
 
-func getPool(postgresConfig *postgres.Config) *postgres.DB {
+func getPool(postgresConfig *postgres.Config) (*postgres.DB, error) {
 	var err error
 	var postgresDB *postgres.DB
 
@@ -259,10 +277,10 @@ func getPool(postgresConfig *postgres.Config) *postgres.DB {
 		return err
 	})
 	if err != nil {
-		log.Fatalf("Timed out trying to open database: %v", err)
+		return nil, err
 	}
 
-	return postgresDB
+	return postgresDB, nil
 }
 
 // getAvailablePostgresCapacity - retrieves the capacity for Postgres
@@ -276,9 +294,12 @@ func getAvailablePostgresCapacity(postgresConfig *postgres.Config) (int64, error
 	}
 
 	// Connect to database for admin functions
-	connectPool := GetAdminPool(postgresConfig)
+	connectPool, err := GetAdminPool(postgresConfig)
 	// Close the admin connection pool
 	defer connectPool.Close()
+	if err != nil {
+		return pgconfig.GetPostgresCapacity(), nil
+	}
 
 	// Wrap in a transaction
 	ctx, cancel := context.WithTimeout(context.Background(), PostgresQueryTimeout)
@@ -382,9 +403,12 @@ func GetRemainingCapacity(postgresConfig *postgres.Config) (int64, error) {
 	}
 
 	// Connect to database for admin functions
-	connectPool := GetAdminPool(postgresConfig)
+	connectPool, err := GetAdminPool(postgresConfig)
 	// Close the admin connection pool
 	defer connectPool.Close()
+	if err != nil {
+		return pgconfig.GetPostgresCapacity(), nil
+	}
 
 	sizeUsed, err := GetTotalPostgresSize(postgresConfig)
 	if err != nil {
@@ -408,9 +432,12 @@ func GetDatabaseSize(postgresConfig *postgres.Config, dbName string) (int64, err
 	log.Debugf("GetDatabaseSize -- %q", dbName)
 
 	// Connect to different database for admin functions
-	connectPool := GetAdminPool(postgresConfig)
+	connectPool, err := GetAdminPool(postgresConfig)
 	// Close the admin connection pool
 	defer connectPool.Close()
+	if err != nil {
+		return 0, err
+	}
 
 	// Create a context with a timeout
 	ctx, cancel := context.WithTimeout(context.Background(), PostgresQueryTimeout)
@@ -429,9 +456,12 @@ func GetDatabaseSize(postgresConfig *postgres.Config, dbName string) (int64, err
 // GetTotalPostgresSize - retrieves the total size of all Postgres databases
 func GetTotalPostgresSize(postgresConfig *postgres.Config) (int64, error) {
 	// Connect to database for admin functions
-	connectPool := GetAdminPool(postgresConfig)
+	connectPool, err := GetAdminPool(postgresConfig)
 	// Close the admin connection pool
 	defer connectPool.Close()
+	if err != nil {
+
+	}
 
 	// Create a context with a timeout
 	ctx, cancel := context.WithTimeout(context.Background(), PostgresQueryTimeout)
@@ -439,7 +469,7 @@ func GetTotalPostgresSize(postgresConfig *postgres.Config) (int64, error) {
 
 	row := connectPool.QueryRow(ctx, totalSizeStmt)
 	var sizeUsed int64
-	err := row.Scan(&sizeUsed)
+	err = row.Scan(&sizeUsed)
 	if err != nil {
 		return 0, err
 	}
@@ -448,18 +478,21 @@ func GetTotalPostgresSize(postgresConfig *postgres.Config) (int64, error) {
 }
 
 // GetAllDatabases - returns list of databases in Postgres
-func GetAllDatabases(postgresConfig *postgres.Config) []string {
+func GetAllDatabases(postgresConfig *postgres.Config) ([]string, error) {
 	// Connect to different database for admin functions
-	connectPool := GetAdminPool(postgresConfig)
+	connectPool, err := GetAdminPool(postgresConfig)
 	// Close the admin connection pool
 	defer connectPool.Close()
+	if err != nil {
+		return nil, err
+	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), PostgresQueryTimeout)
 	defer cancel()
 
 	rows, err := connectPool.Query(ctx, "SELECT datname FROM pg_catalog.pg_database")
 	if err != nil {
-		return nil
+		return nil, err
 	}
 	defer rows.Close()
 
@@ -467,11 +500,11 @@ func GetAllDatabases(postgresConfig *postgres.Config) []string {
 	for rows.Next() {
 		var cloneName string
 		if err := rows.Scan(&cloneName); err != nil {
-			return nil
+			return nil, err
 		}
 
 		clones = append(clones, cloneName)
 	}
 
-	return clones
+	return clones, nil
 }

--- a/pkg/postgres/pgadmin/admin_utils_test.go
+++ b/pkg/postgres/pgadmin/admin_utils_test.go
@@ -87,7 +87,8 @@ func (s *PostgresRestoreSuite) TestUtilities() {
 	s.True(CheckIfDBExists(s.config, restoreDB))
 
 	// Get a connection to the restore database
-	restorePool := GetClonePool(s.config, restoreDB)
+	restorePool, err := GetClonePool(s.config, restoreDB)
+	s.Nil(err)
 	s.NotNil(restorePool)
 	err = restorePool.Ping(s.ctx)
 	s.Nil(err)
@@ -105,18 +106,22 @@ func (s *PostgresRestoreSuite) TestUtilities() {
 	s.NotNil(err)
 
 	// Get a connection to the active DB
-	activePool := GetClonePool(s.config, activeDB)
+	activePool, err := GetClonePool(s.config, activeDB)
+	s.Nil(err)
 	s.NotNil(activePool)
 
 	// Rename activeDB to a new one
 	err = RenameDB(s.pool, activeDB, tempDB)
 	s.Nil(err)
-	s.True(CheckIfDBExists(s.config, tempDB))
+	exists, err := CheckIfDBExists(s.config, tempDB)
+	s.Nil(err)
+	s.True(exists)
 	// Make sure connection to active database was terminated
 	s.NotNil(activePool.Ping(s.ctx))
 
 	// Reacquire a connection to the restore database
-	restorePool = GetClonePool(s.config, restoreDB)
+	restorePool, err = GetClonePool(s.config, restoreDB)
+	s.Nil(err)
 	s.NotNil(restorePool)
 	s.Nil(restorePool.Ping(s.ctx))
 


### PR DESCRIPTION
## Description

In getPool we were logging a fatal error if we were unable to get a pool.  There are instances such as getting a pool for statistics where we do not want to fail.  If there is some flake that prevents a connection to get stats we can just log the error and move on.  We only need to fail when trying to getting connections for main workflow items and migrations.  So those errors are now passed back to the callers to choose to fail if necessary.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Updated the tests and worked with @vladbologa to verify this resolved the scenario where he encountered the issue running a local central with an external RDS DB.
