### PR TITLE
Add missing CVSS to ImageCVE page Images table

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/SummaryCards/TopCvssScoreBreakdown.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/SummaryCards/TopCvssScoreBreakdown.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Card, CardTitle, CardBody, Flex, Tooltip, Text } from '@patternfly/react-core';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
+import CvssTd from '../components/CvssTd';
 
 export type TopCvssScoreBreakdownProps = {
     className?: string;
@@ -19,7 +20,9 @@ function TopCvssScoreBreakdown({ className, cvssScore, vector }: TopCvssScoreBre
             </CardTitle>
             <CardBody>
                 <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsSm' }}>
-                    <Text>{cvssScore.toFixed(1)}</Text>
+                    <Text>
+                        <CvssTd cvss={cvssScore} />
+                    </Text>
                     <Text className="pf-u-color-200">{vector}</Text>
                 </Flex>
             </CardBody>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedImagesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedImagesTable.tsx
@@ -30,6 +30,7 @@ import ImageComponentVulnerabilitiesTable, {
 } from './ImageComponentVulnerabilitiesTable';
 import EmptyTableResults from '../components/EmptyTableResults';
 import DatePhraseTd from '../components/DatePhraseTd';
+import CvssTd from '../components/CvssTd';
 
 export type ImageForCve = {
     id: string;
@@ -148,7 +149,7 @@ function AffectedImagesTable({ images, getSortParams, isFiltered }: AffectedImag
                                 </span>
                             </Td>
                             <Td dataLabel="CVSS">
-                                {cvss.toFixed(1)} ({scoreVersion})
+                                <CvssTd cvss={cvss} scoreVersion={scoreVersion} />
                             </Td>
                             <Td dataLabel="Fix status">
                                 <span>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/CVEsTable.tsx
@@ -19,6 +19,7 @@ import { getEntityPagePath } from '../searchUtils';
 import SeverityCountLabels from '../components/SeverityCountLabels';
 import { DynamicColumnIcon } from '../components/DynamicIcon';
 import DatePhraseTd from '../components/DatePhraseTd';
+import CvssTd from '../components/CvssTd';
 
 export const cveListQuery = gql`
     query getImageCVEList($query: String, $pagination: Pagination) {
@@ -145,7 +146,9 @@ function CVEsTable({ cves, unfilteredImageCount, getSortParams, isFiltered }: CV
                                     />
                                 </Td>
                                 {/* TODO: score version? */}
-                                <Td>{topCVSS.toFixed(1)}</Td>
+                                <Td>
+                                    <CvssTd cvss={topCVSS} />
+                                </Td>
                                 <Td>
                                     {/* TODO: fix upon PM feedback */}
                                     {affectedImageCount}/{unfilteredImageCount} affected images

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentComponentVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentComponentVulnerabilitiesTable.tsx
@@ -15,6 +15,7 @@ import {
 import FixedByVersionTd from '../components/FixedByVersionTd';
 import DockerfileLayerTd from '../components/DockerfileLayerTd';
 import ComponentLocationTd from '../components/ComponentLocationTd';
+import CvssTd from '../components/CvssTd';
 
 export { imageMetadataContextFragment };
 export type { ImageMetadataContext, DeploymentComponentVulnerability };
@@ -110,7 +111,7 @@ function DeploymentComponentVulnerabilitiesTable({
                                 <VulnerabilitySeverityIconText severity={severity} />
                             </Td>
                             <Td>
-                                {cvss.toFixed(1)} ({scoreVersion})
+                                <CvssTd cvss={cvss} scoreVersion={scoreVersion} />
                             </Td>
                             <Td>{version}</Td>
                             <Td>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
@@ -28,6 +28,7 @@ import ImageComponentVulnerabilitiesTable, {
 
 import EmptyTableResults from '../components/EmptyTableResults';
 import DatePhraseTd from '../components/DatePhraseTd';
+import CvssTd from '../components/CvssTd';
 
 export const imageVulnerabilitiesFragment = gql`
     ${imageComponentVulnerabilitiesFragment}
@@ -153,7 +154,7 @@ function ImageVulnerabilitiesTable({
                                     </span>
                                 </Td>
                                 <Td dataLabel="CVSS">
-                                    {cvss.toFixed(1)} ({scoreVersion})
+                                    <CvssTd cvss={cvss} scoreVersion={scoreVersion} />
                                 </Td>
                                 <Td dataLabel="Affected components">
                                     {imageComponents.length === 1

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/table.utils.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/table.utils.ts
@@ -242,3 +242,20 @@ export function getAnyVulnerabilityIsFixable(
         component.imageVulnerabilities.some(({ fixedByVersion }) => fixedByVersion !== '')
     );
 }
+
+export function getHighestCvssScore(imageComponents: ImageComponentVulnerability[]): {
+    cvss: number;
+    scoreVersion: string;
+} {
+    let topCvss = 0;
+    let topScoreVersion = 'N/A';
+    imageComponents.forEach((component) => {
+        component.imageVulnerabilities.forEach(({ cvss, scoreVersion }) => {
+            if (cvss > topCvss) {
+                topCvss = cvss;
+                topScoreVersion = scoreVersion;
+            }
+        });
+    });
+    return { cvss: topCvss, scoreVersion: topScoreVersion };
+}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/CvssTd.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/CvssTd.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+export type CvssTdProps = {
+    cvss: number;
+    scoreVersion?: string;
+};
+
+function CvssTd({ cvss, scoreVersion }: CvssTdProps) {
+    return (
+        <>
+            {cvss.toFixed(1)} {scoreVersion ? `(${scoreVersion})` : null}
+        </>
+    );
+}
+
+export default CvssTd;


### PR DESCRIPTION
## Description

As titled.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Visit a CVE single page, and view that the CVSS is present in the top level of the table.
![image](https://user-images.githubusercontent.com/1292638/236272929-7edac1ea-bcbe-4b7c-ae02-be7b84c3a59d.png)

