### PR TITLE
ROX-16756: Central side changes to send network policy yamls via secured clusters notifiers

### DIFF
--- a/central/networkpolicies/service/service_impl.go
+++ b/central/networkpolicies/service/service_impl.go
@@ -22,8 +22,10 @@ import (
 	"github.com/stackrox/rox/central/role/sachelper"
 	"github.com/stackrox/rox/central/sensor/service/connection"
 	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/auth/permissions"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/errorhelpers"
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/features"
@@ -322,6 +324,7 @@ func (s *serviceImpl) SendNetworkPolicyYAML(ctx context.Context, request *v1.Sen
 	}
 
 	errorList := errorhelpers.NewErrorList("unable to use all requested notifiers")
+	var securedNotifierIds []string
 	for _, notifierID := range request.GetNotifierIds() {
 		notifierProto, exists, err := s.notifierStore.GetNotifier(ctx, notifierID)
 		if err != nil {
@@ -344,12 +347,33 @@ func (s *serviceImpl) SendNetworkPolicyYAML(ctx context.Context, request *v1.Sen
 			continue
 		}
 
+		if env.SecuredClusterNotifiers.BooleanSetting() && notifier.IsSecuredClusterNotifier() {
+			// for secured cluster notifiers, the network policy modification will be sent out
+			// to the notifiers from the secured cluster
+			securedNotifierIds = append(securedNotifierIds, notifierID)
+			continue
+		}
+
 		err = netpolNotifier.NetworkPolicyYAMLNotify(ctx, request.GetModification().GetApplyYaml(), clusterName)
 		if err != nil {
 			errorList.AddStringf("error sending yaml notification to %s: %v", notifierProto.GetName(), err)
 		}
 	}
 
+	if len(securedNotifierIds) > 0 {
+		err = s.sensorConnMgr.SendMessage(request.GetClusterId(), &central.MsgToSensor{
+			Msg: &central.MsgToSensor_SendNetworkPolicyYaml{
+				SendNetworkPolicyYaml: &central.SendNetworkPolicyYamlRequest{
+					ClusterId:    request.GetClusterId(),
+					NotifierIds:  securedNotifierIds,
+					Modification: request.GetModification(),
+				},
+			},
+		})
+		if err != nil {
+			errorList.AddStringf("error sending yaml notification to cluster %s: %v", clusterName, err)
+		}
+	}
 	err = errorList.ToError()
 	if err != nil {
 		return nil, err

--- a/central/notifier/processor/mocks/processor.go
+++ b/central/notifier/processor/mocks/processor.go
@@ -93,20 +93,6 @@ func (mr *MockProcessorMockRecorder) HasNotifiers() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasNotifiers", reflect.TypeOf((*MockProcessor)(nil).HasNotifiers))
 }
 
-// IsSecuredClusterNotifier mocks base method.
-func (m *MockProcessor) IsSecuredClusterNotifier(notifier notifiers.Notifier) bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsSecuredClusterNotifier", notifier)
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// IsSecuredClusterNotifier indicates an expected call of IsSecuredClusterNotifier.
-func (mr *MockProcessorMockRecorder) IsSecuredClusterNotifier(notifier interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsSecuredClusterNotifier", reflect.TypeOf((*MockProcessor)(nil).IsSecuredClusterNotifier), notifier)
-}
-
 // ProcessAlert mocks base method.
 func (m *MockProcessor) ProcessAlert(ctx context.Context, alert *storage.Alert) {
 	m.ctrl.T.Helper()

--- a/central/notifier/processor/processor.go
+++ b/central/notifier/processor/processor.go
@@ -23,7 +23,6 @@ type Processor interface {
 
 	HasNotifiers() bool
 	HasEnabledAuditNotifiers() bool
-	IsSecuredClusterNotifier(notifier notifiers.Notifier) bool
 
 	UpdateNotifier(ctx context.Context, notifier notifiers.Notifier)
 	RemoveNotifier(ctx context.Context, id string)

--- a/central/notifier/processor/processor_impl.go
+++ b/central/notifier/processor/processor_impl.go
@@ -53,23 +53,6 @@ func (p *processorImpl) UpdateNotifier(ctx context.Context, notifier notifiers.N
 	p.ns.UpsertNotifier(ctx, notifier)
 }
 
-// IsSecuredClusterNotifier returns true if this is a notifier that can be accessed by the secured cluster
-func (p *processorImpl) IsSecuredClusterNotifier(notifier notifiers.Notifier) bool {
-	if !env.SecuredClusterNotifiers.BooleanSetting() {
-		return false
-	}
-	if _, ok := notifier.ProtoNotifier().Config.(*storage.Notifier_Jira); ok {
-		return true
-	}
-	if _, ok := notifier.ProtoNotifier().Config.(*storage.Notifier_Generic); ok {
-		return true
-	}
-	if _, ok := notifier.ProtoNotifier().Config.(*storage.Notifier_Syslog); ok {
-		return true
-	}
-	return false
-}
-
 // ProcessAlert pushes the alert into a channel to be processed
 func (p *processorImpl) ProcessAlert(ctx context.Context, alert *storage.Alert) {
 	if len(alert.GetPolicy().GetNotifiers()) == 0 {
@@ -82,7 +65,7 @@ func (p *processorImpl) ProcessAlert(ctx context.Context, alert *storage.Alert) 
 			// If this is a secured cluster notifier the notification for this alert has already been processed in the secured
 			// cluster before the alert reached here for processing. Hence, skip the notifier and continue with the rest
 			// of the notifiers configured for the policy that generated the alert
-			if p.IsSecuredClusterNotifier(notifier) {
+			if notifier.IsSecuredClusterNotifier() {
 				return
 			}
 			go func() {
@@ -136,7 +119,7 @@ func (p *processorImpl) processAlertSync(ctx context.Context, alert *storage.Ale
 	alertNotifiers := set.NewStringSet(alert.GetPolicy().GetNotifiers()...)
 	p.ns.ForEach(ctx, func(ctx context.Context, notifier notifiers.Notifier, failures AlertSet) {
 		if alertNotifiers.Contains(notifier.ProtoNotifier().GetId()) {
-			if p.IsSecuredClusterNotifier(notifier) {
+			if env.SecuredClusterNotifiers.BooleanSetting() && notifier.IsSecuredClusterNotifier() {
 				return
 			}
 			err := tryToAlert(ctx, notifier, alert)

--- a/central/notifier/processor/processor_impl_test.go
+++ b/central/notifier/processor/processor_impl_test.go
@@ -200,10 +200,13 @@ func TestProcessor_SkipNotificationsForSecuredClusterNotifiers(t *testing.T) {
 	ns := NewNotifierSet()
 	processor := &processorImpl{ns: ns}
 
-	// Add the notifiers to the processor.
 	mockJiraAlertNotifier.EXPECT().ProtoNotifier().Return(jiraAlertNotfierProto).AnyTimes()
 	mockEmailAlertNotifier.EXPECT().ProtoNotifier().Return(emailAlertNotfierProto).AnyTimes()
 
+	mockJiraAlertNotifier.EXPECT().IsSecuredClusterNotifier().Return(true).AnyTimes()
+	mockEmailAlertNotifier.EXPECT().IsSecuredClusterNotifier().Return(false).AnyTimes()
+
+	// Add the notifiers to the processor.
 	processor.UpdateNotifier(ctx, mockJiraAlertNotifier)
 	processor.UpdateNotifier(ctx, mockEmailAlertNotifier)
 

--- a/central/notifier/service/service_impl.go
+++ b/central/notifier/service/service_impl.go
@@ -232,7 +232,7 @@ func (s *serviceImpl) TestUpdatedNotifier(ctx context.Context, request *v1.Updat
 		}
 	}()
 
-	if env.SecuredClusterNotifiers.BooleanSetting() && s.processor.IsSecuredClusterNotifier(notifier) {
+	if env.SecuredClusterNotifiers.BooleanSetting() && notifier.IsSecuredClusterNotifier() {
 		return s.testSecuredClusterNotifier(ctx, notifier)
 	}
 	// if secured cluster notifications are not enabled or if this is not a secured cluster notifier

--- a/central/notifiers/cscc/cscc.go
+++ b/central/notifiers/cscc/cscc.go
@@ -279,3 +279,7 @@ func (c *cscc) ProtoNotifier() *storage.Notifier {
 func (c *cscc) Test(context.Context) error {
 	return errors.New("Test is not yet implemented for Cloud SCC")
 }
+
+func (c *cscc) IsSecuredClusterNotifier() bool {
+	return false
+}

--- a/pkg/notifiers/awssh/notifier.go
+++ b/pkg/notifiers/awssh/notifier.go
@@ -426,6 +426,10 @@ func (n *notifier) AlertNotify(ctx context.Context, alert *storage.Alert) error 
 	}
 }
 
+func (n *notifier) IsSecuredClusterNotifier() bool {
+	return false
+}
+
 func (n *notifier) AckAlert(_ context.Context, _ *storage.Alert) error {
 	return nil
 }

--- a/pkg/notifiers/email/email.go
+++ b/pkg/notifiers/email/email.go
@@ -355,6 +355,10 @@ func (e *email) Test(ctx context.Context) error {
 	return err
 }
 
+func (e *email) IsSecuredClusterNotifier() bool {
+	return false
+}
+
 func (e *email) sendEmail(ctx context.Context, recipient, subject, body string) error {
 	var from string
 	if e.config.GetFrom() != "" {

--- a/pkg/notifiers/generic/generic.go
+++ b/pkg/notifiers/generic/generic.go
@@ -158,6 +158,10 @@ func (g *generic) Test(ctx context.Context) error {
 	return g.AlertNotify(ctx, alert)
 }
 
+func (g *generic) IsSecuredClusterNotifier() bool {
+	return true
+}
+
 func (g *generic) constructJSON(message proto.Message, msgKey string) (io.Reader, error) {
 	msgStr, err := new(jsonpb.Marshaler).MarshalToString(message)
 	if err != nil {

--- a/pkg/notifiers/jira/jira.go
+++ b/pkg/notifiers/jira/jira.go
@@ -335,6 +335,10 @@ func (j *jira) Test(ctx context.Context) error {
 	return j.createIssue(ctx, storage.Severity_LOW_SEVERITY, i)
 }
 
+func (j *jira) IsSecuredClusterNotifier() bool {
+	return true
+}
+
 // Optimistically tries to match all of the Jira priorities with the known mapping defined in defaultPriorities
 // If any severity is not matched, then it returns a nil map
 func optimisticMatching(prios []jiraLib.Priority) map[storage.Severity]string {

--- a/pkg/notifiers/mocks/alert_notifier.go
+++ b/pkg/notifiers/mocks/alert_notifier.go
@@ -63,6 +63,20 @@ func (mr *MockAlertNotifierMockRecorder) Close(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockAlertNotifier)(nil).Close), arg0)
 }
 
+// IsSecuredClusterNotifier mocks base method.
+func (m *MockAlertNotifier) IsSecuredClusterNotifier() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsSecuredClusterNotifier")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsSecuredClusterNotifier indicates an expected call of IsSecuredClusterNotifier.
+func (mr *MockAlertNotifierMockRecorder) IsSecuredClusterNotifier() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsSecuredClusterNotifier", reflect.TypeOf((*MockAlertNotifier)(nil).IsSecuredClusterNotifier))
+}
+
 // ProtoNotifier mocks base method.
 func (m *MockAlertNotifier) ProtoNotifier() *storage.Notifier {
 	m.ctrl.T.Helper()

--- a/pkg/notifiers/mocks/audit_notifier.go
+++ b/pkg/notifiers/mocks/audit_notifier.go
@@ -64,6 +64,20 @@ func (mr *MockAuditNotifierMockRecorder) Close(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockAuditNotifier)(nil).Close), arg0)
 }
 
+// IsSecuredClusterNotifier mocks base method.
+func (m *MockAuditNotifier) IsSecuredClusterNotifier() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsSecuredClusterNotifier")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsSecuredClusterNotifier indicates an expected call of IsSecuredClusterNotifier.
+func (mr *MockAuditNotifierMockRecorder) IsSecuredClusterNotifier() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsSecuredClusterNotifier", reflect.TypeOf((*MockAuditNotifier)(nil).IsSecuredClusterNotifier))
+}
+
 // ProtoNotifier mocks base method.
 func (m *MockAuditNotifier) ProtoNotifier() *storage.Notifier {
 	m.ctrl.T.Helper()

--- a/pkg/notifiers/mocks/notifier.go
+++ b/pkg/notifiers/mocks/notifier.go
@@ -49,6 +49,20 @@ func (mr *MockNotifierMockRecorder) Close(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockNotifier)(nil).Close), arg0)
 }
 
+// IsSecuredClusterNotifier mocks base method.
+func (m *MockNotifier) IsSecuredClusterNotifier() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsSecuredClusterNotifier")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsSecuredClusterNotifier indicates an expected call of IsSecuredClusterNotifier.
+func (mr *MockNotifierMockRecorder) IsSecuredClusterNotifier() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsSecuredClusterNotifier", reflect.TypeOf((*MockNotifier)(nil).IsSecuredClusterNotifier))
+}
+
 // ProtoNotifier mocks base method.
 func (m *MockNotifier) ProtoNotifier() *storage.Notifier {
 	m.ctrl.T.Helper()

--- a/pkg/notifiers/mocks/report_notifier.go
+++ b/pkg/notifiers/mocks/report_notifier.go
@@ -50,6 +50,20 @@ func (mr *MockReportNotifierMockRecorder) Close(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockReportNotifier)(nil).Close), arg0)
 }
 
+// IsSecuredClusterNotifier mocks base method.
+func (m *MockReportNotifier) IsSecuredClusterNotifier() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsSecuredClusterNotifier")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsSecuredClusterNotifier indicates an expected call of IsSecuredClusterNotifier.
+func (mr *MockReportNotifierMockRecorder) IsSecuredClusterNotifier() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsSecuredClusterNotifier", reflect.TypeOf((*MockReportNotifier)(nil).IsSecuredClusterNotifier))
+}
+
 // ProtoNotifier mocks base method.
 func (m *MockReportNotifier) ProtoNotifier() *storage.Notifier {
 	m.ctrl.T.Helper()

--- a/pkg/notifiers/mocks/resolvable_alert_notifier.go
+++ b/pkg/notifiers/mocks/resolvable_alert_notifier.go
@@ -77,6 +77,20 @@ func (mr *MockResolvableAlertNotifierMockRecorder) Close(arg0 interface{}) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockResolvableAlertNotifier)(nil).Close), arg0)
 }
 
+// IsSecuredClusterNotifier mocks base method.
+func (m *MockResolvableAlertNotifier) IsSecuredClusterNotifier() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsSecuredClusterNotifier")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsSecuredClusterNotifier indicates an expected call of IsSecuredClusterNotifier.
+func (mr *MockResolvableAlertNotifierMockRecorder) IsSecuredClusterNotifier() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsSecuredClusterNotifier", reflect.TypeOf((*MockResolvableAlertNotifier)(nil).IsSecuredClusterNotifier))
+}
+
 // ProtoNotifier mocks base method.
 func (m *MockResolvableAlertNotifier) ProtoNotifier() *storage.Notifier {
 	m.ctrl.T.Helper()

--- a/pkg/notifiers/notifier.go
+++ b/pkg/notifiers/notifier.go
@@ -16,4 +16,6 @@ type Notifier interface {
 	ProtoNotifier() *storage.Notifier
 	// Test sends a test message
 	Test(context.Context) error
+	// IsSecuredClusterNotifier returns true if this notifier can be used in the secured cluster
+	IsSecuredClusterNotifier() bool
 }

--- a/pkg/notifiers/pagerduty/pagerduty.go
+++ b/pkg/notifiers/pagerduty/pagerduty.go
@@ -109,6 +109,10 @@ func (p *pagerDuty) Test(_ context.Context) error {
 	}, newAlert)
 }
 
