### PR TITLE
ROX-16876: `roxctl declarative-config create notifier *` commands

### DIFF
--- a/central/declarativeconfig/manager_impl_test.go
+++ b/central/declarativeconfig/manager_impl_test.go
@@ -511,7 +511,7 @@ func TestUpdateDeclarativeConfigContents_Errors(t *testing.T) {
 		Name:         "Config Map my-cool-config-map",
 		Type:         storage.IntegrationHealth_DECLARATIVE_CONFIG,
 		Status:       storage.IntegrationHealth_UNHEALTHY,
-		ErrorMessage: "could not unmarshal configuration into any of the supported types [auth-provider,access-scope,permission-set,role]",
+		ErrorMessage: "could not unmarshal configuration into any of the supported types [auth-provider,access-scope,permission-set,role,notifier]",
 	}))
 
 	m.UpdateDeclarativeConfigContents("/some/config/dir/to/my-cool-config-map", [][]byte{

--- a/pkg/declarativeconfig/configuration.go
+++ b/pkg/declarativeconfig/configuration.go
@@ -28,6 +28,7 @@ func supportedConfigurationTypes() string {
 		AccessScopeConfiguration,
 		PermissionSetConfiguration,
 		RoleConfiguration,
+		NotifierConfiguration,
 	}, ",")
 }
 
@@ -72,7 +73,7 @@ func fromUnstructured(unstructured interface{}) (Configuration, error) {
 		return nil, errors.Wrap(err, "marshalling unstructured configuration")
 	}
 
