### PR TITLE
Jv rox change name of process listening on ports table to listening endpoints

### DIFF
--- a/central/processlisteningonport/store/postgres/full_store.go
+++ b/central/processlisteningonport/store/postgres/full_store.go
@@ -33,7 +33,7 @@ type fullStoreImpl struct {
 // XXX: Verify the query plan to make sure needed indexes are in use.
 const getByDeploymentStmt = "SELECT plop.id, plop.serialized, " +
 	"proc.serialized as proc_serialized " +
-	"FROM process_listening_on_ports plop " +
+	"FROM listening_endpoints plop " +
 	"LEFT OUTER JOIN process_indicators proc " +
 	"ON plop.processindicatorid = proc.id " +
 	"WHERE plop.deploymentid = $1 AND plop.closed = false"

--- a/central/processlisteningonport/store/postgres/gen.go
+++ b/central/processlisteningonport/store/postgres/gen.go
@@ -1,3 +1,3 @@
 package postgres
 
-//go:generate pg-table-bindings-wrapper --type=storage.ProcessListeningOnPortStorage --references storage.ProcessIndicator,storage.Deployment --table=process_listening_on_ports --search-category PROCESS_LISTENING_ON_PORT
+//go:generate pg-table-bindings-wrapper --type=storage.ProcessListeningOnPortStorage --references storage.ProcessIndicator,storage.Deployment --table=listening_endpoints --search-category PROCESS_LISTENING_ON_PORT

--- a/central/processlisteningonport/store/postgres/store_test.go
+++ b/central/processlisteningonport/store/postgres/store_test.go
@@ -16,17 +16,17 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-type ProcessListeningOnPortsStoreSuite struct {
+type ListeningEndpointsStoreSuite struct {
 	suite.Suite
 	store  Store
 	testDB *pgtest.TestPostgres
 }
 
-func TestProcessListeningOnPortsStore(t *testing.T) {
-	suite.Run(t, new(ProcessListeningOnPortsStoreSuite))
+func TestListeningEndpointsStore(t *testing.T) {
+	suite.Run(t, new(ListeningEndpointsStoreSuite))
 }
 
-func (s *ProcessListeningOnPortsStoreSuite) SetupSuite() {
+func (s *ListeningEndpointsStoreSuite) SetupSuite() {
 	s.T().Setenv(env.PostgresDatastoreEnabled.EnvVar(), "true")
 
 	if !env.PostgresDatastoreEnabled.BooleanSetting() {
@@ -38,18 +38,18 @@ func (s *ProcessListeningOnPortsStoreSuite) SetupSuite() {
 	s.store = New(s.testDB.DB)
 }
 
-func (s *ProcessListeningOnPortsStoreSuite) SetupTest() {
+func (s *ListeningEndpointsStoreSuite) SetupTest() {
 	ctx := sac.WithAllAccess(context.Background())
-	tag, err := s.testDB.Exec(ctx, "TRUNCATE process_listening_on_ports CASCADE")
-	s.T().Log("process_listening_on_ports", tag)
+	tag, err := s.testDB.Exec(ctx, "TRUNCATE listening_endpoints CASCADE")
+	s.T().Log("listening_endpoints", tag)
 	s.NoError(err)
 }
 
-func (s *ProcessListeningOnPortsStoreSuite) TearDownSuite() {
+func (s *ListeningEndpointsStoreSuite) TearDownSuite() {
 	s.testDB.Teardown(s.T())
 }
 
-func (s *ProcessListeningOnPortsStoreSuite) TestStore() {
+func (s *ListeningEndpointsStoreSuite) TestStore() {
 	ctx := sac.WithAllAccess(context.Background())
 
 	store := s.store

--- a/pkg/postgres/schema/listening_endpoints.go
+++ b/pkg/postgres/schema/listening_endpoints.go
@@ -15,19 +15,19 @@ import (
 )
 
 var (
-	// CreateTableProcessListeningOnPortsStmt holds the create statement for table `process_listening_on_ports`.
-	CreateTableProcessListeningOnPortsStmt = &postgres.CreateStmts{
-		GormModel: (*ProcessListeningOnPorts)(nil),
+	// CreateTableListeningEndpointsStmt holds the create statement for table `listening_endpoints`.
+	CreateTableListeningEndpointsStmt = &postgres.CreateStmts{
+		GormModel: (*ListeningEndpoints)(nil),
 		Children:  []*postgres.CreateStmts{},
 	}
 
-	// ProcessListeningOnPortsSchema is the go schema for table `process_listening_on_ports`.
-	ProcessListeningOnPortsSchema = func() *walker.Schema {
-		schema := GetSchemaForTable("process_listening_on_ports")
+	// ListeningEndpointsSchema is the go schema for table `listening_endpoints`.
+	ListeningEndpointsSchema = func() *walker.Schema {
+		schema := GetSchemaForTable("listening_endpoints")
 		if schema != nil {
 			return schema
 		}
-		schema = walker.Walk(reflect.TypeOf((*storage.ProcessListeningOnPortStorage)(nil)), "process_listening_on_ports")
+		schema = walker.Walk(reflect.TypeOf((*storage.ProcessListeningOnPortStorage)(nil)), "listening_endpoints")
 		referencedSchemas := map[string]*walker.Schema{
 			"storage.ProcessIndicator": ProcessIndicatorsSchema,
 			"storage.Deployment":       DeploymentsSchema,
@@ -37,23 +37,23 @@ var (
 			return referencedSchemas[fmt.Sprintf("storage.%s", messageTypeName)]
 		})
 		schema.SetOptionsMap(search.Walk(v1.SearchCategory_PROCESS_LISTENING_ON_PORT, "processlisteningonportstorage", (*storage.ProcessListeningOnPortStorage)(nil)))
-		RegisterTable(schema, CreateTableProcessListeningOnPortsStmt)
+		RegisterTable(schema, CreateTableListeningEndpointsStmt)
 		mapping.RegisterCategoryToTable(v1.SearchCategory_PROCESS_LISTENING_ON_PORT, schema)
 		return schema
 	}()
 )
 
 const (
-	ProcessListeningOnPortsTableName = "process_listening_on_ports"
+	ListeningEndpointsTableName = "listening_endpoints"
 )
 
-// ProcessListeningOnPorts holds the Gorm model for Postgres table `process_listening_on_ports`.
-type ProcessListeningOnPorts struct {
+// ListeningEndpoints holds the Gorm model for Postgres table `listening_endpoints`.
+type ListeningEndpoints struct {
 	Id                 string             `gorm:"column:id;type:uuid;primaryKey"`
 	Port               uint32             `gorm:"column:port;type:bigint"`
 	Protocol           storage.L4Protocol `gorm:"column:protocol;type:integer"`
-	ProcessIndicatorId string             `gorm:"column:processindicatorid;type:uuid;index:processlisteningonports_processindicatorid,type:btree"`
-	Closed             bool               `gorm:"column:closed;type:bool;index:processlisteningonports_closed,type:btree"`
-	DeploymentId       string             `gorm:"column:deploymentid;type:uuid;index:processlisteningonports_deploymentid,type:btree"`
+	ProcessIndicatorId string             `gorm:"column:processindicatorid;type:uuid;index:listeningendpoints_processindicatorid,type:btree"`
+	Closed             bool               `gorm:"column:closed;type:bool;index:listeningendpoints_closed,type:btree"`
+	DeploymentId       string             `gorm:"column:deploymentid;type:uuid;index:listeningendpoints_deploymentid,type:btree"`
 	Serialized         []byte             `gorm:"column:serialized;type:bytea"`
 }


### PR DESCRIPTION
## Description

The purpose of this name change is to emphasize listening endpoints not processes.

## Checklist
- [x] Investigated and inspected CI test results (Two CI failures are in many other unrelated PRs)
- [x] Checked table name in postgres database.

If any of these don't apply, please comment below.

## Testing Performed

Logged into the postgres database and performed the following query

select * from listening_endpoints;