### PR TITLE
ROX-16659: Prevent policy lifecycle and criteria change when active alerts exist

### DIFF
--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step2/PolicyBehaviorForm.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step2/PolicyBehaviorForm.tsx
@@ -30,7 +30,11 @@ import DownloadCLIDropdown from './DownloadCLIDropdown';
 
 import './PolicyBehaviorForm.css';
 
-function PolicyBehaviorForm() {
+type PolicyBehaviorFormProps = {
+    hasActiveViolations: boolean;
+};
+
+function PolicyBehaviorForm({ hasActiveViolations }: PolicyBehaviorFormProps) {
     const { values, setFieldValue, setValues } = useFormikContext<ClientPolicy>();
     const hasEnforcementActions =
         values.enforcementActions?.length > 0 &&
@@ -174,6 +178,7 @@ function PolicyBehaviorForm() {
                                 onChange={(isChecked) => {
                                     onChangeLifecycleStage('BUILD', isChecked);
                                 }}
+                                isDisabled={hasActiveViolations}
                             />
                             <Checkbox
                                 label="Deploy"
@@ -182,6 +187,7 @@ function PolicyBehaviorForm() {
                                 onChange={(isChecked) => {
                                     onChangeLifecycleStage('DEPLOY', isChecked);
                                 }}
+                                isDisabled={hasActiveViolations}
                             />
                             <Checkbox
                                 label="Runtime"
@@ -190,9 +196,17 @@ function PolicyBehaviorForm() {
                                 onChange={(isChecked) => {
                                     onChangeLifecycleStage('RUNTIME', isChecked);
                                 }}
+                                isDisabled={hasActiveViolations}
                             />
                         </Flex>
                     </FormGroup>
+                    {hasActiveViolations && (
+                        <Alert
+                            isInline
+                            variant="warning"
+                            title="Policy has active violations, and the lifecycle stage cannot be changed. To update the lifecycle, clone and create a new policy."
+                        />
+                    )}
                     <FormGroup
                         fieldId="policy-event-source"
                         label="Event sources (Runtime lifecycle only)"
@@ -205,7 +219,7 @@ function PolicyBehaviorForm() {
                                 id="policy-event-source-deployment"
                                 name="eventSource"
                                 onChange={() => setFieldValue('eventSource', 'DEPLOYMENT_EVENT')}
-                                isDisabled={!hasRuntime}
+                                isDisabled={!hasRuntime || hasActiveViolations}
                             />
                             <Radio
                                 label="Audit logs"
@@ -213,7 +227,7 @@ function PolicyBehaviorForm() {
                                 id="policy-event-source-audit-logs"
                                 name="eventSource"
                                 onChange={onChangeAuditLogEventSource}
-                                isDisabled={!hasRuntime}
+                                isDisabled={!hasRuntime || hasActiveViolations}
                             />
                         </Flex>
                     </FormGroup>

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyCriteriaForm.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyCriteriaForm.tsx
@@ -81,7 +81,7 @@ function PolicyCriteriaForm({ hasActiveViolations }: PolicyBehaviorFormProps) {
                         isInline
                         title="This policy has active violations, and the policy criteria cannot be changed. To update criteria, clone and create a new policy."
                         className="pf-u-mt-sm pf-u-mb-md"
-                        data-testid="default-policy-alert"
+                        data-testid="active-violations-policy-alert"
                     />
                 )}
                 <BooleanPolicyLogicSection readOnly />

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyCriteriaForm.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyCriteriaForm.tsx
@@ -14,7 +14,11 @@ import './PolicyCriteriaForm.css';
 
 const MAX_POLICY_SECTIONS = 16;
 
-function PolicyCriteriaForm() {
+type PolicyBehaviorFormProps = {
+    hasActiveViolations: boolean;
+};
+
+function PolicyCriteriaForm({ hasActiveViolations }: PolicyBehaviorFormProps) {
     const { values, setFieldValue } = useFormikContext<Policy>();
     const { criteriaLocked } = values;
     const { isFeatureFlagEnabled } = useFeatureFlags();
@@ -49,7 +53,7 @@ function PolicyCriteriaForm() {
         </>
     );
 
-    if (criteriaLocked) {
+    if (criteriaLocked || hasActiveViolations) {
         return (
             <Flex
                 fullWidth={{ default: 'fullWidth' }}
@@ -60,15 +64,26 @@ function PolicyCriteriaForm() {
                 id="policy-sections-container"
             >
                 {headingElements}
-                <Alert
-                    variant="info"
-                    isInline
-                    title="Editing policy criteria is disabled for system default policies"
-                    className="pf-u-mt-sm pf-u-mb-md"
-                    data-testid="default-policy-alert"
-                >
-                    If you need to edit policy criteria, clone this policy or create a new policy.
-                </Alert>
+                {criteriaLocked ? (
+                    <Alert
+                        variant="info"
+                        isInline
+                        title="Editing policy criteria is disabled for system default policies"
+                        className="pf-u-mt-sm pf-u-mb-md"
+                        data-testid="default-policy-alert"
+                    >
+                        If you need to edit policy criteria, clone this policy or create a new
+                        policy.
+                    </Alert>
+                ) : (
+                    <Alert
+                        variant="warning"
+                        isInline
+                        title="This policy has active violations, and the policy criteria cannot be changed. To update criteria, clone and create a new policy."
+                        className="pf-u-mt-sm pf-u-mb-md"
+                        data-testid="default-policy-alert"
+                    />
+                )}
                 <BooleanPolicyLogicSection readOnly />
             </Flex>
         );

--- a/ui/apps/platform/src/css/trumps.css
+++ b/ui/apps/platform/src/css/trumps.css
@@ -167,11 +167,13 @@ button.pf-c-tree-view__node {
 /*
  * Override disabled checkbox styles when the input element is in a PF table
  */
-.pf-c-table__check input[type="checkbox"]:disabled {
+.pf-c-table__check input[type="checkbox"]:disabled,
+.pf-c-form__group input[type="checkbox"]:disabled {
     cursor: not-allowed;
     border-color: revert;
 }
-.pf-c-table__check input[type="checkbox"]:checked:disabled {
+.pf-c-table__check input[type="checkbox"]:checked:disabled,
+.pf-c-form__group input[type="checkbox"]:checked:disabled {
     background-color: var(--pf-global--disabled-color--200);
     border-color: transparent;
 }


### PR DESCRIPTION
## Description

1. Retrieved the count of current violations for policy being edited, at the Wizard level.
2. Save flag if violations exist
3. Pass down to PolicyBehaviorForm and PolicyCriteriaForm
4. Disable Lifecycle inputs and show message on PolicyBehaviorForm, and on PolicyCriteriaForm.


## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

Created a non-default policy and triggered violations.

<img width="1658" alt="Screen Shot 2023-04-25 at 9 19 36 PM" src="https://user-images.githubusercontent.com/715729/234443108-d4f0e5cb-fc7a-4669-9637-385b0338d88c.png">

<img width="1658" alt="Screen Shot 2023-04-25 at 9 19 42 PM" src="https://user-images.githubusercontent.com/715729/234443124-f606f483-324c-4675-9b2f-99cd1e4501c7.png">
