### PR TITLE
Prefactor: Extract logger interface

### DIFF
--- a/pkg/auth/user/util.go
+++ b/pkg/auth/user/util.go
@@ -49,7 +49,7 @@ func protoToJSON(message proto.Message) string {
 }
 
 // LogSuccessfulUserLogin logs user attributes in the specified logger instance.
-func LogSuccessfulUserLogin(logger *logging.Logger, user *v1.AuthStatus) {
+func LogSuccessfulUserLogin(logger logging.Logger, user *v1.AuthStatus) {
 	logger.Warnw("User successfully logged in with user attributes", extractUserLogFields(user)...)
 }
 

--- a/pkg/grpc/errors/interceptor_test.go
+++ b/pkg/grpc/errors/interceptor_test.go
@@ -92,7 +92,7 @@ func TestLogInternalErrorInterceptor(t *testing.T) {
 			core, logs := observer.New(zap.ErrorLevel)
 			module := logging.CurrentModule()
 			log = &logging.LoggerImpl{
-				SugaredLogger: zap.New(core).Named(module.Name()).Sugar(),
+				InnerLogger: zap.New(core).Named(module.Name()).Sugar(),
 			}
 			resp, _ := LogInternalErrorInterceptor(context.Background(), nil, nil, tt.handler)
 			assert.Equal(t, "", resp)

--- a/pkg/grpc/errors/interceptor_test.go
+++ b/pkg/grpc/errors/interceptor_test.go
@@ -91,7 +91,7 @@ func TestLogInternalErrorInterceptor(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			core, logs := observer.New(zap.ErrorLevel)
 			module := logging.CurrentModule()
-			log = &logging.Logger{
+			log = &logging.LoggerImpl{
 				SugaredLogger: zap.New(core).Named(module.Name()).Sugar(),
 			}
 			resp, _ := LogInternalErrorInterceptor(context.Background(), nil, nil, tt.handler)

--- a/pkg/grpc/logging/logging.go
+++ b/pkg/grpc/logging/logging.go
@@ -10,8 +10,8 @@ import (
 
 // UnaryServerInterceptor returns a grpc.UnaryServerInterceptor that logs incoming requests
 // and associated tags to "logger".
-func UnaryServerInterceptor(logger *logging.LoggerImpl) grpc.UnaryServerInterceptor {
-	return grpc_zap.UnaryServerInterceptor(logger.SugaredLogger.Desugar(), grpc_zap.WithLevels(grpc_zap.DefaultCodeToLevel))
+func UnaryServerInterceptor(logger logging.Logger) grpc.UnaryServerInterceptor {
+	return grpc_zap.UnaryServerInterceptor(logger.SugaredLogger().Desugar(), grpc_zap.WithLevels(grpc_zap.DefaultCodeToLevel))
 }
 
 // InitGrpcLogger initializes gRPC logger using our logging framework.
@@ -26,7 +26,7 @@ func InitGrpcLogger() {
 }
 
 type zapGrpcLogger struct {
-	logger *logging.LoggerImpl
+	logger logging.Logger
 }
 
 func (l *zapGrpcLogger) Info(args ...interface{}) {

--- a/pkg/grpc/logging/logging.go
+++ b/pkg/grpc/logging/logging.go
@@ -10,7 +10,7 @@ import (
 
 // UnaryServerInterceptor returns a grpc.UnaryServerInterceptor that logs incoming requests
 // and associated tags to "logger".
-func UnaryServerInterceptor(logger *logging.Logger) grpc.UnaryServerInterceptor {
+func UnaryServerInterceptor(logger *logging.LoggerImpl) grpc.UnaryServerInterceptor {
 	return grpc_zap.UnaryServerInterceptor(logger.SugaredLogger.Desugar(), grpc_zap.WithLevels(grpc_zap.DefaultCodeToLevel))
 }
 
@@ -26,7 +26,7 @@ func InitGrpcLogger() {
 }
 
 type zapGrpcLogger struct {
-	logger *logging.Logger
+	logger *logging.LoggerImpl
 }
 
 func (l *zapGrpcLogger) Info(args ...interface{}) {

--- a/pkg/grpc/server.go
+++ b/pkg/grpc/server.go
@@ -53,7 +53,7 @@ func init() {
 }
 
 var (
-	log = logging.LoggerImplForModule()
+	log = logging.LoggerForModule()
 
 	maxResponseMsgSizeSetting = env.RegisterSetting("ROX_GRPC_MAX_RESPONSE_SIZE")
 	enableRequestTracing      = env.RegisterBooleanSetting("ROX_GRPC_ENABLE_REQUEST_TRACING", false)

--- a/pkg/grpc/server.go
+++ b/pkg/grpc/server.go
@@ -53,7 +53,7 @@ func init() {
 }
 
 var (
-	log = logging.LoggerForModule()
+	log = logging.LoggerImplForModule()
 
 	maxResponseMsgSizeSetting = env.RegisterSetting("ROX_GRPC_MAX_RESPONSE_SIZE")
 	enableRequestTracing      = env.RegisterBooleanSetting("ROX_GRPC_ENABLE_REQUEST_TRACING", false)

--- a/pkg/logging/internal/internal_test.go
+++ b/pkg/logging/internal/internal_test.go
@@ -12,7 +12,7 @@ func TestCurrentModule(t *testing.T) {
 }
 
 func TestLoggerForModule(t *testing.T) {
-	assert.Equal(t, "pkg/logging/internal", logging.LoggerImplForModule().Module().Name())
+	assert.Equal(t, "pkg/logging/internal", logging.CurrentModule().Logger().Module().Name())
 }
 
 func TestLoggerCreationSite(_ *testing.T) {

--- a/pkg/logging/internal/internal_test.go
+++ b/pkg/logging/internal/internal_test.go
@@ -12,7 +12,7 @@ func TestCurrentModule(t *testing.T) {
 }
 
 func TestLoggerForModule(t *testing.T) {
-	assert.Equal(t, "pkg/logging/internal", logging.LoggerForModule().Module().Name())
+	assert.Equal(t, "pkg/logging/internal", logging.LoggerImplForModule().Module().Name())
 }
 
 func TestLoggerCreationSite(_ *testing.T) {

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -5,14 +5,38 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
-// Logger wraps a zap.SugaredLogger.
-type Logger struct {
+// Logger is the interface exposed for logging purposes
+type Logger interface {
+	Log(level zapcore.Level, args ...interface{})
+	Logf(level zapcore.Level, format string, args ...interface{})
+	Panicf(template string, args ...interface{})
+	Fatalf(template string, args ...interface{})
+	Errorf(template string, args ...interface{})
+	Warnf(template string, args ...interface{})
+	Infof(template string, args ...interface{})
+	Debugf(template string, args ...interface{})
+	Panic(args ...interface{})
+	Fatal(args ...interface{})
+	Error(args ...interface{})
+	Warn(args ...interface{})
+	Info(args ...interface{})
+	Debug(args ...interface{})
+	Panicw(msg string, keysAndValues ...interface{})
+	Fatalw(msg string, keysAndValues ...interface{})
+	Errorw(msg string, keysAndValues ...interface{})
+	Warnw(msg string, keysAndValues ...interface{})
+	Infow(msg string, keysAndValues ...interface{})
+	Debugw(msg string, keysAndValues ...interface{})
+}
+
+// LoggerImpl wraps a zap.SugaredLogger.
+type LoggerImpl struct {
 	*zap.SugaredLogger
 	module *Module
 }
 
 // Log logs at level.
-func (l *Logger) Log(level zapcore.Level, args ...interface{}) {
+func (l *LoggerImpl) Log(level zapcore.Level, args ...interface{}) {
 	switch level {
 	case zapcore.PanicLevel:
 		l.Panic(args...)
@@ -30,7 +54,7 @@ func (l *Logger) Log(level zapcore.Level, args ...interface{}) {
 }
 
 // Logf logs at level.
-func (l *Logger) Logf(level zapcore.Level, template string, args ...interface{}) {
+func (l *LoggerImpl) Logf(level zapcore.Level, template string, args ...interface{}) {
 	switch level {
 	case zapcore.PanicLevel:
 		l.Panicf(template, args...)
@@ -48,12 +72,12 @@ func (l *Logger) Logf(level zapcore.Level, template string, args ...interface{})
 }
 
 // Module module returns the module that l belongs to.
-func (l *Logger) Module() *Module {
+func (l *LoggerImpl) Module() *Module {
 	return l.module
 }
 
 // finalize finalizes l and decrements the per-module reference count.
-func (l *Logger) finalize() {
+func (l *LoggerImpl) finalize() {
 	if l.module != nil {
 		modules.unrefModule(l.module.name)
 	}

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -5,34 +5,42 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
-// Logger is the interface exposed for logging purposes
+// Logger is the interface exposed for logging purposes.
 type Logger interface {
 	Log(level zapcore.Level, args ...interface{})
 	Logf(level zapcore.Level, format string, args ...interface{})
-	Panicf(template string, args ...interface{})
-	Fatalf(template string, args ...interface{})
-	Errorf(template string, args ...interface{})
-	Warnf(template string, args ...interface{})
-	Infof(template string, args ...interface{})
-	Debugf(template string, args ...interface{})
+
 	Panic(args ...interface{})
-	Fatal(args ...interface{})
-	Error(args ...interface{})
-	Warn(args ...interface{})
-	Info(args ...interface{})
-	Debug(args ...interface{})
+	Panicf(template string, args ...interface{})
 	Panicw(msg string, keysAndValues ...interface{})
+
+	Fatal(args ...interface{})
+	Fatalf(template string, args ...interface{})
 	Fatalw(msg string, keysAndValues ...interface{})
+
+	Error(args ...interface{})
+	Errorf(template string, args ...interface{})
 	Errorw(msg string, keysAndValues ...interface{})
+
+	Warn(args ...interface{})
+	Warnf(template string, args ...interface{})
 	Warnw(msg string, keysAndValues ...interface{})
+
+	Info(args ...interface{})
+	Infof(template string, args ...interface{})
 	Infow(msg string, keysAndValues ...interface{})
+
+	Debug(args ...interface{})
+	Debugf(template string, args ...interface{})
 	Debugw(msg string, keysAndValues ...interface{})
+
+	SugaredLogger() *zap.SugaredLogger
 }
 
 // LoggerImpl wraps a zap.SugaredLogger.
 type LoggerImpl struct {
-	*zap.SugaredLogger
-	module *Module
+	InnerLogger *zap.SugaredLogger
+	module      *Module
 }
 
 // Log logs at level.
@@ -81,4 +89,105 @@ func (l *LoggerImpl) finalize() {
 	if l.module != nil {
 		modules.unrefModule(l.module.name)
 	}
+}
+
+// SugaredLogger exposes the underlying sugared logger.
+func (l *LoggerImpl) SugaredLogger() *zap.SugaredLogger {
+	return l.InnerLogger
+}
+
+// Panic uses fmt.Sprintf to construct and log a message, then panics.
+func (l *LoggerImpl) Panic(args ...interface{}) {
+	l.InnerLogger.Panic(args...)
+}
+
+// Panicf uses fmt.Sprintf to log a templated message, then panics.
+func (l *LoggerImpl) Panicf(template string, args ...interface{}) {
+	l.InnerLogger.Panicf(template, args...)
+}
+
+// Panicw logs a message with some additional context, then panics.
+// The variadic key-value pairs are treated as in zap SugaredLogger With.
+func (l *LoggerImpl) Panicw(msg string, keysAndValues ...interface{}) {
+	l.InnerLogger.Panicw(msg, keysAndValues...)
+}
+
+// Fatal uses fmt.Sprintf to construct and log a message, then calls os.Exit.
+func (l *LoggerImpl) Fatal(args ...interface{}) {
+	l.InnerLogger.Fatal(args...)
+}
+
+// Fatalf uses fmt.Sprintf to log a templated message, then calls os.Exit.
+func (l *LoggerImpl) Fatalf(template string, args ...interface{}) {
+	l.InnerLogger.Fatalf(template, args...)
+}
+
+// Fatalw logs a message with some additional context, then calls os.Exit.
+// The variadic key-value pairs are treated as in zap SugaredLogger With.
+func (l *LoggerImpl) Fatalw(msg string, keysAndValues ...interface{}) {
+	l.InnerLogger.Fatalw(msg, keysAndValues...)
+}
+
+// Error uses fmt.Sprintf to construct and log a message.
+func (l *LoggerImpl) Error(args ...interface{}) {
+	l.InnerLogger.Error(args...)
+}
+
+// Errorf uses fmt.Sprintf to log a templated message.
+func (l *LoggerImpl) Errorf(template string, args ...interface{}) {
+	l.InnerLogger.Errorf(template, args...)
+}
+
+// Errorw logs a message with some additional context.
+// The variadic key-value pairs are treated as in zap SugaredLogger With.
+func (l *LoggerImpl) Errorw(msg string, keysAndValues ...interface{}) {
+	l.InnerLogger.Errorw(msg, keysAndValues...)
+}
+
+// Warn uses fmt.Sprintf to construct and log a message.
+func (l *LoggerImpl) Warn(args ...interface{}) {
+	l.InnerLogger.Warn(args...)
+}
+
+// Warnf uses fmt.Sprintf to log a templated message.
+func (l *LoggerImpl) Warnf(template string, args ...interface{}) {
+	l.InnerLogger.Warnf(template, args...)
+}
+
+// Warnw logs a message with some additional context.
+// The variadic key-value pairs are treated as in zap SugaredLogger With.
+func (l *LoggerImpl) Warnw(msg string, keysAndValues ...interface{}) {
+	l.InnerLogger.Warnw(msg, keysAndValues...)
+}
+
+// Info uses fmt.Sprintf to construct and log a message.
+func (l *LoggerImpl) Info(args ...interface{}) {
+	l.InnerLogger.Info(args...)
+}
+
+// Infof uses fmt.Sprintf to log a templated message.
+func (l *LoggerImpl) Infof(template string, args ...interface{}) {
+	l.InnerLogger.Infof(template, args...)
+}
+
+// Infow logs a message with some additional context.
+// The variadic key-value pairs are treated as in zap SugaredLogger With.
+func (l *LoggerImpl) Infow(msg string, keysAndValues ...interface{}) {
+	l.InnerLogger.Infow(msg, keysAndValues...)
+}
+
+// Debug uses fmt.Sprintf to construct and log a message.
+func (l *LoggerImpl) Debug(args ...interface{}) {
+	l.InnerLogger.Debug(args...)
+}
+
+// Debugf uses fmt.Sprintf to log a templated message.
+func (l *LoggerImpl) Debugf(template string, args ...interface{}) {
+	l.InnerLogger.Debugf(template, args...)
+}
+
+// Debugw logs a message with some additional context.
+// The variadic key-value pairs are treated as in zap SugaredLogger With.
+func (l *LoggerImpl) Debugw(msg string, keysAndValues ...interface{}) {
+	l.InnerLogger.Debugw(msg, keysAndValues...)
 }

--- a/pkg/logging/logger_test.go
+++ b/pkg/logging/logger_test.go
@@ -3,7 +3,7 @@ package logging
 import "testing"
 
 func TestLogging(_ *testing.T) {
-	for _, logger := range []*Logger{rootLogger, CurrentModule().Logger()} {
+	for _, logger := range []Logger{rootLogger, CurrentModule().Logger()} {
 		// Log at all non-destructive levels
 		for _, level := range sortedLevels[:len(sortedLevels)-2] {
 			for i := 0; i < 100; i++ {

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -157,10 +157,10 @@ var (
 	}()
 
 	// rootLogger is the convenience logger used when module specific loggers are not specified
-	rootLogger *LoggerImpl
+	rootLogger Logger
 
 	// thisModuleLogger is the logger for logging in this module.
-	thisModuleLogger *LoggerImpl
+	thisModuleLogger Logger
 )
 
 func init() {
@@ -268,12 +268,7 @@ func GetGlobalLogLevel() zapcore.Level {
 
 // LoggerForModule returns a logger for the current module.
 func LoggerForModule() Logger {
-	return currentModule(3).Logger()
-}
-
-// LoggerImplForModule returns the underlying structure of a logger for the current module.
-func LoggerImplForModule() *LoggerImpl {
-	return currentModule(3).Logger()
+	return CurrentModule().Logger()
 }
 
 // convenience methods log apply to root logger
@@ -384,8 +379,8 @@ func createLoggerWithConfig(lc *zap.Config, module *Module, skip int) *LoggerImp
 	}
 
 	result := &LoggerImpl{
-		SugaredLogger: logger.Named(module.name).Sugar(),
-		module:        module,
+		InnerLogger: logger.Named(module.name).Sugar(),
+		module:      module,
 	}
 
 	runtime.SetFinalizer(result, (*LoggerImpl).finalize)

--- a/pkg/logging/module.go
+++ b/pkg/logging/module.go
@@ -62,7 +62,7 @@ func newModule(name string, logLevel zap.AtomicLevel) *Module {
 }
 
 // Logger returns a new logger for m.
-func (m *Module) Logger() *Logger {
+func (m *Module) Logger() *LoggerImpl {
 	return CreateLogger(m, 0)
 }
 

--- a/pkg/logging/module_test.go
+++ b/pkg/logging/module_test.go
@@ -88,9 +88,9 @@ func TestLoggerCreatedFromModuleUpdatesLogLevel(t *testing.T) {
 		module := newModule(uuid.Must(uuid.NewV4()).String(), zap.NewAtomicLevelAt(zapcore.InfoLevel))
 		logger := module.Logger()
 		module.SetLogLevel(zapLevel)
-		assert.True(t, logger.Desugar().Core().Enabled(zapLevel))
+		assert.True(t, logger.SugaredLogger().Desugar().Core().Enabled(zapLevel))
 		// uses internal knowledge of how Enabled(level) method works
-		assert.False(t, logger.Desugar().Core().Enabled(zapLevel-1))
+		assert.False(t, logger.SugaredLogger().Desugar().Core().Enabled(zapLevel-1))
 	}
 }
 
@@ -103,11 +103,11 @@ func TestLoggerLevelUpdatesWithGlobalLevel(t *testing.T) {
 
 	// verify the global level remains unchanged
 	assert.Equal(t, level, GetGlobalLogLevel())
-	assert.True(t, logger.Desugar().Core().Enabled(zapcore.DebugLevel))
+	assert.True(t, logger.SugaredLogger().Desugar().Core().Enabled(zapcore.DebugLevel))
 
 	SetGlobalLogLevel(zapcore.WarnLevel)
 	// verify logger level changes with global level
 	assert.Equal(t, zapcore.WarnLevel, GetGlobalLogLevel())
-	assert.True(t, logger.Desugar().Core().Enabled(zapcore.WarnLevel))
-	assert.False(t, logger.Desugar().Core().Enabled(zapcore.InfoLevel))
+	assert.True(t, logger.SugaredLogger().Desugar().Core().Enabled(zapcore.WarnLevel))
+	assert.False(t, logger.SugaredLogger().Desugar().Core().Enabled(zapcore.InfoLevel))
 }

--- a/pkg/logging/rate_limited_logger.go
+++ b/pkg/logging/rate_limited_logger.go
@@ -9,17 +9,17 @@ import (
 
 // RateLimitedLogger wraps a zap.SugaredLogger that supports rate limiting.
 type RateLimitedLogger struct {
-	*Logger
+	Logger       Logger
 	frequency    float64
 	burst        int
 	rateLimiters *lru.Cache[string, *rate.Limiter]
 }
 
 // NewRateLimitLogger returns a rate limited logger
-func NewRateLimitLogger(l *Logger, size int, logLines int, interval time.Duration, burst int) *RateLimitedLogger {
+func NewRateLimitLogger(l Logger, size int, logLines int, interval time.Duration, burst int) *RateLimitedLogger {
 	cache, err := lru.New[string, *rate.Limiter](size)
 	if err != nil {
-		l.Errorf("unable to create rate limiter cache for logger in module %q: %v", l.module.name, err)
+		l.Errorf("unable to create rate limiter cache for logger in module %q: %v", CurrentModule().name, err)
 		return nil
 	}
 	return &RateLimitedLogger{
@@ -37,11 +37,41 @@ func (rl *RateLimitedLogger) ErrorL(limiter string, template string, args ...int
 	}
 }
 
+// Error logs the consecutive interfaces
+func (rl *RateLimitedLogger) Error(args ...interface{}) {
+	rl.Logger.Error(args)
+}
+
+// Errorf logs the input template filled with argument data
+func (rl *RateLimitedLogger) Errorf(template string, args ...interface{}) {
+	rl.Logger.Errorf(template, args)
+}
+
+// Errorw logs the input message and keyValues
+func (rl *RateLimitedLogger) Errorw(msg string, keysAndValues ...interface{}) {
+	rl.Logger.Errorw(msg, keysAndValues)
+}
+
 // WarnL logs a templated warn message if allowed by the rate limiter corresponding to the identifier
 func (rl *RateLimitedLogger) WarnL(limiter string, template string, args ...interface{}) {
 	if rl.allowLog(limiter) {
 		rl.Warnf(template, args...)
 	}
+}
+
+// Warn logs the consecutive interfaces
+func (rl *RateLimitedLogger) Warn(args ...interface{}) {
+	rl.Logger.Warn(args)
+}
+
+// Warnf logs the input template filled with argument data
+func (rl *RateLimitedLogger) Warnf(template string, args ...interface{}) {
+	rl.Logger.Warnf(template, args)
+}
+
+// Warnw logs the input message and keyValues
+func (rl *RateLimitedLogger) Warnw(msg string, keysAndValues ...interface{}) {
+	rl.Logger.Warnw(msg, keysAndValues)
 }
 
 // InfoL logs a templated info message if allowed by the rate limiter corresponding to the identifier
@@ -51,11 +81,41 @@ func (rl *RateLimitedLogger) InfoL(limiter string, template string, args ...inte
 	}
 }
 
+// Info logs the consecutive interfaces
+func (rl *RateLimitedLogger) Info(args ...interface{}) {
+	rl.Logger.Info(args)
+}
+
+// Infof logs the input template filled with argument data
+func (rl *RateLimitedLogger) Infof(template string, args ...interface{}) {
+	rl.Logger.Infof(template, args)
+}
+
+// Infow logs the input message and keyValues
+func (rl *RateLimitedLogger) Infow(msg string, keysAndValues ...interface{}) {
+	rl.Logger.Infow(msg, keysAndValues)
+}
+
 // DebugL logs a templated debug message if allowed by the rate limiter corresponding to the identifier
 func (rl *RateLimitedLogger) DebugL(limiter string, template string, args ...interface{}) {
 	if rl.allowLog(limiter) {
 		rl.Debugf(template, args...)
 	}
+}
+
+// Debug logs the consecutive interfaces
+func (rl *RateLimitedLogger) Debug(args ...interface{}) {
+	rl.Logger.Debug(args)
+}
+
+// Debugf logs the input template filled with argument data
+func (rl *RateLimitedLogger) Debugf(template string, args ...interface{}) {
+	rl.Logger.Debugf(template, args)
+}
+
+// Debugw logs the input message and keyValues
+func (rl *RateLimitedLogger) Debugw(msg string, keysAndValues ...interface{}) {
+	rl.Logger.Debugw(msg, keysAndValues)
 }
 
 func (rl *RateLimitedLogger) allowLog(limiter string) bool {

--- a/pkg/logging/rate_limited_logger.go
+++ b/pkg/logging/rate_limited_logger.go
@@ -39,17 +39,17 @@ func (rl *RateLimitedLogger) ErrorL(limiter string, template string, args ...int
 
 // Error logs the consecutive interfaces
 func (rl *RateLimitedLogger) Error(args ...interface{}) {
-	rl.Logger.Error(args)
+	rl.Logger.Error(args...)
 }
 
 // Errorf logs the input template filled with argument data
 func (rl *RateLimitedLogger) Errorf(template string, args ...interface{}) {
-	rl.Logger.Errorf(template, args)
+	rl.Logger.Errorf(template, args...)
 }
 
 // Errorw logs the input message and keyValues
 func (rl *RateLimitedLogger) Errorw(msg string, keysAndValues ...interface{}) {
-	rl.Logger.Errorw(msg, keysAndValues)
+	rl.Logger.Errorw(msg, keysAndValues...)
 }
 
 // WarnL logs a templated warn message if allowed by the rate limiter corresponding to the identifier
@@ -61,17 +61,17 @@ func (rl *RateLimitedLogger) WarnL(limiter string, template string, args ...inte
 
 // Warn logs the consecutive interfaces
 func (rl *RateLimitedLogger) Warn(args ...interface{}) {
-	rl.Logger.Warn(args)
+	rl.Logger.Warn(args...)
 }
 
 // Warnf logs the input template filled with argument data
 func (rl *RateLimitedLogger) Warnf(template string, args ...interface{}) {
-	rl.Logger.Warnf(template, args)
+	rl.Logger.Warnf(template, args...)
 }
 
 // Warnw logs the input message and keyValues
 func (rl *RateLimitedLogger) Warnw(msg string, keysAndValues ...interface{}) {
-	rl.Logger.Warnw(msg, keysAndValues)
+	rl.Logger.Warnw(msg, keysAndValues...)
 }
 
 // InfoL logs a templated info message if allowed by the rate limiter corresponding to the identifier
@@ -83,17 +83,17 @@ func (rl *RateLimitedLogger) InfoL(limiter string, template string, args ...inte
 
 // Info logs the consecutive interfaces
 func (rl *RateLimitedLogger) Info(args ...interface{}) {
-	rl.Logger.Info(args)
+	rl.Logger.Info(args...)
 }
 
 // Infof logs the input template filled with argument data
 func (rl *RateLimitedLogger) Infof(template string, args ...interface{}) {
-	rl.Logger.Infof(template, args)
+	rl.Logger.Infof(template, args...)
 }
 
 // Infow logs the input message and keyValues
 func (rl *RateLimitedLogger) Infow(msg string, keysAndValues ...interface{}) {
-	rl.Logger.Infow(msg, keysAndValues)
+	rl.Logger.Infow(msg, keysAndValues...)
 }
 
 // DebugL logs a templated debug message if allowed by the rate limiter corresponding to the identifier
@@ -105,17 +105,17 @@ func (rl *RateLimitedLogger) DebugL(limiter string, template string, args ...int
 
 // Debug logs the consecutive interfaces
 func (rl *RateLimitedLogger) Debug(args ...interface{}) {
-	rl.Logger.Debug(args)
+	rl.Logger.Debug(args...)
 }
 
 // Debugf logs the input template filled with argument data
 func (rl *RateLimitedLogger) Debugf(template string, args ...interface{}) {
-	rl.Logger.Debugf(template, args)
+	rl.Logger.Debugf(template, args...)
 }
 
 // Debugw logs the input message and keyValues
 func (rl *RateLimitedLogger) Debugw(msg string, keysAndValues ...interface{}) {
-	rl.Logger.Debugw(msg, keysAndValues)
+	rl.Logger.Debugw(msg, keysAndValues...)
 }
 
 func (rl *RateLimitedLogger) allowLog(limiter string) bool {

--- a/pkg/postgres/postgres.go
+++ b/pkg/postgres/postgres.go
@@ -57,12 +57,12 @@ func (qt *queryTracer) AddEvent(start time.Time, query string, args ...interface
 }
 
 // LogTracef is a wrapper around LogTrace that provides formatting
-func LogTracef(ctx context.Context, logger *logging.Logger, contextString string, args ...interface{}) {
+func LogTracef(ctx context.Context, logger logging.Logger, contextString string, args ...interface{}) {
 	LogTrace(ctx, logger, fmt.Sprintf(contextString, args...))
 }
 
 // LogTrace logs the queries seen in the current trace
-func LogTrace(ctx context.Context, logger *logging.Logger, contextString string) {
+func LogTrace(ctx context.Context, logger logging.Logger, contextString string) {
 	tracer := GetTracerFromContext(ctx)
 
 	logger.Infof("trace=%s: %s", tracer.id, contextString)

--- a/pkg/probeupload/server_handler.go
+++ b/pkg/probeupload/server_handler.go
@@ -34,7 +34,7 @@ type handler struct {
 }
 
 // LogCallback returns an error callback that simply logs.
-func LogCallback(logger *logging.Logger) func(error) {
+func LogCallback(logger logging.Logger) func(error) {
 	return func(err error) {
 		logger.Errorf("Error serving kernel probe: %v", err)
 	}

--- a/pkg/telemetry/phonehome/segment/segment.go
+++ b/pkg/telemetry/phonehome/segment/segment.go
@@ -74,7 +74,7 @@ func NewTelemeter(key, endpoint, clientID, clientType string, interval time.Dura
 }
 
 type logWrapper struct {
-	internal *logging.Logger
+	internal logging.Logger
 }
 
 func (l *logWrapper) Logf(format string, args ...any) {


### PR DESCRIPTION
## Description

The point here is to extract an interface from the Logger type in order to be able to instantiate mocks and further test the types wrapping around loggers.

## Checklist
- [ ] Investigated and inspected CI test results
~~- [ ] Unit test and regression tests added~~
~~- [ ] Evaluated and added CHANGELOG entry if required~~
~~- [ ] Determined and documented upgrade steps~~
~~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

CI should be sufficient.

Manual testing by building and deploying a local image with the changes and check that the container logs have the expected form.