### PR TITLE
ROX-16381, ROX-16407: byodb connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Please avoid adding duplicate information across this changelog and JIRA/doc inp
 - ROX-16962: A new parameter `spec.admissionControl.replicas` has been added to the `SecuredCluster` CRD.
 - ROX-18073: The implementation of Add Capabilities policy criteria has been fixed to ensure violations are generated \
 correctly for the specified values.
+- Rollback to a 3.y release or the 4.0 release will no longer be supported starting from 4.3.
+- Rollbacks from future releases to the 4.2 or later release will no longer require `ForceRollbackVersion` to be set.
 
 ## [4.1.0]
 

--- a/central/globaldb/v2backuprestore/manager/manager.go
+++ b/central/globaldb/v2backuprestore/manager/manager.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stackrox/rox/pkg/fsutils"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/osutils"
+	"github.com/stackrox/rox/pkg/postgres/pgconfig"
 	"github.com/stackrox/rox/pkg/sync"
 )
 
@@ -137,6 +138,10 @@ func (m *manager) LaunchRestoreProcess(ctx context.Context, id string, requestHe
 		if err := m.checkDiskSpace(totalSizeUncompressed); err != nil {
 			return nil, err
 		}
+	}
+
+	if process.postgresBundle && pgconfig.IsExternalDatabase() {
+		return nil, errors.New("restore is not supported with external database.  Use your normal DB restoration methods.")
 	}
 
 	// Create the paths for the restore directory

--- a/central/probeupload/manager/manager_impl.go
+++ b/central/probeupload/manager/manager_impl.go
@@ -161,9 +161,8 @@ func (m *manager) StoreFile(ctx context.Context, file string, data io.Reader, si
 		return errors.Errorf("invalid file name %q", file)
 	}
 
