### PR TITLE
Simplify theme for SimulationFrame in Network Graph 1.0

### DIFF
--- a/ui/apps/platform/src/Components/SimulationFrame.tsx
+++ b/ui/apps/platform/src/Components/SimulationFrame.tsx
@@ -1,55 +1,40 @@
 import React, { ReactNode, ReactElement } from 'react';
 import { StopCircle } from 'react-feather';
 
-type StopSimulationButtonProps = {
-    isError?: boolean;
-    onStop: () => void;
-};
-
-function StopSimulationButton({ isError, onStop }: StopSimulationButtonProps): ReactElement {
-    const colorType = isError ? 'alert' : 'success';
-    return (
-        <button
-            type="button"
-            className={`flex items-center bg-${colorType}-700 text-base-100 font-600 uppercase p-2 mt-1 hover:bg-${colorType}-800`}
-            onClick={onStop}
-        >
-            <StopCircle className={`mr-2 w-4 h-4 text-${colorType}-100`} />
-            Stop
-        </button>
-    );
-}
-
 type SimulationLabelProps = {
-    isError?: boolean;
+    isError: boolean;
     onStop: () => void;
 };
 
 function SimulationLabel({ isError, onStop }: SimulationLabelProps): ReactElement | null {
-    const colorType = isError ? 'alert' : 'success';
+    // Note: border-4 corresponds to box shadow width in app.tw.css file.
+    const borderClass = isError ? 'border-alert-700' : 'border-success-700';
+    const bgClass = isError ? 'bg-alert-700' : 'bg-success-700';
     return (
-        <div className="absolute top-0 left-0 z-1 flex">
-            <div className={`bg-${colorType}-600 text-base-100 font-600 uppercase p-2 ml-1 mt-1`}>
-                Simulated View
-            </div>
-            <StopSimulationButton isError={isError} onStop={onStop} />
+        <div className={`absolute top-0 left-0 z-1 flex border-4 ${borderClass}`}>
+            <div className={`${bgClass} text-base-100 font-600 uppercase p-2`}>Simulated View</div>
+            <button
+                type="button"
+                className="flex items-center bg-base-100 hover:bg-base-200 text-base-600 font-600 uppercase p-2"
+                onClick={onStop}
+            >
+                <StopCircle className="mr-2 w-4 h-4" />
+                Stop
+            </button>
         </div>
     );
 }
 
 export type SimulationFrameProps = {
     children: ReactNode;
-    isError?: boolean;
+    isError: boolean;
     onStop: () => void;
 };
 
 function SimulationFrame({ children, isError, onStop }: SimulationFrameProps): ReactElement {
+    const boxShadowClass = isError ? 'before:text-alert-700' : 'before:text-success-700';
     return (
-        <div
-            className={`flex flex-1 flex-col relative simulator-mode ${
-                isError ? 'error' : 'success'
-            }`}
-        >
+        <div className={`flex flex-1 flex-col relative simulator-mode ${boxShadowClass}`}>
             <SimulationLabel isError={isError} onStop={onStop} />
             {children}
         </div>

--- a/ui/apps/platform/src/Components/SimulationFrame.tsx
+++ b/ui/apps/platform/src/Components/SimulationFrame.tsx
@@ -10,12 +10,15 @@ function SimulationLabel({ isError, onStop }: SimulationLabelProps): ReactElemen
     // Note: border-4 corresponds to box shadow width in app.tw.css file.
     const borderClass = isError ? 'border-alert-700' : 'border-success-700';
     const bgClass = isError ? 'bg-alert-700' : 'bg-success-700';
+    const bgStopButtonClasses = isError
+        ? 'bg-alert-300 hover:bg-alert-400'
+        : 'bg-success-300 hover:bg-success-400';
     return (
         <div className={`absolute top-0 left-0 z-1 flex border-4 ${borderClass}`}>
             <div className={`${bgClass} text-base-100 font-600 uppercase p-2`}>Simulated View</div>
             <button
                 type="button"
-                className="flex items-center bg-base-100 hover:bg-base-200 text-base-600 font-600 uppercase p-2"
+                className={`flex items-center ${bgStopButtonClasses} text-base-600 font-600 uppercase p-2`}
                 onClick={onStop}
             >
                 <StopCircle className="mr-2 w-4 h-4" />

--- a/ui/apps/platform/src/Containers/Network/SidePanel/Simulator/Simulator.tsx
+++ b/ui/apps/platform/src/Containers/Network/SidePanel/Simulator/Simulator.tsx
@@ -28,7 +28,6 @@ function Simulator({
         setModification(null);
     }
 
-    const colorType = modificationState === 'ERROR' ? 'alert' : 'success';
     const isProcessing = modificationState === 'REQUEST' && policyGraphState === 'REQUEST';
     const isError = modificationState === 'ERROR' && policyGraphState === 'ERROR';
     const isSuccess = modificationState === 'SUCCESS' && policyGraphState === 'SUCCESS';
@@ -45,8 +44,8 @@ function Simulator({
                     <PanelHeadEnd>
                         <CloseButton
                             onClose={onCloseHandler}
-                            className={`bg-${colorType}-600 hover:bg-${colorType}-700`}
-                            iconColor="text-base-100"
+                            className="border-base-400 border-l"
+                            iconColor="text-base-600"
                         />
                     </PanelHeadEnd>
                 </PanelHead>

--- a/ui/apps/platform/src/app.tw.css
+++ b/ui/apps/platform/src/app.tw.css
@@ -369,8 +369,7 @@ h6 {
 /**
   Outline for Simulation Mode
  */
-.simulator-mode.success:before,
-.simulator-mode.error:before {
+.simulator-mode:before {
     content: '';
     position: absolute;
     left: 0;
@@ -381,16 +380,10 @@ h6 {
     pointer-events: none;
 }
 
-.simulator-mode.error:before {
-    -webkit-box-shadow: inset 0px 0px 0px 4px theme('colors.alert-600');
-    -moz-box-shadow: inset 0px 0px 0px 4px theme('colors.alert-600');
-    box-shadow: inset 0px 0px 0px 4px theme('colors.alert-600');
-}
-
-.simulator-mode.success:before {
-    -webkit-box-shadow: inset 0px 0px 0px 4px theme('colors.success-600');
-    -moz-box-shadow: inset 0px 0px 0px 4px theme('colors.success-600');
-    box-shadow: inset 0px 0px 0px 4px theme('colors.success-600');
+.simulator-mode:before {
+    -webkit-box-shadow: inset 0px 0px 0px 4px;
+    -moz-box-shadow: inset 0px 0px 0px 4px;
+    box-shadow: inset 0px 0px 0px 4px;
 }
 
 .top-navigation {


### PR DESCRIPTION
## Description

Prerequisite simplification to solve insufficient color contrast issues elsewhere.

### Problems

1. Classic theme has subtle lightness distinctions within a hue:
    * Even if foreground and background have sufficient contrast, lightness distinctions probably do not.
    * Especially for red, PatternFly has fewer distinctions.

2. Color in template makes it hard for us or Tailwind to know which classes are in use.

    * src/Components/SimulationFrame.tsx 14 `flex items-center bg-${colorType}-700 text-base-100 font-600 uppercase p-2 mt-1 hover:bg-${colorType}-800`
    * src/Components/SimulationFrame.tsx 17 `mr-2 w-4 h-4 text-${colorType}-100`
    * src/Components/SimulationFrame.tsx 32 `bg-${colorType}-600 text-base-100 font-600 uppercase p-2 ml-1 mt-1`
    * src/Containers/Network/SidePanel/Simulator/Simulator.tsx 48 `bg-${colorType}-600 hover:bg-${colorType}-700`

4. Indirect reference to theme colors in css file is very subtle.

### Analysis

1. Use 700 level for alert and success because it is most common for non-base colors.

2. Specify colors via full class names:
    * before:text for box shadow
    * border for label and button
    * bg for label

3. Use plain bg, bg:hover, and text colors for button at upper left.

4. Adding insult to injury, `hover:bg-alert-300` in `CloseButton` element at upper right wins over conditional classes because of rule order in app.tw.css file:

### Solution

1. Replace conditional stop button colors with `text-base-600 hover:bg-base-200` like many other buttons.

2. Replace background color of frame with either `bg-alert-700` or `bg-success-700` class. Because Network Graph 1.0 is deprecated, and therefore this component will become obsolete, specify classes in the file.

3. Replace conditional background color of `CloseButton` element with neutral color because its inherent hover color is alert, which looks strange when the non-hover color is success (see below).

4. Delete indirect color references and conditional style rules for box shadow in app.tw.css file.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

### Manual testing

#### Simulation success

complicated theme with classic colors
![success_Tailwind](https://user-images.githubusercontent.com/11862657/230666120-d92c0108-ca15-4bcf-9194-1cfda016bc1a.png)

simplified theme mapped to PatternFly colors (coming soon)
![success_PatternFly](https://user-images.githubusercontent.com/11862657/230666108-2f289149-5556-4f86-a49a-23eddfb9230b.png)

#### Simulation failure

complicated theme with classic colors
![alert_Tailwind](https://user-images.githubusercontent.com/11862657/230666099-4bb17cc6-c532-449e-b952-3cb9c89413e4.png)

simplified theme mapped to PatternFly colors (coming soon)
![alert_PatternFly](https://user-images.githubusercontent.com/11862657/230666091-59aa6ae6-c585-44ee-89a8-0274b61908cd.png)

#### Simulator close button

A nuance that I missed at first:
* Click **Network Policy Simulator** to open Creator.
* And then click **Generate and simulate network policies** to open Simulator.

Close button is green for simulator success
![Simulator_success](https://user-images.githubusercontent.com/11862657/230672601-375727f7-d028-4237-bfa4-d71f7005b4af.png)

Close button hover is red regardless of simulator success or failure
![Simulator_hover](https://user-images.githubusercontent.com/11862657/230672616-8d575631-51cb-475c-8b93-b6f6af0c3b25.png)
