### PR TITLE
Scope workload CVE queries to correct VulnerabilityState

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/riskAcceptanceFlow.test.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/riskAcceptanceFlow.test.js
@@ -1,0 +1,15 @@
+import withAuth from '../../../helpers/basicAuth';
+
+// TODO - These tests are intended to test the filtering/linking/etc of the Workload CVE
+// pages as it pertains to 'Vulnerability State' (Observed/Deferred/False Positive). Once the VM 2.0
+// Risk Acceptance workload is added, these tests should be filled out to ensure all flows are working correctly
+// and that the correct CVEs are being displayed on the Workload CVE pages.
+describe.skip('Workload CVE Risk Acceptance flow', () => {
+    withAuth();
+
+    describe('Observed/Deferred/False Positive CVEs', () => {
+        it('should correctly filter Observed CVEs on Workload CVE pages', () => {});
+        it('should correctly filter Deferred CVEs on Workload CVE pages', () => {});
+        it('should correctly filter False Positive CVEs on Workload CVE pages', () => {});
+    });
+});

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities.tsx
@@ -27,7 +27,7 @@ import useURLStringUnion from 'hooks/useURLStringUnion';
 import useURLSearch from 'hooks/useURLSearch';
 import useURLSort from 'hooks/useURLSort';
 import { Pagination as PaginationParam } from 'services/types';
