### PR TITLE
ROX-17661: fix declarative config "successful creation" test

### DIFF
--- a/qa-tests-backend/src/test/groovy/DeclarativeConfigTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DeclarativeConfigTest.groovy
@@ -823,15 +823,18 @@ splunk:
     // shares the same values.
     // The retrieved auth provider from the API will be returned, which will have the ID field populated.
     private AuthProvider verifyDeclarativeAuthProvider(AuthProvider expectedAuthProvider) {
-        def authProviderResponse = AuthProviderService.getAuthProviderService().
-                getAuthProviders(
-                        AuthproviderService.GetAuthProvidersRequest.newBuilder()
-                                .setName(expectedAuthProvider.getName()).build()
-                )
-        assert authProviderResponse.getAuthProvidersCount() == 1 :
-                "expected one auth provider with name ${expectedAuthProvider.getName()} but " +
-                        "got ${authProviderResponse.getAuthProvidersCount()}"
-        def authProvider = authProviderResponse.getAuthProviders(0)
+        def authProvider = null
+        withRetry(RETRIES, PAUSE_SECS) {
+            def authProviderResponse = AuthProviderService.getAuthProviderService().
+                    getAuthProviders(
+                            AuthproviderService.GetAuthProvidersRequest.newBuilder()
+                                    .setName(expectedAuthProvider.getName()).build()
+                    )
+            assert authProviderResponse.getAuthProvidersCount() == 1 :
+                    "expected one auth provider with name ${expectedAuthProvider.getName()} but " +
+                            "got ${authProviderResponse.getAuthProvidersCount()}"
+            authProvider = authProviderResponse.getAuthProviders(0)
+        }
         assert authProvider
         assert authProvider.getName() == expectedAuthProvider.getName()
         assert authProvider.getType() == expectedAuthProvider.getType()


### PR DESCRIPTION
## Description

The pattern is similar to the one observed here: https://github.com/stackrox/stackrox/pull/6403

1. Health is created
2. Other declarative resources are created
3. Auth provider is not created

Apparently, there's some delay between health of auth provider created and auth provider being created. 
Solving in the same manner as the referenced CI failure

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

1. CI is sufficient. Optimistically assuming it will be enough and failures will stop
