### PR TITLE
Add timeout to backup test

### DIFF
--- a/tests/backup_test.go
+++ b/tests/backup_test.go
@@ -47,14 +47,17 @@ func doTestBackup(t *testing.T, includeCerts bool) {
 	require.NoError(t, err)
 
 	client := centralgrpc.HTTPClientForCentral(t)
+
+	// Backup could be long depend on the size of current database.
+	// Allow up to 3 minutes.
+	backupTimeout := 3 * time.Minute
+	client.Timeout = backupTimeout
 	endpoint := "/db/backup"
 	if includeCerts {
 		endpoint = "/api/extensions/backup"
 	}
 
-	// Backup could be long depend on the size of current database.
-	// Allow up to 5 minutes to backup.
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), backupTimeout)
 	defer cancel()
 
 	req, err := http.NewRequestWithContext(ctx, "GET", endpoint, nil)


### PR DESCRIPTION
## Description

Non-groovy test fail in backup test frequently due to timeout. This PR increate the timeout.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
