### PR TITLE
ROX-11780: Strip http[s] from CENTRAL_ENDPOINT

### DIFF
--- a/pkg/env/sensor.go
+++ b/pkg/env/sensor.go
@@ -4,7 +4,8 @@ package env
 // Please check the files before deleting
 var (
 	// CentralEndpoint is used to provide Central's reachable endpoint to a sensor.
-	CentralEndpoint = RegisterSetting("ROX_CENTRAL_ENDPOINT", WithDefault("central.stackrox.svc:443"))
+	CentralEndpoint = RegisterSetting("ROX_CENTRAL_ENDPOINT", WithDefault("central.stackrox.svc:443"),
+		StripAnyPrefix("https://", "http://"))
 
 	// AdvertisedEndpoint is used to provide the Sensor with the endpoint it
 	// should advertise to services that need to contact it, within its own cluster.

--- a/pkg/env/setting.go
+++ b/pkg/env/setting.go
@@ -3,6 +3,7 @@ package env
 import (
 	"fmt"
 	"os"
+	"strings"
 )
 
 // A Setting is a runtime configuration set using an environment variable.
@@ -14,8 +15,9 @@ type Setting interface {
 }
 
 type settingOptions struct {
-	defaultValue string
-	allowEmpty   bool
+	defaultValue  string
+	allowEmpty    bool
+	stripPrefixes []string
 }
 
 type setting struct {
@@ -54,6 +56,14 @@ func AllowEmpty() SettingOption {
 	})
 }
 
+// StripAnyPrefix will remove prefix (any that matches) from the setting value.
+// If prefix is not found, the value is unchanged.
+func StripAnyPrefix(pref ...string) SettingOption {
+	return settingOptionFn(func(so *settingOptions) {
+		so.stripPrefixes = pref
+	})
+}
+
 // RegisterSetting registers a new setting for the given environment variable with the given options
 func RegisterSetting(envVar string, opts ...SettingOption) Setting {
 	s := &setting{
@@ -76,6 +86,14 @@ func (s *setting) EnvVar() string {
 
 func (s *setting) Setting() string {
 	val, ok := os.LookupEnv(s.envVar)
+	for _, prefix := range s.stripPrefixes {
+		prev := val
+		val = strings.TrimPrefix(val, prefix)
+		if prev != val {
+			// only one change allowed to avoid depending on the order of prefixes provided
+			break
+		}
+	}
 	if val != "" || (ok && s.allowEmpty) {
 		return val
 	}

--- a/pkg/env/setting_test.go
+++ b/pkg/env/setting_test.go
@@ -44,6 +44,63 @@ func TestWithDefault(t *testing.T) {
 	a.Equal("baz", s.Setting())
 }
 
+func TestWithStripPrefixes(t *testing.T) {
+	a := assert.New(t)
+
+	cases := map[string]struct {
+		value    string
+		prefixes []string
+		expValue string
+	}{
+		"shall remove prefix if present": {
+			value:    "https://example.com",
+			prefixes: []string{"https://"},
+			expValue: "example.com",
+		},
+		"shall remove one of prefixes if first of them present": {
+			value:    "https://example.com",
+			prefixes: []string{"https://", "http://"},
+			expValue: "example.com",
+		},
+		"shall remove one of prefixes if second of them present": {
+			value:    "http://example.com",
+			prefixes: []string{"https://", "http://"},
+			expValue: "example.com",
+		},
+		"shall not remove more than one prefix": {
+			value:    "123-abc-xyz",
+			prefixes: []string{"123-", "abc-", "xyz"},
+			expValue: "abc-xyz",
+		},
+		"value should be unchanged when no prefix matches": {
+			value:    "123-abc-xyz",
+			prefixes: []string{"abc"},
+			expValue: "123-abc-xyz",
+		},
+		"value should be unchanged when 0 prefixes are provided": {
+			value:    "123-abc-xyz",
+			prefixes: []string{},
+			expValue: "123-abc-xyz",
+		},
+		"value should be unchanged when prefixes are provided with nil slice": {
+			value:    "123-abc-xyz",
+			prefixes: nil,
+			expValue: "123-abc-xyz",
+		},
+	}
+
+	for tname, tt := range cases {
+		t.Run(tname, func(t *testing.T) {
+			name := newRandomName()
+			s := RegisterSetting(name, StripAnyPrefix(tt.prefixes...))
+			defer unregisterSetting(name)
+			a.NoError(os.Setenv(name, tt.value))
+
+			a.Equal(tt.expValue, s.Setting())
+		})
+	}
+}
+
 func TestWithDefaultAndAllowEmpty(t *testing.T) {
 	a := assert.New(t)
 


### PR DESCRIPTION
## Description

This PR strips the prefix `http://` or `https://` from the `ROX_CENTRAL_ENDPOINT` variable to avoid Sensor crashing (as in the ticket).

Using UI to generate init bundle is already immune to providing `http[s]://` as prefix.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added

### N/A
- [ ] Evaluated and added CHANGELOG entry if required - not adding as these prefixes were never supported
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

- [x] Unit tests
- [x] CI
- [x] Local deploy + manually changing the deployment to include `- name: ROX_CENTRAL_ENDPOINT value: https://central.stackrox:443` and observing Sensor starting properly
