### PR TITLE
fix GHA: remove too generic UI cache

### DIFF
--- a/.github/actions/cache-ui-dependencies/action.yaml
+++ b/.github/actions/cache-ui-dependencies/action.yaml
@@ -1,7 +1,7 @@
 name: Cache UI Dependencies
 description: Cache UI Dependencies
 inputs:
-  lockFile: 
+  lockFile:
     description: Where the monorepo lock is written
     required: true
     default: "ui/monorepo.lock"
@@ -24,4 +24,3 @@ runs:
         restore-keys: |
           npm-v2-${{ hashFiles(inputs.lockFile) }}-${{ github.job }}
           npm-v2-${{ hashFiles(inputs.lockFile) }}-
-          npm-v2-


### PR DESCRIPTION
## Description

* `npm-v2` is too generic, it could happen that a lock file with different contents is taken as input
* we also deleted a cache that we believe was corrupted as it didn't build properly
  * build failure: https://github.com/stackrox/stackrox/actions/runs/4859026771/jobs/8661140006
  * successful build: https://github.com/stackrox/stackrox/actions/runs/4859509864/jobs/8662358093?pr=5876

