### PR TITLE
ROX-14324: Add default role and permission set to display network graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 
 ### Added Features
 - A default role `Vulnerability Manager` has been added that provides sufficient privileges to analyze and manage system vulnerabilities.
+- A default role `Network Graph Viewer` has been added that provides sufficient privileges to display network graphs.
 
 ### Removed Features
 

--- a/central/role/datastore/permissionset_ids.go
+++ b/central/role/datastore/permissionset_ids.go
@@ -2,17 +2,18 @@ package datastore
 
 // Postgres IDs for permission sets
 // The values are UUIDs taken in descending order from ffffffff-ffff-fff4-f5ff-ffffffffffff
-// Next ID: ffffffff-ffff-fff4-f5ff-fffffffffff5
+// Next ID: ffffffff-ffff-fff4-f5ff-fffffffffff4
 const (
 	adminPermissionSetID                 = "ffffffff-ffff-fff4-f5ff-ffffffffffff"
 	analystPermissionSetID               = "ffffffff-ffff-fff4-f5ff-fffffffffffe"
 	continuousIntegrationPermissionSetID = "ffffffff-ffff-fff4-f5ff-fffffffffffd"
 	nonePermissionSetID                  = "ffffffff-ffff-fff4-f5ff-fffffffffffc"
 	// TODO: ROX-14398 Remove ScopeManager default role
-	scopeManagerPermissionSetID      = "ffffffff-ffff-fff4-f5ff-fffffffffffb"
-	sensorCreatorPermissionSetID     = "ffffffff-ffff-fff4-f5ff-fffffffffffa"
-	vulnMgmtApproverPermissionSetID  = "ffffffff-ffff-fff4-f5ff-fffffffffff9"
-	vulnMgmtRequesterPermissionSetID = "ffffffff-ffff-fff4-f5ff-fffffffffff8"
-	vulnReporterPermissionSetID      = "ffffffff-ffff-fff4-f5ff-fffffffffff7"
-	vulnMgmtPermissionSetID          = "ffffffff-ffff-fff4-f5ff-fffffffffff6"
+	scopeManagerPermissionSetID       = "ffffffff-ffff-fff4-f5ff-fffffffffffb"
+	sensorCreatorPermissionSetID      = "ffffffff-ffff-fff4-f5ff-fffffffffffa"
+	vulnMgmtApproverPermissionSetID   = "ffffffff-ffff-fff4-f5ff-fffffffffff9"
+	vulnMgmtRequesterPermissionSetID  = "ffffffff-ffff-fff4-f5ff-fffffffffff8"
+	vulnReporterPermissionSetID       = "ffffffff-ffff-fff4-f5ff-fffffffffff7"
+	vulnMgmtPermissionSetID           = "ffffffff-ffff-fff4-f5ff-fffffffffff6"
+	networkGraphViewerPermissionSetID = "ffffffff-ffff-fff4-f5ff-fffffffffff5"
 )

--- a/central/role/datastore/singleton.go
+++ b/central/role/datastore/singleton.go
@@ -98,6 +98,16 @@ var defaultRoles = map[string]roleAttributes{
 			permissions.Modify(resources.Image),
 		},
 	},
+	rolePkg.NetworkGraphViewer: {
+		idSuffix:    "networkgraphviewer",
+		postgresID:  networkGraphViewerPermissionSetID,
+		description: "For users: use it to give read-only access to the NetworkGraph pages",
+		resourceWithAccess: []permissions.ResourceWithAccess{
+			permissions.View(resources.Deployment),
+			permissions.View(resources.NetworkGraph),
+			permissions.View(resources.NetworkPolicy),
+		},
+	},
 	rolePkg.None: {
 		idSuffix:    "none",
 		postgresID:  nonePermissionSetID,

--- a/central/role/default.go
+++ b/central/role/default.go
@@ -23,6 +23,9 @@ const (
 	// ContinuousIntegration is for CI pipelines.
 	ContinuousIntegration = "Continuous Integration"
 
+	// NetworkGraphViewer is a role that has the minimal privileges required to display network graphs.
+	NetworkGraphViewer = "Network Graph Viewer"
+
 	// SensorCreator is a role that has the minimal privileges required to create a sensor.
 	SensorCreator = "Sensor Creator"
 


### PR DESCRIPTION
## Description

Adds a new permission set and the associated default role.
These provide minimum permissions to display the Network Graph pages

## Checklist
- [ ] Investigated and inspected CI test results
~~- [ ] Unit test and regression tests added~~
- [ ] Evaluated and added CHANGELOG entry if required
~~- [ ] Determined and documented upgrade steps~~
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

CI is sufficient
