### PR TITLE
ROX-18010: Delete non-postgres code in widgets UI

### DIFF
--- a/ui/apps/platform/src/Containers/VulnMgmt/widgets/MostCommonVulnerabiltiesInDeployment.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/widgets/MostCommonVulnerabiltiesInDeployment.js
@@ -14,28 +14,6 @@ import Loader from 'Components/Loader';
 import NumberedList from 'Components/NumberedList';
 import Widget from 'Components/Widget';
 import NoResultsMessage from 'Components/NoResultsMessage';
-import useFeatureFlags from 'hooks/useFeatureFlags';
-
-const MOST_COMMON_VULNERABILITIES = gql`
-    query mostCommonVulnerabilitiesInDeployment(
-        $query: String
-        $scopeQuery: String
-        $vulnPagination: Pagination
-    ) {
-        results: vulnerabilities(query: $query, pagination: $vulnPagination) {
-            id
-            cve
-            cvss
-            scoreVersion
-            imageCount
-            deploymentCount
-            createdAt
-            summary
-            isFixable(query: $scopeQuery)
-            envImpact
-        }
-    }
-`;
 
 const MOST_COMMON_IMAGE_VULNERABILITIES = gql`
     query mostCommonImageVulnerabilities($query: String, $vulnPagination: Pagination) {
@@ -61,14 +39,7 @@ const processData = (data, workflowState) => {
 };
 
 const MostCommonVulnerabiltiesInDeployment = ({ deploymentId, limit }) => {
-    const { isFeatureFlagEnabled } = useFeatureFlags();
-    const showVMUpdates = isFeatureFlagEnabled('ROX_POSTGRES_DATASTORE');
-
-    const queryToUse = showVMUpdates
-        ? MOST_COMMON_IMAGE_VULNERABILITIES
-        : MOST_COMMON_VULNERABILITIES;
-
-    const { loading, data = {} } = useQuery(queryToUse, {
+    const { loading, data = {} } = useQuery(MOST_COMMON_IMAGE_VULNERABILITIES, {
         variables: {
             query: queryService.objectToWhereClause({
                 'Deployment ID': deploymentId,
@@ -114,14 +85,10 @@ const MostCommonVulnerabiltiesInDeployment = ({ deploymentId, limit }) => {
         ])
         .toUrl();
 
-    const header = showVMUpdates
-        ? 'Most Common Image Vulnerabilities'
-        : 'Most Common Vulnerabilities';
-
     return (
         <Widget
             className="h-full pdf-page"
-            header={header}
+            header="Most Common Image Vulnerabilities"
             headerComponents={<ViewAllButton url={viewAllURL} />}
         >
             {content}


### PR DESCRIPTION
## Description

> deprecating our Postgres feature flag

### Analysis

Find in Files decrease from 36 results in 30 files to 25 results in 19 files

| Folder                        | results | files |
| :---                          |    ---: |  ---: |
| Components/workflow           |       1 |     1 |
| Containers/VulnMgmt/Dashboard |       1 |     1 |
| Containers/VulnMgmt/Entity    |      12 |    12 |
| Containers/VulnMgmt/List      |      10 |     8 |
| Containers/VulnMgmt/widgets   |      11 |     7 |
| types                         |       1 |     1 |
|                               |      36 |    30 |

### Residue

1. CvesByCvssScore `pushRelatedEntity`
2. TopRiskiestEntities `entityContext === {}`

## Checklist
- [ ] Investigated and inspected CI test results
- [x] ~Unit test and regression tests added~

## Testing Performed

1. `yarn lint` in ui
2. `yarn build` in ui
    * `wc build/static/js/*.js`
        branch - master: -8178 = 11777461 - 11785639
3. `yarn start` in ui

### Manual testing

1. Visit /main/vulnerability-management
    * See **Top risky deployments by CVE count & CVSS score** widget.
    * See **Most Common Image Vulnerabilities** widget.
    * See **Clusters With Most Orchestrator & Istio Vulnerabilities** widget.

2. Visit /main/vulnerability-management/clusters and click a row
    * See **Top risky namespaces by CVE count & CVSS score** widget.

3. Visit /main/vulnerability-management/namespaces and click a row
    * See **Top risky deployments by CVE count & CVSS score** widget.

4. Visit /main/vulnerability-management/deployments and click a row that has vulnerabilities.
    * See **CVEs by CVSS Score** widget.
    * See **Recently Detected Image Vulnerabilities** widget.
    * See **Most Common Image Vulnerabilities** widget.

5. Visit /main/vulnerability-management/images and click a row that has vulnerabilities.
    * See **CVEs by CVSS Score** widget.

6. Visit /main/vulnerability-management/nodes and click a row that has vulnerabilities.
    * See **CVEs by CVSS Score** widget.

### Integration testing

1. `yarn cypress-open` in ui/apps/platform
    * vulnmanagement/clusters.test.js
    * vulnmanagement/dashboard.test.js
    * vulnmanagement/dashboardToEntityPage.test.js
    * vulnmanagement/deployments.test.js
    * vulnmanagement/images.test.js
    * vulnmanagement/namespaces.test.js
    * vulnmanagement/nodes.test.js