### PR TITLE
ROX-16557: Stop creating stackrox-db on installation - operator

### DIFF
--- a/operator/pkg/central/common/common.go
+++ b/operator/pkg/central/common/common.go
@@ -2,5 +2,5 @@ package common
 
 const (
 	// CentralPVCObsoletedAnnotation represents Central PVC has been obsoleted
-	CentralPVCObsoletedAnnotation = "platform.stackrox.io/central-pvc-obsoleted"
+	CentralPVCObsoletedAnnotation = "platform.stackrox.io/obsolete-central-pvc"
 )

--- a/operator/pkg/central/common/common.go
+++ b/operator/pkg/central/common/common.go
@@ -1,0 +1,6 @@
+package common
+
+const (
+	// CentralPVCObsoletedAnnotation represents Central PVC has been obsoleted
+	CentralPVCObsoletedAnnotation = "platform.stackrox.io/central-pvc-obsoleted"
+)

--- a/operator/pkg/central/common/common.go
+++ b/operator/pkg/central/common/common.go
@@ -1,6 +1,6 @@
 package common
 
 const (
-	// CentralPVCObsoletedAnnotation represents Central PVC has been obsoleted
-	CentralPVCObsoletedAnnotation = "platform.stackrox.io/obsolete-central-pvc"
+	// CentralPVCObsoleteAnnotation represents Central PVC has been obsoleted
+	CentralPVCObsoleteAnnotation = "platform.stackrox.io/obsolete-central-pvc"
 )

--- a/operator/pkg/central/common/common.go
+++ b/operator/pkg/central/common/common.go
@@ -8,9 +8,6 @@ const (
 )
 
 // ObsoletePVC determines if we should obsolete PVC
