### PR TITLE
ROX-17994: AdmissionControllerTest: Wait for pods to be ready to work

### DIFF
--- a/qa-tests-backend/src/main/groovy/util/ApplicationHealth.groovy
+++ b/qa-tests-backend/src/main/groovy/util/ApplicationHealth.groovy
@@ -13,6 +13,7 @@ class ApplicationHealth {
     Integer waitTimeForHealthiness
     final Integer delayBetweenChecks = 5
     final Map<String, String> readyLogMessages = [
+            "admission-control": "Applied new admission control settings",
             "collector": "Sensor connectivity is successful",
             "sensor": "TLS-enabled multiplexed HTTP/gRPC server listening on",
     ]
@@ -30,6 +31,12 @@ class ApplicationHealth {
     void waitForCollectorHealthiness() {
         Deployment collector = new DaemonSet().setNamespace(Constants.STACKROX_NAMESPACE).setName("collector")
         waitForHealthiness(collector)
+    }
+
+    void waitForAdmissionControllerHealthiness() {
+        Deployment admissionController = new DaemonSet().setNamespace(Constants.STACKROX_NAMESPACE)
+            .setName("admission-control")
+        waitForHealthiness(admissionController)
     }
 
     void waitForHealthiness(Deployment deployment) {

--- a/qa-tests-backend/src/main/groovy/util/ApplicationHealth.groovy
+++ b/qa-tests-backend/src/main/groovy/util/ApplicationHealth.groovy
@@ -34,7 +34,7 @@ class ApplicationHealth {
     }
 
     void waitForAdmissionControllerHealthiness() {
-        Deployment admissionController = new DaemonSet().setNamespace(Constants.STACKROX_NAMESPACE)
+        Deployment admissionController = new Deployment().setNamespace(Constants.STACKROX_NAMESPACE)
             .setName("admission-control")
         waitForHealthiness(admissionController)
     }
@@ -58,6 +58,9 @@ class ApplicationHealth {
                 }
                 else {
                     throw new RuntimeException("Expect DaemonSet or Deployment")
+                }
+                if (replicaCount == null) {
+                    throw new RuntimeException("Expected to get replica count")
                 }
                 log.debug "${replicaCount} ${deployment.name} pods expected"
                 return replicaCount

--- a/qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy
+++ b/qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy
@@ -14,6 +14,7 @@ import services.ClusterService
 import services.ImageIntegrationService
 import services.ImageService
 import services.PolicyService
+import util.ApplicationHealth
 import util.ChaosMonkey
 import util.Timer
 
@@ -130,7 +131,7 @@ class AdmissionControllerTest extends BaseSpecification {
 
     @Unroll
     @Tag("BAT")
-    def "Verify Admission Controller Config (#desc)"() {
+    def "Verify Admission Controller Config: #desc"() {
         when:
         prepareChaosMonkey()
 
@@ -296,7 +297,7 @@ class AdmissionControllerTest extends BaseSpecification {
 
     @Unroll
     @Tag("BAT")
-    def "Verify Admission Controller Enforcement on Updates (#desc)"() {
+    def "Verify Admission Controller Enforcement on Updates: #desc"() {
         when:
         prepareChaosMonkey()
 
@@ -348,7 +349,7 @@ class AdmissionControllerTest extends BaseSpecification {
 
     @Unroll
     @Tag("BAT")
-    def "Verify Admission Controller Enforcement respects Cluster/Namespace scopes (match: #clusterMatch/#nsMatch)"() {
+    def "Verify Admission Controller Enforcement respects Cluster/Namespace scopes: match: #clusterMatch/#nsMatch"() {
         when:
         prepareChaosMonkey()
 
@@ -520,6 +521,11 @@ class AdmissionControllerTest extends BaseSpecification {
         orchestrator.waitForPodsReady("stackrox", admCtrlDeploy.spec.selector.matchLabels,
                 originalAdmCtrlReplicas, 30, 1)
         log.info("Admission controller scaled back to ${originalAdmCtrlReplicas}")
+
+        and:
+        "Admission controller is ready for work"
+        ApplicationHealth ah = new ApplicationHealth(orchestrator, 60)
+        ah.waitForAdmissionControllerHealthiness()
 
         when:
         "A deployment with an image violating a policy is created"


### PR DESCRIPTION
## Description

The "AdmissionControllerTest > Verify admission controller performs image scans if Sensor is Unavailable" test can fail because while it waits for admission-control pods to be ready it does not wait for them to be healthy and ready to work. This change uses the ApplicationHealth package to ensure admission-control is ready to work before trying to deploy an image that it should refuse.

E.g. in a failing test the admission-control pod is not logging readiness until about `15:50:37` but the test tries to create at `15:50:33`:

```
AdmissionControllerTest > Verify admission controller performs image scans if Sensor is Unavailable STANDARD_OUT
    15:50:07 | INFO  | AdmissionControllerTest   | Starting testcase
    15:50:12 | INFO  | Kubernetes                | Scaled the deployment sensor to 0
    15:50:15 | INFO  | AdmissionControllerTest   | Sensor is now scaled to 0
    15:50:15 | INFO  | Kubernetes                | Scaled the deployment admission-control to 0
    15:50:32 | INFO  | AdmissionControllerTest   | Admission controller scaled to 0, was 3
    15:50:32 | INFO  | Kubernetes                | Scaled the deployment admission-control to 3
    15:50:33 | DEBUG | Kubernetes                | Encountered 3 ready pods matching [app:admission-control]: [admission-control-7d8f48d9c5-fmxsr, admission-control-7d8f48d9c5-pd2lp, admission-control-7d8f48d9c5-rfwp9]
    15:50:33 | INFO  | AdmissionControllerTest   | Admission controller scaled back to 3
    15:50:33 | DEBUG | Kubernetes                | Told the orchestrator to createOrReplace qagcrnginx
[edit: the point of failure is here and what follows is from the cleanup: block]
    15:50:33 | INFO  | Kubernetes                | Scaled the deployment sensor to 1
    15:50:33 | DEBUG | Kubernetes                | Encountered 1 ready pods matching [app:sensor]: [sensor-d4d87774c-sjrfh]
    15:50:33 | DEBUG | Kubernetes                | Removed the deployment: qagcrnginx
    15:50:33 | ERROR | Helpers                   | An exception occurred in test
    org.spockframework.runtime.ConditionNotSatisfiedError: Condition not satisfied:

    !created
    ||
    |true
    false
```

Logs from admission-control pods show they are not ready to do anything until later:
```
No certificates found in /usr/local/share/ca-certificates
'/etc/pki/injected-ca-trust/tls-ca-bundle.pem' -> '/etc/pki/ca-trust/source/anchors/tls-ca-bundle.pem'
main: 2023/06/22 15:50:37.127183 main.go:39: Info: StackRox Sensor Admission Control Service, version 4.0.x-781-g55e7775a9c
admission-control/settingswatch: 2023/06/22 15:50:37.148772 k8s.go:144: Info: Detected and propagated updated admission controller settings via Kubernetes config map watch, timestamp: 2023-06-22T15:50:07.72651334Z
admission-control/manager: 2023/06/22 15:50:37.152671 manager_impl.go:329: Info: RE-ENABLING admission control service
admission-control/manager: 2023/06/22 15:50:37.152727 manager_impl.go:339: Info: Applied new admission control settings (enforcing on 2 deploy-time policies; detecting on 5 run-time policies; enforcing on 0 run-time policies).
admission-control/settingswatch: 2023/06/22 15:50:37.207718 mount.go:146: Info: Detected and propagated updated admission controller settings via config map mount, timestamp: 2023-06-22T15:50:07.72651334Z
admission-control/alerts: 2023/06/22 15:50:37.207826 sender.go:50: Info: Starting admission control alert pusher
pkg/grpc: 2023/06/22 15:50:37.208081 server.go:217: Info: Launching backend gRPC listener
admission-control/settingswatch: 2023/06/22 15:50:37.208610 sensor_push.go:66: Warn: Communication to sensor failed: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial tcp 172.30.139.209:443: connect: connection refused". Retrying in 6.835658599s

```

## Checklist
- [ ] Investigated and inspected CI test results

## Testing Performed

CI and in particular OCP 4.13 where this test regularly fails.