### PR TITLE
fix(ui): Skip hideScanResults integration tests for openshift

### DIFF
--- a/ui/apps/platform/cypress/integration/compliance/hideScanResults.test.js
+++ b/ui/apps/platform/cypress/integration/compliance/hideScanResults.test.js
@@ -1,5 +1,5 @@
 import withAuth from '../../helpers/basicAuth';
-import { hasFeatureFlag } from '../../helpers/features';
+import { hasFeatureFlag, hasOrchestratorFlavor } from '../../helpers/features';
 import { getInputByLabel } from '../../helpers/formHelpers';
 
 import { visitComplianceDashboard } from './Compliance.helpers';
@@ -60,6 +60,10 @@ describe('Compliance hideScanResults', () => {
 
     before(function beforeHook() {
         if (!hasFeatureFlag('ROX_DISABLE_COMPLIANCE_STANDARDS')) {
+            this.skip();
+        }
+
+        if (hasOrchestratorFlavor('openshift')) {
             this.skip();
         }
     });


### PR DESCRIPTION
## Description

> Compliance hideScanResults should hide HIPAA standard: should hide HIPAA standard
Message

> Timed out retrying after 4000ms: Expected to find element: `.widget:has('[data-testid="widget-header"]:contains("Passing standards across clusters")') a:contains("HIPAA")`, but never found it.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed