### PR TITLE
ROX-17827: 'Create report' should start the creation process

### DIFF
--- a/ui/apps/platform/src/Containers/MainPage/Body.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Body.tsx
@@ -28,7 +28,7 @@ import {
     vulnManagementRiskAcceptancePath,
     collectionsPath,
     vulnerabilitiesWorkloadCvesPath,
-    vulnerabilityReportingPath,
+    vulnerabilityReportsPath,
 } from 'routePaths';
 import { useTheme } from 'Containers/ThemeProvider';
 
@@ -157,7 +157,7 @@ function Body({ hasReadAccess, isFeatureFlagEnabled }: BodyProps): ReactElement 
                     {hasVulnerabilityReportsPermission &&
                         isVulnerabilityReportingEnhancementsEnabled && (
                             <Route
-                                path={vulnerabilityReportingPath}
+                                path={vulnerabilityReportsPath}
                                 component={AsyncVulnerabilityReportingPage}
                             />
                         )}

--- a/ui/apps/platform/src/Containers/MainPage/Sidebar/NavigationSidebar.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Sidebar/NavigationSidebar.tsx
@@ -24,7 +24,7 @@ import {
     collectionsBasePath,
     vulnerabilitiesWorkloadCvesPath,
     networkBasePathPF,
-    vulnerabilityReportingPath,
+    vulnerabilityReportsPath,
 } from 'routePaths';
 
 import LeftNavItem from './LeftNavItem';
@@ -75,7 +75,7 @@ function NavigationSidebar({
         );
     }
 
