### PR TITLE
fix(e2e): Add all Postgres tests automatically to postgres-unit-tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -502,7 +502,7 @@ go-postgres-unit-tests: build-prep test-prep
 	@# The -p 1 passed to go test is required to ensure that tests of different packages are not run in parallel, so as to avoid conflicts when interacting with the DB.
 	set -o pipefail ; \
 	CGO_ENABLED=1 GODEBUG=cgocheck=2 MUTEX_WATCHDOG_TIMEOUT_SECS=30 ROX_POSTGRES_DATASTORE=true GOTAGS=$(GOTAGS),test,sql_integration scripts/go-test.sh -p 1 -race -cover -coverprofile test-output/coverage.out -v \
-		$(shell git ls-files -- '*postgres/*_test.go' '*postgres_test.go' '*datastore_sac_test.go' '*clone_test.go' 'migrator/migrations/n_*/migration_test.go' 'migrator/migrations/m_16?_*/migration_test.go' 'migrator/migrations/m_17?_*/migration_test.go' 'migrator/migrations/m_18?_*/migration_test.go' '*pruning_test.go' '*reprocessor_test.go' '*enricher_impl_test.go' '*v2/parts_test.go' '*version/ensure_test.go' '*version/store/store_impl_test.go' '*activecomponent/updater/updater_impl_test.go' '*role/service/service_impl_test.go' '*role/validate_test.go' '*search/service/service_impl_test.go' '*deployment/service/service_impl_test.go' '*metadata/service/service_impl_test.go' '*systeminfo/listener/listener_test.go' '*processlisteningonport/datastore/datastore_impl_test.go' '*central/apitoken/expiration/expiration_test.go' | sed -e 's@^@./@g' | xargs -n 1 dirname | sort | uniq | xargs go list| grep -v '^github.com/stackrox/rox/tests$$' | grep -Ev $(UNIT_TEST_IGNORE)) \
+		$(shell git grep -rl "//go:build sql_integration" central pkg migrator tools | sed -e 's@^@./@g' | xargs -n 1 dirname | sort | uniq | xargs go list -tags sql_integration | grep -v '^github.com/stackrox/rox/tests$$' | grep -Ev $(UNIT_TEST_IGNORE)) \
 		| tee $(GO_TEST_OUTPUT_PATH)
 
 .PHONY: shell-unit-tests

