### PR TITLE
fix GHA: bump upgrade test cluster resources

### DIFF
--- a/.github/workflows/scripts/prepare-upgrade-test.sh
+++ b/.github/workflows/scripts/prepare-upgrade-test.sh
@@ -34,6 +34,7 @@ deploy_central() {
     ./roxctl-"${PREVIOUS_RELEASE}" central generate k8s pvc \
         --lb-type=lb \
         --main-image=quay.io/rhacs-eng/main:"${PREVIOUS_RELEASE}" \
+        --central-db-image=quay.io/rhacs-eng/central-db:"${PREVIOUS_RELEASE}" \
         --scanner-db-image=quay.io/rhacs-eng/scanner-db:"${PREVIOUS_SCANNER_VERSION}" \
         --scanner-image=quay.io/rhacs-eng/scanner:"${PREVIOUS_SCANNER_VERSION}" \
         --output-dir bundle-test1

--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -78,6 +78,7 @@ jobs:
           flavor: gke-default
           name: upgrade-${{ matrix.name }}-${{ inputs.milestone }}
           lifespan: 48h
+          args: nodes=5,machine-type=e2-standard-8
           wait: true
 
   prepare-clusters:


### PR DESCRIPTION
## Description

With central-db part of deployment, the GKE cluster provisioned for the upgrade tests is too small.
Making it bigger with this PR in line with the demo cluster from cut-rc workflow.

Successful run: https://github.com/stackrox/stackrox/actions/runs/4979408086. 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Successful workflow run: https://github.com/stackrox/stackrox/actions/runs/4979408086.
