### PR TITLE
ROX-17931: refactor resolver to use uniqueue

### DIFF
--- a/pkg/uniqueue/uniqueue.go
+++ b/pkg/uniqueue/uniqueue.go
@@ -161,5 +161,5 @@ func (q *UniQueue[T]) IsEmpty() bool {
 func (q *UniQueue[T]) Size() int {
 	q.mu.Lock()
 	defer q.mu.Unlock()
-	return len(q.inQueue)
+	return len(q.inQueue) + len(q.frontChannel)
 }

--- a/pkg/uniqueue/uniqueue.go
+++ b/pkg/uniqueue/uniqueue.go
@@ -1,0 +1,154 @@
+package uniqueue
+
+import (
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/logging"
+	"github.com/stackrox/rox/pkg/sync"
+)
+
+var (
+	errMultipleCallsToStart = errors.New("unable to start more than once")
+	log                     = logging.LoggerForModule()
+)
+
+type UniQueue[T comparable] struct {
+	stopper      concurrency.Stopper
+	mu           sync.Mutex
+	queueSize    int
+	backChannel  chan T
+	frontChannel chan T
+	queueChannel chan T
+	inQueue      map[T]struct{}
+}
+
+func NewUniQueue[T comparable](size int) *UniQueue[T] {
+	return &UniQueue[T]{
+		stopper:      concurrency.NewStopper(),
+		queueSize:    size,
+		backChannel:  nil,
+		queueChannel: nil,
+		frontChannel: nil,
+		inQueue:      nil,
+	}
+}
+
+func (q *UniQueue[T]) PushC() chan<- T {
+	if q.inQueue == nil {
+		log.Panic("Start must be called before PushC")
+	}
+	return q.backChannel
+}
+
+func (q *UniQueue[T]) PopC() <-chan T {
+	if q.inQueue == nil {
+		log.Panic("Start must be called before PopC")
+	}
+	return q.frontChannel
+}
+
+func (q *UniQueue[T]) Start() error {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if q.inQueue != nil {
+		return errMultipleCallsToStart
+	}
+	q.stopper.LowLevel().ResetStopRequest()
+	q.backChannel = make(chan T, 1)
+	q.queueChannel = make(chan T, q.queueSize)
+	q.frontChannel = make(chan T, 1)
+	q.inQueue = make(map[T]struct{})
+	go q.run()
+	return nil
+}
+
+func (q *UniQueue[T]) run() {
+	defer q.stopper.Flow().ReportStopped()
+	wg := &sync.WaitGroup{}
+	wg.Add(2)
+	go q.pushFromBack(wg)
+	go q.popToFront(wg)
+	// Wait for the push and pop goroutines to finish
+	wg.Wait()
+	// Close channels
+	close(q.backChannel)
+	close(q.queueChannel)
+	close(q.frontChannel)
+	q.inQueue = nil
+}
+
+func (q *UniQueue[T]) Stop() {
+	if !q.stopper.Client().Stopped().IsDone() {
+		defer func() {
+			_ = q.stopper.Client().Stopped().Wait()
+		}()
+	}
+	q.stopper.Client().Stop()
+}
+
+func (q *UniQueue[T]) pushFromBack(wg *sync.WaitGroup) {
+	defer wg.Done()
+	for {
+		select {
+		case <-q.stopper.Flow().StopRequested():
+			return
+		case el, ok := <-q.backChannel:
+			if !ok {
+				return
+			}
+			if q.maybeAddToQueue(el) {
+				q.queueChannel <- el
+			}
+		}
+	}
+}
+
+func (q *UniQueue[T]) maybeAddToQueue(el T) bool {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if _, alreadyInQueue := q.inQueue[el]; alreadyInQueue {
+		return false
+	}
+	q.inQueue[el] = struct{}{}
+	return true
+}
+
+func (q *UniQueue[T]) popToFront(wg *sync.WaitGroup) {
+	defer wg.Done()
+	for {
+		select {
+		case <-q.stopper.Flow().StopRequested():
+			return
+		case el, ok := <-q.queueChannel:
+			if !ok {
+				return
+			}
+			select {
+			case <-q.stopper.Flow().StopRequested():
+				return
+			case q.frontChannel <- el:
+				q.removeFromQueue(el)
+			}
+		}
+	}
+}
+
+func (q *UniQueue[T]) removeFromQueue(el T) bool {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if _, ok := q.inQueue[el]; ok {
+		delete(q.inQueue, el)
+		return true
+	}
+	return false
+}
+
+func (q *UniQueue[T]) isEmpty() bool {
+	return len(q.queueChannel) == 0 && len(q.frontChannel) == 0
+}
+
+func (q *UniQueue[T]) Size() int {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return len(q.inQueue)
+}

--- a/pkg/uniqueue/uniqueue_test.go
+++ b/pkg/uniqueue/uniqueue_test.go
@@ -1,0 +1,242 @@
+package uniqueue
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackrox/rox/pkg/sync"
+	"github.com/stackrox/rox/pkg/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
+)
+
+func TestAdd(t *testing.T) {
+	q := NewUniQueue[int](6)
+	assert.NoError(t, q.Start())
+	numsToPush := []int{1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 3}
+	expected := []int{0, 1, 2, 3}
+	pushC := q.PushC()
+	// We push the first item that would be put in the frontChannel
+	pushC <- 0
+	require.True(t, waitWithRetry(func() bool {
+		return len(q.PopC()) > 0
+	}))
+	// The rest of the items can be pushed
+	for _, n := range numsToPush {
+		pushC <- n
+	}
+	assert.True(t, waitWithRetry(func() bool {
+		return q.Size() == 3
+	}))
+	var queueContent []int
+	for i := 0; i < len(expected); i++ {
+		n := <-q.PopC()
+		queueContent = append(queueContent, n)
+	}
+
+	assert.Equal(t, expected, queueContent)
+	assert.Len(t, q.frontChannel, 0)
+	q.Stop()
+}
+
+func TestCallStartTwice(t *testing.T) {
+	q := NewUniQueue[int](5)
+	assert.NoError(t, q.Start())
+	assert.Error(t, q.Start())
+}
+
+func TestStop(t *testing.T) {
+	q := NewUniQueue[int](5)
+	assert.NoError(t, q.Start())
+	q.Stop()
+	_, ok := <-q.backChannel
+	assert.False(t, ok)
+	_, ok = <-q.queueChannel
+	assert.False(t, ok)
+	_, ok = <-q.frontChannel
+	assert.False(t, ok)
+	assert.Nil(t, q.inQueue)
+	assert.True(t, q.stopper.Client().Stopped().IsDone())
+}
+
+func TestStartAfterStop(t *testing.T) {
+	q := NewUniQueue[int](5)
+	assert.NoError(t, q.Start())
+	q.Stop()
+	assert.NoError(t, q.Start())
+}
+
+func TestPushCPanicsIfStartIsNotCalled(t *testing.T) {
+	q := NewUniQueue[int](5)
+	callPushC := func() {
+		q.PushC()
+	}
+	assert.Panics(t, callPushC)
+}
+
+func TestPopCPanicsIfStartIsNotCalled(t *testing.T) {
+	q := NewUniQueue[int](5)
+	callPopC := func() {
+		q.PopC()
+	}
+	assert.Panics(t, callPopC)
+}
+
+func TestStartFromDifferentRoutines(t *testing.T) {
+	q := NewUniQueue[int](5)
+	go func() {
+		utils.IgnoreError(q.Start)
+	}()
+	go func() {
+		utils.IgnoreError(q.Start)
+	}()
+}
+
+func TestStopFromDifferentRoutines(t *testing.T) {
+	q := NewUniQueue[int](5)
+	assert.NoError(t, q.Start())
+	go func() {
+		q.Stop()
+	}()
+	go func() {
+		q.Stop()
+	}()
+}
+
+func TestAddFromDifferentRoutines(t *testing.T) {
+	q := NewUniQueue[int](5)
+	assert.NoError(t, q.Start())
+	numsToPush := []int{1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2}
+	expected := []int{0, 1, 2, 3}
+	pushC := q.PushC()
+	// We push the first item that would be put in the frontChannel
+	pushC <- 0
+	require.True(t, waitWithRetry(func() bool {
+		return len(q.PopC()) > 0
+	}))
+	// The rest of the items can be pushed
+	wg := &sync.WaitGroup{}
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for _, n := range numsToPush {
+			q.PushC() <- n
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for _, n := range numsToPush {
+			q.PushC() <- n
+		}
+	}()
+	wg.Wait()
+	// We push a different value to make sure we read all elements
+	pushC <- 3
+	assert.True(t, waitWithRetry(func() bool {
+		return q.Size() == 3
+	}))
+	var queueContent []int
+	for i := 0; i < len(expected); i++ {
+		n := <-q.PopC()
+		queueContent = append(queueContent, n)
+	}
+	assert.Equal(t, expected, queueContent)
+	assert.Len(t, q.frontChannel, 0)
+	q.Stop()
+}
+
+func TestReadFromDifferentRoutines(t *testing.T) {
+	q := NewUniQueue[int](5)
+	assert.NoError(t, q.Start())
+	numsToPush := []int{1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 3}
+	expected := map[int]struct{}{
+		0: {},
+		1: {},
+		2: {},
+		3: {},
+	}
+	pushC := q.PushC()
+	// We push the first item that would be put in the frontChannel
+	pushC <- 0
+	require.True(t, waitWithRetry(func() bool {
+		return len(q.PopC()) > 0
+	}))
+	// The rest of the items can be pushed
+	for _, n := range numsToPush {
+		pushC <- n
+	}
+	assert.True(t, waitWithRetry(func() bool {
+		return q.Size() == 3
+	}))
+	assert.True(t, waitWithRetry(func() bool {
+		return len(q.backChannel) == 0
+	}))
+	wg := &sync.WaitGroup{}
+	ctx, cancelFn := context.WithCancel(context.Background())
+	wg.Add(2)
+	numReads := atomic.Int32{}
+	var poppedContent1 []int
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case n, ok := <-q.PopC():
+				assert.True(t, ok)
+				poppedContent1 = append(poppedContent1, n)
+				numReads.Add(1)
+				if numReads.Load() == int32(len(expected)) {
+					cancelFn()
+					return
+				}
+			}
+		}
+	}()
+	var poppedContent2 []int
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case n, ok := <-q.PopC():
+				assert.True(t, ok)
+				poppedContent2 = append(poppedContent2, n)
+				numReads.Add(1)
+				if numReads.Load() == int32(len(expected)) {
+					cancelFn()
+					return
+				}
+			}
+		}
+	}()
+	wg.Wait()
+	poppedContentMap := make(map[int]struct{})
+	for _, el := range poppedContent1 {
+		poppedContentMap[el] = struct{}{}
+	}
+	for _, el := range poppedContent2 {
+		poppedContentMap[el] = struct{}{}
+	}
+	assert.Equal(t, len(poppedContentMap), len(expected))
+	assert.Equal(t, expected, poppedContentMap)
+	assert.Len(t, q.frontChannel, 0)
+	q.Stop()
+}
+
+func waitWithRetry(fn func() bool) bool {
+	timeout := time.After(3 * time.Second)
+	for {
+		select {
+		case <-timeout:
+			return false
+		default:
+			if fn() {
+				return true
+			}
+		}
+	}
+}

