### PR TITLE
Add Tech Preview designation to Operator for connection string

### DIFF
--- a/operator/apis/platform/v1alpha1/central_types.go
+++ b/operator/apis/platform/v1alpha1/central_types.go
@@ -185,9 +185,9 @@ type CentralDBSpec struct {
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:hidden"}
 	IsEnabled *CentralDBEnabled `json:"isEnabled,omitempty"`
 
-	// Specify a secret that contains the password in the "password" data item. This should only be used when
+	// Specify a secret that contains the password in the "password" data item. This can only be used when
 	// specifying a connection string manually.
-	// If omitted, the operator will auto-generate a DB password and store it in the "password" item
+	// When omitted, the operator will auto-generate a DB password and store it in the "password" item
 	// in the "central-db-password" secret.
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Administrator Password",order=1
 	PasswordSecret *LocalSecretReference `json:"passwordSecret,omitempty"`

--- a/operator/apis/platform/v1alpha1/central_types.go
+++ b/operator/apis/platform/v1alpha1/central_types.go
@@ -185,16 +185,18 @@ type CentralDBSpec struct {
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:hidden"}
 	IsEnabled *CentralDBEnabled `json:"isEnabled,omitempty"`
 
-	// Specify a secret that contains the password in the "password" data item.
+	// Specify a secret that contains the password in the "password" data item. This is only required
+	// if setting the connection string manually.
 	// If omitted, the operator will auto-generate a DB password and store it in the "password" item
 	// in the "central-db-password" secret.
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Administrator Password",order=1
 	PasswordSecret *LocalSecretReference `json:"passwordSecret,omitempty"`
 
+	// NOTE: Connecting to an existing database is in Technology Preview.
 	// Specify a connection string that corresponds to an existing database. If set, the operator will not manage Central DB.
 	// When using this option, you must explicitly set a password secret; automatically generating a password will not
 	// be supported.
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,order=2
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,order=2,displayName="Connection String (Technology Preview)"
 	ConnectionStringOverride *string `json:"connectionString,omitempty"`
 
 	// Configures how Central DB should store its persistent data. You can choose between using a persistent

--- a/operator/apis/platform/v1alpha1/central_types.go
+++ b/operator/apis/platform/v1alpha1/central_types.go
@@ -185,8 +185,8 @@ type CentralDBSpec struct {
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:hidden"}
 	IsEnabled *CentralDBEnabled `json:"isEnabled,omitempty"`
 
-	// Specify a secret that contains the password in the "password" data item. This is only required
-	// if setting the connection string manually.
+	// Specify a secret that contains the password in the "password" data item. This should only be used when
+	// specifying a connection string manually.
 	// If omitted, the operator will auto-generate a DB password and store it in the "password" item
 	// in the "central-db-password" secret.
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Administrator Password",order=1

--- a/operator/apis/platform/v1alpha1/central_types.go
+++ b/operator/apis/platform/v1alpha1/central_types.go
@@ -192,8 +192,8 @@ type CentralDBSpec struct {
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Administrator Password",order=1
 	PasswordSecret *LocalSecretReference `json:"passwordSecret,omitempty"`
 
-	// NOTE: Connecting to an existing database is in Technology Preview.
-	// Specify a connection string that corresponds to an existing database. If set, the operator will not manage Central DB.
+	// NOTE: Connecting to an external database is in Technology Preview.
+	// Specify a connection string that corresponds to an external database. If set, the operator will not manage Central DB.
 	// When using this option, you must explicitly set a password secret; automatically generating a password will not
 	// be supported.
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,order=2,displayName="Connection String (Technology Preview)"

--- a/operator/bundle/manifests/platform.stackrox.io_centrals.yaml
+++ b/operator/bundle/manifests/platform.stackrox.io_centrals.yaml
@@ -97,10 +97,10 @@ spec:
                         type: object
                       passwordSecret:
                         description: Specify a secret that contains the password in
-                          the "password" data item. This should only be used when
-                          specifying a connection string manually. If omitted, the
-                          operator will auto-generate a DB password and store it in
-                          the "password" item in the "central-db-password" secret.
+                          the "password" data item. This can only be used when specifying
+                          a connection string manually. When omitted, the operator
+                          will auto-generate a DB password and store it in the "password"
+                          item in the "central-db-password" secret.
                         properties:
                           name:
                             description: The name of the referenced secret.

--- a/operator/bundle/manifests/platform.stackrox.io_centrals.yaml
+++ b/operator/bundle/manifests/platform.stackrox.io_centrals.yaml
@@ -97,10 +97,10 @@ spec:
                         type: object
                       passwordSecret:
                         description: Specify a secret that contains the password in
-                          the "password" data item. This is only required if setting
-                          the connection string manually. If omitted, the operator
-                          will auto-generate a DB password and store it in the "password"
-                          item in the "central-db-password" secret.
+                          the "password" data item. This should only be used when
+                          specifying a connection string manually. If omitted, the
+                          operator will auto-generate a DB password and store it in
+                          the "password" item in the "central-db-password" secret.
                         properties:
                           name:
                             description: The name of the referenced secret.

--- a/operator/bundle/manifests/platform.stackrox.io_centrals.yaml
+++ b/operator/bundle/manifests/platform.stackrox.io_centrals.yaml
@@ -73,9 +73,9 @@ spec:
                         - name
                         type: object
                       connectionString:
-                        description: 'NOTE: Connecting to an existing database is
+                        description: 'NOTE: Connecting to an external database is
                           in Technology Preview. Specify a connection string that
-                          corresponds to an existing database. If set, the operator
+                          corresponds to an external database. If set, the operator
                           will not manage Central DB. When using this option, you
                           must explicitly set a password secret; automatically generating
                           a password will not be supported.'

--- a/operator/bundle/manifests/platform.stackrox.io_centrals.yaml
+++ b/operator/bundle/manifests/platform.stackrox.io_centrals.yaml
@@ -73,11 +73,12 @@ spec:
                         - name
                         type: object
                       connectionString:
-                        description: Specify a connection string that corresponds
-                          to an existing database. If set, the operator will not manage
-                          Central DB. When using this option, you must explicitly
-                          set a password secret; automatically generating a password
-                          will not be supported.
+                        description: 'NOTE: Connecting to an existing database is
+                          in Technology Preview. Specify a connection string that
+                          corresponds to an existing database. If set, the operator
+                          will not manage Central DB. When using this option, you
+                          must explicitly set a password secret; automatically generating
+                          a password will not be supported.'
                         type: string
                       isEnabled:
                         default: Default
@@ -96,8 +97,9 @@ spec:
                         type: object
                       passwordSecret:
                         description: Specify a secret that contains the password in
-                          the "password" data item. If omitted, the operator will
-                          auto-generate a DB password and store it in the "password"
+                          the "password" data item. This is only required if setting
+                          the connection string manually. If omitted, the operator
+                          will auto-generate a DB password and store it in the "password"
                           item in the "central-db-password" secret.
                         properties:
                           name:

--- a/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
@@ -150,9 +150,9 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:io.kubernetes:Secret
       - description: Specify a secret that contains the password in the "password"
-          data item. This is only required if setting the connection string manually.
-          If omitted, the operator will auto-generate a DB password and store it in
-          the "password" item in the "central-db-password" secret.
+          data item. This should only be used when specifying a connection string
+          manually. If omitted, the operator will auto-generate a DB password and
+          store it in the "password" item in the "central-db-password" secret.
         displayName: Administrator Password
         path: central.db.passwordSecret
       - description: 'NOTE: Connecting to an existing database is in Technology Preview.

--- a/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
@@ -150,9 +150,9 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:io.kubernetes:Secret
       - description: Specify a secret that contains the password in the "password"
-          data item. This should only be used when specifying a connection string
-          manually. If omitted, the operator will auto-generate a DB password and
-          store it in the "password" item in the "central-db-password" secret.
+          data item. This can only be used when specifying a connection string manually.
+          When omitted, the operator will auto-generate a DB password and store it
+          in the "password" item in the "central-db-password" secret.
         displayName: Administrator Password
         path: central.db.passwordSecret
       - description: 'NOTE: Connecting to an existing database is in Technology Preview.

--- a/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
@@ -155,8 +155,8 @@ spec:
           in the "password" item in the "central-db-password" secret.
         displayName: Administrator Password
         path: central.db.passwordSecret
-      - description: 'NOTE: Connecting to an existing database is in Technology Preview.
-          Specify a connection string that corresponds to an existing database. If
+      - description: 'NOTE: Connecting to an external database is in Technology Preview.
+          Specify a connection string that corresponds to an external database. If
           set, the operator will not manage Central DB. When using this option, you
           must explicitly set a password secret; automatically generating a password
           will not be supported.'

--- a/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
@@ -150,15 +150,17 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:io.kubernetes:Secret
       - description: Specify a secret that contains the password in the "password"
-          data item. If omitted, the operator will auto-generate a DB password and
-          store it in the "password" item in the "central-db-password" secret.
+          data item. This is only required if setting the connection string manually.
+          If omitted, the operator will auto-generate a DB password and store it in
+          the "password" item in the "central-db-password" secret.
         displayName: Administrator Password
         path: central.db.passwordSecret
-      - description: Specify a connection string that corresponds to an existing database.
-          If set, the operator will not manage Central DB. When using this option,
-          you must explicitly set a password secret; automatically generating a password
-          will not be supported.
-        displayName: Connection String Override
+      - description: 'NOTE: Connecting to an existing database is in Technology Preview.
+          Specify a connection string that corresponds to an existing database. If
+          set, the operator will not manage Central DB. When using this option, you
+          must explicitly set a password secret; automatically generating a password
+          will not be supported.'
+        displayName: Connection String (Technology Preview)
         path: central.db.connectionString
       - description: Configures how Central DB should store its persistent data. You
           can choose between using a persistent volume claim (recommended default),

--- a/operator/config/crd/bases/platform.stackrox.io_centrals.yaml
+++ b/operator/config/crd/bases/platform.stackrox.io_centrals.yaml
@@ -74,11 +74,12 @@ spec:
                         - name
                         type: object
                       connectionString:
-                        description: Specify a connection string that corresponds
-                          to an existing database. If set, the operator will not manage
-                          Central DB. When using this option, you must explicitly
-                          set a password secret; automatically generating a password
-                          will not be supported.
+                        description: 'NOTE: Connecting to an existing database is
+                          in Technology Preview. Specify a connection string that
+                          corresponds to an existing database. If set, the operator
+                          will not manage Central DB. When using this option, you
+                          must explicitly set a password secret; automatically generating
+                          a password will not be supported.'
                         type: string
                       isEnabled:
                         default: Default
@@ -97,8 +98,9 @@ spec:
                         type: object
                       passwordSecret:
                         description: Specify a secret that contains the password in
-                          the "password" data item. If omitted, the operator will
-                          auto-generate a DB password and store it in the "password"
+                          the "password" data item. This is only required if setting
+                          the connection string manually. If omitted, the operator
+                          will auto-generate a DB password and store it in the "password"
                           item in the "central-db-password" secret.
                         properties:
                           name:

--- a/operator/config/crd/bases/platform.stackrox.io_centrals.yaml
+++ b/operator/config/crd/bases/platform.stackrox.io_centrals.yaml
@@ -98,10 +98,10 @@ spec:
                         type: object
                       passwordSecret:
                         description: Specify a secret that contains the password in
-                          the "password" data item. This is only required if setting
-                          the connection string manually. If omitted, the operator
-                          will auto-generate a DB password and store it in the "password"
-                          item in the "central-db-password" secret.
+                          the "password" data item. This should only be used when
+                          specifying a connection string manually. If omitted, the
+                          operator will auto-generate a DB password and store it in
+                          the "password" item in the "central-db-password" secret.
                         properties:
                           name:
                             description: The name of the referenced secret.

--- a/operator/config/crd/bases/platform.stackrox.io_centrals.yaml
+++ b/operator/config/crd/bases/platform.stackrox.io_centrals.yaml
@@ -98,10 +98,10 @@ spec:
                         type: object
                       passwordSecret:
                         description: Specify a secret that contains the password in
-                          the "password" data item. This should only be used when
-                          specifying a connection string manually. If omitted, the
-                          operator will auto-generate a DB password and store it in
-                          the "password" item in the "central-db-password" secret.
+                          the "password" data item. This can only be used when specifying
+                          a connection string manually. When omitted, the operator
+                          will auto-generate a DB password and store it in the "password"
+                          item in the "central-db-password" secret.
                         properties:
                           name:
                             description: The name of the referenced secret.

--- a/operator/config/crd/bases/platform.stackrox.io_centrals.yaml
+++ b/operator/config/crd/bases/platform.stackrox.io_centrals.yaml
@@ -74,9 +74,9 @@ spec:
                         - name
                         type: object
                       connectionString:
-                        description: 'NOTE: Connecting to an existing database is
+                        description: 'NOTE: Connecting to an external database is
                           in Technology Preview. Specify a connection string that
-                          corresponds to an existing database. If set, the operator
+                          corresponds to an external database. If set, the operator
                           will not manage Central DB. When using this option, you
                           must explicitly set a password secret; automatically generating
                           a password will not be supported.'

--- a/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
@@ -50,8 +50,9 @@ spec:
         displayName: Administrator Password
         path: central.adminPasswordSecret
       - description: Specify a secret that contains the password in the "password"
-          data item. If omitted, the operator will auto-generate a DB password and
-          store it in the "password" item in the "central-db-password" secret.
+          data item. This is only required if setting the connection string manually.
+          If omitted, the operator will auto-generate a DB password and store it in
+          the "password" item in the "central-db-password" secret.
         displayName: Administrator Password
         path: central.db.passwordSecret
       - description: Uses a Kubernetes persistent volume claim (PVC) to manage the
@@ -124,11 +125,12 @@ spec:
           settings in this section will have no effect.
         displayName: Scanner Component
         path: scanner.scannerComponent
-      - description: Specify a connection string that corresponds to an existing database.
-          If set, the operator will not manage Central DB. When using this option,
-          you must explicitly set a password secret; automatically generating a password
-          will not be supported.
-        displayName: Connection String Override
+      - description: 'NOTE: Connecting to an existing database is in Technology Preview.
+          Specify a connection string that corresponds to an existing database. If
+          set, the operator will not manage Central DB. When using this option, you
+          must explicitly set a password secret; automatically generating a password
+          will not be supported.'
+        displayName: Connection String (Technology Preview)
         path: central.db.connectionString
       - description: The size of the persistent volume when created through the claim.
           If a claim was automatically created, this can be used after the initial

--- a/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
@@ -125,8 +125,8 @@ spec:
           settings in this section will have no effect.
         displayName: Scanner Component
         path: scanner.scannerComponent
-      - description: 'NOTE: Connecting to an existing database is in Technology Preview.
-          Specify a connection string that corresponds to an existing database. If
+      - description: 'NOTE: Connecting to an external database is in Technology Preview.
+          Specify a connection string that corresponds to an external database. If
           set, the operator will not manage Central DB. When using this option, you
           must explicitly set a password secret; automatically generating a password
           will not be supported.'

--- a/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
@@ -50,9 +50,9 @@ spec:
         displayName: Administrator Password
         path: central.adminPasswordSecret
       - description: Specify a secret that contains the password in the "password"
-          data item. This should only be used when specifying a connection string
-          manually. If omitted, the operator will auto-generate a DB password and
-          store it in the "password" item in the "central-db-password" secret.
+          data item. This can only be used when specifying a connection string manually.
+          When omitted, the operator will auto-generate a DB password and store it
+          in the "password" item in the "central-db-password" secret.
         displayName: Administrator Password
         path: central.db.passwordSecret
       - description: Uses a Kubernetes persistent volume claim (PVC) to manage the

--- a/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
@@ -50,9 +50,9 @@ spec:
         displayName: Administrator Password
         path: central.adminPasswordSecret
       - description: Specify a secret that contains the password in the "password"
-          data item. This is only required if setting the connection string manually.
-          If omitted, the operator will auto-generate a DB password and store it in
-          the "password" item in the "central-db-password" secret.
+          data item. This should only be used when specifying a connection string
+          manually. If omitted, the operator will auto-generate a DB password and
+          store it in the "password" item in the "central-db-password" secret.
         displayName: Administrator Password
         path: central.db.passwordSecret
       - description: Uses a Kubernetes persistent volume claim (PVC) to manage the


### PR DESCRIPTION
## Description

- Specifying the connection string is tech preview in 4.0
- If a user specifies the DB password, then this is not currently picked up by Central DB pod and it uses the autogenerated one so tell users not to specify it

https://issues.redhat.com/browse/ROX-16488

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Just docs, but will look at it in the UI view