### PR TITLE
ROX-16322: Telemetry should be enabled by default

### DIFF
--- a/ui/apps/platform/src/Containers/SystemConfig/Details/PublicConfigTelemetryDetails.tsx
+++ b/ui/apps/platform/src/Containers/SystemConfig/Details/PublicConfigTelemetryDetails.tsx
@@ -19,7 +19,8 @@ export type PublicConfigTelemetryDetailsProps = {
 const PublicConfigTelemetryDetails = ({
     publicConfig,
 }: PublicConfigTelemetryDetailsProps): ReactElement => {
-    const isEnabled = publicConfig?.telemetry?.enabled || false;
+    // telemetry will be enabled by default which is why we only check for false here. null/undefined/true will all equate to enabled.
+    const isEnabled = publicConfig?.telemetry?.enabled !== false;
 
     return (
         <Card isFlat data-testid="telemetry-config">

--- a/ui/apps/platform/src/Containers/SystemConfig/Details/SystemConfigDetails.tsx
+++ b/ui/apps/platform/src/Containers/SystemConfig/Details/SystemConfigDetails.tsx
@@ -19,7 +19,7 @@ function SystemConfigDetails({
     isClustersRoutePathRendered,
     systemConfig,
 }: SystemConfigDetailsProps): ReactElement {
-    const telemetryConfigEnabled = useSelector(selectors.getIsTelemetryConfigured);
+    const isTelemetryConfigured = useSelector(selectors.getIsTelemetryConfigured);
     return (
         <>
             <PageSection data-testid="data-retention-config">
@@ -51,7 +51,7 @@ function SystemConfigDetails({
                     <GridItem sm={12} md={6}>
                         <PublicConfigLoginDetails publicConfig={systemConfig?.publicConfig} />
                     </GridItem>
-                    {telemetryConfigEnabled && (
+                    {isTelemetryConfigured && (
                         <GridItem sm={12} md={6}>
                             <PublicConfigTelemetryDetails
                                 publicConfig={systemConfig?.publicConfig}

--- a/ui/apps/platform/src/Containers/SystemConfig/Form/SystemConfigForm.tsx
+++ b/ui/apps/platform/src/Containers/SystemConfig/Form/SystemConfigForm.tsx
@@ -56,7 +56,7 @@ function getCompletePublicConfig(systemConfig: SystemConfig): PublicConfig {
             enabled: systemConfig?.publicConfig?.loginNotice?.enabled || false,
         },
         telemetry: {
-            enabled: systemConfig?.publicConfig?.telemetry?.enabled || false,
+            enabled: systemConfig?.publicConfig?.telemetry?.enabled !== false,
         },
     };
 }

--- a/ui/apps/platform/src/reducers/telemetryConfig.js
+++ b/ui/apps/platform/src/reducers/telemetryConfig.js
@@ -20,7 +20,8 @@ export const fetchTelemetryConfigThunk = () => {
         try {
             const result = await fetchTelemetryConfig();
             const { app: appState } = getState();
-            const telemetryEnabled = appState?.publicConfig?.publicConfig?.telemetry?.enabled;
+            const telemetryEnabled =
+                appState?.publicConfig?.publicConfig?.telemetry?.enabled !== false;
             if (telemetryEnabled) {
                 initializeAnalytics(result.response.storageKeyV1, result.response.userId);
             }


### PR DESCRIPTION
## Description

Enable telemetry by default by allowing null/undefined to equate to true

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Running fresh deployment results in telemetry defaulting to enabled