### PR TITLE
Execute CertExpiryTest & CertRotationTest only if central is deployed

### DIFF
--- a/qa-tests-backend/src/main/groovy/util/Env.groovy
+++ b/qa-tests-backend/src/main/groovy/util/Env.groovy
@@ -30,9 +30,9 @@ class Env {
     // the remote cluster arch can be ppc64le or s390x, default is x86_64
     static final REMOTE_CLUSTER_ARCH = System.getenv("REMOTE_CLUSTER_ARCH") ?: "x86_64"
 
-    // STANDALONE_SECURED_CLUSTER specifies that the remote cluster being used to execute tests
+    // ONLY_SECURED_CLUSTER specifies that the remote cluster being used to execute tests
     // only has secured-cluster deployed and connects to a remote central
-    static final STANDALONE_SECURED_CLUSTER = System.getenv("STANDALONE_SECURED_CLUSTER") ?: "true"
+    static final ONLY_SECURED_CLUSTER = System.getenv("ONLY_SECURED_CLUSTER") ?: "false"
 
     private static final Env INSTANCE = new Env()
 

--- a/qa-tests-backend/src/main/groovy/util/Env.groovy
+++ b/qa-tests-backend/src/main/groovy/util/Env.groovy
@@ -30,6 +30,10 @@ class Env {
     // the remote cluster arch can be ppc64le or s390x, default is x86_64
     static final REMOTE_CLUSTER_ARCH = System.getenv("REMOTE_CLUSTER_ARCH") ?: "x86_64"
 
+    // STANDALONE_SECURED_CLUSTER specifies that the remote cluster being used to execute tests
+    // only has secured-cluster deployed and connects to a remote central
+    static final STANDALONE_SECURED_CLUSTER = System.getenv("STANDALONE_SECURED_CLUSTER") ?: "true"
+
     private static final Env INSTANCE = new Env()
 
     static String get(String key, String defVal = null) {

--- a/qa-tests-backend/src/test/groovy/CertExpiryTest.groovy
+++ b/qa-tests-backend/src/test/groovy/CertExpiryTest.groovy
@@ -7,8 +7,8 @@ import util.Env
 
 @Tag("BAT")
 @Tag("COMPATIBILITY")
-// ROX-14228 skipping tests for 1st release on power & z
-@IgnoreIf({ Env.REMOTE_CLUSTER_ARCH == "ppc64le" || Env.REMOTE_CLUSTER_ARCH == "s390x" })
+// skip if executed on a cluster with just secured-cluster deployed i.e. central is not deployed
+@IgnoreIf({ Env.STANDALONE_SECURED_CLUSTER == "true" })
 class CertExpiryTest extends BaseSpecification {
 
     def "Test Central cert expiry"() {

--- a/qa-tests-backend/src/test/groovy/CertExpiryTest.groovy
+++ b/qa-tests-backend/src/test/groovy/CertExpiryTest.groovy
@@ -7,8 +7,9 @@ import util.Env
 
 @Tag("BAT")
 @Tag("COMPATIBILITY")
-// skip if executed on a cluster with just secured-cluster deployed i.e. central is not deployed
-@IgnoreIf({ Env.STANDALONE_SECURED_CLUSTER == "true" })
+// skip if executed in a test environment with just secured-cluster deployed in the test cluster
+// i.e. central is deployed elsewhere
+@IgnoreIf({ Env.ONLY_SECURED_CLUSTER == "true" })
 class CertExpiryTest extends BaseSpecification {
 
     def "Test Central cert expiry"() {

--- a/qa-tests-backend/src/test/groovy/CertRotationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/CertRotationTest.groovy
@@ -26,8 +26,9 @@ import spock.lang.IgnoreIf
 import spock.lang.Tag
 
 @Tag("BAT")
-// skip if executed on a cluster with just secured-cluster deployed i.e. central is not deployed
-@IgnoreIf({ Env.STANDALONE_SECURED_CLUSTER == "true" })
+// skip if executed in a test environment with just secured-cluster deployed in the test cluster
+// i.e. central is deployed elsewhere
+@IgnoreIf({ Env.ONLY_SECURED_CLUSTER == "true" })
 class CertRotationTest extends BaseSpecification {
 
     def generateCerts(String path, String expectedFileName, JsonObject data = null) {

--- a/qa-tests-backend/src/test/groovy/CertRotationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/CertRotationTest.groovy
@@ -26,8 +26,8 @@ import spock.lang.IgnoreIf
 import spock.lang.Tag
 
 @Tag("BAT")
-// ROX-14228 skipping tests for 1st release on power & z
-@IgnoreIf({ Env.REMOTE_CLUSTER_ARCH == "ppc64le" || Env.REMOTE_CLUSTER_ARCH == "s390x" })
+// skip if executed on a cluster with just secured-cluster deployed i.e. central is not deployed
+@IgnoreIf({ Env.STANDALONE_SECURED_CLUSTER == "true" })
 class CertRotationTest extends BaseSpecification {
 
     def generateCerts(String path, String expectedFileName, JsonObject data = null) {


### PR DESCRIPTION
This PR intends to make changes in `CertExpiryTest` and `CertRotationTest` so that the tests are only executed only if both central & secures-cluster are deployed on same cluster. 
These tests executes only when `ONLY_SECURED_CLUSTER` is set to `true`.
To skip the test set `ONLY_SECURED_CLUSTER` to `false`, which is also the default value. 

Changes are verified manually using `./gradlew test --tests=TestName`

Part of this PR intends to revert few changes added as part of #4357