### PR TITLE
Modified syslog test to use syslog server with rest endpoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -644,7 +644,7 @@ syslog-image: syslog-build
 	docker build \
 		-t stackrox/qa:syslog_server_1_0 \
 		-t quay.io/rhacs-eng/qa:syslog_server_1_0 \
-		-f syslog/Dockerfile syslog
+		-f qa-tests-backend/test-images/syslog/Dockerfile qa-tests-backend/test-images/syslog
 
 .PHONY: mock-grpc-server-image
 mock-grpc-server-image: mock-grpc-server-build clean-image

--- a/qa-tests-backend/src/main/groovy/util/SyslogServer.groovy
+++ b/qa-tests-backend/src/main/groovy/util/SyslogServer.groovy
@@ -24,8 +24,8 @@ class SyslogServer {
                     new Deployment()
                             .setNamespace(namespace)
                             .setName(deploymentName)
-                            // The original is at docker.io/rsyslog/syslog_appliance_alpine:8.36.0-3.7
-                            // and https://github.com/rsyslog/rsyslog-docker
+                            // The source for this image is in qa-tests-backend/test-images/syslog
+                            // Run make syslog-image from the main folder to build the image
                             .setImage("quay.io/rhacs-eng/qa:syslog_server_1_0")
                             .setCommand(["/syslog"])
                             .addPort(SYSLOG_PORT)
@@ -46,7 +46,7 @@ class SyslogServer {
 
             orchestrator.createService(rsyslog.syslogSvc)
             orchestrator.createService(rsyslog.restSvc)
-           rsyslog.syslogPortForward = orchestrator.
+            rsyslog.syslogPortForward = orchestrator.
                     createPortForward(REST_PORT, rsyslog.deployment) as LocalPortForward
         }   catch (Exception e) {
             log.info("error creating syslog deployment or service", e)

--- a/qa-tests-backend/src/main/groovy/util/SyslogServer.groovy
+++ b/qa-tests-backend/src/main/groovy/util/SyslogServer.groovy
@@ -1,6 +1,8 @@
 package util
 
 import groovy.util.logging.Slf4j
+import io.fabric8.kubernetes.client.LocalPortForward
+
 import objects.Deployment
 import objects.Service
 import orchestratormanager.OrchestratorMain
@@ -8,8 +10,11 @@ import orchestratormanager.OrchestratorMain
 @Slf4j
 class SyslogServer {
     public static final Integer SYSLOG_PORT = 514
+    public static final Integer REST_PORT = 8080
     private Service syslogSvc
+    private Service restSvc
     private Deployment deployment
+    private LocalPortForward syslogPortForward
 
     static SyslogServer createRsyslog(OrchestratorMain orchestrator, String namespace) {
         def deploymentName = "syslog-${UUID.randomUUID()}"
@@ -21,7 +26,8 @@ class SyslogServer {
                             .setName(deploymentName)
                             // The original is at docker.io/rsyslog/syslog_appliance_alpine:8.36.0-3.7
                             // and https://github.com/rsyslog/rsyslog-docker
-                            .setImage("quay.io/rhacs-eng/qa:rsyslog_appliance_alpine")
+                            .setImage("quay.io/rhacs-eng/qa:syslog_server_1_0")
+                            .setCommand(["/syslog"])
                             .addPort(SYSLOG_PORT)
                             .addLabel("app", deploymentName)
             orchestrator.createDeployment(rsyslog.deployment)
@@ -31,7 +37,17 @@ class SyslogServer {
                                             .addPort(SYSLOG_PORT , "TCP")
                                             .setTargetPort(SYSLOG_PORT)
                                             .setType(Service.Type.CLUSTERIP)
+
+            rsyslog.restSvc = new Service("rest-service", orchestrator.getNameSpace())
+                    .addLabel("app", deploymentName)
+                    .addPort(REST_PORT , "TCP")
+                    .setTargetPort(REST_PORT)
+                    .setType(Service.Type.CLUSTERIP)
+
             orchestrator.createService(rsyslog.syslogSvc)
+            orchestrator.createService(rsyslog.restSvc)
+           rsyslog.syslogPortForward = orchestrator.
+                    createPortForward(REST_PORT, rsyslog.deployment) as LocalPortForward
         }   catch (Exception e) {
             log.info("error creating syslog deployment or service", e)
             tearDown(orchestrator)
@@ -40,9 +56,21 @@ class SyslogServer {
         return rsyslog
     }
 
+    String fetchLastMsg() {
+        def formattedUrl = String.format("http://localhost:%s", syslogPortForward.getLocalPort())
+        def con = (HttpURLConnection) new URL(formattedUrl).openConnection()
+        con.setRequestMethod("GET")
+        assert con.getResponseCode() == 200
+        def res = con.getInputStream().getText()
+        return res
+    }
+
     void tearDown(OrchestratorMain orchestrator) {
         if (syslogSvc) {
             orchestrator.deleteService(syslogSvc.name, syslogSvc.namespace)
+        }
+        if (restSvc) {
+            orchestrator.deleteService(restSvc.name, restSvc.namespace)
         }
         if (deployment) {
             orchestrator.deleteDeployment(deployment)

--- a/qa-tests-backend/src/test/groovy/IntegrationsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/IntegrationsTest.groovy
@@ -3,7 +3,6 @@ import static util.Helpers.withRetry
 import java.util.concurrent.TimeUnit
 
 import io.grpc.StatusRuntimeException
-import org.apache.commons.lang3.RandomStringUtils
 
 import io.stackrox.proto.storage.ClusterOuterClass
 import io.stackrox.proto.storage.NotifierOuterClass
@@ -762,6 +761,7 @@ class IntegrationsTest extends BaseSpecification {
     }
 
     @Tag("Integration")
+    @Tag("BAT")
     def "Verify syslog notifier"() {
        given:
        "syslog server is created"
@@ -777,12 +777,12 @@ class IntegrationsTest extends BaseSpecification {
         withRetry(3, 10) {
             assert notifier.testNotifier()
         }
+        def msg = syslog.fetchLastMsg()
+        assert msg.contains("app_name:stackRoxKubernetesSecurityPlatform")
+
         cleanup:
         "remove syslog notifier integration"
         syslog.tearDown(orchestrator)
     }
 
-    def uniqueName(String name) {
-        return name + RandomStringUtils.randomAlphanumeric(5).toLowerCase()
-    }
 }


### PR DESCRIPTION
In this PR syslog notifier test is changed to use syslog server image with rest endpoint. Additional test steps are added to verify that syslog receives alert notification message from central.

Testing Performed
Test is run in CI to verify that it passes 

