### PR TITLE
ROX-16693: RuntimePolicyTest allow apt failure (backport 3.73)

### DIFF
--- a/qa-tests-backend/src/test/groovy/DeploymentTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DeploymentTest.groovy
@@ -20,7 +20,7 @@ class DeploymentTest extends BaseSpecification {
             .setName(DEPLOYMENT_NAME)
             .setImage("nginx@sha256:204a9a8e65061b10b92ad361dd6f406248404fe60efd5d6a8f2595f18bb37aad")
             .addLabel("app", "test")
-            .setCommand(["sh", "-c", "apt-get -y update && sleep 600"])
+            .setCommand(["sh", "-c", "apt-get -y update || true && sleep 600"])
 
     private static final Job JOB = new Job()
             .setName("test-job-pi")

--- a/qa-tests-backend/src/test/groovy/RuntimePolicyTest.groovy
+++ b/qa-tests-backend/src/test/groovy/RuntimePolicyTest.groovy
@@ -20,20 +20,20 @@ class RuntimePolicyTest extends BaseSpecification  {
                     .setImage ("quay.io/rhacs-eng/qa:nginx-"+
                                "204a9a8e65061b10b92ad361dd6f406248404fe60efd5d6a8f2595f18bb37aad")
                     .addLabel ( "app", "test" )
-                    .setCommand(["sh" , "-c" , "apt-get -y update && sleep 600"]),
+                    .setCommand(["sh" , "-c" , "apt-get -y update || true && sleep 600"]),
             new Deployment()
                     .setName (DEPLOYMENTAPT)
                     .setImage ("quay.io/rhacs-eng/qa:redis-"+
                                "96be1b5b6e4fe74dfe65b2b52a0fee254c443184b34fe448f3b3498a512db99e")
                     .addLabel ( "app", "test" )
-                    .setCommand(["sh" , "-c" , "apt -y update && sleep 600"]),
+                    .setCommand(["sh" , "-c" , "apt -y update || true && sleep 600"]),
     ]
 
     static final private DEPLOYMENTREMOVAL =  new Deployment()
             .setName ("runtimeremoval")
             .setImage ("quay.io/rhacs-eng/qa:redis-96be1b5b6e4fe74dfe65b2b52a0fee254c443184b34fe448f3b3498a512db99e")
             .addLabel ( "app", "test" )
-            .setCommand(["sh" , "-c" , "apt -y update && sleep 600"])
+            .setCommand(["sh" , "-c" , "apt -y update || true && sleep 600"])
 
     def setupSpec() {
         orchestrator.batchCreateDeployments(DEPLOYMENTS)

--- a/qa-tests-backend/src/test/groovy/RuntimeViolationLifecycleTest.groovy
+++ b/qa-tests-backend/src/test/groovy/RuntimeViolationLifecycleTest.groovy
@@ -22,7 +22,7 @@ class RuntimeViolationLifecycleTest extends BaseSpecification  {
         .setName(DEPLOYMENTNAME)
         .setImage ("quay.io/rhacs-eng/qa:nginx-204a9a8e65061b10b92ad361dd6f406248404fe60efd5d6a8f2595f18bb37aad")
         .addLabel ("app", DEPLOYMENTNAME)
-        .setCommand(["sh" , "-c" , "apt-get -y update && sleep 600"])
+        .setCommand(["sh" , "-c" , "apt-get -y update || true && sleep 600"])
 
     def checkPolicyExists(String policyName) {
         assert getPolicies().stream()


### PR DESCRIPTION
## Description

Backport https://github.com/stackrox/stackrox/pull/5802 to release 3.73 to avoid flakes with release CI.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient.