### PR TITLE
ROX-17683: Enable telemetry by default for release operator versions

### DIFF
--- a/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml
+++ b/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        {{- if ._rox.central.telemetry.enabled }}
+        {{- if ne (._rox.central.telemetry.enabled | toString) "false" }}
         {{- if ._rox.central.telemetry.storage.endpoint }}
         - name: ROX_TELEMETRY_ENDPOINT
           value: {{ ._rox.central.telemetry.storage.endpoint | quote }}

--- a/image/templates/helm/stackrox-central/templates/NOTES.txt.htpl
+++ b/image/templates/helm/stackrox-central/templates/NOTES.txt.htpl
@@ -47,4 +47,10 @@ IMPORTANT: You have deployed into an OpenShift-enabled cluster. If you see that 
 {{ end -}}
 [< end >]
 
+{{ if ne (._rox.central.telemetry.enabled | toString) "false" }}
+StackRox Kubernetes Security Platform collects and transmits anonymous usage and
+system configuration information. If you want to OPT OUT from this, use
+--set central.telemetry.enabled=false.
+{{ end }}
+
 Thank you for using StackRox!

--- a/image/templates/helm/stackrox-central/values.yaml.htpl
+++ b/image/templates/helm/stackrox-central/values.yaml.htpl
@@ -103,14 +103,24 @@
 ## If specified, this should be a map mapping file names to PEM-encoded contents.
 #additionalCAs: null
 #
+[<- if and .TelemetryEnabled (and (eq .TelemetryKey "") (eq .TelemetryEndpoint ""))>]
 #central:
 #
-#  # Settings for telemetry data collection. Telemetry is disabled by default.
+#  # Settings for telemetry data collection. Telemetry is enabled by default.
 #  telemetry:
-#    enabled: false
+#    enabled: true
 #    storage:
 #      endpoint: null
 #      key: null
+[<- else >]
+central:
+# # Settings for telemetry data collection.
+  telemetry:
+    enabled: [< .TelemetryEnabled >]
+    storage:
+      endpoint: "[< .TelemetryEndpoint >]"
+      key: "[< .TelemetryKey >]"
+[<- end >]
 #
 #
 #  config: "@config/central/config.yaml|config/central/config.yaml.default"

