### PR TITLE
ROX-16650: Warn when editing lifecycle stage that existing criteria will reset

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,7 +36,8 @@ jobs:
 
       - uses: ./.github/actions/create-concatenated-ui-monorepo-lock
 
-      - uses: ./.github/actions/cache-ui-dependencies
+      # disable ui cache to troubleshoot build
+      # - uses: ./.github/actions/cache-ui-dependencies
 
       - uses: ./.github/actions/handle-tagged-build
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,8 +36,7 @@ jobs:
 
       - uses: ./.github/actions/create-concatenated-ui-monorepo-lock
 
-      # disable ui cache to troubleshoot build
-      # - uses: ./.github/actions/cache-ui-dependencies
+      - uses: ./.github/actions/cache-ui-dependencies
 
       - uses: ./.github/actions/handle-tagged-build
 

--- a/ui/apps/platform/src/Components/PatternFly/ConfirmationModal/ConfirmationModal.css
+++ b/ui/apps/platform/src/Components/PatternFly/ConfirmationModal/ConfirmationModal.css
@@ -1,3 +1,0 @@
-.pf-confirmation-modal-confirm-btn {
-    text-transform: capitalize;
-}

--- a/ui/apps/platform/src/Components/PatternFly/ConfirmationModal/ConfirmationModal.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/ConfirmationModal/ConfirmationModal.tsx
@@ -1,8 +1,6 @@
 import React, { ReactElement, ReactNode } from 'react';
 import { Modal, ModalVariant, Button, ButtonVariant } from '@patternfly/react-core';
 
