### PR TITLE
ROX-17835: show header and subheader for report parameters section

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/CreateVulnReport/CreateVulnReportPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/CreateVulnReport/CreateVulnReportPage.tsx
@@ -14,6 +14,7 @@ import { vulnerabilityReportsPath } from 'routePaths';
 
 import PageTitle from 'Components/PageTitle';
 import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
+import ReportParametersForm from '../forms/ReportParametersForm';
 
 function VulnReportsPage() {
     return (
@@ -47,7 +48,10 @@ function VulnReportsPage() {
                     // @TODO: Make the mainAriaLabel dynamic based on whether you're creating, editing, or cloning
                     mainAriaLabel="Report creation content"
                     steps={[
-                        { name: 'Configure report parameters', component: <p /> },
+                        {
+                            name: 'Configure report parameters',
+                            component: <ReportParametersForm />,
+                        },
                         { name: 'Configure delivery destinations (Optional)', component: <p /> },
                         {
                             name: 'Review and create',
@@ -55,6 +59,7 @@ function VulnReportsPage() {
                             nextButtonText: 'Finish',
                         },
                     ]}
+                    hasNoBodyPadding
                 />
             </PageSection>
         </>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/ReportParametersForm.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/ReportParametersForm.tsx
@@ -1,0 +1,23 @@
+import { Divider, Flex, FlexItem, PageSection, Title } from '@patternfly/react-core';
+import React, { ReactElement } from 'react';
+
+function ReportParametersForm(): ReactElement {
+    return (
+        <>
+            <PageSection variant="light" padding={{ default: 'noPadding' }}>
+                <Flex direction={{ default: 'column' }} className="pf-u-py-lg pf-u-px-lg">
+                    <FlexItem>
+                        <Title headingLevel="h2">Configure report parameters</Title>
+                    </FlexItem>
+                    <FlexItem>
+                        Configure report&apos;s name, CVE attributes, and setup schedule to send
+                        reports on a recurring basis.
+                    </FlexItem>
+                </Flex>
+            </PageSection>
+            <Divider component="div" />
+        </>
+    );
+}
+
+export default ReportParametersForm;


### PR DESCRIPTION
## Description

This PR adds a new `ReportParametersForm` component that will eventually keep track of the form fields in the `Configure report parameters` section of the wizard. This simply creates the component and adds the header + subheader. Eventually, we'll make form components for each wizard step. I'm imagining passing the state and setter function for the form values to each form component and we'll keep track of it all in the parent component

<img width="1552" alt="Screenshot 2023-06-22 at 9 47 23 PM" src="https://github.com/stackrox/stackrox/assets/4805485/03647c9a-3f5a-49ad-b108-eef96c679ab8">
