### PR TITLE
Provide aria-label for external link in Compliance side panel

### DIFF
--- a/ui/apps/platform/src/Containers/Compliance/List/SidePanel.js
+++ b/ui/apps/platform/src/Containers/Compliance/List/SidePanel.js
@@ -68,6 +68,7 @@ const ComplianceListSidePanel = ({ entityType, entityId, match, location, histor
                                 className="mx-2 text-primary-700 hover:text-primary-800 p-1 bg-primary-300 rounded flex"
                                 to={headerUrl}
                                 target="_blank"
+                                aria-label="External link"
                             >
                                 <ExternalLink size="14" />
                             </Link>


### PR DESCRIPTION
## Description

Oops, I missed Compliance in #5531

### Problem

Solve serious issue from axe DevTools Compliance side panel:

> Links must have discernable text

### Analysis

src/Containers/Compliance/List/SidePanel.js
* name link: open in same tab
* image link: open in new tab

Preserve current behavior, although it seems simpler for UI to get out of the way and leave it between user and browser:
* Click link to open in same tab.
* Right-click link, and then click Open Link in New Tab

### Solution

1. Add `aria-label="External link"` prop.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

### Integration testing

* compliance/complianceDashboard.test.js
* compliance/complianceList.test.js