### PR TITLE
ROX-17499: Check resource leaks over the entire test run

### DIFF
--- a/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
+++ b/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
@@ -66,7 +66,7 @@ class BaseSpecification extends Specification {
 
     public static strictIntegrationTesting = false
 
-    Map<String, List<String>> resourceRecord = [:]
+    private static Map<String, List<String>> resourceRecord = [:]
 
     public static String coreImageIntegrationId = null
 
@@ -162,6 +162,11 @@ class BaseSpecification extends Specification {
             LOG.error("Error setting up orchestrator", e)
             throw e
         }
+        
+        // ROX-9950 Limit to GKE due to issues on other providers.
+        if (orchestrator.isGKE()) {
+            recordResourcesAtSpecStart()
+        }
 
         addShutdownHook {
             LOG.info "Performing global shutdown"
@@ -184,6 +189,11 @@ class BaseSpecification extends Specification {
             } catch (Exception e) {
                 LOG.error("Failed to clean up orchestrator", e)
                 throw e
+            }
+            
+            // ROX-9950 Limit to GKE due to issues on other providers.
+            if (orchestrator.isGKE()) {
+                compareResourcesAtSpecEnd()
             }
         }
 
@@ -222,8 +232,6 @@ class BaseSpecification extends Specification {
 
         BaseService.useBasicAuth()
         BaseService.setUseClientCert(false)
-
-        recordResourcesAtSpecStart()
     }
 
     static setupCoreImageIntegration() {
@@ -289,11 +297,6 @@ class BaseSpecification extends Specification {
 
         BaseService.useBasicAuth()
         BaseService.setUseClientCert(false)
-
-        // https://issues.redhat.com/browse/ROX-9950 -- fails on OSD-on-AWS
-        if (orchestrator.isGKE()) {
-            compareResourcesAtSpecEnd()
-        }
     }
 
     def compareResourcesAtSpecEnd() {

--- a/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
+++ b/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
@@ -165,7 +165,7 @@ class BaseSpecification extends Specification {
         
         // ROX-9950 Limit to GKE due to issues on other providers.
         if (orchestrator.isGKE()) {
-            recordResourcesAtSpecStart()
+            recordResourcesAtSpecStart(orchestrator)
         }
 
         addShutdownHook {
@@ -193,7 +193,7 @@ class BaseSpecification extends Specification {
             
             // ROX-9950 Limit to GKE due to issues on other providers.
             if (orchestrator.isGKE()) {
-                compareResourcesAtSpecEnd()
+                compareResourcesAtSpecEnd(orchestrator)
             }
         }
 
@@ -259,7 +259,7 @@ class BaseSpecification extends Specification {
         }
     }
 
-    def recordResourcesAtSpecStart() {
+    private static void recordResourcesAtSpecStart(OrchestratorMain orchestrator) {
         resourceRecord = [
                 "namespaces": orchestrator.getNamespaces(),
                 "deployments": orchestrator.getDeployments("default") +
@@ -299,7 +299,7 @@ class BaseSpecification extends Specification {
         BaseService.setUseClientCert(false)
     }
 
-    def compareResourcesAtSpecEnd() {
+    private static void compareResourcesAtSpecEnd(OrchestratorMain orchestrator) {
         Javers javers = JaversBuilder.javers()
                 .withListCompareAlgorithm(ListCompareAlgorithm.AS_SET)
                 .build()
@@ -307,8 +307,8 @@ class BaseSpecification extends Specification {
         List<String> namespaces = orchestrator.getNamespaces()
         Diff diff = javers.compare(resourceRecord["namespaces"], namespaces)
         if (diff.hasChanges()) {
-            log.info "There is a difference in namespaces between the start and end of this test spec:"
-            log.info diff.prettyPrint()
+            LOG.info "There is a difference in namespaces between the start and end of this test run:"
+            LOG.info diff.prettyPrint()
             throw new TestSpecRuntimeException("Namespaces have changed. Ensure that any namespace created " +
                     "in a test spec is deleted in that test spec.")
         }
@@ -317,8 +317,8 @@ class BaseSpecification extends Specification {
                 orchestrator.getDeployments(Constants.ORCHESTRATOR_NAMESPACE)
         diff = javers.compare(resourceRecord["deployments"], deployments)
         if (diff.hasChanges()) {
-            log.info "There is a difference in deployments between the start and end of this test spec"
-            log.info diff.prettyPrint()
+            LOG.info "There is a difference in deployments between the start and end of this test run"
+            LOG.info diff.prettyPrint()
             throw new TestSpecRuntimeException("Deployments have changed. Ensure that any deployments created " +
                     "in a test spec are destroyed in that test spec.")
         }

--- a/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
+++ b/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
@@ -162,7 +162,7 @@ class BaseSpecification extends Specification {
             LOG.error("Error setting up orchestrator", e)
             throw e
         }
-        
+
         // ROX-9950 Limit to GKE due to issues on other providers.
         if (orchestrator.isGKE()) {
             recordResourcesAtRunStart(orchestrator)
@@ -190,7 +190,7 @@ class BaseSpecification extends Specification {
                 LOG.error("Failed to clean up orchestrator", e)
                 throw e
             }
-            
+
             // ROX-9950 Limit to GKE due to issues on other providers.
             if (orchestrator.isGKE()) {
                 compareResourcesAtRunEnd(orchestrator)

--- a/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
+++ b/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
@@ -165,7 +165,7 @@ class BaseSpecification extends Specification {
         
         // ROX-9950 Limit to GKE due to issues on other providers.
         if (orchestrator.isGKE()) {
-            recordResourcesAtSpecStart(orchestrator)
+            recordResourcesAtRunStart(orchestrator)
         }
 
         addShutdownHook {
@@ -193,7 +193,7 @@ class BaseSpecification extends Specification {
             
             // ROX-9950 Limit to GKE due to issues on other providers.
             if (orchestrator.isGKE()) {
-                compareResourcesAtSpecEnd(orchestrator)
+                compareResourcesAtRunEnd(orchestrator)
             }
         }
 
@@ -259,7 +259,7 @@ class BaseSpecification extends Specification {
         }
     }
 
-    private static void recordResourcesAtSpecStart(OrchestratorMain orchestrator) {
+    private static void recordResourcesAtRunStart(OrchestratorMain orchestrator) {
         resourceRecord = [
                 "namespaces": orchestrator.getNamespaces(),
                 "deployments": orchestrator.getDeployments("default") +
@@ -299,7 +299,7 @@ class BaseSpecification extends Specification {
         BaseService.setUseClientCert(false)
     }
 
-    private static void compareResourcesAtSpecEnd(OrchestratorMain orchestrator) {
+    private static void compareResourcesAtRunEnd(OrchestratorMain orchestrator) {
         Javers javers = JaversBuilder.javers()
                 .withListCompareAlgorithm(ListCompareAlgorithm.AS_SET)
                 .build()


### PR DESCRIPTION
## Description

Previously this was done on a per spec basis but that will not be feasible with concurrent tests. This PR changes the record and compare to a per run basis.

## Checklist
- [x] Investigated and inspected CI test results - the test failure is a flake unrelated to this change.

## Testing Performed

CI is sufficient