### PR TITLE
ROX-16212: Fix cert rotation broken on some installations

### DIFF
--- a/pkg/renderer/kubernetes_helm.go
+++ b/pkg/renderer/kubernetes_helm.go
@@ -74,11 +74,11 @@ func RenderSensorTLSSecretsOnly(values charts.MetaValues, certs *sensor.Certs) (
 //
 // Ideally, this should not be needed, and it only happens due to the logic necessary to build manifest bundles.
 // Either the logic to render TLS secrets should be decoupled from the manifest bundle, and only the necessary
-// are files rendered. Or we fix the logic in the manifest bundle so that ImageTag is always set, regardless of the
+// files are rendered. Or we fix the logic in the manifest bundle so that ImageTag is always set, regardless of the
 // cluster configuration.
 func overwriteEmptyImageValues(values *charts.MetaValues) {
 	if values.ImageTag == "" {
-		values.ImageTag = "should-never-use"
+		values.ImageTag = "should-never-see-this"
 	}
 }
 

--- a/pkg/renderer/kubernetes_helm.go
+++ b/pkg/renderer/kubernetes_helm.go
@@ -36,6 +36,8 @@ func RenderSensorTLSSecretsOnly(values charts.MetaValues, certs *sensor.Certs) (
 	// Currently, we rely on Go to copy the struct as it is passed by value, not by pointer.
 	values.CertsOnly = true
 
+	overwriteEmptyImageValues(&values)
+
 	ch, err := helmImage.GetSensorChart(&values, certs)
 	if err != nil {
 		return nil, errors.Wrap(err, "pre-rendering sensor chart")
@@ -63,6 +65,21 @@ func RenderSensorTLSSecretsOnly(values charts.MetaValues, certs *sensor.Certs) (
 		firstPrinted = true
 	}
 	return out.Bytes(), nil
+}
+
+// overwriteEmptyImageValues overrides an empty ImageTag in charts.MetaValues to avoid errors when rendering charts.
+// This should only be used when rendering TLS charts, because `ImageTag` will never be needed there. Hence, the
+// tag value that makes explicit that this value should never appear in a user chart. More info on the issue
+// refer to ROX-16212.
+//
+// Ideally, this should not be needed, and it only happens due to the logic necessary to build manifest bundles.
+// Either the logic to render TLS secrets should be decoupled from the manifest bundle, and only the necessary
+// are files rendered. Or we fix the logic in the manifest bundle so that ImageTag is always set, regardless of the
+// cluster configuration.
+func overwriteEmptyImageValues(values *charts.MetaValues) {
+	if values.ImageTag == "" {
+		values.ImageTag = "should-never-use"
+	}
 }
 
 // RenderSensor renders the sensorchart and returns rendered files

--- a/pkg/renderer/kubernetes_helm.go
+++ b/pkg/renderer/kubernetes_helm.go
@@ -36,7 +36,7 @@ func RenderSensorTLSSecretsOnly(values charts.MetaValues, certs *sensor.Certs) (
 	// Currently, we rely on Go to copy the struct as it is passed by value, not by pointer.
 	values.CertsOnly = true
 
-	overwriteEmptyImageValues(&values)
+	fixEmptyImageTag(&values)
 
 	ch, err := helmImage.GetSensorChart(&values, certs)
 	if err != nil {
@@ -67,7 +67,7 @@ func RenderSensorTLSSecretsOnly(values charts.MetaValues, certs *sensor.Certs) (
 	return out.Bytes(), nil
 }
 
-// overwriteEmptyImageValues overrides an empty ImageTag in charts.MetaValues to avoid errors when rendering charts.
+// fixEmptyImageTag overrides an empty ImageTag in charts.MetaValues to avoid errors when rendering charts.
 // This should only be used when rendering TLS charts, because `ImageTag` will never be needed there. Hence, the
 // tag value that makes explicit that this value should never appear in a user chart. More info on the issue
 // refer to ROX-16212.
@@ -76,7 +76,7 @@ func RenderSensorTLSSecretsOnly(values charts.MetaValues, certs *sensor.Certs) (
 // Either the logic to render TLS secrets should be decoupled from the manifest bundle, and only the necessary
 // files are rendered. Or we fix the logic in the manifest bundle so that ImageTag is always set, regardless of the
 // cluster configuration.
-func overwriteEmptyImageValues(values *charts.MetaValues) {
+func fixEmptyImageTag(values *charts.MetaValues) {
 	if values.ImageTag == "" {
 		values.ImageTag = "should-never-see-this"
 	}

--- a/pkg/renderer/kubernetes_helm_test.go
+++ b/pkg/renderer/kubernetes_helm_test.go
@@ -169,7 +169,7 @@ func TestRenderSensorHelm(t *testing.T) {
 	}
 }
 
-func TestRenderSensorTLSSensorOnly_NotPanicOnMissingImageData(t *testing.T) {
+func TestRenderSensorTLSSensorOnly_NoErrorOnMissingImageData(t *testing.T) {
 	fields := getDefaultMetaValues(t)
 	fields.CertsOnly = true
 	// (ROX-16212) Should not fail when meta-values don't set ImageTag (e.g. when running with Operator installation)

--- a/pkg/renderer/kubernetes_helm_test.go
+++ b/pkg/renderer/kubernetes_helm_test.go
@@ -169,6 +169,16 @@ func TestRenderSensorHelm(t *testing.T) {
 	}
 }
 
+func TestRenderSensorTLSSensorOnly_NotPanicOnMissingImageData(t *testing.T) {
+	fields := getDefaultMetaValues(t)
+	fields.CertsOnly = true
+	// (ROX-16212) Should not fail when meta-values don't set ImageTag (e.g. when running with Operator installation)
+	// ImageTag isn't used to render TLS secrets, therefore it shouldn't result in RenderSensorTLSSecretsOnly returning an error
+	fields.ImageTag = ""
+	_, err := RenderSensorTLSSecretsOnly(*fields, certs)
+	require.NoError(t, err)
+}
+
 func TestRenderSensorTLSSecretsOnly(t *testing.T) {
 	fields := getDefaultMetaValues(t)
 	fields.CertsOnly = true

--- a/pkg/renderer/kubernetes_helm_test.go
+++ b/pkg/renderer/kubernetes_helm_test.go
@@ -175,8 +175,15 @@ func TestRenderSensorTLSSensorOnly_NoErrorOnMissingImageData(t *testing.T) {
 	// (ROX-16212) Should not fail when meta-values don't set ImageTag (e.g. when running with Operator installation)
 	// ImageTag isn't used to render TLS secrets, therefore it shouldn't result in RenderSensorTLSSecretsOnly returning an error
 	fields.ImageTag = ""
-	_, err := RenderSensorTLSSecretsOnly(*fields, certs)
+	renderedManifests, err := RenderSensorTLSSecretsOnly(*fields, certs)
 	require.NoError(t, err)
+
+	// Image tag should not be seen in any of the yaml files
+	rawYamlString := string(renderedManifests)
+	assert.Contains(t, rawYamlString, "sensor-tls")
+	assert.Contains(t, rawYamlString, "collector-tls")
+	assert.Contains(t, rawYamlString, "admission-control-tls")
+	assert.NotContains(t, rawYamlString, "should-never-see-this")
 }
 
 func TestRenderSensorTLSSecretsOnly(t *testing.T) {


### PR DESCRIPTION
## Description

Cert rotation seems to be breaking if cluster image tag is a SHA reference. 

This PR aims to "stop the bleeding" and bring Cert Rotation back to a healthy state. The underlying issue will eventually be fixed by decoupling the secret rendering from full sensor bundle rendering or by implementing support for SHAs in manifest installations.  

See comments and commit messages for more context.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

- [x] (Unit) Regression test added 
- [x] CI
- [x] Manual test on cluster 

**Cluster "remote" has digest reference:**
![image](https://user-images.githubusercontent.com/6811076/235966899-f2ce0770-a42e-496f-a4dc-c83b55b0ecbe.png)

**Generating manifest bundles still fails with error:**
![Screenshot 2023-05-03 at 17 41 41](https://user-images.githubusercontent.com/6811076/235967560-38092d78-020d-4231-b6e8-ea65af21497b.png)
```
message: unable to get required cluster information: pre-rendering sensor chart: instantiating sensor chart template: instantiating file internal/defaults/50-images.yaml: instantiating template file internal/defaults/50-images.yaml: template: internal/defaults/50-images.yaml:73:12: executing "internal/defaults/50-images.yaml" at <required "" .ImageTag>: error calling required: required value was not specified
```

**Generating TLS certs from `roxctl` successfully generates yaml files:**
```
$ roxctl --insecure-skip-tls-verify -e localhost:8000 sensor generate-certs "remote"
INFO:	Successfully downloaded new certs. Use kubectl apply -f cluster-remote-tls.yaml to apply them.
```
