### PR TITLE
feat(helm): add support affinities and tolerations

### DIFF
--- a/image/templates/helm/shared/internal/scanner-config-shape.yaml
+++ b/image/templates/helm/shared/internal/scanner-config-shape.yaml
@@ -11,6 +11,7 @@ scanner:
     disable: null # bool
     minReplicas: null # int
     maxReplicas: null # int
+  affinity: null # dict
   resources: null # string | dict
   image:
     registry: null # string

--- a/image/templates/helm/shared/templates/02-scanner-06-deployment.yaml.htpl
+++ b/image/templates/helm/shared/templates/02-scanner-06-deployment.yaml.htpl
@@ -39,38 +39,7 @@ spec:
         {{- toYaml ._rox.scanner.tolerations | nindent 8 }}
       {{- end }}
       affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: scanner
-              topologyKey: kubernetes.io/hostname
-        nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 50
-              preference:
-                matchExpressions:
-                  - key: node-role.kubernetes.io/infra
-                    operator: Exists
-            - weight: 25
-              preference:
-                matchExpressions:
-                  - key: node-role.kubernetes.io/compute
-                    operator: Exists
-            # From v1.20 node-role.kubernetes.io/control-plane replaces node-role.kubernetes.io/master (removed in
-            # v1.25). We apply both because our goal is not to run pods on control plane nodes for any version of k8s.
-            - weight: 100
-              preference:
-                matchExpressions:
-                  - key: node-role.kubernetes.io/master
-                    operator: DoesNotExist
-            - weight: 100
-              preference:
-                matchExpressions:
-                  - key: node-role.kubernetes.io/control-plane
-                    operator: DoesNotExist
+        {{- toYaml ._rox.scanner.affinity | nindent 8 }}
       containers:
       - name: scanner
         {{ if eq ._rox.scanner.mode "slim" -}}

--- a/image/templates/helm/stackrox-central/internal/config-shape.yaml
+++ b/image/templates/helm/stackrox-central/internal/config-shape.yaml
@@ -29,6 +29,7 @@ central:
   endpointsConfig: null # string | dict
   nodeSelector: null # string | dict
   tolerations: null # [dict]
+  affinity: null # dict
   exposeMonitoring: null # bool
   jwtSigner:
     key: null # string

--- a/image/templates/helm/stackrox-central/internal/defaults.yaml.htpl
+++ b/image/templates/helm/stackrox-central/internal/defaults.yaml.htpl
@@ -17,6 +17,40 @@ defaults:
 
     exposeMonitoring: false
 
+    affinity:
+      nodeAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+        # Central is single-homed, so avoid preemptible nodes.
+        - weight: 100
+          preference: 
+            matchExpressions:
+            - key: cloud.google.com/gke-preemptible
+              operator: NotIn
+              values:
+                - "true"
+        - weight: 50
+          preference:
+            matchExpressions:
+            - key: node-role.kubernetes.io/infra
+              operator: Exists
+        - weight: 25
+          preference:
+            matchExpressions:
+            - key: node-role.kubernetes.io/compute
+              operator: Exists
+        # From v1.20 node-role.kubernetes.io/control-plane replaces node-role.kubernetes.io/master (removed in
+        # v1.25). We apply both because our goal is not to run pods on control plane nodes for any version of k8s.    
+        - weight: 100
+          preference:
+            matchExpressions:
+            - key: node-role.kubernetes.io/master
+              operator: DoesNotExist
+        - weight: 100
+          preference:
+            matchExpressions:
+            - key: node-role.kubernetes.io/control-plane
+              operator: DoesNotExist
+
     image:
       name: [< required "" .ImageRemote >]
       tag: [< required "" .ImageTag >]
@@ -70,6 +104,40 @@ defaults:
       disable: false
       minReplicas: 2
       maxReplicas: 5
+
+    affinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                app: scanner
+            topologyKey: kubernetes.io/hostname
+      nodeAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 50
+          preference:
+            matchExpressions:
+              - key: node-role.kubernetes.io/infra
+                operator: Exists
+        - weight: 25
+          preference:
+            matchExpressions:
+              - key: node-role.kubernetes.io/compute
+                operator: Exists
+        # From v1.20 node-role.kubernetes.io/control-plane replaces node-role.kubernetes.io/master (removed in
+        # v1.25). We apply both because our goal is not to run pods on control plane nodes for any version of k8s.
+        - weight: 100
+          preference:
+            matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: DoesNotExist
+        - weight: 100
+          preference:
+            matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: DoesNotExist
 
     resources:
       requests:

