### PR TITLE
ROX-16692: Use intersect instead of cardinality

### DIFF
--- a/qa-tests-backend/src/test/groovy/SACTest.groovy
+++ b/qa-tests-backend/src/test/groovy/SACTest.groovy
@@ -634,10 +634,10 @@ class SACTest extends BaseSpecification {
 
         and:
         "The masked deployments should be external to stackrox namespace"
-        assert sacFlows.size() - sacFlowsFiltered.size() ==
-                allAccessFlows.size() - allAccessFlowsWithoutNeighbors.size()
-        assert sacFlowsNoQuery.size() - sacFlowsNoQueryFiltered.size() ==
-                allAccessFlows.size() - allAccessFlowsWithoutNeighbors.size()
+        assert sacFlows.intersect(sacFlowsFiltered) ==
+                allAccessFlows.intersect(allAccessFlowsWithoutNeighbors)
+        assert sacFlowsNoQuery.intersect(sacFlowsNoQueryFiltered) ==
+                allAccessFlows.intersect(allAccessFlowsWithoutNeighbors)
     }
 
     def "test role aggregation should not combine permissions sets"() {


### PR DESCRIPTION
## Description

Looks like we should use `intersect` instead of cardinality as it's important what is in the set.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

CI