### PR TITLE
Additional minor fixes for Workload CVEs

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePageHeader.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePageHeader.tsx
@@ -62,7 +62,10 @@ export type ImageCvePageHeaderProps = {
 };
 
 function ImageCvePageHeader({ data }: ImageCvePageHeaderProps) {
-    const prioritizedDistros = uniqBy(sortCveDistroList(data?.distroTuples ?? []), 'distro');
+    const prioritizedDistros = uniqBy(
+        sortCveDistroList(data?.distroTuples ?? []),
+        getDistroLinkText
+    );
     return data ? (
         <Flex direction={{ default: 'column' }} alignItems={{ default: 'alignItemsFlexStart' }}>
             <Title headingLevel="h1" className="pf-u-mb-sm">

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx
@@ -38,6 +38,7 @@ export const deploymentWithVulnerabilitiesFragment = gql`
             ...ImageMetadataContext
         }
         imageVulnerabilities(query: $query, pagination: $pagination) {
+            vulnerabilityId: id
             cve
             summary
             images(query: $query) {
@@ -54,6 +55,7 @@ export type DeploymentWithVulnerabilities = {
     id: string;
     images: ImageMetadataContext[];
     imageVulnerabilities: {
+        vulnerabilityId: string;
         cve: string;
         summary: string;
         images: {
@@ -69,6 +71,7 @@ type DeploymentVulnerabilityImageMapping = {
 };
 
 function formatVulnerabilityData(deployment: DeploymentWithVulnerabilities): {
+    vulnerabilityId: string;
     cve: string;
     severity: VulnerabilitySeverity;
     isFixable: boolean;
@@ -85,7 +88,7 @@ function formatVulnerabilityData(deployment: DeploymentWithVulnerabilities): {
     });
 
     return deployment.imageVulnerabilities.map((vulnerability) => {
-        const { cve, summary, images } = vulnerability;
+        const { vulnerabilityId, cve, summary, images } = vulnerability;
         // Severity, Fixability, and Discovered date are all based on the aggregate value of all components
         const allVulnerableComponents = vulnerability.images.flatMap((img) => img.imageComponents);
         const highestVulnSeverity = getHighestVulnerabilitySeverity(allVulnerableComponents);
@@ -113,6 +116,7 @@ function formatVulnerabilityData(deployment: DeploymentWithVulnerabilities): {
             );
 
         return {
+            vulnerabilityId,
             cve,
             severity: highestVulnSeverity,
             isFixable: isAnyVulnFixable,
@@ -160,6 +164,7 @@ function DeploymentVulnerabilitiesTable({
             {vulnerabilities.length === 0 && <EmptyTableResults colSpan={7} />}
             {vulnerabilities.map((vulnerability, rowIndex) => {
                 const {
+                    vulnerabilityId,
                     cve,
                     severity,
                     summary,
@@ -171,7 +176,7 @@ function DeploymentVulnerabilitiesTable({
                 const isExpanded = expandedRowSet.has(cve);
 
                 return (
-                    <Tbody key={cve} isExpanded={isExpanded}>
+                    <Tbody key={vulnerabilityId} isExpanded={isExpanded}>
                         <Tr>
                             <Td
                                 expand={{


### PR DESCRIPTION
## Description

A few more minor fixes I found when testing against stagingdb:

- Re-adds the `vulnerabilityId` field to vulns on the deployment page. Previously this used `cve` as the React key, which isn't unique in a deployment context. We need the `id`, which is cve + operating system.
- Fixes another error with duplicate CVE links on the ImageCVE page. This was de-duping links by OS, but since `rhel` and `centos` use the same link and text it was causing doubles on pages with cves using both images. Now it de-dups on the link text, ensuring that we only get a single instance of each type of link

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Manual
