### PR TITLE
feat(helm): Add ability to set custom nodeAffinity to deployments

### DIFF
--- a/image/templates/helm/shared/templates/02-scanner-06-deployment.yaml.htpl
+++ b/image/templates/helm/shared/templates/02-scanner-06-deployment.yaml.htpl
@@ -47,30 +47,10 @@ spec:
                 matchLabels:
                   app: scanner
               topologyKey: kubernetes.io/hostname
+        {{- if ._rox.scanner.nodeAffinity }}
         nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 50
-              preference:
-                matchExpressions:
-                  - key: node-role.kubernetes.io/infra
-                    operator: Exists
-            - weight: 25
-              preference:
-                matchExpressions:
-                  - key: node-role.kubernetes.io/compute
-                    operator: Exists
-            # From v1.20 node-role.kubernetes.io/control-plane replaces node-role.kubernetes.io/master (removed in
-            # v1.25). We apply both because our goal is not to run pods on control plane nodes for any version of k8s.
-            - weight: 100
-              preference:
-                matchExpressions:
-                  - key: node-role.kubernetes.io/master
-                    operator: DoesNotExist
-            - weight: 100
-              preference:
-                matchExpressions:
-                  - key: node-role.kubernetes.io/control-plane
-                    operator: DoesNotExist
+          {{- toYaml ._rox.scanner.nodeAffinity | nindent 10 }}
+        {{- end }}
       containers:
       - name: scanner
         {{ if eq ._rox.scanner.mode "slim" -}}
@@ -218,38 +198,10 @@ spec:
         {{- toYaml ._rox.scanner.dbTolerations | nindent 8 }}
       {{- end }}
       affinity:
+        {{- if ._rox.scanner.nodeAffinity }}
         nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            # ScannerDB is single-homed, so avoid preemptible nodes.
-            - weight: 100
-              preference:
-                matchExpressions:
-                  - key: cloud.google.com/gke-preemptible
-                    operator: NotIn
-                    values:
-                    - "true"
-            - weight: 50
-              preference:
-                matchExpressions:
-                  - key: node-role.kubernetes.io/infra
-                    operator: Exists
-            - weight: 25
-              preference:
-                matchExpressions:
-                  - key: node-role.kubernetes.io/compute
-                    operator: Exists
-            # From v1.20 node-role.kubernetes.io/control-plane replaces node-role.kubernetes.io/master (removed in
-            # v1.25). We apply both because our goal is not to run pods on control plane nodes for any version of k8s.
-            - weight: 100
-              preference:
-                matchExpressions:
-                  - key: node-role.kubernetes.io/master
-                    operator: DoesNotExist
-            - weight: 100
-              preference:
-                matchExpressions:
-                  - key: node-role.kubernetes.io/control-plane
-                    operator: DoesNotExist
+          {{- toYaml ._rox.scanner.nodeAffinity | nindent 10 }}
+        {{- end }}
       initContainers:
         - name: init-db
           {{ if eq ._rox.scanner.mode "slim" -}}

--- a/image/templates/helm/stackrox-central/internal/defaults.yaml.htpl
+++ b/image/templates/helm/stackrox-central/internal/defaults.yaml.htpl
@@ -38,6 +38,40 @@ defaults:
         port: null
       route:
         enabled: false
+
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        # Central is single-homed, so avoid preemptible nodes.
+        - weight: 100
+          preference:
+            matchExpressions:
+              - key: cloud.google.com/gke-preemptible
+                operator: NotIn
+                values:
+                - "true"
+        - weight: 50
+          preference:
+            matchExpressions:
+              - key: node-role.kubernetes.io/infra
+                operator: Exists
+        - weight: 25
+          preference:
+            matchExpressions:
+              - key: node-role.kubernetes.io/compute
+                operator: Exists
+        # From v1.20 node-role.kubernetes.io/control-plane replaces node-role.kubernetes.io/master (removed in
+        # v1.25). We apply both because our goal is not to run pods on control plane nodes for any version of k8s.
+        - weight: 100
+          preference:
+            matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: DoesNotExist
+        - weight: 100
+          preference:
+            matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: DoesNotExist
+
     db:
       external: false
 
@@ -60,6 +94,7 @@ defaults:
         limits:
           memory: "16Gi"
           cpu: "8"