--- a/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml
+++ b/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml
@@ -37,38 +37,7 @@ spec:
         {{- toYaml ._rox.central.tolerations | nindent 8 }}
       {{- end }}
       affinity:
-        nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            # Central is single-homed, so avoid preemptible nodes.
-            - weight: 100
-              preference:
-                matchExpressions:
-                  - key: cloud.google.com/gke-preemptible
-                    operator: NotIn
-                    values:
-                    - "true"
-            - weight: 50
-              preference:
-                matchExpressions:
-                  - key: node-role.kubernetes.io/infra
-                    operator: Exists
-            - weight: 25
-              preference:
-                matchExpressions:
-                  - key: node-role.kubernetes.io/compute
-                    operator: Exists
-            # From v1.20 node-role.kubernetes.io/control-plane replaces node-role.kubernetes.io/master (removed in
-            # v1.25). We apply both because our goal is not to run pods on control plane nodes for any version of k8s.
-            - weight: 100
-              preference:
-                matchExpressions:
-                  - key: node-role.kubernetes.io/master
-                    operator: DoesNotExist
-            - weight: 100
-              preference:
-                matchExpressions:
-                  - key: node-role.kubernetes.io/control-plane
-                    operator: DoesNotExist
+        {{- toYaml ._rox.central.affinity | nindent 8 }}
       serviceAccountName: central
       securityContext:
         fsGroup: 4000

--- a/image/templates/helm/stackrox-central/values-public.yaml.example.htpl
+++ b/image/templates/helm/stackrox-central/values-public.yaml.example.htpl
@@ -133,6 +133,41 @@
 #     - effect: NoExecute
 #       key: infra
 #       value: reserved
+#   
+#   If scheduling needs specific affinities, you can specify the corresponding affinities here.
+#   affinity:
+#     nodeAffinity:
+#       preferredDuringSchedulingIgnoredDuringExecution:
+#       # Central is single-homed, so avoid preemptible nodes.
+#       - weight: 100
+#           preference:
+#           matchExpressions:
+#               - key: cloud.google.com/gke-preemptible
+#               operator: NotIn
+#               values:
+#               - "true"
+#       - weight: 50
+#           preference:
+#           matchExpressions:
+#               - key: node-role.kubernetes.io/infra
+#               operator: Exists
+#       - weight: 25
+#           preference:
+#           matchExpressions:
+#               - key: node-role.kubernetes.io/compute
+#               operator: Exists
+#       # From v1.20 node-role.kubernetes.io/control-plane replaces node-role.kubernetes.io/master (removed in
+#       # v1.25). We apply both because our goal is not to run pods on control plane nodes for any version of k8s.
+#       - weight: 100
+#           preference:
+#           matchExpressions:
+#               - key: node-role.kubernetes.io/master
+#               operator: DoesNotExist
+#       - weight: 100
+#           preference:
+#           matchExpressions:
+#               - key: node-role.kubernetes.io/control-plane
+#               operator: DoesNotExist
 #
 #   # Configures the Central image to be used. Most users will only need to configure a
 #   # custom registry (if any) at the global scope, and do not require any settings here.
@@ -319,6 +354,41 @@
 #     - effect: NoExecute
 #       key: infra
 #       value: reserved
