### PR TITLE
Fix Deny All typo

### DIFF
--- a/pkg/defaults/accesscontrol/access_scope.go
+++ b/pkg/defaults/accesscontrol/access_scope.go
@@ -4,7 +4,7 @@ const (
 	// UnrestrictedAccessScope is the name of the default unrestricted access scope.
 	UnrestrictedAccessScope = "Unrestricted"
 	// DenyAllAccessScope is the name of the default deny all access scope.
-	DenyAllAccessScope = "Deny all"
+	DenyAllAccessScope = "Deny All"
 )
 
 // Postgres IDs for access scopes


### PR DESCRIPTION
## Description

During the refactoring of the default roles / access scopes / permission sets, there was a typo in the `Deny All` access scope: `Deny all`. This lead to failing UI E2E tests, this PR fixes the typo.
## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

- see CI passing (this time also with UI E2E tests)
