### PR TITLE
ROX-17982: Wait for secondary entities request in verifyTableLink

### DIFF
--- a/ui/apps/platform/cypress/helpers/vulnmanagement/entities.js
+++ b/ui/apps/platform/cypress/helpers/vulnmanagement/entities.js
@@ -332,8 +332,10 @@ function verifyTableLink(
             // 4. Visit single page for primary entity.
             cy.get(selectors.sidePanelExternalLinkButton).click(); // does not make requests
 
-            // 5. Visit list page for secondary entities.
-            cy.get(relatedEntitiesSelector).click(); // might make some requests
+            // 5. Visit single page list for secondary entities.
+            interactAndWaitForResponses(() => {
+                cy.get(relatedEntitiesSelector).click();
+            }, getRouteMatcherMapForGraphQL([opnameForEntities[entitiesKey2]]));
 
             cy.get(
                 `li[data-testid="grouped-tab"] a[data-testid="tab"].active:contains("${headingPlural[entitiesKey2]}")`

--- a/ui/apps/platform/cypress/integration/vulnmanagement/clusterCves.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/clusterCves.test.js
@@ -97,6 +97,6 @@ describe('Vulnerability Management Cluster (Platform) CVEs', () => {
             this.skip();
         }
 
-        verifySecondaryEntities(entitiesKey, 'clusters', 9, /^\d+ clusters?$/);
+        verifySecondaryEntities(entitiesKey, 'clusters', 9);
     });
 });

--- a/ui/apps/platform/cypress/integration/vulnmanagement/clusters.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/clusters.test.js
@@ -123,14 +123,14 @@ describe('Vulnerability Management Clusters', () => {
     });
 
     it('should display links for namespaces', () => {
-        verifySecondaryEntities(entitiesKey, 'namespaces', 7, /^\d+ namespaces?$/);
+        verifySecondaryEntities(entitiesKey, 'namespaces', 7);
     });
 
     it('should display links for deployments', () => {
-        verifySecondaryEntities(entitiesKey, 'deployments', 7, /^\d+ deployments?$/);
+        verifySecondaryEntities(entitiesKey, 'deployments', 7);
     });
 
     it('should display links for nodes', () => {
-        verifySecondaryEntities(entitiesKey, 'nodes', 7, /^\d+ nodes?$/);
+        verifySecondaryEntities(entitiesKey, 'nodes', 7);
     });
 });

--- a/ui/apps/platform/cypress/integration/vulnmanagement/deployments.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/deployments.test.js
@@ -89,6 +89,6 @@ describe('Vulnerability Management Deployments', () => {
     });
 
     it('should display links for images', () => {
-        verifySecondaryEntities(entitiesKey, 'images', 7, /^\d+ images?$/);
+        verifySecondaryEntities(entitiesKey, 'images', 7);
     });
 });

--- a/ui/apps/platform/cypress/integration/vulnmanagement/imageComponents.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/imageComponents.test.js
@@ -131,10 +131,10 @@ describe('Vulnerability Management Image Components', () => {
     });
 
     it('should display links for images', () => {
-        verifySecondaryEntities(entitiesKey, 'images', 7, /^\d+ images?$/);
+        verifySecondaryEntities(entitiesKey, 'images', 7);
     });
 
     it('should display links for deployments', () => {
-        verifySecondaryEntities(entitiesKey, 'deployments', 8, /^\d+ deployments?$/);
+        verifySecondaryEntities(entitiesKey, 'deployments', 8);
     });
 });

--- a/ui/apps/platform/cypress/integration/vulnmanagement/imageCves.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/imageCves.test.js
@@ -127,15 +127,15 @@ describe('Vulnerability Management Image CVEs', () => {
     // Some tests might fail in local deployment.
 
     it('should display links for deployments', () => {
-        verifySecondaryEntities(entitiesKey, 'deployments', 10, /^\d+ deployments?$/);
+        verifySecondaryEntities(entitiesKey, 'deployments', 10);
     });
 
     it('should display links for images', () => {
-        verifySecondaryEntities(entitiesKey, 'images', 10, /^\d+ images?$/);
+        verifySecondaryEntities(entitiesKey, 'images', 10);
     });
 
     it('should display links for image-components', () => {
-        verifySecondaryEntities(entitiesKey, 'image-components', 10, /^\d+ image components?$/);
+        verifySecondaryEntities(entitiesKey, 'image-components', 10);
     });
 
     // @TODO: Rework this test. Seems like each of these do the same thing

--- a/ui/apps/platform/cypress/integration/vulnmanagement/images.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/images.test.js
@@ -122,11 +122,11 @@ describe('Vulnerability Management Images', () => {
     });
 
     it('should display links for deployments', () => {
-        verifySecondaryEntities(entitiesKey, 'deployments', 9, /^\d+ deployments?$/);
+        verifySecondaryEntities(entitiesKey, 'deployments', 9);
     });
 
     it('should display links for image-components', () => {
-        verifySecondaryEntities(entitiesKey, 'image-components', 9, /^\d+ image components?$/);
+        verifySecondaryEntities(entitiesKey, 'image-components', 9);
     });
 
     it('should show entity icon, not back button, if there is only one item on the side panel stack', () => {

--- a/ui/apps/platform/cypress/integration/vulnmanagement/namespaces.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/namespaces.test.js
@@ -89,10 +89,10 @@ describe('Vulnerability Management Namespaces', () => {
     });
 
     it('should display links for deployments', () => {
-        verifySecondaryEntities(entitiesKey, 'deployments', 5, /^\d+ deployments?$/);
+        verifySecondaryEntities(entitiesKey, 'deployments', 5);
     });
 
     it('should display links for images', () => {
-        verifySecondaryEntities(entitiesKey, 'images', 6, /^\d+ images?$/);
+        verifySecondaryEntities(entitiesKey, 'images', 6);
     });
 });

--- a/ui/apps/platform/cypress/integration/vulnmanagement/nodeComponents.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/nodeComponents.test.js
@@ -133,6 +133,6 @@ describe('Vulnerability Management Node Components', () => {
     });
 
     it('should display links for nodes', () => {
-        verifySecondaryEntities(entitiesKey, 'nodes', 6, /^\d+ nodes?$/);
+        verifySecondaryEntities(entitiesKey, 'nodes', 6);
     });
 });

