### PR TITLE
ROX-14483: Add operator subscription annotation

### DIFF
--- a/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
@@ -19,6 +19,8 @@ metadata:
       services necessary to secure each of your OpenShift and Kubernetes clusters.
     operatorframework.io/suggested-namespace: rhacs-operator
     operators.openshift.io/infrastructure-features: '["disconnected", "proxy-aware"]'
+    operators.openshift.io/valid-subscription: '["OpenShift Platform Plus", "Red Hat
+      Advanced Cluster Security"]'
     operators.operatorframework.io/builder: operator-sdk-unknown
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     support: Red Hat

--- a/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
@@ -11,6 +11,8 @@ metadata:
       services necessary to secure each of your OpenShift and Kubernetes clusters.
     operatorframework.io/suggested-namespace: rhacs-operator
     operators.openshift.io/infrastructure-features: '["disconnected", "proxy-aware"]'
+    operators.openshift.io/valid-subscription: '["OpenShift Platform Plus", "Red Hat
+      Advanced Cluster Security"]'
     support: Red Hat
   name: rhacs-operator.v0.0.0
   namespace: placeholder


### PR DESCRIPTION
## Description

As was requested in https://issues.redhat.com/browse/ROX-14483

Note that Daniel Messer suggested
`"['OpenShift Platform Plus', 'Red Hat Advanced Cluster Security']"`

whereas the examples in the official documentation combine single- and double- quotes differently.
See https://docs.openshift.com/container-platform/4.10/operators/operator_sdk/osdk-generating-csvs.html#osdk-csv-manual-annotations_osdk-generating-csvs

Example given there:
`'["3Scale Commercial License", "Red Hat Managed Integration"]'`

Choosing between two formats I decided for the latter provided that's the style already used for
`operators.openshift.io/infrastructure-features` attribute.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Evaluated and added CHANGELOG entry if required~ - theoretically, we can enter this in the changelog but I'm not sure what this change impacts.

Won't do these:
- [ ] Unit test and regression tests added
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

* CI should be green.
* Not sure how to test this and where to look. Therefore, I will just rely on Daniel knowing what he suggested. Also, there are CVP tests in downstream which check some Red Hat logic for operators. I would hope these will warn us in case anything goes wrong.