### PR TITLE
ROX-16893: Allow references to default resources in declarative roles

### DIFF
--- a/central/auth/userpass/auth.go
+++ b/central/auth/userpass/auth.go
@@ -5,12 +5,12 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"github.com/stackrox/rox/central/role"
 	roleDatastore "github.com/stackrox/rox/central/role/datastore"
 	"github.com/stackrox/rox/central/role/mapper"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/auth/authproviders"
 	basicAuthProvider "github.com/stackrox/rox/pkg/auth/authproviders/basic"
+	"github.com/stackrox/rox/pkg/defaults/accesscontrol"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/grpc/authn"
 	basicAuthn "github.com/stackrox/rox/pkg/grpc/authn/basic"
@@ -36,7 +36,7 @@ var (
 // CreateManager creates and returns a manager for user/password authentication.
 func CreateManager(store roleDatastore.DataStore) (*basicAuthn.Manager, error) {
 	ctx := sac.WithGlobalAccessScopeChecker(context.Background(), sac.AllowAllAccessScopeChecker())
-	adminRole, found, err := store.GetRole(ctx, role.Admin)
+	adminRole, found, err := store.GetRole(ctx, accesscontrol.Admin)
 	if err != nil || !found || adminRole == nil {
 		return nil, errors.Wrap(err, "Could not look up admin role")
 	}
@@ -103,7 +103,7 @@ func RegisterAuthProviderOrPanic(ctx context.Context, mgr *basicAuthn.Manager, r
 // IdentityExtractorOrPanic creates and returns the identity extractor for basic authentication.
 func IdentityExtractorOrPanic(store roleDatastore.DataStore, mgr *basicAuthn.Manager, authProvider authproviders.Provider) authn.IdentityExtractor {
 	ctx := sac.WithGlobalAccessScopeChecker(context.Background(), sac.AllowAllAccessScopeChecker())
-	adminRole, found, err := store.GetRole(ctx, role.Admin)
+	adminRole, found, err := store.GetRole(ctx, accesscontrol.Admin)
 	if err != nil || !found || adminRole == nil {
 		log.Panic("Could not look up admin role")
 	}

--- a/central/centralhealth/service/service_impl.go
+++ b/central/centralhealth/service/service_impl.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/pkg/errors"
-	"github.com/stackrox/rox/central/role"
 	versionUtils "github.com/stackrox/rox/central/version/utils"
 	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/pkg/defaults/accesscontrol"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/fileutils"
 	"github.com/stackrox/rox/pkg/fsutils"
@@ -27,7 +27,7 @@ const (
 )
 
 var (
-	authorizer             = user.WithRole(role.Admin)
+	authorizer             = user.WithRole(accesscontrol.Admin)
 	capacityMarginFraction = migrations.CapacityMarginFraction + 0.05
 )
 

--- a/central/clusterinit/service/service_impl.go
+++ b/central/clusterinit/service/service_impl.go
@@ -8,8 +8,8 @@ import (
 	clusterStore "github.com/stackrox/rox/central/cluster/datastore"
 	"github.com/stackrox/rox/central/clusterinit/backend"
 	"github.com/stackrox/rox/central/clusterinit/store"
-	"github.com/stackrox/rox/central/role"
 	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/pkg/defaults/accesscontrol"
 	"github.com/stackrox/rox/pkg/grpc/authz/user"
 	"github.com/stackrox/rox/pkg/set"
 	"google.golang.org/grpc"
@@ -18,7 +18,7 @@ import (
 )
 
 var (
-	authorizer = user.WithRole(role.Admin)
+	authorizer = user.WithRole(accesscontrol.Admin)
 )
 
 var _ v1.ClusterInitServiceServer = (*serviceImpl)(nil)

--- a/central/main.go
+++ b/central/main.go
@@ -111,7 +111,6 @@ import (
 	"github.com/stackrox/rox/central/reprocessor"
 	collectionService "github.com/stackrox/rox/central/resourcecollection/service"
 	"github.com/stackrox/rox/central/risk/handlers/timeline"
-	"github.com/stackrox/rox/central/role"
 	roleDataStore "github.com/stackrox/rox/central/role/datastore"
 	"github.com/stackrox/rox/central/role/mapper"
 	"github.com/stackrox/rox/central/role/resources"
@@ -156,6 +155,7 @@ import (
 	"github.com/stackrox/rox/pkg/clientconn"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/config"
+	"github.com/stackrox/rox/pkg/defaults/accesscontrol"
 	"github.com/stackrox/rox/pkg/devbuild"
 	"github.com/stackrox/rox/pkg/devmode"
 	"github.com/stackrox/rox/pkg/env"
@@ -719,7 +719,7 @@ func customRoutes() (customRoutes []routes.CustomRoute) {
 		})
 		customRoutes = append(customRoutes, routes.CustomRoute{
 			Route:      "/api/extensions/backup",
-			Authorizer: user.WithRole(role.Admin),
+			Authorizer: user.WithRole(accesscontrol.Admin),
 			ServerHandler: notImplementedOnManagedServices(
 				globaldbHandlers.BackupDB(nil, nil, globaldb.GetPostgres(), listener.Singleton(), true),
 			),
@@ -752,7 +752,7 @@ func customRoutes() (customRoutes []routes.CustomRoute) {
 		})
 		customRoutes = append(customRoutes, routes.CustomRoute{
 			Route:         "/api/extensions/backup",
-			Authorizer:    user.WithRole(role.Admin),
+			Authorizer:    user.WithRole(accesscontrol.Admin),
 			ServerHandler: notImplementedOnManagedServices(globaldbHandlers.BackupDB(globaldb.GetGlobalDB(), globaldb.GetRocksDB(), nil, listener.Singleton(), true)),
 			Compression:   true,
 		})
@@ -815,7 +815,7 @@ func debugRoutes() []routes.CustomRoute {
 	for r, h := range routes.DebugRoutes {
 		customRoutes = append(customRoutes, routes.CustomRoute{
 			Route:         r,
-			Authorizer:    user.WithRole(role.Admin),
+			Authorizer:    user.WithRole(accesscontrol.Admin),
 			ServerHandler: h,
 			Compression:   true,
 		})

--- a/central/role/accessscope_ids.go
+++ b/central/role/accessscope_ids.go
@@ -1,9 +1,0 @@
-package role
-
-// Postgres IDs for access scopes
-// The values are UUIDs taken in descending order from ffffffff-ffff-fff4-f5ff-ffffffffffff
-// Next ID: ffffffff-ffff-fff4-f5ff-fffffffffffd
-const (
-	unrestrictedAccessScopeID = "ffffffff-ffff-fff4-f5ff-ffffffffffff"
-	denyAllAccessScopeID      = "ffffffff-ffff-fff4-f5ff-fffffffffffe"
-)

--- a/central/role/datastore/datastore_impl_test.go
+++ b/central/role/datastore/datastore_impl_test.go
@@ -1,3 +1,5 @@
+//go:build sql_integration
+
 package datastore
 
 import (
@@ -33,7 +35,7 @@ func TestAllDefaultRolesAreCovered(t *testing.T) {
 	// Merge the roles for vuln reporting into the defaults
 	assert.Len(t, defaultRoles, len(accesscontrol.DefaultRoleNames))
 	for r := range defaultRoles {
-		assert.Contains(t, accesscontrol.DefaultRoleNames, r)
+		assert.Truef(t, accesscontrol.DefaultRoleNames.Contains(r), "role %s not found in default role names", r)
 	}
 }
 

--- a/central/role/datastore/datastore_impl_test.go
+++ b/central/role/datastore/datastore_impl_test.go
@@ -1,5 +1,3 @@
-//go:build sql_integration
-
 package datastore
 
 import (
@@ -18,6 +16,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/bolthelper"
 	"github.com/stackrox/rox/pkg/declarativeconfig"
+	"github.com/stackrox/rox/pkg/defaults/accesscontrol"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/postgres/pgtest"
@@ -32,14 +31,14 @@ import (
 
 func TestAllDefaultRolesAreCovered(t *testing.T) {
 	// Merge the roles for vuln reporting into the defaults
-	assert.Len(t, defaultRoles, len(role.DefaultRoleNames))
+	assert.Len(t, defaultRoles, len(accesscontrol.DefaultRoleNames))
 	for r := range defaultRoles {
-		assert.Contains(t, role.DefaultRoleNames, r)
+		assert.Contains(t, accesscontrol.DefaultRoleNames, r)
 	}
 }
 
 func TestAnalystRoleDoesNotContainAdministration(t *testing.T) {
-	analystRole, found := defaultRoles[role.Analyst]
+	analystRole, found := defaultRoles[accesscontrol.Analyst]
 	// Analyst is one of the default roles.
 	assert.True(t, found)
 
@@ -267,7 +266,7 @@ func (s *roleDataStoreTestSuite) TestRoleWriteOperations() {
 	updatedGoodRole := getValidRole("valid role", secondExistingPermissionSet.GetId(), s.existingScope.GetId())
 	badRole := &storage.Role{Name: "invalid role"}
 	cloneRole := getValidRole(s.existingRole.GetName(), s.existingPermissionSet.GetId(), s.existingScope.GetId())
-	updatedAdminRole := getValidRole(role.Admin, s.existingPermissionSet.GetId(), s.existingScope.GetId())
+	updatedAdminRole := getValidRole(accesscontrol.Admin, s.existingPermissionSet.GetId(), s.existingScope.GetId())
 	declarativeRole := getValidRole("declarative role", s.existingDeclarativePermissionSet.GetId(), s.existingDeclarativeScope.GetId())
 	declarativeRole.Traits = &storage.Traits{
 		Origin: storage.Traits_DECLARATIVE,
@@ -507,7 +506,7 @@ func (s *roleDataStoreTestSuite) TestPermissionSetWriteOperations() {
 	badDeclarativePermissionSet.Traits = &storage.Traits{
 		Origin: storage.Traits_DECLARATIVE,
 	}
-	updatedAdminPermissionSet := getValidPermissionSet(role.EnsureValidAccessScopeID("admin"), role.Admin)
+	updatedAdminPermissionSet := getValidPermissionSet(role.EnsureValidAccessScopeID("admin"), accesscontrol.Admin)
 
 	err := s.dataStore.AddPermissionSet(s.hasWriteCtx, badPermissionSet)
 	s.ErrorIs(err, errox.InvalidArgs, "invalid permission set for Add*() yields an error")

--- a/central/role/datastore/singleton.go
+++ b/central/role/datastore/singleton.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/auth/permissions"
 	permissionsUtils "github.com/stackrox/rox/pkg/auth/permissions/utils"
+	"github.com/stackrox/rox/pkg/defaults/accesscontrol"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/sync"
@@ -77,30 +78,30 @@ func (attributes *roleAttributes) getID() string {
 }
 
 var defaultRoles = map[string]roleAttributes{
-	rolePkg.Admin: {
+	accesscontrol.Admin: {
 		idSuffix:           "admin",
-		postgresID:         adminPermissionSetID,
+		postgresID:         accesscontrol.DefaultPermissionSetIDs[accesscontrol.Admin],
 		description:        "For users: use it to provide read and write access to all the resources",
 		resourceWithAccess: resources.AllResourcesModifyPermissions(),
 	},
-	rolePkg.Analyst: {
+	accesscontrol.Analyst: {
 		idSuffix:           "analyst",
-		postgresID:         analystPermissionSetID,
+		postgresID:         accesscontrol.DefaultPermissionSetIDs[accesscontrol.Analyst],
 		resourceWithAccess: rolePkg.GetAnalystPermissions(),
 		description:        "For users: use it to give read-only access to all the resources",
 	},
-	rolePkg.ContinuousIntegration: {
+	accesscontrol.ContinuousIntegration: {
 		idSuffix:    "continuousintegration",
-		postgresID:  continuousIntegrationPermissionSetID,
+		postgresID:  accesscontrol.DefaultPermissionSetIDs[accesscontrol.ContinuousIntegration],
 		description: "For automation: it includes the permissions required to enforce deployment policies",
 		resourceWithAccess: []permissions.ResourceWithAccess{
 			permissions.View(resources.Detection),
 			permissions.Modify(resources.Image),
 		},
 	},
-	rolePkg.NetworkGraphViewer: {
+	accesscontrol.NetworkGraphViewer: {
 		idSuffix:    "networkgraphviewer",
-		postgresID:  networkGraphViewerPermissionSetID,
+		postgresID:  accesscontrol.DefaultPermissionSetIDs[accesscontrol.NetworkGraphViewer],
 		description: "For users: use it to give read-only access to the NetworkGraph pages",
 		resourceWithAccess: []permissions.ResourceWithAccess{
 			permissions.View(resources.Deployment),
@@ -108,15 +109,15 @@ var defaultRoles = map[string]roleAttributes{
 			permissions.View(resources.NetworkPolicy),
 		},
 	},
-	rolePkg.None: {
+	accesscontrol.None: {
 		idSuffix:    "none",
-		postgresID:  nonePermissionSetID,
+		postgresID:  accesscontrol.DefaultPermissionSetIDs[accesscontrol.None],
 		description: "For users: use it to provide no read and write access to any resource",
 	},
 	// TODO: ROX-14398 Remove ScopeManager default role
-	rolePkg.ScopeManager: {
+	accesscontrol.ScopeManager: {
 		idSuffix:    "scopemanager",
-		postgresID:  scopeManagerPermissionSetID,
+		postgresID:  accesscontrol.DefaultPermissionSetIDs[accesscontrol.ScopeManager],
 		description: "For users: use it to create and modify scopes for the purpose of access control or vulnerability reporting",
 		resourceWithAccess: []permissions.ResourceWithAccess{
 			permissions.View(resources.Access),
@@ -126,9 +127,9 @@ var defaultRoles = map[string]roleAttributes{
 			permissions.Modify(resources.Role),
 		},
 	},
-	rolePkg.SensorCreator: {
+	accesscontrol.SensorCreator: {
 		idSuffix:    "sensorcreator",
-		postgresID:  sensorCreatorPermissionSetID,
+		postgresID:  accesscontrol.DefaultPermissionSetIDs[accesscontrol.SensorCreator],
 		description: "For automation: it consists of the permissions to create Sensors in secured clusters",
 		resourceWithAccess: []permissions.ResourceWithAccess{
 			permissions.View(resources.Cluster),
@@ -136,18 +137,18 @@ var defaultRoles = map[string]roleAttributes{
 			permissions.Modify(resources.Administration),
 		},
 	},
-	rolePkg.VulnMgmtApprover: {
+	accesscontrol.VulnMgmtApprover: {
 		idSuffix:    "vulnmgmtapprover",
-		postgresID:  vulnMgmtApproverPermissionSetID,
+		postgresID:  accesscontrol.DefaultPermissionSetIDs[accesscontrol.VulnMgmtApprover],
 		description: "For users: use it to provide access to approve vulnerability deferrals or false positive requests",
 		resourceWithAccess: []permissions.ResourceWithAccess{
 			permissions.View(resources.VulnerabilityManagementApprovals),
 			permissions.Modify(resources.VulnerabilityManagementApprovals),
 		},
 	},
-	rolePkg.VulnMgmtRequester: {
+	accesscontrol.VulnMgmtRequester: {
 		idSuffix:    "vulnmgmtrequester",
-		postgresID:  vulnMgmtRequesterPermissionSetID,
+		postgresID:  accesscontrol.DefaultPermissionSetIDs[accesscontrol.VulnMgmtRequester],
 		description: "For users: use it to provide access to request vulnerability deferrals or false positives",
 		resourceWithAccess: []permissions.ResourceWithAccess{
 			permissions.View(resources.VulnerabilityManagementRequests),
@@ -155,9 +156,9 @@ var defaultRoles = map[string]roleAttributes{
 		},
 	},
 	// TODO ROX-13888 when we migrate to WorkflowAdministration we can remove VulnerabilityReports and Role resources
-	rolePkg.VulnReporter: {
+	accesscontrol.VulnReporter: {
 		idSuffix:    "vulnreporter",
-		postgresID:  vulnReporterPermissionSetID,
+		postgresID:  accesscontrol.DefaultPermissionSetIDs[accesscontrol.VulnReporter],
 		description: "For users: use it to create and manage vulnerability reporting configurations for scheduled vulnerability reports",
 		resourceWithAccess: func() []permissions.ResourceWithAccess {
 			if !env.PostgresDatastoreEnabled.BooleanSetting() {
@@ -175,9 +176,9 @@ var defaultRoles = map[string]roleAttributes{
 			}
 		}(),
 	},
-	rolePkg.VulnerabilityManager: {
+	accesscontrol.VulnerabilityManager: {
 		idSuffix:    "vulnmgmt",
-		postgresID:  vulnMgmtPermissionSetID,
+		postgresID:  accesscontrol.DefaultPermissionSetIDs[accesscontrol.VulnerabilityManager],
 		description: "For users: use it to provide access to analyze and manage system vulnerabilities",
 		resourceWithAccess: []permissions.ResourceWithAccess{
 			permissions.View(resources.Cluster),

--- a/central/role/default.go
+++ b/central/role/default.go
@@ -4,58 +4,12 @@ import (
 	"github.com/stackrox/rox/central/role/resources"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/auth/permissions"
+	"github.com/stackrox/rox/pkg/defaults/accesscontrol"
 	"github.com/stackrox/rox/pkg/env"
-	"github.com/stackrox/rox/pkg/grpc/authn"
 	"github.com/stackrox/rox/pkg/set"
 )
 
-// All builtin, immutable role names are declared in the block below.
-const (
-	// Admin is a role that's, well, authorized to do anything.
-	Admin = "Admin"
-
-	// Analyst is a role that has read access to all resources.
-	Analyst = "Analyst"
-
-	// None role has no access.
-	None = authn.NoneRole
-
-	// ContinuousIntegration is for CI pipelines.
-	ContinuousIntegration = "Continuous Integration"
-
-	// NetworkGraphViewer is a role that has the minimal privileges required to display network graphs.
-	NetworkGraphViewer = "Network Graph Viewer"
-
-	// SensorCreator is a role that has the minimal privileges required to create a sensor.
-	SensorCreator = "Sensor Creator"
-
-	// VulnerabilityManager is a role that has the necessary privileges required to view and manage system vulnerabilities and its insights.
-	// This includes privileges to:
-	// - view cluster, node, namespace, deployments, images (along with its scan data), and vulnerability requests.
-	// - view and create requests to watch images for vulnerability insights.
-	// - view and request vulnerability deferrals or false positives. This does include permissions to approve vulnerability requests.
-	// - view and create vulnerability reports.
-	VulnerabilityManager = "Vulnerability Manager"
-
-	// VulnMgmtApprover is a role that has the minimal privileges required to approve vulnerability deferrals or false positive requests.
-	VulnMgmtApprover = "Vulnerability Management Approver"
-
-	// VulnMgmtRequester is a role that has the minimal privileges required to request vulnerability deferrals or false positives.
-	VulnMgmtRequester = "Vulnerability Management Requester"
-
-	// TODO: ROX-14398 Remove default role VulnReporter
-	// VulnReporter is a role that has the minimal privileges required to create and manage vulnerability reporting configurations.
-	VulnReporter = "Vulnerability Report Creator"
-
-	// TODO: ROX-14398 Remove ScopeManager default role
-	// ScopeManager is a role that has the minimal privileges to view and modify scopes for use in access control, vulnerability reporting etc.
-	ScopeManager = "Scope Manager"
-)
-
 var (
-	// DefaultRoleNames is a string set containing the names of all default (built-in) Roles.
-	DefaultRoleNames = set.NewStringSet(Admin, Analyst, None, ContinuousIntegration, ScopeManager, SensorCreator, VulnerabilityManager, VulnMgmtApprover, VulnMgmtRequester, VulnReporter)
-
 	// defaultScopesIDs is a string set containing the names of all default (built-in) scopes.
 	defaultScopesIDs = set.NewFrozenStringSet(AccessScopeIncludeAll.Id, AccessScopeExcludeAll.Id)
 
@@ -63,7 +17,7 @@ var (
 	// scoped resources. Global resources must be unaffected.
 	AccessScopeExcludeAll = &storage.SimpleAccessScope{
 		Id:          getAccessScopeExcludeAllID(),
-		Name:        "Deny All",
+		Name:        accesscontrol.DenyAllAccessScope,
 		Description: "No access to scoped resources",
 		Rules:       &storage.SimpleAccessScope_Rules{},
 		Traits: &storage.Traits{
@@ -75,7 +29,7 @@ var (
 	// Rules cannot represent unrestricted scope.
 	AccessScopeIncludeAll = &storage.SimpleAccessScope{
 		Id:          getAccessScopeIncludeAllID(),
-		Name:        "Unrestricted",
+		Name:        accesscontrol.UnrestrictedAccessScope,
 		Description: "Access to all clusters and namespaces",
 		Traits: &storage.Traits{
 			Origin: storage.Traits_DEFAULT,
@@ -85,27 +39,27 @@ var (
 
 func getAccessScopeExcludeAllID() string {
 	if env.PostgresDatastoreEnabled.BooleanSetting() {
-		return denyAllAccessScopeID
+		return accesscontrol.DefaultAccessScopeIDFromName(accesscontrol.DenyAllAccessScope)
 	}
 	return EnsureValidAccessScopeID("denyall")
 }
 
 func getAccessScopeIncludeAllID() string {
 	if env.PostgresDatastoreEnabled.BooleanSetting() {
-		return unrestrictedAccessScopeID
+		return accesscontrol.DefaultAccessScopeIDFromName(accesscontrol.UnrestrictedAccessScope)
 	}
 	return EnsureValidAccessScopeID("unrestricted")
 }
 
 // IsDefaultRole checks if a given role corresponds to a default role.
 func IsDefaultRole(role *storage.Role) bool {
-	return role.GetTraits().GetOrigin() == storage.Traits_DEFAULT || DefaultRoleNames.Contains(role.GetName())
+	return role.GetTraits().GetOrigin() == storage.Traits_DEFAULT || accesscontrol.IsDefaultRole(role.GetName())
 }
 
 // IsDefaultPermissionSet checks if a given permission set corresponds to a default role.
 func IsDefaultPermissionSet(permissionSet *storage.PermissionSet) bool {
 	return permissionSet.GetTraits().GetOrigin() == storage.Traits_DEFAULT ||
-		DefaultRoleNames.Contains(permissionSet.GetName())
+		accesscontrol.IsDefaultPermissionSet(permissionSet.GetName())
 }
 
 // IsDefaultAccessScope checks if a given access scope corresponds to a

--- a/central/role/default.go
+++ b/central/role/default.go
@@ -39,14 +39,14 @@ var (
 
 func getAccessScopeExcludeAllID() string {
 	if env.PostgresDatastoreEnabled.BooleanSetting() {
-		return accesscontrol.DefaultAccessScopeIDFromName(accesscontrol.DenyAllAccessScope)
+		return accesscontrol.DefaultAccessScopeIDs[accesscontrol.DenyAllAccessScope]
 	}
 	return EnsureValidAccessScopeID("denyall")
 }
 
 func getAccessScopeIncludeAllID() string {
 	if env.PostgresDatastoreEnabled.BooleanSetting() {
-		return accesscontrol.DefaultAccessScopeIDFromName(accesscontrol.UnrestrictedAccessScope)
+		return accesscontrol.DefaultAccessScopeIDs[accesscontrol.UnrestrictedAccessScope]
 	}
 	return EnsureValidAccessScopeID("unrestricted")
 }

--- a/central/role/default_test.go
+++ b/central/role/default_test.go
@@ -4,12 +4,13 @@ import (
 	"testing"
 
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/defaults/accesscontrol"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestIsDefaultRole(t *testing.T) {
-	defaultRoleWithTraits := &storage.Role{Name: Admin, Traits: &storage.Traits{Origin: storage.Traits_DEFAULT}}
-	defaultRoleWithoutTraits := &storage.Role{Name: Admin}
+	defaultRoleWithTraits := &storage.Role{Name: accesscontrol.Admin, Traits: &storage.Traits{Origin: storage.Traits_DEFAULT}}
+	defaultRoleWithoutTraits := &storage.Role{Name: accesscontrol.Admin}
 	nonDefaultRole := &storage.Role{Name: "some-random-role"}
 
 	assert.True(t, IsDefaultRole(defaultRoleWithTraits))
@@ -29,9 +30,9 @@ func TestIsDefaultAccessScope(t *testing.T) {
 }
 
 func TestIsDefaultPermissionSet(t *testing.T) {
-	defaultPermissionSetWithTraits := &storage.PermissionSet{Name: Admin,
+	defaultPermissionSetWithTraits := &storage.PermissionSet{Name: accesscontrol.Admin,
 		Traits: &storage.Traits{Origin: storage.Traits_DEFAULT}}
-	defaultPermissionSetWithoutTraits := &storage.PermissionSet{Name: Admin}
+	defaultPermissionSetWithoutTraits := &storage.PermissionSet{Name: accesscontrol.Admin}
 	nonDefaultPermissionSet := &storage.PermissionSet{Name: "some-random-permission-set"}
 
 	assert.True(t, IsDefaultPermissionSet(defaultPermissionSetWithTraits))

--- a/central/role/mapper/always_admin_mapper_impl.go
+++ b/central/role/mapper/always_admin_mapper_impl.go
@@ -3,9 +3,9 @@ package mapper
 import (
 	"context"
 
-	"github.com/stackrox/rox/central/role"
 	roleDatastore "github.com/stackrox/rox/central/role/datastore"
 	"github.com/stackrox/rox/pkg/auth/permissions"
+	"github.com/stackrox/rox/pkg/defaults/accesscontrol"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/utils"
 )
@@ -24,7 +24,7 @@ func AlwaysAdminRoleMapper() permissions.RoleMapper {
 	// It is only valid to store a reference to the Admin role because it is
 	// immutable, otherwise we would fetch it on every FromUserDescriptor call.
 	ctx := sac.WithGlobalAccessScopeChecker(context.Background(), sac.AllowAllAccessScopeChecker())
-	adminRole, err := roleDatastore.Singleton().GetAndResolveRole(ctx, role.Admin)
+	adminRole, err := roleDatastore.Singleton().GetAndResolveRole(ctx, accesscontrol.Admin)
 	utils.CrashOnError(err)
 
 	return &alwaysAdminMapperImpl{

--- a/pkg/declarativeconfig/transform/role.go
+++ b/pkg/declarativeconfig/transform/role.go
@@ -6,7 +6,9 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/declarativeconfig"
+	"github.com/stackrox/rox/pkg/defaults/accesscontrol"
 	"github.com/stackrox/rox/pkg/errox"
+	"github.com/stackrox/rox/pkg/stringutils"
 )
 
 var (
@@ -38,11 +40,13 @@ func (r *roleTransform) Transform(configuration declarativeconfig.Configuration)
 	}
 
 	roleProto := &storage.Role{
-		Name:            roleConfig.Name,
-		Description:     roleConfig.Description,
-		PermissionSetId: declarativeconfig.NewDeclarativePermissionSetUUID(roleConfig.PermissionSet).String(),
-		AccessScopeId:   declarativeconfig.NewDeclarativeAccessScopeUUID(roleConfig.AccessScope).String(),
-		Traits:          &storage.Traits{Origin: storage.Traits_DECLARATIVE},
+		Name:        roleConfig.Name,
+		Description: roleConfig.Description,
+		PermissionSetId: stringutils.FirstNonEmpty(accesscontrol.DefaultPermissionSetIDs[roleConfig.PermissionSet],
+			declarativeconfig.NewDeclarativePermissionSetUUID(roleConfig.PermissionSet).String()),
+		AccessScopeId: stringutils.FirstNonEmpty(accesscontrol.DefaultAccessScopeIDFromName(roleConfig.AccessScope),
+			declarativeconfig.NewDeclarativeAccessScopeUUID(roleConfig.AccessScope).String()),
+		Traits: &storage.Traits{Origin: storage.Traits_DECLARATIVE},
 	}
 	return map[reflect.Type][]proto.Message{
 		roleType: {roleProto},

--- a/pkg/declarativeconfig/transform/role.go
+++ b/pkg/declarativeconfig/transform/role.go
@@ -44,7 +44,7 @@ func (r *roleTransform) Transform(configuration declarativeconfig.Configuration)
 		Description: roleConfig.Description,
 		PermissionSetId: stringutils.FirstNonEmpty(accesscontrol.DefaultPermissionSetIDs[roleConfig.PermissionSet],
 			declarativeconfig.NewDeclarativePermissionSetUUID(roleConfig.PermissionSet).String()),
-		AccessScopeId: stringutils.FirstNonEmpty(accesscontrol.DefaultAccessScopeIDFromName(roleConfig.AccessScope),
+		AccessScopeId: stringutils.FirstNonEmpty(accesscontrol.DefaultAccessScopeIDs[roleConfig.AccessScope],
 			declarativeconfig.NewDeclarativeAccessScopeUUID(roleConfig.AccessScope).String()),
 		Traits: &storage.Traits{Origin: storage.Traits_DECLARATIVE},
 	}

--- a/pkg/declarativeconfig/transform/role_test.go
+++ b/pkg/declarativeconfig/transform/role_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/declarativeconfig"
+	"github.com/stackrox/rox/pkg/defaults/accesscontrol"
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -80,5 +81,32 @@ func TestTransformRole(t *testing.T) {
 	assert.Equal(t, role.Description, roleProto.GetDescription())
 	assert.Equal(t, declarativeconfig.NewDeclarativeAccessScopeUUID(role.AccessScope).String(), roleProto.GetAccessScopeId())
 	assert.Equal(t, declarativeconfig.NewDeclarativePermissionSetUUID(role.PermissionSet).String(), roleProto.GetPermissionSetId())
+	assert.Equal(t, storage.Traits_DECLARATIVE, roleProto.GetTraits().GetOrigin())
+}
+
+func TestTransformRole_DefaultValues(t *testing.T) {
+	role := &declarativeconfig.Role{
+		Name:          "some-role",
+		Description:   "with references to default resources",
+		AccessScope:   accesscontrol.UnrestrictedAccessScope,
+		PermissionSet: accesscontrol.Admin,
+	}
+
+	rt := newRoleTransform()
+
+	protos, err := rt.Transform(role)
+	assert.NoError(t, err)
+
+	require.Len(t, protos, 1)
+	require.Contains(t, protos, roleType)
+	require.Len(t, protos[roleType], 1)
+
+	roleProto, ok := protos[roleType][0].(*storage.Role)
+	require.True(t, ok)
+
+	assert.Equal(t, role.Name, roleProto.GetName())
+	assert.Equal(t, role.Description, roleProto.GetDescription())
+	assert.Equal(t, accesscontrol.DefaultAccessScopeIDFromName(role.AccessScope), roleProto.GetAccessScopeId())
+	assert.Equal(t, accesscontrol.DefaultPermissionSetIDs[role.PermissionSet], roleProto.GetPermissionSetId())
 	assert.Equal(t, storage.Traits_DECLARATIVE, roleProto.GetTraits().GetOrigin())
 }

--- a/pkg/declarativeconfig/transform/role_test.go
+++ b/pkg/declarativeconfig/transform/role_test.go
@@ -106,7 +106,7 @@ func TestTransformRole_DefaultValues(t *testing.T) {
 
 	assert.Equal(t, role.Name, roleProto.GetName())
 	assert.Equal(t, role.Description, roleProto.GetDescription())
-	assert.Equal(t, accesscontrol.DefaultAccessScopeIDFromName(role.AccessScope), roleProto.GetAccessScopeId())
+	assert.Equal(t, accesscontrol.DefaultAccessScopeIDs[role.AccessScope], roleProto.GetAccessScopeId())
 	assert.Equal(t, accesscontrol.DefaultPermissionSetIDs[role.PermissionSet], roleProto.GetPermissionSetId())
 	assert.Equal(t, storage.Traits_DECLARATIVE, roleProto.GetTraits().GetOrigin())
 }

--- a/pkg/defaults/accesscontrol/access_scope.go
+++ b/pkg/defaults/accesscontrol/access_scope.go
@@ -1,0 +1,29 @@
+package accesscontrol
+
+const (
+	// UnrestrictedAccessScope is the name of the default unrestricted access scope.
+	UnrestrictedAccessScope = "Unrestricted"
+	// DenyAllAccessScope is the name of the default deny all access scope.
+	DenyAllAccessScope = "Deny all"
+)
+
+// Postgres IDs for access scopes
+// The values are UUIDs taken in descending order from ffffffff-ffff-fff4-f5ff-ffffffffffff
+// Next ID: ffffffff-ffff-fff4-f5ff-fffffffffffd
+const (
+	unrestrictedAccessScopeID = "ffffffff-ffff-fff4-f5ff-ffffffffffff"
+	denyAllAccessScopeID      = "ffffffff-ffff-fff4-f5ff-fffffffffffe"
+)
+
+// DefaultAccessScopeIDFromName returns the default access scope ID for the given name.
+// In case the name is not a default access scope, return an empty string.
+func DefaultAccessScopeIDFromName(name string) string {
+	switch name {
+	case UnrestrictedAccessScope:
+		return unrestrictedAccessScopeID
+	case DenyAllAccessScope:
+		return denyAllAccessScopeID
+	default:
+		return ""
+	}
+}

--- a/pkg/defaults/accesscontrol/access_scope.go
+++ b/pkg/defaults/accesscontrol/access_scope.go
@@ -15,15 +15,10 @@ const (
 	denyAllAccessScopeID      = "ffffffff-ffff-fff4-f5ff-fffffffffffe"
 )
 
-// DefaultAccessScopeIDFromName returns the default access scope ID for the given name.
-// In case the name is not a default access scope, return an empty string.
-func DefaultAccessScopeIDFromName(name string) string {
-	switch name {
-	case UnrestrictedAccessScope:
-		return unrestrictedAccessScopeID
-	case DenyAllAccessScope:
-		return denyAllAccessScopeID
-	default:
-		return ""
+var (
+	// DefaultAccessScopeIDs holds all UUIDs for default access scopes.
+	DefaultAccessScopeIDs = map[string]string{
+		UnrestrictedAccessScope: unrestrictedAccessScopeID,
+		DenyAllAccessScope:      denyAllAccessScopeID,
 	}
-}
+)

--- a/pkg/defaults/accesscontrol/permission_set.go
+++ b/pkg/defaults/accesscontrol/permission_set.go
@@ -1,0 +1,41 @@
+package accesscontrol
+
+// Postgres IDs for permission sets
+// The values are UUIDs taken in descending order from ffffffff-ffff-fff4-f5ff-ffffffffffff
+// Next ID: ffffffff-ffff-fff4-f5ff-fffffffffff4
+const (
+	adminPermissionSetID                 = "ffffffff-ffff-fff4-f5ff-ffffffffffff"
+	analystPermissionSetID               = "ffffffff-ffff-fff4-f5ff-fffffffffffe"
+	continuousIntegrationPermissionSetID = "ffffffff-ffff-fff4-f5ff-fffffffffffd"
+	nonePermissionSetID                  = "ffffffff-ffff-fff4-f5ff-fffffffffffc"
+	// TODO: ROX-14398 Remove ScopeManager default role
+	scopeManagerPermissionSetID       = "ffffffff-ffff-fff4-f5ff-fffffffffffb"
+	sensorCreatorPermissionSetID      = "ffffffff-ffff-fff4-f5ff-fffffffffffa"
+	vulnMgmtApproverPermissionSetID   = "ffffffff-ffff-fff4-f5ff-fffffffffff9"
+	vulnMgmtRequesterPermissionSetID  = "ffffffff-ffff-fff4-f5ff-fffffffffff8"
+	vulnReporterPermissionSetID       = "ffffffff-ffff-fff4-f5ff-fffffffffff7"
+	vulnMgmtPermissionSetID           = "ffffffff-ffff-fff4-f5ff-fffffffffff6"
+	networkGraphViewerPermissionSetID = "ffffffff-ffff-fff4-f5ff-fffffffffff5"
+)
+
+var (
+	// DefaultPermissionSetIDs is a list of all permission set IDs keyed by their name.
+	DefaultPermissionSetIDs = map[string]string{
+		Admin:                 adminPermissionSetID,
+		Analyst:               analystPermissionSetID,
+		ContinuousIntegration: continuousIntegrationPermissionSetID,
+		NetworkGraphViewer:    networkGraphViewerPermissionSetID,
+		None:                  nonePermissionSetID,
+		ScopeManager:          scopeManagerPermissionSetID,
+		SensorCreator:         sensorCreatorPermissionSetID,
+		VulnMgmtApprover:      vulnMgmtApproverPermissionSetID,
+		VulnMgmtRequester:     vulnMgmtRequesterPermissionSetID,
+		VulnReporter:          vulnReporterPermissionSetID,
+		VulnerabilityManager:  vulnMgmtPermissionSetID,
+	}
+)
+
+// IsDefaultPermissionSet will return true if the given permission set name is a default permission set.
+func IsDefaultPermissionSet(name string) bool {
+	return DefaultRoleNames.Contains(name)
+}

--- a/pkg/defaults/accesscontrol/role.go
+++ b/pkg/defaults/accesscontrol/role.go
@@ -48,48 +48,10 @@ const (
 	ScopeManager = "Scope Manager"
 )
 
-// Postgres IDs for permission sets
-// The values are UUIDs taken in descending order from ffffffff-ffff-fff4-f5ff-ffffffffffff
-// Next ID: ffffffff-ffff-fff4-f5ff-fffffffffff4
-const (
-	adminPermissionSetID                 = "ffffffff-ffff-fff4-f5ff-ffffffffffff"
-	analystPermissionSetID               = "ffffffff-ffff-fff4-f5ff-fffffffffffe"
-	continuousIntegrationPermissionSetID = "ffffffff-ffff-fff4-f5ff-fffffffffffd"
-	nonePermissionSetID                  = "ffffffff-ffff-fff4-f5ff-fffffffffffc"
-	// TODO: ROX-14398 Remove ScopeManager default role
-	scopeManagerPermissionSetID       = "ffffffff-ffff-fff4-f5ff-fffffffffffb"
-	sensorCreatorPermissionSetID      = "ffffffff-ffff-fff4-f5ff-fffffffffffa"
-	vulnMgmtApproverPermissionSetID   = "ffffffff-ffff-fff4-f5ff-fffffffffff9"
-	vulnMgmtRequesterPermissionSetID  = "ffffffff-ffff-fff4-f5ff-fffffffffff8"
-	vulnReporterPermissionSetID       = "ffffffff-ffff-fff4-f5ff-fffffffffff7"
-	vulnMgmtPermissionSetID           = "ffffffff-ffff-fff4-f5ff-fffffffffff6"
-	networkGraphViewerPermissionSetID = "ffffffff-ffff-fff4-f5ff-fffffffffff5"
-)
-
 var (
 	// DefaultRoleNames is a string set containing the names of all default (built-in) Roles.
 	DefaultRoleNames = set.NewStringSet(Admin, Analyst, NetworkGraphViewer, None, ContinuousIntegration, ScopeManager, SensorCreator, VulnerabilityManager, VulnMgmtApprover, VulnMgmtRequester, VulnReporter)
-
-	// DefaultPermissionSetIDs is a list of all permission set IDs keyed by their name.
-	DefaultPermissionSetIDs = map[string]string{
-		Admin:                 adminPermissionSetID,
-		Analyst:               analystPermissionSetID,
-		ContinuousIntegration: continuousIntegrationPermissionSetID,
-		NetworkGraphViewer:    networkGraphViewerPermissionSetID,
-		None:                  nonePermissionSetID,
-		ScopeManager:          scopeManagerPermissionSetID,
-		SensorCreator:         sensorCreatorPermissionSetID,
-		VulnMgmtApprover:      vulnMgmtApproverPermissionSetID,
-		VulnMgmtRequester:     vulnMgmtRequesterPermissionSetID,
-		VulnReporter:          vulnReporterPermissionSetID,
-		VulnerabilityManager:  vulnMgmtPermissionSetID,
-	}
 )
-
-// IsDefaultPermissionSet will return true if the given permission set name is a default permission set.
-func IsDefaultPermissionSet(name string) bool {
-	return DefaultRoleNames.Contains(name)
-}
 
 // IsDefaultRole will return true if the given role name is a default role.
 func IsDefaultRole(name string) bool {

--- a/pkg/defaults/accesscontrol/role.go
+++ b/pkg/defaults/accesscontrol/role.go
@@ -1,0 +1,97 @@
+package accesscontrol
+
+import (
+	"github.com/stackrox/rox/pkg/grpc/authn"
+	"github.com/stackrox/rox/pkg/set"
+)
+
+// All builtin, immutable role names are declared in the block below.
+const (
+	// Admin is a role that's, well, authorized to do anything.
+	Admin = "Admin"
+
+	// Analyst is a role that has read access to all resources.
+	Analyst = "Analyst"
+
+	// None role has no access.
+	None = authn.NoneRole
+
+	// ContinuousIntegration is for CI pipelines.
+	ContinuousIntegration = "Continuous Integration"
+
+	// NetworkGraphViewer is a role that has the minimal privileges required to display network graphs.
+	NetworkGraphViewer = "Network Graph Viewer"
+
+	// SensorCreator is a role that has the minimal privileges required to create a sensor.
+	SensorCreator = "Sensor Creator"
+
+	// VulnerabilityManager is a role that has the necessary privileges required to view and manage system vulnerabilities and its insights.
+	// This includes privileges to:
+	// - view cluster, node, namespace, deployments, images (along with its scan data), and vulnerability requests.
+	// - view and create requests to watch images for vulnerability insights.
+	// - view and request vulnerability deferrals or false positives. This does include permissions to approve vulnerability requests.
+	// - view and create vulnerability reports.
+	VulnerabilityManager = "Vulnerability Manager"
+
+	// VulnMgmtApprover is a role that has the minimal privileges required to approve vulnerability deferrals or false positive requests.
+	VulnMgmtApprover = "Vulnerability Management Approver"
+
+	// VulnMgmtRequester is a role that has the minimal privileges required to request vulnerability deferrals or false positives.
+	VulnMgmtRequester = "Vulnerability Management Requester"
+
+	// TODO: ROX-14398 Remove default role VulnReporter
+	// VulnReporter is a role that has the minimal privileges required to create and manage vulnerability reporting configurations.
+	VulnReporter = "Vulnerability Report Creator"
+
+	// TODO: ROX-14398 Remove ScopeManager default role
+	// ScopeManager is a role that has the minimal privileges to view and modify scopes for use in access control, vulnerability reporting etc.
+	ScopeManager = "Scope Manager"
+)
+
+// Postgres IDs for permission sets
+// The values are UUIDs taken in descending order from ffffffff-ffff-fff4-f5ff-ffffffffffff
+// Next ID: ffffffff-ffff-fff4-f5ff-fffffffffff4
+const (
+	adminPermissionSetID                 = "ffffffff-ffff-fff4-f5ff-ffffffffffff"
+	analystPermissionSetID               = "ffffffff-ffff-fff4-f5ff-fffffffffffe"
+	continuousIntegrationPermissionSetID = "ffffffff-ffff-fff4-f5ff-fffffffffffd"
+	nonePermissionSetID                  = "ffffffff-ffff-fff4-f5ff-fffffffffffc"
+	// TODO: ROX-14398 Remove ScopeManager default role
+	scopeManagerPermissionSetID       = "ffffffff-ffff-fff4-f5ff-fffffffffffb"
+	sensorCreatorPermissionSetID      = "ffffffff-ffff-fff4-f5ff-fffffffffffa"
+	vulnMgmtApproverPermissionSetID   = "ffffffff-ffff-fff4-f5ff-fffffffffff9"
+	vulnMgmtRequesterPermissionSetID  = "ffffffff-ffff-fff4-f5ff-fffffffffff8"
+	vulnReporterPermissionSetID       = "ffffffff-ffff-fff4-f5ff-fffffffffff7"
+	vulnMgmtPermissionSetID           = "ffffffff-ffff-fff4-f5ff-fffffffffff6"
+	networkGraphViewerPermissionSetID = "ffffffff-ffff-fff4-f5ff-fffffffffff5"
+)
+
+var (
+	// DefaultRoleNames is a string set containing the names of all default (built-in) Roles.
+	DefaultRoleNames = set.NewStringSet(Admin, Analyst, None, ContinuousIntegration, ScopeManager, SensorCreator, VulnerabilityManager, VulnMgmtApprover, VulnMgmtRequester, VulnReporter)
+
+	// DefaultPermissionSetIDs is a list of all permission set IDs keyed by their name.
+	DefaultPermissionSetIDs = map[string]string{
+		Admin:                 adminPermissionSetID,
+		Analyst:               analystPermissionSetID,
+		ContinuousIntegration: continuousIntegrationPermissionSetID,
+		NetworkGraphViewer:    networkGraphViewerPermissionSetID,
+		None:                  nonePermissionSetID,
+		ScopeManager:          scopeManagerPermissionSetID,
+		SensorCreator:         sensorCreatorPermissionSetID,
+		VulnMgmtApprover:      vulnMgmtApproverPermissionSetID,
+		VulnMgmtRequester:     vulnMgmtRequesterPermissionSetID,
+		VulnReporter:          vulnReporterPermissionSetID,
+		VulnerabilityManager:  vulnMgmtPermissionSetID,
+	}
+)
+
+// IsDefaultPermissionSet will return true if the given permission set name is a default permission set.
+func IsDefaultPermissionSet(name string) bool {
+	return DefaultRoleNames.Contains(name)
+}
+
+// IsDefaultRole will return true if the given role name is a default role.
+func IsDefaultRole(name string) bool {
+	return DefaultRoleNames.Contains(name)
+}

--- a/pkg/defaults/accesscontrol/role.go
+++ b/pkg/defaults/accesscontrol/role.go
@@ -68,7 +68,7 @@ const (
 
 var (
 	// DefaultRoleNames is a string set containing the names of all default (built-in) Roles.
-	DefaultRoleNames = set.NewStringSet(Admin, Analyst, None, ContinuousIntegration, ScopeManager, SensorCreator, VulnerabilityManager, VulnMgmtApprover, VulnMgmtRequester, VulnReporter)
+	DefaultRoleNames = set.NewStringSet(Admin, Analyst, NetworkGraphViewer, None, ContinuousIntegration, ScopeManager, SensorCreator, VulnerabilityManager, VulnMgmtApprover, VulnMgmtRequester, VulnReporter)
 
 	// DefaultPermissionSetIDs is a list of all permission set IDs keyed by their name.
 	DefaultPermissionSetIDs = map[string]string{


### PR DESCRIPTION
## Description

This PR allows roles created via declarative configuration to reference default resources (specifically permission sets and access scopes), which previously wasn't possible.

The change required refactoring of the existing role package which defined the default resources.

Specficially, the following was done:
- a new `accesscontrol` package was created under `pkg/defaults`.
- the consts for roles and access scopes have been moved there. As a result, all current role imports have been moved to `accesscontrol` within central.
- the transformer for roles has been adjusted to first check if the referenced permission set or role is a default one before attempting to create a UUID out of the name.

One caveat is within this PR:
This currently only works for postgres. In non-postgres environments, the IDs are created on-the-fly, which makes it not possible to expose these within the `pkg/declarativeconfig/transform` during runtime.
However, since declarative configuration is planned for release in 4.1 and postgres is mandatory from 4.0, this shouldn't be of concern.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

- see added unit tests.

