### PR TITLE
Disable query duration metric due to high cardinality

### DIFF
--- a/pkg/postgres/conn.go
+++ b/pkg/postgres/conn.go
@@ -2,7 +2,6 @@ package postgres
 
 import (
 	"context"
-	"time"
 
 	"github.com/jackc/pgconn"
 	"github.com/jackc/pgx/v4"
@@ -42,7 +41,6 @@ func (c *Conn) Exec(ctx context.Context, sql string, args ...interface{}) (pgcon
 	ctx, cancel := contextutil.ContextWithTimeoutIfNotExists(ctx, defaultTimeout)
 	defer cancel()
 
-	defer setQueryDuration(time.Now(), "conn", sql)
 	ct, err := c.Conn.Exec(ctx, sql, args...)
 	if err != nil {
 		incQueryErrors(sql, err)
@@ -55,7 +53,6 @@ func (c *Conn) Exec(ctx context.Context, sql string, args ...interface{}) (pgcon
 func (c *Conn) Query(ctx context.Context, sql string, args ...interface{}) (*Rows, error) {
 	ctx, cancel := contextutil.ContextWithTimeoutIfNotExists(ctx, defaultTimeout)
 
-	defer setQueryDuration(time.Now(), "conn", sql)
 	rows, err := c.Conn.Query(ctx, sql, args...)
 	if err != nil {
 		incQueryErrors(sql, err)
@@ -73,7 +70,6 @@ func (c *Conn) Query(ctx context.Context, sql string, args ...interface{}) (*Row
 func (c *Conn) QueryRow(ctx context.Context, sql string, args ...interface{}) *Row {
 	ctx, cancel := contextutil.ContextWithTimeoutIfNotExists(ctx, defaultTimeout)
 
-	defer setQueryDuration(time.Now(), "conn", sql)
 	return &Row{
 		Row:        c.Conn.QueryRow(ctx, sql, args...),
 		query:      sql,

--- a/pkg/postgres/metrics.go
+++ b/pkg/postgres/metrics.go
@@ -1,8 +1,6 @@
 package postgres
 
 import (
-	"time"
-
 	"github.com/jackc/pgx/v4"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stackrox/rox/pkg/metrics"
@@ -10,20 +8,11 @@ import (
 
 func init() {
 	prometheus.MustRegister(
-		//queryDuration,
 		queryErrors,
 	)
 }
 
 var (
-	//queryDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-	//	Namespace: metrics.PrometheusNamespace,
-	//	Subsystem: metrics.CentralSubsystem.String(),
-	//	Name:      "postgres_query_duration",
-	//	Help:      "Time in ms for a query to execute",
-	//	Buckets:   prometheus.ExponentialBuckets(4, 2, 16),
-	//}, []string{"scope", "query"})
-
 	queryErrors = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: metrics.PrometheusNamespace,
 		Subsystem: metrics.CentralSubsystem.String(),
@@ -31,20 +20,6 @@ var (
 		Help:      "Counter of errors occurring Postgres",
 	}, []string{"query", "error"})
 )
-
-func setQueryDuration(t time.Time, scope, query string) {
-	// Currently disable this metric as it is too noisy for dynamic queries
-	/*
-		if strings.HasPrefix(query, "FETCH") {
-			query = stringutils.GetUpTo(query, "_")
-		}
-		query = strings.ReplaceAll(query, "\n", " ")
-
-		logSlowQuery(t, query)
-
-		queryDuration.With(prometheus.Labels{"scope": scope, "query": query}).Observe(float64(time.Since(t).Milliseconds()))
-	*/
-}
 
 func incQueryErrors(query string, err error) {
 	if err == pgx.ErrNoRows {

--- a/pkg/postgres/metrics.go
+++ b/pkg/postgres/metrics.go
@@ -1,30 +1,28 @@
 package postgres
 
 import (
-	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v4"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stackrox/rox/pkg/metrics"
-	"github.com/stackrox/rox/pkg/stringutils"
 )
 
 func init() {
 	prometheus.MustRegister(
-		queryDuration,
+		//queryDuration,
 		queryErrors,
 	)
 }
 
 var (
-	queryDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Namespace: metrics.PrometheusNamespace,
-		Subsystem: metrics.CentralSubsystem.String(),
-		Name:      "postgres_query_duration",
-		Help:      "Time in ms for a query to execute",
-		Buckets:   prometheus.ExponentialBuckets(4, 2, 16),
-	}, []string{"scope", "query"})
+	//queryDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	//	Namespace: metrics.PrometheusNamespace,
+	//	Subsystem: metrics.CentralSubsystem.String(),
+	//	Name:      "postgres_query_duration",
+	//	Help:      "Time in ms for a query to execute",
+	//	Buckets:   prometheus.ExponentialBuckets(4, 2, 16),
+	//}, []string{"scope", "query"})
 
 	queryErrors = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: metrics.PrometheusNamespace,
@@ -35,14 +33,17 @@ var (
 )
 
 func setQueryDuration(t time.Time, scope, query string) {
-	if strings.HasPrefix(query, "FETCH") {
-		query = stringutils.GetUpTo(query, "_")
-	}
-	query = strings.ReplaceAll(query, "\n", " ")
+	// Currently disable this metric as it is too noisy for dynamic queries
+	/*
+		if strings.HasPrefix(query, "FETCH") {
+			query = stringutils.GetUpTo(query, "_")
+		}
+		query = strings.ReplaceAll(query, "\n", " ")
 
-	logSlowQuery(t, query)
+		logSlowQuery(t, query)
 
-	queryDuration.With(prometheus.Labels{"scope": scope, "query": query}).Observe(float64(time.Since(t).Milliseconds()))
+		queryDuration.With(prometheus.Labels{"scope": scope, "query": query}).Observe(float64(time.Since(t).Milliseconds()))
+	*/
 }
 
 func incQueryErrors(query string, err error) {

--- a/pkg/postgres/pool.go
+++ b/pkg/postgres/pool.go
@@ -72,7 +72,6 @@ func (d *DB) Exec(ctx context.Context, sql string, args ...interface{}) (pgconn.
 	ctx, cancel := contextutil.ContextWithTimeoutIfNotExists(ctx, defaultTimeout)
 	defer cancel()
 
-	defer setQueryDuration(time.Now(), "pool", sql)
 	ct, err := d.Pool.Exec(ctx, sql, args...)
 	if err != nil {
 		incQueryErrors(sql, err)
@@ -85,7 +84,6 @@ func (d *DB) Exec(ctx context.Context, sql string, args ...interface{}) (pgconn.
 func (d *DB) Query(ctx context.Context, sql string, args ...interface{}) (*Rows, error) {
 	ctx, cancel := contextutil.ContextWithTimeoutIfNotExists(ctx, defaultTimeout)
 
-	defer setQueryDuration(time.Now(), "pool", sql)
 	rows, err := d.Pool.Query(ctx, sql, args...)
 	if err != nil {
 		incQueryErrors(sql, err)
@@ -102,7 +100,6 @@ func (d *DB) Query(ctx context.Context, sql string, args ...interface{}) (*Rows,
 func (d *DB) QueryRow(ctx context.Context, sql string, args ...interface{}) pgx.Row {
 	ctx, cancel := contextutil.ContextWithTimeoutIfNotExists(ctx, defaultTimeout)
 
-	defer setQueryDuration(time.Now(), "pool", sql)
 	return &Row{
 		Row:        d.Pool.QueryRow(ctx, sql, args...),
 		query:      sql,

--- a/pkg/postgres/tx.go
+++ b/pkg/postgres/tx.go
@@ -2,7 +2,6 @@ package postgres
 
 import (
 	"context"
-	"time"
 
 	"github.com/jackc/pgconn"
 	"github.com/jackc/pgx/v4"
@@ -16,8 +15,6 @@ type Tx struct {
 
 // Exec wraps pgx.Tx Exec
 func (t *Tx) Exec(ctx context.Context, sql string, args ...interface{}) (commandTag pgconn.CommandTag, err error) {
-	defer setQueryDuration(time.Now(), "tx", sql)
-
 	ct, err := t.Tx.Exec(ctx, sql, args...)
 	if err != nil {
 		incQueryErrors(sql, err)
@@ -28,8 +25,6 @@ func (t *Tx) Exec(ctx context.Context, sql string, args ...interface{}) (command
 
 // Query wraps pgx.Tx Query
 func (t *Tx) Query(ctx context.Context, sql string, args ...interface{}) (*Rows, error) {
-	defer setQueryDuration(time.Now(), "tx", sql)
-
 	rows, err := t.Tx.Query(ctx, sql, args...)
 	if err != nil {
 		incQueryErrors(sql, err)
@@ -44,8 +39,6 @@ func (t *Tx) Query(ctx context.Context, sql string, args ...interface{}) (*Rows,
 
 // QueryRow wraps pgx.Tx QueryRow
 func (t *Tx) QueryRow(ctx context.Context, sql string, args ...interface{}) pgx.Row {
-	defer setQueryDuration(time.Now(), "tx", sql)
-
 	return t.Tx.QueryRow(ctx, sql, args...)
 }
 


### PR DESCRIPTION
## Description

Disable the query duration metric as it can have a very high cardinality on a busy cluster. It currently has very high cardinality for things like removing process listening on ports:

```
delete from listening_endpoints where (listening_endpoints.ProcessIndicatorId = $1 or listening_endpoints.ProcessIndicatorId = $2 or listening_endpoints.ProcessIndicatorId = $3 or listening_endpoints.ProcessIndicatorId = $4
```

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Simple disable