### PR TITLE
ROX-17770: Delete non-postgres code in getFragmentInfo functions

### DIFF
--- a/ui/apps/platform/src/Containers/Workflow/WorkflowEntityPage.js
+++ b/ui/apps/platform/src/Containers/Workflow/WorkflowEntityPage.js
@@ -8,7 +8,6 @@ import MessageCentered from 'Components/MessageCentered';
 import PageNotFound from 'Components/PageNotFound';
 import { useTheme } from 'Containers/ThemeProvider';
 import queryService from 'utils/queryService';
-import useFeatureFlags from 'hooks/useFeatureFlags';
 
 import { LIST_PAGE_SIZE, defaultCountKeyMap } from 'constants/workflowPages.constants';
 import useCases from 'constants/useCaseTypes';
@@ -48,9 +47,6 @@ const WorkflowEntityPage = ({
 }) => {
     const { isDarkMode } = useTheme();
 
-    const { isFeatureFlagEnabled } = useFeatureFlags();
-    const showVMUpdates = isFeatureFlagEnabled('ROX_POSTGRES_DATASTORE');
-
     const enhancedQueryOptions =
         queryOptions && queryOptions.variables ? queryOptions : { variables: {} };
     let query = overviewQuery;
@@ -68,8 +64,7 @@ const WorkflowEntityPage = ({
         const { listFieldName, fragmentName, fragment } = queryService.getFragmentInfo(
             entityType,
             entityListType,
-            useCase,
-            showVMUpdates
+            useCase
         );
         fieldName = listFieldName;
         query = getListQuery(listFieldName, fragmentName, fragment);

--- a/ui/apps/platform/src/utils/queryService.js
+++ b/ui/apps/platform/src/utils/queryService.js
@@ -2,7 +2,6 @@ import pluralize from 'pluralize';
 
 import entityTypes from 'constants/entityTypes';
 import useCases from 'constants/useCaseTypes';
-import decodeBase64 from 'utils/decodeBase64/decodeBase64';
 import { NODE_FRAGMENT } from 'queries/node';
 import { DEPLOYMENT_FRAGMENT } from 'queries/deployment';
 import { NAMESPACE_FRAGMENT } from 'queries/namespace';
@@ -14,7 +13,6 @@ import { CONTROL_FRAGMENT } from 'queries/controls';
 import { POLICY_FRAGMENT } from 'queries/policy';
 import { IMAGE_FRAGMENT } from 'queries/image';
 import {
-    VULN_COMPONENT_LIST_FRAGMENT,
     VULN_CVE_LIST_FRAGMENT,
     IMAGE_LIST_FRAGMENT as VULN_IMAGE_LIST_FRAGMENT,
     CLUSTER_LIST_FRAGMENT_UPDATED as VULN_CLUSTER_LIST_FRAGMENT_UPDATED,
@@ -62,23 +60,12 @@ function entityContextToQueryObject(entityContext) {
         return {};
     }
 
-    // TODO: waiting for backend to use COMPONENT ID instead of NAME and VERSION. workaround for now
     return Object.keys(entityContext).reduce((acc, key) => {
         const entityQueryObj = {};
         if (key === entityTypes.IMAGE) {
             entityQueryObj[`${key} SHA`] = entityContext[key];
-        } else if (
-            // TODO: remove the plain COMPONENT option after migration to Postgres
-            key === entityTypes.COMPONENT
-        ) {
-            const parsedComponentID = entityContext[key].split(':').map(decodeBase64);
-            // eslint-disable-next-line dot-notation
-            [entityQueryObj['COMPONENT'], entityQueryObj[`COMPONENT VERSION`]] = parsedComponentID;
         } else if (key === entityTypes.IMAGE_COMPONENT || key === entityTypes.NODE_COMPONENT) {
             entityQueryObj['COMPONENT ID'] = entityContext[key];
-        } else if (key === entityTypes.CVE) {
-            // TODO: remove the plain CVE option after migration to Postgres
-            entityQueryObj.CVE = entityContext[key];
         } else if (
             key === entityTypes.IMAGE_CVE ||
             key === entityTypes.NODE_CVE ||
@@ -236,8 +223,6 @@ function getFragmentName(listType) {
             return 'nodeCVEFields';
         case entityTypes.CLUSTER_CVE:
             return 'clusterCVEFields';
-        case entityTypes.COMPONENT:
-            return 'componentFields';
         case entityTypes.NODE_COMPONENT:
             return 'nodeComponentFields';
         case entityTypes.IMAGE_COMPONENT:
@@ -269,7 +254,6 @@ function getFragment(entityType, listType, useCase) {
         },
         [useCases.VULN_MANAGEMENT]: {
             ...defaultFragments,
-            [entityTypes.COMPONENT]: VULN_COMPONENT_LIST_FRAGMENT,
             [entityTypes.NODE_COMPONENT]: VULN_NODE_COMPONENT_LIST_FRAGMENT,
             [entityTypes.IMAGE_COMPONENT]: VULN_IMAGE_COMPONENT_LIST_FRAGMENT,
             [entityTypes.CVE]: VULN_CVE_LIST_FRAGMENT,

--- a/ui/apps/platform/src/utils/queryService.js
+++ b/ui/apps/platform/src/utils/queryService.js
@@ -16,15 +16,10 @@ import { IMAGE_FRAGMENT } from 'queries/image';
 import {
     VULN_COMPONENT_LIST_FRAGMENT,
     VULN_CVE_LIST_FRAGMENT,
-    OLD_IMAGE_LIST_FRAGMENT as OLD_VULN_IMAGE_LIST_FRAGMENT,
     IMAGE_LIST_FRAGMENT as VULN_IMAGE_LIST_FRAGMENT,
-    CLUSTER_LIST_FRAGMENT as VULN_CLUSTER_LIST_FRAGMENT,
     CLUSTER_LIST_FRAGMENT_UPDATED as VULN_CLUSTER_LIST_FRAGMENT_UPDATED,
-    DEPLOYMENT_LIST_FRAGMENT as VULN_DEPLOYMENT_LIST_FRAGMENT,
     DEPLOYMENT_LIST_FRAGMENT_UPDATED as VULN_DEPLOYMENT_LIST_FRAGMENT_UPDATED,
-    NAMESPACE_LIST_FRAGMENT as VULN_NAMESPACE_LIST_FRAGMENT,
     NAMESPACE_LIST_FRAGMENT_UPDATED as VULN_NAMESPACE_LIST_FRAGMENT_UPDATED,
-    NODE_LIST_FRAGMENT as VULN_NODE_LIST_FRAGMENT,
     NODE_LIST_FRAGMENT_UPDATED as VULN_NODE_LIST_FRAGMENT_UPDATED,
     POLICY_LIST_FRAGMENT as VULN_POLICY_LIST_FRAGMENT,
     VULN_IMAGE_COMPONENT_LIST_FRAGMENT,
@@ -211,7 +206,7 @@ function getListFieldName(entityType, listType, useCase) {
     return parts.join('');
 }
 
-function getFragmentName(entityType, listType) {
+function getFragmentName(listType) {
     switch (listType) {
         case entityTypes.CLUSTER:
             return 'clusterFields';
@@ -235,14 +230,6 @@ function getFragmentName(entityType, listType) {
             return 'serviceAccountFields';
         case entityTypes.CONTROL:
             return 'controlFields';
-        case entityTypes.CVE:
-            if (entityType === entityTypes.NODE_COMPONENT) {
-                return 'nodeCVEFields';
-            }
-            if (entityType === entityTypes.IMAGE_COMPONENT) {
-                return 'imageCVEFields';
-            }
-            return 'cveFields';
         case entityTypes.IMAGE_CVE:
             return 'imageCVEFields';
         case entityTypes.NODE_CVE:
@@ -260,7 +247,7 @@ function getFragmentName(entityType, listType) {
     }
 }
 
-function getFragment(entityType, listType, useCase, showVMUpdates = false) {
+function getFragment(entityType, listType, useCase) {
     const defaultFragments = {
         [entityTypes.IMAGE]: IMAGE_FRAGMENT,
         [entityTypes.NODE]: NODE_FRAGMENT,
@@ -289,22 +276,12 @@ function getFragment(entityType, listType, useCase, showVMUpdates = false) {
             [entityTypes.CLUSTER_CVE]: CLUSTER_CVE_LIST_FRAGMENT,
             [entityTypes.NODE_CVE]: NODE_CVE_LIST_FRAGMENT,
             [entityTypes.IMAGE_CVE]: VULN_IMAGE_CVE_LIST_FRAGMENT,
-            [entityTypes.IMAGE]: showVMUpdates
-                ? VULN_IMAGE_LIST_FRAGMENT
-                : OLD_VULN_IMAGE_LIST_FRAGMENT,
-            [entityTypes.CLUSTER]: showVMUpdates
-                ? VULN_CLUSTER_LIST_FRAGMENT_UPDATED
-                : VULN_CLUSTER_LIST_FRAGMENT,
-            [entityTypes.NAMESPACE]: showVMUpdates
-                ? VULN_NAMESPACE_LIST_FRAGMENT_UPDATED
-                : VULN_NAMESPACE_LIST_FRAGMENT,
+            [entityTypes.IMAGE]: VULN_IMAGE_LIST_FRAGMENT,
+            [entityTypes.CLUSTER]: VULN_CLUSTER_LIST_FRAGMENT_UPDATED,
+            [entityTypes.NAMESPACE]: VULN_NAMESPACE_LIST_FRAGMENT_UPDATED,
             [entityTypes.POLICY]: VULN_POLICY_LIST_FRAGMENT,
-            [entityTypes.DEPLOYMENT]: showVMUpdates
-                ? VULN_DEPLOYMENT_LIST_FRAGMENT_UPDATED
-                : VULN_DEPLOYMENT_LIST_FRAGMENT,
-            [entityTypes.NODE]: showVMUpdates
-                ? VULN_NODE_LIST_FRAGMENT_UPDATED
-                : VULN_NODE_LIST_FRAGMENT,
+            [entityTypes.DEPLOYMENT]: VULN_DEPLOYMENT_LIST_FRAGMENT_UPDATED,
+            [entityTypes.NODE]: VULN_NODE_LIST_FRAGMENT_UPDATED,
         },
     };
 
@@ -330,10 +307,10 @@ function getFragment(entityType, listType, useCase, showVMUpdates = false) {
     return fragmentMap[listType];
 }
 
-function getFragmentInfo(entityType, listType, useCase, showVMUpdates = false) {
+function getFragmentInfo(entityType, listType, useCase) {
     const listFieldName = getListFieldName(entityType, listType, useCase);
-    const fragmentName = getFragmentName(entityType, listType);
-    const fragment = getFragment(entityType, listType, useCase, showVMUpdates);
+    const fragmentName = getFragmentName(listType);
+    const fragment = getFragment(entityType, listType, useCase);
 
     return {
         listFieldName,

--- a/ui/apps/platform/src/utils/queryService.test.js
+++ b/ui/apps/platform/src/utils/queryService.test.js
@@ -49,19 +49,6 @@ describe('queryService.', () => {
     });
 
     describe('entityContextToQueryObject', () => {
-        it('returns the query object for a Component', () => {
-            const entityContext = {
-                COMPONENT: 'cHl0aG9uMy40:My40LjMtMXVidW50dTF-MTQuMDQuNw',
-            };
-
-            const queryObject = queryService.entityContextToQueryObject(entityContext);
-
-            expect(queryObject).toEqual({
-                COMPONENT: 'python3.4',
-                'COMPONENT VERSION': '3.4.3-1ubuntu1~14.04.7',
-            });
-        });
-
         it('returns the query object for an Image Component', () => {
             const entityContext = {
                 IMAGE_COMPONENT: 'openssl#1.1.1d-0+deb10u7#debian:10',
@@ -83,18 +70,6 @@ describe('queryService.', () => {
 
             expect(queryObject).toEqual({
                 'COMPONENT ID': 'linux-gke#5.4.0-1068#ubuntu:20.04',
-            });
-        });
-
-        it('returns the query object for a CVE', () => {
-            const entityContext = {
-                CVE: 'CVE-2022-2068',
-            };
-
-            const queryObject = queryService.entityContextToQueryObject(entityContext);
-
-            expect(queryObject).toEqual({
-                CVE: 'CVE-2022-2068',
             });
         });
 


### PR DESCRIPTION
## Description

chore(ui): this is part of removing all references to the Postgres feature flag

## Checklist
- [x] Investigated and inspected CI test results (ui-e2e test failure is for unrelated API change, being fixed by other team)

## Testing Performed

Smoke tested and ran ui-e2e tests locally