### PR TITLE
feat(ui): Add external link icon to workload cve distro links

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePageHeader.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePageHeader.tsx
@@ -10,6 +10,7 @@ import {
     List,
     ListItem,
 } from '@patternfly/react-core';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import uniqBy from 'lodash/uniqBy';
 import { getDateTime } from 'utils/dateUtils';
 import { ensureExhaustive } from 'utils/type.utils';
@@ -91,6 +92,7 @@ function ImageCvePageHeader({ data }: ImageCvePageHeaderProps) {
                                     rel="noopener noreferrer"
                                 >
                                     {getDistroLinkText(distro)}
+                                    <ExternalLinkAltIcon className="pf-u-display-inline pf-u-ml-sm" />
                                 </a>
                             </ListItem>
                         ))}


### PR DESCRIPTION
## Description

Realized from discussions yesterday during planning that links to vendor CVE databases from the Workload CVE page should have an external link icon to let the user know they are being taken to an external site. Making the PR was faster than making a Jira ticket.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Visit any CVE page in the Workload CVE section. All external links in the header should have the PatternFly external link icon.
![image](https://github.com/stackrox/stackrox/assets/1292638/62d0196d-4419-49b2-8872-04864d0eefac)

