### PR TITLE
Add empty state for Workload CVE tables when filters return zero results

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedDeploymentsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedDeploymentsTable.tsx
@@ -23,6 +23,7 @@ import ComponentVulnerabilitiesTable, {
     imageMetadataContextFragment,
 } from './ComponentVulnerabilitiesTable';
 import { DynamicColumnIcon } from '../components/DynamicIcon';
+import EmptyTableResults from '../components/EmptyTableResults';
 
 export type DeploymentForCve = {
     id: string;
@@ -86,6 +87,7 @@ function AffectedDeploymentsTable({
                     <Th>First discovered</Th>
                 </Tr>
             </Thead>
+            {deployments.length === 0 && <EmptyTableResults colSpan={7} />}
             {deployments.map((deployment, rowIndex) => {
                 const { id, name, namespace, clusterName, imageCount, created, images } =
                     deployment;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedImagesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedImagesTable.tsx
@@ -26,6 +26,7 @@ import ComponentVulnerabilitiesTable, {
     componentVulnerabilitiesFragment,
     imageMetadataContextFragment,
 } from './ComponentVulnerabilitiesTable';
+import EmptyTableResults from '../components/EmptyTableResults';
 
 export type ImageForCve = {
     id: string;
@@ -123,6 +124,7 @@ function AffectedImagesTable({ images, getSortParams, isFiltered }: AffectedImag
                     <Th>First discovered</Th>
                 </Tr>
             </Thead>
+            {images.length === 0 && <EmptyTableResults colSpan={7} />}
             {images.map((image, rowIndex) => {
                 const { id, name, operatingSystem, scanTime, imageComponents } = image;
                 const topSeverity = getVulnerabilitySeverity(imageComponents);

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentsTable.tsx
@@ -10,6 +10,7 @@ import { UseURLSortResult } from 'hooks/useURLSort';
 import { getEntityPagePath } from '../searchUtils';
 import SeverityCountLabels from '../components/SeverityCountLabels';
 import { DynamicColumnIcon } from '../components/DynamicIcon';
+import EmptyTableResults from '../components/EmptyTableResults';
 
 export const deploymentListQuery = gql`
     query getDeploymentList($query: String, $pagination: Pagination) {
@@ -71,6 +72,7 @@ function DeploymentsTable({ deployments, getSortParams, isFiltered }: Deployment
                     <Th>First discovered</Th>
                 </Tr>
             </Thead>
+            {deployments.length === 0 && <EmptyTableResults colSpan={6} />}
             {deployments.map(
                 ({
                     id,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImagesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImagesTable.tsx
@@ -11,6 +11,7 @@ import ImageNameTd from '../components/ImageNameTd';
 import { getEntityPagePath } from '../searchUtils';
 import SeverityCountLabels from '../components/SeverityCountLabels';
 import { DynamicColumnIcon } from '../components/DynamicIcon';
+import EmptyTableResults from '../components/EmptyTableResults';
 
 export const imageListQuery = gql`
     query getImageList($query: String, $pagination: Pagination) {
@@ -90,6 +91,7 @@ function ImagesTable({ images, getSortParams, isFiltered }: ImagesTableProps) {
                     <Th sort={getSortParams('Scan Time')}>Scan time</Th>
                 </Tr>
             </Thead>
+            {images.length === 0 && <EmptyTableResults colSpan={6} />}
             {images.map(
                 ({
                     id,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/SingleEntityVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/SingleEntityVulnerabilitiesTable.tsx
@@ -35,6 +35,8 @@ export const imageVulnerabilitiesFragment = gql`
         isFixable
         cve
         summary
+        cvss
+        scoreVersion
         discoveredAtImage
         imageComponents(query: $query) {
             ...ComponentVulnerabilities
@@ -48,6 +50,8 @@ export type ImageVulnerability = {
     isFixable: boolean;
     cve: string;
     summary: string;
+    cvss: number;
+    scoreVersion: string;
     discoveredAtImage: Date | null;
     imageComponents: ComponentVulnerability[];
 };
@@ -81,7 +85,7 @@ function SingleEntityVulnerabilitiesTable({
                         CVE Status
                         {isFiltered && <DynamicColumnIcon />}
                     </Th>
-                    {/* TODO Add sorting for these columns once aggregate sorting is available in BE */}
+                    <Th sort={getSortParams('CVSS')}>CVSS</Th>
                     <Th>
                         Affected components
                         {isFiltered && <DynamicColumnIcon />}
@@ -91,7 +95,16 @@ function SingleEntityVulnerabilitiesTable({
             </Thead>
             {image.imageVulnerabilities.map(
                 (
-                    { cve, severity, summary, isFixable, imageComponents, discoveredAtImage },
+                    {
+                        cve,
+                        severity,
+                        summary,
+                        isFixable,
+                        cvss,
+                        scoreVersion,
+                        imageComponents,
+                        discoveredAtImage,
+                    },
                     rowIndex
                 ) => {
                     const SeverityIcon: React.FC<SVGIconProps> | undefined =
@@ -139,6 +152,9 @@ function SingleEntityVulnerabilitiesTable({
                                         </span>
                                     </span>
                                 </Td>
+                                <Td dataLabel="CVSS">
+                                    {cvss.toFixed(1)} ({scoreVersion})
+                                </Td>
                                 <Td dataLabel="Affected components">
                                     {imageComponents.length === 1
                                         ? imageComponents[0].name
@@ -150,7 +166,7 @@ function SingleEntityVulnerabilitiesTable({
                             </Tr>
                             <Tr isExpanded={isExpanded}>
                                 <Td />
-                                <Td colSpan={5}>
+                                <Td colSpan={6}>
                                     <ExpandableRowContent>
                                         <p className="pf-u-mb-md">{summary}</p>
                                         <ComponentVulnerabilitiesTable

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/SingleEntityVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/SingleEntityVulnerabilitiesTable.tsx
@@ -10,6 +10,7 @@ import {
     Tr,
 } from '@patternfly/react-table';
 import { SVGIconProps } from '@patternfly/react-icons/dist/js/createIcon';
+import { gql } from '@apollo/client';
 
 import LinkShim from 'Components/PatternFly/LinkShim';
 import SeverityIcons from 'Components/PatternFly/SeverityIcons';
@@ -18,7 +19,6 @@ import { vulnerabilitySeverityLabels } from 'messages/common';
 import { getDistanceStrictAsPhrase } from 'utils/dateUtils';
 import { UseURLSortResult } from 'hooks/useURLSort';
 import { FixableIcon, NotFixableIcon } from 'Components/PatternFly/FixabilityIcons';
-import { gql } from '@apollo/client';
 import { getEntityPagePath } from '../searchUtils';
 import { DynamicColumnIcon } from '../components/DynamicIcon';
 import ComponentVulnerabilitiesTable, {
@@ -26,6 +26,8 @@ import ComponentVulnerabilitiesTable, {
     ImageMetadataContext,
     componentVulnerabilitiesFragment,
 } from './ComponentVulnerabilitiesTable';
+
+import EmptyTableResults from '../components/EmptyTableResults';
 
 export const imageVulnerabilitiesFragment = gql`
     ${componentVulnerabilitiesFragment}
@@ -93,6 +95,7 @@ function SingleEntityVulnerabilitiesTable({
                     <Th>First discovered</Th>
                 </Tr>
             </Thead>
+            {image.imageVulnerabilities.length === 0 && <EmptyTableResults colSpan={7} />}
             {image.imageVulnerabilities.map(
                 (
                     {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/EmptyTableResults.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/EmptyTableResults.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { Bullseye, Button, Text } from '@patternfly/react-core';
+import { SearchIcon } from '@patternfly/react-icons';
+import { Tbody, Tr, Td } from '@patternfly/react-table';
+
+import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';
+import useURLSearch from 'hooks/useURLSearch';
+
+export type EmptyTableResultsProps = {
+    colSpan: number;
+};
+
+function EmptyTableResults({ colSpan }: EmptyTableResultsProps) {
+    const { setSearchFilter } = useURLSearch();
+    return (
+        <Tbody>
+            <Tr>
+                <Td colSpan={colSpan}>
+                    <Bullseye>
+                        <EmptyStateTemplate
+                            title="No results found"
+                            headingLevel="h2"
+                            icon={SearchIcon}
+                        >
+                            <Text>Clear all filters and try again.</Text>
+                            <Button variant="link" onClick={() => setSearchFilter({})}>
+                                Clear filters
+                            </Button>
+                        </EmptyStateTemplate>
+                    </Bullseye>
+                </Td>
+            </Tr>
+        </Tbody>
+    );
+}
+
+export default EmptyTableResults;


### PR DESCRIPTION
## Description

Adds an empty state in the table when a request completes successfully, but the applied filters cause zero results to be returned.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Overview images:
![image](https://user-images.githubusercontent.com/1292638/232879146-7544f147-f302-4e8b-b37d-37b426514c81.png)

Overview deployments:
![image](https://user-images.githubusercontent.com/1292638/232879069-c4fd1ef9-aada-4ff6-bf6e-552b11caeeee.png)

CVE Single images:
![image](https://user-images.githubusercontent.com/1292638/232879210-3fcb053c-79a6-48b7-abc9-c4a2d44f76e4.png)

CVE Single deployments:
![image](https://user-images.githubusercontent.com/1292638/232879248-258dd7f5-0702-4a20-ba63-b67767048ab5.png)

Image single:
![image](https://user-images.githubusercontent.com/1292638/232879326-3ac93d1f-87c0-4272-83ae-74eb15e71208.png)
