### PR TITLE
ROX-17682, ROX-17684: Download telemetry key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,15 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 
 ### Added Features
 
+- Telemetry collection enabled by default for self-managed installations. Opt-out is available on bundle generation, or at any time via the System Configuration UI.
+
 ### Removed Features
+
 - The `--offline-mode` flag for the `roxctl scanner generate` command was removed, as Scanner's default behavior is
   to fetch vulnerability updates from Central.
 
 ### Deprecated Features
+
 - RBAC risk was deprecated in release 4.0 due to poor performance.
 
 ### Technical Changes

--- a/central/telemetry/centralclient/instance_config.go
+++ b/central/telemetry/centralclient/instance_config.go
@@ -76,12 +76,15 @@ func getInstanceConfig() (*phonehome.Config, map[string]any, error) {
 		return nil, nil, nil
 	}
 
-	if key == "" && (isReleaseBuild() || env.TelemetryConfigURL.Setting() != "") {
+	if env.TelemetryConfigURL.Setting() != "" &&
+		// Development versions must provide a key on top of the URL.
+		(key == "" && isReleaseBuild() || key != "") {
 		remoteCfg, err := downloadConfig(env.TelemetryConfigURL.Setting())
 		if err != nil {
 			return nil, nil, err
 		}
-		if remoteCfg != nil {
+		// The key has to match for development versions.
+		if remoteCfg != nil && (isReleaseBuild() || remoteCfg.Key == key) {
 			key = remoteCfg.Key
 			log.Info("Telemetry configuration has been downloaded from ",
 				env.TelemetryConfigURL.Setting())

--- a/central/telemetry/centralclient/instance_config.go
+++ b/central/telemetry/centralclient/instance_config.go
@@ -39,12 +39,11 @@ var (
 )
 
 const (
-	telemetryConfigURL = "https://telemetry.stackrox.io/config.json"
-	disabledKey        = "DISABLED"
+	disabledKey = "DISABLED"
 )
 
 type remoteConfig struct {
-	Key string `json:"key,omitempty"`
+	Key string `json:"storage_key_v1,omitempty"`
 }
 
 func downloadConfig(u string) (*remoteConfig, error) {
@@ -78,7 +77,7 @@ func getInstanceConfig() (*phonehome.Config, map[string]any, error) {
 	}
 
 	if key == "" && isReleaseBuild() {
-		remoteCfg, err := downloadConfig(telemetryConfigURL)
+		remoteCfg, err := downloadConfig(env.TelemetryConfigURL.Setting())
 		if err != nil {
 			return nil, nil, err
 		}

--- a/central/telemetry/centralclient/instance_config.go
+++ b/central/telemetry/centralclient/instance_config.go
@@ -76,17 +76,19 @@ func getInstanceConfig() (*phonehome.Config, map[string]any, error) {
 		return nil, nil, nil
 	}
 
-	if key == "" && isReleaseBuild() {
+	if key == "" && (isReleaseBuild() || env.TelemetryConfigURL.Setting() != "") {
 		remoteCfg, err := downloadConfig(env.TelemetryConfigURL.Setting())
 		if err != nil {
 			return nil, nil, err
 		}
 		if remoteCfg != nil {
 			key = remoteCfg.Key
+			log.Info("Telemetry configuration has been downloaded from ",
+				env.TelemetryConfigURL.Setting())
 		}
 	}
 
-	if key == "" {
+	if key == "" || key == disabledKey {
 		return nil, nil, nil
 	}
 

--- a/central/telemetry/centralclient/instance_config_test.go
+++ b/central/telemetry/centralclient/instance_config_test.go
@@ -1,0 +1,61 @@
+package centralclient
+
+import (
+	"testing"
+)
+
+func Test_toDownload(t *testing.T) {
+	tests := map[string]struct {
+		release bool
+		key     string
+		cfgURL  string
+
+		download bool
+	}{
+		"a": {release: false, key: "", cfgURL: "", download: false},
+		"b": {release: false, key: "abc", cfgURL: "", download: false},
+		"c": {release: false, key: "", cfgURL: "url", download: false},
+		"d": {release: false, key: "abc", cfgURL: "url", download: true},
+
+		"e": {release: true, key: "", cfgURL: "", download: false},
+		"f": {release: true, key: "abc", cfgURL: "", download: false},
+		"g": {release: true, key: "", cfgURL: "url", download: true},
+		"h": {release: true, key: "abc", cfgURL: "url", download: true},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			if got := toDownload(tt.release, tt.key, tt.cfgURL); got != tt.download {
+				t.Errorf("toDownload() = %v, want %v", got, tt.download)
+			}
+		})
+	}
+}
+
+func Test_useRemoteKey(t *testing.T) {
+	tests := map[string]struct {
+		release  bool
+		cfg      *remoteConfig
+		localKey string
+
+		useRemote bool
+	}{
+		"a": {release: false, cfg: nil, localKey: "", useRemote: false},
+		"b": {release: false, cfg: &remoteConfig{Key: "abc"}, localKey: "", useRemote: false},
+		"c": {release: false, cfg: nil, localKey: "", useRemote: false},
+		"d": {release: false, cfg: &remoteConfig{Key: "abc"}, localKey: "abc", useRemote: true},
+		"e": {release: false, cfg: &remoteConfig{Key: "abc"}, localKey: "def", useRemote: false},
+
+		"f": {release: true, cfg: nil, localKey: "", useRemote: false},
+		"g": {release: true, cfg: &remoteConfig{Key: "abc"}, localKey: "", useRemote: true},
+		"h": {release: true, cfg: nil, localKey: "", useRemote: false},
+		"i": {release: true, cfg: &remoteConfig{Key: "abc"}, localKey: "abc", useRemote: true},
+		"j": {release: true, cfg: &remoteConfig{Key: "abc"}, localKey: "def", useRemote: true},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			if got := useRemoteKey(tt.release, tt.cfg, tt.localKey); got != tt.useRemote {
+				t.Errorf("useRemoteKey() = %v, want %v", got, tt.useRemote)
+			}
+		})
+	}
+}

--- a/deploy/common/ci-values.yaml
+++ b/deploy/common/ci-values.yaml
@@ -10,6 +10,9 @@ central:
         cpu: 1
         memory: 1Gi
 
+  telemetry:
+    enabled: false
+
 scanner:
   replicas: 1
   autoscaling:

--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -209,6 +209,12 @@ function launch_central {
         add_args "--declarative-config-config-maps=declarative-configurations"
     fi
 
+    if [[ -n "${ROX_TELEMETRY_STORAGE_KEY_V1}" ]]; then
+      add_args "--enable-telemetry=true"
+    else
+      add_args "--enable-telemetry=false"
+    fi
+
     local unzip_dir="${k8s_dir}/central-deploy/"
     rm -rf "${unzip_dir}"
     if ! (( use_docker )); then
@@ -218,7 +224,7 @@ function launch_central {
         rm -rf central-bundle
     else
         docker run --rm ${DOCKER_PLATFORM_ARGS[@]} "${EXTRA_DOCKER_ARGS[@]}" --env-file <(env | grep '^ROX_') "$ROXCTL_IMAGE" \
-        	central generate "${ORCH}" "${EXTRA_ARGS[@]}" "${STORAGE}" "${STORAGE_ARGS[@]}" > "${k8s_dir}/central.zip"
+          central generate "${ORCH}" "${EXTRA_ARGS[@]}" "${STORAGE}" "${STORAGE_ARGS[@]}" > "${k8s_dir}/central.zip"
         unzip "${k8s_dir}/central.zip" -d "${unzip_dir}"
     fi
 

--- a/deploy/common/local-dev-values.yaml
+++ b/deploy/common/local-dev-values.yaml
@@ -20,6 +20,9 @@ central:
         cpu: 1
         memory: 4Gi
 
+  telemetry:
+    enabled: false
+
 scanner:
   replicas: 1
   autoscaling:

--- a/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml
+++ b/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        {{- if ._rox.central.telemetry.enabled }}
+        {{- if ne (._rox.central.telemetry.enabled | toString) "false" }}
         {{- if ._rox.central.telemetry.storage.endpoint }}
         - name: ROX_TELEMETRY_ENDPOINT
           value: {{ ._rox.central.telemetry.storage.endpoint | quote }}

--- a/image/templates/helm/stackrox-central/templates/NOTES.txt.htpl
+++ b/image/templates/helm/stackrox-central/templates/NOTES.txt.htpl
@@ -47,4 +47,10 @@ IMPORTANT: You have deployed into an OpenShift-enabled cluster. If you see that 
 {{ end -}}
 [< end >]
 
+{{ if ne (._rox.central.telemetry.enabled | toString) "false" }}
+StackRox Kubernetes Security Platform collects and transmits anonymous usage and
+system configuration information. If you want to OPT OUT from this, use
+--set central.telemetry.enabled=false.
+{{ end }}
+
 Thank you for using StackRox!

--- a/image/templates/helm/stackrox-central/values.yaml.htpl
+++ b/image/templates/helm/stackrox-central/values.yaml.htpl
@@ -103,14 +103,24 @@
 ## If specified, this should be a map mapping file names to PEM-encoded contents.
 #additionalCAs: null
 #
+[<- if and .TelemetryEnabled (and (eq .TelemetryKey "") (eq .TelemetryEndpoint ""))>]
 #central:
 #
-#  # Settings for telemetry data collection. Telemetry is disabled by default.
+#  # Settings for telemetry data collection. Telemetry is enabled by default.
 #  telemetry:
-#    enabled: false
+#    enabled: true
 #    storage:
 #      endpoint: null
 #      key: null
+[<- else >]
+central:
+# # Settings for telemetry data collection.
+  telemetry:
+    enabled: [< .TelemetryEnabled >]
+    storage:
+      endpoint: "[< .TelemetryEndpoint >]"
+      key: "[< .TelemetryKey >]"
+[<- end >]
 #
 #
 #  config: "@config/central/config.yaml|config/central/config.yaml.default"

--- a/operator/apis/platform/v1alpha1/central_types.go
+++ b/operator/apis/platform/v1alpha1/central_types.go
@@ -431,6 +431,8 @@ type ExposureRoute struct {
 // Telemetry defines telemetry settings for Central.
 type Telemetry struct {
 	// Specifies if Telemetry is enabled.
+	//+kubebuilder:validation:Default=true
+	//+kubebuilder:default=true
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,order=1,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
 	Enabled *bool `json:"enabled,omitempty"`
 

--- a/operator/bundle/manifests/platform.stackrox.io_centrals.yaml
+++ b/operator/bundle/manifests/platform.stackrox.io_centrals.yaml
@@ -456,6 +456,7 @@ spec:
                       storage backend.
                     properties:
                       enabled:
+                        default: true
                         description: Specifies if Telemetry is enabled.
                         type: boolean
                       storage:

--- a/operator/config/crd/bases/platform.stackrox.io_centrals.yaml
+++ b/operator/config/crd/bases/platform.stackrox.io_centrals.yaml
@@ -457,6 +457,7 @@ spec:
                       storage backend.
                     properties:
                       enabled:
+                        default: true
                         description: Specifies if Telemetry is enabled.
                         type: boolean
                       storage:

--- a/operator/pkg/central/values/translation/translation_test.go
+++ b/operator/pkg/central/values/translation/translation_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/stackrox/rox/operator/pkg/central/common"
 	"github.com/stackrox/rox/operator/pkg/central/extensions"
 	"github.com/stackrox/rox/operator/pkg/values/translation"
+	"github.com/stackrox/rox/pkg/buildinfo"
+	"github.com/stackrox/rox/pkg/version/testutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"helm.sh/helm/v3/pkg/chartutil"
@@ -32,6 +34,7 @@ func TestTranslate(t *testing.T) {
 		clientSet kubernetes.Interface
 		c         platform.Central
 		pvcs      []*corev1.PersistentVolumeClaim
+		version   string
 	}
 
 	connectivityPolicy := platform.ConnectivityOffline
@@ -42,6 +45,11 @@ func TestTranslate(t *testing.T) {
 	monitoringExposeEndpointDisabled := platform.ExposeEndpointDisabled
 	telemetryEndpoint := "endpoint"
 	telemetryKey := "key"
+	telemetryDisabledKey := map[string]interface{}{
+		"enabled": false,
+		"storage": map[string]interface{}{"key": disabledTelemetryKey}}
+	dirtyVersion := "1.2.3-dirty"
+	releaseVersion := "1.2.3"
 
 	truth := true
 	falsity := false
@@ -771,7 +779,104 @@ func TestTranslate(t *testing.T) {
 				"central": map[string]interface{}{
 					"exposeMonitoring": false,
 					"persistence":      map[string]interface{}{"persistentVolumeClaim": map[string]interface{}{"createClaim": false}},
-					"telemetry":        map[string]interface{}{"enabled": false},
+					"telemetry":        telemetryDisabledKey,
+					"db": map[string]interface{}{
+						"persistence": map[string]interface{}{
+							"persistentVolumeClaim": map[string]interface{}{
+								"createClaim": false,
+							},
+						},
+					},
+				},
+			},
+		},
+		"default dev telemetry": {
+			args: args{
+				c: platform.Central{
+					ObjectMeta: v1.ObjectMeta{
+						Namespace: "stackrox",
+					},
+				},
+				pvcs:    []*corev1.PersistentVolumeClaim{defaultPvc},
+				version: dirtyVersion,
+			},
+			want: chartutil.Values{
+				"central": map[string]interface{}{
+					"exposeMonitoring": false,
+					"persistence":      map[string]interface{}{"persistentVolumeClaim": map[string]interface{}{"createClaim": false}},
+					"telemetry":        telemetryDisabledKey,
+					"db": map[string]interface{}{
+						"persistence": map[string]interface{}{
+							"persistentVolumeClaim": map[string]interface{}{
+								"createClaim": false,
+							},
+						},
+					},
+				},
+			},
+		},
+		"enabled telemetry in dev": {
+			args: args{
+				c: platform.Central{
+					ObjectMeta: v1.ObjectMeta{
+						Namespace: "stackrox",
+					},
+					Spec: platform.CentralSpec{
+						Central: &platform.CentralComponentSpec{
+							Telemetry: &platform.Telemetry{
+								Enabled: &truth,
+								Storage: &platform.TelemetryStorage{
+									Key:      &telemetryKey,
+									Endpoint: &telemetryEndpoint,
+								},
+							},
+						},
+					},
+				},
+				pvcs:    []*corev1.PersistentVolumeClaim{defaultPvc},
+				version: dirtyVersion,
+			},
+			want: chartutil.Values{
+				"central": map[string]interface{}{
+					"exposeMonitoring": false,
+					"persistence":      map[string]interface{}{"persistentVolumeClaim": map[string]interface{}{"createClaim": false}},
+					"telemetry": map[string]interface{}{
+						"enabled": true,
+						"storage": map[string]interface{}{
+							"endpoint": "endpoint",
+							"key":      "key",
+						},
+					},
+					"db": map[string]interface{}{
+						"persistence": map[string]interface{}{
+							"persistentVolumeClaim": map[string]interface{}{
+								"createClaim": false,
+							},
+						},
+					},
+				},
+			},
+		},
+		"enabled telemetry no key": {
+			args: args{
+				c: platform.Central{
+					ObjectMeta: v1.ObjectMeta{
+						Namespace: "stackrox",
+					},
+					Spec: platform.CentralSpec{
+						Central: &platform.CentralComponentSpec{
+							Telemetry: &platform.Telemetry{
+								Enabled: &truth,
+							},
+						},
+					},
+				},
+				pvcs: []*corev1.PersistentVolumeClaim{defaultPvc},
+			},
+			want: chartutil.Values{
+				"central": map[string]interface{}{
+					"exposeMonitoring": false,
+					"persistence":      map[string]interface{}{"persistentVolumeClaim": map[string]interface{}{"createClaim": false}},
 					"db": map[string]interface{}{
 						"persistence": map[string]interface{}{
 							"persistentVolumeClaim": map[string]interface{}{
@@ -786,6 +891,18 @@ func TestTranslate(t *testing.T) {
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
+			if !buildinfo.ReleaseBuild || buildinfo.TestBuild {
+				wantCentral := tt.want["central"].(map[string]any)
+				if _, ok := wantCentral["telemetry"]; !ok {
+					wantCentral["telemetry"] = telemetryDisabledKey
+				}
+			}
+			if tt.args.version == "" {
+				testutils.SetMainVersion(t, releaseVersion)
+			} else {
+				testutils.SetMainVersion(t, tt.args.version)
+			}
+
 			wantAsValues, err := translation.ToHelmValues(tt.want)
 			require.NoError(t, err, "error in test specification: cannot translate `want` specification to Helm values")
 			var allExisting []ctrlClient.Object

--- a/operator/tests/common/central-cr.yaml
+++ b/operator/tests/common/central-cr.yaml
@@ -22,6 +22,8 @@ spec:
         limits:
           memory: 4Gi
           cpu: 1
+    telemetry:
+      enabled: false
   scanner:
     analyzer:
       scaling:

--- a/pkg/buildinfo/buildinfo.go
+++ b/pkg/buildinfo/buildinfo.go
@@ -4,6 +4,9 @@ const (
 	// ReleaseBuild indicates whether this build is a release build.
 	ReleaseBuild bool = releaseBuild
 
+	// TestBuild indicates whether this build is a test build.
+	TestBuild bool = testBuild
+
 	// BuildFlavor indicates the build flavor ("release" for release builds, "development" for development builds).
 	BuildFlavor string = buildFlavor
 

--- a/pkg/buildinfo/buildinfo_intest.go
+++ b/pkg/buildinfo/buildinfo_intest.go
@@ -1,0 +1,7 @@
+//go:build test
+
+package buildinfo
+
+const (
+	testBuild = true
+)

--- a/pkg/buildinfo/buildinfo_notest.go
+++ b/pkg/buildinfo/buildinfo_notest.go
@@ -1,0 +1,7 @@
+//go:build !test
+
+package buildinfo
+
+const (
+	testBuild = false
+)

--- a/pkg/env/telemetry.go
+++ b/pkg/env/telemetry.go
@@ -5,8 +5,11 @@ import "time"
 var (
 	// Phone-Home telemetry variables:
 
-	// TelemetryEndpoint is the endpoint to which to send telemetry data.
+	// TelemetryEndpoint is the URL to send telemetry to.
 	TelemetryEndpoint = RegisterSetting("ROX_TELEMETRY_ENDPOINT", AllowEmpty())
+
+	// TelemetryConfigURL to retrieve the telemetry configuration from.
+	TelemetryConfigURL = RegisterSetting("ROX_TELEMETRY_CONFIG_URL", WithDefault("https://telemetry.stackrox.io/config.json"))
 
 	// TelemetryFrequency is the frequency at which we will report telemetry.
 	TelemetryFrequency = registerDurationSetting("ROX_TELEMETRY_FREQUENCY", 10*time.Minute)

--- a/pkg/env/telemetry.go
+++ b/pkg/env/telemetry.go
@@ -10,7 +10,7 @@ var (
 
 	// TelemetryConfigURL to retrieve the telemetry configuration from.
 	// TODO(ROX-17726): Set default URL for self-managed installations use.
-	TelemetryConfigURL = RegisterSetting("ROX_TELEMETRY_CONFIG_URL", WithDefault(""))
+	TelemetryConfigURL = RegisterSetting("ROX_TELEMETRY_CONFIG_URL", WithDefault("hardcoded"))
 
 	// TelemetryFrequency is the frequency at which we will report telemetry.
 	TelemetryFrequency = registerDurationSetting("ROX_TELEMETRY_FREQUENCY", 10*time.Minute)

--- a/pkg/env/telemetry.go
+++ b/pkg/env/telemetry.go
@@ -9,7 +9,8 @@ var (
 	TelemetryEndpoint = RegisterSetting("ROX_TELEMETRY_ENDPOINT", AllowEmpty())
 
 	// TelemetryConfigURL to retrieve the telemetry configuration from.
-	TelemetryConfigURL = RegisterSetting("ROX_TELEMETRY_CONFIG_URL", WithDefault("https://telemetry.stackrox.io/config.json"))
+	// TODO(ROX-17726): Set default URL for self-managed installations use.
+	TelemetryConfigURL = RegisterSetting("ROX_TELEMETRY_CONFIG_URL", WithDefault(""))
 
 	// TelemetryFrequency is the frequency at which we will report telemetry.
 	TelemetryFrequency = registerDurationSetting("ROX_TELEMETRY_FREQUENCY", 10*time.Minute)

--- a/pkg/helm/charts/meta.go
+++ b/pkg/helm/charts/meta.go
@@ -53,6 +53,9 @@ type MetaValues struct {
 	AdmissionControllerEnabled       bool
 	AdmissionControlEnforceOnUpdates bool
 	ReleaseBuild                     bool
+	TelemetryEnabled                 bool
+	TelemetryKey                     string
+	TelemetryEndpoint                string
 
 	AutoSensePodSecurityPolicies bool
 	EnablePodSecurityPolicies    bool // Only used in the Helm chart if AutoSensePodSecurityPolicies is false.

--- a/pkg/renderer/render_new.go
+++ b/pkg/renderer/render_new.go
@@ -101,6 +101,9 @@ func renderNewBasicFiles(c Config, mode mode, imageFlavor defaults.ImageFlavor) 
 	if metaVals.KubectlOutput {
 		metaVals.AutoSensePodSecurityPolicies = false
 	}
+	metaVals.TelemetryEnabled = c.K8sConfig.Telemetry.Enabled
+	metaVals.TelemetryKey = c.K8sConfig.Telemetry.StorageKey
+	metaVals.TelemetryEndpoint = c.K8sConfig.Telemetry.StorageEndpoint
 	chartFiles, err := chTpl.InstantiateRaw(metaVals)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to instantiate central services chart template")

--- a/pkg/telemetry/phonehome/client_config.go
+++ b/pkg/telemetry/phonehome/client_config.go
@@ -13,8 +13,6 @@ import (
 	"google.golang.org/grpc"
 )
 
-const disabled = "DISABLED"
-
 var (
 	log = logging.LoggerForModule()
 )
@@ -62,7 +60,7 @@ type Config struct {
 
 // Enabled tells whether telemetry data collection is enabled.
 func (cfg *Config) Enabled() bool {
-	return cfg != nil && cfg.StorageKey != "" && cfg.StorageKey != disabled
+	return cfg != nil && cfg.StorageKey != ""
 }
 
 // Gatherer returns the telemetry gatherer instance.

--- a/pkg/telemetry/phonehome/client_config.go
+++ b/pkg/telemetry/phonehome/client_config.go
@@ -13,6 +13,8 @@ import (
 	"google.golang.org/grpc"
 )
 
+const disabled = "DISABLED"
+
 var (
 	log = logging.LoggerForModule()
 )
@@ -60,7 +62,7 @@ type Config struct {
 
 // Enabled tells whether telemetry data collection is enabled.
 func (cfg *Config) Enabled() bool {
-	return cfg != nil && cfg.StorageKey != ""
+	return cfg != nil && cfg.StorageKey != "" && cfg.StorageKey != disabled
 }
 
 // Gatherer returns the telemetry gatherer instance.

--- a/pkg/telemetry/phonehome/client_config_test.go
+++ b/pkg/telemetry/phonehome/client_config_test.go
@@ -17,4 +17,9 @@ func TestConfig_Enabled(t *testing.T) {
 		StorageKey: "test-key",
 	}
 	assert.True(t, cfg.Enabled())
+
+	cfg = &Config{
+		StorageKey: disabled,
+	}
+	assert.False(t, cfg.Enabled())
 }

--- a/pkg/telemetry/phonehome/client_config_test.go
+++ b/pkg/telemetry/phonehome/client_config_test.go
@@ -17,9 +17,4 @@ func TestConfig_Enabled(t *testing.T) {
 		StorageKey: "test-key",
 	}
 	assert.True(t, cfg.Enabled())
-
-	cfg = &Config{
-		StorageKey: disabled,
-	}
-	assert.False(t, cfg.Enabled())
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	"github.com/stackrox/rox/pkg/buildinfo"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/rox/pkg/version/internal"
@@ -182,4 +183,11 @@ func deriveChartVersion(mainVersion string) (string, error) {
 
 	chartVersion := fmt.Sprintf("%d.%d.%d%s", chartMajor, chartMinor, chartPatch, chartSuffix)
 	return chartVersion, nil
+}
+
+// IsReleaseVersion tells whether the binary is built for a release.
+func IsReleaseVersion() bool {
+	return buildinfo.ReleaseBuild && !buildinfo.TestBuild &&
+		GetMainVersion() != "" &&
+		!strings.Contains(GetMainVersion(), "-")
 }

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -3,10 +3,26 @@ package version
 import (
 	"testing"
 
+	"github.com/stackrox/rox/pkg/buildinfo"
+	"github.com/stackrox/rox/pkg/version/internal"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestParseCurrentVersion(t *testing.T) {
 	_, err := parseMainVersion(GetMainVersion())
 	assert.NoError(t, err)
+}
+
+func TestIsReleaseVersion(t *testing.T) {
+	if buildinfo.ReleaseBuild && !buildinfo.TestBuild {
+		internal.MainVersion = "1.2.3"
+		assert.True(t, IsReleaseVersion())
+		internal.MainVersion = "1.2.3-dirty"
+		assert.False(t, IsReleaseVersion())
+	} else {
+		internal.MainVersion = "1.2.3"
+		assert.False(t, IsReleaseVersion())
+		internal.MainVersion = "1.2.3-dirty"
+		assert.False(t, IsReleaseVersion())
+	}
 }

--- a/roxctl/central/generate/generate.go
+++ b/roxctl/central/generate/generate.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stackrox/rox/pkg/renderer"
 	"github.com/stackrox/rox/pkg/roxctl"
 	"github.com/stackrox/rox/pkg/utils"
+	"github.com/stackrox/rox/pkg/version"
 	"github.com/stackrox/rox/pkg/zip"
 	"github.com/stackrox/rox/roxctl/common"
 	"github.com/stackrox/rox/roxctl/common/environment"
@@ -201,13 +202,13 @@ func updateConfig(config *renderer.Config) error {
 	if config.K8sConfig != nil {
 		config.Environment[env.OfflineModeEnv.EnvVar()] = strconv.FormatBool(config.K8sConfig.OfflineMode)
 
-		if config.K8sConfig.Telemetry.Enabled {
-			// TODO(ROX-13889): (when enabled for on-prem)
-			// if env.TelemetryStorageKey.Setting() == "" {
-			//   return errox.InvalidArgs.Newf("telemetry storage key is not set")
-			// }
+		if config.K8sConfig.Telemetry.Enabled &&
+			(version.IsReleaseVersion() || env.TelemetryStorageKey.Setting() != "") {
 			config.K8sConfig.Telemetry.StorageKey = env.TelemetryStorageKey.Setting()
 			config.K8sConfig.Telemetry.StorageEndpoint = env.TelemetryEndpoint.Setting()
+		} else {
+			config.K8sConfig.Telemetry.StorageKey = "DISABLED"
+			config.K8sConfig.Telemetry.Enabled = false
 		}
 	}
 
@@ -251,18 +252,11 @@ func OutputZip(logger logger.Logger, io io2.IO, config renderer.Config) error {
 		return err
 	}
 	if config.K8sConfig.Telemetry.Enabled {
-		if config.K8sConfig.Telemetry.StorageKey == "" {
-			// TODO(ROX-13889): won't be reachable
-			logger.WarnfLn("No telemetry storage key has been provided. " +
-				"Telemetry collection will not be enabled.")
-			config.K8sConfig.Telemetry.Enabled = false
-		} else {
-			logger.InfofLn("StackRox Kubernetes Security Platform collects " +
-				"and transmits anonymous usage and system configuration " +
-				"information. If you want to OPT OUT from this, re-generate " +
-				"the deployment bundle with the '--enable-telemetry=false' " +
-				"flag.")
-		}
+		logger.InfofLn("StackRox Kubernetes Security Platform collects " +
+			"and transmits anonymous usage and system configuration " +
+			"information. If you want to OPT OUT from this, re-generate " +
+			"the deployment bundle with the '--enable-telemetry=false' " +
+			"flag.")
 	}
 
 	wrapper, err := createBundle(&config)

--- a/roxctl/central/generate/generate_test.go
+++ b/roxctl/central/generate/generate_test.go
@@ -143,35 +143,38 @@ func TestTelemetryConfiguration(t *testing.T) {
 		err     error
 		key     interface{}
 	}
+	dirtyVersion := "1.2.3-dirty"
+	releaseVersion := "1.2.3"
+	var disabledInDebug any
+	if !buildinfo.ReleaseBuild || buildinfo.TestBuild {
+		disabledInDebug = "DISABLED"
+	}
+
 	testCases := []struct {
-		testDir   string
-		offline   bool
+		testName  string
+		version   string
 		telemetry bool
 		key       string
 		expected  result
 	}{
-		{testDir: "test1", offline: false, telemetry: false, key: "", expected: result{enabled: false}},
-		{testDir: "test2", offline: true, telemetry: false, key: "", expected: result{enabled: false}},
-		// TODO(ROX-13889): (when the key is hardcoded for on-prem telemetry)
-		// {testDir: "test3", offline: false, telemetry: true, key: "", expected: result{err: errox.InvalidArgs}},
-		{testDir: "test3", offline: false, telemetry: true, key: "", expected: result{enabled: false}},
-		{testDir: "test4", offline: false, telemetry: true, key: "test", expected: result{enabled: true, key: "test"}},
-		{testDir: "test5", offline: false, telemetry: false, key: "test", expected: result{enabled: false, key: "test"}},
-		{testDir: "test6", offline: true, telemetry: true, key: "test", expected: result{enabled: true, key: "test"}},
+		{testName: "test1", version: dirtyVersion, telemetry: true, key: "", expected: result{enabled: false, key: "DISABLED"}},
+		{testName: "test2", version: dirtyVersion, telemetry: false, key: "", expected: result{enabled: false, key: "DISABLED"}},
+		{testName: "test3", version: dirtyVersion, telemetry: true, key: "KEY", expected: result{enabled: true, key: "KEY"}},
+		{testName: "test4", version: dirtyVersion, telemetry: false, key: "KEY", expected: result{enabled: false, key: "DISABLED"}},
+
+		{testName: "test5", version: releaseVersion, telemetry: true, key: "", expected: result{enabled: buildinfo.ReleaseBuild && !buildinfo.TestBuild, key: disabledInDebug}},
+		{testName: "test6", version: releaseVersion, telemetry: false, key: "", expected: result{enabled: false, key: "DISABLED"}},
+		{testName: "test7", version: releaseVersion, telemetry: true, key: "KEY", expected: result{enabled: true, key: "KEY"}},
+		{testName: "test8", version: releaseVersion, telemetry: false, key: "KEY", expected: result{enabled: false, key: "DISABLED"}},
 	}
 
 	logio, _, _, _ := io2.TestIO()
 	logger := logger.NewLogger(logio, printer.DefaultColorPrinter())
 
 	for _, testCase := range testCases {
-		t.Run(testCase.testDir, func(t *testing.T) {
-			if testCase.telemetry {
-				t.Setenv(env.TelemetryStorageKey.EnvVar(), testCase.key)
-			} else {
-				t.Setenv(env.TelemetryStorageKey.EnvVar(), "")
-			}
-
-			config.K8sConfig.OfflineMode = testCase.offline
+		t.Run(testCase.testName, func(t *testing.T) {
+			t.Setenv(env.TelemetryStorageKey.EnvVar(), testCase.key)
+			testutils.SetMainVersion(t, testCase.version)
 			config.K8sConfig.Telemetry.Enabled = testCase.telemetry
 
 			bundleio, _, out, _ := io2.TestIO()

--- a/roxctl/central/generate/k8s.go
+++ b/roxctl/central/generate/k8s.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stackrox/rox/pkg/renderer"
 	"github.com/stackrox/rox/pkg/roxctl"
 	"github.com/stackrox/rox/pkg/utils"
+	"github.com/stackrox/rox/pkg/version"
 	"github.com/stackrox/rox/roxctl/common"
 	"github.com/stackrox/rox/roxctl/common/environment"
 	"github.com/stackrox/rox/roxctl/common/flags"
@@ -105,7 +106,7 @@ func k8sBasedOrchestrator(cliEnvironment environment.Environment, k8sConfig *ren
 	flagWrap.StringVar(&k8sConfig.CentralDBImage, flags.FlagNameCentralDBImage, "", "central-db image to use"+defaultImageHelp, "central")
 	flagWrap.StringVar(&k8sConfig.ScannerImage, flags.FlagNameScannerImage, "", "scanner image to use"+defaultImageHelp, "scanner")
 	flagWrap.StringVar(&k8sConfig.ScannerDBImage, flags.FlagNameScannerDBImage, "", "scanner-db image to use"+defaultImageHelp, "scanner")
-	flagWrap.BoolVar(&k8sConfig.Telemetry.Enabled, "enable-telemetry", false, "whether to enable telemetry", "central")
+	flagWrap.BoolVar(&k8sConfig.Telemetry.Enabled, "enable-telemetry", version.IsReleaseVersion(), "whether to enable telemetry", "central")
 
 	if env.DeclarativeConfiguration.BooleanSetting() {
 		flagWrap.StringSliceVar(&k8sConfig.DeclarativeConfigMounts.ConfigMaps, "declarative-config-config-maps", nil,

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -106,6 +106,7 @@ export_test_environment() {
     ci_export ROX_SEND_NAMESPACE_LABELS_IN_SYSLOG "${ROX_SEND_NAMESPACE_LABELS_IN_SYSLOG:-true}"
     ci_export ROX_DECLARATIVE_CONFIGURATION "${ROX_DECLARATIVE_CONFIGURATION:-true}"
     ci_export ROX_COMPLIANCE_ENHANCEMENTS "${ROX_COMPLIANCE_ENHANCEMENTS:-true}"
+    ci_export ROX_TELEMETRY_STORAGE_KEY_V1 "DISABLED"
 
     if is_in_PR_context && pr_has_label ci-fail-fast; then
         ci_export FAIL_FAST "true"
@@ -187,6 +188,8 @@ deploy_central_via_operator() {
     customize_envVars+=$'\n        value: "'"${ROX_POSTGRES_DATASTORE:-false}"'"'
     customize_envVars+=$'\n      - name: ROX_PROCESSES_LISTENING_ON_PORT'
     customize_envVars+=$'\n        value: "'"${ROX_PROCESSES_LISTENING_ON_PORT:-true}"'"'
+    customize_envVars+=$'\n      - name: ROX_TELEMETRY_STORAGE_KEY_V1'
+    customize_envVars+=$'\n        value: "'"${ROX_TELEMETRY_STORAGE_KEY_V1:-DISABLED}"'"'
 
     env - \
       centralAdminPasswordBase64="$centralAdminPasswordBase64" \


### PR DESCRIPTION
## Description

Release version central binary will download a json document from a URL, defined via `ROX_TELEMETRY_CONFIG_URL` (with some hardcoded default value) on startup if there's no telemetry key defined. Development version will download the config if only a key is also defined via environment variable and if the key is equal to the one found in the config.

Example document:
```json
{ "storage_key_v1": "asdfm52347fhvsdkj" }
```

*Update*: until the default endpoint is implemented, we'll use the hardcoded key.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

With an HTTP server pod, serving `config.json`, central logs:
```
...
telemetry/centralclient: 2023/06/13 15:08:16.374527 instance_config.go:86: Info: Telemetry configuration has been downloaded from http://10.244.0.18:8000/config.json
...
```
