### PR TITLE
ROX-16888: Analytics for declarative config feature

### DIFF
--- a/central/authprovider/telemetry/telemetry.go
+++ b/central/authprovider/telemetry/telemetry.go
@@ -60,7 +60,7 @@ var Gather phonehome.GatherFunc = func(ctx context.Context) (map[string]any, err
 	}
 
 	for origin, count := range providerOriginCount {
-		props[fmt.Sprintf("Total %s auth providers",
+		props[fmt.Sprintf("Total %s Auth Providers",
 			cases.Title(language.English, cases.Compact).String(origin.String()))] = count
 	}
 	cases.Title(language.English, cases.NoLower)

--- a/central/authprovider/telemetry/telemetry.go
+++ b/central/authprovider/telemetry/telemetry.go
@@ -63,6 +63,5 @@ var Gather phonehome.GatherFunc = func(ctx context.Context) (map[string]any, err
 		props[fmt.Sprintf("Total %s Auth Providers",
 			cases.Title(language.English, cases.Compact).String(origin.String()))] = count
 	}
-	cases.Title(language.English, cases.NoLower)
 	return props, nil
 }

--- a/central/declarativeconfig/manager.go
+++ b/central/declarativeconfig/manager.go
@@ -1,6 +1,9 @@
 package declarativeconfig
 
+import "github.com/stackrox/rox/pkg/telemetry/phonehome"
+
 // Manager manages reconciling declarative configuration.
 type Manager interface {
 	ReconcileDeclarativeConfigurations()
+	Gather() phonehome.GatherFunc
 }

--- a/central/main.go
+++ b/central/main.go
@@ -564,6 +564,7 @@ func startGRPCServer() {
 				gs.AddGatherer(signatureIntegrationDS.Gather)
 				gs.AddGatherer(roleDataStore.Gather)
 				gs.AddGatherer(clusterDataStore.Gather)
+				gs.AddGatherer(declarativeconfig.ManagerSingleton(registry).Gather())
 			}
 		}
 	}

--- a/central/role/datastore/telemetry.go
+++ b/central/role/datastore/telemetry.go
@@ -3,13 +3,14 @@ package datastore
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/stackrox/rox/central/role/resources"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/errorhelpers"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/telemetry/phonehome"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 // Gather the total amount of permission sets, access scopes, and roles for
@@ -50,7 +51,8 @@ func totalPermissionSets(ctx context.Context, props map[string]any, rs DataStore
 
 	props["Total PermissionSets"] = len(permissionSets)
 	for origin, count := range permissionSetsByOrigin {
-		props[fmt.Sprintf("Total %s PermissionSets", strings.ToLower(origin.String()))] = count
+		props[fmt.Sprintf("Total %s PermissionSets",
+			cases.Title(language.English, cases.Compact).String(origin.String()))] = count
 	}
 	return nil
 }
@@ -74,7 +76,8 @@ func totalRoles(ctx context.Context, props map[string]any, rs DataStore) error {
 
 	props["Total Roles"] = len(roles)
 	for origin, count := range rolesByOrigin {
-		props[fmt.Sprintf("Total %s Roles", strings.ToLower(origin.String()))] = count
+		props[fmt.Sprintf("Total %s Roles",
+			cases.Title(language.English, cases.Compact).String(origin.String()))] = count
 	}
 	return nil
 }
@@ -98,7 +101,8 @@ func totalAccessScopes(ctx context.Context, props map[string]any, rs DataStore) 
 
 	props["Total Access Scopes"] = len(accessScopes)
 	for origin, count := range accessScopesByOrigin {
-		props[fmt.Sprintf("Total %s Access Scopes", strings.ToLower(origin.String()))] = count
+		props[fmt.Sprintf("Total %s Access Scopes",
+			cases.Title(language.English, cases.Compact).String(origin.String()))] = count
 	}
 	return nil
 }

