### PR TITLE
Jv rox 16471 add processes listening on ports as a sensor capability

### DIFF
--- a/pkg/centralsensor/caps_list.go
+++ b/pkg/centralsensor/caps_list.go
@@ -34,6 +34,6 @@ const (
 	// NodeScanningCap identifies the capability to scan nodes and provide node components for vulnerability analysis.
 	NodeScanningCap SensorCapability = "NodeScanning"
 
-	// ListeningEndpointsCap identifies the capability for sensor to process and send information about listening endpoints and their processes, AKA processes listening on ports
-	ListeningEndpointsCap SensorCapability = "ListeningEndpoints"
+	// ListeningEndpointsWithProcessesCap identifies the capability for sensor to process and send information about listening endpoints and their processes, AKA processes listening on ports
+	ListeningEndpointsWithProcessesCap SensorCapability = "ListeningEndpoints"
 )

--- a/pkg/centralsensor/caps_list.go
+++ b/pkg/centralsensor/caps_list.go
@@ -35,5 +35,5 @@ const (
 	NodeScanningCap SensorCapability = "NodeScanning"
 
 	// ListeningEndpointsWithProcessesCap identifies the capability for sensor to process and send information about listening endpoints and their processes, AKA processes listening on ports
-	ListeningEndpointsWithProcessesCap SensorCapability = "ListeningEndpoints"
+	ListeningEndpointsWithProcessesCap SensorCapability = "ListeningEndpointsWithProcesses"
 )

--- a/pkg/centralsensor/caps_list.go
+++ b/pkg/centralsensor/caps_list.go
@@ -33,4 +33,7 @@ const (
 
 	// NodeScanningCap identifies the capability to scan nodes and provide node components for vulnerability analysis.
 	NodeScanningCap SensorCapability = "NodeScanning"
+
+	// ListeningEndpointsCap identifies the capability for sensor to process and send information about listening endpoints and their processes, AKA processes listening on ports 
+	ListeningEndpointsCap SensorCapability = "ListeningEndpoints"
 )

--- a/pkg/centralsensor/caps_list.go
+++ b/pkg/centralsensor/caps_list.go
@@ -34,6 +34,6 @@ const (
 	// NodeScanningCap identifies the capability to scan nodes and provide node components for vulnerability analysis.
 	NodeScanningCap SensorCapability = "NodeScanning"
 
-	// ListeningEndpointsCap identifies the capability for sensor to process and send information about listening endpoints and their processes, AKA processes listening on ports 
+	// ListeningEndpointsCap identifies the capability for sensor to process and send information about listening endpoints and their processes, AKA processes listening on ports
 	ListeningEndpointsCap SensorCapability = "ListeningEndpoints"
 )


### PR DESCRIPTION
## Description

Adds a new capability to the list of sensor capabilities. The capability is called ListeningEndpointsCap. This is contrary to the ticket and name of the branch. The name processes listening on ports is somewhat in flux and is likely to end up being listening endpoints instead. The service, API endpoint, and table were all changed to listening_endpoint and the name of the capability is consistent with that. Nothing is currently being done with the capability.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient.
