### PR TITLE
Workflow CVEs: Sort fixes

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
@@ -61,7 +61,7 @@ const imageVulnerabilitiesQuery = gql`
     }
 `;
 
-const defaultSortFields = ['CVE'];
+const defaultSortFields = ['CVE', 'CVSS', 'Severity'];
 
 const imageResourceFilters = new Set<Resource>(['CVE']);
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/CVEsTable.tsx
@@ -21,7 +21,13 @@ import SeverityCountLabels from '../components/SeverityCountLabels';
 import { DynamicColumnIcon } from '../components/DynamicIcon';
 import DatePhraseTd from '../components/DatePhraseTd';
 import CvssTd from '../components/CvssTd';
-import { getScoreVersionsForTopCVSS, sortCveDistroList } from '../sortUtils';
+import {
+    getScoreVersionsForTopCVSS,
+    sortCveDistroList,
+    aggregateByCVSS,
+    aggregateByCreatedTime,
+    aggregateByImageSha,
+} from '../sortUtils';
 
 export const cveListQuery = gql`
     query getImageCVEList($query: String, $pagination: Pagination) {
@@ -107,20 +113,20 @@ function CVEsTable({
                         {isFiltered && <DynamicColumnIcon />}
                     </TooltipTh>
                     <TooltipTh
-                        sort={getSortParams('CVSS')}
+                        sort={getSortParams('CVSS', aggregateByCVSS)}
                         tooltip="Highest CVSS score of this CVE across images"
                     >
                         Top CVSS
                     </TooltipTh>
                     <TooltipTh
-                        // sort={getSortParams('Image sha')} TBD
+                        sort={getSortParams('Image sha', aggregateByImageSha)}
                         tooltip="Ratio of total environment affect by this CVE"
                     >
                         Affected images
                         {isFiltered && <DynamicColumnIcon />}
                     </TooltipTh>
                     <TooltipTh
-                        // sort={getSortParams('CVE Created Time')} TBD
+                        sort={getSortParams('CVE Created Time', aggregateByCreatedTime)}
                         tooltip="Time since this CVE first affected an entity"
                     >
                         First discovered

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/CVEsTable.tsx
@@ -99,7 +99,6 @@ function CVEsTable({
     return (
         <TableComposable borders={false} variant="compact">
             <Thead noWrap>
-                {/* TODO: need to double check sorting on columns  */}
                 <Tr>
                     <Th>{/* Header for expanded column */}</Th>
                     <Th sort={getSortParams('CVE')}>CVE</Th>
@@ -107,14 +106,23 @@ function CVEsTable({
                         Images by severity
                         {isFiltered && <DynamicColumnIcon />}
                     </TooltipTh>
-                    <TooltipTh tooltip="Highest CVSS score of this CVE across images">
+                    <TooltipTh
+                        sort={getSortParams('CVSS')}
+                        tooltip="Highest CVSS score of this CVE across images"
+                    >
                         Top CVSS
                     </TooltipTh>
-                    <TooltipTh tooltip="Ratio of total environment affect by this CVE">
+                    <TooltipTh
+                        // sort={getSortParams('Image sha')} TBD
+                        tooltip="Ratio of total environment affect by this CVE"
+                    >
                         Affected images
                         {isFiltered && <DynamicColumnIcon />}
                     </TooltipTh>
-                    <TooltipTh tooltip="Time since this CVE first affected an entity">
+                    <TooltipTh
+                        // sort={getSortParams('CVE Created Time')} TBD
+                        tooltip="Time since this CVE first affected an entity"
+                    >
                         First discovered
                         {isFiltered && <DynamicColumnIcon />}
                     </TooltipTh>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentsTable.tsx
@@ -85,7 +85,7 @@ function DeploymentsTable({
                         Images
                         {isFiltered && <DynamicColumnIcon />}
                     </Th>
-                    <Th>First discovered</Th>
+                    <Th sort={getSortParams('Created')}>First discovered</Th>
                 </Tr>
             </Thead>
             {deployments.length === 0 && <EmptyTableResults colSpan={6} />}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
@@ -77,7 +77,7 @@ function ImageVulnerabilitiesTable({
                 <Tr>
                     <Th>{/* Header for expanded column */}</Th>
                     <Th sort={getSortParams('CVE')}>CVE</Th>
-                    <Th>Severity</Th>
+                    <Th sort={getSortParams('Severity')}>Severity</Th>
                     <Th>
                         CVE Status
                         {isFiltered && <DynamicColumnIcon />}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImagesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImagesTable.tsx
@@ -93,13 +93,13 @@ function ImagesTable({ images, getSortParams, isFiltered, filteredSeverities }: 
                         CVEs by severity
                         {isFiltered && <DynamicColumnIcon />}
                     </TooltipTh>
-                    <Th sort={getSortParams('Operating System')}>Operating system</Th>
-                    <Th sort={getSortParams('Deployment Count')}>
+                    <Th sort={getSortParams('Image OS')}>Operating system</Th>
+                    <Th>
                         Deployments
                         {isFiltered && <DynamicColumnIcon />}
                     </Th>
-                    <Th sort={getSortParams('Age')}>Age</Th>
-                    <Th sort={getSortParams('Scan Time')}>Scan time</Th>
+                    <Th sort={getSortParams('Image created time')}>Age</Th>
+                    <Th sort={getSortParams('Image scan time')}>Scan time</Th>
                 </Tr>
             </Thead>
             {images.length === 0 && <EmptyTableResults colSpan={6} />}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/TooltipTh.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/TooltipTh.tsx
@@ -1,17 +1,18 @@
 import React from 'react';
 import { Tooltip } from '@patternfly/react-core';
-import { Th } from '@patternfly/react-table';
+import { Th, ThProps } from '@patternfly/react-table';
 
 type TooltipThProps = {
     children: string | React.ReactNode;
+    sort?: ThProps['sort'];
     tooltip: string;
 };
 
 // this is to ensure that the tooltip always shows up on hover since
 // the tooltip prop on Th only shows when the header is truncated
-function TooltipTh({ children, tooltip }: TooltipThProps) {
+function TooltipTh({ children, tooltip, sort }: TooltipThProps) {
     return (
-        <Th>
+        <Th sort={sort || undefined}>
             <Tooltip content={tooltip} position="top-start" isContentLeftAligned>
                 <div>{children}</div>
             </Tooltip>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/sortUtils.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/sortUtils.tsx
@@ -1,13 +1,13 @@
 import sortBy from 'lodash/sortBy';
 import { ensureExhaustive } from 'utils/type.utils';
+import { SortAggregate } from 'types/table';
 import { EntityTab } from './types';
 
 export const defaultImageSortFields = [
     'Image',
-    'Operating system',
-    'Deployment count',
-    'Age',
-    'Scan time',
+    'Image OS',
+    'Image created time',
+    'Image scan time',
 ];
 
 export const imagesDefaultSort = {
@@ -17,12 +17,25 @@ export const imagesDefaultSort = {
 
 export const defaultCVESortFields = ['CVE', 'CVSS', 'Image Sha', 'CVE Created Time'];
 
+export const aggregateByCVSS: SortAggregate = {
+    aggregateFunc: 'max',
+};
+
+export const aggregateByImageSha: SortAggregate = {
+    aggregateFunc: 'count',
+    distinct: true,
+};
+
+export const aggregateByCreatedTime: SortAggregate = {
+    aggregateFunc: 'min',
+};
+
 export const CVEsDefaultSort = {
     field: 'CVE',
     direction: 'asc',
 } as const;
 
-export const defaultDeploymentSortFields = ['Deployment', 'Cluster', 'Namespace'];
+export const defaultDeploymentSortFields = ['Deployment', 'Cluster', 'Namespace', 'Created'];
 
 export const deploymentsDefaultSort = {
     field: 'Deployment',

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/sortUtils.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/sortUtils.tsx
@@ -15,7 +15,7 @@ export const imagesDefaultSort = {
     direction: 'desc',
 } as const;
 
-export const defaultCVESortFields = ['Deployment', 'Cluster', 'Namespace'];
+export const defaultCVESortFields = ['CVE', 'CVSS', 'Image Sha', 'CVE Created Time'];
 
 export const CVEsDefaultSort = {
     field: 'CVE',

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/sortUtils.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/sortUtils.tsx
@@ -23,7 +23,7 @@ export const aggregateByCVSS: SortAggregate = {
 
 export const aggregateByImageSha: SortAggregate = {
     aggregateFunc: 'count',
-    distinct: true,
+    distinct: 'true',
 };
 
 export const aggregateByCreatedTime: SortAggregate = {

--- a/ui/apps/platform/src/hooks/useURLSort.ts
+++ b/ui/apps/platform/src/hooks/useURLSort.ts
@@ -47,10 +47,6 @@ function isDirection(val: unknown): val is 'asc' | 'desc' {
     return val === 'asc' || val === 'desc';
 }
 
-function isAggregate(val: unknown): val is SortAggregate {
-    return !!(typeof val === 'object' && val !== null && 'aggregateBy' in val);
-}
-
 function useURLSort({ sortFields, defaultSortOption, onSort }: UseURLSortProps): UseURLSortResult {
     const [sortOption, setSortOption] = useURLParameter('sortOption', defaultSortOption);
 
@@ -65,8 +61,8 @@ function useURLSort({ sortFields, defaultSortOption, onSort }: UseURLSortProps):
             ? sortOption.direction
             : defaultSortOption.direction;
     const activeAggregateBy =
-        isParsedQs(sortOption) && isAggregate(sortOption?.aggregateBy)
-            ? sortOption?.aggregateBy
+        isParsedQs(sortOption) && sortOption?.aggregateBy
+            ? (sortOption?.aggregateBy as SortAggregate)
             : undefined;
 
     const internalSortResultOption = useRef<ApiSortOption>(

--- a/ui/apps/platform/src/hooks/useURLSort.ts
+++ b/ui/apps/platform/src/hooks/useURLSort.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import useURLParameter from 'hooks/useURLParameter';
-import { SortDirection, SortOption, ThProps } from 'types/table';
+import { SortAggregate, SortDirection, SortOption, ThProps } from 'types/table';
 import { ApiSortOption } from 'types/search';
 import { isParsedQs } from 'utils/queryStringUtils';
 
@@ -60,7 +60,7 @@ function useURLSort({ sortFields, defaultSortOption, onSort }: UseURLSortProps):
         setFieldToIndexMap(newFieldToIndexMap);
     }, [sortFields]);
 
-    function getSortParams(field: string): ThProps['sort'] {
+    function getSortParams(field: string, aggregateBy?: SortAggregate): ThProps['sort'] {
         const index = fieldToIndexMap[field];
         const activeSortIndex = activeSortField ? fieldToIndexMap[activeSortField] : undefined;
 
@@ -74,6 +74,7 @@ function useURLSort({ sortFields, defaultSortOption, onSort }: UseURLSortProps):
                 // modify the URL based on the new sort
                 const newSortOption: SortOption = {
                     field,
+                    aggregateBy,
                     direction,
                 };
                 if (onSort) {

--- a/ui/apps/platform/src/hooks/useURLSort.ts
+++ b/ui/apps/platform/src/hooks/useURLSort.ts
@@ -47,6 +47,10 @@ function isDirection(val: unknown): val is 'asc' | 'desc' {
     return val === 'asc' || val === 'desc';
 }
 
+function isAggregate(val: unknown): val is SortAggregate {
+    return !!(typeof val === 'object' && val !== null && 'aggregateBy' in val);
+}
+
 function useURLSort({ sortFields, defaultSortOption, onSort }: UseURLSortProps): UseURLSortResult {
     const [sortOption, setSortOption] = useURLParameter('sortOption', defaultSortOption);
 
@@ -60,9 +64,13 @@ function useURLSort({ sortFields, defaultSortOption, onSort }: UseURLSortProps):
         isParsedQs(sortOption) && isDirection(sortOption?.direction)
             ? sortOption.direction
             : defaultSortOption.direction;
+    const activeAggregateBy =
+        isParsedQs(sortOption) && isAggregate(sortOption?.aggregateBy)
+            ? sortOption?.aggregateBy
+            : undefined;
 
     const internalSortResultOption = useRef<ApiSortOption>(
-        tableSortOption(activeSortField, activeSortDirection, sortOption?.aggregateBy)
+        tableSortOption(activeSortField, activeSortDirection, activeAggregateBy)
     );
 
     // we'll use this to map the sort fields to an index PatternFly can use internally
@@ -111,7 +119,7 @@ function useURLSort({ sortFields, defaultSortOption, onSort }: UseURLSortProps):
         internalSortResultOption.current = tableSortOption(
             activeSortField,
             activeSortDirection,
-            sortOption?.aggregateBy
+            activeAggregateBy
         );
     }
 

--- a/ui/apps/platform/src/types/search.ts
+++ b/ui/apps/platform/src/types/search.ts
@@ -1,4 +1,4 @@
-import { SortAggregate } from './table';
+import { AggregateFunc } from './table';
 
 /*
  * Examples of search filter object properties parsed from search query string:
@@ -22,7 +22,10 @@ export type SearchEntry = {
 
 export type ApiSortOption = {
     field: string;
-    aggregateBy?: SortAggregate;
+    aggregateBy?: {
+        aggregateFunc: AggregateFunc;
+        distinct?: boolean;
+    };
     reversed: boolean;
 };
 

--- a/ui/apps/platform/src/types/search.ts
+++ b/ui/apps/platform/src/types/search.ts
@@ -1,3 +1,5 @@
+import { SortAggregate } from './table';
+
 /*
  * Examples of search filter object properties parsed from search query string:
  * 'Lifecycle Stage': 'BUILD' from 's[Lifecycle Stage]=BUILD
@@ -20,6 +22,7 @@ export type SearchEntry = {
 
 export type ApiSortOption = {
     field: string;
+    aggregateBy?: SortAggregate;
     reversed: boolean;
 };
 

--- a/ui/apps/platform/src/types/table.ts
+++ b/ui/apps/platform/src/types/table.ts
@@ -3,10 +3,11 @@ import { ReactElement } from 'react';
 export type { ThProps } from '@patternfly/react-table';
 
 export type SortDirection = 'asc' | 'desc';
+export type AggregateFunc = 'max' | 'count' | 'min';
 
 export type SortAggregate = {
-    aggregateFunc: 'max' | 'count' | 'min';
-    distict?: boolean;
+    aggregateFunc: AggregateFunc;
+    distinct?: boolean;
 };
 
 export type SortOption = {

--- a/ui/apps/platform/src/types/table.ts
+++ b/ui/apps/platform/src/types/table.ts
@@ -4,8 +4,14 @@ export type { ThProps } from '@patternfly/react-table';
 
 export type SortDirection = 'asc' | 'desc';
 
+export type SortAggregate = {
+    aggregateFunc: 'max' | 'count' | 'min';
+    distict?: boolean;
+};
+
 export type SortOption = {
     field: string;
+    aggregateBy?: SortAggregate;
     direction: SortDirection;
 };
 

--- a/ui/apps/platform/src/types/table.ts
+++ b/ui/apps/platform/src/types/table.ts
@@ -7,7 +7,7 @@ export type AggregateFunc = 'max' | 'count' | 'min';
 
 export type SortAggregate = {
     aggregateFunc: AggregateFunc;
-    distinct?: boolean;
+    distinct?: 'true' | 'false';
 };
 
 export type SortOption = {


### PR DESCRIPTION
As it states, fixes a variety of sort issues in the feature. Unfortunately, it does not look like the PF table supports multisort yet (I was mistaken, must've been thinking of react-table) :(

This PR fixes:
* Overview -> Images: `The 'Age' column does not sort`
* Overview -> Images:  `The `Scan time` column does not sort`
* Overview -> Images:  `Trying to sort by `Operating system`, `Deployments`, or `Scan time` highlights all three columns`
* Overview -> Images: `Top CVSS, Affected images, and First discovered does not sort`
* `When you clear filters then sort the scan time column, this error appears:` cannot reproduce
* Overview -> Images: `Sorting by deployments columns excludes watched images. I believe we had decided to not sort on the deployments column. The API contract document states that.`