### PR TITLE
ROX-7047: Network Flow test 

### DIFF
--- a/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
@@ -489,7 +489,6 @@ class NetworkFlowTest extends BaseSpecification {
         assert edges
     }
 
-    // TODO(ROX-7047): Re-enable this test
     @Tag("NetworkFlowVisualization")
     def "Verify connections from external sources"() {
         given:

--- a/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
@@ -492,8 +492,6 @@ class NetworkFlowTest extends BaseSpecification {
     // TODO(ROX-7047): Re-enable this test
     @Tag("NetworkFlowVisualization")
     def "Verify connections from external sources"() {
-        Assume.assumeFalse(ClusterService.isOpenShift4())
-
         given:
         "Deployment A, where an external source communicates to A"
         String deploymentUid = deployments.find { it.name == NGINXCONNECTIONTARGET }?.deploymentUid


### PR DESCRIPTION
## Description

Enable Network Flow test.

Test might still be flaking, but to get a new ticket with prow logs, I propose that we enable this test now and monitor it in nightly/master CI runs. 

## Checklist
- [x] Investigated and inspected CI test results
- [ ] ~~Unit test and regression tests added~~
- [ ] ~~Evaluated and added CHANGELOG entry if required~~
- [ ] ~~Determined and documented upgrade steps~~
- [ ] ~~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

Ran in CI 5 times. Step failed for other reasons than because of enabled test.

