### PR TITLE
ROX-7416 Add failure test cases for TLS secret reconciliation

### DIFF
--- a/operator/pkg/central/extensions/common_test.go
+++ b/operator/pkg/central/extensions/common_test.go
@@ -22,11 +22,12 @@ type secretVerifyFunc func(t *testing.T, data types.SecretDataMap)
 type statusVerifyFunc func(t *testing.T, status *platform.CentralStatus)
 
 type secretReconciliationTestCase struct {
-	Spec            platform.CentralSpec
-	Deleted         bool
-	Existing        []*v1.Secret
-	ExistingManaged []*v1.Secret
-	Other           []ctrlClient.Object
+	Spec                   platform.CentralSpec
+	Deleted                bool
+	Existing               []*v1.Secret
+	ExistingManaged        []*v1.Secret
+	Other                  []ctrlClient.Object
+	InterceptedK8sApiCalls testutils.InterceptorFns
 
 	ExpectedCreatedSecrets     map[string]secretVerifyFunc
 	ExpectedError              string
@@ -93,6 +94,8 @@ func testSecretReconciliation(t *testing.T, runFn func(ctx context.Context, cent
 		WithObjects(existingSecrets...).
 		WithRuntimeObjects(otherExisting...).
 		Build()
+
+	client = testutils.Interceptor(client, c.InterceptedK8sApiCalls)
 
 	// Verify that an initial invocation does not touch any of the existing secrets, and creates
 	// the expected ones.

--- a/operator/pkg/central/extensions/reconcile_tls_test.go
+++ b/operator/pkg/central/extensions/reconcile_tls_test.go
@@ -1,11 +1,15 @@
 package extensions
 
 import (
+	"context"
 	"crypto/x509"
+	"errors"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/cloudflare/cfssl/csr"
+	"github.com/cloudflare/cfssl/initca"
 	"github.com/stackrox/rox/generated/storage"
 	platform "github.com/stackrox/rox/operator/apis/platform/v1alpha1"
 	"github.com/stackrox/rox/operator/pkg/types"
@@ -16,6 +20,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -154,7 +159,90 @@ func TestCreateCentralTLS(t *testing.T) {
 			Spec:     basicSpecWithScanner(true),
 			Existing: []*v1.Secret{existingCentral, existingCentralDB, existingScanner, existingScannerDB},
 		},
-		// TODO(ROX-7416): Test error cases
+		"When creating a new central-tls secret fails, an error should be returned": {
+			Spec:                   basicSpecWithScanner(false),
+			InterceptedK8sApiCalls: creatingSecretFails("central-tls"),
+			ExpectedError:          "reconciling central-tls secret",
+		},
+		"When creating a new central-db-tls secret fails, an error should be returned": {
+			Spec:                   basicSpecWithScanner(false),
+			InterceptedK8sApiCalls: creatingSecretFails("central-db-tls"),
+			ExpectedError:          "reconciling central-db-tls secret",
+		},
+		"When creating a new scanner-tls secret fails, an error should be returned": {
+			Spec:                   basicSpecWithScanner(true),
+			InterceptedK8sApiCalls: creatingSecretFails("scanner-tls"),
+			ExpectedError:          "reconciling scanner-tls secret",
+		},
+		"When creating a new scanner-db-tls secret fails, an error should be returned": {
+			Spec:                   basicSpecWithScanner(true),
+			InterceptedK8sApiCalls: creatingSecretFails("scanner-db-tls"),
+			ExpectedError:          "reconciling scanner-db-tls secret",
+		},
+		"When getting an existing central-tls secret fails with a non-404 error, an error should be returned": {
+			Spec:                   basicSpecWithScanner(false),
+			InterceptedK8sApiCalls: gettingSecretFails("central-tls"),
+			ExpectedError:          "reconciling central-tls secret",
+		},
+		"When getting an existing central-db-tls secret fails with a non-404 error, an error should be returned": {
+			Spec:                   basicSpecWithScanner(false),
+			InterceptedK8sApiCalls: gettingSecretFails("central-db-tls"),
+			ExpectedError:          "reconciling central-db-tls secret",
+		},
+		"When getting an existing scanner-tls secret fails with a non-404 error, an error should be returned": {
+			Spec:                   basicSpecWithScanner(true),
+			InterceptedK8sApiCalls: gettingSecretFails("scanner-tls"),
+			ExpectedError:          "reconciling scanner-tls secret",
+		},
+		"When getting an existing scanner-db-tls secret fails with a non-404 error, an error should be returned": {
+			Spec:                   basicSpecWithScanner(true),
+			InterceptedK8sApiCalls: gettingSecretFails("scanner-db-tls"),
+			ExpectedError:          "reconciling scanner-db-tls secret",
+		},
+		"When deleting an existing central-tls secret fails, an error should be returned": {
+			Deleted:                true,
+			ExistingManaged:        []*v1.Secret{existingCentral},
+			InterceptedK8sApiCalls: deletingSecretFails("central-tls"),
+			ExpectedError:          "reconciling central-tls secret",
+		},
+		"When deleting an existing central-tls secret fails with a 404, an error should not be returned because the secret is likely to be already deleted": {
+			Deleted:                true,
+			ExistingManaged:        []*v1.Secret{existingCentral},
+			InterceptedK8sApiCalls: secretIsAlreadyDeleted("central-tls"),
+		},
+		"When deleting an existing central-db-tls secret fails, an error should be returned": {
+			Deleted:                true,
+			ExistingManaged:        []*v1.Secret{existingCentralDB},
+			InterceptedK8sApiCalls: deletingSecretFails("central-db-tls"),
+			ExpectedError:          "reconciling central-db-tls secret",
+		},
+		"When deleting an existing central-db-tls secret fails with a 404, an error should not be returned because the secret is likely to be already deleted": {
+			Deleted:                true,
+			ExistingManaged:        []*v1.Secret{existingCentralDB},
+			InterceptedK8sApiCalls: secretIsAlreadyDeleted("central-db-tls"),
+		},
+		"When deleting an existing scanner-tls secret fails, an error should be returned": {
+			Deleted:                true,
+			ExistingManaged:        []*v1.Secret{existingScanner},
+			InterceptedK8sApiCalls: deletingSecretFails("scanner-tls"),
+			ExpectedError:          "reconciling scanner-tls secret",
+		},
+		"When deleting an existing scanner-tls secret fails with a 404, an error should not be returned because the secret is likely to be already deleted": {
+			Deleted:                true,
+			ExistingManaged:        []*v1.Secret{existingScanner},
+			InterceptedK8sApiCalls: secretIsAlreadyDeleted("scanner-tls"),
+		},
+		"When deleting an existing scanner-db-tls secret fails, an error should be returned": {
+			Deleted:                true,
+			ExistingManaged:        []*v1.Secret{existingScannerDB},
+			InterceptedK8sApiCalls: deletingSecretFails("scanner-db-tls"),
+			ExpectedError:          "reconciling scanner-db-tls secret",
+		},
+		"When deleting an existing scanner-db-tls secret fails with a 404, an error should not be returned because the secret is likely to be already deleted": {
+			Deleted:                true,
+			ExistingManaged:        []*v1.Secret{existingScannerDB},
+			InterceptedK8sApiCalls: secretIsAlreadyDeleted("scanner-db-tls"),
+		},
 	}
 
 	for name, c := range cases {
@@ -169,6 +257,55 @@ func TestCreateCentralTLS(t *testing.T) {
 
 			testSecretReconciliation(t, reconcileCentralTLS, c)
 		})
+	}
+}
+
+func gettingSecretFails(secretName string) testutils.InterceptorFns {
+	return testutils.InterceptorFns{
+		Get: func(ctx context.Context, client ctrlClient.WithWatch, key ctrlClient.ObjectKey, obj ctrlClient.Object, opts ...ctrlClient.GetOption) error {
+			_, ok := obj.(*v1.Secret)
+			if !ok || key.Name != secretName {
+				return client.Get(ctx, key, obj, opts...)
+			}
+			return k8sErrors.NewServiceUnavailable("failure")
+		},
+	}
+}
+
+func creatingSecretFails(secretName string) testutils.InterceptorFns {
+	return testutils.InterceptorFns{
+		Create: func(ctx context.Context, client ctrlClient.WithWatch, obj ctrlClient.Object, opts ...ctrlClient.CreateOption) error {
+			secret, ok := obj.(*v1.Secret)
+			if !ok || secret.Name != secretName {
+				return client.Create(ctx, obj, opts...)
+			}
+			return k8sErrors.NewServiceUnavailable("failure")
+		},
+	}
+}
+
+func deletingSecretFails(secretName string) testutils.InterceptorFns {
+	return testutils.InterceptorFns{
+		Delete: func(ctx context.Context, client ctrlClient.WithWatch, obj ctrlClient.Object, opts ...ctrlClient.DeleteOption) error {
+			secret, ok := obj.(*v1.Secret)
+			if !ok || secret.Name != secretName {
+				return client.Delete(ctx, obj, opts...)
+			}
+			return k8sErrors.NewServiceUnavailable("failure")
+		},
+	}
+}
+func secretIsAlreadyDeleted(secretName string) testutils.InterceptorFns {
+	return testutils.InterceptorFns{
+		Delete: func(ctx context.Context, client ctrlClient.WithWatch, obj ctrlClient.Object, opts ...ctrlClient.DeleteOption) error {
+			secret, ok := obj.(*v1.Secret)
+			shouldReturn404 := ok && secret.Name == secretName
+			err := client.Delete(ctx, obj, opts...)
+			if shouldReturn404 {
+				return k8sErrors.NewNotFound(v1.SchemeGroupVersion.WithResource("secrets").GroupResource(), secretName)
+			}
+			return err
+		},
 	}
 }
 
@@ -235,5 +372,381 @@ func TestRenewInitBundle(t *testing.T) {
 				assert.NoError(t, checkInitBundleCertRenewal(cert, now))
 			}
 		})
