### PR TITLE
Update eslint-plugin-jest-dom-4.0.3 devDependencies in ui

### DIFF
--- a/ui/apps/platform/package.json
+++ b/ui/apps/platform/package.json
@@ -114,6 +114,7 @@
         "test": "JEST_JUNIT_UNIQUE_OUTPUT_NAME=true JEST_JUNIT_OUTPUT_DIR=${TEST_RESULTS_OUTPUT_DIR:-test-results}/reports react-app-rewired test --verbose=true --slowTestThreshold=1  --coverage --reporters=default --reporters=jest-junit",
         "test-watch": "react-app-rewired test",
         "lint": "NODE_PATH=src eslint --quiet --ext .js,.ts,.tsx src cypress tailwind.config.js .prettierrc.js .eslintrc.js",
+        "lint:fix": "NODE_PATH=src eslint --fix --quiet --ext .js,.ts,.tsx src cypress tailwind.config.js .prettierrc.js .eslintrc.js",
         "cypress-open": "./scripts/cypress.sh open --config defaultCommandTimeout=8000",
         "cypress-spec": "./scripts/cypress.sh run --spec",
         "test-e2e": "./scripts/cypress.sh run --reporter mocha-multi-reporters --reporter-options configFile=cypress/mocha.config.js",

--- a/ui/apps/platform/src/hooks/useWidgetConfig.test.tsx
+++ b/ui/apps/platform/src/hooks/useWidgetConfig.test.tsx
@@ -140,8 +140,8 @@ describe('useWidgetConfig hook', () => {
             </>
         );
 
-        expect(renderSpies[idA]).toBeCalledTimes(1);
-        expect(renderSpies[idB]).toBeCalledTimes(1);
+        expect(renderSpies[idA]).toHaveBeenCalledTimes(1);
+        expect(renderSpies[idB]).toHaveBeenCalledTimes(1);
 
         reactAct(() => {
             hookReturns[idA][1]({ sort: 'desc' });
@@ -149,8 +149,8 @@ describe('useWidgetConfig hook', () => {
 
         // Updating the config for one component should not cause the other component to rerender
         // and should only update the config state of the changed component.
-        expect(renderSpies[idA]).toBeCalledTimes(2);
-        expect(renderSpies[idB]).toBeCalledTimes(1);
+        expect(renderSpies[idA]).toHaveBeenCalledTimes(2);
+        expect(renderSpies[idB]).toHaveBeenCalledTimes(1);
         expect(hookReturns[idA][0]).toEqual({ sort: 'desc', filter: '' });
         expect(hookReturns[idB][0]).toEqual({ sort: 'asc', filter: '' });
 
@@ -158,8 +158,8 @@ describe('useWidgetConfig hook', () => {
             hookReturns[idB][1]({ filter: 'Namespace:stackrox' });
         });
 
-        expect(renderSpies[idA]).toBeCalledTimes(2);
-        expect(renderSpies[idB]).toBeCalledTimes(2);
+        expect(renderSpies[idA]).toHaveBeenCalledTimes(2);
+        expect(renderSpies[idB]).toHaveBeenCalledTimes(2);
         expect(hookReturns[idA][0]).toEqual({ sort: 'desc', filter: '' });
         expect(hookReturns[idB][0]).toEqual({ sort: 'asc', filter: 'Namespace:stackrox' });
 

--- a/ui/apps/platform/src/services/AuthService/AccessTokenManager.test.js
+++ b/ui/apps/platform/src/services/AuthService/AccessTokenManager.test.js
@@ -43,9 +43,9 @@ describe('AccessTokenManager', () => {
         const tokenInfo = { expiry: new Date(Date.now() + 31000).toISOString() };
 
         m.setToken('my-token', tokenInfo);
-        expect(refreshToken).not.toBeCalled();
+        expect(refreshToken).not.toHaveBeenCalled();
         jest.advanceTimersByTime(1000);
-        expect(refreshToken).toBeCalledWith(tokenInfo);
+        expect(refreshToken).toHaveBeenCalledWith(tokenInfo);
     });
 
     it('should clear timeout on refresh token invocation', () => {
@@ -54,7 +54,7 @@ describe('AccessTokenManager', () => {
         const tokenInfo = { expiry: new Date(Date.now() + 31000).toISOString() };
         m.setToken('my-token', tokenInfo);
         m.refreshToken();
-        expect(timeoutSpy).toBeCalledTimes(1);
+        expect(timeoutSpy).toHaveBeenCalledTimes(1);
     });
 
     it('should store new token info after refresh', () => {
@@ -95,14 +95,14 @@ describe('AccessTokenManager', () => {
 
         m.onRefreshTokenStarted(refreshTokenListener);
         m.refreshToken();
-        expect(refreshTokenListener).toBeCalledTimes(1);
+        expect(refreshTokenListener).toHaveBeenCalledTimes(1);
 
         m.removeRefreshTokenListener(refreshTokenListener);
         return m.getRefreshTokenOpPromise().then(() => {
             expect(m.getRefreshTokenOpPromise()).toEqual(null);
             m.refreshToken();
-            expect(refreshToken).toBeCalledTimes(2);
-            expect(refreshTokenListener).toBeCalledTimes(1);
+            expect(refreshToken).toHaveBeenCalledTimes(2);
+            expect(refreshTokenListener).toHaveBeenCalledTimes(1);
         });
     });
 
@@ -113,11 +113,11 @@ describe('AccessTokenManager', () => {
 
         m.onRefreshTokenStarted(refreshTokenListener);
         m.refreshToken();
-        expect(refreshTokenListener).toBeCalledTimes(1);
+        expect(refreshTokenListener).toHaveBeenCalledTimes(1);
 
         const firstOpPromise = m.getRefreshTokenOpPromise();
         m.refreshToken();
-        expect(refreshTokenListener).toBeCalledTimes(1);
+        expect(refreshTokenListener).toHaveBeenCalledTimes(1);
         expect(m.getRefreshTokenOpPromise()).toEqual(firstOpPromise);
     });
 });

--- a/ui/apps/platform/src/services/AuthService/addTokenRefreshInterceptors.test.js
+++ b/ui/apps/platform/src/services/AuthService/addTokenRefreshInterceptors.test.js
@@ -52,7 +52,7 @@ describe('addTokenRefreshInterceptors', () => {
             .resolves.toMatchObject({ myRequest: true })
             .then(() => {
                 // should not initiate refresh token operation as another one is in progress
-                expect(m.refreshToken).not.toBeCalled();
+                expect(m.refreshToken).not.toHaveBeenCalled();
             });
     });
 
@@ -73,8 +73,8 @@ describe('addTokenRefreshInterceptors', () => {
         return expect(handler.rejected(error))
             .resolves.toMatchObject({ myRequest: true })
             .then(() => {
-                expect(m.refreshToken).not.toBeCalled();
-                expect(extractAccessToken).toBeCalledTimes(1);
+                expect(m.refreshToken).not.toHaveBeenCalled();
+                expect(extractAccessToken).toHaveBeenCalledTimes(1);
             });
     });
 
@@ -92,7 +92,7 @@ describe('addTokenRefreshInterceptors', () => {
         return expect(handler.rejected(error))
             .resolves.toMatchObject({ myRequest: true })
             .then(() => {
-                expect(m.refreshToken).toBeCalledTimes(1);
+                expect(m.refreshToken).toHaveBeenCalledTimes(1);
             });
     });
 
@@ -117,7 +117,7 @@ describe('addTokenRefreshInterceptors', () => {
         return expect(handler.rejected(retriedResponseError))
             .rejects.toEqual(retriedResponseError)
             .then(() => {
-                expect(handleAuthError).toBeCalledTimes(1);
+                expect(handleAuthError).toHaveBeenCalledTimes(1);
             });
     });
 

--- a/ui/apps/platform/src/utils/networkGraphUtils.test.js
+++ b/ui/apps/platform/src/utils/networkGraphUtils.test.js
@@ -308,7 +308,7 @@ describe('networkGraphUtils', () => {
             function getUnknownNodeNamespace() {
                 return getNodeNamespace(node);
             }
-            expect(getUnknownNodeNamespace).toThrowError(
+            expect(getUnknownNodeNamespace).toThrow(
                 'Node with unexpected type (UNKNOWN) was supplied to function'
             );
         });
@@ -364,7 +364,7 @@ describe('networkGraphUtils', () => {
             function getUnknownNodeName() {
                 return getNodeName(node);
             }
-            expect(getUnknownNodeName).toThrowError(
+            expect(getUnknownNodeName).toThrow(
                 'Node with unexpected type (UNKNOWN) was supplied to function'
             );
         });

--- a/ui/packages/ui-components/package.json
+++ b/ui/packages/ui-components/package.json
@@ -63,7 +63,7 @@
         "eslint-plugin-eslint-comments": "^3.2.0",
         "eslint-plugin-import": "^2.25.3",
         "eslint-plugin-jest": "^24.5.0",
-        "eslint-plugin-jest-dom": "^4.0.2",
+        "eslint-plugin-jest-dom": "^4.0.3",
         "eslint-plugin-jsx-a11y": "^6.5.1",
         "eslint-plugin-prettier": "^4.0.0",
         "eslint-plugin-react": "^7.27.0",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -10764,10 +10764,10 @@ eslint-plugin-import@^2.25.3:
     resolve "^1.20.0"
     tsconfig-paths "^3.11.0"
 
-eslint-plugin-jest-dom@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jest-dom/-/eslint-plugin-jest-dom-4.0.2.tgz#9d3e2f51055f74c74e745d89c4b1a9781e0ec7a9"
-  integrity sha512-Jo51Atwyo2TdcUncjmU+UQeSTKh3sc2LF/M5i/R3nTU0Djw9V65KGJisdm/RtuKhy2KH/r7eQ1n6kwYFPNdHlA==
+eslint-plugin-jest-dom@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jest-dom/-/eslint-plugin-jest-dom-4.0.3.tgz#ec17171385660e78465cce9f3e1ce90294ea1190"
+  integrity sha512-9j+n8uj0+V0tmsoS7bYC7fLhQmIvjRqRYEcbDSi+TKPsTThLLXCyj5swMSSf/hTleeMktACnn+HFqXBr5gbcbA==
   dependencies:
     "@babel/runtime" "^7.16.3"
     "@testing-library/dom" "^8.11.1"


### PR DESCRIPTION
## Description

First step to upgrade eslint-related devDependencies.

Auto-fix 21 `jest/no-alias-methods` errors from attempted eslint-plugin-jest 27.2.1 attempted upgrade because they are backward compatible, but wait on that upgrade, because it indirectly causes hundreds of typescript-eslint errors that await future investigation.

```text
  dependencies:
    "@typescript-eslint/utils" "^5.10.0"
```

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited unit tests

## Testing Performed

1. `yarn lint`

    * ui folder
    * ui/apps/platform folder
    * ui/packages/ui-components folder

2. `yarn lint:fix` in ui/apps/platform folder

3. `yarn test` and then press a

    * ui/apps/platform folder
    * ui/packages/ui-components folder