### PR TITLE
ROX-15278: Improve panic log message when central is recreated without persistence

### DIFF
--- a/pkg/centralsensor/init_cert.go
+++ b/pkg/centralsensor/init_cert.go
@@ -44,7 +44,8 @@ func GetClusterID(explicitID, idFromCert string) (string, error) {
 
 	if IsInitCertClusterID(id) {
 		return "", errors.Errorf("no concrete cluster ID was specified in conjunction with wildcard ID %q. "+
-			"This may be caused by Central data not being persisted between restarts; try deploying Central with STORAGE=pvc", id)
+			"This may be caused by Central data not being persisted between restarts; you may try deploying Central with STORAGE=pvc."+
+			"For other potential solutions reffer to https://access.redhat.com/solutions/6972449", id)
 	}
 
 	return id, nil

--- a/pkg/centralsensor/init_cert.go
+++ b/pkg/centralsensor/init_cert.go
@@ -43,7 +43,8 @@ func GetClusterID(explicitID, idFromCert string) (string, error) {
 	}
 
 	if IsInitCertClusterID(id) {
-		return "", errors.Errorf("no concrete cluster ID was specified in conjunction with wildcard ID %q", id)
+		return "", errors.Errorf("no concrete cluster ID was specified in conjunction with wildcard ID %q. " +
+			"This may be caused by Central data not being persisted between restarts; try deploying Central with STORAGE=pvc", id)
 	}
 
 	return id, nil

--- a/pkg/centralsensor/init_cert.go
+++ b/pkg/centralsensor/init_cert.go
@@ -44,7 +44,7 @@ func GetClusterID(explicitID, idFromCert string) (string, error) {
 
 	if IsInitCertClusterID(id) {
 		return "", errors.Errorf("no concrete cluster ID was specified in conjunction with wildcard ID %q. "+
-			"This may be caused by Central data not being persisted between restarts; you may try deploying Central with STORAGE=pvc."+
+			"This may be caused by Central data not being persisted between restarts; you may try deploying Central with STORAGE=pvc. "+
 			"For other potential solutions reffer to https://access.redhat.com/solutions/6972449", id)
 	}
 

--- a/pkg/centralsensor/init_cert.go
+++ b/pkg/centralsensor/init_cert.go
@@ -43,7 +43,7 @@ func GetClusterID(explicitID, idFromCert string) (string, error) {
 	}
 
 	if IsInitCertClusterID(id) {
-		return "", errors.Errorf("no concrete cluster ID was specified in conjunction with wildcard ID %q. " +
+		return "", errors.Errorf("no concrete cluster ID was specified in conjunction with wildcard ID %q. "+
 			"This may be caused by Central data not being persisted between restarts; try deploying Central with STORAGE=pvc", id)
 	}
 


### PR DESCRIPTION
## Description

Many customers and colleagues report seeing this panic message as a bug: `Panic: Invalid dynamic cluster ID value "": no concrete cluster ID was specified in conjunction with wildcard ID "00000000-0000-0000-0000-000000000000"
panic: Invalid dynamic cluster ID value "": no concrete cluster ID was specified in conjunction with wildcard ID "00000000-0000-0000-0000-000000000000"`. This is usually (always?) caused by Central being restarted without persisting its data between the restarts. Adding additional information to the log message helps understand why we see this panic.

## Checklist
- [x] Investigated and inspected CI test results

### N/A
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

- [x] CI only
