### PR TITLE
ROX-17642: Filter according to hideScanResults in EntityCompliance

### DIFF
--- a/ui/apps/platform/src/Containers/Compliance/widgets/EntityCompliance.js
+++ b/ui/apps/platform/src/Containers/Compliance/widgets/EntityCompliance.js
@@ -82,7 +82,6 @@ const EntityCompliance = ({ entityType, entityName, clusterName }) => {
                             <NoResultsMessage message="No data available. Please ensure your cluster is properly configured." />
                         );
                     } else {
-                        console.log(JSON.stringify(results, null, 2));
                         const barData = getBarData(results);
                         const totals = getTotals(results);
                         const pct =


### PR DESCRIPTION
## Description

### Problem

After change to `hideScanResults` properties of standards, Compliance entity side panel:
* does **not** filter EntityCompliance vertical bar chart
* does filter sunburst graphs

### Analysis and solution

Similar to #6281

### Residue

1. See item 4 under **Testing Performed** for `isControlList` code path in Table.js file, which does not seem to have access to `complianceStandards` array without risky amout of refactoring. Thankfully, the entity single page seems off the main path.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

In ui folder: 

1. `export ROX_DISABLE_COMPLIANCE_STANDARDS=true`

2. `yarn start`

### Manual testing

1. Visit /main/compliance, click **deployments** button, and then click a deployment: see 5 standards in vertical bar chart and sunburst graphs (that is, all except CIS Kubernetes, which is not relevant for deployments).

2. Go back to dashboard, click **Manage standards**, click to clear **HIPAA 164** and **PCI DSS 3.2.1** standards, and then click **Save**: see filtering in bar charts and sunburst graphs.

3. Go forward to deployment side panel: see 5 - 2 = 3 standards
    * table columns
    * EntityCompliance vertical bar chart
    * sunburst graphs
    ![EntityCompliance](https://github.com/stackrox/stackrox/assets/11862657/9534de5c-2115-4cda-8645-843baded35bc)

4. Click deployment link to single page, and then click **Controls**: see 5 standards. 
    ![isControlList_Table](https://github.com/stackrox/stackrox/assets/11862657/840f026f-9fda-45c6-9fde-976be3bff148)
