### PR TITLE
Replace classic colors in Compliance Sunburst with PatternFly colors

### DIFF
--- a/ui/apps/platform/src/Containers/Compliance/widgets/ComplianceByStandard.js
+++ b/ui/apps/platform/src/Containers/Compliance/widgets/ComplianceByStandard.js
@@ -9,22 +9,25 @@ import Widget from 'Components/Widget';
 import Sunburst from 'Components/visuals/Sunburst';
 import Query from 'Components/CacheFirstQuery';
 import Loader from 'Components/Loader';
+import {
+    COMPLIANCE_PASS_COLOR,
+    CRITICAL_SEVERITY_COLOR,
+    IMPORTANT_HIGH_SEVERITY_COLOR,
+    MODERATE_MEDIUM_SEVERITY_COLOR,
+} from 'constants/visuals/colors';
 import { COMPLIANCE_STANDARDS } from 'queries/standard';
 import queryService from 'utils/queryService';
 import searchContext from 'Containers/searchContext';
 import isGQLLoading from 'utils/gqlLoading';
 
-const passColor = 'var(--tertiary-400)';
-const warningColor = 'var(--warning-400)';
-const cautionColor = 'var(--caution-400)';
-const skippedColor = 'var(--base-300)';
-const alertColor = 'var(--alert-400)';
+const passColor = COMPLIANCE_PASS_COLOR;
+const warningColor = MODERATE_MEDIUM_SEVERITY_COLOR;
+const cautionColor = IMPORTANT_HIGH_SEVERITY_COLOR;
+const skippedColor = 'var(--base-400)'; // same as NAColor in ComplianceByControls
+const alertColor = CRITICAL_SEVERITY_COLOR;
 
