### PR TITLE
fix(ui): Remove default filter useEffect from workload cve toolbar

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/WorkloadTableToolbar.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/WorkloadTableToolbar.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import noop from 'lodash/noop';
 import { Toolbar, ToolbarGroup, ToolbarContent, ToolbarChip } from '@patternfly/react-core';
 
@@ -73,14 +73,6 @@ function WorkloadTableToolbar({
     function onDeleteAll() {
         onChangeSearchFilter({});
     }
-
-    // The `onChangeSearchFilter` function is intentionally not used in place of `setSearchFilter` below since
-    // it is intended to respond to a change via user action, and this useEffect is intended to sync the
-    // state when the page loads or local storage changes.
-    useEffect(() => {
-        setSearchFilter(defaultFilters, 'replace');
-        // unsure how to reset filters with URL filters only on defaultFilter change
-    }, [defaultFilters, setSearchFilter]);
 
     return (
         <Toolbar id="workload-cves-table-toolbar">


### PR DESCRIPTION
## Description

This effect was causing the search filter to be cleared when navigating tabs on the workload CVE overview page. Since a new version of this component is rendered each time the tab changes, the effect will always fire once. Previously it merged the default filter state with the URL state, but since we aren't using default filters it seems safe to remove entirely.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Go to a tab on the workload cve overview page and apply a filter.
![image](https://github.com/stackrox/stackrox/assets/1292638/673cba03-affa-413a-8cfc-67e90a1b1611)

Change tabs and ensure the filter persists.
![image](https://github.com/stackrox/stackrox/assets/1292638/b20e7a76-b62c-4063-9c14-710a0d947d01)
