### PR TITLE
Delete ID fields in Workload CVE gql queries to avoid cache normalization

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentComponentVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentComponentVulnerabilitiesTable.tsx
@@ -28,7 +28,7 @@ export const deploymentComponentVulnerabilitiesFragment = gql`
         source
         layerIndex
         imageVulnerabilities(query: $query) {
-            id
+            vulnerabilityId: id
             severity
             cvss
             scoreVersion

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx
@@ -38,7 +38,6 @@ export const deploymentWithVulnerabilitiesFragment = gql`
             ...ImageMetadataContext
         }
         imageVulnerabilities(query: $query, pagination: $pagination) {
-            id
             cve
             summary
             images(query: $query) {
@@ -55,7 +54,6 @@ export type DeploymentWithVulnerabilities = {
     id: string;
     images: ImageMetadataContext[];
     imageVulnerabilities: {
-        id: string;
         cve: string;
         summary: string;
         images: {
@@ -66,7 +64,6 @@ export type DeploymentWithVulnerabilities = {
 };
 
 function formatVulnerabilityData(deployment: DeploymentWithVulnerabilities): {
-    id: string;
     cve: string;
     severity: VulnerabilitySeverity;
     isFixable: boolean;
@@ -84,7 +81,7 @@ function formatVulnerabilityData(deployment: DeploymentWithVulnerabilities): {
     });
 
     return deployment.imageVulnerabilities.map((vulnerability) => {
-        const { id, cve, summary, images } = vulnerability;
+        const { cve, summary, images } = vulnerability;
         // Severity, Fixability, and Discovered date are all based on the aggregate value of all components
         const allVulnerableComponents = vulnerability.images.flatMap((img) => img.imageComponents);
         const highestVulnSeverity = getHighestVulnerabilitySeverity(allVulnerableComponents);
@@ -101,7 +98,6 @@ function formatVulnerabilityData(deployment: DeploymentWithVulnerabilities): {
                 : `${uniqueComponents.size} components`;
 
         return {
-            id,
             cve,
             severity: highestVulnSeverity,
             isFixable: isAnyVulnFixable,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageComponentVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageComponentVulnerabilitiesTable.tsx
@@ -25,7 +25,7 @@ export const imageComponentVulnerabilitiesFragment = gql`
         source
         layerIndex
         imageVulnerabilities(query: $query) {
-            id
+            vulnerabilityId: id
             severity
             fixedByVersion
         }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
@@ -33,7 +33,6 @@ import CvssTd from '../components/CvssTd';
 export const imageVulnerabilitiesFragment = gql`
     ${imageComponentVulnerabilitiesFragment}
     fragment ImageVulnerabilityFields on ImageVulnerability {
-        id
         severity
         isFixable
         cve
@@ -48,7 +47,6 @@ export const imageVulnerabilitiesFragment = gql`
 `;
 
 export type ImageVulnerability = {
-    id: string;
     severity: string;
     isFixable: boolean;
     cve: string;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/table.utils.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/table.utils.ts
@@ -60,7 +60,7 @@ export type ComponentVulnerabilityBase = {
     source: SourceType;
     layerIndex: number | null;
     imageVulnerabilities: {
-        id: string;
+        vulnerabilityId: string;
         severity: string;
         fixedByVersion: string;
     }[];
@@ -73,7 +73,7 @@ export type DeploymentComponentVulnerability = Omit<
     'imageVulnerabilities'
 > & {
     imageVulnerabilities: {
-        id: string;
+        vulnerabilityId: string;
         severity: string;
         cvss: number;
         scoreVersion: string;
@@ -172,7 +172,7 @@ function extractCommonComponentFields(
         }
     }
 
-    const vulnerabilityId = vulnerability?.id ?? 'N/A';
+    const vulnerabilityId = vulnerability?.vulnerabilityId ?? 'N/A';
     const severity =
         vulnerability?.severity && isVulnerabilitySeverity(vulnerability.severity)
             ? vulnerability.severity


### PR DESCRIPTION
## Description

Apollo's normalized cache to the rescue again...

This deletes or aliases `id` fields in graphql queries for `imageComponents` and `imageVulnerabilities` that are nested in deeper queries. This was causing duplicate data to appear in tables when multiple child objects were returned with the same ID.


## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Example: CVE-2013-1965 impacts two components in the below image, with with cve being fixable in one, but not fixable in the other. Due to Apollo's caching, only one instance of the `imageVulnerability` is stored in the cache and displayed in the table, leading to the `CVE Fixed In` field being incorrectly identical in both rows.
![image](https://github.com/stackrox/stackrox/assets/1292638/f513050b-ef91-4b3b-9b32-ba6c6f5d3ab5)

After this change, since the `id` field is aliased to something else, the data is embedded directly in the parent object and is not duplicated in the table.
![image](https://github.com/stackrox/stackrox/assets/1292638/1f58aa91-e856-4a83-afee-076343fbec80)

## Explanation

The following minimal query used on the above page causes the "CVE Fixed In" field of the embedded table to be duplicated. (The "Severity" field is affected too, but it isn't noticeable since the value is the same in both objects.)

```graphql
query getCvesForImage(
	$id: ID!
	$query: String!
) {
	image(id: $id) {
                id
		imageVulnerabilities(query: $query) {
			id
			isFixable
			imageComponents(query: $query) {
				name
				imageVulnerabilities(query: $query) {
					id
					severity
					fixedByVersion
				}
			}
		}
	}
}

# variables
{
  "id": "sha256:381a90208031e7910555c99e7a88183389f5d159dcd118c2b98fd8ce196ab79e",
  "query": "CVE:CVE-2013-1965"
}
```

This is due to a single `Image` being stored in the cache by ID, as well as only a single imageVulnerability being stored in the cache by ID.

The raw server results for the above query are:

```json
{
	"data": {
		"image": {
			"imageVulnerabilities": [
				{
					"id": "CVE-2013-1965#debian:8",
					"isFixable": true,
					"imageComponents": [
						{
							"name": "struts",
							"imageVulnerabilities": [
								{
									"id": "CVE-2013-1965#debian:8",
									"severity": "IMPORTANT_VULNERABILITY_SEVERITY",
									"fixedByVersion": "2.3.14.1"
								}
							]
						},
						{
							"name": "struts2-showcase",
							"imageVulnerabilities": [
								{
									"id": "CVE-2013-1965#debian:8",
									"severity": "IMPORTANT_VULNERABILITY_SEVERITY",
									"fixedByVersion": ""
								}
							]
						}
					]
				}
			]
		}
	}
}
```

Which when normalized, results in the following cache structure. Since all instances of `imageVulnerabilities` result in a single value with an ID of `CVE-2013-1965#debian:8`, only a single entry is cached at the top level which is then referenced elsewhere in the structure:
```json
{
    "Image:sha256:381a90208031e7910555c99e7a88183389f5d159dcd118c2b98fd8ce196ab79e": {
        "id": "sha256:381a90208031e7910555c99e7a88183389f5d159dcd118c2b98fd8ce196ab79e",
        "imageVulnerabilities({\"pagination\":{\"limit\":20,\"offset\":0,\"sortOption\":{\"field\":\"CVE\",\"reversed\":false}},\"query\":\"CVE:CVE-2013-1965\"})": [
            {
                "__ref": "ImageVulnerability:CVE-2013-1965#debian:8"
            }
        ]
    },
    "ImageVulnerability:CVE-2013-1965#debian:8": {
        "id": "CVE-2013-1965#debian:8",
        "severity": "IMPORTANT_VULNERABILITY_SEVERITY",
        "fixedByVersion": "2.3.14.1",
        "isFixable": true,
        "imageComponents({\"query\":\"CVE:CVE-2013-1965\"})": [
            {
                "name": "struts",
                "imageVulnerabilities({\"query\":\"CVE:CVE-2013-1965\"})": [
                    {
                        "__ref": "ImageVulnerability:CVE-2013-1965#debian:8"
                    }
                ]
            },
            {
                "name": "struts2-showcase",
                "imageVulnerabilities({\"query\":\"CVE:CVE-2013-1965\"})": [
                    {
                        "__ref": "ImageVulnerability:CVE-2013-1965#debian:8"
                    }
                ]
            }
        ]
    }
}
```
With the id fields aliased, the cache correctly embeds the imageVulnerabilities directly in the parent object, keeping the distinct `fixedByVersion` values separate:
```json
{
    "Image:sha256:381a90208031e7910555c99e7a88183389f5d159dcd118c2b98fd8ce196ab79e": {
        "id": "sha256:381a90208031e7910555c99e7a88183389f5d159dcd118c2b98fd8ce196ab79e",
        "imageVulnerabilities({\"pagination\":{\"limit\":20,\"offset\":0,\"sortOption\":{\"field\":\"CVE\",\"reversed\":false}},\"query\":\"CVE:CVE-2013-1965\"})": [
            {
                "severity": "IMPORTANT_VULNERABILITY_SEVERITY",
                "isFixable": true,
                "discoveredAtImage": "2023-05-16T12:36:43.935654778Z",
                "imageComponents({\"query\":\"CVE:CVE-2013-1965\"})": [
                    {
                        "name": "struts",
                        "imageVulnerabilities({\"query\":\"CVE:CVE-2013-1965\"})": [
                            {
                                "id": "CVE-2013-1965#debian:8",
                                "severity": "IMPORTANT_VULNERABILITY_SEVERITY",
                                "fixedByVersion": "2.3.14.1"
                            }
                        ]
                    },
                    {
                        "name": "struts2-showcase",
                        "imageVulnerabilities({\"query\":\"CVE:CVE-2013-1965\"})": [
                            {
                                "id": "CVE-2013-1965#debian:8",
                                "severity": "IMPORTANT_VULNERABILITY_SEVERITY",
                                "fixedByVersion": ""
                            }
                        ]
                    }
                ]
            }
        ]
    }
}
```

