### PR TITLE
Update prettier 2.8.7 devDependencies in ui

### DIFF
--- a/ui/apps/platform/package.json
+++ b/ui/apps/platform/package.json
@@ -162,7 +162,7 @@
         "npm-run-all": "^4.1.5",
         "postcss": "^8.3.4",
         "postcss-cli": "^8.3.1",
-        "prettier": "^2.8.0",
+        "prettier": "^2.8.7",
         "randomstring": "^1.2.1",
         "react-app-rewired": "^2.2.1",
         "react-scripts": "^5.0.1",

--- a/ui/apps/platform/src/Components/workflow/TableCountLinks/TableCountLinks.tsx
+++ b/ui/apps/platform/src/Components/workflow/TableCountLinks/TableCountLinks.tsx
@@ -19,7 +19,7 @@ type TableCountLinksProps = {
 };
 
 function TableCountLinks({ row, textOnly }: TableCountLinksProps): ReactElement {
-    const fixableVulnType: typeof entityTypes[keyof typeof entityTypes] | '' | null | undefined =
+    const fixableVulnType: (typeof entityTypes)[keyof typeof entityTypes] | '' | null | undefined =
         useContext(fixableVulnTypeContext);
     const workflowState = useContext(workflowStateContext);
     const entityType = workflowState.getCurrentEntityType();

--- a/ui/apps/platform/src/Containers/Collections/types.ts
+++ b/ui/apps/platform/src/Containers/Collections/types.ts
@@ -1,5 +1,5 @@
 export const selectorEntityTypes = ['Cluster', 'Namespace', 'Deployment'] as const;
-export type SelectorEntityType = typeof selectorEntityTypes[number];
+export type SelectorEntityType = (typeof selectorEntityTypes)[number];
 
 export type ByNameSelectorField = `${SelectorEntityType}`;
 export type ByLabelSelectorField = `${SelectorEntityType} Label`;
@@ -28,9 +28,9 @@ export function isByAnnotationField(field: SelectorField): field is ByAnnotation
 }
 
 export const byLabelMatchTypes = ['EXACT'] as const;
-export type ByLabelMatchType = typeof byLabelMatchTypes[number];
+export type ByLabelMatchType = (typeof byLabelMatchTypes)[number];
 export const byNameMatchType = ['EXACT', 'REGEX'] as const;
