### PR TITLE
ROX-14479 Adding validation logic for the central.spec.tls.additionalCAs

### DIFF
--- a/operator/apis/platform/v1alpha1/validation/central.go
+++ b/operator/apis/platform/v1alpha1/validation/central.go
@@ -1,0 +1,166 @@
+package validation
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+
+	"github.com/stackrox/rox/operator/apis/platform/v1alpha1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+const (
+	errAdditionalCANameRequired         = "must specify a name for the additional CA"
+	errAdditionalCAContentRequired      = "must specify a certificate for the additional CA"
+	errAdditionalCAContentNoCertFound   = "no certificates found in the provided CA cert content"
+	errAdditionalCAContentParsingFailed = "failed to parse the provided CA cert content"
+	errFailedToVerifyCertificateChain   = "failed to verify the certificate chain"
+)
+
+// ValidateCentral validates the Central CR.
+//
+// This method will return a useful/meaningful error message for
+// each field that does not pass validation, as well as the field path, so the user can easily
+// identify the source of the error.
+//
+// Currently this only validates the TLS.additionalCAs field, but is intended to be
+// expanded to validate the entire CR.
+//
+// See: TODO(ROX-7683)
+func ValidateCentral(central *v1alpha1.Central) field.ErrorList {
+	var errs field.ErrorList
+	errs = append(errs, validateCentralSpec(field.NewPath("spec"), central.Spec)...)
+	return errs
+}
+
+func validateCentralSpec(path *field.Path, spec v1alpha1.CentralSpec) field.ErrorList {
+	var errs field.ErrorList
+	errs = append(errs, validateCentralTLSConfig(path.Child("tls"), spec.TLS)...)
+	return errs
+}
+
+func validateCentralTLSConfig(path *field.Path, tlsConfig *v1alpha1.TLSConfig) field.ErrorList {
+	var errs field.ErrorList
+	if tlsConfig == nil {
+		return nil
+	}
+	errs = append(errs, validateCentralTLSConfigAdditionalCAs(path.Child("additionalCAs"), tlsConfig.AdditionalCAs)...)
+	return errs
+}
+
+func validateCentralTLSConfigAdditionalCAs(path *field.Path, additionalCAs []v1alpha1.AdditionalCA) field.ErrorList {
+	var errs field.ErrorList
+	for i, additionalCA := range additionalCAs {
+		errs = append(errs, validateCentralTLSConfigAdditionalCA(path.Index(i), additionalCA)...)
+	}
+	return errs
+}
+
+func validateCentralTLSConfigAdditionalCA(path *field.Path, additionalCA v1alpha1.AdditionalCA) field.ErrorList {
+	var errs field.ErrorList
+	if additionalCA.Name == "" {
+		errs = append(errs, field.Required(path.Child("name"), errAdditionalCANameRequired))
+	}
+	errs = append(errs, validateCentralTLSConfigAdditionalCACertificate(path.Child("content"), additionalCA.Content)...)
+	return errs
+}
+
+func validateCentralTLSConfigAdditionalCACertificate(path *field.Path, content string) field.ErrorList {
+	var errs field.ErrorList
+	if len(content) == 0 {
+		errs = append(errs, field.Required(path, errAdditionalCAContentRequired))
+		return errs
+	}
+	certificates, err := parseCertificateChainFromPEM([]byte(content))
+	if err != nil {
+		errs = append(errs, field.Invalid(path, content, fmt.Sprintf("%s: %s", errAdditionalCAContentParsingFailed, err.Error())))
+		return errs
+	}
+	if len(certificates) == 0 {
+		errs = append(errs, field.Invalid(path, content, errAdditionalCAContentNoCertFound))
+		return errs
+	}
+
+	if err := validateCertificateChain(certificates); err != nil {
+		errs = append(errs, field.Invalid(path, content, err.Error()))
+		return errs
+	}
+
+	return errs
+}
+
+func validateCertificateChain(certificates []*x509.Certificate) error {
+	if len(certificates) == 1 {
+		// No need to validate the certificate chain when there is only one certificate
+		return nil
+	}
+	rootCertificate := certificates[len(certificates)-1]
+	certPool := x509.NewCertPool()
+	certPool.AddCert(rootCertificate)
+
+	var intermediates = x509.NewCertPool()
+	for i := len(certificates) - 1; i >= 0; i-- {
+		position := prettyPosition(i + 1)
+		intermediateCertificate := certificates[i]
+		opts := x509.VerifyOptions{
+			Roots:         certPool,
+			Intermediates: intermediates,
+		}
+		if _, err := intermediateCertificate.Verify(opts); err != nil {
+			return fmt.Errorf("%s: %s: %s",
+				errFailedToVerifyCertificateChain,
+				"could not verify the "+position+" certificate in the chain",
+				err.Error(),
+			)
+		}
+		intermediates.AddCert(certificates[i])
+	}
+
+	return nil
+}
+
+func parseCertificateChainFromPEM(data []byte) ([]*x509.Certificate, error) {
+	var certs []*x509.Certificate
+	var i = 0
+	for {
+
+		if len(data) == 0 {
+			break
+		}
+
+		position := prettyPosition(i)
+
+		var block *pem.Block
+		block, data = pem.Decode(data)
+		if block == nil {
+			return nil, fmt.Errorf(fmt.Sprintf("failed to parse %s certificate in chain: no PEM data found", position))
+		}
+		if block.Type != "CERTIFICATE" {
+			return nil, fmt.Errorf("failed to parse %s certificate in chain: unexpected PEM type '%s'", position, block.Type)
+		}
+		if len(block.Headers) != 0 {
+			return nil, fmt.Errorf("failed to parse %s certificate in chain: unexpected PEM optional headers", position)
+		}
+		cert, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse %s certificate in chain: %s", position, err.Error())
+		}
+		certs = append(certs, cert)
+		i++
+	}
+	return certs, nil
+}
+
+func prettyPosition(i int) string {
+	var position string
+	if i == 0 {
+		position = "1st"
+	} else if i == 1 {
+		position = "2nd"
+	} else if i == 2 {
+		position = "3rd"
+	} else {
+		position = fmt.Sprintf("%dth", i+1)
+	}
+	return position
+}

