### PR TITLE
ROX-14267: Allow central to `get pods/log`

### DIFF
--- a/image/templates/helm/stackrox-central/templates/01-central-03-diagnostics-rbac.yaml
+++ b/image/templates/helm/stackrox-central/templates/01-central-03-diagnostics-rbac.yaml
@@ -20,6 +20,7 @@ rules:
   - "configmaps"
   - "services"
   - "pods"
+  - "pods/log"
   - "events"
   - "namespaces"
   verbs:

--- a/pkg/k8sintrospect/collector.go
+++ b/pkg/k8sintrospect/collector.go
@@ -183,7 +183,8 @@ func (c *collector) collectPodData(pod *v1.Pod) error {
 			}
 			logsData, err := c.client.CoreV1().Pods(pod.GetNamespace()).GetLogs(pod.GetName(), podLogOpts).DoRaw(c.ctx)
 			if err != nil {
-				logsData = []byte(fmt.Sprintf("Error retrieving container logs: %v", err))
+				logsData = []byte(fmt.Sprintf("Error retrieving container logs: %v\n", err))
+				logsData = appendDebugError(logsData, err)
 			} else {
 				logsData = truncateLogData(logsData, maxLogFileSize, maxFirstLineCutOff)
 			}
@@ -208,7 +209,8 @@ func (c *collector) collectPodData(pod *v1.Pod) error {
 			}
 			logsData, err := c.client.CoreV1().Pods(pod.GetNamespace()).GetLogs(pod.GetName(), podLogOpts).DoRaw(c.ctx)
 			if err != nil {
-				logsData = []byte(fmt.Sprintf("Error retrieving previous container logs: %v", err))
+				logsData = []byte(fmt.Sprintf("Error retrieving previous container logs: %v\n", err))
+				logsData = appendDebugError(logsData, err)
 			} else {
 				logsData = truncateLogData(logsData, maxLogFileSize, maxFirstLineCutOff)
 			}
@@ -220,6 +222,14 @@ func (c *collector) collectPodData(pod *v1.Pod) error {
 	}
 
 	return nil
+}
+
+func appendDebugError(logsData []byte, err error) []byte {
+	var serr *k8sErrors.StatusError
+	if errors.As(err, &serr) {
+		logsData = append(logsData, fmt.Sprintf(serr.DebugError())...)
+	}
+	return logsData
 }
 
 func (c *collector) recordError(err error) {

--- a/pkg/k8sintrospect/collector.go
+++ b/pkg/k8sintrospect/collector.go
@@ -227,8 +227,8 @@ func (c *collector) collectPodData(pod *v1.Pod) error {
 func appendDebugError(logsData []byte, err error) []byte {
 	var serr *k8sErrors.StatusError
 	if errors.As(err, &serr) {
-		fsf := fmt.Sprintf // supress roxvet error: DebugError() returns format.
-		logsData = append(logsData, fsf(serr.DebugError())...)
+		f, status := serr.DebugError()
+		logsData = append(logsData, fmt.Sprintf(f, status)...)
 	}
 	return logsData
 }

--- a/pkg/k8sintrospect/collector.go
+++ b/pkg/k8sintrospect/collector.go
@@ -227,7 +227,8 @@ func (c *collector) collectPodData(pod *v1.Pod) error {
 func appendDebugError(logsData []byte, err error) []byte {
 	var serr *k8sErrors.StatusError
 	if errors.As(err, &serr) {
-		logsData = append(logsData, fmt.Sprintf(serr.DebugError())...)
+		fsf := fmt.Sprintf // supress roxvet error: DebugError() returns format.
+		logsData = append(logsData, fsf(serr.DebugError())...)
 	}
 	return logsData
 }


### PR DESCRIPTION
## Description

* Added error debug message for the case when logs cannot be retrieved;
* Added "get pods/log" permission to the `stackrox-central-diagnostic` role.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] ~Unit test and regression tests added~
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

Tested with local setup.

Before giving permissions:
```
Error retrieving container logs: unknown (get pods central-756858c7cf-6wgts)
server response object: [{
  "metadata": {},
  "status": "Failure",
  "message": "unknown (get pods central-756858c7cf-6wgts)",
  "reason": "Forbidden",
  "details": {
    "name": "central-756858c7cf-6wgts",
    "kind": "pods",
    "causes": [
      {
        "reason": "UnexpectedServerResponse",
        "message": "unknown"
      }
    ]
  },
  "code": 403
}]
```
