### PR TITLE
ROX-16871: adjust UI for declarative notifiers

### DIFF
--- a/ui/apps/platform/src/Containers/Integrations/IntegrationDetailsPage.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationDetailsPage.tsx
@@ -19,7 +19,11 @@ function IntegrationDetailsPage(): ReactElement {
     }
 
     return (
-        <IntegrationPage title={integration.name} name={integration.name}>
+        <IntegrationPage
+            title={integration.name}
+            name={integration.name}
+            traits={integration.traits}
+        >
             <IntegrationForm source={source} type={type} initialValues={integration} />
         </IntegrationPage>
     );

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/IntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/IntegrationForm.tsx
@@ -1,6 +1,8 @@
 import React, { FunctionComponent, ReactElement } from 'react';
 
+import { isUserResource } from 'Containers/AccessControl/traits';
 import { Integration, IntegrationSource, IntegrationType } from '../utils/integrationUtils';
+
 // image integrations
 import ClairifyIntegrationForm from './Forms/ClairifyIntegrationForm';
 import ClairIntegrationForm from './Forms/ClairIntegrationForm';
@@ -37,7 +39,6 @@ import ClusterInitBundleIntegrationForm from './Forms/ClusterInitBundleIntegrati
 import SignatureIntegrationForm from './Forms/SignatureIntegrationForm';
 
 import './IntegrationForm.css';