-	configs := []Configuration{&AuthProvider{}, &AccessScope{}, &PermissionSet{}, &Role{}}
+	configs := []Configuration{&AuthProvider{}, &AccessScope{}, &PermissionSet{}, &Role{}, &Notifier{}}
 	for _, c := range configs {
 		err := decodeYAMLToConfiguration(rawConfiguration, c)
 		if err == nil {

--- a/roxctl/declarativeconfig/create/create.go
+++ b/roxctl/declarativeconfig/create/create.go
@@ -18,6 +18,7 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 		authProviderCommand(cliEnvironment),
 		permissionSetCommand(cliEnvironment),
 		roleCommand(cliEnvironment),
+		notifierCommand(cliEnvironment),
 	)
 
 	c.PersistentFlags().String(k8sobject.ConfigMapFlag, "", `Config Map to which the declarative config YAML should be written to.

--- a/roxctl/declarativeconfig/create/notifier.go
+++ b/roxctl/declarativeconfig/create/notifier.go
@@ -192,7 +192,10 @@ func (n *notifierCmd) construct(cmd *cobra.Command) error {
 
 func (n *notifierCmd) validate() error {
 	if _, err := url.Parse(n.gc.Endpoint); err != nil {
-		return errox.InvalidArgs.New("parsing notifier endpoint URL").CausedBy(err)
+		return errox.InvalidArgs.New("parsing notifier webhook endpoint URL").CausedBy(err)
+	}
+	if _, err := url.Parse(n.sc.HTTPEndpoint); err != nil {
+		return errox.InvalidArgs.New("parsing notifier Splunk endpoint URL").CausedBy(err)
 	}
 	if n.sc.HTTPEndpoint == "" && n.sc.HTTPToken != "" {
 		return errox.InvalidArgs.New("missing endpoint")

--- a/roxctl/declarativeconfig/create/notifier.go
+++ b/roxctl/declarativeconfig/create/notifier.go
@@ -3,21 +3,23 @@ package create
 import (
 	"bytes"
 	"context"
+	"encoding/pem"
 	"fmt"
+	"io/ioutil"
+	"net/url"
+	"sort"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/stackrox/rox/pkg/declarativeconfig"
 	"github.com/stackrox/rox/pkg/errox"
+	"github.com/stackrox/rox/pkg/maputil"
 	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/rox/roxctl/common/environment"
 	"github.com/stackrox/rox/roxctl/declarativeconfig/k8sobject"
+	"github.com/stackrox/rox/roxctl/declarativeconfig/lint"
 	"gopkg.in/yaml.v3"
-)
-
-var (
-	errInvalidPair = errox.InvalidArgs.New("invalid key-value pair")
 )
 
 func notifierCommand(cliEnvironment environment.Environment) *cobra.Command {
@@ -26,39 +28,40 @@ func notifierCommand(cliEnvironment environment.Environment) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   notifierCommand.notifier.Type(),
 		Args:  cobra.NoArgs,
-		RunE:  notifierCommand.RunE(),
+		RunE:  notifierCommand.runE(),
 		Short: "Create a declarative configuration for a notifier",
 	}
 
-	cmd.Flags().StringVar(&notifierCommand.notifier.Name, "name", "", "name of the notifier")
+	cmd.Flags().StringVar(&notifierCommand.notifier.Name, "name", "", "Name of the notifier")
 
 	genericFlags := pflag.NewFlagSet("generic", pflag.PanicOnError)
 	notifierCommand.gc = &declarativeconfig.GenericConfig{}
-	genericFlags.BoolVar(&notifierCommand.gc.AuditLoggingEnabled, "audit-logging", false, "Audit logging enabled")
-	genericFlags.StringVar(&notifierCommand.gc.Endpoint, "endpoint", "", "Endpoint")
-	genericFlags.StringVar(&notifierCommand.gc.Username, "username", "", "Username")
-	genericFlags.StringVar(&notifierCommand.gc.Password, "password", "", "Password")
-	genericFlags.StringVar(&notifierCommand.gc.CACertPEM, "cacert", "", "CA certificate file name")
+	genericFlags.BoolVar(&notifierCommand.gc.AuditLoggingEnabled, "audit-logging", false, "Notifier audit logging enabled")
+	genericFlags.StringVar(&notifierCommand.gc.Endpoint, "endpoint", "", "Endpoint URL")
+	genericFlags.StringVar(&notifierCommand.gc.Username, "username", "", "Username for the endpoint basic authentication")
+	genericFlags.StringVar(&notifierCommand.gc.Password, "password", "", "Password for the endpoint basic authentication")
+	genericFlags.StringVar(&notifierCommand.gc.CACertPEM, "cacert", "", "Endpoint CA certificate file name (PEM format)")
 	genericFlags.StringToStringVar(&notifierCommand.gcHeaders, "headers", nil, "Headers (comma separated key=value pairs)")
 	genericFlags.StringToStringVar(&notifierCommand.gcExtraFields, "extra-fields", nil, "Extra fields (comma separated key=value pairs)")
 	genericFlags.BoolVar(&notifierCommand.gc.SkipTLSVerify, "skip-tls-verify", false, "Skip TLS verification")
 	notifierCommand.genericFlagSet = genericFlags
+	cmd.Flags().AddFlagSet(genericFlags)
 
 	splunkFlags := pflag.NewFlagSet("splunk", pflag.PanicOnError)
 	notifierCommand.sc = &declarativeconfig.SplunkConfig{}
+	splunkFlags.BoolVar(&notifierCommand.sc.AuditLoggingEnabled, "splunk-audit-logging", false, "Splunk audit logging enabled")
 	splunkFlags.StringVar(&notifierCommand.sc.HTTPToken, "splunk-token", "", "Splunk HTTP token")
 	splunkFlags.StringVar(&notifierCommand.sc.HTTPEndpoint, "splunk-endpoint", "", "Splunk HTTP endpoint")
 	splunkFlags.BoolVar(&notifierCommand.sc.Insecure, "splunk-insecure", false, "Insecure connection to Splunk")
-	splunkFlags.BoolVar(&notifierCommand.sc.AuditLoggingEnabled, "splunk-audit-logging", false, "Audit logging enabled")
 	splunkFlags.Int64Var(&notifierCommand.sc.Truncate, "splunk-truncate", 0, "Splunk truncate limit")
 	splunkFlags.StringToStringVar(&notifierCommand.scSourceTypes, "splunk-source-types", nil, "Splunk source types")
 	notifierCommand.splunkFlagSet = splunkFlags
 
-	cmd.Flags().AddFlagSet(genericFlags)
 	cmd.Flags().AddFlagSet(splunkFlags)
-	// No additional validation is required for notifiers, since a notifier
-	// is valid when name is set, which is covered by requiring the flag.
+
+	utils.Must(cmd.MarkFlagFilename("cacert"))
 	utils.Must(cmd.MarkFlagRequired("name"))
+	utils.Must(cmd.MarkFlagRequired("endpoint"))
 	return cmd
 }
 
@@ -81,26 +84,48 @@ type notifierCmd struct {
 	namespace string
 }
 
-func (n *notifierCmd) RunE() func(cmd *cobra.Command, args []string) error {
+func (n *notifierCmd) runE() func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {
-		if err := n.Construct(cmd); err != nil {
+		if err := n.construct(cmd); err != nil {
 			return err
 		}
-		return n.PrintYAML()
+		if err := n.validate(); err != nil {
+			return err
+		}
+		return n.printYAML()
 	}
 }
 
 func anyFlagChanged(fs *pflag.FlagSet) bool {
+	if fs == nil {
+		return false
+	}
 	var changed bool
-	fs.VisitAll(func(f *pflag.Flag) {
-		if f.Changed {
-			changed = true
-		}
-	})
+	fs.VisitAll(func(f *pflag.Flag) { changed = changed || f.Changed })
 	return changed
 }
 
-func (n *notifierCmd) Construct(cmd *cobra.Command) error {
+func loadCertficate(path string) (string, error) {
+	raw, err := ioutil.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+
+	for {
+		block, rest := pem.Decode(raw)
+		if block == nil {
+			break
+		}
+		if block.Type == "CERTIFICATE" {
+			return (string)(block.Bytes), nil
+		}
+		raw = rest
+	}
+
+	return "", errox.InvalidArgs.Newf("no certificate found in \"%s\"", path)
+}
+
+func (n *notifierCmd) construct(cmd *cobra.Command) error {
 	configMap, secret, namespace, err := k8sobject.ReadK8sObjectFlags(cmd)
 	if err != nil {
 		return errors.Wrap(err, "reading config map flag values")
@@ -110,29 +135,54 @@ func (n *notifierCmd) Construct(cmd *cobra.Command) error {
 	n.namespace = namespace
 
 	if anyFlagChanged(n.genericFlagSet) {
-		for k, v := range n.gcHeaders {
-			n.gc.Headers = append(n.gc.Headers, declarativeconfig.KeyValuePair{k, v})
+		keys := maputil.Keys(n.gcHeaders)
+		sort.Strings(keys)
+		for _, k := range keys {
+			n.gc.Headers = append(n.gc.Headers, declarativeconfig.KeyValuePair{k, n.gcHeaders[k]})
 		}
-		for k, v := range n.gcExtraFields {
-			n.gc.ExtraFields = append(n.gc.ExtraFields, declarativeconfig.KeyValuePair{k, v})
+		keys = maputil.Keys(n.gcExtraFields)
+		sort.Strings(keys)
+		for _, k := range keys {
+			n.gc.ExtraFields = append(n.gc.ExtraFields, declarativeconfig.KeyValuePair{k, n.gcExtraFields[k]})
+		}
+
+		if n.gc.CACertPEM != "" {
+			if n.gc.CACertPEM, err = loadCertficate(n.gc.CACertPEM); err != nil {
+				return errors.Wrap(err, "reading CA certificate file")
+			}
 		}
 		n.notifier.GenericConfig = n.gc
 	}
 
 	if anyFlagChanged(n.splunkFlagSet) {
-		for k, v := range n.scSourceTypes {
-			n.sc.SourceTypes = append(n.sc.SourceTypes, declarativeconfig.SourceTypePair{k, v})
+		keys := maputil.Keys(n.scSourceTypes)
+		sort.Strings(keys)
+		for _, k := range keys {
+			n.sc.SourceTypes = append(n.sc.SourceTypes, declarativeconfig.SourceTypePair{k, n.scSourceTypes[k]})
 		}
 		n.notifier.SplunkConfig = n.sc
 	}
 	return nil
 }
 
-func (n *notifierCmd) PrintYAML() error {
+func (n *notifierCmd) validate() error {
+	if _, err := url.Parse(n.gc.Endpoint); err != nil {
+		return errox.InvalidArgs.New("parsing notifier endpoint URL").CausedBy(err)
+	}
+	if n.sc.HTTPEndpoint == "" && n.sc.HTTPToken != "" {
+		return errox.InvalidArgs.New("missing splunk-endpoint")
+	}
+	return nil
+}
+
+func (n *notifierCmd) printYAML() error {
 	yamlOutput := &bytes.Buffer{}
 	enc := yaml.NewEncoder(yamlOutput)
 	if err := enc.Encode(n.notifier); err != nil {
 		return errors.Wrap(err, "creating the YAML output")
+	}
+	if err := lint.Lint(yamlOutput.Bytes()); err != nil {
+		return errors.Wrap(err, "linting the YAML output")
 	}
 	if n.configMap != "" || n.secret != "" {
 		return errors.Wrap(k8sobject.WriteToK8sObject(context.Background(), n.configMap, n.secret, n.namespace,

--- a/roxctl/declarativeconfig/create/notifier.go
+++ b/roxctl/declarativeconfig/create/notifier.go
@@ -50,7 +50,7 @@ func (n *notifierCmd) genericCommand() *cobra.Command {
 	}
 	genericFlags := cmd.Flags()
 	n.gc = &declarativeconfig.GenericConfig{}
-	genericFlags.BoolVar(&n.gc.AuditLoggingEnabled, "audit-logging", false, "Notifier audit logging enabled")
+	genericFlags.BoolVar(&n.gc.AuditLoggingEnabled, "audit-logging", false, "Audit logging enabled")
 	genericFlags.StringVar(&n.gc.Endpoint, "webhook-endpoint", "", "Webhook endpoint URL")
 	genericFlags.StringVar(&n.gc.Username, "webhook-username", "", "Username for the endpoint basic authentication")
 	genericFlags.StringVar(&n.gc.Password, "webhook-password", "", "Password for the endpoint basic authentication")
@@ -78,7 +78,7 @@ func (n *notifierCmd) splunkCommand() *cobra.Command {
 
 	splunkFlags := cmd.Flags()
 	n.sc = &declarativeconfig.SplunkConfig{}
-	splunkFlags.BoolVar(&n.sc.AuditLoggingEnabled, "audit-logging", false, "Splunk audit logging enabled")
+	splunkFlags.BoolVar(&n.sc.AuditLoggingEnabled, "audit-logging", false, "Audit logging enabled")
 	splunkFlags.StringVar(&n.sc.HTTPToken, "splunk-token", "", "Splunk HTTP token")
 	splunkFlags.StringVar(&n.sc.HTTPEndpoint, "splunk-endpoint", "", "Splunk HTTP endpoint")
 	splunkFlags.BoolVar(&n.sc.Insecure, "splunk-insecure-skip-tls-verify", false, "Insecure connection to Splunk")

--- a/roxctl/declarativeconfig/create/notifier.go
+++ b/roxctl/declarativeconfig/create/notifier.go
@@ -50,18 +50,29 @@ func (n *notifierCmd) genericCommand() *cobra.Command {
 	}
 	genericFlags := cmd.Flags()
 	n.gc = &declarativeconfig.GenericConfig{}
-	genericFlags.BoolVar(&n.gc.AuditLoggingEnabled, "audit-logging", false, "Audit logging enabled")
-	genericFlags.StringVar(&n.gc.Endpoint, "webhook-endpoint", "", "Webhook endpoint URL")
-	genericFlags.StringVar(&n.gc.Username, "webhook-username", "", "Username for the endpoint basic authentication")
-	genericFlags.StringVar(&n.gc.Password, "webhook-password", "", "Password for the endpoint basic authentication")
-	genericFlags.StringVar(&n.gc.CACertPEM, "webhook-cacert-file", "", "Endpoint CA certificate file name (PEM format)")
-	genericFlags.StringToStringVar(&n.gcHeaders, "headers", nil, "Headers (comma separated key=value pairs)")
-	genericFlags.StringToStringVar(&n.gcExtraFields, "extra-fields", nil, "Extra fields (comma separated key=value pairs)")
-	genericFlags.BoolVar(&n.gc.SkipTLSVerify, "webhook-insecure-skip-tls-verify", false, "Skip TLS verification")
+	genericFlags.BoolVar(&n.gc.AuditLoggingEnabled, "audit-logging", false,
+		"Audit logging enabled")
+	genericFlags.StringVar(&n.gc.Endpoint, "webhook-endpoint", "",
+		"Webhook endpoint URL")
+	genericFlags.StringVar(&n.gc.Username, "webhook-username", "",
+		"Username for the webhook endpoint basic authentication. "+
+			"No authentication if not provided. Requires --webhook-password")
+	genericFlags.StringVar(&n.gc.Password, "webhook-password", "",
+		"Password for the webhook endpoint basic authentication. "+
+			"No authentication if not provided. Requires --webhook-username")
+	genericFlags.StringVar(&n.gc.CACertPEM, "webhook-cacert-file", "",
+		"Endpoint CA certificate file name (PEM format)")
+	genericFlags.StringToStringVar(&n.gcHeaders, "headers", nil,
+		"Headers (comma separated key=value pairs)")
+	genericFlags.StringToStringVar(&n.gcExtraFields, "extra-fields", nil,
+		"Extra fields (comma separated key=value pairs)")
+	genericFlags.BoolVar(&n.gc.SkipTLSVerify, "webhook-insecure-skip-tls-verify", false,
+		"Skip webhook TLS verification")
 	n.genericFlagSet = genericFlags
 
 	cmd.Flags().AddFlagSet(genericFlags)
 
+	cmd.MarkFlagsRequiredTogether("webhook-username", "webhook-password")
 	utils.Must(cmd.MarkFlagFilename("webhook-cacert-file"))
 	utils.Must(cmd.MarkFlagRequired("webhook-endpoint"))
 	return cmd
@@ -78,16 +89,24 @@ func (n *notifierCmd) splunkCommand() *cobra.Command {
 
 	splunkFlags := cmd.Flags()
 	n.sc = &declarativeconfig.SplunkConfig{}
-	splunkFlags.BoolVar(&n.sc.AuditLoggingEnabled, "audit-logging", false, "Audit logging enabled")
-	splunkFlags.StringVar(&n.sc.HTTPToken, "splunk-token", "", "Splunk HTTP token")
-	splunkFlags.StringVar(&n.sc.HTTPEndpoint, "splunk-endpoint", "", "Splunk HTTP endpoint")
-	splunkFlags.BoolVar(&n.sc.Insecure, "splunk-insecure-skip-tls-verify", false, "Insecure connection to Splunk")
-	splunkFlags.Int64Var(&n.sc.Truncate, "truncate", 0, "Splunk truncate limit")
-	splunkFlags.StringToStringVar(&n.scSourceTypes, "source-types", nil, "Splunk source types (comma separated key=value pairs)")
+	splunkFlags.BoolVar(&n.sc.AuditLoggingEnabled, "audit-logging", false,
+		"Audit logging enabled")
+	splunkFlags.StringVar(&n.sc.HTTPToken, "splunk-token", "",
+		"Splunk HTTP token (required)")
+	splunkFlags.StringVar(&n.sc.HTTPEndpoint, "splunk-endpoint", "",
+		"Splunk HTTP endpoint (required)")
+	splunkFlags.BoolVar(&n.sc.Insecure, "splunk-insecure-skip-tls-verify", false,
+		"Insecure connection to Splunk")
+	splunkFlags.Int64Var(&n.sc.Truncate, "truncate", 0,
+		"Splunk truncate limit")
+	splunkFlags.StringToStringVar(&n.scSourceTypes, "source-types", nil,
+		"Splunk source types (comma separated key=value pairs)")
 	n.splunkFlagSet = splunkFlags
 
 	cmd.Flags().AddFlagSet(splunkFlags)
 
+	utils.Must(cmd.MarkFlagRequired("splunk-endpoint"))
+	utils.Must(cmd.MarkFlagRequired("splunk-token"))
 	return cmd
 }
 

--- a/roxctl/declarativeconfig/create/notifier.go
+++ b/roxctl/declarativeconfig/create/notifier.go
@@ -5,8 +5,8 @@ import (
 	"context"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"net/url"
+	"os"
 	"sort"
 
 	"github.com/pkg/errors"
@@ -131,9 +131,9 @@ func anyFlagChanged(fs *pflag.FlagSet) bool {
 }
 
 func loadCertficate(path string) (string, error) {
-	raw, err := ioutil.ReadFile(path)
+	raw, err := os.ReadFile(path)
 	if err != nil {
-		return "", err
+		return "", errors.Wrap(err, "reading certificate file")
 	}
 
 	for {
@@ -163,12 +163,12 @@ func (n *notifierCmd) construct(cmd *cobra.Command) error {
 		keys := maputil.Keys(n.gcHeaders)
 		sort.Strings(keys)
 		for _, k := range keys {
-			n.gc.Headers = append(n.gc.Headers, declarativeconfig.KeyValuePair{k, n.gcHeaders[k]})
+			n.gc.Headers = append(n.gc.Headers, declarativeconfig.KeyValuePair{Key: k, Value: n.gcHeaders[k]})
 		}
 		keys = maputil.Keys(n.gcExtraFields)
 		sort.Strings(keys)
 		for _, k := range keys {
-			n.gc.ExtraFields = append(n.gc.ExtraFields, declarativeconfig.KeyValuePair{k, n.gcExtraFields[k]})
+			n.gc.ExtraFields = append(n.gc.ExtraFields, declarativeconfig.KeyValuePair{Key: k, Value: n.gcExtraFields[k]})
 		}
 
 		if n.gc.CACertPEM != "" {
@@ -183,7 +183,7 @@ func (n *notifierCmd) construct(cmd *cobra.Command) error {
 		keys := maputil.Keys(n.scSourceTypes)
 		sort.Strings(keys)
 		for _, k := range keys {
-			n.sc.SourceTypes = append(n.sc.SourceTypes, declarativeconfig.SourceTypePair{k, n.scSourceTypes[k]})
+			n.sc.SourceTypes = append(n.sc.SourceTypes, declarativeconfig.SourceTypePair{Key: k, Value: n.scSourceTypes[k]})
 		}
 		n.notifier.SplunkConfig = n.sc
 	}

--- a/roxctl/declarativeconfig/create/notifier.go
+++ b/roxctl/declarativeconfig/create/notifier.go
@@ -1,0 +1,146 @@
+package create
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/stackrox/rox/pkg/declarativeconfig"
+	"github.com/stackrox/rox/pkg/errox"
+	"github.com/stackrox/rox/pkg/utils"
+	"github.com/stackrox/rox/roxctl/common/environment"
+	"github.com/stackrox/rox/roxctl/declarativeconfig/k8sobject"
+	"gopkg.in/yaml.v3"
+)
+
+var (
+	errInvalidPair = errox.InvalidArgs.New("invalid key-value pair")
+)
+
+func notifierCommand(cliEnvironment environment.Environment) *cobra.Command {
+	notifierCommand := &notifierCmd{notifier: &declarativeconfig.Notifier{}, env: cliEnvironment}
+
+	cmd := &cobra.Command{
+		Use:   notifierCommand.notifier.Type(),
+		Args:  cobra.NoArgs,
+		RunE:  notifierCommand.RunE(),
+		Short: "Create a declarative configuration for a notifier",
+	}
+
+	cmd.Flags().StringVar(&notifierCommand.notifier.Name, "name", "", "name of the notifier")
+
+	genericFlags := pflag.NewFlagSet("generic", pflag.PanicOnError)
+	notifierCommand.gc = &declarativeconfig.GenericConfig{}
+	genericFlags.BoolVar(&notifierCommand.gc.AuditLoggingEnabled, "audit-logging", false, "Audit logging enabled")
+	genericFlags.StringVar(&notifierCommand.gc.Endpoint, "endpoint", "", "Endpoint")
+	genericFlags.StringVar(&notifierCommand.gc.Username, "username", "", "Username")
+	genericFlags.StringVar(&notifierCommand.gc.Password, "password", "", "Password")
+	genericFlags.StringVar(&notifierCommand.gc.CACertPEM, "cacert", "", "CA certificate file name")
+	genericFlags.StringToStringVar(&notifierCommand.gcHeaders, "headers", nil, "Headers (comma separated key=value pairs)")
+	genericFlags.StringToStringVar(&notifierCommand.gcExtraFields, "extra-fields", nil, "Extra fields (comma separated key=value pairs)")
+	genericFlags.BoolVar(&notifierCommand.gc.SkipTLSVerify, "skip-tls-verify", false, "Skip TLS verification")
+	notifierCommand.genericFlagSet = genericFlags
+
+	splunkFlags := pflag.NewFlagSet("splunk", pflag.PanicOnError)
+	notifierCommand.sc = &declarativeconfig.SplunkConfig{}
+	splunkFlags.StringVar(&notifierCommand.sc.HTTPToken, "splunk-token", "", "Splunk HTTP token")
+	splunkFlags.StringVar(&notifierCommand.sc.HTTPEndpoint, "splunk-endpoint", "", "Splunk HTTP endpoint")
+	splunkFlags.BoolVar(&notifierCommand.sc.Insecure, "splunk-insecure", false, "Insecure connection to Splunk")
+	splunkFlags.BoolVar(&notifierCommand.sc.AuditLoggingEnabled, "splunk-audit-logging", false, "Audit logging enabled")
+	splunkFlags.Int64Var(&notifierCommand.sc.Truncate, "splunk-truncate", 0, "Splunk truncate limit")
+	splunkFlags.StringToStringVar(&notifierCommand.scSourceTypes, "splunk-source-types", nil, "Splunk source types")
+	notifierCommand.splunkFlagSet = splunkFlags
+
+	cmd.Flags().AddFlagSet(genericFlags)
+	cmd.Flags().AddFlagSet(splunkFlags)
+	// No additional validation is required for notifiers, since a notifier
+	// is valid when name is set, which is covered by requiring the flag.
+	utils.Must(cmd.MarkFlagRequired("name"))
+	return cmd
+}
+
+type notifierCmd struct {
+	notifier *declarativeconfig.Notifier
+
+	genericFlagSet *pflag.FlagSet
+	splunkFlagSet  *pflag.FlagSet
+
+	gc *declarativeconfig.GenericConfig
+	sc *declarativeconfig.SplunkConfig
+
+	gcHeaders     map[string]string
+	gcExtraFields map[string]string
+	scSourceTypes map[string]string
+
+	env       environment.Environment
+	configMap string
+	secret    string
+	namespace string
+}
+
+func (n *notifierCmd) RunE() func(cmd *cobra.Command, args []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		if err := n.Construct(cmd); err != nil {
+			return err
+		}
+		return n.PrintYAML()
+	}
+}
+
+func anyFlagChanged(fs *pflag.FlagSet) bool {
+	var changed bool
+	fs.VisitAll(func(f *pflag.Flag) {
+		if f.Changed {
+			changed = true
+		}
+	})
+	return changed
+}
+
+func (n *notifierCmd) Construct(cmd *cobra.Command) error {
+	configMap, secret, namespace, err := k8sobject.ReadK8sObjectFlags(cmd)
+	if err != nil {
+		return errors.Wrap(err, "reading config map flag values")
+	}
+	n.configMap = configMap
+	n.secret = secret
+	n.namespace = namespace
+
+	if anyFlagChanged(n.genericFlagSet) {
+		for k, v := range n.gcHeaders {
+			n.gc.Headers = append(n.gc.Headers, declarativeconfig.KeyValuePair{k, v})
+		}
+		for k, v := range n.gcExtraFields {
+			n.gc.ExtraFields = append(n.gc.ExtraFields, declarativeconfig.KeyValuePair{k, v})
+		}
+		n.notifier.GenericConfig = n.gc
+	}
+
+	if anyFlagChanged(n.splunkFlagSet) {
+		for k, v := range n.scSourceTypes {
+			n.sc.SourceTypes = append(n.sc.SourceTypes, declarativeconfig.SourceTypePair{k, v})
+		}
+		n.notifier.SplunkConfig = n.sc
+	}
+	return nil
+}
+
+func (n *notifierCmd) PrintYAML() error {
+	yamlOutput := &bytes.Buffer{}
+	enc := yaml.NewEncoder(yamlOutput)
+	if err := enc.Encode(n.notifier); err != nil {
+		return errors.Wrap(err, "creating the YAML output")
+	}
+	if n.configMap != "" || n.secret != "" {
+		return errors.Wrap(k8sobject.WriteToK8sObject(context.Background(), n.configMap, n.secret, n.namespace,
+			fmt.Sprintf("%s-%s", n.notifier.Type(), n.notifier.Name),
+			yamlOutput.Bytes()), "writing the YAML output to config map")
+	}
+	if _, err := n.env.InputOutput().Out().Write(yamlOutput.Bytes()); err != nil {
+		return errors.Wrap(err, "writing the YAML output")
+	}
+	return nil
+}

--- a/roxctl/declarativeconfig/create/notifier.go
+++ b/roxctl/declarativeconfig/create/notifier.go
@@ -216,9 +216,6 @@ func (n *notifierCmd) validate() error {
 	if _, err := url.Parse(n.sc.HTTPEndpoint); err != nil {
 		return errox.InvalidArgs.New("parsing notifier Splunk endpoint URL").CausedBy(err)
 	}
-	if n.sc.HTTPEndpoint == "" && n.sc.HTTPToken != "" {
-		return errox.InvalidArgs.New("missing endpoint")
-	}
 	return nil
 }
 

--- a/roxctl/declarativeconfig/create/notifier.go
+++ b/roxctl/declarativeconfig/create/notifier.go
@@ -66,7 +66,7 @@ func (n *notifierCmd) genericCommand() *cobra.Command {
 		"Headers (comma separated key=value pairs)")
 	genericFlags.StringToStringVar(&n.gcExtraFields, "extra-fields", nil,
 		"Extra fields (comma separated key=value pairs)")
-	genericFlags.BoolVar(&n.gc.SkipTLSVerify, "webhook-insecure-skip-tls-verify", false,
+	genericFlags.BoolVar(&n.gc.SkipTLSVerify, "webhook-skip-tls-verify", false,
 		"Skip webhook TLS verification")
 	n.genericFlagSet = genericFlags
 
@@ -95,10 +95,10 @@ func (n *notifierCmd) splunkCommand() *cobra.Command {
 		"Splunk HTTP token (required)")
 	splunkFlags.StringVar(&n.sc.HTTPEndpoint, "splunk-endpoint", "",
 		"Splunk HTTP endpoint (required)")
-	splunkFlags.BoolVar(&n.sc.Insecure, "splunk-insecure-skip-tls-verify", false,
+	splunkFlags.BoolVar(&n.sc.Insecure, "splunk-skip-tls-verify", false,
 		"Insecure connection to Splunk")
 	splunkFlags.Int64Var(&n.sc.Truncate, "truncate", 0,
-		"Splunk truncate limit")
+		"Splunk truncate limit (default 10000)")
 	splunkFlags.StringToStringVar(&n.scSourceTypes, "source-types", nil,
 		"Splunk source types (comma separated key=value pairs)")
 	n.splunkFlagSet = splunkFlags

--- a/roxctl/declarativeconfig/create/notifier.go
+++ b/roxctl/declarativeconfig/create/notifier.go
@@ -166,7 +166,7 @@ func loadCertficate(path string) (string, error) {
 		raw = rest
 	}
 
-	return "", errox.InvalidArgs.Newf("no certificate found in \"%s\"", path)
+	return "", errox.InvalidArgs.Newf("no certificate found in %q", path)
 }
 
 func (n *notifierCmd) construct(cmd *cobra.Command) error {

--- a/roxctl/declarativeconfig/create/notifier_test.go
+++ b/roxctl/declarativeconfig/create/notifier_test.go
@@ -16,16 +16,15 @@ func TestCreateNotifier_Failures(t *testing.T) {
 		err    error
 	}{
 		"missing name flag": {
-			args:   []string{"notifier"},
-			errOut: "Error: required flag(s) \"endpoint\", \"name\" not set\n",
+			args:   []string{"notifier", "generic"},
+			errOut: "Error: required flag(s) \"name\", \"webhook-endpoint\" not set\n",
 		},
 		"splunk flags group": {
-			args: []string{"notifier",
+			args: []string{"notifier", "splunk",
 				"--name=some-name",
-				"--endpoint=some-endpoint",
 				"--splunk-token=token",
 			},
-			errOut: `Error: missing splunk-endpoint
+			errOut: `Error: missing endpoint
 `,
 		},
 	}
