### PR TITLE
Set re-sync disabled in sensor-integration-tests

### DIFF
--- a/sensor/tests/replay/replay_test.go
+++ b/sensor/tests/replay/replay_test.go
@@ -126,6 +126,7 @@ func (tw *TraceWriterWithChannel) Write(_ []byte) (nb int, retErr error) {
 }
 
 func (suite *ReplayEventsSuite) Test_ReplayEvents() {
+	suite.T().Setenv("ROX_RESYNC_DISABLED", "true")
 	conn, spyCentral, _ := createConnectionAndStartServer(suite.fakeCentral)
 	fakeConnectionFactory := centralDebug.MakeFakeConnectionFactory(conn)
 

--- a/sensor/tests/resource/imagescan/imagescan_test.go
+++ b/sensor/tests/resource/imagescan/imagescan_test.go
@@ -1,6 +1,7 @@
 package imagescan
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -61,6 +62,7 @@ func Test_ImageScan(t *testing.T) {
 }
 
 func (s *ImageScanSuite) SetupSuite() {
+	s.T().Setenv("ROX_RESYNC_DISABLED", "true")
 	testContext, err := resource.NewContextWithConfig(s.T(), resource.CentralConfig{
 		InitialSystemPolicies: Policies,
 	})
@@ -78,6 +80,7 @@ func (s *ImageScanSuite) Test_AlertsUpdatedOnImageUpdate() {
 		resource.WithTestCase(func(t *testing.T, tc *resource.TestContext, resource map[string]k8s.Object) {
 			var image *storage.ContainerImage
 			// Image should be received by central
+			fmt.Println("lvm: waiting for pod")
 			tc.LastDeploymentStateWithTimeout("myapp", func(dp *storage.Deployment, _ central.ResourceAction) error {
 				if len(dp.GetContainers()) != 1 {
 					return errors.Errorf("expected 1 container found %d", len(dp.GetContainers()))

--- a/sensor/tests/resource/networkpolicy/networkpolicy_test.go
+++ b/sensor/tests/resource/networkpolicy/networkpolicy_test.go
@@ -28,6 +28,7 @@ var _ suite.SetupAllSuite = &NetworkPolicySuite{}
 var _ suite.TearDownTestSuite = &NetworkPolicySuite{}
 
 func (s *NetworkPolicySuite) SetupSuite() {
+	s.T().Setenv("ROX_RESYNC_DISABLED", "true")
 	if testContext, err := resource.NewContext(s.T()); err != nil {
 		s.Fail("failed to setup test context: %s", err)
 	} else {

--- a/sensor/tests/resource/pod/pod_test.go
+++ b/sensor/tests/resource/pod/pod_test.go
@@ -38,6 +38,7 @@ var _ suite.SetupAllSuite = &PodHierarchySuite{}
 var _ suite.TearDownTestSuite = &PodHierarchySuite{}
 
 func (s *PodHierarchySuite) SetupSuite() {
+	s.T().Setenv("ROX_RESYNC_DISABLED", "true")
 	if testContext, err := resource.NewContext(s.T()); err != nil {
 		s.Fail("failed to setup test context: %s", err)
 	} else {

--- a/sensor/tests/resource/role/role_test.go
+++ b/sensor/tests/resource/role/role_test.go
@@ -40,6 +40,7 @@ func (s *RoleDependencySuite) TearDownTest() {
 }
 
 func (s *RoleDependencySuite) SetupSuite() {
+	s.T().Setenv("ROX_RESYNC_DISABLED", "true")
 	if testContext, err := resource.NewContext(s.T()); err != nil {
 		s.Fail("failed to setup test context: %s", err)
 	} else {

--- a/sensor/tests/resource/service/service_test.go
+++ b/sensor/tests/resource/service/service_test.go
@@ -133,6 +133,7 @@ func (s *DeploymentExposureSuite) TearDownTest() {
 }
 
 func (s *DeploymentExposureSuite) SetupSuite() {
+	s.T().Setenv("ROX_RESYNC_DISABLED", "true")
 	policies, err := testutils.GetPoliciesFromFile("data/policies.json")
 	if err != nil {
 		log.Fatalln(err)


### PR DESCRIPTION
## Description

Disabled re-sync in `sensor-integration-tests`.

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

* CI
* Manual test `sensor-integration-tests`
