### PR TITLE
ROX-13798: Add resource limits for the node-inventory container

### DIFF
--- a/image/templates/helm/stackrox-secured-cluster/README.md.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/README.md.htpl
@@ -59,7 +59,7 @@ roxctl central init-bundles generate <cluster init bundle name> --output cluster
 - Make sure that you store this bundle securely as it contains secrets. You can
   use the same bundle to set up multiple StackRox secured clusters.
 
-### Deploy Secured Cluster Services 
+### Deploy Secured Cluster Services
 
 You can use the following command to deploy secured cluster services by using
 this Helm chart:
@@ -147,7 +147,7 @@ the options which you can configure:
 
   env:
     istio: true  # enable istio support
-  
+
   sensor:
     # Use custom resource overrides for sensor
     resources:
@@ -157,11 +157,11 @@ the options which you can configure:
       limits:
         cpu: "4"
         memory: "8Gi"
-  
+
   admissionControl:
     dynamic:
       disableBypass: true # Disable bypassing of Admission Controller
-  
+
   customize:
     # Apply the important-service=true label for all objects managed by this chart.
     labels:
@@ -282,6 +282,7 @@ non-standard environments:
 |`sensor.resources`|Resource specification for Sensor.|See below.|
 |`collector.resources`|Resource specification for Collector.|See below.|
 |`collector.complianceResources`|Resource specification for Collector's Compliance container.|See below.|
+|`collector.nodeInventoryResources`|Resource specification for Collector's Node Inventory container.|See below.|
 |`collector.nodeSelector` | Node selector for Collector pods placement. | `null` (no placement constraints) |
 |`admissionControl.resources`|Resource specification for Admission Control.|See below.|
 |`sensor.imagePullPolicy`| Kubernetes image pull policy for Sensor. | `IfNotPresent` |
@@ -301,12 +302,13 @@ Each container's default resource settings are defined in the
 `internal/defaults.yaml` file in this chart. The following table lists the YAML
 paths to the respective defaults for each container that this chart deploys:
 
-|Container        |Path in `internal/defaults.yaml`        |
-|:----------------|:---------------------------------------|
-|Sensor           |`defaults.sensor.resources`             |
-|Collector        |`defaults.collector.resources`          |
-|Compliance       |`defaults.collector.complianceResources`|
-|Admission Control|`defaults.admissionControl.resources`   |
+|Container        |Path in `internal/defaults.yaml`           |
+|:----------------|:------------------------------------------|
+|Sensor           |`defaults.sensor.resources`                |
+|Collector        |`defaults.collector.resources`             |
+|Compliance       |`defaults.collector.complianceResources`   |
+|NodeInventory    |`defaults.collector.nodeInventoryResources`|
+|Admission Control|`defaults.admissionControl.resources`      |
 
 ### Customization settings
 

--- a/image/templates/helm/stackrox-secured-cluster/internal/config-shape.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/internal/config-shape.yaml
@@ -103,6 +103,7 @@ collector:
   resources: null # string | dict
   complianceImagePullPolicy: null # string
   complianceResources: null # string | dict
+  nodeInventoryResources: null # string | dict
   serviceTLS:
     cert: null # string
     key: null # string

--- a/image/templates/helm/stackrox-secured-cluster/internal/defaults/40-resources.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/internal/defaults/40-resources.yaml
@@ -34,3 +34,11 @@ collector:
     limits:
       memory: "2Gi"
       cpu: "1"
+
+  nodeInventoryResources:
+    requests:
+      memory: "10Mi"
+      cpu: "10m"
+    limits:
+      memory: "2Gi"
+      cpu: "1"

--- a/image/templates/helm/stackrox-secured-cluster/internal/expandables.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/internal/expandables.yaml
@@ -27,6 +27,7 @@ collector:
     key: true
   resources: true
   complianceResources: true
+  nodeInventoryResources: true
   nodeSelector: true
 scanner:
   resources: true

--- a/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml
@@ -150,6 +150,8 @@ spec:
         ports:
           - containerPort: 8444
             name: grpc
+        resources:
+          {{- ._rox.collector._nodeInventoryResources | nindent 10 }}
         env:
         - name: ROX_NODE_NAME
           valueFrom:

--- a/image/templates/helm/stackrox-secured-cluster/values-public.yaml.example
+++ b/image/templates/helm/stackrox-secured-cluster/values-public.yaml.example
@@ -272,6 +272,15 @@
 #      memory: "2Gi"
 #      cpu: "1"
 #
+#  # Resource configuration for the Node Inventory container.
+#  nodeInventoryResources:
+#    requests:
+#      memory: "10Mi"
+#      cpu: "10m"
+#    limits:
+#      memory: "2Gi"
+#      cpu: "1"
+#
 #  # Settings for the internal service-to-service TLS certificate used by Collector.
 #  serviceTLS:
 #    cert: null


### PR DESCRIPTION
## Description

The newly created collector container `node-inventory` has now resource limits. They are set to the default values of the compliance container, as it hasn't observed any issues during load testing. The limits are set with a large error margin to avoid OOM kills. Should a OOM happen, the blast radius will be limited to a single container (and the RHCOS node scanning feature), so that ACS with all other features can continue running.

## Checklist
- [x] Investigated and inspected CI test results

### N/A
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

- [x] Running `roxctl helm output secured-cluster-services` followed by `helm template` and analyzing the `collector.yaml` manifest manually
- [x] Running `roxctl sensor generate openshift` and analyzing the `collector.yaml` manifest manually
- [x] CI
