### PR TITLE
ROX-14917: Switch Helm versioning to respect Main major version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 - The default resources for Sensor have moved to a request of 2 cores, 4GB of RAM and a limit of 4 cores, 8GB of RAM in order to
   support a higher number of clusters without modification.
 - ROX-14280: ACS operator default channel changes from `latest` to `stable`. Users of older versions must follow the upgrade procedure in order to preserve ACS data in case of issues with the upgrade.
+- ROX-14917: Helm charts versioning scheme changed. Previously the product version (Major).(Minor).(Patch) was rendered to the Helm chart version (Minor).(Patch).0, e.g. 3.74.2 -> 74.2.0. The new versioning scheme maps product version (Major).(Minor).(Patch) to the Helm chart version as (Major*100).(Minor).(Patch), e.g. 4.0.2 -> 400.0.2.
 
 ## [3.74.0]
 

--- a/pkg/version/chart_version_test.go
+++ b/pkg/version/chart_version_test.go
@@ -101,7 +101,7 @@ func TestChartVersionGeneration(t *testing.T) {
 	for _, testCase := range testCases {
 		description := fmt.Sprintf("Checking if DeriveChartVersion(%s) = %s", testCase.mainVersion, testCase.chartVersion)
 		t.Run(description, func(t *testing.T) {
-			generatedChartVersion, err := doDeriveChartVersion(testCase.mainVersion)
+			generatedChartVersion, err := deriveChartVersion(testCase.mainVersion)
 			if testCase.expectedError != "" {
 				assert.ErrorContains(t, err, testCase.expectedError)
 			} else {

--- a/pkg/version/chart_version_test.go
+++ b/pkg/version/chart_version_test.go
@@ -16,15 +16,15 @@ func TestChartVersionGeneration(t *testing.T) {
 	}{
 		{
 			mainVersion:  "3.0.49.x-1-ga0897a21ee-dirty",
-			chartVersion: "49.0.1-ga0897a21ee-dirty",
+			chartVersion: "300.49.0-1-ga0897a21ee-dirty",
 		},
 		{
 			mainVersion:  "3.0.49.0-1-ga0897a21ee",
-			chartVersion: "49.0.1-ga0897a21ee",
+			chartVersion: "300.49.0-1-ga0897a21ee",
 		},
 		{
 			mainVersion:  "3.0.49.1-22-ga0897a21ee",
-			chartVersion: "49.1.22-ga0897a21ee",
+			chartVersion: "300.49.1-22-ga0897a21ee",
 		},
 		{
 			mainVersion:   "99.0.101.42-212-ga0897a21ee",
@@ -32,31 +32,27 @@ func TestChartVersionGeneration(t *testing.T) {
 		},
 		{
 			mainVersion:  "3.0.48.0-rc.1",
-			chartVersion: "48.0.0-rc.1",
+			chartVersion: "300.48.0-rc.1",
 		},
 		{
 			mainVersion:  "3.0.48.5-nightly-20200910",
-			chartVersion: "48.5.0-nightly-20200910",
+			chartVersion: "300.48.5-nightly-20200910",
 		},
 		{
 			mainVersion:  "3.0.48.5",
-			chartVersion: "48.5.0",
-		},
-		{
-			mainVersion:   "3.62",
-			expectedError: "failed to parse main version",
+			chartVersion: "300.48.5",
 		},
 		{
 			mainVersion:  "3.62.x-1-ga0897a21ee-dirty",
-			chartVersion: "62.0.1-ga0897a21ee-dirty",
+			chartVersion: "300.62.0-1-ga0897a21ee-dirty",
 		},
 		{
 			mainVersion:  "3.62.0-1-ga0897a21ee",
-			chartVersion: "62.0.1-ga0897a21ee",
+			chartVersion: "300.62.0-1-ga0897a21ee",
 		},
 		{
 			mainVersion:  "3.62.1-22-ga0897a21ee",
-			chartVersion: "62.1.22-ga0897a21ee",
+			chartVersion: "300.62.1-22-ga0897a21ee",
 		},
 		{
 			mainVersion:  "99.101.42-212-ga0897a21ee",
@@ -64,15 +60,15 @@ func TestChartVersionGeneration(t *testing.T) {
 		},
 		{
 			mainVersion:  "3.62.0-rc.1",
-			chartVersion: "62.0.0-rc.1",
+			chartVersion: "300.62.0-rc.1",
 		},
 		{
 			mainVersion:  "3.62.5-nightly-20200910",
-			chartVersion: "62.5.0-nightly-20200910",
+			chartVersion: "300.62.5-nightly-20200910",
 		},
 		{
 			mainVersion:  "3.62.5",
-			chartVersion: "62.5.0",
+			chartVersion: "300.62.5",
 		},
 		{
 			mainVersion:   "3.62",
@@ -94,7 +90,7 @@ func TestChartVersionGeneration(t *testing.T) {
 			// Downstream trunk builds will identify themselves as such.
 			// This case checks there's no error.
 			mainVersion:  "1.0.0",
-			chartVersion: "0.0.0",
+			chartVersion: "100.0.0",
 		},
 	}
 

--- a/pkg/version/chart_version_test.go
+++ b/pkg/version/chart_version_test.go
@@ -10,8 +10,9 @@ import (
 
 func TestChartVersionGeneration(t *testing.T) {
 	testCases := []struct {
-		mainVersion  string
-		chartVersion string
+		mainVersion   string
+		chartVersion  string
+		expectedError string
 	}{
 		{
 			mainVersion:  "3.0.49.x-1-ga0897a21ee-dirty",
@@ -26,8 +27,8 @@ func TestChartVersionGeneration(t *testing.T) {
 			chartVersion: "49.1.22-ga0897a21ee",
 		},
 		{
-			mainVersion:  "99.0.101.42-212-ga0897a21ee",
-			chartVersion: "101.42.212-ga0897a21ee",
+			mainVersion:   "99.0.101.42-212-ga0897a21ee",
+			expectedError: "unexpected main version",
 		},
 		{
 			mainVersion:  "3.0.48.0-rc.1",
@@ -42,8 +43,8 @@ func TestChartVersionGeneration(t *testing.T) {
 			chartVersion: "48.5.0",
 		},
 		{
-			mainVersion:  "3.62",
-			chartVersion: "",
+			mainVersion:   "3.62",
+			expectedError: "failed to parse main version",
 		},
 		{
 			mainVersion:  "3.62.x-1-ga0897a21ee-dirty",
@@ -59,7 +60,7 @@ func TestChartVersionGeneration(t *testing.T) {
 		},
 		{
 			mainVersion:  "99.101.42-212-ga0897a21ee",
-			chartVersion: "101.42.212-ga0897a21ee",
+			chartVersion: "9900.101.42-212-ga0897a21ee",
 		},
 		{
 			mainVersion:  "3.62.0-rc.1",
@@ -74,8 +75,26 @@ func TestChartVersionGeneration(t *testing.T) {
 			chartVersion: "62.5.0",
 		},
 		{
-			mainVersion:  "3.62",
-			chartVersion: "",
+			mainVersion:   "3.62",
+			expectedError: "failed to parse main version",
+		},
+		{
+			mainVersion:  "4.0.0-rc.2",
+			chartVersion: "400.0.0-rc.2",
+		},
+		{
+			mainVersion:  "4.1.3",
+			chartVersion: "400.1.3",
+		},
+		{
+			mainVersion:  "4.0.x-79-g9abecf2368-dirty",
+			chartVersion: "400.0.0-79-g9abecf2368-dirty",
+		},
+		{
+			// Downstream trunk builds will identify themselves as such.
+			// This case checks there's no error.
+			mainVersion:  "1.0.0",
+			chartVersion: "0.0.0",
 		},
 	}
 
@@ -83,8 +102,8 @@ func TestChartVersionGeneration(t *testing.T) {
 		description := fmt.Sprintf("Checking if DeriveChartVersion(%s) = %s", testCase.mainVersion, testCase.chartVersion)
 		t.Run(description, func(t *testing.T) {
 			generatedChartVersion, err := doDeriveChartVersion(testCase.mainVersion)
-			if testCase.chartVersion == "" {
-				assert.ErrorContains(t, err, "failed to parse main version")
+			if testCase.expectedError != "" {
+				assert.ErrorContains(t, err, testCase.expectedError)
 			} else {
 				assert.NoError(t, err)
 				assert.Equal(t, testCase.chartVersion, generatedChartVersion)

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -152,17 +152,51 @@ func doDeriveChartVersion(mainVersion string) (string, error) {
 		}
 	}
 
-	// We need to make sure that the patch suffix will begin with a number for obtaining a valid SemVer 2 version string.
-	patchSuffixWithInitialNumber := parsedMainVersion.PatchSuffix
-	if patchSuffixWithInitialNumber == "" {
-		// For release versions.
-		patchSuffixWithInitialNumber = "0"
-	} else if c := patchSuffixWithInitialNumber[0]; !(c >= '0' && c <= '9') {
-		// Prefix with "0-".
-		patchSuffixWithInitialNumber = fmt.Sprintf("0-%s", patchSuffixWithInitialNumber)
+	var chartMajor int
+	var chartMinor int
+	var chartPatchAndSuffix string
+
+	if parsedMainVersion.MarketingMajor > 3 {
+		if parsedMainVersion.MarketingMinor != nil {
+			return "", errors.Errorf(
+				"unexpected main version %s: minor marketing version component is not supported after the product version 3",
+				mainVersion)
+		}
+
+		// In 3[.0].y.z era Y/Minor versions got up to 74 and occupied Helm chart versions 74.something.something.
+		// Because of that, we have to assign even bigger Major Helm chart version. Otherwise, if we simply take Main
+		// Major (e.g. 4) and assign it to Helm Major, it will be recognized as old according to SemVer (4.0.0<74.0.0).
+		// Therefore, we pad Main Major with two trailing zeroes making such chart appear newer than charts from
+		// 3[.0].y.z era, as it should.
+		chartMajor = parsedMainVersion.MarketingMajor * 100
+
+		chartMinor = parsedMainVersion.EngRelease
+
+		if parsedMainVersion.PatchSuffix == "" {
+			chartPatchAndSuffix = strconv.Itoa(patchLevelInteger)
+		} else {
+			chartPatchAndSuffix = fmt.Sprintf("%d-%s", patchLevelInteger, parsedMainVersion.PatchSuffix)
+		}
+	} else {
+		// For some reason that was not recorded and got lost in time, Helm charts in 3[.0].y.z era were versioned by
+		// taking Main Minor as Helm Major and Main Patch as Helm Minor. Thus, Main Major was simply ignored.
+		chartMajor = parsedMainVersion.EngRelease
+		chartMinor = patchLevelInteger
+
+		// This converts Main Suffix to Helm Patch+Suffix. If Main Suffix begins with a number, this number is used as
+		// Helm Patch and the rest goes to Helm Suffix. Otherwise, Helm Patch is assigned to zero and Suffix is copied
+		// (if present).
+		chartPatchAndSuffix = parsedMainVersion.PatchSuffix
+		if chartPatchAndSuffix == "" {
+			// For release versions.
+			chartPatchAndSuffix = "0"
+		} else if c := chartPatchAndSuffix[0]; !(c >= '0' && c <= '9') {
+			// Prefix with "0-".
+			chartPatchAndSuffix = fmt.Sprintf("0-%s", chartPatchAndSuffix)
+		}
 	}
 
-	chartVersion := fmt.Sprintf("%d.%d.%s", parsedMainVersion.EngRelease, patchLevelInteger, patchSuffixWithInitialNumber)
+	chartVersion := fmt.Sprintf("%d.%d.%s", chartMajor, chartMinor, chartPatchAndSuffix)
 	return chartVersion, nil
 }
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -134,10 +134,13 @@ func parseMainVersion(mainVersion string) (parsedMainVersion, error) {
 
 // GetChartVersion derives a Chart Version string from the provided Main Version string.
 func GetChartVersion() string {
-	return DeriveChartVersion(GetMainVersion())
+	chartVersion, err := deriveChartVersion(GetMainVersion())
+	utils.Should(err)
+	return chartVersion
 }
 
-func doDeriveChartVersion(mainVersion string) (string, error) {
+// deriveChartVersion derives a Chart Version string from the provided Main Version string.
+func deriveChartVersion(mainVersion string) (string, error) {
 	parsedMainVersion, err := parseMainVersion(mainVersion)
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to parse main version %q", mainVersion)
@@ -198,13 +201,6 @@ func doDeriveChartVersion(mainVersion string) (string, error) {
 
 	chartVersion := fmt.Sprintf("%d.%d.%s", chartMajor, chartMinor, chartPatchAndSuffix)
 	return chartVersion, nil
-}
-
-// DeriveChartVersion derives a Chart Version string from the provided Main Version string.
-func DeriveChartVersion(mainVersion string) string {
-	chartVersion, err := doDeriveChartVersion(mainVersion)
-	utils.Should(err)
-	return chartVersion
 }
 
 // GetMajorMinor returns first two parts of the provided version.

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -183,12 +183,3 @@ func deriveChartVersion(mainVersion string) (string, error) {
 	chartVersion := fmt.Sprintf("%d.%d.%d%s", chartMajor, chartMinor, chartPatch, chartSuffix)
 	return chartVersion, nil
 }
-
-// GetMajorMinor returns first two parts of the provided version.
-func GetMajorMinor(version string) string {
-	components := strings.SplitN(version, ".", 3)
-	if len(components) >= 2 {
-		return fmt.Sprintf("%s.%s", components[0], components[1])
-	}
-	return version
-}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -96,6 +96,10 @@ func parseMainVersion(mainVersion string) (parsedMainVersion, error) {
 	var marketingMinorOpt *int
 	engReleaseOfs := 1
 	if len(components) == 4 {
+		// It's highly unlikely we're going to ever use non-SemVer product versions that include four components.
+		// However, there's a lot of test code that was written when this was the way of versioning. Therefore this
+		// parsing still exists.
+		// TODO: clean up all versioning and test code that deals with "marketing minor".
 		marketingMinor, err := strconv.Atoi(components[1])
 		if err != nil {
 			return parsedMainVersion{}, errors.Wrapf(err, "invalid marketing minor major version (%q)", components[1])

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -10,14 +10,3 @@ func TestParseCurrentVersion(t *testing.T) {
 	_, err := parseMainVersion(GetMainVersion())
 	assert.NoError(t, err)
 }
-
-func TestGetMajorMinor(t *testing.T) {
-	assert.Equal(t, "3.73", GetMajorMinor("3.73.x"))
-	assert.Equal(t, "38.753", GetMajorMinor("38.753.15"))
-	assert.Equal(t, "38.753", GetMajorMinor("38.753.15.18"))
-	assert.Equal(t, "38.75", GetMajorMinor("38.75"))
-	assert.Equal(t, "38", GetMajorMinor("38"))
-	assert.Equal(t, "a.b", GetMajorMinor("a.b.c"))
-	assert.Equal(t, "a.b", GetMajorMinor("a.b.c-d.e"))
-	assert.Equal(t, "", GetMajorMinor(""))
-}


### PR DESCRIPTION
## Description

Old Helm charts were versioned like this:
```
Main Version -> Helm Chart Version
3.0.58.2 -> 58.2.0
3.74.1 -> 74.1.0
```

This creates a problem with the major version bump from 3.74.z to 4.0.0 because under such scheme
```
Main Version -> Helm Chart Version
4.0.0 -> 0.0.0
4.1.0 -> 1.0.0
4.2.0 -> 2.0.0
```
which, according to [SemVer used in Helm](https://helm.sh/docs/topics/charts/#charts-and-versioning), is considered to be older versions than 3.74.z rendered to (I also verified this manually).

It seems weird why the release number was put into Helm Major version. Unfortunately, @mtesseract is on the leave to answer. I made extensive search in Confluence, in the Internet and also [asked](https://redhat-internal.slack.com/archives/C02HTD51SMD/p1680778117629319) @SimonBaeumer in Slack but wasn't able to find an answer whether there's a different treatment between Major and Minor versions that Helm does. It seems like there's no difference which version to use. The original change https://github.com/stackrox/rox/pull/6522 and its related ticket [ROX-5469](https://issues.redhat.com/browse/ROX-5469) did not make it clear either.

Obviously, we need to make Helm versions for 4.y.z Main versions to go after 74.y.z ones.
I decided to take Main Major and multiply it with 100 which should work just fine.
This makes for:
```
Main Version -> Helm Chart Version
4.0.0 -> 400.0.0
4.1.0 -> 400.1.0
4.2.3 -> 400.2.3
5.17.4 -> 500.17.4
```

If differentiating Major Helm version for each product release and patch is significant, we **could** make `Helm_Major = Main_Major * 100 + Main_Minor`, but if there's no difference (and it needs to be proven), I prefer not to do that as it makes things more confusing.

For reviewers: please review this change per commit because I described each commit in the message to help with the context and the intent.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] Evaluated and added CHANGELOG entry if required

These aren't necessary:
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

* CI on GKE must be green enough.
* [x] Manual test done and described.

### Test 1. Before the fix.

Helm charts were generated as `stackrox-central-services-0.0.0.tgz` and `stackrox-secured-cluster-services-0.0.0.tgz`.
Upgrades did not change the StackRox version from 3.74.2 because 0.0.0 is clearly older.

### Test 2. After the fix with TAG=4.0.0-rc.2

Helm charts generated as `stackrox-central-services-400.0.0-rc.2.tgz` and `stackrox-secured-cluster-services-400.0.0-rc.2.tgz`. Charts show above 3.yy ones.

The upgrade succeeds, Central comes to live. Central and Sensor images get reported as `quay.io/stackrox-io/main:4.0.0-rc.2`.

### Test 3. From 4.0.0-rc.2 to 4.1.0-non-existent

In step 3 I did not `rm -rf ~/tmp/helm-test` to keep charts from 4.0.0-rc.2 in the same repo.
Helm charts generated as `stackrox-central-services-400.1.0-non-existent.tgz` and `tackrox-secured-cluster-services-400.1.0-non-existent.tgz`.
Charts `400.1.0-non-existent` go before `400.0.0-rc.2`. That's desired and expected.

Upgrade commands in Step 6 modified as:
```sh
helm upgrade -n stackrox --devel stackrox-central-services helm-test/stackrox-central-services \
  --reuse-values --set central.db.persistence.persistentVolumeClaim.createClaim=false

helm upgrade -n stackrox --devel stackrox-secured-cluster-services helm-test/stackrox-secured-cluster-services \
  --reuse-values
```

Then, `kubectl -n stackrox get deploy/sensor -o yaml | grep image:` shows `image: quay.io/stackrox-io/main:4.1.0-non-existent` which means the upgrade from 4.0.0-rc.2 to 4.1.0-non-existent was performed and Helm indeed considers  `400.1.0-non-existent` to be newer than `400.0.0-rc.2`

### Test 4. Brand-new deployment of 4.0.0-rc.2

Skip Prerequisites 1 and 2.

Instead of Step 6.
Run:
```sh
git checkout misha/update-central-db-resources-in-scripts -- scripts/quick-helm-install.sh
helm repo remove stackrox
```
Modify line 47 to `helm repo add stackrox http://localhost:9876/`.
Modify lines 73 and 99 by adding `--devel` flag to `helm install` commands.
Then run
```sh
scripts/quick-helm-install.sh --small
```

StackRox comes online, reports itself as 4.0.0-rc.2 and images are `quay.io/stackrox-io/main:4.0.0-rc.2`.

### How this was tested

Prerequisite 1. Helm-deployed StackRox 3.74.latest on the cluster.
Can be done with fixed readme/script from https://github.com/stackrox/stackrox/pull/5707.

Prerequisite 2. Saved certs for central-db provisioning.
Follow <https://docs.google.com/document/d/1MPMVBvy4R9SIVdL6cXm9FIhFhackTW3ijDwHgRcE1FU/edit#heading=h.1s1t86iuuz4> and save certs with `create_certificate_values_file.sh doc-certs.yaml`.

Step 1. Build cli with custom tag/version:
```sh
$ make cli TAG=4.0.0
$ roxctl version
4.0.0
```

Step 2. Generate Helm charts with that version:
```sh
rm -rf tmp-central-stackrox tmp-sensor-stackrox
roxctl helm output central-services --image-defaults=opensource --output-dir tmp-central-stackrox
helm package -d . tmp-central-stackrox
roxctl helm output secured-cluster-services --image-defaults=opensource --output-dir tmp-sensor-stackrox
helm package -d . tmp-sensor-stackrox
```

Step 3. Create a local Helm repo from upstream plus these charts:
```sh
rm -rf ~/tmp/helm-test
git clone --depth 1 git@github.com:stackrox/helm-charts.git ~/tmp/helm-test
mv stackrox-central-services-*.tgz stackrox-secured-cluster-services-*.tgz ~/tmp/helm-test/opensource
helm repo index ~/tmp/helm-test/opensource
```

Step 4. Serve Helm repo. Should be running in a background terminal. This has to be done because Helm does not work with repos in FS.
```sh
cd ~/tmp/helm-test/opensource
python -m http.server 9876
```

Step 5. (Re-)add the custom Helm repo:
```sh
helm repo remove helm-test
helm repo add helm-test http://localhost:9876
helm search repo -l --devel | grep helm-test
```

Step 6. (Try) upgrade StackRox deployment to the latest available Helm charts:
```sh
helm upgrade -n stackrox --devel stackrox-central-services helm-test/stackrox-central-services \
  --reuse-values \
  -f doc-certs.yaml \
  --set central.db.password.generate=true \
  --set central.db.serviceTLS.generate=true \
  --set central.db.persistence.persistentVolumeClaim.createClaim=true

helm upgrade -n stackrox --devel stackrox-secured-cluster-services helm-test/stackrox-secured-cluster-services \
  --reuse-values
```

Step 7. Verify deployed images:
```sh
kubectl -n stackrox get deploy/central -o yaml | grep image:
kubectl -n stackrox get deploy/sensor -o yaml | grep image:
```