### PR TITLE
refactor: Remove bleve from Compliance by using predicates

### DIFF
--- a/central/compliance/checks/all_test.go
+++ b/central/compliance/checks/all_test.go
@@ -13,7 +13,7 @@ func TestAllCheckIDsAreValid(t *testing.T) {
 	allChecks := framework.RegistrySingleton().GetAll()
 	var allControls []string
 
-	registryInstance, err := standards.NewRegistry(nil, framework.RegistrySingleton(), metadata.AllStandards...)
+	registryInstance, err := standards.NewRegistry(framework.RegistrySingleton(), metadata.AllStandards...)
 	assert.NoError(t, err)
 	for _, standard := range registryInstance.AllStandards() {
 		for _, ctrl := range standard.AllControls() {

--- a/central/compliance/manager/test/manager_test.go
+++ b/central/compliance/manager/test/manager_test.go
@@ -78,7 +78,7 @@ func (s *managerTestSuite) TestExpandSelection_AllOne_GetClustersError() {
 
 func (s *managerTestSuite) TestExpandSelection_OneAll_OK() {
 	var err error
-	s.standardRegistry, err = standards.NewRegistry(nil, nil,
+	s.standardRegistry, err = standards.NewRegistry(nil,
 		metadata.Standard{ID: "standard1"},
 		metadata.Standard{ID: "standard2"},
 	)
@@ -98,7 +98,7 @@ func (s *managerTestSuite) TestExpandSelection_AllAll_OK() {
 		{Id: "cluster2"},
 	}, nil)
 	var err error
-	s.standardRegistry, err = standards.NewRegistry(nil, nil,
+	s.standardRegistry, err = standards.NewRegistry(nil,
 		metadata.Standard{ID: "standard1"},
 		metadata.Standard{ID: "standard2"},
 	)
@@ -133,7 +133,7 @@ func (s *managerTestSuite) SetupTest() {
 			sac.ResourceScopeKeys(resources.Compliance)))
 	s.mockCtrl = gomock.NewController(s.T())
 	var err error
-	s.standardRegistry, err = standards.NewRegistry(nil, nil)
+	s.standardRegistry, err = standards.NewRegistry(nil)
 	s.Require().NoError(err)
 	s.mockClusterStore = clusterDatastoreMocks.NewMockDataStore(s.mockCtrl)
 	s.mockNodeStore = nodeDatastoreMocks.NewMockDataStore(s.mockCtrl)

--- a/central/compliance/standards/registry.go
+++ b/central/compliance/standards/registry.go
@@ -249,6 +249,8 @@ func (r *Registry) GetCISKubernetesStandardID() (string, error) {
 
 // SearchStandards searches across standards
 func (r *Registry) SearchStandards(q *v1.Query) ([]search.Result, error) {
+	// Predicate search does not support sorting, but sort options are not used in the current code path for
+	// the calls to this function
 	var results []search.Result
 	for _, standard := range r.AllStandards() {
 		pred, err := standardPredicateFactory.GeneratePredicate(q)
@@ -266,6 +268,8 @@ func (r *Registry) SearchStandards(q *v1.Query) ([]search.Result, error) {
 
 // SearchControls searches across controls
 func (r *Registry) SearchControls(q *v1.Query) ([]search.Result, error) {
+	// Predicate search does not support sorting, but sort options are not used in the current code path for
+	// the calls to this function
 	pred, err := controlPredicateFactory.GeneratePredicate(q)
 	if err != nil {
 		return nil, errors.Wrap(err, "generating predicate for query")

--- a/central/compliance/standards/registry.go
+++ b/central/compliance/standards/registry.go
@@ -6,11 +6,16 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/central/compliance/framework"
-	"github.com/stackrox/rox/central/compliance/standards/index"
 	"github.com/stackrox/rox/central/compliance/standards/metadata"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/predicate"
 	"github.com/stackrox/rox/pkg/sync"
+)
+
+var (
+	standardPredicateFactory = predicate.NewFactory("standard", &v1.ComplianceStandard{})
+	controlPredicateFactory  = predicate.NewFactory("control", &v1.ComplianceControl{})
 )
 
 // Registry stores compliance standards by their ID.
@@ -20,17 +25,15 @@ type Registry struct {
 	categoriesByID map[string]*Category
 	controlsByID   map[string]*Control
 
-	indexer       index.Indexer
 	checkRegistry framework.CheckRegistry
 }
 
 // NewRegistry creates and returns a new standards registry.
-func NewRegistry(indexer index.Indexer, checkRegistry framework.CheckRegistry, standardMDs ...metadata.Standard) (*Registry, error) {
+func NewRegistry(checkRegistry framework.CheckRegistry, standardMDs ...metadata.Standard) (*Registry, error) {
 	r := &Registry{
 		standardsByID:  make(map[string]*Standard),
 		categoriesByID: make(map[string]*Category),
 		controlsByID:   make(map[string]*Control),
-		indexer:        indexer,
 		checkRegistry:  checkRegistry,
 	}
 	if err := r.RegisterStandards(standardMDs...); err != nil {
@@ -63,19 +66,9 @@ func (r *Registry) DeleteStandard(id string) error {
 		return nil
 	}
 	delete(r.standardsByID, id)
-	if r.indexer != nil {
-		if err := r.indexer.DeleteStandard(id); err != nil {
-			return err
-		}
-	}
 	for id := range r.controlsByID {
 		if ChildOfStandard(id, standard.ID) {
 			delete(r.controlsByID, id)
-			if r.indexer != nil {
-				if err := r.indexer.DeleteControl(id); err != nil {
-					return err
-				}
-			}
 			r.checkRegistry.Delete(id)
 		}
 	}
@@ -94,12 +87,6 @@ func (r *Registry) DeleteControl(id string) error {
 
 	r.checkRegistry.Delete(id)
 	delete(r.controlsByID, id)
-	if r.indexer == nil {
-		return nil
-	}
-	if err := r.indexer.DeleteControl(id); err != nil {
-		return err
-	}
 	return nil
 }
 
@@ -120,11 +107,7 @@ func (r *Registry) RegisterStandard(standardMD metadata.Standard, overwrite bool
 	for _, ctrl := range standard.controls {
 		r.controlsByID[ctrl.QualifiedID()] = ctrl
 	}
-
-	if r.indexer == nil {
-		return nil
-	}
-	return r.indexer.IndexStandard(standard.ToProto())
+	return nil
 }
 
 // LookupStandard returns the standard object with the given ID.
@@ -266,14 +249,36 @@ func (r *Registry) GetCISKubernetesStandardID() (string, error) {
 
 // SearchStandards searches across standards
 func (r *Registry) SearchStandards(q *v1.Query) ([]search.Result, error) {
-	r.lock.RLock()
-	defer r.lock.RUnlock()
-	return r.indexer.SearchStandards(q)
+	var results []search.Result
+	for _, standard := range r.AllStandards() {
+		pred, err := standardPredicateFactory.GeneratePredicate(q)
+		if err != nil {
+			return nil, errors.Wrap(err, "generating predicate for query")
+		}
+		result, ok := pred.Evaluate(standard.ToProto())
+		if ok {
+			result.ID = standard.ID
+			results = append(results, *result)
+		}
+	}
+	return results, nil
 }
 
 // SearchControls searches across controls
 func (r *Registry) SearchControls(q *v1.Query) ([]search.Result, error) {
-	r.lock.RLock()
-	defer r.lock.RUnlock()
-	return r.indexer.SearchControls(q)
+	pred, err := controlPredicateFactory.GeneratePredicate(q)
+	if err != nil {
+		return nil, errors.Wrap(err, "generating predicate for query")
+	}
+	var results []search.Result
+	for _, standards := range r.AllStandards() {
+		for _, control := range standards.controls {
+			result, ok := pred.Evaluate(control.ToProto())
+			if ok {
+				result.ID = control.ID
+				results = append(results, *result)
+			}
+		}
+	}
+	return results, nil
 }

--- a/central/compliance/standards/registry_singleton.go
+++ b/central/compliance/standards/registry_singleton.go
@@ -2,9 +2,7 @@ package standards
 
 import (
 	"github.com/stackrox/rox/central/compliance/framework"
-	"github.com/stackrox/rox/central/compliance/standards/index"
 	"github.com/stackrox/rox/central/compliance/standards/metadata"
-	"github.com/stackrox/rox/central/globalindex"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/pkg/utils"
 )
@@ -17,10 +15,8 @@ var (
 // RegistrySingleton returns the singleton instance of the compliance standards Registry.
 func RegistrySingleton() *Registry {
 	registryInstanceInit.Do(func() {
-		memIndex, err := globalindex.MemOnlyIndex()
-		utils.CrashOnError(err)
-		indexer := index.New(memIndex)
-		registryInstance, err = NewRegistry(indexer, framework.RegistrySingleton(), metadata.AllStandards...)
+		var err error
+		registryInstance, err = NewRegistry(framework.RegistrySingleton(), metadata.AllStandards...)
 		utils.CrashOnError(err)
 	})
 	return registryInstance

--- a/central/compliance/standards/registry_test.go
+++ b/central/compliance/standards/registry_test.go
@@ -3,24 +3,22 @@ package standards
 import (
 	"testing"
 
-	"github.com/stackrox/rox/central/compliance/standards/index"
 	"github.com/stackrox/rox/central/compliance/standards/metadata"
-	"github.com/stackrox/rox/central/globalindex"
 	"github.com/stackrox/rox/pkg/search"
-	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestIndexer(t *testing.T) {
-	globalIdx, err := globalindex.MemOnlyIndex()
-	require.NoError(t, err)
-	defer utils.IgnoreError(globalIdx.Close)
-
-	standardIdx := index.New(globalIdx)
-	registry, err := NewRegistry(standardIdx, nil, metadata.AllStandards...)
+	registry, err := NewRegistry(nil, metadata.AllStandards...)
 	require.NoError(t, err)
 	results, err := registry.SearchStandards(search.NewQueryBuilder().AddStrings(search.StandardID, "pci").ProtoQuery())
-	assert.NoError(t, err)
-	assert.Len(t, results, 1)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "PCI_DSS_3_2", results[0].ID)
+
+	results, err = registry.SearchControls(search.NewQueryBuilder().AddExactMatches(search.Control, "1.1.1").AddStrings(search.StandardID, "pci").ProtoQuery())
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, results[0].ID, "1_1_1")
 }

--- a/central/complianceoperator/manager/manager_test.go
+++ b/central/complianceoperator/manager/manager_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 func newManager(t *testing.T) *managerImpl {
-	registry, err := standards.NewRegistry(nil, framework.RegistrySingleton(), metadata.AllStandards...)
+	registry, err := standards.NewRegistry(framework.RegistrySingleton(), metadata.AllStandards...)
 	require.NoError(t, err)
 
 	db := pgtest.ForT(t)

--- a/pkg/search/predicate/basematchers/base_matchers.go
+++ b/pkg/search/predicate/basematchers/base_matchers.go
@@ -226,8 +226,9 @@ func forStringExactMatch(value string, negated bool) (func(string) bool, error) 
 }
 
 func forStringPrefixMatch(value string, negated bool) (func(string) bool, error) {
+	lowerValue := strings.ToLower(value)
 	return func(instance string) bool {
 		// matched != negated is equivalent to (matched XOR negated), which is what we want here
-		return (value == search.WildcardString || strings.HasPrefix(instance, value)) != negated
+		return (value == search.WildcardString || strings.HasPrefix(strings.ToLower(instance), lowerValue)) != negated
 	}, nil
 }


### PR DESCRIPTION
## Description

Use our search predicates instead of bleve. Prefix match in predicates should be capitalization agnostic just like search

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

CI + small unit test
