### PR TITLE
Add data tables for deployment single page

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPage.tsx
@@ -34,7 +34,7 @@ const workloadCveOverviewDeploymentsPath = getOverviewCvesPath({
 
 const deploymentMetadataQuery = gql`
     ${deploymentMetadataFragment}
-    query DeploymentMetadata($id: ID!) {
+    query getDeploymentMetadata($id: ID!) {
         deployment(id: $id) {
             ...DeploymentMetadata
         }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedDeploymentsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedDeploymentsTable.tsx
@@ -136,7 +136,6 @@ function AffectedDeploymentsTable({
                             <Td colSpan={6}>
                                 <ExpandableRowContent>
                                     <DeploymentComponentVulnerabilitiesTable
-                                        showImage
                                         images={imageComponentVulns}
                                     />
                                 </ExpandableRowContent>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentComponentVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentComponentVulnerabilitiesTable.tsx
@@ -3,6 +3,7 @@ import { TableComposable, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-tab
 import { gql } from '@apollo/client';
 
 import useTableSort from 'hooks/patternfly/useTableSort';
+import VulnerabilitySeverityIconText from 'Components/PatternFly/IconText/VulnerabilitySeverityIconText';
 import ImageNameTd from '../components/ImageNameTd';
 import {
     imageMetadataContextFragment,
@@ -29,6 +30,7 @@ export const deploymentComponentVulnerabilitiesFragment = gql`
             cvss
             scoreVersion
             fixedByVersion
+            discoveredAtImage
         }
     }
 `;
@@ -101,7 +103,9 @@ function DeploymentComponentVulnerabilitiesTable({
                                 )}
                             </Td>
                             <Td>{name}</Td>
-                            <Td>{severity}</Td>
+                            <Td>
+                                <VulnerabilitySeverityIconText severity={severity} />
+                            </Td>
                             <Td>
                                 {cvss.toFixed(1)} ({scoreVersion})
                             </Td>
@@ -112,7 +116,7 @@ function DeploymentComponentVulnerabilitiesTable({
                             <Td>{location || 'N/A'}</Td>
                         </Tr>
                         <Tr>
-                            <Td colSpan={6} className="pf-u-pt-0">
+                            <Td colSpan={7} className="pf-u-pt-0">
                                 <DockerfileLayerTd layer={layer} />
                             </Td>
                         </Tr>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx
@@ -1,0 +1,219 @@
+import React from 'react';
+import { Button, ButtonVariant } from '@patternfly/react-core';
+import {
+    ExpandableRowContent,
+    TableComposable,
+    Tbody,
+    Td,
+    Th,
+    Thead,
+    Tr,
+} from '@patternfly/react-table';
+import { gql } from '@apollo/client';
+import { min } from 'date-fns';
+
+import LinkShim from 'Components/PatternFly/LinkShim';
+import useSet from 'hooks/useSet';
+import { getDistanceStrictAsPhrase } from 'utils/dateUtils';
+import { UseURLSortResult } from 'hooks/useURLSort';
+import { FixableIcon, NotFixableIcon } from 'Components/PatternFly/FixabilityIcons';
+import VulnerabilitySeverityIconText from 'Components/PatternFly/IconText/VulnerabilitySeverityIconText';
+import { VulnerabilitySeverity } from 'types/cve.proto';
+import { getEntityPagePath } from '../searchUtils';
+import { DynamicColumnIcon } from '../components/DynamicIcon';
+
+import EmptyTableResults from '../components/EmptyTableResults';
+import DeploymentComponentVulnerabilitiesTable, {
+    DeploymentComponentVulnerability,
+    ImageMetadataContext,
+    deploymentComponentVulnerabilitiesFragment,
+} from './DeploymentComponentVulnerabilitiesTable';
+import { getAnyVulnerabilityIsFixable, getHighestVulnerabilitySeverity } from './table.utils';
+
+export const deploymentWithVulnerabilitiesFragment = gql`
+    ${deploymentComponentVulnerabilitiesFragment}
+    fragment DeploymentWithVulnerabilities on Deployment {
+        id
+        images(query: $query) {
+            ...ImageMetadataContext
+        }
+        imageVulnerabilities(query: $query, pagination: $pagination) {
+            id
+            cve
+            summary
+            images(query: $query) {
+                imageId: id
+                imageComponents(query: $query) {
+                    ...DeploymentComponentVulnerabilities
+                }
+            }
+        }
+    }
+`;
+
+export type DeploymentWithVulnerabilities = {
+    id: string;
+    images: ImageMetadataContext[];
+    imageVulnerabilities: {
+        id: string;
+        cve: string;
+        summary: string;
+        images: {
+            imageId: string;
+            imageComponents: DeploymentComponentVulnerability[];
+        }[];
+    }[];
+};
+
+function formatVulnerabilityData(deployment: DeploymentWithVulnerabilities): {
+    id: string;
+    cve: string;
+    severity: VulnerabilitySeverity;
+    isFixable: boolean;
+    discoveredAtImage: Date | null;
+    summary: string;
+    affectedComponentsText: string;
+    images: {
+        imageMetadataContext: ImageMetadataContext;
+        componentVulnerabilities: DeploymentComponentVulnerability[];
+    }[];
+}[] {
+    const imageMap: Record<string, ImageMetadataContext> = {};
+    deployment.images.forEach((image) => {
+        imageMap[image.id] = image;
+    });
+
+    return deployment.imageVulnerabilities.map((vulnerability) => {
+        const { id, cve, summary, images } = vulnerability;
+        // Severity, Fixability, and Discovered date are all based on the aggregate value of all components
+        const allComponents = vulnerability.images.flatMap((img) => img.imageComponents);
+        const severity = getHighestVulnerabilitySeverity(allComponents);
+        const isFixable = getAnyVulnerabilityIsFixable(allComponents);
+        const allDiscoveredDates = allComponents
+            .flatMap((c) => c.imageVulnerabilities.map((v) => v.discoveredAtImage))
+            .filter((d): d is string => d !== null);
+        const discoveredAtImage = min(...allDiscoveredDates);
+        // TODO This logic is used in many places, could extract to a util
+        const uniqueComponents = new Set(allComponents.map((c) => c.name));
+        const affectedComponentsText =
+            uniqueComponents.size === 1
+                ? uniqueComponents.values().next().value
+                : `${uniqueComponents.size} components`;
+
+        return {
+            id,
+            cve,
+            severity,
+            isFixable,
+            discoveredAtImage,
+            summary,
+            affectedComponentsText,
+            images: images.map((img) => ({
+                imageMetadataContext: imageMap[img.imageId],
+                componentVulnerabilities: img.imageComponents,
+            })),
+        };
+    });
+}
+
+export type DeploymentVulnerabilitiesTableProps = {
+    deployment: DeploymentWithVulnerabilities;
+    getSortParams: UseURLSortResult['getSortParams'];
+    isFiltered: boolean;
+};
+
+function DeploymentVulnerabilitiesTable({
+    deployment,
+    getSortParams,
+    isFiltered,
+}: DeploymentVulnerabilitiesTableProps) {
+    const expandedRowSet = useSet<string>();
+
+    const vulnerabilities = formatVulnerabilityData(deployment);
+
+    return (
+        <TableComposable variant="compact">
+            <Thead>
+                <Tr>
+                    <Th>{/* Header for expanded column */}</Th>
+                    <Th sort={getSortParams('CVE')}>CVE</Th>
+                    <Th>Severity</Th>
+                    <Th>
+                        CVE Status
+                        {isFiltered && <DynamicColumnIcon />}
+                    </Th>
+                    <Th>
+                        Affected components
+                        {isFiltered && <DynamicColumnIcon />}
+                    </Th>
+                    <Th>First discovered</Th>
+                </Tr>
+            </Thead>
+            {vulnerabilities.length === 0 && <EmptyTableResults colSpan={7} />}
+            {vulnerabilities.map((vulnerability, rowIndex) => {
+                const {
+                    cve,
+                    severity,
+                    summary,
+                    isFixable,
+                    images,
+                    affectedComponentsText,
+                    discoveredAtImage,
+                } = vulnerability;
+                const isExpanded = expandedRowSet.has(cve);
+
+                const FixabilityIcon = isFixable ? FixableIcon : NotFixableIcon;
+
+                return (
+                    <Tbody key={cve} isExpanded={isExpanded}>
+                        <Tr>
+                            <Td
+                                expand={{
+                                    rowIndex,
+                                    isExpanded,
+                                    onToggle: () => expandedRowSet.toggle(cve),
+                                }}
+                            />
+                            <Td dataLabel="CVE">
+                                <Button
+                                    variant={ButtonVariant.link}
+                                    isInline
+                                    component={LinkShim}
+                                    href={getEntityPagePath('CVE', cve)}
+                                >
+                                    {cve}
+                                </Button>
+                            </Td>
+                            <Td dataLabel="Severity">
+                                <VulnerabilitySeverityIconText severity={severity} />
+                            </Td>
+                            <Td dataLabel="CVE Status">
+                                <span>
+                                    <FixabilityIcon className="pf-u-display-inline" />
+                                    <span className="pf-u-pl-sm">
+                                        {isFixable ? 'Fixable' : 'Not fixable'}
+                                    </span>
+                                </span>
+                            </Td>
+                            <Td dataLabel="Affected components">{affectedComponentsText}</Td>
+                            <Td dataLabel="First discovered">
+                                {getDistanceStrictAsPhrase(discoveredAtImage, new Date())}
+                            </Td>
+                        </Tr>
+                        <Tr isExpanded={isExpanded}>
+                            <Td />
+                            <Td colSpan={6}>
+                                <ExpandableRowContent>
+                                    <p className="pf-u-mb-md">{summary}</p>
+                                    <DeploymentComponentVulnerabilitiesTable images={images} />
+                                </ExpandableRowContent>
+                            </Td>
+                        </Tr>
+                    </Tbody>
+                );
+            })}
+        </TableComposable>
+    );
+}
+
+export default DeploymentVulnerabilitiesTable;


### PR DESCRIPTION
## Description

Adds the main data table for the deployment single page.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Visit a deployment single page and view the main table:
![image](https://user-images.githubusercontent.com/1292638/235153607-6d11046a-9994-4f6c-8c6d-fe995d7febd1.png)

Loading state:
![image](https://user-images.githubusercontent.com/1292638/235153652-1641c5a3-faea-4e80-bc1b-2b111a5f9801.png)

Error state:
![image](https://user-images.githubusercontent.com/1292638/235154054-e2a992ee-d4f6-4249-8184-07dadc35d5c5.png)

Viewing the embedded table with multiple related images:
![image](https://user-images.githubusercontent.com/1292638/235154221-1242c6a7-8732-459c-a474-51458d06624c.png)

