### PR TITLE
ROX-17020: Add descriptions below policy event source options in form

### DIFF
--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step2/PolicyBehaviorForm.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step2/PolicyBehaviorForm.tsx
@@ -38,6 +38,18 @@ type PolicyBehaviorFormProps = {
     hasActiveViolations: boolean;
 };
 
+function getEventSourceHelperText(eventSource) {
+    if (eventSource === 'DEPLOYMENT_EVENT') {
+        return 'Event sources that include process and network activity, pod exec and pod port forwarding.';
+    }
+
+    if (eventSource === 'AUDIT_LOG_EVENT') {
+        return 'Event sources that match Kubernetes audit log records.';
+    }
+
+    return '';
+}
+
 function PolicyBehaviorForm({ hasActiveViolations }: PolicyBehaviorFormProps) {
     const { values, setFieldValue, setValues } = useFormikContext<ClientPolicy>();
     const [lifeCycleChange, setLifeCycleChange] = useState<{
@@ -123,6 +135,8 @@ function PolicyBehaviorForm({ hasActiveViolations }: PolicyBehaviorFormProps) {
         const clearedCriteria = cloneDeep(initialPolicy.policySections);
         setFieldValue('policySections', clearedCriteria, false);
     }
+
+    const eventSourceHelperText = getEventSourceHelperText(values.eventSource);
 
     const responseMethodHelperText = showEnforcement
         ? 'Inform and enforce will execute enforcement behavior at the stages you select.'
@@ -234,6 +248,7 @@ function PolicyBehaviorForm({ hasActiveViolations }: PolicyBehaviorFormProps) {
                         fieldId="policy-event-source"
                         label="Event sources (Runtime lifecycle only)"
                         isRequired={hasRuntime}
+                        helperText={eventSourceHelperText}
                     >
                         <Flex direction={{ default: 'row' }}>
                             <Radio


### PR DESCRIPTION
## Description

Adding descriptions as helper text below the radio buttons for the two types of event source for RUNTIME lifecycle in the Policy behavior form step.

## Checklist
- [x] Investigated and inspected CI test results (ui-e2e failures are unrelated false positives introduced by another change)

## Testing Performed

RUNTIME not selected, then no helper text (existing behavior)
![Screen Shot 2023-06-05 at 11 31 57 AM](https://github.com/stackrox/stackrox/assets/715729/b82af7b2-3e7c-47ad-a915-61e109f12cec)

RUNTIME selected, and Deployment Event Source selected
![Screen Shot 2023-06-05 at 11 32 03 AM](https://github.com/stackrox/stackrox/assets/715729/6718cd1a-8eb8-46ae-afb4-f661cd38a725)

RUNTIME selected, and Audit Logs Event Source selected
![Screen Shot 2023-06-05 at 11 32 07 AM](https://github.com/stackrox/stackrox/assets/715729/2a13f2df-88c5-4a06-bc97-6e93a2a3d654)


