### PR TITLE
Minor UX details for Workload CVEs

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageHeader.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageHeader.tsx
@@ -8,7 +8,7 @@ export type DeploymentMetadata = {
     name: string;
     namespace: string;
     clusterName: string;
-    created: Date | null;
+    created: string | null;
     imageCount: number;
 };
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities.tsx
@@ -45,6 +45,7 @@ import DeploymentVulnerabilitiesTable, {
     deploymentWithVulnerabilitiesFragment,
     DeploymentWithVulnerabilities,
 } from '../Tables/DeploymentVulnerabilitiesTable';
+import { Resource } from '../components/FilterResourceDropdown';
 
 const summaryQuery = gql`
     ${resourceCountByCveSeverityAndStatusFragment}
@@ -70,6 +71,8 @@ const vulnerabilityQuery = gql`
 `;
 
 const defaultSortFields = ['CVE'];
+
+const deploymentResourceFilters = new Set<Resource>(['CVE', 'IMAGE']);
 
 export type DeploymentPageVulnerabilitiesProps = {
     deploymentId: string;
@@ -165,7 +168,9 @@ function DeploymentPageVulnerabilities({ deploymentId }: DeploymentPageVulnerabi
                         title={<TabTitleText>Observed CVEs</TabTitleText>}
                     >
                         <div className="pf-u-px-sm pf-u-background-color-100">
-                            <WorkloadTableToolbar />
+                            <WorkloadTableToolbar
+                                supportedResourceFilters={deploymentResourceFilters}
+                            />
                         </div>
                         <div className="pf-u-flex-grow-1 pf-u-background-color-100">
                             <div className="pf-u-px-lg pf-u-pb-lg">

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
@@ -70,7 +70,7 @@ export type ImagePageVulnerabilitiesProps = {
 function ImagePageVulnerabilities({ imageId }: ImagePageVulnerabilitiesProps) {
     const { searchFilter } = useURLSearch();
     const querySearchFilter = parseQuerySearchFilter(searchFilter);
-    const { page, perPage, setPage, setPerPage } = useURLPagination(50);
+    const { page, perPage, setPage, setPerPage } = useURLPagination(20);
     const { sortOption, getSortParams } = useURLSort({
         sortFields: defaultSortFields,
         defaultSortOption: {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
@@ -43,6 +43,7 @@ import { getHiddenSeverities, getHiddenStatuses, parseQuerySearchFilter } from '
 import { cveStatusTabValues } from '../types';
 import BySeveritySummaryCard from '../SummaryCards/BySeveritySummaryCard';
 import { imageMetadataContextFragment, ImageMetadataContext } from '../Tables/table.utils';
+import { Resource } from '../components/FilterResourceDropdown';
 
 const imageVulnerabilitiesQuery = gql`
     ${imageMetadataContextFragment}
@@ -62,6 +63,8 @@ const imageVulnerabilitiesQuery = gql`
 `;
 
 const defaultSortFields = ['CVE'];
