### PR TITLE
ROX-16766: Disable IAM Role when necessary

### DIFF
--- a/ui/apps/platform/cypress/integration/integrations/externalBackups.test.js
+++ b/ui/apps/platform/cypress/integration/integrations/externalBackups.test.js
@@ -11,6 +11,8 @@ import {
     saveCreatedIntegrationInForm,
     testIntegrationInFormWithStoredCredentials,
     visitIntegrationsTable,
+    visitIntegrationsWithStaticResponseForCapabilities,
+    visitIntegrationsAndVerifyRedirectWithStaticResponseForCapabilities,
 } from './integrations.helpers';
 import { selectors } from './integrations.selectors';
 
@@ -146,6 +148,33 @@ describe('Backup Integrations', () => {
             saveCreatedIntegrationInForm(integrationSource, integrationType);
 
             deleteIntegrationInTable(integrationSource, integrationType, integrationName);
+        });
+    });
+
+    describe('when cloud backup capability is disabled', () => {
+        it('should not render Image back integrations', () => {
+            visitIntegrationsWithStaticResponseForCapabilities({
+                body: { centralCanUseCloudBackupIntegrations: 'CapabilityDisabled' },
+            });
+            cy.get('h2:contains("Backup Integrations")').should('not.exist');
+            cy.get('a .pf-c-card__title:contains("Amazon S3")').should('not.exist');
+            cy.get('a .pf-c-card__title:contains("Google Cloud Storage")').should('not.exist');
+
+            visitIntegrationsAndVerifyRedirectWithStaticResponseForCapabilities(
+                {
+                    body: { centralCanUseCloudBackupIntegrations: 'CapabilityDisabled' },
+                },
+                'backups',
+                's3'
+            );
+
+            visitIntegrationsAndVerifyRedirectWithStaticResponseForCapabilities(
+                {
+                    body: { centralCanUseCloudBackupIntegrations: 'CapabilityDisabled' },
+                },
+                'backups',
+                'gcs'
+            );
         });
     });
 });

--- a/ui/apps/platform/cypress/integration/integrations/imageIntegrations.test.js
+++ b/ui/apps/platform/cypress/integration/integrations/imageIntegrations.test.js
@@ -14,6 +14,7 @@ import {
     testIntegrationInFormWithStoredCredentials,
     testIntegrationInFormWithoutStoredCredentials,
     visitIntegrationsTable,
+    visitIntegrationsWithStaticResponseForCapabilities,
 } from './integrations.helpers';
 import { selectors } from './integrations.selectors';
 
