### PR TITLE
ROX-17163: [3.74] Format Go code for 1.19

### DIFF
--- a/central/activecomponent/datastore/datastore.go
+++ b/central/activecomponent/datastore/datastore.go
@@ -18,6 +18,7 @@ import (
 )
 
 // DataStore is an intermediary to ActiveComponent storage.
+//
 //go:generate mockgen-wrapper
 type DataStore interface {
 	Search(ctx context.Context, query *v1.Query) ([]pkgSearch.Result, error)

--- a/central/activecomponent/datastore/index/indexer.go
+++ b/central/activecomponent/datastore/index/indexer.go
@@ -9,8 +9,9 @@ import (
 	"github.com/stackrox/rox/pkg/search/blevesearch"
 )
 
-//go:generate mockgen-wrapper
 // Indexer is the interface for indexing active component
+//
+//go:generate mockgen-wrapper
 type Indexer interface {
 	Count(ctx context.Context, q *v1.Query, opts ...blevesearch.SearchOption) (int, error)
 	Search(ctx context.Context, q *v1.Query, opts ...blevesearch.SearchOption) ([]search.Result, error)

--- a/central/activecomponent/datastore/internal/store/store.go
+++ b/central/activecomponent/datastore/internal/store/store.go
@@ -7,6 +7,7 @@ import (
 )
 
 // Store provides storage functionality for active component.
+//
 //go:generate mockgen-wrapper
 type Store interface {
 	Exists(ctx context.Context, id string) (bool, error)

--- a/central/activecomponent/datastore/search/searcher.go
+++ b/central/activecomponent/datastore/search/searcher.go
@@ -15,6 +15,7 @@ import (
 )
 
 // Searcher provides search functionality on active components
+//
 //go:generate mockgen-wrapper
 type Searcher interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)

--- a/central/activecomponent/updater/aggregator/process_aggregator.go
+++ b/central/activecomponent/updater/aggregator/process_aggregator.go
@@ -6,6 +6,7 @@ import (
 )
 
 // ProcessAggregator combines the incoming process indicators and generates updates for each <deployment, container>.
+//
 //go:generate mockgen-wrapper
 type ProcessAggregator interface {
 	Add(indicators []*storage.ProcessIndicator)

--- a/central/alert/datastore/datastore.go
+++ b/central/alert/datastore/datastore.go
@@ -23,6 +23,7 @@ import (
 )
 
 // DataStore is a transaction script with methods that provide the domain logic for CRUD uses cases for Alert objects.
+//
 //go:generate mockgen-wrapper
 type DataStore interface {
 	Search(ctx context.Context, q *v1.Query) ([]searchPkg.Result, error)

--- a/central/alert/datastore/internal/search/searcher.go
+++ b/central/alert/datastore/internal/search/searcher.go
@@ -11,6 +11,7 @@ import (
 )
 
 // Searcher provides search functionality on existing alerts
+//
 //go:generate mockgen-wrapper
 type Searcher interface {
 	SearchAlerts(ctx context.Context, q *v1.Query) ([]*v1.SearchResult, error)

--- a/central/alert/datastore/internal/store/store.go
+++ b/central/alert/datastore/internal/store/store.go
@@ -7,6 +7,7 @@ import (
 )
 
 // Store provides storage functionality for alerts.
+//
 //go:generate mockgen-wrapper
 type Store interface {
 	Walk(ctx context.Context, fn func(*storage.Alert) error) error

--- a/central/apitoken/datastore/internal/store/store.go
+++ b/central/apitoken/datastore/internal/store/store.go
@@ -9,6 +9,7 @@ import (
 // Store is the (bolt-backed) store for API tokens.
 // We don't store the tokens themselves, but do store metadata.
 // Importantly, the Store persists token revocations.
+//
 //go:generate mockgen-wrapper
 type Store interface {
 	Get(ctx context.Context, id string) (*storage.TokenMetadata, bool, error)

--- a/central/authprovider/datastore/internal/store/store.go
+++ b/central/authprovider/datastore/internal/store/store.go
@@ -7,6 +7,7 @@ import (
 )
 
 // Store stores and retrieves providers from the KV storage mechanism.
+//
 //go:generate mockgen-wrapper
 type Store interface {
 	GetAll(ctx context.Context) ([]*storage.AuthProvider, error)

--- a/central/cluster/store/cluster/store.go
+++ b/central/cluster/store/cluster/store.go
@@ -7,6 +7,7 @@ import (
 )
 
 // Store provides storage functionality for clusters.
+//
 //go:generate mockgen-wrapper
 type Store interface {
 	Count(ctx context.Context) (int, error)

--- a/central/cluster/store/clusterhealth/store.go
+++ b/central/cluster/store/clusterhealth/store.go
@@ -7,6 +7,7 @@ import (
 )
 
 // Store provides storage functionality for cluster health store.
+//
 //go:generate mockgen-wrapper
 type Store interface {
 	Count(ctx context.Context) (int, error)

--- a/central/clustercveedge/datastore/datastore.go
+++ b/central/clustercveedge/datastore/datastore.go
@@ -14,6 +14,7 @@ import (
 )
 
 // DataStore is an intermediary to Cluster/CVE edge storage.
+//
 //go:generate mockgen-wrapper
 type DataStore interface {
 	Search(ctx context.Context, q *v1.Query) ([]searchPkg.Result, error)

--- a/central/clustercveedge/search/searcher.go
+++ b/central/clustercveedge/search/searcher.go
@@ -13,6 +13,7 @@ import (
 )
 
 // Searcher provides search functionality on existing cves.
+//
 //go:generate mockgen-wrapper
 type Searcher interface {
 	Search(ctx context.Context, query *v1.Query) ([]search.Result, error)

--- a/central/clustercveedge/store/store.go
+++ b/central/clustercveedge/store/store.go
@@ -8,6 +8,7 @@ import (
 )
 
 // Store provides storage functionality for cluster-cve edges.
+//
 //go:generate mockgen-wrapper
 type Store interface {
 	Count(ctx context.Context) (int, error)

--- a/central/clusterinit/backend/backend.go
+++ b/central/clusterinit/backend/backend.go
@@ -29,6 +29,7 @@ var (
 )
 
 // Backend is the backend for the cluster-init component.
+//
 //go:generate mockgen-wrapper
 type Backend interface {
 	GetAll(ctx context.Context) ([]*storage.InitBundleMeta, error)

--- a/central/clusterinit/backend/certificate/certprovider.go
+++ b/central/clusterinit/backend/certificate/certprovider.go
@@ -8,6 +8,7 @@ import (
 )
 
 // Provider provides CA and service certificates to the cluster init backend.
+//
 //go:generate mockgen-wrapper
 type Provider interface {
 	GetCA() (string, error)

--- a/central/compliance/datastore/datastore.go
+++ b/central/compliance/datastore/datastore.go
@@ -10,6 +10,7 @@ import (
 )
 
 // DataStore is the interface for accessing stored compliance data
+//
 //go:generate mockgen-wrapper
 type DataStore interface {
 	GetSpecificRunResults(ctx context.Context, clusterID, standardID, runID string, flags types.GetFlags) (types.ResultsWithStatus, error)

--- a/central/compliance/datastore/internal/store/store.go
+++ b/central/compliance/datastore/internal/store/store.go
@@ -9,6 +9,7 @@ import (
 )
 
 // Store is the interface for accessing stored compliance data
+//
 //go:generate mockgen-wrapper
 type Store interface {
 	GetSpecificRunResults(ctx context.Context, clusterID, standardID, runID string, flags types.GetFlags) (types.ResultsWithStatus, error)

--- a/central/compliance/framework/context.go
+++ b/central/compliance/framework/context.go
@@ -17,6 +17,7 @@ import (
 //
 // Through a context, evidence (pass or fail) can be recorded; additionally, in the case of abnormal termination,
 // errors may be recorded. This is accomplished by calling `Abort` within a check function.
+//
 //go:generate mockgen-wrapper
 type ComplianceContext interface {
 	// StandardName returns the current standard name

--- a/central/compliance/standards/index/indexer.go
+++ b/central/compliance/standards/index/indexer.go
@@ -18,6 +18,7 @@ var (
 )
 
 // Indexer is the interface for Compliance Search
+//
 //go:generate mockgen-wrapper
 type Indexer interface {
 	IndexStandard(standard *v1.ComplianceStandard) error

--- a/central/componentcveedge/datastore/datastore.go
+++ b/central/componentcveedge/datastore/datastore.go
@@ -29,6 +29,7 @@ import (
 )
 
 // DataStore is an intermediary to Component/CVE edge storage.
+//
 //go:generate mockgen-wrapper
 type DataStore interface {
 	Search(ctx context.Context, q *v1.Query) ([]searchPkg.Result, error)

--- a/central/componentcveedge/search/searcher.go
+++ b/central/componentcveedge/search/searcher.go
@@ -21,6 +21,7 @@ import (
 )
 
 // Searcher provides search functionality on existing cves.
+//
 //go:generate mockgen-wrapper
 type Searcher interface {
 	Search(ctx context.Context, query *v1.Query) ([]search.Result, error)

--- a/central/componentcveedge/store/store.go
+++ b/central/componentcveedge/store/store.go
@@ -7,6 +7,7 @@ import (
 )
 
 // Store provides storage functionality for component-cve edges.
+//
 //go:generate mockgen-wrapper
 type Store interface {
 	Count(ctx context.Context) (int, error)

--- a/central/config/datastore/datastore.go
+++ b/central/config/datastore/datastore.go
@@ -13,6 +13,7 @@ import (
 )
 
 // DataStore is the entry point for modifying Config data.
+//
 //go:generate mockgen-wrapper
 type DataStore interface {
 	GetConfig(context.Context) (*storage.Config, error)

--- a/central/config/store/store.go
+++ b/central/config/store/store.go
@@ -7,6 +7,7 @@ import (
 )
 
 // Store provides an interface to the underlying data layer
+//
 //go:generate mockgen-wrapper
 type Store interface {
 	Get(ctx context.Context) (*storage.Config, bool, error)

--- a/central/cve/cluster/datastore/datastore.go
+++ b/central/cve/cluster/datastore/datastore.go
@@ -15,6 +15,7 @@ import (
 )
 
 // DataStore is an intermediary to cluster CVE storage.
+//
 //go:generate mockgen-wrapper
 type DataStore interface {
 	Search(ctx context.Context, q *v1.Query) ([]searchPkg.Result, error)

--- a/central/cve/cluster/datastore/index/index.go
+++ b/central/cve/cluster/datastore/index/index.go
@@ -10,6 +10,7 @@ import (
 )
 
 // Indexer provides functionality to index cluster cves.
+//
 //go:generate mockgen-wrapper
 type Indexer interface {
 	AddClusterCVE(cve *storage.ClusterCVE) error

--- a/central/cve/cluster/datastore/search/searcher.go
+++ b/central/cve/cluster/datastore/search/searcher.go
@@ -22,6 +22,7 @@ var (
 )
 
 // Searcher provides search functionality on existing cves.
+//
 //go:generate mockgen-wrapper
 type Searcher interface {
 	Search(ctx context.Context, query *v1.Query) ([]search.Result, error)

--- a/central/cve/cluster/datastore/store/store.go
+++ b/central/cve/cluster/datastore/store/store.go
@@ -8,6 +8,7 @@ import (
 )
 
 // Store provides storage functionality for CVEs.
+//
 //go:generate mockgen-wrapper
 type Store interface {
 	Count(ctx context.Context) (int, error)

--- a/central/cve/datastore/datastore.go
+++ b/central/cve/datastore/datastore.go
@@ -32,6 +32,7 @@ import (
 )
 
 // DataStore is an intermediary to CVE storage.
+//
 //go:generate mockgen-wrapper
 type DataStore interface {
 	Search(ctx context.Context, q *v1.Query) ([]searchPkg.Result, error)

--- a/central/cve/image/datastore/datastore.go
+++ b/central/cve/image/datastore/datastore.go
@@ -18,6 +18,7 @@ import (
 )
 
 // DataStore is an intermediary to CVE storage.
+//
 //go:generate mockgen-wrapper
 type DataStore interface {
 	Search(ctx context.Context, q *v1.Query) ([]searchPkg.Result, error)

--- a/central/cve/image/datastore/index/indexer.go
+++ b/central/cve/image/datastore/index/indexer.go
@@ -10,6 +10,7 @@ import (
 )
 
 // Indexer provides functionality to index node cves.
+//
 //go:generate mockgen-wrapper
 type Indexer interface {
 	AddImageCVE(cve *storage.ImageCVE) error

--- a/central/cve/image/datastore/search/searcher.go
+++ b/central/cve/image/datastore/search/searcher.go
@@ -21,6 +21,7 @@ var (
 )
 
 // Searcher provides search functionality on existing cves.
+//
 //go:generate mockgen-wrapper
 type Searcher interface {
 	Search(ctx context.Context, query *v1.Query) ([]search.Result, error)

--- a/central/cve/image/datastore/store/store.go
+++ b/central/cve/image/datastore/store/store.go
@@ -7,6 +7,7 @@ import (
 )
 
 // Store provides storage functionality for CVEs.
+//
 //go:generate mockgen-wrapper
 type Store interface {
 	Count(ctx context.Context) (int, error)

--- a/central/cve/node/datastore/datastore.go
+++ b/central/cve/node/datastore/datastore.go
@@ -18,6 +18,7 @@ import (
 )
 
 // DataStore is an intermediary to CVE storage.
+//
 //go:generate mockgen-wrapper
 type DataStore interface {
 	Search(ctx context.Context, q *v1.Query) ([]searchPkg.Result, error)

--- a/central/cve/node/datastore/index/index.go
+++ b/central/cve/node/datastore/index/index.go
@@ -10,6 +10,7 @@ import (
 )
 
 // Indexer provides functionality to index node cves.
+//
 //go:generate mockgen-wrapper
 type Indexer interface {
 	AddNodeCVE(cve *storage.NodeCVE) error

--- a/central/cve/node/datastore/search/searcher.go
+++ b/central/cve/node/datastore/search/searcher.go
@@ -21,6 +21,7 @@ var (
 )
 
 // Searcher provides search functionality on existing cves.
+//
 //go:generate mockgen-wrapper
 type Searcher interface {
 	Search(ctx context.Context, query *v1.Query) ([]search.Result, error)

--- a/central/cve/node/datastore/store/store.go
+++ b/central/cve/node/datastore/store/store.go
@@ -7,6 +7,7 @@ import (
 )
 
 // Store provides storage functionality for CVEs.
+//
 //go:generate mockgen-wrapper
 type Store interface {
 	Count(ctx context.Context) (int, error)

--- a/central/cve/search/searcher.go
+++ b/central/cve/search/searcher.go
@@ -22,6 +22,7 @@ import (
 )
 
 // Searcher provides search functionality on existing cves.
+//
 //go:generate mockgen-wrapper
 type Searcher interface {
 	Search(ctx context.Context, query *v1.Query) ([]search.Result, error)

--- a/central/cve/store/store.go
+++ b/central/cve/store/store.go
@@ -7,6 +7,7 @@ import (
 )
 
 // Store provides storage functionality for CVEs.
+//
 //go:generate mockgen-wrapper
 type Store interface {
 	Count(ctx context.Context) (int, error)

--- a/central/deployment/datastore/datastore.go
+++ b/central/deployment/datastore/datastore.go
@@ -38,6 +38,7 @@ import (
 )
 
 // DataStore is an intermediary to DeploymentStorage.
+//
 //go:generate mockgen-wrapper
 type DataStore interface {
 	Search(ctx context.Context, q *v1.Query) ([]pkgSearch.Result, error)

--- a/central/deployment/datastore/internal/search/searcher.go
+++ b/central/deployment/datastore/internal/search/searcher.go
@@ -23,6 +23,7 @@ var (
 )
 
 // Searcher provides search functionality on existing alerts
+//
 //go:generate mockgen-wrapper
 type Searcher interface {
 	SearchDeployments(ctx context.Context, q *v1.Query) ([]*v1.SearchResult, error)

--- a/central/deployment/index/indexer.go
+++ b/central/deployment/index/indexer.go
@@ -11,6 +11,7 @@ import (
 )
 
 // Indexer encapsulates the deployment indexer
+//
 //go:generate mockgen-wrapper
 type Indexer interface {
 	AddDeployment(deployment *storage.Deployment) error

--- a/central/deployment/queue/observation_queue.go
+++ b/central/deployment/queue/observation_queue.go
@@ -14,8 +14,9 @@ type DeploymentObservation struct {
 	ObservationEnd *types.Timestamp
 }
 
-//go:generate mockgen-wrapper
 // DeploymentObservationQueue interface for observation queue
+//
+//go:generate mockgen-wrapper
 type DeploymentObservationQueue interface {
 	InObservation(deploymentID string) bool
 	Pull() *DeploymentObservation

--- a/central/deployment/store/store.go
+++ b/central/deployment/store/store.go
@@ -7,6 +7,7 @@ import (
 )
 
 // Store provides storage functionality.
+//
 //go:generate mockgen-wrapper
 type Store interface {
 	GetListDeployment(ctx context.Context, id string) (*storage.ListDeployment, bool, error)

--- a/central/detection/lifecycle/manager.go
+++ b/central/detection/lifecycle/manager.go
@@ -31,6 +31,7 @@ var (
 )
 
 // A Manager manages deployment/policy lifecycle updates.
+//
 //go:generate mockgen-wrapper
 type Manager interface {
 	IndicatorAdded(indicator *storage.ProcessIndicator) error

--- a/central/enrichment/enricher.go
+++ b/central/enrichment/enricher.go
@@ -14,6 +14,7 @@ var (
 )
 
 // Enricher enriches images with data from registries and scanners.
+//
 //go:generate mockgen-wrapper
 type Enricher interface {
 	// EnrichDeployment enriches the deployment and images only if they have IDs

--- a/central/enrichment/integration.go
+++ b/central/enrichment/integration.go
@@ -9,6 +9,7 @@ import (
 )
 
 // Manager implements a bit of multiplexing logic between ImageIntegrations and NodeIntegrations
+//
 //go:generate mockgen-wrapper
 type Manager interface {
 	Upsert(integration *storage.ImageIntegration) error

--- a/central/externalbackups/datastore/datastore.go
+++ b/central/externalbackups/datastore/datastore.go
@@ -8,6 +8,7 @@ import (
 )
 
 // DataStore is the entry point for modifying External Backup data.
+//
 //go:generate mockgen-wrapper
 type DataStore interface {
 	ListBackups(ctx context.Context) ([]*storage.ExternalBackup, error)

--- a/central/externalbackups/internal/store/store.go
+++ b/central/externalbackups/internal/store/store.go
@@ -7,6 +7,7 @@ import (
 )
 
 // Store implements a store of all external backups in a cluster.
+//
 //go:generate mockgen-wrapper
 type Store interface {
 	GetAll(ctx context.Context) ([]*storage.ExternalBackup, error)

--- a/central/globaldb/v2backuprestore/backup/generators/directory.go
+++ b/central/globaldb/v2backuprestore/backup/generators/directory.go
@@ -5,6 +5,7 @@ import (
 )
 
 // DirectoryGenerator is a generator that produces a backup in the form of a directory of files.
+//
 //go:generate mockgen-wrapper
 type DirectoryGenerator interface {
 	WriteDirectory(ctx context.Context) (string, error)

--- a/central/globaldb/v2backuprestore/backup/generators/file.go
+++ b/central/globaldb/v2backuprestore/backup/generators/file.go
@@ -10,6 +10,7 @@ import (
 )
 
 // FileGenerator is a generator that produces a backup in the form of a file.
+//
 //go:generate mockgen-wrapper
 type FileGenerator interface {
 	WriteFile(ctx context.Context, path string) error

--- a/central/globaldb/v2backuprestore/backup/generators/path_map.go
+++ b/central/globaldb/v2backuprestore/backup/generators/path_map.go
@@ -5,6 +5,7 @@ import (
 )
 
 // PathMapGenerator is a generator that produces a map from structured backup files/directories layout to its source.
+//
 //go:generate mockgen-wrapper
 type PathMapGenerator interface {
 	GeneratePathMap(ctx context.Context) (map[string]string, error)

--- a/central/globaldb/v2backuprestore/backup/generators/stream.go
+++ b/central/globaldb/v2backuprestore/backup/generators/stream.go
@@ -10,6 +10,7 @@ import (
 )
 
 // StreamGenerator writes a backup directly to a writer.
+//
 //go:generate mockgen-wrapper
 type StreamGenerator interface {
 	WriteTo(ctx context.Context, writer io.Writer) error

--- a/central/globaldb/v2backuprestore/backup/generators/tar.go
+++ b/central/globaldb/v2backuprestore/backup/generators/tar.go
@@ -10,6 +10,7 @@ import (
 )
 
 // TarGenerator writes a backup directly to a writer.
+//
 //go:generate mockgen-wrapper
 type TarGenerator interface {
 	WriteTo(ctx context.Context, writer *tar.Writer) error

--- a/central/globaldb/v2backuprestore/backup/generators/zip.go
+++ b/central/globaldb/v2backuprestore/backup/generators/zip.go
@@ -10,6 +10,7 @@ import (
 )
 
 // ZipGenerator writes a backup directly to a writer.
+//
 //go:generate mockgen-wrapper
 type ZipGenerator interface {
 	WriteTo(ctx context.Context, writer *zip.Writer) error

--- a/central/graphql/resolvers/active_state.go
+++ b/central/graphql/resolvers/active_state.go
@@ -7,6 +7,7 @@ import (
 )
 
 // ActiveStateEnum represents the active state of a vuln or component in a deployment.
+//
 //go:generate stringer -type=ActiveStateEnum
 type ActiveStateEnum int32
 

--- a/central/graphql/resolvers/common_vulnerabilities.go
+++ b/central/graphql/resolvers/common_vulnerabilities.go
@@ -37,7 +37,8 @@ var commonVulnerabilitySubResolvers = []string{
 }
 
 // CommonVulnerabilityResolver represents the supported API on all vulnerabilities
-//  NOTE: This list is and should remain alphabetically ordered
+//
+//	NOTE: This list is and should remain alphabetically ordered
 type CommonVulnerabilityResolver interface {
 	CreatedAt(ctx context.Context) (*graphql.Time, error)
 	CVE(ctx context.Context) string

--- a/central/group/datastore/datastore.go
+++ b/central/group/datastore/datastore.go
@@ -8,6 +8,7 @@ import (
 )
 
 // DataStore is the datastore for groups.
+//
 //go:generate mockgen-wrapper
 type DataStore interface {
 	Get(ctx context.Context, props *storage.GroupProperties) (*storage.Group, error)

--- a/central/group/datastore/internal/store/store.go
+++ b/central/group/datastore/internal/store/store.go
@@ -7,6 +7,7 @@ import (
 )
 
 // Store updates and utilizes groups, which are attribute to role mappings.
+//
 //go:generate mockgen-wrapper
 type Store interface {
 	Get(ctx context.Context, propsID string) (*storage.Group, bool, error)

--- a/central/group/datastore/validate.go
+++ b/central/group/datastore/validate.go
@@ -9,13 +9,14 @@ import (
 
 // groupIDPrefix should be prepended to every human-hostile ID of a
 // group for readability, e.g.,
-//     "io.stackrox.authz.group.94ac7bfe-f9b2-402e-b4f2-bfda480e1a13".
+//
+//	"io.stackrox.authz.group.94ac7bfe-f9b2-402e-b4f2-bfda480e1a13".
 const groupIDPrefix = "io.stackrox.authz.group."
 
 // ValidateGroup validates the given group for conformity.
 // A group must fulfill the following:
-//	- have valid properties (validated via ValidateProps).
-//	- have a role name set.
+//   - have valid properties (validated via ValidateProps).
+//   - have a role name set.
 func ValidateGroup(group *storage.Group, requireID bool) error {
 	if group.GetProps() == nil {
 		return errors.New("group properties must be set")
@@ -31,8 +32,8 @@ func ValidateGroup(group *storage.Group, requireID bool) error {
 
 // ValidateProps validates the given properties for conformity.
 // A property must fulfill the following:
-//	- have an auth provider ID.
-// 	- if no key is given, no value shall be given.
+//   - have an auth provider ID.
+//   - if no key is given, no value shall be given.
 func ValidateProps(props *storage.GroupProperties, requireID bool) error {
 	if requireID && props.GetId() == "" {
 		return errors.Errorf("group ID must be set in {%s}", proto.MarshalTextString(props))

--- a/central/image/datastore/datastore.go
+++ b/central/image/datastore/datastore.go
@@ -24,6 +24,7 @@ import (
 )
 
 // DataStore is an intermediary to AlertStorage.
+//
 //go:generate mockgen-wrapper
 type DataStore interface {
 	SearchListImages(ctx context.Context, q *v1.Query) ([]*storage.ListImage, error)

--- a/central/image/datastore/search/searcher.go
+++ b/central/image/datastore/search/searcher.go
@@ -18,6 +18,7 @@ import (
 )
 
 // Searcher provides search functionality on existing alerts
+//
 //go:generate mockgen-wrapper
 type Searcher interface {
 	SearchImages(ctx context.Context, q *v1.Query) ([]*v1.SearchResult, error)

--- a/central/image/datastore/store/store.go
+++ b/central/image/datastore/store/store.go
@@ -7,6 +7,7 @@ import (
 )
 
 // Store provides storage functionality for images.
+//
 //go:generate mockgen-wrapper
 type Store interface {
 	Count(ctx context.Context) (int, error)

--- a/central/image/index/indexer.go
+++ b/central/image/index/indexer.go
@@ -11,6 +11,7 @@ import (
 )
 
 // Indexer is the image indexer.
+//
 //go:generate mockgen-wrapper
 type Indexer interface {
 	AddImage(image *storage.Image) error

--- a/central/imagecomponent/datastore/datastore.go
+++ b/central/imagecomponent/datastore/datastore.go
@@ -32,6 +32,7 @@ import (
 )
 
 // DataStore is an intermediary to ImageComponent storage.
+//
 //go:generate mockgen-wrapper
 type DataStore interface {
 	Search(ctx context.Context, q *v1.Query) ([]searchPkg.Result, error)

--- a/central/imagecomponent/search/searcher.go
+++ b/central/imagecomponent/search/searcher.go
@@ -21,6 +21,7 @@ import (
 )
 
 // Searcher provides search functionality on existing image components.
+//
 //go:generate mockgen-wrapper
 type Searcher interface {
 	Search(ctx context.Context, query *v1.Query) ([]search.Result, error)

--- a/central/imagecomponent/store/store.go
+++ b/central/imagecomponent/store/store.go
@@ -7,6 +7,7 @@ import (
 )
 
 // Store provides storage functionality for Image Components.
+//
 //go:generate mockgen-wrapper
 type Store interface {
 	Count(ctx context.Context) (int, error)

--- a/central/imagecomponentedge/datastore/datastore.go
+++ b/central/imagecomponentedge/datastore/datastore.go
@@ -13,6 +13,7 @@ import (
 )
 
 // DataStore is an intermediary to Image/Component edge storage.
+//
 //go:generate mockgen-wrapper
 type DataStore interface {
 	Search(ctx context.Context, q *v1.Query) ([]searchPkg.Result, error)

--- a/central/imagecomponentedge/search/searcher.go
+++ b/central/imagecomponentedge/search/searcher.go
@@ -11,6 +11,7 @@ import (
 )
 
 // Searcher provides search functionality on existing cves.
+//
 //go:generate mockgen-wrapper
 type Searcher interface {
 	Search(ctx context.Context, query *v1.Query) ([]search.Result, error)

--- a/central/imagecomponentedge/store/store.go
+++ b/central/imagecomponentedge/store/store.go
@@ -7,6 +7,7 @@ import (
 )
 
 // Store provides storage functionality for image-component edges.
+//
 //go:generate mockgen-wrapper
 type Store interface {
 	Count(ctx context.Context) (int, error)

--- a/central/imagecveedge/datastore/datastore.go
+++ b/central/imagecveedge/datastore/datastore.go
@@ -12,6 +12,7 @@ import (
 )
 
 // DataStore is an intermediary to Image/CVE edge storage.
+//
 //go:generate mockgen-wrapper
 type DataStore interface {
 	Search(ctx context.Context, q *v1.Query) ([]pkgSearch.Result, error)

--- a/central/imagecveedge/search/searcher.go
+++ b/central/imagecveedge/search/searcher.go
@@ -18,6 +18,7 @@ import (
 )
 
 // Searcher provides search functionality on existing CVEs (for the attributes pertaining to direct image-cve relationship).
+//
 //go:generate mockgen-wrapper
 type Searcher interface {
 	Search(ctx context.Context, query *v1.Query) ([]search.Result, error)

--- a/central/imagecveedge/store/store.go
+++ b/central/imagecveedge/store/store.go
@@ -7,6 +7,7 @@ import (
 )
 
 // Store provides storage functionality for ImageCVEEdges.
+//
 //go:generate mockgen-wrapper
 type Store interface {
 	Count(ctx context.Context) (int, error)

--- a/central/imageintegration/datastore/datastore.go
+++ b/central/imageintegration/datastore/datastore.go
@@ -24,6 +24,7 @@ var (
 )
 
 // DataStore is the entry point for modifying Cluster data.
+//
 //go:generate mockgen-wrapper
 type DataStore interface {
 	GetImageIntegration(ctx context.Context, id string) (*storage.ImageIntegration, bool, error)

--- a/central/imageintegration/search/searcher.go
+++ b/central/imageintegration/search/searcher.go
@@ -15,6 +15,7 @@ var (
 )
 
 // Searcher provides search functionality on existing image integrations
+//
 //go:generate mockgen-wrapper
 type Searcher interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)

--- a/central/integrationhealth/datastore/datastore.go
+++ b/central/integrationhealth/datastore/datastore.go
@@ -13,6 +13,7 @@ var (
 )
 
 // DataStore is the entry point for modifying integration health data.
+//
 //go:generate mockgen-wrapper
 type DataStore interface {
 	GetRegistriesAndScanners(ctx context.Context) ([]*storage.IntegrationHealth, error)

--- a/central/logimbue/handler/handler_test.go
+++ b/central/logimbue/handler/handler_test.go
@@ -106,7 +106,7 @@ func (suite *LogImbueHandlerTestSuite) TestPostHandlesCloseError() {
 }
 
 // Mock ReadCloser implementation to function as the http request body.
-///////////////////////////////////////////////////////////////////////
+// /////////////////////////////////////////////////////////////////////
 func mockReadCloseMessage(message string) *mockReadCloser {
 	byteSlice := []byte(message)
 	return &mockReadCloser{

--- a/central/mitre/datastore/store.go
+++ b/central/mitre/datastore/store.go
@@ -16,6 +16,7 @@ var (
 
 // MitreAttackReadOnlyDataStore provides functionality to read MITRE ATT&CK vectors.
 // A vector represents MITRE tactics (why) and its techniques/sub-techniques (how).
+//
 //go:generate mockgen-wrapper
 type MitreAttackReadOnlyDataStore interface {
 	GetAll() []*storage.MitreAttackVector

--- a/central/namespace/store/store.go
+++ b/central/namespace/store/store.go
@@ -7,6 +7,7 @@ import (
 )
 
 // Store provides storage functionality for alerts.
+//
 //go:generate mockgen-wrapper
 type Store interface {
 	Get(ctx context.Context, id string) (*storage.NamespaceMetadata, bool, error)

--- a/central/networkbaseline/datastore/datastore.go
+++ b/central/networkbaseline/datastore/datastore.go
@@ -13,6 +13,7 @@ type ReadOnlyDataStore interface {
 }
 
 // DataStore stores network baselines for all deployments.
+//
 //go:generate mockgen-wrapper
 type DataStore interface {
 	ReadOnlyDataStore

--- a/central/networkbaseline/manager/manager.go
+++ b/central/networkbaseline/manager/manager.go
@@ -10,9 +10,10 @@ import (
 	"github.com/stackrox/rox/pkg/timestamp"
 )
 
-//go:generate mockgen-wrapper
 // The Manager manages network baselines.
 // ALL writes to network baselines MUST go through the manager.
+//
+//go:generate mockgen-wrapper
 type Manager interface {
 	// CreateNetworkBaseline creates a network baseline if one does not exit
 	// The baseline manager then creates a baseline for this deployment if it does not already exist.

--- a/central/networkbaseline/store/store.go
+++ b/central/networkbaseline/store/store.go
@@ -7,6 +7,7 @@ import (
 )
 
 // Store provides storage functionality for network baselines.
+//
 //go:generate mockgen-wrapper
 type Store interface {
 	Exists(ctx context.Context, id string) (bool, error)

--- a/central/networkgraph/aggregator/aggregator.go
+++ b/central/networkgraph/aggregator/aggregator.go
@@ -8,6 +8,7 @@ import (
 )
 
 // NetworkConnsAggregator provides functionality to aggregate supplied network connections into a new slice.
+//
 //go:generate mockgen-wrapper
 type NetworkConnsAggregator interface {
 	Aggregate(conns []*storage.NetworkFlow) []*storage.NetworkFlow

--- a/central/networkgraph/config/datastore/datastore.go
+++ b/central/networkgraph/config/datastore/datastore.go
@@ -7,6 +7,7 @@ import (
 )
 
 // DataStore provides functionality to interact with network graph configuration.
+//
 //go:generate mockgen-wrapper
 type DataStore interface {
 	GetNetworkGraphConfig(ctx context.Context) (*storage.NetworkGraphConfig, error)

--- a/central/networkgraph/config/datastore/internal/store/store.go
+++ b/central/networkgraph/config/datastore/internal/store/store.go
@@ -7,6 +7,7 @@ import (
 )
 
 // Store provides storage functionality for network graph configuration.
+//
 //go:generate mockgen-wrapper
 type Store interface {
 	Get(ctx context.Context, id string) (*storage.NetworkGraphConfig, bool, error)

--- a/central/networkgraph/entity/datastore/datastore.go
+++ b/central/networkgraph/entity/datastore/datastore.go
@@ -8,6 +8,7 @@ import (
 
 // EntityDataStore stores network graph entities across all clusters.
 // Note: Currently only external sources are stored i.e. user-created CIDR blocks
+//
 //go:generate mockgen-wrapper
 type EntityDataStore interface {
 	Exists(ctx context.Context, id string) (bool, error)

--- a/central/networkgraph/entity/datastore/internal/store/store.go
+++ b/central/networkgraph/entity/datastore/internal/store/store.go
@@ -7,6 +7,7 @@ import (
 )
 
 // EntityStore stores network graph entities.
+//
 //go:generate mockgen-wrapper
 type EntityStore interface {
 	Exists(ctx context.Context, id string) (bool, error)

--- a/central/networkgraph/entity/networktree/manager.go
+++ b/central/networkgraph/entity/networktree/manager.go
@@ -9,6 +9,7 @@ import (
 )
 
 // Manager provides a centralized location for creating and fetching network trees for clusters.
+//
 //go:generate mockgen-wrapper
 type Manager interface {
 	Initialize(entitiesByCluster map[string][]*storage.NetworkEntityInfo) error

--- a/central/networkgraph/flow/datastore/cluster.go
+++ b/central/networkgraph/flow/datastore/cluster.go
@@ -16,6 +16,7 @@ import (
 )
 
 // ClusterDataStore stores the network edges per cluster.
+//
 //go:generate mockgen-wrapper
 type ClusterDataStore interface {
 	GetFlowStore(ctx context.Context, clusterID string) (FlowDataStore, error)

--- a/central/networkpolicies/datastore/datastore.go
+++ b/central/networkpolicies/datastore/datastore.go
@@ -25,6 +25,7 @@ var (
 )
 
 // UndoDataStore provides storage functionality for the undo records resulting from policy application.
+//
 //go:generate mockgen-wrapper
 type UndoDataStore interface {
 	GetUndoRecord(ctx context.Context, clusterID string) (*storage.NetworkPolicyApplicationUndoRecord, bool, error)
@@ -32,6 +33,7 @@ type UndoDataStore interface {
 }
 
 // DataStore provides storage functionality for network policies.
+//
 //go:generate mockgen-wrapper
 type DataStore interface {
 	GetNetworkPolicy(ctx context.Context, id string) (*storage.NetworkPolicy, bool, error)
@@ -47,6 +49,7 @@ type DataStore interface {
 
 // UndoDeploymentDataStore provides storage functionality for the undo deployment records resulting
 // from policy application.
+//
 //go:generate mockgen-wrapper
 type UndoDeploymentDataStore interface {
 	GetUndoDeploymentRecord(ctx context.Context, deploymentID string) (*storage.NetworkPolicyApplicationUndoDeploymentRecord, bool, error)

--- a/central/networkpolicies/datastore/datastore_impl.go
+++ b/central/networkpolicies/datastore/datastore_impl.go
@@ -172,7 +172,7 @@ func (ds *datastoreImpl) UpsertUndoRecord(ctx context.Context, undoRecord *stora
 }
 
 // UndoDeploymentDataStore functionality.
-///////////////////////////////
+// /////////////////////////////
 func (ds *datastoreImpl) GetUndoDeploymentRecord(ctx context.Context, deploymentID string) (*storage.NetworkPolicyApplicationUndoDeploymentRecord, bool, error) {
 	undoRecord, found, err := ds.undoDeploymentStorage.Get(ctx, deploymentID)
 	if err != nil || !found {

--- a/central/networkpolicies/datastore/internal/store/store.go
+++ b/central/networkpolicies/datastore/internal/store/store.go
@@ -6,8 +6,9 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 )
 
-//go:generate mockgen-wrapper
 // Store provides the interface to the underlying storage
+//
+//go:generate mockgen-wrapper
 type Store interface {
 	Get(ctx context.Context, id string) (*storage.NetworkPolicy, bool, error)
 	Upsert(ctx context.Context, obj *storage.NetworkPolicy) error

--- a/central/networkpolicies/datastore/internal/undodeploymentstore/undodeploymentstore.go
+++ b/central/networkpolicies/datastore/internal/undodeploymentstore/undodeploymentstore.go
@@ -7,6 +7,7 @@ import (
 )
 
 // UndoDeploymentStore provides storage functionality for network baselines.
+//
 //go:generate mockgen-wrapper
 type UndoDeploymentStore interface {
 	Get(ctx context.Context, deploymentID string) (*storage.NetworkPolicyApplicationUndoDeploymentRecord, bool, error)

--- a/central/networkpolicies/datastore/internal/undostore/undostore.go
+++ b/central/networkpolicies/datastore/internal/undostore/undostore.go
@@ -7,6 +7,7 @@ import (
 )
 
 // UndoStore provides storage functionality for undo records.
+//
 //go:generate mockgen-wrapper
 type UndoStore interface {
 	Get(ctx context.Context, clusterID string) (*storage.NetworkPolicyApplicationUndoRecord, bool, error)

--- a/central/networkpolicies/graph/evaluator.go
+++ b/central/networkpolicies/graph/evaluator.go
@@ -25,6 +25,7 @@ var (
 )
 
 // Evaluator implements the interface for the network graph generator
+//
 //go:generate mockgen-wrapper
 type Evaluator interface {
 	// GetGraph returns the network policy graph. If `queryDeploymentIDs` is nil, it is assumed that all deployments are queried/relevant.

--- a/central/networkpolicies/service/service_impl_test.go
+++ b/central/networkpolicies/service/service_impl_test.go
@@ -751,6 +751,7 @@ func depToInfo(dep *storage.Deployment) *storage.NetworkEntityInfo {
 // getSampleNetworkGraph requires at least 4 deployments
 // This function configures a graph which has explicit edges like this:
 //   - deployment001 -> deployment000 -> deployment002
+//
 // deployment003 is an "island" in this graph
 // deployment001 has non-isolated ingress, and deployment002 has non-isolated egress. Thus
 // there should be an implicit edge from deployment002 -> deployment001

--- a/central/node/datastore/search/searcher.go
+++ b/central/node/datastore/search/searcher.go
@@ -16,6 +16,7 @@ import (
 )
 
 // Searcher provides search functionality on existing nodes
+//
 //go:generate mockgen-wrapper
 type Searcher interface {
 	SearchNodes(ctx context.Context, q *v1.Query) ([]*v1.SearchResult, error)

--- a/central/node/datastore/store/store.go
+++ b/central/node/datastore/store/store.go
@@ -7,6 +7,7 @@ import (
 )
 
 // Store provides storage functionality for nodes.
+//
 //go:generate mockgen-wrapper
 type Store interface {
 	Count(ctx context.Context) (int, error)

--- a/central/nodecomponent/datastore/datastore.go
+++ b/central/nodecomponent/datastore/datastore.go
@@ -16,6 +16,7 @@ import (
 )
 
 // DataStore is an intermediary to NodeComponent storage.
+//
 //go:generate mockgen-wrapper
 type DataStore interface {
 	Search(ctx context.Context, q *v1.Query) ([]searchPkg.Result, error)

--- a/central/nodecomponent/datastore/search/searcher.go
+++ b/central/nodecomponent/datastore/search/searcher.go
@@ -21,6 +21,7 @@ var (
 )
 
 // Searcher provides search functionality on existing image components.
+//
 //go:generate mockgen-wrapper
 type Searcher interface {
 	Search(ctx context.Context, query *v1.Query) ([]search.Result, error)

--- a/central/nodecomponentcveedge/datastore/search/searcher.go
+++ b/central/nodecomponentcveedge/datastore/search/searcher.go
@@ -21,6 +21,7 @@ var (
 )
 
 // Searcher provides search functionality on existing cves.
+//
 //go:generate mockgen-wrapper
 type Searcher interface {
 	Search(ctx context.Context, query *v1.Query) ([]search.Result, error)

--- a/central/nodecomponentedge/datastore/datastore.go
+++ b/central/nodecomponentedge/datastore/datastore.go
@@ -13,6 +13,7 @@ import (
 )
 
 // DataStore is an intermediary to Node/Component edge storage.
+//
 //go:generate mockgen-wrapper
 type DataStore interface {
 	Search(ctx context.Context, q *v1.Query) ([]searchPkg.Result, error)

--- a/central/nodecomponentedge/search/searcher.go
+++ b/central/nodecomponentedge/search/searcher.go
@@ -22,6 +22,7 @@ var (
 )
 
 // Searcher provides search functionality on existing node component edges.
+//
 //go:generate mockgen-wrapper
 type Searcher interface {
 	Search(ctx context.Context, query *v1.Query) ([]search.Result, error)

--- a/central/nodecomponentedge/store/store.go
+++ b/central/nodecomponentedge/store/store.go
@@ -7,6 +7,7 @@ import (
 )
 
 // Store provides storage functionality for Node Component Edges.
+//
 //go:generate mockgen-wrapper
 type Store interface {
 	Count(ctx context.Context) (int, error)

--- a/central/notifier/datastore/datastore.go
+++ b/central/notifier/datastore/datastore.go
@@ -8,6 +8,7 @@ import (
 )
 
 // DataStore provides storage functionality for notifiers.
+//
 //go:generate mockgen-wrapper
 type DataStore interface {
 	GetNotifier(ctx context.Context, id string) (*storage.Notifier, bool, error)

--- a/central/notifier/datastore/internal/store/store.go
+++ b/central/notifier/datastore/internal/store/store.go
@@ -7,6 +7,7 @@ import (
 )
 
 // Store provides storage functionality for alerts.
+//
 //go:generate mockgen-wrapper
 type Store interface {
 	Get(ctx context.Context, id string) (*storage.Notifier, bool, error)

--- a/central/notifier/processor/processor.go
+++ b/central/notifier/processor/processor.go
@@ -15,6 +15,7 @@ var (
 )
 
 // Processor is the interface for processing benchmarks, notifiers, and policies.
+//
 //go:generate mockgen-wrapper
 type Processor interface {
 	ProcessAlert(ctx context.Context, alert *storage.Alert)

--- a/central/notifiers/alert_notifier.go
+++ b/central/notifiers/alert_notifier.go
@@ -7,6 +7,7 @@ import (
 )
 
 // AlertNotifier is a notifier for active alerts
+//
 //go:generate mockgen-wrapper AlertNotifier
 type AlertNotifier interface {
 	Notifier

--- a/central/notifiers/audit_notifier.go
+++ b/central/notifiers/audit_notifier.go
@@ -7,6 +7,7 @@ import (
 )
 
 // AuditNotifier is the notifier for audit logs
+//
 //go:generate mockgen-wrapper AuditNotifier
 type AuditNotifier interface {
 	Notifier

--- a/central/notifiers/awssh/notifier.go
+++ b/central/notifiers/awssh/notifier.go
@@ -337,8 +337,9 @@ func (n *notifier) ProtoNotifier() *storage.Notifier {
 }
 
 // Test checks if:
-//   * n is running, i.e., exactly one go routine is executing n.run(...)
-//   * AWS SecurityHub is reachable
+//   - n is running, i.e., exactly one go routine is executing n.run(...)
+//   - AWS SecurityHub is reachable
+//
 // If either of the checks fails, an error is returned.
 func (n *notifier) Test(ctx context.Context) error {
 	if n.stoppedSig.IsDone() {

--- a/central/notifiers/notifier.go
+++ b/central/notifiers/notifier.go
@@ -7,6 +7,7 @@ import (
 )
 
 // Notifier is the base notifier that all types of notifiers must implement
+//
 //go:generate mockgen-wrapper
 type Notifier interface {
 	// Close closes a notifier instances and releases all its resources.

--- a/central/notifiers/report_notifier.go
+++ b/central/notifiers/report_notifier.go
@@ -6,6 +6,7 @@ import (
 )
 
 // ReportNotifier is a notifier for sending reports
+//
 //go:generate mockgen-wrapper ReportNotifier
 type ReportNotifier interface {
 	Notifier

--- a/central/notifiers/resolvable_alert_notifier.go
+++ b/central/notifiers/resolvable_alert_notifier.go
@@ -7,6 +7,7 @@ import (
 )
 
 // ResolvableAlertNotifier is the interface for notifiers that support the alert workflow
+//
 //go:generate mockgen-wrapper ResolvableAlertNotifier
 type ResolvableAlertNotifier interface {
 	AlertNotifier

--- a/central/pod/datastore/datastore.go
+++ b/central/pod/datastore/datastore.go
@@ -22,6 +22,7 @@ import (
 )
 
 // DataStore is an intermediary to PodStorage.
+//
 //go:generate mockgen-wrapper
 type DataStore interface {
 	Count(ctx context.Context, q *v1.Query) (int, error)

--- a/central/pod/datastore/internal/search/searcher.go
+++ b/central/pod/datastore/internal/search/searcher.go
@@ -16,6 +16,7 @@ var (
 )
 
 // Searcher provides search functionality on existing pods
+//
 //go:generate mockgen-wrapper
 type Searcher interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)

--- a/central/pod/store/store.go
+++ b/central/pod/store/store.go
@@ -7,6 +7,7 @@ import (
 )
 
 // Store provides storage functionality for pods.
+//
 //go:generate mockgen-wrapper
 type Store interface {
 	GetIDs(ctx context.Context) ([]string, error)

--- a/central/policy/datastore/datastore.go
+++ b/central/policy/datastore/datastore.go
@@ -16,6 +16,7 @@ import (
 )
 
 // DataStore is an intermediary to PolicyStorage.
+//
 //go:generate mockgen-wrapper
 type DataStore interface {
 	Search(ctx context.Context, q *v1.Query) ([]searchPkg.Result, error)

--- a/central/policy/search/searcher.go
+++ b/central/policy/search/searcher.go
@@ -16,6 +16,7 @@ var (
 )
 
 // Searcher provides search functionality on existing alerts
+//
 //go:generate mockgen-wrapper
 type Searcher interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)

--- a/central/policy/store/boltdb/store.go
+++ b/central/policy/store/boltdb/store.go
@@ -56,6 +56,7 @@ func (i *NameConflictError) Error() string {
 }
 
 // Store provides storage functionality for policies.
+//
 //go:generate mockgen-wrapper
 type Store interface {
 	Get(ctx context.Context, id string) (*storage.Policy, bool, error)

--- a/central/policy/store/store.go
+++ b/central/policy/store/store.go
@@ -7,6 +7,7 @@ import (
 )
 
 // Store provides storage functionality for policies.
+//
 //go:generate mockgen-wrapper
 type Store interface {
 	Get(ctx context.Context, id string) (*storage.Policy, bool, error)

--- a/central/policycategory/datastore/datastore.go
+++ b/central/policycategory/datastore/datastore.go
@@ -15,6 +15,7 @@ import (
 )
 
 // DataStore is an intermediary to policy category storage.
+//
 //go:generate mockgen-wrapper
 type DataStore interface {
 	Search(ctx context.Context, q *v1.Query) ([]searchPkg.Result, error)

--- a/central/policycategory/search/searcher.go
+++ b/central/policycategory/search/searcher.go
@@ -16,6 +16,7 @@ var (
 )
 
 // Searcher provides search functionality on existing alerts
+//
 //go:generate mockgen-wrapper
 type Searcher interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)

--- a/central/policycategory/store/store.go
+++ b/central/policycategory/store/store.go
@@ -7,6 +7,7 @@ import (
 )
 
 // Store provides storage functionality for policy categories.
+//
 //go:generate mockgen-wrapper
 type Store interface {
 	Count(ctx context.Context) (int, error)

--- a/central/policycategoryedge/datastore/datastore.go
+++ b/central/policycategoryedge/datastore/datastore.go
@@ -12,6 +12,7 @@ import (
 )
 
 // DataStore is an intermediary to Policy Category edge storage.
+//
 //go:generate mockgen-wrapper
 type DataStore interface {
 	Search(ctx context.Context, q *v1.Query) ([]searchPkg.Result, error)

--- a/central/policycategoryedge/search/searcher.go
+++ b/central/policycategoryedge/search/searcher.go
@@ -9,6 +9,7 @@ import (
 )
 
 // Searcher provides search functionality on existing policy category edges.
+//
 //go:generate mockgen-wrapper
 type Searcher interface {
 	Search(ctx context.Context, query *v1.Query) ([]search.Result, error)

--- a/central/processbaseline/datastore/datastore.go
+++ b/central/processbaseline/datastore/datastore.go
@@ -22,6 +22,7 @@ import (
 )
 
 // DataStore wraps storage, indexer, and searcher for ProcessBaselines.
+//
 //go:generate mockgen-wrapper
 type DataStore interface {
 	SearchRawProcessBaselines(ctx context.Context, q *v1.Query) ([]*storage.ProcessBaseline, error)

--- a/central/processbaseline/evaluator/evaluator.go
+++ b/central/processbaseline/evaluator/evaluator.go
@@ -8,6 +8,7 @@ import (
 )
 
 // An Evaluator evaluates process baselines, and stores their cached results.
+//
 //go:generate mockgen-wrapper
 type Evaluator interface {
 	EvaluateBaselinesAndPersistResult(deployment *storage.Deployment) (violatingProcesses []*storage.ProcessIndicator, err error)

--- a/central/processbaseline/search/searcher.go
+++ b/central/processbaseline/search/searcher.go
@@ -18,6 +18,7 @@ var (
 )
 
 // Searcher provides search functionality on existing alerts
+//
 //go:generate mockgen-wrapper
 type Searcher interface {
 	SearchRawProcessBaselines(ctx context.Context, q *v1.Query) ([]*storage.ProcessBaseline, error)

--- a/central/processbaseline/store/store.go
+++ b/central/processbaseline/store/store.go
@@ -7,6 +7,7 @@ import (
 )
 
 // Store provides storage functionality for process baselines.
+//
 //go:generate mockgen-wrapper
 type Store interface {
 	Get(ctx context.Context, id string) (*storage.ProcessBaseline, bool, error)

--- a/central/processbaselineresults/datastore/datastore.go
+++ b/central/processbaselineresults/datastore/datastore.go
@@ -13,6 +13,7 @@ import (
 )
 
 // DataStore wraps storage, indexer, and searcher for ProcessBaselineResults.
+//
 //go:generate mockgen-wrapper
 type DataStore interface {
 	UpsertBaselineResults(ctx context.Context, results *storage.ProcessBaselineResults) error

--- a/central/processindicator/datastore/datastore.go
+++ b/central/processindicator/datastore/datastore.go
@@ -22,6 +22,7 @@ import (
 )
 
 // DataStore represents the interface to access data.
+//
 //go:generate mockgen-wrapper
 type DataStore interface {
 	Count(ctx context.Context, q *v1.Query) (int, error)

--- a/central/processindicator/index/indexer.go
+++ b/central/processindicator/index/indexer.go
@@ -11,6 +11,7 @@ import (
 )
 
 // Indexer is the process indicator indexer.
+//
 //go:generate mockgen-wrapper
 type Indexer interface {
 	AddProcessIndicator(processindicator *storage.ProcessIndicator) error

--- a/central/processindicator/search/searcher.go
+++ b/central/processindicator/search/searcher.go
@@ -16,6 +16,7 @@ var (
 )
 
 // Searcher provides search functionality on existing alerts
+//
 //go:generate mockgen-wrapper
 type Searcher interface {
 	SearchRawProcessIndicators(ctx context.Context, q *v1.Query) ([]*storage.ProcessIndicator, error)

--- a/central/processindicator/store/store.go
+++ b/central/processindicator/store/store.go
@@ -8,6 +8,7 @@ import (
 )
 
 // Store provides storage functionality for process indicators.
+//
 //go:generate mockgen-wrapper
 type Store interface {
 	Get(ctx context.Context, id string) (*storage.ProcessIndicator, bool, error)

--- a/central/rbac/k8srole/datastore/datastore.go
+++ b/central/rbac/k8srole/datastore/datastore.go
@@ -22,6 +22,7 @@ import (
 )
 
 // DataStore is an intermediary to RoleStorage.
+//
 //go:generate mockgen-wrapper
 type DataStore interface {
 	Search(ctx context.Context, q *v1.Query) ([]searchPkg.Result, error)

--- a/central/rbac/k8srole/search/searcher.go
+++ b/central/rbac/k8srole/search/searcher.go
@@ -16,6 +16,7 @@ var (
 )
 
 // Searcher provides search functionality on existing k8s roles.
+//
 //go:generate mockgen-wrapper
 type Searcher interface {
 	Search(ctx context.Context, query *v1.Query) ([]search.Result, error)

--- a/central/rbac/k8srolebinding/datastore/datastore.go
+++ b/central/rbac/k8srolebinding/datastore/datastore.go
@@ -22,6 +22,7 @@ import (
 )
 
 // DataStore is an intermediary to RoleBindingStorage.
+//
 //go:generate mockgen-wrapper
 type DataStore interface {
 	Search(ctx context.Context, q *v1.Query) ([]searchPkg.Result, error)

--- a/central/rbac/k8srolebinding/search/searcher.go
+++ b/central/rbac/k8srolebinding/search/searcher.go
@@ -16,6 +16,7 @@ var (
 )
 
 // Searcher provides search functionality on existing k8s role bindings.
+//
 //go:generate mockgen-wrapper
 type Searcher interface {
 	Search(ctx context.Context, query *v1.Query) ([]search.Result, error)

--- a/central/reportconfigurations/search/search.go
+++ b/central/reportconfigurations/search/search.go
@@ -16,6 +16,7 @@ var (
 )
 
 // Searcher provides search functionality on existing report configurations.
+//
 //go:generate mockgen-wrapper
 type Searcher interface {
 	Search(ctx context.Context, query *v1.Query) ([]search.Result, error)

--- a/central/reportconfigurations/store/store.go
+++ b/central/reportconfigurations/store/store.go
@@ -7,6 +7,7 @@ import (
 )
 
 // Store provides access and update functions for report configurations.
+//
 //go:generate mockgen-wrapper
 type Store interface {
 	Count(ctx context.Context) (int, error)

--- a/central/reports/manager/manager.go
+++ b/central/reports/manager/manager.go
@@ -7,6 +7,7 @@ import (
 )
 
 // Manager implements the interface for scheduled reports
+//
 //go:generate mockgen-wrapper
 type Manager interface {
 	// Upsert adds/updates a report configuration into the scheduler

--- a/central/risk/datastore/internal/search/searcher.go
+++ b/central/risk/datastore/internal/search/searcher.go
@@ -11,6 +11,7 @@ import (
 )
 
 // Searcher provides search functionality on existing risks
+//
 //go:generate mockgen-wrapper
 type Searcher interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)

--- a/central/risk/datastore/internal/store/store.go
+++ b/central/risk/datastore/internal/store/store.go
@@ -7,6 +7,7 @@ import (
 )
 
 // Store defines the interface for Risk storage
+//
 //go:generate mockgen-wrapper
 type Store interface {
 	Get(ctx context.Context, id string) (*storage.Risk, bool, error)

--- a/central/role/datastore/datastore.go
+++ b/central/role/datastore/datastore.go
@@ -9,6 +9,7 @@ import (
 )
 
 // DataStore is the datastore for roles.
+//
 //go:generate mockgen-wrapper
 type DataStore interface {
 	GetRole(ctx context.Context, name string) (*storage.Role, bool, error)

--- a/central/role/store/store.go
+++ b/central/role/store/store.go
@@ -7,6 +7,7 @@ import (
 )
 
 // PermissionSetStore provides storage functionality for permission sets.
+//
 //go:generate mockgen-wrapper
 type PermissionSetStore interface {
 	Get(ctx context.Context, id string) (*storage.PermissionSet, bool, error)
@@ -18,6 +19,7 @@ type PermissionSetStore interface {
 }
 
 // SimpleAccessScopeStore provides storage functionality for simple access scopes.
+//
 //go:generate mockgen-wrapper
 type SimpleAccessScopeStore interface {
 	Get(ctx context.Context, id string) (*storage.SimpleAccessScope, bool, error)
@@ -29,6 +31,7 @@ type SimpleAccessScopeStore interface {
 }
 
 // RoleStore provides storage functionality for roles.
+//
 //go:generate mockgen-wrapper
 type RoleStore interface {
 	Get(ctx context.Context, id string) (*storage.Role, bool, error)

--- a/central/secret/datastore/datastore.go
+++ b/central/secret/datastore/datastore.go
@@ -21,6 +21,7 @@ import (
 )
 
 // DataStore is an intermediary to SecretStorage.
+//
 //go:generate mockgen-wrapper
 type DataStore interface {
 	Search(ctx context.Context, q *v1.Query) ([]searchPkg.Result, error)

--- a/central/secret/internal/store/store.go
+++ b/central/secret/internal/store/store.go
@@ -7,6 +7,7 @@ import (
 )
 
 // Store provides access and update functions for secrets.
+//
 //go:generate mockgen-wrapper
 type Store interface {
 	Count(ctx context.Context) (int, error)

--- a/central/secret/search/searcher.go
+++ b/central/secret/search/searcher.go
@@ -16,6 +16,7 @@ var (
 )
 
 // Searcher provides search functionality on existing secrets.
+//
 //go:generate mockgen-wrapper
 type Searcher interface {
 	Search(ctx context.Context, query *v1.Query) ([]search.Result, error)

--- a/central/sensor/service/common/manager.go
+++ b/central/sensor/service/common/manager.go
@@ -31,6 +31,7 @@ type NetworkBaselineManager interface {
 }
 
 // NetworkEntityManager implements an interface to retrieve network entities.
+//
 //go:generate mockgen-wrapper
 type NetworkEntityManager interface {
 	GetAllEntitiesForCluster(ctx context.Context, clusterID string) ([]*storage.NetworkEntity, error)

--- a/central/sensor/service/connection/manager.go
+++ b/central/sensor/service/connection/manager.go
@@ -11,6 +11,7 @@ import (
 )
 
 // Manager is responsible for managing all active connections from sensors.
+//
 //go:generate mockgen-wrapper
 type Manager interface {
 	// Need to register cluster manager to avoid cyclic dependencies with cluster datastore

--- a/central/sensor/service/pipeline/pipeline.go
+++ b/central/sensor/service/pipeline/pipeline.go
@@ -14,6 +14,7 @@ type BasePipeline interface {
 }
 
 // ClusterPipeline processes a message received from a given cluster.
+//
 //go:generate mockgen-wrapper
 type ClusterPipeline interface {
 	BasePipeline
@@ -30,6 +31,7 @@ type Factory interface {
 // Fragment is a component of a Pipeline that only processes specific messages.
 // Fragments can be either local or global across clusters;
 // they are passed clusterIDs along with every event, which they are free to use.
+//
 //go:generate mockgen-wrapper
 type Fragment interface {
 	BasePipeline

--- a/central/sensorupgradeconfig/datastore/datastore.go
+++ b/central/sensorupgradeconfig/datastore/datastore.go
@@ -8,6 +8,7 @@ import (
 )
 
 // DataStore is the datastore for the sensor upgrade config.
+//
 //go:generate mockgen-wrapper
 type DataStore interface {
 	GetSensorUpgradeConfig(context.Context) (*storage.SensorUpgradeConfig, error)

--- a/central/sensorupgradeconfig/datastore/internal/store/store.go
+++ b/central/sensorupgradeconfig/datastore/internal/store/store.go
@@ -7,6 +7,7 @@ import (
 )
 
 // Store provides access to the underlying data layer
+//
 //go:generate mockgen-wrapper
 type Store interface {
 	Get(ctx context.Context) (*storage.SensorUpgradeConfig, bool, error)

--- a/central/serviceaccount/datastore/datastore.go
+++ b/central/serviceaccount/datastore/datastore.go
@@ -22,6 +22,7 @@ import (
 )
 
 // DataStore is an intermediary to ServiceAccountStorage.
+//
 //go:generate mockgen-wrapper
 type DataStore interface {
 	Search(ctx context.Context, q *v1.Query) ([]searchPkg.Result, error)

--- a/central/serviceaccount/search/searcher.go
+++ b/central/serviceaccount/search/searcher.go
@@ -16,6 +16,7 @@ var (
 )
 
 // Searcher provides search functionality on existing service accounts.
+//
 //go:generate mockgen-wrapper
 type Searcher interface {
 	Search(ctx context.Context, query *v1.Query) ([]search.Result, error)

--- a/central/serviceidentities/datastore/datastore.go
+++ b/central/serviceidentities/datastore/datastore.go
@@ -8,6 +8,7 @@ import (
 )
 
 // DataStore is the datastore for serviceidentities keys.
+//
 //go:generate mockgen-wrapper
 type DataStore interface {
 	GetServiceIdentities(context.Context) ([]*storage.ServiceIdentity, error)

--- a/central/serviceidentities/internal/store/store.go
+++ b/central/serviceidentities/internal/store/store.go
@@ -7,6 +7,7 @@ import (
 )
 
 // Store provides storage functionality for service identities.
+//
 //go:generate mockgen-wrapper
 type Store interface {
 	GetAll(ctx context.Context) ([]*storage.ServiceIdentity, error)

--- a/central/signatureintegration/datastore/validate.go
+++ b/central/signatureintegration/datastore/validate.go
@@ -13,7 +13,9 @@ import (
 
 // signatureIntegrationIDPrefix should be prepended to every human-hostile ID of a
 // signature integration for readability, e.g.,
-//     "io.stackrox.signatureintegration.94ac7bfe-f9b2-402e-b4f2-bfda480e1a13".
+//
+//	"io.stackrox.signatureintegration.94ac7bfe-f9b2-402e-b4f2-bfda480e1a13".
+//
 // TODO(ROX-9716): refactor to reference the same constant here and in
 // pkg/booleanpolicy/value_regex.go
 const signatureIntegrationIDPrefix = "io.stackrox.signatureintegration."

--- a/central/signatureintegration/store/store.go
+++ b/central/signatureintegration/store/store.go
@@ -7,6 +7,7 @@ import (
 )
 
 // SignatureIntegrationStore provides storage functionality for signature integrations.
+//
 //go:generate mockgen-wrapper
 type SignatureIntegrationStore interface {
 	Get(ctx context.Context, id string) (*storage.SignatureIntegration, bool, error)

--- a/central/splunk/violations.go
+++ b/central/splunk/violations.go
@@ -615,6 +615,7 @@ func refineDeploymentInfo(alertID string, deploymentInfo *integrations.SplunkVio
 // splunkCheckpoint represents parsed checkpoint. Possible checkpoint formats are:
 //  1. "FromTimestamp__ToTimestamp__FromAlertID"
 //  2. "FromTimestamp"
+//
 // #2 is used as initial checkpoint setting in Splunk TA config and when there were no more alerts in the previous request.
 // #1 is used when there were more alerts between FromTimestamp and ToTimestamp and response had to stop because
 // sufficient number of violations was returned.

--- a/central/user/datastore/datastore.go
+++ b/central/user/datastore/datastore.go
@@ -8,6 +8,7 @@ import (
 )
 
 // DataStore is the datastore for users.
+//
 //go:generate mockgen-wrapper
 type DataStore interface {
 	GetUser(ctx context.Context, name string) (*storage.User, error)

--- a/central/user/datastore/internal/store/store.go
+++ b/central/user/datastore/internal/store/store.go
@@ -8,6 +8,7 @@ import (
 )
 
 // Store is the storage and tracking mechanism for users.
+//
 //go:generate mockgen-wrapper
 type Store interface {
 	GetUser(id string) (*storage.User, error)

--- a/central/vulnerabilityrequest/cache/cache.go
+++ b/central/vulnerabilityrequest/cache/cache.go
@@ -4,8 +4,9 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 )
 
-//go:generate mockgen-wrapper
 // VulnReqCache provides functionality to cache vulnerability requests.
+//
+//go:generate mockgen-wrapper
 type VulnReqCache interface {
 	Add(request *storage.VulnerabilityRequest) bool
 	AddMany(requests ...*storage.VulnerabilityRequest)

--- a/central/vulnerabilityrequest/datastore/datastore.go
+++ b/central/vulnerabilityrequest/datastore/datastore.go
@@ -23,6 +23,7 @@ import (
 )
 
 // DataStore is an intermediary to VulnerabilityRequest storage.
+//
 //go:generate mockgen-wrapper
 type DataStore interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)

--- a/central/vulnerabilityrequest/datastore/datastore_impl.go
+++ b/central/vulnerabilityrequest/datastore/datastore_impl.go
@@ -378,7 +378,7 @@ func (ds *datastoreImpl) RemoveRequest(ctx context.Context, id string) error {
 	return nil
 }
 
-// // FOR INTERNAL USE ONLY
+// FOR INTERNAL USE ONLY
 func (ds *datastoreImpl) RemoveRequestsInternal(ctx context.Context, ids []string) error {
 	if ok, err := requesterSAC.WriteAllowed(ctx); err != nil {
 		return err

--- a/central/vulnerabilityrequest/datastore/internal/searcher/searcher.go
+++ b/central/vulnerabilityrequest/datastore/internal/searcher/searcher.go
@@ -16,6 +16,7 @@ var (
 )
 
 // Searcher provides search functionality on existing VulnerabilityRequest.
+//
 //go:generate mockgen-wrapper
 type Searcher interface {
 	Count(ctx context.Context, query *v1.Query) (int, error)

--- a/central/vulnerabilityrequest/datastore/internal/store/store.go
+++ b/central/vulnerabilityrequest/datastore/internal/store/store.go
@@ -7,6 +7,7 @@ import (
 )
 
 // Store provides access and update functions for vulnerability watch requests.
+//
 //go:generate mockgen-wrapper
 type Store interface {
 	Count(ctx context.Context) (int, error)

--- a/central/vulnerabilityrequest/manager/querymgr/query_manager.go
+++ b/central/vulnerabilityrequest/manager/querymgr/query_manager.go
@@ -8,8 +8,9 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 )
 
-//go:generate mockgen-wrapper
 // VulnReqQueryManager provides functionality to answer derived field queries related to vulnerability requests.
+//
+//go:generate mockgen-wrapper
 type VulnReqQueryManager interface {
 	DeploymentCount(ctx context.Context, requestID string, query *v1.Query) (int, error)
 	ImageCount(ctx context.Context, requestID string, query *v1.Query) (int, error)

--- a/central/vulnerabilityrequest/manager/requestmgr/manager.go
+++ b/central/vulnerabilityrequest/manager/requestmgr/manager.go
@@ -7,9 +7,10 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 )
 
-//go:generate mockgen-wrapper
 // The Manager manages snoozing and unsnoozing vulnerabilities based on a request as well as re-observing vulnerabilities
 // if the original request has expired.
+//
+//go:generate mockgen-wrapper
 type Manager interface {
 	// Create process a new deferral or false-positive vuln request.
 	// This is the entry point to vuln request workflow from service layer—rest or graphql.

--- a/central/watchedimage/datastore/datastore.go
+++ b/central/watchedimage/datastore/datastore.go
@@ -13,6 +13,7 @@ var (
 )
 
 // DataStore returns a datastore for watched images.
+//
 //go:generate mockgen-wrapper
 type DataStore interface {
 	Exists(ctx context.Context, name string) (bool, error)

--- a/migrator/migrations/m_170_to_m_171_create_policy_categories_and_edges/policypostgresstore/store.go
+++ b/migrator/migrations/m_170_to_m_171_create_policy_categories_and_edges/policypostgresstore/store.go
@@ -54,7 +54,7 @@ func New(db *pgxpool.Pool) Store {
 	}
 }
 
-//// Helper functions
+// Helper functions
 func (s *storeImpl) copyFrom(ctx context.Context, objs ...*storage.Policy) error {
 	conn, release, err := s.acquireConn(ctx, ops.Get, "Policy")
 	if err != nil {

--- a/migrator/migrations/m_171_to_m_172_move_scope_to_collection_in_report_configurations/accessScopePostgresStore/postgres_plugin.go
+++ b/migrator/migrations/m_171_to_m_172_move_scope_to_collection_in_report_configurations/accessScopePostgresStore/postgres_plugin.go
@@ -61,7 +61,7 @@ func New(db *pgxpool.Pool) Store {
 	}
 }
 
-//// Helper functions
+// Helper functions
 func insertIntoSimpleAccessScopes(ctx context.Context, batch *pgx.Batch, obj *storage.SimpleAccessScope) error {
 
 	serialized, marshalErr := obj.Marshal()

--- a/operator/apis/platform/v1alpha1/central_types.go
+++ b/operator/apis/platform/v1alpha1/central_types.go
@@ -69,7 +69,7 @@ type Egress struct {
 }
 
 // ConnectivityPolicy is a type for values of spec.egress.connectivityPolicy.
-//+kubebuilder:validation:Enum=Online;Offline
+// +kubebuilder:validation:Enum=Online;Offline
 type ConnectivityPolicy string
 
 const (
@@ -209,7 +209,7 @@ type CentralDBSpec struct {
 }
 
 // CentralDBEnabled is a type for values of spec.central.db.enabled.
-//+kubebuilder:validation:Enum=Default;Enabled
+// +kubebuilder:validation:Enum=Default;Enabled
 type CentralDBEnabled string
 
 const (
@@ -497,7 +497,7 @@ func (s *ScannerComponentSpec) IsEnabled() bool {
 }
 
 // ScannerComponentPolicy is a type for values of spec.scanner.scannerComponent.
-//+kubebuilder:validation:Enum=Enabled;Disabled
+// +kubebuilder:validation:Enum=Enabled;Disabled
 type ScannerComponentPolicy string
 
 const (

--- a/operator/apis/platform/v1alpha1/common_types.go
+++ b/operator/apis/platform/v1alpha1/common_types.go
@@ -164,7 +164,7 @@ type ScannerAnalyzerScaling struct {
 }
 
 // AutoScalingPolicy is a type for values of spec.scanner.analyzer.replicas.autoScaling.
-//+kubebuilder:validation:Enum=Enabled;Disabled
+// +kubebuilder:validation:Enum=Enabled;Disabled
 type AutoScalingPolicy string
 
 const (
@@ -194,7 +194,7 @@ func (s *Monitoring) IsEnabled() bool {
 }
 
 // ExposeEndpoint is a type for monitoring sub-struct.
-//+kubebuilder:validation:Enum=Enabled;Disabled
+// +kubebuilder:validation:Enum=Enabled;Disabled
 type ExposeEndpoint string
 
 const (

--- a/operator/apis/platform/v1alpha1/groupversion_info.go
+++ b/operator/apis/platform/v1alpha1/groupversion_info.go
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 // Package v1alpha1 contains API Schema definitions for the platform v1alpha1 API group
-//+kubebuilder:object:generate=true
-//+groupName=platform.stackrox.io
+// +kubebuilder:object:generate=true
+// +groupName=platform.stackrox.io
 package v1alpha1
 
 import (

--- a/operator/apis/platform/v1alpha1/securedcluster_types.go
+++ b/operator/apis/platform/v1alpha1/securedcluster_types.go
@@ -137,7 +137,7 @@ type AdmissionControlComponentSpec struct {
 }
 
 // ImageScanPolicy defines whether images should be scanned at admission control time.
-//+kubebuilder:validation:Enum=ScanIfMissing;DoNotScanInline
+// +kubebuilder:validation:Enum=ScanIfMissing;DoNotScanInline
 type ImageScanPolicy string
 
 const (
@@ -153,7 +153,7 @@ func (p ImageScanPolicy) Pointer() *ImageScanPolicy {
 }
 
 // BypassPolicy defines whether admission controller can be bypassed.
-//+kubebuilder:validation:Enum=BreakGlassAnnotation;Disabled
+// +kubebuilder:validation:Enum=BreakGlassAnnotation;Disabled
 type BypassPolicy string
 
 const (
@@ -191,7 +191,7 @@ type PerNodeSpec struct {
 }
 
 // CollectionMethod defines the method of collection used by collector. Options are 'EBPF', 'KernelModule' or 'None'.
-//+kubebuilder:validation:Enum=EBPF;KernelModule;NoCollection
+// +kubebuilder:validation:Enum=EBPF;KernelModule;NoCollection
 type CollectionMethod string
 
 const (
@@ -220,7 +220,7 @@ type AuditLogsSpec struct {
 }
 
 // AuditLogsCollectionSetting determines if audit log collection is enabled.
-//+kubebuilder:validation:Enum=Auto;Disabled;Enabled
+// +kubebuilder:validation:Enum=Auto;Disabled;Enabled
 type AuditLogsCollectionSetting string
 
 const (
@@ -239,7 +239,7 @@ func (s AuditLogsCollectionSetting) Pointer() *AuditLogsCollectionSetting {
 }
 
 // TaintTolerationPolicy is a type for values of spec.collector.taintToleration
-//+kubebuilder:validation:Enum=TolerateTaints;AvoidTaints
+// +kubebuilder:validation:Enum=TolerateTaints;AvoidTaints
 type TaintTolerationPolicy string
 
 const (
@@ -286,7 +286,7 @@ type ContainerSpec struct {
 }
 
 // CollectorImageFlavor is a type for values of spec.collector.collector.imageFlavor
-//+kubebuilder:validation:Enum=Regular;Slim
+// +kubebuilder:validation:Enum=Regular;Slim
 type CollectorImageFlavor string
 
 const (
@@ -323,7 +323,7 @@ type LocalScannerComponentSpec struct {
 }
 
 // LocalScannerComponentPolicy is a type for values of spec.scanner.scannerComponent.
-//+kubebuilder:validation:Enum=AutoSense;Disabled
+// +kubebuilder:validation:Enum=AutoSense;Disabled
 type LocalScannerComponentPolicy string
 
 const (

--- a/pkg/auth/permissions/resolved_role.go
+++ b/pkg/auth/permissions/resolved_role.go
@@ -5,6 +5,7 @@ import "github.com/stackrox/rox/generated/storage"
 // ResolvedRole type unites a role with the corresponding permission set and
 // access scope. It has been designed to simplify working with the new Role +
 // Permission Set format but is also safe to use with the old Role only format.
+//
 //go:generate mockgen-wrapper
 type ResolvedRole interface {
 	GetRoleName() string

--- a/pkg/backgroundtasks/manager_impl.go
+++ b/pkg/backgroundtasks/manager_impl.go
@@ -104,7 +104,7 @@ func (m *managerImpl) applyDefaults() {
 	m.cancelFuncTasksMutex = concurrency.NewKeyedMutex(uint32(cap(m.parallel) + cap(m.pendingTasks)))
 }
 
-// // AddTask adds a task to its pending task list to be run as a background process and returns a jobid.
+// AddTask adds a task to its pending task list to be run as a background process and returns a jobid.
 func (m *managerImpl) AddTask(metadata map[string]interface{}, task Task) (string, error) {
 	t := &taskWrapper{
 		exec:     task,

--- a/pkg/booleanpolicy/evaluator/pathutil/augmented_obj.go
+++ b/pkg/booleanpolicy/evaluator/pathutil/augmented_obj.go
@@ -54,9 +54,11 @@ func addAugmentedObjToTreeAtPath(rootTree *augmentTree, path *Path, subObj *Augm
 // -> the core object itself
 // -> a mapping of Paths to other (possibly augmented) objects.
 // For example, given a struct like
-// type A struct {
-//    IntVal int
-// }
+//
+//	type A struct {
+//	   IntVal int
+//	}
+//
 // and an object like A{IntVal: 1},
 // you could augment it with "StringVal": "string".
 // This makes it possible to treat the Augmented object _as if_

--- a/pkg/booleanpolicy/evaluator/pathutil/augmented_obj_meta.go
+++ b/pkg/booleanpolicy/evaluator/pathutil/augmented_obj_meta.go
@@ -13,33 +13,34 @@ import (
 // An AugmentedObjMeta represents metadata (ie, type information) about an augmented object.
 // An augmented object is an object that is augmented to look like has certain extra fields that it doesn't.
 // For example, if have something like
-// type A struct {
-//    Bs []B
-// }
 //
-// type B struct {
-//    BVal string
-// }
+//	type A struct {
+//	   Bs []B
+//	}
 //
-// type C struct {
-//   CVal float64
-// }
+//	type B struct {
+//	   BVal string
+//	}
+//
+//	type C struct {
+//	  CVal float64
+//	}
+//
 // Let's say you want to actually have a C inside each B.
 // ie, you want to make it appear that the types are:
 //
+//	type A struct {
+//	   Bs []B
+//	}
 //
-// type A struct {
-//    Bs []B
-// }
+//	type B struct {
+//	   BVal string
+//	   EmbeddedC C
+//	}
 //
-// type B struct {
-//    BVal string
-//    EmbeddedC C
-// }
-//
-// type C struct {
-//   CVal float64
-// }
+//	type C struct {
+//	  CVal float64
+//	}
 //
 // Augmentation allows you to achieve this, by simply adding
 // ("Bs.EmbeddedC", C) as an augment.

--- a/pkg/booleanpolicy/query/query.go
+++ b/pkg/booleanpolicy/query/query.go
@@ -8,6 +8,7 @@ import (
 )
 
 // An Operator denotes how to combine multiple values.
+//
 //go:generate stringer -type=Operator
 type Operator int
 

--- a/pkg/concurrency/retry_ticker.go
+++ b/pkg/concurrency/retry_ticker.go
@@ -35,6 +35,7 @@ type tickFunc func(ctx context.Context) (timeToNextTick time.Duration, err error
 // then:
 //   - If that error is ErrNonRecoverable (according to `errors.Is`) then the RetryTicker stops.
 //   - Otherwise the RetryTicker will wait the time returned by `backoff.Step` before calling `doFunc` again.
+//
 // - `doFunc` should return an error if ctx is cancelled. RetryTicker always calls `doFunc` with a context
 // with a timeout of `timeout`.
 // - On success `RetryTicker` will reset `backoff`, and wait the amount of time returned by `doFunc` before

--- a/pkg/concurrency/timeout.go
+++ b/pkg/concurrency/timeout.go
@@ -27,12 +27,12 @@ func Timeout(duration time.Duration) WaitableChan {
 // duration.
 // The motivation for not triggering the returned waitable when cancelCond is triggered is to allow statements such as
 //
-// select {
-// case <-sig.Done():
-//   ... happy path ...
-// case <-TimeoutOr(timeoutDuration, &sig):
-//   ... oh no, a timeout ...
-// }
+//	select {
+//	case <-sig.Done():
+//		... happy path ...
+//	case <-TimeoutOr(timeoutDuration, &sig):
+//		... oh no, a timeout ...
+//	}
 //
 // Due to the non-deterministic nature of select, a trigger might otherwise show up as a timeout, and only checking
 // `sig.Done()` would allow a user to distinguish the two.

--- a/pkg/concurrency/value_stream.go
+++ b/pkg/concurrency/value_stream.go
@@ -14,38 +14,38 @@ import (
 // cause unbounded memory growth. It is considerably slower than writing to a fully buffered channel or appending to
 // a slice, but considerably faster than those options if some synchronization/contention is involved. It also
 // has a number of practical benefits over approaches with explicit synchronization on the sender-side:
-// - Since senders do not have to synchronize, the performance of pushing a value does not depend on the number of
-//   subscribed observers.
-// - The order of pushed elements is always preserved, since it is never necessary to spawn goroutines for pushing.
-// - The observer maintains the entire state required for reading all future values in a single iterator, which obeys
-//   Go garbage collection rules. Hence, no explicit registration/deregistration of observers is necessary.
+//   - Since senders do not have to synchronize, the performance of pushing a value does not depend on the number of
+//     subscribed observers.
+//   - The order of pushed elements is always preserved, since it is never necessary to spawn goroutines for pushing.
+//   - The observer maintains the entire state required for reading all future values in a single iterator, which obeys
+//     Go garbage collection rules. Hence, no explicit registration/deregistration of observers is necessary.
 //
 // Receivers operate on this class via iterators obtained via the `Iterator` method. There are two modes of iteration:
-// - If you care about processing every single value in the stream, set the `strict` parameter to `true` when calling
-//   `Iterator`. Traversing the stream via the iterator is guaranteed to yield every single element that subsequently
-//   gets pushed to the stream, no matter how fast the writer and how slow this reader. This mode of operation might
-//   cause unbounded memory growth.
-//   Should you occasionally want to skip over intermediate elements and jump to the most recent one, you can call
-//   `FastForward` or `TryFastForward` on the `ValueStream`.
-// - Perhaps equally common is the case that you *do not* care about every single value in the stream, and are fine
-//   skipping over values, if, e.g., your observer might take a long time to process an observation, as long as you
-//   are sure to always be informed about the most recent value. For this, set the `strict` parameter to `false` when
-//   calling `Iterator`. Calling `Next` on the returned iterator will always return the most recent element in the
-//   stream that is newer than the current one. If the element pointed to by the current iterator is the most recent
-//   one, `Next` will block until a more recent one becomes available.
+//   - If you care about processing every single value in the stream, set the `strict` parameter to `true` when calling
+//     `Iterator`. Traversing the stream via the iterator is guaranteed to yield every single element that subsequently
+//     gets pushed to the stream, no matter how fast the writer and how slow this reader. This mode of operation might
+//     cause unbounded memory growth.
+//     Should you occasionally want to skip over intermediate elements and jump to the most recent one, you can call
+//     `FastForward` or `TryFastForward` on the `ValueStream`.
+//   - Perhaps equally common is the case that you *do not* care about every single value in the stream, and are fine
+//     skipping over values, if, e.g., your observer might take a long time to process an observation, as long as you
+//     are sure to always be informed about the most recent value. For this, set the `strict` parameter to `false` when
+//     calling `Iterator`. Calling `Next` on the returned iterator will always return the most recent element in the
+//     stream that is newer than the current one. If the element pointed to by the current iterator is the most recent
+//     one, `Next` will block until a more recent one becomes available.
 //
 // The following code exemplifies how to iterate over all values in the stream, in strict mode.
-//       it := stream.Iterator(true)  // pass false for skipping mode
-//       var err error
-//       for it != nil {
-//         fmt.Println("Value", it.Value())
-//         time.Sleep(1)
-//         it, err = it.Next(ctx)
-//       }
-//       if err != nil {
-//         fmt.Fprintln("Context error aborted iteration: %v", err)
-//       }
 //
+//	it := stream.Iterator(true)  // pass false for skipping mode
+//	var err error
+//	for it != nil {
+//	  fmt.Println("Value", it.Value())
+//	  time.Sleep(1)
+//	  it, err = it.Next(ctx)
+//	}
+//	if err != nil {
+//	  fmt.Fprintln("Context error aborted iteration: %v", err)
+//	}
 type ValueStream[T any] struct {
 	curr unsafe.Pointer // always holds a *valueStreamStrictIter[T]
 }

--- a/pkg/cryptoutils/nonce_generator.go
+++ b/pkg/cryptoutils/nonce_generator.go
@@ -7,6 +7,7 @@ import (
 )
 
 // NonceGenerator is a generator for cryptographically secure nonces.
+//
 //go:generate mockgen-wrapper
 type NonceGenerator interface {
 	Nonce() (string, error)

--- a/pkg/dackbox/graph/graph.go
+++ b/pkg/dackbox/graph/graph.go
@@ -9,6 +9,7 @@ import (
 )
 
 // RGraph is a read-only view of a Graph.
+//
 //go:generate mockgen-wrapper
 type RGraph interface {
 	HasRefsFrom(from []byte) bool
@@ -31,6 +32,7 @@ type RGraph interface {
 }
 
 // RWGraph is a read-write view of a Graph.
+//
 //go:generate mockgen-wrapper
 type RWGraph interface {
 	RGraph
@@ -52,6 +54,7 @@ type applyableGraph interface {
 
 // DiscardableRGraph is an RGraph (read only view of the ID->[]ID map layer) that needs to be discarded when finished.
 // NOTE: THIS HAS TO BE HERE FOR MOCK GENERATION TO WORK. IF YOU PUT IT IN A DIFFERENT FILE, 'go generate' WILL FAIL.
+//
 //go:generate mockgen-wrapper
 type DiscardableRGraph interface {
 	RGraph

--- a/pkg/dackbox/graph/graph_provider.go
+++ b/pkg/dackbox/graph/graph_provider.go
@@ -1,6 +1,7 @@
 package graph
 
 // Provider is an interface that allows us to interact with an RGraph for the duration of a function's execution.
+//
 //go:generate mockgen-wrapper
 type Provider interface {
 	NewGraphView() DiscardableRGraph

--- a/pkg/dackbox/indexer/wrapper.go
+++ b/pkg/dackbox/indexer/wrapper.go
@@ -6,6 +6,7 @@ import (
 )
 
 // Wrapper is an object that wraps keys and values into their indexed id:value pair.
+//
 //go:generate mockgen-wrapper
 type Wrapper interface {
 	Wrap(key []byte, msg proto.Message) (string, interface{})

--- a/pkg/dackbox/utils/queue/waitable.go
+++ b/pkg/dackbox/utils/queue/waitable.go
@@ -12,6 +12,7 @@ type AcceptsKeyValue interface {
 }
 
 // WaitableQueue is a thread safe queue with an extra provided function that allows you to wait for a value to pop.
+//
 //go:generate mockgen-wrapper
 type WaitableQueue interface {
 	Push(key []byte, value proto.Message)

--- a/pkg/db/crud.go
+++ b/pkg/db/crud.go
@@ -3,6 +3,7 @@ package db
 import "github.com/gogo/protobuf/proto"
 
 // Crud provides a simple crud layer on top of a DB supporting proto messages
+//
 //go:generate mockgen-wrapper
 type Crud interface {
 	// Read functions

--- a/pkg/detection/policy_set.go
+++ b/pkg/detection/policy_set.go
@@ -11,6 +11,7 @@ var (
 )
 
 // PolicySet is a set of policies.
+//
 //go:generate mockgen-wrapper
 type PolicySet interface {
 	ForOne(policyID string, f func(CompiledPolicy) error) error

--- a/pkg/docker/client/client.go
+++ b/pkg/docker/client/client.go
@@ -8,7 +8,7 @@ be used by your own Go applications to do anything the command-line interface do
 For more information about the Engine API, see the documentation:
 https://docs.docker.com/engine/reference/api/
 
-Usage
+# Usage
 
 You use the library by creating a client object and calling methods on it. The
 client can be created either from environment variables with NewEnvClient, or
@@ -41,7 +41,6 @@ For example, to list running containers (the equivalent of "docker ps"):
 			fmt.Printf("%s %s\n", container.ID[:10], container.Image)
 		}
 	}
-
 */
 package client
 

--- a/pkg/errox/roxerror.go
+++ b/pkg/errox/roxerror.go
@@ -1,27 +1,32 @@
 // Package errox implements tooling and an interface for project errors
 // handling, and a list of base sentinel errors.
 //
-// Usage
+// # Usage
 //
 // Base new errors on one of the existing sentinel errors:
-//     ObjectNotFound := errox.NotFound.New("object not found")
+//
+//	ObjectNotFound := errox.NotFound.New("object not found")
 //
 // Classify encountered errors by making them a cause:
-//     err := parse(args)
-//     return errox.InvalidArgs.CausedBy(err)
+//
+//	err := parse(args)
+//	return errox.InvalidArgs.CausedBy(err)
 //
 // Check error class:
-//     if errors.Is(err, errox.InvalidArgs) ...
+//
+//	if errors.Is(err, errox.InvalidArgs) ...
 //
 // Format error messages:
-//     return errox.NotFound.Newf("file %q not found", filename)
+//
+//	return errox.NotFound.Newf("file %q not found", filename)
 //
 // Create error factories for generic errors:
-//     ErrInvalidAlgorithmF := func(alg string) errox.Error {
-//         return errox.InvalidArgs.Newf("invalid algorithm %q used", alg)
-//     }
-//     ...
-//     return ErrInvalidAlgorithmF("256")
+//
+//	ErrInvalidAlgorithmF := func(alg string) errox.Error {
+//	    return errox.InvalidArgs.Newf("invalid algorithm %q used", alg)
+//	}
+//	...
+//	return ErrInvalidAlgorithmF("256")
 package errox
 
 import "fmt"
@@ -67,9 +72,10 @@ func (e *RoxError) Unwrap() error {
 // error's base error in the chain but hide its message.
 //
 // Example:
-//     ErrRecordNotFound := errox.NotFound.New("record not found")
-//     ErrRecordNotFound.Error() == "record not found" // true
-//     errors.Is(ErrRecordNotFound, errox.NotFound)    // true
+//
+//	ErrRecordNotFound := errox.NotFound.New("record not found")
+//	ErrRecordNotFound.Error() == "record not found" // true
+//	errors.Is(ErrRecordNotFound, errox.NotFound)    // true
 func (e *RoxError) New(message string) *RoxError {
 	// Return *RoxError instead of errox.Error to enable `go vet` checks.
 	return &RoxError{message, e}
@@ -80,9 +86,10 @@ func (e *RoxError) New(message string) *RoxError {
 // the error's base error in the chain but hide its message.
 //
 // Example:
-//     ErrRecordNotFound := errox.NotFound.Newf("record <%d> not found", recordIndex)
-//     ErrRecordNotFound.Error() == "record <5> not found" // true
-//     errors.Is(ErrRecordNotFound, errox.NotFound)        // true
+//
+//	ErrRecordNotFound := errox.NotFound.Newf("record <%d> not found", recordIndex)
+//	ErrRecordNotFound.Error() == "record <5> not found" // true
+//	errors.Is(ErrRecordNotFound, errox.NotFound)        // true
 func (e *RoxError) Newf(format string, args ...interface{}) *RoxError {
 	// Return *RoxError instead of errox.Error to enable `go vet` checks.
 	return e.New(fmt.Sprintf(format, args...))
@@ -93,12 +100,16 @@ func (e *RoxError) Newf(format string, args ...interface{}) *RoxError {
 //
 // Note, that if cause is an error chain, the chain is collapsed to the message
 // and the cause class is dropped, i.e.:
-//     errors.Is(err.CausedBy(cause), cause) == false
+//
+//	errors.Is(err.CausedBy(cause), cause) == false
 //
 // Example:
-//     return errox.InvalidArgument.CausedBy(err)
+//
+//	return errox.InvalidArgument.CausedBy(err)
+//
 // or
-//     return errox.InvalidArgument.CausedBy("unknown parameter")
+//
+//	return errox.InvalidArgument.CausedBy("unknown parameter")
 func (e *RoxError) CausedBy(cause interface{}) error {
 	return fmt.Errorf("%w: %v", e, cause)
 }
@@ -108,7 +119,8 @@ func (e *RoxError) CausedBy(cause interface{}) error {
 // provided format specifier and arguments, following a colon.
 //
 // Example:
-//     return errox.InvalidArgument.CausedByf("unknown parameter %v", p)
+//
+//	return errox.InvalidArgument.CausedByf("unknown parameter %v", p)
 func (e *RoxError) CausedByf(format string, args ...interface{}) error {
 	return e.CausedBy(fmt.Sprintf(format, args...))
 }

--- a/pkg/expiringcache/clock.go
+++ b/pkg/expiringcache/clock.go
@@ -5,6 +5,7 @@ import (
 )
 
 // Clock is an interface that provides the current time.s
+//
 //go:generate mockgen-wrapper
 type Clock interface {
 	Now() time.Time

--- a/pkg/gjson/row.go
+++ b/pkg/gjson/row.go
@@ -124,28 +124,33 @@ func jaggedArrayError(maxAmount, violatedAmount, arrayIndex int) error {
 //
 // Example:
 // Assuming you have a multi-path query such as:
-// {result.deployments.#.depName,result.deployments.#.images.#.imgName,result.deployments.#.images.#.components.#.compName,result.deployments.#.images.#.components.#.vulns.#.vulnName}
+//
+//	{result.deployments.#.depName,result.deployments.#.images.#.imgName,result.deployments.#.images.#.components.#.compName,result.deployments.#.images.#.components.#.vulns.#.vulnName}
+//
 // which is used against the following JSON object:
-// {"result":{"deployments":[{"name":"dep1","images":[{"name":"image1","components":[{"name":"comp11","vulns":[{"name":"cve1"}]},{"name":"comp12"}]},{"name":"image2","components":[{"name":"comp21","vulns":[{"name":"cve1"}]},{"name":"comp22","vulns":[{"name":"cve2"}]}]}]}]}}
+//
+//	{"result":{"deployments":[{"name":"dep1","images":[{"name":"image1","components":[{"name":"comp11","vulns":[{"name":"cve1"}]},{"name":"comp12"}]},{"name":"image2","components":[{"name":"comp21","vulns":[{"name":"cve1"}]},{"name":"comp22","vulns":[{"name":"cve2"}]}]}]}]}}
 //
 // The yielded gjson.Result would look like this:
-// {"depName":["dep1"],"imgName":[["image1","image2"]],"compName":[[["comp11","comp12"],["comp21","comp22"]]],"vulnName":[[[["cve1"],[]],[["cve1"],["cve2"]]]]}
+//
+//	{"depName":["dep1"],"imgName":[["image1","image2"]],"compName":[[["comp11","comp12"],["comp21","comp22"]]],"vulnName":[[[["cve1"],[]],[["cve1"],["cve2"]]]]}
 //
 // When constructing the column tree, the query will be sorted for "dimension". A dimension is the depth of arrays
 // available per result.
 //
 // The constructed tree would look like the following:
+//
 //	dep1
-//	- image1
+//	 - image1
 //	  - comp11
-//      - cve1
-//    - comp12
-//      - -
-//  - image2
-//    - comp21
-//      - cve1
-//    - comp22
-//      - cve2
+//		- cve1
+//	  - comp12
+//	     - -
+//	 - image2
+//	  - comp21
+//	  	- cve1
+//	  - comp22
+//	    - cve2
 //
 // Each children is representing a related data. Now, when constructing the column, we are aware of
 // related data and can expand the column values.

--- a/pkg/grpc/metrics/grpc_metrics.go
+++ b/pkg/grpc/metrics/grpc_metrics.go
@@ -8,6 +8,7 @@ import (
 )
 
 // GRPCMetrics provides an grpc interceptor which monitors API calls and recovers from panics and provides a method to get the metrics
+//
 //go:generate mockgen-wrapper
 type GRPCMetrics interface {
 	UnaryMonitoringInterceptor(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error)

--- a/pkg/grpc/metrics/http_metrics.go
+++ b/pkg/grpc/metrics/http_metrics.go
@@ -6,6 +6,7 @@ import (
 
 // HTTPMetrics provides an object which can wrap HTTP handlers and provide a method to get metrics about the wrapped
 // HTTP handlers
+//
 //go:generate mockgen-wrapper
 type HTTPMetrics interface {
 	WrapHandler(handler http.Handler, path string) http.Handler

--- a/pkg/grpc/requestinfo/requestinfo.go
+++ b/pkg/grpc/requestinfo/requestinfo.go
@@ -58,10 +58,10 @@ type HTTPRequest struct {
 // RequestInfo provides a unified view of a GRPC request, regardless of whether it came through the HTTP/1.1 gateway
 // or directly via GRPC.
 // When forwarding requests in the HTTP/1.1 gateway, there are two independent mechanisms to defend against spoofing:
-// - Only requests originating from a local loopback address are permitted to carry a RequestInfo in their metadata.
-// - RequestInfos are timestamped, and expire after 200ms. The timestamp is derived from a monotonic clock reading;
-//   to prevent attackers from fabricating a RequestInfo with timestamp (in case a monotonic clock reading should ever
-//   leak), the entire RequestInfo (with timestamp) is signed with a cryptographic signature.
+//   - Only requests originating from a local loopback address are permitted to carry a RequestInfo in their metadata.
+//   - RequestInfos are timestamped, and expire after 200ms. The timestamp is derived from a monotonic clock reading;
+//     to prevent attackers from fabricating a RequestInfo with timestamp (in case a monotonic clock reading should ever
+//     leak), the entire RequestInfo (with timestamp) is signed with a cryptographic signature.
 type RequestInfo struct {
 	// Hostname is the hostname specified in a request, as intended by the client. This is derived from the
 	// `X-Forwarded-Host` (if present) or the `Hostname` header for a HTTP/1.1 request, and from the TLS ServerName

--- a/pkg/helm/util/tables.go
+++ b/pkg/helm/util/tables.go
@@ -6,7 +6,8 @@ import "helm.sh/helm/v3/pkg/chartutil"
 // It combines an arbitrary number of tables, modifying the first argument (`dst`) and giving preference
 // to arguments in left-to-right order.
 // Hence, `CoalesceTables(dst, src1, src2, ..., srcN)` is equivalent to calling
-//   CoalesceTables(...CoalesceTables(CoalesceTables(dst, src1), src2)..., srcN)
+//
+//	CoalesceTables(...CoalesceTables(CoalesceTables(dst, src1), src2)..., srcN)
 func CoalesceTables(dst map[string]interface{}, srcs ...map[string]interface{}) map[string]interface{} {
 	res := dst
 	for _, src := range srcs {

--- a/pkg/images/enricher/enricher.go
+++ b/pkg/images/enricher/enricher.go
@@ -85,6 +85,7 @@ type EnrichmentResult struct {
 }
 
 // A ScanResult denotes the result of an attempt to scan an image.
+//
 //go:generate stringer -type=ScanResult
 type ScanResult int
 
@@ -99,6 +100,7 @@ const (
 )
 
 // ImageEnricher provides functions for enriching images with integrations.
+//
 //go:generate mockgen-wrapper
 type ImageEnricher interface {
 	// EnrichImage will enrich an image with its metadata, scan results, signatures and signature verification results.

--- a/pkg/images/integration/set.go
+++ b/pkg/images/integration/set.go
@@ -8,6 +8,7 @@ import (
 )
 
 // Set provides an interface for reading the active set of image integrations.
+//
 //go:generate mockgen-wrapper
 type Set interface {
 	RegistryFactory() registries.Factory

--- a/pkg/integrationhealth/health_reporter.go
+++ b/pkg/integrationhealth/health_reporter.go
@@ -5,6 +5,7 @@ import (
 )
 
 // Reporter is an interface to report integration health updates and deletes
+//
 //go:generate mockgen-wrapper
 type Reporter interface {
 	Register(id, name string, typ storage.IntegrationHealth_Type) error

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -2,21 +2,29 @@
 //
 // This package supports runtime configuration via the following
 // environment variables:
-//   * LOGLEVEL supporting the following values (case insensitive), order is indicative of importance:
-//     * fatal
-//     * panic
-//     * error
-//     * warn
-//     * info
-//     * debug
-//   * LOGENCODING supporting the following values:
-//     * json
-//     * console
-//   * MODULE_LOGLEVELS supporting ,-separated module=level pairs, e.g.: grpc=debug,kubernetes=warn
-//   * MAX_LOG_LINE_QUOTA in the format max/duration_in_seconds, e.g.: 100/10
-//   * PERSISTENT_LOG supporting the following values for additional log file on persistent storage
-//     * true
-//     * false
+//
+// 1. LOGLEVEL supporting the following values (case insensitive), order is indicative of importance:
+//
+//   - fatal
+//   - panic
+//   - error
+//   - warn
+//   - info
+//   - debug
+//
+// 2. LOGENCODING supporting the following values:
+//
+//   - json
+//   - console
+//
+// 3. MODULE_LOGLEVELS supporting ,-separated module=level pairs, e.g.: grpc=debug,kubernetes=warn
+//
+// 4. MAX_LOG_LINE_QUOTA in the format max/duration_in_seconds, e.g.: 100/10
+//
+// 5. PERSISTENT_LOG supporting the following values for additional log file on persistent storage
+//
+//   - true
+//   - false
 //
 // LOGLEVEL semantics follow common conventions, i.e., any log message with a level less than the
 // currently set log level will be discarded.

--- a/pkg/logging/module.go
+++ b/pkg/logging/module.go
@@ -35,8 +35,8 @@ func ModuleForName(name string) *Module {
 
 // ForEachModule invokes f for known modules. If selector is not empty,
 // f is invoked for every entry in selector:
-//   * a pointer to a known Module instance if the entry is known
-//   * a nil pointer if the entry is not known
+//   - a pointer to a known Module instance if the entry is known
+//   - a nil pointer if the entry is not known
 func ForEachModule(f func(name string, m *Module), selector []string) {
 	modules.forEachModule(f, selector)
 }
@@ -172,12 +172,12 @@ func callerFileToPackage(skip int) string {
 // getCallingModule returns the short name of the module calling this function, skipping <skip> stack frames in the
 // call stack.
 // The short name is determined as follows:
-// - If the package is a subpackage of "<projectPrefix>/pkg", the short name is the result of stripping
-//   "<projectPrefix>/".
-// - Otherwise, if the package is a subpackage of "<projectPrefix>/", the short name is the result of stripping
-//   "<projectPrefix>/" and the first component of the remaining path name, including any trailing slashes. If the
-//   resulting string is the empty string, the short name is "main".
-// - Otherwise, the short name is the full package name.
+//   - If the package is a subpackage of "<projectPrefix>/pkg", the short name is the result of stripping
+//     "<projectPrefix>/".
+//   - Otherwise, if the package is a subpackage of "<projectPrefix>/", the short name is the result of stripping
+//     "<projectPrefix>/" and the first component of the remaining path name, including any trailing slashes. If the
+//     resulting string is the empty string, the short name is "main".
+//   - Otherwise, the short name is the full package name.
 func getCallingModule(skip int) string {
 	callingPackage := callerFileToPackage(skip)
 	if callingPackage == "" {

--- a/pkg/metrics/operations.go
+++ b/pkg/metrics/operations.go
@@ -1,6 +1,7 @@
 package metrics
 
 // Op represents a bolt operation that we want to time.
+//
 //go:generate stringer -type=Op
 type Op int
 

--- a/pkg/metrics/resolvers.go
+++ b/pkg/metrics/resolvers.go
@@ -1,6 +1,7 @@
 package metrics
 
 // Resolver represents a graphql resolver that we want to time.
+//
 //go:generate stringer -type=Resolver
 type Resolver int
 

--- a/pkg/mitre/common.go
+++ b/pkg/mitre/common.go
@@ -33,10 +33,11 @@ func GetMitreBundle() (*storage.MitreAttackBundle, error) {
 
 // FlattenMitreMatrices flattens multiple matrices such as container, network, etc. into one enterprise matrix.
 // For example,
-//   matrix1: tactic1: technique1, technique2
-//   matrix2: tactic1: technique2; tactic2: technique3
-//   result:
-//     tactic1: technique1, technique2; tactic2: technique3
+//
+//	matrix1: tactic1: technique1, technique2
+//	matrix2: tactic1: technique2; tactic2: technique3
+//	result:
+//	  tactic1: technique1, technique2; tactic2: technique3
 func FlattenMitreMatrices(matrices ...*storage.MitreAttackMatrix) []*storage.MitreAttackVector {
 	tactics := make(map[string]*storage.MitreTactic)
 	techniques := make(map[string]*storage.MitreTechnique)

--- a/pkg/mtls/ca.go
+++ b/pkg/mtls/ca.go
@@ -13,6 +13,7 @@ import (
 )
 
 // CA represents a StackRox service certificate authority.
+//
 //go:generate mockgen-wrapper
 type CA interface {
 	// CheckProperties checks that the underlying CA certificate is indeed one

--- a/pkg/nodes/enricher/enricher.go
+++ b/pkg/nodes/enricher/enricher.go
@@ -14,6 +14,7 @@ var (
 )
 
 // NodeEnricher provides functions for enriching nodes with vulnerability data.
+//
 //go:generate mockgen-wrapper
 type NodeEnricher interface {
 	EnrichNodeWithInventory(node *storage.Node, nodeInventory *storage.NodeInventory) error

--- a/pkg/printers/csv.go
+++ b/pkg/printers/csv.go
@@ -68,24 +68,29 @@ type CSVPrinter struct {
 // GJSON's syntax expression to read more about modifiers.
 // The following example illustrates a JSON compatible structure and its gjson multi path expression
 // JSON structure:
-// type data struct {
-//		Infos 	[]info `json:"infos"`
-//		Name 	string `json:"name"`
-// }
-// type info struct {
-//		info 	string `json:"info"`
-//		topic 	string `json:"topic"`
-// }
+//
+//	type data struct {
+//			Infos 	[]info `json:"infos"`
+//			Name 	string `json:"name"`
+//	}
+//
+//	type info struct {
+//			info 	string `json:"info"`
+//			topic 	string `json:"topic"`
+//	}
+//
 // Data:
-// data := &data{Name: "example", Infos: []info{
-//										{info: "info1", topic: "topic1"},
-//										{info: "info2", topic: "topic2"},
-//										{info: "info3", topic: "topic3"},
-//										}
+//
+//	data := &data{Name: "example", Infos: []info{
+//											{info: "info1", topic: "topic1"},
+//											{info: "info2", topic: "topic2"},
+//											{info: "info3", topic: "topic3"},
+//											}
+//
 // gjson multi path expression: "{name,infos.#.info,infos.#.topic}"
-// 	- bundle multiple gjson expression surrounded by "{}" to form a multi path expression
-// 	- specify "#" to visit each element in the array
-// 	- each expression in the multi path expression is correlated with the given header(s)!
+//   - bundle multiple gjson expression surrounded by "{}" to form a multi path expression
+//   - specify "#" to visit each element in the array
+//   - each expression in the multi path expression is correlated with the given header(s)!
 //
 // headers := []string{"name", "info", "topic"}
 //

--- a/pkg/printers/junit.go
+++ b/pkg/printers/junit.go
@@ -51,42 +51,53 @@ type JUnitPrinter struct {
 // GJSON's syntax expression to read more about modifiers.
 // The following example illustrates a JSON compatible structure and an example for the map of JSON Path expressions
 // JSON structure:
-// type data struct {
-//		Policies []policy `json:"policies"`
-//		FailedPolicies []failedPolicy `json:"failedPolicies"`
-// }
-// type policy struct {
-//		name string `json:"name"`
-//		severity string `json:"severity"`
-// }
-// type failedPolicy struct {
-//		name string `json:"name"`
-//		error string `json:"error"`
-// }
+//
+//	type data struct {
+//			Policies []policy `json:"policies"`
+//			FailedPolicies []failedPolicy `json:"failedPolicies"`
+//	}
+//
+//	type policy struct {
+//			name string `json:"name"`
+//			severity string `json:"severity"`
+//	}
+//
+//	type failedPolicy struct {
+//			name string `json:"name"`
+//			error string `json:"error"`
+//	}
+//
 // Data:
-// data := &data{Policies: []policy{
-//								{name: "policy1", severity: "HIGH"},
-//								{name: "policy2", severity: "LOW"},
-//								{name: "policy3", severity: "MEDIUM"}
-//								},
-//				 FailedPolicies: []failedPolicy{
-//								{name: "policy1", error: "error msg1"}},
-//				}
+//
+//	data := &data{Policies: []policy{
+//									{name: "policy1", severity: "HIGH"},
+//									{name: "policy2", severity: "LOW"},
+//									{name: "policy3", severity: "MEDIUM"}
+//									},
+//					 FailedPolicies: []failedPolicy{
+//									{name: "policy1", error: "error msg1"}},
+//					}
+//
 // Map of GJSON expressions:
-//	- specify "#" to visit each element of an array
-//	- the expressions for failed test cases and error messages MUST be equal and correlated
-// expressions := map[string]{
-//					JUnitFailedTestCasesExpressionKey: "data.failedPolicies.#.name",
-//					JUnitFailedTestCaseErrMsgExpressionKey: "data.failedPolicies.#.error",
-//					JUnitTestCasesExpressionKey: "data.policies.#.name",
-//				}
+//
+//   - specify "#" to visit each element of an array
+//
+//   - the expressions for failed test cases and error messages MUST be equal and correlated
+//
+// Example:
+//
+//	expressions := map[string] {
+//	JUnitFailedTestCasesExpressionKey: "data.failedPolicies.#.name",
+//	JUnitFailedTestCaseErrMsgExpressionKey: "data.failedPolicies.#.error",
+//	JUnitTestCasesExpressionKey: "data.policies.#.name",
+//	}
 //
 // This would result in the following test cases and failed test cases:
 // Amount of test cases: 3
 // Testcases:
-//		- Name: policy1, Failed: "error msg1"
-//		- Name: policy2, Successful
-//		- Name: policy3, Successful
+//   - Name: policy1, Failed: "error msg1"
+//   - Name: policy2, Successful
+//   - Name: policy3, Successful
 func NewJUnitPrinter(suiteName string, jsonPathExpressions map[string]string) *JUnitPrinter {
 	return &JUnitPrinter{suiteName: suiteName, jsonPathExpressions: jsonPathExpressions}
 }

--- a/pkg/printers/table.go
+++ b/pkg/printers/table.go
@@ -46,24 +46,29 @@ type TablePrinter struct {
 // GJSON's syntax expression to read more about modifiers.
 // The following example illustrates a JSON compatible structure and its gjson multi path expression
 // JSON structure:
-// type data struct {
-//		Infos 	[]info `json:"infos"`
-//		Name 	string `json:"name"`
-// }
-// type info struct {
-//		info 	string `json:"info"`
-//		topic 	string `json:"topic"`
-// }
+//
+//	type data struct {
+//			Infos 	[]info `json:"infos"`
+//			Name 	string `json:"name"`
+//	}
+//
+//	type info struct {
+//			info 	string `json:"info"`
+//			topic 	string `json:"topic"`
+//	}
+//
 // Data:
-// data := &data{Name: "example", Infos: []info{
-//										{info: "info1", topic: "topic1"},
-//										{info: "info2", topic: "topic2"},
-//										{info: "info3", topic: "topic3"},
-//										}
+//
+//	data := &data{Name: "example", Infos: []info{
+//											{info: "info1", topic: "topic1"},
+//											{info: "info2", topic: "topic2"},
+//											{info: "info3", topic: "topic3"},
+//											}
+//
 // gjson multi path expression: "{name,infos.#.info,infos.#.topic}"
-// 	- bundle multiple gjson expression surrounded by "{}" to form a multi path expression
-// 	- specify "#" to visit each element in the array
-// 	- each expression in the multi path expression is correlated with the given header(s)!
+//   - bundle multiple gjson expression surrounded by "{}" to form a multi path expression
+//   - specify "#" to visit each element in the array
+//   - each expression in the multi path expression is correlated with the given header(s)!
 //
 // headers := []string{"name", "info", "topic"}
 //

--- a/pkg/process/filter/filter.go
+++ b/pkg/process/filter/filter.go
@@ -36,6 +36,7 @@ var (
 )
 
 // Filter takes in a process indicator via add and determines if should be filtered or not
+//
 //go:generate mockgen-wrapper
 type Filter interface {
 	Add(indicator *storage.ProcessIndicator) bool

--- a/pkg/registries/set.go
+++ b/pkg/registries/set.go
@@ -6,6 +6,7 @@ import (
 )
 
 // Set provides an interface for reading the active set of image integrations.
+//
 //go:generate mockgen-wrapper
 type Set interface {
 	GetAll() []types.ImageRegistry

--- a/pkg/renderer/kubernetes.go
+++ b/pkg/renderer/kubernetes.go
@@ -23,6 +23,7 @@ func init() {
 }
 
 // mode is the mode we want the renderer to function in.
+//
 //go:generate stringer -type=mode
 type mode int
 

--- a/pkg/sac/allow_fixed_scopes_checker_core.go
+++ b/pkg/sac/allow_fixed_scopes_checker_core.go
@@ -11,10 +11,12 @@ type allowFixedScopesCheckerCore []scopeKeySet
 
 // AllowFixedScopes returns a scope checker core that allows those scopes that
 // are in the cross product of all individual scope key lists. I.e.,
-// AllowFixedScopes(
-//   AccessModeScopeKeys(storage.Access_READ, storage.Access_READ_WRITE),
-//   ResourceScopeKeys(resources.CLUSTER),
-// )
+//
+//	AllowFixedScopes(
+//		AccessModeScopeKeys(storage.Access_READ, storage.Access_READ_WRITE),
+//		ResourceScopeKeys(resources.CLUSTER),
+//	)
+//
 // returns a scope checker core that allows read and write access to all cluster resources.
 func AllowFixedScopes(keyLists ...[]ScopeKey) ScopeCheckerCore {
 	sets := make(allowFixedScopesCheckerCore, len(keyLists))

--- a/pkg/sac/effectiveaccessscope/conversion.go
+++ b/pkg/sac/effectiveaccessscope/conversion.go
@@ -94,9 +94,9 @@ func sortScopesInEffectiveAccessScope(msg *storage.EffectiveAccessScope) {
 }
 
 // convertRulesToLabelSelectors:
-//   * converts included_clusters rules to a single cluster label selector,
-//   * converts included_namespaces rules to a single namespace label selector,
-//   * converts all label selectors to standard ones with matching support.
+//   - converts included_clusters rules to a single cluster label selector,
+//   - converts included_namespaces rules to a single namespace label selector,
+//   - converts all label selectors to standard ones with matching support.
 func convertRulesToLabelSelectors(scopeRules *storage.SimpleAccessScope_Rules) (clusterSelectors, namespaceSelectors []labels.Selector, err error) {
 	// Convert each selector to labels.Selector.
 	clusterSelectors, err = convertEachSetBasedLabelSelectorToK8sLabelSelector(scopeRules.GetClusterLabelSelectors())
@@ -178,8 +178,9 @@ func convertEachRulesNamespaceToFQSN(namespaces []*storage.SimpleAccessScope_Rul
 
 // newUnvalidatedRequirement is like labels.NewRequirement() but without label
 // key and values validation. Fully qualified scope names:
-//   * contain a separator which must be forbidden in label values;
-//   * might exceed 63 length limit.
+//   - contain a separator which must be forbidden in label values;
+//   - might exceed 63 length limit.
+//
 // The hacks below enable us to create labels.Requirement for FQSN and hence
 // embed the by-name inclusions into the general selector matching approach.
 func newUnvalidatedRequirement(key string, op selection.Operator, values []string) (*labels.Requirement, error) {

--- a/pkg/sac/effectiveaccessscope/effective_access_scope.go
+++ b/pkg/sac/effectiveaccessscope/effective_access_scope.go
@@ -255,8 +255,8 @@ func (root *ScopeTree) populateStateForCluster(cluster *storage.Cluster, cluster
 // included directly.
 //
 // For MINIMAL level of detail, delete from the tree:
-//   * subtrees *with roots* in the Excluded state,
-//   * subtrees *of nodes* in the Included state.
+//   - subtrees *with roots* in the Excluded state,
+//   - subtrees *of nodes* in the Included state.
 func (root *ScopeTree) bubbleUpStatesAndCompactify(detail v1.ComputeEffectiveAccessScopeRequest_Detail) {
 	deleteUnnecessaryNodes := detail == v1.ComputeEffectiveAccessScopeRequest_MINIMAL
 	for clusterName, cluster := range root.Clusters {

--- a/pkg/sac/effectiveaccessscope/effective_access_scope_test.go
+++ b/pkg/sac/effectiveaccessscope/effective_access_scope_test.go
@@ -1114,8 +1114,8 @@ func TestUnrestrictedEffectiveAccessScope(t *testing.T) {
 }
 
 // TestNewUnvalidatedRequirement covers both use cases we currently have:
-//   * label value contains a forbidden token (scope separator);
-//   * label value length exceeds 63 characters.
+//   - label value contains a forbidden token (scope separator);
+//   - label value length exceeds 63 characters.
 func TestNewUnvalidatedRequirement(t *testing.T) {
 	validKey := "stackrox.io/authz.metadata.test.valid.key"
 	operatorIn := selection.In

--- a/pkg/scanners/factory.go
+++ b/pkg/scanners/factory.go
@@ -13,6 +13,7 @@ import (
 )
 
 // Factory provides a centralized location for creating Scanner from v1.ImageIntegrations.
+//
 //go:generate mockgen-wrapper
 type Factory interface {
 	CreateScanner(source *storage.ImageIntegration) (types.ImageScannerWithDataSource, error)

--- a/pkg/scanners/set.go
+++ b/pkg/scanners/set.go
@@ -6,6 +6,7 @@ import (
 )
 
 // Set provides an interface for reading the active set of image integrations.
+//
 //go:generate mockgen-wrapper
 type Set interface {
 	GetAll() []types.ImageScannerWithDataSource

--- a/pkg/search/blevesearch/unsafe_searcher.go
+++ b/pkg/search/blevesearch/unsafe_searcher.go
@@ -8,6 +8,7 @@ import (
 )
 
 // UnsafeSearcher is a searcher that does not take in a context to perform SAC enforcement.
+//
 //go:generate mockgen-wrapper
 type UnsafeSearcher interface {
 	Search(ctx context.Context, q *v1.Query, opts ...SearchOption) ([]search.Result, error)

--- a/pkg/search/options_map.go
+++ b/pkg/search/options_map.go
@@ -18,6 +18,7 @@ func HasApplicableOptions(specifiedFields []string, optionsMap OptionsMap) bool 
 }
 
 // An OptionsMap is a mapping from field labels to search field that permits case-insensitive lookups.
+//
 //go:generate mockgen-wrapper
 type OptionsMap interface {
 	// Get looks for the given string in the OptionsMap. The string is usually user-entered.

--- a/pkg/search/searcher.go
+++ b/pkg/search/searcher.go
@@ -7,6 +7,7 @@ import (
 )
 
 // Searcher allows you to search objects.
+//
 //go:generate mockgen-wrapper
 type Searcher interface {
 	Search(ctx context.Context, q *v1.Query) ([]Result, error)

--- a/pkg/search/sorted/searcher.go
+++ b/pkg/search/sorted/searcher.go
@@ -9,6 +9,7 @@ import (
 )
 
 // Ranker returns the rank for the given id for the given field.
+//
 //go:generate mockgen-wrapper
 type Ranker interface {
 	// GetRankForID returns the rank of the object referenced by the given ID.

--- a/pkg/sensorupgrader/stage.go
+++ b/pkg/sensorupgrader/stage.go
@@ -1,6 +1,7 @@
 package sensorupgrader
 
 // A Stage represents a stage in the sensor upgrader process.
+//
 //go:generate stringer -type=Stage
 type Stage int
 

--- a/pkg/sliceutils/find.go
+++ b/pkg/sliceutils/find.go
@@ -13,9 +13,11 @@ func Find[T comparable](slice []T, elem T) int {
 // FindMatching returns the first index of slice where the passed predicate returns true, or -1 if it doesn't return
 // true for any element.
 // Example usage:
-// FindMatching([]string{"a", "b", "cd"}, func(s string) bool {
-//   return len(s) > 1
-// })
+//
+//	FindMatching([]string{"a", "b", "cd"}, func(s string) bool {
+//	  return len(s) > 1
+//	})
+//
 // will return 2.
 func FindMatching[T any](slice []T, predicate func(T) bool) int {
 	for i, v := range slice {

--- a/pkg/sliceutils/map.go
+++ b/pkg/sliceutils/map.go
@@ -2,9 +2,11 @@ package sliceutils
 
 // Map maps the elements of slice, using the given mapFunc
 // Example usage:
-// Map([]string{"a", "b", "cd"}, func(s string) int {
-//   return len(s)
-// })
+//
+//	Map([]string{"a", "b", "cd"}, func(s string) int {
+//	  return len(s)
+//	})
+//
 // will return []int{1, 1, 2}.
 func Map[T, U any](slice []T, mapFunc func(T) U) []U {
 	result := make([]U, 0, len(slice))

--- a/pkg/sync/mutex_dev.go
+++ b/pkg/sync/mutex_dev.go
@@ -56,6 +56,7 @@ func panicOnTimeout(action string, do func(), timeout time.Duration) {
 
 // panicOnTimeoutMarked allows recording the timestamp (in nanoseconds since unix epoch) as a parameter on the
 // stack. The noinline directive is supposed to prevent the optimizer from removing it.
+//
 //go:noinline
 func panicOnTimeoutMarked(action string, do func(), timeout time.Duration, nowNanos int64) {
 	do()

--- a/qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy
+++ b/qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy
@@ -86,8 +86,8 @@ class AdmissionControllerTest extends BaseSpecification {
 
     def setup() {
         // https://stack-rox.atlassian.net/browse/ROX-7026 - Disable ChaosMonkey
-        // // By default, operate with a chaos monkey that keeps one ready replica alive and deletes with a 10s grace
-        // // period, which should be sufficient for K8s to pick up readiness changes and update endpoints.
+        // By default, operate with a chaos monkey that keeps one ready replica alive and deletes with a 10s grace
+        // period, which should be sufficient for K8s to pick up readiness changes and update endpoints.
         // chaosMonkey = new ChaosMonkey(orchestrator, 1, 10L)
         // chaosMonkey.waitForEffect()
     }

--- a/roxctl/common/auth.go
+++ b/roxctl/common/auth.go
@@ -28,7 +28,7 @@ func checkAuthParameters() error {
 	return nil
 }
 
-//#nosec G101 -- This is a false positive
+// #nosec G101 -- This is a false positive
 const userHelpLiteralToken = `There is no token in file %q. The token file should only contain a single authentication token.
 To provide a token value directly, set the ROX_API_TOKEN environment variable.
 `

--- a/roxctl/common/environment/environment.go
+++ b/roxctl/common/environment/environment.go
@@ -11,6 +11,7 @@ import (
 )
 
 // Environment abstracts the interfaces.RoxctlHTTPClient, IO and grpc.ClientConn used within each command of the CLI.
+//
 //go:generate mockgen-wrapper
 type Environment interface {
 	// HTTPClient returns a interfaces.RoxctlHTTPClient

--- a/roxctl/common/printer/junitprinter_factory.go
+++ b/roxctl/common/printer/junitprinter_factory.go
@@ -60,42 +60,53 @@ func (j *JUnitPrinterFactory) SupportedFormats() []string {
 // GJSON's syntax expression to read more about modifiers.
 // The following example illustrates a JSON compatible structure and an example for the map of JSON Path expressions
 // JSON structure:
-// type data struct {
-//		Policies []policy `json:"policies"`
-//		FailedPolicies []failedPolicy `json:"failedPolicies"`
-// }
-// type policy struct {
-//		name string `json:"name"`
-//		severity string `json:"severity"`
-// }
-// type failedPolicy struct {
-//		name string `json:"name"`
-//		error string `json:"error"`
-// }
+//
+//	type data struct {
+//			Policies []policy `json:"policies"`
+//			FailedPolicies []failedPolicy `json:"failedPolicies"`
+//	}
+//
+//	type policy struct {
+//			name string `json:"name"`
+//			severity string `json:"severity"`
+//	}
+//
+//	type failedPolicy struct {
+//			name string `json:"name"`
+//			error string `json:"error"`
+//	}
+//
 // Data:
-// data := &data{Policies: []policy{
-//								{name: "policy1", severity: "HIGH"},
-//								{name: "policy2", severity: "LOW"},
-//								{name: "policy3", severity: "MEDIUM"}
-//								},
-//				 FailedPolicies: []failedPolicy{
-//								{name: "policy1", error: "error msg1"}},
-//				}
+//
+//	data := &data{Policies: []policy{
+//									{name: "policy1", severity: "HIGH"},
+//									{name: "policy2", severity: "LOW"},
+//									{name: "policy3", severity: "MEDIUM"}
+//									},
+//					 FailedPolicies: []failedPolicy{
+//									{name: "policy1", error: "error msg1"}},
+//					}
+//
 // Map of GJSON expressions:
-//	- specify "#" to visit each element of an array
-//	- the expressions for failed test cases and error messages MUST be equal and correlated
-// expressions := map[string]{
-//					JUnitFailedTestCasesExpressionKey: "data.failedPolicies.#.name",
-//					JUnitFailedTestCaseErrMsgExpressionKey: "data.failedPolicies.#.error",
-//					JUnitTestCasesExpressionKey: "data.policies.#.name",
-//				}
+//
+//   - specify "#" to visit each element of an array
+//
+//   - the expressions for failed test cases and error messages MUST be equal and correlated
+//
+// Example:
+//
+//	expressions := map[string]{
+//	JUnitFailedTestCasesExpressionKey: "data.failedPolicies.#.name",
+//	JUnitFailedTestCaseErrMsgExpressionKey: "data.failedPolicies.#.error",
+//	JUnitTestCasesExpressionKey: "data.policies.#.name",
+//	}
 //
 // This would result in the following test cases and failed test cases:
 // Amount of test cases: 3
 // Testcases:
-//		- Name: policy1, Failed: "error msg1"
-//		- Name: policy2, Successful
-//		- Name: policy3, Successful
+//   - Name: policy1, Failed: "error msg1"
+//   - Name: policy2, Successful
+//   - Name: policy3, Successful
 func (j *JUnitPrinterFactory) CreatePrinter(format string) (ObjectPrinter, error) {
 	if err := j.validate(); err != nil {
 		return nil, err

--- a/roxctl/common/printer/tabularprinter_factory.go
+++ b/roxctl/common/printer/tabularprinter_factory.go
@@ -75,24 +75,29 @@ func (t *TabularPrinterFactory) SupportedFormats() []string {
 // GJSON's syntax expression to read more about modifiers.
 // The following example illustrates a JSON compatible structure and its gjson multi path expression
 // JSON structure:
-// type data struct {
-//		Infos 	[]info `json:"infos"`
-//		Name 	string `json:"name"`
-// }
-// type info struct {
-//		info 	string `json:"info"`
-//		topic 	string `json:"topic"`
-// }
+//
+//	type data struct {
+//			Infos 	[]info `json:"infos"`
+//			Name 	string `json:"name"`
+//	}
+//
+//	type info struct {
+//			info 	string `json:"info"`
+//			topic 	string `json:"topic"`
+//	}
+//
 // Data:
-// data := &data{Name: "example", Infos: []info{
-//										{info: "info1", topic: "topic1"},
-//										{info: "info2", topic: "topic2"},
-//										{info: "info3", topic: "topic3"},
-//										}
+//
+//	data := &data{Name: "example", Infos: []info{
+//											{info: "info1", topic: "topic1"},
+//											{info: "info2", topic: "topic2"},
+//											{info: "info3", topic: "topic3"},
+//											}
+//
 // gjson multi path expression: "{name,infos.#.info,infos.#.topic}"
-// 	- bundle multiple gjson expression surrounded by "{}" to form a multi path expression
-// 	- specify "#" to visit each element in the array
-// 	- each expression in the multi path expression is correlated with the given header(s)!
+//   - bundle multiple gjson expression surrounded by "{}" to form a multi path expression
+//   - specify "#" to visit each element in the array
+//   - each expression in the multi path expression is correlated with the given header(s)!
 //
 // headers := []string{"name", "info", "topic"}
 //

--- a/roxctl/helm/output/output_test.go
+++ b/roxctl/helm/output/output_test.go
@@ -94,47 +94,43 @@ func (suite *helmOutputTestSuite) TestConstruct() {
 
 func (suite *helmOutputTestSuite) TestValidate() {
 	cases := map[string]struct {
-		chartName       string
-		outputDir       string
-		createOutputDir bool
-		removeOutputDir bool
-		errOutRegexp    string
-		shouldFail      bool
-		error           error
-		errorRegexp     string
+		chartName    string
+		outputDir    string
+		createOutDir bool
+		removeOutDir bool
+		errOutRegexp string
+		shouldFail   bool
+		error        error
+		errorRegexp  string
 	}{
 		"should not fail for valid chartName and provided outputDir": {
-			chartName: common.ChartCentralServices,
 			outputDir: "test_output_dir",
 		},
 		"should not fail for valid chartName and non provided outputDir": {
-			chartName: common.ChartCentralServices,
 			errOutRegexp: `WARN:	No output directory specified, using default directory "./stackrox-central-services-chart"`,
 		},
 		"should not fail for valid chartName and existed outputDir": {
-			chartName:       common.ChartCentralServices,
-			createOutputDir: true,
-			removeOutputDir: true,
+			createOutDir: true,
+			removeOutDir: true,
 			errOutRegexp: "WARN:	Removed output directory .*",
 		},
 		"should fail for already existed output directory": {
-			chartName:       common.ChartCentralServices,
-			createOutputDir: true,
-			removeOutputDir: false,
+			error:        errox.AlreadyExists,
+			shouldFail:   true,
+			errorRegexp:  `directory ".*" already exists`,
+			createOutDir: true,
+			removeOutDir: false,
 			errOutRegexp: "ERROR:	Directory .* already exists, use --remove or select a different directory with --output-dir.",
-			shouldFail:  true,
-			error:       errox.AlreadyExists,
-			errorRegexp: `directory ".*" already exists`,
 		},
 	}
 
 	for name, c := range cases {
 		suite.Run(name, func() {
 			helmOutputCmd := suite.helmOutputCommand
-			helmOutputCmd.chartName = c.chartName
-			helmOutputCmd.removeOutputDir = c.removeOutputDir
+			helmOutputCmd.chartName = common.ChartCentralServices
+			helmOutputCmd.removeOutputDir = c.removeOutDir
 			helmOutputCmd.outputDir = c.outputDir
-			if c.createOutputDir {
+			if c.createOutDir {
 				helmOutputCmd.outputDir = suite.T().TempDir()
 			}
 

--- a/sensor/common/admissioncontroller/settings_manager.go
+++ b/sensor/common/admissioncontroller/settings_manager.go
@@ -9,6 +9,7 @@ import (
 
 // SettingsManager allows managing admission control settings. It allows updating policies and cluster configuration
 // independently, and makes the settings available via a ValueStream.
+//
 //go:generate mockgen-wrapper
 type SettingsManager interface {
 	UpdatePolicies(allPolicies []*storage.Policy)

--- a/sensor/common/awscredentials/registry.go
+++ b/sensor/common/awscredentials/registry.go
@@ -37,6 +37,7 @@ type RegistryCredentials struct {
 
 // RegistryCredentialsManager is a sensor component that manages
 // credentials for docker registries.
+//
 //go:generate mockgen-wrapper
 type RegistryCredentialsManager interface {
 	// GetRegistryCredentials returns the most recent registry credential for the given

--- a/sensor/common/detector/detector.go
+++ b/sensor/common/detector/detector.go
@@ -41,6 +41,7 @@ var (
 )
 
 // Detector is the sensor component that syncs policies from Central and runs detection
+//
 //go:generate mockgen-wrapper
 type Detector interface {
 	common.SensorComponent

--- a/sensor/common/store/types.go
+++ b/sensor/common/store/types.go
@@ -8,6 +8,7 @@ import (
 )
 
 // DeploymentStore provides functionality to fetch all deployments from underlying store.
+//
 //go:generate mockgen-wrapper
 type DeploymentStore interface {
 	GetAll() []*storage.Deployment
@@ -18,6 +19,7 @@ type DeploymentStore interface {
 }
 
 // PodStore provides functionality to fetch all pods from underlying store.
+//
 //go:generate mockgen-wrapper
 type PodStore interface {
 	GetAll() []*storage.Pod
@@ -26,6 +28,7 @@ type PodStore interface {
 
 // NetworkPolicyStore provides functionality to find matching Network Policies given a deployment
 // object.
+//
 //go:generate mockgen-wrapper
 type NetworkPolicyStore interface {
 	Size() int
@@ -37,6 +40,7 @@ type NetworkPolicyStore interface {
 }
 
 // ServiceAccountStore provides functionality to find image pull secrets by service account
+//
 //go:generate mockgen-wrapper
 type ServiceAccountStore interface {
 	Add(sa *storage.ServiceAccount)
@@ -45,12 +49,14 @@ type ServiceAccountStore interface {
 }
 
 // ServiceStore provides functionality to find port exposure infos from in-memory services
+//
 //go:generate mockgen-wrapper
 type ServiceStore interface {
 	GetExposureInfos(namespace string, labels map[string]string) []map[service.PortRef][]*storage.PortConfig_ExposureInfo
 }
 
 // RBACStore provides functionality to find permission level from in-memory RBACs
+//
 //go:generate mockgen-wrapper
 type RBACStore interface {
 	GetPermissionLevelForDeployment(deployment rbac.NamespacedServiceAccount) storage.PermissionLevel

--- a/sensor/kubernetes/eventpipeline/component/component.go
+++ b/sensor/kubernetes/eventpipeline/component/component.go
@@ -9,6 +9,7 @@ type PipelineComponent interface {
 }
 
 // Resolver component that performs the dependency resolution
+//
 //go:generate mockgen-wrapper
 type Resolver interface {
 	PipelineComponent
@@ -16,6 +17,7 @@ type Resolver interface {
 }
 
 // OutputQueue component that redirects Resource Events and Alerts to the output channel
+//
 //go:generate mockgen-wrapper
 type OutputQueue interface {
 	PipelineComponent

--- a/sensor/kubernetes/listener/resource_event_handler.go
+++ b/sensor/kubernetes/listener/resource_event_handler.go
@@ -276,7 +276,7 @@ func (k *listenerImpl) handleAllEvents() {
 }
 
 // Helper function that creates and adds a handler to an informer.
-//////////////////////////////////////////////////////////////////
+// ////////////////////////////////////////////////////////////////
 func handle(
 	informer cache.SharedIndexInformer,
 	dispatcher resources.Dispatcher,

--- a/sensor/kubernetes/listener/resource_event_handler_impl_test.go
+++ b/sensor/kubernetes/listener/resource_event_handler_impl_test.go
@@ -86,7 +86,7 @@ func (suite *ResourceEventHandlerImplTestSuite) newHandlerImpl() *resourceEventH
 	}
 }
 
-//// Test that when a message is handled by an unsynced resourceEventHandlerImpl it's ID is added to the seedIDs set
+// Test that when a message is handled by an unsynced resourceEventHandlerImpl it's ID is added to the seedIDs set
 func (suite *ResourceEventHandlerImplTestSuite) TestIDsAddedToSyncSet() {
 	handler := suite.newHandlerImpl()
 

--- a/sensor/kubernetes/listener/resources/deployments.go
+++ b/sensor/kubernetes/listener/resources/deployments.go
@@ -236,7 +236,6 @@ func (d *deploymentHandler) processWithType(obj, oldObj interface{}, action cent
 // The method doesn't process REMOVE_RESOURCE actions. Notice that this means
 // integrations are only recreated if the deployment exists, so it can be
 // permanently deleted in Central.
-//
 func (d *deploymentHandler) appendIntegrationsOnCredentials(
 	action central.ResourceAction,
 	containers []*storage.Container,

--- a/sensor/kubernetes/listener/resources/dispatcher.go
+++ b/sensor/kubernetes/listener/resources/dispatcher.go
@@ -26,6 +26,7 @@ import (
 
 // Dispatcher is responsible for processing resource events, and returning the sensor events that should be emitted
 // in response.
+//
 //go:generate mockgen-wrapper
 type Dispatcher interface {
 	ProcessEvent(obj, oldObj interface{}, action central.ResourceAction) *component.ResourceEvent

--- a/sensor/kubernetes/localscanner/service_certificates_repository_test.go
+++ b/sensor/kubernetes/localscanner/service_certificates_repository_test.go
@@ -269,13 +269,13 @@ type certSecretsRepoFixture struct {
 }
 
 // newFixture creates a certSecretsRepoFixture that contains:
-// - A secrets client corresponding to a fake k8s client set such that:
+// 1. A secrets client corresponding to a fake k8s client set such that:
 //   - It is initialized to represent a cluster with sensorDeployment and a secret that contains certificates
 //     on its data, or partial data according to spec.
 //   - The client set will fail all operations on the HTTP verb indicated in spec.
-// - The certificates used to initialize the data of the aforementioned secret.
-// - A repository that uses that secrets client, sensorDeployment as owner, and with a single serviceCertSecretSpec
-//   for the aforementioned secret in its secrets.
+//   - The certificates used to initialize the data of the aforementioned secret.
+//   - A repository that uses that secrets client, sensorDeployment as owner, and with a single serviceCertSecretSpec
+//     for the aforementioned secret in its secrets.
 func (s *serviceCertificatesRepoSecretsImplSuite) newFixture(config certSecretsRepoFixtureConfig) *certSecretsRepoFixture {
 	certificates := certificates.Clone()
 	ownerRef := sensorOwnerReference()

--- a/sensor/upgrader/common/bundle_resources.go
+++ b/sensor/upgrader/common/bundle_resources.go
@@ -8,7 +8,9 @@ import (
 // bundle. They should be ordered according to the preferred creation order. If there are multiple versions of the
 // same resource kind, they should be in ascending order.
 // IMPORTANT: Any resource type that is part of a sensor bundle deployment (either in a YAML or indirectly via a
-//            `kubectl` command invocation) must be listed here, otherwise the auto-upgrade will fail.
+//
+//	`kubectl` command invocation) must be listed here, otherwise the auto-upgrade will fail.
+//
 // NEVER REMOVE ELEMENTS FROM THIS LIST, OTHERWISE UPGRADES MIGHT FAIL IN UNEXPECTED WAYS. The upgrader logic
 // automatically detects the resources supported by the server, having GroupVersionKinds that are no longer supported
 // hence does not hurt.

--- a/sensor/upgrader/common/bundle_resources_completeness_test.go
+++ b/sensor/upgrader/common/bundle_resources_completeness_test.go
@@ -28,13 +28,13 @@ var (
 // If you see this test failing, the right course of action is most likely to extend the OrderedBundleResourceTypes
 // list. However, if you are convinced that one of the reported GVKs is a false positive, you have the following
 // options:
-// - If the GVK in question can never appear in YAML bundle mode, use meta-templating ([< if not .KubectlOutput >])
-//   blocks to exclude the resources from the chart.
-// - If the GVK is reported due to the approximative nature of the GVK from chart extractor, often small reformatting
-//   of the chart can be helpful. It's often sufficient to include an extra "---" document separator before the
-//   start of the object definition.
-// - If the false positive cannot be suppressed using the above methods, you can add it to the above
-//   ExcludedFromCompletenessTest list to explicitly suppress it in this test.
+//   - If the GVK in question can never appear in YAML bundle mode, use meta-templating ([< if not .KubectlOutput >])
+//     blocks to exclude the resources from the chart.
+//   - If the GVK is reported due to the approximative nature of the GVK from chart extractor, often small reformatting
+//     of the chart can be helpful. It's often sufficient to include an extra "---" document separator before the
+//     start of the object definition.
+//   - If the false positive cannot be suppressed using the above methods, you can add it to the above
+//     ExcludedFromCompletenessTest list to explicitly suppress it in this test.
 func TestBundleResourcesComplete(t *testing.T) {
 	featureFlags := make(map[string]interface{})
 	for _, ff := range features.Flags {

--- a/sensor/upgrader/resources/purpose.go
+++ b/sensor/upgrader/resources/purpose.go
@@ -1,6 +1,7 @@
 package resources
 
 // Purpose declares the purpose of a resource (bundle or state).
+//
 //go:generate stringer -type=Purpose
 type Purpose int32
 

--- a/tools/roxvet/analyzers/storeinterface/analyzer.go
+++ b/tools/roxvet/analyzers/storeinterface/analyzer.go
@@ -104,8 +104,10 @@ func qualifierAndIdentifierFromExpr(expr ast.Expr) (qualifier, identifier string
 
 // If the interface is returning any values that are imported from the set of passed packageNames, this function returns it.
 // Example, if we have a store:
-// type Store interface {
-//    A() (*v1.Deployment)
+//
+//	type Store interface {
+//	   A() (*v1.Deployment)
+//
 // and packageNames contains `v1`,
 // we would return v1.Deployment since it is from the list of forbidden package names.
 func returnValuesFromForbiddenPackage(forbiddenPackageNames set.StringSet, interfaceType *ast.InterfaceType) string {


### PR DESCRIPTION
## Description

This PR cherrypicks e8acc2dcfd351aad8a4b1797723e31dd4c643011

- #4648

```bash
stackrox git:(release-3.74) ✗ git cherry-pick e8acc2dcfd351aad8a4b1797723e31dd4c643011
Auto-merging central/processindicator/datastore/datastore.go
Auto-merging operator/apis/platform/v1alpha1/central_types.go
Auto-merging pkg/metrics/operations.go
Auto-merging pkg/renderer/kubernetes.go
Auto-merging qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy
Auto-merging sensor/kubernetes/listener/resource_event_handler.go
Auto-merging sensor/kubernetes/listener/resources/deployments.go
[release-3.74 f8907401ad] Format Go code for 1.19 (#4648)
 Date: Mon Feb 6 18:35:15 2023 +0100
 251 files changed, 623 insertions(+), 328 deletions(-)
```

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

CI