### PR TITLE
Add ImageCVE page summary cards

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCveSummaryCards.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCveSummaryCards.tsx
@@ -55,7 +55,9 @@ function ImageCveSummaryCards({
     severitySummary,
     hiddenSeverities,
 }: ImageCveSummaryCardsProps) {
-    const countBySeverity = severitySummary.affectedImageCountBySeverity;
+    const { critical, important, moderate, low } = severitySummary.affectedImageCountBySeverity;
+    const { affectedImageCount, topCVSS } = severitySummary;
+    const { imageCount } = summaryCounts;
     return (
         <Flex
             direction={{ default: 'column', lg: 'row' }}
@@ -64,23 +66,23 @@ function ImageCveSummaryCards({
         >
             <EnvironmentalImpact
                 className="pf-u-flex-grow-1"
-                affectedImageCount={severitySummary.affectedImageCount}
-                totalImagesCount={summaryCounts.imageCount}
+                affectedImageCount={affectedImageCount}
+                totalImagesCount={imageCount}
             />
             <BySeveritySummaryCard
                 className="pf-u-flex-grow-1"
                 title="Images by severity"
                 severityCounts={{
-                    CRITICAL_VULNERABILITY_SEVERITY: countBySeverity.critical,
-                    IMPORTANT_VULNERABILITY_SEVERITY: countBySeverity.important,
-                    MODERATE_VULNERABILITY_SEVERITY: countBySeverity.moderate,
-                    LOW_VULNERABILITY_SEVERITY: countBySeverity.low,
+                    CRITICAL_VULNERABILITY_SEVERITY: critical,
+                    IMPORTANT_VULNERABILITY_SEVERITY: important,
+                    MODERATE_VULNERABILITY_SEVERITY: moderate,
+                    LOW_VULNERABILITY_SEVERITY: low,
                 }}
                 hiddenSeverities={hiddenSeverities}
             />
             <TopCvssScoreBreakdown
                 className="pf-u-flex-grow-1"
-                cvssScore={severitySummary.topCVSS}
+                cvssScore={topCVSS}
                 vector="TODO - Not implemented"
             />
         </Flex>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageSingleVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageSingleVulnerabilities.tsx
@@ -115,6 +115,7 @@ function ImageSingleVulnerabilities({ imageId }: ImageSingleVulnerabilitiesProps
         const hiddenStatuses = getHiddenStatuses(querySearchFilter);
         const vulnCounter = vulnerabilityData.image.imageVulnerabilityCounter;
         const totalVulnerabilityCount = vulnCounter.all.total;
+        const { critical, important, moderate, low } = vulnCounter;
 
         mainContent = (
             <>
@@ -124,10 +125,10 @@ function ImageSingleVulnerabilities({ imageId }: ImageSingleVulnerabilitiesProps
                             <BySeveritySummaryCard
                                 title="CVEs by severity"
                                 severityCounts={{
-                                    CRITICAL_VULNERABILITY_SEVERITY: vulnCounter.critical.total,
-                                    IMPORTANT_VULNERABILITY_SEVERITY: vulnCounter.important.total,
-                                    MODERATE_VULNERABILITY_SEVERITY: vulnCounter.moderate.total,
-                                    LOW_VULNERABILITY_SEVERITY: vulnCounter.low.total,
+                                    CRITICAL_VULNERABILITY_SEVERITY: critical.total,
+                                    IMPORTANT_VULNERABILITY_SEVERITY: important.total,
+                                    MODERATE_VULNERABILITY_SEVERITY: moderate.total,
+                                    LOW_VULNERABILITY_SEVERITY: low.total,
                                 }}
                                 hiddenSeverities={hiddenSeverities}
                             />

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageSingleVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageSingleVulnerabilities.tsx
@@ -19,7 +19,6 @@ import {
     Title,
 } from '@patternfly/react-core';
 
-import { vulnerabilitySeverities, VulnerabilitySeverity } from 'types/cve.proto';
 import useURLStringUnion from 'hooks/useURLStringUnion';
 import useURLSearch from 'hooks/useURLSearch';
 import useURLPagination from 'hooks/useURLPagination';
@@ -34,14 +33,8 @@ import CvesByStatusSummaryCard from './SummaryCards/CvesByStatusSummaryCard';
 import SingleEntityVulnerabilitiesTable from './Tables/SingleEntityVulnerabilitiesTable';
 import useImageVulnerabilities from './hooks/useImageVulnerabilities';
 import { DynamicTableLabel } from './DynamicIcon';
-import { parseQuerySearchFilter } from './searchUtils';
+import { getHiddenSeverities, parseQuerySearchFilter } from './searchUtils';
 import { QuerySearchFilter, FixableStatus, cveStatusTabValues } from './types';
-
-function getHiddenSeverities(querySearchFilter: QuerySearchFilter): Set<VulnerabilitySeverity> {
-    return querySearchFilter.Severity
-        ? new Set(vulnerabilitySeverities.filter((s) => !querySearchFilter.Severity?.includes(s)))
-        : new Set([]);
-}
 
 function getHiddenStatuses(querySearchFilter: QuerySearchFilter): Set<FixableStatus> {
     const hiddenStatuses = new Set<FixableStatus>([]);
@@ -120,7 +113,8 @@ function ImageSingleVulnerabilities({ imageId }: ImageSingleVulnerabilitiesProps
     } else if (vulnerabilityData) {
         const hiddenSeverities = getHiddenSeverities(querySearchFilter);
         const hiddenStatuses = getHiddenStatuses(querySearchFilter);
-        const totalVulnerabilityCount = vulnerabilityData.image.imageVulnerabilityCounter.all.total;
+        const vulnCounter = vulnerabilityData.image.imageVulnerabilityCounter;
+        const totalVulnerabilityCount = vulnCounter.all.total;
 
         mainContent = (
             <>
@@ -129,7 +123,12 @@ function ImageSingleVulnerabilities({ imageId }: ImageSingleVulnerabilitiesProps
                         <GridItem sm={12} md={6} xl2={4}>
                             <BySeveritySummaryCard
                                 title="CVEs by severity"
-                                severityCounts={vulnerabilityData.image.imageVulnerabilityCounter}
+                                severityCounts={{
+                                    CRITICAL_VULNERABILITY_SEVERITY: vulnCounter.critical.total,
+                                    IMPORTANT_VULNERABILITY_SEVERITY: vulnCounter.important.total,
+                                    MODERATE_VULNERABILITY_SEVERITY: vulnCounter.moderate.total,
+                                    LOW_VULNERABILITY_SEVERITY: vulnCounter.low.total,
+                                }}
                                 hiddenSeverities={hiddenSeverities}
                             />
                         </GridItem>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/SummaryCards/BySeveritySummaryCard.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/SummaryCards/BySeveritySummaryCard.tsx
@@ -6,47 +6,42 @@ import SeverityIcons from 'Components/PatternFly/SeverityIcons';
 import { VulnerabilitySeverity } from 'types/cve.proto';
 import { vulnerabilitySeverityLabels } from 'messages/common';
 import { SVGIconProps } from '@patternfly/react-icons/dist/esm/createIcon';
-import {
-    ImageVulnerabilityCounter,
-    ImageVulnerabilityCounterKey,
-} from '../hooks/useImageVulnerabilities';
 
 export type BySeveritySummaryCardProps = {
+    className?: string;
     title: string;
-    severityCounts: ImageVulnerabilityCounter;
+    severityCounts: Omit<Record<VulnerabilitySeverity, number>, 'UNKNOWN_VULNERABILITY_SEVERITY'>;
     hiddenSeverities: Set<VulnerabilitySeverity>;
 };
 
-const vulnCounterToSeverity: Record<ImageVulnerabilityCounterKey, VulnerabilitySeverity> = {
-    low: 'LOW_VULNERABILITY_SEVERITY',
-    moderate: 'MODERATE_VULNERABILITY_SEVERITY',
-    important: 'IMPORTANT_VULNERABILITY_SEVERITY',
-    critical: 'CRITICAL_VULNERABILITY_SEVERITY',
-} as const;
-
-const severitiesCriticalToLow = ['critical', 'important', 'moderate', 'low'] as const;
+const severitiesCriticalToLow = [
+    'CRITICAL_VULNERABILITY_SEVERITY',
+    'IMPORTANT_VULNERABILITY_SEVERITY',
+    'MODERATE_VULNERABILITY_SEVERITY',
+    'LOW_VULNERABILITY_SEVERITY',
+] as const;
 
 const disabledColor100 = 'var(--pf-global--disabled-color--100)';
 const disabledColor200 = 'var(--pf-global--disabled-color--200)';
 
 function BySeveritySummaryCard({
+    className = '',
     title,
     severityCounts,
     hiddenSeverities,
 }: BySeveritySummaryCardProps) {
     return (
-        <Card isCompact>
+        <Card className={className} isCompact>
             <CardTitle>{title}</CardTitle>
             <CardBody>
                 <Grid className="pf-u-pl-sm">
                     {severitiesCriticalToLow.map((severity) => {
                         const count = severityCounts[severity];
-                        const hasNoResults = count.total === 0;
-                        const vulnSeverity = vulnCounterToSeverity[severity];
-                        const isHidden = hiddenSeverities.has(vulnSeverity);
+                        const hasNoResults = count === 0;
+                        const isHidden = hiddenSeverities.has(severity);
 
                         let textColor = '';
-                        let text = `${count.total} ${vulnerabilitySeverityLabels[vulnSeverity]}`;
+                        let text = `${count} ${vulnerabilitySeverityLabels[severity]}`;
 
                         if (isHidden) {
                             textColor = disabledColor100;
@@ -56,11 +51,10 @@ function BySeveritySummaryCard({
                             text = 'No results';
                         }
 
-                        const Icon: React.FC<SVGIconProps> | undefined =
-                            SeverityIcons[vulnSeverity];
+                        const Icon: React.FC<SVGIconProps> | undefined = SeverityIcons[severity];
 
                         return (
-                            <GridItem key={vulnSeverity} span={6}>
+                            <GridItem key={severity} span={6}>
                                 <Flex
                                     className="pf-u-pt-sm"
                                     spaceItems={{ default: 'spaceItemsSm' }}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/SummaryCards/EnvironmentalImpact.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/SummaryCards/EnvironmentalImpact.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Card, CardTitle, CardBody } from '@patternfly/react-core';
+
+export type EnvironmentalImpactProps = {
+    className?: string;
+    affectedImageCount: number;
+    totalImagesCount: number;
+};
+
+function EnvironmentalImpact({
+    className = '',
+    affectedImageCount,
+    totalImagesCount,
+}: EnvironmentalImpactProps) {
+    return (
+        <Card className={className} isCompact>
+            <CardTitle>Environmental impact</CardTitle>
+            <CardBody>
+                {affectedImageCount}/{totalImagesCount} images affected
+            </CardBody>
+        </Card>
+    );
+}
+
+export default EnvironmentalImpact;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/SummaryCards/TopCvssScoreBreakdown.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/SummaryCards/TopCvssScoreBreakdown.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Card, CardTitle, CardBody, Flex, Tooltip, Text } from '@patternfly/react-core';
+import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
+
+export type TopCvssScoreBreakdownProps = {
+    className?: string;
+    cvssScore: number;
+    vector: string;
+};
+
+function TopCvssScoreBreakdown({ className, cvssScore, vector }: TopCvssScoreBreakdownProps) {
+    return (
+        <Card className={className} isCompact>
+            <CardTitle>
+                Top CVSS score breakdown{' '}
+                <Tooltip content="TODO - Add description for this card">
+                    <OutlinedQuestionCircleIcon className="pf-u-display-inline" />
+                </Tooltip>
+            </CardTitle>
+            <CardBody>
+                <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsSm' }}>
+                    <Text>{cvssScore.toFixed(1)}</Text>
+                    <Text className="pf-u-color-200">{vector}</Text>
+                </Flex>
+            </CardBody>
+        </Card>
+    );
+}
+
+export default TopCvssScoreBreakdown;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/searchUtils.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/searchUtils.tsx
@@ -1,6 +1,7 @@
 import qs from 'qs';
 
 import { vulnerabilitiesWorkloadCvesPath } from 'routePaths';
+import { VulnerabilitySeverity, vulnerabilitySeverities } from 'types/cve.proto';
 import { SearchFilter } from 'types/search';
 import { getQueryString } from 'utils/queryStringUtils';
 import { searchValueAsArray } from 'utils/searchUtils';
@@ -89,4 +90,13 @@ export function parseQuerySearchFilter(rawSearchFilter: SearchFilter): QuerySear
     }
 
     return cleanSearchFilter;
+}
+
+// Given a search filter, determine which severities should be hidden from the user
+export function getHiddenSeverities(
+    querySearchFilter: QuerySearchFilter
+): Set<VulnerabilitySeverity> {
+    return querySearchFilter.Severity
+        ? new Set(vulnerabilitySeverities.filter((s) => !querySearchFilter.Severity?.includes(s)))
+        : new Set([]);
 }

--- a/ui/apps/platform/src/configureApolloClient.js
+++ b/ui/apps/platform/src/configureApolloClient.js
@@ -57,6 +57,9 @@ export default function configureApolloClient() {
                         },
                     },
                 },
+                ImageCVECore: {
+                    keyFields: ['cve'],
+                },
             },
         }),
     });


### PR DESCRIPTION
## Description

This adds summary cards to the ImageCVE single page.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Load a CVE page:

![image](https://user-images.githubusercontent.com/1292638/227592231-137ed609-1bc4-4366-8abd-56c77fa6313e.png)

Apply search filters and observe that the total number of images in the ""Environmental impact" card as well as the labels in the "By severity" card are updated. *Note that the actual values here are _wrong_, since the BE query support is not fully merged yet*
![image](https://user-images.githubusercontent.com/1292638/227592757-61c00272-7a5b-4786-bb62-90bb48c4c368.png)

Query error state:
![image](https://user-images.githubusercontent.com/1292638/227593139-fbc2153e-8808-4b8b-8a86-25a1439b570e.png)

Loading state:
![image](https://user-images.githubusercontent.com/1292638/227593401-33caac24-f819-4298-a276-08b2b2aeae80.png)


Small screen views:
<img width="400px" src="https://user-images.githubusercontent.com/1292638/227592942-e8ba6512-ce25-4eed-8a42-35620a7e6c4d.png">
<img width="400px" src="https://user-images.githubusercontent.com/1292638/227593286-0577e9dd-349b-4713-9026-4975029094a0.png">
<img width="400px" src="https://user-images.githubusercontent.com/1292638/227593360-6bb4cee5-08d2-4275-88ce-0b39ba4c4611.png">


