### PR TITLE
fix(ci): e2e no bin test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -351,13 +351,16 @@ build-prep: deps
 .PHONY: cli-build
 cli-build: cli-linux cli-darwin cli-windows
 
-.PHONY: cli
-cli: cli-build
+.PHONY: cli-install
+cli-install:
 	# Workaround a bug on MacOS
 	rm -f $(GOPATH)/bin/roxctl
 	# Copy the user's specific OS into gopath
 	cp bin/$(HOST_OS)_$(GOARCH)/roxctl $(GOPATH)/bin/roxctl
 	chmod u+w $(GOPATH)/bin/roxctl
+
+.PHONY: cli
+cli: cli-build cli-install
 
 cli-linux: cli_linux-amd64 cli_linux-arm64 cli_linux-ppc64le cli_linux-s390x
 cli-darwin: cli_darwin-amd64 cli_darwin-arm64

--- a/Makefile
+++ b/Makefile
@@ -372,6 +372,9 @@ cli_%: build-prep
 	$(eval arch := $(lastword  $(w)))
 	RACE=0 CGO_ENABLED=0 GOOS=$(os) GOARCH=$(arch) $(GOBUILD) ./roxctl
 
+.PHONY: cli_host-arch
+cli_host-arch: cli_$(HOST_OS)-$(GOARCH)
+
 upgrader: bin/$(HOST_OS)_$(GOARCH)/upgrader
 
 bin/$(HOST_OS)_$(GOARCH)/upgrader: build-prep

