### PR TITLE
Reduce central-db resources in Helm installation scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,13 +103,15 @@ To see all available Helm charts in the repo run (you may add the option `--deve
 ```sh
 helm search repo stackrox
 ```
-To install stackrox-central-services, you will need a secure password. This password will be needed later when creating an init bundle.
+To install stackrox-central-services, you will need a secure password. This password will be needed later for UI login and when creating an init bundle.
 ```sh
 STACKROX_ADMIN_PASSWORD="$(openssl rand -base64 20 | tr -d '/=+')"
 ```
 From here, you can install stackrox-central-services to get Central and Scanner components deployed on your cluster. Note that you need only one deployed instance of stackrox-central-services even if you plan to secure multiple clusters.
 ```sh
-helm upgrade --install -n stackrox --create-namespace stackrox-central-services stackrox/stackrox-central-services --set central.adminPassword.value="${STACKROX_ADMIN_PASSWORD}"
+helm upgrade --install -n stackrox --create-namespace stackrox-central-services \
+  stackrox/stackrox-central-services \
+  --set central.adminPassword.value="${STACKROX_ADMIN_PASSWORD}"
 ```
 
 #### Install Central in Clusters With Limited Resources
@@ -122,6 +124,10 @@ helm upgrade -n stackrox stackrox-central-services stackrox/stackrox-central-ser
   --set central.resources.requests.cpu=1 \
   --set central.resources.limits.memory=4Gi \
   --set central.resources.limits.cpu=1 \
+  --set central.db.resources.requests.memory=1Gi \
+  --set central.db.resources.requests.cpu=500m \
+  --set central.db.resources.limits.memory=4Gi \
+  --set central.db.resources.limits.cpu=1 \
   --set scanner.autoscaling.disable=true \
   --set scanner.replicas=1 \
   --set scanner.resources.requests.memory=500Mi \
@@ -167,10 +173,15 @@ helm install -n stackrox stackrox-secured-cluster-services stackrox/stackrox-sec
   --set sensor.resources.limits.memory=500Mi \
   --set sensor.resources.limits.cpu=500m
 ```
+</details>
+
+<details>
+<summary>Additional information about Helm charts</summary>
 
 To further customize your Helm installation consult these documents:
-* <https://docs.openshift.com/acs/installing/installing_helm/install-helm-quick.html>
-* <https://docs.openshift.com/acs/installing/installing_helm/install-helm-customization.html>
+
+* <https://docs.openshift.com/acs/installing/installing_other/install-central-other.html#install-using-helm-customizations-other>
+* <https://docs.openshift.com/acs/installing/installing_other/install-secured-cluster-other.html#configure-secured-cluster-services-helm-chart-customizations-other>
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -74,10 +74,6 @@ The script adds the StackRox helm repository, generates an admin password, insta
 
 Finally, the script will automatically open the browser and log you into StackRox. A certificate warning may be displayed since the certificate is self-signed. See the [Accessing the StackRox User Interface (UI)](#accessing-the-stackrox-user-interface-ui) section to read more about the warnings. After authenticating you can access the dashboard using <https://localhost:8000/main/dashboard>.
 
-To further customize your Helm installation, consult these documents:
-* <https://docs.openshift.com/acs/installing/installing_helm/install-helm-quick.html>
-* <https://docs.openshift.com/acs/installing/installing_helm/install-helm-customization.html>
-
 </details>
 
 ### Manual Installation using Helm

--- a/scripts/quick-helm-install.sh
+++ b/scripts/quick-helm-install.sh
@@ -58,6 +58,10 @@ if [[ "$SMALL_INSTALL" == "true" ]]; then
     installflags+=('--set' 'central.resources.requests.cpu=1')
     installflags+=('--set' 'central.resources.limits.memory=4Gi')
     installflags+=('--set' 'central.resources.limits.cpu=1')
+    installflags+=('--set' 'central.db.resources.requests.memory=1Gi')
+    installflags+=('--set' 'central.db.resources.requests.cpu=500m')
+    installflags+=('--set' 'central.db.resources.limits.memory=4Gi')
+    installflags+=('--set' 'central.db.resources.limits.cpu=1')
     installflags+=('--set' 'scanner.autoscaling.disable=true')
     installflags+=('--set' 'scanner.replicas=1')
     installflags+=('--set' 'scanner.resources.requests.memory=500Mi')
@@ -106,8 +110,8 @@ echo -e "
 You may access the dashboard via https://localhost:8000/main/dashboard, the user is admin.
 
 Consult these documents for additional information on customizing your Helm installation:
-https://docs.openshift.com/acs/installing/installing_helm/install-helm-quick.html
-https://docs.openshift.com/acs/installing/installing_helm/install-helm-customization.html
+https://docs.openshift.com/acs/installing/installing_other/install-central-other.html#install-using-helm-customizations-other
+https://docs.openshift.com/acs/installing/installing_other/install-secured-cluster-other.html#configure-secured-cluster-services-helm-chart-customizations-other
 
 STACKROX_ADMIN_PASSWORD='$STACKROX_ADMIN_PASSWORD'
 Above is your automatically generated stackrox admin password. Please store it securely, as you will need it during further configuration.


### PR DESCRIPTION
## Description

Reduce central-db resources in Helm installation scripts with `--small` variant so that Central does not come overprovisioned as by default (4 cpu & 8Gb) and follows what we set in `deploy.sh`-based deployments (see https://github.com/stackrox/stackrox/blob/3269be7471c24aa387b7c988b81f475754e64571/deploy/common/local-dev-values.yaml).

Also updated a bit README around Helm-based installation.

Rendered README: https://github.com/stackrox/stackrox/blob/misha/update-central-db-resources-in-scripts/README.md#deploying-stackrox

## Checklist
- [ ] Investigated and inspected CI test results

These aren't needed:
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

Tested `scripts/quick-helm-install.sh --small` as part of https://github.com/stackrox/stackrox/pull/5692.