### PR TITLE
CI: Allow quoted newlines in results

### DIFF
--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -1245,7 +1245,10 @@ store_test_results() {
             -orchestrator "${ORCHESTRATOR_FLAVOR:-PROW}" \
             -threshold 5 \
             -csv-output "${csv_output}"
-        bq load --skip_leading_rows=1 ci_metrics.stackrox_tests "${csv_output}"
+        bq load \
+            --skip_leading_rows=1 \
+            --allow_quoted_newlines \
+            ci_metrics.stackrox_tests "${csv_output}"
     } || true
     fi
     set -u


### PR DESCRIPTION
## Description

Per title. There is CSV data with a column like:
```
"Verify k8s exec detection into [k8seventnginx2, k8seventprivnginx2] with addl groups [field_name: ""Privileged Container""
values {
  value: ""true""
}
]"
```

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

Ran a manual load of previously failed data.