### PR TITLE
[ROX-17521] Round up time fields to microseconds

### DIFF
--- a/central/views/imagecve/view_test.go
+++ b/central/views/imagecve/view_test.go
@@ -172,6 +172,7 @@ func (s *ImageCVEViewTestSuite) TestGetImageCVECore() {
 						record.GetImagesBySeverity().GetCriticalSeverityCount().GetTotal(),
 					record.GetAffectedImageCount(),
 				)
+
 			}
 		})
 	}
@@ -748,7 +749,6 @@ func compileExpected(images []*storage.Image, filter *filterImpl, options views.
 				}
 
 				vulnTime, _ := types.TimestampFromProto(vuln.GetFirstSystemOccurrence())
-				vulnTime = vulnTime.Round(time.Microsecond)
 				val := cveMap[vuln.GetCve()]
 				if val == nil {
 					val = &imageCVECoreResponse{

--- a/central/views/imagecve/view_test.go
+++ b/central/views/imagecve/view_test.go
@@ -172,7 +172,6 @@ func (s *ImageCVEViewTestSuite) TestGetImageCVECore() {
 						record.GetImagesBySeverity().GetCriticalSeverityCount().GetTotal(),
 					record.GetAffectedImageCount(),
 				)
-
 			}
 		})
 	}
@@ -749,6 +748,7 @@ func compileExpected(images []*storage.Image, filter *filterImpl, options views.
 				}
 
 				vulnTime, _ := types.TimestampFromProto(vuln.GetFirstSystemOccurrence())
