### PR TITLE
Delete slick-carousel package and styles from UI

### DIFF
--- a/ui/apps/platform/package.json
+++ b/ui/apps/platform/package.json
@@ -95,7 +95,6 @@
         "redux-saga": "^0.16.0",
         "redux-thunk": "^2.4.1",
         "reselect": "^4.1.2",
-        "slick-carousel": "^1.8.1",
         "store": "^2.0.12",
         "styled-components": "^5.3.1",
         "tippy.js": "^6.3.7",

--- a/ui/apps/platform/src/app.tw.css
+++ b/ui/apps/platform/src/app.tw.css
@@ -1,5 +1,3 @@
-@import '~slick-carousel/slick/slick.css';
-@import '~slick-carousel/slick/slick-theme.css';
 @import 'css/style.css';
 
 @import '~@stackrox/tailwind-config/light.theme.css';
@@ -302,38 +300,6 @@ h6 {
 
 .severity-tile {
     background: hsla(0, 0%, 100%, 0.19);
-}
-
-.slick-initialized.slick-slider,
-.slick-list,
-.slick-track {
-    height: 100%;
-    user-select: text;
-}
-
-.slick-arrow::before {
-    display: none;
-}
-
-.carousel-prev-arrow,
-.carousel-next-arrow {
-    position: absolute;
-    top: 0%;
-    z-index: 2;
-}
-.carousel-prev-arrow,
-.carousel-next-arrow {
-    position: absolute;
-    top: 0%;
-    z-index: 2;
-}
-
-.carousel-prev-arrow {
-    right: 70px;
-}
-
-.carousel-next-arrow {
-    right: 24px;
 }
 
 .cursor-text {

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -17530,11 +17530,6 @@ slice-ansi@^4.0.0:
     astral-regex "^2.0.0"
     is-fullwidth-code-point "^3.0.0"
 
-slick-carousel@^1.8.1:
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/slick-carousel/-/slick-carousel-1.8.1.tgz#a4bfb29014887bb66ce528b90bd0cda262cc8f8d"
-  integrity sha512-XB9Ftrf2EEKfzoQXt3Nitrt/IPbT+f1fgqBdoxO3W/+JYvtEOW6EgxnWfr9GH6nmULv7Y2tPmEX3koxThVmebA==
-
 slide@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/slide/-/slide-1.1.6.tgz#56eb027d65b4d2dce6cb2e2d32c4d4afc9e1d707"


### PR DESCRIPTION
## Description

Left over after delete `react-slick` in #3065

Find in files only references to **slick** or **carousel** are in app.tw.css file

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

1. Delete dependency and then `yarn` in ui

2. `yarn build` in ui to see expected error because of reference in app.tw.css

3. Delete reference

4. `yarn build` in ui and then
    * `wc build/static/css/main.*.css` in ui
        branch - master: -9415 = 4855447 - 4864862
    * `wc build/static/css/*.chunk.css` in ui
        branch - master: 0 = 1069736 - 1069736

5. `yarn start` in ui and then visit pages that have links in left navigation