### PR TITLE
Jv dont show listening endpoints with no process info

### DIFF
--- a/central/processlisteningonport/store/postgres/full_store.go
+++ b/central/processlisteningonport/store/postgres/full_store.go
@@ -128,6 +128,10 @@ func (s *fullStoreImpl) readRows(
 			execFilePath = msg.GetProcess().GetProcessExecFilePath()
 		}
 
+		if podID == "" && containerName == "" && name == "" && args == "" && execFilePath == "" {
+			continue
+		}
+
 		plop := &storage.ProcessListeningOnPort{
 			Endpoint: &storage.ProcessListeningOnPort_Endpoint{
 				Port:     msg.GetPort(),

--- a/central/processlisteningonport/store/postgres/full_store.go
+++ b/central/processlisteningonport/store/postgres/full_store.go
@@ -128,6 +128,9 @@ func (s *fullStoreImpl) readRows(
 			execFilePath = msg.GetProcess().GetProcessExecFilePath()
 		}
 
+		// If we don't have any of this information from either the process indicator side or
+		// processes listening on ports side, the process indicator has been deleted and the
+		// port has been closed. Central just hasn't gotten the message yet.
 		if podID == "" && containerName == "" && name == "" && args == "" && execFilePath == "" {
 			continue
 		}


### PR DESCRIPTION
## Description

In the following scenario we could end up with a situation where for a brief period of time the only information reported for a listening endpoint is the port, protocol, and deployment Id. Central receives a listening endpoint and matching process indicator. The process indicator is deleted before the message that the port is closed reaches central. In such cases the port is almost certainly closed and should not be reported by the API.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Added unit test

## Testing Performed

CI is sufficient
