### PR TITLE
Dashrews/db anti affinity

### DIFF
--- a/image/templates/helm/stackrox-central/templates/01-central-12-central-db.yaml
+++ b/image/templates/helm/stackrox-central/templates/01-central-12-central-db.yaml
@@ -69,6 +69,15 @@ spec:
               matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: DoesNotExist
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - central-db
+            topologyKey: kubernetes.io/hostname
       serviceAccountName: central-db
       terminationGracePeriodSeconds: 120
       initContainers:


### PR DESCRIPTION
## Description

chaos tests have shown that we will get into states where when central-db is killed sometimes the new pod will start on the same node and thus begin accessing the PVC because RWO on a volume does not enforce access on the same node.  Adding anti-affinity helps ensure that if the pod gets scheduled on the same node, it will remain at Pending until the previous one is gone.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
