### PR TITLE
ROX-16932: Make DefaultPoliciesTest multi-arch compliant

### DIFF
--- a/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
@@ -53,7 +53,7 @@ class DefaultPoliciesTest extends BaseSpecification {
     // Deployment names
     static final private String NGINX_LATEST = "qadefpolnginxlatest"
     static final private String STRUTS = "qadefpolstruts"
-    static final private String SSL_TERMINATOR = "qadefpolsslterm"
+    //static final private String SSL_TERMINATOR = "qadefpolsslterm"
     static final private String TRIGGER_MOST = "qadefpoltriggermost"
     static final private String K8S_DASHBOARD = "kubernetes-dashboard"
     static final private String GCR_NGINX = "qadefpolnginx"
@@ -61,9 +61,11 @@ class DefaultPoliciesTest extends BaseSpecification {
     static final private String STRUTS_IMAGE = ((Env.REMOTE_CLUSTER_ARCH == "x86_64") ?
         "quay.io/rhacs-eng/qa:struts-app":"quay.io/rhacs-eng/qa-multi-arch:struts-app")
     //static final private String CVE_COUNT = ((Env.REMOTE_CLUSTER_ARCH == "x86_64") ? 537:139)
-    static private String COMPONENT_COUNT = ""
     static final private String COMPONENTS = ((Env.REMOTE_CLUSTER_ARCH == "x86_64") ?
         " apt, bash, curl, wget":" apt, bash, curl")
+
+    @Shared
+    private String componentCount = ""
 
     static final private List<String> WHITELISTED_KUBE_SYSTEM_POLICIES = [
             "Fixable CVSS >= 6 and Privileged",
@@ -94,7 +96,8 @@ class DefaultPoliciesTest extends BaseSpecification {
     static final private List<Deployment> DEPLOYMENTS = [
         new Deployment()
             .setName (NGINX_LATEST)
-            .setImage ("quay.io/rhacs-eng/qa-multi-arch-nginx:latest")// this is docker.io/nginx:1.23.3 but tagged as latest
+            // this is docker.io/nginx:1.23.3 but tagged as latest
+            .setImage ("quay.io/rhacs-eng/qa-multi-arch-nginx:latest")
             .addPort (22)
             .addLabel ("app", "test")
             .setEnv([SECRET: 'true']),
@@ -171,15 +174,16 @@ class DefaultPoliciesTest extends BaseSpecification {
                 STRUTS_DEPLOYMENT.getImage(), 'default-policies-test-struts-app.json'
         )
 
-        switch(Env.REMOTE_CLUSTER_ARCH){
+        switch (Env.REMOTE_CLUSTER_ARCH) {
             case "s390x":
-                COMPONENT_COUNT=92;
-                break;
+                componentCount=92
+                break
             case "ppc64le":
-                COMPONENT_COUNT=91;
-                break;
+                componentCount=91
+                break
             default:
-                COMPONENT_COUNT=169;
+                componentCount=169
+                break
         }
     }
 
@@ -464,7 +468,7 @@ class DefaultPoliciesTest extends BaseSpecification {
 
         "Number of Components in Image"   | 1.5f     | null |
                 "Image \"" + STRUTS_IMAGE + "\\\"" +
-                " contains " + COMPONENT_COUNT + " components" | []
+                " contains " + componentCount + " components" | []
 
         "Image Freshness"                 | 1.5f     | null | null | []
         // TODO(ROX-9637)

--- a/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
@@ -113,7 +113,7 @@ class DefaultPoliciesTest extends BaseSpecification {
             .addLabel("app", "test"),
         new Deployment()
             .setName(GCR_NGINX)
-            .setImage("quay.io/rhacs-eng/qa-multi-arch:nginx-1.12")
+            .setImage("us.gcr.io/stackrox-ci/qa-multi-arch:nginx-1.12")
             .addLabel ( "app", "test" )
             .setCommand(["sleep", "600"]),
     ]

--- a/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
@@ -60,7 +60,6 @@ class DefaultPoliciesTest extends BaseSpecification {
     static final private String WGET_CURL = ((Env.REMOTE_CLUSTER_ARCH == "x86_64") ? STRUTS:TRIGGER_MOST)
     static final private String STRUTS_IMAGE = ((Env.REMOTE_CLUSTER_ARCH == "x86_64") ?
         "quay.io/rhacs-eng/qa:struts-app":"quay.io/rhacs-eng/qa-multi-arch:struts-app")
-    //static final private String CVE_COUNT = ((Env.REMOTE_CLUSTER_ARCH == "x86_64") ? 537:139)
     static final private String COMPONENTS = ((Env.REMOTE_CLUSTER_ARCH == "x86_64") ?
         " apt, bash, curl, wget":" apt, bash, curl")
 

--- a/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
@@ -94,7 +94,7 @@ class DefaultPoliciesTest extends BaseSpecification {
     static final private List<Deployment> DEPLOYMENTS = [
         new Deployment()
             .setName (NGINX_LATEST)
-            .setImage ("quay.io/rhacs-eng/qa-multi-arch-nginx:latest")
+            .setImage ("quay.io/rhacs-eng/qa-multi-arch-nginx:latest")// this is docker.io/nginx:1.23.3 but tagged as latest
             .addPort (22)
             .addLabel ("app", "test")
             .setEnv([SECRET: 'true']),

--- a/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
@@ -99,11 +99,11 @@ class DefaultPoliciesTest extends BaseSpecification {
             .addLabel ("app", "test")
             .setEnv([SECRET: 'true']),
         STRUTS_DEPLOYMENT,
-        new Deployment()
-            .setName(SSL_TERMINATOR)
-            .setImage("quay.io/rhacs-eng/qa:ssl-terminator")
-            .addLabel("app", "test")
-            .setCommand(["sleep", "600"]),
+        // new Deployment()
+        //     .setName(SSL_TERMINATOR)
+        //     .setImage("quay.io/rhacs-eng/qa:ssl-terminator")
+        //     .addLabel("app", "test")
+        //     .setCommand(["sleep", "600"]),
         new Deployment()
             .setName(TRIGGER_MOST)
             .setImage("quay.io/rhacs-eng/qa-multi-arch:trigger-policy-violations-most")

--- a/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
@@ -54,9 +54,10 @@ class DefaultPoliciesTest extends BaseSpecification {
     static final private String NGINX_LATEST = "qadefpolnginxlatest"
     static final private String STRUTS = "qadefpolstruts"
     static final private String SSL_TERMINATOR = "qadefpolsslterm"
-    static final private String NGINX_1_10 = "qadefpolnginx110"
+    static final private String TRIGGER_MOST = "qadefpoltriggermost"
     static final private String K8S_DASHBOARD = "kubernetes-dashboard"
     static final private String GCR_NGINX = "qadefpolnginx"
+    static final private String WGET_CURL_IMAGE = ((Env.REMOTE_CLUSTER_ARCH == "x86_64") STRUTS:TRIGGER_MOST)
 
     static final private List<String> WHITELISTED_KUBE_SYSTEM_POLICIES = [
             "Fixable CVSS >= 6 and Privileged",
@@ -98,7 +99,7 @@ class DefaultPoliciesTest extends BaseSpecification {
             .addLabel("app", "test")
             .setCommand(["sleep", "600"]),
         new Deployment()
-            .setName(NGINX_1_10)
+            .setName(TRIGGER_MOST)
             .setImage("quay.io/rhacs-eng/qa-multi-arch:trigger-policy-violations-most")
             .addLabel("app", "test"),
         new Deployment()
@@ -236,7 +237,7 @@ class DefaultPoliciesTest extends BaseSpecification {
 
         "Apache Struts: CVE-2017-5638"                  | STRUTS         | "C938"
 
-        "Wget in Image"                                 | NGINX_1_10     | "C939"
+        "Wget in Image"                                 | WGET_CURL_IMAGE  | "C939"
 
         "90-Day Image Age"                              | STRUTS         | "C810"
 
@@ -246,7 +247,7 @@ class DefaultPoliciesTest extends BaseSpecification {
 
         "Fixable CVSS >= 7"                             | GCR_NGINX      | "C933"
 
-        "Curl in Image"                                 | NGINX_1_10     | "C948"
+        "Curl in Image"                                 | WGET_CURL_IMAGE  | "C948"
     }
 
     def hasApacheStrutsVuln(image) {
@@ -432,21 +433,21 @@ class DefaultPoliciesTest extends BaseSpecification {
 
         "Image Vulnerabilities"           | 4.0f     | null |
                 // This makes sure it has at least 100 CVEs.
-                "Image \"quay.io/rhacs-eng/qa:struts-app\"" +
-                     " contains \\d{2,3}\\d+ CVEs with severities ranging between " +
+                "Image \"quay.io/rhacs-eng/qa-multi-arch:struts-app\"" +
+                     " contains 139 CVEs with severities ranging between " +
                      "Low and Critical" | []
 
         "Service Configuration"           | 2.0f     |
                 "No capabilities were dropped" | null | []
 
         "Components Useful for Attackers" | 1.5f     |
-                "Image \"quay.io/rhacs-eng/qa:struts-app\" " +
+                "Image \"quay.io/rhacs-eng/qa-multi-arch:struts-app\" " +
                 "contains components useful for attackers:" +
-                    " apt, bash, curl, wget" | null | []
+                    " apt, bash, curl" | null | []
 
         "Number of Components in Image"   | 1.5f     | null |
-                "Image \"quay.io/rhacs-eng/qa:struts-app\"" +
-                " contains 169 components" | []
+                "Image \"quay.io/rhacs-eng/qa-multi-arch:struts-app\"" +
+                " contains 91 components" | []
 
         "Image Freshness"                 | 1.5f     | null | null | []
         // TODO(ROX-9637)

--- a/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
@@ -80,14 +80,14 @@ class DefaultPoliciesTest extends BaseSpecification {
 
     static final private Deployment STRUTS_DEPLOYMENT = new Deployment()
             .setName(STRUTS)
-            .setImage("quay.io/rhacs-eng/qa:struts-app")
+            .setImage("quay.io/rhacs-eng/qa-multi-arch:struts-app")
             .addLabel("app", "test")
             .addPort(80)
 
     static final private List<Deployment> DEPLOYMENTS = [
         new Deployment()
             .setName (NGINX_LATEST)
-            .setImage ("quay.io/rhacs-eng/qa:latest") // this is docker.io/nginx:1.22-alpine but tagged as latest
+            .setImage ("quay.io/rhacs-eng/qa-multi-arch-nginx:latest")
             .addPort (22)
             .addLabel ("app", "test")
             .setEnv([SECRET: 'true']),
@@ -99,11 +99,11 @@ class DefaultPoliciesTest extends BaseSpecification {
             .setCommand(["sleep", "600"]),
         new Deployment()
             .setName(NGINX_1_10)
-            .setImage("quay.io/rhacs-eng/qa:docker-io-nginx-1-10")
+            .setImage("quay.io/rhacs-eng/qa-multi-arch:trigger-policy-violations-most")
             .addLabel("app", "test"),
         new Deployment()
             .setName(GCR_NGINX)
-            .setImage("us.gcr.io/stackrox-ci/nginx:1.11.1")
+            .setImage("quay.io/rhacs-eng/qa-multi-arch:nginx-1.12")
             .addLabel ( "app", "test" )
             .setCommand(["sleep", "600"]),
     ]
@@ -236,7 +236,7 @@ class DefaultPoliciesTest extends BaseSpecification {
 
         "Apache Struts: CVE-2017-5638"                  | STRUTS         | "C938"
 
-        "Wget in Image"                                 | STRUTS         | "C939"
+        "Wget in Image"                                 | NGINX_1_10     | "C939"
 
         "90-Day Image Age"                              | STRUTS         | "C810"
 
@@ -246,7 +246,7 @@ class DefaultPoliciesTest extends BaseSpecification {
 
         "Fixable CVSS >= 7"                             | GCR_NGINX      | "C933"
 
-        "Curl in Image"                                 | STRUTS         | "C948"
+        "Curl in Image"                                 | NGINX_1_10     | "C948"
     }
 
     def hasApacheStrutsVuln(image) {

--- a/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
@@ -61,7 +61,7 @@ class DefaultPoliciesTest extends BaseSpecification {
     static final private String STRUTS_IMAGE = ((Env.REMOTE_CLUSTER_ARCH == "x86_64") ?
         "quay.io/rhacs-eng/qa:struts-app":"quay.io/rhacs-eng/qa-multi-arch:struts-app")
     //static final private String CVE_COUNT = ((Env.REMOTE_CLUSTER_ARCH == "x86_64") ? 537:139)
-    static final private String COMPONENT_COUNT = ((Env.REMOTE_CLUSTER_ARCH == "x86_64") ? 169:91)
+    static private String COMPONENT_COUNT = ""
     static final private String COMPONENTS = ((Env.REMOTE_CLUSTER_ARCH == "x86_64") ?
         " apt, bash, curl, wget":" apt, bash, curl")
 
@@ -170,6 +170,17 @@ class DefaultPoliciesTest extends BaseSpecification {
         Helpers.collectImageScanForDebug(
                 STRUTS_DEPLOYMENT.getImage(), 'default-policies-test-struts-app.json'
         )
+
+        switch(Env.REMOTE_CLUSTER_ARCH){
+            case "s390x":
+                COMPONENT_COUNT=92;
+                break;
+            case "ppc64le":
+                COMPONENT_COUNT=91;
+                break;
+            default:
+                COMPONENT_COUNT=169;
+        }
     }
 
     def cleanupSpec() {

--- a/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
@@ -57,7 +57,13 @@ class DefaultPoliciesTest extends BaseSpecification {
     static final private String TRIGGER_MOST = "qadefpoltriggermost"
     static final private String K8S_DASHBOARD = "kubernetes-dashboard"
     static final private String GCR_NGINX = "qadefpolnginx"
-    static final private String WGET_CURL_IMAGE = ((Env.REMOTE_CLUSTER_ARCH == "x86_64") STRUTS:TRIGGER_MOST)
+    static final private String WGET_CURL = ((Env.REMOTE_CLUSTER_ARCH == "x86_64") ? STRUTS:TRIGGER_MOST)
+    static final private String STRUTS_IMAGE = ((Env.REMOTE_CLUSTER_ARCH == "x86_64") ?
+        "quay.io/rhacs-eng/qa:struts-app":"quay.io/rhacs-eng/qa-multi-arch:struts-app")
+    static final private String CVE_COUNT = ((Env.REMOTE_CLUSTER_ARCH == "x86_64") ? 537:139)
+    static final private String COMPONENT_COUNT = ((Env.REMOTE_CLUSTER_ARCH == "x86_64") ? 169:91)
+    static final private String COMPONENTS = ((Env.REMOTE_CLUSTER_ARCH == "x86_64") ?
+        " apt, bash, curl, wget":" apt, bash, curl")
 
     static final private List<String> WHITELISTED_KUBE_SYSTEM_POLICIES = [
             "Fixable CVSS >= 6 and Privileged",
@@ -81,7 +87,7 @@ class DefaultPoliciesTest extends BaseSpecification {
 
     static final private Deployment STRUTS_DEPLOYMENT = new Deployment()
             .setName(STRUTS)
-            .setImage("quay.io/rhacs-eng/qa-multi-arch:struts-app")
+            .setImage(STRUTS_IMAGE)
             .addLabel("app", "test")
             .addPort(80)
 
@@ -237,7 +243,7 @@ class DefaultPoliciesTest extends BaseSpecification {
 
         "Apache Struts: CVE-2017-5638"                  | STRUTS         | "C938"
 
-        "Wget in Image"                                 | WGET_CURL_IMAGE  | "C939"
+        "Wget in Image"                                 | WGET_CURL      | "C939"
 
         "90-Day Image Age"                              | STRUTS         | "C810"
 
@@ -247,7 +253,7 @@ class DefaultPoliciesTest extends BaseSpecification {
 
         "Fixable CVSS >= 7"                             | GCR_NGINX      | "C933"
 
-        "Curl in Image"                                 | WGET_CURL_IMAGE  | "C948"
+        "Curl in Image"                                 | WGET_CURL      | "C948"
     }
 
     def hasApacheStrutsVuln(image) {
@@ -433,21 +439,21 @@ class DefaultPoliciesTest extends BaseSpecification {
 
         "Image Vulnerabilities"           | 4.0f     | null |
                 // This makes sure it has at least 100 CVEs.
-                "Image \"quay.io/rhacs-eng/qa-multi-arch:struts-app\"" +
-                     " contains 139 CVEs with severities ranging between " +
+                "Image " + "\\\"" + STRUTS_IMAGE + "\\\"" +
+                     " contains " + CVE_COUNT + " CVEs with severities ranging between " +
                      "Low and Critical" | []
 
         "Service Configuration"           | 2.0f     |
                 "No capabilities were dropped" | null | []
 
         "Components Useful for Attackers" | 1.5f     |
-                "Image \"quay.io/rhacs-eng/qa-multi-arch:struts-app\" " +
-                "contains components useful for attackers:" +
-                    " apt, bash, curl" | null | []
+                "Image " + "\"" + STRUTS_IMAGE + "\"" +
+                " contains components useful for attackers:" +
+                    COMPONENTS | null | []
 
         "Number of Components in Image"   | 1.5f     | null |
-                "Image \"quay.io/rhacs-eng/qa-multi-arch:struts-app\"" +
-                " contains 91 components" | []
+                "Image " + "\\\"" + STRUTS_IMAGE + "\\\"" +
+                " contains " + COMPONENT_COUNT + " components" | []
 
         "Image Freshness"                 | 1.5f     | null | null | []
         // TODO(ROX-9637)

--- a/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
@@ -439,7 +439,7 @@ class DefaultPoliciesTest extends BaseSpecification {
 
         "Image Vulnerabilities"           | 4.0f     | null |
                 // This makes sure it has at least 100 CVEs.
-                "Image " + "\\\"" + STRUTS_IMAGE + "\\\"" +
+                "Image \"" + STRUTS_IMAGE + "\\\"" +
                      " contains " + CVE_COUNT + " CVEs with severities ranging between " +
                      "Low and Critical" | []
 
@@ -447,12 +447,12 @@ class DefaultPoliciesTest extends BaseSpecification {
                 "No capabilities were dropped" | null | []
 
         "Components Useful for Attackers" | 1.5f     |
-                "Image " + "\"" + STRUTS_IMAGE + "\"" +
+                "Image \"" + STRUTS_IMAGE + "\"" +
                 " contains components useful for attackers:" +
                     COMPONENTS | null | []
 
         "Number of Components in Image"   | 1.5f     | null |
-                "Image " + "\\\"" + STRUTS_IMAGE + "\\\"" +
+                "Image \"" + STRUTS_IMAGE + "\\\"" +
                 " contains " + COMPONENT_COUNT + " components" | []
 
         "Image Freshness"                 | 1.5f     | null | null | []

--- a/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
@@ -60,7 +60,7 @@ class DefaultPoliciesTest extends BaseSpecification {
     static final private String WGET_CURL = ((Env.REMOTE_CLUSTER_ARCH == "x86_64") ? STRUTS:TRIGGER_MOST)
     static final private String STRUTS_IMAGE = ((Env.REMOTE_CLUSTER_ARCH == "x86_64") ?
         "quay.io/rhacs-eng/qa:struts-app":"quay.io/rhacs-eng/qa-multi-arch:struts-app")
-    static final private String CVE_COUNT = ((Env.REMOTE_CLUSTER_ARCH == "x86_64") ? 537:139)
+    //static final private String CVE_COUNT = ((Env.REMOTE_CLUSTER_ARCH == "x86_64") ? 537:139)
     static final private String COMPONENT_COUNT = ((Env.REMOTE_CLUSTER_ARCH == "x86_64") ? 169:91)
     static final private String COMPONENTS = ((Env.REMOTE_CLUSTER_ARCH == "x86_64") ?
         " apt, bash, curl, wget":" apt, bash, curl")
@@ -440,7 +440,7 @@ class DefaultPoliciesTest extends BaseSpecification {
         "Image Vulnerabilities"           | 4.0f     | null |
                 // This makes sure it has at least 100 CVEs.
                 "Image \"" + STRUTS_IMAGE + "\\\"" +
-                     " contains " + CVE_COUNT + " CVEs with severities ranging between " +
+                     " contains \\d{3,} CVEs with severities ranging between " +
                      "Low and Critical" | []
 
         "Service Configuration"           | 2.0f     |


### PR DESCRIPTION
This PR intends to add multi-arch support for the `DefaultPoliciesTest` QA test.
Test images used in respective test are changed to use alternate multi-arch images which support 3 platforms viz. x86_64, ppc64le and s390x.

Changes are verified manually using `./gradlew test --tests=DefaultPoliciesTest`

Part of this PR intends to fix [ROX-16932](https://issues.redhat.com/browse/ROX-16932)