-import { isUserResource } from '../../AccessControl/traits';
 
 type IntegrationFormProps = {
     source: IntegrationSource;

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/IntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/IntegrationForm.tsx
@@ -37,6 +37,7 @@ import ClusterInitBundleIntegrationForm from './Forms/ClusterInitBundleIntegrati
 import SignatureIntegrationForm from './Forms/SignatureIntegrationForm';
 
 import './IntegrationForm.css';
+import { isUserResource } from '../../AccessControl/traits';
 
 type IntegrationFormProps = {
     source: IntegrationSource;
@@ -104,7 +105,12 @@ function IntegrationForm({
             `There are no integration form components for source (${source}) and type (${type})`
         );
     }
-    return <Form initialValues={initialValues} isEditable={isEditable} />;
+    return (
+        <Form
+            initialValues={initialValues}
+            isEditable={isEditable && isUserResource(initialValues?.traits)}
+        />
+    );
 }
 
 export default IntegrationForm;

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationPage.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationPage.tsx
@@ -13,18 +13,15 @@ import {
 } from '@patternfly/react-core';
 
 import { integrationsPath } from 'routePaths';
-import {
-    getEditDisabledMessage,
-    getIntegrationLabel,
-} from 'Containers/Integrations/utils/integrationUtils';
 import PageTitle from 'Components/PageTitle';
 import LinkShim from 'Components/PatternFly/LinkShim';
 import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
-import useIntegrationPermissions from './hooks/useIntegrationPermissions';
+import { Traits } from 'types/traits.proto';
+import { TraitsOriginLabel } from 'Containers/AccessControl/TraitsOriginLabel';
+import { isUserResource } from 'Containers/AccessControl/traits';
+import { getEditDisabledMessage, getIntegrationLabel } from './utils/integrationUtils';
 import usePageState from './hooks/usePageState';
-import { Traits } from '../../types/traits.proto';
-import { TraitsOriginLabel } from '../AccessControl/TraitsOriginLabel';
-import { isUserResource } from '../AccessControl/traits';
+import useIntegrationPermissions from './hooks/useIntegrationPermissions';
 
 export type IntegrationPageProps = {
     title: string;
@@ -46,6 +43,10 @@ function IntegrationPage({ title, name, traits, children }: IntegrationPageProps
 
     const editDisabledMessage = getEditDisabledMessage(type);
 
+    const hasTraitsLabel =
+        pageState !== 'CREATE' && pageState !== 'LIST' && (type === 'generic' || type === 'splunk');
+    const hasEditButton =
+        pageState === 'VIEW_DETAILS' && permissions[source].write && isUserResource(traits);
     return (
         <>
             <PageTitle title={title} />
@@ -62,37 +63,31 @@ function IntegrationPage({ title, name, traits, children }: IntegrationPageProps
                     <FlexItem>
                         <Title headingLevel="h1">{name}</Title>
                     </FlexItem>
-                    {pageState !== 'CREATE' &&
-                        pageState !== 'LIST' &&
-                        (type === 'generic' || type === 'splunk') && (
-                            <TraitsOriginLabel traits={traits} />
-                        )}
-                    {pageState === 'VIEW_DETAILS' &&
-                        permissions[source].write &&
-                        isUserResource(traits) && (
-                            <FlexItem align={{ default: 'alignRight' }}>
-                                {editDisabledMessage ? (
-                                    <Tooltip content={editDisabledMessage}>
-                                        <Button
-                                            variant={ButtonVariant.secondary}
-                                            component={LinkShim}
-                                            href={integrationEditPath}
-                                            isAriaDisabled={!!editDisabledMessage}
-                                        >
-                                            Edit
-                                        </Button>
-                                    </Tooltip>
-                                ) : (
+                    {hasTraitsLabel && <TraitsOriginLabel traits={traits} />}
+                    {hasEditButton && (
+                        <FlexItem align={{ default: 'alignRight' }}>
+                            {editDisabledMessage ? (
+                                <Tooltip content={editDisabledMessage}>
                                     <Button
                                         variant={ButtonVariant.secondary}
                                         component={LinkShim}
                                         href={integrationEditPath}
+                                        isAriaDisabled={!!editDisabledMessage}
                                     >
                                         Edit
                                     </Button>
-                                )}
-                            </FlexItem>
-                        )}
+                                </Tooltip>
+                            ) : (
+                                <Button
+                                    variant={ButtonVariant.secondary}
+                                    component={LinkShim}
+                                    href={integrationEditPath}
+                                >
+                                    Edit
+                                </Button>
+                            )}
+                        </FlexItem>
+                    )}
                 </Flex>
             </PageSection>
             {children}

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationPage.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationPage.tsx
@@ -1,14 +1,14 @@
 import React, { ReactElement } from 'react';
 import {
+    Breadcrumb,
+    BreadcrumbItem,
     Button,
     ButtonVariant,
+    Divider,
     Flex,
     FlexItem,
     PageSection,
     Title,
-    Breadcrumb,
-    BreadcrumbItem,
-    Divider,
     Tooltip,
 } from '@patternfly/react-core';
 
@@ -22,14 +22,18 @@ import LinkShim from 'Components/PatternFly/LinkShim';
 import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
 import useIntegrationPermissions from './hooks/useIntegrationPermissions';
 import usePageState from './hooks/usePageState';
+import { Traits } from '../../types/traits.proto';
+import { TraitsOriginLabel } from '../AccessControl/TraitsOriginLabel';
+import { isUserResource } from '../AccessControl/traits';
 
 export type IntegrationPageProps = {
     title: string;
     name: string;
+    traits?: Traits;
     children: ReactElement | ReactElement[];
 };
 
-function IntegrationPage({ title, name, children }: IntegrationPageProps): ReactElement {
+function IntegrationPage({ title, name, traits, children }: IntegrationPageProps): ReactElement {
     const permissions = useIntegrationPermissions();
     const {
         pageState,
@@ -58,30 +62,37 @@ function IntegrationPage({ title, name, children }: IntegrationPageProps): React
                     <FlexItem>
                         <Title headingLevel="h1">{name}</Title>
                     </FlexItem>
-                    {pageState === 'VIEW_DETAILS' && permissions[source].write && (
-                        <FlexItem align={{ default: 'alignRight' }}>
-                            {editDisabledMessage ? (
-                                <Tooltip content={editDisabledMessage}>
+                    {pageState !== 'CREATE' &&
+                        pageState !== 'LIST' &&
+                        (type === 'generic' || type === 'splunk') && (
+                            <TraitsOriginLabel traits={traits} />
+                        )}
+                    {pageState === 'VIEW_DETAILS' &&
+                        permissions[source].write &&
+                        isUserResource(traits) && (
+                            <FlexItem align={{ default: 'alignRight' }}>
+                                {editDisabledMessage ? (
+                                    <Tooltip content={editDisabledMessage}>
+                                        <Button
+                                            variant={ButtonVariant.secondary}
+                                            component={LinkShim}
+                                            href={integrationEditPath}
+                                            isAriaDisabled={!!editDisabledMessage}
+                                        >
+                                            Edit
+                                        </Button>
+                                    </Tooltip>
+                                ) : (
                                     <Button
                                         variant={ButtonVariant.secondary}
                                         component={LinkShim}
                                         href={integrationEditPath}
-                                        isAriaDisabled={!!editDisabledMessage}
                                     >
                                         Edit
                                     </Button>
-                                </Tooltip>
-                            ) : (
-                                <Button
-                                    variant={ButtonVariant.secondary}
-                                    component={LinkShim}
-                                    href={integrationEditPath}
-                                >
-                                    Edit
-                                </Button>
-                            )}
-                        </FlexItem>
-                    )}
+                                )}
+                            </FlexItem>
+                        )}
                 </Flex>
             </PageSection>
             {children}

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationsListPage/IntegrationsTable.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationsListPage/IntegrationsTable.tsx
@@ -18,12 +18,12 @@ import LinkShim from 'Components/PatternFly/LinkShim';
 import useFeatureFlags from 'hooks/useFeatureFlags';
 import useTableSelection from 'hooks/useTableSelection';
 import TableCellValue from 'Components/TableCellValue/TableCellValue';
+import { isUserResource } from 'Containers/AccessControl/traits';
 import useIntegrationPermissions from '../hooks/useIntegrationPermissions';
 import usePageState from '../hooks/usePageState';
 import { Integration, getIsAPIToken, getIsClusterInitBundle } from '../utils/integrationUtils';
 import tableColumnDescriptor from '../utils/tableColumnDescriptor';
 import DownloadCAConfigBundle from './DownloadCAConfigBundle';
-import { isUserResource } from '../../AccessControl/traits';
 
 function getNewButtonText(type) {
     if (type === 'apitoken') {

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationsListPage/IntegrationsTable.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationsListPage/IntegrationsTable.tsx
@@ -23,6 +23,7 @@ import usePageState from '../hooks/usePageState';
 import { Integration, getIsAPIToken, getIsClusterInitBundle } from '../utils/integrationUtils';
 import tableColumnDescriptor from '../utils/tableColumnDescriptor';
 import DownloadCAConfigBundle from './DownloadCAConfigBundle';
+import { isUserResource } from '../../AccessControl/traits';
 
 function getNewButtonText(type) {
     if (type === 'apitoken') {
@@ -222,7 +223,9 @@ function IntegrationsTable({
                                         <Td
                                             actions={{
                                                 items: actionItems,
-                                                disable: !permissions[source].write,
+                                                disable:
+                                                    !permissions[source].write ||
+                                                    !isUserResource(integration.traits),
                                             }}
                                             className="pf-u-text-align-right"
                                         />

--- a/ui/apps/platform/src/Containers/Integrations/utils/integrationUtils.ts
+++ b/ui/apps/platform/src/Containers/Integrations/utils/integrationUtils.ts
@@ -5,6 +5,7 @@ import { IntegrationBase } from 'services/IntegrationsService';
 import { IntegrationSource, IntegrationType } from 'types/integration';
 import { ImageIntegrationCategory } from 'types/imageIntegration.proto';
 
+import { Traits } from 'types/traits.proto';
 import integrationsList from './integrationsList';
 
 export type { IntegrationSource, IntegrationType };
@@ -13,6 +14,7 @@ export type Integration = {
     type: IntegrationType;
     id: string;
     name: string;
+    traits?: Traits;
 };
 
 export function getIntegrationLabel(source: string, type: string): string {

--- a/ui/apps/platform/src/Containers/Integrations/utils/tableColumnDescriptor.ts
+++ b/ui/apps/platform/src/Containers/Integrations/utils/tableColumnDescriptor.ts
@@ -27,6 +27,7 @@ import {
     daysOfWeek,
     timesOfDay,
 } from './integrationUtils';
+import { getOriginLabel } from '../../AccessControl/traits';
 
 const { getCategoriesText: getCategoriesTextForClairifyScanner } =
     categoriesUtilsForClairifyScanner;
@@ -73,6 +74,13 @@ type IntegrationTableColumnDescriptorMap = {
         SignatureIntegrationType,
         IntegrationTableColumnDescriptor<SignatureIntegration>[]
     >;
+};
+
+const originColumnDescriptor = {
+    accessor: (integration) => {
+        return getOriginLabel(integration.traits);
+    },
+    Header: 'Origin',
 };
 
 const tableColumnDescriptor: Readonly<IntegrationTableColumnDescriptorMap> = {
@@ -123,6 +131,7 @@ const tableColumnDescriptor: Readonly<IntegrationTableColumnDescriptorMap> = {
         ],
         splunk: [
             { accessor: 'name', Header: 'Name' },
+            originColumnDescriptor,
             {
                 accessor: 'splunk.httpEndpoint',
                 Header: 'URL',
@@ -132,6 +141,7 @@ const tableColumnDescriptor: Readonly<IntegrationTableColumnDescriptorMap> = {
         pagerduty: [{ accessor: 'name', Header: 'Name' }],
         generic: [
             { accessor: 'name', Header: 'Name' },
+            originColumnDescriptor,
             { accessor: 'generic.endpoint', Header: 'Endpoint' },
         ],
         sumologic: [

--- a/ui/apps/platform/src/Containers/Integrations/utils/tableColumnDescriptor.ts
+++ b/ui/apps/platform/src/Containers/Integrations/utils/tableColumnDescriptor.ts
@@ -21,13 +21,13 @@ import {
 } from 'types/notifier.proto';
 import { SignatureIntegration } from 'types/signatureIntegration.proto';
 
+import { getOriginLabel } from 'Containers/AccessControl/traits';
 import {
     categoriesUtilsForClairifyScanner,
     categoriesUtilsForRegistryScanner,
     daysOfWeek,
     timesOfDay,
 } from './integrationUtils';
-import { getOriginLabel } from '../../AccessControl/traits';
 
 const { getCategoriesText: getCategoriesTextForClairifyScanner } =
     categoriesUtilsForClairifyScanner;

--- a/ui/apps/platform/src/services/NotifierIntegrationsService.ts
+++ b/ui/apps/platform/src/services/NotifierIntegrationsService.ts
@@ -2,6 +2,7 @@ import axios from './instance';
 
 import { IntegrationBase, IntegrationOptions } from './IntegrationsService';
 import { Empty } from './types';
+import { Traits } from '../types/traits.proto';
 
 const notifierIntegrationsUrl = '/v1/notifiers';
 
@@ -13,6 +14,7 @@ export type NotifierIntegrationBase = {
     uiEndpoint: string;
     labelKey: string;
     labelDefault: string;
+    traits?: Traits;
 } & IntegrationBase;
 
 /*

--- a/ui/apps/platform/src/services/NotifierIntegrationsService.ts
+++ b/ui/apps/platform/src/services/NotifierIntegrationsService.ts
@@ -1,8 +1,8 @@
+import { Traits } from 'types/traits.proto';
 import axios from './instance';
 
 import { IntegrationBase, IntegrationOptions } from './IntegrationsService';
 import { Empty } from './types';
-import { Traits } from '../types/traits.proto';
 
 const notifierIntegrationsUrl = '/v1/notifiers';
 

--- a/ui/apps/platform/src/types/notifier.proto.ts
+++ b/ui/apps/platform/src/types/notifier.proto.ts
@@ -1,5 +1,6 @@
 import { KeyValuePair } from './common.proto';
 import { PolicySeverity } from './policy.proto';
+import { Traits } from './traits.proto';
 
 export type NotifierIntegration =
     | AWSSecurityHubNotifierIntegration
@@ -19,6 +20,7 @@ export type BaseNotifierIntegration = {
     uiEndpoint: string;
     labelKey: string;
     labelDefault: string;
+    traits?: Traits;
 };
 
 /*


### PR DESCRIPTION
## Description

 - Display origin(User or Declarative) in the Splunk/Generic Webhook notifier list view.
 - Display origin in details page for Splunk/Generic Webhook notifiers.
 - Disable editing/deleting declaratively created Splunk/Generic Webhook notifiers from UI.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

<img width="1781" alt="Screenshot 2023-05-23 at 15 09 56" src="https://github.com/stackrox/stackrox/assets/78353299/ae0b9e4e-9fc4-4d0b-bafb-8a9c586a1557">
<img width="1781" alt="Screenshot 2023-05-23 at 15 09 29" src="https://github.com/stackrox/stackrox/assets/78353299/d1ea732e-aa02-4744-8439-d0417fbba698">
<img width="1781" alt="Screenshot 2023-05-23 at 15 09 39" src="https://github.com/stackrox/stackrox/assets/78353299/0760e65d-7900-45ec-ae9c-3f82b9e3cbaa">

