### PR TITLE
CI: Add OCP jobs

### DIFF
--- a/scripts/ci/jobs/ocp_operator_e2e_tests.py
+++ b/scripts/ci/jobs/ocp_operator_e2e_tests.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env -S python3 -u
+
+"""
+Run operator e2e tests in a openshift 4 cluster provided via a hive cluster_claim.
+"""
+from runners import ClusterTestRunner
+from ci_tests import OperatorE2eTest
+from pre_tests import PreSystemTests
+from post_tests import PostClusterTest, FinalPost
+
+
+ClusterTestRunner(
+    pre_test=PreSystemTests(),
+    test=OperatorE2eTest(),
+    post_test=PostClusterTest(collect_central_artifacts=False),
+    final_post=FinalPost(handle_e2e_progress_failures=False),
+).run()

--- a/scripts/ci/jobs/ocp_qa_e2e_tests.py
+++ b/scripts/ci/jobs/ocp_qa_e2e_tests.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env -S python3 -u
+
+"""
+Run qa-tests-backend in a openshift 4 cluster provided via a hive cluster_claim.
+"""
+import os
+from base_qa_e2e_test import make_qa_e2e_test_runner
+from clusters import OpenShiftScaleWorkersCluster
+
+# set required test parameters
+os.environ["DEPLOY_STACKROX_VIA_OPERATOR"] = "true"
+os.environ["ORCHESTRATOR_FLAVOR"] = "openshift"
+os.environ["ROX_POSTGRES_DATASTORE"] = "true"
+
+# Scale up the cluster to support postgres
+cluster = OpenShiftScaleWorkersCluster(increment=1)
+
+make_qa_e2e_test_runner(cluster=cluster).run()

--- a/scripts/ci/jobs/ocp_ui_e2e_tests.py
+++ b/scripts/ci/jobs/ocp_ui_e2e_tests.py
@@ -12,7 +12,6 @@ from post_tests import PostClusterTest, FinalPost
 
 # set required test parameters
 os.environ["DEPLOY_STACKROX_VIA_OPERATOR"] = "true"
-os.environ["OPENSHIFT_CI_CLUSTER_CLAIM"] = "openshift-4"
 os.environ["ORCHESTRATOR_FLAVOR"] = "openshift"
 os.environ["ROX_POSTGRES_DATASTORE"] = "false"
 


### PR DESCRIPTION
## Description

All openshift e2e tests now have ocp in their job names. This PR creates jobs in the target repo (this) to reflect that. TEST_SUITE will then be updated in a subsequent PR in openshift/release to use (and test) these jobs. And then another PR in this repo will remove the openshift-4 ones.

## Checklist

n/a

## Testing Performed

n/a