### PR TITLE
Add image/deployment resource tables for Workload CVEs

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPage.tsx
@@ -108,9 +108,8 @@ function DeploymentPage() {
                         className="pf-u-display-flex pf-u-flex-direction-column pf-u-flex-grow-1"
                         eventKey="Resources"
                         title={<TabTitleText>Resources</TabTitleText>}
-                        isDisabled
                     >
-                        <DeploymentPageResources />
+                        <DeploymentPageResources deploymentId={deploymentId} />
                     </Tab>
                 </Tabs>
             </PageSection>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageResources.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageResources.tsx
@@ -1,11 +1,120 @@
-import React from 'react';
+import React, { CSSProperties } from 'react';
+import {
+    Bullseye,
+    Divider,
+    ExpandableSection,
+    PageSection,
+    Pagination,
+    Spinner,
+    Text,
+} from '@patternfly/react-core';
+import { gql, useQuery } from '@apollo/client';
+import { Pagination as PaginationParam } from 'services/types';
 
-export type DeploymentPageResourcesProps = Record<string, never>;
+import useURLPagination from 'hooks/useURLPagination';
+import useURLSort from 'hooks/useURLSort';
+import useSelectToggle from 'hooks/patternfly/useSelectToggle';
+import { defaultImageSortFields, imagesDefaultSort } from '../sortUtils';
+import TableErrorComponent from '../components/TableErrorComponent';
+import ImageResourceTable, { ImageResources, imageResourcesFragment } from './ImageResourceTable';
 
-function DeploymentPageResources() {
+export type DeploymentPageResourcesProps = {
+    deploymentId: string;
+};
+
+const deploymentResourcesQuery = gql`
+    ${imageResourcesFragment}
+    query getDeploymentResources($id: ID!, $query: String, $pagination: Pagination) {
+        deployment(id: $id) {
+            id
+            ...ImageResources
+        }
+    }
+`;
+
+function DeploymentPageResources({ deploymentId }: DeploymentPageResourcesProps) {
+    const { page, perPage, setPage, setPerPage } = useURLPagination(20);
+    const { sortOption, getSortParams } = useURLSort({
+        sortFields: defaultImageSortFields,
+        defaultSortOption: imagesDefaultSort,
+        onSort: () => setPage(1),
+    });
+
+    const imageTableToggle = useSelectToggle(true);
+
+    const { data, previousData, loading, error } = useQuery<
+        { deployment: ImageResources | null },
+        { id: string; query: string; pagination: PaginationParam }
+    >(deploymentResourcesQuery, {
+        variables: {
+            id: deploymentId,
+            query: '',
+            pagination: {
+                offset: (page - 1) * perPage,
+                limit: perPage,
+                sortOption,
+            },
+        },
+    });
+
+    const deploymentResourcesData = data?.deployment ?? previousData?.deployment;
+    const imageCount = deploymentResourcesData?.imageCount ?? 0;
+
     return (
         <>
-            <div>DeploymentPageResources</div>
+            <PageSection component="div" variant="light" className="pf-u-py-md pf-u-px-xl">
+                <Text>Navigate to resources associated with this deployment</Text>
+            </PageSection>
+            <Divider component="div" />
+            <PageSection
+                className="pf-u-display-flex pf-u-flex-direction-column pf-u-flex-grow-1"
+                component="div"
+            >
+                {error && (
+                    <TableErrorComponent
+                        error={error}
+                        message="Adjust your filters and try again"
+                    />
+                )}
+                {loading && !deploymentResourcesData && (
+                    <Bullseye>
+                        <Spinner isSVG />
+                    </Bullseye>
+                )}
+                {deploymentResourcesData && (
+                    <ExpandableSection
+                        toggleText={`Images (${imageCount})`}
+                        onToggle={imageTableToggle.onToggle}
+                        isExpanded={imageTableToggle.isOpen}
+                        style={
+                            {
+                                '--pf-c-expandable-section__content--MarginTop':
+                                    'var(--pf-global--spacer--xs)',
+                            } as CSSProperties
+                        }
+                    >
+                        <div className="pf-u-background-color-100 pf-u-pt-sm">
+                            <Pagination
+                                isCompact
+                                itemCount={imageCount}
+                                page={page}
+                                perPage={perPage}
+                                onSetPage={(_, newPage) => setPage(newPage)}
+                                onPerPageSelect={(_, newPerPage) => {
+                                    if (imageCount < (page - 1) * newPerPage) {
+                                        setPage(1);
+                                    }
+                                    setPerPage(newPerPage);
+                                }}
+                            />
+                            <ImageResourceTable
+                                data={deploymentResourcesData}
+                                getSortParams={getSortParams}
+                            />
+                        </div>
+                    </ExpandableSection>
+                )}
+            </PageSection>
         </>
     );
 }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/ImageResourceTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/ImageResourceTable.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { TableComposable, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
+import { gql } from '@apollo/client';
+
+import { UseURLSortResult } from 'hooks/useURLSort';
+import DatePhraseTd from '../components/DatePhraseTd';
+import EmptyTableResults from '../components/EmptyTableResults';
+import ImageNameTd from '../components/ImageNameTd';
+
+export type ImageResources = {
+    imageCount: number;
+    images: {
+        id: string;
+        name: {
+            registry: string;
+            remote: string;
+            tag: string;
+        } | null;
+        deploymentCount: number;
+        operatingSystem: string;
+        scanTime: string | null;
+    }[];
+};
+
+export const imageResourcesFragment = gql`
+    fragment ImageResources on Deployment {
+        imageCount(query: $query)
+        images(query: $query, pagination: $pagination) {
+            id
+            name {
+                registry
+                remote
+                tag
+            }
+            deploymentCount(query: $query)
+            operatingSystem
+            scanTime
+        }
+    }
+`;
+
+export type ImageResourceTableProps = {
+    data: ImageResources;
+    getSortParams: UseURLSortResult['getSortParams'];
+};
+
+function ImageResourceTable({ data, getSortParams }: ImageResourceTableProps) {
+    return (
+        <TableComposable borders={false} variant="compact">
+            <Thead noWrap>
+                <Tr>
+                    <Th sort={getSortParams('Image')}>Name</Th>
+                    <Th>Image status</Th>
+                    <Th>Image OS</Th>
+                    <Th>Created</Th>
+                </Tr>
+            </Thead>
+            {data.images.length === 0 && <EmptyTableResults colSpan={4} />}
+            {data.images.map(({ id, name, deploymentCount, operatingSystem, scanTime }) => {
+                return (
+                    <Tbody
+                        key={id}
+                        style={{
+                            borderBottom: '1px solid var(--pf-c-table--BorderColor)',
+                        }}
+                    >
+                        <Tr>
+                            <Td>{name ? <ImageNameTd id={id} name={name} /> : 'NAME UNKNOWN'}</Td>
+                            {/* Given that this is in the context of a deployment, when would `deploymentCount` ever be less than zero? */}
+                            <Td>{deploymentCount > 0 ? 'Active' : 'Inactive'}</Td>
+                            <Td>{operatingSystem}</Td>
+                            <Td>
+                                <DatePhraseTd date={scanTime} />
+                            </Td>
+                        </Tr>
+                    </Tbody>
+                );
+            })}
+        </TableComposable>
+    );
+}
+
+export default ImageResourceTable;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/DeploymentResourceTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/DeploymentResourceTable.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { Button, ButtonVariant } from '@patternfly/react-core';
+import { TableComposable, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
+import { gql } from '@apollo/client';
+
+import LinkShim from 'Components/PatternFly/LinkShim';
+import { UseURLSortResult } from 'hooks/useURLSort';
+import DatePhraseTd from '../components/DatePhraseTd';
+import EmptyTableResults from '../components/EmptyTableResults';
+import { getEntityPagePath } from '../searchUtils';
+
+export type DeploymentResources = {
+    deploymentCount: number;
+    deployments: {
+        id: string;
+        name: string;
+        clusterName: string;
+        namespace: string;
+        created: string | null;
+    }[];
+};
+
+export const deploymentResourcesFragment = gql`
+    fragment DeploymentResources on Image {
+        deploymentCount(query: $query)
+        deployments(query: $query, pagination: $pagination) {
+            id
+            name
+            clusterName
+            namespace
+            created
+        }
+    }
+`;
+
+export type DeploymentResourceTableProps = {
+    data: DeploymentResources;
+    getSortParams: UseURLSortResult['getSortParams'];
+};
+
+function DeploymentResourceTable({ data, getSortParams }: DeploymentResourceTableProps) {
+    return (
+        <TableComposable borders={false} variant="compact">
+            <Thead noWrap>
+                <Tr>
+                    <Th sort={getSortParams('Deployment')}>Name</Th>
+                    <Th sort={getSortParams('Cluster')}>Cluster</Th>
+                    <Th sort={getSortParams('Namespace')}>Namespace</Th>
+                    <Th>Created</Th>
+                </Tr>
+            </Thead>
+            {data.deployments.length === 0 && <EmptyTableResults colSpan={4} />}
+            {data.deployments.map(({ id, name, clusterName, namespace, created }) => {
+                return (
+                    <Tbody
+                        key={id}
+                        style={{
+                            borderBottom: '1px solid var(--pf-c-table--BorderColor)',
+                        }}
+                    >
+                        <Tr>
+                            <Td>
+                                <Button
+                                    variant={ButtonVariant.link}
+                                    isInline
+                                    component={LinkShim}
+                                    href={getEntityPagePath('Deployment', id)}
+                                >
+                                    {name}
+                                </Button>
+                            </Td>
+                            <Td>{clusterName}</Td>
+                            <Td>{namespace}</Td>
+                            <Td>
+                                <DatePhraseTd date={created} />
+                            </Td>
+                        </Tr>
+                    </Tbody>
+                );
+            })}
+        </TableComposable>
+    );
+}
+
+export default DeploymentResourceTable;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePage.tsx
@@ -152,9 +152,8 @@ function ImagePage() {
                             className="pf-u-display-flex pf-u-flex-direction-column pf-u-flex-grow-1"
                             eventKey="Resources"
                             title={<TabTitleText>Resources</TabTitleText>}
-                            isDisabled
                         >
-                            <ImagePageResources />
+                            <ImagePageResources imageId={imageId} />
                         </Tab>
                     </Tabs>
                 </PageSection>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageResources.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageResources.tsx
@@ -1,8 +1,125 @@
-import React from 'react';
-import { PageSection } from '@patternfly/react-core';
+import React, { CSSProperties } from 'react';
+import {
+    Bullseye,
+    Divider,
+    ExpandableSection,
+    PageSection,
+    Pagination,
+    Spinner,
+    Text,
+} from '@patternfly/react-core';
+import { gql, useQuery } from '@apollo/client';
+import { Pagination as PaginationParam } from 'services/types';
 
-function ImagePageResources() {
-    return <PageSection>Resources (TODO)</PageSection>;
+import useURLPagination from 'hooks/useURLPagination';
+import useURLSort from 'hooks/useURLSort';
+import useSelectToggle from 'hooks/patternfly/useSelectToggle';
+import { deploymentsDefaultSort, defaultDeploymentSortFields } from '../sortUtils';
+import TableErrorComponent from '../components/TableErrorComponent';
+import DeploymentResourceTable, {
+    DeploymentResources,
+    deploymentResourcesFragment,
+} from './DeploymentResourceTable';
+
+export type ImagePageResourcesProps = {
+    imageId: string;
+};
+
+const imageResourcesQuery = gql`
+    ${deploymentResourcesFragment}
+    query getImageResources($id: ID!, $query: String, $pagination: Pagination) {
+        image(id: $id) {
+            id
+            ...DeploymentResources
+        }
+    }
+`;
+
+function ImagePageResources({ imageId }: ImagePageResourcesProps) {
+    const { page, perPage, setPage, setPerPage } = useURLPagination(20);
+    const { sortOption, getSortParams } = useURLSort({
+        sortFields: defaultDeploymentSortFields,
+        defaultSortOption: deploymentsDefaultSort,
+        onSort: () => setPage(1),
+    });
+
+    const deploymentTableToggle = useSelectToggle(true);
+
+    const { data, previousData, loading, error } = useQuery<
+        { image: DeploymentResources | null },
+        { id: string; query: string; pagination: PaginationParam }
+    >(imageResourcesQuery, {
+        variables: {
+            id: imageId,
+            query: '',
+            pagination: {
+                offset: (page - 1) * perPage,
+                limit: perPage,
+                sortOption,
+            },
+        },
+    });
+
+    const imageResourcesData = data?.image ?? previousData?.image;
+    const deploymentCount = imageResourcesData?.deploymentCount ?? 0;
+
+    return (
+        <>
+            <PageSection component="div" variant="light" className="pf-u-py-md pf-u-px-xl">
+                <Text>Navigate to resources associated with this image</Text>
+            </PageSection>
+            <Divider component="div" />
+            <PageSection
+                className="pf-u-display-flex pf-u-flex-direction-column pf-u-flex-grow-1"
+                component="div"
+            >
+                {error && (
+                    <TableErrorComponent
+                        error={error}
+                        message="Adjust your filters and try again"
+                    />
+                )}
+                {loading && !imageResourcesData && (
+                    <Bullseye>
+                        <Spinner isSVG />
+                    </Bullseye>
+                )}
+                {imageResourcesData && (
+                    <ExpandableSection
+                        toggleText={`Deployments (${deploymentCount})`}
+                        onToggle={deploymentTableToggle.onToggle}
+                        isExpanded={deploymentTableToggle.isOpen}
+                        style={
+                            {
+                                '--pf-c-expandable-section__content--MarginTop':
+                                    'var(--pf-global--spacer--xs)',
+                            } as CSSProperties
+                        }
+                    >
+                        <div className="pf-u-background-color-100 pf-u-pt-sm">
+                            <Pagination
+                                isCompact
+                                itemCount={deploymentCount}
+                                page={page}
+                                perPage={perPage}
+                                onSetPage={(_, newPage) => setPage(newPage)}
+                                onPerPageSelect={(_, newPerPage) => {
+                                    if (deploymentCount < (page - 1) * newPerPage) {
+                                        setPage(1);
+                                    }
+                                    setPerPage(newPerPage);
+                                }}
+                            />
+                            <DeploymentResourceTable
+                                data={imageResourcesData}
+                                getSortParams={getSortParams}
+                            />
+                        </div>
+                    </ExpandableSection>
+                )}
+            </PageSection>
+        </>
+    );
 }
 
 export default ImagePageResources;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentsTable.tsx
@@ -120,12 +120,13 @@ function DeploymentsTable({ deployments, getSortParams, isFiltered }: Deployment
                                 <Td>{clusterName}</Td>
                                 <Td>{namespace}</Td>
                                 <Td>
-                                    {/* TODO: add modal */}
                                     <Button
                                         variant={ButtonVariant.link}
                                         isInline
                                         component={LinkShim}
-                                        href={getEntityPagePath('Deployment', id)}
+                                        href={getEntityPagePath('Deployment', id, {
+                                            detailsTab: 'Resources',
+                                        })}
                                     >
                                         {imageCount} {pluralize('image', imageCount)}
                                     </Button>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImagesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImagesTable.tsx
@@ -136,13 +136,14 @@ function ImagesTable({ images, getSortParams, isFiltered }: ImagesTableProps) {
                                 </Td>
                                 <Td>{operatingSystem}</Td>
                                 <Td>
-                                    {/* TODO: add modal */}
                                     {deploymentCount > 0 ? (
                                         <Button
                                             variant={ButtonVariant.link}
                                             isInline
                                             component={LinkShim}
-                                            href={getEntityPagePath('Deployment', id)}
+                                            href={getEntityPagePath('Image', id, {
+                                                detailsTab: 'Resources',
+                                            })}
                                         >
                                             {deploymentCount}{' '}
                                             {pluralize('deployment', deploymentCount)}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/searchUtils.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/searchUtils.tsx
@@ -29,14 +29,19 @@ export function getOverviewCvesPath(workloadCvesSearch: WorkloadCvesSearch): str
     return `${vulnerabilitiesWorkloadCvesPath}${getQueryString(workloadCvesSearch)}`;
 }
 
-export function getEntityPagePath(workloadCveEntity: EntityTab, id: string): string {
+export function getEntityPagePath(
+    workloadCveEntity: EntityTab,
+    id: string,
+    queryOptions?: qs.ParsedQs
+): string {
+    const queryString = getQueryString(queryOptions);
     switch (workloadCveEntity) {
         case 'CVE':
-            return `${vulnerabilitiesWorkloadCvesPath}/cves/${id}`;
+            return `${vulnerabilitiesWorkloadCvesPath}/cves/${id}${queryString}`;
         case 'Image':
-            return `${vulnerabilitiesWorkloadCvesPath}/images/${id}`;
+            return `${vulnerabilitiesWorkloadCvesPath}/images/${id}${queryString}`;
         case 'Deployment':
-            return `${vulnerabilitiesWorkloadCvesPath}/deployments/${id}`;
+            return `${vulnerabilitiesWorkloadCvesPath}/deployments/${id}${queryString}`;
         default:
             return ensureExhaustive(workloadCveEntity);
     }


### PR DESCRIPTION
## Description

Enables the "Resource" tabs for images and deployments, and points links from the tables on the main page to them.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

From the workload cve overview page, view the image table and click one of the "# deployments" links in the table.
![image](https://user-images.githubusercontent.com/1292638/236897101-2ab2a5e0-83a7-4921-b7cd-4768ed40336c.png)
![image](https://user-images.githubusercontent.com/1292638/236897199-50c16780-c986-449b-8969-c6f3563ace35.png)
![image](https://user-images.githubusercontent.com/1292638/236897244-360a1767-1e74-4d82-8da2-cacb961dc868.png)
Error state:
![image](https://user-images.githubusercontent.com/1292638/236897940-b4386461-05a2-4297-8357-b360c02591f2.png)

From the workload cve overview page, view the deployment table and click one of the "# images" links in the table.
![image](https://user-images.githubusercontent.com/1292638/236899013-9b9221d1-64e9-4763-8855-2db94b25e880.png)
![image](https://user-images.githubusercontent.com/1292638/236899067-4f9a3369-9d90-4507-be8c-bce5581605a0.png)
![image](https://user-images.githubusercontent.com/1292638/236899127-75bb30af-ccd0-4086-a2f1-8eb18e443572.png)

