### PR TITLE
ROX-16008: Enable declarative config feature by default

### DIFF
--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -199,10 +199,7 @@ function launch_central {
       add_args "--enable-pod-security-policies=${POD_SECURITY_POLICIES}"
     fi
 
-    # TODO(ROX-16008): Once the feature flag is enabled by default, always add the config map mount.
-    if [[ -n "${ROX_DECLARATIVE_CONFIGURATION}" ]]; then
-        add_args "--declarative-config-config-maps=declarative-configurations"
-    fi
+    add_args "--declarative-config-config-maps=declarative-configurations"
 
     local unzip_dir="${k8s_dir}/central-deploy/"
     rm -rf "${unzip_dir}"

--- a/pkg/env/declarative_config.go
+++ b/pkg/env/declarative_config.go
@@ -12,5 +12,5 @@ var (
 		20*time.Second)
 
 	// DeclarativeConfiguration enables declarative configuration feature as a preview.
-	DeclarativeConfiguration = RegisterBooleanSetting("ROX_DECLARATIVE_CONFIGURATION", false)
+	DeclarativeConfiguration = RegisterBooleanSetting("ROX_DECLARATIVE_CONFIGURATION", true)
 )

--- a/qa-tests-backend/src/test/groovy/DeclarativeConfigTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DeclarativeConfigTest.groovy
@@ -16,8 +16,6 @@ import io.stackrox.proto.storage.RoleOuterClass.SimpleAccessScope
 import io.stackrox.proto.storage.RoleOuterClass.Role
 import io.stackrox.proto.storage.TraitsOuterClass.Traits
 
-import util.Env
-
 import services.AuthProviderService
 import services.GroupService
 import services.IntegrationHealthService
@@ -25,13 +23,10 @@ import services.RoleService
 
 import org.junit.Rule
 import org.junit.rules.Timeout
-import spock.lang.IgnoreIf
 import spock.lang.Retry
 import spock.lang.Tag
 
 @Retry(count = 0)
-// TODO(ROX-16008): Remove this once the declarative config feature flag is enabled by default.
-@IgnoreIf({ Env.get("ROX_DECLARATIVE_CONFIGURATION", "false") == "false" })
 class DeclarativeConfigTest extends BaseSpecification {
     static final private String DEFAULT_NAMESPACE = "stackrox"
 

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -105,11 +105,6 @@ export_test_environment() {
     ci_export ROX_VULN_MGMT_WORKLOAD_CVES "${ROX_VULN_MGMT_WORKLOAD_CVES:-true}"
     ci_export ROX_SEND_NAMESPACE_LABELS_IN_SYSLOG "${ROX_SEND_NAMESPACE_LABELS_IN_SYSLOG:-true}"
 
-    if [[ -z "${BUILD_TAG:-}" ]]; then
-        # TODO(ROX-16008): Remove this once the declarative config feature flag is enabled by default.
-        ci_export ROX_DECLARATIVE_CONFIGURATION "${ROX_DECLARATIVE_CONFIGURATION:-true}"
-    fi
-
     if is_in_PR_context && pr_has_label ci-fail-fast; then
         ci_export FAIL_FAST "true"
     fi
@@ -190,8 +185,6 @@ deploy_central_via_operator() {
     customize_envVars+=$'\n        value: "'"${ROX_POSTGRES_DATASTORE:-false}"'"'
     customize_envVars+=$'\n      - name: ROX_PROCESSES_LISTENING_ON_PORT'
     customize_envVars+=$'\n        value: "'"${ROX_PROCESSES_LISTENING_ON_PORT:-true}"'"'
-    customize_envVars+=$'\n      - name: ROX_DECLARATIVE_CONFIGURATION'
-    customize_envVars+=$'\n        value: "'"${ROX_DECLARATIVE_CONFIGURATION:-true}"'"'
 
     env - \
       centralAdminPasswordBase64="$centralAdminPasswordBase64" \

--- a/tests/roxctl/bats-tests/local/expect/flavor-interactive.expect.tcl
+++ b/tests/roxctl/bats-tests/local/expect/flavor-interactive.expect.tcl
@@ -42,6 +42,7 @@ expect "Enter administrator password*:*: " { send "\n" }
 expect "Enter orchestrator (k8s, openshift)*: " { send "k8s\n" }
 expect "Enter default container images settings*:*: " { send "$flavor\n" }
 expect "Enter the directory to output the deployment bundle to*:*: " { send "$out_dir\n" }
+expect "Enter whether to enable telemetry*:" { send "\n" }
 
 # Enter central-db image to use (default: "docker.io/stackrox/central-db:2.21.0-15-g448f2dc8fa"):
 # Enter central-db image to use (default: "stackrox.io/central-db:3.67.x-296-g56df6a892d"):
@@ -67,7 +68,7 @@ expect {
   }
 }
 
-expect "Enter whether to enable telemetry*:*: " { send "\n" }
+expect "Enter list of secrets to add as declarative configuration*:" { send "\n" }
 expect "Enter the method of exposing Central*:*: " { send "none\n" }
 
 # Enter main image to use (default: "docker.io/stackrox/main:3.67.x-296-g56df6a892d"):
@@ -94,6 +95,7 @@ expect {
   }
 }
 expect "Enter whether to run StackRox in offline mode, which avoids reaching out to the Internet*" { send "\n" }
+expect "Enter list of config maps to add as declarative configuration*:" { send "\n" }
 expect "Enter the deployment tool to use (kubectl, helm, helm-values)*:" { send "\n" }
 expect "Enter Istio version when deploying into an Istio-enabled cluster*:" { send "\n" }
 


### PR DESCRIPTION
## Description

With the release of 4.1, the declarative config feature will be released.

We previously introduced this as environment variable to have the developer preview in 4.0, so now the environment variable will be marked as `true` by default.

Adjusted most of the code to respect this.

Once the feature is stable, we shall remove the environment variable completely.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

- see CI passing.
