### PR TITLE
ROX-16899: fix the error type test

### DIFF
--- a/tests/endpoints_test.go
+++ b/tests/endpoints_test.go
@@ -185,13 +185,15 @@ func (c *endpointsTestCase) runConnectionTest(t *testing.T, testCtx *endpointsTe
 	// Test connecting with all invalid server names
 	invalidServerNames := set.NewStringSet(testCtx.allServerNames...)
 	invalidServerNames.RemoveAll(c.validServerNames...)
+	nameErr := &x509.HostnameError{}
 	for serverName := range invalidServerNames {
 		tlsConf := testCtx.tlsConfig(c.clientCert, serverName, true)
 		conn, err := tls.DialWithDialer(&dialer, "tcp", c.endpoint(), tlsConf)
 		if conn != nil {
 			_ = conn.Close()
 		}
-		assert.ErrorIs(t, err, x509.HostnameError{}, "expected error to be of type x509.HostnameError, was: %T (%v)", err, err)
+		require.Error(t, err)
+		assert.ErrorAs(t, err, nameErr, "expected error to be of type x509.HostnameError, was: %T (%v)", err, err)
 	}
 }
 


### PR DESCRIPTION
## Description

e2e test fix after go version bump to 1.20.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

CI e2e.