-	// When using managed services, Postgres space is not a concern.
-	// TODO(ROX-16407): Use flag to guard space calculating
-	if !env.ManagedCentral.BooleanSetting() {
+	// When using external databases, Postgres space cannot be calculated.
+	if !env.ManagedCentral.BooleanSetting() && !pgconfig.IsExternalDatabase() {
 		requiredBytes := uint64(size) + uint64(metadataSizeOverhead) + uint64(m.freeStorageThreshold)
 		if freeBytes, err := availableBytes(); err == nil && uint64(freeBytes) < requiredBytes {
 			return errors.Errorf("only %d bytes left on database, not storing probes to avoid impacting database health", freeBytes)

--- a/image/templates/helm/stackrox-central/templates/01-central-08-external-db-configmap.yaml
+++ b/image/templates/helm/stackrox-central/templates/01-central-08-external-db-configmap.yaml
@@ -12,8 +12,10 @@ data:
   central-external-db.yaml: |
     centralDB:
       {{- if ._rox.central.db.external }}
+      external: true
       source: {{ ._rox.central.db.source.connectionString }} statement_timeout={{ ._rox.central.db.source.statementTimeoutMs }} pool_min_conns={{ ._rox.central.db.source.minConns }} pool_max_conns={{ ._rox.central.db.source.maxConns }}
       {{- else }}
+      external: false
       source: >
         host=central-db.{{ .Release.Namespace }}.svc
         port=5432

--- a/image/templates/helm/stackrox-central/values-public.yaml.example.htpl
+++ b/image/templates/helm/stackrox-central/values-public.yaml.example.htpl
@@ -261,6 +261,10 @@
 #         key: infra
 #         value: reserved
 #
+#     # External signifies that a Postgres wire-compatible database has already been deployed and a Central DB pod
+#     # does not need to be deployed
+#     external: false
+#
 #     # Customized Central DB source configurations to connect to Postgres database.
 #     # Default configurations are applied if the configurations are omitted.
 #     source:

--- a/migrator/clone/clone_test.go
+++ b/migrator/clone/clone_test.go
@@ -308,7 +308,7 @@ func doTestForceRollbackRocksToPostgresFailure(t *testing.T) {
 			withPrevious:         false,
 			forceRollback:        "",
 			toVersion:            futureVerDifferentMin,
-			expectedErrorMessage: metadata.ErrForceUpgradeDisabled,
+			expectedErrorMessage: fmt.Sprintf(metadata.ErrSoftwareNotCompatibleWithDatabase, currVer.minSeqNum, futureVerDifferentMin.minSeqNum),
 		},
 		{
 			// Any rollbacks to 4.1 or later will only use central_active
@@ -330,7 +330,7 @@ func doTestForceRollbackRocksToPostgresFailure(t *testing.T) {
 			withPrevious:         true,
 			forceRollback:        "",
 			toVersion:            futureVerDifferentMin,
-			expectedErrorMessage: metadata.ErrForceUpgradeDisabled,
+			expectedErrorMessage: fmt.Sprintf(metadata.ErrSoftwareNotCompatibleWithDatabase, currVer.minSeqNum, futureVerDifferentMin.minSeqNum),
 		},
 		{
 			description:          "with force rollback code does not support min sequence in DB",

--- a/migrator/main.go
+++ b/migrator/main.go
@@ -55,13 +55,13 @@ func run() error {
 		log.WriteToStderrf("conf.Maintenance.ForceRollbackVersion: %s", rollbackVersion)
 	}
 
-	var dbm cloneMgr.DBCloneManager
 	// Create the clone manager
 	sourceMap, adminConfig, err := pgconfig.GetPostgresConfig()
 	if err != nil {
 		return errors.Wrap(err, "unable to get Postgres DB config")
 	}
-	dbm = cloneMgr.NewPostgres(migrations.DBMountPath(), rollbackVersion, adminConfig, sourceMap)
+
+	dbm := cloneMgr.NewPostgres(migrations.DBMountPath(), rollbackVersion, adminConfig, sourceMap)
 
 	err = dbm.Scan()
 	if err != nil {

--- a/migrator/migrations/frozenschema/v73/network_flows.go
+++ b/migrator/migrations/frozenschema/v73/network_flows.go
@@ -17,7 +17,7 @@ var (
 	CreateTableNetworkFlowsStmt = &postgres.CreateStmts{
 		GormModel: (*NetworkFlows)(nil),
 		PostStmts: []string{
-			"CREATE INDEX IF NOT EXISTS network_flows_lastseentimestamp ON public.network_flows USING brin (lastseentimestamp) WITH (pages_per_range='32')",
+			"CREATE INDEX IF NOT EXISTS network_flows_lastseentimestamp ON network_flows USING brin (lastseentimestamp) WITH (pages_per_range='32')",
 		},
 	}
 

--- a/migrator/postgres/gorm/config.go
+++ b/migrator/postgres/gorm/config.go
@@ -58,7 +58,10 @@ func getConfig() (*gormConfig, error) {
 
 // Connect connects to the Postgres database and returns a Gorm DB instance with error if applicable.
 func (gc *gormConfig) Connect(dbName string) (*gorm.DB, error) {
-	source := fmt.Sprintf("%s database=%s", gc.source, dbName)
+	source := gc.source
+	if !pgconfig.IsExternalDatabase() && dbName != "" {
+		source = fmt.Sprintf("%s database=%s", gc.source, dbName)
+	}
 	log.WriteToStderrf("connect to gorm: %v", strings.Replace(source, gc.password, "<REDACTED>", -1))
 
 	db, err := gorm.Open(postgres.Open(source), &gorm.Config{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -79,6 +79,7 @@ func (m *Maintenance) validate() error {
 // CentralDB defines the config options to access central-db
 type CentralDB struct {
 	Source       string `yaml:"source"`
+	External     bool   `yaml:"external"`
 	DatabaseName string
 }
 

--- a/pkg/postgres/pgadmin/admin_utils.go
+++ b/pkg/postgres/pgadmin/admin_utils.go
@@ -235,8 +235,10 @@ func GetAdminPool(postgresConfig *postgres.Config) (postgres.DB, error) {
 	// Clone config to connect to template DB
 	tempConfig := postgresConfig.Copy()
 
-	// Need to connect on a static DB so we can rename the used DBs.
-	tempConfig.ConnConfig.Database = AdminDB
+	if !pgconfig.IsExternalDatabase() {
+		// Need to connect on a static DB so we can rename the used DBs.
+		tempConfig.ConnConfig.Database = AdminDB
+	}
 
 	postgresDB, err := getPool(tempConfig)
 	if err != nil {
@@ -255,8 +257,10 @@ func GetClonePool(postgresConfig *postgres.Config, clone string) (postgres.DB, e
 	// Clone config to connect to template DB
 	tempConfig := postgresConfig.Copy()
 
-	// Need to connect on a static DB so we can rename the used DBs.
-	tempConfig.ConnConfig.Database = clone
+	if !pgconfig.IsExternalDatabase() {
+		// Need to connect on a static DB so we can rename the used DBs.
+		tempConfig.ConnConfig.Database = clone
+	}
 
 	postgresDB, err := getPool(tempConfig)
 	if err != nil {
@@ -286,7 +290,7 @@ func getPool(postgresConfig *postgres.Config) (postgres.DB, error) {
 // getAvailablePostgresCapacity - retrieves the capacity for Postgres
 func getAvailablePostgresCapacity(postgresConfig *postgres.Config) (int64, error) {
 	// When using managed services, Postgres space is not a concern at this time.
-	if env.ManagedCentral.BooleanSetting() {
+	if env.ManagedCentral.BooleanSetting() || pgconfig.IsExternalDatabase() {
 		utils.Should(errors.New("unexpected call, cannot yet determine managed capacity.  Calculation is an estimate based on suggested size."))
 
 		// Cannot get managed services capacity via Postgres.  Assume size for now.
@@ -390,7 +394,7 @@ func getAvailablePostgresCapacity(postgresConfig *postgres.Config) (int64, error
 // GetRemainingCapacity - retrieves the amount of space left in Postgres
 func GetRemainingCapacity(postgresConfig *postgres.Config) (int64, error) {
 	// When using managed services, Postgres space is not a concern at this time.
-	if env.ManagedCentral.BooleanSetting() {
+	if env.ManagedCentral.BooleanSetting() || pgconfig.IsExternalDatabase() {
 		utils.Should(errors.New("unexpected call, cannot yet determine managed capacity.  Calculation is an estimate based on suggested size."))
 
 		// Cannot get managed services capacity via Postgres.  Assume size for now.

--- a/pkg/postgres/pgconfig/config.go
+++ b/pkg/postgres/pgconfig/config.go
@@ -77,3 +77,8 @@ func GetActiveDB() string {
 func GetPostgresCapacity() int64 {
 	return capacity
 }
+
+// IsExternalDatabase - retrieves whether Postgres is external
+func IsExternalDatabase() bool {
+	return config.GetConfig().CentralDB.External
+}


### PR DESCRIPTION
## Description

Setup to use an external database Postgres instance.  Requires the database be created.  

Summary of changes:
- if external do not restore a postgres backup bundle
- if external do not make any copies of the database.  ONLY use the database for the initial connection
- Switch the creation of the pg_stats extension to log as a warning instead of an error.
- fixed a rocks to postgres migration to not explicitly call out the `public` schema.  If a customer is using best practices they will have restricted use of the `public` schema.  (plus whenever we go to postgres 15 that will be restricted by default)
- As we phase out `central_previous` a lot of the things done here will become the main path.  Unfortunately we have to support the creation of `central_previous` as long as we support a rollback to 3.74 or 4.0.
- Do NOT attempt to calculate space for external databases

Changes to `central_previous` and `central_active` will occur under other tickets such as ROX-16774

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
~- [ ] Determined and documented upgrade steps~
~- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs]~(https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Created a postgres sql database in GCP.  
Tested initial creation as well as upgrade from 3.73/3.74 RocksDB scenarios.

Ran a few iterations of access to ensure things worked.
- postgres user with postgres database with unrestricted permissions
- postgres user with stackrox database with unrestricted permissions
- stackrox user with stackrox database with unrestricted permissions
- stackrox user with stackrox database with restricted permissions

connection string used where user and database filled in from bullets above:
connectionString: "host=<MY_GCP_SQL_INSTANCE> user=<USER> statement_timeout=600000 client_encoding=SJIS database=<DATABASE>"

DB, user and permissions were created as follows:
```
# setup
drop database stackrox;
drop role readwrite;
drop user stackrox;

show search_path;

# create the user
  CREATE USER stackrox WITH PASSWORD 'THE_CREDS_I_WAS_USING';

# create database
create database stackrox;

# create schema for the user
\c stackrox
create schema stackrox;
# alter schema stackrox owner to stackrox;

# revoke rights on public
REVOKE CREATE ON SCHEMA public FROM PUBLIC;

# revoke rights on public to the database
REVOKE ALL ON DATABASE stackrox FROM PUBLIC;

# readwrite role
CREATE ROLE readwrite;
GRANT CONNECT ON DATABASE stackrox TO readwrite;
GRANT USAGE ON SCHEMA stackrox TO readwrite;
GRANT USAGE, CREATE ON SCHEMA stackrox TO readwrite;
GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA stackrox TO readwrite;
ALTER DEFAULT PRIVILEGES IN SCHEMA stackrox GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO readwrite;
GRANT USAGE ON ALL SEQUENCES IN SCHEMA stackrox TO readwrite;
ALTER DEFAULT PRIVILEGES IN SCHEMA stackrox GRANT USAGE ON SEQUENCES TO readwrite;

# grant the readwrite role to stackrox
GRANT readwrite TO stackrox;
```
