### PR TITLE
ROX-18030: AuditLogAlertsTest: Wait longer for violations to appear

### DIFF
--- a/qa-tests-backend/src/test/groovy/AuditLogAlertsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/AuditLogAlertsTest.groovy
@@ -22,6 +22,9 @@ import util.Env
 @Requires({ Env.mustGetOrchestratorType() == OrchestratorTypes.OPENSHIFT })
 @Stepwise
 class AuditLogAlertsTest extends BaseSpecification {
+    static final private Integer WAIT_FOR_VIOLATION_TIMEOUT =
+                isRaceBuild() ? 450 : ((Env.mustGetOrchestratorType() == OrchestratorTypes.OPENSHIFT) ? 100 : 60)
+
     @Unroll
     @Tag("BAT")
     @Tag("RUNTIME")
@@ -53,7 +56,8 @@ class AuditLogAlertsTest extends BaseSpecification {
 
         then:
         "Verify that policy was violated"
-        def violations =  getResourceViolationsWithTimeout(resourceType, resName, policy.getName(), 60)
+        def violations =  getResourceViolationsWithTimeout(resourceType, resName,
+                policy.getName(), WAIT_FOR_VIOLATION_TIMEOUT)
         // There should be exactly one violation because we are testing only verb at a time
         assert violations != null && violations.size() == 1
 
@@ -102,7 +106,7 @@ class AuditLogAlertsTest extends BaseSpecification {
         "A violation is generated and resolved"
         createGetAndDeleteConfigMap(resName, Constants.ORCHESTRATOR_NAMESPACE)
         def violations =  getResourceViolationsWithTimeout("CONFIGMAPS", resName,
-                policy.getName(), 60)
+                policy.getName(), WAIT_FOR_VIOLATION_TIMEOUT)
         // There should be exactly one violation
         assert violations != null && violations.size() == 1
 
@@ -120,7 +124,7 @@ class AuditLogAlertsTest extends BaseSpecification {
         then:
         "Verify that only the access after restart triggers a violation"
         def allViolations =  getAllResourceViolationsWithTimeout("CONFIGMAPS",
-                policy.getName(), 60)
+                policy.getName(), WAIT_FOR_VIOLATION_TIMEOUT)
 
         // There should only be one violation - the new one
         assert allViolations != null &&
@@ -169,7 +173,7 @@ class AuditLogAlertsTest extends BaseSpecification {
         "A violation is generated and resolved"
         createGetAndDeleteConfigMap(resName, Constants.ORCHESTRATOR_NAMESPACE)
         def violations =  getResourceViolationsWithTimeout("CONFIGMAPS", resName,
-                policy.getName(), 60)
+                policy.getName(), WAIT_FOR_VIOLATION_TIMEOUT)
         // There should be exactly one violation
         assert violations != null && violations.size() == 1
 
@@ -190,7 +194,7 @@ class AuditLogAlertsTest extends BaseSpecification {
         then:
         "Verify that only the access after restart triggers a violation"
         def allViolations =  getAllResourceViolationsWithTimeout("CONFIGMAPS",
-                policy.getName(), 60)
+                policy.getName(), WAIT_FOR_VIOLATION_TIMEOUT)
 
         // There should only be one violation - the new one
         assert allViolations != null &&
@@ -230,7 +234,7 @@ class AuditLogAlertsTest extends BaseSpecification {
         then:
         "Verify that no violations were generated"
         def violations =  getResourceViolationsWithTimeout("CONFIGMAPS", resName,
-                policy.getName(), 60)
+                policy.getName(), WAIT_FOR_VIOLATION_TIMEOUT)
         assert violations == null || violations.size() == 0
 
         cleanup:

--- a/qa-tests-backend/src/test/groovy/PolicyFieldsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/PolicyFieldsTest.groovy
@@ -247,7 +247,7 @@ class PolicyFieldsTest extends BaseSpecification {
             "some_configuration": "a value",
     ]
 
-    // https://stack-rox.atlassian.net/browse/ROX-6891
+    // ROX-6891
     static final private Integer WAIT_FOR_VIOLATION_TIMEOUT =
                 isRaceBuild() ? 450 : ((Env.mustGetOrchestratorType() == OrchestratorTypes.OPENSHIFT) ? 100 : 30)
 
@@ -256,7 +256,7 @@ class PolicyFieldsTest extends BaseSpecification {
             .addCategories("Test")
             .setDisabled(false)
             .setSeverityValue(2)
-            // https://stack-rox.atlassian.net/browse/ROX-6891
+            // ROX-6891
             // limiting the scope of the test policies to the test namespaces reduces the workload that
             // causes slow alert triggers.
             .addAllScope(["qa", "qa-policyfieldstest-.*"].collect


### PR DESCRIPTION
## Description

As seen with other tests (e.g. [PolicyFieldsTest](https://github.com/stackrox/stackrox/blob/f7527862e93c9c126862f8a2d28ad8c154ddef71/qa-tests-backend/src/test/groovy/PolicyFieldsTest.groovy#L250)), policy violations can be slow to appear under OCP and particularly after policies are created or changed. This PR gives the test more time to find the violation.

## Checklist
- [x] Investigated and inspected CI test results

## Testing Performed

CI is sufficient - with OCP.
