### PR TITLE
ROX-17742: Fix CI `cannot parse UUID id` error

### DIFF
--- a/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
+++ b/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
@@ -213,7 +213,7 @@ class BaseSpecification extends Specification {
 
     static setupCoreImageIntegration() {
         coreImageIntegrationId = ImageIntegrationService.getImageIntegrationByName(
-                Constants.CORE_IMAGE_INTEGRATION_NAME)
+                Constants.CORE_IMAGE_INTEGRATION_NAME)?.id
         if (!coreImageIntegrationId) {
             LOG.info "Adding core image registry integration"
             coreImageIntegrationId = ImageIntegrationService.createImageIntegration(


### PR DESCRIPTION
## Description

Fixes an edge case causing CI failures.

If an image integration with name `core quay` exists in the cluster under test when the groovy test suite is started, attempts to delete the integration will fail due to an invalid UUID.  This is caused by the `coreImageIntegrationId` var being set to the value `id: <uuid>`, the `id:` prefix will cause UUID parse errors:

```
ImageScanningTest > Image metadata from registry test - #testName > ImageScanningTest.Image metadata from registry test - quay-auto STANDARD_OUT
    17:23:23 | INFO  | ImageScanningTest         | Starting testcase
    17:23:23 | WARN  | ImageIntegrationService   | Failed to delete integration
    io.grpc.StatusRuntimeException: INTERNAL: cannot parse UUID id: "56489001-b712-4301-9a50-c1650c30d88b"
```

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

- Created a `core quay` integration and then ran `./gradlew test --tests=ImageScanningTest.*metadata*` to reproduce the error.
- Made the fix and re-ran with success
