### PR TITLE
ROX-17663: Fix Test_SensorReconnects failing due to feature flag not set

### DIFF
--- a/sensor/tests/connection/connection_test.go
+++ b/sensor/tests/connection/connection_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stackrox/rox/pkg/buildinfo"
 	"github.com/stackrox/rox/sensor/tests/helper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -17,6 +18,10 @@ var (
 )
 
 func Test_SensorReconnects(t *testing.T) {
+	if buildinfo.ReleaseBuild {
+		t.Skipf("Don't run test in release mode: feature flag cannot be enabled")
+	}
+
 	t.Setenv("ROX_PREVENT_SENSOR_RESTART_ON_DISCONNECT", "true")
 	t.Setenv("ROX_RESYNC_DISABLED", "true")
 	t.Setenv("ROX_SENSOR_CONNECTION_RETRY_INITIAL_INTERVAL", "1s")


### PR DESCRIPTION
## Description

Tests pass locally and in PRs, but they are failing in nightlies and in release branches. I assume this could be due to the feature flag not being set. Checking the failure logs, sensor isn't running with restarts, therefore tests fail because the restart behavior is not there.

I'm not sure if this is because these tests are running with `BuildInfo` release set, I haven't found any evidence for it, but this is a quick way to test and mitigate the failure. 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] ~~Unit test and regression tests added~~
- [ ] ~~Evaluated and added CHANGELOG entry if required~~
- [ ] ~~Determined and documented upgrade steps~~
- [ ] ~~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

- [ ] CI 
