### PR TITLE
Adjust UI for Origin field in access control resources

### DIFF
--- a/ui/apps/platform/src/Containers/AccessControl/AccessScopes/AccessScopesList.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessScopes/AccessScopesList.tsx
@@ -16,8 +16,7 @@ import { Role } from 'services/RolesService';
 
 import { AccessControlEntityLink, RolesLink } from '../AccessControlLinks';
 import usePermissions from '../../../hooks/usePermissions';
-import { TraitsOriginLabel } from '../TraitsOriginLabel';
-import { isUserResource } from '../traits';
+import { getOriginLabel, isUserResource } from '../traits';
 
 const entityType = 'ACCESS_SCOPE';
 
@@ -94,9 +93,7 @@ function AccessScopesList({
                                     entityName={name}
                                 />
                             </Td>
-                            <Td dataLabel="Origin">
-                                <TraitsOriginLabel traits={traits} />
-                            </Td>
+                            <Td dataLabel="Origin">{getOriginLabel(traits)}</Td>
                             <Td dataLabel="Description">{description}</Td>
                             <Td dataLabel="Roles">
                                 <RolesLink

--- a/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProvidersList.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProvidersList.tsx
@@ -10,7 +10,7 @@ import { actions as authActions } from 'reducers/auth';
 import { AuthProvider, AuthProviderInfo, getIsAuthProviderImmutable } from 'services/AuthService';
 
 import { AccessControlEntityLink } from '../AccessControlLinks';
-import { TraitsOriginLabel } from '../TraitsOriginLabel';
+import { getOriginLabel } from '../traits';
 
 // TODO import from where?
 const unselectedRowStyle = {};
@@ -86,9 +86,7 @@ function AuthProvidersList({ entityId, authProviders }: AuthProvidersListProps):
                                         entityName={name}
                                     />
                                 </Td>
-                                <Td dataLabel="Origin">
-                                    <TraitsOriginLabel traits={traits} />
-                                </Td>
+                                <Td dataLabel="Origin">{getOriginLabel(traits)}</Td>
                                 <Td dataLabel="Type">{typeLabel}</Td>
                                 <Td dataLabel="Minimum access role">
                                     <AccessControlEntityLink

--- a/ui/apps/platform/src/Containers/AccessControl/AuthProviders/RuleGroups.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AuthProviders/RuleGroups.tsx
@@ -174,7 +174,7 @@ function RuleGroups({
                                     </FlexItem>
                                 ) : (
                                     <FlexItem>
-                                        <Tooltip content="This rule is managed declaratively and cannot be edited.">
+                                        <Tooltip content="This rule is managed declaratively and can only be edited declaratively.">
                                             <Button
                                                 variant="plain"
                                                 aria-label="Information button"

--- a/ui/apps/platform/src/Containers/AccessControl/AuthProviders/RuleGroups.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AuthProviders/RuleGroups.tsx
@@ -1,13 +1,21 @@
 /* eslint-disable react/no-array-index-key */
 import React, { ReactElement } from 'react';
 import { FieldArray } from 'formik';
-import { Button, Flex, FlexItem, FormGroup, SelectOption, TextInput } from '@patternfly/react-core';
-import { ArrowRightIcon, PlusCircleIcon, TrashIcon } from '@patternfly/react-icons';
+import {
+    Button,
+    Flex,
+    FlexItem,
+    FormGroup,
+    SelectOption,
+    TextInput,
+    Tooltip,
+} from '@patternfly/react-core';
+import { ArrowRightIcon, InfoCircleIcon, PlusCircleIcon, TrashIcon } from '@patternfly/react-icons';
 
 import { Group } from 'services/AuthService';
 import { Role } from 'services/RolesService';
 import SelectSingle from 'Components/SelectSingle';
-import { isUserResource } from '../traits';
+import { getOriginLabel, isUserResource } from '../traits';
 
 export type RuleGroupErrors = {
     roleName?: string;
@@ -81,6 +89,15 @@ function RuleGroups({
                             <Flex key={`${group.props.authProviderId}_custom_rule_${index}`}>
                                 <FlexItem>
                                     <FormGroup
+                                        label="Origin"
+                                        fieldId={`groups[${index}].props.traits.origin`}
+                                        validated="default"
+                                    >
+                                        {getOriginLabel(group?.props?.traits)}
+                                    </FormGroup>
+                                </FlexItem>
+                                <FlexItem>
+                                    <FormGroup
                                         label="Key"
                                         fieldId={`groups[${index}].props.key`}
                                         helperTextInvalid={errors[index]?.props?.key ?? ''}
@@ -144,7 +161,7 @@ function RuleGroups({
                                         </SelectSingle>
                                     </FormGroup>
                                 </FlexItem>
-                                {!isDisabled(group) && (
+                                {!isDisabled(group) ? (
                                     <FlexItem>
                                         <Button
                                             variant="plain"
@@ -155,6 +172,18 @@ function RuleGroups({
                                             <TrashIcon />
                                         </Button>
                                     </FlexItem>
+                                ) : (
+                                    <FlexItem>
+                                        <Tooltip content="This rule is managed declaratively and cannot be edited.">
+                                            <Button
+                                                variant="plain"
+                                                aria-label="Information button"
+                                                style={{ transform: 'translate(0, 42px)' }}
+                                            >
+                                                <InfoCircleIcon />
+                                            </Button>
+                                        </Tooltip>
+                                    </FlexItem>
                                 )}
                             </Flex>
                         ))}
@@ -164,7 +193,7 @@ function RuleGroups({
                                 <Button
                                     variant="link"
                                     isInline
-                                    isDisabled={!!errors?.length}
+                                    isDisabled={false}
                                     icon={<PlusCircleIcon className="pf-u-mr-sm" />}
                                     onClick={() =>
                                         arrayHelpers.push({

--- a/ui/apps/platform/src/Containers/AccessControl/AuthProviders/RuleGroups.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AuthProviders/RuleGroups.tsx
@@ -193,7 +193,7 @@ function RuleGroups({
                                 <Button
                                     variant="link"
                                     isInline
-                                    isDisabled={false}
+                                    isDisabled={!!errors?.length}
                                     icon={<PlusCircleIcon className="pf-u-mr-sm" />}
                                     onClick={() =>
                                         arrayHelpers.push({

--- a/ui/apps/platform/src/Containers/AccessControl/PermissionSets/PermissionSetsList.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/PermissionSets/PermissionSetsList.tsx
@@ -15,8 +15,7 @@ import { PermissionSet, Role } from 'services/RolesService';
 
 import { AccessControlEntityLink, RolesLink } from '../AccessControlLinks';
 import usePermissions from '../../../hooks/usePermissions';
-import { TraitsOriginLabel } from '../TraitsOriginLabel';
-import { isUserResource } from '../traits';
+import { getOriginLabel, isUserResource } from '../traits';
 
 const entityType = 'PERMISSION_SET';
 
@@ -95,9 +94,7 @@ function PermissionSetsList({
                                         entityName={name}
                                     />
                                 </Td>
-                                <Td dataLabel="Origin">
-                                    <TraitsOriginLabel traits={traits} />
-                                </Td>
+                                <Td dataLabel="Origin">{getOriginLabel(traits)}</Td>
                                 <Td dataLabel="Description">{description}</Td>
                                 <Td dataLabel="Roles">
                                     <RolesLink

--- a/ui/apps/platform/src/Containers/AccessControl/Roles/RolesList.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/Roles/RolesList.tsx
@@ -18,8 +18,7 @@ import { PermissionSet, Role } from 'services/RolesService';
 import { AccessControlEntityLink } from '../AccessControlLinks';
 import { AccessControlQueryFilter } from '../accessControlPaths';
 import usePermissions from '../../../hooks/usePermissions';
-import { TraitsOriginLabel } from '../TraitsOriginLabel';
-import { isUserResource } from '../traits';
+import { getOriginLabel, isUserResource } from '../traits';
 
 // Return whether an auth provider rule refers to a role name,
 // therefore need to disable the delete action for the role.
@@ -125,9 +124,7 @@ function RolesList({
                                             entityName={name}
                                         />
                                     </Td>
-                                    <Td dataLabel="Origin">
-                                        <TraitsOriginLabel traits={traits} />
-                                    </Td>
+                                    <Td dataLabel="Origin">{getOriginLabel(traits)}</Td>
                                     <Td dataLabel="Description">{description}</Td>
                                     <Td dataLabel="Permission set">
                                         <AccessControlEntityLink

--- a/ui/apps/platform/src/Containers/AccessControl/TraitsOriginLabel.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/TraitsOriginLabel.tsx
@@ -1,16 +1,13 @@
 import React, { ReactElement } from 'react';
 import { Label } from '@patternfly/react-core';
 import { Traits } from 'types/traits.proto';
-import { originLabelColours, traitsOriginLabels } from './traits';
+import { getOriginLabel, originLabelColours } from './traits';
 
 export type TraitsOriginLabelProps = {
     traits?: Traits;
 };
 
 export function TraitsOriginLabel({ traits }: TraitsOriginLabelProps): ReactElement {
-    const originLabel =
-        traits && traits.origin && traitsOriginLabels[traits.origin]
-            ? traitsOriginLabels[traits.origin]
-            : 'User';
+    const originLabel = getOriginLabel(traits);
     return <Label color={originLabelColours[originLabel]}>{originLabel}</Label>;
 }

--- a/ui/apps/platform/src/Containers/AccessControl/traits.ts
+++ b/ui/apps/platform/src/Containers/AccessControl/traits.ts
@@ -15,3 +15,9 @@ export const originLabelColours = {
     User: 'green',
     Declarative: 'blue',
 };
+
+export function getOriginLabel(traits?: Traits): string {
+    return traits && traits.origin && traitsOriginLabels[traits.origin]
+        ? traitsOriginLabels[traits.origin]
+        : 'User';
+}


### PR DESCRIPTION
## Description

* Show origin as simple text instead of the label in list view
*  show origin for groups + info icon with explanation for unmodifiable groups

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed


<img width="1780" alt="Screenshot 2023-03-24 at 18 26 51" src="https://user-images.githubusercontent.com/78353299/227598549-32f53210-08b7-468d-992d-51183b76fca3.png">

<img width="1762" alt="Screenshot 2023-03-24 at 18 28 59" src="https://user-images.githubusercontent.com/78353299/227598601-9d0010e6-6c5c-47a6-a7e6-2da739933b25.png">

