### PR TITLE
fix: typos in referencing central-db-image for QA Demo cluster in cut-rc workflow

### DIFF
--- a/.github/workflows/cut-rc.yml
+++ b/.github/workflows/cut-rc.yml
@@ -326,7 +326,7 @@ jobs:
         token: ${{ secrets.INFRA_TOKEN }}
         flavor: qa-demo
         name: qa-k8s-${{ needs.variables.outputs.milestone }}
-        args: main-image=quay.io/rhacs-eng/main:${{ needs.variables.outputs.milestone }},central-db-image:${{ needs.variables.outputs.milestone }}
+        args: main-image=quay.io/rhacs-eng/main:${{ needs.variables.outputs.milestone }},central-db-image=quay.io/rhacs-eng/central-db:${{ needs.variables.outputs.milestone }}
         lifespan: 48h
 
   notify-k8s-cluster:
@@ -382,7 +382,7 @@ jobs:
         token: ${{ secrets.INFRA_TOKEN }}
         flavor: openshift-4-demo
         name: openshift-4-demo-${{ needs.variables.outputs.milestone }}
-        args: central-services-helm-chart-version=${{ needs.variables.outputs.milestone }},secured-cluster-services-helm-chart-version=${{ needs.variables.outputs.milestone }},
+        args: central-services-helm-chart-version=${{ needs.variables.outputs.milestone }},secured-cluster-services-helm-chart-version=${{ needs.variables.outputs.milestone }}
         lifespan: 48h
 
   notify-os4-cluster:


### PR DESCRIPTION
## Description

* The image needs to be fully specified, not just image tag
* key and value need to be separated by `=`, not `:`

Added to milestone, so also be fixed on release branch.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Fixed based on manual cluster provisioning "gke-demo-4-0-0-rc-4-manual". 