+	}
+}
+
+func Test_createCentralTLSExtensionRun_validateAndConsumeCentralTLSData(t *testing.T) {
+
+	type validateTlsDataCase struct {
+		fileMap types.SecretDataMap
+		assert  func(t *testing.T, err error)
+	}
+
+	randomCA := func() (mtls.CA, error) {
+		serial, err := mtls.RandomSerial()
+		if err != nil {
+			return nil, errors.New("could not generate serial number")
+		}
+		req := csr.CertificateRequest{
+			CN:           "Planet Express",
+			KeyRequest:   csr.NewKeyRequest(),
+			SerialNumber: serial.String(),
+		}
+		caCert, _, caKey, err := initca.New(&req)
+		if err != nil {
+			return nil, errors.New("could not generate CA")
+		}
+		return mtls.LoadCAForSigning(caCert, caKey)
+	}
+
+	ca1, err := certgen.GenerateCA()
+	require.NoError(t, err)
+
+	centralCertFromCA1, err := ca1.IssueCertForSubject(mtls.CentralSubject)
+	require.NoError(t, err)
+
+	unexpectedSubjectCertFromCA1, err := ca1.IssueCertForSubject(mtls.AdmissionControlSubject)
+	require.NoError(t, err)
+
+	ca2, err := certgen.GenerateCA()
+	require.NoError(t, err)
+
+	centralCertFromCA2, err := ca2.IssueCertForSubject(mtls.CentralSubject)
+	require.NoError(t, err)
+
+	caNotFromACS, err := randomCA()
+	require.NoError(t, err)
+
+	cases := map[string]validateTlsDataCase{
+		"should fail if the CA was not issued by ACS": {
+			fileMap: types.SecretDataMap{
+				mtls.CACertFileName: caNotFromACS.CertPEM(),
+				mtls.CAKeyFileName:  caNotFromACS.KeyPEM(),
+			},
+			assert: func(t *testing.T, err error) {
+				assert.ErrorContains(t, err, "invalid certificate common name")
+			},
+		},
+		"should fail if the CA is not... a CA": {
+			fileMap: types.SecretDataMap{
+				mtls.CACertFileName: centralCertFromCA1.CertPEM,
+				mtls.CAKeyFileName:  centralCertFromCA1.KeyPEM,
+			},
+			assert: func(t *testing.T, err error) {
+				assert.ErrorContains(t, err, "certificate is not valid as CA")
+			},
+		},
+		"should fail when the ca cert and key do not match": {
+			fileMap: types.SecretDataMap{
+				mtls.CACertFileName: ca1.CertPEM(),
+				mtls.CAKeyFileName:  ca2.KeyPEM(),
+			},
+			assert: func(t *testing.T, err error) {
+				assert.ErrorContains(t, err, "private key does not match public key")
+			},
+		},
+		"should fail when the ca cert is missing": {
+			fileMap: types.SecretDataMap{
+				mtls.CAKeyFileName: ca1.KeyPEM(),
+			},
+			assert: func(t *testing.T, err error) {
+				assert.ErrorContains(t, err, "no CA certificate in file map")
+			},
+		},
+		"should fail when the ca key is missing": {
+			fileMap: types.SecretDataMap{
+				mtls.CACertFileName: ca1.CertPEM(),
+			},
+			assert: func(t *testing.T, err error) {
+				assert.ErrorContains(t, err, "no CA key in file map")
+			},
+		},
+		"should fail when the ca cert is invalid": {
+			fileMap: types.SecretDataMap{
+				mtls.CACertFileName: []byte("invalid"),
+				mtls.CAKeyFileName:  ca1.KeyPEM(),
+			},
+			assert: func(t *testing.T, err error) {
+				assert.ErrorContains(t, err, "failed to find any PEM data in certificate input")
+			},
+		},
+		"should fail when the ca key is invalid": {
+			fileMap: types.SecretDataMap{
+				mtls.CACertFileName: ca1.CertPEM(),
+				mtls.CAKeyFileName:  []byte("invalid"),
+			},
+			assert: func(t *testing.T, err error) {
+				assert.ErrorContains(t, err, "failed to find any PEM data in key input")
+			},
+		},
+		"should fail when the service cert is missing": {
+			fileMap: types.SecretDataMap{
+				mtls.CACertFileName:     ca1.CertPEM(),
+				mtls.CAKeyFileName:      ca1.KeyPEM(),
+				mtls.ServiceKeyFileName: centralCertFromCA1.KeyPEM,
+			},
+			assert: func(t *testing.T, err error) {
+				assert.ErrorContains(t, err, "no service certificate in file map")
+			},
+		},
+		"should fail when the service key is missing": {
+			fileMap: types.SecretDataMap{
+				mtls.CACertFileName:      ca1.CertPEM(),
+				mtls.CAKeyFileName:       ca1.KeyPEM(),
+				mtls.ServiceCertFileName: centralCertFromCA1.CertPEM,
+			},
+			assert: func(t *testing.T, err error) {
+				assert.ErrorContains(t, err, "no service private key in file map")
+			},
+		},
+		"should fail when the service cert does not match the service key": {
+			fileMap: types.SecretDataMap{
+				mtls.CACertFileName:      ca1.CertPEM(),
+				mtls.CAKeyFileName:       ca1.KeyPEM(),
+				mtls.ServiceCertFileName: centralCertFromCA1.CertPEM,
+				mtls.ServiceKeyFileName:  centralCertFromCA2.KeyPEM,
+			},
+			assert: func(t *testing.T, err error) {
+				assert.ErrorContains(t, err, "mismatched certificate and private key")
+			},
+		},
+		"should fail when the service cert is invalid": {
+			fileMap: types.SecretDataMap{
+				mtls.CACertFileName:      ca1.CertPEM(),
+				mtls.CAKeyFileName:       ca1.KeyPEM(),
+				mtls.ServiceCertFileName: []byte("invalid"),
+				mtls.ServiceKeyFileName:  centralCertFromCA1.KeyPEM,
+			},
+			assert: func(t *testing.T, err error) {
+				assert.ErrorContains(t, err, "unparseable certificate in file map")
+			},
+		},
+		"should fail when the service key is invalid": {
+			fileMap: types.SecretDataMap{
+				mtls.CACertFileName:      ca1.CertPEM(),
+				mtls.CAKeyFileName:       ca1.KeyPEM(),
+				mtls.ServiceCertFileName: centralCertFromCA1.CertPEM,
+				mtls.ServiceKeyFileName:  []byte("invalid"),
+			},
+			assert: func(t *testing.T, err error) {
+				assert.ErrorContains(t, err, "invalid private key")
+			},
+		},
+		"should fail when the service cert is not signed by the ca cert": {
+			fileMap: types.SecretDataMap{
+				mtls.CACertFileName:      ca1.CertPEM(),
+				mtls.CAKeyFileName:       ca1.KeyPEM(),
+				mtls.ServiceCertFileName: centralCertFromCA2.CertPEM,
+				mtls.ServiceKeyFileName:  centralCertFromCA2.KeyPEM,
+			},
+			assert: func(t *testing.T, err error) {
+				assert.ErrorContains(t, err, "certificate signed by unknown authority")
+			},
+		},
+		"should fail when the service cert subject is not the expected service name": {
+			fileMap: types.SecretDataMap{
+				mtls.CACertFileName:      ca1.CertPEM(),
+				mtls.CAKeyFileName:       ca1.KeyPEM(),
+				mtls.ServiceCertFileName: unexpectedSubjectCertFromCA1.CertPEM,
+				mtls.ServiceKeyFileName:  unexpectedSubjectCertFromCA1.KeyPEM,
+			},
+			assert: func(t *testing.T, err error) {
+				assert.ErrorContains(t, err, "unexpected certificate service type")
+			},
+		},
+		"should succeed when the ca cert and key are valid": {
+			fileMap: types.SecretDataMap{
+				mtls.CACertFileName:      ca1.CertPEM(),
+				mtls.CAKeyFileName:       ca1.KeyPEM(),
+				mtls.ServiceCertFileName: centralCertFromCA1.CertPEM,
+				mtls.ServiceKeyFileName:  centralCertFromCA1.KeyPEM,
+			},
+			assert: func(t *testing.T, err error) {
+				assert.NoError(t, err)
+			},
+		},
+		// TODO: Discuss tests around ca/service cert expiration, as well as "NotBefore".
+		// Currently these verifications are only done for the init bundle secret reconciliation,
+		// which has been disabled anyways. We also currently ignore CRLs and OCSPs.
+	}
+
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			r := &createCentralTLSExtensionRun{}
+			err := r.validateAndConsumeCentralTLSData(tt.fileMap, true)
+			tt.assert(t, err)
+		})
+	}
+}
+
+func Test_createCentralTLSExtensionRun_validateServiceTLSData(t *testing.T) {
+	type testCase struct {
+		ca      mtls.CA
+		fileMap types.SecretDataMap
+		assert  func(t *testing.T, err error)
+	}
+
+	subjects := []mtls.Subject{
+		mtls.ScannerSubject,
+		mtls.ScannerDBSubject,
+		mtls.CentralDBSubject,
+	}
+
+	ca1, err := certgen.GenerateCA()
+	require.NoError(t, err)
+
+	unexpectedSubjectCertFromCA1, err := ca1.IssueCertForSubject(mtls.AdmissionControlSubject)
+	require.NoError(t, err)
+
+	ca2, err := certgen.GenerateCA()
+	require.NoError(t, err)
+
+	for _, subject := range subjects {
+		t.Run(subject.Identifier, func(t *testing.T) {
+
+			certForServiceFromCA1, err := ca1.IssueCertForSubject(subject)
+			require.NoError(t, err)
+
+			certForServiceFromCA2, err := ca2.IssueCertForSubject(subject)
+			require.NoError(t, err)
+
+			cases := map[string]testCase{
+				"should fail when the certificate does not match the ca": {
+					ca: ca1,
+					fileMap: types.SecretDataMap{
+						mtls.CACertFileName:      ca1.CertPEM(),
+						mtls.CAKeyFileName:       ca1.KeyPEM(),
+						mtls.ServiceKeyFileName:  certForServiceFromCA2.KeyPEM,
+						mtls.ServiceCertFileName: certForServiceFromCA2.CertPEM,
+					},
+					assert: func(t *testing.T, err error) {
+						assert.ErrorContains(t, err, "certificate signed by unknown authority")
+					},
+				},
+				"should fail when the key is missing": {
+					ca: ca1,
+					fileMap: types.SecretDataMap{
+						mtls.CACertFileName:      ca1.CertPEM(),
+						mtls.CAKeyFileName:       ca1.KeyPEM(),
+						mtls.ServiceCertFileName: certForServiceFromCA1.CertPEM,
+					},
+					assert: func(t *testing.T, err error) {
+						assert.ErrorContains(t, err, "no service private key")
+					},
+				},
+				"should fail when the certificate is missing": {
+					ca: ca1,
+					fileMap: types.SecretDataMap{
+						mtls.CACertFileName:     ca1.CertPEM(),
+						mtls.CAKeyFileName:      ca1.KeyPEM(),
+						mtls.ServiceKeyFileName: certForServiceFromCA1.KeyPEM,
+					},
+					assert: func(t *testing.T, err error) {
+						assert.ErrorContains(t, err, "no service certificate")
+					},
+				},
+				"should fail when the key is invalid": {
+					ca: ca1,
+					fileMap: types.SecretDataMap{
+						mtls.CACertFileName:      ca1.CertPEM(),
+						mtls.CAKeyFileName:       ca1.KeyPEM(),
+						mtls.ServiceCertFileName: certForServiceFromCA1.CertPEM,
+						mtls.ServiceKeyFileName:  []byte("invalid key"),
+					},
+					assert: func(t *testing.T, err error) {
+						assert.ErrorContains(t, err, "invalid private key")
+					},
+				},
+				"should fail when the certificate is invalid": {
+					ca: ca1,
+					fileMap: types.SecretDataMap{
+						mtls.CACertFileName:      ca1.CertPEM(),
+						mtls.CAKeyFileName:       ca1.KeyPEM(),
+						mtls.ServiceKeyFileName:  certForServiceFromCA1.KeyPEM,
+						mtls.ServiceCertFileName: []byte("invalid cert"),
+					},
+					assert: func(t *testing.T, err error) {
+						assert.ErrorContains(t, err, "unparseable certificate")
+					},
+				},
+				"should fail when the key does not match the cert": {
+					ca: ca1,
+					fileMap: types.SecretDataMap{
+						mtls.CACertFileName:      ca1.CertPEM(),
+						mtls.CAKeyFileName:       ca1.KeyPEM(),
+						mtls.ServiceKeyFileName:  certForServiceFromCA2.KeyPEM,
+						mtls.ServiceCertFileName: certForServiceFromCA1.CertPEM,
+					},
+					assert: func(t *testing.T, err error) {
+						assert.ErrorContains(t, err, "mismatched certificate and private key")
+					},
+				},
+				"should fail when the subject is unexpected": {
+					ca: ca1,
+					fileMap: types.SecretDataMap{
+						mtls.CACertFileName:      ca1.CertPEM(),
+						mtls.CAKeyFileName:       ca1.KeyPEM(),
+						mtls.ServiceKeyFileName:  unexpectedSubjectCertFromCA1.KeyPEM,
+						mtls.ServiceCertFileName: unexpectedSubjectCertFromCA1.CertPEM,
+					},
+					assert: func(t *testing.T, err error) {
+						assert.ErrorContains(t, err, "unexpected certificate service type")
+					},
+				},
+				"should fail, if for some reason, the ca cert is missing from the file map": {
+					ca: ca1,
+					fileMap: types.SecretDataMap{
+						mtls.CAKeyFileName:       ca1.KeyPEM(),
+						mtls.ServiceKeyFileName:  certForServiceFromCA1.KeyPEM,
+						mtls.ServiceCertFileName: certForServiceFromCA1.CertPEM,
+					},
+					assert: func(t *testing.T, err error) {
+						assert.ErrorContains(t, err, "no CA certificate in file map")
+					},
+				},
+				"should not fail if the ca key is missing from the file map": {
+					// TODO: Confirm that this behavior is correct.
+					ca: ca1,
+					fileMap: types.SecretDataMap{
+						mtls.CACertFileName:      ca1.CertPEM(),
+						mtls.ServiceKeyFileName:  certForServiceFromCA1.KeyPEM,
+						mtls.ServiceCertFileName: certForServiceFromCA1.CertPEM,
+					},
+					assert: func(t *testing.T, err error) {
+						assert.NoError(t, err)
+					},
+				},
+				"should succeed when the certificate matches the ca": {
+					ca: ca1,
+					fileMap: types.SecretDataMap{
+						mtls.CACertFileName:      ca1.CertPEM(),
+						mtls.CAKeyFileName:       ca1.KeyPEM(),
+						mtls.ServiceKeyFileName:  certForServiceFromCA1.KeyPEM,
+						mtls.ServiceCertFileName: certForServiceFromCA1.CertPEM,
+					},
+					assert: func(t *testing.T, err error) {
+						assert.NoError(t, err)
+					},
+				},
+				// TODO: Discuss tests around ca/service cert expiration, as well as "NotBefore"
+			}
+
+			for name, tt := range cases {
+				t.Run(name, func(t *testing.T) {
+					r := &createCentralTLSExtensionRun{
+						ca: tt.ca,
+					}
+					switch subject {
+					case mtls.ScannerSubject:
+						tt.assert(t, r.validateScannerTLSData(tt.fileMap, true))
+					case mtls.ScannerDBSubject:
+						tt.assert(t, r.validateScannerDBTLSData(tt.fileMap, true))
+					case mtls.CentralDBSubject:
+						tt.assert(t, r.validateCentralDBTLSData(tt.fileMap, true))
+					}
+				})
+			}
+		})
+
 	}
 }

