### PR TITLE
Add CentralServicesCapabilities to MetadataService

### DIFF
--- a/ui/apps/platform/src/services/MetadataService.ts
+++ b/ui/apps/platform/src/services/MetadataService.ts
@@ -14,3 +14,32 @@ export function fetchMetadata(): Promise<{ response: Metadata }> {
         response: response.data,
     }));
 }
+
+// Provides availability of certain functionality of Central Services in the current configuration.
+// The initial intended use is to disable certain functionality that does not make sense in the Cloud Service context.
+
+// "Unknown" means "not disabled".
+// The reason it's not called "Enabled" is that extended checks might be required to confirm true ability to use
+// e.g. container AWS IAM role or GCP workload identity, and we can't positively say "Enabled" while such checks
+// aren't implemented.
+// This means the user should be allowed to use the capability (both via UI and API) but an attempt may not be
+// successful if the corresponding configuration does not match the actual environment.
+
+// Capability is disabled, meaning the corresponding UI should be disabled and attempts to use related APIs
+// should lead to errors.
+
+export type CentralServicesCapabilityStatus = 'Unknown' | 'Disabled';
+
+export type CentralServicesCapabilities = {
+    // Ability to use container IAM role for scanning images from Amazon ECR using Scanner deployed as part of Central Services.
+    centralScanningUseContainerIamRoleForEcr: CentralServicesCapabilityStatus;
+
+    // Ability to configure and perform Central backups to Amazon S3 or Google Cloud Storage.
+    centralCloudBackupIntegrations: CentralServicesCapabilityStatus;
+};
+
+export function fetchCentralCapabilities(): Promise<CentralServicesCapabilities> {
+    return axios
+        .get<CentralServicesCapabilities>('/v1/central-capabilities')
+        .then((response) => response.data);
+}


### PR DESCRIPTION
## Description

Prerequisite for conditional rendering with same source of truth as for conditional behavior on backend.

Follow up #6253

One step forward, although request has status code 501 Not Implemented

* https://github.com/stackrox/stackrox/blob/master/proto/api/v1/metadata_service.proto#L70-L93
* https://github.com/stackrox/stackrox/blob/master/proto/api/v1/metadata_service.proto#L121-L125

API Reference is a hint from Misha to verify frontend camelCase for backend underscore case:
![API_Reference](https://github.com/stackrox/stackrox/assets/11862657/3071ad46-9d13-438a-919c-3011ae52da22)

## Checklist
- [ ] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed