### PR TITLE
Increase NETWORK_FLOW_UPDATE_CADENCE_IN_SECONDS for few ARCH's

### DIFF
--- a/qa-tests-backend/src/main/groovy/util/NetworkGraphUtil.groovy
+++ b/qa-tests-backend/src/main/groovy/util/NetworkGraphUtil.groovy
@@ -9,7 +9,6 @@ import objects.Edge
 import io.stackrox.proto.api.v1.NetworkGraphServiceOuterClass
 import services.DeploymentService
 import services.NetworkGraphService
-import util.Env
 
 @Slf4j
 class NetworkGraphUtil {

--- a/qa-tests-backend/src/main/groovy/util/NetworkGraphUtil.groovy
+++ b/qa-tests-backend/src/main/groovy/util/NetworkGraphUtil.groovy
@@ -9,13 +9,14 @@ import objects.Edge
 import io.stackrox.proto.api.v1.NetworkGraphServiceOuterClass
 import services.DeploymentService
 import services.NetworkGraphService
+import util.Env
 
 @Slf4j
 class NetworkGraphUtil {
 
     // more time is needed on few architectures
     static final NETWORK_FLOW_UPDATE_CADENCE_IN_SECONDS =
-        ((System.getenv("REMOTE_CLUSTER_ARCH") == "x86_64" ) ? 30 : 120)
+        ((Env.REMOTE_CLUSTER_ARCH == "x86_64" ) ? 30 : 120)
 
     static int edgeCount(NetworkGraphServiceOuterClass.NetworkGraph graph) {
         int numEdges = 0

--- a/qa-tests-backend/src/main/groovy/util/NetworkGraphUtil.groovy
+++ b/qa-tests-backend/src/main/groovy/util/NetworkGraphUtil.groovy
@@ -13,7 +13,8 @@ import services.NetworkGraphService
 @Slf4j
 class NetworkGraphUtil {
 
-    static final NETWORK_FLOW_UPDATE_CADENCE_IN_SECONDS = 30 // Network flow data is updated every 30 seconds
+    // more time is needed on few architectures
+    static final NETWORK_FLOW_UPDATE_CADENCE_IN_SECONDS = ((System.getenv("REMOTE_CLUSTER_ARCH") == "x86_64" ) ? 30 : 120)
 
     static int edgeCount(NetworkGraphServiceOuterClass.NetworkGraph graph) {
         int numEdges = 0

--- a/qa-tests-backend/src/main/groovy/util/NetworkGraphUtil.groovy
+++ b/qa-tests-backend/src/main/groovy/util/NetworkGraphUtil.groovy
@@ -14,7 +14,8 @@ import services.NetworkGraphService
 class NetworkGraphUtil {
 
     // more time is needed on few architectures
-    static final NETWORK_FLOW_UPDATE_CADENCE_IN_SECONDS = ((System.getenv("REMOTE_CLUSTER_ARCH") == "x86_64" ) ? 30 : 120)
+    static final NETWORK_FLOW_UPDATE_CADENCE_IN_SECONDS =
+        ((System.getenv("REMOTE_CLUSTER_ARCH") == "x86_64" ) ? 30 : 120)
 
     static int edgeCount(NetworkGraphServiceOuterClass.NetworkGraph graph) {
         int numEdges = 0


### PR DESCRIPTION
This PR intends to fix timeout issue on P/Z with `Verify two flows co-exist if larger network entity added first` test which is part of `ExternalNetworkSourcesTest`.
Changes are verified manually using `./gradlew test --tests=TestName`

This PR intends to fix [ROX-16938](https://issues.redhat.com/browse/ROX-16938)