### PR TITLE
Show integration name instead of integration type as the page header

### DIFF
--- a/ui/apps/platform/src/Containers/Integrations/CreateIntegrationPage.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/CreateIntegrationPage.tsx
@@ -11,7 +11,7 @@ function CreateIntegrationPage(): ReactElement {
     } = usePageState();
 
     return (
-        <IntegrationPage title="Create Integration">
+        <IntegrationPage title="Create Integration" name="Create Integration">
             <IntegrationForm source={source} type={type} isEditable />
         </IntegrationPage>
     );

--- a/ui/apps/platform/src/Containers/Integrations/EditIntegrationPage.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/EditIntegrationPage.tsx
@@ -19,7 +19,7 @@ function EditIntegrationPage(): ReactElement {
     }
 
     return (
-        <IntegrationPage title="Edit Integration">
+        <IntegrationPage title="Edit Integration" name={integration.name}>
             <IntegrationForm source={source} type={type} initialValues={integration} isEditable />
         </IntegrationPage>
     );

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationDetailsPage.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationDetailsPage.tsx
@@ -19,7 +19,7 @@ function IntegrationDetailsPage(): ReactElement {
     }
 
     return (
-        <IntegrationPage title={integration.name}>
+        <IntegrationPage title={integration.name} name={integration.name}>
             <IntegrationForm source={source} type={type} initialValues={integration} />
         </IntegrationPage>
     );

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationPage.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationPage.tsx
@@ -25,10 +25,11 @@ import usePageState from './hooks/usePageState';
 
 export type IntegrationPageProps = {
     title: string;
+    name: string;
     children: ReactElement | ReactElement[];
 };
 
-function IntegrationPage({ title, children }: IntegrationPageProps): ReactElement {
+function IntegrationPage({ title, name, children }: IntegrationPageProps): ReactElement {
     const permissions = useIntegrationPermissions();
     const {
         pageState,
@@ -55,9 +56,7 @@ function IntegrationPage({ title, children }: IntegrationPageProps): ReactElemen
             <PageSection variant="light">
                 <Flex>
                     <FlexItem>
-                        <Title headingLevel="h1">{`${
-                            pageState === 'VIEW_DETAILS' ? '' : 'Configure'
-                        } ${typeLabel} Integration`}</Title>
+                        <Title headingLevel="h1">{name}</Title>
                     </FlexItem>
                     {pageState === 'VIEW_DETAILS' && permissions[source].write && (
                         <FlexItem align={{ default: 'alignRight' }}>


### PR DESCRIPTION
## Description

Integration type can be deduced from breadcrumbs. This change makes UI more similar to Access Control detail pages.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

<img width="1778" alt="Screenshot 2023-05-23 at 15 36 05" src="https://github.com/stackrox/stackrox/assets/78353299/043a3380-d843-444f-ab0e-f9af8d52097d">
<img width="1790" alt="Screenshot 2023-05-23 at 15 36 13" src="https://github.com/stackrox/stackrox/assets/78353299/e75ed20f-a1c2-4570-b0f4-1a181736351a">

