### PR TITLE
Use alias instead of struct in concurrency.Flag

### DIFF
--- a/pkg/concurrency/flag.go
+++ b/pkg/concurrency/flag.go
@@ -3,28 +3,26 @@ package concurrency
 import "sync/atomic"
 
 // Flag is an atomic boolean flag.
-type Flag struct {
-	val uint32
-}
+type Flag uint32
 
 // Get gets the current value of the flag.
 func (f *Flag) Get() bool {
-	return atomic.LoadUint32(&f.val)&0x1 != 0
+	return atomic.LoadUint32((*uint32)(f))&0x1 != 0
 }
 
 // Set sets the value of the flag, discarding the previous value.
 func (f *Flag) Set(v bool) {
-	atomic.StoreUint32(&f.val, b2i(v))
+	atomic.StoreUint32((*uint32)(f), b2i(v))
 }
 
 // TestAndSet sets the value of the flag, and returns the *previous* value of the flag.
 func (f *Flag) TestAndSet(v bool) bool {
-	return atomic.SwapUint32(&f.val, b2i(v))&0x1 != 0
+	return atomic.SwapUint32((*uint32)(f), b2i(v))&0x1 != 0
 }
 
 // Toggle flips the value of the flag, and returns the *new* value of the flag.
 func (f *Flag) Toggle() bool {
-	return atomic.AddUint32(&f.val, 1)&0x1 != 0
+	return atomic.AddUint32((*uint32)(f), 1)&0x1 != 0
 }
 
 func b2i(v bool) uint32 {


### PR DESCRIPTION
## Description

Looks like the wrapper struct is not needed and we can use simple type alias for Flag.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

CI
