### PR TITLE
ROX-17668: pod pruning no walk

### DIFF
--- a/central/pruning/pruning_test.go
+++ b/central/pruning/pruning_test.go
@@ -1966,7 +1966,7 @@ func (s *PruningTestSuite) TestRemoveLogImbues() {
 }
 
 func (s *PruningTestSuite) TestRemoveOrphanedPods() {
-	_, _, clusterDS, _ := s.generateClusterDataStructures()
+	_, _, clusterDS := s.generateClusterDataStructures()
 
 	clusterID1, err := clusterDS.AddCluster(s.ctx, &storage.Cluster{Name: "testOrphanPodCluster1", MainImage: "docker.io/stackrox/rox:latest"})
 	s.Nil(err)


### PR DESCRIPTION
## Description

Update pod pruning to use SQL and not walk.

## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
~- [ ] Evaluated and added CHANGELOG entry if required~
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Added some simple tests.  pruning pods isn't as complicated as others as it is either orphaned or it is not.
