### PR TITLE
chore(roxctl): hide non-required global flags where applicable

### DIFF
--- a/roxctl/common/flags/hide.go
+++ b/roxctl/common/flags/hide.go
@@ -1,0 +1,23 @@
+package flags
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/stackrox/rox/pkg/set"
+)
+
+// HideInheritedFlags hides all inherited flags except the flag names given.
+// This is especially useful for commands that do not require central connectivity and want to avoid exposing these
+// flags to the client to avoid confusion.
+func HideInheritedFlags(cmd *cobra.Command, flagsToShow ...string) {
+	flagSet := set.NewStringSet(flagsToShow...)
+	orig := cmd.HelpFunc()
+	cmd.SetHelpFunc(func(cmd *cobra.Command, strings []string) {
+		cmd.InheritedFlags().VisitAll(func(flag *pflag.Flag) {
+			if !flagSet.Contains(flag.Name) {
+				flag.Hidden = true
+			}
+		})
+		orig(cmd, strings)
+	})
+}

--- a/roxctl/completion/completion.go
+++ b/roxctl/completion/completion.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/stackrox/rox/roxctl/common"
 	"github.com/stackrox/rox/roxctl/common/environment"
+	"github.com/stackrox/rox/roxctl/common/flags"
 )
 
 var (
@@ -63,7 +64,7 @@ PowerShell:
 
 // Command provides the shell completion cobra command
 func Command(cliEnvironment environment.Environment) *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		DisableFlagsInUseLine: true,
 		Use:                   "completion [bash|zsh|fish|powershell]",
 		Short:                 "Generate shell completion scripts.",
@@ -86,4 +87,6 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 			return errors.Wrap(gen(cliEnvironment.InputOutput().Out()), "could not generate completion")
 		},
 	}
+	flags.HideInheritedFlags(cmd)
+	return cmd
 }

--- a/roxctl/declarativeconfig/create/access_scope.go
+++ b/roxctl/declarativeconfig/create/access_scope.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stackrox/rox/pkg/maputil"
 	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/rox/roxctl/common/environment"
+	"github.com/stackrox/rox/roxctl/common/flags"
 	"github.com/stackrox/rox/roxctl/declarativeconfig/k8sobject"
 	"github.com/stackrox/rox/roxctl/declarativeconfig/lint"
 	"gopkg.in/yaml.v3"
@@ -82,6 +83,8 @@ In case only a subset of namespace should be included, specify --included cluste
 		fmt.Sprintf(labelSelectorUsage, "namespace-label-selector", "namespace-label-selector"))
 
 	utils.Must(cmd.MarkFlagRequired("name"))
+
+	flags.HideInheritedFlags(cmd, k8sobject.ConfigMapFlag, k8sobject.NamespaceFlag)
 
 	return cmd
 }

--- a/roxctl/declarativeconfig/create/auth_provider.go
+++ b/roxctl/declarativeconfig/create/auth_provider.go
@@ -14,9 +14,25 @@ import (
 	"github.com/stackrox/rox/pkg/maputil"
 	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/rox/roxctl/common/environment"
+	"github.com/stackrox/rox/roxctl/common/flags"
 	"github.com/stackrox/rox/roxctl/declarativeconfig/k8sobject"
 	"github.com/stackrox/rox/roxctl/declarativeconfig/lint"
 	"gopkg.in/yaml.v3"
+)
+
+var (
+	persistentFlagsToShow = []string{
+		"name",
+		"minimum-access-role",
+		"ui-endpoint",
+		"extra-ui-endpoints",
+		"required-attributes",
+		"groups-key",
+		"groups-value",
+		"groups-role",
+		k8sobject.ConfigMapFlag,
+		k8sobject.NamespaceFlag,
+	}
 )
 
 func authProviderCommand(cliEnvironment environment.Environment) *cobra.Command {
@@ -71,6 +87,8 @@ Example of a group: --groups-key "email" --groups-value "my@domain.com" --groups
 		authProviderCmd.userPKICommand(),
 		authProviderCmd.openShiftCommand(),
 	)
