### PR TITLE
Add cluster role integration tests

### DIFF
--- a/sensor/tests/resource/helper.go
+++ b/sensor/tests/resource/helper.go
@@ -85,6 +85,10 @@ func objByKind(kind string) k8s.Object {
 		return &v12.Role{}
 	case "Binding":
 		return &v12.RoleBinding{}
+	case "ClusterRole":
+		return &v12.ClusterRole{}
+	case "ClusterRoleBinding":
+		return &v12.ClusterRoleBinding{}
 	case "Pod":
 		return &v1.Pod{}
 	case "ServiceAccount":

--- a/sensor/tests/resource/role/role_test.go
+++ b/sensor/tests/resource/role/role_test.go
@@ -20,6 +20,8 @@ var (
 	NginxRole             = resource.K8sResourceInfo{Kind: "Role", YamlFile: "nginx-role.yaml"}
 	NginxRoleBinding      = resource.K8sResourceInfo{Kind: "Binding", YamlFile: "nginx-binding.yaml"}
 	NginxRoleGroupBinding = resource.K8sResourceInfo{Kind: "Binding", YamlFile: "nginx-binding-group.yaml"}
+	NginxClusterRole      = resource.K8sResourceInfo{Kind: "ClusterRole", YamlFile: "nginx-cluster-role.yaml"}
+	NginxClusterBinding   = resource.K8sResourceInfo{Kind: "ClusterRoleBinding", YamlFile: "nginx-cluster-binding.yaml"}
 )
 
 type RoleDependencySuite struct {
@@ -71,7 +73,7 @@ func assertBindingHasRoleID(roleID string) resource.AssertFuncAny {
 	}
 }
 
-func (s *RoleDependencySuite) Test_PermutationTest() {
+func (s *RoleDependencySuite) Test_RolePermutationTest() {
 	s.testContext.GetFakeCentral().ClearReceivedBuffer()
 	s.testContext.RunTest(
 		resource.WithResources([]resource.K8sResourceInfo{
@@ -84,6 +86,24 @@ func (s *RoleDependencySuite) Test_PermutationTest() {
 			testC.LastDeploymentState("nginx-deployment",
 				assertPermissionLevel(storage.PermissionLevel_ELEVATED_IN_NAMESPACE),
 				"Permission level has to be elevated in namespace")
+			testC.GetFakeCentral().ClearReceivedBuffer()
+		}),
+	)
+}
+
+func (s *RoleDependencySuite) Test_ClusterRolePermutationTest() {
+	s.testContext.GetFakeCentral().ClearReceivedBuffer()
+	s.testContext.RunTest(
+		resource.WithResources([]resource.K8sResourceInfo{
+			NginxDeployment,
+			NginxClusterRole,
+			NginxClusterBinding,
+		}),
+		resource.WithPermutation(),
+		resource.WithTestCase(func(t *testing.T, testC *resource.TestContext, objects map[string]k8s.Object) {
+			testC.LastDeploymentState("nginx-deployment",
+				assertPermissionLevel(storage.PermissionLevel_ELEVATED_CLUSTER_WIDE),
+				"Permission level has to be elevated cluster wide")
 			testC.GetFakeCentral().ClearReceivedBuffer()
 		}),
 	)

--- a/sensor/tests/resource/role/yaml/nginx-cluster-binding.yaml
+++ b/sensor/tests/resource/role/yaml/nginx-cluster-binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: nginx-cluster-binding
+subjects:
+- kind: ServiceAccount
+  name: nginx-sa
+  namespace: sensor-integration
+roleRef:
+  kind: ClusterRole
+  name: nginx-cluster-role
+  apiGroup: ""

--- a/sensor/tests/resource/role/yaml/nginx-cluster-role.yaml
+++ b/sensor/tests/resource/role/yaml/nginx-cluster-role.yaml
@@ -1,0 +1,8 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: nginx-cluster-role
+rules:
+- apiGroups: [""]
+  resources: [""]
+  verbs: ["get", "list", "create", "delete"]


### PR DESCRIPTION
## Description

Enhance the `sensor-integration-tests` with `ClusterRoles`.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

* Running the integration tests manually.
* CI