+
   scanner:
     disable: false
     replicas: 3
@@ -94,6 +129,39 @@ defaults:
     dbImage:
       name: [< required "" .ScannerDBImageRemote >]
       tag: [< required "" .ScannerImageTag >]
+
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        # ScannerDB is single-homed, so avoid preemptible nodes.
+        - weight: 100
+          preference:
+            matchExpressions:
+              - key: cloud.google.com/gke-preemptible
+                operator: NotIn
+                values:
+                - "true"
+        - weight: 50
+          preference:
+            matchExpressions:
+              - key: node-role.kubernetes.io/infra
+                operator: Exists
+        - weight: 25
+          preference:
+            matchExpressions:
+              - key: node-role.kubernetes.io/compute
+                operator: Exists
+        # From v1.20 node-role.kubernetes.io/control-plane replaces node-role.kubernetes.io/master (removed in
+        # v1.25). We apply both because our goal is not to run pods on control plane nodes for any version of k8s.
+        - weight: 100
+          preference:
+            matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: DoesNotExist
+        - weight: 100
+          preference:
+            matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: DoesNotExist
 
   system:
     createSCCs: [< not .Operator >]

--- a/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml
+++ b/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml
@@ -37,38 +37,10 @@ spec:
         {{- toYaml ._rox.central.tolerations | nindent 8 }}
       {{- end }}
       affinity:
+        {{- if ._rox.central.nodeAffinity }}
         nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            # Central is single-homed, so avoid preemptible nodes.
-            - weight: 100
-              preference:
-                matchExpressions:
-                  - key: cloud.google.com/gke-preemptible
-                    operator: NotIn
-                    values:
-                    - "true"
-            - weight: 50
-              preference:
-                matchExpressions:
-                  - key: node-role.kubernetes.io/infra
-                    operator: Exists
-            - weight: 25
-              preference:
-                matchExpressions:
-                  - key: node-role.kubernetes.io/compute
-                    operator: Exists
-            # From v1.20 node-role.kubernetes.io/control-plane replaces node-role.kubernetes.io/master (removed in
-            # v1.25). We apply both because our goal is not to run pods on control plane nodes for any version of k8s.
-            - weight: 100
-              preference:
-                matchExpressions:
-                  - key: node-role.kubernetes.io/master
-                    operator: DoesNotExist
-            - weight: 100
-              preference:
-                matchExpressions:
-                  - key: node-role.kubernetes.io/control-plane
-                    operator: DoesNotExist
+          {{- toYaml ._rox.central.nodeAffinity | nindent 10 }}
+        {{- end }}
       serviceAccountName: central
       securityContext:
         fsGroup: 4000

--- a/image/templates/helm/stackrox-central/values.yaml.htpl
+++ b/image/templates/helm/stackrox-central/values.yaml.htpl
@@ -120,6 +120,8 @@
 #
 #  nodeSelector: null
 #
+#  nodeAffinity: null
+#
 #  jwtSigner:
 #    key: null
 #    generate: null
@@ -277,6 +279,8 @@
 #    limits:
 #      memory: "4Gi"
 #      cpu: "2000m"
+#
+#  nodeAffinity: null
 #
 #  image:
 #    registry: null


### PR DESCRIPTION
## Description

Fixes #6622 

Enables setting a custom nodeAffinity on the central and scanner components, using the current default nodeAffinity settings, if no customization is provided.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Haven't ran the test from this repo as I don't have the knowledge to run it, but tested the templating by doing the same changes in the helm chart version `4.0.2`, and it seems to be working just fine:

By default, `nodeAffinity` settings remain with the current values:

<details open>
<summary>Default values templates/01-central-13-deployment.yaml</summary>

```
❯ helm template stackrox-central-services -n stackrox . --set imagePullSecrets.allowNone=true -s templates/01-central-13-deployment.yaml | yq '.spec.template.spec.affinity'
nodeAffinity:
  preferredDuringSchedulingIgnoredDuringExecution:
    - preference:
        matchExpressions:
          - key: cloud.google.com/gke-preemptible
            operator: NotIn
            values:
              - "true"
      weight: 100
    - preference:
        matchExpressions:
          - key: node-role.kubernetes.io/infra
            operator: Exists
      weight: 50
    - preference:
        matchExpressions:
          - key: node-role.kubernetes.io/compute
            operator: Exists
      weight: 25
    - preference:
        matchExpressions:
          - key: node-role.kubernetes.io/master
            operator: DoesNotExist
      weight: 100
    - preference:
        matchExpressions:
          - key: node-role.kubernetes.io/control-plane
            operator: DoesNotExist
      weight: 100
```
</details>

