### PR TITLE
refactor(pg): inject graph only once in test

### DIFF
--- a/central/nodecomponentcveedge/datastore/datastore_sac_test.go
+++ b/central/nodecomponentcveedge/datastore/datastore_sac_test.go
@@ -23,9 +23,6 @@ import (
 
 var (
 	nodeScanOperatingSystem = "Linux"
-
-	dontWaitForIndexing = false
-	waitForIndexing     = true
 )
 
 func TestNodeComponentCVEEdgeDatastoreSAC(t *testing.T) {
@@ -49,14 +46,13 @@ func (s *nodeComponentCVEEdgeDatastoreSACTestSuite) SetupSuite() {
 	pool := s.testGraphDatastore.GetPostgresPool()
 	s.datastore = GetTestPostgresDataStore(s.T(), pool)
 	s.testContexts = sacTestUtils.GetNamespaceScopedTestContexts(context.Background(), s.T(), resources.Node)
+
+	err = s.testGraphDatastore.PushNodeToVulnerabilitiesGraph()
+	s.Require().NoError(err)
 }
 
 func (s *nodeComponentCVEEdgeDatastoreSACTestSuite) TearDownSuite() {
 	s.testGraphDatastore.Cleanup(s.T())
-}
-
-func (s *nodeComponentCVEEdgeDatastoreSACTestSuite) cleanNodeToVulnerabilitiesGraph() {
-	s.Require().NoError(s.testGraphDatastore.CleanNodeToVulnerabilitiesGraph())
 }
 
 func getComponentID(component *storage.EmbeddedNodeScanComponent, os string) string {
@@ -183,9 +179,6 @@ var (
 
 func (s *nodeComponentCVEEdgeDatastoreSACTestSuite) TestExistsEdgeFromSingleComponent() {
 	// Inject the fixture graph, and test exists for Component1 to CVE-1234-0001 edge
-	err := s.testGraphDatastore.PushNodeToVulnerabilitiesGraph()
-	defer s.cleanNodeToVulnerabilitiesGraph()
-	s.Require().NoError(err)
 	targetEdgeID := cmp1cve1edge
 	for _, c := range testCases {
 		s.Run(c.contextKey, func() {
@@ -199,9 +192,6 @@ func (s *nodeComponentCVEEdgeDatastoreSACTestSuite) TestExistsEdgeFromSingleComp
 
 func (s *nodeComponentCVEEdgeDatastoreSACTestSuite) TestExistsEdgeFromSingleComponentToSharedCVE() {
 	// Inject the fixture graph, and test exists for Component1 to CVE-4567-0002 edge
-	err := s.testGraphDatastore.PushNodeToVulnerabilitiesGraph()
-	defer s.cleanNodeToVulnerabilitiesGraph()
-	s.Require().NoError(err)
 	targetEdgeID := cmp1cve2edge
 	for _, c := range testCases {
 		s.Run(c.contextKey, func() {
@@ -215,9 +205,6 @@ func (s *nodeComponentCVEEdgeDatastoreSACTestSuite) TestExistsEdgeFromSingleComp
 
 func (s *nodeComponentCVEEdgeDatastoreSACTestSuite) TestExistsEdgeFromSharedComponent() {
 	// Inject the fixture graph, and test exists for Component3 to CVE-3456-0004 edge
-	err := s.testGraphDatastore.PushNodeToVulnerabilitiesGraph()
-	defer s.cleanNodeToVulnerabilitiesGraph()
-	s.Require().NoError(err)
 	targetEdgeID := cmp3cve4edge
 	for _, c := range testCases {
 		s.Run(c.contextKey, func() {
@@ -231,9 +218,6 @@ func (s *nodeComponentCVEEdgeDatastoreSACTestSuite) TestExistsEdgeFromSharedComp
 
 func (s *nodeComponentCVEEdgeDatastoreSACTestSuite) TestGetEdgeFromSingleComponent() {
 	// Inject the fixture graph, and test read for Component1 to CVE-1234-0001 edge
-	err := s.testGraphDatastore.PushNodeToVulnerabilitiesGraph()
-	defer s.cleanNodeToVulnerabilitiesGraph()
-	s.Require().NoError(err)
 	targetEdgeID := cmp1cve1edge
 	expectedSrcID := getComponentID(fixtures.GetEmbeddedNodeComponent1x1(), nodeScanOperatingSystem)
 	expectedTargetID := getVulnerabilityID(fixtures.GetEmbeddedNodeCVE1234x0001(), nodeScanOperatingSystem)
@@ -257,9 +241,6 @@ func (s *nodeComponentCVEEdgeDatastoreSACTestSuite) TestGetEdgeFromSingleCompone
 
 func (s *nodeComponentCVEEdgeDatastoreSACTestSuite) TestGetEdgeFromSingleComponentToSharedCVE() {
 	// Inject the fixture graph, and test read for Component1 to CVE-4567-0002 edge
-	err := s.testGraphDatastore.PushNodeToVulnerabilitiesGraph()
-	defer s.cleanNodeToVulnerabilitiesGraph()
-	s.Require().NoError(err)
 	targetEdgeID := cmp1cve2edge
 	expectedSrcID := getComponentID(fixtures.GetEmbeddedNodeComponent1x1(), nodeScanOperatingSystem)
 	expectedTargetID := getVulnerabilityID(fixtures.GetEmbeddedNodeCVE4567x0002(), nodeScanOperatingSystem)
@@ -283,9 +264,6 @@ func (s *nodeComponentCVEEdgeDatastoreSACTestSuite) TestGetEdgeFromSingleCompone
 
 func (s *nodeComponentCVEEdgeDatastoreSACTestSuite) TestGetEdgeFromSharedComponent() {
 	// Inject the fixture graph, and test read for Component3 to CVE-3456-0004 edge
-	err := s.testGraphDatastore.PushNodeToVulnerabilitiesGraph()
-	defer s.cleanNodeToVulnerabilitiesGraph()
-	s.Require().NoError(err)
 	targetEdgeID := cmp3cve4edge
 	expectedSrcID := getComponentID(fixtures.GetEmbeddedNodeComponent1s2x3(), nodeScanOperatingSystem)
 	expectedTargetID := getVulnerabilityID(fixtures.GetEmbeddedNodeCVE3456x0004(), nodeScanOperatingSystem)
@@ -309,9 +287,6 @@ func (s *nodeComponentCVEEdgeDatastoreSACTestSuite) TestGetEdgeFromSharedCompone
 
 func (s *nodeComponentCVEEdgeDatastoreSACTestSuite) TestCount() {
 	// Inject the fixture graph, and test data filtering on count operations
-	err := s.testGraphDatastore.PushNodeToVulnerabilitiesGraph()
-	defer s.cleanNodeToVulnerabilitiesGraph()
-	s.Require().NoError(err)
 	for _, c := range testCases {
 		s.Run(c.contextKey, func() {
 			expectedCount := 0
@@ -330,9 +305,6 @@ func (s *nodeComponentCVEEdgeDatastoreSACTestSuite) TestCount() {
 
 func (s *nodeComponentCVEEdgeDatastoreSACTestSuite) TestSearch() {
 	// Inject the fixture graph, and test data filtering on count operations
-	err := s.testGraphDatastore.PushNodeToVulnerabilitiesGraph()
-	defer s.cleanNodeToVulnerabilitiesGraph()
-	s.Require().NoError(err)
 	for _, c := range testCases {
 		s.Run(c.contextKey, func() {
 			expectedCount := 0
@@ -354,9 +326,6 @@ func (s *nodeComponentCVEEdgeDatastoreSACTestSuite) TestSearch() {
 
 func (s *nodeComponentCVEEdgeDatastoreSACTestSuite) TestSearchEdges() {
 	// Inject the fixture graph, and test data filtering on count operations
-	err := s.testGraphDatastore.PushNodeToVulnerabilitiesGraph()
-	defer s.cleanNodeToVulnerabilitiesGraph()
-	s.Require().NoError(err)
 	for _, c := range testCases {
 		s.Run(c.contextKey, func() {
 			expectedCount := 0
@@ -378,9 +347,6 @@ func (s *nodeComponentCVEEdgeDatastoreSACTestSuite) TestSearchEdges() {
 
 func (s *nodeComponentCVEEdgeDatastoreSACTestSuite) TestSearchRawEdges() {
 	// Inject the fixture graph, and test data filtering on count operations
-	err := s.testGraphDatastore.PushNodeToVulnerabilitiesGraph()
-	defer s.cleanNodeToVulnerabilitiesGraph()
-	s.Require().NoError(err)
 	for _, c := range testCases {
 		s.Run(c.contextKey, func() {
 			expectedCount := 0

--- a/central/nodecomponentedge/datastore/datastore_sac_test.go
+++ b/central/nodecomponentedge/datastore/datastore_sac_test.go
@@ -19,9 +19,6 @@ import (
 
 const (
 	nodeScanOperatingSystem = "Linux"
-
-	dontWaitForIndexing = false
-	waitForIndexing     = true
 )
 
 func TestNodeComponentEdgeDatastoreSAC(t *testing.T) {
@@ -45,14 +42,12 @@ func (s *nodeComponentEdgeDatastoreSACTestSuite) SetupSuite() {
 	s.datastore, err = GetTestPostgresDataStore(s.T(), pool)
 	s.Require().NoError(err)
 	s.testContexts = sacTestUtils.GetNamespaceScopedTestContexts(context.Background(), s.T(), resources.Node)
+	err = s.testGraphDatastore.PushNodeToVulnerabilitiesGraph()
+	s.Require().NoError(err)
 }
 
 func (s *nodeComponentEdgeDatastoreSACTestSuite) TearDownSuite() {
 	s.testGraphDatastore.Cleanup(s.T())
-}
-
-func (s *nodeComponentEdgeDatastoreSACTestSuite) cleanupNodeToVulnerabilityGraph() {
-	s.Require().NoError(s.testGraphDatastore.CleanNodeToVulnerabilitiesGraph())
 }
 
 func getComponentID(component *storage.EmbeddedNodeScanComponent, os string) string {
@@ -177,9 +172,6 @@ func getTestCases(nodeIDs []string) []edgeTestCase {
 
 func (s *nodeComponentEdgeDatastoreSACTestSuite) TestExists() {
 	// Inject the fixture graph and test for node1 to component1 edge
-	err := s.testGraphDatastore.PushNodeToVulnerabilitiesGraph()
-	defer s.cleanupNodeToVulnerabilityGraph()
-	s.Require().NoError(err)
 
 	nodeIDs := s.testGraphDatastore.GetStoredNodeIDs()
 	node1 := nodeIDs[0]
@@ -197,9 +189,6 @@ func (s *nodeComponentEdgeDatastoreSACTestSuite) TestExists() {
 
 func (s *nodeComponentEdgeDatastoreSACTestSuite) TestGet() {
 	// Inject the fixture graph and test for node1 to component1 edge
-	err := s.testGraphDatastore.PushNodeToVulnerabilitiesGraph()
-	defer s.cleanupNodeToVulnerabilityGraph()
-	s.Require().NoError(err)
 
 	nodeIDs := s.testGraphDatastore.GetStoredNodeIDs()
 	node1 := nodeIDs[0]
@@ -228,9 +217,6 @@ func (s *nodeComponentEdgeDatastoreSACTestSuite) TestGet() {
 
 func (s *nodeComponentEdgeDatastoreSACTestSuite) TestGetBatch() {
 	// Inject the fixture graph and test for node1 to component1 edge and node2 to component 4 edges
-	err := s.testGraphDatastore.PushNodeToVulnerabilitiesGraph()
-	defer s.cleanupNodeToVulnerabilityGraph()
-	s.Require().NoError(err)
 
 	nodeIDs := s.testGraphDatastore.GetStoredNodeIDs()
 	testCases := getTestCases(nodeIDs)
@@ -284,9 +270,6 @@ func (s *nodeComponentEdgeDatastoreSACTestSuite) TestGetBatch() {
 }
 
 func (s *nodeComponentEdgeDatastoreSACTestSuite) TestCount() {
-	err := s.testGraphDatastore.PushNodeToVulnerabilitiesGraph()
-	defer s.cleanupNodeToVulnerabilityGraph()
-	s.Require().NoError(err)
 
 	nodeIDs := s.testGraphDatastore.GetStoredNodeIDs()
 	testCases := getTestCases(nodeIDs)
@@ -308,9 +291,6 @@ func (s *nodeComponentEdgeDatastoreSACTestSuite) TestCount() {
 }
 
 func (s *nodeComponentEdgeDatastoreSACTestSuite) TestSearch() {
-	err := s.testGraphDatastore.PushNodeToVulnerabilitiesGraph()
-	defer s.cleanupNodeToVulnerabilityGraph()
-	s.Require().NoError(err)
 
 	nodeIDs := s.testGraphDatastore.GetStoredNodeIDs()
 	testCases := getTestCases(nodeIDs)
@@ -337,9 +317,6 @@ func (s *nodeComponentEdgeDatastoreSACTestSuite) TestSearch() {
 }
 
 func (s *nodeComponentEdgeDatastoreSACTestSuite) TestSearchEdges() {
-	err := s.testGraphDatastore.PushNodeToVulnerabilitiesGraph()
-	defer s.cleanupNodeToVulnerabilityGraph()
-	s.Require().NoError(err)
 
 	nodeIDs := s.testGraphDatastore.GetStoredNodeIDs()
 	testCases := getTestCases(nodeIDs)
@@ -366,9 +343,6 @@ func (s *nodeComponentEdgeDatastoreSACTestSuite) TestSearchEdges() {
 }
 
 func (s *nodeComponentEdgeDatastoreSACTestSuite) TestSearchRawEdges() {
-	err := s.testGraphDatastore.PushNodeToVulnerabilitiesGraph()
-	defer s.cleanupNodeToVulnerabilityGraph()
-	s.Require().NoError(err)
 
 	nodeIDs := s.testGraphDatastore.GetStoredNodeIDs()
 	testCases := getTestCases(nodeIDs)


### PR DESCRIPTION
## Description

There is no need to inject data at every test case run, we can do it on test suite setup. 

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

CI