### PR TITLE
ROX-16850: Fix secured cluster provider name

### DIFF
--- a/central/cluster/datastore/telemetry.go
+++ b/central/cluster/datastore/telemetry.go
@@ -108,6 +108,7 @@ func UpdateSecuredClusterIdentity(ctx context.Context, clusterID string, metrics
 			}
 			props["Provider Region"] = pmd.GetRegion()
 			props["Provider Zone"] = pmd.GetZone()
+			props["Provider Verified"] = pmd.GetVerified()
 		}
 
 		omd := cluster.GetStatus().GetOrchestratorMetadata()

--- a/central/cluster/datastore/telemetry.go
+++ b/central/cluster/datastore/telemetry.go
@@ -96,7 +96,16 @@ func UpdateSecuredClusterIdentity(ctx context.Context, clusterID string, metrics
 		props["CPU Capacity"] = metrics.CpuCapacity
 
 		if pmd := cluster.GetStatus().GetProviderMetadata(); pmd.GetProvider() != nil {
-			props["Provider"] = pmd.GetProvider()
+			switch pmd.GetProvider().(type) {
+			case *storage.ProviderMetadata_Aws:
+				props["Provider"] = "AWS"
+			case *storage.ProviderMetadata_Azure:
+				props["Provider"] = "Azure"
+			case *storage.ProviderMetadata_Google:
+				props["Provider"] = "Google"
+			default:
+				props["Provider"] = "Unknown"
+			}
 			props["Provider Region"] = pmd.GetRegion()
 			props["Provider Zone"] = pmd.GetZone()
 		}


### PR DESCRIPTION
## Description

Secured cluster telemetry data contains of a wrongly formatted "Provider" property.
The PR fixes the formatting and also adds the "Provider Verified" property, which is also a part of generic provider metadata.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

New secured cluster properties as seen on Segment:
```json
    "traits": {
      "Admission Controller": false,
      "CPU Capacity": 12,
      "Cluster Type": "KUBERNETES_CLUSTER",
      "Collection Method": "EBPF",
      "Collector Image": "quay.io/stackrox-io/collector",
      "Main Image": "quay.io/stackrox-io/main",
      "Managed By": "MANAGER_TYPE_UNKNOWN",
      "Orchestrator Version": "v1.25.6",
      "Priority": 1,
      "Provider": "Azure",
      "Provider Region": "eastus",
      "Provider Verified": true,
      "Provider Zone": "",
      "Slim Collector": true,
      "Total Nodes": 3
    }
```