### PR TITLE
ROX-17497: Make globalSetup() thread safe

### DIFF
--- a/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
+++ b/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
@@ -70,7 +70,7 @@ class BaseSpecification extends Specification {
 
     public static String coreImageIntegrationId = null
 
-    private static globalSetup() {
+    private static synchronized globalSetup() {
         if (globalSetupDone) {
             return
         }

--- a/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
+++ b/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
@@ -70,7 +70,13 @@ class BaseSpecification extends Specification {
 
     public static String coreImageIntegrationId = null
 
-    private static synchronized globalSetup() {
+    private static synchronizedGlobalSetup() {
+        synchronized(BaseSpecification) {
+            globalSetup()
+        }
+    }
+
+    private static globalSetup() {
         if (globalSetupDone) {
             return
         }
@@ -212,7 +218,7 @@ class BaseSpecification extends Specification {
 
         testSpecStartTimeMillis = System.currentTimeMillis()
 
-        globalSetup()
+        synchronizedGlobalSetup()
 
         BaseService.useBasicAuth()
         BaseService.setUseClientCert(false)


### PR DESCRIPTION
## Description

Per title. This helps prepare for groovy tests to run concurrently. The test failure is from a flake unrelated to this change.

## Checklist
- [x] Investigated and inspected CI test results - the test failure is a flake unrelated to this change.

## Testing Performed

CI is sufficient - and ensures that the changes are benign at this point i.e. before tests actually run in parallel. Experimentation in https://github.com/gavin-stackrox/spock-example/blob/abd5082887c1f7687875b35c5e80ddeb86e3d60a/src/test/groovy/stackrox/BaseSpecification.groovy#L57 show using `synchonized()` in this manner works as desired.