### PR TITLE
ROX-15462: Add sarif output format to roxctl

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -72,6 +72,7 @@ require (
 	github.com/openshift/api v3.9.1-0.20191201231411-9f834e337466+incompatible
 	github.com/openshift/client-go v0.0.0-20200623090625-83993cebb5ae
 	github.com/operator-framework/helm-operator-plugins v0.0.7
+	github.com/owenrumney/go-sarif/v2 v2.1.3
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.14.0
 	github.com/prometheus/client_model v0.3.0
@@ -359,8 +360,6 @@ require (
 	sigs.k8s.io/kustomize/kyaml v0.13.9 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 )
-
-require github.com/owenrumney/go-sarif/v2 v2.1.3
 
 // To bump the version of a replacement package, use:
 //

--- a/go.mod
+++ b/go.mod
@@ -360,6 +360,8 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 )
 
+require github.com/owenrumney/go-sarif/v2 v2.1.3
+
 // To bump the version of a replacement package, use:
 //
 //   $ go mod edit -replace <package>=<replacement>@<branch or commit reference>

--- a/go.sum
+++ b/go.sum
@@ -209,6 +209,7 @@ github.com/apex/log v1.1.4/go.mod h1:AlpoD9aScyQfJDVHmLMEcx4oU6LqzkWp4Mg9GdAcEvQ
 github.com/apex/logs v0.0.4/go.mod h1:XzxuLZ5myVHDy9SAmYpamKKRNApGj54PfYLcFrXqDwo=
 github.com/aphistic/golf v0.0.0-20180712155816-02c07f170c5a/go.mod h1:3NqKYiepwy8kCu4PNA+aP7WUV72eXWJeP9/r3/K9aLE=
 github.com/aphistic/sweet v0.2.0/go.mod h1:fWDlIh/isSE9n6EPsRmC0det+whmX6dJid3stzu0Xys=
+github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
@@ -1543,6 +1544,9 @@ github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJ
 github.com/otiai10/curr v1.0.0/go.mod h1:LskTG5wDwr8Rs+nNQ+1LlxRjAtTZZjtJW4rMXl6j4vs=
 github.com/otiai10/mint v1.3.0/go.mod h1:F5AjcsTsWUqX+Na9fpHb52P8pcRX2CI6A3ctIT91xUo=
 github.com/otiai10/mint v1.3.1/go.mod h1:/yxELlJQ0ufhjUwhshSj+wFjZ78CnZ48/1wtmBH1OTc=
+github.com/owenrumney/go-sarif v1.1.1/go.mod h1:dNDiPlF04ESR/6fHlPyq7gHKmrM0sHUvAGjsoh8ZH0U=
+github.com/owenrumney/go-sarif/v2 v2.1.3 h1:1guchw824yg1CwjredY8pnzcE0SG+sfNzFY5CUYWgE4=
+github.com/owenrumney/go-sarif/v2 v2.1.3/go.mod h1:MSqMMx9WqlBSY7pXoOZWgEsVB4FDNfhcaXDA1j6Sr+w=
 github.com/pact-foundation/pact-go v1.0.4/go.mod h1:uExwJY4kCzNPcHRj+hCR/HBbOOIwwtUjcrb0b5/5kLM=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
@@ -1932,7 +1936,10 @@ github.com/vishvananda/netns v0.0.0-20180720170159-13995c7128cc/go.mod h1:ZjcWmF
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
 github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
 github.com/vladimirvivien/gexe v0.1.1 h1:2A0SBaOSKH+cwLVdt6H+KkHZotZWRNLlWygANGw5DxE=
+github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/msgpack/v5 v5.3.5 h1:5gO0H1iULLWGhs2H5tbAHIZTV8/cYafcFOr9znI5mJU=
+github.com/vmihailenco/tagparser v0.1.1 h1:quXMXlA39OCbd2wAdTsGDlK9RkOk6Wuw+x37wVyIuWY=
+github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
 github.com/weppos/publicsuffix-go v0.12.0/go.mod h1:z3LCPQ38eedDQSwmsSRW4Y7t2L8Ln16JPQ02lHAdn5k=
 github.com/weppos/publicsuffix-go v0.13.1-0.20210123135404-5fd73613514e/go.mod h1:HYux0V0Zi04bHNwOHy4cXJVz/TQjYonnF6aoYhj+3QE=
@@ -1984,6 +1991,7 @@ github.com/yvasiyarov/gorelic v0.0.7 h1:4DTF1WOM2ZZS/xMOkTFBOcb6XiHu/PKn3rVo6dbe
 github.com/yvasiyarov/newrelic_platform_go v0.0.0-20140908184405-b21fdbd4370f/go.mod h1:GlGEuHIJweS1mbCqG+7vt2nvWLzLLnRHbXz5JKd/Qbg=
 github.com/yvasiyarov/newrelic_platform_go v0.0.0-20160601141957-9c099fbc30e9 h1:AsFN8kXcCVkUFHyuzp1FtYbzp1nCO/H6+1uPSGEyPzM=
 github.com/zalando/go-keyring v0.1.0/go.mod h1:RaxNwUITJaHVdQ0VC7pELPZ3tOWn13nr0gZMZEhpVU0=
+github.com/zclconf/go-cty v1.10.0/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=
 github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxtB1Q=
 github.com/ziutek/mymysql v1.5.4/go.mod h1:LMSpPZ6DbqWFxNCHW77HeMg9I646SAhApZ/wKdgO/C0=
 github.com/zmap/rc2 v0.0.0-20131011165748-24b9757f5521/go.mod h1:3YZ9o3WnatTIZhuOtot4IcUfzoKVjUHqu6WALIyI0nE=

