### PR TITLE
fix(ui): Fix incorrect link text in System Health Certificate cards

### DIFF
--- a/ui/apps/platform/src/Containers/SystemHealth/CertificateHealth/CertificateCard.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/CertificateHealth/CertificateCard.tsx
@@ -144,7 +144,7 @@ function CertificateCard({ component, pollingCount }: CertificateCardProps): Rea
                                         alignItems={{ default: 'alignItemsCenter' }}
                                         spaceItems={{ default: 'spaceItemsSm' }}
                                     >
-                                        <span>Generate a diagnostic bundle</span>
+                                        <span>Reissuing internal certificates</span>
                                         <ExternalLinkAltIcon color="var(--pf-global--link--Color)" />
                                     </Flex>
                                 </Button>


### PR DESCRIPTION
## Description

Correct copy paste mistake in #6258

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

1. Visit /main/system-health and click link to verify that `href` attribute was correct although text was incorrect
    ![Reissuing_internal_certificates](https://github.com/stackrox/stackrox/assets/11862657/715997fe-e385-4fff-a183-1b3d19d84e64)
