### PR TITLE
style: Use `make --quiet --no-print-directory` everywhere

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -333,11 +333,11 @@ jobs:
 
       - name: Set build tag for prerelease images
         if: matrix.name == 'prerelease'
-        run: echo "BUILD_TAG=$(make --quiet tag)-prerelease" >> "$GITHUB_ENV"
+        run: echo "BUILD_TAG=$(make --quiet --no-print-directory tag)-prerelease" >> "$GITHUB_ENV"
 
       - name: Set build tag for race condition images
         if: matrix.name == 'race-condition-debug'
-        run: echo "BUILD_TAG=$(make --quiet tag)-rcd" >> "$GITHUB_ENV"
+        run: echo "BUILD_TAG=$(make --quiet --no-print-directory tag)-rcd" >> "$GITHUB_ENV"
 
       - name: Build main images
         run: make docker-build-main-image
@@ -441,7 +441,7 @@ jobs:
         run: make -C operator/ build docker-build
 
       - name: Check that Operator image is runnable
-        run: docker run --rm "quay.io/rhacs-eng/stackrox-operator:$(make --quiet -C operator tag)" --help
+        run: docker run --rm "quay.io/rhacs-eng/stackrox-operator:$(make --quiet --no-print-directory -C operator tag)" --help
 
       - name: Push images
         # Skip for external contributions.
@@ -489,7 +489,7 @@ jobs:
     - name: Get tag
       id: tag
       run: |
-        echo "TAG=$(make --quiet tag)" >> "$GITHUB_OUTPUT"
+        echo "TAG=$(make --quiet --no-print-directory tag)" >> "$GITHUB_OUTPUT"
 
     - name: Build image
       run: make mock-grpc-server-image

--- a/dev-tools/upgrade-dev-secured-cluster.sh
+++ b/dev-tools/upgrade-dev-secured-cluster.sh
@@ -28,7 +28,7 @@ if [[ -f  "$default_init_bundle_path" ]]; then
   )
 fi
 
