### PR TITLE
Revert "Revert "Fix GitHub actions to allow for external contributions""

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -84,7 +84,6 @@ jobs:
         with:
           name: cli-build
           path: cli-build.tgz
-
   pre-build-go-binaries:
     runs-on: ubuntu-latest
     container:
@@ -123,7 +122,6 @@ jobs:
         with:
           name: go-binaries-build
           path: go-binaries-build.tgz
-
   pre-build-go-binaries-rcd:
     runs-on: ubuntu-latest
     container:
@@ -165,7 +163,6 @@ jobs:
       with:
         name: go-binaries-build-rcd
         path: go-binaries-build-rcd.tgz
-
   pre-build-docs:
     runs-on: ubuntu-latest
     container:
@@ -273,11 +270,6 @@ jobs:
       - name: Generate OSS notice
         run: make ossls-notice
 
-      # needed for docs ensure_image.sh initial pull with RHACS_BRANDING
-      - name: Docker login
-        run: |
-            docker login -u "${QUAY_RHACS_ENG_RO_USERNAME}" --password-stdin quay.io <<<"${QUAY_RHACS_ENG_RO_PASSWORD}"
-
       - name: Build main images
         run: make docker-build-main-image
 
@@ -287,7 +279,16 @@ jobs:
       - name: Build roxctl image
         run: make docker-build-roxctl-image
 
+      # needed for docs ensure_image.sh initial pull with RHACS_BRANDING
+      - name: Docker login
+        # Skip for external contributions.
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        run: |
+          docker login -u "${QUAY_RHACS_ENG_RO_USERNAME}" --password-stdin quay.io <<<"${QUAY_RHACS_ENG_RO_PASSWORD}"
+
       - name: Push images
+        # Skip for external contributions.
+        if: github.event.pull_request.head.repo.full_name == github.repository
         run: |
             source ./scripts/ci/lib.sh
             echo "Will determin context from: ${{ github.event_name }} & ${{ github.ref_name }}"
@@ -298,11 +299,15 @@ jobs:
             push_main_image_set "$push_context" "${{ env.ROX_PRODUCT_BRANDING }}"
 
       - name: Push matching collector and scanner images
+        # Skip for external contributions.
+        if: github.event.pull_request.head.repo.full_name == github.repository
         run: |
             source ./scripts/ci/lib.sh
             push_matching_collector_scanner_images "${{ env.ROX_PRODUCT_BRANDING }}"
 
       - name: Comment on the PR
+        # Skip for external contributions.
+        if: github.event.pull_request.head.repo.full_name == github.repository
         env:
           GITHUB_TOKEN: "${{ secrets.ROBOT_ROX_GITHUB_TOKEN }}"
         run: |
@@ -380,21 +385,25 @@ jobs:
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
+
+    - name: Build main images
+      run: make docker-build-main-image
+
     - name: Login to quay.io/rhacs-eng
+
+      if: github.event.pull_request.head.repo.full_name == github.repository
       uses: docker/login-action@v2
       with:
         registry: quay.io
         username: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
         password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
 
-    - name: Build main images
-      run: make docker-build-main-image
-
     - name: Push to quay.io/rhacs-eng
       uses: docker/build-push-action@v4
       with:
         context: image/rhel
-        push: true
+        # Skip for external contributions.
+        push: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         build-args: |
           ROX_PRODUCT_BRANDING=${{ env.ROX_PRODUCT_BRANDING }}
         file: image/rhel/Dockerfile.gen
@@ -440,6 +449,8 @@ jobs:
         run: echo "GOTAGS=release" >> "$GITHUB_ENV"
 
       - name: Docker login
+        # Skip for external contributions.
+        if: github.event.pull_request.head.repo.full_name == github.repository
         run: |
             docker login -u "${QUAY_RHACS_ENG_RW_USERNAME}" --password-stdin quay.io <<<"${QUAY_RHACS_ENG_RW_PASSWORD}"
 
