### PR TITLE
Specify memory parameters in postgresql.conf

### DIFF
--- a/image/templates/helm/stackrox-central/config/centraldb/postgresql.conf.default
+++ b/image/templates/helm/stackrox-central/config/centraldb/postgresql.conf.default
@@ -9,6 +9,10 @@ ssl_cert_file = '/run/secrets/stackrox.io/certs/server.crt'
 ssl_key_file = '/run/secrets/stackrox.io/certs/server.key'
 
 shared_buffers = 2GB
+work_mem = 20MB
+maintenance_work_mem = 200MB
+effective_cache_size = 4GB
+
 dynamic_shared_memory_type = posix
 max_wal_size = 5GB
 min_wal_size = 80MB

--- a/image/templates/helm/stackrox-central/config/centraldb/postgresql.conf.default
+++ b/image/templates/helm/stackrox-central/config/centraldb/postgresql.conf.default
@@ -9,8 +9,8 @@ ssl_cert_file = '/run/secrets/stackrox.io/certs/server.crt'
 ssl_key_file = '/run/secrets/stackrox.io/certs/server.key'
 
 shared_buffers = 2GB
-work_mem = 20MB
-maintenance_work_mem = 200MB
+work_mem = 40MB
+maintenance_work_mem = 512MB
 effective_cache_size = 4GB
 
 dynamic_shared_memory_type = posix


### PR DESCRIPTION
## Description

Looks like we are leaving some performance on the table:

Previously effective_cache_size and maintenance_work_mem were set to 6GB and 1GB, but were dropped in the consolidation of the postgresql.conf

90 conns * 10MB overhead estimated + 90 conns(ish) + parallel workers can spawn more * 40MB (work_mem) + 3 (autovacuum_max_workers ) * 512MB (maintenance_work_mem) + shared_buffers(2GB) ~= 8GB. Default resource requests are 4 CPU and 8 GB. Limits are 8 CPU and 16 GB so even here we may be leaving some performance on the table, but keeping it as close to requests as possible to avoid eviction / ooms

4 GB effective_cache_size is just a hint to the planner. This one is pretty difficult to set in kubernetes because it's not clear how much cache is available, but 4GB is the default anyways

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Ran a scale test with these numbers

Vuln dashboard current on the scale test
<img width="928" alt="Screenshot 2023-05-01 at 9 50 26 AM" src="https://user-images.githubusercontent.com/2565181/235496548-bbeefa2d-6989-4c39-ae3f-77c602cceb8e.png">

With new 
<img width="927" alt="Screenshot 2023-05-01 at 9 50 33 AM" src="https://user-images.githubusercontent.com/2565181/235496542-e06165da-eceb-460a-beb0-10b175231981.png">

