### PR TITLE
ROX-16737: Add audit logs for custom routes

### DIFF
--- a/central/audit/audit.go
+++ b/central/audit/audit.go
@@ -39,8 +39,7 @@ func New(notifications processor.Processor) auditPkg.Auditor {
 	}
 }
 
-// SendAuditMessage will send an audit message for the specified request. It is done on an adhoc basis as opposed to via the unary interceptor
-// because GraphQL mutation apis won't get intercepted. This will be removed in the future once GraphQL also goes through the same pipeline as other APIs
+// SendAuditMessage will send an audit message for the specified request.
 func (a *audit) SendAuditMessage(ctx context.Context, req interface{}, grpcMethod string, authError interceptor.AuthStatus, requestError error) {
 	if !a.notifications.HasEnabledAuditNotifiers() {
 		return
@@ -136,6 +135,7 @@ func (a *audit) UnaryServerInterceptor() func(ctx context.Context, req interface
 	}
 }
 
+// PostAuthHTTPInterceptor is the interceptor for audit logging after the route authorization handler.
 func (a *audit) PostAuthHTTPInterceptor(handler http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		statusTrackingWriter := httputil.NewStatusTrackingWriter(w)

--- a/central/graphql/resolvers/vulnerability_requests.go
+++ b/central/graphql/resolvers/vulnerability_requests.go
@@ -13,7 +13,6 @@ import (
 	vulnReqUtils "github.com/stackrox/rox/central/vulnerabilityrequest/utils"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
-	"github.com/stackrox/rox/pkg/grpc/authz/interceptor"
 	pkgMetrics "github.com/stackrox/rox/pkg/metrics"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/paginated"
@@ -76,19 +75,6 @@ func init() {
 		schema.AddQuery("vulnerabilityRequests(query: String, requestIDSelector: String, pagination: Pagination): [VulnerabilityRequest!]!"),
 		schema.AddQuery("vulnerabilityRequestsCount(query: String): Int!"),
 	)
-}
-
-// processWithAuditLog runs handler and logs to the audit log pipeline (assuming there is a notifier setup for audit logging).
-// It logs details of the request and if there was an error. processWithAuditLog will return the response and error directly
-// from handler. You may need to cast it back to your desired type.
-// This is required because currently audit logs are only automatically added for GRPC calls and not GraphQL.
-// However, mutating calls should also log. This is a workaround for this limitation.
-func (resolver *Resolver) processWithAuditLog(ctx context.Context, req interface{}, method string, handler func() (interface{}, error)) (interface{}, error) {
-	resp, err := handler()
-	if resolver.AuditLogger != nil {
-		go resolver.AuditLogger.SendAdhocAuditMessage(ctx, req, method, interceptor.AuthStatus{}, err)
-	}
-	return resp, err
 }
 
 // DeferVulnerability starts the  workflow to defer a vulnerability.

--- a/central/main.go
+++ b/central/main.go
@@ -823,7 +823,6 @@ func debugRoutes() []routes.CustomRoute {
 			Authorizer:    user.WithRole(role.Admin),
 			ServerHandler: h,
 			Compression:   true,
-			EnableAudit:   true,
 		})
 	}
 	return customRoutes

--- a/central/main.go
+++ b/central/main.go
@@ -694,17 +694,20 @@ func customRoutes() (customRoutes []routes.CustomRoute) {
 			Route:         "/db/v2/restore",
 			Authorizer:    dbAuthz.DBWriteAccessAuthorizer(),
 			ServerHandler: backupRestoreService.Singleton().RestoreHandler(),
+			EnableAudit:   true,
 		},
 		{
 			Route:         "/db/v2/resumerestore",
 			Authorizer:    dbAuthz.DBWriteAccessAuthorizer(),
 			ServerHandler: backupRestoreService.Singleton().ResumeRestoreHandler(),
+			EnableAudit:   true,
 		},
 		{
 			Route:         "/api/logimbue",
 			Authorizer:    user.With(),
 			ServerHandler: logimbueHandler.Singleton(),
 			Compression:   false,
+			EnableAudit:   true,
 		},
 	}
 
