### PR TITLE
Provide aria-label for buttons and links in classic side panels

### DIFF
--- a/ui/apps/platform/cypress/constants/RiskPage.js
+++ b/ui/apps/platform/cypress/constants/RiskPage.js
@@ -33,7 +33,7 @@ const sidePanel = scopeSelectors('[data-testid="panel"]:eq(1)', {
     deploymentDetailsTab: 'button[data-testid="tab"]:contains("Deployment Details")',
     processDiscoveryTab: 'button[data-testid="tab"]:contains("Process Discovery")',
 
-    cancelButton: 'button[data-testid="cancel"]',
+    closeButton: 'button[aria-label="Close"]',
 });
 
 const eventSelectors = {
@@ -89,7 +89,6 @@ export const selectors = {
         deploymentDetails: 'button[data-testid="tab"]:contains("Deployment Details")',
         processDiscovery: 'button[data-testid="tab"]:contains("Process Discovery")',
     },
-    cancelButton: 'button[data-testid="cancel"]',
     search: {
         valueContainer: '.react-select__value-container',
         searchLabels: '.react-select__multi-value__label',

--- a/ui/apps/platform/cypress/constants/VulnManagementPage.js
+++ b/ui/apps/platform/cypress/constants/VulnManagementPage.js
@@ -119,7 +119,7 @@ const linkSelectors = {
 const sidePanelSelectors = {
     backButton: '[data-testid="sidepanelBackButton"]',
     entityIcon: '[data-testid="entity-icon"]',
-    sidePanelExpandButton: '[data-testid = "external-link"]',
+    sidePanelExpandButton: '[aria-label="External link"]',
     getSidePanelTabLink: (title) => {
         return `[data-testid="tab"]:contains('${title}')`;
     },

--- a/ui/apps/platform/cypress/constants/VulnManagementPage.js
+++ b/ui/apps/platform/cypress/constants/VulnManagementPage.js
@@ -119,7 +119,7 @@ const linkSelectors = {
 const sidePanelSelectors = {
     backButton: '[data-testid="sidepanelBackButton"]',
     entityIcon: '[data-testid="entity-icon"]',
-    sidePanelExpandButton: '[aria-label="External link"]',
+    sidePanelExternalLinkButton: '[aria-label="External link"]',
     getSidePanelTabLink: (title) => {
         return `[data-testid="tab"]:contains('${title}')`;
     },

--- a/ui/apps/platform/cypress/helpers/vulnmanagement/entities.js
+++ b/ui/apps/platform/cypress/helpers/vulnmanagement/entities.js
@@ -317,7 +317,7 @@ export function verifySecondaryEntities(
             cy.get(relatedEntitiesSelector);
 
             // 4. Visit single page for primary entity.
-            cy.get(selectors.sidePanelExpandButton).click(); // does not make requests
+            cy.get(selectors.sidePanelExternalLinkButton).click(); // does not make requests
 
             // 5. Visit list page for secondary entities.
             cy.get(relatedEntitiesSelector).click(); // might make some requests

--- a/ui/apps/platform/cypress/integration/clusters/clusters.test.js
+++ b/ui/apps/platform/cypress/integration/clusters/clusters.test.js
@@ -89,7 +89,7 @@ describe.skip('Cluster Creation Flow', () => {
             );
 
             cy.intercept('GET', '/v1/clusters').as('getClusters');
-            cy.get('button[data-testid="cancel"]').click();
+            cy.get('[data-testid="panel"] button[aria-label="Close"]').click();
             cy.wait('@getClusters');
 
             // clean up after the test by deleting the cluster

--- a/ui/apps/platform/cypress/integration/compliance/complianceList.test.js
+++ b/ui/apps/platform/cypress/integration/compliance/complianceList.test.js
@@ -46,7 +46,7 @@ describe('Compliance entities list', () => {
                 cy.get('[data-testid="side-panel"]').should('exist');
                 cy.get('[data-testid="side-panel-header"]').contains(name);
                 cy.get(selectors.widget.relatedEntities).should('not.exist');
-                cy.get('[data-testid="cancel"]').click();
+                cy.get('[data-testid="panel"] [aria-label="Close"]').click();
                 cy.get('[data-testid="side-panel"]').should('not.exist');
                 cy.get('[data-testid="panel-header"]').should('contain', 'CLUSTER');
             });

--- a/ui/apps/platform/cypress/integration/compliance/complianceList.test.js
+++ b/ui/apps/platform/cypress/integration/compliance/complianceList.test.js
@@ -46,7 +46,7 @@ describe('Compliance entities list', () => {
                 cy.get('[data-testid="side-panel"]').should('exist');
                 cy.get('[data-testid="side-panel-header"]').contains(name);
                 cy.get(selectors.widget.relatedEntities).should('not.exist');
-                cy.get('[data-testid="panel"] [aria-label="Close"]').click();
+                cy.get('[data-testid="side-panel"] [aria-label="Close"]').click();
                 cy.get('[data-testid="side-panel"]').should('not.exist');
                 cy.get('[data-testid="panel-header"]').should('contain', 'CLUSTER');
             });

--- a/ui/apps/platform/cypress/integration/configmanagement/ConfigurationManagement.helpers.js
+++ b/ui/apps/platform/cypress/integration/configmanagement/ConfigurationManagement.helpers.js
@@ -241,7 +241,7 @@ export function interactAndWaitForConfigurationManagementScan(interactionCallbac
 
 export function navigateToSingleEntityPage(entitiesKey) {
     interactAndWaitForConfigurationManagementEntityPage(() => {
-        cy.get('[data-testid="side-panel"] [data-testid="external-link"]').click();
+        cy.get('[data-testid="side-panel"] [aria-label="External link"]').click();
     }, entitiesKey);
 }
 

--- a/ui/apps/platform/cypress/integration/networkGraph/tooltip.test.js
+++ b/ui/apps/platform/cypress/integration/networkGraph/tooltip.test.js
@@ -50,7 +50,7 @@ describe.skip('Network Graph tooltip', () => {
 
                     expect(nBidirectional).to.equal(2);
 
-                    cy.get('#panel-close-button').click();
+                    cy.get('#panel-close-button').click(); // obsolete interaction to close panel
 
                     cy.getCytoscape(cytoscapeContainer).then((cytoscape2) => {
                         mouseOverNodeByName(cytoscape2, { type: 'DEPLOYMENT', name });
@@ -88,7 +88,7 @@ describe.skip('Network Graph tooltip', () => {
 
                     expect(nBidirectional).not.to.equal(0);
 
-                    cy.get('#panel-close-button').click();
+                    cy.get('#panel-close-button').click(); // obsolete interaction to close panel
 
                     cy.getCytoscape(cytoscapeContainer).then((cytoscape2) => {
                         mouseOverNodeByName(cytoscape2, { type: 'DEPLOYMENT', name });
@@ -128,7 +128,7 @@ describe.skip('Network Graph tooltip', () => {
                     expect(nEgressOnly).to.equal(0);
                     expect(nBidirectional).to.equal(0);
 
-                    cy.get('#panel-close-button').click();
+                    cy.get('#panel-close-button').click(); // obsolete interaction to close panel
 
                     cy.getCytoscape(cytoscapeContainer).then((cytoscape2) => {
                         mouseOverNodeByName(cytoscape2, { type: 'DEPLOYMENT', name });
@@ -168,7 +168,7 @@ describe.skip('Network Graph tooltip', () => {
                     expect(nIngressOnly).to.equal(0);
                     expect(nBidirectional).to.equal(0);
 
-                    cy.get('#panel-close-button').click();
+                    cy.get('#panel-close-button').click(); // obsolete interaction to close panel
 
                     cy.getCytoscape(cytoscapeContainer).then((cytoscape2) => {
                         mouseOverNodeByName(cytoscape2, { type: 'DEPLOYMENT', name });

--- a/ui/apps/platform/cypress/integration/risk/risk.test.js
+++ b/ui/apps/platform/cypress/integration/risk/risk.test.js
@@ -120,7 +120,7 @@ describe('Risk page', () => {
 
             cy.get(RiskPageSelectors.panel).should('have.length', 2); // main panel and side panel
             cy.get(RiskPageSelectors.panelTabs.riskIndicators);
-            cy.get(RiskPageSelectors.cancelButton).click();
+            cy.get(RiskPageSelectors.sidePanel.closeButton).click();
             cy.get(RiskPageSelectors.panel).should('have.length', 1); // main panel
         });
 
@@ -130,7 +130,7 @@ describe('Risk page', () => {
 
             cy.get(RiskPageSelectors.panel).should('have.length', 2); // main panel and side panel
             cy.get(RiskPageSelectors.panelTabs.deploymentDetails);
-            cy.get(RiskPageSelectors.cancelButton).click();
+            cy.get(RiskPageSelectors.sidePanel.closeButton).click();
             cy.get(RiskPageSelectors.panel).should('have.length', 1); // main panel
         });
 

--- a/ui/apps/platform/cypress/integration/vulnmanagement/entitypages.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/entitypages.test.js
@@ -187,7 +187,7 @@ describe('Entities single views', () => {
             entitiesKey2
         );
 
-        cy.get(selectors.sidePanelExpandButton).click();
+        cy.get(selectors.sidePanelExternalLinkButton).click();
 
         // Entity single page, not side panel.
         cy.get(`${selectors.tableBodyRows} ${selectors.statusChips}:contains('fail')`).should(

--- a/ui/apps/platform/cypress/selectors/panel.js
+++ b/ui/apps/platform/cypress/selectors/panel.js
@@ -7,7 +7,6 @@ const panel = {
     nextButton: '[data-testid="next-button"]',
     saveButton: '[data-testid="save-button"]',
     form: '[data-testid="side-panel"] form',
-    closeButton: '[data-testid="cancel"]',
 };
 
 export default panel;

--- a/ui/apps/platform/src/Components/Button/Button.js
+++ b/ui/apps/platform/src/Components/Button/Button.js
@@ -20,6 +20,7 @@ const Button = ({
     isLoading,
     loaderSize,
     tabIndex,
+    ...ariaProps
 }) => {
     const content = (
         <div className="flex items-center">
@@ -42,6 +43,7 @@ const Button = ({
             disabled={disabled}
             data-testid={dataTestId}
             tabIndex={tabIndex}
+            {...ariaProps}
         >
             {isLoading ? <Loader size={loaderSize} /> : content}
         </button>

--- a/ui/apps/platform/src/Components/CloseButton.js
+++ b/ui/apps/platform/src/Components/CloseButton.js
@@ -11,8 +11,7 @@ const CloseButton = ({ className, iconColor, onClose }) => (
                 type="button"
                 className={`flex p-3 text-center text-sm items-center ${iconColor}`}
                 onClick={onClose}
-                data-testid="cancel"
-                id="panel-close-button"
+                aria-label="Close"
             >
                 <Icon.X className="h-7 w-7" height={null} width={null} />
             </button>

--- a/ui/apps/platform/src/Components/CollapsibleSection/CollapsibleSection.js
+++ b/ui/apps/platform/src/Components/CollapsibleSection/CollapsibleSection.js
@@ -17,13 +17,13 @@ const CollapsibleSection = ({
     dataTestId,
     defaultOpen,
 }) => {
-    const [open, setOpen] = useState(defaultOpen);
+    const [isOpen, setIsOpen] = useState(defaultOpen);
 
     function toggleOpen() {
-        setOpen(!open);
+        setIsOpen(!isOpen);
     }
 
-    const Icon = open ? (
+    const Icon = isOpen ? (
         <ChevronDown className={iconClass} />
     ) : (
         <ChevronRight className={iconClass} />
@@ -36,13 +36,18 @@ const CollapsibleSection = ({
                     <div
                         className={`flex py-1 text-base-600 rounded-r-sm font-700 items-center ${titleClassName}`}
                     >
-                        <Button icon={Icon} onClick={toggleOpen} dataTestId="collapsible-btn" />
+                        <Button
+                            icon={Icon}
+                            onClick={toggleOpen}
+                            aria-label={isOpen ? 'Collapse' : 'Expand'}
+                            aria-expanded={isOpen}
+                        />
                         <span className="ml-2">{title}</span>
                     </div>
                 </div>
                 {headerComponents}
             </header>
-            <CollapsibleAnimatedDiv defaultOpen isOpen={open} dataTestId="collapsible-content">
+            <CollapsibleAnimatedDiv defaultOpen isOpen={isOpen} dataTestId="collapsible-content">
                 {children}
             </CollapsibleAnimatedDiv>
         </div>

--- a/ui/apps/platform/src/Containers/ConfigManagement/SidePanel/SidePanel.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/SidePanel/SidePanel.js
@@ -78,7 +78,7 @@ const SidePanel = ({
         <div className="flex items-center h-full hover:bg-base-300">
             <Link
                 to={externalURL}
-                data-testid="external-link"
+                aria-label="External link"
                 className="border-base-400 border-l h-full p-4"
             >
                 <ExternalLink className="h-6 w-6 text-base-600" />

--- a/ui/apps/platform/src/Containers/Workflow/WorkflowSidePanel.js
+++ b/ui/apps/platform/src/Containers/Workflow/WorkflowSidePanel.js
@@ -18,19 +18,12 @@ const WorkflowSidePanel = ({ history, location, children }) => {
         history.push(url);
     }
 
-    WorkflowSidePanel.handleClickOutside = () => {
-        const btn = document.getElementById('panel-close-button');
-        if (btn) {
-            btn.click();
-        }
-    };
-
     const url = workflowState.getSkimmedStack().toUrl();
     const externalLink = (
         <div className="flex items-center h-full hover:bg-base-300">
             <Link
                 to={url}
-                data-testid="external-link"
+                aria-label="External link"
                 className="border-base-400 border-l h-full p-4"
             >
                 <ExternalLink className="h-6 w-6 text-base-600" />


### PR DESCRIPTION
## Description

### Problems

1. Solve critical issue from axe DevTools on pages that have classic side panels:

    > Buttons must have discernable text

2. Solve serious issue from axe DevTools on pages that have classic side panels:

    > Links must have discernable text

### Analysis

1. src/Components/CloseButton.js

    ```html
    <button type="button" class="flex p-3 text-center text-sm items-center " data-testid="cancel" id="panel-close-button">
    ```

2. src/Components/CollapsibleSection.js

    ```html
    <button type="button" class="" data-testid="collapsible-btn">
    ```

3. src/Containers/ConfigManagement/SidePanel.js and src/Containers/Workflow/WorkflowSidePanel.js

    ```html
    <a data-testid="external-link" class="border-base-400 border-l h-full p-4" href="/main/configmanagement/cluster/fdf2741d-f5c9-4214-8355-b467d02b8a9c">
    ```

### Solution

1. Delete `id` and replace `data-testid="cancel"` with `aria-label="Close"` prop and update selectors for integration tests:

    * cypress/constants/RiskPage.js
        Rename selector and remove redundant selector

    * cypress/integration/clusters/clusters.test.js
        Replace `data-testid` with `aria-label` attribute, although the test is skipped and probably obsolete.

    * cypress/integration/compliance/complianceList.test.js
        Replace `data-testid` with `aria-label` attribute.

    * cypress/integration/networkGraph/tooltip.test.js
        Replace `id` with `aria-label` attribute, although the tests are skipped.

    * cypress/selectors/panel.js
        Delete selector because not used.

    * src/Containers/Workflow/WorkflowSidePanel.js
        Delete obsolete `handleClickOutside` handler that indirectly closed side panel via click on close button (by its `id` attribute).

2. Replace `data-testid="collapsible-btn"` with `aria-label` and `aria-expanded` props.

3. Replace `data-testid="external-link"` with `aria-label="External link"` prop and update selectors for integration tests:

    * ConfigurationManagement.helpers.js
        Replace `data-testid` with `aria-label` attribute.

    * VulnManagementPage.js
        Rename selector and replace `data-testid` with `aria-label` attribute.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed

### Manual testing

Visit /main/configmanagement/clusters and then click a row to open side panel.

1. Close button

    * without `aria-label` attribute:
        ![close_button_without](https://user-images.githubusercontent.com/11862657/229578424-a26833b3-b484-4791-96b1-fa8f0a906b1b.png)

    * with `aria-label` attribute:
        ![close_button_with](https://user-images.githubusercontent.com/11862657/229579693-47d544cf-faec-4e54-b4b6-e15fefb01054.png)

        ![close_button_with_aria-label](https://user-images.githubusercontent.com/11862657/229579922-ee95bfe9-39f5-4cd3-8b31-7149f3b7b387.png)

2. Collapsible section

    * without `aria-label` attribute:
        ![collapsible_section_without](https://user-images.githubusercontent.com/11862657/229578521-1f8ddb57-7905-4071-a9bf-24849bb99f24.png)

    * Collapse button with `aria-label="Collapse"` and `aria-expanded="true"` attributes:
        ![collapsible_section_with_aria-label_Collapse](https://user-images.githubusercontent.com/11862657/229578569-dcaa904d-9a05-4a50-956c-d570bf1874ea.png)

    * Expand button with `aria-label="Expand"` and `aria-expanded="false"` attributes:
        ![collapsible_section_with_aria-label_Expand](https://user-images.githubusercontent.com/11862657/229578599-54ac9c1f-8da5-4781-992a-11976f58d795.png)

3. External link

    * without `aria-label` attribute:
        ![external_link_without](https://user-images.githubusercontent.com/11862657/229578626-19b28f69-ed65-4fdd-9b00-e2058f2003c8.png)

    * with `aria-label` attribute:
        ![external_link_with](https://user-images.githubusercontent.com/11862657/229578657-620a7ce9-79ee-4203-b6a2-7e0ec84131cd.png)

        ![external_link_with_aria-label](https://user-images.githubusercontent.com/11862657/229579424-2b3b5a86-9bf0-4ff5-ae71-950e55b796fa.png)

#### Compliance

/main/compliance/clusters/id
/main/compliance/namespaces/id
/main/compliance/nodes/id
/main/compliance/deployments/id

#### Vulnerability Management

/main/vulnerability-management/image-cves?…
/main/vulnerability-management/node-cves?…
/main/vulnerability-management/cluster-cves?…
/main/vulnerability-management/policies?…
/main/vulnerability-management/nodes?…
/main/vulnerability-management/images?…
/main/vulnerability-management/clusters?…
/main/vulnerability-management/namespaces?…
/main/vulnerability-management/deployments?…
/main/vulnerability-management/node-components?…
/main/vulnerability-management/image-components?…

#### Configuration Management

/main/configmanagement/policies/id
/main/configmanagement/controls/id
/main/configmanagement/clusters/id
/main/configmanagement/namespaces/id
/main/configmanagement/nodes/id
/main/configmanagement/deployments/id
/main/configmanagement/images/id
/main/configmanagement/secrets/id
/main/configmanagement/subjects/id
/main/configmanagement/serviceaccounts/id
/main/configmanagement/roles/id

#### Other

/main/clusters/id
/main/risk/id

### Integration testing

For vulnmanagement test file:

```sh
export CYPRESS_ROX_POSTGRES_DATASTORE=true
```

* integration/configmanagement/whatever.test.js for all entities
* integration/risk/risk.test.js
* integration/vulnmanagement/entitypages.test.js
