### PR TITLE
Bump react-user-feedback to latest verions, 1.1.2

### DIFF
--- a/ui/apps/platform/package.json
+++ b/ui/apps/platform/package.json
@@ -19,7 +19,7 @@
         "@patternfly/react-styles": "4.92.6",
         "@patternfly/react-table": "4.112.39",
         "@patternfly/react-topology": "4.93.5",
-        "@patternfly/react-user-feedback": "^1.0.9",
+        "@patternfly/react-user-feedback": "^1.1.2",
         "@stackrox/ui-components": "*",
         "axios": "^0.25.0",
         "classnames": "^2.3.2",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -3497,10 +3497,10 @@
     tslib "^2.0.0"
     webcola "3.4.0"
 
-"@patternfly/react-user-feedback@^1.0.9":
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-user-feedback/-/react-user-feedback-1.0.9.tgz#87ed69561336337d8004caebb8be2ddfbfd27771"
-  integrity sha512-dhYe3CCIltf0wPcnTA8TvzoFkQm77rE8P8OyD3aKIrFGuOGSrj05lwhJuDfpSYLH4RqIP9NDT/eh8wpAsLaA+Q==
+"@patternfly/react-user-feedback@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-user-feedback/-/react-user-feedback-1.1.2.tgz#be7c8b051c983696b5163991ab3c2bbaa2411c5e"
+  integrity sha512-Z7NVUMb1FrbxvUwG6IYRCjQmwIt2T4lDSQKicf1toStZMK+tVezoZX3yiTTmrexOP6wdXLAC61Ur6Ioykuxk5g==
   dependencies:
     "@patternfly/react-core" "^4.276.6"
     "@patternfly/react-icons" "^4.93.6"


### PR DESCRIPTION
## Description

Upgrading to the latest prerelease to make sure it didn’t break. This will be the last upgrade we will do before the ACS 4.1.0 release is cut


## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

Upgrade seems to have worked. 

Besides the change to package.json, it looks like the only line in yarn.lock that changed is the entry for the extension package itself. (No dependency bumps)

I submitted a form, and it went through, So, I think it is successfully smoke-tested.
https://issues.redhat.com/projects/RHPF/issues/RHPF-15?filter=allissues#:~:text=Hat%20Product%20Feedback-,RHPF%2D15,-RH%20Product%20Feedback