### PR TITLE
ROX-16935: Make PolicyConfigurationTest multi-arch compliant

### DIFF
--- a/qa-tests-backend/src/test/groovy/PolicyConfigurationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/PolicyConfigurationTest.groovy
@@ -30,6 +30,7 @@ import org.junit.Assume
 import spock.lang.Shared
 import spock.lang.Tag
 import spock.lang.Unroll
+import util.Env
 
 class PolicyConfigurationTest extends BaseSpecification {
     static final private String DEPLOYMENTNGINX = "deploymentnginx"
@@ -39,7 +40,7 @@ class PolicyConfigurationTest extends BaseSpecification {
     static final private String DEPLOYMENTNGINX_NP = "deploymentnginx-np"
     static final private String DEPLOYMENT_RBAC = "deployment-rbac"
     static final private String SERVICE_ACCOUNT_NAME = "policy-config-sa"
-    static final private String NGINX_LATEST_WITH_DIGEST_NAME = "nginx-1-17-with-tag-and-digest"
+    static final private String NGINX_LATEST_WITH_DIGEST_NAME = "nginx-1-12-1-with-tag-and-digest"
     static final private String NGINX_LATEST_NAME = "nginx-latest"
     private static final String CLUSTER_ROLE_NAME = "policy-config-role"
 
@@ -61,7 +62,7 @@ class PolicyConfigurationTest extends BaseSpecification {
     static final private List<Deployment> DEPLOYMENTS = [
             new Deployment()
                     .setName(DEPLOYMENTNGINX)
-                    .setImage(TEST_IMAGE)
+                    .setImage("quay.io/rhacs-eng/qa-multi-arch:nginx-1.12")
                     .addPort(22, "TCP")
                     .setEnv(["CLUSTER_NAME": "main"])
                     .addLabel("app", "test")
@@ -78,15 +79,15 @@ class PolicyConfigurationTest extends BaseSpecification {
                             mountPath: "/tmp/test")),
             new Deployment()
                     .setName(STRUTS)
-                    .setImage("quay.io/rhacs-eng/qa:struts-app")
+                    .setImage("quay.io/rhacs-eng/qa-multi-arch:struts-app")
                     .addLabel("app", "test"),
             new Deployment()
                     .setName(DNS)
-                    .setImage("quay.io/rhacs-eng/qa:apache-dns")
+                    .setImage("quay.io/rhacs-eng/qa-multi-arch:apache-dns")
                     .addLabel("app", "test"),
             new Deployment()
                     .setName(DEPLOYMENTNGINX_LB)
-                    .setImage(TEST_IMAGE)
+                    .setImage("quay.io/rhacs-eng/qa-multi-arch:nginx-1.12")
                     .addPort(22, "TCP")
                     .addAnnotation("test", "annotation")
                     .setEnv(["CLUSTER_NAME": "main"])
@@ -94,7 +95,7 @@ class PolicyConfigurationTest extends BaseSpecification {
                     .setCreateLoadBalancer(true).setExposeAsService(true),
             new Deployment()
                     .setName(DEPLOYMENTNGINX_NP)
-                    .setImage(TEST_IMAGE)
+                    .setImage("quay.io/rhacs-eng/qa-multi-arch:nginx-1.12")
                     .addPort(22, "TCP")
                     .addAnnotation("test", "annotation")
                     .setEnv(["CLUSTER_NAME": "main"])
@@ -103,19 +104,21 @@ class PolicyConfigurationTest extends BaseSpecification {
                     .setName(DEPLOYMENT_RBAC)
                     .setNamespace(Constants.ORCHESTRATOR_NAMESPACE)
                     .setServiceAccountName(SERVICE_ACCOUNT_NAME)
-                    .setImage("quay.io/rhacs-eng/qa:nginx-1-15-4-alpine")
+                    .setImage("quay.io/rhacs-eng/qa-multi-arch:nginx-1-15-4-alpine")
                     .setSkipReplicaWait(true),
     ]
 
     static final private Deployment NGINX_WITH_DIGEST = new Deployment()
             .setName(NGINX_LATEST_WITH_DIGEST_NAME)
-            .setImage("nginx:1.17@sha256:86ae264c3f4acb99b2dee4d0098c40cb8c46dcf9e1148f05d3a51c4df6758c12")
+            .setImage("quay.io/rhacs-eng/qa-multi-arch:nginx-1.21.1" +
+                "@sha256:a05b0cdd4fc1be3b224ba9662ebdf98fe44c09c0c9215b45f84344c12867002e")
             .setCommand(["sleep", "60000"])
             .setSkipReplicaWait(false)
 
     static final private Deployment NGINX_LATEST = new Deployment()
             .setName(NGINX_LATEST_NAME)
-            .setImage("nginx:latest@sha256:86ae264c3f4acb99b2dee4d0098c40cb8c46dcf9e1148f05d3a51c4df6758c12")
+            .setImage("quay.io/rhacs-eng/qa-multi-arch:latest" +
+                "@sha256:a05b0cdd4fc1be3b224ba9662ebdf98fe44c09c0c9215b45f84344c12867002e")
             .setCommand(["sleep", "60000"])
             .setSkipReplicaWait(false)
 
@@ -160,7 +163,7 @@ class PolicyConfigurationTest extends BaseSpecification {
         when:
         withRetry(30, 2) {
             def image = ImageService.getImage(
-                    "sha256:86ae264c3f4acb99b2dee4d0098c40cb8c46dcf9e1148f05d3a51c4df6758c12")
+                    "sha256:a05b0cdd4fc1be3b224ba9662ebdf98fe44c09c0c9215b45f84344c12867002e")
             assert image != null
         }
 
@@ -268,7 +271,7 @@ class PolicyConfigurationTest extends BaseSpecification {
                                         PolicyOuterClass.PolicyGroup.newBuilder()
                                                 .setFieldName("Image Tag")
                                                 .addValues(PolicyOuterClass.PolicyValue.newBuilder()
-                                                        .setValue("nginx-1-7-9").build())
+                                                        .setValue("nginx-1.12").build())
                                                 .build()
                                 ).build()
                         ).build()       | DEPLOYMENTNGINX | null | false
@@ -287,7 +290,7 @@ class PolicyConfigurationTest extends BaseSpecification {
                                         PolicyOuterClass.PolicyGroup.newBuilder()
                                                 .setFieldName("Image Remote")
                                                 .addValues(PolicyOuterClass.PolicyValue.newBuilder()
-                                                        .setValue("rhacs-eng/qa")
+                                                        .setValue("rhacs-eng/qa-multi-arch")
                                                         .build()).build()
                                 ).build()
                         ).build()  | DEPLOYMENTNGINX | null | false
@@ -359,10 +362,10 @@ class PolicyConfigurationTest extends BaseSpecification {
                                         PolicyOuterClass.PolicyGroup.newBuilder()
                                                 .setFieldName("CVE")
                                                 .addValues(PolicyOuterClass.PolicyValue.newBuilder()
-                                                        .setValue("CVE-2017-5638")
+                                                        .setValue("CVE-2017-18269")
                                                         .build()).build()
                                 ).build()
-                        ).build()  | STRUTS | null | true
+                        ).build()  | DEPLOYMENTNGINX | null | true
 
         "Port"                                |
                 Policy.newBuilder()
