### PR TITLE
ROX-17715: Delete non-postgres code in Collections UI

### DIFF
--- a/ui/apps/platform/cypress/integration/collections/collectionsCrudWorkflow.test.js
+++ b/ui/apps/platform/cypress/integration/collections/collectionsCrudWorkflow.test.js
@@ -1,5 +1,4 @@
 import withAuth from '../../helpers/basicAuth';
-import { hasFeatureFlag } from '../../helpers/features';
 import { tryDeleteCollection, visitCollections } from './Collections.helpers';
 
 /* 
@@ -8,12 +7,6 @@ import { tryDeleteCollection, visitCollections } from './Collections.helpers';
 */
 describe('Create collection', () => {
     withAuth();
-
-    beforeEach(function beforeHook() {
-        if (!hasFeatureFlag('ROX_POSTGRES_DATASTORE')) {
-            this.skip();
-        }
-    });
 
     const collectionName = 'Financial deployments';
     const clonedName = `${collectionName} -COPY-`;

--- a/ui/apps/platform/cypress/integration/collections/collectionsTable.test.js
+++ b/ui/apps/platform/cypress/integration/collections/collectionsTable.test.js
@@ -1,5 +1,4 @@
 import withAuth from '../../helpers/basicAuth';
-import { hasFeatureFlag } from '../../helpers/features';
 import { getRegExpForTitleWithBranding } from '../../helpers/title';
 import {
     collectionsAlias,
@@ -24,12 +23,6 @@ const staticResponseMap = {
 
 describe('Collections table', () => {
     withAuth();
-
-    before(function beforeHook() {
-        if (!hasFeatureFlag('ROX_POSTGRES_DATASTORE')) {
-            this.skip();
-        }
-    });
 
     it('should visit via link in left nav', () => {
         visitCollectionsFromLeftNav(staticResponseMap);

--- a/ui/apps/platform/cypress/integration/collections/deploymentMatching.test.js
+++ b/ui/apps/platform/cypress/integration/collections/deploymentMatching.test.js
@@ -1,5 +1,4 @@
 import withAuth from '../../helpers/basicAuth';
-import { hasFeatureFlag } from '../../helpers/features';
 import {
     assertDeploymentsAreMatched,
     assertDeploymentsAreMatchedExactly,
@@ -15,18 +14,10 @@ describe('Collection deployment matching', () => {
     const sampleCollectionName = 'Stackrox sample deployments';
     const withEmbeddedCollectionName = 'Contains embedded collections';
 
-    beforeEach(function beforeHook() {
-        if (!hasFeatureFlag('ROX_POSTGRES_DATASTORE')) {
-            this.skip();
-        }
-    });
-
     // Clean up when the test suite exits
     after(() => {
-        if (hasFeatureFlag('ROX_POSTGRES_DATASTORE')) {
-            tryDeleteCollection(withEmbeddedCollectionName);
-            tryDeleteCollection(sampleCollectionName);
-        }
+        tryDeleteCollection(withEmbeddedCollectionName);
+        tryDeleteCollection(sampleCollectionName);
     });
 
     it('should preview deployments matching specified rules', () => {

--- a/ui/apps/platform/cypress/integration/collections/permissions.test.js
+++ b/ui/apps/platform/cypress/integration/collections/permissions.test.js
@@ -1,5 +1,4 @@
 import withAuth from '../../helpers/basicAuth';
-import { hasFeatureFlag } from '../../helpers/features';
 import { visit, visitWithStaticResponseForPermissions } from '../../helpers/visit';
 import navSelectors from '../../selectors/navigation';
 import { tryCreateCollection, tryDeleteCollection } from './Collections.helpers';
@@ -10,23 +9,13 @@ describe('Collection permission checks', () => {
 
     const collectionName = 'Permission test collection';
 
-    beforeEach(function beforeHook() {
-        if (!hasFeatureFlag('ROX_POSTGRES_DATASTORE')) {
-            this.skip();
-        }
+    before(() => {
+        const rules = [{ fieldName: 'Namespace', values: [{ value: 'stackrox' }], operator: 'OR' }];
+
+        tryCreateCollection(collectionName, 'e2e test description', [], [{ rules }]);
     });
 
-    // Ensure a collection exists in the system for permission tests
-    if (hasFeatureFlag('ROX_POSTGRES_DATASTORE')) {
-        before(() => {
-            const rules = [
-                { fieldName: 'Namespace', values: [{ value: 'stackrox' }], operator: 'OR' },
-            ];
-
-            tryCreateCollection(collectionName, 'e2e test description', [], [{ rules }]);
-        });
-        after(() => tryDeleteCollection(collectionName));
-    }
+    after(() => tryDeleteCollection(collectionName));
 
     it('should prevent users with no access from viewing collections', () => {
         // Mock a 'NO_ACCESS' permission response

--- a/ui/apps/platform/src/Containers/MainPage/Body.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Body.tsx
@@ -105,7 +105,6 @@ function Body({ hasReadAccess, isFeatureFlagEnabled }: BodyProps): ReactElement 
     const { isDarkMode } = useTheme();
 
     const isPostgresEnabled = isFeatureFlagEnabled('ROX_POSTGRES_DATASTORE');
-    const isCollectionsEnabled = isPostgresEnabled;
     const isNetworkGraphPatternflyEnabled = isFeatureFlagEnabled('ROX_NETWORK_GRAPH_PATTERNFLY');
     const isVulnMgmtWorkloadCvesEnabled =
         isFeatureFlagEnabled('ROX_VULN_MGMT_WORKLOAD_CVES') && isPostgresEnabled;
@@ -134,7 +133,7 @@ function Body({ hasReadAccess, isFeatureFlagEnabled }: BodyProps): ReactElement 
                     <Route path={policyManagementBasePath} component={AsyncPolicyManagementPage} />
                     {/* Make sure the following Redirect element works after react-router-dom upgrade */}
                     <Redirect exact from={deprecatedPoliciesPath} to={policiesPath} />
-                    {isCollectionsEnabled && hasCollectionsPermission && (
+                    {hasCollectionsPermission && (
                         <Route path={collectionsPath} component={AsyncCollectionsPage} />
                     )}
                     <Route path={riskPath} component={AsyncRiskPage} />

--- a/ui/apps/platform/src/Containers/MainPage/Sidebar/NavigationSidebar.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Sidebar/NavigationSidebar.tsx
@@ -62,7 +62,7 @@ function NavigationSidebar({
         systemHealthPath,
     ];
 
-    if (isFeatureFlagEnabled('ROX_POSTGRES_DATASTORE') && hasReadAccess('WorkflowAdministration')) {
+    if (hasReadAccess('WorkflowAdministration')) {
         // Insert 'Collections' after 'Policy Management'
         platformConfigurationPaths.splice(
             platformConfigurationPaths.indexOf(policyManagementBasePath) + 1,

--- a/ui/apps/platform/src/hooks/useFetchReport.ts
+++ b/ui/apps/platform/src/hooks/useFetchReport.ts
@@ -1,10 +1,8 @@
 import { useEffect, useState } from 'react';
-import { fetchAccessScopes } from 'services/AccessScopesService';
 import { getCollection } from 'services/CollectionsService';
 
 import { fetchReportById } from 'services/ReportsService';
 import { ReportConfiguration } from 'types/report.proto';
-import useFeatureFlags from './useFeatureFlags';
 
 export type ReportScope = {
     // The 'AccessControlScope' type is deprecated and should be able to be removed in the release after 3.74
@@ -39,50 +37,11 @@ function fetchCollectionReportScope(scopeId: string): Promise<ReportScope> {
     }));
 }
 
-function fetchAccessScopeReportScope(scopeId: string): Promise<ReportScope | null> {
-    return fetchAccessScopes().then((scopes) => {
-        const fullScope = scopes.find((scope) => scope.id === scopeId);
-
-        if (!fullScope) {
-            return null;
-        }
-
-        const { id, name, description } = fullScope;
-        return { type: 'AccessControlScope', id, name, description };
-    });
-}
-
-/*
-    When migrating the report config from using access scopes as the "report scope", to using
-    collections, there are some access scope configurations that could not be converted. In this
-    case, the `scopeId` attached to the report will still reference an access scope. If our request
-    to obtain the collection fails (since the ID is not for a collection), we make a second request
-    for an access scope using the same ID. If this request succeeds, we know that the user has an
-    invalid access scope attached to the report and we can use this information to prompt them
-    to configure a collection.
-
-    TODO - In the next release when the feature flag is removed:
-    This impacts systems that have upgraded from 3.73 to 3.74. In the release after 3.74 we can 
-    remove this check, as all invalid report configurations will be removed.
-*/
-function fetchReportScope(scopeId: string, isCollectionsEnabled: boolean) {
-    if (isCollectionsEnabled) {
-        return fetchCollectionReportScope(scopeId).catch(() =>
-            // Could not get a collection, so try to get an access scope instead
-            fetchAccessScopeReportScope(scopeId)
-        );
-    }
-    return fetchAccessScopeReportScope(scopeId);
-}
-
 /*
  * This hook does an API call to the report configurations API to get the list of reports
  */
 function useFetchReport(reportId: string, refresh = 0): Result {
     const [result, setResult] = useState<Result>(defaultResultState);
-
-    const { isFeatureFlagEnabled } = useFeatureFlags();
-    const isCollectionsEnabled = isFeatureFlagEnabled('ROX_POSTGRES_DATASTORE');
 
     useEffect(() => {
         setResult(defaultResultState);
@@ -90,7 +49,7 @@ function useFetchReport(reportId: string, refresh = 0): Result {
         if (reportId) {
             fetchReportById(reportId)
                 .then((report) =>
-                    fetchReportScope(report.scopeId, isCollectionsEnabled).then((reportScope) => {
+                    fetchCollectionReportScope(report.scopeId).then((reportScope) => {
                         setResult({ report, reportScope, error: null, isLoading: false });
                     })
                 )
@@ -98,7 +57,7 @@ function useFetchReport(reportId: string, refresh = 0): Result {
                     setResult({ report: null, error, isLoading: false, reportScope: null });
                 });
         }
-    }, [reportId, refresh, isCollectionsEnabled]);
+    }, [reportId, refresh]);
 
     return result;
 }


### PR DESCRIPTION
## Description

> deprecating our Postgres feature flag

### Analysis

Find in files `ROX_POSTGRES_DATASTORE`
* cypress: decrease from 43 results in 25 files to 37 results in 21 files
* src: decrease from 60 results in 49 files to 58 results in 48 files

### Solution

1. Delete skip from integration tests.
2. Delete conditional rendering from body and left navigation.
3. Delete conditional code for upgrade from 3.73 to 3.74 version in reports.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed

1. `yarn lint` in ui
2. `yarn build` in ui
    * `wc build/static/js/*.js`
        branch - master: -362 = 11794399 - 11794761
3. `yarn start` in ui

### Manual testing

1. Visit /main/collections and then click **Create collection**
2. Click **Cancel** and then go back to main dashboard
3. Expand **Platform Configuration** and then click **Collections**

### Integration testing

1. `yarn cypress-open` in ui/apps/platform
    * collections/collectionsCrudWorkflow.test.js
    * collections/collectionsTable.test.js
    * collections/deploymentMatching.test.js
    * collections/permissions.test.js