### PR TITLE
Swap to running Kill from shell for restartPodByLabelWithExecKill

### DIFF
--- a/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
@@ -352,7 +352,8 @@ class Kubernetes implements OrchestratorMain {
     Boolean restartPodByLabelWithExecKill(String ns, Map<String, String> labels) {
         Pod pod = getPodsByLabel(ns, labels).get(0)
         int prevRestartCount = pod.status.containerStatuses.get(0).restartCount
-        execInContainerByPodName(pod.metadata.name, pod.metadata.namespace, "kill 1")
+        def cmds = ["sh", "-c", "kill -15 1"] as String[]
+        execInContainerByPodName(pod.metadata.name, pod.metadata.namespace, cmds)
         log.debug "Killed pod ${pod.metadata.name}"
         return waitForPodRestart(pod.metadata.namespace, pod.metadata.name, prevRestartCount, 25, 5)
     }
@@ -1824,7 +1825,7 @@ class Kubernetes implements OrchestratorMain {
         Misc/Helper Methods
     */
 
-    boolean execInContainerByPodName(String name, String namespace, String cmd, int retries = 1) {
+    boolean execInContainerByPodName(String name, String namespace, String[] splitCmd, int retries = 1) {
         // Wait for container 0 to be running first.
         def timer = new Timer(retries, 1)
         while (timer.IsValid()) {
@@ -1881,13 +1882,7 @@ class Kubernetes implements OrchestratorMain {
             }
         }
 
-        final String[] splitCmd = CommandLine.parse(cmd).with {
-            final List<String> result = new ArrayList()
-            result.add(it.getExecutable())
-            result.addAll(it.getArguments())
-            return result as String[]
-        }
-        log.debug("Exec-ing the following command in pod {}: {}", name, cmd)
+        log.debug("Exec-ing the following command in pod {}: {}", name, splitCmd)
         try {
             final ExecWatch execCmd = client.pods()
                     .inNamespace(namespace)
@@ -1918,6 +1913,16 @@ class Kubernetes implements OrchestratorMain {
             log.warn("Error exec-ing command in pod", e)
         }
         return execStatus == ExecStatus.SUCCESS
+    }
+
+    boolean execInContainerByPodName(String name, String namespace, String cmd, int retries = 1) {
+        String[] splitCmd = CommandLine.parse(cmd).with {
+            final List<String> result = new ArrayList()
+            result.add(it.getExecutable())
+            result.addAll(it.getArguments())
+            return result as String[]
+        }
+        return execInContainerByPodName(name, namespace, splitCmd, retries)
     }
 
     private enum ExecStatus {


### PR DESCRIPTION
Changing tests to restart pods with kill via shell sh -c kill 1 instead of kill 1. Due to the central images not containing kill binary in PATH. This error was seen when testing central with test case TLSChallengeTest on s390x and power. This change will use the built in shell command for kill, if no binary is found.

Remake of pr https://github.com/stackrox/stackrox/pull/5534
