### PR TITLE
ROX-16724: Operator testing on GKE

### DIFF
--- a/operator/Makefile
+++ b/operator/Makefile
@@ -87,6 +87,13 @@ SCORECARD_ARGS ?= --storage-image="$(SCORECARD_STORAGE_IMAGE)" --wait-time="$(SC
 # TEST_NAMESPACE is where the operator is installed for e2e tests by CI.
 TEST_NAMESPACE ?= stackrox-operator
 
+# TEST_E2E_ENV_IS_OPENSHIFT is "true" when the cluster to run e2e tests on is an
+# OpenShift one, and "false" otherwise.
+TEST_E2E_ENV_IS_OPENSHIFT ?= $(shell kubectl get scc > /dev/null 2>&1 && echo true || echo false)
+
+# KUTTL_TEST_RUN_LABELS_ARGS specifies what label set to use for kuttl tests.
+KUTTL_TEST_RUN_LABELS_ARGS ?= --test-run-labels openshift=$(TEST_E2E_ENV_IS_OPENSHIFT)
+
 # ENABLE_WEBHOOKS determines if webhooks should be set up in manager when running locally.
 # Disabled by default since it requires setting up of custom routing from your k8s API server
 # to your manager process.
@@ -229,19 +236,19 @@ validate-crs:
 .PHONY: test-e2e
 test-e2e: build install validate-crs kuttl ensure-rox-main-image-exists ## Run e2e tests with local manager.
 	mkdir -p $(PROJECT_DIR)/build/kuttl-test-artifacts
-	KUTTL=$(KUTTL) ENABLE_WEBHOOKS=$(ENABLE_WEBHOOKS) $(KUTTL) test
+	KUTTL=$(KUTTL) ENABLE_WEBHOOKS=$(ENABLE_WEBHOOKS) $(KUTTL) test $(KUTTL_TEST_RUN_LABELS_ARGS)
 
 .PHONY: test-e2e-deployed
 test-e2e-deployed: validate-crs kuttl ## Run e2e tests with manager deployed on cluster.
 	mkdir -p $(PROJECT_DIR)/build/kuttl-test-artifacts
-	KUTTL=$(KUTTL) SKIP_MANAGER_START=1 $(KUTTL) test
+	KUTTL=$(KUTTL) SKIP_MANAGER_START=1 $(KUTTL) test $(KUTTL_TEST_RUN_LABELS_ARGS)
 
 .PHONY: test-upgrade
 test-upgrade: kuttl bundle-post-process ## Run OLM-based operator upgrade tests.
 	mkdir -p $(PROJECT_DIR)/build/kuttl-test-artifacts-upgrade
 	SKIP_MANAGER_START=1 \
 	NEW_PRODUCT_VERSION=$$(make --quiet --no-print-directory -C .. tag) \
-	KUTTL=$(KUTTL) $(KUTTL) test --config kuttl-test.yaml --artifacts-dir build/kuttl-test-artifacts-upgrade tests/upgrade
+	KUTTL=$(KUTTL) $(KUTTL) test --config kuttl-test.yaml --artifacts-dir build/kuttl-test-artifacts-upgrade $(KUTTL_TEST_RUN_LABELS_ARGS) tests/upgrade
 
 .PHONY: stackrox-image-pull-secret
 stackrox-image-pull-secret: ## Create default image pull secret for StackRox images on Quay.io. Used by Helm chart.

