### PR TITLE
Fix flaky watch handler test

### DIFF
--- a/central/declarativeconfig/watch_handler.go
+++ b/central/declarativeconfig/watch_handler.go
@@ -56,7 +56,7 @@ func (w *watchHandler) OnChange(dir string) (interface{}, error) {
 		}
 		entryContents, err := readDeclarativeConfigFile(path.Join(dir, entry.Name()))
 		if err != nil {
-			log.Errorf("Error reading file %s: %+v", entry.Name(), err)
+			log.Errorf("Error reading file %s: %v", entry.Name(), err)
 			continue
 		}
 		declarativeConfigFiles[entry.Name()] = entryContents
@@ -93,7 +93,7 @@ func (w *watchHandler) OnStableUpdate(val interface{}, err error) {
 }
 
 func (w *watchHandler) OnWatchError(err error) {
-	log.Errorf("Error watching declarative configuration directory: %+v", err)
+	log.Errorf("Error watching declarative configuration directory: %v", err)
 }
 
 // compareHashesForChanges compares the file contents for changes based on previous hashes stored for this handler.

--- a/central/declarativeconfig/watch_handler_test.go
+++ b/central/declarativeconfig/watch_handler_test.go
@@ -126,7 +126,7 @@ func TestWatchHandler_WithEmptyDirectory(t *testing.T) {
 
 	wh := newWatchHandler("empty-directory", updaterMock)
 	opts := k8scfgwatch.Options{
-		Interval: 10 * time.Millisecond,
+		Interval: 100 * time.Millisecond,
 	}
 
 	dirToWatch := t.TempDir()
@@ -164,7 +164,7 @@ func TestWatchHandler_WithEmptyDirectory(t *testing.T) {
 		wh.mutex.RLock()
 		defer wh.mutex.RUnlock()
 		return maputil.Equal(expectedCache, wh.cachedFileHashes)
-	}, 100*time.Millisecond, 10*time.Millisecond)
+	}, 500*time.Millisecond, 100*time.Millisecond)
 }
 
 func TestWatchHandler_WithPrefilledDirectory(t *testing.T) {
@@ -173,7 +173,7 @@ func TestWatchHandler_WithPrefilledDirectory(t *testing.T) {
 
 	wh := newWatchHandler("prefilled-directory", updaterMock)
 	opts := k8scfgwatch.Options{
-		Interval: 10 * time.Millisecond,
+		Interval: 100 * time.Millisecond,
 	}
 
 	dirToWatch := t.TempDir()
@@ -212,7 +212,7 @@ func TestWatchHandler_WithPrefilledDirectory(t *testing.T) {
 		wh.mutex.RLock()
 		defer wh.mutex.RUnlock()
 		return maputil.Equal(expectedCache, wh.cachedFileHashes)
-	}, 100*time.Millisecond, 10*time.Millisecond)
+	}, 500*time.Millisecond, 100*time.Millisecond)
 
 	// 4.  Add another valid YAML file to the directory the handler will be watching.
 	permissionSet := declarativeconfig.PermissionSet{
@@ -246,7 +246,7 @@ func TestWatchHandler_WithPrefilledDirectory(t *testing.T) {
 		wh.mutex.RLock()
 		defer wh.mutex.RUnlock()
 		return maputil.Equal(expectedCache, wh.cachedFileHashes)
-	}, 100*time.Millisecond, 10*time.Millisecond)
+	}, 500*time.Millisecond, 100*time.Millisecond)
 }
 
 func TestWatchHandler_WithRemovedFiles(t *testing.T) {
@@ -255,7 +255,7 @@ func TestWatchHandler_WithRemovedFiles(t *testing.T) {
 
 	wh := newWatchHandler("removed-files", updaterMock)
 	opts := k8scfgwatch.Options{
-		Interval: 10 * time.Millisecond,
+		Interval: 100 * time.Millisecond,
 	}
 
 	dirToWatch := t.TempDir()
@@ -293,7 +293,7 @@ func TestWatchHandler_WithRemovedFiles(t *testing.T) {
 		wh.mutex.RLock()
 		defer wh.mutex.RUnlock()
 		return maputil.Equal(expectedCache, wh.cachedFileHashes)
-	}, 100*time.Millisecond, 10*time.Millisecond)
+	}, 500*time.Millisecond, 100*time.Millisecond)
 
 	// 4.Set the expected calls to the updater.
 	updaterMock.EXPECT().UpdateDeclarativeConfigContents("removed-files", [][]byte{})
@@ -308,5 +308,5 @@ func TestWatchHandler_WithRemovedFiles(t *testing.T) {
 		wh.mutex.RLock()
 		defer wh.mutex.RUnlock()
 		return maputil.Equal(expectedCache, wh.cachedFileHashes)
-	}, 100*time.Millisecond, 10*time.Millisecond)
+	}, 500*time.Millisecond, 100*time.Millisecond)
 }


### PR DESCRIPTION
## Description

There has been an instance where the watch handler test for declarative config has been flaky: https://github.com/stackrox/stackrox/actions/runs/4503411483

Looking at the test in question, it seems like we are missing a call to the `UpdateDeclarativeConfigContents`.

Locally, it was reproducible when running the tests multiple times, i.e. with `-test.count 500`.

The culprit seems to be the low interval we use. Using a more relaxed interval (100ms instead of 10ms) seemed to have fixed the flakiness, at the very least from the first glance locally.

Furthermore did a small QoL change: instead of printing the errors with `%+v` which included too much information, resorted back to `%v`.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

- unit tests. 
