### PR TITLE
ROX-16869: reconcile declarative notifiers

### DIFF
--- a/central/declarativeconfig/manager_impl.go
+++ b/central/declarativeconfig/manager_impl.go
@@ -91,7 +91,7 @@ func New(reconciliationTickerDuration, watchIntervalDuration time.Duration, upda
 	writeDeclarativeRoleCtx = sac.WithGlobalAccessScopeChecker(writeDeclarativeRoleCtx,
 		sac.AllowFixedScopes(
 			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
-			sac.ResourceScopeKeys(resources.Access)))
+			sac.ResourceScopeKeys(resources.Access, resources.Integration)))
 	return &managerImpl{
 		universalTransformer:           transform.New(),
 		transformedMessagesByHandler:   map[string]protoMessagesByType{},

--- a/central/declarativeconfig/manager_impl.go
+++ b/central/declarativeconfig/manager_impl.go
@@ -79,6 +79,7 @@ var protoTypesOrder = []reflect.Type{
 	types.RoleType,
 	types.AuthProviderType,
 	types.GroupType,
+	types.NotifierType,
 }
 
 // New creates a new instance of Manager.

--- a/central/declarativeconfig/types/accepted_types.go
+++ b/central/declarativeconfig/types/accepted_types.go
@@ -17,4 +17,6 @@ var (
 	PermissionSetType = reflect.TypeOf((*storage.PermissionSet)(nil))
 	// RoleType reflects the type of storage.Role.
 	RoleType = reflect.TypeOf((*storage.Role)(nil))
+	// NotifierType reflects the type of storage.Notifier.
+	NotifierType = reflect.TypeOf((*storage.Notifier)(nil))
 )

--- a/central/declarativeconfig/updater/notifier_updater.go
+++ b/central/declarativeconfig/updater/notifier_updater.go
@@ -52,7 +52,7 @@ func (u *notifierUpdater) Upsert(ctx context.Context, m proto.Message) error {
 	}
 	notifier, err := notifiers.CreateNotifier(notifierProto)
 	if err != nil {
-		return errox.InvalidArgs.CauseBy(err)
+		return errox.InvalidArgs.CausedBy(err)
 	}
 	u.processor.UpdateNotifier(ctx, notifier)
 

--- a/central/declarativeconfig/updater/notifier_updater.go
+++ b/central/declarativeconfig/updater/notifier_updater.go
@@ -1,0 +1,106 @@
+package updater
+
+import (
+	"context"
+
+	"github.com/gogo/protobuf/proto"
+	"github.com/hashicorp/go-multierror"
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/central/declarativeconfig/types"
+	declarativeCfgUtils "github.com/stackrox/rox/central/declarativeconfig/utils"
+	notifierDataStore "github.com/stackrox/rox/central/notifier/datastore"
+	"github.com/stackrox/rox/central/notifier/policycleaner"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/declarativeconfig"
+	"github.com/stackrox/rox/pkg/errox"
+	"github.com/stackrox/rox/pkg/integrationhealth"
+	"github.com/stackrox/rox/pkg/notifier"
+	"github.com/stackrox/rox/pkg/notifiers"
+	"github.com/stackrox/rox/pkg/set"
+)
+
+type notifierUpdater struct {
+	notifierDS    notifierDataStore.DataStore
+	reporter      integrationhealth.Reporter
+	idExtractor   types.IDExtractor
+	nameExtractor types.NameExtractor
+	processor     notifier.Processor
+	policyCleaner policycleaner.PolicyCleaner
+}
+
+var _ ResourceUpdater = (*notifierUpdater)(nil)
+
+func newNotifierUpdater(notifierDS notifierDataStore.DataStore, policyCleaner policycleaner.PolicyCleaner, processor notifier.Processor, reporter integrationhealth.Reporter) ResourceUpdater {
+	return &notifierUpdater{
+		notifierDS:    notifierDS,
+		policyCleaner: policyCleaner,
+		processor:     processor,
+		reporter:      reporter,
+		idExtractor:   types.UniversalIDExtractor(),
+		nameExtractor: types.UniversalNameExtractor(),
+	}
+}
+
+func (u *notifierUpdater) Upsert(ctx context.Context, m proto.Message) error {
+	notifierProto, ok := m.(*storage.Notifier)
+	if !ok {
+		return errox.InvariantViolation.Newf("wrong type passed to role updater: %T", notifierProto)
+	}
+	// TODO: replace with Upsert
+	_, err := u.notifierDS.AddNotifier(ctx, notifierProto)
+	if err != nil {
+		return err
+	}
+	notifier, err := notifiers.CreateNotifier(notifierProto)
+	if err != nil {
+		return errors.Wrap(errox.InvalidArgs, err.Error())
+	}
+	u.processor.UpdateNotifier(ctx, notifier)
+
+	return u.reporter.Register(notifierProto.GetId(), notifierProto.GetName(), storage.IntegrationHealth_NOTIFIER)
+}
+
+func (u *notifierUpdater) DeleteResources(ctx context.Context, resourceIDsToSkip ...string) ([]string, error) {
+	notifiersToSkip := set.NewFrozenStringSet(resourceIDsToSkip...)
+
+	notifiers, err := u.notifierDS.GetNotifiersFiltered(ctx, func(n *storage.Notifier) bool {
+		return declarativeconfig.IsDeclarativeOrigin(n) &&
+			!notifiersToSkip.Contains(n.GetId())
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "retrieving declarative notifiers")
+	}
+
+	var notifierDeletionErr *multierror.Error
+	var notifierIDs []string
+	for _, n := range notifiers {
+		err = u.policyCleaner.DeleteNotifierFromPolicies(n.GetId())
+		if err != nil {
+			err := errors.Wrap(err, "deleting notifier from policies")
+			notifierDeletionErr, notifierIDs = u.processDeletionError(notifierDeletionErr, err, notifierIDs, n)
+			continue
+		}
+
+		if err := u.notifierDS.RemoveNotifier(ctx, n.GetId()); err != nil {
+			err := errors.Wrap(err, "deleting notifier from database")
+			notifierDeletionErr, notifierIDs = u.processDeletionError(notifierDeletionErr, err, notifierIDs, n)
+			continue
+		}
+
+		u.processor.RemoveNotifier(ctx, n.GetId())
+		if err := u.reporter.RemoveIntegrationHealth(n.GetId()); err != nil {
+			err := errors.Wrap(err, "deleting notifier's integration health")
+			notifierDeletionErr, notifierIDs = u.processDeletionError(notifierDeletionErr, err, notifierIDs, n)
+		}
+	}
+	return notifierIDs, notifierDeletionErr.ErrorOrNil()
+}
+
+func (u *notifierUpdater) processDeletionError(notifierDeletionErr *multierror.Error, err error, notifierIDs []string, notifier *storage.Notifier) (*multierror.Error, []string) {
+	notifierDeletionErr = multierror.Append(notifierDeletionErr, err)
+	notifierIDs = append(notifierIDs, notifier.GetId())
+
+	u.reporter.UpdateIntegrationHealthAsync(declarativeCfgUtils.IntegrationHealthForProtoMessage(notifier, "", err,
+		u.idExtractor, u.nameExtractor))
+	return notifierDeletionErr, notifierIDs
+}

--- a/central/declarativeconfig/updater/notifier_updater.go
+++ b/central/declarativeconfig/updater/notifier_updater.go
@@ -46,8 +46,7 @@ func (u *notifierUpdater) Upsert(ctx context.Context, m proto.Message) error {
 	if !ok {
 		return errox.InvariantViolation.Newf("wrong type passed to role updater: %T", notifierProto)
 	}
-	// TODO: replace with Upsert
-	_, err := u.notifierDS.AddNotifier(ctx, notifierProto)
+	_, err := u.notifierDS.UpsertNotifier(ctx, notifierProto)
 	if err != nil {
 		return err
 	}

--- a/central/declarativeconfig/updater/updater.go
+++ b/central/declarativeconfig/updater/updater.go
@@ -9,6 +9,9 @@ import (
 	"github.com/stackrox/rox/central/declarativeconfig/types"
 	groupDataStore "github.com/stackrox/rox/central/group/datastore"
 	"github.com/stackrox/rox/central/integrationhealth/reporter"
+	notifierDataStore "github.com/stackrox/rox/central/notifier/datastore"
+	"github.com/stackrox/rox/central/notifier/policycleaner"
+	notifierProcessor "github.com/stackrox/rox/central/notifier/processor"
 	roleDatastore "github.com/stackrox/rox/central/role/datastore"
 	"github.com/stackrox/rox/pkg/auth/authproviders"
 )
@@ -34,5 +37,6 @@ func DefaultResourceUpdaters(registry authproviders.Registry) map[reflect.Type]R
 		types.RoleType:          newRoleUpdater(roleDatastore.Singleton(), groupDataStore.Singleton(), reporter.Singleton()),
 		types.PermissionSetType: newPermissionSetUpdater(roleDatastore.Singleton(), reporter.Singleton()),
 		types.AccessScopeType:   newAccessScopeUpdater(roleDatastore.Singleton(), reporter.Singleton()),
+		types.NotifierType:      newNotifierUpdater(notifierDataStore.Singleton(), policycleaner.Singleton(), notifierProcessor.Singleton(), reporter.Singleton()),
 	}
 }