@@ -142,6 +143,7 @@ describe('Image Integrations', () => {
         getInputByLabel('Integration name').clear().type(integrationName);
         getInputByLabel('Registry ID').clear().type('12345');
         getInputByLabel('Region').clear().type('us-west-1');
+        cy.get('label:contains("Use container IAM role")').click(); // turn on Use IAM Role
 
         testIntegrationInFormWithStoredCredentials(
             integrationSource,
@@ -152,6 +154,20 @@ describe('Image Integrations', () => {
         saveCreatedIntegrationInForm(integrationSource, integrationType, staticResponseForPOST);
 
         // Test does not delete, because it did not create.
+    });
+
+    it('should not render IAM Role on ECR form, when that capability is disabled', () => {
+        visitIntegrationsWithStaticResponseForCapabilities(
+            {
+                body: { centralScanningCanUseContainerIamRoleForEcr: 'CapabilityDisabled' },
+            },
+            'imageIntegrations',
+            'ecr',
+            '',
+            'create'
+        );
+
+        cy.get('label:contains("Use container IAM role")').should('not.exist');
     });
 
     it('should create a new Google Container Registry integration', () => {

--- a/ui/apps/platform/cypress/integration/integrations/integrations.helpers.js
+++ b/ui/apps/platform/cypress/integration/integrations/integrations.helpers.js
@@ -1,7 +1,7 @@
 import { visitFromLeftNavExpandable } from '../../helpers/nav';
 import { interactAndWaitForResponses } from '../../helpers/request';
 import { getTableRowActionButtonByName } from '../../helpers/tableHelpers';
-import { visit } from '../../helpers/visit';
+import { visit, visitWithStaticResponseForCapabilities } from '../../helpers/visit';
 
 import { selectors } from './integrations.selectors';
 
@@ -246,6 +246,43 @@ export function visitIntegrationsTable(integrationSource, integrationType, stati
     );
 
     assertIntegrationsTable(integrationSource, integrationType);
+}
+
+/**
+ * Visit an integrations page with
+ * static response either body or fixture
+ * optional segments for additional path beyond integrations dashboard
+ *
+ * @param {{ body: { [key: string]: 'CapabilityAvailable' | 'CapabilityDisabled' } } | { fixture: string }} staticResponseForCapabilities
+ * @param string [integrationSource]
+ * @param string [integrationType]
+ * @param string [integrationId]
+ * @param {String('view' | 'edit' | 'create')} [integrationAction]
+ */
+export function visitIntegrationsWithStaticResponseForCapabilities(
+    staticResponseForCapabilities,
+    integrationSource,
+    integrationType,
+    integrationId,
+    integrationAction
+) {
+    visitWithStaticResponseForCapabilities(
+        getIntegrationsPath(integrationSource, integrationType, integrationId, integrationAction),
+        staticResponseForCapabilities
+    );
+}
+export function visitIntegrationsAndVerifyRedirectWithStaticResponseForCapabilities(
+    staticResponseForCapabilities,
+    integrationSource,
+    integrationType,
+    integrationId,
+    integrationAction
+) {
+    visitWithStaticResponseForCapabilities(
+        getIntegrationsPath(integrationSource, integrationType, integrationId, integrationAction),
+        staticResponseForCapabilities
+    );
+    cy.location('pathname').should('eq', basePath);
 }
 
 // interact on dashboard

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/EcrIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/EcrIntegrationForm.tsx
@@ -9,6 +9,7 @@ import FormMessage from 'Components/PatternFly/FormMessage';
 import FormTestButton from 'Components/PatternFly/FormTestButton';
 import FormSaveButton from 'Components/PatternFly/FormSaveButton';
 import FormCancelButton from 'Components/PatternFly/FormCancelButton';
+import useCentralCapabilities from 'hooks/useCentralCapabilities';
 import useIntegrationForm from '../useIntegrationForm';
 import { IntegrationFormProps } from '../integrationFormTypes';
 
@@ -117,7 +118,7 @@ export const defaultValues: EcrIntegrationFormValues = {
             registryId: '',
             endpoint: '',
             region: '',
-            useIam: true,
+            useIam: false,
             accessKeyId: '',
             secretAccessKey: '',
             useAssumeRole: false,
@@ -138,6 +139,12 @@ function EcrIntegrationForm({
     isEditable = false,
 }: IntegrationFormProps<EcrIntegration>): ReactElement {
     const formInitialValues = { ...defaultValues, ...initialValues };
+
+    const { isCentralCapabilityAvailable } = useCentralCapabilities();
+    const canUseContainerIamRoleForEcr = isCentralCapabilityAvailable(
+        'centralScanningCanUseContainerIamRoleForEcr'
+    );
+
     if (initialValues) {
         formInitialValues.config = { ...formInitialValues.config, ...initialValues };
         // We want to clear the password because backend returns '******' to represent that there
@@ -268,17 +275,23 @@ function EcrIntegrationForm({
                             />
                         </FormLabelGroup>
                     )}
-                    <FormLabelGroup fieldId="config.ecr.useIam" touched={touched} errors={errors}>
-                        <Checkbox
-                            label="Use container IAM role"
-                            id="config.ecr.useIam"
-                            aria-label="use container iam role"
-                            isChecked={values.config.ecr.useIam}
-                            onChange={onChange}
-                            onBlur={handleBlur}
-                            isDisabled={!isEditable}
-                        />
-                    </FormLabelGroup>
+                    {canUseContainerIamRoleForEcr && (
+                        <FormLabelGroup
+                            fieldId="config.ecr.useIam"
+                            touched={touched}
+                            errors={errors}
+                        >
+                            <Checkbox
+                                label="Use container IAM role"
+                                id="config.ecr.useIam"
+                                aria-label="use container iam role"
+                                isChecked={values.config.ecr.useIam}
+                                onChange={onChange}
+                                onBlur={handleBlur}
+                                isDisabled={!isEditable}
+                            />
+                        </FormLabelGroup>
+                    )}
                     {!values.config.ecr.useIam && (
                         <>
                             <FormLabelGroup

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/S3IntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/S3IntegrationForm.tsx
@@ -10,7 +10,6 @@ import FormMessage from 'Components/PatternFly/FormMessage';
 import FormCancelButton from 'Components/PatternFly/FormCancelButton';
 import FormTestButton from 'Components/PatternFly/FormTestButton';
 import FormSaveButton from 'Components/PatternFly/FormSaveButton';
-import useCentralCapabilities from 'hooks/useCentralCapabilities';
 import useIntegrationForm from '../useIntegrationForm';
 import { IntegrationFormProps } from '../integrationFormTypes';
 
@@ -121,11 +120,6 @@ function S3IntegrationForm({
     isEditable = false,
 }: IntegrationFormProps<S3Integration>): ReactElement {
     const formInitialValues = { ...defaultValues, ...initialValues };
-
-    const { isCentralCapabilityAvailable } = useCentralCapabilities();
-    const canUseCloudBackupIntegrations = isCentralCapabilityAvailable(
-        'centralCanUseCloudBackupIntegrations'
-    );
 
     if (initialValues) {
         formInitialValues.externalBackup = {
@@ -335,23 +329,21 @@ function S3IntegrationForm({
                             isDisabled={!isEditable}
                         />
                     </FormLabelGroup>
-                    {canUseCloudBackupIntegrations && (
-                        <FormLabelGroup
-                            label=""
-                            fieldId="externalBackup.s3.useIam"
-                            touched={touched}
-                            errors={errors}
-                        >
-                            <Checkbox
-                                label="Use container IAM role"
-                                id="externalBackup.s3.useIam"
-                                isChecked={values.externalBackup.s3.useIam}
-                                onChange={updateKeysOnChange}
-                                onBlur={handleBlur}
-                                isDisabled={!isEditable}
-                            />
-                        </FormLabelGroup>
-                    )}
+                    <FormLabelGroup
+                        label=""
+                        fieldId="externalBackup.s3.useIam"
+                        touched={touched}
+                        errors={errors}
+                    >
+                        <Checkbox
+                            label="Use container IAM role"
+                            id="externalBackup.s3.useIam"
+                            isChecked={values.externalBackup.s3.useIam}
+                            onChange={updateKeysOnChange}
+                            onBlur={handleBlur}
+                            isDisabled={!isEditable}
+                        />
+                    </FormLabelGroup>
                     {!isCreating && isEditable && (
                         <FormLabelGroup
                             label=""

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/S3IntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/S3IntegrationForm.tsx
@@ -10,6 +10,7 @@ import FormMessage from 'Components/PatternFly/FormMessage';
 import FormCancelButton from 'Components/PatternFly/FormCancelButton';
 import FormTestButton from 'Components/PatternFly/FormTestButton';
 import FormSaveButton from 'Components/PatternFly/FormSaveButton';
+import useCentralCapabilities from 'hooks/useCentralCapabilities';
 import useIntegrationForm from '../useIntegrationForm';
 import { IntegrationFormProps } from '../integrationFormTypes';
 
@@ -120,6 +121,12 @@ function S3IntegrationForm({
     isEditable = false,
 }: IntegrationFormProps<S3Integration>): ReactElement {
     const formInitialValues = { ...defaultValues, ...initialValues };
+
+    const { isCentralCapabilityAvailable } = useCentralCapabilities();
+    const canUseCloudBackupIntegrations = isCentralCapabilityAvailable(
+        'centralCanUseCloudBackupIntegrations'
+    );
+
     if (initialValues) {
         formInitialValues.externalBackup = {
             ...formInitialValues.externalBackup,
@@ -328,21 +335,23 @@ function S3IntegrationForm({
                             isDisabled={!isEditable}
                         />
                     </FormLabelGroup>
-                    <FormLabelGroup
-                        label=""
-                        fieldId="externalBackup.s3.useIam"
-                        touched={touched}
-                        errors={errors}
-                    >
-                        <Checkbox
-                            label="Use container IAM role"
-                            id="externalBackup.s3.useIam"
-                            isChecked={values.externalBackup.s3.useIam}
-                            onChange={updateKeysOnChange}
-                            onBlur={handleBlur}
-                            isDisabled={!isEditable}
-                        />
-                    </FormLabelGroup>
+                    {canUseCloudBackupIntegrations && (
+                        <FormLabelGroup
+                            label=""
+                            fieldId="externalBackup.s3.useIam"
+                            touched={touched}
+                            errors={errors}
+                        >
+                            <Checkbox
+                                label="Use container IAM role"
+                                id="externalBackup.s3.useIam"
+                                isChecked={values.externalBackup.s3.useIam}
+                                onChange={updateKeysOnChange}
+                                onBlur={handleBlur}
+                                isDisabled={!isEditable}
+                            />
+                        </FormLabelGroup>
+                    )}
                     {!isCreating && isEditable && (
                         <FormLabelGroup
                             label=""

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/IntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/IntegrationForm.tsx
@@ -1,6 +1,9 @@
 import React, { FunctionComponent, ReactElement } from 'react';
+import { useHistory } from 'react-router-dom';
 
 import { isUserResource } from 'Containers/AccessControl/traits';
+import useCentralCapabilities from 'hooks/useCentralCapabilities';
+import { integrationsPath } from 'routePaths';
 import { Integration, IntegrationSource, IntegrationType } from '../utils/integrationUtils';
 
 // image integrations
@@ -100,6 +103,16 @@ function IntegrationForm({
     initialValues,
     isEditable,
 }: IntegrationFormProps): ReactElement {
+    const history = useHistory();
+
+    const { isCentralCapabilityAvailable } = useCentralCapabilities();
+    const canUseCloudBackupIntegrations = isCentralCapabilityAvailable(
+        'centralCanUseCloudBackupIntegrations'
+    );
+    if (!canUseCloudBackupIntegrations && source === 'backups') {
+        history.replace(integrationsPath);
+    }
+
     const Form: FunctionComponent<FormProps> = ComponentFormMap?.[source]?.[type];
     if (!Form) {
         throw new Error(

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationTilesPage/IntegrationTilesPage.js
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationTilesPage/IntegrationTilesPage.js
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
 import { PageSection, Title } from '@patternfly/react-core';
 
+import useCentralCapabilities from 'hooks/useCentralCapabilities';
 import useFeatureFlags from 'hooks/useFeatureFlags';
 import { integrationsPath } from 'routePaths';
 import { selectors } from 'reducers';
@@ -21,6 +22,11 @@ const IntegrationTilesPage = ({
     signatureIntegrations,
 }) => {
     const { isFeatureFlagEnabled } = useFeatureFlags();
+
+    const { isCentralCapabilityAvailable } = useCentralCapabilities();
+    const canUseCloudBackupIntegrations = isCentralCapabilityAvailable(
+        'centralCanUseCloudBackupIntegrations'
+    );
 
     function findIntegrations(source, type) {
         const typeLowerMatches = (integration) =>
@@ -114,9 +120,14 @@ const IntegrationTilesPage = ({
                 >
                     {notifierTiles}
                 </IntegrationsSection>
-                <IntegrationsSection headerName="Backup Integrations" testId="backup-integrations">
-                    {backupTiles}
-                </IntegrationsSection>
+                {canUseCloudBackupIntegrations && (
+                    <IntegrationsSection
+                        headerName="Backup Integrations"
+                        testId="backup-integrations"
+                    >
+                        {backupTiles}
+                    </IntegrationsSection>
+                )}
                 <IntegrationsSection headerName="Authentication Tokens" testId="token-integrations">
                     {authProviderTiles}
                 </IntegrationsSection>

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationsListPage/IntegrationsListPage.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationsListPage/IntegrationsListPage.tsx
@@ -7,10 +7,11 @@ import {
     BreadcrumbItem,
     Divider,
 } from '@patternfly/react-core';
-import { useParams } from 'react-router-dom';
+import { useParams, useHistory } from 'react-router-dom';
 import { connect } from 'react-redux';
 
 import ConfirmationModal from 'Components/PatternFly/ConfirmationModal';
+import useCentralCapabilities from 'hooks/useCentralCapabilities';
 import { actions as integrationsActions } from 'reducers/integrations';
 import { actions as apitokensActions } from 'reducers/apitokens';
 import { actions as clusterInitBundlesActions } from 'reducers/clusterInitBundles';
@@ -43,6 +44,16 @@ function IntegrationsListPage({
     const { source, type } = useParams();
     const integrations = useIntegrations({ source, type });
     const [deletingIntegrationIds, setDeletingIntegrationIds] = useState([]);
+
+    const history = useHistory();
+
+    const { isCentralCapabilityAvailable } = useCentralCapabilities();
+    const canUseCloudBackupIntegrations = isCentralCapabilityAvailable(
+        'centralCanUseCloudBackupIntegrations'
+    );
+    if (!canUseCloudBackupIntegrations && source === 'backups') {
+        history.replace(integrationsPath);
+    }
 
     const typeLabel = getIntegrationLabel(source, type);
     const isAPIToken = getIsAPIToken(source, type);


### PR DESCRIPTION
## Description

### Part 1:
Hide the Use IAM role option for the ECR integration

### Part 2:
@connorgorman  suggests to entirely remove Cloud Backup integrations, both S3 and GCS. (Not just hiding the IAM option from S3 backup.)

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

Verified that IAM role is still available in ECR integration when the `centralScanningCanUseContainerIamRoleForEcr` capability is available, and that the IAM role is not visible when `centralScanningCanUseContainerIamRoleForEcr` is NOT available.
<img width="1112" alt="Screen Shot 2023-06-14 at 1 47 45 PM" src="https://github.com/stackrox/stackrox/assets/715729/9369b42d-bb68-4dfc-b22c-b67d0b884dee">

Verified that the backup integrations section is still visible and usable on the Integrations dashboard when `canUseCloudBackupIntegrations` capability is available, and that the backup integrations section is not visible when `canUseCloudBackupIntegrations` is NOT available. In addition, I also added redirects if someone tries to visible the table or form views for any backup integration when `canUseCloudBackupIntegrations` is NOT available.
<img width="1134" alt="Screen Shot 2023-06-14 at 1 27 31 PM" src="https://github.com/stackrox/stackrox/assets/715729/b4698d96-c052-4967-bb05-1ff89bea4ad0">

