### PR TITLE
Add flock to DB initialization

### DIFF
--- a/image/postgres/scripts/docker-entrypoint.sh
+++ b/image/postgres/scripts/docker-entrypoint.sh
@@ -344,7 +344,7 @@ _main() {
 		fi
 	fi
 
-	flock -n /var/lib/postgresql/data/pglock "$@" &
+	flock /var/lib/postgresql/data/pglock "$@" &
 	child=$!
 	echo "Waiting for child process $child to exit"
 	wait "$child"

--- a/image/postgres/scripts/docker-entrypoint.sh
+++ b/image/postgres/scripts/docker-entrypoint.sh
@@ -344,7 +344,7 @@ _main() {
 		fi
 	fi
 
-	"$@" &
+	flock -n /var/lib/postgresql/data/pglock "$@" &
 	child=$!
 	echo "Waiting for child process $child to exit"
 	wait "$child"


### PR DESCRIPTION
## Description

Add flock to the DB initialization to avoid multiple instances using the mount at the same time. RWO volumes can have multiple pods on the same node utilize a mount point. This has lead to potential overlap of postgres processes that lead to corruption as they are both accessing the data at the same time (one is shutting down and the other is starting up). Reference https://github.com/kubernetes/kubernetes/issues/29855#issuecomment-384099479. This may also just occur on GCP

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

No corruption so far on runs with flock
