### PR TITLE
chore(e2e): Update cypress 12.15.0 devDependencies in ui

### DIFF
--- a/ui/apps/platform/package.json
+++ b/ui/apps/platform/package.json
@@ -140,7 +140,7 @@
         "@types/segment-analytics": "^0.0.34",
         "autoprefixer": "^10.2.5",
         "babel-eslint": "^10.1.0",
-        "cypress": "^12.14.0",
+        "cypress": "^12.15.0",
         "eslint": "^7.32.0",
         "eslint-config-airbnb": "^18.2.1",
         "eslint-config-airbnb-typescript": "12.3.1",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -7340,10 +7340,10 @@ cyclist@^1.0.1:
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
 
-cypress@^12.14.0:
-  version "12.14.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-12.14.0.tgz#37a19b85f5e9d881995e9fee1ddf41b3d3a623dd"
-  integrity sha512-HiLIXKXZaIT1RT7sw1sVPt+qKtis3uYNm6KwC4qoYjabwLKaqZlyS/P+uVvvlBNcHIwL/BC6nQZajpbUd7hOgQ==
+cypress@^12.15.0:
+  version "12.15.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-12.15.0.tgz#06103529583c41f39712c6cfa6d9d09a01731760"
+  integrity sha512-FqGbxsH+QgjStuTO9onXMIeF44eOrgVwPvlcvuzLIaePQMkl72YgBvpuHlBGRcrw3Q4SvqKfajN8iV5XWShAiQ==
   dependencies:
     "@cypress/request" "^2.88.10"
     "@cypress/xvfb" "^1.2.4"


### PR DESCRIPTION
## Description

https://docs.cypress.io/guides/references/changelog#12-15-0

1. Added support for running Cypress tests with Chrome's new `--headless=new` flag. Chrome versions 112 and above will now be run in the `headless` mode that matches the headed browser implementation.

    CI uses Electron 106 (headless). Investigate whether this feature is relevant.

2. The `videoCompression` configuration option now accepts both a boolean or a Constant Rate Factor (CRF) number between `1` and `51`. The videoCompression default value is still `32` CRF and when `videoCompression` is set to `true` the default of 32 CRF will be used.

    Investigate whether this feature is relevant for EPIPE failures on CI during video compression.

3. Removed `cypress/mocha-teamcity-reporter` as this package was no longer being referenced.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

1. `yarn start` in ui
2. `yarn cypress-open` in ui/apps/platform

    * vulnerabilities/workloadCves/imageCveSingle.test.js
    * vulnerabilities/workloadCves/workloadTableToolbar.test.js