### PR TITLE
ROX-14398: Group Role resource with Access - UI part

### DIFF
--- a/central/compliance/datastore/internal/store/postgres/compliance_config/store_test.go
+++ b/central/compliance/datastore/internal/store/postgres/compliance_config/store_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/stackrox/rox/generated/storage"
-	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/postgres/pgtest"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/testutils"
@@ -27,12 +26,6 @@ func TestComplianceConfigsStore(t *testing.T) {
 }
 
 func (s *ComplianceConfigsStoreSuite) SetupSuite() {
-	s.T().Setenv(env.PostgresDatastoreEnabled.EnvVar(), "true")
-
-	if !env.PostgresDatastoreEnabled.BooleanSetting() {
-		s.T().Skip("Skip postgres store tests")
-		s.T().SkipNow()
-	}
 
 	s.testDB = pgtest.ForT(s.T())
 	s.store = New(s.testDB.DB)

--- a/ui/apps/platform/cypress/fixtures/auth/declarativePermissionSet.json
+++ b/ui/apps/platform/cypress/fixtures/auth/declarativePermissionSet.json
@@ -30,7 +30,6 @@
         "Node": "READ_WRITE_ACCESS",
         "Policy": "READ_WRITE_ACCESS",
         "ProbeUpload": "READ_WRITE_ACCESS",
-        "Role": "READ_WRITE_ACCESS",
         "ScannerBundle": "READ_WRITE_ACCESS",
         "ScannerDefinitions": "READ_WRITE_ACCESS",
         "Secret": "READ_WRITE_ACCESS",

--- a/ui/apps/platform/cypress/fixtures/auth/mypermissionsMinimalAccess.json
+++ b/ui/apps/platform/cypress/fixtures/auth/mypermissionsMinimalAccess.json
@@ -19,7 +19,6 @@
         "NetworkPolicy": "READ_ACCESS",
         "Node": "NO_ACCESS",
         "Policy": "READ_ACCESS",
-        "Role": "NO_ACCESS",
         "Secret": "READ_ACCESS",
         "ServiceAccount": "NO_ACCESS",
         "VulnerabilityManagementApprovals": "NO_ACCESS",

--- a/ui/apps/platform/cypress/fixtures/auth/mypermissionsNoAccess.json
+++ b/ui/apps/platform/cypress/fixtures/auth/mypermissionsNoAccess.json
@@ -19,7 +19,6 @@
         "NetworkPolicy": "NO_ACCESS",
         "Node": "NO_ACCESS",
         "Policy": "NO_ACCESS",
-        "Role": "NO_ACCESS",
         "Secret": "NO_ACCESS",
         "ServiceAccount": "NO_ACCESS",
         "VulnerabilityManagementApprovals": "NO_ACCESS",

--- a/ui/apps/platform/src/Containers/AccessControl/AccessControl.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessControl.tsx
@@ -26,7 +26,7 @@ function AccessControl(): ReactElement {
                         <List>
                             <ListItem>
                                 <b>Access</b> replaces{' '}
-                                <b>AuthProvider, Group, Licenses, and User</b>
+                                <b>AuthProvider, Group, Licenses, Role, and User</b>
                             </ListItem>
                             <ListItem>
                                 <b>Administration</b> replaces{' '}
@@ -63,9 +63,6 @@ function AccessControl(): ReactElement {
                             versions:
                         </p>
                         <List>
-                            <ListItem>
-                                <b>Access</b> will replace <b>Role</b>
-                            </ListItem>
                             <ListItem>
                                 <b>WorkflowAdministration</b> will replace{' '}
                                 <b>Policy, VulnerabilityReports</b>

--- a/ui/apps/platform/src/Containers/AccessControl/AccessControlNoPermission.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessControlNoPermission.tsx
@@ -21,7 +21,7 @@ function AccessControlNoPermission({
             <PageSection variant={PageSectionVariants.light}>
                 <Alert
                     className="pf-u-mt-md"
-                    title={`You do not have permission to view ${subPage}. To access this page, you should have access to both Role and Access resources.`}
+                    title={`You do not have permission to view ${subPage}. To access this page, you should have access to the Access resource.`}
                     variant={AlertVariant.info}
                     isInline
                 />

--- a/ui/apps/platform/src/Containers/AccessControl/AccessControlNoPermission.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessControlNoPermission.tsx
@@ -21,7 +21,7 @@ function AccessControlNoPermission({
             <PageSection variant={PageSectionVariants.light}>
                 <Alert
                     className="pf-u-mt-md"
-                    title={`You do not have permission to view ${subPage}. To access this page, you should have access to the Access resource.`}
+                    title={`You do not have permission to view ${subPage}. To access this page, you should have READ permission to the Access resource.`}
                     variant={AlertVariant.info}
                     isInline
                 />

--- a/ui/apps/platform/src/Containers/AccessControl/AccessScopes/AccessScopeFormWrapper.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessScopes/AccessScopeFormWrapper.tsx
@@ -48,7 +48,7 @@ function AccessScopeFormWrapper({
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [alertSubmit, setAlertSubmit] = useState<ReactElement | null>(null);
     const { hasReadWriteAccess } = usePermissions();
-    const hasWriteAccessForPage = hasReadWriteAccess('Role') && hasReadWriteAccess('Access');
+    const hasWriteAccessForPage = hasReadWriteAccess('Access');
 
     // Disable Save button while editing label selectors.
     const [labelSelectorsEditingState, setLabelSelectorsEditingState] =

--- a/ui/apps/platform/src/Containers/AccessControl/AccessScopes/AccessScopes.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessScopes/AccessScopes.tsx
@@ -41,8 +41,8 @@ const entityType = 'ACCESS_SCOPE';
 
 function AccessScopes(): ReactElement {
     const { hasReadAccess, hasReadWriteAccess } = usePermissions();
-    const hasReadAccessToPage = hasReadAccess('Role') && hasReadAccess('Access');
-    const hasWriteAccessForPage = hasReadWriteAccess('Role') && hasReadWriteAccess('Access');
+    const hasReadAccessToPage = hasReadAccess('Access');
+    const hasWriteAccessForPage = hasReadWriteAccess('Access');
     const history = useHistory();
     const { search } = useLocation();
     const queryObject = getQueryObject(search);

--- a/ui/apps/platform/src/Containers/AccessControl/AccessScopes/AccessScopesList.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessScopes/AccessScopesList.tsx
@@ -35,7 +35,7 @@ function AccessScopesList({
     const [nameConfirmingDelete, setNameConfirmingDelete] = useState<string | null>(null);
     const [alertDelete, setAlertDelete] = useState<ReactElement | null>(null);
     const { hasReadWriteAccess } = usePermissions();
-    const hasWriteAccessForPage = hasReadWriteAccess('Role') && hasReadWriteAccess('Access');
+    const hasWriteAccessForPage = hasReadWriteAccess('Access');
 
     function onClickDelete(id: string) {
         setIdDeleting(id);

--- a/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviders.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviders.tsx
@@ -64,8 +64,8 @@ function getNewAuthProviderObj(type) {
 
 function AuthProviders(): ReactElement {
     const { hasReadAccess, hasReadWriteAccess } = usePermissions();
-    const hasReadAccessForPage = hasReadAccess('Role') && hasReadAccess('Access');
-    const hasWriteAccessForPage = hasReadWriteAccess('Role') && hasReadWriteAccess('Access');
+    const hasReadAccessForPage = hasReadAccess('Access');
+    const hasWriteAccessForPage = hasReadWriteAccess('Access');
     const history = useHistory();
     const { search } = useLocation();
     const queryObject = getQueryObject(search);

--- a/ui/apps/platform/src/Containers/AccessControl/PermissionSets/PermissionSetForm.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/PermissionSets/PermissionSetForm.tsx
@@ -48,7 +48,7 @@ function PermissionSetForm({
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [alertSubmit, setAlertSubmit] = useState<ReactElement | null>(null);
     const { hasReadWriteAccess } = usePermissions();
-    const hasWriteAccessForPage = hasReadWriteAccess('Role') && hasReadWriteAccess('Access');
+    const hasWriteAccessForPage = hasReadWriteAccess('Access');
 
     const { dirty, errors, handleChange, isValid, resetForm, setFieldValue, values } = useFormik({
         initialValues: permissionSet,

--- a/ui/apps/platform/src/Containers/AccessControl/PermissionSets/PermissionSets.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/PermissionSets/PermissionSets.tsx
@@ -42,8 +42,8 @@ const entityType = 'PERMISSION_SET';
 
 function PermissionSets(): ReactElement {
     const { hasReadAccess, hasReadWriteAccess } = usePermissions();
-    const hasReadAccessForPage = hasReadAccess('Role') && hasReadAccess('Access');
-    const hasWriteAccessForPage = hasReadWriteAccess('Role') && hasReadWriteAccess('Access');
+    const hasReadAccessForPage = hasReadAccess('Access');
+    const hasWriteAccessForPage = hasReadWriteAccess('Access');
     const history = useHistory();
     const { search } = useLocation();
     const queryObject = getQueryObject(search);

--- a/ui/apps/platform/src/Containers/AccessControl/PermissionSets/PermissionSetsList.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/PermissionSets/PermissionSetsList.tsx
@@ -35,7 +35,7 @@ function PermissionSetsList({
     const [nameConfirmingDelete, setNameConfirmingDelete] = useState<string | null>(null);
     const [alertDelete, setAlertDelete] = useState<ReactElement | null>(null);
     const { hasReadWriteAccess } = usePermissions();
-    const hasWriteAccessForPage = hasReadWriteAccess('Role') && hasReadWriteAccess('Access');
+    const hasWriteAccessForPage = hasReadWriteAccess('Access');
 
     function onClickDelete(id: string) {
         setIdDeleting(id);

--- a/ui/apps/platform/src/Containers/AccessControl/PermissionSets/ResourceDescription.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/PermissionSets/ResourceDescription.tsx
@@ -32,7 +32,6 @@ const resourceDescriptions: Record<ResourceName, string> = {
     NetworkPolicy:
         'Read: View network policies in secured clusters and simulate changes. Write: Apply network policy changes in secured clusters.',
     Node: 'Read: View Kubernetes nodes in secured clusters. Write: N/A',
-    Role: 'Read: View roles, permision sets and access scopes. Write: Add, modify or delete roles, permission sets and access scopes.',
     Policy: 'Read: View system policies. Write: Add, modify, or delete system policies.',
     Secret: 'Read: View metadata about secrets in secured clusters. Write: N/A',
     ServiceAccount: 'Read: List Kubernetes service accounts in secured clusters. Write: N/A',

--- a/ui/apps/platform/src/Containers/AccessControl/Roles/RoleForm.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/Roles/RoleForm.tsx
@@ -54,7 +54,7 @@ function RoleForm({
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [alertSubmit, setAlertSubmit] = useState<ReactElement | null>(null);
     const { hasReadWriteAccess } = usePermissions();
-    const hasWriteAccessForPage = hasReadWriteAccess('Role') && hasReadWriteAccess('Access');
+    const hasWriteAccessForPage = hasReadWriteAccess('Access');
 
     const { dirty, errors, handleChange, isValid, resetForm, values } = useFormik({
         initialValues: role,

--- a/ui/apps/platform/src/Containers/AccessControl/Roles/Roles.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/Roles/Roles.tsx
@@ -48,8 +48,8 @@ const entityType = 'ROLE';
 
 function Roles(): ReactElement {
     const { hasReadAccess, hasReadWriteAccess } = usePermissions();
-    const hasReadAccessForPage = hasReadAccess('Role') && hasReadAccess('Access');
-    const hasWriteAccessForPage = hasReadWriteAccess('Role') && hasReadWriteAccess('Access');
+    const hasReadAccessForPage = hasReadAccess('Access');
+    const hasWriteAccessForPage = hasReadWriteAccess('Access');
     const history = useHistory();
     const { search } = useLocation();
     const queryObject = getQueryObject(search);

--- a/ui/apps/platform/src/Containers/AccessControl/Roles/RolesList.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/Roles/RolesList.tsx
@@ -49,7 +49,7 @@ function RolesList({
     const [nameConfirmingDelete, setNameConfirmingDelete] = useState<string | null>(null);
     const [alertDelete, setAlertDelete] = useState<ReactElement | null>(null);
     const { hasReadWriteAccess } = usePermissions();
-    const hasWriteAccessForPage = hasReadWriteAccess('Role') && hasReadWriteAccess('Access');
+    const hasWriteAccessForPage = hasReadWriteAccess('Access');
 
     function onClickDelete(name: string) {
         setNameDeleting(name);

--- a/ui/apps/platform/src/Containers/VulnMgmt/Reports/VulnMgmtReportForm.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Reports/VulnMgmtReportForm.tsx
@@ -112,11 +112,11 @@ function VulnMgmtReportForm({
     const isCollectionsEnabled = isFeatureFlagEnabled('ROX_POSTGRES_DATASTORE');
 
     const { hasReadWriteAccess, hasReadAccess } = usePermissions();
-    const hasRoleWriteAccess = hasReadWriteAccess('Role');
+    const hasAccessWriteAccess = hasReadWriteAccess('Access');
     const hasClusterReadAccess = hasReadAccess('Cluster');
     const hasNamespaceReadAccess = hasReadAccess('Namespace');
     const hasNotifierWriteAccess = hasReadWriteAccess('Integration');
-    const canWriteScopes = hasRoleWriteAccess && hasClusterReadAccess && hasNamespaceReadAccess;
+    const canWriteScopes = hasAccessWriteAccess && hasClusterReadAccess && hasNamespaceReadAccess;
     const canWriteCollections = hasReadWriteAccess('WorkflowAdministration');
 
     const formik = useFormik<ReportConfiguration>({

--- a/ui/apps/platform/src/Containers/VulnMgmt/Reports/VulnMgmtReportTablePage.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Reports/VulnMgmtReportTablePage.tsx
@@ -45,12 +45,12 @@ function ReportTablePage({ query }: ReportTablePageProps): ReactElement {
     const { hasReadWriteAccess, hasReadAccess } = usePermissions();
     const hasVulnReportWriteAccess = hasReadWriteAccess('VulnerabilityReports');
     const hasImageReadAccess = hasReadAccess('Image');
-    const hasRoleScopeReadAccess = hasReadAccess('Role');
+    const hasAccessScopeReadAccess = hasReadAccess('Access');
     const hasNotifierIntegrationReadAccess = hasReadAccess('Integration');
     const canWriteReports =
         hasVulnReportWriteAccess &&
         hasImageReadAccess &&
-        hasRoleScopeReadAccess &&
+        hasAccessScopeReadAccess &&
         hasNotifierIntegrationReadAccess;
 
     const searchOptions = useSearchOptions(searchCategories.REPORT_CONFIGURATIONS) || [];

--- a/ui/apps/platform/src/constants/accessControl.ts
+++ b/ui/apps/platform/src/constants/accessControl.ts
@@ -74,7 +74,7 @@ export const defaultSelectedRole = {
 
 // TODO: ROX-13888 Remove WorkflowAdministration.
 export const resourceSubstitutions: Record<string, string[]> = {
-    Access: ['AuthProvider', 'Group', 'Licenses', 'User'],
+    Access: ['AuthProvider', 'Group', 'Licenses', 'Role', 'User'],
     Administration: [
         'AllComments',
         'Config',
@@ -103,7 +103,6 @@ export const resourceSubstitutions: Record<string, string[]> = {
 // TODO: ROX-13888 Remove Policy, VulnerabilityReports.
 export const resourceRemovalReleaseVersions = new Map<ResourceName, string>([
     ['Policy', '4.1'],
-    ['Role', '4.1'],
     ['VulnerabilityReports', '4.1'],
 ]);
 
@@ -112,7 +111,6 @@ export const replacedResourceMapping = new Map<ResourceName, string>([
     // TODO: ROX-13888 Remove Policy, VulnerabilityReports.
     ['Policy', 'WorkflowAdministration'],
     ['VulnerabilityReports', 'WorkflowAdministration'],
-    ['Role', 'Access'],
 ]);
 
 export const deprecatedResourceRowStyle = { backgroundColor: 'rgb(255,250,205)' };

--- a/ui/apps/platform/src/types/roleResources.ts
+++ b/ui/apps/platform/src/types/roleResources.ts
@@ -36,8 +36,6 @@ export type ResourceName =
     // To-be-deprecated resources.
     // TODO: ROX-13888 Remove Policy, VulnerabilityReports.
     | 'Policy'
-    // TODO: ROX-14398 Remove Role
-    | 'Role'
     // TODO: ROX-13888 Remove Policy, VulnerabilityReports.
     | 'VulnerabilityReports'
     ;


### PR DESCRIPTION
## Description

This change is part of a series with the goal of making the configuration of user access control easier, and of limiting the risk of features not working because of missing permissions.

The goal is to bring the `Role` permission under the umbrella of the `Access` one.
This part focuses on the UI changes.

## Checklist
- [ ] Investigated and inspected CI test results
~~- [ ] Unit test and regression tests added~~
- [ ] Evaluated and added CHANGELOG entry if required
~~- [ ] Determined and documented upgrade steps~~
~~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

CI should be sufficient