### PR TITLE
Bump runc version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -292,7 +292,7 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/nwaples/rardecode v1.1.0 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
-	github.com/opencontainers/runc v1.1.4 // indirect
+	github.com/opencontainers/runc v1.1.5 // indirect
 	github.com/opencontainers/runtime-spec v1.1.0-rc.1 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/operator-framework/operator-lib v0.11.0 // indirect


### PR DESCRIPTION
## Description

This PR is not required as we have replace statement for runc but looks like some scanning tools do not recognize it.

https://github.com/stackrox/stackrox/blob/303752244696f8ba7c7c1180a40bbd55c8c54c62/go.mod#L419

Fixes:

- https://github.com/stackrox/stackrox/security/dependabot/158
- https://github.com/stackrox/stackrox/security/dependabot/159
- https://github.com/stackrox/stackrox/security/dependabot/160
 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

CI
