### PR TITLE
Move icons to left of card title in System Health

### DIFF
--- a/ui/apps/platform/cypress/integration/systemHealth/clusters.test.js
+++ b/ui/apps/platform/cypress/integration/systemHealth/clusters.test.js
@@ -65,6 +65,17 @@ const clustersFixturePath = 'clusters/health.json';
 describe('System Health Clusters with fixture', () => {
     withAuth();
 
+    it('should have phrase in Cluster status card', () => {
+        setClock(currentDatetime); // call before visit
+        visitSystemHealth({
+            clusters: { fixture: clustersFixturePath },
+        });
+
+        const cardTitle = 'Cluster status';
+
+        cy.get(getCardHeaderDescendantSelector(cardTitle, 'div:contains("2 unhealthy")'));
+    });
+
     it('should have counts in row 1 of Cluster status card', () => {
         setClock(currentDatetime); // call before visit
         visitSystemHealth({
@@ -82,7 +93,7 @@ describe('System Health Clusters with fixture', () => {
         cy.get(getTableCellContainsSelector(cardTitle, nthRow, 'Total', 7));
     });
 
-    it('should have counts in row 2 of Cluster status card', () => {
+    it('should have counts in row 2 of Cluster status card header', () => {
         setClock(currentDatetime); // call before visit
         visitSystemHealth({
             clusters: { fixture: clustersFixturePath },
@@ -137,6 +148,17 @@ describe('System Health Clusters with fixture', () => {
         cy.get(getTableCellContainsSelector(cardTitle, nthRow, 'Total', 7));
     });
 
+    it('should have phrase in Sensor upgrade card header', () => {
+        setClock(currentDatetime); // call before visit
+        visitSystemHealth({
+            clusters: { fixture: clustersFixturePath },
+        });
+
+        const cardTitle = 'Sensor upgrade';
+
+        cy.get(getCardHeaderDescendantSelector(cardTitle, 'div:contains("2 degraded")'));
+    });
+
     it('should have counts in Sensor upgrade card', () => {
         setClock(currentDatetime); // call before visit
         visitSystemHealth({
@@ -152,6 +174,17 @@ describe('System Health Clusters with fixture', () => {
         cy.get(getTableCellContainsSelector(cardTitle, nthRow, 'Unavailable', 0));
         cy.get(getTableCellContainsSelector(cardTitle, nthRow, 'Uninitialized', 1));
         cy.get(getTableCellContainsSelector(cardTitle, nthRow, 'Total', 7));
+    });
+
+    it('should have phrase in Credential expiration card header', () => {
+        setClock(currentDatetime); // call before visit
+        visitSystemHealth({
+            clusters: { fixture: clustersFixturePath },
+        });
+
+        const cardTitle = 'Credential expiration';
+
+        cy.get(getCardHeaderDescendantSelector(cardTitle, 'div:contains("1 unhealthy")'));
     });
 
     it('should have counts in Credential expiration card', () => {
@@ -176,6 +209,15 @@ describe('System Health Clusters subset 3', () => {
     withAuth();
 
     const clusterNames = ['eta-7', 'kappa-kilogramme-10', 'lambda-liverpool-11'];
+
+    it('should have phrase in Cluster status card header', () => {
+        setClock(currentDatetime); // call before visit
+        visitSystemHealthWithClustersFixtureFilteredByNames(clustersFixturePath, clusterNames);
+
+        const cardTitle = 'Cluster status';
+
+        cy.get(getCardHeaderDescendantSelector(cardTitle, 'div:contains("1 unhealthy")'));
+    });
 
     it('should have counts in row 1 of Cluster status card', () => {
         setClock(currentDatetime); // call before visit
@@ -243,8 +285,17 @@ describe('System Health Clusters subset 3', () => {
 
         const cardTitle = 'Sensor upgrade';
 
-        cy.get(getCardHeaderDescendantSelector(cardTitle, 'span:contains("healthy")'));
+        cy.get(getCardHeaderDescendantSelector(cardTitle, 'div:contains("3 healthy")'));
         cy.get(getCardBodyDescendantSelector(cardTitle, 'table')).should('not.exist');
+    });
+
+    it('should have phrase in Credential expiration card header', () => {
+        setClock(currentDatetime); // call before visit
+        visitSystemHealthWithClustersFixtureFilteredByNames(clustersFixturePath, clusterNames);
+
+        const cardTitle = 'Credential expiration';
+
+        cy.get(getCardHeaderDescendantSelector(cardTitle, 'div:contains("1 degraded")'));
     });
 
     it('should have counts in Credential expiration card', () => {
@@ -267,6 +318,8 @@ describe('System Health Clusters subset 1 Uninitialized', () => {
     withAuth();
 
     const clusterNames = ['alpha-amsterdam-1']; // which has Uninitialized status
+
+    // No phrases in card header if no unhealthy, degraded, nor healthy.
 
     it('should have counts in row 1 of Cluster status card', () => {
         visitSystemHealthWithClustersFixtureFilteredByNames(clustersFixturePath, clusterNames);
@@ -366,7 +419,7 @@ describe('System Health Clusters subset 1 Healthy', () => {
 
         const cardTitle = 'Cluster status';
 
-        cy.get(getCardHeaderDescendantSelector(cardTitle, 'span:contains("healthy")'));
+        cy.get(getCardHeaderDescendantSelector(cardTitle, 'div:contains("1 healthy")'));
         cy.get(getCardBodyDescendantSelector(cardTitle, 'table')).should('not.exist');
     });
 
@@ -376,7 +429,7 @@ describe('System Health Clusters subset 1 Healthy', () => {
 
         const cardTitle = 'Sensor upgrade';
 
-        cy.get(getCardHeaderDescendantSelector(cardTitle, 'span:contains("healthy")'));
+        cy.get(getCardHeaderDescendantSelector(cardTitle, 'div:contains("1 healthy")'));
         cy.get(getCardBodyDescendantSelector(cardTitle, 'table')).should('not.exist');
     });
 
@@ -386,7 +439,7 @@ describe('System Health Clusters subset 1 Healthy', () => {
 
         const cardTitle = 'Credential expiration';
 
-        cy.get(getCardHeaderDescendantSelector(cardTitle, 'span:contains("healthy")'));
+        cy.get(getCardHeaderDescendantSelector(cardTitle, 'div:contains("1 healthy")'));
         cy.get(getCardBodyDescendantSelector(cardTitle, 'table')).should('not.exist');
     });
 });

--- a/ui/apps/platform/cypress/integration/systemHealth/clusters.test.js
+++ b/ui/apps/platform/cypress/integration/systemHealth/clusters.test.js
@@ -93,7 +93,7 @@ describe('System Health Clusters with fixture', () => {
         cy.get(getTableCellContainsSelector(cardTitle, nthRow, 'Total', 7));
     });
 
-    it('should have counts in row 2 of Cluster status card header', () => {
+    it('should have counts in row 2 of Cluster status card', () => {
         setClock(currentDatetime); // call before visit
         visitSystemHealth({
             clusters: { fixture: clustersFixturePath },

--- a/ui/apps/platform/src/Containers/SystemHealth/CardHeaderIcons.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/CardHeaderIcons.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactElement } from 'react';
 import { Spinner } from '@patternfly/react-core';
 import {
     CheckCircleIcon,
@@ -18,7 +18,9 @@ export const DangerIcon = <ExclamationCircleIcon color="var(--pf-global--danger-
 export const SuccessIcon = <CheckCircleIcon color="var(--pf-global--success-color--100)" />;
 export const WarningIcon = <ExclamationTriangleIcon color="var(--pf-global--warning-color--100)" />;
 
-export const healthIconMap = {
+export type HealthVariant = 'danger' | 'warning' | 'success';
+
+export const healthIconMap: Record<HealthVariant, ReactElement> = {
     danger: DangerIcon,
     success: SuccessIcon,
     warning: WarningIcon,

--- a/ui/apps/platform/src/Containers/SystemHealth/CertificateHealth/CertificateCard.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/CertificateHealth/CertificateCard.tsx
@@ -79,7 +79,13 @@ function CertificateCard({ component, pollingCount }: CertificateCardProps): Rea
     }
 
     const title = `${nameOfComponent[component]} certificate`;
+
+    /*
+     * Wait for isFetching only until response to the initial request.
+     * Otherwise phrase temporarily disappears during each subsequent request.
+     */
     const isFetchingInitialRequest = isFetching && pollingCount === 0;
+
     /* eslint-disable no-nested-ternary */
     const icon = isFetchingInitialRequest
         ? SpinnerIcon
@@ -91,7 +97,7 @@ function CertificateCard({ component, pollingCount }: CertificateCardProps): Rea
         <Card isCompact>
             <CardHeader>
                 <Flex className="pf-u-flex-grow-1">
-                    {icon}
+                    <FlexItem>{icon}</FlexItem>
                     <FlexItem>
                         <CardTitle component="h2">{title}</CardTitle>
                     </FlexItem>

--- a/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/ClusterStatusCard.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/ClusterStatusCard.tsx
@@ -19,26 +19,28 @@ import {
 export type ClusterStatusTableProps = {
     clusters: Cluster[];
     isFetchingInitialRequest: boolean;
-    requestErrorMessage: string;
+    errorMessageFetching: string;
 };
 
 function ClusterStatusTable({
     clusters,
     isFetchingInitialRequest,
-    requestErrorMessage,
+    errorMessageFetching,
 }: ClusterStatusTableProps): ReactElement {
     const countsOverall =
-        !isFetchingInitialRequest && !requestErrorMessage ? getClusterStatusCounts(clusters) : null;
+        !isFetchingInitialRequest && !errorMessageFetching
+            ? getClusterStatusCounts(clusters)
+            : null;
     const countsSensor =
-        !isFetchingInitialRequest && !requestErrorMessage
+        !isFetchingInitialRequest && !errorMessageFetching
             ? getClusterBecauseOfStatusCounts(clusters, 'sensorHealthStatus')
             : null;
     const countsCollector =
-        !isFetchingInitialRequest && !requestErrorMessage
+        !isFetchingInitialRequest && !errorMessageFetching
             ? getClusterBecauseOfStatusCounts(clusters, 'collectorHealthStatus')
             : null;
     const countsAdmissionControl =
-        !isFetchingInitialRequest && !requestErrorMessage
+        !isFetchingInitialRequest && !errorMessageFetching
             ? getClusterBecauseOfStatusCounts(clusters, 'admissionControlHealthStatus')
             : null;
 
@@ -60,9 +62,9 @@ function ClusterStatusTable({
                 isFetchingInitialRequest={isFetchingInitialRequest}
                 title="Cluster status"
             />
-            {requestErrorMessage ? (
+            {errorMessageFetching ? (
                 <CardBody>
-                    <Alert isInline variant="warning" title={requestErrorMessage} />
+                    <Alert isInline variant="warning" title={errorMessageFetching} />
                 </CardBody>
             ) : countsOverall !== null &&
               countsSensor !== null &&

--- a/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/ClustersHealth.utils.ts
+++ b/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/ClustersHealth.utils.ts
@@ -5,6 +5,8 @@ import {
 import { CertExpiryStatus } from 'Containers/Clusters/clusterTypes'; // TODO types/cluster.proto.ts
 import { Cluster } from 'types/cluster.proto';
 
+import { HealthVariant } from '../CardHeaderIcons';
+
 export type ClusterStatus = 'HEALTHY' | 'UNHEALTHY' | 'DEGRADED' | 'UNAVAILABLE' | 'UNINITIALIZED';
 
 export type ClusterStatusCounts = Record<ClusterStatus, number>;
@@ -101,4 +103,27 @@ export function getClusterBecauseOfStatusCounts(
     });
 
     return counts;
+}
+
+export function getClustersHealthPhrase(counts: ClusterStatusCounts): string {
+    if (counts.UNHEALTHY !== 0) {
+        return `${counts.UNHEALTHY} unhealthy`;
+    }
+    if (counts.DEGRADED !== 0) {
+        return `${counts.DEGRADED} degraded`;
+    }
+    if (counts.HEALTHY !== 0) {
+        return `${counts.HEALTHY} healthy`;
+    }
+    return '';
+}
+
+export function getClustersHealthVariant(counts: ClusterStatusCounts): HealthVariant {
+    if (counts.UNHEALTHY !== 0) {
+        return 'danger';
+    }
+    if (counts.DEGRADED !== 0) {
+        return 'warning';
+    }
+    return 'success';
 }

--- a/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/ClustersHealthCardHeader.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/ClustersHealthCardHeader.tsx
@@ -1,12 +1,16 @@
 import React, { ReactElement } from 'react';
-import { CheckCircleIcon } from '@patternfly/react-icons';
-import { Button, CardHeader, CardTitle, Flex, FlexItem, Spinner } from '@patternfly/react-core';
+import { Button, CardHeader, CardTitle, Flex, FlexItem } from '@patternfly/react-core';
 
-import IconText from 'Components/PatternFly/IconText/IconText';
 import LinkShim from 'Components/PatternFly/LinkShim/LinkShim';
 import { clustersBasePath } from 'routePaths';
 
-import { ClusterStatusCounts } from './ClustersHealth.utils';
+import { ErrorIcon, healthIconMap, SpinnerIcon } from '../CardHeaderIcons';
+
+import {
+    ClusterStatusCounts,
+    getClustersHealthPhrase,
+    getClustersHealthVariant,
+} from './ClustersHealth.utils';
 
 export type ClustersHealthCardHeaderProps = {
     counts: ClusterStatusCounts | null;
@@ -19,22 +23,24 @@ function ClustersHealthCardHeader({
     isFetchingInitialRequest,
     title,
 }: ClustersHealthCardHeaderProps): ReactElement {
-    const isHealthy =
-        counts !== null && counts.HEALTHY !== 0 && counts.UNHEALTHY === 0 && counts.DEGRADED === 0;
+    /* eslint-disable no-nested-ternary */
+    const icon = isFetchingInitialRequest
+        ? SpinnerIcon
+        : !counts
+        ? ErrorIcon
+        : healthIconMap[getClustersHealthVariant(counts)];
+    /* eslint-enable no-nested-ternary */
+
+    const phrase = counts === null ? '' : getClustersHealthPhrase(counts);
 
     return (
         <CardHeader>
             <Flex className="pf-u-flex-grow-1">
+                <FlexItem>{icon}</FlexItem>
                 <FlexItem>
                     <CardTitle component="h2">{title}</CardTitle>
                 </FlexItem>
-                {isFetchingInitialRequest && <Spinner isSVG size="md" />}
-                {isHealthy && (
-                    <IconText
-                        icon={<CheckCircleIcon color="var(--pf-global--success-color--100)" />}
-                        text="healthy"
-                    />
-                )}
+                {phrase && <FlexItem>{phrase}</FlexItem>}
                 <FlexItem align={{ default: 'alignRight' }}>
                     <Button variant="link" isInline component={LinkShim} href={clustersBasePath}>
                         View clusters

--- a/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/ClustersHealthCards.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/ClustersHealthCards.tsx
@@ -15,7 +15,7 @@ type ClustersHealthCardsProps = {
 
 const ClustersHealthCards = ({ pollingCount }: ClustersHealthCardsProps): ReactElement => {
     const [isFetching, setIsFetching] = useState(false);
-    const [requestErrorMessage, setRequestErrorMessage] = useState('');
+    const [errorMessageFetching, setErrorMessageFetching] = useState('');
     const [clusters, setClusters] = useState<Cluster[]>([]);
 
     const [currentDatetime, setCurrentDatetime] = useState<Date | null>(null);
@@ -24,7 +24,7 @@ const ClustersHealthCards = ({ pollingCount }: ClustersHealthCardsProps): ReactE
         setIsFetching(true);
         fetchClustersAsArray()
             .then((clustersFetched) => {
-                setRequestErrorMessage('');
+                setErrorMessageFetching('');
                 // TODO supersede src/Containers/Clusters/clusterTypes.ts with types/cluster.proto.ts
                 // eslint-disable-next-line
                 // @ts-ignore
@@ -32,7 +32,7 @@ const ClustersHealthCards = ({ pollingCount }: ClustersHealthCardsProps): ReactE
                 setCurrentDatetime(new Date());
             })
             .catch((error) => {
-                setRequestErrorMessage(getAxiosErrorMessage(error));
+                setErrorMessageFetching(getAxiosErrorMessage(error));
                 setClusters([]);
                 setCurrentDatetime(null);
             })
@@ -49,14 +49,14 @@ const ClustersHealthCards = ({ pollingCount }: ClustersHealthCardsProps): ReactE
                 <ClusterStatusCard
                     clusters={clusters}
                     isFetchingInitialRequest={isFetchingInitialRequest}
-                    requestErrorMessage={requestErrorMessage}
+                    errorMessageFetching={errorMessageFetching}
                 />
             </GridItem>
             <GridItem span={12}>
                 <SensorUpgradeCard
                     clusters={clusters}
                     isFetchingInitialRequest={isFetchingInitialRequest}
-                    requestErrorMessage={requestErrorMessage}
+                    errorMessageFetching={errorMessageFetching}
                 />
             </GridItem>
             <GridItem span={12}>
@@ -64,7 +64,7 @@ const ClustersHealthCards = ({ pollingCount }: ClustersHealthCardsProps): ReactE
                     clusters={clusters}
                     currentDatetime={currentDatetime}
                     isFetchingInitialRequest={isFetchingInitialRequest}
-                    requestErrorMessage={requestErrorMessage}
+                    errorMessageFetching={errorMessageFetching}
                 />
             </GridItem>
         </>

--- a/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/CredentialExpirationCard.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/CredentialExpirationCard.tsx
@@ -24,14 +24,14 @@ export type CredentialExpirationCardProps = {
     clusters: Cluster[];
     currentDatetime: Date | null;
     isFetchingInitialRequest: boolean;
-    requestErrorMessage: string;
+    errorMessageFetching: string;
 };
 
 function CredentialExpirationCard({
     clusters,
     currentDatetime,
     isFetchingInitialRequest,
-    requestErrorMessage,
+    errorMessageFetching,
 }: CredentialExpirationCardProps): ReactElement {
     const counts = currentDatetime
         ? getCertificateExpirationCounts(clusters, currentDatetime)
@@ -55,9 +55,9 @@ function CredentialExpirationCard({
                 isFetchingInitialRequest={isFetchingInitialRequest}
                 title="Credential expiration"
             />
-            {requestErrorMessage ? (
+            {errorMessageFetching ? (
                 <CardBody>
-                    <Alert isInline variant="warning" title={requestErrorMessage} />
+                    <Alert isInline variant="warning" title={errorMessageFetching} />
                 </CardBody>
             ) : counts !== null &&
               (counts.HEALTHY === 0 || counts.UNHEALTHY !== 0 || counts.DEGRADED !== 0) ? (

--- a/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/SensorUpgradeCard.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/SensorUpgradeCard.tsx
@@ -23,16 +23,18 @@ const dataLabelDegraded = 'Out of date';
 export type SensorUpgradeCardProps = {
     clusters: Cluster[];
     isFetchingInitialRequest: boolean;
-    requestErrorMessage: string;
+    errorMessageFetching: string;
 };
 
 function SensorUpgradeCard({
     clusters,
     isFetchingInitialRequest,
-    requestErrorMessage,
+    errorMessageFetching,
 }: SensorUpgradeCardProps): ReactElement {
     const counts =
-        !isFetchingInitialRequest && !requestErrorMessage ? getSensorUpgradeCounts(clusters) : null;
+        !isFetchingInitialRequest && !errorMessageFetching
+            ? getSensorUpgradeCounts(clusters)
+            : null;
 
     /*
      * Render card header without body:
@@ -52,9 +54,9 @@ function SensorUpgradeCard({
                 isFetchingInitialRequest={isFetchingInitialRequest}
                 title="Sensor upgrade"
             />
-            {requestErrorMessage ? (
+            {errorMessageFetching ? (
                 <CardBody>
-                    <Alert isInline variant="warning" title={requestErrorMessage} />
+                    <Alert isInline variant="warning" title={errorMessageFetching} />
                 </CardBody>
             ) : counts !== null &&
               (counts.HEALTHY === 0 || counts.UNHEALTHY !== 0 || counts.DEGRADED !== 0) ? (

--- a/ui/apps/platform/src/Containers/SystemHealth/VulnerabilityDefinitionsHealth/VulnerabilityDefinitionsHealthCard.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/VulnerabilityDefinitionsHealth/VulnerabilityDefinitionsHealthCard.tsx
@@ -8,19 +8,14 @@ import {
     Flex,
     FlexItem,
 } from '@patternfly/react-core';
-import { CheckCircleIcon, ExclamationCircleIcon } from '@patternfly/react-icons';
 import { differenceInMinutes } from 'date-fns';
 
-import IconText from 'Components/PatternFly/IconText/IconText';
 import { fetchVulnerabilityDefinitionsInfo } from 'services/IntegrationHealthService';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
-const dayInMinutes = 24 * 60;
+import { ErrorIcon, healthIconMap, SpinnerIcon } from '../CardHeaderIcons';
 
-// TODO Import from services/IntegrationHealthService after we rewrite it in TypeScript.
-type VulnerabilityDefinitionsInfo = {
-    lastUpdatedTimestamp: string;
-};
+const dayInMinutes = 24 * 60;
 
 type VulnerabilityDefinitionsHealthCardProps = {
     pollingCount: number;
@@ -30,22 +25,22 @@ const VulnerabilityDefinitionsHealthCard = ({
     pollingCount,
 }: VulnerabilityDefinitionsHealthCardProps): ReactElement => {
     const [isFetching, setIsFetching] = useState(false);
-    const [requestErrorMessage, setRequestErrorMessage] = useState('');
-    const [vulnerabilityDefinitionsInfo, setVulnerabilityDefinitionsInfo] =
-        useState<VulnerabilityDefinitionsInfo | null>(null);
+    const [errorMessageFetching, setErrorMessageFetching] = useState('');
+    const [lastUpdatedTimestamp, setLastUpdatedTimestamp] = useState('');
     const [currentDatetime, setCurrentDatetime] = useState<Date | null>(null);
 
     useEffect(() => {
         setIsFetching(true);
         fetchVulnerabilityDefinitionsInfo()
             .then((info) => {
-                setRequestErrorMessage('');
-                setVulnerabilityDefinitionsInfo(info);
+                setErrorMessageFetching('');
+                setLastUpdatedTimestamp(info.lastUpdatedTimestamp);
                 setCurrentDatetime(new Date());
             })
             .catch((error) => {
-                setRequestErrorMessage(getAxiosErrorMessage(error));
-                setVulnerabilityDefinitionsInfo(null);
+                setErrorMessageFetching(getAxiosErrorMessage(error));
+                setLastUpdatedTimestamp('');
+                setCurrentDatetime(null);
             })
             .finally(() => {
                 setIsFetching(false);
@@ -54,49 +49,46 @@ const VulnerabilityDefinitionsHealthCard = ({
 
     /*
      * Wait for isFetching only until response to the initial request.
-     * Otherwise info temporarily disappears during each subsequent request.
+     * Otherwise timestamp temporarily disappears during each subsequent request.
      */
-    const hasInfo = (pollingCount !== 0 || !isFetching) && !requestErrorMessage;
-    const lastUpdatedTimestamp = vulnerabilityDefinitionsInfo?.lastUpdatedTimestamp;
+    const isFetchingInitialRequest = isFetching && pollingCount === 0;
+
     // Beware: the order of the arguments in date-fns@1 (later, earlier)
     // will be reversed in date-fns@2 to differenceInMinutes(earlier, later).
     const isUpToDate =
-        hasInfo &&
         lastUpdatedTimestamp &&
-        currentDatetime !== null &&
+        currentDatetime &&
         differenceInMinutes(currentDatetime, lastUpdatedTimestamp) < dayInMinutes;
+
+    /* eslint-disable no-nested-ternary */
+    const icon = isFetchingInitialRequest
+        ? SpinnerIcon
+        : errorMessageFetching
+        ? ErrorIcon
+        : healthIconMap[isUpToDate ? 'success' : 'danger'];
+    /* eslint-enable no-nested-ternary */
 
     return (
         <Card isCompact>
             <CardHeader>
                 <Flex className="pf-u-flex-grow-1">
+                    <FlexItem>{icon}</FlexItem>
                     <FlexItem>
                         <CardTitle component="h2">Vulnerability definitions</CardTitle>
                     </FlexItem>
-                    {hasInfo && (
-                        <FlexItem>
-                            <IconText
-                                icon={
-                                    isUpToDate ? (
-                                        <CheckCircleIcon color="var(--pf-global--success-color--100)" />
-                                    ) : (
-                                        <ExclamationCircleIcon color="var(--pf-global--danger-color--100)" />
-                                    )
-                                }
-                                text={isUpToDate ? 'up to date' : 'out of date'}
-                            />
-                        </FlexItem>
-                    )}
-                    {hasInfo && lastUpdatedTimestamp && (
-                        <FlexItem align={{ default: 'alignRight' }}>
-                            {lastUpdatedTimestamp}
-                        </FlexItem>
+                    {lastUpdatedTimestamp && currentDatetime && (
+                        <>
+                            <FlexItem>{isUpToDate ? 'up to date' : 'out of date'}</FlexItem>
+                            <FlexItem align={{ default: 'alignRight' }}>
+                                {lastUpdatedTimestamp}
+                            </FlexItem>
+                        </>
                     )}
                 </Flex>
             </CardHeader>
-            {requestErrorMessage && (
+            {errorMessageFetching && (
                 <CardBody>
-                    <Alert isInline variant="warning" title={requestErrorMessage} />
+                    <Alert isInline variant="warning" title={errorMessageFetching} />
                 </CardBody>
             )}
         </Card>

--- a/ui/apps/platform/src/types/integrationHealth.proto.ts
+++ b/ui/apps/platform/src/types/integrationHealth.proto.ts
@@ -1,0 +1,20 @@
+export type IntegrationHealthStatus = 'UNINITIALIZED' | 'UNHEALTHY' | 'HEALTHY';
+
+// Semicolon on separate line following the strings prevents an extra changed line to add a string at the end.
+// prettier-ignore
+export type IntegrationHealthType =
+    | 'UNKNOWN'
+    | 'IMAGE_INTEGRATION'
+    | 'NOTIFIER'
+    | 'BACKUP'
+    | 'DECLARATIVE_CONFIG'
+    ;
+
+export type IntegrationHealth = {
+    id: string;
+    name: string;
+    type: IntegrationHealthType;
+    status: IntegrationHealthStatus;
+    errorMessage: string;
+    lastTimestamp: string; // ISO 8601 timestamp when the status was ascertained
+};


### PR DESCRIPTION
## Description

Provide consistent pattern, especially so Ivan can adapt DeclarativeConfigurationHealthCard to 3 integration health cards.

1. Align icons at the left of card title
    * Spinner while waiting for initial fetch
    * MinusIcon if request error
    * ExclamationCircleIcon if any unhealthy
    * ExclamationTriangleIcon if any degraded
    * CheckCircleIcon if none of the above

2. Clusters health phrase at the right of card title
    * N unhealthy
    * N degraded
    * N healthy
    * empty string if none of the above (that is, edges cases of no clusters or only Unavailable or Uninitialized clusters)

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed

1. `yarn lint` in ui
2. `yarn build` in ui
3. `yarn start` in ui

### Manual testing

1. Visit /main/system-health: see that cards fit when all healthy, even before rewrite of integration health from widgets to cards.

    * 1920px panel width and height
        ![1920](https://github.com/stackrox/stackrox/assets/11862657/eafef65e-a203-4908-a689-13a076da74b8)

    * 1440px laptop width but panel height
        ![1440](https://github.com/stackrox/stackrox/assets/11862657/3707f14c-a1f9-40a0-857d-e7385104b9ae)

### Integration testing

1. `yarn cypress-open` in ui/apps/platform

    * clusters.test.js
