### PR TITLE
Fix errors due to timeouts through net.Error interface

### DIFF
--- a/central/sensor/service/connection/worker_queue.go
+++ b/central/sensor/service/connection/worker_queue.go
@@ -66,7 +66,7 @@ func (w *workerQueue) runWorker(ctx context.Context, idx int, stopSig *concurren
 	queue := w.queues[idx]
 	for msg := queue.pullBlocking(stopSig); msg != nil; msg = queue.pullBlocking(stopSig) {
 		err := handler(ctx, msg)
-		if err != nil {
+		if err != nil && err != context.Canceled {
 			if pgutils.IsTransientError(err) {
 				msg.ProcessingAttempt++
 

--- a/central/sensor/service/pipeline/all/pipeline.go
+++ b/central/sensor/service/pipeline/all/pipeline.go
@@ -60,6 +60,9 @@ func (s *pipelineImpl) Run(ctx context.Context, msg *central.MsgFromSensor, inje
 				err = fragment.Run(ctx, s.clusterID, msg, injector)
 			})
 			if err != nil {
+				if err == context.Canceled {
+					return nil
+				}
 				return errors.Wrap(err, "processing message from sensor")
 			}
 			if panicErr != nil {

--- a/pkg/postgres/pgutils/error.go
+++ b/pkg/postgres/pgutils/error.go
@@ -6,6 +6,7 @@ import (
 	"syscall"
 
 	"github.com/jackc/pgconn"
+	"github.com/jackc/pgx/v4"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/pkg/errorhelpers"
 	"github.com/stackrox/rox/pkg/set"

--- a/pkg/postgres/pgutils/error.go
+++ b/pkg/postgres/pgutils/error.go
@@ -6,10 +6,10 @@ import (
 	"syscall"
 
 	"github.com/jackc/pgconn"
-	"github.com/jackc/pgx/v4"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/pkg/errorhelpers"
 	"github.com/stackrox/rox/pkg/set"
+	"golang.org/x/net/context"
 )
 
 var transientPGCodes = set.NewFrozenStringSet(
@@ -59,6 +59,9 @@ func IsTransientError(err error) bool {
 		return false
 	}
 	if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+		return true
+	}
+	if errorhelpers.IsAny(err, context.DeadlineExceeded) {
 		return true
 	}
 	return errorhelpers.IsAny(err, io.EOF, io.ErrUnexpectedEOF, io.ErrClosedPipe, syscall.ECONNREFUSED, syscall.ECONNRESET, syscall.ECONNABORTED, syscall.EPIPE)

--- a/pkg/postgres/pgutils/error.go
+++ b/pkg/postgres/pgutils/error.go
@@ -58,13 +58,10 @@ func IsTransientError(err error) bool {
 	if errorhelpers.IsAny(err, pgx.ErrNoRows, pgx.ErrTxClosed, pgx.ErrTxCommitRollback) {
 		return false
 	}
-	if netErr := (*net.OpError)(nil); errors.As(err, &netErr) {
-		if netErr.Temporary() || netErr.Timeout() {
-			return true
-		}
-		return errorhelpers.IsAny(err, syscall.ECONNREFUSED, syscall.ECONNRESET, syscall.ECONNABORTED, syscall.EPIPE)
+	if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+		return true
 	}
-	return errorhelpers.IsAny(err, io.EOF, io.ErrUnexpectedEOF, io.ErrClosedPipe)
+	return errorhelpers.IsAny(err, io.EOF, io.ErrUnexpectedEOF, io.ErrClosedPipe, syscall.ECONNREFUSED, syscall.ECONNRESET, syscall.ECONNABORTED, syscall.EPIPE)
 }
 
 const (


### PR DESCRIPTION
## Description

The net.Error interface is better because there are a wide variety of errors we may hit. Temporary() comments say not to use it

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Will run a proxy to make sure this happens and that the error is returned