### PR TITLE
CI: Increase overall QA e2e test timeout

### DIFF
--- a/qa-tests-backend/build.gradle
+++ b/qa-tests-backend/build.gradle
@@ -132,7 +132,7 @@ tasks.withType(Test) {
         exceptionFormat "full"
         events "passed", "skipped", "failed"
     }
-    timeout = Duration.ofHours(3.5)
+    timeout = Duration.ofHours(3).ofMinutes(30)
 
     // This ensures that repeated invocations of tests actually run the tests.
     // Otherwise, if the tests pass, Gradle "caches" the result and doesn't actually run the tests,

--- a/qa-tests-backend/build.gradle
+++ b/qa-tests-backend/build.gradle
@@ -132,7 +132,7 @@ tasks.withType(Test) {
         exceptionFormat "full"
         events "passed", "skipped", "failed"
     }
-    timeout = Duration.ofHours(3).ofMinutes(30)
+    timeout = Duration.ofMinutes(210)
 
     // This ensures that repeated invocations of tests actually run the tests.
     // Otherwise, if the tests pass, Gradle "caches" the result and doesn't actually run the tests,

--- a/qa-tests-backend/build.gradle
+++ b/qa-tests-backend/build.gradle
@@ -132,7 +132,7 @@ tasks.withType(Test) {
         exceptionFormat "full"
         events "passed", "skipped", "failed"
     }
-    timeout = Duration.ofHours(3)
+    timeout = Duration.ofHours(3.5)
 
     // This ensures that repeated invocations of tests actually run the tests.
     // Otherwise, if the tests pass, Gradle "caches" the result and doesn't actually run the tests,


### PR DESCRIPTION
## Description

A number of recent merge test failures are because tests are taking > 3 hours. This PR bumps the overall test timeout to 3.5 hours. 

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient.