### PR TITLE
Logger PKG / Line Nums

### DIFF
--- a/pkg/logging/module.go
+++ b/pkg/logging/module.go
@@ -21,7 +21,7 @@ var (
 
 // CurrentModule returns the module corresponding to the caller.
 func CurrentModule() *Module {
-	return currentModule(3)
+	return currentModule(4)
 }
 
 func currentModule(skip int) *Module {
@@ -63,7 +63,7 @@ func newModule(name string, logLevel zap.AtomicLevel) *Module {
 
 // Logger returns a new logger for m.
 func (m *Module) Logger() *LoggerImpl {
-	return CreateLogger(m, 0)
+	return CreateLogger(m, 1)
 }
 
 // Name returns the name of m


### PR DESCRIPTION
## Description

Attempt to fix logging of appropriate pkg and line nums. 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed
Created a dummy unit test (sensor/common/scan/dignore_test.go) and ran with LOGLEVEL=DEBUG and `go test -v ...`, the log lines seem to be appropriate now:

```go
package scan

import "testing"

func TestLogger(t *testing.T) {
	log.Debug("hi")
	log.Info("hi")
	log.Warn("hi")
	log.Error("hi")
}
```
Before
```
pkg/logging: 2023/06/04 09:26:44.146460 /Users/dcaravel/dev/stackrox/stackrox/sensor/common/scan/logger.go:181: Debug: hi
pkg/logging: 2023/06/04 09:26:44.146681 /Users/dcaravel/dev/stackrox/stackrox/sensor/common/scan/logger.go:165: Info: hi
pkg/logging: 2023/06/04 09:26:44.146711 /Users/dcaravel/dev/stackrox/stackrox/sensor/common/scan/logger.go:149: Warn: hi
pkg/logging: 2023/06/04 09:26:44.146838 /Users/dcaravel/dev/stackrox/stackrox/sensor/common/scan/logger.go:133: Error: hi
```

After
```
common/scan: 2023/06/04 09:28:32.676992 /Users/dcaravel/dev/stackrox/stackrox/sensor/common/scan/dignore_test.go:6: Debug: hi
common/scan: 2023/06/04 09:28:32.677135 /Users/dcaravel/dev/stackrox/stackrox/sensor/common/scan/dignore_test.go:7: Info: hi
common/scan: 2023/06/04 09:28:32.677161 /Users/dcaravel/dev/stackrox/stackrox/sensor/common/scan/dignore_test.go:8: Warn: hi
common/scan: 2023/06/04 09:28:32.677224 /Users/dcaravel/dev/stackrox/stackrox/sensor/common/scan/dignore_test.go:9: Error: hi
```
