### PR TITLE
ROX-16212: Remove panic from failed charts

### DIFF
--- a/image/embed_charts.go
+++ b/image/embed_charts.go
@@ -16,7 +16,6 @@ import (
 	"github.com/stackrox/rox/pkg/k8sutil/k8sobjects"
 	"github.com/stackrox/rox/pkg/namespaces"
 	"github.com/stackrox/rox/pkg/templates"
-	"github.com/stackrox/rox/pkg/utils"
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chart/loader"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -114,17 +113,6 @@ func (i *Image) GetChartTemplate(chartPrefixPath ChartPrefix) (*helmTemplate.Cha
 	}
 
 	return chartTpl, nil
-}
-
-func (i *Image) mustGetSensorChart(values *charts.MetaValues, certs *sensor.Certs) *chart.Chart {
-	ch, err := i.getSensorChart(values, certs)
-	utils.CrashOnError(err)
-	return ch
-}
-
-// GetSensorChart returns the Helm chart for sensor
-func (i *Image) GetSensorChart(values *charts.MetaValues, certs *sensor.Certs) *chart.Chart {
-	return i.mustGetSensorChart(values, certs)
 }
 
 // GetCentralServicesChartTemplate retrieves the StackRox Central Services Helm chart template.
@@ -260,7 +248,8 @@ func (i *Image) GetSensorChartTemplate() (*helmTemplate.ChartTemplate, error) {
 	return load, errors.Wrap(err, "could not load chart template")
 }
 
-func (i *Image) getSensorChart(values *charts.MetaValues, certs *sensor.Certs) (*chart.Chart, error) {
+// GetSensorChart returns the Helm chart for sensor
+func (i *Image) GetSensorChart(values *charts.MetaValues, certs *sensor.Certs) (*chart.Chart, error) {
 	chartTpl, err := i.GetSensorChartTemplate()
 	if err != nil {
 		return nil, errors.Wrap(err, "loading sensor chart template")

--- a/pkg/renderer/kubernetes_helm.go
+++ b/pkg/renderer/kubernetes_helm.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/pkg/errors"
 	"github.com/stackrox/rox/image"
 	"github.com/stackrox/rox/image/sensor"
 	"github.com/stackrox/rox/pkg/helm/charts"
@@ -35,7 +36,10 @@ func RenderSensorTLSSecretsOnly(values charts.MetaValues, certs *sensor.Certs) (
 	// Currently, we rely on Go to copy the struct as it is passed by value, not by pointer.
 	values.CertsOnly = true
 
-	ch := helmImage.GetSensorChart(&values, certs)
+	ch, err := helmImage.GetSensorChart(&values, certs)
+	if err != nil {
+		return nil, errors.Wrap(err, "pre-rendering sensor chart")
+	}
 
 	m, err := helmUtil.Render(ch, nil, helmUtil.Options{})
 	if err != nil {
@@ -64,7 +68,10 @@ func RenderSensorTLSSecretsOnly(values charts.MetaValues, certs *sensor.Certs) (
 // RenderSensor renders the sensorchart and returns rendered files
 func RenderSensor(values *charts.MetaValues, certs *sensor.Certs, opts helmUtil.Options) ([]*zip.File, error) {
 	helmImage := image.GetDefaultImage()
-	ch := helmImage.GetSensorChart(values, certs)
+	ch, err := helmImage.GetSensorChart(values, certs)
+	if err != nil {
+		return nil, errors.Wrap(err, "pre-rendering sensor chart")
+	}
 
 	m, err := helmUtil.Render(ch, nil, opts)
 	if err != nil {


### PR DESCRIPTION
## Description

Removes the panic when creating generating Secured Cluster manifests with SHA. Instead this should surface the error to the caller.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

