### PR TITLE
Delete occurrences of theme secondary color

### DIFF
--- a/ui/apps/platform/src/Containers/Clusters/cluster.helpers.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/cluster.helpers.tsx
@@ -163,8 +163,8 @@ export const healthStatusStyles = {
     UNINITIALIZED: styleUninitialized,
     UNAVAILABLE: {
         Icon: ResourcesEmptyIcon,
-        bgColor: 'bg-secondary-200',
-        fgColor: 'text-secondary-700',
+        bgColor: 'bg-base-200',
+        fgColor: 'text-base-700',
     },
     UNHEALTHY: styleUnhealthy,
     DEGRADED: styleDegraded,

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/widgets/ScopedPermissions.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/widgets/ScopedPermissions.js
@@ -1,22 +1,15 @@
 import React from 'react';
 
-const colors = ['primary', 'secondary', 'tertiary'];
-
 const getLabelColor = (key) => {
-    let color = '';
     switch (key) {
         case 'create':
         case 'update':
-            color = 'success';
-            break;
+            return 'success';
         case 'delete':
-            color = 'alert';
-            break;
+            return 'alert';
         default:
-            color = colors[Math.floor(Math.random() * colors.length)];
-            break;
+            return 'primary';
     }
-    return color;
 };
 
 const ScopedPermissions = ({ permissions }) => {

--- a/ui/apps/platform/src/constants/visuals/colors.ts
+++ b/ui/apps/platform/src/constants/visuals/colors.ts
@@ -16,7 +16,6 @@ export const colorTypes = [
     'success',
     'accent',
     'tertiary',
-    'secondary',
     'primary',
     'base',
 ];

--- a/ui/apps/platform/src/utils/vulnerabilityUtils.js
+++ b/ui/apps/platform/src/utils/vulnerabilityUtils.js
@@ -163,7 +163,7 @@ export function getVulnerabilityChips(workflowState, vulnerabilities, cveType = 
                         <div className="ml-2">
                             <LabelChip
                                 text={`Env Impact: ${envImpactPercentage}`}
-                                type="secondary"
+                                type="base"
                                 size="small"
                             />
                         </div>


### PR DESCRIPTION
## Description

Prerequisite to solve insufficient color contrast accessibility issues by mapping from classic to PatternFly theme.

PatternFly color palette does have purple, but there are few occurrences of this color, none of which have an intuitive semantic meaning.

https://www.patternfly.org/v4/guidelines/colors#color-palette

### Changed files

1. Edit src/Containers/Clusters/cluster.helpers.tsx

    * Replace secondary with base for status of Unavailable clusters.

2. Edit src/Containers/ConfigManagement/Entity/widgets/ScopedPermissions.js

    * Replace random selection from `['primary', 'secondary', 'tertiary']` with `primary` color.

3. Edit src/constants/visuals/colors.ts

    * Delete `'secondary'` from `colorTypes` array.

4. Edit src/utils/vulnerabilityUtils.js

    * Replace `type="secondary"` with `type="base"` in `LabelChip` element for **Env impact**.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

### Manual testing

#### cluster

1. `yarn cypress-open` in ui/apps/platform

2. Temporarily edit cypress/integration/clusters/clustersHealthStatus.test.js

    Add `.only` to `it.only('should appear in the list'` test.

    * With secondary color for Unavailable collector in mu-madegascar-12 cluster.
        ![cluster_secondary](https://user-images.githubusercontent.com/11862657/231229669-11d33e22-4169-4d08-8447-67f10240502b.png)

    * With base color for Unavailable collector in mu-madegascar-12 cluster.
        ![cluster_base](https://user-images.githubusercontent.com/11862657/231229711-90d4118c-a516-44f5-9a06-17a216cb52c9.png)

#### ScopedPermissions

1. Visit /main/configmanagement/namespaces

2. Click on a Service Accounts link.

3. Click on a row in the table.

    * With inconsistent random colors. Notice that **Get** has primary color at the left and secondary color at the right.
        ![ScopedPermissions_secondary](https://user-images.githubusercontent.com/11862657/231229603-186e42ac-1609-4bee-8ac1-de715fea7191.png)

    * With consistent primary color.
        ![ScopedPermissions_primary](https://user-images.githubusercontent.com/11862657/231229626-10819fe1-6f31-4ed5-972c-c47a85f2e237.png)

#### vulnerabilityUtils

1. Visit /main/vulnerability-management

2. Scroll down to **Recently detected image vulnerabilities** widget.

    * With **Env impact** in secondary color.
        ![vulnerabilityUtils_secondary](https://user-images.githubusercontent.com/11862657/231229527-17d2dc97-7a7e-48f1-baa2-ffcf837c77e4.png)

    * With **Env impact** in base color.
        ![vulnerabilityUtils_base](https://user-images.githubusercontent.com/11862657/231229557-5b205051-4aaa-4fe2-9e47-40741f7a1cf8.png)
