### PR TITLE
ROX-16748: Short circuit notification processing in Central for secured cluster notifiers, when feature is turned on.

### DIFF
--- a/central/notifier/processor/mocks/processor.go
+++ b/central/notifier/processor/mocks/processor.go
@@ -79,6 +79,20 @@ func (mr *MockProcessorMockRecorder) HasNotifiers() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasNotifiers", reflect.TypeOf((*MockProcessor)(nil).HasNotifiers))
 }
 
+// IsSecuredClusterNotifier mocks base method.
+func (m *MockProcessor) IsSecuredClusterNotifier(notifier notifiers.Notifier) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsSecuredClusterNotifier", notifier)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsSecuredClusterNotifier indicates an expected call of IsSecuredClusterNotifier.
+func (mr *MockProcessorMockRecorder) IsSecuredClusterNotifier(notifier interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsSecuredClusterNotifier", reflect.TypeOf((*MockProcessor)(nil).IsSecuredClusterNotifier), notifier)
+}
+
 // ProcessAlert mocks base method.
 func (m *MockProcessor) ProcessAlert(ctx context.Context, alert *storage.Alert) {
 	m.ctrl.T.Helper()

--- a/central/notifier/processor/processor.go
+++ b/central/notifier/processor/processor.go
@@ -23,6 +23,7 @@ type Processor interface {
 
 	HasNotifiers() bool
 	HasEnabledAuditNotifiers() bool
+	IsSecuredClusterNotifier(notifier notifiers.Notifier) bool
 
 	UpdateNotifier(ctx context.Context, notifier notifiers.Notifier)
 	RemoveNotifier(ctx context.Context, id string)

--- a/central/notifier/processor/processor_impl.go
+++ b/central/notifier/processor/processor_impl.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stackrox/rox/central/notifiers"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/integrationhealth"
 	"github.com/stackrox/rox/pkg/set"
 )
@@ -47,14 +48,38 @@ func (p *processorImpl) UpdateNotifier(ctx context.Context, notifier notifiers.N
 	p.ns.UpsertNotifier(ctx, notifier)
 }
 
+// IsSecuredClusterNotifier returns true if this is a notifier that can be accessed by the secured cluster
+func (p *processorImpl) IsSecuredClusterNotifier(notifier notifiers.Notifier) bool {
+	if !env.SecuredClusterNotifiers.BooleanSetting() {
+		return false
+	}
+	if _, ok := notifier.ProtoNotifier().Config.(*storage.Notifier_Jira); ok {
+		return true
+	}
+	if _, ok := notifier.ProtoNotifier().Config.(*storage.Notifier_Generic); ok {
+		return true
+	}
+	if _, ok := notifier.ProtoNotifier().Config.(*storage.Notifier_Syslog); ok {
+		return true
+	}
+	return false
+}
+
 // ProcessAlert pushes the alert into a channel to be processed
 func (p *processorImpl) ProcessAlert(ctx context.Context, alert *storage.Alert) {
 	if len(alert.GetPolicy().GetNotifiers()) == 0 {
 		return
 	}
 	alertNotifiers := set.NewStringSet(alert.GetPolicy().GetNotifiers()...)
+
 	p.ns.ForEach(ctx, func(ctx context.Context, notifier notifiers.Notifier, failures AlertSet) {
 		if alertNotifiers.Contains(notifier.ProtoNotifier().GetId()) {
+			// If this is a secured cluster notifier the notification for this alert has already been processed in the secured
+			// cluster before the alert reached here for processing. Hence, skip the notifier and continue with the rest
+			// of the notifiers configured for the policy that generated the alert
+			if p.IsSecuredClusterNotifier(notifier) {
+				return
+			}
 			go func() {
 				err := tryToAlert(ctx, notifier, alert)
 				if err != nil {
@@ -106,6 +131,9 @@ func (p *processorImpl) processAlertSync(ctx context.Context, alert *storage.Ale
 	alertNotifiers := set.NewStringSet(alert.GetPolicy().GetNotifiers()...)
 	p.ns.ForEach(ctx, func(ctx context.Context, notifier notifiers.Notifier, failures AlertSet) {
 		if alertNotifiers.Contains(notifier.ProtoNotifier().GetId()) {
+			if p.IsSecuredClusterNotifier(notifier) {
+				return
+			}
 			err := tryToAlert(ctx, notifier, alert)
 			if err != nil {
 				failures.Add(alert)

--- a/central/notifier/processor/processor_impl_test.go
+++ b/central/notifier/processor/processor_impl_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/golang/mock/gomock"
 	notifierMocks "github.com/stackrox/rox/central/notifiers/mocks"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/env"
 )
 
 func TestProcessor_LoopDoesNothing(t *testing.T) {
@@ -180,4 +181,46 @@ func TestProcessor_LoopHandlesFailures(t *testing.T) {
 	// Retry previous failures. (None)
 	loop.retryFailures(ctx)
 	mockCtrl.Finish()
+}
+
+func TestProcessor_SkipNotificationsForSecuredClusterNotifiers(t *testing.T) {
+	t.Setenv(env.SecuredClusterNotifiers.EnvVar(), "true")
+	ctx := context.Background()
+	// Create mocks.
+	mockCtrl := gomock.NewController(t)
+
+	jiraAlertNotfierProto := &storage.Notifier{Id: "n1", Config: &storage.Notifier_Jira{Jira: &storage.Jira{}}}
+	mockJiraAlertNotifier := notifierMocks.NewMockAlertNotifier(mockCtrl)
+
+	emailAlertNotfierProto := &storage.Notifier{Id: "n2", Config: &storage.Notifier_Email{Email: &storage.Email{}}}
+	mockEmailAlertNotifier := notifierMocks.NewMockAlertNotifier(mockCtrl)
+
+	// Create our tested objects.
+	ns := NewNotifierSet()
+	processor := &processorImpl{ns: ns}
+
+	// Add the notifiers to the processor.
+	mockJiraAlertNotifier.EXPECT().ProtoNotifier().Return(jiraAlertNotfierProto).AnyTimes()
+	mockEmailAlertNotifier.EXPECT().ProtoNotifier().Return(emailAlertNotfierProto).AnyTimes()
+
+	processor.UpdateNotifier(ctx, mockJiraAlertNotifier)
+	processor.UpdateNotifier(ctx, mockEmailAlertNotifier)
+
+	policy := &storage.Policy{
+		Id:        "p1",
+		Notifiers: []string{"n1", "n2"},
+	}
+
+	// Running the loop should do anything if all of the alerts succeed.
+	activeAlert := &storage.Alert{
+		Id:     "a1",
+		State:  storage.ViolationState_ACTIVE,
+		Policy: policy,
+	}
+
+	// Since JIRA is a secured cluster notifier, notifications to it will not be processed in Central
+	mockEmailAlertNotifier.EXPECT().AlertNotify(gomock.Any(), activeAlert).Return(nil)
+
+	processor.processAlertSync(ctx, activeAlert)
+
 }


### PR DESCRIPTION
## Description
Short circuit notification processing in Central for secured cluster notifiers, when feature is turned on.

Added unit test.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed
Unit test only