### PR TITLE
fix: update the docs submodule branch and content

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "docs/content"]
 	path = docs/content
 	url = https://github.com/openshift/openshift-docs.git
-	branch = rhacs-docs-3.73.3
+	branch = rhacs-docs-3.73.4
 [submodule "docs/tools"]
 	path = docs/tools
 	url = https://github.com/stackrox/docs-tools.git


### PR DESCRIPTION
## Description

The docs submodule branch wasn't updated prior to cutting RC.1. Automation would have updated the submodule content, which I did manually now.

That caused https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/branch-ci-stackrox-stackrox-release-3.73-merge-push-and-release/1641038477795528704 to fail.

This PR fixes that. Next RCs (or final cut) will include the updated docs.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Manually ran https://github.com/stackrox/stackrox/blob/release-3.73/scripts/ci/lib.sh#L573-L604 to verify the check will pass in the next iteration.
