### PR TITLE
Revert "Upgrade junit2jira (#5672)"

### DIFF
--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -1221,17 +1221,9 @@ store_test_results() {
     if ! is_in_PR_context; then
     {
         info "Creating JIRA task for failures found in $from"
-        curl --retry 5 -SsfL https://github.com/stackrox/junit2jira/releases/download/v0.0.6/junit2jira -o junit2jira && \
+        curl --retry 5 -SsfL https://github.com/stackrox/junit2jira/releases/download/v0.0.5/junit2jira -o junit2jira && \
         chmod +x junit2jira && \
-        ./junit2jira \
-            -base-link "$(echo "$JOB_SPEC" | jq ".refs.base_link" -r)" \
-            -build-id "$BUILD_ID" \
-            -build-link "https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/$JOB_NAME/$BUILD_ID" \
-            -build-tag "$STACKROX_BUILD_TAG" \
-            -job-name "$JOB_NAME" \
-            -junit-reports-dir "$from" \
-            -orchestrator "$ORCHESTRATOR_FLAVOR" \
-            -threshold 5
+        ./junit2jira -junit-reports-dir "$from" -threshold 5
     } || true
     fi
 


### PR DESCRIPTION
This reverts commit 6f5d9f26e8af3423f5b55b365c25d2aa045c37ea.

## Description

Undefined vars cause the junit2jira block to exit.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

CI is sufficient.