### PR TITLE
Dashrews/ROX-17134 gke upgrade test collector previous

### DIFF
--- a/scripts/ci/logcheck/restart-ok-patterns.json
+++ b/scripts/ci/logcheck/restart-ok-patterns.json
@@ -34,5 +34,11 @@
         "job": "upgrade",
         "logfile": "collector-previous",
         "logline": "Unable to connect to Sensor at"
+    },
+    {
+        "comment": "collector downloads throttled due to bouncing in upgrade test",
+        "job": "upgrade",
+        "logfile": "collector-previous",
+        "logline": "Failed to initialize collector kernel components"
     }
 ]


### PR DESCRIPTION
## Description

Due to the bouncing in the upgrade test, collector can get into a situation where the downloads on the new pods are throttled.  As such we may have a previous collector that was not able to initialize kernel components.  If this error appears in a previous and the subsequent collector starts up, then we are functioning as we want.

I was fortunate enough to hit this condition on the first try to see that this update resolved the issue.
https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/stackrox_stackrox/6051/pull-ci-stackrox-stackrox-master-gke-postgres-upgrade-tests/1658546797745803264

## Checklist
- [x] Investigated and inspected CI test results
~- [ ] Unit test and regression tests added~
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

This is a test.  
