### PR TITLE
Provide aria-label for ColorPicker button in System Configuration

### DIFF
--- a/ui/apps/platform/cypress/integration/systemConfig/systemConfig.selectors.js
+++ b/ui/apps/platform/cypress/integration/systemConfig/systemConfig.selectors.js
@@ -5,7 +5,8 @@ export const selectors = {
         config: {
             toggle: '[data-testid="header-config"] .pf-c-switch input',
             textInput: '[data-testid="header-config"] textarea',
-            colorPickerBtn: '[data-testid="header-config"] [data-testid="color-picker"]',
+            backgroundColorPickerButton: 'button[aria-label="Background color of header"]',
+            colorPickerButton: 'button[aria-label="Text color of header"]',
             colorInput: '[data-testid="header-config"] .chrome-picker input',
             size: {
                 input: '[data-testid="header-config"] .pf-c-select button',
@@ -20,7 +21,8 @@ export const selectors = {
         config: {
             toggle: '[data-testid="footer-config"] .pf-c-switch input',
             textInput: '[data-testid="footer-config"] textarea',
-            colorPickerBtn: '[data-testid="footer-config"] [data-testid="color-picker"]',
+            backgroundColorPickerButton: 'button[aria-label="Background color of footer"]',
+            colorPickerButton: 'button[aria-label="Text color of footer"]',
             colorInput: '[data-testid="footer-config"] .chrome-picker input',
             size: {
                 input: '[data-testid="footer-config"] .pf-c-select button',

--- a/ui/apps/platform/cypress/integration/systemConfig/systemConfig.test.js
+++ b/ui/apps/platform/cypress/integration/systemConfig/systemConfig.test.js
@@ -19,12 +19,12 @@ function editBaseConfig(type) {
 }
 
 function editBannerConfig(type) {
-    cy.get(selectors[type].config.colorPickerBtn).first().click();
+    cy.get(selectors[type].config.colorPickerButton).click();
     cy.get(selectors[type].config.colorInput).clear().type(text.color);
     cy.get(selectors[type].widget).click();
     cy.get(selectors[type].config.size.input).click();
     cy.get(selectors[type].config.size.options).first().click();
-    cy.get(selectors[type].config.colorPickerBtn).last().click();
+    cy.get(selectors[type].config.backgroundColorPickerButton).click();
     cy.get(selectors[type].config.colorInput).clear().type(text.backgroundColor);
     cy.get(selectors[type].widget).click();
 }

--- a/ui/apps/platform/src/Components/ColorPicker.js
+++ b/ui/apps/platform/src/Components/ColorPicker.js
@@ -7,14 +7,14 @@ import { Manager, Target, Popper } from 'react-popper';
 
 class ColorPickerComponent extends Component {
     static propTypes = {
-        id: PropTypes.string,
+        id: PropTypes.string.isRequired,
+        label: PropTypes.string.isRequired,
         color: PropTypes.string,
         onChange: PropTypes.func,
         disabled: PropTypes.bool,
     };
 
     static defaultProps = {
-        id: null,
         color: null,
         onChange: () => {},
         disabled: false,
@@ -46,7 +46,8 @@ class ColorPickerComponent extends Component {
                 <Target>
                     <button
                         type="button"
-                        data-testid="color-picker"
+                        id={this.props.id}
+                        aria-label={this.props.label}
                         onClick={this.onClickHandler}
                         className={`p-1 h-5 w-full border border-base-300 ignore-react-onclickoutside ${
                             this.props.disabled ? 'pointer-events-none' : ''

--- a/ui/apps/platform/src/Containers/SystemConfig/Details/PublicConfigBannerDetails.tsx
+++ b/ui/apps/platform/src/Containers/SystemConfig/Details/PublicConfigBannerDetails.tsx
@@ -63,7 +63,12 @@ const PublicConfigBannerDetails = ({
                     <DescriptionListGroup>
                         <DescriptionListTerm>Text color</DescriptionListTerm>
                         <DescriptionListDescription>
-                            <ColorPicker color={color} disabled />
+                            <ColorPicker
+                                id={`publicConfig.${type}.color`}
+                                label={`Text color of ${type}`}
+                                color={color}
+                                disabled
+                            />
                             {color || 'None'}
                         </DescriptionListDescription>
                     </DescriptionListGroup>
@@ -74,7 +79,12 @@ const PublicConfigBannerDetails = ({
                     <DescriptionListGroup>
                         <DescriptionListTerm>Background color</DescriptionListTerm>
                         <DescriptionListDescription>
-                            <ColorPicker color={backgroundColor} disabled />
+                            <ColorPicker
+                                id={`publicConfig.${type}.backgroundColor`}
+                                label={`Background color of ${type}`}
+                                color={backgroundColor}
+                                disabled
+                            />
                             {backgroundColor || 'None'}
                         </DescriptionListDescription>
                     </DescriptionListGroup>

--- a/ui/apps/platform/src/Containers/SystemConfig/Form/SystemConfigForm.tsx
+++ b/ui/apps/platform/src/Containers/SystemConfig/Form/SystemConfigForm.tsx
@@ -360,6 +360,7 @@ const SystemConfigForm = ({
                                         >
                                             <ColorPicker
                                                 id="publicConfig.header.color"
+                                                label="Text color of header"
                                                 color={values?.publicConfig?.header?.color}
                                                 onChange={onCustomChange}
                                             />
@@ -392,6 +393,7 @@ const SystemConfigForm = ({
                                         >
                                             <ColorPicker
                                                 id="publicConfig.header.backgroundColor"
+                                                label="Background color of header"
                                                 color={
                                                     values?.publicConfig?.header?.backgroundColor
                                                 }
@@ -447,6 +449,7 @@ const SystemConfigForm = ({
                                         >
                                             <ColorPicker
                                                 id="publicConfig.footer.color"
+                                                label="Text color of footer"
                                                 color={values?.publicConfig?.footer?.color}
                                                 onChange={onCustomChange}
                                             />
@@ -479,6 +482,7 @@ const SystemConfigForm = ({
                                         >
                                             <ColorPicker
                                                 id="publicConfig.footer.backgroundColor"
+                                                label="Background color of footer"
                                                 color={
                                                     values?.publicConfig?.footer?.backgroundColor
                                                 }


### PR DESCRIPTION
## Description

### Problem

Solve critical issue from axe DevTools on System Configuration page:

> Buttons must have discernable text

### Analysis

### Solution

1. Make `id` prop required.

2. Replace `data-testid` with `aria-label` prop.

3. Update selectors for integration tests.

### Residue

1. Reduce redundancy between details and form.
    * For example, PatternFly read-only text input form element for data retention details?

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed

### Manual testing

Without `aria-label` attribute
![without_aria-label](https://user-images.githubusercontent.com/11862657/229195092-f94b8358-78e0-4303-b2e5-2272c684a66f.png)

With `aria-label` attribute
![with_aria-label](https://user-images.githubusercontent.com/11862657/229195076-4ae41862-12ed-4826-a3ab-ebb2e128c334.png)

### Integration testing

1. `yarn start` in ui folder
2. `yarn cypress-open` in ui/apps/platform folder
    * systemConfig/systemConfig.test.js
