### PR TITLE
ROX-16554: Add changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 
 ### Technical Changes
 
+- Helm setting `collector.nodeInventoryResources` has been renamed to `collector.nodeScanningResources`
+
 ## [4.0.0]
 
 ### Added Features


### PR DESCRIPTION
## Description

Add chagnelog entry for "Rename Helm setting nodeInventoryResources to nodeScanningResources" as it was forgotten in https://github.com/stackrox/stackrox/pull/5781 

## Checklist

- [x] Evaluated and added CHANGELOG entry if required

### N/A
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

- nothing
