### PR TITLE
fix(e2e): Fix compliance predicate search for controls

### DIFF
--- a/central/compliance/standards/registry.go
+++ b/central/compliance/standards/registry.go
@@ -275,11 +275,11 @@ func (r *Registry) SearchControls(q *v1.Query) ([]search.Result, error) {
 		return nil, errors.Wrap(err, "generating predicate for query")
 	}
 	var results []search.Result
-	for _, standards := range r.AllStandards() {
-		for _, control := range standards.controls {
-			result, ok := pred.Evaluate(control.ToProto())
+	for _, standard := range r.AllStandards() {
+		for _, control := range standard.ToProto().GetControls() {
+			result, ok := pred.Evaluate(control)
 			if ok {
-				result.ID = control.ID
+				result.ID = control.Id
 				results = append(results, *result)
 			}
 		}

--- a/central/compliance/standards/registry_test.go
+++ b/central/compliance/standards/registry_test.go
@@ -20,5 +20,10 @@ func TestIndexer(t *testing.T) {
 	results, err = registry.SearchControls(search.NewQueryBuilder().AddExactMatches(search.Control, "1.1.1").AddStrings(search.StandardID, "pci").ProtoQuery())
 	require.NoError(t, err)
 	require.Len(t, results, 1)
-	assert.Equal(t, results[0].ID, "1_1_1")
+	assert.Equal(t, "PCI_DSS_3_2:1_1_1", results[0].ID)
+
+	results, err = registry.SearchControls(search.NewQueryBuilder().AddExactMatches(search.ControlID, "PCI_DSS_3_2:1_1_1").AddStrings(search.StandardID, "pci").ProtoQuery())
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "PCI_DSS_3_2:1_1_1", results[0].ID)
 }


### PR DESCRIPTION
## Description

Historically, the control's id was fully qualified. This was due to the proto format from the standard.ToProto(). I had a bug where I used control.ToProto() from the internal standard and not the proto from the resolution of standard.ToProto()

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

UI e2e
