### PR TITLE
Replace uses of severityColorMap from severityColors with accessible alternatives

### DIFF
--- a/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/widgets/PolicyViolationsBySeverity.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/widgets/PolicyViolationsBySeverity.js
@@ -24,7 +24,7 @@ const legendData = policySeverities.map((severity) => ({
     color: policySeverityColorMap[severity],
 }));
 
-const linkColor = 'var(--primary-600)'; // TODO might be able to remove after PatternFly dark them
+const linkColor = 'var(--primary-600)'; // TODO might be able to remove after PatternFly dark theme
 const textColor = 'var(--base-600)';
 const passingChartColor = 'var(--base-400)';
 

--- a/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/widgets/PolicyViolationsBySeverity.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/widgets/PolicyViolationsBySeverity.js
@@ -10,18 +10,23 @@ import { Link, withRouter } from 'react-router-dom';
 import { gql } from '@apollo/client';
 import max from 'lodash/max';
 import { severityValues, severities } from 'constants/severities';
-import {
-    severityColorMap,
-    severityTextColorMap,
-    severityColorLegend,
-} from 'constants/severityColors';
+import { policySeverityColorMap } from 'constants/visuals/colors';
+import { severityLabels as policySeverityLabels } from 'messages/common';
 import policyStatus from 'constants/policyStatus';
 import entityTypes from 'constants/entityTypes';
 import searchContext from 'Containers/searchContext';
 import { CLIENT_SIDE_SEARCH_OPTIONS as SEARCH_OPTIONS } from 'constants/searchOptions';
 import { getPercentage } from 'utils/mathUtils';
 
