### PR TITLE
ROX-16171: Create node-inventory container only on Openshift 4

### DIFF
--- a/.github/workflows/cut-rc.yml
+++ b/.github/workflows/cut-rc.yml
@@ -452,7 +452,7 @@ jobs:
         run: |
           ./oc -n stackrox set image ds/collector compliance="quay.io/rhacs-eng/main:$TAG"
           ./oc -n stackrox set image ds/collector collector="quay.io/rhacs-eng/collector:$TAG"
-          ./oc -n stackrox set image ds/collector node-inventory="quay.io/rhacs-eng/scanner-slim:$TAG"
+          ./oc -n stackrox set image ds/collector node-inventory="quay.io/rhacs-eng/scanner-slim:$TAG" || echo "node-inventory shall be deployed only on Openshift 4 clusters"
           ./oc -n stackrox set image deploy/admission-control admission-control="quay.io/rhacs-eng/main:$TAG"
 
   notify-os4-cluster:

--- a/.github/workflows/cut-rc.yml
+++ b/.github/workflows/cut-rc.yml
@@ -452,7 +452,7 @@ jobs:
         run: |
           ./oc -n stackrox set image ds/collector compliance="quay.io/rhacs-eng/main:$TAG"
           ./oc -n stackrox set image ds/collector collector="quay.io/rhacs-eng/collector:$TAG"
-          ./oc -n stackrox set image ds/collector node-inventory="quay.io/rhacs-eng/scanner-slim:$TAG" || echo "node-inventory shall be deployed only on Openshift 4 clusters"
+          ./oc -n stackrox set image ds/collector node-inventory="quay.io/rhacs-eng/scanner-slim:$TAG"
           ./oc -n stackrox set image deploy/admission-control admission-control="quay.io/rhacs-eng/main:$TAG"
 
   notify-os4-cluster:

--- a/central/clusters/zip/render_test.go
+++ b/central/clusters/zip/render_test.go
@@ -68,11 +68,15 @@ func doTestRenderOpenshif(t *testing.T, clusterType storage.ClusterType) {
 	}
 	assertScannerRemote := func(obj runtime.Object) {
 		ds := obj.(*v1.DaemonSet)
-		assert.Len(t, ds.Spec.Template.Spec.Containers, 3)
-		mainImage := ds.Spec.Template.Spec.Containers[1].Image
-		nodeInvCont := ds.Spec.Template.Spec.Containers[2]
-		expectedScannerParts := strings.Split(strings.ReplaceAll(mainImage, "/main:", "/scanner-slim:"), ":")
-		assert.Truef(t, strings.HasPrefix(nodeInvCont.Image, expectedScannerParts[0]), "scanner-slim image (%q) should be from the same registry as main (%q)", nodeInvCont.Image, mainImage)
+		if clusterType == storage.ClusterType_OPENSHIFT4_CLUSTER {
+			assert.Len(t, ds.Spec.Template.Spec.Containers, 3)
+			mainImage := ds.Spec.Template.Spec.Containers[1].Image
+			nodeInvCont := ds.Spec.Template.Spec.Containers[2]
+			expectedScannerParts := strings.Split(strings.ReplaceAll(mainImage, "/main:", "/scanner-slim:"), ":")
+			assert.Truef(t, strings.HasPrefix(nodeInvCont.Image, expectedScannerParts[0]), "scanner-slim image (%q) should be from the same registry as main (%q)", nodeInvCont.Image, mainImage)
+		} else {
+			assert.Len(t, ds.Spec.Template.Spec.Containers, 2)
+		}
 	}
 
 	cases := map[string]func(object runtime.Object){

--- a/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml
@@ -143,6 +143,7 @@ spec:
         - mountPath: /run/secrets/stackrox.io/certs/
           name: certs
           readOnly: true
+      {{- if eq ._rox.env.openshift 4 }}
       - name: node-inventory
         image: {{ quote ._rox.image.scanner.fullRef }}
         imagePullPolicy: IfNotPresent
@@ -165,6 +166,7 @@ spec:
            name: tmp-volume
          - mountPath: /cache
            name: cache-volume
+      {{- end }}
       volumes:
       - hostPath:
           path: /var/run/docker.sock

--- a/tests/upgrade/postgres_run.sh
+++ b/tests/upgrade/postgres_run.sh
@@ -235,8 +235,7 @@ test_upgrade_paths() {
     kubectl -n stackrox set image deploy/admission-control "*=$REGISTRY/main:$CURRENT_TAG"
     kubectl -n stackrox set image ds/collector "collector=$REGISTRY/collector:$(make collector-tag)" \
         "compliance=$REGISTRY/main:$CURRENT_TAG"
-    # Check if collector has 2 or 3 containers - we expect to see 3 only on Openshift 4
-    if kubectl -n stackrox get ds/collector -o=jsonpath='{$.spec.template.spec.containers[2].image}'; then
+    if [[ "$(kubectl -n stackrox get ds/collector -o=jsonpath='{$.spec.template.spec.containers[*].name}')" == *"node-inventory"* ]]; then
         echo "Upgrading node-inventory container"
         kubectl -n stackrox set image ds/collector "node-inventory=$REGISTRY/scanner-slim:$(make scanner-tag)"
     else

--- a/tests/upgrade/run.sh
+++ b/tests/upgrade/run.sh
@@ -208,8 +208,7 @@ test_upgrade_paths() {
     kubectl -n stackrox set image deploy/admission-control "*=$REGISTRY/main:$(make --quiet tag)"
     kubectl -n stackrox set image ds/collector "collector=$REGISTRY/collector:$(cat COLLECTOR_VERSION)" \
         "compliance=$REGISTRY/main:$(make --quiet tag)"
-    # Check if collector has 2 or 3 containers - we expect to see 3 only on Openshift 4
-    if kubectl -n stackrox get ds/collector -o=jsonpath='{$.spec.template.spec.containers[2].image}'; then
+    if [[ "$(kubectl -n stackrox get ds/collector -o=jsonpath='{$.spec.template.spec.containers[*].name}')" == *"node-inventory"* ]]; then
         echo "Upgrading node-inventory container"
         kubectl -n stackrox set image ds/collector "node-inventory=$REGISTRY/scanner-slim:$(cat SCANNER_VERSION)"
     else


### PR DESCRIPTION
## Description

The node-inventory container within the collector pod shall be created only on Openshift clusters in version 4. RHCOS node scanning feature is only supported on such clusters, so it does not make sense to create it on all other types of clusters. This exclusion allows us to save resources.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added

### N/A

- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

- [x] Running `roxctl helm output secured-cluster-services` followed by `helm template ... --set env.openshift=4` and analyzing the `collector.yaml` manifest manually - expecting to see the node-inventory container
- [x] Running `roxctl helm output secured-cluster-services` followed by `helm template` (without `--set env.openshift=4`) and analyzing the `collector.yaml` manifest manually - expecting not to see the node-inventory container
- [x] Running `roxctl sensor generate openshift --insecure-skip-tls-verify --name cluster2 --openshift-version 4` and analyzing the `collector.yaml` manifest manually
- [x] Running `roxctl sensor generate openshift --insecure-skip-tls-verify --name cluster3 --openshift-version 3` and analyzing the `collector.yaml` manifest manually
- [x] CI

