### PR TITLE
Dashrews/ROX-17195 set version when no migration

### DIFF
--- a/migrator/runner/runner.go
+++ b/migrator/runner/runner.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	versionStorage "github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/migrator/log"
 	"github.com/stackrox/rox/migrator/migrations"
 	"github.com/stackrox/rox/migrator/types"
@@ -58,6 +59,14 @@ func Run(databases *types.Databases) error {
 		}
 	} else {
 		log.WriteToStderrf("DB is up to date at version %d. Nothing to do here.", dbSeqNum)
+	}
+
+	// Make sure version is up to date after migrations to ensure latest version schema is used in the event
+	// there are no migrations executed.
+	currentVersion := &versionStorage.Version{SeqNum: int32(pkgMigrations.CurrentDBVersionSeqNum())}
+	err = updateVersion(databases, currentVersion)
+	if err != nil {
+		return errors.Wrapf(err, "failed to update version after migrations %d", currentVersion.SeqNum)
 	}
 
 	return nil


### PR DESCRIPTION
## Description

This issue arose because in staging-db we upgrade within the release to stay current.  This issue would not have impacted a customer as migrations would have executed and the version table would have been upgraded appropriately.  A migration for the version and this case would be a lot of extra overhead.  We just need to ensure that after the migrations are done we set the sequence number to be the latest.  

(@vjwilson added you here for awareness)

## Checklist
- [ ] Investigated and inspected CI test results
~- [ ] Unit test and regression tests added~
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Ran various iterations of upgrades.
3.74 -> this PR
3.74 -> 4.0.0 -> this PR
4.0.0 -> this PR
4.0.0 -> 4.0.x-372-g5434f93a80 (the one where it breaks) -> this PR
3.74 -> 4.0.0 -> 4.0.x-372-g5434f93a80 -> this PR

All behave as expected and most importantly any upgrade from the image that has staging-db crashed to the images in this PR, will fix the version table and start up with the rest of the data in tact.
