### PR TITLE
ROX-16235: Add deprecation notice for Network Graph 1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 - The `--offline-mode` flag for the `roxctl scanner generate` command is deprecated, as Scanner's default behavior is
   to fetch vulnerability updates from Central. The flag will be removed as part of the 4.2.0 release.
 - ROX-15925: The KernelModule collection method is deprecated in favor of EBPF. This method will be removed in the 4.1 release.
+- Deprecated v1.0 of Network Graph. Please switch to the new 2.0 version for improved functionality and a better user experience.
 
 ### Required Actions
 - The `Analyst` permission set will change behaviour: instead of allowing read to all resources except `DebugLogs`, it will

--- a/ui/apps/platform/src/Containers/Network/Page.js
+++ b/ui/apps/platform/src/Containers/Network/Page.js
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { connect, useDispatch, useSelector } from 'react-redux';
 import { useRouteMatch } from 'react-router-dom';
 import { createStructuredSelector } from 'reselect';
+import { Alert } from '@patternfly/react-core';
 
 import { selectors } from 'reducers';
 import useLocalStorage from 'hooks/useLocalStorage';
@@ -143,6 +144,17 @@ function NetworkPage({
 
     return (
         <>
+            <Alert
+                isInline
+                variant="warning"
+                title={
+                    <p>
+                        Version 1.0 of Network Graph is being deprecated soon. Please switch to the
+                        new 2.0 version for improved functionality and a better user experience.
+                        Contant our support team for assistance
+                    </p>
+                }
+            />
             <Header
                 isGraphDisabled={hasNoSelectedNamespace || hasGraphLoadError}
                 isSimulationOn={isSimulationOn}


### PR DESCRIPTION
## Description

This PR adds a deprecation notice to v1.0 of Network Graph and adds a line item to the CHANGELOG

<img width="1440" alt="Screenshot 2023-03-28 at 3 33 48 PM" src="https://user-images.githubusercontent.com/4805485/228381850-c8530c96-9f43-46d7-9391-c8d2526e2a67.png">
