### PR TITLE
ROX-16552 Add basic autosense for PSPs in generated sensor.sh scripts.

### DIFF
--- a/image/templates/sensor/kubernetes/sensor.sh
+++ b/image/templates/sensor/kubernetes/sensor.sh
@@ -38,6 +38,8 @@ else
     fi
 fi
 
+SUPPORTS_PSP=$(${KUBE_COMMAND} api-resources | grep "podsecuritypolicies" -c || true)
+
 ${KUBE_COMMAND} get namespace "$NAMESPACE" &>/dev/null || ${KUBE_COMMAND} create namespace "$NAMESPACE"
 
 if ! ${KUBE_COMMAND} get secret/stackrox -n "$NAMESPACE" &>/dev/null; then
@@ -96,7 +98,7 @@ ${KUBE_COMMAND} apply -f "$DIR/sensor-netpol.yaml" || exit 1
 
 if [[ -f "$DIR/sensor-pod-security.yaml" ]]; then
   # Checking if the cluster supports pod security policies
-  if ! ${KUBE_COMMAND} api-resources | grep "podsecuritypolicies" &>/dev/null; then
+  if [[ "${SUPPORTS_PSP}" -eq 0 ]]; then
     echo "Pod security policies are not supported on this cluster. Skipping..."
   else
     echo "Creating sensor pod security policies..."
@@ -116,8 +118,12 @@ ${KUBE_COMMAND} apply -f "$DIR/admission-controller-rbac.yaml" || print_rbac_ins
 echo "Creating admission controller network policies..."
 ${KUBE_COMMAND} apply -f "$DIR/admission-controller-netpol.yaml"
 if [[ -f "$DIR/admission-controller-pod-security.yaml" ]]; then
-  echo "Creating admission controller pod security policies..."
-  ${KUBE_COMMAND} apply -f "$DIR/admission-controller-pod-security.yaml"
+  if [[ "${SUPPORTS_PSP}" -eq 0 ]]; then
+    echo "Pod security policies are not supported on this cluster. Skipping..."
+  else
+    echo "Creating admission controller pod security policies..."
+    ${KUBE_COMMAND} apply -f "$DIR/admission-controller-pod-security.yaml"
+  fi
 fi
 echo "Creating admission controller deployment..."
 ${KUBE_COMMAND} apply -f "$DIR/admission-controller.yaml"
@@ -137,8 +143,13 @@ ${KUBE_COMMAND} apply -f "$DIR/collector-rbac.yaml" || print_rbac_instructions
 echo "Creating collector network policies..."
 ${KUBE_COMMAND} apply -f "$DIR/collector-netpol.yaml"
 if [[ -f "$DIR/collector-pod-security.yaml" ]]; then
-  echo "Creating collector pod security policies..."
   ${KUBE_COMMAND} apply -f "$DIR/collector-pod-security.yaml"
+  if [[ "${SUPPORTS_PSP}" -eq 0 ]]; then
+    echo "Pod security policies are not supported on this cluster. Skipping..."
+  else
+    echo "Creating collector pod security policies..."
+    ${KUBE_COMMAND} apply -f "$DIR/collector-pod-security.yaml"
+  fi
 fi
 echo "Creating collector daemon set..."
 ${KUBE_COMMAND} apply -f "$DIR/collector.yaml"

--- a/image/templates/sensor/kubernetes/sensor.sh
+++ b/image/templates/sensor/kubernetes/sensor.sh
@@ -95,8 +95,13 @@ echo "Creating sensor network policies..."
 ${KUBE_COMMAND} apply -f "$DIR/sensor-netpol.yaml" || exit 1
 
 if [[ -f "$DIR/sensor-pod-security.yaml" ]]; then
-  echo "Creating sensor pod security policies..."
-  ${KUBE_COMMAND} apply -f "$DIR/sensor-pod-security.yaml"
+  # Checking if the cluster supports pod security policies
+  if ! ${KUBE_COMMAND} api-resources | grep "podsecuritypolicies" &>/dev/null; then
+    echo "Pod security policies are not supported on this cluster. Skipping..."
+  else
+    echo "Creating sensor pod security policies..."
+    ${KUBE_COMMAND} apply -f "$DIR/sensor-pod-security.yaml"
+  fi
 fi
 
 {{ if .CreateUpgraderSA }}

--- a/image/templates/sensor/openshift/sensor.sh
+++ b/image/templates/sensor/openshift/sensor.sh
@@ -35,8 +35,13 @@ echo "Creating sensor network policies..."
 ${KUBE_COMMAND} apply -f "$DIR/sensor-netpol.yaml"
 
 if [[ -f "$DIR/sensor-pod-security.yaml" ]]; then
