### PR TITLE
ROX-17388: Retry curls in roxctl tests

### DIFF
--- a/tests/roxctl/slim-collector.sh
+++ b/tests/roxctl/slim-collector.sh
@@ -24,7 +24,7 @@ curl_central() {
   url="$1"
   shift
   [[ -n "${url}" ]] || die "No URL specified"
-  curl -Sskf -u "admin:${ROX_PASSWORD}" "https://${API_ENDPOINT}/${url}" "$@"
+  curl --retry 5 -Sskf -u "admin:${ROX_PASSWORD}" "https://${API_ENDPOINT}/${url}" "$@"
 }
 
 check_image() {


### PR DESCRIPTION
## Description

There was an existing flake within the tests for the sensor bundle creation.

Within the tests, curl is used to reach out to central to retrieve the cluster ID. Occasionally, the call failed due to timeouts etc.

Added retries for the curl command to ensure such flakes should be reduced to a minimum.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

- see CI passing.
