### PR TITLE
Add image components table to ImageCVE expanded table rows

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedImagesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedImagesTable.tsx
@@ -95,6 +95,7 @@ export const imagesForCveFragment = gql`
             fixedIn
             location
             layerIndex
+            # TODO I think we can drop this sub-resolver
             imageVulnerabilities(query: $query) {
                 severity # same for all components in an image
                 fixedByVersion

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedImagesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedImagesTable.tsx
@@ -21,6 +21,7 @@ import { getDistanceStrictAsPhrase } from 'utils/dateUtils';
 
 import { DynamicColumnIcon } from '../DynamicIcon';
 import { getEntityPagePath } from '../searchUtils';
+import ImageComponentsTable from './ImageComponentsTable';
 
 export type ImageForCve = {
     id: string;
@@ -46,8 +47,10 @@ export type ImageForCve = {
     } | null;
     imageComponentCount: number;
     imageComponents: {
+        id: string;
         name: string;
         version: string;
+        fixedIn: string;
         location: string;
         layerIndex: number | null;
         imageVulnerabilities: {
@@ -86,8 +89,10 @@ export const imagesForCveFragment = gql`
 
         imageComponentCount(query: $query)
         imageComponents(query: $query, pagination: $imageComponentPagination) {
+            id
             name
             version
+            fixedIn
             location
             layerIndex
             imageVulnerabilities(query: $query) {
@@ -132,7 +137,15 @@ function AffectedImagesTable({ images, getSortParams, isFiltered }: AffectedImag
             </Thead>
             {images.map(
                 (
-                    { id, name, operatingSystem, scanTime, topImageVulnerability, imageComponents },
+                    {
+                        id,
+                        name,
+                        metadata,
+                        operatingSystem,
+                        scanTime,
+                        topImageVulnerability,
+                        imageComponents,
+                    },
                     rowIndex
                 ) => {
                     const topSeverity =
@@ -208,8 +221,13 @@ function AffectedImagesTable({ images, getSortParams, isFiltered }: AffectedImag
                             </Tr>
                             <Tr isExpanded={isExpanded}>
                                 <Td />
-                                <Td colSpan={5}>
-                                    <ExpandableRowContent>TODO</ExpandableRowContent>
+                                <Td colSpan={6}>
+                                    <ExpandableRowContent>
+                                        <ImageComponentsTable
+                                            layers={metadata?.v1?.layers ?? []}
+                                            imageComponents={imageComponents}
+                                        />
+                                    </ExpandableRowContent>
                                 </Td>
                             </Tr>
                         </Tbody>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageComponentsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageComponentsTable.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { CodeBlock, CodeBlockCode } from '@patternfly/react-core';
+import { CodeBlock, CodeBlockCode, Flex } from '@patternfly/react-core';
 import { TableComposable, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
+import { NotFixableIcon } from 'Components/PatternFly/FixabilityIcons';
 import { ImageMetadataLayer, ImageVulnerabilityComponent } from '../hooks/useImageVulnerabilities';
 
 export type ImageComponentsTableProps = {
@@ -11,7 +12,13 @@ export type ImageComponentsTableProps = {
 
 function ImageComponentsTable({ layers, imageComponents }: ImageComponentsTableProps) {
     return (
-        <TableComposable borders={false}>
+        <TableComposable
+            className="pf-u-p-md"
+            style={{
+                border: '1px solid var(--pf-c-table--BorderColor)',
+            }}
+            borders={false}
+        >
             <Thead>
                 <Tr>
                     <Th>Component</Th>
@@ -21,12 +28,15 @@ function ImageComponentsTable({ layers, imageComponents }: ImageComponentsTableP
                 </Tr>
             </Thead>
             {imageComponents.map(({ id, name, version, fixedIn, location, layerIndex }) => {
-                let dockerfileText = `* Dockerfile layer information is not available *`;
+                let dockerfileText = `Dockerfile layer information is not available`;
 
                 if (layerIndex !== null) {
                     const layer = layers[layerIndex];
                     if (layer) {
-                        dockerfileText = `${layer.instruction} ${layer.value}`;
+                        // Convert the zero-based layer index to a one-based layer number in the instruction
+                        dockerfileText = `${layerIndex + 1} ${layer.instruction} ${'     '} ${
+                            layer.instruction
+                        } ${layer.value}`;
                     }
                 }
                 return (
@@ -39,8 +49,18 @@ function ImageComponentsTable({ layers, imageComponents }: ImageComponentsTableP
                         <Tr>
                             <Td>{name}</Td>
                             <Td>{version}</Td>
-                            <Td>{fixedIn || 'TODO - why empty'}</Td>
-                            <Td>{location || 'TODO - why empty'}</Td>
+                            <Td>
+                                {fixedIn || (
+                                    <Flex
+                                        alignItems={{ default: 'alignItemsCenter' }}
+                                        spaceItems={{ default: 'spaceItemsSm' }}
+                                    >
+                                        <NotFixableIcon />
+                                        <span>Not fixable</span>
+                                    </Flex>
+                                )}
+                            </Td>
+                            <Td>{location || 'N/A'}</Td>
                         </Tr>
                         <Tr>
                             <Td colSpan={4} className="pf-u-pt-0">

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/SingleEntityVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/SingleEntityVulnerabilitiesTable.tsx
@@ -118,18 +118,11 @@ function SingleEntityVulnerabilitiesTable({
                                 <Td />
                                 <Td colSpan={5}>
                                     <ExpandableRowContent>
-                                        <p>{summary}</p>
-                                        <div
-                                            className="pf-u-p-md pf-u-mt-md"
-                                            style={{
-                                                border: '1px solid var(--pf-c-table--BorderColor)',
-                                            }}
-                                        >
-                                            <ImageComponentsTable
-                                                layers={image.metadata?.v1?.layers ?? []}
-                                                imageComponents={imageComponents}
-                                            />
-                                        </div>
+                                        <p className="pf-u-mb-md">{summary}</p>
+                                        <ImageComponentsTable
+                                            layers={image.metadata?.v1?.layers ?? []}
+                                            imageComponents={imageComponents}
+                                        />
                                     </ExpandableRowContent>
                                 </Td>
                             </Tr>


### PR DESCRIPTION
## Description

WIP - Needs work - likely depends on changes to the Image single page query to work cleanly. e.g. The component and vulnerabilities resolvers need to be flipped in that component.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
