### PR TITLE
CI: Combine OOM checks for junit2jira

### DIFF
--- a/tests/e2e/bats/check_for_stackrox_OOMs.bats
+++ b/tests/e2e/bats/check_for_stackrox_OOMs.bats
@@ -19,10 +19,8 @@ load "../../../scripts/test_helpers.bats"
     assert_output --partial tests=\"2\"
     assert_output --partial failures=\"1\"
 
-    # Sensor has a result
-    assert_output --regexp '<testcase name="Check for sensor OOM kills" classname="OOM Check">.+</testcase>'
-    # But not a failure
-    refute_output --regexp '<testcase name="Check for sensor OOM kills" classname="OOM Check">.+failure.+</testcase>'
-    # Central was a failure
-    assert_output --regexp '<testcase name="Check for central OOM kills" classname="OOM Check">.+failure.+</testcase>'
+    # Sensor has a non failure result
+    assert_output --regexp '<testcase name="Check for sensor OOM kills" classname="OOM Check">\s+</testcase>'
+    # Central has a failure result
+    assert_output --regexp '<testcase name="Check for central OOM kills" classname="OOM Check">\s+<failure><..CDATA.A container of central was OOM killed..></failure>\s+</testcase>'
 }

--- a/tests/e2e/bats/check_for_stackrox_OOMs.bats
+++ b/tests/e2e/bats/check_for_stackrox_OOMs.bats
@@ -11,16 +11,18 @@ load "../../../scripts/test_helpers.bats"
     source "${BATS_TEST_DIRNAME}/../lib.sh"
 
     run check_for_stackrox_OOMs "${BATS_TEST_TMPDIR}/oom-test"
-
-    with_oomkilled_test="$(ls ${ARTIFACT_DIR}/junit-misc/junit-OOMCheck-central-84bf956f94-bg6hr.xml)"
-    assert [ -f "$with_oomkilled_test" ]
-    run grep -q "was OOMKilled" "$with_oomkilled_test"
     assert_success
 
-    without_oomkilled_test="$(ls ${ARTIFACT_DIR}/junit-misc/junit-OOMCheck-sensor-67d98c67bf-v688m.xml)"
-    assert [ -f "$without_oomkilled_test" ]
-    run grep -q "was not OOMKilled" "$without_oomkilled_test"
+    run cat "${ARTIFACT_DIR}/junit-misc/junit-OOM Check.xml"
     assert_success
 
-    refute [ -f "${ARTIFACT_DIR}/junit-.xml" ]
+    assert_output --partial tests=\"2\"
+    assert_output --partial failures=\"1\"
+
+    # Sensor has a result
+    assert_output --regexp '<testcase name="Check for sensor OOM kills" classname="OOM Check">.+</testcase>'
+    # But not a failure
+    refute_output --regexp '<testcase name="Check for sensor OOM kills" classname="OOM Check">.+failure.+</testcase>'
+    # Central was a failure
+    assert_output --regexp '<testcase name="Check for central OOM kills" classname="OOM Check">.+failure.+</testcase>'
 }


### PR DESCRIPTION
## Description

In this way OOM checks failures for each app will go to a app specific JIRA which is easier to manage than a new JIRA for each OOM instance.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

Tested with a previously spotted OOM:

