### PR TITLE
feat(ui): Add central capabilities cypress test helpers

### DIFF
--- a/ui/apps/platform/cypress/helpers/systemHealth.js
+++ b/ui/apps/platform/cypress/helpers/systemHealth.js
@@ -2,7 +2,7 @@ import * as api from '../constants/apiEndpoints';
 import { systemHealthUrl } from '../constants/SystemHealth';
 
 import { visitFromLeftNavExpandable } from './nav';
-import { visit } from './visit';
+import { visit, visitWithStaticResponseForCapabilities } from './visit';
 
 // clock
 
@@ -15,6 +15,7 @@ export function setClock(currentDatetime) {
 
 export const integrationHealthVulnDefinitionsAlias = 'integrationhealth/vulndefinitions';
 
+const SystemHealthHeadingSelector = 'h1:contains("System Health")';
 const routeMatcherMap = {
     'integrationhealth/imageintegrations': {
         method: 'GET',
@@ -58,11 +59,21 @@ export function visitSystemHealthFromLeftNav() {
     visitFromLeftNavExpandable('Platform Configuration', 'System Health', routeMatcherMap);
 
     cy.location('pathname').should('eq', systemHealthUrl);
-    cy.get('h1:contains("System Health")');
+    cy.get(SystemHealthHeadingSelector);
 }
 
 export function visitSystemHealth(staticResponseMap) {
     visit(systemHealthUrl, routeMatcherMap, staticResponseMap);
 
-    cy.get('h1:contains("System Health")');
+    cy.get(SystemHealthHeadingSelector);
+}
+
+export function visitSystemHealthWithStaticResponseForCapabilities(staticResponseForCapabilities) {
+    visitWithStaticResponseForCapabilities(
+        systemHealthUrl,
+        staticResponseForCapabilities,
+        routeMatcherMap
+    );
+
+    cy.get(SystemHealthHeadingSelector);
 }

--- a/ui/apps/platform/cypress/helpers/systemHealth.js
+++ b/ui/apps/platform/cypress/helpers/systemHealth.js
@@ -14,6 +14,7 @@ export function setClock(currentDatetime) {
 // visit
 
 export const integrationHealthVulnDefinitionsAlias = 'integrationhealth/vulndefinitions';
+export const integrationHealthDeclarativeConfigsAlias = 'integrationhealth/declarativeconfigs';
 
 const SystemHealthHeadingSelector = 'h1:contains("System Health")';
 const routeMatcherMap = {
@@ -49,7 +50,7 @@ const routeMatcherMap = {
         method: 'GET',
         url: api.integrationHealth.vulnDefinitions,
     },
-    'integrationhealth/declarativeconfigs': {
+    [integrationHealthDeclarativeConfigsAlias]: {
         method: 'GET',
         url: '/v1/integrationhealth/declarativeconfigs',
     },
@@ -68,11 +69,17 @@ export function visitSystemHealth(staticResponseMap) {
     cy.get(SystemHealthHeadingSelector);
 }
 
-export function visitSystemHealthWithStaticResponseForCapabilities(staticResponseForCapabilities) {
+export function visitSystemHealthWithStaticResponseForCapabilities(
+    staticResponseForCapabilities,
+    keysToRemoveFromRouteMatcherMap = []
+) {
+    const updatedRouteMatcherMap = { ...routeMatcherMap };
+    keysToRemoveFromRouteMatcherMap.forEach((key) => delete updatedRouteMatcherMap[key]);
+
     visitWithStaticResponseForCapabilities(
         systemHealthUrl,
         staticResponseForCapabilities,
-        routeMatcherMap
+        updatedRouteMatcherMap
     );
 
     cy.get(SystemHealthHeadingSelector);

--- a/ui/apps/platform/cypress/helpers/visit.js
+++ b/ui/apps/platform/cypress/helpers/visit.js
@@ -7,6 +7,7 @@ export const loginAuthProvidersAlias = 'login/authproviders';
 export const myPermissionsAlias = 'mypermissions';
 export const configPublicAlias = 'config/public';
 export const authStatusAlias = 'auth/status';
+export const centralCapabilitiesAlias = 'central-capabilities';
 
 // Requests to render pages via MainPage and Body components.
 const routeMatcherMapForAuthenticatedRoutes = {
@@ -33,7 +34,11 @@ const routeMatcherMapForAuthenticatedRoutes = {
     [authStatusAlias]: {
         method: 'GET',
         url: '/v1/auth/status',
-    }, // sagas/authSagas
+    }, // sagas/authSagas,
+    [centralCapabilitiesAlias]: {
+        method: 'GET',
+        url: '/v1/central-capabilities',
+    }, // reducers/centralCapabilities,
     /*
      * Intentionally omit credentialexpiry requests for central and scanner,
      * because they are in parallel with (and possibly even delayed by) page-specific requests.
@@ -118,6 +123,38 @@ export function visitWithStaticResponseForPermissions(
 ) {
     const staticResponseMapForAuthenticatedRoutes = {
         [myPermissionsAlias]: staticResponseForPermissions,
+    };
+    interceptRequests(
+        routeMatcherMapForAuthenticatedRoutes,
+        staticResponseMapForAuthenticatedRoutes
+    );
+    interceptRequests(routeMatcherMap, staticResponseMap);
+
+    cy.visit(pageUrl);
+
+    waitForResponses(routeMatcherMapForAuthenticatedRoutes);
+    waitForResponses(routeMatcherMap);
+}
+
+/**
+ * Visit page to test conditional rendering for central capabilities specified as response or fixture.
+ *
+ * { body: { ... } }
+ * { fixture: 'fixtures/wherever/whatever.json' }
+ *
+ * @param {string} pageUrl
+ * @param {{ body: { [key: string]: 'CapabilityAvailable' | 'CapabilityDisabled' } }} staticResponseForCapabilities
+ * @param {Record<string, { method: string, url: string }>} [routeMatcherMap]
+ * @param {Record<string, { body: unknown } | { fixture: string }>} [staticResponseMap]
+ */
+export function visitWithStaticResponseForCapabilities(
+    pageUrl,
+    staticResponseForCapabilities,
+    routeMatcherMap,
+    staticResponseMap
+) {
+    const staticResponseMapForAuthenticatedRoutes = {
+        [centralCapabilitiesAlias]: staticResponseForCapabilities,
     };
     interceptRequests(
         routeMatcherMapForAuthenticatedRoutes,

--- a/ui/apps/platform/cypress/integration/systemHealth/declarativeConfiguration.test.js
+++ b/ui/apps/platform/cypress/integration/systemHealth/declarativeConfiguration.test.js
@@ -1,5 +1,8 @@
 import withAuth from '../../helpers/basicAuth';
-import { visitSystemHealthWithStaticResponseForCapabilities } from '../../helpers/systemHealth';
+import {
+    visitSystemHealthWithStaticResponseForCapabilities,
+    integrationHealthDeclarativeConfigsAlias,
+} from '../../helpers/systemHealth';
 
 describe('System Health Declarative Configuration', () => {
     withAuth();
@@ -24,11 +27,14 @@ describe('System Health Declarative Configuration', () => {
     });
 
     it('should not display declarative configuration when capability is disabled', () => {
-        visitSystemHealthWithStaticResponseForCapabilities({
-            body: {
-                centralCanDisplayDeclarativeConfigHealth: 'CapabilityDisabled',
+        visitSystemHealthWithStaticResponseForCapabilities(
+            {
+                body: {
+                    centralCanDisplayDeclarativeConfigHealth: 'CapabilityDisabled',
+                },
             },
-        });
+            [integrationHealthDeclarativeConfigsAlias]
+        );
 
         cy.get(declarativeConfigHeadingSelector).should('not.exist');
     });

--- a/ui/apps/platform/cypress/integration/systemHealth/declarativeConfiguration.test.js
+++ b/ui/apps/platform/cypress/integration/systemHealth/declarativeConfiguration.test.js
@@ -1,0 +1,35 @@
+import withAuth from '../../helpers/basicAuth';
+import { visitSystemHealthWithStaticResponseForCapabilities } from '../../helpers/systemHealth';
+
+describe('System Health Declarative Configuration', () => {
+    withAuth();
+    const declarativeConfigHeadingSelector = 'h2:contains("Declarative configuration")';
+
+    it('should display declarative configuration when capability is available', () => {
+        visitSystemHealthWithStaticResponseForCapabilities({
+            body: {
+                centralCanDisplayDeclarativeConfigHealth: 'CapabilityAvailable',
+            },
+        });
+
+        cy.get(declarativeConfigHeadingSelector);
+    });
+
+    it('should display declarative configuration when central capabilities return an empty object', () => {
+        visitSystemHealthWithStaticResponseForCapabilities({
+            body: {},
+        });
+
+        cy.get(declarativeConfigHeadingSelector);
+    });
+
+    it('should not display declarative configuration when capability is disabled', () => {
+        visitSystemHealthWithStaticResponseForCapabilities({
+            body: {
+                centralCanDisplayDeclarativeConfigHealth: 'CapabilityDisabled',
+            },
+        });
+
+        cy.get(declarativeConfigHeadingSelector).should('not.exist');
+    });
+});


### PR DESCRIPTION
## Description

Add a new visit method for mocking central capabilities response data. Demonstrate new method by writing tests for System Health -> Declarative Configuration

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.