### PR TITLE
ROX-16639: Fix RHCOS test flake

### DIFF
--- a/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
@@ -634,14 +634,20 @@ class Kubernetes implements OrchestratorMain {
             throw new OrchestratorManagerException(
                 "Could not update env var, did not find container ${containerName} in ${ns}/${name}")
         }
+        log.debug "Container ${ns}/${name}/${containerName} found on index: ${containerIndex}"
         List<EnvVar> envVars = containers.get(containerIndex).env
+        log.debug "Current env vars of ${ns}/${name}/${containerName}: ${envVars}"
+
 
         int index = envVars.findIndexOf { EnvVar it -> it.name == key }
-        if (index < 0) {
-            throw new OrchestratorManagerException(
-                "Could not update env var, did not find env variable ${key} in ${ns}/${name}")
+        if (index > -1) {
+            log.debug "Env var ${key} found on index: ${index}"
+            envVars.get(index).value = value
         }
-        envVars.get(index).value = value
+        else {
+            log.debug "Env var ${key} not found. Adding it now"
+            envVars.add(new EnvVarBuilder().withName(key).withValue(value))
+        }
 
         client.apps().daemonSets().inNamespace(ns).withName(name)
             .edit { d -> new DaemonSetBuilder(d)

--- a/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
@@ -619,11 +619,17 @@ class Kubernetes implements OrchestratorMain {
         log.debug "${daemonSet.name}: daemonset removed."
     }
 
+    boolean containsDaemonSetContainer(String ns, String name, String containerName) {
+        return client.apps().daemonSets().inNamespace(ns).withName(name).get().spec.template
+            .spec.containers.findIndexOf { it.name == containerName } > -1
+    }
+
+
     def updateDaemonSetEnv(String ns, String name, String containerName, String key, String value) {
         log.debug "Update env var in ${ns}/${name}/${containerName}: ${key} = ${value}"
         List<Container> containers = client.apps().daemonSets().inNamespace(ns).withName(name).get().spec.template
             .spec.containers
-        int containerIndex = containers.findIndexOf { it.name = containerName }
+        int containerIndex = containers.findIndexOf { it.name == containerName }
         if (containerIndex == -1) {
             throw new OrchestratorManagerException(
                 "Could not update env var, did not find container ${containerName} in ${ns}/${name}")

--- a/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
@@ -624,7 +624,6 @@ class Kubernetes implements OrchestratorMain {
             .spec.containers.findIndexOf { it.name == containerName } > -1
     }
 
-
     def updateDaemonSetEnv(String ns, String name, String containerName, String key, String value) {
         log.debug "Update env var in ${ns}/${name}/${containerName}: ${key} = ${value}"
         List<Container> containers = client.apps().daemonSets().inNamespace(ns).withName(name).get().spec.template
@@ -638,7 +637,6 @@ class Kubernetes implements OrchestratorMain {
         List<EnvVar> envVars = containers.get(containerIndex).env
         log.debug "Current env vars of ${ns}/${name}/${containerName}: ${envVars}"
 
-
         int index = envVars.findIndexOf { EnvVar it -> it.name == key }
         if (index > -1) {
             log.debug "Env var ${key} found on index: ${index}"
@@ -646,7 +644,7 @@ class Kubernetes implements OrchestratorMain {
         }
         else {
             log.debug "Env var ${key} not found. Adding it now"
-            envVars.add(new EnvVarBuilder().withName(key).withValue(value))
+            envVars.add(new EnvVarBuilder().withName(key).withValue(value).build())
         }
 
         client.apps().daemonSets().inNamespace(ns).withName(name)
@@ -675,6 +673,57 @@ class Kubernetes implements OrchestratorMain {
             log.debug "Waiting for daemonset ${ns}/${name} being ready, retrying..."
         }
         return false
+    }
+
+    // waitForDaemonSetEnvVarUpdate checks if all pods are ready and the env var has a given value for all pods
+    def waitForDaemonSetEnvVarUpdate(String ns, String name, String containerName, String envVarName,
+                                     String envVarValue, int retries, int intervalSeconds) {
+        Timer t = new Timer(retries, intervalSeconds)
+        int attempt = 0
+        while (t.IsValid()) {
+            attempt++
+            def ds = client.apps().daemonSets().inNamespace(ns).withName(name).get()
+            if (ds.getStatus().getNumberReady() != client.nodes().list().getItems().size()) {
+                log.debug "Only ${ds.getStatus().getNumberReady()} out of " +
+                    "${client.nodes().list().getItems().size()} pods in ds are ready"
+                continue
+            }
+            def pods = client.pods().inNamespace(ns).withLabel("app", name).list().getItems()
+            int podsPassing = 0
+            for (Pod pod : pods) {
+                log.debug "Found pod \"${pod.getMetadata().name}\" with ${pod.getSpec().containers.size()} containers"
+                int containerIndex = pod.getSpec().containers.findIndexOf { it.name == containerName }
+                if (containerIndex == -1) {
+                    log.debug "Pod ${pod.getMetadata().name}: could not find container ${containerName}"
+                    break
+                }
+                log.debug "Pod ${pod.getMetadata().name}: " +
+                    "Container ${ns}/${name}/${containerName} found on index: ${containerIndex}"
+                List<EnvVar> envVars = pod.getSpec().containers.get(containerIndex).env
+                int index = envVars.findIndexOf { EnvVar it -> it.name == envVarName }
+                if (index == -1) {
+                    log.debug "Pod ${pod.getMetadata().name}: " +
+                        "could not find env variable ${envVarName} in container ${containerName}"
+                    break
+                }
+                def value = envVars.get(index).value
+                log.debug "Pod ${pod.getMetadata().name}: " +
+                    "Env var ${envVarName} found on index: ${index} with value ${value}"
+                if (value != envVarValue) {
+                    log.debug "Pod ${pod.getMetadata().name}: " +
+                        "Expected value ${envVarValue} does not match current ${value}"
+                    break
+                }
+                log.debug "Pod ${pod.getMetadata().name}: All conditions have been met"
+                podsPassing++
+            }
+            if (podsPassing == pods.size()) {
+                return true
+            }
+            log.debug "Attempt ${attempt}: Only ${podsPassing} out of ${pods.size()} met the condition. Retrying"
+        }
+        throw new OrchestratorManagerException(
+            "DaemonSet ${ns}/${name} could not reach desired state")
     }
 
     def createJob(Job job) {

--- a/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
@@ -623,12 +623,12 @@ class Kubernetes implements OrchestratorMain {
         log.debug "Update env var in ${ns}/${name}/${containerName}: ${key} = ${value}"
         List<Container> containers = client.apps().daemonSets().inNamespace(ns).withName(name).get().spec.template
             .spec.containers
-        Container container = containers.find { it.name = containerName }
-        if (container == null) {
+        int containerIndex = containers.findIndexOf { it.name = containerName }
+        if (containerIndex == -1) {
             throw new OrchestratorManagerException(
                 "Could not update env var, did not find container ${containerName} in ${ns}/${name}")
         }
-        List<EnvVar> envVars = container.env
+        List<EnvVar> envVars = containers.get(containerIndex).env
 
         int index = envVars.findIndexOf { EnvVar it -> it.name == key }
         if (index < 0) {
@@ -642,7 +642,7 @@ class Kubernetes implements OrchestratorMain {
                 .editSpec()
                 .editTemplate()
                 .editSpec()
-                .editContainer(0)
+                .editContainer(containerIndex)
                 .withEnv(envVars)
                 .endContainer()
                 .endSpec()

--- a/qa-tests-backend/src/main/groovy/orchestratormanager/OrchestratorMain.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/OrchestratorMain.groovy
@@ -59,6 +59,7 @@ interface OrchestratorMain {
     EnvVar getDeploymentEnv(String ns, String name, String key)
     def scaleDeployment(String ns, String name, Integer replicas)
     List<String> getDeployments(String ns)
+    boolean deploymentReady(String ns, String name)
 
     //DaemonSets
     def createDaemonSet(DaemonSet daemonSet)
@@ -70,10 +71,9 @@ interface OrchestratorMain {
     def getDaemonSetUnavailableReplicaCount(DaemonSet daemonSet)
     def getDaemonSetCount()
     def getDaemonSetCount(String ns)
+    boolean daemonSetReady(String ns, String name)
+    boolean daemonSetEnvVarUpdated(String ns, String name, String containerName, String envVarName, String envVarValue)
     def waitForDaemonSetDeletion(String name)
-    def waitForDaemonSetReady(String ns, String name, int retires, int intervalSeconds)
-    def waitForDaemonSetEnvVarUpdate(String ns, String name, String containerName, String envVarName,
-                                     String envVarValue, int retries, int intervalSeconds)
     String getDaemonSetId(DaemonSet daemonSet)
 
     // StatefulSets

--- a/qa-tests-backend/src/main/groovy/orchestratormanager/OrchestratorMain.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/OrchestratorMain.groovy
@@ -72,6 +72,8 @@ interface OrchestratorMain {
     def getDaemonSetCount(String ns)
     def waitForDaemonSetDeletion(String name)
     def waitForDaemonSetReady(String ns, String name, int retires, int intervalSeconds)
+    def waitForDaemonSetEnvVarUpdate(String ns, String name, String containerName, String envVarName,
+                                     String envVarValue, int retries, int intervalSeconds)
     String getDaemonSetId(DaemonSet daemonSet)
 
     // StatefulSets

--- a/qa-tests-backend/src/main/groovy/orchestratormanager/OrchestratorMain.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/OrchestratorMain.groovy
@@ -63,6 +63,7 @@ interface OrchestratorMain {
     //DaemonSets
     def createDaemonSet(DaemonSet daemonSet)
     def deleteDaemonSet(DaemonSet daemonSet)
+    boolean containsDaemonSetContainer(String ns, String name, String containerName)
     def updateDaemonSetEnv(String ns, String name, String containerName, String key, String value)
     def getDaemonSetReplicaCount(DaemonSet daemonSet)
     def getDaemonSetNodeSelectors(DaemonSet daemonSet)

--- a/qa-tests-backend/src/main/groovy/orchestratormanager/OrchestratorMain.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/OrchestratorMain.groovy
@@ -63,6 +63,7 @@ interface OrchestratorMain {
     //DaemonSets
     def createDaemonSet(DaemonSet daemonSet)
     def deleteDaemonSet(DaemonSet daemonSet)
+    def updateDaemonSetEnv(String ns, String name, String containerName, String key, String value)
     def getDaemonSetReplicaCount(DaemonSet daemonSet)
     def getDaemonSetNodeSelectors(DaemonSet daemonSet)
     def getDaemonSetUnavailableReplicaCount(DaemonSet daemonSet)

--- a/qa-tests-backend/src/main/groovy/util/Helpers.groovy
+++ b/qa-tests-backend/src/main/groovy/util/Helpers.groovy
@@ -65,22 +65,17 @@ class Helpers {
         return willRetry
     }
 
-    static <V> V waitForTrue(int retries, int intervalSeconds, Closure <V> closure) {
+    static boolean waitForTrue(int retries, int intervalSeconds, Closure closure) {
         Timer t = new Timer(retries, intervalSeconds)
         int attempt = 0
-        boolean result = false
         while (t.IsValid()) {
             attempt++
-            result = closure()
-            if (result) {
+            if (closure()) {
                 return true
             }
             log.debug "Attempt ${attempt} failed, retrying"
         }
-        if (!result) {
-            throw new RuntimeException("All ${attempt} attempts failed, could not reach desired state")
-        }
-        return result
+        throw new RuntimeException("All ${attempt} attempts failed, could not reach desired state")
     }
 
     static void resetRetryAttempts() {

--- a/qa-tests-backend/src/main/groovy/util/Helpers.groovy
+++ b/qa-tests-backend/src/main/groovy/util/Helpers.groovy
@@ -65,6 +65,24 @@ class Helpers {
         return willRetry
     }
 
+    static <V> V waitForTrue(int retries, int intervalSeconds, Closure <V> closure) {
+        Timer t = new Timer(retries, intervalSeconds)
+        int attempt = 0
+        boolean result = false
+        while (t.IsValid()) {
+            attempt++
+            result = closure()
+            if (result) {
+                return true
+            }
+            log.debug "Attempt ${attempt} failed, retrying"
+        }
+        if (!result) {
+            throw new RuntimeException("All ${attempt} attempts failed, could not reach desired state")
+        }
+        return result
+    }
+
     static void resetRetryAttempts() {
         retryAttempt = 0
     }

--- a/qa-tests-backend/src/test/groovy/NodeInventoryTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NodeInventoryTest.groovy
@@ -25,7 +25,14 @@ class NodeInventoryTest extends BaseSpecification {
         List<Node> nodes = NodeService.getNodes()
         assert nodes.size() > 0
 
-        expect:
+        when:
+        log.info("Setting collector.node-inventory ROX_NODE_SCANNING_MAX_INITIAL_WAIT to 1s")
+        orchestrator.updateDaemonSetEnv("stackrox", "collector", "node-inventory", "ROX_NODE_SCANNING_MAX_INITIAL_WAIT", "1s")
+        log.info("Wait for collector ds to be restarted")
+        orchestrator.waitForDaemonSetReady("stackrox", "collector", 20, 6)
+
+
+        then:
         "confirm the number of components in the inventory and their scan"
         // ensure that the nodes got scanned at least once - retry up to 6 minutes
         withRetry(12, 30) {


### PR DESCRIPTION
## Description

We expected the nodes to be scanned immediately (what is not the case), thus the test was super-flaky.
In this PR, the flakiness should be addressed by:
- Changing the collector config to start scanning immediately on the fly
- Add retries to the assertion regarding the number of components

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added

### N/A
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))


## Testing Performed

- [x] CI
- [x] Running the affected test locally
