### PR TITLE
ROX-11462: Allow graceful stop on `pkg/grpc`

### DIFF
--- a/central/main.go
+++ b/central/main.go
@@ -428,7 +428,7 @@ func servicesToRegister() []pkgGRPC.APIService {
 	return servicesToRegister
 }
 
-func watchdog(signal *concurrency.Signal, timeout time.Duration) {
+func watchdog(signal concurrency.Waitable, timeout time.Duration) {
 	if !concurrency.WaitWithTimeout(signal, timeout) {
 		log.Errorf("API server failed to start within %v!", timeout)
 		log.Error("This usually means something is *very* wrong. Terminating ...")

--- a/pkg/grpc/endpoints.go
+++ b/pkg/grpc/endpoints.go
@@ -1,6 +1,7 @@
 package grpc
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"io"
@@ -196,6 +197,11 @@ func (c *EndpointConfig) instantiate(httpHandler http.Handler, grpcSrv *grpc.Ser
 			srv:      httpSrv,
 			listener: httpLis,
 			endpoint: c,
+			stopper: func() {
+				if err := httpSrv.Shutdown(context.Background()); err != nil {
+					log.Warnf("stopping HTTP listener: %s", err)
+				}
+			},
 		})
 	}
 	if grpcLis != nil {

--- a/pkg/grpc/endpoints.go
+++ b/pkg/grpc/endpoints.go
@@ -199,7 +199,7 @@ func (c *EndpointConfig) instantiate(httpHandler http.Handler, grpcSrv *grpc.Ser
 			endpoint: c,
 			stopper: func() {
 				if err := httpSrv.Shutdown(context.Background()); err != nil {
-					log.Warnf("stopping HTTP listener: %s", err)
+					log.Warnf("Stopping HTTP listener: %s", err)
 				}
 			},
 		})

--- a/pkg/grpc/server.go
+++ b/pkg/grpc/server.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"strconv"
 	"strings"
 	"time"
 
@@ -56,19 +55,12 @@ func init() {
 var (
 	log = logging.LoggerForModule()
 
-	maxResponseMsgSizeSetting = env.RegisterSetting("ROX_GRPC_MAX_RESPONSE_SIZE")
+	maxResponseMsgSizeSetting = env.RegisterIntegerSetting("ROX_GRPC_MAX_RESPONSE_SIZE", defaultMaxResponseMsgSize)
 	enableRequestTracing      = env.RegisterBooleanSetting("ROX_GRPC_ENABLE_REQUEST_TRACING", false)
 )
 
 func maxResponseMsgSize() int {
-	if setting := maxResponseMsgSizeSetting.Setting(); setting != "" {
-		value, err := strconv.Atoi(setting)
-		if err == nil {
-			return value
-		}
-		log.Warnf("Invalid value %q for %s: %v", setting, maxResponseMsgSizeSetting.EnvVar(), err)
-	}
-	return defaultMaxResponseMsgSize
+	return maxResponseMsgSizeSetting.IntegerSetting()
 }
 
 type server interface {

--- a/pkg/grpc/server.go
+++ b/pkg/grpc/server.go
@@ -166,16 +166,13 @@ func (a *apiImpl) Stop() bool {
 	}
 
 	log.Infof("Starting stop procedure")
-	// a.shutdownInProgress.Signal()
 	a.grpcServer.GracefulStop()
 	log.Infof("gRPC server fully stopped")
 	for _, listener := range a.listeners {
 		if listener.stopper != nil {
-			log.Infof("running http stopper")
 			listener.stopper()
 		}
 	}
-	log.Infof("Stop() finished -> returning true")
 	return true
 }
 
@@ -247,7 +244,6 @@ func (a *apiImpl) listenOnLocalEndpoint(server *grpc.Server) pipeconn.DialContex
 	lis, dialContext := pipeconn.NewPipeListener()
 
 	log.Info("Launching backend gRPC listener")
-	// Launch the GRPC listener
 	go func() {
 		if err := server.Serve(lis); err != nil {
 			log.Fatal(err)

--- a/pkg/grpc/server.go
+++ b/pkg/grpc/server.go
@@ -257,8 +257,6 @@ func (a *apiImpl) listenOnLocalEndpoint(server *grpc.Server) pipeconn.DialContex
 			log.Fatal(err)
 		}
 
-		// If server returned an error, the gRPC listener has stopped. If `.Stop()` was not called, we should
-		// crash the application here rather than running without a gRPC listener.
 		if !a.shutdownInProgress.IsDone() {
 			log.Fatal("Unexpected local API server termination.")
 		}

--- a/pkg/grpc/server.go
+++ b/pkg/grpc/server.go
@@ -153,6 +153,11 @@ func (a *apiImpl) Register(services ...APIService) {
 }
 
 func (a *apiImpl) Stop() *concurrency.Signal {
+	if a.grpcShutdownRequested.IsDone() {
+		log.Warnf("API Stop called but shutdown was already requested")
+		return &a.grpcShutdownFinished
+	}
+
 	go a.stop()
 	return &a.grpcShutdownFinished
 }

--- a/pkg/grpc/server.go
+++ b/pkg/grpc/server.go
@@ -260,7 +260,7 @@ func (a *apiImpl) listenOnLocalEndpoint(server *grpc.Server) pipeconn.DialContex
 		// If server returned an error, the gRPC listener has stopped. If `.Stop()` was not called, we should
 		// crash the application here rather than running without a gRPC listener.
 		if !a.shutdownInProgress.IsDone() {
-			log.Fatal("The local API server should never terminate unless explicitly requested")
+			log.Fatal("Unexpected local API server termination.")
 		}
 	}()
 	return dialContext

--- a/pkg/grpc/server_test.go
+++ b/pkg/grpc/server_test.go
@@ -1,33 +1,31 @@
 package grpc
 
 import (
-	"os"
+	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 )
 
-func TestMaxResponseMsgSize_Unset(t *testing.T) {
-	require.NoError(t, os.Unsetenv(maxResponseMsgSizeSetting.EnvVar()))
-
-	assert.Equal(t, defaultMaxResponseMsgSize, maxResponseMsgSize())
+type APIServerSuite struct {
+	suite.Suite
 }
 
-func TestMaxResponseMsgSize_Empty(t *testing.T) {
-	require.NoError(t, os.Setenv(maxResponseMsgSizeSetting.EnvVar(), ""))
-
-	assert.Equal(t, defaultMaxResponseMsgSize, maxResponseMsgSize())
+func Test_APIServerSuite(t *testing.T) {
+	suite.Run(t, new(APIServerSuite))
 }
 
-func TestMaxResponseMsgSize_Invalid(t *testing.T) {
-	require.NoError(t, os.Setenv(maxResponseMsgSizeSetting.EnvVar(), "notAnInt"))
+func (a *APIServerSuite) TestEnvValues() {
+	cases := map[string]int{
+		"":         defaultMaxResponseMsgSize,
+		"notAnInt": defaultMaxResponseMsgSize,
+		"1337":     1337,
+	}
 
-	assert.Equal(t, defaultMaxResponseMsgSize, maxResponseMsgSize())
-}
-
-func TestMaxResponseMsgSize_Valid(t *testing.T) {
-	require.NoError(t, os.Setenv(maxResponseMsgSizeSetting.EnvVar(), "1337"))
-
-	assert.Equal(t, 1337, maxResponseMsgSize())
+	for envValue, expected := range cases {
+		a.Run(fmt.Sprintf("%s=%d", envValue, expected), func() {
+			a.T().Setenv(maxResponseMsgSizeSetting.EnvVar(), envValue)
+			a.Assert().Equal(expected, maxResponseMsgSize())
+		})
+	}
 }

--- a/pkg/grpc/server_test.go
+++ b/pkg/grpc/server_test.go
@@ -45,6 +45,7 @@ func (a *APIServerSuite) Test_TwoTestsStartingAPIs() {
 		// Running two tests that start the API results in failure.
 		a.Run(fmt.Sprintf("API test %d", i), func() {
 			api.Start().Wait()
+			api.Stop().Wait()
 		})
 	}
 }

--- a/pkg/grpc/server_test.go
+++ b/pkg/grpc/server_test.go
@@ -1,9 +1,15 @@
 package grpc
 
 import (
+	"crypto/tls"
 	"fmt"
+	"net/http"
 	"testing"
+	"time"
 
+	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/grpc/authz/allow"
+	"github.com/stackrox/rox/pkg/grpc/routes"
 	"github.com/stackrox/rox/pkg/mtls/verifier"
 	"github.com/stretchr/testify/suite"
 )
@@ -50,6 +56,68 @@ func (a *APIServerSuite) Test_TwoTestsStartingAPIs() {
 	}
 }
 
+func (a *APIServerSuite) Test_CustomAPI() {
+	// TODO: Use TLS mock instead of overriding this with dummy certs
+	a.T().Setenv("ROX_MTLS_CERT_FILE", "../../tools/local-sensor/certs/cert.pem")
+	a.T().Setenv("ROX_MTLS_KEY_FILE", "../../tools/local-sensor/certs/key.pem")
+	a.T().Setenv("ROX_MTLS_CA_FILE", "../../tools/local-sensor/certs/caCert.pem")
+	a.T().Setenv("ROX_MTLS_CA_KEY_FILE", "../../tools/local-sensor/certs/caKey.pem")
+
+	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+
+	a.Run("fetch data from /test", func() {
+		cfg, endpointReached := configWithCustomRoute()
+		api := NewAPI(cfg)
+		api.Start().Wait()
+		defer func() {
+			api.Stop().Wait()
+		}()
+
+		a.requestWithoutErr("https://localhost:8080/test")
+		a.waitForSignal(endpointReached)
+	})
+
+	a.Run("cannot fetch data from /test after server stopped", func() {
+		cfg, endpointReached := configWithCustomRoute()
+		api := NewAPI(cfg)
+		api.Start().Wait()
+		api.Stop().Wait()
+
+		_, err := http.Get("https://localhost:8080/test")
+		a.Require().Error(err)
+		a.Require().False(endpointReached.IsDone())
+	})
+
+}
+
+func (a *APIServerSuite) requestWithoutErr(url string) {
+	_, err := http.Get(url)
+	a.Require().NoError(err)
+}
+
+func (a *APIServerSuite) waitForSignal(s *concurrency.Signal) {
+	select {
+	case <-s.Done():
+		break
+	case <-time.After(2 * time.Second):
+		a.FailNow("Should have received request on endpoint")
+	}
+}
+
+func configWithCustomRoute() (Config, *concurrency.Signal) {
+	endpointReached := concurrency.NewSignal()
+	cfg := defaultConf()
+	handler := &testHandler{received: &endpointReached}
+	cfg.CustomRoutes = []routes.CustomRoute{
+		{
+			Route:         "/test",
+			Authorizer:    allow.Anonymous(),
+			ServerHandler: handler,
+		},
+	}
+	return cfg, &endpointReached
+}
+
 func defaultConf() Config {
 	return Config{
 		Endpoints: []*EndpointConfig{
@@ -61,4 +129,14 @@ func defaultConf() Config {
 			},
 		},
 	}
+}
+
+type testHandler struct {
+	name     string
+	received *concurrency.Signal
+}
+
+func (h *testHandler) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
+	h.received.Signal()
+	_, _ = w.Write([]byte("Hello!"))
 }

--- a/pkg/grpc/server_test.go
+++ b/pkg/grpc/server_test.go
@@ -59,7 +59,7 @@ func (a *APIServerSuite) Test_TwoTestsStartingAPIs() {
 		// Running two tests that start the API results in failure.
 		a.Run(fmt.Sprintf("API test %d", i), func() {
 			api.Start().Wait()
-			api.Stop().Wait()
+			api.Stop()
 		})
 	}
 }
@@ -72,7 +72,7 @@ func (a *APIServerSuite) Test_CustomAPI() {
 		api := NewAPI(cfg)
 		api.Start().Wait()
 		defer func() {
-			api.Stop().Wait()
+			api.Stop()
 		}()
 
 		a.requestWithoutErr("https://localhost:8080/test")
@@ -83,7 +83,7 @@ func (a *APIServerSuite) Test_CustomAPI() {
 		cfg, endpointReached := configWithCustomRoute()
 		api := NewAPI(cfg)
 		api.Start().Wait()
-		api.Stop().Wait()
+		api.Stop()
 
 		_, err := http.Get("https://localhost:8080/test")
 		a.Require().Error(err)
@@ -96,15 +96,9 @@ func (a *APIServerSuite) Test_Stop_CalledMultipleTimes() {
 
 	api.Start().Wait()
 
-	// Calling Stop multiple times should not panic
-	stopSig1 := api.Stop()
-	stopSig2 := api.Stop()
-	stopSig3 := api.Stop()
-
-	stopSig1.Wait()
-
-	a.Assert().True(stopSig2.IsDone())
-	a.Assert().True(stopSig3.IsDone())
+	a.Assert().True(api.Stop())
+	// second call should return false as stop already finished
+	a.Assert().False(api.Stop())
 }
 
 func (a *APIServerSuite) requestWithoutErr(url string) {

--- a/pkg/grpc/server_test.go
+++ b/pkg/grpc/server_test.go
@@ -58,7 +58,7 @@ func (a *APIServerSuite) Test_TwoTestsStartingAPIs() {
 	for i, api := range []API{api1, api2} {
 		// Running two tests that start the API results in failure.
 		a.Run(fmt.Sprintf("API test %d", i), func() {
-			api.Start().Wait()
+			a.Assert().NoError(api.Start().Wait())
 			api.Stop()
 		})
 	}
@@ -70,7 +70,7 @@ func (a *APIServerSuite) Test_CustomAPI() {
 	a.Run("fetch data from /test", func() {
 		cfg, endpointReached := configWithCustomRoute()
 		api := NewAPI(cfg)
-		api.Start().Wait()
+		a.Assert().NoError(api.Start().Wait())
 		defer func() {
 			api.Stop()
 		}()
@@ -82,7 +82,7 @@ func (a *APIServerSuite) Test_CustomAPI() {
 	a.Run("cannot fetch data from /test after server stopped", func() {
 		cfg, endpointReached := configWithCustomRoute()
 		api := NewAPI(cfg)
-		api.Start().Wait()
+		a.Assert().NoError(api.Start().Wait())
 		api.Stop()
 
 		_, err := http.Get("https://localhost:8080/test")
@@ -94,11 +94,18 @@ func (a *APIServerSuite) Test_CustomAPI() {
 func (a *APIServerSuite) Test_Stop_CalledMultipleTimes() {
 	api := NewAPI(defaultConf())
 
-	api.Start().Wait()
+	a.Assert().NoError(api.Start().Wait())
 
 	a.Assert().True(api.Stop())
 	// second call should return false as stop already finished
 	a.Assert().False(api.Stop())
+}
+
+func (a *APIServerSuite) Test_CantCallStartMultipleTimes() {
+	api := NewAPI(defaultConf())
+	a.Assert().NoError(api.Start().Wait())
+	a.Assert().True(api.Stop())
+	a.Assert().Error(api.Start().Wait())
 }
 
 func (a *APIServerSuite) requestWithoutErr(url string) {

--- a/pkg/sync/mutex_dev.go
+++ b/pkg/sync/mutex_dev.go
@@ -74,6 +74,15 @@ func (m *Mutex) Lock() {
 	m.acquireTime = time.Now()
 }
 
+// TryLock acquires the lock if not yet locked.
+func (m *Mutex) TryLock() bool {
+	if m.Mutex.TryLock() {
+		m.acquireTime = time.Now()
+		return true
+	}
+	return false
+}
+
 // Unlock releases an acquired lock on the mutex.
 func (m *Mutex) Unlock() {
 	panicIfTooMuchTimeElapsed("Mutex.Unlock", m.acquireTime, lockTimeout, 1)

--- a/pkg/sync/mutex_dev.go
+++ b/pkg/sync/mutex_dev.go
@@ -74,15 +74,6 @@ func (m *Mutex) Lock() {
 	m.acquireTime = time.Now()
 }
 
-// TryLock acquires the lock if not yet locked.
-func (m *Mutex) TryLock() bool {
-	if m.Mutex.TryLock() {
-		m.acquireTime = time.Now()
-		return true
-	}
-	return false
-}
-
 // Unlock releases an acquired lock on the mutex.
 func (m *Mutex) Unlock() {
 	panicIfTooMuchTimeElapsed("Mutex.Unlock", m.acquireTime, lockTimeout, 1)


### PR DESCRIPTION
## Description

This is a refactor in `pkg/grpc` to allow calling `.Stop()` on a gRPC server and stopping all TCP listeners underneath (for gRPC and HTTP multiplexers).

With the current code is not possible to start two servers in separate tests. The server is bound to the lifecycle of Go runtime, and it should never stop unless the process exists.

This makes writing unit and integration tests in Sensor (and presumably in Central) much harder. You can't have two tests that start a gRPC server in the same file or package.

This was attempted sometime ago (#2130) but it was dropped in favor of simply running sensor integration tests in separate `go test` commands (see #2202). 

In order to close this technical debt and allow us to write tests starting and stopping the gRPC server multiple times, this PR aims to add a new function `.Stop()`, which should be called by the clients (sensor and central) in order to Stop their servers gracefully.

**Note** that this PR does not introduce any code in Central or Sensor to use this new API. This is only the library part of the code.

For a more in-depth reasoning on all the changes, I suggest to read the commit messages, which contain explanations to the changes every step of the way.


## Checklist
- [ ] Investigated and inspected CI test results
- [x] Unit test and regression tests added
- [ ] ~~Evaluated and added CHANGELOG entry if required~~
- [ ] ~~Determined and documented upgrade steps~~
- [ ] ~~Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))~~

If any of these don't apply, please comment below.

## Testing Performed

- [x] gRPC start/stop tests passing
- [ ] CI