### PR TITLE
Update navigation to use UX standardized badges

### DIFF
--- a/ui/apps/platform/cypress/helpers/networkGraph.js
+++ b/ui/apps/platform/cypress/helpers/networkGraph.js
@@ -283,7 +283,7 @@ export function interactAndVisitNetworkGraphWithDeploymentSelected(
 
 export function visitOldNetworkGraphFromLeftNav() {
     const oldNetworkGraphNavItemText = hasFeatureFlag('ROX_NETWORK_GRAPH_PATTERNFLY')
-        ? 'Network Graph (1.0 deprecated)'
+        ? 'Network Graph (1.0)'
         : 'Network Graph';
     visitFromLeftNav(oldNetworkGraphNavItemText, routeMatcherMapToVisitNetworkGraph);
 

--- a/ui/apps/platform/cypress/helpers/vulnmanagement/entities.js
+++ b/ui/apps/platform/cypress/helpers/vulnmanagement/entities.js
@@ -130,8 +130,11 @@ function getEntityPath(entitiesKey, entityId) {
 }
 
 export function visitVulnerabilityManagementDashboardFromLeftNav() {
+    const oldVulnMgmtNavText = hasFeatureFlag('ROX_VULN_MGMT_WORKLOAD_CVES')
+        ? 'Vulnerability Management (1.0)'
+        : 'Vulnerability Management';
     visitFromLeftNavExpandable(
-        'Vulnerability Management',
+        oldVulnMgmtNavText,
         'Dashboard',
         routeMatcherMapForVulnerabilityManagementDashboard
     );

--- a/ui/apps/platform/cypress/integration/vulnmanagement/reporting/reporting.helpers.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/reporting/reporting.helpers.js
@@ -1,3 +1,4 @@
+import { hasFeatureFlag } from '../../../helpers/features';
 import { visitFromLeftNavExpandable } from '../../../helpers/nav';
 import {
     getRouteMatcherMapForGraphQL,
@@ -54,11 +55,10 @@ export function interactAndVisitVulnerabilityReporting(interactionCallback, stat
 }
 
 export function visitVulnerabilityReportingFromLeftNav() {
-    visitFromLeftNavExpandable(
-        'Vulnerability Management',
-        'Reporting',
-        routeMatcherMapWithSearchOptions
-    );
+    const oldVulnMgmtNavText = hasFeatureFlag('ROX_VULN_MGMT_WORKLOAD_CVES')
+        ? 'Vulnerability Management (1.0)'
+        : 'Vulnerability Management';
+    visitFromLeftNavExpandable(oldVulnMgmtNavText, 'Reporting', routeMatcherMapWithSearchOptions);
 
     cy.location('pathname').should('eq', basePath);
     cy.location('search').should('eq', '');

--- a/ui/apps/platform/src/Containers/MainPage/Sidebar/BadgedNavItem.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Sidebar/BadgedNavItem.tsx
@@ -1,0 +1,44 @@
+import React, { CSSProperties } from 'react';
+import { Flex, Label } from '@patternfly/react-core';
+
+import LeftNavItem, { LeftNavItemProps } from './LeftNavItem';
+
+export type BadgedNavItemProps = LeftNavItemProps & {
+    variant: 'TechPreview' | 'Deprecated';
+};
+
+const badges = {
+    TechPreview: (
+        <Label isCompact color="orange">
+            Tech preview
+        </Label>
+    ),
+    Deprecated: (
+        <Label
+            isCompact
+            style={
+                {
+                    '--pf-c-label--BackgroundColor': 'var(--pf-global--disabled-color--200)',
+                } as CSSProperties
+            }
+        >
+            Deprecated
+        </Label>
+    ),
+} as const;
+
+function BadgedNavItem(props: BadgedNavItemProps) {
+    return (
+        <LeftNavItem
+            {...props}
+            title={
+                <Flex spaceItems={{ default: 'spaceItemsSm' }}>
+                    <span>{props.title}</span>
+                    <span>{badges[props.variant]}</span>
+                </Flex>
+            }
+        />
+    );
+}
+
+export default BadgedNavItem;

--- a/ui/apps/platform/src/Containers/MainPage/Sidebar/NavigationSidebar.css
+++ b/ui/apps/platform/src/Containers/MainPage/Sidebar/NavigationSidebar.css
@@ -1,0 +1,3 @@
+.pf-c-nav__item button {
+  text-align: left;
+}

--- a/ui/apps/platform/src/Containers/MainPage/Sidebar/NavigationSidebar.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Sidebar/NavigationSidebar.tsx
@@ -28,6 +28,9 @@ import {
 import LeftNavItem from './LeftNavItem';
 import NetworkGraphNavItems from './NetworkGraphNavItems';
 
+import './NavigationSidebar.css';
+import BadgedNavItem from './BadgedNavItem';
+
 type NavigationSidebarProps = {
     hasReadAccess: HasReadAccess;
     isFeatureFlagEnabled: IsFeatureFlagEnabled;
@@ -69,6 +72,9 @@ function NavigationSidebar({
     }
 
     const vulnerabilitiesPaths = [vulnerabilitiesWorkloadCvesPath];
+    const isWorkloadCvesEnabled =
+        isFeatureFlagEnabled('ROX_VULN_MGMT_WORKLOAD_CVES') &&
+        isFeatureFlagEnabled('ROX_POSTGRES_DATASTORE');
 
     const Navigation = (
         <Nav id="nav-primary-simple">
@@ -89,36 +95,33 @@ function NavigationSidebar({
                     path={complianceBasePath}
                     title={basePathToLabelMap[complianceBasePath]}
                 />
-
-                {isFeatureFlagEnabled('ROX_VULN_MGMT_WORKLOAD_CVES') &&
-                    isFeatureFlagEnabled('ROX_POSTGRES_DATASTORE') && (
-                        // TODO We need to designate this as Tech Preview in a more standard way, based on UX guidance
-                        <NavExpandable
-                            id="Vulnerabilities"
-                            title="Vulnerabilities (preview)"
-                            isActive={vulnerabilitiesPaths.some((path) =>
-                                location.pathname.includes(path)
-                            )}
-                            isExpanded={vulnerabilitiesPaths.some((path) =>
-                                location.pathname.includes(path)
-                            )}
-                        >
-                            {vulnerabilitiesPaths.map((path) => {
-                                const isActive = location.pathname.includes(path);
-                                return (
-                                    <LeftNavItem
-                                        key={path}
-                                        isActive={isActive}
-                                        path={path}
-                                        title={basePathToLabelMap[path]}
-                                    />
-                                );
-                            })}
-                        </NavExpandable>
-                    )}
+                {isWorkloadCvesEnabled && (
+                    <NavExpandable
+                        id="Vulnerabilities"
+                        title="Vulnerability Management (2.0)"
+                        isActive={vulnerabilitiesPaths.some((path) =>
+                            location.pathname.includes(path)
+                        )}
+                        isExpanded={vulnerabilitiesPaths.some((path) =>
+                            location.pathname.includes(path)
+                        )}
+                    >
+                        <BadgedNavItem
+                            variant="TechPreview"
+                            key={vulnerabilitiesWorkloadCvesPath}
+                            isActive={location.pathname.includes(vulnerabilitiesWorkloadCvesPath)}
+                            path={vulnerabilitiesWorkloadCvesPath}
+                            title={basePathToLabelMap[vulnerabilitiesWorkloadCvesPath]}
+                        />
+                    </NavExpandable>
+                )}
                 <NavExpandable
                     id="VulnerabilityManagement"
-                    title="Vulnerability Management"
+                    title={
+                        isWorkloadCvesEnabled
+                            ? 'Vulnerability Management (1.0)'
+                            : 'Vulnerability Management'
+                    }
                     isActive={vulnerabilityManagementPaths.some((path) =>
                         location.pathname.includes(path)
                     )}

--- a/ui/apps/platform/src/Containers/MainPage/Sidebar/NetworkGraphNavItems.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Sidebar/NetworkGraphNavItems.tsx
@@ -4,7 +4,7 @@ import { networkBasePath, networkBasePathPF } from 'routePaths';
 
 import { IsFeatureFlagEnabled } from 'hooks/useFeatureFlags';
 
-import LeftNavItem from './LeftNavItem';
+import BadgedNavItem from './BadgedNavItem';
 
 type NetworkGraphNavItemsProps = {
     isFeatureFlagEnabled: IsFeatureFlagEnabled;
@@ -14,22 +14,22 @@ function NetworkGraphNavItems({ isFeatureFlagEnabled }: NetworkGraphNavItemsProp
     const location: Location = useLocation();
     const isNetworkGraphPFEnabled = isFeatureFlagEnabled('ROX_NETWORK_GRAPH_PATTERNFLY');
 
-    const networkGraphTitle = isNetworkGraphPFEnabled
-        ? 'Network Graph (1.0 deprecated)'
-        : 'Network Graph';
+    const networkGraphTitle = isNetworkGraphPFEnabled ? 'Network Graph (1.0)' : 'Network Graph';
     const networkGraphPFTitle = 'Network Graph (2.0)';
 
     return (
         <>
             {isNetworkGraphPFEnabled && (
-                <LeftNavItem
+                <BadgedNavItem
+                    variant="TechPreview"
                     isActive={location.pathname.includes(networkBasePathPF)}
                     path={networkBasePathPF}
                     title={networkGraphPFTitle}
                 />
             )}
 
-            <LeftNavItem
+            <BadgedNavItem
+                variant="Deprecated"
                 isActive={
                     location.pathname.includes(networkBasePath) &&
                     !location.pathname.includes(networkBasePathPF)


### PR DESCRIPTION
## Description

Updates the sidebar navigation to communicate the status of new features in a standard way according to UX mocks from @zhenpesky . This currently only impacts the Workload CVE and Network Graph features.

_Easier to review with "Hide whitespace" turned on_

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Load the app and view the left hand navigation, with ROX_VULN_MGMT_WORKLOAD_CVES and ROX_POSTGRES_DATASTORE and ROX_NETWORK_GRAPH_PATTERNFLY enabled. Note that we are not officially deprecating any of the navigation items for VM 1.0 at this point, even if Workload CVEs are beginning their deprecation.

![image](https://github.com/stackrox/stackrox/assets/1292638/9cf1ab4d-5cc2-4f27-aadd-1b2fed74a2f9)
![image](https://github.com/stackrox/stackrox/assets/1292638/3d85a49d-c11b-43f6-9122-8178e86a5e08)

Load the app with ROX_NETWORK_GRAPH_PATTERNFLY disabled. (This is marked deprecated in the nav still, even with the FF off since we have previously released it as a deprecated version. I'm not sure having the flag disabled is even a valid consideration at this point.)
![image](https://github.com/stackrox/stackrox/assets/1292638/368ed5f8-e42d-4772-929b-61e7ea455545)

Load the app with ROX_VULN_MGMT_WORKLOAD_CVES disabled.
![image](https://github.com/stackrox/stackrox/assets/1292638/83e73f59-63b8-4b1f-925e-1f179beba079)


