### PR TITLE
Add support for comma separated env of migrations to skip in case they can be rebuilt

### DIFF
--- a/migrator/runner/runner.go
+++ b/migrator/runner/runner.go
@@ -11,9 +11,10 @@ import (
 	"github.com/stackrox/rox/migrator/migrations"
 	"github.com/stackrox/rox/migrator/types"
 	pkgMigrations "github.com/stackrox/rox/pkg/migrations"
+	"github.com/stackrox/rox/pkg/set"
 )
 
-var skipMigrationMap = make(map[int]struct{})
+var skipMigrationMap = set.NewIntSet()
 
 func init() {
 	env := os.Getenv("ROX_SKIP_MIGRATIONS")
@@ -26,7 +27,7 @@ func init() {
 			log.WriteToStderrf("could not parse %v. Not skipping", skipped)
 			continue
 		}
-		skipMigrationMap[migration] = struct{}{}
+		skipMigrationMap.Add(migration)
 	}
 }
 
@@ -69,7 +70,7 @@ func runMigrations(databases *types.Databases, startingSeqNum int) error {
 			return fmt.Errorf("no migration found starting at %d", seqNum)
 		}
 
-		if _, ok := skipMigrationMap[seqNum]; ok {
+		if skipMigrationMap.Contains(seqNum) {
 			log.WriteToStderrf("Skipping migration %d based on environment variable", seqNum)
 		} else {
 			err := migration.Run(databases)


### PR DESCRIPTION
## Description

Allow for skipping migrations when they fail if we think we can reconcile them after the migrations have run and they are not required for consistency. This could be very useful in providing support for failed Postgres migrations where we just want to skip the migration and let it naturally rebuild or fix it after the fact.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed
```
 ks set env deploy/central ROX_SKIP_MIGRATIONS="125,127,129,131"
 ```

```
Migrator: 2023/04/04 18:33:40.677768 log.go:18: Info: Skipping migration 125 based on environment variable
Migrator: 2023/04/04 18:33:40.681027 log.go:18: Info: Successfully updated DB from version 125 to 126
Migrator: 2023/04/04 18:33:40.698724 log.go:18: Info: Successfully updated DB from version 126 to 127
Migrator: 2023/04/04 18:33:40.698850 log.go:18: Info: Skipping migration 127 based on environment variable
Migrator: 2023/04/04 18:33:40.702466 log.go:18: Info: Successfully updated DB from version 127 to 128
Migrator: 2023/04/04 18:33:40.723597 log.go:18: Info: Successfully updated DB from version 128 to 129
Migrator: 2023/04/04 18:33:40.723694 log.go:18: Info: Skipping migration 129 based on environment variable
Migrator: 2023/04/04 18:33:40.727579 log.go:18: Info: Successfully updated DB from version 129 to 130
Migrator: 2023/04/04 18:33:40.746350 log.go:18: Info: Successfully updated DB from version 130 to 131
Migrator: 2023/04/04 18:33:40.746441 log.go:18: Info: Skipping migration 131 based on environment variable
Migrator: 2023/04/04 18:33:40.749636 log.go:18: Info: Successfully updated DB from version 131 to 132

```

Will run a test on this