-const passTextColor = 'var(--tertiary-500)';
-const warningTextColor = 'var(--warning-500)';
-const cautionTextColor = 'var(--caution-500)';
-const skippedTextColor = 'var(--base-500)';
-const alertTextColor = 'var(--alert-500)';
+const linkColor = 'var(--primary-600)'; // TODO might be able to remove after PatternFly dark theme
+const textColor = 'var(--base-600)';
 
 const getColor = (value) => {
     if (value === 100) {
@@ -40,22 +43,6 @@ const getColor = (value) => {
         return skippedColor;
     }
     return alertColor;
-};
-
-const getTextColor = (value) => {
-    if (value === 100) {
-        return passTextColor;
-    }
-    if (value >= 70) {
-        return warningTextColor;
-    }
-    if (value >= 50) {
-        return cautionTextColor;
-    }
-    if (Number.isNaN(value)) {
-        return skippedTextColor;
-    }
-    return alertTextColor;
 };
 
 const sunburstLegendData = [
@@ -107,7 +94,7 @@ const processSunburstData = (match, location, data, standard) => {
             groupMapping[datum.id] = {
                 name: `${datum?.name}. ${datum?.description}`,
                 color: getColor(value),
-                textColor: getTextColor(value),
+                textColor,
                 value,
                 children: [],
             };
@@ -129,7 +116,7 @@ const processSunburstData = (match, location, data, standard) => {
                 group.children.push({
                     name: `${datum?.name} - ${datum?.description}`,
                     color: getColor(value),
-                    textColor: getTextColor(value),
+                    textColor,
                     link: url,
                     value,
                 });
@@ -225,7 +212,7 @@ const ComplianceByStandard = ({
                         {
                             text: `${getNumControls(sunburstData)} Controls`,
                             link: url,
-                            color: 'var(--tertiary-700)',
+                            color: linkColor,
                         },
                     ];
 

--- a/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/widgets/ComplianceByControls.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/widgets/ComplianceByControls.js
@@ -4,6 +4,7 @@ import ReactRouterPropTypes from 'react-router-prop-types';
 import { gql } from '@apollo/client';
 import queryService from 'utils/queryService';
 import entityTypes, { standardEntityTypes, standardBaseTypes } from 'constants/entityTypes';
+import { COMPLIANCE_FAIL_COLOR, COMPLIANCE_PASS_COLOR } from 'constants/visuals/colors';
 import { standardLabels } from 'messages/standards';
 import { Link, withRouter } from 'react-router-dom';
 import URLService from 'utils/URLService';
@@ -19,18 +20,17 @@ import Sunburst from 'Components/visuals/Sunburst';
 import TextSelect from 'Components/TextSelect';
 import NoResultsMessage from 'Components/NoResultsMessage';
 
-const passingColor = 'var(--tertiary-400)';
-const failingColor = 'var(--alert-400)';
-const NAColor = 'var(--base-400)';
+const passingColor = COMPLIANCE_PASS_COLOR;
+const failingColor = COMPLIANCE_FAIL_COLOR;
+const NAColor = 'var(--base-400)'; // same as skippedColor in ComplianceByStandards
 
-const passingTextColor = 'var(--tertiary-500)';
-const failingTextColor = 'var(--alert-500)';
-const NATextColor = 'var(--base-500)';
+const linkColor = 'var(--primary-600)'; // TODO might be able to remove after PatternFly dark theme
+const textColor = 'var(--base-600)';
 
 const sunburstLegendData = [
-    { title: 'Passing', color: 'var(--tertiary-400)' },
-    { title: 'Failing', color: 'var(--alert-400)' },
-    { title: 'N/A', color: 'var(--base-400)' },
+    { title: 'Passing', color: passingColor },
+    { title: 'Failing', color: failingColor },
+    { title: 'N/A', color: NAColor },
 ];
 
 const QUERY = gql`
@@ -102,16 +102,6 @@ const getColor = (numPassing, numFailing) => {
     return failingColor;
 };
 
-const getTextColor = (numPassing, numFailing) => {
-    if (!numPassing && !numFailing) {
-        return NATextColor;
-    }
-    if (!numFailing) {
-        return passingTextColor;
-    }
-    return failingTextColor;
-};
-
 const getSunburstData = (categoryMapping, urlBuilder, searchParam, standardType) => {
     const categories = Object.keys(categoryMapping);
     const data = categories.map((categoryId) => {
@@ -128,7 +118,7 @@ const getSunburstData = (categoryMapping, urlBuilder, searchParam, standardType)
         return {
             name: `${category.name}. ${category.description}`,
             color: getColor(totalPassing, totalFailing),
-            textColor: getTextColor(totalPassing, totalFailing),
+            textColor,
             value: categoryValue,
             children: controls.map(({ control, numPassing, numFailing }) => {
                 const value = getPercentagePassing(numPassing, numFailing);
@@ -145,7 +135,7 @@ const getSunburstData = (categoryMapping, urlBuilder, searchParam, standardType)
                 return {
                     name: `${control.name} - ${control.description}`,
                     color: getColor(numPassing, numFailing),
-                    textColor: getTextColor(numPassing, numFailing),
+                    textColor,
                     value,
                     link,
                 };
@@ -216,17 +206,17 @@ const getSunburstRootData = (
         {
             text: `${controlsPassing} Controls Passing`,
             link: controlsPassingLink,
-            className: 'text-tertiary-700',
+            color: linkColor,
         },
         {
             text: `${controlsFailing} Controls Failing`,
             link: controlsFailingLink,
-            className: 'text-alert-700',
+            color: linkColor,
         },
         {
             text: `${controlsNA} Controls N/A`,
             link: controlsNALink,
-            className: 'text-base-700',
+            color: linkColor,
         },
     ];
     return sunburstRootData;

--- a/ui/apps/platform/src/constants/visuals/colors.ts
+++ b/ui/apps/platform/src/constants/visuals/colors.ts
@@ -38,6 +38,9 @@ export const IMPORTANT_HIGH_SEVERITY_COLOR = 'var(--pf-global--palette--orange-2
 export const CRITICAL_SEVERITY_COLOR = 'var(--pf-global--palette--red-100)';
 export const UNKNOWN_SEVERITY_COLOR = 'var(--pf-global--palette--black-400)';
 
+export const COMPLIANCE_PASS_COLOR = LOW_SEVERITY_COLOR; // so long as LOW_SEVERITY_COLOR is blue!
+export const COMPLIANCE_FAIL_COLOR = CRITICAL_SEVERITY_COLOR;
+
 export const policySeverityColorMap: Record<PolicySeverity, string> = {
     LOW_SEVERITY: LOW_SEVERITY_COLOR,
     MEDIUM_SEVERITY: MODERATE_MEDIUM_SEVERITY_COLOR,


### PR DESCRIPTION
## Description

### Problems

1. Classic colors have less contrast generally than PatternFly colors. Even for PatternFly severity colors, there is work-in-progress to improve contrast specifically for color vision.

2. Inconsistent colors for severity and corresponding concepts throughout UI.

### Analysis

Similar to `PolicyViolationsBySeverity` component in #5825

Especially because `ComplianceByStandard` is to the right of the former on Configuration Management dashboard.

Notice how the comparison in classic light mode emphasized how the subtle classic color looks like disabled?

### Solution

1. Use consistent classic color for links.

2. Use plain text for descriptions.

3. Associate compliance colors with corresponding severity colors.

### Residue

* Light edge around legend in dark theme is not new. The better the rest of the page looks, the worse it looks :(

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

### Integration testing

1. `yarn lint` in ui/apps/platform

    * compliance/complianceDashboard.test.js
    * configmanagement/dashboard.test.js

### Manual testing

1. Visit /main/compliance and click **Scan environment** to see sunbursts for standards

    * classic colors in dark theme
        ![compliance_dark_classic](https://user-images.githubusercontent.com/11862657/234900195-9bd3771d-6082-4bd5-9713-7c6bda67f240.png)

    * PatternFly colors in dark theme
        ![compliance_dark_PatternFly](https://user-images.githubusercontent.com/11862657/234900250-5026875c-9bad-498b-bc8a-3645fcc920da.png)

    * classic colors in light theme
        ![compliance_light_classic](https://user-images.githubusercontent.com/11862657/234900281-4be54df7-4d8b-4b89-9fd1-3c5164009f3e.png)

    * PatternFly colors in light theme
        ![compliance_light_PatternFly](https://user-images.githubusercontent.com/11862657/234900311-f10bed81-b766-40a4-abf6-88834cdd0fe2.png)

2. Visit /main/configmanagement and compare sunbursts for controls versus policies (at upper left)

    * classic colors in dark theme
        ![configmanagement_dark_classic](https://user-images.githubusercontent.com/11862657/234900358-3a31a795-1633-464a-84b3-77fdd4d92a2b.png)

    * PatternFly colors in dark theme
        ![configmanagement_dark_PatternFly](https://user-images.githubusercontent.com/11862657/234900426-62f2298f-ddd4-4d0e-a272-cda724d59686.png)

    * classic colors in light theme
        ![configmanagement_light_classic](https://user-images.githubusercontent.com/11862657/234900452-dd0d41ed-5ceb-436f-b844-ff6832c7bc03.png)

    * PatternFly colors in light theme
        ![configmanagement_light_PatternFly](https://user-images.githubusercontent.com/11862657/234900482-2493c0b9-d130-4afd-ab32-4d7964d7a195.png)