### PR TITLE
chore(e2e): Update cypress 12.14.0 devDependencies in ui

### DIFF
--- a/ui/apps/platform/package.json
+++ b/ui/apps/platform/package.json
@@ -139,7 +139,7 @@
         "@types/segment-analytics": "^0.0.34",
         "autoprefixer": "^10.2.5",
         "babel-eslint": "^10.1.0",
-        "cypress": "^12.12.0",
+        "cypress": "^12.14.0",
         "eslint": "^7.32.0",
         "eslint-config-airbnb": "^18.2.1",
         "eslint-config-airbnb-typescript": "12.3.1",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -7340,10 +7340,10 @@ cyclist@^1.0.1:
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
 
-cypress@^12.12.0:
-  version "12.12.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-12.12.0.tgz#0da622a34c970d8699ca6562d8e905ed7ce33c77"
-  integrity sha512-UU5wFQ7SMVCR/hyKok/KmzG6fpZgBHHfrXcHzDmPHWrT+UUetxFzQgt7cxCszlwfozckzwkd22dxMwl/vNkWRw==
+cypress@^12.14.0:
+  version "12.14.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-12.14.0.tgz#37a19b85f5e9d881995e9fee1ddf41b3d3a623dd"
+  integrity sha512-HiLIXKXZaIT1RT7sw1sVPt+qKtis3uYNm6KwC4qoYjabwLKaqZlyS/P+uVvvlBNcHIwL/BC6nQZajpbUd7hOgQ==
   dependencies:
     "@cypress/request" "^2.88.10"
     "@cypress/xvfb" "^1.2.4"


### PR DESCRIPTION
## Description

https://docs.cypress.io/guides/references/changelog#12-14-0

* Upgraded `find-process` from 1.4.1 to 1.4.7 to address Synk security vulnerability.
* Upgraded `firefox-profile` from 4.0.0 to 4.3.2 to address security vulnerabilities within sub-dependencies.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Upgraded integration test devDependencies

## Testing Performed

1. `yarn start` in ui
2. `yarn cypress-open` in ui/apps/platform

    * compliance/complianceDashboard.test.js
    * compliance/hideScanResults.test.js (failed when run before the preceding)

Aha, now I better understand ocp-4-12-ui-e2e-tests failures for #6362

* hideScanResults.test.js **assumes** that environment has already been scanned, but complianceDashboard.test.js is skipped on openshift.
* Therefore, the first test in hideScanResults needs to scan, so that it does not depend on side-effects from another test file.
* In contrast to the emergency skip in #6393
