### PR TITLE
Replace LabelChip with NoEntitiesIconText in Configuration Management

### DIFF
--- a/ui/apps/platform/src/Components/PatternFly/IconText/IconText.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/IconText/IconText.tsx
@@ -19,7 +19,7 @@ function IconText({ icon, text, isTextOnly }: IconTextProps): ReactElement {
     return (
         <span className="pf-u-display-inline-flex pf-u-align-items-center">
             {icon}
-            <span className="pf-u-pl-sm">{text}</span>
+            <span className="pf-u-pl-sm pf-u-text-nowrap">{text}</span>
         </span>
     );
 }

--- a/ui/apps/platform/src/Containers/ConfigManagement/List/Clusters.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/List/Clusters.js
@@ -8,7 +8,6 @@ import {
     nonSortableHeaderClassName,
 } from 'Components/Table';
 import TableCellLink from 'Components/TableCellLink';
-import LabelChip from 'Components/LabelChip';
 import PolicyStatusIconText from 'Components/PatternFly/IconText/PolicyStatusIconText';
 import { entityListPropTypes, entityListDefaultprops } from 'constants/entityPageProps';
 import entityTypes from 'constants/entityTypes';
@@ -17,6 +16,7 @@ import { clusterSortFields } from 'constants/sortFields';
 import queryService from 'utils/queryService';
 import URLService from 'utils/URLService';
 import List from './List';
