### PR TITLE
Workflow CVEs: Updating severity count labels

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
@@ -53,6 +53,7 @@ import BySeveritySummaryCard, {
 } from '../SummaryCards/BySeveritySummaryCard';
 import { resourceCountByCveSeverityAndStatusFragment } from '../SummaryCards/CvesByStatusSummaryCard';
 import { Resource } from '../components/FilterResourceDropdown';
+import { VulnerabilitySeverityLabel } from '../types';
 
 const workloadCveOverviewImagePath = getOverviewCvesPath({
     cveStatusTab: 'Observed',
@@ -408,6 +409,9 @@ function ImageCvePage() {
                                                 deployments={deploymentData?.deployments ?? []}
                                                 getSortParams={getSortParams}
                                                 isFiltered={isFiltered}
+                                                filteredSeverities={
+                                                    searchFilter.Severity as VulnerabilitySeverityLabel[]
+                                                }
                                             />
                                         )}
                                     </div>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/CVEsTableContainer.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/CVEsTableContainer.tsx
@@ -9,7 +9,7 @@ import { getHasSearchApplied, getRequestQueryStringForSearchFilter } from 'utils
 import CVEsTable, { cveListQuery, unfilteredImageCountQuery } from '../Tables/CVEsTable';
 import TableErrorComponent from '../components/TableErrorComponent';
 import { EntityCounts } from '../components/EntityTypeToggleGroup';
-import { DefaultFilters } from '../types';
+import { DefaultFilters, VulnerabilitySeverityLabel } from '../types';
 import { parseQuerySearchFilter } from '../searchUtils';
 import { defaultCVESortFields, CVEsDefaultSort } from '../sortUtils';
 import TableEntityToolbar from '../components/TableEntityToolbar';
@@ -73,6 +73,7 @@ function CVEsTableContainer({ defaultFilters, countsData }: CVEsTableContainerPr
                         unfilteredImageCount={imageCountData?.imageCount || 0}
                         getSortParams={getSortParams}
                         isFiltered={isFiltered}
+                        filteredSeverities={searchFilter.Severity as VulnerabilitySeverityLabel[]}
                     />
                 </div>
             )}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/DeploymentsTableContainer.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/DeploymentsTableContainer.tsx
@@ -12,7 +12,7 @@ import TableEntityToolbar from '../components/TableEntityToolbar';
 import { EntityCounts } from '../components/EntityTypeToggleGroup';
 import { parseQuerySearchFilter } from '../searchUtils';
 import { defaultDeploymentSortFields, deploymentsDefaultSort } from '../sortUtils';
-import { DefaultFilters } from '../types';
+import { DefaultFilters, VulnerabilitySeverityLabel } from '../types';
 
 type DeploymentsTableContainerProps = {
     defaultFilters: DefaultFilters;
@@ -72,6 +72,7 @@ function DeploymentsTableContainer({ defaultFilters, countsData }: DeploymentsTa
                         deployments={tableData.deployments}
                         getSortParams={getSortParams}
                         isFiltered={isFiltered}
+                        filteredSeverities={searchFilter.Severity as VulnerabilitySeverityLabel[]}
                     />
                 </div>
             )}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/ImagesTableContainer.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/ImagesTableContainer.tsx
@@ -71,6 +71,7 @@ function ImagesTableContainer({ defaultFilters, countsData }: ImagesTableContain
                         images={tableData.images}
                         getSortParams={getSortParams}
                         isFiltered={isFiltered}
+                        filteredSeverities={searchFilter.Severity}
                     />
                 </div>
             )}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/ImagesTableContainer.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/ImagesTableContainer.tsx
@@ -71,7 +71,7 @@ function ImagesTableContainer({ defaultFilters, countsData }: ImagesTableContain
                         images={tableData.images}
                         getSortParams={getSortParams}
                         isFiltered={isFiltered}
-                        filteredSeverities={searchFilter.Severity}
+                        filteredSeverities={searchFilter.Severity as VulnerabilitySeverityLabel[]}
                     />
                 </div>
             )}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/ImagesTableContainer.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/ImagesTableContainer.tsx
@@ -11,7 +11,7 @@ import TableErrorComponent from '../components/TableErrorComponent';
 import { EntityCounts } from '../components/EntityTypeToggleGroup';
 import { parseQuerySearchFilter } from '../searchUtils';
 import { defaultImageSortFields, imagesDefaultSort } from '../sortUtils';
