### PR TITLE
Script for port-forwarding to Prometheus metrics endpoint

### DIFF
--- a/scripts/k8s/prometheus-local-port-forward.sh
+++ b/scripts/k8s/prometheus-local-port-forward.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -e
+
+LOCAL_PORT=${LOCAL_PORT:-9090}
+NAMESPACE="${NAMESPACE:-stackrox}"
+
+CENTRAL_POD=""
+echo -n "Waiting for a running Central pod"
+until [ -n "${CENTRAL_POD}" ]; do
+  echo -n '.'
+  sleep 2
+  CENTRAL_POD="$(kubectl get pod -n $NAMESPACE --selector 'app=central' | grep Running | awk '{print $1}')"
+done
+echo "found Central pod: ${CENTRAL_POD}"
+
+echo -n "Setting up Prometheus port-forwarding..."
+
+pkill -f "kubectl port-forward -n ${NAMESPACE} ${CENTRAL_POD} ${LOCAL_PORT}:9090" || true
+
+# kubectl should be killed whenever this script is killed
+trap 'kill -TERM ${PID}; wait ${PID}' TERM INT
+kubectl port-forward -n "$NAMESPACE" "$CENTRAL_POD" "${LOCAL_PORT}:9090" > /dev/null &
+PID=$!
+
+until $(curl --output /dev/null --silent --fail -k "http://localhost:${LOCAL_PORT}/metrics"); do
+    echo -n '.'
+    sleep 1
+done
+echo "done"
+
+echo "StackRox Central metrics are available on http://localhost:${LOCAL_PORT}/metrics"
+
+wait ${PID}

--- a/scripts/k8s/prometheus-local-port-forward.sh
+++ b/scripts/k8s/prometheus-local-port-forward.sh
@@ -15,8 +15,6 @@ echo "found Central pod: ${CENTRAL_POD}"
 
 echo -n "Setting up Prometheus port-forwarding..."
 
-pkill -f "kubectl port-forward -n ${NAMESPACE} ${CENTRAL_POD} ${LOCAL_PORT}:9090" || true
-
 # kubectl should be killed whenever this script is killed
 trap 'kill -TERM ${PID}; wait ${PID}' TERM INT
 kubectl port-forward -n "$NAMESPACE" "$CENTRAL_POD" "${LOCAL_PORT}:9090" > /dev/null &

--- a/scripts/k8s/prometheus-local-port-forward.sh
+++ b/scripts/k8s/prometheus-local-port-forward.sh
@@ -9,7 +9,7 @@ echo -n "Waiting for a running Central pod"
 until [ -n "${CENTRAL_POD}" ]; do
   echo -n '.'
   sleep 2
-  CENTRAL_POD="$(kubectl get pod -n $NAMESPACE --selector 'app=central' | grep Running | awk '{print $1}')"
+  CENTRAL_POD="$(kubectl get pod -n "$NAMESPACE" --selector 'app=central' | grep Running | awk '{print $1}')"
 done
 echo "found Central pod: ${CENTRAL_POD}"
 
@@ -20,7 +20,7 @@ trap 'kill -TERM ${PID}; wait ${PID}' TERM INT
 kubectl port-forward -n "$NAMESPACE" "$CENTRAL_POD" "${LOCAL_PORT}:9090" > /dev/null &
 PID=$!
 
-until $(curl --output /dev/null --silent --fail -k "http://localhost:${LOCAL_PORT}/metrics"); do
+until curl --output /dev/null --silent --fail -k "http://localhost:${LOCAL_PORT}/metrics"; do
     echo -n '.'
     sleep 1
 done


### PR DESCRIPTION
## Description

This utility script can be used if a developer needs access to their `/metrics` endpoint.

This script mainly follows the same approach as `local-port-forward.sh` with a few tweaks:
* https://github.com/stackrox/stackrox/blob/0a0be38de8110e06347f4df43ff5af67c82d9d64/scripts/k8s/local-port-forward.sh#L7-L7 line is removed as killing parallel port-forwards can delete port-forward to ACS API port
* Verification that the port is ready is done using `/metrics` endpoint
* Default ports are adjusted to `9090`
* Displayed link is adjusted to `http://localhost:${LOCAL_PORT}/metrics`

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

1. Executed the script
