### PR TITLE
ROX-16391: Fix declarative config E2E tests

### DIFF
--- a/pkg/declarativeconfig/transform/access_scope.go
+++ b/pkg/declarativeconfig/transform/access_scope.go
@@ -8,8 +8,6 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/declarativeconfig"
 	"github.com/stackrox/rox/pkg/errox"
-	"github.com/stackrox/rox/pkg/sac/effectiveaccessscope"
-	"k8s.io/apimachinery/pkg/labels"
 )
 
 var _ Transformer = (*accessScopeTransform)(nil)
@@ -94,15 +92,9 @@ func labelSelectorsFromScopeConfig(labelSelectors []declarativeconfig.LabelSelec
 	for _, ls := range labelSelectors {
 		reqs := make([]*storage.SetBasedLabelSelector_Requirement, 0, len(ls.Requirements))
 		for _, req := range ls.Requirements {
-			op := storage.SetBasedLabelSelector_Operator(req.Operator)
-			selectionOperator := effectiveaccessscope.ConvertLabelSelectorOperatorToSelectionOperator(op)
-			if _, err := labels.NewRequirement(req.Key, selectionOperator, req.Values); err != nil {
-				labelSelectorErrs = multierror.Append(labelSelectorErrs, err)
-				continue
-			}
 			reqs = append(reqs, &storage.SetBasedLabelSelector_Requirement{
 				Key:    req.Key,
-				Op:     op,
+				Op:     storage.SetBasedLabelSelector_Operator(req.Operator),
 				Values: req.Values,
 			})
 		}

--- a/pkg/declarativeconfig/transform/access_scope_test.go
+++ b/pkg/declarativeconfig/transform/access_scope_test.go
@@ -19,26 +19,6 @@ func TestWrongConfigurationTypeTransformAccessScope(t *testing.T) {
 	assert.ErrorIs(t, err, errox.InvalidArgs)
 }
 
-func TestTransformAccessScope_InvalidLabelSelector(t *testing.T) {
-	at := newAccessScopeTransform()
-
-	scopeConfig := &declarativeconfig.AccessScope{
-		Name:        "test-scope",
-		Description: "test description",
-		Rules: declarativeconfig.Rules{
-			ClusterLabelSelectors: []declarativeconfig.LabelSelector{
-				{Requirements: []declarativeconfig.Requirement{
-					{
-						Key:      "a",
-						Operator: declarativeconfig.Operator(storage.LabelSelector_EXISTS),
-						Values:   []string{"a", "b", "c"}}}}}},
-	}
-
-	msgs, err := at.Transform(scopeConfig)
-	assert.ErrorIs(t, err, errox.InvalidArgs)
-	assert.Nil(t, msgs)
-}
-
 func TestTransformAccessScope(t *testing.T) {
 	at := newAccessScopeTransform()
 


### PR DESCRIPTION
## Description

We moved some validation within the `transform` method, specifically whether the label selectors contained within the access scope are valid.

This leads to the access scope not being created, and the integration health status not being created. This is undesired, as we want to specifically have an integration health status for it.

Hence, reverting the changes made to the `transform` now, but will make sure in a follow-up that the `roxctl declarative-config create access-scope` command will validate the access scope's label selectors.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

- CI should be passing again, specifically `DeclarativeConfigTest`.
