### PR TITLE
chore: configure dependabot conventional commit-message

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -20,7 +20,8 @@ updates:
       - "stackrox/ui-dep-updaters"
     commit-message:
       include: scope
-      prefix: chore(ui-npm)
+      prefix: chore(ui)
+      prefix-development: "chore(ui-dev)"
 
 
   - package-ecosystem: 'gradle'
@@ -36,7 +37,7 @@ updates:
       - "stackrox/backend-dep-updaters"
     commit-message:
       include: scope
-      prefix: chore(qa-tests-backend)
+      prefix: chore(qa)
 
   - package-ecosystem: 'gomod'
     directory: '/'
@@ -84,7 +85,7 @@ updates:
       - "stackrox/backend-dep-updaters"
     commit-message:
       include: scope
-      prefix: chore(tools-linters)
+      prefix: chore(linters)
 
   - package-ecosystem: 'gomod'
     directory: '/tools/test/'
@@ -99,7 +100,7 @@ updates:
       - "stackrox/backend-dep-updaters"
     commit-message:
       include: scope
-      prefix: chore(tools-test)
+      prefix: chore(test-tools)
 
   - package-ecosystem: 'gomod'
     directory: '/operator/tools/'
@@ -146,7 +147,7 @@ updates:
     - "stackrox/backend-dep-updaters"
     commit-message:
       include: scope
-      prefix: chore(image-rhel)
+      prefix: chore(rhel)
 
   - package-ecosystem: 'docker'
     directory: 'image/postgres'
@@ -161,7 +162,7 @@ updates:
     - "stackrox/backend-dep-updaters"
     commit-message:
       include: scope
-      prefix: chore(image-postgres)
+      prefix: chore(postgres)
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -18,6 +18,9 @@ updates:
       - "area/ui"
     reviewers:
       - "stackrox/ui-dep-updaters"
+    commit-message:
+      include: scope
+      prefix: chore(ui-npm)
 
 
   - package-ecosystem: 'gradle'
@@ -31,6 +34,9 @@ updates:
       - "auto-merge"
     reviewers:
       - "stackrox/backend-dep-updaters"
+    commit-message:
+      include: scope
+      prefix: chore(qa-tests-backend)
 
   - package-ecosystem: 'gomod'
     directory: '/'
@@ -43,6 +49,9 @@ updates:
       - "auto-merge"
     reviewers:
       - "stackrox/backend-dep-updaters"
+    commit-message:
+      include: scope
+      prefix: chore(gomod)
     ignore:
       - dependency-name: "github.com/aws/aws-sdk-go"
         update-types: ["version-update:semver-patch"]
@@ -58,6 +67,9 @@ updates:
     - "dependencies"
     reviewers:
     - "stackrox/scanner"
+    commit-message:
+      include: scope
+      prefix: chore(scanner)
 
   - package-ecosystem: 'gomod'
     directory: '/tools/linters/'
@@ -70,6 +82,9 @@ updates:
     - "auto-merge"
     reviewers:
       - "stackrox/backend-dep-updaters"
+    commit-message:
+      include: scope
+      prefix: chore(tools-linters)
 
   - package-ecosystem: 'gomod'
     directory: '/tools/test/'
@@ -82,6 +97,9 @@ updates:
     - "auto-merge"
     reviewers:
       - "stackrox/backend-dep-updaters"
+    commit-message:
+      include: scope
+      prefix: chore(tools-test)
 
   - package-ecosystem: 'gomod'
     directory: '/operator/tools/'
@@ -95,6 +113,9 @@ updates:
     - "auto-merge"
     reviewers:
     - "stackrox/backend-dep-updaters"
+    commit-message:
+      include: scope
+      prefix: chore(operator-tools)
 
   - package-ecosystem: 'docker'
     directory: 'operator/'
@@ -108,6 +129,9 @@ updates:
     - "auto-merge"
     reviewers:
     - "stackrox/backend-dep-updaters"
+    commit-message:
+      include: scope
+      prefix: chore(operator)
 
   - package-ecosystem: 'docker'
     directory: 'image/rhel'
@@ -120,6 +144,9 @@ updates:
     - "dependencies"
     reviewers:
     - "stackrox/backend-dep-updaters"
+    commit-message:
+      include: scope
+      prefix: chore(image-rhel)
 
   - package-ecosystem: 'docker'
     directory: 'image/postgres'
@@ -132,6 +159,9 @@ updates:
     - "dependencies"
     reviewers:
     - "stackrox/backend-dep-updaters"
+    commit-message:
+      include: scope
+      prefix: chore(image-postgres)
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -141,3 +171,6 @@ updates:
     open-pull-requests-limit: 1
     reviewers:
     - "stackrox/backend-dep-updaters"
+    commit-message:
+      include: scope
+      prefix: chore(actions)


### PR DESCRIPTION
## Description

Configure dependabot to prefix the commits and PRs with, e.g. `chore(ui-npm):`.