--- a/pkg/gjson/modifiers.go
+++ b/pkg/gjson/modifiers.go
@@ -185,8 +185,8 @@ func (r *resultToTextModifier) resultToText(key, value gjson.Result) string {
 
 	if r.opts.PrintKeys {
 		sb.WriteString(key.String())
-		// Add a whitespace between key and value.
-		sb.WriteString(" ")
+		// Add a colon, and tab space between key and value.
+		sb.WriteString(":\t")
 	}
 	sb.WriteString(value.String())
 	sb.WriteString(utils.IfThenElse(r.opts.CustomSeparator != "", r.opts.CustomSeparator, "\n"))

--- a/pkg/gjson/modifiers.go
+++ b/pkg/gjson/modifiers.go
@@ -144,14 +144,7 @@ func TextModifier() CustomModifier {
 		res := gjson.Parse(jsonString)
 		texts := map[int]string{}
 		res.ForEach(func(key, value gjson.Result) bool {
-			if !value.IsArray() {
-				texts[0] += modifier.resultToText(key, value)
-				return true
-			}
-
-			for i, val := range value.Array() {
-				texts[i] += modifier.resultToText(key, val)
-			}
+			toText(texts, key, value, modifier, 0)
 			return true
 		})
 		// Ensure we keep the same order for the texts we generated.
@@ -164,6 +157,23 @@ func TextModifier() CustomModifier {
 		bytes, _ := json.Marshal(result)
 		return string(bytes)
 	}
+}
+
+func toText(texts map[int]string, key gjson.Result, value gjson.Result, modifier resultToTextModifier, index int) int {
+	if !value.IsArray() {
+		texts[index] += modifier.resultToText(key, value)
+		index++
+		return index
+	}
+	for _, val := range value.Array() {
+		if val.IsArray() {
+			index = toText(texts, key, val, modifier, index)
+			continue
+		}
+		texts[index] += modifier.resultToText(key, val)
+		index++
+	}
+	return index
 }
 
 type resultToTextModifier struct {

--- a/pkg/gjson/modifiers.go
+++ b/pkg/gjson/modifiers.go
@@ -3,8 +3,11 @@ package gjson
 import (
 	"encoding/json"
 	"regexp"
+	"sort"
 	"strings"
 
+	"github.com/stackrox/rox/pkg/maputil"
+	"github.com/stackrox/rox/pkg/utils"
 	"github.com/tidwall/gjson"
 )
 
@@ -13,16 +16,18 @@ type CustomModifier = func(json, arg string) string
 
 var boolReplaceRegex = regexp.MustCompile(`.@boolReplace.*(})`)
 var listReplaceRegex = regexp.MustCompile(`.@list`)
+var textReplaceRegex = regexp.MustCompile(`.@text.*(})`)
 
 // modifiersRegexp provides a list of regex expressions that match all custom modifier prefixes for
 // sanitizing of queries.
 func modifiersRegexp() []*regexp.Regexp {
-	return []*regexp.Regexp{boolReplaceRegex, listReplaceRegex}
+	return []*regexp.Regexp{boolReplaceRegex, listReplaceRegex, textReplaceRegex}
 }
 
 var customGJSONModifiers = map[string]CustomModifier{
 	"list":        ListModifier(),
 	"boolReplace": BoolReplaceModifier(),
+	"text":        TextModifier(),
 }
 
 func init() {
@@ -106,4 +111,78 @@ func defaultReplaceBoolOptions() *replaceBoolOptions {
 		TrueReplace:  "true",
 		FalseReplace: "false",
 	}
+}
+
+type textOptions struct {
+	PrintKeys       bool   `json:"printKeys"`
+	CustomSeparator string `json:"customSeparator"`
+}
+
+func defaultTextOptions() *textOptions {
+	return &textOptions{
+		PrintKeys: true,
+	}
+}
+
+// TextModifier provides the @text modifier for gjson which creates a single string from the result, which contains
+// the key value pairs and a newline as separator.
+func TextModifier() CustomModifier {
+	return func(jsonString, arg string) string {
+		opts := defaultTextOptions()
+		if arg != "" {
+			gjson.Parse(arg).ForEach(func(key, value gjson.Result) bool {
+				switch key.String() {
+				case "printKeys":
+					opts.PrintKeys = value.Bool()
+				case "customSeparator":
+					opts.CustomSeparator = value.String()
+				}
+				return true
+			})
+		}
+		modifier := resultToTextModifier{opts: opts}
+		res := gjson.Parse(jsonString)
+		texts := map[int]string{}
+		res.ForEach(func(key, value gjson.Result) bool {
+			if !value.IsArray() {
+				texts[0] += modifier.resultToText(key, value)
+				return true
+			}
+
+			for i, val := range value.Array() {
+				texts[i] += modifier.resultToText(key, val)
+			}
+			return true
+		})
+		// Ensure we keep the same order for the texts we generated.
+		keys := maputil.Keys(texts)
+		sort.Ints(keys)
+		var result []string
+		for _, key := range keys {
+			result = append(result, modifier.trimSeparator(texts[key]))
+		}
+		bytes, _ := json.Marshal(result)
+		return string(bytes)
+	}
+}
+
+type resultToTextModifier struct {
+	opts *textOptions
+}
+
+func (r *resultToTextModifier) resultToText(key, value gjson.Result) string {
+	var sb strings.Builder
+
+	if r.opts.PrintKeys {
+		sb.WriteString(key.String())
+		// Add a whitespace between key and value.
+		sb.WriteString(" ")
+	}
+	sb.WriteString(value.String())
+	sb.WriteString(utils.IfThenElse(r.opts.CustomSeparator != "", r.opts.CustomSeparator, "\n"))
+	return sb.String()
+}
+
+func (r *resultToTextModifier) trimSeparator(s string) string {
+	return strings.TrimSuffix(s, utils.IfThenElse(r.opts.CustomSeparator != "", r.opts.CustomSeparator, "\n"))
 }

--- a/pkg/gjson/modifiers_test.go
+++ b/pkg/gjson/modifiers_test.go
@@ -124,7 +124,7 @@ func TestTextModifier(t *testing.T) {
 			{
 				Name:    "Hermione Granger",
 				Address: "Heathgate",
-				Age:     18,
+				Age:     19,
 			},
 		},
 	}
@@ -137,15 +137,15 @@ func TestTextModifier(t *testing.T) {
 	}{
 		"without custom column names": {
 			expression: "{textTest.#.name,textTest.#.age,textTest.#.address}.@text",
-			result:     "[\"name Harry Potter\\nage 18\\naddress Privet Drive\",\"name Ron Weasley\\nage 18\\naddress The Burrow\",\"name Hermione Granger\\nage 18\\naddress Heathgate\"]",
+			result:     "[\"name Harry Potter\\nage 18\\naddress Privet Drive\",\"name Ron Weasley\\nage 18\\naddress The Burrow\",\"name Hermione Granger\\nage 19\\naddress Heathgate\"]",
 		},
 		"without modifier should not modify the output": {
 			expression: "{textTest.#.name,textTest.#.age,textTest.#.address}",
-			result:     "{\"name\":[\"Harry Potter\",\"Ron Weasley\",\"Hermione Granger\"],\"age\":[18,18,18],\"address\":[\"Privet Drive\",\"The Burrow\",\"Heathgate\"]}",
+			result:     "{\"name\":[\"Harry Potter\",\"Ron Weasley\",\"Hermione Granger\"],\"age\":[18,18,19],\"address\":[\"Privet Drive\",\"The Burrow\",\"Heathgate\"]}",
 		},
 		"with custom column names": {
 			expression: "{\"Super Cool Name\":textTest.#.name,textTest.#.age,textTest.#.address}.@text",
-			result:     "[\"Super Cool Name Harry Potter\\nage 18\\naddress Privet Drive\",\"Super Cool Name Ron Weasley\\nage 18\\naddress The Burrow\",\"Super Cool Name Hermione Granger\\nage 18\\naddress Heathgate\"]",
+			result:     "[\"Super Cool Name Harry Potter\\nage 18\\naddress Privet Drive\",\"Super Cool Name Ron Weasley\\nage 18\\naddress The Burrow\",\"Super Cool Name Hermione Granger\\nage 19\\naddress Heathgate\"]",
 		},
 		"with singular value": {
 			expression: "{textTest.0.name,textTest.0.age,textTest.0.address}.@text",
@@ -153,15 +153,15 @@ func TestTextModifier(t *testing.T) {
 		},
 		"without printing keys": {
 			expression: `{textTest.#.name,textTest.#.age,textTest.#.address}.@text:{"printKeys": "false"}`,
-			result:     "[\"Harry Potter\\n18\\nPrivet Drive\",\"Ron Weasley\\n18\\nThe Burrow\",\"Hermione Granger\\n18\\nHeathgate\"]",
+			result:     "[\"Harry Potter\\n18\\nPrivet Drive\",\"Ron Weasley\\n18\\nThe Burrow\",\"Hermione Granger\\n19\\nHeathgate\"]",
 		},
 		"with custom separator": {
 			expression: `{textTest.#.name,textTest.#.age,textTest.#.address}.@text:{"customSeparator": "-"}`,
-			result:     "[\"name Harry Potter-age 18-address Privet Drive\",\"name Ron Weasley-age 18-address The Burrow\",\"name Hermione Granger-age 18-address Heathgate\"]",
+			result:     "[\"name Harry Potter-age 18-address Privet Drive\",\"name Ron Weasley-age 18-address The Burrow\",\"name Hermione Granger-age 19-address Heathgate\"]",
 		},
 		"without printing keys and with custom separator": {
 			expression: `{textTest.#.name,textTest.#.age,textTest.#.address}.@text:{"customSeparator": "-", "printKeys": "false"}`,
-			result:     "[\"Harry Potter-18-Privet Drive\",\"Ron Weasley-18-The Burrow\",\"Hermione Granger-18-Heathgate\"]",
+			result:     "[\"Harry Potter-18-Privet Drive\",\"Ron Weasley-18-The Burrow\",\"Hermione Granger-19-Heathgate\"]",
 		},
 	}
 
@@ -191,7 +191,7 @@ func TestTextModifier_MultipleArrays(t *testing.T) {
 					{
 						Name:    "Hermione Granger",
 						Address: "Heathgate",
-						Age:     18,
+						Age:     19,
 					},
 				},
 			},
@@ -207,15 +207,15 @@ func TestTextModifier_MultipleArrays(t *testing.T) {
 	}{
 		"without custom column names": {
 			expression: "{textTestMultipleArrays.#.textTest.#.name,textTestMultipleArrays.#.textTest.#.age,textTestMultipleArrays.#.textTest.#.address}.@text",
-			result:     "[\"name Harry Potter\\nage 18\\naddress Privet Drive\",\"name Ron Weasley\\nage 18\\naddress The Burrow\",\"name Hermione Granger\\nage 18\\naddress Heathgate\"]",
+			result:     "[\"name Harry Potter\\nage 18\\naddress Privet Drive\",\"name Ron Weasley\\nage 18\\naddress The Burrow\",\"name Hermione Granger\\nage 19\\naddress Heathgate\"]",
 		},
 		"without modifier should not modify the output": {
 			expression: "{textTestMultipleArrays.#.textTest.#.name,textTestMultipleArrays.#.textTest.#.age,textTestMultipleArrays.#.textTest.#.address}",
-			result:     "{\"name\":[[\"Harry Potter\",\"Ron Weasley\",\"Hermione Granger\"]],\"age\":[[18,18,18]],\"address\":[[\"Privet Drive\",\"The Burrow\",\"Heathgate\"]]}",
+			result:     "{\"name\":[[\"Harry Potter\",\"Ron Weasley\",\"Hermione Granger\"]],\"age\":[[18,18,19]],\"address\":[[\"Privet Drive\",\"The Burrow\",\"Heathgate\"]]}",
 		},
 		"with custom column names": {
 			expression: "{\"Super Cool Name\":textTestMultipleArrays.#.textTest.#.name,textTestMultipleArrays.#.textTest.#.age,textTestMultipleArrays.#.textTest.#.address}.@text",
-			result:     "[\"Super Cool Name Harry Potter\\nage 18\\naddress Privet Drive\",\"Super Cool Name Ron Weasley\\nage 18\\naddress The Burrow\",\"Super Cool Name Hermione Granger\\nage 18\\naddress Heathgate\"]",
+			result:     "[\"Super Cool Name Harry Potter\\nage 18\\naddress Privet Drive\",\"Super Cool Name Ron Weasley\\nage 18\\naddress The Burrow\",\"Super Cool Name Hermione Granger\\nage 19\\naddress Heathgate\"]",
 		},
 		"with singular value": {
 			expression: "{textTestMultipleArrays.#.textTest.0.name,textTestMultipleArrays.#.textTest.0.age,textTestMultipleArrays.#.textTest.0.address}.@text",
@@ -223,15 +223,15 @@ func TestTextModifier_MultipleArrays(t *testing.T) {
 		},
 		"without printing keys": {
 			expression: `{textTestMultipleArrays.#.textTest.#.name,textTestMultipleArrays.#.textTest.#.age,textTestMultipleArrays.#.textTest.#.address}.@text:{"printKeys": "false"}`,
-			result:     "[\"Harry Potter\\n18\\nPrivet Drive\",\"Ron Weasley\\n18\\nThe Burrow\",\"Hermione Granger\\n18\\nHeathgate\"]",
+			result:     "[\"Harry Potter\\n18\\nPrivet Drive\",\"Ron Weasley\\n18\\nThe Burrow\",\"Hermione Granger\\n19\\nHeathgate\"]",
 		},
 		"with custom separator": {
 			expression: `{textTestMultipleArrays.#.textTest.#.name,textTestMultipleArrays.#.textTest.#.age,textTestMultipleArrays.#.textTest.#.address}.@text:{"customSeparator": "-"}`,
-			result:     "[\"name Harry Potter-age 18-address Privet Drive\",\"name Ron Weasley-age 18-address The Burrow\",\"name Hermione Granger-age 18-address Heathgate\"]",
+			result:     "[\"name Harry Potter-age 18-address Privet Drive\",\"name Ron Weasley-age 18-address The Burrow\",\"name Hermione Granger-age 19-address Heathgate\"]",
 		},
 		"without printing keys and with custom separator": {
 			expression: `{textTestMultipleArrays.#.textTest.#.name,textTestMultipleArrays.#.textTest.#.age,textTestMultipleArrays.#.textTest.#.address}.@text:{"customSeparator": "-", "printKeys": "false"}`,
-			result:     "[\"Harry Potter-18-Privet Drive\",\"Ron Weasley-18-The Burrow\",\"Hermione Granger-18-Heathgate\"]",
+			result:     "[\"Harry Potter-18-Privet Drive\",\"Ron Weasley-18-The Burrow\",\"Hermione Granger-19-Heathgate\"]",
 		},
 	}
 

--- a/pkg/gjson/modifiers_test.go
+++ b/pkg/gjson/modifiers_test.go
@@ -137,7 +137,7 @@ func TestTextModifier(t *testing.T) {
 	}{
 		"without custom column names": {
 			expression: "{textTest.#.name,textTest.#.age,textTest.#.address}.@text",
-			result:     "[\"name Harry Potter\\nage 18\\naddress Privet Drive\",\"name Ron Weasley\\nage 18\\naddress The Burrow\",\"name Hermione Granger\\nage 19\\naddress Heathgate\"]",
+			result:     "[\"name:\\tHarry Potter\\nage:\\t18\\naddress:\\tPrivet Drive\",\"name:\\tRon Weasley\\nage:\\t18\\naddress:\\tThe Burrow\",\"name:\\tHermione Granger\\nage:\\t19\\naddress:\\tHeathgate\"]",
 		},
 		"without modifier should not modify the output": {
 			expression: "{textTest.#.name,textTest.#.age,textTest.#.address}",
@@ -145,11 +145,11 @@ func TestTextModifier(t *testing.T) {
 		},
 		"with custom column names": {
 			expression: "{\"Super Cool Name\":textTest.#.name,textTest.#.age,textTest.#.address}.@text",
-			result:     "[\"Super Cool Name Harry Potter\\nage 18\\naddress Privet Drive\",\"Super Cool Name Ron Weasley\\nage 18\\naddress The Burrow\",\"Super Cool Name Hermione Granger\\nage 19\\naddress Heathgate\"]",
+			result:     "[\"Super Cool Name:\\tHarry Potter\\nage:\\t18\\naddress:\\tPrivet Drive\",\"Super Cool Name:\\tRon Weasley\\nage:\\t18\\naddress:\\tThe Burrow\",\"Super Cool Name:\\tHermione Granger\\nage:\\t19\\naddress:\\tHeathgate\"]",
 		},
 		"with singular value": {
 			expression: "{textTest.0.name,textTest.0.age,textTest.0.address}.@text",
-			result:     "[\"name Harry Potter\\nage 18\\naddress Privet Drive\"]",
+			result:     "[\"name:\\tHarry Potter\\nage:\\t18\\naddress:\\tPrivet Drive\"]",
 		},
 		"without printing keys": {
 			expression: `{textTest.#.name,textTest.#.age,textTest.#.address}.@text:{"printKeys": "false"}`,
@@ -157,7 +157,7 @@ func TestTextModifier(t *testing.T) {
 		},
 		"with custom separator": {
 			expression: `{textTest.#.name,textTest.#.age,textTest.#.address}.@text:{"customSeparator": "-"}`,
-			result:     "[\"name Harry Potter-age 18-address Privet Drive\",\"name Ron Weasley-age 18-address The Burrow\",\"name Hermione Granger-age 19-address Heathgate\"]",
+			result:     "[\"name:\\tHarry Potter-age:\\t18-address:\\tPrivet Drive\",\"name:\\tRon Weasley-age:\\t18-address:\\tThe Burrow\",\"name:\\tHermione Granger-age:\\t19-address:\\tHeathgate\"]",
 		},
 		"without printing keys and with custom separator": {
 			expression: `{textTest.#.name,textTest.#.age,textTest.#.address}.@text:{"customSeparator": "-", "printKeys": "false"}`,
@@ -207,7 +207,7 @@ func TestTextModifier_MultipleArrays(t *testing.T) {
 	}{
 		"without custom column names": {
 			expression: "{textTestMultipleArrays.#.textTest.#.name,textTestMultipleArrays.#.textTest.#.age,textTestMultipleArrays.#.textTest.#.address}.@text",
-			result:     "[\"name Harry Potter\\nage 18\\naddress Privet Drive\",\"name Ron Weasley\\nage 18\\naddress The Burrow\",\"name Hermione Granger\\nage 19\\naddress Heathgate\"]",
+			result:     "[\"name:\\tHarry Potter\\nage:\\t18\\naddress:\\tPrivet Drive\",\"name:\\tRon Weasley\\nage:\\t18\\naddress:\\tThe Burrow\",\"name:\\tHermione Granger\\nage:\\t19\\naddress:\\tHeathgate\"]",
 		},
 		"without modifier should not modify the output": {
 			expression: "{textTestMultipleArrays.#.textTest.#.name,textTestMultipleArrays.#.textTest.#.age,textTestMultipleArrays.#.textTest.#.address}",
@@ -215,11 +215,11 @@ func TestTextModifier_MultipleArrays(t *testing.T) {
 		},
 		"with custom column names": {
 			expression: "{\"Super Cool Name\":textTestMultipleArrays.#.textTest.#.name,textTestMultipleArrays.#.textTest.#.age,textTestMultipleArrays.#.textTest.#.address}.@text",
-			result:     "[\"Super Cool Name Harry Potter\\nage 18\\naddress Privet Drive\",\"Super Cool Name Ron Weasley\\nage 18\\naddress The Burrow\",\"Super Cool Name Hermione Granger\\nage 19\\naddress Heathgate\"]",
+			result:     "[\"Super Cool Name:\\tHarry Potter\\nage:\\t18\\naddress:\\tPrivet Drive\",\"Super Cool Name:\\tRon Weasley\\nage:\\t18\\naddress:\\tThe Burrow\",\"Super Cool Name:\\tHermione Granger\\nage:\\t19\\naddress:\\tHeathgate\"]",
 		},
 		"with singular value": {
 			expression: "{textTestMultipleArrays.#.textTest.0.name,textTestMultipleArrays.#.textTest.0.age,textTestMultipleArrays.#.textTest.0.address}.@text",
-			result:     "[\"name Harry Potter\\nage 18\\naddress Privet Drive\"]",
+			result:     "[\"name:\\tHarry Potter\\nage:\\t18\\naddress:\\tPrivet Drive\"]",
 		},
 		"without printing keys": {
 			expression: `{textTestMultipleArrays.#.textTest.#.name,textTestMultipleArrays.#.textTest.#.age,textTestMultipleArrays.#.textTest.#.address}.@text:{"printKeys": "false"}`,
@@ -227,7 +227,7 @@ func TestTextModifier_MultipleArrays(t *testing.T) {
 		},
 		"with custom separator": {
 			expression: `{textTestMultipleArrays.#.textTest.#.name,textTestMultipleArrays.#.textTest.#.age,textTestMultipleArrays.#.textTest.#.address}.@text:{"customSeparator": "-"}`,
-			result:     "[\"name Harry Potter-age 18-address Privet Drive\",\"name Ron Weasley-age 18-address The Burrow\",\"name Hermione Granger-age 19-address Heathgate\"]",
+			result:     "[\"name:\\tHarry Potter-age:\\t18-address:\\tPrivet Drive\",\"name:\\tRon Weasley-age:\\t18-address:\\tThe Burrow\",\"name:\\tHermione Granger-age:\\t19-address:\\tHeathgate\"]",
 		},
 		"without printing keys and with custom separator": {
 			expression: `{textTestMultipleArrays.#.textTest.#.name,textTestMultipleArrays.#.textTest.#.age,textTestMultipleArrays.#.textTest.#.address}.@text:{"customSeparator": "-", "printKeys": "false"}`,

--- a/pkg/gjson/modifiers_test.go
+++ b/pkg/gjson/modifiers_test.go
@@ -10,9 +10,10 @@ import (
 )
 
 type modifierTestObject struct {
-	List     []string                `json:"list"`
-	BoolTest []boolReplaceTestObject `json:"boolTest"`
-	TextTest []textReplaceTestObject `json:"textTest"`
+	List                   []string                `json:"list"`
+	BoolTest               []boolReplaceTestObject `json:"boolTest"`
+	TextTest               []textReplaceTestObject `json:"textTest"`
+	TextTestMultipleArrays []testTextMultipleArray `json:"textTestMultipleArrays"`
 }
 
 type boolReplaceTestObject struct {
@@ -23,6 +24,10 @@ type textReplaceTestObject struct {
 	Name    string `json:"name"`
 	Address string `json:"address"`
 	Age     int    `json:"age"`
+}
+
+type testTextMultipleArray struct {
+	TextTest []textReplaceTestObject `json:"textTest"`
 }
 
 func TestListModifier(t *testing.T) {
@@ -156,6 +161,76 @@ func TestTextModifier(t *testing.T) {
 		},
 		"without printing keys and with custom separator": {
 			expression: `{textTest.#.name,textTest.#.age,textTest.#.address}.@text:{"customSeparator": "-", "printKeys": "false"}`,
+			result:     "[\"Harry Potter-18-Privet Drive\",\"Ron Weasley-18-The Burrow\",\"Hermione Granger-18-Heathgate\"]",
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			res := gjson.GetBytes(bytes, c.expression)
+			assert.Equal(t, c.result, res.String())
+		})
+	}
+}
+
+func TestTextModifier_MultipleArrays(t *testing.T) {
+	testObjectWithMultipleArrays := &modifierTestObject{
+		TextTestMultipleArrays: []testTextMultipleArray{
+			{
+				TextTest: []textReplaceTestObject{
+					{
+						Name:    "Harry Potter",
+						Address: "Privet Drive",
+						Age:     18,
+					},
+					{
+						Name:    "Ron Weasley",
+						Address: "The Burrow",
+						Age:     18,
+					},
+					{
+						Name:    "Hermione Granger",
+						Address: "Heathgate",
+						Age:     18,
+					},
+				},
+			},
+		},
+	}
+
+	bytes, err := json.Marshal(testObjectWithMultipleArrays)
+	require.NoError(t, err)
+
+	cases := map[string]struct {
+		expression string
+		result     string
+	}{
+		"without custom column names": {
+			expression: "{textTestMultipleArrays.#.textTest.#.name,textTestMultipleArrays.#.textTest.#.age,textTestMultipleArrays.#.textTest.#.address}.@text",
+			result:     "[\"name Harry Potter\\nage 18\\naddress Privet Drive\",\"name Ron Weasley\\nage 18\\naddress The Burrow\",\"name Hermione Granger\\nage 18\\naddress Heathgate\"]",
+		},
+		"without modifier should not modify the output": {
+			expression: "{textTestMultipleArrays.#.textTest.#.name,textTestMultipleArrays.#.textTest.#.age,textTestMultipleArrays.#.textTest.#.address}",
+			result:     "{\"name\":[[\"Harry Potter\",\"Ron Weasley\",\"Hermione Granger\"]],\"age\":[[18,18,18]],\"address\":[[\"Privet Drive\",\"The Burrow\",\"Heathgate\"]]}",
+		},
+		"with custom column names": {
+			expression: "{\"Super Cool Name\":textTestMultipleArrays.#.textTest.#.name,textTestMultipleArrays.#.textTest.#.age,textTestMultipleArrays.#.textTest.#.address}.@text",
+			result:     "[\"Super Cool Name Harry Potter\\nage 18\\naddress Privet Drive\",\"Super Cool Name Ron Weasley\\nage 18\\naddress The Burrow\",\"Super Cool Name Hermione Granger\\nage 18\\naddress Heathgate\"]",
+		},
+		"with singular value": {
+			expression: "{textTestMultipleArrays.#.textTest.0.name,textTestMultipleArrays.#.textTest.0.age,textTestMultipleArrays.#.textTest.0.address}.@text",
+			result:     "[\"name Harry Potter\\nage 18\\naddress Privet Drive\"]",
+		},
+		"without printing keys": {
+			expression: `{textTestMultipleArrays.#.textTest.#.name,textTestMultipleArrays.#.textTest.#.age,textTestMultipleArrays.#.textTest.#.address}.@text:{"printKeys": "false"}`,
+			result:     "[\"Harry Potter\\n18\\nPrivet Drive\",\"Ron Weasley\\n18\\nThe Burrow\",\"Hermione Granger\\n18\\nHeathgate\"]",
+		},
+		"with custom separator": {
+			expression: `{textTestMultipleArrays.#.textTest.#.name,textTestMultipleArrays.#.textTest.#.age,textTestMultipleArrays.#.textTest.#.address}.@text:{"customSeparator": "-"}`,
+			result:     "[\"name Harry Potter-age 18-address Privet Drive\",\"name Ron Weasley-age 18-address The Burrow\",\"name Hermione Granger-age 18-address Heathgate\"]",
+		},
+		"without printing keys and with custom separator": {
+			expression: `{textTestMultipleArrays.#.textTest.#.name,textTestMultipleArrays.#.textTest.#.age,textTestMultipleArrays.#.textTest.#.address}.@text:{"customSeparator": "-", "printKeys": "false"}`,
 			result:     "[\"Harry Potter-18-Privet Drive\",\"Ron Weasley-18-The Burrow\",\"Hermione Granger-18-Heathgate\"]",
 		},
 	}

--- a/pkg/gjson/utils.go
+++ b/pkg/gjson/utils.go
@@ -1,6 +1,9 @@
 package gjson
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/tidwall/gjson"
 )
 
@@ -27,4 +30,31 @@ func getStringValuesFromNestedArrays(value gjson.Result, values []string) []stri
 		})
 	}
 	return values
+}
+
+// Expression is a gjson expression that can be used in multipath expressions.
+// The key is optional, in case a different, custom key should be used in the resulting JSON.
+type Expression struct {
+	Key        string
+	Expression string
+}
+
+// MultiPathExpression will generate a gjson compatible multipath expression string.
+func MultiPathExpression(modifier string, expressions ...Expression) string {
+	var sb strings.Builder
+	sb.WriteString("{")
+	for i, expression := range expressions {
+		if i != 0 {
+			sb.WriteString(",")
+		}
+		if expression.Key != "" {
+			sb.WriteString(fmt.Sprintf("%q:", expression.Key))
+		}
+		sb.WriteString(expression.Expression)
+	}
+	sb.WriteString("}")
+	if modifier != "" {
+		sb.WriteString(fmt.Sprintf(".%s", modifier))
+	}
+	return sb.String()
 }

--- a/pkg/printers/sarif.go
+++ b/pkg/printers/sarif.go
@@ -148,7 +148,8 @@ func addEntry(run *sarif.Run, entry sarifEntry, entity string, name string) {
 	rule := run.AddRule(entry.ruleID)
 	rule.WithName(name).
 		WithShortDescription(sarif.NewMultiformatMessageString(entry.description)).
-		WithFullDescription(sarif.NewMultiformatMessageString(entry.description)).
+		// Setting the full description is also setting the title displayed in GitHub.
+		WithFullDescription(sarif.NewMultiformatMessageString(entry.ruleID)).
 		WithHelp(sarif.NewMultiformatMessageString(entry.help))
 
 	if entry.helpLink != "" {

--- a/pkg/printers/sarif.go
+++ b/pkg/printers/sarif.go
@@ -198,13 +198,31 @@ func sarifEntriesFromJSONObject(jsonObject interface{}, pathExpressions map[stri
 	return sarifEntries, nil
 }
 
+// All our supported severities. We have different severities for policy violations and CVE violations, and the sarif
+// report printer shall be capable of handling both.
+var (
+	criticalVulnSeverity  = strings.TrimSuffix(storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY.String(), "_VULNERABILITY_SEVERITY")
+	importantVulnSeverity = strings.TrimSuffix(storage.VulnerabilitySeverity_IMPORTANT_VULNERABILITY_SEVERITY.String(), "_VULNERABILITY_SEVERITY")
+	moderateVulnSeverity  = strings.TrimSuffix(storage.VulnerabilitySeverity_MODERATE_VULNERABILITY_SEVERITY.String(), "_VULNERABILITY_SEVERITY")
+	lowVulnSeverity       = strings.TrimSuffix(storage.VulnerabilitySeverity_LOW_VULNERABILITY_SEVERITY.String(), "_VULNERABILITY_SEVERITY")
+
+	criticalPolicySeverity = strings.TrimSuffix(storage.Severity_CRITICAL_SEVERITY.String(), "_SEVERITY")
+	highPolicySeverity     = strings.TrimSuffix(storage.Severity_HIGH_SEVERITY.String(), "_SEVERITY")
+	mediumPolicySeverity   = strings.TrimSuffix(storage.Severity_MEDIUM_SEVERITY.String(), "_SEVERITY")
+	lowPolicySeverity      = strings.TrimSuffix(storage.Severity_LOW_SEVERITY.String(), "_SEVERITY")
+)
+
 func toSarifLevel(severity string) string {
+	// While this shouldn't be the case, let's be on the safe side and strip the enum suffix.
+	severity = strings.TrimSuffix(severity, "_VULNERABILITY_SEVERITY")
+	severity = strings.TrimSuffix(severity, "_SEVERITY")
+
 	switch severity {
-	case storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY.String():
+	case criticalVulnSeverity, criticalPolicySeverity, importantVulnSeverity, highPolicySeverity:
 		return "error"
-	case storage.VulnerabilitySeverity_MODERATE_VULNERABILITY_SEVERITY.String():
+	case moderateVulnSeverity, mediumPolicySeverity:
 		return "warning"
-	case storage.VulnerabilitySeverity_UNKNOWN_VULNERABILITY_SEVERITY.String(), storage.VulnerabilitySeverity_LOW_VULNERABILITY_SEVERITY.String():
+	case lowVulnSeverity, lowPolicySeverity:
 		return "note"
 	default:
 		return "none"

--- a/pkg/printers/sarif_test.go
+++ b/pkg/printers/sarif_test.go
@@ -43,7 +43,7 @@ func TestSarifPrinter_Print_Success(t *testing.T) {
 				ID:          "first-violation",
 				Description: "something about violation one",
 				Reason:      "something about misconfiguration",
-				Severity:    "HIGH",
+				Severity:    "IMPORTANT",
 			},
 			{
 				ID:          "second-violation",

--- a/pkg/printers/sarif_test.go
+++ b/pkg/printers/sarif_test.go
@@ -25,9 +25,8 @@ type violation struct {
 
 func TestSarifPrinter_Print_InvalidJSONPathExpressions(t *testing.T) {
 	expressions := map[string]string{
-		SarifRuleJSONPathExpressionKey:        "",
-		SarifDescriptionJSONPathExpressionKey: "",
-		SarifHelpJSONPathExpressionKey:        "",
+		SarifRuleJSONPathExpressionKey: "",
+		SarifHelpJSONPathExpressionKey: "",
 	}
 
 	printer := NewSarifPrinter(expressions, "", "")
@@ -61,10 +60,9 @@ func TestSarifPrinter_Print_Success(t *testing.T) {
 	}
 
 	expressions := map[string]string{
-		SarifRuleJSONPathExpressionKey:        "violations.#.id",
-		SarifDescriptionJSONPathExpressionKey: "violations.#.description",
-		SarifHelpJSONPathExpressionKey:        "violations.#.reason",
-		SarifSeverityJSONPathExpressionKey:    "violations.#.severity",
+		SarifRuleJSONPathExpressionKey:     "violations.#.id",
+		SarifHelpJSONPathExpressionKey:     "violations.#.reason",
+		SarifSeverityJSONPathExpressionKey: "violations.#.severity",
 	}
 
 	out := strings.Builder{}

--- a/pkg/printers/sarif_test.go
+++ b/pkg/printers/sarif_test.go
@@ -3,6 +3,7 @@ package printers
 import (
 	"os"
 	"path"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -74,5 +75,9 @@ func TestSarifPrinter_Print_Success(t *testing.T) {
 	err = printer.Print(obj, &out)
 	require.NoError(t, err)
 
-	assert.Equal(t, string(expectedOutput), out.String())
+	// Since the report contains the version, replace it specifically here.
+	exp, err := regexp.Compile(`"version": "3.*"`)
+	require.NoError(t, err)
+	output := exp.ReplaceAllString(out.String(), `"version": ""`)
+	assert.Equal(t, string(expectedOutput), output)
 }

--- a/pkg/printers/sarif_test.go
+++ b/pkg/printers/sarif_test.go
@@ -25,9 +25,9 @@ type violation struct {
 
 func TestSarifPrinter_Print_InvalidJSONPathExpressions(t *testing.T) {
 	expressions := map[string]string{
-		RuleJSONPathExpressionKey:        "",
-		DescriptionJSONPathExpressionKey: "",
-		HelpJSONPathExpressionKey:        "",
+		SarifRuleJSONPathExpressionKey:        "",
+		SarifDescriptionJSONPathExpressionKey: "",
+		SarifHelpJSONPathExpressionKey:        "",
 	}
 
 	printer := NewSarifPrinter(expressions, "", "")
@@ -61,17 +61,17 @@ func TestSarifPrinter_Print_Success(t *testing.T) {
 	}
 
 	expressions := map[string]string{
-		RuleJSONPathExpressionKey:        "violations.#.id",
-		DescriptionJSONPathExpressionKey: "violations.#.description",
-		HelpJSONPathExpressionKey:        "violations.#.reason",
-		SeverityJSONPathExpressionKey:    "violations.#.severity",
+		SarifRuleJSONPathExpressionKey:        "violations.#.id",
+		SarifDescriptionJSONPathExpressionKey: "violations.#.description",
+		SarifHelpJSONPathExpressionKey:        "violations.#.reason",
+		SarifSeverityJSONPathExpressionKey:    "violations.#.severity",
 	}
 
 	out := strings.Builder{}
 	expectedOutput, err := os.ReadFile(path.Join("testdata", "sarif_report.json"))
 	require.NoError(t, err)
 
-	printer := NewSarifPrinter(expressions, "docker.io/nginx:1.19", PolicyReport)
+	printer := NewSarifPrinter(expressions, "docker.io/nginx:1.19", SarifPolicyReport)
 	err = printer.Print(obj, &out)
 	require.NoError(t, err)
 

--- a/pkg/printers/testdata/sarif_report.json
+++ b/pkg/printers/testdata/sarif_report.json
@@ -68,9 +68,7 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endLine": 1,
-                  "endColumn": 1
+                  "endLine": 1
                 }
               }
             }
@@ -91,9 +89,7 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endLine": 1,
-                  "endColumn": 1
+                  "endLine": 1
                 }
               }
             }
@@ -114,9 +110,7 @@
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1,
-                  "endLine": 1,
-                  "endColumn": 1
+                  "endLine": 1
                 }
               }
             }

--- a/pkg/printers/testdata/sarif_report.json
+++ b/pkg/printers/testdata/sarif_report.json
@@ -1,0 +1,128 @@
+{
+  "version": "2.1.0",
+  "$schema": "https://json.schemastore.org/sarif-2.1.0-rtm.5.json",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "fullName": "roxctl command line utility",
+          "informationUri": "https://github.com/stackrox/stackrox",
+          "name": "roxctl",
+          "rules": [
+            {
+              "id": "first-violation",
+              "name": "PolicyViolations",
+              "shortDescription": {
+                "text": "something about violation one"
+              },
+              "fullDescription": {
+                "text": "something about violation one"
+              },
+              "help": {
+                "text": "something about misconfiguration"
+              }
+            },
+            {
+              "id": "second-violation",
+              "name": "PolicyViolations",
+              "shortDescription": {
+                "text": "something about violation two"
+              },
+              "fullDescription": {
+                "text": "something about violation two"
+              },
+              "help": {
+                "text": "something about vulnerabilities"
+              }
+            },
+            {
+              "id": "third-violation",
+              "name": "PolicyViolations",
+              "shortDescription": {
+                "text": "something about violation three"
+              },
+              "fullDescription": {
+                "text": "something about violation three"
+              },
+              "help": {
+                "text": "something about secrets"
+              }
+            }
+          ],
+          "version": ""
+        }
+      },
+      "results": [
+        {
+          "ruleId": "first-violation",
+          "ruleIndex": 0,
+          "level": "none",
+          "message": {
+            "text": "something about misconfiguration"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "docker.io/nginx:1.19"
+                },
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endLine": 1,
+                  "endColumn": 1
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "second-violation",
+          "ruleIndex": 1,
+          "level": "none",
+          "message": {
+            "text": "something about vulnerabilities"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "docker.io/nginx:1.19"
+                },
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endLine": 1,
+                  "endColumn": 1
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "third-violation",
+          "ruleIndex": 2,
+          "level": "none",
+          "message": {
+            "text": "something about secrets"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "docker.io/nginx:1.19"
+                },
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endLine": 1,
+                  "endColumn": 1
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/printers/testdata/sarif_report.json
+++ b/pkg/printers/testdata/sarif_report.json
@@ -56,7 +56,7 @@
         {
           "ruleId": "first-violation",
           "ruleIndex": 0,
-          "level": "none",
+          "level": "error",
           "message": {
             "text": "something about misconfiguration"
           },
@@ -79,7 +79,7 @@
         {
           "ruleId": "second-violation",
           "ruleIndex": 1,
-          "level": "none",
+          "level": "note",
           "message": {
             "text": "something about vulnerabilities"
           },
@@ -102,7 +102,7 @@
         {
           "ruleId": "third-violation",
           "ruleIndex": 2,
-          "level": "none",
+          "level": "error",
           "message": {
             "text": "something about secrets"
           },

--- a/pkg/printers/testdata/sarif_report.json
+++ b/pkg/printers/testdata/sarif_report.json
@@ -13,39 +13,60 @@
               "id": "first-violation",
               "name": "PolicyViolations",
               "shortDescription": {
-                "text": "something about violation one"
+                "text": "first-violation"
               },
               "fullDescription": {
-                "text": "something about violation one"
+                "text": "first-violation"
               },
               "help": {
                 "text": "something about misconfiguration"
+              },
+              "properties": {
+                "precision": "very-high",
+                "tags": [
+                  "policy-violation",
+                  "IMPORTANT"
+                ]
               }
             },
             {
               "id": "second-violation",
               "name": "PolicyViolations",
               "shortDescription": {
-                "text": "something about violation two"
+                "text": "second-violation"
               },
               "fullDescription": {
-                "text": "something about violation two"
+                "text": "second-violation"
               },
               "help": {
                 "text": "something about vulnerabilities"
+              },
+              "properties": {
+                "precision": "very-high",
+                "tags": [
+                  "policy-violation",
+                  "LOW"
+                ]
               }
             },
             {
               "id": "third-violation",
               "name": "PolicyViolations",
               "shortDescription": {
-                "text": "something about violation three"
+                "text": "third-violation"
               },
               "fullDescription": {
-                "text": "something about violation three"
+                "text": "third-violation"
               },
               "help": {
                 "text": "something about secrets"
+              },
+              "properties": {
+                "precision": "very-high",
+                "tags": [
+                  "policy-violation",
+                  "CRITICAL"
+                ]
               }
             }
           ],

--- a/roxctl/common/printer/objectprinter_factory.go
+++ b/roxctl/common/printer/objectprinter_factory.go
@@ -13,7 +13,7 @@ import (
 
 var (
 	// standardizedFormats holds all output formats that follow either an RFC standard or a de-facto standard
-	standardizedFormats = set.NewFrozenStringSet("json", "csv", "junit")
+	standardizedFormats = set.NewFrozenStringSet("json", "csv", "junit", "sarif")
 )
 
 func unsupportedOutputFormatError(format string, supportedFormats []string) error {

--- a/roxctl/common/printer/sarifprinter_factory.go
+++ b/roxctl/common/printer/sarifprinter_factory.go
@@ -1,0 +1,71 @@
+package printer
+
+import (
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/stackrox/rox/pkg/errox"
+	"github.com/stackrox/rox/pkg/printers"
+)
+
+var _ CustomPrinterFactory = (*SarifPrinterFactory)(nil)
+
+// SarifPrinterFactory holds all configuration options for a Sarif printer.
+type SarifPrinterFactory struct {
+	// jsonPathExpressions hold all required expressions to build a sarif report.
+	// The data is currently NOT expected to be given by the user. The map itself MUST contain the keys
+	jsonPathExpressions map[string]string
+
+	// The entity for which the report is created. This can either be a container image, or a Kubernetes YAML file.
+	entity *string
+
+	// The type of report that should be created.
+	// This is currently NOT expected to be given by the user, but rather be set by the command using the format.
+	// The values can be either printers.VulnerabilityReport or printers.PolicyReport.
+	reportType string
+}
+
+// NewSarifPrinterFactory creates a factory that is able to construct a printers.SarifPrinter from the given options.
+func NewSarifPrinterFactory(reportType string, jsonPathExpressions map[string]string, entity *string) *SarifPrinterFactory {
+	return &SarifPrinterFactory{
+		jsonPathExpressions: jsonPathExpressions,
+		entity:              entity,
+		reportType:          reportType,
+	}
+}
+
+// SupportedFormats list the supported formats of the factory.
+func (s *SarifPrinterFactory) SupportedFormats() []string {
+	return []string{"sarif"}
+}
+
+// AddFlags adds all printer specific flags to the cobra.Command.
+func (s *SarifPrinterFactory) AddFlags(_ *cobra.Command) {
+}
+
+// CreatePrinter will create a printers.SarifPrinter with the provided settings.
+func (s *SarifPrinterFactory) CreatePrinter(format string) (ObjectPrinter, error) {
+	if err := s.validate(); err != nil {
+		return nil, err
+	}
+
+	switch strings.ToLower(format) {
+	case "sarif":
+		return printers.NewSarifPrinter(s.jsonPathExpressions, *s.entity, s.reportType), nil
+	default:
+		return nil, errox.InvalidArgs.Newf("invalid output format used for sarif printer %q", format)
+	}
+}
+
+func (s *SarifPrinterFactory) validate() error {
+	if *s.entity == "" {
+		return errox.InvalidArgs.New("empty entity name given, please provide a name")
+	}
+
+	if s.reportType != printers.VulnerabilityReport && s.reportType != printers.PolicyReport {
+		return errox.InvariantViolation.Newf("report type must be either %s or %s, but was %s",
+			printers.VulnerabilityReport, printers.PolicyReport, s.reportType)
+	}
+
+	return nil
+}

--- a/roxctl/common/printer/sarifprinter_factory.go
+++ b/roxctl/common/printer/sarifprinter_factory.go
@@ -49,6 +49,10 @@ func (s *SarifPrinterFactory) CreatePrinter(format string) (ObjectPrinter, error
 		return nil, err
 	}
 
+	if *s.entity == "" {
+		return nil, errox.InvalidArgs.New("empty entity name given, please provide a name")
+	}
+
 	switch strings.ToLower(format) {
 	case "sarif":
 		return printers.NewSarifPrinter(s.jsonPathExpressions, *s.entity, s.reportType), nil
@@ -58,10 +62,6 @@ func (s *SarifPrinterFactory) CreatePrinter(format string) (ObjectPrinter, error
 }
 
 func (s *SarifPrinterFactory) validate() error {
-	if *s.entity == "" {
-		return errox.InvalidArgs.New("empty entity name given, please provide a name")
-	}
-
 	if s.reportType != printers.VulnerabilityReport && s.reportType != printers.PolicyReport {
 		return errox.InvariantViolation.Newf("report type must be either %s or %s, but was %s",
 			printers.VulnerabilityReport, printers.PolicyReport, s.reportType)

--- a/roxctl/common/printer/sarifprinter_factory.go
+++ b/roxctl/common/printer/sarifprinter_factory.go
@@ -21,7 +21,7 @@ type SarifPrinterFactory struct {
 
 	// The type of report that should be created.
 	// This is currently NOT expected to be given by the user, but rather be set by the command using the format.
-	// The values can be either printers.VulnerabilityReport or printers.PolicyReport.
+	// The values can be either printers.SarifVulnerabilityReport or printers.SarifPolicyReport.
 	reportType string
 }
 
@@ -62,9 +62,9 @@ func (s *SarifPrinterFactory) CreatePrinter(format string) (ObjectPrinter, error
 }
 
 func (s *SarifPrinterFactory) validate() error {
-	if s.reportType != printers.VulnerabilityReport && s.reportType != printers.PolicyReport {
+	if s.reportType != printers.SarifVulnerabilityReport && s.reportType != printers.SarifPolicyReport {
 		return errox.InvariantViolation.Newf("report type must be either %s or %s, but was %s",
-			printers.VulnerabilityReport, printers.PolicyReport, s.reportType)
+			printers.SarifVulnerabilityReport, printers.SarifPolicyReport, s.reportType)
 	}
 
 	return nil

--- a/roxctl/common/printer/sarifprinter_factory_test.go
+++ b/roxctl/common/printer/sarifprinter_factory_test.go
@@ -20,7 +20,7 @@ func TestSarifPrinterFactory_CreatePrinter(t *testing.T) {
 			factory: &SarifPrinterFactory{
 				jsonPathExpressions: map[string]string{},
 				entity:              &entityName,
-				reportType:          printers.VulnerabilityReport,
+				reportType:          printers.SarifVulnerabilityReport,
 			},
 			format: "sarif",
 		},
@@ -28,7 +28,7 @@ func TestSarifPrinterFactory_CreatePrinter(t *testing.T) {
 			factory: &SarifPrinterFactory{
 				jsonPathExpressions: map[string]string{},
 				entity:              &empty,
-				reportType:          printers.VulnerabilityReport,
+				reportType:          printers.SarifVulnerabilityReport,
 			},
 			format: "sarif",
 			err:    errox.InvalidArgs,
@@ -46,7 +46,7 @@ func TestSarifPrinterFactory_CreatePrinter(t *testing.T) {
 			factory: &SarifPrinterFactory{
 				jsonPathExpressions: map[string]string{},
 				entity:              &entityName,
-				reportType:          printers.VulnerabilityReport,
+				reportType:          printers.SarifVulnerabilityReport,
 			},
 			format: "junit",
 			err:    errox.InvalidArgs,

--- a/roxctl/common/printer/sarifprinter_factory_test.go
+++ b/roxctl/common/printer/sarifprinter_factory_test.go
@@ -1,0 +1,68 @@
+package printer
+
+import (
+	"testing"
+
+	"github.com/stackrox/rox/pkg/errox"
+	"github.com/stackrox/rox/pkg/printers"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSarifPrinterFactory_CreatePrinter(t *testing.T) {
+	entityName := "entity"
+	var empty string
+	cases := map[string]struct {
+		factory *SarifPrinterFactory
+		err     error
+		format  string
+	}{
+		"with valid values the printer should be created": {
+			factory: &SarifPrinterFactory{
+				jsonPathExpressions: map[string]string{},
+				entity:              &entityName,
+				reportType:          printers.VulnerabilityReport,
+			},
+			format: "sarif",
+		},
+		"fail with empty entity": {
+			factory: &SarifPrinterFactory{
+				jsonPathExpressions: map[string]string{},
+				entity:              &empty,
+				reportType:          printers.VulnerabilityReport,
+			},
+			format: "sarif",
+			err:    errox.InvalidArgs,
+		},
+		"fail with invalid report type": {
+			factory: &SarifPrinterFactory{
+				jsonPathExpressions: map[string]string{},
+				entity:              &entityName,
+				reportType:          "custom report",
+			},
+			format: "sarif",
+			err:    errox.InvariantViolation,
+		},
+		"fail with invalid format": {
+			factory: &SarifPrinterFactory{
+				jsonPathExpressions: map[string]string{},
+				entity:              &entityName,
+				reportType:          printers.VulnerabilityReport,
+			},
+			format: "junit",
+			err:    errox.InvalidArgs,
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			printer, err := c.factory.CreatePrinter(c.format)
+			if c.err != nil {
+				assert.ErrorIs(t, err, c.err)
+			} else {
+				assert.NoError(t, err)
+				_, ok := printer.(*printers.SarifPrinter)
+				assert.True(t, ok)
+			}
+		})
+	}
+}

--- a/roxctl/deployment/check/check.go
+++ b/roxctl/deployment/check/check.go
@@ -47,8 +47,7 @@ var (
 	}
 
 	sarifJSONPathExpressions = map[string]string{
-		printers.SarifRuleJSONPathExpressionKey:        "results.#.violatedPolicies.#.name",
-		printers.SarifDescriptionJSONPathExpressionKey: "results.#.violatedPolicies.#.description",
+		printers.SarifRuleJSONPathExpressionKey: "results.#.violatedPolicies.#.name",
 		printers.SarifHelpJSONPathExpressionKey: gjson.MultiPathExpression(
 			"@text",
 			gjson.Expression{

--- a/roxctl/deployment/check/check.go
+++ b/roxctl/deployment/check/check.go
@@ -83,9 +83,8 @@ var (
 func Command(cliEnvironment environment.Environment) *cobra.Command {
 	deploymentCheckCmd := &deploymentCheckCommand{env: cliEnvironment}
 
-	supportedObjectPrinters = append(supportedObjectPrinters,
-		printer.NewSarifPrinterFactory(printers.PolicyReport, sarifJSONPathExpressions, &deploymentCheckCmd.file))
-	objectPrinterFactory, err := printer.NewObjectPrinterFactory("table", supportedObjectPrinters...)
+	objectPrinterFactory, err := printer.NewObjectPrinterFactory("table", append(supportedObjectPrinters,
+		printer.NewSarifPrinterFactory(printers.PolicyReport, sarifJSONPathExpressions, &deploymentCheckCmd.file))...)
 	// this error should never occur, it would only occur if default values are invalid
 	utils.Must(err)
 

--- a/roxctl/deployment/check/check.go
+++ b/roxctl/deployment/check/check.go
@@ -47,9 +47,9 @@ var (
 	}
 
 	sarifJSONPathExpressions = map[string]string{
-		printers.RuleJSONPathExpressionKey:        "results.#.violatedPolicies.#.name",
-		printers.DescriptionJSONPathExpressionKey: "results.#.violatedPolicies.#.description",
-		printers.HelpJSONPathExpressionKey: gjson.MultiPathExpression(
+		printers.SarifRuleJSONPathExpressionKey:        "results.#.violatedPolicies.#.name",
+		printers.SarifDescriptionJSONPathExpressionKey: "results.#.violatedPolicies.#.description",
+		printers.SarifHelpJSONPathExpressionKey: gjson.MultiPathExpression(
 			"@text",
 			gjson.Expression{
 				Key:        "Policy",
@@ -68,7 +68,7 @@ var (
 				Expression: "results.#.violatedPolicies.#.remediation",
 			},
 		),
-		printers.SeverityJSONPathExpressionKey: "results.#.violatedPolicies.#.severity",
+		printers.SarifSeverityJSONPathExpressionKey: "results.#.violatedPolicies.#.severity",
 	}
 
 	// supported output formats with default values
@@ -84,7 +84,7 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 	deploymentCheckCmd := &deploymentCheckCommand{env: cliEnvironment}
 
 	objectPrinterFactory, err := printer.NewObjectPrinterFactory("table", append(supportedObjectPrinters,
-		printer.NewSarifPrinterFactory(printers.PolicyReport, sarifJSONPathExpressions, &deploymentCheckCmd.file))...)
+		printer.NewSarifPrinterFactory(printers.SarifPolicyReport, sarifJSONPathExpressions, &deploymentCheckCmd.file))...)
 	// this error should never occur, it would only occur if default values are invalid
 	utils.Must(err)
 

--- a/roxctl/deployment/check/check.go
+++ b/roxctl/deployment/check/check.go
@@ -47,28 +47,28 @@ var (
 	}
 
 	sarifJSONPathExpressions = map[string]string{
-		printers.RuleJSONPathExpressionKey:        "result.#.violatedPolicies.#.name",
-		printers.DescriptionJSONPathExpressionKey: "result.#.violatedPolicies.#.description",
+		printers.RuleJSONPathExpressionKey:        "results.#.violatedPolicies.#.name",
+		printers.DescriptionJSONPathExpressionKey: "results.#.violatedPolicies.#.description",
 		printers.HelpJSONPathExpressionKey: gjson.MultiPathExpression(
 			"@text",
 			gjson.Expression{
 				Key:        "Policy",
-				Expression: "result.#.violatedPolicies.#.name",
+				Expression: "results.#.violatedPolicies.#.name",
 			},
 			gjson.Expression{
 				Key:        "Severity",
-				Expression: "result.#.violatedPolicies.#.severity",
+				Expression: "results.#.violatedPolicies.#.severity",
 			},
 			gjson.Expression{
 				Key:        "Violations",
-				Expression: "results.#.violatedPolicies.violation.@list",
+				Expression: "results.#.violatedPolicies.#.violation.@list",
 			},
 			gjson.Expression{
 				Key:        "Remediation",
 				Expression: "results.#.violatedPolicies.#.remediation",
 			},
 		),
-		printers.SeverityJSONPathExpressionKey: "result.#.violatedPolicies.#.severity",
+		printers.SeverityJSONPathExpressionKey: "results.#.violatedPolicies.#.severity",
 	}
 
 	// supported output formats with default values

--- a/roxctl/image/check/check.go
+++ b/roxctl/image/check/check.go
@@ -48,17 +48,17 @@ var (
 	}
 
 	sarifJSONPathExpressions = map[string]string{
-		printers.RuleJSONPathExpressionKey:        "result.#.violatedPolicies.#.name",
-		printers.DescriptionJSONPathExpressionKey: "result.#.violatedPolicies.#.description",
+		printers.RuleJSONPathExpressionKey:        "results.#.violatedPolicies.#.name",
+		printers.DescriptionJSONPathExpressionKey: "results.#.violatedPolicies.#.description",
 		printers.HelpJSONPathExpressionKey: gjson.MultiPathExpression(
 			"@text",
 			gjson.Expression{
 				Key:        "Policy",
-				Expression: "result.#.violatedPolicies.#.name",
+				Expression: "results.#.violatedPolicies.#.name",
 			},
 			gjson.Expression{
 				Key:        "Severity",
-				Expression: "result.#.violatedPolicies.#.severity",
+				Expression: "results.#.violatedPolicies.#.severity",
 			},
 			gjson.Expression{
 				Key:        "Violations",
@@ -69,7 +69,7 @@ var (
 				Expression: "results.#.violatedPolicies.#.remediation",
 			},
 		),
-		printers.SeverityJSONPathExpressionKey: "result.#.violatedPolicies.#.severity",
+		printers.SeverityJSONPathExpressionKey: "results.#.violatedPolicies.#.severity",
 	}
 
 	// supported output formats with default values

--- a/roxctl/image/check/check.go
+++ b/roxctl/image/check/check.go
@@ -84,11 +84,8 @@ var (
 func Command(cliEnvironment environment.Environment) *cobra.Command {
 	imageCheckCmd := &imageCheckCommand{env: cliEnvironment}
 
-	// object printer factory - allows output formats of JSON, csv, table with table being the default
-	supportedObjectPrinters = append(supportedObjectPrinters,
-		printer.NewSarifPrinterFactory(printers.PolicyReport, sarifJSONPathExpressions, &imageCheckCmd.image))
-
-	objectPrinterFactory, err := printer.NewObjectPrinterFactory("table", supportedObjectPrinters...)
+	objectPrinterFactory, err := printer.NewObjectPrinterFactory("table", append(supportedObjectPrinters,
+		printer.NewSarifPrinterFactory(printers.PolicyReport, sarifJSONPathExpressions, &imageCheckCmd.image))...)
 	// the returned error only occurs when default values do not allow the creation of any printer, this should be considered
 	// a programming error rather than a user error
 	pkgUtils.Must(err)

--- a/roxctl/image/check/check.go
+++ b/roxctl/image/check/check.go
@@ -48,8 +48,7 @@ var (
 	}
 
 	sarifJSONPathExpressions = map[string]string{
-		printers.SarifRuleJSONPathExpressionKey:        "results.#.violatedPolicies.#.name",
-		printers.SarifDescriptionJSONPathExpressionKey: "results.#.violatedPolicies.#.description",
+		printers.SarifRuleJSONPathExpressionKey: "results.#.violatedPolicies.#.name",
 		printers.SarifHelpJSONPathExpressionKey: gjson.MultiPathExpression(
 			"@text",
 			gjson.Expression{

--- a/roxctl/image/check/check.go
+++ b/roxctl/image/check/check.go
@@ -48,9 +48,9 @@ var (
 	}
 
 	sarifJSONPathExpressions = map[string]string{
-		printers.RuleJSONPathExpressionKey:        "results.#.violatedPolicies.#.name",
-		printers.DescriptionJSONPathExpressionKey: "results.#.violatedPolicies.#.description",
-		printers.HelpJSONPathExpressionKey: gjson.MultiPathExpression(
+		printers.SarifRuleJSONPathExpressionKey:        "results.#.violatedPolicies.#.name",
+		printers.SarifDescriptionJSONPathExpressionKey: "results.#.violatedPolicies.#.description",
+		printers.SarifHelpJSONPathExpressionKey: gjson.MultiPathExpression(
 			"@text",
 			gjson.Expression{
 				Key:        "Policy",
@@ -62,14 +62,14 @@ var (
 			},
 			gjson.Expression{
 				Key:        "Violations",
-				Expression: "results.#.violatedPolicies.violation.@list",
+				Expression: "results.#.violatedPolicies.#.violation.@list",
 			},
 			gjson.Expression{
 				Key:        "Remediation",
 				Expression: "results.#.violatedPolicies.#.remediation",
 			},
 		),
-		printers.SeverityJSONPathExpressionKey: "results.#.violatedPolicies.#.severity",
+		printers.SarifSeverityJSONPathExpressionKey: "results.#.violatedPolicies.#.severity",
 	}
 
 	// supported output formats with default values
@@ -85,7 +85,7 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 	imageCheckCmd := &imageCheckCommand{env: cliEnvironment}
 
 	objectPrinterFactory, err := printer.NewObjectPrinterFactory("table", append(supportedObjectPrinters,
-		printer.NewSarifPrinterFactory(printers.PolicyReport, sarifJSONPathExpressions, &imageCheckCmd.image))...)
+		printer.NewSarifPrinterFactory(printers.SarifPolicyReport, sarifJSONPathExpressions, &imageCheckCmd.image))...)
 	// the returned error only occurs when default values do not allow the creation of any printer, this should be considered
 	// a programming error rather than a user error
 	pkgUtils.Must(err)

--- a/roxctl/image/scan/scan.go
+++ b/roxctl/image/scan/scan.go
@@ -98,9 +98,9 @@ var (
 func Command(cliEnvironment environment.Environment) *cobra.Command {
 	imageScanCmd := &imageScanCommand{env: cliEnvironment}
 
-	supportedObjectPrinters = append(supportedObjectPrinters,
-		printer.NewSarifPrinterFactory(printers.VulnerabilityReport, sarifJSONPathExpressions, &imageScanCmd.image))
-	objectPrinterFactory, err := printer.NewObjectPrinterFactory("table", supportedObjectPrinters...)
+	objectPrinterFactory, err := printer.NewObjectPrinterFactory("table",
+		append(supportedObjectPrinters,
+			printer.NewSarifPrinterFactory(printers.VulnerabilityReport, sarifJSONPathExpressions, &imageScanCmd.image))...)
 	// should not happen when using default values, must be a programming error
 	utils.Must(err)
 	// Set the Output Format to empty, so by default the new output format will not be used and the legacy one will be

--- a/roxctl/image/scan/scan.go
+++ b/roxctl/image/scan/scan.go
@@ -44,7 +44,7 @@ var (
 
 	// JSON Path expressions to use for sarif report generation
 	sarifJSONPathExpressions = map[string]string{
-		printers.RuleJSONPathExpressionKey: gjson.MultiPathExpression(
+		printers.SarifRuleJSONPathExpressionKey: gjson.MultiPathExpression(
 			`@text:{"printKeys":"false","customSeparator":"_"}`,
 			gjson.Expression{
 				Expression: "result.vulnerabilities.#.cveId",
@@ -56,8 +56,8 @@ var (
 				Expression: "result.vulnerabilities.#.componentVersion",
 			},
 		),
-		printers.DescriptionJSONPathExpressionKey: "result.vulnerabilities.#.cveInfo",
-		printers.HelpJSONPathExpressionKey: gjson.MultiPathExpression(
+		printers.SarifDescriptionJSONPathExpressionKey: "result.vulnerabilities.#.cveInfo",
+		printers.SarifHelpJSONPathExpressionKey: gjson.MultiPathExpression(
 			"@text",
 			gjson.Expression{
 				Key:        "Vulnerability",
@@ -84,7 +84,8 @@ var (
 				Expression: "result.vulnerabilities.#.componentFixedVersion",
 			},
 		),
-		printers.SeverityJSONPathExpressionKey: "result.vulnerabilities.#.cveSeverity",
+		printers.SarifSeverityJSONPathExpressionKey: "result.vulnerabilities.#.cveSeverity",
+		printers.SarifHelpLinkJSONPathExpressionKey: "result.vulnerabilities.#.cveInfo",
 	}
 
 	// supported output formats with default values
@@ -100,7 +101,7 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 
 	objectPrinterFactory, err := printer.NewObjectPrinterFactory("table",
 		append(supportedObjectPrinters,
-			printer.NewSarifPrinterFactory(printers.VulnerabilityReport, sarifJSONPathExpressions, &imageScanCmd.image))...)
+			printer.NewSarifPrinterFactory(printers.SarifVulnerabilityReport, sarifJSONPathExpressions, &imageScanCmd.image))...)
 	// should not happen when using default values, must be a programming error
 	utils.Must(err)
 	// Set the Output Format to empty, so by default the new output format will not be used and the legacy one will be

--- a/roxctl/image/scan/scan.go
+++ b/roxctl/image/scan/scan.go
@@ -56,7 +56,6 @@ var (
 				Expression: "result.vulnerabilities.#.componentVersion",
 			},
 		),
-		printers.SarifDescriptionJSONPathExpressionKey: "result.vulnerabilities.#.cveInfo",
 		printers.SarifHelpJSONPathExpressionKey: gjson.MultiPathExpression(
 			"@text",
 			gjson.Expression{

--- a/roxctl/image/scan/scan.go
+++ b/roxctl/image/scan/scan.go
@@ -11,7 +11,9 @@ import (
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/errox"
+	"github.com/stackrox/rox/pkg/gjson"
 	imageUtils "github.com/stackrox/rox/pkg/images/utils"
+	"github.com/stackrox/rox/pkg/printers"
 	"github.com/stackrox/rox/pkg/retry"
 	pkgCommon "github.com/stackrox/rox/pkg/roxctl/common"
 	"github.com/stackrox/rox/pkg/utils"
@@ -39,6 +41,52 @@ var (
 		"result.vulnerabilities.#.cveId," +
 		"result.vulnerabilities.#.cveSeverity," +
 		"result.vulnerabilities.#.cveInfo}"
+
+	// JSON Path expressions to use for sarif report generation
+	sarifJSONPathExpressions = map[string]string{
+		printers.RuleJSONPathExpressionKey: gjson.MultiPathExpression(
+			`@text:{"printKeys":"false","customSeparator":"_"}`,
+			gjson.Expression{
+				Expression: "result.vulnerabilities.#.cveId",
+			},
+			gjson.Expression{
+				Expression: "result.vulnerabilities.#.componentName",
+			},
+			gjson.Expression{
+				Expression: "result.vulnerabilities.#.componentVersion",
+			},
+		),
+		printers.DescriptionJSONPathExpressionKey: "result.vulnerabilities.#.cveInfo",
+		printers.HelpJSONPathExpressionKey: gjson.MultiPathExpression(
+			"@text",
+			gjson.Expression{
+				Key:        "Vulnerability",
+				Expression: "result.vulnerabilities.#.cveId",
+			},
+			gjson.Expression{
+				Key:        "Link",
+				Expression: "result.vulnerabilities.#.cveInfo",
+			},
+			gjson.Expression{
+				Key:        "Severity",
+				Expression: "result.vulnerabilities.#.cveSeverity",
+			},
+			gjson.Expression{
+				Key:        "Component",
+				Expression: "result.vulnerabilities.#.componentName",
+			},
+			gjson.Expression{
+				Key:        "Version",
+				Expression: "result.vulnerabilities.#.componentVersion",
+			},
+			gjson.Expression{
+				Key:        "Fixed Version",
+				Expression: "result.vulnerabilities.#.componentFixedVersion",
+			},
+		),
+		printers.SeverityJSONPathExpressionKey: "result.vulnerabilities.#.cveSeverity",
+	}
+
 	// supported output formats with default values
 	supportedObjectPrinters = []printer.CustomPrinterFactory{
 		printer.NewTabularPrinterFactoryWithAutoMerge(defaultImageScanHeaders, columnsToMerge, defaultImageScanJSONPathExpression),
@@ -50,6 +98,8 @@ var (
 func Command(cliEnvironment environment.Environment) *cobra.Command {
 	imageScanCmd := &imageScanCommand{env: cliEnvironment}
 
+	supportedObjectPrinters = append(supportedObjectPrinters,
+		printer.NewSarifPrinterFactory(printers.VulnerabilityReport, sarifJSONPathExpressions, &imageScanCmd.image))
 	objectPrinterFactory, err := printer.NewObjectPrinterFactory("table", supportedObjectPrinters...)
 	// should not happen when using default values, must be a programming error
 	utils.Must(err)


### PR DESCRIPTION
## Description

This PR adds the SARIF output format to roxctl.

The [SARIF output format](https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html) is a standard for analysis tools to share their results. Most notably, its required by GitHub to support publishing code scanning results ([more info can be found here](https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning)).

The following are noteworthy changes within this PR:
- a new custom modifier for gjson has been added: `@text`, which creates a single text from a JSON object. This is used to create a multiline help message within the SARIF report consisting of multiple values (e.g. a component's CVE, name, version, fixed version).
- a new printer that is capable of printing SARIF reports.
- commands which should make use of the SARIF output format have been adjusted to include their relevant JSON path expressions, the commands are: `roxctl image scan, roxctl image check, roxctl deployment check`.

Additional notes for the PR / caveats:
- Currenlty, the location within the SARIF report will be set, but to default values (i.e. line 1 column 1). We cannot leave the location empty, as it is required by the SARIF specification.
- The short and full description of a rule currently show the _same_ output. This is due to us not really having separate informations for the information.
- Currently, no markdown support is added within the report for messages. We may add this at a latter point.
- The library `github.com/owenrumney/go-sarif/v2/sarif` has been used to create the SARIF support. If we want to avoid pulling in the library in the future, we can generate required structs from [SARIF JSON 
schema](https://github.com/oasis-tcs/sarif-spec/blob/main/Documents/CommitteeSpecifications/2.1.0/sarif-schema-2.1.0.json). I decided against it simply for time reasons, but am happy to make the change in a follow-up.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

- see added unit tests.

Manual tests that the integration works with e.g. GitHub:
- Created a separate repository https://github.com/dhaus67/roxctl-sarif-test
- The [action](https://github.com/dhaus67/roxctl-sarif-test/blob/main/.github/workflows/scan.yaml) currently does the following: a) scan an image via an ACSCS instance b) upload the sarif format
- SARIF format output: https://github.com/dhaus67/roxctl-sarif-test/security/code-scanning

