### PR TITLE
Remove redundancy from alt attribute in integration tile images

### DIFF
--- a/ui/apps/platform/src/Containers/Integrations/IntegrationTilesPage/IntegrationTile.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationTilesPage/IntegrationTile.tsx
@@ -35,10 +35,10 @@ function IntegrationTile({
 
     return (
         <Link to={linkTo} data-testid="integration-tile">
-            <Card isHoverable isCompact isFlat style={styleCard}>
+            <Card isSelectableRaised isCompact isFlat style={styleCard}>
                 <CardHeader className="pf-u-mb-lg">
                     <CardHeaderMain>
-                        <img src={image} alt={label} style={{ height: '100px' }} />
+                        <img src={image} alt="" style={{ height: '100px' }} />
                     </CardHeaderMain>
                     <CardActions>
                         {numIntegrations > 0 && <Badge>{numIntegrations}</Badge>}


### PR DESCRIPTION
## Description

### Problem

Solve minor issue from axe DevTools on Integrations page:

> Alternative image alternative is not repeated as text

https://dequeuniversity.com/rules/axe/4.6/image-redundant-alt?application=AxeChrome

For example, given the icon markup `<img alt="Home Page"/>`, the adjacent text also says "Home Page".

In such a scenario, a screen reader will announce this content to the user as "Home Page Home Page". The redundancy is unnecessary and potentially confusing.

In this scenario, the icon image's `alt` attribute value is better left empty by setting `alt=""`.

### Analysis

Hard to say why axe DevTools reports the problem for only 14 of the images.

### Solution

1. Replace `alt={label}` with `alt=""` prop.

2. Replace deprecated `isHoverable` with `isSelectableRaised` prop

    https://www.patternfly.org/v4/components/card#card

    > to make a card hoverable, use isSelectable or isSelectableRaised

    > Specifies the card is selectable, and applies the new raised styling on hover and select

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

### Manual testing

With `alt` attribute that is repeated as text:
![with_redundant_alt](https://user-images.githubusercontent.com/11862657/229154977-22894903-1cdd-4852-8719-efbcabf2313e.png)

With `alt` attribute that is empty instead of repeated as text:
![with_empty_alt](https://user-images.githubusercontent.com/11862657/229154931-5a9627fc-41f5-4889-9630-3b935853b271.png)

With `isSelectableRaised` prop blue line at bottom edge in addition to hover shadow:
![isSelectableRaised](https://user-images.githubusercontent.com/11862657/229154908-035faf8f-7dea-4c8e-96a9-0a9cff0f4e9f.png)

### Integration testing

1. `yarn start` in ui folder
2. `yarn cypress-open` in ui/apps/platform folder
    * integrations/general.test.js