### PR TITLE
Make declarative config setting visible in operator

### DIFF
--- a/operator/apis/platform/v1alpha1/central_types.go
+++ b/operator/apis/platform/v1alpha1/central_types.go
@@ -125,7 +125,7 @@ type CentralComponentSpec struct {
 	Telemetry *Telemetry `json:"telemetry,omitempty"`
 
 	// Configures resources within Central in a declarative manner.
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,order=8,displayName="Declarative Configuration",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:hidden"}
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,order=8,displayName="Declarative Configuration"
 	DeclarativeConfiguration *DeclarativeConfiguration `json:"declarativeConfiguration,omitempty"`
 
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,order=99

--- a/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
@@ -118,8 +118,6 @@ spec:
       - description: Configures resources within Central in a declarative manner.
         displayName: Declarative Configuration
         path: central.declarativeConfiguration
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
       - description: Allows overriding the default resource settings for this component.
           Please consult the documentation for an overview of default resource requirements
           and a sizing guide.

--- a/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
@@ -296,8 +296,6 @@ spec:
       - description: Configures resources within Central in a declarative manner.
         displayName: Declarative Configuration
         path: central.declarativeConfiguration
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
       - description: Stores persistent data on a directory on the host. This is not
           recommended, and should only be used together with a node selector (only
           available in YAML view).


### PR DESCRIPTION
## Description

With the release of 4.1, the declarative config setting shall now be visible when using the operator.

This PR removes the previously "hidden" settings for the operator.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

- TODO @dhaus67 test the bundle w/ screenshots.