--- a/operator/README.md
+++ b/operator/README.md
@@ -255,7 +255,7 @@ make kuttl
 
 These make targets will add the executable to your `$GOPATH`.
 If that is not on your `$PATH`, then you can install the Operator SDK from its [release page](https://github.com/operator-framework/operator-sdk/releases)
-and kuttl from its [release page](https://github.com/kudobuilder/kuttl/releases/tag/v0.15.0).
+and kuttl from its [release page](https://github.com/porridge/kuttl/releases).
 
 #### Pull Secret
 

--- a/operator/hack/envsubst-kuttl.sh
+++ b/operator/hack/envsubst-kuttl.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# This script is used by some assert files in the test directory.
+# It replaces $NAMESPACE in the file supplied as the first argument,
+# and then runs kuttl with subsequent arguments on the result.
+set -euo pipefail
+input_file="$1"
+shift
+intermediate_file=$(mktemp)
+trap 'rm -f ${intermediate_file}' EXIT
+env - PATH="${PATH}" NAMESPACE="${NAMESPACE}" envsubst < "${input_file}" > "${intermediate_file}"
+${KUTTL:-kubectl-kuttl} "$@" "${intermediate_file}"

--- a/operator/tests/central/basic-central/10-assert-openshift.yaml
+++ b/operator/tests/central/basic-central/10-assert-openshift.yaml
@@ -1,0 +1,31 @@
+# Make kuttl ignore this file unless running against openshift.
+apiVersion: kuttl.dev/v1beta1
+kind: TestFile
+testRunSelector:
+  matchLabels:
+    openshift: "true"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: central-prometheus-k8s
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: central-prometheus-k8s
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: central-monitoring-tls
+spec:
+  ingress:
+  - ports:
+    - port: 9091
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      app: central
+  policyTypes:
+  - Ingress

--- a/operator/tests/central/basic-central/10-assert.yaml
+++ b/operator/tests/central/basic-central/10-assert.yaml
@@ -13,6 +13,11 @@ collectors:
 - type: pod
   selector: app=scanner-db
   tail: -1
+- command: kubectl describe pod -n $NAMESPACE -l app=central
+- command: kubectl describe pod -n $NAMESPACE -l app=central-db
+- command: kubectl describe pod -n $NAMESPACE -l app=scanner
+- command: kubectl describe pod -n $NAMESPACE -l app=scanner-db
+timeout: 900
 ---
 apiVersion: platform.stackrox.io/v1alpha1
 kind: Central

--- a/operator/tests/central/basic-central/10-assert.yaml
+++ b/operator/tests/central/basic-central/10-assert.yaml
@@ -1,5 +1,10 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
+commands:
+- script: |
+    set -eu # shell in CI does not grok -o pipefail
+    # On OpenShift, test that Central auth reader rolebinding exists in kube-system.
+    if kubectl get scc > /dev/null 2>&1; then kubectl get rolebinding rhacs-central-auth-reader-${NAMESPACE} -n kube-system; fi
 collectors:
 - type: pod
   selector: app=central
@@ -88,35 +93,3 @@ spec:
   resources:
     requests:
       storage: 100Gi
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: central-prometheus-k8s
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: central-prometheus-k8s
----
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-commands:
-- script: |
-    # Test that Central auth reader rolebinding exists in kube-system.
-    kubectl get rolebinding rhacs-central-auth-reader-${NAMESPACE} -n kube-system
----
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  name: central-monitoring-tls
-spec:
-  ingress:
-  - ports:
-    - port: 9091
-      protocol: TCP
-  podSelector:
-    matchLabels:
-      app: central
-  policyTypes:
-  - Ingress

--- a/operator/tests/central/basic-central/100-errors-openshift.yaml
+++ b/operator/tests/central/basic-central/100-errors-openshift.yaml
@@ -1,0 +1,1 @@
+../../common/delete-central-errors-openshift.yaml

--- a/operator/tests/central/basic-central/61-assert.yaml
+++ b/operator/tests/central/basic-central/61-assert.yaml
@@ -1,3 +1,10 @@
+# Make kuttl ignore this file unless running against openshift.
+apiVersion: kuttl.dev/v1beta1
+kind: TestFile
+testRunSelector:
+  matchLabels:
+    openshift: "true"
+---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
 collectors:

--- a/operator/tests/central/basic-central/61-set-expose-monitoring.yaml
+++ b/operator/tests/central/basic-central/61-set-expose-monitoring.yaml
@@ -1,3 +1,10 @@
+# Make kuttl ignore this file unless running against openshift.
+apiVersion: kuttl.dev/v1beta1
+kind: TestFile
+testRunSelector:
+  matchLabels:
+    openshift: "true"
+---
 apiVersion: platform.stackrox.io/v1alpha1
 kind: Central
 metadata:

--- a/operator/tests/central/basic-central/62-unset-expose-monitoring.yaml
+++ b/operator/tests/central/basic-central/62-unset-expose-monitoring.yaml
@@ -1,3 +1,10 @@
+# Make kuttl ignore this file unless running against openshift.
+apiVersion: kuttl.dev/v1beta1
+kind: TestFile
+testRunSelector:
+  matchLabels:
+    openshift: "true"
+---
 apiVersion: platform.stackrox.io/v1alpha1
 kind: Central
 metadata:

--- a/operator/tests/central/basic-central/80-assert-non-openshift.yaml
+++ b/operator/tests/central/basic-central/80-assert-non-openshift.yaml
@@ -1,0 +1,52 @@
+# Make kuttl ignore this file if running against openshift.
+apiVersion: kuttl.dev/v1beta1
+kind: TestFile
+testRunSelector:
+  matchLabels:
+    openshift: "false"
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app=central
+  tail: -1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: central
+spec:
+  template:
+    spec:
+      containers:
+        - name: central
+          env:
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
+            - name: ROX_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: ROX_TELEMETRY_ENDPOINT
+              value: https://telemetry.endpoint
+            - name: ROX_TELEMETRY_STORAGE_KEY_V1
+              value: my-api-key
+            - name: ROX_OFFLINE_MODE
+              value: "false"
+            - name: ROX_INSTALL_METHOD
+              value: "operator"
+            - name: NO_PROXY
+              valueFrom:
+                secretKeyRef:
+                  key: NO_PROXY
+                  name: central-stackrox-central-services-proxy-env
+status:
+  availableReplicas: 1

--- a/operator/tests/central/basic-central/80-assert-openshift.yaml
+++ b/operator/tests/central/basic-central/80-assert-openshift.yaml
@@ -1,3 +1,10 @@
+# Make kuttl ignore this file unless running against openshift.
+apiVersion: kuttl.dev/v1beta1
+kind: TestFile
+testRunSelector:
+  matchLabels:
+    openshift: "true"
+---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
 collectors:
@@ -28,6 +35,10 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.namespace
+            - name: ROX_TELEMETRY_ENDPOINT
+              value: https://telemetry.endpoint
+            - name: ROX_TELEMETRY_STORAGE_KEY_V1
+              value: my-api-key
             - name: ROX_OFFLINE_MODE
               value: "false"
             - name: ROX_ENABLE_OPENSHIFT_AUTH

--- a/operator/tests/central/basic-central/81-assert-non-openshift.yaml
+++ b/operator/tests/central/basic-central/81-assert-non-openshift.yaml
@@ -1,0 +1,48 @@
+# Make kuttl ignore this file if running against openshift.
+apiVersion: kuttl.dev/v1beta1
+kind: TestFile
+testRunSelector:
+  matchLabels:
+    openshift: "false"
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: pod
+  selector: app=central
+  tail: -1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: central
+spec:
+  template:
+    spec:
+      containers:
+        - name: central
+          env:
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
+            - name: ROX_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: ROX_OFFLINE_MODE
+              value: "false"
+            - name: ROX_INSTALL_METHOD
+              value: "operator"
+            - name: NO_PROXY
+              valueFrom:
+                secretKeyRef:
+                  key: NO_PROXY
+                  name: central-stackrox-central-services-proxy-env
+status:
+  availableReplicas: 1

--- a/operator/tests/central/basic-central/81-assert-openshift.yaml
+++ b/operator/tests/central/basic-central/81-assert-openshift.yaml
@@ -1,3 +1,10 @@
+# Make kuttl ignore this file unless running against openshift.
+apiVersion: kuttl.dev/v1beta1
+kind: TestFile
+testRunSelector:
+  matchLabels:
+    openshift: "true"
+---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
 collectors:
@@ -28,10 +35,6 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.namespace
-            - name: ROX_TELEMETRY_ENDPOINT
-              value: https://telemetry.endpoint
-            - name: ROX_TELEMETRY_STORAGE_KEY_V1
-              value: my-api-key
             - name: ROX_OFFLINE_MODE
               value: "false"
             - name: ROX_ENABLE_OPENSHIFT_AUTH

--- a/operator/tests/central/basic-central/90-assert-non-openshift.yaml
+++ b/operator/tests/central/basic-central/90-assert-non-openshift.yaml
@@ -1,3 +1,10 @@
+# Make kuttl ignore this file if running against openshift.
+apiVersion: kuttl.dev/v1beta1
+kind: TestFile
+testRunSelector:
+  matchLabels:
+    openshift: "false"
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -59,9 +66,6 @@ spec:
            readOnly: true
          - name: secret-2
            mountPath: /run/stackrox.io/declarative-configuration/secret-2
-           readOnly: true
-         - mountPath: /etc/pki/injected-ca-trust/
-           name: trusted-ca-volume
            readOnly: true
       volumes:
       - emptyDir: {}
@@ -148,13 +152,5 @@ spec:
           secretName: secret-2
           optional: true
           defaultMode: 420
-      - configMap:
-          defaultMode: 420
-          items:
-          - key: ca-bundle.crt
-            path: tls-ca-bundle.pem
-          name: injected-cabundle-stackrox-central-services
-          optional: true
-        name: trusted-ca-volume
 status:
   availableReplicas: 1

--- a/operator/tests/central/basic-central/90-assert-openshift.yaml
+++ b/operator/tests/central/basic-central/90-assert-openshift.yaml
@@ -1,0 +1,167 @@
+# Make kuttl ignore this file unless running against openshift.
+apiVersion: kuttl.dev/v1beta1
+kind: TestFile
+testRunSelector:
+  matchLabels:
+    openshift: "true"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: central
+spec:
+  template:
+    spec:
+      containers:
+      - name: central
+        volumeMounts:
+         - mountPath: /var/log/stackrox/
+           name: varlog
+         - mountPath: /tmp
+           name: central-tmp-volume
+         - mountPath: /etc/ssl
+           name: central-etc-ssl-volume
+         - mountPath: /etc/pki/ca-trust
+           name: central-etc-pki-volume
+         - mountPath: /run/secrets/stackrox.io/certs/
+           name: central-certs-volume
+           readOnly: true
+         - mountPath: /run/secrets/stackrox.io/default-tls-cert/
+           name: central-default-tls-cert-volume
+           readOnly: true
+         - mountPath: /run/secrets/stackrox.io/htpasswd/
+           name: central-htpasswd-volume
+           readOnly: true
+         - mountPath: /run/secrets/stackrox.io/jwt/
+           name: central-jwt-volume
+           readOnly: true
+         - mountPath: /usr/local/share/ca-certificates/
+           name: additional-ca-volume
+           readOnly: true
+         - mountPath: /run/secrets/stackrox.io/central-license/
+           name: central-license-volume
+           readOnly: true
+         - mountPath: /var/lib/stackrox
+           name: stackrox-db
+         - mountPath: /etc/stackrox
+           name: central-config-volume
+         - mountPath: /run/secrets/stackrox.io/proxy-config/
+           name: proxy-config-volume
+           readOnly: true
+         - mountPath: /etc/stackrox.d/endpoints/
+           name: endpoints-config-volume
+           readOnly: true
+         - mountPath: /run/secrets/stackrox.io/db-password
+           name: central-db-password
+         - mountPath: /etc/ext-db
+           name: central-external-db-volume
+         - name: config-map-1
+           mountPath: /run/stackrox.io/declarative-configuration/config-map-1
+           readOnly: true
+         - name: config-map-2
+           mountPath: /run/stackrox.io/declarative-configuration/config-map-2
+           readOnly: true
+         - name: secret-1
+           mountPath: /run/stackrox.io/declarative-configuration/secret-1
+           readOnly: true
+         - name: secret-2
+           mountPath: /run/stackrox.io/declarative-configuration/secret-2
+           readOnly: true
+         - mountPath: /etc/pki/injected-ca-trust/
+           name: trusted-ca-volume
+           readOnly: true
+      volumes:
+      - emptyDir: {}
+        name: varlog
+      - emptyDir: {}
+        name: central-tmp-volume
+      - emptyDir: {}
+        name: central-etc-ssl-volume
+      - emptyDir: {}
+        name: central-etc-pki-volume
+      - name: central-certs-volume
+        secret:
+          defaultMode: 420
+          secretName: central-tls
+      - name: central-default-tls-cert-volume
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: central-default-tls-cert
+      - name: central-htpasswd-volume
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: central-htpasswd
+      - name: central-jwt-volume
+        secret:
+          defaultMode: 420
+          items:
+          - key: jwt-key.pem
+            path: jwt-key.pem
+          secretName: central-tls
+      - name: additional-ca-volume
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: additional-ca
+      - name: central-license-volume
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: central-license
+      - configMap:
+          defaultMode: 420
+          name: central-config
+          optional: true
+        name: central-config-volume
+      - name: proxy-config-volume
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: proxy-config
+      - configMap:
+          defaultMode: 420
+          name: central-endpoints
+        name: endpoints-config-volume
+      - name: central-db-password
+        secret:
+          defaultMode: 420
+          secretName: central-db-password
+      - configMap:
+          defaultMode: 420
+          name: central-external-db
+          optional: true
+        name: central-external-db-volume
+      - name: stackrox-db
+        emptyDir: {}
+      - name: config-map-1
+        configMap:
+          name: config-map-1
+          optional: true
+          defaultMode: 420
+      - name: config-map-2
+        configMap:
+          name: config-map-2
+          optional: true
+          defaultMode: 420
+      - name: secret-1
+        secret:
+          secretName: secret-1
+          optional: true
+          defaultMode: 420
+      - name: secret-2
+        secret:
+          secretName: secret-2
+          optional: true
+          defaultMode: 420
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: ca-bundle.crt
+            path: tls-ca-bundle.pem
+          name: injected-cabundle-stackrox-central-services
+          optional: true
+        name: trusted-ca-volume
+status:
+  availableReplicas: 1

--- a/operator/tests/central/basic-central/91-assert-non-openshift.yaml
+++ b/operator/tests/central/basic-central/91-assert-non-openshift.yaml
@@ -1,3 +1,10 @@
+# Make kuttl ignore this file if running against openshift.
+apiVersion: kuttl.dev/v1beta1
+kind: TestFile
+testRunSelector:
+  matchLabels:
+    openshift: "false"
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -48,9 +55,6 @@ spec:
           name: central-db-password
         - mountPath: /etc/ext-db
           name: central-external-db-volume
-        - mountPath: /etc/pki/injected-ca-trust/
-          name: trusted-ca-volume
-          readOnly: true
       volumes:
       - emptyDir: {}
         name: varlog
@@ -116,13 +120,5 @@ spec:
         name: central-external-db-volume
       - name: stackrox-db
         emptyDir: {}
-      - configMap:
-          defaultMode: 420
-          items:
-          - key: ca-bundle.crt
-            path: tls-ca-bundle.pem
-          name: injected-cabundle-stackrox-central-services
-          optional: true
-        name: trusted-ca-volume
 status:
   availableReplicas: 1

--- a/operator/tests/central/basic-central/91-assert-openshift.yaml
+++ b/operator/tests/central/basic-central/91-assert-openshift.yaml
@@ -1,0 +1,135 @@
+# Make kuttl ignore this file unless running against openshift.
+apiVersion: kuttl.dev/v1beta1
+kind: TestFile
+testRunSelector:
+  matchLabels:
+    openshift: "true"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: central
+spec:
+  template:
+    spec:
+      containers:
+      - name: central
+        volumeMounts:
+        - mountPath: /var/log/stackrox/
+          name: varlog
+        - mountPath: /tmp
+          name: central-tmp-volume
+        - mountPath: /etc/ssl
+          name: central-etc-ssl-volume
+        - mountPath: /etc/pki/ca-trust
+          name: central-etc-pki-volume
+        - mountPath: /run/secrets/stackrox.io/certs/
+          name: central-certs-volume
+          readOnly: true
+        - mountPath: /run/secrets/stackrox.io/default-tls-cert/
+          name: central-default-tls-cert-volume
+          readOnly: true
+        - mountPath: /run/secrets/stackrox.io/htpasswd/
+          name: central-htpasswd-volume
+          readOnly: true
+        - mountPath: /run/secrets/stackrox.io/jwt/
+          name: central-jwt-volume
+          readOnly: true
+        - mountPath: /usr/local/share/ca-certificates/
+          name: additional-ca-volume
+          readOnly: true
+        - mountPath: /run/secrets/stackrox.io/central-license/
+          name: central-license-volume
+          readOnly: true
+        - mountPath: /var/lib/stackrox
+          name: stackrox-db
+        - mountPath: /etc/stackrox
+          name: central-config-volume
+        - mountPath: /run/secrets/stackrox.io/proxy-config/
+          name: proxy-config-volume
+          readOnly: true
+        - mountPath: /etc/stackrox.d/endpoints/
+          name: endpoints-config-volume
+          readOnly: true
+        - mountPath: /run/secrets/stackrox.io/db-password
+          name: central-db-password
+        - mountPath: /etc/ext-db
+          name: central-external-db-volume
+        - mountPath: /etc/pki/injected-ca-trust/
+          name: trusted-ca-volume
+          readOnly: true
+      volumes:
+      - emptyDir: {}
+        name: varlog
+      - emptyDir: {}
+        name: central-tmp-volume
+      - emptyDir: {}
+        name: central-etc-ssl-volume
+      - emptyDir: {}
+        name: central-etc-pki-volume
+      - name: central-certs-volume
+        secret:
+          defaultMode: 420
+          secretName: central-tls
+      - name: central-default-tls-cert-volume
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: central-default-tls-cert
+      - name: central-htpasswd-volume
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: central-htpasswd
+      - name: central-jwt-volume
+        secret:
+          defaultMode: 420
+          items:
+          - key: jwt-key.pem
+            path: jwt-key.pem
+          secretName: central-tls
+      - name: additional-ca-volume
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: additional-ca
+      - name: central-license-volume
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: central-license
+      - configMap:
+          defaultMode: 420
+          name: central-config
+          optional: true
+        name: central-config-volume
+      - name: proxy-config-volume
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: proxy-config
+      - configMap:
+          defaultMode: 420
+          name: central-endpoints
+        name: endpoints-config-volume
+      - name: central-db-password
+        secret:
+          defaultMode: 420
+          secretName: central-db-password
+      - configMap:
+          defaultMode: 420
+          name: central-external-db
+          optional: true
+        name: central-external-db-volume
+      - name: stackrox-db
+        emptyDir: {}
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: ca-bundle.crt
+            path: tls-ca-bundle.pem
+          name: injected-cabundle-stackrox-central-services
+          optional: true
+        name: trusted-ca-volume
+status:
+  availableReplicas: 1

--- a/operator/tests/common/central-cr-assert.yaml
+++ b/operator/tests/common/central-cr-assert.yaml
@@ -7,6 +7,17 @@ collectors:
 - type: pod
   selector: app=central-db
   tail: -1
+- type: pod
+  selector: app=scanner
+  tail: -1
+- type: pod
+  selector: app=scanner-db
+  tail: -1
+- command: kubectl describe pod -n $NAMESPACE -l app=central
+- command: kubectl describe pod -n $NAMESPACE -l app=central-db
+- command: kubectl describe pod -n $NAMESPACE -l app=scanner
+- command: kubectl describe pod -n $NAMESPACE -l app=scanner-db
+timeout: 900
 ---
 apiVersion: platform.stackrox.io/v1alpha1
 kind: Central

--- a/operator/tests/common/delete-central-assert.yaml
+++ b/operator/tests/common/delete-central-assert.yaml
@@ -5,12 +5,11 @@ kind: TestAssert
 commands:
 - script: |
     set -eu # shell in CI does not grok -o pipefail
-    errors_file=$(mktemp)
     # Note: apparently $PWD is NOT set to directory of this file for TestAssert but it is for TestStep
-    env - PATH=$PATH NAMESPACE=$NAMESPACE envsubst < tests/common/delete-central-errors-cluster.envsubst.yaml > $errors_file
     # Note: As of kuttl 0.11.0 the timeout value actually means "the number of attempts".
     # With 6 objects in the assert file, each attempt typically takes ~22 seconds (including the 1s sleep between attempts),
     # although it can occasionally take significantly longer, see https://github.com/kudobuilder/kuttl/issues/321
-    # So we specify a timeout value of 13, aiming for under 5 minutes.
-    ${KUTTL:-kubectl-kuttl} errors --timeout 13 $errors_file
-    rm $errors_file
+    # With 3 objects we specify a timeout value of 25, aiming for ~5 minutes.
+    ./hack/envsubst-kuttl.sh tests/common/delete-central-errors-cluster.envsubst.yaml errors --timeout 25
+    # With 2 objects we specify a timeout value of 32, aiming for ~5 minutes.
+    if kubectl get scc > /dev/null 2>&1; then ./hack/envsubst-kuttl.sh tests/common/delete-central-errors-cluster-openshift.envsubst.yaml errors --timeout 32; fi

--- a/operator/tests/common/delete-central-errors-cluster-openshift.envsubst.yaml
+++ b/operator/tests/common/delete-central-errors-cluster-openshift.envsubst.yaml
@@ -1,0 +1,10 @@
+# The following resources are obtained by following the instructions in delete-central-errors-cluster.envsubst.yaml.
+apiVersion: authorization.openshift.io/v1
+kind: ClusterRole
+metadata:
+  name: stackrox-${NAMESPACE}-central-psp
+---
+apiVersion: authorization.openshift.io/v1
+kind: ClusterRole
+metadata:
+  name: stackrox-${NAMESPACE}-scanner-psp

--- a/operator/tests/common/delete-central-errors-cluster.envsubst.yaml
+++ b/operator/tests/common/delete-central-errors-cluster.envsubst.yaml
@@ -7,16 +7,7 @@
 # 6. kubectl get "${cluster_kinds}" -o yaml > cluster_resources_after.yaml
 # 7. ./operator/bin/yq-* --null-input  '[load("cluster_resources_after.yaml") | .items[] | (with_entries(select(.key == "apiVersion" or .key == "kind")) + {"metadata": {"name": .metadata.name}})] - [load("cluster_resources_before.yaml") | .items[] | (with_entries(select(.key == "apiVersion" or .key == "kind")) + {"metadata": {"name": .metadata.name}})] | .[] | split_doc' | sed 's,kuttl-ns,${NAMESPACE},g'
 # 8. Massage the output to omit the PersistentVolume whose name is unpredictable
-apiVersion: authorization.openshift.io/v1
-kind: ClusterRole
-metadata:
-  name: stackrox-${NAMESPACE}-central-psp
----
-apiVersion: authorization.openshift.io/v1
-kind: ClusterRole
-metadata:
-  name: stackrox-${NAMESPACE}-scanner-psp
----
+# 9. Move the openshift-specific resources to delete-central-errors-cluster-openshift.envsubst.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/operator/tests/common/delete-central-errors-openshift.yaml
+++ b/operator/tests/common/delete-central-errors-openshift.yaml
@@ -1,0 +1,57 @@
+# Make kuttl ignore this file unless running against openshift.
+apiVersion: kuttl.dev/v1beta1
+kind: TestFile
+testRunSelector:
+  matchLabels:
+    openshift: "true"
+---
+# The following resources are obtained by following the instructions in delete-central-errors.yaml
+apiVersion: authorization.openshift.io/v1
+kind: RoleBinding
+metadata:
+  name: central-use-scc
+---
+apiVersion: authorization.openshift.io/v1
+kind: RoleBinding
+metadata:
+  name: scanner-use-scc
+---
+apiVersion: authorization.openshift.io/v1
+kind: RoleBinding
+metadata:
+  name: stackrox-central-diagnostics
+---
+apiVersion: authorization.openshift.io/v1
+kind: RoleBinding
+metadata:
+  name: stackrox-central-psp
+---
+apiVersion: authorization.openshift.io/v1
+kind: RoleBinding
+metadata:
+  name: stackrox-scanner-psp
+---
+apiVersion: authorization.openshift.io/v1
+kind: Role
+metadata:
+  name: stackrox-central-diagnostics
+---
+apiVersion: authorization.openshift.io/v1
+kind: Role
+metadata:
+  name: use-central-scc
+---
+apiVersion: authorization.openshift.io/v1
+kind: Role
+metadata:
+  name: use-scanner-scc
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: central
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: central-mtls

--- a/operator/tests/common/delete-central-errors.yaml
+++ b/operator/tests/common/delete-central-errors.yaml
@@ -12,6 +12,7 @@ metadata:
 # 6. kubectl get "${ns_kinds}" -n kuttl-ns -o yaml > ns_resources_after.yaml
 # 7. ./operator/bin/yq-* --null-input  '[load("ns_resources_after.yaml") | .items[] | (with_entries(select(.key == "apiVersion" or .key == "kind")) + {"metadata": {"name": .metadata.name}})] - [load("ns_resources_before.yaml") | .items[] | (with_entries(select(.key == "apiVersion" or .key == "kind")) + {"metadata": {"name": .metadata.name}})]| .[]| select(.kind != "PersistentVolumeClaim" and .kind != "Event" and .kind != "Pod" and .kind != "PodMetrics" and .kind != "ReplicaSet" and .kind != "EndpointSlice") | split_doc'
 # 8. Massage the output to omit those few Secrets whose names are unpredictable
+# 9. Move the openshift-specific resources to delete-central-errors-openshift.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -117,46 +118,6 @@ kind: Deployment
 metadata:
   name: scanner-db
 ---
-apiVersion: authorization.openshift.io/v1
-kind: RoleBinding
-metadata:
-  name: central-use-scc
----
-apiVersion: authorization.openshift.io/v1
-kind: RoleBinding
-metadata:
-  name: scanner-use-scc
----
-apiVersion: authorization.openshift.io/v1
-kind: RoleBinding
-metadata:
-  name: stackrox-central-diagnostics
----
-apiVersion: authorization.openshift.io/v1
-kind: RoleBinding
-metadata:
-  name: stackrox-central-psp
----
-apiVersion: authorization.openshift.io/v1
-kind: RoleBinding
-metadata:
-  name: stackrox-scanner-psp
----
-apiVersion: authorization.openshift.io/v1
-kind: Role
-metadata:
-  name: stackrox-central-diagnostics
----
-apiVersion: authorization.openshift.io/v1
-kind: Role
-metadata:
-  name: use-central-scc
----
-apiVersion: authorization.openshift.io/v1
-kind: Role
-metadata:
-  name: use-scanner-scc
----
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
@@ -221,16 +182,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: use-scanner-scc
----
-apiVersion: route.openshift.io/v1
-kind: Route
-metadata:
-  name: central
----
-apiVersion: route.openshift.io/v1
-kind: Route
-metadata:
-  name: central-mtls
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/operator/tests/common/delete-securedcluster-errors-openshift.yaml
+++ b/operator/tests/common/delete-securedcluster-errors-openshift.yaml
@@ -1,0 +1,132 @@
+# Make kuttl ignore this file unless running against openshift.
+apiVersion: kuttl.dev/v1beta1
+kind: TestFile
+testRunSelector:
+  matchLabels:
+    openshift: "true"
+# The following resources are obtained by following the instructions in delete-securedcluster-errors.yaml:
+---
+apiVersion: authorization.openshift.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: stackrox:create-events-binding
+---
+apiVersion: authorization.openshift.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: stackrox:enforce-policies
+---
+apiVersion: authorization.openshift.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: stackrox:monitor-cluster
+---
+apiVersion: authorization.openshift.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: stackrox:network-policies-binding
+---
+apiVersion: authorization.openshift.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: stackrox:review-tokens-binding
+---
+apiVersion: authorization.openshift.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: stackrox:update-namespaces-binding
+---
+apiVersion: authorization.openshift.io/v1
+kind: ClusterRole
+metadata:
+  name: stackrox-admission-control-psp
+---
+apiVersion: authorization.openshift.io/v1
+kind: ClusterRole
+metadata:
+  name: stackrox-collector-psp
+---
+apiVersion: authorization.openshift.io/v1
+kind: ClusterRole
+metadata:
+  name: stackrox-sensor-psp
+---
+apiVersion: authorization.openshift.io/v1
+kind: ClusterRole
+metadata:
+  name: stackrox:create-events
+---
+apiVersion: authorization.openshift.io/v1
+kind: ClusterRole
+metadata:
+  name: stackrox:edit-workloads
+---
+apiVersion: authorization.openshift.io/v1
+kind: ClusterRole
+metadata:
+  name: stackrox:network-policies
+---
+apiVersion: authorization.openshift.io/v1
+kind: ClusterRole
+metadata:
+  name: stackrox:review-tokens
+---
+apiVersion: authorization.openshift.io/v1
+kind: ClusterRole
+metadata:
+  name: stackrox:update-namespaces
+---
+apiVersion: authorization.openshift.io/v1
+kind: ClusterRole
+metadata:
+  name: stackrox:view-cluster
+---
+apiVersion: authorization.openshift.io/v1
+kind: RoleBinding
+metadata:
+  name: admission-control-use-scc
+---
+apiVersion: authorization.openshift.io/v1
+kind: RoleBinding
+metadata:
+  name: admission-control-watch-config
+---
+apiVersion: authorization.openshift.io/v1
+kind: RoleBinding
+metadata:
+  name: collector-use-scc
+---
+apiVersion: authorization.openshift.io/v1
+kind: RoleBinding
+metadata:
+  name: manage-namespace
+---
+apiVersion: authorization.openshift.io/v1
+kind: RoleBinding
+metadata:
+  name: stackrox-admission-control-psp
+---
+apiVersion: authorization.openshift.io/v1
+kind: RoleBinding
+metadata:
+  name: stackrox-collector-psp
+---
+apiVersion: authorization.openshift.io/v1
+kind: RoleBinding
+metadata:
+  name: stackrox-sensor-psp
+---
+apiVersion: authorization.openshift.io/v1
+kind: Role
+metadata:
+  name: edit
+---
+apiVersion: authorization.openshift.io/v1
+kind: Role
+metadata:
+  name: use-privileged-scc
+---
+apiVersion: authorization.openshift.io/v1
+kind: Role
+metadata:
+  name: watch-config

--- a/operator/tests/common/delete-securedcluster-errors.yaml
+++ b/operator/tests/common/delete-securedcluster-errors.yaml
@@ -13,85 +13,11 @@
 # 12. echo ---
 # 13. ./operator/bin/yq-* --null-input  '[load("ns_resources_after.yaml") | .items[] | (with_entries(select(.key == "apiVersion" or .key == "kind")) + {"metadata": {"name": .metadata.name}})] - [load("ns_resources_before.yaml") | .items[] | (with_entries(select(.key == "apiVersion" or .key == "kind")) + {"metadata": {"name": .metadata.name}})]| .[]| select(.kind != "Event" and .kind != "Pod" and .kind != "PodMetrics" and .kind != "ReplicaSet" and .kind != "ControllerRevision" and .kind != "EndpointSlice") | split_doc'
 # 14. Massage the output from the last command to omit those few Secrets whose names are unpredictable
+# 15. Move the openshift-specific resources to delete-securedcluster-errors-openshift.yaml
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: stackrox
----
-apiVersion: authorization.openshift.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: stackrox:create-events-binding
----
-apiVersion: authorization.openshift.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: stackrox:enforce-policies
----
-apiVersion: authorization.openshift.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: stackrox:monitor-cluster
----
-apiVersion: authorization.openshift.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: stackrox:network-policies-binding
----
-apiVersion: authorization.openshift.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: stackrox:review-tokens-binding
----
-apiVersion: authorization.openshift.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: stackrox:update-namespaces-binding
----
-apiVersion: authorization.openshift.io/v1
-kind: ClusterRole
-metadata:
-  name: stackrox-admission-control-psp
----
-apiVersion: authorization.openshift.io/v1
-kind: ClusterRole
-metadata:
-  name: stackrox-collector-psp
----
-apiVersion: authorization.openshift.io/v1
-kind: ClusterRole
-metadata:
-  name: stackrox-sensor-psp
----
-apiVersion: authorization.openshift.io/v1
-kind: ClusterRole
-metadata:
-  name: stackrox:create-events
----
-apiVersion: authorization.openshift.io/v1
-kind: ClusterRole
-metadata:
-  name: stackrox:edit-workloads
----
-apiVersion: authorization.openshift.io/v1
-kind: ClusterRole
-metadata:
-  name: stackrox:network-policies
----
-apiVersion: authorization.openshift.io/v1
-kind: ClusterRole
-metadata:
-  name: stackrox:review-tokens
----
-apiVersion: authorization.openshift.io/v1
-kind: ClusterRole
-metadata:
-  name: stackrox:update-namespaces
----
-apiVersion: authorization.openshift.io/v1
-kind: ClusterRole
-metadata:
-  name: stackrox:view-cluster
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -254,56 +180,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: sensor
----
-apiVersion: authorization.openshift.io/v1
-kind: RoleBinding
-metadata:
-  name: admission-control-use-scc
----
-apiVersion: authorization.openshift.io/v1
-kind: RoleBinding
-metadata:
-  name: admission-control-watch-config
----
-apiVersion: authorization.openshift.io/v1
-kind: RoleBinding
-metadata:
-  name: collector-use-scc
----
-apiVersion: authorization.openshift.io/v1
-kind: RoleBinding
-metadata:
-  name: manage-namespace
----
-apiVersion: authorization.openshift.io/v1
-kind: RoleBinding
-metadata:
-  name: stackrox-admission-control-psp
----
-apiVersion: authorization.openshift.io/v1
-kind: RoleBinding
-metadata:
-  name: stackrox-collector-psp
----
-apiVersion: authorization.openshift.io/v1
-kind: RoleBinding
-metadata:
-  name: stackrox-sensor-psp
----
-apiVersion: authorization.openshift.io/v1
-kind: Role
-metadata:
-  name: edit
----
-apiVersion: authorization.openshift.io/v1
-kind: Role
-metadata:
-  name: use-privileged-scc
----
-apiVersion: authorization.openshift.io/v1
-kind: Role
-metadata:
-  name: watch-config
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/operator/tests/common/secured-cluster-cr-assert.yaml
+++ b/operator/tests/common/secured-cluster-cr-assert.yaml
@@ -7,6 +7,8 @@ collectors:
 - type: pod
   selector: app=admission-control
   tail: -1
+- command: kubectl describe pod -n $NAMESPACE -l app=sensor
+- command: kubectl describe pod -n $NAMESPACE -l app=admission-control
 ---
 apiVersion: platform.stackrox.io/v1alpha1
 kind: SecuredCluster

--- a/operator/tests/scripts/validate-crs.sh
+++ b/operator/tests/scripts/validate-crs.sh
@@ -40,6 +40,11 @@ CRS=$(
 
 # Validate CRs.
 for cr in $CRS; do
+    if grep -q '^apiVersion: kuttl.dev/' "${cr}"; then
+        # TODO(ROX-19283): make it possible to validate these files somehow.
+        echo "Skipping ${cr} since it contains kuttl CR(s)."
+        continue
+    fi
     echo -n "Validating custom resource $cr with kubectl... "
     if output=$(kubectl apply --dry-run=client --validate=true -f "$cr" 2>&1); then
         echo PASSED

--- a/operator/tests/securedcluster/basic-sc/40-assert.yaml
+++ b/operator/tests/securedcluster/basic-sc/40-assert.yaml
@@ -1,5 +1,9 @@
+# Make kuttl ignore this file unless running against openshift.
 apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
+kind: TestFile
+testRunSelector:
+  matchLabels:
+    openshift: "true"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -10,5 +14,6 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
 commands:
 - script: |
-    # Test that Sensor auth reader rolebinding exists in kube-system.
-    kubectl get rolebinding rhacs-sensor-auth-reader-${NAMESPACE} -n kube-system
+    set -eu # shell in CI does not grok -o pipefail
+    # On OpenShift, test that Sensor auth reader rolebinding exists in kube-system.
+    if kubectl get scc > /dev/null 2>&1; then kubectl get rolebinding rhacs-sensor-auth-reader-${NAMESPACE} -n kube-system; fi

--- a/operator/tests/securedcluster/basic-sc/40-enable-monitoring.yaml
+++ b/operator/tests/securedcluster/basic-sc/40-enable-monitoring.yaml
@@ -1,3 +1,10 @@
+# Make kuttl ignore this file unless running against openshift.
+apiVersion: kuttl.dev/v1beta1
+kind: TestFile
+testRunSelector:
+  matchLabels:
+    openshift: "true"
+---
 apiVersion: platform.stackrox.io/v1alpha1
 kind: SecuredCluster
 metadata:

--- a/operator/tests/securedcluster/basic-sc/41-disable-monitoring.yaml
+++ b/operator/tests/securedcluster/basic-sc/41-disable-monitoring.yaml
@@ -1,3 +1,10 @@
+# Make kuttl ignore this file unless running against openshift.
+apiVersion: kuttl.dev/v1beta1
+kind: TestFile
+testRunSelector:
+  matchLabels:
+    openshift: "true"
+---
 apiVersion: platform.stackrox.io/v1alpha1
 kind: SecuredCluster
 metadata:

--- a/operator/tests/securedcluster/basic-sc/70-assert-openshift.yaml
+++ b/operator/tests/securedcluster/basic-sc/70-assert-openshift.yaml
@@ -1,3 +1,10 @@
+# Make kuttl ignore this file unless running against openshift.
+apiVersion: kuttl.dev/v1beta1
+kind: TestFile
+testRunSelector:
+  matchLabels:
+    openshift: "true"
+---
 # The central CR and its operands are gone in previous step.
 # However, the SecuredCluster reconciler should notice Central disappearing and
 # create a local scanner now that the central scanner is gone.

--- a/operator/tests/securedcluster/basic-sc/70-errors-non-openshift.yaml
+++ b/operator/tests/securedcluster/basic-sc/70-errors-non-openshift.yaml
@@ -1,0 +1,15 @@
+# Make kuttl ignore this file if running against openshift.
+apiVersion: kuttl.dev/v1beta1
+kind: TestFile
+testRunSelector:
+  matchLabels:
+    openshift: "false"
+---
+# The central CR and its operands are gone in previous step.
+# On platforms where local scanner is not supported (i.e. on non-OpenShift ones)
+# the reconciler should NOT create a local scanner now that the central scanner is gone.
+# So we have this errors file to make sure it is gone and not re-created.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: scanner

--- a/operator/tests/upgrade/upgrade/90-errors-central-openshift.yaml
+++ b/operator/tests/upgrade/upgrade/90-errors-central-openshift.yaml
@@ -1,0 +1,1 @@
+../../common/delete-central-errors-openshift.yaml

--- a/operator/tools/go.mod
+++ b/operator/tools/go.mod
@@ -10,6 +10,8 @@ require (
 	sigs.k8s.io/kustomize/kustomize/v4 v4.5.7
 )
 
+replace github.com/kudobuilder/kuttl v0.15.0 => github.com/porridge/kuttl v0.15.1-0.20230822121151-29595547752a
+
 require (
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
 	github.com/BurntSushi/toml v1.2.1 // indirect

--- a/operator/tools/go.sum
+++ b/operator/tools/go.sum
@@ -817,8 +817,6 @@ github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/kshvakov/clickhouse v1.3.5/go.mod h1:DMzX7FxRymoNkVgizH0DWAL8Cur7wHLgx3MUnGwJqpE=
-github.com/kudobuilder/kuttl v0.15.0 h1:OmCbpY3ebn+myJaatD+IT1AL1OTz34+Cv6ettiXd/hI=
-github.com/kudobuilder/kuttl v0.15.0/go.mod h1:UtAOt+GE8HQZFveEN8p1fk3j+H1Cp5Fk1eMdQkXPqH0=
 github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 h1:SOEGU9fKiNWd/HOJuq6+3iTQz8KNCLtVX6idSoTLdUw=
 github.com/lann/builder v0.0.0-20180802200727-47ae307949d0/go.mod h1:dXGbAdH5GtBTC4WfIxhKZfyBF/HBFgRZSWwZ9g/He9o=
 github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 h1:P6pPBnrTSX3DEVR4fDembhRWSsG5rVo6hYhAB/ADZrk=
@@ -1046,6 +1044,8 @@ github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZ
 github.com/pkg/sftp v1.13.1/go.mod h1:3HaPG6Dq1ILlpPZRO0HVMrsydcdLt6HRDccSgb87qRg=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/porridge/kuttl v0.15.1-0.20230822121151-29595547752a h1:ET6VCOrqPmCrVSqBygp54wOl1zDaBOqHkSvrXfD984s=
+github.com/porridge/kuttl v0.15.1-0.20230822121151-29595547752a/go.mod h1:UtAOt+GE8HQZFveEN8p1fk3j+H1Cp5Fk1eMdQkXPqH0=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSgv7Sy7s/s=
 github.com/poy/onpar v0.0.0-20190519213022-ee068f8ea4d1 h1:oL4IBbcqwhhNWh31bjOX8C/OCy0zs9906d/VUru+bqg=

--- a/scripts/ci/jobs/gke_operator_e2e_tests.py
+++ b/scripts/ci/jobs/gke_operator_e2e_tests.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env -S python3 -u
+
+"""
+Run operator e2e tests in GKE cluster.
+"""
+from clusters import GKECluster
+from runners import ClusterTestRunner
+from ci_tests import OperatorE2eTest
+from pre_tests import PreSystemTests
+from post_tests import PostClusterTest, FinalPost
+
+
+ClusterTestRunner(
+    cluster=GKECluster("operator-e2e-test"),
+    pre_test=PreSystemTests(),
+    test=OperatorE2eTest(operator_cluster_type="gke"),
+    post_test=PostClusterTest(collect_central_artifacts=False),
+    final_post=FinalPost(handle_e2e_progress_failures=False),
+).run()


### PR DESCRIPTION
## Description

* Introduce a gke-operator e2e job.
* Use a modified `kuttl` with support for conditional inclusion of files, see https://github.com/kudobuilder/kuttl/pull/483
* Split openshift-specific parts/variants of tests into separate files to make the test suite pass on GKE.
* The above broke validation of some files. Made the script skip them as a quick workaround. Proper solution tracked in a sister subtask.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

Ran the tests on my workstation against an openshift and GKE cluster. Otherwise CI tests should be sufficient.