### PR TITLE
bind to 0.0.0.0 on port-forward

### DIFF
--- a/image/templates/common/port-forward.sh
+++ b/image/templates/common/port-forward.sh
@@ -31,5 +31,5 @@ while true; do
 done
 echo
 
-nohup ${KUBE_COMMAND} port-forward -n 'stackrox' svc/central "$1:443" 1>/dev/null 2>&1 &
+nohup ${KUBE_COMMAND} port-forward -n 'stackrox' svc/central "$1:443" --address='0.0.0.0' 1>/dev/null 2>&1 &
 echo "Access central on https://localhost:$1"


### PR DESCRIPTION
## Description

Bind to `0.0.0.0` to allow calling local proxy from containers.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

CI
