### PR TITLE
Dashrews/ROX-16779 rollback to central active

### DIFF
--- a/migrator/clone/metadata/db_clone_impl.go
+++ b/migrator/clone/metadata/db_clone_impl.go
@@ -29,6 +29,9 @@ kubectl -n stackrox set env deploy/central ROX_DONT_COMPARE_DEV_BUILDS=true
 
 	// ErrUnableToRestore -- cannot restore upgraded backup to a downgraded central
 	ErrUnableToRestore = "The backup bundle being restored is from an upgraded version of central and thus cannot applied.  The restored version %s, current version %s"
+
+	// ErrSoftwareNotCompatibleWithDatabase -- downgrade is not supported as software is incompatible with the data.
+	ErrSoftwareNotCompatibleWithDatabase = "Software downgrade is not supported.  Software supports database version of %d but database request software to support a database version of at least %d"
 )
 
 // DBClone -- holds information related to DB clones
@@ -52,6 +55,14 @@ func (d *DBClone) GetSeqNum() int {
 		return 0
 	}
 	return d.migVer.SeqNum
+}
+
+// GetMinimumSeqNum -- returns the minimum sequence number supported by the database.
+func (d *DBClone) GetMinimumSeqNum() int {
+	if d.migVer == nil {
+		return 0
+	}
+	return d.migVer.MinimumSeqNum
 }
 
 // GetDirName -- returns the file system location of the clone.  (Only valid pre-Postgres)

--- a/migrator/clone/metadata/db_clone_impl.go
+++ b/migrator/clone/metadata/db_clone_impl.go
@@ -31,7 +31,7 @@ kubectl -n stackrox set env deploy/central ROX_DONT_COMPARE_DEV_BUILDS=true
 	ErrUnableToRestore = "The backup bundle being restored is from an upgraded version of central and thus cannot applied.  The restored version %s, current version %s"
 
 	// ErrSoftwareNotCompatibleWithDatabase -- downgrade is not supported as software is incompatible with the data.
-	ErrSoftwareNotCompatibleWithDatabase = "Software downgrade is not supported.  Software supports database version of %d but database request software to support a database version of at least %d"
+	ErrSoftwareNotCompatibleWithDatabase = "Software downgrade is not supported.  The software supports database version of %d but the database requires the software support a database version to be at least least %d"
 )
 
 // DBClone -- holds information related to DB clones

