### PR TITLE
fix(test): skip flaky Splunk test with Postgres

### DIFF
--- a/central/splunk/violations_test.go
+++ b/central/splunk/violations_test.go
@@ -613,6 +613,7 @@ var (
 )
 
 func TestViolations(t *testing.T) {
+	t.Skip("ROX-18045: Test is flaky under Postgres")
 	suite.Run(t, &violationsTestSuite{})
 }
 


### PR DESCRIPTION
## Description

This test is flaky since the postgres unit test selection was fixed. If it persists, disable it

## Checklist
- [ ] Investigated and inspected CI test results
- [ ] Unit test and regression tests added
- [ ] Evaluated and added CHANGELOG entry if required
- [ ] Determined and documented upgrade steps
- [ ] Documented user facing changes (create PR based on [openshift/openshift-docs](https://github.com/openshift/openshift-docs) and merge into [rhacs-docs](https://github.com/openshift/openshift-docs/tree/rhacs-docs))

If any of these don't apply, please comment below.

## Testing Performed

CI
