### PR TITLE
Replace text color in ScopedPermissions

### DIFF
--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/widgets/ScopedPermissions.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/widgets/ScopedPermissions.js
@@ -1,46 +1,42 @@
 import React from 'react';
+import { MinusCircleIcon, PlusCircleIcon } from '@patternfly/react-icons';
 
-const getLabelColor = (key) => {
+const getVerbIcon = (key) => {
     switch (key) {
         case 'create':
         case 'update':
-            return 'success';
+            // Keep success color for backward compatibility, although it is questionable semantically.
+            return <PlusCircleIcon color="var(--pf-global--success-color--100)" />;
         case 'delete':
-            return 'alert';
+            return <MinusCircleIcon color="var(--pf-global--danger-color--100)" />;
         default:
-            return 'primary';
+            return null;
     }
 };
 
 const ScopedPermissions = ({ permissions }) => {
-    let content = [];
-    const { length } = permissions;
-    if (length) {
-        content = permissions.map((datum, i) => {
-            const colorClass = getLabelColor(datum.key);
-            const permissionKeyClass = `rounded bg-${colorClass}-200 text-${colorClass}-700 ${
-                i !== permissions.length - 1 ? `border border-${colorClass}-300` : ''
-            } px-2 py-1 self-center`;
-            return (
-                <div className="flex border-b border-base-300" key={datum.key}>
-                    <div className="w-43 border-r border-base-300 px-3 text-sm flex">
-                        <div className={permissionKeyClass}>
+    return permissions.map((datum) => {
+        return (
+            <div className="flex border-b border-base-300" key={datum.key}>
+                <div className="w-43 border-r border-base-300 p-3 text-sm flex">
+                    <span className="pf-u-display-inline-flex pf-u-align-items-center">
+                        <span className="w-4 pr-3">{getVerbIcon(datum.key)}</span>
+                        <span>
                             {datum.key === '*' ? (
                                 '* (All verbs)'
                             ) : (
                                 <span className="capitalize">{datum.key}</span>
                             )}
                             :
-                        </div>
-                    </div>
-                    <div className="w-full font-500 p-3 text-primary-800 text-sm leading-normal">
-                        {datum.values.includes('*') ? '* (All resources)' : datum.values.join(', ')}
-                    </div>
+                        </span>
+                    </span>
                 </div>
-            );
-        });
-    }
-    return content;
+                <div className="w-full p-3 text-sm leading-normal">
+                    {datum.values.includes('*') ? '* (All resources)' : datum.values.join(', ')}
+                </div>
+            </div>
+        );
+    });
 };
 
 export default ScopedPermissions;

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/widgets/ScopedPermissions.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/widgets/ScopedPermissions.js
@@ -1,37 +1,18 @@
 import React from 'react';
-import { MinusCircleIcon, PlusCircleIcon } from '@patternfly/react-icons';
-
-const getVerbIcon = (key) => {
-    switch (key) {
-        case 'create':
-        case 'update':
-            // Keep success color for backward compatibility, although it is questionable semantically.
-            return <PlusCircleIcon color="var(--pf-global--success-color--100)" />;
-        case 'delete':
-            return <MinusCircleIcon color="var(--pf-global--danger-color--100)" />;
-        default:
-            return null;
-    }
-};
 
 const ScopedPermissions = ({ permissions }) => {
     return permissions.map((datum) => {
         return (
             <div className="flex border-b border-base-300" key={datum.key}>
-                <div className="w-43 border-r border-base-300 p-3 text-sm flex">
-                    <span className="pf-u-display-inline-flex pf-u-align-items-center">
-                        <span className="w-4 pr-3">{getVerbIcon(datum.key)}</span>
-                        <span>
-                            {datum.key === '*' ? (
-                                '* (All verbs)'
-                            ) : (
-                                <span className="capitalize">{datum.key}</span>
-                            )}
-                            :
-                        </span>
-                    </span>
+                <div className="w-43 border-r border-base-300 px-2 py-3 text-sm flex">
+                    {datum.key === '*' ? (
+                        '* (All verbs)'
+                    ) : (
+                        <span className="capitalize">{datum.key}</span>
+                    )}
+                    :
                 </div>
-                <div className="w-full p-3 text-sm leading-normal">
+                <div className="w-full px-2 py-3 text-sm leading-normal">
                     {datum.values.includes('*') ? '* (All resources)' : datum.values.join(', ')}
                 </div>
             </div>


### PR DESCRIPTION
## Description

### Problems

1. Color text causes accessibility problems like assumption of perfect color vision.

2. Color theme classes from template literal like `bg-${colorClass}-200 text-${colorClass}-700` and `border-${colorClass}-300` prevents Tailwind optimization to purge unused classes.

### Analysis

Plain text seems like an alternative, because semantics of colors does not fit create/update and delete.

### Solution

1. Render verbs as plain text.

This is the caboose of the Tailwind template literal train, along with #5923

### Residue

1. Black text in classic dark theme might be solved by PatternFly dark theme.

2. Now that accessible alternatives have replaced template literals, how many complete string classes remain for the most used levels of text and background colors?

|         text class | results | files |
|               ---: |    ---: |  ---: |
|   text-primary-700 |      38 |    30 |
|     text-alert-700 |      11 |    10 |
|  text-tertiary-700 |       7 |     4 |
|   text-warning-700 |       5 |     4 |
|   text-success-700 |       4 |     4 |
|    text-accent-700 |       0 |     0 |
|   text-caution-700 |       0 |     0 |
| text-secondary-700 |       0 |     0 |
|                    |      65 |    52 |

| background class | results | files |
|             ---: |    ---: |  ---: |
|   bg-primary-200 |      45 |    28 |
|     bg-alert-200 |      17 |    15 |
|  bg-tertiary-200 |      10 |     6 |
|   bg-success-200 |       5 |     5 |
|   bg-warning-200 |       4 |     4 |
|    bg-accent-200 |       0 |     0 |
|   bg-caution-200 |       0 |     0 |
| bg-secondary-200 |       0 |     0 |
|                  |      81 |    58 |

According to 80/20 principle, cluster.helpers.tsx file is next to replace text background colors with more accessible alternatives.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

### Integration testing

In ui/apps/platform folder:

1. `yarn cypress-open`

    * configmanagement/roles.test.js
    * configmanagement/serviceaccounts.test.js
    * configmanagement/usersandgroups.test.js

### Manual testing
1. Visit /main/configmanagement/subjects

    * classic color text in light theme (local deployment)
        ![subjects_classic](https://user-images.githubusercontent.com/11862657/236543296-7002c1e3-6b6e-4faf-94a5-0091ed49b4d5.png)

    * PatternFly color icon in light theme
        ![subjects_PatternFly_text](https://user-images.githubusercontent.com/11862657/236933138-0a364a13-68f7-4560-817c-882562db4545.png)

2. Visit /main/configmanagement/serviceaccounts

    * classic color text in dark theme (stagingdb)
        ![serviceaccounts_classic_dark_stagingdb](https://user-images.githubusercontent.com/11862657/236543108-98998f4a-39f1-4d73-9190-565e9ab19e07.png)

    * PatternFly color icon in dark theme
        ![serviceaccounts_PatternFly_dark_text](https://user-images.githubusercontent.com/11862657/236933215-cd8164f9-f8f5-4971-8609-8396161d2a3c.png)

3. Visit /main/configmanagement/roles

    * classic color text in dark theme (stagingdb)
        ![roles_classic_dark_stagingdb](https://user-images.githubusercontent.com/11862657/236543191-fedfe15c-a439-45fa-8ad3-48f5b9fd64ae.png)

    * PatternFly color icon in dark theme
        ![roles_PatternFly_dark_text](https://user-images.githubusercontent.com/11862657/236933596-8533628d-b13d-44ea-bc2a-3c54fa66968f.png)
