### PR TITLE
ROX-17622: Fix ImageScanningTest error message

### DIFF
--- a/qa-tests-backend/src/test/groovy/ImageScanningTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageScanningTest.groovy
@@ -523,8 +523,8 @@ class ImageScanningTest extends BaseSpecification {
         "tests are:"
 
         scanner                          | expectedMessage                      | testAspect
-        new ClairScannerIntegration()    | /Failed to get the manifest digest/  | "image does not exist"
-        new StackroxScannerIntegration() | /Failed to get the manifest digest/  | "image does not exist"
+        new ClairScannerIntegration()    | /failed to get the manifest digest/  | "image does not exist"
+        new StackroxScannerIntegration() | /failed to get the manifest digest/  | "image does not exist"
         new ClairScannerIntegration()    | /no matching image registries found/ | "missing required registry"
         new StackroxScannerIntegration() | /no matching image registries found/ | "missing required registry"
 // This is not supported. Scanners get access to previous creds and can pull the images that way.


### PR DESCRIPTION
## Description

We previously refactored the metadata function and made [the returned error lowercase](https://github.com/stackrox/stackrox/commit/fe9b99ed2dcd9c26e99bc4a089c561be1f70b8fe#diff-fb9aae01acef1decdba85965a284ff9c4388f66ceb350ea68c6e51dfe95a2a2dR210) (which it should have been to begin with), so adjusting the 
test to get rid of the failures.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

- see CI passing