--- a/operator/apis/platform/v1alpha1/validation/central_test.go
+++ b/operator/apis/platform/v1alpha1/validation/central_test.go
@@ -44,7 +44,17 @@ func TestValidateCentral(t *testing.T) {
 
 	testCases := []testCase{
 		{
-			name: "additionalCAs: name must be provided",
+			name: "spec.tls: should not panic if tls is nil",
+			central: v1alpha1.Central{
+				Spec: v1alpha1.CentralSpec{
+					TLS: nil,
+				},
+			},
+			assert: func(t *testing.T, errorList field.ErrorList) {
+				assert.Empty(t, errorList)
+			},
+		}, {
+			name: "spec.tls.additionalCAs: name must be provided",
 			central: v1alpha1.Central{
 				Spec: v1alpha1.CentralSpec{
 					TLS: &v1alpha1.TLSConfig{
@@ -63,7 +73,7 @@ func TestValidateCentral(t *testing.T) {
 				),
 			}),
 		}, {
-			name: "additionalCAs: names must be unique",
+			name: "spec.tls.additionalCAs: names must be unique",
 			central: v1alpha1.Central{
 				Spec: v1alpha1.CentralSpec{
 					TLS: &v1alpha1.TLSConfig{
@@ -86,7 +96,7 @@ func TestValidateCentral(t *testing.T) {
 				),
 			}),
 		}, {
-			name: "additionalCAs: content must be provided",
+			name: "spec.tls.additionalCAs: content must be provided",
 			central: v1alpha1.Central{
 				Spec: v1alpha1.CentralSpec{
 					TLS: &v1alpha1.TLSConfig{
@@ -105,7 +115,7 @@ func TestValidateCentral(t *testing.T) {
 				),
 			}),
 		}, {
-			name: "additionalCAs: content must be valid PEM",
+			name: "spec.tls.additionalCAs: content must be valid PEM",
 			central: v1alpha1.Central{
 				Spec: v1alpha1.CentralSpec{
 					TLS: &v1alpha1.TLSConfig{
@@ -126,7 +136,7 @@ func TestValidateCentral(t *testing.T) {
 				),
 			}),
 		}, {
-			name: "additionalCAs: PEM headers must be of type CERTIFICATE",
+			name: "spec.tls.additionalCAs: PEM headers must be of type CERTIFICATE",
 			central: v1alpha1.Central{
 				Spec: v1alpha1.CentralSpec{
 					TLS: &v1alpha1.TLSConfig{
@@ -153,7 +163,7 @@ func TestValidateCentral(t *testing.T) {
 				),
 			}),
 		}, {
-			name: "additionalCAs: PEM content must be a valid certificate",
+			name: "spec.tls.additionalCAs: PEM content must be a valid certificate",
 			central: v1alpha1.Central{
 				Spec: v1alpha1.CentralSpec{
 					TLS: &v1alpha1.TLSConfig{
@@ -180,7 +190,7 @@ func TestValidateCentral(t *testing.T) {
 				),
 			}),
 		}, {
-			name: "additionalCAs: PEM content must be base64-encoded",
+			name: "spec.tls.additionalCAs: PEM content must be base64-encoded",
 			central: v1alpha1.Central{
 				Spec: v1alpha1.CentralSpec{
 					TLS: &v1alpha1.TLSConfig{
@@ -207,7 +217,7 @@ func TestValidateCentral(t *testing.T) {
 				),
 			}),
 		}, {
-			name: "additionalCAs: the certificate chain must be valid",
+			name: "spec.tls.additionalCAs: the certificate chain must be valid",
 			central: v1alpha1.Central{
 				Spec: v1alpha1.CentralSpec{
 					TLS: &v1alpha1.TLSConfig{
@@ -235,7 +245,7 @@ func TestValidateCentral(t *testing.T) {
 				),
 			}),
 		}, {
-			name: "additionalCAs: the certificate chain must be in order",
+			name: "spec.tls.additionalCAs: the certificate chain must be in order",
 			central: v1alpha1.Central{
 				Spec: v1alpha1.CentralSpec{
 					TLS: &v1alpha1.TLSConfig{
@@ -265,7 +275,7 @@ func TestValidateCentral(t *testing.T) {
 				),
 			}),
 		}, {
-			name: "additionalCAs: using a single certificate is allowed",
+			name: "spec.tls.additionalCAs: using a single certificate is allowed",
 			central: v1alpha1.Central{
 				Spec: v1alpha1.CentralSpec{
 					TLS: &v1alpha1.TLSConfig{
@@ -302,7 +312,7 @@ func TestValidateCentral(t *testing.T) {
 				assert.Empty(t, errorList)
 			},
 		}, {
-			name: "additionalCAs: using multiple certificates is allowed",
+			name: "spec.tls.additionalCAs: using multiple certificates is allowed",
 			central: v1alpha1.Central{
 				Spec: v1alpha1.CentralSpec{
 					TLS: &v1alpha1.TLSConfig{

--- a/operator/apis/platform/v1alpha1/validation/central_test.go
+++ b/operator/apis/platform/v1alpha1/validation/central_test.go
@@ -1,0 +1,431 @@
+package validation
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stackrox/rox/operator/apis/platform/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+func TestValidateCentral(t *testing.T) {
+
+	type testCase struct {
+		name    string
+		central v1alpha1.Central
+		assert  func(t *testing.T, errorList field.ErrorList)
+	}
+	certChain1With1Cert, err := createCertificateChain(1)
+	require.NoError(t, err)
+
+	chain1RootCA := string(certChain1With1Cert[0])
+
+	certChain2With2Certs, err := createCertificateChain(2)
+	require.NoError(t, err)
+
+	chain2RootCA := string(certChain2With2Certs[1])
+	chain2IntermediateCA := string(certChain2With2Certs[0])
+
+	certChainWith3Certs, err := createCertificateChain(3)
+	require.NoError(t, err)
+
+	chain3RootCA := string(certChainWith3Certs[2])
+	chain3IntermediateCA := string(certChainWith3Certs[1])
+	chain3LeafCA := string(certChainWith3Certs[0])
+
+	testCases := []testCase{
+		{
+			name: "additionalCAs: name must be provided",
+			central: v1alpha1.Central{
+				Spec: v1alpha1.CentralSpec{
+					TLS: &v1alpha1.TLSConfig{
+						AdditionalCAs: []v1alpha1.AdditionalCA{
+							{
+								Content: chain1RootCA,
+							},
+						},
+					},
+				},
+			},
+			assert: errorsEqual(field.ErrorList{
+				field.Required(
+					field.NewPath("spec.tls.additionalCAs[0].name"),
+					errAdditionalCANameRequired,
+				),
+			}),
+		}, {
+			name: "additionalCAs: content must be provided",
+			central: v1alpha1.Central{
+				Spec: v1alpha1.CentralSpec{
+					TLS: &v1alpha1.TLSConfig{
+						AdditionalCAs: []v1alpha1.AdditionalCA{
+							{
+								Name: "name",
+							},
+						},
+					},
+				},
+			},
+			assert: errorsEqual(field.ErrorList{
+				field.Required(
+					field.NewPath("spec.tls.additionalCAs[0].content"),
+					errAdditionalCAContentRequired,
+				),
+			}),
+		}, {
+			name: "additionalCAs: content must be valid PEM",
+			central: v1alpha1.Central{
+				Spec: v1alpha1.CentralSpec{
+					TLS: &v1alpha1.TLSConfig{
+						AdditionalCAs: []v1alpha1.AdditionalCA{
+							{
+								Name:    "name",
+								Content: "invalid",
+							},
+						},
+					},
+				},
+			},
+			assert: errorsEqual(field.ErrorList{
+				field.Invalid(
+					field.NewPath("spec.tls.additionalCAs[0].content"),
+					"invalid",
+					"failed to parse the provided CA cert content: failed to parse 1st certificate in chain: no PEM data found",
+				),
+			}),
+		}, {
+			name: "additionalCAs: PEM headers must be of type CERTIFICATE",
+			central: v1alpha1.Central{
+				Spec: v1alpha1.CentralSpec{
+					TLS: &v1alpha1.TLSConfig{
+						AdditionalCAs: []v1alpha1.AdditionalCA{
+							{
+								Name: "name",
+								Content: strings.Join([]string{
+									chain1RootCA,
+									"-----BEGIN SNOOPY-----\n-----END SNOOPY-----",
+								}, "\n"),
+							},
+						},
+					},
+				},
+			},
+			assert: errorsEqual(field.ErrorList{
+				field.Invalid(
+					field.NewPath("spec.tls.additionalCAs[0].content"),
+					strings.Join([]string{
+						chain1RootCA,
+						"-----BEGIN SNOOPY-----\n-----END SNOOPY-----",
+					}, "\n"),
+					"failed to parse the provided CA cert content: failed to parse 2nd certificate in chain: unexpected PEM type 'SNOOPY'",
+				),
+			}),
+		}, {
+			name: "additionalCAs: PEM content must be a valid certificate",
+			central: v1alpha1.Central{
+				Spec: v1alpha1.CentralSpec{
+					TLS: &v1alpha1.TLSConfig{
+						AdditionalCAs: []v1alpha1.AdditionalCA{
+							{
+								Name: "name",
+								Content: strings.Join([]string{
+									chain1RootCA,
+									"-----BEGIN CERTIFICATE-----\naW52YWxpZAo=\n-----END CERTIFICATE-----",
+								}, "\n"),
+							},
+						},
+					},
+				},
+			},
+			assert: errorsEqual(field.ErrorList{
+				field.Invalid(
+					field.NewPath("spec.tls.additionalCAs[0].content"),
+					strings.Join([]string{
+						chain1RootCA,
+						"-----BEGIN CERTIFICATE-----\naW52YWxpZAo=\n-----END CERTIFICATE-----",
+					}, "\n"),
+					"failed to parse the provided CA cert content: failed to parse 2nd certificate in chain: x509: malformed certificate",
+				),
+			}),
+		}, {
+			name: "additionalCAs: PEM content must be base64-encoded",
+			central: v1alpha1.Central{
+				Spec: v1alpha1.CentralSpec{
+					TLS: &v1alpha1.TLSConfig{
+						AdditionalCAs: []v1alpha1.AdditionalCA{
+							{
+								Name: "name",
+								Content: strings.Join([]string{
+									chain1RootCA,
+									"-----BEGIN CERTIFICATE-----\ninvalid!\n-----END CERTIFICATE-----",
+								}, "\n"),
+							},
+						},
+					},
+				},
+			},
+			assert: errorsEqual(field.ErrorList{
+				field.Invalid(
+					field.NewPath("spec.tls.additionalCAs[0].content"),
+					strings.Join([]string{
+						chain1RootCA,
+						"-----BEGIN CERTIFICATE-----\ninvalid!\n-----END CERTIFICATE-----",
+					}, "\n"),
+					"failed to parse the provided CA cert content: failed to parse 2nd certificate in chain: no PEM data found",
+				),
+			}),
+		}, {
+			name: "additionalCAs: the certificate chain must be valid",
+			central: v1alpha1.Central{
+				Spec: v1alpha1.CentralSpec{
+					TLS: &v1alpha1.TLSConfig{
+						AdditionalCAs: []v1alpha1.AdditionalCA{
+							{
+								Name: "name",
+								// Concatenating two unrelated certificate chains
+								Content: strings.Join([]string{
+									chain1RootCA,
+									chain2IntermediateCA,
+								}, "\n"),
+							},
+						},
+					},
+				},
+			},
+			assert: errorsEqual(field.ErrorList{
+				field.Invalid(
+					field.NewPath("spec.tls.additionalCAs[0].content"),
+					strings.Join([]string{
+						chain1RootCA,
+						chain2IntermediateCA,
+					}, "\n"),
+					`failed to verify the certificate chain: could not verify the 2nd certificate in the chain: x509: certificate signed by unknown authority (possibly because of "crypto/rsa: verification error" while trying to verify candidate authority certificate "RHACS")`,
+				),
+			}),
+		}, {
+			name: "additionalCAs: the certificate chain must be in order",
+			central: v1alpha1.Central{
+				Spec: v1alpha1.CentralSpec{
+					TLS: &v1alpha1.TLSConfig{
+						AdditionalCAs: []v1alpha1.AdditionalCA{
+							{
+								Name: "name",
+								// Reversing the order of the certificate chain
+								Content: strings.Join([]string{
+									chain3LeafCA,
+									chain3RootCA,
+									chain3IntermediateCA,
+								}, "\n"),
+							},
+						},
+					},
+				},
+			},
+			assert: errorsEqual(field.ErrorList{
+				field.Invalid(
+					field.NewPath("spec.tls.additionalCAs[0].content"),
+					strings.Join([]string{
+						chain3LeafCA,
+						chain3RootCA,
+						chain3IntermediateCA,
+					}, "\n"),
+					`failed to verify the certificate chain: could not verify the 3rd certificate in the chain: x509: certificate signed by unknown authority (possibly because of "crypto/rsa: verification error" while trying to verify candidate authority certificate "RHACS")`,
+				),
+			}),
+		}, {
+			name: "additionalCAs: using a single certificate is allowed",
+			central: v1alpha1.Central{
+				Spec: v1alpha1.CentralSpec{
+					TLS: &v1alpha1.TLSConfig{
+						AdditionalCAs: []v1alpha1.AdditionalCA{
+							{
+								Name:    "name",
+								Content: chain1RootCA,
+							},
+						},
+					},
+				},
+			},
+			assert: func(t *testing.T, errorList field.ErrorList) {
+				assert.Empty(t, errorList)
+			},
+		}, {
+			name: "additionalCAs: using two certificates is allowed",
+			central: v1alpha1.Central{
+				Spec: v1alpha1.CentralSpec{
+					TLS: &v1alpha1.TLSConfig{
+						AdditionalCAs: []v1alpha1.AdditionalCA{
+							{
+								Name: "name",
+								Content: strings.Join([]string{
+									chain2IntermediateCA,
+									chain2RootCA,
+								}, "\n"),
+							},
+						},
+					},
+				},
+			},
+			assert: func(t *testing.T, errorList field.ErrorList) {
+				assert.Empty(t, errorList)
+			},
+		}, {
+			name: "additionalCAs: using multiple certificates is allowed",
+			central: v1alpha1.Central{
+				Spec: v1alpha1.CentralSpec{
+					TLS: &v1alpha1.TLSConfig{
+						AdditionalCAs: []v1alpha1.AdditionalCA{
+							{
+								Name: "name",
+								Content: strings.Join([]string{
+									chain3LeafCA,
+									chain3IntermediateCA,
+									chain3RootCA,
+								}, "\n"),
+							},
+						},
+					},
+				},
+			},
+			assert: func(t *testing.T, errorList field.ErrorList) {
+				assert.Empty(t, errorList)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.assert(t, ValidateCentral(&tc.central))
+		})
+	}
+}
+
+func errorsEqual(errors field.ErrorList) func(t *testing.T, errorList field.ErrorList) {
+	return func(t *testing.T, errorList field.ErrorList) {
+		assert.Equalf(t, errors, errorList, "expected %v but got %v", errors, errorList)
+	}
+}
+
+func createCertificateChain(length int) ([][]byte, error) {
+
+	if length < 1 {
+		return [][]byte{}, nil
+	}
+
+	subject := pkix.Name{
+		Organization:  []string{"RHACS"},
+		Country:       []string{"US"},
+		Locality:      []string{"San Francisco"},
+		StreetAddress: []string{"Golden Gate Bridge"},
+		PostalCode:    []string{"94016"},
+	}
+
+	caSerialNumber, err := generateSerialNumber()
+	if err != nil {
+		return nil, err
+	}
+
+	ca := &x509.Certificate{
+		SerialNumber:          caSerialNumber,
+		Subject:               subject,
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().AddDate(10, 0, 0),
+		IsCA:                  true,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+
+	// create our private and public key
+	caPrivKey, err := rsa.GenerateKey(rand.Reader, 4096)
+	if err != nil {
+		return nil, err
+	}
+
+	// create the CA
+	caBytes, err := x509.CreateCertificate(rand.Reader, ca, ca, &caPrivKey.PublicKey, caPrivKey)
+	if err != nil {
+		return nil, err
+	}
+
+	caCert, err := x509.ParseCertificate(caBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	caPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: caBytes,
+	})
+
+	result := [][]byte{caPEM}
+
+	var currentParent = caCert
+	var currentParentPrivKey = caPrivKey
+
+	for i := 1; i < length; i++ {
+
+		childSerialNumber, err := generateSerialNumber()
+		if err != nil {
+			return nil, err
+		}
+
+		childCertificateTemplate := &x509.Certificate{
+			SerialNumber:          childSerialNumber,
+			Subject:               subject,
+			NotBefore:             time.Now(),
+			NotAfter:              time.Now().AddDate(10, 0, 0),
+			IsCA:                  true,
+			KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+			BasicConstraintsValid: true,
+		}
+
+		// create our private and public key
+		childPrivateKey, err := rsa.GenerateKey(rand.Reader, 4096)
+		if err != nil {
+			return nil, err
+		}
+
+		// create the intermediate CA
+		childCertificateBytes, err := x509.CreateCertificate(rand.Reader, childCertificateTemplate, currentParent, &childPrivateKey.PublicKey, currentParentPrivKey)
+		if err != nil {
+			return nil, err
+		}
+
+		childCertificate, err := x509.ParseCertificate(childCertificateBytes)
+		if err != nil {
+			return nil, err
+		}
+
+		childCertificatePem := pem.EncodeToMemory(&pem.Block{
+			Type:  "CERTIFICATE",
+			Bytes: childCertificateBytes,
+		})
+
+		result = append(result, childCertificatePem)
+		currentParent = childCertificate
+		currentParentPrivKey = childPrivateKey
+
+	}
+
+	// reverse the order of the certificates
+	for i, j := 0, len(result)-1; i < j; i, j = i+1, j-1 {
+		result[i], result[j] = result[j], result[i]
+	}
+
+	return result, nil
+}
+
+func generateSerialNumber() (*big.Int, error) {
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	return rand.Int(rand.Reader, serialNumberLimit)
+}

--- a/operator/apis/platform/v1alpha1/validation/central_test.go
+++ b/operator/apis/platform/v1alpha1/validation/central_test.go
@@ -63,6 +63,29 @@ func TestValidateCentral(t *testing.T) {
 				),
 			}),
 		}, {
+			name: "additionalCAs: names must be unique",
+			central: v1alpha1.Central{
+				Spec: v1alpha1.CentralSpec{
+					TLS: &v1alpha1.TLSConfig{
+						AdditionalCAs: []v1alpha1.AdditionalCA{
+							{
+								Name:    "name",
+								Content: chain1RootCA,
+							}, {
+								Name:    "name",
+								Content: chain2RootCA,
+							},
+						},
+					},
+				},
+			},
+			assert: errorsEqual(field.ErrorList{
+				field.Duplicate(
+					field.NewPath("spec.tls.additionalCAs[1].name"),
+					"name",
+				),
+			}),
+		}, {
 			name: "additionalCAs: content must be provided",
 			central: v1alpha1.Central{
 				Spec: v1alpha1.CentralSpec{


### PR DESCRIPTION
## Description

This PR **simply adds the validation logic without hooking it into the operator**. I want to validate with the reviewers if this approach is OK, then go about plugging this logic into the operator in another PR. 

A detailed explanation of the changes in your PR.

This adds a kubernetes-style validation method for statically validating the `Central` spec. Currently, this only validates the `spec.tls.additionalCAs` field, but it is intended to be used for validating the entire CR. This would be useful when implementing the validation in the admission webhook (ROX-7683). 