@@ -762,6 +765,7 @@ func customRoutes() (customRoutes []routes.CustomRoute) {
 			Route:         "/db/restore",
 			Authorizer:    dbAuthz.DBWriteAccessAuthorizer(),
 			ServerHandler: globaldbHandlers.RestoreDB(globaldb.GetGlobalDB(), globaldb.GetRocksDB()),
+			EnableAudit:   true,
 		})
 	}
 
@@ -796,6 +800,7 @@ func customRoutes() (customRoutes []routes.CustomRoute) {
 				},
 			}),
 			ServerHandler: definitionsFileGzipHandler(scannerDefinitionsHandler.Singleton()),
+			EnableAudit:   true,
 		},
 	)
 
@@ -818,6 +823,7 @@ func debugRoutes() []routes.CustomRoute {
 			Authorizer:    user.WithRole(role.Admin),
 			ServerHandler: h,
 			Compression:   true,
+			EnableAudit:   true,
 		})
 	}
 	return customRoutes

--- a/pkg/audit/audit.go
+++ b/pkg/audit/audit.go
@@ -11,6 +11,6 @@ import (
 // Auditor implements a unary server interceptor
 type Auditor interface {
 	UnaryServerInterceptor() func(context.Context, interface{}, *grpc.UnaryServerInfo, grpc.UnaryHandler) (interface{}, error)
-	HTTPInterceptor(handler http.Handler) http.Handler
-	SendAdhocAuditMessage(ctx context.Context, req interface{}, grpcMethod string, authError interceptor.AuthStatus, requestError error)
+	PostAuthHTTPInterceptor(handler http.Handler) http.Handler
+	SendAuditMessage(ctx context.Context, req interface{}, grpcMethod string, authError interceptor.AuthStatus, requestError error)
 }

--- a/pkg/audit/audit.go
+++ b/pkg/audit/audit.go
@@ -2,6 +2,7 @@ package audit
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/stackrox/rox/pkg/grpc/authz/interceptor"
 	"google.golang.org/grpc"
@@ -10,5 +11,6 @@ import (
 // Auditor implements a unary server interceptor
 type Auditor interface {
 	UnaryServerInterceptor() func(context.Context, interface{}, *grpc.UnaryServerInfo, grpc.UnaryHandler) (interface{}, error)
+	HTTPInterceptor(handler http.Handler) http.Handler
 	SendAdhocAuditMessage(ctx context.Context, req interface{}, grpcMethod string, authError interceptor.AuthStatus, requestError error)
 }

--- a/pkg/grpc/routes/routes.go
+++ b/pkg/grpc/routes/routes.go
@@ -26,6 +26,7 @@ type CustomRoute struct {
 	Authorizer    authz.Authorizer
 	ServerHandler http.Handler
 	Compression   bool
+	EnableAudit   bool
 }
 
 // RPCNameForHTTP returns the RPCName to be used for this HTTP route.

--- a/pkg/grpc/server.go
+++ b/pkg/grpc/server.go
@@ -287,6 +287,14 @@ func (a *apiImpl) muxer(localConn *grpc.ClientConn) http.Handler {
 	}
 	for _, route := range allRoutes {
 		handler := preAuthHTTPInterceptors(route.Handler(postAuthHTTPInterceptors))
+
+		if a.config.Auditor != nil && route.EnableAudit {
+			postAuthHTTPInterceptorsWithAudit := httputil.ChainInterceptors(
+				append([]httputil.HTTPInterceptor{a.config.Auditor.HTTPInterceptor}, postAuthHTTPInterceptors)...,
+			)
+			handler = preAuthHTTPInterceptors(route.Handler(postAuthHTTPInterceptorsWithAudit))
+		}
+
 		if a.config.HTTPMetrics != nil {
 			handler = a.config.HTTPMetrics.WrapHandler(handler, route.Route)
 		}

--- a/pkg/grpc/server.go
+++ b/pkg/grpc/server.go
@@ -290,7 +290,7 @@ func (a *apiImpl) muxer(localConn *grpc.ClientConn) http.Handler {
 
 		if a.config.Auditor != nil && route.EnableAudit {
 			postAuthHTTPInterceptorsWithAudit := httputil.ChainInterceptors(
-				append([]httputil.HTTPInterceptor{a.config.Auditor.HTTPInterceptor}, postAuthHTTPInterceptors)...,
+				append([]httputil.HTTPInterceptor{a.config.Auditor.PostAuthHTTPInterceptor}, postAuthHTTPInterceptors)...,
 			)
 			handler = preAuthHTTPInterceptors(route.Handler(postAuthHTTPInterceptorsWithAudit))
 		}

--- a/pkg/httputil/status_tracking_writer.go
+++ b/pkg/httputil/status_tracking_writer.go
@@ -2,6 +2,8 @@ package httputil
 
 import (
 	"net/http"
+
+	"github.com/pkg/errors"
 )
 
 // StatusTrackingWriter tracks status code written to ResponseWriter instance.
@@ -27,6 +29,15 @@ func (w *StatusTrackingWriter) recordStatusCodeOnce(statusCode int) {
 // GetStatusCode returns recorded status code. Returns nil if no status code was recorded.
 func (w *StatusTrackingWriter) GetStatusCode() *int {
 	return w.statusCode
+}
+
+// GetStatusCodeError returns error for status code. Return nil if status code is OK.
+func (w *StatusTrackingWriter) GetStatusCodeError() error {
+	if w.statusCode == nil || *w.statusCode == http.StatusOK {
+		return nil
+	}
+
+	return errors.Errorf("%d %s", *w.statusCode, http.StatusText(*w.statusCode))
 }
 
 // WriteHeader records statusCode and calls underlying WriteHeader.


### PR DESCRIPTION
## Description

This PR is adding audit logs for custom routes that are modifying the status of the ACS stack.

The following changes are made:
- HTTP Interceptor handler is added to auditor
- several custom routes are marked to have enabled audit
- helper function for status code error is moved into `StatusTrackingWriter` - so that it can be reused
- audit log for GraphQL mutation `complianceTriggerRuns` is added

**EDIT: After review**
- removed not used `log` variable from `central/audit/audit.go`
- removed internal `sendAuditMessage` function and promoted `SendAdhocAuditMessage` to `SendAuditMessage`, because it was the same function
- moved `Resolver.processWithAuditLog` to `central/graphql/resolvers/utils.go`, because it's now used in vulnerability_requests and compliance_management.

For additional information please check the comment in the ticket: https://issues.redhat.com/browse/ROX-16737 

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- [x] Evaluated and added CHANGELOG entry if required
- ~[ ] Determined and documented upgrade steps~ - no need for upgrades
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~ - no UI changes

**Open questions:**
- Should we add a Changelog record? With this change, customers can get additional audit logs.

## Testing Performed

Manual testing requires some setup:
1. You need to set up a notifier with "Enable audit logging" (i.e. Generic Webhook) - check the example below
2. Use roxctl to create a backup
3. Use roxctl to restore the backup. You should see that `/db/v2/restore` was called in the audit logs
4. In UI -> Compliance -> Click the "Scan environment" button. You should see `/api/graphql?opname=triggerScan` in audit logs

**Example to setup local audit log storage with Vector and Generic Webhook notifier**

You can use Vector.dev Helm installation. First, create `rhacs-vector-values.yaml` file with following content
```
role: "Stateless-Aggregator"
serviceHeadless:
  enabled: false
customConfig:
  sources:
    http_server:
      type: "http_server"
      address: "0.0.0.0:8888"
      decoding:
        codec: "json"
  sinks:
    console:
      type: "console"
      inputs: [ "http_server" ]
      encoding:
        codec: json
```

After that, install it
```
helm repo add vector https://helm.vector.dev
helm repo update

k create namespace rhacs-audit
helm install rhacs-audit-vector --namespace rhacs-audit --values rhacs-vector-values.yaml vector/vector
```

The last command will output the URL to the vector endpoint. Something like this: `http://rhacs-audit-vector.rhacs-audit:8282` <- copy that

Go to ACS UI -> Integrations -> Notifiers -> Create Generic Webhook notifier with "Enable audit logging" checked.
Use previously copied URL to vector endpoint, but change the port to **8888**

After that, you can simply use kubectl to watch Vector logs where audit logs will be output. In example:
```
k logs -n rhacs-audit rhacs-audit-vector-79458869dc-jmgb4 -f
```
