### PR TITLE
chore(config): Add ROX_HASH_FLUSH_INTERVAL to control hash flush rate

### DIFF
--- a/central/hash/manager/manager.go
+++ b/central/hash/manager/manager.go
@@ -8,12 +8,13 @@ import (
 	"github.com/stackrox/rox/central/hash/datastore"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/sync"
 )
 
-const (
-	flushInterval = 1 * time.Minute
+var (
+	flushInterval = env.HashFlushInterval.DurationSetting()
 )
 
 var (
@@ -74,6 +75,9 @@ func (m *managerImpl) flushHashes(ctx context.Context) {
 }
 
 func (m *managerImpl) Start(ctx context.Context) {
+	if flushInterval == 0 {
+		return
+	}
 	t := time.NewTicker(flushInterval)
 	defer t.Stop()
 	for {

--- a/pkg/env/hash_flush_interval.go
+++ b/pkg/env/hash_flush_interval.go
@@ -1,0 +1,8 @@
+package env
+
+import "time"
+
+var (
+	// HashFlushInterval sets the frequency of flushing the received hashes to the database
+	HashFlushInterval = registerDurationSetting("ROX_HASH_FLUSH_INTERVAL", 1*time.Minute)
+)


### PR DESCRIPTION
## Description

ROX_HASH_FLUSH_INTERVAL controls the frequency of flushing the hashes to the database. Unlikely to be used, but a good thing to tune just in case

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Trivial