### PR TITLE
Improve icons for Enabled Fixable Pass in UI

### DIFF
--- a/ui/apps/platform/src/Components/PatternFly/IconText/ImageActiveIconText.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/IconText/ImageActiveIconText.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import { CheckIcon, TimesIcon } from '@patternfly/react-icons';
+import { CheckIcon, MinusIcon } from '@patternfly/react-icons';
 
 import IconText from './IconText';
 
@@ -9,11 +9,7 @@ export type ImageActiveIconTextProps = {
 };
 
 function ImageActiveIconText({ isActive, isTextOnly }: ImageActiveIconTextProps): ReactElement {
-    const icon = isActive ? (
-        <CheckIcon color="var(--pf-global--success-color--100)" />
-    ) : (
-        <TimesIcon />
-    );
+    const icon = isActive ? <CheckIcon /> : <MinusIcon />;
     const text = isActive ? 'Active' : 'Inactive';
 
     return <IconText icon={icon} text={text} isTextOnly={isTextOnly} />;

--- a/ui/apps/platform/src/Components/PatternFly/IconText/NotApplicableIconText.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/IconText/NotApplicableIconText.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import { Minus } from 'react-feather';
+import { MinusIcon } from '@patternfly/react-icons';
 
 import IconText from './IconText';
 
@@ -8,7 +8,7 @@ export type NotApplicableIconTextProps = {
 };
 
 function NotApplicableIconText({ isTextOnly }: NotApplicableIconTextProps): ReactElement {
-    const icon = <Minus className="h-4 w-4" />;
+    const icon = <MinusIcon />;
     const text = 'N/A';
 
     return <IconText icon={icon} text={text} isTextOnly={isTextOnly} />;

--- a/ui/apps/platform/src/Components/PatternFly/IconText/PolicyDisabledIconText.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/IconText/PolicyDisabledIconText.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import { BanIcon, CheckIcon } from '@patternfly/react-icons';
+import { CheckIcon, MinusIcon } from '@patternfly/react-icons';
 
 import IconText from './IconText';
 
@@ -12,11 +12,7 @@ function PolicyDisabledIconText({
     isDisabled,
     isTextOnly,
 }: PolicyDisabledIconTextProps): ReactElement {
-    const icon = isDisabled ? (
-        <BanIcon />
-    ) : (
-        <CheckIcon color="var(--pf-global--success-color--100)" />
-    );
+    const icon = isDisabled ? <MinusIcon /> : <CheckIcon />;
     const text = isDisabled ? 'Disabled' : 'Enabled';
 
     return <IconText icon={icon} text={text} isTextOnly={isTextOnly} />;

--- a/ui/apps/platform/src/Components/PatternFly/IconText/PolicyStatusIconText.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/IconText/PolicyStatusIconText.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import { ThumbsDown, ThumbsUp } from 'react-feather';
+import { CheckCircleIcon, ExclamationCircleIcon } from '@patternfly/react-icons';
 
 import IconText from './IconText';
 
@@ -10,9 +10,9 @@ export type PolicyStatusIconTextProps = {
 
 function PolicyStatusIconText({ isPass, isTextOnly }: PolicyStatusIconTextProps): ReactElement {
     const icon = isPass ? (
-        <ThumbsUp className="h-4 w-4 pf-u-success-color-100" />
+        <CheckCircleIcon color="var(--pf-global--success-color--100)" />
     ) : (
-        <ThumbsDown className="h-4 w-4 pf-u-danger-color-100" />
+        <ExclamationCircleIcon color="var(--pf-global--danger-color--100)" />
     );
     const text = isPass ? 'Pass' : 'Fail';
 

--- a/ui/apps/platform/src/Components/PatternFly/IconText/VulnerabilityFixableIconText.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/IconText/VulnerabilityFixableIconText.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import { CheckIcon, TimesIcon } from '@patternfly/react-icons';
+import { MinusIcon, WrenchIcon } from '@patternfly/react-icons';
 
 import IconText from './IconText';
 
@@ -12,11 +12,7 @@ function VulnerabilityFixableIconText({
     isFixable,
     isTextOnly,
 }: VulnerabilityFixableIconTextProps): ReactElement {
-    const icon = isFixable ? (
-        <CheckIcon color="var(--pf-global--default-color--200)" />
-    ) : (
-        <TimesIcon />
-    );
+    const icon = isFixable ? <WrenchIcon /> : <MinusIcon />;
     const text = isFixable ? 'Fixable' : 'Not fixable';
 
     return <IconText icon={icon} text={text} isTextOnly={isTextOnly} />;


### PR DESCRIPTION
## Description

Follow up after first draft in #5696

Thanks to Mansur for guiding the discussion by Design and Product.

| entity        | text        | icon                  | color         |
| :---          | :---        | :---                  | :---          |
| policy        | Enabled     | CheckIcon             | normal black  |
| policy        | Disabled    | MinusIcon             | normal black  |
| vulnerability | Fixable     | WrenchIcon            | normal black  |
| vulnerability | Not fixable | MinusIcon             | normal black  |
| policy        | Pass        | CircleCheckIcon       | success green |
| policy        | Fail        | ExclamationCircleIcon | danger red    |

Bonus improvements for consistency:
* ImageActiveIconText renders CheckIcon and MinusIcon like policy Enabled/Disabled
* NotApplicableIconText renders MinusIcon like policy Disabled and vulnerability Not fixable

## Checklist
- [ ] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

### Integration testing

In ui/apps/platform folder:

1. `export CYPRESS_ROX_POSTGRES_DATASTORE=true`

2. `yarn cypress-open`

    * configmanagement/ciscontrols.test.js
    * configmanagement/clusters.test.js
    * configmanagement/deployments.test.js
    * configmanagement/namespaces.test.js
    * configmanagement/policies.test.js
    * vulnmanagement/clusterCves.test.js
    * vulnmanagement/clusters.test.js
    * vulnmanagement/deployments.test.js
    * vulnmanagement/entitypages.test.js
    * vulnmanagement/imageComponents.test.js
    * vulnmanagement/imageCves.test.js
    * vulnmanagement/images.test.js
    * vulnmanagement/namespaces.test.js
    * vulnmanagement/nodeComponents.test.js
    * vulnmanagement/nodeCves.test.js
    * vulnmanagement/nodes.test.js

### Manual testing

#### Configuration Management

1. Visit /main/configmanagement/policies

    * See Disabled/Enabled and Disabled/Fail/Pass in dark theme
        ![configmanagement_policies_dark](https://github.com/stackrox/stackrox/assets/11862657/270a386d-5066-44a9-84c5-0e80d4d2ce5a)

    * See Disabled/Enabled and Disabled/Fail/Pass in light theme
        ![configmanagement_policies_light](https://github.com/stackrox/stackrox/assets/11862657/d306824b-9644-4926-b32d-3a64364b1ebd)

2. Visit /main/configmanagement/controls

    * See Fail and Pass in light theme
        ![configmanagement_controls_Fail_Pass](https://github.com/stackrox/stackrox/assets/11862657/19d9ebb0-d8e1-4a16-8b02-ba14b9e4b2ec)

    * See Pass and N/A in light theme
        ![configmanagement_Pass_NA](https://github.com/stackrox/stackrox/assets/11862657/add027f4-5383-4724-9604-896d97e9a5ee)

#### Vulnerability Management

1. Visit /main/vulnerability-management/policies

    * See Pass/Disabled/Fail in dark theme
        ![vulnerability-management_policies_dark](https://github.com/stackrox/stackrox/assets/11862657/fadb5fd7-7ad5-4a67-a5cf-8f4fafcedcf0)

    * See Pass/Disabled/Fail in light theme
![vulnerability-management_policies_light](https://github.com/stackrox/stackrox/assets/11862657/45746e5a-4980-41d0-9cb3-4fd84444c172)

2. Visit /main/vulnerability-management/node-cves

    * See Not fixable and Fixable in dark theme
        ![vulnerability-management_node-cves_dark](https://github.com/stackrox/stackrox/assets/11862657/604dbfc1-c263-4b1f-af14-e171e57ce8a7)

    * See Not fixable and Fixable in light theme
        ![vulnerability-management_node-cves_light](https://github.com/stackrox/stackrox/assets/11862657/05a441ad-f903-4410-b46f-245001a73b34)

3. Visit /main/vulnerability-management/images

    * See Active in dark theme
        ![vulnerability-management_images_dark](https://github.com/stackrox/stackrox/assets/11862657/85daea31-0f8d-4d8e-9e39-03823fde12c1)

    * See Active in light theme
        ![vulnerability-management_images_light](https://github.com/stackrox/stackrox/assets/11862657/9c863f27-f89c-4b5b-83d6-ce5df3b8c3d2)
