### PR TITLE
ROX-16753: Central side changes to send NotifierSync to sensor

### DIFF
--- a/central/main.go
+++ b/central/main.go
@@ -89,6 +89,7 @@ import (
 	nodeService "github.com/stackrox/rox/central/node/service"
 	notifierDS "github.com/stackrox/rox/central/notifier/datastore"
 	"github.com/stackrox/rox/central/notifier/processor"
+	notifierProcessor "github.com/stackrox/rox/central/notifier/processor"
 	notifierService "github.com/stackrox/rox/central/notifier/service"
 	_ "github.com/stackrox/rox/central/notifiers/all" // These imports are required to register things from the respective packages.
 	"github.com/stackrox/rox/central/option"
@@ -414,6 +415,7 @@ func servicesToRegister(registry authproviders.Registry, authzTraceSink observe.
 		policyDataStore.Singleton(),
 		processBaselineDataStore.Singleton(),
 		networkBaselineDataStore.Singleton(),
+		notifierProcessor.Singleton(),
 		autoTriggerUpgrades,
 	); err != nil {
 		log.Panicf("Couldn't start sensor connection manager: %v", err)

--- a/central/notifier/processor/mocks/processor.go
+++ b/central/notifier/processor/mocks/processor.go
@@ -51,6 +51,20 @@ func (mr *MockProcessorMockRecorder) GetNotifier(ctx, id interface{}) *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNotifier", reflect.TypeOf((*MockProcessor)(nil).GetNotifier), ctx, id)
 }
 
+// GetNotifiers mocks base method.
+func (m *MockProcessor) GetNotifiers(ctx context.Context) []notifiers.Notifier {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetNotifiers", ctx)
+	ret0, _ := ret[0].([]notifiers.Notifier)
+	return ret0
+}
+
+// GetNotifiers indicates an expected call of GetNotifiers.
+func (mr *MockProcessorMockRecorder) GetNotifiers(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNotifiers", reflect.TypeOf((*MockProcessor)(nil).GetNotifiers), ctx)
+}
+
 // HasEnabledAuditNotifiers mocks base method.
 func (m *MockProcessor) HasEnabledAuditNotifiers() bool {
 	m.ctrl.T.Helper()

--- a/central/notifier/processor/notifier_set.go
+++ b/central/notifier/processor/notifier_set.go
@@ -24,6 +24,7 @@ type NotifierSet interface {
 	UpsertNotifier(ctx context.Context, notifier notifiers.Notifier)
 	RemoveNotifier(ctx context.Context, id string)
 	GetNotifier(ctx context.Context, id string) notifiers.Notifier
+	GetNotifiers(ctx context.Context) []notifiers.Notifier
 }
 
 // NewNotifierSet returns a new instance of a NotifierSet
@@ -118,4 +119,16 @@ func (p *notifierSetImpl) GetNotifier(ctx context.Context, id string) notifiers.
 	defer p.lock.Unlock()
 
 	return p.notifiers[id]
+}
+
+// GetNotifies gets notifiers from the set.
+func (p *notifierSetImpl) GetNotifiers(_ context.Context) []notifiers.Notifier {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	var notifiers []notifiers.Notifier
+	for _, notifier := range p.notifiers {
+		notifiers = append(notifiers, notifier)
+	}
+	return notifiers
 }

--- a/central/notifier/processor/notifier_set_test.go
+++ b/central/notifier/processor/notifier_set_test.go
@@ -85,7 +85,7 @@ func (s *notifierSetTestSuite) TestCoorelatedPoliciesAndNotifiers() {
 	s.ns.UpsertNotifier(ctx, s.mockResolvableAlertN)
 	s.ns.UpsertNotifier(ctx, s.mockAuditN)
 
-	s.ElementsMatch(s.ns.GetNotifiers(ctx), []notifiers.Notifier{s.mockAlertN, s.mockResolvableAlertN, s.mockAuditN})
+	s.ElementsMatch(s.ns.GetNotifiers(ctx), []pkgNotifiers.Notifier{s.mockAlertN, s.mockResolvableAlertN, s.mockAuditN})
 
 	// Check that the alert notifiers are activated.
 	s.mockAlertN.EXPECT().AlertNotify(gomock.Any(), gomock.Any()).Return(nil).Times(1)

--- a/central/notifier/processor/notifier_set_test.go
+++ b/central/notifier/processor/notifier_set_test.go
@@ -59,7 +59,7 @@ func (s *notifierSetTestSuite) TestHasFunctions() {
 	s.True(s.ns.HasNotifiers())
 	s.False(s.ns.HasEnabledAuditNotifiers())
 
-	// An alet and an enabled audit notifier.
+	// An alert and an enabled audit notifier.
 	notifier2 := &storage.Notifier{Id: "n2"}
 	s.mockAuditN.EXPECT().ProtoNotifier().Return(notifier2)
 	s.mockAuditN.EXPECT().AuditLoggingEnabled().Return(true)
@@ -84,6 +84,8 @@ func (s *notifierSetTestSuite) TestCoorelatedPoliciesAndNotifiers() {
 	s.ns.UpsertNotifier(ctx, s.mockAlertN)
 	s.ns.UpsertNotifier(ctx, s.mockResolvableAlertN)
 	s.ns.UpsertNotifier(ctx, s.mockAuditN)
+
+	s.ElementsMatch(s.ns.GetNotifiers(ctx), []notifiers.Notifier{s.mockAlertN, s.mockResolvableAlertN, s.mockAuditN})
 
 	// Check that the alert notifiers are activated.
 	s.mockAlertN.EXPECT().AlertNotify(gomock.Any(), gomock.Any()).Return(nil).Times(1)

--- a/central/notifier/processor/processor.go
+++ b/central/notifier/processor/processor.go
@@ -28,6 +28,8 @@ type Processor interface {
 	UpdateNotifier(ctx context.Context, notifier notifiers.Notifier)
 	RemoveNotifier(ctx context.Context, id string)
 	GetNotifier(ctx context.Context, id string) notifiers.Notifier
+	GetNotifiers(ctx context.Context) []notifiers.Notifier
+
 	UpdateNotifierHealthStatus(notifier notifiers.Notifier, healthStatus storage.IntegrationHealth_Status, errMessage string)
 }
 

--- a/central/notifier/processor/processor_impl.go
+++ b/central/notifier/processor/processor_impl.go
@@ -43,6 +43,11 @@ func (p *processorImpl) GetNotifier(ctx context.Context, id string) (notifier no
 	return p.ns.GetNotifier(ctx, id)
 }
 
+// GetNotifiers gets the in memory copies of all notifiers
+func (p *processorImpl) GetNotifiers(ctx context.Context) (notifiers []notifiers.Notifier) {
+	return p.ns.GetNotifiers(ctx)
+}
+
 // UpdateNotifier updates or adds the passed notifier into memory
 func (p *processorImpl) UpdateNotifier(ctx context.Context, notifier notifiers.Notifier) {
 	p.ns.UpsertNotifier(ctx, notifier)

--- a/central/notifier/service/service.go
+++ b/central/notifier/service/service.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stackrox/rox/central/detection"
 	"github.com/stackrox/rox/central/notifier/datastore"
 	"github.com/stackrox/rox/central/notifier/processor"
+	"github.com/stackrox/rox/central/sensor/service/connection"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/pkg/grpc"
 	"github.com/stackrox/rox/pkg/integrationhealth"
@@ -31,7 +32,8 @@ func New(storage datastore.DataStore,
 	buildTimePolicies detection.PolicySet,
 	deployTimePolicies detection.PolicySet,
 	runTimePolicies detection.PolicySet,
-	reporter integrationhealth.Reporter) Service {
+	reporter integrationhealth.Reporter,
+	connectionManager connection.Manager) Service {
 	return &serviceImpl{
 		storage:            storage,
 		processor:          processor,
@@ -39,5 +41,6 @@ func New(storage datastore.DataStore,
 		deployTimePolicies: deployTimePolicies,
 		runTimePolicies:    runTimePolicies,
 		reporter:           reporter,
+		connectionManager:  connectionManager,
 	}
 }

--- a/central/notifier/service/service_impl.go
+++ b/central/notifier/service/service_impl.go
@@ -11,10 +11,12 @@ import (
 	"github.com/stackrox/rox/central/notifier/processor"
 	"github.com/stackrox/rox/central/notifiers/splunk"
 	"github.com/stackrox/rox/central/role/resources"
+	"github.com/stackrox/rox/central/sensor/service/connection"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/auth/permissions"
 	"github.com/stackrox/rox/pkg/endpoints"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/errorhelpers"
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/grpc/authz"
@@ -50,13 +52,21 @@ var (
 type serviceImpl struct {
 	v1.UnimplementedNotifierServiceServer
 
-	storage   datastore.DataStore
-	processor processor.Processor
-	reporter  integrationhealth.Reporter
+	storage           datastore.DataStore
+	processor         processor.Processor
+	reporter          integrationhealth.Reporter
+	connectionManager connection.Manager
 
 	buildTimePolicies  detection.PolicySet
 	deployTimePolicies detection.PolicySet
 	runTimePolicies    detection.PolicySet
+}
+
+func (s *serviceImpl) syncNotifiersWithSensors(ctx context.Context) {
+	if env.SecuredClusterNotifiers.BooleanSetting() {
+		notifiers := s.processor.GetNotifiers(ctx)
+		s.connectionManager.PrepareNotifiersAndBroadcast(notifiers)
+	}
 }
 
 // RegisterServiceServer registers this service with the given gRPC Server.
@@ -146,6 +156,9 @@ func (s *serviceImpl) UpdateNotifier(ctx context.Context, request *v1.UpdateNoti
 		return nil, err
 	}
 	s.processor.UpdateNotifier(ctx, notifier)
+
+	s.syncNotifiersWithSensors(ctx)
+
 	return &v1.Empty{}, nil
 }
 
@@ -226,6 +239,8 @@ func (s *serviceImpl) DeleteNotifier(ctx context.Context, request *v1.DeleteNoti
 	}
 
 	s.processor.RemoveNotifier(ctx, request.GetId())
+	s.syncNotifiersWithSensors(ctx)
+
 	if err := s.reporter.RemoveIntegrationHealth(request.GetId()); err != nil {
 		return nil, err
 	}

--- a/central/notifier/service/service_impl_test.go
+++ b/central/notifier/service/service_impl_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/pkg/errors"
 	storageMocks "github.com/stackrox/rox/central/notifier/datastore/mocks"
 	"github.com/stackrox/rox/central/notifier/processor/mocks"
-	"github.com/stackrox/rox/central/notifiers"
 	_ "github.com/stackrox/rox/central/notifiers/all"
 	connectionMocks "github.com/stackrox/rox/central/sensor/service/connection/mocks"
 	v1 "github.com/stackrox/rox/generated/api/v1"
@@ -16,6 +15,7 @@ import (
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/errox"
 	reporterMocks "github.com/stackrox/rox/pkg/integrationhealth/mocks"
+	pkgNotifiers "github.com/stackrox/rox/pkg/notifiers"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/secrets"
 	"github.com/stretchr/testify/suite"
@@ -89,7 +89,7 @@ func (s *notifierServiceTestSuite) TestPutNotifier() {
 	s.processor.EXPECT().UpdateNotifier(gomock.Any(), gomock.Any()).Return()
 
 	if env.SecuredClusterNotifiers.BooleanSetting() {
-		s.processor.EXPECT().GetNotifiers(gomock.Any()).Return([]notifiers.Notifier{})
+		s.processor.EXPECT().GetNotifiers(gomock.Any()).Return([]pkgNotifiers.Notifier{})
 		s.connectionManager.EXPECT().PrepareNotifiersAndBroadcast(gomock.Any()).Times(1)
 	}
 	_, err := s.getSvc().PutNotifier(s.ctx, &storage.Notifier{})
@@ -105,7 +105,7 @@ func (s *notifierServiceTestSuite) TestUpdateNotifier() {
 	s.processor.EXPECT().UpdateNotifier(gomock.Any(), gomock.Any()).Times(3).Return()
 
 	if env.SecuredClusterNotifiers.BooleanSetting() {
-		s.processor.EXPECT().GetNotifiers(gomock.Any()).Times(3).Return([]notifiers.Notifier{})
+		s.processor.EXPECT().GetNotifiers(gomock.Any()).Times(3).Return([]pkgNotifiers.Notifier{})
 		s.connectionManager.EXPECT().PrepareNotifiersAndBroadcast(gomock.Any()).Times(3)
 	}
 

--- a/central/notifier/service/singleton.go
+++ b/central/notifier/service/singleton.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stackrox/rox/central/integrationhealth/reporter"
 	"github.com/stackrox/rox/central/notifier/datastore"
 	"github.com/stackrox/rox/central/notifier/processor"
+	"github.com/stackrox/rox/central/sensor/service/connection"
 	"github.com/stackrox/rox/pkg/sync"
 )
 
@@ -24,6 +25,7 @@ func initialize() {
 		deployTimeDetection.SingletonPolicySet(),
 		runTimeDetection.SingletonPolicySet(),
 		reporter.Singleton(),
+		connection.ManagerSingleton(),
 	)
 }
 

--- a/central/sensor/service/connection/connection_impl.go
+++ b/central/sensor/service/connection/connection_impl.go
@@ -514,7 +514,7 @@ func (c *sensorConnection) Run(ctx context.Context, server central.SensorService
 			return errors.Wrapf(err, "unable to get notifier sync msg for %q", c.clusterID)
 		}
 		if err := server.Send(msg); err != nil {
-			return errors.Wrapf(err, "unable to sync initial policies to cluster %q", c.clusterID)
+			return errors.Wrapf(err, "unable to sync initial notifiers to cluster %q", c.clusterID)
 		}
 	}
 

--- a/central/sensor/service/connection/connection_impl.go
+++ b/central/sensor/service/connection/connection_impl.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stackrox/rox/central/metrics"
 	"github.com/stackrox/rox/central/networkpolicies/graph"
 	notifierProcessor "github.com/stackrox/rox/central/notifier/processor"
-	"github.com/stackrox/rox/central/notifiers"
 	"github.com/stackrox/rox/central/scrape"
 	"github.com/stackrox/rox/central/sensor/networkentities"
 	"github.com/stackrox/rox/central/sensor/networkpolicies"
@@ -23,6 +22,7 @@ import (
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/logging"
+	pkgNotifiers "github.com/stackrox/rox/pkg/notifiers"
 	"github.com/stackrox/rox/pkg/postgres/pgutils"
 	"github.com/stackrox/rox/pkg/reflectutils"
 	"github.com/stackrox/rox/pkg/sac"
@@ -300,7 +300,7 @@ func (c *sensorConnection) getNotifierSyncMsg(ctx context.Context) *central.MsgT
 	return getNotifierSyncMsgFromNotifiers(c.notifierProcessor.GetNotifiers(ctx))
 }
 
-func getNotifierSyncMsgFromNotifiers(notifiers []notifiers.Notifier) *central.MsgToSensor {
+func getNotifierSyncMsgFromNotifiers(notifiers []pkgNotifiers.Notifier) *central.MsgToSensor {
 	var protoNotifiers []*storage.Notifier
 	for _, notifier := range notifiers {
 		protoNotifiers = append(protoNotifiers, notifier.ProtoNotifier())

--- a/central/sensor/service/connection/connection_impl.go
+++ b/central/sensor/service/connection/connection_impl.go
@@ -8,6 +8,8 @@ import (
 	"github.com/stackrox/rox/central/localscanner"
 	"github.com/stackrox/rox/central/metrics"
 	"github.com/stackrox/rox/central/networkpolicies/graph"
+	notifierProcessor "github.com/stackrox/rox/central/notifier/processor"
+	"github.com/stackrox/rox/central/notifiers"
 	"github.com/stackrox/rox/central/scrape"
 	"github.com/stackrox/rox/central/sensor/networkentities"
 	"github.com/stackrox/rox/central/sensor/networkpolicies"
@@ -19,6 +21,7 @@ import (
 	"github.com/stackrox/rox/pkg/booleanpolicy/policyversion"
 	"github.com/stackrox/rox/pkg/centralsensor"
 	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/postgres/pgutils"
 	"github.com/stackrox/rox/pkg/reflectutils"
@@ -56,6 +59,7 @@ type sensorConnection struct {
 	policyMgr          common.PolicyManager
 	baselineMgr        common.ProcessBaselineManager
 	networkBaselineMgr common.NetworkBaselineManager
+	notifierProcessor  notifierProcessor.Processor
 
 	sensorHello  *central.SensorHello
 	capabilities set.Set[centralsensor.SensorCapability]
@@ -69,6 +73,7 @@ func newConnection(sensorHello *central.SensorHello,
 	policyMgr common.PolicyManager,
 	baselineMgr common.ProcessBaselineManager,
 	networkBaselineMgr common.NetworkBaselineManager,
+	notifierProcessor notifierProcessor.Processor,
 	msgDeduper *deduper,
 ) *sensorConnection {
 
@@ -85,6 +90,7 @@ func newConnection(sensorHello *central.SensorHello,
 		networkEntityMgr:   networkEntityMgr,
 		baselineMgr:        baselineMgr,
 		networkBaselineMgr: networkBaselineMgr,
+		notifierProcessor:  notifierProcessor,
 
 		sensorHello:  sensorHello,
 		capabilities: centralsensor.CapSetFromStringSlice(sensorHello.GetCapabilities()...),
@@ -289,6 +295,25 @@ func (c *sensorConnection) processIssueLocalScannerCertsRequest(ctx context.Cont
 	return nil
 }
 
+// getNotifierSyncMsg fetches stored notifiers and prepares them for delivery to sensor.
+func (c *sensorConnection) getNotifierSyncMsg(ctx context.Context) *central.MsgToSensor {
+	return getNotifierSyncMsgFromNotifiers(c.notifierProcessor.GetNotifiers(ctx))
+}
+
+func getNotifierSyncMsgFromNotifiers(notifiers []notifiers.Notifier) *central.MsgToSensor {
+	var protoNotifiers []*storage.Notifier
+	for _, notifier := range notifiers {
+		protoNotifiers = append(protoNotifiers, notifier.ProtoNotifier())
+	}
+	return &central.MsgToSensor{
+		Msg: &central.MsgToSensor_NotifierSync{
+			NotifierSync: &central.NotifierSync{
+				Notifiers: protoNotifiers,
+			},
+		},
+	}
+}
+
 // getPolicySyncMsg fetches stored policies and prepares them for delivery to sensor.
 func (c *sensorConnection) getPolicySyncMsg(ctx context.Context) (*central.MsgToSensor, error) {
 	policies, err := c.policyMgr.GetAllPolicies(ctx)
@@ -481,7 +506,16 @@ func (c *sensorConnection) Run(ctx context.Context, server central.SensorService
 		if err := server.Send(msg); err != nil {
 			return errors.Wrapf(err, "unable to sync initial network baselines to cluster %q", c.clusterID)
 		}
+	}
 
+	if env.SecuredClusterNotifiers.BooleanSetting() && connectionCapabilities.Contains(centralsensor.SecuredClusterNotifications) {
+		msg := c.getNotifierSyncMsg(ctx)
+		if err != nil {
+			return errors.Wrapf(err, "unable to get notifier sync msg for %q", c.clusterID)
+		}
+		if err := server.Send(msg); err != nil {
+			return errors.Wrapf(err, "unable to sync initial policies to cluster %q", c.clusterID)
+		}
 	}
 
 	go c.runSend(server)

--- a/central/sensor/service/connection/manager.go
+++ b/central/sensor/service/connection/manager.go
@@ -3,6 +3,8 @@ package connection
 import (
 	"context"
 
+	notifierProcessor "github.com/stackrox/rox/central/notifier/processor"
+	"github.com/stackrox/rox/central/notifiers"
 	"github.com/stackrox/rox/central/sensor/service/common"
 	"github.com/stackrox/rox/central/sensor/service/pipeline"
 	"github.com/stackrox/rox/generated/internalapi/central"
@@ -20,6 +22,7 @@ type Manager interface {
 		policyMgr common.PolicyManager,
 		baselineMgr common.ProcessBaselineManager,
 		networkBaselineMgr common.NetworkBaselineManager,
+		notifierProcessor notifierProcessor.Processor,
 		autoTriggerUpgrades *concurrency.Flag) error
 
 	// Connection-related methods.
@@ -28,6 +31,8 @@ type Manager interface {
 	CloseConnection(clusterID string)
 	GetActiveConnections() []SensorConnection
 	PreparePoliciesAndBroadcast(policies []*storage.Policy)
+	PrepareNotifiersAndBroadcast(notifiers []notifiers.Notifier)
+
 	BroadcastMessage(msg *central.MsgToSensor)
 	SendMessage(clusterID string, msg *central.MsgToSensor) error
 

--- a/central/sensor/service/connection/manager.go
+++ b/central/sensor/service/connection/manager.go
@@ -4,12 +4,12 @@ import (
 	"context"
 
 	notifierProcessor "github.com/stackrox/rox/central/notifier/processor"
-	"github.com/stackrox/rox/central/notifiers"
 	"github.com/stackrox/rox/central/sensor/service/common"
 	"github.com/stackrox/rox/central/sensor/service/pipeline"
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/concurrency"
+	pkgNotifiers "github.com/stackrox/rox/pkg/notifiers"
 )
 
 // Manager is responsible for managing all active connections from sensors.
@@ -31,7 +31,7 @@ type Manager interface {
 	CloseConnection(clusterID string)
 	GetActiveConnections() []SensorConnection
 	PreparePoliciesAndBroadcast(policies []*storage.Policy)
-	PrepareNotifiersAndBroadcast(notifiers []notifiers.Notifier)
+	PrepareNotifiersAndBroadcast(notifiers []pkgNotifiers.Notifier)
 
 	BroadcastMessage(msg *central.MsgToSensor)
 	SendMessage(clusterID string, msg *central.MsgToSensor) error

--- a/central/sensor/service/connection/manager_impl.go
+++ b/central/sensor/service/connection/manager_impl.go
@@ -7,7 +7,6 @@ import (
 	"github.com/gogo/protobuf/types"
 	"github.com/pkg/errors"
 	notifierProcessor "github.com/stackrox/rox/central/notifier/processor"
-	"github.com/stackrox/rox/central/notifiers"
 	"github.com/stackrox/rox/central/role/resources"
 	"github.com/stackrox/rox/central/sensor/service/common"
 	"github.com/stackrox/rox/central/sensor/service/connection/upgradecontroller"
@@ -18,6 +17,7 @@ import (
 	"github.com/stackrox/rox/pkg/clusterhealth"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/errorhelpers"
+	pkgNotifiers "github.com/stackrox/rox/pkg/notifiers"
 	"github.com/stackrox/rox/pkg/protoconv"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/sync"
@@ -410,7 +410,7 @@ func (m *manager) PreparePoliciesAndBroadcast(policies []*storage.Policy) {
 
 // PrepareNotifiersAndBroadcast prepares and sends NotifierSync message
 // separately for each sensor.
-func (m *manager) PrepareNotifiersAndBroadcast(notifiers []notifiers.Notifier) {
+func (m *manager) PrepareNotifiersAndBroadcast(notifiers []pkgNotifiers.Notifier) {
 	m.connectionsByClusterIDMutex.RLock()
 	defer m.connectionsByClusterIDMutex.RUnlock()
 

--- a/central/sensor/service/connection/manager_impl.go
+++ b/central/sensor/service/connection/manager_impl.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/gogo/protobuf/types"
 	"github.com/pkg/errors"
+	notifierProcessor "github.com/stackrox/rox/central/notifier/processor"
+	"github.com/stackrox/rox/central/notifiers"
 	"github.com/stackrox/rox/central/role/resources"
 	"github.com/stackrox/rox/central/sensor/service/common"
 	"github.com/stackrox/rox/central/sensor/service/connection/upgradecontroller"
@@ -63,6 +65,7 @@ type manager struct {
 	policies            common.PolicyManager
 	baselines           common.ProcessBaselineManager
 	networkBaselines    common.NetworkBaselineManager
+	notifierProcessor   notifierProcessor.Processor
 	autoTriggerUpgrades *concurrency.Flag
 }
 
@@ -98,6 +101,7 @@ func (m *manager) Start(clusterManager common.ClusterManager,
 	policyManager common.PolicyManager,
 	baselineManager common.ProcessBaselineManager,
 	networkBaselineManager common.NetworkBaselineManager,
+	notifierProcessor notifierProcessor.Processor,
 	autoTriggerUpgrades *concurrency.Flag,
 ) error {
 	m.clusters = clusterManager
@@ -105,6 +109,7 @@ func (m *manager) Start(clusterManager common.ClusterManager,
 	m.policies = policyManager
 	m.baselines = baselineManager
 	m.networkBaselines = networkBaselineManager
+	m.notifierProcessor = notifierProcessor
 	m.autoTriggerUpgrades = autoTriggerUpgrades
 	err := m.initializeUpgradeControllers()
 	if err != nil {
@@ -265,6 +270,7 @@ func (m *manager) HandleConnection(ctx context.Context, sensorHello *central.Sen
 			m.policies,
 			m.baselines,
 			m.networkBaselines,
+			m.notifierProcessor,
 			msgDeduper)
 	ctx = withConnection(ctx, conn)
 
@@ -400,7 +406,31 @@ func (m *manager) PreparePoliciesAndBroadcast(policies []*storage.Policy) {
 			log.Errorf("error broadcasting message to cluster %q", clusterID)
 		}
 	}
+}
 
+// PrepareNotifiersAndBroadcast prepares and sends NotifierSync message
+// separately for each sensor.
+func (m *manager) PrepareNotifiersAndBroadcast(notifiers []notifiers.Notifier) {
+	m.connectionsByClusterIDMutex.RLock()
+	defer m.connectionsByClusterIDMutex.RUnlock()
+
+	msg := getNotifierSyncMsgFromNotifiers(notifiers)
+	for clusterID, connAndUpgradeCtrl := range m.connectionsByClusterID {
+		if connAndUpgradeCtrl.connection == nil {
+			log.Debugf("could not broadcast message to cluster %q which has no active connection", clusterID)
+			continue
+		}
+
+		if !connAndUpgradeCtrl.connection.HasCapability(centralsensor.SecuredClusterNotifications) {
+			log.Debugf("did not broadcast notifiersync message to cluster %q since it does not have the %s capapbility",
+				clusterID, centralsensor.SecuredClusterNotifications)
+			continue
+		}
+
+		if err := connAndUpgradeCtrl.connection.InjectMessage(concurrency.Never(), msg); err != nil {
+			log.Errorf("error broadcasting message to cluster %q", clusterID)
+		}
+	}
 }
 
 func (m *manager) BroadcastMessage(msg *central.MsgToSensor) {

--- a/central/sensor/service/connection/mocks/manager.go
+++ b/central/sensor/service/connection/mocks/manager.go
@@ -10,13 +10,13 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	processor "github.com/stackrox/rox/central/notifier/processor"
-	notifiers "github.com/stackrox/rox/central/notifiers"
 	common "github.com/stackrox/rox/central/sensor/service/common"
 	connection "github.com/stackrox/rox/central/sensor/service/connection"
 	pipeline "github.com/stackrox/rox/central/sensor/service/pipeline"
 	central "github.com/stackrox/rox/generated/internalapi/central"
 	storage "github.com/stackrox/rox/generated/storage"
 	concurrency "github.com/stackrox/rox/pkg/concurrency"
+	notifiers "github.com/stackrox/rox/pkg/notifiers"
 )
 
 // MockManager is a mock of Manager interface.

--- a/central/sensor/service/connection/mocks/manager.go
+++ b/central/sensor/service/connection/mocks/manager.go
@@ -9,6 +9,8 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
+	processor "github.com/stackrox/rox/central/notifier/processor"
+	notifiers "github.com/stackrox/rox/central/notifiers"
 	common "github.com/stackrox/rox/central/sensor/service/common"
 	connection "github.com/stackrox/rox/central/sensor/service/connection"
 	pipeline "github.com/stackrox/rox/central/sensor/service/pipeline"
@@ -106,6 +108,18 @@ func (mr *MockManagerMockRecorder) HandleConnection(ctx, sensorHello, cluster, e
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleConnection", reflect.TypeOf((*MockManager)(nil).HandleConnection), ctx, sensorHello, cluster, eventPipeline, server)
 }
 
+// PrepareNotifiersAndBroadcast mocks base method.
+func (m *MockManager) PrepareNotifiersAndBroadcast(notifiers []notifiers.Notifier) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "PrepareNotifiersAndBroadcast", notifiers)
+}
+
+// PrepareNotifiersAndBroadcast indicates an expected call of PrepareNotifiersAndBroadcast.
+func (mr *MockManagerMockRecorder) PrepareNotifiersAndBroadcast(notifiers interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrepareNotifiersAndBroadcast", reflect.TypeOf((*MockManager)(nil).PrepareNotifiersAndBroadcast), notifiers)
+}
+
 // PreparePoliciesAndBroadcast mocks base method.
 func (m *MockManager) PreparePoliciesAndBroadcast(policies []*storage.Policy) {
 	m.ctrl.T.Helper()
@@ -190,17 +204,17 @@ func (mr *MockManagerMockRecorder) SendMessage(clusterID, msg interface{}) *gomo
 }
 
 // Start mocks base method.
-func (m *MockManager) Start(mgr common.ClusterManager, netEntitiesMgr common.NetworkEntityManager, policyMgr common.PolicyManager, baselineMgr common.ProcessBaselineManager, networkBaselineMgr common.NetworkBaselineManager, autoTriggerUpgrades *concurrency.Flag) error {
+func (m *MockManager) Start(mgr common.ClusterManager, netEntitiesMgr common.NetworkEntityManager, policyMgr common.PolicyManager, baselineMgr common.ProcessBaselineManager, networkBaselineMgr common.NetworkBaselineManager, notifierProcessor processor.Processor, autoTriggerUpgrades *concurrency.Flag) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Start", mgr, netEntitiesMgr, policyMgr, baselineMgr, networkBaselineMgr, autoTriggerUpgrades)
+	ret := m.ctrl.Call(m, "Start", mgr, netEntitiesMgr, policyMgr, baselineMgr, networkBaselineMgr, notifierProcessor, autoTriggerUpgrades)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Start indicates an expected call of Start.
-func (mr *MockManagerMockRecorder) Start(mgr, netEntitiesMgr, policyMgr, baselineMgr, networkBaselineMgr, autoTriggerUpgrades interface{}) *gomock.Call {
+func (mr *MockManagerMockRecorder) Start(mgr, netEntitiesMgr, policyMgr, baselineMgr, networkBaselineMgr, notifierProcessor, autoTriggerUpgrades interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockManager)(nil).Start), mgr, netEntitiesMgr, policyMgr, baselineMgr, networkBaselineMgr, autoTriggerUpgrades)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockManager)(nil).Start), mgr, netEntitiesMgr, policyMgr, baselineMgr, networkBaselineMgr, notifierProcessor, autoTriggerUpgrades)
 }
 
 // TriggerCertRotation mocks base method.

--- a/pkg/centralsensor/caps_list.go
+++ b/pkg/centralsensor/caps_list.go
@@ -36,4 +36,7 @@ const (
 
 	// ListeningEndpointsWithProcessesCap identifies the capability for sensor to process and send information about listening endpoints and their processes, AKA processes listening on ports
 	ListeningEndpointsWithProcessesCap SensorCapability = "ListeningEndpointsWithProcesses"
+
+	// SecuredClusterNotifications identifies the capability for sensor to process and send alert notifications to notifiers
+	SecuredClusterNotifications SensorCapability = "SecuredClusterNotifications"
 )


### PR DESCRIPTION
## Description
Central side changes to send NotifierSync messages when CRUD operations on notifiers are performed in Central, and initial sync to sensor, iff ROX_SECURED_CLUSTER_NOTIFICATIONS is true

Added sensor capability for secured cluster notifications.

Note: Secured cluster side processing will come in following PRs

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))


## Testing Performed
Manual testing TBD, once sensor and admission controller changes come in, in following PRs