### PR TITLE
Add generic type for deployment gql query response

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/DeploymentsTableContainer.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/DeploymentsTableContainer.tsx
@@ -6,7 +6,7 @@ import useURLSort from 'hooks/useURLSort';
 import useURLPagination from 'hooks/useURLPagination';
 import useURLSearch from 'hooks/useURLSearch';
 import { getHasSearchApplied, getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
-import DeploymentsTable, { deploymentListQuery } from '../Tables/DeploymentsTable';
+import DeploymentsTable, { Deployment, deploymentListQuery } from '../Tables/DeploymentsTable';
 import TableErrorComponent from '../components/TableErrorComponent';
 import { parseQuerySearchFilter } from '../searchUtils';
 
@@ -26,7 +26,9 @@ function DeploymentsTableContainer() {
         onSort: () => setPage(1),
     });
 
-    const { error, loading, data, previousData } = useQuery(deploymentListQuery, {
+    const { error, loading, data, previousData } = useQuery<{
+        deployments: Deployment[];
+    }>(deploymentListQuery, {
         variables: {
             query: getRequestQueryStringForSearchFilter({
                 ...querySearchFilter,
@@ -52,7 +54,7 @@ function DeploymentsTableContainer() {
             )}
             {tableData && (
                 <DeploymentsTable
-                    deployments={data.deployments}
+                    deployments={tableData.deployments}
                     getSortParams={getSortParams}
                     isFiltered={isFiltered}
                 />

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentsTable.tsx
@@ -30,7 +30,7 @@ export const deploymentListQuery = gql`
     }
 `;
 
-type Deployment = {
+export type Deployment = {
     id: string;
     name: string;
     imageCVECountBySeverity: {


### PR DESCRIPTION
## Description

Quick fix for page crashes on the deployments tab when filters/sorting/pages are changed due to `data` becoming `undefined`.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Load the workload CVE overview page, go to the deployments tab, and filter/sort/paginate.
