### PR TITLE
Fix declarative config test annotation

### DIFF
--- a/qa-tests-backend/src/test/groovy/DeclarativeConfigTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DeclarativeConfigTest.groovy
@@ -16,6 +16,8 @@ import io.stackrox.proto.storage.RoleOuterClass.SimpleAccessScope
 import io.stackrox.proto.storage.RoleOuterClass.Role
 import io.stackrox.proto.storage.TraitsOuterClass.Traits
 
+import util.Env
+
 import services.AuthProviderService
 import services.GroupService
 import services.IntegrationHealthService


### PR DESCRIPTION
## Description

Fixes the initialization error here: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/branch-ci-stackrox-stackrox-nightlies-gke-qa-e2e-tests/1640223063058419712


## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

