### PR TITLE
ROX-16992: Allow long Role select-menu to scroll

### DIFF
--- a/ui/apps/platform/src/Containers/AccessControl/AccessScopes/AccessScopes.css
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessScopes/AccessScopes.css
@@ -134,3 +134,11 @@ table .pf-c-dropdown__toggle.pf-m-plain svg {
 .certificate-input {
     min-height: 12ex;
 }
+
+/*
+ * Allow pop-up selects to scroll when customer has more roles than can be shown by height of screen
+ */
+ .pf-c-select__menu {
+    max-height: 100vh;
+    overflow: scroll;
+}


### PR DESCRIPTION
## Description

Select popup list PR component seems to have no limit, and when user has more roles than can fit on height of whole webpage, there is no way to scroll to them.

This simple fix gives that popup list a max-height of the vertical height of the page, and the forces and scrolling when number of item is taller than that.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

Manual test: create a bunch of roles and make sure they scroll

<img width="1218" alt="Screen Shot 2023-06-06 at 11 36 36 AM" src="https://github.com/stackrox/stackrox/assets/715729/38ebc4b6-444f-4314-8fb3-b04a0b53a544">