+import NoEntitiesIconText from './utilities/NoEntitiesIconText';
 import filterByPolicyStatus from './utilities/filterByPolicyStatus';
 
 const CLUSTERS_QUERY = gql`
@@ -103,7 +103,7 @@ const buildTableColumns = (match, location) => {
                 const { passingCount, failingCount, unknownCount } = complianceControlCount;
                 const totalCount = passingCount + failingCount + unknownCount;
                 if (!totalCount) {
-                    return <LabelChip text="No Controls" type="alert" />;
+                    return <NoEntitiesIconText text="No Controls" isTextOnly={pdf} />;
                 }
                 const url = URLService.getURL(match, location)
                     .push(original.id)
@@ -125,7 +125,7 @@ const buildTableColumns = (match, location) => {
             Cell: ({ original, pdf }) => {
                 const { subjectCount } = original;
                 if (!subjectCount) {
-                    return <LabelChip text="No Users & Groups" type="alert" />;
+                    return <NoEntitiesIconText text="No Users & Groups" isTextOnly={pdf} />;
                 }
                 const url = URLService.getURL(match, location)
                     .push(original.id)
@@ -149,7 +149,7 @@ const buildTableColumns = (match, location) => {
             Cell: ({ original, pdf }) => {
                 const { serviceAccountCount } = original;
                 if (!serviceAccountCount) {
-                    return <LabelChip text="No Service Accounts" type="alert" />;
+                    return <NoEntitiesIconText text="No Service Accounts" isTextOnly={pdf} />;
                 }
                 const url = URLService.getURL(match, location)
                     .push(original.id)
@@ -176,7 +176,7 @@ const buildTableColumns = (match, location) => {
             Cell: ({ original, pdf }) => {
                 const { k8sRoleCount } = original;
                 if (!k8sRoleCount) {
-                    return <LabelChip text="No Roles" type="alert" />;
+                    return <NoEntitiesIconText text="No Roles" isTextOnly={pdf} />;
                 }
                 const url = URLService.getURL(match, location)
                     .push(original.id)

--- a/ui/apps/platform/src/Containers/ConfigManagement/List/Nodes.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/List/Nodes.js
@@ -4,7 +4,6 @@ import { gql } from '@apollo/client';
 import { format } from 'date-fns';
 import pluralize from 'pluralize';
 
-import LabelChip from 'Components/LabelChip';
 import {
     defaultHeaderClassName,
     defaultColumnClassName,
@@ -18,6 +17,7 @@ import { nodeSortFields } from 'constants/sortFields';
 import queryService from 'utils/queryService';
 import URLService from 'utils/URLService';
 import List from './List';
+import NoEntitiesIconText from './utilities/NoEntitiesIconText';
 
 const QUERY = gql`
     query nodes($query: String, $pagination: Pagination) {
@@ -128,7 +128,7 @@ const buildTableColumns = (match, location, entityContext) => {
                           nodeComplianceControlCount;
                       const controlCount = passingCount + failingCount + unknownCount;
                       if (!controlCount) {
-                          return <LabelChip text="No Controls" type="alert" />;
+                          return <NoEntitiesIconText text="No Controls" isTextOnly={pdf} />;
                       }
                       const url = URLService.getURL(match, location)
                           .push(original.id)

--- a/ui/apps/platform/src/Containers/ConfigManagement/List/Roles.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/List/Roles.js
@@ -2,7 +2,6 @@ import React from 'react';
 import pluralize from 'pluralize';
 import { format } from 'date-fns';
 
-import LabelChip from 'Components/LabelChip';
 import {
     defaultHeaderClassName,
     defaultColumnClassName,
@@ -17,6 +16,7 @@ import { K8S_ROLES_QUERY } from 'queries/role';
 import queryService from 'utils/queryService';
 import URLService from 'utils/URLService';
 import List from './List';
+import NoEntitiesIconText from './utilities/NoEntitiesIconText';
 
 export const defaultRoleSort = [
     {
@@ -131,7 +131,7 @@ const buildTableColumns = (match, location, entityContext) => {
                 if (!subjectsLength) {
                     return !serviceAccountsLength ||
                         (serviceAccountsLength === 1 && serviceAccounts[0].message) ? (
-                        <LabelChip text="No Users & Groups" type="alert" />
+                        <NoEntitiesIconText text="No Users & Groups" isTextOnly={pdf} />
                     ) : (
                         'No Users & Groups'
                     );
@@ -172,7 +172,7 @@ const buildTableColumns = (match, location, entityContext) => {
                         (serviceAccountsLength === 1 && serviceAccounts[0].message)) &&
                     !subjectsLength
                 ) {
-                    return <LabelChip text="No Service Accounts" type="alert" />;
+                    return <NoEntitiesIconText text="No Service Accounts" isTextOnly={pdf} />;
                 }
                 if (!serviceAccountsLength) {
                     return 'No Service Accounts';

--- a/ui/apps/platform/src/Containers/ConfigManagement/List/utilities/NoEntitiesIconText.tsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/List/utilities/NoEntitiesIconText.tsx
@@ -1,0 +1,21 @@
+import React, { ReactElement } from 'react';
+import { ExclamationTriangleIcon } from '@patternfly/react-icons';
+
+import IconText from 'Components/PatternFly/IconText/IconText';
+
+export type NoEntitiesIconTextProps = {
+    text: string;
+    isTextOnly?: boolean;
+};
+
+/*
+ * Render No Whatevers text with icon only when it is a security problem.
+ * Otherwise, render as plain text.
+ */
+function NoEntitiesIconText({ text, isTextOnly }: NoEntitiesIconTextProps): ReactElement {
+    const icon = <ExclamationTriangleIcon color="var(--pf-global--warning-color--100)" />;
+
+    return <IconText icon={icon} text={text} isTextOnly={isTextOnly} />;
+}
+
+export default NoEntitiesIconText;


### PR DESCRIPTION
## Description

### Problem

Color text causes accessibility problems like insufficient contrast or assumption of perfect color vision.

### Analysis

Compare `LabelChip` element versus plain text for either of the following
* No whatevers: Clusters, Deployments, Namespaces, Nodes, Roles
* 0 whatevers: Images

| List            | element | text | total |
| :---            |    ---: | ---: |  ---: |
| CISControls     |       0 |    0 |     0 |
| Clusters        |       4 |    0 |     4 |
| Deployments     |       0 |    2 |     2 |
| Images          |       0 |    1 |     1 |
| Namespaces      |       0 |    4 |     4 |
| Nodes           |       1 |    0 |     1 |
| Policies        |       0 |    0 |     0 |
| Roles           |       2 |    3 |     5 |
| Secrets         |       0 |    2 |     2 |
| ServiceAccounts |       0 |    3 |     3 |
| Subjects        |       0 |    1 |     1 |
|                 |       7 |   16 |    23 |

My first impression on seeing a majority of plain text was doubt whether red text indicated a security problem (versus inconsistency).

The following code for Roles suggests it can indicate a problem:

```js
                if (!subjectsLength) {
                    return !serviceAccountsLength ||
                        (serviceAccountsLength === 1 && serviceAccounts[0].message) ? (
                        <LabelChip text="No Users & Groups" type="alert" />
                    ) : (
                        'No Users & Groups'
                    );
                }
```

```js
                if (
                    (!serviceAccountsLength ||
                        (serviceAccountsLength === 1 && serviceAccounts[0].message)) &&
                    !subjectsLength
                ) {
                    return <LabelChip text="No Service Accounts" type="alert" />;
                }
                if (!serviceAccountsLength) {
                    return 'No Service Accounts';
                }
```

### Solution

Replace occurrences of `LabelChip` element with `NoEntitiesIconText` element that renders `ExclamationTriangleIcon` in case gold for warning is more appropriate than red for danger, major error, or critical error.

As discussed in team meeting, this is a container-specific IconText component.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

### Integration testing

1. `yarn start` in ui

2. `yarn cypress-open` in ui/apps/platform

    * configmanagement/clusters.test.js
    * configmanagement/nodes.test.js
    * configmanagement/roles.test.js

### Manual testing

1. Visit /main/configmanagement/clusters renders element unconditionally

    * `LabelChip`
        ![configmanagement_clusters_LabelChip](https://user-images.githubusercontent.com/11862657/233130350-274f479d-50ad-4421-9d01-932038298a2f.png)

    * `NoEntitiesIconText`
        ![configmanagement_clusters_IconText](https://user-images.githubusercontent.com/11862657/233130417-2270acd5-f0a4-4d75-905e-e006ed16e149.png)

2. Visit /main/configmanagement/deployments renders plain text only
        ![configmanagement_deployments](https://user-images.githubusercontent.com/11862657/233130473-ccced206-efbf-4d0a-9ae8-f243f3da6b84.png)

3. Visit /main/configmanagement/namespaces renders plain text only
        ![configmanagement_namespaces](https://user-images.githubusercontent.com/11862657/233130504-045fae57-d03d-4e62-99a7-4a9787713917.png)

4. Visit /main/configmanagement/nodes renders element unconditionally

    * `LabelChip`
        ![configmanagement_nodes_LabelChip](https://user-images.githubusercontent.com/11862657/233130583-668b37c1-1301-4288-b6f7-2f1010cb8685.png)

    * `NoEntitiesIconText`
        ![configmanagement_nodes_IconText](https://user-images.githubusercontent.com/11862657/233130619-36beb9e7-2fee-4a7b-9784-294991a78b75.png)

5. Visit /main/configmanagement/roles renders element conditionally

    * `LabelChip`
        ![configmanagement_roles_LabelChip](https://user-images.githubusercontent.com/11862657/233130678-aa6f5c15-64ce-4b46-b83b-ff8f0140e8e6.png)

    * `NoEntitiesIconText` without `pf-u-text-nowrap` utility class in `IconText` component
        ![configmanagement_roles_IconText_wrap](https://user-images.githubusercontent.com/11862657/233130713-81d91949-5d4c-454f-8a63-5a2c67fc20a6.png)

    * `NoEntitiesIconText` with `pf-u-text-nowrap` utility class in `IconText` component
        ![configmanagement_roles_IconText_nowrap](https://user-images.githubusercontent.com/11862657/233130756-fb04b338-0359-4659-9adb-8428106e3752.png)

6. Visit /main/configmanagement/secrets renders plain text only
        ![configmanagement_secrets](https://user-images.githubusercontent.com/11862657/233130784-f99be898-b53c-412c-80b7-2538ff3b59f7.png)

7. Visit /main/configmanagement/serviceaccounts renders plain text only
        ![configmanagement_serviceaccounts](https://user-images.githubusercontent.com/11862657/233130820-c453b163-e01b-47d3-8dc9-12e93a57e68c.png)

8. Visit /main/configmanagement/subjects renders plain text only
        ![configmanagement_subjects](https://user-images.githubusercontent.com/11862657/233130910-5d4ad889-371b-439b-a2b3-5150fb668950.png)
