### PR TITLE
Clean up some error types for reconnects

### DIFF
--- a/central/sensor/service/connection/worker_queue.go
+++ b/central/sensor/service/connection/worker_queue.go
@@ -5,6 +5,7 @@ import (
 	"hash/fnv"
 	"time"
 
+	"github.com/pkg/errors"
 	"github.com/stackrox/rox/central/sensor/service/common"
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/pkg/concurrency"
@@ -66,7 +67,7 @@ func (w *workerQueue) runWorker(ctx context.Context, idx int, stopSig *concurren
 	queue := w.queues[idx]
 	for msg := queue.pullBlocking(stopSig); msg != nil; msg = queue.pullBlocking(stopSig) {
 		err := handler(ctx, msg)
-		if err != nil && err != context.Canceled {
+		if err != nil && !errors.Is(err, context.Canceled) {
 			if pgutils.IsTransientError(err) {
 				msg.ProcessingAttempt++
 

--- a/central/sensor/service/pipeline/all/pipeline.go
+++ b/central/sensor/service/pipeline/all/pipeline.go
@@ -60,7 +60,7 @@ func (s *pipelineImpl) Run(ctx context.Context, msg *central.MsgFromSensor, inje
 				err = fragment.Run(ctx, s.clusterID, msg, injector)
 			})
 			if err != nil {
-				if err == context.Canceled {
+				if errors.Is(err, context.Canceled) {
 					return nil
 				}
 				return errors.Wrap(err, "processing message from sensor")

--- a/pkg/errorhelpers/format.go
+++ b/pkg/errorhelpers/format.go
@@ -76,23 +76,24 @@ func (e *ErrorList) AddStrings(errs ...string) {
 
 // ToError returns an error if there were errors added or nil
 func (e *ErrorList) ToError() error {
-	switch len(e.errors) {
-	case 0:
-		return nil
-	case 1:
-		return fmt.Errorf("%s error: %s", e.start, e.errors[0])
-	default:
-		return fmt.Errorf("%s errors: [%s]", e.start, strings.Join(e.ErrorStrings(), ", "))
-	}
+	return e
+}
+
+// Error implements the error interface
+func (e *ErrorList) Error() string {
+	return e.String()
 }
 
 // String converts the list to a string, returning empty if no errors were added.
 func (e *ErrorList) String() string {
-	err := e.ToError()
-	if err == nil {
+	switch len(e.errors) {
+	case 0:
 		return ""
+	case 1:
+		return fmt.Sprintf("%s error: %s", e.start, e.errors[0])
+	default:
+		return fmt.Sprintf("%s errors: [%s]", e.start, strings.Join(e.ErrorStrings(), ", "))
 	}
-	return err.Error()
 }
 
 // ErrorStrings returns all the error strings in this ErrorList as a slice, ignoring the start string.

--- a/pkg/errorhelpers/format.go
+++ b/pkg/errorhelpers/format.go
@@ -76,6 +76,9 @@ func (e *ErrorList) AddStrings(errs ...string) {
 
 // ToError returns an error if there were errors added or nil
 func (e *ErrorList) ToError() error {
+	if len(e.errors) == 0 {
+		return nil
+	}
 	return e
 }
 

--- a/pkg/errorhelpers/format.go
+++ b/pkg/errorhelpers/format.go
@@ -108,6 +108,7 @@ func (e *ErrorList) ErrorStrings() []string {
 	return errors
 }
 
+// Errors returns the underlying errors in the error list
 func (e *ErrorList) Errors() []error {
 	return e.errors
 }

--- a/pkg/postgres/pgutils/error.go
+++ b/pkg/postgres/pgutils/error.go
@@ -50,6 +50,9 @@ var transientPGCodes = set.NewFrozenStringSet(
 
 // IsTransientError specifies if the passed error is transient and should be retried
 func IsTransientError(err error) bool {
+	if err == pgx.ErrNoRows {
+		return false
+	}
 	if pgErr := (*pgconn.PgError)(nil); errors.As(err, &pgErr) {
 		return transientPGCodes.Contains(pgErr.Code)
 	}
@@ -65,7 +68,13 @@ func IsTransientError(err error) bool {
 	if errorhelpers.IsAny(err, context.DeadlineExceeded) {
 		return true
 	}
-	return errorhelpers.IsAny(err, io.EOF, io.ErrUnexpectedEOF, io.ErrClosedPipe, syscall.ECONNREFUSED, syscall.ECONNRESET, syscall.ECONNABORTED, syscall.EPIPE)
+	if errorhelpers.IsAny(err, io.EOF, io.ErrUnexpectedEOF, io.ErrClosedPipe, syscall.ECONNREFUSED, syscall.ECONNRESET, syscall.ECONNABORTED, syscall.EPIPE) {
+		return true
+	}
+	if err := errors.Unwrap(err); err != nil {
+		return IsTransientError(err)
+	}
+	return false
 }
 
 const (

--- a/pkg/postgres/pgutils/error.go
+++ b/pkg/postgres/pgutils/error.go
@@ -53,6 +53,13 @@ func IsTransientError(err error) bool {
 	if errors.Is(err, pgx.ErrNoRows) {
 		return false
 	}
+	if multiError := (*errorhelpers.ErrorList)(nil); errors.As(err, &multiError) {
+		for _, err := range multiError.Errors() {
+			if IsTransientError(err) {
+				return true
+			}
+		}
+	}
 	if pgErr := (*pgconn.PgError)(nil); errors.As(err, &pgErr) {
 		return transientPGCodes.Contains(pgErr.Code)
 	}

--- a/pkg/postgres/pgutils/error.go
+++ b/pkg/postgres/pgutils/error.go
@@ -50,7 +50,7 @@ var transientPGCodes = set.NewFrozenStringSet(
 
 // IsTransientError specifies if the passed error is transient and should be retried
 func IsTransientError(err error) bool {
-	if err == pgx.ErrNoRows {
+	if errors.Is(err, pgx.ErrNoRows) {
 		return false
 	}
 	if pgErr := (*pgconn.PgError)(nil); errors.As(err, &pgErr) {

--- a/pkg/postgres/pgutils/error_test.go
+++ b/pkg/postgres/pgutils/error_test.go
@@ -1,0 +1,63 @@
+package pgutils
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/pkg/errorhelpers"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWrappedErrors(t *testing.T) {
+	multiErrorEmpty := errorhelpers.NewErrorList("any")
+
+	multiError1Error := errorhelpers.NewErrorList("hello")
+	multiError1Error.AddError(context.DeadlineExceeded)
+
+	multiErrorDeadlineExceeded := errorhelpers.NewErrorList("hello")
+	multiErrorDeadlineExceeded.AddError(context.DeadlineExceeded)
+	multiErrorDeadlineExceeded.AddErrors(errors.New("other error"))
+
+	cases := []struct {
+		err       error
+		transient bool
+	}{
+		{
+			err:       errors.New("hello"),
+			transient: false,
+		},
+		{
+			err:       errors.Wrap(errors.New("hello"), "hello"),
+			transient: false,
+		},
+		{
+			err:       errors.Wrap(context.DeadlineExceeded, "hello"),
+			transient: true,
+		},
+		{
+			err:       errors.Wrap(errors.Wrap(io.EOF, "1"), "2"),
+			transient: true,
+		},
+		{
+			err:       errors.Wrap(errors.Wrap(errors.New("nothing"), "1"), "2"),
+			transient: false,
+		},
+		{
+			err:       multiErrorEmpty.ToError(),
+			transient: false,
+		},
+		{
+			err:       multiError1Error.ToError(),
+			transient: true,
+		},
+		{
+			err:       multiErrorDeadlineExceeded.ToError(),
+			transient: true,
+		},
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.transient, IsTransientError(c.err))
+	}
+}


### PR DESCRIPTION
## Description

Some error types needed to be unwrapped to get to the root error which may be retryable. I have run this on a chaos PR and there are no instances of Unretryable log which means that we are correctly retrying and eventually succeeding

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Will run the chaos test with this and see what errors pop up
