### PR TITLE
ROX-17785: Fix the e2e test breakage by adding back latest tag

### DIFF
--- a/tests/yamls/multi-container-pod.yaml
+++ b/tests/yamls/multi-container-pod.yaml
@@ -16,7 +16,7 @@ spec:
         - name: html
           mountPath: /usr/share/nginx/html
     - name: 2nd
-      image: debian@sha256:1e5f2d70c9441c971607727f56d0776fb9eecf23cd37b595b26db7a974b2301d
+      image: debian:latest@sha256:1e5f2d70c9441c971607727f56d0776fb9eecf23cd37b595b26db7a974b2301d
       volumeMounts:
         - name: html
           mountPath: /html


### PR DESCRIPTION
## Description

Fixed one thing, but broke the roxctl test

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

gke nongroovy should pass