--- a/qa-tests-backend/scripts/run-compatibility.sh
+++ b/qa-tests-backend/scripts/run-compatibility.sh
@@ -28,6 +28,7 @@ compatibility_test() {
     info "Starting test (sensor compatibility test ${SENSOR_CHART_VERSION})"
 
     export_test_environment
+    ensure_roxctl
 
     if [[ "${SKIP_DEPLOY:-false}" = "false" ]]; then
         if [[ "${CI:-false}" = "true" ]]; then

--- a/qa-tests-backend/scripts/run-part-1.sh
+++ b/qa-tests-backend/scripts/run-part-1.sh
@@ -37,6 +37,11 @@ config_part_1() {
 
     export_test_environment
 
+    if is_CI && ! command -v roxctl >/dev/null 2>&1; then
+        make cli_linux-amd64
+        make cli-install
+    fi
+
     setup_gcp
     setup_deployment_env false false
     setup_podsecuritypolicies_config

--- a/qa-tests-backend/scripts/run-part-1.sh
+++ b/qa-tests-backend/scripts/run-part-1.sh
@@ -36,11 +36,7 @@ config_part_1() {
     DEPLOY_DIR="deploy/${ORCHESTRATOR_FLAVOR}"
 
     export_test_environment
-
-    if is_CI && ! command -v roxctl >/dev/null 2>&1; then
-        make cli_linux-amd64
-        make cli-install
-    fi
+    ensure_roxctl
 
     setup_gcp
     setup_deployment_env false false
@@ -64,6 +60,8 @@ reuse_config_part_1() {
     DEPLOY_DIR="deploy/${ORCHESTRATOR_FLAVOR}"
 
     export_test_environment
+    ensure_roxctl
+
     setup_deployment_env false false
     export_default_TLS_certs "$ROOT/$DEPLOY_DIR/default_TLS_certs"
     export_client_TLS_certs "$ROOT/$DEPLOY_DIR/client_TLS_certs"

--- a/scripts/ci/jobs/test-binary-build-commands.sh
+++ b/scripts/ci/jobs/test-binary-build-commands.sh
@@ -9,8 +9,8 @@ set -euo pipefail
 make_test_bin() {
     info "Making test-bin"
 
-    make cli-build upgrader
-    install_built_roxctl_in_gopath
+    make cli_host-arch upgrader
+    make cli-install
 }
 
 make_test_bin "$*"

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -125,33 +125,6 @@ setup_deployment_env() {
     ci_export COLLECTOR_IMAGE_REPO "quay.io/$REPO/collector"
 }
 
-install_built_roxctl_in_gopath() {
-    require_environment "GOPATH"
-
-    local bin_os bin_platform
-    if is_darwin; then
-        bin_os="darwin"
-    elif is_linux; then
-        bin_os="linux"
-    else
-        die "Only linux or darwin are supported for this test"
-    fi
-
-    case "$(uname -m)" in
-        x86_64) bin_platform="${bin_os}_amd64" ;;
-        aarch64) bin_platform="${bin_os}_arm64" ;;
-        ppc64le) bin_platform="${bin_os}_ppc64le" ;;
-        s390x) bin_platform="${bin_os}_s390x" ;;
-        *) die "Unknown architecture" ;;
-    esac
-
-    local roxctl="$SCRIPTS_ROOT/bin/${bin_platform}/roxctl"
-
-    require_executable "$roxctl" "roxctl should be built"
-
-    cp "$roxctl" "$GOPATH/bin/roxctl"
-}
-
 get_central_debug_dump() {
     info "Getting a central debug dump"
 
@@ -1186,8 +1159,8 @@ handle_nightly_binary_version_mismatch() {
     echo "Current roxctl is: $(command -v roxctl || true), version: $(roxctl version || true)"
 
     if ! [[ "$(roxctl version || true)" =~ nightly-$(date '+%Y%m%d') ]]; then
-        make cli-build upgrader
-        install_built_roxctl_in_gopath
+        make cli_host-arch upgrader
+        make cli-install
         echo "Replacement roxctl is: $(command -v roxctl || true), version: $(roxctl version || true)"
     fi
 }

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -111,6 +111,14 @@ export_test_environment() {
     fi
 }
 
+# ensure_roxctl() - ensure roxctl exists and is executable
+ensure_roxctl() {
+    if ! command -v roxctl >/dev/null 2>&1; then
+        make cli_host-arch
+        make cli-install
+    fi
+}
+
 deploy_stackrox_operator() {
     if [[ "${DEPLOY_STACKROX_VIA_OPERATOR}" == "false" ]]; then
         return

--- a/tests/e2e/run-scale.sh
+++ b/tests/e2e/run-scale.sh
@@ -26,6 +26,7 @@ scale_test() {
     require_environment "COMPARISON_METRICS"
 
     export_test_environment
+    ensure_roxctl
 
     setup_gcp
     setup_deployment_env false false

--- a/tests/e2e/run-ui-e2e.sh
+++ b/tests/e2e/run-ui-e2e.sh
@@ -23,11 +23,7 @@ test_ui_e2e() {
     export DEPLOY_DIR="deploy/${ORCHESTRATOR_FLAVOR}"
 
     export_test_environment
-
-    if is_CI && ! command -v roxctl >/dev/null 2>&1; then
-        make cli_linux-amd64
-        make cli-install
-    fi
+    ensure_roxctl
 
     setup_deployment_env false false
     remove_existing_stackrox_resources

--- a/tests/e2e/run-ui-e2e.sh
+++ b/tests/e2e/run-ui-e2e.sh
@@ -24,6 +24,11 @@ test_ui_e2e() {
 
     export_test_environment
 
+    if is_CI && ! command -v roxctl >/dev/null 2>&1; then
+        make cli_linux-amd64
+        make cli-install
+    fi
+
     setup_deployment_env false false
     remove_existing_stackrox_resources
     setup_default_TLS_certs

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -22,15 +22,11 @@ test_e2e() {
     require_environment "KUBECONFIG"
 
     export_test_environment
+    ensure_roxctl
 
     export SENSOR_HELM_DEPLOY=true
     export ROX_ACTIVE_VULN_REFRESH_INTERVAL=1m
     export ROX_NETPOL_FIELDS=true
-
-    if is_CI && ! command -v roxctl >/dev/null 2>&1; then
-        make cli_linux-amd64
-        make cli-install
-    fi
 
     test_preamble
     setup_deployment_env false false

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -27,6 +27,11 @@ test_e2e() {
     export ROX_ACTIVE_VULN_REFRESH_INTERVAL=1m
     export ROX_NETPOL_FIELDS=true
 
+    if is_CI && ! command -v roxctl >/dev/null 2>&1; then
+        make cli_linux-amd64
+        make cli-install
+    fi
+
     test_preamble
     setup_deployment_env false false
     remove_existing_stackrox_resources

--- a/tests/e2e/sensor.sh
+++ b/tests/e2e/sensor.sh
@@ -31,6 +31,7 @@ test_sensor() {
     require_environment "KUBECONFIG"
 
     export_test_environment
+    ensure_roxctl
 
     export SENSOR_HELM_DEPLOY=true
     export ROX_ACTIVE_VULN_REFRESH_INTERVAL=1m

--- a/tests/upgrade/legacy_to_postgres_run.sh
+++ b/tests/upgrade/legacy_to_postgres_run.sh
@@ -39,6 +39,7 @@ test_upgrade() {
     require_environment "KUBECONFIG"
 
     export_test_environment
+    ensure_roxctl
 
     # repo for old version with legacy database
     REPO_FOR_TIME_TRAVEL="/tmp/rox-postgres-upgrade-test"

--- a/tests/upgrade/lib.sh
+++ b/tests/upgrade/lib.sh
@@ -418,6 +418,10 @@ preamble() {
 
     require_executable "$TEST_ROOT/bin/${TEST_HOST_PLATFORM}/roxctl"
 
+    if ! command -v "$TEST_ROOT/bin/${TEST_HOST_PLATFORM}/upgrader" >/dev/null 2>&1; then
+        make upgrader
+    fi
+
     info "Will clone or update a clean copy of the rox repo for legacy DB test at $REPO_FOR_TIME_TRAVEL"
     if [[ -d "$REPO_FOR_TIME_TRAVEL" ]]; then
         if is_CI; then

--- a/tests/upgrade/postgres_run.sh
+++ b/tests/upgrade/postgres_run.sh
@@ -44,6 +44,7 @@ test_upgrade() {
     require_environment "KUBECONFIG"
 
     export_test_environment
+    ensure_roxctl
 
     # repo for old version with legacy database
     REPO_FOR_TIME_TRAVEL="/tmp/rox-postgres-upgrade-test"

--- a/tests/upgrade/postgres_sensor_run.sh
+++ b/tests/upgrade/postgres_sensor_run.sh
@@ -102,7 +102,10 @@ preamble() {
     esac
 
     require_executable "$TEST_ROOT/bin/${TEST_HOST_PLATFORM}/roxctl"
-    require_executable "$TEST_ROOT/bin/${TEST_HOST_PLATFORM}/upgrader"
+
+    if ! command -v "$TEST_ROOT/bin/${TEST_HOST_PLATFORM}/upgrader" >/dev/null 2>&1; then
+        make upgrader
+    fi
 
     info "Will clone or update a clean copy of the rox repo for test at $REPO_FOR_TIME_TRAVEL"
     if [[ -d "$REPO_FOR_TIME_TRAVEL" ]]; then

--- a/tests/upgrade/postgres_sensor_run.sh
+++ b/tests/upgrade/postgres_sensor_run.sh
@@ -39,6 +39,7 @@ test_upgrade() {
     require_environment "KUBECONFIG"
 
     export_test_environment
+    ensure_roxctl
 
     REPO_FOR_TIME_TRAVEL="/tmp/rox-postgres-sensor-upgrade-test"
     DEPLOY_DIR="deploy/k8s"


### PR DESCRIPTION
## Description

E2e tests driven by openshift/release run from a `test-bin` image. Building this `test-bin` takes time, e.g. 18 minutes and it only adds roxctl and the upgrader binaries. Most of this time is spent in image copy steps and not in binary builds.

This PR prepares the e2e tests to build the binaries they need. Testing is via https://github.com/openshift/release/pull/39397.

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

CI is sufficient
