### PR TITLE
3.74: fix grouped-static-tests: make proto-generated-srcs

### DIFF
--- a/generated/api/v1/authprovider_service.pb.go
+++ b/generated/api/v1/authprovider_service.pb.go
@@ -440,9 +440,11 @@ func (m *PostAuthProviderRequest) Clone() *PostAuthProviderRequest {
 type UpdateAuthProviderRequest struct {
 	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
 	// Types that are valid to be assigned to NameOpt:
+	//
 	//	*UpdateAuthProviderRequest_Name
 	NameOpt isUpdateAuthProviderRequest_NameOpt `protobuf_oneof:"name_opt"`
 	// Types that are valid to be assigned to EnabledOpt:
+	//
 	//	*UpdateAuthProviderRequest_Enabled
 	EnabledOpt           isUpdateAuthProviderRequest_EnabledOpt `protobuf_oneof:"enabled_opt"`
 	XXX_NoUnkeyedLiteral struct{}                               `json:"-"`

--- a/generated/api/v1/debug_service.pb.go
+++ b/generated/api/v1/debug_service.pb.go
@@ -766,6 +766,7 @@ func (m *AuthorizationTraceResponse_User_Role) Clone() *AuthorizationTraceRespon
 type AuthorizationTraceResponse_Trace struct {
 	ScopeCheckerType string `protobuf:"bytes,1,opt,name=scope_checker_type,json=scopeCheckerType,proto3" json:"scope_checker_type,omitempty"`
 	// Types that are valid to be assigned to Authorizer:
+	//
 	//	*AuthorizationTraceResponse_Trace_BuiltIn
 	Authorizer           isAuthorizationTraceResponse_Trace_Authorizer `protobuf_oneof:"authorizer"`
 	XXX_NoUnkeyedLiteral struct{}                                      `json:"-"`

--- a/generated/internalapi/central/sensor_events.pb.go
+++ b/generated/internalapi/central/sensor_events.pb.go
@@ -1279,6 +1279,7 @@ func (m *ContainerInstanceEnforcement) Clone() *ContainerInstanceEnforcement {
 type ScrapeCommand struct {
 	ScrapeId string `protobuf:"bytes,1,opt,name=scrape_id,json=scrapeId,proto3" json:"scrape_id,omitempty"`
 	// Types that are valid to be assigned to Command:
+	//
 	//	*ScrapeCommand_StartScrape
 	//	*ScrapeCommand_KillScrape
 	Command              isScrapeCommand_Command `protobuf_oneof:"command"`
@@ -1542,6 +1543,7 @@ func (m *KillScrape) Clone() *KillScrape {
 type ScrapeUpdate struct {
 	ScrapeId string `protobuf:"bytes,1,opt,name=scrape_id,json=scrapeId,proto3" json:"scrape_id,omitempty"`
 	// Types that are valid to be assigned to Update:
+	//
 	//	*ScrapeUpdate_ComplianceReturn
 	//	*ScrapeUpdate_ScrapeStarted
 	//	*ScrapeUpdate_ScrapeKilled
@@ -1955,6 +1957,7 @@ func (m *NetworkPoliciesCommand_Apply) Clone() *NetworkPoliciesCommand_Apply {
 
 type NetworkPoliciesCommand_Payload struct {
 	// Types that are valid to be assigned to Cmd:
+	//
 	//	*NetworkPoliciesCommand_Payload_Apply
 	Cmd                  isNetworkPoliciesCommand_Payload_Cmd `protobuf_oneof:"cmd"`
 	XXX_NoUnkeyedLiteral struct{}                             `json:"-"`
@@ -2255,6 +2258,7 @@ func (m *NetworkPoliciesResponse_Error) Clone() *NetworkPoliciesResponse_Error {
 
 type NetworkPoliciesResponse_Payload struct {
 	// Types that are valid to be assigned to Cmd:
+	//
 	//	*NetworkPoliciesResponse_Payload_Error
 	//	*NetworkPoliciesResponse_Payload_Apply
 	Cmd                  isNetworkPoliciesResponse_Payload_Cmd `protobuf_oneof:"cmd"`

--- a/generated/storage/cluster.pb.go
+++ b/generated/storage/cluster.pb.go
@@ -2268,12 +2268,15 @@ type CollectorHealthInfo struct {
 	// This is the version of the collector deamonset as returned by k8s API
 	Version string `protobuf:"bytes,1,opt,name=version,proto3" json:"version,omitempty"`
 	// Types that are valid to be assigned to TotalDesiredPodsOpt:
+	//
 	//	*CollectorHealthInfo_TotalDesiredPods
 	TotalDesiredPodsOpt isCollectorHealthInfo_TotalDesiredPodsOpt `protobuf_oneof:"total_desired_pods_opt"`
 	// Types that are valid to be assigned to TotalReadyPodsOpt:
+	//
 	//	*CollectorHealthInfo_TotalReadyPods
 	TotalReadyPodsOpt isCollectorHealthInfo_TotalReadyPodsOpt `protobuf_oneof:"total_ready_pods_opt"`
 	// Types that are valid to be assigned to TotalRegisteredNodesOpt:
+	//
 	//	*CollectorHealthInfo_TotalRegisteredNodes
 	TotalRegisteredNodesOpt isCollectorHealthInfo_TotalRegisteredNodesOpt `protobuf_oneof:"total_registered_nodes_opt"`
 	// Collection of errors that occurred while trying to obtain collector health info.
@@ -2471,9 +2474,11 @@ func (m *CollectorHealthInfo) Clone() *CollectorHealthInfo {
 // first reports AdmissionControlHealthInfo (sensor).
 type AdmissionControlHealthInfo struct {
 	// Types that are valid to be assigned to TotalDesiredPodsOpt:
+	//
 	//	*AdmissionControlHealthInfo_TotalDesiredPods
 	TotalDesiredPodsOpt isAdmissionControlHealthInfo_TotalDesiredPodsOpt `protobuf_oneof:"total_desired_pods_opt"`
 	// Types that are valid to be assigned to TotalReadyPodsOpt:
+	//
 	//	*AdmissionControlHealthInfo_TotalReadyPods
 	TotalReadyPodsOpt isAdmissionControlHealthInfo_TotalReadyPodsOpt `protobuf_oneof:"total_ready_pods_opt"`
 	// Collection of errors that occurred while trying to obtain admission control health info.
@@ -2631,15 +2636,19 @@ func (m *AdmissionControlHealthInfo) Clone() *AdmissionControlHealthInfo {
 // first reports ScannerHealthInfo (sensor).
 type ScannerHealthInfo struct {
 	// Types that are valid to be assigned to TotalDesiredAnalyzerPodsOpt:
+	//
 	//	*ScannerHealthInfo_TotalDesiredAnalyzerPods
 	TotalDesiredAnalyzerPodsOpt isScannerHealthInfo_TotalDesiredAnalyzerPodsOpt `protobuf_oneof:"total_desired_analyzer_pods_opt"`
 	// Types that are valid to be assigned to TotalReadyAnalyzerPodsOpt:
+	//
 	//	*ScannerHealthInfo_TotalReadyAnalyzerPods
 	TotalReadyAnalyzerPodsOpt isScannerHealthInfo_TotalReadyAnalyzerPodsOpt `protobuf_oneof:"total_ready_analyzer_pods_opt"`
 	// Types that are valid to be assigned to TotalDesiredDbPodsOpt:
+	//
 	//	*ScannerHealthInfo_TotalDesiredDbPods
 	TotalDesiredDbPodsOpt isScannerHealthInfo_TotalDesiredDbPodsOpt `protobuf_oneof:"total_desired_db_pods_opt"`
 	// Types that are valid to be assigned to TotalReadyDbPodsOpt:
+	//
 	//	*ScannerHealthInfo_TotalReadyDbPods
 	TotalReadyDbPodsOpt isScannerHealthInfo_TotalReadyDbPodsOpt `protobuf_oneof:"total_ready_db_pods_opt"`
 	// Collection of errors that occurred while trying to obtain scanner health info.

--- a/generated/storage/group.pb.go
+++ b/generated/storage/group.pb.go
@@ -98,10 +98,11 @@ func (m *Group) Clone() *Group {
 
 // GroupProperties defines the properties of a group. Groups apply to users when
 // their properties match. For instance:
-//   * If GroupProperties has only an auth_provider_id, then that group applies
+//   - If GroupProperties has only an auth_provider_id, then that group applies
 //     to all users logged in with that auth provider.
-//   * If GroupProperties in addition has a claim key, then it applies to all
+//   - If GroupProperties in addition has a claim key, then it applies to all
 //     users with that auth provider and the claim key, etc.
+//
 // Note: Changes to GroupProperties may require changes to v1.DeleteGroupRequest.
 type GroupProperties struct {
 	// Unique identifier for group properties and respectively the group.

--- a/generated/storage/labels.pb.go
+++ b/generated/storage/labels.pb.go
@@ -91,7 +91,8 @@ func (SetBasedLabelSelector_Operator) EnumDescriptor() ([]byte, []int) {
 }
 
 // Label selector components are joined with logical AND, see
-//     https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+//
+//	https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 //
 // Next available tag: 3
 type LabelSelector struct {

--- a/generated/storage/network_policy.pb.go
+++ b/generated/storage/network_policy.pb.go
@@ -572,6 +572,7 @@ func (m *IPBlock) Clone() *IPBlock {
 type NetworkPolicyPort struct {
 	Protocol Protocol `protobuf:"varint,1,opt,name=protocol,proto3,enum=storage.Protocol" json:"protocol,omitempty"`
 	// Types that are valid to be assigned to PortRef:
+	//
 	//	*NetworkPolicyPort_Port
 	//	*NetworkPolicyPort_PortName
 	PortRef              isNetworkPolicyPort_PortRef `protobuf_oneof:"port_ref"`

--- a/generated/storage/node.pb.go
+++ b/generated/storage/node.pb.go
@@ -1124,6 +1124,7 @@ type EmbeddedNodeScanComponent struct {
 	Vulnerabilities []*NodeVulnerability     `protobuf:"bytes,7,rep,name=vulnerabilities,proto3" json:"vulnerabilities,omitempty"`
 	Priority        int64                    `protobuf:"varint,4,opt,name=priority,proto3" json:"priority,omitempty"`
 	// Types that are valid to be assigned to SetTopCvss:
+	//
 	//	*EmbeddedNodeScanComponent_TopCvss
 	SetTopCvss           isEmbeddedNodeScanComponent_SetTopCvss `protobuf_oneof:"set_top_cvss"`
 	RiskScore            float32                                `protobuf:"fixed32,6,opt,name=risk_score,json=riskScore,proto3" json:"risk_score,omitempty"`

--- a/generated/storage/notifier.pb.go
+++ b/generated/storage/notifier.pb.go
@@ -1363,6 +1363,7 @@ type Syslog struct {
 	// Eventually this will support TCP, UDP, and local endpoints
 	//
 	// Types that are valid to be assigned to Endpoint:
+	//
 	//	*Syslog_TcpConfig
 	Endpoint             isSyslog_Endpoint `protobuf_oneof:"endpoint"`
 	ExtraFields          []*KeyValuePair   `protobuf:"bytes,3,rep,name=extra_fields,json=extraFields,proto3" json:"extra_fields,omitempty"`

--- a/generated/storage/rbac.pb.go
+++ b/generated/storage/rbac.pb.go
@@ -97,7 +97,7 @@ func (PermissionLevel) EnumDescriptor() ([]byte, []int) {
 }
 
 // Properties of an individual k8s Role or ClusterRole.
-//////////////////////////////////////////
+// ////////////////////////////////////////
 type K8SRole struct {
 	Id                   string            `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" search:"Role ID,hidden" sql:"pk,type(uuid)"`
 	Name                 string            `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty" search:"Role"`
@@ -250,7 +250,7 @@ func (m *K8SRole) Clone() *K8SRole {
 }
 
 // Properties of an individual rules that grant permissions to resources.
-//////////////////////////////////////////
+// ////////////////////////////////////////
 type PolicyRule struct {
 	Verbs                []string `protobuf:"bytes,1,rep,name=verbs,proto3" json:"verbs,omitempty"`
 	ApiGroups            []string `protobuf:"bytes,2,rep,name=api_groups,json=apiGroups,proto3" json:"api_groups,omitempty"`
@@ -364,7 +364,7 @@ func (m *PolicyRule) Clone() *PolicyRule {
 }
 
 // Properties of an individual k8s RoleBinding or ClusterRoleBinding.
-//////////////////////////////////////////
+// ////////////////////////////////////////
 type K8SRoleBinding struct {
 	Id          string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" search:"Role Binding ID,hidden" sql:"pk,type(uuid)"`
 	Name        string `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty" search:"Role Binding"`
@@ -528,7 +528,7 @@ func (m *K8SRoleBinding) Clone() *K8SRoleBinding {
 }
 
 // Properties of an individual subjects who are granted roles via role bindings.
-//////////////////////////////////////////
+// ////////////////////////////////////////
 type Subject struct {
 	Id                   string      `protobuf:"bytes,4,opt,name=id,proto3" json:"id,omitempty"`
 	Kind                 SubjectKind `protobuf:"varint,1,opt,name=kind,proto3,enum=storage.SubjectKind" json:"kind,omitempty" search:"Subject Kind"`

--- a/generated/storage/secret.pb.go
+++ b/generated/storage/secret.pb.go
@@ -82,7 +82,7 @@ func (SecretType) EnumDescriptor() ([]byte, []int) {
 // Flat secret object.
 // Any properties of an individual secret.
 // (regardless of time, scope, or context)
-//////////////////////////////////////////
+// ////////////////////////////////////////
 type Secret struct {
 	Id          string            `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" search:"Secret ID,store,hidden" sql:"pk,type(uuid)"`
 	Name        string            `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty" search:"Secret,store"`
@@ -735,6 +735,7 @@ type SecretDataFile struct {
 	Name string     `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
 	Type SecretType `protobuf:"varint,2,opt,name=type,proto3,enum=storage.SecretType" json:"type,omitempty" search:"Secret Type"`
 	// Types that are valid to be assigned to Metadata:
+	//
 	//	*SecretDataFile_Cert
 	//	*SecretDataFile_ImagePullSecret
 	Metadata             isSecretDataFile_Metadata `protobuf_oneof:"metadata"`

--- a/generated/storage/service_account.pb.go
+++ b/generated/storage/service_account.pb.go
@@ -26,7 +26,7 @@ const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
 // Any properties of an individual service account.
 // (regardless of time, scope, or context)
-//////////////////////////////////////////
+// ////////////////////////////////////////
 type ServiceAccount struct {
 	Id                   string            `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" sql:"pk,type(uuid)"`
 	Name                 string            `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty" search:"Service Account,store"`

--- a/generated/storage/test.pb.go
+++ b/generated/storage/test.pb.go
@@ -1428,6 +1428,7 @@ type TestMultiKeyStruct struct {
 	Embedded           *TestMultiKeyStruct_Embedded `protobuf:"bytes,12,opt,name=embedded,proto3" json:"embedded,omitempty"`
 	Nested             []*TestMultiKeyStruct_Nested `protobuf:"bytes,13,rep,name=nested,proto3" json:"nested,omitempty"`
 	// Types that are valid to be assigned to Oneof:
+	//
 	//	*TestMultiKeyStruct_Oneofstring
 	//	*TestMultiKeyStruct_Oneofnested
 	Oneof                isTestMultiKeyStruct_Oneof `protobuf_oneof:"oneof"`
@@ -2099,19 +2100,20 @@ func (m *TestMultiKeyStruct_OneOfNested_Nested2) Clone() *TestMultiKeyStruct_One
 // The test graph is as below. The numbers next to the edges
 // indicate the cardinality of the relationship, either n-1, 1-n or n-n.
 // The first element is the child and second is the parent.
-//             TestGrandparent
-//        (n-1) /      (n-1) |   (n-1) \          \ (n-1) (namespaced search)
-//       TestParent1  TestParent2   TestParent3   TestParent4
-//       (n-n) |           | (n-1)                   \ (n-1)
-//       TestChild1    TestChild2                TestChild1P4
-//         (1-n)  |
-//       TestGrandChild1
-//         (n-1)  |
-//       TestGGrandChild1
-//         (1-n)   |
-//       TestG2GrandChild1
-//        (n-1)   |
-//        TestG3GrandChild1
+//
+//	      TestGrandparent
+//	 (n-1) /      (n-1) |   (n-1) \          \ (n-1) (namespaced search)
+//	TestParent1  TestParent2   TestParent3   TestParent4
+//	(n-n) |           | (n-1)                   \ (n-1)
+//	TestChild1    TestChild2                TestChild1P4
+//	  (1-n)  |
+//	TestGrandChild1
+//	  (n-1)  |
+//	TestGGrandChild1
+//	  (1-n)   |
+//	TestG2GrandChild1
+//	 (n-1)   |
+//	 TestG3GrandChild1
 type TestGrandparent struct {
 	Id                   string                      `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" search:"Test Grandparent ID" sql:"pk"`
 	Val                  string                      `protobuf:"bytes,2,opt,name=val,proto3" json:"val,omitempty" search:"Test Grandparent Val"`

--- a/generated/test/test.pb.go
+++ b/generated/test/test.pb.go
@@ -128,6 +128,7 @@ type TestClone struct {
 	EnumSlice   []TestClone_CloneEnum           `protobuf:"varint,6,rep,packed,name=enum_slice,json=enumSlice,proto3,enum=test.TestClone_CloneEnum" json:"enum_slice,omitempty"`
 	Ts          *types.Timestamp                `protobuf:"bytes,7,opt,name=ts,proto3" json:"ts,omitempty"`
 	// Types that are valid to be assigned to Primitive:
+	//
 	//	*TestClone_Int32
 	//	*TestClone_String_
 	//	*TestClone_Msg


### PR DESCRIPTION
## Description

Failed job: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/branch-ci-stackrox-stackrox-release-3.74-merge-grouped-static-checks/1660897599969824768

I did: `make proto-generated-srcs`

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Successful job: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/stackrox_stackrox/6124/pull-ci-stackrox-stackrox-release-3.74-grouped-static-checks/1660905949495300096. 

Let's ignore pending E2E tests.
I will ask the responsible team to look at the `local-roxctl-tests` failure.