### PR TITLE
CI: Clean up logs

### DIFF
--- a/qa-tests-backend/src/main/groovy/orchestratormanager/OpenShift.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/OpenShift.groovy
@@ -37,14 +37,13 @@ class OpenShift extends Kubernetes {
 
         try {
             oClient.projectrequests().create(projectRequest)
-            log.debug "Created namespace ${ns}"
+            log.info "Created namespace ${ns}"
             provisionDefaultServiceAccount(ns)
         } catch (KubernetesClientException kce) {
             if (kce.code != 409) {
                 throw kce
-            } else {
-                log.info("namespace already exists", kce)
             }
+            log.debug("Namespace ${ns} already exists")
         }
 
         try {

--- a/qa-tests-backend/src/main/groovy/services/GraphQLService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/GraphQLService.groovy
@@ -134,7 +134,7 @@ class GraphQLService {
         private Response parseResponse(HttpResponse response)  {
             def bsa = new ByteArrayOutputStream()
             response.getEntity().writeTo(bsa)
-            log.info "GraphQL response: " + bsa
+            log.debug "GraphQL response: " + (bsa.length() < 1024 ? bsa : bsa.take(1024) + "...")
             def returnedValue = new JsonSlurper().parseText(bsa.toString())
             return new Response(response.getStatusLine().getStatusCode(), returnedValue.data, returnedValue.errors)
         }
@@ -163,7 +163,7 @@ class GraphQLService {
                 httpPost.addHeader(header.getFirst(), header.getSecond())
             }
             def jsonContent = new JsonOutput().toJson(content)
-            log.info "GraphQL query: " + jsonContent
+            log.debug "GraphQL query: " + (jsonContent.length() < 1024 ? jsonContent : jsonContent.take(1024) + "...")
             httpPost.setEntity(new StringEntity(jsonContent))
             return httpPost
         }

--- a/qa-tests-backend/src/main/groovy/services/GraphQLService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/GraphQLService.groovy
@@ -136,7 +136,8 @@ class GraphQLService {
         private Response parseResponse(HttpResponse response)  {
             def bsa = new ByteArrayOutputStream()
             response.getEntity().writeTo(bsa)
-            log.debug "GraphQL response: " + (bsa.size() < MAX_LOG_CHARS ? bsa : bsa.toString().take(MAX_LOG_CHARS) + "...")
+            log.debug "GraphQL response: " + (
+                bsa.size() < MAX_LOG_CHARS ? bsa : bsa.toString().take(MAX_LOG_CHARS) + "...")
             def returnedValue = new JsonSlurper().parseText(bsa.toString())
             return new Response(response.getStatusLine().getStatusCode(), returnedValue.data, returnedValue.errors)
         }
@@ -165,7 +166,8 @@ class GraphQLService {
                 httpPost.addHeader(header.getFirst(), header.getSecond())
             }
             def jsonContent = new JsonOutput().toJson(content)
-            log.debug "GraphQL query: " + (jsonContent.length() < MAX_LOG_CHARS ? jsonContent : jsonContent.take(MAX_LOG_CHARS) + "...")
+            log.debug "GraphQL query: " + (
+                jsonContent.length() < MAX_LOG_CHARS ? jsonContent : jsonContent.take(MAX_LOG_CHARS) + "...")
             httpPost.setEntity(new StringEntity(jsonContent))
             return httpPost
         }

--- a/qa-tests-backend/src/main/groovy/services/GraphQLService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/GraphQLService.groovy
@@ -113,6 +113,8 @@ class GraphQLService {
         private final List<Tuple2<String, String>> defaultHeaders
         private final String addr
 
+        private static final Integer MAX_LOG_CHARS = 1024
+
         Poster(String addr) {
             this.addr = addr
             this.defaultHeaders = [new Tuple2<String, String>("Content-Type", "application/json")]
@@ -134,7 +136,7 @@ class GraphQLService {
         private Response parseResponse(HttpResponse response)  {
             def bsa = new ByteArrayOutputStream()
             response.getEntity().writeTo(bsa)
-            log.debug "GraphQL response: " + (bsa.length() < 1024 ? bsa : bsa.take(1024) + "...")
+            log.debug "GraphQL response: " + (bsa.size() < MAX_LOG_CHARS ? bsa : bsa.toString().take(MAX_LOG_CHARS) + "...")
             def returnedValue = new JsonSlurper().parseText(bsa.toString())
             return new Response(response.getStatusLine().getStatusCode(), returnedValue.data, returnedValue.errors)
         }
@@ -163,7 +165,7 @@ class GraphQLService {
                 httpPost.addHeader(header.getFirst(), header.getSecond())
             }
             def jsonContent = new JsonOutput().toJson(content)
-            log.debug "GraphQL query: " + (jsonContent.length() < 1024 ? jsonContent : jsonContent.take(1024) + "...")
+            log.debug "GraphQL query: " + (jsonContent.length() < MAX_LOG_CHARS ? jsonContent : jsonContent.take(MAX_LOG_CHARS) + "...")
             httpPost.setEntity(new StringEntity(jsonContent))
             return httpPost
         }

--- a/qa-tests-backend/src/main/groovy/services/ImageIntegrationService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/ImageIntegrationService.groovy
@@ -159,7 +159,7 @@ class ImageIntegrationService extends BaseService {
 
     static String addStackroxScannerIntegration() {
         ImageIntegrationOuterClass.ImageIntegration existing =
-            getImageIntegrationByName(StackroxScannerIntegration.name())
+            getImageIntegrationByName(Constants.AUTO_REGISTERED_STACKROX_SCANNER_INTEGRATION)
         if (existing) {
             return existing.id
         }

--- a/qa-tests-backend/src/main/groovy/services/ImageIntegrationService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/ImageIntegrationService.groovy
@@ -158,6 +158,11 @@ class ImageIntegrationService extends BaseService {
     }
 
     static String addStackroxScannerIntegration() {
+        ImageIntegrationOuterClass.ImageIntegration existing =
+            getImageIntegrationByName(StackroxScannerIntegration.name())
+        if (existing) {
+            return existing.id
+        }
         return StackroxScannerIntegration.createDefaultIntegration()
     }
 

--- a/qa-tests-backend/src/main/groovy/services/RoleService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/RoleService.groovy
@@ -73,12 +73,14 @@ class RoleService extends BaseService {
         role
     }
 
-    static deleteRole(String name) {
+    static deleteRole(String name, Boolean deletePermissionSet = true) {
         try {
             def role = getRole(name)
             getRoleService().deleteRole(Common.ResourceByID.newBuilder().setId(name).build())
-            deletePermissionSet(role.permissionSetId)
-            log.info "Deleted role: ${name}"
+            if (deletePermissionSet) {
+                deletePermissionSet(role.permissionSetId)
+            }
+            log.info "Deleted role: ${name}, and permission set (${deletePermissionSet})"
         } catch (Exception e) {
             log.warn("Error deleting role ${name}", e)
         }

--- a/qa-tests-backend/src/main/groovy/services/RoleService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/RoleService.groovy
@@ -73,14 +73,14 @@ class RoleService extends BaseService {
         role
     }
 
-    static deleteRole(String name, Boolean deletePermissionSet = true) {
+    static deleteRole(String name, Boolean alsoDeletePermissionSet = true) {
         try {
             def role = getRole(name)
             getRoleService().deleteRole(Common.ResourceByID.newBuilder().setId(name).build())
-            if (deletePermissionSet) {
+            if (alsoDeletePermissionSet) {
                 deletePermissionSet(role.permissionSetId)
             }
-            log.info "Deleted role: ${name}, and permission set (${deletePermissionSet})"
+            log.info "Deleted role: ${name}, and permission set (${alsoDeletePermissionSet})"
         } catch (Exception e) {
             log.warn("Error deleting role ${name}", e)
         }

--- a/qa-tests-backend/src/main/groovy/services/RoleService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/RoleService.groovy
@@ -73,14 +73,22 @@ class RoleService extends BaseService {
         role
     }
 
-    static deleteRole(String name, Boolean alsoDeletePermissionSet = true) {
+    static deleteRole(String name) {
         try {
             def role = getRole(name)
             getRoleService().deleteRole(Common.ResourceByID.newBuilder().setId(name).build())
-            if (alsoDeletePermissionSet) {
-                deletePermissionSet(role.permissionSetId)
-            }
-            log.info "Deleted role: ${name}, and permission set (${alsoDeletePermissionSet})"
+            deletePermissionSet(role.permissionSetId)
+            log.info "Deleted role: ${name} and permission set")
+        } catch (Exception e) {
+            log.warn("Error deleting role ${name} or permission set", e)
+        }
+    }
+
+    static deleteRoleWithoutPermissionSet(String name, Boolean alsoDeletePermissionSet = true) {
+        try {
+            def role = getRole(name)
+            getRoleService().deleteRole(Common.ResourceByID.newBuilder().setId(name).build())
+            log.info "Deleted role: ${name}")
         } catch (Exception e) {
             log.warn("Error deleting role ${name}", e)
         }

--- a/qa-tests-backend/src/main/groovy/services/RoleService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/RoleService.groovy
@@ -55,6 +55,7 @@ class RoleService extends BaseService {
                 .setRole(role)
                 .build()
         )
+        log.info "Created role: ${role.name}"
         role
     }
 
@@ -63,6 +64,7 @@ class RoleService extends BaseService {
             def role = getRole(name)
             getRoleService().deleteRole(Common.ResourceByID.newBuilder().setId(name).build())
             deletePermissionSet(role.permissionSetId)
+            log.info "Deleted role: ${name}"
         } catch (Exception e) {
             log.warn("Error deleting role ${name}", e)
         }

--- a/qa-tests-backend/src/main/groovy/services/RoleService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/RoleService.groovy
@@ -1,6 +1,8 @@
 package services
 
 import groovy.util.logging.Slf4j
+import io.grpc.Status
+import io.grpc.StatusRuntimeException
 import io.stackrox.proto.api.v1.Common
 import io.stackrox.proto.api.v1.RoleServiceGrpc
 import io.stackrox.proto.api.v1.RoleServiceOuterClass
@@ -19,6 +21,18 @@ class RoleService extends BaseService {
 
     static getRole(String roleId) {
         return getRoleService().getRole(Common.ResourceByID.newBuilder().setId(roleId).build())
+    }
+
+    static Boolean checkRoleExists(String roleId) {
+        try {
+            getRoleService().getRole(Common.ResourceByID.newBuilder().setId(roleId).build())
+        } catch (StatusRuntimeException e) {
+            if (e.status.code == Status.Code.NOT_FOUND) {
+                return false
+            }
+            throw e
+        }
+        return true
     }
 
     static RoleServiceOuterClass.GetResourcesResponse getResources() {

--- a/qa-tests-backend/src/main/groovy/services/RoleService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/RoleService.groovy
@@ -78,7 +78,7 @@ class RoleService extends BaseService {
             def role = getRole(name)
             getRoleService().deleteRole(Common.ResourceByID.newBuilder().setId(name).build())
             deletePermissionSet(role.permissionSetId)
-            log.info "Deleted role: ${name} and permission set")
+            log.info "Deleted role: ${name} and permission set"
         } catch (Exception e) {
             log.warn("Error deleting role ${name} or permission set", e)
         }
@@ -86,9 +86,8 @@ class RoleService extends BaseService {
 
     static deleteRoleWithoutPermissionSet(String name, Boolean alsoDeletePermissionSet = true) {
         try {
-            def role = getRole(name)
             getRoleService().deleteRole(Common.ResourceByID.newBuilder().setId(name).build())
-            log.info "Deleted role: ${name}")
+            log.info "Deleted role: ${name}"
         } catch (Exception e) {
             log.warn("Error deleting role ${name}", e)
         }

--- a/qa-tests-backend/src/main/groovy/util/Helpers.groovy
+++ b/qa-tests-backend/src/main/groovy/util/Helpers.groovy
@@ -97,7 +97,7 @@ class Helpers {
 
         if (exception && (exception instanceof AssumptionViolatedException ||
                 exception.getMessage()?.contains("org.junit.AssumptionViolatedException"))) {
-            log.info("Won't collect logs for", exception)
+            log.info("Won't collect logs for: " + exception)
             return
         }
 

--- a/qa-tests-backend/src/main/groovy/util/Helpers.groovy
+++ b/qa-tests-backend/src/main/groovy/util/Helpers.groovy
@@ -23,7 +23,7 @@ class Helpers {
             try {
                 return closure()
             } catch (Exception | PowerAssertionError | SpockAssertionError t) {
-                log.debug("Caught exception. Retrying in ${pauseSecs}s", t)
+                log.debug("Caught exception. Retrying in ${pauseSecs}s. " + t)
             }
             sleep pauseSecs * 1000
         }

--- a/qa-tests-backend/src/test/groovy/AuditLogAlertsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/AuditLogAlertsTest.groovy
@@ -1,6 +1,8 @@
 import static Services.getAllResourceViolationsWithTimeout
 import static Services.getResourceViolationsWithTimeout
 
+import orchestratormanager.OrchestratorTypes
+
 import io.stackrox.proto.storage.PolicyOuterClass
 import io.stackrox.proto.storage.ScopeOuterClass
 
@@ -11,22 +13,20 @@ import services.ClusterService
 import services.PolicyService
 import util.Helpers
 
-import org.junit.Assume
+import spock.lang.Requires
 import spock.lang.Stepwise
 import spock.lang.Tag
 import spock.lang.Unroll
 import util.Env
 
+// Audit Log alerts are only supported on OpenShift 4
+@Requires({ Env.mustGetOrchestratorType() == OrchestratorTypes.OPENSHIFT })
 @Stepwise
 class AuditLogAlertsTest extends BaseSpecification {
     @Unroll
     @Tag("BAT")
     @Tag("RUNTIME")
     def "Verify Audit Log Event Source Policies Trigger: #verb - #resourceType"() {
-        given:
-        "Running on an OpenShift 4 cluster"
-        Assume.assumeTrue("Audit Log alerts are only supported on OpenShift 4", ClusterService.isOpenShift4())
-
         when:
         "Audit log collection is enabled"
         def previouslyDisabled = ClusterService.getCluster().getDynamicConfig().getDisableAuditLogs()
@@ -82,10 +82,6 @@ class AuditLogAlertsTest extends BaseSpecification {
     @Tag("BAT")
     @Tag("RUNTIME")
     def "Verify collection continues even after ACS components restarts: #component"() {
-        given:
-        "Running on an OpenShift 4 cluster"
-        Assume.assumeTrue("Audit Log alerts are only supported on OpenShift 4", ClusterService.isOpenShift4())
-
         when:
         "Audit log collection is enabled"
         def previouslyDisabled = ClusterService.getCluster().getDynamicConfig().getDisableAuditLogs()
@@ -153,10 +149,6 @@ class AuditLogAlertsTest extends BaseSpecification {
     @Tag("BAT")
     @Tag("RUNTIME")
     def "Verify collection continues when it is disabled and then re-enabled"() {
-        given:
-        "Running on an OpenShift 4 cluster"
-        Assume.assumeTrue("Audit Log alerts are only supported on OpenShift 4", ClusterService.isOpenShift4())
-
         when:
         "Audit log collection is enabled"
         def previouslyDisabled = ClusterService.getCluster().getDynamicConfig().getDisableAuditLogs()
@@ -217,10 +209,6 @@ class AuditLogAlertsTest extends BaseSpecification {
     @Tag("BAT")
     @Tag("RUNTIME")
     def "Verify collection stops when feature is is disabled"() {
-        given:
-        "Running on an OpenShift 4 cluster"
-        Assume.assumeTrue("Audit Log alerts are only supported on OpenShift 4", ClusterService.isOpenShift4())
-
         when:
         "Audit log collection is disabled"
         def previouslyDisabled = ClusterService.getCluster().getDynamicConfig().getDisableAuditLogs()

--- a/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
+++ b/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
@@ -135,8 +135,11 @@ class BaseSpecification extends Specification {
 
             String testRoleName = "Test Automation Role - ${RUN_ID}"
 
-            RoleService.deleteRole(testRoleName)
-            RoleService.createRoleWithScopeAndPermissionSet(testRoleName, UNRESTRICTED_SCOPE_ID, resourceAccess)
+            if (RoleService.getRole(testRoleName)) {
+                RoleService.deleteRole(testRoleName)
+            }
+            testRole = RoleService.createRoleWithScopeAndPermissionSet(
+                testRoleName, UNRESTRICTED_SCOPE_ID, resourceAccess)
 
             tokenResp = services.ApiTokenService.generateToken("allAccessToken-${RUN_ID}", testRoleName)
         }

--- a/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
+++ b/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
@@ -135,7 +135,7 @@ class BaseSpecification extends Specification {
 
             String testRoleName = "Test Automation Role - ${RUN_ID}"
 
-            if (RoleService.getRole(testRoleName)) {
+            if (RoleService.checkRoleExists(testRoleName)) {
                 RoleService.deleteRole(testRoleName)
             }
             testRole = RoleService.createRoleWithScopeAndPermissionSet(

--- a/qa-tests-backend/src/test/groovy/GroupsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/GroupsTest.groovy
@@ -118,7 +118,7 @@ class GroupsTest extends BaseSpecification {
             }
         }
         for (def role : ROLES) {
-            RoleService.deleteRole(role.getName())
+            RoleService.deleteRole(role.getName(), false)
         }
     }
 

--- a/qa-tests-backend/src/test/groovy/GroupsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/GroupsTest.groovy
@@ -118,7 +118,7 @@ class GroupsTest extends BaseSpecification {
             }
         }
         for (def role : ROLES) {
-            RoleService.deleteRole(role.getName(), false)
+            RoleService.deleteRoleWithoutPermissionSet(role.getName())
         }
     }
 

--- a/qa-tests-backend/src/test/groovy/SACTest.groovy
+++ b/qa-tests-backend/src/test/groovy/SACTest.groovy
@@ -208,7 +208,7 @@ class SACTest extends BaseSpecification {
                 RoleService.deleteRole(role.name)
                 RoleService.deleteAccessScope(role.accessScopeId)
             } catch (Exception e) {
-                log.error("Error deleting role ${name}", e)
+                log.error("Error deleting role ${it} or associated access scope: " + e)
             }
         }
     }

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -1015,19 +1015,21 @@ gate_pr_job() {
 openshift_ci_mods() {
     info "BEGIN OpenShift CI mods"
 
-    info "Env A-Z dump:"
-    env | sort | grep -E '^[A-Z]' || true
+    local debug="${ARTIFACT_DIR:-/tmp}/debug.txt"
+
+    echo "Env A-Z dump:" > "${debug}"
+    env | sort | grep -E '^[A-Z]' >> "${debug}" || true
 
     ensure_writable_home_dir
 
     # Prevent fatal error "detected dubious ownership in repository" from recent git.
     git config --global --add safe.directory "$(pwd)"
 
-    info "Git log:"
-    git log --oneline --decorate -n 20 || true
+    echo "Git log:" >> "${debug}"
+    git log --oneline --decorate -n 20 >> "${debug}" || true
 
-    info "Recent git refs:"
-    git for-each-ref --format='%(creatordate) %(refname)' --sort=creatordate | tail -20
+    echo "Recent git refs:" >> "${debug}"
+    git for-each-ref --format='%(creatordate) %(refname)' --sort=creatordate | tail -20 >> "${debug}"
 
     info "Current Status:"
     "$ROOT/status.sh" || true


### PR DESCRIPTION
## Description

Some of what is logged is not useful. See https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/branch-ci-stackrox-stackrox-nightlies-gke-qa-e2e-tests/1648553247369072640/artifacts/gke-qa-e2e-tests/stackrox-e2e/build-log.txt for the log used to drive this PR.

Changes following issues in the log & commit order:

- Don't try to delete the test role if it does not exist. Avoids the initial stack dump starting `io.grpc.StatusRuntimeException: NOT_FOUND: failed to retrieve role "Test Automation Role - 6672": not found`
- Don't try to create Stackrox Scanner if it already exists. Avoids repeated `io.grpc.StatusRuntimeException: INVALID_ARGUMENT: Validation error: integration with name "Stackrox Scanner" already exists: invalid arguments`. 
- GraphQL responses are very verbose and hard to imagine these are useful to anyone. If they are needed lets dump to file. For now truncate at 1024.
- AuditLogAlertsTest can be skipped at the class level to avoid running `cleanup:` blocks under GKE.
- GroupsTest should not try to delete the default permission sets.
- Don't print stack when choosing not to gather logs.
- Don't print stack when retrying in `evaluateWithRetry`. It would still be printed if it ultimately fails.
- Remove initial debug dump. Save to file instead.
- Don't print stack trace when namespace 'qa' exists (under openshift, this is already the way for !openshift.)

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

Run with `all-tests`, `ocp`.
