### PR TITLE
Increase minimum version of node to 14.17.0 in ui

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -16,7 +16,7 @@
         ]
     },
     "engines": {
-        "node": ">=12.13.0"
+        "node": ">=14.17.0"
     },
     "scripts": {
         "postinstall": "./scripts/patch-deps.sh",


### PR DESCRIPTION
## Description

Prerequisite for TypeScript 5.1 upgrade about May 30

https://github.com/microsoft/TypeScript/issues/53031

https://devblogs.microsoft.com/typescript/announcing-typescript-5-1-beta/#es2020-and-node-js-14-17-as-minimum-runtime-requirements

> TypeScript 5.1 now ships JavaScript functionality that was introduced in ECMAScript 2020. As a result, at minimum TypeScript must be run in a reasonably modern runtime. For most users, this means TypeScript now only runs on Node.js 14.17 and later.

CI for ui-e2e-tests currently runs Node.js 16.17.1 and UI team runs 16.y.z so this is for good citizenship in open source community.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

1. `yarn build` in ui

2. `yarn lint`
    * in ui/apps/platform
    * in ui/packages/tailwind-config
    * in ui/packages/ui-components