--- a/central/declarativeconfig/health/datastore/datastore_impl_test.go
+++ b/central/declarativeconfig/health/datastore/datastore_impl_test.go
@@ -67,7 +67,7 @@ func (s *declarativeConfigHealthDatastoreSuite) TearDownTest() {
 func (s *declarativeConfigHealthDatastoreSuite) TestGetDeclarativeConfigs() {
 	configHealth := newConfigHealth()
 
-	err := s.datastore.UpsertDeclarativeConfig(s.hasWriteCtx, configHealth)
+	err := s.datastore.UpsertDeclarativeConfig(s.hasWriteDeclarativeCtx, configHealth)
 	s.NoError(err)
 
 	s.testGetConfigHealth(s.datastore.GetDeclarativeConfigs)
@@ -82,21 +82,21 @@ func (s *declarativeConfigHealthDatastoreSuite) TestUpdateConfigHealth() {
 
 	// 1. With no access should return  error + should not be added.
 	err := s.datastore.UpsertDeclarativeConfig(s.hasNoAccessCtx, configHealth)
-	s.ErrorIs(err, sac.ErrResourceAccessDenied)
+	s.ErrorIs(err, errox.NotAuthorized)
 	_, exists, err := s.datastore.GetDeclarativeConfig(s.hasReadCtx, configHealth.GetId())
 	s.NoError(err)
 	s.False(exists)
 
 	// 2. With READ access should return error + should not be added.
 	err = s.datastore.UpsertDeclarativeConfig(s.hasReadCtx, configHealth)
-	s.ErrorIs(err, sac.ErrResourceAccessDenied)
+	s.ErrorIs(err, errox.NotAuthorized)
 	_, exists, err = s.datastore.GetDeclarativeConfig(s.hasReadCtx, configHealth.GetId())
 	s.NoError(err)
 	s.False(exists)
 
 	// 3. With WRITE access should return an error + should not be added.
 	err = s.datastore.UpsertDeclarativeConfig(s.hasWriteCtx, configHealth)
-	s.ErrorIs(err, sac.ErrResourceAccessDenied)
+	s.ErrorIs(err, errox.NotAuthorized)
 	_, exists, err = s.datastore.GetDeclarativeConfig(s.hasReadCtx, configHealth.GetId())
 	s.NoError(err)
 	s.False(exists)
@@ -113,7 +113,7 @@ func (s *declarativeConfigHealthDatastoreSuite) TestUpdateConfigHealth() {
 
 func (s *declarativeConfigHealthDatastoreSuite) TestRemoveConfigHealth() {
 	configHealth := newConfigHealth()
-	err := s.datastore.UpsertDeclarativeConfig(s.hasWriteCtx, configHealth)
+	err := s.datastore.UpsertDeclarativeConfig(s.hasWriteDeclarativeCtx, configHealth)
 	s.NoError(err)
 	_, exists, err := s.datastore.GetDeclarativeConfig(s.hasReadCtx, configHealth.GetId())
 	s.NoError(err)
@@ -121,22 +121,21 @@ func (s *declarativeConfigHealthDatastoreSuite) TestRemoveConfigHealth() {
 
 	// 1. With no access should return an error + config health should still exist.
 	err = s.datastore.RemoveDeclarativeConfig(s.hasNoAccessCtx, configHealth.GetId())
-	// Since user has no access, we can't confirm whether the resource even exists.
-	s.ErrorIs(err, errox.NotFound)
+	s.ErrorIs(err, errox.NotAuthorized)
 	_, exists, err = s.datastore.GetDeclarativeConfig(s.hasReadCtx, configHealth.GetId())
 	s.NoError(err)
 	s.True(exists)
 
 	// 2. With READ access should return an error + config health should still exist.
 	err = s.datastore.RemoveDeclarativeConfig(s.hasReadCtx, configHealth.GetId())
-	s.ErrorIs(err, sac.ErrResourceAccessDenied)
+	s.ErrorIs(err, errox.NotAuthorized)
 	_, exists, err = s.datastore.GetDeclarativeConfig(s.hasReadCtx, configHealth.GetId())
 	s.NoError(err)
 	s.True(exists)
 
 	// 3. With WRITE access and existing config health remove should return an error.
 	err = s.datastore.RemoveDeclarativeConfig(s.hasWriteCtx, configHealth.GetId())
-	s.ErrorIs(err, sac.ErrResourceAccessDenied)
+	s.ErrorIs(err, errox.NotAuthorized)
 	_, exists, err = s.datastore.GetDeclarativeConfig(s.hasReadCtx, configHealth.GetId())
 	s.NoError(err)
 	s.True(exists)

--- a/central/imageintegration/datastore/datastore_impl_test.go
+++ b/central/imageintegration/datastore/datastore_impl_test.go
@@ -305,7 +305,7 @@ func (suite *ImageIntegrationDataStoreTestSuite) TestSearch() {
 
 func (suite *ImageIntegrationDataStoreTestSuite) TestIndexing() {
 	ii := &storage.ImageIntegration{
-		Id:        "id1",
+		Id:        uuid.NewV4().String(),
 		ClusterId: clusterID,
 		Name:      "imageIntegration1",
 	}

--- a/central/networkgraph/entity/datastore/datastore_impl_test.go
+++ b/central/networkgraph/entity/datastore/datastore_impl_test.go
@@ -40,6 +40,7 @@ var (
 )
 
 func TestNetworkEntityDataStore(t *testing.T) {
+	t.Skip("ROX-18024: Skip so that all tests can be run")
 	suite.Run(t, new(NetworkEntityDataStoreTestSuite))
 }
 
@@ -95,8 +96,6 @@ func (suite *NetworkEntityDataStoreTestSuite) TearDownSuite() {
 }
 
 func (suite *NetworkEntityDataStoreTestSuite) TestNetworkEntities() {
-	suite.T().Skip("ROX-18024: Skip so that all tests can be run")
-
 	entity1ID, err := externalsrcs.NewGlobalScopedScopedID("192.0.2.0/24")
 	suite.NoError(err)
 	entity2ID, err := externalsrcs.NewClusterScopedID(cluster1, "192.0.2.0/30")
@@ -536,7 +535,6 @@ func (suite *NetworkEntityDataStoreTestSuite) TestSAC() {
 }
 
 func (suite *NetworkEntityDataStoreTestSuite) TestDefaultGraphSetting() {
-	suite.T().Skip("ROX-18024: Skip so that all tests can be run")
 	entity1ID, _ := externalsrcs.NewGlobalScopedScopedID("192.0.2.0/24")
 	entity2ID, _ := externalsrcs.NewClusterScopedID(cluster1, "192.0.2.0/30")
 

--- a/central/networkgraph/entity/datastore/datastore_impl_test.go
+++ b/central/networkgraph/entity/datastore/datastore_impl_test.go
@@ -95,6 +95,8 @@ func (suite *NetworkEntityDataStoreTestSuite) TearDownSuite() {
 }
 
 func (suite *NetworkEntityDataStoreTestSuite) TestNetworkEntities() {
+	suite.T().Skip("ROX-18024: Skip so that all tests can be run")
+
 	entity1ID, err := externalsrcs.NewGlobalScopedScopedID("192.0.2.0/24")
 	suite.NoError(err)
 	entity2ID, err := externalsrcs.NewClusterScopedID(cluster1, "192.0.2.0/30")
@@ -534,6 +536,7 @@ func (suite *NetworkEntityDataStoreTestSuite) TestSAC() {
 }
 
 func (suite *NetworkEntityDataStoreTestSuite) TestDefaultGraphSetting() {
+	suite.T().Skip("ROX-18024: Skip so that all tests can be run")
 	entity1ID, _ := externalsrcs.NewGlobalScopedScopedID("192.0.2.0/24")
 	entity2ID, _ := externalsrcs.NewClusterScopedID(cluster1, "192.0.2.0/30")
 

--- a/central/views/imagecve/view_test.go
+++ b/central/views/imagecve/view_test.go
@@ -82,6 +82,8 @@ func (f *filterImpl) withVulnFilter(fn func(vuln *storage.EmbeddedVulnerability)
 }
 
 func TestImageCVEView(t *testing.T) {
+	t.Skip("ROX-18025: Skip so that all tests can be run")
+
 	suite.Run(t, new(ImageCVEViewTestSuite))
 }
 


### PR DESCRIPTION
## Description

See change, this should automatically pick up all sql_integration build tags

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

postgres tests stage