### PR TITLE
Fix integration health datastore_impl_test.go

### DIFF
--- a/central/integrationhealth/datastore/datastore_impl_test.go
+++ b/central/integrationhealth/datastore/datastore_impl_test.go
@@ -132,14 +132,14 @@ func (s *integrationHealthDatastoreTestSuite) TestUpdateIntegrationHealth() {
 
 	// 1. With no access should return no error but should not be added.
 	err := s.datastore.UpsertIntegrationHealth(s.hasNoAccessCtx, integrationHealth)
-	s.NoError(err)
+	s.ErrorIs(err, sac.ErrResourceAccessDenied)
 	_, exists, err := s.datastore.GetIntegrationHealth(s.hasReadCtx, integrationHealth.GetId())
 	s.NoError(err)
 	s.False(exists)
 
 	// 2. With READ access should return no error but should not be added.
 	err = s.datastore.UpsertIntegrationHealth(s.hasReadCtx, integrationHealth)
-	s.NoError(err)
+	s.ErrorIs(err, sac.ErrResourceAccessDenied)
 	_, exists, err = s.datastore.GetIntegrationHealth(s.hasReadCtx, integrationHealth.GetId())
 	s.NoError(err)
 	s.False(exists)
@@ -168,14 +168,14 @@ func (s *integrationHealthDatastoreTestSuite) TestRemoveIntegrationHealth() {
 
 	// 1. With no access should not return an error but integration should still exist.
 	err = s.datastore.RemoveIntegrationHealth(s.hasNoAccessCtx, integrationHealth.GetId())
-	s.NoError(err)
+	s.ErrorIs(err, sac.ErrResourceAccessDenied)
 	_, exists, err = s.datastore.GetIntegrationHealth(s.hasReadCtx, integrationHealth.GetId())
 	s.NoError(err)
 	s.True(exists)
 
 	// 2. With READ access should not return an error but integration should still exist.
 	err = s.datastore.RemoveIntegrationHealth(s.hasReadCtx, integrationHealth.GetId())
-	s.NoError(err)
+	s.ErrorIs(err, sac.ErrResourceAccessDenied)
 	_, exists, err = s.datastore.GetIntegrationHealth(s.hasReadCtx, integrationHealth.GetId())
 	s.NoError(err)
 	s.True(exists)


### PR DESCRIPTION
## Description

Most likely was broken due to recent changes to integration health datastore related to declarative config. The reason it was not caught on is because apparently, this test is not on the list of postgres tests to execute. This PR should address it: https://github.com/stackrox/stackrox/pull/6245

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

1. Executed unit tests locally
