### PR TITLE
Mount CRI socket usual paths in Collector container ROX-17096 

### DIFF
--- a/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml
@@ -67,6 +67,15 @@ spec:
         - mountPath: /host/var/run/docker.sock
           name: var-run-docker-sock
           readOnly: true
+        - mountPath: /host/run/crio/crio.sock
+          name: run-crio-sock
+          readOnly: true
+        - mountPath: /host/run/containerd/containerd.sock
+          name: run-containerd-sock
+          readOnly: true
+        - mountPath: /host/run/k3s/containerd/containerd.sock
+          name: run-k3s-containerd-sock
+          readOnly: true
         - mountPath: /host/proc
           name: proc-ro
           readOnly: true
@@ -175,6 +184,15 @@ spec:
       - hostPath:
           path: /var/run/docker.sock
         name: var-run-docker-sock
+      - hostPath:
+          path: /run/crio/crio.sock
+        name: run-crio-sock
+      - hostPath:
+          path: /run/containerd/containerd.sock
+        name: run-containerd-sock
+      - hostPath:
+          path: /run/k3s/containerd/containerd.sock
+        name: run-k3s-containerd-sock
       - hostPath:
           path: /proc
         name: proc-ro


### PR DESCRIPTION
## Description

Collector, and in particular Falco, communicates with the CRI engine to retrieve objects and receive events. The CRI spec does not define a standard socket path and every container manager has its own default. We mount all supported known paths.

ROX-17096: when not able to receive events through the CRI, falco fails to free some objects (container+user-info), which results in a ever increasing memory consumption.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))
