### PR TITLE
fix(qa): Enable executing TLSChallengeTest and UpgradesTest on P/Z

### DIFF
--- a/qa-tests-backend/src/test/groovy/TLSChallengeTest.groovy
+++ b/qa-tests-backend/src/test/groovy/TLSChallengeTest.groovy
@@ -19,12 +19,8 @@ import util.Timer
 import spock.lang.Retry
 import spock.lang.Shared
 import spock.lang.Tag
-import spock.lang.IgnoreIf
-import util.Env
 
 @Retry(count = 1)
-// ROX-14228 skipping tests for 1st release on power & z
-@IgnoreIf({ Env.REMOTE_CLUSTER_ARCH == "ppc64le" || Env.REMOTE_CLUSTER_ARCH == "s390x" })
 class TLSChallengeTest extends BaseSpecification {
     @Shared
     private EnvVar originalCentralEndpoint = new EnvVar()

--- a/qa-tests-backend/src/test/groovy/UpgradesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/UpgradesTest.groovy
@@ -18,10 +18,7 @@ import spock.lang.Unroll
 import spock.lang.IgnoreIf
 
 class UpgradesTest extends BaseSpecification {
-    // workaround for P/Z clusters
-    private final static String CLUSTERID =
-            ((Env.REMOTE_CLUSTER_ARCH == "x86_64" ) ? Env.mustGet("UPGRADE_CLUSTER_ID") : "")
-
+    private final static String CLUSTERID = Env.mustGet("UPGRADE_CLUSTER_ID")
     private final static String POLICIES_JSON_PATH =
             Env.get("POLICIES_JSON_RELATIVE_PATH", "../pkg/defaults/policies/files")
 

--- a/qa-tests-backend/src/test/groovy/UpgradesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/UpgradesTest.groovy
@@ -17,10 +17,11 @@ import spock.lang.Tag
 import spock.lang.Unroll
 import spock.lang.IgnoreIf
 
-// ROX-14228 skipping tests for 1st release on power & z
-@IgnoreIf({ Env.REMOTE_CLUSTER_ARCH == "ppc64le" || Env.REMOTE_CLUSTER_ARCH == "s390x" })
 class UpgradesTest extends BaseSpecification {
-    private final static String CLUSTERID = Env.mustGet("UPGRADE_CLUSTER_ID")
+    // workaround for P/Z clusters
+    private final static String CLUSTERID =
+            ((Env.REMOTE_CLUSTER_ARCH == "x86_64" ) ? Env.mustGet("UPGRADE_CLUSTER_ID") : "")
+
     private final static String POLICIES_JSON_PATH =
             Env.get("POLICIES_JSON_RELATIVE_PATH", "../pkg/defaults/policies/files")
 


### PR DESCRIPTION
This PR intends to enable executing `TLSChallengeTest` and `UpgradesTest` on P/Z. Also a workaround has been added in UpgradesTest to make it execute on P/Z.

Changes are verified manually using `./gradlew test --tests=TestName`

Part of this PR intends to revert few changes added as part of #4357