### PR TITLE
Replace Th which has empty text with Td

### DIFF
--- a/ui/apps/platform/src/Containers/AccessControl/AccessScopes/LabelSelectorCard.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessScopes/LabelSelectorCard.tsx
@@ -16,7 +16,7 @@ import {
     Tooltip,
 } from '@patternfly/react-core';
 import { OutlinedQuestionCircleIcon, PlusCircleIcon } from '@patternfly/react-icons';
-import { TableComposable, Tbody, Th, Thead, Tr } from '@patternfly/react-table';
+import { TableComposable, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
 import { LabelSelectorRequirement, LabelSelectorsKey } from 'services/AccessScopesService';
 
@@ -197,7 +197,7 @@ function LabelSelectorCard({
                         <Thead>
                             <Tr>
                                 <Th width={40}>Key</Th>
-                                <Th />
+                                <Td />
                                 <Th width={40}>Values</Th>
                                 {isLabelSelectorActive && <Th modifier="fitContent">Action</Th>}
                             </Tr>

--- a/ui/apps/platform/src/Containers/AccessControl/Roles/AccessScopesTable.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/Roles/AccessScopesTable.tsx
@@ -22,7 +22,7 @@ function AccessScopesTable({
         <TableComposable variant="compact" isStickyHeader>
             <Thead>
                 <Tr>
-                    <Th />
+                    <Td />
                     <Th width={20}>Name</Th>
                     <Th>Description</Th>
                 </Tr>

--- a/ui/apps/platform/src/Containers/NetworkGraph/common/FlowsTable.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/common/FlowsTable.tsx
@@ -163,7 +163,7 @@ function FlowsTable({
         <TableComposable aria-label={label} variant="compact">
             <Thead>
                 <Tr>
-                    <Th />
+                    <Td />
                     {isEditable && (
                         <Th
                             select={{
@@ -172,11 +172,11 @@ function FlowsTable({
                             }}
                         />
                     )}
-                    {isBaselineSimulation && <Th />}
+                    {isBaselineSimulation && <Td />}
                     <Th>{columnNames.entity}</Th>
                     <Th modifier="nowrap">{columnNames.direction}</Th>
                     <Th modifier="nowrap">{columnNames.portAndProtocol}</Th>
-                    <Th />
+                    <Td />
                 </Tr>
             </Thead>
             {flows.map((row, rowIndex) => {

--- a/ui/apps/platform/src/Containers/Policies/Modal/EnableDisableNotificationModal.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Modal/EnableDisableNotificationModal.tsx
@@ -94,7 +94,6 @@ function EnableDisableNotificationModal({
                                 }}
                             />
                             <Th modifier="wrap">Select notifers</Th>
-                            <Th />
                         </Tr>
                     </Thead>
                     <Tbody>

--- a/ui/apps/platform/src/Containers/Policies/Table/PoliciesTable.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Table/PoliciesTable.tsx
@@ -370,7 +370,7 @@ function PoliciesTable({
                                     </Th>
                                 );
                             })}
-                            <Th />
+                            <Td />
                         </Tr>
                     </Thead>
                     <Tbody>

--- a/ui/apps/platform/src/Containers/Violations/ViolationsTablePanel.tsx
+++ b/ui/apps/platform/src/Containers/Violations/ViolationsTablePanel.tsx
@@ -193,7 +193,7 @@ function ViolationsTablePanel({
                                     </Th>
                                 );
                             })}
-                            <Th />
+                            <Td />
                         </Tr>
                     </Thead>
                     <Tbody>

--- a/ui/apps/platform/src/Containers/VulnMgmt/Reports/VulnMgmtReportTablePanel.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Reports/VulnMgmtReportTablePanel.tsx
@@ -286,7 +286,7 @@ function ReportingTablePanel({
                                     </Th>
                                 );
                             })}
-                            <Th />
+                            <Td />
                         </Tr>
                     </Thead>
                     <Tbody>

--- a/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/AffectedComponents/AffectedComponentsModal.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/RiskAcceptance/AffectedComponents/AffectedComponentsModal.tsx
@@ -82,7 +82,7 @@ function AffectedComponentsModal({
                 <TableComposable aria-label="Affected Components Table" variant="compact" borders>
                     <Thead>
                         <Tr>
-                            <Th />
+                            <Td />
                             <Th>Component</Th>
                             <Th>Version</Th>
                             <Th>Fixed in</Th>


### PR DESCRIPTION
## Description

### Problem

Solve minor issue from axe DevTools in Search results table:

> Table header text should not be empty

### Analysis

PatternFly examples follow the accessibility work-around to render `Td` instead of `Th` element.

### Solution

Join them if you cannot beat them: an attempt to render **Actions** required additional utility classes in both the table **head** and table **data** cells.

Delete extra `Th` element that does not correspond to a column in `EnableDisableNotificationModal` component.

### Residue

1. Replace `any` in `VulnMgmtReportTablePanel` component.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

### Manual testing

1. Visit /main/violations

    * with PatternFly `Th` element that renders as HTML `th` element.
        ![Th_axe](https://user-images.githubusercontent.com/11862657/229613775-36cf2d4b-032d-4ef7-8b2b-95929099f0e8.png)

        ![Th_inspect](https://user-images.githubusercontent.com/11862657/229613817-5bd4dc7d-ac24-422b-ba3d-eef4bd0a857f.png)

    * with PatternFly `Td` element that renders as HTML `td` element
        ![Td_axe](https://user-images.githubusercontent.com/11862657/229613863-a8a91a9b-b7d0-4c23-9a5e-4b245674cad5.png)

        ![Td_inspect](https://user-images.githubusercontent.com/11862657/229613901-daa2029d-f439-40a4-b3cf-460be58bf073.png)
