### PR TITLE
Integrate workload cve image single page table with search filter

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/hooks/useImageVulnerabilities.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/hooks/useImageVulnerabilities.ts
@@ -1,7 +1,5 @@
 import { gql, useQuery } from '@apollo/client';
 import { Pagination } from 'services/types';
-import { SearchFilter } from 'types/search';
-import { getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
 
 export type ImageVulnerabilitiesVariables = {
     id: string;
@@ -109,7 +107,7 @@ export const imageVulnerabilitiesQuery = gql`
 
 export default function useImageVulnerabilities(
     imageId: string,
-    searchFilter: SearchFilter,
+    vulnQuery: string,
     pagination: Pagination
 ) {
     return useQuery<ImageVulnerabilitiesResponse, ImageVulnerabilitiesVariables>(
@@ -117,7 +115,7 @@ export default function useImageVulnerabilities(
         {
             variables: {
                 id: imageId,
-                vulnQuery: getRequestQueryStringForSearchFilter(searchFilter),
+                vulnQuery,
                 pagination,
             },
         }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/searchUtils.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/searchUtils.tsx
@@ -3,9 +3,9 @@ import qs from 'qs';
 import { vulnerabilitiesWorkloadCvesPath } from 'routePaths';
 import { SearchFilter } from 'types/search';
 import { getQueryString } from 'utils/queryStringUtils';
-import { ensureExhaustive } from 'utils/type.utils';
+import { ensureExhaustive, ValueOf } from 'utils/type.utils';
 
-import { CveStatusTab, isValidCveStatusTab } from './types';
+import { CveStatusTab, isValidCveStatusTab, QuerySearchFilter } from './types';
 
 export type EntityTab = 'CVE' | 'Image' | 'Deployment';
 
@@ -38,4 +38,71 @@ export function getEntityPagePath(workloadCveEntity: EntityTab, id: string): str
         default:
             return ensureExhaustive(workloadCveEntity);
     }
+}
+
+/**
+ * Coerces a search filter value obtained from the URL into an array of strings.
+ *
+ * Array values will be returned unchanged.
+ * String values will return an array of length one.
+ * undefined values will return an empty array.
+ */
+export function searchValueAsArray(searchValue: ValueOf<SearchFilter>): string[] {
+    if (!searchValue) {
+        return [];
+    }
+    if (Array.isArray(searchValue)) {
+        return searchValue;
+    }
+    return [searchValue];
+}
+
+/**
+ * Parses an open `SearchFilter` obtained from the URL into a restricted `SearchFilter` that
+ * matches the fields and values expected by the backend.
+ */
+export function parseQuerySearchFilter(rawSearchFilter: SearchFilter): QuerySearchFilter {
+    const cleanSearchFilter: QuerySearchFilter = {};
+
+    // SearchFilter values that can be directly translated over to the backend equivalent
+    const unprocessedSearchKeys = ['IMAGE', 'DEPLOYMENT', 'NAMESPACE', 'CLUSTER'] as const;
+    unprocessedSearchKeys.forEach((key) => {
+        if (rawSearchFilter[key]) {
+            cleanSearchFilter[key] = searchValueAsArray(rawSearchFilter[key]);
+        }
+    });
+
+    if (rawSearchFilter.Fixable) {
+        const rawFixable = searchValueAsArray(rawSearchFilter.Fixable);
+        const cleanFixable: ('true' | 'false')[] = [];
+
+        rawFixable.forEach((status) => {
+            if (status === 'Fixable') {
+                cleanFixable.push('true');
+            } else if (status === 'Not fixable') {
+                cleanFixable.push('false');
+            }
+        });
+
+        cleanSearchFilter.Fixable = cleanFixable;
+    }
+
+    if (rawSearchFilter.Severity) {
+        const rawSeverities = searchValueAsArray(rawSearchFilter.Severity);
+        cleanSearchFilter.Severity = [];
+
+        rawSeverities.forEach((rs) => {
+            if (rs === 'Critical') {
+                cleanSearchFilter.Severity?.push('CRITICAL_VULNERABILITY_SEVERITY');
+            } else if (rs === 'Important') {
+                cleanSearchFilter.Severity?.push('IMPORTANT_VULNERABILITY_SEVERITY');
+            } else if (rs === 'Moderate') {
+                cleanSearchFilter.Severity?.push('MODERATE_VULNERABILITY_SEVERITY');
+            } else if (rs === 'Low') {
+                cleanSearchFilter.Severity?.push('LOW_VULNERABILITY_SEVERITY');
+            }
+        });
+    }
+
+    return cleanSearchFilter;
 }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/searchUtils.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/searchUtils.tsx
@@ -3,7 +3,8 @@ import qs from 'qs';
 import { vulnerabilitiesWorkloadCvesPath } from 'routePaths';
 import { SearchFilter } from 'types/search';
 import { getQueryString } from 'utils/queryStringUtils';
-import { ensureExhaustive, ValueOf } from 'utils/type.utils';
+import { searchValueAsArray } from 'utils/searchUtils';
+import { ensureExhaustive } from 'utils/type.utils';
 
 import { CveStatusTab, isValidCveStatusTab, QuerySearchFilter } from './types';
 
@@ -38,23 +39,6 @@ export function getEntityPagePath(workloadCveEntity: EntityTab, id: string): str
         default:
             return ensureExhaustive(workloadCveEntity);
     }
-}
-
-/**
- * Coerces a search filter value obtained from the URL into an array of strings.
- *
- * Array values will be returned unchanged.
- * String values will return an array of length one.
- * undefined values will return an empty array.
- */
-export function searchValueAsArray(searchValue: ValueOf<SearchFilter>): string[] {
-    if (!searchValue) {
-        return [];
-    }
-    if (Array.isArray(searchValue)) {
-        return searchValue;
-    }
-    return [searchValue];
 }
 
 /**

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/types.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/types.ts
@@ -1,3 +1,5 @@
+import { VulnerabilitySeverity } from 'types/cve.proto';
+
 export type VulnerabilitySeverityLabel = 'Critical' | 'Important' | 'Moderate' | 'Low';
 export type FixableStatus = 'Fixable' | 'Not fixable';
 
@@ -5,6 +7,18 @@ export type DefaultFilters = {
     Severity: VulnerabilitySeverityLabel[];
     Fixable: FixableStatus[];
 };
+
+// `QuerySearchFilter` is a restricted subset of the `SearchFilter` obtained from the URL that only
+// supports search keys that are valid in the Workload CVE section of the app
+export type QuerySearchFilter = Partial<{
+    Severity: VulnerabilitySeverity[];
+    Fixable: ('true' | 'false')[];
+    CVE: string[];
+    IMAGE: string[];
+    DEPLOYMENT: string[];
+    NAMESPACE: string[];
+    CLUSTER: string[];
+}>;
 
 export type VulnMgmtLocalStorage = {
     preferences: {

--- a/ui/apps/platform/src/types/cve.proto.ts
+++ b/ui/apps/platform/src/types/cve.proto.ts
@@ -1,9 +1,12 @@
-export type VulnerabilitySeverity =
-    | 'UNKNOWN_VULNERABILITY_SEVERITY'
-    | 'LOW_VULNERABILITY_SEVERITY'
-    | 'MODERATE_VULNERABILITY_SEVERITY'
-    | 'IMPORTANT_VULNERABILITY_SEVERITY'
-    | 'CRITICAL_VULNERABILITY_SEVERITY';
+export const vulnerabilitySeverities = [
+    'UNKNOWN_VULNERABILITY_SEVERITY',
+    'LOW_VULNERABILITY_SEVERITY',
+    'MODERATE_VULNERABILITY_SEVERITY',
+    'IMPORTANT_VULNERABILITY_SEVERITY',
+    'CRITICAL_VULNERABILITY_SEVERITY',
+] as const;
+
+export type VulnerabilitySeverity = typeof vulnerabilitySeverities[number];
 
 export type VulnerabilityState = 'OBSERVED' | 'DEFERRED' | 'FALSE_POSITIVE';
 

--- a/ui/apps/platform/src/utils/searchUtils.test.js
+++ b/ui/apps/platform/src/utils/searchUtils.test.js
@@ -6,6 +6,7 @@ import {
     convertSortToRestFormat,
     searchOptionsToSearchFilter,
     getListQueryParams,
+    searchValueAsArray,
 } from './searchUtils';
 
 describe('searchUtils', () => {
@@ -375,6 +376,21 @@ describe('searchUtils', () => {
                 const offset = parseInt(offsetParam, 10);
                 expect(offset % page).toBe(0);
             });
+        });
+    });
+
+    describe('searchValueAsArray', () => {
+        it('converts an undefined value to an empty array', () => {
+            expect(searchValueAsArray(undefined)).toEqual([]);
+        });
+
+        it('converts a string value to an array with the string as the only element', () => {
+            expect(searchValueAsArray('cluster')).toEqual(['cluster']);
+        });
+
+        it('converts an array value to an array with the same elements', () => {
+            expect(searchValueAsArray([])).toEqual([]);
+            expect(searchValueAsArray(['cluster', 'namespace'])).toEqual(['cluster', 'namespace']);
         });
     });
 });

--- a/ui/apps/platform/src/utils/searchUtils.ts
+++ b/ui/apps/platform/src/utils/searchUtils.ts
@@ -1,5 +1,6 @@
 import qs from 'qs';
 import { SearchEntry, ApiSortOption, GraphQLSortOption, SearchFilter } from 'types/search';
+import { ValueOf } from './type.utils';
 
 /**
  *  Checks if the modifier exists in the searchOptions
@@ -215,4 +216,24 @@ export function getListQueryParams(
         },
         { allowDots: true }
     );
+}
+
+/**
+ * Coerces a search filter value obtained from the URL into an array of strings.
+ *
+ * Array values will be returned unchanged.
+ * String values will return an array of length one.
+ * undefined values will return an empty array.
+ *
+ * @param searchValue The value of a single key from a `SearchFilter`
+ * @returns An array of strings
+ */
+export function searchValueAsArray(searchValue: ValueOf<SearchFilter>): string[] {
+    if (!searchValue) {
+        return [];
+    }
+    if (Array.isArray(searchValue)) {
+        return searchValue;
+    }
+    return [searchValue];
 }


### PR DESCRIPTION
## Description

Integrates the WorkloadTableToolbar search filter with the images single page table.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Apply a severity filter and see it reflected in the URL, summary cards, and table:
![image](https://user-images.githubusercontent.com/1292638/227534348-1c746e85-8ee0-49cf-bbc1-a605d52c606a.png)

Apply another severity filter and a fixable filter and see them reflected in the URL, summary cards, and table:
![image](https://user-images.githubusercontent.com/1292638/227534495-24035242-b7db-413e-a0df-ff439ed13b94.png)

Apply entity filters and see them reflected in the URL (none of the data is impacted by these filters in my environment)
![image](https://user-images.githubusercontent.com/1292638/227534782-a122d0da-55e9-44b9-8c0d-bcf3736c70dc.png)
Verify that the entity filters are correctly sent as part of the query:
![image](https://user-images.githubusercontent.com/1292638/227534983-e085dfb7-17c5-4b46-aed5-9226ea9359a3.png)

