### PR TITLE
Dashrews/ROX-16435-add db to patch os4 cluster

### DIFF
--- a/.github/workflows/cut-rc.yml
+++ b/.github/workflows/cut-rc.yml
@@ -415,6 +415,7 @@ jobs:
       - name: Patch central
         run: |
           ./oc -n stackrox set image deploy/central central="quay.io/rhacs-eng/main:$TAG"
+          ./oc -n stackrox set image deploy/central-db central-db="quay.io/rhacs-eng/central-db:$TAG"
       - name: Patch scanner
         run: |
           ./oc -n stackrox patch hpa/scanner -p '{"spec":{"minReplicas":2}}'


### PR DESCRIPTION
## Description

`patch-os4-cluster` patches all the images except for central-db.  For consistency it needs to patch central-db to match the specified tag as well.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
