### PR TITLE
fix(ui): Delete unneeded Tailwind font weight (part 4)

### DIFF
--- a/ui/apps/platform/src/Components/Pagination/PaginationInput/PaginationInput.js
+++ b/ui/apps/platform/src/Components/Pagination/PaginationInput/PaginationInput.js
@@ -32,7 +32,7 @@ const PaginationInput = ({ totalSize, onChange, currentPage, pageSize }) => {
     }
 
     return (
-        <div className="font-600 select-none">
+        <div className="select-none">
             Page
             <input
                 type="number"

--- a/ui/apps/platform/src/Components/ReactSelect/ReactSelect.js
+++ b/ui/apps/platform/src/Components/ReactSelect/ReactSelect.js
@@ -25,13 +25,13 @@ const Control = ({ className, ...props }) => (
         {...props}
         className={`${className} ${
             props.isDisabled ? 'bg-base-200' : 'bg-base-100'
-        } h-full cursor-text border-2 leading-normal min-h-10 border-base-300 flex items-center font-600 shadow-none overflow-auto hover:border-base-400`}
+        } h-full cursor-text border-2 leading-normal min-h-10 border-base-300 flex items-center shadow-none overflow-auto hover:border-base-400`}
     />
 );
 
 const Menu = ({ className, ...props }) => (
     <selectComponents.Menu
-        className={`${className} bg-base-200 shadow-lg z-60 font-600 text-left`}
+        className={`${className} bg-base-200 shadow-lg z-60 text-left`}
         {...props}
     />
 );

--- a/ui/apps/platform/src/Components/URLSearchInputWithAutocomplete.js
+++ b/ui/apps/platform/src/Components/URLSearchInputWithAutocomplete.js
@@ -22,7 +22,7 @@ export const placeholderCreator = (placeholderText) => () =>
     (
         <span className="flex h-full items-center pointer-events-none">
             <input
-                className="font-600 bg-base-100 text-base-600 absolute"
+                className="bg-base-100 text-base-600 absolute"
                 placeholder={placeholderText}
                 readOnly
             />

--- a/ui/apps/platform/src/Components/forms/ReduxPasswordField.js
+++ b/ui/apps/platform/src/Components/forms/ReduxPasswordField.js
@@ -8,7 +8,7 @@ const ReduxPasswordField = ({ name, placeholder, disabled }) => (
         name={name}
         component="input"
         type="password"
-        className={`bg-base-100 border-2 rounded p-2 border-base-300 w-full font-600 text-base-600 leading-normal min-h-10 ${
+        className={`bg-base-100 border-2 rounded p-2 border-base-300 w-full text-base-600 leading-normal min-h-10 ${
             disabled ? 'bg-base-200' : 'hover:border-base-400'
         }`}
         placeholder={placeholder}

--- a/ui/apps/platform/src/Components/forms/ReduxTextField.js
+++ b/ui/apps/platform/src/Components/forms/ReduxTextField.js
@@ -8,7 +8,7 @@ const ReduxTextField = ({ name, disabled, placeholder }) => (
         name={name}
         component="input"
         type="text"
-        className={`bg-base-100 border-2 rounded p-2 border-base-300 w-full font-600 text-base-600 leading-normal min-h-10 ${
+        className={`bg-base-100 border-2 rounded p-2 border-base-300 w-full text-base-600 leading-normal min-h-10 ${
             disabled ? 'bg-base-200' : 'hover:border-base-400'
         }`}
         disabled={disabled}

--- a/ui/apps/platform/src/Containers/Clusters/Components/AdmissionControl/AdmissionControlStatusTotals.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/AdmissionControl/AdmissionControlStatusTotals.tsx
@@ -3,9 +3,9 @@ import React, { ReactElement } from 'react';
 import { healthStatusStyles } from '../../cluster.helpers';
 
 const trClassName = 'align-bottom leading-normal'; // align-bottom in case heading text wraps
-const thClassName = 'font-600 pl-0 pr-1 py-0 text-left';
+const thClassName = 'font-700 pl-0 pr-1 py-0 text-left';
 const tdClassName = 'p-0 text-right';
-const tdErrorsClassName = 'font-600 pb-0 pl-0 pr-1 pt-2 text-left'; // pt for gap above errors
+const tdErrorsClassName = 'pb-0 pl-0 pr-1 pt-2 text-left'; // pt for gap above errors
 
 type AdmissionControlStatusTotalsProps = {
     admissionControlHealthInfo: {

--- a/ui/apps/platform/src/Containers/Clusters/Components/Collector/CollectorStatusTotals.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/Collector/CollectorStatusTotals.tsx
@@ -3,9 +3,9 @@ import React, { ReactElement } from 'react';
 import { healthStatusStyles } from '../../cluster.helpers';
 
 const trClassName = 'align-bottom leading-normal'; // align-bottom in case heading text wraps
-const thClassName = 'font-600 pl-0 pr-1 py-0 text-left';
+const thClassName = 'font-700 pl-0 pr-1 py-0 text-left';
 const tdClassName = 'p-0 text-right';
-const tdErrorsClassName = 'font-600 pb-0 pl-0 pr-1 pt-2 text-left'; // pt for gap above errors
+const tdErrorsClassName = 'pb-0 pl-0 pr-1 pt-2 text-left'; // pt for gap above errors
 
 type CollectorStatusTotalsProps = {
     collectorHealthInfo: {

--- a/ui/apps/platform/src/Containers/Clusters/Components/Scanner/ScannerStatusTotals.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/Scanner/ScannerStatusTotals.tsx
@@ -3,9 +3,9 @@ import { healthStatusLabels } from 'messages/common';
 import { healthStatusStyles } from '../../cluster.helpers';
 
 const trClassName = 'align-bottom leading-normal'; // align-bottom in case heading text wraps
-const thClassName = 'font-600 pl-0 pr-1 py-0 text-left';
+const thClassName = 'font-700 pl-0 pr-1 py-0 text-left';
 const tdClassName = 'p-0 text-right';
-const tdErrorsClassName = 'font-600 pb-0 pl-0 pr-1 pt-2 text-left'; // pt for gap above errors
+const tdErrorsClassName = 'pb-0 pl-0 pr-1 pt-2 text-left'; // pt for gap above errors
 
 type ScannerStatusTotalsProps = {
     scannerHealthInfo: {

--- a/ui/apps/platform/src/Containers/Clusters/Components/SensorUpgrade.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/SensorUpgrade.tsx
@@ -7,7 +7,7 @@ import { findUpgradeState, formatSensorVersion, sensorUpgradeStyles } from '../c
 import { SensorUpgradeStatus } from '../clusterTypes';
 
 const trClassName = 'align-top leading-normal';
-const thClassName = 'font-600 pl-0 pr-1 py-0 text-left';
+const thClassName = 'font-700 pl-0 pr-1 py-0 text-left';
 const tdClassName = 'p-0 text-left';
 
 const testId = 'sensorUpgrade';

--- a/ui/apps/platform/src/constants/form.constants.ts
+++ b/ui/apps/platform/src/constants/form.constants.ts
@@ -1,21 +1,22 @@
 // styles for forms, until we standardize on UI components for forms
 export const labelClassName = 'block py-2 text-base-600 font-700';
-export const sublabelClassName = 'font-600';
+export const sublabelClassName = 'font-400';
 
 export const wrapperMarginClassName = 'mb-4';
 
 export const inputBaseClassName =
-    'bg-base-100 border-2 border-base-300 hover:border-base-400 font-600 leading-normal p-2 first:rounded-t last:rounded-b text-base-600 disabled:bg-base-200';
+    'bg-base-100 border-2 border-base-300 hover:border-base-400 leading-normal p-2 first:rounded-t last:rounded-b text-base-600 disabled:bg-base-200';
 export const inputTextClassName = `${inputBaseClassName} w-full`;
 export const inputNumberClassName = `${inputBaseClassName} text-right w-12`;
 
 export const divToggleOuterClassName =
-    'bg-base-100 border-2 border-base-300 hover:border-base-400 font-600 leading-normal px-2 py-2 rounded-t last:rounded-b text-base-600 w-full';
+    'bg-base-100 border-2 border-base-300 hover:border-base-400 leading-normal px-2 py-2 rounded-t last:rounded-b text-base-600 w-full';
 
 export const justifyBetweenClassName = 'flex items-center justify-between';
 
 // The select element base style includes: pr-8 w-full
+// Add font-400 to override `font-weight: 600` for select element from ui-components.css file.
 export const selectElementClassName =
-    'bg-base-100 block border-base-300 focus:border-base-500 p-2 text-base-600 z-1';
+    'bg-base-100 block border-base-300 focus:border-base-500 p-2 text-base-600 font-400 z-1';
 export const selectWrapperClassName =
-    'bg-base-100 border-2 border-base-300 hover:border-base-400 font-600 leading-normal rounded text-base-600 w-full';
+    'bg-base-100 border-2 border-base-300 hover:border-base-400 leading-normal rounded text-base-600 w-full';


### PR DESCRIPTION
## Description

As part of ongoing accessibilty effort, delete leftover styles that detract from legibility of Red Hat font with PatternFly colors.

### Problem

* Classic contrast between bold font-700 and normal font-600 was sometimes too subtle to see.
* PatternFly contrast between bold font-700 and normal font-400 makes obvious some inconsistent unneeded bold formatting.

### Analysis and Solution

Find in Files `font-600` reduced from 25 results in 16 files to 8 results in 6 files that are soon to be deleted: 5 files for Network Graph 1.0 and 1 file for Vulnerability Management Policy.

1. Remove `font-600` if normal font weight is appropriate:
    * src/Components/Pagination/PaginationInput/PaginationInput.js
    * src/Components/ReactSelect/ReactSelect.js
    * src/Components/URLSearchInputWithAutocomplete.js
    * src/Components/forms/ReduxPasswordField.js
    * src/Components/forms/ReduxTextField.js
    * src/constants/form.constants.ts but specify `font-400` where parent style class or element style rule specifies bold font weight that is not necessary for sublabel or select element.

2. Replace `font-600` with `font-700` if bold font weight is appropriate:
    * src/Containers/Clusters/Components/SensorUpgrade.tsx
    * src/Containers/Clusters/Components/AdmissionControl/AdmissionControlStatusTotals.tsx replace in `thClassName` but remove in `tdErrorsClassName`
    * src/Containers/Clusters/Components/Collector/CollectorStatusTotals.tsx ditto
    * src/Containers/Clusters/Components/Scanner/ScannerStatusTotals.tsx ditto

### Residue

1. Replace Redux form elements with PatternFly form elements and `LoginPage` element.

## Checklist
- [x] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

### Manual testing

1. Start or log out to visit /main/login
    * See normal font weight 400 in `div` element for **Select an auth provider**
    * See normal font weight 400 in `input` element for **Username**
    * See normal font weight 400 in `input` element for **Password**
        ![login](https://github.com/stackrox/stackrox/assets/11862657/cd4c4e07-2d98-49bb-be71-608974e90c2f)

2. Visit /main/vulnerability-management/images and click **Manage Watches**.
    * See normal font weight for sublabel sentence under **Image Name** label.
        ![Manage_Watches](https://github.com/stackrox/stackrox/assets/11862657/da3ba3d2-cd3d-437b-b69e-70ff8c05f78d)

3. Visit /main/risk
    * See normal font weight for placeholder in search filter.
        ![risk_placeholder](https://github.com/stackrox/stackrox/assets/11862657/c34f3b60-aba6-41f8-bbc8-c636b66737fb)

4. Click a deployment, click **Process Discovery**, and then click **View Graph**.
    * See bold font weight for pagination at lower left from ancestor class.
        ![risk_PaginationInput](https://github.com/stackrox/stackrox/assets/11862657/de920f31-501c-49f4-a4d0-a22030261f8d)

5. Visit /main/clusters and click a row to open the side panel.
    * See bold font weight for table head (scope row) cells.
        ![clusters_th](https://github.com/stackrox/stackrox/assets/11862657/27efc3aa-e216-43ef-96b8-3bf702a4d179)

6. Scroll down to **Static Configuration** and **Dynamic Configuration** forms.
    * See normal font weight in `input` elements.
        ![clusters_Configuration](https://github.com/stackrox/stackrox/assets/11862657/23b683ac-193e-405e-b10b-06dfe9fd1409)
