### PR TITLE
Fix role datastore_impl_test.go

### DIFF
--- a/central/role/datastore/datastore_impl_test.go
+++ b/central/role/datastore/datastore_impl_test.go
@@ -634,8 +634,9 @@ func (s *roleDataStoreTestSuite) TestPermissionSetWriteOperations() {
 
 func getValidAccessScope(id string, name string) *storage.SimpleAccessScope {
 	return &storage.SimpleAccessScope{
-		Id:   role.EnsureValidAccessScopeID(id),
-		Name: name,
+		Id:    role.EnsureValidAccessScopeID(id),
+		Name:  name,
+		Rules: &storage.SimpleAccessScope_Rules{},
 	}
 }
 
@@ -755,12 +756,14 @@ func (s *roleDataStoreTestSuite) TestAccessScopeWriteOperations() {
 	}
 	badScope := getInvalidAccessScope("scope.new", "new invalid scope")
 	mimicScope := &storage.SimpleAccessScope{
-		Id:   goodScope.Id,
-		Name: "existing scope",
+		Id:    goodScope.Id,
+		Name:  "existing scope",
+		Rules: &storage.SimpleAccessScope_Rules{},
 	}
 	cloneScope := &storage.SimpleAccessScope{
-		Id:   s.existingScope.Id,
-		Name: "new existing scope",
+		Id:    s.existingScope.Id,
+		Name:  "new existing scope",
+		Rules: &storage.SimpleAccessScope_Rules{},
 	}
 	updatedDefaultScope := getValidAccessScope("ffffffff-ffff-fff4-f5ff-fffffffffffe",
 		role.AccessScopeExcludeAll.GetName())


### PR DESCRIPTION
## Description

Was broken due to  https://github.com/stackrox/stackrox/pull/6226. The reason it was not caught on is that apparently, this test is not on the list of Postgres tests to execute. This PR should address it: https://github.com/stackrox/stackrox/pull/6245

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

1. Run test manually
