### PR TITLE
Patch Sensor for manifests and operator installations

### DIFF
--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -606,6 +606,11 @@ function launch_sensor {
         fi
     fi
 
+    # If we deployed sensor with manifests then we need to set re-sync flag manually by patching the deployment.
+    if [[ "$ROX_RESYNC_DISABLED" == "true" && "$OUTPUT_FORMAT" == "kubectl" ]]; then
+        kubectl -n stackrox set env deploy/sensor ROX_RESYNC_DISABLED="true"
+    fi
+
     if [[ "$MONITORING_SUPPORT" == "true" || ( "$(local_dev)" != "true" && -z "$MONITORING_SUPPORT" ) ]]; then
       "${COMMON_DIR}/monitoring.sh"
     fi

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -278,7 +278,8 @@ deploy_sensor_via_operator() {
        kubectl -n stackrox set env ds/collector ROX_PROCESSES_LISTENING_ON_PORT="${ROX_PROCESSES_LISTENING_ON_PORT}"
     fi
 
-    kubectl -n stackrox set env deployment/sensor ROX_RESYNC_DISABLED="${ROX_RESYNC_DISABLED}"
+    # Every E2E test should have ROX_RESYNC_DISABLED="true"
+    kubectl -n stackrox set env deployment/sensor ROX_RESYNC_DISABLED="true"
 }
 
 export_central_basic_auth_creds() {

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -277,6 +277,8 @@ deploy_sensor_via_operator() {
        kubectl -n stackrox set env deployment/sensor ROX_PROCESSES_LISTENING_ON_PORT="${ROX_PROCESSES_LISTENING_ON_PORT}"
        kubectl -n stackrox set env ds/collector ROX_PROCESSES_LISTENING_ON_PORT="${ROX_PROCESSES_LISTENING_ON_PORT}"
     fi
+
+    kubectl -n stackrox set env deployment/sensor ROX_RESYNC_DISABLED="${ROX_RESYNC_DISABLED}"
 }
 
 export_central_basic_auth_creds() {


### PR DESCRIPTION
## Description

This is a fix for #5492 which incorrectly only disabled re-sync for helm installations. 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] ~~Unit test and regression tests added~~
- [ ] ~~Evaluated and added CHANGELOG entry if required~~
- [ ] ~~Determined and documented upgrade steps~~
- [ ] ~~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

## Testing Performed

CI run

