### PR TITLE
CI: Fix DefaultPoliciesTest flake.

### DIFF
--- a/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
@@ -485,15 +485,17 @@ class DefaultPoliciesTest extends BaseSpecification {
                 // The OpenShift: Kubeadmin Secret Accessed policy can sometimes
                 // get triggered by the CI. This happens when the CI scripts use
                 // kubectl to pull resources to save on an earlier test failure.
-                // Ignore this alert iff _all_ violations was by kube:admin or
-                // system:admin using kubectl. Do not ignore for any other
-                // violations. See https://issues.redhat.com/browse/ROX-10018
+                // Ignore this alert iff _all_ violations was by admin,
+                // kube:admin or system:admin using kubectl. Do not ignore for
+                // any other violations. See
+                // https://issues.redhat.com/browse/ROX-10018
                 def noKubectlViolation = true
                 if (alert.policy.getName() == "OpenShift: Kubeadmin Secret Accessed") {
                     noKubectlViolation = !AlertService.getViolation(alert.id).getViolationsList().
                         stream().allMatch { v ->
                             def user = v.getKeyValueAttrs().getAttrsList().find { a ->
-                                a.getKey() == "Username" && a.getValue() =~ /(kube|system)\:admin/
+                                a.getKey() == "Username" && (a.getValue() == "admin" ||
+                                                             a.getValue() =~ /(kube|system)\:admin/)
                             }
                             def ua = v.getKeyValueAttrs().getAttrsList().find { a ->
                                 a.getKey() == "User Agent" && a.getValue().startsWith("kubectl/")


### PR DESCRIPTION
## Description

The admin user is "admin" under OSD GCP. 

https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/branch-ci-stackrox-stackrox-nightlies-osd-gcp-qa-e2e-tests/1650727352700768256

```
    07:09:07 | DEBUG | DefaultPoliciesTest       | The attribute list:
    07:09:07 | DEBUG | DefaultPoliciesTest       | 	Verb: GET
    07:09:07 | DEBUG | DefaultPoliciesTest       | 	Username: admin
    07:09:07 | DEBUG | DefaultPoliciesTest       | 	Groups: cluster-admins, system:authenticated:oauth, system:authenticated
    07:09:07 | DEBUG | DefaultPoliciesTest       | 	User Agent: kubectl/v1.26.2 (linux/amd64) kubernetes/fc04e73
    07:09:07 | DEBUG | DefaultPoliciesTest       | 	IP address: 34.139.57.84
    07:09:07 | DEBUG | DefaultPoliciesTest       | 	Resource: /api/v1/namespaces/kube-system/secrets/kubeadmin
    07:09:07 | DEBUG | DefaultPoliciesTest       | 	Verb: GET
    07:09:07 | DEBUG | DefaultPoliciesTest       | 	Username: admin
    07:09:07 | DEBUG | DefaultPoliciesTest       | 	Groups: cluster-admins, system:authenticated:oauth, system:authenticated
    07:09:07 | DEBUG | DefaultPoliciesTest       | 	User Agent: kubectl/v1.26.2 (linux/amd64) kubernetes/fc04e73
    07:09:07 | DEBUG | DefaultPoliciesTest       | 	IP address: 34.139.57.84
    07:09:07 | DEBUG | DefaultPoliciesTest       | 	Resource: /api/v1/namespaces/kube-system/secrets/kubeadmin
    07:09:07 | DEBUG | DefaultPoliciesTest       | 	Verb: GET
    07:09:07 | DEBUG | DefaultPoliciesTest       | 	Username: admin
    07:09:07 | DEBUG | DefaultPoliciesTest       | 	Groups: cluster-admins, system:authenticated:oauth, system:authenticated
    07:09:07 | DEBUG | DefaultPoliciesTest       | 	User Agent: kubectl/v1.26.2 (linux/amd64) kubernetes/fc04e73
    07:09:07 | DEBUG | DefaultPoliciesTest       | 	IP address: 34.139.57.84
    07:09:07 | DEBUG | DefaultPoliciesTest       | 	Resource: /api/v1/namespaces/kube-system/secrets/kubeadmin
    07:09:07 | DEBUG | DefaultPoliciesTest       | 	Verb: GET
    07:09:07 | DEBUG | DefaultPoliciesTest       | 	Username: admin
    07:09:07 | DEBUG | DefaultPoliciesTest       | 	Groups: cluster-admins, system:authenticated:oauth, system:authenticated
    07:09:07 | DEBUG | DefaultPoliciesTest       | 	User Agent: kubectl/v1.26.2 (linux/amd64) kubernetes/fc04e73
    07:09:07 | DEBUG | DefaultPoliciesTest       | 	IP address: 34.139.57.84
    07:09:07 | DEBUG | DefaultPoliciesTest       | 	Resource: /api/v1/namespaces/kube-system/secrets/kubeadmin
    07:09:07 | DEBUG | DefaultPoliciesTest       | 	Verb: GET
    07:09:07 | DEBUG | DefaultPoliciesTest       | 	Username: admin
    07:09:07 | DEBUG | DefaultPoliciesTest       | 	Groups: cluster-admins, system:authenticated:oauth, system:authenticated
    07:09:07 | DEBUG | DefaultPoliciesTest       | 	User Agent: kubectl/v1.26.2 (linux/amd64) kubernetes/fc04e73
    07:09:07 | DEBUG | DefaultPoliciesTest       | 	IP address: 34.139.57.84
    07:09:07 | DEBUG | DefaultPoliciesTest       | 	Resource: /api/v1/namespaces/kube-system/secrets/kubeadmin

```

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

CI is sufficient