### PR TITLE
Bulk action cve to policy breaks without custom policies

### DIFF
--- a/ui/apps/platform/src/Containers/VulnMgmt/List/Cves/CveBulkActionDialogue.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/Cves/CveBulkActionDialogue.js
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { gql, useQuery } from '@apollo/client';
 import cloneDeep from 'lodash/cloneDeep';
@@ -157,22 +157,18 @@ const CveBulkActionDialogue = ({ closeAction, bulkActionCveIds, cveType }) => {
         policyQueryOptions
     );
 
-    if (
-        !policyLoading &&
-        policyData &&
-        policyData.results &&
-        policyData.results.length &&
-        policies.length === 0
-    ) {
-        const existingPolicies = policyData.results
-            .filter((policyToFilter) => !policyToFilter?.isDefault)
-            .map((policyToMap, idx) => ({
-                ...policyToMap,
-                value: idx,
-                label: policyToMap.name,
-            }));
-        setPolicies(existingPolicies);
-    }
+    useEffect(() => {
+        if (!policyLoading && policyData?.results?.length) {
+            const existingPolicies = policyData.results
+                .filter((policyToFilter) => !policyToFilter?.isDefault)
+                .map((policyToMap, idx) => ({
+                    ...policyToMap,
+                    value: idx,
+                    label: policyToMap.name,
+                }));
+            setPolicies(existingPolicies);
+        }
+    }, [policyLoading, policyData]);
 
     function handleChange(event) {
         if (get(policy, event.target.name) !== undefined) {


### PR DESCRIPTION
## Description

If no custom policies have been created, adding a CVE to a policy in vulnerability management will cause the page to error out due to an infinite loop in the `CveBulkActionDialogue` component.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed
Action:
![Screenshot 2023-04-10 at 4 27 37 PM](https://user-images.githubusercontent.com/61400697/231002680-8e55ae08-3e0d-40e2-86f1-ee7f927dace0.png)

Results before:
![Screenshot 2023-04-10 at 4 07 06 PM](https://user-images.githubusercontent.com/61400697/231000886-cf6312fc-828d-4e92-b9bb-191667ab121a.png)

Results after:
![Screenshot 2023-04-10 at 4 18 13 PM](https://user-images.githubusercontent.com/61400697/231000901-3a4f8993-6659-4a10-b5e5-7992cf594a56.png)