--- a/migrator/clone/mock_central.go
+++ b/migrator/clone/mock_central.go
@@ -206,16 +206,15 @@ func (m *mockCentral) upgradeDB(path, _, pgClone string) {
 }
 
 func (m *mockCentral) downgradeDB(path, _, pgClone string) {
-	if env.PostgresDatastoreEnabled.BooleanSetting() {
-		if exists, _ := pgadmin.CheckIfDBExists(m.adminConfig, pgClone); exists {
-			cloneVer, err := migVer.ReadVersionPostgres(m.ctx, pgClone)
-			require.NoError(m.t, err)
-			require.GreaterOrEqual(m.t, cloneVer.SeqNum, migrations.CurrentDBVersionSeqNum())
-		}
-		if !m.runBoth {
-			return
-		}
+	if exists, _ := pgadmin.CheckIfDBExists(m.adminConfig, pgClone); exists {
+		cloneVer, err := migVer.ReadVersionPostgres(m.ctx, pgClone)
+		require.NoError(m.t, err)
+		require.GreaterOrEqual(m.t, cloneVer.SeqNum, migrations.CurrentDBVersionSeqNum())
 	}
+	if !m.runBoth {
+		return
+	}
+
 	if path != "" {
 		// Verify no downgrade
 		if exists, _ := fileutils.Exists(filepath.Join(path, "db")); exists {

--- a/migrator/clone/mock_central.go
+++ b/migrator/clone/mock_central.go
@@ -44,8 +44,9 @@ var (
 )
 
 type versionPair struct {
-	version string
-	seqNum  int
+	version   string
+	seqNum    int
+	minSeqNum int
 }
 
 type mockCentral struct {
@@ -104,10 +105,12 @@ func (m *mockCentral) destroyCentral() {
 func (m *mockCentral) rebootCentral() {
 	curSeq := migrations.CurrentDBVersionSeqNum()
 	curVer := version.GetMainVersion()
+	curMinSeq := migrations.MinimumSupportedDBVersionSeqNum()
 	m.runMigrator("", "")
 	m.runCentral()
 	assert.Equal(m.t, curSeq, migrations.CurrentDBVersionSeqNum())
 	assert.Equal(m.t, curVer, version.GetMainVersion())
+	assert.Equal(m.t, curMinSeq, migrations.MinimumSupportedDBVersionSeqNum())
 }
 
 func (m *mockCentral) migrateWithVersion(ver *versionPair, breakpoint string, forceRollback string) {
@@ -137,7 +140,11 @@ func (m *mockCentral) legacyUpgrade(t *testing.T, ver *versionPair, previousVer 
 }
 
 func (m *mockCentral) upgradeCentral(ver *versionPair, breakpoint string) {
-	curVer := &versionPair{version: version.GetMainVersion(), seqNum: migrations.CurrentDBVersionSeqNum()}
+	curVer := &versionPair{
+		version:   version.GetMainVersion(),
+		seqNum:    migrations.CurrentDBVersionSeqNum(),
+		minSeqNum: migrations.MinimumSupportedDBVersionSeqNum()}
+
 	m.migrateWithVersion(ver, breakpoint, "")
 	// Re-run migrator if the previous one breaks
 	if breakpoint != "" {
@@ -198,6 +205,31 @@ func (m *mockCentral) upgradeDB(path, _, pgClone string) {
 	}
 }
 
+func (m *mockCentral) downgradeDB(path, _, pgClone string) {
+	if env.PostgresDatastoreEnabled.BooleanSetting() {
+		if exists, _ := pgadmin.CheckIfDBExists(m.adminConfig, pgClone); exists {
+			cloneVer, err := migVer.ReadVersionPostgres(m.ctx, pgClone)
+			require.NoError(m.t, err)
+			require.GreaterOrEqual(m.t, cloneVer.SeqNum, migrations.CurrentDBVersionSeqNum())
+		}
+		if !m.runBoth {
+			return
+		}
+	}
+	if path != "" {
+		// Verify no downgrade
+		if exists, _ := fileutils.Exists(filepath.Join(path, "db")); exists {
+			data, err := os.ReadFile(filepath.Join(path, "db"))
+			require.NoError(m.t, err)
+			currDBSeq, err := strconv.Atoi(string(data))
+			require.NoError(m.t, err)
+			require.LessOrEqual(m.t, currDBSeq, migrations.CurrentDBVersionSeqNum())
+		}
+
+		require.NoError(m.t, os.WriteFile(filepath.Join(path, "db"), []byte(fmt.Sprintf("%d", mathutil.MinInt(migrations.LastRocksDBVersionSeqNum(), migrations.CurrentDBVersionSeqNum()))), 0644))
+	}
+}
+
 func (m *mockCentral) runMigrator(breakPoint string, forceRollback string) {
 	var dbm DBCloneManager
 
@@ -238,7 +270,11 @@ func (m *mockCentral) runMigrator(breakPoint string, forceRollback string) {
 		return
 	}
 
-	m.upgradeDB(clonePath, clone, pgClone)
+	if forceRollback == "" {
+		m.upgradeDB(clonePath, clone, pgClone)
+	} else {
+		m.downgradeDB(clonePath, clone, pgClone)
+	}
 	if breakPoint == breakBeforePersist {
 		return
 	}
@@ -290,7 +326,11 @@ func (m *mockCentral) runCentral() {
 }
 
 func (m *mockCentral) restoreCentral(ver *versionPair, breakPoint string, rocksToPostgres bool) {
-	curVer := &versionPair{version: version.GetMainVersion(), seqNum: migrations.CurrentDBVersionSeqNum()}
+	curVer := &versionPair{
+		version:   version.GetMainVersion(),
+		seqNum:    migrations.CurrentDBVersionSeqNum(),
+		minSeqNum: migrations.MinimumSupportedDBVersionSeqNum(),
+	}
 	m.restore(ver, rocksToPostgres)
 	if breakPoint == "" {
 		m.runMigrator(breakPoint, "")
@@ -341,7 +381,7 @@ func (m *mockCentral) restore(ver *versionPair, rocksToPostgres bool) {
 
 func (m *mockCentral) verifyCurrent() {
 	if env.PostgresDatastoreEnabled.BooleanSetting() {
-		m.verifyClonePostgres(pgClone.CurrentClone, &versionPair{version: version.GetMainVersion(), seqNum: migrations.CurrentDBVersionSeqNum()})
+		m.verifyClonePostgres(pgClone.CurrentClone, &versionPair{version: version.GetMainVersion(), seqNum: migrations.CurrentDBVersionSeqNum(), minSeqNum: migrations.MinimumSupportedDBVersionSeqNum()})
 	} else {
 		m.verifyClone(rocksdb.CurrentClone, &versionPair{version: version.GetMainVersion(), seqNum: migrations.CurrentDBVersionSeqNum()})
 	}
@@ -361,19 +401,19 @@ func (m *mockCentral) verifyClonePostgres(clone string, ver *versionPair) {
 	if version.CompareVersions(ver.version, "3.0.57.0") >= 0 {
 		m.verifyMigrationVersionPostgres(clone, ver)
 	} else {
-		m.verifyMigrationVersionPostgres(clone, &versionPair{version: "0", seqNum: 0})
+		m.verifyMigrationVersionPostgres(clone, &versionPair{version: "0", seqNum: 0, minSeqNum: 0})
 	}
 }
 
 func (m *mockCentral) setMigrationVersion(path string, ver *versionPair) {
-	migVer := migrations.MigrationVersion{MainVersion: ver.version, SeqNum: ver.seqNum}
+	migVer := migrations.MigrationVersion{MainVersion: ver.version, SeqNum: ver.seqNum, MinimumSeqNum: ver.minSeqNum}
 	bytes, err := yaml.Marshal(migVer)
 	require.NoError(m.t, err)
 	require.NoError(m.t, os.WriteFile(filepath.Join(path, migrations.MigrationVersionFile), bytes, 0644))
 }
 
 func (m *mockCentral) setMigrationVersionPostgres(clone string, ver *versionPair) {
-	migVer.SetVersionPostgres(m.ctx, clone, &storage.Version{SeqNum: int32(ver.seqNum), Version: ver.version})
+	migVer.SetVersionPostgres(m.ctx, clone, &storage.Version{SeqNum: int32(ver.seqNum), Version: ver.version, MinSeqNum: int32(ver.minSeqNum)})
 }
 
 func (m *mockCentral) verifyMigrationVersion(dbPath string, ver *versionPair) {
@@ -388,6 +428,7 @@ func (m *mockCentral) verifyMigrationVersionPostgres(clone string, ver *versionP
 	require.NoError(m.t, err)
 	log.Infof("clone => %q.  Version incoming => %v", clone, ver)
 	assert.Equal(m.t, ver.seqNum, migVer.SeqNum)
+	assert.Equal(m.t, ver.minSeqNum, migVer.MinimumSeqNum)
 	require.Equal(m.t, ver.version, migVer.MainVersion)
 }
 

--- a/migrator/clone/postgres/db_clone_manager_impl.go
+++ b/migrator/clone/postgres/db_clone_manager_impl.go
@@ -71,25 +71,20 @@ func (d *dbCloneManagerImpl) Scan() error {
 	if !currExists || currClone.GetMigVersion() == nil {
 		log.Info("Cannot find the current database or it has no version, so we need to let it create and ignore other clones.")
 	} else {
-		if currClone.GetSeqNum() > migrations.CurrentDBVersionSeqNum() || version.CompareVersions(currClone.GetVersion(), version.GetMainVersion()) > 0 {
-			// If there is no previous clone or force rollback is not requested, we cannot downgrade.
-			prevClone, prevExists := d.cloneMap[PreviousClone]
-			if !prevExists && currClone.GetSeqNum() > migrations.CurrentDBVersionSeqNum() {
-				if version.GetVersionKind(currClone.GetVersion()) == version.ReleaseKind && version.GetVersionKind(version.GetMainVersion()) == version.ReleaseKind {
-					return errors.New(metadata.ErrNoPrevious)
-				}
-				return errors.New(metadata.ErrNoPreviousInDevEnv)
-			}
-
+		// If the database version is newer than the software version make the user explicitly state they want to rollback.
+		// TODO:  Do we still want to do this `forceRollbackVersion` check?
+		if version.CompareVersions(currClone.GetVersion(), version.GetMainVersion()) > 0 {
 			// Force rollback is not requested.
 			if d.forceRollbackVersion != version.GetMainVersion() {
 				return errors.New(metadata.ErrForceUpgradeDisabled)
 			}
+		}
 
-			// If previous clone does not match
-			if prevExists && prevClone.GetVersion() != version.GetMainVersion() {
-				return errors.Errorf(metadata.ErrPreviousMismatchWithVersions, prevClone.GetVersion(), version.GetMainVersion())
-			}
+		// current sequence number == database sequence number -- All good
+		// current sequence number != database sequence number BUT database min >= current min -- ALL Good
+		// version min < current database min -- DO NOT ROLLBACK
+		if currClone.GetMinimumSeqNum() > migrations.MinimumSupportedDBVersionSeqNum() {
+			return errors.Errorf(metadata.ErrSoftwareNotCompatibleWithDatabase, migrations.MinimumSupportedDBVersionSeqNum(), currClone.GetMinimumSeqNum())
 		}
 	}
 
@@ -175,20 +170,22 @@ func (d *dbCloneManagerImpl) GetCloneToMigrate(rocksVersion *migrations.Migratio
 		}
 	}
 
-	prevClone, prevExists := d.cloneMap[PreviousClone]
+	// TODO(ROX-16774) -- Remove the use of central_temp and central_previous as all work will be done in
+	// central_active.
 	// Only need to make a copy if the migrations need to be performed
 	if d.rollbackEnabled() && currClone.GetSeqNum() != migrations.CurrentDBVersionSeqNum() {
-		// If previous clone has the same version as current version, the previous upgrade was not completed.
-		// Central could be in a loop of booting up the service. So we should continue to run with current.
-		if prevExists && currClone.GetVersion() == prevClone.GetVersion() {
-			return CurrentClone, false, nil
-		}
+		// This is a rollback.  The minimum sequence number check was performed in the scan, so if we are here, we
+		// can safely assume that passed and we can proceed rolling our version back with a compatible version of the
+		// central database.
 		if version.CompareVersions(currClone.GetVersion(), version.GetMainVersion()) > 0 || currClone.GetSeqNum() > migrations.CurrentDBVersionSeqNum() {
+			log.Infof("rollback to %q", currClone.GetDatabaseName())
 			// Force rollback
-			return PreviousClone, false, nil
+			return CurrentClone, false, nil
 		}
 
 		d.safeRemove(PreviousClone)
+		// This is an upgrade, we are going to use `central_temp` until ROX-16774 so that a rollback to the previous
+		// version works.  At the point of ROX-16774 all upgrades and rollbacks will use a single database.
 		if d.hasSpaceForRollback() {
 			// Create a temp clone for processing of current
 			// If such a clone already exists then we were previously in the middle of processing
@@ -217,11 +214,6 @@ func (d *dbCloneManagerImpl) GetCloneToMigrate(rocksVersion *migrations.Migratio
 
 		// If the space is not enough to make a clone, continue to upgrade with current.
 		return CurrentClone, false, nil
-	}
-
-	// Rollback from previous version.
-	if prevExists && prevClone.GetVersion() == version.GetMainVersion() {
-		return PreviousClone, false, nil
 	}
 
 	log.Info("Fell through all checks to return current.")
@@ -259,8 +251,6 @@ func (d *dbCloneManagerImpl) Persist(cloneName string) error {
 		// No need to persist
 	case TempClone:
 		return d.doPersist(cloneName, PreviousClone)
-	case PreviousClone:
-		return d.doPersist(cloneName, "")
 	default:
 		utils.CrashOnError(errors.Errorf("commit with unknown clone: %s", cloneName))
 	}
@@ -304,6 +294,8 @@ func (d *dbCloneManagerImpl) doPersist(cloneName string, prev string) error {
 	return nil
 }
 
+// TODO(ROX-16774) -- remove this.  At that point all work will be performend in a single database with the possible
+// exception of restores for a ACS hosted Postgres.
 func (d *dbCloneManagerImpl) moveClones(previousClone, updatedClone string) error {
 	// Connect to different database for admin functions
 	connectPool, err := pgadmin.GetAdminPool(d.adminConfig)
@@ -356,6 +348,8 @@ func (d *dbCloneManagerImpl) moveClones(previousClone, updatedClone string) erro
 	return nil
 }
 
+// TODO(ROX-16774) -- remove this.  At that point all work will be performend in a single database with the possible
+// exception of restores for a ACS hosted Postgres.
 func (d *dbCloneManagerImpl) renameClone(ctx context.Context, tx *postgres.Tx, srcClone, destClone string) error {
 	// Move the current to the previous clone
 	err := pgadmin.TerminateConnection(d.adminConfig, srcClone)
@@ -385,6 +379,8 @@ func (d *dbCloneManagerImpl) rollbackEnabled() bool {
 	return currClone.GetSeqNum() != 0
 }
 
+// TODO(ROX-16774) -- remove this.  At that point all work will be performed in a single database with the possible
+// exception of restores for a ACS hosted Postgres.
 func (d *dbCloneManagerImpl) hasSpaceForRollback() bool {
 	currReplica, currExists := d.cloneMap[CurrentClone]
 	if !currExists {

--- a/pkg/migrations/testutils/utils.go
+++ b/pkg/migrations/testutils/utils.go
@@ -13,6 +13,12 @@ func SetCurrentDBSequenceNumber(t *testing.T, seqNum int) {
 	internal.CurrentDBVersionSeqNum = seqNum
 }
 
+// SetCurrentMinDBSequenceNumber is used in unit test only
+func SetCurrentMinDBSequenceNumber(t *testing.T, minSeqNum int) {
+	testutils.MustBeInTest(t)
+	internal.MinimumSupportedDBVersionSeqNum = minSeqNum
+}
+
 // SetDBMountPath is used for unit test only
 func SetDBMountPath(t *testing.T, dbPath string) {
 	testutils.MustBeInTest(t)


### PR DESCRIPTION
## Description

Made updates so that a rollback to 4.1 will not use `central_previous` for the rollback.  It will use `central_active` under the assumption that in 4.2 all changes will be backwards compatible with 4.1.  Rollbacks from 4.1 to an earlier release will still use `central_previous`.  Upon upgrade to 4.1, `central_previous` will still be created.  That copy of `central_previous` will end in 4.2.  Highlights:

- If the minimum database sequence number of the software is less than the minimum database sequence number in the database, then an error will be thrown signifying that the database has had breaking changes that are not supported by this version of the software.  For example, some change in 4.10 deletes a column that was deprecated in 4.3 then we would not be able to rollback from 4.10 to a version older than 4.3.  
- Updates to not use `central_previous` if we are in a rollback.
- The `forceRollbackVersion` is retained at this time.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Updated the unit and integration tests to drive and verify the conditions.
