### PR TITLE
Exclude `node_modules` from UI caching

### DIFF
--- a/.github/actions/cache-ui-dependencies/action.yaml
+++ b/.github/actions/cache-ui-dependencies/action.yaml
@@ -12,14 +12,9 @@ runs:
       uses: actions/cache@v2
       with:
         path: |
-          ui/deps
           /github/home/.cache/yarn
           /github/home/.cache/Cypress
           /usr/local/share/.cache
-          ui/node_modules
-          ui/apps/platform/node_modules
-          ui/packages/ui-components/node_modules
-          ui/packages/tailwind-config/node_modules
         key: npm-v2-${{ hashFiles(inputs.lockFile) }}-${{ github.job }}
         restore-keys: |
           npm-v2-${{ hashFiles(inputs.lockFile) }}-${{ github.job }}

--- a/ui/Makefile
+++ b/ui/Makefile
@@ -14,7 +14,7 @@ PACKAGE_JSON_FILES := $(shell find . -type d \( -name node_modules \) -prune -fa
 export REACT_APP_ROX_PRODUCT_BRANDING := $(shell $(MAKE) --quiet --no-print-directory -C .. product-branding)
 
 deps: yarn.lock $(PACKAGE_JSON_FILES)
-	yarn install --frozen-lockfile --network-timeout=$(YARN_NETWORK_TIMEOUT)
+	yarn install --frozen-lockfile --prefer-offline --network-timeout=$(YARN_NETWORK_TIMEOUT)
 	@touch deps
 
 .PHONY: printsrcs


### PR DESCRIPTION
## Description

Triggered by https://github.com/stackrox/stackrox/pull/5865 merge failing `pre-build-ui`: https://github.com/stackrox/stackrox/actions/runs/4891147510/jobs/8731299737#step:9:37

Related thread https://redhat-internal.slack.com/archives/CELUQKESC/p1683284029430709

The problem with the former approach is that `node_modules` contents must be very specific to what's requested by `yarn.lock` and `package.json` files. Any unwanted dependencies that came from GHA cache will be there and can interfere.
In the new approach, we exclude `node_modules` from saving and restoring through GHA cache and do that only to yarn cache (verified that the location reported by `yarn cache dir` is `/usr/local/share/.cache/yarn/v6`). Further, when we run `yarn install`, `yarn` should look for packages in that cache first before trying to download them.
If packages are in cache, yarn will put them in respective `node_modules`. This should be cheaper than downloading files from the network and cleaner than before because only requested packages will come to `node_modules`.

A side-effect of this change is that UI cache size dropped from [~916MB](https://github.com/stackrox/stackrox/actions/runs/4891147510/jobs/8731299737#step:6:34) to [~422MB](https://github.com/stackrox/stackrox/actions/runs/4892780148/jobs/8734943018?pr=5933#step:19:5).

## Checklist
- [ ] Investigated and inspected CI test results

None of these will be done:
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

* CI should be green.
