### PR TITLE
[ROX-17254] Workaround for vulnerability management 2.0 due to the fanned BFS search issue 

### DIFF
--- a/central/graphql/resolvers/image_cve_core.go
+++ b/central/graphql/resolvers/image_cve_core.go
@@ -162,10 +162,10 @@ func (resolver *imageCVECoreResolver) Deployments(ctx context.Context, args stru
 		return nil, nil
 	}
 
-	// The IDs are already paginated, so skip the pagination portion.
 	depQ := search.NewQueryBuilder().AddExactMatches(search.DeploymentID, deploymentIDs...).Query()
 	return resolver.root.Deployments(ctx, PaginatedQuery{
-		Query: pointers.String(depQ),
+		Query:      pointers.String(depQ),
+		Pagination: args.Pagination,
 	})
 }
 
@@ -209,10 +209,10 @@ func (resolver *imageCVECoreResolver) Images(ctx context.Context, args struct{ P
 		return nil, nil
 	}
 
-	// The IDs are already paginated, so skip the pagination portion.
 	imageQ := search.NewQueryBuilder().AddExactMatches(search.ImageSHA, imageIDs...).Query()
 	return resolver.root.Images(ctx, PaginatedQuery{
-		Query: pointers.String(imageQ),
+		Query:      pointers.String(imageQ),
+		Pagination: args.Pagination,
 	})
 }
 

--- a/central/graphql/resolvers/image_cve_core.go
+++ b/central/graphql/resolvers/image_cve_core.go
@@ -136,7 +136,7 @@ func (resolver *imageCVECoreResolver) CVE(_ context.Context) string {
 	return resolver.data.GetCVE()
 }
 
