### PR TITLE
ROX-16548: test latest sensor vs older central

### DIFF
--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -365,14 +365,14 @@ function launch_central {
 
       local helm_chart="$unzip_dir/chart"
 
+      if [[ -n "${CENTRAL_CHART_DIR_OVERRIDE}" ]]; then
+        helm_chart="${CENTRAL_CHART_DIR_OVERRIDE}"
+      fi
+
       if [[ -n "$CI" ]]; then
         helm lint "${helm_chart}"
         helm lint "${helm_chart}" -n stackrox
         helm lint "${helm_chart}" -n stackrox "${helm_args[@]}"
-      fi
-
-      if [[ -n "${CENTRAL_CHART_DIR_OVERRIDE}" ]]; then
-        helm_chart="${CENTRAL_CHART_DIR_OVERRIDE}"
       fi
 
       set -x
@@ -625,6 +625,10 @@ function launch_sensor {
 
       local helm_chart="$k8s_dir/sensor-deploy/chart"
 
+      if [[ -n "${SENSOR_CHART_DIR_OVERRIDE}" ]]; then
+        helm_chart="${SENSOR_CHART_DIR_OVERRIDE}"
+      fi
+
       if [[ -n "$CI" ]]; then
         helm lint "${helm_chart}"
         helm lint "${helm_chart}" -n stackrox
@@ -634,10 +638,6 @@ function launch_sensor {
       if [[ "$sensor_namespace" != "stackrox" ]]; then
         kubectl create namespace "$sensor_namespace" &>/dev/null || true
         kubectl -n "$sensor_namespace" get secret stackrox &>/dev/null || kubectl -n "$sensor_namespace" create -f - < <("${common_dir}/pull-secret.sh" stackrox docker.io)
-      fi
-
-      if [[ -n "${SENSOR_CHART_DIR_OVERRIDE}" ]]; then
-        helm_chart="${SENSOR_CHART_DIR_OVERRIDE}"
       fi
 
       set -x

--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -366,6 +366,7 @@ function launch_central {
       local helm_chart="$unzip_dir/chart"
 
       if [[ -n "${CENTRAL_CHART_DIR_OVERRIDE}" ]]; then
+        echo "Using override central helm chart from ${CENTRAL_CHART_DIR_OVERRIDE}"
         helm_chart="${CENTRAL_CHART_DIR_OVERRIDE}"
       fi
 
@@ -376,8 +377,6 @@ function launch_central {
       fi
 
       set -x
-      echo "About to install central, running ls -la"
-      ls -la "${helm_chart}"
       helm upgrade --install -n stackrox stackrox-central-services "$helm_chart" \
           "${helm_args[@]}"
       set +x
@@ -626,6 +625,7 @@ function launch_sensor {
       local helm_chart="$k8s_dir/sensor-deploy/chart"
 
       if [[ -n "${SENSOR_CHART_DIR_OVERRIDE}" ]]; then
+        echo "Using override sensor helm chart from ${SENSOR_CHART_DIR_OVERRIDE}"
         helm_chart="${SENSOR_CHART_DIR_OVERRIDE}"
       fi
 
@@ -641,8 +641,6 @@ function launch_sensor {
       fi
 
       set -x
-      echo "About to install sensor, running ls -la"
-      ls -la "${helm_chart}"
       helm upgrade --install -n "$sensor_namespace" --create-namespace stackrox-secured-cluster-services "$helm_chart" \
           "${helm_args[@]}" "${extra_helm_config[@]}"
       set +x

--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -376,6 +376,8 @@ function launch_central {
       fi
 
       set -x
+      echo "About to install central, running ls -la"
+      ls -la "${helm_chart}"
       helm upgrade --install -n stackrox stackrox-central-services "$helm_chart" \
           "${helm_args[@]}"
       set +x
@@ -639,6 +641,8 @@ function launch_sensor {
       fi
 
       set -x
+      echo "About to install sensor, running ls -la"
+      ls -la "${helm_chart}"
       helm upgrade --install -n "$sensor_namespace" --create-namespace stackrox-secured-cluster-services "$helm_chart" \
           "${helm_args[@]}" "${extra_helm_config[@]}"
       set +x

--- a/scripts/ci/jobs/gke_version_compatibility_tests.py
+++ b/scripts/ci/jobs/gke_version_compatibility_tests.py
@@ -5,31 +5,52 @@ Run version compatibility tests
 """
 import logging
 import os
+import subprocess
 import sys
 
 from clusters import GKECluster
+from collections import namedtuple
 from compatibility_test import make_compatibility_test_runner
 from get_latest_helm_chart_versions import get_latest_helm_chart_versions
+from pathlib import Path
+
+# start logging
+logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
 
 # set required test parameters
 os.environ["ORCHESTRATOR_FLAVOR"] = "k8s"
 os.environ["ROX_POSTGRES_DATASTORE"] = "true"
 
-logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
+central_chart_versions = get_latest_helm_chart_versions("stackrox-central-services", 2)
+sensor_chart_versions = get_latest_helm_chart_versions("stackrox-secured-cluster-services", 3)
+makefile_path = Path(__file__).parent.parent.parent.parent
+latest_tag = subprocess.check_output(["make", "tag", "-C", makefile_path, "--quiet", "--no-print-director"], shell=False, encoding='utf-8').strip()
 
-chart_versions = get_latest_helm_chart_versions("stackrox-secured-cluster-services")
+if len(central_chart_versions) == 0:
+    raise RuntimeError("Could not find central chart versions.")
+if len(sensor_chart_versions) == 0:
+    raise RuntimeError("Could not find sensor chart versions.")
+
+Chart_versions = namedtuple("Chart_versions", ["central_version", "sensor_version"])
+
+# Latest central vs sensor versions in sensor_chart_versions
+test_tuples = [Chart_versions(central_version=latest_tag, sensor_version=sensor_chart_version) for sensor_chart_version in sensor_chart_versions]
+# Latest sensor vs central versions in central_chart_versions
+test_tuples.extend([Chart_versions(central_version=central_chart_version, sensor_version=latest_tag) for central_chart_version in central_chart_versions])
 
 gkecluster = GKECluster("compat-test", machine_type="e2-standard-8", num_nodes=2)
 
-failing_sensor_versions = []
-for version in chart_versions:
-    os.environ["SENSOR_CHART_VERSION"] = version
+failing_tuples = []
+for tuple in test_tuples:
+    os.environ["CENTRAL_CHART_VERSION_OVERRIDE"] = tuple.central_version
+    os.environ["SENSOR_CHART_VERSION_OVERRIDE"] = tuple.sensor_version
     try:
         make_compatibility_test_runner(cluster=gkecluster).run()
-    except Exception:
-        print(f"Exception \"{Exception}\" raised in compatibility test for sensor chart version {version}",
-              file=sys.stderr)
-        failing_sensor_versions += version
+    except Exception as e:
+        print(f"Exception \"{str(e)}\" raised in compatibility test for central version {tuple.central_version} and sensor version {tuple.sensor_version}",
+            file=sys.stderr)
+        failing_tuples.append(tuple)
 
-if len(failing_sensor_versions) > 0:
-    raise RuntimeError(f"Compatibility tests failed for Sensor versions " + ', '.join(failing_sensor_versions))
+if len(failing_tuples) > 0:
+    failing_string = ', '.join([("(Central v" + str(failing_tuple.central_version) + ", Sensor v" + str(failing_tuple.sensor_version) + ")") for failing_tuple in failing_tuples])
+    raise RuntimeError("Compatibility tests failed for versions " + failing_string + ".")

--- a/scripts/style/shellcheck_skip.txt
+++ b/scripts/style/shellcheck_skip.txt
@@ -48,7 +48,6 @@ scripts/offline-bundle/image-collector-bundle/import.sh
 scripts/port-forward-ui.sh
 scripts/reference/build-quay-operator-bundles.sh
 scripts/sync-release-branch.sh
-tests/e2e/lib.sh
 tests/roxctl/authz-trace.sh
 tests/roxctl/helm-chart-generation.sh
 tests/roxctl/istio-support.sh

--- a/scripts/style/shellcheck_skip.txt
+++ b/scripts/style/shellcheck_skip.txt
@@ -48,6 +48,7 @@ scripts/offline-bundle/image-collector-bundle/import.sh
 scripts/port-forward-ui.sh
 scripts/reference/build-quay-operator-bundles.sh
 scripts/sync-release-branch.sh
+tests/e2e/lib.sh
 tests/roxctl/authz-trace.sh
 tests/roxctl/helm-chart-generation.sh
 tests/roxctl/istio-support.sh

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -56,7 +56,7 @@ deploy_stackrox_with_custom_central_and_sensor_versions() {
     helm repo add "${helm_repo_name}" https://raw.githubusercontent.com/stackrox/helm-charts/main/opensource
     helm repo update
 
-    current_tag="$(make tag--quiet --no-print-directory)"
+    current_tag="$(make tag --quiet --no-print-directory)"
 
     helm_charts="$(helm search repo "${helm_repo_name}" -l)"
     central_regex="${helm_repo_name}/stackrox-central-services[ \t]*.${CENTRAL_CHART_VERSION_OVERRIDE}[ \t]*.([0-9]+\.[0-9]+\.[0-9]+)"
@@ -66,15 +66,15 @@ deploy_stackrox_with_custom_central_and_sensor_versions() {
     chart_parent_dir="./central-chart-dir-compatibility-tests"
     chart_name="stackrox-central-services"
     if  [[ $helm_charts =~ $central_regex ]]; then
-        central_chart=""${helm_repo_name}"/"${chart_name}""
-        ci_export CENTRAL_CHART_DIR_OVERRIDE ""${chart_parent_dir}"/"${chart_name}""
+        central_chart="${helm_repo_name}/${chart_name}"
+        ci_export CENTRAL_CHART_DIR_OVERRIDE "${chart_parent_dir}/${chart_name}"
         helm pull "${central_chart}" --version "${CENTRAL_CHART_VERSION_OVERRIDE}" --untar --untardir "${chart_parent_dir}"
-        echo >&2 "Pulled helm chart for "${chart_name}" to ${CENTRAL_CHART_DIR_OVERRIDE}, running ls -a"
+        echo >&2 "Pulled helm chart for ${chart_name} to ${CENTRAL_CHART_DIR_OVERRIDE}, running ls -la"
         set -x
         ls -la "${CENTRAL_CHART_DIR_OVERRIDE}"
         set +x
     elif [[ "$current_tag" != "$CENTRAL_CHART_VERSION_OVERRIDE" ]]; then
-        echo ""${chart_name}" helm chart for version ${CENTRAL_CHART_VERSION_OVERRIDE} not found in ${helm_repo_name} repo nor is it the current tag."
+        echo "${chart_name} helm chart for version ${CENTRAL_CHART_VERSION_OVERRIDE} not found in ${helm_repo_name} repo nor is it the current tag."
         exit 1
     fi
 
@@ -84,23 +84,23 @@ deploy_stackrox_with_custom_central_and_sensor_versions() {
     chart_parent_dir="./sensor-chart-dir-compatibility-tests"
     chart_name="stackrox-secured-cluster-services"
     if [[ $helm_charts =~ $sensor_regex ]]; then
-        sensor_chart=""${helm_repo_name}"/"${chart_name}""
-        ci_export SENSOR_CHART_DIR_OVERRIDE ""${chart_parent_dir}"/"${chart_name}""
+        sensor_chart="${helm_repo_name}/${chart_name}"
+        ci_export SENSOR_CHART_DIR_OVERRIDE "${chart_parent_dir}/${chart_name}"
         helm pull "${sensor_chart}" --version "${SENSOR_CHART_VERSION_OVERRIDE}" --untar --untardir "${chart_parent_dir}"
-        echo "Pulled helm chart for "${chart_name}" to ${SENSOR_CHART_DIR_OVERRIDE}, running ls -a"
+        echo "Pulled helm chart for ${chart_name} to ${SENSOR_CHART_DIR_OVERRIDE}, running ls -a"
         set -x
         ls -la "${SENSOR_CHART_DIR_OVERRIDE}"
         set +x
     elif [[ "$current_tag" == "$SENSOR_CHART_VERSION_OVERRIDE" ]]; then
         if [[ $(roxctl version) != "$current_tag" ]]; then
-            >&2 echo "Reported roxctl version $(roxctl version) is different from requested tag ${current_tag}. It won't be possible to get helm charts for ${current_tag}. Please check test setup."
+            >&2 echo "Reported roxctl version "$(roxctl version)" is different from requested tag ${current_tag}. It won't be possible to get helm charts for ${current_tag}. Please check test setup."
             exit 1
         fi
-        ci_export SENSOR_CHART_DIR_OVERRIDE ""${chart_parent_dir}"/"${chart_name}""
+        ci_export SENSOR_CHART_DIR_OVERRIDE "${chart_parent_dir}/${chart_name}"
         roxctl helm output secured-cluster-services --image-defaults=opensource --output-dir "${SENSOR_CHART_DIR_OVERRIDE}" --remove
-        echo "Downloaded "${chart_name}" helm chart for version ${SENSOR_CHART_VERSION_OVERRIDE} to ${SENSOR_CHART_DIR_OVERRIDE}"
+        echo "Downloaded ${chart_name} helm chart for version ${SENSOR_CHART_VERSION_OVERRIDE} to ${SENSOR_CHART_DIR_OVERRIDE}"
     else
-        echo >&2 ""${chart_name}" helm chart for version ${SENSOR_CHART_VERSION_OVERRIDE} not found in ${helm_repo_name} repo nor is it the latest tag."
+        echo >&2 "${chart_name} helm chart for version ${SENSOR_CHART_VERSION_OVERRIDE} not found in ${helm_repo_name} repo nor is it the latest tag."
         exit 1
     fi
 

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -72,7 +72,7 @@ deploy_stackrox_with_custom_central_and_sensor_versions() {
         helm pull "${central_chart}" --version "${CENTRAL_CHART_VERSION_OVERRIDE}" --untar --untardir "${charts_dir}"
         echo "Pulled helm chart for ${chart_name} to ${CENTRAL_CHART_DIR_OVERRIDE}"
     elif [[ "$current_tag" != "$CENTRAL_CHART_VERSION_OVERRIDE" ]]; then
-        echo "${chart_name} helm chart for version ${CENTRAL_CHART_VERSION_OVERRIDE} not found in ${helm_repo_name} repo nor is it the current tag."
+        echo >&2 "${chart_name} helm chart for version ${CENTRAL_CHART_VERSION_OVERRIDE} not found in ${helm_repo_name} repo nor is it the current tag."
         exit 1
     fi
 
@@ -87,7 +87,7 @@ deploy_stackrox_with_custom_central_and_sensor_versions() {
         echo "Pulled helm chart for ${chart_name} to ${SENSOR_CHART_DIR_OVERRIDE}"
     elif [[ "$current_tag" == "$SENSOR_CHART_VERSION_OVERRIDE" ]]; then
         if [[ $(roxctl version) != "$current_tag" ]]; then
-            >&2 echo "Reported roxctl version $(roxctl version) is different from requested tag ${current_tag}. It won't be possible to get helm charts for ${current_tag}. Please check test setup."
+            echo >&2 "Reported roxctl version $(roxctl version) is different from requested tag ${current_tag}. It won't be possible to get helm charts for ${current_tag}. Please check test setup."
             exit 1
         fi
         ci_export SENSOR_CHART_DIR_OVERRIDE "${charts_dir}/${chart_name}"

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -92,8 +92,8 @@ deploy_stackrox_with_custom_central_and_sensor_versions() {
         ls -la "${SENSOR_CHART_DIR_OVERRIDE}"
         set +x
     elif [[ "$current_tag" == "$SENSOR_CHART_VERSION_OVERRIDE" ]]; then
-        if [[ $(roxctl version) != "$latest_tag" ]]; then
-            echo >&2 "Roxctl version $(roxctl version) is not equal to latest tag ${current_tag}"
+        if [[ $(roxctl version) != "$current_tag" ]]; then
+            >&2 echo "Reported roxctl version $(roxctl version) is different from requested tag ${current_tag}. It won't be possible to get helm charts for ${current_tag}. Please check test setup."
             exit 1
         fi
         ci_export SENSOR_CHART_DIR_OVERRIDE ""${chart_parent_dir}"/"${chart_name}""

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -69,8 +69,12 @@ deploy_stackrox_with_custom_central_and_sensor_versions() {
         ci_export CENTRAL_CHART_DIR_OVERRIDE "./central-chart-dir-compatibility-tests"
         central_chart="${helm_repo_name}/stackrox-central-services"
         helm pull "${central_chart}" --version "${CENTRAL_CHART_VERSION_OVERRIDE}" --untar --untardir "${CENTRAL_CHART_DIR_OVERRIDE}"
+        echo >&2 "Pulled helm chart for central-services to ${CENTRAL_CHART_DIR_OVERRIDE}, running ls -a"
+        set -x
+        ls -la "${CENTRAL_CHART_DIR_OVERRIDE}"
+        set +x
     elif [[ "$latest_tag" != "$CENTRAL_CHART_VERSION_OVERRIDE" ]]; then
-        echo >&2 "stackrox-central-services helm chart for version ${CENTRAL_CHART_VERSION_OVERRIDE} not found in ${helm_repo_name} repo nor is it the latest tag."
+        echo "stackrox-central-services helm chart for version ${CENTRAL_CHART_VERSION_OVERRIDE} not found in ${helm_repo_name} repo nor is it the latest tag."
         exit 1
     fi
 
@@ -81,6 +85,10 @@ deploy_stackrox_with_custom_central_and_sensor_versions() {
         sensor_chart="${helm_repo_name}/stackrox-secured-cluster-services"
         ci_export SENSOR_CHART_DIR_OVERRIDE "./sensor-chart-dir-compatibility-tests"
         helm pull "${sensor_chart}" --version "${SENSOR_CHART_VERSION_OVERRIDE}" --untar --untardir "${SENSOR_CHART_DIR_OVERRIDE}"
+        echo "Pulled helm chart for central-services to ${SENSOR_CHART_DIR_OVERRIDE}, running ls -a"
+        set -x
+        ls -la "${SENSOR_CHART_DIR_OVERRIDE}"
+        set +x
     elif [[ "$latest_tag" == "$SENSOR_CHART_VERSION_OVERRIDE" ]]; then
         if [[ $(roxctl version) != "$latest_tag" ]]; then
             echo >&2 "Roxctl version $(roxctl version) is not equal to latest tag ${latest_tag}"
@@ -89,7 +97,6 @@ deploy_stackrox_with_custom_central_and_sensor_versions() {
         ci_export SENSOR_CHART_DIR_OVERRIDE "./sensor-chart-dir-compatibility-tests"
         roxctl helm output secured-cluster-services --image-defaults=opensource --output-dir "${SENSOR_CHART_DIR_OVERRIDE}" --remove
         echo "Downloaded stackrox-secured-cluster-services helm chart for version ${SENSOR_CHART_VERSION_OVERRIDE} to ${SENSOR_CHART_DIR_OVERRIDE}"
-        unset SENSOR_CHART_VERSION_OVERRIDE
     else
         echo >&2 "stackrox-secured-cluster-services helm chart for version ${SENSOR_CHART_VERSION_OVERRIDE} not found in ${helm_repo_name} repo nor is it the latest tag."
         exit 1

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -87,7 +87,7 @@ deploy_stackrox_with_custom_central_and_sensor_versions() {
         echo "Pulled helm chart for ${chart_name} to ${SENSOR_CHART_DIR_OVERRIDE}"
     elif [[ "$current_tag" == "$SENSOR_CHART_VERSION_OVERRIDE" ]]; then
         if [[ $(roxctl version) != "$current_tag" ]]; then
-            >&2 echo "Reported roxctl version "$(roxctl version)" is different from requested tag ${current_tag}. It won't be possible to get helm charts for ${current_tag}. Please check test setup."
+            >&2 echo "Reported roxctl version $(roxctl version) is different from requested tag ${current_tag}. It won't be possible to get helm charts for ${current_tag}. Please check test setup."
             exit 1
         fi
         ci_export SENSOR_CHART_DIR_OVERRIDE "${charts_dir}/${chart_name}"

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -64,7 +64,7 @@ deploy_stackrox_with_custom_central_and_sensor_versions() {
 
     charts_dir="$(mktemp -d ./charts-dir.XXXXXX)"
 
-    # If the central version is the latest the default behavior of deploy_central() is correct for compatibility tests
+    # If the central version is the same as the current_tag, the default behavior of deploy_central() is correct for compatibility tests
     chart_name="stackrox-central-services"
     if  [[ $helm_charts =~ $central_regex ]]; then
         central_chart="${helm_repo_name}/${chart_name}"
@@ -76,9 +76,9 @@ deploy_stackrox_with_custom_central_and_sensor_versions() {
         exit 1
     fi
 
-    # If the sensor version is the latest the default behavior of deploy_sensor() is incorrect, because it will deploy
-    # a sensor version to match the central version. In our tests we want to test latest sensor vs older central too,
-    # and since latest sensor is not available in the repo either the chart is created here in the elif case.
+    # If the sensor version is the same as the current_tag the default behavior of deploy_sensor() is incorrect, because it will deploy
+    # a sensor version to match the central version. In our tests we want to test current sensor vs older central too,
+    # and since current sensor is not available in the repo either the chart is created here in the elif case.
     chart_name="stackrox-secured-cluster-services"
     if [[ $helm_charts =~ $sensor_regex ]]; then
         sensor_chart="${helm_repo_name}/${chart_name}"


### PR DESCRIPTION
## Description

Add version compatibility tests for a central deployment one version behind the latest release vs latest sensor. Methods vary as follows based on what version is changed:
 * Latest Central: Default deployment
 * Older Central: Overriding chart directory to stackrox-oss and setting the `--version` flag.
 * Latest Sensor: Using `roxctl helm output secured-cluster-services` to create the latest helm chart and overriding the chart directory to the directory of that chart. This is necessary because by default the sensor helm chart is provisioned from the central deployment, but given an older central that helm chart won't be the latest.
 * Older Sensor: Overriding chart directory to stackrox-oss and setting the `--version` flag.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

The compatibility tests are now running as expected with the correct versions for sensor and central, see [the latest run](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/stackrox_stackrox/5795/pull-ci-stackrox-stackrox-master-gke-version-compatibility-tests/1682480622532038656) and attached screenshots. [Here](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/stackrox_stackrox/5795/pull-ci-stackrox-stackrox-master-gke-version-compatibility-tests/1682480622532038656/artifacts/gke-version-compatibility-tests/stackrox-e2e/build-log.txt) is the build log. Below are screenshots showing that the expected version tuples are being tested in order:

<img width="712" alt="image" src="https://github.com/stackrox/stackrox/assets/102952141/fcd2de93-9f50-4a6a-a8c3-b048f2cf68fa">
<img width="2474" alt="image" src="https://github.com/stackrox/stackrox/assets/102952141/8b6585f1-ead1-48f3-ae70-51a1b97fad19">
<img width="2503" alt="image" src="https://github.com/stackrox/stackrox/assets/102952141/4e9a716e-03e8-42ba-a8dd-5633e9b7270c">
<img width="2478" alt="image" src="https://github.com/stackrox/stackrox/assets/102952141/97bd600c-1e42-4e7f-8b63-25da4f0ef852">
<img width="2502" alt="image" src="https://github.com/stackrox/stackrox/assets/102952141/62a4c4ca-4208-41e6-a664-4c928cb7feb7">
<img width="2485" alt="image" src="https://github.com/stackrox/stackrox/assets/102952141/0b60428a-40c3-4b6e-9c9c-2634fa351ecc">
<img width="2509" alt="image" src="https://github.com/stackrox/stackrox/assets/102952141/4a088f7a-9bc4-4cff-a88a-dbad42c931c2">
<img width="2529" alt="image" src="https://github.com/stackrox/stackrox/assets/102952141/64775d41-8cfa-4cdb-9ed1-1f76e789055a">
<img width="2532" alt="image" src="https://github.com/stackrox/stackrox/assets/102952141/73526026-fe8d-47cb-b7e8-7899f75ef1d0">
<img width="2537" alt="image" src="https://github.com/stackrox/stackrox/assets/102952141/ccbb1906-c48e-4f82-af64-1a8d97ed41b6">
<img width="2534" alt="image" src="https://github.com/stackrox/stackrox/assets/102952141/865d4fda-4048-4801-9429-a7d95282898e">
