### PR TITLE
Remove aggregated permissions from access log

### DIFF
--- a/pkg/auth/user/util.go
+++ b/pkg/auth/user/util.go
@@ -58,12 +58,8 @@ func LogSuccessfulUserLogin(logger *logging.Logger, user *v1.AuthStatus) {
 // to []interface{}.
 func extractUserLogFields(user *v1.AuthStatus) []interface{} {
 	serviceIDJSON := ""
-	permissionsJSON := ""
 	if user.GetServiceId() != nil {
 		serviceIDJSON = protoToJSON(user.GetServiceId())
-	}
-	if user.GetUserInfo().GetPermissions() != nil {
-		permissionsJSON = protoToJSON(user.GetUserInfo().GetPermissions())
 	}
 	return []interface{}{
 		zap.String("userID", user.GetUserId()),
@@ -72,7 +68,6 @@ func extractUserLogFields(user *v1.AuthStatus) []interface{} {
 		zap.String("username", user.GetUserInfo().GetUsername()),
 		zap.String("friendlyName", user.GetUserInfo().GetFriendlyName()),
 		zap.Any("roleNames", utils.RoleNamesFromUserInfo(user.GetUserInfo().GetRoles())),
-		zap.String("permissions", permissionsJSON),
 		zap.Any("authProvider", &loggableAuthProvider{
 			ID:   user.GetAuthProvider().GetId(),
 			Type: user.GetAuthProvider().GetType(),

--- a/pkg/auth/user/util_test.go
+++ b/pkg/auth/user/util_test.go
@@ -43,14 +43,13 @@ func TestExtractUserLogFields_MainFieldsTransformed(t *testing.T) {
 		},
 	}
 	fields := extractUserLogFields(user)
-	assert.Len(t, fields, 9)
+	assert.Len(t, fields, 8)
 	assert.Contains(t, fields, zap.String("userID", user.GetUserId()))
 	assert.Contains(t, fields, zap.String("serviceID", ""))
 	assert.Contains(t, fields, zap.Any("expires", user.GetExpires()))
 	assert.Contains(t, fields, zap.String("username", user.GetUserInfo().GetUsername()))
 	assert.Contains(t, fields, zap.String("friendlyName", user.GetUserInfo().GetFriendlyName()))
 	assert.Contains(t, fields, zap.Any("roleNames", []string{"Admin", "Analyst"}))
-	assert.Contains(t, fields, zap.String("permissions", "{\"resourceToAccess\":{\"Close Magic Doors\":\"READ_ACCESS\",\"Open Magic Doors\":\"READ_WRITE_ACCESS\"}}"))
 	assert.Contains(t, fields, zap.Any("authProvider", &loggableAuthProvider{
 		ID:   user.GetAuthProvider().GetId(),
 		Name: user.GetAuthProvider().GetName(),
@@ -71,14 +70,13 @@ func TestExtractUserLogFields_ServiceIdTransformed(t *testing.T) {
 		},
 	}
 	fields := extractUserLogFields(user)
-	assert.Len(t, fields, 9)
+	assert.Len(t, fields, 8)
 	assert.Contains(t, fields, zap.String("userID", ""))
 	assert.Contains(t, fields, zap.String("serviceID", "{\"serialStr\":\"serialStr\",\"id\":\"id\",\"type\":\"CENTRAL_SERVICE\",\"initBundleId\":\"initBundleId\"}"))
 	assert.Contains(t, fields, zap.Any("expires", user.GetExpires()))
 	assert.Contains(t, fields, zap.String("username", ""))
 	assert.Contains(t, fields, zap.String("friendlyName", ""))
 	assert.Contains(t, fields, zap.Any("roleNames", []string{}))
-	assert.Contains(t, fields, zap.String("permissions", ""))
 	assert.Contains(t, fields, zap.Any("authProvider", &loggableAuthProvider{
 		ID:   "",
 		Name: "",
@@ -91,14 +89,13 @@ func TestExtractUserLogFields_ServiceIdTransformed(t *testing.T) {
 func TestExtractUserLogFields_NilTransformed(t *testing.T) {
 	var user *v1.AuthStatus
 	fields := extractUserLogFields(user)
-	assert.Len(t, fields, 9)
+	assert.Len(t, fields, 8)
 	assert.Contains(t, fields, zap.String("userID", ""))
 	assert.Contains(t, fields, zap.String("serviceID", ""))
 	assert.Contains(t, fields, zap.Any("expires", user.GetExpires()))
 	assert.Contains(t, fields, zap.String("username", ""))
 	assert.Contains(t, fields, zap.String("friendlyName", ""))
 	assert.Contains(t, fields, zap.Any("roleNames", []string{}))
-	assert.Contains(t, fields, zap.String("permissions", ""))
 	assert.Contains(t, fields, zap.Any("authProvider", &loggableAuthProvider{
 		ID:   "",
 		Name: "",


### PR DESCRIPTION
## Description

In https://issues.redhat.com/browse/ROX-14521, we added access log as part of Central logs. Considering we don't show access scope in access log, `permissions` field does not provide much useful formation. To avoid on-call engineers confusion, let's remove `permissions` and leave only `roleNames` as a way to determine what level of access user actually had.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

1. CI is sufficient
