### PR TITLE
ROX-17886: Remove pre-pg query from ImagesAtMostRisk widget

### DIFF
--- a/ui/apps/platform/cypress/helpers/main.js
+++ b/ui/apps/platform/cypress/helpers/main.js
@@ -11,7 +11,7 @@ export const summaryCountsOpname = 'summary_counts';
 export const getAllNamespacesByClusterOpname = 'getAllNamespacesByCluster';
 export const alertCountsBySeverityOpname = 'alertCountsBySeverity';
 export const mostRecentAlertsOpname = 'mostRecentAlerts';
-export const getImagesOpname = 'getImages';
+export const getImagesAtMostRiskOpname = 'getImagesAtMostRisk';
 export const deploymentsWithProcessInfoAlias = 'deploymentswithprocessinfo';
 export const agingImagesQueryOpname = 'agingImagesQuery';
 export const alertsSummaryCountsGroupByCategoryAlias = 'alerts/summary/counts_CATEGORY';
@@ -25,7 +25,9 @@ const routeMatcherMapForViolationsByPolicySeverity = {
     ...getRouteMatcherMapForGraphQL([alertCountsBySeverityOpname]),
     ...getRouteMatcherMapForGraphQL([mostRecentAlertsOpname]),
 };
-const routeMatcherMapForImagesAtMostRisk = getRouteMatcherMapForGraphQL([getImagesOpname]);
+const routeMatcherMapForImagesAtMostRisk = getRouteMatcherMapForGraphQL([
+    getImagesAtMostRiskOpname,
+]);
 const routeMatcherMapForDeploymentsAtMostRisk = {
     [deploymentsWithProcessInfoAlias]: {
         method: 'GET',

--- a/ui/apps/platform/cypress/helpers/vulnmanagement/entities.js
+++ b/ui/apps/platform/cypress/helpers/vulnmanagement/entities.js
@@ -8,7 +8,7 @@ import { visit } from '../visit';
 const opnamesForDashboard = [
     'cvesCount',
     'getNodes',
-    'getImagesAtMostRisk',
+    'getImages',
     'topRiskyDeployments',
     'topRiskiestImageVulns',
     'recentlyDetectedImageVulnerabilities',

--- a/ui/apps/platform/cypress/helpers/vulnmanagement/entities.js
+++ b/ui/apps/platform/cypress/helpers/vulnmanagement/entities.js
@@ -8,7 +8,7 @@ import { visit } from '../visit';
 const opnamesForDashboard = [
     'cvesCount',
     'getNodes',
-    'getImages',
+    'getImagesAtMostRisk',
     'topRiskyDeployments',
     'topRiskiestImageVulns',
     'recentlyDetectedImageVulnerabilities',

--- a/ui/apps/platform/src/Containers/Dashboard/Widgets/ImagesAtMostRisk.test.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/Widgets/ImagesAtMostRisk.test.tsx
@@ -6,7 +6,7 @@ import '@testing-library/jest-dom/extend-expect';
 
 import renderWithRouter from 'test-utils/renderWithRouter';
 import { vulnManagementImagesPath, vulnManagementPath } from 'routePaths';
-import ImagesAtMostRisk, { getImagesQuery } from './ImagesAtMostRisk';
+import ImagesAtMostRisk, { imagesAtMostRiskQuery } from './ImagesAtMostRisk';
 
 function makeMockImage(
     id: string,
@@ -48,9 +48,7 @@ const mockImages = [1, 2, 3, 4, 5, 6].map((n) =>
 const mocks = [
     {
         request: {
-            // The component for this uses a feature flag to swap sub-resolvers, so treat it as
-            // disabled here until the feature flag is enabled in the production release.
-            query: getImagesQuery(false),
+            query: imagesAtMostRiskQuery,
             variables: {
                 query: '',
             },


### PR DESCRIPTION
## Description

Removal of the backend implementation of the non-pg part of this query was causing errors in https://github.com/stackrox/stackrox/pull/6303 so looks like I get to join in the fun.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

UI unit tests

