### PR TITLE
ROX-17713: Disable telemetry in our ci runs

### DIFF
--- a/deploy/common/ci-values.yaml
+++ b/deploy/common/ci-values.yaml
@@ -10,6 +10,9 @@ central:
         cpu: 1
         memory: 1Gi
 
+  telemetry:
+    enabled: false
+
 scanner:
   replicas: 1
   autoscaling:

--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -213,12 +213,12 @@ function launch_central {
     rm -rf "${unzip_dir}"
     if ! (( use_docker )); then
         rm -rf central-bundle "${k8s_dir}/central-bundle"
-        roxctl central generate "${ORCH}" "${EXTRA_ARGS[@]}" --output-dir="central-bundle" "${STORAGE}" "${STORAGE_ARGS[@]}"
+        roxctl central generate --enable-telemetry=false "${ORCH}" "${EXTRA_ARGS[@]}" --output-dir="central-bundle" "${STORAGE}" "${STORAGE_ARGS[@]}"
         cp -R central-bundle/ "${unzip_dir}/"
         rm -rf central-bundle
     else
         docker run --rm ${DOCKER_PLATFORM_ARGS[@]} "${EXTRA_DOCKER_ARGS[@]}" --env-file <(env | grep '^ROX_') "$ROXCTL_IMAGE" \
-        	central generate "${ORCH}" "${EXTRA_ARGS[@]}" "${STORAGE}" "${STORAGE_ARGS[@]}" > "${k8s_dir}/central.zip"
+          central generate --enable-telemetry=false "${ORCH}" "${EXTRA_ARGS[@]}" "${STORAGE}" "${STORAGE_ARGS[@]}" > "${k8s_dir}/central.zip"
         unzip "${k8s_dir}/central.zip" -d "${unzip_dir}"
     fi
 

--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -209,16 +209,22 @@ function launch_central {
         add_args "--declarative-config-config-maps=declarative-configurations"
     fi
 
+    if [[ -n "${ROX_TELEMETRY_STORAGE_KEY_V1}" ]]; then
+      add_args "--enable-telemetry=true"
+    else
+      add_args "--enable-telemetry=false"
+    fi
+
     local unzip_dir="${k8s_dir}/central-deploy/"
     rm -rf "${unzip_dir}"
     if ! (( use_docker )); then
         rm -rf central-bundle "${k8s_dir}/central-bundle"
-        roxctl central generate --enable-telemetry=false "${ORCH}" "${EXTRA_ARGS[@]}" --output-dir="central-bundle" "${STORAGE}" "${STORAGE_ARGS[@]}"
+        roxctl central generate "${ORCH}" "${EXTRA_ARGS[@]}" --output-dir="central-bundle" "${STORAGE}" "${STORAGE_ARGS[@]}"
         cp -R central-bundle/ "${unzip_dir}/"
         rm -rf central-bundle
     else
         docker run --rm ${DOCKER_PLATFORM_ARGS[@]} "${EXTRA_DOCKER_ARGS[@]}" --env-file <(env | grep '^ROX_') "$ROXCTL_IMAGE" \
-          central generate --enable-telemetry=false "${ORCH}" "${EXTRA_ARGS[@]}" "${STORAGE}" "${STORAGE_ARGS[@]}" > "${k8s_dir}/central.zip"
+          central generate "${ORCH}" "${EXTRA_ARGS[@]}" "${STORAGE}" "${STORAGE_ARGS[@]}" > "${k8s_dir}/central.zip"
         unzip "${k8s_dir}/central.zip" -d "${unzip_dir}"
     fi
 

--- a/deploy/common/local-dev-values.yaml
+++ b/deploy/common/local-dev-values.yaml
@@ -20,6 +20,9 @@ central:
         cpu: 1
         memory: 4Gi
 
+  telemetry:
+    enabled: false
+
 scanner:
   replicas: 1
   autoscaling:

--- a/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml
+++ b/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        {{- if ._rox.central.telemetry.enabled }}
+        {{- if ne (._rox.central.telemetry.enabled | toString) "false" }}
         {{- if ._rox.central.telemetry.storage.endpoint }}
         - name: ROX_TELEMETRY_ENDPOINT
           value: {{ ._rox.central.telemetry.storage.endpoint | quote }}

--- a/image/templates/helm/stackrox-central/templates/NOTES.txt.htpl
+++ b/image/templates/helm/stackrox-central/templates/NOTES.txt.htpl
@@ -47,4 +47,10 @@ IMPORTANT: You have deployed into an OpenShift-enabled cluster. If you see that 
 {{ end -}}
 [< end >]
 
+{{ if ne (._rox.central.telemetry.enabled | toString) "false" }}
+StackRox Kubernetes Security Platform collects and transmits anonymous usage and
+system configuration information. If you want to OPT OUT from this, use
+--set central.telemetry.enabled=false.
+{{ end }}
+
 Thank you for using StackRox!

--- a/image/templates/helm/stackrox-central/values.yaml.htpl
+++ b/image/templates/helm/stackrox-central/values.yaml.htpl
@@ -103,14 +103,24 @@
 ## If specified, this should be a map mapping file names to PEM-encoded contents.
 #additionalCAs: null
 #
+[<- if and .TelemetryEnabled (and (eq .TelemetryKey "") (eq .TelemetryEndpoint ""))>]
 #central:
 #
-#  # Settings for telemetry data collection. Telemetry is disabled by default.
+#  # Settings for telemetry data collection. Telemetry is enabled by default.
 #  telemetry:
-#    enabled: false
+#    enabled: true
 #    storage:
 #      endpoint: null
 #      key: null
+[<- else >]
+central:
+# # Settings for telemetry data collection.
+  telemetry:
+    enabled: [< .TelemetryEnabled >]
+    storage:
+      endpoint: "[< .TelemetryEndpoint >]"
+      key: "[< .TelemetryKey >]"
+[<- end >]
 #
 #
 #  config: "@config/central/config.yaml|config/central/config.yaml.default"

--- a/operator/apis/platform/v1alpha1/central_types.go
+++ b/operator/apis/platform/v1alpha1/central_types.go
@@ -431,6 +431,8 @@ type ExposureRoute struct {
 // Telemetry defines telemetry settings for Central.
 type Telemetry struct {
 	// Specifies if Telemetry is enabled.
+	//+kubebuilder:validation:Default=true
+	//+kubebuilder:default=true
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,order=1,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
 	Enabled *bool `json:"enabled,omitempty"`
 

--- a/operator/bundle/manifests/platform.stackrox.io_centrals.yaml
+++ b/operator/bundle/manifests/platform.stackrox.io_centrals.yaml
@@ -456,6 +456,7 @@ spec:
                       storage backend.
                     properties:
                       enabled:
+                        default: true
                         description: Specifies if Telemetry is enabled.
                         type: boolean
                       storage:

--- a/operator/config/crd/bases/platform.stackrox.io_centrals.yaml
+++ b/operator/config/crd/bases/platform.stackrox.io_centrals.yaml
@@ -457,6 +457,7 @@ spec:
                       storage backend.
                     properties:
                       enabled:
+                        default: true
                         description: Specifies if Telemetry is enabled.
                         type: boolean
                       storage:

--- a/operator/pkg/central/values/translation/translation_test.go
+++ b/operator/pkg/central/values/translation/translation_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/stackrox/rox/operator/pkg/central/common"
 	"github.com/stackrox/rox/operator/pkg/central/extensions"
 	"github.com/stackrox/rox/operator/pkg/values/translation"
+	"github.com/stackrox/rox/pkg/buildinfo"
+	"github.com/stackrox/rox/pkg/version/testutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"helm.sh/helm/v3/pkg/chartutil"
@@ -32,6 +34,7 @@ func TestTranslate(t *testing.T) {
 		clientSet kubernetes.Interface
 		c         platform.Central
 		pvcs      []*corev1.PersistentVolumeClaim
+		version   string
 	}
 
 	connectivityPolicy := platform.ConnectivityOffline
@@ -42,6 +45,11 @@ func TestTranslate(t *testing.T) {
 	monitoringExposeEndpointDisabled := platform.ExposeEndpointDisabled
 	telemetryEndpoint := "endpoint"
 	telemetryKey := "key"
+	telemetryDisabledKey := map[string]interface{}{
+		"enabled": false,
+		"storage": map[string]interface{}{"key": disabledTelemetryKey}}
+	dirtyVersion := "1.2.3-dirty"
+	releaseVersion := "1.2.3"
 
 	truth := true
 	falsity := false
@@ -771,7 +779,104 @@ func TestTranslate(t *testing.T) {
 				"central": map[string]interface{}{
 					"exposeMonitoring": false,
 					"persistence":      map[string]interface{}{"persistentVolumeClaim": map[string]interface{}{"createClaim": false}},
-					"telemetry":        map[string]interface{}{"enabled": false},
+					"telemetry":        telemetryDisabledKey,
+					"db": map[string]interface{}{
+						"persistence": map[string]interface{}{
+							"persistentVolumeClaim": map[string]interface{}{
+								"createClaim": false,
+							},
+						},
+					},
+				},
+			},
+		},
+		"default dev telemetry": {
+			args: args{
+				c: platform.Central{
+					ObjectMeta: v1.ObjectMeta{
+						Namespace: "stackrox",
+					},
+				},
+				pvcs:    []*corev1.PersistentVolumeClaim{defaultPvc},
+				version: dirtyVersion,
+			},
+			want: chartutil.Values{
+				"central": map[string]interface{}{
+					"exposeMonitoring": false,
+					"persistence":      map[string]interface{}{"persistentVolumeClaim": map[string]interface{}{"createClaim": false}},
+					"telemetry":        telemetryDisabledKey,
+					"db": map[string]interface{}{
+						"persistence": map[string]interface{}{
+							"persistentVolumeClaim": map[string]interface{}{
+								"createClaim": false,
+							},
+						},
+					},
+				},
+			},
+		},
+		"enabled telemetry in dev": {
+			args: args{
+				c: platform.Central{
+					ObjectMeta: v1.ObjectMeta{
+						Namespace: "stackrox",
+					},
+					Spec: platform.CentralSpec{
+						Central: &platform.CentralComponentSpec{
+							Telemetry: &platform.Telemetry{
+								Enabled: &truth,
+								Storage: &platform.TelemetryStorage{
+									Key:      &telemetryKey,
+									Endpoint: &telemetryEndpoint,
+								},
+							},
+						},
+					},
+				},
+				pvcs:    []*corev1.PersistentVolumeClaim{defaultPvc},
+				version: dirtyVersion,
+			},
+			want: chartutil.Values{
+				"central": map[string]interface{}{
+					"exposeMonitoring": false,
+					"persistence":      map[string]interface{}{"persistentVolumeClaim": map[string]interface{}{"createClaim": false}},
+					"telemetry": map[string]interface{}{
+						"enabled": true,
+						"storage": map[string]interface{}{
+							"endpoint": "endpoint",
+							"key":      "key",
+						},
+					},
+					"db": map[string]interface{}{
+						"persistence": map[string]interface{}{
+							"persistentVolumeClaim": map[string]interface{}{
+								"createClaim": false,
+							},
+						},
+					},
+				},
+			},
+		},
+		"enabled telemetry no key": {
+			args: args{
+				c: platform.Central{
+					ObjectMeta: v1.ObjectMeta{
+						Namespace: "stackrox",
+					},
+					Spec: platform.CentralSpec{
+						Central: &platform.CentralComponentSpec{
+							Telemetry: &platform.Telemetry{
+								Enabled: &truth,
+							},
+						},
+					},
+				},
+				pvcs: []*corev1.PersistentVolumeClaim{defaultPvc},
+			},
+			want: chartutil.Values{
+				"central": map[string]interface{}{
+					"exposeMonitoring": false,
+					"persistence":      map[string]interface{}{"persistentVolumeClaim": map[string]interface{}{"createClaim": false}},
 					"db": map[string]interface{}{
 						"persistence": map[string]interface{}{
 							"persistentVolumeClaim": map[string]interface{}{
@@ -786,6 +891,18 @@ func TestTranslate(t *testing.T) {
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
+			if !buildinfo.ReleaseBuild || buildinfo.TestBuild {
+				wantCentral := tt.want["central"].(map[string]any)
+				if _, ok := wantCentral["telemetry"]; !ok {
+					wantCentral["telemetry"] = telemetryDisabledKey
+				}
+			}
+			if tt.args.version == "" {
+				testutils.SetMainVersion(t, releaseVersion)
+			} else {
+				testutils.SetMainVersion(t, tt.args.version)
+			}
+
 			wantAsValues, err := translation.ToHelmValues(tt.want)
 			require.NoError(t, err, "error in test specification: cannot translate `want` specification to Helm values")
 			var allExisting []ctrlClient.Object

--- a/operator/tests/common/central-cr.yaml
+++ b/operator/tests/common/central-cr.yaml
@@ -22,6 +22,8 @@ spec:
         limits:
           memory: 4Gi
           cpu: 1
+    telemetry:
+      enabled: false
   scanner:
     analyzer:
       scaling:

--- a/pkg/helm/charts/meta.go
+++ b/pkg/helm/charts/meta.go
@@ -53,6 +53,9 @@ type MetaValues struct {
 	AdmissionControllerEnabled       bool
 	AdmissionControlEnforceOnUpdates bool
 	ReleaseBuild                     bool
+	TelemetryEnabled                 bool
+	TelemetryKey                     string
+	TelemetryEndpoint                string
 
 	AutoSensePodSecurityPolicies bool
 	EnablePodSecurityPolicies    bool // Only used in the Helm chart if AutoSensePodSecurityPolicies is false.

--- a/pkg/renderer/render_new.go
+++ b/pkg/renderer/render_new.go
@@ -101,6 +101,9 @@ func renderNewBasicFiles(c Config, mode mode, imageFlavor defaults.ImageFlavor) 
 	if metaVals.KubectlOutput {
 		metaVals.AutoSensePodSecurityPolicies = false
 	}
+	metaVals.TelemetryEnabled = c.K8sConfig.Telemetry.Enabled
+	metaVals.TelemetryKey = c.K8sConfig.Telemetry.StorageKey
+	metaVals.TelemetryEndpoint = c.K8sConfig.Telemetry.StorageEndpoint
 	chartFiles, err := chTpl.InstantiateRaw(metaVals)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to instantiate central services chart template")

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -188,6 +188,8 @@ deploy_central_via_operator() {
     customize_envVars+=$'\n        value: "'"${ROX_POSTGRES_DATASTORE:-false}"'"'
     customize_envVars+=$'\n      - name: ROX_PROCESSES_LISTENING_ON_PORT'
     customize_envVars+=$'\n        value: "'"${ROX_PROCESSES_LISTENING_ON_PORT:-true}"'"'
+    customize_envVars+=$'\n      - name: ROX_TELEMETRY_STORAGE_KEY_V1'
+    customize_envVars+=$'\n        value: "'"${ROX_TELEMETRY_STORAGE_KEY_V1:-DISABLED}"'"'
 
     env - \
       centralAdminPasswordBase64="$centralAdminPasswordBase64" \

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -106,6 +106,7 @@ export_test_environment() {
     ci_export ROX_SEND_NAMESPACE_LABELS_IN_SYSLOG "${ROX_SEND_NAMESPACE_LABELS_IN_SYSLOG:-true}"
     ci_export ROX_DECLARATIVE_CONFIGURATION "${ROX_DECLARATIVE_CONFIGURATION:-true}"
     ci_export ROX_COMPLIANCE_ENHANCEMENTS "${ROX_COMPLIANCE_ENHANCEMENTS:-true}"
+    ci_export ROX_TELEMETRY_STORAGE_KEY_V1 "DISABLED"
 
     if is_in_PR_context && pr_has_label ci-fail-fast; then
         ci_export FAIL_FAST "true"


### PR DESCRIPTION
## Description

We want to disable telemetry when running CI tests. It will be automatically disabled for non-release versions (as no key is provided), but it has to be disabled explicitly when testing release versions of central. Otherwise, centrals will download and use the on-prem configuration.

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

Local deploy with helm and kubectl.