### PR TITLE
ROX-17963: Make service auth thread safe

### DIFF
--- a/qa-tests-backend/src/main/groovy/services/BaseService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/BaseService.groovy
@@ -130,7 +130,7 @@ class BaseService {
             effectiveChannel.set(null)
         }
 
-        if (authInterceptor == null) {
+        if (authInterceptor.get() == null) {
             effectiveChannel.set(transportChannel.get())
         } else {
             effectiveChannel.set(ClientInterceptors.intercept(transportChannel.get(), authInterceptor.get()))

--- a/qa-tests-backend/src/main/groovy/services/BaseService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/BaseService.groovy
@@ -116,7 +116,7 @@ class BaseService {
             SslContextBuilder sslContextBuilder = GrpcSslContexts
                     .forClient()
                     .trustManager(InsecureTrustManagerFactory.INSTANCE)
-            if (useClientCert) {
+            if (useClientCert.get()) {
                 sslContextBuilder = sslContextBuilder.keyManager(Keys.keyManagerFactory())
             }
             def sslContext = sslContextBuilder.build()

--- a/qa-tests-backend/src/main/groovy/services/BaseService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/BaseService.groovy
@@ -133,7 +133,7 @@ class BaseService {
         if (authInterceptor == null) {
             effectiveChannel.set(transportChannel.get())
         } else {
-            effectiveChannel.set(ClientInterceptors.intercept(transportChannel.get(), authInterceptor))
+            effectiveChannel.set(ClientInterceptors.intercept(transportChannel.get(), authInterceptor.get()))
         }
     }
 

--- a/qa-tests-backend/src/main/groovy/services/BaseService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/BaseService.groovy
@@ -104,10 +104,12 @@ class BaseService {
         }
     }
 
-    static ThreadLocal<ManagedChannel> transportChannel = ThreadLocal.withInitial(() -> null)
-    static ThreadLocal<ClientInterceptor> authInterceptor = ThreadLocal.withInitial(() -> null)
-    static ThreadLocal<Channel> effectiveChannel = ThreadLocal.withInitial(() -> null)
-    private static ThreadLocal<boolean> useClientCert = ThreadLocal.withInitial(() -> false)
+    // codenarc-disable FieldName
+    private static final ThreadLocal<ManagedChannel> transportChannel = ThreadLocal.withInitial(() -> null)
+    private static final ThreadLocal<ClientInterceptor> authInterceptor = ThreadLocal.withInitial(() -> null)
+    private static final ThreadLocal<Channel> effectiveChannel = ThreadLocal.withInitial(() -> null)
+    private static final ThreadLocal<boolean> useClientCert = ThreadLocal.withInitial(() -> false)
+    // codenarc-enable FieldName
 
     static initializeChannel() {
         if (transportChannel.get() == null) {

--- a/qa-tests-backend/src/main/groovy/services/BaseService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/BaseService.groovy
@@ -1,5 +1,6 @@
 package services
 
+import groovy.transform.CompileStatic
 import groovy.transform.EqualsAndHashCode
 import io.grpc.CallOptions
 import io.grpc.Channel
@@ -19,10 +20,11 @@ import io.stackrox.proto.api.v1.EmptyOuterClass
 import util.Env
 import util.Keys
 
+@CompileStatic
 class BaseService {
 
-    static final BASIC_AUTH_USERNAME = Env.mustGetUsername()
-    static final BASIC_AUTH_PASSWORD = Env.mustGetPassword()
+    static final String BASIC_AUTH_USERNAME = Env.mustGetUsername()
+    static final String BASIC_AUTH_PASSWORD = Env.mustGetPassword()
 
     static final EMPTY = EmptyOuterClass.Empty.newBuilder().build()
 
@@ -42,11 +44,11 @@ class BaseService {
         updateAuthConfig(useClientCert.get(), null)
     }
 
-    static setUseClientCert(boolean use) {
+    static setUseClientCert(Boolean use) {
         updateAuthConfig(use, authInterceptor.get())
     }
 
-    private static updateAuthConfig(boolean newUseClientCert, ClientInterceptor newAuthInterceptor) {
+    private static updateAuthConfig(Boolean newUseClientCert, ClientInterceptor newAuthInterceptor) {
         if (useClientCert.get() == newUseClientCert && authInterceptor.get() == newAuthInterceptor) {
             return
         }
@@ -108,7 +110,7 @@ class BaseService {
     private static final ThreadLocal<ManagedChannel> transportChannel = ThreadLocal.withInitial(() -> null)
     private static final ThreadLocal<ClientInterceptor> authInterceptor = ThreadLocal.withInitial(() -> null)
     private static final ThreadLocal<Channel> effectiveChannel = ThreadLocal.withInitial(() -> null)
-    private static final ThreadLocal<boolean> useClientCert = ThreadLocal.withInitial(() -> false)
+    private static final ThreadLocal<Boolean> useClientCert = ThreadLocal.withInitial(() -> false)
     // codenarc-enable FieldName
 
     static initializeChannel() {

--- a/qa-tests-backend/src/test/groovy/AuthServiceTest.groovy
+++ b/qa-tests-backend/src/test/groovy/AuthServiceTest.groovy
@@ -48,8 +48,7 @@ class AuthServiceTest extends BaseSpecification {
 
     def "Verify response for auth token"() {
         when:
-        Assume.assumeTrue(allAccessToken != null)
-        BaseService.useApiToken(allAccessToken)
+        useTokenServiceAuth()
 
         AuthServiceOuterClass.AuthStatus status = AuthService.getAuthStatus()
 

--- a/qa-tests-backend/src/test/groovy/AuthServiceTest.groovy
+++ b/qa-tests-backend/src/test/groovy/AuthServiceTest.groovy
@@ -4,7 +4,6 @@ import io.stackrox.proto.storage.RoleOuterClass
 import services.AuthService
 import services.BaseService
 
-import org.junit.Assume
 import spock.lang.Tag
 
 @Tag("BAT")

--- a/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
+++ b/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
@@ -151,6 +151,7 @@ class BaseSpecification extends Specification {
         }
 
         allAccessToken = tokenResp.token
+        assert allAccessToken
 
         setupCoreImageIntegration()
 
@@ -267,20 +268,26 @@ class BaseSpecification extends Specification {
         ]
     }
 
-    def resetAuth() {
+    // useDesiredServiceAuth() - configure the central gRPC connection auth as
+    // desired for test.
+    def useDesiredServiceAuth() {
         BaseService.setUseClientCert(false)
-        if (allAccessToken) {
-            BaseService.useApiToken(allAccessToken)
-        } else {
-            BaseService.useBasicAuth()
-        }
+        useTokenServiceAuth()
+    }
+
+    // useTokenServiceAuth() - configure the central gRPC connection auth to
+    // use an all access token.
+    def useTokenServiceAuth() {
+        assert allAccessToken
+        BaseService.useApiToken(allAccessToken)
     }
 
     def setup() {
         log.info("Starting testcase")
 
-        //Always make sure to revert back to the allAccessToken before each test
-        resetAuth()
+        // Make sure to use or revert back to the desired central gRPC auth
+        // before each test.
+        useDesiredServiceAuth()
 
         if (ClusterService.isEKS() && System.currentTimeSeconds() > orchestratorCreateTime + 600) {
             // Avoid EKS k8s client time out which occurs at approx. 15 minutes.

--- a/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
+++ b/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
@@ -150,6 +150,7 @@ class BaseSpecification extends Specification {
             tokenResp = services.ApiTokenService.generateToken("allAccessToken-${RUN_ID}", testRoleName)
         }
 
+        assert tokenResp
         allAccessToken = tokenResp.token
         assert allAccessToken
 

--- a/qa-tests-backend/src/test/groovy/RbacAuthTest.groovy
+++ b/qa-tests-backend/src/test/groovy/RbacAuthTest.groovy
@@ -97,7 +97,7 @@ spec:
                 throw ex
             }
         } finally {
-            resetAuth()
+            useDesiredServiceAuth()
         }
         return true
     }
@@ -109,7 +109,7 @@ spec:
         try {
             return RoleService.myPermissions()
         } finally {
-            resetAuth()
+            useDesiredServiceAuth()
         }
     }
 
@@ -142,7 +142,7 @@ spec:
         }
 
         cleanup:
-        resetAuth()
+        useDesiredServiceAuth()
 
         "remove role and token"
         if (resourceAccess.containsKey("NetworkPolicy") &&


### PR DESCRIPTION
## Description

This PR changes BaseService.groovy, the class that manages the central gRPC channel for test, to use ThreadLocal vars for static state. Which helps prepare for groovy tests to run concurrently.

## Checklist
- [x] Investigated and inspected CI test results - the test failure is a flake unrelated to this change.

## Testing Performed

CI is sufficient - ci-all-qa-tests - this ensures that the changes are benign at this point i.e. before tests actually run in parallel. Experimentation in https://github.com/gavin-stackrox/spock-example/blob/master/src/test/groovy/stackrox/BaseService.groovy confirms it as a reasonable way to provide thread local state.