### PR TITLE
ROX-16607: Explicitly specify connection string encoding

### DIFF
--- a/image/templates/helm/stackrox-central/templates/01-central-08-external-db-configmap.yaml
+++ b/image/templates/helm/stackrox-central/templates/01-central-08-external-db-configmap.yaml
@@ -23,4 +23,5 @@ data:
         statement_timeout={{ ._rox.central.db.source.statementTimeoutMs }}
         pool_min_conns={{ ._rox.central.db.source.minConns }}
         pool_max_conns={{ ._rox.central.db.source.maxConns }}
+        client_encoding=UTF8
       {{- end }}


### PR DESCRIPTION
## Description

We are missing client_encoding in the connection string definition

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
