### PR TITLE
ROX-17517: Tolerate PSP messages in "suspicious entries" check

### DIFF
--- a/scripts/ci/logcheck/allowlist-patterns
+++ b/scripts/ci/logcheck/allowlist-patterns
@@ -14,3 +14,7 @@ FATAL:  connection to client lost
 # with operator installs, sensor logs contain this error w.r.t. refreshing a cert for local scanning.
 # TODO: check if this is benign and/or if sensor is configured appropriately for test.
 unexpected owner for certificate secrets
+# By design, we keep installing PodSecurityPolicy objects as long as the server supports them.
+# We detect if they are not supported and in that case do not apply them, so these warnings are not useful at this point.
+# See ROX-17796 ROX-17766 ROX-17734 for related work.
+policy/v1beta1 PodSecurityPolicy is deprecated in v1.21., unavailable in v1.25.


### PR DESCRIPTION
## Description

The post-e2e-test check which looks for suspicious entries in pod logs is frequently failing due to deprecation warnings about PodSecurityPolicy objects.

However by design, we keep installing PodSecurityPolicy objects as long as the server supports them.
We detect if they are not supported and in that case do not apply them, so these warnings are not useful at this point.

See also ROX-17796 ROX-17766 ROX-17734 for related work.

The original message is `2595:/tmp/postgres-upgrade-test-logs/04_postgres_postgres_rollback/stackrox/pods/sensor-upgrader-5578dbc74-9wpmk-upgrader.log:W0602 14:41:14.496056       1 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+` but the check script uses `grep -vP` (Perl-compatible REs) so I've used a dot in place of the plus.


## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [x] ~Evaluated and added CHANGELOG entry if required~
- [x] ~Determined and documented upgrade steps~
- [x] ~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

## Testing Performed

CI is sufficient.