--- a/operator/apis/platform/v1alpha1/central_types.go
+++ b/operator/apis/platform/v1alpha1/central_types.go
@@ -431,6 +431,8 @@ type ExposureRoute struct {
 // Telemetry defines telemetry settings for Central.
 type Telemetry struct {
 	// Specifies if Telemetry is enabled.
+	//+kubebuilder:validation:Default=true
+	//+kubebuilder:default=true
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,order=1,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
 	Enabled *bool `json:"enabled,omitempty"`
 

--- a/operator/bundle/manifests/platform.stackrox.io_centrals.yaml
+++ b/operator/bundle/manifests/platform.stackrox.io_centrals.yaml
@@ -458,6 +458,7 @@ spec:
                       enabled:
                         description: Specifies if Telemetry is enabled.
                         type: boolean
+                        default: true
                       storage:
                         description: Defines the telemetry storage backend for Central.
                         properties:

--- a/operator/bundle/manifests/platform.stackrox.io_centrals.yaml
+++ b/operator/bundle/manifests/platform.stackrox.io_centrals.yaml
@@ -456,9 +456,9 @@ spec:
                       storage backend.
                     properties:
                       enabled:
+                        default: true
                         description: Specifies if Telemetry is enabled.
                         type: boolean
-                        default: true
                       storage:
                         description: Defines the telemetry storage backend for Central.
                         properties:

--- a/operator/config/crd/bases/platform.stackrox.io_centrals.yaml
+++ b/operator/config/crd/bases/platform.stackrox.io_centrals.yaml
@@ -457,6 +457,7 @@ spec:
                       storage backend.
                     properties:
                       enabled:
+                        default: true
                         description: Specifies if Telemetry is enabled.
                         type: boolean
                       storage:

--- a/operator/pkg/central/values/translation/translation.go
+++ b/operator/pkg/central/values/translation/translation.go
@@ -302,24 +302,23 @@ func isTelemetryEnabled(t *platform.Telemetry) bool {
 }
 
 func getTelemetryValues(t *platform.Telemetry) *translation.ValuesBuilder {
-	tv := translation.NewValuesBuilder()
-	enabled := isTelemetryEnabled(t)
-	if enabled {
-		if t != nil && t.Storage != nil {
-			tv.SetBoolValue("enabled", true)
-			storage := translation.NewValuesBuilder()
-			storage.SetString("key", t.Storage.Key)
-			storage.SetString("endpoint", t.Storage.Endpoint)
-			tv.AddChild("storage", &storage)
-		}
-	} else {
+	if !isTelemetryEnabled(t) {
+		tv := translation.NewValuesBuilder()
 		tv.SetBoolValue("enabled", false)
 		storage := translation.NewValuesBuilder()
 		storage.SetString("key", &disabledTelemetryKey)
 		tv.AddChild("storage", &storage)
+		return &tv
+	} else if t != nil && t.Storage != nil {
+		tv := translation.NewValuesBuilder()
+		tv.SetBoolValue("enabled", true)
+		storage := translation.NewValuesBuilder()
+		storage.SetString("key", t.Storage.Key)
+		storage.SetString("endpoint", t.Storage.Endpoint)
+		tv.AddChild("storage", &storage)
+		return &tv
 	}
-
-	return &tv
+	return nil
 }
 
 func getDeclarativeConfigurationValues(c *platform.DeclarativeConfiguration) *translation.ValuesBuilder {

--- a/operator/pkg/central/values/translation/translation.go
+++ b/operator/pkg/central/values/translation/translation.go
@@ -302,19 +302,22 @@ func isTelemetryEnabled(t *platform.Telemetry) bool {
 }
 
 func getTelemetryValues(t *platform.Telemetry) *translation.ValuesBuilder {
-	storage := translation.NewValuesBuilder()
+	tv := translation.NewValuesBuilder()
 	enabled := isTelemetryEnabled(t)
 	if enabled {
-		if t.Storage != nil {
+		if t != nil && t.Storage != nil {
+			tv.SetBoolValue("enabled", true)
+			storage := translation.NewValuesBuilder()
 			storage.SetString("key", t.Storage.Key)
 			storage.SetString("endpoint", t.Storage.Endpoint)
+			tv.AddChild("storage", &storage)
 		}
 	} else {
+		tv.SetBoolValue("enabled", false)
+		storage := translation.NewValuesBuilder()
 		storage.SetString("key", &disabledTelemetryKey)
+		tv.AddChild("storage", &storage)
 	}
-	tv := translation.NewValuesBuilder()
-	tv.SetBoolValue("enabled", enabled)
-	tv.AddChild("storage", &storage)
 
 	return &tv
 }

--- a/operator/pkg/central/values/translation/translation_test.go
+++ b/operator/pkg/central/values/translation/translation_test.go
@@ -877,10 +877,6 @@ func TestTranslate(t *testing.T) {
 				"central": map[string]interface{}{
 					"exposeMonitoring": false,
 					"persistence":      map[string]interface{}{"persistentVolumeClaim": map[string]interface{}{"createClaim": false}},
-					"telemetry": map[bool]any{
-						true:  map[string]interface{}{"enabled": true},
-						false: telemetryDisabledKey,
-					}[buildinfo.ReleaseBuild],
 					"db": map[string]interface{}{
 						"persistence": map[string]interface{}{
 							"persistentVolumeClaim": map[string]interface{}{

--- a/operator/pkg/central/values/translation/translation_test.go
+++ b/operator/pkg/central/values/translation/translation_test.go
@@ -891,7 +891,7 @@ func TestTranslate(t *testing.T) {
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			if !buildinfo.ReleaseBuild {
+			if !buildinfo.ReleaseBuild || buildinfo.TestBuild {
 				wantCentral := tt.want["central"].(map[string]any)
 				if _, ok := wantCentral["telemetry"]; !ok {
 					wantCentral["telemetry"] = telemetryDisabledKey

--- a/operator/tests/common/central-cr.yaml
+++ b/operator/tests/common/central-cr.yaml
@@ -22,6 +22,8 @@ spec:
         limits:
           memory: 4Gi
           cpu: 1
+    telemetry:
+      enabled: false
   scanner:
     analyzer:
       scaling:

--- a/pkg/helm/charts/meta.go
+++ b/pkg/helm/charts/meta.go
@@ -53,6 +53,9 @@ type MetaValues struct {
 	AdmissionControllerEnabled       bool
 	AdmissionControlEnforceOnUpdates bool
 	ReleaseBuild                     bool
+	TelemetryEnabled                 bool
+	TelemetryKey                     string
+	TelemetryEndpoint                string
 
 	AutoSensePodSecurityPolicies bool
 	EnablePodSecurityPolicies    bool // Only used in the Helm chart if AutoSensePodSecurityPolicies is false.

--- a/pkg/renderer/render_new.go
+++ b/pkg/renderer/render_new.go
@@ -101,6 +101,9 @@ func renderNewBasicFiles(c Config, mode mode, imageFlavor defaults.ImageFlavor) 
 	if metaVals.KubectlOutput {
 		metaVals.AutoSensePodSecurityPolicies = false
 	}
+	metaVals.TelemetryEnabled = c.K8sConfig.Telemetry.Enabled
+	metaVals.TelemetryKey = c.K8sConfig.Telemetry.StorageKey
+	metaVals.TelemetryEndpoint = c.K8sConfig.Telemetry.StorageEndpoint
 	chartFiles, err := chTpl.InstantiateRaw(metaVals)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to instantiate central services chart template")


### PR DESCRIPTION
## Description

Similarly to #6453, make development operator versions to disable telemetry in the central by default, and release operator versions to enable it.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] ~Evaluated and added CHANGELOG entry if required~
- [ ] ~Determined and documented upgrade steps~
- [ ] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

Unit tests.