### PR TITLE
Integrate ImageCVE page with EntityTypeToggleGroup

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/CveStatusTabNavigation.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/CveStatusTabNavigation.tsx
@@ -44,7 +44,7 @@ function CveStatusTabNavigation({ defaultFilters }: CveStatusTabNavigationProps)
                         <CardBody>
                             <WorkloadTableToolbar defaultFilters={defaultFilters} />
                             <Divider component="div" />
-                            <EntityTypeToggleGroup />
+                            <EntityTypeToggleGroup className="pf-u-pl-md pf-u-pt-md" />
                             cve overview table here
                         </CardBody>
                     </Card>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/EntityTypeToggleGroup.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/EntityTypeToggleGroup.tsx
@@ -2,51 +2,57 @@ import React from 'react';
 import { ToggleGroup, ToggleGroupItem } from '@patternfly/react-core';
 
 import useURLStringUnion from 'hooks/useURLStringUnion';
+import { NonEmptyArray } from 'utils/type.utils';
 import { entityTabValues, EntityTab } from './types';
 
 type EntityTabToggleGroupProps = {
-    entityContext?: EntityTab;
+    className?: string;
+    entityTabs?: Readonly<NonEmptyArray<EntityTab>>;
     cveCount?: number;
     imageCount?: number;
     deploymentCount?: number;
 };
 
 function EntityTabToggleGroup({
-    entityContext,
+    className = '',
+    entityTabs = entityTabValues,
     cveCount = 0,
     imageCount = 0,
     deploymentCount = 0,
 }: EntityTabToggleGroupProps) {
-    const [activeEntityTabKey, setActiveEntityTabKey] = useURLStringUnion(
-        'entityTab',
-        entityTabValues
-    );
+    const [activeEntityTabKey, setActiveEntityTabKey] = useURLStringUnion('entityTab', entityTabs);
 
     return (
-        <ToggleGroup className="pf-u-pl-md pf-u-pt-md">
-            {entityContext !== 'CVE' && (
+        <ToggleGroup className={className}>
+            {entityTabs.includes('CVE') ? (
                 <ToggleGroupItem
                     text={`${cveCount} CVEs`}
                     buttonId="cves"
                     isSelected={activeEntityTabKey === 'CVE'}
                     onChange={() => setActiveEntityTabKey('CVE')}
                 />
+            ) : (
+                <></>
             )}
-            {entityContext !== 'Image' && (
+            {entityTabs.includes('Image') ? (
                 <ToggleGroupItem
                     text={`${imageCount} Images`}
                     buttonId="images"
                     isSelected={activeEntityTabKey === 'Image'}
                     onChange={() => setActiveEntityTabKey('Image')}
                 />
+            ) : (
+                <></>
             )}
-            {entityContext !== 'Deployment' && (
+            {entityTabs.includes('Deployment') ? (
                 <ToggleGroupItem
                     text={`${deploymentCount} Deployments`}
                     buttonId="deployments"
                     isSelected={activeEntityTabKey === 'Deployment'}
                     onChange={() => setActiveEntityTabKey('Deployment')}
                 />
+            ) : (
+                <></>
             )}
         </ToggleGroup>
     );

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCvePage.tsx
@@ -89,6 +89,7 @@ export const imageCveAffectedImagesQuery = gql`
 `;
 
 const defaultSortFields = ['Image', 'Severity', 'Fixable', 'Operating System'];
+const imageCveEntities = ['Image', 'Deployment'] as const;
 
 function ImageCvePage() {
     const { cveId } = useParams();
@@ -104,8 +105,7 @@ function ImageCvePage() {
         onSort: () => setPage(1),
     });
 
-    // TODO This will need to be updated once https://github.com/stackrox/stackrox/pull/5392 is merged
-    const [entityTab] = useURLStringUnion('entityTab', ['Image', 'Deployment'] as const);
+    const [entityTab] = useURLStringUnion('entityTab', imageCveEntities);
 
     const metadataRequest = useQuery<{ imageCVE: ImageCveMetadata }, { cve: string }>(
         imageCveMetadataQuery,
@@ -236,6 +236,32 @@ function ImageCvePage() {
                 </div>
                 <Divider />
                 <div className="pf-u-background-color-100 pf-u-flex-grow-1">
+                    <Split className="pf-u-px-lg pf-u-py-md pf-u-align-items-baseline">
+                        <SplitItem isFilled>
+                            <Flex alignItems={{ default: 'alignItemsCenter' }}>
+                                <EntityTypeToggleGroup
+                                    imageCount={imageData?.imageCount ?? 0}
+                                    entityTabs={imageCveEntities}
+                                />
+                                {isFiltered && <DynamicTableLabel />}
+                            </Flex>
+                        </SplitItem>
+                        <SplitItem>
+                            <Pagination
+                                isCompact
+                                itemCount={tableRowCount}
+                                page={page}
+                                perPage={perPage}
+                                onSetPage={(_, newPage) => setPage(newPage)}
+                                onPerPageSelect={(_, newPerPage) => {
+                                    if (tableRowCount < (page - 1) * newPerPage) {
+                                        setPage(1);
+                                    }
+                                    setPerPage(newPerPage);
+                                }}
+                            />
+                        </SplitItem>
+                    </Split>
                     {tableError ? (
                         <Bullseye>
                             <EmptyStateTemplate
@@ -256,29 +282,6 @@ function ImageCvePage() {
                             )}
                             {tableDataAvailable && (
                                 <>
-                                    <Split className="pf-u-px-lg pf-u-py-sm pf-u-align-items-baseline">
-                                        <SplitItem isFilled>
-                                            <Flex alignItems={{ default: 'alignItemsCenter' }}>
-                                                <EntityTypeToggleGroup />
-                                                {isFiltered && <DynamicTableLabel />}
-                                            </Flex>
-                                        </SplitItem>
-                                        <SplitItem>
-                                            <Pagination
-                                                isCompact
-                                                itemCount={tableRowCount}
-                                                page={page}
-                                                perPage={perPage}
-                                                onSetPage={(_, newPage) => setPage(newPage)}
-                                                onPerPageSelect={(_, newPerPage) => {
-                                                    if (tableRowCount < (page - 1) * newPerPage) {
-                                                        setPage(1);
-                                                    }
-                                                    setPerPage(newPerPage);
-                                                }}
-                                            />
-                                        </SplitItem>
-                                    </Split>
                                     <Divider />
                                     <div className="pf-u-px-lg">
                                         {entityTab === 'Image' && (


### PR DESCRIPTION
## Description

Integrates the EntityTypeToggleGroup component.

I did find an issue unrelated to this change that needs to be fixed as a [follow up](https://github.com/stackrox/stackrox/pull/5458):

The image and deployment queries are only run when their tab is active, by design, to avoid the unnecessary overhead of loading data for both tabs. However, this means that the image/deployment counts are not updated when their tab is not active i.e. when filters change. I'll likely need to restructure these queries a bit.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Load the ImageCVE page, and see that the default URL parameter is "Image", and the "Image" tab is selected. The "CVE" tab should not render and the total image count should be visible.

![image](https://user-images.githubusercontent.com/1292638/228580337-7778462e-ccf3-4d0e-96b3-ad6335cb02d4.png)

Clicking the Deployments tab hides the images tab and correctly highlights the deployments toggle button and updates the URL parameter.
![image](https://user-images.githubusercontent.com/1292638/228582626-15d486cb-14af-40a6-83cd-590b1471c29b.png)

Applying a filter correctly updates the text in the toggle button.
![image](https://user-images.githubusercontent.com/1292638/228582944-cea598db-66e8-4cae-9381-945f4a3a0c57.png)


In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