-import { getHasSearchApplied, getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
+import { getHasSearchApplied } from 'utils/searchUtils';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
 import NotFoundMessage from 'Components/NotFoundMessage';
@@ -40,7 +40,12 @@ import CvesByStatusSummaryCard, {
     resourceCountByCveSeverityAndStatusFragment,
     ResourceCountByCveSeverityAndStatus,
 } from '../SummaryCards/CvesByStatusSummaryCard';
-import { parseQuerySearchFilter, getHiddenSeverities, getHiddenStatuses } from '../searchUtils';
+import {
+    parseQuerySearchFilter,
+    getHiddenSeverities,
+    getHiddenStatuses,
+    getCveStatusScopedQueryString,
+} from '../searchUtils';
 import { imageMetadataContextFragment } from '../Tables/table.utils';
 import DeploymentVulnerabilitiesTable, {
     deploymentWithVulnerabilitiesFragment,
@@ -98,6 +103,8 @@ function DeploymentPageVulnerabilities({ deploymentId }: DeploymentPageVulnerabi
     const hiddenSeverities = getHiddenSeverities(querySearchFilter);
     const hiddenStatuses = getHiddenStatuses(querySearchFilter);
 
+    const query = getCveStatusScopedQueryString(querySearchFilter, activeTabKey);
+
     const summaryRequest = useQuery<
         {
             deployment: {
@@ -107,10 +114,7 @@ function DeploymentPageVulnerabilities({ deploymentId }: DeploymentPageVulnerabi
         },
         { id: string; query: string }
     >(summaryQuery, {
-        variables: {
-            id: deploymentId,
-            query: getRequestQueryStringForSearchFilter(querySearchFilter),
-        },
+        variables: { id: deploymentId, query },
     });
 
     const summaryData = summaryRequest.data ?? summaryRequest.previousData;
@@ -135,11 +139,7 @@ function DeploymentPageVulnerabilities({ deploymentId }: DeploymentPageVulnerabi
             pagination: PaginationParam;
         }
     >(vulnerabilityQuery, {
-        variables: {
-            id: deploymentId,
-            query: getRequestQueryStringForSearchFilter(querySearchFilter),
-            pagination,
-        },
+        variables: { id: deploymentId, query, pagination },
     });
 
     const vulnerabilityData = vulnerabilityRequest.data ?? vulnerabilityRequest.previousData;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
@@ -26,7 +26,7 @@ import useURLSearch from 'hooks/useURLSearch';
 import useURLPagination from 'hooks/useURLPagination';
 import useURLSort from 'hooks/useURLSort';
 import { Pagination as PaginationParam } from 'services/types';
-import { getHasSearchApplied, getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
+import { getHasSearchApplied } from 'utils/searchUtils';
 import EmptyStateTemplate from 'Components/PatternFly/EmptyStateTemplate';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import WorkloadTableToolbar from '../components/WorkloadTableToolbar';
@@ -39,7 +39,12 @@ import ImageVulnerabilitiesTable, {
     imageVulnerabilitiesFragment,
 } from '../Tables/ImageVulnerabilitiesTable';
 import { DynamicTableLabel } from '../components/DynamicIcon';
-import { getHiddenSeverities, getHiddenStatuses, parseQuerySearchFilter } from '../searchUtils';
+import {
+    getHiddenSeverities,
+    getHiddenStatuses,
+    getCveStatusScopedQueryString,
+    parseQuerySearchFilter,
+} from '../searchUtils';
 import { cveStatusTabValues } from '../types';
 import BySeveritySummaryCard from '../SummaryCards/BySeveritySummaryCard';
 import { imageMetadataContextFragment, ImageMetadataContext } from '../Tables/table.utils';
@@ -71,6 +76,8 @@ export type ImagePageVulnerabilitiesProps = {
 };
 
 function ImagePageVulnerabilities({ imageId }: ImagePageVulnerabilitiesProps) {
+    const [activeTabKey, setActiveTabKey] = useURLStringUnion('cveStatus', cveStatusTabValues);
+
     const { searchFilter } = useURLSearch();
     const querySearchFilter = parseQuerySearchFilter(searchFilter);
     const { page, perPage, setPage, setPerPage } = useURLPagination(20);
@@ -104,12 +111,10 @@ function ImagePageVulnerabilities({ imageId }: ImagePageVulnerabilitiesProps) {
     >(imageVulnerabilitiesQuery, {
         variables: {
             id: imageId,
-            query: getRequestQueryStringForSearchFilter(querySearchFilter),
+            query: getCveStatusScopedQueryString(querySearchFilter, activeTabKey),
             pagination,
         },
     });
-
-    const [activeTabKey, setActiveTabKey] = useURLStringUnion('cveStatus', cveStatusTabValues);
 
     const isFiltered = getHasSearchApplied(querySearchFilter);
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/CVEsTableContainer.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/CVEsTableContainer.tsx
@@ -5,21 +5,22 @@ import { Bullseye, Spinner, Divider } from '@patternfly/react-core';
 import useURLSort from 'hooks/useURLSort';
 import useURLPagination from 'hooks/useURLPagination';
 import useURLSearch from 'hooks/useURLSearch';
-import { getHasSearchApplied, getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
+import { getHasSearchApplied } from 'utils/searchUtils';
 import CVEsTable, { cveListQuery, unfilteredImageCountQuery } from '../Tables/CVEsTable';
 import TableErrorComponent from '../components/TableErrorComponent';
 import { EntityCounts } from '../components/EntityTypeToggleGroup';
-import { DefaultFilters, VulnerabilitySeverityLabel } from '../types';
-import { parseQuerySearchFilter } from '../searchUtils';
+import { DefaultFilters, VulnerabilitySeverityLabel, CveStatusTab } from '../types';
+import { getCveStatusScopedQueryString, parseQuerySearchFilter } from '../searchUtils';
 import { defaultCVESortFields, CVEsDefaultSort } from '../sortUtils';
 import TableEntityToolbar from '../components/TableEntityToolbar';
 
 type CVEsTableContainerProps = {
     defaultFilters: DefaultFilters;
     countsData: EntityCounts;
+    cveStatusTab: CveStatusTab;
 };
 
-function CVEsTableContainer({ defaultFilters, countsData }: CVEsTableContainerProps) {
+function CVEsTableContainer({ defaultFilters, countsData, cveStatusTab }: CVEsTableContainerProps) {
     const { searchFilter } = useURLSearch();
     const querySearchFilter = parseQuerySearchFilter(searchFilter);
     const isFiltered = getHasSearchApplied(querySearchFilter);
@@ -33,9 +34,7 @@ function CVEsTableContainer({ defaultFilters, countsData }: CVEsTableContainerPr
 
     const { error, loading, data, previousData } = useQuery(cveListQuery, {
         variables: {
-            query: getRequestQueryStringForSearchFilter({
-                ...querySearchFilter,
-            }),
+            query: getCveStatusScopedQueryString(querySearchFilter, cveStatusTab),
             pagination: {
                 offset: (page - 1) * perPage,
                 limit: perPage,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/CveStatusTabNavigation.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/CveStatusTabNavigation.tsx
@@ -12,13 +12,12 @@ import {
 
 import useURLStringUnion from 'hooks/useURLStringUnion';
 import useURLSearch from 'hooks/useURLSearch';
-import { getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
 import ImagesTableContainer from './ImagesTableContainer';
 import DeploymentsTableContainer from './DeploymentsTableContainer';
 import CVEsTableContainer from './CVEsTableContainer';
 import { entityTypeCountsQuery } from '../components/EntityTypeToggleGroup';
 import { DefaultFilters, cveStatusTabValues, entityTabValues } from '../types';
-import { parseQuerySearchFilter } from '../searchUtils';
+import { getCveStatusScopedQueryString, parseQuerySearchFilter } from '../searchUtils';
 
 type CveStatusTabNavigationProps = {
     defaultFilters: DefaultFilters;
@@ -41,9 +40,7 @@ function CveStatusTabNavigation({ defaultFilters }: CveStatusTabNavigationProps)
         entityTypeCountsQuery,
         {
             variables: {
-                query: getRequestQueryStringForSearchFilter({
-                    ...querySearchFilter,
-                }),
+                query: getCveStatusScopedQueryString(querySearchFilter, activeCVEStatusKey),
             },
         }
     );
@@ -65,18 +62,21 @@ function CveStatusTabNavigation({ defaultFilters }: CveStatusTabNavigationProps)
                                 <CVEsTableContainer
                                     defaultFilters={defaultFilters}
                                     countsData={countsData}
+                                    cveStatusTab={activeCVEStatusKey}
                                 />
                             )}
                             {activeEntityTabKey === 'Image' && (
                                 <ImagesTableContainer
                                     defaultFilters={defaultFilters}
                                     countsData={countsData}
+                                    cveStatusTab={activeCVEStatusKey}
                                 />
                             )}
                             {activeEntityTabKey === 'Deployment' && (
                                 <DeploymentsTableContainer
                                     defaultFilters={defaultFilters}
                                     countsData={countsData}
+                                    cveStatusTab={activeCVEStatusKey}
                                 />
                             )}
                         </CardBody>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/DeploymentsTableContainer.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/DeploymentsTableContainer.tsx
@@ -5,21 +5,26 @@ import { Bullseye, Spinner, Divider } from '@patternfly/react-core';
 import useURLSort from 'hooks/useURLSort';
 import useURLPagination from 'hooks/useURLPagination';
 import useURLSearch from 'hooks/useURLSearch';
-import { getHasSearchApplied, getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
+import { getHasSearchApplied } from 'utils/searchUtils';
 import DeploymentsTable, { Deployment, deploymentListQuery } from '../Tables/DeploymentsTable';
 import TableErrorComponent from '../components/TableErrorComponent';
 import TableEntityToolbar from '../components/TableEntityToolbar';
 import { EntityCounts } from '../components/EntityTypeToggleGroup';
-import { parseQuerySearchFilter } from '../searchUtils';
+import { getCveStatusScopedQueryString, parseQuerySearchFilter } from '../searchUtils';
 import { defaultDeploymentSortFields, deploymentsDefaultSort } from '../sortUtils';
-import { DefaultFilters, VulnerabilitySeverityLabel } from '../types';
+import { DefaultFilters, VulnerabilitySeverityLabel, CveStatusTab } from '../types';
 
 type DeploymentsTableContainerProps = {
     defaultFilters: DefaultFilters;
     countsData: EntityCounts;
+    cveStatusTab: CveStatusTab;
 };
 
-function DeploymentsTableContainer({ defaultFilters, countsData }: DeploymentsTableContainerProps) {
+function DeploymentsTableContainer({
+    defaultFilters,
+    countsData,
+    cveStatusTab,
+}: DeploymentsTableContainerProps) {
     const { searchFilter } = useURLSearch();
     const querySearchFilter = parseQuerySearchFilter(searchFilter);
     const isFiltered = getHasSearchApplied(querySearchFilter);
@@ -35,9 +40,7 @@ function DeploymentsTableContainer({ defaultFilters, countsData }: DeploymentsTa
         deployments: Deployment[];
     }>(deploymentListQuery, {
         variables: {
-            query: getRequestQueryStringForSearchFilter({
-                ...querySearchFilter,
-            }),
+            query: getCveStatusScopedQueryString(querySearchFilter, cveStatusTab),
             pagination: {
                 offset: (page - 1) * perPage,
                 limit: perPage,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/ImagesTableContainer.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/ImagesTableContainer.tsx
@@ -5,21 +5,26 @@ import { Bullseye, Spinner, Divider } from '@patternfly/react-core';
 import useURLSort from 'hooks/useURLSort';
 import useURLPagination from 'hooks/useURLPagination';
 import useURLSearch from 'hooks/useURLSearch';
-import { getHasSearchApplied, getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
+import { getHasSearchApplied } from 'utils/searchUtils';
 import ImagesTable, { imageListQuery } from '../Tables/ImagesTable';
 import TableErrorComponent from '../components/TableErrorComponent';
 import { EntityCounts } from '../components/EntityTypeToggleGroup';
-import { parseQuerySearchFilter } from '../searchUtils';
+import { getCveStatusScopedQueryString, parseQuerySearchFilter } from '../searchUtils';
 import { defaultImageSortFields, imagesDefaultSort } from '../sortUtils';
-import { DefaultFilters, VulnerabilitySeverityLabel } from '../types';
+import { DefaultFilters, VulnerabilitySeverityLabel, CveStatusTab } from '../types';
 import TableEntityToolbar from '../components/TableEntityToolbar';
 
 type ImagesTableContainerProps = {
     defaultFilters: DefaultFilters;
     countsData: EntityCounts;
+    cveStatusTab: CveStatusTab;
 };
 
-function ImagesTableContainer({ defaultFilters, countsData }: ImagesTableContainerProps) {
+function ImagesTableContainer({
+    defaultFilters,
+    countsData,
+    cveStatusTab,
+}: ImagesTableContainerProps) {
     const { searchFilter } = useURLSearch();
     const querySearchFilter = parseQuerySearchFilter(searchFilter);
     const isFiltered = getHasSearchApplied(querySearchFilter);
@@ -34,9 +39,7 @@ function ImagesTableContainer({ defaultFilters, countsData }: ImagesTableContain
 
     const { error, loading, data, previousData } = useQuery(imageListQuery, {
         variables: {
-            query: getRequestQueryStringForSearchFilter({
-                ...querySearchFilter,
-            }),
+            query: getCveStatusScopedQueryString(querySearchFilter, cveStatusTab),
             pagination: {
                 offset: (page - 1) * perPage,
                 limit: perPage,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/searchUtils.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/searchUtils.tsx
@@ -1,10 +1,14 @@
 import qs from 'qs';
 
 import { vulnerabilitiesWorkloadCvesPath } from 'routePaths';
-import { VulnerabilitySeverity, vulnerabilitySeverities } from 'types/cve.proto';
+import {
+    VulnerabilitySeverity,
+    VulnerabilityState,
+    vulnerabilitySeverities,
+} from 'types/cve.proto';
 import { SearchFilter } from 'types/search';
 import { getQueryString } from 'utils/queryStringUtils';
-import { searchValueAsArray } from 'utils/searchUtils';
+import { searchValueAsArray, getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
 import { ensureExhaustive } from 'utils/type.utils';
 
 import { CveStatusTab, FixableStatus, isValidCveStatusTab, QuerySearchFilter } from './types';
@@ -121,4 +125,23 @@ export function getHiddenStatuses(querySearchFilter: QuerySearchFilter): Set<Fix
     }
 
     return hiddenStatuses;
+}
+
+// Map from the CVE status tab to the backend equivalent search value
+const vulnerabilitySearchStateForCveStatus: Record<CveStatusTab, VulnerabilityState> = {
+    Observed: 'OBSERVED',
+    Deferred: 'DEFERRED',
+    'False Positive': 'FALSE_POSITIVE',
+} as const;
+
+// Returns a search filter string that scopes results to a CVE Workflow state (e.g. 'OBSERVED')
+export function getCveStatusScopedQueryString(
+    searchFilter: QuerySearchFilter,
+    cveStatusTab: CveStatusTab
+): string {
+    const vulnerabilityState = vulnerabilitySearchStateForCveStatus[cveStatusTab];
+    return getRequestQueryStringForSearchFilter({
+        ...searchFilter,
+        'Vulnerability State': [vulnerabilityState],
+    });
 }


### PR DESCRIPTION
## Description

Correctly scopes data according to the Observed/Deferred/False positive state of CVEs according to the selected tab.

Note that the CVE single page is unscoped - it will list all images/deployments containing the CVE regardless of the status of the CVE in that particular entity. This is a known edge case that will be addressed post MVP.

**Note: It has been decided to move this functionality to post-MVP and a follow up PR will disable the CveStatusTabs. This is left in since we will still want the logic once the functionality is re-enabled **

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

From the main overview page, check the total number of CVEs. In this system all CVEs are observed. CVE-2004-0971 will be marked as **Deferred** and CVE-2009-5155 will be marked as **False positive**. Each of these CVEs has a different severity and belongs to exactly one image and one deployment - the image is the apache-struts2-cve image. Verify CVE counts for this image before marking the above CVEs.
![image](https://github.com/stackrox/stackrox/assets/1292638/a30345ef-77ff-4eb0-98cf-c27a6e9ee7f5)
![image](https://github.com/stackrox/stackrox/assets/1292638/391a6912-e019-408e-a7ea-ee6f7d022765)
![image](https://github.com/stackrox/stackrox/assets/1292638/d517b5b4-da6c-4ec3-a731-080bf06f16a4)
![image](https://github.com/stackrox/stackrox/assets/1292638/edb64860-ebb7-4079-9bf2-215c17334807)
![image](https://github.com/stackrox/stackrox/assets/1292638/cd3b21f7-1ec4-477d-892f-234694ee75c3)

After marking the first CVE (Severity: Low, Fixable: false) as deferred:
![image](https://github.com/stackrox/stackrox/assets/1292638/fde0fbc1-ab81-42d2-a728-e006469fd70e)
![image](https://github.com/stackrox/stackrox/assets/1292638/29fe2cb8-72ad-4c49-974d-8866bb20d918)
![image](https://github.com/stackrox/stackrox/assets/1292638/d41ab34e-ec1a-4fb3-a0b3-b3644d42b745)
![image](https://github.com/stackrox/stackrox/assets/1292638/634e4211-5865-4b6a-9575-1fd950a0839e)
![image](https://github.com/stackrox/stackrox/assets/1292638/f6b48663-8d9b-49c1-a29b-6e1508865855)

After marking the second CVE (Severity: Important, Fixable: false) as false positive:
![image](https://github.com/stackrox/stackrox/assets/1292638/c33bce05-1007-4a9f-9275-18a519e75983)
![image](https://github.com/stackrox/stackrox/assets/1292638/ccafd357-087f-4a6a-bcf2-34f3f0c834bd)
![image](https://github.com/stackrox/stackrox/assets/1292638/f5bf76ae-47c6-4273-a525-36fd57e68c7e)
![image](https://github.com/stackrox/stackrox/assets/1292638/348d8899-dcb9-4e01-bbf3-029f1518275a)
![image](https://github.com/stackrox/stackrox/assets/1292638/a58b6d17-b7ef-40c6-a92f-2c23a6f30e2a)
