### PR TITLE
Dashrews/update default migration timeout

### DIFF
--- a/pkg/env/postgres_default_timeout.go
+++ b/pkg/env/postgres_default_timeout.go
@@ -10,5 +10,5 @@ var (
 	PostgresDefaultCursorTimeout = registerDurationSetting("ROX_POSTGRES_DEFAULT_CURSOR_TIMEOUT", 10*time.Minute)
 
 	// PostgresDefaultMigrationStatementTimeout sets the default timeout for Postgres statements during migration
-	PostgresDefaultMigrationStatementTimeout = registerDurationSetting("ROX_POSTGRES_MIGRATION_STATEMENT_TIMEOUT", 20*time.Minute)
+	PostgresDefaultMigrationStatementTimeout = registerDurationSetting("ROX_POSTGRES_MIGRATION_STATEMENT_TIMEOUT", 2*time.Hour)
 )


### PR DESCRIPTION
## Description

Make the default migration timeout long

## Checklist
- [ ] Investigated and inspected CI test results
~- [ ] Unit test and regression tests added~
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed


