### PR TITLE
ROX-16957: Switch out of the box RPM Policies to label-based exclusions

### DIFF
--- a/migrator/migrations/m_180_to_m_181_rpm_policies_to_labels/migration.go
+++ b/migrator/migrations/m_180_to_m_181_rpm_policies_to_labels/migration.go
@@ -1,0 +1,56 @@
+package m180tom181
+
+import (
+	"embed"
+
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/migrator/migrations"
+	postgresHelper "github.com/stackrox/rox/migrator/migrations/m_179_to_m_180_openshift_policy_exclusions/postgres"
+	"github.com/stackrox/rox/migrator/migrations/policymigrationhelper"
+	"github.com/stackrox/rox/migrator/types"
+	"github.com/stackrox/rox/pkg/postgres"
+)
+
+var (
+	migration = types.Migration{
+		StartingSeqNum: 180,
+		VersionAfter:   &storage.Version{SeqNum: 181},
+		Run: func(databases *types.Databases) error {
+			err := updatePolicies(databases.PostgresDB)
+			if err != nil {
+				return errors.Wrap(err, "updating policies")
+			}
+			return nil
+		},
+	}
+
+	//go:embed policies_before_and_after
+	policyDiffFS embed.FS
+
+	// We want to migrate only if the existing policy sections,name and description haven't changed.
+	fieldsToCompare = []postgresHelper.FieldComparator{
+		policymigrationhelper.DescriptionComparator,
+		policymigrationhelper.PolicySectionComparator,
+		policymigrationhelper.NameComparator,
+	}
+
+	policyDiffs = []postgresHelper.PolicyDiff{
+		{
+			FieldsToCompare: fieldsToCompare,
+			PolicyFileName:  "dnf.json",
+		},
+		{
+			FieldsToCompare: fieldsToCompare,
+			PolicyFileName:  "exec-dnf.json",
+		},
+	}
+)
+
+func updatePolicies(db postgres.DB) error {
+	return postgresHelper.MigratePoliciesWithDiffs(db, policyDiffFS, policyDiffs)
+}
+
+func init() {
+	migrations.MustRegisterMigration(migration)
+}

