### PR TITLE
Delete line break in htmlFor attribute of timeoutSeconds label

### DIFF
--- a/ui/apps/platform/src/Containers/Clusters/DynamicConfigurationSection.js
+++ b/ui/apps/platform/src/Containers/Clusters/DynamicConfigurationSection.js
@@ -110,8 +110,7 @@ const DynamicConfigurationSection = ({
                 <div className={wrapperMarginClassName}>
                     <div className={`pl-2 ${justifyBetweenClassName}`}>
                         <label
-                            htmlFor="dynamicConfig.admissionControllerConfig
-                    .timeoutSeconds"
+                            htmlFor="dynamicConfig.admissionControllerConfig.timeoutSeconds"
                             className={labelClassName}
                         >
                             Timeout (seconds)


### PR DESCRIPTION
## Description

### Problem

Solve critical issue from axe DevTools in cluster side panel:

> Form elements must have labels

### Analysis

A line break in `htmlFor` attribute of `label` element breaks its association with the corresponding `input` element.

### Solution

Delete line break

## Checklist
- [ ] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

### Manual testing

1. Visit /main/clusters and then click a cluster to open side panel.

    * Does have issue with line break:
        ![with_line_break](https://user-images.githubusercontent.com/11862657/229548380-8a1ac463-2b1e-4927-bbde-8e0223234f11.png)

    * Does not have issue without line break:
        ![without_line_break](https://user-images.githubusercontent.com/11862657/229548437-9378c434-b2f9-4301-98e3-92e5e5ceefa2.png)
