### PR TITLE
ROX-16159: Fix styling issues when selecting a namespace or external group

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphContainer.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphContainer.tsx
@@ -161,30 +161,44 @@ function fadeOutUnconnectedNodes(
     edges: CustomEdgeModel[],
     selectedNodeId: string | undefined
 ): CustomNodeModel[] {
-    if (!selectedNodeId) {
+    const selectedNode = getNodeById(nodes, selectedNodeId);
+    // if nothing is selected we don't want to fade anything out
+    if (!selectedNodeId || !selectedNode) {
         return nodes;
     }
-    const connectedNodeIds = getConnectedNodeIds(edges, selectedNodeId);
+    let emphasizedNodeIds: string[] = [];
+    if (selectedNode.children) {
+        // if the selected node is a group, we want to emphasize all connected nodes of the children
+        emphasizedNodeIds =
+            selectedNode.children.reduce((acc, currId) => {
+                const connectedNodeIds = getConnectedNodeIds(edges, currId);
+                return [...acc, ...connectedNodeIds];
+            }, [] as string[]) || [];
+        // we include the child nodes so that they aren't faded out
+        emphasizedNodeIds = [...emphasizedNodeIds, ...selectedNode.children];
+    } else {
+        // if the selected node is not a group, we want to emphasize all connected nodes of the selected node
+        emphasizedNodeIds = getConnectedNodeIds(edges, selectedNodeId);
+        // we include the selected node so that it isn't faded out
+        emphasizedNodeIds = [...emphasizedNodeIds, selectedNodeId];
+    }
     const modifiedNodes: CustomNodeModel[] = nodes.map((node) => {
         const { data } = node;
-        // We only want to fade out nodes (not groups), so we target node types specifically
-        if (
-            data.type === 'DEPLOYMENT' ||
-            data.type === 'CIDR_BLOCK' ||
-            data.type === 'EXTERNAL_ENTITIES'
-        ) {
-            const isConnectedToSelectedNode = connectedNodeIds.includes(node.id);
-            const isSelectedNode = node.id === selectedNodeId;
-            const isFadedOut = !isConnectedToSelectedNode && !isSelectedNode;
-            return {
-                ...node,
-                data: {
-                    ...data,
-                    isFadedOut,
-                },
-            } as CustomNodeModel;
+        let isFadedOut = false;
+        if (node.children) {
+            isFadedOut = !node.children.some((childNodeId) =>
+                emphasizedNodeIds.includes(childNodeId)
+            );
+        } else {
+            isFadedOut = !emphasizedNodeIds.includes(node.id);
         }
-        return node;
+        return {
+            ...node,
+            data: {
+                ...data,
+                isFadedOut,
+            },
+        } as CustomNodeModel;
     });
     return modifiedNodes;
 }

--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.css
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.css
@@ -66,6 +66,10 @@ div#topology-resize-panel table td {
     fill: #000000;
 }
 
+.derived-namespace.pf-m-selected text, .derived-namespace.pf-m-selected .pf-topology__node__action-icon svg {
+    fill: #ffffff;
+}
+
 .derived-namespace path.pf-topology__group__background {
     stroke-dasharray: 5;
 }

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/StyleGroup.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/StyleGroup.tsx
@@ -85,6 +85,9 @@ const StyleGroup: React.FunctionComponent<StyleGroupProps> = ({
         }`.trim();
     }
 
+    // @TODO: If multiple classes need to be stringed together, then we need a more systematic way to generate those here
+    className = `${className} ${passedData?.isFadedOut ? 'pf-topology-node-faded' : ''}`.trim();
+
     return (
         <DefaultGroup
             element={element}

--- a/ui/apps/platform/src/Containers/NetworkGraph/types/topology.type.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/types/topology.type.ts
@@ -51,6 +51,7 @@ export type NamespaceData = {
     cluster: string;
     isFilteredNamespace: boolean;
     labelIconClass: string;
+    isFadedOut: boolean;
 };
 
 export type NetworkPolicyState = 'none' | 'both' | 'ingress' | 'egress';
@@ -84,6 +85,7 @@ export type ExternalGroupData = {
     type: 'EXTERNAL_GROUP';
     collapsible: boolean;
     showContextMenu: boolean;
+    isFadedOut: boolean;
 };
 
 export type ExternalEntitiesData = {


### PR DESCRIPTION
## Description

This PR fixes an issue when selecting a namespace or external group node. The group nodes were not faded out correctly

<img width="1552" alt="Screenshot 2023-03-23 at 4 57 45 PM" src="https://user-images.githubusercontent.com/4805485/227390363-94a0dce5-965c-43c1-ad32-ea33bd3ccb89.png">
<img width="1552" alt="Screenshot 2023-03-23 at 4 57 54 PM" src="https://user-images.githubusercontent.com/4805485/227390368-252c31d4-c7dc-4cf6-ba45-c6cd0ab1efe4.png">
<img width="1552" alt="Screenshot 2023-03-23 at 4 58 02 PM" src="https://user-images.githubusercontent.com/4805485/227390370-b4f290bc-d9c6-460c-ab6c-7b3464118d01.png">
