### PR TITLE
ROX-16726: Propagate collection method for operator-based deployment

### DIFF
--- a/scripts/ci/jobs/ocp_core_bpf_qa_e2e_tests.py
+++ b/scripts/ci/jobs/ocp_core_bpf_qa_e2e_tests.py
@@ -9,7 +9,7 @@ from base_qa_e2e_test import make_qa_e2e_test_runner
 from clusters import OpenShiftScaleWorkersCluster
 
 # set required test parameters
-os.environ["DEPLOY_STACKROX_VIA_OPERATOR"] = "true"
+os.environ["DEPLOY_STACKROX_VIA_OPERATOR"] = "false"
 os.environ["ORCHESTRATOR_FLAVOR"] = "openshift"
 os.environ["ROX_POSTGRES_DATASTORE"] = "true"
 

--- a/scripts/ci/jobs/ocp_core_bpf_qa_e2e_tests.py
+++ b/scripts/ci/jobs/ocp_core_bpf_qa_e2e_tests.py
@@ -9,7 +9,7 @@ from base_qa_e2e_test import make_qa_e2e_test_runner
 from clusters import OpenShiftScaleWorkersCluster
 
 # set required test parameters
-os.environ["DEPLOY_STACKROX_VIA_OPERATOR"] = "false"
+os.environ["DEPLOY_STACKROX_VIA_OPERATOR"] = "true"
 os.environ["ORCHESTRATOR_FLAVOR"] = "openshift"
 os.environ["ROX_POSTGRES_DATASTORE"] = "true"
 

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -290,6 +290,7 @@ deploy_sensor_via_operator() {
     fi
 
     if [[ -n "${COLLECTION_METHOD:-}" ]]; then
+       echo "Using COLLECTION_METHOD=${COLLECTION_METHOD}"
        kubectl -n stackrox set env ds/collector COLLECTION_METHOD="${COLLECTION_METHOD}"
     fi
 

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -289,6 +289,10 @@ deploy_sensor_via_operator() {
        kubectl -n stackrox set env ds/collector ROX_PROCESSES_LISTENING_ON_PORT="${ROX_PROCESSES_LISTENING_ON_PORT}"
     fi
 
+    if [[ -n "${COLLECTION_METHOD:-}" ]]; then
+       kubectl -n stackrox set env ds/collector COLLECTION_METHOD="${COLLECTION_METHOD}"
+    fi
+
     # Every E2E test should have ROX_RESYNC_DISABLED="true"
     kubectl -n stackrox set env deployment/sensor ROX_RESYNC_DISABLED="true"
 }


### PR DESCRIPTION
## Description

The default value for the operator based deployment is specified via SecuredCluster CRD and is ebpf. This prevents using core_bpf in E2E tests.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient.