### PR TITLE
Delete unneeded Tailwind font weight (part 2)

### DIFF
--- a/ui/apps/platform/src/Components/RelatedEntityListCount.js
+++ b/ui/apps/platform/src/Components/RelatedEntityListCount.js
@@ -24,7 +24,7 @@ const RelatedEntityListCount = ({ match, location, history, name, value, entityT
         history.push(url);
     }
 
-    const content = <div className="font-400 text-6xl text-lg text-primary-700">{value}</div>;
+    const content = <div className="text-6xl text-lg text-primary-700">{value}</div>;
 
     const result = (
         <button

--- a/ui/apps/platform/src/Components/visuals/SunburstDetailSection.js
+++ b/ui/apps/platform/src/Components/visuals/SunburstDetailSection.js
@@ -81,19 +81,18 @@ class SunburstDetailSection extends Component {
                         idx
                     ) => {
                         const color = textColor || graphColor;
+                        console.log(idx, parentDatum?.name, text, color, labelValue, labelColor); // eslint-disable-line no-console
                         return (
                             <div
                                 key={text}
-                                className={`widget-detail-bullet border-b border-base-300 pb-3 mb-1 font-600 ${
-                                    parentDatum && parentDatum.name && idx === 0
-                                        ? 'text-base-500'
-                                        : ''
-                                }`}
+                                className="widget-detail-bullet border-b border-base-300 pb-3 mb-1"
                             >
                                 {link && (
                                     <Link
                                         title={text}
-                                        className={`underline leading-normal flex w-full word-break ${className}`}
+                                        className={`underline leading-normal flex w-full word-break ${
+                                            className ?? ''
+                                        }`}
                                         style={color ? { color } : null}
                                         to={link}
                                     >

--- a/ui/apps/platform/src/Components/visuals/SunburstDetailSection.js
+++ b/ui/apps/platform/src/Components/visuals/SunburstDetailSection.js
@@ -67,21 +67,17 @@ class SunburstDetailSection extends Component {
         return (
             <div className="py-2 px-3 lc:border-none lc:mb-0 lc:pb-0">
                 {bullets.map(
-                    (
-                        {
-                            text,
-                            link,
-                            className,
-                            value,
-                            color: graphColor,
-                            textColor,
-                            labelValue,
-                            labelColor,
-                        },
-                        idx
-                    ) => {
+                    ({
+                        text,
+                        link,
+                        className,
+                        value,
+                        color: graphColor,
+                        textColor,
+                        labelValue,
+                        labelColor,
+                    }) => {
                         const color = textColor || graphColor;
-                        console.log(idx, parentDatum?.name, text, color, labelValue, labelColor); // eslint-disable-line no-console
                         return (
                             <div
                                 key={text}

--- a/ui/apps/platform/src/Containers/BreadCrumbs/EntityBreadCrumb.js
+++ b/ui/apps/platform/src/Containers/BreadCrumbs/EntityBreadCrumb.js
@@ -16,11 +16,11 @@ const EntityBreadCrumb = ({ workflowEntity, url }) => {
     return (
         <span className="flex flex-col max-w-full" data-testid="breadcrumb-link-text">
             {url ? (
-                <Link className="text-primary-700 underline" title={title} to={url}>
+                <Link className="text-primary-700 underline font-700" title={title} to={url}>
                     {title}
                 </Link>
             ) : (
-                <span className="w-full truncate" title={title}>
+                <span className="w-full truncate font-700" title={title}>
                     {title}
                 </span>
             )}

--- a/ui/apps/platform/src/Containers/BreadCrumbs/EntityBreadCrumbs.js
+++ b/ui/apps/platform/src/Containers/BreadCrumbs/EntityBreadCrumbs.js
@@ -101,7 +101,7 @@ const BreadCrumbLinks = ({ workflowEntities }) => {
     return (
         <span
             style={{ flex: '10 1' }}
-            className="flex items-center font-700 leading-normal text-base-600 truncate"
+            className="flex items-center leading-normal text-base-600 truncate"
         >
             <BackLink workflowState={workflowState} enabled={backButtonEnabled} />
             {breadCrumbLinks}

--- a/ui/apps/platform/src/Containers/Compliance/widgets/ComplianceByStandard.js
+++ b/ui/apps/platform/src/Containers/Compliance/widgets/ComplianceByStandard.js
@@ -26,7 +26,7 @@ const cautionColor = IMPORTANT_HIGH_SEVERITY_COLOR;
 const skippedColor = 'var(--base-400)'; // same as NAColor in ComplianceByControls
 const alertColor = CRITICAL_SEVERITY_COLOR;
 
-const linkColor = 'var(--primary-600)'; // TODO might be able to remove after PatternFly dark theme
+const linkColor = 'var(--base-600)';
 const textColor = 'var(--base-600)';
 
 const getColor = (value) => {

--- a/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/widgets/ComplianceByControls.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/widgets/ComplianceByControls.js
@@ -24,7 +24,7 @@ const passingColor = COMPLIANCE_PASS_COLOR;
 const failingColor = COMPLIANCE_FAIL_COLOR;
 const NAColor = 'var(--base-400)'; // same as skippedColor in ComplianceByStandards
 
-const linkColor = 'var(--primary-600)'; // TODO might be able to remove after PatternFly dark theme
+const linkColor = 'var(--base-600)';
 const textColor = 'var(--base-600)';
 
 const sunburstLegendData = [

--- a/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/widgets/PolicyViolationsBySeverity.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/widgets/PolicyViolationsBySeverity.js
@@ -24,7 +24,7 @@ const legendData = policySeverities.map((severity) => ({
     color: policySeverityColorMap[severity],
 }));
 
-const linkColor = 'var(--primary-600)'; // TODO might be able to remove after PatternFly dark theme
+const linkColor = 'var(--base-600)';
 const textColor = 'var(--base-600)';
 const passingChartColor = 'var(--base-400)';
 

--- a/ui/apps/platform/src/Containers/ConfigManagement/SidePanel/BreadCrumbs.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/SidePanel/BreadCrumbs.js
@@ -96,12 +96,16 @@ const BreadCrumbLinks = (props) => {
         const link = getLink(match, location, i, length);
         const name = state.type === 'entity list' ? upperFirst(state.name) : state.name;
         const content = link ? (
-            <Link className="text-primary-700 underline truncate" title={state.name} to={link}>
+            <Link
+                className="text-primary-700 underline truncate font-700"
+                title={state.name}
+                to={link}
+            >
                 {name}
             </Link>
         ) : (
             <span className="w-full truncate" title={state.name}>
-                <span className="truncate">{name}</span>
+                <span className="truncate font-700">{name}</span>
             </span>
         );
         if (!state) {

--- a/ui/apps/platform/src/Containers/ConfigManagement/SidePanel/SidePanel.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/SidePanel/SidePanel.js
@@ -98,7 +98,7 @@ const SidePanel = ({
             <PanelNew testid="side-panel">
                 <PanelHead>
                     <BreadCrumbs
-                        className="font-700 leading-normal text-base-600 truncate"
+                        className="leading-normal text-base-600 truncate"
                         entityType1={entityType1 || entityListType1}
                         entityId1={entityId1}
                         entityType2={entityType2}

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Policy/VulnMgmtPolicyOverview.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Policy/VulnMgmtPolicyOverview.js
@@ -259,7 +259,7 @@ const VulnMgmtPolicyOverview = ({ data, entityContext, setRefreshTrigger }) => {
                     const failingDeployments = policyData.deployments;
                     const totalCount = policyData.deploymentCount;
                     const headerText = `${totalCount} ${pluralize(
-                        entityTypes.DEPLOYMENT,
+                        'deployment',
                         totalCount
                     )} ${pluralizeHas(totalCount)} failed across this policy`;
                     return (

--- a/ui/apps/platform/src/app.tw.css
+++ b/ui/apps/platform/src/app.tw.css
@@ -964,7 +964,7 @@ h6 {
 /* widget detail */
 .widget-detail-bullet {
     position: relative;
-    @apply font-500 py-2 px-1;
+    @apply py-2 px-1;
 }
 
 .widget-detail-bullet::before {


### PR DESCRIPTION
## Description

Remove inconsistencies that I have noticed during manual testing for integration test failures. In some cases search for source of one problem lead to related problems.

### Problem

* Classic contrast between bold font-700 and normal font-600 was sometimes too subtle to see.
* PatternFly contrast between bold font-700 and normal font-400 makes obvious some inconsistent unneeded bold formatting. Especially combination of light color with bold weight.

### Solution

1. Delete rare `font-400` normal font weight that is redundant now.

    * RelatedEntityListCount

2. Delete `font-600` almost-bold font weight and `text-base-500` light color for supporting text like count of policies violated.

    * SunburstDetailSection also prevent `undefined` in `class` attribute

3. Move `font-700` bold font weight from Vulnerability Management workflow breadcrumbs container to upper text of each breadcrumb so it contrasts with normal font weight for lower text.

    * EntityBreadCrumb
    * EntityBreadCrumbs

4. Replace 3 occurrences `var(--primary-600)` with `var(--base-600)` to increase contrast with normal font weight.

    * ComplianceByStandard
    * ComplianceByControls
    * PolicyViolationsBySeverity

5. Move `font-700` bold font weight from Configuration Management breadcrumbs container to upper text of each breadcrumb so it contrasts with normal font weight for lower text.

    * BreadCrumbs
    * SidePanel

6. Replace internal entity type with external entity type string to fix uppercase in text: 2 DEPLOYMENTS have failed across this policy

    * VulnMgmtPolicyOverview    

7. Delete rare `font-500` slightly-bold font weight for widget-detail-bullet.

    * app.tw.css

## Checklist
- [ ] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

### Compliance

1. Visit /main/compliance: see links have normal text color at the right of sunbursts.

    * dark theme
        ![compliance_dark](https://github.com/stackrox/stackrox/assets/11862657/fe80fab6-447a-4ac3-aa7a-1d9b66b0ec94)

    * light theme
        ![compliance_light](https://github.com/stackrox/stackrox/assets/11862657/ea729309-bfd6-472f-a7dd-b2473192e522)

### Configuration Management

1. Visit /main/configmanagement: see links have normal font weight at the right of Policy Violations by Severity sunburst.

    * dark theme
        ![configmanagement_dashboard_dark](https://github.com/stackrox/stackrox/assets/11862657/e78558fc-0631-4e5b-b988-b4ac4d06e180)

    * light theme
        ![configmanagement_dashboard_light](https://github.com/stackrox/stackrox/assets/11862657/7dfcb8ad-03cf-4802-be28-585792be4d50)

2. Visit /main/configmanagement/policies and click a policy that has **Fail** status: see Policy entity type has normal font weight and also count link in Deployments tile.

    * dark theme
        ![configmanagement_policy_dark](https://github.com/stackrox/stackrox/assets/11862657/ea0ad141-f173-4bdf-aafc-80cc9c66c9ef)

    * light theme
        ![configmanagement_policy_light](https://github.com/stackrox/stackrox/assets/11862657/291a8467-4f88-491e-bdb9-ba7b7fd8aba9)

### Vulnerability Management

1. Visit /main/vulnerability-management/policies and click a policy that has **Fail** status: see lowercase deployments in Policy Findings card.

    * dark theme
        ![vulnerability-management_policy_dark](https://github.com/stackrox/stackrox/assets/11862657/8e7b2e22-1245-4cf4-9da6-eda75c428cc9)

    * light theme
        ![vulnerability-management_policy_light](https://github.com/stackrox/stackrox/assets/11862657/2249ff84-00fc-4e86-aa96-5af77400651c)