### PR TITLE
ROX-18044: Skip deduping of attempted alerts

### DIFF
--- a/central/hash/manager/deduper.go
+++ b/central/hash/manager/deduper.go
@@ -73,8 +73,11 @@ type deduperImpl struct {
 }
 
 func pruneInvalidAlerts(existingHashes map[string]uint64) {
-	// Due to a bug where we are not skipping deduping on ATTEMPTED alerts
-	// we need to prune the invalid entries
+	// In the hash deduper, we were treating attempted alerts as normal alerts that could be potentially deduped
+	// even though they are more like runtime alerts. This would lead to the "hash" maps growing until we hit the
+	// max number of hashes and resetting. This ensures that we remove them from the "hash" maps because the only
+	// valid alerts are deploy time alerts where the id of the alert result is the same id as a deployment.
+	// This prunes all alert results in the "hash" maps that do not have a corresponding deployment in the hash map.
 	for k := range existingHashes {
 		if strings.HasPrefix(k, alertResourceKey) {
 			depKey := buildKey(deploymentResourceKey, getIDFromKey(k))

--- a/central/hash/manager/deduper_test.go
+++ b/central/hash/manager/deduper_test.go
@@ -92,6 +92,31 @@ func TestDeduper(t *testing.T) {
 			},
 		},
 		{
+			testName: "attempted alert",
+			testEvents: []testEvents{
+				{
+					event: &central.MsgFromSensor{
+						Msg: &central.MsgFromSensor_Event{
+							Event: &central.SensorEvent{
+								Id: "abc",
+								Resource: &central.SensorEvent_AlertResults{
+									AlertResults: &central.AlertResults{
+										Stage: storage.LifecycleStage_DEPLOY,
+										Alerts: []*storage.Alert{
+											{
+												State: storage.ViolationState_ATTEMPTED,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					result: true,
+				},
+			},
+		},
+		{
 			testName: "process indicator",
 			testEvents: []testEvents{
 				{


### PR DESCRIPTION
## Description

Attempted alerts had their hashes stored in the database, but they should be treated like runtime alerts

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Ran master and created thousands of attempted alerts, then upgraded to this PR and saw the total number of hashes drop down to the original level