### PR TITLE
Remove ListAlert function from datastore that used v1.ListAlertRequest

### DIFF
--- a/central/alert/datastore/bench_postgres_test.go
+++ b/central/alert/datastore/bench_postgres_test.go
@@ -123,7 +123,7 @@ func runSearch(ctx context.Context, t testing.TB, datastore DataStore, query *v1
 }
 
 func runSearchListAlerts(ctx context.Context, t testing.TB, datastore DataStore, expected []*violationsBySeverity) {
-	results, err := datastore.ListAlerts(ctx, &v1.ListAlertsRequest{})
+	results, err := datastore.SearchListAlerts(ctx, pkgSearch.EmptyQuery())
 	require.NoError(t, err)
 	require.NotNil(t, results)
 

--- a/central/alert/datastore/datastore.go
+++ b/central/alert/datastore/datastore.go
@@ -37,7 +37,6 @@ type DataStore interface {
 	SearchRawAlerts(ctx context.Context, q *v1.Query) ([]*storage.Alert, error)
 	SearchListAlerts(ctx context.Context, q *v1.Query) ([]*storage.ListAlert, error)
 
-	ListAlerts(ctx context.Context, request *v1.ListAlertsRequest) ([]*storage.ListAlert, error)
 	WalkAll(ctx context.Context, fn func(alert *storage.ListAlert) error) error
 	GetAlert(ctx context.Context, id string) (*storage.Alert, bool, error)
 	CountAlerts(ctx context.Context) (int, error)

--- a/central/alert/datastore/datastore_impl.go
+++ b/central/alert/datastore/datastore_impl.go
@@ -3,7 +3,6 @@ package datastore
 import (
 	"context"
 	"fmt"
-	"math"
 	"time"
 
 	"github.com/gogo/protobuf/types"
@@ -26,7 +25,6 @@ import (
 	"github.com/stackrox/rox/pkg/postgres/pgutils"
 	"github.com/stackrox/rox/pkg/sac"
 	searchCommon "github.com/stackrox/rox/pkg/search"
-	"github.com/stackrox/rox/pkg/search/paginated"
 	"github.com/stackrox/rox/pkg/sync"
 )
 
@@ -81,28 +79,6 @@ func (ds *datastoreImpl) SearchRawAlerts(ctx context.Context, q *v1.Query) ([]*s
 	defer metrics.SetDatastoreFunctionDuration(time.Now(), "Alert", "SearchRawAlerts")
 
 	return ds.searcher.SearchRawAlerts(ctx, q)
-}
-
-func (ds *datastoreImpl) ListAlerts(ctx context.Context, request *v1.ListAlertsRequest) ([]*storage.ListAlert, error) {
-	var q *v1.Query
-	if request.GetQuery() == "" {
-		q = searchCommon.EmptyQuery()
-	} else {
-		var err error
-		q, err = searchCommon.ParseQuery(request.GetQuery())
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	paginated.FillPagination(q, request.GetPagination(), math.MaxInt32)
-	q = paginated.FillDefaultSortOption(q, paginated.GetViolationTimeSortOption())
-
-	alerts, err := ds.SearchListAlerts(ctx, q)
-	if err != nil {
-		return nil, err
-	}
-	return alerts, nil
 }
 
 // GetAlert returns an alert by id.

--- a/central/alert/datastore/datastore_sac_test.go
+++ b/central/alert/datastore/datastore_sac_test.go
@@ -649,7 +649,7 @@ func (s *alertDatastoreSACTestSuite) TestAlertUnrestrictedSearchListAlerts() {
 
 func (s *alertDatastoreSACTestSuite) runListAlertsTest(testparams alertSACSearchResult) {
 	ctx := s.testContexts[testparams.scopeKey]
-	searchResults, err := s.datastore.ListAlerts(ctx, nil)
+	searchResults, err := s.datastore.SearchListAlerts(ctx, searchPkg.EmptyQuery())
 	s.NoError(err)
 	resultsDistribution := countListAlertsResultsPerClusterAndNamespace(searchResults)
 	testutils.ValidateSACSearchResultDistribution(&s.Suite, testparams.resultCounts, resultsDistribution)

--- a/central/alert/datastore/mocks/datastore.go
+++ b/central/alert/datastore/mocks/datastore.go
@@ -102,21 +102,6 @@ func (mr *MockDataStoreMockRecorder) GetAlert(ctx, id interface{}) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAlert", reflect.TypeOf((*MockDataStore)(nil).GetAlert), ctx, id)
 }
 
-// ListAlerts mocks base method.
-func (m *MockDataStore) ListAlerts(ctx context.Context, request *v1.ListAlertsRequest) ([]*storage.ListAlert, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListAlerts", ctx, request)
-	ret0, _ := ret[0].([]*storage.ListAlert)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListAlerts indicates an expected call of ListAlerts.
-func (mr *MockDataStoreMockRecorder) ListAlerts(ctx, request interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAlerts", reflect.TypeOf((*MockDataStore)(nil).ListAlerts), ctx, request)
-}
-
 // MarkAlertStaleBatch mocks base method.
 func (m *MockDataStore) MarkAlertStaleBatch(ctx context.Context, id ...string) ([]*storage.Alert, error) {
 	m.ctrl.T.Helper()

--- a/central/risk/getters/alert.go
+++ b/central/risk/getters/alert.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 )
 
-// AlertGetter provides the required access to alerts for risk scoring.
-type AlertGetter interface {
-	ListAlerts(ctx context.Context, request *v1.ListAlertsRequest) ([]*storage.ListAlert, error)
+// AlertSearcher provides the required access to alerts for risk scoring.
+type AlertSearcher interface {
+	SearchListAlerts(ctx context.Context, q *v1.Query) ([]*storage.ListAlert, error)
 }

--- a/central/risk/getters/alert_mock.go
+++ b/central/risk/getters/alert_mock.go
@@ -14,6 +14,7 @@ type MockAlertsSearcher struct {
 	Alerts []*storage.ListAlert
 }
 
+// SearchListAlerts implements the AlertsSearcher interface
 func (m MockAlertsSearcher) SearchListAlerts(_ context.Context, q *v1.Query) (alerts []*storage.ListAlert, err error) {
 	state := storage.ViolationState_ACTIVE.String()
 	search.ApplyFnToAllBaseQueries(q, func(bq *v1.BaseQuery) {

--- a/central/risk/getters/alert_mock.go
+++ b/central/risk/getters/alert_mock.go
@@ -9,19 +9,12 @@ import (
 	"github.com/stackrox/rox/pkg/search"
 )
 
-// MockAlertsGetter is a mock AlertsGetter.
-type MockAlertsGetter struct {
+// MockAlertsSearcher is a mock AlertsSearcher.
+type MockAlertsSearcher struct {
 	Alerts []*storage.ListAlert
 }
 
-// ListAlerts supports a limited set of request parameters.
-// It only needs to be as specific as the production code.
-func (m MockAlertsGetter) ListAlerts(_ context.Context, req *v1.ListAlertsRequest) (alerts []*storage.ListAlert, err error) {
-	q, err := search.ParseQuery(req.GetQuery())
-	if err != nil {
-		return nil, err
-	}
-
+func (m MockAlertsSearcher) SearchListAlerts(ctx context.Context, q *v1.Query) (alerts []*storage.ListAlert, err error) {
 	state := storage.ViolationState_ACTIVE.String()
 	search.ApplyFnToAllBaseQueries(q, func(bq *v1.BaseQuery) {
 		mfQ, ok := bq.GetQuery().(*v1.BaseQuery_MatchFieldQuery)

--- a/central/risk/getters/alert_mock.go
+++ b/central/risk/getters/alert_mock.go
@@ -14,7 +14,7 @@ type MockAlertsSearcher struct {
 	Alerts []*storage.ListAlert
 }
 
-func (m MockAlertsSearcher) SearchListAlerts(ctx context.Context, q *v1.Query) (alerts []*storage.ListAlert, err error) {
+func (m MockAlertsSearcher) SearchListAlerts(_ context.Context, q *v1.Query) (alerts []*storage.ListAlert, err error) {
 	state := storage.ViolationState_ACTIVE.String()
 	search.ApplyFnToAllBaseQueries(q, func(bq *v1.BaseQuery) {
 		mfQ, ok := bq.GetQuery().(*v1.BaseQuery_MatchFieldQuery)

--- a/central/risk/multipliers/deployment/violations.go
+++ b/central/risk/multipliers/deployment/violations.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/stackrox/rox/central/risk/getters"
 	"github.com/stackrox/rox/central/risk/multipliers"
-	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/search"
@@ -28,7 +27,7 @@ var (
 
 // ViolationsMultiplier is a scorer for the violations on a deployment
 type ViolationsMultiplier struct {
-	getter getters.AlertGetter
+	searcher getters.AlertSearcher
 }
 
 type policyFactor struct {
@@ -37,9 +36,9 @@ type policyFactor struct {
 }
 
 // NewViolations scores the data based on the number and severity of policy violations.
-func NewViolations(getter getters.AlertGetter) *ViolationsMultiplier {
+func NewViolations(searcher getters.AlertSearcher) *ViolationsMultiplier {
 	return &ViolationsMultiplier{
-		getter: getter,
+		searcher: searcher,
 	}
 }
 
@@ -47,9 +46,7 @@ func NewViolations(getter getters.AlertGetter) *ViolationsMultiplier {
 func (v *ViolationsMultiplier) Score(ctx context.Context, deployment *storage.Deployment, _ map[string][]*storage.Risk_Result) *storage.Risk_Result {
 	qb := search.NewQueryBuilder().AddExactMatches(search.DeploymentID, deployment.GetId()).AddExactMatches(search.ViolationState, storage.ViolationState_ACTIVE.String())
 
-	alerts, err := v.getter.ListAlerts(ctx, &v1.ListAlertsRequest{
-		Query: qb.Query(),
-	})
+	alerts, err := v.searcher.SearchListAlerts(ctx, qb.ProtoQuery())
 	if err != nil {
 		log.Errorf("Couldn't get risk violations for %s: %s", deployment.GetId(), err)
 		return nil

--- a/central/risk/multipliers/deployment/violations_test.go
+++ b/central/risk/multipliers/deployment/violations_test.go
@@ -178,7 +178,7 @@ func TestViolationsScore(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			mult := NewViolations(&getters.MockAlertsGetter{
+			mult := NewViolations(&getters.MockAlertsSearcher{
 				Alerts: c.alerts,
 			})
 			deployment := multipliers.GetMockDeployment()

--- a/central/risk/scorer/deployment/scorer.go
+++ b/central/risk/scorer/deployment/scorer.go
@@ -26,14 +26,14 @@ type Scorer interface {
 }
 
 // NewDeploymentScorer returns a new scorer that encompasses multipliers for evaluating deployment risk
-func NewDeploymentScorer(alertGetter getters.AlertGetter, roles roleStore.DataStore, bindings bindingStore.DataStore, serviceAccounts saStore.DataStore, allowlistEvaluator evaluator.Evaluator) Scorer {
+func NewDeploymentScorer(alertSearcher getters.AlertSearcher, roles roleStore.DataStore, bindings bindingStore.DataStore, serviceAccounts saStore.DataStore, allowlistEvaluator evaluator.Evaluator) Scorer {
 	scoreImpl := &deploymentScorerImpl{
 		// These multipliers are intentionally ordered based on the order that we want them to be displayed in.
 		// Order aligns with the maximum output multiplier value, which would make sense to correlate
 		// with how important a specific multiplier is.
 		// DO NOT REORDER WITHOUT THOUGHT.
 		ConfiguredMultipliers: []deployment.Multiplier{
-			deployment.NewViolations(alertGetter),
+			deployment.NewViolations(alertSearcher),
 			deployment.NewProcessBaselines(allowlistEvaluator),
 			deployment.NewImageMultiplier(image.VulnerabilitiesHeading),
 			deployment.NewServiceConfig(),

--- a/central/risk/scorer/deployment/scorer_test.go
+++ b/central/risk/scorer/deployment/scorer_test.go
@@ -43,7 +43,7 @@ func TestScore(t *testing.T) {
 	mockEvaluator := evaluatorMocks.NewMockEvaluator(mockCtrl)
 
 	deployment := pkgScorer.GetMockDeployment()
-	scorer := NewDeploymentScorer(&getters.MockAlertsGetter{
+	scorer := NewDeploymentScorer(&getters.MockAlertsSearcher{
 		Alerts: []*storage.ListAlert{
 			{
 				Entity: &storage.ListAlert_Deployment{Deployment: &storage.ListAlertDeployment{}},


### PR DESCRIPTION
## Description

```
 percent | exec_min | max_time | mean_time |  calls   |   rows   |                                                                query                                                                
---------+----------+----------+-----------+----------+----------+-------------------------------------------------------------------------------------------------------------------------------------
       5 |      129 |      386 |         1 | 14833342 | 61640777 | select "alerts".serialized from alerts where (alerts.Deployment_Id = $1 and (alerts.State = $2)) order by alerts.Time desc LIMIT $3
```

Can remove the sort for this query which is due to risk
```
central_active=# explain analyze select serialized from alerts where state = 0 and deployment_id = '4790c16b-af89-4fae-9809-10e06de4f84e' order by Time;
                                                             QUERY PLAN                                                              
-------------------------------------------------------------------------------------------------------------------------------------
 Sort  (cost=56.27..56.27 rows=1 width=41) (actual time=0.257..0.258 rows=5 loops=1)
   Sort Key: "time"
   Sort Method: quicksort  Memory: 25kB
   ->  Index Scan using alerts_deployment_id on alerts  (cost=0.00..56.26 rows=1 width=41) (actual time=0.137..0.236 rows=5 loops=1)
         Index Cond: (deployment_id = '4790c16b-af89-4fae-9809-10e06de4f84e'::uuid)
         Filter: (state = 0)
 Planning Time: 0.624 ms
 Execution Time: 0.309 ms
(8 rows)

central_active=# explain analyze select serialized from alerts where state = 0 and deployment_id = '4790c16b-af89-4fae-9809-10e06de4f84e';
                                                          QUERY PLAN                                                           
-------------------------------------------------------------------------------------------------------------------------------
 Index Scan using alerts_deployment_id on alerts  (cost=0.00..56.26 rows=1 width=33) (actual time=0.087..0.161 rows=5 loops=1)
   Index Cond: (deployment_id = '4790c16b-af89-4fae-9809-10e06de4f84e'::uuid)
   Filter: (state = 0)
 Planning Time: 0.111 ms
 Execution Time: 0.179 ms
(5 rows)
```

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
