### PR TITLE
Skip slack notification related tests on P/Z

### DIFF
--- a/qa-tests-backend/src/test/groovy/IntegrationsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/IntegrationsTest.groovy
@@ -248,6 +248,8 @@ class IntegrationsTest extends BaseSpecification {
     @Unroll
     @Tag("BAT")
     @Tag("Notifiers")
+    // slack notifications are not supported on P/Z
+    @IgnoreIf({ Env.REMOTE_CLUSTER_ARCH == "ppc64le" || Env.REMOTE_CLUSTER_ARCH == "s390x" })
     def "Verify Network Simulator Notifications: #type"() {
         when:
         "create notifier"
@@ -533,6 +535,8 @@ class IntegrationsTest extends BaseSpecification {
     @Unroll
     @Tag("BAT")
     @Tag("Notifiers")
+    // slack notifications are not supported on P/Z
+    @IgnoreIf({ Env.REMOTE_CLUSTER_ARCH == "ppc64le" || Env.REMOTE_CLUSTER_ARCH == "s390x" })
     def "Verify Policy Violation Notifications Destination Overrides: #type"() {
         when:
         "Create notifier"

--- a/qa-tests-backend/src/test/groovy/VulnReportingTest.groovy
+++ b/qa-tests-backend/src/test/groovy/VulnReportingTest.groovy
@@ -12,7 +12,11 @@ import util.MailServer
 import org.junit.Assume
 import spock.lang.Shared
 import spock.lang.Tag
+import spock.lang.IgnoreIf
+import util.Env
 
+// slack notifications are not supported on P/Z
+@IgnoreIf({ Env.REMOTE_CLUSTER_ARCH == "ppc64le" || Env.REMOTE_CLUSTER_ARCH == "s390x" })
 class VulnReportingTest extends BaseSpecification {
 
     static final private String SECONDARY_NAMESPACE = "vulnreport-2nd-namespace"


### PR DESCRIPTION
This PR intends to skip few of the groovy tests related to slack notifications on P/Z.
Changes are verified manually using `./gradlew test --tests=TestName`
