### PR TITLE
Provide sufficient color contrast in classic pagination

### DIFF
--- a/ui/apps/platform/src/Components/TablePagination.js
+++ b/ui/apps/platform/src/Components/TablePagination.js
@@ -68,16 +68,13 @@ const TablePagination = ({ dataLength, setPage, page, pageSize }) => {
     // useEffect(resetPage, [searchOptions]);
 
     return (
-        <div
-            data-testid="pagination-header"
-            className="flex items-center justify-end text-base-500 font-500"
-        >
+        <div data-testid="pagination-header" className="flex items-center justify-end">
             <div className="flex items-center pl-5">
-                <div className="mr-4 font-600 min-w-24">
+                <div className="mr-4 min-w-24">
                     Page
                     <input
                         type="number"
-                        className="text-center bg-base-100 text-base-900 border-2 border-base-300 px-1 py-1 mx-2 focus:border-primary-100 outline-none"
+                        className="text-center bg-base-100 text-base-600 border-2 border-base-300 px-1 py-1 mx-2 focus:border-primary-100 outline-none"
                         value={localPage}
                         min={1}
                         max={totalPages}
@@ -90,7 +87,7 @@ const TablePagination = ({ dataLength, setPage, page, pageSize }) => {
                 </div>
                 <button
                     type="button"
-                    className="flex items-center rounded-full hover:bg-primary-200 hover:text-primary-600 mr-1 p-1"
+                    className="flex items-center rounded-full text-base-600 hover:bg-primary-200 hover:text-primary-600 mr-1 p-1"
                     onClick={previousPage}
                     disabled={page <= 0}
                     aria-label="Go to previous page"


### PR DESCRIPTION
## Description

### Problem

Solve serious issue from axe DevTools on classic pages which have paginated tables

> Elements must have sufficient color contrast

### Analysis

Light mode contrast ratio is less than 4.5

| class | hex | ratio |
| ---: | ---: | ---: |
| `text-base-500` | `#a1a1a1` | 2.58 |
| `text-base-600` | `#6e6e6e` | 5.09 |

Dark mode contrast ratio is sufficient but see below

### Solution

1. Inherit color and font-weight from ancestor page style.
    * Delete `text-base-500 font-500` from `div` element.

2. Specify color for elements that have PatternFly style rules:
    * Replace `text-base-900` with `text-base-600` for `input` element.
    * Add `text-base-600` for first `button` element, especially to prevent inconsistency from seeming to imply enabled versus disabled state. Even worse, absence of class caused the button to (seem to) disappear in dark mode!

3. Delete `font-600` which is redundant with rule for classic pages.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added

## Testing Performed

**Light** mode with **insufficient** contrast and **inconsistent** disabled button color
![light-problem](https://user-images.githubusercontent.com/11862657/228960140-83e5f4da-5991-46aa-b0be-7029c3a02ed3.png)

**Light** mode with **sufficient** contrast and both with correct **disabled** color
![light-solution](https://user-images.githubusercontent.com/11862657/228960150-a9efdc10-8887-44c1-b08c-b2a394e36156.png)

**Light** mode with sufficient contrast and correct **disabled** versus **enabled** color
![light-solution-disabled-enabled](https://user-images.githubusercontent.com/11862657/228960166-cf4aff6d-5e03-4308-8693-99f903013874.png)

**Dark** mode with sufficient contrast but **first** button seems **invisible**
![dark-problem](https://user-images.githubusercontent.com/11862657/228960071-5146f09e-8ae9-4241-a193-fb13ccfcdb0f.png)

**Dark** mode with sufficient contrast and **both** buttons are **visible**
![dark-solution](https://user-images.githubusercontent.com/11862657/228960114-8989d883-beeb-451e-9420-eed8007a0ddd.png)

We could multiple the following case analysis with lists on tabs of single pages.

### Compliance

/main/compliance/clusters
/main/compliance/namespaces
/main/compliance/nodes
/main/compliance/deployments

### Vulnerability Management

/main/vulnerability-management/image-cves
/main/vulnerability-management/node-cves
/main/vulnerability-management/cluster-cves
/main/vulnerability-management/policies
/main/vulnerability-management/nodes
/main/vulnerability-management/images
/main/vulnerability-management/clusters
/main/vulnerability-management/namespaces
/main/vulnerability-management/deployments
/main/vulnerability-management/node-components
/main/vulnerability-management/image-components

### Configuration Management

/main/configmanagement/policies
/main/configmanagement/controls
/main/configmanagement/clusters
/main/configmanagement/namespaces
/main/configmanagement/nodes
/main/configmanagement/deployments
/main/configmanagement/images
/main/configmanagement/secrets
/main/configmanagement/subjects
/main/configmanagement/serviceaccounts
/main/configmanagement/roles

### Other

/main/risk
/main/clusters