### PR TITLE
ROX-17499: Create quay registry once

### DIFF
--- a/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
+++ b/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
@@ -70,6 +70,8 @@ class BaseSpecification extends Specification {
 
     Map<String, List<String>> resourceRecord = [:]
 
+    private static String coreImageIntegrationId = null
+
     private static globalSetup() {
         if (globalSetupDone) {
             return
@@ -159,7 +161,7 @@ class BaseSpecification extends Specification {
                 }
             }
 
-            log.info "Removing core image registry integration"
+            LOG.info "Removing core image registry integration"
             if (coreImageIntegrationId != null) {
                 ImageIntegrationService.deleteImageIntegration(coreImageIntegrationId)
             }
@@ -189,9 +191,6 @@ class BaseSpecification extends Specification {
     long orchestratorCreateTime = System.currentTimeSeconds()
 
     @Shared
-    String coreImageIntegrationId = null
-
-    @Shared
     private long testStartTimeMillis
 
     def setupSpec() {
@@ -214,11 +213,11 @@ class BaseSpecification extends Specification {
         recordResourcesAtSpecStart()
     }
 
-    protected void setupCoreImageIntegration() {
+    private static setupCoreImageIntegration() {
         coreImageIntegrationId = ImageIntegrationService.getImageIntegrationByName(
                 Constants.CORE_IMAGE_INTEGRATION_NAME)
         if (!coreImageIntegrationId) {
-            log.info "Adding core image registry integration"
+            LOG.info "Adding core image registry integration"
             coreImageIntegrationId = ImageIntegrationService.createImageIntegration(
                     ImageIntegrationOuterClass.ImageIntegration.newBuilder()
                             .setName(Constants.CORE_IMAGE_INTEGRATION_NAME)
@@ -234,8 +233,8 @@ class BaseSpecification extends Specification {
             )
         }
         if (!coreImageIntegrationId) {
-            log.warn "Could not create the core image integration."
-            log.warn "Check that REGISTRY_USERNAME and REGISTRY_PASSWORD are valid for quay.io."
+            LOG.warn "Could not create the core image integration."
+            LOG.warn "Check that REGISTRY_USERNAME and REGISTRY_PASSWORD are valid for quay.io."
         }
     }
 

--- a/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
+++ b/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
@@ -213,7 +213,7 @@ class BaseSpecification extends Specification {
         recordResourcesAtSpecStart()
     }
 
-    public static setupCoreImageIntegration() {
+    static setupCoreImageIntegration() {
         coreImageIntegrationId = ImageIntegrationService.getImageIntegrationByName(
                 Constants.CORE_IMAGE_INTEGRATION_NAME)
         if (!coreImageIntegrationId) {

--- a/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
+++ b/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
@@ -146,6 +146,8 @@ class BaseSpecification extends Specification {
 
         allAccessToken = tokenResp.token
 
+        setupCoreImageIntegration()
+
         addShutdownHook {
             LOG.info "Performing global shutdown"
             BaseService.useBasicAuth()
@@ -156,9 +158,12 @@ class BaseSpecification extends Specification {
                     RoleService.deleteRole(testRole.name)
                 }
             }
-        }
 
-        setupCoreImageIntegration()
+            log.info "Removing core image registry integration"
+            if (coreImageIntegrationId != null) {
+                ImageIntegrationService.deleteImageIntegration(coreImageIntegrationId)
+            }
+        }
 
         globalSetupDone = true
     }
@@ -213,7 +218,7 @@ class BaseSpecification extends Specification {
         coreImageIntegrationId = ImageIntegrationService.getImageIntegrationByName(
                 Constants.CORE_IMAGE_INTEGRATION_NAME)
         if (!coreImageIntegrationId) {
-            log.info "Adding core image integration"
+            log.info "Adding core image registry integration"
             coreImageIntegrationId = ImageIntegrationService.createImageIntegration(
                     ImageIntegrationOuterClass.ImageIntegration.newBuilder()
                             .setName(Constants.CORE_IMAGE_INTEGRATION_NAME)

--- a/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
+++ b/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
@@ -70,7 +70,7 @@ class BaseSpecification extends Specification {
 
     Map<String, List<String>> resourceRecord = [:]
 
-    private static String coreImageIntegrationId = null
+    public static String coreImageIntegrationId = null
 
     private static globalSetup() {
         if (globalSetupDone) {
@@ -213,7 +213,7 @@ class BaseSpecification extends Specification {
         recordResourcesAtSpecStart()
     }
 
-    private static setupCoreImageIntegration() {
+    public static setupCoreImageIntegration() {
         coreImageIntegrationId = ImageIntegrationService.getImageIntegrationByName(
                 Constants.CORE_IMAGE_INTEGRATION_NAME)
         if (!coreImageIntegrationId) {

--- a/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
+++ b/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
@@ -158,6 +158,8 @@ class BaseSpecification extends Specification {
             }
         }
 
+        setupCoreImageIntegration()
+
         globalSetupDone = true
     }
 
@@ -203,8 +205,6 @@ class BaseSpecification extends Specification {
         }
         BaseService.useBasicAuth()
         BaseService.setUseClientCert(false)
-
-        setupCoreImageIntegration()
 
         recordResourcesAtSpecStart()
     }
@@ -272,11 +272,6 @@ class BaseSpecification extends Specification {
 
         BaseService.useBasicAuth()
         BaseService.setUseClientCert(false)
-
-        log.info "Removing integration"
-        if (coreImageIntegrationId != null) {
-            ImageIntegrationService.deleteImageIntegration(coreImageIntegrationId)
-        }
 
         try {
             orchestrator.cleanup()


### PR DESCRIPTION
## Description

Currently the quay.io registry integration is created and deleted on a test spec basis. When tests run in parallel this would be problematic for tests that require its presence. This PR changes it to create and delete the integration on a test run basis.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

`all-qa-tests`.
