### PR TITLE
Fix declarative config tests for release builds

### DIFF
--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -200,7 +200,7 @@ function launch_central {
     fi
 
     # TODO(ROX-16008): Once the feature flag is enabled by default, always add the config map mount.
-    if [[ -n "${ROX_DECLARATIVE_CONFIGURATION}" && "${IS_RELEASE_BUILD}" != "true" ]]; then
+    if [[ -n "${ROX_DECLARATIVE_CONFIGURATION}" ]]; then
         add_args "--declarative-config-config-maps=declarative-configurations"
     fi
 

--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -200,7 +200,7 @@ function launch_central {
     fi
 
     # TODO(ROX-16008): Once the feature flag is enabled by default, always add the config map mount.
-    if [[ -n "${ROX_DECLARATIVE_CONFIGURATION}" ]]; then
+    if [[ -n "${ROX_DECLARATIVE_CONFIGURATION}" && "${IS_RELEASE_BUILD}" != "true" ]]; then
         add_args "--declarative-config-config-maps=declarative-configurations"
     fi
 

--- a/qa-tests-backend/src/test/groovy/DeclarativeConfigTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DeclarativeConfigTest.groovy
@@ -29,7 +29,7 @@ import spock.lang.Tag
 
 @Retry(count = 0)
 // TODO(ROX-16008): Remove this once the declarative config feature flag is enabled by default.
-@IgnoreIf({ Env.get("IS_RELEASE_BUILD", "false") == "true" })
+@IgnoreIf({ Env.get("ROX_DECLARATIVE_CONFIGURATION", "false") == "false" })
 class DeclarativeConfigTest extends BaseSpecification {
     static final private String DEFAULT_NAMESPACE = "stackrox"
 

--- a/qa-tests-backend/src/test/groovy/DeclarativeConfigTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DeclarativeConfigTest.groovy
@@ -19,7 +19,6 @@ import io.stackrox.proto.storage.TraitsOuterClass.Traits
 import services.AuthProviderService
 import services.GroupService
 import services.IntegrationHealthService
-import services.MetadataService
 import services.RoleService
 
 import org.junit.Rule
@@ -30,7 +29,7 @@ import spock.lang.Tag
 
 @Retry(count = 0)
 // TODO(ROX-16008): Remove this once the declarative config feature flag is enabled by default.
-@IgnoreIf({ MetadataService.isReleaseBuild() })
+@IgnoreIf({ Env.get("IS_RELEASE_BUILD", "false") == "true" })
 class DeclarativeConfigTest extends BaseSpecification {
     static final private String DEFAULT_NAMESPACE = "stackrox"
 

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -98,6 +98,10 @@ export_test_environment() {
     ci_export ROX_SYSLOG_EXTRA_FIELDS "${ROX_SYSLOG_EXTRA_FIELDS:-true}"
     ci_export ROX_VULN_MGMT_WORKLOAD_CVES "${ROX_VULN_MGMT_WORKLOAD_CVES:-true}"
     ci_export ROX_PROCESSES_LISTENING_ON_PORT "${ROX_PROCESSES_LISTENING_ON_PORT:-true}"
+
+
+    version="${MAIN_IMAGE_TAG:-$(make --quiet --no-print-directory -C "$(git rev-parse --show-toplevel)" tag)}"
+    ci_export IS_RELEASE_BUILD (is_nightly_run || is_release_version "${version}")
 }
 
 deploy_stackrox_operator() {

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -101,7 +101,9 @@ export_test_environment() {
 
 
     version="${MAIN_IMAGE_TAG:-$(make --quiet --no-print-directory -C "$(git rev-parse --show-toplevel)" tag)}"
-    ci_export IS_RELEASE_BUILD (is_nightly_run || is_release_version "${version}")
+    if ( is_nightly_run || is_release_version "${version}"); then
+        ci_export IS_RELEASE_BUILD "true"
+    fi
 }
 
 deploy_stackrox_operator() {

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -91,7 +91,6 @@ export_test_environment() {
 
     ci_export ROX_BASELINE_GENERATION_DURATION "${ROX_BASELINE_GENERATION_DURATION:-1m}"
     ci_export ROX_NETWORK_BASELINE_OBSERVATION_PERIOD "${ROX_NETWORK_BASELINE_OBSERVATION_PERIOD:-2m}"
-    ci_export ROX_DECLARATIVE_CONFIGURATION "${ROX_DECLARATIVE_CONFIGURATION:-true}"
     ci_export ROX_NETWORK_GRAPH_PATTERNFLY "${ROX_NETWORK_GRAPH_PATTERNFLY:-true}"
     ci_export ROX_QUAY_ROBOT_ACCOUNTS "${ROX_QUAY_ROBOT_ACCOUNTS:-true}"
     ci_export ROX_SYSTEM_HEALTH_PF "${ROX_SYSTEM_HEALTH_PF:-true}"
@@ -99,10 +98,8 @@ export_test_environment() {
     ci_export ROX_VULN_MGMT_WORKLOAD_CVES "${ROX_VULN_MGMT_WORKLOAD_CVES:-true}"
     ci_export ROX_PROCESSES_LISTENING_ON_PORT "${ROX_PROCESSES_LISTENING_ON_PORT:-true}"
 
-
-    version="${MAIN_IMAGE_TAG:-$(make --quiet --no-print-directory -C "$(git rev-parse --show-toplevel)" tag)}"
-    if ( is_nightly_run || is_release_version "${version}" ); then
-        ci_export IS_RELEASE_BUILD "true"
+    if [[ -n "${BUILD_TAG:-}" ]]; then
+        ci_export ROX_DECLARATIVE_CONFIGURATION "${ROX_DECLARATIVE_CONFIGURATION:-true}"
     fi
 }
 

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -98,7 +98,8 @@ export_test_environment() {
     ci_export ROX_VULN_MGMT_WORKLOAD_CVES "${ROX_VULN_MGMT_WORKLOAD_CVES:-true}"
     ci_export ROX_PROCESSES_LISTENING_ON_PORT "${ROX_PROCESSES_LISTENING_ON_PORT:-true}"
 
-    if [[ -n "${BUILD_TAG:-}" ]]; then
+    if [[ -z "${BUILD_TAG:-}" ]]; then
+        # TODO(ROX-16008): Remove this once the declarative config feature flag is enabled by default.
         ci_export ROX_DECLARATIVE_CONFIGURATION "${ROX_DECLARATIVE_CONFIGURATION:-true}"
     fi
 }

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -101,7 +101,7 @@ export_test_environment() {
 
 
     version="${MAIN_IMAGE_TAG:-$(make --quiet --no-print-directory -C "$(git rev-parse --show-toplevel)" tag)}"
-    if ( is_nightly_run || is_release_version "${version}"); then
+    if ( is_nightly_run || is_release_version "${version}" ); then
         ci_export IS_RELEASE_BUILD "true"
     fi
 }


### PR DESCRIPTION
## Description

Currently, release builds are failing after #5266 . The reason is the change for declarative config within the deploy scripts.

We currently only verify whether the feature flag is passed, but not whether the build is a release build, since the command will not be available for the release build irrespective of the feature flag being set or not.

We conditionally only set `ROX_DECLARATIVE_CONFIGURATION` to true if `BUILD_TAG == ""`.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
