### PR TITLE
Use expanded form of pagination component for workload cve tables

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageResources.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageResources.tsx
@@ -95,7 +95,6 @@ function DeploymentPageResources({ deploymentId }: DeploymentPageResourcesProps)
                     >
                         <div className="pf-u-background-color-100 pf-u-pt-sm">
                             <Pagination
-                                isCompact
                                 itemCount={imageCount}
                                 page={page}
                                 perPage={perPage}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageResources.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageResources.tsx
@@ -98,7 +98,6 @@ function ImagePageResources({ imageId }: ImagePageResourcesProps) {
                     >
                         <div className="pf-u-background-color-100 pf-u-pt-sm">
                             <Pagination
-                                isCompact
                                 itemCount={deploymentCount}
                                 page={page}
                                 perPage={perPage}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
@@ -173,7 +173,6 @@ function ImagePageVulnerabilities({ imageId }: ImagePageVulnerabilitiesProps) {
                         </SplitItem>
                         <SplitItem>
                             <Pagination
-                                isCompact
                                 itemCount={totalVulnerabilityCount}
                                 page={page}
                                 perPage={perPage}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
@@ -373,7 +373,6 @@ function ImageCvePage() {
                         </SplitItem>
                         <SplitItem>
                             <Pagination
-                                isCompact
                                 itemCount={tableRowCount}
                                 page={page}
                                 perPage={perPage}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/TableEntityToolbar.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/TableEntityToolbar.tsx
@@ -51,7 +51,6 @@ function TableEntityToolbar({
                     )}
                     <ToolbarItem alignment={{ default: 'alignRight' }} variant="pagination">
                         <Pagination
-                            isCompact
                             itemCount={tableRowCount}
                             page={page}
                             perPage={perPage}


### PR DESCRIPTION
## Description

One small change that slipped through - this removes the `isCompact` form of the Pagination component to allow users to directly enter the page number.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

All pages use the expanded pagination component:
![image](https://github.com/stackrox/stackrox/assets/1292638/fd42444c-cd92-44df-a9de-ee63aca8e72b)

