### PR TITLE
ROX-14570: add metrics to track the size of the eventPipeline channels

### DIFF
--- a/pkg/env/sensor.go
+++ b/pkg/env/sensor.go
@@ -25,7 +25,7 @@ var (
 	ForceLocalImageScanning = RegisterBooleanSetting("ROX_FORCE_LOCAL_IMAGE_SCANNING", false)
 
 	// EventPipelineQueueSize is used to specify the size of the eventPipeline's queues
-	EventPipelineQueueSize = RegisterIntegerSetting("ROX_EVENT_PIPELINE_QUEUE_SIZE", 100)
+	EventPipelineQueueSize = RegisterIntegerSetting("ROX_EVENT_PIPELINE_QUEUE_SIZE", 1000)
 
 	// ResyncDisabled disables the resync behavior of the kubernetes listeners in sensor
 	ResyncDisabled = RegisterBooleanSetting("ROX_RESYNC_DISABLED", false)

--- a/sensor/common/metrics/init.go
+++ b/sensor/common/metrics/init.go
@@ -22,5 +22,7 @@ func init() {
 		k8sObjectCounts,
 		k8sObjectProcessingDuration,
 		k8sObjectIngestionToSendDuration,
+		resolverChannelSize,
+		outputChannelSize,
 	)
 }

--- a/sensor/common/metrics/metrics.go
+++ b/sensor/common/metrics/metrics.go
@@ -128,6 +128,20 @@ var (
 		Help:      "Time taken to fully process an event from Kubernetes",
 		Buckets:   prometheus.ExponentialBuckets(4, 2, 8),
 	}, []string{"Action", "Resource", "Dispatcher"})
+
+	resolverChannelSize = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.SensorSubsystem.String(),
+		Name:      "resolver_channel_size",
+		Help:      "A gauge to track the resolver channel size",
+	})
+
+	outputChannelSize = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.SensorSubsystem.String(),
+		Name:      "output_channel_size",
+		Help:      "A gauge to track the output channel size",
+	})
 )
 
 // IncrementPanicCounter increments the number of panic calls seen in a function
@@ -206,4 +220,24 @@ func IncK8sEventCount(action string, resource string) {
 // SetResourceProcessingDurationForResource sets the duration for how long it takes to process the resource
 func SetResourceProcessingDurationForResource(event *central.SensorEvent) {
 	metrics.SetResourceProcessingDurationForEvent(k8sObjectProcessingDuration, event, "")
+}
+
+// IncResolverChannelSize increases the resolverChannel by 1
+func IncResolverChannelSize() {
+	resolverChannelSize.Inc()
+}
+
+// DecResolverChannelSize decreases the resolverChannel by 1
+func DecResolverChannelSize() {
+	resolverChannelSize.Dec()
+}
+
+// IncOutputChannelSize increases the outputChannel by 1
+func IncOutputChannelSize() {
+	outputChannelSize.Inc()
+}
+
+// DecOutputChannelSize decreases the outputChannel by 1
+func DecOutputChannelSize() {
+	outputChannelSize.Dec()
 }

--- a/sensor/kubernetes/eventpipeline/output/output_impl.go
+++ b/sensor/kubernetes/eventpipeline/output/output_impl.go
@@ -4,6 +4,7 @@ import (
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/sensor/common/detector"
+	"github.com/stackrox/rox/sensor/common/metrics"
 	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/component"
 )
 
@@ -20,6 +21,7 @@ type outputQueueImpl struct {
 // Send a ResourceEvent message to the inner queue
 func (q *outputQueueImpl) Send(msg *component.ResourceEvent) {
 	q.innerQueue <- msg
+	metrics.IncOutputChannelSize()
 }
 
 // ResponsesC returns the MsgFromSensor channel
@@ -60,5 +62,6 @@ func (q *outputQueueImpl) runOutputQueue() {
 		for _, detectorRequest := range msg.DetectorMessages {
 			q.detector.ProcessDeployment(detectorRequest.Object, detectorRequest.Action)
 		}
+		metrics.DecOutputChannelSize()
 	}
 }

--- a/sensor/kubernetes/eventpipeline/resolver/resolver_impl.go
+++ b/sensor/kubernetes/eventpipeline/resolver/resolver_impl.go
@@ -4,6 +4,7 @@ import (
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/logging"
+	"github.com/stackrox/rox/sensor/common/metrics"
 	"github.com/stackrox/rox/sensor/common/store"
 	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/component"
 )
@@ -33,6 +34,7 @@ func (r *resolverImpl) Stop(_ error) {
 // Send a ResourceEvent message to the inner queue
 func (r *resolverImpl) Send(event *component.ResourceEvent) {
 	r.innerQueue <- event
+	metrics.IncResolverChannelSize()
 }
 
 // runResolver reads messages from the inner queue and process the message
@@ -43,6 +45,7 @@ func (r *resolverImpl) runResolver() {
 			return
 		}
 		r.processMessage(msg)
+		metrics.DecResolverChannelSize()
 	}
 }
 

--- a/sensor/kubernetes/sensor/options.go
+++ b/sensor/kubernetes/sensor/options.go
@@ -77,7 +77,7 @@ func (cfg *CreateOptions) WithResyncPeriod(duration time.Duration) *CreateOption
 }
 
 // WithEventPipelineQueueSize sets the size of the eventPipeline's queue.
-// Default: 100
+// Default: 1000
 func (cfg *CreateOptions) WithEventPipelineQueueSize(size int) *CreateOptions {
 	cfg.eventPipelineQueueSize = size
 	return cfg


### PR DESCRIPTION
## Description

Adds to metrics `resolverChannelSize` and `outputChannelSize` to track the size of the `eventPipeline` channels.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

* [x] CI
* [x] local-sensor
