### PR TITLE
Improve color contrast in Violations table

### DIFF
--- a/ui/apps/platform/src/Containers/Violations/violationTableColumnDescriptors.tsx
+++ b/ui/apps/platform/src/Containers/Violations/violationTableColumnDescriptors.tsx
@@ -34,7 +34,7 @@ function EntityTableCell({ original }: EntityTableCellProps): ReactElement {
     return (
         <Flex direction={{ default: 'column' }}>
             <FlexItem className="pf-u-mb-0">{name}</FlexItem>
-            <FlexItem className="pf-u-color-400 pf-u-font-size-xs">
+            <FlexItem className="pf-u-color-200 pf-u-font-size-xs">
                 {`in "${clusterName}/${namespace}"`}
             </FlexItem>
         </Flex>


### PR DESCRIPTION
## Description

### Problem

Solve serious issue from axe DevTools in Search results table:

> Elements must have sufficient color contrast

Aha, 16 results but only 9 issues because axe DevTools does not analyze the table rows that are scrolled out of view?

### Analysis

Contrast ratio of `pf-u-color-400` is less than 4.5

Contrast ratios for foreground colors on `#ffffff` background color:

| class | color | ratio |
| ---: | ---: | ---: |
| `pf-u-color-100` | `#151515` | 18.26 |
| `pf-u-color-200` | `#6a6e73` |  5.13 |
| `pf-u-color-300` | `#3c3f42` | 10.59 |
| `pf-u-color-400` | `#8a8d90` |  3.33 |

https://webaim.org/resources/contrastchecker/

### Solution

Thanks to Dave Vail for investigating and recommending `pf-u-color-200` utility class.

### Residue

1. Investigate **Table header text should not be empty** issue.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

### Manual testing

Visit /main/violations

Insufficient color contrast with `pf-u-color-400` utility class:
![Violations_pf-u-color-400](https://user-images.githubusercontent.com/11862657/229213314-d0a59b3d-5e9a-4d40-95ad-1e5c41d89ece.png)

Sufficient color contrast with `pf-u-color-200` utility class:
![Violations_pf-u-color-200](https://user-images.githubusercontent.com/11862657/229213299-8a5fd9ba-83dd-41b3-8094-73a0d2021d99.png)
