### PR TITLE
ROX-15259: Do not show DNS flows in the inactive view

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphContainer.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphContainer.tsx
@@ -24,8 +24,8 @@ import {
     createExtraneousEdges,
     graphModel,
     getConnectedNodeIds,
-    removeDNSFlows,
 } from './utils/modelUtils';
+import { removeDNSEdges } from './utils/edgeUtils';
 import {
     cidrBlockBadgeColor,
     cidrBlockBadgeText,
@@ -319,7 +319,7 @@ function NetworkGraphContainer({
 
     // we want to filter out the DNS flows when viewing "inactive" flows (without DNS flows)
     if (edgeState === 'inactive') {
-        filteredEdges = removeDNSFlows(filteredEdges);
+        filteredEdges = removeDNSEdges(filteredEdges);
     }
 
     // if edgeState is extraneous && there is a selectedNode, add in/egress flows nodes/edges

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/EdgeStateSelect.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/EdgeStateSelect.tsx
@@ -3,7 +3,7 @@ import { Select, SelectOption } from '@patternfly/react-core';
 
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
 
-export type EdgeState = 'active' | 'inactive';
+export type EdgeState = 'active' | 'inactive' | 'inactive with dns';
 
 type EdgeStateSelectProps = {
     edgeState: EdgeState;
@@ -41,6 +41,7 @@ function EdgeStateSelect({ edgeState, setEdgeState, isDisabled }: EdgeStateSelec
             >
                 Inactive flows
             </SelectOption>
+            <SelectOption value="inactive with dns">Inactive flows with DNS flows</SelectOption>
         </Select>
     );
 }

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentFlows.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentFlows.tsx
@@ -102,6 +102,11 @@ function DeploymentFlows({
 
     const selectedRows = [...selectedAnomalousRows, ...selectedBaselineRows];
 
+    let flowType = edgeState;
+    if (flowType === 'inactive with dns') {
+        flowType = 'inactive';
+    }
+
     const onSelectFlow = (entityId: string) => {
         onNodeSelect(entityId);
     };
@@ -175,7 +180,7 @@ function DeploymentFlows({
                     <Toolbar className="pf-u-p-0">
                         <ToolbarContent className="pf-u-px-0">
                             <ToolbarItem>
-                                <FlowsTableHeaderText type={edgeState} numFlows={totalFlows} />
+                                <FlowsTableHeaderText type={flowType} numFlows={totalFlows} />
                             </ToolbarItem>
                             <ToolbarItem alignment={{ default: 'alignRight' }}>
                                 <FlowsBulkActions

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/edgeUtils.test.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/edgeUtils.test.ts
@@ -1,0 +1,202 @@
+import { EdgeTerminalType } from '@patternfly/react-topology';
+import { CustomEdgeModel } from '../types/topology.type';
+import { removeDNSEdges } from './edgeUtils';
+
+describe('edgeUtils', () => {
+    describe('removeDNSEdges', () => {
+        it('should not remove a one-directional non-dns edge', () => {
+            const edges: CustomEdgeModel[] = [
+                {
+                    id: 'edge-1',
+                    type: 'edge',
+                    source: 'node-1',
+                    target: 'node-2',
+                    data: {
+                        isBidirectional: false,
+                        portProtocolLabel: '80 TCP',
+                        tag: '80 TCP',
+                        sourceToTargetProperties: [
+                            {
+                                port: 80,
+                                protocol: 'L4_PROTOCOL_TCP',
+                                lastActiveTimestamp: '',
+                            },
+                        ],
+                        endTerminalType: 'directional' as EdgeTerminalType,
+                    },
+                },
+            ];
+            const edgesWithoutDNSFlows = removeDNSEdges(edges);
+            const result: CustomEdgeModel[] = [
+                {
+                    id: 'edge-1',
+                    type: 'edge',
+                    source: 'node-1',
+                    target: 'node-2',
+                    data: {
+                        isBidirectional: false,
+                        portProtocolLabel: '80 TCP',
+                        tag: '80 TCP',
+                        sourceToTargetProperties: [
+                            {
+                                port: 80,
+                                protocol: 'L4_PROTOCOL_TCP',
+                                lastActiveTimestamp: '',
+                            },
+                        ],
+                        targetToSourceProperties: [],
+                        startTerminalType: 'none' as EdgeTerminalType,
+                        endTerminalType: 'directional' as EdgeTerminalType,
+                    },
+                },
+            ];
+            expect(edgesWithoutDNSFlows).toEqual(result);
+        });
+
+        it('should remove a one-directional dns edge', () => {
+            const edges: CustomEdgeModel[] = [
+                {
+                    id: 'edge-1',
+                    type: 'edge',
+                    source: 'node-1',
+                    target: 'node-2',
+                    data: {
+                        isBidirectional: false,
+                        portProtocolLabel: '53 UDP',
+                        tag: '53 UDP',
+                        sourceToTargetProperties: [
+                            {
+                                port: 53,
+                                protocol: 'L4_PROTOCOL_UDP',
+                                lastActiveTimestamp: '',
+                            },
+                        ],
+                        endTerminalType: 'directional' as EdgeTerminalType,
+                    },
+                },
+            ];
+            const edgesWithoutDNSFlows = removeDNSEdges(edges);
+            expect(edgesWithoutDNSFlows).toEqual([]);
+        });
+
+        it('should not remove a non-dns edge from a bi-directional edge', () => {
+            const edges: CustomEdgeModel[] = [
+                {
+                    id: 'edge-1',
+                    type: 'edge',
+                    source: 'node-1',
+                    target: 'node-2',
+                    data: {
+                        isBidirectional: true,
+                        portProtocolLabel: '2',
+                        tag: '2',
+                        sourceToTargetProperties: [
+                            {
+                                port: 3000,
+                                protocol: 'L4_PROTOCOL_TCP',
+                                lastActiveTimestamp: '',
+                            },
+                        ],
+                        targetToSourceProperties: [
+                            {
+                                port: 8080,
+                                protocol: 'L4_PROTOCOL_TCP',
+                                lastActiveTimestamp: '',
+                            },
+                        ],
+                        endTerminalType: 'directional' as EdgeTerminalType,
+                        startTerminalType: 'directional' as EdgeTerminalType,
+                    },
+                },
+            ];
+            const edgesWithoutDNSFlows = removeDNSEdges(edges);
+            const result: CustomEdgeModel[] = [
+                {
+                    id: 'edge-1',
+                    type: 'edge',
+                    source: 'node-1',
+                    target: 'node-2',
+                    data: {
+                        isBidirectional: true,
+                        portProtocolLabel: '2',
+                        tag: '2',
+                        sourceToTargetProperties: [
+                            {
+                                port: 3000,
+                                protocol: 'L4_PROTOCOL_TCP',
+                                lastActiveTimestamp: '',
+                            },
+                        ],
+                        targetToSourceProperties: [
+                            {
+                                port: 8080,
+                                protocol: 'L4_PROTOCOL_TCP',
+                                lastActiveTimestamp: '',
+                            },
+                        ],
+                        endTerminalType: 'directional' as EdgeTerminalType,
+                        startTerminalType: 'directional' as EdgeTerminalType,
+                    },
+                },
+            ];
+            expect(edgesWithoutDNSFlows).toEqual(result);
+        });
+
+        it('should remove a dns edge from a bi-directional edge', () => {
+            const edges: CustomEdgeModel[] = [
+                {
+                    id: 'edge-1',
+                    type: 'edge',
+                    source: 'node-1',
+                    target: 'node-2',
+                    data: {
+                        isBidirectional: true,
+                        portProtocolLabel: '2',
+                        tag: '2',
+                        sourceToTargetProperties: [
+                            {
+                                port: 53,
+                                protocol: 'L4_PROTOCOL_UDP',
+                                lastActiveTimestamp: '',
+                            },
+                        ],
+                        targetToSourceProperties: [
+                            {
+                                port: 8080,
+                                protocol: 'L4_PROTOCOL_TCP',
+                                lastActiveTimestamp: '',
+                            },
+                        ],
+                        endTerminalType: 'directional' as EdgeTerminalType,
+                        startTerminalType: 'directional' as EdgeTerminalType,
+                    },
+                },
+            ];
+            const edgesWithoutDNSFlows = removeDNSEdges(edges);
+            const result: CustomEdgeModel[] = [
+                {
+                    id: 'edge-1',
+                    type: 'edge',
+                    source: 'node-1',
+                    target: 'node-2',
+                    data: {
+                        isBidirectional: false,
+                        portProtocolLabel: '8080 TCP',
+                        tag: '8080 TCP',
+                        sourceToTargetProperties: [],
+                        targetToSourceProperties: [
+                            {
+                                port: 8080,
+                                protocol: 'L4_PROTOCOL_TCP',
+                                lastActiveTimestamp: '',
+                            },
+                        ],
+                        endTerminalType: 'none' as EdgeTerminalType,
+                        startTerminalType: 'directional' as EdgeTerminalType,
+                    },
+                },
+            ];
+            expect(edgesWithoutDNSFlows).toEqual(result);
+        });
+    });
+});

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/edgeUtils.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/edgeUtils.ts
@@ -1,0 +1,68 @@
+import { EdgeProperties, L4Protocol } from 'types/networkFlow.proto';
+import { EdgeTerminalType } from '@patternfly/react-topology';
+import { CustomEdgeModel, EdgeData } from '../types/topology.type';
+import { protocolLabel } from './flowUtils';
+
+function getPortProtocolLabel(port: number, protocol: L4Protocol): string {
+    return `${port} ${protocolLabel[protocol]}`;
+}
+
+export function getPortProtocolEdgeLabel(properties: EdgeProperties[]): string {
+    const { port, protocol } = properties[0];
+    const singlePortLabel = getPortProtocolLabel(port, protocol);
+    return `${properties.length === 1 ? singlePortLabel : properties.length}`;
+}
+
+function filterDNSEdges(properties) {
+    return !(
+        (properties.port === 53 || properties.port === 5353) &&
+        properties.protocol === 'L4_PROTOCOL_UDP'
+    );
+}
+
+export function removeDNSEdges(edges: CustomEdgeModel[]): CustomEdgeModel[] {
+    const modifiedEdges: CustomEdgeModel[] = [];
+    edges.forEach((edge) => {
+        const filteredSourceToTargetProperties =
+            edge.data.sourceToTargetProperties.filter(filterDNSEdges);
+        const filteredTargetToSourceProperties =
+            edge.data?.targetToSourceProperties?.filter(filterDNSEdges) || [];
+        const combinedProperties = [
+            ...filteredSourceToTargetProperties,
+            ...filteredTargetToSourceProperties,
+        ];
+
+        if (combinedProperties.length !== 0) {
+            const portProtocolLabel = getPortProtocolEdgeLabel([
+                ...filteredSourceToTargetProperties,
+                ...filteredTargetToSourceProperties,
+            ]);
+            const modifiedData: EdgeData = {
+                sourceToTargetProperties: filteredSourceToTargetProperties,
+                targetToSourceProperties: filteredTargetToSourceProperties,
+                isBidirectional:
+                    filteredTargetToSourceProperties.length !== 0 &&
+                    filteredSourceToTargetProperties.length !== 0,
+                portProtocolLabel,
+                tag: portProtocolLabel,
+            };
+            if (filteredSourceToTargetProperties.length !== 0) {
+                modifiedData.endTerminalType = 'directional' as EdgeTerminalType;
+            } else {
+                modifiedData.endTerminalType = 'none' as EdgeTerminalType;
+            }
+            if (filteredTargetToSourceProperties.length !== 0) {
+                modifiedData.startTerminalType = 'directional' as EdgeTerminalType;
+            } else {
+                modifiedData.startTerminalType = 'none' as EdgeTerminalType;
+            }
+            const modifiedEdge = {
+                ...edge,
+                data: modifiedData,
+            };
+
+            modifiedEdges.push(modifiedEdge);
+        }
+    });
+    return modifiedEdges;
+}

--- a/ui/apps/platform/src/hooks/useFetchDeploymentCount.ts
+++ b/ui/apps/platform/src/hooks/useFetchDeploymentCount.ts
@@ -1,8 +1,9 @@
-import { useState, useEffect } from 'react';
 import { gql, useQuery, ApolloError } from '@apollo/client';
 
 type DeploymentCountResponse = {
-    count: number;
+    cluster: {
+        count: number;
+    };
 };
 
 type UseFetchDeploymentCount = {
@@ -12,14 +13,14 @@ type UseFetchDeploymentCount = {
 };
 
 const DEPLOYMENT_COUNT_FOR_CLUSTER = gql`
-    query deployments($query: String) {
-        count: deploymentCount(query: $query)
+    query getDeploymentCountForCluster($id: ID!) {
+        cluster(id: $id) {
+            count: deploymentCount
+        }
     }
 `;
 
 function useFetchDeploymentCount(selectedClusterId: string): UseFetchDeploymentCount {
-    const [deploymentCount, setDeploymentCount] = useState<number>();
-
     // If the selectedClusterId has not been set yet, do not run the gql query
     const queryOptions = selectedClusterId
         ? { variables: { id: selectedClusterId } }
@@ -30,18 +31,10 @@ function useFetchDeploymentCount(selectedClusterId: string): UseFetchDeploymentC
         queryOptions
     );
 
-    useEffect(() => {
-        if (!data || !data.count) {
-            return;
-        }
-
-        setDeploymentCount(data.count);
-    }, [data]);
-
     return {
         loading,
         error,
-        deploymentCount,
+        deploymentCount: data?.cluster?.count || undefined,
     };
 }
 

--- a/ui/apps/platform/src/hooks/useFetchDeploymentCount.ts
+++ b/ui/apps/platform/src/hooks/useFetchDeploymentCount.ts
@@ -1,9 +1,8 @@
+import { useState, useEffect } from 'react';
 import { gql, useQuery, ApolloError } from '@apollo/client';
 
 type DeploymentCountResponse = {
-    cluster: {
-        count: number;
-    };
+    count: number;
 };
 
 type UseFetchDeploymentCount = {
@@ -13,14 +12,14 @@ type UseFetchDeploymentCount = {
 };
 
 const DEPLOYMENT_COUNT_FOR_CLUSTER = gql`
-    query getDeploymentCountForCluster($id: ID!) {
-        cluster(id: $id) {
-            count: deploymentCount
-        }
+    query deployments($query: String) {
+        count: deploymentCount(query: $query)
     }
 `;
 
 function useFetchDeploymentCount(selectedClusterId: string): UseFetchDeploymentCount {
+    const [deploymentCount, setDeploymentCount] = useState<number>();
+
     // If the selectedClusterId has not been set yet, do not run the gql query
     const queryOptions = selectedClusterId
         ? { variables: { id: selectedClusterId } }
@@ -31,10 +30,18 @@ function useFetchDeploymentCount(selectedClusterId: string): UseFetchDeploymentC
         queryOptions
     );
 
+    useEffect(() => {
+        if (!data || !data.count) {
+            return;
+        }
+
+        setDeploymentCount(data.count);
+    }, [data]);
+
     return {
         loading,
         error,
-        deploymentCount: data?.cluster?.count || undefined,
+        deploymentCount,
     };
 }
 


### PR DESCRIPTION
## Description

This PR hides the DNS flows when we pick the "Inactive flows" option and we show it when we pick a new (third) option called "Inactive flows with DNS flows"

<img width="1552" alt="Screenshot 2023-05-11 at 12 01 58 PM" src="https://github.com/stackrox/stackrox/assets/4805485/86e70215-e581-4293-922e-0e3c48bb2e24">
