### PR TITLE
Make CSVTest multi-arch compliant

### DIFF
--- a/qa-tests-backend/src/test/groovy/CSVTest.groovy
+++ b/qa-tests-backend/src/test/groovy/CSVTest.groovy
@@ -137,11 +137,11 @@ class CSVTest extends BaseSpecification {
 
     static final private Deployment CVE_DEPLOYMENT = new Deployment()
             .setName("nginx-deployment")
-            .setImage("quay.io/rhacs-eng/qa:nginx-1-9")
+            .setImage("quay.io/rhacs-eng/qa-multi-arch:nginx")
             .addLabel("app", "test")
 
     def setupSpec() {
-        ImageService.scanImage("quay.io/rhacs-eng/qa:nginx-1-9")
+        ImageService.scanImage("quay.io/rhacs-eng/qa-multi-arch:nginx")
         orchestrator.createDeployment(CVE_DEPLOYMENT)
         assert Services.waitForDeployment(CVE_DEPLOYMENT)
         // wait for all image CVEs to be discovered and added to db
@@ -186,7 +186,7 @@ class CSVTest extends BaseSpecification {
     }
 
     def getComponentId() {
-        return isPostgresRun() ? "openssl#1.0.1k-3+deb8u5#debian:8" : "b3BlbnNzbA:MS4wLjFrLTMrZGViOHU1"
+        return isPostgresRun() ? "openssl#1.1.1d-0+deb10u7#debian:10" : "b3BlbnNzbA:MS4wLjFrLTMrZGViOHU1"
     }
 
     def getComponentQuery() {
@@ -286,14 +286,14 @@ class CSVTest extends BaseSpecification {
 
         baseGraphQLQuery                | postgresGraphQLQuery                       | graphQLPayload | csvQuery
         FIXABLE_CVES_IN_IMAGE_QUERY     | FIXABLE_CVES_IN_IMAGE_POSTGRES_QUERY       | [
-                id        : "sha256:e18c5814a9f7ddd5fe410f17417a48d2de562325e9d71337274134f4a6654e3f",
+                id        : "sha256:a05b0cdd4fc1be3b224ba9662ebdf98fe44c09c0c9215b45f84344c12867002e",
                 query: "",
                 // must scope without scope query since graphQL is hitting sub-resolver
                 scopeQuery: "",
                 vulnQuery : "Fixable:true",
                 vulnPagination: new Pagination(0, 0, new SortOption("cvss", true)),
         ] | getCVETypeImageQuery() +
-            "Image Sha:sha256:e18c5814a9f7ddd5fe410f17417a48d2de562325e9d71337274134f4a6654e3f+Fixable:true"
+            "Image Sha:sha256:a05b0cdd4fc1be3b224ba9662ebdf98fe44c09c0c9215b45f84344c12867002e+Fixable:true"
         FIXABLE_CVES_IN_COMPONENT_QUERY | FIXABLE_CVES_IN_COMPONENT_POSTGRES_QUERY   | [
                 // openssl 1.0.1k-3+deb8u5
                 id        : getComponentId(),


### PR DESCRIPTION
This PR intends to make CSVtest multi-arch compliant using MA images for test execution
Changes are verified manually using `./gradlew test --tests=TestName`