### PR TITLE
fix(ui): Show formatted time in Vuln Def widget

### DIFF
--- a/ui/apps/platform/src/Containers/SystemHealth/VulnerabilityDefinitionsHealth/VulnerabilityDefinitionsHealthCard.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/VulnerabilityDefinitionsHealth/VulnerabilityDefinitionsHealthCard.tsx
@@ -12,6 +12,7 @@ import { differenceInMinutes } from 'date-fns';
 
 import { fetchVulnerabilityDefinitionsInfo } from 'services/IntegrationHealthService';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
+import { getDateTime } from 'utils/dateUtils';
 
 import { ErrorIcon, healthIconMap, SpinnerIcon } from '../CardHeaderIcons';
 
@@ -80,7 +81,7 @@ const VulnerabilityDefinitionsHealthCard = ({
                         <>
                             <FlexItem>{isUpToDate ? 'up to date' : 'out of date'}</FlexItem>
                             <FlexItem align={{ default: 'alignRight' }}>
-                                {lastUpdatedTimestamp}
+                                {getDateTime(lastUpdatedTimestamp)}
                             </FlexItem>
                         </>
                     )}


### PR DESCRIPTION
## Description

Bringing displayed time into alignment with rest of time display in app

## Checklist
- [ ] Investigated and inspected CI test results


## Testing Performed

Before
<img width="1588" alt="Screen Shot 2023-06-08 at 4 21 24 PM" src="https://github.com/stackrox/stackrox/assets/715729/7409460f-ea71-4c7f-aaa1-d8e9882654e0">

After
<img width="1544" alt="Screen Shot 2023-06-08 at 4 24 09 PM" src="https://github.com/stackrox/stackrox/assets/715729/ac313a30-4841-4994-aa86-dedbefadfa48">
