### PR TITLE
Make Central-DB a StatefulSet

### DIFF
--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -335,10 +335,12 @@ function launch_central {
       if [[ "${is_local_dev}" == "true" ]]; then
           kubectl -n stackrox patch deploy/central --patch '{"spec":{"template":{"spec":{"containers":[{"name":"central","resources":{"limits":{"cpu":"1","memory":"4Gi"},"requests":{"cpu":"1","memory":"1Gi"}}}]}}}}'
           if [[ "${ROX_POSTGRES_DATASTORE}" == "true" ]]; then
-            kubectl -n stackrox patch deploy/central-db --patch '{"spec":{"template":{"spec":{"initContainers":[{"name":"init-db","resources":{"limits":{"cpu":"1","memory":"4Gi"},"requests":{"cpu":1,"memory":"1Gi"}}}],"containers":[{"name":"central-db","resources":{"limits":{"cpu":"1","memory":"4Gi"},"requests":{"cpu":"1","memory":"1Gi"}}}]}}}}'
+            kubectl -n stackrox patch statefulset/central-db --patch '{"spec":{"template":{"spec":{"initContainers":[{"name":"init-db","resources":{"limits":{"cpu":"1","memory":"4Gi"},"requests":{"cpu":1,"memory":"1Gi"}}}],"containers":[{"name":"central-db","resources":{"limits":{"cpu":"1","memory":"4Gi"},"requests":{"cpu":"1","memory":"1Gi"}}}]}}}}'
+            kubectl  -n stackrox rollout restart statefulset/central-db
           fi
       elif [[ "${ROX_POSTGRES_DATASTORE}" == "true" ]]; then
-          ${ORCH_CMD} -n stackrox patch deploy/central-db --patch "$(cat "${common_dir}/central-db-patch.yaml")"
+          ${ORCH_CMD} -n stackrox patch statefulset/central-db --patch "$(cat "${common_dir}/central-db-patch.yaml")"
+          kubectl  -n stackrox rollout restart statefulset/central-db
       fi
       if [[ "${CGO_CHECKS}" == "true" ]]; then
         echo "CGO_CHECKS set to true. Setting GODEBUG=cgocheck=2 and MUTEX_WATCHDOG_TIMEOUT_SECS=15"

--- a/image/templates/helm/stackrox-central/templates/01-central-12-central-db.yaml
+++ b/image/templates/helm/stackrox-central/templates/01-central-12-central-db.yaml
@@ -15,6 +15,8 @@ spec:
   serviceName: central-db
   replicas: 1
   minReadySeconds: 15
+  updateStrategy:
+    type: RollingUpdate
   selector:
     matchLabels:
       app: central-db

--- a/image/templates/helm/stackrox-central/templates/01-central-12-central-db.yaml
+++ b/image/templates/helm/stackrox-central/templates/01-central-12-central-db.yaml
@@ -2,7 +2,7 @@
 
 {{ if not ._rox.central.db.external -}}
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: central-db
   namespace: {{ .Release.Namespace }}
@@ -12,13 +12,12 @@ metadata:
   annotations:
     {{- include "srox.annotations" (list . "deployment" "central-db") | nindent 4 }}
 spec:
+  serviceName: central-db
   replicas: 1
   minReadySeconds: 15
   selector:
     matchLabels:
       app: central-db
-  strategy:
-    type: Recreate
   template:
     metadata:
       namespace: {{ .Release.Namespace }}

--- a/scale/dev/launch_central.sh
+++ b/scale/dev/launch_central.sh
@@ -20,7 +20,7 @@ fi
 
 kubectl -n stackrox patch deploy/central -p '{"spec":{"template":{"spec":{"containers":[{"name":"central","resources":{"requests":{"memory":"16Gi","cpu":"8"},"limits":{"memory":"16Gi","cpu":"8"}}}]}}}}'
 if [[ "$ROX_POSTGRES_DATASTORE" == "true" ]]; then
-  kubectl -n stackrox patch deploy/central-db -p '{"spec":{"template":{"spec":{"containers":[{"name":"central-db","resources":{"requests":{"memory":"32Gi","cpu":"16"},"limits":{"memory":"32Gi","cpu":"16"}}}]}}}}'
+  kubectl -n stackrox patch sts/central-db -p '{"spec":{"template":{"spec":{"containers":[{"name":"central-db","resources":{"requests":{"memory":"32Gi","cpu":"16"},"limits":{"memory":"32Gi","cpu":"16"}}}]}}}}'
 fi
 
 $DIR/port-forward.sh 8000

--- a/scale/launch_workload.sh
+++ b/scale/launch_workload.sh
@@ -44,12 +44,12 @@ if [[ -n "$CI" ]]; then
   kubectl -n stackrox patch deploy/sensor -p '{"spec":{"template":{"spec":{"containers":[{"name":"sensor","resources":{"requests":{"memory":"8Gi","cpu":"5"},"limits":{"memory":"16Gi","cpu":"8"}}}]}}}}'
   kubectl -n stackrox patch deploy/central -p '{"spec":{"template":{"spec":{"containers":[{"name":"central","resources":{"requests":{"memory":"8Gi","cpu":"5"},"limits":{"memory":"16Gi","cpu":"8"}}}]}}}}'
   if [[ "$ROX_POSTGRES_DATASTORE" == "true" ]]; then
-    kubectl -n stackrox patch deploy/central-db -p '{"spec":{"template":{"spec":{"containers":[{"name":"central-db","resources":{"requests":{"memory":"8Gi","cpu":"5"},"limits":{"memory":"16Gi","cpu":"8"}}}]}}}}'
+    kubectl -n stackrox patch sts/central-db -p '{"spec":{"template":{"spec":{"containers":[{"name":"central-db","resources":{"requests":{"memory":"8Gi","cpu":"5"},"limits":{"memory":"16Gi","cpu":"8"}}}]}}}}'
   fi
 else
   kubectl -n stackrox patch deploy/sensor -p '{"spec":{"template":{"spec":{"containers":[{"name":"sensor","resources":{"requests":{"memory":"3Gi","cpu":"2"},"limits":{"memory":"12Gi","cpu":"4"}}}]}}}}'
   kubectl -n stackrox patch deploy/central -p '{"spec":{"template":{"spec":{"containers":[{"name":"central","resources":{"requests":{"memory":"3Gi","cpu":"2"},"limits":{"memory":"12Gi","cpu":"4"}}}]}}}}'
   if [[ "$ROX_POSTGRES_DATASTORE" == "true" ]]; then
-    kubectl -n stackrox patch deploy/central-db -p '{"spec":{"template":{"spec":{"containers":[{"name":"central-db","resources":{"requests":{"memory":"3Gi","cpu":"2"},"limits":{"memory":"12Gi","cpu":"4"}}}]}}}}'
+    kubectl -n stackrox patch sts/central-db -p '{"spec":{"template":{"spec":{"containers":[{"name":"central-db","resources":{"requests":{"memory":"3Gi","cpu":"2"},"limits":{"memory":"12Gi","cpu":"4"}}}]}}}}'
   fi
 fi

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -743,7 +743,7 @@ wait_for_central_db() {
     max_seconds=300
 
     while true; do
-        central_db_json="$(kubectl -n stackrox get deploy/central-db -o json)"
+        central_db_json="$(kubectl -n stackrox get sts/central-db -o json)"
         replicas="$(jq '.status.replicas' <<<"$central_db_json")"
         ready_replicas="$(jq '.status.readyReplicas' <<<"$central_db_json")"
         curr_time="$(date '+%s')"

--- a/tests/upgrade/postgres_run.sh
+++ b/tests/upgrade/postgres_run.sh
@@ -187,7 +187,7 @@ test_upgrade_paths() {
     # Upgrade to current to run any Postgres -> Postgres migrations                        #
     ########################################################################################
     kubectl -n stackrox set image deploy/central "*=$REGISTRY/main:$CURRENT_TAG"
-    kubectl -n stackrox set image deploy/central-db "*=$REGISTRY/central-db:$CURRENT_TAG"
+    kubectl -n stackrox set image sts/central-db "*=$REGISTRY/central-db:$CURRENT_TAG"
     wait_for_api
 
     # Verify data is still there
@@ -216,7 +216,7 @@ test_upgrade_paths() {
     # Upgrade back to latest to run the smoke tests                                        #
     ########################################################################################
     kubectl -n stackrox set image deploy/central "*=$REGISTRY/main:$CURRENT_TAG"
-    kubectl -n stackrox set image deploy/central-db "*=$REGISTRY/central-db:$CURRENT_TAG"
+    kubectl -n stackrox set image sts/central-db "*=$REGISTRY/central-db:$CURRENT_TAG"
 
     wait_for_api
 
@@ -315,7 +315,7 @@ force_rollback_to_previous_postgres() {
 
     kubectl -n stackrox patch configmap/central-config -p "$config_patch"
     kubectl -n stackrox set image deploy/central "central=$REGISTRY/main:$FORCE_ROLLBACK_VERSION"
-    kubectl -n stackrox set image deploy/central-db "*=$REGISTRY/central-db:$FORCE_ROLLBACK_VERSION"
+    kubectl -n stackrox set image sts/central-db "*=$REGISTRY/central-db:$FORCE_ROLLBACK_VERSION"
 }
 
 deploy_scaled_workload() {


### PR DESCRIPTION
## Description

Central-DB is better suited as a stateful set than a deployment as only one is allowed at a time

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

CI
