### PR TITLE
ROX-17785: Fix roxctl yaml-verification test

### DIFF
--- a/tests/yamls/roxctl_verification.sh
+++ b/tests/yamls/roxctl_verification.sh
@@ -12,7 +12,7 @@ fi
 FAILED="false"
 for yaml in "$DIR"/*.yaml; do
 	[ -e "$yaml" ] || continue
-	NUM_ALERTS="$(roxctl "${extra_args[@]}" -e "$API_ENDPOINT" -p "$ROX_PASSWORD" deployment check --file $yaml --json | \
+	NUM_ALERTS="$(roxctl "${extra_args[@]}" -e "$API_ENDPOINT" -p "$ROX_PASSWORD" deployment check --file $yaml --output json | \
 	    jq '.alerts[].policy.name | select(.=="Latest tag" or .=="No resource requests or limits specified")' | jq -s '. | length')"
 	if [[ $NUM_ALERTS != "2" ]]; then
 		>&2 echo "Did not find 2 alerts for $yaml"


### PR DESCRIPTION
## Description

roxctl yaml-verification test is failing with error:

> Flag --json has been deprecated, use the new output format which also offers JSON. NOTE: The new output format's structure has changed in a non-backward compatible way.

## Checklist
- [ ] Investigated and inspected CI test results

### N/A
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))


## Testing Performed

- In CI we trust
