### PR TITLE
Add --allow-empty flag to cherry-pick call in cut-rc.yml

### DIFF
--- a/.github/workflows/cut-rc.yml
+++ b/.github/workflows/cut-rc.yml
@@ -189,7 +189,7 @@ jobs:
         run: |
           set -uo pipefail
           gh api -H "$ACCEPT_RAW" "${{env.script_url}}" | bash -s -- \
-            cherry-pick \
+            cherry-pick --allow-empty \
             "${{needs.variables.outputs.milestone}}" \
             "${{needs.variables.outputs.branch}}" \
             "${{needs.variables.outputs.named-release-patch}}"


### PR DESCRIPTION
## Description

When the cut-rc.yml script cherry-picks a commit that has no diff to the release branch, the script fails. This could be avoided by adding the '--allow-empty flag to the cherry-pick call.
See https://redhat-internal.slack.com/archives/C05AZF8T7GW/p1686749350971619 here the script failed for this reason

## Checklist
- ~[ ] Investigated and inspected CI test results~
- ~[ ] Unit test and regression tests added~
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

TODO
Not sure yet how to properly test the script, thoughts?
