### PR TITLE
ROX-15348: Log network baseline to see if kube api server gets there

### DIFF
--- a/qa-tests-backend/src/test/groovy/IntegrationsSplunkViolationsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/IntegrationsSplunkViolationsTest.groovy
@@ -330,6 +330,8 @@ class IntegrationsSplunkViolationsTest extends BaseSpecification {
         // Lock the baseline so that any different requests from (and to) Splunk pod would make a violation.
         NetworkBaselineService.lockNetworkBaseline(splunkUid)
 
+        log.info("Current network baseline is: ${NetworkBaselineService.getNetworkBaseline(splunkUid)}")
+
         // Make anomalous request from Splunk towards Kube API server. This should trigger a network flow violation.
         assert retryUntilTrue({
             orchestrator.execInContainer(splunkDeployment.deployment,


### PR DESCRIPTION
## Description

This is to investigate cause for network flow violation not appearing.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

* Check Splunk test output in CI.
