### PR TITLE
ROX-17673: Remove pre and post tests from sensor-integration target

### DIFF
--- a/.openshift-ci/pre_tests.py
+++ b/.openshift-ci/pre_tests.py
@@ -16,6 +16,9 @@ class PreSystemTests:
     cluster from which to get information.
     """
 
+    def __init__(self, run_poll_for_system_test_images=True):
+        self.run_poll_for_system_test_images = run_poll_for_system_test_images
+
     VERSIONS_TIMEOUT = 10 * 60
     POLL_TIMEOUT = 60 * 60
 
@@ -28,13 +31,13 @@ class PreSystemTests:
             check=False,
             timeout=PreSystemTests.VERSIONS_TIMEOUT,
         )
-
-        subprocess.run(
-            [
-                "scripts/ci/lib.sh",
-                "poll_for_system_test_images",
-                str(PreSystemTests.POLL_TIMEOUT),
-            ],
-            check=True,
-            timeout=PreSystemTests.POLL_TIMEOUT * 1.2,
-        )
+        if self.run_poll_for_system_test_images:
+            subprocess.run(
+                [
+                    "scripts/ci/lib.sh",
+                    "poll_for_system_test_images",
+                    str(PreSystemTests.POLL_TIMEOUT),
+                ],
+                check=True,
+                timeout=PreSystemTests.POLL_TIMEOUT * 1.2,
+            )

--- a/scripts/ci/jobs/gke_sensor_integration_tests.py
+++ b/scripts/ci/jobs/gke_sensor_integration_tests.py
@@ -14,6 +14,7 @@ from post_tests import PostClusterTest, FinalPost
 os.environ["ORCHESTRATOR_FLAVOR"] = "k8s"
 
 ClusterTestRunner(
+    pre_test=PreSystemTests(),
     cluster=GKECluster("sensor-integration-test"),
     test=SensorIntegration(),
 ).run()

--- a/scripts/ci/jobs/gke_sensor_integration_tests.py
+++ b/scripts/ci/jobs/gke_sensor_integration_tests.py
@@ -16,12 +16,5 @@ os.environ["ORCHESTRATOR_FLAVOR"] = "k8s"
 ClusterTestRunner(
     cluster=GKECluster("sensor-integration-test"),
     test=SensorIntegration(),
-    post_test=PostClusterTest(
-        check_stackrox_logs=False,
-    ),
-    final_post=FinalPost(
-        store_qa_test_debug_logs=False,
-        store_qa_spock_results=False,
-    ),
 ).run()
 

--- a/scripts/ci/jobs/gke_sensor_integration_tests.py
+++ b/scripts/ci/jobs/gke_sensor_integration_tests.py
@@ -8,14 +8,12 @@ from runners import ClusterTestRunner
 from clusters import GKECluster
 from pre_tests import PreSystemTests
 from ci_tests import SensorIntegration
-from post_tests import PostClusterTest, FinalPost
 
 # set required test parameters
 os.environ["ORCHESTRATOR_FLAVOR"] = "k8s"
 
 ClusterTestRunner(
-    pre_test=PreSystemTests(),
+    pre_test=PreSystemTests(run_poll_for_system_test_images=False),
     cluster=GKECluster("sensor-integration-test"),
     test=SensorIntegration(),
 ).run()
-

--- a/scripts/ci/jobs/ocp_sensor_integration_tests.py
+++ b/scripts/ci/jobs/ocp_sensor_integration_tests.py
@@ -1,13 +1,12 @@
 #!/usr/bin/env -S python3 -u
 
 """
-Run tests/e2e in a GKE cluster
+Run tests/e2e in a OCP cluster
 """
 import os
 from runners import ClusterTestRunner
 from pre_tests import PreSystemTests
 from ci_tests import SensorIntegration
-from post_tests import PostClusterTest, FinalPost
 
 # set required test parameters
 os.environ["ORCHESTRATOR_FLAVOR"] = "openshift"
@@ -15,5 +14,6 @@ os.environ["ROX_POSTGRES_DATASTORE"] = "true"
 os.environ["ROX_ACTIVE_VULN_MGMT"] = "true"
 
 ClusterTestRunner(
+    pre_test=PreSystemTests(run_poll_for_system_test_images=False),
     test=SensorIntegration(),
 ).run()

--- a/scripts/ci/jobs/ocp_sensor_integration_tests.py
+++ b/scripts/ci/jobs/ocp_sensor_integration_tests.py
@@ -15,11 +15,5 @@ os.environ["ROX_POSTGRES_DATASTORE"] = "true"
 os.environ["ROX_ACTIVE_VULN_MGMT"] = "true"
 
 ClusterTestRunner(
-    pre_test=PreSystemTests(),
     test=SensorIntegration(),
-    post_test=PostClusterTest(collect_central_artifacts=False),
-    final_post=FinalPost(
-        store_qa_test_debug_logs=False,
-        store_qa_spock_results=False,
-    ),
 ).run()


### PR DESCRIPTION
## Description

Extracted from https://github.com/stackrox/stackrox/pull/6416/ to make the empty/dummy sensor-integration tests pass.
The pre and post tests assume that Stackrox was deployed to the cluster, but the `sensor-integration` tests do not need ACS installation to run. Thus, the CI was failing as it expected particular namespaces to exist.

Required for the rehearsals in https://github.com/openshift/release/pull/40290 to pass.

## Checklist
- [ ] Investigated and inspected CI test results


### N/A
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

- CI