+func (p *pagerDuty) IsSecuredClusterNotifier() bool {
+	return false
+}
+
 func (p *pagerDuty) AckAlert(_ context.Context, alert *storage.Alert) error {
 	return p.postAlert(alert, ackAlert)
 }

--- a/pkg/notifiers/slack/slack.go
+++ b/pkg/notifiers/slack/slack.go
@@ -253,6 +253,10 @@ func (s *slack) Test(ctx context.Context) error {
 	)
 }
 
+func (s *slack) IsSecuredClusterNotifier() bool {
+	return false
+}
+
 func (s *slack) postMessage(ctx context.Context, url string, jsonPayload []byte) error {
 	req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonPayload))
 	if err != nil {

--- a/pkg/notifiers/splunk/splunk.go
+++ b/pkg/notifiers/splunk/splunk.go
@@ -84,6 +84,10 @@ func (s *splunk) Test(ctx context.Context) error {
 	return s.postAlert(ctx, alert)
 }
 
+func (s *splunk) IsSecuredClusterNotifier() bool {
+	return false
+}
+
 func (s *splunk) postAlert(ctx context.Context, alert *storage.Alert) error {
 	clonedAlert := alert.Clone()
 	// Splunk's HEC by default has a limitation of data size == 10KB

--- a/pkg/notifiers/sumologic/sumologic.go
+++ b/pkg/notifiers/sumologic/sumologic.go
@@ -137,6 +137,10 @@ func (s *sumologic) Test(ctx context.Context) error {
 	return s.sendPayload(ctx, bytes.NewBuffer(marshaledPayload))
 }
 
+func (s *sumologic) IsSecuredClusterNotifier() bool {
+	return false
+}
+
 func init() {
 	notifiers.Add("sumologic", func(notifier *storage.Notifier) (notifiers.Notifier, error) {
 		return newSumoLogic(notifier)

--- a/pkg/notifiers/syslog/syslog.go
+++ b/pkg/notifiers/syslog/syslog.go
@@ -251,6 +251,10 @@ func (s *syslog) Test(context.Context) error {
 	return s.sendSyslog(testMessageSeverity, time.Now(), "stackroxKubernetesSecurityPlatformIntegrationTest", data)
 }
 
+func (s *syslog) IsSecuredClusterNotifier() bool {
+	return true
+}
+
 func (s *syslog) SendAuditMessage(_ context.Context, msg *v1.Audit_Message) error {
 	unstructuredData := auditLogToCEF(msg, s.Notifier)
 	timestamp, err := types.TimestampFromProto(msg.GetTime())

--- a/pkg/notifiers/teams/teams.go
+++ b/pkg/notifiers/teams/teams.go
@@ -372,6 +372,10 @@ func (t *teams) Test(ctx context.Context) error {
 	)
 }
 
+func (t *teams) IsSecuredClusterNotifier() bool {
+	return false
+}
+
 func postMessage(ctx context.Context, url string, jsonPayload []byte) error {
 	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(jsonPayload))
 	if err != nil {


### PR DESCRIPTION
## Description
Central side changes to send network policy yamls via secured clusters notifiers

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed
CI only, manual testing once secured cluster side changes come in.