### PR TITLE
Remove default filters and local fixability filters

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
@@ -3,8 +3,6 @@ import {
     PageSection,
     Title,
     Divider,
-    Toolbar,
-    ToolbarItem,
     Flex,
     FlexItem,
     Card,
@@ -12,14 +10,12 @@ import {
 } from '@patternfly/react-core';
 import { useQuery } from '@apollo/client';
 
-import useLocalStorage from 'hooks/useLocalStorage';
 import useURLSearch from 'hooks/useURLSearch';
 import useURLStringUnion from 'hooks/useURLStringUnion';
 import PageTitle from 'Components/PageTitle';
 import useURLPagination from 'hooks/useURLPagination';
 import { VulnMgmtLocalStorage, entityTabValues } from '../types';
 import { parseQuerySearchFilter, getCveStatusScopedQueryString } from '../searchUtils';
-import DefaultFilterModal from '../components/DefaultFilterModal';
 import { entityTypeCountsQuery } from '../components/EntityTypeToggleGroup';
 import CVEsTableContainer from './CVEsTableContainer';
 import DeploymentsTableContainer from './DeploymentsTableContainer';
@@ -48,31 +44,12 @@ function WorkloadCvesOverviewPage() {
         }
     );
 
-    const [storedValue, setStoredValue] = useLocalStorage('vulnerabilityManagement', emptyStorage);
     const pagination = useURLPagination(20);
