### PR TITLE
ROX-16134: Remove the selection of anomalous/baseline flows from the advanced filters

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/common/AdvancedFlowsFilter/AdvancedFlowsFilter.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/common/AdvancedFlowsFilter/AdvancedFlowsFilter.tsx
@@ -12,21 +12,18 @@ import { AdvancedFlowsFilterType } from './types';
 import { filtersToSelections, selectionsToFilters } from './advancedFlowsFilterUtils';
 
 export type AdvancedFlowsFilterProps = {
-    isBaseline?: boolean;
     filters: AdvancedFlowsFilterType;
     setFilters: React.Dispatch<React.SetStateAction<AdvancedFlowsFilterType>>;
     allUniquePorts: string[];
 };
 
 export const defaultAdvancedFlowsFilters: AdvancedFlowsFilterType = {
-    flows: [],
     directionality: [],
     protocols: [],
     ports: [],
 };
 
 function AdvancedFlowsFilter({
-    isBaseline = false,
     filters,
     setFilters,
     allUniquePorts,
@@ -84,14 +81,6 @@ function AdvancedFlowsFilter({
             isGrouped
             position={SelectPosition.right}
         >
-            {!isBaseline ? (
-                <SelectGroup label="Deployment flows">
-                    <SelectOption value="anomalous">Anomalous flows</SelectOption>
-                    <SelectOption value="baseline">Baselined flows</SelectOption>
-                </SelectGroup>
-            ) : (
-                <></>
-            )}
             <SelectGroup label="Flow directionality">
                 <SelectOption value="ingress">Ingress (inbound)</SelectOption>
                 <SelectOption value="egress">Egress (outbound)</SelectOption>

--- a/ui/apps/platform/src/Containers/NetworkGraph/common/AdvancedFlowsFilter/types.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/common/AdvancedFlowsFilter/types.ts
@@ -1,15 +1,12 @@
-type Flows = 'anomalous' | 'baseline';
-
 type Directionality = 'egress' | 'ingress';
 
 type Protocols = 'L4_PROTOCOL_TCP' | 'L4_PROTOCOL_UDP';
 
 type Ports = string; // number format
 
-export type FilterValue = Flows | Directionality | Protocols | Ports;
+export type FilterValue = Directionality | Protocols | Ports;
 
 export type AdvancedFlowsFilterType = {
-    flows: Flows[];
     directionality: Directionality[];
     protocols: Protocols[];
     ports: Ports[];

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentBaseline.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentBaseline.tsx
@@ -194,7 +194,6 @@ function DeploymentBaselines({ deployment, deploymentId, onNodeSelect }: Deploym
                         </FlexItem>
                         <FlexItem>
                             <AdvancedFlowsFilter
-                                isBaseline
                                 filters={advancedFilters}
                                 setFilters={setAdvancedFilters}
                                 allUniquePorts={allUniquePorts}

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/flowUtils.test.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/flowUtils.test.ts
@@ -400,7 +400,6 @@ describe('flowUtils', () => {
             ];
             const entityNameFilter = 'deployment2';
             const advancedFilters: AdvancedFlowsFilterType = {
-                flows: ['baseline'],
                 directionality: ['ingress'],
                 protocols: ['L4_PROTOCOL_TCP'],
                 ports: ['8443'],

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/flowUtils.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/flowUtils.ts
@@ -180,7 +180,6 @@ export function filterNetworkFlows(
 ): Flow[] {
     const filteredFlows = flows.filter((flow) => {
         let matchedEntityName = false;
-        let matchedFlowType = true;
         let matchedDirectionality = true;
         const matchedProtocol = true;
         let matchedPort = true;
@@ -188,15 +187,6 @@ export function filterNetworkFlows(
         // check filtering by entity name
         if (flow.entity.includes(entityNameFilter)) {
             matchedEntityName = true;
-        }
-
-        // check filtering by flow type
-        if (advancedFilters.flows.length) {
-            const isAnomalousFiltered =
-                advancedFilters.flows.includes('anomalous') && flow.isAnomalous;
-            const isBaselineFiltered =
-                advancedFilters.flows.includes('baseline') && !flow.isAnomalous;
-            matchedFlowType = isAnomalousFiltered || isBaselineFiltered;
         }
 
         // check filtering by directionality
@@ -224,13 +214,7 @@ export function filterNetworkFlows(
             matchedPort = false;
         }
 
-        return (
-            matchedEntityName &&
-            matchedFlowType &&
-            matchedDirectionality &&
-            matchedProtocol &&
-            matchedPort
-        );
+        return matchedEntityName && matchedDirectionality && matchedProtocol && matchedPort;
     });
     return filteredFlows;
 }


### PR DESCRIPTION
## Description

This PR removes the option of filtering by anomalous/baseline flows in the advanced filters. Since we will be separating the anomalous and baseline flows into separate expandable sections (https://github.com/stackrox/stackrox/pull/5351), the need for these filter options will be less useful

Note: I won't branch this off of https://github.com/stackrox/stackrox/pull/5351 as it'll take much longer to get it merged

<img width="1552" alt="Screenshot 2023-03-23 at 10 34 06 AM" src="https://user-images.githubusercontent.com/4805485/227290363-a2d3030f-e85f-49a7-b28d-38d228ad5693.png">
<img width="1552" alt="Screenshot 2023-03-23 at 10 34 09 AM" src="https://user-images.githubusercontent.com/4805485/227290375-142d241c-b0ad-4a44-9a00-1eb1761ee426.png">
