### PR TITLE
Improve color contrast in Search results table

### DIFF
--- a/ui/apps/platform/src/Containers/Search/NotApplicable.tsx
+++ b/ui/apps/platform/src/Containers/Search/NotApplicable.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement } from 'react';
 
 function NotApplicable(): ReactElement {
-    return <span className="pf-u-color-400 pf-u-text-nowrap">Not applicable</span>;
+    return <span className="pf-u-color-200 pf-u-text-nowrap">Not applicable</span>;
 }
 
 export default NotApplicable;

--- a/ui/apps/platform/src/Containers/Search/SearchTable.tsx
+++ b/ui/apps/platform/src/Containers/Search/SearchTable.tsx
@@ -87,14 +87,14 @@ function SearchTable({ navCategory, searchFilter, searchResults }: SearchTablePr
                                     location.length !== 0 && (
                                         <div
                                             aria-label={getLocationLabelForCategory(category)}
-                                            className="pf-u-color-400"
+                                            className="pf-u-color-200"
                                         >
                                             {getLocationTextForCategory(location, category)}
                                         </div>
                                     )}
                             </Td>
                             {hasLocationColumn && (
-                                <Td dataLabel={locationColumnHeading} className="pf-u-color-400">
+                                <Td dataLabel={locationColumnHeading} className="pf-u-color-200">
                                     {getLocationTextForCategory(location, category)}
                                 </Td>
                             )}


### PR DESCRIPTION
## Description

### Problem

Solve serious issue from axe DevTools in Search results table:

> Elements must have sufficient color contrast

### Analysis

Contrast ratio of `pf-u-color-400` is less than 4.5

Contrast ratios for foreground colors on `#ffffff` background color:

| class | color | ratio |
| ---: | ---: | ---: |
| `pf-u-color-100` | `#151515` | 18.26 |
| `pf-u-color-200` | `#6a6e73` |  5.13 |
| `pf-u-color-300` | `#3c3f42` | 10.59 |
| `pf-u-color-400` | `#8a8d90` |  3.33 |

https://webaim.org/resources/contrastchecker/

### Solution

Thanks to Dave Vail for investigating and recommending `pf-u-color-200` utility class.

### Residue

1. Improve color contrast for blue **Namespace: stackrox** in search filter.
2. Investigate **Elements must use only allowed ARIA attributes** issues.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

### Manual testing

Visit /main/search?s[Namespace]=stackrox

Insufficient color contrast with `pf-u-color-400` utility class:
![Insufficient_pf-u-color-400](https://user-images.githubusercontent.com/11862657/229211121-4387a884-8ac6-416b-83e9-235f5420cc97.png)

Sufficient color contrast with `pf-u-color-200` utility class:
![Sufficient_pf-u-color-200](https://user-images.githubusercontent.com/11862657/229211097-af16ffc0-e7c7-462e-a1c9-6687ae296291.png)