-const passingLinkColor = 'var(--base-500)';
+const policySeverities = ['LOW_SEVERITY', 'MEDIUM_SEVERITY', 'HIGH_SEVERITY', 'CRITICAL_SEVERITY'];
+
+const legendData = policySeverities.map((severity) => ({
+    title: policySeverityLabels[severity],
+    color: policySeverityColorMap[severity],
+}));
+
+const linkColor = 'var(--primary-600)'; // TODO might be able to remove after PatternFly dark them
+const textColor = 'var(--base-600)';
 const passingChartColor = 'var(--base-400)';
 
 const QUERY = gql`
@@ -54,7 +59,7 @@ function getCategorySeverity(category, violationsByCategory) {
         return passingChartColor;
     }
 
-    return severityColorMap[severityEntry[0]];
+    return policySeverityColorMap[severityEntry[0]];
 }
 
 const PolicyViolationsBySeverity = ({ match, location }) => {
@@ -75,7 +80,7 @@ const PolicyViolationsBySeverity = ({ match, location }) => {
                 if (!newItems[category]) {
                     newItems[category] = [];
                 }
-                const color = !isPassing ? severityColorMap[severity] : passingChartColor;
+                const color = !isPassing ? policySeverityColorMap[severity] : passingChartColor;
                 const queryObj = !isPassing
                     ? {
                           [searchParam]: {
@@ -94,7 +99,7 @@ const PolicyViolationsBySeverity = ({ match, location }) => {
                     severity,
                     passing: isPassing,
                     color,
-                    textColor: passingLinkColor,
+                    textColor,
                     value: 0,
                     labelColor: color,
                     name: `${isPassing ? '' : 'View deployments violating'} "${fullPolicyName}"`,
@@ -119,7 +124,7 @@ const PolicyViolationsBySeverity = ({ match, location }) => {
                 value,
                 labelValue,
                 color,
-                textColor: passingLinkColor,
+                textColor,
             };
         });
     }
@@ -151,7 +156,7 @@ const PolicyViolationsBySeverity = ({ match, location }) => {
         if (criticalCount) {
             links.push({
                 text: `${criticalCount} rated as critical`,
-                color: severityTextColorMap.CRITICAL_SEVERITY,
+                color: linkColor,
                 link: url
                     .query({
                         [searchParam]: {
@@ -168,7 +173,7 @@ const PolicyViolationsBySeverity = ({ match, location }) => {
         if (highCount) {
             links.push({
                 text: `${highCount} rated as high`,
-                color: severityTextColorMap.HIGH_SEVERITY,
+                color: linkColor,
                 link: url
                     .query({
                         [searchParam]: {
@@ -186,7 +191,7 @@ const PolicyViolationsBySeverity = ({ match, location }) => {
         if (mediumCount) {
             links.push({
                 text: `${mediumCount} rated as medium`,
-                color: severityTextColorMap.MEDIUM_SEVERITY,
+                color: linkColor,
                 link: url
                     .query({
                         [searchParam]: {
@@ -204,7 +209,7 @@ const PolicyViolationsBySeverity = ({ match, location }) => {
         if (lowCount) {
             links.push({
                 text: `${lowCount} rated as low`,
-                color: severityTextColorMap.LOW_SEVERITY,
+                color: linkColor,
                 link: url
                     .query({
                         [searchParam]: {
@@ -222,7 +227,7 @@ const PolicyViolationsBySeverity = ({ match, location }) => {
         if (passingCount) {
             links.push({
                 text: `${passingCount} policies without violations`,
-                color: passingLinkColor,
+                color: linkColor,
                 link: url
                     .query({
                         [searchParam]: {
@@ -275,7 +280,7 @@ const PolicyViolationsBySeverity = ({ match, location }) => {
                             <Sunburst
                                 data={sunburstData}
                                 rootData={sidePanelData}
-                                legendData={severityColorLegend}
+                                legendData={legendData}
                                 totalValue={centerValue}
                                 units="value"
                             />

--- a/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/widgets/PolicyViolationsBySeverity.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/widgets/PolicyViolationsBySeverity.js
@@ -12,13 +12,12 @@ import max from 'lodash/max';
 import { severityValues, severities } from 'constants/severities';
 import { policySeverityColorMap } from 'constants/visuals/colors';
 import { severityLabels as policySeverityLabels } from 'messages/common';
+import { policySeverities } from 'types/policy.proto';
 import policyStatus from 'constants/policyStatus';
 import entityTypes from 'constants/entityTypes';
 import searchContext from 'Containers/searchContext';
 import { CLIENT_SIDE_SEARCH_OPTIONS as SEARCH_OPTIONS } from 'constants/searchOptions';
 import { getPercentage } from 'utils/mathUtils';
-
-const policySeverities = ['LOW_SEVERITY', 'MEDIUM_SEVERITY', 'HIGH_SEVERITY', 'CRITICAL_SEVERITY'];
 
 const legendData = policySeverities.map((severity) => ({
     title: policySeverityLabels[severity],

--- a/ui/apps/platform/src/Containers/VulnMgmt/widgets/TopRiskyEntitiesByVulnerabilities.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/widgets/TopRiskyEntitiesByVulnerabilities.js
@@ -16,6 +16,7 @@ import entityTypes from 'constants/entityTypes';
 import entityLabels from 'messages/entity';
 import { policySeverityColorMap } from 'constants/visuals/colors';
 import { severityLabels as policySeverityLabels } from 'messages/common';
+import { policySeverities } from 'types/policy.proto';
 import { checkForPermissionErrorMessage } from 'utils/permissionUtils';
 import { getSeverityByCvss } from 'utils/vulnerabilityUtils';
 import { entitySortFieldsMap, cveSortFields } from 'constants/sortFields';
@@ -24,8 +25,6 @@ import { entityPriorityField } from 'Containers/VulnMgmt/VulnMgmt.constants';
 import useFeatureFlags from 'hooks/useFeatureFlags';
 
 // Beware, policy instead of vulnerability severities because of getSeverityByCvss function!
-
-const policySeverities = ['LOW_SEVERITY', 'MEDIUM_SEVERITY', 'HIGH_SEVERITY', 'CRITICAL_SEVERITY'];
 
 const legendData = policySeverities.map((severity) => ({
     title: policySeverityLabels[severity],

--- a/ui/apps/platform/src/Containers/VulnMgmt/widgets/TopRiskyEntitiesByVulnerabilities.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/widgets/TopRiskyEntitiesByVulnerabilities.js
@@ -14,18 +14,23 @@ import HoverHintListItem from 'Components/visuals/HoverHintListItem';
 import TextSelect from 'Components/TextSelect';
 import entityTypes from 'constants/entityTypes';
 import entityLabels from 'messages/entity';
-import { severityLabels } from 'messages/common';
-import {
-    severityColorMap,
-    severityTextColorMap,
-    severityColorLegend,
-} from 'constants/severityColors';
+import { policySeverityColorMap } from 'constants/visuals/colors';
+import { severityLabels as policySeverityLabels } from 'messages/common';
 import { checkForPermissionErrorMessage } from 'utils/permissionUtils';
 import { getSeverityByCvss } from 'utils/vulnerabilityUtils';
 import { entitySortFieldsMap, cveSortFields } from 'constants/sortFields';
 import { WIDGET_PAGINATION_START_OFFSET } from 'constants/workflowPages.constants';
 import { entityPriorityField } from 'Containers/VulnMgmt/VulnMgmt.constants';
 import useFeatureFlags from 'hooks/useFeatureFlags';
+
+// Beware, policy instead of vulnerability severities because of getSeverityByCvss function!
+
+const policySeverities = ['LOW_SEVERITY', 'MEDIUM_SEVERITY', 'HIGH_SEVERITY', 'CRITICAL_SEVERITY'];
+
+const legendData = policySeverities.map((severity) => ({
+    title: policySeverityLabels[severity],
+    color: policySeverityColorMap[severity],
+}));
 
 const ENTITY_COUNT = 25;
 const VULN_COUNT = 50;
@@ -375,8 +380,7 @@ const TopRiskyEntitiesByVulnerabilities = ({
                 ? (datum.metadata && datum.metadata.priority) || 0
                 : datum.priority;
         const severityKey = getSeverityByCvss(datum.avgSeverity);
-        const severityTextColor = severityTextColorMap[severityKey];
-        const severityText = severityLabels[severityKey];
+        const severityText = policySeverityLabels[severityKey];
 
         let cveCountText =
             filter !== 'Fixable' ? `${datum.plottedVulns.basicVulnCounter.all.total} total / ` : '';
@@ -389,11 +393,7 @@ const TopRiskyEntitiesByVulnerabilities = ({
                 (datum.metadata && datum.metadata.name),
             body: (
                 <ul className="flex-1 border-base-300 overflow-hidden">
-                    <HoverHintListItem
-                        key="severity"
-                        label="Severity"
-                        value={<span style={{ color: severityTextColor }}>{severityText}</span>}
-                    />
+                    <HoverHintListItem key="severity" label="Severity" value={severityText} />
                     <HoverHintListItem
                         key="riskPriority"
                         label="Risk Priority"
@@ -421,7 +421,7 @@ const TopRiskyEntitiesByVulnerabilities = ({
                 const vulnCount = result?.plottedVulns?.basicVulnCounter?.all?.total;
                 const url = workflowState.pushRelatedEntity(selectedEntityType, entityId).toUrl();
                 const avgSeverity = getAverageSeverity(result.plottedVulns.vulns);
-                const color = severityColorMap[getSeverityByCvss(avgSeverity)];
+                const color = policySeverityColorMap[getSeverityByCvss(avgSeverity)];
 
                 return {
                     x: vulnCount,
@@ -494,7 +494,7 @@ const TopRiskyEntitiesByVulnerabilities = ({
                         yMultiple={5}
                         yAxisTitle="Weighted CVSS Score"
                         xAxisTitle="Critical Vulnerabilities & Exposures"
-                        legendData={!small ? severityColorLegend : []}
+                        legendData={!small ? legendData : []}
                     />
                 );
             }

--- a/ui/apps/platform/src/constants/visuals/colors.ts
+++ b/ui/apps/platform/src/constants/visuals/colors.ts
@@ -20,6 +20,7 @@ export const fileUploadColors = {
 
 export const defaultColorType = 'base';
 
+// TODO supersede with policySeverityColors below.
 export const severityColors: Record<PolicySeverity, string> = {
     LOW_SEVERITY: 'var(--color-severity-low)',
     MEDIUM_SEVERITY: 'var(--color-severity-medium)',
@@ -27,12 +28,31 @@ export const severityColors: Record<PolicySeverity, string> = {
     CRITICAL_SEVERITY: 'var(--color-severity-critical)',
 };
 
+/*
+ * Export individual constants for consistency in pseudo-severity use cases like compliance.
+ * Vulnerability severity name preceded policy severity name when they differ.
+ */
+export const LOW_SEVERITY_COLOR = 'var(--pf-global--palette--blue-300)';
+export const MODERATE_MEDIUM_SEVERITY_COLOR = 'var(--pf-global--palette--gold-300)';
+export const IMPORTANT_HIGH_SEVERITY_COLOR = 'var(--pf-global--palette--orange-200)';
+export const CRITICAL_SEVERITY_COLOR = 'var(--pf-global--palette--red-100)';
+export const UNKNOWN_SEVERITY_COLOR = 'var(--pf-global--palette--black-400)';
+
+export const policySeverityColorMap: Record<PolicySeverity, string> = {
+    LOW_SEVERITY: LOW_SEVERITY_COLOR,
+    MEDIUM_SEVERITY: MODERATE_MEDIUM_SEVERITY_COLOR,
+    HIGH_SEVERITY: IMPORTANT_HIGH_SEVERITY_COLOR,
+    CRITICAL_SEVERITY: UNKNOWN_SEVERITY_COLOR,
+};
+
+// TODO rename as vulnerabilitySeverityColorMap.
+// TODO include Icon in name only if color text below is confirmed.
 export const vulnSeverityIconColors: Record<VulnerabilitySeverity, string> = {
-    LOW_VULNERABILITY_SEVERITY: 'var(--pf-global--palette--blue-300)',
-    MODERATE_VULNERABILITY_SEVERITY: 'var(--pf-global--palette--gold-300)',
-    IMPORTANT_VULNERABILITY_SEVERITY: 'var(--pf-global--palette--orange-200)',
-    CRITICAL_VULNERABILITY_SEVERITY: 'var(--pf-global--palette--red-100)',
-    UNKNOWN_VULNERABILITY_SEVERITY: 'var(--pf-global--palette--black-400)',
+    LOW_VULNERABILITY_SEVERITY: LOW_SEVERITY_COLOR,
+    MODERATE_VULNERABILITY_SEVERITY: MODERATE_MEDIUM_SEVERITY_COLOR,
+    IMPORTANT_VULNERABILITY_SEVERITY: IMPORTANT_HIGH_SEVERITY_COLOR,
+    CRITICAL_VULNERABILITY_SEVERITY: CRITICAL_SEVERITY_COLOR,
+    UNKNOWN_VULNERABILITY_SEVERITY: UNKNOWN_SEVERITY_COLOR,
 };
 
 export const vulnSeverityTextColors: Record<VulnerabilitySeverity, string> = {


### PR DESCRIPTION
## Description

### Problems

1. Color text causes accessibility problems like assumption of perfect color vision.

2. Inconsistent colors for severity throughout UI.

### Analysis

1. src/Containers/ConfigManagement/Dashboard/widgets/PolicyViolationsBySeverity.js

    * This use of `Sunburst` element is similar to `CvesByCvssScore` component.

2. src/Containers/VulnMgmt/widgets/TopRiskyEntitiesByVulnerabilities.js

    * This is the only use of `Scatterplot` element.

### Solution

1. Except for **policy** colors, labels, and severities, instead of vulnerability, changes are similar to src/Containers/VulnMgmt/widgets/CvesByCvssScore.js in #5811

2. Encapsulate `legendData` within component.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

### Integration testing

In ui/apps/platform folder:

1. `export CYPRESS_ROX_POSTGRES_DATASTORE=true`

2. `yarn cypress-open`

    * configmanagement/dashboard.test.js
    * vulnmanagement/dashboard.test.js
    * vulnmanagement/dashboardToEntityPage.test.js

### Manual testing

1. Visit /main/configmanagement and see widget at upper left

    * classic severity colors in dark theme
        ![Sunburst_dark_classic](https://user-images.githubusercontent.com/11862657/234592121-dac6666e-796d-4a94-91cb-2579ac8ae376.png)

    * PatternFly severity colors in dark theme
        ![Sunburst_dark_PatternFly](https://user-images.githubusercontent.com/11862657/234592170-788f20cc-7fee-422d-bc54-6480b2c97be4.png)

    * classic severity colors in light theme
        ![Sunburst_light_classic](https://user-images.githubusercontent.com/11862657/234592222-33a81236-0f64-4a98-9d53-edb7f82fe44f.png)

    * PatternFly severity colors in light theme
        ![Sunburst_light_PatternFly](https://user-images.githubusercontent.com/11862657/234592264-3cc3a342-6658-478a-a340-ed7f43a113a6.png)

2. Visit /main/vulnerability-management and see widget at upper left

    * classic severity colors in dark theme
        ![Scatterplot_dark_classic](https://user-images.githubusercontent.com/11862657/234592318-230a82f0-153d-48ee-bf08-6e628d4f0a76.png)

    * PatternFly severity colors in dark theme
        ![Scatterplot_dark_PatternFly](https://user-images.githubusercontent.com/11862657/234592356-f7c30c7a-f22d-41e3-8b5e-65e0b46115a4.png)

    * classic severity colors in light theme
        ![Scatterplot_light_classic](https://user-images.githubusercontent.com/11862657/234592392-dc16e247-30e7-4f23-8e48-d29b95fc0dee.png)

    * PatternFly severity colors in light theme
        ![Scatterplot_light_PatternFly](https://user-images.githubusercontent.com/11862657/234592420-5bf47469-4592-47a3-802b-5f13f6179011.png)