--- a/sensor/kubernetes/eventpipeline/resolver/resolver.go
+++ b/sensor/kubernetes/eventpipeline/resolver/resolver.go
@@ -3,6 +3,8 @@ package resolver
 import (
 	"sync/atomic"
 
+	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/uniqueue"
 	"github.com/stackrox/rox/sensor/common/store"
 	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/component"
 )
@@ -10,9 +12,12 @@ import (
 // New instantiates a Resolver component
 func New(outputQueue component.OutputQueue, provider store.Provider, queueSize int) component.Resolver {
 	return &resolverImpl{
-		outputQueue:   outputQueue,
-		innerQueue:    make(chan *component.ResourceEvent, queueSize),
-		storeProvider: provider,
-		stopped:       &atomic.Bool{},
+		stopper:        concurrency.NewStopper(),
+		outputQueue:    outputQueue,
+		innerQueue:     nil,
+		innerQueueSize: queueSize,
+		storeProvider:  provider,
+		stopped:        &atomic.Bool{},
+		queue:          uniqueue.NewUniQueue[deploymentRef](queueSize),
 	}
 }

--- a/sensor/kubernetes/eventpipeline/resolver/resolver_impl.go
+++ b/sensor/kubernetes/eventpipeline/resolver/resolver_impl.go
@@ -67,7 +67,7 @@ func (r *resolverImpl) Send(event *component.ResourceEvent) {
 	}
 }
 