-import './ConfirmationModal.css';
-
 type ConfirmationModalProps = {
     ariaLabel: string;
     title?: string;
@@ -33,6 +31,7 @@ function ConfirmationModal({
             isOpen={isOpen}
             variant={ModalVariant.small}
             title={title || ''}
+            titleIconVariant="warning"
             actions={[
                 <Button
                     key="confirm"

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationsListPage/IntegrationsListPage.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationsListPage/IntegrationsListPage.tsx
@@ -107,6 +107,7 @@ function IntegrationsListPage({
                     isOpen={deletingIntegrationIds.length !== 0}
                     onConfirm={onConfirmDeletingIntegrationIds}
                     onCancel={onCancelDeleteIntegrationIds}
+                    title="Delete API token"
                 >
                     <DeleteAPITokensConfirmationText
                         numIntegrations={deletingIntegrationIds.length}

--- a/ui/apps/platform/src/Containers/Policies/PolicyPage.tsx
+++ b/ui/apps/platform/src/Containers/Policies/PolicyPage.tsx
@@ -12,7 +12,7 @@ import { ClientPolicy } from 'types/policy.proto';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import { ExtendedPageAction } from 'utils/queryStringUtils';
 
-import { getClientWizardPolicy } from './policies.utils';
+import { getClientWizardPolicy, initialPolicy } from './policies.utils';
 import PolicyDetail from './Detail/PolicyDetail';
 import PolicyWizard from './Wizard/PolicyWizard';
 
@@ -31,41 +31,6 @@ function clonePolicy(policy: ClientPolicy) {
         name: `${policy.name} (COPY)`,
     };
 }
-
-const initialPolicy: ClientPolicy = {
-    id: '',
-    name: '',
-    description: '',
-    severity: 'LOW_SEVERITY',
-    disabled: false,
-    lifecycleStages: [],
-    notifiers: [],
-    lastUpdated: null,
-    eventSource: 'NOT_APPLICABLE',
-    isDefault: false,
-    rationale: '',
-    remediation: '',
-    categories: [],
-    exclusions: [],
-    scope: [],
-    enforcementActions: [],
-    excludedImageNames: [],
-    excludedDeploymentScopes: [],
-    SORTName: '', // For internal use only.
-    SORTLifecycleStage: '', // For internal use only.
-    SORTEnforcement: false, // For internal use only.
-    policyVersion: '',
-    serverPolicySections: [],
-    policySections: [
-        {
-            sectionName: 'Policy Section 1',
-            policyGroups: [],
-        },
-    ],
-    mitreAttackVectors: [],
-    criteriaLocked: false,
-    mitreVectorsLocked: false,
-};
 
 type WizardPolicyState = {
     wizardPolicy: ClientPolicy;

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step2/PolicyBehaviorForm.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step2/PolicyBehaviorForm.tsx
@@ -18,6 +18,7 @@ import {
     GridItem,
 } from '@patternfly/react-core';
 import { useFormikContext } from 'formik';
+import cloneDeep from 'lodash/cloneDeep';
 
 import ConfirmationModal from 'Components/PatternFly/ConfirmationModal';
 import { ClientPolicy, LifecycleStage } from 'types/policy.proto';
@@ -50,7 +51,7 @@ function PolicyBehaviorForm({ hasActiveViolations }: PolicyBehaviorFormProps) {
     const [showEnforcement, setShowEnforcement] = React.useState(hasEnforcementActions);
 
     function onChangeLifecycleStage(lifecycleStage: LifecycleStage, isChecked: boolean) {
-        if (values?.id) {
+        if (values.id) {
             // for existing policies, warn that changing lifecycles will clear all policy criteria
             setLifeCycleChange({ lifecycleStage, isChecked });
         } else {
@@ -70,7 +71,7 @@ function PolicyBehaviorForm({ hasActiveViolations }: PolicyBehaviorFormProps) {
             const newValues = getLifeCyclesUpdates(values, lifecycleStage, !!isChecked);
 
             // second, clear the policy criteria
-            const clearedCriteria = initialPolicy.policySections;
+            const clearedCriteria = cloneDeep(initialPolicy.policySections);
             newValues.policySections = clearedCriteria;
             setValues(newValues);
         }
@@ -119,16 +120,8 @@ function PolicyBehaviorForm({ hasActiveViolations }: PolicyBehaviorFormProps) {
         });
 
         // clear policy sections to prevent non-runtime criteria from being sent to BE
-        setFieldValue(
-            'policySections',
-            [
-                {
-                    sectionName: 'Policy Section 1',
-                    policyGroups: [],
-                },
-            ],
-            false
-        );
+        const clearedCriteria = cloneDeep(initialPolicy.policySections);
+        setFieldValue('policySections', clearedCriteria, false);
     }
 
     const responseMethodHelperText = showEnforcement

--- a/ui/apps/platform/src/Containers/Policies/policies.utils.ts
+++ b/ui/apps/platform/src/Containers/Policies/policies.utils.ts
@@ -28,6 +28,41 @@ function isValidAction(action: unknown): action is ExtendedPageAction {
     return action === 'clone' || action === 'create' || action === 'edit' || action === 'generate';
 }
 
+export const initialPolicy: ClientPolicy = {
+    id: '',
+    name: '',
+    description: '',
+    severity: 'LOW_SEVERITY',
+    disabled: false,
+    lifecycleStages: [],
+    notifiers: [],
+    lastUpdated: null,
+    eventSource: 'NOT_APPLICABLE',
+    isDefault: false,
+    rationale: '',
+    remediation: '',
+    categories: [],
+    exclusions: [],
+    scope: [],
+    enforcementActions: [],
+    excludedImageNames: [],
+    excludedDeploymentScopes: [],
+    SORTName: '', // For internal use only.
+    SORTLifecycleStage: '', // For internal use only.
+    SORTEnforcement: false, // For internal use only.
+    policyVersion: '',
+    serverPolicySections: [],
+    policySections: [
+        {
+            sectionName: 'Policy Section 1',
+            policyGroups: [],
+        },
+    ],
+    mitreAttackVectors: [],
+    criteriaLocked: false,
+    mitreVectorsLocked: false,
+};
+
 export type PoliciesSearch = {
     pageAction?: ExtendedPageAction;
     searchFilter?: SearchFilter;

--- a/ui/apps/platform/src/css/trumps.css
+++ b/ui/apps/platform/src/css/trumps.css
@@ -114,7 +114,8 @@ body {
 .pf-c-table__toggle-icon svg,
 .pf-c-expandable-section__toggle-icon svg,
 .chr-c-feedback-modal svg,
-.pf-c-breadcrumb__item-divider svg {
+.pf-c-breadcrumb__item-divider svg,
+.pf-c-modal-box__title-icon svg {
     display: inline;
 }
 


### PR DESCRIPTION
## Description

This is the 2nd stage in a group of three tasks to improve the UX around lifecycles and criteria in the Policy Wizard.

1. ROX-16659: Prevent policy lifecycle and criteria change when active alerts exist
2. **ROX-16650: Warn when editing lifecycle stage that existing criteria will reset, when no active alerts _(this PR)_**
3. ROX-16651	Prevent users from selecting combinations of criteria that don't adhere with the selected lifecycle stages (requires code design review before implementation)

As preliminary work, I moved the code that calculates the new values for Lifecycle based on user input into a pure function. For a new Policy, the input handle calls this newly-extracted function to get its values and uses those to update the form object.

Because of the way our Policy Wizard / PatternFly's Wizard component works, I implemented the confirmation modal with a "flag" value, which consists of the Lifecycle checkbox to change, and its new value, to indicate when the confirmation is shown. 

* If the user cancels the dialog, the dialog flag is cleared, and no change is made to the form data.
* If the user accepts the confirmation, a callback is made with the data in the "flag" (lifecycle and on/off boolean).

The change callback calls the same newly-extracted function to get its values, and then also sets the criteria array structure back to its empty state. (Combining the new values into one Formik update was necessary, because running two Formik updates in close proximity caused the updates to clobber each other.)

**Note: The wizard operates on a copy of the policy data. So, even if the user confirms changing the lifecycle mix, and thus deletes the existing criteria, if they cancel the wizard without saving at the end, the original lifecycles mix and criteria will remain untouched.**

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

Existing policy "Scrappy" with no active violations, and a criterion of **Image tag contains 'earliest'**
<img width="1658" alt="Screen Shot 2023-04-27 at 9 29 26 AM" src="https://user-images.githubusercontent.com/715729/234939888-64a5e65c-5740-478e-ac11-3679c7f96b1e.png">

The new dialog confirming that criteria will be cleared, if you make a change in the Lifecycle stages
<img width="1614" alt="Screen Shot 2023-04-27 at 9 29 57 AM" src="https://user-images.githubusercontent.com/715729/234939997-d3748983-1358-481b-86a9-dddfd2546805.png">

Existing policy "Scrappy" now has no criteria in the form.
<img width="1658" alt="Screen Shot 2023-04-27 at 10 56 52 AM" src="https://user-images.githubusercontent.com/715729/234941961-a86854ab-7b77-42db-aeb4-fb92bbc52776.png">


