### PR TITLE
ROX-14946: change PSP auto-sensing in e2e tests

### DIFF
--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -368,21 +368,20 @@ setup_generated_certs_for_test() {
 
 setup_podsecuritypolicies_config() {
     info "Set POD_SECURITY_POLICIES variable based on kubernetes version"
-    local version
-    version=$(kubectl version --output json)
-    local majorVersion
-    majorVersion=$(echo "$version" | jq -r .serverVersion.major)
-    local minorVersion
-    minorVersion=$(echo "$version" | jq -r .serverVersion.minor)
+    available_api_resources=$(kubectl api-resources -o name)
 
-    # PodSecurityPolicy was removed in version 1.25
-    if (( "$majorVersion" >= 1 && "$minorVersion" >= 25 )); then
-        ci_export "POD_SECURITY_POLICIES" "false"
-        info "POD_SECURITY_POLICIES set to false"
-    else
+    # using && true to ignore errexit option and store the command exit code in $? instead
+    echo $available_api_resources | grep -Fxq podsecuritypolicies.policy && true
+
+    if [ $? ]
+    then
         ci_export "POD_SECURITY_POLICIES" "true"
         info "POD_SECURITY_POLICIES set to true"
+    else
+        ci_export "POD_SECURITY_POLICIES" "false"
+        info "POD_SECURITY_POLICIES set to false"
     fi
+
 }
 
 # wait_for_collectors_to_be_operational() ensures that collector pods are able

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -371,7 +371,7 @@ setup_podsecuritypolicies_config() {
     available_api_resources=$(kubectl api-resources -o name)
 
     # using && true to ignore errexit option and store the command exit code in $? instead
-    echo $available_api_resources | grep -q podsecuritypolicies.policu && true
+    echo $available_api_resources | grep -q podsecuritypolicies.policy && true
 
     if [ $? -eq 0 ]
     then

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -371,9 +371,9 @@ setup_podsecuritypolicies_config() {
     available_api_resources=$(kubectl api-resources -o name)
 
     # using && true to ignore errexit option and store the command exit code in $? instead
-    echo $available_api_resources | grep -Fxq podsecuritypolicies.policy && true
+    echo $available_api_resources | grep -q podsecuritypolicies.policu && true
 
-    if [ $? ]
+    if [ $? -eq 0 ]
     then
         ci_export "POD_SECURITY_POLICIES" "true"
         info "POD_SECURITY_POLICIES set to true"

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -368,17 +368,15 @@ setup_generated_certs_for_test() {
 
 setup_podsecuritypolicies_config() {
     info "Set POD_SECURITY_POLICIES variable based on kubernetes version"
-    available_api_resources=$(kubectl api-resources -o name)
 
-    if echo "$available_api_resources" | grep -q podsecuritypolicies.policy;
-    then
-        ci_export "POD_SECURITY_POLICIES" "true"
-        info "POD_SECURITY_POLICIES set to true"
-    else
+    SUPPORTS_PSP=$(kubectl api-resources | grep "podsecuritypolicies" -c || true)
+    if [[ "${SUPPORTS_PSP}" -eq 0 ]]; then
         ci_export "POD_SECURITY_POLICIES" "false"
         info "POD_SECURITY_POLICIES set to false"
+    else
+        ci_export "POD_SECURITY_POLICIES" "true"
+        info "POD_SECURITY_POLICIES set to true"
     fi
-
 }
 
 # wait_for_collectors_to_be_operational() ensures that collector pods are able

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -370,10 +370,7 @@ setup_podsecuritypolicies_config() {
     info "Set POD_SECURITY_POLICIES variable based on kubernetes version"
     available_api_resources=$(kubectl api-resources -o name)
 
-    # using && true to ignore errexit option and store the command exit code in $? instead
-    echo $available_api_resources | grep -q podsecuritypolicies.policy && true
-
-    if [ $? -eq 0 ]
+    if echo "$available_api_resources" | grep -q podsecuritypolicies.policy;
     then
         ci_export "POD_SECURITY_POLICIES" "true"
         info "POD_SECURITY_POLICIES set to true"


### PR DESCRIPTION
## Description

There are CI Errors for the auto-sensing logic for PSP introduced in #4488.

The checks where failing for EKS because they put other characters in their version strings returned by kubectl.

There are additional consideration to why the approach with major/minor version check is brittle in #4813 comments.

This PR changes the check so that it uses `kubectl api-resources` command instead. This should be a more reliable solution.

## Checklist
- [ ] Investigated and inspected CI test results
- ~~[ ] Unit test and regression tests added~~
- ~~[ ] Evaluated and added CHANGELOG entry if required~~
- ~~[ ] Determined and documented upgrade steps~~
- ~~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

Running the following once against a cluster with PSPs and once against another cluster without PSPs
```
source tests/e2e/lib.sh
setup_podsecuritypolicies_config
```

In addition to reviewing your code, reviewers **must** also review your testing
instructions and make sure they are sufficient.
