### PR TITLE
release-3.74 : CI: Backport cluster logging

### DIFF
--- a/.openshift-ci/pre_tests.py
+++ b/.openshift-ci/pre_tests.py
@@ -12,12 +12,23 @@ class NullPreTest:
 
 class PreSystemTests:
     """
-    PreSystemTests - System tests (upgrade, e2e) need images.
+    PreSystemTests - System tests (upgrade, e2e) need images and have a target
+    cluster from which to get information.
     """
 
+    VERSIONS_TIMEOUT = 10 * 60
     POLL_TIMEOUT = 60 * 60
 
     def run(self):
+        subprocess.run(
+            [
+                "scripts/ci/lib.sh",
+                "highlight_cluster_versions",
+            ],
+            check=False,
+            timeout=PreSystemTests.VERSIONS_TIMEOUT,
+        )
+
         subprocess.run(
             [
                 "scripts/ci/lib.sh",

--- a/scripts/ci/gke.sh
+++ b/scripts/ci/gke.sh
@@ -329,6 +329,7 @@ LINK
 
     cat >> "$artifact_file" <<- FOOT
     </ul>
+  </body>
 </html>
 FOOT
 }

--- a/scripts/ci/gke.sh
+++ b/scripts/ci/gke.sh
@@ -294,9 +294,14 @@ create_log_explorer_links() {
     artifact_file="$ARTIFACT_DIR/gke-logs-summary.html"
 
     cat > "$artifact_file" <<- HEAD
-<html style="background: #fff">
+<html>
     <head>
         <title><h4>GKE Logs Explorer</h4></title>
+        <style>
+          body { color: #e8e8e8; background-color: #424242; font-family: "Roboto", "Helvetica", "Arial", sans-serif }
+          a { color: #ff8caa }
+          a:visited { color: #ff8caa }
+        </style>
     </head>
     <body>
     <p>(These links require a 'right-click -> open in new tab'. The authUser is the number for your @stackrox.com account.)</p>

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -1518,9 +1518,14 @@ highlight_cluster_versions() {
     artifact_file="$ARTIFACT_DIR/cluster-version-summary.html"
 
     cat > "$artifact_file" <<- HEAD
-<html style="background: #fff">
+<html>
     <head>
         <title><h4>Cluster Versions</h4></title>
+        <style>
+          body { color: #e8e8e8; background-color: #424242; font-family: "Roboto", "Helvetica", "Arial", sans-serif }
+          a { color: #ff8caa }
+          a:visited { color: #ff8caa }
+        </style>
     </head>
     <body>
 HEAD

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -1527,8 +1527,10 @@ HEAD
 
     local nodes
     nodes="$(kubectl get nodes -o wide 2>&1 || true)"
-    local versions
-    versions="$(kubectl version -o json 2>&1 || true)"
+    local kubectl_version
+    kubectl_version="$(kubectl version -o json 2>&1 || true)"
+    local oc_version
+    oc_version="$(oc version -o json 2>&1 || true)"
 
     cat >> "$artifact_file" << DETAILS
       <h3>Nodes:</h3>
@@ -1536,7 +1538,9 @@ HEAD
       <pre>$nodes</pre>
       <h3>Versions:</h3>
       kubectl version -o json
-      <pre>$versions</pre>
+      <pre>$kubectl_version</pre>
+      oc version -o json
+      <pre>$oc_version</pre>
 DETAILS
 
     cat >> "$artifact_file" <<- FOOT

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -1509,6 +1509,44 @@ slack_prow_notice() {
 | curl -XPOST -d @- -H 'Content-Type: application/json' "$webhook_url"
 }
 
+highlight_cluster_versions() {
+    if [[ -z "${ARTIFACT_DIR:-}" ]]; then
+        info "No place for artifacts, skipping cluster version dump"
+        return
+    fi
+
+    artifact_file="$ARTIFACT_DIR/cluster-version-summary.html"
+
+    cat > "$artifact_file" <<- HEAD
+<html style="background: #fff">
+    <head>
+        <title><h4>Cluster Versions</h4></title>
+    </head>
+    <body>
+HEAD
+
+    local nodes
+    nodes="$(kubectl get nodes -o wide 2>&1 || true)"
+    local versions
+    versions="$(kubectl version -o json 2>&1 || true)"
+
+    cat >> "$artifact_file" << DETAILS
+      <h3>Nodes:</h3>
+      kubectl get nodes -o wide
+      <pre>$nodes</pre>
+      <h3>Versions:</h3>
+      kubectl version -o json
+      <pre>$versions</pre>
+DETAILS
+
+    cat >> "$artifact_file" <<- FOOT
+    <br />
+    <br />
+  </body>
+</html>
+FOOT
+}
+
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
     if [[ "$#" -lt 1 ]]; then
         die "When invoked at the command line a method is required."

--- a/scripts/ci/store-artifacts.sh
+++ b/scripts/ci/store-artifacts.sh
@@ -145,31 +145,52 @@ make_artifacts_help() {
     local help_file
     if is_OPENSHIFT_CI; then
         require_environment "ARTIFACT_DIR"
-        help_file="$ARTIFACT_DIR/howto-locate-other-artifacts.html"
-    elif is_CIRCLECI; then
-        help_file="/tmp/howto-locate-artifacts.html"
+        help_file="$ARTIFACT_DIR/howto-locate-other-artifacts-summary.html"
     else
         die "This is an unsupported environment"
     fi
 
     cat > "$help_file" <<- EOH
-        Artifacts are stored in a GCS bucket ($GS_URL). There are at least two options for access:
+        <html>
+        <head>
+        <title><h4>Additional StackRox e2e artifacts</h4></title>
+        <style>
+          body { color: #e8e8e8; background-color: #424242; font-family: "Roboto", "Helvetica", "Arial", sans-serif }
+          a { color: #ff8caa }
+          a:visited { color: #ff8caa }
+        </style>
+        </head>
+        <body>
 
-        <h3>gsutil cp</h3>
+        Additional StackRox e2e artifacts are stored in a GCS bucket (<code>$GS_URL</code>) by the
+        <code>store_artifacts</code> bash function.<br>
+
+        There are at least two options for access:
+
+        <h2>Option 1: gsutil cp</h2>
 
         Copy all artifacts for the build/job:
         <pre>gsutil -m cp -r $gs_job_url .</pre>
 
-        Copy all artifacts for the entire workflow:
+        or copy all artifacts for the entire workflow:
         <pre>gsutil -m cp -r $gs_workflow_url .</pre>
 
-        <h3>Browse using the google cloud UI</h3>
+        Then browse files locally.
 
-        <p>The URL you use will depend on the <i>authuser</i> value you use for your @stackrox.com account.</p>
+        <h2>Option 2: Browse using the Google cloud UI</h2>
+
+        <p>Make sure to use the URL where <code>authuser</code> corresponds to your @stackrox.com account.<br>
+        You can check this by clicking on the user avatar in the top right corner of Google Cloud Console page
+        after following the link.</p>
 
         <a href="$browser_job_url?authuser=0">authuser=0</a><br>
         <a href="$browser_job_url?authuser=1">authuser=1</a><br>
         <a href="$browser_job_url?authuser=2">authuser=2</a><br>
+
+        <br><br>
+
+        </body>
+        </html>
 EOH
 
     info "Artifacts are stored in a GCS bucket ($GS_URL)"


### PR DESCRIPTION
## Description

The release-3.74 branch is missing some useful info e.g. what OCP version is it running. This PR backports the changes for that.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient. The failures are OK IMO. There was an imaging glitch. I'm running one full gke-qa for sanity.
