### PR TITLE
ROX-16406: Fix RBAC verify scaped bindings test

### DIFF
--- a/qa-tests-backend/src/main/groovy/services/RbacService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/RbacService.groovy
@@ -1,31 +1,35 @@
 package services
 
+import static io.stackrox.proto.api.v1.RbacServiceOuterClass.SubjectAndRoles
+import static io.stackrox.proto.api.v1.SearchServiceOuterClass.RawQuery
+import static io.stackrox.proto.storage.Rbac.Subject
+
+import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
+
 import io.stackrox.proto.api.v1.Common
 import io.stackrox.proto.api.v1.RbacServiceGrpc
-import io.stackrox.proto.api.v1.SearchServiceOuterClass
+import io.stackrox.proto.storage.Rbac
+
 import objects.K8sRole
 import objects.K8sRoleBinding
 import util.Timer
 
 @Slf4j
+@CompileStatic
 class RbacService extends BaseService {
-    static getRbacService() {
+    static RbacServiceGrpc.RbacServiceBlockingStub getRbacService() {
         return RbacServiceGrpc.newBlockingStub(getChannel())
     }
 
-    static getRoles(SearchServiceOuterClass.RawQuery query = SearchServiceOuterClass.RawQuery.newBuilder().build()) {
+    static List<Rbac.K8sRole> getRoles(RawQuery query = RawQuery.newBuilder().build()) {
         return getRbacService().listRoles(query).rolesList
     }
 
-    static getRole(String id) {
-        try {
-            return getRbacService().getRole(
-                    Common.ResourceByID.newBuilder().setId(id).build()
-            ).role
-        } catch (Exception e) {
-            log.warn("Error fetching role", e)
-        }
+    static Rbac.K8sRole getRole(String id) {
+        return getRbacService().getRole(
+                Common.ResourceByID.newBuilder().setId(id).build()
+        ).role
     }
 
     static boolean waitForRole(K8sRole role) {
@@ -63,19 +67,9 @@ class RbacService extends BaseService {
         return false
     }
 
-    static getRoleBindings(
-            SearchServiceOuterClass.RawQuery query = SearchServiceOuterClass.RawQuery.newBuilder().build()) {
+    static List<Rbac.K8sRoleBinding> getRoleBindings(RawQuery query = RawQuery.newBuilder().build()) {
+        log.debug("Get bindings list: ${query}")
         return getRbacService().listRoleBindings(query).bindingsList
-    }
-
-    static getRoleBinding(String id) {
-        try {
-            return getRbacService().getRoleBinding(
-                    Common.ResourceByID.newBuilder().setId(id).build()
-            ).binding
-        } catch (Exception e) {
-            log.warn("Error fetching role binding", e)
-        }
     }
 
     static boolean waitForRoleBinding(K8sRoleBinding roleBinding) {
@@ -113,17 +107,14 @@ class RbacService extends BaseService {
         return false
     }
 
-    static getSubjects(SearchServiceOuterClass.RawQuery query = SearchServiceOuterClass.RawQuery.newBuilder().build()) {
+    static List<SubjectAndRoles> getSubjects(
+            RawQuery query = RawQuery.newBuilder().build()) {
         return getRbacService().listSubjects(query).subjectAndRolesList
     }
 
-    static getSubject(String id) {
-        try {
-            return getRbacService().getSubject(
-                    Common.ResourceByID.newBuilder().setId(id).build()
-            ).subject
-        } catch (Exception e) {
-            log.warn("Error fetching subject", e)
-        }
+    static Subject getSubject(String id) {
+        return getRbacService().getSubject(
+                Common.ResourceByID.newBuilder().setId(id).build()
+        ).subject
     }
 }

--- a/qa-tests-backend/src/test/groovy/K8sRbacTest.groovy
+++ b/qa-tests-backend/src/test/groovy/K8sRbacTest.groovy
@@ -246,7 +246,7 @@ class K8sRbacTest extends BaseSpecification {
         withRetry(45, 2) {
             def stackroxBindings = RbacService.getRoleBindings()
             def orchestratorBindings = orchestrator.getRoleBindings() + orchestrator.getClusterRoleBindings()
-            assert stackroxBindings.size() == orchestratorBindings.size()
+            assert stackroxBindings.size() == orchestratorBindings.size(), "Binding sizes differ"
 
             for (Rbac.K8sRoleBinding b : stackroxBindings) {
                 K8sRoleBinding binding = orchestratorBindings.find {
@@ -268,8 +268,6 @@ class K8sRbacTest extends BaseSpecification {
                     assert CaseFormat.UPPER_UNDERSCORE.to(CaseFormat.UPPER_CAMEL, sSubject.kind.toString()) ==
                             oSubject.kind
                 }
-
-                assert RbacService.getRoleBinding(b.id) == b
             }
         }
     }


### PR DESCRIPTION
## Description

Fix failure of tests due to test timeout exception. For some reason this test downloads list of all bindings and then compare downloaded list with current state on server. That operation takes a lot of time (~30s for over 1.7k bindings) and did not add any value so we can safe remove it making test much faster.
This PR also adds `@CompileStatic` to RBAC service. 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

CI