### PR TITLE
Fix lint issues on cherry pick 5523

### DIFF
--- a/migrator/migrations/n_31_to_n_32_postgres_network_graph_configs/migration_test.go
+++ b/migrator/migrations/n_31_to_n_32_postgres_network_graph_configs/migration_test.go
@@ -82,7 +82,7 @@ func (s *postgresMigrationSuite) TestNetworkGraphConfigMigration() {
 }
 
 func (s *postgresMigrationSuite) TestNetworkGraphConfigMigrationWithEmptyID() {
-	newStore := pgStore.New(s.postgresDB.DB)
+	newStore := pgStore.New(s.postgresDB.Pool)
 	legacyStore, err := legacy.New(s.legacyDB)
 	s.NoError(err)
 
@@ -94,7 +94,7 @@ func (s *postgresMigrationSuite) TestNetworkGraphConfigMigrationWithEmptyID() {
 	s.NoError(crud.UpsertWithID(networkGraphConfigKey, networkGraphConfig))
 
 	// Move
-	s.NoError(move(s.postgresDB.GetGormDB(), s.postgresDB.DB, legacyStore))
+	s.NoError(move(s.postgresDB.GetGormDB(), s.postgresDB.Pool, legacyStore))
 
 	// Verify
 	count, err := newStore.Count(s.ctx)
@@ -109,7 +109,7 @@ func (s *postgresMigrationSuite) TestNetworkGraphConfigMigrationWithEmptyID() {
 }
 
 func (s *postgresMigrationSuite) TestNetworkGraphConfigMigrationMultiple() {
-	newStore := pgStore.New(s.postgresDB.DB)
+	newStore := pgStore.New(s.postgresDB.Pool)
 	legacyStore, err := legacy.New(s.legacyDB)
 	s.NoError(err)
 
@@ -121,7 +121,7 @@ func (s *postgresMigrationSuite) TestNetworkGraphConfigMigrationMultiple() {
 	s.NoError(crud.UpsertWithID("random", networkGraphConfig))
 
 	// Move
-	s.NoError(move(s.postgresDB.GetGormDB(), s.postgresDB.DB, legacyStore))
+	s.NoError(move(s.postgresDB.GetGormDB(), s.postgresDB.Pool, legacyStore))
 
 	// Verify
 	count, err := newStore.Count(s.ctx)


### PR DESCRIPTION
## Description

Automatic milestone cherry-pick for #5523 introduced code that uses refactored struct that exists in the master branch, but not in 3.74.

This PR should fix that.

## Checklist
- [ ] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

1. Checked locally with linter
2. CI pipeline
