### PR TITLE
ROX-17938: Fix handling of NG epoch updates in UI

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
@@ -136,87 +136,93 @@ function NetworkGraphPage() {
         }
     }, 30000);
 
-    useDeepCompareEffect(() => {
+    function updateNetworkNodes() {
         // check that user is finished adding a complete filter
         const isQueryFilterComplete = isCompleteSearchFilter(remainingQuery);
 
         // only refresh the graph data from the API if both a cluster and at least one namespace are selected
-        // TODO - The deployment count does not update if deployments are added/removed unless the selectedClusterId changes
         const isClusterNamespaceSelected =
             clusterFromUrl && namespacesFromUrl.length > 0 && deploymentCount;
 
         if (isQueryFilterComplete && selectedClusterId && isClusterNamespaceSelected) {
-            // TODO - The below check causes the graph to stop updating when pending updates are available, even if
-            // the user changes the search parameters
-            if (nodeUpdatesCount === 0) {
-                setIsLoading(true);
+            setIsLoading(true);
 
-                const queryToUse = queryService.objectToWhereClause(remainingQuery);
-                const timestampToUse = timeWindowToDate(timeWindow);
+            const queryToUse = queryService.objectToWhereClause(remainingQuery);
+            const timestampToUse = timeWindowToDate(timeWindow);
 
-                Promise.all([
-                    // fetch the network graph data used for the active graph
-                    fetchNetworkFlowGraph(
-                        selectedClusterId,
-                        namespacesFromUrl,
-                        deploymentsFromUrl,
-                        queryToUse,
-                        timestampToUse || undefined,
-                        includePorts,
-                        ALWAYS_SHOW_ORCHESTRATOR_COMPONENTS
-                    ),
-                    // fetch the network graph data, including policies, for the inactive graph
-                    fetchNetworkFlowGraph(
-                        selectedClusterId,
-                        namespacesFromUrl,
-                        deploymentsFromUrl,
-                        queryToUse,
-                        undefined,
-                        includePorts,
-                        ALWAYS_SHOW_ORCHESTRATOR_COMPONENTS,
-                        INCLUDE_POLICIES
-                    ),
-                ])
-                    .then((values) => {
-                        // get policy nodes, and the starting epoch, from policy graph API response
-                        const { nodes: policyNodes, epoch } = values[1].response;
-                        // transform policy data to DataModel
-                        const { policyDataModel, policyNodeMap } = transformPolicyData(policyNodes);
-                        // get active nodes from network flow graph API response
-                        const { nodes: activeNodes } = values[0].response;
-                        // transform active data to DataModel
-                        const { activeDataModel, activeEdgeMap, activeNodeMap } =
-                            transformActiveData(activeNodes, policyNodeMap, namespacesFromUrl);
+            Promise.all([
+                // fetch the network graph data used for the active graph
+                fetchNetworkFlowGraph(
+                    selectedClusterId,
+                    namespacesFromUrl,
+                    deploymentsFromUrl,
+                    queryToUse,
+                    timestampToUse || undefined,
+                    includePorts,
+                    ALWAYS_SHOW_ORCHESTRATOR_COMPONENTS
+                ),
+                // fetch the network graph data, including policies, for the inactive graph
+                fetchNetworkFlowGraph(
+                    selectedClusterId,
+                    namespacesFromUrl,
+                    deploymentsFromUrl,
+                    queryToUse,
+                    undefined,
+                    includePorts,
+                    ALWAYS_SHOW_ORCHESTRATOR_COMPONENTS,
+                    INCLUDE_POLICIES
+                ),
+            ])
+                .then((values) => {
+                    // get policy nodes from policy graph API response
+                    const { nodes: policyNodes } = values[1].response;
+                    // transform policy data to DataModel
+                    const { policyDataModel, policyNodeMap } = transformPolicyData(policyNodes);
+                    // get active nodes from network flow graph API response
+                    const { nodes: activeNodes } = values[0].response;
+                    // transform active data to DataModel
+                    const { activeDataModel, activeEdgeMap, activeNodeMap } = transformActiveData(
+                        activeNodes,
+                        policyNodeMap,
+                        namespacesFromUrl
+                    );
 
-                        // create extraneous flows graph
-                        const extraneousFlowsDataModel = createExtraneousFlowsModel(
-                            policyDataModel,
-                            activeNodeMap,
-                            activeEdgeMap,
-                            namespacesFromUrl
-                        );
+                    // create extraneous flows graph
+                    const extraneousFlowsDataModel = createExtraneousFlowsModel(
+                        policyDataModel,
+                        activeNodeMap,
+                        activeEdgeMap,
+                        namespacesFromUrl
+                    );
 
-                        const newUpdatedTimestamp = new Date();
-                        // show only hours and minutes, use options with the default locale - use an empty array
-                        const lastUpdatedDisplayTime = newUpdatedTimestamp.toLocaleTimeString([], {
-                            hour: 'numeric',
-                            minute: '2-digit',
-                        });
-                        setLastUpdatedTime(lastUpdatedDisplayTime);
-                        setPrevEpochCount(epoch);
-                        setCurrentEpochCount(epoch);
+                    const newUpdatedTimestamp = new Date();
+                    // show only hours and minutes, use options with the default locale - use an empty array
+                    const lastUpdatedDisplayTime = newUpdatedTimestamp.toLocaleTimeString([], {
+                        hour: 'numeric',
+                        minute: '2-digit',
+                    });
+                    setLastUpdatedTime(lastUpdatedDisplayTime);
 
-                        setModels({
-                            activeModel: activeDataModel,
-                            extraneousModel: extraneousFlowsDataModel,
-                        });
-                    })
-                    .catch(() => {
-                        // TODO
-                    })
-                    .finally(() => setIsLoading(false));
-            }
+                    // Set the epoch to the most recent value from the server, since the state should now be up to date
+                    // with that value at worst.
+                    setPrevEpochCount(currentEpochCount);
+
+                    setModels({
+                        activeModel: activeDataModel,
+                        extraneousModel: extraneousFlowsDataModel,
+                    });
+                })
+                .catch(() => {
+                    // TODO
+                })
+                .finally(() => setIsLoading(false));
         }
+    }
+
+    // TODO - This ignores some dependencies that would normally be included in the dep array of a regular `useEffect`.
+    // We can probably remove the effect and rely on callbacks when setting the parameters instead.
+    useDeepCompareEffect(() => {
+        updateNetworkNodes();
     }, [
         clusterFromUrl,
         namespacesFromUrl,
@@ -224,21 +230,15 @@ function NetworkGraphPage() {
         remainingQuery,
         timeWindow,
         deploymentCount,
-        nodeUpdatesCount,
     ]);
 
     function toggleCIDRBlockForm() {
         setIsCIDRBlockFormOpen(!isCIDRBlockFormOpen);
     }
 
-    function updateNetworkNodes() {
-        setPrevEpochCount(0);
-        setCurrentEpochCount(0);
-    }
-
     return (
         <>
-            <PageTitle title="Network Graph (2.0 preview)" />
+            <PageTitle title="Network Graph" />
             <PageSection variant="light" padding={{ default: 'noPadding' }}>
                 <Toolbar
                     className="network-graph-selector-bar"

--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import {
     PageSection,
     Title,
@@ -78,7 +78,6 @@ function NetworkGraphPage() {
         undefined
     );
 
-    const [pollEpoch, setPollEpoch] = useState(0);
     const [isLoading, setIsLoading] = useState(false);
     const [timeWindow, setTimeWindow] = useState<(typeof timeWindows)[number]>(timeWindows[0]);
     const [lastUpdatedTime, setLastUpdatedTime] = useState<string>('');
@@ -126,11 +125,7 @@ function NetworkGraphPage() {
 
     // We will update the poll epoch after 30 seconds to update the node count for a cluster
     useInterval(() => {
-        setPollEpoch(pollEpoch + 1);
-    }, 30000);
-
-    useEffect(() => {
-        if (selectedClusterId && namespacesFromUrl.length > 0 && pollEpoch !== 0) {
+        if (selectedClusterId && namespacesFromUrl.length > 0) {
             fetchNodeUpdates(selectedClusterId)
                 .then((result) => {
                     setCurrentEpochCount(result?.response?.epoch || 0);
@@ -139,7 +134,7 @@ function NetworkGraphPage() {
                     // failure to update the node count is not critical
                 });
         }
-    }, [selectedClusterId, namespacesFromUrl.length, pollEpoch]);
+    }, 30000);
 
     useDeepCompareEffect(() => {
         // check that user is finished adding a complete filter

--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
     PageSection,
     Title,
@@ -219,6 +219,12 @@ function NetworkGraphPage() {
         }
     }
 
+    // Epoch counts are tracked separately for each cluster, so reset them when the cluster changes.
+    useEffect(() => {
+        setPrevEpochCount(0);
+        setCurrentEpochCount(0);
+    }, [selectedClusterId]);
+
     // TODO - This ignores some dependencies that would normally be included in the dep array of a regular `useEffect`.
     // We can probably remove the effect and rely on callbacks when setting the parameters instead.
     useDeepCompareEffect(() => {
@@ -231,7 +237,6 @@ function NetworkGraphPage() {
         timeWindow,
         deploymentCount,
     ]);
-
     function toggleCIDRBlockForm() {
         setIsCIDRBlockFormOpen(!isCIDRBlockFormOpen);
     }

--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
@@ -146,10 +146,13 @@ function NetworkGraphPage() {
         const isQueryFilterComplete = isCompleteSearchFilter(remainingQuery);
 
         // only refresh the graph data from the API if both a cluster and at least one namespace are selected
+        // TODO - The deployment count does not update if deployments are added/removed unless the selectedClusterId changes
         const isClusterNamespaceSelected =
             clusterFromUrl && namespacesFromUrl.length > 0 && deploymentCount;
 
         if (isQueryFilterComplete && selectedClusterId && isClusterNamespaceSelected) {
+            // TODO - The below check causes the graph to stop updating when pending updates are available, even if
+            // the user changes the search parameters
             if (nodeUpdatesCount === 0) {
                 setIsLoading(true);
 


### PR DESCRIPTION
## Description

This fixes a couple of issues causing the problem described in the ticket. The current logic makes it so that the Network Graph cannot update whenever the "# updates available" button is visible. Clicking on the button will correctly apply the updates and makes the filters usable again for 30 seconds, until the next time the epoch polling causes the button to reappear.

There were two issues causing this behavior:
1. A check in the update function that skipped the update if the current epoch `!== 0`. This was likely put in place to avoid automatically updating the graph when there was a change to the nodes, but unintentionally skipped _all_ updates to the graph when a node update was available.
2. The UI set the current epoch to the value returned from the `/v1/networkgraph/cluster` endpoint's `epoch` value, which appears to always be `0`. (Possible backend bug?)

The fix does the following:
1. Move the update function out of the `useEffect` so that it isn't called automatically when the epoch changes, and instead call the new function directly when the user clicks the "# updates available" button or a search filter changes.
2. Sets the client side epoch to the latest value returned from the polling endpoint whenever the visualization is updated. This ensures we keep the client side `epoch` value current with what the server has returned.
3. Clears the current epoch when the cluster is changed. (Epoch is tracked separately for each cluster).

__This is easier to review with "hide whitespace" on__

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Load the NG and select a cluster and namespace. Ensure that all filters and options work correctly and update the graph.

After 30 seconds, the "# updates available" button should become active. (Since we default to an epoch of 0, this should always be the case after the first interval, even if the data is up to date.) When the button becomes active, the data in the graph should **not** refresh.

With "# updates available" visible, ensure filters still work correctly and update the graph.

Click the "# updates available" button. The graph should update again and the button should disappear.

Test filters again and ensure the graph responds to changes.

The "# updates available" button should **not** become visible again after 30 seconds, if no changes have been made to deployments in the cluster.

After > 30 seconds, make a change to a deployment and ensure the "# updates available" button reappears again after 30 more seconds.
