### PR TITLE
Provide conditional integration testing for Vulnerability Management links

### DIFF
--- a/ui/apps/platform/cypress/constants/VulnManagementPage.js
+++ b/ui/apps/platform/cypress/constants/VulnManagementPage.js
@@ -14,6 +14,7 @@ export const vmHomePageSelectors = {
     vulnManagementExpandedReportingNavLink: `${navigationSelectors.nestedNavLinks}:contains("Reporting")`,
 };
 
+// The one-based index includes checkbox, hidden, invisible cells.
 const getTableDataColumnSelector = (columnIndex) => `.rt-tbody .rt-td:nth-child(${columnIndex})`;
 
 export const listSelectors = {

--- a/ui/apps/platform/cypress/constants/VulnManagementPage.js
+++ b/ui/apps/platform/cypress/constants/VulnManagementPage.js
@@ -13,12 +13,16 @@ export const vmHomePageSelectors = {
     vulnManagementExpandedDashboardNavLink: `${navigationSelectors.nestedNavLinks}:contains("Dashboard")`,
     vulnManagementExpandedReportingNavLink: `${navigationSelectors.nestedNavLinks}:contains("Reporting")`,
 };
+
+const getTableDataColumnSelector = (columnIndex) => `.rt-tbody .rt-td:nth-child(${columnIndex})`;
+
 export const listSelectors = {
     riskScoreCol: '.rt-table > .rt-tbody > div > div > div:nth-child(10)',
     componentsRiskScoreCol: '.rt-table > .rt-tbody >div > div > div:nth-child(7)',
     cvesCvssScoreCol: '.rt-table > .rt-tbody > div > .rt-tr.-odd > div:nth-child(4) > div > span',
     tableRows: '.rt-tr',
     tableCells: '.rt-td',
+    getTableDataColumnSelector,
     tableBodyRowGroups: '.rt-tbody .rt-tr-group',
     tableBodyRows: '.rt-tbody .rt-tr',
     tableRowCheckbox: '[data-testid="checkbox-table-row-selector"]',

--- a/ui/apps/platform/cypress/helpers/visit.js
+++ b/ui/apps/platform/cypress/helpers/visit.js
@@ -55,6 +55,7 @@ const routeMatcherMapForAuthenticatedRoutes = {
  * @param {string} pageUrl
  * @param {Record<string, { method: string, url: string }>} [routeMatcherMap]
  * @param {Record<string, { body: unknown } | { fixture: string }>} [staticResponseMap]
+ * @returns {{ request: Record<string, unknown>, response: Record<string, unknown>}[]}
  */
 export function visit(pageUrl, routeMatcherMap, staticResponseMap) {
     interceptRequests(routeMatcherMapForAuthenticatedRoutes);

--- a/ui/apps/platform/cypress/helpers/visit.js
+++ b/ui/apps/platform/cypress/helpers/visit.js
@@ -63,7 +63,7 @@ export function visit(pageUrl, routeMatcherMap, staticResponseMap) {
     cy.visit(pageUrl);
 
     waitForResponses(routeMatcherMapForAuthenticatedRoutes);
-    waitForResponses(routeMatcherMap);
+    return waitForResponses(routeMatcherMap);
 }
 
 /**

--- a/ui/apps/platform/cypress/helpers/vulnmanagement/entities.js
+++ b/ui/apps/platform/cypress/helpers/vulnmanagement/entities.js
@@ -304,6 +304,9 @@ export function verifySecondaryEntities(
     );
 }
 
+/*
+ * Verify panelHeader text, and then visit related entities pages,
+ */
 function verifyLinkCountDeep(
     entitiesKey1,
     entitiesKey2,
@@ -381,6 +384,12 @@ export function verifyLinkCountShallow(
 const allCVEsRegExp = /^\d+ CVEs?$/;
 const fixableCVEsRegExp = /^\d+ Fixable$/;
 
+/*
+ * Conditional test of either links for CVEs or text for No CVEs.
+ * 1. Prefer link for Fixable CVEs and visit only side panel (shallow).
+ * 2. Otherwise link for all CVEs and visit related entities pages (deep).
+ * 3. Otherwise text for No CVEs.
+ */
 export function verifyConditionalCVEs(
     entitiesKey1,
     entitiesKey2,
@@ -394,6 +403,7 @@ export function verifyConditionalCVEs(
     visitVulnerabilityManagementEntities(entitiesKey1).then(([, { response }]) => {
         const { results } = response.body.data;
 
+        // Check sources of truth whether or not to assert existence of links.
         const hasFixableCVEs = results.some((result) => result[vulnCounterKey]?.all?.fixable > 0);
         const hasCVEs = results.some((result) => result[vulnCounterKey]?.all?.total > 0);
 

--- a/ui/apps/platform/cypress/helpers/vulnmanagement/entities.js
+++ b/ui/apps/platform/cypress/helpers/vulnmanagement/entities.js
@@ -446,54 +446,6 @@ export function verifyConditionalCVEs(
     });
 }
 
-/*
- * For fixable CVEs link when primary entities are images,
- * also verify special case that image side panel has risk acceptance tabs.
- *
- * Keep arguments consistent with other functions,
- * expecially in case risk acceptance ever applies to node or platform CVEs.
- */
-export function verifyFixableCVEsLinkAndRiskAcceptanceTabs(
-    entitiesKey1,
-    _entitiesKey2, // unused because response might have been cached
-    columnIndex, // one-based index includes checkbox, hidden, invisible
-    getCountAndNounFromLinkResults
-) {
-    // 1. Visit list page for primary entities.
-    visitVulnerabilityManagementEntities(entitiesKey1);
-
-    // Find the first link for secondary entities.
-    cy.get(selectors.getTableDataColumnSelector(columnIndex))
-        .contains('a', fixableCVEsRegExp)
-        .then(($a) => {
-            const { panelHeaderText } = getCountAndNounFromLinkResults(
-                /^(\d+) (\D+)$/.exec($a.text())
-            );
-
-            // 2. Visit secondary entities side panel.
-            cy.wrap($a).click();
-
-            cy.get(`${selectors.entityRowHeader}:contains(${panelHeaderText})`);
-
-            // 3. Visit primary entity side panel.
-            cy.get(selectors.parentEntityInfoHeader).click();
-
-            // Verify risk acceptance tabs under Image Findings.
-            cy.get('.pf-c-tabs .pf-c-tabs__item:eq(0):contains("Observed CVEs")').click({
-                force: true,
-                waitForAnimations: false,
-            });
-            cy.get('.pf-c-tabs .pf-c-tabs__item:eq(1):contains("Deferred CVEs")').click({
-                force: true,
-                waitForAnimations: false,
-            });
-            cy.get('.pf-c-tabs .pf-c-tabs__item:eq(2):contains("False positive CVEs")').click({
-                force: true,
-                waitForAnimations: false,
-            });
-        });
-}
-
 // table
 
 /*

--- a/ui/apps/platform/cypress/integration/vulnmanagement/clusters.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/clusters.test.js
@@ -10,7 +10,7 @@ import {
     getCountAndNounFromNodeCVEsLinkResults,
     hasTableColumnHeadings,
     interactAndWaitForVulnerabilityManagementEntities,
-    verifyFilteredSecondaryEntitiesLink,
+    verifyConditionalCVEs,
     verifySecondaryEntities,
     visitVulnerabilityManagementEntities,
 } from '../../helpers/vulnmanagement/entities';
@@ -91,56 +91,40 @@ describe('Vulnerability Management Clusters', () => {
     // Argument 3 in verify functions is index of column which has the links.
     // The one-based index includes checkbox, hidden, invisible.
 
-    // Some tests might fail in local deployment.
-
-    it('should display links for all image CVEs', () => {
-        verifySecondaryEntities(
+    it('should display either links for image CVEs or text for No CVEs', () => {
+        verifyConditionalCVEs(
             entitiesKey,
             'image-cves',
             3,
-            /^\d+ CVEs?$/,
+            'imageVulnerabilityCounter',
             getCountAndNounFromImageCVEsLinkResults
         );
     });
 
-    it('should display links for fixable image CVEs', function () {
+    it('should display either links for node CVEs or text for No CVEs', function () {
         if (hasOrchestratorFlavor('openshift')) {
-            this.skip();
+            this.skip(); // TODO verify and remove
         }
 
-        verifyFilteredSecondaryEntitiesLink(
-            entitiesKey,
-            'image-cves',
-            3,
-            /^\d+ Fixable$/,
-            getCountAndNounFromImageCVEsLinkResults
-        );
-    });
-
-    it('should display links for all node CVEs', function () {
-        if (hasOrchestratorFlavor('openshift')) {
-            this.skip();
-        }
-
-        verifySecondaryEntities(
+        verifyConditionalCVEs(
             entitiesKey,
             'node-cves',
             4,
-            /^\d+ CVEs?$/,
+            'nodeVulnerabilityCounter',
             getCountAndNounFromNodeCVEsLinkResults
         );
     });
 
-    it('should display links for all cluster CVEs', function () {
+    it('should display either links for cluster CVEs of text for No CVEs', function () {
         if (hasOrchestratorFlavor('openshift')) {
-            this.skip();
+            this.skip(); // TODO verify and remove
         }
 
-        verifySecondaryEntities(
+        verifyConditionalCVEs(
             entitiesKey,
             'cluster-cves',
             5,
-            /^\d+ CVEs?$/,
+            'clusterVulnerabilityCounter',
             getCountAndNounFromClusterCVEsLinkResults
         );
     });

--- a/ui/apps/platform/cypress/integration/vulnmanagement/clusters.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/clusters.test.js
@@ -115,7 +115,7 @@ describe('Vulnerability Management Clusters', () => {
         );
     });
 
-    it('should display either links for cluster CVEs of text for No CVEs', function () {
+    it('should display either links for cluster CVEs or text for No CVEs', function () {
         if (hasOrchestratorFlavor('openshift')) {
             this.skip(); // TODO verify and remove
         }

--- a/ui/apps/platform/cypress/integration/vulnmanagement/componentsNonPostgress.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/componentsNonPostgress.test.js
@@ -8,7 +8,7 @@ import {
 import {
     hasTableColumnHeadings,
     interactAndWaitForVulnerabilityManagementEntities,
-    verifyFilteredSecondaryEntitiesLink,
+    verifyConditionalCVEs,
     verifySecondaryEntities,
     visitVulnerabilityManagementEntities,
 } from '../../helpers/vulnmanagement/entities';
@@ -88,24 +88,12 @@ describe('Vulnerability Management Components', () => {
     // Argument 3 in verify functions is index of column which has the links.
     // The one-based index includes checkbox, hidden, invisible.
 
-    // Some tests might fail in local deployment.
-
-    it('should display links for all CVEs', () => {
-        verifySecondaryEntities(
+    it('should display either links for CVEs of text for No CVEs', () => {
+        verifyConditionalCVEs(
             entitiesKey,
             'cves',
             3,
-            /^\d+ CVEs?$/,
-            getCountAndNounFromCVEsLinkResults
-        );
-    });
-
-    it('should display links for fixable CVEs', () => {
-        verifyFilteredSecondaryEntitiesLink(
-            entitiesKey,
-            'cves',
-            3,
-            /^\d+ Fixable$/,
+            'vulnCounter',
             getCountAndNounFromCVEsLinkResults
         );
     });

--- a/ui/apps/platform/cypress/integration/vulnmanagement/componentsNonPostgress.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/componentsNonPostgress.test.js
@@ -88,7 +88,7 @@ describe('Vulnerability Management Components', () => {
     // Argument 3 in verify functions is index of column which has the links.
     // The one-based index includes checkbox, hidden, invisible.
 
-    it('should display either links for CVEs of text for No CVEs', () => {
+    it('should display either links for CVEs or text for No CVEs', () => {
         verifyConditionalCVEs(
             entitiesKey,
             'cves',

--- a/ui/apps/platform/cypress/integration/vulnmanagement/deployments.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/deployments.test.js
@@ -9,7 +9,7 @@ import {
     getCountAndNounFromImageCVEsLinkResults,
     hasTableColumnHeadings,
     interactAndWaitForVulnerabilityManagementEntities,
-    verifyFilteredSecondaryEntitiesLink,
+    verifyConditionalCVEs,
     verifySecondaryEntities,
     visitVulnerabilityManagementEntities,
 } from '../../helpers/vulnmanagement/entities';
@@ -81,28 +81,16 @@ describe('Vulnerability Management Deployments', () => {
     // Argument 3 in verify functions is index of column which has the links.
     // The one-based index includes checkbox, hidden, invisible.
 
-    // Some tests might fail in local deployment.
-
-    it('should display links for all image CVEs', () => {
-        verifySecondaryEntities(
-            entitiesKey,
-            'image-cves',
-            3,
-            /^\d+ CVEs?$/,
-            getCountAndNounFromImageCVEsLinkResults
-        );
-    });
-
-    it('should display links for fixable image CVEs', function () {
+    it('should display either links for image CVEs or text for No CVEs', function () {
         if (hasOrchestratorFlavor('openshift')) {
-            this.skip();
+            this.skip(); // verify and remove
         }
 
-        verifyFilteredSecondaryEntitiesLink(
+        verifyConditionalCVEs(
             entitiesKey,
             'image-cves',
             3,
-            /^\d+ Fixable$/,
+            'imageVulnerabilityCounter',
             getCountAndNounFromImageCVEsLinkResults
         );
     });

--- a/ui/apps/platform/cypress/integration/vulnmanagement/deployments.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/deployments.test.js
@@ -83,7 +83,7 @@ describe('Vulnerability Management Deployments', () => {
 
     it('should display either links for image CVEs or text for No CVEs', function () {
         if (hasOrchestratorFlavor('openshift')) {
-            this.skip(); // verify and remove
+            this.skip(); // TODO verify and remove
         }
 
         verifyConditionalCVEs(

--- a/ui/apps/platform/cypress/integration/vulnmanagement/deploymentsNonPostgress.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/deploymentsNonPostgress.test.js
@@ -8,7 +8,7 @@ import {
 import {
     hasTableColumnHeadings,
     interactAndWaitForVulnerabilityManagementEntities,
-    verifyFilteredSecondaryEntitiesLink,
+    verifyConditionalCVEs,
     verifySecondaryEntities,
     visitVulnerabilityManagementEntities,
 } from '../../helpers/vulnmanagement/entities';
@@ -100,11 +100,11 @@ describe('Vulnerability Management Deployments', () => {
     });
 
     it('should display links for fixable CVEs', () => {
-        verifyFilteredSecondaryEntitiesLink(
+        verifyConditionalCVEs(
             entitiesKey,
             'cves',
             3,
-            /^\d+ Fixable$/,
+            'vulnCounter',
             getCountAndNounFromCVEsLinkResults
         );
     });

--- a/ui/apps/platform/cypress/integration/vulnmanagement/deploymentsNonPostgress.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/deploymentsNonPostgress.test.js
@@ -89,7 +89,7 @@ describe('Vulnerability Management Deployments', () => {
 
     // Some tests might fail in local deployment.
 
-    it('should display either links for CVEs of text for No CVEs', () => {
+    it('should display either links for CVEs or text for No CVEs', () => {
         verifyConditionalCVEs(
             entitiesKey,
             'cves',

--- a/ui/apps/platform/cypress/integration/vulnmanagement/deploymentsNonPostgress.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/deploymentsNonPostgress.test.js
@@ -89,17 +89,7 @@ describe('Vulnerability Management Deployments', () => {
 
     // Some tests might fail in local deployment.
 
-    it('should display links for all CVEs', () => {
-        verifySecondaryEntities(
-            entitiesKey,
-            'cves',
-            3,
-            /^\d+ CVEs?$/,
-            getCountAndNounFromCVEsLinkResults
-        );
-    });
-
-    it('should display links for fixable CVEs', () => {
+    it('should display either links for CVEs of text for No CVEs', () => {
         verifyConditionalCVEs(
             entitiesKey,
             'cves',

--- a/ui/apps/platform/cypress/integration/vulnmanagement/imageComponents.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/imageComponents.test.js
@@ -9,7 +9,7 @@ import {
     getCountAndNounFromImageCVEsLinkResults,
     hasTableColumnHeadings,
     interactAndWaitForVulnerabilityManagementEntities,
-    verifyFilteredSecondaryEntitiesLink,
+    verifyConditionalCVEs,
     verifySecondaryEntities,
     visitVulnerabilityManagementEntities,
 } from '../../helpers/vulnmanagement/entities';
@@ -122,28 +122,16 @@ describe('Vulnerability Management Image Components', () => {
     // Argument 3 in verify functions is index of column which has the links.
     // The one-based index includes checkbox, hidden, invisible.
 
-    // Some tests might fail in local deployment.
-
-    it('should display links for all image CVEs', () => {
-        verifySecondaryEntities(
-            entitiesKey,
-            'image-cves',
-            4,
-            /^\d+ CVEs?$/,
-            getCountAndNounFromImageCVEsLinkResults
-        );
-    });
-
-    it('should display links for fixable image CVEs', function () {
+    it('should display either links for image CVEs or text for No CVEs', function () {
         if (hasOrchestratorFlavor('openshift')) {
-            this.skip();
+            this.skip(); // verify and remove
         }
 
-        verifyFilteredSecondaryEntitiesLink(
+        verifyConditionalCVEs(
             entitiesKey,
             'image-cves',
             4,
-            /^\d+ Fixable$/,
+            'vulnCounter',
             getCountAndNounFromImageCVEsLinkResults
         );
     });

--- a/ui/apps/platform/cypress/integration/vulnmanagement/imageComponents.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/imageComponents.test.js
@@ -124,7 +124,7 @@ describe('Vulnerability Management Image Components', () => {
 
     it('should display either links for image CVEs or text for No CVEs', function () {
         if (hasOrchestratorFlavor('openshift')) {
-            this.skip(); // verify and remove
+            this.skip(); // TODO verify and remove
         }
 
         verifyConditionalCVEs(

--- a/ui/apps/platform/cypress/integration/vulnmanagement/images.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/images.test.js
@@ -139,7 +139,6 @@ describe('Vulnerability Management Images', () => {
             entitiesKey,
             'image-cves',
             3,
-            /^\d+ Fixable$/,
             getCountAndNounFromImageCVEsLinkResults
         );
     });

--- a/ui/apps/platform/cypress/integration/vulnmanagement/images.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/images.test.js
@@ -1,6 +1,6 @@
 import { selectors } from '../../constants/VulnManagementPage';
 import withAuth from '../../helpers/basicAuth';
-import { hasFeatureFlag, hasOrchestratorFlavor } from '../../helpers/features';
+import { hasFeatureFlag } from '../../helpers/features';
 import {
     assertSortedItems,
     callbackForPairOfAscendingNumberValuesFromElements,
@@ -10,7 +10,7 @@ import {
     getCountAndNounFromImageCVEsLinkResults,
     hasTableColumnHeadings,
     interactAndWaitForVulnerabilityManagementEntities,
-    verifyFixableCVEsLinkAndRiskAcceptanceTabs,
+    verifyConditionalCVEs,
     verifySecondaryEntities,
     visitVulnerabilityManagementEntities,
 } from '../../helpers/vulnmanagement/entities';
@@ -118,27 +118,12 @@ describe('Vulnerability Management Images', () => {
     // Argument 3 in verify functions is index of column which has the links.
     // The one-based index includes checkbox, hidden, invisible.
 
-    // Some tests might fail in local deployment.
-
-    it('should display links for all image CVEs', () => {
-        verifySecondaryEntities(
+    it('should display either links for image CVEs or text for No CVEs', () => {
+        verifyConditionalCVEs(
             entitiesKey,
             'image-cves',
             3,
-            /^\d+ CVEs?$/,
-            getCountAndNounFromImageCVEsLinkResults
-        );
-    });
-
-    it('should display links for fixable image CVEs and also Risk Acceptance tabs', function () {
-        if (hasOrchestratorFlavor('openshift')) {
-            this.skip();
-        }
-
-        verifyFixableCVEsLinkAndRiskAcceptanceTabs(
-            entitiesKey,
-            'image-cves',
-            3,
+            'vulnCounter',
             getCountAndNounFromImageCVEsLinkResults
         );
     });

--- a/ui/apps/platform/cypress/integration/vulnmanagement/namespaces.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/namespaces.test.js
@@ -83,7 +83,7 @@ describe('Vulnerability Management Namespaces', () => {
 
     it('should display either links for image CVEs or text for No CVEs', function () {
         if (hasOrchestratorFlavor('openshift')) {
-            this.skip(); // verify and remove
+            this.skip(); // TODO verify and remove
         }
 
         verifyConditionalCVEs(

--- a/ui/apps/platform/cypress/integration/vulnmanagement/namespaces.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/namespaces.test.js
@@ -9,7 +9,7 @@ import {
     getCountAndNounFromImageCVEsLinkResults,
     hasTableColumnHeadings,
     interactAndWaitForVulnerabilityManagementEntities,
-    verifyFilteredSecondaryEntitiesLink,
+    verifyConditionalCVEs,
     verifySecondaryEntities,
     visitVulnerabilityManagementEntities,
 } from '../../helpers/vulnmanagement/entities';
@@ -81,28 +81,16 @@ describe('Vulnerability Management Namespaces', () => {
     // Argument 3 in verify functions is index of column which has the links.
     // The one-based index includes checkbox, hidden, invisible.
 
-    // Some tests might fail in local deployment.
-
-    it('should display links for all image CVEs', () => {
-        verifySecondaryEntities(
-            entitiesKey,
-            'image-cves',
-            3,
-            /^\d+ CVEs?$/,
-            getCountAndNounFromImageCVEsLinkResults
-        );
-    });
-
-    it('should display links for fixable image CVEs', function () {
+    it('should display either links for image CVEs or text for No CVEs', function () {
         if (hasOrchestratorFlavor('openshift')) {
-            this.skip();
+            this.skip(); // verify and remove
         }
 
-        verifyFilteredSecondaryEntitiesLink(
+        verifyConditionalCVEs(
             entitiesKey,
             'image-cves',
             3,
-            /^\d+ Fixable$/,
+            'imageVulnerabilityCounter',
             getCountAndNounFromImageCVEsLinkResults
         );
     });

--- a/ui/apps/platform/cypress/integration/vulnmanagement/namespacesNonPostgress.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/namespacesNonPostgress.test.js
@@ -8,7 +8,7 @@ import {
 import {
     hasTableColumnHeadings,
     interactAndWaitForVulnerabilityManagementEntities,
-    verifyFilteredSecondaryEntitiesLink,
+    verifyConditionalCVEs,
     verifySecondaryEntities,
     visitVulnerabilityManagementEntities,
 } from '../../helpers/vulnmanagement/entities';
@@ -88,24 +88,12 @@ describe('Vulnerability Management Namespaces', () => {
     // Argument 3 in verify functions is index of column which has the links.
     // The one-based index includes checkbox, hidden, invisible.
 
-    // Some tests might fail in local deployment.
-
-    it('should display links for all CVEs', () => {
-        verifySecondaryEntities(
+    it('should display either links for image CVEs or text for No CVEs', () => {
+        verifyConditionalCVEs(
             entitiesKey,
             'cves',
             3,
-            /^\d+ CVEs?$/,
-            getCountAndNounFromCVEsLinkResults
-        );
-    });
-
-    it('should display links for fixable CVEs', () => {
-        verifyFilteredSecondaryEntitiesLink(
-            entitiesKey,
-            'cves',
-            3,
-            /^\d+ Fixable$/,
+            'vulnCounter',
             getCountAndNounFromCVEsLinkResults
         );
     });

--- a/ui/apps/platform/cypress/integration/vulnmanagement/nodeComponents.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/nodeComponents.test.js
@@ -9,7 +9,7 @@ import {
     getCountAndNounFromNodeCVEsLinkResults,
     hasTableColumnHeadings,
     interactAndWaitForVulnerabilityManagementEntities,
-    verifyFilteredSecondaryEntitiesLink,
+    verifyConditionalCVEs,
     verifySecondaryEntities,
     visitVulnerabilityManagementEntities,
 } from '../../helpers/vulnmanagement/entities';
@@ -124,32 +124,16 @@ describe('Vulnerability Management Node Components', () => {
     // Argument 3 in verify functions is index of column which has the links.
     // The one-based index includes checkbox, hidden, invisible.
 
-    // Some tests might fail in local deployment.
-
-    it('should display links for all node CVEs', function () {
+    it('should display either links for node CVEs or text for No CVEs', function () {
         if (hasOrchestratorFlavor('openshift')) {
-            this.skip();
+            this.skip(); // TODO verify and remove
         }
 
-        verifySecondaryEntities(
+        verifyConditionalCVEs(
             entitiesKey,
             'node-cves',
             4,
-            /^\d+ CVEs?$/,
-            getCountAndNounFromNodeCVEsLinkResults
-        );
-    });
-
-    it('should display links for fixable node CVEs', function () {
-        if (hasOrchestratorFlavor('openshift')) {
-            this.skip();
-        }
-
-        verifyFilteredSecondaryEntitiesLink(
-            entitiesKey,
-            'node-cves',
-            4,
-            /^\d+ Fixable$/,
+            'vulnCounter',
             getCountAndNounFromNodeCVEsLinkResults
         );
     });

--- a/ui/apps/platform/cypress/integration/vulnmanagement/policies.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/policies.test.js
@@ -10,7 +10,7 @@ import {
 import {
     hasTableColumnHeadings,
     interactAndWaitForVulnerabilityManagementEntities,
-    verifyFilteredSecondaryEntitiesLink,
+    verifyLinkCountShallow,
     visitVulnerabilityManagementEntities,
 } from '../../helpers/vulnmanagement/entities';
 
@@ -90,7 +90,7 @@ describe('Vulnerability Management Policies', () => {
             this.skip();
         }
 
-        verifyFilteredSecondaryEntitiesLink(
+        verifyLinkCountShallow(
             entitiesKey,
             'deployments',
             10,

--- a/ui/apps/platform/cypress/integration/vulnmanagement/policies.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/policies.test.js
@@ -10,7 +10,7 @@ import {
 import {
     hasTableColumnHeadings,
     interactAndWaitForVulnerabilityManagementEntities,
-    verifyLinkCountShallow,
+    verifyConditionalFailingDeployments,
     visitVulnerabilityManagementEntities,
 } from '../../helpers/vulnmanagement/entities';
 
@@ -82,21 +82,12 @@ describe('Vulnerability Management Policies', () => {
     // Argument 3 in verify functions is index of column which has the links.
     // The one-based index includes checkbox, hidden, invisible.
 
-    // Some tests might fail in local deployment.
-
-    // ROX-15891 ROX-15985: skip until decision whether valid to assume high severity violations.
-    it.skip('should display links for failing deployments', function () {
+    it('should display either links for failing deployments or text for No failing deployments', function () {
         if (hasOrchestratorFlavor('openshift')) {
-            this.skip();
+            this.skip(); // TODO verify and remove
         }
 
-        verifyLinkCountShallow(
-            entitiesKey,
-            'deployments',
-            10,
-            /^\d+ failing deployments?$/,
-            getPanelHeaderTextFromLinkResults
-        );
+        verifyConditionalFailingDeployments(10, getPanelHeaderTextFromLinkResults);
     });
 
     describe('post-Boolean Policy Logic tests', () => {


### PR DESCRIPTION
## Description

This conditional testing pattern is safe only if all conditional rendering scenarios are likely to occur. It is risky for edge cases that rarely occur.

### Problem

Intermittant test failures if links do not exist for fixable vulnerabilies or failing deployments:

> Timed out retrying after 4000ms: Expected to find content: '/^\d+ Fixable$/' within the element: <div.rt-td.w-1/8.p-2.flex.items-center.font-600.text-base-600.text-left.border-r-0.leading-normal> and with the selector: 'a' but never did.
![node-components-prow](https://user-images.githubusercontent.com/11862657/236241661-20e06441-51f4-45f1-bf1e-d6dade671074.png)

> Timed out retrying after 4000ms: Expected to find content: '/^\d+ failing deployments?$/' within the element: <div.rt-td.w-1/8.p-2.flex.items-center.font-600.text-base-600.text-left.border-r-0.leading-normal> and with the selector: 'a' but never did.

### Analysis

Tests make an **invalid assumption** that images, nodes, or clusters always have vulnerabilities.

### Solution

Use response as **source of truth** to make conditional assertions for existence or non-existence of DOM elements in **all** conditional rendering scenarios.

For more information:
https://docs.cypress.io/guides/core-concepts/conditional-testing#docusaurus_skipToContent_fallback

1. Return interceptions from `visit` helper function.

2. Refactor Vulnerability Management helpers to provide new functions:

    * `verifyConditionalCVEs` for **Fixable** link, **CVEs** link, or **No CVEs** text.

    * `verifyConditionalFailingDeployments` for **failing deployments** link or **No failing deployments** text.

3. Merge all CVEs and fixable CVEs tests.

### Residue

1. Test on OpenShift, and then remove skip.
2. Move constants and helpers files into vulnmanagement folder.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed

### Integration testing

1. `yarn cyress-open` in ui/apps/platform

    * vulnmanagement/clusters.test.js
    * vulnmanagement/componentsNonPostgress.test.js skipped
    * vulnmanagement/deployments.test.js
    * vulnmanagement/deploymentsNonPostgress.test.js skipped
    * vulnmanagement/imageComponents.test.js
    * vulnmanagement/images.test.js
    * vulnmanagement/namespaces.test.js
    * vulnmanagement/namespacesNonPostgress.test.js skipped
    * vulnmanagement/nodeComponents.test.js
    * vulnmanagement/policies.test.js

### Manual testing

1. Look for keys in responses in browser Network panel.
2. Temporarily edit conditional rendering for data cell and `hasWhatever` assignments in tests to verify conditional helper for all scenarios.
