### PR TITLE
ROX-17673: Prepare dummy test target for sensor-integration tests

### DIFF
--- a/.openshift-ci/ci_tests.py
+++ b/.openshift-ci/ci_tests.py
@@ -162,6 +162,22 @@ class NonGroovyE2e(BaseTest):
             post_start_hook=set_dirs_after_start,
         )
 
+class SensorIntegration(BaseTest):
+    TEST_TIMEOUT = 90 * 60
+    TEST_OUTPUT_DIR = "/tmp/sensor-integration-test-logs"
+
+    def run(self):
+        print("Executing the Sensor Integration Tests")
+
+        def set_dirs_after_start():
+            # let post test know where logs are
+            self.test_outputs = [SensorIntegration.TEST_OUTPUT_DIR]
+
+        self.run_with_graceful_kill(
+            ["tests/e2e/sensor.sh", SensorIntegration.TEST_OUTPUT_DIR],
+            SensorIntegration.TEST_TIMEOUT,
+            post_start_hook=set_dirs_after_start,
+        )
 
 class ScaleTest(BaseTest):
     TEST_TIMEOUT = 90 * 60

--- a/scripts/ci/jobs/ocp_sensor_integration.py
+++ b/scripts/ci/jobs/ocp_sensor_integration.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env -S python3 -u
+
+"""
+Run tests/e2e in a GKE cluster
+"""
+import os
+from runners import ClusterTestRunner
+from pre_tests import PreSystemTests
+from ci_tests import SensorIntegration
+from post_tests import PostClusterTest, FinalPost
+
+# set required test parameters
+os.environ["ORCHESTRATOR_FLAVOR"] = "openshift"
+os.environ["ROX_POSTGRES_DATASTORE"] = "true"
+os.environ["ROX_ACTIVE_VULN_MGMT"] = "true"
+
+ClusterTestRunner(
+    pre_test=PreSystemTests(),
+    test=SensorIntegration(),
+    post_test=PostClusterTest(collect_central_artifacts=False),
+    final_post=FinalPost(
+        store_qa_test_debug_logs=False,
+        store_qa_spock_results=False,
+    ),
+).run()

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -60,17 +60,6 @@ test_e2e() {
     # Give some time for previous tests to finish up
     wait_for_api
 
-    info "Sensor k8s integration tests"
-    make sensor-integration-test || touch FAIL
-    info "Saving junit XML report"
-    make generate-junit-reports || touch FAIL
-    store_test_results junit-reports reports
-    store_test_results "test-output/test.log" "sensor-integration"
-    [[ ! -f FAIL ]] || die "sensor-integration e2e tests failed"
-
-    # Give some time for previous tests to finish up
-    wait_for_api
-
     setup_proxy_tests "localhost"
     run_proxy_tests "localhost"
     cd "$ROOT"
@@ -104,7 +93,7 @@ test_preamble() {
 
     export ROX_PLAINTEXT_ENDPOINTS="8080,grpc@8081"
     export ROXDEPLOY_CONFIG_FILE_MAP="$ROOT/scripts/ci/endpoints/endpoints.yaml"
-    
+
     local registry="quay.io/rhacs-eng"
 
     SCANNER_IMAGE="$registry/scanner:$(cat "$ROOT"/SCANNER_VERSION)"

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -60,6 +60,17 @@ test_e2e() {
     # Give some time for previous tests to finish up
     wait_for_api
 
+    info "Sensor k8s integration tests"
+    make sensor-integration-test || touch FAIL
+    info "Saving junit XML report"
+    make generate-junit-reports || touch FAIL
+    store_test_results junit-reports reports
+    store_test_results "test-output/test.log" "sensor-integration"
+    [[ ! -f FAIL ]] || die "sensor-integration e2e tests failed"
+
+    # Give some time for previous tests to finish up
+    wait_for_api
+
     setup_proxy_tests "localhost"
     run_proxy_tests "localhost"
     cd "$ROOT"

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -60,6 +60,7 @@ test_e2e() {
     # Give some time for previous tests to finish up
     wait_for_api
 
+    # TODO(ROX-17674): Remove the block for running sensor integration tests
     info "Sensor k8s integration tests"
     make sensor-integration-test || touch FAIL
     info "Saving junit XML report"

--- a/tests/e2e/sensor.sh
+++ b/tests/e2e/sensor.sh
@@ -18,6 +18,12 @@ source "$ROOT/tests/e2e/lib.sh"
 # shellcheck source=../../tests/e2e/run.sh
 source "$ROOT/tests/e2e/run.sh"
 
+# test_sensor_wip is here to unlock the changes in the openshift/release repo.
+# Once they are merged, we will open another PR where we switch to test_sensor
+test_sensor_wip() {
+    info "Placeholder for sensor integration tests"
+}
+
 test_sensor() {
     info "Starting sensor integration tests"
 
@@ -57,5 +63,5 @@ test_sensor() {
 }
 
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
-    test_sensor "$*"
+    test_sensor_wip "$*"
 fi

--- a/tests/e2e/sensor.sh
+++ b/tests/e2e/sensor.sh
@@ -20,6 +20,7 @@ source "$ROOT/tests/e2e/run.sh"
 
 # test_sensor_wip is here to unlock the changes in the openshift/release repo.
 # Once they are merged, we will open another PR where we switch to test_sensor
+# TODO(ROX-17674): Remove test_sensor_wip
 test_sensor_wip() {
     info "Placeholder for sensor integration tests"
 }
@@ -63,5 +64,6 @@ test_sensor() {
 }
 
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    # TODO(ROX-17674): Switch to test_sensor
     test_sensor_wip "$*"
 fi

--- a/tests/e2e/sensor.sh
+++ b/tests/e2e/sensor.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC1091
+
+set -euo pipefail
+
+# Runs all e2e tests. Derived from the workload of CircleCI gke-api-nongroovy-tests.
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd)"
+
+# shellcheck source=../../scripts/lib.sh
+source "$ROOT/scripts/lib.sh"
+# shellcheck source=../../scripts/ci/sensor-wait.sh
+source "$ROOT/scripts/ci/sensor-wait.sh"
+# shellcheck source=../../tests/scripts/setup-certs.sh
+source "$ROOT/tests/scripts/setup-certs.sh"
+# shellcheck source=../../tests/e2e/lib.sh
+source "$ROOT/tests/e2e/lib.sh"
+# shellcheck source=../../tests/e2e/run.sh
+source "$ROOT/tests/e2e/run.sh"
+
+test_sensor() {
+    info "Starting sensor integration tests"
+
+    require_environment "KUBECONFIG"
+
+    export_test_environment
+
+    export SENSOR_HELM_DEPLOY=true
+    export ROX_ACTIVE_VULN_REFRESH_INTERVAL=1m
+    export ROX_NETPOL_FIELDS=true
+
+    test_preamble
+    setup_deployment_env false false
+    remove_existing_stackrox_resources
+    setup_default_TLS_certs
+    "$ROOT/tests/complianceoperator/create.sh"
+
+    deploy_stackrox
+    deploy_optional_e2e_components
+
+    rm -f FAIL
+
+    prepare_for_endpoints_test
+
+    info "Sensor k8s integration tests"
+    make sensor-integration-test || touch FAIL
+    info "Saving junit XML report"
+    make generate-junit-reports || touch FAIL
+    store_test_results junit-reports reports
+    store_test_results "test-output/test.log" "sensor-integration"
+    [[ ! -f FAIL ]] || die "sensor-integration e2e tests failed"
+
+    # Give some time for previous tests to finish up
+    wait_for_api
+
+    collect_and_check_stackrox_logs "/tmp/sensor-integration-test-logs" "initial_tests"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    test_sensor "$*"
+fi


### PR DESCRIPTION
## Description

This PR adds dummy test run (one that always passes) required by https://github.com/openshift/release/pull/40182

The proper moving of the tests will happen in the follow-up 👉 The goal of https://issues.redhat.com/browse/ROX-17674 is to move the sensor integration tests away from the nongroovy step as the integration tests are now larger and keep growing. This would allow us (who work on Sensor) to iterate quicker when adding new features and tests in the upcoming epic.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

- Running it locally the way the CI will run this, i.e.:
```
QUAY_RHACS_ENG_RO_USERNAME="xxx" \
QUAY_RHACS_ENG_RO_PASSWORD="yyy" \
ORCHESTRATOR_FLAVOR="openshift" \
MAIN_IMAGE_TAG="4.0.x-619-g2c7a6f32b8" \
KUBECONFIG="~/.cluster/kubeconfig" \
./tests/e2e/sensor.sh
```


