### PR TITLE
fix(check-pr): increase max length of PR title

### DIFF
--- a/.github/workflows/check-pr-title.yaml
+++ b/.github/workflows/check-pr-title.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Check PR title length
         if: github.event.pull_request.user.login != 'dependabot[bot]'
         env:
-          LENGTH: '70'
+          LENGTH: '120'
         run: |
           TITLE_LENGTH="$(echo -nE "$PR_TITLE" | wc --chars)"
           if [ "$TITLE_LENGTH" -gt "$LENGTH" ]


### PR DESCRIPTION
## Description

I'd favor to increase the length of the PR title, it's currently a bit hard to create meaningful PR titles with the current limitations of 70 characters.

As examples:
- https://github.com/stackrox/stackrox/pull/6309
- https://github.com/stackrox/stackrox/pull/6378

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