+				vulnTime = vulnTime.Round(time.Microsecond)
 				val := cveMap[vuln.GetCve()]
 				if val == nil {
 					val = &imageCVECoreResponse{

--- a/migrator/migrations/n_30_to_n_31_postgres_network_flows/migration_test.go
+++ b/migrator/migrations/n_30_to_n_31_postgres_network_flows/migration_test.go
@@ -82,7 +82,7 @@ func (s *postgresMigrationSuite) verify(flowStore store.FlowStore, flows []*stor
 	for i, flow := range flows {
 		// Postgres Datetime columns only have microsecond granularity for timestamps.
 		// Adapt the input data to take this into account.
-		timestamp.RoundTimeStamp(flow.GetLastSeenTimestamp(), time.Microsecond)
+		timestamp.RoundTimestamp(flow.GetLastSeenTimestamp(), time.Microsecond)
 		s.Equal(flow, fetched[i])
 	}
 }

--- a/migrator/migrations/n_30_to_n_31_postgres_network_flows/migration_test.go
+++ b/migrator/migrations/n_30_to_n_31_postgres_network_flows/migration_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/gogo/protobuf/types"
 	"github.com/stackrox/rox/generated/storage"
@@ -68,16 +69,6 @@ func (s *postgresMigrationSuite) populateStore(clusterStore store.ClusterStore, 
 	return flowStore, flows
 }
 
-func roundTimestampToMicroseconds(timestamp *types.Timestamp) {
-	if timestamp == nil {
-		return
-	}
-	timestampNanos := timestamp.GetNanos()
-	timestampNanos /= 1000
-	timestampNanos *= 1000
-	timestamp.Nanos = timestampNanos
-}
-
 func (s *postgresMigrationSuite) verify(flowStore store.FlowStore, flows []*storage.NetworkFlow) {
 	fetched, _, err := flowStore.GetAllFlows(s.ctx, &types.Timestamp{})
 	s.NoError(err)
@@ -91,7 +82,7 @@ func (s *postgresMigrationSuite) verify(flowStore store.FlowStore, flows []*stor
 	for i, flow := range flows {
 		// Postgres Datetime columns only have microsecond granularity for timestamps.
 		// Adapt the input data to take this into account.
-		roundTimestampToMicroseconds(flow.GetLastSeenTimestamp())
+		timestamp.RoundTimeStamp(flow.GetLastSeenTimestamp(), time.Microsecond)
 		s.Equal(flow, fetched[i])
 	}
 }

--- a/migrator/version/convert_versions.go
+++ b/migrator/version/convert_versions.go
@@ -1,10 +1,13 @@
 package version
 
 import (
+	"time"
+
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres/pgutils"
 	"github.com/stackrox/rox/pkg/postgres/schema"
 	"github.com/stackrox/rox/pkg/protoconv"
+	"github.com/stackrox/rox/pkg/timestamp"
 )
 
 // ConvertVersionFromProto converts a `*storage.Version` to Gorm model
@@ -38,7 +41,9 @@ func ConvertVersionToProto(m *schema.Versions) (*storage.Version, error) {
 	}
 
 	if m.LastPersisted != nil {
-		msg.LastPersisted = protoconv.MustConvertTimeToTimestamp(*m.LastPersisted)
+		ts := protoconv.MustConvertTimeToTimestamp(*m.LastPersisted)
+		timestamp.RoundTimestamp(ts, time.Microsecond)
+		msg.LastPersisted = ts
 	}
 
 	return &msg, nil

--- a/migrator/version/convert_versions_test.go
+++ b/migrator/version/convert_versions_test.go
@@ -2,20 +2,24 @@ package version
 
 import (
 	"testing"
+	"time"
 
-	timestamp "github.com/gogo/protobuf/types"
+	"github.com/gogo/protobuf/types"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/testutils"
+	"github.com/stackrox/rox/pkg/timestamp"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestVersionSerialization(t *testing.T) {
 	obj := &storage.Version{}
 	assert.NoError(t, testutils.FullInit(obj, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
-	obj.LastPersisted = timestamp.TimestampNow()
+	obj.LastPersisted = types.TimestampNow()
 	m, err := ConvertVersionFromProto(obj)
 	assert.NoError(t, err)
 	conv, err := ConvertVersionToProto(m)
 	assert.NoError(t, err)
+	// ConvertVersionFromProto and ConvertVersionToProto rounds up ts to microseconds, so make sure obj field is also rounded up.
+	timestamp.RoundTimestamp(obj.LastPersisted, time.Microsecond)
 	assert.Equal(t, obj, conv)
 }

--- a/pkg/postgres/pgutils/utils.go
+++ b/pkg/postgres/pgutils/utils.go
@@ -60,6 +60,7 @@ func NilOrTime(t *types.Timestamp) *time.Time {
 	if err != nil {
 		return nil
 	}
+	ts = ts.Round(time.Microsecond)
 	return &ts
 }
 

--- a/pkg/timestamp/utils.go
+++ b/pkg/timestamp/utils.go
@@ -8,7 +8,7 @@ import (
 )
 
 // RoundTimestamp rounds up ts to the nearest multiple of d. In case of error, the function returns without rounding up.
-func RoundTimeStamp(ts *types.Timestamp, d time.Duration) {
+func RoundTimestamp(ts *types.Timestamp, d time.Duration) {
 	t, err := types.TimestampFromProto(ts)
 	if err != nil {
 		return

--- a/pkg/timestamp/utils.go
+++ b/pkg/timestamp/utils.go
@@ -1,0 +1,17 @@
+package timestamp
+
+import (
+	"time"
+
+	"github.com/gogo/protobuf/types"
+	"github.com/stackrox/rox/pkg/protoconv"
+)
+
+// RoundTimestamp rounds up ts to the nearest multiple of d. In case of error, the function returns without rounding up.
+func RoundTimeStamp(ts *types.Timestamp, d time.Duration) {
+	t, err := types.TimestampFromProto(ts)
+	if err != nil {
+		return
+	}
+	*ts = *protoconv.ConvertTimeToTimestamp(t.Round(d))
+}


### PR DESCRIPTION
## Description

Postgres precision for time fields is microseconds and thus drops nanos seconds. Whereas the default precision for `types.Timestamp` or `time.Time` typed fields in our codebase is nanos. Thus, this can lead to failures in unit tests that perform equality on timestamps. Since nanosecond precision is anyway not important to us, round up to microsecond.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed
Unit