### PR TITLE
Dashrews/ROX-16422 rocks restore postgres start over

### DIFF
--- a/migrator/clone/postgres/db_clone_manager_impl.go
+++ b/migrator/clone/postgres/db_clone_manager_impl.go
@@ -149,6 +149,12 @@ func (d *dbCloneManagerImpl) GetCloneToMigrate(rocksVersion *migrations.Migratio
 	// If a restore clone exists, our focus is to try to restore that database.
 	if _, ok := d.cloneMap[RestoreClone]; ok || restoreFromRocks {
 		if restoreFromRocks {
+			// We are restoring from Rocks, so we need to start with fresh Postgres each time
+			err := pgadmin.DropDB(d.sourceMap, d.adminConfig, RestoreClone)
+			if err != nil {
+				log.Errorf("Unable to drop clone - %q", RestoreClone)
+				return "", false, err
+			}
 			d.cloneMap[RestoreClone] = metadata.NewPostgres(rocksVersion, RestoreClone)
 			return RestoreClone, true, nil
 		}


### PR DESCRIPTION
## Description

when restoring a rocks backup to Postgres we do not clear out any instances of central_restore.  So if such a restore failed then our central_restore would be dirty.  So the fix is to drop central_restore in the event we are processing a rocks restore into postgres.

## Checklist
- [ ] Investigated and inspected CI test results
~- [ ] Unit test and regression tests added~
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

tested manually by starting a cluster and killing the central pod during the migration.  When pod came back up it deleted central_restore and started the restore from rocks again fresh.
