### PR TITLE
ROX-17039: Sensor retries gRPC connection when failed

### DIFF
--- a/sensor/common/centralclient/grpc_connection.go
+++ b/sensor/common/centralclient/grpc_connection.go
@@ -22,6 +22,7 @@ type CentralConnectionFactory interface {
 	SetCentralConnectionWithRetries(ptr *util.LazyClientConn)
 	StopSignal() *concurrency.ErrorSignal
 	OkSignal() *concurrency.Signal
+	Reset()
 }
 
 type centralConnectionFactoryImpl struct {
@@ -56,6 +57,12 @@ func (f *centralConnectionFactoryImpl) OkSignal() *concurrency.Signal {
 // StopSignal returns a concurrency.Signal that alerts if there is an error trying to establish gRPC connection.
 func (f *centralConnectionFactoryImpl) StopSignal() *concurrency.ErrorSignal {
 	return &f.stopSignal
+}
+
+// Reset signals. This should be used when re-attempting the connection in case it was broken.
+func (f *centralConnectionFactoryImpl) Reset() {
+	f.stopSignal.Reset()
+	f.okSignal.Reset()
 }
 
 func (f *centralConnectionFactoryImpl) pollMetadata() error {

--- a/sensor/common/sensor/sensor.go
+++ b/sensor/common/sensor/sensor.go
@@ -302,6 +302,7 @@ func (s *Sensor) communicationWithCentralWithRetries(centralReachable *concurren
 	// connection is up again.
 	exponential := backoff.NewExponentialBackOff()
 	exponential.MaxElapsedTime = 0 // It never stops if set to 0
+	// TODO(ROX-17209): add configurable time for restart intervals
 	exponential.InitialInterval = 1 * time.Minute
 	exponential.MaxInterval = 10 * time.Minute
 

--- a/sensor/debugger/central/grpc_client.go
+++ b/sensor/debugger/central/grpc_client.go
@@ -39,3 +39,9 @@ func (f *fakeGRPCClient) StopSignal() *concurrency.ErrorSignal {
 func (f *fakeGRPCClient) OkSignal() *concurrency.Signal {
 	return &f.okSig
 }
+
+// Reset signals
+func (f *fakeGRPCClient) Reset() {
+	f.stopSig.Reset()
+	f.okSig.Reset()
+}


### PR DESCRIPTION
## Description

This PR adds a simple backoff strategy for when the gRPC connection breaks. 

I tested locally with local sensor support (#6024) connecting to a real Central instance. More information on the `Testing Performed`.

There are still many things that might fail with this (sensor does not reconcile or send `SYNC` event on reconnect), which will be tackled in the remaining of the epic ([ROX-9776](https://issues.redhat.com/browse/ROX-9776)). 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] ~~Unit test and regression tests added~~
- [ ] ~~Evaluated and added CHANGELOG entry if required~~
- [ ] ~~Determined and documented upgrade steps~~
- [ ] ~~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~



## Testing Performed

1. Deployed ACS on an infra cluster
2. Scaled sensor down to `0` replicas
3. Port-forwarded central API to `localhost:8000`
4. Ran local-sensor pointing to real Central
```
$ ROX_PREVENT_SENSOR_RESTART_ON_DISCONNECT="true" LOGLEVEL="debug" go run ./tools/local-sensor/main.go -connect-central "localhost:8000"
```
5. After connection was alive and steady, killed the port-forward.
6. Sensor attempts to reconnect:
```
common/sensor: 2023/05/17 09:53:02.739616 central_communication_impl.go:164: Info: Communication with central ended.
common/centralclient: 2023/05/17 09:53:02.740787 grpc_connection.go:86: Info: Check Central status failed: receiving Central metadata: calling https://localhost:8000/v1/metadata: Get "https://localhost:8000/v1/metadata": dial tcp [::1]:8000: connect: connection refused. Retrying after 618ms...
common/centralclient: 2023/05/17 09:53:03.359917 grpc_connection.go:86: Info: Check Central status failed: receiving Central metadata: calling https://localhost:8000/v1/metadata: Get "https://localhost:8000/v1/metadata": dial tcp [::1]:8000: connect: connection refused. Retrying after 806ms...
common/centralclient: 2023/05/17 09:53:04.167798 grpc_connection.go:86: Info: Check Central status failed: receiving Central metadata: calling https://localhost:8000/v1/metadata: Get "https://localhost:8000/v1/metadata": dial tcp [::1]:8000: connect: connection refused. Retrying after 953ms...
common/centralclient: 2023/05/17 09:53:05.122115 grpc_connection.go:86: Info: Check Central status failed: receiving Central metadata: calling https://localhost:8000/v1/metadata: Get "https://localhost:8000/v1/metadata": dial tcp [::1]:8000: connect: connection refused. Retrying after 1.07s...
common/centralclient: 2023/05/17 09:53:06.193349 grpc_connection.go:86: Info: Check Central status failed: receiving Central metadata: calling https://localhost:8000/v1/metadata: Get "https://localhost:8000/v1/metadata": dial tcp [::1]:8000: connect: connection refused. Retrying after 2.024s...
common/centralclient: 2023/05/17 09:53:08.219086 grpc_connection.go:86: Info: Check Central status failed: receiving Central metadata: calling https://localhost:8000/v1/metadata: Get "https://localhost:8000/v1/metadata": dial tcp [::1]:8000: connect: connection refused. Retrying after 2.298s...
common/centralclient: 2023/05/17 09:53:10.518664 grpc_connection.go:86: Info: Check Central status failed: receiving Central metadata: calling https://localhost:8000/v1/metadata: Get "https://localhost:8000/v1/metadata": dial tcp [::1]:8000: connect: connection refused. Retrying after 5.612s...
```
7. After a few attempts, I recreated the port-forward
8. Sensor was able to reconnect:
```
common/centralclient: 2023/05/17 09:53:16.722271 grpc_connection.go:128: Info: Did not add central CA cert to gRPC connection
grpc_internal: 2023/05/17 09:53:16.722694 clientconn.go:188: Debug: [core][Channel #17] Channel created
grpc_internal: 2023/05/17 09:53:16.722721 logging.go:43: Debug: [core][Channel #17] original dial target is: "localhost:8000"
grpc_internal: 2023/05/17 09:53:16.722738 logging.go:43: Debug: [core][Channel #17] parsed dial target is: {Scheme:localhost Authority: URL:{Scheme:localhost Opaque:8000 User: Host: Path: RawPath: OmitHost:false ForceQuery:false RawQuery: Fragment: RawFragment:}}
grpc_internal: 2023/05/17 09:53:16.722746 logging.go:43: Debug: [core][Channel #17] fallback to scheme "passthrough"
grpc_internal: 2023/05/17 09:53:16.722758 logging.go:43: Debug: [core][Channel #17] parsed dial target is: {Scheme:passthrough Authority: URL:{Scheme:passthrough Opaque: User: Host: Path:/localhost:8000 RawPath: OmitHost:false ForceQuery:false RawQuery: Fragment: RawFragment:}}
grpc_internal: 2023/05/17 09:53:16.722767 logging.go:43: Debug: [core][Channel #17] Channel authority set to "localhost"
grpc_internal: 2023/05/17 09:53:16.722799 logging.go:43: Debug: [core][Channel #17] Resolver state updated: {
  "Addresses": [
    {
      "Addr": "localhost:8000",
      "ServerName": "",
      "Attributes": null,
      "BalancerAttributes": null,
      "Type": 0,
      "Metadata": null
    }
  ],
  "ServiceConfig": null,
  "Attributes": null
} (resolver returned new addresses)
grpc_internal: 2023/05/17 09:53:16.722823 logging.go:43: Debug: [core][Channel #17] Channel switches to new LB policy "pick_first"
grpc_internal: 2023/05/17 09:53:16.722857 clientconn.go:735: Debug: [core][Channel #17 SubChannel #18] Subchannel created
grpc_internal: 2023/05/17 09:53:16.722874 logging.go:43: Debug: [core][Channel #17] Channel Connectivity change to CONNECTING
grpc_internal: 2023/05/17 09:53:16.722907 logging.go:43: Debug: [core][Channel #17 SubChannel #18] Subchannel Connectivity change to CONNECTING
grpc_internal: 2023/05/17 09:53:16.722929 logging.go:43: Debug: [core][Channel #17 SubChannel #18] Subchannel picks a new address "localhost:8000" to connect
grpc_internal: 2023/05/17 09:53:17.187751 logging.go:43: Debug: [core][Channel #17 SubChannel #18] Subchannel Connectivity change to READY
grpc_internal: 2023/05/17 09:53:17.187803 logging.go:43: Debug: [core][Channel #17] Channel Connectivity change to READY
```