@@ -59,9 +58,9 @@ func TestCreateNotifier_Success(t *testing.T) {
 		expectedYAML string
 	}{
 		"only name": {
-			args: []string{"notifier",
+			args: []string{"notifier", "generic",
 				"--name=some-name",
-				"--endpoint=some-endpoint",
+				"--webhook-endpoint=some-endpoint",
 			},
 			expectedYAML: `name: some-name
 generic:
@@ -69,9 +68,9 @@ generic:
 `,
 		},
 		"with headers": {
-			args: []string{"notifier",
+			args: []string{"notifier", "generic",
 				"--name=some-name",
-				"--endpoint=some-endpoint",
+				"--webhook-endpoint=some-endpoint",
 				"--headers=k2=v2,k1=v1",
 			},
 			expectedYAML: `name: some-name
@@ -85,15 +84,14 @@ generic:
 `,
 		},
 		"with splunk types": {
-			args: []string{"notifier",
+			args: []string{"notifier", "splunk",
 				"--name=some-name",
-				"--endpoint=some-endpoint",
-				"--splunk-source-types=k2=v2,k1=v1",
+				"--splunk-endpoint=some-endpoint",
+				"--source-types=k2=v2,k1=v1",
 			},
 			expectedYAML: `name: some-name
-generic:
-    endpoint: some-endpoint
 splunk:
+    endpoint: some-endpoint
     sourceTypes:
         - key: k1
           sourceType: v1

--- a/roxctl/declarativeconfig/create/notifier_test.go
+++ b/roxctl/declarativeconfig/create/notifier_test.go
@@ -1,0 +1,156 @@
+package create
+
+import (
+	"testing"
+
+	"github.com/stackrox/rox/roxctl/common/environment/mocks"
+	"github.com/stackrox/rox/roxctl/declarativeconfig/k8sobject"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateNotifier_Failures(t *testing.T) {
+	cases := map[string]struct {
+		args   []string
+		errOut string
+		err    error
+	}{
+		"missing name flag": {
+			args:   []string{"notifier"},
+			errOut: "Error: required flag(s) \"endpoint\", \"name\" not set\n",
+		},
+		"splunk flags group": {
+			args: []string{"notifier",
+				"--name=some-name",
+				"--endpoint=some-endpoint",
+				"--splunk-token=token",
+			},
+			errOut: `Error: missing splunk-endpoint
+`,
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			env, out, errOut := mocks.NewEnvWithConn(nil, t)
+			cmd := Command(env)
+
+			cmd.SetArgs(c.args)
+			cmd.SetErr(errOut)
+			cmd.SetOut(out)
+
+			err := cmd.Execute()
+			assert.Error(t, err)
+
+			if c.err != nil {
+				assert.ErrorIs(t, err, c.err)
+			}
+
+			if c.errOut != "" {
+				assert.Equal(t, c.errOut, errOut.String())
+			}
+		})
+	}
+}
+
+func TestCreateNotifier_Success(t *testing.T) {
+	cases := map[string]struct {
+		args         []string
+		expectedYAML string
+	}{
+		"only name": {
+			args: []string{"notifier",
+				"--name=some-name",
+				"--endpoint=some-endpoint",
+			},
+			expectedYAML: `name: some-name
+generic:
+    endpoint: some-endpoint
+`,
+		},
+		"with headers": {
+			args: []string{"notifier",
+				"--name=some-name",
+				"--endpoint=some-endpoint",
+				"--headers=k2=v2,k1=v1",
+			},
+			expectedYAML: `name: some-name
+generic:
+    endpoint: some-endpoint
+    headers:
+        - key: k1
+          value: v1
+        - key: k2
+          value: v2
+`,
+		},
+		"with splunk types": {
+			args: []string{"notifier",
+				"--name=some-name",
+				"--endpoint=some-endpoint",
+				"--splunk-source-types=k2=v2,k1=v1",
+			},
+			expectedYAML: `name: some-name
+generic:
+    endpoint: some-endpoint
+splunk:
+    sourceTypes:
+        - key: k1
+          sourceType: v1
+        - key: k2
+          sourceType: v2
+`,
+		}}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			env, out, errOut := mocks.NewEnvWithConn(nil, t)
+			cmd := Command(env)
+
+			cmd.SetArgs(c.args)
+			cmd.SetErr(errOut)
+			cmd.SetOut(out)
+
+			err := cmd.Execute()
+			assert.NoError(t, err)
+
+			assert.Empty(t, errOut)
+			assert.Equal(t, c.expectedYAML, out.String())
+		})
+	}
+}
+
+func TestNotifier_WriteToK8sObject(t *testing.T) {
+	cases := map[string]struct {
+		secret                 string
+		configMap              string
+		shouldWriteToK8sObject bool
+	}{
+		"no flag set should not write to k8s object": {},
+		"config map flag set should write to k8s object": {
+			configMap:              "something",
+			shouldWriteToK8sObject: true,
+		},
+		"secret flag set should write to k8s object": {
+			secret:                 "something",
+			shouldWriteToK8sObject: true,
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			env, _, _ := mocks.NewEnvWithConn(nil, t)
+			cmd := Command(env)
+			if c.configMap != "" {
+				require.NoError(t, cmd.Flags().Set(k8sobject.ConfigMapFlag, c.configMap))
+			}
+			if c.secret != "" {
+				require.NoError(t, cmd.Flags().Set(k8sobject.SecretFlag, c.secret))
+			}
+
+			nc := notifierCmd{}
+			require.NoError(t, nc.construct(cmd))
+			assert.Equal(t, c.shouldWriteToK8sObject, nc.configMap != "" || nc.secret != "")
+		})
+	}
+}

--- a/roxctl/declarativeconfig/create/notifier_test.go
+++ b/roxctl/declarativeconfig/create/notifier_test.go
@@ -24,7 +24,7 @@ func TestCreateNotifier_Failures(t *testing.T) {
 				"--name=some-name",
 				"--splunk-token=token",
 			},
-			errOut: `Error: missing endpoint
+			errOut: `Error: required flag(s) "splunk-endpoint" not set
 `,
 		},
 	}
@@ -87,10 +87,12 @@ generic:
 			args: []string{"notifier", "splunk",
 				"--name=some-name",
 				"--splunk-endpoint=some-endpoint",
+				"--splunk-token=some-token",
 				"--source-types=k2=v2,k1=v1",
 			},
 			expectedYAML: `name: some-name
 splunk:
+    token: some-token
     endpoint: some-endpoint
     sourceTypes:
         - key: k1


### PR DESCRIPTION
## Description

`generic` and `splunk` subcommands to the `declarative-config create notifier` command.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Unit tests, manual CLI tests.