### PR TITLE
ROX-17872: Remove ROX_NETPOL_FIELDS feature flag

### DIFF
--- a/central/policy/service/service_impl.go
+++ b/central/policy/service/service_impl.go
@@ -32,7 +32,6 @@ import (
 	"github.com/stackrox/rox/pkg/errorhelpers"
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/expiringcache"
-	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/grpc/authn"
 	"github.com/stackrox/rox/pkg/grpc/authz"
 	"github.com/stackrox/rox/pkg/grpc/authz/perrpc"
@@ -486,13 +485,10 @@ func (s *serviceImpl) predicateBasedDryRunPolicy(ctx context.Context, cancelCtx 
 				return
 			}
 
-			var matched *augmentedobjs.NetworkPoliciesApplied
-			if features.NetworkPolicySystemPolicy.Enabled() {
-				matched, err = s.getNetworkPoliciesForDeployment(ctx, deployment)
-				if err != nil {
-					log.Errorf("failed to fetch network policies for deployment: %s", err.Error())
-					return
-				}
+			matched, err := s.getNetworkPoliciesForDeployment(ctx, deployment)
+			if err != nil {
+				log.Errorf("failed to fetch network policies for deployment: %s", err.Error())
+				return
 			}
 
 			violations, err := compiledPolicy.MatchAgainstDeployment(nil, booleanpolicy.EnhancedDeployment{

--- a/central/policy/service/validator.go
+++ b/central/policy/service/validator.go
@@ -14,7 +14,6 @@ import (
 	"github.com/stackrox/rox/pkg/booleanpolicy/fieldnames"
 	"github.com/stackrox/rox/pkg/booleanpolicy/policyversion"
 	"github.com/stackrox/rox/pkg/errorhelpers"
-	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/policies"
 	"github.com/stackrox/rox/pkg/scopecomp"
 	"github.com/stackrox/rox/pkg/set"
@@ -48,10 +47,8 @@ func newPolicyValidator(notifierStorage notifierDataStore.DataStore) *policyVali
 		notifierStorage:            notifierStorage,
 		nonEnforceablePolicyFields: make(map[string]struct{}),
 	}
-	if features.NetworkPolicySystemPolicy.Enabled() {
-		pv.nonEnforceablePolicyFields[augmentedobjs.HasIngressPolicyCustomTag] = struct{}{}
-		pv.nonEnforceablePolicyFields[augmentedobjs.HasEgressPolicyCustomTag] = struct{}{}
-	}
+	pv.nonEnforceablePolicyFields[augmentedobjs.HasIngressPolicyCustomTag] = struct{}{}
+	pv.nonEnforceablePolicyFields[augmentedobjs.HasEgressPolicyCustomTag] = struct{}{}
 	return pv
 }
 

--- a/central/policy/service/validator_test.go
+++ b/central/policy/service/validator_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/stackrox/rox/pkg/booleanpolicy/fieldnames"
 	"github.com/stackrox/rox/pkg/booleanpolicy/policyversion"
 	"github.com/stackrox/rox/pkg/defaults/policies"
-	"github.com/stackrox/rox/pkg/features"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
@@ -917,8 +916,6 @@ func (s *PolicyValidatorTestSuite) TestValidateNoDockerfileLineFrom() {
 }
 
 func (s *PolicyValidatorTestSuite) TestValidateEnforcement() {
-	s.T().Setenv(features.NetworkPolicySystemPolicy.EnvVar(), "true")
-
 	validatorWithFlag := newPolicyValidator(s.nStorage)
 
 	cases := map[string]struct {

--- a/pkg/booleanpolicy/default_policies_test.go
+++ b/pkg/booleanpolicy/default_policies_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/stackrox/rox/pkg/booleanpolicy/policyversion"
 	"github.com/stackrox/rox/pkg/booleanpolicy/violationmessages/printer"
 	"github.com/stackrox/rox/pkg/defaults/policies"
-	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/fixtures"
 	"github.com/stackrox/rox/pkg/images/types"
 	"github.com/stackrox/rox/pkg/kubernetes"
@@ -93,8 +92,6 @@ func (suite *DefaultPoliciesTestSuite) SetupSuite() {
 	} {
 		suite.customPolicies[customPolicy.GetName()] = customPolicy
 	}
-
-	suite.T().Setenv(features.NetworkPolicySystemPolicy.EnvVar(), "true")
 }
 
 func (suite *DefaultPoliciesTestSuite) TearDownSuite() {}
@@ -3282,10 +3279,6 @@ func (suite *DefaultPoliciesTestSuite) getViolations(policy *storage.Policy, dep
 }
 
 func (suite *DefaultPoliciesTestSuite) TestNetworkPolicyFields() {
-	if !features.NetworkPolicySystemPolicy.Enabled() {
-		return
-	}
-
 	testCases := map[string]struct {
 		netpolsApplied *augmentedobjs.NetworkPoliciesApplied
 		alerts         []*storage.Alert_Violation

--- a/pkg/booleanpolicy/field_metadata.go
+++ b/pkg/booleanpolicy/field_metadata.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stackrox/rox/pkg/booleanpolicy/query"
 	"github.com/stackrox/rox/pkg/booleanpolicy/querybuilders"
 	"github.com/stackrox/rox/pkg/booleanpolicy/violationmessages"
-	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/sync"
 )
@@ -812,25 +811,23 @@ func initializeFieldMetadata() FieldMetadata {
 		[]RuntimeFieldType{}, operatorsForbidden,
 	)
 
-	if features.NetworkPolicySystemPolicy.Enabled() {
-		f.registerFieldMetadata(fieldnames.HasIngressNetworkPolicy,
-			querybuilders.ForFieldLabel(augmentedobjs.HasIngressPolicyCustomTag), nil,
-			func(*validateConfiguration) *regexp.Regexp {
-				return booleanValueRegex
-			},
-			[]storage.EventSource{storage.EventSource_NOT_APPLICABLE},
-			[]RuntimeFieldType{}, operatorsForbidden,
-		)
+	f.registerFieldMetadata(fieldnames.HasIngressNetworkPolicy,
+		querybuilders.ForFieldLabel(augmentedobjs.HasIngressPolicyCustomTag), nil,
+		func(*validateConfiguration) *regexp.Regexp {
+			return booleanValueRegex
+		},
+		[]storage.EventSource{storage.EventSource_NOT_APPLICABLE},
+		[]RuntimeFieldType{}, operatorsForbidden,
+	)
 
-		f.registerFieldMetadata(fieldnames.HasEgressNetworkPolicy,
-			querybuilders.ForFieldLabel(augmentedobjs.HasEgressPolicyCustomTag), nil,
-			func(*validateConfiguration) *regexp.Regexp {
-				return booleanValueRegex
-			},
-			[]storage.EventSource{storage.EventSource_NOT_APPLICABLE},
-			[]RuntimeFieldType{}, operatorsForbidden,
-		)
-	}
+	f.registerFieldMetadata(fieldnames.HasEgressNetworkPolicy,
+		querybuilders.ForFieldLabel(augmentedobjs.HasEgressPolicyCustomTag), nil,
+		func(*validateConfiguration) *regexp.Regexp {
+			return booleanValueRegex
+		},
+		[]storage.EventSource{storage.EventSource_NOT_APPLICABLE},
+		[]RuntimeFieldType{}, operatorsForbidden,
+	)
 
 	return f
 }

--- a/pkg/defaults/policies/policies.go
+++ b/pkg/defaults/policies/policies.go
@@ -23,9 +23,8 @@ var (
 	//go:embed files/*.json
 	policiesFS embed.FS
 
-	featureFlagFileGuard = map[string]features.FeatureFlag{
-		"deployment_has_ingress_network_policy.json": features.NetworkPolicySystemPolicy,
-	}
+	// featureFlagFileGuard is a map indexed by file name that ignores files if the feature flag is not enabled.
+	featureFlagFileGuard = map[string]features.FeatureFlag{}
 )
 
 // DefaultPolicies returns a slice of the default policies.

--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -15,10 +15,6 @@ var (
 	// ComplianceOperatorCheckResults enables getting compliance results from the compliance operator
 	ComplianceOperatorCheckResults = registerFeature("Enable fetching of compliance operator results", "ROX_COMPLIANCE_OPERATOR_INTEGRATION", true)
 
-	// NetworkPolicySystemPolicy enables two system policy fields (Missing (Ingress|Egress) Network Policy) to check deployments
-	// against network policies applied in the secured cluster.
-	NetworkPolicySystemPolicy = registerFeature("Enable NetworkPolicy-related system policy fields", "ROX_NETPOL_FIELDS", true)
-
 	// QuayRobotAccounts enables Robot accounts as credentials in Quay Image Integration.
 	QuayRobotAccounts = registerFeature("Enable Robot accounts in Quay Image Integration", "ROX_QUAY_ROBOT_ACCOUNTS", true)
 

--- a/sensor/common/detector/detector.go
+++ b/sensor/common/detector/detector.go
@@ -17,7 +17,6 @@ import (
 	"github.com/stackrox/rox/pkg/detection/deploytime"
 	"github.com/stackrox/rox/pkg/errorhelpers"
 	"github.com/stackrox/rox/pkg/expiringcache"
-	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/networkgraph"
 	"github.com/stackrox/rox/pkg/networkgraph/networkbaseline"
@@ -420,11 +419,6 @@ func (d *detectorImpl) ReprocessDeployments(deploymentIDs ...string) {
 }
 
 func (d *detectorImpl) getNetworkPoliciesApplied(deployment *storage.Deployment) *augmentedobjs.NetworkPoliciesApplied {
-	if !features.NetworkPolicySystemPolicy.Enabled() {
-		// If feature flag is disabled we simply don't do the calculation.
-		// It is fine (from the Matcher perspective) to use nil augmented objects
-		return nil
-	}
 	networkPolicies := d.networkPolicyStore.Find(deployment.GetNamespace(), deployment.GetPodLabels())
 	return networkpolicy.GenerateNetworkPoliciesAppliedObj(networkPolicies)
 }

--- a/sensor/kubernetes/listener/resources/networkpolicy_test.go
+++ b/sensor/kubernetes/listener/resources/networkpolicy_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/env"
-	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/protoconv"
 	networkPolicyConversion "github.com/stackrox/rox/pkg/protoconv/networkpolicy"
 	"github.com/stackrox/rox/pkg/set"
@@ -94,8 +93,6 @@ func (suite *NetworkPolicyDispatcherSuite) SetupTest() {
 	for _, d := range deployments {
 		suite.deploymentStore.addOrUpdateDeployment(d)
 	}
-
-	suite.T().Setenv(features.NetworkPolicySystemPolicy.EnvVar(), "true")
 }
 
 func (suite *NetworkPolicyDispatcherSuite) TearDownTest() {
@@ -141,10 +138,6 @@ func createSensorEvent(np *networkingV1.NetworkPolicy, action central.ResourceAc
 }
 
 func (suite *NetworkPolicyDispatcherSuite) Test_ProcessEvent() {
-	if !features.NetworkPolicySystemPolicy.Enabled() {
-		suite.T().Skipf("Skipping test since the %s variable is not set", features.NetworkPolicySystemPolicy.EnvVar())
-	}
-
 	cases := map[string]struct {
 		netpol              interface{}
 		oldNetpol           interface{}

--- a/tests/networkpolicy_test.go
+++ b/tests/networkpolicy_test.go
@@ -9,12 +9,9 @@ import (
 
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
-	"github.com/stackrox/rox/pkg/buildinfo"
-	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/testutils"
 	"github.com/stackrox/rox/pkg/testutils/centralgrpc"
 	"github.com/stretchr/testify/assert"
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -99,26 +96,8 @@ func getAlertsForPolicy(t testutils.T, client v1.AlertServiceClient, policyName 
 	return alerts
 }
 
-func CheckIfCentralHasFeatureFlag(t *testing.T, conn *grpc.ClientConn) bool {
-	ffClient := v1.NewFeatureFlagServiceClient(conn)
-
-	flags, err := ffClient.GetFeatureFlags(context.Background(), &v1.Empty{})
-	assert.NoError(t, err)
-
-	for _, flag := range flags.FeatureFlags {
-		if flag.Name == features.NetworkPolicySystemPolicy.Name() {
-			return flag.Enabled
-		}
-	}
-
-	return false
-}
-
 func Test_GetViolationForIngressPolicy(t *testing.T) {
 	conn := centralgrpc.GRPCConnectionToCentral(t)
-	if buildinfo.ReleaseBuild || !CheckIfCentralHasFeatureFlag(t, conn) {
-		t.Skip("Feature flag disabled")
-	}
 
 	testCases := map[string]struct {
 		policyName        string


### PR DESCRIPTION
## Description

Removing old feature flag for Network Policy system policies. The feature has been enabled for at least three releases already. 

## Checklist
- [x] Investigated and inspected CI test results
- [ ] ~~Unit test and regression tests added~~
- [ ] ~~Evaluated and added CHANGELOG entry if required~~
- [ ] ~~Determined and documented upgrade steps~~
- [ ] ~~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

## Testing Performed

CI should be sufficient
