### PR TITLE
Fix on-prem reg panic

### DIFF
--- a/sensor/common/detector/detector.go
+++ b/sensor/common/detector/detector.go
@@ -277,6 +277,7 @@ func (d *detectorImpl) ProcessUpdatedImage(image *storage.Image) error {
 	newValue := &cacheValue{
 		image:     image,
 		localScan: d.enricher.localScan,
+		regStore:  d.enricher.regStore,
 	}
 	d.enricher.imageCache.Add(key, newValue)
 	d.admissionCacheNeedsFlush = true

--- a/sensor/common/registry/registry_store.go
+++ b/sensor/common/registry/registry_store.go
@@ -64,10 +64,11 @@ func NewRegistryStore(checkTLS CheckTLS) *Store {
 	})
 
 	store := &Store{
-		factory:          factory,
-		store:            make(map[string]registries.Set),
-		checkTLS:         tlscheck.CheckTLS,
-		globalRegistries: registries.NewSet(factory),
+		factory:                   factory,
+		store:                     make(map[string]registries.Set),
+		checkTLS:                  tlscheck.CheckTLS,
+		globalRegistries:          registries.NewSet(factory),
+		clusterLocalRegistryHosts: set.NewStringSet(),
 	}
 
 	if checkTLS != nil {


### PR DESCRIPTION
## Description

To address CI failures, stacktrace from CI failures below, stacktrace does not appear to be accurate to the line that is panic'ing

```
[signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0x28ee32d]

goroutine 26011 [running]:
github.com/stackrox/rox/sensor/common/registry.(*Store).hasClusterLocalRegistryHost(0x0, {0xc0128d74f0?, 0x30?})
	github.com/stackrox/rox/sensor/common/registry/registry_store.go:260 +0xed
github.com/stackrox/rox/sensor/common/registry.(*Store).IsLocal(0x0, 0xc009c64b40)
	github.com/stackrox/rox/sensor/common/registry/registry_store.go:213 +0x68
github.com/stackrox/rox/sensor/common/detector.(*cacheValue).scanAndSet(0xc008f30080, {0x401cc98, 0xc00b877158}, {0x4031a78, 0xc000624100}, 0xc00897cc80)
	github.com/stackrox/rox/sensor/common/detector/enricher.go:148 +0xc5
github.com/stackrox/rox/sensor/common/detector.(*enricher).runScan(0xc000c16690, 0xc00897cc80)
	github.com/stackrox/rox/sensor/common/detector/enricher.go:234 +0x4cf
github.com/stackrox/rox/sensor/common/detector.(*enricher).runImageScanAsync.func1()
	github.com/stackrox/rox/sensor/common/detector/enricher.go:252 +0x2a
created by github.com/stackrox/rox/sensor/common/detector.(*enricher).runImageScanAsync
	github.com/stackrox/rox/sensor/common/detector/enricher.go:250 +0x92
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0x28ee32d]

goroutine 25988 [running]:
github.com/stackrox/rox/sensor/common/registry.(*Store).hasClusterLocalRegistryHost(0x0, {0xc0128d74f0?, 0x30?})
	github.com/stackrox/rox/sensor/common/registry/registry_store.go:260 +0xed
github.com/stackrox/rox/sensor/common/registry.(*Store).IsLocal(0x0, 0xc009c64b40)
	github.com/stackrox/rox/sensor/common/registry/registry_store.go:213 +0x68
github.com/stackrox/rox/sensor/common/detector.(*cacheValue).scanAndSet(0xc008f30080, {0x401cc98, 0xc00b68d7d0}, {0x4031a78, 0xc000624100}, 0xc009c2d680)
	github.com/stackrox/rox/sensor/common/detector/enricher.go:148 +0xc5
github.com/stackrox/rox/sensor/common/detector.(*enricher).runScan(0xc000c16690, 0xc009c2d680)
	github.com/stackrox/rox/sensor/common/detector/enricher.go:234 +0x4cf
github.com/stackrox/rox/sensor/common/detector.(*enricher).runImageScanAsync.func1()
	github.com/stackrox/rox/sensor/common/detector/enricher.go:252 +0x2a
created by github.com/stackrox/rox/sensor/common/detector.(*enricher).runImageScanAsync
	github.com/stackrox/rox/sensor/common/detector/enricher.go:250 +0x92
```

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
