### PR TITLE
Send analytics by default when user hasn't modified telemetry option

### DIFF
--- a/ui/apps/platform/src/Containers/Clusters/ClustersSidePanel.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClustersSidePanel.tsx
@@ -21,7 +21,7 @@ import {
 } from 'services/ClustersService';
 import { Cluster } from 'types/cluster.proto';
 import { DecommissionedClusterRetentionInfo } from 'types/clusterService.proto';
-import useAnalytics, { clusterCreated } from 'hooks/useAnalytics';
+import useAnalytics, { CLUSTER_CREATED } from 'hooks/useAnalytics';
 
 import ClusterEditForm from './ClusterEditForm';
 import ClusterDeployment from './ClusterDeployment';
@@ -258,7 +258,7 @@ function ClustersSidePanel({ selectedClusterId, setSelectedClusterId }) {
                     */
                     // TODO After saveCluster returns response without normalize,
                     // something like the preceding commented lines should replace the following:
-                    analyticsTrack(clusterCreated);
+                    analyticsTrack(CLUSTER_CREATED);
                     const newId = response.response.result.cluster; // really is nested like this
                     const clusterWithId = { ...selectedCluster, id: newId };
                     setSelectedCluster(clusterWithId);

--- a/ui/apps/platform/src/Containers/MainPage/Body.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Body.tsx
@@ -103,7 +103,7 @@ function Body({ hasReadAccess, isFeatureFlagEnabled }: BodyProps): ReactElement 
     const location = useLocation();
     const { analyticsPageVisit } = useAnalytics();
     useEffect(() => {
-        analyticsPageVisit('visit', location.pathname);
+        analyticsPageVisit('Page Viewed', '', { path: location.pathname });
     }, [location, analyticsPageVisit]);
 
     const { isDarkMode } = useTheme();

--- a/ui/apps/platform/src/hooks/useAnalytics.ts
+++ b/ui/apps/platform/src/hooks/useAnalytics.ts
@@ -10,7 +10,7 @@ const useAnalytics = () => {
 
     const analyticsPageVisit = useCallback(
         (type: string, name: string, additionalProperties = {}): void => {
-            if (isTelemetryEnabled) {
+            if (isTelemetryEnabled !== false) {
                 window.analytics?.page(type, name, additionalProperties);
             }
         },
@@ -19,7 +19,7 @@ const useAnalytics = () => {
 
     const analyticsTrack = useCallback(
         (event: string, additionalProperties = {}): void => {
-            if (isTelemetryEnabled) {
+            if (isTelemetryEnabled !== false) {
                 window.analytics?.track(event, additionalProperties);
             }
         },
@@ -31,4 +31,4 @@ const useAnalytics = () => {
 
 export default useAnalytics;
 
-export const clusterCreated = 'Cluster Created';
+export const CLUSTER_CREATED = 'Cluster Created';


### PR DESCRIPTION
## Description

We are currently configuring telemetry by default when a user hasn't selected an option, however events won't be sent due to a check in the useAnalytics hooks. 

We also want to change the way page visit events are being sent to segment.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed
Check segment to verify events are being sent when the public config telemetry value is set to null
