### PR TITLE
fix(ui): Delete unneeded Tailwind font weight (part 3)

### DIFF
--- a/ui/apps/platform/src/Components/InfoList/InfoList.js
+++ b/ui/apps/platform/src/Components/InfoList/InfoList.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 const InfoList = ({ items, renderItem, extraClassNames }) => {
     return (
         <ul
-            className={`bg-base-100 border-2 rounded p-2 border-base-300 w-full font-600 text-base-600 hover:border-base-400 leading-normal last:mb-0 overflow-scroll ${extraClassNames}`}
+            className={`bg-base-100 border-2 rounded p-2 border-base-300 w-full text-base-600 hover:border-base-400 leading-normal last:mb-0 overflow-scroll ${extraClassNames}`}
         >
             {items.map(renderItem)}
         </ul>

--- a/ui/apps/platform/src/Components/LinkListWidget.js
+++ b/ui/apps/platform/src/Components/LinkListWidget.js
@@ -17,7 +17,7 @@ function getLI(item) {
         <Link
             to={item.link}
             title={item.label}
-            className="font-600 text-base-600 hover:bg-primary-100 focus:bg-primary-100 focus:text-primary-700 hover:text-primary-700 leading-normal px-2 inline-block w-full h-8 items-center flex"
+            className="text-base-600 underline leading-normal px-2 inline-block w-full h-8 items-center flex"
         >
             <span className="truncate w-full">{item.label}</span>
         </Link>

--- a/ui/apps/platform/src/Components/NumberedGrid/NumberedGrid.js
+++ b/ui/apps/platform/src/Components/NumberedGrid/NumberedGrid.js
@@ -19,16 +19,14 @@ const NumberedGrid = ({ data, history }) => {
         } ${stacked ? 'py-4' : 'py-2 border-r'}`;
         const content = (
             <div className="flex flex-1 items-center">
-                <span className="text-base-600 self-center text-2xl pl-2 pr-4 font-600">
-                    {index + 1}
-                </span>
+                <span className="text-base-600 self-center pl-2 pr-4">{index + 1}</span>
                 <div className={`flex flex-1 ${stacked ? 'justify-between' : 'flex-col'}`}>
                     {subText && (
-                        <div className="text-base-500 font-600 text-sm mb-1 whitespace-nowrap truncate">
+                        <div className="text-base-500 text-sm mb-1 whitespace-nowrap truncate">
                             {subText}
                         </div>
                     )}
-                    <div className="text-base-600 font-600 flex items-center text-base mr-4 whitespace-nowrap truncate">
+                    <div className="text-base-600 flex items-center text-base mr-4 whitespace-nowrap truncate">
                         {text}
                     </div>
                     {component && <div className={`${stacked ? '' : 'mt-2'}`}>{component}</div>}

--- a/ui/apps/platform/src/Components/NumberedList/NumberedList.js
+++ b/ui/apps/platform/src/Components/NumberedList/NumberedList.js
@@ -5,7 +5,7 @@ import { Tooltip } from '@patternfly/react-core';
 
 import DetailedTooltipContent from 'Components/DetailedTooltipContent';
 
-const leftSideClasses = 'p-2 text-sm text-primary-800 font-600 w-full';
+const leftSideClasses = 'p-2 text-sm text-primary-800 w-full';
 
 const NumberedList = ({ data, linkLeftOnly }) => {
     const list = data.map(({ text, subText, url, component, tooltip }, i) => {

--- a/ui/apps/platform/src/Components/TableGroup.js
+++ b/ui/apps/platform/src/Components/TableGroup.js
@@ -61,7 +61,7 @@ class TableGroup extends Component {
                     <div className="flex ml-4 mr-3 rounded-full bg-base-100 h-5 w-5 justify-center text-tertiary-700 items-center border border-tertiary-400">
                         {icons[state]}
                     </div>
-                    <h1 className="p-3 pl-0 font-600 text-lg leading-normal">{name}</h1>
+                    <h1 className="p-3 pl-0 font-700 text-lg leading-normal">{name}</h1>
                 </div>
                 <div className="flex items-center flex-shrink-0 font-700 text-sm p-3 pr-4 opacity-50">{`${
                     rows.length

--- a/ui/apps/platform/src/Containers/Clusters/Components/FormFieldRequired.js
+++ b/ui/apps/platform/src/Containers/Clusters/Components/FormFieldRequired.js
@@ -9,7 +9,7 @@ import PropTypes from 'prop-types';
  * If the value is not empty: label color and (assumed) ordinary weight.
  */
 const FormFieldRequired = ({ empty }) => (
-    <span className={empty ? 'text-warning-700' : 'font-600'} data-testid="required">
+    <span className={empty ? 'text-warning-700' : 'font-700'} data-testid="required">
         (required)
     </span>
 );

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/widgets/Rules.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/widgets/Rules.js
@@ -36,13 +36,13 @@ const Rules = ({ rules, ...rest }) => {
         content = (
             <div className="flex">
                 <div>
-                    <h1 className="font-600 border-b border-base-300 text-sm justify-left flex p-2 px-3">
+                    <h1 className="font-700 border-b border-base-300 text-sm justify-left flex p-2 px-3">
                         Verbs
                     </h1>
                     <ul className="p-3">{verbs}</ul>
                 </div>
                 <div>
-                    <h1 className="font-600 border-b border-base-300 text-sm justify-left flex p-2 px-3">
+                    <h1 className="font-700 border-b border-base-300 text-sm justify-left flex p-2 px-3">
                         Resources and Non-resource URLs
                     </h1>
                     <ul className="p-3">{resourcesAndNonResourcesURL}</ul>

--- a/ui/apps/platform/src/Containers/Images/CVETable.js
+++ b/ui/apps/platform/src/Containers/Images/CVETable.js
@@ -27,7 +27,7 @@ const CVETable = (props) => {
                 Header: 'Name',
                 accessor: 'name',
                 headerClassName:
-                    'pl-3 font-600 text-left border-b border-base-300 border-r-0 bg-primary-200',
+                    'pl-3 font-700 text-left border-b border-base-300 border-r-0 bg-primary-200',
                 Cell: ({ value }) => <div>{value}</div>,
             },
             {
@@ -35,21 +35,21 @@ const CVETable = (props) => {
                 accessor: 'version',
                 className: 'w-1/8 pr-4 flex items-center justify-end',
                 headerClassName:
-                    'w-1/8 font-600 text-right border-b border-base-300 border-r-0 pr-4 bg-primary-200',
+                    'w-1/8 font-700 text-right border-b border-base-300 border-r-0 pr-4 bg-primary-200',
             },
             {
                 Header: 'Source',
                 accessor: 'source',
                 className: 'pr-4 flex items-center justify-end w-1/8',
                 headerClassName:
-                    'w-1/8 font-600 text-right border-b border-base-300 border-r-0 pr-4 bg-primary-200',
+                    'w-1/8 font-700 text-right border-b border-base-300 border-r-0 pr-4 bg-primary-200',
             },
             {
                 Header: 'Location',
                 accessor: 'location',
                 className: 'flex items-center justify-start word-break-all w-1/4',
                 headerClassName:
-                    'w-1/4 font-600 border-b border-base-300 border-r-0 bg-primary-200',
+                    'w-1/4 font-700 border-b border-base-300 border-r-0 bg-primary-200',
                 Cell: ({ value }) => (
                     <Tooltip content={value}>
                         <div>{value}</div>
@@ -61,7 +61,7 @@ const CVETable = (props) => {
                 accessor: 'vulns.length',
                 className: 'w-1/10 pr-4 flex items-center justify-end',
                 headerClassName:
-                    'w-1/10 font-600 text-right border-b border-base-300 border-r-0 pr-4 bg-primary-200',
+                    'w-1/10 font-700 text-right border-b border-base-300 border-r-0 pr-4 bg-primary-200',
             },
         ];
 
@@ -70,7 +70,7 @@ const CVETable = (props) => {
                 Header: 'Fixable',
                 className: 'w-1/10 pr-4 flex items-center justify-end',
                 headerClassName:
-                    'w-1/10 font-600 text-right border-b border-base-300 border-r-0 pr-4 bg-primary-200',
+                    'w-1/10 font-700 text-right border-b border-base-300 border-r-0 pr-4 bg-primary-200',
                 Cell: ({ original }) => {
                     return original.vulns.filter((vuln) => vuln.fixedBy).length;
                 },

--- a/ui/apps/platform/src/Containers/Images/VulnsTable.js
+++ b/ui/apps/platform/src/Containers/Images/VulnsTable.js
@@ -15,14 +15,14 @@ const VulnsTable = ({ vulns, containsFixableCVEs, isOSPkg }) => {
                         href={ci.original.link}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="text-primary-600 font-600 pointer-events-auto"
+                        className="text-primary-600 font-700 pointer-events-auto"
                     >
                         {ci.value}
                     </a>
                     <div className="mt-2">{ci.original.summary}</div>
                 </div>
             ),
-            headerClassName: 'font-600 border-b border-base-300 flex items-end bg-primary-300',
+            headerClassName: 'font-700 border-b border-base-300 flex items-end bg-primary-300',
             className: 'pointer-events-none flex items-center justify-left',
         },
         {
@@ -44,7 +44,7 @@ const VulnsTable = ({ vulns, containsFixableCVEs, isOSPkg }) => {
                 return `${cvss} (${ci.original.scoreVersion === 'V2' ? 'v2' : 'v3'})`;
             },
             headerClassName:
-                'font-600 border-b border-base-300 flex items-end justify-end bg-primary-300',
+                'font-700 border-b border-base-300 flex items-end justify-end bg-primary-300',
             className: 'flex items-center justify-end',
         },
     ];
@@ -53,7 +53,7 @@ const VulnsTable = ({ vulns, containsFixableCVEs, isOSPkg }) => {
             Header: 'Fixed',
             accessor: 'fixedBy',
             width: 130,
-            headerClassName: 'font-600 border-b border-base-300 flex items-end',
+            headerClassName: 'font-700 border-b border-base-300 flex items-end',
             className: 'pointer-events-none flex items-center justify-end',
             Cell: ({ value }) => (value === '' && !isOSPkg ? 'Unknown' : value),
         });

--- a/ui/apps/platform/src/Containers/MainPage/Header/OrchestratorComponentsToggle.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Header/OrchestratorComponentsToggle.tsx
@@ -39,10 +39,7 @@ const OrchestratorComponentsToggle = ({
 
     // TODO: update wrapper classes to PatternFly, like  `pf-u-background-color-100
     return (
-        <div
-            className="flex justify-center items-center pr-3 font-600 relative"
-            style={{ top: '2px' }}
-        >
+        <div className="flex justify-center items-center pr-3 relative" style={{ top: '2px' }}>
             <Switch
                 id="orchestrator-components-toggle"
                 aria-label="Toggle Showing Orchestrator Components"

--- a/ui/apps/platform/src/Containers/Risk/Process/BinaryCollapsible.js
+++ b/ui/apps/platform/src/Containers/Risk/Process/BinaryCollapsible.js
@@ -16,8 +16,8 @@ function BinaryCollapsible({ commandLineArgs, children }) {
             <div className={`${titleClassName} ${backgroundClass}`}>
                 <div className="flex items-center">
                     <div className="flex pl-2">{icon}</div>
-                    <div className="p-2 text-primary-800 flex flex-1">
-                        <span className="text-base font-600 word-break">{displayArgs}</span>
+                    <div className="p-2 flex flex-1">
+                        <span className="text-base word-break">{displayArgs}</span>
                     </div>
                 </div>
             </div>

--- a/ui/apps/platform/src/Containers/Risk/Process/DiscoveryCardHeader.js
+++ b/ui/apps/platform/src/Containers/Risk/Process/DiscoveryCardHeader.js
@@ -38,15 +38,15 @@ function ProcessesDiscoveryCardHeader({
 
     const trimmedName = name.length > 48 ? `${name.substring(0, 48)}...` : name;
     const backgroundClass = suspicious ? suspiciousProcessClassName : headerClassName;
-    const textClass = suspicious ? 'text-alert-800' : 'text-primary-800';
+    const textClass = suspicious ? 'text-alert-700' : 'text-base-600';
     return (
         <div
             className={`${titleClassName} ${backgroundClass}`}
             data-testid={suspicious ? 'suspicious-process' : 'process'}
         >
             <div className={`p-3 ${textClass} flex flex-col`}>
-                <h1 className="text-lg font-700">{trimmedName}</h1>
-                <h2 className="text-sm font-600">{`in container ${containerName} `}</h2>
+                <h1 className="font-700">{trimmedName}</h1>
+                <h2 className="text-sm">{`in container ${containerName} `}</h2>
             </div>
             <div className="flex content-center">
                 {suspicious && (
@@ -55,14 +55,14 @@ function ProcessesDiscoveryCardHeader({
                             <button
                                 type="button"
                                 onClick={addBaseline}
-                                className="border rounded p-px mr-3 ml-3 border-alert-800 flex items-center hover:bg-alert-300"
+                                className="border rounded p-px mr-3 ml-3 border-alert-300 flex items-center hover:bg-alert-200"
                             >
-                                <Icon.Plus className="h-4 w-4 text-alert-800" />
+                                <Icon.Plus className="h-4 w-4 text-alert-700" />
                             </button>
                         </Tooltip>
                     </div>
                 )}
-                <button type="button" className={`pl-3 pr-3 ${suspicious && 'text-alert-800'}`}>
+                <button type="button" className={`pl-3 pr-3 ${suspicious && 'text-alert-700'}`}>
                     {icon}
                 </button>
             </div>

--- a/ui/apps/platform/src/Containers/Risk/SecurityContext.js
+++ b/ui/apps/platform/src/Containers/Risk/SecurityContext.js
@@ -36,10 +36,10 @@ const SecurityContext = ({ deployment }) => {
                 );
             });
         if (!containers.length) {
-            containers = <span className="py-3 font-600">None</span>;
+            containers = <span className="py-3">None</span>;
         }
     } else {
-        containers = <span className="py-3 font-600">None</span>;
+        containers = <span className="py-3">None</span>;
     }
     return (
         <div className="px-3 pt-5">

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Cve/VulnMgmtCveOverview.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Cve/VulnMgmtCveOverview.js
@@ -61,8 +61,8 @@ const VulnMgmtCveOverview = ({ data, entityContext }) => {
             <ExternalLink size={16} />
         </a>
     ) : (
-        <span className="font-600 uppercase text-center text-base-600 bg-base-100 text-xs p-1">
-            Full Description Unavailable
+        <span className="text-center text-base-600 bg-base-100 text-sm p-1">
+            Full description unavailable
         </span>
     );
 

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/Cves/CveBulkActionDialogue.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/Cves/CveBulkActionDialogue.js
@@ -258,7 +258,7 @@ const CveBulkActionDialogue = ({ closeAction, bulkActionCveIds, cveType }) => {
         const truncatedSummary = truncate(item.summary, 120);
         return (
             <li key={item.id} className="flex items-center bg-tertiary-200 mb-2 p-2">
-                <span className="min-w-32">{item.cve}</span>
+                <span className="min-w-32 font-700">{item.cve}</span>
                 <span>{truncatedSummary}</span>
             </li>
         );

--- a/ui/apps/platform/src/Containers/VulnMgmt/VulnMgmtComponents/FixableCveExportButton.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/VulnMgmtComponents/FixableCveExportButton.js
@@ -23,8 +23,8 @@ const FixableCveExportButton = ({ workflowState, entityName, disabled, exportTyp
 
     return (
         <Button
-            className="inline-flex px-1 rounded-sm font-600 uppercase text-center items-center min-w-24 justify-center border-2 !important;
-    line-height text-base-600 border-base-300 bg-base-100 text-base-600 text-sm my-2 py-2 pr-3 hover:bg-base-200 hover:text-base-700"
+            className="inline-flex px-1 rounded-sm text-center items-center min-w-24 justify-center border-2 !important;
+    line-height text-base-600 border-base-300 bg-base-100 text-sm my-2 py-2 pr-3 hover:bg-base-200"
             disabled={disabled}
             text="Export as CSV"
             textCondensed="Export as CSV"


### PR DESCRIPTION
## Description

As part of ongoing accessibilty effort, delete leftover styles that detract from legibility of Red Hat font with PatternFly colors.

### Problem

* Classic contrast between bold font-700 and normal font-600 was sometimes too subtle to see.
* PatternFly contrast between bold font-700 and normal font-400 makes obvious some inconsistent unneeded bold formatting.

### Analysis and Solution

Find in Files `font-600` reduced by half from 52 results in 31 files to 25 results in 16 files

### Residue

1. Verify that SimulationFrame will be deleted with classic Network Graph.
2. Verify whether any Redux form fields are obsolete.
3. Verify whether or not src/Containers/VulnMgmt/Entity/Policy folder is obsolete after #6235
4. Return to presentation components for cluster health in a follow up to reduce risk of merge conflicts with recent changes for 4.1 release.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

### Manual testing

#### Compliance

1. Visit /main/compliance, click a standard that has controls which apply to entities, click a control that has a non-zero percent.
    * See bold font weight for name in heading of collapsible table group.
    * See normal font weight for names in Related widgets.
    ![compliance_LinkListWidget](https://github.com/stackrox/stackrox/assets/11862657/a6dd491a-0b57-49fa-948f-dc8839e54a4e)

#### Vulnerability Management

1. Visit /main/vulnerability-management, and scroll down:
    * See normal font weight for links in numbered lists in 3 widgets.
    * See normal font weight for cluster name and compatible font side for number in fourth **Clusters With Most Orchestrator & Istio Vulnerabilities** widget.
    ![vulnmanagement_NumberedGrid](https://github.com/stackrox/stackrox/assets/11862657/bf2d0b55-ce49-4139-987c-7b97b6d04256)

2. Visit /main/vulnerability-management/image-cves, click one or more check boxes, and then click **Add to Policy**
    * See bold font weight for CVE id but normal font weight for truncated description.
    ![vulnmanagement_CveBulkActionDialogue_InfoList](https://github.com/stackrox/stackrox/assets/11862657/38567726-92cf-43d5-aef4-e0301600a63f)

3. Click a row, and temporarily edit code:
    * See normal font weight, sentence case, and small text size for **Full description unavailable** at right of **Description & Details** widget.
    ![vulnmanagement_VulnMgmtCveOverview](https://github.com/stackrox/stackrox/assets/11862657/a8e787a9-ae07-4cb1-9b19-893b55463893)

4. Visit /main/vulnerability-management/images, click an image that has fixable CVEs, click to expand **Dockerfile**, click to expand a layer that have fixable CVEs.
    * See bold font weight for **Name**, **Version**, **Source**, and so on.
    * See bold font weight for **CVE**, **CVSS**, and vulnerability id link.
    ![vulnmanagement_CVETable_VulnsTable](https://github.com/stackrox/stackrox/assets/11862657/ae054be7-6eba-4f30-a20d-21fecdb14509)

5. Visit /main/vulnerability-management/clusters, click a cluster:
    * See normal font weight and sentence case for **Export as CSV** button under **Cluster Findings**.
    ![vulnmanagement_FixableCveExportButton](https://github.com/stackrox/stackrox/assets/11862657/6f0ca9b7-8757-4dd2-9735-a7188e7adc00)

#### Configuration Management

1. Visit /main/configmanagement/roles, click a role.
    * See bold font weight for **Verbs** and **Resources and Non-resource URLs** headings.
    ![configmanagement_Rules](https://github.com/stackrox/stackrox/assets/11862657/a532dfd0-c4b8-4353-9e1c-ea09912b2c1a)

#### Risk

1. Visit /main/risk
    * See normal font weight for **Show Orchestrator Components** consistent with **Search** and **CLI**.
    ![risk_OrchestratorComponentsToggle](https://github.com/stackrox/stackrox/assets/11862657/78f6ddc3-90ba-48ed-84d9-9b7aaafd6fd0)

2. Click a deployment row, and then click **Process discovery**.
    * See contrast between bold font weight and normal text size of process versus normal font weight and small text size of location.
        ![risk_DiscoveryCardHeader_BinaryCollapsible](https://github.com/stackrox/stackrox/assets/11862657/bfcf88db-c5d3-46d1-896e-d3be25c44bd7)

    * Temporarily edit code to see classic red alert color for suspicious processes
        ![risk_DiscoveryCardHeader_BinaryCollapsible_suspicious](https://github.com/stackrox/stackrox/assets/11862657/1306669a-86ae-4571-9473-9ce424e2919c)

#### Clusters

1. Visit /main/clusters, click a row, and then scroll down to **Static Configuration**.
    * See bold font weight for **(required)** same as label.
    ![clusters_FormFieldRequired](https://github.com/stackrox/stackrox/assets/11862657/8b8f5cb8-1791-474e-8ac1-e3bfdeee7c70)
