### PR TITLE
ROX-17503: Filter according to hideScanResults in StandardsAcrossEntity horizontal bar graphs

### DIFF
--- a/ui/apps/platform/src/Containers/Compliance/widgets/StandardsAcrossEntity.js
+++ b/ui/apps/platform/src/Containers/Compliance/widgets/StandardsAcrossEntity.js
@@ -22,10 +22,13 @@ function formatAsPercent(x) {
     return `${x}%`;
 }
 
-function setStandardsMapping(data, type) {
+function setStandardsMapping(data, key, type) {
     const mapping = {};
-    data.results.forEach((result) => {
+    data[key].results.forEach((result) => {
         const standardId = result.aggregationKeys[0].id;
+        if (!data.complianceStandards.some(({ id }) => id === standardId)) {
+            return; // because it implies standardId has hideScanResults: true
+        }
         const { numPassing, numFailing } = result;
         if (numPassing === 0 && numFailing === 0) {
             return;
@@ -60,8 +63,8 @@ const StandardsAcrossEntity = ({ match, location, entityType, bodyClassName, cla
         const { complianceStandards } = data;
         const standardsMapping = merge(
             {},
-            setStandardsMapping(data.results, 'checks'),
-            setStandardsMapping(data.controls, 'controls')
+            setStandardsMapping(data, 'results', 'checks'),
+            setStandardsMapping(data, 'controls', 'controls')
         );
 
         const barData = Object.keys(standardsMapping).map((standardId) => {


### PR DESCRIPTION
## Description

### Problem

After change to `hideScanResults` properties of standards, Compliance dashboard:
* does filter **Passing standards by cluster** vertical bar chart
* does **not** filter **Passing standards across whatever** horizontal bar charts

### Analysis

Responses of getAggregatedResultsAcrossEntity_ENTITY and getAggregatedResultsByEntity_ENTITY are similar:
* `complianceStandards` array is filtered according to `hideScanResults` property.
* `controls.results` array is not filtered
* `results.results` array is not filtered

Comparison of helper functions in components:
* StandardsByEntity filters with `!standard` here: https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Compliance/widgets/StandardsByEntity.js#L36-L38
* StandardsAcrossEntity without condition here: https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Compliance/widgets/StandardsAcrossEntity.js#L30-L32

### Solution

Adapt early return from StandardsByEntity to StandardsAcrossEntity.

### Residue

1. Notice NIST SP 800-190 but no bar in horizontal bar chart at lower right. This is a pre-existing problem.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

### Manual testing

1. Visit /main/compliance, click **Manage standards**, click to clear **HIPAA** and **PCI** check boxes, and then click **Save**.

    * incorrect filtering without early return: see presence of standards in horizontal bar charts at the left that is inconsistent with vertical bar chart at upper right
        ![getAggregatedResultsByEntity_CLUSTER](https://github.com/stackrox/stackrox/assets/11862657/623d78d5-9613-4c9e-88b0-2037e59061e8)

    * correct filtering with early return: see absence of **HIPAA** and **PCI** in horizontal bar charts at the left that is consistent with vertical bar chart at upper right
        ![absence_of_HIPAA_and_PCI](https://github.com/stackrox/stackrox/assets/11862657/f9e98821-ae60-492d-b4c5-c54d4babe23c)

2. Click **Manage standards**, click to select **PCI** check box, and then click **Save**.

    * correct filtering with early return: see absence of **HIPAA** and presence of **PCI** in horizontal bar charts at the left that is consistent with vertical bar chart at upper right
![absence_of_HIPAA_presence_of_PCI](https://github.com/stackrox/stackrox/assets/11862657/48fae798-0d4a-4d81-adcb-0d300819bb5f)
