### PR TITLE
ROX-16648: Change default to not update creds on integration form edit

### DIFF
--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ArtifactRegistryIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ArtifactRegistryIntegrationForm.tsx
@@ -96,6 +96,9 @@ function ArtifactRegistryIntegrationForm({
         // We want to clear the password because backend returns '******' to represent that there
         // are currently stored credentials
         formInitialValues.config.google.serviceAccount = '';
+
+        // Don't assume user wants to change password; that has caused confusing UX.
+        formInitialValues.updatePassword = false;
     }
     const {
         values,

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ArtifactoryIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/ArtifactoryIntegrationForm.tsx
@@ -81,6 +81,9 @@ function ArtifactoryIntegrationForm({
         // We want to clear the password because backend returns '******' to represent that there
         // are currently stored credentials
         formInitialValues.config.docker.password = '';
+
+        // Don't assume user wants to change password; that has caused confusing UX.
+        formInitialValues.updatePassword = false;
     }
     const {
         values,

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/AwsSecurityHubIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/AwsSecurityHubIntegrationForm.tsx
@@ -123,6 +123,9 @@ function AwsSecurityHubIntegrationForm({
         // are currently stored credentials
         formInitialValues.notifier.awsSecurityHub.credentials.accessKeyId = '';
         formInitialValues.notifier.awsSecurityHub.credentials.secretAccessKey = '';
+
+        // Don't assume user wants to change password; that has caused confusing UX.
+        formInitialValues.updatePassword = false;
     }
     const {
         values,

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/AzureIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/AzureIntegrationForm.tsx
@@ -99,6 +99,9 @@ function ClairifyIntegrationForm({
         // We want to clear the password because backend returns '******' to represent that there
         // are currently stored credentials
         formInitialValues.config.docker.password = '';
+
+        // Don't assume user wants to change password; that has caused confusing UX.
+        formInitialValues.updatePassword = false;
     }
     const {
         values,

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/DockerIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/DockerIntegrationForm.tsx
@@ -81,6 +81,9 @@ function DockerIntegrationForm({
         // We want to clear the password because backend returns '******' to represent that there
         // are currently stored credentials
         formInitialValues.config.docker.password = '';
+
+        // Don't assume user wants to change password; that has caused confusing UX.
+        formInitialValues.updatePassword = false;
     }
     const {
         values,

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/EcrIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/EcrIntegrationForm.tsx
@@ -144,6 +144,9 @@ function EcrIntegrationForm({
         // are currently stored credentials
         formInitialValues.config.ecr.accessKeyId = '';
         formInitialValues.config.ecr.secretAccessKey = '';
+
+        // Don't assume user wants to change password; that has caused confusing UX.
+        formInitialValues.updatePassword = false;
     }
     const {
         values,

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/EmailIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/EmailIntegrationForm.tsx
@@ -153,6 +153,8 @@ function EmailIntegrationForm({
         // We want to clear the password because backend returns '******' to represent that there
         // are currently stored credentials
         formInitialValues.notifier.email.password = '';
+        // Don't assume user wants to change password; that has caused confusing UX.
+        formInitialValues.updatePassword = false;
     }
     const {
         values,

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/GcsIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/GcsIntegrationForm.tsx
@@ -118,6 +118,9 @@ function GcsIntegrationForm({
         // We want to clear the password because backend returns '******' to represent that there
         // are currently stored credentials
         formInitialValues.externalBackup.gcs.serviceAccount = '';
+
+        // Don't assume user wants to change password; that has caused confusing UX.
+        formInitialValues.updatePassword = false;
     }
     const {
         values,

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/GenericWebhookIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/GenericWebhookIntegrationForm.tsx
@@ -113,6 +113,9 @@ function GenericWebhookIntegrationForm({
         // We want to clear the password because backend returns '******' to represent that there
         // are currently stored credentials
         formInitialValues.notifier.generic.password = '';
+
+        // Don't assume user wants to change password; that has caused confusing UX.
+        formInitialValues.updatePassword = false;
     }
     const formik = useIntegrationForm<GenericWebhookIntegrationFormValues>({
         initialValues: formInitialValues,

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/GoogleCloudSccIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/GoogleCloudSccIntegrationForm.tsx
@@ -103,6 +103,9 @@ function GoogleCloudSccIntegrationForm({
         // We want to clear the password because backend returns '******' to represent that there
         // are currently stored credentials
         formInitialValues.notifier.cscc.serviceAccount = '';
+
+        // Don't assume user wants to change password; that has caused confusing UX.
+        formInitialValues.updatePassword = false;
     }
     const {
         values,

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/GoogleIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/GoogleIntegrationForm.tsx
@@ -88,7 +88,7 @@ export const defaultValues: GoogleIntegrationFormValues = {
     updatePassword: true,
 };
 
-function DockerIntegrationForm({
+function GoogleIntegrationForm({
     initialValues = null,
     isEditable = false,
 }: IntegrationFormProps<GoogleImageIntegration>): ReactElement {
@@ -98,6 +98,9 @@ function DockerIntegrationForm({
         // We want to clear the password because backend returns '******' to represent that there
         // are currently stored credentials
         formInitialValues.config.google.serviceAccount = '';
+
+        // Don't assume user wants to change password; that has caused confusing UX.
+        formInitialValues.updatePassword = false;
     }
     const {
         values,
@@ -293,4 +296,4 @@ function DockerIntegrationForm({
     );
 }
 
-export default DockerIntegrationForm;
+export default GoogleIntegrationForm;

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/IbmIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/IbmIntegrationForm.tsx
@@ -92,6 +92,9 @@ function IbmIntegrationForm({
         // We want to clear the password because backend returns '******' to represent that there
         // are currently stored credentials
         formInitialValues.config.ibm.apiKey = '';
+
+        // Don't assume user wants to change password; that has caused confusing UX.
+        formInitialValues.updatePassword = false;
     }
     const {
         values,

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/JiraIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/JiraIntegrationForm.tsx
@@ -132,6 +132,9 @@ function JiraIntegrationForm({
         // We want to clear the password because backend returns '******' to represent that there
         // are currently stored credentials
         formInitialValues.notifier.jira.password = '';
+
+        // Don't assume user wants to change password; that has caused confusing UX.
+        formInitialValues.updatePassword = false;
     }
     const formik = useIntegrationForm<JiraIntegrationFormValues>({
         initialValues: formInitialValues,

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/NexusIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/NexusIntegrationForm.tsx
@@ -113,6 +113,9 @@ function NexusIntegrationForm({
         // We want to clear the password because backend returns '******' to represent that there
         // are currently stored credentials
         formInitialValues.config.docker.password = '';
+
+        // Don't assume user wants to change password; that has caused confusing UX.
+        formInitialValues.updatePassword = false;
     }
     const {
         values,

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/QuayIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/QuayIntegrationForm.tsx
@@ -94,7 +94,11 @@ function computeInitialValues(
             config.quay.registryRobotCredentials.password = '';
         }
 
+        // Don't assume user wants to change password; that has caused confusing UX.
+        const updatePassword = false;
         /*
+         * DEPRECATED: this is no longer needed
+         *
          * Special case for Quay integration,
          * because unauthenticated is an implicit instead of explicit property.
          * If an existing integration does not have stored credentials,
@@ -102,9 +106,11 @@ function computeInitialValues(
          *
          * However, assignment statement is from positive instead of negative viewpoint.
          */
+        /*
         const hasInitialOauthToken = Boolean(initialValues.quay.oauthToken);
         const hasInitialRobotAccount = Boolean(initialValues.quay.registryRobotCredentials);
         const updatePassword = hasInitialOauthToken || hasInitialRobotAccount;
+        */
 
         // Edit or view existing integration.
         return { config, updatePassword };

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/RhelIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/RhelIntegrationForm.tsx
@@ -112,6 +112,9 @@ function RhelIntegrationForm({
         // We want to clear the password because backend returns '******' to represent that there
         // are currently stored credentials
         formInitialValues.config.docker.password = '';
+
+        // Don't assume user wants to change password; that has caused confusing UX.
+        formInitialValues.updatePassword = false;
     }
     const {
         values,

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/S3IntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/S3IntegrationForm.tsx
@@ -129,6 +129,9 @@ function S3IntegrationForm({
         // are currently stored credentials
         formInitialValues.externalBackup.s3.accessKeyId = '';
         formInitialValues.externalBackup.s3.secretAccessKey = '';
+
+        // Don't assume user wants to change password; that has caused confusing UX.
+        formInitialValues.updatePassword = false;
     }
     const {
         values,

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/SplunkIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/SplunkIntegrationForm.tsx
@@ -113,6 +113,9 @@ function SplunkIntegrationForm({
         // We want to clear the password because backend returns '******' to represent that there
         // are currently stored credentials
         formInitialValues.notifier.splunk.httpToken = '';
+
+        // Don't assume user wants to change password; that has caused confusing UX.
+        formInitialValues.updatePassword = false;
     }
     const {
         values,


### PR DESCRIPTION
## Description

This change makes the "update token / update password" etc checkbox on all integration forms that have saved credentials no longer be checked by default when opening the form to edit an existing integration. (This was causing confusion with customers not being able to Test existing integrations, unless they unchecked the box--and they got stuck because the flow is not obvious.)

Rather than change the default value of the `updatePassword` property, which is our API's way of noting new creds will be in the request, and which is required to be `true` on create, I leverage the already-existing condition which clears out the "******" value that comes back on edit. I added changing the `updatePassword` field to `false` in those situations.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

I manually tested each form with credentials.

Artifactory
<img width="1532" alt="artifactory" src="https://user-images.githubusercontent.com/715729/234128794-a9211526-5ba3-40b0-beb5-8e1c24dd0542.png">

Google Artifact Registry
<img width="1532" alt="google-artifact-registry" src="https://user-images.githubusercontent.com/715729/234128817-9804ce55-c84d-420c-a447-f3e3b2d36b55.png">

AWS Security Hub
<img width="1580" alt="aws-security-hub" src="https://user-images.githubusercontent.com/715729/234128838-b0ed3af7-0480-4021-9edf-efba44f0426f.png">

Azure Registry
<img width="1580" alt="azure-registry" src="https://user-images.githubusercontent.com/715729/234128874-c0519c7c-2216-4e0c-a489-06f6bc0b43ed.png">

Docker Registry
<img width="1580" alt="docker-registry" src="https://user-images.githubusercontent.com/715729/234128906-c9e97884-ebdf-4cd2-b735-0768d5df65c1.png">

Email
<img width="1488" alt="email" src="https://user-images.githubusercontent.com/715729/234128929-28754331-2038-4181-a747-5fecdd1ecd44.png">

Google Cloud Storage
<img width="1580" alt="google-cloud-storage" src="https://user-images.githubusercontent.com/715729/234128945-50c347de-17e7-49e8-81ad-cab74384fb86.png">

Generic Webhook
<img width="1580" alt="generic-webhook" src="https://user-images.githubusercontent.com/715729/234128955-e1a457dc-8995-43fd-bc4b-d83601c0c4f1.png">

Google Cloud SCC
<img width="1580" alt="google-cloud-scc" src="https://user-images.githubusercontent.com/715729/234128971-4148f861-1bcd-4e6f-a5d6-8b87229272fb.png">

GCR
<img width="1580" alt="gcr" src="https://user-images.githubusercontent.com/715729/234128978-be1894ff-fd2c-4f9c-bb22-cfce077f3141.png">

IBM Cloud Registry
<img width="1580" alt="ibm-cloud" src="https://user-images.githubusercontent.com/715729/234129012-d3312534-d1b7-4236-add2-af5ad1410bb5.png">

Nexus
<img width="1580" alt="nexus" src="https://user-images.githubusercontent.com/715729/234129025-d980eea7-4f43-4bde-b680-dc0e64688a10.png">

Quay
<img width="1580" alt="quay" src="https://user-images.githubusercontent.com/715729/234129036-63cd7ef4-1218-4f38-9569-3ed6ba3969ac.png">

RHEL
<img width="1580" alt="rhel" src="https://user-images.githubusercontent.com/715729/234129051-1ed59b84-e153-4407-b7ce-bd3566ecf97e.png">

S3
<img width="1580" alt="s3" src="https://user-images.githubusercontent.com/715729/234129060-2ad1b870-d9f5-4213-a632-7c5c81154ab9.png">

Splunk
<img width="1580" alt="splunk" src="https://user-images.githubusercontent.com/715729/234129073-b7ee835f-be2c-407f-8542-fa523bee45dc.png">
