### PR TITLE
Dashrews/ROX-17232 bench network baseline init

### DIFF
--- a/central/networkbaseline/datastore/datastore_impl.go
+++ b/central/networkbaseline/datastore/datastore_impl.go
@@ -37,6 +37,12 @@ func GetTestPostgresDataStore(_ *testing.T, pool postgres.DB) (DataStore, error)
 	return newNetworkBaselineDataStore(dbstore), nil
 }
 
+// GetBenchPostgresDataStore provides a datastore connected to postgres for testing purposes.
+func GetBenchPostgresDataStore(_ testing.TB, pool postgres.DB) (DataStore, error) {
+	dbstore := pgStore.New(pool)
+	return newNetworkBaselineDataStore(dbstore), nil
+}
+
 // GetTestRocksBleveDataStore provides a datastore connected to rocksdb and bleve for testing purposes.
 func GetTestRocksBleveDataStore(_ *testing.T, rocksengine *rocksdbBase.RocksDB) (DataStore, error) {
 	dbstore := rocksdb.New(rocksengine)

--- a/central/networkbaseline/manager/manager_impl_bench_test.go
+++ b/central/networkbaseline/manager/manager_impl_bench_test.go
@@ -56,12 +56,9 @@ func BenchmarkInitFromStore(b *testing.B) {
 	// load it up
 	require.NoError(b, nbStore.UpsertNetworkBaselines(ctx, generateBaselines(b)))
 
-	var networkPolicys []*storage.NetworkPolicy
-	var networkPolicyIDs []string
 	for i := 0; i < 2000; i++ {
 		networkPolicy := &storage.NetworkPolicy{}
 		require.NoError(b, testutils.FullInit(networkPolicy, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
-		networkPolicys = append(networkPolicys, networkPolicy)
 		require.NoError(b, npStore.UpsertNetworkPolicy(ctx, networkPolicy))
 	}
 

--- a/central/networkbaseline/manager/manager_impl_bench_test.go
+++ b/central/networkbaseline/manager/manager_impl_bench_test.go
@@ -1,0 +1,77 @@
+//go:build sql_integration
+// +build sql_integration
+
+package manager
+
+import (
+	"context"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	deploymentMocks "github.com/stackrox/rox/central/deployment/datastore/mocks"
+	nbDS "github.com/stackrox/rox/central/networkbaseline/datastore"
+	networkEntityDS "github.com/stackrox/rox/central/networkgraph/entity/datastore"
+	networkFlowDSMocks "github.com/stackrox/rox/central/networkgraph/flow/datastore/mocks"
+	npDS "github.com/stackrox/rox/central/networkpolicies/datastore"
+	connectionMocks "github.com/stackrox/rox/central/sensor/service/connection/mocks"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
+	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stackrox/rox/pkg/testutils"
+	"github.com/stretchr/testify/require"
+)
+
+func generateBaselines(b *testing.B) []*storage.NetworkBaseline {
+	var networkBaselines []*storage.NetworkBaseline
+	for i := 0; i < 2000; i++ {
+		networkBaseline := &storage.NetworkBaseline{}
+		require.NoError(b, testutils.FullInit(networkBaseline, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
+		networkBaseline.Peers = nil
+		networkBaseline.ForbiddenPeers = nil
+		networkBaselines = append(networkBaselines, networkBaseline)
+	}
+
+	return networkBaselines
+}
+
+func BenchmarkInitFromStore(b *testing.B) {
+	mockCtrl := gomock.NewController(b)
+	ctx := sac.WithAllAccess(context.Background())
+
+	pgtestbase := pgtest.ForT(b)
+	require.NotNil(b, pgtestbase)
+
+	nbStore, err := nbDS.GetBenchPostgresDataStore(b, pgtestbase.DB)
+	require.NoError(b, err)
+	npStore, err := npDS.GetBenchPostgresDataStore(b, pgtestbase.DB)
+	require.NoError(b, err)
+	networkEntityStore, err := networkEntityDS.GetBenchPostgresDataStore(b, pgtestbase.DB)
+	require.NoError(b, err)
+
+	deploymentDS := deploymentMocks.NewMockDataStore(mockCtrl)
+	clusterFlows := networkFlowDSMocks.NewMockClusterDataStore(mockCtrl)
+
+	sensorCnxMgr := connectionMocks.NewMockManager(mockCtrl)
+
+	// load it up
+	require.NoError(b, nbStore.UpsertNetworkBaselines(ctx, generateBaselines(b)))
+
+	var networkPolicys []*storage.NetworkPolicy
+	var networkPolicyIDs []string
+	for i := 0; i < 2000; i++ {
+		networkPolicy := &storage.NetworkPolicy{}
+		require.NoError(b, testutils.FullInit(networkPolicy, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
+		networkPolicys = append(networkPolicys, networkPolicy)
+		networkPolicyIDs = append(networkPolicyIDs, networkPolicy.GetId())
+		require.NoError(b, npStore.UpsertNetworkPolicy(ctx, networkPolicy))
+	}
+
+	b.Run("New", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_, err := New(nbStore, networkEntityStore, deploymentDS, npStore, clusterFlows, sensorCnxMgr)
+			require.NoError(b, err)
+		}
+	})
+
+	log.Infof("Welcome to benching.")
+}

--- a/central/networkbaseline/manager/manager_impl_bench_test.go
+++ b/central/networkbaseline/manager/manager_impl_bench_test.go
@@ -62,7 +62,6 @@ func BenchmarkInitFromStore(b *testing.B) {
 		networkPolicy := &storage.NetworkPolicy{}
 		require.NoError(b, testutils.FullInit(networkPolicy, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 		networkPolicys = append(networkPolicys, networkPolicy)
-		networkPolicyIDs = append(networkPolicyIDs, networkPolicy.GetId())
 		require.NoError(b, npStore.UpsertNetworkPolicy(ctx, networkPolicy))
 	}
 

--- a/central/networkgraph/config/datastore/datastore_impl.go
+++ b/central/networkgraph/config/datastore/datastore_impl.go
@@ -55,6 +55,12 @@ func GetTestPostgresDataStore(_ *testing.T, pool postgres.DB) (DataStore, error)
 	return New(dbstore), nil
 }
 
+// GetBenchPostgresDataStore provides a datastore connected to postgres for testing purposes.
+func GetBenchPostgresDataStore(_ testing.TB, pool postgres.DB) (DataStore, error) {
+	dbstore := pgStore.New(pool)
+	return New(dbstore), nil
+}
+
 // GetTestRocksBleveDataStore provides a datastore connected to rocksdb and bleve for testing purposes.
 func GetTestRocksBleveDataStore(_ *testing.T, rocksengine *rocksdbBase.RocksDB) (DataStore, error) {
 	dbstore := rocksdb.New(rocksengine)

--- a/central/networkgraph/entity/datastore/datastore_impl.go
+++ b/central/networkgraph/entity/datastore/datastore_impl.go
@@ -76,6 +76,18 @@ func GetTestPostgresDataStore(t *testing.T, pool postgres.DB) (EntityDataStore, 
 	return NewEntityDataStore(dbstore, graphConfigStore, treeMgr, sensorCnxMgr), nil
 }
 
+// GetBenchPostgresDataStore provides a datastore connected to postgres for testing purposes.
+func GetBenchPostgresDataStore(t testing.TB, pool postgres.DB) (EntityDataStore, error) {
+	dbstore := pgStore.New(pool)
+	graphConfigStore, err := graphConfigDS.GetBenchPostgresDataStore(t, pool)
+	if err != nil {
+		return nil, err
+	}
+	treeMgr := networktree.Singleton()
+	sensorCnxMgr := connection.ManagerSingleton()
+	return NewEntityDataStore(dbstore, graphConfigStore, treeMgr, sensorCnxMgr), nil
+}
+
 // GetTestRocksBleveDataStore provides a datastore connected to rocksdb and bleve for testing purposes.
 func GetTestRocksBleveDataStore(t *testing.T, rocksengine *rocksdbBase.RocksDB) (EntityDataStore, error) {
 	dbstore, err := rocksdb.New(rocksengine)

--- a/central/networkpolicies/datastore/datastore.go
+++ b/central/networkpolicies/datastore/datastore.go
@@ -73,6 +73,14 @@ func GetTestPostgresDataStore(_ *testing.T, pool postgres.DB) (DataStore, error)
 	return New(dbstore, undodbstore, undodeploymentdbstore), nil
 }
 
+// GetBenchPostgresDataStore provides a datastore connected to postgres for testing purposes.
+func GetBenchPostgresDataStore(_ testing.TB, pool postgres.DB) (DataStore, error) {
+	dbstore := pgStore.New(pool)
+	undodbstore := undopostgres.New(pool)
+	undodeploymentdbstore := undoDeploymentPostgres.New(pool)
+	return New(dbstore, undodbstore, undodeploymentdbstore), nil
+}
+
 // GetTestRocksBleveDataStore provides a datastore connected to rocksdb and bleve for testing purposes.
 func GetTestRocksBleveDataStore(_ *testing.T, rocksengine *rocksdbBase.RocksDB, boltengine *bbolt.DB) (DataStore, error) {
 	dbstore := bolt.New(boltengine)


### PR DESCRIPTION
## Description

Adding a bench test to a the init of the network baseline manager.  This will help us ensure we do not degrade performance or at least narrow down instances when we do.

Testing with 2000 network baselines and 2000 network policies.
Before #6079
```
BenchmarkInitFromStore/New
BenchmarkInitFromStore/New-12                  1    59098051325 ns/op
networkbaseline/manager: 2023/05/22 10:21:07.138977 manager_impl_bench_test.go:76: Info: Welcome to benching.
PASS

cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkInitFromStore
BenchmarkInitFromStore/New
BenchmarkInitFromStore/New-12                  1    51936488329 ns/op
networkbaseline/manager: 2023/05/22 10:23:48.195401 manager_impl_bench_test.go:76: Info: Welcome to benching.
PASS
```

Same test after #6079 
```
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkInitFromStore
BenchmarkInitFromStore/New
BenchmarkInitFromStore/New-12                  3     374723104 ns/op
networkbaseline/manager: 2023/05/22 10:41:44.326502 manager_impl_bench_test.go:76: Info: Welcome to benching.
PASS
```

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
