### PR TITLE
ROX-16158: Don't populate components from node metadata if Features are provided

### DIFF
--- a/pkg/scanners/clairify/convert_test.go
+++ b/pkg/scanners/clairify/convert_test.go
@@ -84,11 +84,19 @@ func TestConvertNodeToVulnRequest(t *testing.T) {
 					},
 				},
 			},
+			kernelVersion:    "3.10.0-1127.13.1.el7.x86_64",
+			osImage:          "linux",
+			kubeletVersion:   "v1.14.8",
+			kubeProxyVersion: "v1.16.13-gke.401",
 			containerRuntime: &storage.ContainerRuntimeInfo{
 				Type:    storage.ContainerRuntime_UNKNOWN_CONTAINER_RUNTIME,
 				Version: "containerd://1.2.8",
 			},
 			expected: &v1.GetNodeVulnerabilitiesRequest{
+				KernelVersion:    "3.10.0-1127.13.1.el7.x86_64",
+				OsImage:          "linux",
+				KubeletVersion:   "v1.14.8",
+				KubeproxyVersion: "v1.16.13-gke.401",
 				Runtime: &v1.GetNodeVulnerabilitiesRequest_ContainerRuntime{
 					Name:    "containerd",
 					Version: "1.2.8",
@@ -244,6 +252,81 @@ func TestConvertVulnResponseToNodeScan(t *testing.T) {
 							Link: "link4",
 							SetFixedBy: &storage.EmbeddedVulnerability_FixedBy{
 								FixedBy: "4",
+							},
+							VulnerabilityType: storage.EmbeddedVulnerability_NODE_VULNERABILITY,
+						},
+					},
+				},
+			},
+		},
+		{
+			req: &v1.GetNodeVulnerabilitiesRequest{
+				KubeletVersion:   "v1.24.6+deccab3",
+				KubeproxyVersion: "v1.24.6+deccab3",
+				Runtime: &v1.GetNodeVulnerabilitiesRequest_ContainerRuntime{
+					Name:    "cri-o",
+					Version: "1.24.4-5.rhaos4.11.git57d7127.el8",
+				},
+				Components: &v1.Components{
+					Namespace:       "rhcos:4.11",
+					RhelContentSets: []string{"rhel-8-for-x86_64-appstream-rpms", "rhel-8-for-x86_64-baseos-rpms"},
+					RhelComponents: []*v1.RHELComponent{
+						{
+							Id:          int64(1),
+							Name:        "vim-minimal",
+							Namespace:   "rhel:8",
+							Version:     "2:7.4.629-6.el8",
+							Arch:        "x86_64",
+							Module:      "",
+							AddedBy:     "",
+							Cpes:        nil,
+							Executables: []*v1.Executable{},
+						},
+					},
+					OsComponents:       nil,
+					LanguageComponents: nil,
+				},
+			},
+			resp: &v1.GetNodeVulnerabilitiesResponse{
+				Features: []*v1.Feature{
+					{
+						Name:    "vim-minimal",
+						Version: "2:7.4.629-6.el8",
+						Vulnerabilities: []*v1.Vulnerability{
+							{
+								Name:    "CVE-2020-0000",
+								Link:    "link0",
+								FixedBy: "0",
+							},
+							{
+								Name:    "CVE-2020-1111",
+								Link:    "link1",
+								FixedBy: "1",
+							},
+						},
+					},
+				},
+				NodeNotes: []v1.NodeNote{v1.NodeNote_NODE_UNSUPPORTED, v1.NodeNote_NODE_KERNEL_UNSUPPORTED},
+			},
+			expectedNotes: []storage.NodeScan_Note{storage.NodeScan_UNSUPPORTED, storage.NodeScan_KERNEL_UNSUPPORTED},
+			expectedComponents: []*storage.EmbeddedNodeScanComponent{
+				{
+					Name:    "vim-minimal",
+					Version: "2:7.4.629-6.el8",
+					Vulns: []*storage.EmbeddedVulnerability{
+						{
+							Cve:  "CVE-2020-0000",
+							Link: "link0",
+							SetFixedBy: &storage.EmbeddedVulnerability_FixedBy{
+								FixedBy: "0",
+							},
+							VulnerabilityType: storage.EmbeddedVulnerability_NODE_VULNERABILITY,
+						},
+						{
+							Cve:  "CVE-2020-1111",
+							Link: "link1",
+							SetFixedBy: &storage.EmbeddedVulnerability_FixedBy{
+								FixedBy: "1",
 							},
 							VulnerabilityType: storage.EmbeddedVulnerability_NODE_VULNERABILITY,
 						},


### PR DESCRIPTION
## Description

If the field `Features` exists and is populated, it should include all the required components in the scanned inventory, and using the metadata to populate components is redundant and unnecessary. It is only relevant if performing non-host-level node scanning.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added

### N/A

- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

UTs and manual testing. Cluster `jvdm-argilo`, screenshot:

![image](https://user-images.githubusercontent.com/291493/227381035-dd350630-4dcd-4eb5-a4d0-922b67d52ffc.png)
