### PR TITLE
chore(ui): Rename link functions for Configuration Management tests

### DIFF
--- a/ui/apps/platform/cypress/integration/configmanagement/ConfigurationManagement.helpers.js
+++ b/ui/apps/platform/cypress/integration/configmanagement/ConfigurationManagement.helpers.js
@@ -72,7 +72,7 @@ function tableHeaderRegExp(entitiesKey) {
     return new RegExp(`^(1 ${singular}|(?:0|2|3|4|5|6|7|8|9|[123456789]\\d+) ${plural})$`);
 }
 
-const tableLinkRegExp = {
+const countNounRegExp = {
     // clusters has singular link by name
     controls: /\d+ Controls?$/,
     deployments: /^\d+ deployments?$/,
@@ -396,7 +396,7 @@ export function verifyTableLinkToSidePanelTable(entitiesKey1, entitiesKey2) {
     visitConfigurationManagementEntities(entitiesKey1);
 
     cy.get('.rt-td')
-        .contains('a', tableLinkRegExp[entitiesKey2])
+        .contains('a', countNounRegExp[entitiesKey2])
         .then(($a) => {
             // 2. Visit secondary entities side panel.
             const opname = opnameForPrimaryAndSecondaryEntities(entitiesKey1, entitiesKey2);

--- a/ui/apps/platform/cypress/integration/configmanagement/ConfigurationManagement.helpers.js
+++ b/ui/apps/platform/cypress/integration/configmanagement/ConfigurationManagement.helpers.js
@@ -72,6 +72,20 @@ function tableHeaderRegExp(entitiesKey) {
     return new RegExp(`^(1 ${singular}|(?:0|2|3|4|5|6|7|8|9|[123456789]\\d+) ${plural})$`);
 }
 
+const tableLinkRegExp = {
+    // clusters has singular link by name
+    controls: /\d+ Controls?$/,
+    deployments: /^\d+ deployments?$/,
+    images: /\d+ images?$/,
+    // namespaces
+    // nodes
+    // policies
+    roles: /^\d+ Roles?$/,
+    secrets: /\d+ secrets?$/,
+    serviceaccounts: /^\d+ Service Accounts?$/,
+    subjects: /^\d+ Users & Groups$/,
+};
+
 // Title of widget is title case but has uppercase style.
 const widgetTitleForEntities = {
     clusters: 'Clusters',
@@ -330,7 +344,7 @@ export const hasRelatedEntityFor = (entity) => {
 };
 
 // Assume at either entity page or entity in side panel.
-function entityCountMatchesTableRows(entitiesKey1, entitiesKey2, contextSelector) {
+function verifyWidgetLinkToTable(entitiesKey1, entitiesKey2, contextSelector) {
     const listEntity = widgetTitleForEntities[entitiesKey2];
     cy.get(`${selectors.countWidgets}:contains('${listEntity}')`)
         .find(selectors.countWidgetValue)
@@ -366,20 +380,23 @@ function entityCountMatchesTableRows(entitiesKey1, entitiesKey2, contextSelector
         });
 }
 
-export function pageEntityCountMatchesTableRows(entitiesKey1, entitiesKey2) {
-    entityCountMatchesTableRows(entitiesKey1, entitiesKey2, '[data-testid="panel"]');
+export function verifyWidgetLinkToTableFromSinglePage(entitiesKey1, entitiesKey2) {
+    visitConfigurationManagementEntityInSidePanel(entitiesKey1);
+    navigateToSingleEntityPage(entitiesKey1);
+    verifyWidgetLinkToTable(entitiesKey1, entitiesKey2, '[data-testid="panel"]');
 }
 
-export function sidePanelEntityCountMatchesTableRows(entitiesKey1, entitiesKey2) {
-    entityCountMatchesTableRows(entitiesKey1, entitiesKey2, '[data-testid="side-panel"]');
+export function verifyWidgetLinkToTableFromSidePanel(entitiesKey1, entitiesKey2) {
+    visitConfigurationManagementEntityInSidePanel(entitiesKey1);
+    verifyWidgetLinkToTable(entitiesKey1, entitiesKey2, '[data-testid="side-panel"]');
 }
 
-export function entityListCountMatchesTableLinkCount(entitiesKey1, entitiesKey2, entitiesRegExp2) {
+export function verifyTableLinkToSidePanelTable(entitiesKey1, entitiesKey2) {
     // 1. Visit list page for primary entities.
     visitConfigurationManagementEntities(entitiesKey1);
 
     cy.get('.rt-td')
-        .contains('a', entitiesRegExp2)
+        .contains('a', tableLinkRegExp[entitiesKey2])
         .then(($a) => {
             // 2. Visit secondary entities side panel.
             const opname = opnameForPrimaryAndSecondaryEntities(entitiesKey1, entitiesKey2);

--- a/ui/apps/platform/cypress/integration/configmanagement/ciscontrols.test.js
+++ b/ui/apps/platform/cypress/integration/configmanagement/ciscontrols.test.js
@@ -3,15 +3,15 @@ import { hasOrchestratorFlavor } from '../../helpers/features';
 import { triggerScan } from '../compliance/Compliance.helpers';
 
 import {
-    visitConfigurationManagementEntityInSidePanel,
-    navigateToSingleEntityPage,
-    hasCountWidgetsFor,
     clickOnCountWidget,
+    hasCountWidgetsFor,
     hasTabsFor,
-    pageEntityCountMatchesTableRows,
-    sidePanelEntityCountMatchesTableRows,
     interactAndWaitForConfigurationManagementScan,
+    navigateToSingleEntityPage,
+    verifyWidgetLinkToTableFromSidePanel,
+    verifyWidgetLinkToTableFromSinglePage,
     visitConfigurationManagementDashboard,
+    visitConfigurationManagementEntityInSidePanel,
     visitConfigurationManagementEntitiesWithSearch,
 } from './ConfigurationManagement.helpers';
 
@@ -64,18 +64,15 @@ describe('Configuration Management Controls', () => {
         hasTabsFor(['nodes']);
     });
 
-    describe('should have same number in nodes table as in count widget', () => {
+    describe('should go to nodes table from widget link', () => {
         const entitiesKey2 = 'nodes';
 
-        it('of page', () => {
-            visitConfigurationManagementEntityInSidePanel(entitiesKey);
-            navigateToSingleEntityPage(entitiesKey);
-            pageEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
+        it('in single page', () => {
+            verifyWidgetLinkToTableFromSinglePage(entitiesKey, entitiesKey2);
         });
 
-        it('of side panel', () => {
-            visitConfigurationManagementEntityInSidePanel(entitiesKey);
-            sidePanelEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
+        it('in side panel', () => {
+            verifyWidgetLinkToTableFromSidePanel(entitiesKey, entitiesKey2);
         });
     });
 

--- a/ui/apps/platform/cypress/integration/configmanagement/clusters.test.js
+++ b/ui/apps/platform/cypress/integration/configmanagement/clusters.test.js
@@ -166,7 +166,8 @@ describe('Configuration Management Clusters', () => {
         });
     });
 
-    it('should go from table link to controls table in side panel', () => {
+    // ROX-13011: Prevent failures, pending investigation into reason why No Controls instead of link sometimes.
+    it.skip('should go from table link to controls table in side panel', () => {
         visitConfigurationManagementDashboard();
 
         // This test assumes that scan results are available

--- a/ui/apps/platform/cypress/integration/configmanagement/clusters.test.js
+++ b/ui/apps/platform/cypress/integration/configmanagement/clusters.test.js
@@ -5,10 +5,10 @@ import {
     navigateToSingleEntityPage,
     hasCountWidgetsFor,
     hasTabsFor,
-    pageEntityCountMatchesTableRows,
-    sidePanelEntityCountMatchesTableRows,
-    entityListCountMatchesTableLinkCount,
     interactAndWaitForConfigurationManagementScan,
+    verifyTableLinkToSidePanelTable,
+    verifyWidgetLinkToTableFromSidePanel,
+    verifyWidgetLinkToTableFromSinglePage,
     visitConfigurationManagementDashboard,
     visitConfigurationManagementEntities,
 } from './ConfigurationManagement.helpers';
@@ -70,128 +70,103 @@ describe('Configuration Management Clusters', () => {
         ).should('exist');
     });
 
-    describe('should have same number in nodes table as in count widget', () => {
+    describe('should go to nodes table from widget link', () => {
         const entitiesKey2 = 'nodes';
 
-        it('of page', () => {
-            visitConfigurationManagementEntityInSidePanel(entitiesKey);
-            navigateToSingleEntityPage(entitiesKey);
-            pageEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
+        it('in single page', () => {
+            verifyWidgetLinkToTableFromSinglePage(entitiesKey, entitiesKey2);
         });
 
-        it('of side panel', () => {
-            visitConfigurationManagementEntityInSidePanel(entitiesKey);
-            sidePanelEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
+        it('in side panel', () => {
+            verifyWidgetLinkToTableFromSidePanel(entitiesKey, entitiesKey2);
         });
     });
 
-    describe('should have same number in namespaces table as in count widget', () => {
+    describe('should go to namespaces table from widget link', () => {
         const entitiesKey2 = 'namespaces';
 
-        it('of page', () => {
-            visitConfigurationManagementEntityInSidePanel(entitiesKey);
-            navigateToSingleEntityPage(entitiesKey);
-            pageEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
+        it('in single page', () => {
+            verifyWidgetLinkToTableFromSinglePage(entitiesKey, entitiesKey2);
         });
 
-        it('of side panel', () => {
-            visitConfigurationManagementEntityInSidePanel(entitiesKey);
-            sidePanelEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
+        it('in side panel', () => {
+            verifyWidgetLinkToTableFromSidePanel(entitiesKey, entitiesKey2);
         });
     });
 
-    describe('should have same number in deployments table as in count widget', () => {
+    describe('should go to deployments table from widget link', () => {
         const entitiesKey2 = 'deployments';
 
-        it('of page', () => {
-            visitConfigurationManagementEntityInSidePanel(entitiesKey);
-            navigateToSingleEntityPage(entitiesKey);
-            pageEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
+        it('in single page', () => {
+            verifyWidgetLinkToTableFromSinglePage(entitiesKey, entitiesKey2);
         });
 
-        it('of side panel', () => {
-            visitConfigurationManagementEntityInSidePanel(entitiesKey);
-            sidePanelEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
+        it('in side panel', () => {
+            verifyWidgetLinkToTableFromSidePanel(entitiesKey, entitiesKey2);
         });
     });
 
-    describe('should have same number in images table as in count widget', () => {
+    describe('should go to images table from widget link', () => {
         const entitiesKey2 = 'images';
 
-        it('of page', () => {
-            visitConfigurationManagementEntityInSidePanel(entitiesKey);
-            navigateToSingleEntityPage(entitiesKey);
-            pageEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
+        it('in single page', () => {
+            verifyWidgetLinkToTableFromSinglePage(entitiesKey, entitiesKey2);
         });
 
-        it('of side panel', () => {
-            visitConfigurationManagementEntityInSidePanel(entitiesKey);
-            sidePanelEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
+        it('in side panel', () => {
+            verifyWidgetLinkToTableFromSidePanel(entitiesKey, entitiesKey2);
         });
     });
 
-    describe('should have same number in users and groups table as in count widget', () => {
+    describe('should go to subjects table from widget link', () => {
         const entitiesKey2 = 'subjects';
 
-        it('of page', () => {
-            visitConfigurationManagementEntityInSidePanel(entitiesKey);
-            navigateToSingleEntityPage(entitiesKey);
-            pageEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
+        it('in single page', () => {
+            verifyWidgetLinkToTableFromSinglePage(entitiesKey, entitiesKey2);
         });
 
-        it('of side panel', () => {
-            visitConfigurationManagementEntityInSidePanel(entitiesKey);
-            sidePanelEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
+        it('in side panel', () => {
+            verifyWidgetLinkToTableFromSidePanel(entitiesKey, entitiesKey2);
         });
     });
 
-    describe('should have same number in service accounts table as in count widget', () => {
+    describe('should go to serviceaccounts table from widget link', () => {
         const entitiesKey2 = 'serviceaccounts';
 
-        it('of page', () => {
-            visitConfigurationManagementEntityInSidePanel(entitiesKey);
-            navigateToSingleEntityPage(entitiesKey);
-            pageEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
+        it('in single page', () => {
+            verifyWidgetLinkToTableFromSinglePage(entitiesKey, entitiesKey2);
         });
 
-        it('of side panel', () => {
-            visitConfigurationManagementEntityInSidePanel(entitiesKey);
-            sidePanelEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
+        it('in side panel', () => {
+            verifyWidgetLinkToTableFromSidePanel(entitiesKey, entitiesKey2);
         });
     });
 
-    describe('should have same number in roles table as in count widget', () => {
+    describe('should go to roles table from widget link', () => {
         const entitiesKey2 = 'roles';
 
-        it('of page', () => {
-            visitConfigurationManagementEntityInSidePanel(entitiesKey);
-            navigateToSingleEntityPage(entitiesKey);
-            pageEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
+        it('in single page', () => {
+            verifyWidgetLinkToTableFromSinglePage(entitiesKey, entitiesKey2);
         });
 
-        it('of side panel', () => {
-            visitConfigurationManagementEntityInSidePanel(entitiesKey);
-            sidePanelEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
+        it('in side panel', () => {
+            verifyWidgetLinkToTableFromSidePanel(entitiesKey, entitiesKey2);
         });
     });
 
-    describe('should have same number in controls table as in count widget', () => {
+    describe('should go to controls table from widget link', () => {
         const entitiesKey2 = 'controls';
 
-        it('of page', () => {
-            visitConfigurationManagementEntityInSidePanel(entitiesKey);
-            navigateToSingleEntityPage(entitiesKey);
-            pageEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
+        it('in single page', () => {
+            verifyWidgetLinkToTableFromSinglePage(entitiesKey, entitiesKey2);
         });
 
-        it('of side panel', () => {
-            visitConfigurationManagementEntityInSidePanel(entitiesKey);
-            sidePanelEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
+        it('in side panel', () => {
+            verifyWidgetLinkToTableFromSidePanel(entitiesKey, entitiesKey2);
         });
     });
 
-    // ROX-13011: Prevent failures, pending investigation into reason why No Controls instead of link sometimes.
-    it.skip('should open the side panel to show the same number of Controls when the Controls link is clicked', () => {
+    it('should go from table link to controls table in side panel', () => {
         visitConfigurationManagementDashboard();
 
         // This test assumes that scan results are available
@@ -199,22 +174,18 @@ describe('Configuration Management Clusters', () => {
             cy.get('[data-testid="scan-button"]').click();
         });
 
-        entityListCountMatchesTableLinkCount(entitiesKey, 'controls', /\d+ Controls?$/);
+        verifyTableLinkToSidePanelTable(entitiesKey, 'controls');
     });
 
-    it('should open the side panel to show the same number of Users & Groups when the Users & Groups link is clicked', () => {
-        entityListCountMatchesTableLinkCount(entitiesKey, 'subjects', /^\d+ Users & Groups$/);
+    it('should go from table link to subjects table in side panel', () => {
+        verifyTableLinkToSidePanelTable(entitiesKey, 'subjects');
     });
 
-    it('should open the side panel to show the same number of Service Accounts when the Service Accounts link is clicked', () => {
-        entityListCountMatchesTableLinkCount(
-            entitiesKey,
-            'serviceaccounts',
-            /^\d+ Service Accounts?$/
-        );
+    it('should go from table link to serviceaccounts table in side panel', () => {
+        verifyTableLinkToSidePanelTable(entitiesKey, 'serviceaccounts');
     });
 
-    it('should open the side panel to show the same number of Roles when the Roles link is clicked', () => {
-        entityListCountMatchesTableLinkCount(entitiesKey, 'roles', /^\d+ Roles?$/);
+    it('should go from table link to roles table in side panel', () => {
+        verifyTableLinkToSidePanelTable(entitiesKey, 'roles');
     });
 });

--- a/ui/apps/platform/cypress/integration/configmanagement/deployments.test.js
+++ b/ui/apps/platform/cypress/integration/configmanagement/deployments.test.js
@@ -4,13 +4,13 @@ import {
     clickEntityTableRowThatHasLinkInColumn,
     clickOnCountWidget,
     clickOnSingularEntityWidgetInSidePanel,
-    entityListCountMatchesTableLinkCount,
     hasCountWidgetsFor,
     hasRelatedEntityFor,
     hasTabsFor,
     navigateToSingleEntityPage,
-    pageEntityCountMatchesTableRows,
-    sidePanelEntityCountMatchesTableRows,
+    verifyTableLinkToSidePanelTable,
+    verifyWidgetLinkToTableFromSidePanel,
+    verifyWidgetLinkToTableFromSinglePage,
     visitConfigurationManagementEntityInSidePanel,
 } from './ConfigurationManagement.helpers';
 
@@ -23,8 +23,8 @@ describe('Configuration Management Deployments', () => {
         visitConfigurationManagementEntityInSidePanel(entitiesKey);
     });
 
-    it('should open the side panel to show the same number of secrets when the secrets link is clicked', () => {
-        entityListCountMatchesTableLinkCount(entitiesKey, 'secrets', /\d+ secrets?$/);
+    it('should go from table link to images table in side panel', () => {
+        verifyTableLinkToSidePanelTable(entitiesKey, 'images');
     });
 
     it('should click on the cluster entity widget in the side panel and match the header ', () => {
@@ -64,33 +64,27 @@ describe('Configuration Management Deployments', () => {
         clickOnCountWidget('images', 'entityList');
     });
 
-    describe('should have same number in images table as in count widget', () => {
+    describe('should go to images table from widget link', () => {
         const entitiesKey2 = 'images';
 
-        it('of page', () => {
-            visitConfigurationManagementEntityInSidePanel(entitiesKey);
-            navigateToSingleEntityPage(entitiesKey);
-            pageEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
+        it('in single page', () => {
+            verifyWidgetLinkToTableFromSinglePage(entitiesKey, entitiesKey2);
         });
 
-        it('of side panel', () => {
-            visitConfigurationManagementEntityInSidePanel(entitiesKey);
-            sidePanelEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
+        it('in side panel', () => {
+            verifyWidgetLinkToTableFromSidePanel(entitiesKey, entitiesKey2);
         });
     });
 
-    describe('should have same number in secrets table as in count widget', () => {
+    describe('should go to secrets table from widget link', () => {
         const entitiesKey2 = 'secrets';
 
-        it('of page', () => {
-            visitConfigurationManagementEntityInSidePanel(entitiesKey);
-            navigateToSingleEntityPage(entitiesKey);
-            pageEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
+        it('in single page', () => {
+            verifyWidgetLinkToTableFromSinglePage(entitiesKey, entitiesKey2);
         });
 
-        it('of side panel', () => {
-            visitConfigurationManagementEntityInSidePanel(entitiesKey);
-            sidePanelEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
+        it('in side panel', () => {
+            verifyWidgetLinkToTableFromSidePanel(entitiesKey, entitiesKey2);
         });
     });
 });

--- a/ui/apps/platform/cypress/integration/configmanagement/images.test.js
+++ b/ui/apps/platform/cypress/integration/configmanagement/images.test.js
@@ -3,12 +3,12 @@ import withAuth from '../../helpers/basicAuth';
 import {
     clickEntityTableRowThatHasLinkInColumn,
     clickOnCountWidget,
-    entityListCountMatchesTableLinkCount,
     hasCountWidgetsFor,
     hasTabsFor,
     navigateToSingleEntityPage,
-    pageEntityCountMatchesTableRows,
-    sidePanelEntityCountMatchesTableRows,
+    verifyTableLinkToSidePanelTable,
+    verifyWidgetLinkToTableFromSidePanel,
+    verifyWidgetLinkToTableFromSinglePage,
     visitConfigurationManagementEntityInSidePanel,
 } from './ConfigurationManagement.helpers';
 
@@ -21,8 +21,8 @@ describe('Configuration Management Images', () => {
         visitConfigurationManagementEntityInSidePanel(entitiesKey);
     });
 
-    it('should open the side panel to show the same number of deployments when the deployments link is clicked', () => {
-        entityListCountMatchesTableLinkCount(entitiesKey, 'deployments', /^\d+ deployments?$/);
+    it('should go from table link to deployments table in side panel', () => {
+        verifyTableLinkToSidePanelTable(entitiesKey, 'deployments');
     });
 
     it('should take you to a images single when the "navigate away" button is clicked', () => {
@@ -50,18 +50,15 @@ describe('Configuration Management Images', () => {
         hasTabsFor(['deployments']);
     });
 
-    describe('should have same number in deployments table as in count widget', () => {
+    describe('should go to deployments table from widget link', () => {
         const entitiesKey2 = 'deployments';
 
-        it('of page', () => {
-            visitConfigurationManagementEntityInSidePanel(entitiesKey);
-            navigateToSingleEntityPage(entitiesKey);
-            pageEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
+        it('in single page', () => {
+            verifyWidgetLinkToTableFromSinglePage(entitiesKey, entitiesKey2);
         });
 
-        it('of side panel', () => {
-            visitConfigurationManagementEntityInSidePanel(entitiesKey);
-            sidePanelEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
+        it('in side panel', () => {
+            verifyWidgetLinkToTableFromSidePanel(entitiesKey, entitiesKey2);
         });
     });
 

--- a/ui/apps/platform/cypress/integration/configmanagement/namespaces.test.js
+++ b/ui/apps/platform/cypress/integration/configmanagement/namespaces.test.js
@@ -5,13 +5,13 @@ import {
     clickOnCountWidget,
     clickOnSingularEntityWidgetInSidePanel,
     clickOnSingleEntityInTable,
-    entityListCountMatchesTableLinkCount,
     hasCountWidgetsFor,
     hasRelatedEntityFor,
     hasTabsFor,
     navigateToSingleEntityPage,
-    pageEntityCountMatchesTableRows,
-    sidePanelEntityCountMatchesTableRows,
+    verifyTableLinkToSidePanelTable,
+    verifyWidgetLinkToTableFromSidePanel,
+    verifyWidgetLinkToTableFromSinglePage,
     visitConfigurationManagementEntityInSidePanel,
 } from './ConfigurationManagement.helpers';
 
@@ -63,60 +63,47 @@ describe('Configuration Management Namespaces', () => {
         hasTabsFor(['deployments', 'secrets', 'images']);
     });
 
-    describe('should have same number in deployments table as in count widget', () => {
+    describe('should go to deployments table from widget link', () => {
         const entitiesKey2 = 'deployments';
 
-        it('of page', () => {
-            visitConfigurationManagementEntityInSidePanel(entitiesKey);
-            navigateToSingleEntityPage(entitiesKey);
-            pageEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
+        it('in single page', () => {
+            verifyWidgetLinkToTableFromSinglePage(entitiesKey, entitiesKey2);
         });
 
-        it('of side panel', () => {
-            visitConfigurationManagementEntityInSidePanel(entitiesKey);
-            sidePanelEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
+        it('in side panel', () => {
+            verifyWidgetLinkToTableFromSidePanel(entitiesKey, entitiesKey2);
         });
     });
 
-    describe('should have same number in secrets table as in count widget', () => {
+    describe('should go to secrets table from widget lin', () => {
         const entitiesKey2 = 'secrets';
 
-        it('of page', () => {
-            visitConfigurationManagementEntityInSidePanel(entitiesKey);
-            navigateToSingleEntityPage(entitiesKey);
-            pageEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
+        it('in single page', () => {
+            verifyWidgetLinkToTableFromSinglePage(entitiesKey, entitiesKey2);
         });
 
-        it('of side panel', () => {
-            visitConfigurationManagementEntityInSidePanel(entitiesKey);
-            sidePanelEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
+        it('in side panel', () => {
+            verifyWidgetLinkToTableFromSidePanel(entitiesKey, entitiesKey2);
         });
     });
 
-    describe('should have same number in images table as in count widget', () => {
+    describe('should go to images table from widget link', () => {
         const entitiesKey2 = 'images';
 
-        it('of page', () => {
-            visitConfigurationManagementEntityInSidePanel(entitiesKey);
-            navigateToSingleEntityPage(entitiesKey);
-            pageEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
+        it('in single page', () => {
+            verifyWidgetLinkToTableFromSinglePage(entitiesKey, entitiesKey2);
         });
 
-        it('of side panel', () => {
-            visitConfigurationManagementEntityInSidePanel(entitiesKey);
-            sidePanelEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
+        it('in side panel', () => {
+            verifyWidgetLinkToTableFromSidePanel(entitiesKey, entitiesKey2);
         });
     });
 
-    it('should open the side panel to show the same number of Service Accounts when the Service Accounts link is clicked', () => {
-        entityListCountMatchesTableLinkCount(
-            entitiesKey,
-            'serviceaccounts',
-            /^\d+ Service Accounts?$/
-        );
+    it('should go from table link to serviceaccounts table in side panel', () => {
+        verifyTableLinkToSidePanelTable(entitiesKey, 'serviceaccounts');
     });
 
-    it('should open the side panel to show the same number of Roles when the Roles link is clicked', () => {
-        entityListCountMatchesTableLinkCount(entitiesKey, 'roles', /^\d+ Roles?$/);
+    it('should go from table link to roles table in side panel', () => {
+        verifyTableLinkToSidePanelTable(entitiesKey, 'roles');
     });
 });

--- a/ui/apps/platform/cypress/integration/configmanagement/namespaces.test.js
+++ b/ui/apps/platform/cypress/integration/configmanagement/namespaces.test.js
@@ -75,7 +75,7 @@ describe('Configuration Management Namespaces', () => {
         });
     });
 
-    describe('should go to secrets table from widget lin', () => {
+    describe('should go to secrets table from widget link', () => {
         const entitiesKey2 = 'secrets';
 
         it('in single page', () => {

--- a/ui/apps/platform/cypress/integration/configmanagement/nodes.test.js
+++ b/ui/apps/platform/cypress/integration/configmanagement/nodes.test.js
@@ -11,8 +11,8 @@ import {
     hasRelatedEntityFor,
     hasTabsFor,
     navigateToSingleEntityPage,
-    pageEntityCountMatchesTableRows,
-    sidePanelEntityCountMatchesTableRows,
+    verifyWidgetLinkToTableFromSidePanel,
+    verifyWidgetLinkToTableFromSinglePage,
     visitConfigurationManagementEntityInSidePanel,
 } from './ConfigurationManagement.helpers';
 
@@ -70,18 +70,15 @@ describe('Configuration Management Nodes', () => {
         clickOnCountWidget('controls', 'entityList');
     });
 
-    describe('should have same number in controls table as in count widget', () => {
+    describe('should go to controls table from widget link', () => {
         const entitiesKey2 = 'controls';
 
-        it('of page', () => {
-            visitConfigurationManagementEntityInSidePanel(entitiesKey);
-            navigateToSingleEntityPage(entitiesKey);
-            pageEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
+        it('in single page', () => {
+            verifyWidgetLinkToTableFromSinglePage(entitiesKey, entitiesKey2);
         });
 
-        it('of side panel', () => {
-            visitConfigurationManagementEntityInSidePanel(entitiesKey);
-            sidePanelEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
+        it('in side panel', () => {
+            verifyWidgetLinkToTableFromSidePanel(entitiesKey, entitiesKey2);
         });
     });
 });

--- a/ui/apps/platform/cypress/integration/configmanagement/policies.test.js
+++ b/ui/apps/platform/cypress/integration/configmanagement/policies.test.js
@@ -1,13 +1,13 @@
 import withAuth from '../../helpers/basicAuth';
 
 import {
-    visitConfigurationManagementEntityInSidePanel,
-    navigateToSingleEntityPage,
-    hasCountWidgetsFor,
     clickOnCountWidget,
+    hasCountWidgetsFor,
     hasTabsFor,
-    pageEntityCountMatchesTableRows,
-    sidePanelEntityCountMatchesTableRows,
+    navigateToSingleEntityPage,
+    verifyWidgetLinkToTableFromSidePanel,
+    verifyWidgetLinkToTableFromSinglePage,
+    visitConfigurationManagementEntityInSidePanel,
 } from './ConfigurationManagement.helpers';
 
 const entitiesKey = 'policies';
@@ -42,18 +42,15 @@ describe('Configuration Management Policies', () => {
         hasTabsFor(['deployments']);
     });
 
-    describe('should have same number in deployments table as in count widget', () => {
+    describe('should go to deployments table from widget link', () => {
         const entitiesKey2 = 'deployments';
 
-        it('of page', () => {
-            visitConfigurationManagementEntityInSidePanel(entitiesKey);
-            navigateToSingleEntityPage(entitiesKey);
-            pageEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
+        it('in single page', () => {
+            verifyWidgetLinkToTableFromSinglePage(entitiesKey, entitiesKey2);
         });
 
-        it('of side panel', () => {
-            visitConfigurationManagementEntityInSidePanel(entitiesKey);
-            sidePanelEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
+        it('in side panel', () => {
+            verifyWidgetLinkToTableFromSidePanel(entitiesKey, entitiesKey2);
         });
     });
 });

--- a/ui/apps/platform/cypress/integration/configmanagement/roles.test.js
+++ b/ui/apps/platform/cypress/integration/configmanagement/roles.test.js
@@ -1,13 +1,13 @@
 import withAuth from '../../helpers/basicAuth';
 
 import {
-    visitConfigurationManagementEntityInSidePanel,
-    navigateToSingleEntityPage,
     hasCountWidgetsFor,
     hasTabsFor,
     hasRelatedEntityFor,
-    pageEntityCountMatchesTableRows,
-    sidePanelEntityCountMatchesTableRows,
+    navigateToSingleEntityPage,
+    verifyWidgetLinkToTableFromSidePanel,
+    verifyWidgetLinkToTableFromSinglePage,
+    visitConfigurationManagementEntityInSidePanel,
 } from './ConfigurationManagement.helpers';
 
 const entitiesKey = 'roles';
@@ -42,33 +42,27 @@ describe('Configuration Management Roles', () => {
         hasTabsFor(['subjects', 'serviceaccounts']);
     });
 
-    describe('should have same number in users and groups table as in count widget', () => {
+    describe('should go to subjects table from widget link', () => {
         const entitiesKey2 = 'subjects';
 
-        it('of page', () => {
-            visitConfigurationManagementEntityInSidePanel(entitiesKey);
-            navigateToSingleEntityPage(entitiesKey);
-            pageEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
+        it('in single page', () => {
+            verifyWidgetLinkToTableFromSinglePage(entitiesKey, entitiesKey2);
         });
 
-        it('of side panel', () => {
-            visitConfigurationManagementEntityInSidePanel(entitiesKey);
-            sidePanelEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
+        it('in side panel', () => {
+            verifyWidgetLinkToTableFromSidePanel(entitiesKey, entitiesKey2);
         });
     });
 
-    describe('should have same number in service accounts table as in count widget', () => {
+    describe('should go to serviceaccounts table from widget link', () => {
         const entitiesKey2 = 'serviceaccounts';
 
-        it('of page', () => {
-            visitConfigurationManagementEntityInSidePanel(entitiesKey);
-            navigateToSingleEntityPage(entitiesKey);
-            pageEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
+        it('in single page', () => {
+            verifyWidgetLinkToTableFromSinglePage(entitiesKey, entitiesKey2);
         });
 
-        it('of side panel', () => {
-            visitConfigurationManagementEntityInSidePanel(entitiesKey);
-            sidePanelEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
+        it('in side panel', () => {
+            verifyWidgetLinkToTableFromSidePanel(entitiesKey, entitiesKey2);
         });
     });
 });

--- a/ui/apps/platform/cypress/integration/configmanagement/secrets.test.js
+++ b/ui/apps/platform/cypress/integration/configmanagement/secrets.test.js
@@ -8,8 +8,8 @@ import {
     hasRelatedEntityFor,
     hasTabsFor,
     navigateToSingleEntityPage,
-    pageEntityCountMatchesTableRows,
-    sidePanelEntityCountMatchesTableRows,
+    verifyWidgetLinkToTableFromSidePanel,
+    verifyWidgetLinkToTableFromSinglePage,
     visitConfigurationManagementEntities,
     visitConfigurationManagementEntityInSidePanel,
 } from './ConfigurationManagement.helpers';
@@ -73,18 +73,15 @@ describe('Configuration Management Secrets', () => {
         clickOnCountWidget('deployments', 'entityList');
     });
 
-    describe('should have same number in deployments table as in count widget', () => {
+    describe('should go to deployments table from widget link', () => {
         const entitiesKey2 = 'deployments';
 
-        it('of page', () => {
-            visitConfigurationManagementEntityInSidePanel(entitiesKey);
-            navigateToSingleEntityPage(entitiesKey);
-            pageEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
+        it('in single page', () => {
+            verifyWidgetLinkToTableFromSinglePage(entitiesKey, entitiesKey2);
         });
 
-        it('of side panel', () => {
-            visitConfigurationManagementEntityInSidePanel(entitiesKey);
-            sidePanelEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
+        it('in side panel', () => {
+            verifyWidgetLinkToTableFromSidePanel(entitiesKey, entitiesKey2);
         });
     });
 });

--- a/ui/apps/platform/cypress/integration/configmanagement/serviceaccount.test.js
+++ b/ui/apps/platform/cypress/integration/configmanagement/serviceaccount.test.js
@@ -1,15 +1,15 @@
 import withAuth from '../../helpers/basicAuth';
 
 import {
-    visitConfigurationManagementEntityInSidePanel,
-    navigateToSingleEntityPage,
-    hasCountWidgetsFor,
     clickOnSingularEntityWidgetInSidePanel,
     clickOnSingleEntityInTable,
+    hasCountWidgetsFor,
     hasTabsFor,
     hasRelatedEntityFor,
-    pageEntityCountMatchesTableRows,
-    sidePanelEntityCountMatchesTableRows,
+    navigateToSingleEntityPage,
+    verifyWidgetLinkToTableFromSidePanel,
+    verifyWidgetLinkToTableFromSinglePage,
+    visitConfigurationManagementEntityInSidePanel,
 } from './ConfigurationManagement.helpers';
 
 const entitiesKey = 'serviceaccounts';
@@ -53,33 +53,27 @@ describe('Configuration Management Service Accounts', () => {
         hasTabsFor(['deployments', 'roles']);
     });
 
-    describe('should have same number in deployments table as in count widget', () => {
+    describe('should go to deployments table from widget link', () => {
         const entitiesKey2 = 'deployments';
 
-        it('of page', () => {
-            visitConfigurationManagementEntityInSidePanel(entitiesKey);
-            navigateToSingleEntityPage(entitiesKey);
-            pageEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
+        it('in single page', () => {
+            verifyWidgetLinkToTableFromSinglePage(entitiesKey, entitiesKey2);
         });
 
-        it('of side panel', () => {
-            visitConfigurationManagementEntityInSidePanel(entitiesKey);
-            sidePanelEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
+        it('in side panel', () => {
+            verifyWidgetLinkToTableFromSidePanel(entitiesKey, entitiesKey2);
         });
     });
 
-    describe('should have same number in roles table as in count widget', () => {
+    describe('should go to roles table from widget link', () => {
         const entitiesKey2 = 'roles';
 
-        it('of page', () => {
-            visitConfigurationManagementEntityInSidePanel(entitiesKey);
-            navigateToSingleEntityPage(entitiesKey);
-            pageEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
+        it('in single page', () => {
+            verifyWidgetLinkToTableFromSinglePage(entitiesKey, entitiesKey2);
         });
 
-        it('of side panel', () => {
-            visitConfigurationManagementEntityInSidePanel(entitiesKey);
-            sidePanelEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
+        it('in side panel', () => {
+            verifyWidgetLinkToTableFromSidePanel(entitiesKey, entitiesKey2);
         });
     });
 });

--- a/ui/apps/platform/cypress/integration/configmanagement/usersandgroups.test.js
+++ b/ui/apps/platform/cypress/integration/configmanagement/usersandgroups.test.js
@@ -1,14 +1,14 @@
 import withAuth from '../../helpers/basicAuth';
 
 import {
-    visitConfigurationManagementEntityInSidePanel,
-    navigateToSingleEntityPage,
-    hasCountWidgetsFor,
     clickOnCountWidget,
-    entityListCountMatchesTableLinkCount,
+    hasCountWidgetsFor,
     hasTabsFor,
-    pageEntityCountMatchesTableRows,
-    sidePanelEntityCountMatchesTableRows,
+    navigateToSingleEntityPage,
+    verifyTableLinkToSidePanelTable,
+    verifyWidgetLinkToTableFromSidePanel,
+    verifyWidgetLinkToTableFromSinglePage,
+    visitConfigurationManagementEntityInSidePanel,
 } from './ConfigurationManagement.helpers';
 
 const entitiesKey = 'subjects';
@@ -20,8 +20,8 @@ describe('Configuration Management Subjects (Users and Groups)', () => {
         visitConfigurationManagementEntityInSidePanel(entitiesKey);
     });
 
-    it('should open the side panel to show the same number of roles when the roles link is clicked', () => {
-        entityListCountMatchesTableLinkCount(entitiesKey, 'roles', /^\d+ Roles?$/);
+    it('should go from table link to roles table in side panel', () => {
+        verifyTableLinkToSidePanelTable(entitiesKey, 'roles');
     });
 
     it('should take you to a subject single when the "navigate away" button is clicked', () => {
@@ -47,18 +47,15 @@ describe('Configuration Management Subjects (Users and Groups)', () => {
         clickOnCountWidget('roles', 'entityList');
     });
 
-    describe('should have same number in roles table as in count widget', () => {
+    describe('should go to roles table from widget link', () => {
         const entitiesKey2 = 'roles';
 
-        it('of page', () => {
-            visitConfigurationManagementEntityInSidePanel(entitiesKey);
-            navigateToSingleEntityPage(entitiesKey);
-            pageEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
+        it('in single page', () => {
+            verifyWidgetLinkToTableFromSinglePage(entitiesKey, entitiesKey2);
         });
 
-        it('of side panel', () => {
-            visitConfigurationManagementEntityInSidePanel(entitiesKey);
-            sidePanelEntityCountMatchesTableRows(entitiesKey, entitiesKey2);
+        it('in side panel', () => {
+            verifyWidgetLinkToTableFromSidePanel(entitiesKey, entitiesKey2);
         });
     });
 });


### PR DESCRIPTION
## Description

Follow up #6187

Original names of helper functions:
1. `entityListCountMatchesTableLinkCount` 14 results in 5 files
2. `sidePanelEntityCountMatchesTableRows` 34 results in 11 files
3. `pageEntityCountMatchesTableRows` 34 results in 11 files

The testing **objective** was and is to verify correct behavior for **links**.

The testing **method** changed:
* from unreliable assertion of **specific value** of count and noun.
* to reliable assertion of **generic RegExp** for count and noun.

Rename helper functions replace obsolete Count and emphasize Link:
1. `verifyTableLinkToSidePanelTable`
2. `verifyWidgetLinkFromSidePanelToTable`
3. `verifyWidgetLinkFromSinglePageToTable`

Rewrite test titles:
1. should go from table link to whatevers table in side panel
2. should go to whatevers table from widget link in side panel
3. should go to whatevers table from widget link in single page

### Residue

1. Investigate inconsistent case for nouns in table links:
    * Controls
    * deployments
    * images
    * Roles
    * secrets
    * Service Accounts
    * Users & Groups

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed


### Manual testing

Here are examples of the links for **deployments** as Key1 and **images** as Key2:

1. should go from **table link** to images table in side panel

    * from
        ![1_table_link_from](https://github.com/stackrox/stackrox/assets/11862657/edfd95b0-92df-4d06-a534-83fbb742434f)

    * to
        ![1_table_link_to](https://github.com/stackrox/stackrox/assets/11862657/732fea30-33ce-4af7-b7e1-83df330b2e89)

2. should go to images table from widget link in **side panel**

    * from
        ![2_side_panel_from](https://github.com/stackrox/stackrox/assets/11862657/ffc72e81-a701-4337-aedf-1541b95c2c65)

    * to
        ![2_side_panel_to](https://github.com/stackrox/stackrox/assets/11862657/a9fa0125-51f9-489a-9dc6-69963b5fb5e7)

3. should go to images table from widget link in **single page**

    * from
        ![3_single_page_from](https://github.com/stackrox/stackrox/assets/11862657/fd908325-15f1-475f-a569-88c7fbe325f2)

    * to
        ![3_single_page_to](https://github.com/stackrox/stackrox/assets/11862657/a2c277b8-fed9-4fe8-9053-05ebd134afd3)

### Integration testing

1. `yarn cypress-open` in ui/apps/platform
    * configmanagement/ciscontrols.test.js
    * configmanagement/clusters.test.js
    * configmanagement/deployements.test.js
    * configmanagement/images.test.js
    * configmanagement/namespaces.test.js
    * configmanagement/nodes.test.js
    * configmanagement/policies.test.js
    * configmanagement/roles.test.js
    * configmanagement/secrets.test.js
    * configmanagement/serviceaccounts.test.js
    * configmanagement/usersandgroups.test.js (also known as subjects)
