### PR TITLE
Use search for network policies instead of walks

### DIFF
--- a/central/networkpolicies/datastore/datastore_impl.go
+++ b/central/networkpolicies/datastore/datastore_impl.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stackrox/rox/pkg/protoconv"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/stringutils"
 	"github.com/stackrox/rox/pkg/sync"
 )
 
@@ -58,8 +59,11 @@ func (ds *datastoreImpl) doForMatching(ctx context.Context, clusterID, namespace
 }
 
 func (ds *datastoreImpl) GetNetworkPolicies(ctx context.Context, clusterID, namespace string) ([]*storage.NetworkPolicy, error) {
-	if env.PostgresDatastoreEnabled.BooleanSetting() {
-		query := search.NewQueryBuilder().AddExactMatches(search.ClusterID, clusterID)
+	if env.PostgresDatastoreEnabled.BooleanSetting() && !stringutils.AllEmpty(clusterID, namespace) {
+		query := search.NewQueryBuilder()
+		if clusterID != "" {
+			query = query.AddExactMatches(search.ClusterID, clusterID)
+		}
 		if namespace != "" {
 			query = query.AddExactMatches(search.Namespace, namespace)
 		}

--- a/central/networkpolicies/datastore/datastore_impl_test.go
+++ b/central/networkpolicies/datastore/datastore_impl_test.go
@@ -125,13 +125,13 @@ func (s *netPolDataStoreTestSuite) TestGetNetworkPolicies() {
 	s.Equal(result, netPolNm2)
 
 	// Test we cannot do the opposite.
-	s.storage.EXPECT().Walk(gomock.Any(), gomock.Any()).Return(nil)
+	s.storage.EXPECT().GetByQuery(gomock.Any(), gomock.Any()).Return(nil, nil)
 
 	netPols, err := s.dataStore.GetNetworkPolicies(s.hasNS1ReadCtx, FakeClusterID, FakeNamespace2)
 	s.NoError(err)
 	s.Equal(0, len(netPols))
 
-	s.storage.EXPECT().Walk(gomock.Any(), gomock.Any()).Return(nil)
+	s.storage.EXPECT().GetByQuery(gomock.Any(), gomock.Any()).Return(nil, nil)
 
 	netPols, err = s.dataStore.GetNetworkPolicies(s.hasNS2ReadCtx, FakeClusterID, FakeNamespace1)
 	s.NoError(err)

--- a/central/networkpolicies/datastore/internal/store/bolt/store_impl.go
+++ b/central/networkpolicies/datastore/internal/store/bolt/store_impl.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/stackrox/rox/central/metrics"
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	ops "github.com/stackrox/rox/pkg/metrics"
 	bolt "go.etcd.io/bbolt"
@@ -29,6 +30,11 @@ func (b *storeImpl) Get(_ context.Context, id string) (np *storage.NetworkPolicy
 		return proto.Unmarshal(val, np)
 	})
 	return
+}
+
+// GetByQuery is unimplemented
+func (b *storeImpl) GetByQuery(_ context.Context, _ *v1.Query) ([]*storage.NetworkPolicy, error) {
+	panic("unimplemented")
 }
 
 func (b *storeImpl) Walk(_ context.Context, fn func(np *storage.NetworkPolicy) error) error {

--- a/central/networkpolicies/datastore/internal/store/mocks/store.go
+++ b/central/networkpolicies/datastore/internal/store/mocks/store.go
@@ -9,6 +9,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	storage "github.com/stackrox/rox/generated/storage"
 )
 
@@ -63,6 +64,21 @@ func (m *MockStore) Get(ctx context.Context, id string) (*storage.NetworkPolicy,
 func (mr *MockStoreMockRecorder) Get(ctx, id interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockStore)(nil).Get), ctx, id)
+}
+
+// GetByQuery mocks base method.
+func (m *MockStore) GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.NetworkPolicy, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetByQuery", ctx, query)
+	ret0, _ := ret[0].([]*storage.NetworkPolicy)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetByQuery indicates an expected call of GetByQuery.
+func (mr *MockStoreMockRecorder) GetByQuery(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByQuery", reflect.TypeOf((*MockStore)(nil).GetByQuery), ctx, query)
 }
 
 // Upsert mocks base method.

--- a/central/networkpolicies/datastore/internal/store/store.go
+++ b/central/networkpolicies/datastore/internal/store/store.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 )
 
@@ -11,6 +12,7 @@ import (
 //go:generate mockgen-wrapper
 type Store interface {
 	Get(ctx context.Context, id string) (*storage.NetworkPolicy, bool, error)
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*storage.NetworkPolicy, error)
 	Upsert(ctx context.Context, obj *storage.NetworkPolicy) error
 	Delete(ctx context.Context, id string) error
 

--- a/scale/workloads/10-sensors.yaml
+++ b/scale/workloads/10-sensors.yaml
@@ -23,3 +23,9 @@ rbacWorkload:
   numRoles: 3000
   numServiceAccounts: 3000
 numNamespaces: 1000
+networkPolicyWorkload:
+- lifecycleDuration: 30m0s
+  numNetworkPolicies: 5000
+  numLifecycles: 0
+  numLabels: 5
+  updateInterval: 10m0s


### PR DESCRIPTION
## Description

Getting many network policies currently uses walk for historical reasons. This is incredibly slow especially if the "query" is scoped. This will be significantly faster.

*Note*: Because this commit will be cherry-picked, I have not tried to optimize the Count function, which will need the indexer to properly work and requires substantial changes. A jira will be created for this

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Before this PR:
imageintegration/datastore: 2023/05/18 17:38:16.092213 singleton.go:58: Info: Completed deletion of 'sourced' image integrations
Got deleted at 11:45 so was running for a good hour and no new logs

On this PR:
```
central_active=# select count(*) from network_baselines;
 count 
-------
 24981
(1 row)

central_active=# select count(*) from networkpolicies;
 count 
-------
 50000
(1 row)

ks logs deploy/central -f | grep 'migrator\|8443'
Migrator: 2023/05/18 16:56:59.897196 log.go:18: Info: Run migrator.run() with version: 4.0.x-374-gbb98d3e4b9, DB sequence: 180
pkg/grpc: 2023/05/18 16:57:35.272181 server.go:379: Info: TLS-enabled multiplexed HTTP/gRPC server listening on [::]:8443
```
Booted in 36s

Scale testing, benchmarking, and e2e will ensure this works
