### PR TITLE
fix GHA: UI cache too generic (3.73 release branch)

### DIFF
--- a/.github/actions/cache-ui-dependencies/action.yaml
+++ b/.github/actions/cache-ui-dependencies/action.yaml
@@ -1,7 +1,7 @@
 name: Cache UI Dependencies
 description: Cache UI Dependencies
 inputs:
-  lockFile: 
+  lockFile:
     description: Where the monorepo lock is written
     required: true
     default: "ui/monorepo.lock"
@@ -21,4 +21,5 @@ runs:
           ui/packages/tailwind-config/node_modules
         key: npm-v2-${{ hashFiles(inputs.lockFile) }}
         restore-keys: |
-          npm-v2-
+          npm-v2-${{ hashFiles(inputs.lockFile) }}-${{ github.job }}
+          npm-v2-${{ hashFiles(inputs.lockFile) }}-


### PR DESCRIPTION
## Description

Previous implementation could restore a cache with wrong dependencies, as the dependency files don't between current and cached don't have to match. Matching of the dependency file content is implemented as part of the cache key, e.g. for npm-v2-7ebb8fb1894252db88b2b5a6f2f2da6f13eea209fc2727c029caf4de57218c74-pre-build-ui the dependency file "fingerprint" / hash is 7ebb8fb1894252db88b2b5a6f2f2da6f13eea209fc2727c029caf4de57218c74.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

CI is sufficient