### PR TITLE
[ROX-16268] : Query parser should skip plus and comma if within double quotes

### DIFF
--- a/pkg/search/autocomplete_query_parser.go
+++ b/pkg/search/autocomplete_query_parser.go
@@ -2,7 +2,6 @@ package search
 
 import (
 	"errors"
-	"strings"
 
 	v1 "github.com/stackrox/rox/generated/api/v1"
 )
@@ -31,10 +30,10 @@ func (pi autocompleteQueryParser) parseInternal(query string) (*v1.Query, string
 			continue
 		}
 		if i == len(pairs)-1 {
-			queries = append(queries, queryFromFieldValues(key, strings.Split(commaSeparatedValues, ","), true))
+			queries = append(queries, queryFromFieldValues(key, splitCommaSeparatedValues(commaSeparatedValues), true))
 			autocompleteKey = key
 		} else {
-			queries = append(queries, queryFromFieldValues(key, strings.Split(commaSeparatedValues, ","), false))
+			queries = append(queries, queryFromFieldValues(key, splitCommaSeparatedValues(commaSeparatedValues), false))
 		}
 	}
 

--- a/pkg/search/autocomplete_query_parser.go
+++ b/pkg/search/autocomplete_query_parser.go
@@ -21,7 +21,7 @@ func (pi autocompleteQueryParser) parse(input string) (*v1.Query, string, error)
 }
 
 func (pi autocompleteQueryParser) parseInternal(query string) (*v1.Query, string, error) {
-	pairs := strings.Split(query, "+")
+	pairs := splitQuery(query)
 
 	queries := make([]*v1.Query, 0, len(pairs))
 	var autocompleteKey string

--- a/pkg/search/autocomplete_query_parser_test.go
+++ b/pkg/search/autocomplete_query_parser_test.go
@@ -69,7 +69,7 @@ func TestParseAutocompleteQuery(t *testing.T) {
 		},
 		{
 			desc:        "Query with plus in double quotes",
-			queryStr:    fmt.Sprintf("%s:field1,\"field12+something\",field13 + %s:\"field2+something\"", DeploymentName, Category),
+			queryStr:    fmt.Sprintf("%s:field1,\"field12+some:thing\",field13 + %s:\"field2+something\"", DeploymentName, Category),
 			shouldError: false,
 			parser:      autocompleteQueryParser{},
 			expectedKey: Category.String(),
@@ -88,7 +88,7 @@ func TestParseAutocompleteQuery(t *testing.T) {
 								{Query: &v1.Query_BaseQuery{
 									BaseQuery: &v1.BaseQuery{
 										Query: &v1.BaseQuery_MatchFieldQuery{
-											MatchFieldQuery: &v1.MatchFieldQuery{Field: DeploymentName.String(), Value: "\"field12+something\""},
+											MatchFieldQuery: &v1.MatchFieldQuery{Field: DeploymentName.String(), Value: "\"field12+some:thing\""},
 										},
 									},
 								}},
@@ -114,7 +114,7 @@ func TestParseAutocompleteQuery(t *testing.T) {
 		},
 		{
 			desc:        "Query with plus and comma in double quotes",
-			queryStr:    fmt.Sprintf("%s:field1,\"field12+some,thing\",field13 + %s:\"field2+some,thing\"", DeploymentName, Category),
+			queryStr:    fmt.Sprintf("%s:field1,\"field12+some,thi:ng\",field13 + %s:\"field2+some,thing\"", DeploymentName, Category),
 			shouldError: false,
 			parser:      autocompleteQueryParser{},
 			expectedKey: Category.String(),
@@ -133,7 +133,7 @@ func TestParseAutocompleteQuery(t *testing.T) {
 								{Query: &v1.Query_BaseQuery{
 									BaseQuery: &v1.BaseQuery{
 										Query: &v1.BaseQuery_MatchFieldQuery{
-											MatchFieldQuery: &v1.MatchFieldQuery{Field: DeploymentName.String(), Value: "\"field12+some,thing\""},
+											MatchFieldQuery: &v1.MatchFieldQuery{Field: DeploymentName.String(), Value: "\"field12+some,thi:ng\""},
 										},
 									},
 								}},

--- a/pkg/search/autocomplete_query_parser_test.go
+++ b/pkg/search/autocomplete_query_parser_test.go
@@ -9,51 +9,120 @@ import (
 )
 
 func TestParseAutocompleteQuery(t *testing.T) {
-	query := fmt.Sprintf("%s:field1,field12+%s:field2", DeploymentName, Category)
-	expectedQuery := &v1.Query{
-		Query: &v1.Query_Conjunction{Conjunction: &v1.ConjunctionQuery{
-			Queries: []*v1.Query{
-				{Query: &v1.Query_Disjunction{Disjunction: &v1.DisjunctionQuery{
+	testCases := []struct {
+		desc          string
+		queryStr      string
+		shouldError   bool
+		parser        autocompleteQueryParser
+		expectedKey   string
+		expectedQuery *v1.Query
+	}{
+		{
+			desc:        "Query with ANDs and ORs",
+			queryStr:    fmt.Sprintf("%s:field1,field12+%s:field2", DeploymentName, Category),
+			shouldError: false,
+			parser:      autocompleteQueryParser{},
+			expectedKey: Category.String(),
+			expectedQuery: &v1.Query{
+				Query: &v1.Query_Conjunction{Conjunction: &v1.ConjunctionQuery{
 					Queries: []*v1.Query{
+						{Query: &v1.Query_Disjunction{Disjunction: &v1.DisjunctionQuery{
+							Queries: []*v1.Query{
+								{Query: &v1.Query_BaseQuery{
+									BaseQuery: &v1.BaseQuery{
+										Query: &v1.BaseQuery_MatchFieldQuery{
+											MatchFieldQuery: &v1.MatchFieldQuery{Field: DeploymentName.String(), Value: "field1"},
+										},
+									},
+								}},
+								{Query: &v1.Query_BaseQuery{
+									BaseQuery: &v1.BaseQuery{
+										Query: &v1.BaseQuery_MatchFieldQuery{
+											MatchFieldQuery: &v1.MatchFieldQuery{Field: DeploymentName.String(), Value: "field12"},
+										},
+									},
+								}},
+							},
+						}}},
 						{Query: &v1.Query_BaseQuery{
 							BaseQuery: &v1.BaseQuery{
 								Query: &v1.BaseQuery_MatchFieldQuery{
-									MatchFieldQuery: &v1.MatchFieldQuery{Field: DeploymentName.String(), Value: "field1"},
+									MatchFieldQuery: &v1.MatchFieldQuery{Field: Category.String(), Value: "field2", Highlight: true},
 								},
 							},
 						}},
-						{Query: &v1.Query_BaseQuery{
-							BaseQuery: &v1.BaseQuery{
-								Query: &v1.BaseQuery_MatchFieldQuery{
-									MatchFieldQuery: &v1.MatchFieldQuery{Field: DeploymentName.String(), Value: "field12"},
-								},
-							},
-						}},
-					},
-				}}},
-				{Query: &v1.Query_BaseQuery{
-					BaseQuery: &v1.BaseQuery{
-						Query: &v1.BaseQuery_MatchFieldQuery{
-							MatchFieldQuery: &v1.MatchFieldQuery{Field: Category.String(), Value: "field2", Highlight: true},
-						},
 					},
 				}},
 			},
-		}},
+		},
+		{
+			desc:        "Empty query",
+			queryStr:    "",
+			shouldError: true,
+			parser:      autocompleteQueryParser{},
+		},
+		{
+			desc:        "Invalid query",
+			queryStr:    "INVALIDQUERY",
+			shouldError: true,
+			parser:      autocompleteQueryParser{},
+		},
+		{
+			desc:        "Query with plus in double quotes",
+			queryStr:    fmt.Sprintf("%s:field1,\"field12+something\",field13 + %s:\"field2+something\"", DeploymentName, Category),
+			shouldError: false,
+			parser:      autocompleteQueryParser{},
+			expectedKey: Category.String(),
+			expectedQuery: &v1.Query{
+				Query: &v1.Query_Conjunction{Conjunction: &v1.ConjunctionQuery{
+					Queries: []*v1.Query{
+						{Query: &v1.Query_Disjunction{Disjunction: &v1.DisjunctionQuery{
+							Queries: []*v1.Query{
+								{Query: &v1.Query_BaseQuery{
+									BaseQuery: &v1.BaseQuery{
+										Query: &v1.BaseQuery_MatchFieldQuery{
+											MatchFieldQuery: &v1.MatchFieldQuery{Field: DeploymentName.String(), Value: "field1"},
+										},
+									},
+								}},
+								{Query: &v1.Query_BaseQuery{
+									BaseQuery: &v1.BaseQuery{
+										Query: &v1.BaseQuery_MatchFieldQuery{
+											MatchFieldQuery: &v1.MatchFieldQuery{Field: DeploymentName.String(), Value: "\"field12+something\""},
+										},
+									},
+								}},
+								{Query: &v1.Query_BaseQuery{
+									BaseQuery: &v1.BaseQuery{
+										Query: &v1.BaseQuery_MatchFieldQuery{
+											MatchFieldQuery: &v1.MatchFieldQuery{Field: DeploymentName.String(), Value: "field13"},
+										},
+									},
+								}},
+							},
+						}}},
+						{Query: &v1.Query_BaseQuery{
+							BaseQuery: &v1.BaseQuery{
+								Query: &v1.BaseQuery_MatchFieldQuery{
+									MatchFieldQuery: &v1.MatchFieldQuery{Field: Category.String(), Value: "\"field2+something\"", Highlight: true},
+								},
+							},
+						}},
+					},
+				}},
+			},
+		},
 	}
-	expectedKey := Category.String()
-
-	var actualKey string
-	actualQuery, actualKey, err := autocompleteQueryParser{}.parse(query)
-	assert.NoError(t, err)
-	assert.Equal(t, expectedKey, actualKey)
-	assert.Equal(t, expectedQuery, actualQuery)
-
-	_, _, err = autocompleteQueryParser{}.parse("")
-	assert.Error(t, err)
-
-	// An invalid query should always return an error.
-	query = "INVALIDQUERY"
-	_, _, err = autocompleteQueryParser{}.parse(query)
-	assert.Error(t, err)
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			actualQuery, actualKey, err := tc.parser.parse(tc.queryStr)
+			if tc.shouldError {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectedKey, actualKey)
+			assert.Equal(t, tc.expectedQuery, actualQuery)
+		})
+	}
 }

--- a/pkg/search/autocomplete_query_parser_test.go
+++ b/pkg/search/autocomplete_query_parser_test.go
@@ -112,6 +112,51 @@ func TestParseAutocompleteQuery(t *testing.T) {
 				}},
 			},
 		},
+		{
+			desc:        "Query with plus and comma in double quotes",
+			queryStr:    fmt.Sprintf("%s:field1,\"field12+some,thing\",field13 + %s:\"field2+some,thing\"", DeploymentName, Category),
+			shouldError: false,
+			parser:      autocompleteQueryParser{},
+			expectedKey: Category.String(),
+			expectedQuery: &v1.Query{
+				Query: &v1.Query_Conjunction{Conjunction: &v1.ConjunctionQuery{
+					Queries: []*v1.Query{
+						{Query: &v1.Query_Disjunction{Disjunction: &v1.DisjunctionQuery{
+							Queries: []*v1.Query{
+								{Query: &v1.Query_BaseQuery{
+									BaseQuery: &v1.BaseQuery{
+										Query: &v1.BaseQuery_MatchFieldQuery{
+											MatchFieldQuery: &v1.MatchFieldQuery{Field: DeploymentName.String(), Value: "field1"},
+										},
+									},
+								}},
+								{Query: &v1.Query_BaseQuery{
+									BaseQuery: &v1.BaseQuery{
+										Query: &v1.BaseQuery_MatchFieldQuery{
+											MatchFieldQuery: &v1.MatchFieldQuery{Field: DeploymentName.String(), Value: "\"field12+some,thing\""},
+										},
+									},
+								}},
+								{Query: &v1.Query_BaseQuery{
+									BaseQuery: &v1.BaseQuery{
+										Query: &v1.BaseQuery_MatchFieldQuery{
+											MatchFieldQuery: &v1.MatchFieldQuery{Field: DeploymentName.String(), Value: "field13"},
+										},
+									},
+								}},
+							},
+						}}},
+						{Query: &v1.Query_BaseQuery{
+							BaseQuery: &v1.BaseQuery{
+								Query: &v1.BaseQuery_MatchFieldQuery{
+									MatchFieldQuery: &v1.MatchFieldQuery{Field: Category.String(), Value: "\"field2+some,thing\"", Highlight: true},
+								},
+							},
+						}},
+					},
+				}},
+			},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {

--- a/pkg/search/general_query_parser.go
+++ b/pkg/search/general_query_parser.go
@@ -16,31 +16,6 @@ type generalQueryParser struct {
 	ExcludedFieldLabels set.StringSet
 }
 
-func splitQuery(query string) []string {
-	var pairs []string
-	var previousEnd, previousPlusIndex int
-	prevDoubleQuoteCount := 0
-	for i, rune := range query {
-		if rune == ':' && previousPlusIndex != 0 {
-			if previousEnd > previousPlusIndex {
-				continue
-			}
-
-			pairs = append(pairs, query[previousEnd:previousPlusIndex])
-			previousEnd = previousPlusIndex + 1
-			continue
-		}
-		if rune == '"' {
-			prevDoubleQuoteCount++
-		}
-		if rune == '+' && prevDoubleQuoteCount%2 == 0 {
-			previousPlusIndex = i
-		}
-	}
-	pairs = append(pairs, query[previousEnd:])
-	return pairs
-}
-
 func getFieldMap(query string) map[FieldLabel][]string {
 	pairs := splitQuery(query)
 

--- a/pkg/search/general_query_parser.go
+++ b/pkg/search/general_query_parser.go
@@ -19,6 +19,7 @@ type generalQueryParser struct {
 func splitQuery(query string) []string {
 	var pairs []string
 	var previousEnd, previousPlusIndex int
+	prevDoubleQuoteCount := 0
 	for i, rune := range query {
 		if rune == ':' && previousPlusIndex != 0 {
 			if previousEnd > previousPlusIndex {
@@ -29,7 +30,10 @@ func splitQuery(query string) []string {
 			previousEnd = previousPlusIndex + 1
 			continue
 		}
-		if rune == '+' {
+		if rune == '"' {
+			prevDoubleQuoteCount++
+		}
+		if rune == '+' && prevDoubleQuoteCount%2 == 0 {
 			previousPlusIndex = i
 		}
 	}

--- a/pkg/search/general_query_parser.go
+++ b/pkg/search/general_query_parser.go
@@ -3,7 +3,6 @@ package search
 import (
 	"errors"
 	"sort"
-	"strings"
 
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/pkg/errox"
@@ -25,7 +24,8 @@ func getFieldMap(query string) map[FieldLabel][]string {
 		if !valid || !IsValidFieldLabel(key) {
 			continue
 		}
-		values := strings.Split(commaSeparatedValues, ",")
+
+		values := splitCommaSeparatedValues(commaSeparatedValues)
 		fieldMap[FieldLabel(key)] = values
 	}
 	return fieldMap

--- a/pkg/search/general_query_parser_test.go
+++ b/pkg/search/general_query_parser_test.go
@@ -111,7 +111,7 @@ func TestParseRawQuery(t *testing.T) {
 		},
 		{
 			desc:        "Query with plus in double quotes",
-			queryStr:    fmt.Sprintf("%s:field1,\"field12+something\",field13 + %s:\"field2+something\"", DeploymentName, Category),
+			queryStr:    fmt.Sprintf("%s:field1,\"field12+some:thing\",field13 + %s:\"field2+something\"", DeploymentName, Category),
 			shouldError: false,
 			parser:      generalQueryParser{},
 			expectedQuery: &v1.Query{
@@ -136,7 +136,7 @@ func TestParseRawQuery(t *testing.T) {
 								{Query: &v1.Query_BaseQuery{
 									BaseQuery: &v1.BaseQuery{
 										Query: &v1.BaseQuery_MatchFieldQuery{
-											MatchFieldQuery: &v1.MatchFieldQuery{Field: DeploymentName.String(), Value: "\"field12+something\""},
+											MatchFieldQuery: &v1.MatchFieldQuery{Field: DeploymentName.String(), Value: "\"field12+some:thing\""},
 										},
 									},
 								}},
@@ -155,7 +155,7 @@ func TestParseRawQuery(t *testing.T) {
 		},
 		{
 			desc:        "Query with plus and comma in double quotes",
-			queryStr:    fmt.Sprintf("%s:field1,\"field12+some,thing\",field13 + %s:\"field2+some,thing\"", DeploymentName, Category),
+			queryStr:    fmt.Sprintf("%s:field1,\"field12+some,thi:ng\",field13 + %s:\"field2+some,thing\"", DeploymentName, Category),
 			shouldError: false,
 			parser:      generalQueryParser{},
 			expectedQuery: &v1.Query{
@@ -180,7 +180,7 @@ func TestParseRawQuery(t *testing.T) {
 								{Query: &v1.Query_BaseQuery{
 									BaseQuery: &v1.BaseQuery{
 										Query: &v1.BaseQuery_MatchFieldQuery{
-											MatchFieldQuery: &v1.MatchFieldQuery{Field: DeploymentName.String(), Value: "\"field12+some,thing\""},
+											MatchFieldQuery: &v1.MatchFieldQuery{Field: DeploymentName.String(), Value: "\"field12+some,thi:ng\""},
 										},
 									},
 								}},

--- a/pkg/search/general_query_parser_test.go
+++ b/pkg/search/general_query_parser_test.go
@@ -9,87 +9,160 @@ import (
 )
 
 func TestParseRawQuery(t *testing.T) {
-	query := fmt.Sprintf("%s:field1,field12+%s:field2", DeploymentName, Category)
-	expectedQuery := &v1.Query{
-		Query: &v1.Query_Conjunction{Conjunction: &v1.ConjunctionQuery{
-			Queries: []*v1.Query{
-				{Query: &v1.Query_BaseQuery{
-					BaseQuery: &v1.BaseQuery{
-						Query: &v1.BaseQuery_MatchFieldQuery{
-							MatchFieldQuery: &v1.MatchFieldQuery{Field: Category.String(), Value: "field2"},
-						},
-					},
-				}},
-				{Query: &v1.Query_Disjunction{Disjunction: &v1.DisjunctionQuery{
+	testCases := []struct {
+		desc          string
+		queryStr      string
+		shouldError   bool
+		parser        generalQueryParser
+		expectedQuery *v1.Query
+	}{
+		{
+			desc:        "Query with ANDs and ORs",
+			queryStr:    fmt.Sprintf("%s:field1,field12+%s:field2", DeploymentName, Category),
+			shouldError: false,
+			parser:      generalQueryParser{},
+			expectedQuery: &v1.Query{
+				Query: &v1.Query_Conjunction{Conjunction: &v1.ConjunctionQuery{
 					Queries: []*v1.Query{
 						{Query: &v1.Query_BaseQuery{
 							BaseQuery: &v1.BaseQuery{
 								Query: &v1.BaseQuery_MatchFieldQuery{
-									MatchFieldQuery: &v1.MatchFieldQuery{Field: DeploymentName.String(), Value: "field1"},
+									MatchFieldQuery: &v1.MatchFieldQuery{Field: Category.String(), Value: "field2"},
 								},
 							},
 						}},
-						{Query: &v1.Query_BaseQuery{
-							BaseQuery: &v1.BaseQuery{
-								Query: &v1.BaseQuery_MatchFieldQuery{
-									MatchFieldQuery: &v1.MatchFieldQuery{Field: DeploymentName.String(), Value: "field12"},
-								},
+						{Query: &v1.Query_Disjunction{Disjunction: &v1.DisjunctionQuery{
+							Queries: []*v1.Query{
+								{Query: &v1.Query_BaseQuery{
+									BaseQuery: &v1.BaseQuery{
+										Query: &v1.BaseQuery_MatchFieldQuery{
+											MatchFieldQuery: &v1.MatchFieldQuery{Field: DeploymentName.String(), Value: "field1"},
+										},
+									},
+								}},
+								{Query: &v1.Query_BaseQuery{
+									BaseQuery: &v1.BaseQuery{
+										Query: &v1.BaseQuery_MatchFieldQuery{
+											MatchFieldQuery: &v1.MatchFieldQuery{Field: DeploymentName.String(), Value: "field12"},
+										},
+									},
+								}},
 							},
-						}},
-					},
-				}}},
-			},
-		}},
-	}
-	actualQuery, err := generalQueryParser{}.parse(query)
-	assert.NoError(t, err)
-	assert.Equal(t, expectedQuery, actualQuery)
-
-	query = fmt.Sprintf("%s:field1,field12 + %s:field2", DeploymentName, Category)
-
-	expectedQuery = &v1.Query{
-		Query: &v1.Query_Conjunction{Conjunction: &v1.ConjunctionQuery{
-			Queries: []*v1.Query{
-				{Query: &v1.Query_BaseQuery{
-					BaseQuery: &v1.BaseQuery{
-						Query: &v1.BaseQuery_MatchFieldQuery{
-							MatchFieldQuery: &v1.MatchFieldQuery{Field: Category.String(), Value: "field2"},
-						},
+						}}},
 					},
 				}},
-				{Query: &v1.Query_Disjunction{Disjunction: &v1.DisjunctionQuery{
+			},
+		},
+		{
+			desc:        "Query with ANDs, ORs and extra white spaces",
+			queryStr:    fmt.Sprintf("%s:field1,field12 + %s:field2", DeploymentName, Category),
+			shouldError: false,
+			parser:      generalQueryParser{},
+			expectedQuery: &v1.Query{
+				Query: &v1.Query_Conjunction{Conjunction: &v1.ConjunctionQuery{
 					Queries: []*v1.Query{
 						{Query: &v1.Query_BaseQuery{
 							BaseQuery: &v1.BaseQuery{
 								Query: &v1.BaseQuery_MatchFieldQuery{
-									MatchFieldQuery: &v1.MatchFieldQuery{Field: DeploymentName.String(), Value: "field1"},
+									MatchFieldQuery: &v1.MatchFieldQuery{Field: Category.String(), Value: "field2"},
 								},
 							},
 						}},
+						{Query: &v1.Query_Disjunction{Disjunction: &v1.DisjunctionQuery{
+							Queries: []*v1.Query{
+								{Query: &v1.Query_BaseQuery{
+									BaseQuery: &v1.BaseQuery{
+										Query: &v1.BaseQuery_MatchFieldQuery{
+											MatchFieldQuery: &v1.MatchFieldQuery{Field: DeploymentName.String(), Value: "field1"},
+										},
+									},
+								}},
+								{Query: &v1.Query_BaseQuery{
+									BaseQuery: &v1.BaseQuery{
+										Query: &v1.BaseQuery_MatchFieldQuery{
+											MatchFieldQuery: &v1.MatchFieldQuery{Field: DeploymentName.String(), Value: "field12"},
+										},
+									},
+								}},
+							},
+						}}},
+					},
+				}},
+			},
+		},
+		{
+			desc:        "Empty query with MatchAllIfEmpty not set to true",
+			queryStr:    "",
+			shouldError: true,
+			parser:      generalQueryParser{},
+		},
+		{
+			desc:          "Empty query with MatchAllIfEmpty set to true",
+			queryStr:      "",
+			shouldError:   false,
+			parser:        generalQueryParser{MatchAllIfEmpty: true},
+			expectedQuery: EmptyQuery(),
+		},
+		{
+			desc:        "Invalid query",
+			queryStr:    "INVALIDQUERY",
+			shouldError: true,
+			parser:      generalQueryParser{},
+		},
+		{
+			desc:        "Query with plus in double quotes",
+			queryStr:    fmt.Sprintf("%s:field1,\"field12+something\",field13 + %s:\"field2+something\"", DeploymentName, Category),
+			shouldError: false,
+			parser:      generalQueryParser{},
+			expectedQuery: &v1.Query{
+				Query: &v1.Query_Conjunction{Conjunction: &v1.ConjunctionQuery{
+					Queries: []*v1.Query{
 						{Query: &v1.Query_BaseQuery{
 							BaseQuery: &v1.BaseQuery{
 								Query: &v1.BaseQuery_MatchFieldQuery{
-									MatchFieldQuery: &v1.MatchFieldQuery{Field: DeploymentName.String(), Value: "field12"},
+									MatchFieldQuery: &v1.MatchFieldQuery{Field: Category.String(), Value: "\"field2+something\""},
 								},
 							},
 						}},
+						{Query: &v1.Query_Disjunction{Disjunction: &v1.DisjunctionQuery{
+							Queries: []*v1.Query{
+								{Query: &v1.Query_BaseQuery{
+									BaseQuery: &v1.BaseQuery{
+										Query: &v1.BaseQuery_MatchFieldQuery{
+											MatchFieldQuery: &v1.MatchFieldQuery{Field: DeploymentName.String(), Value: "field1"},
+										},
+									},
+								}},
+								{Query: &v1.Query_BaseQuery{
+									BaseQuery: &v1.BaseQuery{
+										Query: &v1.BaseQuery_MatchFieldQuery{
+											MatchFieldQuery: &v1.MatchFieldQuery{Field: DeploymentName.String(), Value: "\"field12+something\""},
+										},
+									},
+								}},
+								{Query: &v1.Query_BaseQuery{
+									BaseQuery: &v1.BaseQuery{
+										Query: &v1.BaseQuery_MatchFieldQuery{
+											MatchFieldQuery: &v1.MatchFieldQuery{Field: DeploymentName.String(), Value: "field13"},
+										},
+									},
+								}},
+							},
+						}}},
 					},
-				}}},
+				}},
 			},
-		}},
+		},
 	}
-	actualQuery, err = generalQueryParser{}.parse(query)
-	assert.NoError(t, err)
-	assert.Equal(t, expectedQuery, actualQuery)
-
-	_, err = generalQueryParser{}.parse("")
-	assert.Error(t, err)
-	actualQuery, err = generalQueryParser{MatchAllIfEmpty: true}.parse("")
-	assert.NoError(t, err)
-	assert.Equal(t, EmptyQuery(), actualQuery)
-
-	// An invalid query should return an error.
-	query = "INVALIDQUERY"
-	_, err = generalQueryParser{}.parse(query)
-	assert.Error(t, err)
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			actualQuery, err := tc.parser.parse(tc.queryStr)
+			if tc.shouldError {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectedQuery, actualQuery)
+		})
+	}
 }

--- a/pkg/search/general_query_parser_test.go
+++ b/pkg/search/general_query_parser_test.go
@@ -153,6 +153,50 @@ func TestParseRawQuery(t *testing.T) {
 				}},
 			},
 		},
+		{
+			desc:        "Query with plus and comma in double quotes",
+			queryStr:    fmt.Sprintf("%s:field1,\"field12+some,thing\",field13 + %s:\"field2+some,thing\"", DeploymentName, Category),
+			shouldError: false,
+			parser:      generalQueryParser{},
+			expectedQuery: &v1.Query{
+				Query: &v1.Query_Conjunction{Conjunction: &v1.ConjunctionQuery{
+					Queries: []*v1.Query{
+						{Query: &v1.Query_BaseQuery{
+							BaseQuery: &v1.BaseQuery{
+								Query: &v1.BaseQuery_MatchFieldQuery{
+									MatchFieldQuery: &v1.MatchFieldQuery{Field: Category.String(), Value: "\"field2+some,thing\""},
+								},
+							},
+						}},
+						{Query: &v1.Query_Disjunction{Disjunction: &v1.DisjunctionQuery{
+							Queries: []*v1.Query{
+								{Query: &v1.Query_BaseQuery{
+									BaseQuery: &v1.BaseQuery{
+										Query: &v1.BaseQuery_MatchFieldQuery{
+											MatchFieldQuery: &v1.MatchFieldQuery{Field: DeploymentName.String(), Value: "field1"},
+										},
+									},
+								}},
+								{Query: &v1.Query_BaseQuery{
+									BaseQuery: &v1.BaseQuery{
+										Query: &v1.BaseQuery_MatchFieldQuery{
+											MatchFieldQuery: &v1.MatchFieldQuery{Field: DeploymentName.String(), Value: "\"field12+some,thing\""},
+										},
+									},
+								}},
+								{Query: &v1.Query_BaseQuery{
+									BaseQuery: &v1.BaseQuery{
+										Query: &v1.BaseQuery_MatchFieldQuery{
+											MatchFieldQuery: &v1.MatchFieldQuery{Field: DeploymentName.String(), Value: "field13"},
+										},
+									},
+								}},
+							},
+						}}},
+					},
+				}},
+			},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {

--- a/pkg/search/parser.go
+++ b/pkg/search/parser.go
@@ -87,8 +87,15 @@ func GetFieldValueFromQuery(query string, label FieldLabel) (string, bool) {
 func splitQuery(query string) []string {
 	var pairs []string
 	var previousEnd, previousPlusIndex int
-	prevDoubleQuoteCount := 0
+	insideDoubleQuotes := false
 	for i, rune := range query {
+		if rune == '"' {
+			insideDoubleQuotes = !insideDoubleQuotes
+			continue
+		}
+		if insideDoubleQuotes {
+			continue
+		}
 		if rune == ':' && previousPlusIndex != 0 {
 			if previousEnd > previousPlusIndex {
 				continue
@@ -98,10 +105,7 @@ func splitQuery(query string) []string {
 			previousEnd = previousPlusIndex + 1
 			continue
 		}
-		if rune == '"' {
-			prevDoubleQuoteCount++
-		}
-		if rune == '+' && prevDoubleQuoteCount%2 == 0 {
+		if rune == '+' {
 			previousPlusIndex = i
 		}
 	}
@@ -112,12 +116,13 @@ func splitQuery(query string) []string {
 func splitCommaSeparatedValues(commaSeparatedValues string) []string {
 	var vals []string
 	start := 0
-	prevDoubleQuoteCount := 0
+	insideDoubleQuotes := false
 	for i, char := range commaSeparatedValues {
 		if char == '"' {
-			prevDoubleQuoteCount++
+			insideDoubleQuotes = !insideDoubleQuotes
+			continue
 		}
-		if char == ',' && prevDoubleQuoteCount%2 == 0 {
+		if char == ',' && !insideDoubleQuotes {
 			vals = append(vals, commaSeparatedValues[start:i])
 			start = i + 1
 		}

--- a/pkg/search/parser.go
+++ b/pkg/search/parser.go
@@ -129,6 +129,8 @@ func splitCommaSeparatedValues(commaSeparatedValues string) []string {
 	}
 	if start <= len(commaSeparatedValues)-1 {
 		vals = append(vals, commaSeparatedValues[start:])
+	} else if commaSeparatedValues[len(commaSeparatedValues)-1] == ',' {
+		vals = append(vals, "")
 	}
 	return vals
 }

--- a/pkg/search/parser.go
+++ b/pkg/search/parser.go
@@ -84,6 +84,31 @@ func GetFieldValueFromQuery(query string, label FieldLabel) (string, bool) {
 	return "", false
 }
 
+func splitQuery(query string) []string {
+	var pairs []string
+	var previousEnd, previousPlusIndex int
+	prevDoubleQuoteCount := 0
+	for i, rune := range query {
+		if rune == ':' && previousPlusIndex != 0 {
+			if previousEnd > previousPlusIndex {
+				continue
+			}
+
+			pairs = append(pairs, query[previousEnd:previousPlusIndex])
+			previousEnd = previousPlusIndex + 1
+			continue
+		}
+		if rune == '"' {
+			prevDoubleQuoteCount++
+		}
+		if rune == '+' && prevDoubleQuoteCount%2 == 0 {
+			previousPlusIndex = i
+		}
+	}
+	pairs = append(pairs, query[previousEnd:])
+	return pairs
+}
+
 // Extracts "key", "value1,value2" from a string in the format key:value1,value2
 func parsePair(pair string, allowEmpty bool) (key string, values string, valid bool) {
 	pair = strings.TrimSpace(pair)

--- a/pkg/search/parser.go
+++ b/pkg/search/parser.go
@@ -109,6 +109,25 @@ func splitQuery(query string) []string {
 	return pairs
 }
 
+func splitCommaSeparatedValues(commaSeparatedValues string) []string {
+	var vals []string
+	start := 0
+	prevDoubleQuoteCount := 0
+	for i, char := range commaSeparatedValues {
+		if char == '"' {
+			prevDoubleQuoteCount++
+		}
+		if char == ',' && prevDoubleQuoteCount%2 == 0 {
+			vals = append(vals, commaSeparatedValues[start:i])
+			start = i + 1
+		}
+	}
+	if start <= len(commaSeparatedValues)-1 {
+		vals = append(vals, commaSeparatedValues[start:])
+	}
+	return vals
+}
+
 // Extracts "key", "value1,value2" from a string in the format key:value1,value2
 func parsePair(pair string, allowEmpty bool) (key string, values string, valid bool) {
 	pair = strings.TrimSpace(pair)

--- a/pkg/search/parser_test.go
+++ b/pkg/search/parser_test.go
@@ -43,11 +43,45 @@ func TestSplitQuery(t *testing.T) {
 			query: "Deployment:attempted-alerts-dep-6+Policy:Kubernetes Actions: Exec into Pod,hello+hi+New Deployment Label:value",
 			pairs: []string{"Deployment:attempted-alerts-dep-6", "Policy:Kubernetes Actions: Exec into Pod,hello+hi", "New Deployment Label:value"},
 		},
+		{
+			query: "Deployment:field1,\"field12+some:thing\",field13+Category:\"field2+something\"",
+			pairs: []string{"Deployment:field1,\"field12+some:thing\",field13", "Category:\"field2+something\""},
+		},
+		{
+			query: "Deployment:field1,\"field12+some,thi:ng\",field13+Category:\"field2+some,thing\"",
+			pairs: []string{"Deployment:field1,\"field12+some,thi:ng\",field13", "Category:\"field2+some,thing\""},
+		},
 	}
 
 	for _, c := range cases {
 		t.Run(c.query, func(t *testing.T) {
 			assert.ElementsMatch(t, c.pairs, splitQuery(c.query))
+		})
+	}
+}
+
+func TestSplitCommaSeparateValues(t *testing.T) {
+	cases := []struct {
+		commaSeparatedVals string
+		splitValues        []string
+	}{
+		{
+			commaSeparatedVals: "val1,val2,val3+val4",
+			splitValues:        []string{"val1", "val2", "val3+val4"},
+		},
+		{
+			commaSeparatedVals: "val1,val2,val3+val:4+val5",
+			splitValues:        []string{"val1", "val2", "val3+val:4+val5"},
+		},
+		{
+			commaSeparatedVals: "val1,val2,\"val3,val:4+val5\",val6",
+			splitValues:        []string{"val1", "val2", "\"val3,val:4+val5\"", "val6"},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.commaSeparatedVals, func(t *testing.T) {
+			assert.ElementsMatch(t, c.splitValues, splitCommaSeparatedValues(c.commaSeparatedVals))
 		})
 	}
 }

--- a/pkg/search/parser_test.go
+++ b/pkg/search/parser_test.go
@@ -1,6 +1,7 @@
 package search
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -157,6 +158,12 @@ func TestParsePairs(t *testing.T) {
 			query:      "Deployment Label:attempted-alerts-dep-6+Policy:Kubernetes Actions: Exec into Pod",
 			allowEmpty: false,
 			pairs:      []string{"Deployment Label", "attempted-alerts-dep-6+Policy:Kubernetes Actions: Exec into Pod"},
+			valid:      true,
+		},
+		{
+			query:      "Deployment Label:label1,label2,",
+			allowEmpty: true,
+			pairs:      []string{"Deployment Label", fmt.Sprintf("label1,label2,%s", WildcardString)},
 			valid:      true,
 		},
 	}

--- a/pkg/search/parser_test.go
+++ b/pkg/search/parser_test.go
@@ -77,6 +77,18 @@ func TestSplitCommaSeparateValues(t *testing.T) {
 			commaSeparatedVals: "val1,val2,\"val3,val:4+val5\",val6",
 			splitValues:        []string{"val1", "val2", "\"val3,val:4+val5\"", "val6"},
 		},
+		{
+			commaSeparatedVals: ",val1,val2,val3,",
+			splitValues:        []string{"", "val1", "val2", "val3", ""},
+		},
+		{
+			commaSeparatedVals: ",,",
+			splitValues:        []string{"", "", ""},
+		},
+		{
+			commaSeparatedVals: ",",
+			splitValues:        []string{"", ""},
+		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
## Description

Plus `+` is used to indicate a conjunction (`AND`) between match field queries and comma `,` is used to indicate a disjunction (`OR`). But they can also be a part of search value for a field. To allow that if a plus or comma is enclosed in quotes, it should be ignored.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Unit tests

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
