### PR TITLE
ROX-16233: Read environment variables for the telemetry configuration

### DIFF
--- a/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml
+++ b/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml
@@ -105,10 +105,14 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         {{- if ._rox.central.telemetry.enabled }}
+        {{- if ._rox.central.telemetry.storage.endpoint }}
         - name: ROX_TELEMETRY_ENDPOINT
           value: {{ ._rox.central.telemetry.storage.endpoint | quote }}
+        {{- end }}
+        {{- if ._rox.central.telemetry.storage.key }}
         - name: ROX_TELEMETRY_STORAGE_KEY_V1
           value: {{ ._rox.central.telemetry.storage.key | quote }}
+        {{- end }}
         {{- end }}
         - name: ROX_OFFLINE_MODE
           value: {{ ._rox.env.offlineMode | quote }}

--- a/pkg/renderer/helm_values.go
+++ b/pkg/renderer/helm_values.go
@@ -197,6 +197,8 @@ scanner:
 
 {{- $envVars := deepCopy .EnvironmentMap -}}
 {{- $_ := unset $envVars "ROX_OFFLINE_MODE" -}}
+{{- $_ := unset $envVars "ROX_TELEMETRY_ENDPOINT" -}}
+{{- $_ := unset $envVars "ROX_TELEMETRY_STORAGE_KEY_V1" -}}
 {{- if $envVars }}
 
 customize:

--- a/roxctl/central/generate/generate.go
+++ b/roxctl/central/generate/generate.go
@@ -202,13 +202,12 @@ func updateConfig(config *renderer.Config) error {
 		config.Environment[env.OfflineModeEnv.EnvVar()] = strconv.FormatBool(config.K8sConfig.OfflineMode)
 
 		if config.K8sConfig.Telemetry.Enabled {
-			if env.TelemetryStorageKey.Setting() == "" {
-				// TODO(ROX-13889): (when enabled for on-prem)
-				// return errox.InvalidArgs.Newf("telemetry storage key is not set")
-			} else {
-				config.K8sConfig.Telemetry.StorageKey = env.TelemetryStorageKey.Setting()
-				config.K8sConfig.Telemetry.StorageEndpoint = env.TelemetryEndpoint.Setting()
-			}
+			// TODO(ROX-13889): (when enabled for on-prem)
+			// if env.TelemetryStorageKey.Setting() == "" {
+			//   return errox.InvalidArgs.Newf("telemetry storage key is not set")
+			// }
+			config.K8sConfig.Telemetry.StorageKey = env.TelemetryStorageKey.Setting()
+			config.K8sConfig.Telemetry.StorageEndpoint = env.TelemetryEndpoint.Setting()
 		}
 	}
 

--- a/roxctl/central/generate/generate.go
+++ b/roxctl/central/generate/generate.go
@@ -203,9 +203,12 @@ func createBundle(logger logger.Logger, config renderer.Config) (*zip.Wrapper, e
 		config.Environment[env.OfflineModeEnv.EnvVar()] = strconv.FormatBool(config.K8sConfig.OfflineMode)
 
 		if config.K8sConfig.Telemetry.Enabled {
-			logger.InfofLn(`Unless run in offline mode,
- StackRox Kubernetes Security Platform collects and transmits aggregated usage and system health information.
-  If you want to OPT OUT from this, re-generate the deployment bundle with the '--enable-telemetry=false' flag`)
+			logger.InfofLn("StackRox Kubernetes Security Platform collects and" +
+				" transmits anonymous usage and system configuration information. If you want to" +
+				" OPT OUT from this, re-generate the deployment bundle with the" +
+				" '--enable-telemetry=false' flag.")
+			config.K8sConfig.Telemetry.StorageKey = env.TelemetryStorageKey.Setting()
+			config.K8sConfig.Telemetry.StorageEndpoint = env.TelemetryEndpoint.Setting()
 		}
 	}
 
