### PR TITLE
ROX-16356: Release automation: switch slack notification channels

### DIFF
--- a/.github/properties
+++ b/.github/properties
@@ -1,5 +1,5 @@
 docs-repository=openshift/openshift-docs
-slack-channel=CMH5M8MHN
+slack-channel=C05AZF8T7GW
 dry-slack-channel=C03KSV3N6N8
 jira-project=ROX
 jira-projects=ROX, RS, RTOOLS

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -1663,7 +1663,7 @@ slack_prow_notice() {
             # send to #acs-slack-integration-testing when testing the release process
             webhook_url="${SLACK_MAIN_WEBHOOK}"
         else
-            # send to #forum-acs-eng-release
+            # send to #acs-release-notifications
             webhook_url="${RELEASE_WORKFLOW_NOTIFY_WEBHOOK}"
         fi
     elif is_nightly_run; then

--- a/scripts/ci/publish-helm-charts.sh
+++ b/scripts/ci/publish-helm-charts.sh
@@ -27,7 +27,7 @@ if is_release_test_stream "$version"; then
 	# send to #acs-slack-integration-testing when testing the release process
 	webhook_url="${SLACK_MAIN_WEBHOOK}"
 else
-	# send to #eng-release
+	# send to #acs-release-notifications
 	webhook_url="${RELEASE_WORKFLOW_NOTIFY_WEBHOOK}"
 fi
 


### PR DESCRIPTION
## Description

Splitting notifications and discussions from #forum-acs-eng-release. 

## Checklist
- ~[ ] Investigated and inspected CI test results~
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

GHA tested in https://github.com/stackrox/test-gh-actions/pull/97. 
- New Slack channel: #acs-release-notifications (ID: C05AZF8T7GW)

Secrets were updated on OSCI Vault + GHA settings by @gavin-stackrox . 