### PR TITLE
[ROX-16068] : Fix ImageCVEEdges not getting inserted sometimes

### DIFF
--- a/central/image/datastore/store/postgres/store.go
+++ b/central/image/datastore/store/postgres/store.go
@@ -531,7 +531,7 @@ func copyFromImageCVEEdges(ctx context.Context, tx *postgres.Tx, iTime *protoTyp
 		})
 
 		// if we hit our batch size we need to push the data
-		if (idx+1)%batchSize == 0 || idx == len(objs)-1 {
+		if (idx+1)%batchSize == 0 || idx == len(objsToInsert)-1 {
 			if forceAdd {
 				// Copy does not upsert so have to delete first.
 				_, err = tx.Exec(ctx, "DELETE FROM "+imageCVEEdgesTable+" WHERE id = ANY($1::text[])", deletes.AsSlice())

--- a/central/image/datastore/store/postgres/store.go
+++ b/central/image/datastore/store/postgres/store.go
@@ -483,9 +483,10 @@ func copyFromImageCVEEdges(ctx context.Context, tx *postgres.Tx, iTime *protoTyp
 
 	var err error
 	var oldEdgeIDs set.Set[string]
+	var objsToInsert []*storage.ImageCVEEdge
 	deletes := set.NewStringSet()
 
-	// If the operation is not a force add, then collect the existing edges for the image to determine the skip upsert step later.
+	// If the operation is not a force add, then collect the existing edges for the image the skip re-inserting existing edges.
 	var imageIDs []string
 	if !forceAdd {
 		for _, obj := range objs {
@@ -496,18 +497,23 @@ func copyFromImageCVEEdges(ctx context.Context, tx *postgres.Tx, iTime *protoTyp
 		if err != nil {
 			return err
 		}
-	}
 
-	for idx, obj := range objs {
-		if forceAdd {
-			// Add the id to be deleted.
-			deletes.Add(obj.GetId())
-		} else {
+		for _, obj := range objs {
 			// Since the edge only maintains states enriched by ACS, if the edge already exists, then skip upsert.
 			if oldEdgeIDs.Remove(obj.GetId()) {
 				continue
 			}
 			obj.FirstImageOccurrence = iTime
+			objsToInsert = append(objsToInsert, obj)
+		}
+	} else {
+		objsToInsert = objs
+	}
+
+	for idx, obj := range objsToInsert {
+		if forceAdd {
+			// Add the id to be deleted.
+			deletes.Add(obj.GetId())
 		}
 
 		serialized, marshalErr := obj.Marshal()

--- a/central/image/datastore/store/postgres/store.go
+++ b/central/image/datastore/store/postgres/store.go
@@ -469,9 +469,8 @@ func copyFromImageComponentCVEEdges(ctx context.Context, tx *postgres.Tx, objs .
 	return nil
 }
 
-func copyFromImageCVEEdges(ctx context.Context, tx *postgres.Tx, iTime *protoTypes.Timestamp, forceAdd bool, objs ...*storage.ImageCVEEdge) error {
-	inputRows := [][]interface{}{}
-
+func copyFromImageCVEEdges(ctx context.Context, tx *postgres.Tx, iTime *protoTypes.Timestamp, vulnStateUpdate bool,
+	objs ...*storage.ImageCVEEdge) error {
 	copyCols := []string{
 		"id",
 		"firstimageoccurrence",
@@ -481,68 +480,44 @@ func copyFromImageCVEEdges(ctx context.Context, tx *postgres.Tx, iTime *protoTyp
 		"serialized",
 	}
 
+	if vulnStateUpdate {
+		return copyFromImageCVEEdgesWithVulnStateUpdates(ctx, tx, copyCols, objs)
+	}
+
 	var err error
 	var oldEdgeIDs set.Set[string]
-	var objsToInsert []*storage.ImageCVEEdge
-	deletes := set.NewStringSet()
 
-	// If the operation is not a force add, then collect the existing edges for the image the skip re-inserting existing edges.
 	var imageIDs []string
-	if !forceAdd {
-		for _, obj := range objs {
-			imageIDs = append(imageIDs, obj.GetImageId())
-		}
+	for _, obj := range objs {
+		imageIDs = append(imageIDs, obj.GetImageId())
+	}
 
-		oldEdgeIDs, err = getImageCVEEdgeIDs(ctx, tx, imageIDs...)
+	// Collect the existing edges for the images to skip re-inserting existing edges.
+	oldEdgeIDs, err = getImageCVEEdgeIDs(ctx, tx, imageIDs...)
+	if err != nil {
+		return err
+	}
+
+	var edgesToInsert []*storage.ImageCVEEdge
+	for _, obj := range objs {
+		// Since the edge only maintains states enriched by ACS, if the edge already exists, then it should skip copy from.
+		if oldEdgeIDs.Remove(obj.GetId()) {
+			continue
+		}
+		obj.FirstImageOccurrence = iTime
+		edgesToInsert = append(edgesToInsert, obj)
+	}
+
+	inputRows := [][]interface{}{}
+	for idx, edge := range edgesToInsert {
+		inputRow, err := getImageCVEEdgeRowToInsert(edge)
 		if err != nil {
 			return err
 		}
+		inputRows = append(inputRows, inputRow)
 
-		for _, obj := range objs {
-			// Since the edge only maintains states enriched by ACS, if the edge already exists, then skip upsert.
-			if oldEdgeIDs.Remove(obj.GetId()) {
-				continue
-			}
-			obj.FirstImageOccurrence = iTime
-			objsToInsert = append(objsToInsert, obj)
-		}
-	} else {
-		objsToInsert = objs
-	}
-
-	for idx, obj := range objsToInsert {
-		if forceAdd {
-			// Add the id to be deleted.
-			deletes.Add(obj.GetId())
-		}
-
-		serialized, marshalErr := obj.Marshal()
-		if marshalErr != nil {
-			return marshalErr
-		}
-
-		inputRows = append(inputRows, []interface{}{
-			obj.GetId(),
-			pgutils.NilOrTime(obj.GetFirstImageOccurrence()),
-			obj.GetState(),
-			obj.GetImageId(),
-			obj.GetImageCveId(),
-			serialized,
-		})
-
-		// if we hit our batch size we need to push the data
-		if (idx+1)%batchSize == 0 || idx == len(objsToInsert)-1 {
-			if forceAdd {
-				// Copy does not upsert so have to delete first.
-				_, err = tx.Exec(ctx, "DELETE FROM "+imageCVEEdgesTable+" WHERE id = ANY($1::text[])", deletes.AsSlice())
-				if err != nil {
-					return err
-				}
-
-				// Clear the inserts for the next batch
-				deletes = nil
-			}
-
+		// if we hit our batch size or end of slice, push the edges
+		if (idx+1)%batchSize == 0 || idx == len(edgesToInsert)-1 {
 			_, err = tx.CopyFrom(ctx, pgx.Identifier{imageCVEEdgesTable}, copyCols, pgx.CopyFromRows(inputRows))
 			if err != nil {
 				return err
@@ -555,6 +530,61 @@ func copyFromImageCVEEdges(ctx context.Context, tx *postgres.Tx, iTime *protoTyp
 
 	// Remove orphaned edges.
 	return removeOrphanedImageCVEEdges(ctx, tx, oldEdgeIDs.AsSlice())
+}
+
+func copyFromImageCVEEdgesWithVulnStateUpdates(ctx context.Context, tx *postgres.Tx, copyCols []string,
+	edges []*storage.ImageCVEEdge) error {
+	inputRows := [][]interface{}{}
+	deletes := set.NewStringSet()
+
+	for idx, edge := range edges {
+		// Add the id to be deleted.
+		deletes.Add(edge.GetId())
+
+		inputRow, err := getImageCVEEdgeRowToInsert(edge)
+		if err != nil {
+			return err
+		}
+		inputRows = append(inputRows, inputRow)
+
+		// if we hit our batch size or end of slice, delete old edges and push new ones
+		if (idx+1)%batchSize == 0 || idx == len(edges)-1 {
+			// Copy does not upsert so have to delete first.
+			_, err = tx.Exec(ctx, "DELETE FROM "+imageCVEEdgesTable+" WHERE id = ANY($1::text[])", deletes.AsSlice())
+			if err != nil {
+				return err
+			}
+
+			// Clear the inserts for the next batch
+			deletes = nil
+
+			_, err = tx.CopyFrom(ctx, pgx.Identifier{imageCVEEdgesTable}, copyCols, pgx.CopyFromRows(inputRows))
+			if err != nil {
+				return err
+			}
+
+			// Clear the input rows for the next batch
+			inputRows = inputRows[:0]
+		}
+	}
+
+	return nil
+}
+
+func getImageCVEEdgeRowToInsert(edge *storage.ImageCVEEdge) ([]interface{}, error) {
+	serialized, marshalErr := edge.Marshal()
+	if marshalErr != nil {
+		return nil, marshalErr
+	}
+
+	return []interface{}{
+		edge.GetId(),
+		pgutils.NilOrTime(edge.GetFirstImageOccurrence()),
+		edge.GetState(),
+		edge.GetImageId(),
+		edge.GetImageCveId(),
+		serialized,
+	}, nil
 }
 
 func removeOrphanedImageComponent(ctx context.Context, tx *postgres.Tx) error {


### PR DESCRIPTION
## Description

`copyFromImageCVEEdges` in image postgres store was failing to insert new ImageCVEEdges into postgres when the edges on batchSize boundaries in the input edges were pre-existing edges.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

e2e test ImageScanningTest should not fail