-MAIN_IMAGE_TAG="${MAIN_IMAGE_TAG:-$(make --quiet -C "$DIR/.." tag)}"
+MAIN_IMAGE_TAG="${MAIN_IMAGE_TAG:-$(make --quiet --no-print-directory -C "$DIR/.." tag)}"
 
 helm_args+=(
   --set "image.main.tag=$MAIN_IMAGE_TAG"

--- a/operator/README.md
+++ b/operator/README.md
@@ -194,7 +194,7 @@ $ kubectl -n bundle-test patch serviceaccount default -p '{"imagePullSecrets": [
 
 # 4. Run bundle.
 $ bin/operator-sdk-1.24.1 run bundle \
-  quay.io/rhacs-eng/stackrox-operator-bundle:v$(make --quiet tag) \
+  quay.io/rhacs-eng/stackrox-operator-bundle:v$(make --quiet --no-print-directory tag) \
   --pull-secret-name my-opm-image-pull-secrets \
   --service-account default \
   --namespace bundle-test

--- a/release/scripts/vuln_check.sh
+++ b/release/scripts/vuln_check.sh
@@ -89,9 +89,9 @@ function compare_fixable_vulns {
 FAIL_SCRIPT=false
 
 # determine all image tags
-RELEASE_TAG=$(make --no-print-directory --quiet -C "${GITROOT}" tag)
-COLLECTOR_TAG=$(make --no-print-directory --quiet -C "${GITROOT}" collector-tag)
-SCANNER_TAG=$(make --no-print-directory --quiet -C "${GITROOT}" scanner-tag)
+RELEASE_TAG=$(make --quiet --no-print-directory -C "${GITROOT}" tag)
+COLLECTOR_TAG=$(make --quiet --no-print-directory -C "${GITROOT}" collector-tag)
+SCANNER_TAG=$(make --quiet --no-print-directory -C "${GITROOT}" scanner-tag)
 
 ALLOWED_VULNS=$(jq -c '.[]' "$DIR/allowed_vulns.json")
 

--- a/scale/chaos/deploy.sh
+++ b/scale/chaos/deploy.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 gitroot="$(git rev-parse --show-toplevel)"
 [[ -n "${gitroot}" ]] || { echo >&2 "Could not determine git root!"; exit 1; }
 
-export TAG="$(make --no-print-directory --quiet -C "${gitroot}" tag)"
+export TAG="$(make --quiet --no-print-directory -C "${gitroot}" tag)"
 
 dir="$(dirname "${BASH_SOURCE[0]}")"
 envsubst < "${dir}/deploy.yaml" | kubectl apply -f -

--- a/scripts/ci/bats/lib_release_version_test.bats
+++ b/scripts/ci/bats/lib_release_version_test.bats
@@ -78,7 +78,7 @@ function setup() {
 # check_collector_version(), check_scanner_version() tests
 
 function make() {
-    echo "${tags[$2]}"
+    echo "${tags[$3]}"
 }
 
 @test "spots collector tag is a master commit" {

--- a/scripts/ci/jobs/local-roxctl-tests.sh
+++ b/scripts/ci/jobs/local-roxctl-tests.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 local_roxctl_tests() {
     info "Starting local roxctl tests"
 
-    MAIN_TAG=$(make --quiet tag)
+    MAIN_TAG=$(make --quiet --no-print-directory tag)
     export MAIN_TAG
 
     run_roxctl_bats_tests "roxctl-test-output" "local"  || touch FAIL

--- a/scripts/ci/jobs/push-images.sh
+++ b/scripts/ci/jobs/push-images.sh
@@ -21,7 +21,7 @@ push_images() {
     [[ "${OPENSHIFT_CI:-false}" == "true" ]] || { die "Only supported in OpenShift CI"; }
 
     local tag
-    tag="$(make --quiet tag)"
+    tag="$(make --quiet --no-print-directory tag)"
 
     if is_release_version "$tag"; then
         check_scanner_and_collector_versions

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -116,7 +116,7 @@ setup_deployment_env() {
     ci_export REGISTRY_USERNAME "$QUAY_RHACS_ENG_RO_USERNAME"
     ci_export REGISTRY_PASSWORD "$QUAY_RHACS_ENG_RO_PASSWORD"
     if [[ -z "${MAIN_IMAGE_TAG:-}" ]]; then
-        ci_export MAIN_IMAGE_TAG "$(make --quiet tag)"
+        ci_export MAIN_IMAGE_TAG "$(make --quiet --no-print-directory tag)"
     fi
 
     REPO=rhacs-eng
@@ -239,7 +239,7 @@ push_main_image_set() {
     fi
 
     local tag
-    tag="$(make --quiet tag)"
+    tag="$(make --quiet --no-print-directory tag)"
     for registry in "${destination_registries[@]}"; do
         registry_rw_login "$registry"
 
@@ -339,7 +339,7 @@ push_operator_image_set() {
     fi
 
     local tag
-    tag="$(make --quiet -C operator tag)"
+    tag="$(make --quiet --no-print-directory -C operator tag)"
     for registry in "${destination_registries[@]}"; do
         registry_rw_login "$registry"
 
@@ -371,12 +371,12 @@ push_race_condition_debug_image() {
 
     local registry="quay.io/rhacs-eng"
     registry_rw_login "$registry"
-    oc_image_mirror "$MAIN_RCD_IMAGE" "${registry}/main:$(make --quiet tag)-rcd"
+    oc_image_mirror "$MAIN_RCD_IMAGE" "${registry}/main:$(make --quiet --no-print-directory tag)-rcd"
 }
 
 push_mock_grpc_server_image() {
     local registry="quay.io/rhacs-eng"
-    image="${registry}/grpc-server:$(make --quiet tag)"
+    image="${registry}/grpc-server:$(make --quiet --no-print-directory tag)"
     info "Pushing the mock grpc server image: $MOCK_GRPC_SERVER_IMAGE to $image"
 
     if ! is_OPENSHIFT_CI; then
@@ -456,11 +456,11 @@ push_matching_collector_scanner_images() {
     }
 
     local main_tag
-    main_tag="$(make --quiet tag)"
+    main_tag="$(make --quiet --no-print-directory tag)"
     local scanner_version
-    scanner_version="$(make --quiet scanner-tag)"
+    scanner_version="$(make --quiet --no-print-directory scanner-tag)"
     local collector_version
-    collector_version="$(make --quiet collector-tag)"
+    collector_version="$(make --quiet --no-print-directory collector-tag)"
 
     for target_registry in "${target_registries[@]}"; do
         registry_rw_login "${target_registry}"
@@ -521,7 +521,7 @@ poll_for_system_test_images() {
     info "Will poll for: ${reqd_images[*]}"
 
     local tag
-    tag="$(make --quiet tag)"
+    tag="$(make --quiet --no-print-directory tag)"
     local start_time
     start_time="$(date '+%s')"
 
@@ -572,14 +572,14 @@ check_rhacs_eng_image_exists() {
 
 
 check_scanner_version() {
-    if ! is_release_version "$(make --quiet scanner-tag)"; then
+    if ! is_release_version "$(make --quiet --no-print-directory scanner-tag)"; then
         echo "::error::Scanner tag does not look like a release tag. Please update SCANNER_VERSION file before releasing."
         exit 1
     fi
 }
 
 check_collector_version() {
-    if ! is_release_version "$(make --quiet collector-tag)"; then
+    if ! is_release_version "$(make --quiet --no-print-directory collector-tag)"; then
         echo "::error::Collector tag does not look like a release tag. Please update COLLECTOR_VERSION file before releasing."
         exit 1
     fi
@@ -1079,7 +1079,7 @@ openshift_ci_mods() {
     info "Status after mods:"
     "$ROOT/status.sh" || true
 
-    STACKROX_BUILD_TAG=$(make --quiet tag)
+    STACKROX_BUILD_TAG=$(make --quiet --no-print-directory tag)
     export STACKROX_BUILD_TAG
 
     info "END OpenShift CI mods"
@@ -1271,7 +1271,7 @@ send_slack_notice_for_failures_on_merge() {
     fi
 
     local tag
-    tag="$(make --quiet tag)"
+    tag="$(make --quiet --no-print-directory tag)"
     if [[ "$tag" =~ $RELEASE_RC_TAG_BASH_REGEX ]]; then
         return 0
     fi

--- a/scripts/offline-bundle/create.sh
+++ b/scripts/offline-bundle/create.sh
@@ -44,7 +44,7 @@ store_roxctl() {
 main() {
     # Main uses the version reported by make tag.
     local main_tag
-    main_tag="$(make --quiet tag)"
+    main_tag="$(make --quiet --no-print-directory tag)"
     save "stackrox.io" "main" "${main_tag}" "image-bundle"
 
     # Scanner uses the same version as Main.

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -100,7 +100,7 @@ test_e2e() {
 test_preamble() {
     require_executable "roxctl"
 
-    MAIN_TAG=$(make --quiet tag)
+    MAIN_TAG=$(make --quiet --no-print-directory tag)
     export MAIN_TAG
 
     export ROX_PLAINTEXT_ENDPOINTS="8080,grpc@8081"

--- a/tests/upgrade/legacy_to_postgres_run.sh
+++ b/tests/upgrade/legacy_to_postgres_run.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 # Tests upgrade to Postgres.
 
 TEST_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd)"
-CURRENT_TAG="$(make --quiet tag)"
+CURRENT_TAG="$(make --quiet --no-print-directory tag)"
 
 # shellcheck source=../../scripts/lib.sh
 source "$TEST_ROOT/scripts/lib.sh"

--- a/tests/upgrade/lib.sh
+++ b/tests/upgrade/lib.sh
@@ -113,7 +113,7 @@ force_rollback() {
     local upgradeStatus
     upgradeStatus=$(curl -sSk -X GET -u "admin:${ROX_PASSWORD}" https://"${API_ENDPOINT}"/v1/centralhealth/upgradestatus)
     echo "upgrade status: ${upgradeStatus}"
-    test_equals_non_silent "$(echo "$upgradeStatus" | jq '.upgradeStatus.version' -r)" "$(make --quiet tag)"
+    test_equals_non_silent "$(echo "$upgradeStatus" | jq '.upgradeStatus.version' -r)" "$(make --quiet --no-print-directory tag)"
     test_equals_non_silent "$(echo "$upgradeStatus" | jq '.upgradeStatus.forceRollbackTo' -r)" "$FORCE_ROLLBACK_VERSION"
     test_equals_non_silent "$(echo "$upgradeStatus" | jq '.upgradeStatus.canRollbackAfterUpgrade' -r)" "true"
     test_gt_non_silent "$(echo "$upgradeStatus" | jq '.upgradeStatus.spaceAvailableForRollbackAfterUpgrade' -r)" "$(echo "$upgradeStatus" | jq '.upgradeStatus.spaceRequiredForRollbackAfterUpgrade' -r)"

--- a/tests/upgrade/postgres_run.sh
+++ b/tests/upgrade/postgres_run.sh
@@ -11,7 +11,7 @@ TEST_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd)"
 # also not set to expire
 INITIAL_POSTGRES_TAG="3.74.0-1-gfe924fce30"
 INITIAL_POSTGRES_SHA="fe924fce30bbec4dbd37d731ccd505837a2c2575"
-CURRENT_TAG="$(make --quiet tag)"
+CURRENT_TAG="$(make --quiet --no-print-directory tag)"
 
 # shellcheck source=../../scripts/lib.sh
 source "$TEST_ROOT/scripts/lib.sh"


### PR DESCRIPTION
## Description

Mostly this is cargo-cult and ensuring consistent styling. However, there are some deep edge cases when this may prevent unwanted output from `make`. See https://github.com/stackrox/stackrox/pull/3051#discussion_r968840394

## Checklist
- [x] Investigated and inspected CI test results

These won't be done:
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

## Testing Performed

* Only CI.