### PR TITLE
ROX-15259: Do not show DNS flows in the inactive view

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
@@ -181,10 +181,7 @@ function NetworkGraphPage() {
                         // get policy nodes, and the starting epoch, from policy graph API response
                         const { nodes: policyNodes, epoch } = values[1].response;
                         // transform policy data to DataModel
-                        const { policyDataModel, policyNodeMap } = transformPolicyData(
-                            policyNodes,
-                            edgeState
-                        );
+                        const { policyDataModel, policyNodeMap } = transformPolicyData(policyNodes);
                         // get active nodes from network flow graph API response
                         const { nodes: activeNodes } = values[0].response;
                         // transform active data to DataModel

--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
@@ -181,7 +181,10 @@ function NetworkGraphPage() {
                         // get policy nodes, and the starting epoch, from policy graph API response
                         const { nodes: policyNodes, epoch } = values[1].response;
                         // transform policy data to DataModel
-                        const { policyDataModel, policyNodeMap } = transformPolicyData(policyNodes);
+                        const { policyDataModel, policyNodeMap } = transformPolicyData(
+                            policyNodes,
+                            edgeState
+                        );
                         // get active nodes from network flow graph API response
                         const { nodes: activeNodes } = values[0].response;
                         // transform active data to DataModel

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/EdgeStateSelect.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/EdgeStateSelect.tsx
@@ -3,7 +3,7 @@ import { Select, SelectOption } from '@patternfly/react-core';
 
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
 
-export type EdgeState = 'active' | 'inactive';
+export type EdgeState = 'active' | 'inactive' | 'inactive with dns';
 
 type EdgeStateSelectProps = {
     edgeState: EdgeState;
@@ -41,6 +41,7 @@ function EdgeStateSelect({ edgeState, setEdgeState, isDisabled }: EdgeStateSelec
             >
                 Inactive flows
             </SelectOption>
+            <SelectOption value="inactive with dns">Inactive flows with DNS flows</SelectOption>
         </Select>
     );
 }

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/modelUtils.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/modelUtils.tsx
@@ -11,7 +11,6 @@ import {
     EdgeProperties,
 } from 'types/networkFlow.proto';
 import { ensureExhaustive } from 'utils/type.utils';
-import { mapValues } from 'lodash';
 import {
     CustomModel,
     CustomNodeModel,
@@ -29,25 +28,12 @@ import {
     CIDRBlockData,
 } from '../types/topology.type';
 import { protocolLabel } from './flowUtils';
-import { EdgeState } from '../components/EdgeStateSelect';
 
 export const graphModel = {
     id: 'stackrox-graph',
     type: 'graph',
     layout: 'ColaNoForce',
 };
-
-function removeDNSFlows(outEdges: OutEdges): OutEdges {
-    const outEdgesWithoutDNSFlows: OutEdges = mapValues(outEdges, (value) => {
-        return {
-            ...value,
-            properties: value.properties.filter((obj) => {
-                return obj.port === 53 && obj.protocol === 'L4_PROTOCOL_UDP';
-            }),
-        };
-    });
-    return outEdgesWithoutDNSFlows;
-}
 
 function getBaseNode(id: string): CustomNodeModel {
     return {
@@ -384,10 +370,7 @@ function getNetworkPolicyState(
 // external connections can only be active, so this is hard coded to false
 const POLICY_NODE_EXTERNALLY_CONNECTED_VALUE = false;
 
-export function transformPolicyData(
-    nodes: Node[],
-    edgeState: EdgeState
-): {
+export function transformPolicyData(nodes: Node[]): {
     policyDataModel: CustomModel;
     policyNodeMap: Record<string, DeploymentNodeModel>;
 } {
@@ -401,16 +384,8 @@ export function transformPolicyData(
     // to reference edges so we don't double merge bidirectional edges
     const policyEdgeMap: Record<string, CustomEdgeModel> = {};
     nodes.forEach((policyNode) => {
-        const {
-            entity,
-            policyIds,
-            outEdges: unfilteredOutEdges,
-            nonIsolatedEgress,
-            nonIsolatedIngress,
-        } = policyNode;
+        const { entity, policyIds, outEdges, nonIsolatedEgress, nonIsolatedIngress } = policyNode;
 
-        const outEdges =
-            edgeState === 'inactive' ? removeDNSFlows(unfilteredOutEdges) : unfilteredOutEdges;
         const networkPolicyState = getNetworkPolicyState(nonIsolatedEgress, nonIsolatedIngress);
         const node = getNodeModel(
             entity,

--- a/ui/apps/platform/src/hooks/useFetchDeploymentCount.ts
+++ b/ui/apps/platform/src/hooks/useFetchDeploymentCount.ts
@@ -1,8 +1,9 @@
-import { useState, useEffect } from 'react';
 import { gql, useQuery, ApolloError } from '@apollo/client';
 
 type DeploymentCountResponse = {
-    count: number;
+    cluster: {
+        count: number;
+    };
 };
 
 type UseFetchDeploymentCount = {
@@ -12,14 +13,14 @@ type UseFetchDeploymentCount = {
 };
 
 const DEPLOYMENT_COUNT_FOR_CLUSTER = gql`
-    query deployments($query: String) {
-        count: deploymentCount(query: $query)
+    query getDeploymentCountForCluster($id: ID!) {
+        cluster(id: $id) {
+            count: deploymentCount
+        }
     }
 `;
 
 function useFetchDeploymentCount(selectedClusterId: string): UseFetchDeploymentCount {
-    const [deploymentCount, setDeploymentCount] = useState<number>();
-
     // If the selectedClusterId has not been set yet, do not run the gql query
     const queryOptions = selectedClusterId
         ? { variables: { id: selectedClusterId } }
@@ -30,18 +31,10 @@ function useFetchDeploymentCount(selectedClusterId: string): UseFetchDeploymentC
         queryOptions
     );
 
-    useEffect(() => {
-        if (!data || !data.count) {
-            return;
-        }
-
-        setDeploymentCount(data.count);
-    }, [data]);
-
     return {
         loading,
         error,
-        deploymentCount,
+        deploymentCount: data?.cluster?.count || undefined,
     };
 }
 


### PR DESCRIPTION
## Description

This PR hides the DNS flows when we pick the `Inactive flows` option and we show it when we pick a new (third) option called `Inactive flows with DNS flows`

