### PR TITLE
Fix data race in service store

### DIFF
--- a/pkg/env/sensor.go
+++ b/pkg/env/sensor.go
@@ -29,5 +29,5 @@ var (
 	EventPipelineQueueSize = RegisterIntegerSetting("ROX_EVENT_PIPELINE_QUEUE_SIZE", 1000)
 
 	// ResyncDisabled disables the resync behavior of the kubernetes listeners in sensor
-	ResyncDisabled = RegisterBooleanSetting("ROX_RESYNC_DISABLEDD", false)
+	ResyncDisabled = RegisterBooleanSetting("ROX_RESYNC_DISABLED", false)
 )

--- a/pkg/env/sensor.go
+++ b/pkg/env/sensor.go
@@ -29,5 +29,5 @@ var (
 	EventPipelineQueueSize = RegisterIntegerSetting("ROX_EVENT_PIPELINE_QUEUE_SIZE", 1000)
 
 	// ResyncDisabled disables the resync behavior of the kubernetes listeners in sensor
-	ResyncDisabled = RegisterBooleanSetting("ROX_RESYNC_DISABLED", false)
+	ResyncDisabled = RegisterBooleanSetting("ROX_RESYNC_DISABLEDD", false)
 )

--- a/sensor/kubernetes/listener/resources/service_store.go
+++ b/sensor/kubernetes/listener/resources/service_store.go
@@ -173,5 +173,7 @@ func (ss *serviceStore) getService(namespace string, name string) *serviceWrap {
 }
 
 func (ss *serviceStore) getRoutesForService(svcWrap *serviceWrap) []*routeV1.Route {
+	ss.lock.RLock()
+	defer ss.lock.RUnlock()
 	return ss.routesByServiceMetadata[svcWrap.Namespace][svcWrap.Name]
 }


### PR DESCRIPTION
## Description

The function `getRoutesForServices` does not lock before reading from the service store. This is a potential data race if another goroutine tries to access the service store. This function is only called [here](https://github.com/stackrox/stackrox/blob/74476b76b39dfe2e9cdaeecc3e9eaf262097389f/sensor/kubernetes/listener/resources/service.go#L192), so it only affects the re-sync path (to be removed soon).

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

* CI with resync on passed in [038b94f](https://github.com/stackrox/stackrox/pull/5983/commits/038b94f57299049f6e326d058dd979b3ee5d07ef)
