### PR TITLE
Dashrews/upgrade test and plop

### DIFF
--- a/central/sensor/service/common/common.go
+++ b/central/sensor/service/common/common.go
@@ -4,10 +4,8 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/pkg/logging"
-	"github.com/stackrox/rox/pkg/utils"
 )
 
 var (
@@ -39,7 +37,7 @@ func GetMessageType(msg *central.MsgFromSensor) string {
 	case *central.MsgFromSensor_ProcessListeningOnPortUpdate:
 		return "ProcessListeningOnPortUpdate"
 	default:
-		utils.Should(errors.Errorf("Unknown message type: %T", t))
+		log.Errorf("UNEXPECTED:  Unknown message type: %T", t)
 		return "Unknown"
 	}
 }

--- a/tests/upgrade/postgres_run.sh
+++ b/tests/upgrade/postgres_run.sh
@@ -322,9 +322,11 @@ force_rollback_to_previous_postgres() {
     # downgrading to a version that does not undersatnd process listening on ports
     # so turning that off in sensor and collector to prevent central crashes.
     # Sensor and Collector will be deleted a few steps after this so no need
-    # to turn these back on
-#    kubectl -n stackrox set env deploy/sensor ROX_PROCESSES_LISTENING_ON_PORT=false
-#    kubectl -n stackrox set env ds/collector ROX_PROCESSES_LISTENING_ON_PORT=false
+    # to turn these back on.  Going forward unexpected messages will result in
+    # an `UNEXPECTED` log instead of crashing central.  However that change is
+    # not present in the initial 3.74 version.
+    kubectl -n stackrox set env deploy/sensor ROX_PROCESSES_LISTENING_ON_PORT=false
+    kubectl -n stackrox set env ds/collector ROX_PROCESSES_LISTENING_ON_PORT=false
 
     kubectl -n stackrox patch configmap/central-config -p "$config_patch"
     kubectl -n stackrox set image deploy/central "central=$REGISTRY/main:$FORCE_ROLLBACK_VERSION"

--- a/tests/upgrade/postgres_run.sh
+++ b/tests/upgrade/postgres_run.sh
@@ -132,6 +132,7 @@ test_upgrade_paths() {
     echo "Unable to connect to Sensor at" >> /tmp/allowlist-patterns
     echo "No suitable kernel object downloaded for kernel" >> /tmp/allowlist-patterns
     echo "Unexpected HTTP request failure" >> /tmp/allowlist-patterns
+    echo "UNEXPECTED:  Unknown message type" >> /tmp/allowlist-patterns
     # Using ci_export so the post tests have this as well
     ci_export ALLOWLIST_FILE "/tmp/allowlist-patterns"
 
@@ -322,8 +323,8 @@ force_rollback_to_previous_postgres() {
     # so turning that off in sensor and collector to prevent central crashes.
     # Sensor and Collector will be deleted a few steps after this so no need
     # to turn these back on
-    kubectl -n stackrox set env deploy/sensor ROX_PROCESSES_LISTENING_ON_PORT=false
-    kubectl -n stackrox set env ds/collector ROX_PROCESSES_LISTENING_ON_PORT=false
+#    kubectl -n stackrox set env deploy/sensor ROX_PROCESSES_LISTENING_ON_PORT=false
+#    kubectl -n stackrox set env ds/collector ROX_PROCESSES_LISTENING_ON_PORT=false
 
     kubectl -n stackrox patch configmap/central-config -p "$config_patch"
     kubectl -n stackrox set image deploy/central "central=$REGISTRY/main:$FORCE_ROLLBACK_VERSION"

--- a/tests/upgrade/postgres_run.sh
+++ b/tests/upgrade/postgres_run.sh
@@ -321,7 +321,7 @@ force_rollback_to_previous_postgres() {
     config_patch=$(yq e ".data[\"central-config.yaml\"] |= \"$central_config\"" /tmp/force_rollback_patch)
     echo "config patch: $config_patch"
 
-    # downgrading to a version that does not undersatnd process listening on ports
+    # downgrading to a version that does not understand process listening on ports
     # so turning that off in sensor and collector to prevent central crashes.
     # Sensor and Collector will be deleted a few steps after this so no need
     # to turn these back on.  Going forward unexpected messages will result in

--- a/tests/upgrade/postgres_run.sh
+++ b/tests/upgrade/postgres_run.sh
@@ -318,9 +318,15 @@ force_rollback_to_previous_postgres() {
     config_patch=$(yq e ".data[\"central-config.yaml\"] |= \"$central_config\"" /tmp/force_rollback_patch)
     echo "config patch: $config_patch"
 
+    # downgrading to a version that does not undersatnd process listening on ports
+    # so turning that off in sensor and collector to prevent central crashes.
+    # Sensor and Collector will be deleted a few steps after this so no need
+    # to turn these back on
+    kubectl -n stackrox set env deploy/sensor ROX_PROCESSES_LISTENING_ON_PORT=false
+    kubectl -n stackrox set env ds/collector ROX_PROCESSES_LISTENING_ON_PORT=false
+
     kubectl -n stackrox patch configmap/central-config -p "$config_patch"
     kubectl -n stackrox set image deploy/central "central=$REGISTRY/main:$FORCE_ROLLBACK_VERSION"
-    kubectl -n stackrox set env deploy/central ROX_PROCESSES_LISTENING_ON_PORT=true
     kubectl -n stackrox set image deploy/central-db "*=$REGISTRY/central-db:$FORCE_ROLLBACK_VERSION"
 }
 

--- a/tests/upgrade/postgres_run.sh
+++ b/tests/upgrade/postgres_run.sh
@@ -133,6 +133,8 @@ test_upgrade_paths() {
     echo "No suitable kernel object downloaded for kernel" >> /tmp/allowlist-patterns
     echo "Unexpected HTTP request failure" >> /tmp/allowlist-patterns
     echo "UNEXPECTED:  Unknown message type" >> /tmp/allowlist-patterns
+    # bouncing the database can result in this error
+    echo "FATAL: the database system is shutting down" >> /tmp/allowlist-patterns
     # Using ci_export so the post tests have this as well
     ci_export ALLOWLIST_FILE "/tmp/allowlist-patterns"
 

--- a/tests/upgrade/postgres_run.sh
+++ b/tests/upgrade/postgres_run.sh
@@ -202,9 +202,12 @@ test_upgrade_paths() {
     force_rollback_to_previous_postgres
     wait_for_api
 
-    # Verify data is still there as these were populated before we upgraded
-    checkForRocksAccessScopes
-    checkForPostgresAccessScopes
+    validate_upgrade "04_postgres_postgres_rollback" "Rollback Postgres backed central" "268c98c6-e983-4f4e-95d2-9793cebddfd7"
+
+    collect_and_check_stackrox_logs "$log_output_dir" "04_postgres_postgres_rollback"
+
+    # Ensure central is ready for requests after any previous tests
+    wait_for_api
 
     ########################################################################################
     # Upgrade back to latest to run the smoke tests                                        #
@@ -317,6 +320,7 @@ force_rollback_to_previous_postgres() {
 
     kubectl -n stackrox patch configmap/central-config -p "$config_patch"
     kubectl -n stackrox set image deploy/central "central=$REGISTRY/main:$FORCE_ROLLBACK_VERSION"
+    kubectl -n stackrox set env deploy/central ROX_PROCESSES_LISTENING_ON_PORT=true
     kubectl -n stackrox set image deploy/central-db "*=$REGISTRY/central-db:$FORCE_ROLLBACK_VERSION"
 }
 

--- a/tests/upgrade/postgres_run.sh
+++ b/tests/upgrade/postgres_run.sh
@@ -204,7 +204,7 @@ test_upgrade_paths() {
 
     validate_upgrade "04_postgres_postgres_rollback" "Rollback Postgres backed central" "268c98c6-e983-4f4e-95d2-9793cebddfd7"
 
-    collect_and_check_stackrox_logs "$log_output_dir" "04_postgres_postgres_rollback"
+#    collect_and_check_stackrox_logs "$log_output_dir" "04_postgres_postgres_rollback"
 
     # Ensure central is ready for requests after any previous tests
     wait_for_api

--- a/tests/upgrade/postgres_run.sh
+++ b/tests/upgrade/postgres_run.sh
@@ -202,12 +202,9 @@ test_upgrade_paths() {
     force_rollback_to_previous_postgres
     wait_for_api
 
-    validate_upgrade "04_postgres_postgres_rollback" "Rollback Postgres backed central" "268c98c6-e983-4f4e-95d2-9793cebddfd7"
-
-#    collect_and_check_stackrox_logs "$log_output_dir" "04_postgres_postgres_rollback"
-
-    # Ensure central is ready for requests after any previous tests
-    wait_for_api
+    # Verify data is still there as these were populated before we upgraded
+    checkForRocksAccessScopes
+    checkForPostgresAccessScopes
 
     ########################################################################################
     # Upgrade back to latest to run the smoke tests                                        #


### PR DESCRIPTION
## Description

The issue here is that with the quick rollback to a previous Postgres, we leave the sensors at the level they previously were.  Which means that sensor knows about processes listening on ports and central does not.  The intent is just to downgrade central and ensure that the data remains.  So this update simply changes how we verify that as we are upgrading back to current immediately after.  It becomes a spot check of the data and then we will run a more thorough smoke test and verify the logs after the final upgrade to current.

## Checklist
- [ ] Investigated and inspected CI test results
~- [ ] Unit test and regression tests added~
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

It is a test
