### PR TITLE
Fix issues with Deployment Sidebar in Network Graph 2.0

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentSideBar.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentSideBar.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, CSSProperties } from 'react';
 import {
     Alert,
     AlertVariant,
@@ -35,6 +35,10 @@ import NetworkPolicies from '../common/NetworkPolicies';
 import useSimulation from '../hooks/useSimulation';
 import { EdgeState } from '../components/EdgeStateSelect';
 import { deploymentTabs } from '../utils/deploymentUtils';
+
+const sidebarHeadingStyleConstant = {
+    '--pf-u-max-width--MaxWidth': '26ch',
+} as CSSProperties;
 
 type DeploymentSideBarProps = {
     deploymentId: string;
@@ -97,7 +101,22 @@ function DeploymentSideBar({
 
     if (error) {
         return (
-            <Alert isInline variant={AlertVariant.danger} title={error} className="pf-u-mb-lg" />
+            <Stack>
+                <StackItem>
+                    <Flex direction={{ default: 'row' }} className="pf-u-p-md pf-u-mb-0">
+                        <FlexItem>
+                            <DeploymentIcon />
+                        </FlexItem>
+                    </Flex>
+                </StackItem>
+                <StackItem>
+                    <Alert
+                        variant={AlertVariant.danger}
+                        title={error.toString()}
+                        className="pf-u-my-lg pf-u-mx-lg"
+                    />
+                </StackItem>
+            </Stack>
         );
     }
 
@@ -110,7 +129,11 @@ function DeploymentSideBar({
                     </FlexItem>
                     <FlexItem>
                         <TextContent>
-                            <Text component={TextVariants.h1} className="pf-u-font-size-xl">
+                            <Text
+                                component={TextVariants.h1}
+                                className="pf-u-font-size-xl pf-u-max-width"
+                                style={sidebarHeadingStyleConstant}
+                            >
                                 {deployment?.name}
                             </Text>
                         </TextContent>


### PR DESCRIPTION
## Description

While doing manual scale testing, I happened to find 2 issues:

1. Very long deployment names crowd the Close (X) in the PatternFly sidebar layout, so I added a max-width to the deployment name in the title, so that long names wrap.
2. If an error occurs while retrieving deployment details--as happened during the scale test, when a deployment was deleted in the background--the page crashed. I coerced the error to a string, and moved down the position of the error message, so that the Close (X) is still visible.


## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

1. Long deployment name wrapping
![Screen Shot 2023-03-21 at 5 26 04 PM](https://user-images.githubusercontent.com/715729/226744765-7248cf82-ec8c-479e-9fff-5d35d31bd21c.png)


2. Error message with Close button, instead of page crash
![Screen Shot 2023-03-21 at 4 42 01 PM](https://user-images.githubusercontent.com/715729/226742110-3ff457ca-3596-4391-8a1a-0f5060fe351e.png)
