### PR TITLE
ROX-14324: Use requester scope and target resource to validate cluster existence for NetworkGraph and NetworkPolicy

### DIFF
--- a/central/networkgraph/service/service.go
+++ b/central/networkgraph/service/service.go
@@ -9,6 +9,7 @@ import (
 	networkEntityDS "github.com/stackrox/rox/central/networkgraph/entity/datastore"
 	"github.com/stackrox/rox/central/networkgraph/entity/networktree"
 	nfDS "github.com/stackrox/rox/central/networkgraph/flow/datastore"
+	"github.com/stackrox/rox/central/role/sachelper"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/pkg/grpc"
 	"github.com/stackrox/rox/pkg/logging"
@@ -48,5 +49,6 @@ func newService(store nfDS.ClusterDataStore,
 		deployments:    deployments,
 		clusters:       clusters,
 		graphConfig:    graphConfigDS,
+		sacHelper:      sachelper.NewSacHelper(clusters, nil),
 	}
 }

--- a/central/networkgraph/service/service.go
+++ b/central/networkgraph/service/service.go
@@ -43,12 +43,12 @@ func newService(store nfDS.ClusterDataStore,
 	clusters clusterDS.DataStore,
 	graphConfigDS datastore.DataStore) *serviceImpl {
 	return &serviceImpl{
-		clusterFlows:   store,
-		entities:       entities,
-		networkTreeMgr: networkTreeMgr,
-		deployments:    deployments,
-		clusters:       clusters,
-		graphConfig:    graphConfigDS,
-		sacHelper:      sachelper.NewSacHelper(clusters, nil),
+		clusterFlows:     store,
+		entities:         entities,
+		networkTreeMgr:   networkTreeMgr,
+		deployments:      deployments,
+		clusters:         clusters,
+		graphConfig:      graphConfigDS,
+		clusterSACHelper: sachelper.NewClusterSacHelper(clusters),
 	}
 }

--- a/central/networkgraph/service/service_impl.go
+++ b/central/networkgraph/service/service_impl.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stackrox/rox/central/networkgraph/entity/networktree"
 	networkFlowDS "github.com/stackrox/rox/central/networkgraph/flow/datastore"
 	"github.com/stackrox/rox/central/role/resources"
+	"github.com/stackrox/rox/central/role/sachelper"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/auth/permissions"
@@ -71,6 +72,8 @@ type serviceImpl struct {
 	deployments    deploymentDS.DataStore
 	clusters       clusterDS.DataStore
 	graphConfig    datastore.DataStore
+
+	sacHelper sachelper.SacHelper
 }
 
 // RegisterServiceServer registers this service with the given gRPC Server.
@@ -123,7 +126,7 @@ func (s *serviceImpl) CreateExternalNetworkEntity(ctx context.Context, request *
 		return nil, errors.Wrap(errox.InvalidArgs, err.Error())
 	}
 
