### PR TITLE
ROX-13935: Enable RHCOS FF & add a failsafe switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 - ROX-15102: new `public_config.telemetry` boolean property of the `/v1/config`
   endpoint request that allows for querying the state, enabling or disabling the
   configured telemetry collection.
+- ROX-10818: vulnerability scanning of node components installed through RPM on
+  OpenShift cluster nodes running Core OS (RHCOS).
+
 
 ### Removed Features
 

--- a/central/reprocessor/reprocessor_unit_test.go
+++ b/central/reprocessor/reprocessor_unit_test.go
@@ -9,7 +9,7 @@ import (
 	nodeDatastoreMocks "github.com/stackrox/rox/central/node/datastore/mocks"
 	riskManagerMocks "github.com/stackrox/rox/central/risk/manager/mocks"
 	"github.com/stackrox/rox/generated/storage"
-	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/env"
 	nodesEnricherMocks "github.com/stackrox/rox/pkg/nodes/enricher/mocks"
 )
 
@@ -69,7 +69,7 @@ func Test_loopImpl_reprocessNode(t *testing.T) {
 		},
 	}
 	t.Setenv("ROX_RHCOS_NODE_SCANNING", "true")
-	if !features.RHCOSNodeScanning.Enabled() {
+	if !env.RHCOSNodeScanning.BooleanSetting() {
 		t.Log("Assuming this is a release build, so skipping due to ROX_RHCOS_NODE_SCANNING=false")
 		return
 	}

--- a/central/sensor/service/pipeline/all/factory.go
+++ b/central/sensor/service/pipeline/all/factory.go
@@ -29,6 +29,7 @@ import (
 	"github.com/stackrox/rox/central/sensor/service/pipeline/roles"
 	"github.com/stackrox/rox/central/sensor/service/pipeline/secrets"
 	"github.com/stackrox/rox/central/sensor/service/pipeline/serviceaccounts"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/features"
 )
 
@@ -67,7 +68,7 @@ func (s *factoryImpl) PipelineForCluster(ctx context.Context, clusterID string) 
 		alerts.GetPipeline(),
 		auditlogstateupdate.GetPipeline(),
 	}
-	if features.RHCOSNodeScanning.Enabled() {
+	if env.RHCOSNodeScanning.BooleanSetting() {
 		pipelines = append(pipelines, nodeinventory.GetPipeline())
 	}
 	if features.ComplianceOperatorCheckResults.Enabled() {

--- a/central/sensor/service/pipeline/nodes/pipeline_test.go
+++ b/central/sensor/service/pipeline/nodes/pipeline_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stackrox/rox/central/sensor/service/common"
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
-	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/env"
 	nodesEnricherMocks "github.com/stackrox/rox/pkg/nodes/enricher/mocks"
 	"github.com/stretchr/testify/assert"
 )
@@ -98,7 +98,7 @@ func Test_pipelineImpl_Run(t *testing.T) {
 			},
 		},
 	}
