### PR TITLE
ROX-17526: Move fallback for any groupBy category that is not a resourceLabel

### DIFF
--- a/ui/apps/platform/src/Containers/Compliance/List/Table.js
+++ b/ui/apps/platform/src/Containers/Compliance/List/Table.js
@@ -298,6 +298,7 @@ const ListTable = ({
                         // Resouces: CLUSTER, NAMESPACE, NODE, DEPLOYMENT.
                         // Or CATEGORY from View Standard link of sunburst graph on dashboard.
                         // Or STANDARD on Controls tab of resource single page.
+                        // Otherwise undefined.
                         const groupedByText = groupBy
                             ? `across ${tableData.length} ${pluralize(
                                   resourceLabels[groupBy] ?? groupBy.toLowerCase(),


### PR DESCRIPTION
## Description

Follow up incorrect correction in #6305

The cure was as bad as the disease.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

### Integration testing

1. `yarn cypress-open` in ui/apps/platform

    * compliance/complianceDashboard.test.js
    * compliance/complianceList.test.js