### PR TITLE
ROX-17644: Make GlobalSearch test multi-arch compliant

### DIFF
--- a/qa-tests-backend/src/test/groovy/GlobalSearch.groovy
+++ b/qa-tests-backend/src/test/groovy/GlobalSearch.groovy
@@ -16,7 +16,7 @@ class GlobalSearch extends BaseSpecification {
 
     static final private DEPLOYMENT = new Deployment()
             .setName("qaglobalsearch")
-            .setImage("busybox")
+            .setImage("quay.io/rhacs-eng/qa-multi-arch-busybox:latest")
             .addPort(22)
             .addLabel("app", "test")
             .setCommand(["sleep", "600"])
@@ -101,8 +101,8 @@ class GlobalSearch extends BaseSpecification {
         "Deployment:qaglobalsearch" | [SearchServiceOuterClass.SearchCategory.DEPLOYMENTS] |
                 "qaglobalsearch" | []
 
-        "Image:docker.io/library/busybox:latest" | [SearchServiceOuterClass.SearchCategory.IMAGES] |
-                "docker.io/library/busybox:latest" | []
+        "Image:quay.io/rhacs-eng/qa-multi-arch-busybox:latest" | [SearchServiceOuterClass.SearchCategory.IMAGES] |
+                "quay.io/rhacs-eng/qa-multi-arch-busybox:latest" | []
 
         // This implicitly depends on the policy above triggering on the deployment created during this test.
         "Violation State:ACTIVE+Policy:Latest" | [SearchServiceOuterClass.SearchCategory.ALERTS] | "Latest" | []
@@ -116,7 +116,7 @@ class GlobalSearch extends BaseSpecification {
         // when you don't specify a category.
         "Deployment:qaglobalsearch" | [] | "" | EXPECTED_DEPLOYMENT_CATEGORIES
 
-        "Image:docker.io/library/busybox:latest" | [] | "" | EXPECTED_IMAGE_CATEGORIES
+        "Image:quay.io/rhacs-eng/qa-multi-arch-busybox:latest" | [] | "" | EXPECTED_IMAGE_CATEGORIES
 
         "Subject:system:auth" | [SearchServiceOuterClass.SearchCategory.SUBJECTS] | "system:authenticated" | []
     }


### PR DESCRIPTION
This PR intends to add multi-arch support for the `GlobalSearch` QA test.
Test images used in respective test are changed to use alternate multi-arch images which support 3 platforms viz. `x86_64`, `ppc64le` and `s390x`.

Changes are verified manually using `./gradlew test --tests=GlobalSearch`

Part of this PR intends to fix [ROX-17644](https://issues.redhat.com/browse/ROX-17644)