### PR TITLE
Fetch UI deps to generate OSS notice

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -264,8 +264,13 @@ jobs:
           name: docs-build
           path: image/docs
 
+      - uses: ./.github/actions/create-concatenated-ui-monorepo-lock
+
       # needed to restore node_modules for ossls-nostice
       - uses: ./.github/actions/cache-ui-dependencies
+
+      - name: Fetch UI deps
+        run: make -C ui deps
 
       - name: Generate OSS notice
         run: make ossls-notice
@@ -376,8 +381,13 @@ jobs:
         name: docs-build
         path: image/docs
 
+    - uses: ./.github/actions/create-concatenated-ui-monorepo-lock
+
     # needed to restore node_modules for ossls-nostice
     - uses: ./.github/actions/cache-ui-dependencies
+
+    - name: Fetch UI deps
+      run: make -C ui deps
 
     - name: Generate OSS notice
       run: make ossls-notice

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -269,6 +269,7 @@ jobs:
       # needed to restore node_modules for ossls-nostice
       - uses: ./.github/actions/cache-ui-dependencies
 
+      # explicitly fetch deps just in case cache was not ready
       - name: Fetch UI deps
         run: make -C ui deps
 
@@ -386,6 +387,7 @@ jobs:
     # needed to restore node_modules for ossls-nostice
     - uses: ./.github/actions/cache-ui-dependencies
 
+    # explicitly fetch deps just in case cache was not ready
     - name: Fetch UI deps
       run: make -C ui deps
 


### PR DESCRIPTION
## Description

From time to time if `style` fails the cache is not populated. This results with not generating image due to following error:
> ossls audit --export image/THIRD_PARTY_NOTICES
Processing JS deps directories: [ui/node_modules ui/apps/platform/node_modules ui/packages/ui-components/node_modules ui/packages/tailwind-config/node_modules] 
ossls: failed to locate js dependencies in dirs [ui/node_modules ui/apps/platform/node_modules ui/packages/ui-components/node_modules ui/packages/tailwind-config/node_modules]: failed to walk ui/node_modules: lstat ui/node_modules: no such file or directory

This PR explicitly downloads UI dependencies to not rely on cache. 

Refs:

- https://github.com/stackrox/stackrox/actions/runs/4539789916/jobs/8000175814?pr=5411

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

CI
