### PR TITLE
ROX-17177: Disable declarative config system health for ACS CS

### DIFF
--- a/ui/apps/platform/src/Containers/SystemHealth/DashboardPage.js
+++ b/ui/apps/platform/src/Containers/SystemHealth/DashboardPage.js
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { Flex, FlexItem, Grid, GridItem, PageSection, Title } from '@patternfly/react-core';
 
 import useInterval from 'hooks/useInterval';
+import useCentralCapabilities from 'hooks/useCentralCapabilities';
 
 import CertificateCard from './CertificateHealth/CertificateCard';
 import ClustersHealthCards from './ClustersHealth/ClustersHealthCards';
@@ -14,6 +15,11 @@ import NotifierIntegrationHealthWidget from './Components/NotifierIntegrationHea
 import BackupIntegrationHealthWidget from './Components/BackupIntegrationHealthWidget';
 
 const SystemHealthDashboardPage = () => {
+    const { isCentralCapabilityAvailable } = useCentralCapabilities();
+    const isDeclarativeConfigHealthAvailable = isCentralCapabilityAvailable(
+        'centralCanDisplayDeclarativeConfigHealth'
+    );
+
     const [pollingCountFaster, setPollingCountFaster] = useState(0);
     const [pollingCountSlower, setPollingCountSlower] = useState(0);
 
@@ -52,9 +58,11 @@ const SystemHealthDashboardPage = () => {
                     <GridItem span={12}>
                         <BackupIntegrationHealthWidget pollingCount={pollingCountFaster} />
                     </GridItem>
-                    <GridItem span={12}>
-                        <DeclarativeConfigurationHealthCard pollingCount={pollingCountFaster} />
-                    </GridItem>
+                    {isDeclarativeConfigHealthAvailable && (
+                        <GridItem span={12}>
+                            <DeclarativeConfigurationHealthCard pollingCount={pollingCountFaster} />
+                        </GridItem>
+                    )}
                     <GridItem span={12}>
                         <CertificateCard component="CENTRAL" pollingCount={pollingCountSlower} />
                     </GridItem>


### PR DESCRIPTION
## Description

ACS CS does not provide customers with the ability to use declarative configurations. Therefore, the system health page should not show the declarative config health status when running in "managed service" mode, i.e. for ACS CS instances.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed
`CapabilityAvailable`
![Screenshot 2023-06-06 at 11 47 15 AM](https://github.com/stackrox/stackrox/assets/61400697/d8a4a4b8-659e-4cc0-9b2d-ec09e61eddd5)


`CapabilityDisabled`
![Screenshot 2023-06-06 at 11 47 29 AM](https://github.com/stackrox/stackrox/assets/61400697/f46872b5-2c56-4420-9804-cfcfe4bd3423)
