### PR TITLE
ROX-14960: Fix detection of previous Y-Stream release

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ The following tools are necessary to test code and build image(s):
 * [Bats](https://github.com/sstephenson/bats) is used to run certain shell tests.
   You can obtain it with `brew install bats` or `npm install -g bats`.
 * [oc](https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/) OpenShift cli tool
+* [shellcheck](https://github.com/koalaman/shellcheck#installing) for shell scripts linting.
 
 **Xcode - macOS Only**
 

--- a/scripts/get-previous-y-stream.bats
+++ b/scripts/get-previous-y-stream.bats
@@ -23,6 +23,9 @@ setup() {
     test_invalid "3.0.62.x"
     test_invalid "3.0.62.1"
     test_invalid " v4.0.0"
+    test_invalid ".."
+    test_invalid "..-1.2.3"
+    test_invalid "1.2.3-"
 }
 
 test_invalid() {
@@ -51,6 +54,7 @@ test_excessive_args() {
     test_major_unknown "5.0.0" "5.0"
     test_major_unknown "5.0.1" "5.0"
     test_major_unknown "v5.0.x-nightly-12345" "5.0"
+    test_major_unknown "199.0.88" "199.0"
 }
 
 test_major_unknown() {
@@ -75,6 +79,7 @@ test_major_unknown() {
     test_happy "4.1.0" "4.0.0"
     test_happy "5.10.2" "5.9.0"
     test_happy "v3.62.7" "3.61.0"
+    test_happy "45.67.89" "45.66.0"
 }
 
 test_happy() {

--- a/scripts/get-previous-y-stream.bats
+++ b/scripts/get-previous-y-stream.bats
@@ -1,0 +1,84 @@
+#!/usr/bin/env bats
+
+load "./test_helpers.bats"
+
+setup() {
+    program="$BATS_TEST_DIRNAME"/get-previous-y-stream.sh
+}
+
+@test "when called without arguments, returns no-zero and prints usage" {
+    run "$program"
+    assert_failure
+    assert_output --partial "Usage:"
+}
+
+@test "when asked for help, prints usage" {
+    run "$program" --help
+    assert_output --partial "Usage:"
+}
+
+@test "when called with bogus input, fails with error" {
+    test_invalid "13"
+    test_invalid "a.b.c"
+    test_invalid "3.0.62.x"
+    test_invalid "3.0.62.1"
+    test_invalid " v4.0.0"
+}
+
+test_invalid() {
+    run "$program" "$1"
+    assert_failure
+    assert_output --partial "Error:"
+    assert_output --partial "$1"
+}
+
+@test "when provided more arguments than just one, fails with error" {
+    test_excessive_args "1.2.3" "4.5.6"
+    test_excessive_args "1.2.3" "--help"
+    test_excessive_args "foo" "bar" "baz"
+}
+
+test_excessive_args() {
+    run "$program" "$@"
+    assert_failure
+    assert_output --regexp "Error:.*too many.*arguments"
+}
+
+@test "when called with unknown new major, fails with error" {
+    test_major_unknown "0.0.0" "0.0"
+    test_major_unknown "2.0.0" "2.0"
+    test_major_unknown "3.0.0" "3.0"
+    test_major_unknown "5.0.0" "5.0"
+    test_major_unknown "5.0.1" "5.0"
+    test_major_unknown "v5.0.x-nightly-12345" "5.0"
+}
+
+test_major_unknown() {
+    run "$program" "$1"
+    assert_failure
+    assert_output --partial "Error:"
+    assert_output --partial "$2"
+}
+
+@test "when called with known major, prints expected previous release" {
+    test_happy "4.0.0" "3.74.0"
+    test_happy "4.0.6" "3.74.0"
+    test_happy "4.0.x-12-g8e6387" "3.74.0"
+    test_happy "1.0.0" "0.0.0"
+    test_happy "v1.0.0" "0.0.0"
+}
+
+@test "when called with ordinary minor, prints expected previous release" {
+    test_happy "3.74.x-nightly-20230224" "3.73.0"
+    test_happy "3.74.x-609-g3fc7d38fdf" "3.73.0"
+    test_happy "3.70.0-609-g3fc7d38fdf" "3.69.0"
+    test_happy "4.1.0" "4.0.0"
+    test_happy "5.10.2" "5.9.0"
+    test_happy "v3.62.7" "3.61.0"
+}
+
+test_happy() {
+    run "$program" "$1"
+    assert_success
+    assert_output "$2"
+}

--- a/scripts/get-previous-y-stream.sh
+++ b/scripts/get-previous-y-stream.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-this_file="$(basename ${BASH_SOURCE[0]})"
+this_file="$(basename "${BASH_SOURCE[0]}")"
 
 usage() {
     >&2 echo "Usage: $this_file <version>

--- a/scripts/get-previous-y-stream.sh
+++ b/scripts/get-previous-y-stream.sh
@@ -31,7 +31,7 @@ main() {
         usage
     fi
 
-    if [[ ! "$version" =~ ^v?([0-9]*)\.([0-9]*)\.(x|[0-9]*)(-.*)?$ ]]; then
+    if [[ ! "$version" =~ ^v?([0-9]+)\.([0-9]+)\.(x|[0-9]+)(-.+)?$ ]]; then
         >&2 echo "Error: provided version does not look like a valid one: $version"
         exit 1
     fi

--- a/scripts/get-previous-y-stream.sh
+++ b/scripts/get-previous-y-stream.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+this_file="$(basename ${BASH_SOURCE[0]})"
+
+usage() {
+    >&2 echo "Usage: $this_file <version>
+
+This program prints previous Y-Stream version for a provided <version>.
+
+<version> can be a semantic version, e.g. 3.74.3, and/or the result of make tag, e.g. 3.74.x-nightly-20230224.
+<version> can also include 'v' prefix, e.g. v3.74.3.
+
+Y-Stream is Red Hat term for releases which patch number equals to zero, e.g. 3.73.0, 3.74.0, 4.0.0, 4.1.0.
+This program knows how to subtract one from the minor number of the provided version (e.g. 3.73.0 -> 3.74.0)
+and also knows when major product version was bumped (e.g. 3.74.0 -> 4.0.0)."
+
+    exit 2
+}
+
+main() {
+    if (( $# > 1 )); then
+        >&2 echo "Error: too many command-line arguments provided"
+        exit 1
+    fi
+
+    local version="${1-}"
+
+    if [[ -z "$version" || "$version" == "--help" ]]; then
+        usage
+    fi
+
+    if [[ ! "$version" =~ ^v?([0-9]*)\.([0-9]*)\.(x|[0-9]*)(-.*)?$ ]]; then
+        >&2 echo "Error: provided version does not look like a valid one: $version"
+        exit 1
+    fi
+
+    local major="${BASH_REMATCH[1]}"
+    local minor="${BASH_REMATCH[2]}"
+
+    print_previous "$major" "$minor"
+}
+
+print_previous() {
+    local major="$1"
+    local minor="$2"
+
+    if (( minor > 0 )); then
+        # If the minor version is not zero, than the previous Y-Stream simply had one minor number less.
+        echo "$major.$((minor - 1)).0"
+    else
+        # For major version bumps we need to maintain this mapping of what were previous Y-Streams.
+        case "$major" in
+        "4") echo "3.74.0" ;;
+        "1") echo "0.0.0" ;; # 0.0.0 was never released, but we use 1.0.0 version for "trunk" builds downstream.
+        *)
+            >&2 echo "Error: don't know the previous Y-Stream for $major.$minor"
+            exit 3
+        esac
+    fi
+}
+
+main "$@"


### PR DESCRIPTION
## Description

Please see the mentioned ticket and commit messages for the context.

One thing I'm not 100% sure about is whether to keep the script as external shell one or move the logic inside of `patch-csv.py` (or next to it).

Advantages of keeping a separate script:
- It is unit-tested and tests are ran in CI, we don't have unit tests in CI for Python.
- It can be used in other places (e.g. version-compatibility tests, but I'm yet to run them).

Advantages of integrating in `patch-csv.py`:
- Less moving parts like spawning external process from Python.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added

These aren't needed:
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

* CI here should be green (enough green).
* Testing with `4.0.0-rc.1` tag under https://github.com/stackrox/stackrox/pull/5530