### PR TITLE
Update WorkloadCVE table layouts to fit columns and avoid wrapping.

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities.tsx
@@ -258,11 +258,13 @@ function DeploymentPageVulnerabilities({ deploymentId }: DeploymentPageVulnerabi
                                     </Bullseye>
                                 )}
                                 {vulnerabilityData && (
-                                    <DeploymentVulnerabilitiesTable
-                                        deployment={vulnerabilityData.deployment}
-                                        getSortParams={getSortParams}
-                                        isFiltered={isFiltered}
-                                    />
+                                    <div className="workload-cves-table-container">
+                                        <DeploymentVulnerabilitiesTable
+                                            deployment={vulnerabilityData.deployment}
+                                            getSortParams={getSortParams}
+                                            isFiltered={isFiltered}
+                                        />
+                                    </div>
                                 )}
                             </div>
                         </div>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
@@ -190,11 +190,13 @@ function ImagePageVulnerabilities({ imageId }: ImagePageVulnerabilitiesProps) {
                             />
                         </SplitItem>
                     </Split>
-                    <ImageVulnerabilitiesTable
-                        image={vulnerabilityData.image}
-                        getSortParams={getSortParams}
-                        isFiltered={isFiltered}
-                    />
+                    <div className="workload-cves-table-container">
+                        <ImageVulnerabilitiesTable
+                            image={vulnerabilityData.image}
+                            getSortParams={getSortParams}
+                            isFiltered={isFiltered}
+                        />
+                    </div>
                 </div>
             </>
         );

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
@@ -400,7 +400,7 @@ function ImageCvePage() {
                             {tableDataAvailable && (
                                 <>
                                     <Divider />
-                                    <div className="pf-u-px-lg">
+                                    <div className="pf-u-px-lg workload-cves-table-container">
                                         {entityTab === 'Image' && (
                                             <AffectedImagesTable
                                                 images={imageData?.images ?? []}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/CVEsTableContainer.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/CVEsTableContainer.tsx
@@ -67,12 +67,14 @@ function CVEsTableContainer({ defaultFilters, countsData }: CVEsTableContainerPr
                 <TableErrorComponent error={error} message="Adjust your filters and try again" />
             )}
             {tableData && (
-                <CVEsTable
-                    cves={tableData.imageCVEs}
-                    unfilteredImageCount={imageCountData?.imageCount || 0}
-                    getSortParams={getSortParams}
-                    isFiltered={isFiltered}
-                />
+                <div className="workload-cves-table-container">
+                    <CVEsTable
+                        cves={tableData.imageCVEs}
+                        unfilteredImageCount={imageCountData?.imageCount || 0}
+                        getSortParams={getSortParams}
+                        isFiltered={isFiltered}
+                    />
+                </div>
             )}
         </>
     );

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/DeploymentsTableContainer.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/DeploymentsTableContainer.tsx
@@ -67,11 +67,13 @@ function DeploymentsTableContainer({ defaultFilters, countsData }: DeploymentsTa
                 <TableErrorComponent error={error} message="Adjust your filters and try again" />
             )}
             {tableData && (
-                <DeploymentsTable
-                    deployments={tableData.deployments}
-                    getSortParams={getSortParams}
-                    isFiltered={isFiltered}
-                />
+                <div className="workload-cves-table-container">
+                    <DeploymentsTable
+                        deployments={tableData.deployments}
+                        getSortParams={getSortParams}
+                        isFiltered={isFiltered}
+                    />
+                </div>
             )}
         </>
     );

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/ImagesTableContainer.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/ImagesTableContainer.tsx
@@ -66,11 +66,13 @@ function ImagesTableContainer({ defaultFilters, countsData }: ImagesTableContain
                 <TableErrorComponent error={error} message="Adjust your filters and try again" />
             )}
             {tableData && (
-                <ImagesTable
-                    images={tableData.images}
-                    getSortParams={getSortParams}
-                    isFiltered={isFiltered}
-                />
+                <div className="workload-cves-table-container">
+                    <ImagesTable
+                        images={tableData.images}
+                        getSortParams={getSortParams}
+                        isFiltered={isFiltered}
+                    />
+                </div>
             )}
         </>
     );

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedDeploymentsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedDeploymentsTable.tsx
@@ -79,7 +79,7 @@ function AffectedDeploymentsTable({
         // TODO UX question - Collapse to cards, or allow headers to overflow?
         // <TableComposable gridBreakPoint="grid-xl">
         <TableComposable variant="compact">
-            <Thead>
+            <Thead noWrap>
                 <Tr>
                     <Th>{/* Header for expanded column */}</Th>
                     <Th sort={getSortParams('Deployment')}>Deployment</Th>
@@ -143,7 +143,7 @@ function AffectedDeploymentsTable({
                                     </Button>{' '}
                                 </Flex>
                             </Td>
-                            <Td dataLabel="Images by severity">
+                            <Td modifier="nowrap" dataLabel="Images by severity">
                                 <SeverityCountLabels
                                     critical={criticalImageCount}
                                     important={importantImageCount}
@@ -153,9 +153,11 @@ function AffectedDeploymentsTable({
                             </Td>
                             <Td dataLabel="Cluster">{clusterName}</Td>
                             <Td dataLabel="Namespace">{namespace}</Td>
-                            <Td dataLabel="Images">{pluralize(imageCount, 'image')}</Td>
+                            <Td modifier="nowrap" dataLabel="Images">
+                                {pluralize(imageCount, 'image')}
+                            </Td>
 
-                            <Td dataLabel="First discovered">
+                            <Td modifier="nowrap" dataLabel="First discovered">
                                 <DatePhraseTd date={created} />
                             </Td>
                         </Tr>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedImagesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedImagesTable.tsx
@@ -91,7 +91,7 @@ function AffectedImagesTable({ images, getSortParams, isFiltered }: AffectedImag
         // TODO UX question - Collapse to cards, or allow headers to overflow?
         // <TableComposable gridBreakPoint="grid-xl">
         <TableComposable variant="compact">
-            <Thead>
+            <Thead noWrap>
                 <Tr>
                     <Th>{/* Header for expanded column */}</Th>
                     <Th sort={getSortParams('Image')}>Image</Th>
@@ -138,7 +138,7 @@ function AffectedImagesTable({ images, getSortParams, isFiltered }: AffectedImag
                                     'Image name not available'
                                 )}
                             </Td>
-                            <Td dataLabel="Severity">
+                            <Td dataLabel="Severity" modifier="nowrap">
                                 <span>
                                     {SeverityIcon && (
                                         <SeverityIcon className="pf-u-display-inline" />
@@ -148,10 +148,10 @@ function AffectedImagesTable({ images, getSortParams, isFiltered }: AffectedImag
                                     )}
                                 </span>
                             </Td>
-                            <Td dataLabel="CVSS">
+                            <Td dataLabel="CVSS" modifier="nowrap">
                                 <CvssTd cvss={cvss} scoreVersion={scoreVersion} />
                             </Td>
-                            <Td dataLabel="Fix status">
+                            <Td dataLabel="Fix status" modifier="nowrap">
                                 <span>
                                     <FixabilityIcon className="pf-u-display-inline" />
                                     <span className="pf-u-pl-sm">

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/CVEsTable.tsx
@@ -78,7 +78,7 @@ function CVEsTable({ cves, unfilteredImageCount, getSortParams, isFiltered }: CV
     const expandedRowSet = useSet<string>();
     return (
         <TableComposable borders={false} variant="compact">
-            <Thead>
+            <Thead noWrap>
                 {/* TODO: need to double check sorting on columns  */}
                 <Tr>
                     <Th>{/* Header for expanded column */}</Th>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentComponentVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentComponentVulnerabilitiesTable.tsx
@@ -65,14 +65,14 @@ function DeploymentComponentVulnerabilitiesTable({
             }}
             borders={false}
         >
-            <Thead>
+            <Thead noWrap>
                 <Tr>
                     <Th sort={getSortParams('Image')}>Image</Th>
                     <Th sort={getSortParams('Component')}>Component</Th>
-                    <Th>CVE Severity</Th>
+                    <Th>CVE severity</Th>
                     <Th>CVSS</Th>
                     <Th>Version</Th>
-                    <Th>CVE Fixed in</Th>
+                    <Th>CVE fixed in</Th>
                     <Th>Location</Th>
                 </Tr>
             </Thead>
@@ -107,14 +107,14 @@ function DeploymentComponentVulnerabilitiesTable({
                                 )}
                             </Td>
                             <Td>{name}</Td>
-                            <Td>
+                            <Td modifier="nowrap">
                                 <VulnerabilitySeverityIconText severity={severity} />
                             </Td>
-                            <Td>
+                            <Td modifier="nowrap">
                                 <CvssTd cvss={cvss} scoreVersion={scoreVersion} />
                             </Td>
                             <Td>{version}</Td>
-                            <Td>
+                            <Td modifier="nowrap">
                                 <FixedByVersionTd fixedByVersion={fixedByVersion} />
                             </Td>
                             <Td>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx
@@ -133,7 +133,7 @@ function DeploymentVulnerabilitiesTable({
 
     return (
         <TableComposable variant="compact">
-            <Thead>
+            <Thead noWrap>
                 <Tr>
                     <Th>{/* Header for expanded column */}</Th>
                     <Th sort={getSortParams('CVE')}>CVE</Th>
@@ -184,10 +184,10 @@ function DeploymentVulnerabilitiesTable({
                                     {cve}
                                 </Button>
                             </Td>
-                            <Td dataLabel="Severity">
+                            <Td modifier="nowrap" dataLabel="Severity">
                                 <VulnerabilitySeverityIconText severity={severity} />
                             </Td>
-                            <Td dataLabel="CVE Status">
+                            <Td modifier="nowrap" dataLabel="CVE Status">
                                 <span>
                                     <FixabilityIcon className="pf-u-display-inline" />
                                     <span className="pf-u-pl-sm">
@@ -196,7 +196,7 @@ function DeploymentVulnerabilitiesTable({
                                 </span>
                             </Td>
                             <Td dataLabel="Affected components">{affectedComponentsText}</Td>
-                            <Td dataLabel="First discovered">
+                            <Td modifier="nowrap" dataLabel="First discovered">
                                 <DatePhraseTd date={discoveredAtImage} />
                             </Td>
                         </Tr>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentsTable.tsx
@@ -64,7 +64,7 @@ type DeploymentsTableProps = {
 function DeploymentsTable({ deployments, getSortParams, isFiltered }: DeploymentsTableProps) {
     return (
         <TableComposable borders={false} variant="compact">
-            <Thead>
+            <Thead noWrap>
                 {/* TODO: need to double check sorting on columns  */}
                 <Tr>
                     <Th sort={getSortParams('Deployment')}>Deployment</Th>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageComponentVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageComponentVulnerabilitiesTable.tsx
@@ -59,7 +59,7 @@ function ImageComponentVulnerabilitiesTable({
             }}
             borders={false}
         >
-            <Thead>
+            <Thead noWrap>
                 <Tr>
                     <Th sort={getSortParams('Component')}>Component</Th>
                     <Th>Version</Th>
@@ -89,7 +89,7 @@ function ImageComponentVulnerabilitiesTable({
                         <Tr>
                             <Td>{name}</Td>
                             <Td>{version}</Td>
-                            <Td>
+                            <Td modifier="nowrap">
                                 <FixedByVersionTd fixedByVersion={fixedByVersion} />
                             </Td>
                             <Td>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
@@ -76,7 +76,7 @@ function ImageVulnerabilitiesTable({
 
     return (
         <TableComposable variant="compact">
-            <Thead>
+            <Thead noWrap>
                 <Tr>
                     <Th>{/* Header for expanded column */}</Th>
                     <Th sort={getSortParams('CVE')}>CVE</Th>
@@ -135,7 +135,7 @@ function ImageVulnerabilitiesTable({
                                         {cve}
                                     </Button>
                                 </Td>
-                                <Td dataLabel="Severity">
+                                <Td modifier="nowrap" dataLabel="Severity">
                                     <span>
                                         {SeverityIcon && (
                                             <SeverityIcon className="pf-u-display-inline" />
@@ -145,7 +145,7 @@ function ImageVulnerabilitiesTable({
                                         )}
                                     </span>
                                 </Td>
-                                <Td dataLabel="CVE Status">
+                                <Td modifier="nowrap" dataLabel="CVE Status">
                                     <span>
                                         <FixabilityIcon className="pf-u-display-inline" />
                                         <span className="pf-u-pl-sm">
@@ -153,7 +153,7 @@ function ImageVulnerabilitiesTable({
                                         </span>
                                     </span>
                                 </Td>
-                                <Td dataLabel="CVSS">
+                                <Td modifier="nowrap" dataLabel="CVSS">
                                     <CvssTd cvss={cvss} scoreVersion={scoreVersion} />
                                 </Td>
                                 <Td dataLabel="Affected components">

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImagesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImagesTable.tsx
@@ -83,7 +83,7 @@ type ImagesTableProps = {
 function ImagesTable({ images, getSortParams, isFiltered }: ImagesTableProps) {
     return (
         <TableComposable borders={false} variant="compact">
-            <Thead>
+            <Thead noWrap>
                 {/* TODO: need to double check sorting on columns  */}
                 <Tr>
                     <Th sort={getSortParams('Image')}>Image</Th>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesPage.css
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesPage.css
@@ -1,0 +1,3 @@
+.workload-cves-table-container {
+  overflow-x: auto;
+}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesPage.tsx
@@ -16,6 +16,8 @@ import ImagePage from './Image/ImagePage';
 import WorkloadCvesOverviewPage from './Overview/WorkloadCvesOverviewPage';
 import ImageCvePage from './ImageCve/ImageCvePage';
 
+import './WorkloadCvesPage.css';
+
 function WorkloadCvesPage() {
     return (
         <Switch>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/FixedByVersionTd.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/FixedByVersionTd.tsx
@@ -10,8 +10,14 @@ function FixedByVersionTd({ fixedByVersion }: FixedByVersionTdProps) {
     return fixedByVersion !== '' ? (
         <>{fixedByVersion}</>
     ) : (
-        <Flex alignItems={{ default: 'alignItemsCenter' }} spaceItems={{ default: 'spaceItemsSm' }}>
-            <NotFixableIcon />
+        <Flex
+            alignItems={{ default: 'alignItemsCenter' }}
+            spaceItems={{ default: 'spaceItemsSm' }}
+            flexWrap={{ default: 'nowrap' }}
+        >
+            <div className="pf-u-flex-basis-auto">
+                <NotFixableIcon />
+            </div>
             <span>Not fixable</span>
         </Flex>
     );

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/SeverityCountLabels.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/SeverityCountLabels.tsx
@@ -34,7 +34,7 @@ function SeverityCountLabels({
     const LowIcon = SeverityIcons.LOW_VULNERABILITY_SEVERITY;
 
     return (
-        <Flex spaceItems={{ default: 'spaceItemsSm' }}>
+        <Flex spaceItems={{ default: 'spaceItemsSm' }} flexWrap={{ default: 'nowrap' }}>
             <Tooltip content={getTooltipContent(critical, 'critical', entity)}>
                 <Label
                     variant="outline"


### PR DESCRIPTION
## Description

*Note that this is easier to review with "Hide whitespace" enabled*

Fixes the table layouts to avoid overly small columns by doing the following:

- Setting all table headers to `noWrap`, which ensures each column will never be smaller than the length of its text
- Setting `noWrap` on table cells that look bad when wrapping, and do not have unbounded length (most of the cells containing icons)
- Allowing tables to grow larger than their container, and when they do, adding a horizontal scrollbar consistent with other pages in the app

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Table with ample space:
![image](https://github.com/stackrox/stackrox/assets/1292638/6900bd8a-e734-4255-b4b0-542692f1d534)

Reduced space:
![image](https://github.com/stackrox/stackrox/assets/1292638/5054687d-c508-4498-a67a-38beff474086)

Cramped/horizontal scroll:
![image](https://github.com/stackrox/stackrox/assets/1292638/ca501e02-4685-4389-9af5-a75368f76713)
![image](https://github.com/stackrox/stackrox/assets/1292638/5a4785ee-3cb9-4293-bac2-3e5b9c7c1601)

