### PR TITLE
ROX-16390: Add deprecation for PDF exports in VM1.0 UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 - Deprecated v1.0 of Network Graph. Please switch to the new 2.0 version for improved functionality and a better user experience.
 - ROX-15337: RHACS Operator is not published to Red Hat Operator Catalogs for OpenShift versions 4.9 and earlier.
 - The API endpoint `/v1/serviceaccounts` is deprecated and will be changed as part of the 4.2.0 release.
-- PDF export in current version of the Vulnerability Management UI is deprecated and will be removed in the 4.2 release. Use the vuln reporting feature instead, for more comprehensive CSV data.
+- PDF export in current version of the Vulnerability Management UI is deprecated and will be removed in the 4.2.0 release. Use the vuln reporting feature instead, for more comprehensive CSV data.
 
 ### Required Actions
 - The `Analyst` permission set will change behaviour: instead of allowing read to all resources except `DebugLogs`, it will

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 - Deprecated v1.0 of Network Graph. Please switch to the new 2.0 version for improved functionality and a better user experience.
 - ROX-15337: RHACS Operator is not published to Red Hat Operator Catalogs for OpenShift versions 4.9 and earlier.
 - The API endpoint `/v1/serviceaccounts` is deprecated and will be changed as part of the 4.2.0 release.
+- PDF export in current version of the Vulnerability Management UI is deprecated and will be removed in the 4.2 release. Use the vuln reporting feature instead, for more comprehensive CSV data.
 
 ### Required Actions
 - The `Analyst` permission set will change behaviour: instead of allowing read to all resources except `DebugLogs`, it will


### PR DESCRIPTION
## Description

Based on Chris' presentation we just sat through at the NA F2F, no customer is happy with the PDF export, because all it is, is a "screenshot" of the current page of the UI. They think it will be the CSV emailed report, just "printed" to PDF.

Since this is removing functionality, we need to add a deprecation notice to Changelog and Release Notes for 4.0, so that we can remove it in 4.2.

In the deprecation notice, please add language to the effect of "Use vuln reporting feature instead" - because I believe customers are not aware of/using that feature to get them the info they are looking for.


## Checklist
n/a

## Testing Performed

n/a