### PR TITLE
ROX-18024: Reenable network entity tests

### DIFF
--- a/central/networkgraph/entity/datastore/datastore_impl_test.go
+++ b/central/networkgraph/entity/datastore/datastore_impl_test.go
@@ -40,7 +40,6 @@ var (
 )
 
 func TestNetworkEntityDataStore(t *testing.T) {
-	t.Skip("ROX-18024: Skip so that all tests can be run")
 	suite.Run(t, new(NetworkEntityDataStoreTestSuite))
 }
 
@@ -73,7 +72,7 @@ func (suite *NetworkEntityDataStoreTestSuite) SetupSuite() {
 			sac.ResourceScopeKeys(resources.NetworkGraph)))
 	suite.globalWriteAccessCtx = sac.WithGlobalAccessScopeChecker(context.Background(),
 		sac.AllowFixedScopes(
-			sac.AccessModeScopeKeys(storage.Access_READ_WRITE_ACCESS),
+			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
 			sac.ResourceScopeKeys(resources.NetworkGraph)))
 
 	suite.mockCtrl = gomock.NewController(suite.T())
@@ -316,12 +315,12 @@ func (suite *NetworkEntityDataStoreTestSuite) TestSAC() {
 			sac.ClusterScopeKeys(cluster1)))
 	cluster1WriteCtx := sac.WithGlobalAccessScopeChecker(context.Background(),
 		sac.AllowFixedScopes(
-			sac.AccessModeScopeKeys(storage.Access_READ_WRITE_ACCESS),
+			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
 			sac.ResourceScopeKeys(resources.NetworkGraph),
 			sac.ClusterScopeKeys(cluster1)))
 	cluster2WriteCtx := sac.WithGlobalAccessScopeChecker(context.Background(),
 		sac.AllowFixedScopes(
-			sac.AccessModeScopeKeys(storage.Access_READ_WRITE_ACCESS),
+			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
 			sac.ResourceScopeKeys(resources.NetworkGraph),
 			sac.ClusterScopeKeys(cluster2)))
 
@@ -591,7 +590,7 @@ func (suite *NetworkEntityDataStoreTestSuite) TestDefaultGraphSetting() {
 		} else {
 			pushSig = suite.expectPushExternalNetworkEntitiesToSensor(cluster)
 		}
-		suite.NoError(suite.ds.DeleteExternalNetworkEntity(suite.globalWriteAccessCtx, entity.GetInfo().GetId()))
+		suite.NoError(suite.ds.DeleteExternalNetworkEntity(suite.elevatedCtx, entity.GetInfo().GetId()))
 		suite.True(concurrency.WaitWithTimeout(&pushSig, time.Second))
 	}
 

--- a/central/networkgraph/entity/datastore/datastore_impl_test.go
+++ b/central/networkgraph/entity/datastore/datastore_impl_test.go
@@ -590,7 +590,7 @@ func (suite *NetworkEntityDataStoreTestSuite) TestDefaultGraphSetting() {
 		} else {
 			pushSig = suite.expectPushExternalNetworkEntitiesToSensor(cluster)
 		}
-		suite.NoError(suite.ds.DeleteExternalNetworkEntity(suite.elevatedCtx, entity.GetInfo().GetId()))
+		suite.NoError(suite.ds.DeleteExternalNetworkEntity(suite.globalWriteAccessCtx, entity.GetInfo().GetId()))
 		suite.True(concurrency.WaitWithTimeout(&pushSig, time.Second))
 	}
 


### PR DESCRIPTION
## Description

This reenables the network entity tests; however, I needed to expand the SAC scopes because the datastore does reads which now have implicit scopes via Postgres. It's not possible for a user to have just write access currently so I think we can expand the READ_WRITE access to truly mean RW instead of just W in another PR

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

Unit test