### PR TITLE
ROX-17813: Vulnerability Reporting 2.0 set up

### DIFF
--- a/ui/apps/platform/src/Containers/MainPage/Body.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Body.tsx
@@ -28,6 +28,7 @@ import {
     vulnManagementRiskAcceptancePath,
     collectionsPath,
     vulnerabilitiesWorkloadCvesPath,
+    vulnerabilityReportingPath,
 } from 'routePaths';
 import { useTheme } from 'Containers/ThemeProvider';
 
@@ -81,6 +82,9 @@ const AsyncConfigManagementPage = asyncComponent(() => import('Containers/Config
 const AsyncWorkloadCvesPage = asyncComponent(
     () => import('Containers/Vulnerabilities/WorkloadCves/WorkloadCvesPage')
 );
+const AsyncVulnerabilityReportingPage = asyncComponent(
+    () => import('Containers/Vulnerabilities/VulnerablityReporting/VulnReportingPage')
+);
 const AsyncVulnMgmtReports = asyncComponent(
     () => import('Containers/VulnMgmt/Reports/VulnMgmtReports')
 );
@@ -108,6 +112,9 @@ function Body({ hasReadAccess, isFeatureFlagEnabled }: BodyProps): ReactElement 
     const isNetworkGraphPatternflyEnabled = isFeatureFlagEnabled('ROX_NETWORK_GRAPH_PATTERNFLY');
     const isVulnMgmtWorkloadCvesEnabled =
         isFeatureFlagEnabled('ROX_VULN_MGMT_WORKLOAD_CVES') && isPostgresEnabled;
+    const isVulnerabilityReportingEnhancementsEnabled = isFeatureFlagEnabled(
+        'ROX_VULN_MGMT_REPORTING_ENHANCEMENTS'
+    );
 
     const hasVulnerabilityReportsPermission = hasReadAccess('WorkflowAdministration');
     const hasCollectionsPermission = hasReadAccess('WorkflowAdministration');
@@ -146,6 +153,12 @@ function Body({ hasReadAccess, isFeatureFlagEnabled }: BodyProps): ReactElement 
                         <Route
                             path={vulnerabilitiesWorkloadCvesPath}
                             component={AsyncWorkloadCvesPage}
+                        />
+                    )}
+                    {isVulnerabilityReportingEnhancementsEnabled && (
+                        <Route
+                            path={vulnerabilityReportingPath}
+                            component={AsyncVulnerabilityReportingPage}
                         />
                     )}
                     {hasVulnerabilityReportsPermission && (

--- a/ui/apps/platform/src/Containers/MainPage/Body.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Body.tsx
@@ -155,15 +155,20 @@ function Body({ hasReadAccess, isFeatureFlagEnabled }: BodyProps): ReactElement 
                             component={AsyncWorkloadCvesPage}
                         />
                     )}
-                    {isVulnerabilityReportingEnhancementsEnabled && (
-                        <Route
-                            path={vulnerabilityReportingPath}
-                            component={AsyncVulnerabilityReportingPage}
-                        />
-                    )}
-                    {hasVulnerabilityReportsPermission && (
-                        <Route path={vulnManagementReportsPath} component={AsyncVulnMgmtReports} />
-                    )}
+                    {hasVulnerabilityReportsPermission &&
+                        isVulnerabilityReportingEnhancementsEnabled && (
+                            <Route
+                                path={vulnerabilityReportingPath}
+                                component={AsyncVulnerabilityReportingPage}
+                            />
+                        )}
+                    {hasVulnerabilityReportsPermission &&
+                        !isVulnerabilityReportingEnhancementsEnabled && (
+                            <Route
+                                path={vulnManagementReportsPath}
+                                component={AsyncVulnMgmtReports}
+                            />
+                        )}
                     <Route
                         path={vulnManagementRiskAcceptancePath}
                         component={AsyncVulnMgmtRiskAcceptancePage}

--- a/ui/apps/platform/src/Containers/MainPage/Sidebar/NavigationSidebar.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Sidebar/NavigationSidebar.tsx
@@ -24,6 +24,7 @@ import {
     collectionsBasePath,
     vulnerabilitiesWorkloadCvesPath,
     networkBasePathPF,
+    vulnerabilityReportingPath,
 } from 'routePaths';
 
 import LeftNavItem from './LeftNavItem';
