### PR TITLE
Delete occurrences of Tailwind tracking and class part 1 for uppercase

### DIFF
--- a/ui/apps/platform/cypress/helpers/vulnmanagement/entities.js
+++ b/ui/apps/platform/cypress/helpers/vulnmanagement/entities.js
@@ -79,21 +79,21 @@ const opnameForEntities = {
     policies: 'getPolicies',
 };
 
-// Headings on entities pages: uppercase style hides the inconsistencies.
+// Headings on entities pages has sentence case for entity type.
 const headingPlural = {
-    clusters: 'clusters',
-    components: 'components',
-    'image-components': 'image components',
-    'node-components': 'node components',
+    clusters: 'Clusters',
+    components: 'Components',
+    'image-components': 'Image components',
+    'node-components': 'Node components',
     cves: 'CVES',
-    'image-cves': 'Image CVES',
-    'node-cves': 'Node CVES',
-    'cluster-cves': 'Platform CVES',
-    deployments: 'deployments',
-    images: 'images',
-    namespaces: 'namespaces',
-    nodes: 'nodes',
-    policies: 'policies',
+    'image-cves': 'Image cves', // TODO cves is inconsistent
+    'node-cves': 'Node cves', // TODO cves is inconsistent
+    'cluster-cves': 'Platform cves', // TODO cves is inconsistent
+    deployments: 'Deployments',
+    images: 'Images',
+    namespaces: 'Namespaces',
+    nodes: 'Nodes',
+    policies: 'Policies',
 };
 
 const typeOfEntity = {

--- a/ui/apps/platform/cypress/helpers/vulnmanagement/entities.js
+++ b/ui/apps/platform/cypress/helpers/vulnmanagement/entities.js
@@ -86,9 +86,9 @@ const headingPlural = {
     'image-components': 'Image components',
     'node-components': 'Node components',
     cves: 'CVES',
-    'image-cves': 'Image cves', // TODO cves is inconsistent
-    'node-cves': 'Node cves', // TODO cves is inconsistent
-    'cluster-cves': 'Platform cves', // TODO cves is inconsistent
+    'image-cves': 'Image CVES', // TODO uppercase S from pluralize
+    'node-cves': 'Node CVES', // TODO uppercase S from pluralize
+    'cluster-cves': 'Platform CVES', // TODO uppercase S from pluralize
     deployments: 'Deployments',
     images: 'Images',
     namespaces: 'Namespaces',

--- a/ui/apps/platform/cypress/integration/compliance/Compliance.helpers.js
+++ b/ui/apps/platform/cypress/integration/compliance/Compliance.helpers.js
@@ -66,11 +66,11 @@ export const headingPlural = {
     nodes: 'Nodes',
 };
 
-export const headingSingularLower = {
-    clusters: 'cluster',
-    deployments: 'deployment',
-    namespaces: 'namespace',
-    nodes: 'node',
+export const headingSingular = {
+    clusters: 'Cluster',
+    deployments: 'Deployment',
+    namespaces: 'Namespace',
+    nodes: 'Node',
 };
 
 // assert
@@ -78,7 +78,7 @@ export const headingSingularLower = {
 // assert instead of interact because query might be cached.
 export function assertComplianceEntityPage(entitiesKey) {
     cy.location('pathname').should('contain', getEntityPagePath(entitiesKey)); // contain because pathname has id
-    cy.get(`h1 + div:contains("${headingSingularLower[entitiesKey]}")`);
+    cy.get(`h1 + div:contains("${headingSingular[entitiesKey]}")`);
 }
 
 // visit

--- a/ui/apps/platform/cypress/integration/compliance/complianceDashboard.test.js
+++ b/ui/apps/platform/cypress/integration/compliance/complianceDashboard.test.js
@@ -61,7 +61,7 @@ describe('Compliance Dashboard', () => {
             cy.get(selectors.widget.passingStandardsAcrossClusters.axisLinks).first().click();
         });
         cy.location('search').should('contain', '?s[groupBy]=CLUSTER'); // followed by a standard
-        cy.get('[data-testid="panel-header"]').contains('CLUSTER');
+        cy.get('[data-testid="panel-header"]').contains('cluster');
         cy.get(selectors.list.table.firstGroup).should('be.visible');
     });
 
@@ -72,7 +72,7 @@ describe('Compliance Dashboard', () => {
             cy.get(selectors.widget.passingStandardsAcrossNamespaces.axisLinks).first().click();
         });
         cy.location('search').should('contain', '?s[groupBy]=NAMESPACE'); // followed by a standard
-        cy.get('[data-testid="panel-header"]').contains('NAMESPACE');
+        cy.get('[data-testid="panel-header"]').contains('namespace');
         cy.get(selectors.list.table.firstGroup).should('be.visible');
     });
 
@@ -83,7 +83,7 @@ describe('Compliance Dashboard', () => {
             cy.get(selectors.widget.passingStandardsAcrossNodes.axisLinks).first().click();
         });
         cy.location('search').should('contain', '?s[groupBy]=NODE'); // followed by a standard
-        cy.get('[data-testid="panel-header"]').contains('NODE');
+        cy.get('[data-testid="panel-header"]').contains('node');
         cy.get(selectors.list.table.firstGroup).should('be.visible');
     });
 

--- a/ui/apps/platform/cypress/integration/compliance/complianceList.test.js
+++ b/ui/apps/platform/cypress/integration/compliance/complianceList.test.js
@@ -28,7 +28,7 @@ describe('Compliance entities list', () => {
             cy.get(searchSelectors.input).type('Pass').type('{enter}');
         }, 'namespaces');
         cy.get('.rt-tbody .rt-tr').should('not.exist');
