### PR TITLE
More minor fixes and tweaks for Workload CVEs

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageHeader.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageHeader.tsx
@@ -34,11 +34,11 @@ function DeploymentPageHeader({ data }: DeploymentPageHeaderProps) {
                 {data.name}
             </Title>
             <LabelGroup numLabels={3}>
-                <Label isCompact>
+                <Label>
                     In: {data.clusterName}/{data.namespace}
                 </Label>
-                <Label isCompact>Images: {data.imageCount}</Label>
-                {data.created && <Label isCompact>Created: {getDateTime(data.created)}</Label>}
+                <Label>Images: {data.imageCount}</Label>
+                {data.created && <Label>Created: {getDateTime(data.created)}</Label>}
             </LabelGroup>
         </Flex>
     ) : (

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities.tsx
@@ -183,7 +183,7 @@ function DeploymentPageVulnerabilities({ deploymentId }: DeploymentPageVulnerabi
                                 screenreaderText="Loading deployment summary data"
                             />
                         )}
-                        {summaryData && summaryData.deployment && (
+                        {!summaryRequest.error && summaryData && summaryData.deployment && (
                             <Grid hasGutter>
                                 <GridItem sm={12} md={6} xl2={4}>
                                     <BySeveritySummaryCard

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePage.tsx
@@ -94,7 +94,7 @@ function ImagePage() {
             </PageSection>
         );
     } else {
-        const digest = imageData?.metadata?.v1?.digest;
+        const sha = imageData?.id;
         mainContent = (
             <>
                 <PageSection variant="light">
@@ -106,14 +106,14 @@ function ImagePage() {
                             <Title headingLevel="h1" className="pf-u-m-0">
                                 {imageName}
                             </Title>
-                            {digest && (
+                            {sha && (
                                 <ClipboardCopy
                                     hoverTip="Copy SHA"
                                     clickTip="Copied!"
                                     variant="inline-compact"
                                     className="pf-u-display-inline-flex pf-u-align-items-center pf-u-mt-sm pf-u-mb-md pf-u-font-size-sm"
                                 >
-                                    {digest}
+                                    {sha}
                                 </ClipboardCopy>
                             )}
                             <ImageDetailBadges imageData={imageData} />

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
@@ -327,7 +327,7 @@ function ImageCvePage() {
                                 screenreaderText="Loading image cve summary data"
                             />
                         )}
-                        {summaryRequest.data && (
+                        {!summaryRequest.error && summaryRequest.data && (
                             <Grid hasGutter>
                                 <GridItem sm={12} md={6} xl2={4}>
                                     <AffectedImages

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePageHeader.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePageHeader.tsx
@@ -10,6 +10,7 @@ import {
     List,
     ListItem,
 } from '@patternfly/react-core';
+import uniqBy from 'lodash/uniqBy';
 import { getDateTime } from 'utils/dateUtils';
 import { ensureExhaustive } from 'utils/type.utils';
 import { Distro, sortCveDistroList } from '../sortUtils';
@@ -61,8 +62,7 @@ export type ImageCvePageHeaderProps = {
 };
 
 function ImageCvePageHeader({ data }: ImageCvePageHeaderProps) {
-    const prioritizedDistros = sortCveDistroList(data?.distroTuples ?? []);
-
+    const prioritizedDistros = uniqBy(sortCveDistroList(data?.distroTuples ?? []), 'distro');
     return data ? (
         <Flex direction={{ default: 'column' }} alignItems={{ default: 'alignItemsFlexStart' }}>
             <Title headingLevel="h1" className="pf-u-mb-sm">

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePageHeader.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePageHeader.tsx
@@ -70,7 +70,7 @@ function ImageCvePageHeader({ data }: ImageCvePageHeaderProps) {
             </Title>
             <LabelGroup numLabels={1}>
                 {data.firstDiscoveredInSystem && (
-                    <Label isCompact>
+                    <Label>
                         First discovered in system {getDateTime(data.firstDiscoveredInSystem)}
                     </Label>
                 )}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/CVEsTableContainer.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/CVEsTableContainer.tsx
@@ -65,7 +65,7 @@ function CVEsTableContainer({ defaultFilters, countsData, cveStatusTab }: CVEsTa
             {error && (
                 <TableErrorComponent error={error} message="Adjust your filters and try again" />
             )}
-            {tableData && (
+            {!error && tableData && (
                 <div className="workload-cves-table-container">
                     <CVEsTable
                         cves={tableData.imageCVEs}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/DeploymentsTableContainer.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/DeploymentsTableContainer.tsx
@@ -69,7 +69,7 @@ function DeploymentsTableContainer({
             {error && (
                 <TableErrorComponent error={error} message="Adjust your filters and try again" />
             )}
-            {tableData && (
+            {!error && tableData && (
                 <div className="workload-cves-table-container">
                     <DeploymentsTable
                         deployments={tableData.deployments}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/ImagesTableContainer.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/ImagesTableContainer.tsx
@@ -68,7 +68,7 @@ function ImagesTableContainer({
             {error && (
                 <TableErrorComponent error={error} message="Adjust your filters and try again" />
             )}
-            {tableData && (
+            {!error && tableData && (
                 <div className="workload-cves-table-container">
                     <ImagesTable
                         images={tableData.images}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/SummaryCards/AffectedImages.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/SummaryCards/AffectedImages.tsx
@@ -13,7 +13,7 @@ function AffectedImages({
     totalImagesCount,
 }: AffectedImagesProps) {
     return (
-        <Card className={className} isCompact>
+        <Card className={className} isCompact isFlat>
             <CardTitle>Affected images</CardTitle>
             <CardBody>
                 {affectedImageCount}/{totalImagesCount} images affected

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/SummaryCards/BySeveritySummaryCard.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/SummaryCards/BySeveritySummaryCard.tsx
@@ -43,7 +43,7 @@ function BySeveritySummaryCard({
     hiddenSeverities,
 }: BySeveritySummaryCardProps) {
     return (
-        <Card className={className} isCompact>
+        <Card className={className} isCompact isFlat>
             <CardTitle>{title}</CardTitle>
             <CardBody>
                 <Grid className="pf-u-pl-sm">

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/SummaryCards/CvesByStatusSummaryCard.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/SummaryCards/CvesByStatusSummaryCard.tsx
@@ -76,7 +76,7 @@ function CvesByStatusSummaryCard({
     hiddenStatuses,
 }: CvesByStatusSummaryCardProps) {
     return (
-        <Card isCompact>
+        <Card isCompact isFlat>
             <CardTitle>CVEs by status</CardTitle>
             <CardBody>
                 <Grid className="pf-u-pl-sm">

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedDeploymentsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedDeploymentsTable.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Flex, Button, ButtonVariant, pluralize } from '@patternfly/react-core';
+import { Flex, Button, ButtonVariant, pluralize, Truncate } from '@patternfly/react-core';
 import {
     TableComposable,
     Thead,
@@ -139,7 +139,7 @@ function AffectedDeploymentsTable({
                                         component={LinkShim}
                                         href={getEntityPagePath('Deployment', id)}
                                     >
-                                        {name}
+                                        <Truncate position="middle" content={name} />
                                     </Button>{' '}
                                 </Flex>
                             </Td>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedImagesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedImagesTable.tsx
@@ -87,17 +87,15 @@ function AffectedImagesTable({ images, getSortParams, isFiltered }: AffectedImag
     const expandedRowSet = useSet<string>();
 
     return (
-        // TODO UX question - Collapse to cards, or allow headers to overflow?
-        // <TableComposable gridBreakPoint="grid-xl">
         <TableComposable variant="compact">
             <Thead noWrap>
                 <Tr>
                     <Th>{/* Header for expanded column */}</Th>
                     <Th sort={getSortParams('Image')}>Image</Th>
-                    <Th>Severity</Th>
+                    <Th>CVE severity</Th>
                     <Th>CVSS</Th>
                     <Th>
-                        Fix status
+                        CVE status
                         {isFiltered && <DynamicColumnIcon />}
                     </Th>
                     <Th sort={getSortParams('Operating System')}>Operating system</Th>
@@ -134,13 +132,13 @@ function AffectedImagesTable({ images, getSortParams, isFiltered }: AffectedImag
                                     'Image name not available'
                                 )}
                             </Td>
-                            <Td dataLabel="Severity" modifier="nowrap">
+                            <Td dataLabel="CVE severity" modifier="nowrap">
                                 <VulnerabilitySeverityIconText severity={topSeverity} />
                             </Td>
                             <Td dataLabel="CVSS" modifier="nowrap">
                                 <CvssTd cvss={cvss} scoreVersion={scoreVersion} />
                             </Td>
-                            <Td dataLabel="Fix status" modifier="nowrap">
+                            <Td dataLabel="CVE status" modifier="nowrap">
                                 <VulnerabilityFixableIconText isFixable={isFixable} />
                             </Td>
                             <Td dataLabel="Operating system">{operatingSystem}</Td>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/CVEsTable.tsx
@@ -120,7 +120,7 @@ function CVEsTable({
                     </TooltipTh>
                     <TooltipTh
                         sort={getSortParams('Image sha', aggregateByImageSha)}
-                        tooltip="Ratio of total environment affect by this CVE"
+                        tooltip="Ratio of total images affected by this CVE"
                     >
                         Affected images
                         {isFiltered && <DynamicColumnIcon />}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentComponentVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentComponentVulnerabilitiesTable.tsx
@@ -68,9 +68,9 @@ function DeploymentComponentVulnerabilitiesTable({
             <Thead noWrap>
                 <Tr>
                     <Th sort={getSortParams('Image')}>Image</Th>
-                    <Th sort={getSortParams('Component')}>Component</Th>
                     <Th>CVE severity</Th>
                     <Th>CVSS</Th>
+                    <Th sort={getSortParams('Component')}>Component</Th>
                     <Th>Version</Th>
                     <Th>CVE fixed in</Th>
                     <Th>Location</Th>
@@ -106,13 +106,13 @@ function DeploymentComponentVulnerabilitiesTable({
                                     'Image name not available'
                                 )}
                             </Td>
-                            <Td>{name}</Td>
                             <Td modifier="nowrap">
                                 <VulnerabilitySeverityIconText severity={severity} />
                             </Td>
                             <Td modifier="nowrap">
                                 <CvssTd cvss={cvss} scoreVersion={scoreVersion} />
                             </Td>
+                            <Td>{name}</Td>
                             <Td>{version}</Td>
                             <Td modifier="nowrap">
                                 <FixedByVersionTd fixedByVersion={fixedByVersion} />

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx
@@ -133,9 +133,9 @@ function DeploymentVulnerabilitiesTable({
                 <Tr>
                     <Th>{/* Header for expanded column */}</Th>
                     <Th sort={getSortParams('CVE')}>CVE</Th>
-                    <Th>Severity</Th>
+                    <Th>CVE severity</Th>
                     <Th>
-                        CVE Status
+                        CVE status
                         {isFiltered && <DynamicColumnIcon />}
                     </Th>
                     <Th>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentsTable.tsx
@@ -134,16 +134,9 @@ function DeploymentsTable({
                                 <Td>{clusterName}</Td>
                                 <Td>{namespace}</Td>
                                 <Td>
-                                    <Button
-                                        variant={ButtonVariant.link}
-                                        isInline
-                                        component={LinkShim}
-                                        href={getEntityPagePath('Deployment', id, {
-                                            detailsTab: 'Resources',
-                                        })}
-                                    >
+                                    <>
                                         {imageCount} {pluralize('image', imageCount)}
-                                    </Button>
+                                    </>
                                 </Td>
                                 <Td>
                                     <DatePhraseTd date={created} />

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentsTable.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { gql } from '@apollo/client';
 import pluralize from 'pluralize';
 import { TableComposable, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
-import { Button, ButtonVariant } from '@patternfly/react-core';
+import { Button, ButtonVariant, Truncate } from '@patternfly/react-core';
 
 import LinkShim from 'Components/PatternFly/LinkShim';
 import { UseURLSortResult } from 'hooks/useURLSort';
@@ -118,7 +118,7 @@ function DeploymentsTable({
                                         component={LinkShim}
                                         href={getEntityPagePath('Deployment', id)}
                                     >
-                                        {name}
+                                        <Truncate position="middle" content={name} />
                                     </Button>
                                 </Td>
                                 <Td>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
@@ -77,9 +77,9 @@ function ImageVulnerabilitiesTable({
                 <Tr>
                     <Th>{/* Header for expanded column */}</Th>
                     <Th sort={getSortParams('CVE')}>CVE</Th>
-                    <Th sort={getSortParams('Severity')}>Severity</Th>
+                    <Th sort={getSortParams('Severity')}>CVE Severity</Th>
                     <Th>
-                        CVE Status
+                        CVE status
                         {isFiltered && <DynamicColumnIcon />}
                     </Th>
                     <Th sort={getSortParams('CVSS')}>CVSS</Th>
@@ -127,12 +127,12 @@ function ImageVulnerabilitiesTable({
                                         {cve}
                                     </Button>
                                 </Td>
-                                <Td modifier="nowrap" dataLabel="Severity">
+                                <Td modifier="nowrap" dataLabel="CVE severity">
                                     {isVulnerabilitySeverity(severity) && (
                                         <VulnerabilitySeverityIconText severity={severity} />
                                     )}
                                 </Td>
-                                <Td modifier="nowrap" dataLabel="CVE Status">
+                                <Td modifier="nowrap" dataLabel="CVE status">
                                     <VulnerabilityFixableIconText isFixable={isFixable} />
                                 </Td>
                                 <Td modifier="nowrap" dataLabel="CVSS">

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImagesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImagesTable.tsx
@@ -2,12 +2,10 @@ import React from 'react';
 import { gql } from '@apollo/client';
 import pluralize from 'pluralize';
 import { TableComposable, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
-import { Button, ButtonVariant, Flex } from '@patternfly/react-core';
+import { Flex } from '@patternfly/react-core';
 
-import LinkShim from 'Components/PatternFly/LinkShim';
 import { UseURLSortResult } from 'hooks/useURLSort';
 import ImageNameTd from '../components/ImageNameTd';
-import { getEntityPagePath } from '../searchUtils';
 import SeverityCountLabels from '../components/SeverityCountLabels';
 import { DynamicColumnIcon } from '../components/DynamicIcon';
 import EmptyTableResults from '../components/EmptyTableResults';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImagesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImagesTable.tsx
@@ -146,17 +146,10 @@ function ImagesTable({ images, getSortParams, isFiltered, filteredSeverities }: 
                                 <Td>{operatingSystem}</Td>
                                 <Td>
                                     {deploymentCount > 0 ? (
-                                        <Button
-                                            variant={ButtonVariant.link}
-                                            isInline
-                                            component={LinkShim}
-                                            href={getEntityPagePath('Image', id, {
-                                                detailsTab: 'Resources',
-                                            })}
-                                        >
+                                        <>
                                             {deploymentCount}{' '}
                                             {pluralize('deployment', deploymentCount)}
-                                        </Button>
+                                        </>
                                     ) : (
                                         <Flex>
                                             <div>0 deployments</div>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/DockerfileLayerTd.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/DockerfileLayerTd.tsx
@@ -10,15 +10,11 @@ function DockerfileLayerTd({ layer }: DockerfileLayerTdProps) {
     return layer ? (
         <CodeBlock>
             <Flex>
-                <CodeBlockCode
-                    // 120px is a width that looks good with the largest dockerfile instruction: "HEALTHCHECK"
-                    style={{ flexBasis: '120px' }}
-                    className="pf-u-flex-shrink-0"
-                >
+                <CodeBlockCode className="pf-u-flex-nowrap">
                     {layer.line} {layer.instruction}
                 </CodeBlockCode>
                 <CodeBlockCode className="pf-u-flex-grow-1 pf-u-flex-basis-0">
-                    {layer.instruction} {layer.value}
+                    {layer.value}
                 </CodeBlockCode>
             </Flex>
         </CodeBlock>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/DynamicIcon.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/DynamicIcon.tsx
@@ -8,17 +8,15 @@ export function DynamicIcon(props: SVGIconProps) {
 }
 
 export function DynamicColumnIcon() {
-    return (
-        <Tooltip content="Data in this column can change according to the applied filters">
-            <DynamicIcon className="pf-u-display-inline pf-u-ml-sm" />
-        </Tooltip>
-    );
+    return <DynamicIcon className="pf-u-display-inline pf-u-ml-sm" />;
 }
 
 export function DynamicTableLabel() {
     return (
-        <Label isCompact color="blue" icon={<DynamicIcon />}>
-            Filtered view
-        </Label>
+        <Tooltip content="You are viewing a filtered set of table rows. Column values may also be changed to match the applied filters.">
+            <Label color="blue" icon={<DynamicIcon />}>
+                Filtered view
+            </Label>
+        </Tooltip>
     );
 }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/FilterAutocomplete.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/FilterAutocomplete.tsx
@@ -97,7 +97,7 @@ function FilterAutocompleteSelect({
                 onClear={() => onDeleteGroup(resource)}
                 onToggle={onToggle}
                 isOpen={isOpen}
-                placeholder={`Filter by ${resource as string}`}
+                placeholderText={`Filter results by ${resource.toLowerCase()}`}
                 variant="typeaheadmulti"
                 isCreatable
                 createText="Add"

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/FilterChips.css
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/FilterChips.css
@@ -12,6 +12,6 @@
     display: none;
 }
 
-#workload-cves-table-toolbar .cve-severity-select .pf-c-select__toggle-wrapper {
+#workload-cves-table-toolbar .pf-c-select__toggle-wrapper {
     flex-wrap: nowrap
 }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ImageDetailBadges.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ImageDetailBadges.tsx
@@ -10,7 +10,6 @@ export type ImageDetails = {
     metadata: {
         v1: {
             created: string | null;
-            digest: string;
         } | null;
     } | null;
     dataSource: { name: string } | null;
@@ -24,7 +23,6 @@ export const imageDetailsFragment = gql`
         metadata {
             v1 {
                 created
-                digest
             }
         }
         dataSource {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ImageDetailBadges.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ImageDetailBadges.tsx
@@ -43,15 +43,11 @@ function ImageDetailBadges({ imageData }: ImageDetailBadgesProps) {
 
     return (
         <LabelGroup numLabels={Infinity}>
-            <Label isCompact color={isActive ? 'green' : 'gold'}>
-                {isActive ? 'Active' : 'Inactive'}
-            </Label>
-            {operatingSystem && <Label isCompact>OS: {operatingSystem}</Label>}
-            {created && (
-                <Label isCompact>Age: {getDistanceStrictAsPhrase(created, new Date())}</Label>
-            )}
+            <Label color={isActive ? 'green' : 'gold'}>{isActive ? 'Active' : 'Inactive'}</Label>
+            {operatingSystem && <Label>OS: {operatingSystem}</Label>}
+            {created && <Label>Age: {getDistanceStrictAsPhrase(created, new Date())}</Label>}
             {scanTime && (
-                <Label isCompact>
+                <Label>
                     Scan time: {getDateTime(scanTime)} by {dataSource?.name ?? 'Unknown Scanner'}
                 </Label>
             )}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ImageNameTd.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ImageNameTd.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Flex, Button, ButtonVariant } from '@patternfly/react-core';
+import { Flex, Button, ButtonVariant, Truncate } from '@patternfly/react-core';
 
 import LinkShim from 'Components/PatternFly/LinkShim';
 import { getEntityPagePath } from '../searchUtils';
@@ -22,7 +22,7 @@ function ImageNameTd({ name, id }: ImageNameTdProps) {
                 component={LinkShim}
                 href={getEntityPagePath('Image', id)}
             >
-                {name.remote}:{name.tag}
+                <Truncate position="middle" content={`${name.remote}:${name.tag}`} />
             </Button>{' '}
             <span className="pf-u-color-200 pf-u-font-size-sm">in {name.registry}</span>
         </Flex>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/SeverityCountLabels.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/SeverityCountLabels.tsx
@@ -22,9 +22,9 @@ function getTooltipContent(severity: string, severityCount?: number, entity?: st
         return `${capitalize(severity)} severity is hidden by the applied filter`;
     }
     if (entity) {
-        return `${pluralize(severityCount, `${severity} CVE`)} across this ${entity}`;
+        return `${pluralize(severityCount, `${severity} severity CVE`)} across this ${entity}`;
     }
-    return `${pluralize(severityCount, 'image')} with ${severity} CVEs`;
+    return `${pluralize(severityCount, 'image')} with ${severity} severity`;
 }
 
 function SeverityCountLabels({


### PR DESCRIPTION
## Description

One of the last (??? 🙏 ) rounds of minor fixes for Workload CVEs based on the bug bash.

1. Do not show previous data results in tables if the current request results in an error.
2. Update tooltips for severity icons according to new wording
3. Fix the display of filter toolbar text input placeholders
4. Fix odd wrapping of Select elements in toolbar
5. Update tooltip for the affected images column

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

1. For the overview page tables, as well as summary cards on the image and cve pages, force a simulated error and ensure data does not show below the error message:
![image](https://github.com/stackrox/stackrox/assets/1292638/bba16a9a-4dbc-4ae4-9797-ec949e931e2d)

2. View severity icon tooltip wording on the main table
![image](https://github.com/stackrox/stackrox/assets/1292638/ad1b39a3-c4e7-46c8-ad17-b215164108db)

3. Filter toolbar should show context sensitive placeholder message:
![image](https://github.com/stackrox/stackrox/assets/1292638/1a34f588-fcd7-411c-acf2-7a892958252c)
![image](https://github.com/stackrox/stackrox/assets/1292638/9c3a9596-e153-4083-b699-6c815fcd8ea5)

4. With no other filters applied, select a CVE status of "fixable" and ensure the badge in the dropdown does not wrap to a new line
![image](https://github.com/stackrox/stackrox/assets/1292638/b7145a8a-86cb-4a50-925a-e14794c14179)

5. Check the tooltip on the affected images column
![image](https://github.com/stackrox/stackrox/assets/1292638/945bd654-c83e-48d8-a55f-8347c19e0124)
