### PR TITLE
Add CODEOWNERS entries for Scanner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -30,3 +30,17 @@ pkg/postgres/**/*   @stackrox/data-shepherds
 tests/upgrade/*     @stackrox/data-shepherds
 
 operator/**/* @stackrox/draco
+
+# Scanner team's responsibilities include anything related to the scanner itself and scanning utilities
+# such as vulnerability uploading and image integrations.
+/central/scannerdefinitions/                          @stackrox/scanner
+/central/sensor/service/pipeline/imageintegrations/   @stackrox/scanner
+/pkg/images/enricher/                                 @stackrox/scanner
+/pkg/nodes/                                           @stackrox/scanner
+/pkg/registries/                                      @stackrox/scanner
+/pkg/scanners/                                        @stackrox/scanner
+/pkg/scans/                                           @stackrox/scanner
+/scanner/                                             @stackrox/scanner
+/sensor/common/scannerdefinitions/                    @stackrox/scanner
+/sensor/kubernetes/listener/resources/secrets.go      @stackrox/scanner
+/sensor/kubernetes/listener/resources/secrets_test.go @stackrox/scanner

--- a/.github/workflows/update_scanner_periodic.yaml
+++ b/.github/workflows/update_scanner_periodic.yaml
@@ -36,8 +36,7 @@ jobs:
         labels: |
           ci-all-qa-tests
           dependencies
-        team-reviewers: |
-          scanner-dep-updaters
+        team-reviewers: scanner
         draft: false
     - name: Enable Pull Request Automerge
       if: steps.cpr.outputs.pull-request-operation == 'created'


### PR DESCRIPTION
## Description

Scanner is migrating into this repo, so this PR adds a few CODEOWNERS entries for the team

## Checklist
- [x] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

Nah