### PR TITLE
ROX-16178: Update entity page layout to include CVE type in CVS export call

### DIFF
--- a/ui/apps/platform/src/Containers/Workflow/WorkflowEntityPageLayout.js
+++ b/ui/apps/platform/src/Containers/Workflow/WorkflowEntityPageLayout.js
@@ -65,7 +65,7 @@ const WorkflowEntityPageLayout = ({ location }) => {
     const sidePanelPaging = workflowState.paging[pagingParams.sidePanel];
 
     function customCsvExportHandler(fileName) {
-        return exportCvesAsCsv(fileName, workflowState);
+        return exportCvesAsCsv(fileName, workflowState, pageListType);
     }
 
     const [fadeIn, setFadeIn] = useState(false);


### PR DESCRIPTION
## Description

When we updated the CSV export routines to pass the CVE type in the API call, which is required when using Postgres as the datastore, we only added that parameter when child CVE lists were embedded in the sidepanel of other list pages.

CVE lists in child tabs of a single entity were not passing the new parameter, and so their CSV export API calls were failing.

This change fixes that by adding the new parameter for those on the full-page single entity layout, too.

Compare this to how the `WorkflowListPageLayout.js` file already includes that needed extra parameter, which is called `pageListType` generically, because it has multiple uses in the app, not just on CVE pages.

https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Workflow/WorkflowListPageLayout.js#L55-L74

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

I tested all CSV exports on all single entity pages, in all CVE tabs, of all three types of CVEs: Platform, Node, and Image CVEs.

Look a CSV of CVEs exported from the entity page where the bug was initially reported.
_VM dashboard -> visa-processor image -> Image CVEs (at the top) -> Export -> Download evidence as CSV_

<img width="1880" alt="Screen Shot 2023-03-24 at 11 45 20 AM" src="https://user-images.githubusercontent.com/715729/227583763-8ec7e382-0f85-4a49-a023-5cbb9a3c098e.png">