@@ -454,15 +465,21 @@ jobs:
         run: docker run --rm "quay.io/rhacs-eng/stackrox-operator:$(make --quiet -C operator tag)" --help
 
       - name: Push images
+        # Skip for external contributions.
+        if: github.event.pull_request.head.repo.full_name == github.repository
         run: |
           make -C operator/ docker-push docker-push-bundle | cat
 
       # Index image can only be built once bundle was pushed
       - name: Build index
+        # Skip for external contributions as the build relies on the previous image to be pushed.
+        if: github.event.pull_request.head.repo.full_name == github.repository
         run: |
           make -C operator/ index-build
 
       - name: Push index image
+        # Skip for external contributions.
+        if: github.event.pull_request.head.repo.full_name == github.repository
         run: |
           make -C operator/ docker-push-index | cat
 
@@ -496,9 +513,13 @@ jobs:
       run: make mock-grpc-server-image
 
     - name: Set up Docker Buildx
+      # Skip for external contributions.
+      if: github.event.pull_request.head.repo.full_name == github.repository
       uses: docker/setup-buildx-action@v2
 
     - name: Login to quay.io/rhacs-eng
+      # Skip for external contributions.
+      if: github.event.pull_request.head.repo.full_name == github.repository
       uses: docker/login-action@v2
       with:
         registry: quay.io
@@ -509,7 +530,8 @@ jobs:
       uses: docker/build-push-action@v4
       with:
         context: integration-tests/mock-grpc-server/image
-        push: true
+        # Skip for external contributions.
+        push: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         tags: |
           quay.io/rhacs-eng/grpc-server:${{ steps.tag.outputs.TAG }}
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -282,13 +282,15 @@ jobs:
       # needed for docs ensure_image.sh initial pull with RHACS_BRANDING
       - name: Docker login
         # Skip for external contributions.
-        if: github.event.pull_request.head.repo.full_name == github.repository
+        if: |
+          github.event_name == 'push' || !github.event.pull_request.head.repo.fork
         run: |
           docker login -u "${QUAY_RHACS_ENG_RO_USERNAME}" --password-stdin quay.io <<<"${QUAY_RHACS_ENG_RO_PASSWORD}"
 
       - name: Push images
         # Skip for external contributions.
-        if: github.event.pull_request.head.repo.full_name == github.repository
+        if: |
+          github.event_name == 'push' || !github.event.pull_request.head.repo.fork
         run: |
             source ./scripts/ci/lib.sh
             echo "Will determin context from: ${{ github.event_name }} & ${{ github.ref_name }}"
@@ -300,14 +302,16 @@ jobs:
 
       - name: Push matching collector and scanner images
         # Skip for external contributions.
-        if: github.event.pull_request.head.repo.full_name == github.repository
+        if: |
+          github.event_name == 'push' || !github.event.pull_request.head.repo.fork
         run: |
             source ./scripts/ci/lib.sh
             push_matching_collector_scanner_images "${{ env.ROX_PRODUCT_BRANDING }}"
 
       - name: Comment on the PR
         # Skip for external contributions.
-        if: github.event.pull_request.head.repo.full_name == github.repository
+        if: |
+          github.event_name == 'push' || !github.event.pull_request.head.repo.fork
         env:
           GITHUB_TOKEN: "${{ secrets.ROBOT_ROX_GITHUB_TOKEN }}"
         run: |
@@ -390,8 +394,8 @@ jobs:
       run: make docker-build-main-image
 
     - name: Login to quay.io/rhacs-eng
-
-      if: github.event.pull_request.head.repo.full_name == github.repository
+      if: |
+        github.event_name == 'push' || !github.event.pull_request.head.repo.fork
       uses: docker/login-action@v2
       with:
         registry: quay.io
@@ -400,10 +404,10 @@ jobs:
 
     - name: Push to quay.io/rhacs-eng
       uses: docker/build-push-action@v4
