### PR TITLE
Add images table for CVE single page

### DIFF
--- a/ui/apps/platform/src/Components/PatternFly/FixabilityIcons.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/FixabilityIcons.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { CheckCircleIcon, ExclamationCircleIcon } from '@patternfly/react-icons';
+import { SVGIconProps } from '@patternfly/react-icons/dist/esm/createIcon';
+
+export const FixableIcon = (props: SVGIconProps) => (
+    <CheckCircleIcon color="var(--pf-global--success-color--100)" {...props} />
+);
+
+export const NotFixableIcon = (props: SVGIconProps) => (
+    <ExclamationCircleIcon color="var(--pf-global--danger-color--100)" {...props} />
+);

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCveSummaryCards.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCveSummaryCards.tsx
@@ -2,11 +2,12 @@ import React from 'react';
 import { gql } from '@apollo/client';
 import { Flex } from '@patternfly/react-core';
 import { VulnerabilitySeverity } from 'types/cve.proto';
-import EnvironmentalImpact from './SummaryCards/EnvironmentalImpact';
+import AffectedImages from './SummaryCards/AffectedImages';
 import TopCvssScoreBreakdown from './SummaryCards/TopCvssScoreBreakdown';
 import BySeveritySummaryCard from './SummaryCards/BySeveritySummaryCard';
 
 export type ImageCveSummaryCount = {
+    totalImageCount: number;
     imageCount: number;
     deploymentCount: number;
 };
@@ -39,6 +40,7 @@ export const imageCveSeveritySummaryFragment = gql`
 
 export const imageCveSummaryCountFragment = gql`
     fragment ImageCVESummaryCounts on Query {
+        totalImageCount: imageCount
         imageCount(query: $query)
         deploymentCount(query: $query)
     }
