### PR TITLE
Draft: run non groovy tests on OpenShift CI

### DIFF
--- a/scripts/ci/jobs/ocp_nongroovy_e2e_tests.py
+++ b/scripts/ci/jobs/ocp_nongroovy_e2e_tests.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env -S python3 -u
+
+"""
+Run tests/e2e in a openshift 4 cluster provided via a hive cluster_claim.
+"""
+import os
+from runners import ClusterTestRunner
+from clusters import OpenShiftScaleWorkersCluster
+from pre_tests import PreSystemTests
+from ci_tests import NonGroovyE2e
+from post_tests import PostClusterTest, FinalPost
+
+# set required test parameters
+os.environ["DEPLOY_STACKROX_VIA_OPERATOR"] = "true"
+os.environ["ORCHESTRATOR_FLAVOR"] = "openshift"
+os.environ["ROX_POSTGRES_DATASTORE"] = "true"
+os.environ["ROX_ACTIVE_VULN_MGMT"] = "true"
+
+# Scale up the cluster to support postgres
+cluster = OpenShiftScaleWorkersCluster(increment=1)
+
+ClusterTestRunner(
+    cluster=cluster,
+    pre_test=PreSystemTests(),
+    test=NonGroovyE2e(),
+    post_test=PostClusterTest(collect_central_artifacts=False),
+    final_post=FinalPost(handle_e2e_progress_failures=False),
+).run()

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -1026,7 +1026,7 @@ openshift_ci_mods() {
     info "Git log:"
     git log --oneline --decorate -n 20 || true
 
-    info "Fetch tags"
+    info "Fetch tags:"
     git fetch --tags
 
     info "Recent git refs:"

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -1026,9 +1026,12 @@ openshift_ci_mods() {
     info "Git log:"
     git log --oneline --decorate -n 20 || true
 
+    info "Fetch tags"
+    git fetch --tags
+
     info "Recent git refs:"
     git for-each-ref --format='%(creatordate) %(refname)' --sort=creatordate | tail -20
-
+    
     info "Current Status:"
     "$ROOT/status.sh" || true
 


### PR DESCRIPTION
Jira task: https://issues.redhat.com/projects/ROX/issues/ROX-16412

The PR to verify CI job: https://github.com/openshift/release/pull/38016

This task is to add nongroovy tests to OpenShift CI. To verify whether the CI can pick up these non groovy tests, I would like to test from branch liswang89-5.0. However, it seems not able to pass the CI configuration check. 
