### PR TITLE
Add node version requirements to package.json

### DIFF
--- a/ui/apps/platform/package.json
+++ b/ui/apps/platform/package.json
@@ -173,6 +173,9 @@
         "tailwindcss": "^2.0.3",
         "typescript": "^5.0.4"
     },
+    "engines": {
+        "node" : ">=16.10.0 <17.0.0"
+    },
     "browserslist": [
         ">0.2%",
         "not dead",


### PR DESCRIPTION
## Description

Add node version requirements to `package.json` so that yarn install throws a fit if an incorrect version is used.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

running `yarn-build` with a version out of range:
![Screenshot 2023-05-30 at 8 51 47 AM](https://github.com/stackrox/stackrox/assets/61400697/b41b94a3-30e5-4987-9fe4-89ae195085b2)

