### PR TITLE
Improve color contrast for active row in classic tables

### DIFF
--- a/ui/apps/platform/src/app.tw.css
+++ b/ui/apps/platform/src/app.tw.css
@@ -649,7 +649,7 @@ h6 {
 
 .ReactTable .rt-tbody .rt-tr.row-active .rt-td,
 .ReactTable .rt-tbody .rt-tr.row-active:hover .rt-td {
-    @apply text-tertiary-700 bg-tertiary-200 !important;
+    @apply bg-tertiary-200 !important;
     box-shadow: 0px -1px 0 0 theme('colors.tertiary-400'),
         inset 0px -1px 0 0 theme('colors.tertiary-400');
     z-index: 4 !important;


### PR DESCRIPTION
## Description

### Problem

Solve serious issue from axe DevTools in workflow tables when side panel is open:

> Elements must have sufficient color contrast

### Analysis

Contrast ratio less than 4.5 in light mode for `text-tertiary-700` foreground and `bg-tertiary-200` background colors.

| mode | foreground | background | ratio |
| :--- | :--- | :--- | ---: |
| dark  | `#d1e6fa` | `#2c4258` | 8.09 |
| light | `#417ab4` | `#ebf5ff` | 4.07 |

### Solution

Follow example of PatternFly toggle group in which selected items have ordinary color on light blue background color.

https://www.patternfly.org/v4/components/toggle-group/design-guidelines

Contrast ratio more than 4.5 in light mode for default `text-base-600` foreground and `bg-tertiary-200` background colors.

| mode | foreground | background | ratio |
| :--- | :--- | :--- | ---: |
| dark  | `#dedede` | `#2c4258` | 7.69 |
| light | `#6e6e6e` | `#ebf5ff` | 4.62 |

### Residue

1. Add `aria-label` attribute for external link in Compliance side panel that I missed in #5531

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

### Manual testing

Visit /main/configmanagement/namespaces and click a row to open the side panel.

Light mode with insufficient contrast and with `text-tertiary-700` for color:
![light_insufficient_axe](https://user-images.githubusercontent.com/11862657/229885901-abab9921-ca91-4ffc-9509-ed409c82b4b1.png)

![light_insufficient_style](https://user-images.githubusercontent.com/11862657/229885945-1263ff32-cfbe-4226-888d-cc2c63585daf.png)

Light mode with sufficient contrast but without `text-tertiary-700` for color:
![light_sufficient_axe](https://user-images.githubusercontent.com/11862657/229886055-43b83715-76d2-4400-b7ee-7fe71602b15e.png)

![light_sufficient_style](https://user-images.githubusercontent.com/11862657/229886058-0594f120-c84e-493b-ac84-394435f6362b.png)

Dark mode with sufficient contrast and with `text-tertiary-700` for color:
![dark_original_style](https://user-images.githubusercontent.com/11862657/229886096-d3f0fe78-43e2-486d-bcfd-9ff8572fb285.png)

Dark mode with sufficient contrast but without `text-tertiary-700` for color:
![dark_improved_style](https://user-images.githubusercontent.com/11862657/229886121-a57b7a6a-0d83-46fd-a837-eb20aa50eebd.png)

### Compliance

/main/compliance/clusters/id
/main/compliance/namespaces/id
/main/compliance/nodes/id
/main/compliance/deployments/id

### Vulnerability Management

/main/vulnerability-management/image-cves?…
/main/vulnerability-management/node-cves?…
/main/vulnerability-management/cluster-cves?…
/main/vulnerability-management/policies?…
/main/vulnerability-management/nodes?…
/main/vulnerability-management/images?…
/main/vulnerability-management/clusters?…
/main/vulnerability-management/namespaces?…
/main/vulnerability-management/deployments?…
/main/vulnerability-management/node-components?…
/main/vulnerability-management/image-components?…

### Configuration Management

/main/configmanagement/policies/id
/main/configmanagement/controls/id
/main/configmanagement/clusters/id
/main/configmanagement/namespaces/id
/main/configmanagement/nodes/id
/main/configmanagement/deployments/id
/main/configmanagement/images/id
/main/configmanagement/secrets/id
/main/configmanagement/subjects/id
/main/configmanagement/serviceaccounts/id
/main/configmanagement/roles/id

#### Other

/main/clusters/id
/main/risk/id