--- a/central/role/datastore/telemetry.go
+++ b/central/role/datastore/telemetry.go
@@ -2,6 +2,8 @@ package datastore
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	"github.com/stackrox/rox/central/role/resources"
 	"github.com/stackrox/rox/generated/storage"
@@ -22,9 +24,66 @@ var Gather phonehome.GatherFunc = func(ctx context.Context) (map[string]any, err
 	rs := Singleton()
 
 	gatherErrs := errorhelpers.NewErrorList("cannot gather from role store")
-	gatherErrs.AddError(phonehome.AddTotal(ctx, totals, "PermissionSets", rs.CountPermissionSets))
-	gatherErrs.AddError(phonehome.AddTotal(ctx, totals, "Roles", rs.CountRoles))
-	gatherErrs.AddError(phonehome.AddTotal(ctx, totals, "Access Scopes", rs.CountAccessScopes))
+	gatherErrs.AddError(totalPermissionSets(ctx, totals, rs))
+	gatherErrs.AddError(totalRoles(ctx, totals, rs))
+	gatherErrs.AddError(totalAccessScopes(ctx, totals, rs))
 
 	return totals, gatherErrs.ToError()
+}
+
+func totalPermissionSets(ctx context.Context, props map[string]any, rs DataStore) error {
+	permissionSets, err := rs.GetAllPermissionSets(ctx)
+	if err != nil {
+		return err
+	}
+
+	permissionSetsByOrigin := make(map[storage.Traits_Origin]int)
+
+	for _, ps := range permissionSets {
+		permissionSetsByOrigin[ps.GetTraits().GetOrigin()]++
+	}
+
+	props["Total PermissionSets"] = len(permissionSets)
+	for origin, count := range permissionSetsByOrigin {
+		props[fmt.Sprintf("Total %s PermissionSets", strings.ToLower(origin.String()))] = count
+	}
+	return nil
+}
+
+func totalRoles(ctx context.Context, props map[string]any, rs DataStore) error {
+	roles, err := rs.GetAllRoles(ctx)
+	if err != nil {
+		return err
+	}
+
+	rolesByOrigin := make(map[storage.Traits_Origin]int)
+
+	for _, role := range roles {
+		rolesByOrigin[role.GetTraits().GetOrigin()]++
+	}
+
+	props["Total Roles"] = len(roles)
+	for origin, count := range rolesByOrigin {
+		props[fmt.Sprintf("Total %s Roles", strings.ToLower(origin.String()))] = count
+	}
+	return nil
+}
+
+func totalAccessScopes(ctx context.Context, props map[string]any, rs DataStore) error {
+	accessScopes, err := rs.GetAllAccessScopes(ctx)
+	if err != nil {
+		return err
+	}
+
+	accessScopesByOrigin := make(map[storage.Traits_Origin]int)
+
+	for _, as := range accessScopes {
+		accessScopesByOrigin[as.GetTraits().GetOrigin()]++
+	}
+
+	props["Total Access Scopes"] = len(accessScopes)
+	for origin, count := range accessScopesByOrigin {
+		props[fmt.Sprintf("Total %s Access Scopes", strings.ToLower(origin.String()))] = count
+	}
+	return nil
 }

--- a/central/role/datastore/telemetry.go
+++ b/central/role/datastore/telemetry.go
@@ -37,7 +37,12 @@ func totalPermissionSets(ctx context.Context, props map[string]any, rs DataStore
 		return err
 	}
 