+#
+#   If scheduling needs specific affinities, you can specify the corresponding affinities here.
+#   affinity:
+#     podAntiAffinity:
+#       preferredDuringSchedulingIgnoredDuringExecution:
+#       - weight: 100
+#         podAffinityTerm:
+#           labelSelector:
+#             matchLabels:
+#               app: scanner
+#           topologyKey: kubernetes.io/hostname
+#     nodeAffinity:
+#       preferredDuringSchedulingIgnoredDuringExecution:
+#       - weight: 50
+#         preference:
+#           matchExpressions:
+#             - key: node-role.kubernetes.io/infra
+#               operator: Exists
+#       - weight: 25
+#         preference:
+#           matchExpressions:
+#             - key: node-role.kubernetes.io/compute
+#               operator: Exists
+#       # From v1.20 node-role.kubernetes.io/control-plane replaces node-role.kubernetes.io/master (removed in
+#       # v1.25). We apply both because our goal is not to run pods on control plane nodes for any version of k8s.
+#       - weight: 100
+#         preference:
+#           matchExpressions:
+#             - key: node-role.kubernetes.io/master
+#               operator: DoesNotExist
+#       - weight: 100
+#         preference:
+#           matchExpressions:
+#             - key: node-role.kubernetes.io/control-plane
+#               operator: DoesNotExist
 #
 #   # If you want to enforce StackRox Scanner DB to only run on certain nodes, you can specify
 #   # a node selector here to make sure Scanner DB can only be scheduled on Nodes with the

--- a/image/templates/helm/stackrox-secured-cluster/internal/config-shape.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/internal/config-shape.yaml
@@ -65,6 +65,7 @@ ca:
 sensor:
   imagePullPolicy: null # string
   endpoint: null # string
+  affinity: null # dict
   resources: null # string | dict
   serviceTLS:
     cert: null # string
@@ -89,6 +90,7 @@ admissionControl:
     enforceOnUpdates: null # bool
   imagePullPolicy: null # string
   replicas: null # int
+  affinity: null # dict
   resources: null # string | dict
   serviceTLS:
     cert: null # string
@@ -101,6 +103,7 @@ collector:
   disableTaintTolerations: null # bool
   slimMode: null # bool
   imagePullPolicy: null # string
+  tolerations: null # [dict]
   resources: null # string | dict
   complianceImagePullPolicy: null # string
   complianceResources: null # string | dict

--- a/image/templates/helm/stackrox-secured-cluster/internal/defaults/30-base-config.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/internal/defaults/30-base-config.yaml.htpl
@@ -31,6 +31,39 @@ sensor:
   endpoint: "sensor.{{ required "unknown namespace" ._rox._namespace }}.svc:443"
   localImageScanning:
     enabled: false
+  affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        # Sensor is single-homed, so avoid preemptible nodes.
+        - weight: 100
+          preference:
+            matchExpressions:
+              - key: cloud.google.com/gke-preemptible
+                operator: NotIn
+                values:
+                - "true"
+        - weight: 50
+          preference:
+            matchExpressions:
+            - key: node-role.kubernetes.io/infra
+              operator: Exists
+        - weight: 25
+          preference:
+            matchExpressions:
+            - key: node-role.kubernetes.io/compute
+              operator: Exists
+        # From v1.20 node-role.kubernetes.io/control-plane replaces node-role.kubernetes.io/master (removed in
+        # v1.25). We apply both because our goal is not to run pods on control plane nodes for any version of k8s.
+        - weight: 100
+          preference:
+            matchExpressions:
+            - key: node-role.kubernetes.io/master
+              operator: DoesNotExist
+        - weight: 100
+          preference:
+            matchExpressions:
+            - key: node-role.kubernetes.io/control-plane
+              operator: DoesNotExist
 
 admissionControl:
   listenOnCreates: false
@@ -43,11 +76,38 @@ admissionControl:
     timeout: 20
     enforceOnUpdates: false
   replicas: 3
+  
+  affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        # node-role.kubernetes.io/master is replaced by node-role.kubernetes.io/control-plane from certain version
+        # of k8s. We apply both to be compatible with any k8s version.
+        - weight: 50
+          preference:
+            matchExpressions:
+            - key: node-role.kubernetes.io/master
+              operator: Exists
+        - weight: 50
+          preference:
+            matchExpressions:
+            - key: node-role.kubernetes.io/control-plane
+              operator: Exists
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 60
+          podAffinityTerm:
+            namespaces: ["stackrox"]
+            topologyKey: "kubernetes.io/hostname"
+            labelSelector:
+              matchLabels:
+                app: admission-control
 
 collector:
   collectionMethod: "EBPF"
   disableTaintTolerations: false
   nodescanningEndpoint: "127.0.0.1:8444"
