### PR TITLE
ROX-16129: Add container info to NG 2.0 deployment details

### DIFF
--- a/ui/apps/platform/src/Components/ContainerArgumentsInfo.tsx
+++ b/ui/apps/platform/src/Components/ContainerArgumentsInfo.tsx
@@ -1,0 +1,34 @@
+import React, { CSSProperties } from 'react';
+import { Card, CardBody, CardTitle, EmptyState, List, ListItem } from '@patternfly/react-core';
+
+type ContainerArgumentsInfoProps = {
+    args: string[];
+};
+
+const styleConstant = {
+    overflow: 'scroll',
+    '--pf-u-max-height--MaxHeight': '12ch',
+} as CSSProperties;
+
+function ContainerArgumentsInfo({ args }: ContainerArgumentsInfoProps) {
+    return (
+        <Card>
+            <CardTitle>Arguments</CardTitle>
+            {args.length > 0 ? (
+                <CardBody className="pf-u-background-color-200 pf-u-pt-lg pf-u-mx-lg pf-u-mb-lg">
+                    <List isPlain className="pf-u-max-height" style={styleConstant}>
+                        {args.map((arg) => (
+                            <ListItem>--{arg}</ListItem>
+                        ))}
+                    </List>
+                </CardBody>
+            ) : (
+                <CardBody>
+                    <EmptyState>No arguments</EmptyState>
+                </CardBody>
+            )}
+        </Card>
+    );
+}
+
+export default ContainerArgumentsInfo;

--- a/ui/apps/platform/src/Components/ContainerCommandInfo.tsx
+++ b/ui/apps/platform/src/Components/ContainerCommandInfo.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Card, CardBody, CardTitle, EmptyState, List, ListItem } from '@patternfly/react-core';
+
+type ContainerCommandsInfoProps = {
+    command: string[]; // note: the k8s API, and our data of it, use singular "command" for this array
+};
+
+function ContainerCommandsInfo({ command }: ContainerCommandsInfoProps) {
+    return (
+        <Card>
+            <CardTitle>Commands</CardTitle>
+            {command.length > 0 ? (
+                <CardBody className="">
+                    <List isPlain>
+                        {command.map((arg) => (
+                            <ListItem>{arg}</ListItem>
+                        ))}
+                    </List>
+                </CardBody>
+            ) : (
+                <CardBody>
+                    <EmptyState>No commands</EmptyState>
+                </CardBody>
+            )}
+        </Card>
+    );
+}
+
+export default ContainerCommandsInfo;

--- a/ui/apps/platform/src/Components/ContainerCommandInfo.tsx
+++ b/ui/apps/platform/src/Components/ContainerCommandInfo.tsx
@@ -1,19 +1,19 @@
 import React from 'react';
 import { Card, CardBody, CardTitle, EmptyState, List, ListItem } from '@patternfly/react-core';
 
