### PR TITLE
Delete occurrences of theme accent color

### DIFF
--- a/ui/apps/platform/src/Components/KeyValuePairs.js
+++ b/ui/apps/platform/src/Components/KeyValuePairs.js
@@ -35,14 +35,12 @@ class KeyValuePairs extends Component {
         }
 
         return keys.map((key) => (
-            <div className="py-2 max-w-md text-accent-400" key={key} data-testid={key}>
-                {!isNumeric(key) ? <span className="pr-1 text-secondary-800">{key}:</span> : ''}
+            <div className="py-2 max-w-md" key={key} data-testid={key}>
+                {!isNumeric(key) ? <span className="pr-1 font-700">{key}:</span> : ''}
                 {isObject(nestedData[key]) ? (
                     this.getNestedValue(nestedData[key])
                 ) : (
-                    <span title={nestedData[key]} className="italic text-accent-800">
-                        {nestedData[key].toString()}
-                    </span>
+                    <span title={nestedData[key]}>{nestedData[key].toString()}</span>
                 )}
             </div>
         ));

--- a/ui/apps/platform/src/Components/TimelineGraph/Minimap/BrushableOverlay.js
+++ b/ui/apps/platform/src/Components/TimelineGraph/Minimap/BrushableOverlay.js
@@ -65,8 +65,8 @@ const BrushableOverlay = ({
             .call(brush)
             .call(brush.move, [xScale(minTimeRange), xScale(maxTimeRange)])
             .select('rect.selection')
-            .style('fill', 'var(--base-100)')
-            .style('stroke', 'var(--base-100)');
+            .style('fill', 'var(--accent-500)')
+            .style('stroke', 'var(--accent-500)');
     }
 
     return (

--- a/ui/apps/platform/src/Components/TimelineGraph/Minimap/BrushableOverlay.js
+++ b/ui/apps/platform/src/Components/TimelineGraph/Minimap/BrushableOverlay.js
@@ -65,8 +65,8 @@ const BrushableOverlay = ({
             .call(brush)
             .call(brush.move, [xScale(minTimeRange), xScale(maxTimeRange)])
             .select('rect.selection')
-            .style('fill', 'var(--accent-500)')
-            .style('stroke', 'var(--accent-500)');
+            .style('fill', 'var(--base-100)')
+            .style('stroke', 'var(--base-100)');
     }
 
     return (

--- a/ui/apps/platform/src/Containers/Network/SidePanel/Creator/Tiles/GenerateNetworkPoliciesSection.tsx
+++ b/ui/apps/platform/src/Containers/Network/SidePanel/Creator/Tiles/GenerateNetworkPoliciesSection.tsx
@@ -6,9 +6,9 @@ import GenerateButton from 'Containers/Network/SidePanel/Creator/Buttons/Generat
 function GenerateNetworkPoliciesSection(): ReactElement {
     return (
         <div className="bg-base-100 rounded-sm shadow">
-            <div className="flex text-primary-700 p-3 border-b border-base-300 mb-2 items-center">
+            <div className="flex p-3 border-b border-base-300 mb-2 items-center">
                 <img
-                    className="text-primary-700 h-5"
+                    className="h-5"
                     alt=""
                     src={generate}
                     style={{

--- a/ui/apps/platform/src/Containers/Network/SidePanel/Creator/Tiles/UploadNetworkPolicySection.tsx
+++ b/ui/apps/platform/src/Containers/Network/SidePanel/Creator/Tiles/UploadNetworkPolicySection.tsx
@@ -73,7 +73,7 @@ function UploadNetworkPolicySection({
 
     return (
         <div className="flex flex-col bg-base-100 rounded-sm shadow flex-grow flex-shrink-0 mb-4">
-            <div className="flex text-accent-700 p-3 border-b border-base-300 mb-2 items-center flex-shrink-0">
+            <div className="flex p-3 border-b border-base-300 mb-2 items-center flex-shrink-0">
                 <Icon.Upload size="20px" strokeWidth="1.5px" />
 
                 <div className="pl-3 font-700 text-lg">Upload a network policy YAML</div>

--- a/ui/apps/platform/src/Containers/Network/SidePanel/NetworkDeploymentOverlay/DeploymentDetails/ContainerConfigurations.tsx
+++ b/ui/apps/platform/src/Containers/Network/SidePanel/NetworkDeploymentOverlay/DeploymentDetails/ContainerConfigurations.tsx
@@ -94,11 +94,11 @@ const ContainerVolumes = ({ volumes }: { volumes: Volume[] }): ReactElement => {
                     {Object.keys(volume).map(
                         (key) =>
                             volume[key] && (
-                                <div key={key} className="py-1 font-600">
-                                    <span className=" pr-1">{capitalize(lowerCase(key))}:</span>
-                                    <span className="text-accent-800 italic">
-                                        {volume[key].toString()}
+                                <div key={key} className="py-1">
+                                    <span className="font-700 pr-1">
+                                        {capitalize(lowerCase(key))}:
                                     </span>
+                                    <span className="font-600">{volume[key].toString()}</span>
                                 </div>
                             )
                     )}
@@ -114,19 +114,19 @@ type Secret = {
 };
 const ContainerSecrets = ({ secrets }: { secrets: Secret[] }): ReactElement => {
     if (!secrets?.length) {
-        return <span className="py-1 font-600 italic">None</span>;
+        return <span className="py-1 font-600">None</span>;
     }
     return (
         <>
             {secrets.map(({ name, path }) => (
                 <div key={`${name}-${path}`} className="py-2">
-                    <div className="py-1 font-600">
-                        <span className="pr-1">Name:</span>
-                        <span className="text-accent-800 italic">{name}</span>
+                    <div className="py-1">
+                        <span className="font-700 pr-1">Name:</span>
+                        <span className="font-600">{name}</span>
                     </div>
-                    <div className="py-1 font-600">
-                        <span className="pr-1">Container Path:</span>
-                        <span className="text-accent-800 italic">{path}</span>
+                    <div className="py-1">
+                        <span className="font-700 pr-1">Container Path:</span>
+                        <span className="font-600">{path}</span>
                     </div>
                 </div>
             ))}

--- a/ui/apps/platform/src/Containers/Risk/ContainerConfigurations.js
+++ b/ui/apps/platform/src/Containers/Risk/ContainerConfigurations.js
@@ -80,9 +80,9 @@ const ContainerVolumes = ({ volumes }) => {
             {Object.keys(volume).map(
                 (key) =>
                     volume[key] && (
-                        <div key={key} className="py-1 font-600">
-                            <span className=" pr-1">{capitalize(lowerCase(key))}:</span>
-                            <span className="text-accent-800 italic">{volume[key].toString()}</span>
+                        <div key={key} className="py-1">
+                            <span className="font-700 pr-1">{capitalize(lowerCase(key))}:</span>
+                            <span className="font-600">{volume[key].toString()}</span>
                         </div>
                     )
             )}
@@ -96,13 +96,13 @@ const ContainerSecrets = ({ secrets }) => {
     }
     return secrets.map(({ name, path }) => (
         <div key={name} className="py-2">
-            <div className="py-1 font-600">
-                <span className="pr-1">Name:</span>
-                <span className="text-accent-800 italic">{name}</span>
+            <div className="py-1">
+                <span className="font-700 pr-1">Name:</span>
+                <span className="font-600">{name}</span>
             </div>
-            <div className="py-1 font-600">
-                <span className="pr-1">Container Path:</span>
-                <span className="text-accent-800 italic">{path}</span>
+            <div className="py-1">
+                <span className="font-700 pr-1">Container Path:</span>
+                <span className="font-600">{path}</span>
             </div>
         </div>
     ));

--- a/ui/apps/platform/src/constants/visuals/colors.ts
+++ b/ui/apps/platform/src/constants/visuals/colors.ts
@@ -1,20 +1,13 @@
 import { VulnerabilitySeverity } from 'types/cve.proto';
 import { PolicySeverity } from 'types/policy.proto';
 
-const colors = [
-    'var(--primary-400)',
-    'var(--secondary-400)',
-    'var(--tertiary-400)',
-    'var(--accent-400)',
-    'var(--secondary-500)',
-];
+const colors = ['var(--primary-400)', 'var(--secondary-400)'];
 
 export const colorTypes = [
     'alert',
     'caution',
     'warning',
     'success',
-    'accent',
     'tertiary',
     'secondary',
     'primary',

--- a/ui/apps/platform/src/constants/visuals/colors.ts
+++ b/ui/apps/platform/src/constants/visuals/colors.ts
@@ -1,7 +1,15 @@
 import { VulnerabilitySeverity } from 'types/cve.proto';
 import { PolicySeverity } from 'types/policy.proto';
 
-const colors = ['var(--primary-400)', 'var(--secondary-400)'];
+// For example, vertical bars in Compliance Passing Standards by Clusters chart.
+const colors = [
+    'var(--base-700)',
+    'var(--primary-700)',
+    'var(--secondary-700)',
+    'var(--base-400)',
+    'var(--primary-400)',
+    'var(--secondary-400)',
+];
 
 export const colorTypes = [
     'alert',


### PR DESCRIPTION
## Description

Prerequisite to solve insufficient color contrast accessibility issues by mapping from classic to PatternFly theme.

### Problem

PatternFly color palette does not have magenta.

https://www.patternfly.org/v4/guidelines/colors#color-palette

### Analysis

1. Redundantly distinguishes value from key by accent color in addition to either font style or weight:
    * src/Components/KeyValuePairs.js
    * src/Containers/Network/SidePanel/NetworkDeploymentOverlay/DeploymentDetails/ContainerConfigurations.tsx
    * src/Containers/Risk/ContainerConfigurations.js

    Distinction between secondary and accent is hard in light theme and even harder in dark theme (see pictures).

2. Double style inconsistency accent versus primary above, and both are heading text that look like buttons or links. Too bad, so sad that icon apparently has inherent color independent of theme variables for **Generate network policies** heading (see pictures).
    * src/Containers/Network/SidePanel/Creator/Tiles/UploadNetworkPolicySection.tsx

3. Unique color in BrushableOverlay for timeline graph in Risk.
    * src/Components/TimelineGraph/Minimap/BrushableOverlay.js

4. Unused color type constants because no React element has `type="accent"` prop nor any data has `colorType: 'accent'` property:
    * src/constants/visuals/colors.ts

### Solution

1. Follow example of PatternFly in which `font-700` distinguishes key from value.

2. Remove color classes from heading text, especially because they are not links.

3. Remove distinction from background of modal.

4. Delete accent from color types. Notice that there are not enough colors for 6 compliance standards and the fifth is hard to distinguish from the second. Therefore, provide only two alternating colors for bar charts, and so on.

### Residue

1. Investigate which theme classes does API Reference need from `.redoc-wrap {…}` style rule in app.tw.css file.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

1. `yarn build` in ui

    * `wc build/static/js/*.js`
        branch - master: -504 = 11724000 - 11724504

### Manual testing

1. KeyValuePairs and so on

    * with accent in dark theme
        ![KeyValuePairs_with_dark](https://user-images.githubusercontent.com/11862657/230977630-c1c95661-e87e-4643-a066-377ff848d3e1.png)

    * without accent in dark theme
        ![KeyValuePairs_without_dark](https://user-images.githubusercontent.com/11862657/230977701-c987eac3-f5e0-4b9b-9fb7-3234870f756d.png)

    * with accent in light theme
        ![KeyValuePairs_with_light](https://user-images.githubusercontent.com/11862657/230977774-9b1e526a-af5a-4bc2-99d0-2eefd1940638.png)

    * without accent in light theme
        ![KeyValuePairs_without_light](https://user-images.githubusercontent.com/11862657/230977833-f3b3e2cc-8e60-40ef-9220-d50bc2310c2e.png)

2. UploadNetworkPolicySection

    * with accent in dark theme
        ![UploadNetworkPolicySection_with_dark](https://user-images.githubusercontent.com/11862657/230977927-511c3296-47e5-411a-8321-fca0882cd364.png)

    * without accent in dark theme
        ![UploadNetworkPolicySection_without_dark](https://user-images.githubusercontent.com/11862657/230977982-f53ede86-3f1b-4400-b119-b5f40eff961a.png)

    * with accent in light theme
        ![UploadNetworkPolicySection_with_light](https://user-images.githubusercontent.com/11862657/230978036-ed462e54-5cce-4cea-9b5d-136897ec47f8.png)

    * without accent in light theme
        ![UploadNetworkPolicySection_without_light](https://user-images.githubusercontent.com/11862657/230978084-3552e7e5-90f7-49c6-9510-fa7f527b1df7.png)

3. BrushableOverlay

    * with accent in dark theme
        ![BrushableOverlay_with_dark](https://user-images.githubusercontent.com/11862657/230978161-b7065ead-3440-4a70-a4e0-8facdaa970e2.png)

    * without accent in dark theme
        ![BrushableOverlay_without_dark](https://user-images.githubusercontent.com/11862657/230978206-598c6a6b-b7e2-4ab1-8f16-ba50479c59c0.png)

    * with accent in light theme
        ![BrushableOverlay_with_light](https://user-images.githubusercontent.com/11862657/230978266-85d1afc4-25ad-42f5-bef8-487b5a8985f7.png)

    * without accent in light theme
        ![BrushableOverlay_without_light](https://user-images.githubusercontent.com/11862657/230978323-104c8900-c7a7-4f9e-8b32-355ea3c5f9db.png)

4. VerticalBarChart

    * with accent among 5 colors in dark theme
        ![VerticalBarChart_with_dark](https://user-images.githubusercontent.com/11862657/230978356-d0791d83-94e9-4f12-b673-c5613fdcb1cd.png)

    * without accent among 2 colors in dark theme
        ![VerticalBarChart_without_dark](https://user-images.githubusercontent.com/11862657/230978384-307b60ee-ab2e-4ae9-86d9-7732678bebfc.png)

    * with accent among 5 colors in light theme
        ![VerticalBarChart_with_light](https://user-images.githubusercontent.com/11862657/230978420-8a5f1cfa-808a-444e-933b-71eefde04f8c.png)

    * without accent among 2 colors in light theme
        ![VerticalBarChart_without_light](https://user-images.githubusercontent.com/11862657/230978449-95722071-bae3-4a71-9a52-25d7309cbc54.png)
