### PR TITLE
ROX-16928: Disable pprof endpoints in ACSCS

### DIFF
--- a/central/main.go
+++ b/central/main.go
@@ -797,7 +797,7 @@ func customRoutes() (customRoutes []routes.CustomRoute) {
 		},
 	)
 
-	customRoutes = append(customRoutes, debugRoutes()...)
+	customRoutes = append(customRoutes, utils.IfThenElse(env.ManagedCentral.BooleanSetting(), debugRoutes(), []routes.CustomRoute{})...)
 	return
 }
 


### PR DESCRIPTION
## Description

Even though we removed central profile data from the diagnostic bundle for ACSCS, it is still available via pprof endpoints: https://github.com/stackrox/stackrox/blob/ad11da4f07579787097b66de9d6692be42269fb8/pkg/grpc/routes/debug.go#L9-L20

Let's disable it so customers won't be able to discover them.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
