### PR TITLE
ROX-17499: Make EKS orchestrator reset thread safe

### DIFF
--- a/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
+++ b/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
@@ -259,13 +259,19 @@ class BaseSpecification extends Specification {
         //Always make sure to revert back to the allAccessToken before each test
         resetAuth()
 
-        if (ClusterService.isEKS() && System.currentTimeSeconds() > orchestratorCreateTime + 600) {
+        if (ClusterService.isEKS()) {
             // Avoid EKS k8s client time out which occurs at approx. 15 minutes.
-            orchestrator = OrchestratorType.create(
-                    Env.mustGetOrchestratorType(),
-                    Constants.ORCHESTRATOR_NAMESPACE
-            )
-            orchestratorCreateTime = System.currentTimeSeconds()
+            synchronized(orchestrator) {
+                // synchronized() because orchestrator would be shared amongst
+                // concurrent feature threads.
+                if (System.currentTimeSeconds() > orchestratorCreateTime + 600) {
+                    orchestrator = OrchestratorType.create(
+                            Env.mustGetOrchestratorType(),
+                            Constants.ORCHESTRATOR_NAMESPACE
+                    )
+                    orchestratorCreateTime = System.currentTimeSeconds()
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Description

Per title.

## Checklist
- [x] Investigated and inspected CI test results - the test failure is a flake unrelated to this change.

## Testing Performed

CI and `/test eks-qa-e2e-tests` to check that there are no regressions. In a parallel test environment this would only run concurrently if the test spec features are mult-threaded which is unlikely.