### PR TITLE
ROX-16466: Remove preview from NWG 2.0 and mark 1.0 as deprecated

### DIFF
--- a/ui/apps/platform/cypress/helpers/networkGraph.js
+++ b/ui/apps/platform/cypress/helpers/networkGraph.js
@@ -5,6 +5,7 @@ import { interactAndWaitForResponses, interceptRequests, waitForResponses } from
 import { visit } from './visit';
 import selectSelectors from '../selectors/select';
 import tabSelectors from '../selectors/tab';
+import { hasFeatureFlag } from './features';
 
 const getNodeErrorMessage = (node) => `Could not find node "${node.name}" of type "${node.type}"`;
 
@@ -281,7 +282,10 @@ export function interactAndVisitNetworkGraphWithDeploymentSelected(
 }
 
 export function visitOldNetworkGraphFromLeftNav() {
-    visitFromLeftNav('Network Graph (1.0)', routeMatcherMapToVisitNetworkGraph);
+    const oldNetworkGraphNavItemText = hasFeatureFlag('ROX_NETWORK_GRAPH_PATTERNFLY')
+        ? 'Network Graph (1.0 deprecated)'
+        : 'Network Graph';
+    visitFromLeftNav(oldNetworkGraphNavItemText, routeMatcherMapToVisitNetworkGraph);
 
     cy.location('pathname').should('eq', basePath);
     cy.get(`h1:contains("${title}")`);

--- a/ui/apps/platform/src/Containers/MainPage/Sidebar/NavigationSidebar.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Sidebar/NavigationSidebar.tsx
@@ -1,14 +1,6 @@
 import React, { ReactElement } from 'react';
 import { useLocation, Location } from 'react-router-dom';
-import {
-    Nav,
-    NavList,
-    NavExpandable,
-    PageSidebar,
-    Flex,
-    FlexItem,
-    Badge,
-} from '@patternfly/react-core';
+import { Nav, NavList, NavExpandable, PageSidebar } from '@patternfly/react-core';
 
 import { IsFeatureFlagEnabled } from 'hooks/useFeatureFlags';
 import { HasReadAccess } from 'hooks/usePermissions';
@@ -16,8 +8,6 @@ import { HasReadAccess } from 'hooks/usePermissions';
 import {
     basePathToLabelMap,
     dashboardPath,
-    networkBasePath,
-    networkBasePathPF,
     violationsBasePath,
     complianceBasePath,
     vulnManagementPath,
@@ -36,6 +26,7 @@ import {
 } from 'routePaths';
 
 import LeftNavItem from './LeftNavItem';
+import NetworkGraphNavItems from './NetworkGraphNavItems';
 
 type NavigationSidebarProps = {
     hasReadAccess: HasReadAccess;
@@ -87,34 +78,7 @@ function NavigationSidebar({
                     path={dashboardPath}
                     title={basePathToLabelMap[dashboardPath]}
                 />
-                {isFeatureFlagEnabled('ROX_NETWORK_GRAPH_PATTERNFLY') && (
-                    <LeftNavItem
-                        isActive={location.pathname.includes(networkBasePathPF)}
-                        path={networkBasePathPF}
-                        title={
-                            <Flex>
-                                <FlexItem>Network Graph</FlexItem>
-                                <FlexItem>
-                                    <Badge
-                                        style={{
-                                            backgroundColor: 'var(--pf-global--palette--cyan-400)',
-                                        }}
-                                    >
-                                        2.0 preview
-                                    </Badge>
-                                </FlexItem>
-                            </Flex>
-                        }
-                    />
-                )}
-                <LeftNavItem
-                    isActive={
-                        location.pathname.includes(networkBasePath) &&
-                        !location.pathname.includes(networkBasePathPF)
-                    }
-                    path={networkBasePath}
-                    title={basePathToLabelMap[networkBasePath]}
-                />
+                <NetworkGraphNavItems isFeatureFlagEnabled={isFeatureFlagEnabled} />
                 <LeftNavItem
                     isActive={location.pathname.includes(violationsBasePath)}
                     path={violationsBasePath}

--- a/ui/apps/platform/src/Containers/MainPage/Sidebar/NetworkGraphNavItems.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Sidebar/NetworkGraphNavItems.tsx
@@ -18,20 +18,7 @@ function NetworkGraphNavItems({ isFeatureFlagEnabled }: NetworkGraphNavItemsProp
     const networkGraphTitle = isNetworkGraphPFEnabled
         ? 'Network Graph (1.0 deprecated)'
         : 'Network Graph';
-    const networkGraphPFTitle = (
-        <Flex>
-            <FlexItem>Network Graph</FlexItem>
-            <FlexItem>
-                <Badge
-                    style={{
-                        backgroundColor: 'var(--pf-global--palette--cyan-400)',
-                    }}
-                >
-                    2.0
-                </Badge>
-            </FlexItem>
-        </Flex>
-    );
+    const networkGraphPFTitle = 'Network Graph (2.0)';
 
     return (
         <>

--- a/ui/apps/platform/src/Containers/MainPage/Sidebar/NetworkGraphNavItems.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Sidebar/NetworkGraphNavItems.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { useLocation, Location } from 'react-router-dom';
 import { networkBasePath, networkBasePathPF } from 'routePaths';
-import { Badge, Flex, FlexItem } from '@patternfly/react-core';
 
 import { IsFeatureFlagEnabled } from 'hooks/useFeatureFlags';
 

--- a/ui/apps/platform/src/Containers/MainPage/Sidebar/NetworkGraphNavItems.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Sidebar/NetworkGraphNavItems.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { useLocation, Location } from 'react-router-dom';
+import { networkBasePath, networkBasePathPF } from 'routePaths';
+import { Badge, Flex, FlexItem } from '@patternfly/react-core';
+
+import { IsFeatureFlagEnabled } from 'hooks/useFeatureFlags';
+
+import LeftNavItem from './LeftNavItem';
+
+type NetworkGraphNavItemsProps = {
+    isFeatureFlagEnabled: IsFeatureFlagEnabled;
+};
+
+function NetworkGraphNavItems({ isFeatureFlagEnabled }: NetworkGraphNavItemsProps) {
+    const location: Location = useLocation();
+    const isNetworkGraphPFEnabled = isFeatureFlagEnabled('ROX_NETWORK_GRAPH_PATTERNFLY');
+
+    const networkGraphTitle = isNetworkGraphPFEnabled ? (
+        <Flex>
+            <FlexItem>Network Graph</FlexItem>
+            <FlexItem>
+                <Badge
+                    style={{
+                        backgroundColor: 'var(--pf-global--palette--cyan-400)',
+                    }}
+                >
+                    1.0 deprecated
+                </Badge>
+            </FlexItem>
+        </Flex>
+    ) : (
+        <Flex>
+            <FlexItem>Network Graph</FlexItem>
+        </Flex>
+    );
+    const networkGraphPFTitle = (
+        <Flex>
+            <FlexItem>Network Graph</FlexItem>
+            <FlexItem>(2.0)</FlexItem>
+        </Flex>
+    );
+
+    return (
+        <>
+            {isNetworkGraphPFEnabled && (
+                <LeftNavItem
+                    isActive={location.pathname.includes(networkBasePathPF)}
+                    path={networkBasePathPF}
+                    title={networkGraphPFTitle}
+                />
+            )}
+
+            <LeftNavItem
+                isActive={
+                    location.pathname.includes(networkBasePath) &&
+                    !location.pathname.includes(networkBasePathPF)
+                }
+                path={networkBasePath}
+                title={networkGraphTitle}
+            />
+        </>
+    );
+}
+
+export default NetworkGraphNavItems;

--- a/ui/apps/platform/src/Containers/MainPage/Sidebar/NetworkGraphNavItems.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Sidebar/NetworkGraphNavItems.tsx
@@ -15,7 +15,10 @@ function NetworkGraphNavItems({ isFeatureFlagEnabled }: NetworkGraphNavItemsProp
     const location: Location = useLocation();
     const isNetworkGraphPFEnabled = isFeatureFlagEnabled('ROX_NETWORK_GRAPH_PATTERNFLY');
 
-    const networkGraphTitle = isNetworkGraphPFEnabled ? (
+    const networkGraphTitle = isNetworkGraphPFEnabled
+        ? 'Network Graph (1.0 deprecated)'
+        : 'Network Graph';
+    const networkGraphPFTitle = (
         <Flex>
             <FlexItem>Network Graph</FlexItem>
             <FlexItem>
@@ -24,19 +27,9 @@ function NetworkGraphNavItems({ isFeatureFlagEnabled }: NetworkGraphNavItemsProp
                         backgroundColor: 'var(--pf-global--palette--cyan-400)',
                     }}
                 >
-                    1.0 deprecated
+                    2.0
                 </Badge>
             </FlexItem>
-        </Flex>
-    ) : (
-        <Flex>
-            <FlexItem>Network Graph</FlexItem>
-        </Flex>
-    );
-    const networkGraphPFTitle = (
-        <Flex>
-            <FlexItem>Network Graph</FlexItem>
-            <FlexItem>(2.0)</FlexItem>
         </Flex>
     );
 

--- a/ui/apps/platform/src/Containers/Network/Page.js
+++ b/ui/apps/platform/src/Containers/Network/Page.js
@@ -20,6 +20,7 @@ import SidePanel from 'Containers/Network/SidePanel/SidePanel';
 import SimulationFrame from 'Components/SimulationFrame';
 import { fetchDeployment } from 'services/DeploymentsService';
 import { getErrorMessageFromServerResponse } from 'utils/networkGraphUtils';
+import useFeatureFlags from 'hooks/useFeatureFlags';
 import Header from './Header/Header';
 import NoSelectedNamespace from './NoSelectedNamespace';
 import GraphLoadErrorState from './GraphLoadErrorState';
@@ -88,6 +89,7 @@ function NetworkPage({
     const { isBaselineSimulationOn } = useNetworkBaselineSimulation();
     const isSimulationOn = isNetworkSimulationOn || isBaselineSimulationOn;
     const [isInitialRender, setIsInitialRender] = useState(true);
+    const { isFeatureFlagEnabled } = useFeatureFlags();
 
     const {
         params: { deploymentId },
@@ -144,17 +146,19 @@ function NetworkPage({
 
     return (
         <>
-            <Alert
-                isInline
-                variant="warning"
-                title={
-                    <p>
-                        Version 1.0 of Network Graph is being deprecated soon. Please switch to the
-                        new 2.0 version for improved functionality and a better user experience.
-                        Contact our support team for assistance
-                    </p>
-                }
-            />
+            {isFeatureFlagEnabled('ROX_NETWORK_GRAPH_PATTERNFLY') && (
+                <Alert
+                    isInline
+                    variant="warning"
+                    title={
+                        <p>
+                            Version 1.0 of Network Graph is being deprecated soon. Please switch to
+                            the new 2.0 version for improved functionality and a better user
+                            experience. Contact our support team for assistance
+                        </p>
+                    }
+                />
+            )}
             <Header
                 isGraphDisabled={hasNoSelectedNamespace || hasGraphLoadError}
                 isSimulationOn={isSimulationOn}

--- a/ui/apps/platform/src/routePaths.js
+++ b/ui/apps/platform/src/routePaths.js
@@ -159,7 +159,7 @@ const vulnerabilitiesPathToLabelMap = {
 export const basePathToLabelMap = {
     [dashboardPath]: 'Dashboard',
     [networkBasePath]: 'Network Graph (1.0)',
-    [networkBasePathPF]: 'Network Graph (2.0 preview)',
+    [networkBasePathPF]: 'Network Graph (2.0)',
     [violationsBasePath]: 'Violations',
     [complianceBasePath]: 'Compliance',
     ...vulnerabilitiesPathToLabelMap,


### PR DESCRIPTION
## Description

Jira: https://issues.redhat.com/browse/ROX-16466

This PR makes a change to the left nav bar:
1. The old network graph nav item will now say "Network Graph (1.0 deprecated)"
2. The new network graph nav item will now say "Network Graph (2.0)"
3. The deprecation banner in the old network graph is now feature flagged 

### With feature flag off
<img width="1552" alt="Screenshot 2023-04-13 at 12 37 47 PM" src="https://user-images.githubusercontent.com/4805485/231865984-7bb63469-dbc3-4a36-b2df-27dec41bd7c1.png">

### With feature flag on
<img width="1552" alt="Screenshot 2023-04-13 at 12 38 12 PM" src="https://user-images.githubusercontent.com/4805485/231865994-363e48a8-d00a-470c-a684-501ec7ca9bc2.png">
