### PR TITLE
Workload CVEs: Default filter and other fixes

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
@@ -24,8 +24,9 @@ import ImagesTableContainer from './ImagesTableContainer';
 const emptyStorage: VulnMgmtLocalStorage = {
     preferences: {
         defaultFilters: {
-            Severity: ['Critical', 'Important'],
-            Fixable: ['Fixable'],
+            // TODO: re-add default filters to include critical, important, and fixable
+            Severity: [],
+            Fixable: [],
         },
     },
 };

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
@@ -24,8 +24,8 @@ import ImagesTableContainer from './ImagesTableContainer';
 const emptyStorage: VulnMgmtLocalStorage = {
     preferences: {
         defaultFilters: {
-            Severity: [],
-            Fixable: [],
+            Severity: ['Critical', 'Important'],
+            Fixable: ['Fixable'],
         },
     },
 };

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/CVEsTable.tsx
@@ -28,6 +28,7 @@ import {
     aggregateByCreatedTime,
     aggregateByImageSha,
 } from '../sortUtils';
+import EmptyTableResults from '../components/EmptyTableResults';
 
 export const cveListQuery = gql`
     query getImageCVEList($query: String, $pagination: Pagination) {
@@ -134,6 +135,7 @@ function CVEsTable({
                     </TooltipTh>
                 </Tr>
             </Thead>
+            {cves.length === 0 && <EmptyTableResults colSpan={6} />}
             {cves.map(
                 (
                     {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImagesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImagesTable.tsx
@@ -11,7 +11,7 @@ import { DynamicColumnIcon } from '../components/DynamicIcon';
 import EmptyTableResults from '../components/EmptyTableResults';
 import DatePhraseTd from '../components/DatePhraseTd';
 import TooltipTh from '../components/TooltipTh';
-import { VulnerabilitySeverityLabel } from '../types';
+import { VulnerabilitySeverityLabel, watchStatusLabel, WatchStatus } from '../types';
 
 export const imageListQuery = gql`
     query getImageList($query: String, $pagination: Pagination) {
@@ -64,7 +64,7 @@ type Image = {
     };
     operatingSystem: string;
     deploymentCount: number;
-    watchStatus: 'WATCHED' | 'NOT_WATCHED';
+    watchStatus: WatchStatus;
     metadata: {
         v1: {
             created: string | null;
@@ -152,7 +152,9 @@ function ImagesTable({ images, getSortParams, isFiltered, filteredSeverities }: 
                                         <Flex>
                                             <div>0 deployments</div>
                                             {/* TODO: double check on what this links to */}
-                                            <span>({`${watchStatus}`} image)</span>
+                                            <span>
+                                                ({`${watchStatusLabel[watchStatus]}`} image)
+                                            </span>
                                         </Flex>
                                     )}
                                 </Td>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/DefaultFilterModal.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/DefaultFilterModal.tsx
@@ -56,7 +56,7 @@ function DefaultFilterModal({ defaultFilters, setLocalStorage }: DefaultFilterMo
 
     return (
         <>
-            <Button variant="plain" onClick={handleModalToggle}>
+            <Button variant="plain" className="pf-u-color-300" onClick={handleModalToggle}>
                 <Flex alignItems={{ default: 'alignItemsCenter' }}>
                     <Globe className="pf-u-mr-sm" />
                     Default vulnerability filters

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/WorkloadTableToolbar.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/WorkloadTableToolbar.tsx
@@ -1,11 +1,10 @@
 import React, { useEffect } from 'react';
 import noop from 'lodash/noop';
-import uniq from 'lodash/uniq';
 import { Toolbar, ToolbarGroup, ToolbarContent, ToolbarChip } from '@patternfly/react-core';
 
 import useURLSearch from 'hooks/useURLSearch';
 import { SearchFilter } from 'types/search';
-import { DefaultFilters, VulnerabilitySeverityLabel, FixableStatus } from '../types';
+import { DefaultFilters } from '../types';
 import { Resource } from './FilterResourceDropdown';
 import FilterAutocomplete, { FilterAutocompleteSelectProps } from './FilterAutocomplete';
 import CVESeverityDropdown from './CVESeverityDropdown';
@@ -31,9 +30,6 @@ function WorkloadTableToolbar({
     onFilterChange = noop,
 }: WorkloadTableToolbarProps) {
     const { searchFilter, setSearchFilter } = useURLSearch();
-    const searchSeverity = (searchFilter.Severity as VulnerabilitySeverityLabel[]) || [];
-    const searchFixable = (searchFilter.Fixable as FixableStatus[]) || [];
-    const { Severity: defaultSeverity, Fixable: defaultFixable } = defaultFilters;
 
     function onChangeSearchFilter(newFilter: SearchFilter) {
         setSearchFilter(newFilter);
@@ -82,17 +78,7 @@ function WorkloadTableToolbar({
     // it is intended to respond to a change via user action, and this useEffect is intended to sync the
     // state when the page loads or local storage changes.
     useEffect(() => {
-        const severityFilter = uniq([...defaultSeverity, ...searchSeverity]);
-        const fixableFilter = uniq([...defaultFixable, ...searchFixable]);
-        setSearchFilter(
-            {
-                ...defaultFilters,
-                ...searchFilter,
-                Severity: severityFilter,
-                Fixable: fixableFilter,
-            },
-            'replace'
-        );
+        setSearchFilter(defaultFilters, 'replace');
         // unsure how to reset filters with URL filters only on defaultFilter change
     }, [defaultFilters, setSearchFilter]);
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/sortUtils.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/sortUtils.tsx
@@ -31,7 +31,8 @@ export const aggregateByCreatedTime: SortAggregate = {
 };
 
 export const CVEsDefaultSort = {
-    field: 'CVE',
+    field: 'CVSS',
+    aggregateBy: aggregateByCVSS,
     direction: 'asc',
 } as const;
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/sortUtils.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/sortUtils.tsx
@@ -33,7 +33,7 @@ export const aggregateByCreatedTime: SortAggregate = {
 export const CVEsDefaultSort = {
     field: 'CVSS',
     aggregateBy: aggregateByCVSS,
-    direction: 'asc',
+    direction: 'desc',
 } as const;
 
 export const defaultDeploymentSortFields = ['Deployment', 'Cluster', 'Namespace', 'Created'];

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/types.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/types.ts
@@ -49,3 +49,9 @@ export type EntityTab = (typeof entityTabValues)[number];
 export function isValidEntityTab(value: unknown): value is EntityTab {
     return entityTabValues.some((tab) => tab === value);
 }
+
+export type WatchStatus = 'WATCHED' | 'NOT_WATCHED';
+export const watchStatusLabel = {
+    WATCHED: 'watched',
+    NOT_WATCHED: 'not watched',
+};


### PR DESCRIPTION
Fixes mostly related to default filters -- it shouldn't make a difference right now since they have been removed for the release, but the fixes that are in the DefaultFilterModal will persist within the component.

Also fixes table empty state of the CVEs overview page and default sort to be CVSS
<img width="1502" alt="image" src="https://github.com/stackrox/stackrox/assets/10412893/b6e57734-9d85-442b-aa15-e18bbb44298c">