<details open>
<summary>Default values templates/02-scanner-06-deployment.yaml</summary>

```
❯ helm template stackrox-central-services -n stackrox . --set imagePullSecrets.allowNone=true -s templates/02-scanner-06-deployment.yaml | yq '.spec.template.spec.affinity'
podAntiAffinity:
  preferredDuringSchedulingIgnoredDuringExecution:
    - weight: 100
      podAffinityTerm:
        labelSelector:
          matchLabels:
            app: scanner
        topologyKey: kubernetes.io/hostname
nodeAffinity:
  preferredDuringSchedulingIgnoredDuringExecution:
    - preference:
        matchExpressions:
          - key: cloud.google.com/gke-preemptible
            operator: NotIn
            values:
              - "true"
      weight: 100
    - preference:
        matchExpressions:
          - key: node-role.kubernetes.io/infra
            operator: Exists
      weight: 50
    - preference:
        matchExpressions:
          - key: node-role.kubernetes.io/compute
            operator: Exists
      weight: 25
    - preference:
        matchExpressions:
          - key: node-role.kubernetes.io/master
            operator: DoesNotExist
      weight: 100
    - preference:
        matchExpressions:
          - key: node-role.kubernetes.io/control-plane
            operator: DoesNotExist
      weight: 100
---
nodeAffinity:
  preferredDuringSchedulingIgnoredDuringExecution:
    - preference:
        matchExpressions:
          - key: cloud.google.com/gke-preemptible
            operator: NotIn
            values:
              - "true"
      weight: 100
    - preference:
        matchExpressions:
          - key: node-role.kubernetes.io/infra
            operator: Exists
      weight: 50
    - preference:
        matchExpressions:
          - key: node-role.kubernetes.io/compute
            operator: Exists
      weight: 25
    - preference:
        matchExpressions:
          - key: node-role.kubernetes.io/master
            operator: DoesNotExist
      weight: 100
    - preference:
        matchExpressions:
          - key: node-role.kubernetes.io/control-plane
            operator: DoesNotExist
      weight: 100
```
</details>

But they can be overriden from the `.Values.central.nodeAffinity` and `.Values.scanner.nodeAffinity` respectively:

<details open>
<summary>Customized from values: templates/01-central-13-deployment.yaml</summary>

```
❯ helm template stackrox-central-services -n stackrox . --set imagePullSecrets.allowNone=true -s templates/01-central-13-deployment.yaml | yq '.spec.template.spec.affinity'
nodeAffinity:
  preferredDuringSchedulingIgnoredDuringExecution:
    - preference:
        matchExpressions:
          - key: ThisIsOverridenFromValuesCentral
            operator: NotIn
            values:
              - "true"
      weight: 100
```
</details>

<details open>
<summary>Customized from values: templates/02-scanner-06-deployment.yaml</summary>

```
❯ helm template stackrox-central-services -n stackrox . --set imagePullSecrets.allowNone=true -s templates/02-scanner-06-deployment.yaml | yq '.spec.template.spec.affinity'
podAntiAffinity:
  preferredDuringSchedulingIgnoredDuringExecution:
    - weight: 100
      podAffinityTerm:
        labelSelector:
          matchLabels:
            app: scanner
        topologyKey: kubernetes.io/hostname
nodeAffinity:
  preferredDuringSchedulingIgnoredDuringExecution:
    - preference:
        matchExpressions:
          - key: ThisIsOverridenFromValuesScanner
            operator: NotIn
            values:
              - "true"
      weight: 100
---
nodeAffinity:
  preferredDuringSchedulingIgnoredDuringExecution:
    - preference:
        matchExpressions:
          - key: ThisIsOverridenFromValuesScanner
            operator: NotIn
            values:
              - "true"
      weight: 100
```
</details>

Please let me know if there're any actions to take from my end.

Regards!