### PR TITLE
ROX-17378: Write integration tests for compliance hideScanResults

### DIFF
--- a/ui/apps/platform/cypress/integration/compliance/Compliance.helpers.js
+++ b/ui/apps/platform/cypress/integration/compliance/Compliance.helpers.js
@@ -23,7 +23,7 @@ function getEntityPagePath(entitiesKey) {
 
 // opname
 
-const routeMatcherMapForComplianceDashboard = getRouteMatcherMapForGraphQL([
+const opnamesWithoutStandards = [
     'clustersCount',
     'namespacesCount',
     'nodesCount',
@@ -34,13 +34,24 @@ const routeMatcherMapForComplianceDashboard = getRouteMatcherMapForGraphQL([
     'getAggregatedResultsAcrossEntity_NAMESPACE',
     'getAggregatedResultsAcrossEntity_NODE',
     'getComplianceStandards',
+];
+
+export const routeMatcherMapWithoutStandards =
+    getRouteMatcherMapForGraphQL(opnamesWithoutStandards);
+
+// TODO are these reliable after hideScanResults feature?
+/*
+const opnamesOfStandards = [
     'complianceStandards_CIS_Docker_v1_2_0',
     'complianceStandards_CIS_Kubernetes_v1_5',
     'complianceStandards_HIPAA_164',
     'complianceStandards_NIST_800_190',
     'complianceStandards_NIST_SP_800_53_Rev_4',
     'complianceStandards_PCI_DSS_3_2',
-]);
+];
+*/
+
+const routeMatcherMapForComplianceDashboard = getRouteMatcherMapForGraphQL(opnamesWithoutStandards);
 
 const opnameForEntities = {
     clusters: 'clustersList', // just clusters would be even better, and so on

--- a/ui/apps/platform/cypress/integration/compliance/hideScanResults.helpers.js
+++ b/ui/apps/platform/cypress/integration/compliance/hideScanResults.helpers.js
@@ -1,0 +1,52 @@
+import { interactAndWaitForResponses } from '../../helpers/request';
+
+import { routeMatcherMapWithoutStandards } from './Compliance.helpers';
+
+// selectors
+
+export const selectorForModal = `[role="dialog"]:has('h1:contains("Manage standards")')`;
+
+export function selectorInModal(selector) {
+    return `${selectorForModal} ${selector}`;
+}
+export function selectorForWidget(title) {
+    return `.widget:has('[data-testid="widget-header"]:contains("${title}")')`;
+}
+
+export function selectorInWidget(title, selector) {
+    return `${selectorForWidget(title)} ${selector}`;
+}
+
+// interactions
+
+export function openModal() {
+    const routeMatcherMap = {
+        'compliance/standards': {
+            method: 'GET',
+            url: '/v1/compliance/standards',
+        },
+    };
+
+    interactAndWaitForResponses(() => {
+        cy.get('button:contains("Manage standards")').click();
+    }, routeMatcherMap);
+
+    cy.get(selectorForModal);
+}
+
+export function clickSaveAndWaitForPatchComplianceStandards(standardIds) {
+    const routeMatcherMapForPatch = Object.fromEntries(
+        standardIds.map((standardId) => [
+            `PATCH_${standardId}`,
+            { method: 'PATCH', url: `/v1/compliance/standards/${standardId}` },
+        ])
+    );
+    const routeMatcherMap = {
+        ...routeMatcherMapForPatch,
+        ...routeMatcherMapWithoutStandards,
+    };
+
+    return interactAndWaitForResponses(() => {
+        cy.get(selectorInModal('button:contains("Save")')).click();
+    }, routeMatcherMap); // TODO GraphQL requests?
+}

--- a/ui/apps/platform/cypress/integration/compliance/hideScanResults.test.js
+++ b/ui/apps/platform/cypress/integration/compliance/hideScanResults.test.js
@@ -1,0 +1,133 @@
+import withAuth from '../../helpers/basicAuth';
+import { hasFeatureFlag } from '../../helpers/features';
+import { getInputByLabel } from '../../helpers/formHelpers';
+
+import { visitComplianceDashboard } from './Compliance.helpers';
+import {
+    clickSaveAndWaitForPatchComplianceStandards,
+    openModal,
+    selectorForWidget,
+    selectorForModal,
+    selectorInModal,
+    selectorInWidget,
+} from './hideScanResults.helpers';
+
+const titleAcrossClusters = 'Passing standards across clusters';
+const titleAcrossNamespaces = 'Passing standards across namespaces';
+
+const forHIPAA = {
+    standardId: 'HIPAA_164',
+    barLink: 'a:contains("HIPAA")',
+    checkboxLabel: 'HIPAA 164',
+    sunburstTitle: 'HIPAA 164 Compliance',
+};
+
+const forNIST190 = {
+    standardId: 'NIST_800_190',
+    barLink: 'a:contains("NIST SP 800-190")',
+    checkboxLabel: 'NIST SP 800-190',
+    sunburstTitle: 'NIST SP 800-190 Compliance',
+};
+
+const forNIST53 = {
+    standardId: 'NIST_SP_800_53_Rev_4',
+    barLink: 'a:contains("NIST SP 800-53")',
+    checkboxLabel: 'NIST SP 800-53',
+    sunburstTitle: 'NIST SP 800-53 Compliance',
+};
+
+function assertExistenceOfStandard(forStandard, existence) {
+    const { barLink, sunburstTitle } = forStandard;
+    const existOrNot = existence ? 'exist' : 'not.exist';
+
+    cy.get(selectorInWidget(titleAcrossClusters, barLink)).should(existOrNot);
+    cy.get(selectorInWidget(titleAcrossNamespaces, barLink)).should(existOrNot);
+    cy.get(selectorForWidget(sunburstTitle)).should(existOrNot);
+
+    // TODO columns in entity tables
+}
+
+function assertCheckedAndClickStandard(forStandard, checked) {
+    const { checkboxLabel } = forStandard;
+    const haveAttrOrNot = checked ? 'have.attr' : 'not.have.attr';
+
+    getInputByLabel(checkboxLabel).should(haveAttrOrNot, 'checked');
+    getInputByLabel(checkboxLabel).click();
+}
+
+describe('Compliance hideScanResults', () => {
+    withAuth();
+
+    before(function beforeHook() {
+        if (!hasFeatureFlag('ROX_DISABLE_COMPLIANCE_STANDARDS')) {
+            this.skip();
+        }
+    });
+
+    it('should open modal and then cancel', () => {
+        visitComplianceDashboard();
+        openModal();
+
+        cy.get(selectorInModal('button:contains("Save")')).should('be.disabled');
+        cy.get(selectorInModal('button:contains("Cancel")')).click();
+        cy.get(selectorForModal).should('not.exist');
+    });
+
+    it('should hide HIPAA standard', () => {
+        visitComplianceDashboard();
+
+        assertExistenceOfStandard(forHIPAA, true);
+
+        openModal();
+
+        assertCheckedAndClickStandard(forHIPAA, true);
+        clickSaveAndWaitForPatchComplianceStandards([forHIPAA.standardId]);
+
+        assertExistenceOfStandard(forHIPAA, false);
+    });
+
+    // The following test depends on the preceding test.
+
+    it('should show HIPAA standard and hide NIST standards', () => {
+        visitComplianceDashboard();
+
+        assertExistenceOfStandard(forHIPAA, false);
+        assertExistenceOfStandard(forNIST190, true);
+        assertExistenceOfStandard(forNIST53, true);
+
+        openModal();
+        assertCheckedAndClickStandard(forHIPAA, false);
+        assertCheckedAndClickStandard(forNIST190, true);
+        assertCheckedAndClickStandard(forNIST53, true);
+
+        clickSaveAndWaitForPatchComplianceStandards([
+            forHIPAA.standardId,
+            forNIST190.standardId,
+            forNIST53.standardId,
+        ]);
+
+        assertExistenceOfStandard(forHIPAA, true);
+        assertExistenceOfStandard(forNIST190, false);
+        assertExistenceOfStandard(forNIST53, false);
+    });
+
+    // The following test depends on the preceding test.
+
+    it('should show NIST standards', () => {
+        visitComplianceDashboard();
+
+        assertExistenceOfStandard(forNIST190, false);
+        assertExistenceOfStandard(forNIST53, false);
+
+        openModal();
+        assertCheckedAndClickStandard(forNIST190, false);
+        assertCheckedAndClickStandard(forNIST53, false);
+
+        clickSaveAndWaitForPatchComplianceStandards([forNIST190.standardId, forNIST53.standardId]);
+
+        assertExistenceOfStandard(forNIST190, true);
+        assertExistenceOfStandard(forNIST53, true);
+    });
+
+    // hideScanResults is same at the end as it was at the beginning
+});


### PR DESCRIPTION
## Description

### Residue

1. It is probably not reliable to wait on requests for specific standards, therefore commented out.
2. Will re-evaluate which helpers to factor out versus define in test file when I add more tests.
3. Add a test that **Manage standards** button does not exist if only READ_ACCESS like Analyst role

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed

### Integration testing

In ui/apps/platform

1. `export CYPRESS_ROX_DISABLE_COMPLIANCE_STANDARDS=true`
2. `yarn cypress-open`
    * compliance/hideScanResults.test.js