### PR TITLE
ROX-15402: Change to a sticky search bar in the breadcrumb

### DIFF
--- a/ui/apps/platform/cypress/helpers/networkGraphPF.js
+++ b/ui/apps/platform/cypress/helpers/networkGraphPF.js
@@ -47,12 +47,10 @@ export function selectNamespace(namespace) {
         cy.get(networkGraphSelectors.selector.namespaceSelect).click();
         // Exact match to distinguish stackrox from stackrox-operator namespaces.
         cy.get(
-            `${
-                selectSelectors.patternFlySelect.openMenu
-            } .pf-c-menu__list-item [data-testid="namespace-name"]:contains(${new RegExp(
-                `^${namespace}$`
-            )})`
-        ).click();
+            `${selectSelectors.patternFlySelect.openMenu} .pf-c-menu__list-item [data-testid="namespace-name"]`
+        )
+            .contains(new RegExp(`^${namespace}$`))
+            .click();
         cy.get(networkGraphSelectors.selector.namespaceSelect).click();
     }, routeMatcherMapForClusterInNetworkGraph);
 }
@@ -61,12 +59,10 @@ export function selectDeployment(deployment) {
     interactAndWaitForResponses(() => {
         cy.get(networkGraphSelectors.selector.deploymentSelect).click();
         cy.get(
-            `${
-                selectSelectors.patternFlySelect.openMenu
-            } .pf-c-menu__list-item [data-testid="deployment-name"]:contains(${new RegExp(
-                `^${deployment}$`
-            )})`
-        ).click();
+            `${selectSelectors.patternFlySelect.openMenu} .pf-c-menu__list-item [data-testid="deployment-name"]`
+        )
+            .contains(new RegExp(`^${deployment}$`))
+            .click();
         cy.get(networkGraphSelectors.selector.deploymentSelect).click();
     }, routeMatcherMapForClusterInNetworkGraph);
 }

--- a/ui/apps/platform/cypress/helpers/networkGraphPF.js
+++ b/ui/apps/platform/cypress/helpers/networkGraphPF.js
@@ -47,10 +47,12 @@ export function selectNamespace(namespace) {
         cy.get(networkGraphSelectors.selector.namespaceSelect).click();
         // Exact match to distinguish stackrox from stackrox-operator namespaces.
         cy.get(
-            `${selectSelectors.patternFlySelect.openMenu} .pf-c-select__menu-item [data-testid="namespace-name"]`
-        )
-            .contains(new RegExp(`^${namespace}$`))
-            .click();
+            `${
+                selectSelectors.patternFlySelect.openMenu
+            } .pf-c-menu__list-item [data-testid="namespace-name"]:contains(${new RegExp(
+                `^${namespace}$`
+            )})`
+        ).click();
         cy.get(networkGraphSelectors.selector.namespaceSelect).click();
     }, routeMatcherMapForClusterInNetworkGraph);
 }
@@ -59,10 +61,12 @@ export function selectDeployment(deployment) {
     interactAndWaitForResponses(() => {
         cy.get(networkGraphSelectors.selector.deploymentSelect).click();
         cy.get(
-            `${selectSelectors.patternFlySelect.openMenu} .pf-c-select__menu-item [data-testid="deployment-name"]`
-        )
-            .contains(new RegExp(`^${deployment}$`))
-            .click();
+            `${
+                selectSelectors.patternFlySelect.openMenu
+            } .pf-c-menu__list-item [data-testid="deployment-name"]:contains(${new RegExp(
+                `^${deployment}$`
+            )})`
+        ).click();
         cy.get(networkGraphSelectors.selector.deploymentSelect).click();
     }, routeMatcherMapForClusterInNetworkGraph);
 }

--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.css
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.css
@@ -73,3 +73,15 @@ div#topology-resize-panel table td {
 .derived-namespace path.pf-topology__group__background {
     stroke-dasharray: 5;
 }
+
+.pf-c-check__input {
+    height: 16px;
+    width: 16px;
+}
+
+.namespace-select .pf-c-select__menu,
+.deployment-select .pf-c-select__menu {
+    padding-top: 0;
+    padding-bottom: 0;
+    min-width: 220px;
+}

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/DeploymentSelector.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/DeploymentSelector.tsx
@@ -1,8 +1,24 @@
-import React, { useCallback } from 'react';
-import { Button, Select, SelectGroup, SelectOption, SelectVariant } from '@patternfly/react-core';
+import React, { useMemo } from 'react';
+import {
+    Badge,
+    Button,
+    Divider,
+    Flex,
+    FlexItem,
+    Menu,
+    MenuContent,
+    MenuFooter,
+    MenuGroup,
+    MenuInput,
+    MenuItem,
+    MenuList,
+    SearchInput,
+    Select,
+} from '@patternfly/react-core';
 
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
 import { NamespaceWithDeployments } from 'hooks/useFetchNamespaceDeployments';
