### PR TITLE
Update secret event

### DIFF
--- a/sensor/kubernetes/listener/resources/secrets.go
+++ b/sensor/kubernetes/listener/resources/secrets.go
@@ -332,6 +332,12 @@ func (s *secretDispatcher) processDockerConfigEvent(secret, oldSecret *v1.Secret
 			}
 		}
 	}
+	sort.SliceStable(registries, func(i, j int) bool {
+		if registries[i].Name != registries[j].Name {
+			return registries[i].GetName() != registries[j].GetName()
+		}
+		return registries[i].GetUsername() < registries[j].GetUsername()
+	})
 
 	protoSecret := getProtoSecret(secret)
 	protoSecret.Files = []*storage.SecretDataFile{{

--- a/sensor/kubernetes/listener/resources/secrets.go
+++ b/sensor/kubernetes/listener/resources/secrets.go
@@ -334,7 +334,7 @@ func (s *secretDispatcher) processDockerConfigEvent(secret, oldSecret *v1.Secret
 	}
 	sort.SliceStable(registries, func(i, j int) bool {
 		if registries[i].Name != registries[j].Name {
-			return registries[i].GetName() != registries[j].GetName()
+			return registries[i].GetName() < registries[j].GetName()
 		}
 		return registries[i].GetUsername() < registries[j].GetUsername()
 	})


### PR DESCRIPTION
## Description

Secrets are not deduped correctly on openshift

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Ran this image, and looked at the metrics. When we bounce sensor pod then central metrics show that no more secrets are processed
