### PR TITLE
ROX-11796, ROX-16835, ROX-17416: Fix timeouts for roxctl

### DIFF
--- a/roxctl/central/debug/dump.go
+++ b/roxctl/central/debug/dump.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	dumpTimeout = 2 * time.Minute
+	dumpTimeout = 5 * time.Minute
 )
 
 // dumpCommand allows pulling logs, profiles, and metrics

--- a/roxctl/central/initbundles/constants.go
+++ b/roxctl/central/initbundles/constants.go
@@ -1,8 +1,0 @@
-package initbundles
-
-import "time"
-
-const (
-	// contextTimeout is the timeout used for accessing the init bundle management API.
-	contextTimeout = 10 * time.Second
-)

--- a/roxctl/central/initbundles/fetch_ca.go
+++ b/roxctl/central/initbundles/fetch_ca.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"os"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -12,10 +13,11 @@ import (
 	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/rox/roxctl/common"
 	"github.com/stackrox/rox/roxctl/common/environment"
+	"github.com/stackrox/rox/roxctl/common/flags"
 )
 
-func fetchCAConfig(cliEnvironment environment.Environment, outputFile string) error {
-	ctx, cancel := context.WithTimeout(pkgCommon.Context(), contextTimeout)
+func fetchCAConfig(cliEnvironment environment.Environment, outputFile string, timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(pkgCommon.Context(), timeout)
 	defer cancel()
 
 	conn, err := cliEnvironment.GRPCConnection()
@@ -76,7 +78,7 @@ func fetchCACommand(cliEnvironment environment.Environment) *cobra.Command {
 			} else if outputFile == "-" {
 				outputFile = ""
 			}
-			return fetchCAConfig(cliEnvironment, outputFile)
+			return fetchCAConfig(cliEnvironment, outputFile, flags.Timeout(cmd))
 		},
 	}
 	c.PersistentFlags().StringVar(&outputFile, "output", "", "file to be used for storing the CA config")

