### PR TITLE
R)X-16651: Filter policy criteria available based on Lifecycle Stages

### DIFF
--- a/ui/apps/platform/cypress/integration/policies/policyWizardStep3.test.js
+++ b/ui/apps/platform/cypress/integration/policies/policyWizardStep3.test.js
@@ -87,7 +87,11 @@ describe('Policy wizard, Step 3 Policy Criteria', () => {
         goToPoliciesAndCloneToStep3();
 
         cy.get(selectors.step3.policyCriteria.keyGroup).should((values) => {
-            expect(values).to.have.length(9);
+            // before we began filtering what policy criteria were available,
+            // there were 9 groups of criteria to count
+            // after filtering for Lifecycle was added, the number of groups for a Deploy-only policy is 7
+            const GROUPS_AVAILABLE_FOR_DEPLOY_POLICY = 7;
+            expect(values).to.have.length(GROUPS_AVAILABLE_FOR_DEPLOY_POLICY);
         });
 
         cy.get(`${selectors.step3.policyCriteria.key}:first`).scrollIntoView().should('be.visible');

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/BooleanPolicyLogicSection.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/BooleanPolicyLogicSection.tsx
@@ -4,6 +4,7 @@ import { useFormikContext } from 'formik';
 
 import { Policy } from 'types/policy.proto';
 import useFeatureFlags from 'hooks/useFeatureFlags';
+import { getCriteriaAllowedByLifecycle } from 'Containers/Policies/policies.utils';
 import { policyConfigurationDescriptor, auditLogDescriptor } from './policyCriteriaDescriptors';
 import PolicySection from './PolicySection';
 
@@ -27,6 +28,10 @@ function BooleanPolicyLogicSection({ readOnly = false }: BooleanPolicyLogicSecti
         }
         return true;
     });