-func ObsoletePVC(annotations map[string]string) (obsoletePVC bool) {
-	if value, ok := annotations[CentralPVCObsoleteAnnotation]; ok {
-		obsoletePVC = strings.EqualFold("true", strings.TrimSpace(value))
-	}
-	return
+func ObsoletePVC(annotations map[string]string) bool {
+	return strings.EqualFold(annotations[CentralPVCObsoleteAnnotation], "true")
 }

--- a/operator/pkg/central/common/common.go
+++ b/operator/pkg/central/common/common.go
@@ -1,6 +1,16 @@
 package common
 
+import "strings"
+
 const (
 	// CentralPVCObsoleteAnnotation represents Central PVC has been obsoleted
 	CentralPVCObsoleteAnnotation = "platform.stackrox.io/obsolete-central-pvc"
 )
+
+// ObsoletePVC determines if we should obsolete PVC
+func ObsoletePVC(annotations map[string]string) (obsoletePVC bool) {
+	if value, ok := annotations[CentralPVCObsoleteAnnotation]; ok {
+		obsoletePVC = strings.EqualFold("true", strings.TrimSpace(value))
+	}
+	return
+}

--- a/operator/pkg/central/common/common.go
+++ b/operator/pkg/central/common/common.go
@@ -9,5 +9,5 @@ const (
 
 // ObsoletePVC determines if we should obsolete PVC
 func ObsoletePVC(annotations map[string]string) bool {
-	return strings.EqualFold(annotations[CentralPVCObsoleteAnnotation], "true")
+	return strings.EqualFold(strings.TrimSpace(annotations[CentralPVCObsoleteAnnotation]), "true")
 }

--- a/operator/pkg/central/extensions/reconcile_pvc.go
+++ b/operator/pkg/central/extensions/reconcile_pvc.go
@@ -10,6 +10,7 @@ import (
 	"github.com/operator-framework/helm-operator-plugins/pkg/extensions"
 	"github.com/pkg/errors"
 	platform "github.com/stackrox/rox/operator/apis/platform/v1alpha1"
+	"github.com/stackrox/rox/operator/pkg/central/common"
 	utils "github.com/stackrox/rox/operator/pkg/utils"
 	"github.com/stackrox/rox/pkg/sliceutils"
 	corev1 "k8s.io/api/core/v1"
@@ -134,6 +135,9 @@ func (r *reconcilePVCExtensionRun) Execute() error {
 	if r.centralObj.DeletionTimestamp != nil || r.persistence == nil {
 		return r.handleDelete()
 	}
+	if value, ok := r.centralObj.GetAnnotations()[common.CentralPVCObsoletedAnnotation]; ok && strings.ToLower(strings.TrimSpace(value)) == "true" {
+		return r.handleDelete()
+	}
 
 	if r.persistence.GetHostPath() != "" {
 		if r.persistence.GetPersistentVolumeClaim() != nil {
@@ -179,6 +183,11 @@ func (r *reconcilePVCExtensionRun) Execute() error {
 	}
 
 	if pvc == nil {
+		// Starting from 4.1, we do not create new PVCs for central.
+		if r.target == PVCTargetCentral {
+			return nil
+		}
+
 		return r.handleCreate(claimName, pvcConfig)
 	}
 

--- a/operator/pkg/central/extensions/reconcile_pvc.go
+++ b/operator/pkg/central/extensions/reconcile_pvc.go
@@ -135,7 +135,7 @@ func (r *reconcilePVCExtensionRun) Execute() error {
 	if r.centralObj.DeletionTimestamp != nil || r.persistence == nil {
 		return r.handleDelete()
 	}
-	if value, ok := r.centralObj.GetAnnotations()[common.CentralPVCObsoletedAnnotation]; ok && strings.EqualFold("true", strings.TrimSpace(value)) {
+	if value, ok := r.centralObj.GetAnnotations()[common.CentralPVCObsoleteAnnotation]; ok && strings.EqualFold("true", strings.TrimSpace(value)) {
 		return r.handleDelete()
 	}
 

--- a/operator/pkg/central/extensions/reconcile_pvc.go
+++ b/operator/pkg/central/extensions/reconcile_pvc.go
@@ -135,7 +135,7 @@ func (r *reconcilePVCExtensionRun) Execute() error {
 	if r.centralObj.DeletionTimestamp != nil || r.persistence == nil {
 		return r.handleDelete()
 	}
-	if value, ok := r.centralObj.GetAnnotations()[common.CentralPVCObsoletedAnnotation]; ok && strings.ToLower(strings.TrimSpace(value)) == "true" {
+	if value, ok := r.centralObj.GetAnnotations()[common.CentralPVCObsoletedAnnotation]; ok && strings.EqualFold("true", strings.TrimSpace(value)) {
 		return r.handleDelete()
 	}
 

--- a/operator/pkg/central/extensions/reconcile_pvc.go
+++ b/operator/pkg/central/extensions/reconcile_pvc.go
@@ -135,7 +135,7 @@ func (r *reconcilePVCExtensionRun) Execute() error {
 	if r.centralObj.DeletionTimestamp != nil || r.persistence == nil {
 		return r.handleDelete()
 	}
-	if value, ok := r.centralObj.GetAnnotations()[common.CentralPVCObsoleteAnnotation]; ok && strings.EqualFold("true", strings.TrimSpace(value)) {
+	if common.ObsoletePVC(r.centralObj.GetAnnotations()) {
 		return r.handleDelete()
 	}
 

--- a/operator/pkg/central/extensions/reconcile_pvc_test.go
+++ b/operator/pkg/central/extensions/reconcile_pvc_test.go
@@ -87,7 +87,7 @@ func TestReconcilePVCExtension(t *testing.T) {
 	emptyNotDeletedCentralWithDB.Spec.Central.DB = &platform.CentralDBSpec{}
 
 	pvcObsoletedAnnotation := map[string]string{
-		common.CentralPVCObsoletedAnnotation: "true",
+		common.CentralPVCObsoleteAnnotation: "true",
 	}
 	centralWithPvcObsoletedAnnotation := makeCentral(nil)
 	centralWithPvcObsoletedAnnotation.Annotations = pvcObsoletedAnnotation

--- a/operator/pkg/central/extensions/reconcile_pvc_test.go
+++ b/operator/pkg/central/extensions/reconcile_pvc_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/go-logr/logr"
 	platform "github.com/stackrox/rox/operator/apis/platform/v1alpha1"
+	"github.com/stackrox/rox/operator/pkg/central/common"
 	"github.com/stackrox/rox/pkg/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -85,6 +86,20 @@ func TestReconcilePVCExtension(t *testing.T) {
 	emptyNotDeletedCentralWithDB := makeCentral(nil)
 	emptyNotDeletedCentralWithDB.Spec.Central.DB = &platform.CentralDBSpec{}
 
+	pvcObsoletedAnnotation := map[string]string{
+		common.CentralPVCObsoletedAnnotation: "true",
+	}
+	centralWithPvcObsoletedAnnotation := makeCentral(nil)
+	centralWithPvcObsoletedAnnotation.Annotations = pvcObsoletedAnnotation
+	centralWithPersistenceAndPvcObsoletedAnnotation := makeCentral(&platform.Persistence{
+		PersistentVolumeClaim: &platform.PersistentVolumeClaim{
+			Size:             pointer.String("500Gi"),
+			StorageClassName: pointer.String("new-storage-class"),
+			ClaimName:        pointer.String(testPVCName),
+		},
+	})
+	centralWithPersistenceAndPvcObsoletedAnnotation.Annotations = pvcObsoletedAnnotation
+
 	externalCentralWithDB := makeCentral(nil)
 	externalCentralWithDB.Spec.Central.DB = &platform.CentralDBSpec{}
 	externalCentralWithDB.Spec.Central.DB.ConnectionStringOverride = pointer.String("foobar")
@@ -141,16 +156,31 @@ func TestReconcilePVCExtension(t *testing.T) {
 	}
 
 	cases := map[string]pvcReconciliationTestCase{
-		"empty-state-create-new-default-pvc": {
+		"empty-state-not-create-new-default-pvc": {
 			Central:      emptyNotDeletedCentral,
 			DefaultClaim: DefaultCentralPVCName,
 			Target:       PVCTargetCentral,
 			ExistingPVCs: nil,
+			ExpectedPVCs: nil,
+		},
+		"empty-state-keep-default-pvc": {
+			Central:      emptyNotDeletedCentral,
+			DefaultClaim: DefaultCentralPVCName,
+			Target:       PVCTargetCentral,
+			ExistingPVCs: []*corev1.PersistentVolumeClaim{makePVC(emptyNotDeletedCentral, DefaultCentralPVCName, defaultPVCSize, emptyStorageClass, nil)},
 			ExpectedPVCs: map[string]pvcVerifyFunc{
 				DefaultCentralPVCName: verifyMultiple(ownedBy(emptyNotDeletedCentral), withSize(defaultPVCSize), withStorageClass(emptyStorageClass)),
 			},
 		},
-
+		"empty-state-obsolete-default-pvc": {
+			Central:      centralWithPvcObsoletedAnnotation,
+			DefaultClaim: DefaultCentralPVCName,
+			Target:       PVCTargetCentral,
+			ExistingPVCs: []*corev1.PersistentVolumeClaim{makePVC(centralWithPvcObsoletedAnnotation, DefaultCentralPVCName, defaultPVCSize, emptyStorageClass, nil)},
+			ExpectedPVCs: map[string]pvcVerifyFunc{
+				DefaultCentralPVCName: verifyMultiple(notOwnedBy(emptyNotDeletedCentral), withSize(defaultPVCSize), withStorageClass(emptyStorageClass)),
+			},
+		},
 		"given-hostpath-and-pvc-should-return-error": {
 			Central: makeCentral(&platform.Persistence{
 				HostPath:              makeHostPathSpec("/tmp/hostpath"),
@@ -175,16 +205,32 @@ func TestReconcilePVCExtension(t *testing.T) {
 			},
 		},
 
-		"given-pvc-should-create-pvc-with-config": {
+		"given-pvc-should-not-create-pvc-with-config": {
 			Central:      pvcShouldCreateWithConfigCentral,
 			DefaultClaim: DefaultCentralPVCName,
 			Target:       PVCTargetCentral,
 			ExistingPVCs: nil,
+			ExpectedPVCs: nil,
+		},
+
+		"given-pvc-should-keep-pvc-with-config": {
+			Central:      pvcShouldCreateWithConfigCentral,
+			DefaultClaim: DefaultCentralPVCName,
+			Target:       PVCTargetCentral,
+			ExistingPVCs: []*corev1.PersistentVolumeClaim{makePVC(pvcShouldCreateWithConfigCentral, testPVCName, defaultPVCSize, emptyStorageClass, nil)},
 			ExpectedPVCs: map[string]pvcVerifyFunc{
 				testPVCName: verifyMultiple(ownedBy(pvcShouldCreateWithConfigCentral), withSize(resource.MustParse("50Gi")), withStorageClass("test-storage-class")),
 			},
 		},
-
+		"given-pvc-should-obsolete-pvc-with-config": {
+			Central:      centralWithPersistenceAndPvcObsoletedAnnotation,
+			DefaultClaim: DefaultCentralPVCName,
+			Target:       PVCTargetCentral,
+			ExistingPVCs: []*corev1.PersistentVolumeClaim{makePVC(centralWithPersistenceAndPvcObsoletedAnnotation, testPVCName, defaultPVCSize, emptyStorageClass, nil)},
+			ExpectedPVCs: map[string]pvcVerifyFunc{
+				testPVCName: verifyMultiple(notOwnedBy(pvcShouldCreateWithConfigCentral), withSize(resource.MustParse(defaultPVCSize.String())), withStorageClass(emptyStorageClass)),
+			},
+		},
 		"existing-pvc-should-be-reconciled-with-no-annotation": {
 			Central:      changedPVCConfigCentral,
 			DefaultClaim: DefaultCentralPVCName,
@@ -307,8 +353,7 @@ func TestReconcilePVCExtension(t *testing.T) {
 			Target:       PVCTargetCentral,
 			ExistingPVCs: []*corev1.PersistentVolumeClaim{{ObjectMeta: metav1.ObjectMeta{Name: testPVCName, Namespace: "stackrox"}}},
 			ExpectedPVCs: map[string]pvcVerifyFunc{
-				testPVCName:           verifyMultiple(notOwnedBy(emptyNotDeletedCentral)),
-				DefaultCentralPVCName: verifyMultiple(ownedBy(emptyNotDeletedCentral), withSize(resource.MustParse("100Gi")), withStorageClass(emptyStorageClass)),
+				testPVCName: verifyMultiple(notOwnedBy(emptyNotDeletedCentral)),
 			},
 		},
 
@@ -320,14 +365,12 @@ func TestReconcilePVCExtension(t *testing.T) {
 			ExpectedPVCs: nil,
 		},
 
-		"central-db-empty-state-create-new-default-pvc": {
+		"central-db-empty-state-not-create-new-default-pvc": {
 			Central:      emptyNotDeletedCentralWithDB,
 			DefaultClaim: DefaultCentralDBPVCName,
 			Target:       PVCTargetCentralDB,
 			ExistingPVCs: nil,
-			ExpectedPVCs: map[string]pvcVerifyFunc{
-				DefaultCentralDBPVCName: verifyMultiple(ownedBy(emptyNotDeletedCentralWithDB), withSize(defaultPVCSize), withStorageClass(emptyStorageClass)),
-			},
+			ExpectedPVCs: nil,
 		},
 
 		"central-db-empty-state-create-new-default-pvc-no-annotation-pvc": {

--- a/operator/pkg/central/reconciler/reconciler.go
+++ b/operator/pkg/central/reconciler/reconciler.go
@@ -53,7 +53,7 @@ func RegisterNewReconciler(mgr ctrl.Manager, selector string) error {
 
 	return reconciler.SetupReconcilerWithManager(
 		mgr, platform.CentralGVK, image.CentralServicesChartPrefix,
-		proxy.InjectProxyEnvVars(translation.Translator{Client: mgr.GetClient()}, proxyEnv),
+		proxy.InjectProxyEnvVars(translation.New(mgr.GetClient()), proxyEnv),
 		opts...,
 	)
 }

--- a/operator/pkg/central/reconciler/reconciler.go
+++ b/operator/pkg/central/reconciler/reconciler.go
@@ -53,7 +53,7 @@ func RegisterNewReconciler(mgr ctrl.Manager, selector string) error {
 
 	return reconciler.SetupReconcilerWithManager(
 		mgr, platform.CentralGVK, image.CentralServicesChartPrefix,
-		proxy.InjectProxyEnvVars(translation.Translator{}, proxyEnv),
+		proxy.InjectProxyEnvVars(translation.Translator{Client: mgr.GetClient()}, proxyEnv),
 		opts...,
 	)
 }

--- a/operator/pkg/central/values/translation/pvc_checker.go
+++ b/operator/pkg/central/values/translation/pvc_checker.go
@@ -13,12 +13,12 @@ import (
 type pvcStateChecker struct {
 	ctx         context.Context
 	client      ctrlClient.Client
-	obsoletePvc bool
+	obsoletePVC bool
 	namespace   string
 }
 
 func (c *pvcStateChecker) isObsolete() bool {
-	return c.obsoletePvc
+	return c.obsoletePVC
 }
 
 func (c *pvcStateChecker) pvcExists(name string) (bool, error) {

--- a/operator/pkg/central/values/translation/pvc_checker.go
+++ b/operator/pkg/central/values/translation/pvc_checker.go
@@ -1,0 +1,37 @@
+package translation
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/pkg/utils"
+	corev1 "k8s.io/api/core/v1"
+	apiErrors "k8s.io/apimachinery/pkg/api/errors"
+	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// pvcExistenceChecker wraps up the information and function to detect
+type pvcExistenceChecker struct {
+	ctx         context.Context
+	client      ctrlClient.Client
+	obsoletePvc bool
+	nameSpace   string
+}
+
+func (c *pvcExistenceChecker) toObsolete() bool {
+	return c.obsoletePvc
+}
+
+func (c *pvcExistenceChecker) pvcExists(name string) bool {
+	key := ctrlClient.ObjectKey{Namespace: c.nameSpace, Name: name}
+	pvc := &corev1.PersistentVolumeClaim{}
+	err := c.client.Get(c.ctx, key, pvc)
+	if !apiErrors.IsNotFound(err) {
+		utils.Should(errors.Wrapf(err, "failed to check pvc %s in name space %s", name, c.nameSpace))
+	}
+	// In case of error, we do not know if there is exising pvc there. It would be safer to
+	// assume it is not there. In that case, we may leave two persistent files not migrated
+	// for offline mode. I am not sure how many customer working with operator in offline mode in the first place,
+	// but that scenario can be corrected by upload them again.
+	return err == nil
+}

--- a/operator/pkg/central/values/translation/pvc_checker.go
+++ b/operator/pkg/central/values/translation/pvc_checker.go
@@ -26,12 +26,13 @@ func (c *pvcExistenceChecker) pvcExists(name string) bool {
 	key := ctrlClient.ObjectKey{Namespace: c.nameSpace, Name: name}
 	pvc := &corev1.PersistentVolumeClaim{}
 	err := c.client.Get(c.ctx, key, pvc)
-	if !apiErrors.IsNotFound(err) {
+	if err != nil && !apiErrors.IsNotFound(err) {
+		// In case of error, we do not know if there is exising pvc there. It would be safer to
+		// assume it is not there. In that case, we may leave two persistent files not migrated
+		// for offline mode. I am not sure how many customer working with operator in offline mode in the first place,
+		// but that scenario can be corrected by upload them again.
 		utils.Should(errors.Wrapf(err, "failed to check pvc %s in name space %s", name, c.nameSpace))
+		return false
 	}
-	// In case of error, we do not know if there is exising pvc there. It would be safer to
-	// assume it is not there. In that case, we may leave two persistent files not migrated
-	// for offline mode. I am not sure how many customer working with operator in offline mode in the first place,
-	// but that scenario can be corrected by upload them again.
 	return err == nil
 }

--- a/operator/pkg/central/values/translation/pvc_checker.go
+++ b/operator/pkg/central/values/translation/pvc_checker.go
@@ -11,14 +11,9 @@ import (
 
 // pvcStateChecker wraps up the information and function to determine pvc state
 type pvcStateChecker struct {
-	ctx         context.Context
-	client      ctrlClient.Client
-	obsoletePVC bool
-	namespace   string
-}
-
-func (c *pvcStateChecker) isObsolete() bool {
-	return c.obsoletePVC
+	ctx       context.Context
+	client    ctrlClient.Client
+	namespace string
 }
 
 func (c *pvcStateChecker) pvcExists(name string) (bool, error) {

--- a/operator/pkg/central/values/translation/translation.go
+++ b/operator/pkg/central/values/translation/translation.go
@@ -79,7 +79,7 @@ func (t Translator) translate(ctx context.Context, c platform.Central) (chartuti
 	annotations := c.GetAnnotations()
 	var obsoletePvc bool
 	if value, ok := annotations[common.CentralPVCObsoletedAnnotation]; ok {
-		obsoletePvc = strings.ToLower(strings.TrimSpace(value)) == "true"
+		obsoletePvc = strings.EqualFold("true", strings.TrimSpace(value))
 	}
 	checker := &pvcExistenceChecker{
 		ctx:         ctx,

--- a/operator/pkg/central/values/translation/translation.go
+++ b/operator/pkg/central/values/translation/translation.go
@@ -85,7 +85,7 @@ func (t Translator) translate(ctx context.Context, c platform.Central) (chartuti
 		ctx:         ctx,
 		client:      t.client,
 		namespace:   c.GetNamespace(),
-		obsoletePvc: obsoletePVC,
+		obsoletePVC: obsoletePVC,
 	}
 
 	central, err := getCentralComponentValues(centralSpec, checker)

--- a/operator/pkg/central/values/translation/translation.go
+++ b/operator/pkg/central/values/translation/translation.go
@@ -4,18 +4,24 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 
 	// Required for the usage of go:embed below.
 	_ "embed"
 
 	"github.com/pkg/errors"
 	platform "github.com/stackrox/rox/operator/apis/platform/v1alpha1"
+	"github.com/stackrox/rox/operator/pkg/central/common"
+	"github.com/stackrox/rox/operator/pkg/central/extensions"
 	"github.com/stackrox/rox/operator/pkg/values/translation"
 	helmUtil "github.com/stackrox/rox/pkg/helm/util"
 	"github.com/stackrox/rox/pkg/utils"
 	"helm.sh/helm/v3/pkg/chartutil"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/pointer"
+	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var (
@@ -29,10 +35,11 @@ const (
 
 // Translator translates and enriches helm values
 type Translator struct {
+	Client ctrlClient.Client
 }
 
 // Translate translates and enriches helm values
-func (t Translator) Translate(_ context.Context, u *unstructured.Unstructured) (chartutil.Values, error) {
+func (t Translator) Translate(ctx context.Context, u *unstructured.Unstructured) (chartutil.Values, error) {
 	baseValues, err := chartutil.ReadValues(baseValuesYAML)
 	utils.CrashOnError(err) // ensured through unit test that this doesn't happen.
 
@@ -42,7 +49,7 @@ func (t Translator) Translate(_ context.Context, u *unstructured.Unstructured) (
 		return nil, err
 	}
 
-	valsFromCR, err := translate(c)
+	valsFromCR, err := t.translate(ctx, c)
 	if err != nil {
 		return nil, err
 	}
@@ -56,7 +63,7 @@ func (t Translator) Translate(_ context.Context, u *unstructured.Unstructured) (
 }
 
 // translate translates a Central CR into helm values.
-func translate(c platform.Central) (chartutil.Values, error) {
+func (t Translator) translate(ctx context.Context, c platform.Central) (chartutil.Values, error) {
 	v := translation.NewValuesBuilder()
 
 	v.AddAllFrom(translation.GetImagePullSecrets(c.Spec.ImagePullSecrets))
@@ -70,8 +77,22 @@ func translate(c platform.Central) (chartutil.Values, error) {
 	if centralSpec == nil {
 		centralSpec = &platform.CentralComponentSpec{}
 	}
-
-	v.AddChild("central", getCentralComponentValues(centralSpec))
+	annotations := c.GetAnnotations()
+	var obsoletePvc bool
+	if value, ok := annotations[common.CentralPVCObsoletedAnnotation]; ok {
+		obsoletePvc = strings.ToLower(strings.TrimSpace(value)) == "true"
+	}
+	v.AddChild("central",
+		getCentralComponentValues(centralSpec, func(lookupName string) bool {
+			key := ctrlClient.ObjectKey{Namespace: c.GetNamespace(), Name: lookupName}
+			pvc := &corev1.PersistentVolumeClaim{}
+			err := t.Client.Get(ctx, key, pvc)
+			// In case of error, we do not know if there is exising pvc there. It would be safer to
+			// assume it is not there. In that case, we may leaving two persistent files not migrated
+			// for offline mode. I am not sure how many customer working with operator in offline mode in the first place,
+			// but that scenario can be corrected by upload them again.
+			return err == nil
+		}, obsoletePvc))
 
 	if c.Spec.Scanner != nil {
 		v.AddChild("scanner", getCentralScannerComponentValues(c.Spec.Scanner))
@@ -137,14 +158,30 @@ func getCentralDBPersistenceValues(p *platform.DBPersistence) *translation.Value
 	return &persistence
 }
 
-func getCentralPersistenceValues(p *platform.Persistence) *translation.ValuesBuilder {
+func getCentralPersistenceValues(p *platform.Persistence, pvcExists func(claimName string) bool, pvcObsoleted bool) *translation.ValuesBuilder {
 	persistence := translation.NewValuesBuilder()
+	// Check pvcs which should exist in cluster.
+	if pvcObsoleted {
+		persistence.SetBoolValue("none", true)
+		return &persistence
+	}
+
 	if hostPath := p.GetHostPath(); hostPath != "" {
 		persistence.SetStringValue("hostPath", hostPath)
 	} else {
+		pvc := p.GetPersistentVolumeClaim()
+		lookupName := extensions.DefaultCentralPVCName
+		if pvc != nil {
+			lookupName = pointer.StringDeref(pvc.ClaimName, extensions.DefaultCentralPVCName)
+		}
+		// Do not mount PVC if it does not exist.
+		if !pvcExists(lookupName) {
+			persistence.SetBoolValue("none", true)
+			return &persistence
+		}
 		pvcBuilder := translation.NewValuesBuilder()
 		pvcBuilder.SetBoolValue("createClaim", false)
-		if pvc := p.GetPersistentVolumeClaim(); pvc != nil {
+		if pvc != nil {
 			pvcBuilder.SetString("claimName", pvc.ClaimName)
 		}
 
@@ -153,7 +190,8 @@ func getCentralPersistenceValues(p *platform.Persistence) *translation.ValuesBui
 	return &persistence
 }
 
-func getCentralComponentValues(c *platform.CentralComponentSpec) *translation.ValuesBuilder {
+func getCentralComponentValues(c *platform.CentralComponentSpec, pvcExists func(lookupName string) bool, pvcObsoleted bool) *translation.ValuesBuilder {
+	// Change something here.
 	cv := translation.NewValuesBuilder()
 
 	cv.AddChild(translation.ResourcesKey, translation.GetResources(c.Resources))
@@ -167,7 +205,7 @@ func getCentralComponentValues(c *platform.CentralComponentSpec) *translation.Va
 
 	// TODO(ROX-7147): design CentralEndpointSpec, see central_types.go
 
-	cv.AddChild("persistence", getCentralPersistenceValues(c.GetPersistence()))
+	cv.AddChild("persistence", getCentralPersistenceValues(c.GetPersistence(), pvcExists, pvcObsoleted))
 
 	if c.Exposure != nil {
 		exposure := translation.NewValuesBuilder()

--- a/operator/pkg/central/values/translation/translation.go
+++ b/operator/pkg/central/values/translation/translation.go
@@ -195,7 +195,6 @@ func getCentralPersistenceValues(p *platform.Persistence, pvcExists func(claimNa
 }
 
 func getCentralComponentValues(c *platform.CentralComponentSpec, pvcExists func(lookupName string) bool, pvcObsoleted bool) *translation.ValuesBuilder {
-	// Change something here.
 	cv := translation.NewValuesBuilder()
 
 	cv.AddChild(translation.ResourcesKey, translation.GetResources(c.Resources))

--- a/operator/pkg/central/values/translation/translation_test.go
+++ b/operator/pkg/central/values/translation/translation_test.go
@@ -795,7 +795,7 @@ func TestTranslate(t *testing.T) {
 			client := fkClient.NewClientBuilder().WithObjects(allExisting...).Build()
 			translator := Translator{Client: client}
 
-			got, err := translator.translate(context.TODO(), tt.args.c)
+			got, err := translator.translate(context.Background(), tt.args.c)
 			assert.NoError(t, err)
 
 			assert.Equal(t, wantAsValues, got)

--- a/operator/pkg/central/values/translation/translation_test.go
+++ b/operator/pkg/central/values/translation/translation_test.go
@@ -793,7 +793,7 @@ func TestTranslate(t *testing.T) {
 				allExisting = append(allExisting, existingPVC)
 			}
 			client := fkClient.NewClientBuilder().WithObjects(allExisting...).Build()
-			translator := Translator{Client: client}
+			translator := New(client)
 
 			got, err := translator.translate(context.Background(), tt.args.c)
 			assert.NoError(t, err)

--- a/operator/pkg/central/values/translation/translation_test.go
+++ b/operator/pkg/central/values/translation/translation_test.go
@@ -554,7 +554,7 @@ func TestTranslate(t *testing.T) {
 			args: args{
 				c: platform.Central{
 					ObjectMeta: metav1.ObjectMeta{
-						Annotations: map[string]string{common.CentralPVCObsoletedAnnotation: "true"},
+						Annotations: map[string]string{common.CentralPVCObsoleteAnnotation: "true"},
 						Namespace:   "stackrox",
 					},
 					Spec: platform.CentralSpec{

--- a/operator/tests/central/basic-central/10-assert.yaml
+++ b/operator/tests/central/basic-central/10-assert.yaml
@@ -76,22 +76,6 @@ data:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: stackrox-db
-  ownerReferences:
-  - apiVersion: platform.stackrox.io/v1alpha1
-    kind: Central
-    name: stackrox-central-services
-    controller: true
-spec:
-  accessModes:
-  - ReadWriteOnce
-  resources:
-    requests:
-      storage: 100Gi
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
   name: central-db
 spec:
   accessModes:

--- a/operator/tests/central/basic-central/10-assert.yaml
+++ b/operator/tests/central/basic-central/10-assert.yaml
@@ -76,6 +76,22 @@ data:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
+  name: stackrox-db
+  ownerReferences:
+  - apiVersion: platform.stackrox.io/v1alpha1
+    kind: Central
+    name: stackrox-central-services
+    controller: true
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
   name: central-db
 spec:
   accessModes:

--- a/operator/tests/central/basic-central/10-errors.yaml
+++ b/operator/tests/central/basic-central/10-errors.yaml
@@ -2,3 +2,19 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: proxy-config
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: stackrox-db
+  ownerReferences:
+  - apiVersion: platform.stackrox.io/v1alpha1
+    kind: Central
+    name: stackrox-central-services
+    controller: true
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Gi

--- a/operator/tests/central/basic-central/10-errors.yaml
+++ b/operator/tests/central/basic-central/10-errors.yaml
@@ -2,19 +2,3 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: proxy-config
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: stackrox-db
-  ownerReferences:
-  - apiVersion: platform.stackrox.io/v1alpha1
-    kind: Central
-    name: stackrox-central-services
-    controller: true
-spec:
-  accessModes:
-  - ReadWriteOnce
-  resources:
-    requests:
-      storage: 100Gi

--- a/operator/tests/central/basic-central/100-assert.yaml
+++ b/operator/tests/central/basic-central/100-assert.yaml
@@ -1,18 +1,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: stackrox-db
-spec:
-  accessModes:
-  - ReadWriteOnce
-  resources:
-    requests:
-      storage: 100Gi
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: stackrox-db
+  name: central-db
 spec:
   accessModes:
   - ReadWriteOnce

--- a/operator/tests/central/basic-central/90-assert.yaml
+++ b/operator/tests/central/basic-central/90-assert.yaml
@@ -126,9 +126,6 @@ spec:
           name: central-external-db
           optional: true
         name: central-external-db-volume
-      - name: stackrox-db
-        persistentVolumeClaim:
-          claimName: stackrox-db
       - name: config-map-1
         configMap:
           name: config-map-1

--- a/operator/tests/central/basic-central/90-assert.yaml
+++ b/operator/tests/central/basic-central/90-assert.yaml
@@ -126,6 +126,8 @@ spec:
           name: central-external-db
           optional: true
         name: central-external-db-volume
+      - name: stackrox-db
+        emptyDir: {}
       - name: config-map-1
         configMap:
           name: config-map-1

--- a/operator/tests/central/basic-central/90-errors.yaml
+++ b/operator/tests/central/basic-central/90-errors.yaml
@@ -1,0 +1,11 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: central
+spec:
+  template:
+    spec:
+      volumes:
+      - name: stackrox-db
+        persistentVolumeClaim:
+          claimName: stackrox-db

--- a/operator/tests/central/basic-central/91-assert.yaml
+++ b/operator/tests/central/basic-central/91-assert.yaml
@@ -115,8 +115,7 @@ spec:
           optional: true
         name: central-external-db-volume
       - name: stackrox-db
-        persistentVolumeClaim:
-          claimName: stackrox-db
+        emptyDir: {}
       - configMap:
           defaultMode: 420
           items:

--- a/operator/tests/upgrade/upgrade/25-errors.yaml
+++ b/operator/tests/upgrade/upgrade/25-errors.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: central
+spec:
+  template:
+    spec:
+      volumes:
+      - name: stackrox-db
+        persistentVolumeClaim:
+          claimName: stackrox-db
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: stackrox-db
+  ownerReferences:
+  - apiVersion: platform.stackrox.io/v1alpha1
+    kind: Central
+    name: stackrox-central-services
+    controller: true

--- a/operator/tests/upgrade/upgrade/25-obsolete-pvc.yaml
+++ b/operator/tests/upgrade/upgrade/25-obsolete-pvc.yaml
@@ -1,0 +1,6 @@
+apiVersion: platform.stackrox.io/v1alpha1
+kind: Central
+metadata:
+  name: stackrox-central-services
+  annotations:
+    platform.stackrox.io/obsolete-central-pvc: "true"


### PR DESCRIPTION
## Description
This PR is part of Central PVC retirement. The stackrox-db is attached to Central and holding the RocksDB and some persistent data in Central. After we migrate all data from RocksDB to Postgres, we are ready to retire PVC. This is helpful to make ACSCS stateless to be deployed cross-zone. 

Prior to 4.1, we still have some persistent data on RockDB and those files are move to Postgres in 4.1 or beyond through migration. That requires us to still use the PVC in 4.1 during the migration. In addition to that, keeping the pvc will help rollback and restoration process.

For newly installed Central, we do not need to create and mount stackrox PVC.  After migration and after the customer has confirmed that the Central is running in a good shape, they may start to retire PVC. The process requires that we do not create and mount pvc during installation but we should be able to mount pvc during installation.

## Method
On the other hand, operator does not distinct between installation and upgrade because of its declarative nature. In this PR, we add the logic to leverage the creation of PVC and existence of the PVC to determine if we should mount it. In case of error, this process is not 100% correct but it should be good enough.
1. Operator pvc reconcile process stops creating PVC during installation.
2. Translation process does not mount stackrox-db if the PVC does not exists
3. The customer will add an annotation to Central. With this annotation set, we will stop mount the PVC and remove the owner reference on existing PVC.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- ~[ ] Evaluated and added CHANGELOG entry if required
- ~[ ] Determined and documented upgrade steps
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs] We will need to update release document for this. But I will commit it separately.~

If any of these don't apply, please comment below.

## Testing Performed


Existing and newly added unit test.
Add retirement process to e2e test
