### PR TITLE
Use new gql query to correctly scope CVE images and deployments on cve single page

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedImagesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedImagesTable.tsx
@@ -109,7 +109,7 @@ function AffectedImagesTable({ images, getSortParams, isFiltered }: AffectedImag
                     <Th>First discovered</Th>
                 </Tr>
             </Thead>
-            {images.length === 0 && <EmptyTableResults colSpan={7} />}
+            {images.length === 0 && <EmptyTableResults colSpan={8} />}
             {images.map((image, rowIndex) => {
                 const { id, name, operatingSystem, scanTime, imageComponents } = image;
                 const topSeverity = getHighestVulnerabilitySeverity(imageComponents);


### PR DESCRIPTION
## Description

Uses the updated graphql resolvers to scope images and deployments under a top level `imageCVE` resolver in order to avoid incorrect responses.

Previously on the CVE single page, images and deployments were queried at the top level with a CVE filter passed as a query string. The problem with this approach is that the query `images(query: "CVE ID:CVE-1234+Fixable:false")` is interpreted as all images that contain CVE-1234 **or** contain a CVE that is not fixable. The fixability and CVE ID are executed as a disjunction with the search query language which is not what the page is asking for.

Old query format:
```graphql
query oldQuery {
    images(query: "CVE ID:CVE-1234+Fixable:false") {}
}
```

New query format:
```graphql
query newQuery {
    imageCVE(cve: "CVE-1234", subfieldScopeQuery: "Fixable:false") {
        cve
        images {}
    }
}
```

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Before change, visit a CVE where all images are either fixable or not fixable in context of the CVE:
![image](https://github.com/stackrox/stackrox/assets/1292638/bb797c9e-797c-4bb8-a5eb-7d39264b5a53)
Apply the inverse fixability filter:
![image](https://github.com/stackrox/stackrox/assets/1292638/52bb90ce-705e-4ccd-b2b2-46c374a9f426)

After this change:
![image](https://github.com/stackrox/stackrox/assets/1292638/e14473af-6d8a-4adf-9d54-10f0a9e7fba8)
![image](https://github.com/stackrox/stackrox/assets/1292638/f321e3c7-bb61-4529-840c-944a8336d6d7)