+  tolerations:
+  - operator: "Exists"
 
 auditLogs:
   disableCollection: {{ ne ._rox.env.openshift 4 }}

--- a/image/templates/helm/stackrox-secured-cluster/templates/admission-controller.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/admission-controller.yaml
@@ -33,29 +33,7 @@ spec:
         {{- toYaml ._rox.admissionControl.tolerations | nindent 8 }}
       {{- end }}
       affinity:
-        nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            # node-role.kubernetes.io/master is replaced by node-role.kubernetes.io/control-plane from certain version
-            # of k8s. We apply both to be compatible with any k8s version.
-            - weight: 50
-              preference:
-                matchExpressions:
-                  - key: node-role.kubernetes.io/master
-                    operator: Exists
-            - weight: 50
-              preference:
-                matchExpressions:
-                  - key: node-role.kubernetes.io/control-plane
-                    operator: Exists
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 60
-              podAffinityTerm:
-                namespaces: ["stackrox"]
-                topologyKey: "kubernetes.io/hostname"
-                labelSelector:
-                  matchLabels:
-                    app: admission-control
+        {{- toYaml ._rox.admissionControl.affinity | nindent 8 }}
       {{- if ._rox.admissionControl._nodeSelector }}
       nodeSelector:
         {{- ._rox.admissionControl._nodeSelector | nindent 8 }}

--- a/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       {{- if not ._rox.collector.disableTaintTolerations }}
       tolerations:
-      - operator: "Exists"
+      {{- toYaml ._rox.collector.tolerations | nindent 6 }}
       {{- end }}
       {{- if ._rox.collector._nodeSelector }}
       nodeSelector:

--- a/image/templates/helm/stackrox-secured-cluster/templates/sensor.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/sensor.yaml.htpl
@@ -37,38 +37,7 @@ spec:
         {{- toYaml ._rox.sensor.tolerations | nindent 8 }}
       {{- end }}
       affinity:
-        nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            # Sensor is single-homed, so avoid preemptible nodes.
-            - weight: 100
-              preference:
-                matchExpressions:
-                  - key: cloud.google.com/gke-preemptible
-                    operator: NotIn
-                    values:
-                    - "true"
-            - weight: 50
-              preference:
-                matchExpressions:
-                - key: node-role.kubernetes.io/infra
-                  operator: Exists
-            - weight: 25
-              preference:
-                matchExpressions:
-                  - key: node-role.kubernetes.io/compute
-                    operator: Exists
-            # From v1.20 node-role.kubernetes.io/control-plane replaces node-role.kubernetes.io/master (removed in
-            # v1.25). We apply both because our goal is not to run pods on control plane nodes for any version of k8s.
-            - weight: 100
-              preference:
-                matchExpressions:
-                  - key: node-role.kubernetes.io/master
-                    operator: DoesNotExist
-            - weight: 100
-              preference:
-                matchExpressions:
-                  - key: node-role.kubernetes.io/control-plane
-                    operator: DoesNotExist
+      {{- toYaml ._rox.sensor.affinity | nindent 8 }}
       {{- if not ._rox.env.openshift }}
       securityContext:
         runAsUser: 4000

--- a/image/templates/helm/stackrox-secured-cluster/values-public.yaml.example
+++ b/image/templates/helm/stackrox-secured-cluster/values-public.yaml.example
@@ -148,6 +148,41 @@
 #      key: infra
 #      value: reserved
 #
+#   If scheduling needs specific affinities, you can specify the corresponding affinities here.
+#   affinity:
+#     nodeAffinity:
+#       preferredDuringSchedulingIgnoredDuringExecution:
+#         # Sensor is single-homed, so avoid preemptible nodes.
+#         - weight: 100
+#           preference:
+#             matchExpressions:
+#               - key: cloud.google.com/gke-preemptible
+#                 operator: NotIn
+#                 values:
+#                 - "true"
+#         - weight: 50
+#           preference:
+#             matchExpressions:
+#             - key: node-role.kubernetes.io/infra
+#               operator: Exists
+#         - weight: 25
+#           preference:
+#             matchExpressions:
+#             - key: node-role.kubernetes.io/compute
+#               operator: Exists
+#         # From v1.20 node-role.kubernetes.io/control-plane replaces node-role.kubernetes.io/master (removed in
+#         # v1.25). We apply both because our goal is not to run pods on control plane nodes for any version of k8s.
+#         - weight: 100
+#           preference:
+#             matchExpressions:
+#             - key: node-role.kubernetes.io/master
+#               operator: DoesNotExist
+#         - weight: 100
+#           preference:
+#             matchExpressions:
+#             - key: node-role.kubernetes.io/control-plane
+#               operator: DoesNotExist
+#
 #  # Address of the Sensor endpoint including port number. No trailing slash.
 #  # Rarely needs to be changed.
 #  endpoint: sensor.stackrox.svc:443