-	permissionSetsByOrigin := make(map[storage.Traits_Origin]int)
+	permissionSetsByOrigin := map[storage.Traits_Origin]int{
+		storage.Traits_DEFAULT:              0,
+		storage.Traits_IMPERATIVE:           0,
+		storage.Traits_DECLARATIVE:          0,
+		storage.Traits_DECLARATIVE_ORPHANED: 0,
+	}
 
 	for _, ps := range permissionSets {
 		permissionSetsByOrigin[ps.GetTraits().GetOrigin()]++
@@ -56,7 +61,12 @@ func totalRoles(ctx context.Context, props map[string]any, rs DataStore) error {
 		return err
 	}
 
-	rolesByOrigin := make(map[storage.Traits_Origin]int)
+	rolesByOrigin := map[storage.Traits_Origin]int{
+		storage.Traits_DEFAULT:              0,
+		storage.Traits_IMPERATIVE:           0,
+		storage.Traits_DECLARATIVE:          0,
+		storage.Traits_DECLARATIVE_ORPHANED: 0,
+	}
 
 	for _, role := range roles {
 		rolesByOrigin[role.GetTraits().GetOrigin()]++
@@ -75,7 +85,12 @@ func totalAccessScopes(ctx context.Context, props map[string]any, rs DataStore) 
 		return err
 	}
 
-	accessScopesByOrigin := make(map[storage.Traits_Origin]int)
+	accessScopesByOrigin := map[storage.Traits_Origin]int{
+		storage.Traits_DEFAULT:              0,
+		storage.Traits_IMPERATIVE:           0,
+		storage.Traits_DECLARATIVE:          0,
+		storage.Traits_DECLARATIVE_ORPHANED: 0,
+	}
 
 	for _, as := range accessScopes {
 		accessScopesByOrigin[as.GetTraits().GetOrigin()]++

--- a/go.mod
+++ b/go.mod
@@ -107,6 +107,7 @@ require (
 	golang.org/x/oauth2 v0.7.0
 	golang.org/x/sync v0.2.0
 	golang.org/x/sys v0.8.0
+	golang.org/x/text v0.9.0
 	golang.org/x/time v0.3.0
 	golang.org/x/tools v0.9.1
 	golang.stackrox.io/grpc-http1 v0.2.6
@@ -362,7 +363,6 @@ require (
 	go.uber.org/multierr v1.10.0 // indirect
 	golang.org/x/mod v0.10.0 // indirect
 	golang.org/x/term v0.8.0 // indirect
-	golang.org/x/text v0.9.0 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect


### PR DESCRIPTION
## Description

Based on [the list of analytic ideas for declarative config](https://docs.google.com/document/d/1L4B-xlyYp9eeHOAJbZVon51wLIjzQf9iCvY95EbftBM/edit?usp=sharing), this PR implements the first set of those, namely:
- providing an overview of all created declarative resources per resource type via their origin.
- providing an overview of the number of mount points (this correlates to secrets / config maps).

This way, we can now see which resources are defined declaratively the most, as well as differentiate properly between user created, system defaults, declaratively created resources in the future.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Manual tests:
1. Setup central instance with telemetry configured.
2. View in Amplitude the central identity data:
![Screenshot 2023-06-01 at 07 55 28](https://github.com/stackrox/stackrox/assets/89904305/20557b61-d59f-4fcd-bb50-55c1541a1812)
4. Create a declarative configuration such as:
```yaml
apiVersion: v1
data:
  configs.yaml: |
    name: hello-world
    description: first declaratively created permission set
    resources:
      - resource: Integration
        access: READ_ACCESS
      - resource: Administration
        access: READ_ACCESS
      - resource: Access
        access: READ_ACCESS
    ---
    name: hello-world
    description: first declaratively created role
    permissionSet: hello-world # Referencing the previously created permission set.
    accessScope: Unrestricted # Referencing a system resource, the "Unrestricted" access scope.
    ---
kind: ConfigMap
metadata:
  name: declarative-configurations
```
5. Within the update identity call, observe the reported numbers of declarative resources:
![Screenshot 2023-06-01 at 08 03 54](https://github.com/stackrox/stackrox/assets/89904305/ba7806ba-4071-46cf-a0a8-8b51a607829e)

6. Delete the config map again. Wait until the resources are removed from Central.
7. Verify within Amplitude that the data is now the same as initially:
![Screenshot 2023-06-01 at 07 55 28](https://github.com/stackrox/stackrox/assets/89904305/287b80bb-3296-4f1c-bcb8-b8f0aab9967d)

