### PR TITLE
ROX-17125: Remove splunk TA test from BAT

### DIFF
--- a/qa-tests-backend/src/test/groovy/DeclarativeConfigTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DeclarativeConfigTest.groovy
@@ -46,9 +46,9 @@ class DeclarativeConfigTest extends BaseSpecification {
 
     static final private int CREATED_RESOURCES = 7
 
-    static final private int RETRIES = 450
+    static final private int RETRIES = 45
     static final private int DELETION_RETRIES = 60
-    static final private int PAUSE_SECS = 1
+    static final private int PAUSE_SECS = 10
 
     // Values used within testing for permission sets.
     // These include:

--- a/qa-tests-backend/src/test/groovy/DeclarativeConfigTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DeclarativeConfigTest.groovy
@@ -46,9 +46,9 @@ class DeclarativeConfigTest extends BaseSpecification {
 
     static final private int CREATED_RESOURCES = 7
 
-    static final private int RETRIES = 45
+    static final private int RETRIES = 450
     static final private int DELETION_RETRIES = 60
-    static final private int PAUSE_SECS = 10
+    static final private int PAUSE_SECS = 1
 
     // Values used within testing for permission sets.
     // These include:

--- a/qa-tests-backend/src/test/groovy/IntegrationsSplunkViolationsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/IntegrationsSplunkViolationsTest.groovy
@@ -104,7 +104,6 @@ class IntegrationsSplunkViolationsTest extends BaseSpecification {
     }
 
     @Tag("Integration")
-    @Tag("BAT")
     def "Verify Splunk violations: StackRox violations reach Splunk TA"() {
         given:
         "Splunk TA is installed and configured, network and process violations triggered"


### PR DESCRIPTION
## Description

Per title. This test was added to BAT (probably inadvertently) by #2096 and can be scaled back to only run on demand and merge, etc.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

n/a