### PR TITLE
Set merlin team ownership on declarative config

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -21,6 +21,7 @@ proto/storage/risk.proto            @stackrox/core-workflows
 roxctl/**/*     @stackrox/merlin
 pkg/auth/**/*   @stackrox/merlin
 pkg/sac/**/*    @stackrox/merlin
+*/declarativeconfig/**/* @stackrox/merlin
 
 pkg/images/defaults/**/* @stackrox/maple
 


### PR DESCRIPTION
## Description

This PR sets @stackrox/merlin as an owner of `[central|pkg|rox]/declarativeconfig/`

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

N/A