```
$ rm -rf ttt/*; (ARTIFACT_DIR=ttt; source ~/go/src/github.com/stackrox/stackrox/tests/e2e/lib.sh; check_for_stackrox_OOMs part-1/k8s-service-logs)
INFO: Wed May 24 14:40:36 PDT 2023: Checking part-1/k8s-service-logs/stackrox/pods/admission-control-784d6fdbf-57g2q_object.json for OOMKilled
INFO: Wed May 24 14:40:36 PDT 2023: Checking part-1/k8s-service-logs/stackrox/pods/admission-control-784d6fdbf-gvll2_object.json for OOMKilled
INFO: Wed May 24 14:40:37 PDT 2023: Checking part-1/k8s-service-logs/stackrox/pods/admission-control-784d6fdbf-rpbjz_object.json for OOMKilled
INFO: Wed May 24 14:40:37 PDT 2023: Checking part-1/k8s-service-logs/stackrox/pods/central-6574b9f978-2vtxg_object.json for OOMKilled
INFO: Wed May 24 14:40:37 PDT 2023: Checking part-1/k8s-service-logs/stackrox/pods/central-db-55d9fcc7d9-r5nj9_object.json for OOMKilled
INFO: Wed May 24 14:40:37 PDT 2023: Checking part-1/k8s-service-logs/stackrox/pods/collector-27vqh_object.json for OOMKilled
INFO: Wed May 24 14:40:37 PDT 2023: Checking part-1/k8s-service-logs/stackrox/pods/collector-4tz29_object.json for OOMKilled
INFO: Wed May 24 14:40:37 PDT 2023: Checking part-1/k8s-service-logs/stackrox/pods/collector-gj6zd_object.json for OOMKilled
INFO: Wed May 24 14:40:37 PDT 2023: Checking part-1/k8s-service-logs/stackrox/pods/collector-hcsk7_object.json for OOMKilled
INFO: Wed May 24 14:40:37 PDT 2023: Checking part-1/k8s-service-logs/stackrox/pods/collector-rcblq_object.json for OOMKilled
INFO: Wed May 24 14:40:37 PDT 2023: Checking part-1/k8s-service-logs/stackrox/pods/collector-ttbwh_object.json for OOMKilled
INFO: Wed May 24 14:40:37 PDT 2023: Checking part-1/k8s-service-logs/stackrox/pods/collector-wstvw_object.json for OOMKilled
INFO: Wed May 24 14:40:37 PDT 2023: Checking part-1/k8s-service-logs/stackrox/pods/scanner-6b567d876b-qhcvx_object.json for OOMKilled
INFO: Wed May 24 14:40:37 PDT 2023: Checking part-1/k8s-service-logs/stackrox/pods/scanner-db-6d559fb6b9-jf6ks_object.json for OOMKilled
INFO: Wed May 24 14:40:37 PDT 2023: Checking part-1/k8s-service-logs/stackrox/pods/sensor-64cf5cfdd7-59x2b_object.json for OOMKilled
INFO: Wed May 24 14:40:37 PDT 2023: Checking part-1/k8s-service-logs/stackrox/pods/webhookserver-58f4468f7d-8wzk6_object.json for OOMKilled
```

Produces:
```
$ cat ttt/junit-misc/junit-OOM\ Check.xml 
<testsuite name="OOM Check" tests="16" skipped="0" failures="1" errors="0">
        <testcase name="Check for admission-control OOM kills" classname="OOM Check">
        </testcase>
        <testcase name="Check for admission-control OOM kills" classname="OOM Check">
        </testcase>
        <testcase name="Check for admission-control OOM kills" classname="OOM Check">
        </testcase>
        <testcase name="Check for central OOM kills" classname="OOM Check">
        </testcase>
        <testcase name="Check for central-db OOM kills" classname="OOM Check">
        </testcase>
        <testcase name="Check for collector OOM kills" classname="OOM Check">
        </testcase>
        <testcase name="Check for collector OOM kills" classname="OOM Check">
        </testcase>
        <testcase name="Check for collector OOM kills" classname="OOM Check">
        </testcase>
        <testcase name="Check for collector OOM kills" classname="OOM Check">
        </testcase>
        <testcase name="Check for collector OOM kills" classname="OOM Check">
        </testcase>
        <testcase name="Check for collector OOM kills" classname="OOM Check">
        </testcase>
        <testcase name="Check for collector OOM kills" classname="OOM Check">
        </testcase>
        <testcase name="Check for scanner OOM kills" classname="OOM Check">
            <failure><![CDATA[A container of scanner was OOM killed]]></failure>
        </testcase>
        <testcase name="Check for scanner-db OOM kills" classname="OOM Check">
        </testcase>
        <testcase name="Check for sensor OOM kills" classname="OOM Check">
        </testcase>
        <testcase name="Check for webhookserver OOM kills" classname="OOM Check">
        </testcase>
</testsuite>
```

