### PR TITLE
Look at the scope tree to evaluate layer index

### DIFF
--- a/central/graphql/resolvers/image_components.go
+++ b/central/graphql/resolvers/image_components.go
@@ -244,10 +244,18 @@ func getDeploymentScope(scopeQuery *v1.Query, contexts ...context.Context) strin
 }
 
 func getImageIDFromScope(contexts ...context.Context) string {
+	var scope scoped.Scope
+	var hasScope bool
 	for _, ctx := range contexts {
-		if scope, ok := scoped.GetScope(ctx); ok {
-			if scope.Level == v1.SearchCategory_IMAGES {
+		if features.VulnMgmtWorkloadCVEs.Enabled() {
+			if scope, hasScope = scoped.GetScopeAtLevel(ctx, v1.SearchCategory_IMAGES); !hasScope {
 				return scope.ID
+			}
+		} else {
+			if scope, ok := scoped.GetScope(ctx); ok {
+				if scope.Level == v1.SearchCategory_IMAGES {
+					return scope.ID
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Description

Look at the full scope tree and not just the parent to evaluate image component's layer index.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed
