### PR TITLE
ROX-17814: Show a simple vulnerability reports table

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/HelpIconTh.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/HelpIconTh.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Flex, FlexItem, Tooltip } from '@patternfly/react-core';
+import { Th, ThProps } from '@patternfly/react-table';
+import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
+
+type TooltipThProps = {
+    children: string | React.ReactNode;
+    sort?: ThProps['sort'];
+    tooltip: string;
+};
+
+function HelpIconTh({ children, tooltip, sort }: TooltipThProps) {
+    return (
+        <Th sort={sort || undefined}>
+            <Flex direction={{ default: 'row' }} alignItems={{ default: 'alignItemsCenter' }}>
+                <FlexItem>{children}</FlexItem>
+                <FlexItem>
+                    <Tooltip content={tooltip}>
+                        <OutlinedQuestionCircleIcon />
+                    </Tooltip>
+                </FlexItem>
+            </Flex>
+        </Th>
+    );
+}
+
+export default HelpIconTh;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/HelpIconTh.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/HelpIconTh.tsx
@@ -3,13 +3,13 @@ import { Flex, FlexItem, Tooltip } from '@patternfly/react-core';
 import { Th, ThProps } from '@patternfly/react-table';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 
-type TooltipThProps = {
+type HelpIconThProps = {
     children: string | React.ReactNode;
     sort?: ThProps['sort'];
     tooltip: string;
 };
 
-function HelpIconTh({ children, tooltip, sort }: TooltipThProps) {
+function HelpIconTh({ children, tooltip, sort }: HelpIconThProps) {
     return (
         <Th sort={sort || undefined}>
             <Flex direction={{ default: 'row' }} alignItems={{ default: 'alignItemsCenter' }}>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/LastRunState.test.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/LastRunState.test.tsx
@@ -6,6 +6,19 @@ import { ReportStatus } from 'types/report.proto';
 import LastRunState from './LastRunState';
 
 describe('LastRunState', () => {
+    let originalTimeZone;
+
+    beforeAll(() => {
+        // Save original timezone and set new one for testing
+        originalTimeZone = process.env.TZ;
+        process.env.TZ = 'UTC';
+    });
+
+    afterAll(() => {
+        // Restore original timezone
+        process.env.TZ = originalTimeZone;
+    });
+
     test('should show the time stamp of the last successful prepared download', async () => {
         const reportStatus: ReportStatus = {
             runState: 'SUCCESS',
@@ -19,7 +32,7 @@ describe('LastRunState', () => {
         render(<LastRunState reportStatus={reportStatus} />);
 
         // ASSERT
-        expect(screen.getByText('06/20/2023 | 3:59:46AM')).toBeDefined();
+        expect(screen.getByText('06/20/2023 | 10:59:46AM')).toBeDefined();
     });
 
     test('should show the time stamp of the last error when preparing a download', async () => {
@@ -35,7 +48,7 @@ describe('LastRunState', () => {
         render(<LastRunState reportStatus={reportStatus} />);
 
         // ASSERT
-        expect(screen.getByText('06/20/2023 | 3:59:46AM')).toBeDefined();
+        expect(screen.getByText('06/20/2023 | 10:59:46AM')).toBeDefined();
     });
 
     test('should show the time stamp of the last successful email', async () => {
@@ -51,7 +64,7 @@ describe('LastRunState', () => {
         render(<LastRunState reportStatus={reportStatus} />);
 
         // ASSERT
-        expect(screen.getByText('06/20/2023 | 3:59:46AM')).toBeDefined();
+        expect(screen.getByText('06/20/2023 | 10:59:46AM')).toBeDefined();
     });
 
     test('should show the time stamp of the last error attempting to email', async () => {
@@ -67,7 +80,7 @@ describe('LastRunState', () => {
         render(<LastRunState reportStatus={reportStatus} />);
 
         // ASSERT
-        expect(screen.getByText('06/20/2023 | 3:59:46AM')).toBeDefined();
+        expect(screen.getByText('06/20/2023 | 10:59:46AM')).toBeDefined();
     });
 
     test('should show a spinner and the correct text when preparing a report', async () => {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/LastRunState.test.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/LastRunState.test.tsx
@@ -1,0 +1,105 @@
+import React, { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import { ReportStatus } from 'types/report.proto';
+
+import LastRunState from './LastRunState';
+
+describe('LastRunState', () => {
+    test('should show the time stamp of the last successful prepared download', async () => {
+        const reportStatus: ReportStatus = {
+            runState: 'SUCCESS',
+            runTime: '2023-06-20T10:59:46.383433891Z',
+            errorMsg: '',
+            reportMethod: 'ON_DEMAND',
+            reportNotificationMethod: 'DOWNLOAD',
+        };
+
+        // ARRANGE
+        render(<LastRunState reportStatus={reportStatus} />);
+
+        // ASSERT
+        expect(screen.getByText('06/20/2023 | 3:59:46AM')).toBeDefined();
+    });
+
+    test('should show the time stamp of the last error when preparing a download', async () => {
+        const reportStatus: ReportStatus = {
+            runState: 'FAILURE',
+            runTime: '2023-06-20T10:59:46.383433891Z',
+            errorMsg: '',
+            reportMethod: 'ON_DEMAND',
+            reportNotificationMethod: 'DOWNLOAD',
+        };
+
+        // ARRANGE
+        render(<LastRunState reportStatus={reportStatus} />);
+
+        // ASSERT
+        expect(screen.getByText('06/20/2023 | 3:59:46AM')).toBeDefined();
+    });
+
+    test('should show the time stamp of the last successful email', async () => {
+        const reportStatus: ReportStatus = {
+            runState: 'SUCCESS',
+            runTime: '2023-06-20T10:59:46.383433891Z',
+            errorMsg: '',
+            reportMethod: 'ON_DEMAND',
+            reportNotificationMethod: 'EMAIL',
+        };
+
+        // ARRANGE
+        render(<LastRunState reportStatus={reportStatus} />);
+
+        // ASSERT
+        expect(screen.getByText('06/20/2023 | 3:59:46AM')).toBeDefined();
+    });
+
+    test('should show the time stamp of the last error attempting to email', async () => {
+        const reportStatus: ReportStatus = {
+            runState: 'FAILURE',
+            runTime: '2023-06-20T10:59:46.383433891Z',
+            errorMsg: '',
+            reportMethod: 'ON_DEMAND',
+            reportNotificationMethod: 'EMAIL',
+        };
+
+        // ARRANGE
+        render(<LastRunState reportStatus={reportStatus} />);
+
+        // ASSERT
+        expect(screen.getByText('06/20/2023 | 3:59:46AM')).toBeDefined();
+    });
+
+    test('should show a spinner and the correct text when preparing a report', async () => {
+        const reportStatus: ReportStatus = {
+            runState: 'PREPARING',
+            runTime: '2023-06-20T10:59:46.383433891Z',
+            errorMsg: '',
+            reportMethod: 'ON_DEMAND',
+            reportNotificationMethod: 'EMAIL',
+        };
+
+        // ARRANGE
+        render(<LastRunState reportStatus={reportStatus} />);
+
+        // ASSERT
+        expect(screen.getByLabelText('Preparing report')).toBeDefined();
+        expect(screen.getByText('Preparing')).toBeDefined();
+    });
+
+    test("should show that a run didn't happen when waiting for a report", async () => {
+        const reportStatus: ReportStatus = {
+            runState: 'WAITING',
+            runTime: '2023-06-20T10:59:46.383433891Z',
+            errorMsg: '',
+            reportMethod: 'ON_DEMAND',
+            reportNotificationMethod: 'EMAIL',
+        };
+
+        // ARRANGE
+        render(<LastRunState reportStatus={reportStatus} />);
+
+        // ASSERT
+        expect(screen.getByText('Never run')).toBeDefined();
+    });
+});

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/LastRunState.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/LastRunState.tsx
@@ -1,0 +1,32 @@
+import React, { ReactElement } from 'react';
+import { ReportStatus } from 'types/report.proto';
+import { Flex, FlexItem, Spinner } from '@patternfly/react-core';
+
+import { getDateTime } from 'utils/dateUtils';
+
+type LastRunStateProps = {
+    reportStatus: ReportStatus;
+};
+
+function LastRunState({ reportStatus }: LastRunStateProps): ReactElement {
+    let statusIcon: ReactElement | null = null;
+    let statusText = '';
+
+    if (reportStatus.runState === 'SUCCESS' || reportStatus.runState === 'FAILURE') {
+        statusText = getDateTime(reportStatus.runTime);
+    } else if (reportStatus.runState === 'PREPARING') {
+        statusIcon = <Spinner isSVG size="sm" aria-label="Preparing report" />;
+        statusText = 'Preparing';
+    } else {
+        statusText = 'Never run';
+    }
+
+    return (
+        <Flex alignItems={{ default: 'alignItemsCenter' }}>
+            {statusIcon && <FlexItem>{statusIcon}</FlexItem>}
+            <FlexItem>{statusText}</FlexItem>
+        </Flex>
+    );
+}
+
+export default LastRunState;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/LastRunState.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/LastRunState.tsx
@@ -15,7 +15,7 @@ function LastRunState({ reportStatus }: LastRunStateProps): ReactElement {
     if (reportStatus.runState === 'SUCCESS' || reportStatus.runState === 'FAILURE') {
         statusText = getDateTime(reportStatus.runTime);
     } else if (reportStatus.runState === 'PREPARING') {
-        statusIcon = <Spinner isSVG size="sm" aria-label="Preparing report" />;
+        statusIcon = <Spinner isSVG size="sm" aria-label="Preparing report" aria-valuetext="" />;
         statusText = 'Preparing';
     } else {
         statusText = 'Never run';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/LastRunStatusState.test.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/LastRunStatusState.test.tsx
@@ -1,0 +1,146 @@
+import React, { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import { ReportStatus } from 'types/report.proto';
+
+import LastRunStatusState from './LastRunStatusState';
+
+describe('LastRunStatusState', () => {
+    test('should show the correct rendered output for a successful email', async () => {
+        const reportStatus: ReportStatus = {
+            runState: 'SUCCESS',
+            runTime: '2023-06-20T10:59:46.383433891Z',
+            errorMsg: '',
+            reportMethod: 'ON_DEMAND',
+            reportNotificationMethod: 'EMAIL',
+        };
+
+        // ARRANGE
+        render(<LastRunStatusState reportStatus={reportStatus} />);
+
+        // ASSERT
+        expect(screen.getByTitle('Success icon')).toBeDefined();
+        expect(screen.getByText('Emailed')).toBeDefined();
+    });
+
+    test('should show the correct rendered output for a successful download', async () => {
+        const reportStatus: ReportStatus = {
+            runState: 'SUCCESS',
+            runTime: '2023-06-20T10:59:46.383433891Z',
+            errorMsg: '',
+            reportMethod: 'ON_DEMAND',
+            reportNotificationMethod: 'DOWNLOAD',
+        };
+
+        // ARRANGE
+        render(<LastRunStatusState reportStatus={reportStatus} />);
+
+        // ASSERT
+        expect(screen.getByTitle('Success icon')).toBeDefined();
+        expect(screen.getByText('Download prepared')).toBeDefined();
+    });
+
+    test('should show the correct rendered output for a generic success', async () => {
+        const reportStatus: ReportStatus = {
+            runState: 'SUCCESS',
+            runTime: '2023-06-20T10:59:46.383433891Z',
+            errorMsg: '',
+            reportMethod: 'ON_DEMAND',
+            reportNotificationMethod: 'UNSET',
+        };
+
+        // ARRANGE
+        render(<LastRunStatusState reportStatus={reportStatus} />);
+
+        // ASSERT
+        expect(screen.getByTitle('Success icon')).toBeDefined();
+        expect(screen.getByText('Success')).toBeDefined();
+    });
+
+    test('should show the correct rendered output for an error when emailing', async () => {
+        const reportStatus: ReportStatus = {
+            runState: 'FAILURE',
+            runTime: '2023-06-20T10:59:46.383433891Z',
+            errorMsg: '',
+            reportMethod: 'ON_DEMAND',
+            reportNotificationMethod: 'EMAIL',
+        };
+
+        // ARRANGE
+        render(<LastRunStatusState reportStatus={reportStatus} />);
+
+        // ASSERT
+        expect(screen.getByTitle('Error icon')).toBeDefined();
+        expect(screen.getByText('Email attempted')).toBeDefined();
+    });
+
+    test('should show the correct rendered output for an error when preparing a download', async () => {
+        const reportStatus: ReportStatus = {
+            runState: 'FAILURE',
+            runTime: '2023-06-20T10:59:46.383433891Z',
+            errorMsg: '',
+            reportMethod: 'ON_DEMAND',
+            reportNotificationMethod: 'DOWNLOAD',
+        };
+
+        // ARRANGE
+        render(<LastRunStatusState reportStatus={reportStatus} />);
+
+        // ASSERT
+        expect(screen.getByTitle('Error icon')).toBeDefined();
+        expect(screen.getByText('Failed to generate download')).toBeDefined();
+    });
+
+    test('should show the correct rendered output for a generic error', async () => {
+        const reportStatus: ReportStatus = {
+            runState: 'FAILURE',
+            runTime: '2023-06-20T10:59:46.383433891Z',
+            errorMsg: '',
+            reportMethod: 'ON_DEMAND',
+            reportNotificationMethod: 'UNSET',
+        };
+
+        // ARRANGE
+        render(<LastRunStatusState reportStatus={reportStatus} />);
+
+        // ASSERT
+        expect(screen.getByTitle('Error icon')).toBeDefined();
+        expect(screen.getByText('Error')).toBeDefined();
+    });
+
+    test('should show the correct rendered output for waiting for a report', async () => {
+        const reportStatus: ReportStatus = {
+            runState: 'WAITING',
+            runTime: '2023-06-20T10:59:46.383433891Z',
+            errorMsg: '',
+            reportMethod: 'ON_DEMAND',
+            reportNotificationMethod: 'DOWNLOAD',
+        };
+
+        // ARRANGE
+        render(<LastRunStatusState reportStatus={reportStatus} />);
+
+        // ASSERT
+        expect(screen.queryByTitle('Success icon')).toBeNull();
+        expect(screen.queryByTitle('Error icon')).toBeNull();
+        expect(screen.getByText('-')).toBeDefined();
+    });
+
+    test('should show the correct rendered output for preparing a report', async () => {
+        const reportStatus: ReportStatus = {
+            runState: 'PREPARING',
+            runTime: '2023-06-20T10:59:46.383433891Z',
+            errorMsg: '',
+            reportMethod: 'ON_DEMAND',
+            reportNotificationMethod: 'DOWNLOAD',
+        };
+
+        // ARRANGE
+        render(<LastRunStatusState reportStatus={reportStatus} />);
+
+        // ASSERT
+        expect(screen.queryByTitle('Success icon')).toBeNull();
+        expect(screen.queryByTitle('Error icon')).toBeNull();
+        expect(screen.getByText('-')).toBeDefined();
+    });
+});

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/LastRunStatusState.test.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/LastRunStatusState.test.tsx
@@ -19,7 +19,7 @@ describe('LastRunStatusState', () => {
         render(<LastRunStatusState reportStatus={reportStatus} />);
 
         // ASSERT
-        expect(screen.getByTitle('Success icon')).toBeDefined();
+        expect(screen.getByTitle('Report run was successful')).toBeDefined();
         expect(screen.getByText('Emailed')).toBeDefined();
     });
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/LastRunStatusState.test.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/LastRunStatusState.test.tsx
@@ -36,7 +36,7 @@ describe('LastRunStatusState', () => {
         render(<LastRunStatusState reportStatus={reportStatus} />);
 
         // ASSERT
-        expect(screen.getByTitle('Success icon')).toBeDefined();
+        expect(screen.getByTitle('Report run was successful')).toBeDefined();
         expect(screen.getByText('Download prepared')).toBeDefined();
     });
 
@@ -53,7 +53,7 @@ describe('LastRunStatusState', () => {
         render(<LastRunStatusState reportStatus={reportStatus} />);
 
         // ASSERT
-        expect(screen.getByTitle('Success icon')).toBeDefined();
+        expect(screen.getByTitle('Report run was successful')).toBeDefined();
         expect(screen.getByText('Success')).toBeDefined();
     });
 
@@ -70,7 +70,7 @@ describe('LastRunStatusState', () => {
         render(<LastRunStatusState reportStatus={reportStatus} />);
 
         // ASSERT
-        expect(screen.getByTitle('Error icon')).toBeDefined();
+        expect(screen.getByTitle('Report run was unsuccessful')).toBeDefined();
         expect(screen.getByText('Email attempted')).toBeDefined();
     });
 
@@ -87,7 +87,7 @@ describe('LastRunStatusState', () => {
         render(<LastRunStatusState reportStatus={reportStatus} />);
 
         // ASSERT
-        expect(screen.getByTitle('Error icon')).toBeDefined();
+        expect(screen.getByTitle('Report run was unsuccessful')).toBeDefined();
         expect(screen.getByText('Failed to generate download')).toBeDefined();
     });
 
@@ -104,7 +104,7 @@ describe('LastRunStatusState', () => {
         render(<LastRunStatusState reportStatus={reportStatus} />);
 
         // ASSERT
-        expect(screen.getByTitle('Error icon')).toBeDefined();
+        expect(screen.getByTitle('Report run was unsuccessful')).toBeDefined();
         expect(screen.getByText('Error')).toBeDefined();
     });
 
@@ -121,8 +121,8 @@ describe('LastRunStatusState', () => {
         render(<LastRunStatusState reportStatus={reportStatus} />);
 
         // ASSERT
-        expect(screen.queryByTitle('Success icon')).toBeNull();
-        expect(screen.queryByTitle('Error icon')).toBeNull();
+        expect(screen.queryByTitle('Report run was successful')).toBeNull();
+        expect(screen.queryByTitle('Report run was unsuccessful')).toBeNull();
         expect(screen.getByText('-')).toBeDefined();
     });
 
@@ -139,8 +139,8 @@ describe('LastRunStatusState', () => {
         render(<LastRunStatusState reportStatus={reportStatus} />);
 
         // ASSERT
-        expect(screen.queryByTitle('Success icon')).toBeNull();
-        expect(screen.queryByTitle('Error icon')).toBeNull();
+        expect(screen.queryByTitle('Report run was successful')).toBeNull();
+        expect(screen.queryByTitle('Report run was unsuccessful')).toBeNull();
         expect(screen.getByText('-')).toBeDefined();
     });
 });

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/LastRunStatusState.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/LastRunStatusState.tsx
@@ -18,12 +18,12 @@ function LastRunStatusState({ reportStatus }: LastRunStatusStateProps): ReactEle
     let statusText = '-';
 
     if (reportStatus.runState === 'SUCCESS') {
-        statusIcon = <CheckCircleIcon color={successColor} />;
+        statusIcon = <CheckCircleIcon color={successColor} title="Success icon" />;
     }
     if (reportStatus.runState === 'FAILURE') {
         statusIcon = (
             <Tooltip content={reportStatus.errorMsg || genericMsg}>
-                <ExclamationCircleIcon color={errorColor} />
+                <ExclamationCircleIcon color={errorColor} title="Error icon" />
             </Tooltip>
         );
     }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/LastRunStatusState.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/LastRunStatusState.tsx
@@ -1,0 +1,62 @@
+import React, { ReactElement } from 'react';
+import { ReportStatus } from 'types/report.proto';
+import { CheckCircleIcon, ExclamationCircleIcon } from '@patternfly/react-icons';
+import { Flex, FlexItem, Tooltip } from '@patternfly/react-core';
+
+type LastRunStatusStateProps = {
+    reportStatus: ReportStatus;
+};
+
+const errorColor = 'var(--pf-global--danger-color--100)';
+const successColor = 'var(--pf-global--success-color--100)';
+
+const genericMsg =
+    'An issue was encountered. Please try again later. If the issue persists, please contact support';
+
+function LastRunStatusState({ reportStatus }: LastRunStatusStateProps): ReactElement {
+    let statusIcon: ReactElement | null = null;
+    let statusText = '-';
+
+    if (reportStatus.runState === 'SUCCESS') {
+        statusIcon = <CheckCircleIcon color={successColor} />;
+    }
+    if (reportStatus.runState === 'FAILURE') {
+        statusIcon = (
+            <Tooltip content={reportStatus.errorMsg || genericMsg}>
+                <ExclamationCircleIcon color={errorColor} />
+            </Tooltip>
+        );
+    }
+
+    if (reportStatus.runState === 'SUCCESS' && reportStatus.reportNotificationMethod === 'EMAIL') {
+        statusText = 'Emailed';
+    } else if (
+        reportStatus.runState === 'SUCCESS' &&
+        reportStatus.reportNotificationMethod === 'DOWNLOAD'
+    ) {
+        statusText = 'Download prepared';
+    } else if (
+        reportStatus.runState === 'FAILURE' &&
+        reportStatus.reportNotificationMethod === 'EMAIL'
+    ) {
+        statusText = 'Email attempted';
+    } else if (
+        reportStatus.runState === 'FAILURE' &&
+        reportStatus.reportNotificationMethod === 'DOWNLOAD'
+    ) {
+        statusText = 'Failed to generate download';
+    } else if (reportStatus.runState === 'SUCCESS') {
+        statusText = 'Success';
+    } else if (reportStatus.runState === 'FAILURE') {
+        statusText = 'Error';
+    }
+
+    return (
+        <Flex alignItems={{ default: 'alignItemsCenter' }}>
+            {statusIcon && <FlexItem>{statusIcon}</FlexItem>}
+            <FlexItem>{statusText}</FlexItem>
+        </Flex>
+    );
+}
+
+export default LastRunStatusState;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/LastRunStatusState.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/LastRunStatusState.tsx
@@ -3,7 +3,7 @@ import { ReportStatus } from 'types/report.proto';
 import { CheckCircleIcon, ExclamationCircleIcon } from '@patternfly/react-icons';
 import { Flex, FlexItem, Tooltip } from '@patternfly/react-core';
 
-type LastRunStatusStateProps = {
+export type LastRunStatusStateProps = {
     reportStatus: ReportStatus;
 };
 
@@ -18,12 +18,12 @@ function LastRunStatusState({ reportStatus }: LastRunStatusStateProps): ReactEle
     let statusText = '-';
 
     if (reportStatus.runState === 'SUCCESS') {
-        statusIcon = <CheckCircleIcon color={successColor} title="Success icon" />;
+        statusIcon = <CheckCircleIcon color={successColor} title="Report run was successful" />;
     }
     if (reportStatus.runState === 'FAILURE') {
         statusIcon = (
             <Tooltip content={reportStatus.errorMsg || genericMsg}>
-                <ExclamationCircleIcon color={errorColor} title="Error icon" />
+                <ExclamationCircleIcon color={errorColor} title="Report run was unsuccessful" />
             </Tooltip>
         );
     }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/VulnReportsPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/VulnReportsPage.tsx
@@ -1,8 +1,74 @@
 import React from 'react';
-import { PageSection, Title, Divider, Flex, FlexItem, Button } from '@patternfly/react-core';
+import {
+    PageSection,
+    Title,
+    Divider,
+    Flex,
+    FlexItem,
+    Button,
+    Card,
+    CardBody,
+} from '@patternfly/react-core';
+import { TableComposable, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+
+import { ReportConfiguration } from 'types/reportConfigurationService.proto';
+import { ReportStatus } from 'types/report.proto';
+import { Report } from 'Containers/Vulnerabilities/VulnerablityReporting/types';
+import usePermissions from 'hooks/usePermissions';
 
 import PageTitle from 'Components/PageTitle';
-import usePermissions from 'hooks/usePermissions';
+import HelpIconTh from './HelpIconTh';
+import LastRunStatusState from './LastRunStatusState';
+import LastRunState from './LastRunState';
+
+const reportConfigurations: ReportConfiguration[] = [
+    {
+        id: '1',
+        name: 'bob-report-1',
+        description: '',
+        type: 'VULNERABILITY',
+        vulnReportFilters: {
+            fixability: 'FIXABLE',
+            severities: ['CRITICAL_VULNERABILITY_SEVERITY', 'IMPORTANT_VULNERABILITY_SEVERITY'],
+            imageTypes: ['DEPLOYED', 'WATCHED'],
+            allVuln: true,
+        },
+        emailConfig: {
+            notifierId: 'notifier-1',
+            mailingLists: ['bob@example.com', 'alice@example.com'],
+        },
+        resourceScope: {
+            collectionScope: {
+                collectionId: 'collection-1',
+                collectionName: 'bob-collection-1',
+            },
+        },
+        schedule: {
+            intervalType: 'WEEKLY',
+            hour: 10,
+            minute: 0,
+            daysOfWeek: {
+                days: ['0', '1', '2', '3', '4', '5', '6'],
+            },
+        },
+    },
+];
+
+const reportStatus: ReportStatus = {
+    runState: 'SUCCESS',
+    runTime: '2023-06-20T10:59:46.383433891Z',
+    errorMsg: '',
+    reportMethod: 'ON_DEMAND',
+    reportNotificationMethod: 'DOWNLOAD',
+};
+
+const reportLastRunStatus: ReportStatus = {
+    runState: 'FAILURE',
+    runTime: '2023-06-20T10:59:46.383433891Z',
+    errorMsg: 'Failed to generate download, please try again',
+    reportMethod: 'ON_DEMAND',
+    reportNotificationMethod: 'DOWNLOAD',
+};
 
 function VulnReportsPage() {
     const { hasReadWriteAccess, hasReadAccess } = usePermissions();
@@ -17,6 +83,13 @@ function VulnReportsPage() {
         hasAccessScopeReadAccess &&
         hasNotifierIntegrationReadAccess;
 
+    const reports = reportConfigurations.map((reportConfiguration): Report => {
+        return {
+            ...reportConfiguration,
+            reportStatus,
+            reportLastRunStatus,
+        };
+    });
     return (
         <>
             <PageTitle title="Vulnerability reporting" />
@@ -47,7 +120,59 @@ function VulnReportsPage() {
                     </FlexItem>
                 </Flex>
             </PageSection>
-            <PageSection padding={{ default: 'noPadding' }} />
+            <PageSection padding={{ default: 'noPadding' }}>
+                <PageSection isCenterAligned>
+                    <Card>
+                        <CardBody className="pf-u-p-0">
+                            <TableComposable borders={false}>
+                                <Thead noWrap>
+                                    <Tr>
+                                        <Th>Report</Th>
+                                        <HelpIconTh tooltip="A set of user-configured rules for selecting deployments as part of the report scope">
+                                            Collection
+                                        </HelpIconTh>
+                                        <Th>Last run status</Th>
+                                        <HelpIconTh tooltip="The report that was last run by a schedule or an on-demand action including 'send report now' and 'generate a downloadable report'">
+                                            Last run
+                                        </HelpIconTh>
+                                    </Tr>
+                                </Thead>
+                                {reports.map((report) => {
+                                    return (
+                                        <Tbody
+                                            key={report.id}
+                                            style={{
+                                                borderBottom:
+                                                    '1px solid var(--pf-c-table--BorderColor)',
+                                            }}
+                                        >
+                                            <Tr>
+                                                <Td>{report.name}</Td>
+                                                <Td>
+                                                    {
+                                                        report.resourceScope.collectionScope
+                                                            .collectionName
+                                                    }
+                                                </Td>
+                                                <Td>
+                                                    <LastRunStatusState
+                                                        reportStatus={report.reportLastRunStatus}
+                                                    />
+                                                </Td>
+                                                <Td>
+                                                    <LastRunState
+                                                        reportStatus={report.reportStatus}
+                                                    />
+                                                </Td>
+                                            </Tr>
+                                        </Tbody>
+                                    );
+                                })}
+                            </TableComposable>
+                        </CardBody>
+                    </Card>
+                </PageSection>
+            </PageSection>
         </>
     );
 }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/VulnReportsPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/VulnReportsPage.tsx
@@ -48,7 +48,7 @@ const reportConfigurations: ReportConfiguration[] = [
             hour: 10,
             minute: 0,
             daysOfWeek: {
-                days: ['0', '1', '2', '3', '4', '5', '6'],
+                days: [0, 1, 2, 3, 4, 5, 6],
             },
         },
     },

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/types.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/types.ts
@@ -1,0 +1,7 @@
+import { ReportConfiguration } from 'types/reportConfigurationService.proto';
+import { ReportStatus } from 'types/report.proto';
+
+export type Report = ReportConfiguration & {
+    reportStatus: ReportStatus;
+    reportLastRunStatus: ReportStatus;
+};

--- a/ui/apps/platform/src/services/ReportsService.ts
+++ b/ui/apps/platform/src/services/ReportsService.ts
@@ -1,6 +1,7 @@
 import queryString from 'qs';
 
-import { ReportConfiguration } from 'types/report.proto';
+import { ReportConfiguration as ReportConfigurationV1 } from 'types/report.proto';
+import { ReportConfiguration } from 'types/reportConfigurationService.proto';
 import searchOptionsToQuery, { RestSearchOption } from 'services/searchOptionsToQuery';
 import { ApiSortOption } from 'types/search';
 import axios from './instance';
@@ -16,7 +17,7 @@ export function fetchReports(
     sortOption: ApiSortOption,
     page: number,
     pageSize: number
-): Promise<ReportConfiguration[]> {
+): Promise<ReportConfigurationV1[]> {
     const offset = page * pageSize;
     const searchOptions: RestSearchOption[] = [...options];
     const query = searchOptionsToQuery(searchOptions);
@@ -32,7 +33,7 @@ export function fetchReports(
     }
     const params = queryString.stringify(queryObject, { arrayFormat: 'repeat', allowDots: true });
     return axios
-        .get<{ reportConfigs: ReportConfiguration[] }>(`${reportConfigurationsUrl}?${params}`)
+        .get<{ reportConfigs: ReportConfigurationV1[] }>(`${reportConfigurationsUrl}?${params}`)
         .then((response) => {
             return response?.data?.reportConfigs ?? [];
         });
@@ -58,22 +59,22 @@ export function fetchReportsCount(options: RestSearchOption[] = []): Promise<num
         });
 }
 
-export function fetchReportById(reportId: string): Promise<ReportConfiguration> {
+export function fetchReportById(reportId: string): Promise<ReportConfigurationV1> {
     return axios
-        .get<{ reportConfig: ReportConfiguration }>(`${reportConfigurationsUrl}/${reportId}`)
+        .get<{ reportConfig: ReportConfigurationV1 }>(`${reportConfigurationsUrl}/${reportId}`)
         .then((response) => {
             return response?.data?.reportConfig ?? {};
         });
 }
 
-export function saveReport(report: ReportConfiguration): Promise<ReportConfiguration> {
+export function saveReport(report: ReportConfigurationV1): Promise<ReportConfigurationV1> {
     const apiPayload = {
         reportConfig: report,
     };
 
     const promise = report.id
-        ? axios.put<ReportConfiguration>(`${reportConfigurationsUrl}/${report.id}`, apiPayload)
-        : axios.post<ReportConfiguration>(reportConfigurationsUrl, apiPayload);
+        ? axios.put<ReportConfigurationV1>(`${reportConfigurationsUrl}/${report.id}`, apiPayload)
+        : axios.post<ReportConfigurationV1>(reportConfigurationsUrl, apiPayload);
 
     return promise.then((response) => {
         return response.data;
@@ -86,4 +87,14 @@ export function deleteReport(reportId: string): Promise<Empty> {
 
 export function runReport(reportId: string): Promise<Empty> {
     return axios.post(`${reportServiceUrl}/${reportId}`);
+}
+
+// The following functions are built around the new VM Reporting Enhancements
+
+export function fetchReportConfigurations(): Promise<ReportConfiguration[]> {
+    return axios
+        .get<{ reportConfigs: ReportConfiguration[] }>('/v2/reports/configurations')
+        .then((response) => {
+            return response?.data?.reportConfigs ?? [];
+        });
 }

--- a/ui/apps/platform/src/types/report.proto.ts
+++ b/ui/apps/platform/src/types/report.proto.ts
@@ -59,3 +59,18 @@ export type DaysOfWeek = {
 export type DaysOfMonth = {
     days: string[]; // int32
 };
+
+// For v2 of Vulnerability Reporting
+export type ReportStatus = {
+    runState: RunState;
+    runTime: string; // in the format of google.protobuf.Timestamp};
+    errorMsg: string;
+    reportMethod: ReportMethod;
+    reportNotificationMethod: NotificationMethod;
+};
+
+export type RunState = 'WAITING' | 'PREPARING' | 'SUCCESS' | 'FAILURE';
+
+export type ReportMethod = 'ON_DEMAND' | 'SCHEDULED';
+
+export type NotificationMethod = 'UNSET' | 'EMAIL' | 'DOWNLOAD';

--- a/ui/apps/platform/src/types/reportConfigurationService.proto.ts
+++ b/ui/apps/platform/src/types/reportConfigurationService.proto.ts
@@ -1,0 +1,85 @@
+import { VulnerabilitySeverity } from './cve.proto';
+
+export type ReportType = 'VULNERABILITY';
+
+export type ReportConfiguration = {
+    id: string;
+    name: string;
+    description: string;
+    type: ReportType;
+    vulnReportFilters: VulnerabilityReportFilters;
+    emailConfig: EmailNotifierConfiguration;
+    schedule: Schedule;
+    resourceScope: ResourceScope;
+};
+
+type VulnerabilityReportFiltersBase = {
+    fixability: Fixability;
+    severities: VulnerabilitySeverity[];
+    imageTypes: ImageType[];
+};
+
+export type VulnerabilityReportFilters =
+    | (VulnerabilityReportFiltersBase & {
+          allVuln: boolean;
+      })
+    | (VulnerabilityReportFiltersBase & {
+          lastSuccessfulReport: boolean;
+      })
+    | (VulnerabilityReportFiltersBase & {
+          startDate: string; // in the format of google.protobuf.Timestamp};
+      });
+
+export type Fixability = 'BOTH' | 'FIXABLE' | 'NOT_FIXABLE';
+
+export type ImageType = 'DEPLOYED' | 'WATCHED';
+
+export type EmailNotifierConfiguration = {
+    notifierId: string;
+    mailingLists: string[];
+};
+
+type ScheduleBase = {
+    intervalType: IntervalType;
+    hour: number;
+    minute: number;
+};
+
+export type Schedule =
+    | (ScheduleBase & {
+          weekly: WeeklyInterval;
+      })
+    | (ScheduleBase & {
+          daysOfWeek: DaysOfWeek;
+      })
+    | (ScheduleBase & {
+          daysOfMonth: DaysOfMonth;
+      });
+
+export type IntervalType = 'UNSET' | 'DAILY' | 'WEEKLY' | 'MONTHLY';
+
+export type Interval = DaysOfWeek | DaysOfMonth;
+
+// TODO - Note that the types of `days` below are not exact, the API returns `number[]`, but the UI converts
+// them to strings. This doesn't seem to be a problem, but it's worth noting.
+
+export type WeeklyInterval = {
+    day: string; // int32
+};
+
+// Sunday = 0, Monday = 1, .... Saturday =  6
+export type DaysOfWeek = {
+    days: string[]; // int32
+};
+
+// 1 for 1st, 2 for 2nd .... 31 for 31st
+export type DaysOfMonth = {
+    days: string[]; // int32
+};
+
+export type ResourceScope = {
+    collectionScope: {
+        collectionId: string;
+        collectionName: string;
+    };
+};

--- a/ui/apps/platform/src/types/reportConfigurationService.proto.ts
+++ b/ui/apps/platform/src/types/reportConfigurationService.proto.ts
@@ -1,3 +1,5 @@
+// @TODO: Colocate types from API calls with the function that made the API call
+
 import { VulnerabilitySeverity } from './cve.proto';
 
 export type ReportType = 'VULNERABILITY';
@@ -60,21 +62,18 @@ export type IntervalType = 'UNSET' | 'DAILY' | 'WEEKLY' | 'MONTHLY';
 
 export type Interval = DaysOfWeek | DaysOfMonth;
 
-// TODO - Note that the types of `days` below are not exact, the API returns `number[]`, but the UI converts
-// them to strings. This doesn't seem to be a problem, but it's worth noting.
-
 export type WeeklyInterval = {
-    day: string; // int32
+    day: number; // int32
 };
 
 // Sunday = 0, Monday = 1, .... Saturday =  6
 export type DaysOfWeek = {
-    days: string[]; // int32
+    days: number[]; // int32
 };
 
 // 1 for 1st, 2 for 2nd .... 31 for 31st
 export type DaysOfMonth = {
-    days: string[]; // int32
+    days: number[]; // int32
 };
 
 export type ResourceScope = {


### PR DESCRIPTION
## Description

This PR adds a simple version of the table to be used to display the reports. I added one report to the table to show an example of what will be displayed. The error icon in the "Last run status" column will display a tooltip with the error message. If, for some reason, no error message is populated then we'll use a generic error message. Also, note that we will be merging the report configuration with the last run report status and the report status to display in the table. I added types for each and a merged type as well

<img width="1552" alt="Screenshot 2023-06-20 at 11 55 56 AM" src="https://github.com/stackrox/stackrox/assets/4805485/5ee24eb1-554c-4f37-993c-5c4f34e7607a">
<img width="1440" alt="Screenshot 2023-06-20 at 7 45 41 PM" src="https://github.com/stackrox/stackrox/assets/4805485/c3fe9c39-6389-4832-a9f6-890379bdf3dd">

