### PR TITLE
ROX-17028: Network policies tab for namespaces keeps re-rendering

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/common/NetworkPolicies.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/common/NetworkPolicies.tsx
@@ -20,6 +20,7 @@ import download from 'utils/download';
 import SelectSingle from 'Components/SelectSingle';
 import { useTheme } from 'Containers/ThemeProvider';
 import useFetchNetworkPolicies from 'hooks/useFetchNetworkPolicies';
+import useWhyDidYouUpdate from '../hooks/useWhyDidYouUpdate';
 
 type NetworkPoliciesProps = {
     entityName: string;
@@ -33,14 +34,17 @@ type NetworkPolicyYAML = {
 
 const allNetworkPoliciesId = 'network-policy-combined-yaml-pf-key';
 
-function NetworkPolicies({ entityName, policyIds }: NetworkPoliciesProps): React.ReactElement {
+function NetworkPolicies(props: NetworkPoliciesProps): React.ReactElement {
+    useWhyDidYouUpdate('NetworkPolicies', props);
+    const { entityName, policyIds } = props;
+
     const { networkPolicies, isLoading, error } = useFetchNetworkPolicies(policyIds);
     const { isDarkMode } = useTheme();
     const [customDarkMode, setCustomDarkMode] = React.useState(isDarkMode);
 
     const allNetworkPoliciesYAML = useMemo(
         () => ({
-            name: allNetworkPoliciesId,
+            name: 'All network policies',
             yaml: networkPolicies.map((networkPolicy) => networkPolicy.yaml).join('---\n'),
         }),
         [networkPolicies]
@@ -126,7 +130,9 @@ function NetworkPolicies({ entityName, policyIds }: NetworkPoliciesProps): React
                         handleSelect={handleSelectedNetworkPolicy}
                         placeholderText="Select a network policy"
                     >
-                        <SelectOption value="all">All network policies</SelectOption>
+                        <SelectOption value={allNetworkPoliciesId}>
+                            All network policies
+                        </SelectOption>
                         <Divider component="li" />
                         <>
                             {networkPolicies.map((networkPolicy) => {
@@ -168,4 +174,4 @@ function NetworkPolicies({ entityName, policyIds }: NetworkPoliciesProps): React
     );
 }
 
-export default NetworkPolicies;
+export default React.memo(NetworkPolicies);

--- a/ui/apps/platform/src/Containers/NetworkGraph/hooks/useWhyDidYouUpdate.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/hooks/useWhyDidYouUpdate.ts
@@ -1,0 +1,34 @@
+import { useRef, useEffect } from 'react';
+
+function useWhyDidYouUpdate(name, props) {
+    // Get a mutable ref object where we can store props ...
+    // ... for comparison next time this hook runs.
+    const previousProps = useRef<any>();
+    useEffect(() => {
+        if (previousProps.current) {
+            // Get all keys from previous and current props
+            const allKeys = Object.keys({ ...previousProps.current, ...props });
+            // Use this object to keep track of changed props
+            const changesObj = {};
+            // Iterate through keys
+            allKeys.forEach((key) => {
+                // If previous is different from current
+                if (previousProps.current[key] !== props[key]) {
+                    // Add to changesObj
+                    changesObj[key] = {
+                        from: previousProps.current[key],
+                        to: props[key],
+                    };
+                }
+            });
+            // If changesObj not empty then output to console
+            if (Object.keys(changesObj).length) {
+                console.log('[why-did-you-update]', name, changesObj);
+            }
+        }
+        // Finally update previousProps with current props for next hook call
+        previousProps.current = props;
+    });
+}
+
+export default useWhyDidYouUpdate;

--- a/ui/apps/platform/src/Containers/NetworkGraph/namespace/NamespaceSideBar.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/namespace/NamespaceSideBar.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import {
     Flex,
     FlexItem,
@@ -43,6 +43,7 @@ function NamespaceSideBar({ namespaceId, nodes, edges, onNodeSelect }: Namespace
     const namespaceNode = getNodeById(nodes, namespaceId);
     const deploymentNodes = getDeploymentNodesInNamespace(nodes, namespaceId);
     const cluster = namespaceNode?.data.type === 'NAMESPACE' ? namespaceNode.data.cluster : '';
+    const namespaceName = namespaceNode?.label || '';
 
     const deployments = deploymentNodes.map((deploymentNode) => {
         const numFlows = getNumDeploymentFlows(edges, deploymentNode.id);
@@ -56,7 +57,8 @@ function NamespaceSideBar({ namespaceId, nodes, edges, onNodeSelect }: Namespace
         const policyIds: string[] = curr?.data?.policyIds || [];
         return [...acc, ...policyIds];
     }, [] as string[]);
-    const uniqueNamespacePolicyIds = uniq(namespacePolicyIds);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    const uniqueNamespacePolicyIds = useMemo(() => uniq(namespacePolicyIds), [namespaceId, nodes]);
 
     return (
         <Stack>
@@ -68,7 +70,7 @@ function NamespaceSideBar({ namespaceId, nodes, edges, onNodeSelect }: Namespace
                     <FlexItem>
                         <TextContent>
                             <Text component={TextVariants.h1} className="pf-u-font-size-xl">
-                                {namespaceNode?.label}
+                                {namespaceName}
                             </Text>
                         </TextContent>
                         <TextContent>
@@ -113,7 +115,7 @@ function NamespaceSideBar({ namespaceId, nodes, edges, onNodeSelect }: Namespace
                     className="pf-u-h-100"
                 >
                     <NetworkPolicies
-                        entityName={namespaceNode?.label || ''}
+                        entityName={namespaceName}
                         policyIds={uniqueNamespacePolicyIds}
                     />
                 </TabContent>


### PR DESCRIPTION
## Description

Draft PR for what I figured out so far with this issue. One thing to note is that the `NetworkPolicies` component might be updating because of the value for the `policyIds` prop being recomputed (an array of strings).

Also, don't work about the hook I made. I wanted to check why it was being re-rendered. Not going to be added to the source code