### PR TITLE
ROX-17001: Simplify unreliable selector in Vulnerability Management integration tests

### DIFF
--- a/ui/apps/platform/cypress/helpers/vulnmanagement/entities.js
+++ b/ui/apps/platform/cypress/helpers/vulnmanagement/entities.js
@@ -243,6 +243,23 @@ export function interactAndWaitForVulnerabilityManagementSecondaryEntities(
  * for example, /^\d+ deployments?$/
  */
 
+// ROX-17001: to solve problems where count and singular/plural of noun might have changed,
+// the second and third properties are not used.
+
+// After accessibility-related changes to case of entity types,
+// getCountAndNoun functions might become obsolete, as follows:
+
+// 1. TODO because panelHeaderText theoretically has similar problem.
+//    Replace contains pseudo-selector for panelHeaderText
+//    with contains method and RegExp for exact match:
+//    of digits (not necessarily same as from the link) and
+//    correct case entity type noun with optional plural suffix.
+
+// 2. TODO because visible text is better than data-testid attribute.
+//    Replace selector which has data-testid attribute
+//    with contains method and RegExp for exact match:
+//    correct case entity type noun with optional plural suffix.
+
 function getCountAndNounFromSecondaryEntitiesLinkResults(resultsFromRegExp) {
     return {
         panelHeaderText: resultsFromRegExp[0],
@@ -318,8 +335,9 @@ function verifyLinkCountDeep(
     cy.get(selectors.getTableDataColumnSelector(columnIndex))
         .contains('a', entitiesRegExp2)
         .then(($a) => {
-            const { panelHeaderText, relatedEntitiesCount, relatedEntitiesNoun } =
-                getCountAndNounFromLinkResults(/^(\d+) (\D+)$/.exec($a.text()));
+            const { panelHeaderText } = getCountAndNounFromLinkResults(
+                /^(\d+) (\D+)$/.exec($a.text())
+            );
 
             // 2. Visit secondary entities side panel.
             interactAndWaitForResponses(() => {
@@ -335,7 +353,8 @@ function verifyLinkCountDeep(
 
             // Tilde because link might be under either Contains or Matches.
             // Match data-testid attribute of link to distinguish 1 IMAGE from 114 IMAGE COMPONENTS.
-            const relatedEntitiesSelector = `h2:contains("Related entities") ~ div ul li a[data-testid="${typeOfEntity[entitiesKey2]}-tile-link"]:has('[data-testid="tileLinkSuperText"]:contains("${relatedEntitiesCount}")'):has('[data-testid="tile-link-value"]:contains("${relatedEntitiesNoun}")')`;
+            // Omit has for visible text of count or name of entity because it might have changed (especially for deployments).
+            const relatedEntitiesSelector = `h2:contains("Related entities") ~ div ul li a[data-testid="${typeOfEntity[entitiesKey2]}-tile-link"]`;
             cy.get(relatedEntitiesSelector);
 
             // 4. Visit single page for primary entity.


### PR DESCRIPTION
## Description

### Problem

Problem was overlooked on GKE but occurs often on OpenShift.

Vulnerability Management Clusters should display links for deployments: should display links for deployments

> Timed out retrying after 4000ms: Expected to find element: `h2:contains("Related entities") ~ div ul li a[data-testid="DEPLOYMENT-tile-link"]:has('[data-testid="tileLinkSuperText"]:contains("120")'):has('[data-testid="tile-link-value"]:contains("DEPLOYMENTS")')`, but never found it.

cypress/helpers/vulnmanagement/entities.js
cypress/integration/vulnmanagement/clusters.test.js

Selector has 120 from deployments link in clusters table, but related entities link had 121 in side panel.
![ROX-17001](https://github.com/stackrox/stackrox/assets/11862657/bd25a1cf-1cf9-490c-b509-b3ed95bbbb88)

### Analysis

Thanks to Van for identifying the root of the problem:

Count of deployments changed between steps 1 and 3:
1. clusters page renders deployments link in table
2. click link to open deployments in side panel
3. click link to visit cluster page, which renders deployments link in related entities area

This is an example of mis-using UI as source of truth when Kubernetes environment might have changed.

### Solution

1. Remove `relatedEntitiesCount` and `relatedEntitiesNoun` from selector for related entities links, because they are redundant with `data-testid` attribute.

### Residue

Here are TODO comments:

```js
// After accessibility-related changes to case of entity types,
// getCountAndNoun functions might become obsolete, as follows:

// 1. TODO because panelHeaderText theoretically has similar problem.
//    Replace contains pseudo-selector for panelHeaderText
//    with contains method and RegExp for exact match:
//    of digits (not necessarily same as from the link) and
//    correct case entity type noun with optional plural suffix.

// 2. TODO because visible text is better than data-testid attribute.
//    Replace selector which has data-testid attribute
//    with contains method and RegExp for exact match:
//    correct case entity type noun with optional plural suffix.
```

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed

### Integration testing

In ui/apps/platform folder:

1. `export CYPRESS_ROX_POSTGRES_DATASTORE=true`

3. `yarn cypress-open`

    * vulnmanagement/clusters.test.js
    * vulnmanagement/clusterCves.test.js
    * vulnmanagement/deployments.test.js
    * vulnmanagement/imageComponents.test.js
    * vulnmanagement/imageCves.test.js
    * vulnmanagement/images.test.js
    * vulnmanagement/namespaces.test.js
    * vulnmanagement/nodeComponents.test.js
    * vulnmanagement/nodeCves.test.js
    * vulnmanagement/nodes.test.js
    * vulnmanagement/policies.test.js
