### PR TITLE
ROX-17499: Two minor changes

### DIFF
--- a/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
+++ b/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
@@ -148,6 +148,8 @@ class BaseSpecification extends Specification {
 
         setupCoreImageIntegration()
 
+        RestAssured.useRelaxedHTTPSValidation()
+
         addShutdownHook {
             LOG.info "Performing global shutdown"
             BaseService.useBasicAuth()
@@ -189,14 +191,13 @@ class BaseSpecification extends Specification {
     long orchestratorCreateTime = System.currentTimeSeconds()
 
     @Shared
-    private long testStartTimeMillis
+    private long testSpecStartTimeMillis
 
     def setupSpec() {
         log.info("Starting testsuite")
 
-        testStartTimeMillis = System.currentTimeMillis()
+        testSpecStartTimeMillis = System.currentTimeMillis()
 
-        RestAssured.useRelaxedHTTPSValidation()
         globalSetup()
 
         try {

--- a/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
@@ -672,7 +672,7 @@ class NetworkFlowTest extends BaseSpecification {
         "Check timestamp for each edge"
         for (Edge edge : NetworkGraphUtil.findEdges(currentGraph, null, null)) {
             assert edge.lastActiveTimestamp <= currentTime + 2000 //allow up to 2 sec leeway
-            assert edge.lastActiveTimestamp >= testStartTimeMillis
+            assert edge.lastActiveTimestamp >= testSpecStartTimeMillis
         }
     }
 
@@ -688,7 +688,7 @@ class NetworkFlowTest extends BaseSpecification {
         and:
         "delete a deployment"
         Deployment delete = deployments.find { it.name == NOCONNECTIONSOURCE }
-        orchestrator.deleteDeployment(delete)testSpecStartTimeMillis
+        orchestrator.deleteDeployment(delete)
         Services.waitForSRDeletion(delete)
 
         when:

--- a/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
@@ -688,7 +688,7 @@ class NetworkFlowTest extends BaseSpecification {
         and:
         "delete a deployment"
         Deployment delete = deployments.find { it.name == NOCONNECTIONSOURCE }
-        orchestrator.deleteDeployment(delete)
+        orchestrator.deleteDeployment(delete)testSpecStartTimeMillis
         Services.waitForSRDeletion(delete)
 
         when:


### PR DESCRIPTION
## Description

- Change the test start time variable so that it is more clearly test spec related.
- Move RestAssured config to globalSetup().

## Checklist
- [x] Investigated and inspected CI test results - the test failure is a flake unrelated to this change.

## Testing Performed

CI is sufficient.