### PR TITLE
Fix issues with QA test images

### DIFF
--- a/qa-tests-backend/test-images/trigger-policy-violations/most/Dockerfile
+++ b/qa-tests-backend/test-images/trigger-policy-violations/most/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos
+FROM registry.access.redhat.com/ubi8/ubi:8.2
 
 WORKDIR /
 
@@ -20,6 +20,9 @@ EXPOSE 22/tcp
 
 # For: Wget in Image
 RUN yum -y install wget
+
+# For: Curl in Image
+RUN yum -y install curl
 
 # For: Insecure specified in CMD
 CMD ["/bin/bash", "-x", "trigger-violations-insecure.sh"]

--- a/qa-tests-backend/test-images/trigger-policy-violations/most/trigger-violations.sh
+++ b/qa-tests-backend/test-images/trigger-policy-violations/most/trigger-violations.sh
@@ -76,4 +76,7 @@ test_exec systemd
 echo "For: Ubuntu Package Manager Execution"
 test_exec apt
 
+echo "For: Wget Execution"
+test_exec wget
+
 sleep 36000


### PR DESCRIPTION
This PR intends to fix issues with test images used in qa-backend-tests.
Once merged, images need to be rebuilt for respective architectures & MA image manifest needs to be pushed to `quay.io/rhacs-eng/qa-multi-arch:<image-tag>`