--- a/central/notifier/datastore/datastore.go
+++ b/central/notifier/datastore/datastore.go
@@ -19,6 +19,7 @@ type DataStore interface {
 	Exists(ctx context.Context, id string) (bool, error)
 	AddNotifier(ctx context.Context, notifier *storage.Notifier) (string, error)
 	UpdateNotifier(ctx context.Context, notifier *storage.Notifier) error
+	UpsertNotifier(ctx context.Context, notifier *storage.Notifier) (string, error)
 	RemoveNotifier(ctx context.Context, id string) error
 }
 

--- a/central/notifier/datastore/datastore.go
+++ b/central/notifier/datastore/datastore.go
@@ -13,6 +13,7 @@ import (
 type DataStore interface {
 	GetNotifier(ctx context.Context, id string) (*storage.Notifier, bool, error)
 	GetScrubbedNotifier(ctx context.Context, id string) (*storage.Notifier, bool, error)
+	GetNotifiersFiltered(ctx context.Context, filter func(notifier *storage.Notifier) bool) ([]*storage.Notifier, error)
 	GetNotifiers(ctx context.Context) ([]*storage.Notifier, error)
 	GetScrubbedNotifiers(ctx context.Context) ([]*storage.Notifier, error)
 	Exists(ctx context.Context, id string) (bool, error)

--- a/central/notifier/datastore/datastore_impl.go
+++ b/central/notifier/datastore/datastore_impl.go
@@ -62,6 +62,7 @@ func (b *datastoreImpl) GetNotifiersFiltered(ctx context.Context, filter func(no
 	if err := sac.VerifyAuthzOK(integrationSAC.ReadAllowed(ctx)); err != nil {
 		return nil, err
 	}
+	// TODO: ROX-16071 add ability to pass filter to storage
 	notifiers, err := b.storage.GetAll(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "getting notifiers from storage")

--- a/central/notifier/datastore/datastore_impl.go
+++ b/central/notifier/datastore/datastore_impl.go
@@ -33,7 +33,19 @@ func (b *datastoreImpl) UpsertNotifier(ctx context.Context, notifier *storage.No
 	b.lock.Lock()
 	defer b.lock.Unlock()
 
-	// TODO: forbid declarative modifications via API
+	existing, exists, err := b.GetNotifier(ctx, notifier.GetId())
+	if err != nil {
+		return "", err
+	}
+	if exists {
+		if err = verifyNotifierOrigin(ctx, existing); err != nil {
+			return "", errors.Wrap(err, "origin didn't match for existing notifier")
+		}
+	}
+	if err = verifyNotifierOrigin(ctx, notifier); err != nil {
+		return "", errors.Wrap(err, "origin didn't match for new notifier")
+	}
+
 	return notifier.GetId(), b.storage.Upsert(ctx, notifier)
 }
 

--- a/central/notifier/datastore/datastore_impl.go
+++ b/central/notifier/datastore/datastore_impl.go
@@ -34,6 +34,23 @@ func verifyNotifierOrigin(ctx context.Context, n *storage.Notifier) error {
 	return nil
 }
 
+func (b *datastoreImpl) GetNotifiersFiltered(ctx context.Context, filter func(notifier *storage.Notifier) bool) ([]*storage.Notifier, error) {
+	if err := sac.VerifyAuthzOK(integrationSAC.ReadAllowed(ctx)); err != nil {
+		return nil, err
+	}
+	notifiers, err := b.storage.GetAll(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "getting notifiers from storage")
+	}
+	result := make([]*storage.Notifier, 0)
+	for _, n := range notifiers {
+		if filter(n) {
+			result = append(result, n)
+		}
+	}
+	return result, nil
+}
+
 func (b *datastoreImpl) GetNotifier(ctx context.Context, id string) (*storage.Notifier, bool, error) {
 	if ok, err := integrationSAC.ReadAllowed(ctx); err != nil {
 		return nil, false, err

--- a/central/notifier/datastore/datastore_impl.go
+++ b/central/notifier/datastore/datastore_impl.go
@@ -66,7 +66,7 @@ func (b *datastoreImpl) GetNotifiersFiltered(ctx context.Context, filter func(no
 	if err != nil {
 		return nil, errors.Wrap(err, "getting notifiers from storage")
 	}
-	result := make([]*storage.Notifier, 0)
+	result := make([]*storage.Notifier, 0, len(notifiers))
 	for _, n := range notifiers {
 		if filter(n) {
 			result = append(result, n)

--- a/central/notifier/datastore/datastore_impl.go
+++ b/central/notifier/datastore/datastore_impl.go
@@ -25,6 +25,18 @@ type datastoreImpl struct {
 	storage store.Store
 }
 
+func (b *datastoreImpl) UpsertNotifier(ctx context.Context, notifier *storage.Notifier) (string, error) {
+	if err := sac.VerifyAuthzOK(integrationSAC.WriteAllowed(ctx)); err != nil {
+		return "", err
+	}
+
+	b.lock.Lock()
+	defer b.lock.Unlock()
+
+	// TODO: forbid declarative modifications via API
+	return notifier.GetId(), b.storage.Upsert(ctx, notifier)
+}
+
 func verifyNotifierOrigin(ctx context.Context, n *storage.Notifier) error {
 	if !declarativeconfig.CanModifyResource(ctx, n) {
 		return errox.NotAuthorized.Newf("notifier %q's origin is %s, "+

--- a/central/notifier/datastore/mocks/datastore.go
+++ b/central/notifier/datastore/mocks/datastore.go
@@ -96,6 +96,21 @@ func (mr *MockDataStoreMockRecorder) GetNotifiers(ctx interface{}) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNotifiers", reflect.TypeOf((*MockDataStore)(nil).GetNotifiers), ctx)
 }
 
+// GetNotifiersFiltered mocks base method.
+func (m *MockDataStore) GetNotifiersFiltered(ctx context.Context, filter func(*storage.Notifier) bool) ([]*storage.Notifier, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetNotifiersFiltered", ctx, filter)
+	ret0, _ := ret[0].([]*storage.Notifier)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetNotifiersFiltered indicates an expected call of GetNotifiersFiltered.
+func (mr *MockDataStoreMockRecorder) GetNotifiersFiltered(ctx, filter interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNotifiersFiltered", reflect.TypeOf((*MockDataStore)(nil).GetNotifiersFiltered), ctx, filter)
+}
+
 // GetScrubbedNotifier mocks base method.
 func (m *MockDataStore) GetScrubbedNotifier(ctx context.Context, id string) (*storage.Notifier, bool, error) {
 	m.ctrl.T.Helper()
@@ -153,4 +168,19 @@ func (m *MockDataStore) UpdateNotifier(ctx context.Context, notifier *storage.No
 func (mr *MockDataStoreMockRecorder) UpdateNotifier(ctx, notifier interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateNotifier", reflect.TypeOf((*MockDataStore)(nil).UpdateNotifier), ctx, notifier)
+}
+
+// UpsertNotifier mocks base method.
+func (m *MockDataStore) UpsertNotifier(ctx context.Context, notifier *storage.Notifier) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpsertNotifier", ctx, notifier)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpsertNotifier indicates an expected call of UpsertNotifier.
+func (mr *MockDataStoreMockRecorder) UpsertNotifier(ctx, notifier interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertNotifier", reflect.TypeOf((*MockDataStore)(nil).UpsertNotifier), ctx, notifier)
 }

--- a/central/notifier/policycleaner/clean_policy.go
+++ b/central/notifier/policycleaner/clean_policy.go
@@ -2,6 +2,7 @@ package policycleaner
 
 import "github.com/stackrox/rox/central/detection"
 
+// PolicyCleaner removes notifier from policies.
 type PolicyCleaner struct {
 	buildTimePolicies  detection.PolicySet
 	deployTimePolicies detection.PolicySet

--- a/central/notifier/policycleaner/clean_policy.go
+++ b/central/notifier/policycleaner/clean_policy.go
@@ -9,6 +9,7 @@ type PolicyCleaner struct {
 	runTimePolicies    detection.PolicySet
 }
 
+// DeleteNotifierFromPolicies removes notifier from policies.
 func (s *PolicyCleaner) DeleteNotifierFromPolicies(notifierID string) error {
 	err := s.buildTimePolicies.RemoveNotifier(notifierID)
 	if err != nil {

--- a/central/notifier/policycleaner/clean_policy.go
+++ b/central/notifier/policycleaner/clean_policy.go
@@ -11,18 +11,15 @@ type PolicyCleaner struct {
 
 // DeleteNotifierFromPolicies removes notifier from policies.
 func (p *PolicyCleaner) DeleteNotifierFromPolicies(notifierID string) error {
-	err := s.buildTimePolicies.RemoveNotifier(notifierID)
-	if err != nil {
+	if err := p.buildTimePolicies.RemoveNotifier(notifierID); err != nil {
 		return err
 	}
 
-	err = s.deployTimePolicies.RemoveNotifier(notifierID)
-	if err != nil {
+	if err := p.deployTimePolicies.RemoveNotifier(notifierID); err != nil {
 		return err
 	}
 
-	err = s.runTimePolicies.RemoveNotifier(notifierID)
-	if err != nil {
+	if err := p.runTimePolicies.RemoveNotifier(notifierID); err != nil {
 		return err
 	}
 

--- a/central/notifier/policycleaner/clean_policy.go
+++ b/central/notifier/policycleaner/clean_policy.go
@@ -10,7 +10,7 @@ type PolicyCleaner struct {
 }
 
 // DeleteNotifierFromPolicies removes notifier from policies.
-func (s *PolicyCleaner) DeleteNotifierFromPolicies(notifierID string) error {
+func (p *PolicyCleaner) DeleteNotifierFromPolicies(notifierID string) error {
 	err := s.buildTimePolicies.RemoveNotifier(notifierID)
 	if err != nil {
 		return err

--- a/central/notifier/policycleaner/clean_policy.go
+++ b/central/notifier/policycleaner/clean_policy.go
@@ -1,0 +1,28 @@
+package policycleaner
+
+import "github.com/stackrox/rox/central/detection"
+
+type PolicyCleaner struct {
+	buildTimePolicies  detection.PolicySet
+	deployTimePolicies detection.PolicySet
+	runTimePolicies    detection.PolicySet
+}
+
+func (s *PolicyCleaner) DeleteNotifierFromPolicies(notifierID string) error {
+	err := s.buildTimePolicies.RemoveNotifier(notifierID)
+	if err != nil {
+		return err
+	}
+
+	err = s.deployTimePolicies.RemoveNotifier(notifierID)
+	if err != nil {
+		return err
+	}
+
+	err = s.runTimePolicies.RemoveNotifier(notifierID)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/central/notifier/policycleaner/singleton.go
+++ b/central/notifier/policycleaner/singleton.go
@@ -1,0 +1,28 @@
+package policycleaner
+
+import (
+	buildTimeDetection "github.com/stackrox/rox/central/detection/buildtime"
+	deployTimeDetection "github.com/stackrox/rox/central/detection/deploytime"
+	runTimeDetection "github.com/stackrox/rox/central/detection/runtime"
+	"github.com/stackrox/rox/pkg/sync"
+)
+
+var (
+	once sync.Once
+
+	pc PolicyCleaner
+)
+
+func initialize() {
+	pc = PolicyCleaner{
+		buildTimePolicies:  buildTimeDetection.SingletonPolicySet(),
+		deployTimePolicies: deployTimeDetection.SingletonPolicySet(),
+		runTimePolicies:    runTimeDetection.SingletonPolicySet(),
+	}
+}
+
+// Singleton provides the instance of the Service interface to register.
+func Singleton() PolicyCleaner {
+	once.Do(initialize)
+	return pc
+}

--- a/central/notifier/service/service.go
+++ b/central/notifier/service/service.go
@@ -3,8 +3,8 @@ package service
 import (
 	"context"
 
-	"github.com/stackrox/rox/central/detection"
 	"github.com/stackrox/rox/central/notifier/datastore"
+	"github.com/stackrox/rox/central/notifier/policycleaner"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/pkg/grpc"
 	"github.com/stackrox/rox/pkg/integrationhealth"
@@ -28,16 +28,12 @@ type Service interface {
 // New returns a new Service instance using the given DataStore.
 func New(storage datastore.DataStore,
 	processor notifier.Processor,
-	buildTimePolicies detection.PolicySet,
-	deployTimePolicies detection.PolicySet,
-	runTimePolicies detection.PolicySet,
+	policyCleaner policycleaner.PolicyCleaner,
 	reporter integrationhealth.Reporter) Service {
 	return &serviceImpl{
-		storage:            storage,
-		processor:          processor,
-		buildTimePolicies:  buildTimePolicies,
-		deployTimePolicies: deployTimePolicies,
-		runTimePolicies:    runTimePolicies,
-		reporter:           reporter,
+		storage:       storage,
+		processor:     processor,
+		policyCleaner: policyCleaner,
+		reporter:      reporter,
 	}
 }

--- a/central/notifier/service/singleton.go
+++ b/central/notifier/service/singleton.go
@@ -1,11 +1,9 @@
 package service
 
 import (
-	buildTimeDetection "github.com/stackrox/rox/central/detection/buildtime"
-	deployTimeDetection "github.com/stackrox/rox/central/detection/deploytime"
-	runTimeDetection "github.com/stackrox/rox/central/detection/runtime"
 	"github.com/stackrox/rox/central/integrationhealth/reporter"
 	"github.com/stackrox/rox/central/notifier/datastore"
+	"github.com/stackrox/rox/central/notifier/policycleaner"
 	"github.com/stackrox/rox/central/notifier/processor"
 	"github.com/stackrox/rox/pkg/sync"
 )
@@ -20,9 +18,7 @@ func initialize() {
 	as = New(
 		datastore.Singleton(),
 		processor.Singleton(),
-		buildTimeDetection.SingletonPolicySet(),
-		deployTimeDetection.SingletonPolicySet(),
-		runTimeDetection.SingletonPolicySet(),
+		policycleaner.Singleton(),
 		reporter.Singleton(),
 	)
 }

--- a/pkg/declarativeconfig/configuration.go
+++ b/pkg/declarativeconfig/configuration.go
@@ -28,6 +28,7 @@ func supportedConfigurationTypes() string {
 		AccessScopeConfiguration,
 		PermissionSetConfiguration,
 		RoleConfiguration,
+		NotifierConfiguration,
 	}, ",")
 }
 
@@ -72,7 +73,7 @@ func fromUnstructured(unstructured interface{}) (Configuration, error) {
 		return nil, errors.Wrap(err, "marshalling unstructured configuration")
 	}
 
-	configs := []Configuration{&AuthProvider{}, &AccessScope{}, &PermissionSet{}, &Role{}}
+	configs := []Configuration{&AuthProvider{}, &AccessScope{}, &PermissionSet{}, &Role{}, &Notifier{}}
 	for _, c := range configs {
 		err := decodeYAMLToConfiguration(rawConfiguration, c)
 		if err == nil {

--- a/pkg/declarativeconfig/transform/notifier_test.go
+++ b/pkg/declarativeconfig/transform/notifier_test.go
@@ -18,6 +18,17 @@ func TestWrongConfigurationTypeTransformNotifier(t *testing.T) {
 	assert.ErrorIs(t, err, errox.InvalidArgs)
 }
 
+func TestNoConfigTransformNotifier(t *testing.T) {
+	notifier := &declarativeconfig.Notifier{
+		Name: "test-notifier",
+	}
+	transformer := newNotifierTransform()
+	protos, err := transformer.Transform(notifier)
+	assert.Nil(t, protos)
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, errox.InvalidArgs)
+}
+
 func TestTransformGenericNotifier(t *testing.T) {
 	notifier := &declarativeconfig.Notifier{
 		Name: "test-notifier",


### PR DESCRIPTION
## Description

Reconcile declarative notifiers(create/update/delete).
Policies are cleaned from deleted notifiers same as in API to be consistent.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

TBD
