### PR TITLE
fix: Remove resource replacement banner text for old previous releases

### DIFF
--- a/central/main.go
+++ b/central/main.go
@@ -262,12 +262,6 @@ func main() {
 	log.Infof("Running StackRox Version: %s", pkgVersion.GetMainVersion())
 	log.Warn("The following permission resources have been replaced:\n" +
 		"	Access replaces AuthProvider, Group, Licenses, and User\n" +
-		"	Administration replaces AllComments, Config, DebugLogs, NetworkGraphConfig, ProbeUpload, ScannerBundle, ScannerDefinitions, SensorUpgradeConfig, and ServiceIdentity\n" +
-		"	Cluster also covers ClusterCVE\n" +
-		"	Compliance replaces ComplianceRuns\n" +
-		"	DeploymentExtension replaces Indicator, NetworkBaseline, ProcessWhitelist, and Risk\n" +
-		"	Integration replaces APIToken, BackupPlugins, ImageIntegration, Notifier, and SignatureIntegration\n" +
-		"	Image now also covers ImageComponent\n" +
 		"The following permission resources will be replaced in the upcoming versions:\n" +
 		"	Access will replace Role\n" +
 		"	WorkflowAdministration will replace Policy and VulnerabilityReports.")

--- a/ui/apps/platform/src/Containers/AccessControl/AccessControl.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessControl.tsx
@@ -28,34 +28,6 @@ function AccessControl(): ReactElement {
                                 <b>Access</b> replaces{' '}
                                 <b>AuthProvider, Group, Licenses, Role, and User</b>
                             </ListItem>
-                            <ListItem>
-                                <b>Administration</b> replaces{' '}
-                                <b>
-                                    AllComments, Config, DebugLogs, NetworkGraphConfig, ProbeUpload,
-                                    ScannerBundle, ScannerDefinitions, SensorUpgradeConfig, and
-                                    ServiceIdentity
-                                </b>
-                            </ListItem>
-                            <ListItem>
-                                <b>Compliance</b> replaces <b>ComplianceRuns</b>
-                            </ListItem>
-                            <ListItem>
-                                <b>DeploymentExtension</b> replaces{' '}
-                                <b>Indicator, NetworkBaseline, ProcessWhitelist, and Risk</b>
-                            </ListItem>
-                            <ListItem>
-                                <b>Integration</b> replaces{' '}
-                                <b>
-                                    APIToken, BackupPlugins, ImageIntegration, Notifier, and
-                                    SignatureIntegration
-                                </b>
-                            </ListItem>
-                            <ListItem>
-                                <b>Image</b> now also covers <b>ImageComponent</b>
-                            </ListItem>
-                            <ListItem>
-                                <b>Cluster</b> now also covers <b>ClusterCVE</b>
-                            </ListItem>
                         </List>
 
                         <p>


### PR DESCRIPTION
## Description

Remove the notions of `Administration`, `Compliance`, `DeploymentExtension`, `Integration`, `Image`, and `Cluster` (they were done in 3.73/3.74).

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

<img width="1779" alt="Screenshot 2023-06-07 at 13 58 10" src="https://github.com/stackrox/stackrox/assets/78353299/f6d55be3-4f6c-4503-bc5f-6c51346e0c48">
