### PR TITLE
Add CVE summary and score versions to workload cve list

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/sortUtils.test.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/sortUtils.test.ts
@@ -1,4 +1,4 @@
-import { sortCveDistroList } from './sortUtils';
+import { getScoreVersionsForTopCVSS, sortCveDistroList } from './sortUtils';
 
 describe('sortCveDistroList', () => {
     it('should return an array of objects sorted by operating system priority', () => {
@@ -71,5 +71,45 @@ describe('sortCveDistroList', () => {
             { distro: 'amzn', operatingSystem: 'amzn:2018.03' },
             { distro: 'other', operatingSystem: 'windows:xp' },
         ]);
+    });
+});
+
+describe('getScoreVersionsForTopCVSS', () => {
+    it('should return the correct score versions for the topCVSS', () => {
+        // Empty list
+        expect(getScoreVersionsForTopCVSS(9.5, [])).toEqual([]);
+
+        // Basic checks
+        expect(
+            getScoreVersionsForTopCVSS(9.4, [
+                { cvss: 9.4300001, scoreVersion: 'V1' },
+                { cvss: 8.0, scoreVersion: 'V2' },
+                { cvss: 9.4, scoreVersion: 'V3' },
+                { cvss: 9.4212, scoreVersion: 'V4' },
+                { cvss: 9.48, scoreVersion: 'V5' },
+                { cvss: -9.4300001, scoreVersion: 'V6' },
+                { cvss: 0.0, scoreVersion: 'V7' },
+                { cvss: NaN, scoreVersion: 'V8' },
+                { cvss: Infinity, scoreVersion: 'V9' },
+                { cvss: -Infinity, scoreVersion: 'V10' },
+            ])
+        ).toEqual(['V1', 'V3', 'V4']);
+
+        // Check that duplicates are removed
+        expect(
+            getScoreVersionsForTopCVSS(9.4, [
+                { cvss: 9.4, scoreVersion: 'V1' },
+                { cvss: 9.4, scoreVersion: 'V1' },
+            ])
+        ).toEqual(['V1']);
+
+        // Check that items are sorted correctly
+        expect(
+            getScoreVersionsForTopCVSS(9.4, [
+                { cvss: 9.4, scoreVersion: 'V3' },
+                { cvss: 9.4, scoreVersion: 'V1' },
+                { cvss: 9.4, scoreVersion: 'V2' },
+            ])
+        ).toEqual(['V1', 'V2', 'V3']);
     });
 });

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/sortUtils.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/sortUtils.tsx
@@ -69,3 +69,13 @@ export function sortCveDistroList<Summary extends { operatingSystem: string }>(
     }));
     return sortBy(withDistroKeys, ({ distro }) => distroPriorityMap[distro]);
 }
+
+export function getScoreVersionsForTopCVSS(
+    topCvss: number,
+    scores: { cvss: number; scoreVersion: string }[]
+): string[] {
+    const scoreVersions = scores
+        .filter(({ cvss }) => cvss.toFixed(1) === topCvss.toFixed(1))
+        .map(({ scoreVersion }) => scoreVersion);
+    return Array.from(new Set(scoreVersions)).sort();
+}


### PR DESCRIPTION
## Description

As titled.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Visit the overview page CVE list and see that summaries and score versions are available.
![image](https://github.com/stackrox/stackrox/assets/1292638/e3cd5c7b-d896-4b9a-b255-048be431b1d6)

With multiple score versions, all versions will be displayed in the parens (simulated).
![image](https://github.com/stackrox/stackrox/assets/1292638/bf029ac7-8fff-429e-8f46-557bfb81e07d)

