### PR TITLE
Change rules to run BAT QA tests only in PR context without the label

### DIFF
--- a/qa-tests-backend/scripts/run-part-1.sh
+++ b/qa-tests-backend/scripts/run-part-1.sh
@@ -84,7 +84,10 @@ test_part_1() {
     rm -f FAIL
     local test_target
 
-    if is_in_PR_context && pr_has_label ci-all-qa-tests; then
+    if is_openshift_CI_rehearse_PR; then
+        info "On an openshift rehearse PR, running BAT tests only..."
+        test_target="bat-test"
+    elif is_in_PR_context && pr_has_label ci-all-qa-tests; then
         info "ci-all-qa-tests label was specified, so running all QA tests..."
         test_target="test"
     elif is_in_PR_context; then

--- a/qa-tests-backend/scripts/run-part-1.sh
+++ b/qa-tests-backend/scripts/run-part-1.sh
@@ -84,27 +84,15 @@ test_part_1() {
     rm -f FAIL
     local test_target
 
-    if is_openshift_CI_rehearse_PR; then
-        info "On an openshift rehearse PR, running BAT tests only..."
-        test_target="bat-test"
-    elif is_in_PR_context && pr_has_label ci-all-qa-tests; then
+    if is_in_PR_context && pr_has_label ci-all-qa-tests; then
         info "ci-all-qa-tests label was specified, so running all QA tests..."
         test_target="test"
     elif is_in_PR_context; then
         info "In a PR context without ci-all-qa-tests, running BAT tests only..."
         test_target="bat-test"
-    elif is_nightly_run; then
-        info "Nightly tests, running all QA tests..."
-        test_target="test"
-    elif is_tagged; then
-        info "Tagged, running all QA tests..."
-        test_target="test"
-    elif [[ -n "${QA_TEST_TARGET:-}" ]]; then
-        info "Directed to run the '""${QA_TEST_TARGET}""' target..."
-        test_target="${QA_TEST_TARGET}"
     else
-        info "An unexpected context. Defaulting to BAT tests only..."
-        test_target="bat-test"
+        info "Running all QA tests by default..."
+        test_target="test"
     fi
 
     update_job_record "test_target" "${test_target}"


### PR DESCRIPTION
## Description

This follows up on https://github.com/openshift/release/pull/38678#discussion_r1179631178 discussion.

- This eliminates `QA_TEST_TARGET` environment variable.
- Rehearse tests will run as full tests after the change. I hope that's not a big impact in terms of costs and waiting time, but more confidence. Although, I can restore the rule to do BAT there.
- This also fixes the problem that postsubmit postgres-qa-e2e-tests were running as BAT. E.g. [here](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/branch-ci-stackrox-stackrox-master-merge-gke-postgres-qa-e2e-tests/1653499367778160640):
```
INFO: Tue May  2 21:13:04 UTC 2023: QA Automation Platform Part 1
INFO: Tue May  2 21:13:04 UTC 2023: An unexpected context. Defaulting to BAT tests only...
```

The next step for me would be to get rid of `QA_TEST_TARGET` from our OSCI configs.

## Checklist
- [x] Investigated and inspected CI test results

None of these will be done:
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

- [x] CI is green without `ci-all-qa-tests` label.
- [x] CI is green with `ci-all-qa-tests` label.

Postsubmit I'll check after merging.