### PR TITLE
ROX-16727: Fix ExternalNetworkSourcesTest

### DIFF
--- a/qa-tests-backend/src/test/groovy/ExternalNetworkSourcesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ExternalNetworkSourcesTest.groovy
@@ -1,5 +1,3 @@
-import java.util.concurrent.TimeUnit
-
 import static util.Helpers.withRetry
 
 import com.google.protobuf.Timestamp
@@ -8,7 +6,6 @@ import io.stackrox.proto.api.v1.Common
 import io.stackrox.proto.storage.NetworkFlowOuterClass.NetworkEntity
 
 import objects.Deployment
-import objects.Edge
 import services.ClusterService
 import services.NetworkGraphService
 import util.NetworkGraphUtil
@@ -27,7 +24,7 @@ class ExternalNetworkSourcesTest extends BaseSpecification {
 
     static final private List<Deployment> DEPLOYMENTS = []
 
-    static final private random = new Random()
+    static final private RANDOM = new Random()
 
     static final private Deployment DEP_EXTERNALCONNECTION =
             createAndRegisterDeployment()
@@ -59,7 +56,7 @@ class ExternalNetworkSourcesTest extends BaseSpecification {
     }
 
     private static String generateNameWithPrefix(String prefix) {
-        var externalSourceId = random.nextInt() % 1000
+        var externalSourceId = RANDOM.nextInt() % 1000
         return "$prefix-$externalSourceId"
     }
 
@@ -78,9 +75,9 @@ class ExternalNetworkSourcesTest extends BaseSpecification {
 
         then:
         "Verify edge from deployment to external source exists"
-        withRetry(4, 30, {
+        withRetry(4, 30) {
             assert NetworkGraphUtil.checkForEdge(deploymentUid, externalSourceID, null, 150)
-        })
+        }
 
         cleanup:
         "Remove the external source and associated deployments"
@@ -101,9 +98,9 @@ class ExternalNetworkSourcesTest extends BaseSpecification {
         assert externalSource31ID != null
 
         log.info "Edge from deployment to external source ${externalSource31Name} should exist"
-        withRetry(4, 30, {
+        withRetry(4, 30) {
             assert NetworkGraphUtil.checkForEdge(deploymentUid, externalSource31ID)
-        })
+        }
 
         log.info "Create a supernet external source containing Cloudflare's IP address"
         String externalSource30Name = generateNameWithPrefix("external-source-30")
@@ -113,15 +110,15 @@ class ExternalNetworkSourcesTest extends BaseSpecification {
 
         then:
         "Verify no edge from deployment to supernet exists"
-        withRetry(4, 30, {
+        withRetry(4, 30) {
             verifyNoEdge(deploymentUid, externalSource30ID, null)
-        })
+        }
 
         and:
         "Verify edge from deployment to subnet still exists"
-        withRetry(4, 30, {
+        withRetry(4, 30) {
             assert NetworkGraphUtil.checkForEdge(deploymentUid, externalSource31ID)
-        })
+        }
 
         cleanup:
         deleteNetworkEntity(externalSource30ID)
@@ -145,9 +142,9 @@ class ExternalNetworkSourcesTest extends BaseSpecification {
 
         then:
         "Verify edge from deployment to subnet exists before subnet deletion"
-        withRetry(4, 30, {
+        withRetry(4, 30) {
             assert NetworkGraphUtil.checkForEdge(deploymentUid, externalSource31ID)
-        })
+        }
 
         log.info "Add supernet and remove subnet"
         String externalSource30Name = generateNameWithPrefix("external-source-30")
@@ -157,18 +154,18 @@ class ExternalNetworkSourcesTest extends BaseSpecification {
 
         and:
         "Verify no edge from deployment to supernet exists before subnet deletion"
-        withRetry(4, 30, {
+        withRetry(4, 30) {
             verifyNoEdge(deploymentUid, externalSource30ID, null)
-        })
+        }
 
         "Remove the smaller subnet should add an edge to the larger subnet"
         deleteNetworkEntity(externalSource31ID)
 
         and:
         "Verify edge from deployment to supernet exists after subnet deletion"
-        withRetry(4, 30, {
+        withRetry(4, 30) {
             assert NetworkGraphUtil.checkForEdge(deploymentUid, externalSource30ID, null, 180)
-        })
+        }
 
         cleanup:
         deleteNetworkEntity(externalSource30ID)
@@ -188,9 +185,9 @@ class ExternalNetworkSourcesTest extends BaseSpecification {
         assert externalSource30ID != null
 
         log.info "Verify edge exists from deployment to supernet external source"
-        withRetry(4, 30, {
+        withRetry(4, 30) {
             assert NetworkGraphUtil.checkForEdge(deploymentUid, externalSource30ID)
-        })
+        }
 
         log.info "Add smaller subnet subnet external source"
         String externalSource31Name = generateNameWithPrefix("external-source-31")
@@ -200,27 +197,27 @@ class ExternalNetworkSourcesTest extends BaseSpecification {
 
         then:
         "Verify edge exists from deployment to subnet external source"
-        withRetry(4, 30, {
+        withRetry(4, 30) {
             assert NetworkGraphUtil.checkForEdge(deploymentUid, externalSource31ID, null, 180)
-        })
+        }
 
         and:
         "Verify edge from deployment to supernet exists in older network graph"
-        withRetry(4, 30, {
+        withRetry(4, 30) {
             assert NetworkGraphUtil.checkForEdge(
                     deploymentUid,
                     externalSource30ID,
                     Timestamp.newBuilder().setSeconds(System.currentTimeSeconds() - 60*60).build())
-        })
+        }
 
         and:
         "Verify no edge from deployment to supernet exists in recent network graph"
-        withRetry(4, 30, {
+        withRetry(4, 30) {
             assert verifyNoEdge(
                     deploymentUid,
                     externalSource30ID,
                     Timestamp.newBuilder().setSeconds(System.currentTimeSeconds() - 60).build())
-        })
+        }
 
         cleanup:
         deleteNetworkEntity(externalSource30ID)

--- a/qa-tests-backend/src/test/groovy/ExternalNetworkSourcesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ExternalNetworkSourcesTest.groovy
@@ -1,7 +1,10 @@
 import java.util.concurrent.TimeUnit
 
+import static util.Helpers.withRetry
+
 import com.google.protobuf.Timestamp
 
+import io.stackrox.proto.api.v1.Common
 import io.stackrox.proto.storage.NetworkFlowOuterClass.NetworkEntity
 
 import objects.Deployment
@@ -23,6 +26,8 @@ class ExternalNetworkSourcesTest extends BaseSpecification {
     static final private String EXT_CONN_DEPLOYMENT_NAME = "external-connection"
 
     static final private List<Deployment> DEPLOYMENTS = []
+
+    static final private random = new Random()
 
     static final private Deployment DEP_EXTERNALCONNECTION =
             createAndRegisterDeployment()
@@ -53,6 +58,11 @@ class ExternalNetworkSourcesTest extends BaseSpecification {
         }
     }
 
+    private static String generateNameWithPrefix(String prefix) {
+        var externalSourceId = random.nextInt() % 1000
+        return "$prefix-$externalSourceId"
+    }
+
     @Tag("NetworkFlowVisualization")
     def "Verify connection to a user created external sources"() {
         when:
@@ -61,15 +71,16 @@ class ExternalNetworkSourcesTest extends BaseSpecification {
         assert deploymentUid != null
 
         log.info "Create a external source containing Cloudflare's IP address"
-        String externalSourceName = "external-source"
+        String externalSourceName = generateNameWithPrefix("external-source")
         NetworkEntity externalSource = createNetworkEntityExternalSource(externalSourceName, CF_CIDR_31)
         String externalSourceID = externalSource?.getInfo()?.getId()
         assert externalSourceID != null
 
         then:
         "Verify edge from deployment to external source exists"
-        List<Edge> edges = NetworkGraphUtil.checkForEdge(deploymentUid, externalSourceID, null, 150)
-        assert edges
+        withRetry(4, 30, {
+            assert NetworkGraphUtil.checkForEdge(deploymentUid, externalSourceID, null, 150)
+        })
 
         cleanup:
         "Remove the external source and associated deployments"
@@ -84,27 +95,33 @@ class ExternalNetworkSourcesTest extends BaseSpecification {
         assert deploymentUid != null
 
         log.info "Create a smaller network external source containing Cloudflare's IP address"
-        String externalSource31Name = "external-source-31"
+        String externalSource31Name = generateNameWithPrefix("external-source-31")
         NetworkEntity externalSource31 = createNetworkEntityExternalSource(externalSource31Name, CF_CIDR_31)
         String externalSource31ID = externalSource31?.getInfo()?.getId()
         assert externalSource31ID != null
 
         log.info "Edge from deployment to external source ${externalSource31Name} should exist"
-        assert NetworkGraphUtil.checkForEdge(deploymentUid, externalSource31ID)
+        withRetry(4, 30, {
+            assert NetworkGraphUtil.checkForEdge(deploymentUid, externalSource31ID)
+        })
 
         log.info "Create a supernet external source containing Cloudflare's IP address"
-        String externalSource30Name = "external-source-30"
+        String externalSource30Name = generateNameWithPrefix("external-source-30")
         NetworkEntity externalSource30 = createNetworkEntityExternalSource(externalSource30Name, CF_CIDR_30)
         String externalSource30ID = externalSource30?.getInfo()?.getId()
         assert externalSource30ID != null
 
         then:
         "Verify no edge from deployment to supernet exists"
-        verifyNoEdge(deploymentUid, externalSource30ID, null)
+        withRetry(4, 30, {
+            verifyNoEdge(deploymentUid, externalSource30ID, null)
+        })
 
         and:
         "Verify edge from deployment to subnet still exists"
-        assert NetworkGraphUtil.checkForEdge(deploymentUid, externalSource31ID)
+        withRetry(4, 30, {
+            assert NetworkGraphUtil.checkForEdge(deploymentUid, externalSource31ID)
+        })
 
         cleanup:
         deleteNetworkEntity(externalSource30ID)
@@ -121,31 +138,37 @@ class ExternalNetworkSourcesTest extends BaseSpecification {
         assert deploymentUid != null
 
         log.info "Create a smaller subnet network entities with Cloudflare's IP address"
-        String externalSource31Name = "external-source-31"
+        String externalSource31Name = generateNameWithPrefix("external-source-31")
         NetworkEntity externalSource31 = createNetworkEntityExternalSource(externalSource31Name, CF_CIDR_31)
         String externalSource31ID = externalSource31?.getInfo()?.getId()
         assert externalSource31ID != null
 
         then:
         "Verify edge from deployment to subnet exists before subnet deletion"
-        assert NetworkGraphUtil.checkForEdge(deploymentUid, externalSource31ID)
+        withRetry(4, 30, {
+            assert NetworkGraphUtil.checkForEdge(deploymentUid, externalSource31ID)
+        })
 
         log.info "Add supernet and remove subnet"
-        String externalSource30Name = "external-source-30"
+        String externalSource30Name = generateNameWithPrefix("external-source-30")
         NetworkEntity externalSource30 = createNetworkEntityExternalSource(externalSource30Name, CF_CIDR_30)
         String externalSource30ID = externalSource30?.getInfo()?.getId()
         assert externalSource30ID != null
 
         and:
         "Verify no edge from deployment to supernet exists before subnet deletion"
-        verifyNoEdge(deploymentUid, externalSource30ID, null)
+        withRetry(4, 30, {
+            verifyNoEdge(deploymentUid, externalSource30ID, null)
+        })
 
         "Remove the smaller subnet should add an edge to the larger subnet"
         deleteNetworkEntity(externalSource31ID)
 
         and:
         "Verify edge from deployment to supernet exists after subnet deletion"
-        assert NetworkGraphUtil.checkForEdge(deploymentUid, externalSource30ID, null, 180)
+        withRetry(4, 30, {
+            assert NetworkGraphUtil.checkForEdge(deploymentUid, externalSource30ID, null, 180)
+        })
 
         cleanup:
         deleteNetworkEntity(externalSource30ID)
@@ -159,40 +182,45 @@ class ExternalNetworkSourcesTest extends BaseSpecification {
         String deploymentUid = DEP_EXTERNALCONNECTION.deploymentUid
         assert deploymentUid != null
 
-        String externalSource30Name = "external-source-30"
+        String externalSource30Name = generateNameWithPrefix("external-source-30")
         NetworkEntity externalSource30 = createNetworkEntityExternalSource(externalSource30Name, CF_CIDR_30)
         String externalSource30ID = externalSource30?.getInfo()?.getId()
         assert externalSource30ID != null
 
         log.info "Verify edge exists from deployment to supernet external source"
-        assert NetworkGraphUtil.checkForEdge(deploymentUid, externalSource30ID)
+        withRetry(4, 30, {
+            assert NetworkGraphUtil.checkForEdge(deploymentUid, externalSource30ID)
+        })
 
         log.info "Add smaller subnet subnet external source"
-        String externalSource31Name = "external-source-31"
+        String externalSource31Name = generateNameWithPrefix("external-source-31")
         NetworkEntity externalSource31 = createNetworkEntityExternalSource(externalSource31Name, CF_CIDR_31)
         String externalSource31ID = externalSource31?.getInfo()?.getId()
         assert externalSource31ID != null
 
         then:
         "Verify edge exists from deployment to subnet external source"
-        assert NetworkGraphUtil.checkForEdge(deploymentUid, externalSource31ID, null, 180)
+        withRetry(4, 30, {
+            assert NetworkGraphUtil.checkForEdge(deploymentUid, externalSource31ID, null, 180)
+        })
 
         and:
         "Verify edge from deployment to supernet exists in older network graph"
-        assert NetworkGraphUtil.checkForEdge(
-                deploymentUid,
-                externalSource30ID,
-                Timestamp.newBuilder().setSeconds(System.currentTimeSeconds() - 60*60).build())
-
-        // Wait for some time for to accommodate delays in receiving flows from collector, etc.
-        TimeUnit.SECONDS.sleep(NetworkGraphUtil.NETWORK_FLOW_UPDATE_CADENCE_IN_SECONDS)
+        withRetry(4, 30, {
+            assert NetworkGraphUtil.checkForEdge(
+                    deploymentUid,
+                    externalSource30ID,
+                    Timestamp.newBuilder().setSeconds(System.currentTimeSeconds() - 60*60).build())
+        })
 
         and:
         "Verify no edge from deployment to supernet exists in recent network graph"
-        assert verifyNoEdge(
-                deploymentUid,
-                externalSource30ID,
-                Timestamp.newBuilder().setSeconds(System.currentTimeSeconds() - 60).build())
+        withRetry(4, 30, {
+            assert verifyNoEdge(
+                    deploymentUid,
+                    externalSource30ID,
+                    Timestamp.newBuilder().setSeconds(System.currentTimeSeconds() - 60).build())
+        })
 
         cleanup:
         deleteNetworkEntity(externalSource30ID)
@@ -206,13 +234,12 @@ class ExternalNetworkSourcesTest extends BaseSpecification {
     }
 
     private static deleteNetworkEntity(String entityID) {
-        NetworkGraphService.deleteNetworkEntity(entityID)
+        // Use network graph client without the wrapper because we need the test to fail if the deletion fails.
+        NetworkGraphService.getNetworkGraphClient()
+            .deleteExternalNetworkEntity(Common.ResourceByID.newBuilder().setId(entityID).build())
     }
 
     private verifyNoEdge(String entityID1, String entityID2, Timestamp since) {
-        // First wait for some time to give time for network flow update
-        log.info "Wait a bit before checking graph to verify no edge..."
-        TimeUnit.SECONDS.sleep(NetworkGraphUtil.NETWORK_FLOW_UPDATE_CADENCE_IN_SECONDS*2)
         // Shorter timeout for verifying no edge to save test time
         return !NetworkGraphUtil.checkForEdge(
                 entityID1,


### PR DESCRIPTION
## Description

Multiple external network sources test are failing due to timeouts: [ROX-16727](https://issues.redhat.com/browse/ROX-16727), [ROX-17159](https://issues.redhat.com/browse/ROX-17159) and [ROX-17395](https://issues.redhat.com/browse/ROX-17395). This has also manifested in other aggregated failures in CI jobs ([ROX-17728](https://issues.redhat.com/browse/ROX-17728)). 

We have identified multiple sources of flakiness in this test suite. Here are the key observations:
1. All tests have the same network entity name, this can cause conflicts if previous tests failed to cleanup properly  
2. The deletion request triggers a deletion job, meaning that the actual cleanup takes longer than the request being replied to  
3. If any assertion fails, the tests will retry on the BaseSpec retry loop, taking ~10 minutes between retries in some cases.  JUnit/Spock stops the tests at 800s (13m)  
4. Test does not fail if there is an exception during cleanup  

There are multiple ways to mitigate the points above. During a mob-session, we came up with the following approaches:
1. Retry on the assert so the retry loop on base test is not triggered  
2. Rename external sources to be different in each test (e.g. external-source-30) to avoid conflict  
3. Fail test if the deletion fails during cleanup  
4. Wait for state:  
   4.1: Wait for deletion to finish during cleanup  
   4.2: Wait until state is expected during startup  
5. Use ExternalSources API to check if external entities were already created in ACS

In this PR only **1**, **2** and **3** were implemented. We believe this is enough to reduce the flakiness of this test. If it's not the case, 4 and 5 can also be implemented in a follow-up PR.


## Checklist
- [ ] Investigated and inspected CI test results
- [ ] ~~Unit test and regression tests added~~
- [ ] ~~Evaluated and added CHANGELOG entry if required~~
- [ ] ~~Determined and documented upgrade steps~~
- [ ] ~~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~


## Testing Performed

- [ ] CI