### PR TITLE
Test count of policies independent of severity in Configuration Management

### DIFF
--- a/ui/apps/platform/cypress/integration/configmanagement/dashboard.test.js
+++ b/ui/apps/platform/cypress/integration/configmanagement/dashboard.test.js
@@ -257,53 +257,21 @@ describe('Configuration Management Dashboard', () => {
         }, entitiesKey);
     });
 
-    // This test might fail in local deployment.
-    // ROX-15985: skip until decision whether valid to assume high severity violations.
-    it.skip('should show the same number of high severity policies in the "Policy Violations By Severity" widget as it does in the Policies list', () => {
+    it('should show the same number of policies in the "Policy Violations By Severity" widget as it does in the Policies list', () => {
         const entitiesKey = 'policies';
 
         visitConfigurationManagementDashboard();
 
+        // Click the first bullet list link.
+        // All bases are covered, because policies without violations is a possible link.
         policyViolationsBySeverityLinkShouldMatchList(
-            `${selectors.getWidget('Policy Violations by Severity')} a:contains("rated as high")`,
-            /^(\d+) rated as high/,
+            `${selectors.getWidget('Policy Violations by Severity')} .widget-detail-bullet:eq(0) a`,
+            /^(\d+) /,
             entitiesKey
         );
 
-        cy.location('search').should('contain', '[Severity]=HIGH_SEVERITY');
-        cy.location('search').should('contain', '[Policy%20Status]=Fail');
-    });
-
-    // This test might fail in local deployment.
-    it('should show the same number of low severity policies in the "Policy Violations By Severity" widget as it does in the Policies list', () => {
-        const entitiesKey = 'policies';
-
-        visitConfigurationManagementDashboard();
-
-        policyViolationsBySeverityLinkShouldMatchList(
-            `${selectors.getWidget('Policy Violations by Severity')} a:contains("rated as low")`,
-            /^(\d+) rated as low/,
-            entitiesKey
-        );
-
-        cy.location('search').should('contain', '[Severity]=LOW_SEVERITY');
-        cy.location('search').should('contain', '[Policy%20Status]=Fail');
-    });
-
-    it('should show the same number of policies without violations in the "Policy Violations By Severity" widget as it does in the Policies list', () => {
-        const entitiesKey = 'policies';
-
-        visitConfigurationManagementDashboard();
-
-        policyViolationsBySeverityLinkShouldMatchList(
-            `${selectors.getWidget(
-                'Policy Violations by Severity'
-            )} a:contains("without violations")`,
-            /^(\d+) (policy|policies)/,
-            entitiesKey
-        );
-
-        cy.location('search').should('contain', '[Policy%20Status]=Pass');
+        cy.location('search').should('contain', '[Disabled]=False');
+        cy.location('search').should('contain', '[Policy%20Status]='); // either Fail (for rated as Whatever) or Pass (for policies without violations)
     });
 
     it('clicking the "CIS Standard Across Clusters" widget\'s "passing controls" link should take you to the controls list and filter by passing controls', () => {


### PR DESCRIPTION
## Description

### Problem

Tests of Policy Violations by Severity widget fail intermittently.

### Analysis

Dave Vail found that vulnerabilities (and therefore policy failures) change as image versions change.

The objective of the test is to compare counts from a link. Which severity of policy violations is not significant.

* `'should show the same number of high severity policies in the "Policy Violations By Severity" widget as it does in the Policies list'`
* `'should show the same number of low severity policies in the "Policy Violations By Severity" widget as it does in the Policies list'`
* `'should show the same number of policies without violations in the "Policy Violations By Severity" widget as it does in the Policies list'`

### Solution

Merge the 3 tests to compare the count of policies for the first link in the bullet list of the widget.

All bases are covered, because **policies without violations** is a possible link.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed

1. `yarn start` in ui
2. `yarn cypress-open` in ui/apps/platform
    * cypress/integration/configmanagement/dashboard.test.js

        The first link is **rated as high**
        ![configmanagement_local](https://user-images.githubusercontent.com/11862657/232880497-829e4aa2-23be-4f99-9cc4-c47766c10997.png)

        The counts match in the filtered list
        ![configmanagement_local_test](https://user-images.githubusercontent.com/11862657/232880548-66cb90c8-ffec-4bcb-a0f4-a668c5dfa858.png)

After merge, look for success on the next gke-latest-ui-e2e-tests in nightlies, which has failed with screenshot
![configmanagement_latest](https://user-images.githubusercontent.com/11862657/232880049-0966fbdc-a3c0-4ca7-8f5d-a23c41d30f7f.png)
