### PR TITLE
Generalize fallback for any groupBy category that is not a resourceLabel

### DIFF
--- a/ui/apps/platform/src/Containers/Compliance/List/Table.js
+++ b/ui/apps/platform/src/Containers/Compliance/List/Table.js
@@ -294,8 +294,7 @@ const ListTable = ({
                         tableData = filterByComplianceState(formattedData, query, isControlList);
                         totalRows = getTotalRows(tableData, isControlList);
                         const { groupBy } = query;
-                        const groupByLabel =
-                            groupBy === 'STANDARD' ? 'standard' : resourceLabels[groupBy];
+                        const groupByLabel = resourceLabels[groupBy] ?? groupBy.toLowerCase();
 
                         const groupedByText = groupBy
                             ? `across ${tableData.length} ${pluralize(


### PR DESCRIPTION
## Description

Fix incorrect specific fallback in #6053
https://github.com/stackrox/stackrox/blame/master/ui/apps/platform/src/Containers/Compliance/List/Table.js#L298

## Checklist
- [ ] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

1. Visit /main/compliance
2. Click **View standard** on a sunburst widget.