-	if !features.RHCOSNodeScanning.Enabled() {
+	if !env.RHCOSNodeScanning.BooleanSetting() {
 		t.Log("Assuming this is a release build, so skipping due to ROX_RHCOS_NODE_SCANNING=false")
 		return
 	}

--- a/compliance/collection/main.go
+++ b/compliance/collection/main.go
@@ -19,7 +19,6 @@ import (
 	"github.com/stackrox/rox/pkg/clientconn"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/env"
-	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/k8sutil"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/metrics"
@@ -262,7 +261,7 @@ func main() {
 	var nodeInventoryClient scannerV1.NodeInventoryServiceClient
 	if !env.NodeInventoryContainerEnabled.BooleanSetting() {
 		log.Infof("Compliance will not call the node-inventory container, because this is not Openshift 4 cluster")
-	} else if features.RHCOSNodeScanning.Enabled() {
+	} else if env.RHCOSNodeScanning.BooleanSetting() {
 		// Start the prometheus metrics server
 		metrics.NewDefaultHTTPServer(metrics.ComplianceSubsystem).RunForever()
 		metrics.GatherThrottleMetricsForever(metrics.ComplianceSubsystem.String())
@@ -302,7 +301,7 @@ func main() {
 	go manageStream(ctx, cli, &stoppedSig, sensorC)
 
 	// TODO(ROX-13935): Remove FakeNodeInventory and its FF
-	if features.RHCOSNodeScanning.Enabled() && nodeInventoryClient != nil {
+	if env.RHCOSNodeScanning.BooleanSetting() && nodeInventoryClient != nil {
 		i := intervals.NewNodeScanIntervalFromEnv()
 		nodeInventoriesC := manageNodeScanLoop(ctx, i, nodeInventoryClient)
 

--- a/compliance/collection/main.go
+++ b/compliance/collection/main.go
@@ -300,7 +300,6 @@ func main() {
 	defer close(sensorC)
 	go manageStream(ctx, cli, &stoppedSig, sensorC)
 
-	// TODO(ROX-13935): Remove FakeNodeInventory and its FF
 	if env.RHCOSNodeScanning.BooleanSetting() && nodeInventoryClient != nil {
 		i := intervals.NewNodeScanIntervalFromEnv()
 		nodeInventoriesC := manageNodeScanLoop(ctx, i, nodeInventoryClient)

--- a/pkg/env/node_scan.go
+++ b/pkg/env/node_scan.go
@@ -3,6 +3,9 @@ package env
 import "time"
 
 var (
+	// RHCOSNodeScanning enables phase 1 functions of "Full host level vulnerability scanning for RHCOS nodes" (ROX-10818)
+	RHCOSNodeScanning = RegisterBooleanSetting("ROX_RHCOS_NODE_SCANNING", true)
+
 	// NodeScanningEndpoint is used to provide Compliance with the Node Scanner that is used to carry out Node Scans
 	NodeScanningEndpoint = RegisterSetting("ROX_NODE_SCANNING_ENDPOINT", WithDefault("127.0.0.1:8444"))
 

--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -31,9 +31,6 @@ var (
 	// NetworkGraphPatternFly enables the PatternFly version of NetworkGraph. (used in the front-end app only)
 	NetworkGraphPatternFly = registerFeature("Enable PatternFly version of NetworkGraph", "ROX_NETWORK_GRAPH_PATTERNFLY", true)
 
-	// RHCOSNodeScanning enables phase 1 functions of "Full host level vulnerability scanning for RHCOS nodes" (ROX-10818)
-	RHCOSNodeScanning = registerFeature("Enable RHCOS node scanning of OS and installed packages", "ROX_RHCOS_NODE_SCANNING", false)
-
 	// UseFakeNodeInventory tells compliance to use FakeNodeScanner with hardcoded data instead of calling scanner.Analyze()
 	// TODO(ROX-13935): Remove this FF and the accompanying code
 	UseFakeNodeInventory = registerFeature("Enables compliance to use FakeNodeScanner with hardcoded data instead of calling scanner.Analyze()", "ROX_RHCOS_FAKE_NODE_INVENTORY", false)

--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -31,10 +31,6 @@ var (
 	// NetworkGraphPatternFly enables the PatternFly version of NetworkGraph. (used in the front-end app only)
 	NetworkGraphPatternFly = registerFeature("Enable PatternFly version of NetworkGraph", "ROX_NETWORK_GRAPH_PATTERNFLY", true)
 
-	// UseFakeNodeInventory tells compliance to use FakeNodeScanner with hardcoded data instead of calling scanner.Analyze()
-	// TODO(ROX-13935): Remove this FF and the accompanying code
-	UseFakeNodeInventory = registerFeature("Enables compliance to use FakeNodeScanner with hardcoded data instead of calling scanner.Analyze()", "ROX_RHCOS_FAKE_NODE_INVENTORY", false)
-
 	// ProcessesListeningOnPort enables the NetworkFlow code to also update the processes that are listening on ports
 	ProcessesListeningOnPort = registerFeature("Enable Processes Listening on Port", "ROX_PROCESSES_LISTENING_ON_PORT", false)
 

--- a/pkg/nodes/enricher/enricher_impl.go
+++ b/pkg/nodes/enricher/enricher_impl.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/errorhelpers"
-	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/nodes/converter"
 	pkgScanners "github.com/stackrox/rox/pkg/scanners"
 	"github.com/stackrox/rox/pkg/scanners/types"
@@ -229,7 +228,7 @@ var nodeScanningOSImagePrefixes = []string{"Red Hat Enterprise Linux CoreOS"}
 
 // SupportsNodeScanning returns if the provided node object supports full host node scanning.
 func SupportsNodeScanning(node *storage.Node) bool {
-	if !features.RHCOSNodeScanning.Enabled() {
+	if !env.RHCOSNodeScanning.BooleanSetting() {
 		return false
 	}
 	for _, osPrefix := range nodeScanningOSImagePrefixes {

--- a/sensor/common/compliance/service_impl.go
+++ b/sensor/common/compliance/service_impl.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stackrox/rox/generated/internalapi/compliance"
 	"github.com/stackrox/rox/generated/internalapi/sensor"
 	"github.com/stackrox/rox/generated/storage"
-	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/grpc/authz/idcheck"
 	"github.com/stackrox/rox/pkg/k8sutil"
 	"github.com/stackrox/rox/pkg/sync"
@@ -145,7 +145,7 @@ func (s *serviceImpl) Communicate(server sensor.ComplianceService_CommunicateSer
 			s.auditEvents <- t.AuditEvents
 			s.auditLogCollectionManager.AuditMessagesChan() <- msg
 		case *sensor.MsgFromCompliance_NodeInventory:
-			if features.RHCOSNodeScanning.Enabled() {
+			if env.RHCOSNodeScanning.BooleanSetting() {
 				s.nodeInventories <- t.NodeInventory
 			}
 		}

--- a/sensor/kubernetes/sensor/sensor.go
+++ b/sensor/kubernetes/sensor/sensor.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stackrox/rox/pkg/clusterid"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/expiringcache"
-	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/grpc"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/namespaces"
@@ -138,7 +137,7 @@ func CreateSensor(cfg *CreateOptions) (*sensor.Sensor, error) {
 		auditLogCollectionManager,
 		reprocessorHandler,
 	}
-	if features.RHCOSNodeScanning.Enabled() {
+	if env.RHCOSNodeScanning.BooleanSetting() {
 		matcher := compliance.NewNodeIDMatcher(storeProvider.Nodes())
 		components = append(components, compliance.NewNodeInventoryHandler(complianceService.NodeInventories(), matcher))
 	}


### PR DESCRIPTION
## Description

This PR changes the RHCOS NodeScanning feature flag to an env variable, that is *enabled* by default.
We keep the env variable in order to have a possibility to disable the feature in case something unexpected would happen.

Moreover, we remove the no longer used FakeNodeScanner from this repo (it still needs to be removed from the scanner repo).

⚠️ We need a similar PR for the Scanner repo ⚠️ 

## Checklist
- [x] Investigated and inspected CI test results
- [x] Evaluated and added CHANGELOG entry if required ⚠️ 👉 please review the changelog entry for the feature

### N/A

- [ ] Unit test and regression tests added
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

- [ ] CI

