### PR TITLE
ROX-16325: CI: tear down the GKE cluster on job cancelation

### DIFF
--- a/.openshift-ci/dispatch.sh
+++ b/.openshift-ci/dispatch.sh
@@ -62,9 +62,14 @@ fi
 "${job_script}" "$@" &
 job_pid="$!"
 
+# An Openshift CI job is canceled and sent a SIGINT when for example a new
+# commit is pushed to a PR.
 forward_sigint() {
     echo "Dispatch is forwarding SIGINT to job"
     kill -SIGINT "${job_pid}"
+    # Delay the default exit trap execution and process completion to allow job
+    # SIGINT handlers to complete before ci-operator terminates.
+    sleep 3
 }
 trap forward_sigint SIGINT
 

--- a/scripts/ci/gke.sh
+++ b/scripts/ci/gke.sh
@@ -299,13 +299,17 @@ refresh_gke_token() {
 }
 
 teardown_gke_cluster() {
-    info "Tearing down the GKE cluster: ${CLUSTER_NAME:-}"
+    local canceled="${1:-false}"
+
+    info "Tearing down the GKE cluster: ${CLUSTER_NAME:-}, canceled: ${canceled}"
 
     require_environment "CLUSTER_NAME"
     require_executable "gcloud"
 
-    # (prefix output to avoid triggering prow log focus)
-    "$SCRIPTS_ROOT/scripts/ci/cleanup-deployment.sh" 2>&1 | sed -e 's/^/out: /' || true
+    if [[ "${canceled}" == "false" ]]; then
+        # (prefix output to avoid triggering prow log focus)
+        "$SCRIPTS_ROOT/scripts/ci/cleanup-deployment.sh" 2>&1 | sed -e 's/^/out: /' || true
+    fi
 
     gcloud container clusters delete "$CLUSTER_NAME" --async
 


### PR DESCRIPTION
## Description

When a CI job is canceled (e.g. a new commit is pushed to a PR) the GKE clusters are not always torn down. This is due to the default job exit handler killing the GKE teardown script before it has a chance to complete. Even if that behavior was modified i.e. to not kill the script, there is still a lot of (possibly) extraneous tasks in the teardown path before the required gcloud command is executed. And time in the canceled job interrupt handler is limited.

So this PR changes cancelation handling to teardown the cluster without cleanup and give it some time to execute before exiting.

This is still a pretty fragile piece of code forwarding signals, sleep, etc. A more Openshift CI aware approach as an extra step in the `stackrox-e2e` step-registry task may be worth looking at as a longer term solution: https://issues.redhat.com/browse/ROX-16361

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

- [x] happy path - Expect GKE clusters are still destroyed
  - [run](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/stackrox_stackrox/5569/pull-ci-stackrox-stackrox-master-gke-qa-e2e-tests/1643549487123140608)
  - cluster destroyed as expected 
- [x] cancel path - Expect GKE clusters are destroyed, the job completes without hang
  - [canceled run](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/stackrox_stackrox/5569/pull-ci-stackrox-stackrox-master-gke-qa-e2e-tests/1643606759635423232)
  - cluster destroyed as expected 
