### PR TITLE
ROX-17413: Fix ComplianceTest

### DIFF
--- a/qa-tests-backend/src/test/groovy/ComplianceTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ComplianceTest.groovy
@@ -1326,14 +1326,14 @@ class ComplianceTest extends BaseSpecification {
         String testRole = RoleService.createRoleWithScopeAndPermissionSet(
                 "Compliance Test Automation Role " + UUID.randomUUID(),
                 remoteStackroxAccessScope.id, [
-                "Access"               : READ_WRITE_ACCESS,
-                "Administration"       : READ_WRITE_ACCESS,
-                "Detection"            : READ_WRITE_ACCESS,
-                "Integration"          : READ_WRITE_ACCESS,
-                "Policy"               : READ_WRITE_ACCESS,
-                "Cluster"              : READ_WRITE_ACCESS,
-                "Compliance"           : READ_WRITE_ACCESS,
-                "Node"                 : READ_WRITE_ACCESS,
+                "Access"                    : READ_WRITE_ACCESS,
+                "Administration"            : READ_WRITE_ACCESS,
+                "Detection"                 : READ_WRITE_ACCESS,
+                "Integration"               : READ_WRITE_ACCESS,
+                "WorkflowAdministration"    : READ_WRITE_ACCESS,
+                "Cluster"                   : READ_WRITE_ACCESS,
+                "Compliance"                : READ_WRITE_ACCESS,
+                "Node"                      : READ_WRITE_ACCESS,
         ]).name
 
         "Enable SAC token and add other cluster"


### PR DESCRIPTION
## Description

This PR fixes the ComplianceRuns tests after the `Policy` resource was removed. It now uses the replaced resource `WorkflowAdministration`.
## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

- see CI passing.
