### PR TITLE
fix(ui): Correctly handle phrasing for date distance text

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/ImageResourceTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/ImageResourceTable.tsx
@@ -3,7 +3,7 @@ import { TableComposable, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-tab
 import { gql } from '@apollo/client';
 
 import { UseURLSortResult } from 'hooks/useURLSort';
-import DatePhraseTd from '../components/DatePhraseTd';
+import DateDistanceTd from '../components/DatePhraseTd';
 import EmptyTableResults from '../components/EmptyTableResults';
 import ImageNameTd from '../components/ImageNameTd';
 
@@ -70,7 +70,7 @@ function ImageResourceTable({ data, getSortParams }: ImageResourceTableProps) {
                             <Td>{deploymentCount > 0 ? 'Active' : 'Inactive'}</Td>
                             <Td>{operatingSystem}</Td>
                             <Td>
-                                <DatePhraseTd date={scanTime} />
+                                <DateDistanceTd date={scanTime} />
                             </Td>
                         </Tr>
                     </Tbody>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/DeploymentResourceTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/DeploymentResourceTable.tsx
@@ -5,7 +5,7 @@ import { gql } from '@apollo/client';
 
 import LinkShim from 'Components/PatternFly/LinkShim';
 import { UseURLSortResult } from 'hooks/useURLSort';
-import DatePhraseTd from '../components/DatePhraseTd';
+import DateDistanceTd from '../components/DatePhraseTd';
 import EmptyTableResults from '../components/EmptyTableResults';
 import { getEntityPagePath } from '../searchUtils';
 
@@ -72,7 +72,7 @@ function DeploymentResourceTable({ data, getSortParams }: DeploymentResourceTabl
                             <Td>{clusterName}</Td>
                             <Td>{namespace}</Td>
                             <Td>
-                                <DatePhraseTd date={created} />
+                                <DateDistanceTd date={created} />
                             </Td>
                         </Tr>
                     </Tbody>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedDeploymentsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedDeploymentsTable.tsx
@@ -24,7 +24,7 @@ import DeploymentComponentVulnerabilitiesTable, {
     imageMetadataContextFragment,
 } from './DeploymentComponentVulnerabilitiesTable';
 import SeverityCountLabels from '../components/SeverityCountLabels';
-import DatePhraseTd from '../components/DatePhraseTd';
+import DateDistanceTd from '../components/DatePhraseTd';
 import { VulnerabilitySeverityLabel } from '../types';
 
 export type DeploymentForCve = {
@@ -159,7 +159,7 @@ function AffectedDeploymentsTable({
                             </Td>
 
                             <Td modifier="nowrap" dataLabel="First discovered">
-                                <DatePhraseTd date={created} />
+                                <DateDistanceTd date={created} />
                             </Td>
                         </Tr>
                         <Tr isExpanded={isExpanded}>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedImagesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedImagesTable.tsx
@@ -28,7 +28,7 @@ import ImageComponentVulnerabilitiesTable, {
     imageMetadataContextFragment,
 } from './ImageComponentVulnerabilitiesTable';
 import EmptyTableResults from '../components/EmptyTableResults';
-import DatePhraseTd from '../components/DatePhraseTd';
+import DateDistanceTd from '../components/DatePhraseTd';
 import CvssTd from '../components/CvssTd';
 
 export type ImageForCve = {
@@ -148,7 +148,7 @@ function AffectedImagesTable({ images, getSortParams, isFiltered }: AffectedImag
                                     : `${imageComponents.length} components`}
                             </Td>
                             <Td dataLabel="First discovered">
-                                <DatePhraseTd date={scanTime} />
+                                <DateDistanceTd date={scanTime} />
                             </Td>
                         </Tr>
                         <Tr isExpanded={isExpanded}>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/CVEsTable.tsx
@@ -19,7 +19,7 @@ import { getEntityPagePath } from '../searchUtils';
 import TooltipTh from '../components/TooltipTh';
 import SeverityCountLabels from '../components/SeverityCountLabels';
 import { DynamicColumnIcon } from '../components/DynamicIcon';
-import DatePhraseTd from '../components/DatePhraseTd';
+import DateDistanceTd from '../components/DatePhraseTd';
 import CvssTd from '../components/CvssTd';
 import {
     getScoreVersionsForTopCVSS,
@@ -207,7 +207,7 @@ function CVEsTable({
                                     {affectedImageCount}/{unfilteredImageCount} affected images
                                 </Td>
                                 <Td>
-                                    <DatePhraseTd date={firstDiscoveredInSystem} />
+                                    <DateDistanceTd date={firstDiscoveredInSystem} />
                                 </Td>
                             </Tr>
                             <Tr isExpanded={isExpanded}>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx
@@ -28,7 +28,7 @@ import DeploymentComponentVulnerabilitiesTable, {
     deploymentComponentVulnerabilitiesFragment,
 } from './DeploymentComponentVulnerabilitiesTable';
 import { getAnyVulnerabilityIsFixable, getHighestVulnerabilitySeverity } from './table.utils';
-import DatePhraseTd from '../components/DatePhraseTd';
+import DateDistanceTd from '../components/DatePhraseTd';
 
 export const deploymentWithVulnerabilitiesFragment = gql`
     ${deploymentComponentVulnerabilitiesFragment}
@@ -203,7 +203,7 @@ function DeploymentVulnerabilitiesTable({
                             </Td>
                             <Td dataLabel="Affected components">{affectedComponentsText}</Td>
                             <Td modifier="nowrap" dataLabel="First discovered">
-                                <DatePhraseTd date={discoveredAtImage} />
+                                <DateDistanceTd date={discoveredAtImage} />
                             </Td>
                         </Tr>
                         <Tr isExpanded={isExpanded}>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentsTable.tsx
@@ -10,7 +10,7 @@ import { getEntityPagePath } from '../searchUtils';
 import SeverityCountLabels from '../components/SeverityCountLabels';
 import { DynamicColumnIcon } from '../components/DynamicIcon';
 import EmptyTableResults from '../components/EmptyTableResults';
-import DatePhraseTd from '../components/DatePhraseTd';
+import DateDistanceTd from '../components/DatePhraseTd';
 import TooltipTh from '../components/TooltipTh';
 import { VulnerabilitySeverityLabel } from '../types';
 
@@ -139,7 +139,7 @@ function DeploymentsTable({
                                     </>
                                 </Td>
                                 <Td>
-                                    <DatePhraseTd date={created} />
+                                    <DateDistanceTd date={created} />
                                 </Td>
                             </Tr>
                         </Tbody>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
@@ -26,7 +26,7 @@ import ImageComponentVulnerabilitiesTable, {
 } from './ImageComponentVulnerabilitiesTable';
 
 import EmptyTableResults from '../components/EmptyTableResults';
-import DatePhraseTd from '../components/DatePhraseTd';
+import DateDistanceTd from '../components/DatePhraseTd';
 import CvssTd from '../components/CvssTd';
 import { getAnyVulnerabilityIsFixable } from './table.utils';
 
@@ -143,7 +143,7 @@ function ImageVulnerabilitiesTable({
                                         : `${imageComponents.length} components`}
                                 </Td>
                                 <Td dataLabel="First discovered">
-                                    <DatePhraseTd date={discoveredAtImage} />
+                                    <DateDistanceTd date={discoveredAtImage} />
                                 </Td>
                             </Tr>
                             <Tr isExpanded={isExpanded}>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImagesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImagesTable.tsx
@@ -9,7 +9,7 @@ import ImageNameTd from '../components/ImageNameTd';
 import SeverityCountLabels from '../components/SeverityCountLabels';
 import { DynamicColumnIcon } from '../components/DynamicIcon';
 import EmptyTableResults from '../components/EmptyTableResults';
-import DatePhraseTd from '../components/DatePhraseTd';
+import DateDistanceTd from '../components/DatePhraseTd';
 import TooltipTh from '../components/TooltipTh';
 import { VulnerabilitySeverityLabel, watchStatusLabel, WatchStatus } from '../types';
 
@@ -159,10 +159,10 @@ function ImagesTable({ images, getSortParams, isFiltered, filteredSeverities }: 
                                     )}
                                 </Td>
                                 <Td>
-                                    <DatePhraseTd date={metadata?.v1?.created} />
+                                    <DateDistanceTd date={metadata?.v1?.created} asPhrase={false} />
                                 </Td>
                                 <Td>
-                                    <DatePhraseTd date={scanTime} />
+                                    <DateDistanceTd date={scanTime} />
                                 </Td>
                             </Tr>
                         </Tbody>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/DatePhraseTd.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/DatePhraseTd.tsx
@@ -1,21 +1,26 @@
 import React from 'react';
 import { Tooltip } from '@patternfly/react-core';
 
-import { getDateTime, getDistanceStrictAsPhrase } from 'utils/dateUtils';
+import { getDateTime, getDistanceStrict, getDistanceStrictAsPhrase } from 'utils/dateUtils';
 
-export type DatePhraseTdProps = {
+export type DateDistanceTdProps = {
     date: string | number | Date | null | undefined;
+    asPhrase?: boolean;
 };
 
-function DatePhraseTd({ date }: DatePhraseTdProps) {
+function DateDistanceTd({ date, asPhrase = true }: DateDistanceTdProps) {
     if (!date) {
         return null;
     }
     return (
         <Tooltip content={getDateTime(date)}>
-            <span>{getDistanceStrictAsPhrase(date, new Date())}</span>
+            <span>
+                {asPhrase
+                    ? getDistanceStrictAsPhrase(date, new Date())
+                    : getDistanceStrict(date, new Date())}
+            </span>
         </Tooltip>
     );
 }
 
-export default DatePhraseTd;
+export default DateDistanceTd;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ImageDetailBadges.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ImageDetailBadges.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { LabelGroup, Label } from '@patternfly/react-core';
 import { gql } from '@apollo/client';
 
-import { getDistanceStrictAsPhrase, getDateTime } from 'utils/dateUtils';
+import { getDistanceStrict, getDateTime } from 'utils/dateUtils';
 
 export type ImageDetails = {
     deploymentCount: number;
@@ -45,7 +45,7 @@ function ImageDetailBadges({ imageData }: ImageDetailBadgesProps) {
         <LabelGroup numLabels={Infinity}>
             <Label color={isActive ? 'green' : 'gold'}>{isActive ? 'Active' : 'Inactive'}</Label>
             {operatingSystem && <Label>OS: {operatingSystem}</Label>}
-            {created && <Label>Age: {getDistanceStrictAsPhrase(created, new Date())}</Label>}
+            {created && <Label>Age: {getDistanceStrict(created, new Date())}</Label>}
             {scanTime && (
                 <Label>
                     Scan time: {getDateTime(scanTime)} by {dataSource?.name ?? 'Unknown Scanner'}


### PR DESCRIPTION
## Description

Changes the "Age" badge on the image single page and the "Age" column on the image overview table to read e.g. "3 months" instead of "3 months ago".

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Image overview table:
![image](https://github.com/stackrox/stackrox/assets/1292638/70903049-40e7-475b-88d7-abf544347d19)

Image single page:
![image](https://github.com/stackrox/stackrox/assets/1292638/8789f597-89e3-4026-9e53-28f3b1375214)

