### PR TITLE
ROX-15219: Add fixable flag to Top Riskiest <thing> widget query

### DIFF
--- a/ui/apps/platform/src/Containers/VulnMgmt/Dashboard/VulnMgmtDashboardPage.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Dashboard/VulnMgmtDashboardPage.js
@@ -125,7 +125,7 @@ const VulnDashboardPage = ({ history }) => {
                     />
                 </div>
                 <div className="s-2 xxxl:sx-2">
-                    <TopRiskiestEntities limit={DASHBOARD_LIMIT} />
+                    <TopRiskiestEntities search={searchState} limit={DASHBOARD_LIMIT} />
                 </div>
                 <div className="s-2 xxxl:sx-2">
                     <FrequentlyViolatedPolicies />

--- a/ui/apps/platform/src/Containers/VulnMgmt/widgets/TopRiskiestEntities.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/widgets/TopRiskiestEntities.js
@@ -467,7 +467,7 @@ const processData = (data, entityType, workflowState, showVmUpdates) => {
     return results;
 };
 
-const TopRiskiestEntities = ({ entityContext, limit }) => {
+const TopRiskiestEntities = ({ entityContext, search, limit }) => {
     const { isFeatureFlagEnabled } = useFeatureFlags();
     const showVmUpdates = isFeatureFlagEnabled('ROX_POSTGRES_DATASTORE');
     const entities = getEntitiesByContext(entityContext, showVmUpdates);
@@ -476,6 +476,14 @@ const TopRiskiestEntities = ({ entityContext, limit }) => {
     function onEntityChange(value) {
         setSelectedEntity(value);
     }
+
+    const entityContextObject = queryService.entityContextToQueryObject(entityContext); // deals with BE inconsistency
+
+    const queryObject = {
+        ...entityContextObject,
+        ...search,
+    }; // Combine entity context and search
+    const query = queryService.objectToWhereClause(queryObject); // get final gql query string
 
     const {
         loading,
@@ -487,7 +495,7 @@ const TopRiskiestEntities = ({ entityContext, limit }) => {
             : getQueryBySelectedEntity(selectedEntity),
         {
             variables: {
-                query: queryService.entityContextToQueryString(entityContext),
+                query,
                 pagination: queryService.getPagination(
                     {
                         id: entityPriorityField[selectedEntity],
@@ -552,11 +560,13 @@ const TopRiskiestEntities = ({ entityContext, limit }) => {
 
 TopRiskiestEntities.propTypes = {
     entityContext: PropTypes.shape({}),
+    search: PropTypes.shape({}),
     limit: PropTypes.number,
 };
 
 TopRiskiestEntities.defaultProps = {
     entityContext: {},
+    search: {},
     limit: 5,
 };
 


### PR DESCRIPTION
## Description

Setting "Filter CVEs" toggle to "Fixable" was not filtering these entities by non-fixable CVEs. 
This is because the frontend does not pass the query with the fixable flag to the backend.



## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

Verified that the `Fixable:true`, if on, or nothing, if off, was being added to the query fired by the TopRiskiestEntities widget component.

When all was selected (and no flag filter sent)
<img width="813" alt="Screen Shot 2023-04-07 at 9 36 12 AM" src="https://user-images.githubusercontent.com/715729/230645466-eeec512c-19b4-4620-9226-0f70633f34e9.png">

When Fixable selected, and flag filter is sent, there is a difference in how the backend calculates the list (subtle)
<img width="1196" alt="Screen Shot 2023-04-07 at 9 36 26 AM" src="https://user-images.githubusercontent.com/715729/230645612-2ee71f1d-2f59-4521-a742-7aabf1855659.png">
