### PR TITLE
ROX-17623: Accept Collector restarts on Sensor unavailability

### DIFF
--- a/scripts/ci/logcheck/restart-ok-patterns.json
+++ b/scripts/ci/logcheck/restart-ok-patterns.json
@@ -30,8 +30,8 @@
         "logline": "No suitable kernel object downloaded for kernel"
     },
     {
-        "comment": "collector restart due to bouncing in upgrade test",
-        "job": "upgrade",
+        "comment": "collector restart due to sensor connection failure (likely slow start)",
+        "job": ".*",
         "logfile": "collector-previous",
         "logline": "Unable to connect to Sensor at"
     },


### PR DESCRIPTION
## Description

The deployment of testing environment is not specifically orchestrated to ensure that Sensor is available when Collector is started. It is then likely that when Collector is ready, Sensor is not yet.

We propose to add a general exception for all tests which accept when Collector restart with a log entry stating that the reason is Sensor unavailability.  

## Checklist
- [ ] Investigated and inspected CI test results