### PR TITLE
ROX-17159: ExternalNetworkSourcesTest fix double deletion

### DIFF
--- a/qa-tests-backend/src/test/groovy/ExternalNetworkSourcesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ExternalNetworkSourcesTest.groovy
@@ -169,7 +169,6 @@ class ExternalNetworkSourcesTest extends BaseSpecification {
 
         cleanup:
         deleteNetworkEntity(externalSource30ID)
-        deleteNetworkEntity(externalSource31ID)
     }
 
     @Tag("NetworkFlowVisualization")


### PR DESCRIPTION
## Description

This is a follow-up from #6570 where we introduced a failure in the tests if the external entity isn't deleted, but there was one case where the entity was deleted both in the tests and the cleanup. Causing the second deletion to fail. 

## Checklist
- [x] Investigated and inspected CI test results
- [ ] ~~Unit test and regression tests added~~
- [ ] ~~Evaluated and added CHANGELOG entry if required~~
- [ ] ~~Determined and documented upgrade steps~~
- [ ] ~~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~



## Testing Performed

- [ ] CI