+      if: |
+        github.event_name == 'push' || !github.event.pull_request.head.repo.fork
       with:
         context: image/rhel
-        # Skip for external contributions.
-        push: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         build-args: |
           ROX_PRODUCT_BRANDING=${{ env.ROX_PRODUCT_BRANDING }}
         file: image/rhel/Dockerfile.gen
@@ -450,7 +454,8 @@ jobs:
 
       - name: Docker login
         # Skip for external contributions.
-        if: github.event.pull_request.head.repo.full_name == github.repository
+        if: |
+          github.event_name == 'push' || !github.event.pull_request.head.repo.fork
         run: |
             docker login -u "${QUAY_RHACS_ENG_RW_USERNAME}" --password-stdin quay.io <<<"${QUAY_RHACS_ENG_RW_PASSWORD}"
 
@@ -466,20 +471,23 @@ jobs:
 
       - name: Push images
         # Skip for external contributions.
-        if: github.event.pull_request.head.repo.full_name == github.repository
+        if: |
+          github.event_name == 'push' || !github.event.pull_request.head.repo.fork
         run: |
           make -C operator/ docker-push docker-push-bundle | cat
 
       # Index image can only be built once bundle was pushed
       - name: Build index
         # Skip for external contributions as the build relies on the previous image to be pushed.
-        if: github.event.pull_request.head.repo.full_name == github.repository
+        if: |
+          github.event_name == 'push' || !github.event.pull_request.head.repo.fork
         run: |
           make -C operator/ index-build
 
       - name: Push index image
         # Skip for external contributions.
-        if: github.event.pull_request.head.repo.full_name == github.repository
+        if: |
+          github.event_name == 'push' || !github.event.pull_request.head.repo.fork
         run: |
           make -C operator/ docker-push-index | cat
 
@@ -514,12 +522,14 @@ jobs:
 
     - name: Set up Docker Buildx
       # Skip for external contributions.
-      if: github.event.pull_request.head.repo.full_name == github.repository
+      if: |
+        github.event_name == 'push' || !github.event.pull_request.head.repo.fork
       uses: docker/setup-buildx-action@v2
 
     - name: Login to quay.io/rhacs-eng
       # Skip for external contributions.
-      if: github.event.pull_request.head.repo.full_name == github.repository
+      if: |
+        github.event_name == 'push' || !github.event.pull_request.head.repo.fork
       uses: docker/login-action@v2
       with:
         registry: quay.io
@@ -528,10 +538,10 @@ jobs:
 
     - name: Push to quay.io/rhacs-eng
       uses: docker/build-push-action@v4
+      if: |
+        github.event_name == 'push' || !github.event.pull_request.head.repo.fork
       with:
         context: integration-tests/mock-grpc-server/image
-        # Skip for external contributions.
-        push: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         tags: |
           quay.io/rhacs-eng/grpc-server:${{ steps.tag.outputs.TAG }}
 


### PR DESCRIPTION
Reverts stackrox/stackrox#5349

The previous PR had two issues:
- the `build-push` action failed as the docker buildx was not setup. Instead of using the `context.with`, I've resorted to using just `if` on the step.
- the `push` event when i.e. merging to master didn't trigger builds, since the `event.pull_request` was not set.

Additionally, also moved to `!github.event.pull_request.head.repo.fork` to indicate that the PR is not coming from a fork, since it seemed more readable.


As a sample, this now does the following on a fork with GitHub actions enabled:
- It will detect that the PR is running on a fork, hence the build jobs will be skipped: https://github.com/dhaus67/stackrox/actions/runs/4502247753/jobs/7924325522
- When merging, the push event will be detected, and the jobs will run (this is expected to fail on the fork repo since we do not have secrets configured there, but means the fix works and we do not suddenly "skip" building images): https://github.com/dhaus67/stackrox/actions/runs/4502578300