### PR TITLE
ROX-17956: Fix error in roxctl authorize mode

### DIFF
--- a/ui/apps/platform/src/Containers/Login/LoginPage.js
+++ b/ui/apps/platform/src/Containers/Login/LoginPage.js
@@ -174,6 +174,19 @@ class LoginPage extends Component {
         if (authorizeRoxctlMode) {
             authProviders = authProviders.filter((provider) => provider.type !== 'basic');
             title = 'Authorize roxctl';
+            if (authProviders?.length === 0) {
+                return (
+                    <Alert
+                        variant="danger"
+                        isInline
+                        title="roxct-authorize-error"
+                        className="pf-u-mb-md"
+                    >
+                        Only basic auth provider given. Authorizing roxctl only works with non-basic
+                        auth provider. Configure an auth provider and try again.
+                    </Alert>
+                );
+            }
         }
 
         const options = authProvidersToSelectOptions(authProviders);
@@ -306,7 +319,7 @@ const LoadingOrForm = ({ authProviders, authorizeRoxctlMode = false }) => {
     }
 
     const options = authProvidersToSelectOptions(availableAuthProviders);
-    const initialValues = { authProvider: options[0].value };
+    const initialValues = { authProvider: options[0]?.value };
     return <Form initialValues={initialValues} authorizeRoxctlMode={authorizeRoxctlMode} />;
 };
 

--- a/ui/apps/platform/src/Containers/Login/LoginPage.js
+++ b/ui/apps/platform/src/Containers/Login/LoginPage.js
@@ -174,7 +174,7 @@ class LoginPage extends Component {
         if (authorizeRoxctlMode) {
             authProviders = authProviders.filter((provider) => provider.type !== 'basic');
             title = 'Authorize roxctl';
-            if (authProviders?.length === 0) {
+            if (authProviders.length === 0) {
                 return (
                     <Alert
                         variant="danger"
@@ -319,6 +319,9 @@ const LoadingOrForm = ({ authProviders, authorizeRoxctlMode = false }) => {
     }
 
     const options = authProvidersToSelectOptions(availableAuthProviders);
+    // In case of roxctl authorize mode, we filter out the basic auth provider. This could lead
+    // to us having no auth provider within the initial values, hence we need to be able to handle
+    // the empty list of auth providers here.
     const initialValues = { authProvider: options[0]?.value };
     return <Form initialValues={initialValues} authorizeRoxctlMode={authorizeRoxctlMode} />;
 };


### PR DESCRIPTION
## Description

Currently, when executing `roxctl central login` and the central instance doesn't have any auth provider configured besides the default basic auth provider, the authorize roxctl page will contain an error.

This is due to the current login page code assuming that there will be at least one auth provider within the list of available auth providers. However, since we filter out the basic auth provider in roxctl authorize mode, since its not compatible with the flow, this assumption doesn't hold true anymore.

This PR fixes this by a) ensuring that the current code in `LoadingOrForm` respects potential empty auth provider list within the initial values and b) returning an error in roxctl authorize mode in case of an empty auth provider list after filtering out the basic auth provider.

![Screenshot 2023-06-20 at 18 36 33](https://github.com/stackrox/stackrox/assets/89904305/a291058c-9ef8-4814-88ab-38149062caaf)

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed
