### PR TITLE
Add e2e tests for Network Graphs 2.0 sidebar Flows tab

### DIFF
--- a/ui/apps/platform/cypress/integration/networkGraphPF/networkDeploymentSidebar.test.js
+++ b/ui/apps/platform/cypress/integration/networkGraphPF/networkDeploymentSidebar.test.js
@@ -77,8 +77,6 @@ describe('Network Graph deployment sidebar', () => {
     });
 
     it('should show anomalous and baseline flows in the sidebar', () => {
-        cy.intercept('POST', '/v1/networkbaseline/*/status').as('networkBaselines');
-
         visitNetworkGraph();
 
         checkNetworkGraphEmptyState();
@@ -95,8 +93,6 @@ describe('Network Graph deployment sidebar', () => {
 
         // check Flows tab
         cy.get(`${networkGraphSelectors.drawerTabs}`).contains('Flows').click();
-
-        cy.wait('@networkBaselines');
 
         cy.get(`${networkGraphSelectors.drawerTabs} .pf-m-current:contains("Flows")`); // now that it is clicked, make sure it is selected
 

--- a/ui/apps/platform/src/Containers/NetworkGraph/common/FlowsTableHeaderText.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/common/FlowsTableHeaderText.tsx
@@ -9,7 +9,7 @@ type FlowsTableHeaderTextProps = {
 function FlowsTableHeaderText({ type, numFlows }: FlowsTableHeaderTextProps): ReactElement {
     return (
         <TextContent>
-            <Text component={TextVariants.h3}>
+            <Text component={TextVariants.h3} data-testid="flows-table-header">
                 {numFlows} {type} flows
             </Text>
         </TextContent>

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentFlows.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentFlows.tsx
@@ -197,16 +197,18 @@ function DeploymentFlows({
                     <Stack hasGutter>
                         <StackItem>
                             <ExpandableSection
-                                toggleText={`${numAnomalousFlows} anomalous ${pluralize(
-                                    'flow',
-                                    numAnomalousFlows
-                                )}`}
+                                toggleContent={
+                                    <span data-testid="anomalous-flows-header">
+                                        {numAnomalousFlows} anomalous{' '}
+                                        {pluralize('flow', numAnomalousFlows)}
+                                    </span>
+                                }
                                 onToggle={toggleAnomalousFlowsExpandable}
                                 isExpanded={isAnomalousFlowsExpanded}
                             >
                                 {numAnomalousFlows > 0 ? (
                                     <FlowsTable
-                                        label="Deployment flows"
+                                        label="Anomalous flows"
                                         flows={anomalousFlows}
                                         numFlows={numAnomalousFlows}
                                         expandedRows={expandedRows}
@@ -227,16 +229,18 @@ function DeploymentFlows({
                         </StackItem>
                         <StackItem>
                             <ExpandableSection
-                                toggleText={`${numBaselineFlows} baseline ${pluralize(
-                                    'flow',
-                                    numBaselineFlows
-                                )}`}
+                                toggleContent={
+                                    <span data-testid="baseline-flows-header">
+                                        {numBaselineFlows} baseline{' '}
+                                        {pluralize('flow', numBaselineFlows)}
+                                    </span>
+                                }
                                 onToggle={toggleBaselineFlowsExpandable}
                                 isExpanded={isBaselineFlowsExpanded}
                             >
                                 {numBaselineFlows > 0 ? (
                                     <FlowsTable
-                                        label="Deployment flows"
+                                        label="Baseline flows"
                                         flows={baselineFlows}
                                         numFlows={numBaselineFlows}
                                         expandedRows={expandedRows}


### PR DESCRIPTION
## Description

First attempt at adding tests for the Flows tab of Network Graph 2.0 deployment sidebar.

Questions:
1. The 2nd test is brittle, in that it matters whether it comes after the first test or not. It it comes after the first test, the networkbaselines call is not made in the 2nd test, and so we don't have to await it. If we run the 2nd test in isolation, it often flakes if we do not add an await for the networkbaselines call.
2. I don't like the nested callback to compare the counts of the anomalous and baseline flows, but the options I found are not ideal
    1. Add a dependency to make cypress return a real promise, so we could async-await each value and assign them to top-level variables (example, https://medium.com/@NicholasBoll/cypress-io-using-async-and-await-4034e9bab207)
    2. Get all three values in three top level selectors, each assigned to an alias. Next, use the same three-level nested `.then()` structure to retrieve the three variables to compare. Still nested, but the selectors are all at the top, and the nested is more compact. (One-level example, https://stackoverflow.com/a/69258027)


## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added


## Testing Performed

<img width="2137" alt="Screen Shot 2023-03-31 at 3 46 01 PM" src="https://user-images.githubusercontent.com/715729/229215267-9574d799-b06a-4d7c-8e3d-0708e8424840.png">
