### PR TITLE
ROX-17539: Add central capabilities to redux

### DIFF
--- a/ui/apps/platform/src/Containers/MainPage/MainPage.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/MainPage.tsx
@@ -46,6 +46,7 @@ function MainPage(): ReactElement {
     const { isFeatureFlagEnabled, isLoadingFeatureFlags } = useFeatureFlags();
     const { hasReadAccess, hasReadWriteAccess, isLoadingPermissions } = usePermissions();
     const isLoadingPublicConfig = useSelector(selectors.isLoadingPublicConfigSelector);
+    const isLoadingCentralCapabilities = useSelector(selectors.getIsLoadingCentralCapabilities);
 
     // Check for clusters under management
     // if none, and user can admin Clusters, redirect to clusters section
@@ -64,7 +65,12 @@ function MainPage(): ReactElement {
     // feature flags: for NavigationSidebar and Body
     // permissions: for NavigationSidebar and Body
     // public config: for PublicConfigHeader and PublicConfigFooter and analytics
-    if (isLoadingFeatureFlags || isLoadingPermissions || isLoadingPublicConfig) {
+    if (
+        isLoadingFeatureFlags ||
+        isLoadingPermissions ||
+        isLoadingPublicConfig ||
+        isLoadingCentralCapabilities
+    ) {
         return <LoadingSection message="Loading..." />;
     }
 

--- a/ui/apps/platform/src/hooks/useCentralCapabilities.ts
+++ b/ui/apps/platform/src/hooks/useCentralCapabilities.ts
@@ -14,12 +14,12 @@ function useCentralCapabilities(): UseCentralCapabilityResult {
     const isCentralCapabilityAvailable = useMemo(
         () =>
             (centralCapabilityFlag: CentralCapabilitiesFlags): boolean => {
-                const centralCapacity = centralCapabilities[centralCapabilityFlag];
-                if (centralCapacity === 'CapabilityAvailable') {
-                    return true;
+                const centralCapabilitiesStatus = centralCapabilities[centralCapabilityFlag];
+                if (centralCapabilitiesStatus === 'CapabilityDisabled') {
+                    return false;
                 }
 
-                return false;
+                return true;
             },
         [centralCapabilities]
     );

--- a/ui/apps/platform/src/hooks/useCentralCapabilities.ts
+++ b/ui/apps/platform/src/hooks/useCentralCapabilities.ts
@@ -1,0 +1,30 @@
+import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
+
+import { selectors } from 'reducers';
+import { CentralCapabilitiesFlags } from 'services/MetadataService';
+
+type UseCentralCapabilityResult = {
+    isCentralCapabilityAvailable: (centralCapabilityFlag: CentralCapabilitiesFlags) => boolean;
+};
+
+function useCentralCapabilities(): UseCentralCapabilityResult {
+    const centralCapabilities = useSelector(selectors.getCentralCapabilities);
+
+    const isCentralCapabilityAvailable = useMemo(
+        () =>
+            (centralCapabilityFlag: CentralCapabilitiesFlags): boolean => {
+                const centralCapacity = centralCapabilities[centralCapabilityFlag];
+                if (centralCapacity === 'CapabilityAvailable') {
+                    return true;
+                }
+
+                return false;
+            },
+        [centralCapabilities]
+    );
+
+    return { isCentralCapabilityAvailable };
+}
+
+export default useCentralCapabilities;

--- a/ui/apps/platform/src/index.tsx
+++ b/ui/apps/platform/src/index.tsx
@@ -38,6 +38,7 @@ import installRaven from 'installRaven';
 import { ThunkAction, ThunkDispatch } from 'redux-thunk';
 import { fetchFeatureFlagsThunk } from './reducers/featureFlags';
 import { fetchPublicConfigThunk } from './reducers/publicConfig';
+import { fetchCentralCapabilitiesThunk } from './reducers/centralCapabilities';
 import configureApollo from './configureApolloClient';
 
 // This enables syntax highlighting for the patternfly code editor
@@ -71,6 +72,7 @@ const dispatch = (action) =>
 
 dispatch(fetchFeatureFlagsThunk());
 dispatch(fetchPublicConfigThunk());
+dispatch(fetchCentralCapabilitiesThunk());
 
 ReactDOM.render(
     <Provider store={store}>

--- a/ui/apps/platform/src/reducers/centralCapabilities.ts
+++ b/ui/apps/platform/src/reducers/centralCapabilities.ts
@@ -1,0 +1,93 @@
+import { Reducer, combineReducers } from 'redux';
+import isEqual from 'lodash/isEqual';
+
+import { PrefixedAction } from 'utils/fetchingReduxRoutines';
+import { fetchCentralCapabilities, CentralServicesCapabilities } from 'services/MetadataService';
+
+// Types
+
+export type CentralCapabilitiesAction = PrefixedAction<
+    'metadata/FETCH_CENTRAL_CAPABILITIES',
+    CentralServicesCapabilities
+>;
+
+// Actions
+
+export const fetchCentralCapabilitiesThunk = () => {
+    return async (dispatch) => {
+        dispatch({ type: 'metadata/FETCH_CENTRAL_CAPABILITIES_REQUEST' });
+
+        try {
+            const data = await fetchCentralCapabilities();
+            dispatch({
+                type: 'metadata/FETCH_CENTRAL_CAPABILITIES_SUCCESS',
+                response: data,
+            });
+        } catch (error) {
+            dispatch({ type: 'metadata/FETCH_CENTRAL_CAPABILITIES_FAILURE', error });
+        }
+    };
+};
+
+// Reducers
+
+const centralCapabilities: Reducer<CentralServicesCapabilities, CentralCapabilitiesAction> = (
+    state = {} as CentralServicesCapabilities,
+    action
+) => {
+    if (action.type === 'metadata/FETCH_CENTRAL_CAPABILITIES_SUCCESS') {
+        return isEqual(action.response, state) ? state : action.response;
+    }
+    return state;
+};
+
+const centralCapabilitiesError: Reducer<Error | null, CentralCapabilitiesAction> = (
+    state = null,
+    action
+) => {
+    switch (action.type) {
+        case 'metadata/FETCH_CENTRAL_CAPABILITIES_REQUEST':
+        case 'metadata/FETCH_CENTRAL_CAPABILITIES_SUCCESS':
+            return null;
+
+        case 'metadata/FETCH_CENTRAL_CAPABILITIES_FAILURE':
+            return action.error;
+
+        default:
+            return state;
+    }
+};
+
+const isLoadingCentralCapabilities = (state = true, action) => {
+    switch (action.type) {
+        case 'metadata/FETCH_CENTRAL_CAPABILITIES_REQUEST':
+            return true;
+
+        case 'metadata/FETCH_CENTRAL_CAPABILITIES_FAILURE':
+        case 'metadata/FETCH_CENTRAL_CAPABILITIES_SUCCESS':
+            return false;
+
+        default:
+            return state;
+    }
+};
+
+const reducer = combineReducers({
+    centralCapabilities,
+    centralCapabilitiesError,
+    isLoadingCentralCapabilities,
+});
+
+type State = ReturnType<typeof reducer>;
+
+const getCentralCapabilities = (state: State) => state.centralCapabilities;
+const getCentralCapabilitiesError = (state: State) => state.centralCapabilitiesError;
+const getIsLoadingCentralCapabilities = (state: State) => state.isLoadingCentralCapabilities;
+
+export const selectors = {
+    getCentralCapabilities,
+    getCentralCapabilitiesError,
+    getIsLoadingCentralCapabilities,
+};
+
+export default reducer;

--- a/ui/apps/platform/src/reducers/index.js
+++ b/ui/apps/platform/src/reducers/index.js
@@ -25,6 +25,9 @@ import network, { selectors as networkSelectors } from './network/reducer';
 import groups, { selectors as groupsSelectors } from './groups';
 import publicConfig, { selectors as publicConfigSelectors } from './publicConfig';
 import telemetryConfig, { selectors as telemetryConfigSelectors } from './telemetryConfig';
+import centralCapabilities, {
+    selectors as centralCapabilitiesSelectors,
+} from './centralCapabilities';
 
 // Reducers
 
@@ -48,6 +51,7 @@ const appReducer = combineReducers({
     groups,
     publicConfig,
     telemetryConfig,
+    centralCapabilities,
 });
 
 const createRootReducer = (history) => {
@@ -83,6 +87,7 @@ const getNetwork = (state) => getApp(state).network;
 const getRuleGroups = (state) => getApp(state).groups;
 const getPublicConfig = (state) => getApp(state).publicConfig;
 const getTelemetryConfig = (state) => getApp(state).telemetryConfig;
+const getCentralCapabilities = (state) => getApp(state).centralCapabilities;
 
 const boundSelectors = {
     ...bindSelectors(getAPITokens, apiTokenSelectors),
@@ -105,6 +110,7 @@ const boundSelectors = {
     ...bindSelectors(getRuleGroups, groupsSelectors),
     ...bindSelectors(getPublicConfig, publicConfigSelectors),
     ...bindSelectors(getTelemetryConfig, telemetryConfigSelectors),
+    ...bindSelectors(getCentralCapabilities, centralCapabilitiesSelectors),
 };
 
 export const selectors = {

--- a/ui/apps/platform/src/services/MetadataService.ts
+++ b/ui/apps/platform/src/services/MetadataService.ts
@@ -45,6 +45,8 @@ export type CentralServicesCapabilities = {
     centralCanDisplayDeclarativeConfigHealth: CentralServicesCapabilityStatus;
 };
 
+export type CentralCapabilitiesFlags = keyof CentralServicesCapabilities;
+
 export function fetchCentralCapabilities(): Promise<CentralServicesCapabilities> {
     return axios
         .get<CentralServicesCapabilities>('/v1/central-capabilities')


### PR DESCRIPTION
## Description

Central capabilities data will be used to distinguish between managed services and self-managed solutions. Add central capabilities response data to redux and provide a react hook for easy access of data. 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed
Redux store:
![Screenshot 2023-06-05 at 3 46 59 PM](https://github.com/stackrox/stackrox/assets/61400697/ce884f07-a00d-42a1-a3b0-dccc15c2ce15)



Hook use case:
```typescript
const { isCentralCapabilityAvailable } = useCentralCapabilities();
const isDeclarativeConfigHealthAvailable = isCentralCapabilityAvailable(
    'centralCanDisplayDeclarativeConfigHealth'
);
```
