### PR TITLE
ROX-16231: Respect the ROX_OFFLINE_MODE setting

### DIFF
--- a/central/telemetry/centralclient/instance_config.go
+++ b/central/telemetry/centralclient/instance_config.go
@@ -35,7 +35,7 @@ var (
 
 func getInstanceConfig() (*phonehome.Config, map[string]any, error) {
 	key := env.TelemetryStorageKey.Setting()
-	if key == "" {
+	if key == "" || env.OfflineModeEnv.BooleanSetting() {
 		return nil, nil, nil
 	}
 


### PR DESCRIPTION
## Description

Telemetry configuration must take into account the `ROX_OFFLINE_MODE` setting. This PR makes the central to skip telemetry initialization when this setting is set to true.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed
```sh
$ kubectl get deploy/central -o json | jq ".spec.template.spec.containers[0].env[3,9]"
{
  "name": "ROX_OFFLINE_MODE",
  "value": "true"
}
{
  "name": "ROX_TELEMETRY_STORAGE_KEY_V1",
  "value": "abc"
}
$ kubectl logs deploy/central | grep tele
telemetry/centralclient: 2023/03/29 08:53:00.909162 instance_config.go:107: Info: Phonehome telemetry collection disabled.
```