### PR TITLE
ROX-16169: Compliance shall be calling node inventory only on Openshift 4

### DIFF
--- a/central/clusters/zip/render_test.go
+++ b/central/clusters/zip/render_test.go
@@ -98,6 +98,10 @@ func doTestRenderOpenshif(t *testing.T, clusterType storage.ClusterType) {
 		} else {
 			_, foundNInv := findContainer(ds.Spec.Template.Spec.Containers, "node-inventory")
 			assert.False(t, foundNInv, "node-inventory container must not exist under collector DS")
+
+			value, exists := getEnvVarValue(ds.Spec.Template.Spec.Containers[1].Env, env.NodeInventoryContainerEnabled.EnvVar())
+			assert.True(t, exists)
+			assert.Equalf(t, "false", value, "compliance should have %s=false", env.NodeInventoryContainerEnabled.EnvVar())
 		}
 	}
 

--- a/compliance/collection/main.go
+++ b/compliance/collection/main.go
@@ -260,8 +260,9 @@ func main() {
 	rand.Seed(time.Now().UnixNano())
 
 	var nodeInventoryClient scannerV1.NodeInventoryServiceClient
-
-	if features.RHCOSNodeScanning.Enabled() {
+	if !env.NodeInventoryContainerEnabled.BooleanSetting() {
+		log.Infof("Compliance will not call the node-inventory container, because this is not Openshift 4 cluster")
+	} else if features.RHCOSNodeScanning.Enabled() {
 		// Start the prometheus metrics server
 		metrics.NewDefaultHTTPServer(metrics.ComplianceSubsystem).RunForever()
 		metrics.GatherThrottleMetricsForever(metrics.ComplianceSubsystem.String())

--- a/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml
@@ -99,6 +99,12 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.cpu
+        - name: ROX_CALL_NODE_INVENTORY_ENABLED
+        {{- if eq ._rox.env.openshift 4 }}
+          value: true
+        {{- else}}
+          value: false
+        {{- end }}
         - name: ROX_METRICS_PORT
         {{- if ._rox.collector.exposeMonitoring }}
           value: ":9091"

--- a/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml
@@ -100,11 +100,7 @@ spec:
             resourceFieldRef:
               resource: limits.cpu
         - name: ROX_CALL_NODE_INVENTORY_ENABLED
-        {{- if eq ._rox.env.openshift 4 }}
-          value: true
-        {{- else}}
-          value: false
-        {{- end }}
+          value: {{ if eq ._rox.env.openshift 4 }}"true"{{ else }}"false"{{ end }}
         - name: ROX_METRICS_PORT
         {{- if ._rox.collector.exposeMonitoring }}
           value: ":9091"

--- a/pkg/env/node_scan.go
+++ b/pkg/env/node_scan.go
@@ -26,4 +26,7 @@ var (
 
 	// NodeScanningMaxBackoff is the upper boundary of backoff. Defaults to 5m in seconds, being 50% of Kubernetes restart policy stability timer.
 	NodeScanningMaxBackoff = registerDurationSetting("ROX_NODE_SCANNING_MAX_BACKOFF", 300*time.Second)
+
+	// NodeInventoryContainerEnabled is used to tell compliance whether a connection to the node-inventory container should be attempted
+	NodeInventoryContainerEnabled = RegisterBooleanSetting("ROX_CALL_NODE_INVENTORY_ENABLED", true)
 )


### PR DESCRIPTION
## Description

As per https://github.com/stackrox/stackrox/pull/5422, we are not creating the node-inventory container on clusters that are not Openshift 4. Compliance is able to handle the unavailability of this container, but it will result in errors in the logs. In order to avoid polluting the logs, we can instruct compliance to not attempt to call the node-inventory when we know that it is not there.

The approach from this PR is to keep the `nodeInventoryClient` uninitialized on clusters other that Openshift 4. This results in skipping the `manageNodeScanLoop` that would normally do the call to node-inventory.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added

### N/A
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

- [x] CI
- [x] Running `roxctl helm output secured-cluster-services` followed by `helm template ... --set env.openshift=4` and analyzing the `collector.yaml` manifest manually - expecting to see env variable `ROX_CALL_NODE_INVENTORY_ENABLED=true`
- [x] Running `roxctl helm output secured-cluster-services` followed by `helm template` (without `--set env.openshift=4`) and analyzing the `collector.yaml` manifest manually - expecting to see env variable `ROX_CALL_NODE_INVENTORY_ENABLED=false`
- [x] Running `roxctl sensor generate openshift` and analyzing the `collector.yaml` manifest manually (for openshift 3 and 4)
- [x] Deploying locally on colima (not openshift 4) and checking the logs for any connection attempts
```
main: 2023/03/30 14:35:35.223335 main.go:264: Info: Compliance will not call the node-inventory container, because this is not Openshift 4 cluster
```
