### PR TITLE
Provide sufficient color contrast for placeholder in search filter

### DIFF
--- a/ui/apps/platform/cypress/constants/NetworkPage.js
+++ b/ui/apps/platform/cypress/constants/NetworkPage.js
@@ -62,7 +62,7 @@ export const selectors = {
     }),
     toolbar: scopeSelectors('[data-testid="network-graph-toolbar"]', {
         namespaceSelect: '.namespace-select > button',
-        filterSelect: search.multiSelectInput,
+        filterSelect: `${search.multiSelectInput}:not([readonly])`, // not input element for placeholder
     }),
     selector: scopeSelectors('[data-testid="network-graph-selector-bar"]', {
         clusterSelect: '.cluster-select > button',

--- a/ui/apps/platform/cypress/integration/risk/risk.test.js
+++ b/ui/apps/platform/cypress/integration/risk/risk.test.js
@@ -152,16 +152,13 @@ describe('Risk page', () => {
             viewRiskDeploymentInNetworkGraph();
         });
 
-        const searchPlaceholderText = 'Filter deployments';
+        const searchPlaceholderSelector = `${RiskPageSelectors.search.valueContainer} input[placeholder="Filter deployments"]`;
 
         it('should not have anything in search bar when URL has no search params', () => {
             visitRiskDeployments();
 
             // Positive assertion:
-            cy.get(RiskPageSelectors.search.valueContainer).should(
-                'have.text',
-                searchPlaceholderText
-            );
+            cy.get(searchPlaceholderSelector);
             // Negative assertion:
             cy.get(RiskPageSelectors.search.searchLabels).should('not.exist');
         });
@@ -179,10 +176,7 @@ describe('Risk page', () => {
                 visitRiskDeploymentsWithSearchQuery(`?s[${nsOption}]=${nsValue}`);
 
                 // Negative assertion:
-                cy.get(RiskPageSelectors.search.valueContainer).should(
-                    'not.have.text',
-                    searchPlaceholderText
-                );
+                cy.get(searchPlaceholderSelector).should('not.exist');
                 // Positive assertions:
                 cy.get(RiskPageSelectors.search.searchLabels).should('have.length', 2);
                 cy.get(`${RiskPageSelectors.search.searchLabels}:nth(0)`).should(
@@ -215,10 +209,7 @@ describe('Risk page', () => {
                 );
 
                 // Negative assertion:
-                cy.get(RiskPageSelectors.search.valueContainer).should(
-                    'not.have.text',
-                    searchPlaceholderText
-                );
+                cy.get(searchPlaceholderSelector).should('not.exist');
                 // Positive assertions:
                 cy.get(RiskPageSelectors.search.searchLabels).should('have.length', 4);
                 cy.get(`${RiskPageSelectors.search.searchLabels}:nth(0)`).should(
@@ -253,10 +244,7 @@ describe('Risk page', () => {
                 visitRiskDeploymentsWithSearchQuery(`?s[${sillyOption}]=${sillyValue}`);
 
                 // Positive assertion:
-                cy.get(RiskPageSelectors.search.valueContainer).should(
-                    'have.text',
-                    searchPlaceholderText
-                );
+                cy.get(searchPlaceholderSelector);
                 // Negative assertion:
                 cy.get(RiskPageSelectors.search.searchLabels).should('not.exist');
 

--- a/ui/apps/platform/src/Components/URLSearchInputWithAutocomplete.js
+++ b/ui/apps/platform/src/Components/URLSearchInputWithAutocomplete.js
@@ -17,10 +17,15 @@ const borderClass = 'border border-primary-300';
 const categoryOptionClass = `bg-primary-200 text-primary-700 ${borderClass}`;
 const valueOptionClass = `bg-base-200 text-base-600 ${borderClass}`;
 
+// Render readonly input with placeholder instead of span to prevent insufficient color contrast.
 export const placeholderCreator = (placeholderText) => () =>
     (
-        <span className="text-base-500 flex h-full items-center pointer-events-none">
-            <span className="font-600 absolute text-lg">{placeholderText}</span>
+        <span className="flex h-full items-center pointer-events-none">
+            <input
+                className="font-600 bg-base-100 text-base-600 absolute"
+                placeholder={placeholderText}
+                readOnly
+            />
         </span>
     );
 


### PR DESCRIPTION
## Description

### Problem

Solve serious issue from axe DevTools on classic and PatternFly pages which have search filter

> Elements must have sufficient color contrast

### Analysis

Contrast ratio of `text-base-500` is less than 4.5

| mode | foreground | background | ratio |
| :--- | ---: | ---: | ---: |
| light | `#a1a1a1` | `#ffffff` | 2.58 |
| dark | `#6e6e6e` | `#3b3b3b` | 4.33 |

### Solution

Because axe DevTools does not require the same color contrast for placeholder text as for ordinary text, replace `span` with `input` element that has `placeholder` and `readonly` attributes.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed

Also verified on Safari 16.3 and Firefox Developer Edition 110.0b8

**Light** mode insufficient contrast with `span` element
![light-span](https://user-images.githubusercontent.com/11862657/228991841-bb56e18a-c4f0-4442-9235-59f08a9a9972.png)

**Light** mode with `input` element
![light-input](https://user-images.githubusercontent.com/11862657/228991834-92b33675-47aa-48bd-9dbe-d53d664afc27.png)

**Dark** mode insufficient contrast with `span` element
![dark-span](https://user-images.githubusercontent.com/11862657/228991827-8c3c1b7f-02c2-4f49-887a-a0b9ed28722f.png)

**Dark** mode with `input` element
![dark-input](https://user-images.githubusercontent.com/11862657/228991811-09cbb58f-f5a3-40b8-b80a-93bdde09a232.png)

We could multiple the following case analysis with lists on tabs of single pages.

### Compliance

/main/compliance/clusters
/main/compliance/namespaces
/main/compliance/nodes
/main/compliance/deployments

### Vulnerability Management

/main/vulnerability-management/image-cves
/main/vulnerability-management/node-cves
/main/vulnerability-management/cluster-cves
/main/vulnerability-management/policies
/main/vulnerability-management/nodes
/main/vulnerability-management/images
/main/vulnerability-management/clusters
/main/vulnerability-management/namespaces
/main/vulnerability-management/deployments
/main/vulnerability-management/node-components
/main/vulnerability-management/image-components

### Configuration Management

/main/configmanagement/policies
/main/configmanagement/controls
/main/configmanagement/clusters
/main/configmanagement/namespaces
/main/configmanagement/nodes
/main/configmanagement/deployments
/main/configmanagement/images
/main/configmanagement/secrets
/main/configmanagement/subjects
/main/configmanagement/serviceaccounts
/main/configmanagement/roles

### Other

/main/risk
/main/clusters