### PR TITLE
ROX-15140: Forbid access scope without rules

### DIFF
--- a/central/role/validate_test.go
+++ b/central/role/validate_test.go
@@ -187,10 +187,6 @@ func TestValidateSimpleAccessScope(t *testing.T) {
 	}
 
 	testCasesGood := map[string]*storage.SimpleAccessScope{
-		"id and name are set": {
-			Id:   mockGoodID,
-			Name: mockName,
-		},
 		"id, name, and namespace label selector are set": {
 			Id:    mockGoodID,
 			Name:  mockName,
@@ -224,21 +220,22 @@ func TestValidateSimpleAccessScope(t *testing.T) {
 		{
 			name:                   "empty simple access scope",
 			scope:                  &storage.SimpleAccessScope{},
-			expectedNumberOfErrors: 2,
+			expectedNumberOfErrors: 3,
 		},
 		{
 			name:                   "id is missing",
-			scope:                  &storage.SimpleAccessScope{Name: mockName},
+			scope:                  &storage.SimpleAccessScope{Name: mockName, Rules: &storage.SimpleAccessScope_Rules{}},
 			expectedNumberOfErrors: 1,
 		}, {
 			name:                   "name is missing",
-			scope:                  &storage.SimpleAccessScope{Id: mockGoodID},
+			scope:                  &storage.SimpleAccessScope{Id: mockGoodID, Rules: &storage.SimpleAccessScope_Rules{}},
 			expectedNumberOfErrors: 1,
 		}, {
 			name: "bad id",
 			scope: &storage.SimpleAccessScope{
-				Id:   mockBadID,
-				Name: mockName,
+				Id:    mockBadID,
+				Name:  mockName,
+				Rules: &storage.SimpleAccessScope_Rules{},
 			},
 			expectedNumberOfErrors: 1,
 		},

--- a/pkg/accessscope/validate.go
+++ b/pkg/accessscope/validate.go
@@ -28,6 +28,9 @@ func ValidateSimpleAccessScopeProto(scope *storage.SimpleAccessScope) error {
 // represents valid simple access scope rule.
 func ValidateSimpleAccessScopeRules(rules *storage.SimpleAccessScope_Rules) error {
 	var validationErrs *multierror.Error
+	if rules == nil {
+		validationErrs = multierror.Append(validationErrs, errox.InvalidArgs.New("rules must be set"))
+	}
 	for _, ns := range rules.GetIncludedNamespaces() {
 		if ns.GetClusterName() == "" || ns.GetNamespaceName() == "" {
 			validationErrs = multierror.Append(validationErrs, errox.InvalidArgs.Newf(

--- a/pkg/accessscope/validate.go
+++ b/pkg/accessscope/validate.go
@@ -29,7 +29,7 @@ func ValidateSimpleAccessScopeProto(scope *storage.SimpleAccessScope) error {
 func ValidateSimpleAccessScopeRules(rules *storage.SimpleAccessScope_Rules) error {
 	var validationErrs *multierror.Error
 	if rules == nil {
-		validationErrs = multierror.Append(validationErrs, errox.InvalidArgs.New("rules must be set"))
+		validationErrs = multierror.Append(validationErrs, errox.InvalidArgs.New("rules field must be set"))
 	}
 	for _, ns := range rules.GetIncludedNamespaces() {
 		if ns.GetClusterName() == "" || ns.GetNamespaceName() == "" {

--- a/pkg/accessscope/validate_test.go
+++ b/pkg/accessscope/validate_test.go
@@ -50,6 +50,7 @@ func TestValidateSimpleAccessScopeRules(t *testing.T) {
 	}
 
 	testCasesBad := map[string]*storage.SimpleAccessScope_Rules{
+		"rules are nil": nil,
 		"namespace with missing namespace name": {
 			IncludedNamespaces: []*storage.SimpleAccessScope_Rules_Namespace{
 				mockBadNamespace1,


### PR DESCRIPTION
## Description

POST/PUT of access scope without rules results in a corrupt entry in the database and broken UI(see ticket).

Note: POST/PUT of
```
{
   "name": "habibi",
   "rules": {}
}
```
will still work as it results in next access scope being added to the database:
```
{
    "id": "eb2076f3-d4a8-40d2-91fb-67ba32f0bd7e",
    "name": "habibi",
    "description": "",
    "rules": {
        "includedClusters": [],
        "includedNamespaces": [],
        "clusterLabelSelectors": [],
        "namespaceLabelSelectors": []
    },
    "traits": null
}
```

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

1. Unit test is added
2. Manual test POST/PUT requests