--- a/roxctl/central/initbundles/generate.go
+++ b/roxctl/central/initbundles/generate.go
@@ -3,6 +3,7 @@ package initbundles
 import (
 	"context"
 	"os"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -12,6 +13,7 @@ import (
 	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/rox/roxctl/common"
 	"github.com/stackrox/rox/roxctl/common/environment"
+	"github.com/stackrox/rox/roxctl/common/flags"
 )
 
 type output struct {
@@ -19,8 +21,8 @@ type output struct {
 	filename string
 }
 
-func generateInitBundle(cliEnvironment environment.Environment, name string, outputs []output) error {
-	ctx, cancel := context.WithTimeout(pkgCommon.Context(), contextTimeout)
+func generateInitBundle(cliEnvironment environment.Environment, name string, outputs []output, timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(pkgCommon.Context(), timeout)
 	defer cancel()
 
 	conn, err := cliEnvironment.GRPCConnection()
@@ -127,7 +129,7 @@ func generateCommand(cliEnvironment environment.Environment) *cobra.Command {
 			if len(outputs) == 0 {
 				return common.ErrInvalidCommandOption.New("No output files specified with --output or --output-secrets (for stdout, specify '-')")
 			}
-			return generateInitBundle(cliEnvironment, name, outputs)
+			return generateInitBundle(cliEnvironment, name, outputs, flags.Timeout(cmd))
 		},
 	}
 	c.PersistentFlags().StringVar(&outputFile, "output", "", "file to be used for storing the newly generated init bundle in Helm configuration form (- for stdout)")

--- a/roxctl/central/initbundles/initbundles.go
+++ b/roxctl/central/initbundles/initbundles.go
@@ -3,6 +3,7 @@ package initbundles
 import (
 	"github.com/spf13/cobra"
 	"github.com/stackrox/rox/roxctl/common/environment"
+	"github.com/stackrox/rox/roxctl/common/flags"
 )
 
 // Command defines the bootstrap-token command tree
@@ -17,6 +18,8 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 		revokeCommand(cliEnvironment),
 		fetchCACommand(cliEnvironment),
 	)
+
+	flags.AddTimeout(c)
 
 	return c
 }

--- a/roxctl/central/initbundles/list.go
+++ b/roxctl/central/initbundles/list.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sort"
 	"text/tabwriter"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -12,11 +13,12 @@ import (
 	pkgCommon "github.com/stackrox/rox/pkg/roxctl/common"
 	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/rox/roxctl/common/environment"
+	"github.com/stackrox/rox/roxctl/common/flags"
 	"github.com/stackrox/rox/roxctl/common/util"
 )
 
-func listInitBundles(cliEnvironment environment.Environment) error {
-	ctx, cancel := context.WithTimeout(pkgCommon.Context(), contextTimeout)
+func listInitBundles(cliEnvironment environment.Environment, timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(pkgCommon.Context(), timeout)
 	defer cancel()
 
 	conn, err := cliEnvironment.GRPCConnection()
@@ -62,7 +64,7 @@ func listCommand(cliEnvironment environment.Environment) *cobra.Command {
 		Short: "List cluster init bundles",
 		Long:  "List all previously generated init bundles for bootstrapping new StackRox secured clusters",
 		RunE: util.RunENoArgs(func(c *cobra.Command) error {
-			return listInitBundles(cliEnvironment)
+			return listInitBundles(cliEnvironment, flags.Timeout(c))
 		}),
 	}
 	return c

--- a/roxctl/central/initbundles/revoke.go
+++ b/roxctl/central/initbundles/revoke.go
@@ -3,6 +3,7 @@ package initbundles
 import (
 	"context"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -12,6 +13,7 @@ import (
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/rox/roxctl/common/environment"
+	"github.com/stackrox/rox/roxctl/common/flags"
 	"github.com/stackrox/rox/roxctl/common/logger"
 )
 
@@ -55,8 +57,8 @@ func printResponseResult(logger logger.Logger, resp *v1.InitBundleRevokeResponse
 	}
 }
 
-func revokeInitBundles(cliEnvironment environment.Environment, idsOrNames []string) error {
-	ctx, cancel := context.WithTimeout(pkgCommon.Context(), contextTimeout)
+func revokeInitBundles(cliEnvironment environment.Environment, idsOrNames []string, timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(pkgCommon.Context(), timeout)
 	defer cancel()
 
 	conn, err := cliEnvironment.GRPCConnection()
@@ -81,7 +83,7 @@ func revokeCommand(cliEnvironment environment.Environment) *cobra.Command {
 		Long:  "Revoke an init bundle for bootstrapping new StackRox secured clusters",
 		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return revokeInitBundles(cliEnvironment, args)
+			return revokeInitBundles(cliEnvironment, args, flags.Timeout(cmd))
 		},
 	}
 

--- a/roxctl/cluster/cluster.go
+++ b/roxctl/cluster/cluster.go
@@ -1,8 +1,6 @@
 package cluster
 
 import (
-	"time"
-
 	"github.com/spf13/cobra"
 	"github.com/stackrox/rox/roxctl/cluster/delete"
 	"github.com/stackrox/rox/roxctl/common/environment"
@@ -17,6 +15,6 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 	}
 
 	c.AddCommand(delete.Command(cliEnvironment))
-	flags.AddTimeoutWithDefault(c, 5*time.Second)
+	flags.AddTimeout(c)
 	return c
 }

--- a/roxctl/collector/supportpackages/upload/command.go
+++ b/roxctl/collector/supportpackages/upload/command.go
@@ -1,15 +1,19 @@
 package upload
 
 import (
+	"time"
+
 	"github.com/spf13/cobra"
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/roxctl/common/environment"
+	"github.com/stackrox/rox/roxctl/common/flags"
 )
 
 type collectorSPUploadCommand struct {
 	// Properties that are bound to cobra flags.
 	overwrite   bool
 	packageFile string
+	timeout     time.Duration
 
 	// Properties that are injected or constructed.
 	env environment.Environment
@@ -26,7 +30,7 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 			if err := validate(args); err != nil {
 				return err
 			}
-			if err := collectorSPUploadCmd.construct(args); err != nil {
+			if err := collectorSPUploadCmd.construct(c, args); err != nil {
 				return err
 			}
 			return collectorSPUploadCmd.uploadFilesFromPackage()
@@ -34,6 +38,7 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 	}
 
 	c.Flags().BoolVarP(&collectorSPUploadCmd.overwrite, "overwrite", "", false, "whether to overwrite present but different files")
+	flags.AddTimeout(c)
 	return c
 }
 
@@ -47,7 +52,8 @@ func validate(args []string) error {
 	return nil
 }
 
-func (cmd *collectorSPUploadCommand) construct(args []string) error {
+func (cmd *collectorSPUploadCommand) construct(c *cobra.Command, args []string) error {
 	cmd.packageFile = args[0]
+	cmd.timeout = flags.Timeout(c)
 	return nil
 }

--- a/roxctl/collector/supportpackages/upload/upload.go
+++ b/roxctl/collector/supportpackages/upload/upload.go
@@ -25,9 +25,6 @@ import (
 )
 
 const (
-	grpcTimeout       = 30 * time.Second
-	uploadIdleTimeout = 30 * time.Second
-
 	kernelModulesDirPrefix = "kernel-modules/"
 )
 
@@ -66,7 +63,7 @@ func (cmd *collectorSPUploadCommand) retrieveExistingProbeFiles(probeFilesInPack
 		req.FilesToCheck = append(req.FilesToCheck, probeFileName)
 	}
 
-	ctx, cancel := context.WithTimeout(common.Context(), grpcTimeout)
+	ctx, cancel := context.WithTimeout(common.Context(), cmd.timeout)
 	defer cancel()
 
 	resp, err := probeUploadClient.GetExistingProbes(ctx, req)
@@ -148,7 +145,7 @@ func (cmd *collectorSPUploadCommand) doFileUpload(manifest *v1.ProbeUploadManife
 	req.URL.RawQuery = urlParams.Encode()
 
 	cmd.env.Logger().InfofLn("Uploading %d files from support package ...\n", len(manifest.GetFiles()))
-	resp, err := transfer.ViaHTTP(req, httpClient, time.Now(), uploadIdleTimeout)
+	resp, err := transfer.ViaHTTP(req, httpClient, time.Now(), cmd.timeout)
 	if err != nil {
 		return errors.Wrap(err, "HTTP transport error while uploading collector support files")
 	}

--- a/roxctl/common/flags/timeout.go
+++ b/roxctl/common/flags/timeout.go
@@ -18,12 +18,14 @@ func AddTimeoutWithDefault(c *cobra.Command, defaultDuration time.Duration) {
 
 // AddTimeout adds a timeout flag to the given command, with the global default value.
 func AddTimeout(c *cobra.Command) {
-	AddTimeoutWithDefault(c, 30*time.Second)
+	AddTimeoutWithDefault(c, 1*time.Minute)
 }
 
 // Timeout returns the set timeout.
 func Timeout(c *cobra.Command) time.Duration {
-	duration, err := c.Flags().GetDuration(timeoutFlagName)
+	// Since a command can be the one adding the timeout flag via AddTimeout, make sure we look at the combined
+	// list of persistent flag set and the commands flag set called LocalFlags.
+	duration, err := c.LocalFlags().GetDuration(timeoutFlagName)
 	if err != nil {
 		// This is a programming error. You shouldn't use the timeout flag unless you've added it to your command!
 		// This helps us fail explicitly instead of defaulting to a zero timeout and allowing people to think it worked.

--- a/roxctl/common/flags/timeout.go
+++ b/roxctl/common/flags/timeout.go
@@ -23,13 +23,16 @@ func AddTimeout(c *cobra.Command) {
 
 // Timeout returns the set timeout.
 func Timeout(c *cobra.Command) time.Duration {
-	// Since a command can be the one adding the timeout flag via AddTimeout, make sure we look at the combined
-	// list of persistent flag set and the commands flag set called LocalFlags.
-	duration, err := c.LocalFlags().GetDuration(timeoutFlagName)
-	if err != nil {
-		// This is a programming error. You shouldn't use the timeout flag unless you've added it to your command!
-		// This helps us fail explicitly instead of defaulting to a zero timeout and allowing people to think it worked.
-		panic(fmt.Sprintf("command does not have a timeout flag: %v", err))
+	duration, err := c.Flags().GetDuration(timeoutFlagName)
+	if err == nil {
+		return duration
 	}
-	return duration
+
+	duration, err = c.PersistentFlags().GetDuration(timeoutFlagName)
+	if err == nil {
+		return duration
+	}
+	// This is a programming error. You shouldn't use the timeout flag unless you've added it to your command!
+	// This helps us fail explicitly instead of defaulting to a zero timeout and allowing people to think it worked.
+	panic(fmt.Sprintf("command does not have a timeout flag: %v", err))
 }

--- a/roxctl/deployment/deployment.go
+++ b/roxctl/deployment/deployment.go
@@ -17,6 +17,10 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 	}
 
 	c.AddCommand(check.Command(cliEnvironment))
-	flags.AddTimeoutWithDefault(c, 1*time.Minute)
+	// For deployments with unscanned images, the result of the detection service will take longer since scans are
+	// being performed in-line. Hence, need to set the timeout to a more generous value.
+	// In reality, if the image is already scanned and no force flag is given, this shouldn't take longer than the
+	// default timeout.
+	flags.AddTimeoutWithDefault(c, 10*time.Minute)
 	return c
 }

--- a/roxctl/helm/derivelocalvalues/command_test.go
+++ b/roxctl/helm/derivelocalvalues/command_test.go
@@ -3,6 +3,7 @@ package derivelocalvalues
 import (
 	"bytes"
 	"testing"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/stackrox/rox/pkg/errox"
@@ -78,9 +79,9 @@ func (suite *helmDeriveLocalValuesTestSuite) TestConstruct() {
 	chartName := "test_chartName"
 
 	helmCmd := suite.helmDeriveLocalValuesCommand
-	helmCmd.Construct(chartName)
+	helmCmd.Construct(Command(helmCmd.env), chartName)
 	suite.Assert().Equal(chartName, helmCmd.chartName)
-
+	suite.Assert().Equal(time.Minute, helmCmd.timeout)
 }
 
 func (suite *helmDeriveLocalValuesTestSuite) TestValidate() {

--- a/roxctl/helm/derivelocalvalues/derivelocalvalues.go
+++ b/roxctl/helm/derivelocalvalues/derivelocalvalues.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
@@ -24,9 +25,10 @@ var (
 	supportedCharts = []string{common.ChartCentralServices}
 )
 
-func deriveLocalValuesForChart(env environment.Environment, namespace, chartName, input, output string, useDirectory bool) error {
+func deriveLocalValuesForChart(env environment.Environment, namespace, chartName, input, output string,
+	useDirectory bool, timeout time.Duration) error {
 	var err error
-	ctx, cancel := context.WithTimeout(context.Background(), contextTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	switch chartName {
 	case common.ChartCentralServices:

--- a/roxctl/scanner/scanner.go
+++ b/roxctl/scanner/scanner.go
@@ -1,11 +1,8 @@
 package scanner
 
 import (
-	"time"
-
 	"github.com/spf13/cobra"
 	"github.com/stackrox/rox/roxctl/common/environment"
-	"github.com/stackrox/rox/roxctl/common/flags"
 	"github.com/stackrox/rox/roxctl/scanner/generate"
 	"github.com/stackrox/rox/roxctl/scanner/uploaddb"
 )
@@ -16,7 +13,6 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 		Use:   "scanner",
 		Short: "Commands related to the Scanner service.",
 	}
-	flags.AddTimeoutWithDefault(c, time.Minute)
 	c.AddCommand(
 		generate.Command(cliEnvironment),
 		uploaddb.Command(cliEnvironment),

--- a/roxctl/scanner/uploaddb/uploaddb.go
+++ b/roxctl/scanner/uploaddb/uploaddb.go
@@ -73,6 +73,7 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 	}
 
 	c.Flags().StringVar(&scannerUploadDbCmd.filename, "scanner-db-file", "", "File containing the dumped Scanner definitions DB")
+	flags.AddTimeoutWithDefault(c, 10*time.Minute)
 	utils.Must(c.MarkFlagRequired("scanner-db-file"))
 
 	return c

--- a/roxctl/scanner/uploaddb/uploaddb_test.go
+++ b/roxctl/scanner/uploaddb/uploaddb_test.go
@@ -32,7 +32,6 @@ func executeUpdateDbCommand(t *testing.T, serverURL string) (*bytes.Buffer, *byt
 	env := environment.NewTestCLIEnvironment(t, testIO, printer.DefaultColorPrinter())
 
 	cmd := Command(env)
-	flags.AddTimeout(cmd)
 	flags.AddConnectionFlags(cmd)
 	flags.AddPassword(cmd)
 

--- a/roxctl/sensor/sensor.go
+++ b/roxctl/sensor/sensor.go
@@ -1,8 +1,6 @@
 package sensor
 
 import (
-	"time"
-
 	"github.com/spf13/cobra"
 	"github.com/stackrox/rox/roxctl/common/environment"
 	"github.com/stackrox/rox/roxctl/common/flags"
@@ -22,6 +20,6 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 		getbundle.Command(cliEnvironment),
 		generatecerts.Command(cliEnvironment),
 	)
-	flags.AddTimeoutWithDefault(c, 30*time.Second)
+	flags.AddTimeout(c)
 	return c
 }


### PR DESCRIPTION
## Description

This PR introduces configurable timeouts for all roxctl commands that require it and also adjusted the default timeout from 30 seconds to 1 minute.

The reason for changing the default timeout is due to context deadline exceed flakes seen in CI.

Below is a table that encompasses all changes, showing the previous timeout and notes about changes made:
| Command                           | Previous timeout | Changes made                                                                                               |
| --------------------------------- |:----------------:| ----------------------------------------------------------------------------------------------------------:|
| central backup                    | 1h               | -                                                                                                          |
| central cert                      | 30s              | Increased to 1m by increasing the default timeout                                                          |
| central db backup                 | 1h               | -                                                                                                          |
| central db generate               | 1h               | -                                                                                                          |
| central db restore                | 1h               | -                                                                                                          |
| central debug authz-trace         | 20m              | -                                                                                                          |
| central debug log                 | 30s              | increased to 1m by increasing the default timeout                                                          |
| central debug download-diagnostic | 5m               | -                                                                                                          |
| central debug dump                | 2m               | adjusted to 5m to keep in-line with the download-diagnostic command                                        |
| central debug resync-check        | 5m               | -                                                                                                          |
| central init-bundle               | 10s (hardcoded)  | added timeout flag with default value which was increased to 1m                                            |
| central login                     | 5m               | -                                                                                                          |
| central userpki                   | 30s              | increased to 1m by increasing the default timeout                                                          |
| central whoami                    | 30s              | increased to 1m by increasing the default timeout                                                          |
| cluster delete                    | 5s               | increased to 1m by using the default timeout                                                               |
| collector supportpackages upload  | 30s              | increased to 1m by increasing the default timeout                                                          |
| deployment check                  | 1m               | increased to 10m to keep inline with image scan/check commands, since images may be scanned inline as well |
| helm derive-local-values          | 10s (hardcoded)  | increased to 1m by using the default timeout                                                               |
| scanner upload                    | 1m               | increased to 10m                                                                                           |
| sensor                            | 30s              | increased to 1m by increasing the default timeout                                                          |

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

- see CI passing.