@@ -401,7 +404,8 @@ class PolicyConfigurationTest extends BaseSpecification {
                                                 ])
                                                 .build()
                                 ).build()
-                        ).build() | DEPLOYMENTNGINX_LB | null | false
+                        ).build() | DEPLOYMENTNGINX_LB | { Env.REMOTE_CLUSTER_ARCH != "ppc64le" &&
+                                                           Env.REMOTE_CLUSTER_ARCH != "s390x" } | false
         "Port Exposure by Node Port"         |
                 Policy.newBuilder()
                         .setName("TestPortExposurePolicy")

--- a/qa-tests-backend/src/test/groovy/PolicyConfigurationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/PolicyConfigurationTest.groovy
@@ -117,8 +117,8 @@ class PolicyConfigurationTest extends BaseSpecification {
 
     static final private Deployment NGINX_LATEST = new Deployment()
             .setName(NGINX_LATEST_NAME)
-            .setImage("quay.io/rhacs-eng/qa-multi-arch-nginx:latest" +
-                "@sha256:6650513efd1d27c1f8a5351cbd33edf85cc7e0d9d0fcb4ffb23d8fa89b601ba8")
+            .setImage("quay.io/rhacs-eng/qa-multi-arch:latest" +
+                "@sha256:a05b0cdd4fc1be3b224ba9662ebdf98fe44c09c0c9215b45f84344c12867002e")
             .setCommand(["sleep", "60000"])
             .setSkipReplicaWait(false)
 

--- a/qa-tests-backend/src/test/groovy/PolicyConfigurationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/PolicyConfigurationTest.groovy
@@ -117,8 +117,8 @@ class PolicyConfigurationTest extends BaseSpecification {
 
     static final private Deployment NGINX_LATEST = new Deployment()
             .setName(NGINX_LATEST_NAME)
-            .setImage("quay.io/rhacs-eng/qa-multi-arch:latest" +
-                "@sha256:a05b0cdd4fc1be3b224ba9662ebdf98fe44c09c0c9215b45f84344c12867002e")
+            .setImage("quay.io/rhacs-eng/qa-multi-arch-nginx:latest" +
+                "@sha256:6650513efd1d27c1f8a5351cbd33edf85cc7e0d9d0fcb4ffb23d8fa89b601ba8")
             .setCommand(["sleep", "60000"])
             .setSkipReplicaWait(false)
 


### PR DESCRIPTION
This PR intends to fix failures on P/Z with `PolicyConfigurationTest`. Changes in the test would make it multi-arch compliant.
Changes are verified manually using `./gradlew test --tests=TestName`

This PR intends to fix [ROX-16935](https://issues.redhat.com/browse/ROX-16935)