### PR TITLE
ROX-16816,ROX-16841: Increase timeouts in declarative config tests for deletion

### DIFF
--- a/qa-tests-backend/src/test/groovy/DeclarativeConfigTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DeclarativeConfigTest.groovy
@@ -278,7 +278,7 @@ oidc:
         // Verify the integration health for the access scope is unhealthy and contains an error message.
         // The errors will be surface after at least three consecutive occurrences, hence we need to retry multiple
         // times here.
-        withRetry(30, 10) {
+        withRetry(RETRIES, PAUSE_SECS) {
             def response = IntegrationHealthService.getDeclarativeConfigHealthInfo()
             def accessScopeHealth = response.getIntegrationHealthList().find {
                 it.getName().contains(ACCESS_SCOPE_KEY)

--- a/qa-tests-backend/src/test/groovy/DeclarativeConfigTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DeclarativeConfigTest.groovy
@@ -40,6 +40,10 @@ class DeclarativeConfigTest extends BaseSpecification {
 
     static final private int CREATED_RESOURCES = 6
 
+    static final private int RETRIES = 30
+    static final private int DELETION_RETRIES = 45
+    static final private int PAUSE_SECS = 10
+
     // Values used within testing for permission sets.
     // These include:
     //  - a valid permission set YAML (valid == upserting these will work)
@@ -209,11 +213,11 @@ oidc:
         createDefaultSetOfResources(CONFIGMAP_NAME, DEFAULT_NAMESPACE)
 
         then:
-        // Retry this multiple times, with a pause of 60 seconds.
+        // Retry this multiple times.
         // It may take some time until a) the config map contents are mapped within the pod b) the reconciliation
         // has been triggered.
         // If the tests are flaky, we have to increase this value.
-        withRetry(5, 60) {
+        withRetry(RETRIES, PAUSE_SECS) {
             def response = IntegrationHealthService.getDeclarativeConfigHealthInfo()
             // Expect 6 integration health status for the created resources and one for the config map.
             assert response.integrationHealthCount == CREATED_RESOURCES + 1
@@ -253,7 +257,7 @@ oidc:
         // Verify the integration health for the permission set is unhealthy and contains an error message.
         // The errors will be surface after at least three consecutive occurrences, hence we need to retry multiple
         // times here.
-        withRetry(5, 60) {
+        withRetry(RETRIES, PAUSE_SECS) {
             def response = IntegrationHealthService.getDeclarativeConfigHealthInfo()
             def permissionSetHealth = response.getIntegrationHealthList().find {
                 it.getName().contains(PERMISSION_SET_KEY)
@@ -274,7 +278,7 @@ oidc:
         // Verify the integration health for the access scope is unhealthy and contains an error message.
         // The errors will be surface after at least three consecutive occurrences, hence we need to retry multiple
         // times here.
-        withRetry(5, 60) {
+        withRetry(30, 10) {
             def response = IntegrationHealthService.getDeclarativeConfigHealthInfo()
             def accessScopeHealth = response.getIntegrationHealthList().find {
                 it.getName().contains(ACCESS_SCOPE_KEY)
@@ -293,7 +297,7 @@ oidc:
 
         then:
         // Verify the integration health for the role is unhealthy and contains an error message.
-        withRetry(5, 60) {
+        withRetry(RETRIES, PAUSE_SECS) {
             def response = IntegrationHealthService.getDeclarativeConfigHealthInfo()
             def roleHealth = response.getIntegrationHealthList().find {
                 it.getName().contains(ROLE_KEY)
@@ -314,7 +318,7 @@ oidc:
         // Verify the integration health for the auth provider is unhealthy and contains an error message.
         // The errors will be surface after at least three consecutive occurrences, hence we need to retry multiple
         // times here.
-        withRetry(5, 60) {
+        withRetry(RETRIES, PAUSE_SECS) {
             def response = IntegrationHealthService.getDeclarativeConfigHealthInfo()
             def roleHealth = response.getIntegrationHealthList().find {
                 it.getName().contains(AUTH_PROVIDER_KEY)
@@ -338,7 +342,7 @@ oidc:
         orchestrator.deleteConfigMap(CONFIGMAP_NAME, DEFAULT_NAMESPACE)
 
         then:
-        withRetry(5, 60) {
+        withRetry(DELETION_RETRIES, PAUSE_SECS) {
             def response = IntegrationHealthService.getDeclarativeConfigHealthInfo()
             assert response.getIntegrationHealthCount() == 1
             def configMapHealth = response.getIntegrationHealth(0)
@@ -392,7 +396,7 @@ oidc:
                 ], DEFAULT_NAMESPACE)
 
         then:
-        withRetry(5, 60) {
+        withRetry(RETRIES, PAUSE_SECS) {
             def response = IntegrationHealthService.getDeclarativeConfigHealthInfo()
             // Expect 6 integration health status for the created resources and one for the config map.
             assert response.integrationHealthCount == CREATED_RESOURCES + 1
@@ -443,7 +447,7 @@ oidc:
 
         then:
         // Only the config map health status should exist, all others should be removed.
-        withRetry(5, 60) {
+        withRetry(DELETION_RETRIES, PAUSE_SECS) {
             def response = IntegrationHealthService.getDeclarativeConfigHealthInfo()
             assert response.getIntegrationHealthCount() == 1
             def configMapHealth = response.getIntegrationHealth(0)
@@ -461,11 +465,11 @@ oidc:
         createDefaultSetOfResources(CONFIGMAP_NAME, DEFAULT_NAMESPACE)
 
         then:
-        // Retry this multiple times, with a pause of 60 seconds.
+        // Retry this multiple times.
         // It may take some time until a) the config map contents are mapped within the pod b) the reconciliation
         // has been triggered.
         // If the tests are flaky, we have to increase this value.
-        withRetry(5, 60) {
+        withRetry(RETRIES, PAUSE_SECS) {
             def response = IntegrationHealthService.getDeclarativeConfigHealthInfo()
             // Expect 6 integration health status for the created resources and one for the config map.
             assert response.integrationHealthCount == CREATED_RESOURCES + 1
@@ -483,7 +487,7 @@ oidc:
         // Verify the integration health for the permission set is unhealthy and contains an error message.
         // The errors will be surface after at least three consecutive occurrences, hence we need to retry multiple
         // times here.
-        withRetry(5, 60) {
+        withRetry(RETRIES, PAUSE_SECS) {
             def response = IntegrationHealthService.getDeclarativeConfigHealthInfo()
             def permissionSetHealth = response.getIntegrationHealthList().find {
                 it.getName().contains(PERMISSION_SET_KEY)
@@ -503,7 +507,7 @@ oidc:
         updateConfigMapValue(CONFIGMAP_NAME, DEFAULT_NAMESPACE, PERMISSION_SET_KEY, VALID_PERMISSION_SET_YAML)
 
         then:
-        withRetry(5, 60) {
+        withRetry(RETRIES, PAUSE_SECS) {
             def response = IntegrationHealthService.getDeclarativeConfigHealthInfo()
             def permissionSetHealth = response.getIntegrationHealthList().find {
                 it.getName().contains(PERMISSION_SET_KEY)
@@ -518,7 +522,7 @@ oidc:
         deleteConfigMapValue(CONFIGMAP_NAME, DEFAULT_NAMESPACE, ACCESS_SCOPE_KEY)
 
         then:
-        withRetry(5, 60) {
+        withRetry(RETRIES, PAUSE_SECS) {
             def response = IntegrationHealthService.getDeclarativeConfigHealthInfo()
             def accessScopeHealth = response.getIntegrationHealthList().find {
                 it.getName().contains(ACCESS_SCOPE_KEY)
@@ -538,7 +542,7 @@ oidc:
         updateConfigMapValue(CONFIGMAP_NAME, DEFAULT_NAMESPACE, ACCESS_SCOPE_KEY, VALID_ACCESS_SCOPE_YAML)
 
         then:
-        withRetry(5, 60) {
+        withRetry(RETRIES, PAUSE_SECS) {
             def response = IntegrationHealthService.getDeclarativeConfigHealthInfo()
             def accessScopeHealth = response.getIntegrationHealthList().find {
                 it.getName().contains(ACCESS_SCOPE_KEY)
@@ -554,6 +558,7 @@ oidc:
         def authProvider = authProvidersResponse.getAuthProvidersList().find {
             it.getName() == AUTH_PROVIDER_KEY
         }
+        assert authProvider
         def imperativeGroup = Group.newBuilder()
                 .setRoleName(ROLE_KEY)
                 .setProps(GroupProperties.newBuilder()
@@ -572,7 +577,7 @@ oidc:
         deleteConfigMapValue(CONFIGMAP_NAME, DEFAULT_NAMESPACE, ROLE_KEY)
 
         then:
-        withRetry(5, 60) {
+        withRetry(RETRIES, PAUSE_SECS) {
             def response = IntegrationHealthService.getDeclarativeConfigHealthInfo()
             def roleHealth = response.getIntegrationHealthList().find {
                 it.getName().contains(ROLE_KEY)
@@ -592,7 +597,7 @@ oidc:
         updateConfigMapValue(CONFIGMAP_NAME, DEFAULT_NAMESPACE, ROLE_KEY, VALID_ROLE_YAML)
 
         then:
-        withRetry(5, 60) {
+        withRetry(RETRIES, PAUSE_SECS) {
             def response = IntegrationHealthService.getDeclarativeConfigHealthInfo()
             def roleHealth = response.getIntegrationHealthList().find {
                 it.getName().contains(ROLE_KEY)
@@ -607,7 +612,7 @@ oidc:
         deleteConfigMapValue(CONFIGMAP_NAME, DEFAULT_NAMESPACE, AUTH_PROVIDER_KEY)
 
         then:
-        withRetry(5, 60) {
+        withRetry(RETRIES, PAUSE_SECS) {
             def response = IntegrationHealthService.getDeclarativeConfigHealthInfo()
             // After auth provider deletion we should be left only with integration health for:
             // - access scope
@@ -624,6 +629,21 @@ oidc:
         // Verify imperative group referencing declarative auth provider is deleted with it.
         def error = thrown(StatusRuntimeException)
         assert error.getStatus().getCode() == io.grpc.Status.Code.NOT_FOUND
+
+        when:
+        orchestrator.deleteConfigMap(CONFIGMAP_NAME, DEFAULT_NAMESPACE)
+
+        then:
+        // Only the config map health status should exist, all others should be removed.
+        withRetry(DELETION_RETRIES, PAUSE_SECS) {
+            def response = IntegrationHealthService.getDeclarativeConfigHealthInfo()
+            assert response.getIntegrationHealthCount() == 1
+            def configMapHealth = response.getIntegrationHealth(0)
+            assert configMapHealth
+            assert configMapHealth.getName().contains("Config Map")
+            assert configMapHealth.getErrorMessage() == ""
+            assert configMapHealth.getStatus() == Status.HEALTHY
+        }
     }
 
     // Helpers


### PR DESCRIPTION
## Description

There currently exist two CI flakes within the declarative config tests.

They both are related with deletion of resources. Hence, we increase the timeout only for waiting for the deletions.

Additionally, lowered the pause seconds from 60 to 10, this should also speed up things when we receive an update earlier (previously, the interval was 60 seconds, hence the value. Since we decreased the interval and logic, we may also decrease the pause seconds now to hopefully speed things up in some 
cases).

While it's unfortunate to increase the timeout yet again for an expensive, long-running test like the declarative config one, there's no real way to speed things up on the backend:
- the interval already has lowered from 60 to 20 seconds. Decreasing the interval further would have performance impacts on database reads.
- the time until changes are  propagated to the central pod take time with variance. While the k8s cfg watcher has a 5 seconds interval, it takes time until the change is propagated within the pod's volume mount. This takes the most time within the test (it can take up to 2-3 minutes).

Will observe the impact on this change within the CI runs to come, verifying whether this fixed the issue.

Potential future work:

I played around with the idea locally to try to speed up the tests by creating unique resources per test, i.e. each test will have a separate config key within the config map (e.g. the test name) and resources are being created under this specific config key as a multi-line YAML document.
This way, we could split out the "big tests" which essentially tests the whole flow into smaller tests which could in theory run in parallel.
I'll create a follow-up PR for this to tackle this and hopefully make the tests a) less long-running for single tests and b) isolate potential issues per resource.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

- see CI pass.
