### PR TITLE
refactor: Remove most index usages from datastores

### DIFF
--- a/central/activecomponent/datastore/datastore.go
+++ b/central/activecomponent/datastore/datastore.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stackrox/rox/central/activecomponent/datastore/index"
 	"github.com/stackrox/rox/central/activecomponent/datastore/internal/store"
 	pgStore "github.com/stackrox/rox/central/activecomponent/datastore/internal/store/postgres"
 	"github.com/stackrox/rox/central/activecomponent/datastore/search"
@@ -31,10 +30,9 @@ type DataStore interface {
 }
 
 // New returns a new instance of a DataStore.
-func New(storage store.Store, indexer index.Indexer, searcher search.Searcher) DataStore {
+func New(storage store.Store, searcher search.Searcher) DataStore {
 	ds := &datastoreImpl{
 		storage:  storage,
-		indexer:  indexer,
 		searcher: searcher,
 	}
 	return ds
@@ -46,11 +44,9 @@ func NewForTestOnly(t *testing.T, db postgres.DB) (DataStore, error) {
 	testutils.MustBeInTest(t)
 
 	storage := pgStore.New(db)
-	indexer := pgStore.NewIndexer(db)
-	searcher := search.NewV2(storage, indexer)
+	searcher := search.NewV2(storage, pgStore.NewIndexer(db))
 	ds := &datastoreImpl{
 		storage:  storage,
-		indexer:  indexer,
 		searcher: searcher,
 	}
 

--- a/central/activecomponent/datastore/datastore_impl.go
+++ b/central/activecomponent/datastore/datastore_impl.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
-	"github.com/stackrox/rox/central/activecomponent/datastore/index"
 	"github.com/stackrox/rox/central/activecomponent/datastore/internal/store"
 	"github.com/stackrox/rox/central/activecomponent/datastore/search"
 	"github.com/stackrox/rox/central/role/resources"
@@ -20,7 +19,6 @@ var (
 
 type datastoreImpl struct {
 	storage  store.Store
-	indexer  index.Indexer
 	searcher search.Searcher
 }
 

--- a/central/activecomponent/datastore/singleton.go
+++ b/central/activecomponent/datastore/singleton.go
@@ -15,9 +15,8 @@ var (
 
 func initialize() {
 	storage := pgStore.New(globaldb.GetPostgres())
-	indexer := pgStore.NewIndexer(globaldb.GetPostgres())
-	searcher := search.NewV2(storage, indexer)
-	ds = New(storage, indexer, searcher)
+	searcher := search.NewV2(storage, pgStore.NewIndexer(globaldb.GetPostgres()))
+	ds = New(storage, searcher)
 }
 
 // Singleton provides the interface for non-service external interaction.

--- a/central/alert/datastore/datastore.go
+++ b/central/alert/datastore/datastore.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stackrox/rox/central/alert/datastore/internal/index"
 	"github.com/stackrox/rox/central/alert/datastore/internal/search"
 	"github.com/stackrox/rox/central/alert/datastore/internal/store"
 	pgStore "github.com/stackrox/rox/central/alert/datastore/internal/store/postgres"
@@ -42,11 +41,10 @@ type DataStore interface {
 	DeleteAlerts(ctx context.Context, ids ...string) error
 }
 
-// New returns a new soleInstance of DataStore using the input store, indexer, and searcher.
-func New(alertStore store.Store, indexer index.Indexer, searcher search.Searcher) (DataStore, error) {
+// New returns a new soleInstance of DataStore using the input store, and searcher.
+func New(alertStore store.Store, searcher search.Searcher) (DataStore, error) {
 	ds := &datastoreImpl{
 		storage:    alertStore,
-		indexer:    indexer,
 		searcher:   searcher,
 		keyedMutex: concurrency.NewKeyedMutex(mutexPoolSize),
 		keyFence:   dackboxConcurrency.NewKeyFence(),
@@ -60,5 +58,5 @@ func GetTestPostgresDataStore(_ testing.TB, pool postgres.DB) (DataStore, error)
 	indexer := pgStore.NewIndexer(pool)
 	searcher := search.New(alertStore, indexer)
 
-	return New(alertStore, indexer, searcher)
+	return New(alertStore, searcher)
 }

--- a/central/alert/datastore/datastore_test.go
+++ b/central/alert/datastore/datastore_test.go
@@ -36,7 +36,6 @@ type alertDataStoreTestSuite struct {
 
 	dataStore DataStore
 	storage   *storeMocks.MockStore
-	indexer   *indexMocks.MockIndexer
 	searcher  *searchMocks.MockSearcher
 
 	mockCtrl *gomock.Controller
@@ -54,11 +53,10 @@ func (s *alertDataStoreTestSuite) SetupTest() {
 
 	s.mockCtrl = gomock.NewController(s.T())
 	s.storage = storeMocks.NewMockStore(s.mockCtrl)
-	s.indexer = indexMocks.NewMockIndexer(s.mockCtrl)
 	s.searcher = searchMocks.NewMockSearcher(s.mockCtrl)
 
 	var err error
-	s.dataStore, err = New(s.storage, s.indexer, s.searcher)
+	s.dataStore, err = New(s.storage, s.searcher)
 	s.Require().NoError(err)
 }
 
@@ -199,10 +197,9 @@ func (s *alertDataStoreWithSACTestSuite) SetupTest() {
 
 	s.mockCtrl = gomock.NewController(s.T())
 	s.storage = storeMocks.NewMockStore(s.mockCtrl)
-	s.indexer = indexMocks.NewMockIndexer(s.mockCtrl)
 	s.searcher = searchMocks.NewMockSearcher(s.mockCtrl)
 	var err error
-	s.dataStore, err = New(s.storage, s.indexer, s.searcher)
+	s.dataStore, err = New(s.storage, s.searcher)
 	s.NoError(err)
 }
 

--- a/central/alert/datastore/singleton.go
+++ b/central/alert/datastore/singleton.go
@@ -16,10 +16,9 @@ var (
 
 func initialize() {
 	storage := pgStore.New(globaldb.GetPostgres())
-	indexer := pgStore.NewIndexer(globaldb.GetPostgres())
-	searcher := search.New(storage, indexer)
+	searcher := search.New(storage, pgStore.NewIndexer(globaldb.GetPostgres()))
 	var err error
-	soleInstance, err = New(storage, indexer, searcher)
+	soleInstance, err = New(storage, searcher)
 	utils.CrashOnError(errors.Wrap(err, "unable to load datastore for alerts"))
 }
 

--- a/central/cluster/datastore/datastore.go
+++ b/central/cluster/datastore/datastore.go
@@ -113,7 +113,6 @@ func New(
 		cm:                        cm,
 		notifier:                  notifier,
 		clusterRanker:             clusterRanker,
-		indexer:                   indexer,
 		networkBaselineMgr:        networkBaselineMgr,
 		idToNameCache:             simplecache.New(),
 		nameToIDCache:             simplecache.New(),

--- a/central/cluster/datastore/datastore_impl.go
+++ b/central/cluster/datastore/datastore_impl.go
@@ -10,7 +10,6 @@ import (
 	"github.com/pkg/errors"
 	alertDataStore "github.com/stackrox/rox/central/alert/datastore"
 	"github.com/stackrox/rox/central/cluster/datastore/internal/search"
-	"github.com/stackrox/rox/central/cluster/index"
 	clusterStore "github.com/stackrox/rox/central/cluster/store/cluster"
 	clusterHealthStore "github.com/stackrox/rox/central/cluster/store/clusterhealth"
 	clusterCVEDS "github.com/stackrox/rox/central/cve/cluster/datastore"
@@ -66,7 +65,6 @@ var (
 )
 
 type datastoreImpl struct {
-	indexer                   index.Indexer
 	clusterStorage            clusterStore.Store
 	clusterHealthStorage      clusterHealthStore.Store
 	clusterCVEDataStore       clusterCVEDS.DataStore

--- a/central/cluster/datastore/datastore_test_constructors.go
+++ b/central/cluster/datastore/datastore_test_constructors.go
@@ -67,7 +67,7 @@ func GetTestPostgresDataStore(t *testing.T, pool postgres.DB) (DataStore, error)
 	if err != nil {
 		return nil, err
 	}
-	k8sRoleStore, err := roleDataStore.GetTestPostgresDataStore(t, pool)
+	k8sRoleStore := roleDataStore.GetTestPostgresDataStore(t, pool)
 	if err != nil {
 		return nil, err
 	}

--- a/central/cluster/datastore/datastore_test_constructors.go
+++ b/central/cluster/datastore/datastore_test_constructors.go
@@ -68,9 +68,6 @@ func GetTestPostgresDataStore(t *testing.T, pool postgres.DB) (DataStore, error)
 		return nil, err
 	}
 	k8sRoleStore := roleDataStore.GetTestPostgresDataStore(t, pool)
-	if err != nil {
-		return nil, err
-	}
 	k8sRoleBindingStore, err := roleBindingDataStore.GetTestPostgresDataStore(t, pool)
 	if err != nil {
 		return nil, err

--- a/central/clustercveedge/datastore/datastore.go
+++ b/central/clustercveedge/datastore/datastore.go
@@ -7,6 +7,7 @@ import (
 	pgStore "github.com/stackrox/rox/central/clustercveedge/datastore/store/postgres"
 	"github.com/stackrox/rox/central/clustercveedge/search"
 	"github.com/stackrox/rox/central/clustercveedge/store"
+	"github.com/stackrox/rox/central/globaldb"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
@@ -39,7 +40,6 @@ func New(storage store.Store, searcher search.Searcher) (DataStore, error) {
 // GetTestPostgresDataStore provides a datastore connected to postgres for testing purposes.
 func GetTestPostgresDataStore(_ *testing.T, pool postgres.DB) (DataStore, error) {
 	storage := pgStore.New(pool)
-	indexer := pgStore.NewIndexer(pool)
-	searcher := search.NewV2(storage, indexer)
+	searcher := search.NewV2(storage, pgStore.NewIndexer(globaldb.GetPostgres()))
 	return New(storage, searcher)
 }

--- a/central/clustercveedge/datastore/datastore.go
+++ b/central/clustercveedge/datastore/datastore.go
@@ -7,7 +7,6 @@ import (
 	pgStore "github.com/stackrox/rox/central/clustercveedge/datastore/store/postgres"
 	"github.com/stackrox/rox/central/clustercveedge/search"
 	"github.com/stackrox/rox/central/clustercveedge/store"
-	"github.com/stackrox/rox/central/globaldb"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
@@ -40,6 +39,6 @@ func New(storage store.Store, searcher search.Searcher) (DataStore, error) {
 // GetTestPostgresDataStore provides a datastore connected to postgres for testing purposes.
 func GetTestPostgresDataStore(_ *testing.T, pool postgres.DB) (DataStore, error) {
 	storage := pgStore.New(pool)
-	searcher := search.NewV2(storage, pgStore.NewIndexer(globaldb.GetPostgres()))
+	searcher := search.NewV2(storage, pgStore.NewIndexer(pool))
 	return New(storage, searcher)
 }

--- a/central/clustercveedge/datastore/singleton.go
+++ b/central/clustercveedge/datastore/singleton.go
@@ -17,8 +17,7 @@ var (
 func initialize() {
 	var err error
 	storage := pgStore.New(globaldb.GetPostgres())
-	indexer := pgStore.NewIndexer(globaldb.GetPostgres())
-	ad, err = New(storage, search.NewV2(storage, indexer))
+	ad, err = New(storage, search.NewV2(storage, pgStore.NewIndexer(globaldb.GetPostgres())))
 	utils.CrashOnError(err)
 }
 

--- a/central/clustercveedge/datastoretest/datastore_sac_test.go
+++ b/central/clustercveedge/datastoretest/datastore_sac_test.go
@@ -18,10 +18,6 @@ import (
 )
 
 const (
-	clusterOS = ""
-
-	waitForIndexing = true
-
 	cluster1ToCVE1EdgeID = "cluster1ToCVE1EdgeID"
 	cluster1ToCVE2EdgeID = "cluster1ToCVE2EdgeID"
 	cluster2ToCVE2EdgeID = "cluster2ToCVE2EdgeID"

--- a/central/componentcveedge/datastore/datastore.go
+++ b/central/componentcveedge/datastore/datastore.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	pgStore "github.com/stackrox/rox/central/componentcveedge/datastore/store/postgres"
-	"github.com/stackrox/rox/central/componentcveedge/index"
 	"github.com/stackrox/rox/central/componentcveedge/search"
 	"github.com/stackrox/rox/central/componentcveedge/store"
 	v1 "github.com/stackrox/rox/generated/api/v1"
@@ -28,10 +27,9 @@ type DataStore interface {
 }
 
 // New returns a new instance of a DataStore.
-func New(storage store.Store, indexer index.Indexer, searcher search.Searcher) DataStore {
+func New(storage store.Store, searcher search.Searcher) DataStore {
 	ds := &datastoreImpl{
 		storage:  storage,
-		indexer:  indexer,
 		searcher: searcher,
 	}
 	return ds
@@ -42,5 +40,5 @@ func GetTestPostgresDataStore(_ *testing.T, pool postgres.DB) (DataStore, error)
 	dbstore := pgStore.New(pool)
 	indexer := pgStore.NewIndexer(pool)
 	searcher := search.NewV2(dbstore, indexer)
-	return New(dbstore, indexer, searcher), nil
+	return New(dbstore, searcher), nil
 }

--- a/central/componentcveedge/datastore/datastore_impl.go
+++ b/central/componentcveedge/datastore/datastore_impl.go
@@ -3,7 +3,6 @@ package datastore
 import (
 	"context"
 
-	"github.com/stackrox/rox/central/componentcveedge/index"
 	"github.com/stackrox/rox/central/componentcveedge/search"
 	"github.com/stackrox/rox/central/componentcveedge/store"
 	v1 "github.com/stackrox/rox/generated/api/v1"
@@ -13,7 +12,6 @@ import (
 
 type datastoreImpl struct {
 	storage  store.Store
-	indexer  index.Indexer
 	searcher search.Searcher
 }
 

--- a/central/componentcveedge/datastore/datastore_sac_test.go
+++ b/central/componentcveedge/datastore/datastore_sac_test.go
@@ -20,9 +20,6 @@ import (
 
 var (
 	imageScanOperatingSystem = "crime-stories"
-
-	dontWaitForIndexing = false
-	waitForIndexing     = true
 )
 
 func TestImageComponentCVEEdgeDatastoreSAC(t *testing.T) {

--- a/central/componentcveedge/datastore/singleton.go
+++ b/central/componentcveedge/datastore/singleton.go
@@ -15,9 +15,8 @@ var (
 
 func initialize() {
 	storage := pgStore.New(globaldb.GetPostgres())
-	indexer := pgStore.NewIndexer(globaldb.GetPostgres())
-	searcher := search.NewV2(storage, indexer)
-	ad = New(storage, indexer, searcher)
+	searcher := search.NewV2(storage, pgStore.NewIndexer(globaldb.GetPostgres()))
+	ad = New(storage, searcher)
 }
 
 // Singleton provides the interface for non-service external interaction.

--- a/central/cve/cluster/datastore/datastore.go
+++ b/central/cve/cluster/datastore/datastore.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/gogo/protobuf/types"
-	"github.com/stackrox/rox/central/cve/cluster/datastore/index"
 	"github.com/stackrox/rox/central/cve/cluster/datastore/search"
 	"github.com/stackrox/rox/central/cve/cluster/datastore/store"
 	"github.com/stackrox/rox/central/cve/common"
@@ -38,10 +37,9 @@ type DataStore interface {
 }
 
 // New returns a new instance of a DataStore.
-func New(storage store.Store, indexer index.Indexer, searcher search.Searcher) (DataStore, error) {
+func New(storage store.Store, searcher search.Searcher) (DataStore, error) {
 	ds := &datastoreImpl{
 		storage:  storage,
-		indexer:  indexer,
 		searcher: searcher,
 
 		cveSuppressionCache: make(common.CVESuppressionCache),

--- a/central/cve/cluster/datastore/datastore_impl.go
+++ b/central/cve/cluster/datastore/datastore_impl.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/gogo/protobuf/types"
 	"github.com/pkg/errors"
-	"github.com/stackrox/rox/central/cve/cluster/datastore/index"
 	"github.com/stackrox/rox/central/cve/cluster/datastore/search"
 	"github.com/stackrox/rox/central/cve/cluster/datastore/store"
 	"github.com/stackrox/rox/central/cve/common"
@@ -30,7 +29,6 @@ var (
 
 type datastoreImpl struct {
 	storage  store.Store
-	indexer  index.Indexer
 	searcher search.Searcher
 
 	cveSuppressionLock  sync.RWMutex

--- a/central/cve/cluster/datastore/datastore_test_constructors.go
+++ b/central/cve/cluster/datastore/datastore_test_constructors.go
@@ -11,7 +11,6 @@ import (
 // GetTestPostgresDataStore provides a datastore connected to postgres for testing purposes.
 func GetTestPostgresDataStore(_ *testing.T, pool postgres.DB) (DataStore, error) {
 	dbstore := pgStore.NewFullStore(pool)
-	indexer := pgStore.NewIndexer(pool)
-	searcher := search.New(dbstore, indexer)
-	return New(dbstore, indexer, searcher)
+	searcher := search.New(dbstore, pgStore.NewIndexer(pool))
+	return New(dbstore, searcher)
 }

--- a/central/cve/cluster/datastore/singleton.go
+++ b/central/cve/cluster/datastore/singleton.go
@@ -16,10 +16,9 @@ var (
 
 func initialize() {
 	storage := pgStore.NewFullStore(globaldb.GetPostgres())
-	indexer := pgStore.NewIndexer(globaldb.GetPostgres())
 
 	var err error
-	ds, err = New(storage, indexer, search.New(storage, indexer))
+	ds, err = New(storage, search.New(storage, pgStore.NewIndexer(globaldb.GetPostgres())))
 	utils.CrashOnError(err)
 }
 

--- a/central/cve/image/datastore/datastore.go
+++ b/central/cve/image/datastore/datastore.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/gogo/protobuf/types"
 	"github.com/stackrox/rox/central/cve/common"
-	"github.com/stackrox/rox/central/cve/image/datastore/index"
 	"github.com/stackrox/rox/central/cve/image/datastore/search"
 	"github.com/stackrox/rox/central/cve/image/datastore/store"
 	pgStore "github.com/stackrox/rox/central/cve/image/datastore/store/postgres"
@@ -36,10 +35,9 @@ type DataStore interface {
 }
 
 // New returns a new instance of a DataStore.
-func New(storage store.Store, indexer index.Indexer, searcher search.Searcher, kf concurrency.KeyFence) (DataStore, error) {
+func New(storage store.Store, searcher search.Searcher, kf concurrency.KeyFence) (DataStore, error) {
 	ds := &datastoreImpl{
 		storage:  storage,
-		indexer:  indexer,
 		searcher: searcher,
 
 		cveSuppressionCache: make(common.CVESuppressionCache),
@@ -56,5 +54,5 @@ func GetTestPostgresDataStore(_ *testing.T, pool postgres.DB) (DataStore, error)
 	dbstore := pgStore.New(pool)
 	indexer := pgStore.NewIndexer(pool)
 	searcher := search.New(dbstore, indexer)
-	return New(dbstore, indexer, searcher, concurrency.NewKeyFence())
+	return New(dbstore, searcher, concurrency.NewKeyFence())
 }

--- a/central/cve/image/datastore/datastore_impl.go
+++ b/central/cve/image/datastore/datastore_impl.go
@@ -6,7 +6,6 @@ import (
 	"github.com/gogo/protobuf/types"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/central/cve/common"
-	"github.com/stackrox/rox/central/cve/image/datastore/index"
 	"github.com/stackrox/rox/central/cve/image/datastore/search"
 	"github.com/stackrox/rox/central/cve/image/datastore/store"
 	"github.com/stackrox/rox/central/role/resources"
@@ -29,7 +28,6 @@ var (
 
 type datastoreImpl struct {
 	storage  store.Store
-	indexer  index.Indexer
 	searcher search.Searcher
 
 	cveSuppressionLock  sync.RWMutex

--- a/central/cve/image/datastore/datastore_impl_test.go
+++ b/central/cve/image/datastore/datastore_impl_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/gogo/protobuf/types"
 	"github.com/golang/mock/gomock"
 	"github.com/stackrox/rox/central/cve/common"
-	indexMocks "github.com/stackrox/rox/central/cve/image/datastore/index/mocks"
 	searchMocks "github.com/stackrox/rox/central/cve/image/datastore/search/mocks"
 	storeMocks "github.com/stackrox/rox/central/cve/image/datastore/store/mocks"
 	"github.com/stackrox/rox/generated/storage"
@@ -33,7 +32,6 @@ type ImageCVEDataStoreSuite struct {
 
 	mockCtrl *gomock.Controller
 
-	indexer   *indexMocks.MockIndexer
 	storage   *storeMocks.MockStore
 	searcher  *searchMocks.MockSearcher
 	datastore *datastoreImpl
@@ -42,13 +40,12 @@ type ImageCVEDataStoreSuite struct {
 func (suite *ImageCVEDataStoreSuite) SetupSuite() {
 	suite.mockCtrl = gomock.NewController(suite.T())
 
-	suite.indexer = indexMocks.NewMockIndexer(suite.mockCtrl)
 	suite.storage = storeMocks.NewMockStore(suite.mockCtrl)
 	suite.searcher = searchMocks.NewMockSearcher(suite.mockCtrl)
 
 	suite.searcher.EXPECT().SearchRawImageCVEs(accessAllCtx, testSuppressionQuery).Return([]*storage.ImageCVE{}, nil)
 
-	ds, err := New(suite.storage, suite.indexer, suite.searcher, concurrency.NewKeyFence())
+	ds, err := New(suite.storage, suite.searcher, concurrency.NewKeyFence())
 	suite.Require().NoError(err)
 	suite.datastore = ds.(*datastoreImpl)
 }

--- a/central/cve/image/datastore/singleton.go
+++ b/central/cve/image/datastore/singleton.go
@@ -17,10 +17,9 @@ var (
 
 func initialize() {
 	storage := pgStore.New(globaldb.GetPostgres())
-	indexer := pgStore.NewIndexer(globaldb.GetPostgres())
 
 	var err error
-	ds, err = New(storage, indexer, search.New(storage, indexer), keyfence.ImageKeyFenceSingleton())
+	ds, err = New(storage, search.New(storage, pgStore.NewIndexer(globaldb.GetPostgres())), keyfence.ImageKeyFenceSingleton())
 	utils.CrashOnError(err)
 }
 

--- a/central/cve/node/datastore/datastore.go
+++ b/central/cve/node/datastore/datastore.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/gogo/protobuf/types"
 	"github.com/stackrox/rox/central/cve/common"
-	"github.com/stackrox/rox/central/cve/node/datastore/index"
 	"github.com/stackrox/rox/central/cve/node/datastore/search"
 	"github.com/stackrox/rox/central/cve/node/datastore/store"
 	pgStore "github.com/stackrox/rox/central/cve/node/datastore/store/postgres"
@@ -38,10 +37,9 @@ type DataStore interface {
 }
 
 // New returns a new instance of a DataStore.
-func New(storage store.Store, indexer index.Indexer, searcher search.Searcher, kf concurrency.KeyFence) (DataStore, error) {
+func New(storage store.Store, searcher search.Searcher, kf concurrency.KeyFence) (DataStore, error) {
 	ds := &datastoreImpl{
 		storage:  storage,
-		indexer:  indexer,
 		searcher: searcher,
 
 		cveSuppressionCache: make(common.CVESuppressionCache),
@@ -58,5 +56,5 @@ func GetTestPostgresDataStore(_ *testing.T, pool postgres.DB) (DataStore, error)
 	dbstore := pgStore.New(pool)
 	indexer := pgStore.NewIndexer(pool)
 	searcher := search.New(dbstore, indexer)
-	return New(dbstore, indexer, searcher, concurrency.NewKeyFence())
+	return New(dbstore, searcher, concurrency.NewKeyFence())
 }

--- a/central/cve/node/datastore/datastore_impl.go
+++ b/central/cve/node/datastore/datastore_impl.go
@@ -6,7 +6,6 @@ import (
 	"github.com/gogo/protobuf/types"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/central/cve/common"
-	"github.com/stackrox/rox/central/cve/node/datastore/index"
 	"github.com/stackrox/rox/central/cve/node/datastore/search"
 	"github.com/stackrox/rox/central/cve/node/datastore/store"
 	"github.com/stackrox/rox/central/role/resources"
@@ -29,7 +28,6 @@ var (
 
 type datastoreImpl struct {
 	storage  store.Store
-	indexer  index.Indexer
 	searcher search.Searcher
 
 	cveSuppressionLock  sync.RWMutex

--- a/central/cve/node/datastore/datastore_impl_test.go
+++ b/central/cve/node/datastore/datastore_impl_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/gogo/protobuf/types"
 	"github.com/golang/mock/gomock"
 	"github.com/stackrox/rox/central/cve/common"
-	indexMocks "github.com/stackrox/rox/central/cve/node/datastore/index/mocks"
 	searchMocks "github.com/stackrox/rox/central/cve/node/datastore/search/mocks"
 	storeMocks "github.com/stackrox/rox/central/cve/node/datastore/store/mocks"
 	"github.com/stackrox/rox/generated/storage"
@@ -34,7 +33,6 @@ type NodeCVEDataStoreSuite struct {
 
 	mockCtrl *gomock.Controller
 
-	indexer   *indexMocks.MockIndexer
 	storage   *storeMocks.MockStore
 	searcher  *searchMocks.MockSearcher
 	datastore *datastoreImpl
@@ -43,13 +41,12 @@ type NodeCVEDataStoreSuite struct {
 func (suite *NodeCVEDataStoreSuite) SetupSuite() {
 	suite.mockCtrl = gomock.NewController(suite.T())
 
-	suite.indexer = indexMocks.NewMockIndexer(suite.mockCtrl)
 	suite.storage = storeMocks.NewMockStore(suite.mockCtrl)
 	suite.searcher = searchMocks.NewMockSearcher(suite.mockCtrl)
 
 	suite.searcher.EXPECT().SearchRawCVEs(accessAllCtx, testSuppressionQuery).Return([]*storage.NodeCVE{}, nil)
 
-	ds, err := New(suite.storage, suite.indexer, suite.searcher, concurrency.NewKeyFence())
+	ds, err := New(suite.storage, suite.searcher, concurrency.NewKeyFence())
 	suite.Require().NoError(err)
 	suite.datastore = ds.(*datastoreImpl)
 }

--- a/central/cve/node/datastore/singleton.go
+++ b/central/cve/node/datastore/singleton.go
@@ -17,10 +17,9 @@ var (
 
 func initialize() {
 	storage := pgStore.New(globaldb.GetPostgres())
-	indexer := pgStore.NewIndexer(globaldb.GetPostgres())
 
 	var err error
-	ds, err = New(storage, indexer, search.New(storage, indexer), keyfence.NodeKeyFenceSingleton())
+	ds, err = New(storage, search.New(storage, pgStore.NewIndexer(globaldb.GetPostgres())), keyfence.NodeKeyFenceSingleton())
 	utils.CrashOnError(err)
 }
 

--- a/central/cve/suppress/reprocessor_postgres_test.go
+++ b/central/cve/suppress/reprocessor_postgres_test.go
@@ -65,7 +65,7 @@ func (s *ReprocessorPostgresTestSuite) SetupTest() {
 
 	cveStore := cvePG.New(s.db)
 	cveIndexer := cvePG.NewIndexer(s.db)
-	cveDataStore, err := cveDS.New(cveStore, cveIndexer, cveSearcher.New(cveStore, cveIndexer), concurrency.NewKeyFence())
+	cveDataStore, err := cveDS.New(cveStore, cveSearcher.New(cveStore, cveIndexer), concurrency.NewKeyFence())
 	s.NoError(err)
 	s.cveDataStore = cveDataStore
 

--- a/central/deployment/datastore/datastore.go
+++ b/central/deployment/datastore/datastore.go
@@ -54,9 +54,8 @@ func newDataStore(storage store.Store, pool postgres.DB, images imageDS.DataStor
 		return nil, err
 	}
 
-	deploymentIndexer := pgStore.NewIndexer(pool)
-	searcher := search.NewV2(storage, deploymentIndexer)
-	ds := newDatastoreImpl(storage, deploymentIndexer, searcher, images, baselines, networkFlows, risks, deletedDeploymentCache, processFilter, clusterRanker, nsRanker, deploymentRanker)
+	searcher := search.NewV2(storage, pgStore.NewIndexer(pool))
+	ds := newDatastoreImpl(storage, searcher, images, baselines, networkFlows, risks, deletedDeploymentCache, processFilter, clusterRanker, nsRanker, deploymentRanker)
 
 	ds.initializeRanker()
 	return ds, nil
@@ -77,9 +76,8 @@ func NewTestDataStore(t testing.TB, storage store.Store, pool postgres.DB, image
 		return nil, err
 	}
 
-	deploymentIndexer := pgStore.NewIndexer(pool)
-	searcher := search.NewV2(storage, deploymentIndexer)
-	ds := newDatastoreImpl(storage, deploymentIndexer, searcher, images, baselines, networkFlows, risks, deletedDeploymentCache, processFilter, clusterRanker, nsRanker, deploymentRanker)
+	searcher := search.NewV2(storage, pgStore.NewIndexer(pool))
+	ds := newDatastoreImpl(storage, searcher, images, baselines, networkFlows, risks, deletedDeploymentCache, processFilter, clusterRanker, nsRanker, deploymentRanker)
 
 	ds.initializeRanker()
 	return ds, nil
@@ -110,5 +108,5 @@ func GetTestPostgresDataStore(t testing.TB, pool postgres.DB) (DataStore, error)
 	clusterRanker := ranking.ClusterRanker()
 	namespaceRanker := ranking.NamespaceRanker()
 	deploymentRanker := ranking.DeploymentRanker()
-	return newDatastoreImpl(dbstore, indexer, searcher, imageStore, processBaselineStore, networkFlowClusterStore, riskStore, nil, processFilter, clusterRanker, namespaceRanker, deploymentRanker), nil
+	return newDatastoreImpl(dbstore, searcher, imageStore, processBaselineStore, networkFlowClusterStore, riskStore, nil, processFilter, clusterRanker, namespaceRanker, deploymentRanker), nil
 }

--- a/central/deployment/datastore/datastore_impl_test.go
+++ b/central/deployment/datastore/datastore_impl_test.go
@@ -62,7 +62,7 @@ func (suite *DeploymentDataStoreTestSuite) TestInitializeRanker() {
 	nsRanker := ranking.NewRanker()
 	deploymentRanker := ranking.NewRanker()
 
-	ds := newDatastoreImpl(suite.storage, suite.indexer, suite.searcher, nil, nil, nil, suite.riskStore, nil, suite.filter, clusterRanker, nsRanker, deploymentRanker)
+	ds := newDatastoreImpl(suite.storage, suite.searcher, nil, nil, nil, suite.riskStore, nil, suite.filter, clusterRanker, nsRanker, deploymentRanker)
 
 	deployments := []*storage.Deployment{
 		{

--- a/central/graphql/resolvers/image_components_postgres_test.go
+++ b/central/graphql/resolvers/image_components_postgres_test.go
@@ -48,7 +48,6 @@ type GraphQLImageComponentTestSuite struct {
 }
 
 func (s *GraphQLImageComponentTestSuite) SetupSuite() {
-
 	s.ctx = loaders.WithLoaderContext(sac.WithAllAccess(context.Background()))
 	mockCtrl := gomock.NewController(s.T())
 	s.testDB = SetupTestPostgresConn(s.T())

--- a/central/graphql/resolvers/test_setup_utils.go
+++ b/central/graphql/resolvers/test_setup_utils.go
@@ -158,7 +158,7 @@ func CreateTestImageCVEDatastore(t testing.TB, testDB *pgtest.TestPostgres) imag
 	storage := imageCVEPostgres.CreateTableAndNewStore(ctx, testDB.DB, testDB.GetGormDB(t))
 	indexer := imageCVEPostgres.NewIndexer(testDB.DB)
 	searcher := imageCVESearch.New(storage, indexer)
-	datastore, err := imageCVEDS.New(storage, indexer, searcher, nil)
+	datastore, err := imageCVEDS.New(storage, searcher, nil)
 	assert.NoError(t, err)
 
 	return datastore
@@ -173,7 +173,7 @@ func CreateTestImageComponentCVEEdgeDatastore(t testing.TB, testDB *pgtest.TestP
 	indexer := imageComponentCVEEdgePostgres.NewIndexer(testDB.DB)
 	searcher := imageComponentCVEEdgeSearch.NewV2(storage, indexer)
 
-	return imageComponentCVEEdgeDS.New(storage, indexer, searcher)
+	return imageComponentCVEEdgeDS.New(storage, searcher)
 }
 
 // CreateTestImageComponentEdgeDatastore creates edge datastore for edge table between image and imageComponent
@@ -214,7 +214,7 @@ func CreateTestClusterCVEDatastore(t testing.TB, testDB *pgtest.TestPostgres) cl
 	storage := clusterCVEPostgres.NewFullTestStore(t, testDB.DB, clusterCVEPostgres.CreateTableAndNewStore(ctx, testDB.DB, testDB.GetGormDB(t)))
 	indexer := clusterCVEPostgres.NewIndexer(testDB.DB)
 	searcher := clusterCVESearch.New(storage, indexer)
-	datastore, err := clusterCVEDataStore.New(storage, indexer, searcher)
+	datastore, err := clusterCVEDataStore.New(storage, searcher)
 	assert.NoError(t, err, "failed to create cluster CVE datastore")
 	return datastore
 }
@@ -239,8 +239,7 @@ func CreateTestNamespaceDatastore(t testing.TB, testDB *pgtest.TestPostgres) nam
 
 	storage := namespacePostgres.CreateTableAndNewStore(ctx, testDB.DB, testDB.GetGormDB(t))
 	indexer := namespacePostgres.NewIndexer(testDB.DB)
-	datastore, err := namespaceDataStore.New(storage, indexer, nil, ranking.NamespaceRanker())
-	assert.NoError(t, err, "failed to create namespace datastore")
+	datastore := namespaceDataStore.New(storage, indexer, nil, ranking.NamespaceRanker())
 	return datastore
 }
 
@@ -274,7 +273,7 @@ func CreateTestNodeCVEDatastore(t testing.TB, testDB *pgtest.TestPostgres) nodeC
 	storage := nodeCVEPostgres.CreateTableAndNewStore(ctx, testDB.DB, testDB.GetGormDB(t))
 	indexer := nodeCVEPostgres.NewIndexer(testDB.DB)
 	searcher := nodeCVESearch.New(storage, indexer)
-	datastore, err := nodeCVEDataStore.New(storage, indexer, searcher, concurrency.NewKeyFence())
+	datastore, err := nodeCVEDataStore.New(storage, searcher, concurrency.NewKeyFence())
 	assert.NoError(t, err, "failed to create node CVE datastore")
 	return datastore
 }
@@ -288,7 +287,7 @@ func CreateTestNodeComponentDatastore(t testing.TB, testDB *pgtest.TestPostgres,
 	storage := nodeComponentPostgres.CreateTableAndNewStore(ctx, testDB.DB, testDB.GetGormDB(t))
 	indexer := nodeComponentPostgres.NewIndexer(testDB.DB)
 	searcher := nodeComponentSearch.New(storage, indexer)
-	return nodeComponentDataStore.New(storage, indexer, searcher, mockRisk, ranking.NewRanker())
+	return nodeComponentDataStore.New(storage, searcher, mockRisk, ranking.NewRanker())
 }
 
 // CreateTestNodeDatastore creates node datastore for testing
@@ -300,7 +299,7 @@ func CreateTestNodeDatastore(t testing.TB, testDB *pgtest.TestPostgres, ctrl *go
 	storage := nodePostgres.CreateTableAndNewStore(ctx, t, testDB.DB, testDB.GetGormDB(t), false)
 	indexer := nodePostgres.NewIndexer(testDB.DB)
 	searcher := nodeSearch.NewV2(storage, indexer)
-	return nodeDS.NewWithPostgres(storage, indexer, searcher, mockRisk, ranking.NewRanker(), ranking.NewRanker())
+	return nodeDS.NewWithPostgres(storage, searcher, mockRisk, ranking.NewRanker(), ranking.NewRanker())
 }
 
 // CreateTestNodeComponentCveEdgeDatastore creates edge datastore for edge table between nodeComponent and nodeCVE
@@ -311,7 +310,7 @@ func CreateTestNodeComponentCveEdgeDatastore(t testing.TB, testDB *pgtest.TestPo
 	storage := nodeComponentCVEEdgePostgres.CreateTableAndNewStore(ctx, testDB.DB, testDB.GetGormDB(t))
 	indexer := nodeComponentCVEEdgePostgres.NewIndexer(testDB.DB)
 	searcher := nodeComponentCVEEdgeSearch.New(storage, indexer)
-	return nodeComponentCVEEdgeDataStore.New(storage, indexer, searcher)
+	return nodeComponentCVEEdgeDataStore.New(storage, searcher)
 }
 
 func registerImageLoader(_ testing.TB, ds imageDS.DataStore) {

--- a/central/image/datastore/datastore.go
+++ b/central/image/datastore/datastore.go
@@ -38,11 +38,11 @@ type DataStore interface {
 	Exists(ctx context.Context, id string) (bool, error)
 }
 
-// NewWithPostgres returns a new instance of DataStore using the input store, indexer, and searcher.
+// NewWithPostgres returns a new instance of DataStore using the input store, and searcher.
 // noUpdateTimestamps controls whether timestamps are automatically updated when upserting images.
 // This should be set to `false` except for some tests.
 func NewWithPostgres(storage store.Store, index imageIndexer.Indexer, risks riskDS.DataStore, imageRanker *ranking.Ranker, imageComponentRanker *ranking.Ranker) DataStore {
-	ds := newDatastoreImpl(storage, index, search.NewV2(storage, index), risks, imageRanker, imageComponentRanker)
+	ds := newDatastoreImpl(storage, search.NewV2(storage, index), risks, imageRanker, imageComponentRanker)
 	ds.initializeRankers()
 	return ds
 }

--- a/central/image/datastore/datastore_impl.go
+++ b/central/image/datastore/datastore_impl.go
@@ -8,7 +8,6 @@ import (
 	"github.com/stackrox/rox/central/globaldb"
 	"github.com/stackrox/rox/central/image/datastore/search"
 	"github.com/stackrox/rox/central/image/datastore/store"
-	"github.com/stackrox/rox/central/image/index"
 	"github.com/stackrox/rox/central/metrics"
 	"github.com/stackrox/rox/central/ranking"
 	riskDS "github.com/stackrox/rox/central/risk/datastore"
@@ -36,7 +35,6 @@ type datastoreImpl struct {
 	keyedMutex *concurrency.KeyedMutex
 
 	storage  store.Store
-	indexer  index.Indexer
 	searcher search.Searcher
 
 	risks riskDS.DataStore
@@ -45,11 +43,10 @@ type datastoreImpl struct {
 	imageComponentRanker *ranking.Ranker
 }
 
-func newDatastoreImpl(storage store.Store, indexer index.Indexer, searcher search.Searcher, risks riskDS.DataStore,
+func newDatastoreImpl(storage store.Store, searcher search.Searcher, risks riskDS.DataStore,
 	imageRanker *ranking.Ranker, imageComponentRanker *ranking.Ranker) *datastoreImpl {
 	ds := &datastoreImpl{
 		storage:  storage,
-		indexer:  indexer,
 		searcher: searcher,
 
 		risks: risks,

--- a/central/image/datastore/datastore_impl_postgres_test.go
+++ b/central/image/datastore/datastore_impl_postgres_test.go
@@ -78,7 +78,7 @@ func (s *ImagePostgresDataStoreTestSuite) SetupTest() {
 	cveStorage := imageCVEPostgres.CreateTableAndNewStore(s.ctx, s.db, s.gormDB)
 	cveIndexer := imageCVEPostgres.NewIndexer(s.db)
 	cveSearcher := imageCVESearch.New(cveStorage, cveIndexer)
-	cveDataStore, err := imageCVEDS.New(cveStorage, cveIndexer, cveSearcher, concurrency.NewKeyFence())
+	cveDataStore, err := imageCVEDS.New(cveStorage, cveSearcher, concurrency.NewKeyFence())
 	s.NoError(err)
 	s.cveDataStore = cveDataStore
 }

--- a/central/image/datastore/singleton.go
+++ b/central/image/datastore/singleton.go
@@ -17,8 +17,7 @@ var (
 
 func initialize() {
 	storage := pgStore.New(globaldb.GetPostgres(), false, keyfence.ImageKeyFenceSingleton())
-	indexer := pgStore.NewIndexer(globaldb.GetPostgres())
-	ad = NewWithPostgres(storage, indexer, riskDS.Singleton(), ranking.ImageRanker(), ranking.ComponentRanker())
+	ad = NewWithPostgres(storage, pgStore.NewIndexer(globaldb.GetPostgres()), riskDS.Singleton(), ranking.ImageRanker(), ranking.ComponentRanker())
 }
 
 // Singleton provides the interface for non-service external interaction.

--- a/central/imagecomponent/datastore/singleton.go
+++ b/central/imagecomponent/datastore/singleton.go
@@ -17,8 +17,7 @@ var (
 
 func initialize() {
 	storage := pgStore.New(globaldb.GetPostgres())
-	indexer := pgStore.NewIndexer(globaldb.GetPostgres())
-	searcher := search.NewV2(storage, indexer)
+	searcher := search.NewV2(storage, pgStore.NewIndexer(globaldb.GetPostgres()))
 	ad = New(storage, searcher, riskDataStore.Singleton(), ranking.ComponentRanker())
 }
 

--- a/central/imagecomponentedge/datastore/datastore.go
+++ b/central/imagecomponentedge/datastore/datastore.go
@@ -3,7 +3,6 @@ package datastore
 import (
 	"context"
 
-	"github.com/stackrox/rox/central/imagecomponentedge/index"
 	"github.com/stackrox/rox/central/imagecomponentedge/search"
 	"github.com/stackrox/rox/central/imagecomponentedge/store"
 	v1 "github.com/stackrox/rox/generated/api/v1"
@@ -26,10 +25,9 @@ type DataStore interface {
 }
 
 // New returns a new instance of a DataStore.
-func New(storage store.Store, indexer index.Indexer, searcher search.Searcher) (DataStore, error) {
+func New(storage store.Store, searcher search.Searcher) (DataStore, error) {
 	ds := &datastoreImpl{
 		storage:  storage,
-		indexer:  indexer,
 		searcher: searcher,
 	}
 	return ds, nil

--- a/central/imagecomponentedge/datastore/datastore_impl.go
+++ b/central/imagecomponentedge/datastore/datastore_impl.go
@@ -3,7 +3,6 @@ package datastore
 import (
 	"context"
 
-	"github.com/stackrox/rox/central/imagecomponentedge/index"
 	"github.com/stackrox/rox/central/imagecomponentedge/search"
 	"github.com/stackrox/rox/central/imagecomponentedge/store"
 	v1 "github.com/stackrox/rox/generated/api/v1"
@@ -13,7 +12,6 @@ import (
 
 type datastoreImpl struct {
 	storage  store.Store
-	indexer  index.Indexer
 	searcher search.Searcher
 }
 

--- a/central/imagecomponentedge/datastore/datastore_test_constructors.go
+++ b/central/imagecomponentedge/datastore/datastore_test_constructors.go
@@ -3,7 +3,6 @@ package datastore
 import (
 	"testing"
 
-	"github.com/stackrox/rox/central/globaldb"
 	postgresStore "github.com/stackrox/rox/central/imagecomponentedge/datastore/internal/store/postgres"
 	"github.com/stackrox/rox/central/imagecomponentedge/search"
 	"github.com/stackrox/rox/pkg/postgres"
@@ -12,6 +11,6 @@ import (
 // GetTestPostgresDataStore provides a datastore connected to postgres for testing purposes.
 func GetTestPostgresDataStore(_ testing.TB, pool postgres.DB) (DataStore, error) {
 	storage := postgresStore.New(pool)
-	searcher := search.NewV2(storage, postgresStore.NewIndexer(globaldb.GetPostgres()))
+	searcher := search.NewV2(storage, postgresStore.NewIndexer(pool))
 	return New(storage, searcher)
 }

--- a/central/imagecomponentedge/datastore/datastore_test_constructors.go
+++ b/central/imagecomponentedge/datastore/datastore_test_constructors.go
@@ -3,6 +3,7 @@ package datastore
 import (
 	"testing"
 
+	"github.com/stackrox/rox/central/globaldb"
 	postgresStore "github.com/stackrox/rox/central/imagecomponentedge/datastore/internal/store/postgres"
 	"github.com/stackrox/rox/central/imagecomponentedge/search"
 	"github.com/stackrox/rox/pkg/postgres"
@@ -11,7 +12,6 @@ import (
 // GetTestPostgresDataStore provides a datastore connected to postgres for testing purposes.
 func GetTestPostgresDataStore(_ testing.TB, pool postgres.DB) (DataStore, error) {
 	storage := postgresStore.New(pool)
-	indexer := postgresStore.NewIndexer(pool)
-	searcher := search.NewV2(storage, indexer)
-	return New(storage, indexer, searcher)
+	searcher := search.NewV2(storage, postgresStore.NewIndexer(globaldb.GetPostgres()))
+	return New(storage, searcher)
 }

--- a/central/imagecomponentedge/datastore/singleton.go
+++ b/central/imagecomponentedge/datastore/singleton.go
@@ -17,9 +17,8 @@ var (
 func initialize() {
 	var err error
 	storage := pgStore.New(globaldb.GetPostgres())
-	indexer := pgStore.NewIndexer(globaldb.GetPostgres())
-	searcher := search.NewV2(storage, indexer)
-	ad, err = New(storage, indexer, searcher)
+	searcher := search.NewV2(storage, pgStore.NewIndexer(globaldb.GetPostgres()))
+	ad, err = New(storage, searcher)
 	utils.CrashOnError(err)
 }
 

--- a/central/imagecveedge/datastore/singleton.go
+++ b/central/imagecveedge/datastore/singleton.go
@@ -15,8 +15,7 @@ var (
 
 func initialize() {
 	storage := pgStore.New(globaldb.GetPostgres())
-	indexer := pgStore.NewIndexer(globaldb.GetPostgres())
-	searcher := search.NewV2(storage, indexer)
+	searcher := search.NewV2(storage, pgStore.NewIndexer(globaldb.GetPostgres()))
 	ad = New(storage, searcher)
 }
 

--- a/central/imageintegration/datastore/datastore.go
+++ b/central/imageintegration/datastore/datastore.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stackrox/rox/central/imageintegration/index"
 	"github.com/stackrox/rox/central/imageintegration/search"
 	"github.com/stackrox/rox/central/imageintegration/store"
 	pgStore "github.com/stackrox/rox/central/imageintegration/store/postgres"
@@ -35,20 +34,18 @@ type DataStore interface {
 }
 
 // New returns an instance of DataStore.
-func New(imageIntegrationStorage store.Store, indexer index.Indexer, searcher search.Searcher) DataStore {
+func New(imageIntegrationStorage store.Store, searcher search.Searcher) DataStore {
 	ds := &datastoreImpl{
 		storage:           imageIntegrationStorage,
-		indexer:           indexer,
 		formattedSearcher: searcher,
 	}
 	return ds
 }
 
 // NewForTestOnly returns an instance of DataStore only for tests.
-func NewForTestOnly(imageIntegrationStorage store.Store, indexer index.Indexer, searcher search.Searcher) DataStore {
+func NewForTestOnly(imageIntegrationStorage store.Store, searcher search.Searcher) DataStore {
 	ds := &datastoreImpl{
 		storage:           imageIntegrationStorage,
-		indexer:           indexer,
 		formattedSearcher: searcher,
 	}
 	return ds
@@ -57,7 +54,6 @@ func NewForTestOnly(imageIntegrationStorage store.Store, indexer index.Indexer, 
 // GetTestPostgresDataStore provides a datastore connected to postgres for testing purposes.
 func GetTestPostgresDataStore(_ *testing.T, pool postgres.DB) (DataStore, error) {
 	store := pgStore.New(pool)
-	indexer := pgStore.NewIndexer(pool)
-	searcher := search.New(store, indexer)
-	return New(store, indexer, searcher), nil
+	searcher := search.New(store, pgStore.NewIndexer(pool))
+	return New(store, searcher), nil
 }

--- a/central/imageintegration/datastore/datastore_impl.go
+++ b/central/imageintegration/datastore/datastore_impl.go
@@ -3,7 +3,6 @@ package datastore
 import (
 	"context"
 
-	"github.com/stackrox/rox/central/imageintegration/index"
 	"github.com/stackrox/rox/central/imageintegration/search"
 	"github.com/stackrox/rox/central/imageintegration/store"
 	"github.com/stackrox/rox/central/role/resources"
@@ -21,7 +20,6 @@ var (
 
 type datastoreImpl struct {
 	storage           store.Store
-	indexer           index.Indexer
 	formattedSearcher search.Searcher
 }
 

--- a/central/imageintegration/datastore/datastore_impl_test.go
+++ b/central/imageintegration/datastore/datastore_impl_test.go
@@ -72,7 +72,7 @@ func (suite *ImageIntegrationDataStoreTestSuite) SetupTest() {
 	suite.indexer = postgresStore.NewIndexer(suite.testDB.DB)
 
 	// test formattedSearcher
-	suite.datastore = NewForTestOnly(suite.store, suite.mockIndexer, suite.mockSearcher)
+	suite.datastore = NewForTestOnly(suite.store, suite.mockSearcher)
 }
 
 func (suite *ImageIntegrationDataStoreTestSuite) TearDownTest() {
@@ -326,7 +326,7 @@ func (suite *ImageIntegrationDataStoreTestSuite) TestDataStoreSearch() {
 	}
 
 	// Create a new datastore since the one in suite uses mocks
-	ds := New(suite.store, suite.indexer, search.New(suite.store, suite.indexer))
+	ds := New(suite.store, search.New(suite.store, suite.indexer))
 
 	ctx := sac.WithGlobalAccessScopeChecker(context.Background(), sac.AllowAllAccessScopeChecker())
 	_, err := ds.AddImageIntegration(ctx, ii)

--- a/central/imageintegration/datastore/singleton.go
+++ b/central/imageintegration/datastore/singleton.go
@@ -59,11 +59,10 @@ func initializeIntegrations(storage store.Store) {
 func initialize() {
 	// Create underlying store and datastore.
 	storage := pgStore.New(globaldb.GetPostgres())
-	indexer := pgStore.NewIndexer(globaldb.GetPostgres())
 
 	initializeIntegrations(storage)
-	searcher := search.New(storage, indexer)
-	dataStore = New(storage, indexer, searcher)
+	searcher := search.New(storage, pgStore.NewIndexer(globaldb.GetPostgres()))
+	dataStore = New(storage, searcher)
 }
 
 // Singleton provides the interface for non-service external interaction.

--- a/central/namespace/datastore/datastore.go
+++ b/central/namespace/datastore/datastore.go
@@ -43,15 +43,13 @@ type DataStore interface {
 }
 
 // New returns a new DataStore instance using the provided store and indexer
-func New(nsStore store.Store, indexer index.Indexer, deploymentDataStore deploymentDataStore.DataStore, namespaceRanker *ranking.Ranker) (DataStore, error) {
-	ds := &datastoreImpl{
+func New(nsStore store.Store, indexer index.Indexer, deploymentDataStore deploymentDataStore.DataStore, namespaceRanker *ranking.Ranker) DataStore {
+	return &datastoreImpl{
 		store:             nsStore,
-		indexer:           indexer,
 		deployments:       deploymentDataStore,
 		namespaceRanker:   namespaceRanker,
 		formattedSearcher: formatSearcherV2(indexer, namespaceRanker),
 	}
-	return ds, nil
 }
 
 // GetTestPostgresDataStore provides a datastore connected to postgres for testing purposes.
@@ -63,7 +61,7 @@ func GetTestPostgresDataStore(t *testing.T, pool postgres.DB) (DataStore, error)
 		return nil, err
 	}
 	namespaceRanker := ranking.NamespaceRanker()
-	return New(dbstore, indexer, deploymentStore, namespaceRanker)
+	return New(dbstore, indexer, deploymentStore, namespaceRanker), nil
 }
 
 var (

--- a/central/namespace/datastore/singleton.go
+++ b/central/namespace/datastore/singleton.go
@@ -6,7 +6,6 @@ import (
 	pgStore "github.com/stackrox/rox/central/namespace/store/postgres"
 	"github.com/stackrox/rox/central/ranking"
 	"github.com/stackrox/rox/pkg/sync"
-	"github.com/stackrox/rox/pkg/utils"
 )
 
 var (
@@ -17,10 +16,7 @@ var (
 
 func initialize() {
 	storage := pgStore.New(globaldb.GetPostgres())
-	indexer := pgStore.NewIndexer(globaldb.GetPostgres())
-	var err error
-	as, err = New(storage, indexer, deploymentDataStore.Singleton(), ranking.NamespaceRanker())
-	utils.CrashOnError(err)
+	as = New(storage, pgStore.NewIndexer(globaldb.GetPostgres()), deploymentDataStore.Singleton(), ranking.NamespaceRanker())
 }
 
 // Singleton provides the interface for non-service external interaction.

--- a/central/node/datastore/datastore.go
+++ b/central/node/datastore/datastore.go
@@ -8,7 +8,6 @@ import (
 	"github.com/stackrox/rox/central/node/datastore/search"
 	"github.com/stackrox/rox/central/node/datastore/store"
 	pgStore "github.com/stackrox/rox/central/node/datastore/store/postgres"
-	nodeIndexer "github.com/stackrox/rox/central/node/index"
 	"github.com/stackrox/rox/central/ranking"
 	riskDS "github.com/stackrox/rox/central/risk/datastore"
 	v1 "github.com/stackrox/rox/generated/api/v1"
@@ -39,9 +38,9 @@ type DataStore interface {
 	Exists(ctx context.Context, id string) (bool, error)
 }
 
-// NewWithPostgres returns a new instance of DataStore using the input store, indexer, and searcher.
-func NewWithPostgres(storage store.Store, indexer nodeIndexer.Indexer, searcher search.Searcher, risks riskDS.DataStore, nodeRanker *ranking.Ranker, nodeComponentRanker *ranking.Ranker) DataStore {
-	ds := newDatastoreImpl(storage, indexer, searcher, risks, nodeRanker, nodeComponentRanker)
+// NewWithPostgres returns a new instance of DataStore using the input store, and searcher.
+func NewWithPostgres(storage store.Store, searcher search.Searcher, risks riskDS.DataStore, nodeRanker *ranking.Ranker, nodeComponentRanker *ranking.Ranker) DataStore {
+	ds := newDatastoreImpl(storage, searcher, risks, nodeRanker, nodeComponentRanker)
 	ds.initializeRankers()
 	return ds
 }
@@ -57,7 +56,7 @@ func GetTestPostgresDataStore(t testing.TB, pool postgres.DB) (DataStore, error)
 	}
 	nodeRanker := ranking.NodeRanker()
 	nodeComponentRanker := ranking.NodeComponentRanker()
-	return NewWithPostgres(dbstore, indexer, searcher, riskStore, nodeRanker, nodeComponentRanker), nil
+	return NewWithPostgres(dbstore, searcher, riskStore, nodeRanker, nodeComponentRanker), nil
 }
 
 // NodeString returns a human-readable string representation of a node.

--- a/central/node/datastore/datastore_bench_postgres_test.go
+++ b/central/node/datastore/datastore_bench_postgres_test.go
@@ -42,7 +42,7 @@ func BenchmarkGetManyNodes(b *testing.B) {
 	store := pgStore.CreateTableAndNewStore(ctx, b, db, gormDB, false)
 	indexer := pgStore.NewIndexer(db)
 	searcher := search.NewV2(store, indexer)
-	datastore := NewWithPostgres(store, indexer, searcher, mockRisk, ranking.NewRanker(), ranking.NewRanker())
+	datastore := NewWithPostgres(store, searcher, mockRisk, ranking.NewRanker(), ranking.NewRanker())
 
 	ids := make([]string, 0, 100)
 	nodes := make([]*storage.Node, 0, 100)

--- a/central/node/datastore/datastore_impl.go
+++ b/central/node/datastore/datastore_impl.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stackrox/rox/central/metrics"
 	"github.com/stackrox/rox/central/node/datastore/search"
 	"github.com/stackrox/rox/central/node/datastore/store"
-	"github.com/stackrox/rox/central/node/index"
 	"github.com/stackrox/rox/central/ranking"
 	riskDS "github.com/stackrox/rox/central/risk/datastore"
 	"github.com/stackrox/rox/central/role/resources"
@@ -38,7 +37,6 @@ type datastoreImpl struct {
 	keyedMutex *concurrency.KeyedMutex
 
 	storage  store.Store
-	indexer  index.Indexer
 	searcher search.Searcher
 
 	risks riskDS.DataStore
@@ -47,11 +45,10 @@ type datastoreImpl struct {
 	nodeComponentRanker *ranking.Ranker
 }
 
-func newDatastoreImpl(storage store.Store, indexer index.Indexer, searcher search.Searcher, risks riskDS.DataStore,
+func newDatastoreImpl(storage store.Store, searcher search.Searcher, risks riskDS.DataStore,
 	nodeRanker *ranking.Ranker, nodeComponentRanker *ranking.Ranker) *datastoreImpl {
 	ds := &datastoreImpl{
 		storage:  storage,
-		indexer:  indexer,
 		searcher: searcher,
 
 		risks: risks,

--- a/central/node/datastore/datastore_impl_postgres_test.go
+++ b/central/node/datastore/datastore_impl_postgres_test.go
@@ -12,7 +12,6 @@ import (
 	nodeCVEDS "github.com/stackrox/rox/central/cve/node/datastore"
 	nodeCVESearch "github.com/stackrox/rox/central/cve/node/datastore/search"
 	nodeCVEPostgres "github.com/stackrox/rox/central/cve/node/datastore/store/postgres"
-	"github.com/stackrox/rox/central/globaldb"
 	"github.com/stackrox/rox/central/node/datastore/search"
 	pgStore "github.com/stackrox/rox/central/node/datastore/store/postgres"
 	nodeComponentDS "github.com/stackrox/rox/central/nodecomponent/datastore"
@@ -76,7 +75,7 @@ func (suite *NodePostgresDataStoreTestSuite) SetupTest() {
 	suite.mockCtrl = gomock.NewController(suite.T())
 	suite.mockRisk = mockRisks.NewMockDataStore(suite.mockCtrl)
 	storage := pgStore.CreateTableAndNewStore(suite.ctx, suite.T(), suite.db, suite.gormDB, false)
-	searcher := search.NewV2(storage, pgStore.NewIndexer(globaldb.GetPostgres()))
+	searcher := search.NewV2(storage, pgStore.NewIndexer(suite.db))
 	suite.datastore = NewWithPostgres(storage, searcher, suite.mockRisk, ranking.NewRanker(), ranking.NewRanker())
 
 	componentStorage := nodeComponentPostgres.CreateTableAndNewStore(suite.ctx, suite.db, suite.gormDB)

--- a/central/node/datastore/singleton.go
+++ b/central/node/datastore/singleton.go
@@ -18,9 +18,8 @@ var (
 
 func initialize() {
 	storage := pgStore.New(globaldb.GetPostgres(), false, keyfence.NodeKeyFenceSingleton())
-	indexer := pgStore.NewIndexer(globaldb.GetPostgres())
-	searcher := search.NewV2(storage, indexer)
-	ad = NewWithPostgres(storage, indexer, searcher, riskDS.Singleton(), ranking.NodeRanker(), ranking.NodeComponentRanker())
+	searcher := search.NewV2(storage, pgStore.NewIndexer(globaldb.GetPostgres()))
+	ad = NewWithPostgres(storage, searcher, riskDS.Singleton(), ranking.NodeRanker(), ranking.NodeComponentRanker())
 }
 
 // Singleton provides the interface for non-service external interaction.

--- a/central/nodecomponent/datastore/datastore.go
+++ b/central/nodecomponent/datastore/datastore.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stackrox/rox/central/nodecomponent/datastore/index"
 	"github.com/stackrox/rox/central/nodecomponent/datastore/search"
 	pgStore "github.com/stackrox/rox/central/nodecomponent/datastore/store/postgres"
 	"github.com/stackrox/rox/central/ranking"
@@ -30,10 +29,9 @@ type DataStore interface {
 }
 
 // New returns a new instance of a DataStore.
-func New(storage pgStore.Store, indexer index.Indexer, searcher search.Searcher, risks riskDataStore.DataStore, ranker *ranking.Ranker) DataStore {
+func New(storage pgStore.Store, searcher search.Searcher, risks riskDataStore.DataStore, ranker *ranking.Ranker) DataStore {
 	ds := &datastoreImpl{
 		storage:             storage,
-		indexer:             indexer,
 		searcher:            searcher,
 		risks:               risks,
 		nodeComponentRanker: ranker,
@@ -52,5 +50,5 @@ func GetTestPostgresDataStore(t *testing.T, pool postgres.DB) (DataStore, error)
 	if err != nil {
 		return nil, err
 	}
-	return New(dbstore, indexer, searcher, riskStore, ranking.NodeComponentRanker()), nil
+	return New(dbstore, searcher, riskStore, ranking.NodeComponentRanker()), nil
 }

--- a/central/nodecomponent/datastore/datastore_impl.go
+++ b/central/nodecomponent/datastore/datastore_impl.go
@@ -3,7 +3,6 @@ package datastore
 import (
 	"context"
 
-	"github.com/stackrox/rox/central/nodecomponent/datastore/index"
 	"github.com/stackrox/rox/central/nodecomponent/datastore/search"
 	pgStore "github.com/stackrox/rox/central/nodecomponent/datastore/store/postgres"
 	"github.com/stackrox/rox/central/ranking"
@@ -22,7 +21,6 @@ var (
 
 type datastoreImpl struct {
 	storage  pgStore.Store
-	indexer  index.Indexer
 	searcher search.Searcher
 
 	risks               riskDataStore.DataStore

--- a/central/nodecomponent/datastore/singleton.go
+++ b/central/nodecomponent/datastore/singleton.go
@@ -17,8 +17,7 @@ var (
 
 func initialize() {
 	storage := pgStore.New(globaldb.GetPostgres())
-	indexer := pgStore.NewIndexer(globaldb.GetPostgres())
-	ds = New(storage, indexer, search.New(storage, indexer), riskDataStore.Singleton(), ranking.NodeComponentRanker())
+	ds = New(storage, search.New(storage, pgStore.NewIndexer(globaldb.GetPostgres())), riskDataStore.Singleton(), ranking.NodeComponentRanker())
 }
 
 // Singleton returns a singleton instance of cve datastore

--- a/central/nodecomponentcveedge/datastore/datastore.go
+++ b/central/nodecomponentcveedge/datastore/datastore.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stackrox/rox/central/nodecomponentcveedge/datastore/index"
 	"github.com/stackrox/rox/central/nodecomponentcveedge/datastore/search"
 	pgStore "github.com/stackrox/rox/central/nodecomponentcveedge/datastore/store/postgres"
 	v1 "github.com/stackrox/rox/generated/api/v1"
@@ -27,10 +26,9 @@ type DataStore interface {
 }
 
 // New returns a new instance of a DataStore.
-func New(storage pgStore.Store, indexer index.Indexer, searcher search.Searcher) DataStore {
+func New(storage pgStore.Store, searcher search.Searcher) DataStore {
 	ds := &datastoreImpl{
 		storage:  storage,
-		indexer:  indexer,
 		searcher: searcher,
 	}
 	return ds
@@ -41,5 +39,5 @@ func GetTestPostgresDataStore(_ testing.TB, pool postgres.DB) DataStore {
 	dbstore := pgStore.New(pool)
 	indexer := pgStore.NewIndexer(pool)
 	searcher := search.New(dbstore, indexer)
-	return New(dbstore, indexer, searcher)
+	return New(dbstore, searcher)
 }

--- a/central/nodecomponentcveedge/datastore/datastore_impl.go
+++ b/central/nodecomponentcveedge/datastore/datastore_impl.go
@@ -3,7 +3,6 @@ package datastore
 import (
 	"context"
 
-	"github.com/stackrox/rox/central/nodecomponentcveedge/datastore/index"
 	"github.com/stackrox/rox/central/nodecomponentcveedge/datastore/search"
 	pgStore "github.com/stackrox/rox/central/nodecomponentcveedge/datastore/store/postgres"
 	v1 "github.com/stackrox/rox/generated/api/v1"
@@ -13,7 +12,6 @@ import (
 
 type datastoreImpl struct {
 	storage  pgStore.Store
-	indexer  index.Indexer
 	searcher search.Searcher
 }
 

--- a/central/nodecomponentcveedge/datastore/singleton.go
+++ b/central/nodecomponentcveedge/datastore/singleton.go
@@ -15,9 +15,8 @@ var (
 
 func initialize() {
 	storage := pgStore.New(globaldb.GetPostgres())
-	indexer := pgStore.NewIndexer(globaldb.GetPostgres())
 
-	ds = New(storage, indexer, search.New(storage, indexer))
+	ds = New(storage, search.New(storage, pgStore.NewIndexer(globaldb.GetPostgres())))
 }
 
 // Singleton returns a singleton instance of cve datastore

--- a/central/nodecomponentedge/datastore/singleton.go
+++ b/central/nodecomponentedge/datastore/singleton.go
@@ -15,8 +15,7 @@ var (
 
 func initialize() {
 	storage := pgStore.New(globaldb.GetPostgres())
-	indexer := pgStore.NewIndexer(globaldb.GetPostgres())
-	searcher := search.New(storage, indexer)
+	searcher := search.New(storage, pgStore.NewIndexer(globaldb.GetPostgres()))
 	ad = New(storage, searcher)
 }
 

--- a/central/pod/datastore/datastore.go
+++ b/central/pod/datastore/datastore.go
@@ -40,9 +40,8 @@ func NewPostgresDB(db postgres.DB, indicators piDS.DataStore, processFilter filt
 	if err != nil {
 		return nil, err
 	}
-	indexer := pgStore.NewIndexer(db)
-	searcher := search.New(store, indexer)
-	return newDatastoreImpl(store, indexer, searcher, indicators, processFilter)
+	searcher := search.New(store, pgStore.NewIndexer(db))
+	return newDatastoreImpl(store, searcher, indicators, processFilter), nil
 }
 
 // GetTestPostgresDataStore provides a datastore connected to postgres for testing purposes.

--- a/central/pod/datastore/datastore_impl.go
+++ b/central/pod/datastore/datastore_impl.go
@@ -8,7 +8,6 @@ import (
 	"github.com/stackrox/rox/central/globaldb"
 	"github.com/stackrox/rox/central/metrics"
 	podSearch "github.com/stackrox/rox/central/pod/datastore/internal/search"
-	podIndex "github.com/stackrox/rox/central/pod/index"
 	podStore "github.com/stackrox/rox/central/pod/store"
 	piDS "github.com/stackrox/rox/central/processindicator/datastore"
 	"github.com/stackrox/rox/central/role/resources"
@@ -33,7 +32,6 @@ var (
 
 type datastoreImpl struct {
 	podStore    podStore.Store
-	podIndexer  podIndex.Indexer
 	podSearcher podSearch.Searcher
 
 	indicators    piDS.DataStore
@@ -42,17 +40,14 @@ type datastoreImpl struct {
 	keyedMutex *concurrency.KeyedMutex
 }
 
-func newDatastoreImpl(storage podStore.Store, indexer podIndex.Indexer, searcher podSearch.Searcher,
-	indicators piDS.DataStore, processFilter filter.Filter) (*datastoreImpl, error) {
-	ds := &datastoreImpl{
+func newDatastoreImpl(storage podStore.Store, searcher podSearch.Searcher, indicators piDS.DataStore, processFilter filter.Filter) *datastoreImpl {
+	return &datastoreImpl{
 		podStore:      storage,
-		podIndexer:    indexer,
 		podSearcher:   searcher,
 		indicators:    indicators,
 		processFilter: processFilter,
 		keyedMutex:    concurrency.NewKeyedMutex(globaldb.DefaultDataStorePoolSize),
 	}
-	return ds, nil
 }
 
 func (ds *datastoreImpl) Search(ctx context.Context, q *v1.Query) ([]pkgSearch.Result, error) {

--- a/central/pod/datastore/datastore_impl_test.go
+++ b/central/pod/datastore/datastore_impl_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/pkg/errors"
 	searcherMocks "github.com/stackrox/rox/central/pod/datastore/internal/search/mocks"
-	indexerMocks "github.com/stackrox/rox/central/pod/index/mocks"
 	storeMocks "github.com/stackrox/rox/central/pod/store/mocks"
 	indicatorMocks "github.com/stackrox/rox/central/processindicator/datastore/mocks"
 	"github.com/stackrox/rox/generated/storage"
@@ -33,7 +32,6 @@ type PodDataStoreTestSuite struct {
 	datastore *datastoreImpl
 
 	storage      *storeMocks.MockStore
-	indexer      *indexerMocks.MockIndexer
 	searcher     *searcherMocks.MockSearcher
 	processStore *indicatorMocks.MockDataStore
 	filter       filter.Filter
@@ -45,14 +43,11 @@ func (suite *PodDataStoreTestSuite) SetupTest() {
 	mockCtrl := gomock.NewController(suite.T())
 	suite.mockCtrl = mockCtrl
 	suite.storage = storeMocks.NewMockStore(mockCtrl)
-	suite.indexer = indexerMocks.NewMockIndexer(mockCtrl)
 	suite.searcher = searcherMocks.NewMockSearcher(mockCtrl)
 	suite.processStore = indicatorMocks.NewMockDataStore(mockCtrl)
 	suite.filter = filter.NewFilter(5, 5, []int{5, 4, 3, 2, 1})
 
-	var err error
-	suite.datastore, err = newDatastoreImpl(suite.storage, suite.indexer, suite.searcher, suite.processStore, suite.filter)
-	suite.NoError(err)
+	suite.datastore = newDatastoreImpl(suite.storage, suite.searcher, suite.processStore, suite.filter)
 }
 
 func (suite *PodDataStoreTestSuite) TearDownTest() {

--- a/central/policy/datastore/datastore.go
+++ b/central/policy/datastore/datastore.go
@@ -5,7 +5,6 @@ import (
 
 	clusterDS "github.com/stackrox/rox/central/cluster/datastore"
 	notifierDS "github.com/stackrox/rox/central/notifier/datastore"
-	"github.com/stackrox/rox/central/policy/index"
 	"github.com/stackrox/rox/central/policy/search"
 	"github.com/stackrox/rox/central/policy/store"
 	"github.com/stackrox/rox/central/policy/store/boltdb"
@@ -37,14 +36,13 @@ type DataStore interface {
 	ImportPolicies(ctx context.Context, policies []*storage.Policy, overwrite bool) (responses []*v1.ImportPolicyResponse, allSucceeded bool, err error)
 }
 
-// New returns a new instance of DataStore using the input store, indexer, and searcher.
-func New(storage store.Store, indexer index.Indexer, searcher search.Searcher,
+// New returns a new instance of DataStore using the input store, and searcher.
+func New(storage store.Store, searcher search.Searcher,
 	clusterDatastore clusterDS.DataStore,
 	notifierDatastore notifierDS.DataStore,
 	categoriesDatastore categoriesDataStore.DataStore) DataStore {
 	ds := &datastoreImpl{
 		storage:             storage,
-		indexer:             indexer,
 		searcher:            searcher,
 		clusterDatastore:    clusterDatastore,
 		notifierDatastore:   notifierDatastore,
@@ -54,12 +52,11 @@ func New(storage store.Store, indexer index.Indexer, searcher search.Searcher,
 }
 
 // newWithoutDefaults should be used only for testing purposes.
-func newWithoutDefaults(storage boltdb.Store, indexer index.Indexer,
+func newWithoutDefaults(storage boltdb.Store,
 	searcher search.Searcher, clusterDatastore clusterDS.DataStore, notifierDatastore notifierDS.DataStore,
 	categoriesDatastore categoriesDataStore.DataStore) DataStore {
 	return &datastoreImpl{
 		storage:             storage,
-		indexer:             indexer,
 		searcher:            searcher,
 		clusterDatastore:    clusterDatastore,
 		notifierDatastore:   notifierDatastore,

--- a/central/policy/datastore/datastore_impl.go
+++ b/central/policy/datastore/datastore_impl.go
@@ -8,7 +8,6 @@ import (
 	errorsPkg "github.com/pkg/errors"
 	clusterDS "github.com/stackrox/rox/central/cluster/datastore"
 	notifierDS "github.com/stackrox/rox/central/notifier/datastore"
-	"github.com/stackrox/rox/central/policy/index"
 	"github.com/stackrox/rox/central/policy/search"
 	"github.com/stackrox/rox/central/policy/store"
 	"github.com/stackrox/rox/central/policy/store/boltdb"
@@ -39,7 +38,6 @@ var (
 
 type datastoreImpl struct {
 	storage     store.Store
-	indexer     index.Indexer
 	searcher    search.Searcher
 	policyMutex sync.Mutex
 

--- a/central/policy/datastore/datastore_impl_postgres_test.go
+++ b/central/policy/datastore/datastore_impl_postgres_test.go
@@ -77,11 +77,11 @@ func (s *PolicyPostgresDataStoreTestSuite) SetupTest() {
 	edgeIndex := edgePostgres.NewIndexer(s.db)
 	edgeSearcher := edgeSearch.New(edgeStorage, edgeIndex)
 
-	s.categoryDS = policyCategoryDS.New(categoryStorage, categoryIndex, categorySearcher, policyCategoryEdgeDS.New(edgeStorage, edgeIndex, edgeSearcher))
+	s.categoryDS = policyCategoryDS.New(categoryStorage, categorySearcher, policyCategoryEdgeDS.New(edgeStorage, edgeSearcher))
 
 	policyStore := pgStore.CreateTableAndNewStore(s.ctx, s.db, s.gormDB)
 	policyIndex := pgStore.NewIndexer(s.db)
-	s.datastore = New(policyStore, policyIndex, search.New(policyStore, policyIndex), s.mockClusterDS, s.mockNotifierDS, s.categoryDS)
+	s.datastore = New(policyStore, search.New(policyStore, policyIndex), s.mockClusterDS, s.mockNotifierDS, s.categoryDS)
 
 }
 

--- a/central/policy/datastore/datastore_impl_test.go
+++ b/central/policy/datastore/datastore_impl_test.go
@@ -54,7 +54,7 @@ func (s *PolicyDatastoreTestSuite) SetupTest() {
 	s.notifierDatastore = notifierMocks.NewMockDataStore(s.mockCtrl)
 	s.categoriesDatastore = categoriesMocks.NewMockDataStore(s.mockCtrl)
 
-	s.datastore = newWithoutDefaults(s.store, s.indexer, nil, s.clusterDatastore, s.notifierDatastore, s.categoriesDatastore)
+	s.datastore = newWithoutDefaults(s.store, nil, s.clusterDatastore, s.notifierDatastore, s.categoriesDatastore)
 
 	s.hasReadWriteWorkflowAdministrationAccess = sac.WithGlobalAccessScopeChecker(context.Background(),
 		sac.AllowFixedScopes(

--- a/central/policy/datastore/singleton.go
+++ b/central/policy/datastore/singleton.go
@@ -27,17 +27,14 @@ var (
 
 func initialize() {
 	storage := policyPostgres.New(globaldb.GetPostgres())
-	indexer := policyPostgres.NewIndexer(globaldb.GetPostgres())
-	searcher := search.New(storage, indexer)
+	searcher := search.New(storage, policyPostgres.NewIndexer(globaldb.GetPostgres()))
 
 	clusterDatastore := clusterDS.Singleton()
 	notifierDatastore := notifierDS.Singleton()
 	categoriesDatastore := categoriesDS.Singleton()
 
-	ad = New(storage, indexer, searcher, clusterDatastore, notifierDatastore, categoriesDatastore)
-	if env.PostgresDatastoreEnabled.BooleanSetting() {
-		addDefaults(storage, categoriesDatastore)
-	}
+	ad = New(storage, searcher, clusterDatastore, notifierDatastore, categoriesDatastore)
+	addDefaults(storage, categoriesDatastore)
 }
 
 // Singleton provides the interface for non-service external interaction.

--- a/central/policycategory/datastore/datastore.go
+++ b/central/policycategory/datastore/datastore.go
@@ -3,7 +3,6 @@ package datastore
 import (
 	"context"
 
-	"github.com/stackrox/rox/central/policycategory/index"
 	"github.com/stackrox/rox/central/policycategory/search"
 	"github.com/stackrox/rox/central/policycategory/store"
 	categoryUtils "github.com/stackrox/rox/central/policycategory/utils"
@@ -33,11 +32,10 @@ type DataStore interface {
 	DeletePolicyCategory(ctx context.Context, id string) error
 }
 
-// New returns a new instance of DataStore using the input store, indexer, and searcher.
-func New(store store.Store, indexer index.Indexer, searcher search.Searcher, policyCategoryEdgeDS policyCategoryEdgeDS.DataStore) DataStore {
+// New returns a new instance of DataStore using the input store, and searcher.
+func New(store store.Store, searcher search.Searcher, policyCategoryEdgeDS policyCategoryEdgeDS.DataStore) DataStore {
 	ds := &datastoreImpl{
 		storage:              store,
-		indexer:              indexer,
 		searcher:             searcher,
 		policyCategoryEdgeDS: policyCategoryEdgeDS,
 		categoryNameIDMap:    make(map[string]string, 0),
@@ -57,10 +55,9 @@ func New(store store.Store, indexer index.Indexer, searcher search.Searcher, pol
 }
 
 // newWithoutDefaults should be used only for testing purposes.
-func newWithoutDefaults(store store.Store, indexer index.Indexer, searcher search.Searcher, policyCategoryEdgeDS policyCategoryEdgeDS.DataStore) DataStore {
+func newWithoutDefaults(store store.Store, searcher search.Searcher, policyCategoryEdgeDS policyCategoryEdgeDS.DataStore) DataStore {
 	return &datastoreImpl{
 		storage:              store,
-		indexer:              indexer,
 		searcher:             searcher,
 		policyCategoryEdgeDS: policyCategoryEdgeDS,
 		categoryNameIDMap:    make(map[string]string, 0),

--- a/central/policycategory/datastore/datastore_impl.go
+++ b/central/policycategory/datastore/datastore_impl.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	errorsPkg "github.com/pkg/errors"
-	"github.com/stackrox/rox/central/policycategory/index"
 	"github.com/stackrox/rox/central/policycategory/search"
 	"github.com/stackrox/rox/central/policycategory/store"
 	"github.com/stackrox/rox/central/policycategoryedge/datastore"
@@ -35,7 +34,6 @@ var (
 
 type datastoreImpl struct {
 	storage              store.Store
-	indexer              index.Indexer
 	searcher             search.Searcher
 	policyCategoryEdgeDS datastore.DataStore
 	categoryMutex        sync.Mutex
@@ -188,7 +186,7 @@ func (ds *datastoreImpl) GetAllPolicyCategories(ctx context.Context) ([]*storage
 	return categories, nil
 }
 
-// AddPolicyCategory inserts a policy category into the storage and the indexer
+// AddPolicyCategory inserts a policy category into the storage.
 func (ds *datastoreImpl) AddPolicyCategory(ctx context.Context, category *storage.PolicyCategory) (*storage.PolicyCategory, error) {
 	if ok, err := policyCategorySAC.WriteAllowed(ctx); err != nil {
 		return nil, err
@@ -254,7 +252,7 @@ func (ds *datastoreImpl) RenamePolicyCategory(ctx context.Context, id, newName s
 	}, nil
 }
 
-// DeletePolicyCategory removes a policy from the storage and the indexer
+// DeletePolicyCategory removes a policy from the storage
 func (ds *datastoreImpl) DeletePolicyCategory(ctx context.Context, id string) error {
 	if ok, err := policyCategorySAC.WriteAllowed(ctx); err != nil {
 		return err

--- a/central/policycategory/datastore/datastore_impl_postgres_test.go
+++ b/central/policycategory/datastore/datastore_impl_postgres_test.go
@@ -56,12 +56,11 @@ func (s *PolicyCategoryPostgresDataStoreTestSuite) SetupTest() {
 	policyCategoryEdgeStorage := policyCategoryEdgePostgres.CreateTableAndNewStore(s.ctx, s.db, s.gormDB)
 	policyCategoryEdgeIndexer := policyCategoryEdgePostgres.NewIndexer(s.db)
 	policyCategorySearcher := policyCategoryEdgeSearch.New(policyCategoryEdgeStorage, policyCategoryEdgeIndexer)
-	s.edgeDatastore = edgeDataStore.New(policyCategoryEdgeStorage, policyCategoryEdgeIndexer, policyCategorySearcher)
+	s.edgeDatastore = edgeDataStore.New(policyCategoryEdgeStorage, policyCategorySearcher)
 
 	policyCategoryStore := pgStore.CreateTableAndNewStore(s.ctx, s.db, s.gormDB)
 	policyCategoryIndexer := pgStore.NewIndexer(s.db)
-	s.datastore = New(policyCategoryStore, policyCategoryIndexer,
-		policyCategorySearch.New(policyCategoryStore, policyCategoryIndexer), s.edgeDatastore)
+	s.datastore = New(policyCategoryStore, policyCategorySearch.New(policyCategoryStore, policyCategoryIndexer), s.edgeDatastore)
 }
 
 func (s *PolicyCategoryPostgresDataStoreTestSuite) TearDownSuite() {

--- a/central/policycategory/datastore/datastore_impl_test.go
+++ b/central/policycategory/datastore/datastore_impl_test.go
@@ -39,7 +39,7 @@ func (s *PolicyCategoryDatastoreTestSuite) SetupTest() {
 	s.indexer = indexMocks.NewMockIndexer(s.mockCtrl)
 	s.edgeDataStore = policyCategoryEdgeDSMocks.NewMockDataStore(s.mockCtrl)
 
-	s.datastore = newWithoutDefaults(s.store, s.indexer, nil, s.edgeDataStore)
+	s.datastore = newWithoutDefaults(s.store, nil, s.edgeDataStore)
 
 	s.hasReadWriteWorkflowAdministrationCtx = sac.WithGlobalAccessScopeChecker(context.Background(),
 		sac.AllowFixedScopes(

--- a/central/policycategory/datastore/singleton.go
+++ b/central/policycategory/datastore/singleton.go
@@ -35,7 +35,7 @@ func initialize() {
 
 	addDefaults(store)
 	searcher := search.New(store, indexer)
-	ad = New(store, indexer, searcher, policyCategoryEdgeDS.Singleton())
+	ad = New(store, searcher, policyCategoryEdgeDS.Singleton())
 
 }
 

--- a/central/policycategoryedge/datastore/datastore.go
+++ b/central/policycategoryedge/datastore/datastore.go
@@ -3,7 +3,6 @@ package datastore
 import (
 	"context"
 
-	"github.com/stackrox/rox/central/policycategoryedge/index"
 	"github.com/stackrox/rox/central/policycategoryedge/search"
 	"github.com/stackrox/rox/central/policycategoryedge/store"
 	v1 "github.com/stackrox/rox/generated/api/v1"
@@ -33,10 +32,9 @@ type DataStore interface {
 }
 
 // New returns a new instance of a DataStore.
-func New(storage store.Store, indexer index.Indexer, searcher search.Searcher) DataStore {
+func New(storage store.Store, searcher search.Searcher) DataStore {
 	ds := &datastoreImpl{
 		storage:  storage,
-		indexer:  indexer,
 		searcher: searcher,
 	}
 	return ds

--- a/central/policycategoryedge/datastore/datastore_impl.go
+++ b/central/policycategoryedge/datastore/datastore_impl.go
@@ -3,7 +3,6 @@ package datastore
 import (
 	"context"
 
-	"github.com/stackrox/rox/central/policycategoryedge/index"
 	"github.com/stackrox/rox/central/policycategoryedge/search"
 	"github.com/stackrox/rox/central/policycategoryedge/store"
 	"github.com/stackrox/rox/central/role/resources"
@@ -20,7 +19,6 @@ var (
 
 type datastoreImpl struct {
 	storage  store.Store
-	indexer  index.Indexer
 	searcher search.Searcher
 
 	mutex sync.Mutex

--- a/central/policycategoryedge/datastore/singleton.go
+++ b/central/policycategoryedge/datastore/singleton.go
@@ -2,11 +2,8 @@ package datastore
 
 import (
 	"github.com/stackrox/rox/central/globaldb"
-	"github.com/stackrox/rox/central/policycategoryedge/index"
 	"github.com/stackrox/rox/central/policycategoryedge/search"
-	"github.com/stackrox/rox/central/policycategoryedge/store"
 	pgStore "github.com/stackrox/rox/central/policycategoryedge/store/postgres"
-	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/sync"
 )
 
@@ -17,14 +14,8 @@ var (
 )
 
 func initialize() {
-	var storage store.Store
-	var indexer index.Indexer
-
-	if env.PostgresDatastoreEnabled.BooleanSetting() {
-		storage = pgStore.New(globaldb.GetPostgres())
-		indexer = pgStore.NewIndexer(globaldb.GetPostgres())
-		ds = New(storage, indexer, search.New(storage, indexer))
-	}
+	storage := pgStore.New(globaldb.GetPostgres())
+	ds = New(storage, search.New(storage, pgStore.NewIndexer(globaldb.GetPostgres())))
 }
 
 // Singleton provides the interface for non-service external interaction.

--- a/central/processbaseline/datastore/datastore.go
+++ b/central/processbaseline/datastore/datastore.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/stackrox/rox/central/globaldb"
-	"github.com/stackrox/rox/central/processbaseline/index"
 	"github.com/stackrox/rox/central/processbaseline/search"
 	"github.com/stackrox/rox/central/processbaseline/store"
 	pgStore "github.com/stackrox/rox/central/processbaseline/store/postgres"
@@ -19,7 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// DataStore wraps storage, indexer, and searcher for ProcessBaselines.
+// DataStore wraps storage, and searcher for ProcessBaselines.
 //
 //go:generate mockgen-wrapper
 type DataStore interface {
@@ -43,11 +42,10 @@ type DataStore interface {
 	ClearProcessBaselines(ctx context.Context, ids []string) error
 }
 
-// New returns a new instance of DataStore using the input store, indexer, and searcher.
-func New(storage store.Store, indexer index.Indexer, searcher search.Searcher, processBaselineResults datastore.DataStore, processIndicators processIndicatorDatastore.DataStore) DataStore {
+// New returns a new instance of DataStore using the input store, and searcher.
+func New(storage store.Store, searcher search.Searcher, processBaselineResults datastore.DataStore, processIndicators processIndicatorDatastore.DataStore) DataStore {
 	d := &datastoreImpl{
 		storage:                storage,
-		indexer:                indexer,
 		searcher:               searcher,
 		baselineLock:           concurrency.NewKeyedMutex(globaldb.DefaultDataStorePoolSize),
 		processBaselineResults: processBaselineResults,
@@ -74,5 +72,5 @@ func GetTestPostgresDataStore(t testing.TB, pool postgres.DB) (DataStore, error)
 	if err != nil {
 		return nil, err
 	}
-	return New(store, indexer, searcher, resultsStore, indicatorStore), nil
+	return New(store, searcher, resultsStore, indicatorStore), nil
 }

--- a/central/processbaseline/datastore/datastore_impl.go
+++ b/central/processbaseline/datastore/datastore_impl.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/gogo/protobuf/types"
 	"github.com/pkg/errors"
-	"github.com/stackrox/rox/central/processbaseline/index"
 	"github.com/stackrox/rox/central/processbaseline/search"
 	"github.com/stackrox/rox/central/processbaseline/store"
 	processBaselineResultsStore "github.com/stackrox/rox/central/processbaselineresults/datastore"
@@ -30,7 +29,6 @@ var (
 
 type datastoreImpl struct {
 	storage      store.Store
-	indexer      index.Indexer
 	searcher     search.Searcher
 	baselineLock *concurrency.KeyedMutex
 
@@ -125,7 +123,7 @@ func (ds *datastoreImpl) RemoveProcessBaseline(ctx context.Context, key *storage
 	// Delete process baseline results if this is the last process baseline with the given deploymentID
 	deploymentID := key.GetDeploymentId()
 	q := pkgSearch.NewQueryBuilder().AddExactMatches(pkgSearch.DeploymentID, deploymentID).ProtoQuery()
-	results, err := ds.indexer.Search(ctx, q)
+	results, err := ds.searcher.Search(ctx, q)
 	if err != nil {
 		return errors.Wrapf(err, "failed to query for deployment %s during process baseline deletion", deploymentID)
 	}
@@ -143,7 +141,7 @@ func (ds *datastoreImpl) RemoveProcessBaselinesByDeployment(ctx context.Context,
 	}
 
 	query := pkgSearch.NewQueryBuilder().AddExactMatches(pkgSearch.DeploymentID, deploymentID).ProtoQuery()
-	results, err := ds.indexer.Search(ctx, query)
+	results, err := ds.searcher.Search(ctx, query)
 	if err != nil {
 		return err
 	}
@@ -237,8 +235,6 @@ func (ds *datastoreImpl) updateProcessBaselineElements(ctx context.Context, base
 		return nil, err
 	}
 
-	// no need to index the process baseline here because the only indexed things are
-	// top level fields that are immutable
 	return baseline, nil
 }
 

--- a/central/processbaseline/datastore/datastore_impl_test.go
+++ b/central/processbaseline/datastore/datastore_impl_test.go
@@ -72,7 +72,7 @@ func (suite *ProcessBaselineDataStoreTestSuite) SetupTest() {
 
 	suite.baselineResultsStore = mocks.NewMockDataStore(suite.mockCtrl)
 	suite.indicatorMockStore = indicatorMocks.NewMockDataStore(suite.mockCtrl)
-	suite.datastore = New(suite.storage, suite.indexer, suite.searcher, suite.baselineResultsStore, suite.indicatorMockStore)
+	suite.datastore = New(suite.storage, suite.searcher, suite.baselineResultsStore, suite.indicatorMockStore)
 }
 
 func (suite *ProcessBaselineDataStoreTestSuite) TearDownTest() {

--- a/central/processbaseline/datastore/singleton.go
+++ b/central/processbaseline/datastore/singleton.go
@@ -23,14 +23,13 @@ func initialize() {
 	if err != nil {
 		log.Fatal("failed to open process baseline store")
 	}
-	indexer := pgStore.NewIndexer(globaldb.GetPostgres())
 
-	searcher, err := search.New(storage, indexer)
+	searcher, err := search.New(storage, pgStore.NewIndexer(globaldb.GetPostgres()))
 	if err != nil {
 		panic("unable to load search index for process baseline")
 	}
 
-	ad = New(storage, indexer, searcher, datastore.Singleton(), indicatorStore.Singleton())
+	ad = New(storage, searcher, datastore.Singleton(), indicatorStore.Singleton())
 }
 
 // Singleton provides the interface for non-service external interaction.

--- a/central/processbaseline/service/service_impl_test.go
+++ b/central/processbaseline/service/service_impl_test.go
@@ -118,7 +118,7 @@ func (suite *ProcessBaselineServiceTestSuite) SetupTest() {
 	suite.resultDatastore.EXPECT().DeleteBaselineResults(gomock.Any(), gomock.Any()).AnyTimes()
 
 	suite.indicatorMockStore = indicatorMocks.NewMockDataStore(suite.mockCtrl)
-	suite.datastore = datastore.New(store, indexer, searcher, suite.resultDatastore, suite.indicatorMockStore)
+	suite.datastore = datastore.New(store, searcher, suite.resultDatastore, suite.indicatorMockStore)
 	suite.reprocessor = mocks.NewMockLoop(suite.mockCtrl)
 	suite.connectionMgr = connectionMocks.NewMockManager(suite.mockCtrl)
 	suite.deployments = deploymentMocks.NewMockDataStore(suite.mockCtrl)

--- a/central/processbaselineresults/datastore/datastore.go
+++ b/central/processbaselineresults/datastore/datastore.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stackrox/rox/pkg/postgres"
 )
 
-// DataStore wraps storage, indexer, and searcher for ProcessBaselineResults.
+// DataStore wraps storage, and searcher for ProcessBaselineResults.
 //
 //go:generate mockgen-wrapper
 type DataStore interface {

--- a/central/processindicator/datastore/bench_test.go
+++ b/central/processindicator/datastore/bench_test.go
@@ -29,7 +29,7 @@ func BenchmarkAddIndicator(b *testing.B) {
 	indexer := postgresStore.NewIndexer(db)
 	searcher := search.New(store, indexer)
 
-	datastore, err := New(store, plopStore, indexer, searcher, nil)
+	datastore, err := New(store, plopStore, searcher, nil)
 	require.NoError(b, err)
 
 	ctx := sac.WithAllAccess(context.Background())

--- a/central/processindicator/datastore/datastore.go
+++ b/central/processindicator/datastore/datastore.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/stackrox/rox/central/processindicator"
-	"github.com/stackrox/rox/central/processindicator/index"
 	"github.com/stackrox/rox/central/processindicator/pruner"
 	"github.com/stackrox/rox/central/processindicator/search"
 	"github.com/stackrox/rox/central/processindicator/store"
@@ -44,12 +43,11 @@ type DataStore interface {
 	Wait(cancelWhen concurrency.Waitable) bool
 }
 
-// New returns a new instance of DataStore using the input store, indexer, and searcher.
-func New(store store.Store, plopStorage plopStore.Store, indexer index.Indexer, searcher search.Searcher, prunerFactory pruner.Factory) (DataStore, error) {
+// New returns a new instance of DataStore using the input store, and searcher.
+func New(store store.Store, plopStorage plopStore.Store, searcher search.Searcher, prunerFactory pruner.Factory) (DataStore, error) {
 	d := &datastoreImpl{
 		storage:               store,
 		plopStorage:           plopStorage,
-		indexer:               indexer,
 		searcher:              searcher,
 		prunerFactory:         prunerFactory,
 		prunedArgsLengthCache: make(map[processindicator.ProcessWithContainerInfo]int),
@@ -69,5 +67,5 @@ func GetTestPostgresDataStore(_ testing.TB, pool postgres.DB) (DataStore, error)
 	plopDBstore := plopStore.New(pool)
 	indexer := pgStore.NewIndexer(pool)
 	searcher := search.New(dbstore, indexer)
-	return New(dbstore, plopDBstore, indexer, searcher, nil)
+	return New(dbstore, plopDBstore, searcher, nil)
 }

--- a/central/processindicator/datastore/datastore_impl.go
+++ b/central/processindicator/datastore/datastore_impl.go
@@ -7,7 +7,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/central/metrics"
 	"github.com/stackrox/rox/central/processindicator"
-	"github.com/stackrox/rox/central/processindicator/index"
 	"github.com/stackrox/rox/central/processindicator/pruner"
 	"github.com/stackrox/rox/central/processindicator/search"
 	"github.com/stackrox/rox/central/processindicator/store"
@@ -35,7 +34,6 @@ type datastoreImpl struct {
 	// logically belongs to the datastore implementation of PLOP, but this way
 	// it would be an import cycle, so call the Store directly.
 	plopStorage plopStore.Store
-	indexer     index.Indexer
 	searcher    search.Searcher
 
 	prunerFactory         pruner.Factory

--- a/central/processindicator/datastore/singleton.go
+++ b/central/processindicator/datastore/singleton.go
@@ -30,13 +30,12 @@ var (
 func initialize() {
 	storage := pgStore.New(globaldb.GetPostgres())
 	plopStorage := plopStore.New(globaldb.GetPostgres())
-	indexer := pgStore.NewIndexer(globaldb.GetPostgres())
-	searcher := search.New(storage, indexer)
+	searcher := search.New(storage, pgStore.NewIndexer(globaldb.GetPostgres()))
 
 	p := pruner.NewFactory(minArgsPerProcess, pruneInterval)
 
 	var err error
-	ad, err = New(storage, plopStorage, indexer, searcher, p)
+	ad, err = New(storage, plopStorage, searcher, p)
 	utils.CrashOnError(errors.Wrap(err, "unable to load datastore for process indicators"))
 }
 

--- a/central/processlisteningonport/datastore/datastore_impl_test.go
+++ b/central/processlisteningonport/datastore/datastore_impl_test.go
@@ -65,7 +65,7 @@ func (suite *PLOPDataStoreTestSuite) SetupTest() {
 	indicatorSearcher := processIndicatorSearch.New(indicatorStorage, indicatorIndexer)
 
 	suite.indicatorDataStore, _ = processIndicatorDataStore.New(
-		indicatorStorage, suite.store, indicatorIndexer, indicatorSearcher, nil)
+		indicatorStorage, suite.store, indicatorSearcher, nil)
 	suite.datastore = New(suite.store, suite.indicatorDataStore)
 }
 

--- a/central/pruning/pruning_test.go
+++ b/central/pruning/pruning_test.go
@@ -275,7 +275,6 @@ func (s *PruningTestSuite) generateNodeDataStructures() testNodeDatastore.DataSt
 
 	nodes := testNodeDatastore.NewWithPostgres(
 		nodeStore,
-		nodeIndexer,
 		nodeSearch.NewV2(nodeStore, nodeIndexer),
 		mockRiskDatastore,
 		ranking.NewRanker(),
@@ -1853,8 +1852,7 @@ func (s *PruningTestSuite) TestRemoveOrphanedRBACObjects() {
 		s.T().Run(c.name, func(t *testing.T) {
 			serviceAccounts, err := serviceAccountDataStore.GetTestPostgresDataStore(t, s.pool)
 			assert.NoError(t, err)
-			k8sRoles, err := k8sRoleDataStore.GetTestPostgresDataStore(t, s.pool)
-			assert.NoError(t, err)
+			k8sRoles := k8sRoleDataStore.GetTestPostgresDataStore(t, s.pool)
 			k8sRoleBindings, err := k8sRoleBindingDataStore.GetTestPostgresDataStore(t, s.pool)
 			assert.NoError(t, err)
 

--- a/central/rbac/k8srole/datastore/datastore.go
+++ b/central/rbac/k8srole/datastore/datastore.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stackrox/rox/central/rbac/k8srole/internal/index"
 	"github.com/stackrox/rox/central/rbac/k8srole/internal/store"
 	pgStore "github.com/stackrox/rox/central/rbac/k8srole/internal/store/postgres"
 	"github.com/stackrox/rox/central/rbac/k8srole/search"
@@ -28,20 +27,17 @@ type DataStore interface {
 	RemoveRole(ctx context.Context, id string) error
 }
 
-// New returns a new instance of DataStore using the input store, indexer, and searcher.
-func New(k8sRoleStore store.Store, indexer index.Indexer, searcher search.Searcher) (DataStore, error) {
-	d := &datastoreImpl{
+// New returns a new instance of DataStore using the input store, and searcher.
+func New(k8sRoleStore store.Store, searcher search.Searcher) DataStore {
+	return &datastoreImpl{
 		storage:  k8sRoleStore,
-		indexer:  indexer,
 		searcher: searcher,
 	}
-	return d, nil
 }
 
 // GetTestPostgresDataStore provides a datastore connected to postgres for testing purposes.
-func GetTestPostgresDataStore(_ *testing.T, pool postgres.DB) (DataStore, error) {
+func GetTestPostgresDataStore(_ *testing.T, pool postgres.DB) DataStore {
 	dbstore := pgStore.New(pool)
-	indexer := pgStore.NewIndexer(pool)
-	searcher := search.New(dbstore, indexer)
-	return New(dbstore, indexer, searcher)
+	searcher := search.New(dbstore, pgStore.NewIndexer(pool))
+	return New(dbstore, searcher)
 }

--- a/central/rbac/k8srole/datastore/datastore_impl.go
+++ b/central/rbac/k8srole/datastore/datastore_impl.go
@@ -3,7 +3,6 @@ package datastore
 import (
 	"context"
 
-	"github.com/stackrox/rox/central/rbac/k8srole/internal/index"
 	"github.com/stackrox/rox/central/rbac/k8srole/internal/store"
 	"github.com/stackrox/rox/central/rbac/k8srole/search"
 	"github.com/stackrox/rox/central/role/resources"
@@ -13,17 +12,12 @@ import (
 	searchPkg "github.com/stackrox/rox/pkg/search"
 )
 
-const (
-	batchSize = 1000
-)
-
 var (
 	k8sRolesSAC = sac.ForResource(resources.K8sRole)
 )
 
 type datastoreImpl struct {
 	storage  store.Store
-	indexer  index.Indexer
 	searcher search.Searcher
 }
 

--- a/central/rbac/k8srole/datastore/datastore_sac_test.go
+++ b/central/rbac/k8srole/datastore/datastore_sac_test.go
@@ -36,8 +36,6 @@ type k8sRoleSACSuite struct {
 }
 
 func (s *k8sRoleSACSuite) SetupSuite() {
-	var err error
-
 	pgtestbase := pgtest.ForT(s.T())
 	s.Require().NotNil(pgtestbase)
 	s.pool = pgtestbase.DB

--- a/central/rbac/k8srole/datastore/datastore_sac_test.go
+++ b/central/rbac/k8srole/datastore/datastore_sac_test.go
@@ -41,8 +41,7 @@ func (s *k8sRoleSACSuite) SetupSuite() {
 	pgtestbase := pgtest.ForT(s.T())
 	s.Require().NotNil(pgtestbase)
 	s.pool = pgtestbase.DB
-	s.datastore, err = GetTestPostgresDataStore(s.T(), s.pool)
-	s.Require().NoError(err)
+	s.datastore = GetTestPostgresDataStore(s.T(), s.pool)
 	s.optionsMap = schema.K8sRolesSchema.OptionsMap
 
 	s.testContexts = testutils.GetNamespaceScopedTestContexts(context.Background(), s.T(),

--- a/central/rbac/k8srole/datastore/singleton.go
+++ b/central/rbac/k8srole/datastore/singleton.go
@@ -18,12 +18,7 @@ var (
 
 func initialize() {
 	storage := pgStore.New(globaldb.GetPostgres())
-	indexer := pgStore.NewIndexer(globaldb.GetPostgres())
-	var err error
-	ad, err = New(storage, indexer, search.New(storage, indexer))
-	if err != nil {
-		log.Panicf("Failed to initialize k8s role datastore: %s", err)
-	}
+	ad = New(storage, search.New(storage, pgStore.NewIndexer(globaldb.GetPostgres())))
 }
 
 // Singleton provides the interface for non-service external interaction.

--- a/central/rbac/k8srolebinding/datastore/datastore.go
+++ b/central/rbac/k8srolebinding/datastore/datastore.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stackrox/rox/central/rbac/k8srolebinding/internal/index"
 	"github.com/stackrox/rox/central/rbac/k8srolebinding/internal/store"
 	pgStore "github.com/stackrox/rox/central/rbac/k8srolebinding/internal/store/postgres"
 	"github.com/stackrox/rox/central/rbac/k8srolebinding/search"
@@ -28,11 +27,10 @@ type DataStore interface {
 	RemoveRoleBinding(ctx context.Context, id string) error
 }
 
-// New returns a new instance of DataStore using the input store, indexer, and searcher.
-func New(k8sRoleBindingStore store.Store, indexer index.Indexer, searcher search.Searcher) (DataStore, error) {
+// New returns a new instance of DataStore using the input store, and searcher.
+func New(k8sRoleBindingStore store.Store, searcher search.Searcher) (DataStore, error) {
 	d := &datastoreImpl{
 		storage:  k8sRoleBindingStore,
-		indexer:  indexer,
 		searcher: searcher,
 	}
 	return d, nil
@@ -43,5 +41,5 @@ func GetTestPostgresDataStore(_ *testing.T, pool postgres.DB) (DataStore, error)
 	dbstore := pgStore.New(pool)
 	indexer := pgStore.NewIndexer(pool)
 	searcher := search.New(dbstore, indexer)
-	return New(dbstore, indexer, searcher)
+	return New(dbstore, searcher)
 }

--- a/central/rbac/k8srolebinding/datastore/datastore_impl.go
+++ b/central/rbac/k8srolebinding/datastore/datastore_impl.go
@@ -3,7 +3,6 @@ package datastore
 import (
 	"context"
 
-	"github.com/stackrox/rox/central/rbac/k8srolebinding/internal/index"
 	"github.com/stackrox/rox/central/rbac/k8srolebinding/internal/store"
 	"github.com/stackrox/rox/central/rbac/k8srolebinding/search"
 	"github.com/stackrox/rox/central/role/resources"
@@ -13,17 +12,12 @@ import (
 	searchPkg "github.com/stackrox/rox/pkg/search"
 )
 
-const (
-	batchSize = 1000
-)
-
 var (
 	k8sRoleBindingsSAC = sac.ForResource(resources.K8sRoleBinding)
 )
 
 type datastoreImpl struct {
 	storage  store.Store
-	indexer  index.Indexer
 	searcher search.Searcher
 }
 

--- a/central/rbac/k8srolebinding/datastore/singleton.go
+++ b/central/rbac/k8srolebinding/datastore/singleton.go
@@ -18,9 +18,8 @@ var (
 
 func initialize() {
 	storage := pgStore.New(globaldb.GetPostgres())
-	indexer := pgStore.NewIndexer(globaldb.GetPostgres())
 	var err error
-	ad, err = New(storage, indexer, search.New(storage, indexer))
+	ad, err = New(storage, search.New(storage, pgStore.NewIndexer(globaldb.GetPostgres())))
 	if err != nil {
 		log.Panicf("Failed to initialize secrets datastore: %s", err)
 	}

--- a/central/reportconfigurations/datastore/datastore.go
+++ b/central/reportconfigurations/datastore/datastore.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stackrox/rox/central/reportconfigurations/index"
 	"github.com/stackrox/rox/central/reportconfigurations/search"
 	"github.com/stackrox/rox/central/reportconfigurations/store"
 	pgStore "github.com/stackrox/rox/central/reportconfigurations/store/postgres"
@@ -31,11 +30,10 @@ type DataStore interface {
 }
 
 // New returns a new DataStore instance.
-func New(reportConfigStore store.Store, indexer index.Indexer, searcher search.Searcher) (DataStore, error) {
+func New(reportConfigStore store.Store, searcher search.Searcher) (DataStore, error) {
 	d := &dataStoreImpl{
 		reportConfigStore: reportConfigStore,
 		searcher:          searcher,
-		indexer:           indexer,
 	}
 	return d, nil
 }
@@ -46,5 +44,5 @@ func GetTestPostgresDataStore(_ *testing.T, pool postgres.DB) (DataStore, error)
 	indexer := pgStore.NewIndexer(pool)
 	searcher := search.New(store, indexer)
 
-	return New(store, indexer, searcher)
+	return New(store, searcher)
 }

--- a/central/reportconfigurations/datastore/datastore_impl.go
+++ b/central/reportconfigurations/datastore/datastore_impl.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
-	"github.com/stackrox/rox/central/reportconfigurations/index"
 	"github.com/stackrox/rox/central/reportconfigurations/search"
 	"github.com/stackrox/rox/central/reportconfigurations/store"
 	"github.com/stackrox/rox/central/role/resources"
@@ -26,7 +25,6 @@ type dataStoreImpl struct {
 	reportConfigStore store.Store
 
 	searcher search.Searcher
-	indexer  index.Indexer
 }
 
 func (d *dataStoreImpl) Search(ctx context.Context, q *v1.Query) ([]searchPkg.Result, error) {

--- a/central/reportconfigurations/datastore/singleton.go
+++ b/central/reportconfigurations/datastore/singleton.go
@@ -17,9 +17,8 @@ func Singleton() DataStore {
 	once.Do(func() {
 		var err error
 		storage := pgStore.New(globaldb.GetPostgres())
-		indexer := pgStore.NewIndexer(globaldb.GetPostgres())
 
-		ds, err = New(storage, indexer, search.New(storage, indexer))
+		ds, err = New(storage, search.New(storage, pgStore.NewIndexer(globaldb.GetPostgres())))
 		if err != nil {
 			log.Panicf("Failed to initialize report configurations datastore: %s", err)
 		}

--- a/central/reports/scheduler/vuln_report_collections_test.go
+++ b/central/reports/scheduler/vuln_report_collections_test.go
@@ -72,7 +72,7 @@ func (s *ReportingWithCollectionsTestSuite) SetupSuite() {
 	var err error
 	collectionStore := collectionPostgres.CreateTableAndNewStore(s.ctx, s.testDB.DB, s.testDB.GetGormDB(s.T()))
 	index := collectionPostgres.NewIndexer(s.testDB.DB)
-	s.collectionDatastore, s.collectionQueryResolver, err = collectionDS.New(collectionStore, index, collectionSearch.New(collectionStore, index))
+	s.collectionDatastore, s.collectionQueryResolver, err = collectionDS.New(collectionStore, collectionSearch.New(collectionStore, index))
 	s.NoError(err)
 
 	s.reportScheduler = newSchedulerImpl(nil, nil, nil, nil,

--- a/central/resourcecollection/datastore/datastore.go
+++ b/central/resourcecollection/datastore/datastore.go
@@ -3,7 +3,6 @@ package datastore
 import (
 	"context"
 
-	"github.com/stackrox/rox/central/resourcecollection/datastore/index"
 	"github.com/stackrox/rox/central/resourcecollection/datastore/search"
 	"github.com/stackrox/rox/central/resourcecollection/datastore/store"
 	v1 "github.com/stackrox/rox/generated/api/v1"
@@ -67,10 +66,9 @@ func GetSupportedFieldLabels() []pkgSearch.FieldLabel {
 }
 
 // New returns a new instance of a DataStore and a QueryResolver.
-func New(storage store.Store, indexer index.Indexer, searcher search.Searcher) (DataStore, QueryResolver, error) {
+func New(storage store.Store, searcher search.Searcher) (DataStore, QueryResolver, error) {
 	ds := &datastoreImpl{
 		storage:  storage,
-		indexer:  indexer,
 		searcher: searcher,
 	}
 

--- a/central/resourcecollection/datastore/datastore_bench_postgres_test.go
+++ b/central/resourcecollection/datastore/datastore_bench_postgres_test.go
@@ -37,7 +37,7 @@ func BenchmarkCollections(b *testing.B) {
 	pgStore.Destroy(ctx, db)
 	store := pgStore.CreateTableAndNewStore(ctx, db, gormDB)
 	index := pgStore.NewIndexer(db)
-	datastore, _, err := New(store, index, search.New(store, index))
+	datastore, _, err := New(store, search.New(store, index))
 	require.NoError(b, err)
 
 	numSeedObjects := 5000
@@ -104,7 +104,6 @@ func BenchmarkCollections(b *testing.B) {
 	// graphInit
 	dsImpl := &datastoreImpl{
 		storage:  store,
-		indexer:  index,
 		searcher: search.New(store, index),
 	}
 	b.Run("graphInit", func(b *testing.B) {

--- a/central/resourcecollection/datastore/datastore_impl.go
+++ b/central/resourcecollection/datastore/datastore_impl.go
@@ -10,7 +10,6 @@ import (
 	"github.com/heimdalr/dag"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/central/metrics"
-	"github.com/stackrox/rox/central/resourcecollection/datastore/index"
 	"github.com/stackrox/rox/central/resourcecollection/datastore/search"
 	"github.com/stackrox/rox/central/resourcecollection/datastore/store"
 	"github.com/stackrox/rox/central/role/resources"
@@ -38,7 +37,6 @@ var (
 
 type datastoreImpl struct {
 	storage  store.Store
-	indexer  index.Indexer
 	searcher search.Searcher
 
 	lock  sync.RWMutex

--- a/central/resourcecollection/datastore/datastore_impl_postgres_test.go
+++ b/central/resourcecollection/datastore/datastore_impl_postgres_test.go
@@ -55,7 +55,7 @@ func (s *CollectionPostgresDataStoreTestSuite) SetupSuite() {
 	s.gormDB = pgtest.OpenGormDB(s.T(), source)
 	s.store = pgStore.CreateTableAndNewStore(s.ctx, s.db, s.gormDB)
 	index := pgStore.NewIndexer(s.db)
-	s.datastore, s.qr, err = New(s.store, index, search.New(s.store, index))
+	s.datastore, s.qr, err = New(s.store, search.New(s.store, index))
 	s.NoError(err)
 }
 

--- a/central/resourcecollection/datastore/singleton.go
+++ b/central/resourcecollection/datastore/singleton.go
@@ -19,8 +19,7 @@ var (
 func initialize() {
 	var err error
 	storage := pgStore.New(globaldb.GetPostgres())
-	indexer := pgStore.NewIndexer(globaldb.GetPostgres())
-	ds, qr, err = New(storage, indexer, search.New(storage, indexer))
+	ds, qr, err = New(storage, search.New(storage, pgStore.NewIndexer(globaldb.GetPostgres())))
 	utils.CrashOnError(err)
 }
 

--- a/central/risk/datastore/datastore.go
+++ b/central/risk/datastore/datastore.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/stackrox/rox/central/ranking"
-	"github.com/stackrox/rox/central/risk/datastore/internal/index"
 	"github.com/stackrox/rox/central/risk/datastore/internal/search"
 	"github.com/stackrox/rox/central/risk/datastore/internal/store"
 	pgStore "github.com/stackrox/rox/central/risk/datastore/internal/store/postgres"
@@ -30,11 +29,10 @@ type DataStore interface {
 	RemoveRisk(ctx context.Context, subjectID string, subjectType storage.RiskSubjectType) error
 }
 
-// New returns a new instance of DataStore using the input store, indexer, and searcher.
-func New(riskStore store.Store, indexer index.Indexer, searcher search.Searcher) (DataStore, error) {
+// New returns a new instance of DataStore using the input store, and searcher.
+func New(riskStore store.Store, searcher search.Searcher) (DataStore, error) {
 	d := &datastoreImpl{
 		storage:  riskStore,
-		indexer:  indexer,
 		searcher: searcher,
 		entityTypeToRanker: map[string]*ranking.Ranker{
 			storage.RiskSubjectType_CLUSTER.String():   ranking.ClusterRanker(),
@@ -59,5 +57,5 @@ func GetTestPostgresDataStore(_ testing.TB, pool postgres.DB) (DataStore, error)
 	dbstore := pgStore.New(pool)
 	indexer := pgStore.NewIndexer(pool)
 	searcher := search.New(dbstore, indexer)
-	return New(dbstore, indexer, searcher)
+	return New(dbstore, searcher)
 }

--- a/central/risk/datastore/datastore_impl.go
+++ b/central/risk/datastore/datastore_impl.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/stackrox/rox/central/ranking"
-	"github.com/stackrox/rox/central/risk/datastore/internal/index"
 	"github.com/stackrox/rox/central/risk/datastore/internal/search"
 	"github.com/stackrox/rox/central/risk/datastore/internal/store"
 	"github.com/stackrox/rox/central/role/resources"
@@ -21,7 +20,6 @@ var (
 
 type datastoreImpl struct {
 	storage            store.Store
-	indexer            index.Indexer
 	searcher           search.Searcher
 	entityTypeToRanker map[string]*ranking.Ranker
 }

--- a/central/risk/datastore/singleton.go
+++ b/central/risk/datastore/singleton.go
@@ -18,9 +18,8 @@ var (
 
 func initialize() {
 	storage := pgStore.New(globaldb.GetPostgres())
-	indexer := pgStore.NewIndexer(globaldb.GetPostgres())
 	var err error
-	ad, err = New(storage, indexer, search.New(storage, indexer))
+	ad, err = New(storage, search.New(storage, pgStore.NewIndexer(globaldb.GetPostgres())))
 	if err != nil {
 		log.Panicf("Failed to initialize risks datastore: %s", err)
 	}

--- a/central/search/service/service_impl_test.go
+++ b/central/search/service/service_impl_test.go
@@ -224,7 +224,7 @@ func (s *SearchOperationsTestSuite) TestAutocompleteForEnums() {
 	policyIndexer = policyPostgres.NewIndexer(s.pool)
 	s.NoError(policyStore.Upsert(ctx, fixtures.GetPolicy()))
 	policySearcher := policySearcher.New(policyStore, policyIndexer)
-	ds = policyDatastore.New(policyStore, policyIndexer, policySearcher, nil, nil, categoriesDS)
+	ds = policyDatastore.New(policyStore, policySearcher, nil, nil, categoriesDS)
 
 	builder := NewBuilder().
 		WithAlertStore(alertMocks.NewMockDataStore(s.mockCtrl)).

--- a/central/secret/datastore/datastore.go
+++ b/central/secret/datastore/datastore.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stackrox/rox/central/secret/internal/index"
 	"github.com/stackrox/rox/central/secret/internal/store"
 	pgStore "github.com/stackrox/rox/central/secret/internal/store/postgres"
 	"github.com/stackrox/rox/central/secret/search"
@@ -30,11 +29,10 @@ type DataStore interface {
 	RemoveSecret(ctx context.Context, id string) error
 }
 
-// New returns a new instance of DataStore using the input store, indexer, and searcher.
-func New(secretStore store.Store, indexer index.Indexer, searcher search.Searcher) (DataStore, error) {
+// New returns a new instance of DataStore using the input store, and searcher.
+func New(secretStore store.Store, searcher search.Searcher) (DataStore, error) {
 	d := &datastoreImpl{
 		storage:  secretStore,
-		indexer:  indexer,
 		searcher: searcher,
 	}
 	return d, nil
@@ -45,5 +43,5 @@ func GetTestPostgresDataStore(_ *testing.T, pool postgres.DB) (DataStore, error)
 	dbstore := pgStore.New(pool)
 	indexer := pgStore.NewIndexer(pool)
 	searcher := search.New(dbstore, indexer)
-	return New(dbstore, indexer, searcher)
+	return New(dbstore, searcher)
 }

--- a/central/secret/datastore/datastore_impl.go
+++ b/central/secret/datastore/datastore_impl.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/stackrox/rox/central/role/resources"
-	"github.com/stackrox/rox/central/secret/internal/index"
 	"github.com/stackrox/rox/central/secret/internal/store"
 	"github.com/stackrox/rox/central/secret/search"
 	v1 "github.com/stackrox/rox/generated/api/v1"
@@ -19,7 +18,6 @@ var (
 
 type datastoreImpl struct {
 	storage  store.Store
-	indexer  index.Indexer
 	searcher search.Searcher
 }
 

--- a/central/secret/datastore/singleton.go
+++ b/central/secret/datastore/singleton.go
@@ -18,9 +18,8 @@ var (
 
 func initialize() {
 	storage := pgStore.New(globaldb.GetPostgres())
-	indexer := pgStore.NewIndexer(globaldb.GetPostgres())
 	var err error
-	ad, err = New(storage, indexer, search.New(storage, indexer))
+	ad, err = New(storage, search.New(storage, pgStore.NewIndexer(globaldb.GetPostgres())))
 	if err != nil {
 		log.Panicf("Failed to initialize secrets datastore: %s", err)
 	}

--- a/central/serviceaccount/datastore/datastore.go
+++ b/central/serviceaccount/datastore/datastore.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stackrox/rox/central/serviceaccount/internal/index"
 	"github.com/stackrox/rox/central/serviceaccount/internal/store"
 	pgStore "github.com/stackrox/rox/central/serviceaccount/internal/store/postgres"
 	"github.com/stackrox/rox/central/serviceaccount/search"
@@ -28,11 +27,10 @@ type DataStore interface {
 	RemoveServiceAccount(ctx context.Context, id string) error
 }
 
-// New returns a new instance of DataStore using the input store, indexer, and searcher.
-func New(saStore store.Store, indexer index.Indexer, searcher search.Searcher) (DataStore, error) {
+// New returns a new instance of DataStore using the input store, and searcher.
+func New(saStore store.Store, searcher search.Searcher) (DataStore, error) {
 	d := &datastoreImpl{
 		storage:  saStore,
-		indexer:  indexer,
 		searcher: searcher,
 	}
 	return d, nil
@@ -43,5 +41,5 @@ func GetTestPostgresDataStore(_ *testing.T, pool postgres.DB) (DataStore, error)
 	dbstore := pgStore.New(pool)
 	indexer := pgStore.NewIndexer(pool)
 	searcher := search.New(dbstore, indexer)
-	return New(dbstore, indexer, searcher)
+	return New(dbstore, searcher)
 }

--- a/central/serviceaccount/datastore/datastore_impl.go
+++ b/central/serviceaccount/datastore/datastore_impl.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/stackrox/rox/central/role/resources"
-	"github.com/stackrox/rox/central/serviceaccount/internal/index"
 	"github.com/stackrox/rox/central/serviceaccount/internal/store"
 	"github.com/stackrox/rox/central/serviceaccount/search"
 	v1 "github.com/stackrox/rox/generated/api/v1"
@@ -13,17 +12,12 @@ import (
 	searchPkg "github.com/stackrox/rox/pkg/search"
 )
 
-const (
-	batchSize = 1000
-)
-
 var (
 	serviceAccountsSAC = sac.ForResource(resources.ServiceAccount)
 )
 
 type datastoreImpl struct {
 	storage  store.Store
-	indexer  index.Indexer
 	searcher search.Searcher
 }
 

--- a/central/serviceaccount/datastore/datastore_impl_test.go
+++ b/central/serviceaccount/datastore/datastore_impl_test.go
@@ -53,7 +53,7 @@ func (suite *ServiceAccountDataStoreTestSuite) SetupSuite() {
 	suite.storage = pgStore.New(suite.pool)
 	suite.indexer = pgStore.NewIndexer(suite.pool)
 	suite.searcher = serviceAccountSearch.New(suite.storage, suite.indexer)
-	suite.datastore, err = New(suite.storage, suite.indexer, suite.searcher)
+	suite.datastore, err = New(suite.storage, suite.searcher)
 	suite.Require().NoError(err)
 
 	suite.ctx = sac.WithGlobalAccessScopeChecker(context.Background(),

--- a/central/serviceaccount/datastore/singleton.go
+++ b/central/serviceaccount/datastore/singleton.go
@@ -18,10 +18,9 @@ var (
 
 func initialize() {
 	storage := pgStore.New(globaldb.GetPostgres())
-	indexer := pgStore.NewIndexer(globaldb.GetPostgres())
 
 	var err error
-	ds, err = New(storage, indexer, search.New(storage, indexer))
+	ds, err = New(storage, search.New(storage, pgStore.NewIndexer(globaldb.GetPostgres())))
 	if err != nil {
 		log.Panicf("Failed to initialize secrets datastore: %s", err)
 	}

--- a/central/vulnerabilityrequest/datastore/datastore.go
+++ b/central/vulnerabilityrequest/datastore/datastore.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stackrox/rox/central/vulnerabilityrequest/datastore/internal/searcher"
 	"github.com/stackrox/rox/central/vulnerabilityrequest/datastore/internal/store"
 	pgStore "github.com/stackrox/rox/central/vulnerabilityrequest/datastore/internal/store/postgres"
-	"github.com/stackrox/rox/central/vulnerabilityrequest/index"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
@@ -43,12 +42,11 @@ type DataStore interface {
 	RemoveRequestsInternal(ctx context.Context, ids []string) error
 }
 
-// New returns a new instance of DataStore using the input store, indexer, and searcher.
-func New(s store.Store, indexer index.Indexer, searcher searcher.Searcher,
+// New returns a new instance of DataStore using the input store, and searcher.
+func New(s store.Store, searcher searcher.Searcher,
 	pendingReqCache cache.VulnReqCache, activeReqCache cache.VulnReqCache) (DataStore, error) {
 	d := &datastoreImpl{
 		store:           s,
-		index:           indexer,
 		searcher:        searcher,
 		pendingReqCache: pendingReqCache,
 		activeReqCache:  activeReqCache,
@@ -72,7 +70,6 @@ func GetTestPostgresDataStore(t *testing.T, pool postgres.DB, pendingReqCache ca
 
 	d := &datastoreImpl{
 		store:           storage,
-		index:           indexer,
 		searcher:        searcher.New(storage, indexer),
 		pendingReqCache: pendingReqCache,
 		activeReqCache:  activeReqCache,

--- a/central/vulnerabilityrequest/datastore/datastore_impl.go
+++ b/central/vulnerabilityrequest/datastore/datastore_impl.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stackrox/rox/central/vulnerabilityrequest/cache"
 	"github.com/stackrox/rox/central/vulnerabilityrequest/datastore/internal/searcher"
 	"github.com/stackrox/rox/central/vulnerabilityrequest/datastore/internal/store"
-	"github.com/stackrox/rox/central/vulnerabilityrequest/index"
 	"github.com/stackrox/rox/central/vulnerabilityrequest/utils"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
@@ -28,7 +27,6 @@ type datastoreImpl struct {
 	pendingReqCache cache.VulnReqCache
 	activeReqCache  cache.VulnReqCache
 	store           store.Store
-	index           index.Indexer
 	searcher        searcher.Searcher
 }
 

--- a/central/vulnerabilityrequest/datastore/datastore_impl_test.go
+++ b/central/vulnerabilityrequest/datastore/datastore_impl_test.go
@@ -88,7 +88,6 @@ func (s *VulnRequestDataStoreTestSuite) SetupTest() {
 	s.mockCtrl = gomock.NewController(s.T())
 
 	s.mockStore = storeMock.NewMockStore(s.mockCtrl)
-	s.mockIndexer = indexerMock.NewMockIndexer(s.mockCtrl)
 	s.mockSearcher = searcherMock.NewMockSearcher(s.mockCtrl)
 	s.mockIdentity = mockIdentity.NewMockIdentity(s.mockCtrl)
 	s.mockIdentity.EXPECT().UID().Return(fakeUserID).AnyTimes()
@@ -97,7 +96,6 @@ func (s *VulnRequestDataStoreTestSuite) SetupTest() {
 
 	s.datastore = &datastoreImpl{
 		store:           s.mockStore,
-		index:           s.mockIndexer,
 		searcher:        s.mockSearcher,
 		pendingReqCache: cache.New(),
 	}

--- a/central/vulnerabilityrequest/datastore/singleton.go
+++ b/central/vulnerabilityrequest/datastore/singleton.go
@@ -19,9 +19,8 @@ var (
 
 func initialize() {
 	storage := pgStore.New(globaldb.GetPostgres())
-	indexer := pgStore.NewIndexer(globaldb.GetPostgres())
 	var err error
-	ds, err = New(storage, indexer, searcher.New(storage, indexer),
+	ds, err = New(storage, searcher.New(storage, pgStore.NewIndexer(globaldb.GetPostgres())),
 		cache.PendingReqsCacheSingleton(), cache.ActiveReqsCacheSingleton())
 	if err != nil {
 		log.Panicf("Failed to initialize vulnerability requests datastore: %s", err)


### PR DESCRIPTION
## Description

Datastores are no longer using indexers directly

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

CI
