### PR TITLE
Refine declarative config errors

### DIFF
--- a/central/declarativeconfig/manager_impl.go
+++ b/central/declarativeconfig/manager_impl.go
@@ -310,7 +310,7 @@ func (m *managerImpl) doDeletion(transformedMessagesByHandler map[string]protoMe
 	}
 
 	if err := m.removeStaleHealthStatuses(allProtoIDsToSkip); err != nil {
-		log.Debugf("Failed to delete stale health status entries for declarative config: %v", err)
+		log.Errorf("Failed to delete stale health status entries for declarative config: %v", err)
 	}
 	m.lastDeletionFailed.Set(failureInDeletion)
 }
@@ -360,7 +360,7 @@ func (m *managerImpl) registerHealthForMessage(handler string, messages ...proto
 
 		if err := m.declarativeConfigErrorReporter.Register(messageID, messageName,
 			storage.IntegrationHealth_DECLARATIVE_CONFIG); err != nil {
-			log.Debugf("Error registering health status for declarative config %+v: %v", message, err)
+			log.Errorf("Error registering health status for declarative config %+v: %v", message, err)
 		}
 	}
 }
@@ -416,7 +416,7 @@ func (m *managerImpl) calculateHashAndIndicateChanges(transformedMessagesByHandl
 	// If we received an error for hash generation, log it and _always_ run the deletion. This way we ensure
 	// we don't mistakenly skip reconciliation runs where we shouldn't (e.g. consecutive errors).
 	if err != nil {
-		log.Debugf("Failed to create hash for transformed messages by handler %+v, "+
+		log.Errorf("Failed to create hash for transformed messages by handler %+v, "+
 			"reconciliation will be executed: %v",
 			transformedMessagesByHandler, err)
 		return true

--- a/central/declarativeconfig/manager_impl.go
+++ b/central/declarativeconfig/manager_impl.go
@@ -164,7 +164,7 @@ func (m *managerImpl) UpdateDeclarativeConfigContents(handlerID string, contents
 	configurations, err := declarativeconfig.ConfigurationFromRawBytes(contents...)
 	if err != nil {
 		m.updateHandlerHealth(handlerID, err)
-		log.Errorf("Error during unmarshalling of declarative configuration files: %+v", err)
+		log.Debugf("Error during unmarshalling of declarative configuration files: %+v", err)
 		return
 	}
 
@@ -173,7 +173,7 @@ func (m *managerImpl) UpdateDeclarativeConfigContents(handlerID string, contents
 	for _, configuration := range configurations {
 		transformedConfig, err := m.universalTransformer.Transform(configuration)
 		if err != nil {
-			log.Errorf("Error during transforming declarative configuration %+v: %+v", configuration, err)
+			log.Debugf("Error during transforming declarative configuration %+v: %+v", configuration, err)
 			transformationErrors = multierror.Append(transformationErrors, err)
 			continue
 		}
@@ -310,7 +310,7 @@ func (m *managerImpl) doDeletion(transformedMessagesByHandler map[string]protoMe
 	}
 
 	if err := m.removeStaleHealthStatuses(allProtoIDsToSkip); err != nil {
-		log.Errorf("Failed to delete stale health status entries for declarative config: %v", err)
+		log.Debugf("Failed to delete stale health status entries for declarative config: %v", err)
 	}
 	m.lastDeletionFailed.Set(failureInDeletion)
 }
@@ -360,7 +360,7 @@ func (m *managerImpl) registerHealthForMessage(handler string, messages ...proto
 
 		if err := m.declarativeConfigErrorReporter.Register(messageID, messageName,
 			storage.IntegrationHealth_DECLARATIVE_CONFIG); err != nil {
-			log.Errorf("Error registering health status for declarative config %+v: %v", message, err)
+			log.Debugf("Error registering health status for declarative config %+v: %v", message, err)
 		}
 	}
 }
@@ -416,7 +416,7 @@ func (m *managerImpl) calculateHashAndIndicateChanges(transformedMessagesByHandl
 	// If we received an error for hash generation, log it and _always_ run the deletion. This way we ensure
 	// we don't mistakenly skip reconciliation runs where we shouldn't (e.g. consecutive errors).
 	if err != nil {
-		log.Errorf("Failed to create hash for transformed messages by handler %+v, "+
+		log.Debugf("Failed to create hash for transformed messages by handler %+v, "+
 			"reconciliation will be executed: %v",
 			transformedMessagesByHandler, err)
 		return true

--- a/central/declarativeconfig/manager_impl_test.go
+++ b/central/declarativeconfig/manager_impl_test.go
@@ -511,7 +511,7 @@ func TestUpdateDeclarativeConfigContents_Errors(t *testing.T) {
 		Name:         "Config Map my-cool-config-map",
 		Type:         storage.IntegrationHealth_DECLARATIVE_CONFIG,
 		Status:       storage.IntegrationHealth_UNHEALTHY,
-		ErrorMessage: "unable to unmarshal the configuration: 4 errors occurred:\n\t* yaml: unmarshal errors:\n  line 1: field cool not found in type declarativeconfig.AuthProvider\n  line 2: field value not found in type declarativeconfig.AuthProvider\n\t* yaml: unmarshal errors:\n  line 1: field cool not found in type declarativeconfig.AccessScope\n  line 2: field value not found in type declarativeconfig.AccessScope\n\t* yaml: unmarshal errors:\n  line 1: field cool not found in type declarativeconfig.PermissionSet\n  line 2: field value not found in type declarativeconfig.PermissionSet\n\t* yaml: unmarshal errors:\n  line 1: field cool not found in type declarativeconfig.Role\n  line 2: field value not found in type declarativeconfig.Role\n\n",
+		ErrorMessage: "could not unmarshal configuration into any of the supported types [auth-provider,access-scope,permission-set,role]",
 	}))
 
 	m.UpdateDeclarativeConfigContents("/some/config/dir/to/my-cool-config-map", [][]byte{

--- a/pkg/declarativeconfig/configuration.go
+++ b/pkg/declarativeconfig/configuration.go
@@ -3,6 +3,7 @@ package declarativeconfig
 import (
 	"bytes"
 	"io"
+	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/pkg/errox"
@@ -20,7 +21,14 @@ const (
 	RoleConfiguration          ConfigurationType = "role"
 )
 
-const supportedTypes = AuthProviderConfiguration + "," + AccessScopeConfiguration + "," + PermissionSetConfiguration + "," + RoleConfiguration
+func supportedConfigurationTypes() string {
+	return strings.Join([]string{
+		AuthProviderConfiguration,
+		AccessScopeConfiguration,
+		PermissionSetConfiguration,
+		RoleConfiguration,
+	}, ",")
+}
 
 // Configuration specifies a declarative configuration.
 type Configuration interface {
@@ -73,7 +81,8 @@ func fromUnstructured(unstructured interface{}) (Configuration, error) {
 			return nil, err
 		}
 	}
-	return nil, errox.InvalidArgs.Newf("could not unmarshal configuration into any of the supported types [%s]", supportedTypes)
+	return nil, errox.InvalidArgs.Newf("could not unmarshal configuration into any of the supported types [%s]",
+		supportedConfigurationTypes())
 }
 
 func decodeYAMLToConfiguration(rawYAML []byte, configuration Configuration) error {

--- a/pkg/declarativeconfig/configuration.go
+++ b/pkg/declarativeconfig/configuration.go
@@ -3,7 +3,6 @@ package declarativeconfig
 import (
 	"bytes"
 	"io"
-	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/pkg/errox"
@@ -20,6 +19,8 @@ const (
 	PermissionSetConfiguration ConfigurationType = "permission-set"
 	RoleConfiguration          ConfigurationType = "role"
 )
+
+const supportedTypes = AuthProviderConfiguration + "," + AccessScopeConfiguration + "," + PermissionSetConfiguration + "," + RoleConfiguration
 
 // Configuration specifies a declarative configuration.
 type Configuration interface {
@@ -72,15 +73,7 @@ func fromUnstructured(unstructured interface{}) (Configuration, error) {
 			return nil, err
 		}
 	}
-	return nil, errox.InvalidArgs.Newf("could not unmarshal configuration into any of the supported types [%s]", configNames(configs))
-}
-
-func configNames(configs []Configuration) string {
-	names := make([]string, 0, len(configs))
-	for _, c := range configs {
-		names = append(names, c.Type())
-	}
-	return strings.Join(names, ",")
+	return nil, errox.InvalidArgs.Newf("could not unmarshal configuration into any of the supported types [%s]", supportedTypes)
 }
 
 func decodeYAMLToConfiguration(rawYAML []byte, configuration Configuration) error {

--- a/pkg/declarativeconfig/configuration_test.go
+++ b/pkg/declarativeconfig/configuration_test.go
@@ -13,6 +13,25 @@ func TestConfigurationFromRawBytes(t *testing.T) {
 		expectedConfigurations []Configuration
 		fail                   bool
 	}{
+		"invalid access scope shouldn't be unmarshalled successfully": {
+			rawConfigurations: [][]byte{
+				[]byte(`
+name: test-name
+description: test-description
+rules:
+  included:
+    - cluster: clusterA
+      namespaces:
+      - namespaceA1
+  clusterLabelSelectors:
+    - requirements:
+      - key: a
+        operator: BOGUS
+        values: [a, b, c]
+`),
+			},
+			fail: true,
+		},
 		"single raw role configuration should be unmarshalled successfully": {
 			rawConfigurations: [][]byte{
 				[]byte(`


### PR DESCRIPTION
## Description

This PR refines the current errors emitted by the configuration unmarshal of declarative config.

Previously, this was a multierror with little value:

```
unable to unmarshal the configuration: 4 errors occurred:
 * yaml: unmarshal errors:
line 1: field cool not found in type declarativeconfig.AuthProvider
line 2: field value not found in type declarativeconfig.AuthProvider
* yaml: unmarshal errors:
line 1: field cool not found in type 
declarativeconfig.AccessScope
line 2: field value not found in type declarativeconfig.AccessScope
* yaml: unmarshal errors:
line 1: field cool not found in type declarativeconfig.PermissionSet
line 2: field value not found in type declarativeconfig.PermissionSet
* yaml: unmarshal errors:
line 1: field cool not found in type declarativeconfig.Role
line 2: field value not found in type declarativeconfig.Role
```

Instead, this error has been now refactor to:
- short-circuit in case `errox.InvalidArgs` is emitted. This error will be emitted in case an invalid value is given.
- simplify the error if neither of the supported configuration types could be unmarshalled.

Additionally, as a small caveat, moved the error logs to `Debugf` instead of `Errorf` for the declarative config manager, as errors may be persistent across multiple reconciliation runs, and hence would create a log statement every 30 seconds (which would be 2880 log lines emitted per day, with little value).

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

- see CI, adjusted tests.
