### PR TITLE
Fix SARIF printer tests

### DIFF
--- a/pkg/printers/sarif_test.go
+++ b/pkg/printers/sarif_test.go
@@ -74,7 +74,7 @@ func TestSarifPrinter_Print_Success(t *testing.T) {
 	require.NoError(t, err)
 
 	// Since the report contains the version, replace it specifically here.
-	exp, err := regexp.Compile(`"version": "3.*"`)
+	exp, err := regexp.Compile(`"version": "[34].*"`)
 	require.NoError(t, err)
 	output := exp.ReplaceAllString(out.String(), `"version": ""`)
 	assert.Equal(t, string(expectedOutput), output)


### PR DESCRIPTION
## Description

Within the SARIF printer test, the version of roxctl will be included in the output.

During the assertion of the output against the expected output, the version will be replaced with an empty string. We previously only replaced 3.x versions (due to two different version fields being populated), but now we shall include this to cover 4.x as well.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

- CI should pass again.
