### PR TITLE
ROX-15441: Add anomalous/baseline sections under flows tab

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/common/FlowsTable.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/common/FlowsTable.tsx
@@ -29,7 +29,7 @@ type FlowsTableProps = {
     flows: Flow[];
     numFlows: number;
     expandedRows: string[];
-    setExpandedRows?: React.Dispatch<React.SetStateAction<string[]>>;
+    setExpandedRows: React.Dispatch<React.SetStateAction<string[]>>;
     selectedRows: string[];
     setSelectedRows: React.Dispatch<React.SetStateAction<string[]>>;
     isEditable?: boolean;

--- a/ui/apps/platform/src/Containers/NetworkGraph/common/FlowsTable.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/common/FlowsTable.tsx
@@ -29,7 +29,7 @@ type FlowsTableProps = {
     flows: Flow[];
     numFlows: number;
     expandedRows: string[];
-    setExpandedRows: React.Dispatch<React.SetStateAction<string[]>>;
+    setExpandedRows?: React.Dispatch<React.SetStateAction<string[]>>;
     selectedRows: string[];
     setSelectedRows: React.Dispatch<React.SetStateAction<string[]>>;
     isEditable?: boolean;

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentFlows.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentFlows.tsx
@@ -15,9 +15,9 @@ import {
     ToolbarContent,
     ToolbarItem,
 } from '@patternfly/react-core';
+import pluralize from 'pluralize';
 
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
-import pluralize from 'pluralize';
 import { AdvancedFlowsFilterType } from '../common/AdvancedFlowsFilter/types';
 import {
     filterNetworkFlows,

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentFlows.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentFlows.tsx
@@ -4,6 +4,8 @@ import {
     AlertVariant,
     Bullseye,
     Divider,
+    EmptyState,
+    ExpandableSection,
     Flex,
     FlexItem,
     Spinner,
@@ -14,6 +16,8 @@ import {
     ToolbarItem,
 } from '@patternfly/react-core';
 
+import useSelectToggle from 'hooks/patternfly/useSelectToggle';
+import pluralize from 'pluralize';
 import { AdvancedFlowsFilterType } from '../common/AdvancedFlowsFilter/types';
 import {
     filterNetworkFlows,
@@ -58,6 +62,10 @@ function DeploymentFlows({
     const [advancedFilters, setAdvancedFilters] = React.useState<AdvancedFlowsFilterType>(
         defaultAdvancedFlowsFilters
     );
+    const { isOpen: isAnomalousFlowsExpanded, onToggle: toggleAnomalousFlowsExpandable } =
+        useSelectToggle(true);
+    const { isOpen: isBaselineFlowsExpanded, onToggle: toggleBaselineFlowsExpandable } =
+        useSelectToggle(true);
 
     const {
         isLoading,
@@ -76,14 +84,24 @@ function DeploymentFlows({
         .filter((row) => row.children && !!row.children.length)
         .map((row) => row.id); // Default to all expanded
     const [expandedRows, setExpandedRows] = React.useState<string[]>(initialExpandedRows);
-    const [selectedRows, setSelectedRows] = React.useState<string[]>([]);
+
+    const [selectedAnomalousRows, setSelectedAnomalousRows] = React.useState<string[]>([]);
+    const [selectedBaselineRows, setSelectedBaselineRows] = React.useState<string[]>([]);
 
     // derived data
+    const anomalousFlows = filteredFlows.filter((flow) => flow.isAnomalous);
+    const baselineFlows = filteredFlows.filter((flow) => !flow.isAnomalous);
+
     const numFlows = getNumFlows(filteredFlows);
+    const numAnomalousFlows = getNumFlows(anomalousFlows);
+    const numBaselineFlows = getNumFlows(baselineFlows);
+
     const allUniquePorts = getAllUniquePorts(networkFlows);
     const numExtraneousEgressFlows = getNumExtraneousEgressFlows(nodes);
     const numExtraneousIngressFlows = getNumExtraneousIngressFlows(nodes);
     const totalFlows = numFlows + numExtraneousEgressFlows + numExtraneousIngressFlows;
+
+    const selectedRows = [...selectedAnomalousRows, ...selectedBaselineRows];
 
     const onSelectFlow = (entityId: string) => {
         onNodeSelect(entityId);
@@ -99,14 +117,20 @@ function DeploymentFlows({
 
     function addSelectedToBaseline() {
         const selectedFlows = filteredFlows.filter((networkBaseline) => {
-            return selectedRows.includes(networkBaseline.id);
+            return (
+                selectedAnomalousRows.includes(networkBaseline.id) ||
+                selectedBaselineRows.includes(networkBaseline.id)
+            );
         });
         modifyBaselineStatuses(selectedFlows, 'BASELINE', refetchFlows);
     }
 
     function markSelectedAsAnomalous() {
         const selectedFlows = filteredFlows.filter((networkBaseline) => {
-            return selectedRows.includes(networkBaseline.id);
+            return (
+                selectedAnomalousRows.includes(networkBaseline.id) ||
+                selectedBaselineRows.includes(networkBaseline.id)
+            );
         });
         modifyBaselineStatuses(selectedFlows, 'ANOMALOUS', refetchFlows);
     }
@@ -158,7 +182,10 @@ function DeploymentFlows({
                                 <FlowsBulkActions
                                     type="active"
                                     selectedRows={selectedRows}
-                                    onClearSelectedRows={() => setSelectedRows([])}
+                                    onClearSelectedRows={() => {
+                                        setSelectedAnomalousRows([]);
+                                        setSelectedBaselineRows([]);
+                                    }}
                                     markSelectedAsAnomalous={markSelectedAsAnomalous}
                                     addSelectedToBaseline={addSelectedToBaseline}
                                 />
@@ -167,21 +194,68 @@ function DeploymentFlows({
                     </Toolbar>
                 </StackItem>
                 <StackItem>
-                    <FlowsTable
-                        label="Deployment flows"
-                        flows={filteredFlows}
-                        numFlows={numFlows}
-                        expandedRows={expandedRows}
-                        setExpandedRows={setExpandedRows}
-                        selectedRows={selectedRows}
-                        setSelectedRows={setSelectedRows}
-                        addToBaseline={addToBaseline}
-                        markAsAnomalous={markAsAnomalous}
-                        numExtraneousEgressFlows={numExtraneousEgressFlows}
-                        numExtraneousIngressFlows={numExtraneousIngressFlows}
-                        isEditable
-                        onSelectFlow={onSelectFlow}
-                    />
+                    <Stack hasGutter>
+                        <StackItem>
+                            <ExpandableSection
+                                toggleText={`${numAnomalousFlows} anomalous ${pluralize(
+                                    'flow',
+                                    numAnomalousFlows
+                                )}`}
+                                onToggle={toggleAnomalousFlowsExpandable}
+                                isExpanded={isAnomalousFlowsExpanded}
+                            >
+                                {numAnomalousFlows > 0 ? (
+                                    <FlowsTable
+                                        label="Deployment flows"
+                                        flows={anomalousFlows}
+                                        numFlows={numAnomalousFlows}
+                                        expandedRows={expandedRows}
+                                        setExpandedRows={setExpandedRows}
+                                        selectedRows={selectedAnomalousRows}
+                                        setSelectedRows={setSelectedAnomalousRows}
+                                        addToBaseline={addToBaseline}
+                                        markAsAnomalous={markAsAnomalous}
+                                        numExtraneousEgressFlows={numExtraneousEgressFlows}
+                                        numExtraneousIngressFlows={numExtraneousIngressFlows}
+                                        isEditable
+                                        onSelectFlow={onSelectFlow}
+                                    />
+                                ) : (
+                                    <EmptyState>No anomalous flows</EmptyState>
+                                )}
+                            </ExpandableSection>
+                        </StackItem>
+                        <StackItem>
+                            <ExpandableSection
+                                toggleText={`${numBaselineFlows} baseline ${pluralize(
+                                    'flow',
+                                    numBaselineFlows
+                                )}`}
+                                onToggle={toggleBaselineFlowsExpandable}
+                                isExpanded={isBaselineFlowsExpanded}
+                            >
+                                {numBaselineFlows > 0 ? (
+                                    <FlowsTable
+                                        label="Deployment flows"
+                                        flows={baselineFlows}
+                                        numFlows={numBaselineFlows}
+                                        expandedRows={expandedRows}
+                                        setExpandedRows={setExpandedRows}
+                                        selectedRows={selectedBaselineRows}
+                                        setSelectedRows={setSelectedBaselineRows}
+                                        addToBaseline={addToBaseline}
+                                        markAsAnomalous={markAsAnomalous}
+                                        numExtraneousEgressFlows={numExtraneousEgressFlows}
+                                        numExtraneousIngressFlows={numExtraneousIngressFlows}
+                                        isEditable
+                                        onSelectFlow={onSelectFlow}
+                                    />
+                                ) : (
+                                    <EmptyState>No anomalous flows</EmptyState>
+                                )}
+                            </ExpandableSection>
+                        </StackItem>
+                    </Stack>
                 </StackItem>
             </Stack>
         </div>


### PR DESCRIPTION
## Description

This PR separates the table under the `Flows` tab into two sections: `Anomalous` and `Baseline`

![Screenshot 2023-03-22 at 11 14 02 AM](https://user-images.githubusercontent.com/4805485/226999414-2dc30208-3f51-4f8d-b9cd-d5969d065749.png)
![Screenshot 2023-03-22 at 11 14 10 AM](https://user-images.githubusercontent.com/4805485/226999420-223ed454-7cd8-47a1-8844-5f0f2667a37a.png)
![Screenshot 2023-03-22 at 11 14 22 AM](https://user-images.githubusercontent.com/4805485/226999423-a78a8db1-b3a2-4de7-8475-c4953da36037.png)

