### PR TITLE
ROX-13585: Delete non-postgres conditional code in Access Control UI

### DIFF
--- a/ui/apps/platform/cypress/integration/accessControl/accessControlPermissionSets.test.js
+++ b/ui/apps/platform/cypress/integration/accessControl/accessControlPermissionSets.test.js
@@ -1,5 +1,4 @@
 import withAuth from '../../helpers/basicAuth';
-import { hasFeatureFlag } from '../../helpers/features';
 
 import {
     assertAccessControlEntityDoesNotExist,
@@ -79,13 +78,7 @@ describe('Access Control Permission sets', () => {
     });
 
     it('direct link to default Admin has all read and write access', () => {
-        /*
-         * TODO: ROX-13585 - remove the pre-postgres constants once the migration to postgres
-         * is completed and the support for BoltDB, RocksDB and Bleve is dropped.
-         */
-        const targetID = hasFeatureFlag('ROX_POSTGRES_DATASTORE')
-            ? 'ffffffff-ffff-fff4-f5ff-ffffffffffff'
-            : 'io.stackrox.authz.permissionset.admin';
+        const targetID = 'ffffffff-ffff-fff4-f5ff-ffffffffffff';
         visitAccessControlEntity(entitiesKey, targetID);
 
         cy.get(selectors.form.inputName).should('have.value', 'Admin');
@@ -124,13 +117,7 @@ describe('Access Control Permission sets', () => {
     });
 
     it('direct link to default Analyst has all (but Administration) read and no write access', () => {
-        /*
-         * TODO: ROX-13585 - remove the pre-postgres constants once the migration to postgres
-         * is completed and the support for BoltDB, RocksDB and Bleve is dropped.
-         */
-        const targetID = hasFeatureFlag('ROX_POSTGRES_DATASTORE')
-            ? 'ffffffff-ffff-fff4-f5ff-fffffffffffe'
-            : 'io.stackrox.authz.permissionset.analyst';
+        const targetID = 'ffffffff-ffff-fff4-f5ff-fffffffffffe';
         visitAccessControlEntity(entitiesKey, targetID);
 
         cy.get(selectors.form.inputName).should('have.value', 'Analyst');
@@ -181,13 +168,7 @@ describe('Access Control Permission sets', () => {
     });
 
     it('direct link to default Continuous Integration has limited read and write accesss', () => {
-        /*
-         * TODO: ROX-13585 - remove the pre-postgres constants once the migration to postgres
-         * is completed and the support for BoltDB, RocksDB and Bleve is dropped.
-         */
-        const targetID = hasFeatureFlag('ROX_POSTGRES_DATASTORE')
-            ? 'ffffffff-ffff-fff4-f5ff-fffffffffffd'
-            : 'io.stackrox.authz.permissionset.continuousintegration';
+        const targetID = 'ffffffff-ffff-fff4-f5ff-fffffffffffd';
         visitAccessControlEntity(entitiesKey, targetID);
 
         cy.get(selectors.form.inputName).should('have.value', 'Continuous Integration');
@@ -258,13 +239,7 @@ describe('Access Control Permission sets', () => {
     });
 
     it('direct link to default None has no read nor write access', () => {
-        /*
-         * TODO: ROX-13585 - remove the pre-postgres constants once the migration to postgres
-         * is completed and the support for BoltDB, RocksDB and Bleve is dropped.
-         */
-        const targetID = hasFeatureFlag('ROX_POSTGRES_DATASTORE')
-            ? 'ffffffff-ffff-fff4-f5ff-fffffffffffc'
-            : 'io.stackrox.authz.permissionset.none';
+        const targetID = 'ffffffff-ffff-fff4-f5ff-fffffffffffc';
         visitAccessControlEntity(entitiesKey, targetID);
 
         cy.get(selectors.form.inputName).should('have.value', 'None');
@@ -300,13 +275,7 @@ describe('Access Control Permission sets', () => {
     });
 
     it('direct link to default Sensor Creator has limited read and write access', () => {
-        /*
-         * TODO: ROX-13585 - remove the pre-postgres constants once the migration to postgres
-         * is completed and the support for BoltDB, RocksDB and Bleve is dropped.
-         */
-        const targetID = hasFeatureFlag('ROX_POSTGRES_DATASTORE')
-            ? 'ffffffff-ffff-fff4-f5ff-fffffffffffa'
-            : 'io.stackrox.authz.permissionset.sensorcreator';
+        const targetID = 'ffffffff-ffff-fff4-f5ff-fffffffffffa';
         visitAccessControlEntity(entitiesKey, targetID);
 
         cy.get(selectors.form.inputName).should('have.value', 'Sensor Creator');

--- a/ui/apps/platform/src/Containers/AccessControl/Roles/Roles.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/Roles/Roles.tsx
@@ -41,7 +41,6 @@ import AccessControlHeaderActionBar from '../AccessControlHeaderActionBar';
 import AccessControlHeading from '../AccessControlHeading';
 import usePermissions from '../../../hooks/usePermissions';
 import AccessControlNoPermission from '../AccessControlNoPermission';
-import useFeatureFlags from '../../../hooks/useFeatureFlags';
 import { isUserResource } from '../traits';
 
 const entityType = 'ROLE';
@@ -70,13 +69,8 @@ function Roles(): ReactElement {
     const [accessScopes, setAccessScopes] = useState<AccessScope[]>([]);
     const [alertAccessScopes, setAlertAccessScopes] = useState<ReactElement | null>(null);
 
-    const { isFeatureFlagEnabled } = useFeatureFlags();
-
     function getDefaultAccessScopeID() {
-        if (isFeatureFlagEnabled('ROX_POSTGRES_DATASTORE')) {
-            return defaultAccessScopeIds.UnrestrictedPostgres;
-        }
-        return defaultAccessScopeIds.Unrestricted;
+        return defaultAccessScopeIds.UnrestrictedPostgres;
     }
 
     const roleNew: Role = {

--- a/ui/apps/platform/src/Containers/AccessControl/Roles/Roles.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/Roles/Roles.tsx
@@ -70,7 +70,7 @@ function Roles(): ReactElement {
     const [alertAccessScopes, setAlertAccessScopes] = useState<ReactElement | null>(null);
 
     function getDefaultAccessScopeID() {
-        return defaultAccessScopeIds.UnrestrictedPostgres;
+        return defaultAccessScopeIds.Unrestricted;
     }
 
     const roleNew: Role = {

--- a/ui/apps/platform/src/services/AccessScopesService.ts
+++ b/ui/apps/platform/src/services/AccessScopesService.ts
@@ -4,14 +4,8 @@ import { Traits } from '../types/traits.proto';
 
 const accessScopessUrl = '/v1/simpleaccessscopes';
 
-/*
- * TODO: ROX-13585 - remove the pre-postgres constants once the migration to postgres
- * is completed and the support for BoltDB, RocksDB and Bleve is dropped.
- */
 export const defaultAccessScopeIds = {
-    Unrestricted: 'io.stackrox.authz.accessscope.unrestricted',
     UnrestrictedPostgres: 'ffffffff-ffff-fff4-f5ff-ffffffffffff',
-    DenyAll: 'io.stackrox.authz.accessscope.denyall',
     DenyAllPostgres: 'ffffffff-ffff-fff4-f5ff-fffffffffffe',
 };
 
@@ -22,10 +16,7 @@ export function getIsDefaultAccessScopeId(id: string): boolean {
 }
 
 export function getIsUnrestrictedAccessScopeId(id: string): boolean {
-    return (
-        id === defaultAccessScopeIds.Unrestricted ||
-        id === defaultAccessScopeIds.UnrestrictedPostgres
-    );
+    return id === defaultAccessScopeIds.UnrestrictedPostgres;
 }
 
 export type SimpleAccessScopeNamespace = {

--- a/ui/apps/platform/src/services/AccessScopesService.ts
+++ b/ui/apps/platform/src/services/AccessScopesService.ts
@@ -5,8 +5,8 @@ import { Traits } from '../types/traits.proto';
 const accessScopessUrl = '/v1/simpleaccessscopes';
 
 export const defaultAccessScopeIds = {
-    UnrestrictedPostgres: 'ffffffff-ffff-fff4-f5ff-ffffffffffff',
-    DenyAllPostgres: 'ffffffff-ffff-fff4-f5ff-fffffffffffe',
+    Unrestricted: 'ffffffff-ffff-fff4-f5ff-ffffffffffff',
+    DenyAll: 'ffffffff-ffff-fff4-f5ff-fffffffffffe',
 };
 
 // The only remaining usage of this function is in ResourceScopeSelection.tsx file,
@@ -16,7 +16,7 @@ export function getIsDefaultAccessScopeId(id: string): boolean {
 }
 
 export function getIsUnrestrictedAccessScopeId(id: string): boolean {
-    return id === defaultAccessScopeIds.UnrestrictedPostgres;
+    return id === defaultAccessScopeIds.Unrestricted;
 }
 
 export type SimpleAccessScopeNamespace = {


### PR DESCRIPTION
## Description

> deprecating our Postgres feature flag

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed

### Manual testing

1. Visit /main/access-control/roles

2. Click **Create role**, type **None Unrestricted**, click **None**, and then click **Save**
    ![None_Unrestricted](https://github.com/stackrox/stackrox/assets/11862657/496bff35-5a7d-4492-83c0-fb4d2da7cfd6)

3. Click **Create role**, type **None Deny All**, click **None**, click **Deny All**, and then click **Save**
    ![None_Deny_All](https://github.com/stackrox/stackrox/assets/11862657/429b038a-ef69-4306-9af9-6e5d7ee24803)

### Integration testing

1. `yarn cypress-open` in ui/apps/platform
    * accessControl/accessControlAccessScopes.test.js
    * accessControl/accessControlPermissionSets.test.js
    * accessControl/accessControlRoles.test.js
