### PR TITLE
ROX-14479 Improve error reporting when handling the defaultTLSCertificate

### DIFF
--- a/central/clusters/zip/generate_certs.go
+++ b/central/clusters/zip/generate_certs.go
@@ -59,16 +59,17 @@ func getAdditionalCAs(certs *sensor.Certs) ([]*zip.File, error) {
 }
 
 // maybeCreateZipFileForDefaultTLSCertCA returns a zip file containing the default CA cert if it is not trusted by the system roots.
+// If there is no default CA cert, or if it is already trusted by the system roots, it returns nil.
 func maybeCreateZipFileForDefaultTLSCertCA() (*zip.File, error) {
-	defaultTLSCertificate, err := tlsconfig.MaybeGetDefaultTLSCertificateFromDefaultDirectory()
+	defaultTLSCer, err := tlsconfig.MaybeGetDefaultTLSCertificateFromDefaultDirectory()
 	if err != nil {
 		return nil, errors.Wrap(err, "error getting default TLS certificate from default directory")
 	}
-	if defaultTLSCertificate == nil || len(defaultTLSCertificate.Certificate) == 0 {
+	if defaultTLSCer == nil || len(defaultTLSCer.Certificate) == 0 {
 		return nil, nil
 	}
 
-	lastInChain, err := x509.ParseCertificate(defaultTLSCertificate.Certificate[len(defaultTLSCertificate.Certificate)-1])
+	lastInChain, err := x509.ParseCertificate(defaultTLSCer.Certificate[len(defaultTLSCer.Certificate)-1])
 	if err != nil {
 		return nil, errors.Wrap(err, "error parsing default TLS certificate")
 	}

--- a/central/metadata/service/service_impl.go
+++ b/central/metadata/service/service_impl.go
@@ -104,9 +104,9 @@ func (s *serviceImpl) TLSChallenge(_ context.Context, req *v1.TLSChallengeReques
 	}
 
 	// add default leaf cert to additional CAs
-	defaultCertChain, err := tlsconfig.GetDefaultCertChain()
+	defaultCertChain, err := tlsconfig.MaybeGetDefaultCertChain()
 	if err != nil {
-		return nil, errors.Errorf("could not read default CA cert: %s", err)
+		return nil, errors.Errorf("could not read default cert chain: %s", err)
 	}
 	if len(defaultCertChain) > 0 {
 		additionalCAs = append(additionalCAs, defaultCertChain[0])

--- a/central/tlsconfig/manager_impl.go
+++ b/central/tlsconfig/manager_impl.go
@@ -56,12 +56,12 @@ func newManager(namespace string) (*managerImpl, error) {
 		internalCerts:            internalCerts,
 	}
 
-	certwatch.WatchCertDir(DefaultCertPath, loadDefaultCertificate, mgr.UpdateDefaultCert)
+	certwatch.WatchCertDir(DefaultCertPath, MaybeGetDefaultTLSCertificateFromDirectory, mgr.UpdateDefaultTLSCertificate)
 
 	return mgr, nil
 }
 
-func (m *managerImpl) UpdateDefaultCert(defaultCert *tls.Certificate) {
+func (m *managerImpl) UpdateDefaultTLSCertificate(defaultCert *tls.Certificate) {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 

--- a/central/tlsconfig/manager_impl_test.go
+++ b/central/tlsconfig/manager_impl_test.go
@@ -57,7 +57,7 @@ func (s *managerTestSuite) TestNoExtraCertIssuedInStackRoxNamespace() {
 	s.Require().NoError(err)
 
 	defaultCert := testutils.IssueSelfSignedCert(s.T(), "my-central.example.org")
-	mgr.UpdateDefaultCert(&defaultCert)
+	mgr.UpdateDefaultTLSCertificate(&defaultCert)
 
 	s.Len(mgr.internalCerts, 1)
 	s.testConnectionWithManager(mgr, []string{"", "central.stackrox", "central.stackrox.svc"}, []string{"not-central.stackrox.svc", "central.alt-ns.svc"})
@@ -68,7 +68,7 @@ func (s *managerTestSuite) TestExtraCertIssuedInStackRoxNamespace() {
 	s.Require().NoError(err)
 
 	defaultCert := testutils.IssueSelfSignedCert(s.T(), "my-central.example.org")
-	mgr.UpdateDefaultCert(&defaultCert)
+	mgr.UpdateDefaultTLSCertificate(&defaultCert)
 
 	s.Len(mgr.internalCerts, 2)
 	s.testConnectionWithManager(mgr, []string{"", "central.stackrox", "central.stackrox.svc", "central.alt-ns", "central.alt-ns.svc"}, []string{"not-central.stackrox.svc", "not-central.alt-ns"})

--- a/central/tlsconfig/tlsconfig.go
+++ b/central/tlsconfig/tlsconfig.go
@@ -69,11 +69,12 @@ func MaybeGetDefaultCertChain() ([][]byte, error) {
 	return cert.Certificate, nil
 }
 
+// MaybeGetDefaultTLSCertificateFromDefaultDirectory load the default tls certificate from the default directory.
 func MaybeGetDefaultTLSCertificateFromDefaultDirectory() (*tls.Certificate, error) {
 	return MaybeGetDefaultTLSCertificateFromDirectory(DefaultCertPath)
 }
 
-// MaybeGetDefaultTLSCertificateFromDirectory load the default tls certificate
+// MaybeGetDefaultTLSCertificateFromDirectory load the default tls certificate from the given directory.
 func MaybeGetDefaultTLSCertificateFromDirectory(dir string) (*tls.Certificate, error) {
 	certFile := filepath.Join(dir, TLSCertFileName)
 	keyFile := filepath.Join(dir, TLSKeyFileName)

--- a/central/tlsconfig/tlsconfig.go
+++ b/central/tlsconfig/tlsconfig.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/pkg/fileutils"
@@ -56,39 +57,53 @@ func GetAdditionalCAs() ([][]byte, error) {
 	return certDERs, nil
 }
 
-// GetDefaultCertChain reads and parses default cert chain and returns it in DER encoded format
-func GetDefaultCertChain() ([][]byte, error) {
-	certFile := filepath.Join(DefaultCertPath, TLSCertFileName)
-	content, err := os.ReadFile(certFile)
+// MaybeGetDefaultCertChain reads and parses default cert chain and returns it in DER encoded format
+func MaybeGetDefaultCertChain() ([][]byte, error) {
+	cert, err := MaybeGetDefaultTLSCertificateFromDirectory(DefaultCertPath)
 	if err != nil {
-		// Ignore error if default certs do not exist on filesystem
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
-		return nil, errors.Wrap(err, "reading default cert file")
+		return nil, err
 	}
-
-	certDERsFromFile, err := x509utils.ConvertPEMToDERs(content)
-	if err != nil {
-		return nil, errors.Wrap(err, "converting additional CA cert to DER")
+	if cert == nil {
+		return nil, nil
 	}
-
-	return certDERsFromFile, nil
+	return cert.Certificate, nil
 }
 
-// loadDefaultCertificate load the default tls certificate
-func loadDefaultCertificate(dir string) (*tls.Certificate, error) {
+func MaybeGetDefaultTLSCertificateFromDefaultDirectory() (*tls.Certificate, error) {
+	return MaybeGetDefaultTLSCertificateFromDirectory(DefaultCertPath)
+}
+
+// MaybeGetDefaultTLSCertificateFromDirectory load the default tls certificate
+func MaybeGetDefaultTLSCertificateFromDirectory(dir string) (*tls.Certificate, error) {
 	certFile := filepath.Join(dir, TLSCertFileName)
 	keyFile := filepath.Join(dir, TLSKeyFileName)
 
-	if filesExist, err := fileutils.AllExist(certFile, keyFile); err != nil || !filesExist {
-		return nil, err
+	if exists, err := fileutils.Exists(certFile); err != nil || !exists {
+		if err != nil {
+			log.Warnw("Error checking if default TLS certificate file exists", zap.Error(err))
+			return nil, err
+		}
+		log.Infof("Default TLS certificate file %q does not exist. Skipping", certFile)
+		return nil, nil
+	}
+
+	if exists, err := fileutils.Exists(keyFile); err != nil || !exists {
+		if err != nil {
+			log.Warnw("Error checking if default TLS key file exists", zap.Error(err))
+			return nil, err
+		}
+		log.Infof("Default TLS key file %q does not exist. Skipping", keyFile)
+		return nil, nil
 	}
 
 	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
 	if err != nil {
-		return nil, err
+		if strings.Contains(err.Error(), "private key does not match public key") {
+			return nil, errors.Wrap(err, "loading default certificate. If the certificate file contains a certificate chain, ensure that the certificate chain is in the correct order (the first certificate should be the server certificate, any following certificates should form the certificate chain).")
+		}
+		return nil, errors.Wrap(err, "loading default certificate")
 	}
+
 	cert.Leaf, err = x509.ParseCertificate(cert.Certificate[0])
 	if err != nil {
 		return nil, errors.Wrap(err, "parsing leaf certificate")

--- a/central/tlsconfig/tlsconfig.go
+++ b/central/tlsconfig/tlsconfig.go
@@ -57,7 +57,7 @@ func GetAdditionalCAs() ([][]byte, error) {
 	return certDERs, nil
 }
 
-// MaybeGetDefaultCertChain reads and parses default cert chain and returns it in DER encoded format
+// MaybeGetDefaultCertChain reads and parses default cert chain and returns it in DER encoded format.
 func MaybeGetDefaultCertChain() ([][]byte, error) {
 	cert, err := MaybeGetDefaultTLSCertificateFromDirectory(DefaultCertPath)
 	if err != nil {
@@ -69,12 +69,12 @@ func MaybeGetDefaultCertChain() ([][]byte, error) {
 	return cert.Certificate, nil
 }
 
-// MaybeGetDefaultTLSCertificateFromDefaultDirectory load the default tls certificate from the default directory.
+// MaybeGetDefaultTLSCertificateFromDefaultDirectory loads the default TLS certificate from the default directory.
 func MaybeGetDefaultTLSCertificateFromDefaultDirectory() (*tls.Certificate, error) {
 	return MaybeGetDefaultTLSCertificateFromDirectory(DefaultCertPath)
 }
 
-// MaybeGetDefaultTLSCertificateFromDirectory load the default tls certificate from the given directory.
+// MaybeGetDefaultTLSCertificateFromDirectory loads the default TLS certificate from the given directory.
 func MaybeGetDefaultTLSCertificateFromDirectory(dir string) (*tls.Certificate, error) {
 	certFile := filepath.Join(dir, TLSCertFileName)
 	keyFile := filepath.Join(dir, TLSKeyFileName)
@@ -100,14 +100,14 @@ func MaybeGetDefaultTLSCertificateFromDirectory(dir string) (*tls.Certificate, e
 	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
 	if err != nil {
 		if strings.Contains(err.Error(), "private key does not match public key") {
-			return nil, errors.Wrap(err, "loading default certificate. If the certificate file contains a certificate chain, ensure that the certificate chain is in the correct order (the first certificate should be the server certificate, any following certificates should form the certificate chain).")
+			return nil, errors.Wrap(err, "loading default certificate; if the certificate file contains a certificate chain, ensure that the certificate chain is in the correct order (the first certificate should be the leaf certificate, any following certificates should form the certificate chain)")
 		}
-		return nil, errors.Wrap(err, "loading default certificate")
+		return nil, errors.Wrap(err, "loading default certificate failed")
 	}
 
 	cert.Leaf, err = x509.ParseCertificate(cert.Certificate[0])
 	if err != nil {
-		return nil, errors.Wrap(err, "parsing leaf certificate")
+		return nil, errors.Wrap(err, "parsing leaf certificate failed")
 	}
 
 	return &cert, nil

--- a/central/tlsconfig/tlsconfig_test.go
+++ b/central/tlsconfig/tlsconfig_test.go
@@ -51,7 +51,7 @@ func (s *tlsConfigTestSuite) isCommonNameInCerts(DERs [][]byte, commonName strin
 
 func (s *tlsConfigTestSuite) TestMaybeGetDefaultTLSCertificate_ShouldLoadChainWithOneCert() {
 
-	certs, keys, err := createCertChain(1)
+	certs, keys, err := createCertChainWithLengthOf(1)
 	s.Require().NoError(err)
 
 	tmpDir := s.T().TempDir()
@@ -72,7 +72,7 @@ func (s *tlsConfigTestSuite) TestMaybeGetDefaultTLSCertificate_ShouldLoadChainWi
 
 func (s *tlsConfigTestSuite) TestMaybeGetDefaultTLSCertificate_ShouldLoadChainWithMultipleCerts() {
 
-	certs, keys, err := createCertChain(3)
+	certs, keys, err := createCertChainWithLengthOf(3)
 	s.Require().NoError(err)
 
 	tmpDir := s.T().TempDir()
@@ -101,7 +101,7 @@ func (s *tlsConfigTestSuite) TestMaybeGetDefaultTLSCertificate_ShouldLoadChainWi
 }
 
 func (s *tlsConfigTestSuite) TestMaybeGetDefaultTLSCertificate_ShouldIgnoreWhenKeyIsMissing() {
-	certs, _, err := createCertChain(3)
+	certs, _, err := createCertChainWithLengthOf(3)
 	s.Require().NoError(err)
 
 	tmpDir := s.T().TempDir()
@@ -115,7 +115,7 @@ func (s *tlsConfigTestSuite) TestMaybeGetDefaultTLSCertificate_ShouldIgnoreWhenK
 
 func (s *tlsConfigTestSuite) TestMaybeGetDefaultTLSCertificate_ShouldIgnoreWhenCertIsMissing() {
 	tmpDir := s.T().TempDir()
-	_, keys, err := createCertChain(3)
+	_, keys, err := createCertChainWithLengthOf(3)
 	s.Require().NoError(err)
 	s.Require().NoError(writeKey(tmpDir, keys[0]))
 
@@ -135,7 +135,7 @@ func (s *tlsConfigTestSuite) TestMaybeGetDefaultTLSCertificate_ShouldIgnoreWhenB
 func (s *tlsConfigTestSuite) TestMaybeGetDefaultTLSCertificate_ShouldReturnErrorWhenTheCertIsMalformed() {
 	tmpDir := s.T().TempDir()
 
-	_, keys, err := createCertChain(1)
+	_, keys, err := createCertChainWithLengthOf(1)
 	s.Require().NoError(err)
 	s.Require().NoError(writeKey(tmpDir, keys[0]))
 
@@ -152,7 +152,7 @@ func (s *tlsConfigTestSuite) TestMaybeGetDefaultTLSCertificate_ShouldReturnError
 func (s *tlsConfigTestSuite) TestMaybeGetDefaultTLSCertificate_ShouldReturnAnErrorWhenKeyIsMalformed() {
 	tmpDir := s.T().TempDir()
 
-	certs, _, err := createCertChain(1)
+	certs, _, err := createCertChainWithLengthOf(1)
 	s.Require().NoError(err)
 	s.Require().NoError(writeCerts(tmpDir, certs...))
 
@@ -169,7 +169,7 @@ func (s *tlsConfigTestSuite) TestMaybeGetDefaultTLSCertificate_ShouldReturnAnErr
 func (s *tlsConfigTestSuite) TestMaybeGetDefaultTLSCertificate_ShouldReturnErrorAndWarnTheUserWhenCertsAreInWrongOrder() {
 	tmpDir := s.T().TempDir()
 
-	certs, keys, err := createCertChain(3)
+	certs, keys, err := createCertChainWithLengthOf(3)
 	s.Require().NoError(err)
 	s.Require().NoError(writeCerts(tmpDir, certs[1], certs[0], certs[2]))
 	s.Require().NoError(writeKey(tmpDir, keys[0]))
@@ -179,7 +179,7 @@ func (s *tlsConfigTestSuite) TestMaybeGetDefaultTLSCertificate_ShouldReturnError
 	s.ErrorContains(err, "ensure that the certificate chain is in the correct order")
 }
 
-func createCertChain(length int) ([]*x509.Certificate, []*ecdsa.PrivateKey, error) {
+func createCertChainWithLengthOf(length int) ([]*x509.Certificate, []*ecdsa.PrivateKey, error) {
 	var certs []*x509.Certificate
 	var privateKeys []*ecdsa.PrivateKey
 	for i := 0; i < length; i++ {

--- a/central/tlsconfig/tlsconfig_test.go
+++ b/central/tlsconfig/tlsconfig_test.go
@@ -13,6 +13,7 @@ import (
 	"path"
 	"testing"
 
+	"github.com/stackrox/rox/pkg/sliceutils"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -218,10 +219,8 @@ func createCertChainWithLengthOf(length int) ([]*x509.Certificate, []*ecdsa.Priv
 		privateKeys = append(privateKeys, privateKey)
 	}
 	// inverse the order of the certs so that the leaf is first
-	for i, j := 0, len(certs)-1; i < j; i, j = i+1, j-1 {
-		certs[i], certs[j] = certs[j], certs[i]
-		privateKeys[i], privateKeys[j] = privateKeys[j], privateKeys[i]
-	}
+	sliceutils.ReverseInPlace(certs)
+	sliceutils.ReverseInPlace(privateKeys)
 	return certs, privateKeys, nil
 }
 

--- a/central/tlsconfig/tlsconfig_test.go
+++ b/central/tlsconfig/tlsconfig_test.go
@@ -1,8 +1,16 @@
 package tlsconfig
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
 	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
 	"fmt"
+	"math/big"
+	"os"
+	"path"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -39,4 +47,224 @@ func (s *tlsConfigTestSuite) isCommonNameInCerts(DERs [][]byte, commonName strin
 		}
 	}
 	return result
+}
+
+func (s *tlsConfigTestSuite) TestMaybeGetDefaultTLSCertificate_ShouldLoadChainWithOneCert() {
+
+	certs, keys, err := createCertChain(1)
+	s.Require().NoError(err)
+
+	tmpDir := s.T().TempDir()
+
+	s.Require().NoError(writeCerts(tmpDir, certs...))
+	s.Require().NoError(writeKey(tmpDir, keys[0]))
+
+	result, err := MaybeGetDefaultTLSCertificateFromDirectory(tmpDir)
+	s.Require().NoError(err)
+	s.Require().NotNil(result)
+
+	s.Len(result.Certificate, 1)
+	s.Equal("Cert 0", result.Leaf.Subject.CommonName)
+	leaf, err := x509.ParseCertificate(result.Certificate[0])
+	s.Require().NoError(err)
+	s.Equal("Cert 0", leaf.Subject.CommonName)
+}
+
+func (s *tlsConfigTestSuite) TestMaybeGetDefaultTLSCertificate_ShouldLoadChainWithMultipleCerts() {
+
+	certs, keys, err := createCertChain(3)
+	s.Require().NoError(err)
+
+	tmpDir := s.T().TempDir()
+
+	s.Require().NoError(writeCerts(tmpDir, certs...))
+	s.Require().NoError(writeKey(tmpDir, keys[0]))
+
+	result, err := MaybeGetDefaultTLSCertificateFromDirectory(tmpDir)
+	s.Require().NoError(err)
+	s.Require().NotNil(result)
+
+	s.Len(result.Certificate, 3)
+	s.Equal("Cert 2", result.Leaf.Subject.CommonName)
+	leaf, err := x509.ParseCertificate(result.Certificate[0])
+	s.Require().NoError(err)
+	s.Equal("Cert 2", leaf.Subject.CommonName)
+
+	intermediate, err := x509.ParseCertificate(result.Certificate[1])
+	s.Require().NoError(err)
+	s.Equal("Cert 1", intermediate.Subject.CommonName)
+
+	root, err := x509.ParseCertificate(result.Certificate[2])
+	s.Require().NoError(err)
+	s.Equal("Cert 0", root.Subject.CommonName)
+
+}
+
+func (s *tlsConfigTestSuite) TestMaybeGetDefaultTLSCertificate_ShouldIgnoreWhenKeyIsMissing() {
+	certs, _, err := createCertChain(3)
+	s.Require().NoError(err)
+
+	tmpDir := s.T().TempDir()
+	s.Require().NoError(writeCerts(tmpDir, certs...))
+
+	actual, err := MaybeGetDefaultTLSCertificateFromDirectory(tmpDir)
+	s.NoError(err)
+	s.Nil(actual)
+
+}
+
+func (s *tlsConfigTestSuite) TestMaybeGetDefaultTLSCertificate_ShouldIgnoreWhenCertIsMissing() {
+	tmpDir := s.T().TempDir()
+	_, keys, err := createCertChain(3)
+	s.Require().NoError(err)
+	s.Require().NoError(writeKey(tmpDir, keys[0]))
+
+	actual, err := MaybeGetDefaultTLSCertificateFromDirectory(tmpDir)
+	s.NoError(err)
+	s.Nil(actual)
+
+}
+
+func (s *tlsConfigTestSuite) TestMaybeGetDefaultTLSCertificate_ShouldIgnoreWhenBothCertAndKeyAreMissing() {
+	tmpDir := s.T().TempDir()
+	actual, err := MaybeGetDefaultTLSCertificateFromDirectory(tmpDir)
+	s.NoError(err)
+	s.Nil(actual)
+}
+
+func (s *tlsConfigTestSuite) TestMaybeGetDefaultTLSCertificate_ShouldReturnErrorWhenTheCertIsMalformed() {
+	tmpDir := s.T().TempDir()
+
+	_, keys, err := createCertChain(1)
+	s.Require().NoError(err)
+	s.Require().NoError(writeKey(tmpDir, keys[0]))
+
+	badCertFile, err := os.Create(path.Join(tmpDir, TLSCertFileName))
+	s.Require().NoError(err)
+	_, err = badCertFile.WriteString("invalid cert")
+	s.Require().NoError(err)
+	s.Require().NoError(badCertFile.Close())
+
+	_, err = MaybeGetDefaultTLSCertificateFromDirectory(tmpDir)
+	s.ErrorContains(err, "failed to find any PEM data in certificate input")
+}
+
+func (s *tlsConfigTestSuite) TestMaybeGetDefaultTLSCertificate_ShouldReturnAnErrorWhenKeyIsMalformed() {
+	tmpDir := s.T().TempDir()
+
+	certs, _, err := createCertChain(1)
+	s.Require().NoError(err)
+	s.Require().NoError(writeCerts(tmpDir, certs...))
+
+	keyFile, err := os.Create(path.Join(tmpDir, TLSKeyFileName))
+	s.Require().NoError(err)
+	_, err = keyFile.WriteString("invalid key")
+	s.Require().NoError(err)
+	s.Require().NoError(keyFile.Close())
+
+	_, err = MaybeGetDefaultTLSCertificateFromDirectory(tmpDir)
+	s.ErrorContains(err, "failed to find any PEM data in key input")
+}
+
+func (s *tlsConfigTestSuite) TestMaybeGetDefaultTLSCertificate_ShouldReturnErrorAndWarnTheUserWhenCertsAreInWrongOrder() {
+	tmpDir := s.T().TempDir()
+
+	certs, keys, err := createCertChain(3)
+	s.Require().NoError(err)
+	s.Require().NoError(writeCerts(tmpDir, certs[1], certs[0], certs[2]))
+	s.Require().NoError(writeKey(tmpDir, keys[0]))
+
+	_, err = MaybeGetDefaultTLSCertificateFromDirectory(tmpDir)
+	s.ErrorContains(err, "private key does not match public key")
+	s.ErrorContains(err, "ensure that the certificate chain is in the correct order")
+}
+
+func createCertChain(length int) ([]*x509.Certificate, []*ecdsa.PrivateKey, error) {
+	var certs []*x509.Certificate
+	var privateKeys []*ecdsa.PrivateKey
+	for i := 0; i < length; i++ {
+		var parentCert = &x509.Certificate{}
+		var parentKey = &ecdsa.PrivateKey{}
+		if i > 0 {
+			parentCert = certs[i-1]
+			parentKey = privateKeys[i-1]
+		}
+		serialNumber, err := generateSerialNumber()
+		if err != nil {
+			return nil, nil, err
+		}
+		template := &x509.Certificate{
+			SerialNumber: serialNumber,
+			IsCA:         i != length-1,
+			Subject: pkix.Name{
+				CommonName: fmt.Sprintf("Cert %d", i),
+			},
+		}
+		privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		if err != nil {
+			return nil, nil, err
+		}
+		if i == 0 {
+			parentKey = privateKey
+		}
+		certBytes, err := x509.CreateCertificate(rand.Reader, template, parentCert, &privateKey.PublicKey, parentKey)
+		if err != nil {
+			return nil, nil, err
+		}
+		cert, err := x509.ParseCertificate(certBytes)
+		if err != nil {
+			return nil, nil, err
+		}
+		certs = append(certs, cert)
+		privateKeys = append(privateKeys, privateKey)
+	}
+	// inverse the order of the certs so that the leaf is first
+	for i, j := 0, len(certs)-1; i < j; i, j = i+1, j-1 {
+		certs[i], certs[j] = certs[j], certs[i]
+		privateKeys[i], privateKeys[j] = privateKeys[j], privateKeys[i]
+	}
+	return certs, privateKeys, nil
+}
+
+func writeCerts(dir string, certs ...*x509.Certificate) error {
+	certFilePath := path.Join(dir, TLSCertFileName)
+	certFile, err := os.Create(certFilePath)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = certFile.Close()
+	}()
+
+	for _, cert := range certs {
+		if err := pem.Encode(certFile, &pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeKey(dir string, privateKey *ecdsa.PrivateKey) error {
+	keyFilePath := path.Join(dir, TLSKeyFileName)
+	keyFile, err := os.Create(keyFilePath)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = keyFile.Close()
+	}()
+	privateKeyBytes, err := x509.MarshalECPrivateKey(privateKey)
+	if err != nil {
+		return err
+	}
+	return pem.Encode(keyFile, &pem.Block{Type: "EC PRIVATE KEY", Bytes: privateKeyBytes})
+}
+
+func generateSerialNumber() (*big.Int, error) {
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		return nil, err
+	}
+	return serialNumber, nil
 }

--- a/central/tlsconfig/tlsconfig_test.go
+++ b/central/tlsconfig/tlsconfig_test.go
@@ -65,6 +65,7 @@ func (s *tlsConfigTestSuite) TestMaybeGetDefaultTLSCertificate_ShouldLoadChainWi
 
 	s.Len(result.Certificate, 1)
 	s.Equal("Cert 0", result.Leaf.Subject.CommonName)
+
 	leaf, err := x509.ParseCertificate(result.Certificate[0])
 	s.Require().NoError(err)
 	s.Equal("Cert 0", leaf.Subject.CommonName)
@@ -86,6 +87,7 @@ func (s *tlsConfigTestSuite) TestMaybeGetDefaultTLSCertificate_ShouldLoadChainWi
 
 	s.Len(result.Certificate, 3)
 	s.Equal("Cert 2", result.Leaf.Subject.CommonName)
+
 	leaf, err := x509.ParseCertificate(result.Certificate[0])
 	s.Require().NoError(err)
 	s.Equal("Cert 2", leaf.Subject.CommonName)
@@ -156,11 +158,11 @@ func (s *tlsConfigTestSuite) TestMaybeGetDefaultTLSCertificate_ShouldReturnAnErr
 	s.Require().NoError(err)
 	s.Require().NoError(writeCerts(tmpDir, certs...))
 
-	keyFile, err := os.Create(path.Join(tmpDir, TLSKeyFileName))
+	badKeyFile, err := os.Create(path.Join(tmpDir, TLSKeyFileName))
 	s.Require().NoError(err)
-	_, err = keyFile.WriteString("invalid key")
+	_, err = badKeyFile.WriteString("invalid key")
 	s.Require().NoError(err)
-	s.Require().NoError(keyFile.Close())
+	s.Require().NoError(badKeyFile.Close())
 
 	_, err = MaybeGetDefaultTLSCertificateFromDirectory(tmpDir)
 	s.ErrorContains(err, "failed to find any PEM data in key input")

--- a/central/tlsconfig/tlsconfig_test.go
+++ b/central/tlsconfig/tlsconfig_test.go
@@ -191,10 +191,7 @@ func createCertChainWithLengthOf(length int) ([]*x509.Certificate, []*ecdsa.Priv
 			parentCert = certs[i-1]
 			parentKey = privateKeys[i-1]
 		}
-		serialNumber, err := generateSerialNumber()
-		if err != nil {
-			return nil, nil, err
-		}
+		serialNumber := big.NewInt(int64(i) + 1)
 		template := &x509.Certificate{
 			SerialNumber: serialNumber,
 			IsCA:         i != length-1,
@@ -260,13 +257,4 @@ func writeKey(dir string, privateKey *ecdsa.PrivateKey) error {
 		return err
 	}
 	return pem.Encode(keyFile, &pem.Block{Type: "EC PRIVATE KEY", Bytes: privateKeyBytes})
-}
-
-func generateSerialNumber() (*big.Int, error) {
-	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
-	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
-	if err != nil {
-		return nil, err
-	}
-	return serialNumber, nil
 }


### PR DESCRIPTION

## Description

Errors around malformed `defaultTLSCertificate` are not super helpful. This PR aims at providing better error messages for the customer when such errors occur. 

The previous implementation used 2-3 different methods with duplicated logic to load and verify the default TLS certificate. This basically uses a single access point for handling that. 

