### PR TITLE
ROX-17339: UX enhancements for simulate network policy

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPolicySimulatorSidePanel.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPolicySimulatorSidePanel.tsx
@@ -161,7 +161,9 @@ function NetworkPolicySimulatorSidePanel({
                             title={
                                 simulator.error
                                     ? simulator.error
-                                    : 'Policies generated from all network activity'
+                                    : `Policies generated from the baseline for cluster “${
+                                          clusterName ?? ''
+                                      }”`
                             }
                         />
                     </StackItem>

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPolicySimulatorSidePanel.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPolicySimulatorSidePanel.tsx
@@ -20,6 +20,7 @@ import {
 } from '@patternfly/react-core';
 
 import useTabs from 'hooks/patternfly/useTabs';
+import useURLSearch from 'hooks/useURLSearch';
 import ViewActiveYAMLs from './ViewActiveYAMLs';
 import {
     NetworkPolicySimulator,
@@ -27,6 +28,7 @@ import {
 } from '../hooks/useNetworkPolicySimulator';
 import NetworkPoliciesYAML from './NetworkPoliciesYAML';
 import { getDisplayYAMLFromNetworkPolicyModification } from '../utils/simulatorUtils';
+import { getScopeHierarchyFromSearch } from '../utils/hierarchyUtils';
 import UploadYAMLButton from './UploadYAMLButton';
 import NetworkSimulatorActions from './NetworkSimulatorActions';
 import NotifyYAMLModal from './NotifyYAMLModal';
@@ -53,6 +55,9 @@ function NetworkPolicySimulatorSidePanel({
     const [isExcludingPortsAndProtocols, setIsExcludingPortsAndProtocols] =
         React.useState<boolean>(false);
     const [isNotifyModalOpen, setIsNotifyModalOpen] = React.useState(false);
+
+    const { searchFilter } = useURLSearch();
+    const { cluster: clusterName } = getScopeHierarchyFromSearch(searchFilter);
 
     function handleFileInputChange(
         _event: React.ChangeEvent<HTMLInputElement> | React.DragEvent<HTMLElement>,
@@ -291,8 +296,11 @@ function NetworkPolicySimulatorSidePanel({
                 <Flex direction={{ default: 'row' }} className="pf-u-p-lg pf-u-mb-0">
                     <FlexItem>
                         <TextContent>
-                            <Text component={TextVariants.h2} className="pf-u-font-size-xl">
-                                Simulate network policy
+                            <Text
+                                component={TextVariants.h2}
+                                className="pf-u-font-size-xl pf-u-mr-xl"
+                            >
+                                Simulate network policy for cluster “{clusterName}”
                             </Text>
                         </TextContent>
                     </FlexItem>

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPolicySimulatorSidePanel.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPolicySimulatorSidePanel.tsx
@@ -7,6 +7,7 @@ import {
     Divider,
     Flex,
     FlexItem,
+    Popover,
     Spinner,
     Stack,
     StackItem,
@@ -18,6 +19,7 @@ import {
     TextContent,
     TextVariants,
 } from '@patternfly/react-core';
+import { HelpIcon } from '@patternfly/react-icons';
 
 import useTabs from 'hooks/patternfly/useTabs';
 import useURLSearch from 'hooks/useURLSearch';
@@ -336,7 +338,41 @@ function NetworkPolicySimulatorSidePanel({
                                                 component={TextVariants.h2}
                                                 className="pf-u-font-size-lg"
                                             >
-                                                Generate network policies
+                                                Generate network policies based on the baseline
+                                                <Popover
+                                                    showClose={false}
+                                                    bodyContent={
+                                                        <div>
+                                                            <p className="pf-u-mb-sm">
+                                                                A baseline is considered the trusted
+                                                                traffic (incoming and outgoing) for
+                                                                a given entity, like a cluster,
+                                                                namespace, or deployment.
+                                                            </p>
+                                                            <p className="pf-u-mb-sm">
+                                                                It is automatically generated for
+                                                                every deployment, by collecting
+                                                                incoming and outgoing traffic during
+                                                                its first hour of existence.
+                                                            </p>
+                                                            <p>
+                                                                In addition, a user can modify the
+                                                                baseline by adding or removing any
+                                                                active flows that have been observed
+                                                                over a period of time.
+                                                            </p>
+                                                        </div>
+                                                    }
+                                                >
+                                                    <button
+                                                        type="button"
+                                                        aria-label="More info on network baselines"
+                                                        onClick={(e) => e.preventDefault()}
+                                                        className="pf-u-mx-sm pf-u-mt-xs"
+                                                    >
+                                                        <HelpIcon />
+                                                    </button>
+                                                </Popover>
                                             </Text>
                                         </TextContent>
                                     </StackItem>
@@ -344,10 +380,9 @@ function NetworkPolicySimulatorSidePanel({
                                         <TextContent>
                                             <Text component={TextVariants.p}>
                                                 Generate a set of recommended network policies based
-                                                on your environment&apos;s configuration. Select a
-                                                time window for the network connections you would
-                                                like to capture and generate policies on, and then
-                                                apply them directly or share them with your team.
+                                                on your cluster baseline. Cluster baseline is the
+                                                aggregatation of the baselines of the deployments
+                                                that belong to the cluster.
                                             </Text>
                                         </TextContent>
                                     </StackItem>


### PR DESCRIPTION
## Description

Some minor text changes to the Network Policy side panel, based on early feedback of Network Graph 2.0

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

Manual testing for now. (Will update e2e tests if any check detailed wording)

1. Title includes cluster name, and new subhead, and paragraph
<img width="1552" alt="Screen Shot 2023-05-26 at 4 13 52 PM" src="https://github.com/stackrox/stackrox/assets/715729/dcdc64ca-08c9-4603-9532-099215bc3f7c">


2. Popover with explanation of what a baseline is
<img width="1552" alt="Screen Shot 2023-05-26 at 4 13 58 PM" src="https://github.com/stackrox/stackrox/assets/715729/2343b8e7-030e-4ef1-b3f7-3c782caca1fc">


3. Success message now includes cluster name
<img width="1552" alt="Screen Shot 2023-05-26 at 4 14 02 PM" src="https://github.com/stackrox/stackrox/assets/715729/ee8772c1-1da2-4611-bb90-2fd8ac53fbce">
