### PR TITLE
fix(enricher): Ensure image names are used in image enricher

### DIFF
--- a/pkg/images/enricher/enricher_impl.go
+++ b/pkg/images/enricher/enricher_impl.go
@@ -301,6 +301,10 @@ func (e *enricherImpl) updateImageFromDatabase(ctx context.Context, img *storage
 		return false
 	}
 
+	// Since the image we use may not include all image names associated with the stored image due to different scanning
+	// workflows, ensure we merge the image names.
+	img.Names = utils.UniqueImageNames(existingImg.GetNames(), img.GetNames())
+
 	usesExistingScan := e.useExistingScan(img, existingImg, option)
 	e.useExistingSignature(img, existingImg, option)
 	e.useExistingSignatureVerificationData(img, existingImg, option)

--- a/pkg/images/utils/utils.go
+++ b/pkg/images/utils/utils.go
@@ -236,3 +236,25 @@ func FilterSuppressedCVEsNoClone(img *storage.Image) {
 		}
 	}
 }
+
+// UniqueImageNames returns the unique image names from the two given slices of image names.
+func UniqueImageNames(a, b []*storage.ImageName) []*storage.ImageName {
+	uniqueImageFullNames := set.NewStringSet()
+	uniqueImageNames := make([]*storage.ImageName, 0, len(a)+len(b))
+
+	uniqueImageNames = append(uniqueImageNames, getUniqueImageNames(a, uniqueImageFullNames)...)
+	uniqueImageNames = append(uniqueImageNames, getUniqueImageNames(b, uniqueImageFullNames)...)
+	return uniqueImageNames
+}
+
+func getUniqueImageNames(names []*storage.ImageName, uniqueFullNames set.StringSet) []*storage.ImageName {
+	uniqueImageNames := make([]*storage.ImageName, 0, len(names))
+	for _, name := range names {
+		fullName := name.GetFullName()
+		if !uniqueFullNames.Contains(fullName) {
+			uniqueFullNames.Add(fullName)
+			uniqueImageNames = append(uniqueImageNames, name)
+		}
+	}
+	return uniqueImageNames
+}

--- a/pkg/images/utils/utils.go
+++ b/pkg/images/utils/utils.go
@@ -9,7 +9,9 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/cve"
 	"github.com/stackrox/rox/pkg/logging"
+	"github.com/stackrox/rox/pkg/protoutils"
 	"github.com/stackrox/rox/pkg/set"
+	"github.com/stackrox/rox/pkg/sliceutils"
 	"github.com/stackrox/rox/pkg/stringutils"
 )
 
@@ -239,21 +241,10 @@ func FilterSuppressedCVEsNoClone(img *storage.Image) {
 
 // UniqueImageNames returns the unique image names from the two given slices of image names.
 func UniqueImageNames(a, b []*storage.ImageName) []*storage.ImageName {
-	uniqueImageFullNames := set.NewStringSet()
-	uniqueImageNames := make([]*storage.ImageName, 0, len(a)+len(b))
-
-	uniqueImageNames = append(uniqueImageNames, getUniqueImageNames(a, uniqueImageFullNames)...)
-	uniqueImageNames = append(uniqueImageNames, getUniqueImageNames(b, uniqueImageFullNames)...)
-	return uniqueImageNames
-}
-
-func getUniqueImageNames(names []*storage.ImageName, uniqueFullNames set.StringSet) []*storage.ImageName {
-	uniqueImageNames := make([]*storage.ImageName, 0, len(names))
-	for _, name := range names {
-		fullName := name.GetFullName()
-		if !uniqueFullNames.Contains(fullName) {
-			uniqueFullNames.Add(fullName)
-			uniqueImageNames = append(uniqueImageNames, name)
+	uniqueImageNames := sliceutils.ShallowClone(a)
+	for _, imageName := range b {
+		if !protoutils.SliceContains(imageName, uniqueImageNames) {
+			uniqueImageNames = append(uniqueImageNames, imageName)
 		}
 	}
 	return uniqueImageNames

--- a/pkg/images/utils/utils_test.go
+++ b/pkg/images/utils/utils_test.go
@@ -213,3 +213,38 @@ func TestExtractOpenShiftProject_solelyRemote(t *testing.T) {
 	}
 	assert.Equal(t, "stackrox", ExtractOpenShiftProject(imgName))
 }
+
+func TestUniqueImageNames(t *testing.T) {
+	a := []*storage.ImageName{
+		{
+			Registry: "docker.io",
+			Remote:   "something",
+			Tag:      "latest",
+			FullName: "docker.io/something:latest",
+		},
+		{
+			Registry: "docker.io",
+			Remote:   "someone",
+			Tag:      "latest",
+			FullName: "docker.io/someone:latest",
+		},
+	}
+	b := []*storage.ImageName{
+		{
+			Registry: "docker.io",
+			Remote:   "somewhere",
+			Tag:      "latest",
+			FullName: "docker.io/somewhere:latest",
+		},
+		{
+			Registry: "docker.io",
+			Remote:   "someone",
+			Tag:      "latest",
+			FullName: "docker.io/someone:latest",
+		},
+	}
+
+	res := UniqueImageNames(a, b)
+
+	assert.Equal(t, append(a, b[0]), res)
+}


### PR DESCRIPTION
## Description

In the past we've added a new field `Names` which contains multiple image names for a single digest. The reasoning behind this was that images may have different fullnames but the same digest (e.g. stored under different repositories, stored in different registries but the same digest).

When either scanning images from sensor or when scanning images from central the image names field will be populated. However, when using scanning workflows like the detection service, it currently will always override the image names to the given image name of the image.

This is not excatly what was intended, hence we will now always ensure we add the unique image names from both the cached image as well as the image to-be-scanned, ensuring no overwrite happens when using a detection service scanning flow.

Caveat:
Currently, it is possible to override the _whole_ image names / name field when using the `ForceRefetch` flag (i.e. in requests to the image service or the detection service).

This problem existed prior to the introduction of the image name (i.e. one could already "override" an existing image name by scanning a image with the same digest but different name). Will be addressed in a follow-up after investigation

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

- see CI.
