### PR TITLE
ROX-15028: Adding CVE list to Workload CVEs Overview page

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/CVEsTableContainer.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/CVEsTableContainer.tsx
@@ -6,7 +6,7 @@ import useURLSort from 'hooks/useURLSort';
 import useURLPagination from 'hooks/useURLPagination';
 import useURLSearch from 'hooks/useURLSearch';
 import { getHasSearchApplied, getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
-import CVEsTable, { cveListQuery } from '../Tables/CVEsTable';
+import CVEsTable, { cveListQuery, unfilteredImageCountQuery } from '../Tables/CVEsTable';
 import TableErrorComponent from '../components/TableErrorComponent';
 import { parseQuerySearchFilter } from '../searchUtils';
 
@@ -39,6 +39,8 @@ function CVEsTableContainer() {
         },
     });
 
+    const { data: imageCountData } = useQuery(unfilteredImageCountQuery);
+
     const tableData = data ?? previousData;
     return (
         <>
@@ -52,7 +54,8 @@ function CVEsTableContainer() {
             )}
             {tableData && (
                 <CVEsTable
-                    cves={data.imageCVEs}
+                    cves={tableData.imageCVEs}
+                    unfilteredImageCount={imageCountData?.imageCount || 0}
                     getSortParams={getSortParams}
                     isFiltered={isFiltered}
                 />

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/CVEsTableContainer.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/CVEsTableContainer.tsx
@@ -1,7 +1,64 @@
 import React from 'react';
+import { useQuery } from '@apollo/client';
+import { Bullseye, Spinner } from '@patternfly/react-core';
+
+import useURLSort from 'hooks/useURLSort';
+import useURLPagination from 'hooks/useURLPagination';
+import useURLSearch from 'hooks/useURLSearch';
+import { getHasSearchApplied, getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
+import CVEsTable, { cveListQuery } from '../Tables/CVEsTable';
+import TableErrorComponent from '../components/TableErrorComponent';
+import { parseQuerySearchFilter } from '../searchUtils';
+
+const defaultSortFields = ['Deployment', 'Cluster', 'Namespace'];
 
 function CVEsTableContainer() {
-    return <div>CVE table</div>;
+    const { searchFilter } = useURLSearch();
+    const querySearchFilter = parseQuerySearchFilter(searchFilter);
+    const isFiltered = getHasSearchApplied(querySearchFilter);
+    const { page, perPage, setPage } = useURLPagination(25);
+    const { sortOption, getSortParams } = useURLSort({
+        sortFields: defaultSortFields,
+        defaultSortOption: {
+            field: 'CVE',
+            direction: 'asc',
+        },
+        onSort: () => setPage(1),
+    });
+
+    const { error, loading, data, previousData } = useQuery(cveListQuery, {
+        variables: {
+            query: getRequestQueryStringForSearchFilter({
+                ...querySearchFilter,
+            }),
+            pagination: {
+                offset: (page - 1) * perPage,
+                limit: perPage,
+                sortOption,
+            },
+        },
+    });
+
+    const tableData = data ?? previousData;
+    return (
+        <>
+            {loading && !tableData && (
+                <Bullseye>
+                    <Spinner isSVG />
+                </Bullseye>
+            )}
+            {error && (
+                <TableErrorComponent error={error} message="Adjust your filters and try again" />
+            )}
+            {tableData && (
+                <CVEsTable
+                    cves={data.imageCVEs}
+                    getSortParams={getSortParams}
+                    isFiltered={isFiltered}
+                />
+            )}
+        </>
+    );
 }
 
 export default CVEsTableContainer;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/CveStatusTabNavigation.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/CveStatusTabNavigation.tsx
@@ -104,7 +104,7 @@ function CveStatusTabNavigation({ defaultFilters }: CveStatusTabNavigationProps)
                                     <ToolbarItem>
                                         <EntityTypeToggleGroup
                                             imageCount={countsData?.imageCount}
-                                            cveCount={countsData?.cveCount}
+                                            cveCount={countsData?.imageCVECount}
                                             deploymentCount={countsData?.deploymentCount}
                                         />
                                     </ToolbarItem>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/CVEsTable.tsx
@@ -1,6 +1,14 @@
 import React from 'react';
 import { gql } from '@apollo/client';
-import { TableComposable, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import {
+    TableComposable,
+    Tbody,
+    Td,
+    Th,
+    Thead,
+    Tr,
+    ExpandableRowContent,
+} from '@patternfly/react-table';
 import { Button, ButtonVariant, Tooltip } from '@patternfly/react-core';
 
 import LinkShim from 'Components/PatternFly/LinkShim';
@@ -29,6 +37,12 @@ export const cveListQuery = gql`
     }
 `;
 
+export const unfilteredImageCountQuery = gql`
+    query getUnfilteredImageCount {
+        imageCount
+    }
+`;
+
 type ImageCVE = {
     cve: string;
     // summary: string;
@@ -38,18 +52,19 @@ type ImageCVE = {
         moderate: number;
         low: number;
     };
-    topCVSS: string;
+    topCVSS: number;
     affectedImageCount: number;
     firstDiscoveredInSystem: Date | null;
 };
 
 type CVEsTableProps = {
     cves: ImageCVE[];
+    unfilteredImageCount: number;
     getSortParams: UseURLSortResult['getSortParams'];
     isFiltered: boolean;
 };
 
-function CVEsTable({ cves, getSortParams, isFiltered }: CVEsTableProps) {
+function CVEsTable({ cves, unfilteredImageCount, getSortParams, isFiltered }: CVEsTableProps) {
     const expandedRowSet = useSet<string>();
     return (
         <TableComposable borders={false} variant="compact">
@@ -118,8 +133,12 @@ function CVEsTable({ cves, getSortParams, isFiltered }: CVEsTableProps) {
                                         low={affectedImageCountBySeverity.low}
                                     />
                                 </Td>
-                                <Td>{topCVSS}</Td>
-                                <Td>{affectedImageCount}</Td>
+                                {/* TODO: score version? */}
+                                <Td>{topCVSS.toFixed(1)}</Td>
+                                <Td>
+                                    {/* TODO: fix upon PM feedback */}
+                                    {affectedImageCount}/{unfilteredImageCount} affected images
+                                </Td>
                                 <Td>
                                     <Tooltip content={getDateTime(firstDiscoveredInSystem)}>
                                         <div>
@@ -129,6 +148,22 @@ function CVEsTable({ cves, getSortParams, isFiltered }: CVEsTableProps) {
                                             )}
                                         </div>
                                     </Tooltip>
+                                </Td>
+                            </Tr>
+                            <Tr isExpanded={isExpanded}>
+                                <Td />
+                                <Td colSpan={6}>
+                                    <ExpandableRowContent>
+                                        {/* TODO: add summary once it's in */}
+                                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. In
+                                        a vehicula nisl. Interdum et malesuada fames ac ante ipsum
+                                        primis in faucibus. Duis mollis nisi eget augue rhoncus, a
+                                        consectetur magna tincidunt. Nam est diam, aliquet at
+                                        hendrerit at, venenatis eu est. Integer pulvinar diam ac dui
+                                        efficitur finibus. Vestibulum ante ipsum primis in faucibus
+                                        orci luctus et ultrices posuere cubilia curae; Cras eu ex
+                                        sit amet enim lacinia placerat eget vitae arcu.
+                                    </ExpandableRowContent>
                                 </Td>
                             </Tr>
                         </Tbody>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/CVEsTable.tsx
@@ -1,0 +1,142 @@
+import React from 'react';
+import { gql } from '@apollo/client';
+import { TableComposable, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import { Button, ButtonVariant, Tooltip } from '@patternfly/react-core';
+
+import LinkShim from 'Components/PatternFly/LinkShim';
+import { getDistanceStrictAsPhrase, getDateTime } from 'utils/dateUtils';
+import { UseURLSortResult } from 'hooks/useURLSort';
+import useSet from 'hooks/useSet';
+
+import { getEntityPagePath } from '../searchUtils';
+import SeverityCountLabels from '../components/SeverityCountLabels';
+import { DynamicColumnIcon } from '../components/DynamicIcon';
+
+export const cveListQuery = gql`
+    query getImageCVEList($query: String, $pagination: Pagination) {
+        imageCVEs(query: $query, pagination: $pagination) {
+            cve
+            affectedImageCountBySeverity {
+                critical
+                important
+                moderate
+                low
+            }
+            topCVSS
+            affectedImageCount
+            firstDiscoveredInSystem
+        }
+    }
+`;
+
+type ImageCVE = {
+    cve: string;
+    // summary: string;
+    affectedImageCountBySeverity: {
+        critical: number;
+        important: number;
+        moderate: number;
+        low: number;
+    };
+    topCVSS: string;
+    affectedImageCount: number;
+    firstDiscoveredInSystem: Date | null;
+};
+
+type CVEsTableProps = {
+    cves: ImageCVE[];
+    getSortParams: UseURLSortResult['getSortParams'];
+    isFiltered: boolean;
+};
+
+function CVEsTable({ cves, getSortParams, isFiltered }: CVEsTableProps) {
+    const expandedRowSet = useSet<string>();
+    return (
+        <TableComposable borders={false} variant="compact">
+            <Thead>
+                {/* TODO: need to double check sorting on columns  */}
+                <Tr>
+                    <Th>{/* Header for expanded column */}</Th>
+                    <Th sort={getSortParams('CVE')}>CVE</Th>
+                    <Th tooltip="Severity of this CVE across images">
+                        Images by severity
+                        {isFiltered && <DynamicColumnIcon />}
+                    </Th>
+                    <Th tooltip="Highest CVSS score of this CVE across images">Top CVSS</Th>
+                    <Th tooltip="Ratio of total environment affect by this CVE">
+                        Affected images
+                        {isFiltered && <DynamicColumnIcon />}
+                    </Th>
+                    <Th tooltip="Time since this CVE first affected an entity">First discovered</Th>
+                </Tr>
+            </Thead>
+            {cves.map(
+                (
+                    {
+                        cve,
+                        // summary,
+                        affectedImageCountBySeverity,
+                        topCVSS,
+                        affectedImageCount,
+                        firstDiscoveredInSystem,
+                    },
+                    rowIndex
+                ) => {
+                    const isExpanded = expandedRowSet.has(cve);
+
+                    return (
+                        <Tbody
+                            key={cve}
+                            style={{
+                                borderBottom: '1px solid var(--pf-c-table--BorderColor)',
+                            }}
+                            isExpanded={isExpanded}
+                        >
+                            <Tr>
+                                <Td
+                                    expand={{
+                                        rowIndex,
+                                        isExpanded,
+                                        onToggle: () => expandedRowSet.toggle(cve),
+                                    }}
+                                />
+                                <Td>
+                                    <Button
+                                        variant={ButtonVariant.link}
+                                        isInline
+                                        component={LinkShim}
+                                        href={getEntityPagePath('CVE', cve)}
+                                    >
+                                        {cve}
+                                    </Button>
+                                </Td>
+                                <Td>
+                                    <SeverityCountLabels
+                                        critical={affectedImageCountBySeverity.critical}
+                                        important={affectedImageCountBySeverity.important}
+                                        moderate={affectedImageCountBySeverity.moderate}
+                                        low={affectedImageCountBySeverity.low}
+                                    />
+                                </Td>
+                                <Td>{topCVSS}</Td>
+                                <Td>{affectedImageCount}</Td>
+                                <Td>
+                                    <Tooltip content={getDateTime(firstDiscoveredInSystem)}>
+                                        <div>
+                                            {getDistanceStrictAsPhrase(
+                                                firstDiscoveredInSystem,
+                                                new Date()
+                                            )}
+                                        </div>
+                                    </Tooltip>
+                                </Td>
+                            </Tr>
+                        </Tbody>
+                    );
+                }
+            )}
+        </TableComposable>
+    );
+}
+
+export default CVEsTable;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/SeverityCountLabels.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/SeverityCountLabels.tsx
@@ -2,6 +2,9 @@ import React from 'react';
 import { Flex, Label } from '@patternfly/react-core';
 
 import SeverityIcons from 'Components/PatternFly/SeverityIcons';
+import { vulnSeverityTextColors } from 'constants/visuals/colors';
+
+const fadedTextColor = 'var(--pf-global--Color--200)';
 
 type SeverityCountLabelsProps = {
     critical: number;
@@ -18,17 +21,65 @@ function SeverityCountLabels({ critical, important, moderate, low }: SeverityCou
 
     return (
         <Flex spaceItems={{ default: 'spaceItemsSm' }}>
-            <Label variant="outline" icon={<CriticalIcon />}>
-                {critical}
+            <Label
+                variant="outline"
+                className="pf-u-font-weight-bold"
+                icon={<CriticalIcon color={critical ? undefined : fadedTextColor} />}
+            >
+                <span
+                    style={{
+                        color: critical
+                            ? vulnSeverityTextColors.CRITICAL_VULNERABILITY_SEVERITY
+                            : fadedTextColor,
+                    }}
+                >
+                    {critical}
+                </span>
             </Label>
-            <Label variant="outline" icon={<ImportantIcon />}>
-                {important}
+            <Label
+                variant="outline"
+                className="pf-u-font-weight-bold"
+                icon={<ImportantIcon color={important ? undefined : fadedTextColor} />}
+            >
+                <span
+                    style={{
+                        color: important
+                            ? vulnSeverityTextColors.IMPORTANT_VULNERABILITY_SEVERITY
+                            : fadedTextColor,
+                    }}
+                >
+                    {important}
+                </span>
             </Label>
-            <Label variant="outline" icon={<ModerateIcon />}>
-                {moderate}
+            <Label
+                variant="outline"
+                className="pf-u-font-weight-bold"
+                icon={<ModerateIcon color={moderate ? undefined : fadedTextColor} />}
+            >
+                <span
+                    style={{
+                        color: moderate
+                            ? vulnSeverityTextColors.MODERATE_VULNERABILITY_SEVERITY
+                            : fadedTextColor,
+                    }}
+                >
+                    {moderate}
+                </span>
             </Label>
-            <Label variant="outline" icon={<LowIcon />}>
-                {low}
+            <Label
+                variant="outline"
+                className="pf-u-font-weight-bold"
+                icon={<LowIcon color={low ? undefined : fadedTextColor} />}
+            >
+                <span
+                    style={{
+                        color: low
+                            ? vulnSeverityTextColors.LOW_VULNERABILITY_SEVERITY
+                            : fadedTextColor,
+                    }}
+                >
+                    {low}
+                </span>
             </Label>
         </Flex>
     );

--- a/ui/apps/platform/src/constants/visuals/colors.ts
+++ b/ui/apps/platform/src/constants/visuals/colors.ts
@@ -35,4 +35,12 @@ export const vulnSeverityIconColors: Record<VulnerabilitySeverity, string> = {
     UNKNOWN_VULNERABILITY_SEVERITY: 'var(--pf-global--palette--black-400)',
 };
 
+export const vulnSeverityTextColors: Record<VulnerabilitySeverity, string> = {
+    LOW_VULNERABILITY_SEVERITY: 'var(--pf-global--palette--blue-500)',
+    MODERATE_VULNERABILITY_SEVERITY: 'var(--pf-global--palette--gold-600)',
+    IMPORTANT_VULNERABILITY_SEVERITY: 'var(--pf-global--palette--orange-500)',
+    CRITICAL_VULNERABILITY_SEVERITY: 'var(--pf-global--palette--red-200)',
+    UNKNOWN_VULNERABILITY_SEVERITY: 'var(--pf-global--palette--black-400)',
+};
+
 export default colors;


### PR DESCRIPTION
As the title states, adding the CVE list to the Overview page. Everything should function as expected, although there are a few things tbd on PM that i have left in the comments.
<img width="1439" alt="image" src="https://user-images.githubusercontent.com/10412893/233735452-100d6374-e0a9-4011-8e9c-a61bc7c7c17b.png">
<img width="1423" alt="image" src="https://user-images.githubusercontent.com/10412893/233735632-4c5d4af7-2ea5-4712-8e16-8704a80ca81b.png">
<img width="1415" alt="image" src="https://user-images.githubusercontent.com/10412893/233735668-570b91fd-42e2-4611-8b9f-ee48bb1266f5.png">
<img width="1417" alt="image" src="https://user-images.githubusercontent.com/10412893/233735716-9c0a6f1b-5b4a-4136-8a0e-12de34592083.png">
also fixed the severity colors again on the severity labels

TODO:
* get clarity on score version for CVSS column
* get clarity on denominator for affected images column
* update summary once BE is ready
* add empty results page to tables