### PR TITLE
fix(ui): Delete occurrences of Tailwind uppercase part 4

### DIFF
--- a/ui/apps/platform/cypress/integration/configmanagement/ConfigurationManagement.helpers.js
+++ b/ui/apps/platform/cypress/integration/configmanagement/ConfigurationManagement.helpers.js
@@ -266,8 +266,7 @@ export function clickOnCountWidget(entitiesKey, type) {
     }
 
     if (type === 'entityList') {
-        cy.get(`${selectors.groupedTabs}:contains('${entitiesKey}')`);
-        cy.get(`li.bg-base-100:contains("${entitiesKey}")`);
+        cy.get(`${selectors.groupedTabs}:contains('${headingForEntities[entitiesKey]}')`);
     }
 }
 
@@ -320,9 +319,9 @@ export const clickOnSingleEntityInTable = (entitiesKey1, entitiesKey2) => {
         });
 };
 
-export const hasTabsFor = (entities) => {
-    entities.forEach((entity) => {
-        cy.get(`${selectors.groupedTabs} div:contains("${entity}")`);
+export const hasTabsFor = (entitiesKeys) => {
+    entitiesKeys.forEach((entitiesKey) => {
+        cy.get(`${selectors.groupedTabs} div:contains("${headingForEntities[entitiesKey]}")`);
     });
 };
 

--- a/ui/apps/platform/cypress/integration/configmanagement/clusters.test.js
+++ b/ui/apps/platform/cypress/integration/configmanagement/clusters.test.js
@@ -53,8 +53,8 @@ describe('Configuration Management Clusters', () => {
             'deployments',
             'images',
             'secrets',
-            'users and groups',
-            'service accounts',
+            'subjects',
+            'serviceaccounts',
             'roles',
             'controls',
         ]);

--- a/ui/apps/platform/cypress/integration/configmanagement/roles.test.js
+++ b/ui/apps/platform/cypress/integration/configmanagement/roles.test.js
@@ -39,7 +39,7 @@ describe('Configuration Management Roles', () => {
     it('should have the correct tabs for a single entity view', () => {
         visitConfigurationManagementEntityInSidePanel(entitiesKey);
         navigateToSingleEntityPage(entitiesKey);
-        hasTabsFor(['users and groups', 'service accounts']);
+        hasTabsFor(['subjects', 'serviceaccounts']);
     });
 
     describe('should have same number in users and groups table as in count widget', () => {

--- a/ui/apps/platform/src/Components/BinderTabs/BinderTabs.tsx
+++ b/ui/apps/platform/src/Components/BinderTabs/BinderTabs.tsx
@@ -15,14 +15,8 @@ function BinderTabHeader({
     onSelectTab,
     dataTestId = 'tab',
 }: BinderTabHeaderProps): ReactElement {
-    const className = `${
-        isActive ? 'bg-primary-300' : 'bg-primary-100'
-    } rounded-tr-none first:rounded-tl-lg last:rounded-tr-lg border-b border-primary-300 border-r border-t`;
-    const buttonClassName = `${
-        isActive
-            ? 'bg-primary-200 p-3 text-base-500 text-primary-700 font-700'
-            : 'bg-base-200 text-base-500'
-    } p-3 uppercase text-sm`;
+    const className = 'border-base-400 border'; // 400 instead of 300 to contrast with bg-base-200
+    const buttonClassName = `${isActive ? 'bg-primary-200' : 'bg-base-200'} text-base-600 p-3`;
 
     return (
         <li key={title} className={className} data-testid={dataTestId}>

--- a/ui/apps/platform/src/Components/BinderTabs/BinderTabs.tsx
+++ b/ui/apps/platform/src/Components/BinderTabs/BinderTabs.tsx
@@ -16,7 +16,7 @@ function BinderTabHeader({
     dataTestId = 'tab',
 }: BinderTabHeaderProps): ReactElement {
     const className = 'border-base-400 border'; // 400 instead of 300 to contrast with bg-base-200
-    const buttonClassName = `${isActive ? 'bg-primary-200' : 'bg-base-200'} text-base-600 p-3`;
+    const buttonClassName = `${isActive ? 'bg-primary-200' : 'bg-base-100'} text-base-600 p-3`;
 
     return (
         <li key={title} className={className} data-testid={dataTestId}>

--- a/ui/apps/platform/src/Components/GroupedTabs.js
+++ b/ui/apps/platform/src/Components/GroupedTabs.js
@@ -7,7 +7,7 @@ import { useTheme } from 'Containers/ThemeProvider';
 
 const Tab = ({ text, index, active, to }) => (
     <li
-        className={`flex flex-grow items-center ${active ? 'bg-primary-200' : ''} ${
+        className={`flex flex-grow items-center ${active ? 'bg-primary-200' : 'bg-base-100'} ${
             index !== 0 ? 'border-l border-base-400' : ''
         }`}
     >

--- a/ui/apps/platform/src/Components/GroupedTabs.js
+++ b/ui/apps/platform/src/Components/GroupedTabs.js
@@ -1,21 +1,19 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
+import upperFirst from 'lodash/upperFirst';
+
 import { useTheme } from 'Containers/ThemeProvider';
 
 const Tab = ({ text, index, active, to }) => (
     <li
-        className={`hover:bg-primary-200 flex flex-grow items-center ${
-            active ? 'bg-base-100 text-primary-700' : ''
-        } ${index !== 0 ? 'border-l border-base-400' : ''}`}
+        className={`flex flex-grow items-center ${active ? 'bg-primary-200' : ''} ${
+            index !== 0 ? 'border-l border-base-400' : ''
+        }`}
     >
         <Link to={to} data-testid="tab" className={`w-full no-underline ${active && 'active'}`}>
-            <div
-                className={`${
-                    active ? 'text-primary-700' : 'text-base-500 hover:text-base-600'
-                } cursor-pointer uppercase font-700 p-3 flex justify-center`}
-            >
-                {text}
+            <div className="cursor-pointer text-base-600 p-3 flex justify-center">
+                {upperFirst(text)}
             </div>
         </Link>
     </li>
@@ -51,7 +49,7 @@ const GroupedTabs = ({ groups, tabs, activeTab }) => {
                 >
                     {showGroupTab && (
                         <span
-                            className="truncate absolute top-0 z-10 border-l border-t border-r border-base-400 text-2xs py-1 px-2 rounded-t-lg text-base-500 w-full"
+                            className="truncate absolute top-0 z-10 border-l border-t border-r border-base-400 text-xs py-1 px-2 rounded-t-lg w-full"
                             style={{ transform: 'translateY(-100%)' }}
                         >
                             {group}
@@ -79,7 +77,7 @@ const GroupedTabs = ({ groups, tabs, activeTab }) => {
         <div className="relative">
             <ul
                 data-testid="grouped-tabs"
-                className={` flex border-b border-base-400 px-4 uppercase text-sm ignore-react-onclickoutside ${
+                className={` flex border-b border-base-400 px-4 text-sm ignore-react-onclickoutside ${
                     !isDarkMode ? 'bg-primary-100' : 'bg-base-0'
                 }`}
             >

--- a/ui/apps/platform/src/Components/Tabs.js
+++ b/ui/apps/platform/src/Components/Tabs.js
@@ -10,11 +10,10 @@ class Tabs extends Component {
         onTabClick: null,
         default: null,
         tabClass:
-            'font-700 hover:text-base-600 px-2 text-base-500 text-sm uppercase border-r border-l border-t border-base-400 rounded-t-sm',
+            'bg-base-100 text-base-600 px-2 border-r border-l border-t border-base-400 rounded-t-sm',
         tabActiveClass:
-            'bg-base-100 font-700 text-sm shadow uppercase px-2 py-3 border-r border-l border-t border-base-400 rounded-t-sm',
-        tabDisabledClass:
-            'disabled bg-base-100 font-700 px-2 px-3 py-3 text-base-500 text-sm uppercase',
+            'bg-primary-200 text-base-600 px-2 py-3 border-r border-l border-t border-base-400 rounded-t-sm',
+        tabDisabledClass: 'disabled bg-base-100 text-base-500 px-2 px-3 py-3',
         tabContentBgColor: 'bg-base-200 border-t shadow border-base-400',
         hasTabSpacing: false,
     };
@@ -115,7 +114,7 @@ class Tabs extends Component {
 
         return (
             <div className="w-full h-full flex flex-col">
-                <div className={`flex justify-between z-1 shadow-underline font-700 ${className}`}>
+                <div className={`flex justify-between z-1 shadow-underline ${className}`}>
                     <div className="flex">{this.getHeaders()}</div>
                 </div>
                 <div className={`overflow-auto h-full flex-1 ${tabContentBgColor}`}>


### PR DESCRIPTION
## Description

### Problems

1. PatternFly guidelines do not even mention uppercase.
2. Extra width of uppercase is a blocker to increase classic normal font size from 12px to 14px, especially for same size as PatternFly in tables and key-value lists.

### Analysis and Solution

Find in File `uppercase` decreased from 29 results in 20 files to 23 results in 17 files

Replace uppercase with mixed case and use `bg-primary-200` for active tab similar to PatternFly for `ToggleGroup` element.

1. src/Components/GroupedTabs.js and simplify comlicated styles
    * Vulnerability Management: src/Components/workflow/EntityTabs/EntityTabs.js
    * Configuration Management: src/Containers/ConfigManagement/Entity/EntityTabs.js

2. src/Components/Tabs.js
    * Network Graph: src/Containers/Network/SidePanel/Simulator/SuccessViewTabs.tsx
    * Risk: src/Containers/Risk/RiskSidePanelContent.js

3. src/Components/BinderTabs/BinderTabs.tsx and simplify comlicated styles that did not work correctly
    * Network Graph: src/Containers/Network/SidePanel/NetworkDeploymentOverlay/Flows/Flows.tsx
    * Vulnerability Management: src/Containers/VulnMgmt/Entity/Cluster/VulnMgmtClusterOverview.js
    * Configuration Management: src/Containers/ConfigManagement/Entity/Cluster.js

4. cypress/integration/configmanagement
    * Replace lowercase `'service accounts'` and `'users and groups'` text with `'serviceaccounts'` and `'subjects'` entity keys in `hasTabsFor` calls.
    * Replace text with `headingForEntities[entitiesKey]` in assertions for `clickOnCountWidget` and `hasTabsFor` helper functions.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed

### Manual testing

1. Visit /main/vulnerability-management/clusters, and then click a row.

    * BinderTabs: See sentence case in tabs under **Cluster Findings**.
        ![BinderTabs_vulnerability-management-100](https://github.com/stackrox/stackrox/assets/11862657/1c1e3a04-b44d-4509-9f0a-93abb4bf3e6d)

    * GroupedTabs: Click link to single page to see sentence case in grouped tabs.
        ![GroupedTabs_vulnerability-management](https://github.com/stackrox/stackrox/assets/11862657/1f18753b-12a3-46f6-8704-43fb924d5131)

2. Visit /main/configmanagement/clusters, and then click a row.

    * BinderTabs: See sentence case in tabs under **Cluster Findings**.
        ![BinderTabs_configmanagement-100](https://github.com/stackrox/stackrox/assets/11862657/797647dd-9e10-497b-977c-0ca83d8db41a)

    * GroupedTabs: Click link to single page to see sentence case in grouped tabs.
        ![GroupedTabs_configmanagement](https://github.com/stackrox/stackrox/assets/11862657/00477344-f9f4-4cdb-a5c1-de2114b79487)

3. Visit /main/risk, and then click a row.

    * Tabs: See sentence case in tabs.
        ![Tabs_risk](https://github.com/stackrox/stackrox/assets/11862657/7c14d656-4ea0-4746-967c-f9d06fc44cdc)

4. Visit /main/network, select **stackrox** namespace, and then click a deployment.

    * Tabs: See sentence case in tabs.
        ![Tabs_network](https://github.com/stackrox/stackrox/assets/11862657/2c8ea40a-45fe-4b6d-932c-2b8981407600)

### Integration testing

1. `yarn cypress-open` in ui/apps/platform
    * configmanagement/ciscontrols.test.js
    * configmanagement/clusters.test.js
    * configmanagement/dashboard.test.js
    * configmanagement/images.test.js
    * configmanagement/namespaces.test.js
    * configmanagement/nodes.test.js
    * configmanagement/policies.test.js
    * configmanagement/roles.test.js
    * configmanagement/secrets.test.js
    * configmanagement/serviceaccounts.test.js
    * configmanagement/usersandgroups.test.js
    * risk/risk.test.js
    * vulnmanagement/clusterCves.test.js
    * vulnmanagement/clusters.test.js
    * vulnmanagement/dashboard.test.js
    * vulnmanagement/dashboardToEntityPages.test.js
    * vulnmanagement/deployment.test.js
    * vulnmanagement/entitypages.test.js
    * vulnmanagement/imageComponents.test.js
    * vulnmanagement/imageCves.test.js
    * vulnmanagement/images.test.js
    * vulnmanagement/namespaces.test.js
    * vulnmanagement/nodeComponents.test.js
    * vulnmanagement/nodeCves.test.js
    * vulnmanagement/nodes.test.js
