### PR TITLE
Add type annotations to date utils file

### DIFF
--- a/ui/apps/platform/src/Containers/VulnMgmt/Reports/Components/ScheduleText.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Reports/Components/ScheduleText.tsx
@@ -17,7 +17,7 @@ function ScheduleText({ schedule }: ScheduleTextProps): ReactElement {
 
     const dayListType = schedule?.intervalType === 'WEEKLY' ? 'daysOfWeek' : 'daysOfMonth';
 
-    const dayList = getDayList(schedule?.intervalType, schedule[dayListType]?.days);
+    const dayList = getDayList(schedule?.intervalType, schedule[dayListType]?.days ?? []);
 
     // Intl.ListFormat is in ES2021
     //   rather than install a 3rd-party polyfill, if it's not present we fall back to just a comma-separated list

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageHeader.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageHeader.tsx
@@ -38,7 +38,7 @@ function DeploymentPageHeader({ data }: DeploymentPageHeaderProps) {
                     In: {data.clusterName}/{data.namespace}
                 </Label>
                 <Label isCompact>Images: {data.imageCount}</Label>
-                <Label isCompact>Created: {getDateTime(data.created)}</Label>
+                {data.created && <Label isCompact>Created: {getDateTime(data.created)}</Label>}
             </LabelGroup>
         </Flex>
     ) : (

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePageHeader.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePageHeader.tsx
@@ -28,9 +28,11 @@ function ImageCvePageHeader({ data }: ImageCvePageHeaderProps) {
                 {data.cve}
             </Title>
             <LabelGroup numLabels={1}>
-                <Label isCompact>
-                    First discovered in system {getDateTime(data.firstDiscoveredInSystem)}
-                </Label>
+                {data.firstDiscoveredInSystem && (
+                    <Label isCompact>
+                        First discovered in system {getDateTime(data.firstDiscoveredInSystem)}
+                    </Label>
+                )}
             </LabelGroup>
             <Text>
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam vel aliquet velit.

--- a/ui/apps/platform/src/types/report.proto.ts
+++ b/ui/apps/platform/src/types/report.proto.ts
@@ -48,6 +48,9 @@ export type IntervalType = 'UNSET' | 'DAILY' | 'WEEKLY' | 'MONTHLY';
 
 export type Interval = DaysOfWeek | DaysOfMonth;
 
+// TODO - Note that the types of `days` below are not exact, the API returns `number[]`, but the UI converts
+// them to strings. This doesn't seem to be a problem, but it's worth noting.
+
 // Sunday = 0, Monday = 1, .... Saturday =  6
 export type DaysOfWeek = {
     days: string[]; // int32

--- a/ui/apps/platform/src/utils/dateUtils.ts
+++ b/ui/apps/platform/src/utils/dateUtils.ts
@@ -1,31 +1,34 @@
 import { distanceInWordsStrict, format, addDays } from 'date-fns';
 
 import dateTimeFormat, { dateFormat, timeFormat } from 'constants/dateTimeFormat';
+import { IntervalType } from 'types/report.proto';
+
+type DateLike = string | number | Date;
 
 /**
  * Returns a formatted date and time
- * @param {string | Date} timestamp - The timestamp for the date and time
+ * @param {DateLike} timestamp - The timestamp for the date and time
  * @returns {string} - returns a formatted string for the date time
  */
-export function getDateTime(timestamp) {
+export function getDateTime(timestamp: DateLike) {
     return format(timestamp, dateTimeFormat);
 }
 
 /**
  * Returns a formatted date
- * @param {string | Date} timestamp - The timestamp for the date
+ * @param {DateLike} timestamp - The timestamp for the date
  * @returns {string} - returns a formatted string for the date
  */
-export function getDate(timestamp) {
+export function getDate(timestamp: DateLike) {
     return format(timestamp, dateFormat);
 }
 
 /**
  * Returns a formatted time
- * @param {string | Date} timestamp - The timestamp for the date
+ * @param {DateLike} timestamp - The timestamp for the date
  * @returns {string} - returns a formatted string for the time
  */
-export function getTime(timestamp) {
+export function getTime(timestamp: DateLike) {
     return format(timestamp, timeFormat);
 }
 
@@ -45,18 +48,26 @@ export function getLatestDatedItemByKey<T>(key: string | null, list: T[] = []): 
     }, null);
 }
 
-export function addBrandedTimestampToString(str) {
-    return `StackRox:${str as string}-${format(new Date(), dateFormat)}`;
+export function addBrandedTimestampToString(str: string) {
+    return `StackRox:${str}-${format(new Date(), dateFormat)}`;
 }
 
-const daysOfWeek = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+const daysOfWeek = [
+    'Sunday',
+    'Monday',
+    'Tuesday',
+    'Wednesday',
+    'Thursday',
+    'Friday',
+    'Saturday',
+] as const;
 
 /**
  * Given an ISO 8601 string, return the day of the week.
  *
  * date-fns@2: replace new Date(timestamp).getDay() with getDay(parseISO(timestamp))
  */
-export const getDayOfWeek = (timestamp) => daysOfWeek[new Date(timestamp).getDay()];
+export const getDayOfWeek = (timestamp: DateLike) => daysOfWeek[new Date(timestamp).getDay()];
 
 /*
  * Given an ISO 8601 string and Date instance, return the time difference.
@@ -64,8 +75,11 @@ export const getDayOfWeek = (timestamp) => daysOfWeek[new Date(timestamp).getDay
  * Specify rounding method explicitly because default changes to 'round' in date-fns@2.
  * formatDistanceStrict(currentDatetime, parseISO(dataDatetime), { roundingMethod: 'floor' });
  */
-export const getDistanceStrict = (dataDatetime, currentDatetime, options) =>
-    distanceInWordsStrict(dataDatetime, currentDatetime, options);
+export const getDistanceStrict: typeof distanceInWordsStrict = (
+    dataDatetime,
+    currentDatetime,
+    options
+) => distanceInWordsStrict(dataDatetime, currentDatetime, options);
 //
 /*
  * Given an ISO 8601 string and Date instance, return the time difference:
@@ -76,13 +90,13 @@ export const getDistanceStrict = (dataDatetime, currentDatetime, options) =>
  * Also the order of the arguments is reversed in date-fns@2
  * formatDistanceStrict(parseISO(dataDatetime), currentDatetime, { roundingMethod: 'floor', addSuffix: true });
  */
-export const getDistanceStrictAsPhrase = (dataDatetime, currentDatetime) =>
+export const getDistanceStrictAsPhrase = (dataDatetime: DateLike, currentDatetime: DateLike) =>
     distanceInWordsStrict(currentDatetime, dataDatetime, {
         addSuffix: true,
         partialMethod: 'floor',
     });
 
-export const addDaysToDate = (date, amount: number) => {
+export const addDaysToDate = (date: DateLike, amount: number) => {
     return format(addDays(date, amount + 1), 'YYYY-MM-DD[T]HH:mm:ss.SSSSSSSSS[Z]');
 };
 
@@ -101,7 +115,9 @@ const monthDays = [
     { key: 15, dayName: 'the middle of the month' },
 ];
 
-export function getDayList(dayListType, days) {
+// TODO The type of `days` is always `number[]` but it can't be annotated here due
+// to some type mismatches elsewhere.
+export function getDayList(dayListType: IntervalType, days) {
     const dayNameConstants = dayListType === 'WEEKLY' ? weekDays : monthDays;
 
     const dayNameArray = dayNameConstants.reduce((acc: string[], constant) => {


### PR DESCRIPTION
## Description

Adds types to our date utils, which previsouly inferred `any` for all functions.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Type level change only.
