### PR TITLE
ROX-16321: Junitify the check for pod restarts

### DIFF
--- a/scripts/ci/logcheck/check-restart-logs.sh
+++ b/scripts/ci/logcheck/check-restart-logs.sh
@@ -41,6 +41,10 @@ patterns=$(jq -c '.[]' "$DIR/restart-ok-patterns.json")
             then
                 echo "Ignoring this restart due to: ${comment}"
                 this_log_is_ok=true
+                if [[ -n "${ARTIFACT_DIR:-}" ]]; then
+                    cp "${logfile}" "${ARTIFACT_DIR}" || true
+                    echo "$(basename "${logfile}") copied to Artifacts"
+                fi
                 break
             fi
         done

--- a/scripts/ci/logcheck/check-restart-logs.sh
+++ b/scripts/ci/logcheck/check-restart-logs.sh
@@ -41,15 +41,15 @@ patterns=$(jq -c '.[]' "$DIR/restart-ok-patterns.json")
             then
                 echo "Ignoring this restart due to: ${comment}"
                 this_log_is_ok=true
-                if [[ -n "${ARTIFACT_DIR:-}" ]]; then
-                    cp "${logfile}" "${ARTIFACT_DIR}" || true
-                    echo "$(basename "${logfile}") copied to Artifacts"
-                fi
                 break
             fi
         done
         if ! ${this_log_is_ok}; then
             echo "This restart does not match any ignore patterns"
+            if [[ -n "${ARTIFACT_DIR:-}" ]]; then
+                cp "${logfile}" "${ARTIFACT_DIR}" || true
+                echo "$(basename "${logfile}") copied to Artifacts"
+            fi
             all_ok=false
         fi
     done
@@ -59,4 +59,3 @@ patterns=$(jq -c '.[]' "$DIR/restart-ok-patterns.json")
 )
 
 exit 0
-

--- a/scripts/ci/logcheck/check-restart-logs_test.bats
+++ b/scripts/ci/logcheck/check-restart-logs_test.bats
@@ -81,7 +81,7 @@ TEST_FIXTURES="${BATS_TEST_DIRNAME}/test_fixtures"
 @test "checks them all" {
     run "$CMD" "openshift-api-e2e-tests" "${TEST_FIXTURES}/exception-collector-previous.log" "${TEST_FIXTURES}/no-exception-collector-previous.log" "${TEST_FIXTURES}/rox-5861-exception-compliance-previous.log"
     [ "$status" -eq 2 ]
-    [ "${#lines[@]}" -eq 6 ]
+    [ "${#lines[@]}" -eq 8 ]
 }
 
 @test "this kernel flavor restart is OK" {

--- a/scripts/ci/logcheck/check-restart-logs_test.bats
+++ b/scripts/ci/logcheck/check-restart-logs_test.bats
@@ -81,7 +81,7 @@ TEST_FIXTURES="${BATS_TEST_DIRNAME}/test_fixtures"
 @test "checks them all" {
     run "$CMD" "openshift-api-e2e-tests" "${TEST_FIXTURES}/exception-collector-previous.log" "${TEST_FIXTURES}/no-exception-collector-previous.log" "${TEST_FIXTURES}/rox-5861-exception-compliance-previous.log"
     [ "$status" -eq 2 ]
-    [ "${#lines[@]}" -eq 8 ]
+    [ "${#lines[@]}" -eq 7 ]
 }
 
 @test "this kernel flavor restart is OK" {

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -517,7 +517,7 @@ check_for_stackrox_restarts() {
         local check_out=""
         # shellcheck disable=SC2086
         if ! check_out="$(scripts/ci/logcheck/check-restart-logs.sh "${CI_JOB_NAME}" $previous_logs)"; then
-            save_junit_failure "Pod Restarts" "Check for unexplained pod restart" "$check_out"
+            save_junit_failure "Pod Restarts" "Check for unexplained pod restart" "${check_out}"
             die "ERROR: Found at least one unexplained pod restart. ${check_out}"
         fi
         info "Restarts were considered benign"

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -513,13 +513,17 @@ check_for_stackrox_restarts() {
     local previous_logs
     previous_logs=$(ls "$dir"/stackrox/pods/*-previous.log || true)
     if [[ -n "$previous_logs" ]]; then
-        info "Restarts were found"
+        info "Pod restarts were found"
         local check_out=""
         # shellcheck disable=SC2086
         if ! check_out="$(scripts/ci/logcheck/check-restart-logs.sh "${CI_JOB_NAME}" $previous_logs)"; then
             save_junit_failure "Pod Restarts" "Check for unexplained pod restart" "$check_out"
             die "ERROR: Found at least one unexplained pod restart. ${check_out}"
         fi
+        info "Restarts were considered benign"
+        echo "${check_out}"
+    else
+        info "No pod restarts were found"
     fi
 
     save_junit_success "Pod Restarts" "Check for unexplained pod restart"


### PR DESCRIPTION
## Description

Per title. By wrapping these failures with a junit report we get jira tracking via junit2jira. The offending log is also copied to the top level of openshift/release Artifacts to make it easier to examine.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient.
- with pod restart due to error during test (e.g. `kubectl -n stackrox exec sensor-69d57d6467-vj9ks -- kill -ABRT 1`)
  - [x] the failed check appears in the JUnit panel
  - [x] failure stands out in the prow UI (build log panel)
- without
  - [x] passing check can be found in the JUnit panel
