### PR TITLE
Local-sensor: support connecting to Central instances

### DIFF
--- a/sensor/common/certdistribution/env.go
+++ b/sensor/common/certdistribution/env.go
@@ -1,0 +1,8 @@
+package certdistribution
+
+import "github.com/stackrox/rox/pkg/env"
+
+var (
+	// cacheDir is the directory in which certificates to be distributed are stored.
+	cacheDir = env.RegisterSetting("ROX_CERTIFICATE_CACHE_DIR", env.WithDefault("/var/cache/stackrox/.certificates"))
+)

--- a/sensor/common/certdistribution/persist.go
+++ b/sensor/common/certdistribution/persist.go
@@ -14,13 +14,13 @@ func PersistCertificates(certBundle map[string]string) error {
 	if len(certBundle) == 0 {
 		return nil // nothing to do
 	}
-	if err := os.MkdirAll(cacheDir, 0700); err != nil {
+	if err := os.MkdirAll(cacheDir.Setting(), 0700); err != nil {
 		return errors.Wrap(err, "could not ensure directory for certificate distribution exists")
 	}
 
 	var errs error
 	for certFile, certContents := range certBundle {
-		path := filepath.Join(cacheDir, certFile)
+		path := filepath.Join(cacheDir.Setting(), certFile)
 		if err := os.WriteFile(path, []byte(certContents), 0600); err != nil {
 			errs = multierror.Append(errs, errors.Wrapf(err, "failed to persist certificate file %s", certFile))
 		}

--- a/sensor/common/certdistribution/service_impl.go
+++ b/sensor/common/certdistribution/service_impl.go
@@ -29,9 +29,6 @@ import (
 )
 
 const (
-	// cacheDir is the directory in which certificates to be distributed are stored.
-	cacheDir = `/var/cache/stackrox/.certificates`
-
 	maxQueryRate rate.Limit = 1.0
 
 	maxBurstRequests = 10
@@ -116,8 +113,8 @@ func (s *service) verifyToken(ctx context.Context, token string, expectedSubject
 }
 
 func (s *service) loadCertsForService(serviceName string) (certPEM, keyPEM string, err error) {
-	certFileName := filepath.Join(cacheDir, serviceName+"-cert.pem")
-	keyFileName := filepath.Join(cacheDir, serviceName+"-key.pem")
+	certFileName := filepath.Join(cacheDir.Setting(), serviceName+"-cert.pem")
+	keyFileName := filepath.Join(cacheDir.Setting(), serviceName+"-key.pem")
 
 	if allExist, err := fileutils.AllExist(certFileName, keyFileName); err != nil {
 		return "", "", errors.New("failed to check for existence of certificates")

--- a/sensor/common/sensor/helmconfig/env.go
+++ b/sensor/common/sensor/helmconfig/env.go
@@ -6,4 +6,10 @@ var (
 	// HelmConfigFingerprint is the environment variable that indicates the fingerprint of the helm cluster
 	// config to be used.
 	HelmConfigFingerprint = env.RegisterSetting("ROX_HELM_CLUSTER_CONFIG_FP")
+
+	// HelmConfigFile allows to override the helm config.yaml secret file.
+	HelmConfigFile = env.RegisterSetting("ROX_HELM_CONFIG_FILE_OVERRIDE", env.WithDefault("/run/secrets/stackrox.io/helm-cluster-config/config.yaml"))
+
+	// HelmClusterNameFile allows to override helm effective cluster name file.
+	HelmClusterNameFile = env.RegisterSetting("ROX_HELM_CLUSTER_NAME_FILE_OVERRIDE", env.WithDefault("/run/secrets/stackrox.io/helm-effective-cluster-name/cluster-name"))
 )

--- a/sensor/common/sensor/helmconfig/load.go
+++ b/sensor/common/sensor/helmconfig/load.go
@@ -10,14 +10,9 @@ import (
 	"github.com/stackrox/rox/pkg/jsonutil"
 )
 
-const (
-	configFile      = "/run/secrets/stackrox.io/helm-cluster-config/config.yaml"
-	clusterNameFile = "/run/secrets/stackrox.io/helm-effective-cluster-name/cluster-name"
-)
-
 // Load loads the cluster configuration for Helm-managed cluster from its canonical location.
 func Load() (*central.HelmManagedConfigInit, error) {
-	contents, err := os.ReadFile(configFile)
+	contents, err := os.ReadFile(HelmConfigFile.Setting())
 	if err != nil {
 		return nil, errors.Wrap(err, "loading cluster config file")
 	}
@@ -40,7 +35,7 @@ func load(data []byte) (*central.HelmManagedConfigInit, error) {
 
 // getEffectiveClusterName returns the cluster name which is currently used within central.
 func getEffectiveClusterName() (string, error) {
-	name, err := os.ReadFile(clusterNameFile)
+	name, err := os.ReadFile(HelmClusterNameFile.Setting())
 	if err != nil {
 		return "", err
 	}

--- a/tools/local-sensor/main.go
+++ b/tools/local-sensor/main.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/binary"
 	"encoding/json"
-	"errors"
 	"flag"
 	"fmt"
 	"log"
@@ -19,10 +18,14 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/clientconn"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/metrics"
 	"github.com/stackrox/rox/pkg/utils"
+	"github.com/stackrox/rox/sensor/common/centralclient"
 	centralDebug "github.com/stackrox/rox/sensor/debugger/central"
 	"github.com/stackrox/rox/sensor/debugger/k8s"
 	"github.com/stackrox/rox/sensor/debugger/message"
@@ -87,6 +90,7 @@ type localSensorConfig struct {
 	NoCPUProfile       bool
 	NoMemProfile       bool
 	PprofServer        bool
+	CentralEndpoint    string
 }
 
 const (
@@ -155,6 +159,7 @@ func mustGetCommandLineArgs() localSensorConfig {
 		NoCPUProfile:       false,
 		NoMemProfile:       false,
 		PprofServer:        false,
+		CentralEndpoint:    "",
 	}
 	flag.BoolVar(&sensorConfig.NoCPUProfile, "no-cpu-prof", sensorConfig.NoCPUProfile, "disables producing CPU profile for performance analysis")
 	flag.BoolVar(&sensorConfig.NoMemProfile, "no-mem-prof", sensorConfig.NoMemProfile, "disables producing memory profile for performance analysis")
@@ -173,6 +178,7 @@ func mustGetCommandLineArgs() localSensorConfig {
 	flag.StringVar(&sensorConfig.FakeWorkloadFile, "with-fakeworkload", sensorConfig.FakeWorkloadFile, " a file containing a FakeWorkload definition")
 	flag.BoolVar(&sensorConfig.WithMetrics, "with-metrics", sensorConfig.WithMetrics, "enables the metric server")
 	flag.BoolVar(&sensorConfig.PprofServer, "with-pprof-server", sensorConfig.PprofServer, "enables the pprof server on port :6060")
+	flag.StringVar(&sensorConfig.CentralEndpoint, "connect-central", sensorConfig.CentralEndpoint, "connects to a Central instance rather than a fake Central")
 	flag.Parse()
 
 	sensorConfig.CentralOutput = path.Clean(sensorConfig.CentralOutput)
@@ -224,8 +230,10 @@ func registerHostKillSignals(startTime time.Time, fakeCentral *centralDebug.Fake
 		writeMemoryProfile()
 	}
 	pprof.StopCPUProfile()
-	allMessages := fakeCentral.GetAllMessages()
-	dumpMessages(allMessages, startTime, endTime, outfile, outputFormat)
+	if fakeCentral != nil {
+		allMessages := fakeCentral.GetAllMessages()
+		dumpMessages(allMessages, startTime, endTime, outfile, outputFormat)
+	}
 	os.Exit(0)
 }
 
@@ -278,41 +286,24 @@ func main() {
 	}
 
 	startTime := time.Now()
-	utils.CrashOnError(os.Setenv("ROX_MTLS_CERT_FILE", "tools/local-sensor/certs/cert.pem"))
-	utils.CrashOnError(os.Setenv("ROX_MTLS_KEY_FILE", "tools/local-sensor/certs/key.pem"))
-	utils.CrashOnError(os.Setenv("ROX_MTLS_CA_FILE", "tools/local-sensor/certs/caCert.pem"))
-	utils.CrashOnError(os.Setenv("ROX_MTLS_CA_KEY_FILE", "tools/local-sensor/certs/caKey.pem"))
 
-	var policies []*storage.Policy
-	if localConfig.PoliciesFile != "" {
-		policies, err = testutils.GetPoliciesFromFile(localConfig.PoliciesFile)
-		if err != nil {
-			log.Fatalln(err)
-		}
-	}
+	isFakeCentral := localConfig.CentralEndpoint == ""
 
-	fakeCentral := centralDebug.MakeFakeCentralWithInitialMessages(
-		message.SensorHello("00000000-0000-4000-A000-000000000000"),
-		message.ClusterConfig(),
-		message.PolicySync(policies),
-		message.BaselineSync([]*storage.ProcessBaseline{}))
-
-	if localConfig.Verbose {
-		fakeCentral.OnMessage(func(msg *central.MsgFromSensor) {
-			log.Printf("MESSAGE RECEIVED: %s\n", msg.String())
-		})
+	var connection centralclient.CentralConnectionFactory
+	var spyCentral *centralDebug.FakeService
+	if isFakeCentral {
+		connection, spyCentral = setupCentralWithFakeConnection(localConfig)
+		defer spyCentral.Stop()
+	} else {
+		connection = setupCentralWithRealConnection(localConfig)
 	}
 
 	ctx, cancelFunc := context.WithCancel(context.Background())
-	go registerHostKillSignals(startTime, fakeCentral, !localConfig.NoMemProfile, localConfig.CentralOutput, localConfig.OutputFormat, cancelFunc)
-
-	conn, spyCentral, shutdownFakeServer := createConnectionAndStartServer(fakeCentral)
-	defer shutdownFakeServer()
-	fakeConnectionFactory := centralDebug.MakeFakeConnectionFactory(conn)
+	go registerHostKillSignals(startTime, spyCentral, !localConfig.NoMemProfile, localConfig.CentralOutput, localConfig.OutputFormat, cancelFunc)
 
 	sensorConfig := sensor.ConfigWithDefaults().
 		WithK8sClient(fakeClient).
-		WithCentralConnectionFactory(fakeConnectionFactory).
+		WithCentralConnectionFactory(connection).
 		WithLocalSensor(true).
 		WithResyncPeriod(localConfig.ResyncPeriod).
 		WithWorkloadManager(workloadManager)
@@ -372,15 +363,83 @@ func main() {
 	go s.Start()
 	defer s.Stop()
 
-	spyCentral.ConnectionStarted.Wait()
+	if spyCentral != nil {
+		spyCentral.ConnectionStarted.Wait()
+	}
 
 	log.Printf("Running scenario for %f minutes\n", localConfig.Duration.Minutes())
-	<-time.Tick(localConfig.Duration)
-	endTime := time.Now()
-	allMessages := fakeCentral.GetAllMessages()
-	dumpMessages(allMessages, startTime, endTime, localConfig.CentralOutput, localConfig.OutputFormat)
+	select {
+	case <-time.Tick(localConfig.Duration):
+		break
+	case <-s.Stopped().Done():
+		break
+	}
 
-	spyCentral.KillSwitch.Signal()
+	endTime := time.Now()
+
+	if spyCentral != nil {
+		allMessages := spyCentral.GetAllMessages()
+		dumpMessages(allMessages, startTime, endTime, localConfig.CentralOutput, localConfig.OutputFormat)
+
+		spyCentral.KillSwitch.Signal()
+	}
+}
+
+func setupCentralWithRealConnection(localConfig localSensorConfig) centralclient.CentralConnectionFactory {
+	// These files depend on running `tools/local-sensor/scripts/fetch-certs.sh`.
+	utils.CrashOnError(os.Setenv("ROX_MTLS_CERT_FILE", "tmp/sensor-cert.pem"))
+	utils.CrashOnError(os.Setenv("ROX_MTLS_KEY_FILE", "tmp/sensor-key.pem"))
+	utils.CrashOnError(os.Setenv("ROX_MTLS_CA_FILE", "tmp/ca.pem"))
+
+	utils.CrashOnError(os.Setenv("ROX_HELM_CONFIG_FILE_OVERRIDE", "tmp/helm-config.yaml"))
+	utils.CrashOnError(os.Setenv("ROX_HELM_CLUSTER_NAME_FILE_OVERRIDE", "tmp/helm-name.yaml"))
+
+	utils.CrashOnError(os.Setenv("ROX_CERTIFICATE_CACHE_DIR", "tmp/.local-sensor-cache"))
+
+	utils.CrashOnError(os.Setenv("ROX_CENTRAL_ENDPOINT", localConfig.CentralEndpoint))
+
+	clientconn.SetUserAgent(clientconn.Sensor)
+	centralConnFactory, err := centralclient.NewCentralConnectionFactory(env.CentralEndpoint.Setting())
+	if err != nil {
+		utils.CrashOnError(errors.Wrapf(err, "sensor failed to start while initializing gRPC client to endpoint %s", env.CentralEndpoint.Setting()))
+	}
+
+	return centralConnFactory
+}
+
+func setupCentralWithFakeConnection(localConfig localSensorConfig) (centralclient.CentralConnectionFactory, *centralDebug.FakeService) {
+	utils.CrashOnError(os.Setenv("ROX_MTLS_CERT_FILE", "tools/local-sensor/certs/cert.pem"))
+	utils.CrashOnError(os.Setenv("ROX_MTLS_KEY_FILE", "tools/local-sensor/certs/key.pem"))
+	utils.CrashOnError(os.Setenv("ROX_MTLS_CA_FILE", "tools/local-sensor/certs/caCert.pem"))
+	utils.CrashOnError(os.Setenv("ROX_MTLS_CA_KEY_FILE", "tools/local-sensor/certs/caKey.pem"))
+
+	var policies []*storage.Policy
+	var err error
+	if localConfig.PoliciesFile != "" {
+		policies, err = testutils.GetPoliciesFromFile(localConfig.PoliciesFile)
+		if err != nil {
+			log.Fatalln(err)
+		}
+	}
+
+	fakeCentral := centralDebug.MakeFakeCentralWithInitialMessages(
+		message.SensorHello("00000000-0000-4000-A000-000000000000"),
+		message.ClusterConfig(),
+		message.PolicySync(policies),
+		message.BaselineSync([]*storage.ProcessBaseline{}))
+
+	if localConfig.Verbose {
+		fakeCentral.OnMessage(func(msg *central.MsgFromSensor) {
+			log.Printf("MESSAGE RECEIVED: %s\n", msg.String())
+		})
+	}
+
+	// TODO: use shutdown callback
+	conn, spyCentral, shutdownFakeServer := createConnectionAndStartServer(fakeCentral)
+	fakeCentral.OnShutdown(shutdownFakeServer)
+	fakeConnectionFactory := centralDebug.MakeFakeConnectionFactory(conn)
+
+	return fakeConnectionFactory, spyCentral
 }
 
 type sensorMessageJSONOutput struct {

--- a/tools/local-sensor/scripts/README.md
+++ b/tools/local-sensor/scripts/README.md
@@ -1,5 +1,43 @@
 # Local-sensor
 
+Local Sensor is a binary entrypoint for Sensor to run it outside of a Kubernetes cluster. This can be helpful for development and debugging. Local sensor can be run in two modes:
+
+- **Fake Central**: No Central installation needed. Messages can be output to terminal or a file.
+- **Connected**: Connects to a real Central installation.
+
+## Build local-sensor
+
+```bash
+go build -o local-sensor ./tools/local-sensor/
+```
+
+## Running local-sensor
+
+To run local-sensor using **Fake Central** and writing Sensor Events to `local_sensor_output.json` file:
+
+```bash
+./local-sensor -central-out ./local_sensor_output.json
+```
+
+To run local-sensor against a real cluster, make sure you first have a cluster with ACS installed.
+
+**(!)**: This method only works for secured clusters installed using Helm Charts.
+
+```bash
+# Scale down sensor running on the cluster
+kubectl -n stackrox scale deployment sensor --replicas 0
+
+# Fetch authentication certificates (this will store all files in ./tmp folder)
+./tools/local-sensor/scripts/fetch-certs.sh
+
+# Export helm fingerprint before running sensor (the value will be displayed in stdout after running the command above)
+export ROX_HELM_CLUSTER_CONFIG_FP="<Helm fingerprint>"
+
+# Make sure you have central's port forward to localhost (e.g. at port 8000)
+# Run local-sensor using connected mode
+./local-sensor -connect-central "localhost:8000"
+```
+
 ## How to reproduce the performance tests
 
 ### Using the `local-sensor.sh` script

--- a/tools/local-sensor/scripts/fetch-certs.sh
+++ b/tools/local-sensor/scripts/fetch-certs.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# Use tmp directory to install all certs
+mkdir -p ./tmp
+
+for cert in "ca.pem" "sensor-cert.pem" "sensor-key.pem"; do
+    echo "Fetching $cert"
+    cert_data=$(kubectl -n stackrox get secret sensor-tls -o=jsonpath='{$.data}' | jq -r ".[\"$cert\"]" | base64 -d)
+    echo "$cert_data" > "./tmp/$cert"
+done
+
+echo "Fetching helm config"
+config_data=$(kubectl -n stackrox get secret helm-cluster-config -o=jsonpath='{$.data}' | jq -r '.["config.yaml"]' | base64 -d)
+echo "$config_data" > "./tmp/helm-config.yaml"
+
+echo "Fetching helm name"
+cluster_name=$(kubectl -n stackrox get secret helm-effective-cluster-name -o json | jq -r '.data["cluster-name"]' | base64 -d)
+echo "$cluster_name" > "./tmp/helm-name.yaml"
+
+fingerprint=$(echo "$config_data" | grep "configFingerprint" | xargs | awk '{print $2}')
+echo "Helm Fingerprint: $fingerprint"
+echo "Run the following command in your shell to export helm fingerprint:"
+echo "export ROX_HELM_CLUSTER_CONFIG_FP=$fingerprint"
+


### PR DESCRIPTION
## Description

Allow to run `local-sensor` pointing to a real ACS Central.

This significantly improves debugability of Sensor. With this, you can debug a Sensor connected to a real Central installation on GoLand. This also helps with testing for disconnects, since Fake Central did not require any TLS authentication steps, this feature will allow us to better test how Sensor behaves when re-attempting a connection. 

This will only work with Helm installations at the moment. Clusters installed with `deploy.sh` scripts will use helm for secured-clusters by default. 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

- Ran `local-sensor` against Central installed in infra. Entry added to README.md.