### PR TITLE
fix(ui): Delete occurrences of Tailwind uppercase part 5

### DIFF
--- a/ui/apps/platform/src/Components/CustomDialogue/CustomDialogue.js
+++ b/ui/apps/platform/src/Components/CustomDialogue/CustomDialogue.js
@@ -25,7 +25,7 @@ const CustomDialogue = (props) => {
             className={`ignore-react-onclickoutside ${props.className}`}
         >
             {props.title && (
-                <div className="flex items-center w-full p-3 bg-primary-700 text-xl text-base-100 uppercase">
+                <div className="flex items-center w-full p-3 border-b border-base-300 font-700 text-xl">
                     <div className="flex flex-1">{props.title}</div>
                     <Icon.X className="ml-6 h-4 w-4 cursor-pointer" onClick={props.onCancel} />
                 </div>

--- a/ui/apps/platform/src/Components/ExportButton.js
+++ b/ui/apps/platform/src/Components/ExportButton.js
@@ -132,11 +132,11 @@ class ExportButton extends Component {
         const fileName = addBrandedTimestampToString(headerText);
 
         return (
-            <div className="absolute right-0 z-20 uppercase flex flex-col text-base-600 min-w-64">
+            <div className="absolute right-0 z-20 flex flex-col text-base-600 min-w-64">
                 <div className="arrow-up self-end mr-5" />
                 <ul className=" bg-base-100 border-2 border-primary-600 rounded">
                     <li className="p-4 border-b border-base-400">
-                        <div className="flex uppercase">
+                        <div className="flex">
                             <WorkflowPDFExportButton
                                 id={this.props.pdfId}
                                 className={`${btnClassName}  ${

--- a/ui/apps/platform/src/Components/FormFieldRemoveButton.js
+++ b/ui/apps/platform/src/Components/FormFieldRemoveButton.js
@@ -31,7 +31,7 @@ FormFieldRemoveButton.defaultProps = {
     field: null,
     dataTestId: 'form-field-remove-btn',
     className:
-        'ml-2 p-1 rounded-r-sm text-base-100 uppercase text-alert-700 hover:text-alert-800 bg-alert-200 hover:bg-alert-300 border-alert-300 rounded',
+        'ml-2 p-1 rounded-r-sm text-base-100 text-alert-700 hover:text-alert-800 bg-alert-200 hover:bg-alert-300 border-alert-300 rounded',
 };
 
 export default FormFieldRemoveButton;

--- a/ui/apps/platform/src/Components/ResourceCountPopper/ResourceCountPopper.js
+++ b/ui/apps/platform/src/Components/ResourceCountPopper/ResourceCountPopper.js
@@ -26,7 +26,7 @@ const ResourceCountPopper = ({ data, label, renderContent, reactOutsideClassName
             disabled={!length}
             placement="bottom"
             reactOutsideClassName={reactOutsideClassName}
-            buttonClass={`uppercase w-full rounded border border-base-400 bg-base-100 p-1 px-2 text-left text-xs ${
+            buttonClass={`w-full rounded border border-base-400 bg-base-100 p-1 px-2 text-left text-sm ${
                 length && 'hover:bg-base-200'
             }`}
             buttonContent={buttonContent}


### PR DESCRIPTION
## Description

### Problems

1. PatternFly guidelines do not even mention uppercase.
2. Extra width of uppercase is a blocker to increase classic normal font size from 12px to 14px, especially for same size as PatternFly in tables and key-value lists.

### Analysis and Solution

Find in Files `uppercase` decreased from 23 results in 17 files to 18 results in 13 files.

Replace uppercase with mixed case.

1. src/Components/ExportButton.js 2 occurrences of `uppercase` are redundant because other style rules override for `button` element.

2. src/Components/FormFieldRemoveButton.js will soon become obsolete because only use in classic Network Graph and it overrides the default prop value.

3. src/Components/CustomDialogue/CustomDialogue.js: In header, replace uppercase white on blue with mixed case black on white with bold font weight.
    * src/Containers/Network/SidePanel/NetworkDeploymentOverlay/Flows/NetworkBaselines/NetworkBaselinesTable/ToggleSelectedBaselineStatuses/ToggleSelectedBaselineStatuses.tsx
    * src/Containers/VulnMgmt/List/Cves/CveBulkActionDialogue.js
    * src/Containers/VulnMgmt/List/Images/WatchedImagesDialog.tsx

4. src/Components/ResourceCountPopper/ResourceCountPopper.js
    * src/Components/Metadata/Metadata.js

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

### Manual testing

1. ExportButton

    * Visit /main/vulnerability-management/image-cves, select rows, and then click **Export**.
        ![ExportButton_image-cves](https://github.com/stackrox/stackrox/assets/11862657/52126add-91fd-4f76-8e90-4a1329283613)

2. FormFieldRemoveButton

    * Visit /main/network, select **stackrox** namespace, click **CIDR Blocks** 
        ![FormFieldRemoveButton_network](https://github.com/stackrox/stackrox/assets/11862657/ff5f3f74-3057-4038-8c7e-2aa8edf6f54b)

3. CustomDialogue

    * Visit /main/network, select **stackrox** namespace, click a deployment, click a checkbox under Baseline Flows, and then click **Mark as Anomalous**.
        ![CustomDialogue_network](https://github.com/stackrox/stackrox/assets/11862657/53b632f7-1d74-4deb-b36d-599add99b6d1)

    * Visit /main/vulnerability-management/image-cves, select rows, and then click **Add Selected CVEs to Policy**.
        ![CustomDialogue_image-cves](https://github.com/stackrox/stackrox/assets/11862657/e8379af7-ff37-4bf1-8de5-2d34ad08c2a4)

    * Visit /main/vulnerability-management/images, and then click **Manage Scanning of Watched Images**.
        ![CustomDialogue_images](https://github.com/stackrox/stackrox/assets/11862657/22b837ea-1e7f-42fe-885d-7b30ab878c43)

4. ResouceCountPopper

    * Visit /main/vulnerability-management/namespaces, and then click a row: see mixed case for number of labels.
        ![ResouceCountPopper_namespaces](https://github.com/stackrox/stackrox/assets/11862657/de445a5a-becd-45df-bb52-8dd951ad5d94)
