### PR TITLE
ROX-17480: Use correct module name in logger

### DIFF
--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -268,7 +268,7 @@ func GetGlobalLogLevel() zapcore.Level {
 
 // LoggerForModule returns a logger for the current module.
 func LoggerForModule() Logger {
-	return CurrentModule().Logger()
+	return currentModule(3).Logger()
 }
 
 // convenience methods log apply to root logger
@@ -367,7 +367,9 @@ func SortedLevels() []zapcore.Level {
 // Skip allows to specify how much layers of nested calls we will skip during logging.
 func CreateLogger(module *Module, skip int) *LoggerImpl {
 	lc := config
-	return createLoggerWithConfig(&lc, module, skip)
+	// Need to increase the skip by 1 by default since we call the logger inline. Otherwise, the location of the caller
+	// would also be set to this file.
+	return createLoggerWithConfig(&lc, module, skip+1)
 }
 
 func createLoggerWithConfig(lc *zap.Config, module *Module, skip int) *LoggerImpl {


### PR DESCRIPTION
## Description

Within a refactor of the logging interface the `LoggerForModule()` was refactored to use `CurrentModule().Logger()` instead of `currentModule(3).Logger()`.

In itself, `CurrentModule()` will call `currentModule(3)`, however since the caller will now be the logging package itself (specifically `pkg/logging`), `currentModule(3)` will now yield `pkg/logging` instead of the package where `LoggerForModule()` originally was being called from.

Subsequently, if one were to use `currentModule(4)` instead, the package name would be yielded correctly.

Since `CurrentModule()` is already in use in a few places, reverted the refactoring back to use `curerntModule(3).Logger()` instead.

For the location of the log call (i.e. the `logging.go:170` part, the `AddCallerSkip` option of the zap logger was required to be increased by 1. The reason is that the logger now instead calls the logger in-line within the `Logger` implementation. Previously, the struct fields were embedded, and thus it wasn't required to skip the call from within `logging.go`.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

- see CI tests passing.

- see within E2E test logs that the correct package name is now prefixed instead of `pkg/logging` everywhere and the location also checks out now.

```log
auth/userpass: 2023/06/07 08:09:08.097052 watch_handler.go:38: Info: htpasswd file found. Updating basic auth credentials
imageintegration/datastore: 2023/06/07 08:09:08.129548 singleton.go:58: Info: Completed deletion of 'sourced' image integrations
policycategory/datastore: 2023/06/07 08:09:08.215566 singleton.go:70: Info: Loaded 12 default policy categories
policy/datastore: 2023/06/07 08:09:08.858869 singleton.go:106: Info: Loaded 84 new default Policies
declarativeconfig: 2023/06/07 08:09:09.097657 manager_impl.go:143: Info: Start watch handler for declarative configuration for path /run/stackrox.io/declarative-configuration/declarative-configurations
```
