### PR TITLE
feat: deployment badge text was incorrect

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/common/NetworkGraphIcons.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/common/NetworkGraphIcons.tsx
@@ -16,7 +16,7 @@ export const externalEntitiesBadgeColor = '#000000';
 export function DeploymentIcon(props) {
     return (
         <Badge {...props} style={{ backgroundColor: deploymentBadgeColor }}>
-            {clusterBadgeText}
+            {deploymentBadgeText}
         </Badge>
     );
 }


### PR DESCRIPTION
## Description

This PR fixes an issue I introduced in a [previous merge](https://github.com/stackrox/stackrox/pull/5539) where the deployment badge text was incorrect

### Before
<img width="233" alt="Screenshot 2023-04-04 at 11 38 38 AM" src="https://user-images.githubusercontent.com/4805485/229887855-a5455e5b-1a34-4b23-ae45-d9444cc9ad92.png">

### After
<img width="268" alt="Screenshot 2023-04-04 at 11 38 18 AM" src="https://user-images.githubusercontent.com/4805485/229887850-017afdae-fe77-4da4-89ed-773d99a79ba7.png">