@@ -61,7 +62,6 @@ function NavigationSidebar({
         systemConfigPath,
         systemHealthPath,
     ];
-
     if (hasReadAccess('WorkflowAdministration')) {
         // Insert 'Collections' after 'Policy Management'
         platformConfigurationPaths.splice(
@@ -71,10 +71,14 @@ function NavigationSidebar({
         );
     }
 
-    const vulnerabilitiesPaths = [vulnerabilitiesWorkloadCvesPath];
+    const vulnerabilitiesPaths = [vulnerabilitiesWorkloadCvesPath, vulnerabilityReportingPath];
+
     const isWorkloadCvesEnabled =
         isFeatureFlagEnabled('ROX_VULN_MGMT_WORKLOAD_CVES') &&
         isFeatureFlagEnabled('ROX_POSTGRES_DATASTORE');
+    const isReportingEnhancementsEnabled = isFeatureFlagEnabled(
+        'ROX_VULN_MGMT_REPORTING_ENHANCEMENTS'
+    );
 
     const Navigation = (
         <Nav id="nav-primary-simple">
@@ -99,7 +103,7 @@ function NavigationSidebar({
                     path={complianceBasePath}
                     title={basePathToLabelMap[complianceBasePath]}
                 />
-                {isWorkloadCvesEnabled && (
+                {(isWorkloadCvesEnabled || isReportingEnhancementsEnabled) && (
                     <NavExpandable
                         id="Vulnerabilities"
                         title="Vulnerability Management (2.0)"
@@ -110,13 +114,25 @@ function NavigationSidebar({
                             location.pathname.includes(path)
                         )}
                     >
-                        <BadgedNavItem
-                            variant="TechPreview"
-                            key={vulnerabilitiesWorkloadCvesPath}
-                            isActive={location.pathname.includes(vulnerabilitiesWorkloadCvesPath)}
-                            path={vulnerabilitiesWorkloadCvesPath}
-                            title={basePathToLabelMap[vulnerabilitiesWorkloadCvesPath]}
-                        />
+                        {isWorkloadCvesEnabled && (
+                            <BadgedNavItem
+                                variant="TechPreview"
+                                key={vulnerabilitiesWorkloadCvesPath}
+                                isActive={location.pathname.includes(
+                                    vulnerabilitiesWorkloadCvesPath
+                                )}
+                                path={vulnerabilitiesWorkloadCvesPath}
+                                title={basePathToLabelMap[vulnerabilitiesWorkloadCvesPath]}
+                            />
+                        )}
+                        {isReportingEnhancementsEnabled && (
+                            <LeftNavItem
+                                key={vulnerabilityReportingPath}
+                                isActive={location.pathname.includes(vulnerabilityReportingPath)}
+                                path={vulnerabilityReportingPath}
+                                title={basePathToLabelMap[vulnerabilityReportingPath]}
+                            />
+                        )}
                     </NavExpandable>
                 )}
                 <NavExpandable

--- a/ui/apps/platform/src/Containers/MainPage/Sidebar/NavigationSidebar.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Sidebar/NavigationSidebar.tsx
@@ -42,9 +42,7 @@ function NavigationSidebar({
     isFeatureFlagEnabled,
 }: NavigationSidebarProps): ReactElement {
     const location: Location = useLocation();
-    const isWorkloadCvesEnabled =
-        isFeatureFlagEnabled('ROX_VULN_MGMT_WORKLOAD_CVES') &&
-        isFeatureFlagEnabled('ROX_POSTGRES_DATASTORE');
+    const isWorkloadCvesEnabled = isFeatureFlagEnabled('ROX_VULN_MGMT_WORKLOAD_CVES');
     const isReportingEnhancementsEnabled = isFeatureFlagEnabled(
         'ROX_VULN_MGMT_REPORTING_ENHANCEMENTS'
     );
@@ -56,7 +54,7 @@ function NavigationSidebar({
     ) {
         vulnerabilityManagementPaths.push(vulnManagementRiskAcceptancePath);
     }
-    if (hasReadAccess('WorkflowAdministration') && !isReportingEnhancementsEnabled) {
+    if (hasReadAccess('WorkflowAdministration')) {
         vulnerabilityManagementPaths.push(vulnManagementReportsPath);
     }
 

--- a/ui/apps/platform/src/Containers/MainPage/Sidebar/NavigationSidebar.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Sidebar/NavigationSidebar.tsx
@@ -42,6 +42,12 @@ function NavigationSidebar({
     isFeatureFlagEnabled,
 }: NavigationSidebarProps): ReactElement {
     const location: Location = useLocation();
+    const isWorkloadCvesEnabled =
+        isFeatureFlagEnabled('ROX_VULN_MGMT_WORKLOAD_CVES') &&
+        isFeatureFlagEnabled('ROX_POSTGRES_DATASTORE');
+    const isReportingEnhancementsEnabled = isFeatureFlagEnabled(
+        'ROX_VULN_MGMT_REPORTING_ENHANCEMENTS'
+    );
 
     const vulnerabilityManagementPaths = [vulnManagementPath];
     if (
@@ -50,7 +56,7 @@ function NavigationSidebar({
     ) {
         vulnerabilityManagementPaths.push(vulnManagementRiskAcceptancePath);
     }
-    if (hasReadAccess('WorkflowAdministration')) {
+    if (hasReadAccess('WorkflowAdministration') && !isReportingEnhancementsEnabled) {
         vulnerabilityManagementPaths.push(vulnManagementReportsPath);
     }
 
@@ -72,13 +78,6 @@ function NavigationSidebar({
     }
 
     const vulnerabilitiesPaths = [vulnerabilitiesWorkloadCvesPath, vulnerabilityReportingPath];
-
-    const isWorkloadCvesEnabled =
-        isFeatureFlagEnabled('ROX_VULN_MGMT_WORKLOAD_CVES') &&
-        isFeatureFlagEnabled('ROX_POSTGRES_DATASTORE');
-    const isReportingEnhancementsEnabled = isFeatureFlagEnabled(
-        'ROX_VULN_MGMT_REPORTING_ENHANCEMENTS'
-    );
 
     const Navigation = (
         <Nav id="nav-primary-simple">
@@ -125,14 +124,17 @@ function NavigationSidebar({
                                 title={basePathToLabelMap[vulnerabilitiesWorkloadCvesPath]}
                             />
                         )}
-                        {isReportingEnhancementsEnabled && (
-                            <LeftNavItem
-                                key={vulnerabilityReportingPath}
-                                isActive={location.pathname.includes(vulnerabilityReportingPath)}
-                                path={vulnerabilityReportingPath}
-                                title={basePathToLabelMap[vulnerabilityReportingPath]}
-                            />
-                        )}
+                        {isReportingEnhancementsEnabled &&
+                            hasReadAccess('WorkflowAdministration') && (
+                                <LeftNavItem
+                                    key={vulnerabilityReportingPath}
+                                    isActive={location.pathname.includes(
+                                        vulnerabilityReportingPath
+                                    )}
+                                    path={vulnerabilityReportingPath}
+                                    title={basePathToLabelMap[vulnerabilityReportingPath]}
+                                />
+                            )}
                     </NavExpandable>
                 )}
                 <NavExpandable

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReportingPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReportingPage.tsx
@@ -1,11 +1,8 @@
 import React from 'react';
 import { Route, Switch } from 'react-router-dom';
-import { PageSection } from '@patternfly/react-core';
 
 import { vulnerabilityReportingPath } from 'routePaths';
 
-import PageNotFound from 'Components/PageNotFound';
-import PageTitle from 'Components/PageTitle';
 import VulnReportsPage from './VulnReports/VulnReportsPage';
 
 import './VulnReportingPage.css';
@@ -14,12 +11,6 @@ function VulnReportingPage() {
     return (
         <Switch>
             <Route exact path={vulnerabilityReportingPath} component={VulnReportsPage} />
-            <Route>
-                <PageSection variant="light">
-                    <PageTitle title="Vulnerability Reporting - Not Found" />
-                    <PageNotFound />
-                </PageSection>
-            </Route>
         </Switch>
     );
 }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReportingPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReportingPage.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Route, Switch } from 'react-router-dom';
+import { PageSection } from '@patternfly/react-core';
+
+import { vulnerabilityReportingPath } from 'routePaths';
+
+import PageNotFound from 'Components/PageNotFound';
+import PageTitle from 'Components/PageTitle';
+import VulnReportsPage from './VulnReports/VulnReportsPage';
+
+import './VulnReportingPage.css';
+
+function VulnReportingPage() {
+    return (
+        <Switch>
+            <Route exact path={vulnerabilityReportingPath} component={VulnReportsPage} />
+            <Route>
+                <PageSection variant="light">
+                    <PageTitle title="Vulnerability Reporting - Not Found" />
+                    <PageNotFound />
+                </PageSection>
+            </Route>
+        </Switch>
+    );
+}
+
+export default VulnReportingPage;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/VulnReportsPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/VulnReportsPage.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { PageSection, Title, Divider, Flex, FlexItem, Button } from '@patternfly/react-core';
+
+import PageTitle from 'Components/PageTitle';
+
+function VulnReportsPage() {
+    return (
+        <>
+            <PageTitle title="Vulnerability reporting" />
+            <Divider component="div" />
+            <PageSection variant="light" padding={{ default: 'noPadding' }}>
+                <Flex
+                    direction={{ default: 'row' }}
+                    alignItems={{ default: 'alignItemsCenter' }}
+                    className="pf-u-py-lg pf-u-px-lg"
+                >
+                    <FlexItem flex={{ default: 'flex_1' }}>
+                        <Flex direction={{ default: 'column' }}>
+                            <FlexItem>
+                                <Title headingLevel="h1">Vulnerability reporting</Title>
+                            </FlexItem>
+                            <FlexItem>
+                                Configure reports, define report scopes, and assign distribution
+                                lists to report on vulnerabilities across the organization.
+                            </FlexItem>
+                        </Flex>
+                    </FlexItem>
+                    <FlexItem>
+                        <Button variant="primary" onClick={() => {}}>
+                            Create report
+                        </Button>
+                    </FlexItem>
+                </Flex>
+            </PageSection>
+            <PageSection padding={{ default: 'noPadding' }} />
+        </>
+    );
+}
+
+export default VulnReportsPage;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/VulnReportsPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/VulnReportsPage.tsx
@@ -2,8 +2,21 @@ import React from 'react';
 import { PageSection, Title, Divider, Flex, FlexItem, Button } from '@patternfly/react-core';
 
 import PageTitle from 'Components/PageTitle';
+import usePermissions from 'hooks/usePermissions';
 
 function VulnReportsPage() {
+    const { hasReadWriteAccess, hasReadAccess } = usePermissions();
+
+    const hasWorkflowAdministrationWriteAccess = hasReadWriteAccess('WorkflowAdministration');
+    const hasImageReadAccess = hasReadAccess('Image');
+    const hasAccessScopeReadAccess = hasReadAccess('Access');
+    const hasNotifierIntegrationReadAccess = hasReadAccess('Integration');
+    const canCreateReports =
+        hasWorkflowAdministrationWriteAccess &&
+        hasImageReadAccess &&
+        hasAccessScopeReadAccess &&
+        hasNotifierIntegrationReadAccess;
+
     return (
         <>
             <PageTitle title="Vulnerability reporting" />
@@ -26,9 +39,11 @@ function VulnReportsPage() {
                         </Flex>
                     </FlexItem>
                     <FlexItem>
-                        <Button variant="primary" onClick={() => {}}>
-                            Create report
-                        </Button>
+                        {canCreateReports && (
+                            <Button variant="primary" onClick={() => {}}>
+                                Create report
+                            </Button>
+                        )}
                     </FlexItem>
                 </Flex>
             </PageSection>

--- a/ui/apps/platform/src/routePaths.js
+++ b/ui/apps/platform/src/routePaths.js
@@ -92,10 +92,13 @@ export const vulnManagementApprovedFalsePositivesPath = `${vulnManagementRiskAcc
 
 // VM 2.0 "Vulnerabilities" paths
 export const vulnerabilitiesBasePath = `${mainPath}/vulnerabilities`;
+
 export const vulnerabilitiesWorkloadCvesPath = `${vulnerabilitiesBasePath}/workload-cves`;
 export const vulnerabilitiesWorkloadCveSinglePath = `${vulnerabilitiesBasePath}/workload-cves/cves/:cveId`;
 export const vulnerabilitiesWorkloadCveImageSinglePath = `${vulnerabilitiesBasePath}/workload-cves/images/:imageId`;
 export const vulnerabilitiesWorkloadCveDeploymentSinglePath = `${vulnerabilitiesBasePath}/workload-cves/deployments/:deploymentId`;
+
+export const vulnerabilityReportingPath = `${vulnerabilitiesBasePath}/vulnerability-reporting`;
 
 /**
  * New Framwork-related route paths
@@ -154,6 +157,7 @@ const vulnManagementPathToLabelMap = {
 const vulnerabilitiesPathToLabelMap = {
     [vulnerabilitiesBasePath]: 'Vulnerabilities',
     [vulnerabilitiesWorkloadCvesPath]: 'Workload CVEs',
+    [vulnerabilityReportingPath]: 'Vulnerability Reporting',
 };
 
 export const basePathToLabelMap = {


### PR DESCRIPTION
## Description

This PR adds some boilerplate code to start things off for the new vulnerability reporting page. The routes are in place and a simple header, subheader, and button were added to the main page

<img width="1552" alt="Screenshot 2023-06-15 at 10 50 39 AM" src="https://github.com/stackrox/stackrox/assets/4805485/366854a0-a00b-4364-ab0d-5acf1f1c2fcc">
