### PR TITLE
update docs 3.73.5

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "docs/content"]
 	path = docs/content
 	url = https://github.com/openshift/openshift-docs.git
-	branch = rhacs-docs-3.73.4
+	branch = rhacs-docs-3.73.5
 [submodule "docs/tools"]
 	path = docs/tools
 	url = https://github.com/stackrox/docs-tools.git


### PR DESCRIPTION
## Description

Update docs for 3.73.5 - automation failed because branch did not exist.
Failed build: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/branch-ci-stackrox-stackrox-release-3.73-merge-push-and-release/1661385121825034240. 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

CI is sufficient.