### PR TITLE
Specify explicit versions for dependencies in `build.gradle`

### DIFF
--- a/qa-tests-backend/build.gradle
+++ b/qa-tests-backend/build.gradle
@@ -22,6 +22,8 @@ def protobufVersion = '3.23.1'
 def nettyTcNativeVersion = '2.0.45.Final'
 def fabric8Version = '6.6.2'
 def jacksonVersion = '2.14.2'
+def groovyVersion = '4.0.12'
+def spockVersion = '2.3-groovy-4.0'
 
 protobuf {
     // There is no protoc-grpc-gen for Apple Silicon (M1), so if you are running on it, force the osx-x86_64 version
@@ -69,19 +71,19 @@ dependencies {
     implementation "com.google.protobuf:protobuf-java-util:${protobufVersion}"
     implementation "io.netty:netty-tcnative-boringssl-static:${nettyTcNativeVersion}"
 
-    implementation platform('org.apache.groovy:groovy-bom:4.0.12')
-    implementation 'org.apache.groovy:groovy'
-    implementation platform("org.spockframework:spock-bom:2.3-groovy-4.0")
-    implementation "org.spockframework:spock-core"
-    implementation "org.spockframework:spock-junit4"
+    implementation platform("org.apache.groovy:groovy-bom:${groovyVersion}")
+    implementation "org.apache.groovy:groovy:${groovyVersion}"
+    implementation platform("org.spockframework:spock-bom:${spockVersion}")
+    implementation "org.spockframework:spock-core:${spockVersion}"
+    implementation "org.spockframework:spock-junit4:${spockVersion}"
     implementation 'io.rest-assured:rest-assured:5.3.0'
     testImplementation group: 'org.yaml', name: 'snakeyaml', version: '2.0'
     implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.3.7'
     testImplementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: jacksonVersion
     testImplementation group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version: jacksonVersion
     testImplementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: jacksonVersion
-    implementation group: 'com.google.protobuf', name: 'protobuf-java', version: "${protobufVersion}"
-    implementation group: 'com.google.protobuf', name: 'protobuf-java-util', version: "${protobufVersion}"
+    implementation group: 'com.google.protobuf', name: 'protobuf-java', version: protobufVersion
+    implementation group: 'com.google.protobuf', name: 'protobuf-java-util', version: protobufVersion
 
     // Use the Kubernetes API
     implementation "io.fabric8:kubernetes-client:${fabric8Version}"


### PR DESCRIPTION
## Description

Relying on dependencies resolution isn't secure, can lead to build problems and requires more actions from developers to understand which actual version is used.
For this reason, I believe it's best to provide desired versions explicitly.

I obtained the current versions by running a command similar to the following for each dependency:

```
./gradlew dependencyInsight --dependency org.apache.groovy:groovy
```

## Checklist
- [ ] Investigated and inspected CI test results

None of the following are relevant:
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

- [ ] Groovy test run reveals no Groovy class incompatibilities.