@@ -57,20 +59,22 @@ function ImageCveSummaryCards({
 }: ImageCveSummaryCardsProps) {
     const { critical, important, moderate, low } = severitySummary.affectedImageCountBySeverity;
     const { affectedImageCount, topCVSS } = severitySummary;
-    const { imageCount } = summaryCounts;
+    const { totalImageCount } = summaryCounts;
     return (
         <Flex
             direction={{ default: 'column', lg: 'row' }}
             alignItems={{ lg: 'alignItemsStretch' }}
             justifyContent={{ default: 'justifyContentSpaceBetween' }}
         >
-            <EnvironmentalImpact
-                className="pf-u-flex-grow-1"
+            <AffectedImages
+                className="pf-u-flex-grow-1 pf-u-flex-basis-0"
+                // TODO Should affectedImagesCount be the value derived from
+                //      `imageCount(query: $query)` or from `affectedImageCount`?
                 affectedImageCount={affectedImageCount}
-                totalImagesCount={imageCount}
+                totalImagesCount={totalImageCount}
             />
             <BySeveritySummaryCard
-                className="pf-u-flex-grow-1"
+                className="pf-u-flex-grow-1 pf-u-flex-basis-0"
                 title="Images by severity"
                 severityCounts={{
                     CRITICAL_VULNERABILITY_SEVERITY: critical,
@@ -81,7 +85,7 @@ function ImageCveSummaryCards({
                 hiddenSeverities={hiddenSeverities}
             />
             <TopCvssScoreBreakdown
-                className="pf-u-flex-grow-1"
+                className="pf-u-flex-grow-1 pf-u-flex-basis-0"
                 cvssScore={topCVSS}
                 vector="TODO - Not implemented"
             />

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/SummaryCards/AffectedImages.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/SummaryCards/AffectedImages.tsx
@@ -1,20 +1,20 @@
 import React from 'react';
 import { Card, CardTitle, CardBody } from '@patternfly/react-core';
 
-export type EnvironmentalImpactProps = {
+export type AffectedImagesProps = {
     className?: string;
     affectedImageCount: number;
     totalImagesCount: number;
 };
 
-function EnvironmentalImpact({
+function AffectedImages({
     className = '',
     affectedImageCount,
     totalImagesCount,
-}: EnvironmentalImpactProps) {
+}: AffectedImagesProps) {
     return (
         <Card className={className} isCompact>
-            <CardTitle>Environmental impact</CardTitle>
+            <CardTitle>Affected images</CardTitle>
             <CardBody>
                 {affectedImageCount}/{totalImagesCount} images affected
             </CardBody>
@@ -22,4 +22,4 @@ function EnvironmentalImpact({
     );
 }
 
-export default EnvironmentalImpact;
+export default AffectedImages;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/SummaryCards/BySeveritySummaryCard.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/SummaryCards/BySeveritySummaryCard.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { Card, CardBody, CardTitle, Flex, Grid, GridItem, Text } from '@patternfly/react-core';
+import { SVGIconProps } from '@patternfly/react-icons/dist/esm/createIcon';
 
 import SeverityIcons from 'Components/PatternFly/SeverityIcons';
 
 import { VulnerabilitySeverity } from 'types/cve.proto';
 import { vulnerabilitySeverityLabels } from 'messages/common';
-import { SVGIconProps } from '@patternfly/react-icons/dist/esm/createIcon';
 
 export type BySeveritySummaryCardProps = {
     className?: string;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedDeploymentsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedDeploymentsTable.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+function AffectedDeploymentsTable() {
+    return <>TODO</>;
+}
+
+export default AffectedDeploymentsTable;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedImagesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedImagesTable.tsx
@@ -1,0 +1,223 @@
+import React from 'react';
+import { gql } from '@apollo/client';
+import { Button, ButtonVariant, Flex } from '@patternfly/react-core';
+import {
+    ExpandableRowContent,
+    TableComposable,
+    Tbody,
+    Td,
+    Thead,
+    Th,
+    Tr,
+} from '@patternfly/react-table';
+
+import { FixableIcon, NotFixableIcon } from 'Components/PatternFly/FixabilityIcons';
+import LinkShim from 'Components/PatternFly/LinkShim';
+import SeverityIcons from 'Components/PatternFly/SeverityIcons';
+import useSet from 'hooks/useSet';
+import { UseURLSortResult } from 'hooks/useURLSort';
+import { vulnerabilitySeverityLabels } from 'messages/common';
+import { getDistanceStrictAsPhrase } from 'utils/dateUtils';
+
+import { DynamicColumnIcon } from '../DynamicIcon';
+import { getEntityPagePath } from '../searchUtils';
+
+export type ImageForCve = {
+    id: string;
+    name: {
+        registry: string;
+        remote: string;
+        tag: string;
+    } | null;
+    metadata: {
+        v1: {
+            layers: {
+                instruction: string;
+                value: string;
+            }[];
+        } | null;
+    } | null;
+    operatingSystem: string;
+    watchStatus: 'WATCHED' | 'NOT_WATCHED';
+    scanTime: Date | null;
+    topImageVulnerability: {
+        severity: string;
+        isFixable: boolean;
+    } | null;
+    imageComponentCount: number;
+    imageComponents: {
+        name: string;
+        version: string;
+        location: string;
+        layerIndex: number | null;
+        imageVulnerabilities: {
+            severity: string;
+            fixedByVersion: string;
+        }[];
+    }[];
+};
+
+export const imagesForCveFragment = gql`
+    fragment ImagesForCVE on Image {
+        id
+        name {
+            registry
+            remote
+            tag
+        }
+        metadata {
+            v1 {
+                layers {
+                    instruction
+                    value
+                }
+                created
+            }
+        }
+
+        operatingSystem
+        watchStatus
+        scanTime
+
+        topImageVulnerability {
+            severity
+            isFixable
+        }
+
+        imageComponentCount(query: $query)
+        imageComponents(query: $query, pagination: $imageComponentPagination) {
+            name
+            version
+            location
+            layerIndex
+            imageVulnerabilities(query: $query) {
+                severity # same for all components in an image
+                fixedByVersion
+            }
+        }
+    }
+`;
+
+export type AffectedImagesTableProps = {
+    className?: string;
+    images: ImageForCve[];
+    getSortParams: UseURLSortResult['getSortParams'];
+    isFiltered: boolean;
+};
+
+function AffectedImagesTable({ images, getSortParams, isFiltered }: AffectedImagesTableProps) {
+    const expandedRowSet = useSet<string>();
+
+    return (
+        // TODO UX question - Collapse to cards, or allow headers to overflow?
+        // <TableComposable gridBreakPoint="grid-xl">
+        <TableComposable>
+            <Thead>
+                <Tr>
+                    <Th>{/* Header for expanded column */}</Th>
+                    <Th sort={getSortParams('Image')}>Image</Th>
+                    <Th sort={getSortParams('Severity')}>Severity</Th>
+                    <Th sort={getSortParams('Fixable')}>
+                        Fix status
+                        {isFiltered && <DynamicColumnIcon />}
+                    </Th>
+                    <Th sort={getSortParams('Operating System')}>Operating system</Th>
+                    {/* TODO Add sorting for these columns once aggregate sorting is available in BE */}
+                    <Th>
+                        Affected components
+                        {isFiltered && <DynamicColumnIcon />}
+                    </Th>
+                    <Th>First discovered</Th>
+                </Tr>
+            </Thead>
+            {images.map(
+                (
+                    { id, name, operatingSystem, scanTime, topImageVulnerability, imageComponents },
+                    rowIndex
+                ) => {
+                    const topSeverity =
+                        topImageVulnerability?.severity ?? 'UNKNOWN_VULNERABILITY_SEVERITY';
+
+                    const isFixable = topImageVulnerability?.isFixable ?? false;
+                    const FixabilityIcon = isFixable ? FixableIcon : NotFixableIcon;
+
+                    const SeverityIcon = SeverityIcons[topSeverity];
+                    const severityLabel = vulnerabilitySeverityLabels[topSeverity];
+                    const isExpanded = expandedRowSet.has(id);
+
+                    return (
+                        <Tbody key={id} isExpanded={isExpanded}>
+                            <Tr>
+                                <Td
+                                    expand={{
+                                        rowIndex,
+                                        isExpanded,
+                                        onToggle: () => expandedRowSet.toggle(id),
+                                    }}
+                                />
+                                <Td dataLabel="Image">
+                                    {name ? (
+                                        <Flex
+                                            direction={{ default: 'column' }}
+                                            spaceItems={{ default: 'spaceItemsNone' }}
+                                        >
+                                            <Button
+                                                variant={ButtonVariant.link}
+                                                isInline
+                                                component={LinkShim}
+                                                href={getEntityPagePath('Image', id)}
+                                            >
+                                                {name.remote}
+                                            </Button>{' '}
+                                            <span className="pf-u-color-400 pf-u-font-size-sm">
+                                                in {name.registry}
+                                            </span>
+                                        </Flex>
+                                    ) : (
+                                        'Image name not available'
+                                    )}
+                                </Td>
+                                <Td dataLabel="Severity">
+                                    <span>
+                                        {SeverityIcon && (
+                                            <SeverityIcon className="pf-u-display-inline" />
+                                        )}
+                                        {severityLabel && (
+                                            <span className="pf-u-pl-sm">{severityLabel}</span>
+                                        )}
+                                    </span>
+                                </Td>
+                                <Td dataLabel="Fix status">
+                                    <span>
+                                        <FixabilityIcon className="pf-u-display-inline" />
+                                        <span className="pf-u-pl-sm">
+                                            {isFixable ? 'Fixable' : 'Not fixable'}
+                                        </span>
+                                    </span>
+                                </Td>
+                                <Td dataLabel="Operating system">{operatingSystem}</Td>
+                                <Td dataLabel="Affected components">
+                                    {imageComponents.length === 1
+                                        ? imageComponents[0].name
+                                        : `${imageComponents.length} components`}
+                                </Td>
+                                <Td dataLabel="First discovered">
+                                    {/* TODO Is this the correct field? It differs from the field on the CVE page. */}
+                                    {getDistanceStrictAsPhrase(scanTime, new Date())}
+                                </Td>
+                            </Tr>
+                            <Tr isExpanded={isExpanded}>
+                                <Td />
+                                <Td colSpan={5}>
+                                    <ExpandableRowContent>TODO</ExpandableRowContent>
+                                </Td>
+                            </Tr>
+                        </Tbody>
+                    );
+                }
+            )}
+        </TableComposable>
+    );
+}
+
+export default AffectedImagesTable;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/SingleEntityVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/SingleEntityVulnerabilitiesTable.tsx
@@ -9,7 +9,6 @@ import {
     Thead,
     Tr,
 } from '@patternfly/react-table';
-import { CheckCircleIcon, ExclamationCircleIcon } from '@patternfly/react-icons';
 import { SVGIconProps } from '@patternfly/react-icons/dist/js/createIcon';
 
 import LinkShim from 'Components/PatternFly/LinkShim';
@@ -18,6 +17,7 @@ import useSet from 'hooks/useSet';
 import { vulnerabilitySeverityLabels } from 'messages/common';
 import { getDistanceStrictAsPhrase } from 'utils/dateUtils';
 import { UseURLSortResult } from 'hooks/useURLSort';
+import { FixableIcon, NotFixableIcon } from 'Components/PatternFly/FixabilityIcons';
 import { ImageVulnerabilitiesResponse } from '../hooks/useImageVulnerabilities';
 import { getEntityPagePath } from '../searchUtils';
 import ImageComponentsTable from './ImageComponentsTable';
@@ -65,6 +65,8 @@ function SingleEntityVulnerabilitiesTable({
                     const severityLabel: string | undefined = vulnerabilitySeverityLabels[severity];
                     const isExpanded = expandedRowSet.has(cve);
 
+                    const FixabilityIcon = isFixable ? FixableIcon : NotFixableIcon;
+
                     return (
                         <Tbody key={cve} isExpanded={isExpanded}>
                             <Tr>
@@ -96,23 +98,12 @@ function SingleEntityVulnerabilitiesTable({
                                     </span>
                                 </Td>
                                 <Td dataLabel="CVE Status">
-                                    {isFixable ? (
-                                        <span>
-                                            <CheckCircleIcon
-                                                className="pf-u-display-inline"
-                                                color="var(--pf-global--success-color--100)"
-                                            />
-                                            <span className="pf-u-pl-sm">Fixable</span>
+                                    <span>
+                                        <FixabilityIcon className="pf-u-display-inline" />
+                                        <span className="pf-u-pl-sm">
+                                            {isFixable ? 'Fixable' : 'Not fixable'}
                                         </span>
-                                    ) : (
-                                        <span>
-                                            <ExclamationCircleIcon
-                                                className="pf-u-display-inline"
-                                                color="var(--pf-global--danger-color--100)"
-                                            />
-                                            <span className="pf-u-pl-sm">Not fixable</span>
-                                        </span>
-                                    )}
+                                    </span>
                                 </Td>
                                 <Td dataLabel="Affected components">
                                     {imageComponents.length === 1


### PR DESCRIPTION
## Description

This adds the Images data table on the ImageCVE single page.

It also makes a couple of semi-related tweaks on the same page:
- Abstract out the fixability icons to avoid copy/pasting
- Rename the "Environmental impact" summary card

There are many TODOs throughout this section that need to be broken out into subtasks. Most of them are either verifying with the BE team that field usage is correct, or filling in details that will not cause a large structural change.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Load an ImageCVE page. The default entity tab should be "Images" instead of "Deployments". (TBD for the UI component, but is implemented in the logic.)

Request loading state:
![image](https://user-images.githubusercontent.com/1292638/228324329-d6c8a321-009e-471c-9446-39ad5e32c3ba.png)

Request error state:
![image](https://user-images.githubusercontent.com/1292638/228325085-13efdc3d-5490-41a1-8adc-a8991c7b1c68.png)

Request complete state:
![image](https://user-images.githubusercontent.com/1292638/228325739-699d2d6e-3a02-4bbb-b237-928c8bf72720.png)

Test that the table does not load when the `entityTab` parameter is set to "Deployment" and the graphql request for images is not sent.
![image](https://user-images.githubusercontent.com/1292638/228326199-716540df-10eb-4959-a345-097d0d8ee8c5.png)

Test sorting of "image", "severity", "fix status" and "operating system" columns. (In local data, the latter three are always the same but I can verify that the correct parameter is sent in the request.)
![image](https://user-images.githubusercontent.com/1292638/228326478-d77395ea-030b-40a5-9d3f-0162f2f4a2d5.png)

Mobile view:
![image](https://user-images.githubusercontent.com/1292638/228347968-09c5f50d-2bdd-4179-b2cf-03a3bcbef92a.png)

