### PR TITLE
Control ProcessesListeningOnPort with a BooleanSetting instead of a Feature

### DIFF
--- a/pkg/env/processes_listening_on_port.go
+++ b/pkg/env/processes_listening_on_port.go
@@ -1,0 +1,6 @@
+package env
+
+var (
+	// ProcessesListeningOnPort enables the NetworkFlow code to also update the processes that are listening on ports
+	ProcessesListeningOnPort = RegisterBooleanSetting("ROX_PROCESSES_LISTENING_ON_PORT", true)
+)

--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -31,9 +31,6 @@ var (
 	// NetworkGraphPatternFly enables the PatternFly version of NetworkGraph. (used in the front-end app only)
 	NetworkGraphPatternFly = registerFeature("Enable PatternFly version of NetworkGraph", "ROX_NETWORK_GRAPH_PATTERNFLY", true)
 
-	// ProcessesListeningOnPort enables the NetworkFlow code to also update the processes that are listening on ports
-	ProcessesListeningOnPort = registerFeature("Enable Processes Listening on Port", "ROX_PROCESSES_LISTENING_ON_PORT", true)
-
 	// ClairV4Scanner enables Clair v4 as an Image Integration option
 	ClairV4Scanner = registerFeature("Enable Clair v4 as an Image Integration option", "ROX_CLAIR_V4_SCANNING", true)
 

--- a/sensor/common/networkflow/manager/manager_impl.go
+++ b/sensor/common/networkflow/manager/manager_impl.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/centralsensor"
 	"github.com/stackrox/rox/pkg/concurrency"
-	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/net"
 	"github.com/stackrox/rox/pkg/netutil"
 	"github.com/stackrox/rox/pkg/networkgraph"
@@ -261,7 +261,7 @@ func (m *networkFlowManager) enrichConnections() {
 		case <-ticker.C:
 			m.enrichAndSend()
 
-			if features.ProcessesListeningOnPort.Enabled() {
+			if env.ProcessesListeningOnPort.BooleanSetting() {
 				m.enrichAndSendProcesses()
 			}
 		}
@@ -529,7 +529,7 @@ func (m *networkFlowManager) enrichHostContainerEndpoints(hostConns *hostConnect
 	for ep, status := range hostConns.endpoints {
 		m.enrichContainerEndpoint(&ep, status, enrichedEndpoints)
 		// If processes listening on ports is enabled, it has to be used there as well before being deleted.
-		used := status.used && (status.usedProcess || !features.ProcessesListeningOnPort.Enabled())
+		used := status.used && (status.usedProcess || !env.ProcessesListeningOnPort.BooleanSetting())
 		if used && status.lastSeen != timestamp.InfiniteFuture {
 			// endpoints that are no longer active and have already been used can be deleted.
 			delete(hostConns.endpoints, ep)


### PR DESCRIPTION
## Description

It should enable the feature to be disabled at runtime whereas Features are burned into their default value for Release builds.

## Checklist
- [x] Investigated and inspected CI test results