### PR TITLE
CI: Extend global timeout for DefaultPoliciesTest

### DIFF
--- a/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
@@ -106,6 +106,16 @@ class DefaultPoliciesTest extends BaseSpecification {
             .setCommand(["sleep", "600"]),
     ]
 
+    static final private Integer WAIT_FOR_VIOLATION_TIMEOUT = 300
+
+    // Override the global JUnit test timeout to cover a test instance waiting
+    // WAIT_FOR_VIOLATION_TIMEOUT over three test tries and the appprox. 6
+    // minutes it can take to gather debug when the first test run fails plus
+    // some padding.
+    @Rule
+    @SuppressWarnings(["JUnitPublicProperty"])
+    Timeout globalTimeout = new Timeout(3*WAIT_FOR_VIOLATION_TIMEOUT + 300 + 120, TimeUnit.SECONDS)
+
     @Shared
     private String gcrId
     @Shared
@@ -201,7 +211,7 @@ class DefaultPoliciesTest extends BaseSpecification {
         "Verify Violation for #policyName is triggered"
         // Some of these policies require scans so extend the timeout as the scan will be done inline
         // with our scanner
-        assert waitForViolation(deploymentName,  policyName, 300)
+        assert waitForViolation(deploymentName,  policyName, WAIT_FOR_VIOLATION_TIMEOUT)
 
         cleanup:
         if (policyEnabled) {

--- a/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
@@ -1,6 +1,7 @@
 import static Services.getPolicies
 import static Services.waitForViolation
 
+import java.util.concurrent.TimeUnit
 import java.util.stream.Collectors
 
 import io.grpc.StatusRuntimeException
@@ -38,6 +39,8 @@ import util.Helpers
 import util.SlackUtil
 
 import org.junit.Assume
+import org.junit.Rule
+import org.junit.rules.Timeout
 import spock.lang.IgnoreIf
 import spock.lang.Retry
 import spock.lang.Shared


### PR DESCRIPTION
## Description

The `waitForViolation` timeout for `DefaultPoliciesTest > Verify policy * is triggered` was recently increased to 300 seconds. (#5372). This is reasonable as there is evidence that the Apache Struts policy for example can take > 2 minutes to trigger ([1](https://search.ci.openshift.org/?search=Apache+Struts%3A+CVE-2017-5638+triggered+after+waiting+%5Cd%7B2%2C3%7D+seconds&maxAge=336h&context=1&type=build-log&name=stackrox.*ocp.*&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job)). However if the policy violation is not triggered within that 300 second timeout the JUnit global 800 second timeout invariably kicks off ([2](https://search.ci.openshift.org/?search=Failed+to+trigger+Apache+Struts%3A+CVE-2017-5638+after+waiting&maxAge=336h&context=1&type=build-log&name=stackrox.*ocp.*&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job)) due in part to the approx. 6 minutes spent gathering debug for the first failure. Unfortunately, the Spock test framework does not handle the JUnit test timeout very well and we lose useful debug information as well as not running the desired full 3 test tries. So this PR extends the global timeout.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

CI is sufficient.