### PR TITLE
ROX-17744: Mock grpc server should report multiple connections

### DIFF
--- a/integration-tests/mock-grpc-server/main.go
+++ b/integration-tests/mock-grpc-server/main.go
@@ -126,19 +126,6 @@ func (s *signalServer) UpdateProcessLineageInfo(processName string, parentID str
 	})
 }
 
-func (s *signalServer) UpdateNetworkConnInfo(containerID string, networkInfo string) error {
-	return s.db.Update(func(tx *bolt.Tx) error {
-		b, _ := tx.CreateBucketIfNotExists([]byte(networkBucket))
-		err := b.Put([]byte(containerID), []byte(networkInfo))
-		if err != nil {
-			fmt.Println(err)
-			return err
-		}
-
-		return nil
-	})
-}
-
 func (s *signalServer) UpdateBucket(containerID string, info string, bucket string) error {
 	return s.db.Update(func(tx *bolt.Tx) error {
 		b, err := tx.CreateBucketIfNotExists([]byte(bucket))

--- a/integration-tests/mock-grpc-server/main.go
+++ b/integration-tests/mock-grpc-server/main.go
@@ -90,7 +90,8 @@ func (s *signalServer) PushNetworkConnectionInfo(stream sensorAPI.NetworkConnect
 		for _, networkConn := range networkConns {
 			networkInfo := fmt.Sprintf("%s|%s|%s|%s|%s", getEndpoint(networkConn.GetLocalAddress()), getEndpoint(networkConn.GetRemoteAddress()), networkConn.GetRole().String(), networkConn.GetSocketFamily().String(), networkConn.GetCloseTimestamp().String())
 			fmt.Printf("NetworkInfo: %s %s\n", networkConn.GetContainerId(), networkInfo)
-			if err := s.UpdateNetworkConnInfo(networkConn.GetContainerId(), networkInfo); err != nil {
+			//if err := s.UpdateNetworkConnInfo(networkConn.GetContainerId(), networkInfo); err != nil {
+			if err := s.UpdateBucket(networkConn.GetContainerId(), networkInfo, networkBucket); err != nil {
 				return err
 			}
 		}

--- a/integration-tests/mock-grpc-server/main.go
+++ b/integration-tests/mock-grpc-server/main.go
@@ -90,7 +90,6 @@ func (s *signalServer) PushNetworkConnectionInfo(stream sensorAPI.NetworkConnect
 		for _, networkConn := range networkConns {
 			networkInfo := fmt.Sprintf("%s|%s|%s|%s|%s", getEndpoint(networkConn.GetLocalAddress()), getEndpoint(networkConn.GetRemoteAddress()), networkConn.GetRole().String(), networkConn.GetSocketFamily().String(), networkConn.GetCloseTimestamp().String())
 			fmt.Printf("NetworkInfo: %s %s\n", networkConn.GetContainerId(), networkInfo)
-			//if err := s.UpdateNetworkConnInfo(networkConn.GetContainerId(), networkInfo); err != nil {
 			if err := s.UpdateBucket(networkConn.GetContainerId(), networkInfo, networkBucket); err != nil {
 				return err
 			}


### PR DESCRIPTION
## Description

Currently the mock grpc server used by collector only reports the latest network connection involving a container. With this change all connections involving a container will be reported by that container. The corresponding PR for collector can be found at https://github.com/stackrox/collector/pull/1194

## Checklist
- [x] Investigated and inspected CI test results
- [x] Use in collector integration tests.

## Testing Performed

See above
