### PR TITLE
ROX-16248: Add column for policy origin

### DIFF
--- a/ui/apps/platform/cypress/constants/PoliciesPage.js
+++ b/ui/apps/platform/cypress/constants/PoliciesPage.js
@@ -12,6 +12,7 @@ export const selectors = {
         reassessButton: 'button:contains("Reassess all")',
         policyLink: 'td[data-label="Policy"] a',
         statusCell: 'td[data-label="Status"]',
+        originCell: 'td[data-label="Origin"]',
         severityCell: 'td[data-label="Severity"]',
         lifecycleCell: 'td[data-label="Lifecycle"]',
         selectCheckbox: '.pf-c-table__check input[type="checkbox"]',

--- a/ui/apps/platform/cypress/integration/policies/exportPolicy.test.js
+++ b/ui/apps/platform/cypress/integration/policies/exportPolicy.test.js
@@ -15,7 +15,7 @@ describe('Export policy', () => {
         it('should export policy', () => {
             visitPolicies();
 
-            const trSelector = 'tbody tr:nth-child(1)';
+            const trSelector = 'tbody:nth-child(2) tr:nth-child(1)';
             cy.get(`${trSelector} ${selectors.table.policyLink}`).then(($a) => {
                 const segments = $a.attr('href').split('/');
                 const policyId = segments[segments.length - 1];
@@ -43,7 +43,7 @@ describe('Export policy', () => {
         it('should display toast alert for export request failure', () => {
             visitPolicies();
 
-            const trSelector = 'tbody tr:nth-child(1)';
+            const trSelector = 'tbody:nth-child(2) tr:nth-child(1)';
             const message = 'Some policies could not be retrieved.';
             cy.intercept('POST', api.policies.export, {
                 statusCode: 400,
@@ -62,7 +62,7 @@ describe('Export policy', () => {
         it('should display toast alert for export service failure', () => {
             visitPolicies();
 
-            const trSelector = 'tbody tr:nth-child(1)';
+            const trSelector = 'tbody:nth-child(2) tr:nth-child(1)';
             const message = 'Problem exporting policy data';
             cy.intercept('POST', api.policies.export, {
                 statusCode: 400,

--- a/ui/apps/platform/cypress/integration/policies/policiesTable.test.js
+++ b/ui/apps/platform/cypress/integration/policies/policiesTable.test.js
@@ -66,8 +66,8 @@ describe('Policies table', () => {
         visitPolicies();
 
         cy.get('th[scope="col"]:contains("Policy")');
-        cy.get('th[scope="col"]:contains("Description")');
         cy.get('th[scope="col"]:contains("Status")');
+        cy.get('th[scope="col"]:contains("Origin")');
         cy.get('th[scope="col"]:contains("Notifiers")');
         cy.get('th[scope="col"]:contains("Severity")');
         cy.get('th[scope="col"]:contains("Lifecycle")');
@@ -131,6 +131,15 @@ describe('Policies table', () => {
         // The following assertions assume that the table is not paginated.
         cy.get(`${selectors.table.statusCell}:contains("Disabled")`);
         cy.get(`${selectors.table.statusCell}:contains("Enabled")`);
+    });
+
+    it('should have expected origin values', () => {
+        visitPolicies();
+
+        // The following assertions assume that the table is not paginated.
+        cy.get(`${selectors.table.originCell}:contains("System")`);
+
+        // TODO: create a User policy and check for its presence in the table
     });
 
     it('should filter policies by disabled status', () => {

--- a/ui/apps/platform/src/Containers/Policies/Table/PoliciesTable.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Table/PoliciesTable.tsx
@@ -14,7 +14,6 @@ import {
     ToolbarGroup,
     ToolbarItem,
     Tooltip,
-    Truncate,
 } from '@patternfly/react-core';
 import { TableComposable, Thead, Tbody, Tr, Th, Td } from '@patternfly/react-table';
 import { CaretDownIcon } from '@patternfly/react-icons';
@@ -53,17 +52,16 @@ const columns = [
         Header: 'Policy',
         accessor: 'name',
         sortMethod: (a: ListPolicy, b: ListPolicy) => sortAsciiCaseInsensitive(a.name, b.name),
-        width: 20 as const,
-    },
-    {
-        Header: 'Description',
-        accessor: 'description',
-        width: 40 as const,
+        width: 30 as const,
     },
     {
         Header: 'Status',
         accessor: 'disabled',
-        width: 15 as const,
+    },
+    {
+        Header: 'Origin',
+        accessor: 'isDefault',
+        sortMethod: (a: ListPolicy, b: ListPolicy) => sortPolicyOrigin(a.isDefault, b.isDefault),
     },
     {
         Header: 'Notifiers',
@@ -80,6 +78,16 @@ const columns = [
         accessor: 'lifecycleStages',
     },
 ];
+
+const defaultPolicyLabel = 'System';
+const userPolicyLabel = 'User';
+
+function sortPolicyOrigin(a, b) {
+    const aOrigin = a ? defaultPolicyLabel : userPolicyLabel;
+    const bOrigin = b ? defaultPolicyLabel : userPolicyLabel;
+
+    return sortAsciiCaseInsensitive(aOrigin, bOrigin);
+}
 
 type PoliciesTableProps = {
     notifiers: NotifierIntegration[];
@@ -376,7 +384,6 @@ function PoliciesTable({
                     <Tbody>
                         {rows.map((policy) => {
                             const {
-                                description,
                                 disabled,
                                 id,
                                 isDefault,
@@ -446,14 +453,11 @@ function PoliciesTable({
                                             {name}
                                         </Button>
                                     </Td>
-                                    <Td dataLabel="Description">
-                                        <Truncate
-                                            content={description || '-'}
-                                            tooltipPosition="top"
-                                        />
-                                    </Td>
                                     <Td dataLabel="Status">
                                         <PolicyDisabledIconText isDisabled={disabled} />
+                                    </Td>
+                                    <Td dataLabel="Origin">
+                                        {isDefault ? defaultPolicyLabel : userPolicyLabel}
                                     </Td>
                                     <Td dataLabel="Notifiers">
                                         {notifierCountsWithLabelStrings.length === 0 ? (


### PR DESCRIPTION
## Description

UX recommendation for calling out default policies is to add a column, specifying System or User.

Changes are:
1. Add a column labeled "Origin" after the Status column, in which default policies are designated System, and any user-created policies are designated User. (Bonus: I made this column sortable.)
2. Remove the "Description" column
3. Make the table rows expandable, and now show the Description in the expanded row when a row is expanded. (Uses the same code pattern as is used in the new VM 2.0 CVEs table to reveal the CVE description.)

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added

## Testing Performed

Updated Cypress tests for the Policies table.

Also, manual testing

Policies table before changes:
<img width="1658" alt="policies_table_BEFORE" src="https://github.com/stackrox/stackrox/assets/715729/b79248d9-e059-46a3-a2f7-c3e00a596434">

After changes:
<img width="1658" alt="policies_table_AFTER" src="https://github.com/stackrox/stackrox/assets/715729/fce3fc9a-3f8a-4535-a370-6a4b9c1bbf33">

Origin column sorted ascending:
<img width="1658" alt="policies_sorted_by_Origin_asc_System_first" src="https://github.com/stackrox/stackrox/assets/715729/78c10cd2-b641-4db2-8907-2e80aced7e18">

Origin column sorted descending:
<img width="1658" alt="policies_sorted_by_Origin_desc_User_first" src="https://github.com/stackrox/stackrox/assets/715729/7539d4da-73de-42f3-b339-ab220eff7b4b">

With Description added in expanded row:
<img width="1552" alt="Screen Shot 2023-05-15 at 9 21 03 AM" src="https://github.com/stackrox/stackrox/assets/715729/b82977fc-f51d-4b50-9000-783abd9e22bc">
