### PR TITLE
fix: system health ui tests: backup integrations test

### DIFF
--- a/ui/apps/platform/cypress/integration/systemHealth/integrations.test.js
+++ b/ui/apps/platform/cypress/integration/systemHealth/integrations.test.js
@@ -20,7 +20,7 @@ describe('System Health Integrations fixtures', () => {
             'integrationhealth/externalbackups': { body: { integrationHealth } },
         });
 
-        cy.get(getCardHeaderDescendantSelector('Image Integrations', 'div:contains("no errors")'));
+        cy.get(getCardHeaderDescendantSelector('Backup Integrations', 'div:contains("no errors")'));
     });
 
     it('should not have count in healthy text for image integrations', () => {


### PR DESCRIPTION
## Description

As @pedrottimark said:
```
OCP has an image integration error for Quay.io but GKE has no errors, so that is why CI passed
```

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

1. Extended CI run TBD