+    const descriptorsFilteredByLifecycle = getCriteriaAllowedByLifecycle(
+        descriptors,
+        values.lifecycleStages
+    );
 
     return (
         <>
@@ -38,7 +43,7 @@ function BooleanPolicyLogicSection({ readOnly = false }: BooleanPolicyLogicSecti
                         <GridItem>
                             <PolicySection
                                 sectionIndex={sectionIndex}
-                                descriptors={descriptors}
+                                descriptors={descriptorsFilteredByLifecycle}
                                 readOnly={readOnly}
                             />
                         </GridItem>
@@ -65,7 +70,7 @@ function BooleanPolicyLogicSection({ readOnly = false }: BooleanPolicyLogicSecti
                     <React.Fragment key={sectionIndex}>
                         <PolicySection
                             sectionIndex={sectionIndex}
-                            descriptors={descriptors}
+                            descriptors={descriptorsFilteredByLifecycle}
                             readOnly={readOnly}
                         />
                         {sectionIndex !== values.policySections.length - 1 && (

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyCriteriaForm.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyCriteriaForm.tsx
@@ -6,6 +6,7 @@ import { useFormikContext } from 'formik';
 
 import { Policy } from 'types/policy.proto';
 import useFeatureFlags from 'hooks/useFeatureFlags';
+import { getCriteriaAllowedByLifecycle } from 'Containers/Policies/policies.utils';
 import { policyConfigurationDescriptor, auditLogDescriptor } from './policyCriteriaDescriptors';
 import PolicyCriteriaKeys from './PolicyCriteriaKeys';
 import BooleanPolicyLogicSection from './BooleanPolicyLogicSection';
@@ -45,6 +46,10 @@ function PolicyCriteriaForm({ hasActiveViolations }: PolicyBehaviorFormProps) {
         }
         return true;
     });
+    const descriptorsFilteredByLifecycle = getCriteriaAllowedByLifecycle(
+        descriptors,
+        values.lifecycleStages
+    );
 
     const headingElements = (
         <>
@@ -125,7 +130,7 @@ function PolicyCriteriaForm({ hasActiveViolations }: PolicyBehaviorFormProps) {
                 </Flex>
                 <Divider component="div" isVertical />
                 <Flex className="pf-u-h-100 pf-u-pt-lg" id="policy-criteria-keys-container">
-                    <PolicyCriteriaKeys keys={descriptors} />
+                    <PolicyCriteriaKeys keys={descriptorsFilteredByLifecycle} />
                 </Flex>
             </Flex>
         </DndProvider>

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/policyCriteriaDescriptors.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/policyCriteriaDescriptors.tsx
@@ -11,6 +11,7 @@ import {
 } from 'messages/common';
 import { FeatureFlagEnvVar } from 'types/featureFlag';
 import ImageSigningTableModal from 'Containers/Policies/Wizard/Step3/ImageSigningTableModal';
+import { LifecycleStage } from 'types/policy.proto';
 
 const equalityOptions: DescriptorOption[] = [
     { label: 'Is greater than', value: '>' },
@@ -47,6 +48,7 @@ const cpuResource = (label: string): GroupDescriptor => ({
         },
     ],
     canBooleanLogic: true,
+    lifecycleStages: ['DEPLOY', 'RUNTIME'],
 });
 
 const capabilities: DescriptorOption[] = [
@@ -115,6 +117,7 @@ const memoryResource = (label: string): GroupDescriptor => ({
         },
     ],
     canBooleanLogic: true,
+    lifecycleStages: ['DEPLOY', 'RUNTIME'],
 });
 
 // TODO Delete after signaturePolicyCriteria type encapsulates its behavior.
@@ -180,6 +183,7 @@ export type BaseDescriptor = {
     canBooleanLogic?: boolean;
     disabled?: boolean;
     featureFlagDependency?: FeatureFlagEnvVar;
+    lifecycleStages: LifecycleStage[];
 };
 
 export type DescriptorType =
@@ -247,6 +251,7 @@ export const policyConfigurationDescriptor: Descriptor[] = [
         type: 'text',
         placeholder: 'docker.io',
         canBooleanLogic: true,
+        lifecycleStages: ['BUILD', 'DEPLOY', 'RUNTIME'],
     },
     {
         label: 'Image remote',
@@ -258,6 +263,7 @@ export const policyConfigurationDescriptor: Descriptor[] = [
         type: 'text',
         placeholder: 'library/nginx',
         canBooleanLogic: true,
+        lifecycleStages: ['BUILD', 'DEPLOY', 'RUNTIME'],
     },
     {
         label: 'Image tag',
@@ -268,6 +274,7 @@ export const policyConfigurationDescriptor: Descriptor[] = [
         type: 'text',
         placeholder: 'latest',
         canBooleanLogic: true,
+        lifecycleStages: ['BUILD', 'DEPLOY', 'RUNTIME'],
     },
     {
         label: 'Not verified by trusted image signers',
@@ -279,6 +286,7 @@ export const policyConfigurationDescriptor: Descriptor[] = [
         tableType: 'imageSigning',
         component: ImageSigningTableModal,
         canBooleanLogic: true,
+        lifecycleStages: ['BUILD', 'DEPLOY', 'RUNTIME'],
     },
     {
         label: 'Days since image was created',
@@ -289,6 +297,7 @@ export const policyConfigurationDescriptor: Descriptor[] = [
         type: 'number',
         placeholder: '1',
         canBooleanLogic: false,
+        lifecycleStages: ['BUILD', 'DEPLOY', 'RUNTIME'],
     },
     {
         label: 'Days since image was last scanned',
@@ -299,6 +308,7 @@ export const policyConfigurationDescriptor: Descriptor[] = [
         type: 'number',
         placeholder: '1',
         canBooleanLogic: false,
+        lifecycleStages: ['BUILD', 'DEPLOY', 'RUNTIME'],
     },
     {
         label: 'Image user',
@@ -309,6 +319,7 @@ export const policyConfigurationDescriptor: Descriptor[] = [
         type: 'text',
         placeholder: '0',
         canBooleanLogic: false,
+        lifecycleStages: ['BUILD', 'DEPLOY', 'RUNTIME'],
     },
     {
         label: 'Dockerfile line',
@@ -345,6 +356,7 @@ export const policyConfigurationDescriptor: Descriptor[] = [
             },
         ],
         canBooleanLogic: true,
+        lifecycleStages: ['BUILD', 'DEPLOY', 'RUNTIME'],
     },
     {
         label: 'Image is NOT scanned',
@@ -366,6 +378,7 @@ export const policyConfigurationDescriptor: Descriptor[] = [
         defaultValue: true,
         disabled: true,
         canBooleanLogic: false,
+        lifecycleStages: ['BUILD', 'DEPLOY', 'RUNTIME'],
     },
     {
         label: 'CVSS',
@@ -389,6 +402,7 @@ export const policyConfigurationDescriptor: Descriptor[] = [
             },
         ],
         canBooleanLogic: true,
+        lifecycleStages: ['BUILD', 'DEPLOY', 'RUNTIME'],
     },
     {
         label: 'Severity',
@@ -414,6 +428,7 @@ export const policyConfigurationDescriptor: Descriptor[] = [
         ],
         default: false,
         canBooleanLogic: true,
+        lifecycleStages: ['BUILD', 'DEPLOY', 'RUNTIME'],
     },
     {
         label: 'Fixed by',
@@ -425,6 +440,7 @@ export const policyConfigurationDescriptor: Descriptor[] = [
         type: 'text',
         placeholder: '.*',
         canBooleanLogic: true,
+        lifecycleStages: ['BUILD', 'DEPLOY', 'RUNTIME'],
     },
     {
         label: 'CVE',
@@ -435,6 +451,7 @@ export const policyConfigurationDescriptor: Descriptor[] = [
         type: 'text',
         placeholder: 'CVE-2017-11882',
         canBooleanLogic: true,
+        lifecycleStages: ['BUILD', 'DEPLOY', 'RUNTIME'],
     },
     {
         label: 'Image component',
@@ -457,6 +474,7 @@ export const policyConfigurationDescriptor: Descriptor[] = [
             },
         ],
         canBooleanLogic: true,
+        lifecycleStages: ['BUILD', 'DEPLOY', 'RUNTIME'],
     },
     {
         label: 'Image OS',
@@ -467,6 +485,7 @@ export const policyConfigurationDescriptor: Descriptor[] = [
         type: 'text',
         placeholder: 'ubuntu:19.04',
         canBooleanLogic: true,
+        lifecycleStages: ['BUILD', 'DEPLOY', 'RUNTIME'],
     },
     {
         label: 'Environment variable',
@@ -499,6 +518,7 @@ export const policyConfigurationDescriptor: Descriptor[] = [
             },
         ],
         canBooleanLogic: true,
+        lifecycleStages: ['DEPLOY', 'RUNTIME'],
     },
     {
         label: 'Disallowed annotation',
@@ -521,6 +541,7 @@ export const policyConfigurationDescriptor: Descriptor[] = [
             },
         ],
         canBooleanLogic: true,
+        lifecycleStages: ['DEPLOY', 'RUNTIME'],
     },
     {
         label: 'Required label',
@@ -544,6 +565,7 @@ export const policyConfigurationDescriptor: Descriptor[] = [
             },
         ],
         canBooleanLogic: true,
+        lifecycleStages: ['DEPLOY', 'RUNTIME'],
     },
     {
         label: 'Required annotation',
@@ -567,6 +589,7 @@ export const policyConfigurationDescriptor: Descriptor[] = [
             },
         ],
         canBooleanLogic: true,
+        lifecycleStages: ['DEPLOY', 'RUNTIME'],
     },
     {
         label: 'Runtime class',
@@ -577,6 +600,7 @@ export const policyConfigurationDescriptor: Descriptor[] = [
         type: 'text',
         placeholder: 'kata',
         canBooleanLogic: true,
+        lifecycleStages: ['DEPLOY', 'RUNTIME'],
     },
     {
         label: 'Volume name',
@@ -587,6 +611,7 @@ export const policyConfigurationDescriptor: Descriptor[] = [
         type: 'text',
         placeholder: 'docker-socket',
         canBooleanLogic: true,
+        lifecycleStages: ['DEPLOY', 'RUNTIME'],
     },
     {
         label: 'Volume source',
@@ -597,6 +622,7 @@ export const policyConfigurationDescriptor: Descriptor[] = [
         type: 'text',
         placeholder: '/var/run/docker.sock',
         canBooleanLogic: true,
+        lifecycleStages: ['DEPLOY', 'RUNTIME'],
     },
     {
         label: 'Volume destination',
@@ -607,6 +633,7 @@ export const policyConfigurationDescriptor: Descriptor[] = [
         type: 'text',
         placeholder: '/var/run/docker.sock',
         canBooleanLogic: true,
+        lifecycleStages: ['DEPLOY', 'RUNTIME'],
     },
     {
         label: 'Volume type',
@@ -617,6 +644,7 @@ export const policyConfigurationDescriptor: Descriptor[] = [
         type: 'text',
         placeholder: 'bind, secret',
         canBooleanLogic: true,
+        lifecycleStages: ['DEPLOY', 'RUNTIME'],
     },
     {
         label: 'Writable mounted volume',
@@ -638,6 +666,7 @@ export const policyConfigurationDescriptor: Descriptor[] = [
         defaultValue: false,
         reverse: true,
         canBooleanLogic: false,
+        lifecycleStages: ['DEPLOY', 'RUNTIME'],
     },
     {
         name: 'Mount Propagation',
@@ -650,6 +679,7 @@ export const policyConfigurationDescriptor: Descriptor[] = [
             value: key,
         })),
         canBooleanLogic: true,
+        lifecycleStages: ['DEPLOY', 'RUNTIME'],
     },
     {
         label: 'Protocol',
@@ -660,6 +690,7 @@ export const policyConfigurationDescriptor: Descriptor[] = [
         type: 'text',
         placeholder: 'tcp',
         canBooleanLogic: true,
+        lifecycleStages: ['DEPLOY', 'RUNTIME'],
     },
     {
         label: 'Exposed node port',
@@ -670,6 +701,7 @@ export const policyConfigurationDescriptor: Descriptor[] = [
         type: 'text',
         placeholder: '22',
         canBooleanLogic: true,
+        lifecycleStages: ['DEPLOY', 'RUNTIME'],
     },
     {
         label: 'Port',
@@ -680,6 +712,7 @@ export const policyConfigurationDescriptor: Descriptor[] = [
         type: 'number',
         placeholder: '22',
         canBooleanLogic: true,
+        lifecycleStages: ['DEPLOY', 'RUNTIME'],
     },
     {
         label: 'Port Exposure',
@@ -695,6 +728,7 @@ export const policyConfigurationDescriptor: Descriptor[] = [
                 value: key,
             })),
         canBooleanLogic: true,
+        lifecycleStages: ['DEPLOY', 'RUNTIME'],
     },
     {
         label: 'Network baselining enabled',
@@ -710,6 +744,7 @@ export const policyConfigurationDescriptor: Descriptor[] = [
         defaultValue: false,
         reverse: false,
         canBooleanLogic: false,
+        lifecycleStages: ['RUNTIME'],
     },
     {
         label: 'Ingress Network Policy',
@@ -731,6 +766,7 @@ export const policyConfigurationDescriptor: Descriptor[] = [
         defaultValue: false,
         canBooleanLogic: false,
         featureFlagDependency: 'ROX_NETPOL_FIELDS',
+        lifecycleStages: ['DEPLOY', 'RUNTIME'],
     },
     {
         label: 'Egress Network Policy',
@@ -751,6 +787,7 @@ export const policyConfigurationDescriptor: Descriptor[] = [
         ],
         defaultValue: false,
         canBooleanLogic: false,
+        lifecycleStages: ['DEPLOY', 'RUNTIME'],
         featureFlagDependency: 'ROX_NETPOL_FIELDS',
     },
     cpuResource('Container CPU request'),
@@ -777,6 +814,7 @@ export const policyConfigurationDescriptor: Descriptor[] = [
         defaultValue: true,
         disabled: true,
         canBooleanLogic: false,
+        lifecycleStages: ['DEPLOY', 'RUNTIME'],
     },
     {
         label: 'Read-only root filesystem',
@@ -798,6 +836,7 @@ export const policyConfigurationDescriptor: Descriptor[] = [
         defaultValue: false,
         disabled: true,
         canBooleanLogic: false,
+        lifecycleStages: ['DEPLOY', 'RUNTIME'],
     },
     {
         label: 'Seccomp profile type',
@@ -811,6 +850,7 @@ export const policyConfigurationDescriptor: Descriptor[] = [
             value: key,
         })),
         canBooleanLogic: false,
+        lifecycleStages: ['DEPLOY', 'RUNTIME'],
     },
     {
         label: 'Privilege escalation',
@@ -832,6 +872,7 @@ export const policyConfigurationDescriptor: Descriptor[] = [
         defaultValue: true,
         disabled: true,
         canBooleanLogic: false,
+        lifecycleStages: ['DEPLOY', 'RUNTIME'],
     },
     {
         label: 'Share host network namespace',
@@ -853,6 +894,7 @@ export const policyConfigurationDescriptor: Descriptor[] = [
         defaultValue: true,
         disabled: true,
         canBooleanLogic: false,
+        lifecycleStages: ['DEPLOY', 'RUNTIME'],
     },
     {
         label: 'Share host PID namespace',
@@ -873,6 +915,7 @@ export const policyConfigurationDescriptor: Descriptor[] = [
         defaultValue: true,
         disabled: true,
         canBooleanLogic: false,
+        lifecycleStages: ['DEPLOY', 'RUNTIME'],
     },
     {
         label: 'Share host IPC namespace',
@@ -893,6 +936,7 @@ export const policyConfigurationDescriptor: Descriptor[] = [
         defaultValue: true,
         disabled: true,
         canBooleanLogic: false,
+        lifecycleStages: ['DEPLOY', 'RUNTIME'],
     },
     {
         name: 'Drop Capabilities',
@@ -901,6 +945,7 @@ export const policyConfigurationDescriptor: Descriptor[] = [
         type: 'select',
         options: [...capabilities],
         canBooleanLogic: true,
+        lifecycleStages: ['DEPLOY', 'RUNTIME'],
     },
     {
         name: 'Add Capabilities',
@@ -909,6 +954,7 @@ export const policyConfigurationDescriptor: Descriptor[] = [
         type: 'select',
         options: [...capabilities],
         canBooleanLogic: true,
+        lifecycleStages: ['DEPLOY', 'RUNTIME'],
     },
     {
         name: 'Process Name',
@@ -918,6 +964,7 @@ export const policyConfigurationDescriptor: Descriptor[] = [
         type: 'text',
         placeholder: 'apt-get',
         canBooleanLogic: true,
+        lifecycleStages: ['RUNTIME'],
     },
     {
         name: 'Process Ancestor',
@@ -927,6 +974,7 @@ export const policyConfigurationDescriptor: Descriptor[] = [
         type: 'text',
         placeholder: 'java',
         canBooleanLogic: true,
+        lifecycleStages: ['RUNTIME'],
     },
     {
         name: 'Process Arguments',
@@ -936,6 +984,7 @@ export const policyConfigurationDescriptor: Descriptor[] = [
         type: 'text',
         placeholder: 'install nmap',
         canBooleanLogic: true,
+        lifecycleStages: ['RUNTIME'],
     },
     {
         label: 'Process UID',
@@ -945,6 +994,7 @@ export const policyConfigurationDescriptor: Descriptor[] = [
         type: 'text',
         placeholder: '0',
         canBooleanLogic: true,
+        lifecycleStages: ['RUNTIME'],
     },
     {
         name: 'Writable Host Mount',
@@ -966,6 +1016,7 @@ export const policyConfigurationDescriptor: Descriptor[] = [
         reverse: true,
         disabled: true,
         canBooleanLogic: false,
+        lifecycleStages: ['DEPLOY', 'RUNTIME'],
     },
     {
         label: 'Process baselining enabled',
@@ -981,6 +1032,7 @@ export const policyConfigurationDescriptor: Descriptor[] = [
         defaultValue: false,
         reverse: false,
         canBooleanLogic: false,
+        lifecycleStages: ['RUNTIME'],
     },
     {
         label: 'Service account',
@@ -991,6 +1043,7 @@ export const policyConfigurationDescriptor: Descriptor[] = [
         category: policyCriteriaCategories.KUBERNETES_ACCESS,
         type: 'text',
         canBooleanLogic: true,
+        lifecycleStages: ['DEPLOY', 'RUNTIME'],
     },
     {
         label: 'Automount service account token',
@@ -1011,6 +1064,7 @@ export const policyConfigurationDescriptor: Descriptor[] = [
         ],
         defaultValue: false,
         canBooleanLogic: false,
+        lifecycleStages: ['DEPLOY', 'RUNTIME'],
     },
     {
         label: 'Minimum RBAC permissions',
@@ -1025,6 +1079,7 @@ export const policyConfigurationDescriptor: Descriptor[] = [
             value: key,
         })),
         canBooleanLogic: false,
+        lifecycleStages: ['DEPLOY', 'RUNTIME'],
     },
     {
         label: 'Required image label',
@@ -1047,6 +1102,7 @@ export const policyConfigurationDescriptor: Descriptor[] = [
             },
         ],
         canBooleanLogic: true,
+        lifecycleStages: ['BUILD', 'DEPLOY', 'RUNTIME'],
     },
     {
         label: 'Disallowed image label',
@@ -1069,6 +1125,7 @@ export const policyConfigurationDescriptor: Descriptor[] = [
             },
         ],
         canBooleanLogic: true,
+        lifecycleStages: ['BUILD', 'DEPLOY', 'RUNTIME'],
     },
     {
         label: 'Namespace',
@@ -1079,6 +1136,7 @@ export const policyConfigurationDescriptor: Descriptor[] = [
         type: 'text',
         placeholder: 'default',
         canBooleanLogic: true,
+        lifecycleStages: ['DEPLOY', 'RUNTIME'],
     },
     {
         label: 'Container name',
@@ -1090,6 +1148,7 @@ export const policyConfigurationDescriptor: Descriptor[] = [
         type: 'text',
         placeholder: 'default',
         canBooleanLogic: true,
+        lifecycleStages: ['DEPLOY', 'RUNTIME'],
     },
     {
         label: 'AppArmor profile',
@@ -1101,6 +1160,7 @@ export const policyConfigurationDescriptor: Descriptor[] = [
         type: 'text',
         placeholder: 'default',
         canBooleanLogic: true,
+        lifecycleStages: ['DEPLOY', 'RUNTIME'],
     },
     {
         label: 'Kubernetes action',
@@ -1120,6 +1180,7 @@ export const policyConfigurationDescriptor: Descriptor[] = [
             },
         ],
         canBooleanLogic: false,
+        lifecycleStages: ['RUNTIME'],
     },
     {
         label: 'Kubernetes user name',
@@ -1129,6 +1190,7 @@ export const policyConfigurationDescriptor: Descriptor[] = [
         category: policyCriteriaCategories.KUBERNETES_EVENTS,
         type: 'text',
         canBooleanLogic: false,
+        lifecycleStages: ['RUNTIME'],
     },
     {
         label: 'Kubernetes user groups',
@@ -1137,6 +1199,7 @@ export const policyConfigurationDescriptor: Descriptor[] = [
         category: policyCriteriaCategories.KUBERNETES_EVENTS,
         type: 'text',
         canBooleanLogic: false,
+        lifecycleStages: ['RUNTIME'],
     },
     {
         label: 'Replicas',
@@ -1160,6 +1223,7 @@ export const policyConfigurationDescriptor: Descriptor[] = [
             },
         ],
         canBooleanLogic: true,
+        lifecycleStages: ['DEPLOY', 'RUNTIME'],
     },
     {
         label: 'Liveness probe',
@@ -1180,6 +1244,7 @@ export const policyConfigurationDescriptor: Descriptor[] = [
         ],
         defaultValue: false,
         canBooleanLogic: false,
+        lifecycleStages: ['DEPLOY', 'RUNTIME'],
     },
     {
         label: 'Readiness probe',
@@ -1200,6 +1265,7 @@ export const policyConfigurationDescriptor: Descriptor[] = [
         ],
         defaultValue: false,
         canBooleanLogic: false,
+        lifecycleStages: ['DEPLOY', 'RUNTIME'],
     },
 ];
 
@@ -1222,6 +1288,7 @@ export const auditLogDescriptor: Descriptor[] = [
             },
         ],
         canBooleanLogic: false,
+        lifecycleStages: ['RUNTIME'],
     },
     {
         label: 'Kubernetes API verb',
@@ -1232,6 +1299,7 @@ export const auditLogDescriptor: Descriptor[] = [
         placeholder: 'Select an API verb',
         options: APIVerbs,
         canBooleanLogic: false,
+        lifecycleStages: ['RUNTIME'],
     },
     {
         label: 'Kubernetes resource name',
@@ -1241,6 +1309,7 @@ export const auditLogDescriptor: Descriptor[] = [
         category: policyCriteriaCategories.KUBERNETES_EVENTS,
         type: 'text',
         canBooleanLogic: false,
+        lifecycleStages: ['RUNTIME'],
     },
     {
         label: 'Kubernetes user name',
@@ -1250,6 +1319,7 @@ export const auditLogDescriptor: Descriptor[] = [
         category: policyCriteriaCategories.KUBERNETES_EVENTS,
         type: 'text',
         canBooleanLogic: false,
+        lifecycleStages: ['RUNTIME'],
     },
     {
         label: 'Kubernetes user group',
@@ -1258,6 +1328,7 @@ export const auditLogDescriptor: Descriptor[] = [
         category: policyCriteriaCategories.KUBERNETES_EVENTS,
         type: 'text',
         canBooleanLogic: false,
+        lifecycleStages: ['RUNTIME'],
     },
     {
         label: 'User agent',
@@ -1267,6 +1338,7 @@ export const auditLogDescriptor: Descriptor[] = [
         category: policyCriteriaCategories.KUBERNETES_EVENTS,
         type: 'text',
         canBooleanLogic: false,
+        lifecycleStages: ['RUNTIME'],
     },
     {
         label: 'Source IP address',
@@ -1276,6 +1348,7 @@ export const auditLogDescriptor: Descriptor[] = [
         category: policyCriteriaCategories.KUBERNETES_EVENTS,
         type: 'text',
         canBooleanLogic: false,
+        lifecycleStages: ['RUNTIME'],
     },
     {
         label: 'Is impersonated user',
@@ -1288,5 +1361,6 @@ export const auditLogDescriptor: Descriptor[] = [
             { text: 'False', value: false },
         ],
         canBooleanLogic: false,
+        lifecycleStages: ['RUNTIME'],
     },
 ];

--- a/ui/apps/platform/src/Containers/Policies/policies.utils.ts
+++ b/ui/apps/platform/src/Containers/Policies/policies.utils.ts
@@ -22,7 +22,8 @@ import {
 } from 'types/policy.proto';
 import { SearchFilter } from 'types/search';
 import { ExtendedPageAction } from 'utils/queryStringUtils';
-import { imageSigningCriteriaName } from './Wizard/Step3/policyCriteriaDescriptors';
+import { checkArrayContainsArray } from 'utils/arrayUtils';
+import { imageSigningCriteriaName, Descriptor } from './Wizard/Step3/policyCriteriaDescriptors';
 
 function isValidAction(action: unknown): action is ExtendedPageAction {
     return action === 'clone' || action === 'create' || action === 'edit' || action === 'generate';
@@ -685,4 +686,15 @@ export function getLifeCyclesUpdates(
         );
     }
     return changedValues;
+}
+
+export function getCriteriaAllowedByLifecycle(
+    criteria: Descriptor[],
+    lifecycleStages: LifecycleStage[]
+) {
+    const filteredCriteria = criteria.filter((criterion) =>
+        checkArrayContainsArray(criterion.lifecycleStages, lifecycleStages)
+    );
+
+    return filteredCriteria;
 }

--- a/ui/apps/platform/src/utils/arrayUtils.test.ts
+++ b/ui/apps/platform/src/utils/arrayUtils.test.ts
@@ -1,0 +1,41 @@
+import { checkArrayContainsArray } from './arrayUtils';
+
+describe('arrayUtils', () => {
+    describe('checkArrayContainsArray', () => {
+        it('should return false when no overlap in arrays', () => {
+            const allowed = ['BUILD', 'DEPLOY'];
+            const candidate = ['RUNTIME'];
+
+            const doesContain = checkArrayContainsArray(allowed, candidate);
+
+            expect(doesContain).toBe(false);
+        });
+
+        it('should return false when only partial overlap in arrays', () => {
+            const allowed = ['BUILD', 'DEPLOY'];
+            const candidate = ['BUILD', 'RUNTIME'];
+
+            const doesContain = checkArrayContainsArray(allowed, candidate);
+
+            expect(doesContain).toBe(false);
+        });
+
+        it('should return true when when single-element arrays for both args overlap', () => {
+            const allowed = ['RUNTIME'];
+            const candidate = ['RUNTIME'];
+
+            const doesContain = checkArrayContainsArray(allowed, candidate);
+
+            expect(doesContain).toBe(true);
+        });
+
+        it('should return true when when multi-element array is contained allowed array', () => {
+            const allowed = ['BUILD', 'DEPLOY', 'RUNTIME'];
+            const candidate = ['DEPLOY', 'RUNTIME'];
+
+            const doesContain = checkArrayContainsArray(allowed, candidate);
+
+            expect(doesContain).toBe(true);
+        });
+    });
+});

--- a/ui/apps/platform/src/utils/arrayUtils.ts
+++ b/ui/apps/platform/src/utils/arrayUtils.ts
@@ -1,0 +1,3 @@
+export function checkArrayContainsArray(allowedArray: string[], candidateArray: string[]) {
+    return candidateArray.every((candidate) => allowedArray.includes(candidate));
+}


### PR DESCRIPTION
## Description

This PR contains two related additions:
1. Add the Lifecycle Stages that are allowed for each policy criterion to that criterion's descriptor in `ui/apps/platform/src/Containers/Policies/Wizard/Step3/policyCriteriaDescriptors.tsx`, based on the newly-updated policy documentation in this spreadsheet, https://docs.google.com/spreadsheets/d/17TSHuhtbktVrHvbqfgChc8m7RxNyfILNGFYWZ4PTYdU/edit#gid=63129838 
2. Use those allowed Lifecycle Stages to filter the criteria available in Step 3 of the Policy edit wizard. There was already a chain of conditionals for which criteria to show (based on various checks). This just adds one final filter to that chain, by a policy-specific utility function which in turn calls a potentially-reusable new array filtering function.

Example of the filter logic:
* A user chooses Lifecycles Stages of DEPLOY and RUNTIME
* The criterion Image Age is shown because it has allowed stages of ['BUILD', 'DEPLOY', 'RUNTIME']
* The criterion Kubernetes Resource is not shown because it only has the allowed stage of ['RUNTIME'], and so it doesn't include the DEPLOY part of the chosen Lifecycles.


## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added


## Testing Performed

* Added unit tests for the new array filtering function
* Manually tested various combinations of chosen Lifecycles

---
Build only
<img width="1532" alt="build_only" src="https://github.com/stackrox/stackrox/assets/715729/193387c1-53c8-41a8-be2c-14e1f2dd3915">

Very limited set of criteria shown, only those that include BUILD
<img width="1532" alt="very_limited_build_and_deploy_criteria_because_of_build_stage" src="https://github.com/stackrox/stackrox/assets/715729/ed148f31-f0fc-4302-9a0e-31bcf12bb3df">

---
Build and Deploy
<img width="1532" alt="build_and_deploy" src="https://github.com/stackrox/stackrox/assets/715729/1542b6d9-84e1-487e-adb3-ef37aaa8da60">

Still a very limited set of criteria shown, only those that include BUILD (and also DEPLOY, which happens to be a superset of the BUILD criteria)
<img width="1532" alt="very_limited_build_and_deploy_criteria_because_of_build_stage" src="https://github.com/stackrox/stackrox/assets/715729/9a123caf-c297-408c-82a3-4cf2ff5eeff1">

---
Deploy only
<img width="1532" alt="deploy_only" src="https://github.com/stackrox/stackrox/assets/715729/47ad9122-a224-46b5-873a-849dd6cae9f1">

Deploy only has a lot more available criteria
<img width="1532" alt="deploy_only_has_a_lot_more_criteria" src="https://github.com/stackrox/stackrox/assets/715729/d9de3307-17fd-404b-8a86-6463a4ab0551">

---
Deploy and Runtime
<img width="1532" alt="deploy_and_runtime" src="https://github.com/stackrox/stackrox/assets/715729/2918859d-b493-497a-a703-caec987d2b99">

Deploy and Runtime have a lot more criteria, but no Runtime-only criteria
<img width="1532" alt="deploy_and_runtime_has_a_lot_more_criteria_but_no_runtime_only" src="https://github.com/stackrox/stackrox/assets/715729/7e9c64b9-5a70-4c1e-a1e0-39fbde0df3d5">

---
Runtime only, Deployment event source
<img width="1532" alt="runtime_only" src="https://github.com/stackrox/stackrox/assets/715729/07ec73cf-95f7-4035-ad6a-161486589b35">

Runtime only has the most criteria, including Process and Events criteria
<img width="1539" alt="runtime_only_has_the_most_criteria_including_process_and_events" src="https://github.com/stackrox/stackrox/assets/715729/52d21a27-8a08-45f9-8b09-92c78d8971a9">

---
Runtime only, Audit Log event source
<img width="1539" alt="runtime_with_audit_log" src="https://github.com/stackrox/stackrox/assets/715729/a3d5f77c-41c5-4993-877f-6b40c0951b9d">

Runtime with Audit Log event source only has k8s Events criteria (this is actually no change from current behavior)
<img width="1539" alt="runtime_with_audit_log_only_has_k8s_events_criteria" src="https://github.com/stackrox/stackrox/assets/715729/affae86d-9aa5-4edf-b1f3-39de459d4a10">



