### PR TITLE
refactor: Re-Introduce singleton for debug service

### DIFF
--- a/central/authprovider/registry/singleton.go
+++ b/central/authprovider/registry/singleton.go
@@ -15,12 +15,12 @@ const (
 )
 
 var (
-	once      sync.Once
-	singleton authproviders.Registry
+	once     sync.Once
+	registry authproviders.Registry
 )
 
 func initialize() {
-	singleton = authproviders.NewStoreBackedRegistry(
+	registry = authproviders.NewStoreBackedRegistry(
 		ssoURLPathPrefix, tokenRedirectURLPath,
 		authProviderDS.Singleton(), jwt.IssuerFactorySingleton(),
 		mapper.FactorySingleton())
@@ -29,5 +29,5 @@ func initialize() {
 // Singleton returns the auth providers registry.
 func Singleton() authproviders.Registry {
 	once.Do(initialize)
-	return singleton
+	return registry
 }

--- a/central/authprovider/registry/singleton.go
+++ b/central/authprovider/registry/singleton.go
@@ -1,0 +1,33 @@
+package registry
+
+import (
+	authProviderDS "github.com/stackrox/rox/central/authprovider/datastore"
+	"github.com/stackrox/rox/central/jwt"
+	"github.com/stackrox/rox/central/role/mapper"
+	"github.com/stackrox/rox/pkg/auth/authproviders"
+	"github.com/stackrox/rox/pkg/sync"
+)
+
+const (
+	ssoURLPathPrefix = "/sso/"
+	//#nosec G101 -- This is a false positive
+	tokenRedirectURLPath = "/auth/response/generic"
+)
+
+var (
+	once      sync.Once
+	singleton authproviders.Registry
+)
+
+func initialize() {
+	singleton = authproviders.NewStoreBackedRegistry(
+		ssoURLPathPrefix, tokenRedirectURLPath,
+		authProviderDS.Singleton(), jwt.IssuerFactorySingleton(),
+		mapper.FactorySingleton())
+}
+
+// Singleton returns the auth providers registry.
+func Singleton() authproviders.Registry {
+	once.Do(initialize)
+	return singleton
+}

--- a/central/debug/service/singleton.go
+++ b/central/debug/service/singleton.go
@@ -17,11 +17,11 @@ import (
 var (
 	once sync.Once
 
-	as Service
+	debugService Service
 )
 
 func initialize() {
-	as = New(datastore.Singleton(),
+	debugService = New(datastore.Singleton(),
 		connection.ManagerSingleton(),
 		gatherers.Singleton(),
 		logimbueStore.Singleton(),
@@ -36,5 +36,5 @@ func initialize() {
 // Singleton provides the instance of the Service interface to register.
 func Singleton() Service {
 	once.Do(initialize)
-	return as
+	return debugService
 }

--- a/central/debug/service/singleton.go
+++ b/central/debug/service/singleton.go
@@ -1,0 +1,40 @@
+package service
+
+import (
+	authProviderRegistry "github.com/stackrox/rox/central/authprovider/registry"
+	"github.com/stackrox/rox/central/cluster/datastore"
+	configDS "github.com/stackrox/rox/central/config/datastore"
+	groupDataStore "github.com/stackrox/rox/central/group/datastore"
+	logimbueStore "github.com/stackrox/rox/central/logimbue/store"
+	notifierDS "github.com/stackrox/rox/central/notifier/datastore"
+	roleDataStore "github.com/stackrox/rox/central/role/datastore"
+	"github.com/stackrox/rox/central/sensor/service/connection"
+	"github.com/stackrox/rox/central/telemetry/gatherers"
+	"github.com/stackrox/rox/central/trace"
+	"github.com/stackrox/rox/pkg/sync"
+)
+
+var (
+	once sync.Once
+
+	as Service
+)
+
+func initialize() {
+	as = New(datastore.Singleton(),
+		connection.ManagerSingleton(),
+		gatherers.Singleton(),
+		logimbueStore.Singleton(),
+		trace.AuthzTraceSinkSingleton(),
+		authProviderRegistry.Singleton(),
+		groupDataStore.Singleton(),
+		roleDataStore.Singleton(),
+		configDS.Singleton(),
+		notifierDS.Singleton())
+}
+
+// Singleton provides the instance of the Service interface to register.
+func Singleton() Service {
+	once.Do(initialize)
+	return as
+}

--- a/central/declarativeconfig/singleton.go
+++ b/central/declarativeconfig/singleton.go
@@ -4,7 +4,6 @@ import (
 	declarativeConfigHealth "github.com/stackrox/rox/central/declarativeconfig/health/datastore"
 	"github.com/stackrox/rox/central/declarativeconfig/types"
 	"github.com/stackrox/rox/central/declarativeconfig/updater"
-	"github.com/stackrox/rox/pkg/auth/authproviders"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/sync"
 )
@@ -15,12 +14,12 @@ var (
 )
 
 // ManagerSingleton provides the instance of Manager to use.
-func ManagerSingleton(registry authproviders.Registry) Manager {
+func ManagerSingleton() Manager {
 	once.Do(func() {
 		instance = New(
 			env.DeclarativeConfigReconcileInterval.DurationSetting(),
 			env.DeclarativeConfigWatchInterval.DurationSetting(),
-			updater.DefaultResourceUpdaters(registry),
+			updater.DefaultResourceUpdaters(),
 			declarativeConfigHealth.Singleton(),
 			types.UniversalNameExtractor(),
 			types.UniversalIDExtractor(),

--- a/central/declarativeconfig/updater/updater.go
+++ b/central/declarativeconfig/updater/updater.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	authProviderDatastore "github.com/stackrox/rox/central/authprovider/datastore"
+	authProviderRegistry "github.com/stackrox/rox/central/authprovider/registry"
 	declarativeConfigHealth "github.com/stackrox/rox/central/declarativeconfig/health/datastore"
 	"github.com/stackrox/rox/central/declarativeconfig/types"
 	groupDataStore "github.com/stackrox/rox/central/group/datastore"
@@ -14,7 +15,6 @@ import (
 	"github.com/stackrox/rox/central/notifier/policycleaner"
 	notifierProcessor "github.com/stackrox/rox/central/notifier/processor"
 	roleDatastore "github.com/stackrox/rox/central/role/datastore"
-	"github.com/stackrox/rox/pkg/auth/authproviders"
 )
 
 // ResourceUpdater handles updates of proto resources within declarative config reconciliation routine.
@@ -30,9 +30,9 @@ type ResourceUpdater interface {
 
 // DefaultResourceUpdaters return a map from proto type to an ResourceUpdater instance responsible
 // for updates for this type.
-func DefaultResourceUpdaters(registry authproviders.Registry) map[reflect.Type]ResourceUpdater {
+func DefaultResourceUpdaters() map[reflect.Type]ResourceUpdater {
 	return map[reflect.Type]ResourceUpdater{
-		types.AuthProviderType: newAuthProviderUpdater(authProviderDatastore.Singleton(), registry,
+		types.AuthProviderType: newAuthProviderUpdater(authProviderDatastore.Singleton(), authProviderRegistry.Singleton(),
 			groupDataStore.Singleton(), declarativeConfigHealth.Singleton()),
 		types.GroupType:         newGroupUpdater(groupDataStore.Singleton(), declarativeConfigHealth.Singleton()),
 		types.RoleType:          newRoleUpdater(roleDatastore.Singleton(), groupDataStore.Singleton(), declarativeConfigHealth.Singleton()),

--- a/central/main.go
+++ b/central/main.go
@@ -79,7 +79,6 @@ import (
 	"github.com/stackrox/rox/central/jwt"
 	licenseService "github.com/stackrox/rox/central/license/service"
 	logimbueHandler "github.com/stackrox/rox/central/logimbue/handler"
-	logimbueStore "github.com/stackrox/rox/central/logimbue/store"
 	metadataService "github.com/stackrox/rox/central/metadata/service"
 	mitreService "github.com/stackrox/rox/central/mitre/service"
 	namespaceService "github.com/stackrox/rox/central/namespace/service"
@@ -90,7 +89,6 @@ import (
 	networkFlowService "github.com/stackrox/rox/central/networkgraph/service"
 	networkPolicyService "github.com/stackrox/rox/central/networkpolicies/service"
 	nodeService "github.com/stackrox/rox/central/node/service"
-	notifierDS "github.com/stackrox/rox/central/notifier/datastore"
 	"github.com/stackrox/rox/central/notifier/processor"
 	notifierService "github.com/stackrox/rox/central/notifier/service"
 	_ "github.com/stackrox/rox/central/notifiers/all" // These imports are required to register things from the respective packages.
@@ -136,7 +134,6 @@ import (
 	summaryService "github.com/stackrox/rox/central/summary/service"
 	"github.com/stackrox/rox/central/systeminfo/listener"
 	"github.com/stackrox/rox/central/telemetry/centralclient"
-	"github.com/stackrox/rox/central/telemetry/gatherers"
 	telemetryService "github.com/stackrox/rox/central/telemetry/service"
 	"github.com/stackrox/rox/central/tlsconfig"
 	"github.com/stackrox/rox/central/trace"
@@ -337,18 +334,7 @@ func servicesToRegister() []pkgGRPC.APIService {
 		complianceService.Singleton(),
 		configService.Singleton(),
 		credentialExpiryService.Singleton(),
-		debugService.New(
-			clusterDataStore.Singleton(),
-			connection.ManagerSingleton(),
-			gatherers.Singleton(),
-			logimbueStore.Singleton(),
-			trace.AuthzTraceSinkSingleton(),
-			authProviderRegistry.Singleton(),
-			groupDataStore.Singleton(),
-			roleDataStore.Singleton(),
-			configDS.Singleton(),
-			notifierDS.Singleton(),
-		),
+		debugService.Singleton(),
 		declarativeConfigHealthService.Singleton(),
 		delegatedRegistryConfigService.Singleton(),
 		deploymentService.Singleton(),

--- a/central/main.go
+++ b/central/main.go
@@ -454,13 +454,10 @@ func startGRPCServer() {
 			sac.ResourceScopeKeys(resources.Access)))
 
 	// Create the registry of applied auth providers.
-	registry, err := authproviders.NewStoreBackedRegistry(
+	registry := authproviders.NewStoreBackedRegistry(
 		ssoURLPathPrefix, tokenRedirectURLPath,
 		authProviderDS.Singleton(), jwt.IssuerFactorySingleton(),
 		mapper.FactorySingleton())
-	if err != nil {
-		log.Panicf("Could not create auth provider registry: %v", err)
-	}
 
 	// env.EnableOpenShiftAuth signals the desire but does not guarantee Central
 	// is configured correctly to talk to the OpenShift's OAuth server. If this

--- a/central/trace/singleton.go
+++ b/central/trace/singleton.go
@@ -1,0 +1,21 @@
+package trace
+
+import (
+	"github.com/stackrox/rox/pkg/sac/observe"
+	"github.com/stackrox/rox/pkg/sync"
+)
+
+var (
+	once      sync.Once
+	singleton observe.AuthzTraceSink
+)
+
+func initialize() {
+	singleton = observe.NewAuthzTraceSink()
+}
+
+// AuthzTraceSinkSingleton returns the authz trace sink instance.
+func AuthzTraceSinkSingleton() observe.AuthzTraceSink {
+	once.Do(initialize)
+	return singleton
+}

--- a/central/trace/singleton.go
+++ b/central/trace/singleton.go
@@ -6,16 +6,16 @@ import (
 )
 
 var (
-	once      sync.Once
-	singleton observe.AuthzTraceSink
+	once           sync.Once
+	authzTraceSink observe.AuthzTraceSink
 )
 
 func initialize() {
-	singleton = observe.NewAuthzTraceSink()
+	authzTraceSink = observe.NewAuthzTraceSink()
 }
 
 // AuthzTraceSinkSingleton returns the authz trace sink instance.
 func AuthzTraceSinkSingleton() observe.AuthzTraceSink {
 	once.Do(initialize)
-	return singleton
+	return authzTraceSink
 }

--- a/pkg/auth/authproviders/registry_impl.go
+++ b/pkg/auth/authproviders/registry_impl.go
@@ -23,7 +23,7 @@ var (
 // NewStoreBackedRegistry creates a new auth provider registry that is backed by a store. It also can handle HTTP requests,
 // where every incoming HTTP request URL is expected to refer to a path under `urlPathPrefix`. The redirect URL for
 // clients upon successful/failed authentication is `clientRedirectURL`.
-func NewStoreBackedRegistry(urlPathPrefix string, redirectURL string, store Store, tokenIssuerFactory tokens.IssuerFactory, roleMapperFactory permissions.RoleMapperFactory) (Registry, error) {
+func NewStoreBackedRegistry(urlPathPrefix string, redirectURL string, store Store, tokenIssuerFactory tokens.IssuerFactory, roleMapperFactory permissions.RoleMapperFactory) Registry {
 	urlPathPrefix = strings.TrimRight(urlPathPrefix, "/") + "/"
 	registry := &registryImpl{
 		ServeMux:      http.NewServeMux(),
@@ -38,7 +38,7 @@ func NewStoreBackedRegistry(urlPathPrefix string, redirectURL string, store Stor
 		roleMapperFactory: roleMapperFactory,
 	}
 
-	return registry, nil
+	return registry
 }
 
 type registryImpl struct {


### PR DESCRIPTION
## Description

### What

* Introduce singleton for authz trace sink
* Introduce singleton for auth providers registry
* Remove dependency of declarative config manager singleton on auth providers registry
* Re-introduce singleton for debug service(originally removed as a side-effect of https://github.com/stackrox/rox/pull/9305)

### Why

During the implementation of https://issues.redhat.com/browse/ROX-12125, a lot of debug service code can be reused to the point, where it makes sense to reuse debug service instance.

Additionally, considering we use singleton pattern in almost 100% services in `central`, it makes sense to clean up code further by introducing new singletons. Plus, no need to pass parameters to `servicesToRegister` and `declarativeconfig.ManagerSingleton()`.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

1. CI should be sufficient
