### PR TITLE
fix: use number comparison in deploy.sh

### DIFF
--- a/deploy/common/deploy.sh
+++ b/deploy/common/deploy.sh
@@ -93,7 +93,7 @@ function wait_for_central {
     start_time="$(date '+%s')"
     local deadline=$((start_time + 10*60))  # 10 minutes
     until curl_central --output /dev/null --silent --fail "https://$LOCAL_API_ENDPOINT/v1/ping"; do
-        if [[ "$(date '+%s')" > "$deadline" ]]; then
+        if [[ "$(date '+%s')" -gt "$deadline" ]]; then
             echo >&2 "Exceeded deadline waiting for Central."
             central_pod="$("${ORCH_CMD}" -n stackrox get pods -l app=central -ojsonpath='{.items[0].metadata.name}')"
             if [[ -n "$central_pod" ]]; then


### PR DESCRIPTION
## Description

`$(date '+%s')` and `$deadline` are numbers.