### PR TITLE
fix: UX improvements for clear selections and display for filtered deployments

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/components/DeploymentSelector.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/DeploymentSelector.tsx
@@ -34,11 +34,7 @@ function DeploymentSelector({
     searchFilter,
     setSearchFilter,
 }: DeploymentSelectorProps) {
-    const {
-        isOpen: isDeploymentOpen,
-        toggleSelect: toggleIsDeploymentOpen,
-        closeSelect,
-    } = useSelectToggle();
+    const { isOpen: isDeploymentOpen, toggleSelect: toggleIsDeploymentOpen } = useSelectToggle();
     const [input, setInput] = React.useState('');
 
     const handleTextInputChange = (value: string) => {
@@ -47,7 +43,7 @@ function DeploymentSelector({
 
     const filteredDeploymentSelectMenuItems = useMemo(() => {
         let deploymentSelectMenuItems = deploymentsByNamespace.map((namespace) => {
-            let menuItems = namespace.deployments
+            const menuItems = namespace.deployments
                 .filter((deployment) =>
                     deployment.name.toLowerCase().includes(input.toString().toLowerCase())
                 )
@@ -67,7 +63,7 @@ function DeploymentSelector({
                     </MenuItem>
                 ));
             if (menuItems.length === 0) {
-                menuItems = [<MenuItem isDisabled>-</MenuItem>];
+                return null;
             }
             return (
                 <MenuGroup
@@ -96,7 +92,6 @@ function DeploymentSelector({
     const onClearSelections = () => {
         const modifiedSearchObject = { ...searchFilter };
         delete modifiedSearchObject.Deployment;
-        closeSelect();
         setSearchFilter(modifiedSearchObject);
     };
 
@@ -123,7 +118,12 @@ function DeploymentSelector({
                 </MenuList>
             </MenuContent>
             <MenuFooter>
-                <Button variant="link" isInline onClick={onClearSelections}>
+                <Button
+                    variant="link"
+                    isInline
+                    onClick={onClearSelections}
+                    isDisabled={selectedDeployments.length === 0}
+                >
                     Clear selections
                 </Button>
             </MenuFooter>

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/NamespaceSelector.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/NamespaceSelector.tsx
@@ -38,11 +38,7 @@ function NamespaceSelector({
     searchFilter,
     setSearchFilter,
 }: NamespaceSelectorProps) {
-    const {
-        isOpen: isNamespaceOpen,
-        toggleSelect: toggleIsNamespaceOpen,
-        closeSelect,
-    } = useSelectToggle();
+    const { isOpen: isNamespaceOpen, toggleSelect: toggleIsNamespaceOpen } = useSelectToggle();
     const [input, setInput] = React.useState('');
 
     const handleTextInputChange = (value: string) => {
@@ -104,7 +100,6 @@ function NamespaceSelector({
         const modifiedSearchObject = { ...searchFilter };
         delete modifiedSearchObject.Namespace;
         delete modifiedSearchObject.Deployment;
-        closeSelect();
         setSearchFilter(modifiedSearchObject);
     };
 
@@ -131,7 +126,12 @@ function NamespaceSelector({
                 </MenuList>
             </MenuContent>
             <MenuFooter>
-                <Button variant="link" isInline onClick={onClearSelections}>
+                <Button
+                    variant="link"
+                    isInline
+                    onClick={onClearSelections}
+                    isDisabled={selectedNamespaces.length === 0}
+                >
                     Clear selections
                 </Button>
             </MenuFooter>


### PR DESCRIPTION
## Description

This PR includes some UX improvements:
1. When clearing the selections using the network graph namespace/deployment selectors, we don't want to close the dropdown
2. When no namespaces are selected in the namespace selector, disable the "clear selections" button
3. When no deployments are selected in the deployment selector, disable the "clear selections" button
4. When filtering deployments in the deployment selector, if no deployment matches under a namespace, hide that whole grouping in the display. If no deployments match across namespaces, then show a "No deployments found" text


https://user-images.githubusercontent.com/4805485/232595321-dc7a07ea-3b78-4c14-a80a-ad5d7e7b3ad1.mov

