### PR TITLE
ROX-17283: Filter compliance information according to hideScanResults property

### DIFF
--- a/ui/apps/platform/src/Containers/Compliance/Dashboard/ComplianceDashboardPage.tsx
+++ b/ui/apps/platform/src/Containers/Compliance/Dashboard/ComplianceDashboardPage.tsx
@@ -9,7 +9,10 @@ import useCaseTypes from 'constants/useCaseTypes';
 import { useTheme } from 'Containers/ThemeProvider';
 import useFeatureFlags from 'hooks/useFeatureFlags';
 import usePermissions from 'hooks/usePermissions';
-import { ComplianceStandardMetadata, fetchComplianceStandards } from 'services/ComplianceService';
+import {
+    ComplianceStandardMetadata,
+    fetchComplianceStandardsSortedByName,
+} from 'services/ComplianceService';
 
 import ScanButton from '../ScanButton';
 import StandardsByEntity from '../widgets/StandardsByEntity';
@@ -40,7 +43,7 @@ function ComplianceDashboardPage(): ReactElement {
         hasWriteAccessForComplianceStandards && isDisableComplianceStandardsEnabled;
 
     useEffect(() => {
-        fetchComplianceStandards()
+        fetchComplianceStandardsSortedByName()
             .then((standardsFetched) => {
                 setStandards(standardsFetched);
             })

--- a/ui/apps/platform/src/Containers/Compliance/Dashboard/ComplianceDashboardPage.tsx
+++ b/ui/apps/platform/src/Containers/Compliance/Dashboard/ComplianceDashboardPage.tsx
@@ -1,4 +1,5 @@
 import React, { ReactElement, useEffect, useState } from 'react';
+import { useApolloClient } from '@apollo/client';
 
 import Button from 'Components/Button';
 import ExportButton from 'Components/ExportButton';
@@ -28,6 +29,8 @@ function ComplianceDashboardPage(): ReactElement {
     const [standards, setStandards] = useState<ComplianceStandardMetadata[]>([]);
     const [isManageStandardsModalOpen, setIsManageStandardsModalOpen] = useState(false);
 
+    const client = useApolloClient();
+
     const [isExporting, setIsExporting] = useState(false);
 
     const { isDarkMode } = useTheme();
@@ -52,12 +55,18 @@ function ComplianceDashboardPage(): ReactElement {
             });
     }, []);
 
-    function onSaveFromManageStandardsModal(standardsSaved: ComplianceStandardMetadata[]) {
+    function onSaveManageStandardsModal(standardsSaved: ComplianceStandardMetadata[]) {
         setStandards(standardsSaved);
         setIsManageStandardsModalOpen(false);
+
+        /*
+         * Same method as for Scan button to clear store of any cached query data,
+         * so backend filters out hidden standards in query data according to saved update.
+         */
+        return client.resetStore();
     }
 
-    function onCancelFromManageStandardsModal() {
+    function onCancelManageStandardsModal() {
         setIsManageStandardsModalOpen(false);
     }
 
@@ -141,8 +150,8 @@ function ComplianceDashboardPage(): ReactElement {
             {isManageStandardsModalOpen && (
                 <ManageStandardsModal
                     standards={standards}
-                    onSave={onSaveFromManageStandardsModal}
-                    onCancel={onCancelFromManageStandardsModal}
+                    onSave={onSaveManageStandardsModal}
+                    onCancel={onCancelManageStandardsModal}
                 />
             )}
         </>

--- a/ui/apps/platform/src/Containers/Compliance/Dashboard/ComplianceDashboardPage.tsx
+++ b/ui/apps/platform/src/Containers/Compliance/Dashboard/ComplianceDashboardPage.tsx
@@ -70,7 +70,8 @@ function ComplianceDashboardPage(): ReactElement {
 
         /*
          * Same method as for Scan button to clear store of any cached query data,
-         * so backend filters out hidden standards in query data according to saved update.
+         * so backend filters out standards in query data according to saved update
+         * to hideScanResults properties.
          */
         return client.resetStore();
     }

--- a/ui/apps/platform/src/Containers/Compliance/Dashboard/ManageStandardsModal.tsx
+++ b/ui/apps/platform/src/Containers/Compliance/Dashboard/ManageStandardsModal.tsx
@@ -5,7 +5,7 @@ import { useFormik } from 'formik';
 import {
     ComplianceStandardMetadata,
     fetchComplianceStandards,
-    // patchComplianceStandard,
+    patchComplianceStandard,
 } from 'services/ComplianceService';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
@@ -17,11 +17,11 @@ export type ManageStandardsModalProps = {
 
 /*
  * Formik values have standard id as key and showScanResults as value.
- * Therefore, negate hideScanResults value here and
+ * Therefore, negate hidden value here and
  * showComplianceScanMap[id] value in onSubmit function below.
  */
 function getShowScanResultsMap(standards: ComplianceStandardMetadata[]): Record<string, boolean> {
-    return Object.fromEntries(standards.map(({ id, hideScanResults }) => [id, !hideScanResults]));
+    return Object.fromEntries(standards.map(({ id, hidden }) => [id, !hidden]));
 }
 
 function ManageStandardsModal({ standards, onSave, onCancel }): ReactElement {
@@ -30,19 +30,13 @@ function ManageStandardsModal({ standards, onSave, onCancel }): ReactElement {
         Record<string, boolean>
     >({
         initialValues: getShowScanResultsMap(standards),
-        onSubmit: (/* showScanResultsMap */) => {
+        onSubmit: (showScanResultsMap) => {
             setErrorMessage('');
-            const patchRequestPromises = [];
-            /*
-            // Filter standards for which hideScanResults property has changed,
+            // Filter standards for which hidden property has changed,
             // and them map to promises for patch requests.
             const patchRequestPromises = standards
-                .filter(
-                    ({ hideScanResults, id }) =>
-                        Boolean(hideScanResults) !== !showScanResultsMap[id]
-                )
+                .filter(({ hidden, id }) => Boolean(hidden) !== !showScanResultsMap[id])
                 .map(({ id }) => patchComplianceStandard(id, !showScanResultsMap[id]));
-            */
 
             Promise.all(patchRequestPromises)
                 .then(() => {
@@ -68,7 +62,7 @@ function ManageStandardsModal({ standards, onSave, onCancel }): ReactElement {
     return (
         <Modal
             title="Manage standards"
-            variant="medium"
+            variant="small"
             isOpen
             showClose={false}
             actions={[

--- a/ui/apps/platform/src/Containers/Compliance/Dashboard/ManageStandardsModal.tsx
+++ b/ui/apps/platform/src/Containers/Compliance/Dashboard/ManageStandardsModal.tsx
@@ -4,7 +4,7 @@ import { useFormik } from 'formik';
 
 import {
     ComplianceStandardMetadata,
-    fetchComplianceStandards,
+    fetchComplianceStandardsSortedByName,
     patchComplianceStandard,
 } from 'services/ComplianceService';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
@@ -40,7 +40,7 @@ function ManageStandardsModal({ standards, onSave, onCancel }): ReactElement {
 
             Promise.all(patchRequestPromises)
                 .then(() => {
-                    fetchComplianceStandards()
+                    fetchComplianceStandardsSortedByName()
                         .then((standardsFetchedAfterPatchRequests) => {
                             onSave(standardsFetchedAfterPatchRequests);
                         })
@@ -52,7 +52,7 @@ function ManageStandardsModal({ standards, onSave, onCancel }): ReactElement {
                         });
                 })
                 .catch((error) => {
-                    // TODO fetchComplianceStandards in case some succeed before one fails?
+                    // TODO fetchComplianceStandardsSortedByName in case some succeed before one fails?
                     setErrorMessage(getAxiosErrorMessage(error));
                     setSubmitting(false);
                 });

--- a/ui/apps/platform/src/Containers/Compliance/Dashboard/ManageStandardsModal.tsx
+++ b/ui/apps/platform/src/Containers/Compliance/Dashboard/ManageStandardsModal.tsx
@@ -39,6 +39,9 @@ function ManageStandardsModal({ standards, onSave, onCancel }): ReactElement {
                 .filter(({ hideScanResults, id }) => !hideScanResults !== showScanResultsMap[id])
                 .map(({ id }) => patchComplianceStandard(id, !showScanResultsMap[id]));
 
+            // TODO rewrite with ES2020 allSettled to solve async problem with all.
+            // TODO decide how to display results and update Formik state
+            // if some requests fail but other requests succeed.
             Promise.all(patchRequestPromises)
                 .then(() => {
                     fetchComplianceStandardsSortedByName()
@@ -53,7 +56,6 @@ function ManageStandardsModal({ standards, onSave, onCancel }): ReactElement {
                         });
                 })
                 .catch((error) => {
-                    // TODO fetchComplianceStandardsSortedByName in case some succeed before one fails?
                     setErrorMessage(getAxiosErrorMessage(error));
                     setSubmitting(false);
                 });

--- a/ui/apps/platform/src/Containers/Compliance/Dashboard/ManageStandardsModal.tsx
+++ b/ui/apps/platform/src/Containers/Compliance/Dashboard/ManageStandardsModal.tsx
@@ -17,11 +17,11 @@ export type ManageStandardsModalProps = {
 
 /*
  * Formik values have standard id as key and showScanResults as value.
- * Therefore, negate hidden value here and
+ * Therefore, negate hideScanResults value here and
  * showComplianceScanMap[id] value in onSubmit function below.
  */
 function getShowScanResultsMap(standards: ComplianceStandardMetadata[]): Record<string, boolean> {
-    return Object.fromEntries(standards.map(({ id, hidden }) => [id, !hidden]));
+    return Object.fromEntries(standards.map(({ id, hideScanResults }) => [id, !hideScanResults]));
 }
 
 function ManageStandardsModal({ standards, onSave, onCancel }): ReactElement {
@@ -32,10 +32,11 @@ function ManageStandardsModal({ standards, onSave, onCancel }): ReactElement {
         initialValues: getShowScanResultsMap(standards),
         onSubmit: (showScanResultsMap) => {
             setErrorMessage('');
-            // Filter standards for which hidden property has changed,
+            // Filter standards for which hideScanResults property has changed,
             // and them map to promises for patch requests.
+            // Negate hideScanResults is correct even if property is absent.
             const patchRequestPromises = standards
-                .filter(({ hidden, id }) => Boolean(hidden) !== !showScanResultsMap[id])
+                .filter(({ hideScanResults, id }) => !hideScanResults !== showScanResultsMap[id])
                 .map(({ id }) => patchComplianceStandard(id, !showScanResultsMap[id]));
 
             Promise.all(patchRequestPromises)

--- a/ui/apps/platform/src/Containers/Compliance/widgets/ComplianceByStandards.tsx
+++ b/ui/apps/platform/src/Containers/Compliance/widgets/ComplianceByStandards.tsx
@@ -1,15 +1,25 @@
 import React, { ReactElement } from 'react';
 import { useQuery } from '@apollo/client';
 
-import { ResourceType } from 'constants/entityTypes';
 import Loader from 'Components/Loader';
 import { STANDARDS_QUERY } from 'queries/standard';
+import { ComplianceStandardScope } from 'services/ComplianceService';
+
 import ComplianceByStandard from './ComplianceByStandard';
+
+type StandardsQueryDataType = {
+    results: {
+        id: string;
+        name: string;
+        scopes: ComplianceStandardScope[];
+        hidden: boolean;
+    }[];
+};
 
 type ComplianceByStandardsProps = {
     entityId?: string;
     entityName?: string;
-    entityType?: ResourceType;
+    entityType?: ComplianceStandardScope;
 };
 
 function ComplianceByStandards({
@@ -17,7 +27,7 @@ function ComplianceByStandards({
     entityName,
     entityType,
 }: ComplianceByStandardsProps): ReactElement {
-    const { loading, data, error } = useQuery(STANDARDS_QUERY);
+    const { loading, data, error } = useQuery<StandardsQueryDataType>(STANDARDS_QUERY);
     if (loading) {
         return <Loader />;
     }
@@ -31,12 +41,14 @@ function ComplianceByStandards({
         );
     }
 
-    let standards = data?.results || [];
-    if (entityType && Array.isArray(data?.results)) {
-        standards = data.results.filter(
-            ({ hidden, scopes }): boolean => !hidden && (scopes.includes(entityType) as boolean)
-        );
-    }
+    /* eslint-disable no-nested-ternary */
+    const standards = !data?.results
+        ? []
+        : !entityType
+        ? data.results
+        : data.results.filter(({ scopes }) => scopes.includes(entityType));
+    /* eslint-enable no-nested-ternary */
+
     return (
         <>
             {standards.map(({ name: standardName, id: standardId }) => (

--- a/ui/apps/platform/src/Containers/Compliance/widgets/ComplianceByStandards.tsx
+++ b/ui/apps/platform/src/Containers/Compliance/widgets/ComplianceByStandards.tsx
@@ -34,7 +34,7 @@ function ComplianceByStandards({
     let standards = data?.results || [];
     if (entityType && Array.isArray(data?.results)) {
         standards = data.results.filter(
-            ({ scopes }): boolean => scopes.includes(entityType) as boolean
+            ({ hidden, scopes }): boolean => !hidden && (scopes.includes(entityType) as boolean)
         );
     }
     return (

--- a/ui/apps/platform/src/services/ComplianceService.ts
+++ b/ui/apps/platform/src/services/ComplianceService.ts
@@ -21,6 +21,27 @@ export function fetchComplianceStandards(): Promise<ComplianceStandardMetadata[]
         .then((response) => response.data?.standards ?? []);
 }
 
+/*
+ * Temporary frontend work-around for 4.1 version,
+ * because standards are not always sorted in ascending order by name.
+ */
+
+function compareStandardsByName(
+    standardPrev: ComplianceStandardMetadata,
+    standardNext: ComplianceStandardMetadata
+) {
+    const { name: namePrev } = standardPrev;
+    const { name: nameNext } = standardNext;
+
+    /* eslint-disable no-nested-ternary */
+    return namePrev < nameNext ? -1 : namePrev > nameNext ? 1 : 0;
+    /* eslint-enable no-nested-ternary */
+}
+
+export function fetchComplianceStandardsSortedByName(): Promise<ComplianceStandardMetadata[]> {
+    return fetchComplianceStandards().then((standards) => standards.sort(compareStandardsByName));
+}
+
 export function patchComplianceStandard(id: string, hidden: boolean): Promise<Empty> {
     return axios
         .patch<Empty>(`${standardsUrl}/${id}`, { hidden })

--- a/ui/apps/platform/src/services/ComplianceService.ts
+++ b/ui/apps/platform/src/services/ComplianceService.ts
@@ -12,7 +12,7 @@ export type ComplianceStandardMetadata = {
     numImplementedChecks: number; // int32
     scopes: ComplianceStandardScope[];
     dynamic: boolean;
-    hidden: boolean;
+    hideScanResults: boolean;
 };
 
 export function fetchComplianceStandards(): Promise<ComplianceStandardMetadata[]> {
@@ -42,8 +42,8 @@ export function fetchComplianceStandardsSortedByName(): Promise<ComplianceStanda
     return fetchComplianceStandards().then((standards) => standards.sort(compareStandardsByName));
 }
 
-export function patchComplianceStandard(id: string, hidden: boolean): Promise<Empty> {
+export function patchComplianceStandard(id: string, hideScanResults: boolean): Promise<Empty> {
     return axios
-        .patch<Empty>(`${standardsUrl}/${id}`, { hidden })
+        .patch<Empty>(`${standardsUrl}/${id}`, { hideScanResults })
         .then((response) => response.data);
 }

--- a/ui/apps/platform/src/services/ComplianceService.ts
+++ b/ui/apps/platform/src/services/ComplianceService.ts
@@ -1,6 +1,8 @@
 import axios from './instance';
 import { Empty } from './types';
 
+const standardsUrl = '/v1/compliance/standards';
+
 export type ComplianceStandardScope = 'UNSET' | 'CLUSTER' | 'NAMESPACE' | 'DEPLOYMENT' | 'NODE';
 
 export type ComplianceStandardMetadata = {
@@ -10,19 +12,17 @@ export type ComplianceStandardMetadata = {
     numImplementedChecks: number; // int32
     scopes: ComplianceStandardScope[];
     dynamic: boolean;
-    hideScanResults?: boolean; // TODO optional until backend implements new property
+    hidden: boolean;
 };
 
 export function fetchComplianceStandards(): Promise<ComplianceStandardMetadata[]> {
     return axios
-        .get<{ standards: ComplianceStandardMetadata[] }>('/v1/compliance/standards')
-        .then((response) => {
-            return response.data?.standards ?? [];
-        });
+        .get<{ standards: ComplianceStandardMetadata[] }>(standardsUrl)
+        .then((response) => response.data?.standards ?? []);
 }
 
-export function patchComplianceStandard(id: string, hideScanResults: boolean): Promise<Empty> {
+export function patchComplianceStandard(id: string, hidden: boolean): Promise<Empty> {
     return axios
-        .patch<Empty>(`/v1/compliance/standard/${id}`, { hideScanResults })
+        .patch<Empty>(`${standardsUrl}/${id}`, { hidden })
         .then((response) => response.data);
 }


### PR DESCRIPTION
## Description

Unblock end-to-end backend-to-frontend testing to discover any problems with filtering of GraphQL responses.

1. ComplianceDashboardPage

    * Add `isFetchingStandards` and `errorMessageForStandards` to component state.
    * Replace `fetchComplianceStandards` with `fetchComplianceStandardsSortedByName` as temporary solution for inconsistent sorting of standards in GET /v1/compliance/standards response.
    * Add `client.resetStore()` on successful save. Forgot to write under manual testing that the change causes the 10 or more GraphQL queries for compliance dashboard page. If I remember correctly, sunburst widgets were filtered.
    * Replace temporary condition for `disabled` prop of **Manage standards** button.

2. ManageStandardsModal

    * Rewrite filter condition.
    * Rewrite TODO comment about edge case if some requests fail but other requests succeed (see **Residue**).
    * Update `variant` prop.

3. ComplianceByStandards

    * Define `StandardsQueryDataType` to replace type assertions.
    * Rewrite `standards` conditional logic. Backend filters standards in GraphQL responses according to `hideScanResults` property.

4. ComplianceService

    * Add temporary `fetchComplianceStandardsSortedByName` function.

### Residue

1. Unable to retest for re-re-named `hideScanResults` property, because build hung after most recent backend commit.

2. Decide details for edge case of PATCH request failures:

    ```js
    // TODO rewrite with ES2020 allSettled to solve async problem with all.
    // TODO decide how to display results and update Formik state
    // if some requests fail but other requests succeed.
    ```

3. Write integration tests.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~ coming soon

## Testing Performed

In ui folder:

1. `export ROX_DISABLE_COMPLIANCE_STANDARDS=true`

### Manual testing

1. Visit /main/compliance: see **Manage standards** button disabled and then enabled; see order of standards in response; see obsolete `hidden` property.

    * dark theme
        ![compliance_hidden_dark](https://github.com/stackrox/stackrox/assets/11862657/94b23460-9842-4f3b-8b64-493ab30bcd38)

    * light theme
        ![compliance_hidden_light](https://github.com/stackrox/stackrox/assets/11862657/910c27b3-0c08-4aac-96f4-812ea5e6513e)

2. Click **Manage standards**: see small variant of modal and all standards are selected.
    ![ManageStandards_dark](https://github.com/stackrox/stackrox/assets/11862657/345fa177-b1ff-437f-a940-45e96166b8c0)

3. Click to clear **HIPAA 164** and **PCI DSS 3.2.1** standards, and then click **Save**: see different order or standards in response; see no change in obsolete `hidden` property because of re-re-named `hideScanResults` in PATCH request payload.
    ![PATCH](https://github.com/stackrox/stackrox/assets/11862657/32737143-d111-40c3-8d60-14491170ea35)

### Integration testing

In ui/apps/platform folder:

1. `export CYPRESS_ROX_POSTGRES_DATASTORE=true`

2. `yarn cypress-open`

    * compliance/complianceDashboard.test.js
    * compliance/complianceList.test.js
