### PR TITLE
Fix trailing multiline YAML delimiter for declarative configurations.

### DIFF
--- a/pkg/declarativeconfig/configuration.go
+++ b/pkg/declarativeconfig/configuration.go
@@ -107,7 +107,11 @@ func parseToConfiguration(contents []byte) ([]Configuration, error) {
 		if err != nil {
 			return nil, errors.Wrap(err, "decoding YAML file contents")
 		}
-		unstructuredObjs = append(unstructuredObjs, obj)
+		// In a multi-line YAML document, in case of a trailing "---", no error will be returned by decode. Instead,
+		// a nil object will be decoded. We should skip these decoded objects.
+		if obj != nil {
+			unstructuredObjs = append(unstructuredObjs, obj)
+		}
 	}
 
 	var configurations []Configuration

--- a/pkg/declarativeconfig/configuration_test.go
+++ b/pkg/declarativeconfig/configuration_test.go
@@ -162,6 +162,63 @@ resources:
 				},
 			},
 		},
+		"single multi-line configuration of roles should be unmarshalled successfully": {
+			rawConfigurations: [][]byte{
+				[]byte(`name: test-name
+description: test-description
+accessScope: access-scope
+permissionSet: permission-set
+---
+name: another-test-name
+description: another-test-description
+accessScope: another-access-scope
+permissionSet: another-permission-set
+`),
+			},
+			expectedConfigurations: []Configuration{
+				&Role{
+					Name:          "test-name",
+					Description:   "test-description",
+					AccessScope:   "access-scope",
+					PermissionSet: "permission-set",
+				},
+				&Role{
+					Name:          "another-test-name",
+					Description:   "another-test-description",
+					AccessScope:   "another-access-scope",
+					PermissionSet: "another-permission-set",
+				},
+			},
+		},
+		"single multi-line configuration of roles w/ trailing delimiter should be unmarshalled successfully": {
+			rawConfigurations: [][]byte{
+				[]byte(`name: test-name
+description: test-description
+accessScope: access-scope
+permissionSet: permission-set
+---
+name: another-test-name
+description: another-test-description
+accessScope: another-access-scope
+permissionSet: another-permission-set
+---
+`),
+			},
+			expectedConfigurations: []Configuration{
+				&Role{
+					Name:          "test-name",
+					Description:   "test-description",
+					AccessScope:   "access-scope",
+					PermissionSet: "permission-set",
+				},
+				&Role{
+					Name:          "another-test-name",
+					Description:   "another-test-description",
+					AccessScope:   "another-access-scope",
+					PermissionSet: "another-permission-set",
+				},
+			},
+		},
 		"multiple raw role configurations should be unmarshalled successfully": {
 			rawConfigurations: [][]byte{
 				[]byte(`


### PR DESCRIPTION
## Description

Given a YAML such as:
```yaml
name: hello-world
description: first declaratively created permission set
resources:
  - resource: Integration
    access: READ_ACCESS
  - resource: Administration
    access: READ_ACCESS
  - resource: Access
    access: READ_ACCESS
---
name: hello-world
description: first declaratively created role
permissionSet: hello-world # Referencing the previously created permission set.
accessScope: Unrestricted # Referencing a system resource, the "Unrestricted" access scope.
---
```

`roxctl declarative-config lint` will fail.

The reason is the trailing delimiter within the YAML multiline object. The `decoder.Decode` will actually not return an error, but instead decode a nil object. In that case, we shouldn't add the nil object to our list of unstructured objects, as these will later fail transformations.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

- see added unit tests.
