### PR TITLE
Dashrews/ROX-16450 bump monitor limit

### DIFF
--- a/deploy/charts/monitoring/values.yaml
+++ b/deploy/charts/monitoring/values.yaml
@@ -7,7 +7,7 @@ resources:
     memory: "500Mi"
     cpu: "500m"
   limits:
-    memory: "1Gi"
+    memory: "2Gi"
     cpu: "1000m"
 
 exposure:


### PR DESCRIPTION
## Description

monitoring memory limit is insufficient for long running release cluster.

## Checklist
- [ ] Investigated and inspected CI test results
~- [ ] Unit test and regression tests added~
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
