### PR TITLE
ROX-17563: Require exact match in Access Control integration tests

### DIFF
--- a/ui/apps/platform/cypress/integration/accessControl/accessControl.helpers.js
+++ b/ui/apps/platform/cypress/integration/accessControl/accessControl.helpers.js
@@ -216,7 +216,12 @@ export function visitAccessControlEntity(entitiesKey, entityId, staticResponseMa
 // interact in entities table
 
 export function clickEntityNameInTable(entitiesKey, entityName) {
-    cy.get(`td[data-label="Name"] a:contains("${entityName}")`).click();
+    // RegExp constructor with exact match to prevent multiple matches like
+    // Admin
+    // Vulnerability Management Admin
+    cy.get('td[data-label="Name"]')
+        .contains('a', new RegExp(`^${entityName}$`))
+        .click();
 
     assertAccessControlEntityPage(entitiesKey);
 }


### PR DESCRIPTION
## Description

### Problem

> Access Control Permission sets list link for default Admin goes to form which has label instead of button and disabled input values

> `cy.click()` can only be called on a single element. Your subject contained 2 elements. Pass `{ multiple: true }` if you want to serially click each element.

### Analysis

`:contains` pseudo-selector for **Admin** is ambiguous after **Vulnerability Management Admin** was added in #6140

* Did not fail on branch because no changes in ui folder, therefore ui-e2e-tests did not run.
* Did not fail on merge because of caching?

### Solution

Replace `:contains` pseudo-selector with `contains` method and RegExp.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed

1. `yarn cypress-open` in ui/apps/platform
    * Verify problem and change helper function.
    * Run all accessControl tests.