### PR TITLE
Delete occurrences of Tailwind italic class

### DIFF
--- a/ui/apps/platform/src/Components/DetailsOverlay/DetailsOverlay.tsx
+++ b/ui/apps/platform/src/Components/DetailsOverlay/DetailsOverlay.tsx
@@ -42,9 +42,7 @@ function DetailsOverlay({
                     </div>
                     <div className="flex flex-1 flex-col" data-testid={`${dataTestId}-header`}>
                         <div className="text-base">{headerText}</div>
-                        <div className="italic text-primary-200 text-xs capitalize">
-                            {subHeaderText}
-                        </div>
+                        <div className="text-primary-200 text-xs capitalize">{subHeaderText}</div>
                     </div>
                 </div>
 

--- a/ui/apps/platform/src/Components/NumberedGrid/NumberedGrid.js
+++ b/ui/apps/platform/src/Components/NumberedGrid/NumberedGrid.js
@@ -24,7 +24,7 @@ const NumberedGrid = ({ data, history }) => {
                 </span>
                 <div className={`flex flex-1 ${stacked ? 'justify-between' : 'flex-col'}`}>
                     {subText && (
-                        <div className="text-base-500 italic font-600 text-sm mb-1 whitespace-nowrap truncate">
+                        <div className="text-base-500 font-600 text-sm mb-1 whitespace-nowrap truncate">
                             {subText}
                         </div>
                     )}

--- a/ui/apps/platform/src/Components/NumberedList/NumberedList.js
+++ b/ui/apps/platform/src/Components/NumberedList/NumberedList.js
@@ -15,7 +15,7 @@ const NumberedList = ({ data, linkLeftOnly }) => {
         let leftSide = (
             <>
                 {i + 1}.&nbsp;{text}&nbsp;
-                {subText && <span className="text-base-500 italic">{subText}</span>}
+                {subText && <span className="text-base-500">{subText}</span>}
             </>
         );
         if (url && linkLeftOnly) {

--- a/ui/apps/platform/src/Components/SubHeader/SubHeader.js
+++ b/ui/apps/platform/src/Components/SubHeader/SubHeader.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const SubHeader = ({ text, capitalize }) => {
-    return <div className={`mt-1 italic ${capitalize ? 'capitalize' : ''}`}>{text}</div>;
+    return <div className={`mt-1 ${capitalize ? 'capitalize' : ''}`}>{text}</div>;
 };
 
 SubHeader.propTypes = {

--- a/ui/apps/platform/src/Components/TableGroup.js
+++ b/ui/apps/platform/src/Components/TableGroup.js
@@ -63,7 +63,7 @@ class TableGroup extends Component {
                     </div>
                     <h1 className="p-3 pl-0 font-600 text-lg leading-normal">{name}</h1>
                 </div>
-                <div className="flex items-center flex-shrink-0 italic font-700 text-sm p-3 pr-4 opacity-50">{`${
+                <div className="flex items-center flex-shrink-0 font-700 text-sm p-3 pr-4 opacity-50">{`${
                     rows.length
                 } ${pluralize(this.props.entityType, rows.length)}`}</div>
             </div>

--- a/ui/apps/platform/src/Components/TableHeader.js
+++ b/ui/apps/platform/src/Components/TableHeader.js
@@ -33,7 +33,7 @@ const TableHeader = (props) => {
         component = (
             <div className="pt-2">
                 {component}
-                <div className="pl-4 opacity-75 italic">
+                <div className="pl-4 opacity-75">
                     Please add a filter to narrow down your results.
                 </div>
             </div>

--- a/ui/apps/platform/src/Containers/AccessControl/PermissionSets/PermissionsTable.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/PermissionSets/PermissionsTable.tsx
@@ -67,13 +67,13 @@ function PermissionsTable({
                         }
                     >
                         <Td dataLabel="Resource">
-                            <p>{resource}</p>
-                            <p style={{ fontStyle: 'italic' }}>
+                            <p className="pf-u-font-weight-bold">{resource}</p>
+                            <p>
                                 {resourceSubstitutions[resource] && (
                                     <>Replaces {resourceSubstitutions[resource].join(', ')}</>
                                 )}
                             </p>
-                            <p style={{ fontStyle: 'italic' }}>
+                            <p>
                                 {resourceRemovalReleaseVersions.has(resource as ResourceName) && (
                                     <>
                                         Will be removed in{' '}
@@ -84,7 +84,7 @@ function PermissionsTable({
                                     </>
                                 )}
                             </p>
-                            <p style={{ fontStyle: 'italic' }}>
+                            <p>
                                 {replacedResourceMapping.has(resource as ResourceName) && (
                                     <>
                                         Will be replaced by{' '}

--- a/ui/apps/platform/src/Containers/BreadCrumbs/EntityBreadCrumb.js
+++ b/ui/apps/platform/src/Containers/BreadCrumbs/EntityBreadCrumb.js
@@ -31,7 +31,7 @@ const EntityBreadCrumb = ({ workflowEntity, url }) => {
                     <span className={extraClasses}>{title}</span>
                 </span>
             )}
-            <span className="capitalize italic font-600">{subTitle}</span>
+            <span className="capitalize font-600">{subTitle}</span>
         </span>
     );
 };

--- a/ui/apps/platform/src/Containers/Clusters/Components/FormFieldRequired.js
+++ b/ui/apps/platform/src/Containers/Clusters/Components/FormFieldRequired.js
@@ -9,9 +9,9 @@ import PropTypes from 'prop-types';
  * If the value is not empty: label color and (assumed) ordinary weight.
  */
 const FormFieldRequired = ({ empty }) => (
-    <i className={empty ? 'text-warning-700' : 'font-600'} data-testid="required">
+    <span className={empty ? 'text-warning-700' : 'font-600'} data-testid="required">
         (required)
-    </i>
+    </span>
 );
 
 FormFieldRequired.propTypes = {

--- a/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/widgets/SecretsMostUsedAcrossDeployments.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/widgets/SecretsMostUsedAcrossDeployments.js
@@ -121,7 +121,7 @@ const SecretsMostUsedAcrossDeployments = ({ match, location }) => {
                                                     {index + 1}
                                                 </div>
                                                 <div className="flex flex-col truncate pr-4 pb-4 pt-4 text-sm">
-                                                    <span className="text-xs pb-1 italic text-base-500">
+                                                    <span className="text-xs pb-1 text-base-500">
                                                         {item.clusterName}/{item.namespace}
                                                     </span>
                                                     <span className="pb-2">{item.name}</span>
@@ -139,7 +139,7 @@ const SecretsMostUsedAcrossDeployments = ({ match, location }) => {
                                                         }
                                                     >
                                                         {item.deploymentCount > 0 && (
-                                                            <div className="truncate italic">
+                                                            <div className="truncate">
                                                                 {`${
                                                                     item.deploymentCount
                                                                 } ${pluralize(

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/Policy/Policy.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/Policy/Policy.js
@@ -220,7 +220,7 @@ const Policy = ({ id, entityListType, entityId1, query, entityContext, paginatio
                                     </div>
                                     <div className="p-4">
                                         <span className="font-700">Rationale:&nbsp;</span>
-                                        <span className="italic">{rationale}</span>
+                                        <span>{rationale}</span>
                                     </div>
                                 </Widget>
                             </div>

--- a/ui/apps/platform/src/Containers/ConfigManagement/SidePanel/BreadCrumbs.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/SidePanel/BreadCrumbs.js
@@ -113,7 +113,7 @@ const BreadCrumbLinks = (props) => {
             <div key={`${state.name}--${state.type}`} className={`flex ${maxWidthClass} truncate`}>
                 <span className="flex flex-col max-w-full" data-testid="breadcrumb-link-text">
                     {content}
-                    <span className="capitalize italic font-600">{state.type.toLowerCase()}</span>
+                    <span className="capitalize font-600">{state.type.toLowerCase()}</span>
                 </span>
                 <span className="flex items-center">{icon}</span>
             </div>

--- a/ui/apps/platform/src/Containers/Dashboard/SummaryCounts.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/SummaryCounts.tsx
@@ -118,10 +118,7 @@ function SummaryCounts() {
                     ))}
                 </Split>
             </SplitItem>
-            <div
-                style={{ fontStyle: 'italic' }}
-                className="pf-u-color-200 pf-u-font-size-sm pf-u-mr-md pf-u-mr-lg-on-lg"
-            >
+            <div className="pf-u-color-200 pf-u-font-size-sm pf-u-mr-md pf-u-mr-lg-on-lg">
                 {`Last updated ${dateFormatter.format(lastUpdate)} at ${timeFormatter.format(
                     lastUpdate
                 )}`}

--- a/ui/apps/platform/src/Containers/Images/VulnsTable.js
+++ b/ui/apps/platform/src/Containers/Images/VulnsTable.js
@@ -23,7 +23,7 @@ const VulnsTable = ({ vulns, containsFixableCVEs, isOSPkg }) => {
                 </div>
             ),
             headerClassName: 'font-600 border-b border-base-300 flex items-end bg-primary-300',
-            className: 'pointer-events-none flex items-center justify-left italic',
+            className: 'pointer-events-none flex items-center justify-left',
         },
         {
             Header: 'CVSS',
@@ -45,7 +45,7 @@ const VulnsTable = ({ vulns, containsFixableCVEs, isOSPkg }) => {
             },
             headerClassName:
                 'font-600 border-b border-base-300 flex items-end justify-end bg-primary-300',
-            className: 'flex items-center justify-end italic',
+            className: 'flex items-center justify-end',
         },
     ];
     if (containsFixableCVEs) {
@@ -54,7 +54,7 @@ const VulnsTable = ({ vulns, containsFixableCVEs, isOSPkg }) => {
             accessor: 'fixedBy',
             width: 130,
             headerClassName: 'font-600 border-b border-base-300 flex items-end',
-            className: 'pointer-events-none flex items-center justify-end italic',
+            className: 'pointer-events-none flex items-center justify-end',
             Cell: ({ value }) => (value === '' && !isOSPkg ? 'Unknown' : value),
         });
     }

--- a/ui/apps/platform/src/Containers/Login/TestLoginResultsPage.js
+++ b/ui/apps/platform/src/Containers/Login/TestLoginResultsPage.js
@@ -49,16 +49,16 @@ function getMessage(response) {
     const content = (
         <>
             <p className="pb-2 mb-2 border-b border-success-700">
-                <span className="italic" id="user-id-label">
+                <span className="font-700" id="user-id-label">
                     User ID:
                 </span>{' '}
                 <span aria-labelledby="user-id-label">{response?.userID}</span>
             </p>
             <p className="pb-2 mb-2 border-b border-success-700">
-                <h2 className="italic">User Attributes:</h2>
+                <h2 className="font-700">User Attributes:</h2>
                 <ul className="list-none">{displayAttributes}</ul>
             </p>
-            <h2 className="italic">User Roles:</h2>
+            <h2 className="font-700">User Roles:</h2>
             <ul className="list-none">{displayRoles}</ul>
         </>
     );

--- a/ui/apps/platform/src/Containers/Network/SidePanel/NetworkDeploymentOverlay/DeploymentDetails/ContainerConfigurations.tsx
+++ b/ui/apps/platform/src/Containers/Network/SidePanel/NetworkDeploymentOverlay/DeploymentDetails/ContainerConfigurations.tsx
@@ -43,7 +43,7 @@ const ContainerImage = ({ image }): ReactElement | null => {
                 <div className="font-700 inline pr-1">Image Name:</div>
                 <div className="font-600">
                     {image.name.fullName}
-                    <span className="italic pl-1">({unavailableText})</span>{' '}
+                    <span className="pl-1">({unavailableText})</span>{' '}
                 </div>
             </div>
         );
@@ -64,7 +64,7 @@ const ContainerImage = ({ image }): ReactElement | null => {
 
 const Resources = ({ resources }): ReactElement => {
     if (!resources) {
-        return <span className="py-3 font-600 italic">None</span>;
+        return <span className="py-3 font-600">None</span>;
     }
     const resourceMap = {
         cpuCoresRequest: { label: 'CPU Request (cores)' },
@@ -80,7 +80,7 @@ type Volume = Record<string, string>;
 
 const ContainerVolumes = ({ volumes }: { volumes: Volume[] }): ReactElement => {
     if (!volumes?.length) {
-        return <span className="py-1 font-600 italic">None</span>;
+        return <span className="py-1 font-600">None</span>;
     }
     return (
         <>
@@ -175,7 +175,7 @@ const ContainerConfigurations = ({ deployment }): ReactElement => {
             );
         });
     } else {
-        containers = <span className="py-3 font-600 italic">None</span>;
+        containers = <span className="py-3 font-600">None</span>;
     }
     return <div className="flex-col h-full px-3">{containers}</div>;
 };

--- a/ui/apps/platform/src/Containers/Network/SidePanel/NetworkDeploymentOverlay/DeploymentDetails/SecurityContext.tsx
+++ b/ui/apps/platform/src/Containers/Network/SidePanel/NetworkDeploymentOverlay/DeploymentDetails/SecurityContext.tsx
@@ -45,9 +45,9 @@ const SecurityContext = ({ deployment }): ReactElement => {
             });
         containerResult = containers.length
             ? containers
-            : (containerResult = <span className="py-3 font-600 italic">None</span>);
+            : (containerResult = <span className="py-3 font-600">None</span>);
     } else {
-        containerResult = <span className="py-3 font-600 italic">None</span>;
+        containerResult = <span className="py-3 font-600">None</span>;
     }
     return <div className="flex h-full px-3">{containerResult}</div>;
 };

--- a/ui/apps/platform/src/Containers/Network/SidePanel/NetworkDeploymentOverlay/Flows/NetworkBaselines/NetworkBaselinesTable/GroupedStatusTableCell.tsx
+++ b/ui/apps/platform/src/Containers/Network/SidePanel/NetworkDeploymentOverlay/Flows/NetworkBaselines/NetworkBaselinesTable/GroupedStatusTableCell.tsx
@@ -23,7 +23,7 @@ function GroupedStatusTableCell({ row, colorStyles }: GroupedStatusTableCellProp
 
     const flowText = pluralize('Flow', leafRows.length);
     const text = `${leafRows.length} ${networkFlowStatusLabels[groupByVal]} ${flowText}`;
-    const className = `sticky z-1 top-8 text-left p-2 italic border-b border-t ${bgColor} ${borderColor} ${textColor}`;
+    const className = `sticky z-1 top-8 text-left p-2 border-b border-t ${bgColor} ${borderColor} ${textColor}`;
     const [expanderCell] = cells.filter(isExpanderCell);
     const colSpan = cells.length - (expanderCell ? 1 : 0);
 

--- a/ui/apps/platform/src/Containers/Risk/ContainerConfigurations.js
+++ b/ui/apps/platform/src/Containers/Risk/ContainerConfigurations.js
@@ -36,7 +36,7 @@ const ContainerImage = ({ image }) => {
                 <div className="pr-1 ">Image Name:</div>
                 <div className="font-500">
                     {image.name.fullName}
-                    <span className="italic pl-1">({unavailableText})</span>{' '}
+                    <span className="pl-1">({unavailableText})</span>{' '}
                 </div>
             </div>
         );
@@ -56,7 +56,7 @@ const ContainerImage = ({ image }) => {
 
 const Resources = ({ resources }) => {
     if (!resources) {
-        return <span className="py-3 font-600 italic">None</span>;
+        return <span className="py-3 font-600">None</span>;
     }
     const resourceMap = {
         cpuCoresRequest: { label: 'CPU Request (cores)' },
@@ -70,7 +70,7 @@ const Resources = ({ resources }) => {
 
 const ContainerVolumes = ({ volumes }) => {
     if (!volumes?.length) {
-        return <span className="py-1 font-600 italic">None</span>;
+        return <span className="py-1 font-600">None</span>;
     }
     return volumes.map((volume, idx) => (
         <li
@@ -92,7 +92,7 @@ const ContainerVolumes = ({ volumes }) => {
 
 const ContainerSecrets = ({ secrets }) => {
     if (!secrets?.length) {
-        return <span className="py-1 font-600 italic">None</span>;
+        return <span className="py-1 font-600">None</span>;
     }
     return secrets.map(({ name, path }) => (
         <div key={name} className="py-2">
@@ -145,7 +145,7 @@ const ContainerConfigurations = ({ deployment }) => {
             );
         });
     } else {
-        containers = <span className="py-1 font-600 italic">None</span>;
+        containers = <span className="py-1 font-600">None</span>;
     }
     return (
         <div className="px-3 pt-5">

--- a/ui/apps/platform/src/Containers/Risk/Process/BinaryCollapsible.js
+++ b/ui/apps/platform/src/Containers/Risk/Process/BinaryCollapsible.js
@@ -16,7 +16,7 @@ function BinaryCollapsible({ commandLineArgs, children }) {
             <div className={`${titleClassName} ${backgroundClass}`}>
                 <div className="flex items-center">
                     <div className="flex pl-2">{icon}</div>
-                    <div className="p-2 text-primary-800 flex flex-1 italic">
+                    <div className="p-2 text-primary-800 flex flex-1">
                         <span className="text-base font-600 word-break">{displayArgs}</span>
                     </div>
                 </div>

--- a/ui/apps/platform/src/Containers/Risk/Process/DiscoveryCardHeader.js
+++ b/ui/apps/platform/src/Containers/Risk/Process/DiscoveryCardHeader.js
@@ -46,7 +46,7 @@ function ProcessesDiscoveryCardHeader({
         >
             <div className={`p-3 ${textClass} flex flex-col`}>
                 <h1 className="text-lg font-700">{trimmedName}</h1>
-                <h2 className="text-sm font-600 italic">{`in container ${containerName} `}</h2>
+                <h2 className="text-sm font-600">{`in container ${containerName} `}</h2>
             </div>
             <div className="flex content-center">
                 {suspicious && (

--- a/ui/apps/platform/src/Containers/Risk/SecurityContext.js
+++ b/ui/apps/platform/src/Containers/Risk/SecurityContext.js
@@ -36,10 +36,10 @@ const SecurityContext = ({ deployment }) => {
                 );
             });
         if (!containers.length) {
-            containers = <span className="py-3 font-600 italic">None</span>;
+            containers = <span className="py-3 font-600">None</span>;
         }
     } else {
-        containers = <span className="py-3 font-600 italic">None</span>;
+        containers = <span className="py-3 font-600">None</span>;
     }
     return (
         <div className="px-3 pt-5">

--- a/ui/apps/platform/src/Containers/SystemHealth/Components/ClusterHealth.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/Components/ClusterHealth.tsx
@@ -83,9 +83,7 @@ const ClusterHealth = ({
             </div>
             {healthyCount !== 0 && (
                 <div className="leading-normal p-2 text-center">
-                    <span className="italic" data-testid="healthy-subtext">
-                        {healthySubtext}
-                    </span>
+                    <span data-testid="healthy-subtext">{healthySubtext}</span>
                 </div>
             )}
         </div>

--- a/ui/apps/platform/src/Containers/SystemHealth/Components/IntegrationsHealth.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/Components/IntegrationsHealth.tsx
@@ -44,10 +44,7 @@ const IntegrationsHealth = ({ integrationsMerged }: Props): ReactElement => {
                                     {name}
                                 </div>
                                 {label && label !== name && (
-                                    <div
-                                        className="italic text-base-500"
-                                        data-testid="integration-label"
-                                    >
+                                    <div className="text-base-500" data-testid="integration-label">
                                         {label}
                                     </div>
                                 )}

--- a/ui/apps/platform/src/constants/form.constants.ts
+++ b/ui/apps/platform/src/constants/form.constants.ts
@@ -1,6 +1,6 @@
 // styles for forms, until we standardize on UI components for forms
 export const labelClassName = 'block py-2 text-base-600 font-700';
-export const sublabelClassName = 'font-600 italic';
+export const sublabelClassName = 'font-600';
 
 export const wrapperMarginClassName = 'mb-4';
 


### PR DESCRIPTION
## Description

Follow up #5977

### Problem

1. PatternFly does not include an italic file for RedHatText font.

2. PatternFly typography guidelines do not even mention italic font style.

    https://www.patternfly.org/v4/guidelines/typography

3. PatternFly does not provide a utility class for italic font style.

    You must specify a `style` prop: `style={{ fontStyle: 'italic' }}`

4. Microsoft style guide recommends against italic formatting for **instructions in UI**. It is reasonable to infer that it recommends against italic formatting in **UI itself**.

    https://learn.microsoft.com/en-us/style-guide/procedures-instructions/formatting-text-in-instructions#in-the-ui-and-general-content

    > Instructions can also appear in the UI itself and in content other than documentation, such as blogs and marketing. In this content, avoid bold and italic formatting.

    > Choose one of the approaches below and use it consistently. The fourth and last option: Use bold formatting.

### Analysis and Solution

1. Find in Files **italic** 40 results in 24 files: delete!
2. Find in Files **<i** 1 result in 1 file: replace `i` element with `span` element

### Residue

1. Future follow up will touch some of the same elements: minimize explicit `font-600` Tailwind class because default PatternFly font weight is 400.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

I will update with pictures after rebase to get RedHatText font

### Dashboard

1. Visit /main/dashboard

    * Last updated at upper right

### Network Graph 1.0

1. Visit /main/network, select stackrox, and then click a node

    * Anomalous Flows and Baseline Flows in table

### Compliance

1. Visit /main/compliance and click a standard link

    * Count of controls at upper right

### Configuration Management

1. Visit /main/configmanagement

    * Dashboard at upper left
    * Secrets Most Used Across Deployments widget at lower right

2. Visit /main/configmanagement/policies and then click a table row

    * Policy at upper left

    * Rationale text in Remediation card at lower right

### Vulnerability Management

1. Visit /main/vulnerability-management

    * Auxiliary text in Recently Detected Image Vulnerabilities

### Clusters

1. Visit /main/clusters, click a table row, and scroll down in side panel

    * Sublabels have normal font style

### Access Control

1. Visit /main/access-control/permission-sets and click a permission set

    * Resource has bold font weight and Replaces has normal font style

### System Health

1. Visit /main/system-health

    * Text at lower edge of cards within Cluster Health area
