### PR TITLE
ROX-16999: Do not run junit2jira on cancelled jobs

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -60,7 +60,7 @@ jobs:
         paths: 'junit-reports/report.xml'
 
     - name: Report test failures to Jira
-      if: always() && github.event_name == 'push'
+      if: (!cancelled()) && github.event_name == 'push'
       uses: ./.github/actions/junit2jira
       with:
         jira-token: ${{ secrets.JIRA_TOKEN }}
@@ -109,7 +109,7 @@ jobs:
         paths: 'junit-reports/report.xml'
 
     - name: Report junit failures in jira
-      if: always() && github.event_name == 'push'
+      if: (!cancelled()) && github.event_name == 'push'
       uses: ./.github/actions/junit2jira
       with:
         jira-token: ${{ secrets.JIRA_TOKEN }}
@@ -144,7 +144,7 @@ jobs:
         paths: 'ui/test-results/reports/*.xml'
 
     - name: Report junit failures in jira
-      if: always() && github.event_name == 'push'
+      if: (!cancelled()) && github.event_name == 'push'
       uses: ./.github/actions/junit2jira
       with:
         jira-token: ${{ secrets.JIRA_TOKEN }}
@@ -181,7 +181,7 @@ jobs:
         paths: 'roxctl-test-output/*.xml'
 
     - name: Report junit failures in jira
-      if: always() && github.event_name == 'push'
+      if: (!cancelled()) && github.event_name == 'push'
       uses: ./.github/actions/junit2jira
       with:
         jira-token: ${{ secrets.JIRA_TOKEN }}


### PR DESCRIPTION
## Description

go-junit-reporter mark cancelled tests as failed leading to incorrect tasks in jira. This PR skips issues reporting if workflow was cancelled. 
- https://github.com/orgs/community/discussions/26303#discussioncomment-3251302

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed


