### PR TITLE
ROX-16279: Add new flag to diagnostic bundle

### DIFF
--- a/central/debug/service/service.go
+++ b/central/debug/service/service.go
@@ -104,7 +104,7 @@ type Service interface {
 func New(clusters datastore.DataStore, sensorConnMgr connection.Manager, telemetryGatherer *gatherers.RoxGatherer,
 	store store.Store, authzTraceSink observe.AuthzTraceSink, authProviderRegistry authproviders.Registry,
 	groupDataStore groupDS.DataStore, roleDataStore roleDS.DataStore, configDataStore configDS.DataStore,
-	notifierDataStore notifierDS.DataStore) Service {
+	notifierDataStore notifierDS.DataStore, alertDataStore alertStore.DataStore) Service {
 	return &serviceImpl{
 		clusters:             clusters,
 		sensorConnMgr:        sensorConnMgr,
@@ -116,8 +116,7 @@ func New(clusters datastore.DataStore, sensorConnMgr connection.Manager, telemet
 		roleDataStore:        roleDataStore,
 		configDataStore:      configDataStore,
 		notifierDataStore:    notifierDataStore,
-		// TODO: Inject dependency
-		alertDataStore: nil,
+		alertDataStore:       alertDataStore,
 	}
 }
 
@@ -643,7 +642,6 @@ func (s *serviceImpl) writeZippedDebugDump(ctx context.Context, w http.ResponseW
 		// to be reprocessed will appear in the new JSON file.
 		time.Sleep(time.Minute)
 		fetchAndAddJSONToZip(debugDumpCtx, zipWriter, "alerts-after.json", s.fetchAlerts)
-
 	}
 
 	// Get logs last to also catch logs made during creation of diag bundle.

--- a/central/debug/service/service.go
+++ b/central/debug/service/service.go
@@ -691,7 +691,7 @@ func (s *serviceImpl) getDebugDump(w http.ResponseWriter, r *http.Request) {
 		withLogImbue:      true,
 		withAccessControl: true,
 		withNotifiers:     true,
-		withAlerts:        true,
+		withAlerts:        false,
 		withCentral:       env.EnableCentralDiagnostics.BooleanSetting(),
 		telemetryMode:     0,
 	}
@@ -739,7 +739,7 @@ func (s *serviceImpl) getDiagnosticDump(w http.ResponseWriter, r *http.Request) 
 		withAccessControl: true,
 		withCentral:       env.EnableCentralDiagnostics.BooleanSetting(),
 		withNotifiers:     true,
-		withAlerts:        true,
+		withAlerts:        false,
 	}
 
 	err := getOptionalQueryParams(&opts, r.URL)
@@ -769,6 +769,11 @@ func getOptionalQueryParams(opts *debugDumpOptions, u *url.URL) error {
 		opts.since = t
 	} else {
 		opts.since = time.Now().Add(-logWindow)
+	}
+
+	withAlerts := values.Get("alerts")
+	if withAlerts == "true" {
+		opts.withAlerts = true
 	}
 	return nil
 }

--- a/central/main.go
+++ b/central/main.go
@@ -355,6 +355,7 @@ func servicesToRegister(registry authproviders.Registry, authzTraceSink observe.
 			roleDataStore.Singleton(),
 			configDS.Singleton(),
 			notifierDS.Singleton(),
+			alertDatastore.Singleton(),
 		),
 		deploymentService.Singleton(),
 		detectionService.Singleton(),

--- a/roxctl/central/debug/download_diagnostics.go
+++ b/roxctl/central/debug/download_diagnostics.go
@@ -26,6 +26,7 @@ func downloadDiagnosticsCommand(cliEnvironment environment.Environment) *cobra.C
 	var clusters []string
 	var since string
 	var withAlerts bool
+	var reprocessDelay time.Duration
 
 	c := &cobra.Command{
 		Use:   "download-diagnostics",
@@ -44,6 +45,7 @@ func downloadDiagnosticsCommand(cliEnvironment environment.Environment) *cobra.C
 			}
 			if withAlerts {
 				values.Add("alerts", "true")
+				values.Add("reprocessDelay", reprocessDelay.String())
 			}
 
 			urlParams := values.Encode()
@@ -74,6 +76,7 @@ To specify timeout, run  'roxctl' command:
 	c.PersistentFlags().StringSliceVar(&clusters, "clusters", nil, "comma separated list of sensor clusters from which logs should be collected")
 	c.PersistentFlags().StringVar(&since, "since", "", "timestamp starting when logs should be collected from sensor clusters")
 	c.PersistentFlags().BoolVar(&withAlerts, "with-alerts", false, "add alert data before/after reassessing policies")
+	c.PersistentFlags().DurationVar(&reprocessDelay, "reprocess-delay", 1*time.Minute, "set the delay duration between the policy reprocessing")
 
 	return c
 }

--- a/roxctl/central/debug/download_diagnostics.go
+++ b/roxctl/central/debug/download_diagnostics.go
@@ -25,6 +25,7 @@ func downloadDiagnosticsCommand(cliEnvironment environment.Environment) *cobra.C
 	var outputDir string
 	var clusters []string
 	var since string
+	var withAlerts bool
 
 	c := &cobra.Command{
 		Use:   "download-diagnostics",
@@ -40,6 +41,9 @@ func downloadDiagnosticsCommand(cliEnvironment environment.Environment) *cobra.C
 			}
 			if since != "" {
 				values.Add("since", since)
+			}
+			if withAlerts {
+				values.Add("alerts", "true")
 			}
 
 			urlParams := values.Encode()
@@ -69,6 +73,7 @@ To specify timeout, run  'roxctl' command:
 	c.PersistentFlags().StringVar(&outputDir, "output-dir", "", "output directory in which to store bundle")
 	c.PersistentFlags().StringSliceVar(&clusters, "clusters", nil, "comma separated list of sensor clusters from which logs should be collected")
 	c.PersistentFlags().StringVar(&since, "since", "", "timestamp starting when logs should be collected from sensor clusters")
+	c.PersistentFlags().BoolVar(&withAlerts, "with-alerts", false, "add alert data before/after reassessing policies")
 
 	return c
 }


### PR DESCRIPTION
## Description

Allows diagnostic bundles to have alert information.

**Context:** the reason why this is being added is to check whether Sensors with re-sync disabled are behaving as expected, without having to re-run sensor with re-sync enabled and compare alerts. The alternative we are proposing here is: when requesting a diagnostic bundle, allow a flag that will request alerts, reprocess all deployments and request alerts again. What we (as team Maple) can do with this info is: check that there is no delta between the two. This gives us confidence that, even after reprocessing everything, Sensor was able to identify all resource changes that led to alerts. 

This flag should be used only through `roxctl` and it's here as a sanity check to test that secured clusters with re-sync disabled are producing the correct alerts. 

Since the new files (`alerts-*.json`) will take a while to generate, we shouldn't have them enabled by default, and should only be used explicitly by customers that are testing the re-sync changes. 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

- [ ] Request diagnostic bundle via `roxctl`