### PR TITLE
ROX-16502: future-proof upgrade tests with roxctl generate

### DIFF
--- a/.github/workflows/scripts/prepare-upgrade-test.sh
+++ b/.github/workflows/scripts/prepare-upgrade-test.sh
@@ -130,7 +130,7 @@ save_credentials_to_cluster
 disable_autoupgrader
 deploy_violations "test1"
 deploy_violations "test2"
-deploy_sensor "test1" "central.stackrox:443" "KERNEL_MODULE"
+deploy_sensor "test1" "central.stackrox:443" "EBPF"
 deploy_sensor "test2" "${CENTRAL_IP}:443" "EBPF"
 create_policy
 trigger_compliance_check

--- a/.github/workflows/scripts/prepare-upgrade-test.sh
+++ b/.github/workflows/scripts/prepare-upgrade-test.sh
@@ -5,12 +5,6 @@ set -euo pipefail
 PREVIOUS_RELEASE=$1
 RELEASE=$2
 
-GITHUB_REPOSITORY="stackrox/stackrox"
-PREVIOUS_SCANNER_VERSION="$(gh api \
-    -H "Accept: application/vnd.github.v3.raw" \
-    "/repos/${GITHUB_REPOSITORY}/contents/SCANNER_VERSION?ref=${PREVIOUS_RELEASE}"
-)"
-
 CWD="$(pwd)"
 TMP_DIR="$(mktemp -d)"
 
@@ -32,11 +26,8 @@ deploy_central() {
 
     rm -rf bundle-test1
     ./roxctl-"${PREVIOUS_RELEASE}" central generate k8s pvc \
-        --lb-type=lb \
-        --main-image=quay.io/rhacs-eng/main:"${PREVIOUS_RELEASE}" \
-        --central-db-image=quay.io/rhacs-eng/central-db:"${PREVIOUS_RELEASE}" \
-        --scanner-db-image=quay.io/rhacs-eng/scanner-db:"${PREVIOUS_SCANNER_VERSION}" \
-        --scanner-image=quay.io/rhacs-eng/scanner:"${PREVIOUS_SCANNER_VERSION}" \
+        --lb-type lb \
+        --image-defaults development_build \
         --output-dir bundle-test1
 
     ./bundle-test1/central/scripts/setup.sh
@@ -139,7 +130,7 @@ save_credentials_to_cluster
 disable_autoupgrader
 deploy_violations "test1"
 deploy_violations "test2"
-deploy_sensor "test1" "central.stackrox:443" "EBPF"
+deploy_sensor "test1" "central.stackrox:443" "KERNEL_MODULE"
 deploy_sensor "test2" "${CENTRAL_IP}:443" "EBPF"
 create_policy
 trigger_compliance_check


### PR DESCRIPTION
## Description

We do not need to set the images explicitly during roxctl generate for the upgrade tests.
This will future proof the upgrade tests, because new or removed images won't break stuff.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Tested and reviewed in https://github.com/stackrox/test-gh-actions/pull/96.