-export type ByNameMatchType = typeof byNameMatchType[number];
+export type ByNameMatchType = (typeof byNameMatchType)[number];
 export type MatchType = ByNameMatchType | ByLabelMatchType;
 
 /**
@@ -72,7 +72,7 @@ export function isSupportedSelectorField(field: SelectorField): field is Support
 
 export const selectorOptions = ['All', 'ByName', 'ByLabel'] as const;
 
-export type RuleSelectorOption = typeof selectorOptions[number];
+export type RuleSelectorOption = (typeof selectorOptions)[number];
 
 export type AllResourceSelector = {
     type: 'All';

--- a/ui/apps/platform/src/Containers/Dashboard/SummaryCounts.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/SummaryCounts.tsx
@@ -43,7 +43,7 @@ export const SUMMARY_COUNTS = gql`
 `;
 
 const tileEntityTypes = ['Cluster', 'Node', 'Violation', 'Deployment', 'Image', 'Secret'] as const;
-type TileEntity = typeof tileEntityTypes[number];
+type TileEntity = (typeof tileEntityTypes)[number];
 
 const tileLinks: Record<TileEntity, string> = {
     Cluster: clustersBasePath,

--- a/ui/apps/platform/src/Containers/Dashboard/Widgets/AgingImagesChart.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/Widgets/AgingImagesChart.tsx
@@ -21,7 +21,7 @@ import isResourceScoped from '../utils';
 export type TimeRange = { enabled: boolean; value: number };
 export type TimeRangeTuple = [TimeRange, TimeRange, TimeRange, TimeRange];
 export const timeRangeTupleIndices = [0, 1, 2, 3] as const;
-export type TimeRangeTupleIndex = typeof timeRangeTupleIndices[number];
+export type TimeRangeTupleIndex = (typeof timeRangeTupleIndices)[number];
 export type TimeRangeCounts = Record<`timeRange${TimeRangeTupleIndex}`, number>;
 
 export type ChartData = {

--- a/ui/apps/platform/src/Containers/Network/Header/TimeWindowSelector.tsx
+++ b/ui/apps/platform/src/Containers/Network/Header/TimeWindowSelector.tsx
@@ -9,8 +9,8 @@ import { timeWindows } from 'constants/timeWindows';
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
 
 type TimeWindowSelectorProps = {
-    setActivityTimeWindow: (timeWindow: typeof timeWindows[number]) => void;
-    activityTimeWindow: typeof timeWindows[number];
+    setActivityTimeWindow: (timeWindow: (typeof timeWindows)[number]) => void;
+    activityTimeWindow: (typeof timeWindows)[number];
     isDisabled?: boolean;
 };
 

--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
@@ -79,7 +79,7 @@ function NetworkGraphPage() {
 
     const [pollEpoch, setPollEpoch] = useState(0);
     const [isLoading, setIsLoading] = useState(false);
-    const [timeWindow, setTimeWindow] = useState<typeof timeWindows[number]>(timeWindows[0]);
+    const [timeWindow, setTimeWindow] = useState<(typeof timeWindows)[number]>(timeWindows[0]);
     const [lastUpdatedTime, setLastUpdatedTime] = useState<string>('');
     const [isCIDRBlockFormOpen, setIsCIDRBlockFormOpen] = useState(false);
 

--- a/ui/apps/platform/src/Containers/NetworkGraph/TopologyComponent.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/TopologyComponent.tsx
@@ -43,7 +43,7 @@ export const UrlDetailType = {
     EXTERNAL_GROUP: 'external',
 } as const;
 export type UrlDetailTypeKey = keyof typeof UrlDetailType;
-export type UrlDetailTypeValue = typeof UrlDetailType[UrlDetailTypeKey];
+export type UrlDetailTypeValue = (typeof UrlDetailType)[UrlDetailTypeKey];
 
 function getUrlParamsForEntity(type, id): [UrlDetailTypeValue, string] {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/hooks/useImageVulnerabilities.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/hooks/useImageVulnerabilities.ts
@@ -23,7 +23,7 @@ export type ImageVulnerabilityComponent = {
 
 export const imageVulnerabilityCounterKeys = ['low', 'moderate', 'important', 'critical'] as const;
 
-export type ImageVulnerabilityCounterKey = typeof imageVulnerabilityCounterKeys[number];
+export type ImageVulnerabilityCounterKey = (typeof imageVulnerabilityCounterKeys)[number];
 
 export type ImageVulnerabilityCounter = Record<
     ImageVulnerabilityCounterKey | 'all',

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/types.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/types.ts
@@ -28,7 +28,7 @@ export type VulnMgmtLocalStorage = {
 
 export const detailsTabValues = ['Vulnerabilities', 'Resources'] as const;
 
-export type DetailsTab = typeof detailsTabValues[number];
+export type DetailsTab = (typeof detailsTabValues)[number];
 
 export function isDetailsTab(value: unknown): value is DetailsTab {
     return detailsTabValues.some((tab) => tab === value);
@@ -36,7 +36,7 @@ export function isDetailsTab(value: unknown): value is DetailsTab {
 
 export const cveStatusTabValues = ['Observed', 'Deferred', 'False Positive'] as const;
 
-export type CveStatusTab = typeof cveStatusTabValues[number];
+export type CveStatusTab = (typeof cveStatusTabValues)[number];
 
 export function isValidCveStatusTab(value: unknown): value is CveStatusTab {
     return cveStatusTabValues.some((tab) => tab === value);
@@ -44,7 +44,7 @@ export function isValidCveStatusTab(value: unknown): value is CveStatusTab {
 
 export const entityTabValues = ['CVE', 'Image', 'Deployment'] as const;
 
-export type EntityTab = typeof entityTabValues[number];
+export type EntityTab = (typeof entityTabValues)[number];
 
 export function isValidEntityTab(value: unknown): value is EntityTab {
     return entityTabValues.some((tab) => tab === value);

--- a/ui/apps/platform/src/types/cve.proto.ts
+++ b/ui/apps/platform/src/types/cve.proto.ts
@@ -6,7 +6,7 @@ export const vulnerabilitySeverities = [
     'CRITICAL_VULNERABILITY_SEVERITY',
 ] as const;
 
-export type VulnerabilitySeverity = typeof vulnerabilitySeverities[number];
+export type VulnerabilitySeverity = (typeof vulnerabilitySeverities)[number];
 
 export type VulnerabilityState = 'OBSERVED' | 'DEFERRED' | 'FALSE_POSITIVE';
 

--- a/ui/apps/platform/src/types/policy.proto.ts
+++ b/ui/apps/platform/src/types/policy.proto.ts
@@ -18,7 +18,7 @@ export const policySeverities = [
     'HIGH_SEVERITY',
     'CRITICAL_SEVERITY',
 ] as const;
-export type PolicySeverity = typeof policySeverities[number];
+export type PolicySeverity = (typeof policySeverities)[number];
 
 // TODO supersedes src/Containers/Violations/PatternFly/types/violationTypes.ts
 export type LifecycleStage = 'DEPLOY' | 'BUILD' | 'RUNTIME';

--- a/ui/packages/tailwind-config/package.json
+++ b/ui/packages/tailwind-config/package.json
@@ -38,7 +38,7 @@
         "eslint-plugin-prettier": "^4.0.0",
         "postcss": "^8.3.4",
         "postcss-cli": "^8.3.1",
-        "prettier": "^2.8.0",
+        "prettier": "^2.8.7",
         "tailwindcss": "^2.0.3"
     }
 }

--- a/ui/packages/ui-components/package.json
+++ b/ui/packages/ui-components/package.json
@@ -74,7 +74,7 @@
         "npm-run-all": "^4.1.5",
         "postcss": "^8.3.4",
         "postcss-cli": "^8.3.1",
-        "prettier": "^2.8.0",
+        "prettier": "^2.8.7",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "tailwindcss": "^2.0.3",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -15537,10 +15537,10 @@ prettier@^2.0.0:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.4.tgz#34dd2595629bfbb79d344ac4a91ff948694463c3"
   integrity sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==
 
-prettier@^2.8.0:
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.0.tgz#c7df58393c9ba77d6fba3921ae01faf994fb9dc9"
-  integrity sha512-9Lmg8hTFZKG0Asr/kW9Bp8tJjRVluO8EJQVfY2T7FMw9T5jy4I/Uvx0Rca/XWf50QQ1/SS48+6IJWnrb+2yemA==
+prettier@^2.8.7:
+  version "2.8.7"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.7.tgz#bb79fc8729308549d28fe3a98fce73d2c0656450"
+  integrity sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==
 
 pretty-bytes@^5.3.0:
   version "5.5.0"


### PR DESCRIPTION
## Description

Patch update now to limit number of code changes for major upgrade soon.

1. https://github.com/prettier/prettier/blob/main/CHANGELOG.md#285

    * TypeScript 5.0 introduces two new syntactic features:

        `const` modifiers for type parameters
        `export type *` declarations

    * Add parentheses for (array of) `TypeofTypeAnnotation` to improve readability.

        17 changes in 11 files

        * src/Components/workflow/TableCountLinks/TableCountLinks.tsx
        * src/Containers/Collections/types.ts
        * src/Containers/Dashboard/SummaryCounts.tsx
        * src/Containers/Dashboard/Widgets/AgingImagesChart.tsx
        * src/Containers/Network/Header/TimeWindowSelector.tsx
        * src/Containers/NetworkGraph/NetworkGraphPage.tsx
        * src/Containers/NetworkGraph/TopologyComponent.tsx
        * src/Containers/Vulnerabilities/WorkloadCves/hooks/useImageVulnerabilities.ts
        * src/Containers/Vulnerabilities/WorkloadCves/types.ts
        * src/types/cve.proto.ts
        * src/types/policy.proto.ts

2. https://github.com/prettier/prettier/blob/main/CHANGELOG.md#286

    * Allow decorators on private members and class expressions

3. https://github.com/prettier/prettier/blob/main/CHANGELOG.md#287

    * Allow multiple decorators on same getter/setter

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

1. `yarn lint` in ui