### PR TITLE
ROX-16531: Test group create/update with invalid references

### DIFF
--- a/qa-tests-backend/src/test/groovy/GroupsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/GroupsTest.groovy
@@ -4,7 +4,6 @@ import io.grpc.StatusRuntimeException
 import io.stackrox.proto.api.v1.GroupServiceOuterClass
 import io.stackrox.proto.api.v1.GroupServiceOuterClass.GetGroupsRequest
 import io.stackrox.proto.storage.AuthProviderOuterClass
-import io.stackrox.proto.storage.GroupOuterClass
 import io.stackrox.proto.storage.GroupOuterClass.Group
 import io.stackrox.proto.storage.GroupOuterClass.GroupProperties
 import io.stackrox.proto.storage.RoleOuterClass
@@ -120,7 +119,6 @@ class GroupsTest extends BaseSpecification {
         }
     }
 
-    @Unroll
     def "Test that creating group with invalid role name returns an error"() {
         when:
         def props = GroupProperties.newBuilder()
@@ -133,11 +131,10 @@ class GroupsTest extends BaseSpecification {
                 .setRoleName("non-existent")
                 .build())
         then:
-        def error = thrown(StatusRuntimeException.class)
+        def error = thrown(StatusRuntimeException)
         assert error.getStatus().getCode() == Status.Code.INVALID_ARGUMENT
     }
 
-    @Unroll
     def "Test that creating group with invalid auth provider id returns an error"() {
         when:
         def props = GroupProperties.newBuilder()
@@ -148,11 +145,10 @@ class GroupsTest extends BaseSpecification {
                 .setRoleName("Admin")
                 .build())
         then:
-        def error = thrown(StatusRuntimeException.class)
+        def error = thrown(StatusRuntimeException)
         assert error.getStatus().getCode() == Status.Code.INVALID_ARGUMENT
     }
 
-    @Unroll
     def "Test that updating group with invalid role name returns an error"() {
         when:
         def group = GROUPS_WITH_IDS["QAGroupTest-Group2"]
@@ -165,11 +161,10 @@ class GroupsTest extends BaseSpecification {
                         .build()
         )
         then:
-        def error = thrown(StatusRuntimeException.class)
+        def error = thrown(StatusRuntimeException)
         assert error.getStatus().getCode() == Status.Code.INVALID_ARGUMENT
     }
 
-    @Unroll
     def "Test that updating group with invalid auth provider id returns an error"() {
         when:
         def group = GROUPS_WITH_IDS["QAGroupTest-Group2"]
@@ -184,11 +179,12 @@ class GroupsTest extends BaseSpecification {
                         .build()
         )
         then:
-        def error = thrown(StatusRuntimeException.class)
+        def error = thrown(StatusRuntimeException)
         assert error.getStatus().getCode() == Status.Code.INVALID_ARGUMENT
     }
 
     @Unroll
+    @SuppressWarnings('LineLength')
     def "Test that GetGroup and GetGroups work correctly with query args (#authProviderName, #key, #value)"() {
         when:
         "A query is made for GetGroup and GetGroups with the given params"


### PR DESCRIPTION
## Description

This is first PR in series of PRs to introduce e2e test for behaviour implemented in https://issues.redhat.com/browse/ROX-14700. 

This particular PR focuses on creating/updating groups with invalid role or auth provider references.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

1. Run new tests locally
2. + CI should be sufficient
