### PR TITLE
ROX-18036: Pass full search scope to network graph simulator panel

### DIFF
--- a/ui/apps/platform/src/Containers/Clusters/DelegateScanning/Components/DelegatedScanningSettings.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DelegateScanning/Components/DelegatedScanningSettings.tsx
@@ -12,21 +12,21 @@ import {
 import FormLabelGroup from 'Components/PatternFly/FormLabelGroup';
 import { EnabledSelections } from 'types/dedicatedRegistryConfig.proto';
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
-import { Cluster } from 'types/cluster.proto';
+import { ClusterScopeObject } from 'services/RolesService';
 
 type DelegatedScanningSettingsProps = {
     enabledFor: EnabledSelections;
     onChangeEnabledFor: (newEnabledState: EnabledSelections) => void;
-    clusters?: Cluster[];
-    selectedClusterId?: string;
+    clusters: ClusterScopeObject[];
+    selectedClusterId: string;
     setSelectedClusterId: (newClusterId: string) => void;
 };
 
 function DelegatedScanningSettings({
     enabledFor,
     onChangeEnabledFor,
-    clusters = [],
-    selectedClusterId = '',
+    clusters,
+    selectedClusterId,
     setSelectedClusterId,
 }: DelegatedScanningSettingsProps) {
     const {

--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraph.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraph.tsx
@@ -17,16 +17,9 @@ export type NetworkGraphProps = {
     model: CustomModel;
     simulation: Simulation;
     selectedNode?: CustomNodeModel;
-    selectedClusterId: string;
     edgeState: EdgeState;
 };
-function NetworkGraph({
-    model,
-    simulation,
-    selectedClusterId,
-    selectedNode,
-    edgeState,
-}: NetworkGraphProps) {
+function NetworkGraph({ model, simulation, selectedNode, edgeState }: NetworkGraphProps) {
     const controller = useMemo(() => {
         const newController = new Visualization();
         newController.registerLayoutFactory(defaultLayoutFactory);
@@ -36,7 +29,6 @@ function NetworkGraph({
     }, []);
     const { simulator, setNetworkPolicyModification } = useNetworkPolicySimulator({
         simulation,
-        clusterId: selectedClusterId,
     });
 
     const isSimulating =
@@ -51,7 +43,6 @@ function NetworkGraph({
                 <TopologyComponent
                     model={model}
                     simulation={simulation}
-                    selectedClusterId={selectedClusterId}
                     simulator={simulator}
                     selectedNode={selectedNode}
                     setNetworkPolicyModification={setNetworkPolicyModification}

--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphContainer.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphContainer.tsx
@@ -275,7 +275,6 @@ type NetworkGraphContainerProps = {
     edgeState: EdgeState;
     displayOptions: DisplayOption[];
     simulation: Simulation;
-    selectedClusterId: string;
     clusterDeploymentCount: number;
 };
 
@@ -292,7 +291,6 @@ function NetworkGraphContainer({
     edgeState,
     displayOptions,
     simulation,
-    selectedClusterId,
     clusterDeploymentCount,
 }: NetworkGraphContainerProps) {
     // these are the unfiltered, unmodified data models
@@ -356,7 +354,6 @@ function NetworkGraphContainer({
         <NetworkGraph
             model={updatedModel}
             simulation={simulation}
-            selectedClusterId={selectedClusterId || ''}
             selectedNode={selectedNode}
             edgeState={edgeState}
         />

--- a/ui/apps/platform/src/Containers/NetworkGraph/TopologyComponent.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/TopologyComponent.tsx
@@ -53,7 +53,6 @@ function getUrlParamsForEntity(type, id): [UrlDetailTypeValue, string] {
 export type TopologyComponentProps = {
     model: CustomModel;
     simulation: Simulation;
-    selectedClusterId: string;
     selectedNode?: CustomNodeModel;
     simulator: NetworkPolicySimulator;
     setNetworkPolicyModification: SetNetworkPolicyModification;
@@ -71,7 +70,6 @@ function clearSimulationQuery(search: string): string {
 const TopologyComponent = ({
     model,
     simulation,
-    selectedClusterId,
     selectedNode,
     simulator,
     setNetworkPolicyModification,
@@ -175,7 +173,6 @@ const TopologyComponent = ({
                 <TopologySideBar resizable onClose={closeSidebar}>
                     {simulation.isOn && simulation.type === 'networkPolicy' && (
                         <NetworkPolicySimulatorSidePanel
-                            selectedClusterId={selectedClusterId}
                             simulator={simulator}
                             setNetworkPolicyModification={setNetworkPolicyModification}
                         />

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/ClusterSelector.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/ClusterSelector.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Select, SelectOption } from '@patternfly/react-core';
 
-import { ScopeObject } from 'services/RolesService';
+import { ClusterScopeObject } from 'services/RolesService';
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
 import { ClusterIcon } from '../common/NetworkGraphIcons';
 
 export type ClusterSelectorProps = {
-    clusters: ScopeObject[];
+    clusters: ClusterScopeObject[];
     selectedClusterName?: string;
     searchFilter: Partial<Record<string, string | string[]>>;
     setSearchFilter: (newFilter: Partial<Record<string, string | string[]>>) => void;

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/ClusterSelector.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/ClusterSelector.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Select, SelectOption } from '@patternfly/react-core';
 
-import { Cluster } from 'types/cluster.proto';
+import { ScopeObject } from 'services/RolesService';
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
 import { ClusterIcon } from '../common/NetworkGraphIcons';
 
-type ClusterSelectorProps = {
-    clusters: Cluster[];
+export type ClusterSelectorProps = {
+    clusters: ScopeObject[];
     selectedClusterName?: string;
     searchFilter: Partial<Record<string, string | string[]>>;
     setSearchFilter: (newFilter: Partial<Record<string, string | string[]>>) => void;

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/NamespaceSelector.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/NamespaceSelector.tsx
@@ -16,13 +16,13 @@ import {
 } from '@patternfly/react-core';
 
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
-import { Namespace } from 'hooks/useFetchClusterNamespacesForPermissions';
 import { NamespaceWithDeployments } from 'hooks/useFetchNamespaceDeployments';
+import { NamespaceScopeObject } from 'services/RolesService';
 import { NamespaceIcon } from '../common/NetworkGraphIcons';
 import { getDeploymentLookupMap, getDeploymentsAllowedByNamespaces } from '../utils/hierarchyUtils';
 
 type NamespaceSelectorProps = {
-    namespaces?: Namespace[];
+    namespaces?: NamespaceScopeObject[];
     selectedNamespaces?: string[];
     selectedDeployments?: string[];
     deploymentsByNamespace?: NamespaceWithDeployments[];

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/NetworkBreadcrumbs.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/NetworkBreadcrumbs.tsx
@@ -1,26 +1,25 @@
 import React from 'react';
 import { Breadcrumb, BreadcrumbItem } from '@patternfly/react-core';
 
-import { Cluster } from 'types/cluster.proto';
 import useURLSearch from 'hooks/useURLSearch';
 import { useFetchClusterNamespacesForPermissions } from 'hooks/useFetchClusterNamespacesForPermissions';
 import useFetchNamespaceDeployments from 'hooks/useFetchNamespaceDeployments';
-import ClusterSelector from './ClusterSelector';
+import ClusterSelector, { ClusterSelectorProps } from './ClusterSelector';
 import NamespaceSelector from './NamespaceSelector';
 import DeploymentSelector from './DeploymentSelector';
 
-type NetworkBreadcrumbsProps = {
-    clusters: Cluster[];
-    selectedCluster?: { name?: string; id?: string };
+export type NetworkBreadcrumbsProps = {
+    clusters: ClusterSelectorProps['clusters'];
+    selectedCluster: { name: string; id: string };
     selectedNamespaces: string[];
     selectedDeployments: string[];
 };
 
 function NetworkBreadcrumbs({
-    clusters = [],
-    selectedCluster = {},
-    selectedNamespaces = [],
-    selectedDeployments = [],
+    clusters,
+    selectedCluster,
+    selectedNamespaces,
+    selectedDeployments,
 }: NetworkBreadcrumbsProps) {
     const { searchFilter, setSearchFilter } = useURLSearch();
 

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/NetworkSearch.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/NetworkSearch.tsx
@@ -17,19 +17,19 @@ const searchOptionExclusions = [
     'Orchestrator Component',
 ];
 
-type NetworkSearchsProps = {
-    selectedCluster?: string;
-    selectedNamespaces?: string[];
-    selectedDeployments?: string[];
+type NetworkSearchProps = {
+    selectedCluster: string;
+    selectedNamespaces: string[];
+    selectedDeployments: string[];
     isDisabled: boolean;
 };
 
 function NetworkSearch({
-    selectedCluster = '',
-    selectedNamespaces = [],
-    selectedDeployments = [],
+    selectedCluster,
+    selectedNamespaces,
+    selectedDeployments,
     isDisabled,
-}: NetworkSearchsProps) {
+}: NetworkSearchProps) {
     const [searchOptions, setSearchOptions] = useState<string[]>([]);
     const { searchFilter, setSearchFilter } = useURLSearch();
 

--- a/ui/apps/platform/src/Containers/NetworkGraph/hooks/useNetworkPolicySimulator.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/hooks/useNetworkPolicySimulator.ts
@@ -6,7 +6,7 @@ import { ensureExhaustive } from 'utils/type.utils';
 import { NetworkPolicy, NetworkPolicyModification } from 'types/networkPolicy.proto';
 import { getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
 import { Simulation } from '../utils/getSimulation';
-import { NetworkScopeHierarchy } from '../utils/hierarchyUtils';
+import { NetworkScopeHierarchy } from '../types/networkScopeHierarchy';
 import { useScopeHierarchy } from './useScopeHierarchy';
 
 export type NetworkPolicySimulator =

--- a/ui/apps/platform/src/Containers/NetworkGraph/hooks/useNetworkPolicySimulator.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/hooks/useNetworkPolicySimulator.ts
@@ -1,5 +1,4 @@
-import { useState } from 'react';
-import useDeepCompareEffect from 'use-deep-compare-effect';
+import { useEffect, useState } from 'react';
 
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import * as networkService from 'services/NetworkService';
@@ -30,7 +29,7 @@ type SetNetworkPolicyModificationAction =
     | {
           state: 'ACTIVE';
           options: {
-              scopeHierarchy: NetworkScopeHierarchy;
+              clusterId: string;
           };
       }
     | {
@@ -73,12 +72,12 @@ function useNetworkPolicySimulator({ simulation }: UseNetworkPolicySimulatorPara
     const scopeHierarchy = useScopeHierarchy();
     const [simulator, setSimulator] = useState<NetworkPolicySimulator>(defaultResultState);
 
-    useDeepCompareEffect(() => {
+    useEffect(() => {
         setNetworkPolicyModification({
             state: 'ACTIVE',
-            options: { scopeHierarchy },
+            options: { clusterId: scopeHierarchy.cluster.id },
         });
-    }, [scopeHierarchy, simulation.isOn]);
+    }, [scopeHierarchy.cluster.id, simulation.isOn]);
 
     function setNetworkPolicyModification(action: SetNetworkPolicyModificationAction): void {
         const { state, options } = action;
@@ -101,7 +100,7 @@ function useNetworkPolicySimulator({ simulation }: UseNetworkPolicySimulatorPara
             case 'ACTIVE':
                 // @TODO: Add the network search query as a second argument
                 networkService
-                    .fetchNetworkPoliciesByClusterId(options.scopeHierarchy.cluster.id)
+                    .fetchNetworkPoliciesByClusterId(options.clusterId)
                     .then((data: NetworkPolicy[]) => {
                         setSimulator({
                             state,

--- a/ui/apps/platform/src/Containers/NetworkGraph/hooks/useScopeHierarchy.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/hooks/useScopeHierarchy.ts
@@ -1,6 +1,7 @@
 import useFetchClustersForPermissions from 'hooks/useFetchClustersForPermissions';
 import useURLSearch from 'hooks/useURLSearch';
-import { NetworkScopeHierarchy, getScopeHierarchyFromSearch } from '../utils/hierarchyUtils';
+import { getScopeHierarchyFromSearch } from '../utils/hierarchyUtils';
+import { NetworkScopeHierarchy } from '../types/networkScopeHierarchy';
 
 /**
  * Returns the current scope hierarchy from the URL search params.

--- a/ui/apps/platform/src/Containers/NetworkGraph/hooks/useScopeHierarchy.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/hooks/useScopeHierarchy.ts
@@ -1,0 +1,23 @@
+import useFetchClustersForPermissions from 'hooks/useFetchClustersForPermissions';
+import useURLSearch from 'hooks/useURLSearch';
+import { NetworkScopeHierarchy, getScopeHierarchyFromSearch } from '../utils/hierarchyUtils';
+
+/**
+ * Returns the current scope hierarchy from the URL search params.
+ */
+export function useScopeHierarchy(): NetworkScopeHierarchy {
+    const { searchFilter } = useURLSearch();
+    const { clusters } = useFetchClustersForPermissions(['NetworkGraph', 'Deployment']);
+
+    return (
+        getScopeHierarchyFromSearch(searchFilter, clusters) ?? {
+            cluster: {
+                id: '',
+                name: '',
+            },
+            namespaces: [],
+            deployments: [],
+            remainingQuery: {},
+        }
+    );
+}

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPolicySimulatorSidePanel.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPolicySimulatorSidePanel.tsx
@@ -22,7 +22,6 @@ import {
 import { HelpIcon } from '@patternfly/react-icons';
 
 import useTabs from 'hooks/patternfly/useTabs';
-import useURLSearch from 'hooks/useURLSearch';
 import ViewActiveYAMLs from './ViewActiveYAMLs';
 import {
     NetworkPolicySimulator,
@@ -30,13 +29,12 @@ import {
 } from '../hooks/useNetworkPolicySimulator';
 import NetworkPoliciesYAML from './NetworkPoliciesYAML';
 import { getDisplayYAMLFromNetworkPolicyModification } from '../utils/simulatorUtils';
-import { getScopeHierarchyFromSearch } from '../utils/hierarchyUtils';
 import UploadYAMLButton from './UploadYAMLButton';
 import NetworkSimulatorActions from './NetworkSimulatorActions';
 import NotifyYAMLModal from './NotifyYAMLModal';
+import { useScopeHierarchy } from '../hooks/useScopeHierarchy';
 
 type NetworkPolicySimulatorSidePanelProps = {
-    selectedClusterId: string;
     simulator: NetworkPolicySimulator;
     setNetworkPolicyModification: SetNetworkPolicyModification;
 };
@@ -47,19 +45,16 @@ const tabs = {
 };
 
 function NetworkPolicySimulatorSidePanel({
-    selectedClusterId,
     simulator,
     setNetworkPolicyModification,
 }: NetworkPolicySimulatorSidePanelProps) {
+    const scopeHierarchy = useScopeHierarchy();
     const { activeKeyTab, onSelectTab } = useTabs({
         defaultTab: tabs.SIMULATE_NETWORK_POLICIES,
     });
     const [isExcludingPortsAndProtocols, setIsExcludingPortsAndProtocols] =
         React.useState<boolean>(false);
     const [isNotifyModalOpen, setIsNotifyModalOpen] = React.useState(false);
-
-    const { searchFilter } = useURLSearch();
-    const { cluster: clusterName } = getScopeHierarchyFromSearch(searchFilter);
 
     function handleFileInputChange(
         _event: React.ChangeEvent<HTMLInputElement> | React.DragEvent<HTMLElement>,
@@ -105,8 +100,7 @@ function NetworkPolicySimulatorSidePanel({
         setNetworkPolicyModification({
             state: 'GENERATED',
             options: {
-                clusterId: selectedClusterId,
-                searchQuery: '',
+                scopeHierarchy,
                 networkDataSince: '',
                 excludePortsAndProtocols: isExcludingPortsAndProtocols,
             },
@@ -117,7 +111,7 @@ function NetworkPolicySimulatorSidePanel({
         setNetworkPolicyModification({
             state: 'UNDO',
             options: {
-                clusterId: selectedClusterId,
+                clusterId: scopeHierarchy.cluster.id,
             },
         });
     }
@@ -161,9 +155,7 @@ function NetworkPolicySimulatorSidePanel({
                             title={
                                 simulator.error
                                     ? simulator.error
-                                    : `Policies generated from the baseline for cluster “${
-                                          clusterName ?? ''
-                                      }”`
+                                    : `Policies generated from the baseline for cluster “${scopeHierarchy.cluster.name}”`
                             }
                         />
                     </StackItem>
@@ -182,7 +174,7 @@ function NetworkPolicySimulatorSidePanel({
                 <NotifyYAMLModal
                     isModalOpen={isNotifyModalOpen}
                     setIsModalOpen={setIsNotifyModalOpen}
-                    clusterId={selectedClusterId}
+                    clusterId={scopeHierarchy.cluster.id}
                     modification={simulator.modification}
                 />
             </div>
@@ -236,7 +228,7 @@ function NetworkPolicySimulatorSidePanel({
                 <NotifyYAMLModal
                     isModalOpen={isNotifyModalOpen}
                     setIsModalOpen={setIsNotifyModalOpen}
-                    clusterId={selectedClusterId}
+                    clusterId={scopeHierarchy.cluster.id}
                     modification={simulator.modification}
                 />
             </div>
@@ -287,7 +279,7 @@ function NetworkPolicySimulatorSidePanel({
                 <NotifyYAMLModal
                     isModalOpen={isNotifyModalOpen}
                     setIsModalOpen={setIsNotifyModalOpen}
-                    clusterId={selectedClusterId}
+                    clusterId={scopeHierarchy.cluster.id}
                     modification={simulator.modification}
                 />
             </div>
@@ -304,7 +296,7 @@ function NetworkPolicySimulatorSidePanel({
                                 component={TextVariants.h2}
                                 className="pf-u-font-size-xl pf-u-mr-xl"
                             >
-                                Simulate network policy for cluster “{clusterName}”
+                                Simulate network policy for cluster “{scopeHierarchy.cluster.name}”
                             </Text>
                         </TextContent>
                     </FlexItem>

--- a/ui/apps/platform/src/Containers/NetworkGraph/types/networkScopeHierarchy.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/types/networkScopeHierarchy.ts
@@ -1,0 +1,11 @@
+import { SearchFilter } from 'types/search';
+
+export type NetworkScopeHierarchy = {
+    cluster: {
+        id: string;
+        name: string;
+    };
+    namespaces: string[];
+    deployments: string[];
+    remainingQuery: Omit<SearchFilter, 'Cluster' | 'Namespace' | 'Deployment'>;
+};

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/hierarchyUtils.test.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/hierarchyUtils.test.ts
@@ -1,0 +1,49 @@
+import { getScopeHierarchyFromSearch } from './hierarchyUtils';
+
+describe('hierarchyUtils', () => {
+    describe('getScopeHierarchyFromSearch', () => {
+        it('should return the correct cluster in the result hierarchy', () => {
+            const knownClusters = [
+                { id: '1', name: 'cluster1' },
+                { id: '2', name: 'cluster2' },
+            ];
+
+            expect(getScopeHierarchyFromSearch({}, knownClusters)).toBeNull();
+            expect(getScopeHierarchyFromSearch({ Cluster: undefined }, knownClusters)).toBeNull();
+            expect(getScopeHierarchyFromSearch({ Cluster: 'cluster3' }, knownClusters)).toBeNull();
+            expect(
+                getScopeHierarchyFromSearch({ Cluster: ['cluster1', 'cluster2'] }, knownClusters)
+            ).toBeNull();
+
+            // The only supported case is a non-array Cluster value that matches a known cluster
+            expect(
+                getScopeHierarchyFromSearch({ Cluster: 'cluster2' }, knownClusters)?.cluster.id
+            ).toBe('2');
+        });
+
+        it('should correctly retain namespaces, deployments, and remaining query values', () => {
+            const knownClusters = [
+                { id: '1', name: 'cluster1' },
+                { id: '2', name: 'cluster2' },
+            ];
+
+            const searchFilter = {
+                Cluster: 'cluster1',
+                Namespace: 'namespace1',
+                Deployment: ['deployment1', 'deployment2'],
+                CVE: 'CVE-2020-1234',
+                Other: 'other',
+            };
+
+            expect(getScopeHierarchyFromSearch(searchFilter, knownClusters)).toEqual({
+                cluster: { id: '1', name: 'cluster1' },
+                namespaces: ['namespace1'],
+                deployments: ['deployment1', 'deployment2'],
+                remainingQuery: {
+                    CVE: 'CVE-2020-1234',
+                    Other: 'other',
+                },
+            });
+        });
+    });
+});

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/hierarchyUtils.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/hierarchyUtils.ts
@@ -1,16 +1,7 @@
 import { SearchFilter } from 'types/search';
 import { NamespaceWithDeployments } from 'hooks/useFetchNamespaceDeployments';
 import { ScopeObject } from 'services/RolesService';
-
-export type NetworkScopeHierarchy = {
-    cluster: {
-        id: string;
-        name: string;
-    };
-    namespaces: string[];
-    deployments: string[];
-    remainingQuery: Omit<SearchFilter, 'Cluster' | 'Namespace' | 'Deployment'>;
-};
+import { NetworkScopeHierarchy } from '../types/networkScopeHierarchy';
 
 export function getScopeHierarchyFromSearch(
     searchFilter: SearchFilter,

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/hierarchyUtils.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/hierarchyUtils.ts
@@ -1,11 +1,11 @@
 import { SearchFilter } from 'types/search';
 import { NamespaceWithDeployments } from 'hooks/useFetchNamespaceDeployments';
-import { ScopeObject } from 'services/RolesService';
+import { ClusterScopeObject } from 'services/RolesService';
 import { NetworkScopeHierarchy } from '../types/networkScopeHierarchy';
 
 export function getScopeHierarchyFromSearch(
     searchFilter: SearchFilter,
-    clusters: ScopeObject[]
+    clusters: ClusterScopeObject[]
 ): NetworkScopeHierarchy | null {
     const urlCluster = searchFilter.Cluster;
     if (!urlCluster || Array.isArray(urlCluster)) {

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/hierarchyUtils.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/hierarchyUtils.ts
@@ -1,24 +1,40 @@
 import { SearchFilter } from 'types/search';
 import { NamespaceWithDeployments } from 'hooks/useFetchNamespaceDeployments';
+import { ScopeObject } from 'services/RolesService';
 
-export function getScopeHierarchyFromSearch(searchFilter: SearchFilter) {
+export type NetworkScopeHierarchy = {
+    cluster: {
+        id: string;
+        name: string;
+    };
+    namespaces: string[];
+    deployments: string[];
+    remainingQuery: Omit<SearchFilter, 'Cluster' | 'Namespace' | 'Deployment'>;
+};
+
+export function getScopeHierarchyFromSearch(
+    searchFilter: SearchFilter,
+    clusters: ScopeObject[]
+): NetworkScopeHierarchy | null {
+    const urlCluster = searchFilter.Cluster;
+    if (!urlCluster || Array.isArray(urlCluster)) {
+        return null;
+    }
+
+    const cluster = clusters.find((cl) => cl.name === urlCluster);
+    if (!cluster) {
+        return null;
+    }
+
     const workingQuery = { ...searchFilter };
-    const hierarchy: {
-        cluster: string | undefined;
-        namespaces: string[];
-        deployments: string[];
-        remainingQuery;
-    } = {
-        cluster: undefined,
+    delete workingQuery.Cluster;
+
+    const hierarchy: NetworkScopeHierarchy = {
+        cluster,
         namespaces: [],
         deployments: [],
         remainingQuery: workingQuery,
     };
-
-    if (searchFilter.Cluster && !Array.isArray(searchFilter.Cluster)) {
-        hierarchy.cluster = searchFilter.Cluster;
-        delete hierarchy.remainingQuery.Cluster;
-    }
 
     if (searchFilter.Namespace) {
         hierarchy.namespaces = Array.isArray(searchFilter.Namespace)
@@ -31,6 +47,7 @@ export function getScopeHierarchyFromSearch(searchFilter: SearchFilter) {
         hierarchy.deployments = Array.isArray(searchFilter.Deployment)
             ? searchFilter.Deployment
             : [searchFilter.Deployment];
+        delete hierarchy.remainingQuery.Deployment;
     }
 
     return hierarchy;

--- a/ui/apps/platform/src/hooks/useFetchClusterNamespacesForPermissions.ts
+++ b/ui/apps/platform/src/hooks/useFetchClusterNamespacesForPermissions.ts
@@ -1,22 +1,17 @@
 import { useState, useEffect } from 'react';
-import { ScopeObject, getNamespacesForClusterAndPermissions } from 'services/RolesService';
+import { NamespaceScopeObject, getNamespacesForClusterAndPermissions } from 'services/RolesService';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
-
-export type Namespace = {
-    id: string;
-    name: string;
-};
 
 type NamespaceResponse = {
     loading: boolean;
     error: string;
-    namespaces: Namespace[];
+    namespaces: NamespaceScopeObject[];
 };
 
 const emptyResponse: NamespaceResponse = {
     loading: false,
     error: '',
-    namespaces: [] as Namespace[],
+    namespaces: [],
 };
 
 export function useFetchClusterNamespacesForPermissions(
@@ -35,16 +30,10 @@ export function useFetchClusterNamespacesForPermissions(
             });
             getNamespacesForClusterAndPermissions(selectedClusterId, requestedPermissions)
                 .then((data) => {
-                    const namespaces: Namespace[] = data.namespaces.map((ns: ScopeObject) => {
-                        return {
-                            id: ns.id,
-                            name: ns.name,
-                        } as Namespace;
-                    });
                     setNamespaceResponse({
                         loading: false,
                         error: '',
-                        namespaces,
+                        namespaces: data.namespaces,
                     });
                 })
                 .catch((error) => {

--- a/ui/apps/platform/src/hooks/useFetchClustersForPermissions.ts
+++ b/ui/apps/platform/src/hooks/useFetchClustersForPermissions.ts
@@ -32,7 +32,7 @@ function useFetchClustersForPermissions(permissions: string[]): Result {
         getClustersForPermissions(requestedPermissions)
             .then((data) => {
                 setResult({
-                    clusters: data.clusters,
+                    clusters: data?.clusters || [],
                     error: '',
                     isLoading: false,
                 });

--- a/ui/apps/platform/src/hooks/useFetchClustersForPermissions.ts
+++ b/ui/apps/platform/src/hooks/useFetchClustersForPermissions.ts
@@ -1,12 +1,11 @@
 import { useEffect, useMemo, useState } from 'react';
 
 import { getClustersForPermissions, ScopeObject } from 'services/RolesService';
-import { Cluster } from 'types/cluster.proto';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
 type Result = {
     isLoading: boolean;
-    clusters: Cluster[];
+    clusters: ScopeObject[];
     error: string;
 };
 
@@ -32,14 +31,8 @@ function useFetchClustersForPermissions(permissions: string[]): Result {
 
         getClustersForPermissions(requestedPermissions)
             .then((data) => {
-                const clusters: Cluster[] = data.clusters.map((responseCluster: ScopeObject) => {
-                    return {
-                        id: responseCluster.id,
-                        name: responseCluster.name,
-                    } as Cluster;
-                });
                 setResult({
-                    clusters: clusters || [],
+                    clusters: data.clusters,
                     error: '',
                     isLoading: false,
                 });

--- a/ui/apps/platform/src/hooks/useFetchClustersForPermissions.ts
+++ b/ui/apps/platform/src/hooks/useFetchClustersForPermissions.ts
@@ -1,11 +1,11 @@
 import { useEffect, useMemo, useState } from 'react';
 
-import { getClustersForPermissions, ScopeObject } from 'services/RolesService';
+import { getClustersForPermissions, ClusterScopeObject } from 'services/RolesService';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
 type Result = {
     isLoading: boolean;
-    clusters: ScopeObject[];
+    clusters: ClusterScopeObject[];
     error: string;
 };
 

--- a/ui/apps/platform/src/services/NetworkService.js
+++ b/ui/apps/platform/src/services/NetworkService.js
@@ -366,7 +366,7 @@ export function getUndoNetworkModification(clusterId) {
  * Generates a modification to policies based on a graph.
  *
  * @param {!String} clusterId
- * @param {!Object} query
+ * @param {!String} query
  * @param {!String} networkDataSince
  * @param {Boolean} excludePortsProtocols
  * @returns {Promise<Object, Error>}

--- a/ui/apps/platform/src/services/RolesService.ts
+++ b/ui/apps/platform/src/services/RolesService.ts
@@ -129,13 +129,17 @@ type ClustersForPermissionRequest = {
 
 // ScopeObject represents the (ID, name) pair identifying elements that belong to
 // the access scope of a user.
-export type ScopeObject = {
+type ScopeObject = {
     id: string;
     name: string;
 };
 
+// Aliases to increase readability of server responses with the same shape but different semantics.
+export type ClusterScopeObject = ScopeObject;
+export type NamespaceScopeObject = ScopeObject;
+
 export type ClustersForPermissionsResponse = {
-    clusters: ScopeObject[];
+    clusters: ClusterScopeObject[];
 };
 
 export function getClustersForPermissions(
@@ -153,7 +157,7 @@ type NamespacesForClusterAndPermissionsRequest = {
 };
 
 export type NamespacesForClusterAndPermissionsResponse = {
-    namespaces: ScopeObject[];
+    namespaces: NamespaceScopeObject[];
 };
 
 export function getNamespacesForClusterAndPermissions(


### PR DESCRIPTION
## Description

Adds the user's selects Namespace and Deployment scope to simulated network policy generation. This will cause the generated network policies to only be for deployments that are explicitly selected as part of the user's current scope.

Instead of passing the selected namespaces and deployments alongside the `clusterId` throughout this section, a custom read-only hook is used to pass the user's selected scope to individual components. This avoids threading another property through many component levels and removes the previous threading of `clusterId`.

This PR also updates the cluster SAC response type from `Cluster` to `ScopeObject` to avoid potential issues with consuming code relying on `Cluster` properties that do not exist.

_Note: Much of the Network Graph work for the following release is related to this scoping change and enhancing the UX of the network simulator to better communicate to the user how these policies are generated. Since the design of exactly how we are going to accomplish this is still TBD, this change is solely to enable the new functionality that scopes generated policies to the user's current selection. If for some reason we need to back out of this change before release, we can replace [this function call](https://github.com/stackrox/stackrox/pull/6634/files#diff-df8329d4820e6242150f1c9befafc31e5f31824bf230a371f7e2895715639743R132) with an empty string to revert to the old behavior._

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Load the network graph, select a cluster and at least one namespace. Click the simulate network policy button on the toolbar and then click "Generate and simulate network policies". The generated YAML should only apply to deployments that exist in the selected scope:

![image](https://github.com/stackrox/stackrox/assets/1292638/71052fa0-5435-4514-b2d0-3b138447e77d)
![image](https://github.com/stackrox/stackrox/assets/1292638/253b8031-6209-4bd1-a286-c30be1eccc97)


Further reduce the scope by selecting a deployment and generating network policies:
![image](https://github.com/stackrox/stackrox/assets/1292638/3994663a-4b7b-47b0-8d40-06919d14186a)

Select multiple namespaces and multiple deployments to ensure policy generation works across multiple namespaces:
![image](https://github.com/stackrox/stackrox/assets/1292638/9b684cf6-33a9-4fae-b8d4-3f7a8d828000)
![image](https://github.com/stackrox/stackrox/assets/1292638/431448b8-4f2e-43c3-b250-2c2653289b9b)
![image](https://github.com/stackrox/stackrox/assets/1292638/e64a713b-4b88-46cc-b4a7-0d1eb8b073c4)
![image](https://github.com/stackrox/stackrox/assets/1292638/658fdd57-0deb-4e50-8d4d-aab6d06a2e4b)

