### PR TITLE
Allow 'replace' instead of 'push' to URL history when synchronizing values.

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadTableToolbar.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadTableToolbar.tsx
@@ -79,12 +79,15 @@ function WorkloadTableToolbar({
             const fixableFilter = searchFixable
                 ? uniq([...defaultFixable, ...searchFixable])
                 : defaultFixable;
-            setSearchFilter({
-                ...defaultFilters,
-                ...searchFilter,
-                Severity: severityFilter,
-                Fixable: fixableFilter,
-            });
+            setSearchFilter(
+                {
+                    ...defaultFilters,
+                    ...searchFilter,
+                    Severity: severityFilter,
+                    Fixable: fixableFilter,
+                },
+                'replace'
+            );
         }
     }, [defaultFilters, searchFilter, setSearchFilter]);
 

--- a/ui/apps/platform/src/hooks/useURLParameter.ts
+++ b/ui/apps/platform/src/hooks/useURLParameter.ts
@@ -6,9 +6,12 @@ import { getQueryObject, getQueryString } from 'utils/queryStringUtils';
 export type QueryValue = undefined | string | string[] | qs.ParsedQs | qs.ParsedQs[];
 
 // Note that when we upgrade React Router and 'history' we can probably import a more accurate version of this type
-type Action = 'push' | 'replace';
+export type Action = 'push' | 'replace';
 
-type UseURLParameterResult = [QueryValue, (newValue: QueryValue, historyAction?: Action) => void];
+export type UseURLParameterResult = [
+    QueryValue,
+    (newValue: QueryValue, historyAction?: Action) => void
+];
 
 /**
  * Hook to handle reading and writing of a piece of state in the page's URL query parameters.

--- a/ui/apps/platform/src/hooks/useURLSearch.ts
+++ b/ui/apps/platform/src/hooks/useURLSearch.ts
@@ -3,11 +3,11 @@ import isEqual from 'lodash/isEqual';
 
 import { SearchFilter } from 'types/search';
 import { isParsedQs } from 'utils/queryStringUtils';
-import useURLParameter, { QueryValue } from './useURLParameter';
+import useURLParameter, { Action, QueryValue } from './useURLParameter';
 
 type UseUrlSearchReturn = {
     searchFilter: SearchFilter;
-    setSearchFilter: (newFilter: SearchFilter) => void;
+    setSearchFilter: (newFilter: SearchFilter, historyAction?: Action) => void;
 };
 
 function parseFilter(rawFilter: QueryValue): SearchFilter {

--- a/ui/apps/platform/src/hooks/useURLStringUnion.ts
+++ b/ui/apps/platform/src/hooks/useURLStringUnion.ts
@@ -1,9 +1,12 @@
 import { useEffect } from 'react';
 
-import useURLParameter from 'hooks/useURLParameter';
+import useURLParameter, { Action } from 'hooks/useURLParameter';
 import { NonEmptyArray } from 'utils/type.utils';
 
-export type UseURLStringUnionReturn<Value> = [Value, (nextValue: unknown) => void];
+export type UseURLStringUnionReturn<Value> = [
+    Value,
+    (nextValue: unknown, historyAction?: Action) => void
+];
 
 function isValidValue<Values extends Readonly<NonEmptyArray<unknown>>>(
     values: Values,
@@ -38,10 +41,10 @@ export default function useURLStringUnion<Values extends Readonly<NonEmptyArray<
         setParamValue(currentValue, 'replace');
     }, [currentValue, setParamValue]);
 
-    function safeSetValue(nextValue: unknown) {
+    function safeSetValue(nextValue: unknown, historyAction?: Action) {
         // Ensures the value cannot be set incorrectly by calling code
         if (isValidValue(values, nextValue)) {
-            setParamValue(nextValue);
+            setParamValue(nextValue, historyAction);
         }
     }
 


### PR DESCRIPTION
## Description

The `useURLSearch` and `useURLStringUnion` hooks that wrap `useURLParameter` for specific use cases did not expose the optional `history` argument, which defaults to the `push` action. This was causing multiple history writes when the URL was syncing with local storage that broke back navigation.

This exposes the history option on those two hooks so that we can `replace` history when syncing state in `useEffect` hooks, and use the default of `push` when the URL change is the result of a user action.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Manual testing:

- Visit Workload CVE main page and apply default filters
- Visit any number of other pages in the app
- Visit Workload CVE main page and apply local filters

After doing this, navigating backwards should result in one history "pop" for each local filter applied until only the default filters remain. Hitting the back button again should navigate away from the Workload CVE page and back through the previous app pages until once again hitting the Workload CVE main page.
