### PR TITLE
Dashrews/ROX-16555 no rocksdb restore if space is inadequate or volume is not there

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 - A default role `Vulnerability Manager` has been added that provides sufficient privileges to analyze and manage system vulnerabilities.
 
 ### Removed Features
+- As announced in 3.74, restoring a backup taken on a 3.y release is no longer supported.
 
 ### Deprecated Fatures
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 - A default role `Vulnerability Manager` has been added that provides sufficient privileges to analyze and manage system vulnerabilities.
 
 ### Removed Features
-- As announced in 3.74, restoring a backup taken on a 3.y release is no longer supported.
 
 ### Deprecated Fatures
 

--- a/central/globaldb/v2backuprestore/manager/manager.go
+++ b/central/globaldb/v2backuprestore/manager/manager.go
@@ -96,8 +96,7 @@ func analyzeManifest(manifest *v1.DBExportManifest, format *formats.ExportFormat
 func (m *manager) checkDiskSpace(requiredBytes int64) error {
 	availableBytes, err := fsutils.AvailableBytesIn(m.outputRoot)
 	if err != nil {
-		log.Warnf("Could not determine free disk space of volume containing %s: %v. Assuming free space is sufficient for %d bytes.", m.outputRoot, err, requiredBytes)
-		return nil
+		return errors.Errorf("could not determine free disk space of volume containing %s: %v. Assuming free space is sufficient for %d bytes.", m.outputRoot, err, requiredBytes)
 	}
 	if availableBytes < uint64(requiredBytes) {
 		return errors.Errorf("restoring backup requires %d bytes of free disk space, but volume containing %s only has %d bytes available", requiredBytes, m.outputRoot, availableBytes)
@@ -128,8 +127,7 @@ func (m *manager) LaunchRestoreProcess(ctx context.Context, id string, requestHe
 	}
 
 	if !process.postgresBundle {
-		//if _, err := os.Stat(m.outputRoot); os.IsNotExist(err) {
-		if _, err := os.Stat("This/dir/does/not/exist"); os.IsNotExist(err) {
+		if _, err := os.Stat(m.outputRoot); os.IsNotExist(err) {
 			return nil, errors.Errorf("the volume %q and pre-4.0 restore bundles are no longer supported", m.outputRoot)
 		}
 		if err := m.checkDiskSpace(totalSizeUncompressed); err != nil {

--- a/central/globaldb/v2backuprestore/manager/manager.go
+++ b/central/globaldb/v2backuprestore/manager/manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -121,13 +122,19 @@ func (m *manager) LaunchRestoreProcess(ctx context.Context, id string, requestHe
 		return nil, err
 	}
 
-	if err := m.checkDiskSpace(totalSizeUncompressed); err != nil {
-		return nil, err
-	}
-
 	process, err := newRestoreProcess(ctx, id, requestHeader, handlerFuncs, data)
 	if err != nil {
 		return nil, err
+	}
+
+	if !process.postgresBundle {
+		//if _, err := os.Stat(m.outputRoot); os.IsNotExist(err) {
+		if _, err := os.Stat("This/dir/does/not/exist"); os.IsNotExist(err) {
+			return nil, errors.Errorf("the volume %q and pre-4.0 restore bundles are no longer supported", m.outputRoot)
+		}
+		if err := m.checkDiskSpace(totalSizeUncompressed); err != nil {
+			return nil, err
+		}
 	}
 
 	// Create the paths for the restore directory

--- a/central/globaldb/v2backuprestore/manager/manager.go
+++ b/central/globaldb/v2backuprestore/manager/manager.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -116,7 +115,7 @@ func (m *manager) LaunchRestoreProcess(ctx context.Context, id string, requestHe
 		return nil, errors.Errorf("invalid DB restore format %q", requestHeader.GetFormatName())
 	}
 
-	handlerFuncs, totalSizeUncompressed, err := analyzeManifest(requestHeader.GetManifest(), format)
+	handlerFuncs, _, err := analyzeManifest(requestHeader.GetManifest(), format)
 	if err != nil {
 		return nil, err
 	}
@@ -127,12 +126,7 @@ func (m *manager) LaunchRestoreProcess(ctx context.Context, id string, requestHe
 	}
 
 	if !process.postgresBundle {
-		if _, err := os.Stat(m.outputRoot); os.IsNotExist(err) {
-			return nil, errors.Errorf("the volume %q and pre-4.0 restore bundles are no longer supported", m.outputRoot)
-		}
-		if err := m.checkDiskSpace(totalSizeUncompressed); err != nil {
-			return nil, err
-		}
+		return nil, errors.Errorf("restoration of legacy backup bundles is no longer available")
 	}
 
 	// Create the paths for the restore directory

--- a/central/globaldb/v2backuprestore/manager/manager.go
+++ b/central/globaldb/v2backuprestore/manager/manager.go
@@ -129,10 +129,10 @@ func (m *manager) LaunchRestoreProcess(ctx context.Context, id string, requestHe
 
 	if !process.postgresBundle {
 		if _, err := os.Stat(m.outputRoot); os.IsNotExist(err) {
-			return nil, errors.Errorf("the required volume %q does not exist", m.outputRoot)
+			return nil, errors.Errorf("the required directory %q does not exist", m.outputRoot)
 		}
 		if mounted, err := mountinfo.Mounted(m.outputRoot); !mounted || err != nil {
-			return nil, errors.Errorf("the required volume %q is required to be backed by a PVC", m.outputRoot)
+			return nil, errors.Errorf("the directory %q must be a mounted volume", m.outputRoot)
 		}
 		if err := m.checkDiskSpace(totalSizeUncompressed); err != nil {
 			return nil, err

--- a/central/globaldb/v2backuprestore/manager/manager.go
+++ b/central/globaldb/v2backuprestore/manager/manager.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/moby/sys/mountinfo"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/central/globaldb/v2backuprestore/common"
 	"github.com/stackrox/rox/central/globaldb/v2backuprestore/formats"
@@ -129,6 +130,9 @@ func (m *manager) LaunchRestoreProcess(ctx context.Context, id string, requestHe
 	if !process.postgresBundle {
 		if _, err := os.Stat(m.outputRoot); os.IsNotExist(err) {
 			return nil, errors.Errorf("the required volume %q does not exist", m.outputRoot)
+		}
+		if mounted, err := mountinfo.Mounted(m.outputRoot); !mounted || err != nil {
+			return nil, errors.Errorf("the required volume %q is required to be backed by a PVC", m.outputRoot)
 		}
 		if err := m.checkDiskSpace(totalSizeUncompressed); err != nil {
 			return nil, err

--- a/go.mod
+++ b/go.mod
@@ -280,7 +280,7 @@ require (
 	github.com/moby/patternmatcher v0.5.0 // indirect
 	github.com/moby/spdystream v0.2.0 // indirect
 	github.com/moby/sys/mount v0.3.3 // indirect
-	github.com/moby/sys/mountinfo v0.6.2 // indirect
+	github.com/moby/sys/mountinfo v0.6.2
 	github.com/moby/sys/sequential v0.5.0 // indirect
 	github.com/moby/sys/symlink v0.2.0 // indirect
 	github.com/moby/term v0.0.0-20221205130635-1aeaba878587 // indirect


### PR DESCRIPTION
## Description

Update to NOT process a rocks db restore to Postgres if there is no volume `/var/lib/stackrox`.  Additionally I updated the space check to fail the restore instead of proceeding if we are unable to determine the space.  That is a file system check, we should be able to determine the space unless the directory doesn't exist.  The space check will handle the cases where the volume is backed by something too small whether by the PVC or not.  Additionally this functionality will be deprecated altogether later.

## Checklist
- [ ] Investigated and inspected CI test results
~- [ ] Unit test and regression tests added~
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

deployed instances with significant PVC and with tiny PVC.  Ensured that if the PVC existed a Rocks restore bundle that fit on the volume processed and ensured that a if the restore bundle was too large for the PVC that the restore would return an error regarding space.  Ensured that Postgres restore bundles continued to work regardless of whether the PVC existed and regardless of its size as Postgres restore bundles do not utilize the volume backed by that PVC.
