### PR TITLE
Upgrade NP-Guard's cluster-topology-analyzer to 1.7.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,7 @@ require (
 	github.com/mailru/easyjson v0.7.7
 	github.com/mitchellh/go-wordwrap v1.0.1
 	github.com/mitchellh/hashstructure/v2 v2.0.2
-	github.com/np-guard/cluster-topology-analyzer v1.6.0
+	github.com/np-guard/cluster-topology-analyzer v1.7.0
 	github.com/nxadm/tail v1.4.8
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/opencontainers/go-digest v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -1201,8 +1201,8 @@ github.com/nelsam/hel/v2 v2.3.2/go.mod h1:1ZTGfU2PFTOd5mx22i5O0Lc2GY933lQ2wb/ggy
 github.com/nelsam/hel/v2 v2.3.3/go.mod h1:1ZTGfU2PFTOd5mx22i5O0Lc2GY933lQ2wb/ggy+rL3w=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nishanths/exhaustive v0.1.0/go.mod h1:S1j9110vxV1ECdCudXRkeMnFQ/DQk9ajLT0Uf2MYZQQ=
-github.com/np-guard/cluster-topology-analyzer v1.6.0 h1:vP4LCRd9V+xOLdvZT/WaRFtEOyaVVmRoLsvpXE1gMos=
-github.com/np-guard/cluster-topology-analyzer v1.6.0/go.mod h1:l0VjML9O/arBXd7kIFQDW5tgw/WmSQH7Fo5tk6X8ZSM=
+github.com/np-guard/cluster-topology-analyzer v1.7.0 h1:MtXZ7XF8EFQbM8uJO+RCS6KnArk88Rn4U0CnuFWu7BM=
+github.com/np-guard/cluster-topology-analyzer v1.7.0/go.mod h1:WDOpAZdQcD4t61J4ZsG9BoXhlG04sqKTZgkohng0p3A=
 github.com/nwaples/rardecode v1.1.0 h1:vSxaY8vQhOcVr4mm5e8XllHWTiM4JF507A0Katqw7MQ=
 github.com/nwaples/rardecode v1.1.0/go.mod h1:5DzqNKiOdpKKBH87u8VlvAnPZMXcGRhxWkRpHbbfGS0=
 github.com/oklog/oklog v0.3.2/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtbWGs=

--- a/tests/roxctl/bats-tests/local/roxctl-netpol-generate-development.bats
+++ b/tests/roxctl/bats-tests/local/roxctl-netpol-generate-development.bats
@@ -67,7 +67,7 @@ teardown() {
   run roxctl-development generate netpol "$out_dir/"
   assert_failure
   assert_output --partial 'YAML document is malformed'
-  assert_output --partial 'no relevant Kubernetes resources found'
+  assert_output --partial 'could not find any Kubernetes workload resources'
 }
 
 @test "roxctl-development generate netpol produces errors when some yamls are templated" {
@@ -83,7 +83,7 @@ teardown() {
   run roxctl-development generate netpol "$out_dir/" --remove --output-file=/dev/null
   assert_failure
   assert_output --partial 'YAML document is malformed'
-  refute_output --partial 'no relevant Kubernetes resources found'
+  refute_output --partial 'could not find any Kubernetes workload resources'
 }
 
 @test "roxctl-development generate netpol produces warnings (or errors for --strict) when yamls are not K8s resources" {
@@ -96,12 +96,12 @@ teardown() {
   run roxctl-development generate netpol "$out_dir/" --remove --output-file=/dev/null
   assert_success
   assert_output --partial 'Yaml document is not a K8s resource'
-  assert_output --partial 'no relevant Kubernetes resources found'
+  assert_output --partial 'could not find any Kubernetes workload resources'
 
   run roxctl-development generate netpol "$out_dir/" --remove --output-file=/dev/null --strict
   assert_failure
   assert_output --partial 'Yaml document is not a K8s resource'
-  assert_output --partial 'no relevant Kubernetes resources found'
+  assert_output --partial 'could not find any Kubernetes workload resources'
   assert_output --partial 'ERROR:'
   assert_output --partial 'there were warnings during execution'
 }

--- a/tests/roxctl/bats-tests/local/roxctl-netpol-generate-release.bats
+++ b/tests/roxctl/bats-tests/local/roxctl-netpol-generate-release.bats
@@ -68,7 +68,7 @@ teardown() {
   run roxctl-release generate netpol "$out_dir/"
   assert_failure
   assert_output --partial 'YAML document is malformed'
-  assert_output --partial 'no relevant Kubernetes resources found'
+  assert_output --partial 'could not find any Kubernetes workload resources'
 }
 
 @test "roxctl-release generate netpol produces errors when some yamls are templated" {
@@ -84,7 +84,7 @@ teardown() {
   run roxctl-release generate netpol "$out_dir/" --remove --output-file=/dev/null
   assert_failure
   assert_output --partial 'YAML document is malformed'
-  refute_output --partial 'no relevant Kubernetes resources found'
+  refute_output --partial 'could not find any Kubernetes workload resources'
 }
 
 @test "roxctl-release generate netpol produces warnings (or errors for --strict) when yamls are not K8s resources" {
@@ -97,12 +97,12 @@ teardown() {
   run roxctl-release generate netpol "$out_dir/" --remove --output-file=/dev/null
   assert_success
   assert_output --partial 'Yaml document is not a K8s resource'
-  assert_output --partial 'no relevant Kubernetes resources found'
+  assert_output --partial 'could not find any Kubernetes workload resources'
 
   run roxctl-release generate netpol "$out_dir/" --remove --output-file=/dev/null --strict
   assert_failure
   assert_output --partial 'Yaml document is not a K8s resource'
-  assert_output --partial 'no relevant Kubernetes resources found'
+  assert_output --partial 'could not find any Kubernetes workload resources'
   assert_output --partial 'ERROR:'
   assert_output --partial 'there were warnings during execution'
 }


### PR DESCRIPTION
## Description

Upgrading package version and modifying expected error messages in the tests accordingly.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

No user facing changes

## Testing Performed
CI is sufficient