-	if err := s.validateCluster(request.GetClusterId()); err != nil {
+	if err := s.validateCluster(ctx, request.GetClusterId()); err != nil {
 		return nil, err
 	}
 
@@ -229,16 +232,16 @@ func (s *serviceImpl) getFlowStore(ctx context.Context, clusterID string) (netwo
 	return flowStore, nil
 }
 
-func (s *serviceImpl) validateCluster(clusterID string) error {
-	// Use elevated context to perform certain cluster validations.
-	clusterReadCtx := sac.WithGlobalAccessScopeChecker(context.Background(),
-		sac.AllowFixedScopes(
-			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
-			sac.ResourceScopeKeys(resources.Cluster)))
-
-	if exists, err := s.clusters.Exists(clusterReadCtx, clusterID); err != nil {
+func (s *serviceImpl) validateCluster(ctx context.Context, clusterID string) error {
+	if clusterID == "" {
+		return errors.Wrap(errox.InvalidArgs, "cluster ID must be specified")
+	}
+	requestedResourcesWithAccess := []permissions.ResourceWithAccess{permissions.View(resources.NetworkGraph)}
+	exists, err := s.sacHelper.IsClusterVisibleForPermissions(ctx, clusterID, requestedResourcesWithAccess)
+	if err != nil {
 		return err
-	} else if !exists {
+	}
+	if !exists {
 		return errors.Wrapf(errox.NotFound, "cluster %s not found. It may have been deleted", clusterID)
 	}
 	return nil

--- a/central/networkgraph/service/service_impl.go
+++ b/central/networkgraph/service/service_impl.go
@@ -73,7 +73,7 @@ type serviceImpl struct {
 	clusters       clusterDS.DataStore
 	graphConfig    datastore.DataStore
 
-	sacHelper sachelper.SacHelper
+	clusterSACHelper sachelper.ClusterSacHelper
 }
 
 // RegisterServiceServer registers this service with the given gRPC Server.
@@ -237,7 +237,7 @@ func (s *serviceImpl) validateCluster(ctx context.Context, clusterID string) err
 		return errors.Wrap(errox.InvalidArgs, "cluster ID must be specified")
 	}
 	requestedResourcesWithAccess := []permissions.ResourceWithAccess{permissions.View(resources.NetworkGraph)}
-	exists, err := s.sacHelper.IsClusterVisibleForPermissions(ctx, clusterID, requestedResourcesWithAccess)
+	exists, err := s.clusterSACHelper.IsClusterVisibleForPermissions(ctx, clusterID, requestedResourcesWithAccess)
 	if err != nil {
 		return err
 	}

--- a/central/networkpolicies/service/service.go
+++ b/central/networkpolicies/service/service.go
@@ -59,7 +59,7 @@ func New(storage npDS.DataStore,
 		notifierStore:    notifierStore,
 		clusterStore:     clusterStore,
 		graphEvaluator:   graphEvaluator,
-		sacHelper:        sachelper.NewSacHelper(clusterStore, nil),
+		clusterSACHelper: sachelper.NewClusterSacHelper(clusterStore),
 		policyGenerator:  generator.New(storage, deployments, namespacesStore, globalFlowDataStore, networkTreeMgr, networkBaselines),
 	}
 }

--- a/central/networkpolicies/service/service.go
+++ b/central/networkpolicies/service/service.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stackrox/rox/central/networkpolicies/generator"
 	"github.com/stackrox/rox/central/networkpolicies/graph"
 	notifierDataStore "github.com/stackrox/rox/central/notifier/datastore"
+	"github.com/stackrox/rox/central/role/sachelper"
 	"github.com/stackrox/rox/central/sensor/service/connection"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/pkg/grpc"
@@ -58,6 +59,7 @@ func New(storage npDS.DataStore,
 		notifierStore:    notifierStore,
 		clusterStore:     clusterStore,
 		graphEvaluator:   graphEvaluator,
+		sacHelper:        sachelper.NewSacHelper(clusterStore, nil),
 		policyGenerator:  generator.New(storage, deployments, namespacesStore, globalFlowDataStore, networkTreeMgr, networkBaselines),
 	}
 }

--- a/central/networkpolicies/service/service_impl.go
+++ b/central/networkpolicies/service/service_impl.go
@@ -20,6 +20,7 @@ import (
 	notifierDataStore "github.com/stackrox/rox/central/notifier/datastore"
 	"github.com/stackrox/rox/central/notifiers"
 	"github.com/stackrox/rox/central/role/resources"
+	"github.com/stackrox/rox/central/role/sachelper"
 	"github.com/stackrox/rox/central/sensor/service/connection"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
@@ -95,6 +96,8 @@ type serviceImpl struct {
 	networkPolicies  npDS.DataStore
 	notifierStore    notifierDataStore.DataStore
 	graphEvaluator   graph.Evaluator
+
+	sacHelper sachelper.SacHelper
 
 	policyGenerator generator.Generator
 }
@@ -1126,7 +1129,8 @@ func (s *serviceImpl) clusterExists(ctx context.Context, clusterID string) error
 	if clusterID == "" {
 		return errors.Wrap(errox.InvalidArgs, "cluster ID must be specified")
 	}
-	exists, err := s.clusterStore.Exists(ctx, clusterID)
+	requestedResourcesWithAccess := []permissions.ResourceWithAccess{permissions.View(resources.NetworkPolicy)}
+	exists, err := s.sacHelper.IsClusterVisibleForPermissions(ctx, clusterID, requestedResourcesWithAccess)
 	if err != nil {
 		return err
 	}

--- a/central/networkpolicies/service/service_impl.go
+++ b/central/networkpolicies/service/service_impl.go
@@ -97,7 +97,7 @@ type serviceImpl struct {
 	notifierStore    notifierDataStore.DataStore
 	graphEvaluator   graph.Evaluator
 
-	sacHelper sachelper.SacHelper
+	clusterSACHelper sachelper.ClusterSacHelper
 
 	policyGenerator generator.Generator
 }
@@ -1130,7 +1130,7 @@ func (s *serviceImpl) clusterExists(ctx context.Context, clusterID string) error
 		return errors.Wrap(errox.InvalidArgs, "cluster ID must be specified")
 	}
 	requestedResourcesWithAccess := []permissions.ResourceWithAccess{permissions.View(resources.NetworkPolicy)}
-	exists, err := s.sacHelper.IsClusterVisibleForPermissions(ctx, clusterID, requestedResourcesWithAccess)
+	exists, err := s.clusterSACHelper.IsClusterVisibleForPermissions(ctx, clusterID, requestedResourcesWithAccess)
 	if err != nil {
 		return err
 	}

--- a/central/role/sachelper/access.go
+++ b/central/role/sachelper/access.go
@@ -1,0 +1,8 @@
+package sachelper
+
+const (
+	hasFullAccess    = true
+	hasPartialAccess = false
+	fullAccess       = true
+	partialAccess    = false
+)

--- a/central/role/sachelper/access.go
+++ b/central/role/sachelper/access.go
@@ -1,8 +1,6 @@
 package sachelper
 
 const (
-	hasFullAccess    = true
-	hasPartialAccess = false
-	fullAccess       = true
-	partialAccess    = false
+	fullAccess    = true
+	partialAccess = false
 )

--- a/central/role/sachelper/cluster.go
+++ b/central/role/sachelper/cluster.go
@@ -1,0 +1,81 @@
+package sachelper
+
+import (
+	"context"
+
+	clusterMappings "github.com/stackrox/rox/central/cluster/index/mappings"
+	"github.com/stackrox/rox/pkg/auth/permissions"
+	"github.com/stackrox/rox/pkg/env"
+	"github.com/stackrox/rox/pkg/postgres/schema"
+	"github.com/stackrox/rox/pkg/sac/effectiveaccessscope"
+	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/set"
+)
+
+////////////////////////////////////////////////////////////////////////////////
+// Helpers                                                                    //
+//                                                                            //
+
+// listClusterIDsInScope consolidates the list of cluster IDs in the user scopes associated
+// with the requested resources and access level.
+// - If one of the allowed scopes is unrestricted, then the string set is returned empty
+// and the returned boolean is true.
+// - If no allowed scope is unrestricted, the string set contains the cluster IDs allowed by
+// the user scopes associated with the requested resources, and the returned boolean is false.
+func listClusterIDsInScope(
+	ctx context.Context,
+	resourcesWithAccess []permissions.ResourceWithAccess,
+) (set.StringSet, bool, error) {
+	clusterIDsInScope := set.NewStringSet()
+	for _, r := range resourcesWithAccess {
+		scope, err := getRequesterScopeForReadPermission(ctx, r)
+		if err != nil {
+			return set.NewStringSet(), partialAccess, err
+		}
+		if scope == nil || scope.State == effectiveaccessscope.Excluded {
+			continue
+		}
+		if scope.State == effectiveaccessscope.Included {
+			return set.NewStringSet(), fullAccess, nil
+		}
+		clusterIDs := scope.GetClusterIDs()
+		for _, clusterID := range clusterIDs {
+			if clusterNode := scope.GetClusterByID(clusterID); clusterNode != nil &&
+				clusterNode.State != effectiveaccessscope.Excluded {
+				clusterIDsInScope.Add(clusterID)
+			}
+		}
+	}
+	return clusterIDsInScope, partialAccess, nil
+}
+
+func hasClusterIDInScope(
+	ctx context.Context,
+	clusterID string,
+	resourcesWithAccess []permissions.ResourceWithAccess,
+) (bool, bool, error) {
+	for _, r := range resourcesWithAccess {
+		scope, err := getRequesterScopeForReadPermission(ctx, r)
+		if err != nil {
+			return false, false, err
+		}
+		if scope == nil || scope.State == effectiveaccessscope.Excluded {
+			continue
+		}
+		if scope.State == effectiveaccessscope.Included {
+			return false, fullAccess, nil
+		}
+		clusterSubTree := scope.GetClusterByID(clusterID)
+		if clusterSubTree != nil && clusterSubTree.State != effectiveaccessscope.Excluded {
+			return true, partialAccess, nil
+		}
+	}
+	return false, partialAccess, nil
+}
+
+func getClustersOptionsMap() search.OptionsMap {
+	if env.PostgresDatastoreEnabled.BooleanSetting() {
+		return schema.ClustersSchema.OptionsMap
+	}
+	return clusterMappings.OptionsMap
+}

--- a/central/role/sachelper/cluster.go
+++ b/central/role/sachelper/cluster.go
@@ -12,10 +12,6 @@ import (
 	"github.com/stackrox/rox/pkg/set"
 )
 
-////////////////////////////////////////////////////////////////////////////////
-// Helpers                                                                    //
-//                                                                            //
-
 // listClusterIDsInScope consolidates the list of cluster IDs in the user scopes associated
 // with the requested resources and access level.
 // - If one of the allowed scopes is unrestricted, then the string set is returned empty

--- a/central/role/sachelper/extract.go
+++ b/central/role/sachelper/extract.go
@@ -1,0 +1,34 @@
+package sachelper
+
+import (
+	"fmt"
+
+	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/pkg/search"
+)
+
+func extractScopeElements(results []search.Result, optionsMap search.OptionsMap, searchedField string) []*v1.ScopeObject {
+	scopeElements := make([]*v1.ScopeObject, 0, len(results))
+	targetField, fieldFound := optionsMap.Get(searchedField)
+	for _, r := range results {
+		objID := r.ID
+		objName := ""
+		if fieldFound {
+			for _, v := range r.Matches[targetField.GetFieldPath()] {
+				if len(v) > 0 {
+					objName = v
+					break
+				}
+			}
+		}
+		if len(objName) == 0 {
+			objName = fmt.Sprintf("%s with ID %s", searchedField, objID)
+		}
+		element := &v1.ScopeObject{
+			Id:   objID,
+			Name: objName,
+		}
+		scopeElements = append(scopeElements, element)
+	}
+	return scopeElements
+}

--- a/central/role/sachelper/namespace.go
+++ b/central/role/sachelper/namespace.go
@@ -30,20 +30,20 @@ func listNamespaceNamesInScope(
 	for _, r := range resourcesWithAccess {
 		scope, err := getRequesterScopeForReadPermission(ctx, r)
 		if err != nil {
-			return noNamespaces, hasPartialAccess, err
+			return noNamespaces, partialAccess, err
 		}
 		if scope == nil || scope.State == effectiveaccessscope.Excluded {
 			continue
 		}
 		if scope.State == effectiveaccessscope.Included {
-			return noNamespaces, hasFullAccess, nil
+			return noNamespaces, fullAccess, nil
 		}
 		clusterScope := scope.GetClusterByID(clusterID)
 		if clusterScope == nil || clusterScope.State == effectiveaccessscope.Excluded {
 			continue
 		}
 		if clusterScope.State == effectiveaccessscope.Included {
-			return noNamespaces, hasFullAccess, nil
+			return noNamespaces, fullAccess, nil
 		}
 		for namespace, namespaceScope := range clusterScope.Namespaces {
 			if namespaceScope == nil || namespaceScope.State == effectiveaccessscope.Excluded {
@@ -52,7 +52,7 @@ func listNamespaceNamesInScope(
 			namespacesInScope.Add(namespace)
 		}
 	}
-	return namespacesInScope, hasPartialAccess, nil
+	return namespacesInScope, partialAccess, nil
 }
 
 func getNamespacesOptionsMap() search.OptionsMap {

--- a/central/role/sachelper/namespace.go
+++ b/central/role/sachelper/namespace.go
@@ -1,0 +1,63 @@
+package sachelper
+
+import (
+	"context"
+
+	namespaceMappings "github.com/stackrox/rox/central/namespace/index/mappings"
+	"github.com/stackrox/rox/pkg/auth/permissions"
+	"github.com/stackrox/rox/pkg/env"
+	"github.com/stackrox/rox/pkg/postgres/schema"
+	"github.com/stackrox/rox/pkg/sac/effectiveaccessscope"
+	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/set"
+)
+
+// listNamespaceNamesInScope consolidates the list of names of namespaces in the cluster matching
+// the requested ID and allowed by user scopes associated with the requested resources
+// and access level.
+// - If one of the allowed scopes is unrestricted for the requested cluster, then the string set
+// is returned empty and the returned boolean is true.
+// - If no allowed scope is unrestricted for the requested cluster, the string set contains
+// the names of the namespaces allowed by the user scopes associated with the requested resources,
+// and the returned boolean is false.
+func listNamespaceNamesInScope(
+	ctx context.Context,
+	clusterID string,
+	resourcesWithAccess []permissions.ResourceWithAccess,
+) (set.StringSet, bool, error) {
+	noNamespaces := set.NewStringSet()
+	namespacesInScope := set.NewStringSet()
+	for _, r := range resourcesWithAccess {
+		scope, err := getRequesterScopeForReadPermission(ctx, r)
+		if err != nil {
+			return noNamespaces, hasPartialAccess, err
+		}
+		if scope == nil || scope.State == effectiveaccessscope.Excluded {
+			continue
+		}
+		if scope.State == effectiveaccessscope.Included {
+			return noNamespaces, hasFullAccess, nil
+		}
+		clusterScope := scope.GetClusterByID(clusterID)
+		if clusterScope == nil || clusterScope.State == effectiveaccessscope.Excluded {
+			continue
+		}
+		if clusterScope.State == effectiveaccessscope.Included {
+			return noNamespaces, hasFullAccess, nil
+		}
+		for namespace, namespaceScope := range clusterScope.Namespaces {
+			if namespaceScope == nil || namespaceScope.State == effectiveaccessscope.Excluded {
+				continue
+			}
+			namespacesInScope.Add(namespace)
+		}
+	}
+	return namespacesInScope, hasPartialAccess, nil
+}
+
+func getNamespacesOptionsMap() search.OptionsMap {
+	if env.PostgresDatastoreEnabled.BooleanSetting() {
+		return schema.NamespacesSchema.OptionsMap
+	}
+	return namespaceMappings.OptionsMap
+}

--- a/central/role/sachelper/pagination.go
+++ b/central/role/sachelper/pagination.go
@@ -1,0 +1,29 @@
+package sachelper
+
+import (
+	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/pkg/set"
+)
+
+func getSanitizedPagination(requested *v1.Pagination, allowedSortFields set.StringSet) *v1.QueryPagination {
+	if requested == nil {
+		return nil
+	}
+	sanitized := &v1.QueryPagination{
+		Limit:       requested.GetLimit(),
+		Offset:      requested.GetOffset(),
+		SortOptions: nil,
+	}
+	if requested.GetSortOption() != nil {
+		sortField := requested.GetSortOption().GetField()
+		if allowedSortFields.Contains(sortField) {
+			sanitizedSortOption := &v1.QuerySortOption{
+				Field:          sortField,
+				Reversed:       requested.GetSortOption().GetReversed(),
+				SearchAfterOpt: nil,
+			}
+			sanitized.SortOptions = append(sanitized.SortOptions, sanitizedSortOption)
+		}
+	}
+	return sanitized
+}

--- a/central/role/sachelper/resource_filter.go
+++ b/central/role/sachelper/resource_filter.go
@@ -1,0 +1,32 @@
+package sachelper
+
+import (
+	"github.com/stackrox/rox/central/role/resources"
+	"github.com/stackrox/rox/pkg/auth/permissions"
+	"github.com/stackrox/rox/pkg/sliceutils"
+)
+
+func listReadPermissions(
+	requestedPermissions []string,
+	scope permissions.ResourceScope,
+) []permissions.ResourceWithAccess {
+	readPermissions := resources.AllResourcesViewPermissions()
+	indexedScopeReadPermissions := make(map[string]permissions.ResourceWithAccess, 0)
+	scopeReadPermissions := make([]permissions.ResourceWithAccess, 0, len(readPermissions))
+	for _, permission := range readPermissions {
+		if permission.Resource.GetScope() >= scope {
+			scopeReadPermissions = append(scopeReadPermissions, permission)
+			indexedScopeReadPermissions[permission.Resource.String()] = permission
+		}
+	}
+	if len(requestedPermissions) == 0 {
+		return scopeReadPermissions
+	}
+	scopeRequestedReadPermissions := make([]permissions.ResourceWithAccess, 0, len(scopeReadPermissions))
+	for _, permission := range sliceutils.Unique(requestedPermissions) {
+		if resourceWithAccess, found := indexedScopeReadPermissions[permission]; found {
+			scopeRequestedReadPermissions = append(scopeRequestedReadPermissions, resourceWithAccess)
+		}
+	}
+	return scopeRequestedReadPermissions
+}

--- a/central/role/sachelper/sachelper.go
+++ b/central/role/sachelper/sachelper.go
@@ -128,8 +128,9 @@ func (h *sacHelperImpl) GetNamespacesForClusterAndPermissions(
 	requestedPermissions []string,
 ) ([]*v1.ScopeObject, error) {
 	resourcesWithAccess := listReadPermissions(requestedPermissions, permissions.NamespaceScope)
+	allNsResourcesWithAccess := listReadPermissions([]string{}, permissions.NamespaceScope)
 
-	clusterVisible, err := h.IsClusterVisibleForPermissions(ctx, clusterID, resourcesWithAccess)
+	clusterVisible, err := h.IsClusterVisibleForPermissions(ctx, clusterID, allNsResourcesWithAccess)
 	if err != nil {
 		return nil, err
 	}

--- a/central/role/sachelper/sachelper.go
+++ b/central/role/sachelper/sachelper.go
@@ -1,0 +1,184 @@
+package sachelper
+
+import (
+	"context"
+
+	clusterDS "github.com/stackrox/rox/central/cluster/datastore"
+	namespaceDS "github.com/stackrox/rox/central/namespace/datastore"
+	"github.com/stackrox/rox/central/role/resources"
+	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/auth/permissions"
+	"github.com/stackrox/rox/pkg/errox"
+	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/set"
+)
+
+// SacHelper is an interface to query the requester scope for basic cluster and namespace information (ID and name).
+type SacHelper interface {
+	GetClustersForPermissions(
+		ctx context.Context,
+		requestedPermissions []string,
+		pagination *v1.Pagination,
+	) ([]*v1.ScopeObject, error)
+
+	IsClusterVisibleForPermissions(
+		ctx context.Context,
+		clusterID string,
+		resourcesWithAccess []permissions.ResourceWithAccess,
+	) (bool, error)
+
+	GetNamespacesForClusterAndPermissions(
+		ctx context.Context,
+		clusterID string,
+		requestedPermissions []string,
+	) ([]*v1.ScopeObject, error)
+}
+
+type sacHelperImpl struct {
+	clusterDataStore   clusterDS.DataStore
+	namespaceDataStore namespaceDS.DataStore
+}
+
+// NewSacHelper returns a helper object to get information from user scope.
+func NewSacHelper(clusterDataStore clusterDS.DataStore, namespaceDataStore namespaceDS.DataStore) SacHelper {
+	return &sacHelperImpl{
+		clusterDataStore:   clusterDataStore,
+		namespaceDataStore: namespaceDataStore,
+	}
+}
+
+func (h *sacHelperImpl) GetClustersForPermissions(
+	ctx context.Context,
+	requestedPermissions []string,
+	pagination *v1.Pagination,
+) ([]*v1.ScopeObject, error) {
+	resourcesWithAccess := listReadPermissions(requestedPermissions, permissions.ClusterScope)
+	clusterIDsInScope, hasFullAccess, err := listClusterIDsInScope(ctx, resourcesWithAccess)
+	if err != nil {
+		return nil, err
+	}
+
+	// Use an elevated context to fetch cluster names associated with the listed IDs.
+	// This context must not be propagated.
+	// The search is restricted to the cluster name field, and to the clusters allowed
+	// by the extended scope.
+	var clusterLookupCtx context.Context
+	if hasFullAccess {
+		clusterLookupCtx = sac.WithGlobalAccessScopeChecker(ctx,
+			sac.AllowFixedScopes(
+				sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
+				sac.ResourceScopeKeys(resources.Cluster),
+			),
+		)
+	} else {
+		clusterLookupCtx = sac.WithGlobalAccessScopeChecker(ctx,
+			sac.AllowFixedScopes(
+				sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
+				sac.ResourceScopeKeys(resources.Cluster),
+				sac.ClusterScopeKeys(clusterIDsInScope.AsSlice()...),
+			),
+		)
+	}
+	query := search.NewQueryBuilder().
+		AddStringsHighlighted(search.Cluster, search.WildcardString).
+		ProtoQuery()
+
+	allowedSortFields := set.NewStringSet(search.ClusterID.String(), search.Cluster.String())
+	query.Pagination = getSanitizedPagination(pagination, allowedSortFields)
+	results, err := h.clusterDataStore.Search(clusterLookupCtx, query)
+	if err != nil {
+		return nil, err
+	}
+
+	optionsMap := getClustersOptionsMap()
+	clusters := extractScopeElements(results, optionsMap, search.Cluster.String())
+
+	return clusters, nil
+}
+
+func (h *sacHelperImpl) IsClusterVisibleForPermissions(
+	ctx context.Context,
+	clusterID string,
+	resourcesWithAccess []permissions.ResourceWithAccess,
+) (bool, error) {
+	clusterFound, hasFullAccess, err := hasClusterIDInScope(ctx, clusterID, resourcesWithAccess)
+	if err != nil {
+		return false, err
+	}
+	if hasFullAccess {
+		// Use an elevated context to check the existence of the cluster associated with the listed ID.
+		// This context must not be propagated.
+		elevatedCtx := sac.WithGlobalAccessScopeChecker(
+			ctx,
+			sac.AllowFixedScopes(
+				sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
+				sac.ResourceScopeKeys(resources.Cluster),
+			),
+		)
+		return h.clusterDataStore.Exists(elevatedCtx, clusterID)
+	}
+	return clusterFound, nil
+}
+
+func (h *sacHelperImpl) GetNamespacesForClusterAndPermissions(
+	ctx context.Context,
+	clusterID string,
+	requestedPermissions []string,
+) ([]*v1.ScopeObject, error) {
+	resourcesWithAccess := listReadPermissions(requestedPermissions, permissions.NamespaceScope)
+
+	clusterVisible, err := h.IsClusterVisibleForPermissions(ctx, clusterID, resourcesWithAccess)
+	if err != nil {
+		return nil, err
+	}
+	if !clusterVisible {
+		return nil, errox.NotFound
+	}
+
+	namespacesInScope, hasFullAccess, err := listNamespaceNamesInScope(ctx, clusterID, resourcesWithAccess)
+	if err != nil {
+		return nil, err
+	}
+
+	// Use an elevated context to fetch namespace IDs and names associated with the listed namespace names.
+	// This context must not be propagated.
+	// The search is restricted to the namespace name field, and to the namespaces allowed
+	// by the extended scope.
+	var namespaceLookupCtx context.Context
+	if hasFullAccess {
+		namespaceLookupCtx = sac.WithGlobalAccessScopeChecker(ctx,
+			sac.AllowFixedScopes(
+				sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
+				sac.ResourceScopeKeys(resources.Namespace),
+				sac.ClusterScopeKeys(clusterID),
+			),
+		)
+	} else {
+		namespaceLookupCtx = sac.WithGlobalAccessScopeChecker(ctx,
+			sac.AllowFixedScopes(
+				sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
+				sac.ResourceScopeKeys(resources.Namespace),
+				sac.ClusterScopeKeys(clusterID),
+				sac.NamespaceScopeKeys(namespacesInScope.AsSlice()...),
+			),
+		)
+	}
+	query := search.NewQueryBuilder().
+		AddStringsHighlighted(search.Namespace, search.WildcardString).
+		ProtoQuery()
+	/*
+		// Currently, the namespace search overrides pagination information. As a consequence, pagination is disabled here.
+		allowedSortFields := set.NewStringSet(search.NamespaceID.String(), search.Namespace.String())
+		query.Pagination = getSanitizedPagination(req.GetPagination(), allowedSortFields)
+	*/
+	results, err := h.namespaceDataStore.Search(namespaceLookupCtx, query)
+	if err != nil {
+		return nil, err
+	}
+
+	optionsMap := getNamespacesOptionsMap()
+	namespaces := extractScopeElements(results, optionsMap, search.Namespace.String())
+	return namespaces, nil
+}

--- a/central/role/sachelper/scope.go
+++ b/central/role/sachelper/scope.go
@@ -1,0 +1,18 @@
+package sachelper
+
+import (
+	"context"
+
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/auth/permissions"
+	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stackrox/rox/pkg/sac/effectiveaccessscope"
+)
+
+func getRequesterScopeForReadPermission(
+	ctx context.Context,
+	resourceWithAccess permissions.ResourceWithAccess,
+) (*effectiveaccessscope.ScopeTree, error) {
+	scopeChecker := sac.ForResource(resourceWithAccess.Resource).ScopeChecker(ctx, storage.Access_READ_ACCESS)
+	return scopeChecker.EffectiveAccessScope(resourceWithAccess)
+}

--- a/central/role/service/service.go
+++ b/central/role/service/service.go
@@ -6,6 +6,7 @@ import (
 	clusterDS "github.com/stackrox/rox/central/cluster/datastore"
 	namespaceDS "github.com/stackrox/rox/central/namespace/datastore"
 	"github.com/stackrox/rox/central/role/datastore"
+	"github.com/stackrox/rox/central/role/sachelper"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/pkg/grpc"
 )
@@ -24,5 +25,6 @@ func New(roleDataStore datastore.DataStore, clusterDataStore clusterDS.DataStore
 		roleDataStore:      roleDataStore,
 		clusterDataStore:   clusterDataStore,
 		namespaceDataStore: namespaceDataStore,
+		sacHelper:          sachelper.NewSacHelper(clusterDataStore, namespaceDataStore),
 	}
 }

--- a/central/role/service/service.go
+++ b/central/role/service/service.go
@@ -25,6 +25,7 @@ func New(roleDataStore datastore.DataStore, clusterDataStore clusterDS.DataStore
 		roleDataStore:      roleDataStore,
 		clusterDataStore:   clusterDataStore,
 		namespaceDataStore: namespaceDataStore,
-		sacHelper:          sachelper.NewSacHelper(clusterDataStore, namespaceDataStore),
+		clusterSACHelper:   sachelper.NewClusterSacHelper(clusterDataStore),
+		namespaceSACHelper: sachelper.NewClusterNamespaceSacHelper(clusterDataStore, namespaceDataStore),
 	}
 }

--- a/central/role/service/service_impl.go
+++ b/central/role/service/service_impl.go
@@ -76,7 +76,8 @@ type serviceImpl struct {
 	roleDataStore      datastore.DataStore
 	clusterDataStore   clusterDS.DataStore
 	namespaceDataStore namespaceDS.DataStore
-	sacHelper          sachelper.SacHelper
+	clusterSACHelper   sachelper.ClusterSacHelper
+	namespaceSACHelper sachelper.ClusterNamespaceSacHelper
 }
 
 func (s *serviceImpl) RegisterServiceServer(grpcServer *grpc.Server) {
@@ -356,7 +357,7 @@ func (s *serviceImpl) ComputeEffectiveAccessScope(ctx context.Context, req *v1.C
 func (s *serviceImpl) GetClustersForPermissions(ctx context.Context, req *v1.GetClustersForPermissionsRequest) (*v1.GetClustersForPermissionsResponse, error) {
 	requestedPermissions := req.GetPermissions()
 
-	clusters, err := s.sacHelper.GetClustersForPermissions(ctx, requestedPermissions, req.GetPagination())
+	clusters, err := s.clusterSACHelper.GetClustersForPermissions(ctx, requestedPermissions, req.GetPagination())
 	if err != nil {
 		return nil, err
 	}
@@ -371,7 +372,7 @@ func (s *serviceImpl) GetNamespacesForClusterAndPermissions(ctx context.Context,
 	requestedPermissions := req.GetPermissions()
 	clusterID := req.GetClusterId()
 
-	namespaces, err := s.sacHelper.GetNamespacesForClusterAndPermissions(ctx, clusterID, requestedPermissions)
+	namespaces, err := s.namespaceSACHelper.GetNamespacesForClusterAndPermissions(ctx, clusterID, requestedPermissions)
 	if err != nil {
 		return nil, err
 	}

--- a/central/role/service/service_impl.go
+++ b/central/role/service/service_impl.go
@@ -2,23 +2,20 @@ package service
 
 import (
 	"context"
-	"fmt"
 	"sort"
 
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/pkg/errors"
 	clusterDS "github.com/stackrox/rox/central/cluster/datastore"
-	clusterMappings "github.com/stackrox/rox/central/cluster/index/mappings"
 	namespaceDS "github.com/stackrox/rox/central/namespace/datastore"
-	namespaceMappings "github.com/stackrox/rox/central/namespace/index/mappings"
 	rolePkg "github.com/stackrox/rox/central/role"
 	"github.com/stackrox/rox/central/role/datastore"
 	"github.com/stackrox/rox/central/role/resources"
+	"github.com/stackrox/rox/central/role/sachelper"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/accessscope"
 	"github.com/stackrox/rox/pkg/auth/permissions"
-	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/grpc/authn"
 	"github.com/stackrox/rox/pkg/grpc/authz"
@@ -26,12 +23,7 @@ import (
 	"github.com/stackrox/rox/pkg/grpc/authz/perrpc"
 	"github.com/stackrox/rox/pkg/grpc/authz/user"
 	"github.com/stackrox/rox/pkg/logging"
-	"github.com/stackrox/rox/pkg/postgres/schema"
-	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/sac/effectiveaccessscope"
-	"github.com/stackrox/rox/pkg/search"
-	"github.com/stackrox/rox/pkg/set"
-	"github.com/stackrox/rox/pkg/sliceutils"
 	"google.golang.org/grpc"
 )
 
@@ -84,6 +76,7 @@ type serviceImpl struct {
 	roleDataStore      datastore.DataStore
 	clusterDataStore   clusterDS.DataStore
 	namespaceDataStore namespaceDS.DataStore
+	sacHelper          sachelper.SacHelper
 }
 
 func (s *serviceImpl) RegisterServiceServer(grpcServer *grpc.Server) {
@@ -363,45 +356,11 @@ func (s *serviceImpl) ComputeEffectiveAccessScope(ctx context.Context, req *v1.C
 func (s *serviceImpl) GetClustersForPermissions(ctx context.Context, req *v1.GetClustersForPermissionsRequest) (*v1.GetClustersForPermissionsResponse, error) {
 	requestedPermissions := req.GetPermissions()
 
-	resourcesWithAccess := listReadPermissions(requestedPermissions, permissions.ClusterScope)
-	clusterIDsInScope, hasFullAccess, err := listClusterIDsInScope(ctx, resourcesWithAccess)
+	clusters, err := s.sacHelper.GetClustersForPermissions(ctx, requestedPermissions, req.GetPagination())
 	if err != nil {
 		return nil, err
 	}
 
-	// Use an elevated context to fetch cluster names associated with the listed IDs.
-	// This context must not be propagated.
-	// The search is restricted to the cluster name field, and to the clusters allowed
-	// by the extended scope.
-	var clusterLookupCtx context.Context
-	if hasFullAccess {
-		clusterLookupCtx = sac.WithGlobalAccessScopeChecker(ctx,
-			sac.AllowFixedScopes(
-				sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
-				sac.ResourceScopeKeys(resources.Cluster),
-			),
-		)
-	} else {
-		clusterLookupCtx = sac.WithGlobalAccessScopeChecker(ctx,
-			sac.AllowFixedScopes(
-				sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
-				sac.ResourceScopeKeys(resources.Cluster),
-				sac.ClusterScopeKeys(clusterIDsInScope.AsSlice()...),
-			),
-		)
-	}
-	query := search.NewQueryBuilder().
-		AddStringsHighlighted(search.Cluster, search.WildcardString).
-		ProtoQuery()
-	allowedSortFields := set.NewStringSet(search.ClusterID.String(), search.Cluster.String())
-	query.Pagination = getSanitizedPagination(req.GetPagination(), allowedSortFields)
-	results, err := s.clusterDataStore.Search(clusterLookupCtx, query)
-	if err != nil {
-		return nil, err
-	}
-
-	optionsMap := getClustersOptionsMap()
-	clusters := extractScopeElements(results, optionsMap, search.Cluster.String())
 	response := &v1.GetClustersForPermissionsResponse{
 		Clusters: clusters,
 	}
@@ -412,59 +371,11 @@ func (s *serviceImpl) GetNamespacesForClusterAndPermissions(ctx context.Context,
 	requestedPermissions := req.GetPermissions()
 	clusterID := req.GetClusterId()
 
-	resourcesWithAccess := listReadPermissions(requestedPermissions, permissions.NamespaceScope)
-
-	clusterVisible, err := s.isClusterVisibleForRequester(ctx, clusterID)
-	if err != nil {
-		return nil, err
-	}
-	if !clusterVisible {
-		return nil, errox.NotFound
-	}
-
-	namespacesInScope, hasFullAccess, err := listNamespaceNamesInScope(ctx, clusterID, resourcesWithAccess)
+	namespaces, err := s.sacHelper.GetNamespacesForClusterAndPermissions(ctx, clusterID, requestedPermissions)
 	if err != nil {
 		return nil, err
 	}
 
-	// Use an elevated context to fetch namespace IDs and names associated with the listed namespace names.
-	// This context must not be propagated.
-	// The search is restricted to the namespace name field, and to the namespaces allowed
-	// by the extended scope.
-	var namespaceLookupCtx context.Context
-	if hasFullAccess {
-		namespaceLookupCtx = sac.WithGlobalAccessScopeChecker(ctx,
-			sac.AllowFixedScopes(
-				sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
-				sac.ResourceScopeKeys(resources.Namespace),
-				sac.ClusterScopeKeys(clusterID),
-			),
-		)
-	} else {
-		namespaceLookupCtx = sac.WithGlobalAccessScopeChecker(ctx,
-			sac.AllowFixedScopes(
-				sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
-				sac.ResourceScopeKeys(resources.Namespace),
-				sac.ClusterScopeKeys(clusterID),
-				sac.NamespaceScopeKeys(namespacesInScope.AsSlice()...),
-			),
-		)
-	}
-	query := search.NewQueryBuilder().
-		AddStringsHighlighted(search.Namespace, search.WildcardString).
-		ProtoQuery()
-	/*
-		// Currently, the namespace search overrides pagination information. As a consequence, pagination is disabled here.
-		allowedSortFields := set.NewStringSet(search.NamespaceID.String(), search.Namespace.String())
-		query.Pagination = getSanitizedPagination(req.GetPagination(), allowedSortFields)
-	*/
-	results, err := s.namespaceDataStore.Search(namespaceLookupCtx, query)
-	if err != nil {
-		return nil, err
-	}
-
-	optionsMap := getNamespacesOptionsMap()
-	namespaces := extractScopeElements(results, optionsMap, search.Namespace.String())
 	response := &v1.GetNamespacesForClusterAndPermissionsResponse{
 		Namespaces: namespaces,
 	}
@@ -489,209 +400,4 @@ func effectiveAccessScopeForSimpleAccessScope(scopeRules *storage.SimpleAccessSc
 	}
 
 	return response, nil
-}
-
-const (
-	hasFullAccess    = true
-	hasPartialAccess = false
-)
-
-func listReadPermissions(
-	requestedPermissions []string,
-	scope permissions.ResourceScope,
-) []permissions.ResourceWithAccess {
-	readPermissions := resources.AllResourcesViewPermissions()
-	indexedScopeReadPermissions := make(map[string]permissions.ResourceWithAccess, 0)
-	scopeReadPermissions := make([]permissions.ResourceWithAccess, 0, len(readPermissions))
-	for _, permission := range readPermissions {
-		if permission.Resource.GetScope() >= scope {
-			scopeReadPermissions = append(scopeReadPermissions, permission)
-			indexedScopeReadPermissions[permission.Resource.String()] = permission
-		}
-	}
-	if len(requestedPermissions) == 0 {
-		return scopeReadPermissions
-	}
-	scopeRequestedReadPermissions := make([]permissions.ResourceWithAccess, 0, len(scopeReadPermissions))
-	for _, permission := range sliceutils.Unique(requestedPermissions) {
-		if resourceWithAccess, found := indexedScopeReadPermissions[permission]; found {
-			scopeRequestedReadPermissions = append(scopeRequestedReadPermissions, resourceWithAccess)
-		}
-	}
-	return scopeRequestedReadPermissions
-}
-
-func getRequesterScopeForReadPermission(
-	ctx context.Context,
-	resourceWithAccess permissions.ResourceWithAccess,
-) (*effectiveaccessscope.ScopeTree, error) {
-	scopeChecker := sac.ForResource(resourceWithAccess.Resource).ScopeChecker(ctx, storage.Access_READ_ACCESS)
-	return scopeChecker.EffectiveAccessScope(resourceWithAccess)
-}
-
-// listClusterIDsInScope consolidates the list of cluster IDs in the user scopes associated
-// with the requested resources and access level.
-// - If one of the allowed scopes is unrestricted, then the string set is returned empty
-// and the returned boolean is true.
-// - If no allowed scope is unrestricted, the string set contains the cluster IDs allowed by
-// the user scopes associated with the requested resources, and the returned boolean is false.
-func listClusterIDsInScope(
-	ctx context.Context,
-	resourcesWithAccess []permissions.ResourceWithAccess,
-) (set.StringSet, bool, error) {
-	clusterIDsInScope := set.NewStringSet()
-	for _, r := range resourcesWithAccess {
-		scope, err := getRequesterScopeForReadPermission(ctx, r)
-		if err != nil {
-			return set.NewStringSet(), hasPartialAccess, err
-		}
-		if scope == nil || scope.State == effectiveaccessscope.Excluded {
-			continue
-		}
-		if scope.State == effectiveaccessscope.Included {
-			return set.NewStringSet(), hasFullAccess, nil
-		}
-		clusterIDs := scope.GetClusterIDs()
-		for _, clusterID := range clusterIDs {
-			if clusterNode := scope.GetClusterByID(clusterID); clusterNode != nil &&
-				clusterNode.State != effectiveaccessscope.Excluded {
-				clusterIDsInScope.Add(clusterID)
-			}
-		}
-	}
-	return clusterIDsInScope, hasPartialAccess, nil
-}
-
-func getClustersOptionsMap() search.OptionsMap {
-	if env.PostgresDatastoreEnabled.BooleanSetting() {
-		return schema.ClustersSchema.OptionsMap
-	}
-	return clusterMappings.OptionsMap
-}
-
-func (s *serviceImpl) isClusterVisibleForRequester(
-	ctx context.Context,
-	clusterID string,
-) (bool, error) {
-	resourcesWithAccess := listReadPermissions([]string{}, permissions.ClusterScope)
-	clusterIDsInScope, isFullAccess, err := listClusterIDsInScope(ctx, resourcesWithAccess)
-	if err != nil {
-		return false, err
-	}
-	if !isFullAccess && clusterIDsInScope.Contains(clusterID) {
-		return true, nil
-	}
-	if isFullAccess {
-		clusterLookupElevatedAccess := sac.WithGlobalAccessScopeChecker(ctx,
-			sac.AllowFixedScopes(
-				sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
-				sac.ResourceScopeKeys(resources.Cluster),
-			),
-		)
-		exists, err := s.clusterDataStore.Exists(clusterLookupElevatedAccess, clusterID)
-		if err != nil {
-			return false, err
-		}
-		return exists, nil
-	}
-	return false, nil
-}
-
-// listNamespaceNamesInScope consolidates the list of names of namespaces in the cluster matching
-// the requested ID and allowed by user scopes associated with the requested resources
-// and access level.
-// - If one of the allowed scopes is unrestricted for the requested cluster, then the string set
-// is returned empty and the returned boolean is true.
-// - If no allowed scope is unrestricted for the requested cluster, the string set contains
-// the names of the namespaces allowed by the user scopes associated with the requested resources,
-// and the returned boolean is false.
-func listNamespaceNamesInScope(
-	ctx context.Context,
-	clusterID string,
-	resourcesWithAccess []permissions.ResourceWithAccess,
-) (set.StringSet, bool, error) {
-	noNamespaces := set.NewStringSet()
-	namespacesInScope := set.NewStringSet()
-	for _, r := range resourcesWithAccess {
-		scope, err := getRequesterScopeForReadPermission(ctx, r)
-		if err != nil {
-			return noNamespaces, hasPartialAccess, err
-		}
-		if scope == nil || scope.State == effectiveaccessscope.Excluded {
-			continue
-		}
-		if scope.State == effectiveaccessscope.Included {
-			return noNamespaces, hasFullAccess, nil
-		}
-		clusterScope := scope.GetClusterByID(clusterID)
-		if clusterScope == nil || clusterScope.State == effectiveaccessscope.Excluded {
-			continue
-		}
-		if clusterScope.State == effectiveaccessscope.Included {
-			return noNamespaces, hasFullAccess, nil
-		}
-		for namespace, namespaceScope := range clusterScope.Namespaces {
-			if namespaceScope == nil || namespaceScope.State == effectiveaccessscope.Excluded {
-				continue
-			}
-			namespacesInScope.Add(namespace)
-		}
-	}
-	return namespacesInScope, hasPartialAccess, nil
-}
-
-func getSanitizedPagination(requested *v1.Pagination, allowedSortFields set.StringSet) *v1.QueryPagination {
-	if requested == nil {
-		return nil
-	}
-	sanitized := &v1.QueryPagination{
-		Limit:       requested.GetLimit(),
-		Offset:      requested.GetOffset(),
-		SortOptions: nil,
-	}
-	if requested.GetSortOption() != nil {
-		sortField := requested.GetSortOption().GetField()
-		if allowedSortFields.Contains(sortField) {
-			sanitizedSortOption := &v1.QuerySortOption{
-				Field:          sortField,
-				Reversed:       requested.GetSortOption().GetReversed(),
-				SearchAfterOpt: nil,
-			}
-			sanitized.SortOptions = append(sanitized.SortOptions, sanitizedSortOption)
-		}
-	}
-	return sanitized
-}
-
-func getNamespacesOptionsMap() search.OptionsMap {
-	if env.PostgresDatastoreEnabled.BooleanSetting() {
-		return schema.NamespacesSchema.OptionsMap
-	}
-	return namespaceMappings.OptionsMap
-}
-
-func extractScopeElements(results []search.Result, optionsMap search.OptionsMap, searchedField string) []*v1.ScopeObject {
-	scopeElements := make([]*v1.ScopeObject, 0, len(results))
-	targetField, fieldFound := optionsMap.Get(searchedField)
-	for _, r := range results {
-		objID := r.ID
-		objName := ""
-		if fieldFound {
-			for _, v := range r.Matches[targetField.GetFieldPath()] {
-				if len(v) > 0 {
-					objName = v
-					break
-				}
-			}
-		}
-		if len(objName) == 0 {
-			objName = fmt.Sprintf("%s with ID %s", searchedField, objID)
-		}
-		element := &v1.ScopeObject{
-			Id:   objID,
-			Name: objName,
-		}
-		scopeElements = append(scopeElements, element)
-	}
-	return scopeElements
 }

--- a/central/role/service/service_impl_test.go
+++ b/central/role/service/service_impl_test.go
@@ -13,6 +13,7 @@ import (
 	namespaceDataStore "github.com/stackrox/rox/central/namespace/datastore"
 	roleDatastore "github.com/stackrox/rox/central/role/datastore"
 	"github.com/stackrox/rox/central/role/resources"
+	"github.com/stackrox/rox/central/role/sachelper"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/auth/permissions"
@@ -534,6 +535,7 @@ func (s *serviceImplTestSuite) SetupSuite() {
 			roleDataStore:      roleStore,
 			clusterDataStore:   clusterStore,
 			namespaceDataStore: namespaceStore,
+			sacHelper:          sachelper.NewSacHelper(clusterStore, namespaceStore),
 		}
 	} else {
 		s.boltEngine, err = boltPkg.NewTemp("roleServiceTestBolt")
@@ -559,6 +561,7 @@ func (s *serviceImplTestSuite) SetupSuite() {
 			roleDataStore:      roleStore,
 			clusterDataStore:   clusterStore,
 			namespaceDataStore: namespaceStore,
+			sacHelper:          sachelper.NewSacHelper(clusterStore, namespaceStore),
 		}
 	}
 }

--- a/central/role/service/service_impl_test.go
+++ b/central/role/service/service_impl_test.go
@@ -535,7 +535,8 @@ func (s *serviceImplTestSuite) SetupSuite() {
 			roleDataStore:      roleStore,
 			clusterDataStore:   clusterStore,
 			namespaceDataStore: namespaceStore,
-			sacHelper:          sachelper.NewSacHelper(clusterStore, namespaceStore),
+			clusterSACHelper:   sachelper.NewClusterSacHelper(clusterStore),
+			namespaceSACHelper: sachelper.NewClusterNamespaceSacHelper(clusterStore, namespaceStore),
 		}
 	} else {
 		s.boltEngine, err = boltPkg.NewTemp("roleServiceTestBolt")
@@ -561,7 +562,8 @@ func (s *serviceImplTestSuite) SetupSuite() {
 			roleDataStore:      roleStore,
 			clusterDataStore:   clusterStore,
 			namespaceDataStore: namespaceStore,
-			sacHelper:          sachelper.NewSacHelper(clusterStore, namespaceStore),
+			clusterSACHelper:   sachelper.NewClusterSacHelper(clusterStore),
+			namespaceSACHelper: sachelper.NewClusterNamespaceSacHelper(clusterStore, namespaceStore),
 		}
 	}
 }


### PR DESCRIPTION
## Description

Testing the NetworkGraph 2.0 page, I found out that the network policy lookup requires the `Cluster` permission in order to check if the cluster for which information is requested does exist. Requiring the `Cluster` permission for existence check could lead to data leaks or at least exposure of sensitive data not needed for network graph and policy management.

The change at hand alters the cluster validation flow for network graph and network policy to the verification that the target cluster is in the requester scope for either `NetworkGraph` or `NetworkPolicy` depending on the flow performing the existence check.

The change 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
