### PR TITLE
cherry-pick #5039: fix Helm / Collector version publishing steps for 3.74

### DIFF
--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -640,16 +640,27 @@ mark_collector_release() {
 
     # We need to make sure the file ends with a newline so as not to corrupt it when appending.
     [[ ! -f RELEASED_VERSIONS ]] || sed --in-place -e '$a'\\ RELEASED_VERSIONS
-    echo "${collector_version} ${tag}  # Rox release ${tag} by ${username} at $(date)" \
-        >>RELEASED_VERSIONS
-    gitbot add RELEASED_VERSIONS
-    gitbot commit -m "Automatic update of RELEASED_VERSIONS file for Rox release ${tag}"
-    gitbot push origin "${branch_name}"
+    if grep -q "${tag}" RELEASED_VERSIONS; then
+        echo "Skip RELEASED_VERSIONS file change, already up to date ..." >> "${GITHUB_STEP_SUMMARY}"
+    else
+        echo "Update RELEASED_VERSIONS file ..." >> "${GITHUB_STEP_SUMMARY}"
+        echo "${collector_version} ${tag}  # Rox release ${tag} by ${username} at $(date)" \
+            >>RELEASED_VERSIONS
+        gitbot add RELEASED_VERSIONS
+        gitbot commit -m "Automatic update of RELEASED_VERSIONS file for Rox release ${tag}"
+        gitbot push origin "${branch_name}"
+    fi
 
-    echo "Create a PR for collector to add this release to its RELEASED_VERSIONS file" >> "${GITHUB_STEP_SUMMARY}"
-    gh pr create \
-        --title "Update RELEASED_VERSIONS for StackRox release ${tag}" \
-        --body "Add entry into the RELEASED_VERSIONS file" >> "${GITHUB_STEP_SUMMARY}"
+    PRs=$(gh pr list -s open \
+            --head "${branch_name}" \
+            --json number \
+            --jq length)
+    if [ "$PRs" -eq 0 ]; then
+        echo "Create a PR for collector to add this release to its RELEASED_VERSIONS file" >> "${GITHUB_STEP_SUMMARY}"
+        gh pr create \
+            --title "Update RELEASED_VERSIONS for StackRox release ${tag}" \
+            --body "Add entry into the RELEASED_VERSIONS file" >> "${GITHUB_STEP_SUMMARY}"
+    fi
     popd
 }
 

--- a/scripts/ci/publish-helm-charts.sh
+++ b/scripts/ci/publish-helm-charts.sh
@@ -73,9 +73,7 @@ gitbot -C "$tmp_remote_repository" add -A
 gitbot -C "$tmp_remote_repository" commit -m "Publish Helm Charts for version ${version}"
 gitbot -C "$tmp_remote_repository" push origin "$branch_name"
 
-pr_response_file="$(mktemp)"
-
-message="Hello Release Artifact Publishers!
+message="Hello Release Managers!
 
 Engineering has signed off on release **${version}**! The new Helm charts are ready to be published.
 Once the version is GA, please complete the publishing by merging this PR using the 'Squash and Merge' option.
@@ -84,7 +82,6 @@ Once the version is GA, please complete the publishing by merging this PR using 
 to an unreleased version."
 
 curl -sS --fail \
-	-o "$pr_response_file" \
 	-X POST \
 	-H "Authorization: token ${GITHUB_TOKEN}" \
 	'https://api.github.com/repos/stackrox/release-artifacts/pulls' \
@@ -94,21 +91,3 @@ curl -sS --fail \
 	\"head\": \"${branch_name}\",
 	\"base\": \"main\"
 }" || die "Failed to create GitHub PR"
-
-pr_number="$(jq <"$pr_response_file" -r '.number')"
-
-[[ -n "$pr_number" ]] || die "Failed to determine PR number"
-
-curl -sS --fail \
-	-X POST \
-	-H "Authorization: token ${GITHUB_TOKEN}" \
-	"https://api.github.com/repos/stackrox/release-artifacts/pulls/${pr_number}/requested_reviewers" \
-	-d'{
-	"team_reviewers": ["release-artifact-publishers"]
-}' || die "Failed to assign release-artifact-publishers for review"
-
-jq -n \
-    --arg version "$version" \
-    --arg pr_number "$pr_number" \
-    '{"text": "Hey <!subteam^S01DE67NT7V|release-publishers>! A pull request for the *\($version)* release artifacts has been prepared. Once this version is GA, please _approve and merge_ this pull request in order to publish the artifacts: https://github.com/stackrox/release-artifacts/pull/\($pr_number)"}' \
-  | curl -XPOST -d @- -H 'Content-Type: application/json' "${webhook_url}" || die "Failed to send Slack message!"


### PR DESCRIPTION
## Description

Cherry-picking relevant changes for fixing Helm charts and Collector version update PRs in release-3.74 branches from https://github.com/stackrox/stackrox/pull/5039. 

These have failed in the 3.73.4 release and we can avoid manual work for the release engineer if this PR lands on the release branch before the 3.74.2 release.  

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

n/a
