### PR TITLE
fix: Remove unused constant from declarativeconfig/manager_impl

### DIFF
--- a/central/declarativeconfig/manager_impl.go
+++ b/central/declarativeconfig/manager_impl.go
@@ -38,8 +38,6 @@ const (
 
 	// The number of consecutive errors for a declarative configuration that causes its health status to be UNHEALTHY.
 	consecutiveReconciliationErrorThreshold = 3
-
-	handlerIntegrationHealthStatusPrefix = "Config Map"
 )
 
 type protoMessagesByType = map[reflect.Type][]proto.Message


### PR DESCRIPTION
## Description

Self-explanatory 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

1. CI is sufficient