--- a/operator/pkg/utils/testutils/intercept.go
+++ b/operator/pkg/utils/testutils/intercept.go
@@ -1,0 +1,104 @@
+package testutils
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func Interceptor(client ctrlClient.WithWatch, fns InterceptorFns) ctrlClient.WithWatch {
+	return interceptor{client: client, fns: fns}
+}
+
+type InterceptorFns struct {
+	Get         func(ctx context.Context, client ctrlClient.WithWatch, key ctrlClient.ObjectKey, obj ctrlClient.Object, opts ...ctrlClient.GetOption) error
+	List        func(ctx context.Context, client ctrlClient.WithWatch, list ctrlClient.ObjectList, opts ...ctrlClient.ListOption) error
+	Create      func(ctx context.Context, client ctrlClient.WithWatch, obj ctrlClient.Object, opts ...ctrlClient.CreateOption) error
+	Delete      func(ctx context.Context, client ctrlClient.WithWatch, obj ctrlClient.Object, opts ...ctrlClient.DeleteOption) error
+	DeleteAllOf func(ctx context.Context, client ctrlClient.WithWatch, obj ctrlClient.Object, opts ...ctrlClient.DeleteAllOfOption) error
+	Update      func(ctx context.Context, client ctrlClient.WithWatch, obj ctrlClient.Object, opts ...ctrlClient.UpdateOption) error
+	Patch       func(ctx context.Context, client ctrlClient.WithWatch, obj ctrlClient.Object, patch ctrlClient.Patch, opts ...ctrlClient.PatchOption) error
+	Watch       func(ctx context.Context, client ctrlClient.WithWatch, obj ctrlClient.ObjectList, opts ...ctrlClient.ListOption) (watch.Interface, error)
+}
+
+type interceptor struct {
+	client ctrlClient.WithWatch
+	fns    InterceptorFns
+}
+
+var _ ctrlClient.WithWatch = &interceptor{}
+
+func (c interceptor) Get(ctx context.Context, key ctrlClient.ObjectKey, obj ctrlClient.Object, opts ...ctrlClient.GetOption) error {
+	if c.fns.Get != nil {
+		return c.fns.Get(ctx, c.client, key, obj, opts...)
+	}
+	return c.client.Get(ctx, key, obj, opts...)
+}
+
+func (c interceptor) List(ctx context.Context, list ctrlClient.ObjectList, opts ...ctrlClient.ListOption) error {
+	if c.fns.List != nil {
+		return c.fns.List(ctx, c.client, list, opts...)
+	}
+	return c.client.List(ctx, list, opts...)
+}
+
+func (c interceptor) Create(ctx context.Context, obj ctrlClient.Object, opts ...ctrlClient.CreateOption) error {
+	if c.fns.Create != nil {
+		return c.fns.Create(ctx, c.client, obj, opts...)
+	}
+	return c.client.Create(ctx, obj, opts...)
+}
+
+func (c interceptor) Delete(ctx context.Context, obj ctrlClient.Object, opts ...ctrlClient.DeleteOption) error {
+	if c.fns.Delete != nil {
+		return c.fns.Delete(ctx, c.client, obj, opts...)
+	}
+	return c.client.Delete(ctx, obj, opts...)
+}
+
+func (c interceptor) Update(ctx context.Context, obj ctrlClient.Object, opts ...ctrlClient.UpdateOption) error {
+	if c.fns.Update != nil {
+		return c.fns.Update(ctx, c.client, obj, opts...)
+	}
+	return c.client.Update(ctx, obj, opts...)
+}
+
+func (c interceptor) Patch(ctx context.Context, obj ctrlClient.Object, patch ctrlClient.Patch, opts ...ctrlClient.PatchOption) error {
+	if c.fns.Patch != nil {
+		return c.fns.Patch(ctx, c.client, obj, patch, opts...)
+	}
+	return c.client.Patch(ctx, obj, patch, opts...)
+}
+
+func (c interceptor) DeleteAllOf(ctx context.Context, obj ctrlClient.Object, opts ...ctrlClient.DeleteAllOfOption) error {
+	if c.fns.DeleteAllOf != nil {
+		return c.fns.DeleteAllOf(ctx, c.client, obj, opts...)
+	}
+	return c.client.DeleteAllOf(ctx, obj, opts...)
+}
+
+func (c interceptor) Status() ctrlClient.SubResourceWriter {
+	return c.client.Status()
+}
+
+func (c interceptor) SubResource(subResource string) ctrlClient.SubResourceClient {
+	return c.client.SubResource(subResource)
+}
+
+func (c interceptor) Scheme() *runtime.Scheme {
+	return c.client.Scheme()
+}
+
+func (c interceptor) RESTMapper() meta.RESTMapper {
+	return c.client.RESTMapper()
+}
+
+func (c interceptor) Watch(ctx context.Context, obj ctrlClient.ObjectList, opts ...ctrlClient.ListOption) (watch.Interface, error) {
+	if c.fns.Watch != nil {
+		return c.fns.Watch(ctx, c.client, obj, opts...)
+	}
+	return c.client.Watch(ctx, obj, opts...)
+}


### PR DESCRIPTION
## Description

The current TLS reconciliation logic was not tested for error cases. This PR adds test cases that simulate various failure scenarios such as invalid or missing certificates, and k8s api call errors. These tests will verify that the operator can detect these issues and log appropriate error messages.