### PR TITLE
ROX-17921: make generated store code style check compliant

### DIFF
--- a/central/activecomponent/datastore/internal/store/postgres/store.go
+++ b/central/activecomponent/datastore/internal/store/postgres/store.go
@@ -110,11 +110,11 @@ func insertIntoActiveComponents(ctx context.Context, batch *pgx.Batch, obj *stor
 	return nil
 }
 
-func insertIntoActiveComponentsActiveContextsSlices(_ context.Context, batch *pgx.Batch, obj *storage.ActiveComponent_ActiveContext, active_components_Id string, idx int) error {
+func insertIntoActiveComponentsActiveContextsSlices(_ context.Context, batch *pgx.Batch, obj *storage.ActiveComponent_ActiveContext, activeComponentsID string, idx int) error {
 
 	values := []interface{}{
 		// parent primary keys start
-		active_components_Id,
+		activeComponentsID,
 		idx,
 		obj.GetContainerName(),
 		obj.GetImageId(),
@@ -205,7 +205,7 @@ func (s *storeImpl) copyFromActiveComponents(ctx context.Context, tx *postgres.T
 	return err
 }
 
-func (s *storeImpl) copyFromActiveComponentsActiveContextsSlices(ctx context.Context, tx *postgres.Tx, active_components_Id string, objs ...*storage.ActiveComponent_ActiveContext) error {
+func (s *storeImpl) copyFromActiveComponentsActiveContextsSlices(ctx context.Context, tx *postgres.Tx, activeComponentsID string, objs ...*storage.ActiveComponent_ActiveContext) error {
 
 	inputRows := [][]interface{}{}
 
@@ -230,7 +230,7 @@ func (s *storeImpl) copyFromActiveComponentsActiveContextsSlices(ctx context.Con
 
 		inputRows = append(inputRows, []interface{}{
 
-			active_components_Id,
+			activeComponentsID,
 
 			idx,
 

--- a/central/activecomponent/datastore/internal/store/postgres/store.go
+++ b/central/activecomponent/datastore/internal/store/postgres/store.go
@@ -110,11 +110,11 @@ func insertIntoActiveComponents(ctx context.Context, batch *pgx.Batch, obj *stor
 	return nil
 }
 
-func insertIntoActiveComponentsActiveContextsSlices(_ context.Context, batch *pgx.Batch, obj *storage.ActiveComponent_ActiveContext, activeComponentsID string, idx int) error {
+func insertIntoActiveComponentsActiveContextsSlices(_ context.Context, batch *pgx.Batch, obj *storage.ActiveComponent_ActiveContext, activeComponentID string, idx int) error {
 
 	values := []interface{}{
 		// parent primary keys start
-		activeComponentsID,
+		activeComponentID,
 		idx,
 		obj.GetContainerName(),
 		obj.GetImageId(),
@@ -205,7 +205,7 @@ func (s *storeImpl) copyFromActiveComponents(ctx context.Context, tx *postgres.T
 	return err
 }
 
-func (s *storeImpl) copyFromActiveComponentsActiveContextsSlices(ctx context.Context, tx *postgres.Tx, activeComponentsID string, objs ...*storage.ActiveComponent_ActiveContext) error {
+func (s *storeImpl) copyFromActiveComponentsActiveContextsSlices(ctx context.Context, tx *postgres.Tx, activeComponentID string, objs ...*storage.ActiveComponent_ActiveContext) error {
 
 	inputRows := [][]interface{}{}
 
@@ -230,7 +230,7 @@ func (s *storeImpl) copyFromActiveComponentsActiveContextsSlices(ctx context.Con
 
 		inputRows = append(inputRows, []interface{}{
 
-			activeComponentsID,
+			activeComponentID,
 
 			idx,
 

--- a/central/deployment/store/postgres/store.go
+++ b/central/deployment/store/postgres/store.go
@@ -133,11 +133,11 @@ func insertIntoDeployments(ctx context.Context, batch *pgx.Batch, obj *storage.D
 	return nil
 }
 
-func insertIntoDeploymentsContainers(ctx context.Context, batch *pgx.Batch, obj *storage.Container, deploymentsID string, idx int) error {
+func insertIntoDeploymentsContainers(ctx context.Context, batch *pgx.Batch, obj *storage.Container, deploymentID string, idx int) error {
 
 	values := []interface{}{
 		// parent primary keys start
-		pgutils.NilOrUUID(deploymentsID),
+		pgutils.NilOrUUID(deploymentID),
 		idx,
 		obj.GetImage().GetId(),
 		obj.GetImage().GetName().GetRegistry(),
@@ -160,38 +160,38 @@ func insertIntoDeploymentsContainers(ctx context.Context, batch *pgx.Batch, obj 
 	var query string
 
 	for childIndex, child := range obj.GetConfig().GetEnv() {
-		if err := insertIntoDeploymentsContainersEnvs(ctx, batch, child, deploymentsID, idx, childIndex); err != nil {
+		if err := insertIntoDeploymentsContainersEnvs(ctx, batch, child, deploymentID, idx, childIndex); err != nil {
 			return err
 		}
 	}
 
 	query = "delete from deployments_containers_envs where deployments_Id = $1 AND deployments_containers_idx = $2 AND idx >= $3"
-	batch.Queue(query, pgutils.NilOrUUID(deploymentsID), idx, len(obj.GetConfig().GetEnv()))
+	batch.Queue(query, pgutils.NilOrUUID(deploymentID), idx, len(obj.GetConfig().GetEnv()))
 	for childIndex, child := range obj.GetVolumes() {
-		if err := insertIntoDeploymentsContainersVolumes(ctx, batch, child, deploymentsID, idx, childIndex); err != nil {
+		if err := insertIntoDeploymentsContainersVolumes(ctx, batch, child, deploymentID, idx, childIndex); err != nil {
 			return err
 		}
 	}
 
 	query = "delete from deployments_containers_volumes where deployments_Id = $1 AND deployments_containers_idx = $2 AND idx >= $3"
-	batch.Queue(query, pgutils.NilOrUUID(deploymentsID), idx, len(obj.GetVolumes()))
+	batch.Queue(query, pgutils.NilOrUUID(deploymentID), idx, len(obj.GetVolumes()))
 	for childIndex, child := range obj.GetSecrets() {
-		if err := insertIntoDeploymentsContainersSecrets(ctx, batch, child, deploymentsID, idx, childIndex); err != nil {
+		if err := insertIntoDeploymentsContainersSecrets(ctx, batch, child, deploymentID, idx, childIndex); err != nil {
 			return err
 		}
 	}
 
 	query = "delete from deployments_containers_secrets where deployments_Id = $1 AND deployments_containers_idx = $2 AND idx >= $3"
-	batch.Queue(query, pgutils.NilOrUUID(deploymentsID), idx, len(obj.GetSecrets()))
+	batch.Queue(query, pgutils.NilOrUUID(deploymentID), idx, len(obj.GetSecrets()))
 	return nil
 }
 
-func insertIntoDeploymentsContainersEnvs(_ context.Context, batch *pgx.Batch, obj *storage.ContainerConfig_EnvironmentConfig, deploymentsID string, deploymentsContainersIdx int, idx int) error {
+func insertIntoDeploymentsContainersEnvs(_ context.Context, batch *pgx.Batch, obj *storage.ContainerConfig_EnvironmentConfig, deploymentID string, deploymentContainerIdx int, idx int) error {
 
 	values := []interface{}{
 		// parent primary keys start
-		pgutils.NilOrUUID(deploymentsID),
-		deploymentsContainersIdx,
+		pgutils.NilOrUUID(deploymentID),
+		deploymentContainerIdx,
 		idx,
 		obj.GetKey(),
 		obj.GetValue(),
@@ -204,12 +204,12 @@ func insertIntoDeploymentsContainersEnvs(_ context.Context, batch *pgx.Batch, ob
 	return nil
 }
 
-func insertIntoDeploymentsContainersVolumes(_ context.Context, batch *pgx.Batch, obj *storage.Volume, deploymentsID string, deploymentsContainersIdx int, idx int) error {
+func insertIntoDeploymentsContainersVolumes(_ context.Context, batch *pgx.Batch, obj *storage.Volume, deploymentID string, deploymentContainerIdx int, idx int) error {
 
 	values := []interface{}{
 		// parent primary keys start
-		pgutils.NilOrUUID(deploymentsID),
-		deploymentsContainersIdx,
+		pgutils.NilOrUUID(deploymentID),
+		deploymentContainerIdx,
 		idx,
 		obj.GetName(),
 		obj.GetSource(),
@@ -224,12 +224,12 @@ func insertIntoDeploymentsContainersVolumes(_ context.Context, batch *pgx.Batch,
 	return nil
 }
 
-func insertIntoDeploymentsContainersSecrets(_ context.Context, batch *pgx.Batch, obj *storage.EmbeddedSecret, deploymentsID string, deploymentsContainersIdx int, idx int) error {
+func insertIntoDeploymentsContainersSecrets(_ context.Context, batch *pgx.Batch, obj *storage.EmbeddedSecret, deploymentID string, deploymentContainerIdx int, idx int) error {
 
 	values := []interface{}{
 		// parent primary keys start
-		pgutils.NilOrUUID(deploymentsID),
-		deploymentsContainersIdx,
+		pgutils.NilOrUUID(deploymentID),
+		deploymentContainerIdx,
 		idx,
 		obj.GetName(),
 		obj.GetPath(),
@@ -241,11 +241,11 @@ func insertIntoDeploymentsContainersSecrets(_ context.Context, batch *pgx.Batch,
 	return nil
 }
 
-func insertIntoDeploymentsPorts(ctx context.Context, batch *pgx.Batch, obj *storage.PortConfig, deploymentsID string, idx int) error {
+func insertIntoDeploymentsPorts(ctx context.Context, batch *pgx.Batch, obj *storage.PortConfig, deploymentID string, idx int) error {
 
 	values := []interface{}{
 		// parent primary keys start
-		pgutils.NilOrUUID(deploymentsID),
+		pgutils.NilOrUUID(deploymentID),
 		idx,
 		obj.GetContainerPort(),
 		obj.GetProtocol(),
@@ -258,22 +258,22 @@ func insertIntoDeploymentsPorts(ctx context.Context, batch *pgx.Batch, obj *stor
 	var query string
 
 	for childIndex, child := range obj.GetExposureInfos() {
-		if err := insertIntoDeploymentsPortsExposureInfos(ctx, batch, child, deploymentsID, idx, childIndex); err != nil {
+		if err := insertIntoDeploymentsPortsExposureInfos(ctx, batch, child, deploymentID, idx, childIndex); err != nil {
 			return err
 		}
 	}
 
 	query = "delete from deployments_ports_exposure_infos where deployments_Id = $1 AND deployments_ports_idx = $2 AND idx >= $3"
-	batch.Queue(query, pgutils.NilOrUUID(deploymentsID), idx, len(obj.GetExposureInfos()))
+	batch.Queue(query, pgutils.NilOrUUID(deploymentID), idx, len(obj.GetExposureInfos()))
 	return nil
 }
 
-func insertIntoDeploymentsPortsExposureInfos(_ context.Context, batch *pgx.Batch, obj *storage.PortConfig_ExposureInfo, deploymentsID string, deploymentsPortsIdx int, idx int) error {
+func insertIntoDeploymentsPortsExposureInfos(_ context.Context, batch *pgx.Batch, obj *storage.PortConfig_ExposureInfo, deploymentID string, deploymentPortIdx int, idx int) error {
 
 	values := []interface{}{
 		// parent primary keys start
-		pgutils.NilOrUUID(deploymentsID),
-		deploymentsPortsIdx,
+		pgutils.NilOrUUID(deploymentID),
+		deploymentPortIdx,
 		idx,
 		obj.GetLevel(),
 		obj.GetServiceName(),
@@ -427,7 +427,7 @@ func (s *storeImpl) copyFromDeployments(ctx context.Context, tx *postgres.Tx, ob
 	return err
 }
 
-func (s *storeImpl) copyFromDeploymentsContainers(ctx context.Context, tx *postgres.Tx, deploymentsID string, objs ...*storage.Container) error {
+func (s *storeImpl) copyFromDeploymentsContainers(ctx context.Context, tx *postgres.Tx, deploymentID string, objs ...*storage.Container) error {
 
 	inputRows := [][]interface{}{}
 
@@ -474,7 +474,7 @@ func (s *storeImpl) copyFromDeploymentsContainers(ctx context.Context, tx *postg
 
 		inputRows = append(inputRows, []interface{}{
 
-			pgutils.NilOrUUID(deploymentsID),
+			pgutils.NilOrUUID(deploymentID),
 
 			idx,
 
@@ -524,13 +524,13 @@ func (s *storeImpl) copyFromDeploymentsContainers(ctx context.Context, tx *postg
 	for idx, obj := range objs {
 		_ = idx // idx may or may not be used depending on how nested we are, so avoid compile-time errors.
 
-		if err = s.copyFromDeploymentsContainersEnvs(ctx, tx, deploymentsID, idx, obj.GetConfig().GetEnv()...); err != nil {
+		if err = s.copyFromDeploymentsContainersEnvs(ctx, tx, deploymentID, idx, obj.GetConfig().GetEnv()...); err != nil {
 			return err
 		}
-		if err = s.copyFromDeploymentsContainersVolumes(ctx, tx, deploymentsID, idx, obj.GetVolumes()...); err != nil {
+		if err = s.copyFromDeploymentsContainersVolumes(ctx, tx, deploymentID, idx, obj.GetVolumes()...); err != nil {
 			return err
 		}
-		if err = s.copyFromDeploymentsContainersSecrets(ctx, tx, deploymentsID, idx, obj.GetSecrets()...); err != nil {
+		if err = s.copyFromDeploymentsContainersSecrets(ctx, tx, deploymentID, idx, obj.GetSecrets()...); err != nil {
 			return err
 		}
 	}
@@ -538,7 +538,7 @@ func (s *storeImpl) copyFromDeploymentsContainers(ctx context.Context, tx *postg
 	return err
 }
 
-func (s *storeImpl) copyFromDeploymentsContainersEnvs(ctx context.Context, tx *postgres.Tx, deploymentsID string, deploymentsContainersIdx int, objs ...*storage.ContainerConfig_EnvironmentConfig) error {
+func (s *storeImpl) copyFromDeploymentsContainersEnvs(ctx context.Context, tx *postgres.Tx, deploymentID string, deploymentContainerIdx int, objs ...*storage.ContainerConfig_EnvironmentConfig) error {
 
 	inputRows := [][]interface{}{}
 
@@ -567,9 +567,9 @@ func (s *storeImpl) copyFromDeploymentsContainersEnvs(ctx context.Context, tx *p
 
 		inputRows = append(inputRows, []interface{}{
 
-			pgutils.NilOrUUID(deploymentsID),
+			pgutils.NilOrUUID(deploymentID),
 
-			deploymentsContainersIdx,
+			deploymentContainerIdx,
 
 			idx,
 
@@ -599,7 +599,7 @@ func (s *storeImpl) copyFromDeploymentsContainersEnvs(ctx context.Context, tx *p
 	return err
 }
 
-func (s *storeImpl) copyFromDeploymentsContainersVolumes(ctx context.Context, tx *postgres.Tx, deploymentsID string, deploymentsContainersIdx int, objs ...*storage.Volume) error {
+func (s *storeImpl) copyFromDeploymentsContainersVolumes(ctx context.Context, tx *postgres.Tx, deploymentID string, deploymentContainerIdx int, objs ...*storage.Volume) error {
 
 	inputRows := [][]interface{}{}
 
@@ -632,9 +632,9 @@ func (s *storeImpl) copyFromDeploymentsContainersVolumes(ctx context.Context, tx
 
 		inputRows = append(inputRows, []interface{}{
 
-			pgutils.NilOrUUID(deploymentsID),
+			pgutils.NilOrUUID(deploymentID),
 
-			deploymentsContainersIdx,
+			deploymentContainerIdx,
 
 			idx,
 
@@ -668,7 +668,7 @@ func (s *storeImpl) copyFromDeploymentsContainersVolumes(ctx context.Context, tx
 	return err
 }
 
-func (s *storeImpl) copyFromDeploymentsContainersSecrets(ctx context.Context, tx *postgres.Tx, deploymentsID string, deploymentsContainersIdx int, objs ...*storage.EmbeddedSecret) error {
+func (s *storeImpl) copyFromDeploymentsContainersSecrets(ctx context.Context, tx *postgres.Tx, deploymentID string, deploymentContainerIdx int, objs ...*storage.EmbeddedSecret) error {
 
 	inputRows := [][]interface{}{}
 
@@ -695,9 +695,9 @@ func (s *storeImpl) copyFromDeploymentsContainersSecrets(ctx context.Context, tx
 
 		inputRows = append(inputRows, []interface{}{
 
-			pgutils.NilOrUUID(deploymentsID),
+			pgutils.NilOrUUID(deploymentID),
 
-			deploymentsContainersIdx,
+			deploymentContainerIdx,
 
 			idx,
 
@@ -725,7 +725,7 @@ func (s *storeImpl) copyFromDeploymentsContainersSecrets(ctx context.Context, tx
 	return err
 }
 
-func (s *storeImpl) copyFromDeploymentsPorts(ctx context.Context, tx *postgres.Tx, deploymentsID string, objs ...*storage.PortConfig) error {
+func (s *storeImpl) copyFromDeploymentsPorts(ctx context.Context, tx *postgres.Tx, deploymentID string, objs ...*storage.PortConfig) error {
 
 	inputRows := [][]interface{}{}
 
@@ -752,7 +752,7 @@ func (s *storeImpl) copyFromDeploymentsPorts(ctx context.Context, tx *postgres.T
 
 		inputRows = append(inputRows, []interface{}{
 
-			pgutils.NilOrUUID(deploymentsID),
+			pgutils.NilOrUUID(deploymentID),
 
 			idx,
 
@@ -782,7 +782,7 @@ func (s *storeImpl) copyFromDeploymentsPorts(ctx context.Context, tx *postgres.T
 	for idx, obj := range objs {
 		_ = idx // idx may or may not be used depending on how nested we are, so avoid compile-time errors.
 
-		if err = s.copyFromDeploymentsPortsExposureInfos(ctx, tx, deploymentsID, idx, obj.GetExposureInfos()...); err != nil {
+		if err = s.copyFromDeploymentsPortsExposureInfos(ctx, tx, deploymentID, idx, obj.GetExposureInfos()...); err != nil {
 			return err
 		}
 	}
@@ -790,7 +790,7 @@ func (s *storeImpl) copyFromDeploymentsPorts(ctx context.Context, tx *postgres.T
 	return err
 }
 
-func (s *storeImpl) copyFromDeploymentsPortsExposureInfos(ctx context.Context, tx *postgres.Tx, deploymentsID string, deploymentsPortsIdx int, objs ...*storage.PortConfig_ExposureInfo) error {
+func (s *storeImpl) copyFromDeploymentsPortsExposureInfos(ctx context.Context, tx *postgres.Tx, deploymentID string, deploymentPortIdx int, objs ...*storage.PortConfig_ExposureInfo) error {
 
 	inputRows := [][]interface{}{}
 
@@ -825,9 +825,9 @@ func (s *storeImpl) copyFromDeploymentsPortsExposureInfos(ctx context.Context, t
 
 		inputRows = append(inputRows, []interface{}{
 
-			pgutils.NilOrUUID(deploymentsID),
+			pgutils.NilOrUUID(deploymentID),
 
-			deploymentsPortsIdx,
+			deploymentPortIdx,
 
 			idx,
 

--- a/central/deployment/store/postgres/store.go
+++ b/central/deployment/store/postgres/store.go
@@ -133,11 +133,11 @@ func insertIntoDeployments(ctx context.Context, batch *pgx.Batch, obj *storage.D
 	return nil
 }
 
-func insertIntoDeploymentsContainers(ctx context.Context, batch *pgx.Batch, obj *storage.Container, deployments_Id string, idx int) error {
+func insertIntoDeploymentsContainers(ctx context.Context, batch *pgx.Batch, obj *storage.Container, deploymentsID string, idx int) error {
 
 	values := []interface{}{
 		// parent primary keys start
-		pgutils.NilOrUUID(deployments_Id),
+		pgutils.NilOrUUID(deploymentsID),
 		idx,
 		obj.GetImage().GetId(),
 		obj.GetImage().GetName().GetRegistry(),
@@ -160,38 +160,38 @@ func insertIntoDeploymentsContainers(ctx context.Context, batch *pgx.Batch, obj 
 	var query string
 
 	for childIndex, child := range obj.GetConfig().GetEnv() {
-		if err := insertIntoDeploymentsContainersEnvs(ctx, batch, child, deployments_Id, idx, childIndex); err != nil {
+		if err := insertIntoDeploymentsContainersEnvs(ctx, batch, child, deploymentsID, idx, childIndex); err != nil {
 			return err
 		}
 	}
 
 	query = "delete from deployments_containers_envs where deployments_Id = $1 AND deployments_containers_idx = $2 AND idx >= $3"
-	batch.Queue(query, pgutils.NilOrUUID(deployments_Id), idx, len(obj.GetConfig().GetEnv()))
+	batch.Queue(query, pgutils.NilOrUUID(deploymentsID), idx, len(obj.GetConfig().GetEnv()))
 	for childIndex, child := range obj.GetVolumes() {
-		if err := insertIntoDeploymentsContainersVolumes(ctx, batch, child, deployments_Id, idx, childIndex); err != nil {
+		if err := insertIntoDeploymentsContainersVolumes(ctx, batch, child, deploymentsID, idx, childIndex); err != nil {
 			return err
 		}
 	}
 
 	query = "delete from deployments_containers_volumes where deployments_Id = $1 AND deployments_containers_idx = $2 AND idx >= $3"
-	batch.Queue(query, pgutils.NilOrUUID(deployments_Id), idx, len(obj.GetVolumes()))
+	batch.Queue(query, pgutils.NilOrUUID(deploymentsID), idx, len(obj.GetVolumes()))
 	for childIndex, child := range obj.GetSecrets() {
-		if err := insertIntoDeploymentsContainersSecrets(ctx, batch, child, deployments_Id, idx, childIndex); err != nil {
+		if err := insertIntoDeploymentsContainersSecrets(ctx, batch, child, deploymentsID, idx, childIndex); err != nil {
 			return err
 		}
 	}
 
 	query = "delete from deployments_containers_secrets where deployments_Id = $1 AND deployments_containers_idx = $2 AND idx >= $3"
-	batch.Queue(query, pgutils.NilOrUUID(deployments_Id), idx, len(obj.GetSecrets()))
+	batch.Queue(query, pgutils.NilOrUUID(deploymentsID), idx, len(obj.GetSecrets()))
 	return nil
 }
 
-func insertIntoDeploymentsContainersEnvs(_ context.Context, batch *pgx.Batch, obj *storage.ContainerConfig_EnvironmentConfig, deployments_Id string, deployments_containers_idx int, idx int) error {
+func insertIntoDeploymentsContainersEnvs(_ context.Context, batch *pgx.Batch, obj *storage.ContainerConfig_EnvironmentConfig, deploymentsID string, deploymentsContainersIdx int, idx int) error {
 
 	values := []interface{}{
 		// parent primary keys start
-		pgutils.NilOrUUID(deployments_Id),
-		deployments_containers_idx,
+		pgutils.NilOrUUID(deploymentsID),
+		deploymentsContainersIdx,
 		idx,
 		obj.GetKey(),
 		obj.GetValue(),
@@ -204,12 +204,12 @@ func insertIntoDeploymentsContainersEnvs(_ context.Context, batch *pgx.Batch, ob
 	return nil
 }
 
-func insertIntoDeploymentsContainersVolumes(_ context.Context, batch *pgx.Batch, obj *storage.Volume, deployments_Id string, deployments_containers_idx int, idx int) error {
+func insertIntoDeploymentsContainersVolumes(_ context.Context, batch *pgx.Batch, obj *storage.Volume, deploymentsID string, deploymentsContainersIdx int, idx int) error {
 
 	values := []interface{}{
 		// parent primary keys start
-		pgutils.NilOrUUID(deployments_Id),
-		deployments_containers_idx,
+		pgutils.NilOrUUID(deploymentsID),
+		deploymentsContainersIdx,
 		idx,
 		obj.GetName(),
 		obj.GetSource(),
@@ -224,12 +224,12 @@ func insertIntoDeploymentsContainersVolumes(_ context.Context, batch *pgx.Batch,
 	return nil
 }
 
-func insertIntoDeploymentsContainersSecrets(_ context.Context, batch *pgx.Batch, obj *storage.EmbeddedSecret, deployments_Id string, deployments_containers_idx int, idx int) error {
+func insertIntoDeploymentsContainersSecrets(_ context.Context, batch *pgx.Batch, obj *storage.EmbeddedSecret, deploymentsID string, deploymentsContainersIdx int, idx int) error {
 
 	values := []interface{}{
 		// parent primary keys start
-		pgutils.NilOrUUID(deployments_Id),
-		deployments_containers_idx,
+		pgutils.NilOrUUID(deploymentsID),
+		deploymentsContainersIdx,
 		idx,
 		obj.GetName(),
 		obj.GetPath(),
@@ -241,11 +241,11 @@ func insertIntoDeploymentsContainersSecrets(_ context.Context, batch *pgx.Batch,
 	return nil
 }
 
-func insertIntoDeploymentsPorts(ctx context.Context, batch *pgx.Batch, obj *storage.PortConfig, deployments_Id string, idx int) error {
+func insertIntoDeploymentsPorts(ctx context.Context, batch *pgx.Batch, obj *storage.PortConfig, deploymentsID string, idx int) error {
 
 	values := []interface{}{
 		// parent primary keys start
-		pgutils.NilOrUUID(deployments_Id),
+		pgutils.NilOrUUID(deploymentsID),
 		idx,
 		obj.GetContainerPort(),
 		obj.GetProtocol(),
@@ -258,22 +258,22 @@ func insertIntoDeploymentsPorts(ctx context.Context, batch *pgx.Batch, obj *stor
 	var query string
 
 	for childIndex, child := range obj.GetExposureInfos() {
-		if err := insertIntoDeploymentsPortsExposureInfos(ctx, batch, child, deployments_Id, idx, childIndex); err != nil {
+		if err := insertIntoDeploymentsPortsExposureInfos(ctx, batch, child, deploymentsID, idx, childIndex); err != nil {
 			return err
 		}
 	}
 
 	query = "delete from deployments_ports_exposure_infos where deployments_Id = $1 AND deployments_ports_idx = $2 AND idx >= $3"
-	batch.Queue(query, pgutils.NilOrUUID(deployments_Id), idx, len(obj.GetExposureInfos()))
+	batch.Queue(query, pgutils.NilOrUUID(deploymentsID), idx, len(obj.GetExposureInfos()))
 	return nil
 }
 
-func insertIntoDeploymentsPortsExposureInfos(_ context.Context, batch *pgx.Batch, obj *storage.PortConfig_ExposureInfo, deployments_Id string, deployments_ports_idx int, idx int) error {
+func insertIntoDeploymentsPortsExposureInfos(_ context.Context, batch *pgx.Batch, obj *storage.PortConfig_ExposureInfo, deploymentsID string, deploymentsPortsIdx int, idx int) error {
 
 	values := []interface{}{
 		// parent primary keys start
-		pgutils.NilOrUUID(deployments_Id),
-		deployments_ports_idx,
+		pgutils.NilOrUUID(deploymentsID),
+		deploymentsPortsIdx,
 		idx,
 		obj.GetLevel(),
 		obj.GetServiceName(),
@@ -427,7 +427,7 @@ func (s *storeImpl) copyFromDeployments(ctx context.Context, tx *postgres.Tx, ob
 	return err
 }
 
-func (s *storeImpl) copyFromDeploymentsContainers(ctx context.Context, tx *postgres.Tx, deployments_Id string, objs ...*storage.Container) error {
+func (s *storeImpl) copyFromDeploymentsContainers(ctx context.Context, tx *postgres.Tx, deploymentsID string, objs ...*storage.Container) error {
 
 	inputRows := [][]interface{}{}
 
@@ -474,7 +474,7 @@ func (s *storeImpl) copyFromDeploymentsContainers(ctx context.Context, tx *postg
 
 		inputRows = append(inputRows, []interface{}{
 
-			pgutils.NilOrUUID(deployments_Id),
+			pgutils.NilOrUUID(deploymentsID),
 
 			idx,
 
@@ -524,13 +524,13 @@ func (s *storeImpl) copyFromDeploymentsContainers(ctx context.Context, tx *postg
 	for idx, obj := range objs {
 		_ = idx // idx may or may not be used depending on how nested we are, so avoid compile-time errors.
 
-		if err = s.copyFromDeploymentsContainersEnvs(ctx, tx, deployments_Id, idx, obj.GetConfig().GetEnv()...); err != nil {
+		if err = s.copyFromDeploymentsContainersEnvs(ctx, tx, deploymentsID, idx, obj.GetConfig().GetEnv()...); err != nil {
 			return err
 		}
-		if err = s.copyFromDeploymentsContainersVolumes(ctx, tx, deployments_Id, idx, obj.GetVolumes()...); err != nil {
+		if err = s.copyFromDeploymentsContainersVolumes(ctx, tx, deploymentsID, idx, obj.GetVolumes()...); err != nil {
 			return err
 		}
-		if err = s.copyFromDeploymentsContainersSecrets(ctx, tx, deployments_Id, idx, obj.GetSecrets()...); err != nil {
+		if err = s.copyFromDeploymentsContainersSecrets(ctx, tx, deploymentsID, idx, obj.GetSecrets()...); err != nil {
 			return err
 		}
 	}
@@ -538,7 +538,7 @@ func (s *storeImpl) copyFromDeploymentsContainers(ctx context.Context, tx *postg
 	return err
 }
 
-func (s *storeImpl) copyFromDeploymentsContainersEnvs(ctx context.Context, tx *postgres.Tx, deployments_Id string, deployments_containers_idx int, objs ...*storage.ContainerConfig_EnvironmentConfig) error {
+func (s *storeImpl) copyFromDeploymentsContainersEnvs(ctx context.Context, tx *postgres.Tx, deploymentsID string, deploymentsContainersIdx int, objs ...*storage.ContainerConfig_EnvironmentConfig) error {
 
 	inputRows := [][]interface{}{}
 
@@ -567,9 +567,9 @@ func (s *storeImpl) copyFromDeploymentsContainersEnvs(ctx context.Context, tx *p
 
 		inputRows = append(inputRows, []interface{}{
 
-			pgutils.NilOrUUID(deployments_Id),
+			pgutils.NilOrUUID(deploymentsID),
 
-			deployments_containers_idx,
+			deploymentsContainersIdx,
 
 			idx,
 
@@ -599,7 +599,7 @@ func (s *storeImpl) copyFromDeploymentsContainersEnvs(ctx context.Context, tx *p
 	return err
 }
 
-func (s *storeImpl) copyFromDeploymentsContainersVolumes(ctx context.Context, tx *postgres.Tx, deployments_Id string, deployments_containers_idx int, objs ...*storage.Volume) error {
+func (s *storeImpl) copyFromDeploymentsContainersVolumes(ctx context.Context, tx *postgres.Tx, deploymentsID string, deploymentsContainersIdx int, objs ...*storage.Volume) error {
 
 	inputRows := [][]interface{}{}
 
@@ -632,9 +632,9 @@ func (s *storeImpl) copyFromDeploymentsContainersVolumes(ctx context.Context, tx
 
 		inputRows = append(inputRows, []interface{}{
 
-			pgutils.NilOrUUID(deployments_Id),
+			pgutils.NilOrUUID(deploymentsID),
 
-			deployments_containers_idx,
+			deploymentsContainersIdx,
 
 			idx,
 
@@ -668,7 +668,7 @@ func (s *storeImpl) copyFromDeploymentsContainersVolumes(ctx context.Context, tx
 	return err
 }
 
-func (s *storeImpl) copyFromDeploymentsContainersSecrets(ctx context.Context, tx *postgres.Tx, deployments_Id string, deployments_containers_idx int, objs ...*storage.EmbeddedSecret) error {
+func (s *storeImpl) copyFromDeploymentsContainersSecrets(ctx context.Context, tx *postgres.Tx, deploymentsID string, deploymentsContainersIdx int, objs ...*storage.EmbeddedSecret) error {
 
 	inputRows := [][]interface{}{}
 
@@ -695,9 +695,9 @@ func (s *storeImpl) copyFromDeploymentsContainersSecrets(ctx context.Context, tx
 
 		inputRows = append(inputRows, []interface{}{
 
-			pgutils.NilOrUUID(deployments_Id),
+			pgutils.NilOrUUID(deploymentsID),
 
-			deployments_containers_idx,
+			deploymentsContainersIdx,
 
 			idx,
 
@@ -725,7 +725,7 @@ func (s *storeImpl) copyFromDeploymentsContainersSecrets(ctx context.Context, tx
 	return err
 }
 
-func (s *storeImpl) copyFromDeploymentsPorts(ctx context.Context, tx *postgres.Tx, deployments_Id string, objs ...*storage.PortConfig) error {
+func (s *storeImpl) copyFromDeploymentsPorts(ctx context.Context, tx *postgres.Tx, deploymentsID string, objs ...*storage.PortConfig) error {
 
 	inputRows := [][]interface{}{}
 
@@ -752,7 +752,7 @@ func (s *storeImpl) copyFromDeploymentsPorts(ctx context.Context, tx *postgres.T
 
 		inputRows = append(inputRows, []interface{}{
 
-			pgutils.NilOrUUID(deployments_Id),
+			pgutils.NilOrUUID(deploymentsID),
 
 			idx,
 
@@ -782,7 +782,7 @@ func (s *storeImpl) copyFromDeploymentsPorts(ctx context.Context, tx *postgres.T
 	for idx, obj := range objs {
 		_ = idx // idx may or may not be used depending on how nested we are, so avoid compile-time errors.
 
-		if err = s.copyFromDeploymentsPortsExposureInfos(ctx, tx, deployments_Id, idx, obj.GetExposureInfos()...); err != nil {
+		if err = s.copyFromDeploymentsPortsExposureInfos(ctx, tx, deploymentsID, idx, obj.GetExposureInfos()...); err != nil {
 			return err
 		}
 	}
@@ -790,7 +790,7 @@ func (s *storeImpl) copyFromDeploymentsPorts(ctx context.Context, tx *postgres.T
 	return err
 }
 
-func (s *storeImpl) copyFromDeploymentsPortsExposureInfos(ctx context.Context, tx *postgres.Tx, deployments_Id string, deployments_ports_idx int, objs ...*storage.PortConfig_ExposureInfo) error {
+func (s *storeImpl) copyFromDeploymentsPortsExposureInfos(ctx context.Context, tx *postgres.Tx, deploymentsID string, deploymentsPortsIdx int, objs ...*storage.PortConfig_ExposureInfo) error {
 
 	inputRows := [][]interface{}{}
 
@@ -825,9 +825,9 @@ func (s *storeImpl) copyFromDeploymentsPortsExposureInfos(ctx context.Context, t
 
 		inputRows = append(inputRows, []interface{}{
 
-			pgutils.NilOrUUID(deployments_Id),
+			pgutils.NilOrUUID(deploymentsID),
 
-			deployments_ports_idx,
+			deploymentsPortsIdx,
 
 			idx,
 

--- a/central/pod/store/postgres/store.go
+++ b/central/pod/store/postgres/store.go
@@ -113,11 +113,11 @@ func insertIntoPods(ctx context.Context, batch *pgx.Batch, obj *storage.Pod) err
 	return nil
 }
 
-func insertIntoPodsLiveInstances(_ context.Context, batch *pgx.Batch, obj *storage.ContainerInstance, podsID string, idx int) error {
+func insertIntoPodsLiveInstances(_ context.Context, batch *pgx.Batch, obj *storage.ContainerInstance, podID string, idx int) error {
 
 	values := []interface{}{
 		// parent primary keys start
-		pgutils.NilOrUUID(podsID),
+		pgutils.NilOrUUID(podID),
 		idx,
 		obj.GetImageDigest(),
 	}
@@ -215,7 +215,7 @@ func (s *storeImpl) copyFromPods(ctx context.Context, tx *postgres.Tx, objs ...*
 	return err
 }
 
-func (s *storeImpl) copyFromPodsLiveInstances(ctx context.Context, tx *postgres.Tx, podsID string, objs ...*storage.ContainerInstance) error {
+func (s *storeImpl) copyFromPodsLiveInstances(ctx context.Context, tx *postgres.Tx, podID string, objs ...*storage.ContainerInstance) error {
 
 	inputRows := [][]interface{}{}
 
@@ -238,7 +238,7 @@ func (s *storeImpl) copyFromPodsLiveInstances(ctx context.Context, tx *postgres.
 
 		inputRows = append(inputRows, []interface{}{
 
-			pgutils.NilOrUUID(podsID),
+			pgutils.NilOrUUID(podID),
 
 			idx,
 

--- a/central/pod/store/postgres/store.go
+++ b/central/pod/store/postgres/store.go
@@ -113,11 +113,11 @@ func insertIntoPods(ctx context.Context, batch *pgx.Batch, obj *storage.Pod) err
 	return nil
 }
 
-func insertIntoPodsLiveInstances(_ context.Context, batch *pgx.Batch, obj *storage.ContainerInstance, pods_Id string, idx int) error {
+func insertIntoPodsLiveInstances(_ context.Context, batch *pgx.Batch, obj *storage.ContainerInstance, podsID string, idx int) error {
 
 	values := []interface{}{
 		// parent primary keys start
-		pgutils.NilOrUUID(pods_Id),
+		pgutils.NilOrUUID(podsID),
 		idx,
 		obj.GetImageDigest(),
 	}
@@ -215,7 +215,7 @@ func (s *storeImpl) copyFromPods(ctx context.Context, tx *postgres.Tx, objs ...*
 	return err
 }
 
-func (s *storeImpl) copyFromPodsLiveInstances(ctx context.Context, tx *postgres.Tx, pods_Id string, objs ...*storage.ContainerInstance) error {
+func (s *storeImpl) copyFromPodsLiveInstances(ctx context.Context, tx *postgres.Tx, podsID string, objs ...*storage.ContainerInstance) error {
 
 	inputRows := [][]interface{}{}
 
@@ -238,7 +238,7 @@ func (s *storeImpl) copyFromPodsLiveInstances(ctx context.Context, tx *postgres.
 
 		inputRows = append(inputRows, []interface{}{
 
-			pgutils.NilOrUUID(pods_Id),
+			pgutils.NilOrUUID(podsID),
 
 			idx,
 

--- a/central/rbac/k8srolebinding/internal/store/postgres/store.go
+++ b/central/rbac/k8srolebinding/internal/store/postgres/store.go
@@ -117,11 +117,11 @@ func insertIntoRoleBindings(ctx context.Context, batch *pgx.Batch, obj *storage.
 	return nil
 }
 
-func insertIntoRoleBindingsSubjects(_ context.Context, batch *pgx.Batch, obj *storage.Subject, roleBindingsID string, idx int) error {
+func insertIntoRoleBindingsSubjects(_ context.Context, batch *pgx.Batch, obj *storage.Subject, roleBindingID string, idx int) error {
 
 	values := []interface{}{
 		// parent primary keys start
-		pgutils.NilOrUUID(roleBindingsID),
+		pgutils.NilOrUUID(roleBindingID),
 		idx,
 		obj.GetKind(),
 		obj.GetName(),
@@ -236,7 +236,7 @@ func (s *storeImpl) copyFromRoleBindings(ctx context.Context, tx *postgres.Tx, o
 	return err
 }
 
-func (s *storeImpl) copyFromRoleBindingsSubjects(ctx context.Context, tx *postgres.Tx, roleBindingsID string, objs ...*storage.Subject) error {
+func (s *storeImpl) copyFromRoleBindingsSubjects(ctx context.Context, tx *postgres.Tx, roleBindingID string, objs ...*storage.Subject) error {
 
 	inputRows := [][]interface{}{}
 
@@ -261,7 +261,7 @@ func (s *storeImpl) copyFromRoleBindingsSubjects(ctx context.Context, tx *postgr
 
 		inputRows = append(inputRows, []interface{}{
 
-			pgutils.NilOrUUID(roleBindingsID),
+			pgutils.NilOrUUID(roleBindingID),
 
 			idx,
 

--- a/central/rbac/k8srolebinding/internal/store/postgres/store.go
+++ b/central/rbac/k8srolebinding/internal/store/postgres/store.go
@@ -117,11 +117,11 @@ func insertIntoRoleBindings(ctx context.Context, batch *pgx.Batch, obj *storage.
 	return nil
 }
 
-func insertIntoRoleBindingsSubjects(_ context.Context, batch *pgx.Batch, obj *storage.Subject, role_bindings_Id string, idx int) error {
+func insertIntoRoleBindingsSubjects(_ context.Context, batch *pgx.Batch, obj *storage.Subject, roleBindingsID string, idx int) error {
 
 	values := []interface{}{
 		// parent primary keys start
-		pgutils.NilOrUUID(role_bindings_Id),
+		pgutils.NilOrUUID(roleBindingsID),
 		idx,
 		obj.GetKind(),
 		obj.GetName(),
@@ -236,7 +236,7 @@ func (s *storeImpl) copyFromRoleBindings(ctx context.Context, tx *postgres.Tx, o
 	return err
 }
 
-func (s *storeImpl) copyFromRoleBindingsSubjects(ctx context.Context, tx *postgres.Tx, role_bindings_Id string, objs ...*storage.Subject) error {
+func (s *storeImpl) copyFromRoleBindingsSubjects(ctx context.Context, tx *postgres.Tx, roleBindingsID string, objs ...*storage.Subject) error {
 
 	inputRows := [][]interface{}{}
 
@@ -261,7 +261,7 @@ func (s *storeImpl) copyFromRoleBindingsSubjects(ctx context.Context, tx *postgr
 
 		inputRows = append(inputRows, []interface{}{
 
-			pgutils.NilOrUUID(role_bindings_Id),
+			pgutils.NilOrUUID(roleBindingsID),
 
 			idx,
 

--- a/central/resourcecollection/datastore/store/postgres/store.go
+++ b/central/resourcecollection/datastore/store/postgres/store.go
@@ -110,11 +110,11 @@ func insertIntoCollections(ctx context.Context, batch *pgx.Batch, obj *storage.R
 	return nil
 }
 
-func insertIntoCollectionsEmbeddedCollections(_ context.Context, batch *pgx.Batch, obj *storage.ResourceCollection_EmbeddedResourceCollection, collections_Id string, idx int) error {
+func insertIntoCollectionsEmbeddedCollections(_ context.Context, batch *pgx.Batch, obj *storage.ResourceCollection_EmbeddedResourceCollection, collectionsID string, idx int) error {
 
 	values := []interface{}{
 		// parent primary keys start
-		collections_Id,
+		collectionsID,
 		idx,
 		obj.GetId(),
 	}
@@ -208,7 +208,7 @@ func (s *storeImpl) copyFromCollections(ctx context.Context, tx *postgres.Tx, ob
 	return err
 }
 
-func (s *storeImpl) copyFromCollectionsEmbeddedCollections(ctx context.Context, tx *postgres.Tx, collections_Id string, objs ...*storage.ResourceCollection_EmbeddedResourceCollection) error {
+func (s *storeImpl) copyFromCollectionsEmbeddedCollections(ctx context.Context, tx *postgres.Tx, collectionsID string, objs ...*storage.ResourceCollection_EmbeddedResourceCollection) error {
 
 	inputRows := [][]interface{}{}
 
@@ -231,7 +231,7 @@ func (s *storeImpl) copyFromCollectionsEmbeddedCollections(ctx context.Context, 
 
 		inputRows = append(inputRows, []interface{}{
 
-			collections_Id,
+			collectionsID,
 
 			idx,
 

--- a/central/resourcecollection/datastore/store/postgres/store.go
+++ b/central/resourcecollection/datastore/store/postgres/store.go
@@ -110,11 +110,11 @@ func insertIntoCollections(ctx context.Context, batch *pgx.Batch, obj *storage.R
 	return nil
 }
 
-func insertIntoCollectionsEmbeddedCollections(_ context.Context, batch *pgx.Batch, obj *storage.ResourceCollection_EmbeddedResourceCollection, collectionsID string, idx int) error {
+func insertIntoCollectionsEmbeddedCollections(_ context.Context, batch *pgx.Batch, obj *storage.ResourceCollection_EmbeddedResourceCollection, collectionID string, idx int) error {
 
 	values := []interface{}{
 		// parent primary keys start
-		collectionsID,
+		collectionID,
 		idx,
 		obj.GetId(),
 	}
@@ -208,7 +208,7 @@ func (s *storeImpl) copyFromCollections(ctx context.Context, tx *postgres.Tx, ob
 	return err
 }
 
-func (s *storeImpl) copyFromCollectionsEmbeddedCollections(ctx context.Context, tx *postgres.Tx, collectionsID string, objs ...*storage.ResourceCollection_EmbeddedResourceCollection) error {
+func (s *storeImpl) copyFromCollectionsEmbeddedCollections(ctx context.Context, tx *postgres.Tx, collectionID string, objs ...*storage.ResourceCollection_EmbeddedResourceCollection) error {
 
 	inputRows := [][]interface{}{}
 
@@ -231,7 +231,7 @@ func (s *storeImpl) copyFromCollectionsEmbeddedCollections(ctx context.Context, 
 
 		inputRows = append(inputRows, []interface{}{
 
-			collectionsID,
+			collectionID,
 
 			idx,
 

--- a/central/secret/internal/store/postgres/store.go
+++ b/central/secret/internal/store/postgres/store.go
@@ -114,11 +114,11 @@ func insertIntoSecrets(ctx context.Context, batch *pgx.Batch, obj *storage.Secre
 	return nil
 }
 
-func insertIntoSecretsFiles(ctx context.Context, batch *pgx.Batch, obj *storage.SecretDataFile, secrets_Id string, idx int) error {
+func insertIntoSecretsFiles(ctx context.Context, batch *pgx.Batch, obj *storage.SecretDataFile, secretsID string, idx int) error {
 
 	values := []interface{}{
 		// parent primary keys start
-		pgutils.NilOrUUID(secrets_Id),
+		pgutils.NilOrUUID(secretsID),
 		idx,
 		obj.GetType(),
 		pgutils.NilOrTime(obj.GetCert().GetEndDate()),
@@ -130,22 +130,22 @@ func insertIntoSecretsFiles(ctx context.Context, batch *pgx.Batch, obj *storage.
 	var query string
 
 	for childIndex, child := range obj.GetImagePullSecret().GetRegistries() {
-		if err := insertIntoSecretsFilesRegistries(ctx, batch, child, secrets_Id, idx, childIndex); err != nil {
+		if err := insertIntoSecretsFilesRegistries(ctx, batch, child, secretsID, idx, childIndex); err != nil {
 			return err
 		}
 	}
 
 	query = "delete from secrets_files_registries where secrets_Id = $1 AND secrets_files_idx = $2 AND idx >= $3"
-	batch.Queue(query, pgutils.NilOrUUID(secrets_Id), idx, len(obj.GetImagePullSecret().GetRegistries()))
+	batch.Queue(query, pgutils.NilOrUUID(secretsID), idx, len(obj.GetImagePullSecret().GetRegistries()))
 	return nil
 }
 
-func insertIntoSecretsFilesRegistries(_ context.Context, batch *pgx.Batch, obj *storage.ImagePullSecret_Registry, secrets_Id string, secrets_files_idx int, idx int) error {
+func insertIntoSecretsFilesRegistries(_ context.Context, batch *pgx.Batch, obj *storage.ImagePullSecret_Registry, secretsID string, secretsFilesIdx int, idx int) error {
 
 	values := []interface{}{
 		// parent primary keys start
-		pgutils.NilOrUUID(secrets_Id),
-		secrets_files_idx,
+		pgutils.NilOrUUID(secretsID),
+		secretsFilesIdx,
 		idx,
 		obj.GetName(),
 	}
@@ -247,7 +247,7 @@ func (s *storeImpl) copyFromSecrets(ctx context.Context, tx *postgres.Tx, objs .
 	return err
 }
 
-func (s *storeImpl) copyFromSecretsFiles(ctx context.Context, tx *postgres.Tx, secrets_Id string, objs ...*storage.SecretDataFile) error {
+func (s *storeImpl) copyFromSecretsFiles(ctx context.Context, tx *postgres.Tx, secretsID string, objs ...*storage.SecretDataFile) error {
 
 	inputRows := [][]interface{}{}
 
@@ -272,7 +272,7 @@ func (s *storeImpl) copyFromSecretsFiles(ctx context.Context, tx *postgres.Tx, s
 
 		inputRows = append(inputRows, []interface{}{
 
-			pgutils.NilOrUUID(secrets_Id),
+			pgutils.NilOrUUID(secretsID),
 
 			idx,
 
@@ -300,7 +300,7 @@ func (s *storeImpl) copyFromSecretsFiles(ctx context.Context, tx *postgres.Tx, s
 	for idx, obj := range objs {
 		_ = idx // idx may or may not be used depending on how nested we are, so avoid compile-time errors.
 
-		if err = s.copyFromSecretsFilesRegistries(ctx, tx, secrets_Id, idx, obj.GetImagePullSecret().GetRegistries()...); err != nil {
+		if err = s.copyFromSecretsFilesRegistries(ctx, tx, secretsID, idx, obj.GetImagePullSecret().GetRegistries()...); err != nil {
 			return err
 		}
 	}
@@ -308,7 +308,7 @@ func (s *storeImpl) copyFromSecretsFiles(ctx context.Context, tx *postgres.Tx, s
 	return err
 }
 
-func (s *storeImpl) copyFromSecretsFilesRegistries(ctx context.Context, tx *postgres.Tx, secrets_Id string, secrets_files_idx int, objs ...*storage.ImagePullSecret_Registry) error {
+func (s *storeImpl) copyFromSecretsFilesRegistries(ctx context.Context, tx *postgres.Tx, secretsID string, secretsFilesIdx int, objs ...*storage.ImagePullSecret_Registry) error {
 
 	inputRows := [][]interface{}{}
 
@@ -333,9 +333,9 @@ func (s *storeImpl) copyFromSecretsFilesRegistries(ctx context.Context, tx *post
 
 		inputRows = append(inputRows, []interface{}{
 
-			pgutils.NilOrUUID(secrets_Id),
+			pgutils.NilOrUUID(secretsID),
 
-			secrets_files_idx,
+			secretsFilesIdx,
 
 			idx,
 

--- a/central/vulnerabilityrequest/datastore/internal/store/postgres/store.go
+++ b/central/vulnerabilityrequest/datastore/internal/store/postgres/store.go
@@ -122,11 +122,11 @@ func insertIntoVulnerabilityRequests(ctx context.Context, batch *pgx.Batch, obj 
 	return nil
 }
 
-func insertIntoVulnerabilityRequestsApprovers(_ context.Context, batch *pgx.Batch, obj *storage.SlimUser, vulnerability_requests_Id string, idx int) error {
+func insertIntoVulnerabilityRequestsApprovers(_ context.Context, batch *pgx.Batch, obj *storage.SlimUser, vulnerabilityRequestsID string, idx int) error {
 
 	values := []interface{}{
 		// parent primary keys start
-		vulnerability_requests_Id,
+		vulnerabilityRequestsID,
 		idx,
 		obj.GetName(),
 	}
@@ -137,11 +137,11 @@ func insertIntoVulnerabilityRequestsApprovers(_ context.Context, batch *pgx.Batc
 	return nil
 }
 
-func insertIntoVulnerabilityRequestsComments(_ context.Context, batch *pgx.Batch, obj *storage.RequestComment, vulnerability_requests_Id string, idx int) error {
+func insertIntoVulnerabilityRequestsComments(_ context.Context, batch *pgx.Batch, obj *storage.RequestComment, vulnerabilityRequestsID string, idx int) error {
 
 	values := []interface{}{
 		// parent primary keys start
-		vulnerability_requests_Id,
+		vulnerabilityRequestsID,
 		idx,
 		obj.GetUser().GetName(),
 	}
@@ -262,7 +262,7 @@ func (s *storeImpl) copyFromVulnerabilityRequests(ctx context.Context, tx *postg
 	return err
 }
 
-func (s *storeImpl) copyFromVulnerabilityRequestsApprovers(ctx context.Context, tx *postgres.Tx, vulnerability_requests_Id string, objs ...*storage.SlimUser) error {
+func (s *storeImpl) copyFromVulnerabilityRequestsApprovers(ctx context.Context, tx *postgres.Tx, vulnerabilityRequestsID string, objs ...*storage.SlimUser) error {
 
 	inputRows := [][]interface{}{}
 
@@ -285,7 +285,7 @@ func (s *storeImpl) copyFromVulnerabilityRequestsApprovers(ctx context.Context, 
 
 		inputRows = append(inputRows, []interface{}{
 
-			vulnerability_requests_Id,
+			vulnerabilityRequestsID,
 
 			idx,
 
@@ -311,7 +311,7 @@ func (s *storeImpl) copyFromVulnerabilityRequestsApprovers(ctx context.Context, 
 	return err
 }
 
-func (s *storeImpl) copyFromVulnerabilityRequestsComments(ctx context.Context, tx *postgres.Tx, vulnerability_requests_Id string, objs ...*storage.RequestComment) error {
+func (s *storeImpl) copyFromVulnerabilityRequestsComments(ctx context.Context, tx *postgres.Tx, vulnerabilityRequestsID string, objs ...*storage.RequestComment) error {
 
 	inputRows := [][]interface{}{}
 
@@ -334,7 +334,7 @@ func (s *storeImpl) copyFromVulnerabilityRequestsComments(ctx context.Context, t
 
 		inputRows = append(inputRows, []interface{}{
 
-			vulnerability_requests_Id,
+			vulnerabilityRequestsID,
 
 			idx,
 

--- a/central/vulnerabilityrequest/datastore/internal/store/postgres/store.go
+++ b/central/vulnerabilityrequest/datastore/internal/store/postgres/store.go
@@ -122,11 +122,11 @@ func insertIntoVulnerabilityRequests(ctx context.Context, batch *pgx.Batch, obj 
 	return nil
 }
 
-func insertIntoVulnerabilityRequestsApprovers(_ context.Context, batch *pgx.Batch, obj *storage.SlimUser, vulnerabilityRequestsID string, idx int) error {
+func insertIntoVulnerabilityRequestsApprovers(_ context.Context, batch *pgx.Batch, obj *storage.SlimUser, vulnerabilityRequestID string, idx int) error {
 
 	values := []interface{}{
 		// parent primary keys start
-		vulnerabilityRequestsID,
+		vulnerabilityRequestID,
 		idx,
 		obj.GetName(),
 	}
@@ -137,11 +137,11 @@ func insertIntoVulnerabilityRequestsApprovers(_ context.Context, batch *pgx.Batc
 	return nil
 }
 
-func insertIntoVulnerabilityRequestsComments(_ context.Context, batch *pgx.Batch, obj *storage.RequestComment, vulnerabilityRequestsID string, idx int) error {
+func insertIntoVulnerabilityRequestsComments(_ context.Context, batch *pgx.Batch, obj *storage.RequestComment, vulnerabilityRequestID string, idx int) error {
 
 	values := []interface{}{
 		// parent primary keys start
-		vulnerabilityRequestsID,
+		vulnerabilityRequestID,
 		idx,
 		obj.GetUser().GetName(),
 	}
@@ -262,7 +262,7 @@ func (s *storeImpl) copyFromVulnerabilityRequests(ctx context.Context, tx *postg
 	return err
 }
 
-func (s *storeImpl) copyFromVulnerabilityRequestsApprovers(ctx context.Context, tx *postgres.Tx, vulnerabilityRequestsID string, objs ...*storage.SlimUser) error {
+func (s *storeImpl) copyFromVulnerabilityRequestsApprovers(ctx context.Context, tx *postgres.Tx, vulnerabilityRequestID string, objs ...*storage.SlimUser) error {
 
 	inputRows := [][]interface{}{}
 
@@ -285,7 +285,7 @@ func (s *storeImpl) copyFromVulnerabilityRequestsApprovers(ctx context.Context, 
 
 		inputRows = append(inputRows, []interface{}{
 
-			vulnerabilityRequestsID,
+			vulnerabilityRequestID,
 
 			idx,
 
@@ -311,7 +311,7 @@ func (s *storeImpl) copyFromVulnerabilityRequestsApprovers(ctx context.Context, 
 	return err
 }
 
-func (s *storeImpl) copyFromVulnerabilityRequestsComments(ctx context.Context, tx *postgres.Tx, vulnerabilityRequestsID string, objs ...*storage.RequestComment) error {
+func (s *storeImpl) copyFromVulnerabilityRequestsComments(ctx context.Context, tx *postgres.Tx, vulnerabilityRequestID string, objs ...*storage.RequestComment) error {
 
 	inputRows := [][]interface{}{}
 
@@ -334,7 +334,7 @@ func (s *storeImpl) copyFromVulnerabilityRequestsComments(ctx context.Context, t
 
 		inputRows = append(inputRows, []interface{}{
 
-			vulnerabilityRequestsID,
+			vulnerabilityRequestID,
 
 			idx,
 

--- a/migrator/migrations/postgreshelper/schema/convert_test_grandparents.go
+++ b/migrator/migrations/postgreshelper/schema/convert_test_grandparents.go
@@ -22,9 +22,9 @@ func ConvertTestGrandparentFromProto(obj *storage.TestGrandparent) (*TestGrandpa
 }
 
 // ConvertTestGrandparent_EmbeddedFromProto converts a `*storage.TestGrandparent_Embedded` to Gorm model
-func ConvertTestGrandparent_EmbeddedFromProto(obj *storage.TestGrandparent_Embedded, idx int, test_grandparents_Id string) (*TestGrandparentsEmbeddeds, error) {
+func ConvertTestGrandparent_EmbeddedFromProto(obj *storage.TestGrandparent_Embedded, idx int, testGrandparentsID string) (*TestGrandparentsEmbeddeds, error) {
 	model := &TestGrandparentsEmbeddeds{
-		TestGrandparentsID: test_grandparents_Id,
+		TestGrandparentsID: testGrandparentsID,
 		Idx:                idx,
 		Val:                obj.GetVal(),
 	}
@@ -32,10 +32,10 @@ func ConvertTestGrandparent_EmbeddedFromProto(obj *storage.TestGrandparent_Embed
 }
 
 // ConvertTestGrandparent_Embedded_Embedded2FromProto converts a `*storage.TestGrandparent_Embedded_Embedded2` to Gorm model
-func ConvertTestGrandparent_Embedded_Embedded2FromProto(obj *storage.TestGrandparent_Embedded_Embedded2, idx int, test_grandparents_Id string, test_grandparents_embeddeds_idx int) (*TestGrandparentsEmbeddedsEmbedded2, error) {
+func ConvertTestGrandparent_Embedded_Embedded2FromProto(obj *storage.TestGrandparent_Embedded_Embedded2, idx int, testGrandparentsID string, testGrandparentsEmbeddedsIdx int) (*TestGrandparentsEmbeddedsEmbedded2, error) {
 	model := &TestGrandparentsEmbeddedsEmbedded2{
-		TestGrandparentsID:           test_grandparents_Id,
-		TestGrandparentsEmbeddedsIdx: test_grandparents_embeddeds_idx,
+		TestGrandparentsID:           testGrandparentsID,
+		TestGrandparentsEmbeddedsIdx: testGrandparentsEmbeddedsIdx,
 		Idx:                          idx,
 		Val:                          obj.GetVal(),
 	}

--- a/migrator/migrations/postgreshelper/schema/convert_test_grandparents.go
+++ b/migrator/migrations/postgreshelper/schema/convert_test_grandparents.go
@@ -22,9 +22,9 @@ func ConvertTestGrandparentFromProto(obj *storage.TestGrandparent) (*TestGrandpa
 }
 
 // ConvertTestGrandparent_EmbeddedFromProto converts a `*storage.TestGrandparent_Embedded` to Gorm model
-func ConvertTestGrandparent_EmbeddedFromProto(obj *storage.TestGrandparent_Embedded, idx int, testGrandparentsID string) (*TestGrandparentsEmbeddeds, error) {
+func ConvertTestGrandparent_EmbeddedFromProto(obj *storage.TestGrandparent_Embedded, idx int, testGrandparentID string) (*TestGrandparentsEmbeddeds, error) {
 	model := &TestGrandparentsEmbeddeds{
-		TestGrandparentsID: testGrandparentsID,
+		TestGrandparentsID: testGrandparentID,
 		Idx:                idx,
 		Val:                obj.GetVal(),
 	}
@@ -32,10 +32,10 @@ func ConvertTestGrandparent_EmbeddedFromProto(obj *storage.TestGrandparent_Embed
 }
 
 // ConvertTestGrandparent_Embedded_Embedded2FromProto converts a `*storage.TestGrandparent_Embedded_Embedded2` to Gorm model
-func ConvertTestGrandparent_Embedded_Embedded2FromProto(obj *storage.TestGrandparent_Embedded_Embedded2, idx int, testGrandparentsID string, testGrandparentsEmbeddedsIdx int) (*TestGrandparentsEmbeddedsEmbedded2, error) {
+func ConvertTestGrandparent_Embedded_Embedded2FromProto(obj *storage.TestGrandparent_Embedded_Embedded2, idx int, testGrandparentID string, testGrandparentEmbeddedIdx int) (*TestGrandparentsEmbeddedsEmbedded2, error) {
 	model := &TestGrandparentsEmbeddedsEmbedded2{
-		TestGrandparentsID:           testGrandparentsID,
-		TestGrandparentsEmbeddedsIdx: testGrandparentsEmbeddedsIdx,
+		TestGrandparentsID:           testGrandparentID,
+		TestGrandparentsEmbeddedsIdx: testGrandparentEmbeddedIdx,
 		Idx:                          idx,
 		Val:                          obj.GetVal(),
 	}

--- a/migrator/migrations/postgreshelper/schema/convert_test_multi_key_structs.go
+++ b/migrator/migrations/postgreshelper/schema/convert_test_multi_key_structs.go
@@ -34,10 +34,10 @@ func ConvertTestMultiKeyStructFromProto(obj *storage.TestMultiKeyStruct) (*TestM
 }
 
 // ConvertTestMultiKeyStruct_NestedFromProto converts a `*storage.TestMultiKeyStruct_Nested` to Gorm model
-func ConvertTestMultiKeyStruct_NestedFromProto(obj *storage.TestMultiKeyStruct_Nested, idx int, test_multi_key_structs_Key1 string, test_multi_key_structs_Key2 string) (*TestMultiKeyStructsNesteds, error) {
+func ConvertTestMultiKeyStruct_NestedFromProto(obj *storage.TestMultiKeyStruct_Nested, idx int, testMultiKeyStructsKey1 string, testMultiKeyStructsKey2 string) (*TestMultiKeyStructsNesteds, error) {
 	model := &TestMultiKeyStructsNesteds{
-		TestMultiKeyStructsKey1: test_multi_key_structs_Key1,
-		TestMultiKeyStructsKey2: test_multi_key_structs_Key2,
+		TestMultiKeyStructsKey1: testMultiKeyStructsKey1,
+		TestMultiKeyStructsKey2: testMultiKeyStructsKey2,
 		Idx:                     idx,
 		Nested:                  obj.GetNested(),
 		IsNested:                obj.GetIsNested(),

--- a/migrator/migrations/postgreshelper/schema/convert_test_multi_key_structs.go
+++ b/migrator/migrations/postgreshelper/schema/convert_test_multi_key_structs.go
@@ -34,10 +34,10 @@ func ConvertTestMultiKeyStructFromProto(obj *storage.TestMultiKeyStruct) (*TestM
 }
 
 // ConvertTestMultiKeyStruct_NestedFromProto converts a `*storage.TestMultiKeyStruct_Nested` to Gorm model
-func ConvertTestMultiKeyStruct_NestedFromProto(obj *storage.TestMultiKeyStruct_Nested, idx int, testMultiKeyStructsKey1 string, testMultiKeyStructsKey2 string) (*TestMultiKeyStructsNesteds, error) {
+func ConvertTestMultiKeyStruct_NestedFromProto(obj *storage.TestMultiKeyStruct_Nested, idx int, testMultiKeyStructKey1 string, testMultiKeyStructKey2 string) (*TestMultiKeyStructsNesteds, error) {
 	model := &TestMultiKeyStructsNesteds{
-		TestMultiKeyStructsKey1: testMultiKeyStructsKey1,
-		TestMultiKeyStructsKey2: testMultiKeyStructsKey2,
+		TestMultiKeyStructsKey1: testMultiKeyStructKey1,
+		TestMultiKeyStructsKey2: testMultiKeyStructKey2,
 		Idx:                     idx,
 		Nested:                  obj.GetNested(),
 		IsNested:                obj.GetIsNested(),

--- a/migrator/migrations/postgreshelper/schema/convert_test_parent1.go
+++ b/migrator/migrations/postgreshelper/schema/convert_test_parent1.go
@@ -21,9 +21,9 @@ func ConvertTestParent1FromProto(obj *storage.TestParent1) (*TestParent1, error)
 }
 
 // ConvertTestParent1_Child1RefFromProto converts a `*storage.TestParent1_Child1Ref` to Gorm model
-func ConvertTestParent1_Child1RefFromProto(obj *storage.TestParent1_Child1Ref, idx int, test_parent1_Id string) (*TestParent1Childrens, error) {
+func ConvertTestParent1_Child1RefFromProto(obj *storage.TestParent1_Child1Ref, idx int, testParent1ID string) (*TestParent1Childrens, error) {
 	model := &TestParent1Childrens{
-		TestParent1ID: test_parent1_Id,
+		TestParent1ID: testParent1ID,
 		Idx:           idx,
 		ChildID:       obj.GetChildId(),
 	}

--- a/pkg/postgres/walker/stringutils.go
+++ b/pkg/postgres/walker/stringutils.go
@@ -12,16 +12,32 @@ func applyPointwise(ss []string, f func(string) string) {
 	}
 }
 
-func snakeCaseToLowerCamelCase(s string) string {
+func makeSingular(s string) string {
+	l := len(s)
+	if l == 0 {
+		return s
+	}
+	if l == 1 && (s[0] == 's' || s[0] == 'S') {
+		return s[:l-1]
+	}
+	if s[l-1] == 's' {
+		return s[:l-1]
+	}
+	return s
+}
+
+func snakeCaseToSingularLowerCamelCase(s string) string {
 	words := strings.Split(s, "_")
 	if len(words) == 0 {
 		return s
 	}
 	words[0] = strings.ToLower(words[0])
+	words[0] = makeSingular(words[0])
 	if len(words) == 1 && words[0] == "id" {
 		return "id"
 	}
 	applyPointwise(words[1:], strings.Title)
+	applyPointwise(words[1:], makeSingular)
 	applyPointwise(words, stringutils.UpperCaseAcronyms)
 	return strings.Join(words, "")
 }

--- a/pkg/postgres/walker/stringutils.go
+++ b/pkg/postgres/walker/stringutils.go
@@ -12,13 +12,15 @@ func applyPointwise(ss []string, f func(string) string) {
 	}
 }
 
+// makeSingular aims at converting a title or lower-case word to its singular form.
+// assumption is made that any multi-letter word ending with s is a plural word and its singular form
+// is without trailing s.
+// Although this is not always a valid assumption (example of assumption flaw: matress),
+// this seems to be verified with the postgres table and children-table names.
 func makeSingular(s string) string {
 	l := len(s)
-	if l == 0 {
+	if l <= 1 {
 		return s
-	}
-	if l == 1 && (s[0] == 's' || s[0] == 'S') {
-		return s[:l-1]
 	}
 	if s[l-1] == 's' {
 		return s[:l-1]

--- a/pkg/postgres/walker/stringutils.go
+++ b/pkg/postgres/walker/stringutils.go
@@ -1,0 +1,27 @@
+package walker
+
+import (
+	"strings"
+
+	"github.com/stackrox/rox/pkg/stringutils"
+)
+
+func applyPointwise(ss []string, f func(string) string) {
+	for i, s := range ss {
+		ss[i] = f(s)
+	}
+}
+
+func snakeCaseToLowerCamelCase(s string) string {
+	words := strings.Split(s, "_")
+	if len(words) == 0 {
+		return s
+	}
+	words[0] = strings.ToLower(words[0])
+	if len(words) == 1 && words[0] == "id" {
+		return "id"
+	}
+	applyPointwise(words[1:], strings.Title)
+	applyPointwise(words, stringutils.UpperCaseAcronyms)
+	return strings.Join(words, "")
+}

--- a/pkg/postgres/walker/stringutils_test.go
+++ b/pkg/postgres/walker/stringutils_test.go
@@ -1,0 +1,55 @@
+package walker
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMakeSingular(t *testing.T) {
+	testCases := []struct {
+		name           string
+		sample         string
+		expectedOutput string
+	}{
+		{
+			name:           "Empty string stays empty",
+			sample:         "",
+			expectedOutput: "",
+		},
+		{
+			name:           "single-character string (random not \"s\") stays the same",
+			sample:         "a",
+			expectedOutput: "a",
+		},
+		{
+			name:           "single-character string (random not \"s\") stays the same",
+			sample:         "Z",
+			expectedOutput: "Z",
+		},
+		{
+			name:           "single-character string (\"s\") stays the same",
+			sample:         "s",
+			expectedOutput: "s",
+		},
+		{
+			name:           "single-character string (\"S\") stays the same",
+			sample:         "S",
+			expectedOutput: "S",
+		},
+		{
+			name:           "singular word (not ending with \"s\") stays the same",
+			sample:         "example",
+			expectedOutput: "example",
+		},
+		{
+			name:           "plural word (ending with \"s\") gets corrected",
+			sample:         "deployments",
+			expectedOutput: "deployment",
+		},
+	}
+
+	for _, c := range testCases {
+		assert.Equal(t, c.expectedOutput, makeSingular(c.sample), c.name)
+	}
+}

--- a/pkg/postgres/walker/walker.go
+++ b/pkg/postgres/walker/walker.go
@@ -101,7 +101,7 @@ func addCommonFields(s *Schema, parentPrimaryKeys ...Field) {
 			} else {
 				columnNameInChild = parentPrimaryKey.ColumnName
 			}
-			columnNameInChildForCodeVariables = snakeCaseToLowerCamelCase(columnNameInChild)
+			columnNameInChildForCodeVariables = snakeCaseToSingularLowerCamelCase(columnNameInChild)
 			additionalFields = append(additionalFields, Field{
 				Schema: s,
 				Name:   columnNameInChildForCodeVariables,

--- a/pkg/postgres/walker/walker.go
+++ b/pkg/postgres/walker/walker.go
@@ -91,6 +91,7 @@ func addCommonFields(s *Schema, parentPrimaryKeys ...Field) {
 		// represents the index of this specific child among the parent's children).
 		for _, parentPrimaryKey := range parentPrimaryKeys {
 			var columnNameInChild string
+			var columnNameInChildForCodeVariables string
 			// If a column in a child table references a column "X" in the parent table, we
 			// name the column in the child "parent_table_name_X".
 			// We keep this name even in the grandchild, and do not continuously add prefixes in front.
@@ -100,11 +101,12 @@ func addCommonFields(s *Schema, parentPrimaryKeys ...Field) {
 			} else {
 				columnNameInChild = parentPrimaryKey.ColumnName
 			}
+			columnNameInChildForCodeVariables = snakeCaseToLowerCamelCase(columnNameInChild)
 			additionalFields = append(additionalFields, Field{
 				Schema: s,
-				Name:   columnNameInChild,
+				Name:   columnNameInChildForCodeVariables,
 				ObjectGetter: ObjectGetter{
-					value:    columnNameInChild,
+					value:    columnNameInChildForCodeVariables,
 					variable: true,
 				},
 				ColumnName: columnNameInChild,

--- a/pkg/stringutils/uppercaseacronyms.go
+++ b/pkg/stringutils/uppercaseacronyms.go
@@ -14,6 +14,8 @@ var (
 	}
 )
 
+// UpperCaseAcronyms returns the uppercase variant of the input if it is one of a specific set of acronyms
+// (currently API, CPU, ID, UID, UUID).
 func UpperCaseAcronyms(s string) string {
 	uc := strings.ToUpper(s)
 	if _, found := acronymsToUpperCase[uc]; found {

--- a/pkg/stringutils/uppercaseacronyms.go
+++ b/pkg/stringutils/uppercaseacronyms.go
@@ -1,0 +1,23 @@
+package stringutils
+
+import (
+	"strings"
+)
+
+var (
+	acronymsToUpperCase = map[string]struct{}{
+		"API":  {},
+		"CPU":  {},
+		"ID":   {},
+		"UID":  {},
+		"UUID": {},
+	}
+)
+
+func UpperCaseAcronyms(s string) string {
+	uc := strings.ToUpper(s)
+	if _, found := acronymsToUpperCase[uc]; found {
+		return uc
+	}
+	return s
+}

--- a/tools/generate-helpers/pg-table-bindings/funcs.go
+++ b/tools/generate-helpers/pg-table-bindings/funcs.go
@@ -77,24 +77,6 @@ func applyPointwise(ss []string, f func(string) string) {
 	}
 }
 
-var (
-	acronymsToUpperCase = map[string]struct{}{
-		"API":  {},
-		"CPU":  {},
-		"ID":   {},
-		"UID":  {},
-		"UUID": {},
-	}
-)
-
-func upperCaseAcronyms(s string) string {
-	uc := strings.ToUpper(s)
-	if _, found := acronymsToUpperCase[uc]; found {
-		return uc
-	}
-	return s
-}
-
 func lowerCamelCase(s string) string {
 	words := splitWords(s)
 	if len(words) == 0 {
@@ -105,7 +87,7 @@ func lowerCamelCase(s string) string {
 		return "id"
 	}
 	applyPointwise(words[1:], strings.Title)
-	applyPointwise(words, upperCaseAcronyms)
+	applyPointwise(words, stringutils.UpperCaseAcronyms)
 	return strings.Join(words, "")
 }
 
@@ -115,7 +97,7 @@ func upperCamelCase(s string) string {
 		return ""
 	}
 	applyPointwise(words, strings.Title)
-	applyPointwise(words, upperCaseAcronyms)
+	applyPointwise(words, stringutils.UpperCaseAcronyms)
 	return strings.Join(words, "")
 }
 

--- a/tools/generate-helpers/pg-table-bindings/multitest/postgres/store.go
+++ b/tools/generate-helpers/pg-table-bindings/multitest/postgres/store.go
@@ -121,12 +121,12 @@ func insertIntoTestMultiKeyStructs(ctx context.Context, batch *pgx.Batch, obj *s
 	return nil
 }
 
-func insertIntoTestMultiKeyStructsNesteds(_ context.Context, batch *pgx.Batch, obj *storage.TestMultiKeyStruct_Nested, test_multi_key_structs_Key1 string, test_multi_key_structs_Key2 string, idx int) error {
+func insertIntoTestMultiKeyStructsNesteds(_ context.Context, batch *pgx.Batch, obj *storage.TestMultiKeyStruct_Nested, testMultiKeyStructsKey1 string, testMultiKeyStructsKey2 string, idx int) error {
 
 	values := []interface{}{
 		// parent primary keys start
-		test_multi_key_structs_Key1,
-		test_multi_key_structs_Key2,
+		testMultiKeyStructsKey1,
+		testMultiKeyStructsKey2,
 		idx,
 		obj.GetNested(),
 		obj.GetIsNested(),
@@ -256,7 +256,7 @@ func (s *storeImpl) copyFromTestMultiKeyStructs(ctx context.Context, tx *postgre
 	return err
 }
 
-func (s *storeImpl) copyFromTestMultiKeyStructsNesteds(ctx context.Context, tx *postgres.Tx, test_multi_key_structs_Key1 string, test_multi_key_structs_Key2 string, objs ...*storage.TestMultiKeyStruct_Nested) error {
+func (s *storeImpl) copyFromTestMultiKeyStructsNesteds(ctx context.Context, tx *postgres.Tx, testMultiKeyStructsKey1 string, testMultiKeyStructsKey2 string, objs ...*storage.TestMultiKeyStruct_Nested) error {
 
 	inputRows := [][]interface{}{}
 
@@ -291,9 +291,9 @@ func (s *storeImpl) copyFromTestMultiKeyStructsNesteds(ctx context.Context, tx *
 
 		inputRows = append(inputRows, []interface{}{
 
-			test_multi_key_structs_Key1,
+			testMultiKeyStructsKey1,
 
-			test_multi_key_structs_Key2,
+			testMultiKeyStructsKey2,
 
 			idx,
 

--- a/tools/generate-helpers/pg-table-bindings/multitest/postgres/store.go
+++ b/tools/generate-helpers/pg-table-bindings/multitest/postgres/store.go
@@ -121,12 +121,12 @@ func insertIntoTestMultiKeyStructs(ctx context.Context, batch *pgx.Batch, obj *s
 	return nil
 }
 
-func insertIntoTestMultiKeyStructsNesteds(_ context.Context, batch *pgx.Batch, obj *storage.TestMultiKeyStruct_Nested, testMultiKeyStructsKey1 string, testMultiKeyStructsKey2 string, idx int) error {
+func insertIntoTestMultiKeyStructsNesteds(_ context.Context, batch *pgx.Batch, obj *storage.TestMultiKeyStruct_Nested, testMultiKeyStructKey1 string, testMultiKeyStructKey2 string, idx int) error {
 
 	values := []interface{}{
 		// parent primary keys start
-		testMultiKeyStructsKey1,
-		testMultiKeyStructsKey2,
+		testMultiKeyStructKey1,
+		testMultiKeyStructKey2,
 		idx,
 		obj.GetNested(),
 		obj.GetIsNested(),
@@ -256,7 +256,7 @@ func (s *storeImpl) copyFromTestMultiKeyStructs(ctx context.Context, tx *postgre
 	return err
 }
 
-func (s *storeImpl) copyFromTestMultiKeyStructsNesteds(ctx context.Context, tx *postgres.Tx, testMultiKeyStructsKey1 string, testMultiKeyStructsKey2 string, objs ...*storage.TestMultiKeyStruct_Nested) error {
+func (s *storeImpl) copyFromTestMultiKeyStructsNesteds(ctx context.Context, tx *postgres.Tx, testMultiKeyStructKey1 string, testMultiKeyStructKey2 string, objs ...*storage.TestMultiKeyStruct_Nested) error {
 
 	inputRows := [][]interface{}{}
 
@@ -291,9 +291,9 @@ func (s *storeImpl) copyFromTestMultiKeyStructsNesteds(ctx context.Context, tx *
 
 		inputRows = append(inputRows, []interface{}{
 
-			testMultiKeyStructsKey1,
+			testMultiKeyStructKey1,
 
-			testMultiKeyStructsKey2,
+			testMultiKeyStructKey2,
 
 			idx,
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store.go
@@ -111,11 +111,11 @@ func insertIntoTestGrandparents(ctx context.Context, batch *pgx.Batch, obj *stor
 	return nil
 }
 
-func insertIntoTestGrandparentsEmbeddeds(ctx context.Context, batch *pgx.Batch, obj *storage.TestGrandparent_Embedded, test_grandparents_Id string, idx int) error {
+func insertIntoTestGrandparentsEmbeddeds(ctx context.Context, batch *pgx.Batch, obj *storage.TestGrandparent_Embedded, testGrandparentsID string, idx int) error {
 
 	values := []interface{}{
 		// parent primary keys start
-		test_grandparents_Id,
+		testGrandparentsID,
 		idx,
 		obj.GetVal(),
 	}
@@ -126,22 +126,22 @@ func insertIntoTestGrandparentsEmbeddeds(ctx context.Context, batch *pgx.Batch, 
 	var query string
 
 	for childIndex, child := range obj.GetEmbedded2() {
-		if err := insertIntoTestGrandparentsEmbeddedsEmbedded2(ctx, batch, child, test_grandparents_Id, idx, childIndex); err != nil {
+		if err := insertIntoTestGrandparentsEmbeddedsEmbedded2(ctx, batch, child, testGrandparentsID, idx, childIndex); err != nil {
 			return err
 		}
 	}
 
 	query = "delete from test_grandparents_embeddeds_embedded2 where test_grandparents_Id = $1 AND test_grandparents_embeddeds_idx = $2 AND idx >= $3"
-	batch.Queue(query, test_grandparents_Id, idx, len(obj.GetEmbedded2()))
+	batch.Queue(query, testGrandparentsID, idx, len(obj.GetEmbedded2()))
 	return nil
 }
 
-func insertIntoTestGrandparentsEmbeddedsEmbedded2(_ context.Context, batch *pgx.Batch, obj *storage.TestGrandparent_Embedded_Embedded2, test_grandparents_Id string, test_grandparents_embeddeds_idx int, idx int) error {
+func insertIntoTestGrandparentsEmbeddedsEmbedded2(_ context.Context, batch *pgx.Batch, obj *storage.TestGrandparent_Embedded_Embedded2, testGrandparentsID string, testGrandparentsEmbeddedsIdx int, idx int) error {
 
 	values := []interface{}{
 		// parent primary keys start
-		test_grandparents_Id,
-		test_grandparents_embeddeds_idx,
+		testGrandparentsID,
+		testGrandparentsEmbeddedsIdx,
 		idx,
 		obj.GetVal(),
 	}
@@ -235,7 +235,7 @@ func (s *storeImpl) copyFromTestGrandparents(ctx context.Context, tx *postgres.T
 	return err
 }
 
-func (s *storeImpl) copyFromTestGrandparentsEmbeddeds(ctx context.Context, tx *postgres.Tx, test_grandparents_Id string, objs ...*storage.TestGrandparent_Embedded) error {
+func (s *storeImpl) copyFromTestGrandparentsEmbeddeds(ctx context.Context, tx *postgres.Tx, testGrandparentsID string, objs ...*storage.TestGrandparent_Embedded) error {
 
 	inputRows := [][]interface{}{}
 
@@ -258,7 +258,7 @@ func (s *storeImpl) copyFromTestGrandparentsEmbeddeds(ctx context.Context, tx *p
 
 		inputRows = append(inputRows, []interface{}{
 
-			test_grandparents_Id,
+			testGrandparentsID,
 
 			idx,
 
@@ -284,7 +284,7 @@ func (s *storeImpl) copyFromTestGrandparentsEmbeddeds(ctx context.Context, tx *p
 	for idx, obj := range objs {
 		_ = idx // idx may or may not be used depending on how nested we are, so avoid compile-time errors.
 
-		if err = s.copyFromTestGrandparentsEmbeddedsEmbedded2(ctx, tx, test_grandparents_Id, idx, obj.GetEmbedded2()...); err != nil {
+		if err = s.copyFromTestGrandparentsEmbeddedsEmbedded2(ctx, tx, testGrandparentsID, idx, obj.GetEmbedded2()...); err != nil {
 			return err
 		}
 	}
@@ -292,7 +292,7 @@ func (s *storeImpl) copyFromTestGrandparentsEmbeddeds(ctx context.Context, tx *p
 	return err
 }
 
-func (s *storeImpl) copyFromTestGrandparentsEmbeddedsEmbedded2(ctx context.Context, tx *postgres.Tx, test_grandparents_Id string, test_grandparents_embeddeds_idx int, objs ...*storage.TestGrandparent_Embedded_Embedded2) error {
+func (s *storeImpl) copyFromTestGrandparentsEmbeddedsEmbedded2(ctx context.Context, tx *postgres.Tx, testGrandparentsID string, testGrandparentsEmbeddedsIdx int, objs ...*storage.TestGrandparent_Embedded_Embedded2) error {
 
 	inputRows := [][]interface{}{}
 
@@ -317,9 +317,9 @@ func (s *storeImpl) copyFromTestGrandparentsEmbeddedsEmbedded2(ctx context.Conte
 
 		inputRows = append(inputRows, []interface{}{
 
-			test_grandparents_Id,
+			testGrandparentsID,
 
-			test_grandparents_embeddeds_idx,
+			testGrandparentsEmbeddedsIdx,
 
 			idx,
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testgrandparent/store.go
@@ -111,11 +111,11 @@ func insertIntoTestGrandparents(ctx context.Context, batch *pgx.Batch, obj *stor
 	return nil
 }
 
-func insertIntoTestGrandparentsEmbeddeds(ctx context.Context, batch *pgx.Batch, obj *storage.TestGrandparent_Embedded, testGrandparentsID string, idx int) error {
+func insertIntoTestGrandparentsEmbeddeds(ctx context.Context, batch *pgx.Batch, obj *storage.TestGrandparent_Embedded, testGrandparentID string, idx int) error {
 
 	values := []interface{}{
 		// parent primary keys start
-		testGrandparentsID,
+		testGrandparentID,
 		idx,
 		obj.GetVal(),
 	}
@@ -126,22 +126,22 @@ func insertIntoTestGrandparentsEmbeddeds(ctx context.Context, batch *pgx.Batch, 
 	var query string
 
 	for childIndex, child := range obj.GetEmbedded2() {
-		if err := insertIntoTestGrandparentsEmbeddedsEmbedded2(ctx, batch, child, testGrandparentsID, idx, childIndex); err != nil {
+		if err := insertIntoTestGrandparentsEmbeddedsEmbedded2(ctx, batch, child, testGrandparentID, idx, childIndex); err != nil {
 			return err
 		}
 	}
 
 	query = "delete from test_grandparents_embeddeds_embedded2 where test_grandparents_Id = $1 AND test_grandparents_embeddeds_idx = $2 AND idx >= $3"
-	batch.Queue(query, testGrandparentsID, idx, len(obj.GetEmbedded2()))
+	batch.Queue(query, testGrandparentID, idx, len(obj.GetEmbedded2()))
 	return nil
 }
 
-func insertIntoTestGrandparentsEmbeddedsEmbedded2(_ context.Context, batch *pgx.Batch, obj *storage.TestGrandparent_Embedded_Embedded2, testGrandparentsID string, testGrandparentsEmbeddedsIdx int, idx int) error {
+func insertIntoTestGrandparentsEmbeddedsEmbedded2(_ context.Context, batch *pgx.Batch, obj *storage.TestGrandparent_Embedded_Embedded2, testGrandparentID string, testGrandparentEmbeddedIdx int, idx int) error {
 
 	values := []interface{}{
 		// parent primary keys start
-		testGrandparentsID,
-		testGrandparentsEmbeddedsIdx,
+		testGrandparentID,
+		testGrandparentEmbeddedIdx,
 		idx,
 		obj.GetVal(),
 	}
@@ -235,7 +235,7 @@ func (s *storeImpl) copyFromTestGrandparents(ctx context.Context, tx *postgres.T
 	return err
 }
 
-func (s *storeImpl) copyFromTestGrandparentsEmbeddeds(ctx context.Context, tx *postgres.Tx, testGrandparentsID string, objs ...*storage.TestGrandparent_Embedded) error {
+func (s *storeImpl) copyFromTestGrandparentsEmbeddeds(ctx context.Context, tx *postgres.Tx, testGrandparentID string, objs ...*storage.TestGrandparent_Embedded) error {
 
 	inputRows := [][]interface{}{}
 
@@ -258,7 +258,7 @@ func (s *storeImpl) copyFromTestGrandparentsEmbeddeds(ctx context.Context, tx *p
 
 		inputRows = append(inputRows, []interface{}{
 
-			testGrandparentsID,
+			testGrandparentID,
 
 			idx,
 
@@ -284,7 +284,7 @@ func (s *storeImpl) copyFromTestGrandparentsEmbeddeds(ctx context.Context, tx *p
 	for idx, obj := range objs {
 		_ = idx // idx may or may not be used depending on how nested we are, so avoid compile-time errors.
 
-		if err = s.copyFromTestGrandparentsEmbeddedsEmbedded2(ctx, tx, testGrandparentsID, idx, obj.GetEmbedded2()...); err != nil {
+		if err = s.copyFromTestGrandparentsEmbeddedsEmbedded2(ctx, tx, testGrandparentID, idx, obj.GetEmbedded2()...); err != nil {
 			return err
 		}
 	}
@@ -292,7 +292,7 @@ func (s *storeImpl) copyFromTestGrandparentsEmbeddeds(ctx context.Context, tx *p
 	return err
 }
 
-func (s *storeImpl) copyFromTestGrandparentsEmbeddedsEmbedded2(ctx context.Context, tx *postgres.Tx, testGrandparentsID string, testGrandparentsEmbeddedsIdx int, objs ...*storage.TestGrandparent_Embedded_Embedded2) error {
+func (s *storeImpl) copyFromTestGrandparentsEmbeddedsEmbedded2(ctx context.Context, tx *postgres.Tx, testGrandparentID string, testGrandparentEmbeddedIdx int, objs ...*storage.TestGrandparent_Embedded_Embedded2) error {
 
 	inputRows := [][]interface{}{}
 
@@ -317,9 +317,9 @@ func (s *storeImpl) copyFromTestGrandparentsEmbeddedsEmbedded2(ctx context.Conte
 
 		inputRows = append(inputRows, []interface{}{
 
-			testGrandparentsID,
+			testGrandparentID,
 
-			testGrandparentsEmbeddedsIdx,
+			testGrandparentEmbeddedIdx,
 
 			idx,
 

--- a/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent1/store.go
+++ b/tools/generate-helpers/pg-table-bindings/testgraphtables/testparent1/store.go
@@ -110,11 +110,11 @@ func insertIntoTestParent1(ctx context.Context, batch *pgx.Batch, obj *storage.T
 	return nil
 }
 
-func insertIntoTestParent1Childrens(_ context.Context, batch *pgx.Batch, obj *storage.TestParent1_Child1Ref, test_parent1_Id string, idx int) error {
+func insertIntoTestParent1Childrens(_ context.Context, batch *pgx.Batch, obj *storage.TestParent1_Child1Ref, testParent1ID string, idx int) error {
 
 	values := []interface{}{
 		// parent primary keys start
-		test_parent1_Id,
+		testParent1ID,
 		idx,
 		obj.GetChildId(),
 	}
@@ -204,7 +204,7 @@ func (s *storeImpl) copyFromTestParent1(ctx context.Context, tx *postgres.Tx, ob
 	return err
 }
 
-func (s *storeImpl) copyFromTestParent1Childrens(ctx context.Context, tx *postgres.Tx, test_parent1_Id string, objs ...*storage.TestParent1_Child1Ref) error {
+func (s *storeImpl) copyFromTestParent1Childrens(ctx context.Context, tx *postgres.Tx, testParent1ID string, objs ...*storage.TestParent1_Child1Ref) error {
 
 	inputRows := [][]interface{}{}
 
@@ -227,7 +227,7 @@ func (s *storeImpl) copyFromTestParent1Childrens(ctx context.Context, tx *postgr
 
 		inputRows = append(inputRows, []interface{}{
 
-			test_parent1_Id,
+			testParent1ID,
 
 			idx,
 


### PR DESCRIPTION
## Description

In order to reduce the code adjustment efforts to pass style checks when generated code has to be manually edited, more changes have been introduced.
The changes at hand here are aiming at removing snake case from variable names in generated store code.

## Checklist
- [ ] Investigated and inspected CI test results
~~- [ ] Unit test and regression tests added~~
~~- [ ] Evaluated and added CHANGELOG entry if required~~
~~- [ ] Determined and documented upgrade steps~~
~~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

CI should be sufficient.

Additional manual testing:
- remove the generated code comment from the store and schema code files
- manually run `make style` and check what errors are left
