### PR TITLE
ROX-14150: Add create command for declarative configs

### DIFF
--- a/pkg/declarativeconfig/access_scope.go
+++ b/pkg/declarativeconfig/access_scope.go
@@ -22,9 +22,9 @@ func (a *AccessScope) Type() ConfigurationType {
 type Operator storage.SetBasedLabelSelector_Operator
 
 // MarshalYAML transforms Operator to YAML format.
-func (a Operator) MarshalYAML() ([]byte, error) {
+func (a Operator) MarshalYAML() (interface{}, error) {
 	protoAccess := storage.SetBasedLabelSelector_Operator(a)
-	return []byte(protoAccess.String()), nil
+	return protoAccess.String(), nil
 }
 
 // UnmarshalYAML makes transformation from YAML to Operator.

--- a/pkg/declarativeconfig/access_scope_test.go
+++ b/pkg/declarativeconfig/access_scope_test.go
@@ -9,31 +9,41 @@ import (
 )
 
 func TestAccessScopeYAMLTransformation(t *testing.T) {
-	data := []byte(`
-name: test-name
+	data := []byte(`name: test-name
 description: test-description
 rules:
-  included:
-    - cluster: clusterA
-      namespaces:
-      - namespaceA1
-      - namespaceA2
-    - cluster: clusterB
-  clusterLabelSelectors:
-    - requirements:
-      - key: a
-        operator: IN
-        values: [a, b, c]
-      - key: b
-        operator: NOT_IN
-        values: [b, d]
-    - requirements:
-      - key: c
-        operator: IN
-        values: [d, e, f]
-      - key: d
-        operator: NOT_IN
-        values: [x, y, z]
+    included:
+        - cluster: clusterA
+          namespaces:
+            - namespaceA1
+            - namespaceA2
+        - cluster: clusterB
+    clusterLabelSelectors:
+        - requirements:
+            - key: a
+              operator: IN
+              values:
+                - a
+                - b
+                - c
+            - key: b
+              operator: NOT_IN
+              values:
+                - b
+                - d
+        - requirements:
+            - key: c
+              operator: IN
+              values:
+                - d
+                - e
+                - f
+            - key: d
+              operator: NOT_IN
+              values:
+                - x
+                - "y"
+                - z
 `)
 	as := AccessScope{}
 
@@ -70,4 +80,8 @@ rules:
 	assert.Equal(t, as.Rules.ClusterLabelSelectors[1].Requirements[1].Key, "d")
 	assert.Equal(t, as.Rules.ClusterLabelSelectors[1].Requirements[1].Values, []string{"x", "y", "z"})
 	assert.Len(t, as.Rules.NamespaceLabelSelectors, 0)
+
+	bytes, err := yaml.Marshal(&as)
+	assert.NoError(t, err)
+	assert.Equal(t, string(data), string(bytes))
 }

--- a/pkg/declarativeconfig/auth_provider_test.go
+++ b/pkg/declarativeconfig/auth_provider_test.go
@@ -8,27 +8,27 @@ import (
 )
 
 func TestAuthProviderYAMLTransformation_OIDC(t *testing.T) {
-	data := []byte(`
-name: test-name
-requiredAttributes:
-- key: "groups"
-  value: "stackrox"
-minimumRole: "None"
-uiEndpoint: "localhost:8000"
-extraUIEndpoints: ["localhost:8001"]
+	data := []byte(`name: test-name
+minimumRole: None
+uiEndpoint: localhost:8000
+extraUIEndpoints:
+    - localhost:8001
 groups:
-- key: "email"
-  value: "admin@stackrox.com"
-  role: "Admin"
-- key: "email"
-  value: "someone@stackrox.com"
-  role: "Analyst"
+    - key: email
+      value: admin@stackrox.com
+      role: Admin
+    - key: email
+      value: someone@stackrox.com
+      role: Analyst
+requiredAttributes:
+    - key: groups
+      value: stackrox
 oidc:
-  issuer: "https://stackrox.com"
-  mode: "auto"
-  clientID: "some-client-id"
-  clientSecret: "some-client-secret"
-  disableOfflineAccessScope: true
+    issuer: https://stackrox.com
+    mode: auto
+    clientID: some-client-id
+    clientSecret: some-client-secret
+    disableOfflineAccessScope: true
 `)
 	ap := AuthProvider{}
 
@@ -63,6 +63,10 @@ oidc:
 	assert.Equal(t, "auto", ap.OIDCConfig.CallbackMode)
 	assert.Equal(t, "https://stackrox.com", ap.OIDCConfig.Issuer)
 	assert.True(t, ap.OIDCConfig.DisableOfflineAccessScope)
+
+	bytes, err := yaml.Marshal(&ap)
+	assert.NoError(t, err)
+	assert.Equal(t, string(data), string(bytes))
 }
 
 func TestAuthProviderYAMLTransformation_SAML(t *testing.T) {

--- a/pkg/declarativeconfig/permission_set.go
+++ b/pkg/declarativeconfig/permission_set.go
@@ -28,9 +28,9 @@ type ResourceWithAccess struct {
 }
 
 // MarshalYAML transforms Access to YAML format.
-func (a Access) MarshalYAML() ([]byte, error) {
+func (a Access) MarshalYAML() (interface{}, error) {
 	protoAccess := storage.Access(a)
-	return []byte(protoAccess.String()), nil
+	return protoAccess.String(), nil
 }
 
 // UnmarshalYAML makes transformation from YAML to Access.

--- a/pkg/declarativeconfig/permission_set_test.go
+++ b/pkg/declarativeconfig/permission_set_test.go
@@ -9,14 +9,13 @@ import (
 )
 
 func TestPermissionSetYAMLTransformation(t *testing.T) {
-	data := []byte(`
-name: test-name
+	data := []byte(`name: test-name
 description: test-description
 resources:
-- resource: a
-  access: READ_ACCESS
-- resource: b
-  access: READ_WRITE_ACCESS
+    - resource: a
+      access: READ_ACCESS
+    - resource: b
+      access: READ_WRITE_ACCESS
 `)
 	ps := PermissionSet{}
 
@@ -31,4 +30,8 @@ resources:
 	assert.Equal(t, "b", resourceB.Resource)
 	assert.Equal(t, storage.Access_READ_ACCESS, storage.Access(resourceA.Access))
 	assert.Equal(t, storage.Access_READ_WRITE_ACCESS, storage.Access(resourceB.Access))
+
+	bytes, err := yaml.Marshal(&ps)
+	assert.NoError(t, err)
+	assert.Equal(t, string(data), string(bytes))
 }

--- a/pkg/declarativeconfig/role_test.go
+++ b/pkg/declarativeconfig/role_test.go
@@ -8,8 +8,7 @@ import (
 )
 
 func TestRoleYAMLTransformation(t *testing.T) {
-	data := []byte(`
-name: test-name
+	data := []byte(`name: test-name
 description: test-description
 accessScope: access-scope
 permissionSet: permission-set
@@ -22,4 +21,8 @@ permissionSet: permission-set
 	assert.Equal(t, "test-description", role.Description)
 	assert.Equal(t, "access-scope", role.AccessScope)
 	assert.Equal(t, "permission-set", role.PermissionSet)
+
+	bytes, err := yaml.Marshal(&role)
+	assert.NoError(t, err)
+	assert.Equal(t, string(data), string(bytes))
 }

--- a/pkg/declarativeconfig/transform/access_scope.go
+++ b/pkg/declarativeconfig/transform/access_scope.go
@@ -4,9 +4,12 @@ import (
 	"reflect"
 
 	"github.com/gogo/protobuf/proto"
+	"github.com/hashicorp/go-multierror"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/declarativeconfig"
 	"github.com/stackrox/rox/pkg/errox"
+	"github.com/stackrox/rox/pkg/sac/effectiveaccessscope"
+	"k8s.io/apimachinery/pkg/labels"
 )
 
 var _ Transformer = (*accessScopeTransform)(nil)
@@ -22,11 +25,15 @@ func (a *accessScopeTransform) Transform(configuration declarativeconfig.Configu
 	if !ok {
 		return nil, errox.InvalidArgs.Newf("invalid configuration type received for access scope: %T", configuration)
 	}
+	rules, err := rulesFromScopeConfig(scopeConfig)
+	if err != nil {
+		return nil, errox.InvalidArgs.CausedBy(err)
+	}
 	scopeProto := &storage.SimpleAccessScope{
 		Id:          declarativeconfig.NewDeclarativeAccessScopeUUID(scopeConfig.Name).String(),
 		Name:        scopeConfig.Name,
 		Description: scopeConfig.Description,
-		Rules:       rulesFromScopeConfig(scopeConfig),
+		Rules:       rules,
 		Traits: &storage.Traits{
 			Origin: storage.Traits_DECLARATIVE,
 		},
@@ -37,13 +44,22 @@ func (a *accessScopeTransform) Transform(configuration declarativeconfig.Configu
 	}, nil
 }
 
-func rulesFromScopeConfig(scope *declarativeconfig.AccessScope) *storage.SimpleAccessScope_Rules {
+func rulesFromScopeConfig(scope *declarativeconfig.AccessScope) (*storage.SimpleAccessScope_Rules, error) {
+	clusterLabelSelectors, err := labelSelectorsFromScopeConfig(scope.Rules.ClusterLabelSelectors)
+	if err != nil {
+		return nil, err
+	}
+	namespaceLabelSelectors, err := labelSelectorsFromScopeConfig(scope.Rules.NamespaceLabelSelectors)
+	if err != nil {
+		return nil, err
+	}
+
 	return &storage.SimpleAccessScope_Rules{
 		IncludedClusters:        includedClustersFromScopeConfig(scope),
 		IncludedNamespaces:      includedNamespacesFromScopeConfig(scope),
-		ClusterLabelSelectors:   labelSelectorsFromScopeConfig(scope.Rules.ClusterLabelSelectors),
-		NamespaceLabelSelectors: labelSelectorsFromScopeConfig(scope.Rules.NamespaceLabelSelectors),
-	}
+		ClusterLabelSelectors:   clusterLabelSelectors,
+		NamespaceLabelSelectors: namespaceLabelSelectors,
+	}, nil
 }
 
 func includedClustersFromScopeConfig(scope *declarativeconfig.AccessScope) []string {
@@ -72,14 +88,21 @@ func includedNamespacesFromScopeConfig(scope *declarativeconfig.AccessScope) []*
 	return namespaces
 }
 
-func labelSelectorsFromScopeConfig(labelSelectors []declarativeconfig.LabelSelector) []*storage.SetBasedLabelSelector {
+func labelSelectorsFromScopeConfig(labelSelectors []declarativeconfig.LabelSelector) ([]*storage.SetBasedLabelSelector, error) {
 	var setBasedLabelSelectors []*storage.SetBasedLabelSelector
+	var labelSelectorErrs *multierror.Error
 	for _, ls := range labelSelectors {
 		reqs := make([]*storage.SetBasedLabelSelector_Requirement, 0, len(ls.Requirements))
 		for _, req := range ls.Requirements {
+			op := storage.SetBasedLabelSelector_Operator(req.Operator)
+			selectionOperator := effectiveaccessscope.ConvertLabelSelectorOperatorToSelectionOperator(op)
+			if _, err := labels.NewRequirement(req.Key, selectionOperator, req.Values); err != nil {
+				labelSelectorErrs = multierror.Append(labelSelectorErrs, err)
+				continue
+			}
 			reqs = append(reqs, &storage.SetBasedLabelSelector_Requirement{
 				Key:    req.Key,
-				Op:     storage.SetBasedLabelSelector_Operator(req.Operator),
+				Op:     op,
 				Values: req.Values,
 			})
 		}
@@ -87,5 +110,5 @@ func labelSelectorsFromScopeConfig(labelSelectors []declarativeconfig.LabelSelec
 			Requirements: reqs,
 		})
 	}
-	return setBasedLabelSelectors
+	return setBasedLabelSelectors, labelSelectorErrs.ErrorOrNil()
 }

--- a/pkg/declarativeconfig/transform/access_scope_test.go
+++ b/pkg/declarativeconfig/transform/access_scope_test.go
@@ -19,6 +19,26 @@ func TestWrongConfigurationTypeTransformAccessScope(t *testing.T) {
 	assert.ErrorIs(t, err, errox.InvalidArgs)
 }
 
+func TestTransformAccessScope_InvalidLabelSelector(t *testing.T) {
+	at := newAccessScopeTransform()
+
+	scopeConfig := &declarativeconfig.AccessScope{
+		Name:        "test-scope",
+		Description: "test description",
+		Rules: declarativeconfig.Rules{
+			ClusterLabelSelectors: []declarativeconfig.LabelSelector{
+				{Requirements: []declarativeconfig.Requirement{
+					{
+						Key:      "a",
+						Operator: declarativeconfig.Operator(storage.LabelSelector_EXISTS),
+						Values:   []string{"a", "b", "c"}}}}}},
+	}
+
+	msgs, err := at.Transform(scopeConfig)
+	assert.ErrorIs(t, err, errox.InvalidArgs)
+	assert.Nil(t, msgs)
+}
+
 func TestTransformAccessScope(t *testing.T) {
 	at := newAccessScopeTransform()
 

--- a/pkg/declarativeconfig/transform/role.go
+++ b/pkg/declarativeconfig/transform/role.go
@@ -27,6 +27,16 @@ func (r *roleTransform) Transform(configuration declarativeconfig.Configuration)
 		return nil, errox.InvalidArgs.Newf("invalid configuration type received for role: %T", configuration)
 	}
 
+	if roleConfig.Name == "" {
+		return nil, errox.InvalidArgs.CausedBy("name must be non-empty")
+	}
+	if roleConfig.AccessScope == "" {
+		return nil, errox.InvalidArgs.CausedBy("access scope must be non-empty")
+	}
+	if roleConfig.PermissionSet == "" {
+		return nil, errox.InvalidArgs.CausedBy("permission set must be non-empty")
+	}
+
 	roleProto := &storage.Role{
 		Name:            roleConfig.Name,
 		Description:     roleConfig.Description,

--- a/pkg/declarativeconfig/transform/role_test.go
+++ b/pkg/declarativeconfig/transform/role_test.go
@@ -18,6 +18,44 @@ func TestWrongConfigurationTypeTransformRole(t *testing.T) {
 	assert.ErrorIs(t, err, errox.InvalidArgs)
 }
 
+func TestTransformRole_EmptyValues(t *testing.T) {
+	cases := map[string]struct {
+		role *declarativeconfig.Role
+		err  error
+	}{
+		"empty name": {
+			role: &declarativeconfig.Role{
+				AccessScope:   "and an access scope",
+				PermissionSet: "as well as a permission set",
+			},
+			err: errox.InvalidArgs,
+		},
+		"empty permission set": {
+			role: &declarativeconfig.Role{
+				Name:        "some-role",
+				AccessScope: "and an access scope",
+			},
+			err: errox.InvalidArgs,
+		},
+		"empty access scope": {
+			role: &declarativeconfig.Role{
+				Name:          "some-role",
+				PermissionSet: "as well as a permission set",
+			},
+			err: errox.InvalidArgs,
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			rt := newRoleTransform()
+			protos, err := rt.Transform(c.role)
+			assert.Nil(t, protos)
+			assert.ErrorIs(t, err, c.err)
+		})
+	}
+}
+
 func TestTransformRole(t *testing.T) {
 	role := &declarativeconfig.Role{
 		Name:          "some-role",

--- a/roxctl/declarativeconfig/create/access_scope.go
+++ b/roxctl/declarativeconfig/create/access_scope.go
@@ -28,8 +28,8 @@ Each tuple represents a requirement, which will be used to construct the label s
 You may specify this flag multiple times, to create a conjunction of requirements which should apply for a label selector
 to match.
 
-Example of a label selector requiring values: --cluster-label-selector "key=kubernetes.io/hostname;operator=IN;values=nodeA,nodeB"
-Example of a label selector not requiring values: --cluster-label-selector "key=custom-label;operator=EXISTS"
+Example of a label selector requiring values: --%s "key=kubernetes.io/hostname;operator=IN;values=nodeA,nodeB"
+Example of a label selector not requiring values: --%s "key=custom-label;operator=EXISTS"
 
 NOTE: The created access scope will only contain a single label selector, where each specified requirement
 will be in conjunction. If you desire to create multiple label selectors, you have to adjust the YAML output manually.
@@ -66,10 +66,10 @@ In case only a subset of namespace should be included, specify --included cluste
 	// if they wish to do so.
 
 	cmd.Flags().Var(&requirementFlag{requirements: &accessScopeCmd.clusterRequirements}, "cluster-label-selector",
-		labelSelectorUsage)
+		fmt.Sprintf(labelSelectorUsage, "cluster-label-selector", "cluster-label-selector"))
 
 	cmd.Flags().Var(&requirementFlag{requirements: &accessScopeCmd.namespaceRequirements}, "namespace-label-selector",
-		labelSelectorUsage)
+		fmt.Sprintf(labelSelectorUsage, "namespace-label-selector", "namespace-label-selector"))
 
 	utils.Must(cmd.MarkFlagRequired("name"))
 

--- a/roxctl/declarativeconfig/create/access_scope.go
+++ b/roxctl/declarativeconfig/create/access_scope.go
@@ -153,10 +153,10 @@ func (r *requirementFlag) String() string {
 	res := make([]string, 0, len(*r.requirements))
 
 	for _, requirement := range *r.requirements {
-		requirementString := fmt.Sprintf("key=%s;operator=%s", requirement.Key,
+		requirementString := fmt.Sprintf("key=%q;operator=%q", requirement.Key,
 			storage.SetBasedLabelSelector_Operator(requirement.Operator))
 		if len(requirement.Values) != 0 {
-			requirementString = fmt.Sprintf("%s;values=%s",
+			requirementString = fmt.Sprintf("%s;values=%q",
 				requirementString, strings.Join(requirement.Values, ","))
 		}
 		res = append(res, requirementString)

--- a/roxctl/declarativeconfig/create/access_scope.go
+++ b/roxctl/declarativeconfig/create/access_scope.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stackrox/rox/pkg/declarativeconfig"
 	"github.com/stackrox/rox/pkg/declarativeconfig/transform"
 	"github.com/stackrox/rox/pkg/maputil"
+	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/rox/roxctl/common/environment"
 	"gopkg.in/yaml.v3"
 )
@@ -68,6 +69,8 @@ In case only a subset of namespace should be included, specify --included cluste
 
 	cmd.Flags().Var(&requirementFlag{requirements: &accessScopeCmd.namespaceRequirements}, "namespace-label-selector",
 		labelSelectorUsage)
+
+	utils.Must(cmd.MarkFlagRequired("name"))
 
 	return cmd
 }
@@ -187,7 +190,7 @@ func retrieveRequirement(s string) (*declarativeconfig.Requirement, error) {
 	requirement := &declarativeconfig.Requirement{}
 	for _, kvPair := range kvPairs {
 		if strings.Count(kvPair, "=") != 1 {
-			return nil, fmt.Errorf("%s must specify key=value", s)
+			return nil, fmt.Errorf("%s must specify key=value", kvPair)
 		}
 
 		kv := strings.Split(kvPair, "=")

--- a/roxctl/declarativeconfig/create/access_scope.go
+++ b/roxctl/declarativeconfig/create/access_scope.go
@@ -39,8 +39,9 @@ func accessScopeCommand(cliEnvironment environment.Environment) *cobra.Command {
 	accessScopeCmd := accessScopeCmd{accessScope: &declarativeconfig.AccessScope{}, env: cliEnvironment}
 
 	cmd := &cobra.Command{
-		Use:  accessScopeCmd.accessScope.Type(),
-		Args: cobra.NoArgs,
+		Use:   accessScopeCmd.accessScope.Type(),
+		Short: "Create a declarative configuration for an access scope",
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := accessScopeCmd.Validate(); err != nil {
 				return err

--- a/roxctl/declarativeconfig/create/access_scope.go
+++ b/roxctl/declarativeconfig/create/access_scope.go
@@ -1,0 +1,213 @@
+package create
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/declarativeconfig"
+	"github.com/stackrox/rox/pkg/declarativeconfig/transform"
+	"github.com/stackrox/rox/pkg/maputil"
+	"github.com/stackrox/rox/roxctl/common/environment"
+	"gopkg.in/yaml.v3"
+)
+
+var (
+	_ pflag.Value = (*includedObjectsFlag)(nil)
+	_ pflag.Value = (*requirementFlag)(nil)
+)
+
+const labelSelectorUsage = `The flag consists of three key value pairs with the keys:
+key, value, operator. The key value pairs are expected to be separated with ;.
+Each tuple represents a requirement, which will be used to construct the label selector.
+You may specify this flag multiple times, to create a conjunction of requirements which should apply for a label selector
+to match.
+
+Example of a label selector requiring values: --cluster-label-selector "key=kubernetes.io/hostname;operator=IN;values=nodeA,nodeB"
+Example of a label selector not requiring values: --cluster-label-selector "key=custom-label;operator=EXISTS"
+
+NOTE: The created access scope will only contain a single label selector, where each specified requirement
+will be in conjunction. If you desire to create multiple label selectors, you have to adjust the YAML output manually.
+`
+
+func accessScopeCommand(cliEnvironment environment.Environment) *cobra.Command {
+	accessScopeCmd := accessScopeCmd{accessScope: &declarativeconfig.AccessScope{}, env: cliEnvironment}
+
+	cmd := &cobra.Command{
+		Use:  accessScopeCmd.accessScope.Type(),
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := accessScopeCmd.Validate(); err != nil {
+				return err
+			}
+			return accessScopeCmd.PrintYAML()
+		},
+	}
+
+	cmd.Flags().StringVar(&accessScopeCmd.accessScope.Name, "name", "", "name of the access scope")
+	cmd.Flags().StringVar(&accessScopeCmd.accessScope.Description, "description", "",
+		"description of the access scope")
+
+	cmd.Flags().Var(&includedObjectsFlag{includedObjects: &accessScopeCmd.accessScope.Rules.IncludedObjects}, "included",
+		`list of clusters and their namespaces that should be included within the access scope.
+In case all namespaces of a specific cluster should be included, specify --included cluster-name.
+In case only a subset of namespace should be included, specify --included cluster-name=namespaceA,namespaceB`)
+
+	// Currently, its only support to provide a single cluster-label-selector for the access scope.
+	// The reason is of the complexity of the resulting struct, its currently not possible to associated N requirements
+	// with M label selectors (cluster or namespace). Hence, the command line option only currently allows to create
+	// a single one, with the hint that advanced users may adjust the output YAML to include additional label selectors
+	// if they wish to do so.
+
+	cmd.Flags().Var(&requirementFlag{requirements: &accessScopeCmd.clusterRequirements}, "cluster-label-selector",
+		labelSelectorUsage)
+
+	cmd.Flags().Var(&requirementFlag{requirements: &accessScopeCmd.namespaceRequirements}, "namespace-label-selector",
+		labelSelectorUsage)
+
+	return cmd
+}
+
+type accessScopeCmd struct {
+	accessScope *declarativeconfig.AccessScope
+	env         environment.Environment
+
+	clusterRequirements   []declarativeconfig.Requirement
+	namespaceRequirements []declarativeconfig.Requirement
+}
+
+func (a *accessScopeCmd) Validate() error {
+	if len(a.clusterRequirements) > 0 {
+		a.accessScope.Rules.ClusterLabelSelectors = []declarativeconfig.LabelSelector{
+			{Requirements: a.clusterRequirements},
+		}
+	}
+	if len(a.namespaceRequirements) > 0 {
+		a.accessScope.Rules.NamespaceLabelSelectors = []declarativeconfig.LabelSelector{
+			{Requirements: a.namespaceRequirements},
+		}
+	}
+
+	t := transform.New()
+	_, err := t.Transform(a.accessScope)
+	return errors.Wrap(err, "validating access scope")
+}
+
+func (a *accessScopeCmd) PrintYAML() error {
+	enc := yaml.NewEncoder(a.env.InputOutput().Out())
+	return errors.Wrap(enc.Encode(a.accessScope), "creating the YAML output")
+}
+
+// Implementation of pflag.Value to support complex object declarativeconfig.IncludedObject.
+type includedObjectsFlag struct {
+	includedObjects *[]declarativeconfig.IncludedObject
+}
+
+func (i *includedObjectsFlag) String() string {
+	var res []string
+
+	for _, obj := range *i.includedObjects {
+		res = append(res, obj.Cluster+"="+strings.Join(obj.Namespaces, ","))
+	}
+
+	s, _ := json.Marshal(res)
+
+	return "[" + string(s) + "]"
+}
+
+func (i *includedObjectsFlag) Set(v string) error {
+	c := strings.Count(v, "=")
+	switch c {
+	case 0:
+		*i.includedObjects = append(*i.includedObjects, declarativeconfig.IncludedObject{Cluster: v})
+	case 1:
+		keyValuePair := strings.SplitN(v, "=", 2)
+		*i.includedObjects = append(*i.includedObjects, declarativeconfig.IncludedObject{
+			Cluster:    keyValuePair[0],
+			Namespaces: strings.Split(keyValuePair[1], ","),
+		})
+	default:
+		return fmt.Errorf("%s must be either formatted as key or as key=value pair", v)
+	}
+	return nil
+}
+
+func (i *includedObjectsFlag) Type() string {
+	return "included-object"
+}
+
+// Implementation of pflag.Value to support complex object declarativeconfig.Requirement.
+type requirementFlag struct {
+	requirements *[]declarativeconfig.Requirement
+}
+
+func (r *requirementFlag) String() string {
+	res := make([]string, 0, len(*r.requirements))
+
+	for _, requirement := range *r.requirements {
+		requirementString := fmt.Sprintf("key=%s;operator=%s", requirement.Key,
+			storage.SetBasedLabelSelector_Operator(requirement.Operator))
+		if len(requirement.Values) != 0 {
+			requirementString = fmt.Sprintf("%s;values=%s",
+				requirementString, strings.Join(requirement.Values, ","))
+		}
+		res = append(res, requirementString)
+	}
+
+	s, _ := json.Marshal(res)
+
+	return "[" + string(s) + "]"
+}
+
+func (r *requirementFlag) Set(v string) error {
+	requirement, err := retrieveRequirement(v)
+	if err != nil {
+		return err
+	}
+	*r.requirements = append(*r.requirements, *requirement)
+	return nil
+}
+
+func (r *requirementFlag) Type() string {
+	return "requirement"
+}
+
+func retrieveRequirement(s string) (*declarativeconfig.Requirement, error) {
+	c := strings.Count(s, ";")
+	if c != 1 && c != 2 {
+		return nil, fmt.Errorf("%s must either be formatted as key=v;operator=v or key=v;operator=v;values=v", s)
+	}
+
+	kvPairs := strings.Split(s, ";")
+
+	requirement := &declarativeconfig.Requirement{}
+	for _, kvPair := range kvPairs {
+		if strings.Count(kvPair, "=") != 1 {
+			return nil, fmt.Errorf("%s must specify key=value", s)
+		}
+
+		kv := strings.Split(kvPair, "=")
+
+		switch kv[0] {
+		case "key":
+			requirement.Key = kv[1]
+		case "operator":
+			op, ok := storage.SetBasedLabelSelector_Operator_value[kv[1]]
+			if !ok {
+				return nil, fmt.Errorf("operator %s must be one of the allowed values: [%s]", kvPair,
+					strings.Join(maputil.Keys(storage.SetBasedLabelSelector_Operator_value), ","))
+			}
+			requirement.Operator = declarativeconfig.Operator(op)
+		case "values":
+			requirement.Values = strings.Split(kv[1], ",")
+		default:
+			return nil, fmt.Errorf("%s must specify either key, operator, values", kvPair)
+		}
+	}
+
+	return requirement, nil
+}

--- a/roxctl/declarativeconfig/create/access_scope_test.go
+++ b/roxctl/declarativeconfig/create/access_scope_test.go
@@ -1,0 +1,121 @@
+package create
+
+import (
+	"testing"
+
+	"github.com/stackrox/rox/roxctl/common/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateAccessScope_Failures(t *testing.T) {
+	cases := map[string]struct {
+		args   []string
+		errOut string
+	}{
+		"missing name flag": {
+			args: []string{
+				"--description=some-description",
+			},
+			errOut: `Error: required flag(s) "name" not set
+`,
+		},
+		"invalid operator in label selector": {
+			args: []string{
+				"--name=some-name",
+				"--cluster-label-selector=key=some-key;operator=WRONG;values=some-value",
+			},
+		},
+		"invalid label selector flag value": {
+			args: []string{
+				"--name=some-name",
+				"--cluster-label-selector=key=some-key,operator=WRONG,values=some-value",
+			},
+			errOut: `Error: invalid argument "key=some-key,operator=WRONG,values=some-value" for "--cluster-label-selector" flag: key=some-key,operator=WRONG,values=some-value must either be formatted as key=v;operator=v or key=v;operator=v;values=v
+`,
+		},
+		"invalid label selector key value": {
+			args: []string{
+				"--name=some-name",
+				"--cluster-label-selector=key:some-key;operator=IN;values=some-value",
+			},
+			errOut: `Error: invalid argument "key:some-key;operator=IN;values=some-value" for "--cluster-label-selector" flag: key:some-key must specify key=value
+`,
+		},
+		"invalid included objects flag value": {
+			args: []string{
+				"--name=some-name",
+				"--included=cluster=namespace=",
+			},
+			errOut: `Error: invalid argument "cluster=namespace=" for "--included" flag: cluster=namespace= must be either formatted as key or as key=value pair
+`,
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			env, out, errOut := mocks.NewEnvWithConn(nil, t)
+			cmd := accessScopeCommand(env)
+			cmd.SetArgs(c.args)
+			cmd.SetOut(out)
+			cmd.SetErr(errOut)
+
+			err := cmd.Execute()
+			assert.Error(t, err)
+			if c.errOut != "" {
+				assert.Equal(t, c.errOut, errOut.String())
+			}
+		})
+	}
+}
+
+func TestCreateAccessScope_Success(t *testing.T) {
+	args := []string{
+		"--name=some-name",
+		"--description=some-description",
+		"--included=clusterA",
+		"--included=clusterB=namespaceA,namespaceB",
+		"--cluster-label-selector=key=some-key;operator=IN;values=some-value",
+		"--cluster-label-selector=key=some-key;operator=EXISTS",
+		"--namespace-label-selector=key=some-key;operator=IN;values=some-value",
+		"--namespace-label-selector=key=some-key;operator=EXISTS",
+	}
+
+	expectedYAML := `name: some-name
+description: some-description
+rules:
+    included:
+        - cluster: clusterA
+        - cluster: clusterB
+          namespaces:
+            - namespaceA
+            - namespaceB
+    clusterLabelSelectors:
+        - requirements:
+            - key: some-key
+              operator: IN
+              values:
+                - some-value
+            - key: some-key
+              operator: EXISTS
+    namespaceLabelSelectors:
+        - requirements:
+            - key: some-key
+              operator: IN
+              values:
+                - some-value
+            - key: some-key
+              operator: EXISTS
+`
+
+	env, out, errOut := mocks.NewEnvWithConn(nil, t)
+	cmd := accessScopeCommand(env)
+	cmd.SetArgs(args)
+	cmd.SetOut(out)
+	cmd.SetErr(errOut)
+
+	err := cmd.Execute()
+	assert.NoError(t, err)
+
+	assert.Empty(t, errOut)
+	assert.Equal(t, expectedYAML, out.String())
+}

--- a/roxctl/declarativeconfig/create/auth_provider.go
+++ b/roxctl/declarativeconfig/create/auth_provider.go
@@ -120,6 +120,9 @@ func (a *authProviderCmd) oidcCommand() *cobra.Command {
 		`list of non-standard claims from the IdP token that should be available within auth provider rules, e.g.
 --claim-mappings "my_claim_on_the_idp_token=claim_name_on_the_rox_token"`)
 
+	utils.Must(cmd.MarkFlagRequired("issuer"))
+	utils.Must(cmd.MarkFlagRequired("client-id"))
+
 	return cmd
 }
 
@@ -142,6 +145,10 @@ func (a *authProviderCmd) samlCommand() *cobra.Command {
 	cmd.Flags().StringVar(&a.samlConfig.NameIDFormat, "name-id-format", "",
 		"Name ID format")
 	cmd.Flags().StringVar(&a.samlConfig.IDPIssuer, "idp-issuer", "", "issuer of the IdP")
+
+	utils.Must(cmd.MarkFlagRequired("sp-issuer"))
+	cmd.MarkFlagsRequiredTogether("idp-cert", "sso-url", "idp-issuer")
+	cmd.MarkFlagsMutuallyExclusive("metadata-url", "sso-url")
 
 	return cmd
 }

--- a/roxctl/declarativeconfig/create/auth_provider.go
+++ b/roxctl/declarativeconfig/create/auth_provider.go
@@ -1,0 +1,266 @@
+package create
+
+import (
+	"os"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/stackrox/rox/pkg/declarativeconfig"
+	"github.com/stackrox/rox/pkg/declarativeconfig/transform"
+	"github.com/stackrox/rox/pkg/errox"
+	"github.com/stackrox/rox/pkg/utils"
+	"github.com/stackrox/rox/roxctl/common/environment"
+	"gopkg.in/yaml.v3"
+)
+
+func authProviderCommand(cliEnvironment environment.Environment) *cobra.Command {
+	authProviderCmd := &authProviderCmd{authProvider: &declarativeconfig.AuthProvider{}, env: cliEnvironment}
+
+	cmd := &cobra.Command{
+		Use: authProviderCmd.authProvider.Type(),
+	}
+
+	cmd.PersistentFlags().StringVar(&authProviderCmd.authProvider.Name, "name", "", "name of the auth provider")
+	cmd.PersistentFlags().StringVar(&authProviderCmd.authProvider.MinimumRoleName, "minimum-access-role", "",
+		"minimum access role of the auth provider. This can be left empty if the minimum access role should not"+
+			" be configured via declarative configuration")
+	cmd.PersistentFlags().StringVar(&authProviderCmd.authProvider.UIEndpoint, "ui-endpoint", "", "UI Endpoint "+
+		"from which the auth provider is used (this is typically the public endpoint where RHACS is exposed). The "+
+		"expected format is <endpoint>:<port>")
+	cmd.PersistentFlags().StringSliceVar(&authProviderCmd.authProvider.ExtraUIEndpoints, "extra-ui-endpoints", []string{},
+		"Additional UI endpoints from which the auth provider is used. The expected format is <endpoint>:<port>")
+
+	cmd.PersistentFlags().StringToStringVar(&authProviderCmd.requiredAttributes, "required-attributes",
+		map[string]string{}, `list of attributes that are required to be returned by the auth provider during
+authentication, e.g. --required-attributes "my_org=sample-org"`)
+
+	// pflag.FlagSet currently lacks to provide a tuple of repeated key value pairs, hence we need to resort to
+	// providing three separate flags which hold the values required to construct a single group:
+	// --groups-key, --groups-value, --group-role.
+	// They can be repeated as such within the CLI flags:
+	// --groups-key "email" --groups-value "my@domain.com" --groups-value"Admin" \
+	// --groups-key "user" --groups-value "id" --groups-role "Analyst"
+	cmd.PersistentFlags().StringSliceVar(&authProviderCmd.groupsKeys, "--groups-key", []string{},
+		`keys of the groups to add within the auth provider. Note that the tuple of key, value, role should
+be of the same length. Example of a group: --groups-key "email" --groups-value "my@domain.com" --groups-role "Admin"`)
+
+	cmd.PersistentFlags().StringSliceVar(&authProviderCmd.groupsValues, "--groups-value", []string{},
+		`values of the groups to add within the auth provider. Note that the tuple of key, value, role should
+be of the same length. Example of a group: --groups-key "email" --groups-value "my@domain.com" --groups-role "Admin"`)
+	cmd.PersistentFlags().StringSliceVar(&authProviderCmd.groupsKeys, "--groups-role", []string{},
+		`role of the groups to add within the auth provider. Note that the tuple of key, value, role should
+be of the same length. Example of a group: --groups-key "email" --groups-value "my@domain.com" --groups-role "Admin"`)
+
+	cmd.MarkFlagsRequiredTogether("name", "ui-endpoint")
+
+	cmd.AddCommand(
+		authProviderCmd.oidcCommand(),
+		authProviderCmd.samlCommand(),
+		authProviderCmd.iapCommand(),
+		authProviderCmd.userPKICommand(),
+		authProviderCmd.openShiftCommand(),
+	)
+
+	return cmd
+}
+
+type authProviderCmd struct {
+	authProvider *declarativeconfig.AuthProvider
+
+	requiredAttributes map[string]string
+	claimMapping       map[string]string
+
+	groupsKeys   []string
+	groupsValues []string
+	groupsRoles  []string
+
+	// Custom mappings for SAML command.
+	samlIDPCertFile string
+
+	// Custom mapping for User PKI command.
+	userPKICAFile string
+
+	env environment.Environment
+}
+
+func (a *authProviderCmd) oidcCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:  "oidc",
+		Args: cobra.NoArgs,
+		RunE: a.RunE(),
+	}
+
+	cmd.Flags().StringVar(&a.authProvider.OIDCConfig.Issuer, "issuer", "",
+		"issuer of the OIDC client")
+	cmd.Flags().StringVar(&a.authProvider.OIDCConfig.CallbackMode, "mode", "auto",
+		"The callback mode to use. Possible values are: auto, post, query, fragment")
+	cmd.Flags().StringVar(&a.authProvider.OIDCConfig.ClientID, "client-id", "",
+		"Client ID of the OIDC client")
+	cmd.Flags().StringVar(&a.authProvider.OIDCConfig.ClientSecret, "client-secret", "",
+		"Client Secret of the OIDC client")
+	cmd.Flags().BoolVar(&a.authProvider.OIDCConfig.DisableOfflineAccessScope, "disable-offline-access", false,
+		"Disable requesting the scope offline_access from the OIDC identity provider. This should only be set "+
+			"if there are any limitations from your OIDC IdP about the number of sessions with the offline_access scope")
+
+	cmd.PersistentFlags().StringToStringVar(&a.claimMapping, "claim-mappings", map[string]string{},
+		`list of non-standard claims from the IdP token that should be available within auth provider rules, e.g.
+--claim-mappings "my_claim_on_the_idp_token=claim_name_on_the_rox_token"`)
+
+	return cmd
+}
+
+func (a *authProviderCmd) samlCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:  "saml",
+		Args: cobra.NoArgs,
+		RunE: a.RunE(),
+	}
+
+	cmd.Flags().StringVar(&a.authProvider.SAMLConfig.SpIssuer, "sp-issuer", "", "service provider "+
+		"issuer")
+	cmd.Flags().StringVar(&a.authProvider.SAMLConfig.MetadataURL, "metadata-url", "", "metadata "+
+		"URL of the service provider")
+	cmd.Flags().StringVar(&a.samlIDPCertFile, "idp-cert", "", "file containing the SAML IdP "+
+		"certificate in PEM format")
+	cmd.Flags().StringVar(&a.authProvider.SAMLConfig.SsoURL, "sso-url", "", "URL of the IdP")
+	cmd.Flags().StringVar(&a.authProvider.SAMLConfig.NameIDFormat, "name-id-format", "",
+		"Name ID format")
+	cmd.Flags().StringVar(&a.authProvider.SAMLConfig.IDPIssuer, "idp-issuer", "", "issuer of the IdP")
+
+	return cmd
+}
+
+func (a *authProviderCmd) iapCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:  "iap",
+		Args: cobra.NoArgs,
+		RunE: a.RunE(),
+	}
+
+	cmd.Flags().StringVar(&a.authProvider.IAPConfig.Audience, "audience", "", "audience that should "+
+		"be validated")
+
+	utils.Must(cmd.MarkFlagRequired("audience"))
+
+	return cmd
+}
+
+func (a *authProviderCmd) userPKICommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:  "user-pki",
+		Args: cobra.NoArgs,
+		RunE: a.RunE(),
+	}
+
+	cmd.Flags().StringVar(&a.userPKICAFile, "ca-file", "", "file containing the certificate "+
+		"authorities in PEM format")
+
+	utils.Must(cmd.MarkFlagRequired("ca-file"))
+
+	return cmd
+}
+
+func (a *authProviderCmd) openShiftCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:  "openshift-auth",
+		Args: cobra.NoArgs,
+		RunE: a.RunE(),
+	}
+
+	return cmd
+}
+
+func (a *authProviderCmd) RunE() func(cmd *cobra.Command, args []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		if err := a.Validate(cmd.Use); err != nil {
+			return errors.Wrap(err, "validating auth provider")
+		}
+		return a.PrintYAML()
+	}
+}
+
+func (a *authProviderCmd) Validate(providerType string) error {
+	requiredAttributes := make([]declarativeconfig.RequiredAttribute, 0, len(a.requiredAttributes))
+	for key, value := range a.requiredAttributes {
+		requiredAttributes = append(requiredAttributes, declarativeconfig.RequiredAttribute{
+			AttributeKey:   key,
+			AttributeValue: value,
+		})
+	}
+	a.authProvider.RequiredAttributes = requiredAttributes
+
+	groups, err := a.validateGroups()
+	if err != nil {
+		return errors.Wrap(err, "validating groups")
+	}
+	a.authProvider.Groups = groups
+
+	switch providerType {
+	case "saml":
+		if a.samlIDPCertFile != "" {
+			samlCert, err := readFileContents(a.samlIDPCertFile)
+			if err != nil {
+				return errors.Wrap(err, "reading SAML IdP cert file")
+			}
+			a.authProvider.SAMLConfig.Cert = samlCert
+		}
+	case "user-pki":
+		ca, err := readFileContents(a.userPKICAFile)
+		if err != nil {
+			return errors.Wrap(err, "reading user PKI CA file")
+		}
+		a.authProvider.UserpkiConfig.CertificateAuthorities = ca
+	case "openshift-auth":
+		a.authProvider.OpenshiftConfig.Enable = true
+	case "oid":
+		claimMappings := make([]declarativeconfig.ClaimMapping, 0, len(a.claimMapping))
+		for path, name := range a.claimMapping {
+			claimMappings = append(claimMappings, declarativeconfig.ClaimMapping{
+				Path: path,
+				Name: name,
+			})
+		}
+		a.authProvider.ClaimMappings = claimMappings
+	}
+
+	t := transform.New()
+	_, err = t.Transform(a.authProvider)
+	return errors.Wrap(err, "validating auth provider")
+}
+
+func (a *authProviderCmd) validateGroups() ([]declarativeconfig.Group, error) {
+	expectedGroups := len(a.groupsKeys)
+
+	if len(a.groupsKeys) != expectedGroups || len(a.groupsValues) != expectedGroups || len(a.groupsRoles) != expectedGroups {
+		return nil, errox.InvalidArgs.Newf("the groups tuple of key, value, role should have the the same "+
+			"number of entries, but found a mismatch [keys %d, values %d, roles %d]",
+			len(a.groupsKeys), len(a.groupsValues), len(a.groupsRoles))
+	}
+
+	groups := make([]declarativeconfig.Group, 0, expectedGroups)
+	for i := 0; i < expectedGroups; i++ {
+		groups = append(groups, declarativeconfig.Group{
+			AttributeKey:   a.groupsKeys[i],
+			AttributeValue: a.groupsValues[i],
+			RoleName:       a.groupsRoles[i],
+		})
+	}
+
+	return groups, nil
+}
+
+func readFileContents(f string) (string, error) {
+	contents, err := os.ReadFile(f)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", errox.NotFound.CausedBy(err)
+		}
+		return "", errox.InvalidArgs.CausedBy(err)
+	}
+	return string(contents), nil
+}
+
+func (a *authProviderCmd) PrintYAML() error {
+	enc := yaml.NewEncoder(a.env.InputOutput().Out())
+	return errors.Wrap(enc.Encode(a.authProvider), "creating the YAML output")
+}

--- a/roxctl/declarativeconfig/create/auth_provider.go
+++ b/roxctl/declarativeconfig/create/auth_provider.go
@@ -19,7 +19,8 @@ func authProviderCommand(cliEnvironment environment.Environment) *cobra.Command 
 	authProviderCmd := &authProviderCmd{authProvider: &declarativeconfig.AuthProvider{}, env: cliEnvironment}
 
 	cmd := &cobra.Command{
-		Use: authProviderCmd.authProvider.Type(),
+		Use:   authProviderCmd.authProvider.Type(),
+		Short: "Commands to create a declarative configuration for an auth provider",
 	}
 
 	cmd.PersistentFlags().StringVar(&authProviderCmd.authProvider.Name, "name", "", "name of the auth provider")
@@ -96,9 +97,10 @@ type authProviderCmd struct {
 
 func (a *authProviderCmd) oidcCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:  "oidc",
-		Args: cobra.NoArgs,
-		RunE: a.RunE(),
+		Use:   "oidc",
+		Args:  cobra.NoArgs,
+		RunE:  a.RunE(),
+		Short: "Create a declarative configuration for an OIDC auth provider",
 	}
 	a.oidcConfig = &declarativeconfig.OIDCConfig{}
 
@@ -123,9 +125,10 @@ func (a *authProviderCmd) oidcCommand() *cobra.Command {
 
 func (a *authProviderCmd) samlCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:  "saml",
-		Args: cobra.NoArgs,
-		RunE: a.RunE(),
+		Use:   "saml",
+		Args:  cobra.NoArgs,
+		RunE:  a.RunE(),
+		Short: "Create a declarative configuration for a SAML auth provider",
 	}
 	a.samlConfig = &declarativeconfig.SAMLConfig{}
 
@@ -161,9 +164,10 @@ func (a *authProviderCmd) iapCommand() *cobra.Command {
 
 func (a *authProviderCmd) userPKICommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:  "user-pki",
-		Args: cobra.NoArgs,
-		RunE: a.RunE(),
+		Use:   "user-pki",
+		Args:  cobra.NoArgs,
+		RunE:  a.RunE(),
+		Short: "Create a declarative configuration for an user PKI auth provider",
 	}
 	a.userPKIConfig = &declarativeconfig.UserpkiConfig{}
 
@@ -177,8 +181,9 @@ func (a *authProviderCmd) userPKICommand() *cobra.Command {
 
 func (a *authProviderCmd) openShiftCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:  "openshift-auth",
-		RunE: a.RunE(),
+		Use:   "openshift-auth",
+		RunE:  a.RunE(),
+		Short: "Create a declarative configuration for an OpenShift-Auth auth provider",
 	}
 
 	return cmd

--- a/roxctl/declarativeconfig/create/auth_provider.go
+++ b/roxctl/declarativeconfig/create/auth_provider.go
@@ -2,12 +2,14 @@ package create
 
 import (
 	"os"
+	"sort"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/stackrox/rox/pkg/declarativeconfig"
 	"github.com/stackrox/rox/pkg/declarativeconfig/transform"
 	"github.com/stackrox/rox/pkg/errox"
+	"github.com/stackrox/rox/pkg/maputil"
 	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/rox/roxctl/common/environment"
 	"gopkg.in/yaml.v3"
@@ -193,10 +195,12 @@ func (a *authProviderCmd) RunE() func(cmd *cobra.Command, args []string) error {
 
 func (a *authProviderCmd) Validate(providerType string) error {
 	requiredAttributes := make([]declarativeconfig.RequiredAttribute, 0, len(a.requiredAttributes))
-	for key, value := range a.requiredAttributes {
+	keys := maputil.Keys(a.requiredAttributes)
+	sort.Strings(keys)
+	for _, key := range keys {
 		requiredAttributes = append(requiredAttributes, declarativeconfig.RequiredAttribute{
 			AttributeKey:   key,
-			AttributeValue: value,
+			AttributeValue: a.requiredAttributes[key],
 		})
 	}
 	a.authProvider.RequiredAttributes = requiredAttributes
@@ -228,10 +232,12 @@ func (a *authProviderCmd) Validate(providerType string) error {
 		a.authProvider.OpenshiftConfig = &declarativeconfig.OpenshiftConfig{Enable: true}
 	case "oidc":
 		claimMappings := make([]declarativeconfig.ClaimMapping, 0, len(a.claimMapping))
-		for path, name := range a.claimMapping {
+		paths := maputil.Keys(a.claimMapping)
+		sort.Strings(paths)
+		for _, path := range paths {
 			claimMappings = append(claimMappings, declarativeconfig.ClaimMapping{
 				Path: path,
-				Name: name,
+				Name: a.claimMapping[path],
 			})
 		}
 		a.authProvider.ClaimMappings = claimMappings

--- a/roxctl/declarativeconfig/create/auth_provider.go
+++ b/roxctl/declarativeconfig/create/auth_provider.go
@@ -164,7 +164,7 @@ func (a *authProviderCmd) iapCommand() *cobra.Command {
 
 func (a *authProviderCmd) userPKICommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "user-pki",
+		Use:   "userpki",
 		Args:  cobra.NoArgs,
 		RunE:  a.RunE(),
 		Short: "Create a declarative configuration for an user PKI auth provider",
@@ -226,7 +226,7 @@ func (a *authProviderCmd) Validate(providerType string) error {
 			a.samlConfig.Cert = samlCert
 		}
 		a.authProvider.SAMLConfig = a.samlConfig
-	case "user-pki":
+	case "userpki":
 		ca, err := readFileContents(a.userPKICAFile)
 		if err != nil {
 			return errors.Wrap(err, "reading user PKI CA file")
@@ -259,7 +259,7 @@ func (a *authProviderCmd) Validate(providerType string) error {
 func (a *authProviderCmd) validateGroups() ([]declarativeconfig.Group, error) {
 	expectedGroups := len(a.groupsKeys)
 
-	if len(a.groupsKeys) != expectedGroups || len(a.groupsValues) != expectedGroups || len(a.groupsRoles) != expectedGroups {
+	if len(a.groupsValues) != expectedGroups || len(a.groupsRoles) != expectedGroups {
 		return nil, errox.InvalidArgs.Newf("the groups tuple of key, value, role should have the the same "+
 			"number of entries, but found a mismatch [keys %d, values %d, roles %d]",
 			len(a.groupsKeys), len(a.groupsValues), len(a.groupsRoles))

--- a/roxctl/declarativeconfig/create/auth_provider_test.go
+++ b/roxctl/declarativeconfig/create/auth_provider_test.go
@@ -153,10 +153,10 @@ groups:
       value: example@example.com
       role: Admin
 requiredAttributes:
-    - key: org_id
-      value: "12345"
     - key: name
       value: some_name
+    - key: org_id
+      value: "12345"
 claimMappings:
     - path: org_id
       name: super_cool_claim
@@ -233,10 +233,10 @@ groups:
       value: example@example.com
       role: Admin
 requiredAttributes:
-    - key: org_id
-      value: "12345"
     - key: name
       value: some_name
+    - key: org_id
+      value: "12345"
 saml:
     spIssuer: some-random-issuer
     cert: |
@@ -329,10 +329,10 @@ groups:
       value: example@example.com
       role: Admin
 requiredAttributes:
-    - key: org_id
-      value: "12345"
     - key: name
       value: some_name
+    - key: org_id
+      value: "12345"
 userpki:
     certificateAuthorities: |
         -----BEGIN CERTIFICATE-----
@@ -387,10 +387,10 @@ groups:
       value: example@example.com
       role: Admin
 requiredAttributes:
-    - key: org_id
-      value: "12345"
     - key: name
       value: some_name
+    - key: org_id
+      value: "12345"
 openshift:
     enable: true
 `
@@ -422,10 +422,10 @@ groups:
       value: example@example.com
       role: Admin
 requiredAttributes:
-    - key: org_id
-      value: "12345"
     - key: name
       value: some_name
+    - key: org_id
+      value: "12345"
 iap:
     audience: some-audience
 `

--- a/roxctl/declarativeconfig/create/auth_provider_test.go
+++ b/roxctl/declarativeconfig/create/auth_provider_test.go
@@ -114,7 +114,7 @@ func TestCreateAuthProvider_UserPKI_Failure(t *testing.T) {
 	cmd := authProviderCommand(env)
 
 	args := []string{
-		"user-pki",
+		"userpki",
 		"--ca-file=non-existent/file/path",
 	}
 	cmd.SetArgs(args)
@@ -133,8 +133,12 @@ func TestCreateAuthProvider_OIDC_Success(t *testing.T) {
 		"--groups-key=email",
 		"--groups-value=example@example.com",
 		"--groups-role=Admin",
+		"--groups-key=userid",
+		"--groups-value=someid",
+		"--groups-role=Analyst",
 		"--minimum-access-role=Analyst",
 		"--extra-ui-endpoints=localhost:9090",
+		"--extra-ui-endpoints=localhost:10010",
 		"--required-attributes=org_id=12345,name=some_name",
 		"--issuer=sample.issuer.com",
 		"--mode=auto",
@@ -148,10 +152,14 @@ minimumRole: Analyst
 uiEndpoint: localhost:8000
 extraUIEndpoints:
     - localhost:9090
+    - localhost:10010
 groups:
     - key: email
       value: example@example.com
       role: Admin
+    - key: userid
+      value: someid
+      role: Analyst
 requiredAttributes:
     - key: name
       value: some_name
@@ -213,8 +221,12 @@ q/I2+0j6dAkOGcK/68z7qQXByeGri3n28a1Kn6o=
 		"--groups-key=email",
 		"--groups-value=example@example.com",
 		"--groups-role=Admin",
+		"--groups-key=userid",
+		"--groups-value=someid",
+		"--groups-role=Analyst",
 		"--minimum-access-role=Analyst",
 		"--extra-ui-endpoints=localhost:9090",
+		"--extra-ui-endpoints=localhost:10010",
 		"--required-attributes=org_id=12345,name=some_name",
 		"--sp-issuer=some-random-issuer",
 		"--idp-cert=" + filePath,
@@ -228,10 +240,14 @@ minimumRole: Analyst
 uiEndpoint: localhost:8000
 extraUIEndpoints:
     - localhost:9090
+    - localhost:10010
 groups:
     - key: email
       value: example@example.com
       role: Admin
+    - key: userid
+      value: someid
+      role: Analyst
 requiredAttributes:
     - key: name
       value: some_name
@@ -307,14 +323,18 @@ q/I2+0j6dAkOGcK/68z7qQXByeGri3n28a1Kn6o=
 	assert.NoError(t, err)
 
 	args := []string{
-		"user-pki",
+		"userpki",
 		"--name=some-name",
 		"--ui-endpoint=localhost:8000",
 		"--groups-key=email",
 		"--groups-value=example@example.com",
 		"--groups-role=Admin",
+		"--groups-key=userid",
+		"--groups-value=someid",
+		"--groups-role=Analyst",
 		"--minimum-access-role=Analyst",
 		"--extra-ui-endpoints=localhost:9090",
+		"--extra-ui-endpoints=localhost:10010",
 		"--required-attributes=org_id=12345,name=some_name",
 		"--ca-file=" + filePath,
 	}
@@ -324,10 +344,14 @@ minimumRole: Analyst
 uiEndpoint: localhost:8000
 extraUIEndpoints:
     - localhost:9090
+    - localhost:10010
 groups:
     - key: email
       value: example@example.com
       role: Admin
+    - key: userid
+      value: someid
+      role: Analyst
 requiredAttributes:
     - key: name
       value: some_name
@@ -372,8 +396,12 @@ func TestCreateAuthProvider_OpenShiftAuth_Success(t *testing.T) {
 		"--groups-key=email",
 		"--groups-value=example@example.com",
 		"--groups-role=Admin",
+		"--groups-key=userid",
+		"--groups-value=someid",
+		"--groups-role=Analyst",
 		"--minimum-access-role=Analyst",
 		"--extra-ui-endpoints=localhost:9090",
+		"--extra-ui-endpoints=localhost:10010",
 		"--required-attributes=org_id=12345,name=some_name",
 	}
 
@@ -382,10 +410,14 @@ minimumRole: Analyst
 uiEndpoint: localhost:8000
 extraUIEndpoints:
     - localhost:9090
+    - localhost:10010
 groups:
     - key: email
       value: example@example.com
       role: Admin
+    - key: userid
+      value: someid
+      role: Analyst
 requiredAttributes:
     - key: name
       value: some_name
@@ -406,8 +438,12 @@ func TestCreateAuthProvider_IAP_Success(t *testing.T) {
 		"--groups-key=email",
 		"--groups-value=example@example.com",
 		"--groups-role=Admin",
+		"--groups-key=userid",
+		"--groups-value=someid",
+		"--groups-role=Analyst",
 		"--minimum-access-role=Analyst",
 		"--extra-ui-endpoints=localhost:9090",
+		"--extra-ui-endpoints=localhost:10010",
 		"--required-attributes=org_id=12345,name=some_name",
 		"--audience=some-audience",
 	}
@@ -417,10 +453,14 @@ minimumRole: Analyst
 uiEndpoint: localhost:8000
 extraUIEndpoints:
     - localhost:9090
+    - localhost:10010
 groups:
     - key: email
       value: example@example.com
       role: Admin
+    - key: userid
+      value: someid
+      role: Analyst
 requiredAttributes:
     - key: name
       value: some_name

--- a/roxctl/declarativeconfig/create/auth_provider_test.go
+++ b/roxctl/declarativeconfig/create/auth_provider_test.go
@@ -99,7 +99,10 @@ func TestCreateAuthProvider_SAML_Failure(t *testing.T) {
 
 	args := []string{
 		"saml",
+		"--sp-issuer=something",
 		"--idp-cert=non-existent/file/path",
+		"--sso-url=something",
+		"--idp-issuer=something",
 	}
 	cmd.SetArgs(args)
 	cmd.SetOut(io.Discard)

--- a/roxctl/declarativeconfig/create/auth_provider_test.go
+++ b/roxctl/declarativeconfig/create/auth_provider_test.go
@@ -1,0 +1,447 @@
+package create
+
+import (
+	"io"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stackrox/rox/pkg/errox"
+	"github.com/stackrox/rox/pkg/utils"
+	"github.com/stackrox/rox/roxctl/common/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateAuthProvider_Failures(t *testing.T) {
+
+	cases := map[string]struct {
+		args   []string
+		errOut string
+		err    error
+	}{
+		"missing name flag": {
+			args: []string{
+				"openshift-auth",
+				"--ui-endpoint=localhost:8000",
+			},
+			errOut: `Error: if any flags in the group [name ui-endpoint] are set they must all be set; missing [name]
+`,
+		},
+		"missing ui-endpoint flag": {
+			args: []string{
+				"openshift-auth",
+				"--name=some-name",
+			},
+			errOut: `Error: if any flags in the group [name ui-endpoint] are set they must all be set; missing [ui-endpoint]
+`,
+		},
+		"invalid number of groups keys": {
+			args: []string{
+				"openshift-auth",
+				"--name=some-name",
+				"--ui-endpoint=localhost:8000",
+				"--groups-key=email",
+				"--groups-value=example@example.com",
+				"--groups-role=Admin",
+				"--groups-key=another-one",
+			},
+			err: errox.InvalidArgs,
+		},
+		"invalid number of groups values": {
+			args: []string{
+				"openshift-auth",
+				"--name=some-name",
+				"--ui-endpoint=localhost:8000",
+				"--groups-key=email",
+				"--groups-value=example@example.com",
+				"--groups-role=Admin",
+				"--groups-value=another-one",
+			},
+			err: errox.InvalidArgs,
+		},
+		"invalid number of groups roles": {
+			args: []string{
+				"openshift-auth",
+				"--name=some-name",
+				"--ui-endpoint=localhost:8000",
+				"--groups-key=email",
+				"--groups-value=example@example.com",
+				"--groups-role=Admin",
+				"--groups-role=another-one",
+			},
+			err: errox.InvalidArgs,
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			env, out, errOut := mocks.NewEnvWithConn(nil, t)
+			cmd := authProviderCommand(env)
+			cmd.SetArgs(c.args)
+			cmd.SetErr(errOut)
+			cmd.SetOut(out)
+			err := cmd.Execute()
+			assert.Error(t, err)
+			if c.err != nil {
+				assert.ErrorIs(t, err, c.err)
+			}
+			if c.errOut != "" {
+				assert.Equal(t, c.errOut, errOut.String())
+			}
+
+		})
+	}
+}
+
+func TestCreateAuthProvider_SAML_Failure(t *testing.T) {
+	env, _, _ := mocks.NewEnvWithConn(nil, t)
+	cmd := authProviderCommand(env)
+
+	args := []string{
+		"saml",
+		"--idp-cert=non-existent/file/path",
+	}
+	cmd.SetArgs(args)
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+
+	err := cmd.Execute()
+	assert.ErrorIs(t, err, errox.NotFound)
+}
+
+func TestCreateAuthProvider_UserPKI_Failure(t *testing.T) {
+	env, _, _ := mocks.NewEnvWithConn(nil, t)
+	cmd := authProviderCommand(env)
+
+	args := []string{
+		"user-pki",
+		"--ca-file=non-existent/file/path",
+	}
+	cmd.SetArgs(args)
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+
+	err := cmd.Execute()
+	assert.ErrorIs(t, err, errox.NotFound)
+}
+
+func TestCreateAuthProvider_OIDC_Success(t *testing.T) {
+	args := []string{
+		"oidc",
+		"--name=some-name",
+		"--ui-endpoint=localhost:8000",
+		"--groups-key=email",
+		"--groups-value=example@example.com",
+		"--groups-role=Admin",
+		"--minimum-access-role=Analyst",
+		"--extra-ui-endpoints=localhost:9090",
+		"--required-attributes=org_id=12345,name=some_name",
+		"--issuer=sample.issuer.com",
+		"--mode=auto",
+		"--client-id=CLIENT_ID",
+		"--client-secret=CLIENT_SECRET",
+		"--claim-mappings=org_id=super_cool_claim,republic=far_away",
+	}
+
+	expectedYAML := `name: some-name
+minimumRole: Analyst
+uiEndpoint: localhost:8000
+extraUIEndpoints:
+    - localhost:9090
+groups:
+    - key: email
+      value: example@example.com
+      role: Admin
+requiredAttributes:
+    - key: org_id
+      value: "12345"
+    - key: name
+      value: some_name
+claimMappings:
+    - path: org_id
+      name: super_cool_claim
+    - path: republic
+      name: far_away
+oidc:
+    issuer: sample.issuer.com
+    mode: auto
+    clientID: CLIENT_ID
+    clientSecret: CLIENT_SECRET
+`
+
+	runSuccessfulCommandTest(t, args, expectedYAML)
+}
+
+func TestCreateAuthProvider_SAML_Success(t *testing.T) {
+	dir := t.TempDir()
+
+	filePath := path.Join(dir, "idp-cert")
+	f, err := os.Create(filePath)
+	assert.NoError(t, err)
+	defer utils.IgnoreError(f.Close)
+	_, err = f.Write([]byte(`-----BEGIN CERTIFICATE-----
+MIIECTCCA3KgAwIBAgIUDnU7Oa0fU9GFOwU7EWJP3HsRchEwDQYJKoZIhvcNAQEL
+BQAwgZkxCzAJBgNVBAYTAlVTMRAwDgYDVQQIDAdNb250YW5hMRAwDgYDVQQHDAdC
+b3plbWFuMREwDwYDVQQKDAhTYXd0b290aDEYMBYGA1UECwwPQ29uc3VsdGluZ18x
+MDI0MRgwFgYDVQQDDA93d3cud29sZnNzbC5jb20xHzAdBgkqhkiG9w0BCQEWEGlu
+Zm9Ad29sZnNzbC5jb20wHhcNMjIxMjE2MjExNzQ5WhcNMjUwOTExMjExNzQ5WjCB
+mTELMAkGA1UEBhMCVVMxEDAOBgNVBAgMB01vbnRhbmExEDAOBgNVBAcMB0JvemVt
+YW4xETAPBgNVBAoMCFNhd3Rvb3RoMRgwFgYDVQQLDA9Db25zdWx0aW5nXzEwMjQx
+GDAWBgNVBAMMD3d3dy53b2xmc3NsLmNvbTEfMB0GCSqGSIb3DQEJARYQaW5mb0B3
+b2xmc3NsLmNvbTCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEAzazdR+y+tyTD
+YxtUmHnhxzEWWdadd52N4ovtBBeyxuvkm5G+MVBil1i1fynes3EkC7+XCX8m3C3s
+qC6yZCt6KzUZLaKAy5n9lHEbI41U2y5ijYEILfQkcids+cmO20x1upsB+D8Y9OZ/
++1eUksyIxLQAwqrU5YgYsxEvc8DWKQkCAwEAAaOCAUowggFGMB0GA1UdDgQWBBTT
+Io8oLOAF7tPtw3E9ybI2Oh2/qDCB2QYDVR0jBIHRMIHOgBTTIo8oLOAF7tPtw3E9
+ybI2Oh2/qKGBn6SBnDCBmTELMAkGA1UEBhMCVVMxEDAOBgNVBAgMB01vbnRhbmEx
+EDAOBgNVBAcMB0JvemVtYW4xETAPBgNVBAoMCFNhd3Rvb3RoMRgwFgYDVQQLDA9D
+b25zdWx0aW5nXzEwMjQxGDAWBgNVBAMMD3d3dy53b2xmc3NsLmNvbTEfMB0GCSqG
+SIb3DQEJARYQaW5mb0B3b2xmc3NsLmNvbYIUDnU7Oa0fU9GFOwU7EWJP3HsRchEw
+DAYDVR0TBAUwAwEB/zAcBgNVHREEFTATggtleGFtcGxlLmNvbYcEfwAAATAdBgNV
+HSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADgYEAuIC/
+svWDlVGBan5BhynXw8nGm2DkZaEElx0bO+kn+kPWiWo8nr8o0XU3IfMNZBeyoy2D
+Uv9X8EKpSKrYhOoNgAVxCqojtGzG1n8TSvSCueKBrkaMWfvDjG1b8zLshvBu2ip4
+q/I2+0j6dAkOGcK/68z7qQXByeGri3n28a1Kn6o=
+-----END CERTIFICATE-----
+`))
+	assert.NoError(t, err)
+
+	args := []string{
+		"saml",
+		"--name=some-name",
+		"--ui-endpoint=localhost:8000",
+		"--groups-key=email",
+		"--groups-value=example@example.com",
+		"--groups-role=Admin",
+		"--minimum-access-role=Analyst",
+		"--extra-ui-endpoints=localhost:9090",
+		"--required-attributes=org_id=12345,name=some_name",
+		"--sp-issuer=some-random-issuer",
+		"--idp-cert=" + filePath,
+		"--sso-url=some-sso.url",
+		"--name-id-format=some-format",
+		"--idp-issuer=my.cool.issuer",
+	}
+
+	expectedYAML := `name: some-name
+minimumRole: Analyst
+uiEndpoint: localhost:8000
+extraUIEndpoints:
+    - localhost:9090
+groups:
+    - key: email
+      value: example@example.com
+      role: Admin
+requiredAttributes:
+    - key: org_id
+      value: "12345"
+    - key: name
+      value: some_name
+saml:
+    spIssuer: some-random-issuer
+    cert: |
+        -----BEGIN CERTIFICATE-----
+        MIIECTCCA3KgAwIBAgIUDnU7Oa0fU9GFOwU7EWJP3HsRchEwDQYJKoZIhvcNAQEL
+        BQAwgZkxCzAJBgNVBAYTAlVTMRAwDgYDVQQIDAdNb250YW5hMRAwDgYDVQQHDAdC
+        b3plbWFuMREwDwYDVQQKDAhTYXd0b290aDEYMBYGA1UECwwPQ29uc3VsdGluZ18x
+        MDI0MRgwFgYDVQQDDA93d3cud29sZnNzbC5jb20xHzAdBgkqhkiG9w0BCQEWEGlu
+        Zm9Ad29sZnNzbC5jb20wHhcNMjIxMjE2MjExNzQ5WhcNMjUwOTExMjExNzQ5WjCB
+        mTELMAkGA1UEBhMCVVMxEDAOBgNVBAgMB01vbnRhbmExEDAOBgNVBAcMB0JvemVt
+        YW4xETAPBgNVBAoMCFNhd3Rvb3RoMRgwFgYDVQQLDA9Db25zdWx0aW5nXzEwMjQx
+        GDAWBgNVBAMMD3d3dy53b2xmc3NsLmNvbTEfMB0GCSqGSIb3DQEJARYQaW5mb0B3
+        b2xmc3NsLmNvbTCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEAzazdR+y+tyTD
+        YxtUmHnhxzEWWdadd52N4ovtBBeyxuvkm5G+MVBil1i1fynes3EkC7+XCX8m3C3s
+        qC6yZCt6KzUZLaKAy5n9lHEbI41U2y5ijYEILfQkcids+cmO20x1upsB+D8Y9OZ/
+        +1eUksyIxLQAwqrU5YgYsxEvc8DWKQkCAwEAAaOCAUowggFGMB0GA1UdDgQWBBTT
+        Io8oLOAF7tPtw3E9ybI2Oh2/qDCB2QYDVR0jBIHRMIHOgBTTIo8oLOAF7tPtw3E9
+        ybI2Oh2/qKGBn6SBnDCBmTELMAkGA1UEBhMCVVMxEDAOBgNVBAgMB01vbnRhbmEx
+        EDAOBgNVBAcMB0JvemVtYW4xETAPBgNVBAoMCFNhd3Rvb3RoMRgwFgYDVQQLDA9D
+        b25zdWx0aW5nXzEwMjQxGDAWBgNVBAMMD3d3dy53b2xmc3NsLmNvbTEfMB0GCSqG
+        SIb3DQEJARYQaW5mb0B3b2xmc3NsLmNvbYIUDnU7Oa0fU9GFOwU7EWJP3HsRchEw
+        DAYDVR0TBAUwAwEB/zAcBgNVHREEFTATggtleGFtcGxlLmNvbYcEfwAAATAdBgNV
+        HSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADgYEAuIC/
+        svWDlVGBan5BhynXw8nGm2DkZaEElx0bO+kn+kPWiWo8nr8o0XU3IfMNZBeyoy2D
+        Uv9X8EKpSKrYhOoNgAVxCqojtGzG1n8TSvSCueKBrkaMWfvDjG1b8zLshvBu2ip4
+        q/I2+0j6dAkOGcK/68z7qQXByeGri3n28a1Kn6o=
+        -----END CERTIFICATE-----
+    ssoURL: some-sso.url
+    nameIdFormat: some-format
+    idpIssuer: my.cool.issuer
+`
+
+	runSuccessfulCommandTest(t, args, expectedYAML)
+}
+
+func TestCreateAuthProvider_UserPKI_Success(t *testing.T) {
+	dir := t.TempDir()
+
+	filePath := path.Join(dir, "ca-file")
+	f, err := os.Create(filePath)
+	assert.NoError(t, err)
+	defer utils.IgnoreError(f.Close)
+	_, err = f.Write([]byte(`-----BEGIN CERTIFICATE-----
+MIIECTCCA3KgAwIBAgIUDnU7Oa0fU9GFOwU7EWJP3HsRchEwDQYJKoZIhvcNAQEL
+BQAwgZkxCzAJBgNVBAYTAlVTMRAwDgYDVQQIDAdNb250YW5hMRAwDgYDVQQHDAdC
+b3plbWFuMREwDwYDVQQKDAhTYXd0b290aDEYMBYGA1UECwwPQ29uc3VsdGluZ18x
+MDI0MRgwFgYDVQQDDA93d3cud29sZnNzbC5jb20xHzAdBgkqhkiG9w0BCQEWEGlu
+Zm9Ad29sZnNzbC5jb20wHhcNMjIxMjE2MjExNzQ5WhcNMjUwOTExMjExNzQ5WjCB
+mTELMAkGA1UEBhMCVVMxEDAOBgNVBAgMB01vbnRhbmExEDAOBgNVBAcMB0JvemVt
+YW4xETAPBgNVBAoMCFNhd3Rvb3RoMRgwFgYDVQQLDA9Db25zdWx0aW5nXzEwMjQx
+GDAWBgNVBAMMD3d3dy53b2xmc3NsLmNvbTEfMB0GCSqGSIb3DQEJARYQaW5mb0B3
+b2xmc3NsLmNvbTCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEAzazdR+y+tyTD
+YxtUmHnhxzEWWdadd52N4ovtBBeyxuvkm5G+MVBil1i1fynes3EkC7+XCX8m3C3s
+qC6yZCt6KzUZLaKAy5n9lHEbI41U2y5ijYEILfQkcids+cmO20x1upsB+D8Y9OZ/
++1eUksyIxLQAwqrU5YgYsxEvc8DWKQkCAwEAAaOCAUowggFGMB0GA1UdDgQWBBTT
+Io8oLOAF7tPtw3E9ybI2Oh2/qDCB2QYDVR0jBIHRMIHOgBTTIo8oLOAF7tPtw3E9
+ybI2Oh2/qKGBn6SBnDCBmTELMAkGA1UEBhMCVVMxEDAOBgNVBAgMB01vbnRhbmEx
+EDAOBgNVBAcMB0JvemVtYW4xETAPBgNVBAoMCFNhd3Rvb3RoMRgwFgYDVQQLDA9D
+b25zdWx0aW5nXzEwMjQxGDAWBgNVBAMMD3d3dy53b2xmc3NsLmNvbTEfMB0GCSqG
+SIb3DQEJARYQaW5mb0B3b2xmc3NsLmNvbYIUDnU7Oa0fU9GFOwU7EWJP3HsRchEw
+DAYDVR0TBAUwAwEB/zAcBgNVHREEFTATggtleGFtcGxlLmNvbYcEfwAAATAdBgNV
+HSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADgYEAuIC/
+svWDlVGBan5BhynXw8nGm2DkZaEElx0bO+kn+kPWiWo8nr8o0XU3IfMNZBeyoy2D
+Uv9X8EKpSKrYhOoNgAVxCqojtGzG1n8TSvSCueKBrkaMWfvDjG1b8zLshvBu2ip4
+q/I2+0j6dAkOGcK/68z7qQXByeGri3n28a1Kn6o=
+-----END CERTIFICATE-----
+`))
+	assert.NoError(t, err)
+
+	args := []string{
+		"user-pki",
+		"--name=some-name",
+		"--ui-endpoint=localhost:8000",
+		"--groups-key=email",
+		"--groups-value=example@example.com",
+		"--groups-role=Admin",
+		"--minimum-access-role=Analyst",
+		"--extra-ui-endpoints=localhost:9090",
+		"--required-attributes=org_id=12345,name=some_name",
+		"--ca-file=" + filePath,
+	}
+
+	expectedYAML := `name: some-name
+minimumRole: Analyst
+uiEndpoint: localhost:8000
+extraUIEndpoints:
+    - localhost:9090
+groups:
+    - key: email
+      value: example@example.com
+      role: Admin
+requiredAttributes:
+    - key: org_id
+      value: "12345"
+    - key: name
+      value: some_name
+userpki:
+    certificateAuthorities: |
+        -----BEGIN CERTIFICATE-----
+        MIIECTCCA3KgAwIBAgIUDnU7Oa0fU9GFOwU7EWJP3HsRchEwDQYJKoZIhvcNAQEL
+        BQAwgZkxCzAJBgNVBAYTAlVTMRAwDgYDVQQIDAdNb250YW5hMRAwDgYDVQQHDAdC
+        b3plbWFuMREwDwYDVQQKDAhTYXd0b290aDEYMBYGA1UECwwPQ29uc3VsdGluZ18x
+        MDI0MRgwFgYDVQQDDA93d3cud29sZnNzbC5jb20xHzAdBgkqhkiG9w0BCQEWEGlu
+        Zm9Ad29sZnNzbC5jb20wHhcNMjIxMjE2MjExNzQ5WhcNMjUwOTExMjExNzQ5WjCB
+        mTELMAkGA1UEBhMCVVMxEDAOBgNVBAgMB01vbnRhbmExEDAOBgNVBAcMB0JvemVt
+        YW4xETAPBgNVBAoMCFNhd3Rvb3RoMRgwFgYDVQQLDA9Db25zdWx0aW5nXzEwMjQx
+        GDAWBgNVBAMMD3d3dy53b2xmc3NsLmNvbTEfMB0GCSqGSIb3DQEJARYQaW5mb0B3
+        b2xmc3NsLmNvbTCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEAzazdR+y+tyTD
+        YxtUmHnhxzEWWdadd52N4ovtBBeyxuvkm5G+MVBil1i1fynes3EkC7+XCX8m3C3s
+        qC6yZCt6KzUZLaKAy5n9lHEbI41U2y5ijYEILfQkcids+cmO20x1upsB+D8Y9OZ/
+        +1eUksyIxLQAwqrU5YgYsxEvc8DWKQkCAwEAAaOCAUowggFGMB0GA1UdDgQWBBTT
+        Io8oLOAF7tPtw3E9ybI2Oh2/qDCB2QYDVR0jBIHRMIHOgBTTIo8oLOAF7tPtw3E9
+        ybI2Oh2/qKGBn6SBnDCBmTELMAkGA1UEBhMCVVMxEDAOBgNVBAgMB01vbnRhbmEx
+        EDAOBgNVBAcMB0JvemVtYW4xETAPBgNVBAoMCFNhd3Rvb3RoMRgwFgYDVQQLDA9D
+        b25zdWx0aW5nXzEwMjQxGDAWBgNVBAMMD3d3dy53b2xmc3NsLmNvbTEfMB0GCSqG
+        SIb3DQEJARYQaW5mb0B3b2xmc3NsLmNvbYIUDnU7Oa0fU9GFOwU7EWJP3HsRchEw
+        DAYDVR0TBAUwAwEB/zAcBgNVHREEFTATggtleGFtcGxlLmNvbYcEfwAAATAdBgNV
+        HSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADgYEAuIC/
+        svWDlVGBan5BhynXw8nGm2DkZaEElx0bO+kn+kPWiWo8nr8o0XU3IfMNZBeyoy2D
+        Uv9X8EKpSKrYhOoNgAVxCqojtGzG1n8TSvSCueKBrkaMWfvDjG1b8zLshvBu2ip4
+        q/I2+0j6dAkOGcK/68z7qQXByeGri3n28a1Kn6o=
+        -----END CERTIFICATE-----
+`
+
+	runSuccessfulCommandTest(t, args, expectedYAML)
+}
+
+func TestCreateAuthProvider_OpenShiftAuth_Success(t *testing.T) {
+	args := []string{
+		"openshift-auth",
+		"--name=some-name",
+		"--ui-endpoint=localhost:8000",
+		"--groups-key=email",
+		"--groups-value=example@example.com",
+		"--groups-role=Admin",
+		"--minimum-access-role=Analyst",
+		"--extra-ui-endpoints=localhost:9090",
+		"--required-attributes=org_id=12345,name=some_name",
+	}
+
+	expectedYAML := `name: some-name
+minimumRole: Analyst
+uiEndpoint: localhost:8000
+extraUIEndpoints:
+    - localhost:9090
+groups:
+    - key: email
+      value: example@example.com
+      role: Admin
+requiredAttributes:
+    - key: org_id
+      value: "12345"
+    - key: name
+      value: some_name
+openshift:
+    enable: true
+`
+
+	runSuccessfulCommandTest(t, args, expectedYAML)
+}
+
+func TestCreateAuthProvider_IAP_Success(t *testing.T) {
+	args := []string{
+		"iap",
+		"--name=some-name",
+		"--ui-endpoint=localhost:8000",
+		"--groups-key=email",
+		"--groups-value=example@example.com",
+		"--groups-role=Admin",
+		"--minimum-access-role=Analyst",
+		"--extra-ui-endpoints=localhost:9090",
+		"--required-attributes=org_id=12345,name=some_name",
+		"--audience=some-audience",
+	}
+
+	expectedYAML := `name: some-name
+minimumRole: Analyst
+uiEndpoint: localhost:8000
+extraUIEndpoints:
+    - localhost:9090
+groups:
+    - key: email
+      value: example@example.com
+      role: Admin
+requiredAttributes:
+    - key: org_id
+      value: "12345"
+    - key: name
+      value: some_name
+iap:
+    audience: some-audience
+`
+
+	runSuccessfulCommandTest(t, args, expectedYAML)
+}
+
+func runSuccessfulCommandTest(t *testing.T, args []string, expectedYAML string) {
+	env, out, errOut := mocks.NewEnvWithConn(nil, t)
+	cmd := authProviderCommand(env)
+	cmd.SetArgs(args)
+	cmd.SetOut(out)
+	cmd.SetErr(errOut)
+
+	err := cmd.Execute()
+	assert.NoError(t, err)
+	assert.Empty(t, errOut)
+	assert.Equal(t, expectedYAML, out.String())
+}

--- a/roxctl/declarativeconfig/create/create.go
+++ b/roxctl/declarativeconfig/create/create.go
@@ -1,0 +1,21 @@
+package create
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/stackrox/rox/roxctl/common/environment"
+)
+
+// Command defines the declarative config create command tree.
+func Command(cliEnvironment environment.Environment) *cobra.Command {
+	c := &cobra.Command{
+		Use: "create",
+	}
+
+	c.AddCommand(
+		accessScopeCommand(cliEnvironment),
+		authProviderCommand(cliEnvironment),
+		permissionSetCommand(cliEnvironment),
+		roleCommand(cliEnvironment),
+	)
+	return c
+}

--- a/roxctl/declarativeconfig/create/create.go
+++ b/roxctl/declarativeconfig/create/create.go
@@ -8,7 +8,8 @@ import (
 // Command defines the declarative config create command tree.
 func Command(cliEnvironment environment.Environment) *cobra.Command {
 	c := &cobra.Command{
-		Use: "create",
+		Use:   "create",
+		Short: "Commands related to creating declarative configurations",
 	}
 
 	c.AddCommand(

--- a/roxctl/declarativeconfig/create/permission_set.go
+++ b/roxctl/declarativeconfig/create/permission_set.go
@@ -1,0 +1,77 @@
+package create
+
+import (
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/declarativeconfig"
+	"github.com/stackrox/rox/pkg/errox"
+	"github.com/stackrox/rox/pkg/maputil"
+	"github.com/stackrox/rox/roxctl/common/environment"
+	"gopkg.in/yaml.v3"
+)
+
+func permissionSetCommand(cliEnvironment environment.Environment) *cobra.Command {
+	permSetCmd := &permissionSetCmd{permissionSet: &declarativeconfig.PermissionSet{}, env: cliEnvironment}
+
+	cmd := &cobra.Command{
+		Use:  permSetCmd.permissionSet.Type(),
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := permSetCmd.Validate(); err != nil {
+				return errors.Wrap(err, "validating the permission set")
+			}
+			return permSetCmd.PrintYAML()
+		},
+	}
+
+	cmd.Flags().StringVar(&permSetCmd.permissionSet.Name, "name", "", "name of the permission set")
+	cmd.Flags().StringVar(&permSetCmd.permissionSet.Description, "description", "",
+		"description of the permission set")
+	cmd.Flags().StringToStringVar(&permSetCmd.resourceWithAccess, "resource-with-access", map[string]string{},
+		`list of resource with the respective access, e.g. --resource-with-access Access=READ_ACCESS,Admin=READ_WRITE_ACCESS
+(Note: Capitalization matters!`)
+
+	cmd.MarkFlagsRequiredTogether("name", "resource-with-access")
+
+	return cmd
+}
+
+type permissionSetCmd struct {
+	permissionSet      *declarativeconfig.PermissionSet
+	resourceWithAccess map[string]string
+	env                environment.Environment
+}
+
+func (p *permissionSetCmd) Validate() error {
+	accessMap := p.resourceWithAccess
+
+	resourceWithAccess := make([]declarativeconfig.ResourceWithAccess, 0, len(accessMap))
+
+	var invalidAccessErrors *multierror.Error
+	// Resources are currently defined within central/role/resources, and hence cannot be reused here yet.
+	// There are plans to move the resource definition to a shared place however, in which case we can reuse them here.
+	for resource, access := range accessMap {
+		accessVal, ok := storage.Access_value[access]
+		if !ok {
+			invalidAccessErrors = multierror.Append(invalidAccessErrors, errox.InvalidArgs.
+				Newf("invalid access specified for resource %s: %s. The allowed values for access are: [%s]",
+					resource, access, strings.Join(maputil.Keys(storage.Access_value), ",")))
+			continue
+		}
+		resourceWithAccess = append(resourceWithAccess, declarativeconfig.ResourceWithAccess{
+			Resource: resource,
+			Access:   declarativeconfig.Access(accessVal),
+		})
+	}
+	p.permissionSet.Resources = resourceWithAccess
+	return errors.Wrap(invalidAccessErrors.ErrorOrNil(), "validating permission set")
+}
+
+func (p *permissionSetCmd) PrintYAML() error {
+	enc := yaml.NewEncoder(p.env.InputOutput().Out())
+	return errors.Wrap(enc.Encode(p.permissionSet), "creating the YAML output")
+}

--- a/roxctl/declarativeconfig/create/permission_set.go
+++ b/roxctl/declarativeconfig/create/permission_set.go
@@ -34,7 +34,7 @@ func permissionSetCommand(cliEnvironment environment.Environment) *cobra.Command
 	cmd.Flags().StringVar(&permSetCmd.permissionSet.Description, "description", "",
 		"description of the permission set")
 	cmd.Flags().StringToStringVar(&permSetCmd.resourceWithAccess, "resource-with-access", map[string]string{},
-		`list of resource with the respective access, e.g. --resource-with-access Access=READ_ACCESS,Admin=READ_WRITE_ACCESS
+		`list of resources with the respective access, e.g. --resource-with-access Access=READ_ACCESS,Admin=READ_WRITE_ACCESS
 Note: Capitalization matters!`)
 
 	cmd.MarkFlagsRequiredTogether("name", "resource-with-access")
@@ -57,11 +57,11 @@ func (p *permissionSetCmd) Validate() error {
 	resources := maputil.Keys(accessMap)
 	sort.Strings(resources)
 
-	// Resources are currently defined within central/role/resources, and hence cannot be reused here yet.
+	// TODO(ROX-16330): Resources are currently defined within central/role/resources, and hence cannot be reused here yet.
 	// There are plans to move the resource definition to a shared place however, in which case we can reuse them here.
 	var invalidAccessErrors *multierror.Error
 	for _, resource := range resources {
-		accessVal, ok := storage.Access_value[accessMap[resource]]
+		accessVal, ok := storage.Access_value[strings.ToUpper(accessMap[resource])]
 		if !ok {
 			invalidAccessErrors = multierror.Append(invalidAccessErrors, errox.InvalidArgs.
 				Newf("invalid access specified for resource %s: %s. The allowed values for access are: [%s]",

--- a/roxctl/declarativeconfig/create/permission_set.go
+++ b/roxctl/declarativeconfig/create/permission_set.go
@@ -27,6 +27,7 @@ func permissionSetCommand(cliEnvironment environment.Environment) *cobra.Command
 			}
 			return permSetCmd.PrintYAML()
 		},
+		Short: "Create a declarative configuration for a permission set",
 	}
 
 	cmd.Flags().StringVar(&permSetCmd.permissionSet.Name, "name", "", "name of the permission set")

--- a/roxctl/declarativeconfig/create/permission_set.go
+++ b/roxctl/declarativeconfig/create/permission_set.go
@@ -34,7 +34,7 @@ func permissionSetCommand(cliEnvironment environment.Environment) *cobra.Command
 	cmd.Flags().StringVar(&permSetCmd.permissionSet.Description, "description", "",
 		"description of the permission set")
 	cmd.Flags().StringToStringVar(&permSetCmd.resourceWithAccess, "resource-with-access", map[string]string{},
-		`list of resources with the respective access, e.g. --resource-with-access Access=READ_ACCESS,Admin=READ_WRITE_ACCESS
+		`list of resources with the respective access, e.g. --resource-with-access Access=READ_ACCESS,Administration=READ_WRITE_ACCESS
 Note: Capitalization matters!`)
 
 	cmd.MarkFlagsRequiredTogether("name", "resource-with-access")

--- a/roxctl/declarativeconfig/create/permission_set_test.go
+++ b/roxctl/declarativeconfig/create/permission_set_test.go
@@ -93,6 +93,20 @@ resources:
       access: READ_WRITE_ACCESS
 `,
 		},
+		"with lowercase resource": {
+			args: []string{
+				"--name=some-name",
+				"--resource-with-access=Access=read_access",
+				"--resource-with-access=Admin=read_write_access",
+			},
+			expectedYAML: `name: some-name
+resources:
+    - resource: Access
+      access: READ_ACCESS
+    - resource: Admin
+      access: READ_WRITE_ACCESS
+`,
+		},
 	}
 
 	for name, c := range cases {

--- a/roxctl/declarativeconfig/create/permission_set_test.go
+++ b/roxctl/declarativeconfig/create/permission_set_test.go
@@ -1,0 +1,114 @@
+package create
+
+import (
+	"testing"
+
+	"github.com/stackrox/rox/pkg/errox"
+	"github.com/stackrox/rox/roxctl/common/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreatePermissionSet_Failures(t *testing.T) {
+	cases := map[string]struct {
+		args   []string
+		errOut string
+		err    error
+	}{
+		"missing name flag": {
+			args: []string{
+				`--resource-with-access="Access=READ_ACCESS"`,
+			},
+			errOut: `Error: if any flags in the group [name resource-with-access] are set they must all be set; missing [name]
+`,
+		},
+		"missing resource-with-access flag": {
+			args: []string{
+				"--name=some-name",
+			},
+			errOut: `Error: if any flags in the group [name resource-with-access] are set they must all be set; missing [resource-with-access]
+`,
+		},
+		"invalid access specified in resource-with-access flag": {
+			args: []string{
+				"--name=some-name",
+				`--resource-with-access=Access=ReadAccess,Admin=READ_WRITE_ACCESS,Policy=none_access`,
+			},
+			err: errox.InvalidArgs,
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			env, out, errOut := mocks.NewEnvWithConn(nil, t)
+			cmd := permissionSetCommand(env)
+
+			cmd.SetArgs(c.args)
+			cmd.SetErr(errOut)
+			cmd.SetOut(out)
+
+			err := cmd.Execute()
+			assert.Error(t, err)
+
+			if c.err != nil {
+				assert.ErrorIs(t, err, c.err)
+			}
+
+			if c.errOut != "" {
+				assert.Equal(t, c.errOut, errOut.String())
+			}
+		})
+	}
+}
+
+func TestCreatePermissionSet_Success(t *testing.T) {
+	cases := map[string]struct {
+		args         []string
+		expectedYAML string
+	}{
+		"with description set": {
+			args: []string{
+				"--name=some-name",
+				"--description=some-description",
+				`--resource-with-access=Access=READ_ACCESS,Admin=READ_WRITE_ACCESS`,
+			},
+			expectedYAML: `name: some-name
+description: some-description
+resources:
+    - resource: Access
+      access: READ_ACCESS
+    - resource: Admin
+      access: READ_WRITE_ACCESS
+`,
+		},
+		"without description set": {
+			args: []string{
+				"--name=some-name",
+				`--resource-with-access=Access=READ_ACCESS,Admin=READ_WRITE_ACCESS`,
+			},
+			expectedYAML: `name: some-name
+resources:
+    - resource: Access
+      access: READ_ACCESS
+    - resource: Admin
+      access: READ_WRITE_ACCESS
+`,
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			env, out, errOut := mocks.NewEnvWithConn(nil, t)
+			cmd := permissionSetCommand(env)
+
+			cmd.SetArgs(c.args)
+			cmd.SetErr(errOut)
+			cmd.SetOut(out)
+
+			err := cmd.Execute()
+			assert.NoError(t, err)
+
+			assert.Empty(t, errOut)
+			assert.Equal(t, c.expectedYAML, out.String())
+		})
+	}
+}

--- a/roxctl/declarativeconfig/create/role.go
+++ b/roxctl/declarativeconfig/create/role.go
@@ -1,0 +1,44 @@
+package create
+
+import (
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/stackrox/rox/pkg/declarativeconfig"
+	"github.com/stackrox/rox/roxctl/common/environment"
+	"gopkg.in/yaml.v3"
+)
+
+func roleCommand(cliEnvironment environment.Environment) *cobra.Command {
+	roleCmd := &roleCmd{role: &declarativeconfig.Role{}, env: cliEnvironment}
+
+	cmd := &cobra.Command{
+		Use:  roleCmd.role.Type(),
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return roleCmd.PrintYAML()
+		},
+	}
+
+	cmd.Flags().StringVar(&roleCmd.role.Name, "name", "", "name of the role")
+	cmd.Flags().StringVar(&roleCmd.role.Description, "description", "", "description of the role")
+	cmd.Flags().StringVar(&roleCmd.role.AccessScope, "access-scope", "",
+		"name of the referenced access scope")
+	cmd.Flags().StringVar(&roleCmd.role.PermissionSet, "permission-set", "",
+		"name of the referenced permission set")
+
+	// No additional validation is required for roles, since a role is valid when name, permission set, access
+	// scope are set, which is covered by requiring the flag.
+	cmd.MarkFlagsRequiredTogether("name", "access-scope", "permission-set")
+
+	return cmd
+}
+
+type roleCmd struct {
+	role *declarativeconfig.Role
+	env  environment.Environment
+}
+
+func (r *roleCmd) PrintYAML() error {
+	enc := yaml.NewEncoder(r.env.InputOutput().Out())
+	return errors.Wrap(enc.Encode(r.role), "creating the YAML output")
+}

--- a/roxctl/declarativeconfig/create/role.go
+++ b/roxctl/declarativeconfig/create/role.go
@@ -17,6 +17,7 @@ func roleCommand(cliEnvironment environment.Environment) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return roleCmd.PrintYAML()
 		},
+		Short: "Create a declarative configuration for a role",
 	}
 
 	cmd.Flags().StringVar(&roleCmd.role.Name, "name", "", "name of the role")

--- a/roxctl/declarativeconfig/create/role_test.go
+++ b/roxctl/declarativeconfig/create/role_test.go
@@ -12,12 +12,17 @@ func TestCreateRoleCommand_Failures(t *testing.T) {
 		args   []string
 		errOut string
 	}{
+		"no flag set": {
+			args: []string{},
+			errOut: `Error: required flag(s) "access-scope", "name", "permission-set" not set
+`,
+		},
 		"missing name flag": {
 			args: []string{
 				"--access-scope=some-access-scope",
 				"--permission-set=some-permission-set",
 			},
-			errOut: `Error: if any flags in the group [name access-scope permission-set] are set they must all be set; missing [name]
+			errOut: `Error: required flag(s) "name" not set
 `,
 		},
 		"missing access scope flag": {
@@ -25,7 +30,7 @@ func TestCreateRoleCommand_Failures(t *testing.T) {
 				"--name=some-name",
 				"--permission-set=some-permission-set",
 			},
-			errOut: `Error: if any flags in the group [name access-scope permission-set] are set they must all be set; missing [access-scope]
+			errOut: `Error: required flag(s) "access-scope" not set
 `,
 		},
 		"missing permission set flag": {
@@ -33,7 +38,7 @@ func TestCreateRoleCommand_Failures(t *testing.T) {
 				"--name=some-name",
 				"--access-scope=some-access-scope",
 			},
-			errOut: `Error: if any flags in the group [name access-scope permission-set] are set they must all be set; missing [permission-set]
+			errOut: `Error: required flag(s) "permission-set" not set
 `,
 		},
 	}

--- a/roxctl/declarativeconfig/create/role_test.go
+++ b/roxctl/declarativeconfig/create/role_test.go
@@ -1,0 +1,103 @@
+package create
+
+import (
+	"testing"
+
+	"github.com/stackrox/rox/roxctl/common/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateRoleCommand_Failures(t *testing.T) {
+	cases := map[string]struct {
+		args   []string
+		errOut string
+	}{
+		"missing name flag": {
+			args: []string{
+				"--access-scope=some-access-scope",
+				"--permission-set=some-permission-set",
+			},
+			errOut: `Error: if any flags in the group [name access-scope permission-set] are set they must all be set; missing [name]
+`,
+		},
+		"missing access scope flag": {
+			args: []string{
+				"--name=some-name",
+				"--permission-set=some-permission-set",
+			},
+			errOut: `Error: if any flags in the group [name access-scope permission-set] are set they must all be set; missing [access-scope]
+`,
+		},
+		"missing permission set flag": {
+			args: []string{
+				"--name=some-name",
+				"--access-scope=some-access-scope",
+			},
+			errOut: `Error: if any flags in the group [name access-scope permission-set] are set they must all be set; missing [permission-set]
+`,
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			env, out, errOut := mocks.NewEnvWithConn(nil, t)
+			cmd := roleCommand(env)
+
+			cmd.SetArgs(c.args)
+			cmd.SetErr(errOut)
+			cmd.SetOut(out)
+
+			err := cmd.Execute()
+			assert.Error(t, err)
+			assert.Equal(t, c.errOut, errOut.String())
+		})
+	}
+}
+
+func TestCreateRoleCommand_Success(t *testing.T) {
+	cases := map[string]struct {
+		args         []string
+		expectedYAML string
+	}{
+		"with description set": {
+			args: []string{
+				"--name=some-name",
+				"--description=some-description",
+				"--access-scope=some-access-scope",
+				"--permission-set=some-permission-set",
+			},
+			expectedYAML: `name: some-name
+description: some-description
+accessScope: some-access-scope
+permissionSet: some-permission-set
+`,
+		},
+		"without description set": {
+			args: []string{
+				"--name=some-name",
+				"--access-scope=some-access-scope",
+				"--permission-set=some-permission-set",
+			},
+			expectedYAML: `name: some-name
+accessScope: some-access-scope
+permissionSet: some-permission-set
+`,
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			env, out, errOut := mocks.NewEnvWithConn(nil, t)
+			cmd := roleCommand(env)
+
+			cmd.SetArgs(c.args)
+			cmd.SetErr(errOut)
+			cmd.SetOut(out)
+
+			err := cmd.Execute()
+			assert.NoError(t, err)
+			assert.Empty(t, errOut.String())
+			assert.Equal(t, c.expectedYAML, out.String())
+		})
+	}
+}

--- a/roxctl/declarativeconfig/declarativeconfig.go
+++ b/roxctl/declarativeconfig/declarativeconfig.go
@@ -1,0 +1,19 @@
+package declarativeconfig
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/stackrox/rox/roxctl/common/environment"
+	"github.com/stackrox/rox/roxctl/declarativeconfig/create"
+)
+
+// Command defines the declarative config command tree.
+func Command(cliEnvironment environment.Environment) *cobra.Command {
+	c := &cobra.Command{
+		Use: "declarative-config",
+	}
+
+	c.AddCommand(
+		create.Command(cliEnvironment),
+	)
+	return c
+}

--- a/roxctl/declarativeconfig/declarativeconfig.go
+++ b/roxctl/declarativeconfig/declarativeconfig.go
@@ -10,7 +10,7 @@ import (
 func Command(cliEnvironment environment.Environment) *cobra.Command {
 	c := &cobra.Command{
 		Use:   "declarative-config",
-		Short: "Commands related to declarative configuration",
+		Short: "Commands that help manage declarative configuration",
 	}
 
 	c.AddCommand(

--- a/roxctl/declarativeconfig/declarativeconfig.go
+++ b/roxctl/declarativeconfig/declarativeconfig.go
@@ -9,7 +9,8 @@ import (
 // Command defines the declarative config command tree.
 func Command(cliEnvironment environment.Environment) *cobra.Command {
 	c := &cobra.Command{
-		Use: "declarative-config",
+		Use:   "declarative-config",
+		Short: "Commands related to declarative configuration",
 	}
 
 	c.AddCommand(

--- a/roxctl/maincommand/command.go
+++ b/roxctl/maincommand/command.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stackrox/rox/roxctl/common/environment"
 	"github.com/stackrox/rox/roxctl/common/flags"
 	"github.com/stackrox/rox/roxctl/completion"
+	"github.com/stackrox/rox/roxctl/declarativeconfig"
 	"github.com/stackrox/rox/roxctl/deployment"
 	"github.com/stackrox/rox/roxctl/generate"
 	"github.com/stackrox/rox/roxctl/helm"
@@ -79,6 +80,9 @@ func Command() *cobra.Command {
 	)
 	if features.RoxctlNetpolGenerate.Enabled() {
 		c.AddCommand(generate.Command(cliEnvironment))
+	}
+	if features.DeclarativeConfiguration.Enabled() {
+		c.AddCommand(declarativeconfig.Command(cliEnvironment))
 	}
 
 	return c

--- a/roxctl/maincommand/command.go
+++ b/roxctl/maincommand/command.go
@@ -7,6 +7,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/stackrox/rox/pkg/buildinfo"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/version"
 	"github.com/stackrox/rox/roxctl/central"
@@ -81,7 +82,7 @@ func Command() *cobra.Command {
 	if features.RoxctlNetpolGenerate.Enabled() {
 		c.AddCommand(generate.Command(cliEnvironment))
 	}
-	if features.DeclarativeConfiguration.Enabled() {
+	if env.DeclarativeConfiguration.BooleanSetting() {
 		c.AddCommand(declarativeconfig.Command(cliEnvironment))
 	}
 


### PR DESCRIPTION
## Description

This PR is the first PR in a series of PRs to add roxctl commands to support users with the usage of declarative configurations.

The first command introduced is the `create` command.
The use-case for the `create` command is to offer users with the possibility to generate the YAML format of the declarative configuration via a CLI, instead of manually constructing it themselves (similar to how one can generate a deployment YAML via `kubectl create deployment --replicas=1 --image 
nginx:latest --dry-run-client -o yaml`).

The `create` command exposes subcommands for each resource supported in declarative configuration (`role, auth provider, access scope, permission set`) and each command will a) construct the declarative configuration struct from the flag values b) attempt to transform the struct, as a means of validation.
If everything passed successfully, the YAML will be returned.

There are some caveats within the PR:
- the custom `MarshalYAML` methods added to the `Access` and `Operator` types were fixed, as they had the wrong signature and were never called. Included tests to cover that these work going forward.
- for the `create access-scope` command, a few workarounds had to be taken. This is mainly due to the complex structure of the object, which in turn is quite hard to provide as a CLI:
    - Two custom flag types were added, `included-objects` and `requirements`. The custom flag types allow to add a key with multiple values / three key value pairs within a single flag.

Other alternatives considered within this PR:
While this "manual" work seems OK for now within this PR and for the amount of resources we have, it might be worthwhile generating the flags at the very least going forward. There are a couple of libraries available (such as [go-flags](https://github.com/jessevdk/go-flags)), but either they do not support integration with cobra's `pflag.FlagSet` or are mostly unmaintained, hence I decided against using such a solution.
In the future we might either introduce this as our own / fork one of the libraries, or integrate one if we find a suitable one (the desire for these commands may also be less once we move to CRs).

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

- see added tests.
