### PR TITLE
ROX-17028: Network policies list inconsistencies

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/common/NetworkPolicies.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/common/NetworkPolicies.tsx
@@ -16,6 +16,7 @@ import {
 import { CodeEditor, CodeEditorControl, Language } from '@patternfly/react-code-editor';
 import { MoonIcon, SunIcon } from '@patternfly/react-icons';
 
+import useURLParameter from 'hooks/useURLParameter';
 import download from 'utils/download';
 import SelectSingle from 'Components/SelectSingle';
 import { useTheme } from 'Containers/ThemeProvider';
@@ -31,12 +32,17 @@ type NetworkPolicyYAML = {
     yaml: string;
 };
 
-const allNetworkPoliciesId = 'network-policy-combined-yaml-pf-key';
+const allNetworkPoliciesId = 'All network policies';
 
 function NetworkPolicies({ entityName, policyIds }: NetworkPoliciesProps): React.ReactElement {
     const { networkPolicies, isLoading, error } = useFetchNetworkPolicies(policyIds);
     const { isDarkMode } = useTheme();
     const [customDarkMode, setCustomDarkMode] = React.useState(isDarkMode);
+    const [selectednetpolicy, setSelectednetpolicy] = useURLParameter(
+        'selectednetpolicy',
+        undefined
+    );
+    console.log({ selectednetpolicy });
 
     const allNetworkPoliciesYAML = useMemo(
         () => ({
@@ -126,7 +132,9 @@ function NetworkPolicies({ entityName, policyIds }: NetworkPoliciesProps): React
                         handleSelect={handleSelectedNetworkPolicy}
                         placeholderText="Select a network policy"
                     >
-                        <SelectOption value="all">All network policies</SelectOption>
+                        <SelectOption value={allNetworkPoliciesId}>
+                            All network policies
+                        </SelectOption>
                         <Divider component="li" />
                         <>
                             {networkPolicies.map((networkPolicy) => {

--- a/ui/apps/platform/src/Containers/NetworkGraph/common/NetworkPolicies.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/common/NetworkPolicies.tsx
@@ -16,7 +16,6 @@ import {
 import { CodeEditor, CodeEditorControl, Language } from '@patternfly/react-code-editor';
 import { MoonIcon, SunIcon } from '@patternfly/react-icons';
 
-import useURLParameter from 'hooks/useURLParameter';
 import download from 'utils/download';
 import SelectSingle from 'Components/SelectSingle';
 import { useTheme } from 'Containers/ThemeProvider';
@@ -38,11 +37,6 @@ function NetworkPolicies({ entityName, policyIds }: NetworkPoliciesProps): React
     const { networkPolicies, isLoading, error } = useFetchNetworkPolicies(policyIds);
     const { isDarkMode } = useTheme();
     const [customDarkMode, setCustomDarkMode] = React.useState(isDarkMode);
-    const [selectednetpolicy, setSelectednetpolicy] = useURLParameter(
-        'selectednetpolicy',
-        undefined
-    );
-    console.log({ selectednetpolicy });
 
     const allNetworkPoliciesYAML = useMemo(
         () => ({

--- a/ui/apps/platform/src/hooks/useFetchNetworkPolicies.ts
+++ b/ui/apps/platform/src/hooks/useFetchNetworkPolicies.ts
@@ -1,4 +1,5 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
+import useDeepCompareEffect from 'use-deep-compare-effect';
 
 import { fetchNetworkPolicies } from 'services/NetworkService';
 import { NetworkPolicy } from 'types/networkPolicy.proto';
@@ -13,7 +14,7 @@ const defaultResultState = { networkPolicies: [], error: null, isLoading: true }
 function useFetchNetworkPolicies(policyIds: string[]): Result {
     const [result, setResult] = useState<Result>(defaultResultState);
 
-    useEffect(() => {
+    useDeepCompareEffect(() => {
         setResult(defaultResultState);
 
         if (policyIds) {


### PR DESCRIPTION
## Description

Minimum viable fix, based on Saif's groundwork in draft PR #6170 

## Checklist
- [x] Investigated and inspected CI test results (ui-e2e failure is unrelated, being fixed by another team)

## Testing Performed

Name of "All network policies is now there, and policies YAML doesn't re-render and go back to all, if policy IDs in prop object haven't changed.

![Screen Shot 2023-06-07 at 4 36 59 PM](https://github.com/stackrox/stackrox/assets/715729/020c3ae5-bd35-4049-a5ca-79822acf6550)
