### PR TITLE
Delete occurrences of Tailwind font-condensed and part 2 for uppercase

### DIFF
--- a/ui/apps/platform/cypress/constants/NetworkPage.js
+++ b/ui/apps/platform/cypress/constants/NetworkPage.js
@@ -42,10 +42,10 @@ export const selectors = {
         applyNetworkPolicies: 'button:contains("Apply Network Policies")',
         apply: 'div[aria-modal="true"] button:contains("Apply")',
         // Select buttons by data-testid attribute and contains text, because "allowed" and "all" are ambiguous:
-        activeFilter: 'button[data-testid="network-connections-filter-active"]:contains("active")',
+        activeFilter: 'button[data-testid="network-connections-filter-active"]:contains("Active")',
         allowedFilter:
-            'button[data-testid="network-connections-filter-allowed"]:contains("allowed")',
-        allFilter: 'button[data-testid="network-connections-filter-all"]:contains("all")',
+            'button[data-testid="network-connections-filter-allowed"]:contains("Allowed")',
+        allFilter: 'button[data-testid="network-connections-filter-all"]:contains("All")',
         hideNsEdgesFilter: '[data-testid="namespace-flows-filter"] button:contains("Hide")',
         stopSimulation: '.simulator-mode button:contains("Stop")',
         confirmationButton: 'button:contains("Yes")',

--- a/ui/apps/platform/src/Components/DashboardMenu/DashboardMenu.js
+++ b/ui/apps/platform/src/Components/DashboardMenu/DashboardMenu.js
@@ -6,7 +6,7 @@ import Menu from 'Components/Menu';
 const DashboardMenu = ({ text, options }) => {
     return (
         <Menu
-            buttonClass="bg-base-100 hover:bg-base-200 border border-base-400 btn-class text-sm flex font-condensed h-full text-base-600"
+            buttonClass="bg-base-100 hover:bg-base-200 border border-base-400 btn-class flex h-full text-base-600"
             buttonText={text}
             options={options}
             className="h-full min-w-32"

--- a/ui/apps/platform/src/Components/Menu.tsx
+++ b/ui/apps/platform/src/Components/Menu.tsx
@@ -107,9 +107,7 @@ const Menu = ({
         return Object.keys(formattedOptions).map((group) => {
             return options ? (
                 <React.Fragment key={group}>
-                    <div className="uppercase font-condensed p-3 border-b border-primary-300 text-lg">
-                        {group}
-                    </div>
+                    <div className="p-3 border-b border-primary-300">{group}</div>
                     <div className="px-2">{renderOptions(options[group])}</div>
                 </React.Fragment>
             ) : (

--- a/ui/apps/platform/src/Components/RadioButtonGroup/RadioButtonGroup.tsx
+++ b/ui/apps/platform/src/Components/RadioButtonGroup/RadioButtonGroup.tsx
@@ -40,13 +40,9 @@ const RadioButtonGroup = ({
             <button
                 key={text}
                 type="button"
-                className={`flex flex-1 justify-center items-center px-2 text-sm font-600 font-condensed text-base-600 hover:text-primary-600 uppercase ${
+                className={`flex flex-1 justify-center items-center px-2 text-base-600 ${
                     index !== 0 ? 'border-l border-base-400' : ''
-                } ${
-                    selected === modifiedValue
-                        ? 'bg-primary-200 text-primary-700 hover:text-primary-700 hover:bg-primary-200'
-                        : 'hover:bg-base-200 bg-base-100'
-                }`}
+                } ${selected === modifiedValue ? 'bg-primary-200 font-700' : ''}`}
                 onClick={onClickHandler}
                 value={modifiedValue}
                 disabled={disabled}
@@ -57,16 +53,12 @@ const RadioButtonGroup = ({
     });
     return (
         <div
-            className={`text-xs flex flex-col uppercase rounded border-2 border-base-400 text-center font-condensed text-base-600 font-600 ${
+            className={`text-sm flex flex-col rounded border-2 border-base-400 text-center bg-base-100 text-base-600 ${
                 groupClassName || ''
             }`}
             data-testid={testId}
         >
-            {headerText && (
-                <div className="bg-base-100 border-b-2 border-base-400 px-2 text-base-500">
-                    {headerText}
-                </div>
-            )}
+            {headerText && <div className="border-b-2 border-base-400 px-2">{headerText}</div>}
             <div className="flex h-full">{content}</div>
         </div>
     );

--- a/ui/apps/platform/src/Components/TileContent/TileContent.tsx
+++ b/ui/apps/platform/src/Components/TileContent/TileContent.tsx
@@ -25,7 +25,7 @@ const TileContent = ({
 }: TileContentProps): ReactElement => {
     return (
         <div
-            className={`flex flex-col text-center justify-around font-600 ${textColorClass} ${className}`}
+            className={`flex flex-col text-center justify-around ${textColorClass} ${className}`}
             data-testid={dataTestId}
         >
             {superText !== '' && (

--- a/ui/apps/platform/src/Components/visuals/SunburstDetailSection.js
+++ b/ui/apps/platform/src/Components/visuals/SunburstDetailSection.js
@@ -131,8 +131,8 @@ class SunburstDetailSection extends Component {
     getLockHint = () => {
         const { clicked } = this.props;
         return (
-            <div className="border-t border-base-300 border-dashed flex justify-end px-2 h-7 text-base-500 text-sm">
-                <div className="flex items-center font-condensed opacity-75">
+            <div className="border-t border-base-300 border-dashed flex justify-end px-2 h-7 text-sm">
+                <div className="flex items-center">
                     <Icon.Info size="16" className="pr-1" />
                     {`click to ${clicked ? 'un' : ''}lock selection`}
                 </div>

--- a/ui/apps/platform/src/Components/workflow/EntitiesMenu/EntitiesMenu.js
+++ b/ui/apps/platform/src/Components/workflow/EntitiesMenu/EntitiesMenu.js
@@ -26,7 +26,7 @@ const EntitiesMenu = ({ text, options, grouped }) => {
     }
 
     const buttonClass =
-        'bg-base-100 hover:bg-primary-200 border-base-400 font-weight-600 uppercase font-condensed flex h-full text-base-600 pl-2 border-l border-dashed text-sm';
+        'bg-base-100 hover:bg-primary-200 border-base-400 flex h-full text-base-600 pl-2 border-l border-dashed';
 
     let formattedOptions = [];
     if (!grouped) {

--- a/ui/apps/platform/src/Containers/Network/Graph/Overlays/Filters.tsx
+++ b/ui/apps/platform/src/Containers/Network/Graph/Overlays/Filters.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement } from 'react';
 import { connect } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
+import upperFirst from 'lodash/upperFirst';
 
 import { selectors } from 'reducers';
 import { actions as graphActions } from 'reducers/network/graph';
@@ -8,9 +9,8 @@ import { filterModes, filterLabels } from 'constants/networkFilterModes';
 import NamespaceEdgeFilter, { NamespaceEdgeFilterState } from './NamespaceEdgeFilter';
 
 const baseButtonClassName =
-    'flex-shrink-0 px-2 py-px border-2 rounded-sm uppercase text-xs font-700';
-const buttonClassName = `${baseButtonClassName} border-base-400 hover:bg-primary-200 text-base-600`;
-const activeButtonClassName = `${baseButtonClassName} bg-primary-300 border-primary-400 hover:bg-primary-200 text-primary-700 border-l-2 border-r-2`;
+    'flex-shrink-0 px-2 py-px border-2 border-base-400 rounded-sm text-base-600';
+const activeButtonClassName = `${baseButtonClassName} bg-primary-200 font-700 border-l-2 border-r-2`;
 
 type FiltersProps = {
     setFilterMode: (mode) => void;
@@ -39,8 +39,8 @@ function Filters({
                 sidePanelOpen ? 'flex-col' : ''
             } ml-2 absolute z-1`}
         >
-            <div className="p-2 bg-primary-100 flex items-center text-sm border-base-400 border-2">
-                <span className="text-base-500 font-700 mr-2">Flows:</span>
+            <div className="p-2 bg-base-100 text-base-600 flex items-center text-sm border-base-400 border-2">
+                <span className="mr-2">Flows:</span>
                 <div className="flex items-center">
                     <button
                         type="button"
@@ -48,13 +48,13 @@ function Filters({
                         className={`${
                             filterMode === filterModes.active
                                 ? activeButtonClassName
-                                : buttonClassName
+                                : baseButtonClassName
                         }
                 ${filterMode === filterModes.allowed ? 'border-r-0' : ''}`}
                         onClick={handleChange(filterModes.active)}
                         data-testid="network-connections-filter-active"
                     >
-                        {`${filterLabels[filterModes.active] as string}`}
+                        {upperFirst(filterLabels[filterModes.active])}
                     </button>
                     <button
                         type="button"
@@ -62,29 +62,31 @@ function Filters({
                         className={`${
                             filterMode === filterModes.allowed
                                 ? activeButtonClassName
-                                : `${buttonClassName} border-l-0 border-r-0`
+                                : `${baseButtonClassName} border-l-0 border-r-0`
                         }`}
                         onClick={handleChange(filterModes.allowed)}
                         data-testid="network-connections-filter-allowed"
                     >
-                        {`${filterLabels[filterModes.allowed] as string}`}
+                        {upperFirst(filterLabels[filterModes.allowed])}
                     </button>
                     <button
                         type="button"
                         value={filterMode}
                         className={`${
-                            filterMode === filterModes.all ? activeButtonClassName : buttonClassName
+                            filterMode === filterModes.all
+                                ? activeButtonClassName
+                                : baseButtonClassName
                         }
                 ${filterMode === filterModes.allowed ? 'border-l-0' : ''}`}
                         onClick={handleChange(filterModes.all)}
                         data-testid="network-connections-filter-all"
                     >
-                        {`${filterLabels[filterModes.all] as string}`}
+                        {upperFirst(filterLabels[filterModes.all])}
                     </button>
                 </div>
             </div>
             <div
-                className={`px-2 py-1 bg-primary-100 flex items-center text-sm border-base-400 border-2 ${
+                className={`px-2 py-1 bg-base-100 flex items-center border-base-400 border-2 ${
                     sidePanelOpen ? 'mt-1' : 'ml-1'
                 }`}
             >

--- a/ui/apps/platform/src/Containers/Network/Graph/Overlays/NamespaceEdgeFilter.tsx
+++ b/ui/apps/platform/src/Containers/Network/Graph/Overlays/NamespaceEdgeFilter.tsx
@@ -23,7 +23,7 @@ function NamespaceEdgeFilter({ selectedState, setFilter }: NamespaceEdgeFilterPr
 
     return (
         <div className="flex items-center" data-testid="namespace-flows-filter">
-            <span className="text-base-500 font-700 mr-2">Namespace flows:</span>
+            <span className="text-sm mr-2">Namespace flows:</span>
             <div className="flex items-center">
                 <RadioButtonGroup
                     buttons={buttons}

--- a/ui/apps/platform/src/app.tw.css
+++ b/ui/apps/platform/src/app.tw.css
@@ -365,7 +365,7 @@ h6 {
 }
 
 .btn-class {
-    @apply inline-flex px-2 rounded-sm font-600 uppercase text-center items-center min-w-16 justify-center border-2 !important;
+    @apply inline-flex px-2 rounded-sm text-center items-center min-w-16 justify-center border-2 !important;
     line-height: 14px; /* required because we were relying on the Chrome browser default of 14px earlier */
 }
 

--- a/ui/apps/platform/src/css/trumps.css
+++ b/ui/apps/platform/src/css/trumps.css
@@ -10,6 +10,10 @@
   color: var(--base-600);
 }
 
+#main-page-container > div > :not(.pf-c-page__main-section) button {
+    font-weight: inherit; /* override font-weight: 600 in ui-components.css file */
+}
+
 /* Universal selector increases specificity of these override style rules */
 
 * .theme-dark {

--- a/ui/apps/platform/src/index.tsx
+++ b/ui/apps/platform/src/index.tsx
@@ -10,7 +10,6 @@ import { AnyAction, Store } from 'redux';
 import { ConnectedRouter } from 'connected-react-router';
 import { createBrowserHistory as createHistory } from 'history';
 import { ApolloProvider } from '@apollo/client';
-import 'typeface-open-sans-condensed';
 import 'react-toastify/dist/ReactToastify.css';
 import 'app.tw.css'; // this file is the main Tailwind entrypoint handled by react-scripts
 import '@patternfly/react-core/dist/styles/base.css';


### PR DESCRIPTION
## Description

Follow up #6053

Thanks to Dave for suggesting:

> Is there a reason we need to keep Open Sans Condensed for the buttons instead of moving to a Red Hat font variant? Or is that something we want to change as a follow up?

### Problems

1. Small font size `text-sm` or even `text-xs` for buttons is not needed if the text does have `uppercase` style.
2. Heavier font weight `font-600` for buttons and sometimes lighter color `text-base-500` is not needed ditto.
3. Rarely used `font-condensed` is not needed ditto.
4. Insufficient color contrast for primary color and background-color is solved by normal text color and bold font weight `font-700` with `bg-primary-200` for classic RadioButtonGroup that is similar to PatternFly toggle.

### Analysis

Find in Files `font-condensed` 6 results in 5 files

1. src/Components/Menu.js

2. src/Components/DashboardMenu.js

    * Configuration Management
    * Vulnerability Management

3. ui/apps/platform/src/Components/RadioButtonGroup

    * Network Graph 1.0
    * Vulnerability Management

4. src/Components/visuals/SunburstDetailSection.js

    * Compliance
    * Configuration Management
    * Vulnerability Management

5. src/Components/workflow/EntitiesMenu/EntitiesMenu.js

    * Configuration Management
    * Vulnerability Management

### Solution

1. Invest `font-700` bold versus `font-400` normal weight contrast:
    * page `h1`
    * table count entity heading
    * table column head
    * widget heading
    * key of key-value pairs
    * selected item in RadioButtonGroup

Untangle cause and effect relationships between styles:

1. Edit app.tw.css
    * Delete `font-600 uppercase` from `.btn-class` style rules.

2. Edit trumps.css
    * Add override `font-weight: inherit` because `font-weight: 600` in ui-components.css file.

3. Edit TileContent
    * Delete `font-600` for compatibility with button styles.

### Residue

Possible follow up according to 80/20 principle for some of the following:

| class        | results | files |
| :---         |    ---: |  ---: |
| `capitalize` |      63 |    27 |
| `font-600`   |      57 |    35 |
| `uppercase`  |      33 |    24 |

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed

1. `yarn lint` in ui

2. `yarn build` in ui

    * `wc build/static/css/*.css` in ui
        branch - master: -1117 = 5978536 - 5979653

    * `wc build/static/js/*.js` in ui
        branch - master: -730 = 11846692 - 11847422

    * `wc build/static/media/*.ttf` in ui
        branch - master: 0 = 64596 - 64596

    * `wc build/static/media/*.woff` in ui
        branch - master: -55760 = 1159052 - 1214812

    * `wc build/static/media/*.woff2` in ui
        branch - master: -44540 = 1275745 - 1320285

3. `yarn start` in ui

### Manual testing

1. Visit /main/network: sentence case at upper left for Active, Allowed, All, Show, Hide

    * dark theme
        ![network_dark](https://github.com/stackrox/stackrox/assets/11862657/40edade0-5d8d-4c3c-bad1-7358be3823eb)

    * light theme
        ![network_light](https://github.com/stackrox/stackrox/assets/11862657/4951afd2-d96b-4f17-8e4b-2269ffc73358)

2. Visit /main/compliance: see residue of SCAN ENVIRONMENT button and bold links in widgets

    * dark theme
        ![compliance_dark](https://github.com/stackrox/stackrox/assets/11862657/316582bd-1956-4215-ac68-1d1677df4ed1)

    * light theme
        ![compliance_light](https://github.com/stackrox/stackrox/assets/11862657/868c8c85-996c-447c-bccf-4d1aeb594000)

3. Visit /main/vulnerability-management: see residue react-select style rule has `text-transform: uppercase` for 2 widget titles.

    * dark theme
        ![vulnerability-management_dashboard_dark](https://github.com/stackrox/stackrox/assets/11862657/ab92a898-785f-4c71-a80a-7002e7b1cda7)

    * light theme
        ![vulnerability-management_dashboard_light](https://github.com/stackrox/stackrox/assets/11862657/47007321-1296-4aaa-80be-3a49be6e2ee9)

4. Visit /main/vulnerability-management/image-cves: see `pluralize` Image CVES from Image CVE.

    * dark theme
        ![vulnerability-management_image-cves_dark](https://github.com/stackrox/stackrox/assets/11862657/f621d93f-043b-4756-9bb7-b3e58fc41eab)

    * light theme
        ![vulnerability-management_image-cves_light](https://github.com/stackrox/stackrox/assets/11862657/bff1a0bc-1295-4f70-8da4-7ef8c4f3ba74)

5. Click a row to open side panel: see residue uppercase text of related entity types.

    * dark theme
        ![vulnerability-management_side_dark](https://github.com/stackrox/stackrox/assets/11862657/4b0fb649-3dfc-4e69-a9c4-d26c9abc7346)

    * light theme
        ![vulnerability-management_side_light](https://github.com/stackrox/stackrox/assets/11862657/e17c23bc-7ab3-4662-bab8-8832bc29c7fa)

6. Click link to single page: see absence of CVE identifier at upper left and also uppercase for tabs.

    * dark theme
        ![vulnerability-management_single_dark](https://github.com/stackrox/stackrox/assets/11862657/643354d2-cc11-460d-9c87-6687fe1a3520)

    * light theme
        ![vulnerability-management_single_light](https://github.com/stackrox/stackrox/assets/11862657/31158fef-bb7b-440f-94b6-580ad10674ae)

7. Visit /main/configmanagement: see lowercase entity types and capitalize class in menu items.

    * dark theme
        ![configmanagement_dark](https://github.com/stackrox/stackrox/assets/11862657/629e9876-de8b-49b5-a798-81a20e9f6270)

    * light theme
        ![configmanagement_light](https://github.com/stackrox/stackrox/assets/11862657/3d2264e1-0a73-4ea6-ba55-7dfe30d168aa)

### Integration testing

In ui/apps/platform folder:

1. `export CYPRESS_ROX_POSTGRES_DATASTORE=true`

2. `yarn cypress-open`

    * networkGraph/connections.test.js
    * networkGraph/network.test.js
    * compliance/complianceDashboard.test.js
    * compliance/complianceList.test.js
    * configmanagement/ciscontrols.test.js
    * configmanagement/clusters.test.js
    * configmanagement/dashboard.test.js
    * configmanagement/deployments.test.js
    * confirmanagement/images.test.js
    * configmanagement/namespaces.test.js
    * configmanagement/nodes.test.js
    * configmanagement/policies.test.js
    * configmanagement/roles.test.js
    * configmanagement/secrets.test.js
    * configmanagement/serviceaccount.test.js
    * configmanagement/usersandgroups
    * vulnmanagement/clusterCves.test.js
    * vulnmanagement/clusters.test.js
    * vulnmanagement/dashboard.test.js
    * vulnmanagement/dashboardToEntityPage.test.js
    * vulnmanagement/deployments.test.js
    * vulnmanagement/entitypages.test.js
    * vulnmanagement/imageComponents.test.js
    * vulnmanagement/imageCves.test.js
    * vulnmanagement/images.test.js
    * vulnmanagement/namespaces.test.js
    * vulnmanagement/nodeComponents.test.js
    * vulnmanagement/nodeCves.test.js
    * vulnmanagement/nodes.test.js
    * vulnmanagement/policies.test.js
