### PR TITLE
ROX-16249: Fix AdmissionControllerTest flake

### DIFF
--- a/qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy
+++ b/qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy
@@ -37,6 +37,7 @@ class AdmissionControllerTest extends BaseSpecification {
     private ChaosMonkey chaosMonkey
 
     static final private String GCR_NGINX         = "qagcrnginx"
+    static final private String GCR_NGINX_IMAGE   = "us.gcr.io/stackrox-ci/nginx:1.10.1"
     static final private String BUSYBOX_NO_BYPASS = "busybox-no-bypass"
     static final private String BUSYBOX_BYPASS    = "busybox-bypass"
 
@@ -45,7 +46,7 @@ class AdmissionControllerTest extends BaseSpecification {
 
     static final private Deployment GCR_NGINX_DEPLOYMENT = new Deployment()
             .setName(GCR_NGINX)
-            .setImage("us.gcr.io/stackrox-ci/nginx:1.10.1")
+            .setImage(GCR_NGINX_IMAGE)
             .addLabel("app", "test")
 
     static final private Deployment BUSYBOX_NO_BYPASS_DEPLOYMENT = new Deployment()
@@ -83,7 +84,7 @@ class AdmissionControllerTest extends BaseSpecification {
         assert gcrId != ""
 
         // Pre run scan to avoid timeouts with inline scans in the tests below
-        ImageService.scanImage(GCR_NGINX)
+        ImageService.scanImage(GCR_NGINX_IMAGE)
     }
 
     def setup() {


### PR DESCRIPTION
Fixes "AdmissionControllerTest / Verify admission controller performs image scans if Sensor is Unavailable"

## Description
The root cause is that the setup step fails to scan the vulnerable image in advance. Without this, the inline scan may fail sporadically during the test run.

```
    09:10:59 | ERROR | ImageService              | Image failed to scan: qagcrnginx
    io.grpc.StatusRuntimeException: INTERNAL: image enrichment error: error getting metadata for image: docker.io/library/qagcrnginx:latest errors: [getting metadata from registry: "Public DockerHub": failed to get the manifest digest: Head "https://registry-1.docker.io/v2/library/qagcrnginx/manifests/latest": http: non-successful response (status=401 body=""), getting metadata from registry: "Autogenerated https://registry-1.docker.io for cluster remote": failed to get the manifest digest: Head "https://registry-1.docker.io/v2/library/qagcrnginx/manifests/latest": http: non-successful response (status=401 body="")]
        at io.stackrox.proto.api.v1.ImageServiceGrpc$ImageServiceBlockingStub.scanImage(ImageServiceGrpc.java:940) [3 skipped]
``` 
The registry should be "us.gcr.io", not "registry-1.docker.io"

## Checklist
- [x] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [x] ~~Evaluated and added CHANGELOG entry if required~~
- [x] ~~Determined and documented upgrade steps~~
- [x] ~~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

Test implementation changes, no doc required.

## Testing Performed
- Tested locally 
