### PR TITLE
ROX-17209: Add environment variables for sensor restart timers

### DIFF
--- a/sensor/common/sensor/env.go
+++ b/sensor/common/sensor/env.go
@@ -1,0 +1,39 @@
+package sensor
+
+import (
+	"time"
+
+	"github.com/stackrox/rox/pkg/env"
+)
+
+const (
+	defaultInitialInterval = 10 * time.Minute
+	defaultMaxInterval     = time.Minute
+)
+
+var (
+	connectionRetryInitialIntervalEnv = env.RegisterSetting("ROX_SENSOR_CONNECTION_RETRY_INITIAL_INTERVAL")
+	connectionRetryMaxIntervalEnv     = env.RegisterSetting("ROX_SENSOR_CONNECTION_RETRY_MAX_INTERVAL")
+)
+
+func connectionRetryInitialInterval() time.Duration {
+	return getOrDefault(connectionRetryInitialIntervalEnv, defaultInitialInterval)
+}
+
+func connectionRetryMaxInterval() time.Duration {
+	return getOrDefault(connectionRetryMaxIntervalEnv, defaultMaxInterval)
+}
+
+func getOrDefault(envVar env.Setting, defaultValue time.Duration) time.Duration {
+	if envVar.Setting() == "" {
+		return defaultValue
+	}
+
+	d, err := time.ParseDuration(envVar.Setting())
+	if err != nil {
+		log.Warnf("parsing env %s duration value (%s): %s",
+			envVar.EnvVar(), envVar.Setting(), err)
+		return defaultValue
+	}
+	return d
+}

--- a/sensor/common/sensor/sensor.go
+++ b/sensor/common/sensor/sensor.go
@@ -320,9 +320,8 @@ func (s *Sensor) communicationWithCentralWithRetries(centralReachable *concurren
 	// connection is up again.
 	exponential := backoff.NewExponentialBackOff()
 	exponential.MaxElapsedTime = 0 // It never stops if set to 0
-	// TODO(ROX-17209): add configurable time for restart intervals
-	exponential.InitialInterval = 1 * time.Minute
-	exponential.MaxInterval = 10 * time.Minute
+	exponential.InitialInterval = connectionRetryInitialInterval()
+	exponential.MaxInterval = connectionRetryMaxInterval()
 
 	err := backoff.RetryNotify(func() error {
 		select {


### PR DESCRIPTION
## Description

Add two new env variables in sensor to control connection timeout timers: `ROX_SENSOR_CONNECTION_RETRY_INITIAL_INTERVAL` and `ROX_SENSOR_CONNECTION_RETRY_MAX_INTERVAL`. 

This will be used during gRPC connection setup. If the factory fails to setup a connection, or if the connection broke while sensor is running, these will control how often sensor attempts to re-establish the connection..

The defaults are set to `1m` and `10m` respectively. 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] ~~Unit test and regression tests added~~
- [ ] ~~Evaluated and added CHANGELOG entry if required~~
- [ ] ~~Determined and documented upgrade steps~~
- [ ] ~~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

## Testing Performed

- Running `local-sensor` overwriting these variables (as in [running local sensor against real Central](https://github.com/stackrox/stackrox/tree/master/tools/local-sensor/scripts#running-local-sensor))