### PR TITLE
Update GHA cache action from v2 to v3

### DIFF
--- a/.github/actions/cache-gradle-dependencies/action.yaml
+++ b/.github/actions/cache-gradle-dependencies/action.yaml
@@ -4,7 +4,7 @@ runs:
   using: composite
   steps:
     - name: Cache Gradle Dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           ~/.gradle/caches

--- a/.github/actions/cache-ui-dependencies/action.yaml
+++ b/.github/actions/cache-ui-dependencies/action.yaml
@@ -9,7 +9,7 @@ runs:
   using: composite
   steps:
     - name: Cache UI Dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           /github/home/.cache/yarn


### PR DESCRIPTION
## Description

GitHub does not like v2 action and says its node is obsolete.

![image](https://user-images.githubusercontent.com/537715/236469386-43678bb9-6a5e-4720-9d57-d0d8039e51d8.png)

[link](https://github.com/stackrox/stackrox/actions/runs/4893751877)

## Checklist
- [x] Investigated and inspected CI test results

None of these:
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

* CI is green.