@@ -183,6 +218,32 @@
 #    - effect: NoExecute
 #      key: infra
 #      value: reserved
+#
+#   If scheduling needs specific affinities, you can specify the corresponding affinities here.
+#   affinity:
+#     nodeAffinity:
+#       preferredDuringSchedulingIgnoredDuringExecution:
+#         # node-role.kubernetes.io/master is replaced by node-role.kubernetes.io/control-plane from certain version
+#         # of k8s. We apply both to be compatible with any k8s version.
+#         - weight: 50
+#           preference:
+#             matchExpressions:
+#             - key: node-role.kubernetes.io/master
+#               operator: Exists
+#         - weight: 50
+#           preference:
+#             matchExpressions:
+#             - key: node-role.kubernetes.io/control-plane
+#               operator: Exists
+#     podAntiAffinity:
+#       preferredDuringSchedulingIgnoredDuringExecution:
+#         - weight: 60
+#           podAffinityTerm:
+#             namespaces: ["stackrox"]
+#             topologyKey: "kubernetes.io/hostname"
+#             labelSelector:
+#               matchLabels:
+#                 app: admission-control
 #
 #  # Dynamic part of the configuration which is retrieved from Central and can be modified through
 #  # the frontend.
@@ -264,6 +325,10 @@
 #    limits:
 #      memory: "1Gi"
 #      cpu: "750m"
+#
+#   If the nodes selected by the node selector are tainted, you can specify the corresponding taint tolerations here.
+#   tolerations:
+#     - operator: "Exists"
 #
 #  complianceImagePullPolicy: IfNotPresent
 #

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/central.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/central.test.yaml
@@ -114,3 +114,17 @@ tests:
     env.managedServices: false
   expect: |
     envVars(.deployments.central; "central") | assertThat(has("ROX_TENANT_ID") == false)
+
+- name: "override affinity"
+  values:
+    central:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 50
+              preference:
+                matchExpressions:
+                  - key: node-role.kubernetes.io/master
+                    operator: Exists
+  expect: |
+    .deployments["central"].spec.template.spec.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution | assertThat(length == 1)

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/scanner.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/scanner.test.yaml
@@ -70,8 +70,17 @@ tests:
       autoscaling:
         minReplicas: 50
         maxReplicas: 100
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 50
+              preference:
+                matchExpressions:
+                  - key: node-role.kubernetes.io/master
+                    operator: Exists
   expect: |
     .deployments["scanner"].spec.replicas | assertThat(. == 5)
+    .deployments["scanner"].spec.template.spec.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution | assertThat(length == 1)
     .horizontalpodautoscalers["scanner"].spec.minReplicas | assertThat(. == 50)
     .horizontalpodautoscalers["scanner"].spec.maxReplicas | assertThat(. == 100)
 

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/admission-control.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/admission-control.test.yaml
@@ -81,3 +81,47 @@ tests:
           replicas: 50
       expect: |
         .deployments["admission-control"].spec.replicas | assertThat(. == 50)
