### PR TITLE
Make policy migration helper methods reusable by other migrations

### DIFF
--- a/migrator/migrations/policymigrationhelper/policy_migrator.go
+++ b/migrator/migrations/policymigrationhelper/policy_migrator.go
@@ -306,6 +306,7 @@ const (
 // 3. For each policy being migrated, there must be one copy in the "before" directory and one in the "after" directory.
 // 4. The file names for a policy should match the PolicyFileName in the corresponding PolicyDiff passed in the third argument.
 // This function then automatically computes the diff for each policy, and executes the migration.
+// Deprecated: This relies on boltDB. Remove once we no longer support ACS <4.0
 func MigratePoliciesWithDiffs(db *bolt.DB, policyDiffFS embed.FS, policyDiffs []PolicyDiff) error {
 	policiesToMigrate := make(map[string]PolicyChanges, len(policyDiffs))
 	preMigrationPolicies := make(map[string]*storage.Policy, len(policyDiffs))
@@ -334,6 +335,7 @@ func MigratePoliciesWithDiffs(db *bolt.DB, policyDiffFS embed.FS, policyDiffs []
 // MigratePoliciesWithPreMigrationFS is a variant of MigratePolicies that takes in an embed.FS with the pre migration policies.
 // `preMigFS` is expected to have a directory called `preMigDirName`, which has one JSON file per policy.
 // Each JSON file is expected to have the filename <policy_id>.json.
+// Deprecated: This relies on boltDB. Remove once we no longer support ACS <4.0
 func MigratePoliciesWithPreMigrationFS(db *bolt.DB, policiesToMigrate map[string]PolicyChanges, preMigFS embed.FS, preMigDirName string) error {
 	comparisonPolicies := make(map[string]*storage.Policy)
 	for policyID := range policiesToMigrate {
@@ -349,6 +351,7 @@ func MigratePoliciesWithPreMigrationFS(db *bolt.DB, policiesToMigrate map[string
 
 // MigratePolicies will migrate all policies in the db as specified by policiesToMigrate assuming the policies in the db
 // matches the policies within comparisonPolicies.
+// Deprecated: This relies on boltDB. Remove once we no longer support ACS <4.0
 func MigratePolicies(db *bolt.DB, policiesToMigrate map[string]PolicyChanges, comparisonPolicies map[string]*storage.Policy) error {
 	if exists, err := bolthelpers.BucketExists(db, policyBucketName); err != nil {
 		return errors.Wrapf(err, "getting bucket with name %q", policyBucketName)

--- a/migrator/migrations/policymigrationhelper/policy_migrator_test.go
+++ b/migrator/migrations/policymigrationhelper/policy_migrator_test.go
@@ -12,6 +12,7 @@ import (
 	bolt "go.etcd.io/bbolt"
 )
 
+// TODO: Remove this file and move all tests to postgres_policy_migrator_test.go once we no longer support migrating from boltdb
 func TestPolicyMigrator(t *testing.T) {
 	suite.Run(t, new(policyMigratorTestSuite))
 }

--- a/migrator/migrations/policymigrationhelper/policypostgresstorefortest/postgres_plugin.go
+++ b/migrator/migrations/policymigrationhelper/policypostgresstorefortest/postgres_plugin.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"context"
+	"testing"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
@@ -21,6 +22,7 @@ import (
 // This file is a copy of central/policy/store/postgres/store.go at the time the test was added.
 // It's purely to keep the test consistent regardless of how the policy store is updated. Only functions required for tests are kept.
 // The kept functions are stripped from the scoped access control checks.
+// Furthermore, this store can only be instantiated in tests
 
 const (
 	baseTable = "policies"
@@ -60,7 +62,8 @@ type storeImpl struct {
 }
 
 // New returns a new Store instance using the provided sql instance.
-func New(db postgres.DB) Store {
+// Only used for tests
+func New(db postgres.DB, _ *testing.T) Store {
 	return &storeImpl{
 		db: db,
 	}

--- a/migrator/migrations/policymigrationhelper/policypostgresstorefortest/postgres_plugin.go
+++ b/migrator/migrations/policymigrationhelper/policypostgresstorefortest/postgres_plugin.go
@@ -2,13 +2,10 @@ package postgres
 
 import (
 	"context"
-	"time"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v4"
 	"github.com/pkg/errors"
-	"github.com/stackrox/rox/central/metrics"
-	"github.com/stackrox/rox/central/role/resources"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	frozenSchema "github.com/stackrox/rox/migrator/migrations/policymigrationhelper/policypostgresstorefortest/schema"
@@ -40,9 +37,8 @@ const (
 )
 
 var (
-	log            = logging.LoggerForModule()
-	schema         = frozenSchema.PoliciesSchema
-	targetResource = resources.Policy
+	log    = logging.LoggerForModule()
+	schema = frozenSchema.PoliciesSchema
 )
 
 // Store is the interface to interact with the storage for storage.Policy
@@ -210,7 +206,6 @@ func (s *storeImpl) copyFromPolicies(ctx context.Context, tx *postgres.Tx, objs 
 }
 
 func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*postgres.Conn, func(), error) {
-	defer metrics.SetAcquireDBConnDuration(time.Now(), op, typ)
 	conn, err := s.db.Acquire(ctx)
 	if err != nil {
 		return nil, nil, err

--- a/migrator/migrations/policymigrationhelper/policypostgresstorefortest/postgres_plugin.go
+++ b/migrator/migrations/policymigrationhelper/policypostgresstorefortest/postgres_plugin.go
@@ -205,7 +205,7 @@ func (s *storeImpl) copyFromPolicies(ctx context.Context, tx *postgres.Tx, objs 
 	return err
 }
 
-func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*postgres.Conn, func(), error) {
+func (s *storeImpl) acquireConn(ctx context.Context, _ ops.Op, _ string) (*postgres.Conn, func(), error) {
 	conn, err := s.db.Acquire(ctx)
 	if err != nil {
 		return nil, nil, err

--- a/migrator/migrations/policymigrationhelper/policypostgresstorefortest/postgres_plugin.go
+++ b/migrator/migrations/policymigrationhelper/policypostgresstorefortest/postgres_plugin.go
@@ -21,7 +21,7 @@ import (
 	"github.com/stackrox/rox/pkg/sync"
 )
 
-// This file is a copy of central/polocy/store/postgres/store.go at the time the test was added.
+// This file is a copy of central/policy/store/postgres/store.go at the time the test was added.
 // It's purely to keep the test consistent regardless of how the policy store is updated. Only functions required for tests are kept.
 // The kept functions are stripped from the scoped access control checks.
 

--- a/migrator/migrations/policymigrationhelper/policypostgresstorefortest/postgres_plugin.go
+++ b/migrator/migrations/policymigrationhelper/policypostgresstorefortest/postgres_plugin.go
@@ -1,0 +1,424 @@
+package postgres
+
+import (
+	"context"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/jackc/pgx/v4"
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/central/metrics"
+	"github.com/stackrox/rox/central/role/resources"
+	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/generated/storage"
+	frozenSchema "github.com/stackrox/rox/migrator/migrations/policymigrationhelper/policypostgresstorefortest/schema"
+	"github.com/stackrox/rox/pkg/logging"
+	ops "github.com/stackrox/rox/pkg/metrics"
+	"github.com/stackrox/rox/pkg/postgres"
+	"github.com/stackrox/rox/pkg/postgres/pgutils"
+	"github.com/stackrox/rox/pkg/search"
+	pgSearch "github.com/stackrox/rox/pkg/search/postgres"
+	"github.com/stackrox/rox/pkg/sync"
+)
+
+// This file is a copy of central/polocy/store/postgres/store.go at the time the test was added.
+// It's purely to keep the test consistent regardless of how the policy store is updated. Only functions required for tests are kept.
+// The kept functions are stripped from the scoped access control checks.
+
+const (
+	baseTable = "policies"
+
+	batchAfter = 100
+
+	// using copyFrom, we may not even want to batch.  It would probably be simpler
+	// to deal with failures if we just sent it all.  Something to think about as we
+	// proceed and move into more e2e and larger performance testing
+	batchSize = 10000
+
+	cursorBatchSize = 50
+	deleteBatchSize = 5000
+)
+
+var (
+	log            = logging.LoggerForModule()
+	schema         = frozenSchema.PoliciesSchema
+	targetResource = resources.Policy
+)
+
+// Store is the interface to interact with the storage for storage.Policy
+type Store interface {
+	Upsert(ctx context.Context, obj *storage.Policy) error
+	UpsertMany(ctx context.Context, objs []*storage.Policy) error
+	DeleteMany(ctx context.Context, identifiers []string) error
+
+	Exists(ctx context.Context, id string) (bool, error)
+
+	Get(ctx context.Context, id string) (*storage.Policy, bool, error)
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.Policy, error)
+	GetMany(ctx context.Context, identifiers []string) ([]*storage.Policy, []int, error)
+}
+
+type storeImpl struct {
+	db    postgres.DB
+	mutex sync.RWMutex
+}
+
+// New returns a new Store instance using the provided sql instance.
+func New(db postgres.DB) Store {
+	return &storeImpl{
+		db: db,
+	}
+}
+
+//// Helper functions
+
+func insertIntoPolicies(ctx context.Context, batch *pgx.Batch, obj *storage.Policy) error {
+
+	serialized, marshalErr := obj.Marshal()
+	if marshalErr != nil {
+		return marshalErr
+	}
+
+	values := []interface{}{
+		// parent primary keys start
+		obj.GetId(),
+		obj.GetName(),
+		obj.GetDescription(),
+		obj.GetDisabled(),
+		obj.GetCategories(),
+		obj.GetLifecycleStages(),
+		obj.GetSeverity(),
+		obj.GetEnforcementActions(),
+		pgutils.NilOrTime(obj.GetLastUpdated()),
+		obj.GetSORTName(),
+		obj.GetSORTLifecycleStage(),
+		obj.GetSORTEnforcement(),
+		serialized,
+	}
+
+	finalStr := "INSERT INTO policies (Id, Name, Description, Disabled, Categories, LifecycleStages, Severity, EnforcementActions, LastUpdated, SORTName, SORTLifecycleStage, SORTEnforcement, serialized) VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13) ON CONFLICT(Id) DO UPDATE SET Id = EXCLUDED.Id, Name = EXCLUDED.Name, Description = EXCLUDED.Description, Disabled = EXCLUDED.Disabled, Categories = EXCLUDED.Categories, LifecycleStages = EXCLUDED.LifecycleStages, Severity = EXCLUDED.Severity, EnforcementActions = EXCLUDED.EnforcementActions, LastUpdated = EXCLUDED.LastUpdated, SORTName = EXCLUDED.SORTName, SORTLifecycleStage = EXCLUDED.SORTLifecycleStage, SORTEnforcement = EXCLUDED.SORTEnforcement, serialized = EXCLUDED.serialized"
+	batch.Queue(finalStr, values...)
+
+	return nil
+}
+
+func (s *storeImpl) copyFromPolicies(ctx context.Context, tx *postgres.Tx, objs ...*storage.Policy) error {
+
+	inputRows := [][]interface{}{}
+
+	var err error
+
+	// This is a copy so first we must delete the rows and re-add them
+	// Which is essentially the desired behaviour of an upsert.
+	var deletes []string
+
+	copyCols := []string{
+
+		"id",
+
+		"name",
+
+		"description",
+
+		"disabled",
+
+		"categories",
+
+		"lifecyclestages",
+
+		"severity",
+
+		"enforcementactions",
+
+		"lastupdated",
+
+		"sortname",
+
+		"sortlifecyclestage",
+
+		"sortenforcement",
+
+		"serialized",
+	}
+
+	for idx, obj := range objs {
+		// Todo: ROX-9499 Figure out how to more cleanly template around this issue.
+		log.Debugf("This is here for now because there is an issue with pods_TerminatedInstances where the obj "+
+			"in the loop is not used as it only consists of the parent ID and the index.  Putting this here as a stop gap "+
+			"to simply use the object.  %s", obj)
+
+		serialized, marshalErr := obj.Marshal()
+		if marshalErr != nil {
+			return marshalErr
+		}
+
+		inputRows = append(inputRows, []interface{}{
+
+			obj.GetId(),
+
+			obj.GetName(),
+
+			obj.GetDescription(),
+
+			obj.GetDisabled(),
+
+			obj.GetCategories(),
+
+			obj.GetLifecycleStages(),
+
+			obj.GetSeverity(),
+
+			obj.GetEnforcementActions(),
+
+			pgutils.NilOrTime(obj.GetLastUpdated()),
+
+			obj.GetSORTName(),
+
+			obj.GetSORTLifecycleStage(),
+
+			obj.GetSORTEnforcement(),
+
+			serialized,
+		})
+
+		// Add the ID to be deleted.
+		deletes = append(deletes, obj.GetId())
+
+		// if we hit our batch size we need to push the data
+		if (idx+1)%batchSize == 0 || idx == len(objs)-1 {
+			// copy does not upsert so have to delete first.  parent deletion cascades so only need to
+			// delete for the top level parent
+
+			if err := s.DeleteMany(ctx, deletes); err != nil {
+				return err
+			}
+			// clear the inserts and vals for the next batch
+			deletes = nil
+
+			_, err = tx.CopyFrom(ctx, pgx.Identifier{"policies"}, copyCols, pgx.CopyFromRows(inputRows))
+
+			if err != nil {
+				return err
+			}
+
+			// clear the input rows for the next batch
+			inputRows = inputRows[:0]
+		}
+	}
+
+	return err
+}
+
+func (s *storeImpl) acquireConn(ctx context.Context, op ops.Op, typ string) (*postgres.Conn, func(), error) {
+	defer metrics.SetAcquireDBConnDuration(time.Now(), op, typ)
+	conn, err := s.db.Acquire(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	return conn, conn.Release, nil
+}
+
+func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.Policy) error {
+	conn, release, err := s.acquireConn(ctx, ops.Get, "Policy")
+	if err != nil {
+		return err
+	}
+	defer release()
+
+	tx, err := conn.Begin(ctx)
+	if err != nil {
+		return err
+	}
+
+	if err := s.copyFromPolicies(ctx, tx, objs...); err != nil {
+		if err := tx.Rollback(ctx); err != nil {
+			return err
+		}
+		return err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *storeImpl) upsert(ctx context.Context, objs ...*storage.Policy) error {
+	conn, release, err := s.acquireConn(ctx, ops.Get, "Policy")
+	if err != nil {
+		return err
+	}
+	defer release()
+
+	for _, obj := range objs {
+		batch := &pgx.Batch{}
+		if err := insertIntoPolicies(ctx, batch, obj); err != nil {
+			return err
+		}
+		batchResults := conn.SendBatch(ctx, batch)
+		var result *multierror.Error
+		for i := 0; i < batch.Len(); i++ {
+			_, err := batchResults.Exec()
+			result = multierror.Append(result, err)
+		}
+		if err := batchResults.Close(); err != nil {
+			return err
+		}
+		if err := result.ErrorOrNil(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+//// Helper functions - END
+
+//// Interface functions
+
+// Upsert saves the current state of an object in storage.
+func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Policy) error {
+	return pgutils.Retry(func() error {
+		return s.upsert(ctx, obj)
+	})
+}
+
+// UpsertMany saves the state of multiple objects in the storage.
+func (s *storeImpl) UpsertMany(ctx context.Context, objs []*storage.Policy) error {
+	return pgutils.Retry(func() error {
+		// Lock since copyFrom requires a delete first before being executed.  If multiple processes are updating
+		// same subset of rows, both deletes could occur before the copyFrom resulting in unique constraint
+		// violations
+		if len(objs) < batchAfter {
+			s.mutex.RLock()
+			defer s.mutex.RUnlock()
+
+			return s.upsert(ctx, objs...)
+		}
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
+
+		return s.copyFrom(ctx, objs...)
+	})
+}
+
+// DeleteMany removes the objects associated to the specified IDs from the store.
+func (s *storeImpl) DeleteMany(ctx context.Context, identifiers []string) error {
+	var sacQueryFilter *v1.Query
+	// Batch the deletes
+	localBatchSize := deleteBatchSize
+	numRecordsToDelete := len(identifiers)
+	for {
+		if len(identifiers) == 0 {
+			break
+		}
+
+		if len(identifiers) < localBatchSize {
+			localBatchSize = len(identifiers)
+		}
+
+		identifierBatch := identifiers[:localBatchSize]
+		q := search.ConjunctionQuery(
+			sacQueryFilter,
+			search.NewQueryBuilder().AddDocIDs(identifierBatch...).ProtoQuery(),
+		)
+
+		if err := pgSearch.RunDeleteRequestForSchema(ctx, schema, q, s.db); err != nil {
+			return errors.Wrapf(err, "unable to delete the records.  Successfully deleted %d out of %d", numRecordsToDelete-len(identifiers), numRecordsToDelete)
+		}
+
+		// Move the slice forward to start the next batch
+		identifiers = identifiers[localBatchSize:]
+	}
+
+	return nil
+}
+
+// Exists returns if the ID exists in the store.
+func (s *storeImpl) Exists(ctx context.Context, id string) (bool, error) {
+	var sacQueryFilter *v1.Query
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	count, err := pgSearch.RunCountRequestForSchema(ctx, schema, q, s.db)
+	// With joins and multiple paths to the scoping resources, it can happen that the Count query for an object identifier
+	// returns more than 1, despite the fact that the identifier is unique in the table.
+	return count > 0, err
+}
+
+// Get returns the object, if it exists from the store.
+func (s *storeImpl) Get(ctx context.Context, id string) (*storage.Policy, bool, error) {
+	var sacQueryFilter *v1.Query
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		search.NewQueryBuilder().AddDocIDs(id).ProtoQuery(),
+	)
+
+	data, err := pgSearch.RunGetQueryForSchema[storage.Policy](ctx, schema, q, s.db)
+	if err != nil {
+		return nil, false, pgutils.ErrNilIfNoRows(err)
+	}
+
+	return data, true, nil
+}
+
+// GetByQuery returns the objects from the store matching the query.
+func (s *storeImpl) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.Policy, error) {
+	var sacQueryFilter *v1.Query
+	pagination := query.GetPagination()
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		query,
+	)
+	q.Pagination = pagination
+
+	rows, err := pgSearch.RunGetManyQueryForSchema[storage.Policy](ctx, schema, q, s.db)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return rows, nil
+}
+
+// GetMany returns the objects specified by the IDs from the store as well as the index in the missing indices slice.
+func (s *storeImpl) GetMany(ctx context.Context, identifiers []string) ([]*storage.Policy, []int, error) {
+	if len(identifiers) == 0 {
+		return nil, nil, nil
+	}
+
+	var sacQueryFilter *v1.Query
+	q := search.ConjunctionQuery(
+		sacQueryFilter,
+		search.NewQueryBuilder().AddDocIDs(identifiers...).ProtoQuery(),
+	)
+
+	rows, err := pgSearch.RunGetManyQueryForSchema[storage.Policy](ctx, schema, q, s.db)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			missingIndices := make([]int, 0, len(identifiers))
+			for i := range identifiers {
+				missingIndices = append(missingIndices, i)
+			}
+			return nil, missingIndices, nil
+		}
+		return nil, nil, err
+	}
+	resultsByID := make(map[string]*storage.Policy, len(rows))
+	for _, msg := range rows {
+		resultsByID[msg.GetId()] = msg
+	}
+	missingIndices := make([]int, 0, len(identifiers)-len(resultsByID))
+	// It is important that the elems are populated in the same order as the input identifiers
+	// slice, since some calling code relies on that to maintain order.
+	elems := make([]*storage.Policy, 0, len(resultsByID))
+	for i, identifier := range identifiers {
+		if result, ok := resultsByID[identifier]; !ok {
+			missingIndices = append(missingIndices, i)
+		} else {
+			elems = append(elems, result)
+		}
+	}
+	return elems, missingIndices, nil
+}

--- a/migrator/migrations/policymigrationhelper/policypostgresstorefortest/postgres_plugin.go
+++ b/migrator/migrations/policymigrationhelper/policypostgresstorefortest/postgres_plugin.go
@@ -72,7 +72,7 @@ func New(db postgres.DB) Store {
 
 //// Helper functions
 
-func insertIntoPolicies(ctx context.Context, batch *pgx.Batch, obj *storage.Policy) error {
+func insertIntoPolicies(_ context.Context, batch *pgx.Batch, obj *storage.Policy) error {
 
 	serialized, marshalErr := obj.Marshal()
 	if marshalErr != nil {

--- a/migrator/migrations/policymigrationhelper/policypostgresstorefortest/schema/policies.go
+++ b/migrator/migrations/policymigrationhelper/policypostgresstorefortest/schema/policies.go
@@ -31,12 +31,13 @@ var (
 )
 
 const (
+	// PoliciesTableName is the name of the table used for storage.
 	PoliciesTableName = "policies"
 )
 
 // Policies holds the Gorm model for Postgres table `policies`.
 type Policies struct {
-	Id                 string           `gorm:"column:id;type:varchar;primaryKey"`
+	ID                 string           `gorm:"column:id;type:varchar;primaryKey"`
 	Name               string           `gorm:"column:name;type:varchar;unique"`
 	Description        string           `gorm:"column:description;type:varchar"`
 	Disabled           bool             `gorm:"column:disabled;type:bool"`

--- a/migrator/migrations/policymigrationhelper/policypostgresstorefortest/schema/policies.go
+++ b/migrator/migrations/policymigrationhelper/policypostgresstorefortest/schema/policies.go
@@ -1,0 +1,52 @@
+package schema
+
+import (
+	"reflect"
+	"time"
+
+	"github.com/lib/pq"
+	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/postgres"
+	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/search"
+)
+
+// This file is a copy of pkg/postgres/schema/policies.go at the time the test was added.
+// It's purely to keep the test consistent regardless of how the policy store is updated.
+
+var (
+	// CreateTablePoliciesStmt holds the create statement for table `policies`.
+	CreateTablePoliciesStmt = &postgres.CreateStmts{
+		GormModel: (*Policies)(nil),
+		Children:  []*postgres.CreateStmts{},
+	}
+
+	// PoliciesSchema is the go schema for table `policies`.
+	PoliciesSchema = func() *walker.Schema {
+		schema := walker.Walk(reflect.TypeOf((*storage.Policy)(nil)), "policies")
+		schema.SetOptionsMap(search.Walk(v1.SearchCategory_POLICIES, "policy", (*storage.Policy)(nil)))
+		return schema
+	}()
+)
+
+const (
+	PoliciesTableName = "policies"
+)
+
+// Policies holds the Gorm model for Postgres table `policies`.
+type Policies struct {
+	Id                 string           `gorm:"column:id;type:varchar;primaryKey"`
+	Name               string           `gorm:"column:name;type:varchar;unique"`
+	Description        string           `gorm:"column:description;type:varchar"`
+	Disabled           bool             `gorm:"column:disabled;type:bool"`
+	Categories         *pq.StringArray  `gorm:"column:categories;type:text[]"`
+	LifecycleStages    *pq.Int32Array   `gorm:"column:lifecyclestages;type:int[]"`
+	Severity           storage.Severity `gorm:"column:severity;type:integer"`
+	EnforcementActions *pq.Int32Array   `gorm:"column:enforcementactions;type:int[]"`
+	LastUpdated        *time.Time       `gorm:"column:lastupdated;type:timestamp"`
+	SORTName           string           `gorm:"column:sortname;type:varchar"`
+	SORTLifecycleStage string           `gorm:"column:sortlifecyclestage;type:varchar"`
+	SORTEnforcement    bool             `gorm:"column:sortenforcement;type:bool"`
+	Serialized         []byte           `gorm:"column:serialized;type:bytea"`
+}

--- a/migrator/migrations/policymigrationhelper/postgres_policy_migrator.go
+++ b/migrator/migrations/policymigrationhelper/postgres_policy_migrator.go
@@ -1,0 +1,92 @@
+package policymigrationhelper
+
+import (
+	"context"
+	"embed"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/generated/storage"
+	pglog "github.com/stackrox/rox/migrator/log"
+	"github.com/stackrox/rox/pkg/sac"
+)
+
+// MigratePoliciesWithDiffsAndStore migrates policies with the given diffs.
+// The policyDiffFS should be an embedded FS that satisfies the following conditions:
+// 1. It must contain a top-level directory called "policies_before_and_after".
+// 2. That directory must contain two subdirectories: "before" and "after".
+// 3. For each policy being migrated, there must be one copy in the "before" directory and one in the "after" directory.
+// 4. The file names for a policy should match the PolicyFileName in the corresponding PolicyDiff passed in the third argument.
+// This function then automatically computes the diff for each policy, and executes the migration.
+// This method requires the caller to provide funcs that check if a policy exists,
+// fetches policy from the store and will upsert a policy to the store
+func MigratePoliciesWithDiffsAndStore(policyDiffFS embed.FS,
+	policyDiffs []PolicyDiff,
+	policyExists func(context.Context, string) (bool, error),
+	getPolicy func(context.Context, string) (*storage.Policy, bool, error),
+	upsertPolicy func(context.Context, *storage.Policy) error,
+) error {
+	policiesToMigrate := make(map[string]PolicyChanges, len(policyDiffs))
+	preMigrationPolicies := make(map[string]*storage.Policy, len(policyDiffs))
+	for _, diff := range policyDiffs {
+		beforePolicy, err := ReadPolicyFromFile(policyDiffFS, filepath.Join(beforeDirName, diff.PolicyFileName))
+		if err != nil {
+			return err
+		}
+		afterPolicy, err := ReadPolicyFromFile(policyDiffFS, filepath.Join(afterDirName, diff.PolicyFileName))
+		if err != nil {
+			return err
+		}
+		if beforePolicy.GetId() == "" || beforePolicy.GetId() != afterPolicy.GetId() {
+			return errors.Errorf("policies in file %s don't both have the same, non-empty, id", diff.PolicyFileName)
+		}
+		updates, err := diffPolicies(beforePolicy, afterPolicy)
+		if err != nil {
+			return err
+		}
+		policiesToMigrate[beforePolicy.GetId()] = PolicyChanges{FieldsToCompare: diff.FieldsToCompare, ToChange: updates}
+		preMigrationPolicies[beforePolicy.GetId()] = beforePolicy
+	}
+	return MigratePoliciesWithStore(policiesToMigrate, preMigrationPolicies, policyExists, getPolicy, upsertPolicy)
+}
+
+// MigratePoliciesWithStore will migrate all policies in the db as specified by policiesToMigrate assuming the policies in the db
+// matches the policies within comparisonPolicies. This method requires the caller to provide funcs that check if a policy exists,
+// fetches policy from the store and will upsert a policy to the store
+func MigratePoliciesWithStore(policiesToMigrate map[string]PolicyChanges,
+	comparisonPolicies map[string]*storage.Policy,
+	policyExists func(context.Context, string) (bool, error),
+	getPolicy func(context.Context, string) (*storage.Policy, bool, error),
+	upsertPolicy func(context.Context, *storage.Policy) error,
+) error {
+
+	ctx := sac.WithAllAccess(context.Background())
+
+	for policyID, updateDetails := range policiesToMigrate {
+		if exists, err := policyExists(ctx, policyID); err != nil {
+			pglog.WriteToStderrf("err getting policy with id %s. Will not update.", policyID)
+			continue
+		} else if !exists {
+			pglog.WriteToStderrf("unable to find policy with id %s. Will not update.", policyID)
+			continue
+		}
+
+		policy, _, _ := getPolicy(ctx, policyID)
+		comparePolicy := comparisonPolicies[policyID]
+		if !checkIfPoliciesMatch(updateDetails.FieldsToCompare, comparePolicy, policy) {
+			pglog.WriteToStderrf("policy ID %s has already been altered. Will not update.", policyID)
+			continue
+		}
+
+		// Update policy as needed
+		updateDetails.ToChange.applyToPolicy(policy)
+		err := upsertPolicy(ctx, policy)
+		if err != nil {
+			return err
+		}
+
+	}
+
+	return nil
+
+}

--- a/migrator/migrations/policymigrationhelper/postgres_policy_migrator_test.go
+++ b/migrator/migrations/policymigrationhelper/postgres_policy_migrator_test.go
@@ -33,7 +33,7 @@ func (s *postgresPolicyMigratorTestSuite) SetupTest() {
 	s.db = pghelper.ForT(s.T(), true)
 	s.ctx = context.Background()
 	pgutils.CreateTableFromModel(s.ctx, s.db.GetGormDB(), schema.CreateTablePoliciesStmt)
-	s.store = policypostgresstore.New(s.db)
+	s.store = policypostgresstore.New(s.db, s.T())
 }
 
 func (s *postgresPolicyMigratorTestSuite) TearDownTest() {

--- a/migrator/migrations/policymigrationhelper/postgres_policy_migrator_test.go
+++ b/migrator/migrations/policymigrationhelper/postgres_policy_migrator_test.go
@@ -64,7 +64,7 @@ func (s *postgresPolicyMigratorTestSuite) TestUnrelatedPolicyIsNotUpdated() {
 	}
 
 	s.NoError(s.store.Upsert(s.ctx, policy))
-	s.NoError(MigratePoliciesWithDB(
+	s.NoError(MigratePoliciesWithStore(
 		policiesToMigrate,
 		comparisonPolicies,
 		s.store.Exists,
@@ -91,7 +91,7 @@ func (s *postgresPolicyMigratorTestSuite) TestUnmodifiedAndMatchingPolicyIsUpdat
 	}
 
 	s.NoError(s.store.Upsert(s.ctx, policy))
-	s.NoError(MigratePoliciesWithDB(
+	s.NoError(MigratePoliciesWithStore(
 		policiesToMigrate,
 		comparisonPolicies,
 		s.store.Exists,
@@ -127,7 +127,7 @@ func (s *postgresPolicyMigratorTestSuite) TestAllUnmodifiedPoliciesGetUpdated() 
 
 	s.NoError(s.store.UpsertMany(s.ctx, policiesToTest))
 
-	s.NoError(MigratePoliciesWithDB(
+	s.NoError(MigratePoliciesWithStore(
 		policiesToMigrate,
 		comparisonPolicies,
 		s.store.Exists,
@@ -179,7 +179,7 @@ func (s *postgresPolicyMigratorTestSuite) TestExclusionAreAddedAndRemovedAsNeces
 		},
 	}
 
-	s.NoError(MigratePoliciesWithDB(
+	s.NoError(MigratePoliciesWithStore(
 		policiesToMigrate,
 		comparisonPolicies,
 		s.store.Exists,

--- a/migrator/migrations/policymigrationhelper/postgres_policy_migrator_test.go
+++ b/migrator/migrations/policymigrationhelper/postgres_policy_migrator_test.go
@@ -1,0 +1,201 @@
+//go:build sql_integration
+
+package policymigrationhelper
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stackrox/rox/generated/storage"
+	policypostgresstore "github.com/stackrox/rox/migrator/migrations/policymigrationhelper/policypostgresstorefortest"
+	"github.com/stackrox/rox/migrator/migrations/policymigrationhelper/policypostgresstorefortest/schema"
+	pghelper "github.com/stackrox/rox/migrator/migrations/postgreshelper"
+	"github.com/stackrox/rox/pkg/postgres/pgutils"
+	"github.com/stretchr/testify/suite"
+)
+
+// The tests in here are a subset of what exists in policy_migrator_test.go
+// The ones that were copied over have been updated to work with postgres.
+
+func TestPostgresPolicyMigrator(t *testing.T) {
+	suite.Run(t, new(postgresPolicyMigratorTestSuite))
+}
+
+type postgresPolicyMigratorTestSuite struct {
+	suite.Suite
+	ctx   context.Context
+	db    *pghelper.TestPostgres
+	store policypostgresstore.Store
+}
+
+func (s *postgresPolicyMigratorTestSuite) SetupTest() {
+	s.db = pghelper.ForT(s.T(), true)
+	s.ctx = context.Background()
+	pgutils.CreateTableFromModel(s.ctx, s.db.GetGormDB(), schema.CreateTablePoliciesStmt)
+	s.store = policypostgresstore.New(s.db)
+}
+
+func (s *postgresPolicyMigratorTestSuite) TearDownTest() {
+	s.db.Teardown(s.T())
+}
+
+func (s *postgresPolicyMigratorTestSuite) comparePolicyWithDB(policyID string, policy *storage.Policy) {
+	newPolicy, exists, err := s.store.Get(s.ctx, policyID)
+	s.NoError(err)
+	s.True(exists)
+	s.EqualValues(policy, newPolicy)
+}
+
+// Test that unrelated policies aren't updated
+func (s *postgresPolicyMigratorTestSuite) TestUnrelatedPolicyIsNotUpdated() {
+	policyID := "this-is-a-random-id-that-should-not-exist"
+	policy := testPolicy(policyID)
+
+	policiesToMigrate := map[string]PolicyChanges{
+		"0000-0000-0000-0000": {
+			FieldsToCompare: []FieldComparator{DescriptionComparator},
+			ToChange:        PolicyUpdates{Description: strPtr("this is a new description")},
+		},
+	}
+
+	comparisonPolicies := map[string]*storage.Policy{
+		policyID: policy,
+	}
+
+	s.NoError(s.store.Upsert(s.ctx, policy))
+	s.NoError(MigratePoliciesWithDB(
+		policiesToMigrate,
+		comparisonPolicies,
+		s.store.Exists,
+		s.store.Get,
+		s.store.Upsert,
+	))
+
+	s.comparePolicyWithDB(policyID, policy)
+}
+
+// Test that an unmodified policy that matches comparison policy is updated
+func (s *postgresPolicyMigratorTestSuite) TestUnmodifiedAndMatchingPolicyIsUpdated() {
+	policy := testPolicy(policyID)
+
+	policiesToMigrate := map[string]PolicyChanges{
+		policyID: {
+			FieldsToCompare: []FieldComparator{DescriptionComparator},
+			ToChange:        PolicyUpdates{Description: strPtr("this is a new description")},
+		},
+	}
+
+	comparisonPolicies := map[string]*storage.Policy{
+		policyID: policy,
+	}
+
+	s.NoError(s.store.Upsert(s.ctx, policy))
+	s.NoError(MigratePoliciesWithDB(
+		policiesToMigrate,
+		comparisonPolicies,
+		s.store.Exists,
+		s.store.Get,
+		s.store.Upsert,
+	))
+
+	// Policy should've had description changed, but nothing else
+	policy.Description = *policiesToMigrate[policyID].ToChange.Description
+	s.comparePolicyWithDB(policyID, policy)
+}
+
+// Test that all unmodified policies are updated
+func (s *postgresPolicyMigratorTestSuite) TestAllUnmodifiedPoliciesGetUpdated() {
+	policiesToTest := make([]*storage.Policy, 10)
+	comparisonPolicies := make(map[string]*storage.Policy)
+	policiesToMigrate := make(map[string]PolicyChanges)
+
+	// Create and insert a set of unmodified fake policies
+	for i := 0; i < 10; i++ {
+		policy := testPolicy(fmt.Sprintf("policy%d", i))
+		policiesToTest[i] = policy
+		policy.Name = fmt.Sprintf("policy-name%d", i) // name is a unique key
+		policy.Description = "sfasdf"
+
+		comparisonPolicy := policy.Clone() //testPolicy(policy.Id)
+		comparisonPolicies[policy.Id] = comparisonPolicy
+		policiesToMigrate[policy.Id] = PolicyChanges{
+			FieldsToCompare: []FieldComparator{PolicySectionComparator, ExclusionComparator, RemediationComparator, RationaleComparator},
+			ToChange:        PolicyUpdates{Description: strPtr(fmt.Sprintf("%s new description", policy.Id))}, // give them all a new description
+		}
+	}
+
+	s.NoError(s.store.UpsertMany(s.ctx, policiesToTest))
+
+	s.NoError(MigratePoliciesWithDB(
+		policiesToMigrate,
+		comparisonPolicies,
+		s.store.Exists,
+		s.store.Get,
+		s.store.Upsert,
+	))
+
+	for _, policy := range policiesToTest {
+		// All the policies should've changed
+		policy.Description = fmt.Sprintf("%s new description", policy.Id)
+		s.comparePolicyWithDB(policy.Id, policy)
+	}
+}
+
+// Test that exclusions can get added and removed appropriately
+func (s *postgresPolicyMigratorTestSuite) TestExclusionAreAddedAndRemovedAsNecessary() {
+	policy := testPolicy(policyID)
+
+	// Add a bunch of exclusions into the DB
+	policy.Exclusions = []*storage.Exclusion{
+		{Name: "exclusion0", Deployment: &storage.Exclusion_Deployment{Scope: &storage.Scope{Namespace: "namespace-0"}}},
+		{Name: "exclusion1", Deployment: &storage.Exclusion_Deployment{Scope: &storage.Scope{Namespace: "namespace 1"}}},
+		{Name: "exclusion2", Deployment: &storage.Exclusion_Deployment{Scope: &storage.Scope{Namespace: "namespace-2"}}},
+		{Name: "exclusion3", Deployment: &storage.Exclusion_Deployment{Scope: &storage.Scope{Namespace: "namespace-3"}}},
+		{Name: "exclusion4", Deployment: &storage.Exclusion_Deployment{Scope: &storage.Scope{Namespace: "namespace-4"}}},
+	}
+
+	s.NoError(s.store.Upsert(s.ctx, policy))
+
+	comparisonPolicies := map[string]*storage.Policy{
+		policyID: policy,
+	}
+
+	policiesToMigrate := map[string]PolicyChanges{
+		policyID: {
+			FieldsToCompare: []FieldComparator{ExclusionComparator},
+			ToChange: PolicyUpdates{
+				ExclusionsToAdd: []*storage.Exclusion{
+					{Name: "exclusion1-changed", Deployment: &storage.Exclusion_Deployment{Scope: &storage.Scope{Namespace: "namespace-1"}}},
+					{Name: "NEW exclusion", Deployment: &storage.Exclusion_Deployment{Scope: &storage.Scope{Namespace: "namespace-NEW"}}},
+					{Name: "NEW exclusion2", Deployment: &storage.Exclusion_Deployment{Scope: &storage.Scope{Namespace: "namespace-NEW2"}}},
+				},
+				ExclusionsToRemove: []*storage.Exclusion{
+					{Name: "exclusion1", Deployment: &storage.Exclusion_Deployment{Scope: &storage.Scope{Namespace: "namespace 1"}}},
+					{Name: "exclusion4", Deployment: &storage.Exclusion_Deployment{Scope: &storage.Scope{Namespace: "namespace-4"}}},
+					{Name: "exclusion-NaN", Deployment: &storage.Exclusion_Deployment{Scope: &storage.Scope{Namespace: "namespace-NaN"}}}, // this exclusion doesn't exist so it shouldn't get removed
+				},
+			},
+		},
+	}
+
+	s.NoError(MigratePoliciesWithDB(
+		policiesToMigrate,
+		comparisonPolicies,
+		s.store.Exists,
+		s.store.Get,
+		s.store.Upsert,
+	))
+
+	// Policy exclusions should be updated
+	policy.Exclusions = []*storage.Exclusion{
+		{Name: "exclusion0", Deployment: &storage.Exclusion_Deployment{Scope: &storage.Scope{Namespace: "namespace-0"}}},
+		{Name: "exclusion2", Deployment: &storage.Exclusion_Deployment{Scope: &storage.Scope{Namespace: "namespace-2"}}},
+		{Name: "exclusion3", Deployment: &storage.Exclusion_Deployment{Scope: &storage.Scope{Namespace: "namespace-3"}}},
+		{Name: "exclusion1-changed", Deployment: &storage.Exclusion_Deployment{Scope: &storage.Scope{Namespace: "namespace-1"}}},
+		{Name: "NEW exclusion", Deployment: &storage.Exclusion_Deployment{Scope: &storage.Scope{Namespace: "namespace-NEW"}}},
+		{Name: "NEW exclusion2", Deployment: &storage.Exclusion_Deployment{Scope: &storage.Scope{Namespace: "namespace-NEW2"}}},
+	}
+
+	s.comparePolicyWithDB(policyID, policy)
+}

--- a/migrator/migrations/policymigrationhelper/postgres_policy_migrator_test.go
+++ b/migrator/migrations/policymigrationhelper/postgres_policy_migrator_test.go
@@ -117,7 +117,7 @@ func (s *postgresPolicyMigratorTestSuite) TestAllUnmodifiedPoliciesGetUpdated() 
 		policy.Name = fmt.Sprintf("policy-name%d", i) // name is a unique key
 		policy.Description = "sfasdf"
 
-		comparisonPolicy := policy.Clone() //testPolicy(policy.Id)
+		comparisonPolicy := policy.Clone()
 		comparisonPolicies[policy.Id] = comparisonPolicy
 		policiesToMigrate[policy.Id] = PolicyChanges{
 			FieldsToCompare: []FieldComparator{PolicySectionComparator, ExclusionComparator, RemediationComparator, RationaleComparator},


### PR DESCRIPTION
## Description

Refactor policy migration helper methods and move it into the `policymigrationhelper` package so that it can be used by other migrations in the future. The helper methods use the existing models from the package but now just accept the store methods as params so that they can be used by other migrations regardless of how the store or schema changes since they can use their own frozen store.

NOTE: Not planning on changing any existing migrations to use this new migrator helper.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
~[ ] Evaluated and added CHANGELOG entry if required~
~[ ] Determined and documented upgrade steps~
~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
