### PR TITLE
fix(declarative-config): Fix declarative config store tests

### DIFF
--- a/central/declarativeconfig/health/datastore/datastore_impl_test.go
+++ b/central/declarativeconfig/health/datastore/datastore_impl_test.go
@@ -67,7 +67,7 @@ func (s *declarativeConfigHealthDatastoreSuite) TearDownTest() {
 func (s *declarativeConfigHealthDatastoreSuite) TestGetDeclarativeConfigs() {
 	configHealth := newConfigHealth()
 
-	err := s.datastore.UpsertDeclarativeConfig(s.hasWriteCtx, configHealth)
+	err := s.datastore.UpsertDeclarativeConfig(s.hasWriteDeclarativeCtx, configHealth)
 	s.NoError(err)
 
 	s.testGetConfigHealth(s.datastore.GetDeclarativeConfigs)
@@ -82,21 +82,21 @@ func (s *declarativeConfigHealthDatastoreSuite) TestUpdateConfigHealth() {
 
 	// 1. With no access should return  error + should not be added.
 	err := s.datastore.UpsertDeclarativeConfig(s.hasNoAccessCtx, configHealth)
-	s.ErrorIs(err, sac.ErrResourceAccessDenied)
+	s.ErrorIs(err, errox.NotAuthorized)
 	_, exists, err := s.datastore.GetDeclarativeConfig(s.hasReadCtx, configHealth.GetId())
 	s.NoError(err)
 	s.False(exists)
 
 	// 2. With READ access should return error + should not be added.
 	err = s.datastore.UpsertDeclarativeConfig(s.hasReadCtx, configHealth)
-	s.ErrorIs(err, sac.ErrResourceAccessDenied)
+	s.ErrorIs(err, errox.NotAuthorized)
 	_, exists, err = s.datastore.GetDeclarativeConfig(s.hasReadCtx, configHealth.GetId())
 	s.NoError(err)
 	s.False(exists)
 
 	// 3. With WRITE access should return an error + should not be added.
 	err = s.datastore.UpsertDeclarativeConfig(s.hasWriteCtx, configHealth)
-	s.ErrorIs(err, sac.ErrResourceAccessDenied)
+	s.ErrorIs(err, errox.NotAuthorized)
 	_, exists, err = s.datastore.GetDeclarativeConfig(s.hasReadCtx, configHealth.GetId())
 	s.NoError(err)
 	s.False(exists)
@@ -113,7 +113,7 @@ func (s *declarativeConfigHealthDatastoreSuite) TestUpdateConfigHealth() {
 
 func (s *declarativeConfigHealthDatastoreSuite) TestRemoveConfigHealth() {
 	configHealth := newConfigHealth()
-	err := s.datastore.UpsertDeclarativeConfig(s.hasWriteCtx, configHealth)
+	err := s.datastore.UpsertDeclarativeConfig(s.hasWriteDeclarativeCtx, configHealth)
 	s.NoError(err)
 	_, exists, err := s.datastore.GetDeclarativeConfig(s.hasReadCtx, configHealth.GetId())
 	s.NoError(err)
@@ -121,22 +121,21 @@ func (s *declarativeConfigHealthDatastoreSuite) TestRemoveConfigHealth() {
 
 	// 1. With no access should return an error + config health should still exist.
 	err = s.datastore.RemoveDeclarativeConfig(s.hasNoAccessCtx, configHealth.GetId())
-	// Since user has no access, we can't confirm whether the resource even exists.
-	s.ErrorIs(err, errox.NotFound)
+	s.ErrorIs(err, errox.NotAuthorized)
 	_, exists, err = s.datastore.GetDeclarativeConfig(s.hasReadCtx, configHealth.GetId())
 	s.NoError(err)
 	s.True(exists)
 
 	// 2. With READ access should return an error + config health should still exist.
 	err = s.datastore.RemoveDeclarativeConfig(s.hasReadCtx, configHealth.GetId())
-	s.ErrorIs(err, sac.ErrResourceAccessDenied)
+	s.ErrorIs(err, errox.NotAuthorized)
 	_, exists, err = s.datastore.GetDeclarativeConfig(s.hasReadCtx, configHealth.GetId())
 	s.NoError(err)
 	s.True(exists)
 
 	// 3. With WRITE access and existing config health remove should return an error.
 	err = s.datastore.RemoveDeclarativeConfig(s.hasWriteCtx, configHealth.GetId())
-	s.ErrorIs(err, sac.ErrResourceAccessDenied)
+	s.ErrorIs(err, errox.NotAuthorized)
 	_, exists, err = s.datastore.GetDeclarativeConfig(s.hasReadCtx, configHealth.GetId())
 	s.NoError(err)
 	s.True(exists)


### PR DESCRIPTION
## Description

After introducing the change to only allow modifications with contexts that are able to modify declarative configurations, the tests were failing. This wasn't noticed because they didn't run on master.

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

```
=== RUN   TestDeclarativeConfigHealthDatastore
=== PAUSE TestDeclarativeConfigHealthDatastore
=== CONT  TestDeclarativeConfigHealthDatastore
--- PASS: TestDeclarativeConfigHealthDatastore (11.98s)
=== RUN   TestDeclarativeConfigHealthDatastore/TestGetDeclarativeConfigs
    --- PASS: TestDeclarativeConfigHealthDatastore/TestGetDeclarativeConfigs (3.59s)
=== RUN   TestDeclarativeConfigHealthDatastore/TestRemoveConfigHealth
    --- PASS: TestDeclarativeConfigHealthDatastore/TestRemoveConfigHealth (4.22s)
=== RUN   TestDeclarativeConfigHealthDatastore/TestUpdateConfigHealth
    --- PASS: TestDeclarativeConfigHealthDatastore/TestUpdateConfigHealth (4.17s)
PASS
```
