### PR TITLE
ROX-15448: Add security context to containers displayed in details of NG 2.0

### DIFF
--- a/ui/apps/platform/src/Components/DeploymentContainerConfig.tsx
+++ b/ui/apps/platform/src/Components/DeploymentContainerConfig.tsx
@@ -8,6 +8,7 @@ import ContainerVolumesInfo from 'Components/ContainerVolumesInfo';
 import ContainerSecretsInfo from 'Components/ContainerSecretsInfo';
 import ContainerArgumentsInfo from 'Components/ContainerArgumentsInfo';
 import ContainerCommandInfo from 'Components/ContainerCommandInfo';
+import SecurityContext from 'Components/SecurityContext';
 
 type DeploymentContainerConfigProps = {
     container: Container;
@@ -49,6 +50,9 @@ function DeploymentContainerConfig({ container }: DeploymentContainerConfigProps
                 </StackItem>
                 <StackItem>
                     <ContainerCommandInfo command={container.config.command} />
+                </StackItem>
+                <StackItem>
+                    <SecurityContext securityContext={container.securityContext} />
                 </StackItem>
             </Stack>
         </ExpandableSection>

--- a/ui/apps/platform/src/Components/SecurityContext.tsx
+++ b/ui/apps/platform/src/Components/SecurityContext.tsx
@@ -18,12 +18,10 @@ type SecurityContextProps = {
 };
 
 function SecurityContext({ securityContext }: SecurityContextProps) {
-    // build a map of only those properties that actually have values
-
-    // sort the keys of the prop, so that the map is in alpha order
+    // sort the keys of the security context, so any properties are shown in alpha order
     const sortedKeys = Object.keys(securityContext).sort();
 
-    //
+    // build a map of only those properties that actually have values
     const filteredValues = new Map();
     sortedKeys.forEach((key) => {
         const currentValue = securityContext[key];

--- a/ui/apps/platform/src/Components/SecurityContext.tsx
+++ b/ui/apps/platform/src/Components/SecurityContext.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { isEmpty } from 'lodash';
+import {
+    Card,
+    CardBody,
+    CardTitle,
+    DescriptionList,
+    DescriptionListDescription,
+    DescriptionListGroup,
+    DescriptionListTerm,
+    EmptyState,
+} from '@patternfly/react-core';
+
+import { ContainerSecurityContext } from 'types/deployment.proto';
+
+type SecurityContextProps = {
+    securityContext: ContainerSecurityContext;
+};
+
+function SecurityContext({ securityContext }: SecurityContextProps) {
+    // build a map of only those properties that actually have values
+
+    // sort the keys of the prop, so that the map is in alpha order
+    const sortedKeys = Object.keys(securityContext).sort();
+
+    //
+    const filteredValues = new Map();
+    sortedKeys.forEach((key) => {
+        const currentValue = securityContext[key];
+
+        if (Array.isArray(currentValue) && !isEmpty(currentValue)) {
+            // ensure any array has elements
+            const stringifiedArray = currentValue.toString();
+            filteredValues.set(key, stringifiedArray);
+        } else if (
+            // ensure any object value has at least one property that has a value
+            typeof currentValue === 'object' &&
+            currentValue && // guard against typeof NULL === 'object' bug
+            Object.keys(currentValue).some((subKey) => currentValue[subKey])
+        ) {
+            try {
+                const stringifiedObject = JSON.stringify(currentValue);
+                filteredValues.set(key, stringifiedObject);
+            } catch (err) {
+                filteredValues.set(key, currentValue.toString()); // fallback, if corrupt data prevent JSON parsing
+            }
+        } else if (!Array.isArray(currentValue) && (currentValue || currentValue === 0)) {
+            // otherwise, check for truthy or numeric 0
+            const stringifiedPrimitive = currentValue.toString();
+            filteredValues.set(key, stringifiedPrimitive);
+        }
+    });
+
+    return (
+        <Card>
+            <CardTitle>Security context</CardTitle>
+            <CardBody className="pf-u-background-color-200 pf-u-pt-xl pf-u-mx-lg pf-u-mb-lg">
+                {filteredValues.size > 0 ? (
+                    <DescriptionList columnModifier={{ default: '2Col' }} isCompact>
+                        {Array.from(filteredValues.entries()).map(([key, value]) => {
+                            return (
+                                <DescriptionListGroup>
+                                    <DescriptionListTerm>{key}</DescriptionListTerm>
+                                    <DescriptionListDescription>{value}</DescriptionListDescription>
+                                </DescriptionListGroup>
+                            );
+                        })}
+                    </DescriptionList>
+                ) : (
+                    <EmptyState>No container security context</EmptyState>
+                )}
+            </CardBody>
+        </Card>
+    );
+}
+
+export default SecurityContext;

--- a/ui/apps/platform/src/Components/SecurityContext.tsx
+++ b/ui/apps/platform/src/Components/SecurityContext.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { isEmpty } from 'lodash';
 import {
     Card,
     CardBody,
@@ -12,42 +11,14 @@ import {
 } from '@patternfly/react-core';
 
 import { ContainerSecurityContext } from 'types/deployment.proto';
+import { getFilteredSecurityContextMap } from 'utils/securityContextUtils';
 
 type SecurityContextProps = {
     securityContext: ContainerSecurityContext;
 };
 
 function SecurityContext({ securityContext }: SecurityContextProps) {
-    // sort the keys of the security context, so any properties are shown in alpha order
-    const sortedKeys = Object.keys(securityContext).sort();
-
-    // build a map of only those properties that actually have values
-    const filteredValues = new Map();
-    sortedKeys.forEach((key) => {
-        const currentValue = securityContext[key];
-
-        if (Array.isArray(currentValue) && !isEmpty(currentValue)) {
-            // ensure any array has elements
-            const stringifiedArray = currentValue.toString();
-            filteredValues.set(key, stringifiedArray);
-        } else if (
-            // ensure any object value has at least one property that has a value
-            typeof currentValue === 'object' &&
-            currentValue && // guard against typeof NULL === 'object' bug
-            Object.keys(currentValue).some((subKey) => currentValue[subKey])
-        ) {
-            try {
-                const stringifiedObject = JSON.stringify(currentValue);
-                filteredValues.set(key, stringifiedObject);
-            } catch (err) {
-                filteredValues.set(key, currentValue.toString()); // fallback, if corrupt data prevent JSON parsing
-            }
-        } else if (!Array.isArray(currentValue) && (currentValue || currentValue === 0)) {
-            // otherwise, check for truthy or numeric 0
-            const stringifiedPrimitive = currentValue.toString();
-            filteredValues.set(key, stringifiedPrimitive);
-        }
-    });
+    const filteredValues = getFilteredSecurityContextMap(securityContext);
 
     return (
         <Card>

--- a/ui/apps/platform/src/utils/securityContextUtils.test.js
+++ b/ui/apps/platform/src/utils/securityContextUtils.test.js
@@ -1,0 +1,69 @@
+import { getFilteredSecurityContextMap } from './securityContextUtils';
+
+describe('securityContextUtils', () => {
+    describe('getFilteredSecurityContextMap', () => {
+        it('should return an empty Map when there all security context values are falsy', () => {
+            const securityContext = {
+                privileged: false,
+                selinux: null,
+                dropCapabilities: [],
+                addCapabilities: [],
+                readOnlyRootFilesystem: false,
+                seccompProfile: null,
+                allowPrivilegeEscalation: false,
+            };
+
+            const filteredValues = getFilteredSecurityContextMap(securityContext);
+
+            expect(filteredValues.size).toEqual(0);
+        });
+
+        it('should return a Map of only those security context values which are set', () => {
+            const securityContext = {
+                privileged: false,
+                selinux: null,
+                dropCapabilities: [],
+                addCapabilities: [],
+                readOnlyRootFilesystem: true,
+                seccompProfile: null,
+                allowPrivilegeEscalation: false,
+            };
+
+            const filteredValues = getFilteredSecurityContextMap(securityContext);
+
+            const expectedMap = new Map();
+            expectedMap.set('readOnlyRootFilesystem', 'true');
+
+            expect(filteredValues).toEqual(expectedMap);
+        });
+
+        it('should return a Map which includes array and object security context values which are set', () => {
+            const securityContext = {
+                privileged: false,
+                selinux: {
+                    user: '',
+                    role: '',
+                    type: 'container_runtime_t',
+                    level: '',
+                },
+                dropCapabilities: ['NET_RAW', 'CAP_SYS_TIME'],
+                addCapabilities: [],
+                readOnlyRootFilesystem: true,
+                seccompProfile: null,
+                allowPrivilegeEscalation: false,
+            };
+
+            const filteredValues = getFilteredSecurityContextMap(securityContext);
+
+            const expectedMap = new Map();
+            expectedMap.set('readOnlyRootFilesystem', 'true');
+            expectedMap.set(
+                'selinux',
+                '{"user":"","role":"","type":"container_runtime_t","level":""}'
+            );
+            expectedMap.set('dropCapabilities', 'NET_RAW,CAP_SYS_TIME');
+
+            expect(filteredValues).toEqual(expectedMap);
+        });
+    });
+});

--- a/ui/apps/platform/src/utils/securityContextUtils.ts
+++ b/ui/apps/platform/src/utils/securityContextUtils.ts
@@ -1,0 +1,40 @@
+import { isEmpty } from 'lodash';
+
+import { ContainerSecurityContext } from 'types/deployment.proto';
+
+export function getFilteredSecurityContextMap(
+    securityContext: ContainerSecurityContext
+): Map<string, string> {
+    // sort the keys of the security context, so any properties are shown in alpha order
+    const sortedKeys = Object.keys(securityContext).sort();
+
+    // build a map of only those properties that actually have values
+    const filteredValues = new Map<string, string>();
+    sortedKeys.forEach((key) => {
+        const currentValue = securityContext[key];
+
+        if (Array.isArray(currentValue) && !isEmpty(currentValue)) {
+            // ensure any array has elements
+            const stringifiedArray = currentValue.toString();
+            filteredValues.set(key, stringifiedArray);
+        } else if (
+            // ensure any object value has at least one property that has a value
+            typeof currentValue === 'object' &&
+            currentValue && // guard against typeof NULL === 'object' bug
+            Object.keys(currentValue).some((subKey) => currentValue[subKey])
+        ) {
+            try {
+                const stringifiedObject = JSON.stringify(currentValue);
+                filteredValues.set(key, stringifiedObject);
+            } catch (err) {
+                filteredValues.set(key, currentValue.toString()); // fallback, if corrupt data prevent JSON parsing
+            }
+        } else if (!Array.isArray(currentValue) && (currentValue || currentValue === 0)) {
+            // otherwise, check for truthy or numeric 0
+            const stringifiedPrimitive = currentValue.toString();
+            filteredValues.set(key, stringifiedPrimitive);
+        }
+    });
+
+    return filteredValues;
+}


### PR DESCRIPTION
## Description

Revised requirements:

1. Because the only security context currently available in the Deployment API is at the container level, this ticket will focus on adding security context in each container section of the Deployment Details.
2. In the NG 1.0 implmentation, we limited the Security Context we showed to only Add Capabilities, Drop Capabilities, and Privileged. We will not impose that limit in this implementation–if a security context setting is not empty/null, we will show it.
3. We will not show security context settings that are empty/null.
4. If none of the security context settings are set, we will simply display "No security context

## Checklist
- [ ] Investigated and inspected CI test results


## Testing Performed

Manual testing

Examples (from the three containers within the StackRox `collector` pod

collector container:
<img width="1662" alt="Screen Shot 2023-03-30 at 5 04 34 PM" src="https://user-images.githubusercontent.com/715729/228965168-dd9e04de-e89f-4bec-bddd-d18e683b3020.png">


compliance container (a different set of securityContext settings):
<img width="1662" alt="Screen Shot 2023-03-30 at 5 04 48 PM" src="https://user-images.githubusercontent.com/715729/228965192-84452a6b-5e91-4095-b05c-7e572a725737.png">


node-inventory (no securityContext settings):
<img width="1662" alt="Screen Shot 2023-03-30 at 5 04 55 PM" src="https://user-images.githubusercontent.com/715729/228965217-03c2bd44-ab33-4bd0-a6a0-a21648eb3db9.png">
