### PR TITLE
fix(qa): Skip QA tests on P/Z when central & scanner is on X

### DIFF
--- a/qa-tests-backend/src/test/groovy/NetworkSimulator.groovy
+++ b/qa-tests-backend/src/test/groovy/NetworkSimulator.groovy
@@ -294,6 +294,9 @@ class NetworkSimulator extends BaseSpecification {
 
     @Tag("NetworkPolicySimulation")
     @Tag("BAT")
+    // skip if executed in a test environment with just secured-cluster deployed in the test cluster
+    // i.e. central is deployed elsewhere
+    @IgnoreIf({ Env.ONLY_SECURED_CLUSTER == "true" })
     def "Verify NetworkPolicy Simulator with query - single policy simulation"() {
         given:
         def allDeps = NetworkGraphUtil.getDeploymentsAsGraphNodes()

--- a/qa-tests-backend/src/test/groovy/NodeInventoryTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NodeInventoryTest.groovy
@@ -8,7 +8,12 @@ import services.ClusterService
 import services.NodeService
 import spock.lang.Shared
 import spock.lang.Tag
+import spock.lang.IgnoreIf
+import util.Env
 
+// skip if executed in a test environment with just secured-cluster deployed in the test cluster
+// i.e. central is deployed elsewhere
+@IgnoreIf({ Env.ONLY_SECURED_CLUSTER == "true" })
 class NodeInventoryTest extends BaseSpecification {
     @Shared
     private String clusterId

--- a/qa-tests-backend/src/test/groovy/TLSChallengeTest.groovy
+++ b/qa-tests-backend/src/test/groovy/TLSChallengeTest.groovy
@@ -19,8 +19,13 @@ import util.Timer
 import spock.lang.Retry
 import spock.lang.Shared
 import spock.lang.Tag
+import spock.lang.IgnoreIf
+import util.Env
 
 @Retry(count = 1)
+// skip if executed in a test environment with just secured-cluster deployed in the test cluster
+// i.e. central is deployed elsewhere
+@IgnoreIf({ Env.ONLY_SECURED_CLUSTER == "true" })
 class TLSChallengeTest extends BaseSpecification {
     @Shared
     private EnvVar originalCentralEndpoint = new EnvVar()


### PR DESCRIPTION
This PR intends to add multi-arch support for the QA test.

The `NodeInventoryTest`, `TLSChallengeTest` and few sub-tests in `NetworkSimulator` have dependency on central / scanner deployment.
In a P/Z test environment where only secured-cluster is deployed & central + scanner are deployed on X, these tests need to be skipped.

Changes are verified manually using `./gradlew test --tests=TestName`