-  echo "Creating sensor pod security policies..."
-  ${KUBE_COMMAND} apply -f "$DIR/sensor-pod-security.yaml"
+  # Checking if the cluster supports pod security policies
+  if ! ${KUBE_COMMAND} api-resources | grep "podsecuritypolicies" &>/dev/null; then
+    echo "Pod security policies are not supported on this cluster. Skipping..."
+  else
+    echo "Creating sensor pod security policies..."
+    ${KUBE_COMMAND} apply -f "$DIR/sensor-pod-security.yaml"
+  fi
 fi
 
 # OpenShift roles can be delayed to be added

--- a/image/templates/sensor/openshift/sensor.sh
+++ b/image/templates/sensor/openshift/sensor.sh
@@ -20,6 +20,8 @@ else
     fi
 fi
 
+SUPPORTS_PSP=$(${KUBE_COMMAND} api-resources | grep "podsecuritypolicies" -c || true)
+
 ${KUBE_COMMAND} get namespace stackrox &>/dev/null || ${KUBE_COMMAND} create namespace stackrox
 ${KUBE_COMMAND} -n stackrox annotate namespace/stackrox --overwrite openshift.io/node-selector=""
 
@@ -36,7 +38,7 @@ ${KUBE_COMMAND} apply -f "$DIR/sensor-netpol.yaml"
 
 if [[ -f "$DIR/sensor-pod-security.yaml" ]]; then
   # Checking if the cluster supports pod security policies
-  if ! ${KUBE_COMMAND} api-resources | grep "podsecuritypolicies" &>/dev/null; then
+  if [[ "${SUPPORTS_PSP}" -eq 0 ]]; then
     echo "Pod security policies are not supported on this cluster. Skipping..."
   else
     echo "Creating sensor pod security policies..."
@@ -90,8 +92,12 @@ ${KUBE_COMMAND} apply -f "$DIR/admission-controller-rbac.yaml"
 echo "Creating admission controller network policies..."
 ${KUBE_COMMAND} apply -f "$DIR/admission-controller-netpol.yaml"
 if [[ -f "$DIR/admission-controller-pod-security.yaml" ]]; then
-  echo "Creating admission controller pod security policies..."
-  ${KUBE_COMMAND} apply -f "$DIR/admission-controller-pod-security.yaml"
+  if [[ "${SUPPORTS_PSP}" -eq 0 ]]; then
+    echo "Pod security policies are not supported on this cluster. Skipping..."
+  else
+    echo "Creating admission controller pod security policies..."
+    ${KUBE_COMMAND} apply -f "$DIR/admission-controller-pod-security.yaml"
+  fi
 fi
 echo "Creating admission controller deployment..."
 ${KUBE_COMMAND} apply -f "$DIR/admission-controller.yaml"
@@ -105,8 +111,13 @@ ${KUBE_COMMAND} apply -f "$DIR/collector-rbac.yaml"
 echo "Creating collector network policies..."
 ${KUBE_COMMAND} apply -f "$DIR/collector-netpol.yaml"
 if [[ -f "$DIR/collector-pod-security.yaml" ]]; then
-  echo "Creating collector pod security policies..."
   ${KUBE_COMMAND} apply -f "$DIR/collector-pod-security.yaml"
+  if [[ "${SUPPORTS_PSP}" -eq 0 ]]; then
+    echo "Pod security policies are not supported on this cluster. Skipping..."
+  else
+    echo "Creating collector pod security policies..."
+    ${KUBE_COMMAND} apply -f "$DIR/collector-pod-security.yaml"
+  fi
 fi
 echo "Creating collector daemon set..."
 ${KUBE_COMMAND} apply -f "$DIR/collector.yaml"


### PR DESCRIPTION
## Description

When we generate installation bundle for sensor, there are cases when we cannot detect wether the user has disabled PSPs or not. So we generate a sensor installation script including PSPs, even if the target cluster does not support it.

This introduce a last "fail-safe" mechanism, to ignore the PSPs in a sensor installation bundle if the target k8s cluster does not support it. The ideal situation would be to not generate them altogether. But in the case that these PSPs manifests are generated, at least the installation script will not fail if the cluster cannot install them. 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] ~~Evaluated and added CHANGELOG entry if required~~
- [ ] ~~Determined and documented upgrade steps~~
- [ ] ~~Documented user facing changes (create PR based on [openshift/openshift-docs]~~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed
 
I've tested that the sensor.sh script detects when the PSPs are available or not in a cluster, and will install them conditionally. 
