### PR TITLE
Display 404 instead of error in cases of invalid deployment id

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPage.tsx
@@ -17,6 +17,7 @@ import PageTitle from 'Components/PageTitle';
 import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
 import useURLStringUnion from 'hooks/useURLStringUnion';
 
+import NotFoundMessage from 'Components/NotFoundMessage';
 import { getOverviewCvesPath } from '../searchUtils';
 import DeploymentPageHeader, {
     DeploymentMetadata,
@@ -42,10 +43,10 @@ const deploymentMetadataQuery = gql`
 `;
 
 function DeploymentPage() {
-    const { deploymentId } = useParams();
+    const { deploymentId } = useParams() as { deploymentId: string };
     const [activeTabKey, setActiveTabKey] = useURLStringUnion('detailsTab', detailsTabValues);
 
-    const metadataRequest = useQuery<{ deployment: DeploymentMetadata }, { id: string }>(
+    const metadataRequest = useQuery<{ deployment: DeploymentMetadata | null }, { id: string }>(
         deploymentMetadataQuery,
         {
             variables: { id: deploymentId },
@@ -53,6 +54,7 @@ function DeploymentPage() {
     );
 
     const deploymentName = metadataRequest.data?.deployment?.name;
+    const deploymentNotFound = metadataRequest.data && !metadataRequest.data.deployment;
 
     return (
         <>
@@ -75,44 +77,52 @@ function DeploymentPage() {
                 </Breadcrumb>
             </PageSection>
             <Divider component="div" />
-            <PageSection variant="light">
-                {metadataRequest.error ? (
-                    <TableErrorComponent
-                        error={metadataRequest.error}
-                        message="The system was unable to load metadata for this deployment"
-                    />
-                ) : (
-                    <DeploymentPageHeader data={metadataRequest.data?.deployment} />
-                )}
-            </PageSection>
-            <PageSection
-                className="pf-u-display-flex pf-u-flex-direction-column pf-u-flex-grow-1"
-                padding={{ default: 'noPadding' }}
-            >
-                <Tabs
-                    activeKey={activeTabKey}
-                    onSelect={(e, key) => setActiveTabKey(key)}
-                    component={TabsComponent.nav}
-                    className="pf-u-pl-md pf-u-background-color-100"
-                    mountOnEnter
-                    unmountOnExit
-                >
-                    <Tab
+            {deploymentNotFound ? (
+                <NotFoundMessage
+                    title="404: We couldn't find that page"
+                    message={`A deployment with ID ${deploymentId} could not be found.`}
+                />
+            ) : (
+                <>
+                    <PageSection variant="light">
+                        {metadataRequest.error && (
+                            <TableErrorComponent
+                                error={metadataRequest.error}
+                                message="The system was unable to load metadata for this deployment"
+                            />
+                        )}
+                        <DeploymentPageHeader data={metadataRequest.data?.deployment} />
+                    </PageSection>
+                    <PageSection
                         className="pf-u-display-flex pf-u-flex-direction-column pf-u-flex-grow-1"
-                        eventKey="Vulnerabilities"
-                        title={<TabTitleText>Vulnerabilities</TabTitleText>}
+                        padding={{ default: 'noPadding' }}
                     >
-                        <DeploymentPageVulnerabilities deploymentId={deploymentId} />
-                    </Tab>
-                    <Tab
-                        className="pf-u-display-flex pf-u-flex-direction-column pf-u-flex-grow-1"
-                        eventKey="Resources"
-                        title={<TabTitleText>Resources</TabTitleText>}
-                    >
-                        <DeploymentPageResources deploymentId={deploymentId} />
-                    </Tab>
-                </Tabs>
-            </PageSection>
+                        <Tabs
+                            activeKey={activeTabKey}
+                            onSelect={(e, key) => setActiveTabKey(key)}
+                            component={TabsComponent.nav}
+                            className="pf-u-pl-md pf-u-background-color-100"
+                            mountOnEnter
+                            unmountOnExit
+                        >
+                            <Tab
+                                className="pf-u-display-flex pf-u-flex-direction-column pf-u-flex-grow-1"
+                                eventKey="Vulnerabilities"
+                                title={<TabTitleText>Vulnerabilities</TabTitleText>}
+                            >
+                                <DeploymentPageVulnerabilities deploymentId={deploymentId} />
+                            </Tab>
+                            <Tab
+                                className="pf-u-display-flex pf-u-flex-direction-column pf-u-flex-grow-1"
+                                eventKey="Resources"
+                                title={<TabTitleText>Resources</TabTitleText>}
+                            >
+                                <DeploymentPageResources deploymentId={deploymentId} />
+                            </Tab>
+                        </Tabs>
+                    </PageSection>
+                </>
+            )}
         </>
     );
 }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageHeader.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageHeader.tsx
@@ -24,7 +24,7 @@ export const deploymentMetadataFragment = gql`
 `;
 
 export type DeploymentPageHeaderProps = {
-    data: DeploymentMetadata | undefined;
+    data: DeploymentMetadata | null | undefined;
 };
 
 function DeploymentPageHeader({ data }: DeploymentPageHeaderProps) {


### PR DESCRIPTION
## Description

Better handles that case where a deployment is not found, likely due to an invalid ID in the URL. Instead of crashing the page this will display a 404.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Visit the deployment page with a known bad id in the URL:
![image](https://github.com/stackrox/stackrox/assets/1292638/ad4b37d5-3f16-442d-a737-42f4ec44ce18)