-        cy.get('[data-testid="panel-header"]').should('contain', '0 NAMESPACES');
+        cy.get('[data-testid="panel-header"]').should('contain', '0 namespaces');
     });
 
     it('should filter namespaces table with failing controls', () => {
@@ -39,7 +39,7 @@ describe('Compliance entities list', () => {
             cy.get(searchSelectors.input).type('Fail').type('{enter}');
         }, 'namespaces');
         cy.get('.rt-tbody .rt-tr');
-        cy.get('[data-testid="panel-header"]').should('contain', 'NAMESPACE');
+        cy.get('[data-testid="panel-header"]').should('contain', 'namespace');
     });
 
     it('should open/close side panel when clicking on a table row', () => {
@@ -48,14 +48,14 @@ describe('Compliance entities list', () => {
         cy.get(selectors.list.table.firstRowName)
             .invoke('text')
             .then((name) => {
-                cy.get('[data-testid="panel-header"]').should('contain', 'CLUSTER');
+                cy.get('[data-testid="panel-header"]').should('contain', 'cluster');
                 cy.get(selectors.list.table.firstRow).click();
                 cy.get('[data-testid="side-panel"]').should('exist');
                 cy.get('[data-testid="side-panel-header"]').contains(name);
                 cy.get(selectors.widget.relatedEntities).should('not.exist');
                 cy.get('[data-testid="side-panel"] [aria-label="Close"]').click();
                 cy.get('[data-testid="side-panel"]').should('not.exist');
-                cy.get('[data-testid="panel-header"]').should('contain', 'CLUSTER');
+                cy.get('[data-testid="panel-header"]').should('contain', 'cluster');
             });
     });
 

--- a/ui/apps/platform/cypress/integration/configmanagement/ConfigurationManagement.helpers.js
+++ b/ui/apps/platform/cypress/integration/configmanagement/ConfigurationManagement.helpers.js
@@ -31,34 +31,34 @@ function getEntityPagePath(entitiesKey, id = '') {
     return `${basePath}/${segmentForEntity[entitiesKey]}${id && `/${id}`}`;
 }
 
-// Heading on entities page has uppercase style.
+// Heading on entities page has sentence case for entity type.
 const headingForEntities = {
-    clusters: 'clusters',
-    controls: 'controls',
-    deployments: 'deployments',
-    images: 'images',
-    namespaces: 'namespaces',
-    nodes: 'nodes',
-    policies: 'policies',
-    roles: 'roles',
-    secrets: 'secrets',
-    serviceaccounts: 'service accounts',
-    subjects: 'users and groups',
+    clusters: 'Clusters',
+    controls: 'Controls',
+    deployments: 'Deployments',
+    images: 'Images',
+    namespaces: 'Namespaces',
+    nodes: 'Nodes',
+    policies: 'Policies',
+    roles: 'Roles',
+    secrets: 'Secrets',
+    serviceaccounts: 'Service accounts',
+    subjects: 'Users and groups',
 };
 
-// Heading on entity page or side panel has uppercase style.
+// Heading on entity page or side panel has sentence case for entity type.
 const headingForEntity = {
-    clusters: 'cluster',
-    controls: 'control',
-    deployments: 'deployment',
-    images: 'image',
-    namespaces: 'namespace',
-    nodes: 'node',
-    policies: 'policy',
-    roles: 'role',
-    secrets: 'secret',
-    serviceaccounts: 'service account',
-    subjects: 'users and groups', // plural
+    clusters: 'Cluster',
+    controls: 'Control',
+    deployments: 'Deployment',
+    images: 'Image',
+    namespaces: 'Namespace',
+    nodes: 'Node',
+    policies: 'Policy',
+    roles: 'Role',
+    secrets: 'Secret',
+    serviceaccounts: 'Service account',
+    subjects: 'Users and groups', // plural
 };
 
 function tableHeaderNoun(entitiesKey, countString) {
@@ -66,7 +66,9 @@ function tableHeaderNoun(entitiesKey, countString) {
         return countString === '1' ? 'CIS Control' : 'CIS Controls';
     }
 
-    return countString === '1' ? headingForEntity[entitiesKey] : headingForEntities[entitiesKey];
+    return countString === '1'
+        ? headingForEntity[entitiesKey].toLowerCase()
+        : headingForEntities[entitiesKey].toLowerCase();
 }
 
 // Title of widget is title case but has uppercase style.
@@ -258,7 +260,7 @@ export function clickOnCountWidget(entitiesKey, type) {
 
     if (type === 'side-panel') {
         cy.get(
-            `[data-testid="side-panel"] [data-testid="breadcrumb-link-text"]:contains("${entitiesKey}")`
+            `[data-testid="side-panel"] [data-testid="breadcrumb-link-text"]:contains("${headingForEntity[entitiesKey]}")`
         );
     }
 

--- a/ui/apps/platform/src/Components/EntityList/EntityList.js
+++ b/ui/apps/platform/src/Components/EntityList/EntityList.js
@@ -162,7 +162,7 @@ const EntityList = ({
     return (
         <PanelNew testid="panel">
             <PanelHead>
-                <PanelTitle isUpperCase testid="panel-header" text={header} />
+                <PanelTitle testid="panel-header" text={header} />
                 <PanelHeadEnd>{headerComponents}</PanelHeadEnd>
             </PanelHead>
             <PanelBody>

--- a/ui/apps/platform/src/Components/GroupedTabs.js
+++ b/ui/apps/platform/src/Components/GroupedTabs.js
@@ -13,7 +13,7 @@ const Tab = ({ text, index, active, to }) => (
             <div
                 className={`${
                     active ? 'text-primary-700' : 'text-base-500 hover:text-base-600'
-                } cursor-pointer uppercase tracking-wide font-700 p-3 flex justify-center`}
+                } cursor-pointer uppercase font-700 p-3 flex justify-center`}
             >
                 {text}
             </div>
@@ -51,7 +51,7 @@ const GroupedTabs = ({ groups, tabs, activeTab }) => {
                 >
                     {showGroupTab && (
                         <span
-                            className="truncate absolute top-0 z-10 border-l border-t border-r border-base-400 text-2xs tracking-wide py-1 px-2 rounded-t-lg text-base-500 w-full"
+                            className="truncate absolute top-0 z-10 border-l border-t border-r border-base-400 text-2xs py-1 px-2 rounded-t-lg text-base-500 w-full"
                             style={{ transform: 'translateY(-100%)' }}
                         >
                             {group}

--- a/ui/apps/platform/src/Components/Loader.js
+++ b/ui/apps/platform/src/Components/Loader.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 const Loader = ({ message }) => (
     <div className="flex flex-col items-center justify-center min-h-full w-full">
         <ClipLoader loading size={14} color="currentColor" />
-        {message && <div className="text-lg font-sans font-600 tracking-wide mt-4">{message}</div>}
+        {message && <div className="text-lg mt-4">{message}</div>}
     </div>
 );
 

--- a/ui/apps/platform/src/Components/NumberedGrid/NumberedGrid.js
+++ b/ui/apps/platform/src/Components/NumberedGrid/NumberedGrid.js
@@ -19,7 +19,7 @@ const NumberedGrid = ({ data, history }) => {
         } ${stacked ? 'py-4' : 'py-2 border-r'}`;
         const content = (
             <div className="flex flex-1 items-center">
-                <span className="text-base-600 self-center text-2xl tracking-widest pl-2 pr-4 font-600">
+                <span className="text-base-600 self-center text-2xl pl-2 pr-4 font-600">
                     {index + 1}
                 </span>
                 <div className={`flex flex-1 ${stacked ? 'justify-between' : 'flex-col'}`}>

--- a/ui/apps/platform/src/Components/PageHeader/PageHeader.js
+++ b/ui/apps/platform/src/Components/PageHeader/PageHeader.js
@@ -10,12 +10,11 @@ const PageHeader = ({
     classes,
     bgStyle,
     children,
-    capitalize,
-    lowercaseTitle,
+    // capitalize,
+    // lowercaseTitle,
 }) => {
     const { isDarkMode } = useTheme();
 
-    const extraClasses = lowercaseTitle ? '' : 'uppercase';
     return (
         <div
             className={`flex h-18 px-4 w-full flex-shrink-0 z-10 border-b border-base-400 ${classes} ${
@@ -25,13 +24,10 @@ const PageHeader = ({
             data-testid="page-header"
         >
             <div className="min-w-max pr-4 self-center">
-                <h1
-                    data-testid="header-text"
-                    className={`text-lg tracking-widest font-700 pt-1 ${extraClasses}`}
-                >
+                <h1 data-testid="header-text" className="text-lg font-700">
                     {header}
                 </h1>
-                {subHeader && <SubHeader text={subHeader} capitalize={capitalize} />}
+                {subHeader && <SubHeader text={subHeader} />}
             </div>
             <div className="flex w-full items-center">{children}</div>
         </div>
@@ -45,7 +41,7 @@ PageHeader.propTypes = {
     bgStyle: PropTypes.shape({}),
     children: PropTypes.oneOfType([PropTypes.element, PropTypes.arrayOf(PropTypes.element)]),
     capitalize: PropTypes.bool,
-    lowercaseTitle: PropTypes.bool,
+    // lowercaseTitle: PropTypes.bool,
 };
 
 PageHeader.defaultProps = {
@@ -53,8 +49,8 @@ PageHeader.defaultProps = {
     subHeader: null,
     classes: '',
     bgStyle: null,
-    capitalize: true,
-    lowercaseTitle: false,
+    capitalize: false,
+    // lowercaseTitle: false,
 };
 
 export default PageHeader;

--- a/ui/apps/platform/src/Components/PageHeader/PageHeader.js
+++ b/ui/apps/platform/src/Components/PageHeader/PageHeader.js
@@ -4,15 +4,7 @@ import PropTypes from 'prop-types';
 import { useTheme } from 'Containers/ThemeProvider';
 import SubHeader from 'Components/SubHeader';
 
-const PageHeader = ({
-    header,
-    subHeader,
-    classes,
-    bgStyle,
-    children,
-    // capitalize,
-    // lowercaseTitle,
-}) => {
+const PageHeader = ({ header, subHeader, classes, bgStyle, children }) => {
     const { isDarkMode } = useTheme();
 
     return (
@@ -40,8 +32,6 @@ PageHeader.propTypes = {
     classes: PropTypes.string,
     bgStyle: PropTypes.shape({}),
     children: PropTypes.oneOfType([PropTypes.element, PropTypes.arrayOf(PropTypes.element)]),
-    capitalize: PropTypes.bool,
-    // lowercaseTitle: PropTypes.bool,
 };
 
 PageHeader.defaultProps = {
@@ -49,8 +39,6 @@ PageHeader.defaultProps = {
     subHeader: null,
     classes: '',
     bgStyle: null,
-    capitalize: false,
-    // lowercaseTitle: false,
 };
 
 export default PageHeader;

--- a/ui/apps/platform/src/Components/Panel.js
+++ b/ui/apps/platform/src/Components/Panel.js
@@ -34,9 +34,7 @@ export function PanelHead({ children }) {
 export function PanelTitle({ isUpperCase = false, testid = '', breakAll = true, text }) {
     return (
         <div
-            className={`flex font-700 items-center leading-normal min-w-24 overflow-hidden px-4 text-base-600 tracking-wide ${
-                isUpperCase ? 'uppercase' : 'capitalize'
-            }`}
+            className="flex font-700 items-center leading-normal min-w-24 overflow-hidden px-4 text-base-600"
             data-testid={testid || null}
         >
             <Tooltip content={text}>

--- a/ui/apps/platform/src/Components/Panel.js
+++ b/ui/apps/platform/src/Components/Panel.js
@@ -1,8 +1,5 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { Tooltip } from '@patternfly/react-core';
-
-import CloseButton from './CloseButton';
 
 /*
  * PageBody is sibling of PageHeader and parent of main and side panels.
@@ -73,82 +70,3 @@ export function PanelBody({ children }) {
 }
 
 export const headerClassName = 'flex w-full min-h-14 border-b border-base-400';
-
-const Panel = (props) => (
-    <div className={`flex flex-col w-full ${props.className} h-full`} data-testid={props.id}>
-        <div className="flex-nowrap">
-            <div className={props.headerClassName}>
-                {props.leftButtons && (
-                    <div className="flex items-center pr-3 relative border-base-400 border-r hover:bg-primary-300 hover:border-primary-300">
-                        {props.leftButtons}
-                    </div>
-                )}
-                {props.headerTextComponent ? (
-                    <div className="flex" data-testid={`${props.id}-header`}>
-                        {props.headerTextComponent}
-                    </div>
-                ) : (
-                    <div
-                        className={`overflow-hidden mx-4 flex text-base-600 items-center tracking-wide leading-normal font-700 min-w-24 ${
-                            props.isUpperCase ? 'uppercase' : 'capitalize'
-                        }`}
-                        data-testid={`${props.id}-header`}
-                    >
-                        <Tooltip content={props.header}>
-                            <div className="line-clamp break-all">{props.header}</div>
-                        </Tooltip>
-                    </div>
-                )}
-
-                <div
-                    className={`flex items-center justify-end relative flex-1 ${
-                        props.onClose ? 'pl-3' : 'px-3'
-                    }`}
-                >
-                    {props.headerComponents && props.headerComponents}
-                    {props.onClose && (
-                        <CloseButton
-                            onClose={props.onClose}
-                            className={props.closeButtonClassName}
-                            iconColor={props.closeButtonIconColor}
-                        />
-                    )}
-                </div>
-            </div>
-        </div>
-        <div className={`h-full overflow-y-auto ${props.bodyClassName}`}>{props.children}</div>
-    </div>
-);
-
-Panel.propTypes = {
-    id: PropTypes.string,
-    header: PropTypes.string,
-    headerTextComponent: PropTypes.element,
-    headerClassName: PropTypes.string,
-    bodyClassName: PropTypes.string,
-    className: PropTypes.string,
-    children: PropTypes.node.isRequired,
-    onClose: PropTypes.func,
-    closeButtonClassName: PropTypes.string,
-    closeButtonIconColor: PropTypes.string,
-    headerComponents: PropTypes.element,
-    leftButtons: PropTypes.node,
-    isUpperCase: PropTypes.bool,
-};
-
-Panel.defaultProps = {
-    id: 'panel',
-    header: ' ',
-    headerTextComponent: null,
-    headerClassName,
-    bodyClassName: '',
-    className: '',
-    onClose: null,
-    closeButtonClassName: 'border-base-400 border-l',
-    closeButtonIconColor: '',
-    headerComponents: null,
-    leftButtons: null,
-    isUpperCase: true,
-};
-
-export default Panel;

--- a/ui/apps/platform/src/Components/Panel.js
+++ b/ui/apps/platform/src/Components/Panel.js
@@ -31,7 +31,7 @@ export function PanelHead({ children }) {
     return <div className="border-base-400 border-b flex h-14 w-full">{children}</div>;
 }
 
-export function PanelTitle({ isUpperCase = false, testid = '', breakAll = true, text }) {
+export function PanelTitle({ testid = '', breakAll = true, text }) {
     return (
         <div
             className="flex font-700 items-center leading-normal min-w-24 overflow-hidden px-4 text-base-600"

--- a/ui/apps/platform/src/Components/ResourceTabs.js
+++ b/ui/apps/platform/src/Components/ResourceTabs.js
@@ -22,7 +22,7 @@ const ResourceTabs = ({ entityType, entityId, resourceTabs, selectedType, match,
     function processData(data) {
         const tabData = [
             {
-                title: 'overview',
+                title: 'Overview',
                 link: getLinkToListType(),
                 type: null,
             },
@@ -78,7 +78,7 @@ const ResourceTabs = ({ entityType, entityId, resourceTabs, selectedType, match,
                                 <li key={datum.title} className="inline-block">
                                     <Link
                                         style={style}
-                                        className={`no-underline ${textColor} ${borderLeft} ${bgColor} border-r min-w-32 px-3 text-center pt-3 pb-3 uppercase tracking-widest inline-block`}
+                                        className={`no-underline ${textColor} ${borderLeft} ${bgColor} border-r min-w-32 px-3 text-center pt-3 pb-3 font-700 inline-block`}
                                         to={datum.link}
                                     >
                                         {datum.title}

--- a/ui/apps/platform/src/Components/SubHeader/SubHeader.js
+++ b/ui/apps/platform/src/Components/SubHeader/SubHeader.js
@@ -1,17 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const SubHeader = ({ text, capitalize }) => {
-    return <div className={`mt-1 ${capitalize ? 'capitalize' : ''}`}>{text}</div>;
+const SubHeader = ({ text }) => {
+    return <div>{text}</div>;
 };
 
 SubHeader.propTypes = {
     text: PropTypes.string.isRequired,
-    capitalize: PropTypes.bool,
-};
-
-SubHeader.defaultProps = {
-    capitalize: true,
 };
 
 export default SubHeader;

--- a/ui/apps/platform/src/Components/TableHeader.js
+++ b/ui/apps/platform/src/Components/TableHeader.js
@@ -20,7 +20,7 @@ const TableHeader = (props) => {
     }
     let component = (
         <div
-            className="overflow-hidden mx-4 flex text-base-600 items-center tracking-wide leading-normal font-700 uppercase"
+            className="overflow-hidden mx-4 flex text-base-600 items-center leading-normal font-700"
             data-testid="filtered-header"
         >
             <Tooltip content={headerText}>

--- a/ui/apps/platform/src/Components/Tabs.js
+++ b/ui/apps/platform/src/Components/Tabs.js
@@ -10,11 +10,11 @@ class Tabs extends Component {
         onTabClick: null,
         default: null,
         tabClass:
-            'tracking-wide font-700 hover:text-base-600 px-2 text-base-500 text-sm uppercase border-r border-l border-t border-base-400 rounded-t-sm',
+            'font-700 hover:text-base-600 px-2 text-base-500 text-sm uppercase border-r border-l border-t border-base-400 rounded-t-sm',
         tabActiveClass:
-            'tracking-wide bg-base-100 font-700 text-sm shadow uppercase px-2 py-3 border-r border-l border-t border-base-400 rounded-t-sm',
+            'bg-base-100 font-700 text-sm shadow uppercase px-2 py-3 border-r border-l border-t border-base-400 rounded-t-sm',
         tabDisabledClass:
-            'disabled tracking-wide bg-base-100 font-700 px-2 px-3 py-3 text-base-500 text-sm uppercase',
+            'disabled bg-base-100 font-700 px-2 px-3 py-3 text-base-500 text-sm uppercase',
         tabContentBgColor: 'bg-base-200 border-t shadow border-base-400',
         hasTabSpacing: false,
     };

--- a/ui/apps/platform/src/Components/TileContent/TileContent.tsx
+++ b/ui/apps/platform/src/Components/TileContent/TileContent.tsx
@@ -25,7 +25,7 @@ const TileContent = ({
 }: TileContentProps): ReactElement => {
     return (
         <div
-            className={`flex flex-col text-center justify-around ${textColorClass} ${className}`}
+            className={`flex flex-col text-center justify-around font-600 ${textColorClass} ${className}`}
             data-testid={dataTestId}
         >
             {superText !== '' && (

--- a/ui/apps/platform/src/Components/TileContent/TileContent.tsx
+++ b/ui/apps/platform/src/Components/TileContent/TileContent.tsx
@@ -29,7 +29,7 @@ const TileContent = ({
             data-testid={dataTestId}
         >
             {superText !== '' && (
-                <div className="text-2xl tracking-widest pb-1" data-testid="tileLinkSuperText">
+                <div className="text-2xl pb-1" data-testid="tileLinkSuperText">
                     {superText}
                 </div>
             )}
@@ -37,20 +37,12 @@ const TileContent = ({
             <div
                 className={`flex ${
                     !textWrap ? 'whitespace-nowrap' : ''
-                } items-center font-600 font-condensed uppercase justify-center text-base`}
+                } items-center justify-center text-base`}
                 data-testid="tile-link-value"
             >
                 {text}
             </div>
-            {subText && (
-                <div
-                    className={`${
-                        short ? 'text-xs' : 'text-sm pt-1'
-                    } tracking-wide font-condensed font-600`}
-                >
-                    {subText}
-                </div>
-            )}
+            {subText && <div className={`${short ? 'text-xs' : 'text-sm pt-1'}`}>{subText}</div>}
         </div>
     );
 };

--- a/ui/apps/platform/src/Components/TileList/TileList.js
+++ b/ui/apps/platform/src/Components/TileList/TileList.js
@@ -16,7 +16,7 @@ const TileList = ({ items, title }) => {
         >
             {title !== '' && (
                 <h3
-                    className={`border-b text-xs text-base-600 uppercase text-center tracking-wide p-1 leading-normal font-700 ${
+                    className={`border-b text-base-600 text-center p-1 leading-normal font-700 ${
                         !isDarkMode ? 'border-base-400' : 'border-tertiary-400'
                     }`}
                 >

--- a/ui/apps/platform/src/Components/Widget/Widget.js
+++ b/ui/apps/platform/src/Components/Widget/Widget.js
@@ -88,7 +88,7 @@ function Widget({
             <div className="border-b border-base-300">
                 <div className="flex flex-auto min-h-10 word-break">
                     <div
-                        className="flex flex-auto text-base-600 items-center tracking-wide px-2 leading-normal font-700"
+                        className="flex flex-auto text-base-600 items-center px-2 leading-normal font-700"
                         data-testid="widget-header"
                     >
                         <div className="w-full">{headerContent}</div>

--- a/ui/apps/platform/src/Components/Widget/Widget.js
+++ b/ui/apps/platform/src/Components/Widget/Widget.js
@@ -88,7 +88,7 @@ function Widget({
             <div className="border-b border-base-300">
                 <div className="flex flex-auto min-h-10 word-break">
                     <div
-                        className="flex flex-auto text-sm text-base-600 uppercase items-center tracking-wide px-2 leading-normal font-700"
+                        className="flex flex-auto text-base-600 items-center tracking-wide px-2 leading-normal font-700"
                         data-testid="widget-header"
                     >
                         <div className="w-full">{headerContent}</div>

--- a/ui/apps/platform/src/Containers/BreadCrumbs/EntityBreadCrumb.js
+++ b/ui/apps/platform/src/Containers/BreadCrumbs/EntityBreadCrumb.js
@@ -1,37 +1,30 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import capitalize from 'lodash/capitalize';
 import pluralize from 'pluralize';
 
 import entityLabels from 'messages/entity';
 import useEntityName from 'hooks/useEntityName';
-import { shouldUseOriginalCase } from 'utils/workflowUtils';
 
 const EntityBreadCrumb = ({ workflowEntity, url }) => {
     const { entityId, entityType } = workflowEntity;
     const typeLabel = entityLabels[entityType];
-    const subTitle = entityId ? typeLabel : 'entity list';
+    const subTitle = capitalize(entityId ? typeLabel : 'entity list');
     const { entityName } = useEntityName(entityType, entityId, !entityId);
     const title = entityName || pluralize(typeLabel);
-
-    const useOriginalCase = shouldUseOriginalCase(entityName, entityType);
-    const extraClasses = useOriginalCase ? '' : 'uppercase truncate';
 
     return (
         <span className="flex flex-col max-w-full" data-testid="breadcrumb-link-text">
             {url ? (
-                <Link
-                    className={`text-primary-700 underline ${extraClasses}`}
-                    title={`${title}`}
-                    to={url}
-                >
+                <Link className="text-primary-700 underline" title={title} to={url}>
                     {title}
                 </Link>
             ) : (
                 <span className="w-full truncate" title={title}>
-                    <span className={extraClasses}>{title}</span>
+                    {title}
                 </span>
             )}
-            <span className="capitalize font-600">{subTitle}</span>
+            <span>{subTitle}</span>
         </span>
     );
 };

--- a/ui/apps/platform/src/Containers/BreadCrumbs/EntityBreadCrumb.js
+++ b/ui/apps/platform/src/Containers/BreadCrumbs/EntityBreadCrumb.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import capitalize from 'lodash/capitalize';
+import upperFirst from 'lodash/upperFirst';
 import pluralize from 'pluralize';
 
 import entityLabels from 'messages/entity';
@@ -9,7 +9,7 @@ import useEntityName from 'hooks/useEntityName';
 const EntityBreadCrumb = ({ workflowEntity, url }) => {
     const { entityId, entityType } = workflowEntity;
     const typeLabel = entityLabels[entityType];
-    const subTitle = capitalize(entityId ? typeLabel : 'entity list');
+    const subTitle = entityId ? upperFirst(typeLabel) : 'Entity list';
     const { entityName } = useEntityName(entityType, entityId, !entityId);
     const title = entityName || pluralize(typeLabel);
 

--- a/ui/apps/platform/src/Containers/BreadCrumbs/EntityBreadCrumbs.js
+++ b/ui/apps/platform/src/Containers/BreadCrumbs/EntityBreadCrumbs.js
@@ -101,7 +101,7 @@ const BreadCrumbLinks = ({ workflowEntities }) => {
     return (
         <span
             style={{ flex: '10 1' }}
-            className="flex items-center font-700 leading-normal text-base-600 tracking-wide truncate"
+            className="flex items-center font-700 leading-normal text-base-600 truncate"
         >
             <BackLink workflowState={workflowState} enabled={backButtonEnabled} />
             {breadCrumbLinks}

--- a/ui/apps/platform/src/Containers/Clusters/ClustersSidePanel.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClustersSidePanel.tsx
@@ -337,11 +337,7 @@ function ClustersSidePanel({ selectedClusterId, setSelectedClusterId }) {
         <SidePanelAnimatedArea isDarkMode={isDarkMode} isOpen={!!selectedClusterId}>
             <PanelNew testid="clusters-side-panel">
                 <PanelHead>
-                    <PanelTitle
-                        isUpperCase={false}
-                        testid="clusters-side-panel-header"
-                        text={selectedClusterName}
-                    />
+                    <PanelTitle testid="clusters-side-panel-header" text={selectedClusterName} />
                     <PanelHeadEnd>
                         {panelButtons}
                         <CloseButton

--- a/ui/apps/platform/src/Containers/Clusters/ClustersTablePanel.js
+++ b/ui/apps/platform/src/Containers/Clusters/ClustersTablePanel.js
@@ -207,7 +207,7 @@ function ClustersTablePanel({ selectedClusterId, setSelectedClusterId, searchOpt
     const headerComponent = (
         <TableHeader
             length={currentClusters?.length || 0}
-            type="Cluster"
+            type="cluster"
             isViewFiltered={isViewFiltered}
         />
     );

--- a/ui/apps/platform/src/Containers/Compliance/Entity/Header.js
+++ b/ui/apps/platform/src/Containers/Compliance/Entity/Header.js
@@ -1,13 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import pluralize from 'pluralize';
-import toLower from 'lodash/toLower';
+import capitalize from 'lodash/capitalize';
 
 import PageHeader from 'Components/PageHeader';
 import ScanButton from 'Containers/Compliance/ScanButton';
 import ExportButton from 'Components/ExportButton';
 import useCaseTypes from 'constants/useCaseTypes';
 import entityTypes from 'constants/entityTypes';
+import { resourceLabels } from 'messages/common';
 
 const EntityHeader = ({
     entityType,
@@ -19,7 +20,7 @@ const EntityHeader = ({
     setIsExporting,
 }) => {
     const header = entityName || 'Loading...';
-    const subHeader = toLower(entityType);
+    const subHeader = capitalize(resourceLabels[entityType]);
     let exportFilename = listEntityType
         ? `${pluralize(listEntityType)} ACROSS ${entityType} "${entityName.toUpperCase()}"`
         : `${entityType} "${entityId}"`;

--- a/ui/apps/platform/src/Containers/Compliance/Entity/Header.js
+++ b/ui/apps/platform/src/Containers/Compliance/Entity/Header.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import pluralize from 'pluralize';
-import capitalize from 'lodash/capitalize';
+import upperFirst from 'lodash/upperFirst';
 
 import PageHeader from 'Components/PageHeader';
 import ScanButton from 'Containers/Compliance/ScanButton';
@@ -20,7 +20,7 @@ const EntityHeader = ({
     setIsExporting,
 }) => {
     const header = entityName || 'Loading...';
-    const subHeader = capitalize(resourceLabels[entityType]);
+    const subHeader = upperFirst(resourceLabels[entityType]);
     let exportFilename = listEntityType
         ? `${pluralize(listEntityType)} ACROSS ${entityType} "${entityName.toUpperCase()}"`
         : `${entityType} "${entityId}"`;

--- a/ui/apps/platform/src/Containers/Compliance/List/SidePanel.js
+++ b/ui/apps/platform/src/Containers/Compliance/List/SidePanel.js
@@ -60,7 +60,7 @@ const ComplianceListSidePanel = ({ entityType, entityId, match, location, histor
                                 to={headerUrl}
                                 className="w-full flex text-primary-700 hover:text-primary-800 focus:text-primary-700"
                             >
-                                <div className="flex flex-1 uppercase items-center tracking-wide pl-4 leading-normal font-700">
+                                <div className="flex flex-1 items-center tracking-wide pl-4 leading-normal font-700">
                                     {linkText}
                                 </div>
                             </Link>

--- a/ui/apps/platform/src/Containers/Compliance/List/SidePanel.js
+++ b/ui/apps/platform/src/Containers/Compliance/List/SidePanel.js
@@ -60,7 +60,7 @@ const ComplianceListSidePanel = ({ entityType, entityId, match, location, histor
                                 to={headerUrl}
                                 className="w-full flex text-primary-700 hover:text-primary-800 focus:text-primary-700"
                             >
-                                <div className="flex flex-1 items-center tracking-wide pl-4 leading-normal font-700">
+                                <div className="flex flex-1 items-center pl-4 leading-normal font-700">
                                     {linkText}
                                 </div>
                             </Link>

--- a/ui/apps/platform/src/Containers/Compliance/List/Table.js
+++ b/ui/apps/platform/src/Containers/Compliance/List/Table.js
@@ -6,6 +6,7 @@ import { useQuery } from '@apollo/client';
 import { Message } from '@stackrox/ui-components';
 
 import entityTypes, { standardTypes } from 'constants/entityTypes';
+import { resourceLabels } from 'messages/common';
 import { standardLabels } from 'messages/standards';
 import { CLIENT_SIDE_SEARCH_OPTIONS as SEARCH_OPTIONS } from 'constants/searchOptions';
 import Table from 'Components/Table';
@@ -274,6 +275,7 @@ const ListTable = ({
         tableColumns = getColumnsByEntity(entityType, standardsData.results);
     }
     let tableData;
+    const entityTypeLabel = resourceLabels[entityType];
 
     return (
         <Query query={gqlQuery} variables={variables}>
@@ -286,18 +288,23 @@ const ListTable = ({
                 if (!loading || (data && data.results)) {
                     const formattedData = formatData(data, entityType);
                     if (!formattedData) {
-                        headerText = `0 ${pluralize(entityType, totalRows)}`;
+                        headerText = `0 ${pluralize(entityTypeLabel, totalRows)}`;
                         contents = <NoResultsMessage message="No data matched your search." />;
                     } else {
                         tableData = filterByComplianceState(formattedData, query, isControlList);
                         totalRows = getTotalRows(tableData, isControlList);
                         const { groupBy } = query;
+                        const groupByLabel =
+                            groupBy === 'STANDARD' ? 'standard' : resourceLabels[groupBy];
 
                         const groupedByText = groupBy
-                            ? `across ${tableData.length} ${pluralize(groupBy, tableData.length)}`
+                            ? `across ${tableData.length} ${pluralize(
+                                  groupByLabel,
+                                  tableData.length
+                              )}`
                             : '';
                         headerText = `${totalRows} ${pluralize(
-                            entityType,
+                            entityTypeLabel,
                             totalRows
                         )} ${groupedByText}`;
 

--- a/ui/apps/platform/src/Containers/Compliance/List/Table.js
+++ b/ui/apps/platform/src/Containers/Compliance/List/Table.js
@@ -358,7 +358,7 @@ const ListTable = ({
                 return (
                     <PanelNew testid="panel">
                         <PanelHead>
-                            <PanelTitle isUpperCase testid="panel-header" text={headerText} />
+                            <PanelTitle testid="panel-header" text={headerText} />
                             <PanelHeadEnd>{headerComponent}</PanelHeadEnd>
                         </PanelHead>
                         <PanelBody>{contents}</PanelBody>

--- a/ui/apps/platform/src/Containers/Compliance/widgets/EntityCompliance.js
+++ b/ui/apps/platform/src/Containers/Compliance/widgets/EntityCompliance.js
@@ -1,7 +1,7 @@
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { useRouteMatch, useLocation, useHistory } from 'react-router-dom';
-import capitalize from 'lodash/capitalize';
+import upperFirst from 'lodash/upperFirst';
 
 import Widget from 'Components/Widget';
 import VerticalBarChart from 'Components/visuals/VerticalBarChart';
@@ -18,7 +18,7 @@ import { standardLabels } from 'messages/standards';
 import searchContext from 'Containers/searchContext';
 
 const EntityCompliance = ({ entityType, entityName, clusterName }) => {
-    const entityTypeLabel = capitalize(resourceLabels[entityType]);
+    const entityTypeLabel = upperFirst(resourceLabels[entityType]);
     const searchParam = useContext(searchContext);
     const match = useRouteMatch();
     const location = useLocation();

--- a/ui/apps/platform/src/Containers/Compliance/widgets/EntityCompliance.js
+++ b/ui/apps/platform/src/Containers/Compliance/widgets/EntityCompliance.js
@@ -1,6 +1,7 @@
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { useRouteMatch, useLocation, useHistory } from 'react-router-dom';
+import capitalize from 'lodash/capitalize';
 
 import Widget from 'Components/Widget';
 import VerticalBarChart from 'Components/visuals/VerticalBarChart';
@@ -17,7 +18,7 @@ import { standardLabels } from 'messages/standards';
 import searchContext from 'Containers/searchContext';
 
 const EntityCompliance = ({ entityType, entityName, clusterName }) => {
-    const entityTypeLabel = resourceLabels[entityType];
+    const entityTypeLabel = capitalize(resourceLabels[entityType]);
     const searchParam = useContext(searchContext);
     const match = useRouteMatch();
     const location = useLocation();

--- a/ui/apps/platform/src/Containers/Compliance/widgets/StandardsAcrossEntity.js
+++ b/ui/apps/platform/src/Containers/Compliance/widgets/StandardsAcrossEntity.js
@@ -50,7 +50,8 @@ function setStandardsMapping(data, type) {
 
 const StandardsAcrossEntity = ({ match, location, entityType, bodyClassName, className }) => {
     const searchParam = useContext(searchContext);
-    const headerText = `Passing standards across ${entityType}s`;
+    const entityTypeLabel = resourceLabels[entityType];
+    const headerText = `Passing standards across ${entityTypeLabel}s`;
 
     function processData(data, type) {
         if (!data || !data.results || !data.results.results.length) {

--- a/ui/apps/platform/src/Containers/Compliance/widgets/StandardsByEntity.js
+++ b/ui/apps/platform/src/Containers/Compliance/widgets/StandardsByEntity.js
@@ -101,7 +101,7 @@ function getLabelLinks(match, location, data, entityType) {
 
 const StandardsByEntity = ({ match, location, entityType, bodyClassName, className }) => {
     const searchParam = useContext(searchContext);
-    const headerText = `Passing standards by ${entityType}`;
+    const headerText = `Passing standards by ${resourceLabels[entityType]}`;
 
     const variables = {
         groupBy: [entityTypes.STANDARD, entityType],

--- a/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/widgets/SecretsMostUsedAcrossDeployments.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/widgets/SecretsMostUsedAcrossDeployments.js
@@ -117,7 +117,7 @@ const SecretsMostUsedAcrossDeployments = ({ match, location }) => {
                                     >
                                         <li>
                                             <div className="flex flex-row">
-                                                <div className="self-center text-2xl tracking-widest pl-4 pr-4">
+                                                <div className="self-center text-2xl pl-4 pr-4">
                                                     {index + 1}
                                                 </div>
                                                 <div className="flex flex-col truncate pr-4 pb-4 pt-4 text-sm">

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/EntityPageHeader.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/EntityPageHeader.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import capitalize from 'lodash/capitalize';
+import upperFirst from 'lodash/upperFirst';
 import startCase from 'lodash/startCase';
 
 import PageHeader from 'Components/PageHeader';
@@ -17,7 +17,7 @@ const EntityPageHeader = ({ entityType, entityId, urlParams, isExporting, setIsE
     const { entityName } = useEntityName(entityType, safeEntityId);
 
     const header = entityName || '-';
-    const subHeader = capitalize(entityLabels[entityType]);
+    const subHeader = upperFirst(entityLabels[entityType]);
     const exportFilename = `${startCase(subHeader)} Report: "${header}"`;
 
     let pdfId = 'capture-dashboard-stretch';

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/EntityPageHeader.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/EntityPageHeader.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import capitalize from 'lodash/capitalize';
 import startCase from 'lodash/startCase';
 
 import PageHeader from 'Components/PageHeader';
@@ -16,7 +17,7 @@ const EntityPageHeader = ({ entityType, entityId, urlParams, isExporting, setIsE
     const { entityName } = useEntityName(entityType, safeEntityId);
 
     const header = entityName || '-';
-    const subHeader = entityLabels[entityType];
+    const subHeader = capitalize(entityLabels[entityType]);
     const exportFilename = `${startCase(subHeader)} Report: "${header}"`;
 
     let pdfId = 'capture-dashboard-stretch';

--- a/ui/apps/platform/src/Containers/ConfigManagement/List/List.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/List/List.js
@@ -71,7 +71,7 @@ const List = ({
         return (
             <PanelNew testid="panel">
                 <PanelHead>
-                    <PanelTitle isUpperCase testid="panel-header" text={header} />
+                    <PanelTitle testid="panel-header" text={header} />
                     <PanelHeadEnd>{headerComponents}</PanelHeadEnd>
                 </PanelHead>
                 <PanelBody>

--- a/ui/apps/platform/src/Containers/ConfigManagement/List/ListFrontendPaginated.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/List/ListFrontendPaginated.js
@@ -58,7 +58,7 @@ const ListFrontendPaginated = ({
         return (
             <PanelNew testid="panel">
                 <PanelHead>
-                    <PanelTitle isUpperCase testid="panel-header" text={header} />
+                    <PanelTitle testid="panel-header" text={header} />
                     <PanelHeadEnd>{headerComponents}</PanelHeadEnd>
                 </PanelHead>
                 <PanelBody>

--- a/ui/apps/platform/src/Containers/ConfigManagement/List/Page.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/List/Page.js
@@ -1,7 +1,7 @@
 import React, { useContext, useState } from 'react';
 import ReactRouterPropTypes from 'react-router-prop-types';
 import pluralize from 'pluralize';
-import capitalize from 'lodash/capitalize';
+import upperFirst from 'lodash/upperFirst';
 import startCase from 'lodash/startCase';
 
 import SidePanelAnimatedArea from 'Components/animations/SidePanelAnimatedArea';
@@ -51,7 +51,7 @@ const ListPage = ({ match, location, history }) => {
         history.push(urlBuilder.url());
     }
 
-    const header = capitalize(pluralize(entityLabels[pageEntityListType]));
+    const header = upperFirst(pluralize(entityLabels[pageEntityListType]));
     const exportFilename = `${pluralize(startCase(header))} Report`;
     return (
         <workflowStateContext.Provider value={pageState}>

--- a/ui/apps/platform/src/Containers/ConfigManagement/List/Page.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/List/Page.js
@@ -1,6 +1,7 @@
 import React, { useContext, useState } from 'react';
 import ReactRouterPropTypes from 'react-router-prop-types';
 import pluralize from 'pluralize';
+import capitalize from 'lodash/capitalize';
 import startCase from 'lodash/startCase';
 
 import SidePanelAnimatedArea from 'Components/animations/SidePanelAnimatedArea';
@@ -50,13 +51,13 @@ const ListPage = ({ match, location, history }) => {
         history.push(urlBuilder.url());
     }
 
-    const header = pluralize(entityLabels[pageEntityListType]);
+    const header = capitalize(pluralize(entityLabels[pageEntityListType]));
     const exportFilename = `${pluralize(startCase(header))} Report`;
     return (
         <workflowStateContext.Provider value={pageState}>
             <PageHeader
                 header={header}
-                subHeader="Entity List"
+                subHeader="Entity list"
                 classes="pr-0 ignore-react-onclickoutside"
             >
                 <div className="flex flex-1 justify-end h-full">

--- a/ui/apps/platform/src/Containers/ConfigManagement/SidePanel/BreadCrumbs.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/SidePanel/BreadCrumbs.js
@@ -112,7 +112,7 @@ const BreadCrumbLinks = (props) => {
             <div key={`${state.name}--${state.type}`} className={`flex ${maxWidthClass} truncate`}>
                 <span className="flex flex-col max-w-full" data-testid="breadcrumb-link-text">
                     {content}
-                    <span className="italic font-600">{entityTypeLabel}</span>
+                    <span>{entityTypeLabel}</span>
                 </span>
                 <span className="flex items-center">{icon}</span>
             </div>

--- a/ui/apps/platform/src/Containers/ConfigManagement/SidePanel/BreadCrumbs.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/SidePanel/BreadCrumbs.js
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactRouterPropTypes from 'react-router-prop-types';
 import PropTypes from 'prop-types';
 import pluralize from 'pluralize';
+import capitalize from 'lodash/capitalize';
 import { ChevronRight } from 'react-feather';
 import { Link, withRouter } from 'react-router-dom';
 
@@ -93,27 +94,25 @@ const BreadCrumbLinks = (props) => {
     const breadCrumbLinks = breadCrumbStates.map((state, i, { length }) => {
         const icon = i !== length - 1 ? Icon : null;
         const link = getLink(match, location, i, length);
+        const name = state.type === 'entity list' ? capitalize(state.name) : state.name;
         const content = link ? (
-            <Link
-                className="text-primary-700 underline uppercase truncate"
-                title={state.name}
-                to={link}
-            >
-                {state.name}
+            <Link className="text-primary-700 underline truncate" title={state.name} to={link}>
+                {name}
             </Link>
         ) : (
             <span className="w-full truncate" title={state.name}>
-                <span className="truncate uppercase">{state.name}</span>
+                <span className="truncate">{name}</span>
             </span>
         );
         if (!state) {
             return null;
         }
+        const entityTypeLabel = capitalize(state.type);
         return (
             <div key={`${state.name}--${state.type}`} className={`flex ${maxWidthClass} truncate`}>
                 <span className="flex flex-col max-w-full" data-testid="breadcrumb-link-text">
                     {content}
-                    <span className="capitalize font-600">{state.type.toLowerCase()}</span>
+                    <span className="italic font-600">{entityTypeLabel}</span>
                 </span>
                 <span className="flex items-center">{icon}</span>
             </div>

--- a/ui/apps/platform/src/Containers/ConfigManagement/SidePanel/BreadCrumbs.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/SidePanel/BreadCrumbs.js
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactRouterPropTypes from 'react-router-prop-types';
 import PropTypes from 'prop-types';
 import pluralize from 'pluralize';
-import capitalize from 'lodash/capitalize';
+import upperFirst from 'lodash/upperFirst';
 import { ChevronRight } from 'react-feather';
 import { Link, withRouter } from 'react-router-dom';
 
@@ -94,7 +94,7 @@ const BreadCrumbLinks = (props) => {
     const breadCrumbLinks = breadCrumbStates.map((state, i, { length }) => {
         const icon = i !== length - 1 ? Icon : null;
         const link = getLink(match, location, i, length);
-        const name = state.type === 'entity list' ? capitalize(state.name) : state.name;
+        const name = state.type === 'entity list' ? upperFirst(state.name) : state.name;
         const content = link ? (
             <Link className="text-primary-700 underline truncate" title={state.name} to={link}>
                 {name}
@@ -107,7 +107,7 @@ const BreadCrumbLinks = (props) => {
         if (!state) {
             return null;
         }
-        const entityTypeLabel = capitalize(state.type);
+        const entityTypeLabel = upperFirst(state.type);
         return (
             <div key={`${state.name}--${state.type}`} className={`flex ${maxWidthClass} truncate`}>
                 <span className="flex flex-col max-w-full" data-testid="breadcrumb-link-text">

--- a/ui/apps/platform/src/Containers/ConfigManagement/SidePanel/SidePanel.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/SidePanel/SidePanel.js
@@ -98,7 +98,7 @@ const SidePanel = ({
             <PanelNew testid="side-panel">
                 <PanelHead>
                     <BreadCrumbs
-                        className="font-700 leading-normal text-base-600 tracking-wide truncate"
+                        className="font-700 leading-normal text-base-600 truncate"
                         entityType1={entityType1 || entityListType1}
                         entityId1={entityId1}
                         entityType2={entityType2}

--- a/ui/apps/platform/src/Containers/Login/LoginPage.js
+++ b/ui/apps/platform/src/Containers/Login/LoginPage.js
@@ -209,7 +209,7 @@ class LoginPage extends Component {
                 <div className="p-6 w-full text-center">
                     <button
                         type="button"
-                        className="p-3 px-6 rounded-sm bg-primary-600 hover:bg-primary-700 text-base-100 uppercase text-center tracking-wide"
+                        className="p-3 px-6 rounded-sm bg-primary-600 hover:bg-primary-700 text-base-100 text-center"
                     >
                         <ClipLoader color="white" loading size={15} />
                     </button>
@@ -223,7 +223,7 @@ class LoginPage extends Component {
             return (
                 <div className="p-8 w-full text-center">
                     <Link
-                        className="p-3 px-6 rounded-sm bg-primary-600 hover:bg-primary-700 text-base-100 uppercase text-center tracking-wide no-underline"
+                        className="p-3 px-6 rounded-sm bg-primary-600 hover:bg-primary-700 text-base-100 text-center no-underline"
                         to="/main/dashboard"
                     >
                         Go to Dashboard

--- a/ui/apps/platform/src/Containers/Network/Graph/Overlays/GraphLoader.tsx
+++ b/ui/apps/platform/src/Containers/Network/Graph/Overlays/GraphLoader.tsx
@@ -7,7 +7,7 @@ function GraphLoader(): ReactElement {
             <div className="w-10 rounded-full p-2 bg-base-100 shadow-lg mb-4">
                 <Loader loading size={20} color="currentColor" />
             </div>
-            <div className="uppercase text-sm tracking-widest font-700">Generating Graph...</div>
+            <div className="uppercase text-sm font-700">Generating Graph...</div>
         </div>
     );
 }

--- a/ui/apps/platform/src/Containers/Network/SidePanel/CIDRForm/CIDRPanel.js
+++ b/ui/apps/platform/src/Containers/Network/SidePanel/CIDRForm/CIDRPanel.js
@@ -36,7 +36,6 @@ const CIDRPanel = ({ selectedClusterId, updateNetworkNodes, onClose }) => {
         <PanelNew testid="network-cidr-form">
             <PanelHead>
                 <PanelTitle
-                    isUpperCase
                     testid="network-cidr-form-header"
                     text="Segment External Entities by CIDR Blocks"
                 />

--- a/ui/apps/platform/src/Containers/Network/SidePanel/Creator/Creator.tsx
+++ b/ui/apps/platform/src/Containers/Network/SidePanel/Creator/Creator.tsx
@@ -15,11 +15,7 @@ function Creator({ onClose }: CreatorProps): ReactElement {
         <div className="h-full w-full shadow-md bg-base-200">
             <PanelNew testid="network-creator-panel">
                 <PanelHead>
-                    <PanelTitle
-                        isUpperCase
-                        testid="network-creator-panel-header"
-                        text="SELECT AN OPTION"
-                    />
+                    <PanelTitle testid="network-creator-panel-header" text="SELECT AN OPTION" />
                     <PanelHeadEnd>
                         <ViewActive />
                         <CloseButton onClose={onClose} className="border-base-400 border-l" />

--- a/ui/apps/platform/src/Containers/Network/SidePanel/NetworkDeploymentOverlay/Flows/NetworkBaselines/NetworkBaselines.js
+++ b/ui/apps/platform/src/Containers/Network/SidePanel/NetworkDeploymentOverlay/Flows/NetworkBaselines/NetworkBaselines.js
@@ -57,7 +57,7 @@ function NetworkBaselines({
     return (
         <PanelNew testid={panelId}>
             <PanelHead>
-                <PanelTitle isUpperCase testid={`${panelId}-header`} text={header} />
+                <PanelTitle testid={`${panelId}-header`} text={header} />
                 <PanelHeadEnd>
                     {headerComponents}
                     <TablePagination

--- a/ui/apps/platform/src/Containers/Network/SidePanel/Simulator/Simulator.tsx
+++ b/ui/apps/platform/src/Containers/Network/SidePanel/Simulator/Simulator.tsx
@@ -38,7 +38,6 @@ function Simulator({
             <PanelNew testid="network-simulator-panel">
                 <PanelHead>
                     <PanelTitle
-                        isUpperCase
                         testid="network-simulator-panel-header"
                         text="Network Policy Simulator"
                     />

--- a/ui/apps/platform/src/Containers/Risk/RiskDetails.js
+++ b/ui/apps/platform/src/Containers/Risk/RiskDetails.js
@@ -39,7 +39,7 @@ const RiskDetails = ({ risk }) => {
 
     return risk.results.map((result) => (
         <div className="px-3 pt-5" key={result.name}>
-            <div className="alert-preview bg-base-100 text-primary-600" key={result.name}>
+            <div className="alert-preview bg-base-100 text-primary-600">
                 <CollapsibleCard title={result.name}>
                     {result.factors.map((factor, index) => (
                         // eslint-disable-next-line react/no-array-index-key

--- a/ui/apps/platform/src/Containers/Risk/RiskDetails.js
+++ b/ui/apps/platform/src/Containers/Risk/RiskDetails.js
@@ -39,10 +39,7 @@ const RiskDetails = ({ risk }) => {
 
     return risk.results.map((result) => (
         <div className="px-3 pt-5" key={result.name}>
-            <div
-                className="alert-preview bg-base-100 text-primary-600 tracking-wide"
-                key={result.name}
-            >
+            <div className="alert-preview bg-base-100 text-primary-600" key={result.name}>
                 <CollapsibleCard title={result.name}>
                     {result.factors.map((factor, index) => (
                         // eslint-disable-next-line react/no-array-index-key

--- a/ui/apps/platform/src/Containers/Risk/RiskSidePanel.js
+++ b/ui/apps/platform/src/Containers/Risk/RiskSidePanel.js
@@ -56,7 +56,7 @@ function RiskSidePanel({ selectedDeploymentId, setSelectedDeploymentId }) {
     return (
         <PanelNew testid="panel">
             <PanelHead>
-                <PanelTitle isUpperCase={false} testid="panel-header" text={header} />
+                <PanelTitle testid="panel-header" text={header} />
                 <PanelHeadEnd>
                     <CloseButton
                         onClose={unselectDeployment}

--- a/ui/apps/platform/src/Containers/Risk/RiskTablePanel.js
+++ b/ui/apps/platform/src/Containers/Risk/RiskTablePanel.js
@@ -94,7 +94,7 @@ function RiskTablePanel({
             <PanelHead>
                 <TableHeader
                     length={deploymentCount}
-                    type="Deployment"
+                    type="deployment"
                     isViewFiltered={isViewFiltered}
                 />
                 <PanelHeadEnd>

--- a/ui/apps/platform/src/Containers/Risk/SecurityContext.js
+++ b/ui/apps/platform/src/Containers/Risk/SecurityContext.js
@@ -43,7 +43,7 @@ const SecurityContext = ({ deployment }) => {
     }
     return (
         <div className="px-3 pt-5">
-            <div className="bg-base-100 text-primary-600 tracking-wide">
+            <div className="bg-base-100 text-primary-600">
                 <CollapsibleCard title="Security Context">
                     <div className="flex h-full px-3">{containers}</div>
                 </CollapsibleCard>

--- a/ui/apps/platform/src/Containers/VulnMgmt/Components/ScanDataMessage.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Components/ScanDataMessage.tsx
@@ -9,9 +9,7 @@ function ScanDataMessage({ header = '', body = '' }: ScanMessage): ReactElement 
             <Message type="error">
                 <div className="w-full">
                     <header className="text-lg pb-2 border-b border-alert-300 mb-2 w-full">
-                        <h2 className="mb-1 font-700 tracking-wide uppercase">
-                            CVE Data May Be Inaccurate
-                        </h2>
+                        <h2 className="mb-1 font-700">CVE Data May Be Inaccurate</h2>
                         <span>{header}</span>
                     </header>
                     <p>{body}</p>

--- a/ui/apps/platform/src/Containers/VulnMgmt/Dashboard/CvesMenu.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Dashboard/CvesMenu.js
@@ -62,7 +62,7 @@ const CvesMenu = () => {
 
     return (
         <Menu
-            buttonClass={`bg-base-100 hover:bg-base-200 border border-base-400 btn-class flex font-condensed h-full text-center text-sm text-base-600 ${errorClasses}`}
+            buttonClass={`bg-base-100 hover:bg-base-200 border border-base-400 btn-class flex h-full text-center text-base whitespace-nowrap text-base-600 ${errorClasses}`}
             buttonText={loading ? <Loader className="text-base-100" message="" /> : menuTitle}
             options={options}
             className="h-full min-w-24"

--- a/ui/apps/platform/src/Containers/Workflow/WorkflowEntityPageLayout.js
+++ b/ui/apps/platform/src/Containers/Workflow/WorkflowEntityPageLayout.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { withRouter } from 'react-router-dom';
+import capitalize from 'lodash/capitalize';
 import startCase from 'lodash/startCase';
 
 import SidePanelAnimatedArea from 'Components/animations/SidePanelAnimatedArea';
@@ -20,7 +21,6 @@ import useCaseLabels from 'messages/useCase';
 import useEntityName from 'hooks/useEntityName';
 import useFeatureFlags from 'hooks/useFeatureFlags';
 import { exportCvesAsCsv } from 'services/VulnerabilitiesService';
-import { shouldUseOriginalCase } from 'utils/workflowUtils';
 import entityTypes from 'constants/entityTypes';
 import WorkflowSidePanel from './WorkflowSidePanel';
 import { EntityComponentMap } from './UseCaseComponentMaps';
@@ -85,11 +85,9 @@ const WorkflowEntityPageLayout = ({ location }) => {
               opacity: 0,
           };
 
-    const subheaderText = entityLabels[pageEntityType];
+    const subheaderText = capitalize(entityLabels[pageEntityType]);
     const { entityName = '' } = useEntityName(pageEntityType, pageEntityId);
     const entityContext = {};
-    // const useLowercase = pageEntityType === entityTypes.IMAGE;
-    const useOriginalCase = shouldUseOriginalCase(entityName, pageEntityType);
 
     const exportFilename = `${useCaseLabels[useCase]} ${startCase(
         subheaderText
@@ -124,7 +122,6 @@ const WorkflowEntityPageLayout = ({ location }) => {
                     header={entityName}
                     subHeader={subheaderText}
                     classes="pr-0 ignore-react-onclickoutside"
-                    lowercaseTitle={useOriginalCase}
                 >
                     <div className="flex flex-1 justify-end h-full">
                         <div className="flex items-center pr-2">

--- a/ui/apps/platform/src/Containers/Workflow/WorkflowEntityPageLayout.js
+++ b/ui/apps/platform/src/Containers/Workflow/WorkflowEntityPageLayout.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { withRouter } from 'react-router-dom';
-import capitalize from 'lodash/capitalize';
+import upperFirst from 'lodash/upperFirst';
 import startCase from 'lodash/startCase';
 
 import SidePanelAnimatedArea from 'Components/animations/SidePanelAnimatedArea';
@@ -85,7 +85,7 @@ const WorkflowEntityPageLayout = ({ location }) => {
               opacity: 0,
           };
 
-    const subheaderText = capitalize(entityLabels[pageEntityType]);
+    const subheaderText = upperFirst(entityLabels[pageEntityType]);
     const { entityName = '' } = useEntityName(pageEntityType, pageEntityId);
     const entityContext = {};
 

--- a/ui/apps/platform/src/Containers/Workflow/WorkflowListPageLayout.js
+++ b/ui/apps/platform/src/Containers/Workflow/WorkflowListPageLayout.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import pluralize from 'pluralize';
-import capitalize from 'lodash/capitalize';
+import upperFirst from 'lodash/upperFirst';
 import startCase from 'lodash/startCase';
 
 import { searchParams, sortParams, pagingParams } from 'constants/searchParams';
@@ -66,7 +66,7 @@ const WorkflowListPageLayout = ({ location }) => {
     const sidePanelPaging = workflowState.paging[pagingParams.sidePanel];
     const selectedRow = workflowState.getSelectedTableRow();
 
-    const header = capitalize(pluralize(entityLabels[pageListType]));
+    const header = upperFirst(pluralize(entityLabels[pageListType]));
     const exportFilename = `${useCaseLabels[useCase]} ${startCase(header)} Report`;
     const entityContext = {};
 

--- a/ui/apps/platform/src/Containers/Workflow/WorkflowListPageLayout.js
+++ b/ui/apps/platform/src/Containers/Workflow/WorkflowListPageLayout.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import pluralize from 'pluralize';
+import capitalize from 'lodash/capitalize';
 import startCase from 'lodash/startCase';
 
 import { searchParams, sortParams, pagingParams } from 'constants/searchParams';
@@ -65,8 +66,8 @@ const WorkflowListPageLayout = ({ location }) => {
     const sidePanelPaging = workflowState.paging[pagingParams.sidePanel];
     const selectedRow = workflowState.getSelectedTableRow();
 
-    const header = pluralize(entityLabels[pageListType]);
-    const exportFilename = `${useCaseLabels[useCase]} ${pluralize(startCase(header))} Report`;
+    const header = capitalize(pluralize(entityLabels[pageListType]));
+    const exportFilename = `${useCaseLabels[useCase]} ${startCase(header)} Report`;
     const entityContext = {};
 
     function customCsvExportHandler(fileName) {
@@ -102,7 +103,7 @@ const WorkflowListPageLayout = ({ location }) => {
             <div className="flex flex-col relative h-full">
                 <PageHeader
                     header={header}
-                    subHeader="Entity List"
+                    subHeader="Entity list"
                     classes="pr-0 ignore-react-onclickoutside"
                 >
                     <div className="flex flex-1 justify-end h-full">

--- a/ui/apps/platform/src/utils/workflowUtils.test.ts
+++ b/ui/apps/platform/src/utils/workflowUtils.test.ts
@@ -3,7 +3,7 @@ import entityTypes from 'constants/entityTypes';
 import { getEntityState } from 'test-utils/workflowUtils';
 
 // system under test (SUT)
-import { createOptions, getOption, shouldUseOriginalCase } from './workflowUtils';
+import { createOptions, getOption } from './workflowUtils';
 
 describe('workflowUtils', () => {
     describe('createOptions', () => {
@@ -41,35 +41,6 @@ describe('workflowUtils', () => {
                 label: 'components',
                 link: '/main/configmanagement/components',
             });
-        });
-    });
-
-    describe('shouldUseOriginalCase', () => {
-        it('should be true for a image with a name', () => {
-            const entityName = 'wordpress';
-            const entityType = entityTypes.IMAGE;
-
-            const showInOriginalCase = shouldUseOriginalCase(entityName, entityType);
-
-            expect(showInOriginalCase).toBe(true);
-        });
-
-        it('should be true for a component with a name', () => {
-            const entityName = 'ncurses';
-            const entityType = entityTypes.COMPONENT;
-
-            const showInOriginalCase = shouldUseOriginalCase(entityName, entityType);
-
-            expect(showInOriginalCase).toBe(true);
-        });
-
-        it('should be false for an entity with a name, which is not an image nor compoennt', () => {
-            const entityName = 'ncurses';
-            const entityType = entityTypes.CLUSTER;
-
-            const showInOriginalCase = shouldUseOriginalCase(entityName, entityType);
-
-            expect(showInOriginalCase).toBe(false);
         });
     });
 });

--- a/ui/apps/platform/src/utils/workflowUtils.ts
+++ b/ui/apps/platform/src/utils/workflowUtils.ts
@@ -1,6 +1,5 @@
 import pluralize from 'pluralize';
 
-import entityTypes from 'constants/entityTypes';
 import entityLabels from 'messages/entity';
 
 const getLabel = (entityType) => pluralize(entityLabels[entityType]);
@@ -27,10 +26,4 @@ export function getOption(type: string, workflowState: WorkflowState): MenuLinkO
         label: getLabel(type),
         link: workflowState.resetPage(type).toUrl(),
     };
-}
-
-export function shouldUseOriginalCase(entityName: string, entityType: string): boolean {
-    return (
-        !!entityName && (entityType === entityTypes.IMAGE || entityType === entityTypes.COMPONENT)
-    );
 }


### PR DESCRIPTION
## Description

Follow up #5977

Sorry about so many files changed. Because of merge conflicts and one rebase mistake in the past few:
* part 1 is for information content of pages, except for **Residue**
* part 2 will be for buttons at upper edge of pages and entity count links at right edge of workflow pages

### Problemss

1. UPPERCASE is a serious usability problem for customer data like names of clusters, namespaces, deployments.
2. Leftover classic styles `tracking-wide`, `tracking-widest`, and `uppercase` make RedHatText font look bad.

### Analysis

Find in Files `uppercase`

|         | Results | Files |
| :---    |    ---: |  ---: |
| before  |      54 |    41 |
| deleted |      14 |    11 |
| after   |      40 |    30 |

Also `tracking-wide` delete 21 results in 16 files with #6055
Also `tracking-widest` delete 6 results in 6 files

### Solution

1. Update integration tests.
2. Call lodash `capitalize` for entity types. An alternative solution might have been to add `resourceLabelsSentenceCase` in src/messages/common.ts file.
3. Delete `capitalize`, `isUpperCase`, and `lowerCaseTitle` props.
4. Delete obsolete `Panel` component.

### Residue

1. Investigate ~heading and~ count problems for CVEs. My bad to call `capitalize` instead of `upperFirst` function.
2. Breadcrumbs `font-700` class is lifted up too high.
3. Investigate uppercase titles for select widgets
    * Configuration Management
    * Vulnerability Management

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed

### Integration testing

In ui/apps/platform folder:

1. `export CYPRESS_ROX_POSTGRES_DATASTORE=true`

2. `yarn cypress-open`

    * compliance/complianceDashboard.test.js had 3 failures
    * compliance/complianceList.test.js had 4 failures

    * configmanagement/ciscontrols.test.js had 8 failures
    * configmanagement/clusters.test.js had 24 failures
    * configmanagement/deployments.test.js had 12 failures
    * configmanagement/images.test.js had 9 failures
    * configmanagement/namespaces.test.js had 16 failures
    * configmanagement/nodes.test.js had 10 failures
    * configmanagement/policies.test.js had 7 failures
    * configmanagement/roles.test.js had 9 failures
    * configmanagement/secrets.test.js had 10 failures
    * configmanagement/serviceaccounts.test.js had 11 failures
    * configmanagement/usersandgroups.test.js had 8 failures

    * vulnmanagement/clusterCves.test.js had 4 failures
    * vulnmanagement/clusters.test.js had 8 failures
    * vulnmanagement/dashboard.test.js had 19 failures
    * vulnmanagement/deployments.test.js had 3 failures
    * vulnmanagement/entitypages.test.js had 6 failures
    * vulnmanagement/imageComponents.test.js had 5 failures
    * vulnmanagement/imageCves.test.js had 6 failures
    * vulnmanagement/images.test.js had 6 failures
    * vulnmanagement/namespaces.test.js had 5 failures
    * vulnmanagement/nodeComponents.test.js had 4 failures
    * vulnmanagement/nodeCves.test.js had 5 failures
    * vulnmanagement/nodes.test.js had 2 failures
    * vulnmanagement/policies.test.js had 4 failures
    * vulnmanagement/policyconfigure.test.js had 1 failure

To fix initial failures:
* Update heading strings for assertions.
* Replace one occurrence of internal entity type key with heading string.

### Compliance

1. Visit /main/compliance: widget titles have sentence case instead of uppercase

    * dark theme
        ![compliance_dashboard_dark](https://github.com/stackrox/stackrox/assets/11862657/c0641380-3e80-440f-8335-6bf7590c5b5e)

    * light theme: links have font-600 maybe to delete in part 2 after #6035
        ![compliance_dashboard_light](https://github.com/stackrox/stackrox/assets/11862657/95f61996-19cf-4208-9bee-4e0d310a8c5c)

2. Visit /main/compliance/deployments: page title has sentence case and table title has lowercase

    * dark theme
        ![compliance_deployments_dark](https://github.com/stackrox/stackrox/assets/11862657/f7f4e73b-647a-467f-85c5-4b085836c754)

    * light theme
        ![compliance_deployments_light](https://github.com/stackrox/stackrox/assets/11862657/ea3231c9-a1e2-4b60-83da-c8b10661f802)

3. Click a deployment: deployment name has its own case and widget titles have in this case title case

    * dark theme
        ![compliance_deploment_dark](https://github.com/stackrox/stackrox/assets/11862657/7e44a205-5cdf-4f73-9764-84c5d328b766)

    * light theme: missed opportunity in classic code to distinguish key from value
        ![compliance_deployment_light](https://github.com/stackrox/stackrox/assets/11862657/cce35363-1716-47ba-9d9b-9c15ea02fcc9)

4. Click the deployment link: see sentence case or lowercase in tabs

    * dark theme
        ![compliance_single_dark](https://github.com/stackrox/stackrox/assets/11862657/872137e8-2adc-405f-872a-fbabf5191328)

    * light theme
        ![compliance_single_light](https://github.com/stackrox/stackrox/assets/11862657/efa6e3d5-2b99-4a71-a3fd-9f3e0fd95e1b)

### Vulnerability Management

1. Visit /main/vulnerability-management: 2 widget titles have uppercase style

    * dark theme
        ![vulnerability-management_dashboard_dark](https://github.com/stackrox/stackrox/assets/11862657/3338d6c1-42e2-4ce2-8f12-7fcbcbe3bc24)

    * light theme
        ![vulnerability-management_dashboard_light](https://github.com/stackrox/stackrox/assets/11862657/47dc34dc-bc91-41a3-9f42-0111000a4bc2)

2. Visit /main/vulnerability-management/node-components: page title has sentence case and table title has lowercase

    * dark theme
        ![vulnerability-management_node-components_dark](https://github.com/stackrox/stackrox/assets/11862657/9ac5d365-5792-4785-9b08-3f4df68a52e8)

    * light theme
        ![vulnerability-management_node-components_light](https://github.com/stackrox/stackrox/assets/11862657/1db7e436-f75f-4325-8b27-f014d4947bef)

3. Click a node component: node component name has its own case, but font-700 is lifted up too high in breadcrumbs and last breadcrumb does not have CVE identifier (also on stagingdb)

    * dark theme
        ![vulnerability-management_breadcrumbs_dark](https://github.com/stackrox/stackrox/assets/11862657/cde5b993-68e5-4c53-8525-90710144317b)

    * light theme
        ![vulnerability-management_breadcrumbs_light](https://github.com/stackrox/stackrox/assets/11862657/593739f8-ea32-401d-871d-feeb4adee64d)

4. Click the single page link: missing CVE identifier (as in previous step) and incorrect case for entity type Node CVE

    * dark theme
        ![vulnerability-management_single_dark](https://github.com/stackrox/stackrox/assets/11862657/eeb0bc2b-b679-49dc-95c3-2fc0c1d9cb9c)

    * light theme
        ![vulnerability-management_single_light](https://github.com/stackrox/stackrox/assets/11862657/71aead3d-2e5d-42c5-88a0-d5d209c390de)

### Configuration Management

1. Visit /main/configmanagement: widget titles have title case instead of uppercase

    * dark theme
        ![configmanagement_dashboard_dark](https://github.com/stackrox/stackrox/assets/11862657/94df238c-aa0d-4ff4-a6b4-39cb2bad111b)

    * light theme
        ![configmanagement_dashboard_light](https://github.com/stackrox/stackrox/assets/11862657/46c17e81-f79d-4511-827f-d3d34f4b9aaf)

2. Visit /main/configmanagement/policies: page title has sentence case and table title has lowercase

    * dark theme
        ![configmanagement_policies_dark](https://github.com/stackrox/stackrox/assets/11862657/89b40481-4da5-4c8d-8dbf-505d4c913627)

    * light theme
        ![configmanagement_policies_light](https://github.com/stackrox/stackrox/assets/11862657/71b18760-2cc7-4d84-881a-93f390e7dd85)

3. Visit /main/configmanagement/subjects: ditto for multi word entity type

    * dark theme
        ![configmanagement_subjects_dark](https://github.com/stackrox/stackrox/assets/11862657/5e8037fc-4557-4012-8659-ebbe87bca45e)

    * light theme
        ![configmanagement_subjects_light](https://github.com/stackrox/stackrox/assets/11862657/9d81badc-854f-42ce-93c0-6b7a276155f0)
