### PR TITLE
Jv rox 16819 e2e test for udp port 0 issue

### DIFF
--- a/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
@@ -309,6 +309,26 @@ class NetworkFlowTest extends BaseSpecification {
         }
     }
 
+    @Tag("BAT")
+    @Tag("RUNTIME")
+    @Tag("NetworkFlowVisualization")
+    // TODO: additional handling may be needed for P/Z, skipping for 1st release
+    @IgnoreIf({ Env.REMOTE_CLUSTER_ARCH == "ppc64le" || Env.REMOTE_CLUSTER_ARCH == "s390x" })
+    def "Verify ports are greater than 0"() {
+        given:
+        "ACS is running"
+        def graph = NetworkGraphService.getNetworkGraph(null, null)
+        def nodes = graph.nodesList
+
+        nodes.each { node ->
+            node.outEdges.each { key, value ->
+                value.propertiesList.each { property ->
+                    assert property.port > 0
+                }
+            }
+        }
+    }
+
     @Unroll
     @Tag("BAT")
     @Tag("RUNTIME")


### PR DESCRIPTION
## Description

There have been cases where UDP port 0 is reported in the network graph. This occurs in the connection between collector and kube-dns when the kernel module probe is used. Kernel module probes are in the process of being removed, but we need to ensure that this problem does not occur with other types of probes in the future. More information can be found here https://issues.redhat.com/browse/ROX-16722

## Checklist
- [x] Investigated and inspected CI test results
- [x] e2e test fails locally when kernel module probe is used

## Testing Performed

Deploy using your favorite method. Set the collection method to KERNEL_MODULE.
cd qa-tests-backend
export ROX_POSTGRES_DATASTORE=true
Follow other steps needed to run e2e tests locally
./gradlew test --tests=NetworkFlowTest

The following is observed


NetworkFlowTest > Verify ports are greater than 0 FAILED
    Condition not satisfied:

    property.port > 0
    |        |    |
    |        0    false
    protocol: L4_PROTOCOL_UDP
    last_active_timestamp {
      seconds: 1682972635
      nanos: 977963108
    }
