### PR TITLE
ROX-16038 Regression tests for the data race in the enricher

### DIFF
--- a/sensor/common/detector/enricher_test.go
+++ b/sensor/common/detector/enricher_test.go
@@ -53,14 +53,14 @@ func TestEnricherSuite(t *testing.T) {
 	suite.Run(t, new(enricherSuite))
 }
 
-func createScanImageRequest(containerId int, imageId string, fullName string, notPullable bool) *scanImageRequest {
+func createScanImageRequest(containerID int, imageID string, fullName string, notPullable bool) *scanImageRequest {
 	return &scanImageRequest{
-		containerIdx: containerId,
+		containerIdx: containerID,
 		containerImage: &storage.ContainerImage{
 			Name: &storage.ImageName{
 				FullName: fullName,
 			},
-			Id:          imageId,
+			Id:          imageID,
 			NotPullable: notPullable,
 		},
 	}

--- a/sensor/common/detector/enricher_test.go
+++ b/sensor/common/detector/enricher_test.go
@@ -66,7 +66,7 @@ func createScanImageRequest(containerId int, imageId string, fullName string, no
 	}
 }
 
-func (s *enricherSuite) Test_runScan() {
+func (s *enricherSuite) Test_dataRaceInRunScan() {
 	// Three requests with same Ids but different FullNames
 	// The first one should trigger the scan
 	req := createScanImageRequest(0, "nginx-id", "nginx:latest", false)

--- a/sensor/common/detector/enricher_test.go
+++ b/sensor/common/detector/enricher_test.go
@@ -1,0 +1,137 @@
+package detector
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/env"
+	"github.com/stackrox/rox/pkg/expiringcache"
+	"github.com/stackrox/rox/pkg/images/types"
+	"github.com/stackrox/rox/pkg/sync"
+	"github.com/stackrox/rox/pkg/utils"
+	"github.com/stackrox/rox/sensor/common/registry"
+	mockStore "github.com/stackrox/rox/sensor/common/store/mocks"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+)
+
+type enricherSuite struct {
+	suite.Suite
+	mockCtrl                *gomock.Controller
+	enricher                *enricher
+	mockCache               expiringcache.Cache
+	mockServiceAccountStore *mockStore.MockServiceAccountStore
+	mockRegistryStore       *registry.Store
+}
+
+var _ suite.SetupTestSuite = &enricherSuite{}
+var _ suite.TearDownTestSuite = &enricherSuite{}
+
+func (s *enricherSuite) SetupTest() {
+	s.mockCtrl = gomock.NewController(s.T())
+	s.mockCache = expiringcache.NewExpiringCache(env.ReprocessInterval.DurationSetting())
+	s.mockServiceAccountStore = mockStore.NewMockServiceAccountStore(s.mockCtrl)
+	s.mockRegistryStore = registry.NewRegistryStore(nil)
+	s.enricher = newEnricher(s.mockCache,
+		s.mockServiceAccountStore,
+		s.mockRegistryStore)
+}
+
+func (s *enricherSuite) TearDownTest() {
+	s.T().Cleanup(s.mockCtrl.Finish)
+}
+
+func TestEnricherSuite(t *testing.T) {
+	suite.Run(t, new(enricherSuite))
+}
+
+func createScanImageRequest(containerId int, imageId string, fullName string, notPullable bool) *scanImageRequest {
+	return &scanImageRequest{
+		containerIdx: containerId,
+		containerImage: &storage.ContainerImage{
+			Name: &storage.ImageName{
+				FullName: fullName,
+			},
+			Id:          imageId,
+			NotPullable: notPullable,
+		},
+	}
+}
+
+func (s *enricherSuite) Test_runScan() {
+	// Three requests with same Ids but different FullNames
+	// The first one should trigger the scan
+	req := createScanImageRequest(0, "nginx-id", "nginx:latest", false)
+	// The second third should get image from the Cache (getImageFromCache) and set forceEnrichImageWithSignatures
+	// to true since they names are different. This will force the detection and should trigger the data race.
+	req2 := createScanImageRequest(0, "nginx-id", "quay.io/nginx:latest", false)
+	// The third should behave similarly to req2. We added a third request just in case the second is able to
+	// bypass getImageFromCache and land to GetOrSet. If that happens, it shouldn't trigger the data race because
+	// forceEnrichImageWithSignatures is false and newValue != value so we shouldn't trigger a scan.
+	req3 := createScanImageRequest(0, "nginx-id", "nginx:1.14.2", false)
+	conn, closeFunc := createMockImageService(s.T())
+	s.enricher.imageSvc = v1.NewImageServiceClient(conn)
+	defer closeFunc()
+	s.mockCache.RemoveAll()
+	waitGroup := sync.WaitGroup{}
+	waitGroup.Add(3)
+	go func() {
+		s.enricher.runScan(req)
+		waitGroup.Done()
+	}()
+	// We wait to make sure the first request finishes
+	time.Sleep(2 * time.Second)
+	go func() {
+		s.enricher.runScan(req2)
+		waitGroup.Done()
+	}()
+	go func() {
+		s.enricher.runScan(req3)
+		waitGroup.Done()
+	}()
+	waitGroup.Wait()
+}
+
+func createMockImageService(t *testing.T) (*grpc.ClientConn, func()) {
+	buffer := 1024 * 1024
+	listener := bufconn.Listen(buffer)
+
+	server := grpc.NewServer()
+	v1.RegisterImageServiceServer(server,
+		&mockImageServiceServer{})
+	go func() {
+		utils.IgnoreError(func() error {
+			return server.Serve(listener)
+		})
+	}()
+	conn, err := grpc.DialContext(context.Background(), "", grpc.WithContextDialer(func(ctx context.Context, s string) (net.Conn, error) {
+		return listener.Dial()
+	}), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	closeFunc := func() {
+		utils.IgnoreError(listener.Close)
+		server.Stop()
+	}
+	return conn, closeFunc
+}
+
+type mockImageServiceServer struct {
+	v1.UnimplementedImageServiceServer
+	expectedResponse *v1.ScanImageInternalResponse
+	delayResponse    time.Duration
+	expectedError    error
+}
+
+func (m *mockImageServiceServer) ScanImageInternal(_ context.Context, req *v1.ScanImageInternalRequest) (*v1.ScanImageInternalResponse, error) {
+	return &v1.ScanImageInternalResponse{
+		Image: types.ToImage(req.Image),
+	}, nil
+}


### PR DESCRIPTION
## Description

Update: Adding regression tests for the data race described below. The fix was introduced in #5627.

Opening this PR to discuss how to solve a data race we discovered in the enricher (see [ROX-16038](https://issues.redhat.com/browse/ROX-16038))

Our understanding of the code is that we force a scan of an image with the same id (digest) but different name. This leads to the race condition reproducible by the test added in this PR. I don't know if this `forceEnrichImageWithSignatures` is 100% necessary, but if it is, we need to rework the logic to make sure we fix this race.

cc @dhaus67 since he was the last one modifying this logic.
cc @fredrb 

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

If the data race is not fixed we will see this test fail:

```
go test -race -count=1 github.com/stackrox/rox/sensor/common/detector -v
=== RUN   TestEnricherSuite
=== RUN   TestEnricherSuite/Test_runScan
==================
WARNING: DATA RACE
Write at 0x00c0008ac590 by goroutine 56:
  github.com/stackrox/rox/sensor/common/detector.(*cacheValue).scanAndSet()
      /Users/lvalerom/go/src/github.com/stackrox/stackrox/sensor/common/detector/enricher.go:164 +0x915
  github.com/stackrox/rox/sensor/common/detector.(*enricher).runScan()
      /Users/lvalerom/go/src/github.com/stackrox/stackrox/sensor/common/detector/enricher.go:228 +0x8c4
  github.com/stackrox/rox/sensor/common/detector.(*enricherSuite).Test_runScan.func2()
      /Users/lvalerom/go/src/github.com/stackrox/stackrox/sensor/common/detector/enricher_test.go:93 +0x5e

Previous read at 0x00c0008ac590 by goroutine 37:
  github.com/stackrox/rox/sensor/common/detector.(*cacheValue).waitAndGet()
      /Users/lvalerom/go/src/github.com/stackrox/stackrox/sensor/common/detector/enricher.go:63 +0x8eb
  github.com/stackrox/rox/sensor/common/detector.(*enricher).runScan()
      /Users/lvalerom/go/src/github.com/stackrox/stackrox/sensor/common/detector/enricher.go:231 +0x8cf
  github.com/stackrox/rox/sensor/common/detector.(*enricherSuite).Test_runScan.func1()
      /Users/lvalerom/go/src/github.com/stackrox/stackrox/sensor/common/detector/enricher_test.go:87 +0x5e

Goroutine 56 (running) created at:
  github.com/stackrox/rox/sensor/common/detector.(*enricherSuite).Test_runScan()
      /Users/lvalerom/go/src/github.com/stackrox/stackrox/sensor/common/detector/enricher_test.go:92 +0xb59
  runtime.call16()
      /usr/local/go/src/runtime/asm_amd64.s:724 +0x48
  reflect.Value.Call()
      /usr/local/go/src/reflect/value.go:368 +0xc7
  github.com/stretchr/testify/suite.Run.func1()
      /Users/lvalerom/go/pkg/mod/github.com/stretchr/testify@v1.8.2/suite/suite.go:197 +0x6e6
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1446 +0x216
  testing.(*T).Run.func1()
      /usr/local/go/src/testing/testing.go:1493 +0x47

Goroutine 37 (finished) created at:
  github.com/stackrox/rox/sensor/common/detector.(*enricherSuite).Test_runScan()
      /Users/lvalerom/go/src/github.com/stackrox/stackrox/sensor/common/detector/enricher_test.go:86 +0xa33
  runtime.call16()
      /usr/local/go/src/runtime/asm_amd64.s:724 +0x48
  reflect.Value.Call()
      /usr/local/go/src/reflect/value.go:368 +0xc7
  github.com/stretchr/testify/suite.Run.func1()
      /Users/lvalerom/go/pkg/mod/github.com/stretchr/testify@v1.8.2/suite/suite.go:197 +0x6e6
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1446 +0x216
  testing.(*T).Run.func1()
      /usr/local/go/src/testing/testing.go:1493 +0x47
==================
    testing.go:1319: race detected during execution of test
=== CONT  TestEnricherSuite
    testing.go:1319: race detected during execution of test
--- FAIL: TestEnricherSuite (2.01s)
    --- FAIL: TestEnricherSuite/Test_runScan (2.01s)
=== CONT  
    testing.go:1319: race detected during execution of test
FAIL
FAIL	github.com/stackrox/rox/sensor/common/detector	3.417s
FAIL
```