+import { removeNullValues } from 'utils/removeNullValues';
 import { DeploymentIcon } from '../common/NetworkGraphIcons';
 
 type DeploymentSelectorProps = {
@@ -23,32 +39,49 @@ function DeploymentSelector({
         toggleSelect: toggleIsDeploymentOpen,
         closeSelect,
     } = useSelectToggle();
+    const [input, setInput] = React.useState('');
 
-    const onFilterDeployments = useCallback(
-        (_, filterValue: string) => {
-            const filteredNamespaceDeployments = deploymentsByNamespace.map((namespace) => (
-                <SelectGroup label={namespace.metadata.name} key={namespace.metadata.id}>
-                    {namespace.deployments
-                        .filter((deployment) =>
-                            deployment.name.toLowerCase().includes(filterValue.toLowerCase())
-                        )
-                        .map((deployment) => (
-                            <SelectOption key={deployment.id} value={deployment.name}>
-                                <span>
-                                    <DeploymentIcon />
-                                    <span className="pf-u-mx-xs" data-testid="deployment-name">
-                                        {deployment.name}
-                                    </span>
-                                </span>
-                            </SelectOption>
-                        ))}
-                </SelectGroup>
-            ));
+    const handleTextInputChange = (value: string) => {
+        setInput(value);
+    };
 
-            return filteredNamespaceDeployments;
-        },
-        [deploymentsByNamespace]
-    );
+    const filteredDeploymentSelectMenuItems = useMemo(() => {
+        let deploymentSelectMenuItems = deploymentsByNamespace.map((namespace) => {
+            let menuItems = namespace.deployments
+                .filter((deployment) =>
+                    deployment.name.toLowerCase().includes(input.toString().toLowerCase())
+                )
+                .map((deployment) => (
+                    <MenuItem
+                        key={deployment.id}
+                        hasCheck
+                        itemId={deployment.name}
+                        isSelected={selectedDeployments.includes(deployment.name)}
+                    >
+                        <span>
+                            <DeploymentIcon />
+                            <span className="pf-u-mx-xs" data-testid="deployment-name">
+                                {deployment.name}
+                            </span>
+                        </span>
+                    </MenuItem>
+                ));
+            if (menuItems.length === 0) {
+                menuItems = [<MenuItem isDisabled>-</MenuItem>];
+            }
+            return (
+                <MenuGroup
+                    key={namespace.metadata.id}
+                    label={namespace.metadata.name}
+                    labelHeadingLevel="h3"
+                >
+                    <MenuList>{menuItems}</MenuList>
+                </MenuGroup>
+            );
+        });
+        deploymentSelectMenuItems = removeNullValues(deploymentSelectMenuItems);
+        return deploymentSelectMenuItems;
+    }, [deploymentsByNamespace, input, selectedDeployments]);
 
     const onDeploymentSelect = (_, selected) => {
         const newSelection = selectedDeployments.find((nsFilter) => nsFilter === selected)
@@ -67,47 +100,64 @@ function DeploymentSelector({
         setSearchFilter(modifiedSearchObject);
     };
 
-    const deploymentSelectOptions: JSX.Element[] = deploymentsByNamespace.map((namespace) => (
-        <SelectGroup label={namespace.metadata.name} key={namespace.metadata.id}>
-            {namespace.deployments.map((deployment) => (
-                <SelectOption key={deployment.id} value={deployment.name}>
-                    <span>
-                        <DeploymentIcon /> {deployment.name}
-                    </span>
-                </SelectOption>
-            ))}
-        </SelectGroup>
-    ));
+    const deploymentSelectMenu = (
+        <Menu onSelect={onDeploymentSelect} selected={selectedDeployments} isScrollable>
+            <MenuInput className="pf-u-p-md">
+                <SearchInput
+                    value={input}
+                    aria-label="Filter deployments"
+                    type="search"
+                    placeholder="Filter deployments..."
+                    onChange={(_event, value) => handleTextInputChange(value)}
+                />
+            </MenuInput>
+            <Divider className="pf-u-m-0" />
+            <MenuContent>
+                <MenuList>
+                    {filteredDeploymentSelectMenuItems.length === 0 && (
+                        <MenuItem isDisabled key="no result">
+                            No deployments found
+                        </MenuItem>
+                    )}
+                    {filteredDeploymentSelectMenuItems}
+                </MenuList>
+            </MenuContent>
+            <MenuFooter>
+                <Button variant="link" isInline onClick={onClearSelections}>
+                    Clear selections
+                </Button>
+            </MenuFooter>
+        </Menu>
+    );
 
     return (
         <Select
             isOpen={isDeploymentOpen}
             onToggle={toggleIsDeploymentOpen}
-            onSelect={onDeploymentSelect}
-            onFilter={onFilterDeployments}
             className="deployment-select"
             placeholderText={
-                <span>
-                    <DeploymentIcon className="pf-u-mr-xs" />{' '}
-                    <span style={{ position: 'relative', top: '1px' }}>Deployments</span>
-                </span>
+                <Flex alignSelf={{ default: 'alignSelfCenter' }}>
+                    <FlexItem
+                        spacer={{ default: 'spacerSm' }}
+                        alignSelf={{ default: 'alignSelfCenter' }}
+                    >
+                        <DeploymentIcon />
+                    </FlexItem>
+                    <FlexItem spacer={{ default: 'spacerSm' }}>
+                        <span style={{ position: 'relative', top: '1px' }}>Deployments</span>
+                    </FlexItem>
+                    {selectedDeployments.length !== 0 && (
+                        <FlexItem spacer={{ default: 'spacerSm' }}>
+                            <Badge isRead>{selectedDeployments.length}</Badge>
+                        </FlexItem>
+                    )}
+                </Flex>
             }
             toggleAriaLabel="Select deployments"
             isDisabled={deploymentsByNamespace.length === 0}
-            selections={selectedDeployments}
-            variant={SelectVariant.checkbox}
-            maxHeight="275px"
-            hasInlineFilter
-            isGrouped
             isPlain
-            footer={
-                <Button variant="link" isInline onClick={onClearSelections}>
-                    Clear selections
-                </Button>
-            }
-        >
-            {deploymentSelectOptions}
-        </Select>
+            customContent={deploymentSelectMenu}
+        />
     );
 }
 

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/NamespaceSelector.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/NamespaceSelector.tsx
@@ -1,24 +1,25 @@
-import React, { useCallback, ChangeEvent } from 'react';
-import { Button, Select, SelectOption, SelectVariant } from '@patternfly/react-core';
+import React, { useMemo } from 'react';
+import {
+    Badge,
+    Button,
+    Divider,
+    Flex,
+    FlexItem,
+    Menu,
+    MenuContent,
+    MenuFooter,
+    MenuInput,
+    MenuItem,
+    MenuList,
+    SearchInput,
+    Select,
+} from '@patternfly/react-core';
 
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
 import { Namespace } from 'hooks/useFetchClusterNamespacesForPermissions';
 import { NamespaceWithDeployments } from 'hooks/useFetchNamespaceDeployments';
 import { NamespaceIcon } from '../common/NetworkGraphIcons';
 import { getDeploymentLookupMap, getDeploymentsAllowedByNamespaces } from '../utils/hierarchyUtils';
-
-function filterElementsWithValueProp(
-    filterValue: string,
-    elements: React.ReactElement[] | undefined
-): React.ReactElement[] | undefined {
-    if (filterValue === '' || elements === undefined) {
-        return elements;
-    }
-
-    return elements.filter((reactElement) =>
-        reactElement.props.value?.toLowerCase().includes(filterValue.toLowerCase())
-    );
-}
 
 type NamespaceSelectorProps = {
     namespaces?: Namespace[];
@@ -42,29 +43,42 @@ function NamespaceSelector({
         toggleSelect: toggleIsNamespaceOpen,
         closeSelect,
     } = useSelectToggle();
+    const [input, setInput] = React.useState('');
 
-    const onFilterNamespaces = useCallback(
-        (e: ChangeEvent<HTMLInputElement> | null, filterValue: string) =>
-            filterElementsWithValueProp(
-                filterValue,
-                namespaces.map((namespace) => (
-                    <SelectOption key={namespace.id} value={namespace.name}>
+    const handleTextInputChange = (value: string) => {
+        setInput(value);
+    };
+
+    const clusterSelected = Boolean(searchFilter?.Cluster);
+    const isEmptyCluster = clusterSelected && namespaces.length === 0;
+
+    const deploymentLookupMap = getDeploymentLookupMap(deploymentsByNamespace);
+
+    const filteredDeploymentSelectMenuItems = useMemo(() => {
+        const namespaceSelectMenuItems = namespaces
+            .filter((namespace) =>
+                namespace.name.toLowerCase().includes(input.toString().toLowerCase())
+            )
+            .map((namespace) => {
+                return (
+                    <MenuItem
+                        key={namespace.id}
+                        hasCheck
+                        itemId={namespace.name}
+                        isSelected={selectedNamespaces.includes(namespace.name)}
+                    >
                         <span>
                             <NamespaceIcon />
                             <span className="pf-u-mx-xs" data-testid="namespace-name">
                                 {namespace.name}
                             </span>
                         </span>
-                    </SelectOption>
-                ))
-            ),
-        [namespaces]
-    );
+                    </MenuItem>
+                );
+            });
 
-    const clusterSelected = Boolean(searchFilter?.Cluster);
-    const isEmptyCluster = clusterSelected && namespaces.length === 0;
-
-    const deploymentLookupMap = getDeploymentLookupMap(deploymentsByNamespace);
+        return namespaceSelectMenuItems;
+    }, [namespaces, input, selectedNamespaces]);
 
     const onNamespaceSelect = (_, selected) => {
         const newSelection = selectedNamespaces.find((nsFilter) => nsFilter === selected)
@@ -94,49 +108,66 @@ function NamespaceSelector({
         setSearchFilter(modifiedSearchObject);
     };
 
-    const namespaceSelectOptions: JSX.Element[] = namespaces.map((namespace) => {
-        return (
-            <SelectOption key={namespace.id} value={namespace.name}>
-                <span>
-                    <NamespaceIcon />
-                    <span className="pf-u-mx-xs" data-testid="namespace-name">
-                        {namespace.name}
-                    </span>
-                </span>
-            </SelectOption>
-        );
-    });
+    const namespaceSelectMenu = (
+        <Menu onSelect={onNamespaceSelect} selected={selectedNamespaces} isScrollable>
+            <MenuInput className="pf-u-p-md">
+                <SearchInput
+                    value={input}
+                    aria-label="Filter namespaces"
+                    type="search"
+                    placeholder="Filter namespaces..."
+                    onChange={(_event, value) => handleTextInputChange(value)}
+                />
+            </MenuInput>
+            <Divider className="pf-u-m-0" />
+            <MenuContent>
+                <MenuList>
+                    {filteredDeploymentSelectMenuItems.length === 0 && (
+                        <MenuItem isDisabled key="no result">
+                            No namespaces found
+                        </MenuItem>
+                    )}
+                    {filteredDeploymentSelectMenuItems}
+                </MenuList>
+            </MenuContent>
+            <MenuFooter>
+                <Button variant="link" isInline onClick={onClearSelections}>
+                    Clear selections
+                </Button>
+            </MenuFooter>
+        </Menu>
+    );
 
     return (
         <Select
             isOpen={isNamespaceOpen}
             onToggle={toggleIsNamespaceOpen}
-            onSelect={onNamespaceSelect}
-            onFilter={onFilterNamespaces}
             className="namespace-select"
             placeholderText={
-                <span>
-                    <NamespaceIcon className="pf-u-mr-xs" />{' '}
-                    <span style={{ position: 'relative', top: '1px' }}>
-                        {isEmptyCluster ? 'No namespaces' : 'Namespaces'}
-                    </span>
-                </span>
+                <Flex alignSelf={{ default: 'alignSelfCenter' }}>
+                    <FlexItem
+                        spacer={{ default: 'spacerSm' }}
+                        alignSelf={{ default: 'alignSelfCenter' }}
+                    >
+                        <NamespaceIcon />
+                    </FlexItem>
+                    <FlexItem spacer={{ default: 'spacerSm' }}>
+                        <span style={{ position: 'relative', top: '1px' }}>
+                            {isEmptyCluster ? 'No namespaces' : 'Namespaces'}
+                        </span>
+                    </FlexItem>
+                    {selectedNamespaces.length !== 0 && (
+                        <FlexItem spacer={{ default: 'spacerSm' }}>
+                            <Badge isRead>{selectedNamespaces.length}</Badge>
+                        </FlexItem>
+                    )}
+                </Flex>
             }
             toggleAriaLabel="Select namespaces"
-            isDisabled={namespaceSelectOptions.length === 0}
-            selections={selectedNamespaces}
-            variant={SelectVariant.checkbox}
-            maxHeight="275px"
-            hasInlineFilter
+            isDisabled={namespaces.length === 0}
             isPlain
-            footer={
-                <Button variant="link" isInline onClick={onClearSelections}>
-                    Clear selections
-                </Button>
-            }
-        >
-            {namespaceSelectOptions}
-        </Select>
+            customContent={namespaceSelectMenu}
+        />
     );
 }
 

--- a/ui/apps/platform/src/utils/removeNullValues.ts
+++ b/ui/apps/platform/src/utils/removeNullValues.ts
@@ -1,0 +1,5 @@
+/* eslint-disable @typescript-eslint/no-unsafe-return */
+// The type doesn't matter here. We want to remove null values
+export function removeNullValues(arr) {
+    return arr.filter((item) => item !== null);
+}


### PR DESCRIPTION
## Description

This PR makes the search bar sticky in the namespace/deployment selectors. Because this is not naturally possible to do with the `Select` component, we had to make use of the `customContent` prop to display a `Menu` the same way it functions as it does today

Note: We can refactor the selectors to be more reusable (possibly making an `EntitySelector` component), but in order to keep the PR light, and considering future edge cases, we won't do that right now


https://user-images.githubusercontent.com/4805485/228352245-b2c08378-3b35-4a4e-84a2-2c2274412fc6.mov