@@ -263,7 +266,7 @@ func OutputZip(logger logger.Logger, io io2.IO, config renderer.Config) error {
 	logger.InfofLn("Done!")
 
 	if outputPath != "" {
-		logger.InfofLn("Wrote central bundle to %q", outputPath)
+		logger.InfofLn("Wrote central bundle to %q.", outputPath)
 	}
 
 	if err := config.WriteInstructions(io.ErrOut()); err != nil {

--- a/roxctl/central/generate/generate_test.go
+++ b/roxctl/central/generate/generate_test.go
@@ -87,7 +87,7 @@ func TestRestoreKeysAndCerts(t *testing.T) {
 			// Note: This test is not for parallel run.
 			config.OutputDir = filepath.Join(tmpDir, testCase.testDir)
 			config.BackupBundle = testCase.backupBundle
-			require.NoError(t, OutputZip(logger, io, config))
+			require.NoError(t, OutputZip(logger, io, &config))
 
 			// Load values-private.yaml file
 			values, err := chartutil.ReadValuesFile(filepath.Join(config.OutputDir, "values-private.yaml"))

--- a/roxctl/central/generate/volumes.go
+++ b/roxctl/central/generate/volumes.go
@@ -35,7 +35,7 @@ func externalVolume(cliEnvironment environment.Environment) *cobra.Command {
 		if err := validateConfig(&cfg); err != nil {
 			return err
 		}
-		return OutputZip(cliEnvironment.Logger(), cliEnvironment.InputOutput(), &cfg)
+		return OutputZip(cliEnvironment.Logger(), cliEnvironment.InputOutput(), cfg)
 	}
 	flagWrap := &flagsWrapper{FlagSet: c.Flags()}
 	flagWrap.StringVarP(&external.Central.Name, "name", "", "stackrox-db", "external volume name for Central", "central")
@@ -55,7 +55,7 @@ func noVolume(cliEnvironment environment.Environment) *cobra.Command {
 		if err := validateConfig(&cfg); err != nil {
 			return err
 		}
-		return OutputZip(cliEnvironment.Logger(), cliEnvironment.InputOutput(), &cfg)
+		return OutputZip(cliEnvironment.Logger(), cliEnvironment.InputOutput(), cfg)
 	}
 	c.Hidden = true
 	return c
@@ -74,7 +74,7 @@ func hostPathVolume(cliEnvironment environment.Environment) *cobra.Command {
 		if err := validateConfig(&cfg); err != nil {
 			return err
 		}
-		return OutputZip(cliEnvironment.Logger(), cliEnvironment.InputOutput(), &cfg)
+		return OutputZip(cliEnvironment.Logger(), cliEnvironment.InputOutput(), cfg)
 	}
 	c.Flags().StringVarP(&hostpath.Central.HostPath, "hostpath", "", "/var/lib/stackrox", "path on the host")
 	c.Flags().StringVarP(&hostpath.Central.NodeSelectorKey, "node-selector-key", "", "", "node selector key (e.g. kubernetes.io/hostname)")

--- a/roxctl/central/generate/volumes.go
+++ b/roxctl/central/generate/volumes.go
@@ -35,7 +35,7 @@ func externalVolume(cliEnvironment environment.Environment) *cobra.Command {
 		if err := validateConfig(&cfg); err != nil {
 			return err
 		}
-		return OutputZip(cliEnvironment.Logger(), cliEnvironment.InputOutput(), cfg)
+		return OutputZip(cliEnvironment.Logger(), cliEnvironment.InputOutput(), &cfg)
 	}
 	flagWrap := &flagsWrapper{FlagSet: c.Flags()}
 	flagWrap.StringVarP(&external.Central.Name, "name", "", "stackrox-db", "external volume name for Central", "central")
@@ -55,7 +55,7 @@ func noVolume(cliEnvironment environment.Environment) *cobra.Command {
 		if err := validateConfig(&cfg); err != nil {
 			return err
 		}
-		return OutputZip(cliEnvironment.Logger(), cliEnvironment.InputOutput(), cfg)
+		return OutputZip(cliEnvironment.Logger(), cliEnvironment.InputOutput(), &cfg)
 	}
 	c.Hidden = true
 	return c
@@ -74,7 +74,7 @@ func hostPathVolume(cliEnvironment environment.Environment) *cobra.Command {
 		if err := validateConfig(&cfg); err != nil {
 			return err
 		}
-		return OutputZip(cliEnvironment.Logger(), cliEnvironment.InputOutput(), cfg)
+		return OutputZip(cliEnvironment.Logger(), cliEnvironment.InputOutput(), &cfg)
 	}
 	c.Flags().StringVarP(&hostpath.Central.HostPath, "hostpath", "", "/var/lib/stackrox", "path on the host")
 	c.Flags().StringVarP(&hostpath.Central.NodeSelectorKey, "node-selector-key", "", "", "node selector key (e.g. kubernetes.io/hostname)")

--- a/roxctl/helm/derivelocalvalues/derivelocalvalues.go
+++ b/roxctl/helm/derivelocalvalues/derivelocalvalues.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/maputil"
 	"github.com/stackrox/rox/pkg/set"
@@ -393,7 +394,7 @@ func retrieveCustomLabels(labels map[string]interface{}) map[string]interface{} 
 }
 
 func retrieveCustomEnvVars(envVars map[string]interface{}) map[string]interface{} {
-	return filterMap(envVars, []string{"ROX_OFFLINE_MODE"})
+	return filterMap(envVars, []string{env.OfflineModeEnv.EnvVar()})
 }
 
 func printWarnings(logger logger.Logger, warnings []string) {


### PR DESCRIPTION
## Description

* Make the `--enable-telemetry` option of the `roxctl central generate` command to update the helm values with the data taken from the respective environment variables.
* A few minor improvements in the code around.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

Tested with local `roxctl`:
```sh
$ export ROX_TELEMETRY_STORAGE_KEY_V1=abc
$ ./bin/linux_amd64/roxctl central generate k8s pvc --enable-telemetry=true
...
INFO:	StackRox Kubernetes Security Platform collects and transmits anonymous usage and system configuration information. If you want to OPT OUT from this, re-generate the deployment bundle with the '--enable-telemetry=false' flag.
...
$ rg -B4 abc central-bundle
central-bundle/helm/values-public.yaml
18-  telemetry:
19-    enabled: true
20-    storage:
21-      endpoint: 
22:      key: abc

central-bundle/central/01-central-13-deployment.yaml
118-          valueFrom:
119-            fieldRef:
120-              fieldPath: metadata.namespace
121-        - name: ROX_TELEMETRY_STORAGE_KEY_V1
122:          value: "abc"

$ rm -rf central-bundle
$ ./bin/linux_amd64/roxctl central generate k8s pvc --enable-telemetry=false
...
$ rg -A4 tele central-bundle
central-bundle/helm/values-public.yaml
18:  telemetry:
19-    enabled: false
20-    storage:
21-      endpoint: 
22-      key: 
...
```