### PR TITLE
Quickfix: deploy/common/k8sbased.sh not passing loglevel to sensor

### DIFF
--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -529,6 +529,20 @@ function launch_sensor {
         helm_args+=(--set "helmManaged=false")
       fi
 
+      if [[ -n "$LOGLEVEL" ]]; then
+        helm_args+=(
+          --set customize.envVars.LOGLEVEL="${LOGLEVEL}"
+        )
+      fi
+
+      # TODO(ROX-14310): Remove this patch when re-sync is disabled unconditionally
+      if [[ -n "$ROX_RESYNC_DISABLED" ]]; then
+        echo "Setting re-sync disabled to $ROX_RESYNC_DISABLED"
+        helm_args+=(
+          --set customize.envVars.ROX_RESYNC_DISABLED="${ROX_RESYNC_DISABLED}"
+        )
+      fi
+
       if [[ -n "$CI" ]]; then
         helm lint "$k8s_dir/sensor-deploy/chart"
         helm lint "$k8s_dir/sensor-deploy/chart" -n stackrox
@@ -577,11 +591,6 @@ function launch_sensor {
        if [[ -z "${IS_RACE_BUILD}" ]]; then
            kubectl -n stackrox patch deploy/sensor --patch '{"spec":{"template":{"spec":{"containers":[{"name":"sensor","resources":{"limits":{"cpu":"500m","memory":"500Mi"},"requests":{"cpu":"500m","memory":"500Mi"}}}]}}}}'
        fi
-    fi
-
-    # TODO(ROX-14310): Remove this patch when re-sync is disabled unconditionally
-    if [[ "$ROX_RESYNC_DISABLED" == "true" ]]; then
-        kubectl -n stackrox set env deploy/sensor ROX_RESYNC_DISABLED="true"
     fi
 
     if [[ "$MONITORING_SUPPORT" == "true" || ( "$(local_dev)" != "true" && -z "$MONITORING_SUPPORT" ) ]]; then


### PR DESCRIPTION
## Description

This PR fixes two small issues with our deploy scripts:

1. `LOGLEVEL` was not passed to sensor if exported in the host when deploying. `LOGLEVEL="debug" ./deploy/k8s/deploy.sh` only sets `LOGLEVEL` in Central. With this, it will also inject in Sensor.
2. `ROX_RESYNC_DISABLED` was being set by patching sensor. This is a bit annoying because it will cause sensor to restart right after it's deployed. By injecting with `envVars` it will be deployed with the correct property from the beginning. 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] ~~Unit test and regression tests added~~
- [ ] ~~Evaluated and added CHANGELOG entry if required~~
- [ ] ~~Determined and documented upgrade steps~~
- [ ] ~~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

## Testing Performed

- Deployed using `LOGLEVEL="debug" ROX_RESYNC_DISABLED="true" ./deploy/k8s/deploy.sh`