-    const vulnerabilitiesPaths = [vulnerabilitiesWorkloadCvesPath, vulnerabilityReportingPath];
+    const vulnerabilitiesPaths = [vulnerabilitiesWorkloadCvesPath, vulnerabilityReportsPath];
 
     const Navigation = (
         <Nav id="nav-primary-simple">
@@ -125,12 +125,10 @@ function NavigationSidebar({
                         {isReportingEnhancementsEnabled &&
                             hasReadAccess('WorkflowAdministration') && (
                                 <LeftNavItem
-                                    key={vulnerabilityReportingPath}
-                                    isActive={location.pathname.includes(
-                                        vulnerabilityReportingPath
-                                    )}
-                                    path={vulnerabilityReportingPath}
-                                    title={basePathToLabelMap[vulnerabilityReportingPath]}
+                                    key={vulnerabilityReportsPath}
+                                    isActive={location.pathname.includes(vulnerabilityReportsPath)}
+                                    path={vulnerabilityReportsPath}
+                                    title={basePathToLabelMap[vulnerabilityReportsPath]}
                                 />
                             )}
                     </NavExpandable>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/CreateVulnReport/CreateVulnReportPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/CreateVulnReport/CreateVulnReportPage.tsx
@@ -6,7 +6,7 @@ import PageTitle from 'Components/PageTitle';
 function VulnReportsPage() {
     return (
         <>
-            <PageTitle title="Vulnerability reporting - create" />
+            <PageTitle title="Create vulnerability report" />
             <Divider component="div" />
             <PageSection variant="light" padding={{ default: 'noPadding' }}>
                 <Flex direction={{ default: 'column' }} className="pf-u-py-lg pf-u-px-lg">
@@ -19,9 +19,7 @@ function VulnReportsPage() {
                     </FlexItem>
                 </Flex>
             </PageSection>
-            <PageSection padding={{ default: 'noPadding' }}>
-                <PageSection isCenterAligned />
-            </PageSection>
+            <PageSection padding={{ default: 'noPadding' }} />
         </>
     );
 }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/CreateVulnReport/CreateVulnReportPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/CreateVulnReport/CreateVulnReportPage.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { PageSection, Title, Divider, Flex, FlexItem } from '@patternfly/react-core';
+
+import PageTitle from 'Components/PageTitle';
+
+function VulnReportsPage() {
+    return (
+        <>
+            <PageTitle title="Vulnerability reporting - create" />
+            <Divider component="div" />
+            <PageSection variant="light" padding={{ default: 'noPadding' }}>
+                <Flex direction={{ default: 'column' }} className="pf-u-py-lg pf-u-px-lg">
+                    <FlexItem>
+                        <Title headingLevel="h1">Create report</Title>
+                    </FlexItem>
+                    <FlexItem>
+                        Configure reports, define report scopes, and assign distribution lists to
+                        report on vulnerabilities across the organization.
+                    </FlexItem>
+                </Flex>
+            </PageSection>
+            <PageSection padding={{ default: 'noPadding' }}>
+                <PageSection isCenterAligned />
+            </PageSection>
+        </>
+    );
+}
+
+export default VulnReportsPage;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReportingPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReportingPage.tsx
@@ -1,16 +1,37 @@
 import React from 'react';
 import { Route, Switch } from 'react-router-dom';
 
-import { vulnerabilityReportingPath } from 'routePaths';
+import usePermissions from 'hooks/usePermissions';
+import { vulnerabilityReportingPath, vulnerabilityReportingCreatePath } from 'routePaths';
 
 import VulnReportsPage from './VulnReports/VulnReportsPage';
+import CreateVulnReportPage from './CreateVulnReport/CreateVulnReportPage';
 
 import './VulnReportingPage.css';
 
 function VulnReportingPage() {
+    const { hasReadWriteAccess, hasReadAccess } = usePermissions();
+
+    const hasWorkflowAdministrationWriteAccess = hasReadWriteAccess('WorkflowAdministration');
+    const hasImageReadAccess = hasReadAccess('Image');
+    const hasAccessScopeReadAccess = hasReadAccess('Access');
+    const hasNotifierIntegrationReadAccess = hasReadAccess('Integration');
+    const canReadWriteReports =
+        hasWorkflowAdministrationWriteAccess &&
+        hasImageReadAccess &&
+        hasAccessScopeReadAccess &&
+        hasNotifierIntegrationReadAccess;
+
     return (
         <Switch>
             <Route exact path={vulnerabilityReportingPath} component={VulnReportsPage} />
+            {canReadWriteReports && (
+                <Route
+                    exact
+                    path={vulnerabilityReportingCreatePath}
+                    component={CreateVulnReportPage}
+                />
+            )}
         </Switch>
     );
 }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReportingPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReportingPage.tsx
@@ -1,16 +1,20 @@
 import React from 'react';
-import { Route, Switch } from 'react-router-dom';
+import { Route, Switch, Redirect } from 'react-router-dom';
 
 import usePermissions from 'hooks/usePermissions';
-import { vulnerabilityReportingPath, vulnerabilityReportingCreatePath } from 'routePaths';
+import { vulnerabilityReportsPath } from 'routePaths';
 
 import VulnReportsPage from './VulnReports/VulnReportsPage';
 import CreateVulnReportPage from './CreateVulnReport/CreateVulnReportPage';
 
 import './VulnReportingPage.css';
+import usePageAction from './hooks/usePageState';
+
+type PageActions = 'create' | 'edit' | 'clone';
 
 function VulnReportingPage() {
     const { hasReadWriteAccess, hasReadAccess } = usePermissions();
+    const { pageAction } = usePageAction<PageActions>();
 
     const hasWorkflowAdministrationWriteAccess = hasReadWriteAccess('WorkflowAdministration');
     const hasImageReadAccess = hasReadAccess('Image');
@@ -24,14 +28,19 @@ function VulnReportingPage() {
 
     return (
         <Switch>
-            <Route exact path={vulnerabilityReportingPath} component={VulnReportsPage} />
-            {canReadWriteReports && (
-                <Route
-                    exact
-                    path={vulnerabilityReportingCreatePath}
-                    component={CreateVulnReportPage}
-                />
-            )}
+            <Route
+                exact
+                path={vulnerabilityReportsPath}
+                render={(props) => {
+                    if (pageAction === 'create' && canReadWriteReports) {
+                        return <CreateVulnReportPage {...props} />;
+                    }
+                    if (pageAction === undefined) {
+                        return <VulnReportsPage {...props} />;
+                    }
+                    return <Redirect to={vulnerabilityReportsPath} />;
+                }}
+            />
         </Switch>
     );
 }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReportingPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReportingPage.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Route, Switch, Redirect } from 'react-router-dom';
 
+import usePageAction from 'Containers/Vulnerabilities/VulnerablityReporting/hooks/usePageAction';
 import usePermissions from 'hooks/usePermissions';
 import { vulnerabilityReportsPath } from 'routePaths';
 
@@ -8,7 +9,6 @@ import VulnReportsPage from './VulnReports/VulnReportsPage';
 import CreateVulnReportPage from './CreateVulnReport/CreateVulnReportPage';
 
 import './VulnReportingPage.css';
-import usePageAction from './hooks/usePageState';
 
 type PageActions = 'create' | 'edit' | 'clone';
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/VulnReportsPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/VulnReportsPage.tsx
@@ -10,6 +10,7 @@ import {
     CardBody,
 } from '@patternfly/react-core';
 import { TableComposable, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import { Link } from 'react-router-dom';
 
 import { ReportConfiguration } from 'types/reportConfigurationService.proto';
 import { ReportStatus } from 'types/report.proto';
@@ -17,6 +18,7 @@ import { Report } from 'Containers/Vulnerabilities/VulnerablityReporting/types';
 import usePermissions from 'hooks/usePermissions';
 
 import PageTitle from 'Components/PageTitle';
+import { vulnerabilityReportingCreatePath } from 'routePaths';
 import HelpIconTh from './HelpIconTh';
 import LastRunStatusState from './LastRunStatusState';
 import LastRunState from './LastRunState';
@@ -113,9 +115,11 @@ function VulnReportsPage() {
                     </FlexItem>
                     <FlexItem>
                         {canCreateReports && (
-                            <Button variant="primary" onClick={() => {}}>
-                                Create report
-                            </Button>
+                            <Link to={vulnerabilityReportingCreatePath}>
+                                <Button variant="primary" onClick={() => {}}>
+                                    Create report
+                                </Button>
+                            </Link>
                         )}
                     </FlexItem>
                 </Flex>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/VulnReportsPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/VulnReportsPage.tsx
@@ -18,7 +18,7 @@ import { Report } from 'Containers/Vulnerabilities/VulnerablityReporting/types';
 import usePermissions from 'hooks/usePermissions';
 
 import PageTitle from 'Components/PageTitle';
-import { vulnerabilityReportingCreatePath } from 'routePaths';
+import { vulnerabilityReportsPath } from 'routePaths';
 import HelpIconTh from './HelpIconTh';
 import LastRunStatusState from './LastRunStatusState';
 import LastRunState from './LastRunState';
@@ -115,7 +115,7 @@ function VulnReportsPage() {
                     </FlexItem>
                     <FlexItem>
                         {canCreateReports && (
-                            <Link to={vulnerabilityReportingCreatePath}>
+                            <Link to={`${vulnerabilityReportsPath}?action=create`}>
                                 <Button variant="primary" onClick={() => {}}>
                                     Create report
                                 </Button>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/hooks/usePageAction.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/hooks/usePageAction.ts
@@ -1,17 +1,17 @@
 import useURLParameter, { QueryValue } from 'hooks/useURLParameter';
 
-type PageActionResult<T> = {
+type PageActionResult<T extends QueryValue> = {
     pageAction: T | undefined;
     setPageAction: (action: T) => void;
 };
 
-function usePageAction<T>(): PageActionResult<T> {
+function usePageAction<T extends QueryValue>(): PageActionResult<T> {
     const [pageActionParam, setPageActionParam] = useURLParameter('action', undefined);
 
     const pageAction = pageActionParam as T;
 
     function setPageAction(action: T): void {
-        setPageActionParam(action as QueryValue);
+        setPageActionParam(action);
     }
 
     return { pageAction, setPageAction };

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/hooks/usePageState.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/hooks/usePageState.ts
@@ -1,0 +1,20 @@
+import useURLParameter, { QueryValue } from 'hooks/useURLParameter';
+
+type PageActionResult<T> = {
+    pageAction: T | undefined;
+    setPageAction: (action: T) => void;
+};
+
+function usePageAction<T>(): PageActionResult<T> {
+    const [pageActionParam, setPageActionParam] = useURLParameter('action', undefined);
+
+    const pageAction = pageActionParam as T;
+
+    function setPageAction(action: T): void {
+        setPageActionParam(action as QueryValue);
+    }
+
+    return { pageAction, setPageAction };
+}
+
+export default usePageAction;

--- a/ui/apps/platform/src/routePaths.js
+++ b/ui/apps/platform/src/routePaths.js
@@ -99,10 +99,8 @@ export const vulnerabilitiesWorkloadCveSinglePath = `${vulnerabilitiesBasePath}/
 export const vulnerabilitiesWorkloadCveImageSinglePath = `${vulnerabilitiesBasePath}/workload-cves/images/:imageId`;
 export const vulnerabilitiesWorkloadCveDeploymentSinglePath = `${vulnerabilitiesBasePath}/workload-cves/deployments/:deploymentId`;
 
-export const vulnerabilityReportingPath = `${vulnerabilitiesBasePath}/vulnerability-reporting`;
-export const vulnerabilityReportingCreatePath = `${vulnerabilityReportingPath}/create`;
-export const vulnerabilityReportingEditPath = `${vulnerabilityReportingPath}/edit/:reportId`;
-export const vulnerabilityReportingClonePath = `${vulnerabilityReportingPath}/clone/:reportId`;
+export const vulnerabilityReportsPath = `${vulnerabilitiesBasePath}/reports`;
+export const vulnerabilityReportPath = `${vulnerabilitiesBasePath}/reports/:reportId`;
 
 /**
  * New Framwork-related route paths
@@ -161,7 +159,7 @@ const vulnManagementPathToLabelMap = {
 const vulnerabilitiesPathToLabelMap = {
     [vulnerabilitiesBasePath]: 'Vulnerabilities',
     [vulnerabilitiesWorkloadCvesPath]: 'Workload CVEs',
-    [vulnerabilityReportingPath]: 'Vulnerability Reporting',
+    [vulnerabilityReportsPath]: 'Vulnerability Reporting',
 };
 
 export const basePathToLabelMap = {

--- a/ui/apps/platform/src/routePaths.js
+++ b/ui/apps/platform/src/routePaths.js
@@ -100,6 +100,9 @@ export const vulnerabilitiesWorkloadCveImageSinglePath = `${vulnerabilitiesBaseP
 export const vulnerabilitiesWorkloadCveDeploymentSinglePath = `${vulnerabilitiesBasePath}/workload-cves/deployments/:deploymentId`;
 
 export const vulnerabilityReportingPath = `${vulnerabilitiesBasePath}/vulnerability-reporting`;
+export const vulnerabilityReportingCreatePath = `${vulnerabilityReportingPath}/create`;
+export const vulnerabilityReportingEditPath = `${vulnerabilityReportingPath}/edit/:reportId`;
+export const vulnerabilityReportingClonePath = `${vulnerabilityReportingPath}/clone/:reportId`;
 
 /**
  * New Framwork-related route paths


### PR DESCRIPTION
## Description

This PR adds the following things:
- Some extra paths were created for the following states: `create`, `edit` (to be used in the future), and `clone` (to be used in the future)
- Clicking on `Create report` will take you to the page for creating a report
- The route for the page for creating a report will be conditionally added based on permissions
- A very basic page for creating a report was added (like just a page header type of basic)


https://github.com/stackrox/stackrox/assets/4805485/c2f209f7-f785-46ee-9e1e-ac92797c3ea1