-func (resolver *imageCVECoreResolver) Deployments(ctx context.Context, pagination inputtypes.Pagination) ([]*deploymentResolver, error) {
+func (resolver *imageCVECoreResolver) Deployments(ctx context.Context, args struct{ Pagination *inputtypes.Pagination }) ([]*deploymentResolver, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.ImageCVECore, "Deployments")
 
 	if err := readDeployments(ctx); err != nil {
@@ -148,7 +148,9 @@ func (resolver *imageCVECoreResolver) Deployments(ctx context.Context, paginatio
 	if resolver.subFieldQuery != nil {
 		query = search.ConjunctionQuery(query, resolver.subFieldQuery)
 	}
-	paginated.FillPagination(query, pagination.AsV1Pagination(), maxDeployments)
+	if args.Pagination != nil {
+		paginated.FillPagination(query, args.Pagination.AsV1Pagination(), maxDeployments)
+	}
 
 	// ROX-17254: Because of the incompatibility between
 	// the data model and search framework, run the query through on CVE datastore through SQF.
@@ -181,7 +183,7 @@ func (resolver *imageCVECoreResolver) FirstDiscoveredInSystem(_ context.Context)
 	}
 }
 
-func (resolver *imageCVECoreResolver) Images(ctx context.Context, pagination inputtypes.Pagination) ([]*imageResolver, error) {
+func (resolver *imageCVECoreResolver) Images(ctx context.Context, args struct{ Pagination *inputtypes.Pagination }) ([]*imageResolver, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.ImageCVECore, "Images")
 
 	if err := readImages(ctx); err != nil {
@@ -193,7 +195,9 @@ func (resolver *imageCVECoreResolver) Images(ctx context.Context, pagination inp
 	if resolver.subFieldQuery != nil {
 		query = search.ConjunctionQuery(query, resolver.subFieldQuery)
 	}
-	paginated.FillPagination(query, pagination.AsV1Pagination(), maxImages)
+	if args.Pagination != nil {
+		paginated.FillPagination(query, args.Pagination.AsV1Pagination(), maxImages)
+	}
 
 	// ROX-17254: Because of the incompatibility between
 	// the data model and search framework, run the query through on CVE datastore through SQF.

--- a/central/views/imagecve/db_response.go
+++ b/central/views/imagecve/db_response.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stackrox/rox/central/views/common"
 )
 
-type imageCVECore struct {
+type imageCVECoreResponse struct {
 	CVE                                string    `db:"cve"`
 	CVEIDs                             []string  `db:"cve_id"`
 	ImagesWithCriticalSeverity         int       `db:"critical_severity_count"`
@@ -18,19 +18,19 @@ type imageCVECore struct {
 	ImagesWithLowSeverity              int       `db:"low_severity_count"`
 	FixableImagesWithLowSeverity       int       `db:"fixable_low_severity_count"`
 	TopCVSS                            float32   `db:"cvss_max"`
-	AffectedImages                     int       `db:"image_sha_count"`
+	AffectedImageCount                 int       `db:"image_sha_count"`
 	FirstDiscoveredInSystem            time.Time `db:"cve_created_time_min"`
 }
 
-func (c *imageCVECore) GetCVE() string {
+func (c *imageCVECoreResponse) GetCVE() string {
 	return c.CVE
 }
 
-func (c *imageCVECore) GetCVEIDs() []string {
+func (c *imageCVECoreResponse) GetCVEIDs() []string {
 	return c.CVEIDs
 }
 
-func (c *imageCVECore) GetImagesBySeverity() common.ResourceCountByCVESeverity {
+func (c *imageCVECoreResponse) GetImagesBySeverity() common.ResourceCountByCVESeverity {
 	return &resourceCountByImageCVESeverity{
 		CriticalSeverityCount:         c.ImagesWithCriticalSeverity,
 		FixableCriticalSeverityCount:  c.FixableImagesWithCriticalSeverity,
@@ -43,15 +43,15 @@ func (c *imageCVECore) GetImagesBySeverity() common.ResourceCountByCVESeverity {
 	}
 }
 
-func (c *imageCVECore) GetTopCVSS() float32 {
+func (c *imageCVECoreResponse) GetTopCVSS() float32 {
 	return c.TopCVSS
 }
 
-func (c *imageCVECore) GetAffectedImages() int {
-	return c.AffectedImages
+func (c *imageCVECoreResponse) GetAffectedImageCount() int {
+	return c.AffectedImageCount
 }
 
-func (c *imageCVECore) GetFirstDiscoveredInSystem() time.Time {
+func (c *imageCVECoreResponse) GetFirstDiscoveredInSystem() time.Time {
 	return c.FirstDiscoveredInSystem
 }
 
@@ -109,4 +109,18 @@ func (r *resourceCountByImageCVESeverity) GetLowSeverityCount() common.ResourceC
 		total:   r.LowSeverityCount,
 		fixable: r.FixableLowSeverityCount,
 	}
+}
+
+type imageResponse struct {
+	ImageID         string    `db:"image_sha"`
+	ImageFullName   string    `db:"image"`
+	OperatingSystem string    `db:"image_os"`
+	ScanTime        time.Time `db:"image_scan_time"`
+}
+
+type deploymentResponse struct {
+	DeploymentID   string `db:"deployment_id"`
+	DeploymentName string `db:"deployment"`
+	Cluster        string `db:"cluster"`
+	Namespace      string `db:"namespace"`
 }

--- a/central/views/imagecve/mocks/types.go
+++ b/central/views/imagecve/mocks/types.go
@@ -39,18 +39,18 @@ func (m *MockCveCore) EXPECT() *MockCveCoreMockRecorder {
 	return m.recorder
 }
 
-// GetAffectedImages mocks base method.
-func (m *MockCveCore) GetAffectedImages() int {
+// GetAffectedImageCount mocks base method.
+func (m *MockCveCore) GetAffectedImageCount() int {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAffectedImages")
+	ret := m.ctrl.Call(m, "GetAffectedImageCount")
 	ret0, _ := ret[0].(int)
 	return ret0
 }
 
-// GetAffectedImages indicates an expected call of GetAffectedImages.
-func (mr *MockCveCoreMockRecorder) GetAffectedImages() *gomock.Call {
+// GetAffectedImageCount indicates an expected call of GetAffectedImageCount.
+func (mr *MockCveCoreMockRecorder) GetAffectedImageCount() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAffectedImages", reflect.TypeOf((*MockCveCore)(nil).GetAffectedImages))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAffectedImageCount", reflect.TypeOf((*MockCveCore)(nil).GetAffectedImageCount))
 }
 
 // GetCVE mocks base method.
@@ -189,4 +189,34 @@ func (m *MockCveView) Get(ctx context.Context, q *v1.Query, options views.ReadOp
 func (mr *MockCveViewMockRecorder) Get(ctx, q, options interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockCveView)(nil).Get), ctx, q, options)
+}
+
+// GetDeploymentIDs mocks base method.
+func (m *MockCveView) GetDeploymentIDs(ctx context.Context, q *v1.Query) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDeploymentIDs", ctx, q)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDeploymentIDs indicates an expected call of GetDeploymentIDs.
+func (mr *MockCveViewMockRecorder) GetDeploymentIDs(ctx, q interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeploymentIDs", reflect.TypeOf((*MockCveView)(nil).GetDeploymentIDs), ctx, q)
+}
+
+// GetImageIDs mocks base method.
+func (m *MockCveView) GetImageIDs(ctx context.Context, q *v1.Query) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetImageIDs", ctx, q)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetImageIDs indicates an expected call of GetImageIDs.
+func (mr *MockCveViewMockRecorder) GetImageIDs(ctx, q interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetImageIDs", reflect.TypeOf((*MockCveView)(nil).GetImageIDs), ctx, q)
 }

--- a/central/views/imagecve/types.go
+++ b/central/views/imagecve/types.go
@@ -17,7 +17,7 @@ type CveCore interface {
 	GetCVEIDs() []string
 	GetImagesBySeverity() common.ResourceCountByCVESeverity
 	GetTopCVSS() float32
-	GetAffectedImages() int
+	GetAffectedImageCount() int
 	GetFirstDiscoveredInSystem() time.Time
 }
 
@@ -31,4 +31,6 @@ type CveView interface {
 	Count(ctx context.Context, q *v1.Query) (int, error)
 	CountBySeverity(ctx context.Context, q *v1.Query) (common.ResourceCountByCVESeverity, error)
 	Get(ctx context.Context, q *v1.Query, options views.ReadOptions) ([]CveCore, error)
+	GetImageIDs(ctx context.Context, q *v1.Query) ([]string, error)
+	GetDeploymentIDs(ctx context.Context, q *v1.Query) ([]string, error)
 }


### PR DESCRIPTION
## Description

I added a workaround specifically for an issue in vulnerability management 2.0 for fixable query search on following pages:
- CVE Single -> Image List and Deployment List
- Image List
- Deployment List

**The actual fix is much more expansive as described in [ROX-17252](https://issues.redhat.com/browse/ROX-17252).**

### Issue
For images having both fixable and non-fixable cves, query `cve:x+fixable:false` returns an image containing `cve:x` and has some non-fixable cves instead of the images where `cve:x` is not fixable.

### Cause

Consider the following image-cve map:
```
 img  |  cve  | fixedby | isfixable 
------+-------+---------+-----------
 sha1 | cve-1 | 1.1     | t
 sha1 | cve-2 | 1.5     | t
 sha2 | cve-1 | 1.1     | t
 sha2 | cve-2 |         | f

```

case 1: For query `Fixable:true`, images `sha1` and `sha2` are expected.
case 2: For query `CVE:cve-1+Fixable:true`, images `sha1` and `sha2` are expected.
case 3: For query `CVE:cve-2+Fixable:true`, image `sha1` is expected.
case 4: For query `CVE:cve-1+Fixable:false`, empty response is expected.
case 5: For query `CVE:cve-2+Fixable:false`, image `sha2` is expected.

case 4 fails. The actual response is `sha2` i.e. an image that has match on `Fixable:false` and a match on `CVE:cve-1`. The happens for two reasons:
1. The join construction uses BFS to find tables for all search clauses.
2. There exists two paths between `image` and `image_cves` tables.

```
   _____________image_cve_edges___________
  |                                       |
images         image_components        image_cves
  |                |       |              |
image_component_edges    image_component_cve_edges

```

Thus, the inner join for case 4 happens to be 
```
from images 
inner join image_component_edges 
   on images.Id = image_component_edges.ImageId 
inner join image_component_cve_edges 
   on image_component_edges.ImageComponentId = image_component_cve_edges.ImageComponentId 
inner join image_cve_edges 
   on images.Id = image_cve_edges.ImageId 
inner join image_cves 
   on image_cve_edges.ImageCveId = image_cves.Id
```

instead of

```
from images 
inner join image_component_edges 
   on images.Id = image_component_edges.ImageId 
inner join image_component_cve_edges 
   on image_component_edges.ImageComponentId = image_component_cve_edges.ImageComponentId 
inner join image_cves 
   on image_component_cve_edges.ImageCveId = image_cves.Id
```

Notice the no link between `image_component_cve_edges` and `image_cves` in the former query.

### Workaround
The workaround is to run the query on image_cves table so that we always get inner join between  `image_component_cve_edges` and `image_cves`.

## Checklist
- [ ] Investigated and inspected CI test results
- [X] Unit test and regression tests added
- ~Evaluated and added CHANGELOG entry if required~
- ~Determined and documented upgrade steps~
- ~Documented user facing changes~

If any of these don't apply, please comment below.

## Testing Performed
Unit + Manual

without this PR (current behavior VM 1.0):

<img width="1889" alt="image" src="https://github.com/stackrox/stackrox/assets/9895898/d8bd81de-3688-4490-9a8c-29b674b5409d">

note non-zero images for not fixable query for CVE which is fixable for that image.
<img width="1889" alt="image" src="https://github.com/stackrox/stackrox/assets/9895898/f19b6519-7885-40fc-b7f4-d0406546518d">


using:
```
imageCVE(cve: $cve, subfieldScopeQuery: $query) {
        images(pagination: $pagination) {
            id
            name {
                fullName
            }
        }
    }
```

<img width="1587" alt="image" src="https://github.com/stackrox/stackrox/assets/9895898/bb0dc06c-2253-461e-b96c-613c7a58b6b6">

<img width="1587" alt="image" src="https://github.com/stackrox/stackrox/assets/9895898/4efc5ef0-cf37-4244-8103-9a7d2b3679c3">

<img width="1587" alt="image" src="https://github.com/stackrox/stackrox/assets/9895898/d9eb8cdb-4d9b-4955-8d01-ebfa421396aa">


Pagination: 

reversed=false
<img width="1587" alt="image" src="https://github.com/stackrox/stackrox/assets/9895898/e89ed569-f98e-41af-b990-b73da6cc3b77">

reversed=true
<img width="1587" alt="image" src="https://github.com/stackrox/stackrox/assets/9895898/fbbea95b-ecc0-45af-9cdc-8a966f9ea047">