-// runResolver reads messages from the inner queue and process the message
+// runResolver starts the runSingleDeploymentResolver and the runProcessMessages routines.
 func (r *resolverImpl) runResolver() {
 	defer r.stopper.Flow().ReportStopped()
 	wg := &sync.WaitGroup{}
@@ -77,6 +77,7 @@ func (r *resolverImpl) runResolver() {
 	wg.Wait()
 }
 
+// runProcessMessages reads messages from the innerQueue and process the message
 func (r *resolverImpl) runProcessMessages(wg *sync.WaitGroup) {
 	defer wg.Done()
 	for {
@@ -93,12 +94,14 @@ func (r *resolverImpl) runProcessMessages(wg *sync.WaitGroup) {
 	}
 }
 
+// pushDeploymentIDs pushes deployment IDs to the inner queue.
 func (r *resolverImpl) pushDeploymentIDs(skip bool, action central.ResourceAction, ids ...string) {
 	for _, id := range ids {
 		r.queue.PushC() <- deploymentRef{id, skip, action}
 	}
 }
 
+// runSingleDeploymentResolver reads deploymentRef from the inner queue and resolves them.
 func (r *resolverImpl) runSingleDeploymentResolver(wg *sync.WaitGroup) {
 	defer wg.Done()
 	for {
@@ -114,6 +117,7 @@ func (r *resolverImpl) runSingleDeploymentResolver(wg *sync.WaitGroup) {
 	}
 }
 
+// resolveDeployment resolves the dependencies of a deployment given its ID.
 func (r *resolverImpl) resolveDeployment(id string, skip bool, action central.ResourceAction) {
 	msg := component.NewEvent()
 	if skip {
@@ -159,7 +163,7 @@ func (r *resolverImpl) resolveDeployment(id string, skip bool, action central.Re
 	r.outputQueue.Send(msg)
 }
 
-// processMessage resolves the dependencies and forwards the message to the outputQueue
+// processMessage sends the ids from the DeploymentReferences to the inner queue, and forwards the message to the outputQueue
 func (r *resolverImpl) processMessage(msg *component.ResourceEvent) {
 	if msg.DeploymentReferences != nil {
 

--- a/sensor/kubernetes/eventpipeline/resolver/resolver_impl.go
+++ b/sensor/kubernetes/eventpipeline/resolver/resolver_impl.go
@@ -5,7 +5,10 @@ import (
 
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/logging"
+	"github.com/stackrox/rox/pkg/sync"
+	"github.com/stackrox/rox/pkg/uniqueue"
 	"github.com/stackrox/rox/sensor/common/metrics"
 	"github.com/stackrox/rox/sensor/common/store"
 	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/component"
@@ -15,24 +18,45 @@ var (
 	log = logging.LoggerForModule()
 )
 
+type deploymentRef struct {
+	id     string
+	skip   bool
+	action central.ResourceAction
+}
+
 type resolverImpl struct {
-	outputQueue component.OutputQueue
-	innerQueue  chan *component.ResourceEvent
+	stopper        concurrency.Stopper
+	outputQueue    component.OutputQueue
+	innerQueue     chan *component.ResourceEvent
+	innerQueueSize int
 
 	storeProvider store.Provider
 	stopped       *atomic.Bool
+	queue         *uniqueue.UniQueue[deploymentRef]
 }
 
 // Start the resolverImpl component
 func (r *resolverImpl) Start() error {
+	if err := r.queue.Start(); err != nil {
+		return err
+	}
+	r.stopper.LowLevel().ResetStopRequest()
+	r.innerQueue = make(chan *component.ResourceEvent, r.innerQueueSize)
 	go r.runResolver()
 	return nil
 }
 
 // Stop the resolverImpl component
 func (r *resolverImpl) Stop(_ error) {
-	defer close(r.innerQueue)
-	r.stopped.Store(true)
+	if !r.stopper.Client().Stopped().IsDone() {
+		defer func() {
+			_ = r.stopper.Client().Stopped().Wait()
+			r.queue.Stop()
+			close(r.innerQueue)
+			r.stopped.Store(true)
+		}()
+	}
+	r.stopper.Client().Stop()
 }
 
 // Send a ResourceEvent message to the inner queue
@@ -45,14 +69,94 @@ func (r *resolverImpl) Send(event *component.ResourceEvent) {
 
 // runResolver reads messages from the inner queue and process the message
 func (r *resolverImpl) runResolver() {
+	defer r.stopper.Flow().ReportStopped()
+	wg := &sync.WaitGroup{}
+	wg.Add(2)
+	go r.runSingleDeploymentResolver(wg)
+	go r.runProcessMessages(wg)
+	wg.Wait()
+}
+
+func (r *resolverImpl) runProcessMessages(wg *sync.WaitGroup) {
+	defer wg.Done()
 	for {
-		msg, more := <-r.innerQueue
-		if !more {
+		select {
+		case <-r.stopper.Flow().StopRequested():
+			return
+		case msg, more := <-r.innerQueue:
+			if !more {
+				return
+			}
+			r.processMessage(msg)
+			metrics.DecResolverChannelSize()
+		}
+	}
+}
+
+func (r *resolverImpl) pushDeploymentIDs(skip bool, action central.ResourceAction, ids ...string) {
+	for _, id := range ids {
+		r.queue.PushC() <- deploymentRef{id, skip, action}
+	}
+}
+
+func (r *resolverImpl) runSingleDeploymentResolver(wg *sync.WaitGroup) {
+	defer wg.Done()
+	for {
+		select {
+		case <-r.stopper.Flow().StopRequested():
+			return
+		case msg, more := <-r.queue.PopC():
+			if !more {
+				return
+			}
+			r.resolveDeployment(msg.id, msg.skip, msg.action)
+		}
+	}
+}
+
+func (r *resolverImpl) resolveDeployment(id string, skip bool, action central.ResourceAction) {
+	msg := component.NewEvent()
+	if skip {
+		d, built := r.storeProvider.Deployments().GetBuiltDeployment(id)
+		if d == nil {
+			log.Warnf("Deployment with id %s not found", id)
 			return
 		}
-		r.processMessage(msg)
-		metrics.DecResolverChannelSize()
+
+		if !built {
+			log.Debugf("Deployment with id %s is already in the pipeline, skipping processing", id)
+			return
+		}
+		msg.AddDeploymentForDetection(component.DetectorMessage{Object: d, Action: action})
+		r.outputQueue.Send(msg)
+		return
 	}
+	preBuiltDeployment := r.storeProvider.Deployments().Get(id)
+	if preBuiltDeployment == nil {
+		log.Warnf("Deployment with id %s not found", id)
+		return
+	}
+	// Remove actions are done at the handler level. This is not ideal but for now it allows us to be able to fetch deployments from the store
+	// in the resolver instead of sending a copy. We still manage OnDeploymentCreateOrUpdate here.
+	r.storeProvider.EndpointManager().OnDeploymentCreateOrUpdateByID(id)
+
+	permissionLevel := r.storeProvider.RBAC().GetPermissionLevelForDeployment(preBuiltDeployment)
+	exposureInfo := r.storeProvider.Services().
+		GetExposureInfos(preBuiltDeployment.GetNamespace(), preBuiltDeployment.GetPodLabels())
+
+	d, err := r.storeProvider.Deployments().BuildDeploymentWithDependencies(id, store.Dependencies{
+		PermissionLevel: permissionLevel,
+		Exposures:       exposureInfo,
+	})
+
+	if err != nil {
+		log.Warnf("Failed to build deployment dependency: %s", err)
+		return
+	}
+
+	msg.AddSensorEvent(toEvent(action, d, msg.DeploymentTiming)).
+		AddDeploymentForDetection(component.DetectorMessage{Object: d, Action: action})
+	r.outputQueue.Send(msg)
 }
 
 // processMessage resolves the dependencies and forwards the message to the outputQueue
@@ -69,51 +173,13 @@ func (r *resolverImpl) processMessage(msg *component.ResourceEvent) {
 			if deploymentReference.ForceDetection && len(referenceIds) > 0 {
 				// We append the referenceIds to the msg to be reprocessed
 				msg.AddDeploymentForReprocessing(referenceIds...)
+				for _, id := range referenceIds {
+					r.resolveDeployment(id, deploymentReference.SkipResolving, deploymentReference.ParentResourceAction)
+				}
+				continue
 			}
 
-			for _, id := range referenceIds {
-				preBuiltDeployment := r.storeProvider.Deployments().Get(id)
-				if preBuiltDeployment == nil {
-					log.Warnf("Deployment with id %s not found", id)
-					continue
-				}
-				// Skip resolving the deployment dependencies
-				if deploymentReference.SkipResolving {
-					d, built := r.storeProvider.Deployments().GetBuiltDeployment(id)
-					if d == nil {
-						log.Warnf("Deployment with id %s not found", id)
-						continue
-					}
-
-					if !built {
-						log.Debugf("Deployment with id %s is already in the pipeline, skipping processing", id)
-						continue
-					}
-					msg.AddDeploymentForDetection(component.DetectorMessage{Object: d, Action: deploymentReference.ParentResourceAction})
-					continue
-				}
-
-				// Remove actions are done at the handler level. This is not ideal but for now it allows us to be able to fetch deployments from the store
-				// in the resolver instead of sending a copy. We still manage OnDeploymentCreateOrUpdate here.
-				r.storeProvider.EndpointManager().OnDeploymentCreateOrUpdateByID(id)
-
-				permissionLevel := r.storeProvider.RBAC().GetPermissionLevelForDeployment(preBuiltDeployment)
-				exposureInfo := r.storeProvider.Services().
-					GetExposureInfos(preBuiltDeployment.GetNamespace(), preBuiltDeployment.GetPodLabels())
-
-				d, err := r.storeProvider.Deployments().BuildDeploymentWithDependencies(id, store.Dependencies{
-					PermissionLevel: permissionLevel,
-					Exposures:       exposureInfo,
-				})
-
-				if err != nil {
-					log.Warnf("Failed to build deployment dependency: %s", err)
-					continue
-				}
-
-				msg.AddSensorEvent(toEvent(deploymentReference.ParentResourceAction, d, msg.DeploymentTiming)).
-					AddDeploymentForDetection(component.DetectorMessage{Object: d, Action: deploymentReference.ParentResourceAction})
-			}
+			r.pushDeploymentIDs(deploymentReference.SkipResolving, deploymentReference.ParentResourceAction, referenceIds...)
 		}
 
 	}


### PR DESCRIPTION
## Description

Currently two resources could trigger the same deployment reprocess. The current implementation will process the same deployment twice; this is not necessary. We could instead aggregate these two deployment references and process the deployment just once.

## Checklist
- [x] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- ~[ ] Evaluated and added CHANGELOG entry if required~
- ~[ ] Determined and documented upgrade steps~
- ~[ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~

If any of these don't apply, please comment below.

## Testing Performed

* [x] CI
* [x] Sensor integration tests pass locally
* [x] Unit tests pass locally