+
+const imageResourceFilters = new Set<Resource>(['CVE']);
 
 export type ImagePageVulnerabilitiesProps = {
     imageId: string;
@@ -221,7 +224,7 @@ function ImagePageVulnerabilities({ imageId }: ImagePageVulnerabilitiesProps) {
                         title={<TabTitleText>Observed CVEs</TabTitleText>}
                     >
                         <div className="pf-u-px-sm pf-u-background-color-100">
-                            <WorkloadTableToolbar />
+                            <WorkloadTableToolbar supportedResourceFilters={imageResourceFilters} />
                         </div>
                         <div className="pf-u-flex-grow-1 pf-u-background-color-100">
                             {mainContent}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
@@ -147,7 +147,7 @@ function ImageCvePage() {
         ...querySearchFilter,
         CVE: cveId,
     });
-    const { page, perPage, setPage, setPerPage } = useURLPagination(25);
+    const { page, perPage, setPage, setPerPage } = useURLPagination(20);
 
     const [entityTab] = useURLStringUnion('entityTab', imageCveEntities);
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
@@ -51,6 +51,7 @@ import BySeveritySummaryCard, {
 } from '../SummaryCards/BySeveritySummaryCard';
 import TopCvssScoreBreakdown from '../SummaryCards/TopCvssScoreBreakdown';
 import { resourceCountByCveSeverityAndStatusFragment } from '../SummaryCards/CvesByStatusSummaryCard';
+import { Resource } from '../components/FilterResourceDropdown';
 
 const workloadCveOverviewImagePath = getOverviewCvesPath({
     cveStatusTab: 'Observed',
@@ -137,6 +138,8 @@ const defaultSeveritySummary = {
     affectedImageCount: 0,
     topCVSS: 0,
 };
+
+const imageCveResourceFilters = new Set<Resource>(['IMAGE', 'DEPLOYMENT', 'NAMESPACE', 'CLUSTER']);
 
 function ImageCvePage() {
     const urlParams = useParams();
@@ -307,7 +310,7 @@ function ImageCvePage() {
             <PageSection className="pf-u-display-flex pf-u-flex-direction-column pf-u-flex-grow-1">
                 <div className="pf-u-background-color-100">
                     <div className="pf-u-px-sm">
-                        <WorkloadTableToolbar />
+                        <WorkloadTableToolbar supportedResourceFilters={imageCveResourceFilters} />
                     </div>
                     <div className="pf-u-px-lg pf-u-pb-lg">
                         {summaryRequest.error && (

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePageHeader.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePageHeader.tsx
@@ -5,7 +5,7 @@ import { getDateTime } from 'utils/dateUtils';
 
 export type ImageCveMetadata = {
     cve: string;
-    firstDiscoveredInSystem: Date | null;
+    firstDiscoveredInSystem: string | null;
 };
 
 export const imageCveMetadataFragment = gql`

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/CVEsTableContainer.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/CVEsTableContainer.tsx
@@ -23,7 +23,7 @@ function CVEsTableContainer({ defaultFilters, countsData }: CVEsTableContainerPr
     const { searchFilter } = useURLSearch();
     const querySearchFilter = parseQuerySearchFilter(searchFilter);
     const isFiltered = getHasSearchApplied(querySearchFilter);
-    const pagination = useURLPagination(25);
+    const pagination = useURLPagination(20);
     const { page, perPage, setPage } = pagination;
     const { sortOption, getSortParams, setSortOption } = useURLSort({
         sortFields: defaultCVESortFields,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/DeploymentsTableContainer.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/DeploymentsTableContainer.tsx
@@ -23,7 +23,7 @@ function DeploymentsTableContainer({ defaultFilters, countsData }: DeploymentsTa
     const { searchFilter } = useURLSearch();
     const querySearchFilter = parseQuerySearchFilter(searchFilter);
     const isFiltered = getHasSearchApplied(querySearchFilter);
-    const pagination = useURLPagination(25);
+    const pagination = useURLPagination(20);
     const { page, perPage, setPage } = pagination;
     const { sortOption, getSortParams, setSortOption } = useURLSort({
         sortFields: defaultDeploymentSortFields,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/ImagesTableContainer.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/ImagesTableContainer.tsx
@@ -23,7 +23,7 @@ function ImagesTableContainer({ defaultFilters, countsData }: ImagesTableContain
     const { searchFilter } = useURLSearch();
     const querySearchFilter = parseQuerySearchFilter(searchFilter);
     const isFiltered = getHasSearchApplied(querySearchFilter);
-    const pagination = useURLPagination(25);
+    const pagination = useURLPagination(20);
     const { page, perPage, setPage } = pagination;
     const sort = useURLSort({
         sortFields: defaultImageSortFields,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedDeploymentsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedDeploymentsTable.tsx
@@ -14,7 +14,6 @@ import { gql } from '@apollo/client';
 import LinkShim from 'Components/PatternFly/LinkShim';
 import useSet from 'hooks/useSet';
 import { UseURLSortResult } from 'hooks/useURLSort';
-import { getDistanceStrictAsPhrase } from 'utils/dateUtils';
 import { getEntityPagePath } from '../searchUtils';
 import { DynamicColumnIcon } from '../components/DynamicIcon';
 import EmptyTableResults from '../components/EmptyTableResults';
@@ -25,6 +24,7 @@ import DeploymentComponentVulnerabilitiesTable, {
     imageMetadataContextFragment,
 } from './DeploymentComponentVulnerabilitiesTable';
 import SeverityCountLabels from '../components/SeverityCountLabels';
+import DatePhraseTd from '../components/DatePhraseTd';
 
 export type DeploymentForCve = {
     id: string;
@@ -154,8 +154,9 @@ function AffectedDeploymentsTable({
                             <Td dataLabel="Cluster">{clusterName}</Td>
                             <Td dataLabel="Namespace">{namespace}</Td>
                             <Td dataLabel="Images">{pluralize(imageCount, 'image')}</Td>
+
                             <Td dataLabel="First discovered">
-                                {getDistanceStrictAsPhrase(created, new Date())}
+                                <DatePhraseTd date={created} />
                             </Td>
                         </Tr>
                         <Tr isExpanded={isExpanded}>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedDeploymentsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedDeploymentsTable.tsx
@@ -31,7 +31,7 @@ export type DeploymentForCve = {
     name: string;
     namespace: string;
     clusterName: string;
-    created: Date | null;
+    created: string | null;
     imageCount: number;
     lowImageCount: number;
     moderateImageCount: number;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedDeploymentsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedDeploymentsTable.tsx
@@ -24,6 +24,7 @@ import DeploymentComponentVulnerabilitiesTable, {
     deploymentComponentVulnerabilitiesFragment,
     imageMetadataContextFragment,
 } from './DeploymentComponentVulnerabilitiesTable';
+import SeverityCountLabels from '../components/SeverityCountLabels';
 
 export type DeploymentForCve = {
     id: string;
@@ -32,6 +33,10 @@ export type DeploymentForCve = {
     clusterName: string;
     created: Date | null;
     imageCount: number;
+    lowImageCount: number;
+    moderateImageCount: number;
+    importantImageCount: number;
+    criticalImageCount: number;
     images: (ImageMetadataContext & { imageComponents: DeploymentComponentVulnerability[] })[];
 };
 
@@ -45,6 +50,10 @@ export const deploymentsForCveFragment = gql`
         clusterName
         created
         imageCount(query: $query)
+        lowImageCount: imageCount(query: $lowImageCountQuery)
+        moderateImageCount: imageCount(query: $moderateImageCountQuery)
+        importantImageCount: imageCount(query: $importantImageCountQuery)
+        criticalImageCount: imageCount(query: $criticalImageCountQuery)
         images(query: $query) {
             ...ImageMetadataContext
             imageComponents(query: $query) {
@@ -89,8 +98,19 @@ function AffectedDeploymentsTable({
             </Thead>
             {deployments.length === 0 && <EmptyTableResults colSpan={7} />}
             {deployments.map((deployment, rowIndex) => {
-                const { id, name, namespace, clusterName, imageCount, created, images } =
-                    deployment;
+                const {
+                    id,
+                    name,
+                    namespace,
+                    clusterName,
+                    imageCount,
+                    lowImageCount,
+                    moderateImageCount,
+                    importantImageCount,
+                    criticalImageCount,
+                    created,
+                    images,
+                } = deployment;
                 const isExpanded = expandedRowSet.has(id);
 
                 const imageComponentVulns = images.map((image) => ({
@@ -123,7 +143,14 @@ function AffectedDeploymentsTable({
                                     </Button>{' '}
                                 </Flex>
                             </Td>
-                            <Td dataLabel="Images by severity">TODO</Td>
+                            <Td dataLabel="Images by severity">
+                                <SeverityCountLabels
+                                    critical={criticalImageCount}
+                                    important={importantImageCount}
+                                    moderate={moderateImageCount}
+                                    low={lowImageCount}
+                                />
+                            </Td>
                             <Td dataLabel="Cluster">{clusterName}</Td>
                             <Td dataLabel="Namespace">{namespace}</Td>
                             <Td dataLabel="Images">{pluralize(imageCount, 'image')}</Td>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedImagesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedImagesTable.tsx
@@ -15,7 +15,6 @@ import SeverityIcons from 'Components/PatternFly/SeverityIcons';
 import useSet from 'hooks/useSet';
 import { UseURLSortResult } from 'hooks/useURLSort';
 import { vulnerabilitySeverityLabels } from 'messages/common';
-import { getDistanceStrictAsPhrase } from 'utils/dateUtils';
 import { getAnyVulnerabilityIsFixable, getHighestVulnerabilitySeverity } from './table.utils';
 import ImageNameTd from '../components/ImageNameTd';
 import { DynamicColumnIcon } from '../components/DynamicIcon';
@@ -26,6 +25,7 @@ import ImageComponentVulnerabilitiesTable, {
     imageMetadataContextFragment,
 } from './ImageComponentVulnerabilitiesTable';
 import EmptyTableResults from '../components/EmptyTableResults';
+import DatePhraseTd from '../components/DatePhraseTd';
 
 export type ImageForCve = {
     id: string;
@@ -147,7 +147,7 @@ function AffectedImagesTable({ images, getSortParams, isFiltered }: AffectedImag
                                     : `${imageComponents.length} components`}
                             </Td>
                             <Td dataLabel="First discovered">
-                                {getDistanceStrictAsPhrase(scanTime, new Date())}
+                                <DatePhraseTd date={scanTime} />
                             </Td>
                         </Tr>
                         <Tr isExpanded={isExpanded}>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedImagesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedImagesTable.tsx
@@ -44,7 +44,7 @@ export type ImageForCve = {
     } | null;
     operatingSystem: string;
     watchStatus: 'WATCHED' | 'NOT_WATCHED';
-    scanTime: Date | null;
+    scanTime: string | null;
     imageComponents: ImageComponentVulnerability[];
 };
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/CVEsTable.tsx
@@ -9,16 +9,16 @@ import {
     Tr,
     ExpandableRowContent,
 } from '@patternfly/react-table';
-import { Button, ButtonVariant, Tooltip } from '@patternfly/react-core';
+import { Button, ButtonVariant } from '@patternfly/react-core';
 
 import LinkShim from 'Components/PatternFly/LinkShim';
-import { getDistanceStrictAsPhrase, getDateTime } from 'utils/dateUtils';
 import { UseURLSortResult } from 'hooks/useURLSort';
 import useSet from 'hooks/useSet';
 
 import { getEntityPagePath } from '../searchUtils';
 import SeverityCountLabels from '../components/SeverityCountLabels';
 import { DynamicColumnIcon } from '../components/DynamicIcon';
+import DatePhraseTd from '../components/DatePhraseTd';
 
 export const cveListQuery = gql`
     query getImageCVEList($query: String, $pagination: Pagination) {
@@ -151,14 +151,7 @@ function CVEsTable({ cves, unfilteredImageCount, getSortParams, isFiltered }: CV
                                     {affectedImageCount}/{unfilteredImageCount} affected images
                                 </Td>
                                 <Td>
-                                    <Tooltip content={getDateTime(firstDiscoveredInSystem)}>
-                                        <div>
-                                            {getDistanceStrictAsPhrase(
-                                                firstDiscoveredInSystem,
-                                                new Date()
-                                            )}
-                                        </div>
-                                    </Tooltip>
+                                    <DatePhraseTd date={firstDiscoveredInSystem} />
                                 </Td>
                             </Tr>
                             <Tr isExpanded={isExpanded}>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/CVEsTable.tsx
@@ -62,7 +62,7 @@ type ImageCVE = {
     };
     topCVSS: number;
     affectedImageCount: number;
-    firstDiscoveredInSystem: Date | null;
+    firstDiscoveredInSystem: string | null;
 };
 
 type CVEsTableProps = {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentComponentVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentComponentVulnerabilitiesTable.tsx
@@ -14,6 +14,7 @@ import {
 } from './table.utils';
 import FixedByVersionTd from '../components/FixedByVersionTd';
 import DockerfileLayerTd from '../components/DockerfileLayerTd';
+import ComponentLocationTd from '../components/ComponentLocationTd';
 
 export { imageMetadataContextFragment };
 export type { ImageMetadataContext, DeploymentComponentVulnerability };
@@ -23,6 +24,7 @@ export const deploymentComponentVulnerabilitiesFragment = gql`
         name
         version
         location
+        source
         layerIndex
         imageVulnerabilities(query: $query) {
             id
@@ -84,6 +86,7 @@ function DeploymentComponentVulnerabilitiesTable({
                     scoreVersion,
                     fixedByVersion,
                     location,
+                    source,
                     layer,
                 } = componentVuln;
                 // No border on the last row
@@ -113,7 +116,9 @@ function DeploymentComponentVulnerabilitiesTable({
                             <Td>
                                 <FixedByVersionTd fixedByVersion={fixedByVersion} />
                             </Td>
-                            <Td>{location || 'N/A'}</Td>
+                            <Td>
+                                <ComponentLocationTd location={location} source={source} />
+                            </Td>
                         </Tr>
                         <Tr>
                             <Td colSpan={7} className="pf-u-pt-0">

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx
@@ -14,7 +14,6 @@ import { min } from 'date-fns';
 
 import LinkShim from 'Components/PatternFly/LinkShim';
 import useSet from 'hooks/useSet';
-import { getDistanceStrictAsPhrase } from 'utils/dateUtils';
 import { UseURLSortResult } from 'hooks/useURLSort';
 import { FixableIcon, NotFixableIcon } from 'Components/PatternFly/FixabilityIcons';
 import VulnerabilitySeverityIconText from 'Components/PatternFly/IconText/VulnerabilitySeverityIconText';
@@ -29,6 +28,7 @@ import DeploymentComponentVulnerabilitiesTable, {
     deploymentComponentVulnerabilitiesFragment,
 } from './DeploymentComponentVulnerabilitiesTable';
 import { getAnyVulnerabilityIsFixable, getHighestVulnerabilitySeverity } from './table.utils';
+import DatePhraseTd from '../components/DatePhraseTd';
 
 export const deploymentWithVulnerabilitiesFragment = gql`
     ${deploymentComponentVulnerabilitiesFragment}
@@ -197,7 +197,7 @@ function DeploymentVulnerabilitiesTable({
                             </Td>
                             <Td dataLabel="Affected components">{affectedComponentsText}</Td>
                             <Td dataLabel="First discovered">
-                                {getDistanceStrictAsPhrase(discoveredAtImage, new Date())}
+                                <DatePhraseTd date={discoveredAtImage} />
                             </Td>
                         </Tr>
                         <Tr isExpanded={isExpanded}>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentsTable.tsx
@@ -51,7 +51,7 @@ export type Deployment = {
     clusterName: string;
     namespace: string;
     imageCount: number;
-    created: Date | null;
+    created: string | null;
 };
 
 type DeploymentsTableProps = {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentsTable.tsx
@@ -2,15 +2,15 @@ import React from 'react';
 import { gql } from '@apollo/client';
 import pluralize from 'pluralize';
 import { TableComposable, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
-import { Button, ButtonVariant, Tooltip } from '@patternfly/react-core';
+import { Button, ButtonVariant } from '@patternfly/react-core';
 
 import LinkShim from 'Components/PatternFly/LinkShim';
-import { getDistanceStrictAsPhrase, getDateTime } from 'utils/dateUtils';
 import { UseURLSortResult } from 'hooks/useURLSort';
 import { getEntityPagePath } from '../searchUtils';
 import SeverityCountLabels from '../components/SeverityCountLabels';
 import { DynamicColumnIcon } from '../components/DynamicIcon';
 import EmptyTableResults from '../components/EmptyTableResults';
+import DatePhraseTd from '../components/DatePhraseTd';
 
 export const deploymentListQuery = gql`
     query getDeploymentList($query: String, $pagination: Pagination) {
@@ -131,9 +131,7 @@ function DeploymentsTable({ deployments, getSortParams, isFiltered }: Deployment
                                     </Button>
                                 </Td>
                                 <Td>
-                                    <Tooltip content={getDateTime(created)}>
-                                        <div>{getDistanceStrictAsPhrase(created, new Date())}</div>
-                                    </Tooltip>
+                                    <DatePhraseTd date={created} />
                                 </Td>
                             </Tr>
                         </Tbody>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageComponentVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageComponentVulnerabilitiesTable.tsx
@@ -12,6 +12,7 @@ import {
 } from './table.utils';
 import FixedByVersionTd from '../components/FixedByVersionTd';
 import DockerfileLayerTd from '../components/DockerfileLayerTd';
+import ComponentLocationTd from '../components/ComponentLocationTd';
 
 export { imageMetadataContextFragment };
 export type { ImageMetadataContext, ImageComponentVulnerability };
@@ -21,6 +22,7 @@ export const imageComponentVulnerabilitiesFragment = gql`
         name
         version
         location
+        source
         layerIndex
         imageVulnerabilities(query: $query) {
             id
@@ -66,8 +68,16 @@ function ImageComponentVulnerabilitiesTable({
                 </Tr>
             </Thead>
             {sortedComponentVulns.map((componentVuln, index) => {
-                const { image, name, vulnerabilityId, version, fixedByVersion, location, layer } =
-                    componentVuln;
+                const {
+                    image,
+                    name,
+                    vulnerabilityId,
+                    version,
+                    fixedByVersion,
+                    location,
+                    source,
+                    layer,
+                } = componentVuln;
                 // No border on the last row
                 const style =
                     index !== componentVulns.length - 1
@@ -82,7 +92,9 @@ function ImageComponentVulnerabilitiesTable({
                             <Td>
                                 <FixedByVersionTd fixedByVersion={fixedByVersion} />
                             </Td>
-                            <Td>{location || 'N/A'}</Td>
+                            <Td>
+                                <ComponentLocationTd location={location} source={source} />
+                            </Td>
                         </Tr>
                         <Tr>
                             <Td colSpan={4} className="pf-u-pt-0">

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
@@ -16,7 +16,6 @@ import LinkShim from 'Components/PatternFly/LinkShim';
 import SeverityIcons from 'Components/PatternFly/SeverityIcons';
 import useSet from 'hooks/useSet';
 import { vulnerabilitySeverityLabels } from 'messages/common';
-import { getDistanceStrictAsPhrase } from 'utils/dateUtils';
 import { UseURLSortResult } from 'hooks/useURLSort';
 import { FixableIcon, NotFixableIcon } from 'Components/PatternFly/FixabilityIcons';
 import { getEntityPagePath } from '../searchUtils';
@@ -28,6 +27,7 @@ import ImageComponentVulnerabilitiesTable, {
 } from './ImageComponentVulnerabilitiesTable';
 
 import EmptyTableResults from '../components/EmptyTableResults';
+import DatePhraseTd from '../components/DatePhraseTd';
 
 export const imageVulnerabilitiesFragment = gql`
     ${imageComponentVulnerabilitiesFragment}
@@ -161,7 +161,7 @@ function ImageVulnerabilitiesTable({
                                         : `${imageComponents.length} components`}
                                 </Td>
                                 <Td dataLabel="First discovered">
-                                    {getDistanceStrictAsPhrase(discoveredAtImage, new Date())}
+                                    <DatePhraseTd date={discoveredAtImage} />
                                 </Td>
                             </Tr>
                             <Tr isExpanded={isExpanded}>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
@@ -54,7 +54,7 @@ export type ImageVulnerability = {
     summary: string;
     cvss: number;
     scoreVersion: string;
-    discoveredAtImage: Date | null;
+    discoveredAtImage: string | null;
     imageComponents: ImageComponentVulnerability[];
 };
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImagesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImagesTable.tsx
@@ -67,10 +67,10 @@ type Image = {
     watchStatus: 'WATCHED' | 'NOT_WATCHED';
     metadata: {
         v1: {
-            created: Date | null;
+            created: string | null;
         } | null;
     } | null;
-    scanTime: Date | null;
+    scanTime: string | null;
 };
 
 type ImagesTableProps = {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImagesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImagesTable.tsx
@@ -2,16 +2,16 @@ import React from 'react';
 import { gql } from '@apollo/client';
 import pluralize from 'pluralize';
 import { TableComposable, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
-import { Button, ButtonVariant, Flex, Tooltip } from '@patternfly/react-core';
+import { Button, ButtonVariant, Flex } from '@patternfly/react-core';
 
 import LinkShim from 'Components/PatternFly/LinkShim';
-import { getDistanceStrictAsPhrase, getDateTime } from 'utils/dateUtils';
 import { UseURLSortResult } from 'hooks/useURLSort';
 import ImageNameTd from '../components/ImageNameTd';
 import { getEntityPagePath } from '../searchUtils';
 import SeverityCountLabels from '../components/SeverityCountLabels';
 import { DynamicColumnIcon } from '../components/DynamicIcon';
 import EmptyTableResults from '../components/EmptyTableResults';
+import DatePhraseTd from '../components/DatePhraseTd';
 
 export const imageListQuery = gql`
     query getImageList($query: String, $pagination: Pagination) {
@@ -156,19 +156,10 @@ function ImagesTable({ images, getSortParams, isFiltered }: ImagesTableProps) {
                                     )}
                                 </Td>
                                 <Td>
-                                    <Tooltip content={getDateTime(metadata?.v1?.created)}>
-                                        <div>
-                                            {getDistanceStrictAsPhrase(
-                                                metadata?.v1?.created,
-                                                new Date()
-                                            )}
-                                        </div>
-                                    </Tooltip>
+                                    <DatePhraseTd date={metadata?.v1?.created} />
                                 </Td>
                                 <Td>
-                                    <Tooltip content={getDateTime(scanTime)}>
-                                        <div>{getDistanceStrictAsPhrase(scanTime, new Date())}</div>
-                                    </Tooltip>
+                                    <DatePhraseTd date={scanTime} />
                                 </Td>
                             </Tr>
                         </Tbody>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/table.utils.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/table.utils.ts
@@ -40,12 +40,24 @@ export const imageMetadataContextFragment = gql`
     }
 `;
 
+// This is a general type that isn't specific to this component, so should be moved elsewhere if
+// there is a more appropriate location. (top level ./types/ directory?)
+export type SourceType =
+    | 'OS'
+    | 'PYTHON'
+    | 'JAVA'
+    | 'RUBY'
+    | 'NODEJS'
+    | 'DOTNETCORERUNTIME'
+    | 'INFRASTRUCTURE';
+
 // TODO Enforce a non-empty imageVulnerabilities array at a higher level?
 export type ComponentVulnerabilityBase = {
     type: 'Image' | 'Deployment';
     name: string;
     version: string;
     location: string;
+    source: SourceType;
     layerIndex: number | null;
     imageVulnerabilities: {
         id: string;
@@ -84,6 +96,7 @@ export type TableDataRow = {
     severity: VulnerabilitySeverity;
     version: string;
     location: string;
+    source: SourceType;
     layer: {
         line: number;
         instruction: string;
@@ -143,7 +156,7 @@ function extractCommonComponentFields(
     component: ComponentVulnerabilityBase,
     vulnerability: ComponentVulnerabilityBase['imageVulnerabilities'][0] | undefined
 ): TableDataRow {
-    const { name, version, location, layerIndex } = component;
+    const { name, version, location, source, layerIndex } = component;
 
     let layer: TableDataRow['layer'] = null;
 
@@ -169,6 +182,7 @@ function extractCommonComponentFields(
         name,
         version,
         location,
+        source,
         image,
         layer,
         vulnerabilityId,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ComponentLocationTd.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ComponentLocationTd.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Flex, Tooltip } from '@patternfly/react-core';
+import { InfoCircleIcon } from '@patternfly/react-icons';
+
+import { SourceType } from '../Tables/table.utils';
+
+export type ComponentLocationTdProps = {
+    location: string;
+    source: SourceType;
+};
+
+function ComponentLocationTd({ location, source }: ComponentLocationTdProps) {
+    return (
+        <Flex spaceItems={{ default: 'spaceItemsXs' }} alignItems={{ default: 'alignItemsCenter' }}>
+            <span>{location || 'N/A'}</span>
+            {source === 'OS' && (
+                <Tooltip content="Location is unavailable for operating system packages">
+                    <InfoCircleIcon color="var(--pf-global--info-color--100)" />
+                </Tooltip>
+            )}
+        </Flex>
+    );
+}
+
+export default ComponentLocationTd;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/DatePhraseTd.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/DatePhraseTd.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Tooltip } from '@patternfly/react-core';
+
+import { getDateTime, getDistanceStrictAsPhrase } from 'utils/dateUtils';
+
+export type DatePhraseTdProps = {
+    date: string | number | Date | null | undefined;
+};
+
+function DatePhraseTd({ date }: DatePhraseTdProps) {
+    return (
+        <Tooltip content={getDateTime(date)}>
+            <span>{getDistanceStrictAsPhrase(date, new Date())}</span>
+        </Tooltip>
+    );
+}
+
+export default DatePhraseTd;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/DatePhraseTd.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/DatePhraseTd.tsx
@@ -8,6 +8,9 @@ export type DatePhraseTdProps = {
 };
 
 function DatePhraseTd({ date }: DatePhraseTdProps) {
+    if (!date) {
+        return null;
+    }
     return (
         <Tooltip content={getDateTime(date)}>
             <span>{getDistanceStrictAsPhrase(date, new Date())}</span>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/FilterAutocomplete.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/FilterAutocomplete.tsx
@@ -6,7 +6,11 @@ import { SearchFilter } from 'types/search';
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
 import SEARCH_AUTOCOMPLETE_QUERY from 'queries/searchAutocomplete';
 import { searchCategories } from 'constants/entityTypes';
-import FilterResourceDropdown, { Resource } from './FilterResourceDropdown';
+import FilterResourceDropdown, {
+    FilterResourceDropdownProps,
+    Resource,
+    resources,
+} from './FilterResourceDropdown';
 
 function getOptions(data: string[] | undefined): React.ReactElement[] | undefined {
     return data?.map((value) => <SelectOption key={value} value={value} />);
@@ -31,20 +35,22 @@ function getSearchCategoriesForAutocomplete(resource: Resource) {
     return searchCategories[resource];
 }
 
-type FilterAutocompleteSelectProps = {
+export type FilterAutocompleteSelectProps = {
     searchFilter: SearchFilter;
     setSearchFilter: (s) => void;
-    resourceContext?: Resource;
+    supportedResourceFilters?: FilterResourceDropdownProps['supportedResourceFilters'];
     onDeleteGroup: (category) => void;
 };
 
 function FilterAutocompleteSelect({
     searchFilter,
     setSearchFilter,
-    resourceContext,
+    supportedResourceFilters,
     onDeleteGroup,
 }: FilterAutocompleteSelectProps) {
-    const [resource, setResource] = useState<Resource>('DEPLOYMENT');
+    const [resource, setResource] = useState<Resource>(
+        () => resources.find((r) => supportedResourceFilters?.has(r)) ?? 'DEPLOYMENT'
+    );
     const [typeahead, setTypeahead] = useState('');
     const { isOpen, onToggle } = useSelectToggle();
     const variables = {
@@ -81,7 +87,7 @@ function FilterAutocompleteSelect({
             <FilterResourceDropdown
                 setResource={setResource}
                 resource={resource}
-                resourceContext={resourceContext}
+                supportedResourceFilters={supportedResourceFilters}
             />
             <Select
                 aria-label={`Filter by ${resource as string}`}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/FilterResourceDropdown.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/FilterResourceDropdown.tsx
@@ -3,18 +3,20 @@ import { Select, SelectOption } from '@patternfly/react-core';
 
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
 
-export type Resource = 'CVE' | 'IMAGE' | 'DEPLOYMENT' | 'NAMESPACE' | 'CLUSTER';
+export const resources = ['CVE', 'IMAGE', 'DEPLOYMENT', 'NAMESPACE', 'CLUSTER'] as const;
 
-type FilterResourceDropdownProps = {
+export type Resource = (typeof resources)[number];
+
+export type FilterResourceDropdownProps = {
     setResource: (selection) => void;
     resource: Resource;
-    resourceContext?: Resource;
+    supportedResourceFilters?: Set<Resource>;
 };
 
 function FilterResourceDropdown({
     setResource,
     resource,
-    resourceContext,
+    supportedResourceFilters,
 }: FilterResourceDropdownProps) {
     const { isOpen, onToggle } = useSelectToggle();
 
@@ -52,8 +54,8 @@ function FilterResourceDropdown({
             isOpen={isOpen}
             className="pf-u-w-25"
         >
-            {resourceContext
-                ? resourceOptions.filter((res) => res.key !== resourceContext)
+            {supportedResourceFilters
+                ? resourceOptions.filter((res) => supportedResourceFilters.has(res.key as Resource))
                 : resourceOptions}
         </Select>
     );

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ImageDetailBadges.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ImageDetailBadges.tsx
@@ -10,12 +10,12 @@ export type ImageDetails = {
     operatingSystem: string;
     metadata: {
         v1: {
-            created: Date | null;
+            created: string | null;
             digest: string;
         } | null;
     } | null;
     dataSource: { id: string; name: string } | null;
-    scanTime: Date | null;
+    scanTime: string | null;
 };
 
 export const imageDetailsFragment = gql`

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ImageNameTd.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ImageNameTd.tsx
@@ -8,6 +8,7 @@ type ImageNameTdProps = {
     name: {
         remote: string;
         registry: string;
+        tag: string;
     };
     id: string;
 };
@@ -21,7 +22,7 @@ function ImageNameTd({ name, id }: ImageNameTdProps) {
                 component={LinkShim}
                 href={getEntityPagePath('Image', id)}
             >
-                {name.remote}
+                {name.remote}:{name.tag}
             </Button>{' '}
             <span className="pf-u-color-200 pf-u-font-size-sm">in {name.registry}</span>
         </Flex>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/WorkloadTableToolbar.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/WorkloadTableToolbar.tsx
@@ -5,7 +5,7 @@ import useURLSearch from 'hooks/useURLSearch';
 import { uniq } from 'lodash';
 import { DefaultFilters, VulnerabilitySeverityLabel, FixableStatus } from '../types';
 import { Resource } from './FilterResourceDropdown';
-import FilterAutocomplete from './FilterAutocomplete';
+import FilterAutocomplete, { FilterAutocompleteSelectProps } from './FilterAutocomplete';
 import CVESeverityDropdown from './CVESeverityDropdown';
 import CVEStatusDropdown from './CVEStatusDropdown';
 import FilterChips from './FilterChips';
@@ -18,12 +18,12 @@ const emptyDefaultFilters = {
 type FilterType = 'Severity' | 'Fixable';
 type WorkloadTableToolbarProps = {
     defaultFilters?: DefaultFilters;
-    resourceContext?: Resource;
+    supportedResourceFilters?: FilterAutocompleteSelectProps['supportedResourceFilters'];
 };
 
 function WorkloadTableToolbar({
     defaultFilters = emptyDefaultFilters,
-    resourceContext,
+    supportedResourceFilters,
 }: WorkloadTableToolbarProps) {
     const { searchFilter, setSearchFilter } = useURLSearch();
     const searchSeverity = (searchFilter.Severity as VulnerabilitySeverityLabel[]) || [];
@@ -89,7 +89,7 @@ function WorkloadTableToolbar({
                 <FilterAutocomplete
                     searchFilter={searchFilter}
                     setSearchFilter={setSearchFilter}
-                    resourceContext={resourceContext}
+                    supportedResourceFilters={supportedResourceFilters}
                     onDeleteGroup={onDeleteGroup}
                 />
                 <ToolbarGroup>


### PR DESCRIPTION
## Description

One commit -> one minor update

1. Add the "images by severity" column to the ImageCVE page deployment tab table
2. Add tooltips to all dates in all tables
3. Add tooltip/icon to component vuln table when "source" is equal to "OS"
4. Add the image `tag` to the name in all table cells
5. Update pagination to default to 20 for all tables (PF component defaults are 10, 20, 50, 100)
6. Restrict the filter toolbar dropdown to only appropriate resources based on the page context

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Visit the ImageCve page and click the deployment tab to view the images by severity column:
![image](https://user-images.githubusercontent.com/1292638/235715868-72e1a8a1-6c3d-4a68-bc94-447a33654f07.png)

Visit any table with dates and hover over the value in the date column:
![image](https://user-images.githubusercontent.com/1292638/235716044-9303fe4b-dc6f-497e-8976-28c99e5af17d.png)

Open an embedded component table when the vulnerability is a language-level vuln:
![image](https://user-images.githubusercontent.com/1292638/235716347-2eacf8d3-3a42-4093-aaf9-be4d14c5b611.png)

When it is an OS vuln:
![image](https://user-images.githubusercontent.com/1292638/235716442-712a9868-e0ed-4218-a85c-19f7d2f56910.png)

View an image table and verify the tag is part of the name:
![image](https://user-images.githubusercontent.com/1292638/235716611-6d0e6f2e-e150-4722-a650-db05ee640b4e.png)

Visit any table and ensure the default pagination is 20, and that the correct item is checked in the dropdown:
![image](https://user-images.githubusercontent.com/1292638/235716812-6162746f-bfc5-4b84-9634-026ffe702ef0.png)

Visit the individual entity pages and ensure the toolbar dropdown is filtered appropriately:
![image](https://user-images.githubusercontent.com/1292638/235716911-c991eff0-c7f6-4d83-be57-b9e29bc77c61.png)
![image](https://user-images.githubusercontent.com/1292638/235716936-b32d7c61-702b-4139-84f3-2d2ab59ef94d.png)
![image](https://user-images.githubusercontent.com/1292638/235716974-53a6e3c4-6c00-403b-a881-cdd96bdc298c.png)

