### PR TITLE
ROX-17377: Replace Promise.all with Promise.allSettled for PATCH compliance standards

### DIFF
--- a/ui/apps/platform/src/Containers/Compliance/Dashboard/ComplianceDashboardPage.tsx
+++ b/ui/apps/platform/src/Containers/Compliance/Dashboard/ComplianceDashboardPage.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useEffect, useState } from 'react';
+import React, { ReactElement, useState } from 'react';
 import { useApolloClient } from '@apollo/client';
 
 import Button from 'Components/Button';
@@ -21,6 +21,7 @@ import StandardsByEntity from '../widgets/StandardsByEntity';
 import StandardsAcrossEntity from '../widgets/StandardsAcrossEntity';
 import ComplianceByStandards from '../widgets/ComplianceByStandards';
 
+import ManageStandardsError from './ManageStandardsError';
 import ManageStandardsModal from './ManageStandardsModal';
 import ComplianceDashboardTile from './ComplianceDashboardTile';
 
@@ -28,7 +29,7 @@ function ComplianceDashboardPage(): ReactElement {
     const { hasReadWriteAccess } = usePermissions();
     const { isFeatureFlagEnabled } = useFeatureFlags();
     const [isFetchingStandards, setIsFetchingStandards] = useState(false);
-    const [errorMessageForStandards, setErrorMessageForStandards] = useState('');
+    const [errorMessageFetching, setErrorMessageFetching] = useState('');
     const [standards, setStandards] = useState<ComplianceStandardMetadata[]>([]);
     const [isManageStandardsModalOpen, setIsManageStandardsModalOpen] = useState(false);
 
@@ -48,24 +49,28 @@ function ComplianceDashboardPage(): ReactElement {
     const hasManageStandardsButton =
         hasWriteAccessForComplianceStandards && isDisableComplianceStandardsEnabled;
 
-    useEffect(() => {
+    function clickManageStandardsButton() {
         setIsFetchingStandards(true);
         fetchComplianceStandardsSortedByName()
             .then((standardsFetched) => {
-                setErrorMessageForStandards('');
+                setErrorMessageFetching('');
                 setStandards(standardsFetched);
+                setIsManageStandardsModalOpen(true);
             })
             .catch((error) => {
-                setErrorMessageForStandards(getAxiosErrorMessage(error));
+                setErrorMessageFetching(getAxiosErrorMessage(error));
                 setStandards([]);
             })
             .finally(() => {
                 setIsFetchingStandards(false);
             });
-    }, []);
+    }
 
-    function onSaveManageStandardsModal(standardsSaved: ComplianceStandardMetadata[]) {
-        setStandards(standardsSaved);
+    function onCloseManageStandardsError() {
+        setErrorMessageFetching('');
+    }
+
+    function onSaveOrCloseManageStandardsModal() {
         setIsManageStandardsModalOpen(false);
 
         /*
@@ -80,6 +85,7 @@ function ComplianceDashboardPage(): ReactElement {
         setIsManageStandardsModalOpen(false);
     }
 
+    /* eslint-disable no-nested-ternary */
     return (
         <>
             <PageHeader header="Compliance" subHeader="Dashboard">
@@ -107,11 +113,9 @@ function ComplianceDashboardPage(): ReactElement {
                                         text="Manage standards"
                                         className="btn btn-base h-10 ml-2"
                                         onClick={() => {
-                                            setIsManageStandardsModalOpen(true);
+                                            clickManageStandardsButton();
                                         }}
-                                        disabled={
-                                            isFetchingStandards || Boolean(errorMessageForStandards)
-                                        }
+                                        disabled={isFetchingStandards}
                                     />
                                 </div>
                             )}
@@ -159,15 +163,21 @@ function ComplianceDashboardPage(): ReactElement {
                 </div>
             </div>
             {isExporting && <BackdropExporting />}
-            {isManageStandardsModalOpen && (
-                <ManageStandardsModal
-                    standards={standards}
-                    onSave={onSaveManageStandardsModal}
-                    onCancel={onCancelManageStandardsModal}
+            {errorMessageFetching ? (
+                <ManageStandardsError
+                    onClose={onCloseManageStandardsError}
+                    errorMessage={errorMessageFetching}
                 />
-            )}
+            ) : isManageStandardsModalOpen ? (
+                <ManageStandardsModal
+                    onCancel={onCancelManageStandardsModal}
+                    onSaveOrClose={onSaveOrCloseManageStandardsModal}
+                    standards={standards}
+                />
+            ) : null}
         </>
     );
+    /* eslint-enable no-nested-ternary */
 }
 
 export default ComplianceDashboardPage;

--- a/ui/apps/platform/src/Containers/Compliance/Dashboard/ComplianceDashboardPage.tsx
+++ b/ui/apps/platform/src/Containers/Compliance/Dashboard/ComplianceDashboardPage.tsx
@@ -70,7 +70,7 @@ function ComplianceDashboardPage(): ReactElement {
         setErrorMessageFetching('');
     }
 
-    function onSaveOrCloseManageStandardsModal() {
+    function onChangeManageStandardsModal() {
         setIsManageStandardsModalOpen(false);
 
         /*
@@ -172,7 +172,7 @@ function ComplianceDashboardPage(): ReactElement {
             ) : isManageStandardsModalOpen ? (
                 <ManageStandardsModal
                     onCancel={onCancelManageStandardsModal}
-                    onSaveOrClose={onSaveOrCloseManageStandardsModal}
+                    onChange={onChangeManageStandardsModal}
                     standards={standards}
                 />
             ) : null}

--- a/ui/apps/platform/src/Containers/Compliance/Dashboard/ComplianceDashboardPage.tsx
+++ b/ui/apps/platform/src/Containers/Compliance/Dashboard/ComplianceDashboardPage.tsx
@@ -116,6 +116,7 @@ function ComplianceDashboardPage(): ReactElement {
                                             clickManageStandardsButton();
                                         }}
                                         disabled={isFetchingStandards}
+                                        isLoading={isFetchingStandards}
                                     />
                                 </div>
                             )}

--- a/ui/apps/platform/src/Containers/Compliance/Dashboard/ManageStandardsError.tsx
+++ b/ui/apps/platform/src/Containers/Compliance/Dashboard/ManageStandardsError.tsx
@@ -1,0 +1,19 @@
+import React, { ReactElement } from 'react';
+import { Alert, Modal } from '@patternfly/react-core';
+
+export type ManageStandardsErrorProp = {
+    onClose: () => void;
+    errorMessage: string;
+};
+
+function ManageStandardsError({ onClose, errorMessage }: ManageStandardsErrorProp): ReactElement {
+    return (
+        <Modal title="Manage standards" variant="small" isOpen onClose={onClose} showClose>
+            <Alert title="Unable to fetch standards" variant="warning" isInline>
+                {errorMessage}
+            </Alert>
+        </Modal>
+    );
+}
+
+export default ManageStandardsError;

--- a/ui/apps/platform/src/Containers/Compliance/Dashboard/ManageStandardsModal.tsx
+++ b/ui/apps/platform/src/Containers/Compliance/Dashboard/ManageStandardsModal.tsx
@@ -42,23 +42,23 @@ function ManageStandardsModal({
 
             Promise.allSettled(patchRequestPromises)
                 .then((results) => {
-                    let nRejected = 0;
+                    let numberOfRejectedPromises = 0;
                     let reasonMessage = '';
                     results.forEach((result) => {
                         if (result.status === 'rejected') {
-                            if (nRejected === 0) {
+                            if (numberOfRejectedPromises === 0) {
                                 reasonMessage = getAxiosErrorMessage(result.reason);
                             }
-                            nRejected += 1;
+                            numberOfRejectedPromises += 1;
                         }
                     });
                     setSubmitting(false);
 
-                    if (nRejected === 0) {
+                    if (numberOfRejectedPromises === 0) {
                         onChange();
                     } else {
                         setErrorMessage(reasonMessage);
-                        setCountFulfilledWhenRejected(results.length - nRejected);
+                        setCountFulfilledWhenRejected(results.length - numberOfRejectedPromises);
                     }
                 })
                 .catch((error) => {

--- a/ui/apps/platform/src/Containers/Compliance/Dashboard/ManageStandardsModal.tsx
+++ b/ui/apps/platform/src/Containers/Compliance/Dashboard/ManageStandardsModal.tsx
@@ -7,7 +7,7 @@ import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
 export type ManageStandardsModalProps = {
     onCancel: () => void;
-    onSaveOrClose: () => void;
+    onChange: () => void;
     standards: ComplianceStandardMetadata[];
 };
 
@@ -22,7 +22,7 @@ function getShowScanResultsMap(standards: ComplianceStandardMetadata[]): Record<
 
 function ManageStandardsModal({
     onCancel,
-    onSaveOrClose,
+    onChange,
     standards,
 }: ManageStandardsModalProps): ReactElement {
     const [errorMessage, setErrorMessage] = useState('');
@@ -55,7 +55,7 @@ function ManageStandardsModal({
                     setSubmitting(false);
 
                     if (nRejected === 0) {
-                        onSaveOrClose();
+                        onChange();
                     } else {
                         setErrorMessage(reasonMessage);
                         setCountFulfilledWhenRejected(results.length - nRejected);
@@ -99,7 +99,7 @@ function ManageStandardsModal({
                     <Button
                         key="Close"
                         variant="secondary"
-                        onClick={onSaveOrClose}
+                        onClick={onChange}
                         isDisabled={isSubmitting}
                     >
                         Close


### PR DESCRIPTION
## Description

Handle potential failure of some or all PATCH requests.

### Problems

1. `Promise.all` rejects as soon as the first promise rejects, but `catch` block does not know when all promises have settled.
2. Even knowing when all promises have settled, how to describe rare edge case that some resolved and others rejected?
3. Even knowing when all promises have settled, how to describe rare edge case that GET /v1/compliance/standards request fails?

### Analysis

Because backend filters the standards in GraphQL requests according to `hideScanResults` property:
1. ComplianceDashboardPage calls `client.resetStore()` to re-request.
2. ManageStandardsModal can encapsulate GET /v1/compliance/standards request each time it opens.
    * It makes the request only when needed.
    * Users get immediate feedback if prerequisite GET request fails.
3. If any PATCH requests fail, leave well enough alone to render the first error message.

### Solution

1. Move `standards` from ComplianceDashboardPage to ManageStandardsModal.
2. If GET request fails, conditionally render simple modal with alert and Close button only.
3. If any PATCH requests fail, conditionally render alert,
    * and if no PATCH requests succeed, render Save and Cancel buttons.
    * and if any PATCH requests succees, render Save and Close buttons, because Cancel is no long possible.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

In ui folder: 

1. `export ROX_DISABLE_COMPLIANCE_STANDARDS=true`

2. `yarn start`

### Manual testing

1. Visit /main/compliance: see **no** GET /v1/compliance/standards request.

2. Click **Scan Environment**: see GraphQL requests and then graphs.

3. Click **Manage standards**: see GET /v1/compliance/standards request.

    * With temporary code change: see `isLoading` state.
        ![isLoading](https://github.com/stackrox/stackrox/assets/11862657/a4cffec7-b5ae-4e63-b013-a0c93cde8393)

    * With temporary code change: see warning alert in **Manage standards** moda.
        ![ManageStandardsError](https://github.com/stackrox/stackrox/assets/11862657/191c20e6-7089-412c-88bd-934b757b284a)

    * Without temporary code changes: see form in **Manage standards** modal.
        ![ManageStandardsModal](https://github.com/stackrox/stackrox/assets/11862657/a7b45080-5f70-4fc0-8e74-d93d5e8edb86)

4. Click to clear 3 check boxes, and then click **Save**

    * With temporary code change: see 3 out of 3 PATCH requests fail and **Cancel** button.
        ![Cancel](https://github.com/stackrox/stackrox/assets/11862657/f38efb0b-13de-4266-a84c-5fd24fec3143)

    * With temporary code change: see 2 out of 3 PATCH requests fail and **Close** button.
        ![Close](https://github.com/stackrox/stackrox/assets/11862657/a19dfda7-ee2a-4898-8ba3-0f60c97540cb)

    * Click **Close**: see backend filtering for NIST SP 800-190 which had successful PATCH request.
        ![NIST_1_dashboard](https://github.com/stackrox/stackrox/assets/11862657/d1433ac8-6983-44ff-81f7-8e4e9ec002ba)

5. Click **Manage standards**: see cleared check box for NIST SP 800-190, click to clear check box for NIST SP-800-53, and then click **Save**.

    * See backend filtering for both NIST standards on dashboard: correct filtering for vertical bar chart and sunburst graphs, **but incorrect** filtering for horizontal bar charts.
        ![NIST_2_dashboard](https://github.com/stackrox/stackrox/assets/11862657/cbd64886-4cdf-41a7-9b33-df1b831d4a5e)

    * See backend filtering for both NIST standards: correct in deployments table.
        ![NIST_2_deployments](https://github.com/stackrox/stackrox/assets/11862657/a6a49035-02a1-449e-aae1-a281cbb091ae)