--- a/ui/apps/platform/cypress/integration/vulnmanagement/nodeCves.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/nodeCves.test.js
@@ -144,7 +144,7 @@ describe('Vulnerability Management Node CVEs', () => {
             this.skip();
         }
 
-        verifySecondaryEntities(entitiesKey, 'nodes', 10, /^\d+ nodes?$/);
+        verifySecondaryEntities(entitiesKey, 'nodes', 10);
     });
 
     it('should display links for node-components', function () {
@@ -152,6 +152,6 @@ describe('Vulnerability Management Node CVEs', () => {
             this.skip();
         }
 
-        verifySecondaryEntities(entitiesKey, 'node-components', 10, /^\d+ node components?$/);
+        verifySecondaryEntities(entitiesKey, 'node-components', 10);
     });
 });


### PR DESCRIPTION
## Description

### Problem

ocp-4-10-ui-e2e-tests 

1. Vulnerability Management Clusters should display links for namespaces
2. Vulnerability Management Clusters should display links for deployments
3. Vulnerability Management Clusters should display links for nodes
4. Vulnerability Management Deployments should display links for images
5. Vulnerability Management Image Components should display links for images
6. Vulnerability Management Image Components should display links for deployments
7. Vulnerability Management Image CVEs should display links for deployments
8. Vulnerability Management Image CVEs should display links for images
9. Vulnerability Management Image CVEs should display links for image-components
10. Vulnerability Management Images should display links for deployments
11. Vulnerability Management Images should display links for image-components
12. Vulnerability Management Namespaces should display links for deployments
13. Vulnerability Management Namespaces should display links for images
14. Vulnerability Management Node Components should display links for nodes

> Vulnerability Management Clusters should display links for namespaces

> Timed out retrying after 4000ms: Expected to find element: `li[data-testid="grouped-tab"] a[data-testid="tab"].active:contains("Namespaces")`, but never found it.

![prow_cluster_namespaces](https://github.com/stackrox/stackrox/assets/11862657/3515118a-8bb5-4add-8390-1ba49bb2ddb6)

### Analysis

Find in Files `verifySecondaryEntities(` in cypress/integration/vulnmanagement 17 results in 9 files

All tests failed except 2 tests for clusterCves and 1 test for nodeCves because skip for openshift.

1. As Van noticed, expected tab is active in test failure screenshot. Central sometimes slows down on OpenShift.
2. Furthermore, there is a GraphQL request which would have provided an additional 10 seconds waiting time before the 4 seconds for the DOM assertions.
3. Code comment `// might make some requests` suggests that I was confused whether or not to expect request for step 5 in link navigation.
    * Maybe an obsolete entity like policies was an exception to the pattern?
    * Or maybe I incorrectly expected getClusterNAMESPACE instead of getNamespaces.

Here are the requests for this test for clusters primary and namespaces secondary:

1. getClusters
2. getClusterNAMESPACE
3. getCluster
4. no requests
5. getNamespaces

### Solution

1. Wait for secondary entities request in `verifyTableLink` function.
2. Delete redundant `entitiesRegExp2` argument that was residue to prevent merge conflicts with 4.1 release branch in #6559

## Checklist
- [x] Investigated and inspected CI test results
- [x] Edited integration tests

## Testing Performed

1. `yarn cypress-open` in ui/apps/platform

    * vulnmanagement/clusterCves.test.js
    * vulnmanagement/clusters.test.js
    * vulnmanagement/deployments.test.js
    * vulnmanagement/imageComponents.test.js
    * vulnmanagement/imageCves.test.js
    * vulnmanagement/images.test.js
    * vulnmanagement/namespaces.test.js
    * vulnmanagement/nodeComponents.test.js
    * vulnmanagement/nodeCves.test.js
    * vulnmanagement/nodes.test.js