### PR TITLE
ROX-14908 (GHA): create OSCI configuration for new releases from template instead of master configuration

### DIFF
--- a/.github/workflows/cut-rc.yml
+++ b/.github/workflows/cut-rc.yml
@@ -410,7 +410,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ":tada: *<https://infra.rox.systems/cluster/${{ steps.get_demo_artifacts.outputs.cluster-name }}|Openshift 4 Demo cluster> `${{ steps.get_demo_artifacts.outputs.cluster-name }}` is creating for ${{ needs.variables.outputs.milestone }} milestone of <${{ github.server_url }}/${{ github.repository }}|${{ github.repository }}>.*"
+                    "text": ":tada: *<https://infra.rox.systems/cluster/${{ steps.get_demo_artifacts.outputs.cluster-name }}|Openshift 4 Demo cluster> `${{ steps.get_demo_artifacts.outputs.cluster-name }}` is being created for ${{ needs.variables.outputs.milestone }} milestone of <${{ github.server_url }}/${{ github.repository }}|${{ github.repository }}>.*"
                   }
                 },
                 {

--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -194,11 +194,10 @@ jobs:
         env:
           CFG_DIR: "ci-operator/config/stackrox/stackrox"
         run: |
-          # Duplicate the main config and keep only postsubmit jobs.
-          yq "del(.tests[] | select(.postsubmit != true or has(\"cron\"))) |
-              .zz_generated_metadata.branch=\"release-$RELEASE\"" \
-            "$CFG_DIR/stackrox-stackrox-master.yaml" \
-            > "$CFG_DIR/stackrox-$BRANCH.yaml"
+          # Duplicate the template configurations
+          for yaml in "$CFG_DIR"/stackrox-stackrox-release-x.y*.yaml ; do
+            yq eval ".zz_generated_metadata.branch=\"release-$RELEASE\"" "$yaml" > "${yaml//stackrox-release-x.y/$BRANCH}"
+          done
 
       - name: Make update
         if: steps.check-existing.outputs.branch-exists == 'false'


### PR DESCRIPTION
## Description

* creates OSCI configuration in upstream release flow for new releases from the `release-x.y` templates instead of the master configuration. The templates were created in https://github.com/openshift/release/commit/11e4e5088f49d864e8d9e13a0e34727c4ec5c371. 

I will not backport changes from this PR to release branches for 3.x and 4.0, as neither will run `start-release` code to produce new OSCI configuration)

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Tested in https://github.com/stackrox/test-gh-actions/pull/95, produced https://github.com/openshift/release/pull/39103 (file names fixed in https://github.com/stackrox/test-gh-actions/pull/95/commits/e34e3b43babf0d4e51c16cb4ad5de591c6a5ea35) 