+
+- name: "Admission Controller affinity"
+  tests:
+    - name: "default affinity"
+      expect: |
+        .deployments["admission-control"].spec.template.spec.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution | assertThat(length == 2)
+        .deployments["admission-control"].spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution | assertThat(length == 1)
+    - name: "override node affinity"
+      values:
+        admissionControl:
+          affinity:
+            nodeAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+                - weight: 50
+                  preference:
+                    matchExpressions:
+                      - key: node-role.kubernetes.io/master
+                        operator: Exists
+      expect: |
+        .deployments["admission-control"].spec.template.spec.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution | assertThat(length == 1)
+        .deployments["admission-control"].spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution | assertThat(length == 1)
+    - name: "override antiAffinity"
+      values:
+        admissionControl:
+          affinity:
+            podAntiAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 10
+                podAffinityTerm:
+                  namespaces: ["stackrox"]
+                  topologyKey: "kubernetes.io/hostname"
+                  labelSelector:
+                    matchLabels:
+                      app: admission-control
+              - weight: 10
+                podAffinityTerm:
+                  namespaces: ["stackrox"]
+                  topologyKey: "kubernetes.io/hostname"
+                  labelSelector:
+                    matchLabels:
+                      app: admission-control-other
+      expect: |
+        .deployments["admission-control"].spec.template.spec.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution | assertThat(length == 2)
+        .deployments["admission-control"].spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution | assertThat(length == 2)

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/sensor.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/sensor.test.yaml
@@ -1,0 +1,19 @@
+tests:
+  - name: "Sensor affinity"
+    tests:
+      - name: "default affinity"
+        expect: |
+          .deployments["sensor"].spec.template.spec.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution | assertThat(length == 5)
+      - name: "override node affinity"
+        values:
+          sensor:
+            affinity:
+              nodeAffinity:
+                preferredDuringSchedulingIgnoredDuringExecution:
+                  - weight: 50
+                    preference:
+                      matchExpressions:
+                        - key: node-role.kubernetes.io/master
+                          operator: Exists
+        expect: |
+          .deployments["sensor"].spec.template.spec.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution | assertThat(length == 1)

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/tolerations.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/tolerations.test.yaml
@@ -3,6 +3,7 @@ tests:
   expect: |
     .deployments.sensor.spec.template.spec.tolerations | assertThat(. == null)
     .deployments["admission-control"].spec.template.spec.tolerations | assertThat(. == null)
+    .daemonsets["collector"].spec.template.spec.tolerations | assertThat(length == 1)
 
 - name: "with empty string settings"
   values:
@@ -15,6 +16,7 @@ tests:
   expect: |
     .deployments.sensor.spec.template.spec.tolerations | assertThat(. == null)
     .deployments["admission-control"].spec.template.spec.tolerations | assertThat(. == null)
+    .daemonsets["collector"].spec.template.spec.tolerations | assertThat(length == 1)
 
 - name: "with empty dict settings"
   values:
@@ -27,11 +29,13 @@ tests:
   expect: |
     .deployments.sensor.spec.template.spec.tolerations | assertThat(length == 0)
     .deployments["admission-control"].spec.template.spec.tolerations | assertThat(length == 0)
+    .daemonsets["collector"].spec.template.spec.tolerations | assertThat(length == 1)
 
 - name: "with populated settings"
   expect: |
     .deployments.sensor.spec.template.spec.tolerations | assertThat(length == 2)
     .deployments["admission-control"].spec.template.spec.tolerations | assertThat(length == 2)
+    .daemonsets["collector"].spec.template.spec.tolerations | assertThat(length == 2)
 
   tests:
   - name: "via dictionary"
@@ -43,6 +47,12 @@ tests:
           - key: "node-role.kubernetes.io/master"
             operator: "Exists"
       admissionControl:
+        tolerations:
+          - key: "node-role.kubernetes.io/infra"
+            operator: "Exists"
+          - key: "node-role.kubernetes.io/master"
+            operator: "Exists"
+      collector:
         tolerations:
           - key: "node-role.kubernetes.io/infra"
             operator: "Exists"


### PR DESCRIPTION
## Description

This merge requests adds support for changing affinities 
Current values were defined as default values for all components.

Feel free to remove this section if it is overkill for your PR, and the title of your PR is sufficiently descriptive.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Central services:

```
$ cd pkg/helm/charts/tests/centralservices
$ go test
PASS
ok      github.com/stackrox/rox/pkg/helm/charts/tests/centralservices   29.403s
```

Secured cluster:

```
$ cd pkg/helm/charts/tests/securedclusterservices
$ go test -v
PASS
ok      github.com/stackrox/rox/pkg/helm/charts/tests/securedclusterservices    5.837s
```
