### PR TITLE
Apply active vuln mgmt env var to grpc call

### DIFF
--- a/pkg/scanners/clairify/convert.go
+++ b/pkg/scanners/clairify/convert.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stackrox/rox/pkg/clair"
 	"github.com/stackrox/rox/pkg/cvss/cvssv2"
 	"github.com/stackrox/rox/pkg/cvss/cvssv3"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/scancomponent"
 	"github.com/stackrox/rox/pkg/scans"
 	"github.com/stackrox/rox/pkg/stringutils"
@@ -265,16 +266,18 @@ func convertFeature(feature *v1.Feature, os string) *storage.EmbeddedImageScanCo
 		component.Source = source
 	}
 	component.Vulns = convertVulnerabilities(feature.GetVulnerabilities(), storage.EmbeddedVulnerability_IMAGE_VULNERABILITY)
-	executables := make([]*storage.EmbeddedImageScanComponent_Executable, 0, len(feature.GetProvidedExecutables()))
-	for _, executable := range feature.GetProvidedExecutables() {
-		imageComponentIds := make([]string, 0, len(executable.GetRequiredFeatures()))
-		for _, f := range executable.GetRequiredFeatures() {
-			imageComponentIds = append(imageComponentIds, scancomponent.ComponentID(f.GetName(), f.GetVersion(), os))
+	if env.ActiveVulnMgmt.BooleanSetting() {
+		executables := make([]*storage.EmbeddedImageScanComponent_Executable, 0, len(feature.GetProvidedExecutables()))
+		for _, executable := range feature.GetProvidedExecutables() {
+			imageComponentIds := make([]string, 0, len(executable.GetRequiredFeatures()))
+			for _, f := range executable.GetRequiredFeatures() {
+				imageComponentIds = append(imageComponentIds, scancomponent.ComponentID(f.GetName(), f.GetVersion(), os))
+			}
+			exec := &storage.EmbeddedImageScanComponent_Executable{Path: executable.GetPath(), Dependencies: imageComponentIds}
+			executables = append(executables, exec)
 		}
-		exec := &storage.EmbeddedImageScanComponent_Executable{Path: executable.GetPath(), Dependencies: imageComponentIds}
-		executables = append(executables, exec)
+		component.Executables = executables
 	}
-	component.Executables = executables
 
 	return component
 }


### PR DESCRIPTION
## Description

This was applied to the normal scan path but not to the grpc scan path

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Trivial