+
+	flags.HideInheritedFlags(cmd, k8sobject.ConfigMapFlag, k8sobject.NamespaceFlag)
 
 	return cmd
 }
@@ -131,6 +149,7 @@ func (a *authProviderCmd) oidcCommand() *cobra.Command {
 	utils.Must(cmd.MarkFlagRequired("issuer"))
 	utils.Must(cmd.MarkFlagRequired("client-id"))
 
+	flags.HideInheritedFlags(cmd, persistentFlagsToShow...)
 	return cmd
 }
 
@@ -158,6 +177,7 @@ func (a *authProviderCmd) samlCommand() *cobra.Command {
 	cmd.MarkFlagsRequiredTogether("idp-cert", "sso-url", "idp-issuer")
 	cmd.MarkFlagsMutuallyExclusive("metadata-url", "sso-url")
 
+	flags.HideInheritedFlags(cmd, persistentFlagsToShow...)
 	return cmd
 }
 
@@ -174,6 +194,7 @@ func (a *authProviderCmd) iapCommand() *cobra.Command {
 
 	utils.Must(cmd.MarkFlagRequired("audience"))
 
+	flags.HideInheritedFlags(cmd, persistentFlagsToShow...)
 	return cmd
 }
 
@@ -191,6 +212,7 @@ func (a *authProviderCmd) userPKICommand() *cobra.Command {
 
 	utils.Must(cmd.MarkFlagRequired("ca-file"))
 
+	flags.HideInheritedFlags(cmd, persistentFlagsToShow...)
 	return cmd
 }
 
@@ -201,6 +223,7 @@ func (a *authProviderCmd) openShiftCommand() *cobra.Command {
 		Short: "Create a declarative configuration for an OpenShift-Auth auth provider",
 	}
 
+	flags.HideInheritedFlags(cmd, persistentFlagsToShow...)
 	return cmd
 }
 

--- a/roxctl/declarativeconfig/create/create.go
+++ b/roxctl/declarativeconfig/create/create.go
@@ -3,6 +3,7 @@ package create
 import (
 	"github.com/spf13/cobra"
 	"github.com/stackrox/rox/roxctl/common/environment"
+	"github.com/stackrox/rox/roxctl/common/flags"
 	"github.com/stackrox/rox/roxctl/declarativeconfig/k8sobject"
 )
 
@@ -30,6 +31,7 @@ If this is unset and the flag "config-map" is also unset, the created YAML will 
 If left empty, the default namespace in the current kube config will be used.`)
 
 	c.MarkFlagsMutuallyExclusive(k8sobject.ConfigMapFlag, k8sobject.SecretFlag)
+	flags.HideInheritedFlags(c)
 
 	return c
 }

--- a/roxctl/declarativeconfig/create/permission_set.go
+++ b/roxctl/declarativeconfig/create/permission_set.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/maputil"
 	"github.com/stackrox/rox/roxctl/common/environment"
+	"github.com/stackrox/rox/roxctl/common/flags"
 	"github.com/stackrox/rox/roxctl/declarativeconfig/k8sobject"
 	"github.com/stackrox/rox/roxctl/declarativeconfig/lint"
 	"gopkg.in/yaml.v3"
@@ -46,6 +47,8 @@ func permissionSetCommand(cliEnvironment environment.Environment) *cobra.Command
 Note: Capitalization matters!`)
 
 	cmd.MarkFlagsRequiredTogether("name", "resource-with-access")
+
+	flags.HideInheritedFlags(cmd, k8sobject.ConfigMapFlag, k8sobject.NamespaceFlag)
 
 	return cmd
 }

--- a/roxctl/declarativeconfig/create/role.go
+++ b/roxctl/declarativeconfig/create/role.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/pkg/declarativeconfig"
 	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/rox/roxctl/common/environment"
+	"github.com/stackrox/rox/roxctl/common/flags"
 	"github.com/stackrox/rox/roxctl/declarativeconfig/k8sobject"
 	"github.com/stackrox/rox/roxctl/declarativeconfig/lint"
 	"gopkg.in/yaml.v3"
