### PR TITLE
ROX-16279: Set skipResolving to false when a ReprocessDeployments is requested

### DIFF
--- a/sensor/kubernetes/eventpipeline/pipeline_impl.go
+++ b/sensor/kubernetes/eventpipeline/pipeline_impl.go
@@ -138,6 +138,7 @@ func (p *eventPipeline) processReprocessDeployments() error {
 	}
 	if env.ResyncDisabled.BooleanSetting() {
 		message := component.NewEvent()
+		// TODO(ROX-14310): Add WithSkipResolving to the DeploymentReference (Revert: https://github.com/stackrox/stackrox/pull/5551)
 		message.AddDeploymentReference(resolver.ResolveAllDeployments(),
 			component.WithForceDetection())
 		p.resolver.Send(message)

--- a/sensor/kubernetes/eventpipeline/pipeline_impl.go
+++ b/sensor/kubernetes/eventpipeline/pipeline_impl.go
@@ -139,8 +139,7 @@ func (p *eventPipeline) processReprocessDeployments() error {
 	if env.ResyncDisabled.BooleanSetting() {
 		message := component.NewEvent()
 		message.AddDeploymentReference(resolver.ResolveAllDeployments(),
-			component.WithForceDetection(),
-			component.WithSkipResolving())
+			component.WithForceDetection())
 		p.resolver.Send(message)
 	}
 	return nil

--- a/sensor/kubernetes/eventpipeline/pipeline_impl.go
+++ b/sensor/kubernetes/eventpipeline/pipeline_impl.go
@@ -123,9 +123,9 @@ func (p *eventPipeline) processReassessPolicies() error {
 	}
 	if env.ResyncDisabled.BooleanSetting() {
 		message := component.NewEvent()
+		// TODO(ROX-14310): Add WithSkipResolving to the DeploymentReference (Revert: https://github.com/stackrox/stackrox/pull/5551)
 		message.AddDeploymentReference(resolver.ResolveAllDeployments(),
-			component.WithForceDetection(),
-			component.WithSkipResolving())
+			component.WithForceDetection())
 		p.resolver.Send(message)
 	}
 	return nil

--- a/sensor/kubernetes/eventpipeline/pipeline_test.go
+++ b/sensor/kubernetes/eventpipeline/pipeline_test.go
@@ -131,7 +131,12 @@ func (s *eventPipelineSuite) Test_ReassessPolicies() {
 		defer messageReceived.Done()
 		resourceEvent, ok := msg.(*component.ResourceEvent)
 		assert.True(s.T(), ok)
-		assertResourceEvent(s.T(), resourceEvent)
+		assert.NotNil(s.T(), resourceEvent.DeploymentReferences)
+		assert.Equal(s.T(), 1, len(resourceEvent.DeploymentReferences))
+		assert.NotNil(s.T(), resourceEvent.DeploymentReferences[0].Reference)
+		assert.Equal(s.T(), central.ResourceAction_UPDATE_RESOURCE, resourceEvent.DeploymentReferences[0].ParentResourceAction)
+		assert.False(s.T(), resourceEvent.DeploymentReferences[0].SkipResolving)
+		assert.True(s.T(), resourceEvent.DeploymentReferences[0].ForceDetection)
 	})
 
 	err := s.pipeline.ProcessMessage(msgFromCentral)

--- a/sensor/kubernetes/eventpipeline/pipeline_test.go
+++ b/sensor/kubernetes/eventpipeline/pipeline_test.go
@@ -77,7 +77,12 @@ func (s *eventPipelineSuite) Test_ReprocessDeployments() {
 		defer messageReceived.Done()
 		resourceEvent, ok := msg.(*component.ResourceEvent)
 		assert.True(s.T(), ok)
-		assertResourceEvent(s.T(), resourceEvent)
+		assert.NotNil(s.T(), resourceEvent.DeploymentReferences)
+		assert.Equal(s.T(), 1, len(resourceEvent.DeploymentReferences))
+		assert.NotNil(s.T(), resourceEvent.DeploymentReferences[0].Reference)
+		assert.Equal(s.T(), central.ResourceAction_UPDATE_RESOURCE, resourceEvent.DeploymentReferences[0].ParentResourceAction)
+		assert.False(s.T(), resourceEvent.DeploymentReferences[0].SkipResolving)
+		assert.True(s.T(), resourceEvent.DeploymentReferences[0].ForceDetection)
 	})
 
 	err := s.pipeline.ProcessMessage(msgFromCentral)


### PR DESCRIPTION
## Description

For testing purposes we want to resolve the dependencies again in the resolver instead of just flushing the already built deployment to the detector when a `ReprocessDeployments` message is received.

This should be reverted after [ROX-14310](https://issues.redhat.com/browse/ROX-14310)

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

* CI
