### PR TITLE
ROX-17499: Setup orchestrator once

### DIFF
--- a/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
+++ b/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
@@ -153,7 +153,7 @@ class BaseSpecification extends Specification {
         try {
             orchestrator.setup()
         } catch (Exception e) {
-            log.error("Error setting up orchestrator", e)
+            LOG.error("Error setting up orchestrator", e)
             throw e
         }
 
@@ -176,7 +176,7 @@ class BaseSpecification extends Specification {
             try {
                 orchestrator.cleanup()
             } catch (Exception e) {
-                log.error("Failed to clean up orchestrator", e)
+                LOG.error("Failed to clean up orchestrator", e)
                 throw e
             }
         }

--- a/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
+++ b/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
@@ -150,6 +150,13 @@ class BaseSpecification extends Specification {
 
         RestAssured.useRelaxedHTTPSValidation()
 
+        try {
+            orchestrator.setup()
+        } catch (Exception e) {
+            log.error("Error setting up orchestrator", e)
+            throw e
+        }
+
         addShutdownHook {
             LOG.info "Performing global shutdown"
             BaseService.useBasicAuth()
@@ -164,6 +171,13 @@ class BaseSpecification extends Specification {
             LOG.info "Removing core image registry integration"
             if (coreImageIntegrationId != null) {
                 ImageIntegrationService.deleteImageIntegration(coreImageIntegrationId)
+            }
+
+            try {
+                orchestrator.cleanup()
+            } catch (Exception e) {
+                log.error("Failed to clean up orchestrator", e)
+                throw e
             }
         }
 
@@ -200,12 +214,6 @@ class BaseSpecification extends Specification {
 
         globalSetup()
 
-        try {
-            orchestrator.setup()
-        } catch (Exception e) {
-            log.error("Error setting up orchestrator", e)
-            throw e
-        }
         BaseService.useBasicAuth()
         BaseService.setUseClientCert(false)
 
@@ -275,13 +283,6 @@ class BaseSpecification extends Specification {
 
         BaseService.useBasicAuth()
         BaseService.setUseClientCert(false)
-
-        try {
-            orchestrator.cleanup()
-        } catch (Exception e) {
-            log.error("Failed to clean up orchestrator", e)
-            throw e
-        }
 
         // https://issues.redhat.com/browse/ROX-9950 -- fails on OSD-on-AWS
         if (orchestrator.isGKE()) {


### PR DESCRIPTION
## Description

Per title. It is probably harmless that this occurs for each test specification but there is no need. Moving the setup (namespace, PSP and SA creation) to globalSetup() also makes it thread safe.

## Checklist
- [x] Investigated and inspected CI test results - the test failure is a flake unrelated to this change.

## Testing Performed

CI is sufficient.