### PR TITLE
ROX-14560: Remove orgid and is_org_admin claims from OIDC Rox token

### DIFF
--- a/pkg/auth/authproviders/oidc/backend_impl.go
+++ b/pkg/auth/authproviders/oidc/backend_impl.go
@@ -39,9 +39,6 @@ const (
 	DisableOfflineAccessScopeConfigKey = "disable_offline_access_scope"
 
 	userInfoExpiration = 5 * time.Minute
-
-	orgIDAttribute = "orgid"
-	orgAdminGroup  = "org_admin"
 )
 
 type nonceVerificationSetting int
@@ -603,12 +600,6 @@ type userInfoType struct {
 	EMail  string   `json:"email"`
 	UID    string   `json:"sub"`
 	Groups []string `json:"groups"`
-	// Every Red Hat SSO user belongs to exactly one organization, claim
-	// "account_id" represents that organisation. See more on the claims here:
-	// 	https://source.redhat.com/groups/public/it-user/it_user_team_wiki/topic_external_sso_enablements#attributes-needed
-	OrgID string `json:"account_id"`
-	// Claim "is_org_admin" is the claim that identifies organisation admins within sso.redhat.com.
-	IsOrgAdmin bool `json:"is_org_admin"`
 }
 
 func userInfoToExternalClaims(userInfo *userInfoType) *tokens.ExternalUserClaim {
@@ -640,13 +631,6 @@ func userInfoToExternalClaims(userInfo *userInfoType) *tokens.ExternalUserClaim 
 		claim.Attributes[authproviders.GroupsAttribute] = userInfo.Groups
 	}
 
-	// Add sso.redhat.com attributes.
-	if userInfo.OrgID != "" {
-		claim.Attributes[orgIDAttribute] = []string{userInfo.OrgID}
-	}
-	if userInfo.IsOrgAdmin {
-		claim.Attributes[authproviders.GroupsAttribute] = append(claim.Attributes[authproviders.GroupsAttribute], orgAdminGroup)
-	}
 	return claim
 }
 


### PR DESCRIPTION
## Description

As this code functionality was replaced by claim mappings, there's no need to keep it anymore.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

1. CI should be sufficient
