### PR TITLE
ROX-16604: NWG 2.0 menu should say active flows, not active traffic

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/components/EdgeStateSelect.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/EdgeStateSelect.tsx
@@ -31,13 +31,13 @@ function EdgeStateSelect({ edgeState, setEdgeState, isDisabled }: EdgeStateSelec
         >
             <SelectOption
                 value="active"
-                description="Traffic observed in your selected time window."
+                description="Flows where traffic has been observed during your selected time window."
             >
-                Active traffic
+                Active flows
             </SelectOption>
             <SelectOption
                 value="inactive"
-                description="Inactive flows allowed by your network policies in your selected time window."
+                description="Possible flows allowed by your Kubernetes network policies although they carried no traffic in your selected time window.  In a well isolated implementation this view will be empty."
             >
                 Inactive flows
             </SelectOption>

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/EdgeStateSelect.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/EdgeStateSelect.tsx
@@ -37,7 +37,7 @@ function EdgeStateSelect({ edgeState, setEdgeState, isDisabled }: EdgeStateSelec
             </SelectOption>
             <SelectOption
                 value="inactive"
-                description="Possible flows allowed by your Kubernetes network policies although they carried no traffic in your selected time window.  In a well isolated implementation this view will be empty."
+                description="Possible flows allowed by your Kubernetes network policies, although they carried no traffic in your selected time window.  In a well-isolated implementation, this view will be empty."
             >
                 Inactive flows
             </SelectOption>


### PR DESCRIPTION
## Description

https://issues.redhat.com/browse/ROX-16604

This PR makes a few changes to the edge select component to make terminology more clear and consistent

### Before

<img width="270" alt="Screenshot 2023-04-24 at 2 15 18 PM" src="https://user-images.githubusercontent.com/4805485/234118561-c9ef9b18-7b4f-48a1-b4cf-1e74df565144.png">


### After
<img width="278" alt="Screenshot 2023-04-24 at 2 11 20 PM" src="https://user-images.githubusercontent.com/4805485/234118409-28cde196-066c-4a7e-baa4-ca2cf38f52a8.png">