-
-    function setLocalStorage(values) {
-        pagination.setPage(1);
-        setStoredValue({
-            preferences: {
-                defaultFilters: values,
-            },
-        });
-    }
 
     return (
         <>
             <PageTitle title="Workload CVEs Overview" />
-            <PageSection variant="light" padding={{ default: 'noPadding' }}>
-                <Toolbar>
-                    <ToolbarItem alignment={{ default: 'alignRight' }}>
-                        <DefaultFilterModal
-                            defaultFilters={storedValue.preferences.defaultFilters}
-                            setLocalStorage={setLocalStorage}
-                        />
-                    </ToolbarItem>
-                </Toolbar>
-            </PageSection>
+            {/* Default filters are disabled until fixability filters are fixed */}
             <Divider component="div" />
             <PageSection variant="light" padding={{ default: 'noPadding' }}>
                 <Flex direction={{ default: 'column' }} className="pf-u-py-lg pf-u-pl-lg">
@@ -90,21 +67,21 @@ function WorkloadCvesOverviewPage() {
                         <CardBody>
                             {activeEntityTabKey === 'CVE' && (
                                 <CVEsTableContainer
-                                    defaultFilters={storedValue.preferences.defaultFilters}
+                                    defaultFilters={emptyStorage.preferences.defaultFilters}
                                     countsData={countsData}
                                     pagination={pagination}
                                 />
                             )}
                             {activeEntityTabKey === 'Image' && (
                                 <ImagesTableContainer
-                                    defaultFilters={storedValue.preferences.defaultFilters}
+                                    defaultFilters={emptyStorage.preferences.defaultFilters}
                                     countsData={countsData}
                                     pagination={pagination}
                                 />
                             )}
                             {activeEntityTabKey === 'Deployment' && (
                                 <DeploymentsTableContainer
-                                    defaultFilters={storedValue.preferences.defaultFilters}
+                                    defaultFilters={emptyStorage.preferences.defaultFilters}
                                     countsData={countsData}
                                     pagination={pagination}
                                 />

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
@@ -28,12 +28,12 @@ import ImageComponentVulnerabilitiesTable, {
 import EmptyTableResults from '../components/EmptyTableResults';
 import DatePhraseTd from '../components/DatePhraseTd';
 import CvssTd from '../components/CvssTd';
+import { getAnyVulnerabilityIsFixable } from './table.utils';
 
 export const imageVulnerabilitiesFragment = gql`
     ${imageComponentVulnerabilitiesFragment}
     fragment ImageVulnerabilityFields on ImageVulnerability {
         severity
-        isFixable
         cve
         summary
         cvss
@@ -47,7 +47,6 @@ export const imageVulnerabilitiesFragment = gql`
 
 export type ImageVulnerability = {
     severity: string;
-    isFixable: boolean;
     cve: string;
     summary: string;
     cvss: number;
@@ -97,7 +96,6 @@ function ImageVulnerabilitiesTable({
                         cve,
                         severity,
                         summary,
-                        isFixable,
                         cvss,
                         scoreVersion,
                         imageComponents,
@@ -105,6 +103,7 @@ function ImageVulnerabilitiesTable({
                     },
                     rowIndex
                 ) => {
+                    const isFixable = getAnyVulnerabilityIsFixable(imageComponents);
                     const isExpanded = expandedRowSet.has(cve);
 
                     return (

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/FilterChips.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/FilterChips.tsx
@@ -3,8 +3,7 @@ import { Globe } from 'react-feather';
 import { Flex, FlexItem, ChipGroup, Chip, Button } from '@patternfly/react-core';
 
 import { SearchFilter } from 'types/search';
-import { getHasSearchApplied } from 'utils/searchUtils';
-import { VulnerabilitySeverityLabel, FixableStatus, DefaultFilters } from '../types';
+import { VulnerabilitySeverityLabel, DefaultFilters } from '../types';
 
 import './FilterChips.css';
 
@@ -46,9 +45,10 @@ function FilterChips({
     const namespaces = (searchFilter.NAMESPACE as string[]) || [];
     const clusters = (searchFilter.CLUSTER as string[]) || [];
     const severities = (searchFilter.Severity as VulnerabilitySeverityLabel[]) || [];
-    const fixables = (searchFilter.Fixable as FixableStatus[]) || [];
 
-    const hasSearchApplied = getHasSearchApplied(searchFilter);
+    const hasSearchApplied = [deployments, cves, images, namespaces, clusters, severities].some(
+        (filter) => filter.length > 0
+    );
 
     return (
         <Flex spaceItems={{ default: 'spaceItemsXs' }}>
@@ -144,27 +144,7 @@ function FilterChips({
                     </ChipGroup>
                 </FlexItem>
             )}
-            {fixables.length > 0 && (
-                <FlexItem className="pf-u-pt-xs">
-                    <ChipGroup
-                        categoryName="Fixable"
-                        isClosable
-                        onClick={() => onDeleteGroup('Fixable')}
-                    >
-                        {fixables.map((fixableStatus) => (
-                            <Chip
-                                key={fixableStatus}
-                                onClick={() => onDelete('Fixable', fixableStatus)}
-                            >
-                                <FilterChip
-                                    isGlobal={defaultFilters.Fixable?.includes(fixableStatus)}
-                                    name={fixableStatus}
-                                />
-                            </Chip>
-                        ))}
-                    </ChipGroup>
-                </FlexItem>
-            )}
+            {/* Fixability filters are disabled until the backend implementation is updated */}
             {hasSearchApplied && (
                 <Button variant="link" onClick={onDeleteAll}>
                     Clear filters

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/WorkloadTableToolbar.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/WorkloadTableToolbar.tsx
@@ -9,7 +9,6 @@ import { DefaultFilters, VulnerabilitySeverityLabel, FixableStatus } from '../ty
 import { Resource } from './FilterResourceDropdown';
 import FilterAutocomplete, { FilterAutocompleteSelectProps } from './FilterAutocomplete';
 import CVESeverityDropdown from './CVESeverityDropdown';
-import CVEStatusDropdown from './CVEStatusDropdown';
 import FilterChips from './FilterChips';
 
 const emptyDefaultFilters = {
@@ -109,7 +108,7 @@ function WorkloadTableToolbar({
                 />
                 <ToolbarGroup>
                     <CVESeverityDropdown searchFilter={searchFilter} onSelect={onSelect} />
-                    <CVEStatusDropdown searchFilter={searchFilter} onSelect={onSelect} />
+                    {/* CVEStatusDropdown is disabled until fixability filters are fixed */}
                 </ToolbarGroup>
                 <ToolbarGroup className="pf-u-w-100">
                     <FilterChips

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/searchUtils.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/searchUtils.tsx
@@ -78,7 +78,8 @@ export function parseQuerySearchFilter(rawSearchFilter: SearchFilter): QuerySear
             }
         });
 
-        cleanSearchFilter.Fixable = cleanFixable;
+        // TODO We are explicitly excluding "Fixable" from the search filter until this functionality is re-enabled
+        // cleanSearchFilter.Fixable = cleanFixable;
     }
 
     if (rawSearchFilter.Severity) {


### PR DESCRIPTION
## Description

Removes the default filters and local fixability filters until rework can be done on how "fixable" is calculated via the API.

Additionally, CVEs on the ImageCVE page will calculate the value of the "CVE status" column based on whether or not each imageComponent has a non-empty `fixedByVersion` field, instead of by using the top level `isFixable` field returned from the GraphQL query.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Default filters are not accessible from the main page (note that default filters in local storage will be ignored as well):
![image](https://github.com/stackrox/stackrox/assets/1292638/c35ca02d-0447-4b49-ae0c-65d0cf893a92)

Local fixability filters are not available in any page:
![image](https://github.com/stackrox/stackrox/assets/1292638/def3fc21-20d9-4b2a-a24e-13422e7bc89b)
![image](https://github.com/stackrox/stackrox/assets/1292638/8bdfe099-c961-4748-91e9-18eab6a359c1)
![image](https://github.com/stackrox/stackrox/assets/1292638/5ec66fdd-9fce-4f75-86fb-2cba6faa6609)


Check that "Fixable" in the URL is ignored:
![image](https://github.com/stackrox/stackrox/assets/1292638/1438513c-37d9-443e-9ba3-2d5dc09c80f1)


Viewing a CVE where all components are "Not fixable" before:
![image](https://github.com/stackrox/stackrox/assets/1292638/e6f29614-af25-4ffe-af36-7f6448f0f3e7)

and after:
![image](https://github.com/stackrox/stackrox/assets/1292638/b0c2cd66-43bc-418d-9fa8-7d6390af0651)

