### PR TITLE
ROX-17567: bump the sleep to allow sensor finish processing all messages

### DIFF
--- a/sensor/tests/replay/helper.go
+++ b/sensor/tests/replay/helper.go
@@ -129,7 +129,7 @@ func RunReplayTest(t *testing.T, suite Suite, writer *TraceWriterWithChannel, k8
 	}()
 	writer.disable()
 	// Wait for the re-sync to happen
-	time.Sleep(5 * resyncTime)
+	time.Sleep(10 * resyncTime)
 	allEvents := suite.GetFakeCentral().GetAllMessages()
 	// Read the sensorOutputFile containing the expected sensor's output
 	expectedEvents, err := readSensorOutputFile(sensorOutputFile)


### PR DESCRIPTION
## Description

The replay tests can be flaky if sensor is not able to finish processing all events before 5 seconds. A refactor of this tests is planned in [ROX-13414](https://issues.redhat.com/browse/ROX-13414) and [ROX-14572](https://issues.redhat.com/browse/ROX-14572). In the mean time we bump the sleep to 10 seconds.

## Checklist
- [ ] Investigated and inspected CI test results
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

* Ran the tests locally many many times.
* If we reduce the sleep time, we can almost see it fail every time.
