### PR TITLE
Extend statement timeout to 10m

### DIFF
--- a/image/templates/helm/stackrox-central/internal/defaults.yaml.htpl
+++ b/image/templates/helm/stackrox-central/internal/defaults.yaml.htpl
@@ -46,7 +46,7 @@ defaults:
       source:
         minConns: 10
         maxConns: 90
-        statementTimeoutMs: 60000
+        statementTimeoutMs: 600000
 
       postgresConfig: "@config/centraldb/postgresql.conf|config/centraldb/postgresql.conf.default"
       hbaConfig: "@config/centraldb/pg_hba.conf|config/centraldb/pg_hba.conf.default"

--- a/image/templates/helm/stackrox-central/values-public.yaml.example.htpl
+++ b/image/templates/helm/stackrox-central/values-public.yaml.example.htpl
@@ -269,7 +269,7 @@
 #     connectionString: "host=central-db.stackrox port=5432 user=postgres sslmode=verify-full"
 #     minConns: 10
 #     maxConns: 90
-#     statementTimeoutMs: 60000
+#     statementTimeoutMs: 600000
 #
 #   # Configures the Central DB image to be used. Most users will only need to configure a
 #   # custom registry (if any) at the global scope, and do not require any settings here.

--- a/image/templates/helm/stackrox-central/values.yaml.htpl
+++ b/image/templates/helm/stackrox-central/values.yaml.htpl
@@ -204,7 +204,7 @@
 #      connectionString: null
 #      minConns: 10
 #      maxConns: 90
-#      statementTimeoutMs: 60000
+#      statementTimeoutMs: 600000
 #
 #  # The admin password setting for communication with Central's DB.
 #  # When a value is set explicitly, this is always used, even on upgrade.


### PR DESCRIPTION
## Description

We ran into an issue that had statement timeouts for some Postgres queries, this would decrease the likelihood of those happening on 74. This is mitigated via contexts in 4.0.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Trivial
