### PR TITLE
Introduce environment variable to skip fetching image signatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 - A default role `Network Graph Viewer` has been added that provides sufficient privileges to display network graphs.
 - A new command `roxctl central login` has been added that allows to use a user's token within roxctl instead of an API token or admin password.
 - ROX-15447: A new `DelegatedRegistryConfig` API at `/v1/delegatedregistryconfig` has been added that provides dynamic configuration for local registry scanning (replaces `ROX_FORCE_LOCAL_IMAGE_SCANNING`).
+- A new environment variable `ROX_DISABLE_SIGNATURE_FETCHING` has been added to Central and Sensor which stops fetching image signatures in case the signature verification feature shall not be used.
+  You may set this in case there's too much load on registries due to attempts to fetch image signatures.
+  Note that if the environment variable is set, no signatures will be fetched and thus the signature verification feature cannot be used.
 
 ### Removed Features
 - ROX-14398: As announced in 3.74, the permission `Access` replaces the deprecated permission `Role`.

--- a/pkg/env/signature.go
+++ b/pkg/env/signature.go
@@ -1,0 +1,6 @@
+package env
+
+var (
+	// DisableSignatureFetching disables signature fetching within the reprocessing loop.
+	DisableSignatureFetching = RegisterBooleanSetting("ROX_DISABLE_SIGNATURE_FETCHING", false)
+)


### PR DESCRIPTION
## Description

We've recently had a customer case where the registry of the customer was under a lot of load due to signature fetching. While [this PR](https://github.com/stackrox/stackrox/pull/6158) reduces the amount of calls made to the registry, in case customers are not using the signature verification feature at all, 
we also shouldn't eagerly fetch image signatures.

For that, the PR introduces the environment variable `ROX_DISABLE_SIGNATURE_FETCHING`, which can be set by customers to a) stop fetching image signatures and verification and b) remove all signatures from existing images.

Note that the scope currently is only to have this environment variable on Central, but it may be extended to Sensor as well (within the local scanning cases, as well as the delegated scanning feature that will be released soon).

For now though, Central should suffice.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

