### PR TITLE
Syslog integration CEF fields improvements

### DIFF
--- a/pkg/notifiers/syslog/syslog.go
+++ b/pkg/notifiers/syslog/syslog.go
@@ -188,7 +188,7 @@ func alertToCEF(alert *storage.Alert, notifier *storage.Notifier) string {
 
 	severity := alertToCEFSeverityMap[alert.GetPolicy().GetSeverity()]
 
-	return getCEFHeaderWithExtension(fmt.Sprintf("Policy.{%s}", alert.GetPolicy().GetId()), alert.GetPolicy().GetName(), severity, makeExtensionFromPairs(extensionList))
+	return getCEFHeaderWithExtension("Alert", alert.GetPolicy().GetName(), severity, makeExtensionFromPairs(extensionList))
 }
 
 func getCEFHeaderWithExtension(deviceEventClassID, name string, severity int, extension string) string {

--- a/pkg/notifiers/syslog/syslog.go
+++ b/pkg/notifiers/syslog/syslog.go
@@ -188,7 +188,7 @@ func alertToCEF(alert *storage.Alert, notifier *storage.Notifier) string {
 
 	severity := alertToCEFSeverityMap[alert.GetPolicy().GetSeverity()]
 
-	return getCEFHeaderWithExtension("Alert", alert.GetPolicy().GetName(), severity, makeExtensionFromPairs(extensionList))
+	return getCEFHeaderWithExtension(fmt.Sprintf("Policy.{%s}", alert.GetPolicy().GetId()), alert.GetPolicy().GetName(), severity, makeExtensionFromPairs(extensionList))
 }
 
 func getCEFHeaderWithExtension(deviceEventClassID, name string, severity int, extension string) string {

--- a/pkg/notifiers/syslog/syslog.go
+++ b/pkg/notifiers/syslog/syslog.go
@@ -192,7 +192,7 @@ func alertToCEF(alert *storage.Alert, notifier *storage.Notifier) string {
 }
 
 func getCEFHeaderWithExtension(deviceEventClassID, name string, severity int, extension string) string {
-	return fmt.Sprintf("CEF:0|StackRox|Kubernetes Security Platform|%s|%s|%d|%s|%s", version.GetMainVersion(), deviceEventClassID, severity, name, extension)
+	return fmt.Sprintf("CEF:0|StackRox|Kubernetes Security Platform|%s|%s|%s|%d|%s", version.GetMainVersion(), deviceEventClassID, name, severity, extension)
 }
 
 func makeExtensionPair(key, value string) string {


### PR DESCRIPTION
## Description

* Fixes the ordering of fields to match the CEF standard
* ~~Changes the CEF signature field to indicate the ID of the policy that was violated~~

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Waiting for CI run. I could add a test to validate the order of CEF fields?

https://github.com/stackrox/stackrox/issues/5400