### PR TITLE
ROX-17149: Only build what is required for e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -351,13 +351,16 @@ build-prep: deps
 .PHONY: cli-build
 cli-build: cli-linux cli-darwin cli-windows
 
-.PHONY: cli
-cli: cli-build
+.PHONY: cli-install
+cli-install:
 	# Workaround a bug on MacOS
 	rm -f $(GOPATH)/bin/roxctl
 	# Copy the user's specific OS into gopath
 	cp bin/$(HOST_OS)_$(GOARCH)/roxctl $(GOPATH)/bin/roxctl
 	chmod u+w $(GOPATH)/bin/roxctl
+
+.PHONY: cli
+cli: cli-build cli-install
 
 cli-linux: cli_linux-amd64 cli_linux-arm64 cli_linux-ppc64le cli_linux-s390x
 cli-darwin: cli_darwin-amd64 cli_darwin-arm64
@@ -368,6 +371,9 @@ cli_%: build-prep
 	$(eval   os := $(firstword $(w)))
 	$(eval arch := $(lastword  $(w)))
 	RACE=0 CGO_ENABLED=0 GOOS=$(os) GOARCH=$(arch) $(GOBUILD) ./roxctl
+
+.PHONY: cli_host-arch
+cli_host-arch: cli_$(HOST_OS)-$(GOARCH)
 
 upgrader: bin/$(HOST_OS)_$(GOARCH)/upgrader
 

--- a/scripts/ci/jobs/test-binary-build-commands.sh
+++ b/scripts/ci/jobs/test-binary-build-commands.sh
@@ -9,8 +9,8 @@ set -euo pipefail
 make_test_bin() {
     info "Making test-bin"
 
-    make cli-build upgrader
-    install_built_roxctl_in_gopath
+    make cli_host-arch upgrader
+    make cli-install
 }
 
 make_test_bin "$*"

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -125,33 +125,6 @@ setup_deployment_env() {
     ci_export COLLECTOR_IMAGE_REPO "quay.io/$REPO/collector"
 }
 
-install_built_roxctl_in_gopath() {
-    require_environment "GOPATH"
-
-    local bin_os bin_platform
-    if is_darwin; then
-        bin_os="darwin"
-    elif is_linux; then
-        bin_os="linux"
-    else
-        die "Only linux or darwin are supported for this test"
-    fi
-
-    case "$(uname -m)" in
-        x86_64) bin_platform="${bin_os}_amd64" ;;
-        aarch64) bin_platform="${bin_os}_arm64" ;;
-        ppc64le) bin_platform="${bin_os}_ppc64le" ;;
-        s390x) bin_platform="${bin_os}_s390x" ;;
-        *) die "Unknown architecture" ;;
-    esac
-
-    local roxctl="$SCRIPTS_ROOT/bin/${bin_platform}/roxctl"
-
-    require_executable "$roxctl" "roxctl should be built"
-
-    cp "$roxctl" "$GOPATH/bin/roxctl"
-}
-
 get_central_debug_dump() {
     info "Getting a central debug dump"
 
@@ -1186,8 +1159,8 @@ handle_nightly_binary_version_mismatch() {
     echo "Current roxctl is: $(command -v roxctl || true), version: $(roxctl version || true)"
 
     if ! [[ "$(roxctl version || true)" =~ nightly-$(date '+%Y%m%d') ]]; then
-        make cli-build upgrader
-        install_built_roxctl_in_gopath
+        make cli_host-arch upgrader
+        make cli-install
         echo "Replacement roxctl is: $(command -v roxctl || true), version: $(roxctl version || true)"
     fi
 }


### PR DESCRIPTION
## Description

Per title. The openshift/release `test-bin` image build time can be 18 minutes. Removing it completely is an option (https://github.com/stackrox/stackrox/pull/6525) but we may get a reasonable performance boost just by reducing the build to the only roxctl that is required. 

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient. It ran faster (and all green!) for the [one CI run](https://prow.ci.openshift.org/pr-history/?org=stackrox&repo=stackrox&pr=6550) for this test 7m20s.
