### PR TITLE
Add banner to top of Workload CVE pages

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesPage.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
-import { Route, Switch } from 'react-router-dom';
-import { PageSection } from '@patternfly/react-core';
+import { Link, Route, Switch } from 'react-router-dom';
+import { Alert, PageSection } from '@patternfly/react-core';
 
 import PageNotFound from 'Components/PageNotFound';
 import PageTitle from 'Components/PageTitle';
 
 import {
+    vulnManagementPath,
     vulnerabilitiesWorkloadCveDeploymentSinglePath,
     vulnerabilitiesWorkloadCveImageSinglePath,
     vulnerabilitiesWorkloadCveSinglePath,
@@ -20,25 +21,38 @@ import './WorkloadCvesPage.css';
 
 function WorkloadCvesPage() {
     return (
-        <Switch>
-            <Route path={vulnerabilitiesWorkloadCveSinglePath} component={ImageCvePage} />
-            <Route path={vulnerabilitiesWorkloadCveImageSinglePath} component={ImagePage} />
-            <Route
-                path={vulnerabilitiesWorkloadCveDeploymentSinglePath}
-                component={DeploymentPage}
+        <>
+            <Alert
+                variant="warning"
+                isInline
+                title={
+                    <span>
+                        This is a Technology Preview of this feature. For all production
+                        requirements we recommend using{' '}
+                        <Link to={vulnManagementPath}>Vulnerability Management (1.0)</Link>
+                    </span>
+                }
             />
-            <Route
-                exact
-                path={vulnerabilitiesWorkloadCvesPath}
-                component={WorkloadCvesOverviewPage}
-            />
-            <Route>
-                <PageSection variant="light">
-                    <PageTitle title="Workload CVEs - Not Found" />
-                    <PageNotFound />
-                </PageSection>
-            </Route>
-        </Switch>
+            <Switch>
+                <Route path={vulnerabilitiesWorkloadCveSinglePath} component={ImageCvePage} />
+                <Route path={vulnerabilitiesWorkloadCveImageSinglePath} component={ImagePage} />
+                <Route
+                    path={vulnerabilitiesWorkloadCveDeploymentSinglePath}
+                    component={DeploymentPage}
+                />
+                <Route
+                    exact
+                    path={vulnerabilitiesWorkloadCvesPath}
+                    component={WorkloadCvesOverviewPage}
+                />
+                <Route>
+                    <PageSection variant="light">
+                        <PageTitle title="Workload CVEs - Not Found" />
+                        <PageNotFound />
+                    </PageSection>
+                </Route>
+            </Switch>
+        </>
     );
 }
 


### PR DESCRIPTION
## Description

Adds a banner to the top of all Workload CVE pages.

_This PR is easier to review with "hide whitespace" on_

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Visit any and all Workload CVE pages and view the banner at the top of the page. Ensure the banner does not cause content on the bottom of the pages to be cut off.
![image](https://github.com/stackrox/stackrox/assets/1292638/e3a6db4d-0378-49ec-80af-cc1276ab8be2)
![image](https://github.com/stackrox/stackrox/assets/1292638/b50dfe33-4082-4add-8ef3-140972eb0c4e)

Click on the link inside the banner and ensure you are taken to the VM 1.0 dashboard:
![image](https://github.com/stackrox/stackrox/assets/1292638/4d0e5918-47e0-475c-893f-2db52aef5ee9)

