### PR TITLE
fix: gh repo sync during start of new release

### DIFF
--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -188,7 +188,7 @@ jobs:
         env:
           GH_TOKEN: "${{ secrets.ROBOT_ROX_GITHUB_TOKEN }}"
         run: |
-          gh repo sync stackrox/openshift-release --source stackrox/openshift-release
+          gh repo sync stackrox/openshift-release --source openshift/release
       - name: Make configuration
         if: steps.check-existing.outputs.branch-exists == 'false'
         env:


### PR DESCRIPTION
## Description

Automation to start release 4.0 created:  https://github.com/openshift/release/commit/964ca77047f88c302c2eb65194dfc09e6171f6fe

Looking at the diff, it is apparent that the stackrox/openshift-release fork was not synced correctly by the automation.
For example, there is an unexpected discrepancy in the build root:

* openshift/release: https://github.com/openshift/release/blob/master/ci-operator/config/stackrox/stackrox/stackrox-stackrox-master.yaml#L30 -> 0.3.57
* stackrox/openshift-release based change: https://github.com/openshift/release/commit/964ca77047f88c302c2eb65194dfc09e6171f6fe#diff-9549a14a21da4e92e71a9c4063dd390e19953b01b5600f3fec71bf4e34570fe3R26 -> 0.3.56.

There are other examples in the job names.

The syntax used in the automation is:

```bash
$ gh repo sync -h
...
  # Sync remote repository from another remote repository
  $ gh repo sync owner/repo --source owner2/repo2
```

Source `owner2/repo2` should be the parent of the fork. 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
