### PR TITLE
ROX-16786: Enhancements to feedback system

### DIFF
--- a/ui/apps/platform/src/Containers/MainPage/AcsFeedbackModal.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/AcsFeedbackModal.tsx
@@ -1,8 +1,9 @@
 import React, { ReactElement } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
-import { FeedbackModal } from '@patternfly/react-user-feedback';
+import { FeedbackModal, FeedbackLocale } from '@patternfly/react-user-feedback';
 
+import { getProductBranding } from 'constants/productBranding';
 import redFeedbackImage from 'images/feedback_illo.svg';
 import { selectors } from 'reducers';
 import { actions } from 'reducers/feedback';
@@ -10,61 +11,87 @@ import { actions } from 'reducers/feedback';
 const feedbackState = createStructuredSelector({
     feedback: selectors.feedbackSelector,
 });
-const i18nAcsEnglish = {
-    getSupport: 'Get support',
-    back: 'Back',
-    bugReported: 'Bug Reported',
-    cancel: 'Cancel',
-    close: 'Close',
-    describeBug:
-        'Describe the bug you encountered. For urgent issues, open a support case instead.',
-    describeBugUrgentCases:
-        'Describe the bug you encountered. For urgent issues, open a support case instead.',
-    describeReportBug:
-        'Describe the bug you encountered. Include where it is located and what action caused it. If this issue is urgent or blocking your workflow,',
-    directInfluence:
-        'Your feedback will directly influence the future of Red Hat’s products. Opt in below to hear about future research opportunities via email.',
-    email: 'Email',
-    enterFeedback: 'Enter your feedback',
-    feedback: 'Feedback',
-    feedbackSent: 'Feedback Sent',
-    helpUsImproveHCC: 'Help us improve Advanced Cluster Security.',
-    howIsConsoleExperience: 'What has your console experience been like so far?',
-    joinMailingList: 'Join mailing list',
-    informDirectionDescription:
-        'By participating in feedback sessions, usability tests, and interviews with our',
-    informDirection: 'Inform the direction of Red Hat',
-    learnAboutResearchOpportunities:
-        'Learn about opportunities to share your feedback with our User Research Team.',
-    openSupportCase: 'Support Case',
-    problemProcessingRequest:
-        'There was a problem processing the request. Try reloading the page. If the problem persists, contact',
-    support: 'Red Hat support',
-    reportABug: 'Report a bug',
-    responseSent: 'Response sent',
-    researchOpportunities: 'Yes, I would like to hear about research opportunities',
-    shareFeedback: 'Share feedback',
-    shareYourFeedback: 'Share your feedback with us!',
-    somethingWentWrong: 'Something went wrong',
-    submitFeedback: 'Submit feedback',
-    teamWillReviewBug: 'We appreciate your feedback and our team will review your report shortly',
-    tellAboutExperience: 'Tell us about your experience',
-    thankYouForFeedback: 'Thank you, we appreciate your feedback.',
-    thankYouForInterest:
-        'Thank you for your interest in user research. You have been added to our mailing list.',
-    userResearchTeam: 'User Research Team',
-    weNeverSharePersonalInformation:
-        'We never share your personal information, and you can opt out at any time.',
-};
+
+function getFeedbackTranslations(lang, branding): FeedbackLocale {
+    switch (lang) {
+        case 'en-us':
+        default: {
+            const dialogSubhead =
+                branding === 'RHACS_BRANDING'
+                    ? 'Help us improve Red Hat Advanced Cluster Security for Kubernetes.'
+                    : 'Help us improve StackRox.';
+            const experienceSubhead =
+                branding === 'RHACS_BRANDING'
+                    ? 'What has your RHACS experience been like so far?'
+                    : 'What has your StackRox experience been like so far?';
+
+            return {
+                getSupport: 'Get support',
+                back: 'Back',
+                bugReported: 'Bug Reported',
+                cancel: 'Cancel',
+                close: 'Close',
+                describeBug:
+                    'Describe the bug you encountered. For urgent issues, open a support case instead.',
+                describeBugUrgentCases:
+                    'Describe the bug you encountered. For urgent issues, open a support case instead.',
+                describeReportBug:
+                    'Describe the bug you encountered. Include where it is located and what action caused it. If this issue is urgent or blocking your workflow,',
+                directInfluence:
+                    'Your feedback will directly influence the future of Red Hat’s products. Opt in below to hear about future research opportunities via email.',
+                email: 'Email',
+                enterFeedback: 'Enter your feedback',
+                feedback: 'Feedback',
+                feedbackSent: 'Feedback Sent',
+                helpUsImproveHCC: dialogSubhead,
+                howIsConsoleExperience: experienceSubhead,
+                joinMailingList: 'Join mailing list',
+                informDirectionDescription:
+                    'By participating in feedback sessions, usability tests, and interviews with our',
+                informDirection: 'Inform the direction of Red Hat',
+                learnAboutResearchOpportunities:
+                    'Learn about opportunities to share your feedback with our User Research Team.',
+                openSupportCase: 'Support Case',
+                problemProcessingRequest:
+                    'There was a problem processing the request. Try reloading the page. If the problem persists, contact',
+                support: 'Red Hat support',
+                reportABug: 'Report a bug',
+                responseSent: 'Response sent',
+                researchOpportunities: 'Yes, I would like to hear about research opportunities',
+                shareFeedback: 'Share feedback',
+                shareYourFeedback: 'Share your feedback with us!',
+                somethingWentWrong: 'Something went wrong',
+                submitFeedback: 'Submit feedback',
+                teamWillReviewBug:
+                    'We appreciate your feedback and our team will review your report shortly',
+                tellAboutExperience: 'Tell us about your experience',
+                thankYouForFeedback: 'Thank you, we appreciate your feedback.',
+                thankYouForInterest:
+                    'Thank you for your interest in user research. You have been added to our mailing list.',
+                userResearchTeam: 'User Research Team',
+                weNeverSharePersonalInformation:
+                    'We never share your personal information, and you can opt out at any time.',
+            };
+        }
+    }
+}
 
 function AcsFeedbackModal(): ReactElement | null {
     const { feedback: showFeedbackModal } = useSelector(feedbackState);
     const dispatch = useDispatch();
 
+    const { type } = getProductBranding();
+
+    const i18nAcsEnglish = getFeedbackTranslations('en-us', type);
     return (
         <FeedbackModal
             email="test@redhat.com"
             onShareFeedback="https://console.redhat.com/self-managed-feedback-form?source=acs"
+            onOpenSupportCase={
+                type === 'RHACS_BRANDING'
+                    ? 'https://access.redhat.com/support/cases/#/case/new/open-case?caseCreate=true'
+                    : ''
+            }
             isOpen={showFeedbackModal}
             feedbackImg={redFeedbackImage}
             feedbackLocale={i18nAcsEnglish}

--- a/ui/apps/platform/src/Containers/MainPage/MainPage.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/MainPage.tsx
@@ -89,9 +89,11 @@ function MainPage(): ReactElement {
             <div id="PageParent">
                 <Button
                     style={{
+                        bottom: 'calc(var(--pf-global--spacer--lg) * 6)',
                         position: 'absolute',
-                        bottom: 0,
-                        right: 'var(--pf-global--spacer--xl)',
+                        right: '0',
+                        transform: 'rotate(270deg)',
+                        transformOrigin: 'bottom right',
                         zIndex: 20000,
                     }}
                     icon={<OutlinedCommentsIcon />}


### PR DESCRIPTION
## Description

Text changes:
1. At the top refer to the official name “Help us improve Red Hat Advanced Cluster Security for Kubernetes”. 
-- Can we make the above  “Help us improve StackRox” instead for StackRox ? (but still Red Hat for Cloud ?)
change text for Share Feedback:

2. change text for Share Feedback: "What has your RHACS experience been like so far?"
-- for upstream (opensource), instead use "What has your StackRox experience been like so far?"

Functional change:
* Only show the link to open a support case if running downstream, RHACS branded version

UX change:
* Rotate floating button from bottom edge to right edge (still red, no purple here)


## Checklist
- [ ] Investigated and inspected CI test results


## Testing Performed

Manual testing
Stackrox version (no REACT_APP_ROX_PRODUCT_BRANDING flag set):
<img width="1516" alt="Screen Shot 2023-06-01 at 4 33 32 PM" src="https://github.com/stackrox/stackrox/assets/715729/41e89c9c-8a05-472f-89ef-0f090d10514e">

RHACS version (`export REACT_APP_ROX_PRODUCT_BRANDING='RHACS_BRANDING'; yarn start`):
<img width="1516" alt="Screen Shot 2023-06-01 at 4 57 07 PM" src="https://github.com/stackrox/stackrox/assets/715729/743565dc-b9e1-4605-a67f-2c39b2b0fc96">
