### PR TITLE
Enable "Processes listening on ports" by default

### DIFF
--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -32,7 +32,7 @@ var (
 	NetworkGraphPatternFly = registerFeature("Enable PatternFly version of NetworkGraph", "ROX_NETWORK_GRAPH_PATTERNFLY", true)
 
 	// ProcessesListeningOnPort enables the NetworkFlow code to also update the processes that are listening on ports
-	ProcessesListeningOnPort = registerFeature("Enable Processes Listening on Port", "ROX_PROCESSES_LISTENING_ON_PORT", false)
+	ProcessesListeningOnPort = registerFeature("Enable Processes Listening on Port", "ROX_PROCESSES_LISTENING_ON_PORT", true)
 
 	// ClairV4Scanner enables Clair v4 as an Image Integration option
 	ClairV4Scanner = registerFeature("Enable Clair v4 as an Image Integration option", "ROX_CLAIR_V4_SCANNING", true)

--- a/qa-tests-backend/src/test/groovy/ProcessesListeningOnPortsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ProcessesListeningOnPortsTest.groovy
@@ -13,7 +13,7 @@ import spock.lang.Stepwise
 import services.ProcessesListeningOnPortsService
 
 @Stepwise
-@IgnoreIf({ Env.get("ROX_PROCESSES_LISTENING_ON_PORT", "false") == "false" })
+@IgnoreIf({ Env.get("ROX_PROCESSES_LISTENING_ON_PORT", "true") != "true" })
 class ProcessesListeningOnPortsTest extends BaseSpecification {
 
     // Deployment names

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -98,8 +98,6 @@ export_test_environment() {
     ci_export ROX_VULN_MGMT_WORKLOAD_CVES "${ROX_VULN_MGMT_WORKLOAD_CVES:-true}"
 
     if [[ -z "${BUILD_TAG:-}" ]]; then
-        ci_export ROX_PROCESSES_LISTENING_ON_PORT "${ROX_PROCESSES_LISTENING_ON_PORT:-true}"
-
         # TODO(ROX-16008): Remove this once the declarative config feature flag is enabled by default.
         ci_export ROX_DECLARATIVE_CONFIGURATION "${ROX_DECLARATIVE_CONFIGURATION:-true}"
     fi


### PR DESCRIPTION
## Description

ROX_PROCESSES_LISTENING_ON_PORT is considered 'true' unless explicitly disabled.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

Integration tests covering this feature already exist. We should check in the CI if they were run.
