### PR TITLE
ROX-16867: Add notifier transformer

### DIFF
--- a/pkg/declarativeconfig/transform/auth_provider.go
+++ b/pkg/declarativeconfig/transform/auth_provider.go
@@ -37,7 +37,7 @@ func (a *authProviderTransform) Transform(configuration declarativeconfig.Config
 		return nil, errox.InvalidArgs.Newf("invalid configuration type received for auth provider: %T", configuration)
 	}
 
-	providerType, err := getType(authProviderConfig)
+	providerType, err := getAuthProviderType(authProviderConfig)
 	if err != nil {
 		return nil, errors.Wrap(err, "transforming auth provider type")
 	}
@@ -70,7 +70,7 @@ func (a *authProviderTransform) Transform(configuration declarativeconfig.Config
 	}, nil
 }
 
-func getType(authProviderConfig *declarativeconfig.AuthProvider) (string, error) {
+func getAuthProviderType(authProviderConfig *declarativeconfig.AuthProvider) (string, error) {
 	switch {
 	case authProviderConfig.OIDCConfig != nil:
 		return oidc.TypeName, nil
@@ -88,7 +88,7 @@ func getType(authProviderConfig *declarativeconfig.AuthProvider) (string, error)
 }
 
 func getConfig(authProviderConfig *declarativeconfig.AuthProvider) (map[string]string, error) {
-	authProviderType, err := getType(authProviderConfig)
+	authProviderType, err := getAuthProviderType(authProviderConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/declarativeconfig/transform/auth_provider_test.go
+++ b/pkg/declarativeconfig/transform/auth_provider_test.go
@@ -62,7 +62,7 @@ func TestGetAuthProviderType(t *testing.T) {
 
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
-			typ, err := getType(c.cfg)
+			typ, err := getAuthProviderType(c.cfg)
 			if c.err != nil {
 				assert.Error(t, err)
 				assert.ErrorIs(t, err, c.err)

--- a/pkg/declarativeconfig/transform/notifier.go
+++ b/pkg/declarativeconfig/transform/notifier.go
@@ -1,0 +1,116 @@
+package transform
+
+import (
+	"reflect"
+
+	"github.com/gogo/protobuf/proto"
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/declarativeconfig"
+	"github.com/stackrox/rox/pkg/errox"
+)
+
+var (
+	_ Transformer = (*notifierTransform)(nil)
+
+	notifierType = reflect.TypeOf((*storage.Notifier)(nil))
+)
+
+type notifierTransform struct{}
+
+func newNotifierTransform() *notifierTransform {
+	return &notifierTransform{}
+}
+
+func (r *notifierTransform) Transform(configuration declarativeconfig.Configuration) (map[reflect.Type][]proto.Message, error) {
+	notifierConfig, ok := configuration.(*declarativeconfig.Notifier)
+	if !ok {
+		return nil, errox.InvalidArgs.Newf("invalid configuration type received for role: %T", configuration)
+	}
+
+	if notifierConfig.Name == "" {
+		return nil, errox.InvalidArgs.CausedBy("name must be non-empty")
+	}
+
+	notifierTypeStr, err := getNotifierType(notifierConfig)
+	if err != nil {
+		return nil, errors.Wrap(err, "invalid notifier type")
+	}
+
+	notifierProto := &storage.Notifier{
+		Id:     declarativeconfig.NewDeclarativeNotifierUUID(notifierConfig.Name).String(),
+		Name:   notifierConfig.Name,
+		Type:   notifierTypeStr,
+		Traits: &storage.Traits{Origin: storage.Traits_DECLARATIVE},
+	}
+
+	if notifierConfig.GenericConfig != nil {
+		notifierProto.Config = getGenericConfig(notifierConfig.GenericConfig)
+	} else if notifierConfig.SplunkConfig != nil {
+		notifierProto.Config = getSplunkConfig(notifierConfig.SplunkConfig)
+	} else {
+		return nil, errox.InvalidArgs.Newf("unsupported notifier type %s", notifierTypeStr)
+	}
+
+	return map[reflect.Type][]proto.Message{
+		notifierType: {notifierProto},
+	}, nil
+}
+
+func getSplunkConfig(config *declarativeconfig.SplunkConfig) *storage.Notifier_Splunk {
+	return &storage.Notifier_Splunk{
+		Splunk: &storage.Splunk{
+			HttpToken:           config.HTTPToken,
+			HttpEndpoint:        config.HTTPEndpoint,
+			Insecure:            config.Insecure,
+			Truncate:            config.Truncate,
+			AuditLoggingEnabled: config.AuditLoggingEnabled,
+			SourceTypes:         getSourceTypes(config.SourceTypes),
+		},
+	}
+}
+
+func getSourceTypes(types []declarativeconfig.SourceTypePair) map[string]string {
+	res := map[string]string{}
+	for _, t := range types {
+		res[t.Key] = t.Value
+	}
+	return res
+}
+
+func getGenericConfig(config *declarativeconfig.GenericConfig) *storage.Notifier_Generic {
+	return &storage.Notifier_Generic{
+		Generic: &storage.Generic{
+			Endpoint:            config.Endpoint,
+			Username:            config.Username,
+			Password:            config.Password,
+			SkipTLSVerify:       config.SkipTLSVerify,
+			CaCert:              config.CACertPEM,
+			AuditLoggingEnabled: config.AuditLoggingEnabled,
+			Headers:             getKeyValues(config.Headers),
+			ExtraFields:         getKeyValues(config.ExtraFields),
+		},
+	}
+}
+
+func getKeyValues(headers []declarativeconfig.KeyValuePair) []*storage.KeyValuePair {
+	res := make([]*storage.KeyValuePair, 0, len(headers))
+	for _, h := range headers {
+		res = append(res, &storage.KeyValuePair{
+			Key:   h.Key,
+			Value: h.Value,
+		})
+	}
+	return res
+}
+
+func getNotifierType(config *declarativeconfig.Notifier) (string, error) {
+	switch {
+	case config.GenericConfig != nil:
+		return "generic", nil
+	case config.SplunkConfig != nil:
+		return "splunk", nil
+	default:
+		return "", errox.InvalidArgs.New("no valid notifier config given")
+	}
+}

--- a/pkg/declarativeconfig/transform/notifier.go
+++ b/pkg/declarativeconfig/transform/notifier.go
@@ -25,7 +25,7 @@ func newNotifierTransform() *notifierTransform {
 func (r *notifierTransform) Transform(configuration declarativeconfig.Configuration) (map[reflect.Type][]proto.Message, error) {
 	notifierConfig, ok := configuration.(*declarativeconfig.Notifier)
 	if !ok {
-		return nil, errox.InvalidArgs.Newf("invalid configuration type received for role: %T", configuration)
+		return nil, errox.InvalidArgs.Newf("invalid configuration type received for notifier: %T", configuration)
 	}
 
 	if notifierConfig.Name == "" {

--- a/pkg/declarativeconfig/transform/notifier_test.go
+++ b/pkg/declarativeconfig/transform/notifier_test.go
@@ -1,0 +1,138 @@
+package transform
+
+import (
+	"testing"
+
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/declarativeconfig"
+	"github.com/stackrox/rox/pkg/errox"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWrongConfigurationTypeTransformNotifier(t *testing.T) {
+	nt := newNotifierTransform()
+	msgs, err := nt.Transform(&declarativeconfig.AuthProvider{})
+	assert.Nil(t, msgs)
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, errox.InvalidArgs)
+}
+
+func TestTransformGenericNotifier(t *testing.T) {
+	notifier := &declarativeconfig.Notifier{
+		Name: "test-notifier",
+		GenericConfig: &declarativeconfig.GenericConfig{
+			Endpoint:      "endpoint",
+			SkipTLSVerify: true,
+			CACertPEM:     "cacertpem",
+			Username:      "username",
+			Password:      "password",
+			Headers: []declarativeconfig.KeyValuePair{
+				{
+					Key:   "headers-key-0",
+					Value: "headers-value-0",
+				},
+				{
+					Key:   "headers-key-1",
+					Value: "headers-value-1",
+				},
+			},
+			ExtraFields: []declarativeconfig.KeyValuePair{
+				{
+					Key:   "extra-fields-key-0",
+					Value: "extra-fields-value-0",
+				},
+				{
+					Key:   "extra-fields-key-1",
+					Value: "extra-fields-value-1",
+				},
+			},
+			AuditLoggingEnabled: true,
+		},
+	}
+	expectedNotifierID := declarativeconfig.NewDeclarativeNotifierUUID(notifier.Name).String()
+
+	transformer := newNotifierTransform()
+	protos, err := transformer.Transform(notifier)
+	assert.NoError(t, err)
+
+	require.Contains(t, protos, notifierType)
+	require.Len(t, protos[notifierType], 1)
+	notifierProto, ok := protos[notifierType][0].(*storage.Notifier)
+	require.True(t, ok)
+
+	assert.Equal(t, storage.Traits_DECLARATIVE, notifierProto.GetTraits().GetOrigin())
+
+	assert.Equal(t, expectedNotifierID, notifierProto.GetId())
+	assert.Equal(t, notifier.Name, notifierProto.GetName())
+
+	assert.Equal(t, "generic", notifierProto.GetType())
+	assert.Equal(t, notifier.GenericConfig.Endpoint, notifierProto.GetGeneric().GetEndpoint())
+	assert.Equal(t, notifier.GenericConfig.Password, notifierProto.GetGeneric().GetPassword())
+	assert.Equal(t, notifier.GenericConfig.Username, notifierProto.GetGeneric().GetUsername())
+	assert.Equal(t, notifier.GenericConfig.CACertPEM, notifierProto.GetGeneric().GetCaCert())
+	assert.Equal(t, notifier.GenericConfig.SkipTLSVerify, notifierProto.GetGeneric().GetSkipTLSVerify())
+	assert.Equal(t, notifier.GenericConfig.AuditLoggingEnabled, notifierProto.GetGeneric().GetAuditLoggingEnabled())
+	assert.Len(t, notifierProto.GetGeneric().GetHeaders(), 2)
+	assert.Equal(t, notifier.GenericConfig.Headers[0].Key, notifierProto.GetGeneric().GetHeaders()[0].GetKey())
+	assert.Equal(t, notifier.GenericConfig.Headers[0].Value, notifierProto.GetGeneric().GetHeaders()[0].GetValue())
+	assert.Equal(t, notifier.GenericConfig.Headers[1].Key, notifierProto.GetGeneric().GetHeaders()[1].GetKey())
+	assert.Equal(t, notifier.GenericConfig.Headers[1].Value, notifierProto.GetGeneric().GetHeaders()[1].GetValue())
+	assert.Len(t, notifierProto.GetGeneric().GetExtraFields(), 2)
+	assert.Equal(t, notifier.GenericConfig.ExtraFields[0].Key, notifierProto.GetGeneric().GetExtraFields()[0].GetKey())
+	assert.Equal(t, notifier.GenericConfig.ExtraFields[0].Value, notifierProto.GetGeneric().GetExtraFields()[0].GetValue())
+	assert.Equal(t, notifier.GenericConfig.ExtraFields[1].Key, notifierProto.GetGeneric().GetExtraFields()[1].GetKey())
+	assert.Equal(t, notifier.GenericConfig.ExtraFields[1].Value, notifierProto.GetGeneric().GetExtraFields()[1].GetValue())
+}
+
+func TestTransformSplunkNotifier(t *testing.T) {
+	notifier := &declarativeconfig.Notifier{
+		Name: "test-notifier",
+		SplunkConfig: &declarativeconfig.SplunkConfig{
+			HTTPEndpoint: "endpoint",
+			Insecure:     true,
+			HTTPToken:    "password",
+			SourceTypes: []declarativeconfig.SourceTypePair{
+				{
+					Key:   "source-types-key-0",
+					Value: "source-types-value-0",
+				},
+				{
+					Key:   "source-types-key-1",
+					Value: "source-types-value-1",
+				},
+			},
+			AuditLoggingEnabled: true,
+		},
+	}
+	expectedNotifierID := declarativeconfig.NewDeclarativeNotifierUUID(notifier.Name).String()
+
+	transformer := newNotifierTransform()
+	protos, err := transformer.Transform(notifier)
+	assert.NoError(t, err)
+
+	require.Contains(t, protos, notifierType)
+	require.Len(t, protos[notifierType], 1)
+	notifierProto, ok := protos[notifierType][0].(*storage.Notifier)
+	require.True(t, ok)
+
+	assert.Equal(t, storage.Traits_DECLARATIVE, notifierProto.GetTraits().GetOrigin())
+
+	assert.Equal(t, expectedNotifierID, notifierProto.GetId())
+	assert.Equal(t, notifier.Name, notifierProto.GetName())
+
+	assert.Equal(t, "splunk", notifierProto.GetType())
+	assert.Equal(t, notifier.SplunkConfig.HTTPEndpoint, notifierProto.GetSplunk().GetHttpEndpoint())
+	assert.Equal(t, notifier.SplunkConfig.HTTPToken, notifierProto.GetSplunk().GetHttpToken())
+	assert.Equal(t, notifier.SplunkConfig.Truncate, notifierProto.GetSplunk().GetTruncate())
+	assert.Equal(t, notifier.SplunkConfig.Insecure, notifierProto.GetSplunk().GetInsecure())
+	assert.Equal(t, notifier.SplunkConfig.AuditLoggingEnabled, notifierProto.GetSplunk().GetAuditLoggingEnabled())
+
+	assert.Len(t, notifierProto.GetSplunk().GetSourceTypes(), 2)
+	v, ok := notifierProto.GetSplunk().GetSourceTypes()[notifier.SplunkConfig.SourceTypes[0].Key]
+	assert.True(t, ok)
+	assert.Equal(t, notifier.SplunkConfig.SourceTypes[0].Value, v)
+	v, ok = notifierProto.GetSplunk().GetSourceTypes()[notifier.SplunkConfig.SourceTypes[1].Key]
+	assert.True(t, ok)
+	assert.Equal(t, notifier.SplunkConfig.SourceTypes[1].Value, v)
+}

--- a/pkg/declarativeconfig/transform/notifier_test.go
+++ b/pkg/declarativeconfig/transform/notifier_test.go
@@ -67,6 +67,7 @@ func TestTransformGenericNotifier(t *testing.T) {
 	assert.Equal(t, notifier.Name, notifierProto.GetName())
 
 	assert.Equal(t, "generic", notifierProto.GetType())
+	assert.Nil(t, notifierProto.GetSplunk())
 	assert.Equal(t, notifier.GenericConfig.Endpoint, notifierProto.GetGeneric().GetEndpoint())
 	assert.Equal(t, notifier.GenericConfig.Password, notifierProto.GetGeneric().GetPassword())
 	assert.Equal(t, notifier.GenericConfig.Username, notifierProto.GetGeneric().GetUsername())
@@ -122,6 +123,7 @@ func TestTransformSplunkNotifier(t *testing.T) {
 	assert.Equal(t, notifier.Name, notifierProto.GetName())
 
 	assert.Equal(t, "splunk", notifierProto.GetType())
+	assert.Nil(t, notifierProto.GetGeneric())
 	assert.Equal(t, notifier.SplunkConfig.HTTPEndpoint, notifierProto.GetSplunk().GetHttpEndpoint())
 	assert.Equal(t, notifier.SplunkConfig.HTTPToken, notifierProto.GetSplunk().GetHttpToken())
 	assert.Equal(t, notifier.SplunkConfig.Truncate, notifierProto.GetSplunk().GetTruncate())

--- a/pkg/declarativeconfig/transform/transformer.go
+++ b/pkg/declarativeconfig/transform/transformer.go
@@ -24,6 +24,7 @@ func New() Transformer {
 		declarativeconfig.AuthProviderConfiguration:  newAuthProviderTransformer(),
 		declarativeconfig.PermissionSetConfiguration: newPermissionSetTransform(),
 		declarativeconfig.RoleConfiguration:          newRoleTransform(),
+		declarativeconfig.NotifierConfiguration:      newNotifierTransform(),
 	}}
 }
 


### PR DESCRIPTION
## Description

Add transformer from declarative config notifier to proto notifier. Supports Generic Webhook and Splunk notifiers.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

1. Added unit tests