### PR TITLE
Add prefix to declarative config resources ID

### DIFF
--- a/central/declarativeconfig/manager_impl.go
+++ b/central/declarativeconfig/manager_impl.go
@@ -320,7 +320,7 @@ func (m *managerImpl) doDeletion(transformedMessagesByHandler map[string]protoMe
 // In case err != nil _and_ the number of errors for this message is >= the given threshold, the health
 // status will be set to unhealthy.
 func (m *managerImpl) updateHealthForMessage(handler string, message proto.Message, err error, threshold int32) {
-	messageID := m.idExtractor(message)
+	messageID := declarativeConfigUtils.IDForIntegrationHealthFromProtoMessage(message, m.idExtractor)
 	integrationHealth := declarativeConfigUtils.IntegrationHealthForProtoMessage(message, handler, err, m.idExtractor, m.nameExtractor)
 
 	if err != nil {
@@ -355,7 +355,7 @@ func (m *managerImpl) updateHandlerHealth(handlerID string, err error) {
 
 func (m *managerImpl) registerHealthForMessage(handler string, messages ...proto.Message) {
 	for _, message := range messages {
-		messageID := m.idExtractor(message)
+		messageID := declarativeConfigUtils.IDForIntegrationHealthFromProtoMessage(message, m.idExtractor)
 		messageName := declarativeConfigUtils.NameForIntegrationHealthFromProtoMessage(message, handler, m.nameExtractor, m.idExtractor)
 
 		if err := m.declarativeConfigErrorReporter.Register(messageID, messageName,

--- a/central/declarativeconfig/manager_impl.go
+++ b/central/declarativeconfig/manager_impl.go
@@ -375,11 +375,14 @@ func (m *managerImpl) removeStaleHealthStatuses(idsToSkip []string) error {
 		return errors.Wrap(err, "retrieving integration health statuses for declarative config")
 	}
 
-	idsToSkipSet := set.NewFrozenStringSet(idsToSkip...)
+	healthIDsToSkip := set.NewStringSet()
+	for _, id := range idsToSkip {
+		healthIDsToSkip.Add(declarativeConfigUtils.DeclarativeConfigHealthIDPrefix + id)
+	}
 
 	var removingIntegrationHealthsErr *multierror.Error
 	for _, health := range healths {
-		if idsToSkipSet.Contains(health.GetId()) {
+		if healthIDsToSkip.Contains(health.GetId()) {
 			continue
 		}
 

--- a/central/declarativeconfig/manager_impl_test.go
+++ b/central/declarativeconfig/manager_impl_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stackrox/rox/central/declarativeconfig/types"
 	"github.com/stackrox/rox/central/declarativeconfig/updater"
 	updaterMocks "github.com/stackrox/rox/central/declarativeconfig/updater/mocks"
+	declarativeConfigUtils "github.com/stackrox/rox/central/declarativeconfig/utils"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/declarativeconfig"
 	transformMocks "github.com/stackrox/rox/pkg/declarativeconfig/transform/mocks"
@@ -63,7 +64,7 @@ func matchIntegrationHealth(int *storage.IntegrationHealth) gomock.Matcher {
 }
 
 func addHealthIDPrefix(s string) string {
-	return types.DeclarativeConfigHealthIDPrefix + s
+	return declarativeConfigUtils.DeclarativeConfigHealthIDPrefix + s
 }
 
 func TestReconcileTransformedMessages_Success(t *testing.T) {
@@ -173,12 +174,12 @@ func TestReconcileTransformedMessages_Success(t *testing.T) {
 
 	// Delete resources should be called in order, ignoring the existing IDs from the previously upserted resources.
 	gomock.InOrder(
-		mockUpdater.EXPECT().DeleteResources(gomock.Any(), []string{addHealthIDPrefix("notifierId")}).Return(nil, nil),
-		mockUpdater.EXPECT().DeleteResources(gomock.Any(), []string{addHealthIDPrefix("group")}).Return(nil, nil),
-		mockUpdater.EXPECT().DeleteResources(gomock.Any(), []string{addHealthIDPrefix("id-auth-provider")}).Return(nil, nil),
-		mockUpdater.EXPECT().DeleteResources(gomock.Any(), []string{addHealthIDPrefix("role")}).Return(nil, nil),
-		mockUpdater.EXPECT().DeleteResources(gomock.Any(), gomock.InAnyOrder([]string{addHealthIDPrefix("id-perm-set-1"), addHealthIDPrefix("id-perm-set-2")})).Return(nil, nil),
-		mockUpdater.EXPECT().DeleteResources(gomock.Any(), []string{addHealthIDPrefix("id-access-scope")}).Return([]string{addHealthIDPrefix("skipping-scope")}, errors.New("some-error")),
+		mockUpdater.EXPECT().DeleteResources(gomock.Any(), []string{"notifierId"}).Return(nil, nil),
+		mockUpdater.EXPECT().DeleteResources(gomock.Any(), []string{"group"}).Return(nil, nil),
+		mockUpdater.EXPECT().DeleteResources(gomock.Any(), []string{"id-auth-provider"}).Return(nil, nil),
+		mockUpdater.EXPECT().DeleteResources(gomock.Any(), []string{"role"}).Return(nil, nil),
+		mockUpdater.EXPECT().DeleteResources(gomock.Any(), gomock.InAnyOrder([]string{"id-perm-set-1", "id-perm-set-2"})).Return(nil, nil),
+		mockUpdater.EXPECT().DeleteResources(gomock.Any(), []string{"id-access-scope"}).Return([]string{"skipping-scope"}, errors.New("some-error")),
 	)
 
 	// We retrieve the integration healths on the deletion, only the non-ignored ID that does not have "Config Map"

--- a/central/declarativeconfig/manager_impl_test.go
+++ b/central/declarativeconfig/manager_impl_test.go
@@ -62,6 +62,10 @@ func matchIntegrationHealth(int *storage.IntegrationHealth) gomock.Matcher {
 	}
 }
 
+func addHealthIDPrefix(s string) string {
+	return types.DeclarativeConfigHealthIDPrefix + s
+}
+
 func TestReconcileTransformedMessages_Success(t *testing.T) {
 	controller := gomock.NewController(t)
 	mockUpdater := updaterMocks.NewMockResourceUpdater(controller)
@@ -117,49 +121,49 @@ func TestReconcileTransformedMessages_Success(t *testing.T) {
 
 	gomock.InOrder(
 		reporter.EXPECT().UpdateIntegrationHealthAsync(matchIntegrationHealth(&storage.IntegrationHealth{
-			Id:           "id-access-scope",
+			Id:           addHealthIDPrefix("id-access-scope"),
 			Name:         "accessScope in config map test-handler-1",
 			Type:         storage.IntegrationHealth_DECLARATIVE_CONFIG,
 			Status:       storage.IntegrationHealth_HEALTHY,
 			ErrorMessage: "",
 		})),
 		reporter.EXPECT().UpdateIntegrationHealthAsync(matchIntegrationHealth(&storage.IntegrationHealth{
-			Id:           "id-perm-set-1",
+			Id:           addHealthIDPrefix("id-perm-set-1"),
 			Name:         "permission-set-1 in config map test-handler-1",
 			Type:         storage.IntegrationHealth_DECLARATIVE_CONFIG,
 			Status:       storage.IntegrationHealth_HEALTHY,
 			ErrorMessage: "",
 		})),
 		reporter.EXPECT().UpdateIntegrationHealthAsync(matchIntegrationHealth(&storage.IntegrationHealth{
-			Id:           "id-perm-set-2",
+			Id:           addHealthIDPrefix("id-perm-set-2"),
 			Name:         "permission-set-2 in config map test-handler-1",
 			Type:         storage.IntegrationHealth_DECLARATIVE_CONFIG,
 			Status:       storage.IntegrationHealth_HEALTHY,
 			ErrorMessage: "",
 		})),
 		reporter.EXPECT().UpdateIntegrationHealthAsync(matchIntegrationHealth(&storage.IntegrationHealth{
-			Id:           "role",
+			Id:           addHealthIDPrefix("role"),
 			Name:         "role in config map test-handler-2",
 			Type:         storage.IntegrationHealth_DECLARATIVE_CONFIG,
 			Status:       storage.IntegrationHealth_HEALTHY,
 			ErrorMessage: "",
 		})),
 		reporter.EXPECT().UpdateIntegrationHealthAsync(matchIntegrationHealth(&storage.IntegrationHealth{
-			Id:           "id-auth-provider",
+			Id:           addHealthIDPrefix("id-auth-provider"),
 			Name:         "authProvider in config map test-handler-2",
 			Type:         storage.IntegrationHealth_DECLARATIVE_CONFIG,
 			Status:       storage.IntegrationHealth_HEALTHY,
 			ErrorMessage: "",
 		})),
 		reporter.EXPECT().UpdateIntegrationHealthAsync(matchIntegrationHealth(&storage.IntegrationHealth{
-			Id:           "group",
+			Id:           addHealthIDPrefix("group"),
 			Name:         "group email:some@example.com:Admin for auth provider ID some-auth-provider in config map test-handler-2",
 			Type:         storage.IntegrationHealth_DECLARATIVE_CONFIG,
 			Status:       storage.IntegrationHealth_HEALTHY,
 			ErrorMessage: "",
 		})),
 		reporter.EXPECT().UpdateIntegrationHealthAsync(matchIntegrationHealth(&storage.IntegrationHealth{
-			Id:           "notifierId",
+			Id:           addHealthIDPrefix("notifierId"),
 			Name:         "notifierName in config map test-handler-2",
 			Type:         storage.IntegrationHealth_DECLARATIVE_CONFIG,
 			Status:       storage.IntegrationHealth_HEALTHY,
@@ -169,12 +173,12 @@ func TestReconcileTransformedMessages_Success(t *testing.T) {
 
 	// Delete resources should be called in order, ignoring the existing IDs from the previously upserted resources.
 	gomock.InOrder(
-		mockUpdater.EXPECT().DeleteResources(gomock.Any(), []string{"notifierId"}).Return(nil, nil),
-		mockUpdater.EXPECT().DeleteResources(gomock.Any(), []string{"group"}).Return(nil, nil),
-		mockUpdater.EXPECT().DeleteResources(gomock.Any(), []string{"id-auth-provider"}).Return(nil, nil),
-		mockUpdater.EXPECT().DeleteResources(gomock.Any(), []string{"role"}).Return(nil, nil),
-		mockUpdater.EXPECT().DeleteResources(gomock.Any(), gomock.InAnyOrder([]string{"id-perm-set-1", "id-perm-set-2"})).Return(nil, nil),
-		mockUpdater.EXPECT().DeleteResources(gomock.Any(), []string{"id-access-scope"}).Return([]string{"skipping-scope"}, errors.New("some-error")),
+		mockUpdater.EXPECT().DeleteResources(gomock.Any(), []string{addHealthIDPrefix("notifierId")}).Return(nil, nil),
+		mockUpdater.EXPECT().DeleteResources(gomock.Any(), []string{addHealthIDPrefix("group")}).Return(nil, nil),
+		mockUpdater.EXPECT().DeleteResources(gomock.Any(), []string{addHealthIDPrefix("id-auth-provider")}).Return(nil, nil),
+		mockUpdater.EXPECT().DeleteResources(gomock.Any(), []string{addHealthIDPrefix("role")}).Return(nil, nil),
+		mockUpdater.EXPECT().DeleteResources(gomock.Any(), gomock.InAnyOrder([]string{addHealthIDPrefix("id-perm-set-1"), addHealthIDPrefix("id-perm-set-2")})).Return(nil, nil),
+		mockUpdater.EXPECT().DeleteResources(gomock.Any(), []string{addHealthIDPrefix("id-access-scope")}).Return([]string{addHealthIDPrefix("skipping-scope")}, errors.New("some-error")),
 	)
 
 	// We retrieve the integration healths on the deletion, only the non-ignored ID that does not have "Config Map"
@@ -182,35 +186,35 @@ func TestReconcileTransformedMessages_Success(t *testing.T) {
 	gomock.InOrder(
 		reporter.EXPECT().RetrieveIntegrationHealths(storage.IntegrationHealth_DECLARATIVE_CONFIG).Return([]*storage.IntegrationHealth{
 			{
-				Id:   "some-id",
+				Id:   addHealthIDPrefix("some-id"),
 				Name: "Config Map some-config-map",
 			},
 			{
-				Id:   "notifierId",
+				Id:   addHealthIDPrefix("notifierId"),
 				Name: "",
 			},
 			{
-				Id:   "group",
+				Id:   addHealthIDPrefix("group"),
 				Name: "",
 			},
 			{
-				Id:   "id-auth-provider",
+				Id:   addHealthIDPrefix("id-auth-provider"),
 				Name: "",
 			},
 			{
-				Id:   "role",
+				Id:   addHealthIDPrefix("role"),
 				Name: "",
 			},
 			{
-				Id:   "skipping-scope",
+				Id:   addHealthIDPrefix("skipping-scope"),
 				Name: "",
 			},
 			{
-				Id:   "some-non-existent-id",
+				Id:   addHealthIDPrefix("some-non-existent-id"),
 				Name: "I should be deleted",
 			},
 		}, nil),
-		reporter.EXPECT().RemoveIntegrationHealth("some-non-existent-id"),
+		reporter.EXPECT().RemoveIntegrationHealth(addHealthIDPrefix("some-non-existent-id")),
 	)
 
 	m := newTestManager(t)
@@ -265,7 +269,7 @@ func TestReconcileTransformedMessages_ErrorPropagatedToReporter(t *testing.T) {
 	mockUpdater.EXPECT().Upsert(gomock.Any(), permissionSet1).Return(testError).Times(3)
 
 	reporter.EXPECT().UpdateIntegrationHealthAsync(matchIntegrationHealth(&storage.IntegrationHealth{
-		Id:           "some-id",
+		Id:           addHealthIDPrefix("some-id"),
 		Name:         "permission-set-1 in config map test-handler-1",
 		Type:         storage.IntegrationHealth_DECLARATIVE_CONFIG,
 		Status:       storage.IntegrationHealth_UNHEALTHY,
@@ -507,7 +511,7 @@ func TestUpdateDeclarativeConfigContents_RegisterHealthStatus(t *testing.T) {
 		},
 	}, nil)
 
-	reporter.EXPECT().Register("test-name", "test-name in config map my-cool-config-map", storage.IntegrationHealth_DECLARATIVE_CONFIG)
+	reporter.EXPECT().Register(addHealthIDPrefix("test-name"), "test-name in config map my-cool-config-map", storage.IntegrationHealth_DECLARATIVE_CONFIG)
 
 	reporter.EXPECT().UpdateIntegrationHealthAsync(matchIntegrationHealth(&storage.IntegrationHealth{
 		Id:           "/some/config/dir/to/my-cool-config-map",

--- a/central/declarativeconfig/types/extractors.go
+++ b/central/declarativeconfig/types/extractors.go
@@ -9,20 +9,26 @@ import (
 	"github.com/stackrox/rox/pkg/utils"
 )
 
+const declarativeConfigHealthIDPrefix = "declarativeconfig."
+
 // IDExtractor extracts the ID from proto messages.
 type IDExtractor func(m proto.Message) string
 
 // NameExtractor extracts the name from proto messages.
 type NameExtractor func(m proto.Message) string
 
-// UniversalIDExtractor provides a way to extract the ID from proto messages.
+// UniversalIDExtractor provides a way to extractIDFromProtoMessage the ID from proto messages.
 func UniversalIDExtractor() IDExtractor {
-	return extractIDFromProtoMessage
+	return compileIDFromProtoMessage
 }
 
-// UniversalNameExtractor provides a way to extract the name from proto messages.
+// UniversalNameExtractor provides a way to extractIDFromProtoMessage the name from proto messages.
 func UniversalNameExtractor() NameExtractor {
 	return extractNameFromProtoMessage
+}
+
+func compileIDFromProtoMessage(message proto.Message) string {
+	return declarativeConfigHealthIDPrefix + extractIDFromProtoMessage(message)
 }
 
 func extractIDFromProtoMessage(message proto.Message) string {

--- a/central/declarativeconfig/types/extractors.go
+++ b/central/declarativeconfig/types/extractors.go
@@ -9,7 +9,8 @@ import (
 	"github.com/stackrox/rox/pkg/utils"
 )
 
-const declarativeConfigHealthIDPrefix = "declarativeconfig."
+// DeclarativeConfigHealthIDPrefix is prefix of all integration health's IDs of declarative configurations.
+const DeclarativeConfigHealthIDPrefix = "declarativeconfig."
 
 // IDExtractor extracts the ID from proto messages.
 type IDExtractor func(m proto.Message) string
@@ -28,7 +29,7 @@ func UniversalNameExtractor() NameExtractor {
 }
 
 func compileIDFromProtoMessage(message proto.Message) string {
-	return declarativeConfigHealthIDPrefix + extractIDFromProtoMessage(message)
+	return DeclarativeConfigHealthIDPrefix + extractIDFromProtoMessage(message)
 }
 
 func extractIDFromProtoMessage(message proto.Message) string {

--- a/central/declarativeconfig/types/extractors.go
+++ b/central/declarativeconfig/types/extractors.go
@@ -9,9 +9,6 @@ import (
 	"github.com/stackrox/rox/pkg/utils"
 )
 
-// DeclarativeConfigHealthIDPrefix is prefix of all integration health's IDs of declarative configurations.
-const DeclarativeConfigHealthIDPrefix = "declarativeconfig."
-
 // IDExtractor extracts the ID from proto messages.
 type IDExtractor func(m proto.Message) string
 
@@ -20,16 +17,12 @@ type NameExtractor func(m proto.Message) string
 
 // UniversalIDExtractor provides a way to extractIDFromProtoMessage the ID from proto messages.
 func UniversalIDExtractor() IDExtractor {
-	return compileIDFromProtoMessage
+	return extractIDFromProtoMessage
 }
 
 // UniversalNameExtractor provides a way to extractIDFromProtoMessage the name from proto messages.
 func UniversalNameExtractor() NameExtractor {
 	return extractNameFromProtoMessage
-}
-
-func compileIDFromProtoMessage(message proto.Message) string {
-	return DeclarativeConfigHealthIDPrefix + extractIDFromProtoMessage(message)
 }
 
 func extractIDFromProtoMessage(message proto.Message) string {

--- a/central/declarativeconfig/updater/notifier_updater.go
+++ b/central/declarativeconfig/updater/notifier_updater.go
@@ -44,7 +44,7 @@ func newNotifierUpdater(notifierDS notifierDataStore.DataStore, policyCleaner po
 func (u *notifierUpdater) Upsert(ctx context.Context, m proto.Message) error {
 	notifierProto, ok := m.(*storage.Notifier)
 	if !ok {
-		return errox.InvariantViolation.Newf("wrong type passed to role updater: %T", notifierProto)
+		return errox.InvariantViolation.Newf("wrong type passed to notifier updater: %T", notifierProto)
 	}
 	_, err := u.notifierDS.UpsertNotifier(ctx, notifierProto)
 	if err != nil {

--- a/central/declarativeconfig/utils/integration_health.go
+++ b/central/declarativeconfig/utils/integration_health.go
@@ -52,6 +52,7 @@ func NameForIntegrationHealthFromProtoMessage(message proto.Message, handler str
 	return messageName
 }
 
+// IDForIntegrationHealthFromProtoMessage returns ID for declarative config resource's integration health.
 func IDForIntegrationHealthFromProtoMessage(message proto.Message, idExtractor types.IDExtractor) string {
 	return DeclarativeConfigHealthIDPrefix + idExtractor(message)
 }

--- a/central/declarativeconfig/utils/integration_health.go
+++ b/central/declarativeconfig/utils/integration_health.go
@@ -12,13 +12,16 @@ import (
 	"github.com/stackrox/rox/pkg/utils"
 )
 
+// DeclarativeConfigHealthIDPrefix is prefix of all integration health's IDs of declarative configurations.
+const DeclarativeConfigHealthIDPrefix = "declarativeconfig."
+
 // IntegrationHealthForProtoMessage returns a storage.IntegrationHealth for the given proto.Message.
 // The integration health will be marked as unhealthy if err != nil, and healthy if err == nil.
 // Note: Handler can be left empty. In this case, the name of the integration health will be updated to not include the
 // handler name.
 func IntegrationHealthForProtoMessage(message proto.Message, handler string, err error, idExtractor types.IDExtractor,
 	nameExtractor types.NameExtractor) *storage.IntegrationHealth {
-	messageID := idExtractor(message)
+	messageID := IDForIntegrationHealthFromProtoMessage(message, idExtractor)
 	messageName := NameForIntegrationHealthFromProtoMessage(message, handler, nameExtractor, idExtractor)
 
 	var errMsg string
@@ -47,4 +50,8 @@ func NameForIntegrationHealthFromProtoMessage(message proto.Message, handler str
 		messageName = fmt.Sprintf("%s in config map %s", messageName, path.Base(handler))
 	}
 	return messageName
+}
+
+func IDForIntegrationHealthFromProtoMessage(message proto.Message, idExtractor types.IDExtractor) string {
+	return DeclarativeConfigHealthIDPrefix + idExtractor(message)
 }

--- a/pkg/declarativeconfig/access_scope.go
+++ b/pkg/declarativeconfig/access_scope.go
@@ -16,8 +16,8 @@ type AccessScope struct {
 	Rules       Rules  `yaml:"rules,omitempty"`
 }
 
-// Type returns the AccessScopeConfiguration type.
-func (a *AccessScope) Type() ConfigurationType {
+// ConfigurationType returns the AccessScopeConfiguration type.
+func (a *AccessScope) ConfigurationType() ConfigurationType {
 	return AccessScopeConfiguration
 }
 

--- a/pkg/declarativeconfig/auth_provider.go
+++ b/pkg/declarativeconfig/auth_provider.go
@@ -84,7 +84,7 @@ type AuthProvider struct {
 	OpenshiftConfig    *OpenshiftConfig    `yaml:"openshift,omitempty"`
 }
 
-// Type returns the AuthProviderConfiguration type.
-func (a *AuthProvider) Type() ConfigurationType {
+// ConfigurationType returns the AuthProviderConfiguration type.
+func (a *AuthProvider) ConfigurationType() ConfigurationType {
 	return AuthProviderConfiguration
 }

--- a/pkg/declarativeconfig/configuration.go
+++ b/pkg/declarativeconfig/configuration.go
@@ -34,7 +34,7 @@ func supportedConfigurationTypes() string {
 
 // Configuration specifies a declarative configuration.
 type Configuration interface {
-	Type() ConfigurationType
+	ConfigurationType() ConfigurationType
 }
 
 // ConfigurationFromRawBytes takes in a list of raw bytes, i.e. file contents, and returns the unmarshalled

--- a/pkg/declarativeconfig/notifier.go
+++ b/pkg/declarativeconfig/notifier.go
@@ -41,7 +41,7 @@ type Notifier struct {
 	SplunkConfig  *SplunkConfig  `yaml:"splunk,omitempty"`
 }
 
-// Type returns the NotifierConfiguration type.
-func (r *Notifier) Type() ConfigurationType {
+// ConfigurationType returns the NotifierConfiguration type.
+func (r *Notifier) ConfigurationType() ConfigurationType {
 	return NotifierConfiguration
 }

--- a/pkg/declarativeconfig/permission_set.go
+++ b/pkg/declarativeconfig/permission_set.go
@@ -16,8 +16,8 @@ type PermissionSet struct {
 	Resources   []ResourceWithAccess `yaml:"resources,omitempty"`
 }
 
-// Type returns the PermissionSetConfiguration type.
-func (p *PermissionSet) Type() ConfigurationType {
+// ConfigurationType returns the PermissionSetConfiguration type.
+func (p *PermissionSet) ConfigurationType() ConfigurationType {
 	return PermissionSetConfiguration
 }
 

--- a/pkg/declarativeconfig/role.go
+++ b/pkg/declarativeconfig/role.go
@@ -8,7 +8,7 @@ type Role struct {
 	PermissionSet string `yaml:"permissionSet,omitempty"`
 }
 
-// Type returns the RoleConfiguration type.
-func (r *Role) Type() ConfigurationType {
+// ConfigurationType returns the RoleConfiguration type.
+func (r *Role) ConfigurationType() ConfigurationType {
 	return RoleConfiguration
 }

--- a/pkg/declarativeconfig/transform/transformer.go
+++ b/pkg/declarativeconfig/transform/transformer.go
@@ -33,10 +33,10 @@ type universalTransformer struct {
 }
 
 func (t *universalTransformer) Transform(config declarativeconfig.Configuration) (map[reflect.Type][]proto.Message, error) {
-	ct, exists := t.configurationTransformers[config.Type()]
+	ct, exists := t.configurationTransformers[config.ConfigurationType()]
 	if !exists {
 		return nil, errox.InvariantViolation.Newf("no transformation logic for declarative config type %s found",
-			config.Type())
+			config.ConfigurationType())
 	}
 	return ct.Transform(config)
 }

--- a/roxctl/declarativeconfig/create/access_scope.go
+++ b/roxctl/declarativeconfig/create/access_scope.go
@@ -46,7 +46,7 @@ func accessScopeCommand(cliEnvironment environment.Environment) *cobra.Command {
 	accessScopeCmd := accessScopeCmd{accessScope: &declarativeconfig.AccessScope{}, env: cliEnvironment}
 
 	cmd := &cobra.Command{
-		Use:   accessScopeCmd.accessScope.Type(),
+		Use:   accessScopeCmd.accessScope.ConfigurationType(),
 		Short: "Create a declarative configuration for an access scope",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -149,7 +149,7 @@ func (a *accessScopeCmd) PrintYAML() error {
 	}
 	if a.configMap != "" || a.secret != "" {
 		return errors.Wrap(k8sobject.WriteToK8sObject(context.Background(), a.configMap, a.secret, a.namespace,
-			fmt.Sprintf("%s-%s", a.accessScope.Type(), a.accessScope.Name), yamlOut.Bytes()),
+			fmt.Sprintf("%s-%s", a.accessScope.ConfigurationType(), a.accessScope.Name), yamlOut.Bytes()),
 			"writing the YAML output to config map")
 	}
 

--- a/roxctl/declarativeconfig/create/auth_provider.go
+++ b/roxctl/declarativeconfig/create/auth_provider.go
@@ -23,7 +23,7 @@ func authProviderCommand(cliEnvironment environment.Environment) *cobra.Command 
 	authProviderCmd := &authProviderCmd{authProvider: &declarativeconfig.AuthProvider{}, env: cliEnvironment}
 
 	cmd := &cobra.Command{
-		Use:   authProviderCmd.authProvider.Type(),
+		Use:   authProviderCmd.authProvider.ConfigurationType(),
 		Short: "Commands to create a declarative configuration for an auth provider",
 	}
 
@@ -325,7 +325,7 @@ func (a *authProviderCmd) PrintYAML() error {
 	}
 	if a.configMap != "" || a.secret != "" {
 		return errors.Wrap(k8sobject.WriteToK8sObject(context.Background(), a.configMap, a.secret, a.namespace,
-			fmt.Sprintf("%s-%s", a.authProvider.Type(), a.authProvider.Name), yamlOut.Bytes()),
+			fmt.Sprintf("%s-%s", a.authProvider.ConfigurationType(), a.authProvider.Name), yamlOut.Bytes()),
 			"writing the YAML output to config map")
 	}
 

--- a/roxctl/declarativeconfig/create/permission_set.go
+++ b/roxctl/declarativeconfig/create/permission_set.go
@@ -24,7 +24,7 @@ func permissionSetCommand(cliEnvironment environment.Environment) *cobra.Command
 	permSetCmd := &permissionSetCmd{permissionSet: &declarativeconfig.PermissionSet{}, env: cliEnvironment}
 
 	cmd := &cobra.Command{
-		Use:  permSetCmd.permissionSet.Type(),
+		Use:  permSetCmd.permissionSet.ConfigurationType(),
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := permSetCmd.Construct(cmd); err != nil {
@@ -111,7 +111,7 @@ func (p *permissionSetCmd) PrintYAML() error {
 	}
 	if p.configMap != "" || p.secret != "" {
 		return errors.Wrap(k8sobject.WriteToK8sObject(context.Background(), p.configMap, p.secret, p.namespace,
-			fmt.Sprintf("%s-%s", p.permissionSet.Type(), p.permissionSet.Name), yamlOutput.Bytes()),
+			fmt.Sprintf("%s-%s", p.permissionSet.ConfigurationType(), p.permissionSet.Name), yamlOutput.Bytes()),
 			"writing the YAML output to config map")
 	}
 

--- a/roxctl/declarativeconfig/create/role.go
+++ b/roxctl/declarativeconfig/create/role.go
@@ -19,7 +19,7 @@ func roleCommand(cliEnvironment environment.Environment) *cobra.Command {
 	roleCmd := &roleCmd{role: &declarativeconfig.Role{}, env: cliEnvironment}
 
 	cmd := &cobra.Command{
-		Use:  roleCmd.role.Type(),
+		Use:  roleCmd.role.ConfigurationType(),
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := roleCmd.Construct(cmd); err != nil {
@@ -75,7 +75,7 @@ func (r *roleCmd) PrintYAML() error {
 	}
 	if r.configMap != "" || r.secret != "" {
 		return errors.Wrap(k8sobject.WriteToK8sObject(context.Background(), r.configMap, r.secret, r.namespace,
-			fmt.Sprintf("%s-%s", r.role.Type(), r.role.Name),
+			fmt.Sprintf("%s-%s", r.role.ConfigurationType(), r.role.Name),
 			yamlOutput.Bytes()), "writing the YAML output to config map")
 	}
 	if _, err := r.env.InputOutput().Out().Write(yamlOutput.Bytes()); err != nil {


### PR DESCRIPTION
## Description

Based on this discussion: https://github.com/stackrox/stackrox/pull/6172#discussion_r1206101388
TLDR integration health of integration need to have different ID from declarative config health - that's why the prefix is added.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
