### PR TITLE
ROX-7771: Re-enable Indentation codenarc rule

### DIFF
--- a/qa-tests-backend/codenarc-rules.groovy
+++ b/qa-tests-backend/codenarc-rules.groovy
@@ -176,8 +176,7 @@ ruleset {
     // ClosureStatementOnOpeningLineOfMultipleLineClosure
     ConsecutiveBlankLines 
     FileEndsWithoutNewline
-    //TODO(ROX-7771): Re-enable indentation checks and fix indentation
-    //Indentation
+    Indentation
 
     LineLength 
     MissingBlankLineAfterImports 

--- a/qa-tests-backend/src/main/groovy/objects/Notifiers.groovy
+++ b/qa-tests-backend/src/main/groovy/objects/Notifiers.groovy
@@ -357,6 +357,6 @@ class SyslogNotifier extends Notifier {
     }
 
     def testNotifier() {
-         return NotifierService.testNotifier(notifier)
+        return NotifierService.testNotifier(notifier)
     }
 }

--- a/qa-tests-backend/src/main/groovy/services/PolicyService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/PolicyService.groovy
@@ -51,7 +51,7 @@ class PolicyService extends BaseService {
     }
 
     static PolicyServiceOuterClass.DryRunResponse dryRunPolicy(PolicyOuterClass.Policy policy) {
-            return getPolicyClient().dryRunPolicy(policy)
+        return getPolicyClient().dryRunPolicy(policy)
     }
 
     static patchPolicy(PolicyServiceOuterClass.PatchPolicyRequest pr) {

--- a/qa-tests-backend/src/test/groovy/DeclarativeConfigTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DeclarativeConfigTest.groovy
@@ -355,17 +355,13 @@ oidc:
 
         // The previously created permission set should not exist anymore.
         def permissionSetAfterDeletion = RoleService.getRoleService().listPermissionSets()
-                .getPermissionSetsList().find {
-                    it.getName() == VALID_PERMISSION_SET.getName()
-                }
+                .getPermissionSetsList().find { it.getName() == VALID_PERMISSION_SET.getName() }
         assert permissionSetAfterDeletion == null
 
         // The previously created access scope should not exist anymore.
         def accessScopeAfterDeletion = RoleService.getRoleService()
                 .listSimpleAccessScopes()
-                .getAccessScopesList().find {
-                    it.getName() == VALID_ACCESS_SCOPE.getName()
-                }
+                .getAccessScopesList().find { it.getName() == VALID_ACCESS_SCOPE.getName() }
         assert accessScopeAfterDeletion == null
 
         // The previously created role should not exist anymore.
@@ -423,17 +419,13 @@ oidc:
 
         // No permission set should be created.
         def permissionSetAfterDeletion = RoleService.getRoleService().listPermissionSets()
-                .getPermissionSetsList().find {
-            it.getName() == VALID_PERMISSION_SET.getName()
-        }
+                .getPermissionSetsList().find { it.getName() == VALID_PERMISSION_SET.getName() }
         assert permissionSetAfterDeletion == null
 
         // No access scope should be created.
         def accessScopeAfterDeletion = RoleService.getRoleService()
                 .listSimpleAccessScopes()
-                .getAccessScopesList().find {
-            it.getName() == VALID_ACCESS_SCOPE.getName()
-        }
+                .getAccessScopesList().find { it.getName() == VALID_ACCESS_SCOPE.getName() }
         assert accessScopeAfterDeletion == null
 
         // No role should be created.

--- a/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
@@ -469,42 +469,9 @@ class DefaultPoliciesTest extends BaseSpecification {
              .filter { x -> !WHITELISTED_KUBE_SYSTEM_POLICIES.contains(x.policy.name) }
              .filter { x -> !WHITELISTED_KUBE_SYSTEM_DEPLOYMENTS_AND_POLICIES.contains(
                  x.deployment.name + ' - ' + x.policy.name) }
-             .filter {
-                     // ROX-5350 - Ignore alerts for deleted policies
-            violation -> Boolean exists = false
-                 try {
-                    Services.getPolicy(violation.policy.id)
-                    exists = true
-                }
-                catch (StatusRuntimeException e) {
-                    log.info "Cannot get the policy associated with the alert: ${e}"
-                    log.info violation.toString()
-                }
-                 exists
-             }.filter { alert ->
-                // The OpenShift: Kubeadmin Secret Accessed policy can sometimes
-                // get triggered by the CI. This happens when the CI scripts use
-                // kubectl to pull resources to save on an earlier test failure.
-                // Ignore this alert iff _all_ violations was by admin,
-                // kube:admin or system:admin using kubectl. Do not ignore for
-                // any other violations. See
-                // https://issues.redhat.com/browse/ROX-10018
-                def noKubectlViolation = true
-                if (alert.policy.getName() == "OpenShift: Kubeadmin Secret Accessed") {
-                    noKubectlViolation = !AlertService.getViolation(alert.id).getViolationsList().
-                        stream().allMatch { v ->
-                            def user = v.getKeyValueAttrs().getAttrsList().find { a ->
-                                a.getKey() == "Username" && (a.getValue() == "admin" ||
-                                                             a.getValue() =~ /(kube|system)\:admin/)
-                            }
-                            def ua = v.getKeyValueAttrs().getAttrsList().find { a ->
-                                a.getKey() == "User Agent" && a.getValue().startsWith("kubectl/")
-                            }
-                            user != null && ua != null
-                        }
-                }
-                noKubectlViolation
-            }.collect()
+             .filter { x -> ignoreAlertsForDeletedPolicies(x) }
+             .filter { x -> ignoreAlertsByAdminWithKubectl(x) }
+             .collect()
 
         if (nonWhitelistedKubeSystemViolations.size() != 0) {
             nonWhitelistedKubeSystemViolations.forEach {
@@ -523,6 +490,41 @@ class DefaultPoliciesTest extends BaseSpecification {
         }
 
         nonWhitelistedKubeSystemViolations.size() == 0
+    }
+
+    // The OpenShift: Kubeadmin Secret Accessed policy can sometimes
+    // get triggered by the CI. This happens when the CI scripts use
+    // kubectl to pull resources to save on an earlier test failure.
+    // Ignore this alert iff _all_ violations was by admin,
+    // kube:admin or system:admin using kubectl. Do not ignore for
+    // any other violations. See
+    // https://issues.redhat.com/browse/ROX-10018
+    private boolean ignoreAlertsByAdminWithKubectl(ListAlert alert) {
+        if (alert.policy.getName() != "OpenShift: Kubeadmin Secret Accessed") {
+            return true
+        }
+        return !AlertService.getViolation(alert.id).getViolationsList().
+                stream().allMatch { v ->
+            def user = v.getKeyValueAttrs().getAttrsList().find { a ->
+                a.getKey() == "Username" && (a.getValue() == "admin" ||
+                        a.getValue() =~ /(kube|system)\:admin/)
+            }
+            def ua = v.getKeyValueAttrs().getAttrsList().find { a ->
+                a.getKey() == "User Agent" && a.getValue().startsWith("kubectl/")
+            }
+            user != null && ua != null
+        }
+    }
+
+    // ROX-5350 - Ignore alerts for deleted policies
+    def ignoreAlertsForDeletedPolicies(ListAlert violation) {
+        try {
+            Services.getPolicy(violation.policy.id)
+            return true
+        } catch (StatusRuntimeException e) {
+            log.info("Cannot get the policy associated with the alert ${violation}", e)
+        }
+        return false
     }
 
     def queryForDeployments() {

--- a/qa-tests-backend/src/test/groovy/ImageSignatureVerificationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageSignatureVerificationTest.groovy
@@ -328,16 +328,16 @@ QC+pUMTUP/ZmrvmKaA+pi55F+w3LqVJ17zwXKjaOEiEpn/+lntl/ieweeQ==
 
     // Helper to create a signature integration with given name and public keys.
     private static String createSignatureIntegration(String integrationName, Map<String, String> namedPublicKeys) {
+        List<CosignPublicKeyVerification.PublicKey> publicKeys = namedPublicKeys.collect {
+            CosignPublicKeyVerification.PublicKey.newBuilder()
+                    .setName(it.key).setPublicKeyPemEnc(it.value)
+                    .build()
+        }
         String signatureIntegrationID = SignatureIntegrationService.createSignatureIntegration(
                 SignatureIntegration.newBuilder()
                         .setName(integrationName)
                         .setCosign(CosignPublicKeyVerification.newBuilder()
-                                .addAllPublicKeys(namedPublicKeys.collect
-                                        {
-                                            CosignPublicKeyVerification.PublicKey.newBuilder()
-                                                    .setName(it.key).setPublicKeyPemEnc(it.value)
-                                                    .build()
-                                        })
+                                .addAllPublicKeys(publicKeys)
                                 .build()
                         )
                         .build()

--- a/qa-tests-backend/src/test/groovy/IntegrationsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/IntegrationsTest.groovy
@@ -763,10 +763,10 @@ class IntegrationsTest extends BaseSpecification {
     @Tag("Integration")
     @Tag("BAT")
     def "Verify syslog notifier"() {
-       given:
-       "syslog server is created"
-       def syslog = SyslogServer.createRsyslog(orchestrator, Constants.ORCHESTRATOR_NAMESPACE)
-       sleep 15 * 1000 // wait 15s for service to start
+        given:
+        "syslog server is created"
+        def syslog = SyslogServer.createRsyslog(orchestrator, Constants.ORCHESTRATOR_NAMESPACE)
+        sleep 15 * 1000 // wait 15s for service to start
 
         when:
         "call the grpc API for the syslog notifier integration."

--- a/qa-tests-backend/src/test/groovy/ProcessesListeningOnPortsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ProcessesListeningOnPortsTest.groovy
@@ -246,9 +246,7 @@ class ProcessesListeningOnPortsTest extends BaseSpecification {
 
         sleep 65000 // Sleep for 65 seconds
         processesListeningOnPorts = evaluateWithRetry(10, 10) {
-               def temp = ProcessesListeningOnPortsService
-                       .getProcessesListeningOnPortsResponse(deploymentId2)
-               return temp
+            ProcessesListeningOnPortsService.getProcessesListeningOnPortsResponse(deploymentId2)
         }
 
         // Confirm that the listening endpoint still appears in the API 65 seconds later


### PR DESCRIPTION
## Description

Enable codenarc rule that was disabled during bump of gradle:

- https://github.com/stackrox/stackrox/pull/4924

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

CI style
`make -c qa-tests style`