### PR TITLE
Use SQL to optimize orphaned alert pruning workflow

### DIFF
--- a/central/postgres/pruning.go
+++ b/central/postgres/pruning.go
@@ -60,7 +60,7 @@ func getOrphanedAlertIDs(ctx context.Context, pool *postgres.DB, orphanWindow ti
 		}
 		ids = append(ids, id)
 	}
-	return ids, nil
+	return ids, rows.Err()
 }
 
 // GetOrphanedAlertIDs returns the alert IDs for alerts that are orphaned so they can be resolved

--- a/central/postgres/pruning.go
+++ b/central/postgres/pruning.go
@@ -21,8 +21,8 @@ const (
 		(SELECT 1 FROM clusters parent WHERE
 		child.Id = parent.Id)`
 
-	getAllOrphanedAlerts = `SELECT id from alerts WHERE lifecyclestage = 0 and state = 0 and time < NOW() - INTERVAL '%d MINUTES' and NOT EXISTS
-		"(SELECT 1 FROM deployments WHERE alerts.deployment_id = deployments.Id)`
+	getAllOrphanedAlerts = `SELECT id from alerts WHERE lifecyclestage = 0 and state = 0 and time < now() at time zone 'utc' - INTERVAL '%d MINUTES' and NOT EXISTS
+		(SELECT 1 FROM deployments WHERE alerts.deployment_id = deployments.Id)`
 )
 
 var (

--- a/central/postgres/pruning.go
+++ b/central/postgres/pruning.go
@@ -3,8 +3,10 @@ package postgres
 import (
 	"context"
 
+	"github.com/pkg/errors"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/postgres"
+	"github.com/stackrox/rox/pkg/postgres/pgutils"
 )
 
 const (
@@ -14,6 +16,9 @@ const (
 	pruneClusterHealthStatusesStmt = `DELETE FROM cluster_health_statuses child WHERE NOT EXISTS
 		(SELECT 1 FROM clusters parent WHERE
 		child.Id = parent.Id)`
+
+	getAllOrphanedAlerts = `SELECT id from alerts WHERE lifecyclestage = 0 and state = 0 and time < NOW() - INTERVAL '30 MINUTES' and NOT EXISTS
+		"(SELECT 1 FROM deployments WHERE alerts.deployment_id = deployments.Id)`
 )
 
 var (
@@ -34,4 +39,28 @@ func PruneClusterHealthStatuses(ctx context.Context, pool *postgres.DB) {
 	if _, err := pool.Exec(ctx, pruneClusterHealthStatusesStmt); err != nil {
 		log.Errorf("failed to prune cluster health statuses: %v", err)
 	}
+}
+
+func getOrphanedAlertIDs(ctx context.Context, pool *postgres.DB) ([]string, error) {
+	var ids []string
+	rows, err := pool.Query(ctx, getAllOrphanedAlerts)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get orphaned alerts")
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, errors.Wrap(err, "getting ids from orphaned alerts query")
+		}
+		ids = append(ids, id)
+	}
+	return ids, nil
+}
+
+// GetOrphanedAlertIDs returns the alert IDs for alerts that are orphaned so they can be resolved
+func GetOrphanedAlertIDs(ctx context.Context, pool *postgres.DB) ([]string, error) {
+	return pgutils.Retry2(func() ([]string, error) {
+		return getOrphanedAlertIDs(ctx, pool)
+	})
 }

--- a/central/pruning/pruning.go
+++ b/central/pruning/pruning.go
@@ -83,8 +83,7 @@ func newGarbageCollector(alerts alertDatastore.DataStore,
 	k8sRoles k8sRoleDataStore.DataStore,
 	k8sRoleBindings roleBindingDataStore.DataStore,
 	logimbueStore logimbueDataStore.Store) GarbageCollector {
-	return &garbageCollectorImpl{
-		postgres:        globaldb.GetPostgres(),
+	gci := &garbageCollectorImpl{
 		alerts:          alerts,
 		clusters:        clusters,
 		nodes:           nodes,
@@ -105,6 +104,10 @@ func newGarbageCollector(alerts alertDatastore.DataStore,
 		logimbueStore:   logimbueStore,
 		stopper:         concurrency.NewStopper(),
 	}
+	if env.PostgresDatastoreEnabled.BooleanSetting() {
+		gci.postgres = globaldb.GetPostgres()
+	}
+	return gci
 }
 
 type garbageCollectorImpl struct {


### PR DESCRIPTION
## Description

Use sql instead of cursors. There are 3 million alerts in this database and it times out on cursor timeout. In this cluster there are also 0 matches. Test will be written before merging

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Will run in the cluster
