### PR TITLE
ROX-17547: Set max fan out for unique processes to 5k in Central and max in Sensor

### DIFF
--- a/central/deployment/datastore/datastore_impl_test.go
+++ b/central/deployment/datastore/datastore_impl_test.go
@@ -46,7 +46,7 @@ func (suite *DeploymentDataStoreTestSuite) SetupTest() {
 	suite.indexer = indexerMocks.NewMockIndexer(mockCtrl)
 	suite.searcher = searcherMocks.NewMockSearcher(mockCtrl)
 	suite.riskStore = riskMocks.NewMockDataStore(mockCtrl)
-	suite.filter = filter.NewFilter(5, []int{5, 4, 3, 2, 1})
+	suite.filter = filter.NewFilter(5, 5, []int{5, 4, 3, 2, 1})
 }
 
 func (suite *DeploymentDataStoreTestSuite) TearDownTest() {

--- a/central/pod/datastore/datastore_bench_test.go
+++ b/central/pod/datastore/datastore_bench_test.go
@@ -43,7 +43,7 @@ func BenchmarkSearchAllPods(b *testing.B) {
 	podsStore := rocksStore.New(db)
 	podsIndexer := index.New(bleveIndex)
 	podsSearcher := search.New(podsStore, podsIndexer)
-	simpleFilter := filter.NewFilter(5, []int{5, 4, 3, 2, 1})
+	simpleFilter := filter.NewFilter(5, 5, []int{5, 4, 3, 2, 1})
 
 	podsDatastore, err := newDatastoreImpl(ctx, podsStore, podsIndexer, podsSearcher, nil, simpleFilter)
 	require.NoError(b, err)

--- a/central/pod/datastore/datastore_impl_test.go
+++ b/central/pod/datastore/datastore_impl_test.go
@@ -49,7 +49,7 @@ func (suite *PodDataStoreTestSuite) SetupTest() {
 	suite.indexer = indexerMocks.NewMockIndexer(mockCtrl)
 	suite.searcher = searcherMocks.NewMockSearcher(mockCtrl)
 	suite.processStore = indicatorMocks.NewMockDataStore(mockCtrl)
-	suite.filter = filter.NewFilter(5, []int{5, 4, 3, 2, 1})
+	suite.filter = filter.NewFilter(5, 5, []int{5, 4, 3, 2, 1})
 
 	var err error
 	if !env.PostgresDatastoreEnabled.BooleanSetting() {

--- a/central/processindicator/filter/singleton.go
+++ b/central/processindicator/filter/singleton.go
@@ -1,8 +1,7 @@
 package filter
 
 import (
-	"math"
-
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/process/filter"
 	"github.com/stackrox/rox/pkg/sync"
 )
@@ -14,6 +13,8 @@ const (
 var (
 	singletonInstance sync.Once
 
+	maxUniqueProcesses = env.ProcessFilterMaxProcessPaths.IntegerSetting()
+
 	bucketSizes     = []int{8, 6, 4, 2}
 	singletonFilter filter.Filter
 )
@@ -21,8 +22,7 @@ var (
 // Singleton returns a global, threadsafe process filter
 func Singleton() filter.Filter {
 	singletonInstance.Do(func() {
-		// Set the maximum number of paths to the max integer in order to not filter out new processes in Sensor
-		singletonFilter = filter.NewFilter(maxExactPathMatches, math.MaxInt, bucketSizes)
+		singletonFilter = filter.NewFilter(maxExactPathMatches, maxUniqueProcesses, bucketSizes)
 	})
 	return singletonFilter
 }

--- a/central/processindicator/filter/singleton.go
+++ b/central/processindicator/filter/singleton.go
@@ -1,6 +1,8 @@
 package filter
 
 import (
+	"math"
+
 	"github.com/stackrox/rox/pkg/process/filter"
 	"github.com/stackrox/rox/pkg/sync"
 )
@@ -19,7 +21,8 @@ var (
 // Singleton returns a global, threadsafe process filter
 func Singleton() filter.Filter {
 	singletonInstance.Do(func() {
-		singletonFilter = filter.NewFilter(maxExactPathMatches, bucketSizes)
+		// Set the maximum number of paths to the max integer in order to not filter out new processes in Sensor
+		singletonFilter = filter.NewFilter(maxExactPathMatches, math.MaxInt, bucketSizes)
 	})
 	return singletonFilter
 }

--- a/central/reprocessor/reprocessor_test.go
+++ b/central/reprocessor/reprocessor_test.go
@@ -58,7 +58,7 @@ func TestGetActiveImageIDs(t *testing.T) {
 
 		imageDS = imageDatastore.NewWithPostgres(imagePG.New(pool, false, dackboxConcurrency.NewKeyFence()), imagePG.NewIndexer(pool), nil, ranking.ImageRanker(), ranking.ComponentRanker())
 		deploymentsDS, err = deploymentDatastore.New(nil, dackboxConcurrency.NewKeyFence(), pool, nil, nil, nil, nil, nil, nil,
-			nil, filter.NewFilter(5, []int{5}), ranking.NewRanker(), ranking.NewRanker(), ranking.NewRanker())
+			nil, filter.NewFilter(5, 5, []int{5}), ranking.NewRanker(), ranking.NewRanker(), ranking.NewRanker())
 		require.NoError(t, err)
 	} else {
 		rocksDB := rocksdbtest.RocksDBForT(t)
@@ -84,7 +84,7 @@ func TestGetActiveImageIDs(t *testing.T) {
 		imageDS = imageDatastore.New(dacky, dackboxConcurrency.NewKeyFence(), bleveIndex, bleveIndex, false, nil, ranking.NewRanker(), ranking.NewRanker())
 
 		deploymentsDS, err = deploymentDatastore.New(dacky, dackboxConcurrency.NewKeyFence(), nil, bleveIndex, bleveIndex, nil, nil, nil, nil,
-			nil, filter.NewFilter(5, []int{5}), ranking.NewRanker(), ranking.NewRanker(), ranking.NewRanker())
+			nil, filter.NewFilter(5, 5, []int{5}), ranking.NewRanker(), ranking.NewRanker(), ranking.NewRanker())
 		require.NoError(t, err)
 	}
 

--- a/pkg/env/integersetting.go
+++ b/pkg/env/integersetting.go
@@ -10,6 +10,7 @@ import (
 type IntegerSetting struct {
 	envVar       string
 	defaultValue int
+	isSet        bool
 }
 
 // EnvVar returns the string name of the environment variable

--- a/pkg/env/integersetting.go
+++ b/pkg/env/integersetting.go
@@ -10,7 +10,6 @@ import (
 type IntegerSetting struct {
 	envVar       string
 	defaultValue int
-	isSet        bool
 }
 
 // EnvVar returns the string name of the environment variable

--- a/pkg/env/process_filter_max_paths.go
+++ b/pkg/env/process_filter_max_paths.go
@@ -1,0 +1,6 @@
+package env
+
+var (
+	// ProcessFilterMaxProcessPaths sets the maximum number of process filter unique paths
+	ProcessFilterMaxProcessPaths = RegisterIntegerSetting("ROX_PROCESS_FILTER_MAX_PROCESS_PATHS", 5000)
+)

--- a/pkg/process/filter/filter.go
+++ b/pkg/process/filter/filter.go
@@ -124,13 +124,12 @@ func (f *filterImpl) Add(indicator *storage.ProcessIndicator) bool {
 
 	rootLevel := f.getOrAddRootLevelNoLock(indicator)
 
-	if len(rootLevel.children) >= f.maxUniqueProcesses {
-		return false
-	}
-
 	// Handle the process level independently as we will never reject a new process
 	processLevel := rootLevel.children[indicator.GetSignal().GetExecFilePath()]
 	if processLevel == nil {
+		if len(rootLevel.children) >= f.maxUniqueProcesses {
+			return false
+		}
 		processLevel = newLevel()
 		rootLevel.children[indicator.GetSignal().GetExecFilePath()] = processLevel
 	}

--- a/pkg/process/filter/filter.go
+++ b/pkg/process/filter/filter.go
@@ -124,14 +124,15 @@ func (f *filterImpl) Add(indicator *storage.ProcessIndicator) bool {
 
 	rootLevel := f.getOrAddRootLevelNoLock(indicator)
 
+	if len(rootLevel.children) >= f.maxUniqueProcesses {
+		return false
+	}
+
 	// Handle the process level independently as we will never reject a new process
 	processLevel := rootLevel.children[indicator.GetSignal().GetExecFilePath()]
 	if processLevel == nil {
 		processLevel = newLevel()
 		rootLevel.children[indicator.GetSignal().GetExecFilePath()] = processLevel
-	}
-	if len(rootLevel.children) > f.maxUniqueProcesses {
-		return false
 	}
 
 	return f.siftNoLock(processLevel, strings.Fields(indicator.GetSignal().GetArgs()), 0)

--- a/pkg/process/filter/filter_test.go
+++ b/pkg/process/filter/filter_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestBasicFilterFunctions(t *testing.T) {
-	filter := NewFilter(2, []int{3, 2, 1})
+	filter := NewFilter(2, 2, []int{3, 2, 1})
 
 	pi := fixtures.GetProcessIndicator()
 	assert.True(t, filter.Add(pi))
@@ -71,7 +71,7 @@ func TestBasicFilter(t *testing.T) {
 	for _, c := range cases {
 		currCase := c
 		t.Run(currCase.name, func(t *testing.T) {
-			filter := NewFilter(2, []int{3, 2, 1})
+			filter := NewFilter(2, 2, []int{3, 2, 1})
 			for i, arg := range currCase.args {
 				result := filter.Add(&storage.ProcessIndicator{
 					PodId:         "pod",
@@ -89,7 +89,7 @@ func TestBasicFilter(t *testing.T) {
 }
 
 func TestMultiProcessFilter(t *testing.T) {
-	filter := NewFilter(2, []int{3, 2, 1})
+	filter := NewFilter(2, 2, []int{3, 2, 1})
 
 	// Ensure that different (pod, container name) pairs are isolated
 	pi := fixtures.GetProcessIndicator()
@@ -103,8 +103,22 @@ func TestMultiProcessFilter(t *testing.T) {
 	assert.False(t, filter.Add(pi))
 }
 
+func TestMaxFilePaths(t *testing.T) {
+	filter := NewFilter(2, 2, []int{3, 2, 1})
+
+	// Ensure that different (pod, container name) pairs are isolated
+	pi := fixtures.GetProcessIndicator()
+	assert.True(t, filter.Add(pi))
+
+	pi.Signal.Name = "signal2"
+	assert.True(t, filter.Add(pi))
+
+	pi.Signal.Name = "signal3"
+	assert.False(t, filter.Add(pi))
+}
+
 func TestPodUpdate(t *testing.T) {
-	filter := NewFilter(2, []int{3, 2, 1}).(*filterImpl)
+	filter := NewFilter(2, 2, []int{3, 2, 1}).(*filterImpl)
 
 	pi := fixtures.GetProcessIndicator()
 	filter.Add(pi)
@@ -129,7 +143,7 @@ func TestPodUpdate(t *testing.T) {
 }
 
 func TestPodUpdateWithInstanceTruncation(t *testing.T) {
-	filter := NewFilter(2, []int{3, 2, 1}).(*filterImpl)
+	filter := NewFilter(2, 2, []int{3, 2, 1}).(*filterImpl)
 
 	pi := fixtures.GetProcessIndicator()
 	pi.Signal.ContainerId = "0123456789ab"

--- a/sensor/common/processfilter/filter.go
+++ b/sensor/common/processfilter/filter.go
@@ -1,6 +1,7 @@
 package processfilter
 
 import (
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/process/filter"
 	"github.com/stackrox/rox/pkg/sync"
 )
@@ -12,6 +13,8 @@ const (
 var (
 	singletonInstance sync.Once
 
+	maxUniqueProcesses = env.ProcessFilterMaxProcessPaths.IntegerSetting()
+
 	bucketSizes     = []int{8, 6, 4, 2}
 	singletonFilter filter.Filter
 )
@@ -19,7 +22,7 @@ var (
 // Singleton returns a global, threadsafe process filter
 func Singleton() filter.Filter {
 	singletonInstance.Do(func() {
-		singletonFilter = filter.NewFilter(maxExactPathMatches, bucketSizes)
+		singletonFilter = filter.NewFilter(maxExactPathMatches, maxUniqueProcesses, bucketSizes)
 	})
 	return singletonFilter
 }

--- a/sensor/common/processfilter/filter.go
+++ b/sensor/common/processfilter/filter.go
@@ -1,7 +1,8 @@
 package processfilter
 
 import (
-	"github.com/stackrox/rox/pkg/env"
+	"math"
+
 	"github.com/stackrox/rox/pkg/process/filter"
 	"github.com/stackrox/rox/pkg/sync"
 )
@@ -13,8 +14,6 @@ const (
 var (
 	singletonInstance sync.Once
 
-	maxUniqueProcesses = env.ProcessFilterMaxProcessPaths.IntegerSetting()
-
 	bucketSizes     = []int{8, 6, 4, 2}
 	singletonFilter filter.Filter
 )
@@ -22,7 +21,8 @@ var (
 // Singleton returns a global, threadsafe process filter
 func Singleton() filter.Filter {
 	singletonInstance.Do(func() {
-		singletonFilter = filter.NewFilter(maxExactPathMatches, maxUniqueProcesses, bucketSizes)
+		// Set the maximum number of paths to the max integer in order to not filter out new processes in Sensor
+		singletonFilter = filter.NewFilter(maxExactPathMatches, math.MaxInt, bucketSizes)
 	})
 	return singletonFilter
 }

--- a/sensor/common/processsignal/pipeline_test.go
+++ b/sensor/common/processsignal/pipeline_test.go
@@ -23,7 +23,7 @@ func TestProcessPipeline(t *testing.T) {
 	mockStore := clusterentities.NewStore()
 	mockDetector := mocks.NewMockDetector(mockCtrl)
 
-	p := NewProcessPipeline(sensorEvents, mockStore, filter.NewFilter(5, []int{10, 10, 10}),
+	p := NewProcessPipeline(sensorEvents, mockStore, filter.NewFilter(5, 5, []int{10, 10, 10}),
 		mockDetector)
 	closeChan := make(chan bool)
 


### PR DESCRIPTION
## Description

For environments that are running random / consistently unique processes, cap the process filter in Central to 5k, but leave Sensor's uncapped to avoid missing process alerts due to caps

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Unit tests