### PR TITLE
Add sac check to blob upsert

### DIFF
--- a/central/blob/datastore/store/store.go
+++ b/central/blob/datastore/store/store.go
@@ -7,12 +7,17 @@ import (
 	"github.com/jackc/pgx/v4"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/central/blob/datastore/store/postgres"
+	"github.com/stackrox/rox/central/role/resources"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/logging"
 	pgPkg "github.com/stackrox/rox/pkg/postgres"
+	"github.com/stackrox/rox/pkg/sac"
 )
 
-var log = logging.LoggerForModule()
+var (
+	log          = logging.LoggerForModule()
+	scopeChecker = sac.ForResource(resources.Administration)
+)
 
 // Store is the interface to interact with the storage for storage.Blob
 type Store interface {
@@ -46,6 +51,13 @@ func wrapRollback(ctx context.Context, tx *pgPkg.Tx, err error) error {
 
 // Upsert adds a blob to the database
 func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Blob, reader io.Reader) error {
+	if err := sac.VerifyAuthzOK(scopeChecker.WriteAllowed(ctx)); err != nil {
+		return err
+	}
+	if err := sac.VerifyAuthzOK(scopeChecker.ReadAllowed(ctx)); err != nil {
+		return err
+	}
+
 	tx, err := s.db.Begin(ctx)
 	if err != nil {
 		return err
@@ -166,6 +178,12 @@ func (s *storeImpl) Get(ctx context.Context, name string, writer io.Writer) (*st
 
 // Delete removes a blob from database if it exists
 func (s *storeImpl) Delete(ctx context.Context, name string) error {
+	if err := sac.VerifyAuthzOK(scopeChecker.WriteAllowed(ctx)); err != nil {
+		return err
+	}
+	if err := sac.VerifyAuthzOK(scopeChecker.ReadAllowed(ctx)); err != nil {
+		return err
+	}
 	tx, err := s.db.Begin(ctx)
 	if err != nil {
 		return err

--- a/central/blob/datastore/store/store.go
+++ b/central/blob/datastore/store/store.go
@@ -54,9 +54,11 @@ func (s *storeImpl) Upsert(ctx context.Context, obj *storage.Blob, reader io.Rea
 	if err := sac.VerifyAuthzOK(scopeChecker.WriteAllowed(ctx)); err != nil {
 		return err
 	}
-	if err := sac.VerifyAuthzOK(scopeChecker.ReadAllowed(ctx)); err != nil {
-		return err
-	}
+	// Augment permission because we require read permission internally
+	ctx = sac.WithGlobalAccessScopeChecker(ctx,
+		sac.AllowFixedScopes(
+			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+			sac.ResourceScopeKeys(resources.Administration)))
 
 	tx, err := s.db.Begin(ctx)
 	if err != nil {
@@ -181,9 +183,11 @@ func (s *storeImpl) Delete(ctx context.Context, name string) error {
 	if err := sac.VerifyAuthzOK(scopeChecker.WriteAllowed(ctx)); err != nil {
 		return err
 	}
-	if err := sac.VerifyAuthzOK(scopeChecker.ReadAllowed(ctx)); err != nil {
-		return err
-	}
+	// Augment permission because we require read permission internally
+	ctx = sac.WithGlobalAccessScopeChecker(ctx,
+		sac.AllowFixedScopes(
+			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+			sac.ResourceScopeKeys(resources.Administration)))
 	tx, err := s.db.Begin(ctx)
 	if err != nil {
 		return err

--- a/central/blob/datastore/store/store_test.go
+++ b/central/blob/datastore/store/store_test.go
@@ -118,14 +118,14 @@ func (s *BlobsStoreSuite) TestSacForUpsertAndDelete() {
 	// Upsert fails with read permission
 	s.Require().Error(s.store.Upsert(rCtx, insertBlob, reader))
 	s.verifyLargeObjectCounts(0)
-	// Upsert fails with write permission
-	s.Require().Error(s.store.Upsert(wCtx, insertBlob, reader))
-	s.verifyLargeObjectCounts(0)
-
-	// Upsert succeed with read and write permission
-	s.Require().NoError(s.store.Upsert(rwCtx, insertBlob, reader))
+	// Upsert succeeds with write permission
+	s.Require().NoError(s.store.Upsert(wCtx, insertBlob, reader))
 	s.verifyLargeObjectCounts(1)
-	// Upsert again
+	// Upsert succeeds updating blob
+	reader = bytes.NewBuffer(randomData)
+	s.Require().NoError(s.store.Upsert(wCtx, insertBlob, reader))
+	s.verifyLargeObjectCounts(1)
+	// Upsert succeeds with read and write permission
 	reader = bytes.NewBuffer(randomData)
 	s.Require().NoError(s.store.Upsert(rwCtx, insertBlob, reader))
 	s.verifyLargeObjectCounts(1)
@@ -133,10 +133,13 @@ func (s *BlobsStoreSuite) TestSacForUpsertAndDelete() {
 	// Delete fails with read permission
 	s.Require().Error(s.store.Delete(rCtx, insertBlob.GetName()))
 	s.verifyLargeObjectCounts(1)
-	// Delete fails with write permission
-	s.Require().Error(s.store.Delete(wCtx, insertBlob.GetName()))
-	s.verifyLargeObjectCounts(1)
+	// Delete succeeds with write permission
+	s.Require().NoError(s.store.Delete(wCtx, insertBlob.GetName()))
+	s.verifyLargeObjectCounts(0)
 	// Delete succeeds with read and write permission
+	reader = bytes.NewBuffer(randomData)
+	s.Require().NoError(s.store.Upsert(rwCtx, insertBlob, reader))
+	s.verifyLargeObjectCounts(1)
 	s.Require().NoError(s.store.Delete(rwCtx, insertBlob.GetName()))
 	s.verifyLargeObjectCounts(0)
 }


### PR DESCRIPTION
## Description

Add sac check to upsert and delete.

These two operations require both read/write permissions. If a caller holds only one permission, it will lead to inconsistency.
1. If a caller has write permission but no read permission, upsert will lead to leaking large object.
2. If a caller has read permission but no write permission, delete will lead to a blob without large object.
This PR fixes that by augment ctx with extra read permission.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

TODO(replace-me)
Use this space to explain how you tested your PR, or, if you didn't test it, why
you did not do so. Valid reasons include, for example, "CI is sufficient",
"No testable changes". Feel free to attach JSON snippets, curl commands,
screenshots.

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
