### PR TITLE
refactor: Stop requiring slack env variables for NotifierService

### DIFF
--- a/qa-tests-backend/src/main/groovy/services/NotifierService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/NotifierService.groovy
@@ -15,11 +15,6 @@ class NotifierService extends BaseService {
     // private static final PAGERDUTY_API_KEY = Env.mustGetPagerdutyApiKey()
     private static final String PAGERDUTY_API_KEY = null
 
-    // SLACK_MAIN_WEBHOOK is the webhook URL for #acs-slack-integration-testing
-    public static final SLACK_MAIN_WEBHOOK = Env.mustGetSlackMainWebhook()
-    // SLACK_ALT_WEBHOOK is the webhook URL for #acs-slack-integration-testing-2
-    public static final SLACK_ALT_WEBHOOK = Env.mustGetSlackAltWebhook()
-
     static getNotifierClient() {
         return NotifierServiceGrpc.newBlockingStub(getChannel())
     }
@@ -118,7 +113,7 @@ class NotifierService extends BaseService {
                 .setType("slack")
                 .setName(name)
                 .setLabelKey(labelKey)
-                .setLabelDefault(SLACK_MAIN_WEBHOOK)
+                .setLabelDefault(Env.mustGetSlackMainWebhook())
                 .setUiEndpoint(getStackRoxEndpoint())
                 .build()
     }

--- a/qa-tests-backend/src/test/groovy/IntegrationsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/IntegrationsTest.groovy
@@ -29,7 +29,6 @@ import services.ClusterService
 import services.ExternalBackupService
 import services.ImageIntegrationService
 import services.NetworkPolicyService
-import services.NotifierService
 import services.PolicyService
 import util.Env
 import util.MailServer

--- a/qa-tests-backend/src/test/groovy/IntegrationsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/IntegrationsTest.groovy
@@ -628,15 +628,15 @@ class IntegrationsTest extends BaseSpecification {
          */
         "Slack deploy override"   |
                 new SlackNotifier("slack test", "slack-key")   |
-                null   |
+                null                                                    |
                 new Deployment()
                         .setName("policy-violation-generic-notification-deploy-override")
                         .addLabel("app", "policy-violation-generic-notification-deploy-override")
-                        .addAnnotation("slack-key", NotifierService.SLACK_ALT_WEBHOOK)
+                        .addAnnotation("slack-key", Env.mustGetSlackAltWebhook())
                         .setImage("quay.io/rhacs-eng/qa-multi-arch-nginx:latest")
         "Slack namespace override"   |
                 new SlackNotifier("slack test", "slack-key")   |
-                [key: "slack-key", value: NotifierService.SLACK_ALT_WEBHOOK] |
+                [key: "slack-key", value: Env.mustGetSlackAltWebhook()] |
                 new Deployment()
                         .setName("policy-violation-generic-notification-ns-override")
                         .addLabel("app", "policy-violation-generic-notification-ns-override")


### PR DESCRIPTION
## Description

Makes it easier running locally tests that use `NotifierService` but are not related to slack webhooks - for example, `DeclarativeConfigTest`

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

1. CI is sufficient
