### PR TITLE
ROX-15145: Add environment variables as alternative information source for roxctl global command line flags

### DIFF
--- a/pkg/env/booleansetting.go
+++ b/pkg/env/booleansetting.go
@@ -5,24 +5,29 @@ import (
 	"strconv"
 )
 
-// BooleanSetting represents an environment variable which should be parsed into a boolean
+// BooleanSetting represents an environment variable which should be parsed into a boolean.
 type BooleanSetting struct {
 	envVar         string
 	defaultBoolean bool
 	unchangeable   bool
 }
 
-// EnvVar returns the string name of the environment variable
+// EnvVar returns the string name of the environment variable.
 func (d *BooleanSetting) EnvVar() string {
 	return d.envVar
 }
 
-// Setting returns the string form of the boolean environment variable
+// Setting returns the string form of the boolean environment variable.
 func (d *BooleanSetting) Setting() string {
 	return strconv.FormatBool(d.BooleanSetting())
 }
 
-// BooleanSetting returns the bool object represented by the environment variable
+// DefaultBooleanSetting returns the bool object that is returned if the environment variable is empty.
+func (d *BooleanSetting) DefaultBooleanSetting() bool {
+	return d.defaultBoolean
+}
+
+// BooleanSetting returns the bool object represented by the environment variable.
 func (d *BooleanSetting) BooleanSetting() bool {
 	if d.unchangeable {
 		return d.defaultBoolean
@@ -46,7 +51,7 @@ func RegisterBooleanSetting(envVar string, defaultBoolean bool) *BooleanSetting 
 	return s
 }
 
-// RegisterPermanentBooleanSetting global registers and returns a new boolean setting that is always locked to the default value
+// RegisterPermanentBooleanSetting global registers and returns a new boolean setting that is always locked to the default value.
 func RegisterPermanentBooleanSetting(envVar string, defaultBoolean bool) *BooleanSetting {
 	s := &BooleanSetting{
 		envVar:         envVar,

--- a/pkg/env/roxctl.go
+++ b/pkg/env/roxctl.go
@@ -1,13 +1,13 @@
 package env
 
 var (
-	// CACertFileEnv allows to pass a custom CA certificate file (path to a certificate file in PEN format).
+	// CACertFileEnv allows to pass a custom CA certificate file (path to a certificate file in PEM format).
 	CACertFileEnv = RegisterSetting("ROX_CA_CERT_FILE")
 
-	// ClientForceHTTP1Env ...
+	// ClientForceHTTP1Env configures the use of HTTP/1 for all connections (advanced; only use if you encounter connection issues).
 	ClientForceHTTP1Env = RegisterBooleanSetting("ROX_CLIENT_FORCE_HTTP1", false)
 
-	// DirectGRPCEnv ...
+	// DirectGRPCEnv configures the use of direct gRPC (advanced; only use if you encounter connection issues).
 	DirectGRPCEnv = RegisterBooleanSetting("ROX_DIRECT_GRPC_CLIENT", false)
 
 	// EndpointEnv specifies the central endpoint to use for commandline operations.
@@ -19,8 +19,8 @@ var (
 	// InsecureClientSkipTLSVerifyEnv allows commandline clients to skip the TLS certificate validation.
 	InsecureClientSkipTLSVerifyEnv = RegisterBooleanSetting("ROX_INSECURE_CLIENT_SKIP_TLS_VERIFY", false)
 
-	// NoColorPrinterEnv disables commandline color output.
-	NoColorPrinterEnv = RegisterBooleanSetting("ROX_NO_COLOR_PRINTER", false)
+	// NoColorEnv disables commandline color output.
+	NoColorEnv = RegisterBooleanSetting("ROX_NO_COLOR", false)
 
 	// PasswordEnv specifies the central admin password to use for commandline operations.
 	PasswordEnv = RegisterSetting("ROX_ADMIN_PASSWORD")

--- a/pkg/env/roxctl.go
+++ b/pkg/env/roxctl.go
@@ -1,11 +1,35 @@
 package env
 
 var (
+	// CACertFileEnv allows to pass a custom CA certificate file (path to a certificate file in PEN format).
+	CACertFileEnv = RegisterSetting("ROX_CA_CERT_FILE")
+
+	// ClientForceHTTP1Env ...
+	ClientForceHTTP1Env = RegisterBooleanSetting("ROX_CLIENT_FORCE_HTTP1", false)
+
+	// DirectGRPCEnv ...
+	DirectGRPCEnv = RegisterBooleanSetting("ROX_DIRECT_GRPC_CLIENT", false)
+
 	// EndpointEnv specifies the central endpoint to use for commandline operations.
 	EndpointEnv = RegisterSetting("ROX_ENDPOINT")
 
+	// InsecureClientEnv enables insecure client connection options (DANGEROUS, USE WITH CAUTION).
+	InsecureClientEnv = RegisterBooleanSetting("ROX_INSECURE_CLIENT", false)
+
+	// InsecureClientSkipTLSVerifyEnv allows commandline clients to skip the TLS certificate validation.
+	InsecureClientSkipTLSVerifyEnv = RegisterBooleanSetting("ROX_INSECURE_CLIENT_SKIP_TLS_VERIFY", false)
+
+	// NoColorPrinterEnv disables commandline color output.
+	NoColorPrinterEnv = RegisterBooleanSetting("ROX_NO_COLOR_PRINTER", false)
+
 	// PasswordEnv specifies the central admin password to use for commandline operations.
 	PasswordEnv = RegisterSetting("ROX_ADMIN_PASSWORD")
+
+	// PlaintextEnv specifies whether the commandline operations should communicate over unencrypted channesl.
+	PlaintextEnv = RegisterBooleanSetting("ROX_PLAINTEXT", false)
+
+	// ServerEnv specifies the central server name to use for commandline operations.
+	ServerEnv = RegisterSetting("ROX_SERVER_NAME")
 
 	// TokenEnv is the variable that clients can source for commandline operations.
 	TokenEnv = RegisterSetting("ROX_API_TOKEN")

--- a/roxctl/common/flags/endpoint.go
+++ b/roxctl/common/flags/endpoint.go
@@ -14,18 +14,33 @@ var (
 	endpoint        string
 	endpointChanged *bool
 
-	serverName string
-	directGRPC bool
-	forceHTTP1 bool
+	serverName    string
+	serverNameSet *bool
+	directGRPC    bool
+	directGRPCSet *bool
+	forceHTTP1    bool
+	forceHTTP1Set *bool
 
 	plaintext    bool
 	plaintextSet *bool
 	insecure     bool
+	insecureSet  *bool
 
 	insecureSkipTLSVerify    bool
 	insecureSkipTLSVerifySet *bool
 
-	caCertFile string
+	caCertFile    string
+	caCertFileSet *bool
+)
+
+const (
+	caCertFileFlagName            = "ca"
+	directGRPCFlagName            = "direct-grpc"
+	forceHTTP1FlagName            = "force-http1"
+	insecureFlagName              = "insecure"
+	insecureSkipTLSVerifyFlagName = "insecure-skip-tls-verify"
+	plaintextFlagName             = "plaintext"
+	serverNameFlagName            = "server-name"
 )
 
 // AddConnectionFlags adds connection-related flags to roxctl.
@@ -33,16 +48,30 @@ func AddConnectionFlags(c *cobra.Command) {
 	c.PersistentFlags().StringVarP(&endpoint, "endpoint", "e", "localhost:8443",
 		"endpoint for service to contact. Alternatively, set the endpoint via the ROX_ENDPOINT environment variable")
 	endpointChanged = &c.PersistentFlags().Lookup("endpoint").Changed
-	c.PersistentFlags().StringVarP(&serverName, "server-name", "s", "", "TLS ServerName to use for SNI (if empty, derived from endpoint)")
-	c.PersistentFlags().BoolVar(&directGRPC, "direct-grpc", false, "Use direct gRPC (advanced; only use if you encounter connection issues)")
-	c.PersistentFlags().BoolVar(&forceHTTP1, "force-http1", false, "Always use HTTP/1 for all connections (advanced; only use if you encounter connection issues)")
+	c.PersistentFlags().StringVarP(&serverName, serverNameFlagName, "s", "", "TLS ServerName to use for SNI "+
+		"(if empty, derived from endpoint). Alternately, set the server name via the ROX_SERVER_NAME environment variable")
+	serverNameSet = &c.PersistentFlags().Lookup(serverNameFlagName).Changed
+	c.PersistentFlags().BoolVar(&directGRPC, directGRPCFlagName, false, "Use direct gRPC "+""+
+		"(advanced; only use if you encounter connection issues). Alternately, enable by setting the ROX_DIRECT_GRPC_CLIENT "+
+		"environment variable to true")
+	directGRPCSet = &c.PersistentFlags().Lookup(directGRPCFlagName).Changed
+	c.PersistentFlags().BoolVar(&forceHTTP1, forceHTTP1FlagName, false, "Always use HTTP/1 for all connections "+
+		"(advanced; only use if you encounter connection issues). Alternatively, enable by setting the ROX_CLIENT_FORCE_HTTP1 "+
+		"environment variable to true")
+	forceHTTP1Set = &c.PersistentFlags().Lookup(forceHTTP1FlagName).Changed
 
-	c.PersistentFlags().BoolVar(&plaintext, "plaintext", false, "Use a plaintext (unencrypted) connection; only works in conjunction with --insecure")
-	plaintextSet = &c.PersistentFlags().Lookup("plaintext").Changed
-	c.PersistentFlags().BoolVar(&insecure, "insecure", false, "Enable insecure connection options (DANGEROUS; USE WITH CAUTION)")
-	c.PersistentFlags().BoolVar(&insecureSkipTLSVerify, "insecure-skip-tls-verify", false, "Skip TLS certificate validation")
-	insecureSkipTLSVerifySet = &c.PersistentFlags().Lookup("insecure-skip-tls-verify").Changed
-	c.PersistentFlags().StringVar(&caCertFile, "ca", "", "Custom CA certificate to use (PEM format)")
+	c.PersistentFlags().BoolVar(&plaintext, plaintextFlagName, false, "Use a plaintext (unencrypted) connection; "+
+		"only works in conjunction with --insecure. Alternatively can be enabled by setting the ROX_PLAINTEXT environment variable to true")
+	plaintextSet = &c.PersistentFlags().Lookup(plaintextFlagName).Changed
+	c.PersistentFlags().BoolVar(&insecure, insecureFlagName, false, "Enable insecure connection options (DANGEROUS; USE WITH CAUTION). "+
+		"Alternatively, enable insecure connection options by setting the ROX_INSECURE_CLIENT environment variable to true")
+	insecureSet = &c.PersistentFlags().Lookup(insecureFlagName).Changed
+	c.PersistentFlags().BoolVar(&insecureSkipTLSVerify, insecureSkipTLSVerifyFlagName, false, "Skip TLS certificate validation. "+
+		"Alternatively, disable TLS certivicate validation by setting the ROX_INSECURE_CLIENT_SKIP_TLS_VERIFY environment variable to true")
+	insecureSkipTLSVerifySet = &c.PersistentFlags().Lookup(insecureSkipTLSVerifyFlagName).Changed
+	c.PersistentFlags().StringVar(&caCertFile, caCertFileFlagName, "", "Custom CA certificate to use (PEM format). "+
+		"Alternatively pass the file path using the ROX_CA_CERT_FILE environment variable")
+	caCertFileSet = &c.PersistentFlags().Lookup(caCertFileFlagName).Changed
 }
 
 // EndpointAndPlaintextSetting returns the Central endpoint to connect to, as well as a bool indicating whether to
@@ -72,8 +101,9 @@ func EndpointAndPlaintextSetting() (string, bool, error) {
 		return "", false, errox.InvalidArgs.Newf("invalid scheme %q in endpoint URL, the scheme should be: http(s)://<endpoint>:<port>", u.Scheme)
 	}
 
-	if *plaintextSet {
-		if plaintext != usePlaintext {
+	if *plaintextSet ||
+		(!*plaintextSet && env.PlaintextEnv.BooleanSetting() != env.PlaintextEnv.DefaultBooleanSetting()) {
+		if booleanFlagOrSettingValue(plaintext, *plaintextSet, env.PlaintextEnv) != usePlaintext {
 			return "", false, errox.InvalidArgs.Newf("endpoint URL scheme %q is incompatible with --plaintext=%v setting", u.Scheme, plaintext)
 		}
 	}
@@ -83,34 +113,38 @@ func EndpointAndPlaintextSetting() (string, bool, error) {
 
 // ServerName returns the specified ServerName.
 func ServerName() string {
-	return serverName
+	return flagOrSettingValue(serverName, *serverNameSet, env.ServerEnv)
 }
 
 // UseDirectGRPC returns whether to use gRPC directly, i.e., without a proxy.
 func UseDirectGRPC() bool {
-	return directGRPC
+	return booleanFlagOrSettingValue(directGRPC, *directGRPCSet, env.DirectGRPCEnv)
 }
 
 // ForceHTTP1 indicates that the HTTP/1 should be used for all outgoing connections.
 func ForceHTTP1() bool {
-	return forceHTTP1
+	return booleanFlagOrSettingValue(forceHTTP1, *forceHTTP1Set, env.ClientForceHTTP1Env)
 }
 
 // UseInsecure returns whether to use insecure connection behavior.
 func UseInsecure() bool {
-	return insecure
+	return booleanFlagOrSettingValue(insecure, *insecureSet, env.InsecureClientEnv)
 }
 
 // SkipTLSValidation returns a bool that indicates the value of the `--insecure-skip-tls-verify` flag, with `nil`
 // indicating that it was left at its default value.
 func SkipTLSValidation() *bool {
 	if !*insecureSkipTLSVerifySet {
-		return nil
+		if env.InsecureClientSkipTLSVerifyEnv.BooleanSetting() == env.InsecureClientSkipTLSVerifyEnv.DefaultBooleanSetting() {
+			return nil
+		}
+		envSetting := env.InsecureClientSkipTLSVerifyEnv.BooleanSetting()
+		return &envSetting
 	}
 	return &insecureSkipTLSVerify
 }
 
 // CAFile returns the file for custom CA certificates.
 func CAFile() string {
-	return caCertFile
+	return flagOrSettingValue(caCertFile, *caCertFileSet, env.CACertFileEnv)
 }

--- a/roxctl/common/flags/env_flag.go
+++ b/roxctl/common/flags/env_flag.go
@@ -17,3 +17,18 @@ func flagOrSettingValue(flagValue string, flagChanged bool, setting env.Setting)
 	}
 	return flagValue
 }
+
+// booleanFlagOrSettingValue will either return the following:
+// - the flag value, if the flag value is not the default value (i.e. flagChanged != false).
+// - the setting's boolean value, if the flag value is the default value (i.e. flagChanged == false)
+// _and_ the setting's value is not the environment variable default value.
+// - the default value, if the flag value is the default value (i.e. flagChanged == false) and the setting's value is
+// the environment variable default value.
+func booleanFlagOrSettingValue(flagValue bool, flagChanged bool, setting *env.BooleanSetting) bool {
+	if !flagChanged {
+		if setting.BooleanSetting() != setting.DefaultBooleanSetting() {
+			return setting.BooleanSetting()
+		}
+	}
+	return flagValue
+}

--- a/roxctl/common/flags/env_flag_test.go
+++ b/roxctl/common/flags/env_flag_test.go
@@ -29,3 +29,26 @@ func TestFlagOrSettingValue(t *testing.T) {
 	AddPassword(cmd)
 	assert.Equal(t, "some-test-value", Password())
 }
+
+func TestBooleanFlagOrSettingValue(t *testing.T) {
+	// 1. Default, unchanged flag value and setting not set should lead to the default value being returned.
+	cmd := &cobra.Command{}
+
+	AddConnectionFlags(cmd)
+
+	assert.False(t, UseInsecure())
+
+	// 2. Change the flag value. The changed flag value should be returned, irrespective of whether the setting is set.
+	t.Setenv("ROX_INSECURE_CLIENT", "true")
+	cmd = &cobra.Command{}
+	AddConnectionFlags(cmd)
+	err := cmd.PersistentFlags().Set("insecure", "false")
+	assert.NoError(t, err)
+	assert.Equal(t, false, UseInsecure())
+
+	// 3. Default flag value and setting's value set should return the settings value instead.
+	t.Setenv("ROX_INSECURE_CLIENT", "true")
+	cmd = &cobra.Command{}
+	AddConnectionFlags(cmd)
+	assert.Equal(t, true, UseInsecure())
+}

--- a/roxctl/common/flags/no_color.go
+++ b/roxctl/common/flags/no_color.go
@@ -2,6 +2,7 @@ package flags
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/stackrox/rox/pkg/env"
 )
 
 const (
@@ -16,7 +17,7 @@ func AddNoColor(c *cobra.Command) {
 	// Printer is required to initialize commands thus we cannot follow
 	// https://github.com/fatih/color/blob/v1.13.0/doc.go#L109-L119
 	var noColor bool
-	c.PersistentFlags().BoolVar(&noColor, noColorName, false, "Disable color output")
+	c.PersistentFlags().BoolVar(&noColor, noColorName, false, "Disable color output. Alternately disable the color output by setting the ROX_NO_COLOR_PRINTER environment variable")
 }
 
 // HasNoColor returns true is passed args contain noColorFlag
@@ -25,6 +26,9 @@ func HasNoColor(args []string) bool {
 		if arg == noColorFlag {
 			return true
 		}
+	}
+	if env.NoColorPrinterEnv.BooleanSetting() != env.NoColorPrinterEnv.DefaultBooleanSetting() {
+		return env.NoColorPrinterEnv.BooleanSetting()
 	}
 	return false
 }

--- a/roxctl/common/flags/no_color.go
+++ b/roxctl/common/flags/no_color.go
@@ -17,7 +17,7 @@ func AddNoColor(c *cobra.Command) {
 	// Printer is required to initialize commands thus we cannot follow
 	// https://github.com/fatih/color/blob/v1.13.0/doc.go#L109-L119
 	var noColor bool
-	c.PersistentFlags().BoolVar(&noColor, noColorName, false, "Disable color output. Alternately disable the color output by setting the ROX_NO_COLOR_PRINTER environment variable")
+	c.PersistentFlags().BoolVar(&noColor, noColorName, false, "Disable color output. Alternately disable the color output by setting the ROX_NO_COLOR environment variable")
 }
 
 // HasNoColor returns true is passed args contain noColorFlag
@@ -27,8 +27,8 @@ func HasNoColor(args []string) bool {
 			return true
 		}
 	}
-	if env.NoColorPrinterEnv.BooleanSetting() != env.NoColorPrinterEnv.DefaultBooleanSetting() {
-		return env.NoColorPrinterEnv.BooleanSetting()
+	if env.NoColorEnv.BooleanSetting() != env.NoColorEnv.DefaultBooleanSetting() {
+		return env.NoColorEnv.BooleanSetting()
 	}
 	return false
 }


### PR DESCRIPTION
## Description

Some roxctl command line flags already have associated environment variables. Others don't.
The goal of this change is to harmonize the way roxctl commands can be configured by adding environment variables as additional configuration source for some of the command line flags.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
~~- [ ] Determined and documented upgrade steps~~
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

CI should be sufficient to ensure the basic functions are not broken.

Manual tests will be performed to check roxctl commands also behave as expected if configured through environment variables.

Test `ROX_NO_COLOR`:
![Screenshot 2023-04-21 at 10 29 42](https://user-images.githubusercontent.com/91869377/233592338-788034ab-7a7c-4355-aa98-b0560509bd6f.png)

Various manual tests:
```bash
# Note: The value of ROX_API_TOKEN for the tests below is invalid (matches token for another cluster)
ybrillou@ybrillou-mac stackrox % ROX_ENDPOINT="https://localhost:8000" ROX_PLAINTEXT=false ROX_INSECURE_CLIENT=true roxctl central whoami
WARN:	The remote endpoint failed TLS validation. This will be a fatal error in future releases.
Please do one of the following at your earliest convenience:
  1. Obtain a valid certificate for your Central instance/Load Balancer.
  2. Use the --ca option to specify a custom CA certificate (PEM format). This Certificate can be obtained by
     running "roxctl central cert".
  3. Update all your roxctl usages to pass the --insecure-skip-tls-verify option, in order to
     suppress this warning and retain the old behavior of not validating TLS certificates in
     the future (NOT RECOMMENDED).


WARN:	Certificate validation error: x509: “CENTRAL_SERVICE: Central” certificate is not trusted
ERROR:	rpc error: code = Unauthenticated desc = credentials not found: token validation failed

# Test skip TLS verify
ybrillou@ybrillou-mac stackrox % ROX_ENDPOINT="https://localhost:8000" ROX_PLAINTEXT=false ROX_INSECURE_CLIENT=true ROX_INSECURE_CLIENT_SKIP_TLS_VERIFY=true roxctl central whoami
ERROR:	rpc error: code = Unauthenticated desc = credentials not found: token validation failed

# Reference for test of plaintext
ybrillou@ybrillou-mac stackrox % ROX_ENDPOINT="https://localhost:8000" ROX_PLAINTEXT=false ROX_INSECURE_CLIENT=false ROX_INSECURE_CLIENT_SKIP_TLS_VERIFY=true roxctl central whoami
ERROR:	rpc error: code = Unauthenticated desc = credentials not found: token validation failed

# Plaintext with https -> output shows incompatible value taken into account
ybrillou@ybrillou-mac stackrox % ROX_ENDPOINT="https://localhost:8000" ROX_PLAINTEXT=true ROX_INSECURE_CLIENT=false ROX_INSECURE_CLIENT_SKIP_TLS_VERIFY=true roxctl central whoami
ERROR:	could not get endpoint for gRPC connection: could not get endpoint: endpoint URL scheme "https" is incompatible with --plaintext=false setting

# Missing insecure setup
ybrillou@ybrillou-mac stackrox % ROX_ENDPOINT="http://localhost:8000" ROX_PLAINTEXT=true ROX_INSECURE_CLIENT=false ROX_INSECURE_CLIENT_SKIP_TLS_VERIFY=true roxctl central whoami 
ERROR:	plaintext connection mode must be used in conjunction with --insecure

# Plaintext with insecure (but not listening HTTP server)
ybrillou@ybrillou-mac stackrox % ROX_ENDPOINT="http://localhost:8000" ROX_PLAINTEXT=true ROX_INSECURE_CLIENT=true ROX_INSECURE_CLIENT_SKIP_TLS_VERIFY=true roxctl central whoami
ERROR:	rpc error: code = Unavailable desc = transport: receiving gRPC response from remote endpoint: 400 Bad Request, content-type 

```