### PR TITLE
Minor general workload CVE fixes

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/DeploymentPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/DeploymentPage.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
 
-function WorkloadCvesDeploymentSinglePage() {
+function DeploymentPage() {
     const { deploymentId } = useParams();
     return <>Workload CVE Deployment Single Page: {deploymentId}</>;
 }
 
-export default WorkloadCvesDeploymentSinglePage;
+export default DeploymentPage;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/DeploymentPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/DeploymentPage.tsx
@@ -1,9 +1,16 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
 
+import PageTitle from 'Components/PageTitle';
+
 function DeploymentPage() {
     const { deploymentId } = useParams();
-    return <>Workload CVE Deployment Single Page: {deploymentId}</>;
+    return (
+        <>
+            <PageTitle title={`Workload CVEs - Deployment ${'TODO'}`} />
+            Workload CVE Deployment Single Page: {deploymentId}
+        </>
+    );
 }
 
 export default DeploymentPage;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCvePage.tsx
@@ -14,9 +14,15 @@ import {
     Split,
     SplitItem,
 } from '@patternfly/react-core';
+import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import { useParams } from 'react-router-dom';
 
 import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
+<<<<<<< HEAD
+=======
+import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';
+import PageTitle from 'Components/PageTitle';
+>>>>>>> e672d8c32f (Apply page titles to workload cve single pages)
 import useURLSearch from 'hooks/useURLSearch';
 import useURLStringUnion from 'hooks/useURLStringUnion';
 import useURLPagination from 'hooks/useURLPagination';
@@ -171,6 +177,9 @@ function ImageCvePage() {
 
     return (
         <>
+            <PageTitle
+                title={`Workload CVEs - ImageCVE ${metadataRequest.data?.imageCVE.cve ?? ''}`}
+            />
             <PageSection variant="light" className="pf-u-py-md">
                 <Breadcrumb>
                     <BreadcrumbItemLink to={workloadCveOverviewImagePath}>CVEs</BreadcrumbItemLink>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCvePage.tsx
@@ -14,15 +14,10 @@ import {
     Split,
     SplitItem,
 } from '@patternfly/react-core';
-import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import { useParams } from 'react-router-dom';
 
 import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
-<<<<<<< HEAD
-=======
-import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';
 import PageTitle from 'Components/PageTitle';
->>>>>>> e672d8c32f (Apply page titles to workload cve single pages)
 import useURLSearch from 'hooks/useURLSearch';
 import useURLStringUnion from 'hooks/useURLStringUnion';
 import useURLPagination from 'hooks/useURLPagination';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImagePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImagePage.tsx
@@ -20,6 +20,7 @@ import { CopyIcon, ExclamationCircleIcon } from '@patternfly/react-icons';
 import { useParams } from 'react-router-dom';
 
 import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
+import PageTitle from 'Components/PageTitle';
 import { getDateTime, getDistanceStrictAsPhrase } from 'utils/dateUtils';
 import useURLStringUnion from 'hooks/useURLStringUnion';
 import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';
@@ -167,6 +168,7 @@ function ImagePage() {
 
     return (
         <>
+            <PageTitle title={`Workload CVEs - Image ${imageData ? imageName : ''}`} />
             <PageSection variant="light" className="pf-u-py-md">
                 <Breadcrumb>
                     <BreadcrumbItemLink to={workloadCveOverviewImagePath}>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImagePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImagePage.tsx
@@ -24,8 +24,8 @@ import { getDateTime, getDistanceStrictAsPhrase } from 'utils/dateUtils';
 import useURLStringUnion from 'hooks/useURLStringUnion';
 import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
-import ImageSingleVulnerabilities from './ImageSingleVulnerabilities';
-import ImageSingleResources from './ImageSingleResources';
+import ImagePageVulnerabilities from './ImagePageVulnerabilities';
+import ImagePageResources from './ImagePageResources';
 import { detailsTabValues } from './types';
 import { getOverviewCvesPath } from './searchUtils';
 import useImageDetails, { ImageDetailsResponse } from './hooks/useImageDetails';
@@ -87,7 +87,7 @@ function ImageDetailBadges({ imageData }: { imageData: ImageDetailsResponse['ima
     );
 }
 
-function WorkloadCvesImageSinglePage() {
+function ImagePage() {
     const { imageId } = useParams();
     const { data, error } = useImageDetails(imageId);
     const [activeTabKey, setActiveTabKey] = useURLStringUnion('detailsTab', detailsTabValues);
@@ -149,7 +149,7 @@ function WorkloadCvesImageSinglePage() {
                             eventKey="Vulnerabilities"
                             title={<TabTitleText>Vulnerabilities</TabTitleText>}
                         >
-                            <ImageSingleVulnerabilities imageId={imageId} />
+                            <ImagePageVulnerabilities imageId={imageId} />
                         </Tab>
                         <Tab
                             className="pf-u-display-flex pf-u-flex-direction-column pf-u-flex-grow-1"
@@ -157,7 +157,7 @@ function WorkloadCvesImageSinglePage() {
                             title={<TabTitleText>Resources</TabTitleText>}
                             isDisabled
                         >
-                            <ImageSingleResources />
+                            <ImagePageResources />
                         </Tab>
                     </Tabs>
                 </PageSection>
@@ -189,4 +189,4 @@ function WorkloadCvesImageSinglePage() {
     );
 }
 
-export default WorkloadCvesImageSinglePage;
+export default ImagePage;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImagePageResources.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImagePageResources.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { PageSection } from '@patternfly/react-core';
 
-function ImageSingleResources() {
+function ImagePageResources() {
     return <PageSection>Resources (TODO)</PageSection>;
 }
 
-export default ImageSingleResources;
+export default ImagePageResources;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImagePageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImagePageVulnerabilities.tsx
@@ -55,11 +55,11 @@ function getHiddenStatuses(querySearchFilter: QuerySearchFilter): Set<FixableSta
 
 const defaultSortFields = ['CVE', 'Severity', 'Fixable'];
 
-export type ImageSingleVulnerabilitiesProps = {
+export type ImagePageVulnerabilitiesProps = {
     imageId: string;
 };
 
-function ImageSingleVulnerabilities({ imageId }: ImageSingleVulnerabilitiesProps) {
+function ImagePageVulnerabilities({ imageId }: ImagePageVulnerabilitiesProps) {
     const { searchFilter } = useURLSearch();
     const querySearchFilter = parseQuerySearchFilter(searchFilter);
     const { page, perPage, setPage, setPerPage } = useURLPagination(50);
@@ -226,4 +226,4 @@ function ImageSingleVulnerabilities({ imageId }: ImageSingleVulnerabilitiesProps
     );
 }
 
-export default ImageSingleVulnerabilities;
+export default ImagePageVulnerabilities;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/SummaryCards/BySeveritySummaryCard.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/SummaryCards/BySeveritySummaryCard.tsx
@@ -21,8 +21,7 @@ const severitiesCriticalToLow = [
     'LOW_VULNERABILITY_SEVERITY',
 ] as const;
 
-const disabledColor100 = 'var(--pf-global--disabled-color--100)';
-const disabledColor200 = 'var(--pf-global--disabled-color--200)';
+const fadedTextColor = 'var(--pf-global--Color--200)';
 
 function BySeveritySummaryCard({
     className = '',
@@ -44,10 +43,10 @@ function BySeveritySummaryCard({
                         let text = `${count} ${vulnerabilitySeverityLabels[severity]}`;
 
                         if (isHidden) {
-                            textColor = disabledColor100;
+                            textColor = fadedTextColor;
                             text = 'Results hidden';
                         } else if (hasNoResults) {
-                            textColor = disabledColor200;
+                            textColor = fadedTextColor;
                             text = 'No results';
                         }
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedImagesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedImagesTable.tsx
@@ -108,7 +108,7 @@ function AffectedImagesTable({ images, getSortParams, isFiltered }: AffectedImag
     return (
         // TODO UX question - Collapse to cards, or allow headers to overflow?
         // <TableComposable gridBreakPoint="grid-xl">
-        <TableComposable>
+        <TableComposable variant="compact">
             <Thead>
                 <Tr>
                     <Th>{/* Header for expanded column */}</Th>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageComponentsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageComponentsTable.tsx
@@ -20,7 +20,7 @@ function ImageComponentsTable({ layers, imageComponents }: ImageComponentsTableP
                     <Th>Location</Th>
                 </Tr>
             </Thead>
-            {imageComponents.map(({ id, name, version, fixedIn, location, layerIndex }) => {
+            {imageComponents.map(({ id, name, version, fixedIn, location, layerIndex }, index) => {
                 let dockerfileText = `* Dockerfile layer information is not available *`;
 
                 if (layerIndex !== null) {
@@ -29,13 +29,15 @@ function ImageComponentsTable({ layers, imageComponents }: ImageComponentsTableP
                         dockerfileText = `${layer.instruction} ${layer.value}`;
                     }
                 }
+
+                // No border on the last row
+                const style =
+                    index !== imageComponents.length - 1
+                        ? { borderBottom: '1px solid var(--pf-c-table--BorderColor)' }
+                        : {};
+
                 return (
-                    <Tbody
-                        key={id}
-                        style={{
-                            borderBottom: '1px solid var(--pf-c-table--BorderColor)',
-                        }}
-                    >
+                    <Tbody key={id} style={style}>
                         <Tr>
                             <Td>{name}</Td>
                             <Td>{version}</Td>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/SingleEntityVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/SingleEntityVulnerabilitiesTable.tsx
@@ -37,7 +37,7 @@ function SingleEntityVulnerabilitiesTable({
     const expandedRowSet = useSet<string>();
 
     return (
-        <TableComposable>
+        <TableComposable variant="compact">
             <Thead>
                 <Tr>
                     <Th>{/* Header for expanded column */}</Th>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesPage.tsx
@@ -11,8 +11,8 @@ import {
     vulnerabilitiesWorkloadCveSinglePath,
     vulnerabilitiesWorkloadCvesPath,
 } from 'routePaths';
-import WorkloadCvesDeploymentSinglePage from './WorkloadCvesDeploymentSinglePage';
-import WorkloadCvesImageSinglePage from './WorkloadCvesImageSinglePage';
+import DeploymentPage from './DeploymentPage';
+import ImagePage from './ImagePage';
 import WorkloadCvesOverviewPage from './WorkloadCvesOverviewPage';
 import ImageCvePage from './ImageCvePage';
 
@@ -20,13 +20,10 @@ function WorkloadCvesPage() {
     return (
         <Switch>
             <Route path={vulnerabilitiesWorkloadCveSinglePath} component={ImageCvePage} />
-            <Route
-                path={vulnerabilitiesWorkloadCveImageSinglePath}
-                component={WorkloadCvesImageSinglePage}
-            />
+            <Route path={vulnerabilitiesWorkloadCveImageSinglePath} component={ImagePage} />
             <Route
                 path={vulnerabilitiesWorkloadCveDeploymentSinglePath}
-                component={WorkloadCvesDeploymentSinglePage}
+                component={DeploymentPage}
             />
             <Route
                 exact


### PR DESCRIPTION
## Description

A handful of cleanup items I noticed that don't have tickets, one change for each commit so reviewing is likely easier to do commit-by-commit.

1. Update naming of main page components from `WorkloadCveEntitySinglePage` to just `EntityPage`.
2. Switch existing tables to use the "compact" variant and fix the border display in the embedded table.
3. Add PageTitles (oops) to entity single pages.
4. Change all usage of "faded" text colors in the UI to `color-200` which is the only noticeably lighter text color offered by PatternFly that passes accessibility color tests on a plain white background.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Manual testing of navigation, page titles, and table rendering.
