### PR TITLE
ROX-17365: Delegated Scanning Kill Switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
   Note that if the environment variable is set, no signatures will be fetched and thus the signature verification feature cannot be used.
 - ROX-16532: Resource limits and requests for the node-inventory container can now be configured via the operator.
 - A new environment variable `ROX_SCAN_TIMEOUT` has been added to Sensor which allows for customizing the image scan timeout used in Sensor initiated scans.
+- A new environment variable `ROX_DELEGATED_SCANNING_DISABLED` has been added that disables delegated scanning capabilities while leaving other local scanning capabilities in-tact.
 
 ### Removed Features
 - ROX-14398: As announced in 3.74, the permission `Access` replaces the deprecated permission `Role`.

--- a/generated/api/v1/image_service.pb.go
+++ b/generated/api/v1/image_service.pb.go
@@ -1544,7 +1544,7 @@ type ImageServiceClient interface {
 	// includes the image's vulnerabilities as well as the signature verification data.
 	EnrichLocalImageInternal(ctx context.Context, in *EnrichLocalImageInternalRequest, opts ...grpc.CallOption) (*ScanImageInternalResponse, error)
 	// UpdateLocalScanStatusInternal is used solely by Sensor to send delegated scanning errors to central that
-	// prevent local enrichment from occuring (such as no scanner, thorttled, etc.).
+	// prevent local enrichment from occurring (such as no scanner, throttled, etc.).
 	UpdateLocalScanStatusInternal(ctx context.Context, in *UpdateLocalScanStatusInternalRequest, opts ...grpc.CallOption) (*Empty, error)
 	// InvalidateScanAndRegistryCaches removes the image metadata cache.
 	InvalidateScanAndRegistryCaches(ctx context.Context, in *Empty, opts ...grpc.CallOption) (*Empty, error)
@@ -1705,7 +1705,7 @@ type ImageServiceServer interface {
 	// includes the image's vulnerabilities as well as the signature verification data.
 	EnrichLocalImageInternal(context.Context, *EnrichLocalImageInternalRequest) (*ScanImageInternalResponse, error)
 	// UpdateLocalScanStatusInternal is used solely by Sensor to send delegated scanning errors to central that
-	// prevent local enrichment from occuring (such as no scanner, thorttled, etc.).
+	// prevent local enrichment from occurring (such as no scanner, throttled, etc.).
 	UpdateLocalScanStatusInternal(context.Context, *UpdateLocalScanStatusInternalRequest) (*Empty, error)
 	// InvalidateScanAndRegistryCaches removes the image metadata cache.
 	InvalidateScanAndRegistryCaches(context.Context, *Empty) (*Empty, error)

--- a/pkg/env/sensor.go
+++ b/pkg/env/sensor.go
@@ -37,4 +37,9 @@ var (
 
 	// ScanTimeout defines the scan timeout duration for Sensor initiated scans
 	ScanTimeout = registerDurationSetting("ROX_SCAN_TIMEOUT", 6*time.Minute)
+
+	// DelegatedScanningDisabled disables the data collection (ie: secrets) and capabilities associated with delegated
+	// image scanning. This is meant to be 'kill switch' that allows for local scanning (ie: for OCP internal repos)
+	// to continue in the event the delegated scanning capabilities are causing unforeseen issues.
+	DelegatedScanningDisabled = RegisterBooleanSetting("ROX_DELEGATED_SCANNING_DISABLED", false)
 )

--- a/pkg/env/sensor.go
+++ b/pkg/env/sensor.go
@@ -38,8 +38,8 @@ var (
 	// ScanTimeout defines the scan timeout duration for Sensor initiated scans
 	ScanTimeout = registerDurationSetting("ROX_SCAN_TIMEOUT", 6*time.Minute)
 
-	// DelegatedScanningDisabled disables the data collection (ie: secrets) and capabilities associated with delegated
-	// image scanning. This is meant to be 'kill switch' that allows for local scanning (ie: for OCP internal repos)
-	// to continue in the event the delegated scanning capabilities are causing unforeseen issues.
+	// DelegatedScanningDisabled disables the capabilities associated with delegated image scanning.
+	// This is meant to be a 'kill switch' that allows for local scanning to continue (ie: for OCP internal repos)
+	// in the event the delegated scanning capabilities are causing unforeseen issues.
 	DelegatedScanningDisabled = RegisterBooleanSetting("ROX_DELEGATED_SCANNING_DISABLED", false)
 )

--- a/pkg/images/enricher/enricher_impl.go
+++ b/pkg/images/enricher/enricher_impl.go
@@ -147,7 +147,7 @@ func (e *enricherImpl) delegateEnrichImage(ctx context.Context, enrichCtx Enrich
 	// Ignores in-mem metadata cache because that is not populated via
 	// enrichment requests from secured clusters. fetchFromDatabase will check
 	// if FetchOpt forces refetch. Assumes signatures in DB are OK, reprocessing
-	// or forcing re-scan  will trigger updates as necessary.
+	// or forcing re-scan will trigger updates as necessary.
 	existingImg, exists := e.fetchFromDatabase(ctx, image, enrichCtx.FetchOpt)
 	if exists && cachedImageIsValid(existingImg) {
 		image.Metadata = existingImg.GetMetadata()

--- a/pkg/waiter/waiter_test.go
+++ b/pkg/waiter/waiter_test.go
@@ -22,7 +22,7 @@ func TestStringWaiter(t *testing.T) {
 
 	got, err := w.Wait(context.Background())
 	assert.NoError(t, err)
-	assert.Equal(t, got, want)
+	assert.Equal(t, want, got)
 }
 
 func TestStructWaiter(t *testing.T) {
@@ -41,7 +41,7 @@ func TestStructWaiter(t *testing.T) {
 
 	got, err := w.Wait(context.Background())
 	assert.NoError(t, err)
-	assert.Equal(t, got.msg, want.msg)
+	assert.Equal(t, want.msg, got.msg)
 }
 
 func TestPointerWaiter(t *testing.T) {
@@ -60,10 +60,7 @@ func TestPointerWaiter(t *testing.T) {
 
 	got, err := w.Wait(context.Background())
 	assert.NoError(t, err)
-	assert.Equal(t, got, want)
-	if got != want {
-		t.Errorf("%p != %p", got, want)
-	}
+	assert.Equal(t, want, got)
 }
 
 func TestWaitCancel(t *testing.T) {
@@ -86,7 +83,7 @@ func TestWaitCancel(t *testing.T) {
 
 	// allow time for manager to cleanup canceled waiters
 	time.Sleep(100 * time.Millisecond)
-	assert.Equal(t, wm.len(), 0)
+	assert.Equal(t, 0, wm.len())
 }
 
 func TestWaitClose(t *testing.T) {
@@ -105,13 +102,13 @@ func TestWaitClose(t *testing.T) {
 		assert.ErrorIs(t, err, ErrWaiterClosed)
 	}()
 
-	assert.Equal(t, wm.len(), 1)
+	assert.Equal(t, 1, wm.len())
 	w.Close()
 	wg.Wait()
 
 	// allow time for manager to cleanup closed waiters
 	time.Sleep(200 * time.Millisecond)
-	assert.Equal(t, wm.len(), 0)
+	assert.Equal(t, 0, wm.len())
 }
 
 func TestCloseManager(t *testing.T) {
@@ -161,6 +158,8 @@ func TestCloseManagerMany(t *testing.T) {
 	}()
 
 	wg.Wait()
+
+	assert.Equal(t, 0, wm.len())
 }
 
 func TestSendToClosedWaiter(t *testing.T) {

--- a/proto/api/v1/delegated_registry_config_service.proto
+++ b/proto/api/v1/delegated_registry_config_service.proto
@@ -34,9 +34,9 @@ message DelegatedRegistryConfig {
 
     message DelegatedRegistry {
         // Registry + optional path, ie: quay.example.com/prod
-        string path = 1;
+        string path       = 1;
         // ID of the cluster to delegate ad-hoc requests to
-        string cluster_id    = 2;
+        string cluster_id = 2;
     }
 
     // Determines if delegation is enabled for no registries, all registries, or specific registries

--- a/proto/api/v1/image_service.proto
+++ b/proto/api/v1/image_service.proto
@@ -179,7 +179,7 @@ service ImageService {
     rpc EnrichLocalImageInternal (EnrichLocalImageInternalRequest) returns (ScanImageInternalResponse);
 
     // UpdateLocalScanStatusInternal is used solely by Sensor to send delegated scanning errors to central that
-    // prevent local enrichment from occuring (such as no scanner, thorttled, etc.).
+    // prevent local enrichment from occurring (such as no scanner, throttled, etc.).
     rpc UpdateLocalScanStatusInternal (UpdateLocalScanStatusInternalRequest) returns (Empty);
 
     // InvalidateScanAndRegistryCaches removes the image metadata cache.

--- a/proto/storage/delegated_registry_config.proto
+++ b/proto/storage/delegated_registry_config.proto
@@ -18,8 +18,8 @@ message DelegatedRegistryConfig {
     }
 
     message DelegatedRegistry {
-        string path = 1;
-        string cluster_id    = 2;
+        string path       = 1;
+        string cluster_id = 2;
     }
 
     EnabledFor                 enabled_for        = 1;

--- a/sensor/common/delegatedregistry/delegated_registry_handler.go
+++ b/sensor/common/delegatedregistry/delegated_registry_handler.go
@@ -23,6 +23,8 @@ var (
 
 	scanTimeout         = env.ScanTimeout.DurationSetting()
 	statusUpdateTimeout = 10 * time.Second
+
+	enabled = env.LocalImageScanningEnabled.BooleanSetting() && !env.DelegatedScanningDisabled.BooleanSetting()
 )
 
 // Handler is responsible for processing delegated registry related requests
@@ -48,8 +50,7 @@ func NewHandler(registryStore *registry.Store, localScan *scan.LocalScan) Handle
 }
 
 func (d *delegatedRegistryImpl) Capabilities() []centralsensor.SensorCapability {
-	if !env.LocalImageScanningEnabled.BooleanSetting() {
-		// Do not advertise the capability if local scanning is disabled.
+	if !enabled {
 		return nil
 	}
 
@@ -59,8 +60,7 @@ func (d *delegatedRegistryImpl) Capabilities() []centralsensor.SensorCapability 
 func (d *delegatedRegistryImpl) Notify(_ common.SensorComponentEvent) {}
 
 func (d *delegatedRegistryImpl) ProcessMessage(msg *central.MsgToSensor) error {
-	if !env.LocalImageScanningEnabled.BooleanSetting() {
-		// Ignore all messages if local scanning is disabled.
+	if !enabled {
 		return nil
 	}
 

--- a/sensor/kubernetes/listener/resources/secrets.go
+++ b/sensor/kubernetes/listener/resources/secrets.go
@@ -289,7 +289,7 @@ func (s *secretDispatcher) processDockerConfigEvent(secret, oldSecret *v1.Secret
 				}
 			}
 
-			if env.LocalImageScanningEnabled.BooleanSetting() {
+			if env.LocalImageScanningEnabled.BooleanSetting() && !env.DelegatedScanningDisabled.BooleanSetting() {
 				// Store registry secrets to enable downstream scanning of all images
 				//
 				// This is only triggered when saName is empty so that we do not overwrite entries inserted

--- a/sensor/kubernetes/listener/resources/secrets_test.go
+++ b/sensor/kubernetes/listener/resources/secrets_test.go
@@ -181,6 +181,7 @@ func TestForceLocalScanning(t *testing.T) {
 	}
 
 	t.Setenv(env.LocalImageScanningEnabled.EnvVar(), "false")
+	t.Setenv(env.DelegatedScanningDisabled.EnvVar(), "false")
 
 	// with feature disabled, registry secret should NOT be stored
 	regStore := registry.NewRegistryStore(alwaysInsecureCheckTLS)
@@ -192,6 +193,19 @@ func TestForceLocalScanning(t *testing.T) {
 	assert.Error(t, err)
 
 	t.Setenv(env.LocalImageScanningEnabled.EnvVar(), "true")
+	t.Setenv(env.DelegatedScanningDisabled.EnvVar(), "true")
+
+	// with delegated scanning disabled, registry secret should NOT be stored
+	regStore = registry.NewRegistryStore(alwaysInsecureCheckTLS)
+	d = newSecretDispatcher(regStore)
+
+	d.ProcessEvent(dockerConfigSecret, nil, central.ResourceAction_CREATE_RESOURCE)
+	reg, err = regStore.GetRegistryForImageInNamespace(fakeImage, fakeNamespace)
+	assert.Nil(t, reg)
+	assert.Error(t, err)
+
+	t.Setenv(env.LocalImageScanningEnabled.EnvVar(), "true")
+	t.Setenv(env.DelegatedScanningDisabled.EnvVar(), "false")
 
 	// feature is enabled, registry secret should be stored
 	d.ProcessEvent(dockerConfigSecret, nil, central.ResourceAction_CREATE_RESOURCE)


### PR DESCRIPTION
## Description

Adds an environment variable that disables the capabilities and secret storage associated with delegated image scanning.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] Evaluated and added CHANGELOG entry if required
- [x] Determined and documented upgrade steps
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed
Unit testing, local deployment. 

Verified logs show additional registries are not be upserted, Central does not show the cluster as a valid delegation target, and ad-hoc requests for image scanning to the cluster encounter error as expected.

## PR Stack
- **This PR** - https://github.com/stackrox/stackrox/pull/6311
- https://github.com/stackrox/stackrox/pull/6277
- https://github.com/stackrox/stackrox/pull/6229
- https://github.com/stackrox/stackrox/pull/6186
- https://github.com/stackrox/stackrox/pull/6005
- https://github.com/stackrox/stackrox/pull/5951