@@ -42,6 +43,8 @@ func roleCommand(cliEnvironment environment.Environment) *cobra.Command {
 	utils.Must(cmd.MarkFlagRequired("name"))
 	utils.Must(cmd.MarkFlagRequired("access-scope"))
 	utils.Must(cmd.MarkFlagRequired("permission-set"))
+
+	flags.HideInheritedFlags(cmd, k8sobject.ConfigMapFlag, k8sobject.NamespaceFlag)
 	return cmd
 }
 

--- a/roxctl/declarativeconfig/declarativeconfig.go
+++ b/roxctl/declarativeconfig/declarativeconfig.go
@@ -3,6 +3,7 @@ package declarativeconfig
 import (
 	"github.com/spf13/cobra"
 	"github.com/stackrox/rox/roxctl/common/environment"
+	"github.com/stackrox/rox/roxctl/common/flags"
 	"github.com/stackrox/rox/roxctl/declarativeconfig/create"
 	"github.com/stackrox/rox/roxctl/declarativeconfig/lint"
 )
@@ -17,6 +18,8 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 		create.Command(cliEnvironment),
 		lint.Command(cliEnvironment),
 	)
+
+	flags.HideInheritedFlags(cmd)
 
 	return cmd
 }

--- a/roxctl/declarativeconfig/lint/lint.go
+++ b/roxctl/declarativeconfig/lint/lint.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stackrox/rox/pkg/declarativeconfig/transform"
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/roxctl/common/environment"
+	"github.com/stackrox/rox/roxctl/common/flags"
 	"github.com/stackrox/rox/roxctl/declarativeconfig/k8sobject"
 )
 
@@ -44,6 +45,8 @@ In case this is not set, the namespace set within the current kube config contex
 	cmd.MarkFlagsMutuallyExclusive("file", k8sobject.ConfigMapFlag)
 	cmd.MarkFlagsMutuallyExclusive("file", k8sobject.SecretFlag)
 	cmd.MarkFlagsMutuallyExclusive(k8sobject.ConfigMapFlag, k8sobject.SecretFlag)
+
+	flags.HideInheritedFlags(cmd)
 
 	return cmd
 }

--- a/roxctl/logconvert/logconvert.go
+++ b/roxctl/logconvert/logconvert.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/roxctl/common/environment"
+	"github.com/stackrox/rox/roxctl/common/flags"
 	"github.com/stackrox/rox/roxctl/common/util"
 )
 
@@ -50,6 +51,8 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 
 	c.Flags().StringVar(&module, "module", "logconvert", "Specifies the module for logging purposes")
 	c.Flags().StringVar(&levelLabel, "level", "info", "Specifies the log level in {error, warn, info, debug}")
+
+	flags.HideInheritedFlags(c)
 
 	return c
 }

--- a/roxctl/maincommand/command.go
+++ b/roxctl/maincommand/command.go
@@ -48,6 +48,7 @@ func versionCommand(cliEnvironment environment.Environment) *cobra.Command {
 		},
 	}
 	c.PersistentFlags().Bool("json", false, "display extended version information as JSON")
+	flags.HideInheritedFlags(c)
 	return c
 }
 


### PR DESCRIPTION
## Description

This PR refactors the currently global flags on the `roxctl` command.

Instead of exposing flags related to central connectivity (e.g. endpoint, protocol choice etc.) to _all_ roxctl commands, instead only expose it to commands which use it (or respectively, their subcommands).

The reason for this is that the by default created persistent flags about central connectivity (endpoint, grpc type etc.), may become confusing for clients using subtree of commands where central connectivity is not required.

Additionally, it lead to some of the flags to be less discoverable that are defined as persistent flags (i.e. the config map flags, the shared flags for auth provider types for `roxctl declarative-config create`).

Additionally all scripts have been adjusted which specified `roxctl -e <>`, since the flag now must be passed _after_ the command which provides the global flag has been passed (e.g. `roxctl central -e <>`

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

- see CI
