### PR TITLE
Separate image count query from data loading query in image cve page

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCveSummaryCards.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCveSummaryCards.tsx
@@ -8,8 +8,6 @@ import BySeveritySummaryCard from './SummaryCards/BySeveritySummaryCard';
 
 export type ImageCveSummaryCount = {
     totalImageCount: number;
-    imageCount: number;
-    deploymentCount: number;
 };
 
 export type ImageCveSeveritySummary = {
@@ -41,8 +39,6 @@ export const imageCveSeveritySummaryFragment = gql`
 export const imageCveSummaryCountFragment = gql`
     fragment ImageCVESummaryCounts on Query {
         totalImageCount: imageCount
-        imageCount(query: $query)
-        deploymentCount(query: $query)
     }
 `;
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedImagesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedImagesTable.tsx
@@ -164,7 +164,6 @@ function AffectedImagesTable({ images, getSortParams, isFiltered }: AffectedImag
                                     : `${imageComponents.length} components`}
                             </Td>
                             <Td dataLabel="First discovered">
-                                {/* TODO Is this the correct field? It differs from the field on the CVE page. */}
                                 {getDistanceStrictAsPhrase(scanTime, new Date())}
                             </Td>
                         </Tr>


### PR DESCRIPTION
## Description

Restructures the queries a bit so that the counts for `images` and `deployments` are always kept up to date, regardless of the user's current entity tab. The query that requests the full table data will still only request data for the active tab.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Load the ImageCVE page and see that the counts for both Images and Deployments are up to date.
![image](https://user-images.githubusercontent.com/1292638/228643928-afa01dcf-37ef-453d-b27a-5e4513a6cb90.png)

Change to the Deployments tab, and apply a deployment filter. The counts for both images and deployments should update to match the filter, but the only request that is sent is the `SummaryData` request. The images request is not sent because "Deployments" is the active tab.
![image](https://user-images.githubusercontent.com/1292638/228644300-2bb68979-465d-4c0a-94c7-25667dd17ac9.png)