--- a/migrator/migrations/m_180_to_m_181_rpm_policies_to_labels/policies_before_and_after/after/dnf.json
+++ b/migrator/migrations/m_180_to_m_181_rpm_policies_to_labels/policies_before_and_after/after/dnf.json
@@ -1,0 +1,99 @@
+{
+  "id": "f95ff08d-130a-465a-a27e-32ed1fb05555",
+  "name": "Red Hat Package Manager in Image",
+  "description": "Alert on deployments with components of the Red Hat/Fedora/CentOS package management system.",
+  "rationale": "Package managers make it easier for attackers to use compromised containers, since they can easily add software.",
+  "remediation": "Run `rpm -e --nodeps $(rpm -qa '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*')` in the image build for production containers.",
+  "categories": [
+    "Security Best Practices"
+  ],
+  "lifecycleStages": [
+    "BUILD",
+    "DEPLOY"
+  ],
+  "exclusions": [
+    {
+      "name": "Don't alert on deployment collector",
+      "deployment": {
+        "name": "",
+        "scope": {
+          "label": {
+            "key": "app.kubernetes.io/component",
+            "value": "collector"
+          }
+        }
+      }
+    },
+    {
+      "name": "Don't alert on deployment sensor",
+      "deployment": {
+        "scope": {
+          "label": {
+            "key": "app.kubernetes.io/component",
+            "value": "sensor"
+          }
+        }
+      }
+    },
+    {
+      "name": "Don't alert on deployment central",
+      "deployment": {
+        "scope": {
+          "label": {
+            "key": "app.kubernetes.io/component",
+            "value": "central"
+          }
+        }
+      }
+    },
+    {
+      "name": "Don't alert on deployment admission-control",
+      "deployment": {
+        "scope": {
+          "label": {
+            "key": "app.kubernetes.io/component",
+            "value": "scanner"
+          }
+        }
+      }
+    },
+    {
+      "name": "Don't alert on StackRox scanner",
+      "deployment": {
+        "scope": {
+          "label": {
+            "key": "app.kubernetes.io/component",
+            "value": "admission-control"
+          }
+        }
+      }
+    },
+    {
+      "name": "Don't alert on system namespaces",
+      "deployment": {
+        "scope": {
+          "namespace": "^kube.*|^openshift.*|^redhat.*|^istio-system$"
+        }
+      }
+    }
+  ],
+  "severity": "LOW_SEVERITY",
+  "policyVersion": "1.1",
+  "policySections": [
+    {
+      "policyGroups": [
+        {
+          "fieldName": "Image Component",
+          "values": [
+            {
+              "value": "rpm|microdnf|dnf|yum="
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "criteriaLocked": true,
+  "mitreVectorsLocked": true,
+  "isDefault": true
+}

--- a/migrator/migrations/m_180_to_m_181_rpm_policies_to_labels/policies_before_and_after/after/exec-dnf.json
+++ b/migrator/migrations/m_180_to_m_181_rpm_policies_to_labels/policies_before_and_after/after/exec-dnf.json
@@ -1,0 +1,73 @@
+{
+  "id": "ddb7af9c-5ec1-45e1-a0cf-c36e3ef2b2ce",
+  "name": "Red Hat Package Manager Execution",
+  "description": "Alert when Red Hat/Fedora/CentOS package manager programs are executed at runtime.",
+  "rationale": "Use of package managers at runtime indicates that new software may be being introduced into containers while they are running.",
+  "remediation": "Run `rpm -e --nodeps $(rpm -qa '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*')` in the image build for production containers. Change applications to no longer use package managers at runtime, if applicable.",
+  "categories": [
+    "Security Best Practices"
+  ],
+  "lifecycleStages": [
+    "RUNTIME"
+  ],
+  "eventSource": "DEPLOYMENT_EVENT",
+  "exclusions": [
+    {
+      "name": "Don't alert on StackRox scanner",
+      "deployment": {
+        "scope": {
+          "label": {
+            "key": "app.kubernetes.io/component",
+            "value": "scanner"
+          }
+        }
+      }
+    },
+    {
+      "name": "Don't alert on StackRox collector",
+      "deployment": {
+        "scope": {
+          "label": {
+            "key": "app.kubernetes.io/component",
+            "value": "collector"
+          }
+        }
+      }
+    },
+    {
+      "name": "Don't alert on openshift-compliance namespace",
+      "deployment": {
+        "scope": {
+          "namespace": "openshift-compliance"
+        }
+      }
+    }
+  ],
+  "severity": "LOW_SEVERITY",
+  "policyVersion": "1.1",
+  "policySections": [
+    {
+      "policyGroups": [
+        {
+          "fieldName": "Process Name",
+          "values": [
+            {
+              "value": "rpm|microdnf|dnf|yum"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "mitreAttackVectors": [
+    {
+      "tactic": "TA0011",
+      "techniques": [
+        "T1105"
+      ]
+    }
+  ],
+  "criteriaLocked": true,
+  "mitreVectorsLocked": true,
+  "isDefault": true
+}

--- a/migrator/migrations/m_180_to_m_181_rpm_policies_to_labels/policies_before_and_after/before/dnf.json
+++ b/migrator/migrations/m_180_to_m_181_rpm_policies_to_labels/policies_before_and_after/before/dnf.json
@@ -1,0 +1,88 @@
+{
+  "id": "f95ff08d-130a-465a-a27e-32ed1fb05555",
+  "name": "Red Hat Package Manager in Image",
+  "description": "Alert on deployments with components of the Red Hat/Fedora/CentOS package management system.",
+  "rationale": "Package managers make it easier for attackers to use compromised containers, since they can easily add software.",
+  "remediation": "Run `rpm -e --nodeps $(rpm -qa '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*')` in the image build for production containers.",
+  "categories": [
+    "Security Best Practices"
+  ],
+  "lifecycleStages": [
+    "BUILD",
+    "DEPLOY"
+  ],
+  "exclusions": [
+    {
+      "name": "Don't alert on deployment collector in namespace stackrox",
+      "deployment": {
+        "name": "collector",
+        "scope": {
+          "namespace": "stackrox"
+        }
+      }
+    },
+    {
+      "name": "Don't alert on deployment sensor in namespace stackrox",
+      "deployment": {
+        "name": "sensor",
+        "scope": {
+          "namespace": "stackrox"
+        }
+      }
+    },
+    {
+      "name": "Don't alert on deployment central in namespace stackrox",
+      "deployment": {
+        "name": "central",
+        "scope": {
+          "namespace": "stackrox"
+        }
+      }
+    },
+    {
+      "name": "Don't alert on deployment admission-control in namespace stackrox",
+      "deployment": {
+        "name": "admission-control",
+        "scope": {
+          "namespace": "stackrox"
+        }
+      }
+    },
+    {
+      "name": "Don't alert on StackRox scanner",
+      "deployment": {
+        "name": "scanner",
+        "scope": {
+          "namespace": "stackrox"
+        }
+      }
+    },
+    {
+      "name": "Don't alert on system namespaces",
+      "deployment": {
+        "scope": {
+          "namespace": "^kube.*|^openshift.*|^redhat.*|^istio-system$"
+        }
+      }
+    }
+  ],
+  "severity": "LOW_SEVERITY",
+  "policyVersion": "1.1",
+  "policySections": [
+    {
+      "policyGroups": [
+        {
+          "fieldName": "Image Component",
+          "values": [
+            {
+              "value": "rpm|microdnf|dnf|yum="
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "criteriaLocked": true,
+  "mitreVectorsLocked": true,
+  "isDefault": true
+}

--- a/migrator/migrations/m_180_to_m_181_rpm_policies_to_labels/policies_before_and_after/before/exec-dnf.json
+++ b/migrator/migrations/m_180_to_m_181_rpm_policies_to_labels/policies_before_and_after/before/exec-dnf.json
@@ -1,0 +1,60 @@
+{
+  "id": "ddb7af9c-5ec1-45e1-a0cf-c36e3ef2b2ce",
+  "name": "Red Hat Package Manager Execution",
+  "description": "Alert when Red Hat/Fedora/CentOS package manager programs are executed at runtime.",
+  "rationale": "Use of package managers at runtime indicates that new software may be being introduced into containers while they are running.",
+  "remediation": "Run `rpm -e --nodeps $(rpm -qa '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*')` in the image build for production containers. Change applications to no longer use package managers at runtime, if applicable.",
+  "categories": [
+    "Security Best Practices"
+  ],
+  "lifecycleStages": [
+    "RUNTIME"
+  ],
+  "eventSource": "DEPLOYMENT_EVENT",
+  "exclusions": [
+    {
+      "name": "Don't alert on StackRox scanner",
+      "deployment": {
+        "name": "scanner",
+        "scope": {
+          "namespace": "stackrox"
+        }
+      }
+    },
+    {
+      "name": "Don't alert on openshift-compliance namespace",
+      "deployment": {
+        "scope": {
+          "namespace": "openshift-compliance"
+        }
+      }
+    }
+  ],
+  "severity": "LOW_SEVERITY",
+  "policyVersion": "1.1",
+  "policySections": [
+    {
+      "policyGroups": [
+        {
+          "fieldName": "Process Name",
+          "values": [
+            {
+              "value": "rpm|microdnf|dnf|yum"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "mitreAttackVectors": [
+    {
+      "tactic": "TA0011",
+      "techniques": [
+        "T1105"
+      ]
+    }
+  ],
+  "criteriaLocked": true,
+  "mitreVectorsLocked": true,
+  "isDefault": true
+}

--- a/pkg/defaults/policies/files/dnf.json
+++ b/pkg/defaults/policies/files/dnf.json
@@ -13,47 +13,58 @@
   ],
   "exclusions": [
     {
-      "name": "Don't alert on deployment collector in namespace stackrox",
+      "name": "Don't alert on deployment collector",
       "deployment": {
-        "name": "collector",
+        "name": "",
         "scope": {
-          "namespace": "stackrox"
+          "label": {
+            "key": "app.kubernetes.io/component",
+            "value": "collector"
+          }
         }
       }
     },
     {
-      "name": "Don't alert on deployment sensor in namespace stackrox",
+      "name": "Don't alert on deployment sensor",
       "deployment": {
-        "name": "sensor",
         "scope": {
-          "namespace": "stackrox"
+          "label": {
+            "key": "app.kubernetes.io/component",
+            "value": "sensor"
+          }
         }
       }
     },
     {
-      "name": "Don't alert on deployment central in namespace stackrox",
+      "name": "Don't alert on deployment central",
       "deployment": {
-        "name": "central",
         "scope": {
-          "namespace": "stackrox"
+          "label": {
+            "key": "app.kubernetes.io/component",
+            "value": "central"
+          }
         }
       }
     },
     {
-      "name": "Don't alert on deployment admission-control in namespace stackrox",
+      "name": "Don't alert on deployment admission-control",
       "deployment": {
-        "name": "admission-control",
         "scope": {
-          "namespace": "stackrox"
+          "label": {
+            "key": "app.kubernetes.io/component",
+            "value": "scanner"
+          }
         }
       }
     },
     {
       "name": "Don't alert on StackRox scanner",
       "deployment": {
-        "name": "scanner",
         "scope": {
-          "namespace": "stackrox"
+          "label": {
+            "key": "app.kubernetes.io/component",
+            "value": "admission-control"
+          }
         }
       }
     },

--- a/pkg/defaults/policies/files/exec-dnf.json
+++ b/pkg/defaults/policies/files/exec-dnf.json
@@ -15,9 +15,22 @@
     {
       "name": "Don't alert on StackRox scanner",
       "deployment": {
-        "name": "scanner",
         "scope": {
-          "namespace": "stackrox"
+          "label": {
+            "key": "app.kubernetes.io/component",
+            "value": "scanner"
+          }
+        }
+      }
+    },
+    {
+      "name": "Don't alert on StackRox collector",
+      "deployment": {
+        "scope": {
+          "label": {
+            "key": "app.kubernetes.io/component",
+            "value": "collector"
+          }
         }
       }
     },


### PR DESCRIPTION
## Description

Two of our stock policies have been switched to a label-based exclusion.
So far, our policies have been excluding our deployments based on `namespace`  + ` deployment name`.
This leads to a lot of policy violations, should users choose to install ACS/StackRox into a namespace other than `stackrox`.
Hence, this change switches to a label-based approach where the `app.kubernetes.io/component` label is evaluated instead, yielding a state where violations will not be triggered even when ACS/StackRox is deployed into a non-recommended namespace.

As this was surfaced in the context of RHCOS Node Scanning feature GA, this PR only updates the two policies which are triggered in RHCOS context:
- Red Hat Package Manager in Image
- Red Hat Package Manager Execution

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Testing was performed by manually deploying into a namespace not named `stackrox` and observing that none RPM-related violations are triggered.
