### PR TITLE
ROX-16980: Added API changes for aggregatedresults

### DIFF
--- a/central/compliance/service/service_impl.go
+++ b/central/compliance/service/service_impl.go
@@ -154,14 +154,6 @@ func (s *serviceImpl) GetRunResults(ctx context.Context, request *v1.GetComplian
 	if err != nil {
 		return nil, err
 	}
-	config, exist, errConfig := s.complianceDataStore.GetConfig(ctx, request.GetStandardId())
-	if errConfig != nil {
-		return nil, errConfig
-	}
-	if exist && config.GetHideScanResults() {
-		return nil, errors.Errorf("Results are hidden for standard with ID %s", request.GetStandardId())
-	}
-
 	return &v1.GetComplianceRunResultsResponse{
 		Results:    results.LastSuccessfulResults,
 		FailedRuns: results.FailedRuns,

--- a/central/compliance/service/service_impl.go
+++ b/central/compliance/service/service_impl.go
@@ -133,7 +133,7 @@ func (s *serviceImpl) GetAggregatedResults(ctx context.Context, request *v1.Comp
 		if err != nil {
 			return nil, err
 		}
-		//Not exists implies standards is not hidden
+		// Not exists implies standards is not hidden
 		if exists && config.GetHideScanResults() {
 			continue
 		}

--- a/central/compliance/service/service_impl.go
+++ b/central/compliance/service/service_impl.go
@@ -99,7 +99,7 @@ func (s *serviceImpl) GetStandards(ctx context.Context, _ *v1.Empty) (*v1.GetCom
 	}, nil
 }
 
-// GetStandard returns details + controls for a given standard
+// GetStandard returns details and controls for a given standard
 func (s *serviceImpl) GetStandard(ctx context.Context, req *v1.ResourceByID) (*v1.GetComplianceStandardResponse, error) {
 	standard, exists, err := s.standardsRepo.Standard(req.GetId())
 	if err != nil {
@@ -129,11 +129,11 @@ func (s *serviceImpl) GetAggregatedResults(ctx context.Context, request *v1.Comp
 
 	filteredSources := sources[:0]
 	for _, source := range sources {
-		config, exist, errConfig := s.complianceDataStore.GetConfig(ctx, source.GetStandardId())
+		config, exists, errConfig := s.complianceDataStore.GetConfig(ctx, source.GetStandardId())
 		if errConfig != nil {
 			return nil, errConfig
 		}
-		if !exist || !config.GetHideScanResults() {
+		if !exists || !config.GetHideScanResults() {
 			filteredSources = append(filteredSources, source)
 		}
 	}

--- a/central/compliance/service/service_impl.go
+++ b/central/compliance/service/service_impl.go
@@ -129,9 +129,9 @@ func (s *serviceImpl) GetAggregatedResults(ctx context.Context, request *v1.Comp
 
 	filteredSources := sources[:0]
 	for _, source := range sources {
-		config, exsist, err_config := s.complianceDataStore.GetConfig(ctx, source.GetStandardId())
-		if err_config != nil {
-			return nil, err_config
+		config, exsist, errConfig := s.complianceDataStore.GetConfig(ctx, source.GetStandardId())
+		if errConfig != nil {
+			return nil, errConfig
 		}
 		if !exsist || !config.GetHideScanResults() {
 			filteredSources = append(filteredSources, source)
@@ -154,9 +154,9 @@ func (s *serviceImpl) GetRunResults(ctx context.Context, request *v1.GetComplian
 	if err != nil {
 		return nil, err
 	}
-	config, exist, err_config := s.complianceDataStore.GetConfig(ctx, request.GetStandardId())
-	if err_config != nil {
-		return nil, err_config
+	config, exist, errConfig := s.complianceDataStore.GetConfig(ctx, request.GetStandardId())
+	if errConfig != nil {
+		return nil, errConfig
 	}
 	if exist && config.GetHideScanResults() {
 		return nil, errors.New("Results are hidden for this standard")

--- a/central/compliance/service/service_impl.go
+++ b/central/compliance/service/service_impl.go
@@ -129,11 +129,11 @@ func (s *serviceImpl) GetAggregatedResults(ctx context.Context, request *v1.Comp
 
 	filteredSources := sources[:0]
 	for _, source := range sources {
-		config, exsist, errConfig := s.complianceDataStore.GetConfig(ctx, source.GetStandardId())
-		if errConfig != nil {
+		config, exist, errConfig := s.complianceDataStore.GetConfig(ctx, source.GetStandardId())
+		if err != nil {
 			return nil, errConfig
 		}
-		if !exsist || !config.GetHideScanResults() {
+		if !exist || !config.GetHideScanResults() {
 			filteredSources = append(filteredSources, source)
 		}
 	}

--- a/central/compliance/service/service_impl.go
+++ b/central/compliance/service/service_impl.go
@@ -130,7 +130,7 @@ func (s *serviceImpl) GetAggregatedResults(ctx context.Context, request *v1.Comp
 	filteredSources := sources[:0]
 	for _, source := range sources {
 		config, exist, errConfig := s.complianceDataStore.GetConfig(ctx, source.GetStandardId())
-		if err != nil {
+		if errConfig != nil {
 			return nil, errConfig
 		}
 		if !exist || !config.GetHideScanResults() {

--- a/central/compliance/service/service_impl.go
+++ b/central/compliance/service/service_impl.go
@@ -129,8 +129,11 @@ func (s *serviceImpl) GetAggregatedResults(ctx context.Context, request *v1.Comp
 
 	filteredSources := sources[:0]
 	for _, source := range sources {
-		config, exsist, _ := s.complianceDataStore.GetConfig(ctx, source.GetStandardId())
-		if !exsist || !config.HideScanResults {
+		config, exsist, err_config := s.complianceDataStore.GetConfig(ctx, source.GetStandardId())
+		if err_config != nil {
+			return nil, err_config
+		}
+		if !exsist || !config.GetHideScanResults() {
 			filteredSources = append(filteredSources, source)
 		}
 	}
@@ -151,9 +154,12 @@ func (s *serviceImpl) GetRunResults(ctx context.Context, request *v1.GetComplian
 	if err != nil {
 		return nil, err
 	}
-	config, exsist, _ := s.complianceDataStore.GetConfig(ctx, request.GetStandardId())
-	if exsist && config.GetHideScanResults() {
-		return nil, errors.New("Results are hidden for this stadard")
+	config, exist, err_config := s.complianceDataStore.GetConfig(ctx, request.GetStandardId())
+	if err_config != nil {
+		return nil, err_config
+	}
+	if exist && config.GetHideScanResults() {
+		return nil, errors.New("Results are hidden for this standard")
 	}
 
 	return &v1.GetComplianceRunResultsResponse{

--- a/central/compliance/service/service_impl.go
+++ b/central/compliance/service/service_impl.go
@@ -159,7 +159,7 @@ func (s *serviceImpl) GetRunResults(ctx context.Context, request *v1.GetComplian
 		return nil, errConfig
 	}
 	if exist && config.GetHideScanResults() {
-		return nil, errors.New("Results are hidden for this standard")
+		return nil, errors.Errorf("Results are hidden for standard with ID %s", request.GetStandardId())
 	}
 
 	return &v1.GetComplianceRunResultsResponse{


### PR DESCRIPTION
Changes to get aggregated results and run results API to filter results based on standards


## Testing Performed
Manually tested APIs

Set hideScanResults for IST_SP_800_53_Rev_4 to true

API response
1. GET v1/compliance/runresults?standardId=NIST_SP_800_53_Rev_4&clusterId=506f3088-28ab-4b8f-a8e9-9bde9ccbbefc
{
    "error": "Results are hidden for this stadard",
    "code": 13,
    "message": "Results are hidden for this stadard",
    "details": []
}

2. GET v1/compliance/aggregatedresults
{
    "results": [
        {
            "aggregationKeys": [],
            "unit": "CHECK",
            "numPassing": 771,
            "numFailing": 241,
            "numSkipped": 857
        }
    ],
    "sources": [
        {
            "clusterId": "506f3088-28ab-4b8f-a8e9-9bde9ccbbefc",
            "standardId": "PCI_DSS_3_2",
            "successfulRun": {
                "runId": "0b3d25d6-63ee-4c84-bce6-bbbb0fda9092",
                "standardId": "PCI_DSS_3_2",
                "clusterId": "506f3088-28ab-4b8f-a8e9-9bde9ccbbefc",
                "startTimestamp": "2023-05-31T23:08:03.518417407Z",
                "finishTimestamp": "2023-05-31T23:08:06.209039627Z",
                "success": true,
                "errorMessage": "",
                "domainId": "572467db-79a3-4c69-a461-1a46bb95e8cc"
            },
            "failedRuns": []
        },
        {
            "clusterId": "506f3088-28ab-4b8f-a8e9-9bde9ccbbefc",
            "standardId": "CIS_Docker_v1_2_0",
            "successfulRun": {
                "runId": "56818aed-508d-4933-b733-ccf4f948b4c3",
                "standardId": "CIS_Docker_v1_2_0",
                "clusterId": "506f3088-28ab-4b8f-a8e9-9bde9ccbbefc",
                "startTimestamp": "2023-05-31T23:08:03.520272020Z",
                "finishTimestamp": "2023-05-31T23:08:06.195619765Z",
                "success": true,
                "errorMessage": "",
                "domainId": "572467db-79a3-4c69-a461-1a46bb95e8cc"
            },
            "failedRuns": []
        },
        {
            "clusterId": "506f3088-28ab-4b8f-a8e9-9bde9ccbbefc",
            "standardId": "CIS_Kubernetes_v1_5",
            "successfulRun": {
                "runId": "9b74bfc6-0e8c-4273-aa35-6b6b3a585677",
                "standardId": "CIS_Kubernetes_v1_5",
                "clusterId": "506f3088-28ab-4b8f-a8e9-9bde9ccbbefc",
                "startTimestamp": "2023-05-31T23:08:03.517528930Z",
                "finishTimestamp": "2023-05-31T23:08:06.188827239Z",
                "success": true,
                "errorMessage": "",
                "domainId": "572467db-79a3-4c69-a461-1a46bb95e8cc"
            },
            "failedRuns": []
        },
        {
            "clusterId": "506f3088-28ab-4b8f-a8e9-9bde9ccbbefc",
            "standardId": "HIPAA_164",
            "successfulRun": {
                "runId": "c411b287-90a4-445d-94f8-4eae71fb0444",
                "standardId": "HIPAA_164",
                "clusterId": "506f3088-28ab-4b8f-a8e9-9bde9ccbbefc",
                "startTimestamp": "2023-05-31T23:08:03.517841690Z",
                "finishTimestamp": "2023-05-31T23:08:06.197184658Z",
                "success": true,
                "errorMessage": "",
                "domainId": "572467db-79a3-4c69-a461-1a46bb95e8cc"
            },
            "failedRuns": []
        },
        {
            "clusterId": "506f3088-28ab-4b8f-a8e9-9bde9ccbbefc",
            "standardId": "NIST_800_190",
            "successfulRun": {
                "runId": "5e4b6f51-b686-4e40-9819-851d2a749188",
                "standardId": "NIST_800_190",
                "clusterId": "506f3088-28ab-4b8f-a8e9-9bde9ccbbefc",
                "startTimestamp": "2023-05-31T23:08:03.517911617Z",
                "finishTimestamp": "2023-05-31T23:08:06.208760412Z",
                "success": true,
                "errorMessage": "",
                "domainId": "572467db-79a3-4c69-a461-1a46bb95e8cc"
            },
            "failedRuns": []
        }
    ],
    "errorMessage": ""
}