### PR TITLE
ROX-14398: Group Role permission with Access one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 - A new command `roxctl central login` has been added that allows to use a user's token within roxctl instead of an API token or admin password.
 
 ### Removed Features
-- ROX-12316: As announced in 3.74, the permission `Access` replaces the deprecated permission `Role`.
+- ROX-14398: As announced in 3.74, the permission `Access` replaces the deprecated permission `Role`.
 
 ### Deprecated Fatures
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 - A new command `roxctl central login` has been added that allows to use a user's token within roxctl instead of an API token or admin password.
 
 ### Removed Features
+- ROX-12316: As announced in 3.74, the permission `Access` replaces the deprecated permission `Role`.
 
 ### Deprecated Fatures
 

--- a/central/debug/service/service.go
+++ b/central/debug/service/service.go
@@ -429,8 +429,7 @@ func (s *serviceImpl) getRoles(_ context.Context) (interface{}, error) {
 	accessRolesCtx := sac.WithGlobalAccessScopeChecker(context.Background(),
 		sac.AllowFixedScopes(
 			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
-			// TODO: ROX-14398 Replace Role with Access
-			sac.ResourceScopeKeys(resources.Role)))
+			sac.ResourceScopeKeys(resources.Access)))
 
 	roles, errGetRoles := s.roleDataStore.GetAllRoles(accessRolesCtx)
 	if errGetRoles != nil {

--- a/central/declarativeconfig/manager_impl.go
+++ b/central/declarativeconfig/manager_impl.go
@@ -90,8 +90,7 @@ func New(reconciliationTickerDuration, watchIntervalDuration time.Duration, upda
 	writeDeclarativeRoleCtx = sac.WithGlobalAccessScopeChecker(writeDeclarativeRoleCtx,
 		sac.AllowFixedScopes(
 			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
-			// TODO: ROX-14398 Replace Role with Access
-			sac.ResourceScopeKeys(resources.Role, resources.Access)))
+			sac.ResourceScopeKeys(resources.Access)))
 	return &managerImpl{
 		universalTransformer:           transform.New(),
 		transformedMessagesByHandler:   map[string]protoMessagesByType{},

--- a/central/graphql/resolvers/access_scopes.go
+++ b/central/graphql/resolvers/access_scopes.go
@@ -21,7 +21,7 @@ func init() {
 // SimpleAccessScopes returns GraphQL resolvers for all simple access scopes.
 func (resolver *Resolver) SimpleAccessScopes(ctx context.Context) ([]*simpleAccessScopeResolver, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Root, "SimpleAccessScopes")
-	err := readRoles(ctx)
+	err := readAccess(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -33,7 +33,7 @@ func (resolver *Resolver) SimpleAccessScopes(ctx context.Context) ([]*simpleAcce
 // if it exists.
 func (resolver *Resolver) SimpleAccessScope(ctx context.Context, args struct{ *graphql.ID }) (*simpleAccessScopeResolver, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Root, "SimpleAccessScope")
-	err := readRoles(ctx)
+	err := readAccess(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/central/graphql/resolvers/permission_sets.go
+++ b/central/graphql/resolvers/permission_sets.go
@@ -24,7 +24,7 @@ func init() {
 // PermissionSets returns GraphQL resolvers for all permission sets
 func (resolver *Resolver) PermissionSets(ctx context.Context) ([]*permissionSetResolver, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Root, "PermissionSets")
-	err := readRoles(ctx)
+	err := readAccess(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -38,7 +38,7 @@ func (resolver *Resolver) PermissionSets(ctx context.Context) ([]*permissionSetR
 // PermissionSet returns a GraphQL resolver for the matching permission set, if it exists
 func (resolver *Resolver) PermissionSet(ctx context.Context, args struct{ *graphql.ID }) (*permissionSetResolver, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Root, "PermissionSet")
-	err := readRoles(ctx)
+	err := readAccess(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/central/graphql/resolvers/resolver.go
+++ b/central/graphql/resolvers/resolver.go
@@ -207,9 +207,7 @@ var (
 	readNetPolicies          = readAuth(resources.NetworkPolicy)
 	readNodes                = readAuth(resources.Node)
 	// TODO: ROX-13888 Replace Policy with WorkflowAdministration.
-	readPolicies = readAuth(resources.Policy)
-	// TODO: ROX-14398 Replace Role with Access
-	readRoles                            = readAuth(resources.Role)
+	readPolicies                         = readAuth(resources.Policy)
 	readK8sRoles                         = readAuth(resources.K8sRole)
 	readK8sRoleBindings                  = readAuth(resources.K8sRoleBinding)
 	readK8sSubjects                      = readAuth(resources.K8sSubject)

--- a/central/graphql/resolvers/roles.go
+++ b/central/graphql/resolvers/roles.go
@@ -26,7 +26,7 @@ func init() {
 // Roles returns GraphQL resolvers for all roles
 func (resolver *Resolver) Roles(ctx context.Context) ([]*roleResolver, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Root, "Roles")
-	err := readRoles(ctx)
+	err := readAccess(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -40,7 +40,7 @@ func (resolver *Resolver) Roles(ctx context.Context) ([]*roleResolver, error) {
 // Role returns a GraphQL resolver for the matching role, if it exists
 func (resolver *Resolver) Role(ctx context.Context, args struct{ *graphql.ID }) (*roleResolver, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Root, "Role")
-	err := readRoles(ctx)
+	err := readAccess(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/central/group/datastore/datastore_impl.go
+++ b/central/group/datastore/datastore_impl.go
@@ -25,7 +25,7 @@ var (
 	datastoresAccessCtx = sac.WithGlobalAccessScopeChecker(context.Background(),
 		sac.AllowFixedScopes(
 			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
-			sac.ResourceScopeKeys(resources.Role, resources.Access)))
+			sac.ResourceScopeKeys(resources.Access)))
 )
 
 type dataStoreImpl struct {

--- a/central/reportconfigurations/service/common/authorizer.go
+++ b/central/reportconfigurations/service/common/authorizer.go
@@ -21,9 +21,8 @@ var (
 			"/v1.ReportConfigurationService/CountReportConfigurations",
 		},
 		// TODO: ROX-13888 Replace VulnerabilityReports with WorkflowAdministration.
-		// TODO: ROX-14398 Replace Role with Access
 		or.Or(
-			user.With(permissions.Modify(resources.VulnerabilityReports), permissions.View(resources.Integration), permissions.View(resources.Role)),
+			user.With(permissions.Modify(resources.VulnerabilityReports), permissions.View(resources.Integration), permissions.View(resources.Access)),
 			user.With(permissions.Modify(resources.WorkflowAdministration), permissions.View(resources.Integration))): {
 			"/v1.ReportConfigurationService/PostReportConfiguration",
 			"/v1.ReportConfigurationService/UpdateReportConfiguration",
@@ -35,7 +34,7 @@ var (
 			"/v1.ReportConfigurationService/DeleteReportConfiguration",
 		},
 		or.Or(
-			user.With(permissions.Modify(resources.VulnerabilityReports), permissions.View(resources.Integration), permissions.View(resources.Role)),
+			user.With(permissions.Modify(resources.VulnerabilityReports), permissions.View(resources.Integration), permissions.View(resources.Access)),
 			user.With(permissions.Modify(resources.WorkflowAdministration), permissions.View(resources.Integration))): {
 			"/v2.ReportConfigurationService/PostReportConfiguration",
 		},

--- a/central/reports/service/service_impl.go
+++ b/central/reports/service/service_impl.go
@@ -22,8 +22,7 @@ import (
 var (
 	authorizer = perrpc.FromMap(map[authz.Authorizer][]string{
 		// TODO: ROX-13888 Replace VulnerabilityReports with WorkflowAdministration.
-		// TODO: ROX-14398 Replace Role with Access
-		user.With(permissions.View(resources.VulnerabilityReports), permissions.View(resources.Integration), permissions.View(resources.Role), permissions.View(resources.Image)): {
+		user.With(permissions.View(resources.VulnerabilityReports), permissions.View(resources.Integration), permissions.View(resources.Access), permissions.View(resources.Image)): {
 			"/v1.ReportService/RunReport",
 		},
 	})

--- a/central/role/datastore/datastore_impl.go
+++ b/central/role/datastore/datastore_impl.go
@@ -19,14 +19,9 @@ import (
 )
 
 var (
-	// TODO: ROX-14398 Replace Role with Access
-	roleSAC = sac.ForResource(resources.Role)
+	roleSAC = sac.ForResource(resources.Access)
 
 	log = logging.LoggerForModule()
-
-	// TODO(ROX-14398): Once we use Access for this datastore instead of role, we can reuse the client's context instead.
-	groupReadCtx = sac.WithGlobalAccessScopeChecker(context.Background(), sac.AllowFixedScopes(
-		sac.AccessModeScopeKeys(storage.Access_READ_ACCESS), sac.ResourceScopeKeys(resources.Access)))
 )
 
 type dataStoreImpl struct {
@@ -821,7 +816,7 @@ func (ds *dataStoreImpl) verifyRoleForDeletion(ctx context.Context, name string)
 		return err
 	}
 
-	return ds.verifyNoGroupReferences(groupReadCtx, role)
+	return ds.verifyNoGroupReferences(ctx, role)
 }
 
 // Returns errox.ReferencedByAnotherObject if the given role is referenced by a group.

--- a/central/role/datastore/datastore_impl_test.go
+++ b/central/role/datastore/datastore_impl_test.go
@@ -93,13 +93,11 @@ func (s *roleDataStoreTestSuite) SetupTest() {
 	s.hasReadCtx = sac.WithGlobalAccessScopeChecker(context.Background(),
 		sac.AllowFixedScopes(
 			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
-			// TODO: ROX-14398 Replace Role with Access
-			sac.ResourceScopeKeys(resources.Role)))
+			sac.ResourceScopeKeys(resources.Access)))
 	s.hasWriteCtx = sac.WithGlobalAccessScopeChecker(context.Background(),
 		sac.AllowFixedScopes(
 			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
-			// TODO: ROX-14398 Replace Role with Access
-			sac.ResourceScopeKeys(resources.Role)))
+			sac.ResourceScopeKeys(resources.Access)))
 	s.hasWriteDeclarativeCtx = declarativeconfig.WithModifyDeclarativeResource(s.hasWriteCtx)
 
 	s.initDataStore()

--- a/central/role/datastore/singleton.go
+++ b/central/role/datastore/singleton.go
@@ -54,7 +54,7 @@ func Singleton() DataStore {
 		ctx := sac.WithGlobalAccessScopeChecker(context.Background(),
 			sac.AllowFixedScopes(
 				sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
-				sac.ResourceScopeKeys(resources.Role)))
+				sac.ResourceScopeKeys(resources.Access)))
 		roles, permissionSets, accessScopes := getDefaultObjects()
 		utils.Must(roleStorage.UpsertMany(ctx, roles))
 		utils.Must(permissionSetStorage.UpsertMany(ctx, permissionSets))
@@ -123,8 +123,8 @@ var defaultRoles = map[string]roleAttributes{
 			permissions.View(resources.Access),
 			permissions.View(resources.Cluster),
 			permissions.View(resources.Namespace),
-			permissions.View(resources.Role),
-			permissions.Modify(resources.Role),
+			permissions.View(resources.Access),
+			permissions.Modify(resources.Access),
 		},
 	},
 	accesscontrol.SensorCreator: {
@@ -163,7 +163,7 @@ var defaultRoles = map[string]roleAttributes{
 		resourceWithAccess: func() []permissions.ResourceWithAccess {
 			if !env.PostgresDatastoreEnabled.BooleanSetting() {
 				return []permissions.ResourceWithAccess{
-					permissions.View(resources.Role),                   // required for scopes
+					permissions.View(resources.Access),                 // required for scopes
 					permissions.View(resources.Integration),            // required for vuln report configurations
 					permissions.View(resources.VulnerabilityReports),   // required for vuln report configurations prior to collections
 					permissions.Modify(resources.VulnerabilityReports), // required for vuln report configurations prior to collections

--- a/central/role/datastore/telemetry.go
+++ b/central/role/datastore/telemetry.go
@@ -16,8 +16,7 @@ var Gather phonehome.GatherFunc = func(ctx context.Context) (map[string]any, err
 	ctx = sac.WithGlobalAccessScopeChecker(ctx,
 		sac.AllowFixedScopes(
 			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
-			// TODO: ROX-14398 Replace Role with Access
-			sac.ResourceScopeKeys(resources.Role)))
+			sac.ResourceScopeKeys(resources.Access)))
 
 	totals := make(map[string]any)
 	rs := Singleton()

--- a/central/role/resources/list.go
+++ b/central/role/resources/list.go
@@ -79,8 +79,6 @@ var (
 
 	// To-be-deprecated in 4.1 with ROX-13888 (deprecation notice in 3.74).
 	Policy = newDeprecatedResourceMetadata("Policy", permissions.GlobalScope, WorkflowAdministration)
-	// To-be-deprecated in 4.1 with ROX-14398 (deprecation notice in 3.74).
-	Role = newDeprecatedResourceMetadata("Role", permissions.GlobalScope, Access)
 	// To-be-deprecated in 4.1 with ROX-13888 (deprecation notice in 3.74).
 	VulnerabilityReports = newDeprecatedResourceMetadata("VulnerabilityReports", permissions.GlobalScope,
 		WorkflowAdministration)

--- a/central/role/service/service_impl.go
+++ b/central/role/service/service_impl.go
@@ -29,8 +29,7 @@ import (
 
 var (
 	authorizer = perrpc.FromMap(map[authz.Authorizer][]string{
-		// TODO: ROX-14398 Replace Role with Access
-		user.With(permissions.View(resources.Role)): {
+		user.With(permissions.View(resources.Access)): {
 			"/v1.RoleService/GetRoles",
 			"/v1.RoleService/GetRole",
 			"/v1.RoleService/ListPermissionSets",
@@ -38,12 +37,10 @@ var (
 			"/v1.RoleService/ListSimpleAccessScopes",
 			"/v1.RoleService/GetSimpleAccessScope",
 		},
-		// TODO: ROX-14398 Replace Role with Access
-		user.With(permissions.View(resources.Role), permissions.View(resources.Cluster), permissions.View(resources.Namespace)): {
+		user.With(permissions.View(resources.Access), permissions.View(resources.Cluster), permissions.View(resources.Namespace)): {
 			"/v1.RoleService/ComputeEffectiveAccessScope",
 		},
-		// TODO: ROX-14398 Replace Role with Access
-		user.With(permissions.Modify(resources.Role)): {
+		user.With(permissions.Modify(resources.Access)): {
 			"/v1.RoleService/CreateRole",
 			"/v1.RoleService/SetDefaultRole",
 			"/v1.RoleService/UpdateRole",

--- a/central/role/store/permissionset/postgres/store.go
+++ b/central/role/store/permissionset/postgres/store.go
@@ -42,7 +42,7 @@ const (
 var (
 	log            = logging.LoggerForModule()
 	schema         = pkgSchema.PermissionSetsSchema
-	targetResource = resources.Role
+	targetResource = resources.Access
 )
 
 // Store is the interface to interact with the storage for storage.PermissionSet

--- a/central/role/store/role/postgres/store.go
+++ b/central/role/store/role/postgres/store.go
@@ -42,7 +42,7 @@ const (
 var (
 	log            = logging.LoggerForModule()
 	schema         = pkgSchema.RolesSchema
-	targetResource = resources.Role
+	targetResource = resources.Access
 )
 
 // Store is the interface to interact with the storage for storage.Role

--- a/central/role/store/simpleaccessscope/postgres/store.go
+++ b/central/role/store/simpleaccessscope/postgres/store.go
@@ -42,7 +42,7 @@ const (
 var (
 	log            = logging.LoggerForModule()
 	schema         = pkgSchema.SimpleAccessScopesSchema
-	targetResource = resources.Role
+	targetResource = resources.Access
 )
 
 // Store is the interface to interact with the storage for storage.SimpleAccessScope

--- a/qa-tests-backend/src/test/groovy/ComplianceTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ComplianceTest.groovy
@@ -1331,7 +1331,6 @@ class ComplianceTest extends BaseSpecification {
                 "Detection"            : READ_WRITE_ACCESS,
                 "Integration"          : READ_WRITE_ACCESS,
                 "Policy"               : READ_WRITE_ACCESS,
-                "Role"                 : READ_WRITE_ACCESS,
                 "Cluster"              : READ_WRITE_ACCESS,
                 "Compliance"           : READ_WRITE_ACCESS,
                 "Node"                 : READ_WRITE_ACCESS,

--- a/tools/generate-helpers/pg-table-bindings/list.go
+++ b/tools/generate-helpers/pg-table-bindings/list.go
@@ -61,9 +61,8 @@ func init() {
 		&storage.NodeCVE{}:                                      resources.Node,
 		&storage.NotificationSchedule{}:                         resources.Notifications,
 		&storage.Notifier{}:                                     resources.Integration,
-		// TODO: ROX-14398 Replace Role with Access
-		&storage.PermissionSet{}: resources.Role,
-		&storage.Pod{}:           resources.Deployment,
+		&storage.PermissionSet{}:                                resources.Access,
+		&storage.Pod{}:                                          resources.Deployment,
 		// TODO: ROX-13888 Replace Policy with WorkflowAdministration.
 		&storage.Policy{}:                        resources.Policy,
 		&storage.PolicyCategory{}:                resources.Policy,
@@ -74,15 +73,13 @@ func init() {
 		&storage.ProcessListeningOnPortStorage{}: resources.DeploymentExtension,
 		&storage.ResourceCollection{}:            resources.WorkflowAdministration,
 		// TODO: ROX-13888 Replace VulnerabilityReports with WorkflowAdministration.
-		&storage.ReportConfiguration{}: resources.VulnerabilityReports,
-		&storage.Risk{}:                resources.DeploymentExtension,
-		// TODO: ROX-14398 Replace Role with Access
-		&storage.Role{}:                 resources.Role,
-		&storage.SensorUpgradeConfig{}:  resources.Administration,
-		&storage.ServiceIdentity{}:      resources.Administration,
-		&storage.SignatureIntegration{}: resources.Integration,
-		// TODO: ROX-14398 Replace Role with Access
-		&storage.SimpleAccessScope{}:      resources.Role,
+		&storage.ReportConfiguration{}:    resources.VulnerabilityReports,
+		&storage.Risk{}:                   resources.DeploymentExtension,
+		&storage.Role{}:                   resources.Access,
+		&storage.SensorUpgradeConfig{}:    resources.Administration,
+		&storage.ServiceIdentity{}:        resources.Administration,
+		&storage.SignatureIntegration{}:   resources.Integration,
+		&storage.SimpleAccessScope{}:      resources.Access,
 		&storage.StoredLicenseKey{}:       resources.Access,
 		&storage.TelemetryConfiguration{}: resources.Administration,
 		&storage.TokenMetadata{}:          resources.Integration,


### PR DESCRIPTION
## Description

This change is part of a series with the goal of making the configuration of user access control easier, and of limiting the risk of features not working because of missing permissions.

The goal is to bring the `Role` permission under the umbrella of the `Access` one.

## Checklist
- [ ] Investigated and inspected CI test results
~~- [ ] Unit test and regression tests added~~
- [ ] Evaluated and added CHANGELOG entry if required
~~- [ ] Determined and documented upgrade steps~~
~~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

CI should be sufficient
