### PR TITLE
move jira conditional check to step instead of job level

### DIFF
--- a/.github/workflows/cut-rc.yml
+++ b/.github/workflows/cut-rc.yml
@@ -94,11 +94,11 @@ jobs:
 
   check-jira:
     name: Check Jira tickets for release
-    if: github.event.inputs.check-jira-issues == 'true'
     needs: [variables, properties]
     runs-on: ubuntu-latest
     steps:
       - name: Query JIRA
+        if: github.event.inputs.check-jira-issues == 'true'
         env:
           JIRA_TOKEN: ${{ secrets.JIRA_TOKEN }}
         run: |


### PR DESCRIPTION
## Description

Cherry-pick of https://github.com/stackrox/test-gh-actions/pull/92


... otherwise jobs depending on `check-jira` are also skipped. 

Failed job: https://github.com/stackrox/stackrox/actions/runs/4551026838

Working as expected (failure because release-0.0 branch does not exist)
* with checking jira issues: https://github.com/stackrox/test-gh-actions/actions/runs/4551134738/jobs/8024859527
* without: https://github.com/stackrox/test-gh-actions/actions/runs/4551134903/jobs/8024865314

You can also see the difference when checking the output or by clicking on the [Check Jira tickets for release](https://github.com/stackrox/test-gh-actions/actions/runs/4551134903/jobs/8024865314#logs) box. 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Tested in https://github.com/stackrox/test-gh-actions/pull/92
