### PR TITLE
ROX-15429: Change anomalous traffic icon to triangle

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/common/FlowsTable.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/common/FlowsTable.tsx
@@ -19,7 +19,7 @@ import {
     TextVariants,
     Tooltip,
 } from '@patternfly/react-core';
-import { ExclamationCircleIcon, MinusIcon, PlusIcon } from '@patternfly/react-icons';
+import { ExclamationTriangleIcon, MinusIcon, PlusIcon } from '@patternfly/react-icons';
 
 import { BaselineSimulationDiffState, Flow, FlowEntityType } from '../types/flow.type';
 import { protocolLabel } from '../utils/flowUtils';
@@ -99,13 +99,13 @@ function AnomalousIcon({ type }: { type: FlowEntityType }) {
     if (type === 'CIDR_BLOCK' || type === 'EXTERNAL_ENTITIES') {
         return (
             <Tooltip content={<div>Anomalous external flow</div>}>
-                <ExclamationCircleIcon className="pf-u-danger-color-100" />
+                <ExclamationTriangleIcon className="pf-u-danger-color-100" />
             </Tooltip>
         );
     }
     return (
         <Tooltip content={<div>Anomalous internal flow</div>}>
-            <ExclamationCircleIcon className="pf-u-warning-color-100" />
+            <ExclamationTriangleIcon className="pf-u-warning-color-100" />
         </Tooltip>
     );
 }

--- a/ui/apps/platform/src/Containers/NetworkGraph/common/FlowsTable.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/common/FlowsTable.tsx
@@ -19,7 +19,12 @@ import {
     TextVariants,
     Tooltip,
 } from '@patternfly/react-core';
-import { ExclamationTriangleIcon, MinusIcon, PlusIcon } from '@patternfly/react-icons';
+import {
+    ExclamationCircleIcon,
+    ExclamationTriangleIcon,
+    MinusIcon,
+    PlusIcon,
+} from '@patternfly/react-icons';
 
 import { BaselineSimulationDiffState, Flow, FlowEntityType } from '../types/flow.type';
 import { protocolLabel } from '../utils/flowUtils';
@@ -99,7 +104,7 @@ function AnomalousIcon({ type }: { type: FlowEntityType }) {
     if (type === 'CIDR_BLOCK' || type === 'EXTERNAL_ENTITIES') {
         return (
             <Tooltip content={<div>Anomalous external flow</div>}>
-                <ExclamationTriangleIcon className="pf-u-danger-color-100" />
+                <ExclamationCircleIcon className="pf-u-danger-color-100" />
             </Tooltip>
         );
     }


### PR DESCRIPTION
## Description

This PR updates the anomalous traffic icon to be a triangle for consistency

<img width="450" alt="Screenshot 2023-04-03 at 12 40 07 PM" src="https://user-images.githubusercontent.com/4805485/229610672-2ac3275c-20ab-45f3-9137-9006e4103282.png">
<img width="452" alt="Screenshot 2023-04-03 at 12 40 39 PM" src="https://user-images.githubusercontent.com/4805485/229610678-19a3c055-7078-4991-b485-554f64698fb5.png">
