### PR TITLE
ROX-16969: Make ProcessesListeningOnPortsTest multi-arch compliant

### DIFF
--- a/qa-tests-backend/src/test/groovy/ProcessesListeningOnPortsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ProcessesListeningOnPortsTest.groovy
@@ -34,7 +34,7 @@ class ProcessesListeningOnPortsTest extends BaseSpecification {
         return [
             new Deployment()
                     .setName(TCPCONNECTIONTARGET1)
-                    .setImage("quay.io/rhacs-eng/qa:socat")
+                    .setImage("quay.io/rhacs-eng/qa-multi-arch:socat")
                     .addPort(80)
                     .addPort(8080)
                     .addLabel("app", TCPCONNECTIONTARGET1)
@@ -44,7 +44,7 @@ class ProcessesListeningOnPortsTest extends BaseSpecification {
                                       "socat "+SOCAT_DEBUG+" TCP-LISTEN:8080,fork STDOUT)" as String,]),
             new Deployment()
                     .setName(TCPCONNECTIONTARGET2)
-                    .setImage("quay.io/rhacs-eng/qa:socat")
+                    .setImage("quay.io/rhacs-eng/qa-multi-arch:socat")
                     .addPort(8081, "TCP")
                     .addLabel("app", TCPCONNECTIONTARGET2)
                     .setExposeAsService(true)
@@ -52,7 +52,7 @@ class ProcessesListeningOnPortsTest extends BaseSpecification {
                     .setArgs(["(socat "+SOCAT_DEBUG+" TCP-LISTEN:8081,fork STDOUT)" as String,]),
             new Deployment()
                     .setName(TCPCONNECTIONTARGET3)
-                    .setImage("quay.io/rhacs-eng/qa:socat")
+                    .setImage("quay.io/rhacs-eng/qa-multi-arch:socat")
                     .addPort(8082, "TCP")
                     .addLabel("app", TCPCONNECTIONTARGET3)
                     .setExposeAsService(true)


### PR DESCRIPTION
This PR intends to add multi-arch support for the `ProcessesListeningOnPortsTest` QA test.
Test images used in respective test are changed to use alternate multi-arch images which support 3 platforms viz. `x86_64`, `ppc64le` and `s390x`.

Changes are verified manually using `./gradlew test --tests=ProcessesListeningOnPortsTest
`
This PR intends to fix [ROX-16969](https://issues.redhat.com/browse/ROX-16969)