### PR TITLE
Pass current filters and current search context to workload cve autocomplete

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities.tsx
@@ -164,7 +164,12 @@ function DeploymentPageVulnerabilities({ deploymentId }: DeploymentPageVulnerabi
                 component="div"
             >
                 <div className="pf-u-px-sm pf-u-background-color-100">
-                    <WorkloadTableToolbar supportedResourceFilters={deploymentResourceFilters} />
+                    <WorkloadTableToolbar
+                        autocompleteSearchContext={{
+                            'Deployment ID': deploymentId,
+                        }}
+                        supportedResourceFilters={deploymentResourceFilters}
+                    />
                 </div>
                 <div className="pf-u-flex-grow-1 pf-u-background-color-100">
                     <div className="pf-u-px-lg pf-u-pb-lg">

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
@@ -210,7 +210,12 @@ function ImagePageVulnerabilities({ imageId }: ImagePageVulnerabilitiesProps) {
                 component="div"
             >
                 <div className="pf-u-px-sm pf-u-background-color-100">
-                    <WorkloadTableToolbar supportedResourceFilters={imageResourceFilters} />
+                    <WorkloadTableToolbar
+                        supportedResourceFilters={imageResourceFilters}
+                        autocompleteSearchContext={{
+                            'Image SHA': imageId,
+                        }}
+                    />
                 </div>
                 <div className="pf-u-flex-grow-1 pf-u-background-color-100">{mainContent}</div>
             </PageSection>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
@@ -309,7 +309,12 @@ function ImageCvePage() {
             <PageSection className="pf-u-display-flex pf-u-flex-direction-column pf-u-flex-grow-1">
                 <div className="pf-u-background-color-100">
                     <div className="pf-u-px-sm">
-                        <WorkloadTableToolbar supportedResourceFilters={imageCveResourceFilters} />
+                        <WorkloadTableToolbar
+                            supportedResourceFilters={imageCveResourceFilters}
+                            autocompleteSearchContext={{
+                                'CVE ID': cveId,
+                            }}
+                        />
                     </div>
                     <div className="pf-u-px-lg pf-u-pb-lg">
                         {summaryRequest.error && (

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/FilterAutocomplete.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/FilterAutocomplete.tsx
@@ -11,6 +11,7 @@ import FilterResourceDropdown, {
     Resource,
     resources,
 } from './FilterResourceDropdown';
+import { parseQuerySearchFilter } from '../searchUtils';
 
 function getOptions(data: string[] | undefined): React.ReactElement[] | undefined {
     return data?.map((value) => <SelectOption key={value} value={value} />);
@@ -40,6 +41,11 @@ export type FilterAutocompleteSelectProps = {
     setSearchFilter: (s) => void;
     supportedResourceFilters?: FilterResourceDropdownProps['supportedResourceFilters'];
     onDeleteGroup: (category) => void;
+    autocompleteSearchContext?:
+        | { 'Image SHA': string }
+        | { 'Deployment ID': string }
+        | { 'CVE ID': string }
+        | Record<string, never>;
 };
 
 function FilterAutocompleteSelect({
@@ -47,14 +53,25 @@ function FilterAutocompleteSelect({
     setSearchFilter,
     supportedResourceFilters,
     onDeleteGroup,
+    autocompleteSearchContext = {},
 }: FilterAutocompleteSelectProps) {
+    const querySearchFilter = parseQuerySearchFilter(searchFilter);
     const [resource, setResource] = useState<Resource>(
         () => resources.find((r) => supportedResourceFilters?.has(r)) ?? 'DEPLOYMENT'
     );
     const [typeahead, setTypeahead] = useState('');
     const { isOpen, onToggle } = useSelectToggle();
+
+    // TODO Autocomplete requests for "Cluster" never return results if there is a 'CVE ID' or 'Severity' search filter
+    // included in the query. In this case we don't include the additional filters at all which leaves the cluster results
+    // unfiltered. Not ideal, but better than no results.
+    const autocompleteSearchFilter =
+        resource === 'CLUSTER' && autocompleteSearchContext['CVE ID']
+            ? { [resource]: typeahead }
+            : { ...autocompleteSearchContext, ...querySearchFilter, [resource]: typeahead };
+
     const variables = {
-        query: getAutocompleteOptionsQueryString({ [resource]: typeahead }),
+        query: getAutocompleteOptionsQueryString(autocompleteSearchFilter),
         categories: getSearchCategoriesForAutocomplete(resource),
     };
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/WorkloadTableToolbar.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/WorkloadTableToolbar.tsx
@@ -19,11 +19,13 @@ type FilterType = 'Severity' | 'Fixable';
 type WorkloadTableToolbarProps = {
     defaultFilters?: DefaultFilters;
     supportedResourceFilters?: FilterAutocompleteSelectProps['supportedResourceFilters'];
+    autocompleteSearchContext?: FilterAutocompleteSelectProps['autocompleteSearchContext'];
 };
 
 function WorkloadTableToolbar({
     defaultFilters = emptyDefaultFilters,
     supportedResourceFilters,
+    autocompleteSearchContext,
 }: WorkloadTableToolbarProps) {
     const { searchFilter, setSearchFilter } = useURLSearch();
     const searchSeverity = (searchFilter.Severity as VulnerabilitySeverityLabel[]) || [];
@@ -91,6 +93,7 @@ function WorkloadTableToolbar({
                     setSearchFilter={setSearchFilter}
                     supportedResourceFilters={supportedResourceFilters}
                     onDeleteGroup={onDeleteGroup}
+                    autocompleteSearchContext={autocompleteSearchContext}
                 />
                 <ToolbarGroup>
                     <CVESeverityDropdown searchFilter={searchFilter} onSelect={onSelect} />


### PR DESCRIPTION
## Description

When sending requests to the autocomplete API for the Workload CVE entity search box, we now pass
1. All currently applied search filters
2. The current value of the user's entered text
3. The ID and resource type of the current page context

This makes the autocomplete dropdown only display entries that are valid according to data that will exist in the table below it.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

ImageCVE page:

Suggested images only match items in the table:
![image](https://github.com/stackrox/stackrox/assets/1292638/5f6d4ebe-ad44-4721-b6f1-ff30a9a4cd0a)

Suggested deployments only match items in the table:
![image](https://github.com/stackrox/stackrox/assets/1292638/9d22d596-75e2-4bc9-977b-a77933e288af)

Suggested namespaces:
![image](https://github.com/stackrox/stackrox/assets/1292638/dd595da3-7be8-4463-a970-98a6d1576e01)

Suggested clusters:
**This does not work, passing any other filter results in an empty array response. The alternative is to not pass filters specifically for "cluster", which will always return all results.**

Suggested data when filtered by CVE:
No filter
![image](https://github.com/stackrox/stackrox/assets/1292638/34604d40-53e9-4622-a714-6792ff708ff4)
CVE Severity = Moderate, Autocomplete does not show previous items with "Low" severity:
![image](https://github.com/stackrox/stackrox/assets/1292638/487c48e5-69dc-4424-9f4c-0d373b5ed855)


Image page:

Suggested data when filtered by CVE Severity and Fixability - only displays possible CVEs
![image](https://github.com/stackrox/stackrox/assets/1292638/041c58ce-f887-42f0-af20-d0171853827b)


Deployment page:
Same check for CVE suggestions as image page:
![image](https://github.com/stackrox/stackrox/assets/1292638/e318663d-25a3-4b07-ac69-6712d6999208)

Suggested images when the deployment has multiple images and a CVE filter is applied that only impacts a single image:
![image](https://github.com/stackrox/stackrox/assets/1292638/6f7bff8c-414e-4acc-b976-cb62e12feda2)



