### PR TITLE
Increase Sensor resources by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 - ROX-14251: StackRox now uses IMDSv2 to retrieve AWS metadata instead of IMDSv1.
 - ROX-12750: The `Analyst` permission set which used to have read access on all permissions except
   the now deprecated `DebugLogs` permission now has read access to all permissions except `Administration`.
+- The default resources for Sensor have moved to a request of 2 cores, 4GB of RAM and a limit of 4 cores, 8GB of RAM in order to
+  support a higher number of clusters without modification.
 
 ## [3.74.0]
 

--- a/image/templates/helm/stackrox-secured-cluster/README.md.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/README.md.htpl
@@ -152,11 +152,11 @@ the options which you can configure:
     # Use custom resource overrides for sensor
     resources:
       requests:
-        cpu: "1"
-        memory: "1Gi"
-      limits:
         cpu: "2"
         memory: "4Gi"
+      limits:
+        cpu: "4"
+        memory: "8Gi"
   
   admissionControl:
     dynamic:

--- a/image/templates/helm/stackrox-secured-cluster/internal/defaults/40-resources.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/internal/defaults/40-resources.yaml
@@ -3,11 +3,11 @@
 sensor:
   resources:
     requests:
-      memory: "1Gi"
-      cpu: "1"
-    limits:
       memory: "4Gi"
       cpu: "2"
+    limits:
+      memory: "8Gi"
+      cpu: "4"
 
 admissionControl:
   resources:

--- a/image/templates/helm/stackrox-secured-cluster/values-public.yaml.example
+++ b/image/templates/helm/stackrox-secured-cluster/values-public.yaml.example
@@ -124,11 +124,11 @@
 #  # Resource configuration for the sensor container.
 #  resources:
 #    requests:
-#      memory: "1Gi"
-#      cpu: "1"
-#    limits:
 #      memory: "4Gi"
 #      cpu: "2"
+#    limits:
+#      memory: "8Gi"
+#      cpu: "4"
 #
 #  # Settings for the internal service-to-service TLS certificate used by Sensor.
 #  serviceTLS:

--- a/tests/upgrade/lib.sh
+++ b/tests/upgrade/lib.sh
@@ -226,7 +226,7 @@ test_upgrader() {
 
     info "Verify resources were patched back by the upgrader"
     resources="$(kubectl -n stackrox get deploy/sensor -o 'jsonpath=cpu={.spec.template.spec.containers[?(@.name=="sensor")].resources.requests.cpu},memory={.spec.template.spec.containers[?(@.name=="sensor")].resources.requests.memory}')"
-    if [[ "$resources" != 'cpu=1,memory=1Gi' ]]; then
+    if [[ "$resources" != 'cpu=2,memory=4Gi' ]]; then
         echo "Resources ($resources) not patched back!"
         kubectl -n stackrox get deploy/sensor -o yaml
         exit 1


### PR DESCRIPTION
## Description

Sensor has been under-provisioned by default. Bump the Sensor resources to a more reasonable level. If the resources have not been specified then these will be reconciled to these levels, if resources have been specified then they will remain as specified

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Straightforward, but let's check CI
