### PR TITLE
3.74: fix local roxctl tests

### DIFF
--- a/tests/roxctl/bats-tests/local/expect/flavor-interactive-dummy.expect.tcl
+++ b/tests/roxctl/bats-tests/local/expect/flavor-interactive-dummy.expect.tcl
@@ -23,28 +23,27 @@ if {[llength $argv] != 2} {
 
 spawn {*}"$binary" central generate interactive
 
-expect "Enter path to the backup bundle from which to restore keys and certificates*" { send "\n" }
-expect "Enter read templates from local filesystem*" { send "\n" }
-expect "Enter path to helm templates on your local filesystem*" { send "\n" }
-expect "Enter PEM cert bundle file*" { send "\n" }
-expect "Enter Create PodSecurityPolicy resources*" { send "\n" }
-expect "Enter administrator password*" { send "\n" }
-expect "Enter orchestrator (k8s, openshift)*" { send "k8s\n" }
-expect "Enter the directory to output the deployment bundle to*" { send "$out_dir\n" }
+expect "Enter path to the backup bundle from which to restore keys and certificates*: " { send "\n" }
+expect "Enter read templates from local filesystem*:*: " { send "\n" }
+expect "Enter path to helm templates on your local filesystem*:*: " { send "\n" }
+expect "Enter PEM cert bundle file*: " { send "\n" }
+expect "Enter Create PodSecurityPolicy resources*:*: " { send "\n" }
+expect "Enter administrator password*:*: " { send "\n" }
+expect "Enter orchestrator (k8s, openshift)*: " { send "k8s\n" }
 # Sending invalid value
-expect "Enter default container images settings*" { send "dummy\n" }
+expect "Enter default container images settings*:*:" { send "dummy\n" }
 
 expect {
   "Unexpected value 'dummy', allowed values are*" {
     send "rhacs\n"
     # ensure that the next question is correct after providing a valid answer
-    expect "Enter the method of exposing Central*" {
+    expect "Enter the directory to output*" {
       exit 0
     }
     send_user "\nERROR: roxctl accepted 'rhacs' as flavor and generated unexpected question afterwards\n"
     exit 2
   }
-  "Enter the method of exposing Central*" {
+  "Enter the directory to output*" {
     send_user "\nERROR: roxctl accepted 'dummy' as flavor and did not ask for correction immediately\n"
     exit 1
   }

--- a/tests/roxctl/bats-tests/local/expect/flavor-interactive-postgres.expect.tcl
+++ b/tests/roxctl/bats-tests/local/expect/flavor-interactive-postgres.expect.tcl
@@ -30,15 +30,15 @@ if {[llength $argv] != 4} {
 
 spawn {*}"$binary" central generate interactive
 
-expect "Enter path to the backup bundle from which to restore keys and certificates*" { send "\n" }
-expect "Enter read templates from local filesystem*" { send "\n" }
-expect "Enter path to helm templates on your local filesystem*" { send "\n" }
-expect "Enter PEM cert bundle file*" { send "\n" }
-expect "Enter Create PodSecurityPolicy resources*" { send "\n" }
-expect "Enter administrator password*" { send "\n" }
-expect "Enter orchestrator (k8s, openshift)*" { send "k8s\n" }
-expect "Enter the directory to output the deployment bundle to*" { send "$out_dir\n" }
-expect "Enter default container images settings*" { send "$flavor\n" }
+expect "Enter path to the backup bundle from which to restore keys and certificates*: " { send "\n" }
+expect "Enter read templates from local filesystem*:*: " { send "\n" }
+expect "Enter path to helm templates on your local filesystem*:*: " { send "\n" }
+expect "Enter PEM cert bundle file*: " { send "\n" }
+expect "Enter Create PodSecurityPolicy resources*:*: " { send "\n" }
+expect "Enter administrator password*:*: " { send "\n" }
+expect "Enter orchestrator (k8s, openshift)*: " { send "k8s\n" }
+expect "Enter default container images settings*:*: " { send "$flavor\n" }
+expect "Enter the directory to output the deployment bundle to*:*: " { send "$out_dir\n" }
 
 # Enter central-db image to use (default: "docker.io/stackrox/central-db:2.21.0-15-g448f2dc8fa"):
 # Enter central-db image to use (default: "stackrox.io/central-db:3.67.x-296-g56df6a892d"):
@@ -64,7 +64,9 @@ expect {
   }
 }
 
-expect "Enter the method of exposing Central*" { send "none\n" }
+expect "Enter whether to enable telemetry*:*: " { send "\n" }
+expect "Enter the method of exposing Central*:*: " { send "none\n" }
+
 # Enter main image to use (default: "docker.io/stackrox/main:3.67.x-296-g56df6a892d"):
 # Enter main image to use (default: "stackrox.io/main:3.67.x-296-g56df6a892d")
 # Enter main image to use (default: "registry.redhat.io/advanced-cluster-security/rhacs-main-rhel8:3.68.x-30-g516b4e7a6c-dirty"):
@@ -91,7 +93,6 @@ expect {
 
 
 expect "Enter whether to run StackRox in offline mode, which avoids reaching out to the Internet*" { send "\n" }
-expect "Enter whether to enable telemetry*" { send "\n" }
 expect "Enter the deployment tool to use (kubectl, helm, helm-values)*:" { send "\n" }
 expect "Enter Istio version when deploying into an Istio-enabled cluster*:" { send "\n" }
 

--- a/tests/roxctl/bats-tests/local/expect/flavor-interactive.expect.tcl
+++ b/tests/roxctl/bats-tests/local/expect/flavor-interactive.expect.tcl
@@ -33,16 +33,17 @@ if {[llength $argv] != 4} {
 
 spawn {*}"$binary" central generate interactive
 
-expect "Enter path to the backup bundle from which to restore keys and certificates*" { send "\n" }
-expect "Enter read templates from local filesystem*" { send "\n" }
-expect "Enter path to helm templates on your local filesystem*" { send "\n" }
-expect "Enter PEM cert bundle file*" { send "\n" }
-expect "Enter Create PodSecurityPolicy resources*" { send "\n" }
-expect "Enter administrator password*" { send "\n" }
-expect "Enter orchestrator (k8s, openshift)*" { send "k8s\n" }
-expect "Enter the directory to output the deployment bundle to*" { send "$out_dir\n" }
-expect "Enter default container images settings*" { send "$flavor\n" }
-expect "Enter the method of exposing Central*" { send "none\n" }
+expect "Enter path to the backup bundle from which to restore keys and certificates*: " { send "\n" }
+expect "Enter read templates from local filesystem*:*: " { send "\n" }
+expect "Enter path to helm templates on your local filesystem*:*: " { send "\n" }
+expect "Enter PEM cert bundle file*: " { send "\n" }
+expect "Enter Create PodSecurityPolicy resources*:*: " { send "\n" }
+expect "Enter administrator password*:*: " { send "\n" }
+expect "Enter orchestrator (k8s, openshift)*: " { send "k8s\n" }
+expect "Enter default container images settings*:*: " { send "$flavor\n" }
+expect "Enter the directory to output the deployment bundle to*:*: " { send "$out_dir\n" }
+expect "Enter whether to enable telemetry*:*: " { send "\n" }
+expect "Enter the method of exposing Central*:*: " { send "none\n" }
 
 # Enter main image to use (default: "docker.io/stackrox/main:3.67.x-296-g56df6a892d"):
 # Enter main image to use (default: "stackrox.io/main:3.67.x-296-g56df6a892d")
@@ -68,7 +69,6 @@ expect {
   }
 }
 expect "Enter whether to run StackRox in offline mode, which avoids reaching out to the Internet*" { send "\n" }
-expect "Enter whether to enable telemetry*" { send "\n" }
 expect "Enter the deployment tool to use (kubectl, helm, helm-values)*:" { send "\n" }
 expect "Enter Istio version when deploying into an Istio-enabled cluster*:" { send "\n" }
 


### PR DESCRIPTION
## Description

Failed job: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/branch-ci-stackrox-stackrox-release-3.74-merge-local-roxctl-tests/1660897601647546368

Cherry-picked https://github.com/stackrox/stackrox/pull/4795

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

CI is sufficient.

Successful run: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/stackrox_stackrox/6125/pull-ci-stackrox-stackrox-release-3.74-local-roxctl-tests/1660921326233194496. 