### PR TITLE
CI: Fix spinning JUnit

### DIFF
--- a/scripts/ci/bats/lib_junit.bats
+++ b/scripts/ci/bats/lib_junit.bats
@@ -1,0 +1,105 @@
+#!/usr/bin/env bats
+# shellcheck disable=SC1091
+
+load "../../test_helpers.bats"
+
+function setup() {
+    source "${BATS_TEST_DIRNAME}/../lib.sh"
+    ARTIFACT_DIR="${BATS_TEST_TMPDIR}"
+    junit_dir="$(get_junit_misc_dir)"
+}
+
+@test "creates a single junit for a single test" {
+    run save_junit_success "UNITTest" "A unit test"
+    assert_success
+    run cat "${junit_dir}/junit-UNITTest.xml"
+    assert_output --partial 'tests="1"'
+    assert_output --partial 'failures="0"'
+}
+
+@test "creates multiple junit for multiple tests (different class)" {
+    run save_junit_success "UNITTest" "A unit test"
+    run save_junit_success "OtherUNITTest" "A unit test"
+    assert_success
+    run cat "${junit_dir}/junit-OtherUNITTest.xml"
+    assert_output --partial 'tests="1"'
+    assert_output --partial 'failures="0"'
+}
+
+@test "creates multiple junit for multiple tests (same class)" {
+    run save_junit_success "UNITTest" "A unit test"
+    run save_junit_success "UNITTest" "Another unit test"
+    assert_success
+    run cat "${junit_dir}/junit-UNITTest.xml"
+    assert_output --partial 'tests="2"'
+    assert_output --partial 'failures="0"'
+    run grep -c 'classname="UNITTest"' "${junit_dir}/junit-UNITTest.xml"
+    assert_output 2
+    run grep -c 'name="A unit test"' "${junit_dir}/junit-UNITTest.xml"
+    assert_output 1
+    run grep -c 'name="Another unit test"' "${junit_dir}/junit-UNITTest.xml"
+    assert_output 1
+}
+
+@test "is ok with repeated names" {
+    run save_junit_success "UNITTest" "A unit test"
+    run save_junit_success "UNITTest" "Another unit test"
+    run save_junit_success "UNITTest" "A unit test"
+    assert_success
+    run cat "${junit_dir}/junit-UNITTest.xml"
+    assert_output --partial 'tests="3"'
+    assert_output --partial 'failures="0"'
+    run grep -c 'classname="UNITTest"' "${junit_dir}/junit-UNITTest.xml"
+    assert_output 3
+    run grep -c 'name="A unit test"' "${junit_dir}/junit-UNITTest.xml"
+    assert_output 2
+    run grep -c 'name="Another unit test"' "${junit_dir}/junit-UNITTest.xml"
+    assert_output 1
+}
+
+@test "creates a failure junit" {
+    run save_junit_failure "UNITTest" "A unit test" "more failure details"
+    assert_success
+    run cat "${junit_dir}/junit-UNITTest.xml"
+    assert_output --partial 'tests="1"'
+    assert_output --partial 'failures="1"'
+    run grep -c 'more failure details' "${junit_dir}/junit-UNITTest.xml"
+    assert_output 1
+}
+
+@test "handles success and failure" {
+    run save_junit_failure "UNITTest" "A unit test" "more failure details"
+    run save_junit_success "UNITTest" "A unit test"
+    run cat "${junit_dir}/junit-UNITTest.xml"
+    assert_output --partial 'tests="2"'
+    assert_output --partial 'failures="1"'
+    run grep -c 'more failure details' "${junit_dir}/junit-UNITTest.xml"
+    assert_output 1
+}
+
+@test "handles success and failure II" {
+    run save_junit_failure "UNITTest" "A unit test" "more failure details"
+    run save_junit_success "UNITTest" "A unit test"
+    run save_junit_failure "UNITTest" "A unit test" "more failure details"
+    run save_junit_success "UNITTest" "A unit test"
+    run cat "${junit_dir}/junit-UNITTest.xml"
+    assert_output --partial 'tests="4"'
+    assert_output --partial 'failures="2"'
+    run grep -c 'more failure details' "${junit_dir}/junit-UNITTest.xml"
+    assert_output 2
+}
+
+@test "handles multiline failure details" {
+    read -r -d '' details << _EO_DETAILS_ || true
+more failure details
+other stuff
+more failure details
+more failure details
+_EO_DETAILS_
+    run save_junit_failure "UNITTest" "A unit test" "${details}"
+    run cat "${junit_dir}/junit-UNITTest.xml"
+    assert_output --partial 'tests="1"'
+    assert_output --partial 'failures="1"'
+    run grep -c 'more failure details' "${junit_dir}/junit-UNITTest.xml"
+    assert_output 3
+}

--- a/tests/e2e/bats/check_for_stackrox_OOMs.bats
+++ b/tests/e2e/bats/check_for_stackrox_OOMs.bats
@@ -12,12 +12,12 @@ load "../../../scripts/test_helpers.bats"
 
     run check_for_stackrox_OOMs "${BATS_TEST_TMPDIR}/oom-test"
 
-    with_oomkilled_test="$(ls ${ARTIFACT_DIR}/junit-misc/junit-OOMCheck-central-84bf956f94-bg6hr-*.xml)"
+    with_oomkilled_test="$(ls ${ARTIFACT_DIR}/junit-misc/junit-OOMCheck-central-84bf956f94-bg6hr.xml)"
     assert [ -f "$with_oomkilled_test" ]
     run grep -q "was OOMKilled" "$with_oomkilled_test"
     assert_success
 
-    without_oomkilled_test="$(ls ${ARTIFACT_DIR}/junit-misc/junit-OOMCheck-sensor-67d98c67bf-v688m-*.xml)"
+    without_oomkilled_test="$(ls ${ARTIFACT_DIR}/junit-misc/junit-OOMCheck-sensor-67d98c67bf-v688m.xml)"
     assert [ -f "$without_oomkilled_test" ]
     run grep -q "was not OOMKilled" "$without_oomkilled_test"
     assert_success


### PR DESCRIPTION
## Description

https://github.com/stackrox/stackrox/pull/4917 caused the prow JUnit panel to spin and not render results for gke-version-compatibility-tests [e.g.](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/branch-ci-stackrox-stackrox-nightlies-gke-version-compatibility-tests/1653265032659603456). I'm guessing that this is because in their current form,  the `save_junit_...()` methods can create multiple JUnit XML files with the same testsuite/class and testname. 

This PR creates a record of JUnit results for the same JUnit class and uses that to create multiple test case entries as or if needed. A simple line by line record for results was used because editing XML is too hard for me (in bash at least).

Note: this may not fix the original problem but I think its a better approach and may be used to improve some of the other JUnitification work.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

CI is sufficient.
