### PR TITLE
Fix dev doc info and add missing protobuf lib reference for importing

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ MAIN_IMAGE_TAG=latest ./deploy/deploy-local.sh
 
 After a few minutes, all resources should be deployed.
 
-**Credentials for the 'admin' user can be found in the `./deploy/k8s/deploy-local/password` file.**
+**Credentials for the 'admin' user can be found in the `./deploy/k8s/central-deploy/password` file.**
 
 </details>
 
@@ -467,18 +467,17 @@ $ smart-diff                    # check diff relative to parent branch
 
 If you're using GoLand for development, the following can help improve the experience.
 
-
 Make sure the `Protocol Buffers` plugin is installed. The plugin comes installed by default in GoLand.  
 If it isn't, use `Help | Find Action...`, type `Plugins` and hit enter, then switch to `Marketplace`, type its name and install the plugin.
 
 This plugin does not know where to look for `.proto` imports by default in GoLand therefore you need to explicitly
-configure paths for this plugin. See <https://github.com/jvolkman/intellij-protobuf-editor#path-settings>.
+configure paths for this plugin. See <https://plugins.jetbrains.com/plugin/14004-protocol-buffers>.
 
-* Go to `GoLand | Preferences | Languages & Frameworks | Protocol Buffers`.
+* Go to `GoLand | File | Settings | Languages & Frameworks | Protocol Buffers`.
 * Uncheck `Configure automatically`.
 * Click on `+` button, navigate and select `./proto` directory in the root of the repo.
-* Optionally, also add `$HOME/go/pkg/mod/github.com/gogo/googleapis@1.1.0`
-  and `$HOME/go/pkg/mod/github.com/gogo/protobuf@v1.3.1/`.
+* Optionally, also add `$HOME/go/pkg/mod/github.com/gogo/googleapis@1.4.0/`
+  and `$HOME/go/pkg/mod/github.com/gogo/protobuf@v1.3.2/`.
 * To verify: use menu `Navigate | File...` type any `.proto` file name, e.g. `alert_service.proto`, and check that all
   import strings are shown green, not red.
 

--- a/go.mod
+++ b/go.mod
@@ -381,6 +381,8 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 )
 
+require github.com/gogo/googleapis v1.4.0
+
 // To bump the version of a replacement package, use:
 //
 //   $ go mod edit -replace <package>=<replacement>@<branch or commit reference>

--- a/go.sum
+++ b/go.sum
@@ -600,6 +600,8 @@ github.com/gofrs/uuid v4.4.0+incompatible h1:3qXRTX8/NbyulANqlc0lchS1gqAVxRgsuW1
 github.com/gofrs/uuid v4.4.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/googleapis v0.0.0-20180223154316-0cd9801be74a/go.mod h1:gf4bu3Q80BeJ6H1S1vYPm8/ELATdvryBaNFGgqEef3s=
 github.com/gogo/googleapis v1.1.0/go.mod h1:gf4bu3Q80BeJ6H1S1vYPm8/ELATdvryBaNFGgqEef3s=
+github.com/gogo/googleapis v1.4.0 h1:zgVt4UpGxcqVOw97aRGxT4svlcmdK35fynLNctY32zI=
+github.com/gogo/googleapis v1.4.0/go.mod h1:5YRNX2z1oM5gXdAkurHa942MDgEJyk02w4OecKY87+c=
 github.com/gogo/status v1.1.0/go.mod h1:BFv9nrluPLmrS0EmGVvLaPNmRosr9KapBYd5/hpY1WM=
 github.com/golang-jwt/jwt/v4 v4.4.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang-jwt/jwt/v4 v4.5.0 h1:7cYmW1XlMY7h7ii7UhUyChSgS5wUJEnm9uZVTGqOWzg=

--- a/pkg/protoutils/bench_test.go
+++ b/pkg/protoutils/bench_test.go
@@ -3,6 +3,7 @@ package protoutils
 import (
 	"testing"
 
+	_ "github.com/gogo/googleapis/google/api"
 	"github.com/gogo/protobuf/proto"
 	golangProto "github.com/golang/protobuf/proto"
 	"github.com/stackrox/rox/pkg/fixtures"


### PR DESCRIPTION
## Description

This is small fixes to the development documentation, including:
* `password` file location with local deployment
* actual GoLand protobuf plugin docs and location
* actual `gogo/googleapis` and `gogo/protobuf` versions for development
* implicit `github.com/gogo/googleapis` embedding for using inside the `protobuf` plugin for validation

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