-import { DefaultFilters } from '../types';
+import { DefaultFilters, VulnerabilitySeverityLabel } from '../types';
 import TableEntityToolbar from '../components/TableEntityToolbar';
 
 type ImagesTableContainerProps = {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedDeploymentsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedDeploymentsTable.tsx
@@ -25,6 +25,7 @@ import DeploymentComponentVulnerabilitiesTable, {
 } from './DeploymentComponentVulnerabilitiesTable';
 import SeverityCountLabels from '../components/SeverityCountLabels';
 import DatePhraseTd from '../components/DatePhraseTd';
+import { VulnerabilitySeverityLabel } from '../types';
 
 export type DeploymentForCve = {
     id: string;
@@ -67,12 +68,14 @@ export type AffectedDeploymentsTableProps = {
     deployments: DeploymentForCve[];
     getSortParams: UseURLSortResult['getSortParams'];
     isFiltered: boolean;
+    filteredSeverities?: VulnerabilitySeverityLabel[];
 };
 
 function AffectedDeploymentsTable({
     deployments,
     getSortParams,
     isFiltered,
+    filteredSeverities,
 }: AffectedDeploymentsTableProps) {
     const expandedRowSet = useSet<string>();
     return (
@@ -145,10 +148,12 @@ function AffectedDeploymentsTable({
                             </Td>
                             <Td modifier="nowrap" dataLabel="Images by severity">
                                 <SeverityCountLabels
-                                    critical={criticalImageCount}
-                                    important={importantImageCount}
-                                    moderate={moderateImageCount}
-                                    low={lowImageCount}
+                                    criticalCount={criticalImageCount}
+                                    importantCount={importantImageCount}
+                                    moderateCount={moderateImageCount}
+                                    lowCount={lowImageCount}
+                                    isFiltered={isFiltered}
+                                    filteredSeverities={filteredSeverities}
                                 />
                             </Td>
                             <Td dataLabel="Cluster">{clusterName}</Td>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedDeploymentsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedDeploymentsTable.tsx
@@ -152,7 +152,6 @@ function AffectedDeploymentsTable({
                                     importantCount={importantImageCount}
                                     moderateCount={moderateImageCount}
                                     lowCount={lowImageCount}
-                                    isFiltered={isFiltered}
                                     filteredSeverities={filteredSeverities}
                                 />
                             </Td>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/CVEsTable.tsx
@@ -14,7 +14,7 @@ import { Button, ButtonVariant } from '@patternfly/react-core';
 import LinkShim from 'Components/PatternFly/LinkShim';
 import { UseURLSortResult } from 'hooks/useURLSort';
 import useSet from 'hooks/useSet';
-
+import { VulnerabilitySeverityLabel } from '../types';
 import { getEntityPagePath } from '../searchUtils';
 import TooltipTh from '../components/TooltipTh';
 import SeverityCountLabels from '../components/SeverityCountLabels';
@@ -72,10 +72,18 @@ type CVEsTableProps = {
     unfilteredImageCount: number;
     getSortParams: UseURLSortResult['getSortParams'];
     isFiltered: boolean;
+    filteredSeverities?: VulnerabilitySeverityLabel[];
 };
 
-function CVEsTable({ cves, unfilteredImageCount, getSortParams, isFiltered }: CVEsTableProps) {
+function CVEsTable({
+    cves,
+    unfilteredImageCount,
+    getSortParams,
+    isFiltered,
+    filteredSeverities,
+}: CVEsTableProps) {
     const expandedRowSet = useSet<string>();
+
     return (
         <TableComposable borders={false} variant="compact">
             <Thead noWrap>
@@ -113,6 +121,10 @@ function CVEsTable({ cves, unfilteredImageCount, getSortParams, isFiltered }: CV
                     rowIndex
                 ) => {
                     const isExpanded = expandedRowSet.has(cve);
+                    const criticalCount = affectedImageCountBySeverity.critical.total;
+                    const importantCount = affectedImageCountBySeverity.important.total;
+                    const moderateCount = affectedImageCountBySeverity.moderate.total;
+                    const lowCount = affectedImageCountBySeverity.low.total;
 
                     return (
                         <Tbody
@@ -142,10 +154,12 @@ function CVEsTable({ cves, unfilteredImageCount, getSortParams, isFiltered }: CV
                                 </Td>
                                 <Td>
                                     <SeverityCountLabels
-                                        critical={affectedImageCountBySeverity.critical.total}
-                                        important={affectedImageCountBySeverity.important.total}
-                                        moderate={affectedImageCountBySeverity.moderate.total}
-                                        low={affectedImageCountBySeverity.low.total}
+                                        criticalCount={criticalCount}
+                                        importantCount={importantCount}
+                                        moderateCount={moderateCount}
+                                        lowCount={lowCount}
+                                        isFiltered={isFiltered}
+                                        filteredSeverities={filteredSeverities}
                                     />
                                 </Td>
                                 {/* TODO: score version? */}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/CVEsTable.tsx
@@ -158,7 +158,6 @@ function CVEsTable({
                                         importantCount={importantCount}
                                         moderateCount={moderateCount}
                                         lowCount={lowCount}
-                                        isFiltered={isFiltered}
                                         filteredSeverities={filteredSeverities}
                                     />
                                 </Td>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentsTable.tsx
@@ -12,6 +12,7 @@ import { DynamicColumnIcon } from '../components/DynamicIcon';
 import EmptyTableResults from '../components/EmptyTableResults';
 import DatePhraseTd from '../components/DatePhraseTd';
 import TooltipTh from '../components/TooltipTh';
+import { VulnerabilitySeverityLabel } from '../types';
 
 export const deploymentListQuery = gql`
     query getDeploymentList($query: String, $pagination: Pagination) {
@@ -59,9 +60,15 @@ type DeploymentsTableProps = {
     deployments: Deployment[];
     getSortParams: UseURLSortResult['getSortParams'];
     isFiltered: boolean;
+    filteredSeverities?: VulnerabilitySeverityLabel[];
 };
 
-function DeploymentsTable({ deployments, getSortParams, isFiltered }: DeploymentsTableProps) {
+function DeploymentsTable({
+    deployments,
+    getSortParams,
+    isFiltered,
+    filteredSeverities,
+}: DeploymentsTableProps) {
     return (
         <TableComposable borders={false} variant="compact">
             <Thead noWrap>
@@ -92,6 +99,10 @@ function DeploymentsTable({ deployments, getSortParams, isFiltered }: Deployment
                     imageCount,
                     created,
                 }) => {
+                    const criticalCount = imageCVECountBySeverity.critical.total;
+                    const importantCount = imageCVECountBySeverity.important.total;
+                    const moderateCount = imageCVECountBySeverity.moderate.total;
+                    const lowCount = imageCVECountBySeverity.low.total;
                     return (
                         <Tbody
                             key={id}
@@ -112,11 +123,13 @@ function DeploymentsTable({ deployments, getSortParams, isFiltered }: Deployment
                                 </Td>
                                 <Td>
                                     <SeverityCountLabels
-                                        critical={imageCVECountBySeverity.critical.total}
-                                        important={imageCVECountBySeverity.important.total}
-                                        moderate={imageCVECountBySeverity.moderate.total}
-                                        low={imageCVECountBySeverity.low.total}
+                                        criticalCount={criticalCount}
+                                        importantCount={importantCount}
+                                        moderateCount={moderateCount}
+                                        lowCount={lowCount}
                                         entity="deployment"
+                                        isFiltered={isFiltered}
+                                        filteredSeverities={filteredSeverities}
                                     />
                                 </Td>
                                 <Td>{clusterName}</Td>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentsTable.tsx
@@ -128,7 +128,6 @@ function DeploymentsTable({
                                         moderateCount={moderateCount}
                                         lowCount={lowCount}
                                         entity="deployment"
-                                        isFiltered={isFiltered}
                                         filteredSeverities={filteredSeverities}
                                     />
                                 </Td>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImagesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImagesTable.tsx
@@ -13,6 +13,7 @@ import { DynamicColumnIcon } from '../components/DynamicIcon';
 import EmptyTableResults from '../components/EmptyTableResults';
 import DatePhraseTd from '../components/DatePhraseTd';
 import TooltipTh from '../components/TooltipTh';
+import { VulnerabilitySeverityLabel } from '../types';
 
 export const imageListQuery = gql`
     query getImageList($query: String, $pagination: Pagination) {
@@ -78,9 +79,10 @@ type ImagesTableProps = {
     images: Image[];
     getSortParams: UseURLSortResult['getSortParams'];
     isFiltered: boolean;
+    filteredSeverities?: VulnerabilitySeverityLabel[];
 };
 
-function ImagesTable({ images, getSortParams, isFiltered }: ImagesTableProps) {
+function ImagesTable({ images, getSortParams, isFiltered, filteredSeverities }: ImagesTableProps) {
     return (
         <TableComposable borders={false} variant="compact">
             <Thead noWrap>
@@ -112,6 +114,10 @@ function ImagesTable({ images, getSortParams, isFiltered }: ImagesTableProps) {
                     watchStatus,
                     scanTime,
                 }) => {
+                    const criticalCount = imageCVECountBySeverity.critical.total;
+                    const importantCount = imageCVECountBySeverity.important.total;
+                    const moderateCount = imageCVECountBySeverity.moderate.total;
+                    const lowCount = imageCVECountBySeverity.low.total;
                     return (
                         <Tbody
                             key={id}
@@ -129,11 +135,13 @@ function ImagesTable({ images, getSortParams, isFiltered }: ImagesTableProps) {
                                 </Td>
                                 <Td>
                                     <SeverityCountLabels
-                                        critical={imageCVECountBySeverity.critical.total}
-                                        important={imageCVECountBySeverity.important.total}
-                                        moderate={imageCVECountBySeverity.moderate.total}
-                                        low={imageCVECountBySeverity.low.total}
+                                        criticalCount={criticalCount}
+                                        importantCount={importantCount}
+                                        moderateCount={moderateCount}
+                                        lowCount={lowCount}
                                         entity="image"
+                                        isFiltered={isFiltered}
+                                        filteredSeverities={filteredSeverities}
                                     />
                                 </Td>
                                 <Td>{operatingSystem}</Td>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImagesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImagesTable.tsx
@@ -140,7 +140,6 @@ function ImagesTable({ images, getSortParams, isFiltered, filteredSeverities }: 
                                         moderateCount={moderateCount}
                                         lowCount={lowCount}
                                         entity="image"
-                                        isFiltered={isFiltered}
                                         filteredSeverities={filteredSeverities}
                                     />
                                 </Td>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/SeverityCountLabels.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/SeverityCountLabels.tsx
@@ -14,7 +14,6 @@ type SeverityCountLabelsProps = {
     moderateCount: number;
     lowCount: number;
     entity?: string;
-    isFiltered: boolean;
     filteredSeverities?: VulnerabilitySeverityLabel[];
 };
 
@@ -34,7 +33,6 @@ function SeverityCountLabels({
     moderateCount,
     lowCount,
     entity,
-    isFiltered,
     filteredSeverities,
 }: SeverityCountLabelsProps) {
     const CriticalIcon = SeverityIcons.CRITICAL_VULNERABILITY_SEVERITY;
@@ -42,10 +40,10 @@ function SeverityCountLabels({
     const ModerateIcon = SeverityIcons.MODERATE_VULNERABILITY_SEVERITY;
     const LowIcon = SeverityIcons.LOW_VULNERABILITY_SEVERITY;
 
-    const isCriticalHidden = isFiltered && !filteredSeverities?.includes('Critical');
-    const isImportantHidden = isFiltered && !filteredSeverities?.includes('Important');
-    const isModerateHidden = isFiltered && !filteredSeverities?.includes('Moderate');
-    const isLowHidden = isFiltered && !filteredSeverities?.includes('Low');
+    const isCriticalHidden = !!filteredSeverities && !filteredSeverities.includes('Critical');
+    const isImportantHidden = !!filteredSeverities && !filteredSeverities.includes('Important');
+    const isModerateHidden = !!filteredSeverities && !filteredSeverities.includes('Moderate');
+    const isLowHidden = !!filteredSeverities && !filteredSeverities.includes('Low');
 
     const critical = isCriticalHidden ? undefined : criticalCount;
     const important = isImportantHidden ? undefined : importantCount;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/SeverityCountLabels.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/SeverityCountLabels.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Flex, Label, Tooltip, pluralize, capitalize } from '@patternfly/react-core';
-import { EyeSlashIcon } from '@patternfly/react-icons';
+import { EllipsisHIcon } from '@patternfly/react-icons';
 
 import SeverityIcons from 'Components/PatternFly/SeverityIcons';
 import { vulnSeverityTextColors } from 'constants/visuals/colors';
@@ -19,7 +19,7 @@ type SeverityCountLabelsProps = {
 
 function getTooltipContent(severity: string, severityCount?: number, entity?: string) {
     if (!severityCount && severityCount !== 0) {
-        return `${capitalize(severity)} severity is hidden by the filter`;
+        return `${capitalize(severity)} severity is hidden by the applied filter`;
     }
     if (entity) {
         return `${pluralize(severityCount, `${severity} CVE`)} across this ${entity}`;
@@ -66,7 +66,7 @@ function SeverityCountLabels({
                         }}
                     >
                         {!critical && critical !== 0 ? (
-                            <EyeSlashIcon className="pf-u-my-xs pf-u-ml-xs" />
+                            <EllipsisHIcon className="pf-u-my-xs" />
                         ) : (
                             critical
                         )}
@@ -87,7 +87,7 @@ function SeverityCountLabels({
                         }}
                     >
                         {!important && important !== 0 ? (
-                            <EyeSlashIcon className="pf-u-my-xs pf-u-ml-xs" />
+                            <EllipsisHIcon className="pf-u-my-xs" />
                         ) : (
                             important
                         )}
@@ -108,7 +108,7 @@ function SeverityCountLabels({
                         }}
                     >
                         {!moderate && moderate !== 0 ? (
-                            <EyeSlashIcon className="pf-u-my-xs pf-u-ml-xs" />
+                            <EllipsisHIcon className="pf-u-my-xs" />
                         ) : (
                             moderate
                         )}
@@ -128,11 +128,7 @@ function SeverityCountLabels({
                                 : fadedTextColor,
                         }}
                     >
-                        {!low && low !== 0 ? (
-                            <EyeSlashIcon className="pf-u-my-xs pf-u-ml-xs" />
-                        ) : (
-                            low
-                        )}
+                        {!low && low !== 0 ? <EllipsisHIcon className="pf-u-my-xs" /> : low}
                     </span>
                 </Label>
             </Tooltip>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/SeverityCountLabels.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/SeverityCountLabels.tsx
@@ -1,20 +1,27 @@
 import React from 'react';
-import { Flex, Label, Tooltip, pluralize } from '@patternfly/react-core';
+import { Flex, Label, Tooltip, pluralize, capitalize } from '@patternfly/react-core';
+import { EyeSlashIcon } from '@patternfly/react-icons';
 
 import SeverityIcons from 'Components/PatternFly/SeverityIcons';
 import { vulnSeverityTextColors } from 'constants/visuals/colors';
+import { VulnerabilitySeverityLabel } from '../types';
 
 const fadedTextColor = 'var(--pf-global--Color--200)';
 
 type SeverityCountLabelsProps = {
-    critical: number;
-    important: number;
-    moderate: number;
-    low: number;
+    criticalCount: number;
+    importantCount: number;
+    moderateCount: number;
+    lowCount: number;
     entity?: string;
+    isFiltered: boolean;
+    filteredSeverities?: VulnerabilitySeverityLabel[];
 };
 
-function getTooltipContent(severityCount: number, severity: string, entity?: string) {
+function getTooltipContent(severity: string, severityCount?: number, entity?: string) {
+    if (!severityCount && severityCount !== 0) {
+        return `${capitalize(severity)} severity is hidden by the filter`;
+    }
     if (entity) {
         return `${pluralize(severityCount, `${severity} CVE`)} across this ${entity}`;
     }
@@ -22,20 +29,32 @@ function getTooltipContent(severityCount: number, severity: string, entity?: str
 }
 
 function SeverityCountLabels({
-    critical,
-    important,
-    moderate,
-    low,
+    criticalCount,
+    importantCount,
+    moderateCount,
+    lowCount,
     entity,
+    isFiltered,
+    filteredSeverities,
 }: SeverityCountLabelsProps) {
     const CriticalIcon = SeverityIcons.CRITICAL_VULNERABILITY_SEVERITY;
     const ImportantIcon = SeverityIcons.IMPORTANT_VULNERABILITY_SEVERITY;
     const ModerateIcon = SeverityIcons.MODERATE_VULNERABILITY_SEVERITY;
     const LowIcon = SeverityIcons.LOW_VULNERABILITY_SEVERITY;
 
+    const isCriticalHidden = isFiltered && !filteredSeverities?.includes('Critical');
+    const isImportantHidden = isFiltered && !filteredSeverities?.includes('Important');
+    const isModerateHidden = isFiltered && !filteredSeverities?.includes('Moderate');
+    const isLowHidden = isFiltered && !filteredSeverities?.includes('Low');
+
+    const critical = isCriticalHidden ? undefined : criticalCount;
+    const important = isImportantHidden ? undefined : importantCount;
+    const moderate = isModerateHidden ? undefined : moderateCount;
+    const low = isLowHidden ? undefined : lowCount;
+
     return (
         <Flex spaceItems={{ default: 'spaceItemsSm' }} flexWrap={{ default: 'nowrap' }}>
-            <Tooltip content={getTooltipContent(critical, 'critical', entity)}>
+            <Tooltip content={getTooltipContent('critical', critical, entity)}>
                 <Label
                     variant="outline"
                     className="pf-u-font-weight-bold"
@@ -48,11 +67,15 @@ function SeverityCountLabels({
                                 : fadedTextColor,
                         }}
                     >
-                        {critical}
+                        {!critical && critical !== 0 ? (
+                            <EyeSlashIcon className="pf-u-my-xs pf-u-ml-xs" />
+                        ) : (
+                            critical
+                        )}
                     </span>
                 </Label>
             </Tooltip>
-            <Tooltip content={getTooltipContent(important, 'important', entity)}>
+            <Tooltip content={getTooltipContent('important', important, entity)}>
                 <Label
                     variant="outline"
                     className="pf-u-font-weight-bold"
@@ -65,11 +88,15 @@ function SeverityCountLabels({
                                 : fadedTextColor,
                         }}
                     >
-                        {important}
+                        {!important && important !== 0 ? (
+                            <EyeSlashIcon className="pf-u-my-xs pf-u-ml-xs" />
+                        ) : (
+                            important
+                        )}
                     </span>
                 </Label>
             </Tooltip>
-            <Tooltip content={getTooltipContent(moderate, 'moderate', entity)}>
+            <Tooltip content={getTooltipContent('moderate', moderate, entity)}>
                 <Label
                     variant="outline"
                     className="pf-u-font-weight-bold"
@@ -82,11 +109,15 @@ function SeverityCountLabels({
                                 : fadedTextColor,
                         }}
                     >
-                        {moderate}
+                        {!moderate && moderate !== 0 ? (
+                            <EyeSlashIcon className="pf-u-my-xs pf-u-ml-xs" />
+                        ) : (
+                            moderate
+                        )}
                     </span>
                 </Label>
             </Tooltip>
-            <Tooltip content={getTooltipContent(low, 'low', entity)}>
+            <Tooltip content={getTooltipContent('low', low, entity)}>
                 <Label
                     variant="outline"
                     className="pf-u-font-weight-bold"
@@ -99,7 +130,11 @@ function SeverityCountLabels({
                                 : fadedTextColor,
                         }}
                     >
-                        {low}
+                        {!low && low !== 0 ? (
+                            <EyeSlashIcon className="pf-u-my-xs pf-u-ml-xs" />
+                        ) : (
+                            low
+                        )}
                     </span>
                 </Label>
             </Tooltip>


### PR DESCRIPTION
Updating `SeverityCountLabels` component to reflect when severities are hidden via filter. The data should reflect properly even when the table is not filtered by severity.

CVE -> Deployment table (unfiltered)
<img width="1432" alt="image" src="https://github.com/stackrox/stackrox/assets/10412893/8d3bd82d-a066-4321-bf30-fc1712520cbd">
CVE -> Deployment table (filtered)
 <img width="1439" alt="image" src="https://github.com/stackrox/stackrox/assets/10412893/b76e5b5a-febb-417d-a47c-c1e73f2fd613">

Overview page -> CVEs (unfiltered)
<img width="1426" alt="image" src="https://github.com/stackrox/stackrox/assets/10412893/e037fdba-0342-4926-b404-5f17fbbc170b">
Overview page -> CVEs (filtered)
<img width="1431" alt="image" src="https://github.com/stackrox/stackrox/assets/10412893/ffeb187d-d903-46a6-9767-20c7e36a3bb0">

Overview page -> Images (unfiltered)
<img width="1424" alt="image" src="https://github.com/stackrox/stackrox/assets/10412893/dbe8baa9-334d-4011-90ce-e0a8af22aa0d">
Overview page -> Images (filtered)
<img width="1430" alt="image" src="https://github.com/stackrox/stackrox/assets/10412893/272e2703-a101-4044-a6c5-15c49ce00a39">


Overview page -> Deployments (unfiltered)
<img width="1435" alt="image" src="https://github.com/stackrox/stackrox/assets/10412893/4e859023-4858-49d2-ae6f-32fab470c0a4">
Overview page -> Deployments (filtered)
<img width="1432" alt="image" src="https://github.com/stackrox/stackrox/assets/10412893/03e7e807-4643-4ad6-85fa-5d76f4e237a2">
