### PR TITLE
ROX-16515: Temporarily hide dark mode

### DIFF
--- a/ui/apps/platform/src/Containers/MainPage/Header/MastheadToolbar.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Header/MastheadToolbar.tsx
@@ -11,7 +11,11 @@ import ClusterStatusProblems from './ClusterStatusProblems';
 import GlobalSearchButton from './GlobalSearchButton';
 import HelpMenu from './HelpMenu';
 import OrchestratorComponentsToggle from './OrchestratorComponentsToggle';
+/*
+ * TODO: remove this comment, which hides the light-mode/dark-mode toggle import,
+ *       after we update to use PatternFly themes for dark mode
 import ThemeToggleButton from './ThemeToggleButton';
+ */
 import UserMenu from './UserMenu';
 
 function MastheadToolbar(): ReactElement {
@@ -38,9 +42,13 @@ function MastheadToolbar(): ReactElement {
                 <PageHeaderToolsItem>
                     <CLIDownloadMenu />
                 </PageHeaderToolsItem>
+                {/*
+                  * TODO: remove this comment, which hides the light-mode/dark-mode toggle,
+                  *       after we update to use PatternFly themes for dark mode
                 <PageHeaderToolsItem>
                     <ThemeToggleButton />
                 </PageHeaderToolsItem>
+                */}
                 <PageHeaderToolsItem>
                     <ClusterStatusProblems />
                 </PageHeaderToolsItem>

--- a/ui/apps/platform/src/Containers/ThemeProvider.js
+++ b/ui/apps/platform/src/Containers/ThemeProvider.js
@@ -30,6 +30,10 @@ const useEffectDarkMode = () => {
             // default to light mode.
             isDarkMode = darkModeValue === 'true';
         }
+
+        // TODO: remove this override for never dark-mode, after we update to use PatternFly themes for dark mode
+        isDarkMode = false;
+
         setThemeState({ isDarkMode, hasThemeMounted: true });
     }, [userPrefersDarkMode]);
 
@@ -50,7 +54,12 @@ const ThemeProvider = ({ children }) => {
 
     const toggle = () => {
         const prevTheme = getTheme(themeState.isDarkMode);
-        const darkModeToggled = !themeState.isDarkMode;
+
+        // TODO: remove this override for never dark-mode, ` && false`
+        //       after we update to use PatternFly themes for dark mode
+
+        const darkModeToggled = !themeState.isDarkMode && false;
+
         localStorage.setItem(DARK_MODE_KEY, JSON.stringify(darkModeToggled));
         document.body.classList.remove(prevTheme);
         setThemeState({ ...themeState, isDarkMode: darkModeToggled });


### PR DESCRIPTION
## Description

Request from our UX team. (see Jira)

Until we can fully implement PatternFly themes for dark mode.

## Checklist
- [ ] Investigated and inspected CI test results


## Testing Performed

Tested by switching to Dark Mode, then unstashing code changes. Setting for Dark Mode remained in local storage, but is now ignored.

With luck, when we re-introduce Dark Mode, and if we use the same local storage flag, users who had saved that preference will get Dark Mode back automatically.
![Screen Shot 2023-06-09 at 1 12 04 PM](https://github.com/stackrox/stackrox/assets/715729/0b2163c4-8130-4861-8f12-e4dc79992409)