-type ContainerCommandsInfoProps = {
+type ContainerCommandInfoProps = {
     command: string[]; // note: the k8s API, and our data of it, use singular "command" for this array
 };
 
-function ContainerCommandsInfo({ command }: ContainerCommandsInfoProps) {
+function ContainerCommandInfo({ command }: ContainerCommandInfoProps) {
     return (
         <Card>
             <CardTitle>Commands</CardTitle>
             {command.length > 0 ? (
-                <CardBody className="">
+                <CardBody>
                     <List isPlain>
-                        {command.map((arg) => (
-                            <ListItem>{arg}</ListItem>
+                        {command.map((cmd) => (
+                            <ListItem>{cmd}</ListItem>
                         ))}
                     </List>
                 </CardBody>
@@ -26,4 +26,4 @@ function ContainerCommandsInfo({ command }: ContainerCommandsInfoProps) {
     );
 }
 
-export default ContainerCommandsInfo;
+export default ContainerCommandInfo;

--- a/ui/apps/platform/src/Components/ContainerImageInfo.tsx
+++ b/ui/apps/platform/src/Components/ContainerImageInfo.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { Card, CardBody, CardTitle } from '@patternfly/react-core';
+
+import { vulnManagementPath } from 'routePaths';
+import { ContainerImage } from 'types/deployment.proto';
+
+type ContainerImageInfoProps = {
+    image: ContainerImage; // note: the k8s API, and our data of it, use singular "command" for this array
+};
+
+function ContainerImageInfo({ image }: ContainerImageInfoProps) {
+    if (image.id === '' || image.notPullable) {
+        const unavailableText = image.notPullable
+            ? 'image not currently pullable'
+            : 'image not available until deployment is running';
+        return (
+            <Card>
+                <CardTitle>Image</CardTitle>
+                <CardBody>
+                    <span>{image.name.fullName}</span> <em>({unavailableText})</em>
+                </CardBody>
+            </Card>
+        );
+    }
+
+    return (
+        <Card>
+            <CardTitle>Image</CardTitle>
+            <CardBody>
+                <Link to={`${vulnManagementPath}/image/${image.id}`}>{image.name.fullName}</Link>
+            </CardBody>
+        </Card>
+    );
+}
+
+export default ContainerImageInfo;

--- a/ui/apps/platform/src/Components/ContainerResouresInfo.tsx
+++ b/ui/apps/platform/src/Components/ContainerResouresInfo.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import {
+    Card,
+    CardBody,
+    CardTitle,
+    DescriptionList,
+    DescriptionListDescription,
+    DescriptionListGroup,
+    DescriptionListTerm,
+} from '@patternfly/react-core';
+
+import { ContainerResources } from 'types/deployment.proto';
+
+type ContainerResourcesInfoProps = {
+    resources: ContainerResources;
+};
+
+function ContainerResourcesInfo({ resources }: ContainerResourcesInfoProps) {
+    return (
+        <Card>
+            <CardTitle>Resources</CardTitle>
+            <CardBody className="pf-u-background-color-200 pf-u-pt-xl pf-u-mx-lg pf-u-mb-lg">
+                <DescriptionList columnModifier={{ default: '2Col' }} isCompact>
+                    <DescriptionListGroup>
+                        <DescriptionListTerm>CPU requests (cores)</DescriptionListTerm>
+                        <DescriptionListDescription>
+                            {resources.cpuCoresRequest}
+                        </DescriptionListDescription>
+                    </DescriptionListGroup>
+                    <DescriptionListGroup>
+                        <DescriptionListTerm>CPU limet (cores)</DescriptionListTerm>
+                        <DescriptionListDescription>
+                            {resources.cpuCoresLimit}
+                        </DescriptionListDescription>
+                    </DescriptionListGroup>
+                    <DescriptionListGroup>
+                        <DescriptionListTerm>Memory requests (MB)</DescriptionListTerm>
+                        <DescriptionListDescription>
+                            {resources.memoryMbRequest}
+                        </DescriptionListDescription>
+                    </DescriptionListGroup>
+                    <DescriptionListGroup>
+                        <DescriptionListTerm>Memory limit (MB)</DescriptionListTerm>
+                        <DescriptionListDescription>
+                            {resources.memoryMbLimit}
+                        </DescriptionListDescription>
+                    </DescriptionListGroup>
+                </DescriptionList>
+            </CardBody>
+        </Card>
+    );
+}
+
+export default ContainerResourcesInfo;

--- a/ui/apps/platform/src/Components/ContainerSecretsInfo.tsx
+++ b/ui/apps/platform/src/Components/ContainerSecretsInfo.tsx
@@ -1,0 +1,70 @@
+import React, { useState } from 'react';
+import {
+    Card,
+    CardBody,
+    CardTitle,
+    DescriptionList,
+    DescriptionListDescription,
+    DescriptionListGroup,
+    DescriptionListTerm,
+    EmptyState,
+    ExpandableSection,
+    Stack,
+    StackItem,
+} from '@patternfly/react-core';
+
+import { EmbeddedSecret } from 'types/deployment.proto';
+
+type ContainerSecretInfoProps = {
+    secrets: EmbeddedSecret[];
+};
+
+function ContainerSecretInfo({ secrets }: ContainerSecretInfoProps) {
+    const initialToggleValues = Array.from({ length: secrets.length }, () => true);
+    const [secretToggles, setSecretToggles] = useState(initialToggleValues);
+
+    function setToggleAtIndex(i) {
+        const newToggles = [...secretToggles];
+        newToggles[i] = !newToggles[i];
+
+        setSecretToggles(newToggles);
+    }
+
+    return (
+        <Card>
+            <CardTitle>Secrets</CardTitle>
+            <CardBody>
+                <Stack hasGutter>
+                    {secrets.length > 0 ? (
+                        secrets.map((secret, index) => (
+                            <StackItem>
+                                <ExpandableSection
+                                    toggleText={secret.name}
+                                    onToggle={() => setToggleAtIndex(index)}
+                                    isExpanded={secretToggles[index]}
+                                    className="pf-expandable-not-large"
+                                >
+                                    <DescriptionList
+                                        isCompact
+                                        className="pf-u-background-color-200 pf-u-p-md"
+                                    >
+                                        <DescriptionListGroup>
+                                            <DescriptionListTerm>Source</DescriptionListTerm>
+                                            <DescriptionListDescription>
+                                                {secret.path}
+                                            </DescriptionListDescription>
+                                        </DescriptionListGroup>
+                                    </DescriptionList>
+                                </ExpandableSection>
+                            </StackItem>
+                        ))
+                    ) : (
+                        <EmptyState>No secrets</EmptyState>
+                    )}
+                </Stack>
+            </CardBody>
+        </Card>
+    );
+}
+
+export default ContainerSecretInfo;

--- a/ui/apps/platform/src/Components/ContainerVolumesInfo.tsx
+++ b/ui/apps/platform/src/Components/ContainerVolumesInfo.tsx
@@ -1,0 +1,97 @@
+import React, { useState } from 'react';
+import {
+    Card,
+    CardBody,
+    CardTitle,
+    DescriptionList,
+    DescriptionListDescription,
+    DescriptionListGroup,
+    DescriptionListTerm,
+    EmptyState,
+    ExpandableSection,
+    Stack,
+    StackItem,
+} from '@patternfly/react-core';
+
+import { ContainerVolume } from 'types/deployment.proto';
+
+type ContainerVolumeInfoProps = {
+    volumes: ContainerVolume[];
+};
+
+function ContainerVolumeInfo({ volumes }: ContainerVolumeInfoProps) {
+    const initialToggleValues = Array.from({ length: volumes.length }, () => true);
+    const [volumeToggles, setVolumeToggles] = useState(initialToggleValues);
+
+    function setToggleAtIndex(i) {
+        const newToggles = [...volumeToggles];
+        newToggles[i] = !newToggles[i];
+
+        setVolumeToggles(newToggles);
+    }
+
+    return (
+        <Card>
+            <CardTitle>Volumes</CardTitle>
+            <CardBody>
+                <Stack hasGutter>
+                    {volumes.length > 0 ? (
+                        volumes.map((volume, index) => (
+                            <StackItem>
+                                <ExpandableSection
+                                    toggleText={volume.name}
+                                    onToggle={() => setToggleAtIndex(index)}
+                                    isExpanded={volumeToggles[index]}
+                                    className="pf-expandable-not-large"
+                                >
+                                    <DescriptionList
+                                        columnModifier={{ default: '2Col' }}
+                                        isCompact
+                                        className="pf-u-background-color-200 pf-u-p-md"
+                                    >
+                                        <DescriptionListGroup>
+                                            <DescriptionListTerm>Source</DescriptionListTerm>
+                                            <DescriptionListDescription>
+                                                {volume.source || '-'}
+                                            </DescriptionListDescription>
+                                        </DescriptionListGroup>
+                                        <DescriptionListGroup>
+                                            <DescriptionListTerm>Destination</DescriptionListTerm>
+                                            <DescriptionListDescription>
+                                                {volume.destination || '-'}
+                                            </DescriptionListDescription>
+                                        </DescriptionListGroup>
+                                        <DescriptionListGroup>
+                                            <DescriptionListTerm>Read only</DescriptionListTerm>
+                                            <DescriptionListDescription>
+                                                {volume.readOnly || 'false'}
+                                            </DescriptionListDescription>
+                                        </DescriptionListGroup>
+                                        <DescriptionListGroup>
+                                            <DescriptionListTerm>Type</DescriptionListTerm>
+                                            <DescriptionListDescription>
+                                                {volume.type}
+                                            </DescriptionListDescription>
+                                        </DescriptionListGroup>
+                                        <DescriptionListGroup>
+                                            <DescriptionListTerm>
+                                                Mount propagation
+                                            </DescriptionListTerm>
+                                            <DescriptionListDescription>
+                                                {volume.mountPropagation}
+                                            </DescriptionListDescription>
+                                        </DescriptionListGroup>
+                                    </DescriptionList>
+                                </ExpandableSection>
+                            </StackItem>
+                        ))
+                    ) : (
+                        <EmptyState>No volumes</EmptyState>
+                    )}
+                </Stack>
+            </CardBody>
+        </Card>
+    );
+}
+
+export default ContainerVolumeInfo;

--- a/ui/apps/platform/src/Components/DeploymentContainerConfig.tsx
+++ b/ui/apps/platform/src/Components/DeploymentContainerConfig.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { ExpandableSection, Stack, StackItem } from '@patternfly/react-core';
 
 import { Container } from 'types/deployment.proto';
+import ContainerImageInfo from 'Components/ContainerImageInfo';
 import ContainerResourcesInfo from 'Components/ContainerResouresInfo';
 import ContainerVolumesInfo from 'Components/ContainerVolumesInfo';
 import ContainerSecretsInfo from 'Components/ContainerSecretsInfo';
@@ -19,7 +20,7 @@ function DeploymentContainerConfig({ container }: DeploymentContainerConfigProps
         setIsExpanded(_isExpanded);
     };
 
-    const toggleText = container.image.name.fullName;
+    const toggleText = container.name;
 
     return (
         <ExpandableSection
@@ -30,6 +31,9 @@ function DeploymentContainerConfig({ container }: DeploymentContainerConfigProps
             isWidthLimited
         >
             <Stack hasGutter>
+                <StackItem>
+                    <ContainerImageInfo image={container.image} />
+                </StackItem>
                 <StackItem>
                     <ContainerResourcesInfo resources={container.resources} />
                 </StackItem>

--- a/ui/apps/platform/src/Components/DeploymentContainerConfig.tsx
+++ b/ui/apps/platform/src/Components/DeploymentContainerConfig.tsx
@@ -1,0 +1,53 @@
+import React, { useState } from 'react';
+import { ExpandableSection, Stack, StackItem } from '@patternfly/react-core';
+
+import { Container } from 'types/deployment.proto';
+import ContainerResourcesInfo from 'Components/ContainerResouresInfo';
+import ContainerVolumesInfo from 'Components/ContainerVolumesInfo';
+import ContainerSecretsInfo from 'Components/ContainerSecretsInfo';
+import ContainerArgumentsInfo from 'Components/ContainerArgumentsInfo';
+import ContainerCommandInfo from 'Components/ContainerCommandInfo';
+
+type DeploymentContainerConfigProps = {
+    container: Container;
+};
+
+function DeploymentContainerConfig({ container }: DeploymentContainerConfigProps) {
+    const [isExpanded, setIsExpanded] = useState(false);
+
+    const onToggle = (_isExpanded: boolean) => {
+        setIsExpanded(_isExpanded);
+    };
+
+    const toggleText = container.image.name.fullName;
+
+    return (
+        <ExpandableSection
+            toggleText={toggleText}
+            onToggle={onToggle}
+            isExpanded={isExpanded}
+            displaySize="large"
+            isWidthLimited
+        >
+            <Stack hasGutter>
+                <StackItem>
+                    <ContainerResourcesInfo resources={container.resources} />
+                </StackItem>
+                <StackItem>
+                    <ContainerVolumesInfo volumes={container.volumes} />
+                </StackItem>
+                <StackItem>
+                    <ContainerSecretsInfo secrets={container.secrets} />
+                </StackItem>
+                <StackItem>
+                    <ContainerArgumentsInfo args={container.config.args} />
+                </StackItem>
+                <StackItem>
+                    <ContainerCommandInfo command={container.config.command} />
+                </StackItem>
+            </Stack>
+        </ExpandableSection>
+    );
+}
+
+export default DeploymentContainerConfig;

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentDetails.css
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentDetails.css
@@ -1,0 +1,6 @@
+.pf-expandable-not-large .pf-c-expandable-section__content {
+    padding-right: 0;
+    padding-bottom: 0;
+    padding-left: 0;
+    margin-top: 0;
+}

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentDetails.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentDetails.tsx
@@ -29,12 +29,15 @@ import { getDateTime } from 'utils/dateUtils';
 import { NetworkPolicyState } from 'Containers/NetworkGraph/types/topology.type';
 
 import DeploymentPortConfig from 'Components/DeploymentPortConfig';
+import DeploymentContainerConfig from 'Components/DeploymentContainerConfig';
 
 import { ReactComponent as BothPolicyRules } from 'images/network-graph/both-policy-rules.svg';
 import { ReactComponent as EgressOnly } from 'images/network-graph/egress-only.svg';
 import { ReactComponent as IngressOnly } from 'images/network-graph/ingress-only.svg';
 import { ReactComponent as NoPolicyRules } from 'images/network-graph/no-policy-rules.svg';
 import { deploymentTabs } from '../utils/deploymentUtils';
+
+import './DeploymentDetails.css';
 
 type DeploymentDetailsProps = {
     deployment: Deployment;
@@ -258,7 +261,7 @@ function DeploymentDetails({
                 </li>
                 <Divider component="li" className="pf-u-mb-sm" />
                 <li>
-                    <DetailSection title="Deployment configuration">
+                    <DetailSection title="Deployment overview">
                         <Stack hasGutter>
                             <StackItem>
                                 <DescriptionList columnModifier={{ default: '2Col' }}>
@@ -366,6 +369,28 @@ function DeploymentDetails({
                             <EmptyState variant={EmptyStateVariant.xs}>
                                 <Title headingLevel="h4" size="md">
                                     No ports available
+                                </Title>
+                            </EmptyState>
+                        )}
+                    </DetailSection>
+                </li>
+                <Divider component="li" className="pf-u-mb-sm" />
+                <li>
+                    <DetailSection title="Container configurations">
+                        {deployment.containers.length ? (
+                            <Stack hasGutter>
+                                {deployment.containers.map((container) => {
+                                    return (
+                                        <StackItem key={container.id}>
+                                            <DeploymentContainerConfig container={container} />
+                                        </StackItem>
+                                    );
+                                })}
+                            </Stack>
+                        ) : (
+                            <EmptyState variant={EmptyStateVariant.xs}>
+                                <Title headingLevel="h4" size="md">
+                                    No containers available
                                 </Title>
                             </EmptyState>
                         )}

--- a/ui/apps/platform/src/css/trumps.css
+++ b/ui/apps/platform/src/css/trumps.css
@@ -29,6 +29,9 @@ body {
     align-self: center !important;
 }
 
+.pf-c-expandable-section__toggle-text {
+    text-align: left;
+}
 .pf-c-card__expandable-content {
     border-top: var(--pf-global--BorderColor--100) var(--pf-global--BorderWidth--sm) solid;
 }


### PR DESCRIPTION
## Description

This adds the container information to the Deployment details tab of the Network Graph 2.0 sidebar.

## Checklist
- [ ] Investigated and inspected CI test results


## Testing Performed

Container name and Resources
<img width="1662" alt="Screen Shot 2023-03-23 at 5 38 35 PM" src="https://user-images.githubusercontent.com/715729/227370754-72ebf72d-f3cc-49bf-b0df-652ba2389ae1.png">

Volumes
<img width="1662" alt="Screen Shot 2023-03-23 at 5 38 40 PM" src="https://user-images.githubusercontent.com/715729/227370963-b6b60714-6a90-4021-a798-d2aecc61cb5c.png">

Secrets
<img width="1662" alt="Screen Shot 2023-03-23 at 5 38 48 PM" src="https://user-images.githubusercontent.com/715729/227371009-916019c2-e64a-4c00-b6bf-98f22fd989b3.png">

Arguments and Commands
<img width="1662" alt="Screen Shot 2023-03-23 at 5 37 59 PM" src="https://user-images.githubusercontent.com/715729/227371332-03218c7e-7581-4a62-84e1-b3a5d44310e3.png">

