### PR TITLE
ROX-16554: Rename Helm setting nodeInventoryResources to nodeScanningResources

### DIFF
--- a/image/templates/helm/stackrox-secured-cluster/README.md.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/README.md.htpl
@@ -282,7 +282,7 @@ non-standard environments:
 |`sensor.resources`|Resource specification for Sensor.|See below.|
 |`collector.resources`|Resource specification for Collector.|See below.|
 |`collector.complianceResources`|Resource specification for Collector's Compliance container.|See below.|
-|`collector.nodeInventoryResources`|Resource specification for Collector's Node Inventory container.|See below.|
+|`collector.nodeScanningResources`|Resource specification for Collector's Node Inventory container.|See below.|
 |`collector.nodeSelector` | Node selector for Collector pods placement. | `null` (no placement constraints) |
 |`admissionControl.resources`|Resource specification for Admission Control.|See below.|
 |`sensor.imagePullPolicy`| Kubernetes image pull policy for Sensor. | `IfNotPresent` |
@@ -307,7 +307,7 @@ paths to the respective defaults for each container that this chart deploys:
 |Sensor           |`defaults.sensor.resources`                |
 |Collector        |`defaults.collector.resources`             |
 |Compliance       |`defaults.collector.complianceResources`   |
-|NodeInventory    |`defaults.collector.nodeInventoryResources`|
+|NodeInventory    |`defaults.collector.nodeScanningResources`|
 |Admission Control|`defaults.admissionControl.resources`      |
 
 ### Customization settings

--- a/image/templates/helm/stackrox-secured-cluster/internal/config-shape.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/internal/config-shape.yaml
@@ -103,7 +103,7 @@ collector:
   resources: null # string | dict
   complianceImagePullPolicy: null # string
   complianceResources: null # string | dict
-  nodeInventoryResources: null # string | dict
+  nodeScanningResources: null # string | dict
   serviceTLS:
     cert: null # string
     key: null # string

--- a/image/templates/helm/stackrox-secured-cluster/internal/defaults/40-resources.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/internal/defaults/40-resources.yaml
@@ -35,7 +35,7 @@ collector:
       memory: "2Gi"
       cpu: "1"
 
-  nodeInventoryResources:
+  nodeScanningResources:
     requests:
       memory: "10Mi"
       cpu: "10m"

--- a/image/templates/helm/stackrox-secured-cluster/internal/expandables.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/internal/expandables.yaml
@@ -27,7 +27,7 @@ collector:
     key: true
   resources: true
   complianceResources: true
-  nodeInventoryResources: true
+  nodeScanningResources: true
   nodeSelector: true
 scanner:
   resources: true

--- a/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml
@@ -154,7 +154,7 @@ spec:
           - containerPort: 8444
             name: grpc
         resources:
-          {{- ._rox.collector._nodeInventoryResources | nindent 10 }}
+          {{- ._rox.collector._nodeScanningResources | nindent 10 }}
         env:
         - name: ROX_NODE_NAME
           valueFrom:

--- a/image/templates/helm/stackrox-secured-cluster/values-public.yaml.example
+++ b/image/templates/helm/stackrox-secured-cluster/values-public.yaml.example
@@ -273,7 +273,7 @@
 #      cpu: "1"
 #
 #  # Resource configuration for the Node Inventory container.
-#  nodeInventoryResources:
+#  nodeScanningResources:
 #    requests:
 #      memory: "10Mi"
 #      cpu: "10m"


### PR DESCRIPTION
## Description

Renaming a Helm setting as discussed in https://redhat-internal.slack.com/archives/C04213W844U/p1681745465572349

## Checklist
- [x] Investigated and inspected CI test results

### N/A
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

- [x] CI
- [x] Manual deploy with Helm
